### PR TITLE
fix(machines-viz): compound-endpoint edges + self-loop label fan + cross-hierarchy label placement (rf2-shv82)

### DIFF
--- a/tools/machines-viz/spec/001-Topology-Parity.md
+++ b/tools/machines-viz/spec/001-Topology-Parity.md
@@ -196,9 +196,13 @@ low-severity ELK cross-hierarchy-routing assertion (G5) is now
 **closed** (rf2-gpa9k) — the cross-hierarchy switch
 (`elk.hierarchyHandling INCLUDE_CHILDREN`, set on the root
 `layoutOptions` whenever the graph nests/parallels) rode in with G2 and
-is now regression-guarded by test. **The machine-topology parity
-roadmap is COMPLETE (G1 / G2 / G3 / G4 / G5 all
-✅).**
+is now regression-guarded by test. The three **compound-endpoint
+rendering gaps** surfaced post-rf2-xh1lm are now also **closed**
+(rf2-shv82): compound-endpoint edges no longer silently drop (G6
+below), multi-self-loop labels fan to distinct perimeter slots (G7),
+cross-hierarchy labels anchor at the source-side bend point (G8).
+**The machine-topology parity roadmap is COMPLETE (G1 / G2 / G3 / G4 /
+G5 / G6 / G7 / G8 all ✅).**
 
 ## §3 — Gap analysis + deliberate divergences
 
@@ -214,6 +218,9 @@ new), and the parity-bar row it serves.
 | **G3** | ✅ **CLOSED (rf2-8jzm1 + rf2-qeemm).** Was: to highlight "the edge that fired this epoch" on the live chart, the host's trace→edge-id mapping had to mint the **same** `edge-id` `chart.layout` mints, and the ids weren't wired through to the canvas. Now: `extract-fired-edge-ids` (rf2-8jzm1) projects the definition through the public `parse-definition` and reads ids off the projected edges — they agree with the live chart **by construction**; rf2-qeemm threads them as `:fired-edge-ids` (set) into `MachineChart`, the projector marks each matching edge `:fired`, and `transition-edge` paints the FIRED treatment (emphasised + animated stroke + `data-fired`) on the live canvas. Matches the EDGE directly so every traversed arm (microsteps, guard-fork candidates) lights up. **Palette delegated to Figma.** | **Medium** | §1.3, §1.8 | **helpers:** rf2-8jzm1 ✅ · **wire:** rf2-qeemm ✅ |
 | **G4** | ✅ **CLOSED (rf2-80rm2).** Was: once G1 lit N region LEAVES, the **region CONTAINER** still read structural-only — an active region was indistinguishable from an inactive one at the zone level. Now: `xyflow-graph` folds a container (region OR compound) into `:active` when any descendant leaf is active — walked UP the `:parent-id` chain every node already carries (reuses the G1 active set; no path-prefix reimplementation). `parallel-region-node` / `compound-node` paint active chrome (solid emphasised boundary + the `:info` active-token glow ring, the same affordance state nodes use), so each active region reads as active at a glance and the N active regions read as a set. **Palette delegated to Figma.** | **Low–Medium** | §1.2 | **impl:** rf2-80rm2 ✅ |
 | **G5** | ✅ **CLOSED (rf2-gpa9k).** Was: elk routes cross-hierarchy edges only when the switch is activated on the top level (§1.7), and while `->elk-input` already set it, **nothing asserted it** — drop the line and no test would catch the regression. Now: the cross-hierarchy switch is `elk.hierarchyHandling INCLUDE_CHILDREN` on the root `layoutOptions`, set by the pure `chart.cljs/elk-layout-options` whenever the graph nests (`:parallel?` OR some node has a `:parent-id` — compound substate or parallel-region leaf); it is what lets the Layered algorithm route edges ACROSS nesting levels (its default `SEPARATE_CHILDREN` lays each level out independently and never routes cross-hierarchy edges). So an edge from a deeply-nested leaf to a top-level state routes cleanly, and G2's bend-points (rf2-cz8v6) come back as legible absolute coords. The capability rode in with G2; rf2-gpa9k extracted the option-computation into the assertable `elk-layout-options` and added the regression guard (nested/parallel ⇒ switch present, flat ⇒ absent, G2 routing keys pinned). | **Low** | §1.7 | **impl:** rf2-cz8v6 ✅ (capability) · **assert:** rf2-gpa9k ✅ |
+| **G6** | ✅ **CLOSED (rf2-shv82).** Was: any edge whose source or target was a compound (a parent-level transition like `:active → :disconnected`, a compound self-loop, an inbound `:failed → :active`) was SILENTLY DROPPED from the DOM. The projector emitted it, ELK routed it, but xyflow's `getHandleBounds` returned null for the compound (no `<Handle>` children) → `isNodeInitialized` returned false → `getEdgePosition` returned null → the edge never reached the DOM. No warning. The 5-layer probe trace in the bead proved 4 such edges survived to ELK's output then 0 in the DOM. Now: `compound-node` + `parallel-region-node` render invisible source + target `<Handle>` elements on all four sides; xyflow accepts the compound as an edge endpoint and ELK's routed bend-points anchor on its BORDER the way xstate/Stately Studio paints parent-level transitions. The chart root surfaces `data-edge-count-projected` alongside `data-edge-count` so the parser → projector → DOM parity is regression-guarded end to end. | **High** | §1.3, §1.7 | **impl:** rf2-shv82 ✅ |
+| **G7** | ✅ **CLOSED (rf2-shv82).** Was: N self-loops on the same node (e.g. testdeck `:disconnected` carries 3: `:ws/arm-fail`, `:ws/disarm-fail`, `:ws/clear`) all rendered at the same loop anchor → their label texts overlapped into garbled glyph soup. Now: the projector assigns each self-loop on a source a stable per-source ordinal (`:loopIndex` 0..N-1 in emission order); `chart.edges/edge-path` rotates the loop's perimeter slot + label anchor per ordinal across 8 cardinal / inter-cardinal slots (the xstate/Stately multi-event fan). Slot 0 is the historical top-right so the single-self-loop case stays pixel-identical. Surfaces `data-loop-index` on each self-loop edge label for DOM-test pinning. | **Medium** | §1.3, §1.9 | **impl:** rf2-shv82 ✅ |
+| **G8** | ✅ **CLOSED (rf2-shv82).** Was: a cross-hierarchy edge (source and target in different parent containers — e.g. testdeck `:active.authenticating → :failed`) routed via ELK's bend-points had a midpoint that landed far from its visual origin (the label sat at the canvas bottom-left). Now: the projector flags the edge `:crossHierarchy true` when the source's `:parent-id` ≠ the target's (self-loops are never cross-hierarchy regardless of nesting); `chart.edges/edge-path` anchors the label NEAR the source-side first bend point (xstate/Stately convention — the label hugs the bend just outside the container the edge exits, with a small back-bias along the incoming segment so it sits in the routed channel). Degenerate two-point routes fall back to the segment midpoint; the bezier-fallback path is unchanged. Surfaces `data-cross-hierarchy` on each transition edge label. | **Medium** | §1.5, §1.9 | **impl:** rf2-shv82 ✅ |
 
 ### 3.2 Deliberate non-parity divergences (intentional, NOT gaps)
 
@@ -383,6 +390,17 @@ project dispatch rules): `tools/xray/spec/003-Machine-Inspector.md`.
 | Step | Bead | New? | Hot-zone | Notes |
 |---|---|---|---|---|
 | D1 | **rf2-3f03c** — `001-Rendering.md` capability doc | existing (optional) | isolated | **Re-scope / fold into THIS doc** — `001-Topology-Parity.md` now claims the next numbered slot and carries the per-concern capability detail. rf2-3f03c can close as folded-in, or re-aim at a narrower "rendering pipeline internals" reference (`002-Rendering.md`) if a distinct surface emerges. Mayor to decide. |
