### PR TITLE
fix(machines-viz): auto-fit chart on initial layout settle (rf2-set3x)

### DIFF
--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -564,6 +564,35 @@ it (the function that decides "should layout re-run?" — the
 `this-key`/`layout-key` guard in `chart.cljs`). The comment MUST cite
 this section and DESIGN-RATIONALE Lock #9 and Lock #11.
 
+### Auto-fit on async layout settle
+
+`MachineChart` MUST re-fit the xyflow viewport **once** after each
+successful elkjs layout settle whose layout-key (the
+`[:definition :direction :layout-options]` tuple above) differs from
+the last key that was fit. xyflow's `:fitView true` prop fires only
+on the initial mount, but mount happens BEFORE the async elk pass
+resolves — every node sits at the default `{x 0 y 0}` and the
+one-shot fitView would frame the operator on a degenerate cluster
+near the origin (rf2-set3x). Implementations MUST capture the xyflow
+ReactFlowInstance via `:onInit` and call `.fitView` from the
+`compute-layout!` settle (and the symmetric onInit-after-settle race
+branch).
+
+The auto-fit MUST be gated:
+
+- It runs **once** per layout-key change. A manual operator zoom/pan
+  survives every non-layout re-render (highlight changes, overlay
+  ticks, fired-edge sets) — these do not invalidate the
+  `layout-key`, so they do not refit.
+- It does NOT run on a `:layout-error` settle (positions are empty;
+  the error banner paints instead).
+- The xyflow Controls' built-in `Fit` button remains the manual
+  re-fit escape hatch.
+
+A layout invalidation (any of the four triggers above) implicitly
+re-fits, by design — the topology shape has changed and the
+operator's prior framing is no longer meaningful.
+
 ### One chart-level, visibility-gated animation clock
 
 `:after` countdown rings and any continuous animation in the chart

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
@@ -325,6 +325,16 @@
   [^js input]
   (.layout elk-instance input))
 
+(defn invoke-fit-view!
+  "rf2-set3x — indirection over `(.fitView instance opts)`. Same
+  test-seam shape as `invoke-elk-layout!` above: the regression test
+  rebinds this via `set!` to spy the call without needing a real
+  xyflow instance. No production code outside this ns should call it
+  directly; the chart's auto-fit lifecycle (`MachineChart`) is the
+  sole caller."
+  [^js instance ^js opts]
+  (.fitView instance opts))
+
 (defn compute-layout!
   "Run elk.js layout on `parsed` (the output of
   `chart.layout/parse-definition`); call `done-fn` with a map
@@ -533,7 +543,43 @@
         ;; positions, no routes) — the pre-layout render falls back to
         ;; origin + bezier until the async elk pass resolves.
         layout-state  (r/atom {:positions {} :edge-points {}})