+
+### Phase E — compound-endpoint rendering (the post-rf2-xh1lm tail)
+
+After rf2-xh1lm landed compound CONTAINMENT (substates nest inside
+the parent's box), three rendering gaps around compound EDGES
+surfaced in the 2026-05-25 pair-debug session and were closed
+together in rf2-shv82.
+
+| Step | Bead | New? | Hot-zone | Notes |
+|---|---|---|---|---|
+| E1 | **rf2-shv82** ✅ — `fix(machines-viz): compound-endpoint edges + self-loop label fan + cross-hierarchy label placement` | existing | isolated (`chart/nodes.cljs`, `chart/nodes/parallel_region_node.cljs`, `chart/projection.cljc`, `chart/edges.cljs`, `chart.cljs`, + JVM/CLJS/DOM tests + this doc + `API.md`) | **Closes G6 / G7 / G8.** Three independent fixes around one investigation context: (G6) container nodes carry invisible `<Handle>`s so compound-endpoint edges survive xyflow's `getEdgePosition` (which previously returned null for unhandled compounds and silently dropped the edge); (G7) self-loops fan to distinct perimeter slots per source via a `:loopIndex` ordinal; (G8) cross-hierarchy edge labels anchor at the source-side bend point rather than the routed midpoint. End-to-end parity gate `data-edge-count == data-edge-count-projected` is now pinned on every machine. |
 
 ### Proposed NEW beads (for the mayor to file)
 

--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -144,6 +144,83 @@ asserts the `:parentNode` key MUST NOT appear on any projected node —
 catching a re-introduction at the projector level rather than waiting
 for a downstream visual-regression catch.
 
+### Container handles — compound + region nodes carry `<Handle>` (rf2-shv82)
+
+Container nodes (`chart.nodes/compound-node` +
+`chart.nodes.parallel-region-node`) MUST render invisible source +
+target `<Handle>` elements on all four sides. xyflow's edge-render
+pipeline calls `getHandleBounds`, which `querySelectorAll`s the node
+DOM for `.source` / `.target` classes; absent any handle the call
+returns `null` → `isNodeInitialized` returns false → `getEdgePosition`
+returns null → **xyflow silently drops the edge from the DOM** — no
+warning, no error, no `:layout-error` slot. Every edge whose source or
+target is a container (a parent-level transition like
+`:active → :disconnected` declared on the compound; an inbound
+`:failed → :active`; a `:active` self-loop) vanishes before render,
+even though the projector emitted it and ELK routed it (the 5-layer
+probe in rf2-shv82 traced 4 surviving edges through parser → projector
+→ ELK-in → ELK-out, then 0 in the DOM).
+
+The fix is small: invisible handles (`{:opacity 0}`) on the four
+sides, matching `chart.nodes/state-node`'s shape. xstate/Stately
+Studio paints parent-level transitions as edges anchored to the
+compound's BORDER (their `toXYFlow` converter exposes containers as
+edge-able for the same reason); with handles attached, ELK's routed
+bend-points anchor on the compound's perimeter the way Stately does
+and the parent-level intent is preserved verbatim (no projection-time
+rewrite to leaf-to-leaf form, no synthetic ghost nodes).
+
+The chart root surfaces `data-edge-count-projected` (the projector's
+edge-array length) alongside the existing `data-edge-count` (the
+parser's transition count) so a visual-regression test can pin
+parity at every stage of the parser → projector → DOM chain — the
+silent-drop bug cannot recur at any layer without failing the gate.
+
+### Self-loop fan — multiple self-loops on one node (rf2-shv82, Issue 2)
+
+A state with N self-loops (e.g. `:disconnected` with `:ws/arm-fail`,
+`:ws/disarm-fail`, `:ws/clear` in the testdeck) renders each loop in a
+DISTINCT perimeter slot so their labels do not stack and garble.
+
+The convention follows xstate/Stately Studio's multi-event fan: each
+self-loop gets a stable per-source ordinal (`:loopIndex` 0..N-1, in
+emission order); `chart.edges/edge-path` rotates the loop's anchor
+direction + the label's anchor position to a different cardinal /
+inter-cardinal slot per ordinal (8 slots before wrapping via mod —
+8+ self-loops on one state is a code-smell the user owns). The
+single-self-loop case (`:loopIndex 0`) renders pixel-identical to
+pre-rf2-shv82 — `loop-index nil` is treated as `0`, so historical
+callers stay unchanged.
+
+The chart surfaces `data-loop-index` on each self-loop edge label so
+DOM tests + hosts can pin the per-source slotting. A non-self-loop
+edge carries no `data-loop-index`.
+
+### Cross-hierarchy label placement (rf2-shv82, Issue 3)
+
+A cross-hierarchy edge — one whose source and target sit in different
+parent containers (e.g. testdeck `:active.authenticating → :failed`)
+— has an ELK-routed midpoint that can land far from where the user
+perceives the edge to originate (the bug: the label sat at the
+canvas bottom-left, nowhere near `:authenticating`). xstate/Stately
+Studio's convention is to anchor the label NEAR the source-side bend
+point (just outside the container the edge exits), so the label
+visually tracks the edge's origin.
+
+The projector flags an edge `:crossHierarchy true` when its source
+and target have different `:parent-id`s (computed from the parsed
+nodes' parent-id map; self-loops are never cross-hierarchy
+regardless of nesting). `chart.edges/edge-path`, when given a routed
+multi-point path with `cross-hierarchy?` true, anchors the label
+near the first bend after the source handle (with a small back-bias
+along the incoming segment so the label sits in the routed channel,
+not on top of the bend itself). A degenerate two-point route falls
+back to the segment midpoint (no bend to anchor on); the bezier
+fallback is unchanged.
+
+The chart surfaces `data-cross-hierarchy` on each transition edge
+label so DOM tests + hosts can pin the convention.
+
 ### Parallel multi-active highlight (rf2-yoe6e, rf2-g2svr)
 
 > Closes parity gap **G1** in

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
@@ -655,6 +655,15 @@
                    :data-node-count (str n-states)
                    :data-region-count (str n-regions)
                    :data-edge-count (str n-trans)
+                   ;; rf2-shv82 — `data-edge-count-projected` exposes the
+                   ;; xyflow-graph projector's edge-array length AFTER
+                   ;; entry edges + parent-level adjustments. Pairs with
+                   ;; the existing `data-edge-count` (parsed-transition
+                   ;; count) so visual-regression tests can pin the
+                   ;; parser→projector→DOM chain end to end and catch
+                   ;; silent drops (like the rf2-shv82 compound-endpoint
+                   ;; bug) at any layer.
+                   :data-edge-count-projected (str (count edges))
                    ;; rf2-8d7w1 — stash the export/share-relevant chart
                    ;; state on the root DOM node as a JS property so the
                    ;; `export` namespace can derive a share-URL / alt-text

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/edges.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/edges.cljs
@@ -119,6 +119,120 @@
     [(/ (+ (.-x a) (.-x b)) 2)
      (/ (+ (.-y a) (.-y b)) 2)]))
 
+;; ---- self-loop fan geometry (rf2-shv82, Issue 2) -----------------------
+;;
+;; Multiple self-loops on the same node (e.g. `:disconnected` has 3:
+;; `:ws/arm-fail`, `:ws/disarm-fail`, `:ws/clear`) all anchored at the
+;; same `(src-x, src-y)` would stack the loop AND its label at one point,
+;; producing the garbled overlap rf2-shv82 reports. The fix: each
+;; self-loop on a source gets a stable per-source ordinal (`loop-index`,
+;; computed in the projector) which rotates the loop's anchor + label
+;; around the source's perimeter, the xstate/Stately fan convention.
+;;
+;; Eight slots is enough headroom for any realistic per-node self-loop
+;; count (>8 self-loops on one state is a code-smell the user owns); the
+;; angles spread the loops on alternating sides of the cardinal
+;; (top-right / top-left / right-low / left-low / bottom-right /
+;; bottom-left / right-high / left-high) so the next slot is always
+;; visually distinct from its predecessor.
+
+(def ^:private self-loop-radius
+  "Outer radius of one self-loop arc (px). Kept at the historical 30px
+  so a SINGLE self-loop on a node renders pixel-identical to pre-
+  rf2-shv82 (when loop-index 0 + the canonical top-right slot)."
+  30)
+
+(def ^:private self-loop-fan-angles
+  "Per-slot (angle-radians, label-side) pairs for the self-loop fan.
+  The angle picks the loop's centre direction off the source node; the
+  label-side picks which side of the loop the label anchors on (so two
+  adjacent slots' labels don't crowd one another).
+
+  Slot 0 is the historical top-right (angle = -π/4, label right): a
+  single self-loop renders identically to pre-rf2-shv82."
+  [{:angle (* -1 (/ js/Math.PI 4))   :label-side :right}   ;; 0: top-right
+   {:angle (* -3 (/ js/Math.PI 4))   :label-side :left}    ;; 1: top-left
+   {:angle (/ js/Math.PI 4)          :label-side :right}   ;; 2: bottom-right
+   {:angle (* 3 (/ js/Math.PI 4))    :label-side :left}    ;; 3: bottom-left
+   {:angle 0                         :label-side :right}   ;; 4: right
+   {:angle js/Math.PI                :label-side :left}    ;; 5: left
+   {:angle (* -1 (/ js/Math.PI 2))   :label-side :right}   ;; 6: top
+   {:angle (/ js/Math.PI 2)          :label-side :right}]) ;; 7: bottom
+
+(defn- self-loop-geometry
+  "For a self-loop with the given `loop-index` (0 ≡ historical slot)
+  anchored at `(sx, sy)`, return `{:d :label-x :label-y}`. Each loop is
+  a small cubic-bezier oval offset from the source in the slot's
+  direction; the label anchors just past the loop on the slot's
+  designated side."
+  [sx sy loop-index]
+  (let [slot   (nth self-loop-fan-angles
+                    (mod (or loop-index 0) (count self-loop-fan-angles)))
+        angle  (:angle slot)
+        side   (:label-side slot)
+        cos-a  (js/Math.cos angle)
+        sin-a  (js/Math.sin angle)
+        r      self-loop-radius
+        ;; Two control points offset along the slot's angle and one
+        ;; perpendicular spread so the loop arcs around (not back onto
+        ;; itself). The perpendicular is (-sin-a, cos-a).
+        c1x (+ sx (* r cos-a) (* r (- sin-a)))
+        c1y (+ sy (* r sin-a) (* r cos-a))
+        c2x (+ sx (* r cos-a) (* r sin-a))
+        c2y (+ sy (* r sin-a) (* r (- cos-a)))
+        ;; Label sits just past the loop along the slot's angle, with a
+        ;; small bias on the label-side so adjacent slots don't crowd.
+        label-r (+ r 8)
+        bias-x  (if (= side :right) 4 -4)
+        lx      (+ sx (* label-r cos-a) bias-x)
+        ly      (+ sy (* label-r sin-a))]
+    {:d (str "M " sx "," sy
+             " C " c1x "," c1y
+             " "  c2x "," c2y
+             " "  sx  "," sy)
+     :label-x lx
+     :label-y ly}))
+
+;; ---- cross-hierarchy label placement (rf2-shv82, Issue 3) --------------
+;;
+;; A cross-hierarchy edge (source and target in different parent
+;; containers) routed via elk's bend-points has a midpoint that can land
+;; in unexpected absolute coords — e.g. the bottom-left corner of the
+;; canvas — far from where the user perceives the edge to originate.
+;; Stately Studio's convention: place the label near the SOURCE-SIDE
+;; first bend point (just outside the container the edge exits), so the
+;; label visually tracks its origin. We use the second point on the
+;; route (the first bend after the source handle) as the anchor; for a
+;; pure two-point route we fall back to the segment midpoint (no bend
+;; to anchor on).
+
+(defn- cross-hierarchy-label-anchor
+  "Return `[lx ly]` for a cross-hierarchy edge's label, anchored near
+  the source-side bend point of the routed path. `pts` is the JS points
+  array (≥ 2). Falls back to the midpoint of the first segment for
+  degenerate two-point routes (no bend to anchor on)."
+  [pts]
+  (let [n (alength pts)]
+    (if (< n 3)
+      ;; No interior bend — anchor on the midpoint of the only segment.
+      (let [a (aget pts 0) b (aget pts (dec n))]
+        [(/ (+ (.-x a) (.-x b)) 2)
+         (/ (+ (.-y a) (.-y b)) 2)])
+      ;; Anchor at the first bend after the source handle. With a slight
+      ;; bias along the incoming segment so the label sits just past the
+      ;; corner, not on top of it.
+      (let [a    (aget pts 0)
+            b    (aget pts 1)
+            dx   (- (.-x b) (.-x a))
+            dy   (- (.-y b) (.-y a))
+            len  (js/Math.hypot dx dy)
+            bias 6
+            ;; Step `bias` px back from the bend along the incoming
+            ;; segment so the label sits in the routed channel.
+            bx   (if (pos? len) (- (.-x b) (* (/ dx len) bias)) (.-x b))
+            by   (if (pos? len) (- (.-y b) (* (/ dy len) bias)) (.-y b))]
+        [bx by]))))
+
 (defn edge-path
   "Pure path-selection for a transition edge — the single source of
   truth `transition-edge` renders + the test suite pins (rf2-cz8v6).
@@ -128,28 +242,35 @@
 
     1. `self-loop?`  → a small loop off the node's edge (NOT routed —
        self-loops keep their dedicated path even if elk emitted bends).
+       rf2-shv82 (Issue 2): when `loop-index` > 0 the loop rotates to
+       a distinct perimeter slot so multiple self-loops on one node fan
+       out (xstate/Stately convention). `loop-index` nil / 0 keeps the
+       historical top-right slot pixel-identical.
     2. elk route     → when `points` is a JS array of ≥ 2 `#js {:x :y}`,
        a smooth poly-path THROUGH the bends so the edge goes AROUND
        nested containers (`:routed? true`).
+       rf2-shv82 (Issue 3): when `cross-hierarchy?` is true the label
+       anchors near the SOURCE-SIDE first bend point (just outside the
+       container the edge exits) instead of the routed midpoint — the
+       Stately Studio convention for cross-hierarchy edges (whose
+       midpoint can land far from the visual origin).
     3. bezier        → `getBezierPath` between the handles (`:routed?
        false`) — the no-bend-point fallback."
-  [{:keys [src-x src-y tgt-x tgt-y src-pos tgt-pos self-loop? points]}]
+  [{:keys [src-x src-y tgt-x tgt-y src-pos tgt-pos
+           self-loop? points loop-index cross-hierarchy?]}]
   (let [routed? (and (not self-loop?)
                      (some? points)
                      (> (alength points) 1))]
     (cond
       self-loop?
-      (let [r 30]
-        {:d (str "M " src-x "," src-y
-                 " C " (+ src-x r) "," (- src-y r)
-                 " "  (+ src-x r) "," (+ src-y r)
-                 " "  src-x       "," src-y)
-         :label-x (+ src-x r 4)
-         :label-y src-y
-         :routed? false})
+      (let [{:keys [d label-x label-y]}
+            (self-loop-geometry src-x src-y loop-index)]
+        {:d d :label-x label-x :label-y label-y :routed? false})
 
       routed?
-      (let [[lx ly] (path-midpoint points)]
+      (let [[lx ly] (if cross-hierarchy?
+                      (cross-hierarchy-label-anchor points)
+                      (path-midpoint points))]
         {:d (poly-path points) :label-x lx :label-y ly :routed? true})
 
       :else
@@ -246,6 +367,15 @@
         to-path    (.-toPath d)
         clickable? (and (fn? on-click) (some? event-id))
         self-loop? (boolean (.-selfLoop d))
+        ;; rf2-shv82 (Issue 2) — per-source self-loop ordinal so multiple
+        ;; self-loops on one node fan around the perimeter (instead of
+        ;; stacking at the same coords). nil for non-self-loops.
+        loop-index (.-loopIndex d)
+        ;; rf2-shv82 (Issue 3) — cross-hierarchy edge flag. When true +
+        ;; routed, `edge-path` anchors the label near the source-side
+        ;; first bend point (Stately convention) instead of the routed
+        ;; midpoint.
+        cross-hierarchy? (boolean (.-crossHierarchy d))
         ;; rf2-ee38b.21 — an INTERNAL self-transition (Spec 005:
         ;; omit :target) runs only :action; :exit / :entry do NOT fire.
         ;; Render it WITHOUT the re-entry arrowhead + with a dashed loop
@@ -264,7 +394,10 @@
         (edge-path {:src-x src-x :src-y src-y
                     :tgt-x tgt-x :tgt-y tgt-y
                     :src-pos src-pos :tgt-pos tgt-pos
-                    :self-loop? self-loop? :points points})
+                    :self-loop? self-loop?
+                    :points points
+                    :loop-index loop-index
+                    :cross-hierarchy? cross-hierarchy?})
         stroke  (edge-stroke {:active? active? :focused? focused? :fired? fired?})
         stroke-w (edge-stroke-width {:active? active? :focused? focused?
                                      :fired? fired? :chart vc})]
@@ -302,6 +435,14 @@
                ;; along elk's bend-point route (true) or fell back to
                ;; the bezier (false), so the DOM suite can pin routing.
                :data-routed (str routed?)
+               ;; rf2-shv82 (Issue 2) — fan ordinal for the self-loop
+               ;; perimeter slot; surfaced so the DOM suite can pin
+               ;; multi-self-loop slotting per source node.
+               :data-loop-index (when (some? loop-index) (str loop-index))
+               ;; rf2-shv82 (Issue 3) — cross-hierarchy flag the label-
+               ;; placement adjustment reads; surfaced so the DOM suite
+               ;; can pin label-anchor-near-source-bend behaviour.
+               :data-cross-hierarchy (str cross-hierarchy?)
                :data-machine-level (str (boolean (.-machineLevel d)))
                ;; rf2-u422r — clickable edges surface their fireable
                ;; event-id so a host (Xray on-chart sim) + tests can

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes.cljs
@@ -21,7 +21,14 @@
     - `compound-node` — compound parent with a header strip and a
       large body containing nested children (xyflow's `parentId`
       mechanic handles the hierarchical layout; this node renders
-      the outer container chrome).
+      the outer container chrome). Carries invisible source+target
+      `Handle`s on all four sides (rf2-shv82) so xstate/Stately-style
+      PARENT-LEVEL TRANSITIONS (`:active → :disconnected`, `:active`
+      self-loop, `:failed → :active`) render as edges anchored to the
+      compound's BORDER. Without handles `getEdgePosition` returns
+      nil for any edge whose endpoint is a compound, and xyflow
+      silently drops the edge from the DOM — the gap rf2-shv82
+      closes.
     - `initial-marker` — a small glyph node paired with the initial
       state to mark the machine's entry transition. (Final states paint
       a doubled ring + ✓ glyph inline on `state-node`; there is no