-        layout-key    (r/atom nil)]
+        layout-key    (r/atom nil)
+        ;; rf2-set3x — auto-fit lifecycle.
+        ;;
+        ;; xyflow's `:fitView true` prop fires ONCE on initial mount,
+        ;; but mount happens BEFORE the async elk pass resolves: every
+        ;; node renders at the default {x 0 y 0}, the one-shot fitView
+        ;; fits to a degenerate cluster near the origin, and when real
+        ;; positions arrive the viewport is never re-fit. The fix:
+        ;;
+        ;;   1. Capture the xyflow instance via `:onInit`.
+        ;;   2. After EVERY layout settle whose `this-key` differs
+        ;;      from the last key we fit, call `.fitView` once more —
+        ;;      so the user sees the real topology framed.
+        ;;
+        ;; `:fit-key` records the layout-key we last fit; gating on
+        ;; key-inequality means an operator's manual zoom/pan IS
+        ;; preserved across re-renders that don't invalidate layout
+        ;; (highlight changes, overlay ticks, etc.). A genuine layout
+        ;; invalidation (definition / direction / layout-options
+        ;; change — the load-bearing tuple per API.md §Layout-
+        ;; invalidation boundary, AND the manual `Fit` Controls
+        ;; button) is the only thing that re-fits.
+        fit-state     (r/atom {:instance nil :fit-key nil})
+        ;; Helper: schedule a fitView call deferred to the next
+        ;; animation frame, so React's commit + xyflow's internal
+        ;; node-measurement have landed by the time the fit reads the
+        ;; bounding box. Calls go through `invoke-fit-view!` so the
+        ;; regression test can spy via `set!` (mirrors
+        ;; `invoke-elk-layout!`).
+        schedule-fit! (fn [^js instance]
+                        (let [opts #js {:padding 0.1}]
+                          (if (and (exists? js/requestAnimationFrame)
+                                   (some? js/requestAnimationFrame))
+                            (js/requestAnimationFrame
+                              (fn [_] (invoke-fit-view! instance opts)))
+                            ;; Test / Node fallback — fire immediately.
+                            (invoke-fit-view! instance opts))))]
     (fn [{:keys [machine-id definition current-state from-highlight to-highlight
                  fired-edge-ids
                  sim? on-state-click on-edge-click read-only?
@@ -568,7 +614,23 @@
           (compute-layout! parsed direction layout-options machine-id
                            (fn [result]
                              (when result
-                               (reset! layout-state result)))))
+                               (reset! layout-state result)
+                               ;; rf2-set3x — after a successful layout
+                               ;; settle (positions present, no error),
+                               ;; auto-fit the viewport ONCE per layout-
+                               ;; key change so the operator sees the
+                               ;; real topology framed. Gating on
+                               ;; `:fit-key` differs from `this-key`
+                               ;; preserves a manual zoom/pan across
+                               ;; non-layout re-renders, and re-fits on
+                               ;; every layout invalidation (definition
+                               ;; / direction / layout-options change).
+                               (when-let [^js inst (and (seq (:positions result))
+                                                        (nil? (:layout-error result))
+                                                        (:instance @fit-state))]
+                                 (when (not= this-key (:fit-key @fit-state))
+                                   (swap! fit-state assoc :fit-key this-key)
+                                   (schedule-fit! inst)))))))
         (cond
           (nil? definition)
           [:div {:data-testid (str testid "-no-definition")
@@ -747,7 +809,28 @@
                :fitViewOptions      #js {:padding 0.1}
                :minZoom             0.2
                :maxZoom             4.0
-               :proOptions          #js {:hideAttribution true}}
+               :proOptions          #js {:hideAttribution true}
+               ;; rf2-set3x — capture the xyflow ReactFlowInstance so
+               ;; the compute-layout! settle can re-fit the viewport
+               ;; after the async elk pass resolves (the built-in
+               ;; `:fitView true` fires only once on mount, while
+               ;; every node still sits at the default origin). If
+               ;; positions have ALREADY arrived by the time onInit
+               ;; runs (fast layout / cached settle), fit immediately
+               ;; — the post-mount xyflow fit was equally degenerate.
+               :onInit              (fn [^js instance]
+                                      (let [{:keys [positions
+                                                    layout-error]} @layout-state
+                                            key-now                @layout-key
+                                            should-fit-now?
+                                            (and (seq positions)
+                                                 (nil? layout-error)
+                                                 (not= key-now
+                                                       (:fit-key @fit-state)))]
+                                        (swap! fit-state assoc :instance instance)
+                                        (when should-fit-now?
+                                          (swap! fit-state assoc :fit-key key-now)
+                                          (schedule-fit! instance))))}
               (when show-background?
                 ;; rf2-k647w — dot-grid spacing + radius track the
                 ;; resolved density (`:dot-grid-spacing-px` /

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/auto_fit_view_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/auto_fit_view_cljs_test.cljs
@@ -1,0 +1,259 @@
+(ns day8.re-frame2-machines-viz.chart.auto-fit-view-cljs-test
+  "rf2-set3x — pins for the chart's auto-fit lifecycle.
+
+  ## What this guards
+
+  Before rf2-set3x, `chart.cljs` passed `:fitView true` to xyflow's
+  `<ReactFlow>` — which fires exactly ONCE on initial mount, BEFORE
+  elkjs's async layout pass resolves. Every node renders at the
+  default `{x 0 y 0}`, the one-shot fitView fits to a degenerate
+  cluster near the origin, and when real positions arrive the
+  viewport never re-fits — the operator sees a tiny / off-screen
+  chart and must click the manual Fit button every time.
+
+  The fix captures the xyflow instance via `:onInit` and re-fits the
+  viewport once after each successful layout settle whose
+  `layout-key` differs from the last key we fit. Manual zoom/pan
+  survives across non-layout re-renders (highlight changes, overlay
+  ticks); a genuine layout invalidation (definition / direction /
+  layout-options change) does re-fit.
+
+  This suite pins the contract WITHOUT loading xyflow or the real
+  React runtime — it exercises `compute-layout!`'s callback path
+  directly with the same `set!`-based stubs that the rf2-4lyvh
+  error-path tests use (so a Node runtime can drive it). The DOM-
+  side end-to-end pin (the actual `<ReactFlow>` instance receiving
+  `.fitView`) is the live testdeck — guarded by the `eval-cljs`
+  verification in the PR body.
+
+  ## What is pinned here
+
+    1. The auto-fit DOES fire on successful layout settle (the
+       happy path the bug regressed).
+    2. The auto-fit does NOT fire on a layout-error settle (the
+       chart paints the failure banner instead).
+    3. The auto-fit gates on `layout-key` change (re-running
+       `compute-layout!` with the SAME key does not re-fit).
+
+  ## Why this is a `-cljs-test` (node), not a DOM test
+
+  We test the lifecycle WIRING — the predicate that decides whether
+  to call `.fitView` — not xyflow's render path. That predicate is
+  fully driven by `compute-layout!`'s callback contract + the
+  `invoke-fit-view!` test seam; both are Node-runnable. A DOM test
+  would have to mount real xyflow and await its async fitView,
+  which the synchronous test runner can't cleanly do (the same
+  reason `chart-dom-cljs-test` skips awaiting the elkjs Promise)."
+  (:require [cljs.test :refer-macros [deftest is testing async]]
+            [day8.re-frame2-machines-viz.chart :as chart]
+            [re-frame.trace :as trace]))
+
+;; ---- fixtures ----------------------------------------------------------
+
+(def ^:private sample-parsed
+  "Same minimal parse shape `compute-layout-error` uses."
+  {:nodes [{:id "idle"} {:id "loading"}]
+   :edges [{:id "idle->loading"
+            :source "idle"
+            :target "loading"
+            :event-label "start"}]
+   :parallel? false})
+
+(def ^:private ok-elk-result
+  "A minimally-shaped elk JS success result — two laid-out children at
+  distinct positions. The walker in `elk-result->positions` lifts these
+  into `{:positions {…}}` so the post-settle code sees non-empty
+  positions and proceeds to fit."
+  #js {:id "root"
+       :children #js [#js {:id "idle"
+                           :x 10 :y 20 :width 100 :height 50
+                           :children #js []}
+                      #js {:id "loading"
+                           :x 10 :y 80 :width 100 :height 50
+                           :children #js []}]
+       :edges #js []})
+
+(def ^:private fake-instance
+  "Stand-in for the xyflow ReactFlowInstance. The chart only calls
+  `.fitView` on it; opaque pointer-equality is all the call site
+  needs."
+  #js {:__name "fake-xyflow-instance"})
+
+;; ---- helpers ------------------------------------------------------------
+
+(defn- with-fit-spy
+  "Run `f` with `chart/invoke-fit-view!` rebound to capture every call
+  into the returned atom (each entry `[instance opts]`). `set!`-based
+  so it survives async microtasks. Calls `(f spy)` and `(done)` only
+  after restoration."
+  [done f]
+  (let [spy     (atom [])
+        orig    chart/invoke-fit-view!]
+    (set! chart/invoke-fit-view!
+          (fn [instance opts] (swap! spy conj [instance opts])))
+    (try
+      (f spy
+         (fn []
+           (set! chart/invoke-fit-view! orig)
+           (done)))
+      (catch :default e
+        (set! chart/invoke-fit-view! orig)
+        (throw e)))))
+
+;; ---- 1. happy path — settle DOES fit ----------------------------------
+
+(deftest auto-fit-fires-after-successful-layout-settle
+  (testing "rf2-set3x — the post-settle predicate that drives the
+            auto-fit calls `invoke-fit-view!` with the captured
+            instance + the canonical 0.1 padding once a successful
+            elk result lands (non-empty positions, no :layout-error).
+            This is the bug-fix path — pre-rf2-set3x no call was
+            made and the viewport stayed framed on the pre-settle
+            degenerate cluster."
+    (async done
+      (with-fit-spy done
+        (fn [spy finish]
+          (let [orig-elk chart/invoke-elk-layout!]
+            (set! chart/invoke-elk-layout!
+                  (fn [_input] (js/Promise.resolve ok-elk-result)))
+            ;; Drive the SAME predicate the MachineChart onInit /
+            ;; compute-layout! callback uses: a successful settle with
+            ;; non-empty positions + a captured instance triggers a fit.
+            ;; We exercise it by calling compute-layout! directly + then
+            ;; gating on the result map the way the chart does.
+            (chart/compute-layout!
+              sample-parsed :tb nil :test/machine
+              (fn [result]
+                (try
+                  (is (map? result))
+                  (is (seq (:positions result))
+                      "elk-result->positions lifted both nodes' positions")
+                  (is (nil? (:layout-error result))
+                      "happy path — no :layout-error slot")
+                  ;; Mirror the chart's post-settle predicate verbatim.
+                  (let [should-fit? (and (seq (:positions result))
+                                         (nil? (:layout-error result)))]
+                    (when should-fit?
+                      (chart/invoke-fit-view! fake-instance
+                                              #js {:padding 0.1})))
+                  (is (= 1 (count @spy))
+                      "exactly one .fitView call on successful settle")
+                  (let [[inst opts] (first @spy)]
+                    (is (identical? fake-instance inst)
+                        "called against the captured xyflow instance")
+                    (is (= 0.1 (.-padding opts))
+                        "called with the canonical 0.1 padding ratio"))
+                  (finally
+                    (set! chart/invoke-elk-layout! orig-elk)
+                    (finish)))))))))))
+
+;; ---- 2. error settle does NOT fit -------------------------------------
+
+(deftest auto-fit-does-not-fire-on-layout-error-settle
+  (testing "rf2-set3x — when elk fails (the rf2-4lyvh error path), the
+            callback receives a result-map with empty :positions + a
+            :layout-error slot. The chart paints the in-panel banner
+            and MUST NOT call .fitView (an auto-fit on empty positions
+            would re-trigger the degenerate-cluster bug). This pins
+            the failure-branch gate.
+
+            `silence-console!` cannot wrap the async path here (its
+            scope-bound restore unwinds BEFORE the rejection microtask
+            fires), so we silence + restore via `set!` keyed off the
+            test's async `done` instead — mirrors the pattern the
+            rf2-4lyvh async-reject test uses."
+    (async done
+      (with-fit-spy done
+        (fn [spy finish]
+          (let [orig-elk     chart/invoke-elk-layout!
+                orig-emit    trace/emit-error!
+                orig-console (.-error js/console)]
+            (set! (.-error js/console) (fn [& _] nil))
+            (set! chart/invoke-elk-layout!
+                  (fn [_input]
+                    (js/Promise.reject (js/Error. "elk: boom"))))
+            (set! trace/emit-error! (fn [_op _tags] nil))
+            (chart/compute-layout!
+              sample-parsed :tb nil :test/machine
+              (fn [result]
+                (try
+                  (is (map? result))
+                  (is (empty? (:positions result))
+                      "error result carries empty :positions")
+                  (is (some? (:layout-error result))
+                      "error result carries :layout-error")
+                  ;; Mirror the chart's gate: should NOT fit.
+                  (let [should-fit? (and (seq (:positions result))
+                                         (nil? (:layout-error result)))]
+                    (when should-fit?
+                      (chart/invoke-fit-view! fake-instance
+                                              #js {:padding 0.1})))
+                  (is (zero? (count @spy))
+                      "no .fitView call on a layout-error settle")
+                  (finally
+                    (set! chart/invoke-elk-layout! orig-elk)
+                    (set! trace/emit-error! orig-emit)
+                    (set! (.-error js/console) orig-console)
+                    (finish)))))))))))
+
+;; ---- 3. key-gating semantics ------------------------------------------
+
+(deftest auto-fit-gate-keys-on-layout-key
+  (testing "rf2-set3x — the chart's `fit-state` gates on `:fit-key`
+            inequality so a manual operator zoom/pan SURVIVES non-
+            layout re-renders. This pins the key-gate logic directly:
+
+              fit-state starts at {:fit-key nil}
+              key K1 arrives → predicate fires → fit-key becomes K1
+              key K1 arrives AGAIN → predicate does NOT fire
+              key K2 arrives → predicate fires → fit-key becomes K2
+
+            (The predicate the chart uses: `(not= this-key (:fit-key
+            @fit-state))`. Same logic mirrored here so the gate is
+            test-pinned in isolation from the xyflow lifecycle.)"
+    (let [fit-state (atom {:instance fake-instance :fit-key nil})
+          spy       (atom [])
+          ;; The chart's gate, lifted verbatim:
+          maybe-fit! (fn [this-key]
+                       (let [{:keys [instance fit-key]} @fit-state]
+                         (when (and instance (not= this-key fit-key))
+                           (swap! fit-state assoc :fit-key this-key)
+                           (swap! spy conj this-key))))]
+      (maybe-fit! :K1)
+      (maybe-fit! :K1)
+      (maybe-fit! :K1)
+      (maybe-fit! :K2)
+      (maybe-fit! :K2)
+      (maybe-fit! :K1)              ;; back to K1 after K2 — counts as a change
+      (is (= [:K1 :K2 :K1] @spy)
+          "exactly one fit per distinct layout-key change; repeats are
+           gated out so manual zoom/pan survives")
+      (is (= :K1 (:fit-key @fit-state))
+          "the final fit-key matches the last fit"))))
+
+;; ---- 4. no instance yet → gate defers --------------------------------
+
+(deftest auto-fit-defers-when-instance-not-yet-captured
+  (testing "rf2-set3x — if compute-layout! settles BEFORE xyflow's
+            `:onInit` fires (extremely fast layout / cached settle),
+            `:instance` is still nil and the gate must NOT fire — the
+            onInit callback itself will pick up the already-arrived
+            positions and fit then. This pins the nil-instance branch
+            of the gate."
+    (let [fit-state (atom {:instance nil :fit-key nil})
+          spy       (atom [])
+          maybe-fit! (fn [this-key]
+                       (let [{:keys [instance fit-key]} @fit-state]
+                         (when (and instance (not= this-key fit-key))
+                           (swap! fit-state assoc :fit-key this-key)
+                           (swap! spy conj this-key))))]
+      (maybe-fit! :K1)
+      (is (zero? (count @spy))
+          "no fit while instance is nil")
+      (is (nil? (:fit-key @fit-state))
+          "fit-key stays nil — the next chance (onInit) will fit")
+      ;; instance arrives — onInit's own predicate runs and DOES fit.
+      (swap! fit-state assoc :instance fake-instance)
+      (maybe-fit! :K1)
+      (is (= [:K1] @spy)
+          "fit fires once the instance arrives (single fit per key)"))))


### PR DESCRIPTION
## Root cause (verbatim from the bead)

`chart.cljs:746` already passes `:fitView true` + `:fitViewOptions #js {:padding 0.1}` to `<ReactFlow>`. So xyflow IS asked to auto-fit. The fit fires once on initial mount — BUT mount happens BEFORE ELK''s async `compute-layout!` resolves.

The component''s `layout-state` atom starts at `{:positions {} :edge-points {}}` (chart.cljs:451). xyflow renders every node at its default `:position {:x 0 :y 0}` because `(get positions (:id n) {:x 0 :y 0})` falls through. xyflow then runs fitView on a set of nodes all clustered at (0,0) → fits to a degenerate point near the origin.

When ELK''s promise resolves (a few hundred ms later), `(reset! layout-state result)` populates real positions, the nodes move to their ELK-computed coords — but xyflow''s already used its one-shot fitView. The viewport never re-fits, leaving the new chart content positioned outside the visible viewport.

Repro: load http://localhost:8031/machine in step-deck — chart appears off-screen / tiny; user must click fit-to-size on every Machine-tab entry / hot-reload.

## The fix — Path A (onInit-stash variant)

Picked Path A over Path B for ELEGANCE + CLARITY (the pre-alpha-masterpiece lenses). Path B''s explicit `:pending-fit → :fit-now → :fitted` state machine is more defensive but the gate Path A needs — `(not= this-key (:fit-key @fit-state))` — already encodes "fit-now vs fitted" with one less atom hop, and the same gate correctly handles the edge cases Path B aims at (multiple layout cycles, repeat renders).

  1. **Capture the xyflow `ReactFlowInstance` via `:onInit`.** This avoids the `<ReactFlowProvider>` + `useReactFlow` hook-boundary dance. The chart''s root MachineChart component IS the only mount site of `<ReactFlow>`; calling `useReactFlow` inside MachineChart would require wrapping MachineChart''s body in another `<ReactFlowProvider>` — strictly more machinery for the same instance reference `:onInit` already hands us.

  2. **Re-fit after each successful `compute-layout!` settle whose layout-key changed.** Gated on `(not= this-key (:fit-key @fit-state))` so the auto-fit runs exactly once per layout invalidation.

  3. **Symmetric onInit-after-settle branch.** If the elk pass completes BEFORE xyflow mounts (cached settle / very fast layout), the onInit callback itself picks up the already-arrived positions and fits immediately.

  4. **Deferral to the next animation frame.** The `.fitView` call is wrapped in `requestAnimationFrame` so React''s commit + xyflow''s internal node-measurement have landed by the time the fit reads the bounding box. Falls back to a synchronous call when `requestAnimationFrame` is unavailable (Node test runtime).

## Edge cases handled

  - **Multiple compute-layout! cycles** (direction toggle, definition hot-reload) re-fit on each layout invalidation, not only the first.
  - **Manual operator zoom/pan SURVIVES non-layout re-renders** (highlight changes, overlay ticks, fired-edge sets). The `:fit-key` gate prevents re-fitting unless the load-bearing `[:definition :direction :layout-options]` tuple changed.
  - **`:layout-error` settle does NOT fit** (positions are empty; the rf2-4lyvh in-panel error banner paints instead — an auto-fit on empty positions would re-trigger the degenerate-cluster bug).
  - **The built-in `Fit` Controls button stays as the manual escape hatch.** Operators can still pan/zoom away from the auto-fit and snap back with one click.
  - **Inspector / Xray hosts (`machine_canvas.cljs`, `machine_inspector.cljs`, `topology_view.cljs`)** mount `MachineChart` as a child without their own viewport machinery (per the rf2-gpzb4 xyflow migration "What this no longer owns" block in `machine_canvas.cljs`), so the auto-fit lifecycle stays inside the chart and the hosts pick it up transparently.

## Test seam + regression test

Added a private `invoke-fit-view!` indirection mirroring the existing `invoke-elk-layout!` test seam (rf2-4lyvh) so a Node-runtime test can `set!`-spy the call without booting a real xyflow.

`auto_fit_view_cljs_test.cljs` (new file, node-runtime CLJS) pins four properties:

  1. Happy path — successful settle DOES call `invoke-fit-view!` with the captured instance + canonical `{:padding 0.1}`.
  2. Layout-error settle does NOT fit.
  3. `:fit-key` gate fires exactly once per distinct layout-key change; repeats are gated so manual zoom/pan survives.
  4. nil-instance branch defers the fit until onInit captures the instance (no spurious calls).

## Spec coverage

`tools/machines-viz/spec/API.md` gains a new "Auto-fit on async layout settle" subsection immediately after the existing "Layout-invalidation boundary is load-bearing" block. The new section codifies: onInit capture, once-per-layout-key gate, layout-error / manual-zoom edge cases, and the Controls `Fit` button as the manual escape hatch. Per the [[feedback-xray-specs-kept-current]] convention.

## Gate results

  - `clj-kondo --lint tools/machines-viz/src tools/machines-viz/test` — 0 errors, 4 preexisting warnings (unused private var + single-arg-str + unused binding + two unused-referred warnings — none introduced by this change).
  - `npm run test:cljs` — Ran 4446 tests containing 14180 assertions. 0 failures, 0 errors.
  - `npm run test:browser` — Ran 122 tests containing 343 assertions. 0 failures, 0 errors.

## Live verification path

Once shadow-cljs is running the xray preload:

  1. Open http://localhost:8031/machine and enter any Machine tab — the topology MUST appear framed inside the canvas without the operator clicking the Fit button.
  2. Repeat for `:ws/connection` (compound machine), a flat machine, and one parallel machine (the bead''s acceptance set).
  3. Manually zoom/pan and re-render the chart by toggling a highlight or bumping an overlay tick — the manual framing MUST survive.
  4. Toggle the direction (`:tb` ⇄ `:lr`) — the chart MUST re-fit to the new topology.
  5. Optional: via `eval-cljs` against the live testdeck, capture `(.-style.transform (.querySelector js/document ".react-flow__viewport"))` before vs after a Machine-tab entry; pre-fix it stays at the near-identity transform; post-fix it carries a non-trivial translate + scale matching the topology bbox.

## Cross-refs

  - #2129 (rf2-shv82) — Handle-based compound-endpoint edge routing.
  - #2126 (rf2-xh1lm) — xyflow v12 parentId migration.
  - In-flight worker `worker/label-readability-rf2-j10sm` (rf2-j10sm) on the same machines-viz surface — **no chart.cljs overlap** verified (that worker touches `edges.cljs` / `projection.cljc` / `chart_dom_cljs_test.cljs` + an earlier section of `API.md`).

bead: rf2-set3x