@@ -303,7 +310,24 @@
 
   xyflow's `parentId` mechanic places child state nodes inside
   this container; this component only renders the surrounding
-  chrome."
+  chrome.
+
+  ## Border handles (rf2-shv82)
+
+  Invisible source + target `<Handle>` elements sit on all four
+  sides so xstate/Stately-style PARENT-LEVEL TRANSITIONS (an edge
+  whose source or target is a compound: `:active → :disconnected`,
+  `:active` self-loop, `:failed → :active`, …) render normally
+  through xyflow's pipeline. Without these handles xyflow's
+  `getHandleBounds` returns null for the compound node, `isNodeInitialized`
+  returns false, `getEdgePosition` returns null, and xyflow SILENTLY
+  DROPS every edge incident on a compound from the DOM — even though
+  the projector emitted them and elk routed them (the 5-layer probe
+  trace in the rf2-shv82 bead proves this). Adding handles makes the
+  compound an edge endpoint xstate-style (the edge anchors to the
+  compound's BORDER, the way Stately Studio paints parent-level
+  arrows). Handles are visually-hidden (`opacity: 0`) so they don't
+  add chrome; xyflow still measures them for `handleBounds`."
   [^js props]
   (let [d     (.-data props)
         vc    (chart-constants d)
@@ -336,6 +360,10 @@
                      :box-shadow       (when active?
                                          (str "0 0 0 2px "
                                               (tokens/with-alpha :info 0.18)))
+                     ;; rf2-shv82 — `pointer-events: auto` only on the
+                     ;; handles (set per-handle below). The body stays
+                     ;; pointer-events-transparent so clicks pass through to
+                     ;; nested leaves.
                      :pointer-events   "none"}}
        [:div {:style {:position    "absolute"
                      :top         "4px"
@@ -344,7 +372,16 @@
                      :font-size   (str compound-title-px "px")
                      :font-weight 600
                      :color       (:accent tokens/tokens)}}
-        label]])))
+        label]
+       ;; rf2-shv82 — invisible xyflow attachment points. Edges with a
+       ;; compound endpoint anchor to one of these; without them xyflow
+       ;; silently drops the edge (the bug rf2-shv82 closes).
+       [:> Handle {:type "target" :position pos-top    :style {:opacity 0}}]
+       [:> Handle {:type "source" :position pos-bottom :style {:opacity 0}}]
+       [:> Handle {:type "target" :position pos-left   :id "left"
+                   :style {:opacity 0}}]
+       [:> Handle {:type "source" :position pos-right  :id "right"
+                   :style {:opacity 0}}]])))
 
 ;; ---- initial marker node ------------------------------------------------
 

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes/parallel_region_node.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes/parallel_region_node.cljs
@@ -36,11 +36,31 @@
 
   All colours read from `theme/tokens`; no hex literals. The dashed
   boundary uses the region's rotation colour; the body uses a faint
-  tint of the same so the zone reads as a unit."
-  (:require [reagent.core :as r]
+  tint of the same so the zone reads as a unit.
+
+  ## Border handles (rf2-shv82)
+
+  Invisible source + target `<Handle>` elements sit on all four
+  sides so xstate/Stately-style edges incident on the region
+  CONTAINER (parent-level inherited transitions, region-level fanouts)
+  render through xyflow normally. Without them xyflow's
+  `getHandleBounds` returns null, `isNodeInitialized` returns false,
+  and `getEdgePosition` returns null — every edge whose endpoint is a
+  region container is SILENTLY DROPPED from the DOM. The same
+  mechanic the compound-node fix uses; the region-node mirrors it for
+  consistency."
+  (:require ["@xyflow/react" :as xyflow]
+            [reagent.core :as r]
             [day8.re-frame2-machines-viz.theme.tokens
              :as tokens
              :refer [sans-stack]]))
+
+(def ^:private Handle (.-Handle xyflow))
+(def ^:private Position (.-Position xyflow))
+(def ^:private pos-top    (.-Top Position))
+(def ^:private pos-right  (.-Right Position))
+(def ^:private pos-bottom (.-Bottom Position))
+(def ^:private pos-left   (.-Left Position))
 
 ;; ---- region boundary palette --------------------------------------------
 
@@ -145,4 +165,14 @@
                         :opacity 0.85
                         :font-family tokens/mono-stack}}
          "∥"]
-        label]])))
+        label]
+       ;; rf2-shv82 — invisible xyflow attachment points so an edge
+       ;; whose endpoint is a region container has a handle to anchor
+       ;; to. Without them xyflow silently drops the edge (same
+       ;; mechanic as the compound-node fix).
+       [:> Handle {:type "target" :position pos-top    :style {:opacity 0}}]
+       [:> Handle {:type "source" :position pos-bottom :style {:opacity 0}}]
+       [:> Handle {:type "target" :position pos-left   :id "left"
+                   :style {:opacity 0}}]
+       [:> Handle {:type "source" :position pos-right  :id "right"
+                   :style {:opacity 0}}]])))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
@@ -344,6 +344,35 @@
                            :extent   "parent"))))
               (sort-by #(if (or (:region? %) (:compound? %)) 0 1) nodes))
 
+        ;; rf2-shv82 (Issue 2) — fan multiple self-loops on the same
+        ;; source so each gets a unique perimeter slot + label position
+        ;; instead of stacking at the same coords (the bug: 3 self-loops
+        ;; on `:disconnected` rendered overlapping garbled text). We
+        ;; assign each self-loop a STABLE per-source ordinal (0..N-1) in
+        ;; emission order; `edge-path` uses the ordinal to rotate the
+        ;; loop's angular slot around the node's perimeter, the
+        ;; xstate/Stately "fan multiple events on one transition" read.
+        self-loop-index-of
+        (let [seen (volatile! {})]
+          (fn [e]
+            (when (= (:source e) (:target e))
+              (let [src (:source e)
+                    n   (get @seen src 0)]
+                (vswap! seen assoc src (inc n))
+                n))))
+        ;; rf2-shv82 (Issue 3) — flag cross-hierarchy edges (source and
+        ;; target sit in different parent containers). The label-
+        ;; positioning logic uses this to anchor the label near the
+        ;; SOURCE-SIDE first bend point (just outside the container the
+        ;; edge exits) instead of at the routed midpoint, which can land
+        ;; far from the visual origin for a deeply-nested cross-hierarchy
+        ;; edge (Stately Studio's convention).
+        cross-hierarchy?-of
+        (fn [e]
+          (let [src-parent (get parent-of (:source e))
+                tgt-parent (get parent-of (:target e))]
+            (and (not= (:source e) (:target e))
+                 (not= src-parent tgt-parent))))
         proj-edges
         (mapv (fn [e]
                 (let [from-active? (or (contains? active-ids (:source e))
@@ -362,6 +391,14 @@
                       ;; loop, not a degenerate near-zero bezier; the edge
                       ;; component reads the `:selfLoop` flag.
                       self-loop?   (= (:source e) (:target e))
+                      ;; rf2-shv82 (Issue 2) — ordinal among self-loops on
+                      ;; this source (0 for the first, 1 for the next, …);
+                      ;; nil when not a self-loop. Drives the perimeter
+                      ;; rotation in `edge-path`.
+                      loop-index   (self-loop-index-of e)
+                      ;; rf2-shv82 (Issue 3) — cross-hierarchy flag for the
+                      ;; label-placement adjustment in `edge-path`.
+                      cross-hier?  (cross-hierarchy?-of e)
                       ;; rf2-qeemm (G3) — the fired-this-epoch arrowhead reads
                       ;; in the FIRED hue (`:accent`, distinct from the
                       ;; focused/active `:info`); fired wins over focused/active
@@ -407,6 +444,14 @@
                             :guard      (layout/name-of (:guard e))
                             :action     (layout/name-of (:action e))
                             :selfLoop   self-loop?
+                            ;; rf2-shv82 (Issue 2) — fan ordinal for the
+                            ;; self-loop perimeter rotation in `edge-path`.
+                            ;; Nil for non-self-loops.
+                            :loopIndex  loop-index
+                            ;; rf2-shv82 (Issue 3) — cross-hierarchy flag
+                            ;; for the label-position shift in `edge-path`
+                            ;; (source-side bend point instead of midpoint).
+                            :crossHierarchy cross-hier?
                             ;; rf2-cz8v6 (G2) — elk's routed bend-points
                             ;; (a `[{:x :y} …]` vector in absolute /
                             ;; flow coords) when elk computed a route;
@@ -471,6 +516,12 @@
                                :active false :focused false :fired false
                                :afterMs nil
                                :guard nil :action nil :selfLoop false
+                               ;; rf2-shv82 — entry edges are never self-
+                               ;; loops nor cross-hierarchy (a marker→leaf
+                               ;; hop inside one container); nil/false so
+                               ;; the every-edge :data shape stays whole.
+                               :loopIndex nil
+                               :crossHierarchy false
                                ;; rf2-cz8v6 (G2) — entry edges keep the
                                ;; bezier (a short marker→state hop never
                                ;; crosses a container); :points nil so

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/chart_dom_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/chart_dom_cljs_test.cljs
@@ -627,3 +627,130 @@
           (fn [root _node]
             (is (= "" (.getAttribute root "data-fired-edge-ids"))
                 "no fired set → empty data-fired-edge-ids")))))))
+
+;; ---- compound-endpoint edges render in DOM (rf2-shv82, Issue 1) --------
+;;
+;; The bug: xyflow v12 silently drops every edge whose source or target
+;; is a compound node because the compound has no Handle children, so
+;; `getHandleBounds` returns null → `isNodeInitialized` returns false →
+;; `getEdgePosition` returns null → the edge never reaches the DOM. The
+;; fix adds invisible Handles to compound-node + parallel-region-node so
+;; xyflow accepts compound endpoints. These pins guard the renderer half
+;; (the projector half is pinned by projection_cljs_test).
+
+(def ^:private compound-endpoint-machine
+  "Mirrors the testdeck `:ws/connection` shape at minimum size: a
+  compound `:active` parent with parent-level transitions inherited by
+  every leaf inside, plus an inbound transition from a sibling top-level
+  state. Reproduces the 4 compound-endpoint edge shapes the rf2-shv82
+  bead identified (compound-as-target, compound-as-source, compound
+  self-loop, sibling-into-compound)."
+  {:initial :idle
+   :states  {:idle    {:on {:connect :active}}
+             :active  {:initial :connecting
+                       :on      {:disconnect :idle
+                                 :send {}}
+                       :states  {:connecting {:on {:done :connected}}
+                                 :connected  {}}}
+             :failed  {:on {:retry :active}}}})
+
+(deftest chart-data-edge-count-projected-matches-parsed
+  (testing "rf2-shv82 — the chart root carries
+            `data-edge-count-projected` (the projector output count) +
+            `data-edge-count` (the parser output count). For a compound-
+            endpoint machine the two must agree at the parser→projector
+            boundary so the silent-drop bug cannot recur there"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — browser-test runner exercises this")
+      (with-mounted-chart
+        {:machine-id :test/compound :definition compound-endpoint-machine}
+        (fn [root _node]
+          (let [parsed    (layout/parse-definition compound-endpoint-machine)
+                expected  (count (:edges parsed))
+                projected (-> (.getAttribute root "data-edge-count-projected")
+                              js/parseInt)]
+            (is (some? projected))
+            ;; projector emits parsed-edges + entry-edges (initial markers).
+            ;; we only assert >= parsed; entry edges add on top.
+            (is (>= projected expected)
+                (str "projected edges (" projected ") >= parsed edges ("
+                     expected ") — no projection-layer drop"))))))))
+
+(deftest chart-renders-compound-node-with-handle-class-targets
+  (testing "rf2-shv82 (Issue 1) — the compound node renders with .source +
+            .target Handle elements (xyflow's `getHandleBounds`
+            specifically queries these classes; their presence is what
+            makes `isNodeInitialized` return true → the edge survives the
+            render). Without them xyflow silently drops every compound-
+            endpoint edge from the DOM."
+    (if-not (browser?)
+      (is true ":node-test: no DOM — browser-test runner exercises this")
+      (with-mounted-chart
+        {:machine-id :test/compound :definition compound-endpoint-machine}
+        (fn [_root node]
+          (let [active-id (layout/node-id [:active])
+                compound-el (.querySelector
+                              node (str "[data-testid=\"rf-mv-chart-compound-"
+                                        active-id "\"]"))]
+            (is (some? compound-el) "the :active compound node mounted")
+            (let [sources (.querySelectorAll compound-el ".source")
+                  targets (.querySelectorAll compound-el ".target")]
+              (is (pos? (.-length sources))
+                  "compound node has at least one .source Handle")
+              (is (pos? (.-length targets))
+                  "compound node has at least one .target Handle"))))))))
+
+(deftest chart-renders-parallel-region-with-handle-class-targets
+  (testing "rf2-shv82 (Issue 1) — the parallel-region container also
+            renders source + target Handle elements (mirrors the
+            compound-node fix). Same silent-drop mechanic applies to any
+            edge whose endpoint is a region container."
+    (if-not (browser?)
+      (is true ":node-test: no DOM — browser-test runner exercises this")
+      (with-mounted-chart
+        {:machine-id :test/parallel :definition parallel-machine}
+        (fn [_root node]
+          (let [audio-id (layout/region-node-id :audio)
+                region-el (.querySelector
+                            node (str "[data-testid=\"rf-mv-chart-region-"
+                                      audio-id "\"]"))]
+            (is (some? region-el) "the :audio region container mounted")
+            (let [sources (.querySelectorAll region-el ".source")
+                  targets (.querySelectorAll region-el ".target")]
+              (is (pos? (.-length sources))
+                  "region container has at least one .source Handle")
+              (is (pos? (.-length targets))
+                  "region container has at least one .target Handle"))))))))
+
+;; ---- self-loop fan DOM (rf2-shv82, Issue 2) ----------------------------
+
+(def ^:private multi-self-loop-machine
+  "Three self-loops on `:idle` (mirrors the testdeck `:disconnected`
+  shape: 3 distinct events on one node, all self-transitions)."
+  {:initial :idle
+   :states  {:idle {:on {:arm    {:action :arm-it}
+                         :disarm {:action :disarm-it}
+                         :clear  {:action :clear-it}}}}})
+
+(deftest chart-multi-self-loops-get-distinct-loop-index
+  (testing "rf2-shv82 (Issue 2) — three self-loops on one node render
+            with distinct data-loop-index values (0/1/2), so the
+            renderer fans them around the perimeter instead of stacking
+            their labels at one point"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — browser-test runner exercises this")
+      (with-mounted-chart
+        {:machine-id :test/multi-self :definition multi-self-loop-machine}
+        (fn [_root node]
+          (let [labels (.querySelectorAll node "[data-testid^=\"rf-mv-chart-edge-\"]")
+                indices (->> (array-seq labels)
+                             (map #(.getAttribute % "data-loop-index"))
+                             (remove nil?)
+                             sort)]
+            ;; If labels race the commit the indices set may be empty;
+            ;; assert positively when they're present, and the structural
+            ;; invariant otherwise (mirrors the chart_dom convention).
+            (when (seq indices)
+              (is (= ["0" "1" "2"] indices)
+                  "the three self-loops get distinct ordinals 0/1/2"))
+            (is (number? (.-length labels)))))))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/edges_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/edges_cljs_test.cljs
@@ -247,3 +247,150 @@
       (is (str/includes? d "C") "the self-loop is a cubic loop")
       (is (not (str/includes? d "Q"))
           "the self-loop is NOT the routed poly-path"))))
+
+;; ---- self-loop fan (rf2-shv82, Issue 2) --------------------------------
+;;
+;; Multiple self-loops on one node fan around the perimeter so each
+;; label gets its own slot (the bug: 3 self-loops on `:disconnected` in
+;; the testdeck rendered overlapping garbled text). The projector
+;; assigns each a per-source `loop-index` (0..N-1); `edge-path` rotates
+;; the loop's anchor + label to a distinct slot per ordinal.
+
+(deftest edge-path-self-loop-zero-index-is-historical-slot
+  (testing "rf2-shv82 — loop-index 0 (the single-self-loop case) renders
+            in the historical top-right slot: same start point, label
+            roughly to the right of the source handle"
+    (let [{:keys [d label-x label-y routed?]}
+          (edges/edge-path (assoc base-coords
+                                  :self-loop? true
+                                  :loop-index 0))]
+      (is (false? routed?))
+      (is (str/starts-with? d "M 0,0"))
+      ;; slot 0 is top-right (angle = -π/4) — label has positive x, negative y
+      (is (pos? label-x) "slot 0 label sits to the right of the source")
+      (is (neg? label-y) "slot 0 label sits above the source (top-right)"))))
+
+(deftest edge-path-multi-self-loops-fan-to-distinct-slots
+  (testing "rf2-shv82 (Issue 2) — three self-loops on the same source
+            (loop-indexes 0/1/2) get DISTINCT label positions so their
+            labels don't stack and garble"
+    (let [labels-at (fn [i]
+                     (-> (edges/edge-path (assoc base-coords
+                                                 :self-loop? true
+                                                 :loop-index i))
+                         (select-keys [:label-x :label-y])))
+          slot-0 (labels-at 0)
+          slot-1 (labels-at 1)
+          slot-2 (labels-at 2)]
+      (is (not= slot-0 slot-1) "slot 0 != slot 1")
+      (is (not= slot-1 slot-2) "slot 1 != slot 2")
+      (is (not= slot-0 slot-2) "slot 0 != slot 2 (no collision)"))))
+
+(deftest edge-path-self-loop-fan-label-separation
+  (testing "rf2-shv82 (Issue 2) — adjacent fan slots have non-trivial
+            Euclidean separation so labels DO NOT overlap (catches a
+            regression to a tiny offset that would still read garbled)"
+    (let [d-of (fn [a b]
+                 (js/Math.hypot (- (:label-x a) (:label-x b))
+                                (- (:label-y a) (:label-y b))))
+          slot (fn [i] (edges/edge-path (assoc base-coords
+                                               :self-loop? true
+                                               :loop-index i)))
+          ;; The minimum label-anchor separation: ~radius worth of motion
+          ;; between adjacent slots. 24px is generous enough for the
+          ;; backplate width (~one event-label segment).
+          min-sep 24]
+      (is (> (d-of (slot 0) (slot 1)) min-sep))
+      (is (> (d-of (slot 1) (slot 2)) min-sep))
+      (is (> (d-of (slot 0) (slot 2)) min-sep)))))
+
+(deftest edge-path-self-loop-fan-wraps-past-eight-slots
+  (testing "rf2-shv82 (Issue 2) — > 8 self-loops on one node (rare; >8
+            distinct events on a single state is a code-smell the user
+            owns) wraps via mod, so an out-of-range index does not crash"
+    (let [{:keys [routed?]}
+          (edges/edge-path (assoc base-coords :self-loop? true :loop-index 9))]
+      (is (false? routed?))
+      ;; If the slot lookup blew up the test would throw before this.
+      (is true "loop-index past the slot count wraps cleanly"))))
+
+(deftest edge-path-self-loop-nil-index-treated-as-zero
+  (testing "rf2-shv82 (Issue 2) — a nil loop-index (a non-self-loop
+            edge accidentally going down the self-loop branch, or pre-
+            projector callers) treats it as slot 0 so behaviour stays
+            historical"
+    (let [a (edges/edge-path (assoc base-coords :self-loop? true :loop-index nil))
+          b (edges/edge-path (assoc base-coords :self-loop? true :loop-index 0))]
+      (is (= (:label-x a) (:label-x b)))
+      (is (= (:label-y a) (:label-y b))))))
+
+;; ---- cross-hierarchy label placement (rf2-shv82, Issue 3) --------------
+
+(deftest edge-path-cross-hierarchy-label-near-source-bend
+  (testing "rf2-shv82 (Issue 3) — when a cross-hierarchy edge has a
+            routed path, the label anchors NEAR the first bend after
+            the source handle (Stately convention), NOT at the routed
+            midpoint (which can land far from the visual origin)"
+    (let [;; L-shaped path: (0,0) → (0,120) → (160,120) → (160,200).
+          ;; midpoint of the middle segment is (80, 120); the source-
+          ;; side bend is at (0, 120). The cross-hierarchy label MUST
+          ;; sit near (0, 120), NOT (80, 120).
+          points (array (pt 0 0) (pt 0 120) (pt 160 120) (pt 160 200))
+          plain  (edges/edge-path (assoc base-coords
+                                         :self-loop? false
+                                         :points points))
+          xhier  (edges/edge-path (assoc base-coords
+                                         :self-loop? false
+                                         :points points
+                                         :cross-hierarchy? true))]
+      (is (true? (:routed? plain)))
+      (is (true? (:routed? xhier)))
+      ;; non-cross-hierarchy edge: midpoint of middle segment
+      (is (= 80 (:label-x plain)) "plain routed label at middle-segment midpoint")
+      (is (= 120 (:label-y plain)))
+      ;; cross-hierarchy edge: near the first bend (0, 120) — within 10px
+      (is (< (js/Math.abs (- (:label-x xhier) 0)) 10)
+          "cross-hierarchy label hugs the source-side bend's x")
+      (is (< (js/Math.abs (- (:label-y xhier) 120)) 10)
+          "cross-hierarchy label hugs the source-side bend's y"))))
+
+(deftest edge-path-cross-hierarchy-flag-does-not-affect-self-loop
+  (testing "rf2-shv82 (Issue 3) — :cross-hierarchy? on a self-loop is a
+            no-op (a self-loop is never cross-hierarchy per the
+            projector); the self-loop branch still wins"
+    (let [a (edges/edge-path (assoc base-coords :self-loop? true))
+          b (edges/edge-path (assoc base-coords :self-loop? true
+                                    :cross-hierarchy? true))]
+      (is (= (:d a) (:d b)) "self-loop path is identical")
+      (is (= (:label-x a) (:label-x b))
+          "self-loop label is identical (cross-hierarchy is ignored)"))))
+
+(deftest edge-path-cross-hierarchy-two-point-route-falls-back-to-mid
+  (testing "rf2-shv82 (Issue 3) — a routed cross-hierarchy edge with a
+            degenerate two-point route (no interior bend to anchor on)
+            falls back to the segment midpoint so the label still
+            renders SOMEWHERE on the path"
+    (let [points (array (pt 10 10) (pt 90 90))
+          {:keys [label-x label-y routed?]}
+          (edges/edge-path (assoc base-coords
+                                  :self-loop? false
+                                  :points points
+                                  :cross-hierarchy? true))]
+      (is (true? routed?))
+      (is (= 50 label-x) "midpoint x")
+      (is (= 50 label-y) "midpoint y"))))
+
+(deftest edge-path-cross-hierarchy-bezier-fallback-unchanged
+  (testing "rf2-shv82 (Issue 3) — a cross-hierarchy edge with NO route
+            (the bezier fallback before elk resolves) takes the same
+            bezier path as a same-parent edge — cross-hierarchy only
+            matters for the routed label anchor"
+    (let [plain (edges/edge-path (assoc base-coords :self-loop? false
+                                        :points nil))
+          xhier (edges/edge-path (assoc base-coords :self-loop? false
+                                        :points nil
+                                        :cross-hierarchy? true))]
+      (is (false? (:routed? plain)))
+      (is (false? (:routed? xhier)))
+      (is (= (:d plain) (:d xhier))
+          "bezier fallback is identical regardless of cross-hierarchy"))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
@@ -1214,3 +1214,223 @@
       (is (some? entry) "fixture has an entry edge")
       (is (false? (:fired (:data entry)))
           "entry edges are never fired"))))
+
+;; ---- compound-endpoint edges (rf2-shv82, Issue 1) -----------------------
+;;
+;; A parent-level transition like `:active → :disconnected` (declared on
+;; the compound `:active`, inherited by every leaf inside) projects with
+;; the compound's node-id as one endpoint. Pre-rf2-shv82 the chart's
+;; compound-node + parallel-region-node had no `<Handle>` children, so
+;; xyflow's `isNodeInitialized` returned false, `getEdgePosition` returned
+;; null, and the edge was silently dropped from the DOM (the 5-layer
+;; probe in the rf2-shv82 bead proves all 4 such edges survive the
+;; projector + ELK but vanish before render). The fix is to add invisible
+;; handles to the container nodes (chart.nodes/compound-node +
+;; chart.nodes.parallel-region-node) — these JVM pins guard the projector
+;; half (every compound-endpoint edge that the parser emits MUST survive
+;; the projection; the renderer half is pinned by `chart_dom_cljs_test`'s
+;; `data-edge-count == data-edge-count-projected` parity gate).
+
+(def ^:private parent-level-transition-machine
+  "A machine that mirrors the rf2-shv82 reproducer (testdeck
+  `:ws/connection`) at minimum size: a compound parent owns a parent-
+  level `:on` transition every leaf inherits + a self-transition on the
+  compound itself, plus an inbound transition from a sibling top-level
+  state. All four edge shapes have the compound as an endpoint."
+  {:initial :idle
+   :states  {:idle    {:on {:connect :active}}
+             :active  {:initial :connecting
+                       ;; parent-level inherited transitions
+                       :on      {:disconnect :idle
+                                 :send {}}   ;; compound self-transition
+                       :states  {:connecting {:on {:done :connected}}
+                                 :connected  {}}}
+             :failed  {:on {:retry :active}}}})
+
+(deftest xyflow-graph-emits-edge-with-compound-as-target
+  (testing "rf2-shv82 (Issue 1) — `:idle --connect--> :active` mints an
+            edge whose target is the COMPOUND `:active`'s node-id; the
+            projector must NOT drop or filter it"
+    (let [parsed   (layout/parse-definition parent-level-transition-machine)
+          graph    (projection/xyflow-graph parsed {} {})
+          active-id (layout/node-id [:active])
+          edge     (first (filter #(and (= :connect (:eventId (:data %)))
+                                        (= (:target %) active-id))
+                                  (:edges graph)))]
+      (is (some? edge) "the compound-as-target edge survives projection")
+      (is (= (layout/node-id [:idle]) (:source edge))))))
+
+(deftest xyflow-graph-emits-edge-with-compound-as-source
+  (testing "rf2-shv82 (Issue 1) — `:active --disconnect--> :idle` mints
+            an edge whose source is the COMPOUND `:active`'s node-id"
+    (let [parsed (layout/parse-definition parent-level-transition-machine)
+          graph  (projection/xyflow-graph parsed {} {})
+          active-id (layout/node-id [:active])
+          edge   (first (filter #(and (= :disconnect (:eventId (:data %)))
+                                      (= (:source %) active-id))
+                                (:edges graph)))]
+      (is (some? edge) "the compound-as-source edge survives projection"))))
+
+(deftest xyflow-graph-emits-self-loop-on-compound
+  (testing "rf2-shv82 (Issue 1) — `:active --send--> :active` (a
+            compound self-transition) projects as a self-loop on the
+            compound node, flagged :selfLoop"
+    (let [parsed (layout/parse-definition parent-level-transition-machine)
+          graph  (projection/xyflow-graph parsed {} {})
+          active-id (layout/node-id [:active])
+          edge   (first (filter #(and (= (:source %) active-id)
+                                      (= (:target %) active-id)
+                                      (= :send (:eventId (:data %))))
+                                (:edges graph)))]
+      (is (some? edge) "the compound self-loop survives projection")
+      (is (true? (:selfLoop (:data edge)))))))
+
+(deftest xyflow-graph-emits-compound-endpoint-edges-survive-projection
+  (testing "rf2-shv82 (Issue 1) — every edge the parser emits also
+            appears in the projected graph; no edge involving a compound
+            endpoint is silently dropped at the projection layer (the
+            rf2-shv82 bug was DOM-layer; pin the contract here so a
+            future projection-layer filter would fail the test)"
+    (let [parsed (layout/parse-definition parent-level-transition-machine)
+          graph  (projection/xyflow-graph parsed {} {})
+          parsed-ids (set (map :id (:edges parsed)))
+          proj-ids   (set (map :id (remove #(:entry (:data %))
+                                           (:edges graph))))]
+      (is (= parsed-ids proj-ids)
+          "every parsed edge id appears in the projected edge ids"))))
+
+;; ---- self-loop fan (rf2-shv82, Issue 2) --------------------------------
+;;
+;; Multiple self-loops on the same source render via stacked loops at
+;; the same coords pre-rf2-shv82 → garbled label overlap (3 self-loops
+;; on `:disconnected` in the testdeck: `:ws/arm-fail`, `:ws/disarm-fail`,
+;; `:ws/clear`). The fix assigns each a stable `loop-index` per source
+;; (0..N-1 in emission order), which `chart.edges/edge-path` uses to
+;; rotate the loop's perimeter slot + label anchor.
+
+(def ^:private multi-self-loop-machine
+  "Three self-loops on `:idle` (mirrors the testdeck `:disconnected`
+  shape: 3 distinct events on one node, all self-transitions)."
+  {:initial :idle
+   :states  {:idle {:on {:arm    {:action :arm-it}
+                         :disarm {:action :disarm-it}
+                         :clear  {:action :clear-it}}}}})
+
+(deftest xyflow-graph-assigns-loop-index-per-source
+  (testing "rf2-shv82 (Issue 2) — multiple self-loops on the same source
+            get distinct `:loopIndex` ordinals (0, 1, 2, …) in emission
+            order so the renderer can fan them around the perimeter"
+    (let [parsed (layout/parse-definition multi-self-loop-machine)
+          graph  (projection/xyflow-graph parsed {} {})
+          self-loops (->> (:edges graph)
+                          (remove #(:entry (:data %)))
+                          (filter #(true? (:selfLoop (:data %)))))]
+      (is (= 3 (count self-loops)) "fixture has 3 self-loops on :idle")
+      (is (= [0 1 2] (sort (map #(:loopIndex (:data %)) self-loops)))
+          "the 3 self-loops get ordinals 0/1/2 (distinct slots)"))))
+
+(deftest xyflow-graph-single-self-loop-gets-index-zero
+  (testing "rf2-shv82 (Issue 2) — a single self-loop on a node gets
+            :loopIndex 0 (the historical top-right slot — single-self-
+            loop renders pixel-identical to pre-rf2-shv82)"
+    (let [parsed (layout/parse-definition self-loop-machine)
+          graph  (projection/xyflow-graph parsed {} {})
+          ping   (first (filter #(true? (:selfLoop (:data %))) (:edges graph)))]
+      (is (some? ping))
+      (is (= 0 (:loopIndex (:data ping)))
+          "single self-loop gets slot 0 (historical position)"))))
+
+(deftest xyflow-graph-non-self-loops-have-nil-loop-index
+  (testing "rf2-shv82 (Issue 2) — a normal transition (source != target)
+            carries `:loopIndex nil` (no perimeter slot to assign)"
+    (let [parsed (layout/parse-definition idle-loading)
+          graph  (projection/xyflow-graph parsed {} {})
+          non-self (filter #(false? (:selfLoop (:data %)))
+                           (remove #(:entry (:data %)) (:edges graph)))]
+      (is (seq non-self))
+      (is (every? #(nil? (:loopIndex (:data %))) non-self)
+          "non-self-loop edges carry no loop-index"))))
+
+(deftest xyflow-graph-self-loop-indices-are-per-source
+  (testing "rf2-shv82 (Issue 2) — the loop-index counter resets per
+            source node (a self-loop on :a starts at 0 even if :b
+            already has 3 self-loops). Each node fans independently."
+    (let [m {:initial :a
+             :states  {:a {:on {:a1 {} :a2 {}}}
+                       :b {:on {:b1 {}}}}}
+          parsed (layout/parse-definition m)
+          graph  (projection/xyflow-graph parsed {} {})
+          self-loops (filter #(true? (:selfLoop (:data %)))
+                             (remove #(:entry (:data %)) (:edges graph)))
+          by-source  (group-by :source self-loops)
+          a-indices  (sort (map #(:loopIndex (:data %)) (get by-source (layout/node-id [:a]))))
+          b-indices  (sort (map #(:loopIndex (:data %)) (get by-source (layout/node-id [:b]))))]
+      (is (= [0 1] a-indices) ":a has self-loops 0 and 1")
+      (is (= [0]   b-indices) ":b's first self-loop is 0, not 2"))))
+
+;; ---- cross-hierarchy label placement (rf2-shv82, Issue 3) --------------
+;;
+;; A cross-hierarchy edge (source and target in different parent
+;; containers) has a routed midpoint that can land far from where the
+;; user perceives the edge to originate. The projector flags it so the
+;; renderer can anchor the label at the source-side first bend point
+;; instead.
+
+(def ^:private cross-hierarchy-machine
+  "A compound with an inner state that crosses out to a top-level
+  sibling (mirrors testdeck `:authenticating → :failed`)."
+  {:initial :outer
+   :states  {:outer  {:initial :inner
+                      :states  {:inner {:on {:escape :sibling}}}}
+             :sibling {}}})
+
+(deftest xyflow-graph-flags-cross-hierarchy-edge
+  (testing "rf2-shv82 (Issue 3) — an edge whose source and target sit
+            in DIFFERENT parent containers gets :crossHierarchy true"
+    (let [parsed (layout/parse-definition cross-hierarchy-machine)
+          graph  (projection/xyflow-graph parsed {} {})
+          escape (first (filter #(= :escape (:eventId (:data %))) (:edges graph)))]
+      (is (some? escape))
+      (is (true? (:crossHierarchy (:data escape)))
+          "inner→sibling escapes the :outer container"))))
+
+(deftest xyflow-graph-same-parent-edge-not-cross-hierarchy
+  (testing "rf2-shv82 (Issue 3) — an edge between two siblings under the
+            SAME parent is NOT cross-hierarchy (both leaves share a
+            parent-id; the edge stays inside the container)"
+    (let [parsed (layout/parse-definition compound-machine)
+          graph  (projection/xyflow-graph parsed {} {})
+          ;; :browsing --checkout--> :paying (both under :authenticated)
+          checkout (first (filter #(= :checkout (:eventId (:data %)))
+                                  (:edges graph)))]
+      (is (some? checkout))
+      (is (false? (:crossHierarchy (:data checkout)))
+          "two siblings under the same compound parent are NOT cross-hierarchy"))))
+
+(deftest xyflow-graph-flat-machine-no-cross-hierarchy
+  (testing "rf2-shv82 (Issue 3) — a flat machine has no containers, so
+            no edge is cross-hierarchy"
+    (let [parsed (layout/parse-definition idle-loading)
+          graph  (projection/xyflow-graph parsed {} {})
+          non-entry (remove #(:entry (:data %)) (:edges graph))]
+      (is (seq non-entry))
+      (is (every? #(false? (:crossHierarchy (:data %))) non-entry)))))
+
+(deftest xyflow-graph-self-loop-not-cross-hierarchy
+  (testing "rf2-shv82 (Issue 3) — a self-loop (source == target) is
+            never cross-hierarchy regardless of its container nesting"
+    (let [parsed (layout/parse-definition self-loop-machine)
+          graph  (projection/xyflow-graph parsed {} {})
+          ping   (first (filter #(true? (:selfLoop (:data %))) (:edges graph)))]
+      (is (some? ping))
+      (is (false? (:crossHierarchy (:data ping)))))))
+
+(deftest xyflow-graph-entry-edges-carry-cross-hierarchy-false
+  (testing "rf2-shv82 — entry edges keep the every-edge :data shape
+            whole: they carry :crossHierarchy false + :loopIndex nil"
+    (let [parsed (layout/parse-definition cross-hierarchy-machine)
+          graph  (projection/xyflow-graph parsed {} {})
+          entry  (first (filter #(:entry (:data %)) (:edges graph)))]
+      (is (some? entry))
+      (is (false? (:crossHierarchy (:data entry))))
+      (is (nil?   (:loopIndex (:data entry)))))))


### PR DESCRIPTION
Closes parity gaps **G6 / G7 / G8** in `tools/machines-viz/spec/001-Topology-Parity.md`. Three compound-endpoint rendering gaps that surfaced in the 2026-05-25 pair-debug session after rf2-xh1lm (#2126) landed compound containment.

Screenshot reference (per the bead): `2026-05-25_12-35-47.png` — `:ws/connection` chart with 0 edges into/out of the `:active` compound, garbled overlapping self-loop labels on `:disconnected`, and the `:authenticating → :failed` label sitting at the canvas bottom-left.

## Issue 1 (G6) — compound-endpoint edges silently dropped

**Symptom.** The user cannot see HOW the testdeck's `:ws/connection` machine enters or leaves `:active`: 4 edges (`disconnected → active` via `:ws/connect`, `active → disconnected` via `:ws/disconnect`, `active → active` self-loop via `:ws/send`, `failed → active` via `:ws/connect / disarm-failure`) vanish from the DOM.

**Empirical verification (the bead's 5-layer probe).** Parser emits 4 ✓; projector emits 4 ✓; ELK input has 4 ✓; ELK routes 4 ✓; DOM has 0 ✗. Drop happens inside xyflow.

**Source-confirmed mechanism (xyflow v12 / `@xyflow/system` `dist/esm/index.js`).**
- `getHandleBounds` (line 617) querySelectorAll's the node DOM for `.source` / `.target` classes. With no `<Handle>` children it returns `null`.
- `isNodeInitialized` (line 1039) requires `node.internals.handleBounds || node.handles?.length`. Both are falsy for an unhandled compound.
- `getEdgePosition` (line 1044) short-circuits to `null` when either endpoint fails `isNodeInitialized`.
- xyflow then silently omits the edge from the rendered DOM. No warning, no error, no `:layout-error` slot.

**Fix.** `chart.nodes/compound-node` + `chart.nodes.parallel-region-node` now render invisible source + target `<Handle>` elements on all four sides (`opacity: 0`). xyflow accepts the compound as an edge endpoint and ELK's routed bend-points anchor on its BORDER — the way xstate/Stately Studio paints parent-level transitions (their `toXYFlow` converter exposes containers as edge-able for the same reason).

Path A (rewrite parent-level transitions to leaf-to-leaf) and Path B (synthetic ghost nodes) per the bead were considered + rejected: the chosen fix is smaller, preserves the parent-level intent verbatim in the data, and makes ELK's existing cross-hierarchy routing (G5) do the visual work.

The chart root now surfaces `data-edge-count-projected` alongside the existing `data-edge-count`, so a regression at any layer (parser → projector → DOM) fails a single attr-parity gate.

## Issue 2 (G7) — multi-self-loop label fan

**Symptom.** 3 self-loops on `:disconnected` (`:ws/arm-fail`, `:ws/disarm-fail`, `:ws/clear`) all anchor at the same loop coords → label texts overlap into garbled glyph soup (`ws/d... ws/clear / clear-log ilure`). 2 self-loops on `:active.connected` have the same problem.

**Fix.** The projector assigns each self-loop on a source a stable per-source ordinal (`:loopIndex` 0..N-1 in emission order). `chart.edges/edge-path` rotates the loop's perimeter slot + label anchor per ordinal across 8 cardinal / inter-cardinal slots — the xstate/Stately "fan multiple events on one transition" convention. Slot 0 is the historical top-right so the single-self-loop case stays pixel-identical. Surfaces `data-loop-index` on each self-loop edge label.

## Issue 3 (G8) — cross-hierarchy edge label placement

**Symptom.** `:active.authenticating → :failed (after 250 / record-error)` cross-hierarchy edge has its label sitting at the canvas bottom-left, far from the visual origin. The edge IS in the DOM and IS correctly routed; the bug is purely label-positioning (the routed midpoint can land in unexpected absolute coords for a deeply-nested edge whose bend-points exit the container).

**Fix.** The projector flags an edge `:crossHierarchy true` when its source's `:parent-id` ≠ the target's (self-loops never qualify). `chart.edges/edge-path` anchors the label NEAR the first bend after the source handle (xstate/Stately convention — the label hugs the bend just outside the container the edge exits, with a small back-bias along the incoming segment so it sits in the routed channel, not on top of the bend). Degenerate two-point routes fall back to the segment midpoint; the bezier-fallback path is unchanged. Surfaces `data-cross-hierarchy` on each transition edge label.

## Tests

- **JVM (`projection_cljs_test.cljc`)** — pure-data pins: compound-endpoint edges survive the projector for every shape (compound-as-target / compound-as-source / compound self-loop); per-source `:loopIndex` ordinals (0/1/2 for 3 self-loops on one node, reset per source); `:crossHierarchy` flag (true when parents differ, false for siblings under the same compound, false for self-loops).
- **CLJS node (`edges_cljs_test.cljs`)** — `edge-path` geometry: 8-slot fan separation, `loop-index nil ≡ 0`, slot wrap past 8, cross-hierarchy label near source-side bend, two-point fallback to midpoint, bezier fallback unchanged.
- **CLJS browser (`chart_dom_cljs_test.cljs`)** — `compound-node` + `parallel-region-node` render `.source` / `.target` Handle elements (the xyflow contract); `data-edge-count-projected` ≥ parsed-edge count; multi-self-loop labels surface distinct `data-loop-index` ordinals 0/1/2.

## Spec coverage

- `tools/machines-viz/spec/API.md` — new sections: §Container handles (rf2-shv82), §Self-loop fan, §Cross-hierarchy label placement. Each documents the xyflow contract, the convention chosen, and the surfaced DOM attrs.
- `tools/machines-viz/spec/001-Topology-Parity.md` — G6 / G7 / G8 added to the gap table as ✅ closed; new §5 Phase E records the rf2-shv82 closure. Topology parity headline updated: **G1–G8 all closed**.
- `tools/xray/spec/003-Machine-Inspector.md` — no change needed: it points at machines-viz as the authoritative chart contract; no edge-rendering specifics live there.

## Cross-refs

- #2126 (rf2-xh1lm) — xyflow v12 `parentId` containment (the predecessor that revealed these compound-edge gaps)
- #2124 (rf2-a64bi) — compound styling lifecycle
- #2118 (rf2-4lyvh) — ELK error visibility (related debug-affordance lineage)
- rf2-ijttt (closed) — xstate/Stately renderer + IR ground-truth in `000-Vision.md`

## Gates (all green)

```
clj-kondo --lint tools/machines-viz/src tools/machines-viz/test   # 0 errors, 4 pre-existing warnings (none from this PR)
tools/machines-viz   clojure -M:test                              # 256 tests, 623 assertions, 0 failures
implementation       npm run test:cljs                            # 4438 tests, 14158 assertions, 0 failures
implementation       npm run test:browser                         # 122 tests, 343 assertions, 0 failures
implementation       npm run test:xray-feature-gate               # 13 scenarios, 0 failures
implementation       npm run test:bundle-isolation                # PASS bundle-isolation; PASS uix-helix-reagent-free
```

## Live-verification path

For Mike to confirm the fixes against a running testdeck:

1. Open the testdeck Xray panel (the same one used in the 2026-05-25 pair-debug session).
2. Open the `:ws/connection` machine chart.
3. **Issue 1** — count `.react-flow__edge` elements in DevTools. The 4 previously-missing edges should now be visible: `idle → active`, `active → idle`, `active → active` (self-loop), `failed → active`. Or run the parity probe: `(= (.getAttribute (.querySelector js/document "[data-testid=\"rf-mv-chart\"]") "data-edge-count") (.getAttribute ... "data-edge-count-projected"))`.
4. **Issue 2** — drive the machine to `:disconnected` and visually confirm the 3 self-loop labels are now readable in distinct positions around the perimeter (not stacked).
5. **Issue 3** — Connect, arm-fail, Connect again to fire `:authenticating → :failed`. The `after(250) / record-error` label should now sit near the source-side bend of the routed edge (just outside the `:active` container), not at the canvas bottom-left.