### PR TITLE
fix(xray): app-db panel ▸ triangles click-to-expand wired (re-frame-10x parity) (rf2-dw8n7)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1280,6 +1280,22 @@ formatters) is a complementary follow-on bead. In-DOM widget
 rendering — the contract Xray cares about — flows through the
 facade today.
 
+The cljs-devtools-backed `browse` path (current-state rendering
+through `views.edn-widget.cljs-devtools-render`, per rf2-dmso5) is
+**fully interactive**: every collection surrogate renders a `▸` / `▾`
+triangle wrapped in a clickable `[:span]` with `role="button"`,
+`cursor: pointer`, `tabindex=0`, and an `aria-label`. Click (or
+Enter / Space on a focused triangle) dispatches
+`:rf.xray/data-display-toggle-node` against the per-render walker
+path — **the same sticky-expansion contract** the home-grown
+`data-display/render` engine uses (§10.4), backed by the shared
+`:rf.xray/data-display-expansion` slot. The operator's per-path
+drill-downs persist across re-renders + epoch navigation per
+§10.4. Default expansion follows §10.4's depth+size heuristic;
+`browse` callers may override via `:default-depth N` (the App-db
+panel defaults to `:default-depth 3` for the diff render path,
+matching the re-frame-10x look).
+
 ### §10.1 Capabilities (LOCKED per B.9 super-prompt)
 
 1. **Lazy collapsible tree** — hierarchical EDN with expand/collapse.

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_widget/cljs_devtools_render.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_widget/cljs_devtools_render.cljs
@@ -42,15 +42,22 @@
     `[\"object\" ...]` placeholders (those render as a `▶ {…}`
     summary). Suitable for the `mini` one-liner and inline chips
     where a single line is wanted.
-  - `value->tree-hiccup` — render a CLJS value as a FULLY-EXPANDED
-    cljs-devtools tree (the re-frame-10x look · type-coloured ·
-    nested · indented). Recursively expands `[\"object\" ...]`
-    surrogate references up to a depth budget; deeper levels
-    degrade to the collapsed `▶ {…}` summary so a pathological
-    app-db can't blow the call stack. This is the entry the
-    current-state `browse` path uses for collections.
+  - `value->tree-hiccup` — render a CLJS value as the re-frame-10x
+    nested-tree current-state look (`{ :counter ▸ {3 entries} }`)
+    with INTERACTIVE click-to-toggle per `object` surrogate
+    (rf2-dw8n7). Each collection node renders a `▸` (collapsed) /
+    `▾` (expanded) glyph wrapped in a `[:span]` that dispatches
+    `:rf.xray/data-display-toggle-node` on click — the same sticky-
+    expansion contract `data-display/render` uses, so an operator's
+    drill-downs persist through re-renders. Default expansion
+    follows §10.4's depth+size heuristic (`default-depth` defaults
+    to 1: root expanded, nested collections collapsed). Past the
+    hard `max-depth` stack-guard the node degrades to the one-line
+    `▸ {…}` summary so a pathological / cyclic structure can't blow
+    the call stack.
   - `jsonml->hiccup` — pure JSONML walker; public for tests. The
-    arity that takes an opts map drives recursive expansion.
+    arity that takes an opts map drives recursive expansion + the
+    interactive toggle wiring.
 
   ## Posture
 
@@ -60,6 +67,8 @@
   (:require [clojure.string :as str]
             [devtools.formatters.core :as formatters]
             [devtools.prefs :as devtools-prefs]
+            [re-frame.core :as rf]
+            [day8.re-frame2-xray.data-display.render :as data-display]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens mono-stack]]))
 
@@ -91,20 +100,29 @@
    :initial-hierarchy-depth-budget false})
 
 (def ^:private xray-expanded-prefs
-  "Extra prefs for the FULLY-EXPANDED current-state tree
-  (`value->tree-hiccup`, rf2-dmso5). cljs-devtools defaults inline only
-  `:max-print-level 2` / `:body-line-max-print-level 3` levels and
-  `:max-header-elements 5` entries before degrading a value to a
-  collapsed `▸ {…}` reference — that's the one-line summary look. For
-  Xray's current-state surfaces we want the re-frame-10x
-  fully-expanded look, so the tree renderer lifts the inline budgets
-  generously (the per-leaf header preview then inlines the whole
-  structure for ordinary app-db depths) and `value->tree-hiccup`'s
-  body-recursion picks up anything past them. `value->hiccup` / `mini`
-  do NOT use these — they stay one-line."
+  "Prefs for the interactive tree (`value->tree-hiccup`, rf2-dw8n7).
+  We FORCE cljs-devtools to emit `object` surrogate references for
+  every nested collection rather than inlining them in the header.
+
+  - `:max-print-level 1` clamps the header inline-depth to a single
+    level, so a map like `{:outer {:inner 1}}` renders as
+    `{ :outer ▸ {…} }` — the inner map appears as a surrogate ref
+    that the walker can wrap in a click-to-toggle triangle. With the
+    cljs-devtools default of 2 (or our previously-lifted 10), the
+    whole tree inlines as one uninterruptible line and the toggle UI
+    has nothing to attach to.
+  - `:body-line-max-print-level 1` applies the same clamp to the
+    expanded body rows — each LI emits its value as a surrogate.
+  - `:max-header-elements` / `:max-number-body-items` stay generous
+    so a wide map doesn't truncate visible keys mid-list.
+  - The shallow chrome overrides (`:item-style`, `:body-style`, …)
+    carry through from `xray-prefs`.
+
+  `value->hiccup` / `mini` use the shallow `xray-prefs` instead so
+  they keep their one-line semantics for inline chips."
   (merge xray-prefs
-         {:max-print-level           10
-          :body-line-max-print-level 10
+         {:max-print-level           1
+          :body-line-max-print-level 1
           :max-header-elements       100
           :max-number-body-items     1000}))
 
@@ -165,22 +183,42 @@
   #{"div" "span" "ol" "li" "table" "tr" "td"})
 
 (def ^:private default-max-depth
-  "How deep `value->tree-hiccup` recursively expands `object`
-  surrogate references before degrading to the collapsed `▶ {…}`
-  summary. App-db is rarely deeper than this; the cap is a stack-guard
-  against pathological / cyclic structures more than a UI choice. The
-  re-frame-10x look reads as fully-expanded for ordinary data."
-  12)
+  "Hard stack-guard for `value->tree-hiccup`'s body recursion. Beyond
+  this depth every nested `object` surrogate degrades to the collapsed
+  `▸ {…}` summary regardless of the operator's per-path expansion
+  state — a defence against cyclic / pathological structures, not a
+  UX choice. The §10.4 default-expansion heuristic (default-depth 1)
+  is the UX bound; this cap is a safety floor."
+  16)
 
-(declare jsonml->hiccup)
+(def ^:private default-default-depth
+  "§10.4 default expansion depth for `value->tree-hiccup` when the
+  caller doesn't override. `1` = the root collection's children render
+  as collapsed `▸ {…}` summaries by default; the operator clicks a
+  triangle to expand. Matches re-frame-10x's app-db panel default
+  (rf2-dw8n7 acceptance)."
+  1)
+
+(declare jsonml->hiccup body-child-count)
+
+(defn- toggle-style
+  "Inline style for the click-to-toggle triangle wrapper on an
+  interactive `object` surrogate. Pointer cursor + accessible focus
+  outline (rf2-dw8n7)."
+  []
+  {:cursor       "pointer"
+   :user-select  "none"
+   :display      "inline-block"
+   :margin-right "2px"
+   :color        (:text-tertiary tokens)})
 
 (defn- render-object-summary
   "Render an `[\"object\" {object: v, config: c}]` surrogate as an
   inline `▸ <header>` ONE-LINE summary (no body expansion). Used as
-  the leaf-fallback in `value->hiccup` and as the depth-budget cap in
-  `value->tree-hiccup`: the user still sees \"there is nested structure
-  here\" via the collection's one-line `{…}` header without the tree
-  committing to expand it."
+  the leaf-fallback in `value->hiccup` — non-interactive, no click
+  handler. For the interactive `value->tree-hiccup` path the wrapper
+  is added by `render-object-interactive`; this function still emits
+  the header markup so both paths share the same inline shape."
   [obj opts]
   (let [^js o obj
         v    (some-> o .-object)
@@ -198,20 +236,33 @@
        (when (some? inner)
          [:span (jsonml->hiccup inner opts)]))]))
 
-(defn- render-object-expanded
-  "Recursively EXPAND an `[\"object\" {object: surrogate}]` reference:
-  render the surrogate's header inline, then — when it has a body and
-  we're within the depth budget — render that body indented underneath.
-  This is what produces the re-frame-10x nested-tree look for
-  collections. Beyond the depth budget the reference degrades to the
-  one-line `render-object-summary`.
+(defn- render-object-interactive
+  "Render an `[\"object\" {object: surrogate}]` reference as the
+  re-frame-10x interactive click-to-toggle node (rf2-dw8n7).
 
-  `binaryage/cljs-devtools` models a value's expandable rows as a
-  surrogate whose `body-api-call` returns an `[\"ol\" …]` of `[\"li\" …]`
-  lines; each line embeds the child values as further `object`
-  references — so recursing on `body-api-call` walks the whole
-  structure."
-  [obj {:keys [depth max-depth] :as opts}]
+  The triangle is a `[:span]` with `:on-click` dispatching
+  `:rf.xray/data-display-toggle-node` against this surrogate's
+  walker-path. When expanded, the header line is followed by the
+  surrogate's body indented underneath (recursing through the walker
+  with a deeper path). When collapsed, only the one-line header
+  renders.
+
+  Defaults: §10.4 heuristic — depth ≤ default-depth → expanded; below
+  the body's child-count threshold at the boundary → still expanded;
+  beyond → collapsed. The operator's sticky override (recorded in
+  `:rf.xray/data-display-expansion`) always wins.
+
+  Hard stack-guard at `max-depth`: deeper than that, the node degrades
+  to the inline summary regardless of the operator's choice — a
+  defence against cyclic / pathological structures.
+
+  `cljs-devtools` models a value's expandable rows as a surrogate whose
+  `body-api-call` returns an `[\"ol\" ...]` of `[\"li\" ...]` lines;
+  each line embeds child values as further `object` references — so
+  recursing on `body-api-call` walks the whole structure."
+  [obj {:keys [depth max-depth panel-id render-id path
+               expansion-map default-depth]
+        :as opts}]
   (let [^js o     obj
         surrogate (some-> o .-object)
         cfg       (some-> o .-config)
@@ -224,40 +275,151 @@
       (nil? header)
       (render-object-summary obj opts)
 
-      ;; Leaf-shaped surrogate (no expandable body) — header only.
+      ;; Leaf-shaped surrogate (no expandable body) — header only,
+      ;; no triangle. cljs-devtools uses surrogates for some scalar
+      ;; shapes too (e.g. native JS objects, certain records) — those
+      ;; have nothing to expand so the toggle UI would be misleading.
       (not has-body?)
       [:span {:style {:font-family mono-stack}}
        (jsonml->hiccup header opts)]
 
-      ;; Depth budget hit — keep the one-line summary so we never
-      ;; recurse without bound on a deep / cyclic structure.
+      ;; Hard stack-guard — beyond max-depth degrade to summary
+      ;; regardless of operator override. Defence against cyclic /
+      ;; pathological structures.
       (>= depth max-depth)
       (render-object-summary obj opts)
 
-      ;; Within budget + has a body — expand: header line, then the
-      ;; body's rows indented one level deeper.
       :else
-      (let [body      (try (formatters/body-api-call surrogate cfg)
-                           (catch :default _ nil))
-            next-opts (assoc opts :depth (inc depth))]
-        [:span {:style {:font-family mono-stack}}
-         [:span {:style {:display "block"}}
-          (jsonml->hiccup header opts)]
-         (when (some? body)
-           [:div {:style {:padding-left "14px"
-                          :border-left  (str "1px solid " (:border-subtle tokens))
-                          :margin-left  "2px"}}
-            (jsonml->hiccup body next-opts)])]))))
+      (let [body         (try (formatters/body-api-call surrogate cfg)
+                              (catch :default _ nil))
+            child-cnt    (body-child-count body)
+            default?     (data-display/default-expanded?
+                           {:depth         depth
+                            :child-count   child-cnt
+                            :default-depth (or default-depth
+                                               default-default-depth)})
+            expanded?    (if (and panel-id render-id)
+                           (data-display/resolve-expanded?
+                             expansion-map panel-id render-id path default?)
+                           default?)
+            glyph        (if expanded? "▾" "▸") ; ▾ / ▸
+            ;; Stable dispatch — `:on-click` fires after React pops the
+            ;; frame context, so the dispatch envelope carries the Xray
+            ;; frame explicitly (matches the segment-inspector + copy
+            ;; affordance pattern in `widget.cljs`).
+            toggle-fn    (when (and panel-id render-id)
+                           (fn [^js e]
+                             (when e
+                               (.preventDefault e)
+                               (.stopPropagation e))
+                             (rf/dispatch
+                               [:rf.xray/data-display-toggle-node
+                                panel-id render-id path]
+                               {:frame :rf/xray})))
+            key-fn       (when toggle-fn
+                           (fn [^js e]
+                             (let [k (.-key e)]
+                               (when (or (= k "Enter") (= k " "))
+                                 (.preventDefault e)
+                                 (.stopPropagation e)
+                                 (toggle-fn e)))))
+            testid       (when (and panel-id render-id)
+                           (str "rf-xray-edn-widget-toggle-"
+                                (name panel-id) "-"
+                                render-id "-"
+                                (str/join "/" (map str path))))
+            triangle     (if toggle-fn
+                           [:span (cond-> {:on-click   toggle-fn
+                                           :on-key-down key-fn
+                                           :role       "button"
+                                           :tab-index  0
+                                           :aria-label (str (if expanded? "Collapse" "Expand")
+                                                            " node")
+                                           :style      (toggle-style)}
+                                    testid (assoc :data-testid testid))
+                            glyph]
+                           [:span {:style {:color (:text-tertiary tokens)
+                                           :margin-right "2px"}}
+                            glyph])
+            ;; Surrogates inside the surrogate's header / body represent
+            ;; CHILDREN of this node — they live at depth+1 in the value
+            ;; tree, so the walker descends with the bumped depth (and
+            ;; the per-li path additions the walker layers on top). This
+            ;; is what keeps the default-expansion heuristic honest for
+            ;; deeply nested values — without the bump, inline surrogates
+            ;; in the parent's header all read as depth=parent and the
+            ;; heuristic over-expands.
+            inner-opts   (assoc opts :depth (inc depth))]
+        (if expanded?
+          [:span {:style {:font-family mono-stack}}
+           [:span {:style {:display "block"}}
+            triangle
+            [:span (jsonml->hiccup header inner-opts)]]
+           (when (some? body)
+             [:div {:style {:padding-left "14px"
+                            :border-left  (str "1px solid " (:border-subtle tokens))
+                            :margin-left  "2px"}}
+              (jsonml->hiccup body inner-opts)])]
+          ;; Collapsed: triangle + one-line header summary side-by-side.
+          [:span {:style {:font-family mono-stack
+                          :color       (:text-secondary tokens)}}
+           triangle
+           [:span (jsonml->hiccup header inner-opts)]])))))
 
 (defn- render-object
-  "Route an `object` reference to the expanding or summary renderer
-  based on `opts`. `:expand? true` (set by `value->tree-hiccup`) walks
-  the surrogate's body; otherwise (header-only `value->hiccup`,
-  `mini`) it renders the one-line summary."
+  "Route an `object` reference to the interactive expanding renderer
+  (when `opts` carries `:expand? true` — the `value->tree-hiccup`
+  path) or the static one-line summary (header-only `value->hiccup`,
+  `mini`)."
   [obj opts]
   (if (:expand? opts)
-    (render-object-expanded obj opts)
+    (render-object-interactive obj opts)
     (render-object-summary obj opts)))
+
+(defn body-child-count
+  "Count the `li` rows in a cljs-devtools body. cljs-devtools wraps
+  the row list in `[\"span\" attrs [\"ol\" attrs li li ...]]` — so
+  this fn descends until it finds the `ol` (or `table`) and returns
+  the number of row children inside it. Used to drive the §10.4
+  default-expansion heuristic at the boundary; returns 0 when body
+  is nil or the shape isn't recognised."
+  [body]
+  (letfn [(child-of [node idx]
+            (cond
+              (and (array? node) (> (.-length node) idx)) (aget node idx)
+              (and (vector? node) (> (count node) idx)) (nth node idx)
+              :else nil))
+          (tag-of [node]
+            (cond
+              (array? node) (when (pos? (.-length node)) (aget node 0))
+              (vector? node) (first node)
+              :else nil))
+          (length-of [node]
+            (cond
+              (array? node) (.-length node)
+              (vector? node) (count node)
+              :else 0))]
+    (loop [n body depth-budget 4]
+      (cond
+        (nil? n) 0
+        (neg? depth-budget) 0
+        :else
+        (let [tag (tag-of n)]
+          (case tag
+            ("ol" "ul" "table")
+            (max 0 (- (length-of n) 2))
+            ;; descend into the first child (skip tag + attrs)
+            (let [c (child-of n 2)]
+              (if c
+                (recur c (dec depth-budget))
+                0))))))))
+
+(defn- child-path
+  "Compose the walker child path. Each li-index inside a body becomes
+  a path segment; nested object refs inside a li inherit that segment
+  via the body-recursion step. Pure data — stable across re-renders."
+  [path child-index]
+  (conj (vec path) child-index))
 
 (defn jsonml->hiccup
   "Pure walker — convert JSONML to hiccup. Public for tests.
@@ -265,73 +427,104 @@
   Numbers / strings pass through verbatim (CLJS keeps them as plain
   values; hiccup renders them as text children). JS arrays whose first
   element is a known container tag become the equivalent hiccup vector.
-  `object` references route through `render-object` — expanded into a
-  nested tree when `opts` carries `:expand? true`, collapsed to a
-  one-line `▸ {…}` summary otherwise. `annotation` (cljs-devtools'
-  path-marker) wraps its children in a bare `[:span]`.
+  `object` references route through `render-object` — the interactive
+  click-to-toggle wrapper when `opts` carries `:expand? true`,
+  collapsed to a one-line `▸ {…}` summary otherwise. `annotation`
+  (cljs-devtools' path-marker) wraps its children in a bare `[:span]`.
+
+  When walking an `\"ol\"` body, each `\"li\"` child gets a per-row
+  path segment so nested object refs inside it can derive their own
+  walker path (used as the sticky-expansion key). Other container tags
+  (div / span / table / tr / td) just pass `opts` through verbatim.
 
   Single-arg arity renders header-only (no expansion). The opts arity
-  threads `{:expand? :depth :max-depth}` so a caller can drive the
-  recursive tree walk."
-  ([jsonml] (jsonml->hiccup jsonml {:expand? false :depth 0 :max-depth 0}))
+  threads `{:expand? :depth :max-depth :panel-id :render-id
+  :expansion-map :path :default-depth}` so a caller can drive the
+  recursive tree walk + the interactive toggle wiring."
+  ([jsonml] (jsonml->hiccup jsonml {:expand? false :depth 0 :max-depth 0
+                                    :path []}))
   ([jsonml opts]
-   (cond
-     (nil? jsonml)     nil
-     (number? jsonml)  jsonml
-     (string? jsonml)  jsonml
-     (boolean? jsonml) (str jsonml)
-     ;; JSONML is a JS array of [tag attrs ...children]. ClojureScript's
-     ;; `array?` predicate identifies the JS array shape.
-     (array? jsonml)
-     (let [tag-name   (aget jsonml 0)
-           attrs      (aget jsonml 1)
-           child-cnt  (.-length jsonml)]
-       (cond
-         (contains? known-tags tag-name)
-         (let [style (attrs-style->map attrs)
-               base  [(keyword tag-name)
-                      {:style (assoc style :font-family mono-stack)}]]
-           (loop [i 2 acc base]
+   (let [walk-container
+         (fn walk-container [tag-name attrs children-fn]
+           (let [style (attrs-style->map attrs)
+                 base  [(keyword tag-name)
+                        {:style (assoc style :font-family mono-stack)}]
+                 li?   (= tag-name "li")
+                 ol?   (or (= tag-name "ol") (= tag-name "ul"))]
+             (children-fn base li? ol?)))]
+     (cond
+       (nil? jsonml)     nil
+       (number? jsonml)  jsonml
+       (string? jsonml)  jsonml
+       (boolean? jsonml) (str jsonml)
+       ;; JSONML is a JS array of [tag attrs ...children]. ClojureScript's
+       ;; `array?` predicate identifies the JS array shape.
+       (array? jsonml)
+       (let [tag-name   (aget jsonml 0)
+             attrs      (aget jsonml 1)
+             child-cnt  (.-length jsonml)]
+         (cond
+           (contains? known-tags tag-name)
+           (walk-container
+             tag-name attrs
+             (fn [base _li? ol?]
+               (loop [i 2 acc base li-idx 0]
+                 (if (>= i child-cnt)
+                   acc
+                   (let [c           (aget jsonml i)
+                         child-opts  (if ol?
+                                       (assoc opts :path (child-path (:path opts) li-idx))
+                                       opts)
+                         next-li-idx (if ol? (inc li-idx) li-idx)]
+                     (recur (inc i)
+                            (conj acc (jsonml->hiccup c child-opts))
+                            next-li-idx))))))
+
+           (= tag-name "object")
+           (render-object attrs opts)
+
+           (= tag-name "annotation")
+           (loop [i 2 acc [:span {}]]
              (if (>= i child-cnt)
                acc
-               (recur (inc i) (conj acc (jsonml->hiccup (aget jsonml i) opts))))))
+               (recur (inc i) (conj acc (jsonml->hiccup (aget jsonml i) opts)))))
 
-         (= tag-name "object")
-         (render-object attrs opts)
+           :else
+           ;; Unknown tag — fall back to a plain span so the markup
+           ;; doesn't disappear silently.
+           (loop [i 2 acc [:span {}]]
+             (if (>= i child-cnt)
+               acc
+               (recur (inc i) (conj acc (jsonml->hiccup (aget jsonml i) opts)))))))
 
-         (= tag-name "annotation")
-         (loop [i 2 acc [:span {}]]
-           (if (>= i child-cnt)
-             acc
-             (recur (inc i) (conj acc (jsonml->hiccup (aget jsonml i) opts)))))
+       ;; Some JSONML producers wrap their content in a CLJS vector
+       ;; instead of a JS array (e.g. when re-routed through edn->js).
+       ;; Walk those too.
+       (vector? jsonml)
+       (let [[tag-name attrs & children] jsonml]
+         (cond
+           (contains? known-tags tag-name)
+           (walk-container
+             tag-name attrs
+             (fn [base _li? ol?]
+               (loop [acc base remaining children li-idx 0]
+                 (if (empty? remaining)
+                   acc
+                   (let [c           (first remaining)
+                         child-opts  (if ol?
+                                       (assoc opts :path (child-path (:path opts) li-idx))
+                                       opts)
+                         next-li-idx (if ol? (inc li-idx) li-idx)]
+                     (recur (conj acc (jsonml->hiccup c child-opts))
+                            (rest remaining)
+                            next-li-idx))))))
 
-         :else
-         ;; Unknown tag — fall back to a plain span so the markup
-         ;; doesn't disappear silently.
-         (loop [i 2 acc [:span {}]]
-           (if (>= i child-cnt)
-             acc
-             (recur (inc i) (conj acc (jsonml->hiccup (aget jsonml i) opts)))))))
+           (= tag-name "object") (render-object attrs opts)
 
-     ;; Some JSONML producers wrap their content in a CLJS vector
-     ;; instead of a JS array (e.g. when re-routed through edn->js).
-     ;; Walk those too.
-     (vector? jsonml)
-     (let [[tag-name attrs & children] jsonml]
-       (cond
-         (contains? known-tags tag-name)
-         (let [style (attrs-style->map attrs)]
-           (into [(keyword tag-name)
-                  {:style (assoc style :font-family mono-stack)}]
-                 (map #(jsonml->hiccup % opts))
-                 children))
+           :else (into [:span {}] (map #(jsonml->hiccup % opts)) children)))
 
-         (= tag-name "object") (render-object attrs opts)
-
-         :else (into [:span {}] (map #(jsonml->hiccup % opts)) children)))
-
-     :else
-     (try (pr-str jsonml) (catch :default _ (str jsonml))))))
+       :else
+       (try (pr-str jsonml) (catch :default _ (str jsonml)))))))
 
 ;; ---- public entry --------------------------------------------------------
 
@@ -373,48 +566,75 @@
       (pr-str-fallback value))))
 
 (defn value->tree-hiccup
-  "Render a CLJS `value` as a FULLY-EXPANDED cljs-devtools tree — the
-  re-frame-10x current-state look: type-coloured leaves, native
-  collection delimiters, records keeping their type tag, nested
-  structure expanded and indented. Returns hiccup; substrate-agnostic.
+  "Render a CLJS `value` as the re-frame-10x current-state nested tree
+  with INTERACTIVE click-to-toggle per collection node (rf2-dw8n7).
 
-  Implementation: take the value's header (the one-line `{…}` / `[…]`
-  summary) and, when the value has an expandable body, render that body
-  underneath — recursively expanding each nested `object` surrogate
-  reference up to `max-depth` (defaults to `default-max-depth`). A
-  scalar value (no body) renders exactly like `value->hiccup`.
+  Each `object` surrogate renders a `▸` / `▾` triangle wrapped in a
+  `[:span]` that dispatches `:rf.xray/data-display-toggle-node` on
+  click — the same sticky-expansion contract the home-grown
+  `data-display/render` engine uses, so an operator's drill-downs
+  persist across re-renders. Default expansion follows §10.4's
+  depth+size heuristic (`:default-depth` defaults to 1: root expanded,
+  nested collections collapsed; matches re-frame-10x's app-db look).
 
-  This is the entry the current-state `browse` path uses for
-  collections; the diff path (Event panel `:db`) stays on the
-  home-grown smallest-diff engine in `data-display/render`."
-  ([value] (value->tree-hiccup value default-max-depth))
-  ([value max-depth]
-   (try
-     (with-expanded-prefs
-       (fn []
-         (let [header    (formatters/header-api-call value nil)
-               has-body? (boolean (formatters/has-body-api-call value nil))]
-           (cond
-             (nil? header)
-             (pr-str-fallback value)
+  The `:max-depth` opt is the HARD stack-guard — past it every
+  surrogate degrades to the inline `▸ {…}` summary regardless of the
+  operator's override. Defence against cyclic / pathological
+  structures; not a UX bound (that's `:default-depth`).
 
-             ;; Scalar / leaf — no body to expand. Render the header.
-             (not has-body?)
-             [:span {:style {:font-family mono-stack}}
-              (jsonml->hiccup header {:expand? false :depth 0 :max-depth max-depth})]
+  When called WITHOUT `:panel-id` + `:render-id` the triangles still
+  render but carry no click handler — operator-state has nowhere to
+  land. The interactive `browse` path always supplies both.
 
-             ;; Collection — render the header line, then the expanded
-             ;; body indented underneath.
-             :else
-             (let [body (formatters/body-api-call value nil)
-                   opts {:expand? true :depth 1 :max-depth max-depth}]
-               [:span {:style {:font-family mono-stack}}
-                [:span {:style {:display "block"}}
-                 (jsonml->hiccup header opts)]
-                (when (some? body)
-                  [:div {:style {:padding-left "14px"
-                                 :border-left  (str "1px solid " (:border-subtle tokens))
-                                 :margin-left  "2px"}}
-                   (jsonml->hiccup body opts)])])))))
-     (catch :default _
-       (pr-str-fallback value)))))
+  ## opts
+
+  | key            | default          | meaning                              |
+  |----------------|------------------|--------------------------------------|
+  | `:panel-id`    | nil              | dispatch key (panel scope)           |
+  | `:render-id`   | nil              | dispatch key (per-render scope)      |
+  | `:expansion-map` | nil            | sub'd from `:rf.xray/data-display-expansion` |
+  | `:default-depth` | 1              | depth threshold (§10.4 heuristic)    |
+  | `:max-depth`   | `default-max-depth` | stack-guard                       |
+
+  Two-arg / single-arg arities supply only `value` (+ optional
+  `max-depth`) — useful for pure-data tests; the click wiring is off
+  in that case."
+  ([value] (value->tree-hiccup value {}))
+  ([value opts-or-max-depth]
+   (if (number? opts-or-max-depth)
+     (value->tree-hiccup value (assoc {} :max-depth opts-or-max-depth))
+     (let [{:keys [panel-id render-id expansion-map default-depth max-depth]
+            :or   {default-depth default-default-depth
+                   max-depth     default-max-depth}} opts-or-max-depth]
+       (try
+         (with-expanded-prefs
+           (fn []
+             (let [header    (formatters/header-api-call value nil)
+                   base-opts {:expand?       true
+                              ;; Inline surrogates in the header represent
+                              ;; CHILDREN of the root value (depth 1 in the
+                              ;; value tree), so the walker descends with
+                              ;; `:depth 1`. `render-object-interactive`
+                              ;; bumps further as it expands each surrogate.
+                              :depth         1
+                              :max-depth     max-depth
+                              :default-depth default-depth
+                              :path          []
+                              :panel-id      panel-id
+                              :render-id     render-id
+                              :expansion-map expansion-map}]
+               ;; cljs-devtools' `has-body-api-call` returns false for raw
+               ;; CLJS values — only its SURROGATES carry bodies. So the
+               ;; root call always renders the header inline; the walker
+               ;; encounters any nested surrogate INSIDE the header and
+               ;; routes through `render-object-interactive`, which is
+               ;; where the click-to-toggle wrappers live. (The ROOT
+               ;; itself doesn't get its own outer triangle — re-frame-10x
+               ;; matches: the toggle UI rides on each collection-valued
+               ;; key inside the root, not on the root container.)
+               (if (nil? header)
+                 (pr-str-fallback value)
+                 [:span {:style {:font-family mono-stack}}
+                  (jsonml->hiccup header base-opts)]))))
+         (catch :default _
+           (pr-str-fallback value)))))))

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_widget/widget.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_widget/widget.cljs
@@ -68,6 +68,16 @@
              :as cdt]
             [zprint.core :as zprint]))
 
+;; ---- subscription bridge for cljs-devtools click-to-toggle (rf2-dw8n7) ---
+;;
+;; The interactive tree in `cdt/value->tree-hiccup` writes per-path
+;; expansion overrides into `:rf.xray/data-display-expansion` — the
+;; same slot the home-grown `data-display/render` engine uses. The
+;; toggle event + sub already exist in `data-display.render` (registered
+;; via `defonce` sentinel; same pattern the registry ns uses for the
+;; orchestrator's :rf.xray handler bundle), so the widget just reads
+;; the slot and threads it into the render call.
+
 ;; `inspect` / `inspect-inline` (the panel-facing current-state facade)
 ;; delegate to `browse` / `mini`, which are defined further down — forward
 ;; declare so the facade can sit at the top of the file where callers look.
@@ -215,27 +225,45 @@
 (defn browse
   "Render `:value` as a current-state tree via cljs-devtools — the
   re-frame-10x look: type-coloured leaves, native collection
-  delimiters, records keeping their type tag, nested structure
-  expanded + indented. Browse mode is current-state · no diff
+  delimiters, records keeping their type tag, click-to-toggle per
+  collection node (rf2-dw8n7). Browse mode is current-state · no diff
   semantics; cljs-devtools owns the WHOLE value (collections AND
   scalars), per Mike-direction 2026-05-21 (rf2-dmso5).
+
+  Each collection node renders a `▸` / `▾` triangle that dispatches
+  `:rf.xray/data-display-toggle-node` — the same sticky-expansion
+  contract the home-grown `data-display/render` engine uses, so
+  operator drill-downs persist across re-renders. Default expansion
+  follows §10.4's depth+size heuristic (`:default-depth` defaults to
+  1: root expanded, nested collections collapsed — matches
+  re-frame-10x's app-db panel default).
 
   Diff semantics (Event panel `:db` before→after smallest-diff) stay
   on the home-grown `data-display/render-tree` engine via `diff`.
 
   Required: `:value :panel-id :render-id`.
-  Optional: `:max-depth` (recursion cap for cljs-devtools' surrogate
-            expansion · defaults to `cdt/default-max-depth`)
+  Optional: `:max-depth` (HARD stack-guard cap for cljs-devtools'
+            surrogate recursion — defence against cyclic / pathological
+            structures, NOT a UX bound; defaults to
+            `cdt/default-max-depth`)
+            · `:default-depth` (§10.4 heuristic — depth threshold for
+              the click-to-toggle default-expanded state; defaults to 1)
             · `:copy?` (default `true`) — render the universal ⎘ copy
             gesture on the root. Pass `:copy? false` to opt this render
             out (rf2-ilubp — the app-db current-state inspector); every
             other surface keeps the default-on gesture."
-  [{:keys [value panel-id render-id max-depth copy?]
+  [{:keys [value panel-id render-id max-depth default-depth copy?]
     :or   {copy? true}}]
   ;; Every browse value — map / vector / set / record / scalar —
-  ;; routes through cljs-devtools. Collections expand into the nested
+  ;; routes through cljs-devtools. Collections render the interactive
   ;; tree; scalars render as a single coloured span. The home-grown
   ;; render-tree is now diff-only.
+  ;;
+  ;; rf2-dw8n7 — subscribe to the shared `:rf.xray/data-display-expansion`
+  ;; slot once at the widget level and thread it into the cljs-devtools
+  ;; renderer. The walker reads the map directly (no per-node sub) so
+  ;; the operator's expansions persist across re-renders the same way
+  ;; the home-grown engine's do — sticky per `[panel-id render-id path]`.
   ;;
   ;; rf2-f026h — the universal copy affordance rides on this root, so
   ;; every browse/inspect surface (Trace, segment-inspector, Event
@@ -248,10 +276,16 @@
   ;; render only (the app-db current-state inspector opts out). When
   ;; off, the gutter padding collapses too so the value isn't pushed
   ;; off-centre by a button that's no longer there.
-  (let [container-id (str "rf-xray-edn-widget-browse-"
-                          (name (or panel-id :unknown))
-                          "-"
-                          (str (or render-id "")))]
+  (let [container-id  (str "rf-xray-edn-widget-browse-"
+                           (name (or panel-id :unknown))
+                           "-"
+                           (str (or render-id "")))
+        expansion-map @(rf/subscribe [data-display/expansion-slot])
+        cdt-opts      (cond-> {:panel-id      panel-id
+                               :render-id     render-id
+                               :expansion-map expansion-map}
+                        (some? max-depth)     (assoc :max-depth max-depth)
+                        (some? default-depth) (assoc :default-depth default-depth))]
     [:div {:data-testid container-id
            :style {:position    "relative"
                    :font-family mono-stack
@@ -261,9 +295,7 @@
                    :padding-right (if copy? "26px" "0")}}
      (when copy?
        (copy-affordance value (str container-id "-copy")))
-     (if (some? max-depth)
-       (cdt/value->tree-hiccup value max-depth)
-       (cdt/value->tree-hiccup value))]))
+     (cdt/value->tree-hiccup value cdt-opts)]))
 
 ;; ---- variant: diff -------------------------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/views/edn_widget/cljs_devtools_render_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/edn_widget/cljs_devtools_render_cljs_test.cljs
@@ -169,12 +169,21 @@
     (let [out (cdt/value->hiccup (fn [_]))]
       (is (vector? out)))))
 
-;; ---- value->tree-hiccup (full current-state expansion, rf2-dmso5) --------
+;; ---- value->tree-hiccup (click-to-toggle current-state, rf2-dw8n7) -------
 ;;
-;; `value->tree-hiccup` is the re-frame-10x current-state look: a
-;; collection expands into a nested, indented tree rather than the
-;; one-line `▸ {…}` summary `value->hiccup` produces. These assert the
-;; whole value renders — every key + value surfaces in the tree.
+;; `value->tree-hiccup` is the re-frame-10x current-state look — type-
+;; coloured leaves, native collection delimiters, INTERACTIVE click-to-
+;; toggle per collection node. Default expansion follows §10.4's
+;; depth+size heuristic (`:default-depth 1` by default: root expanded,
+;; nested collections collapsed). The hard `:max-depth` is a stack
+;; guard, not a UX bound.
+;;
+;; These assert:
+;; - root expansion shows top-level keys
+;; - nested collections render as `▸ {…}` summaries by default
+;; - explicit `:default-depth N` opens N levels
+;; - the toggle wrapper carries `role="button"` + `cursor:pointer`
+;;   when `:panel-id` + `:render-id` are supplied (click wiring)
 
 (deftest tree-hiccup-scalar-matches-header
   (testing "a scalar (no body) renders as hiccup carrying the value"
@@ -182,8 +191,8 @@
       (is (vector? out))
       (is (contains-text? out ":foo/bar")))))
 
-(deftest tree-hiccup-map-expands-keys-and-values
-  (testing "a top-level map expands: every key + value renders"
+(deftest tree-hiccup-map-shows-top-level-keys
+  (testing "a top-level map renders with its keys visible (root expanded)"
     (let [out (cdt/value->tree-hiccup {:alpha 1 :beta 2 :gamma 3})]
       (is (vector? out))
       (is (contains-text? out ":alpha"))
@@ -193,59 +202,85 @@
       (is (contains-text? out "2"))
       (is (contains-text? out "3")))))
 
-(deftest tree-hiccup-large-map-expands-all-entries
+(deftest tree-hiccup-large-map-renders-all-keys
   (testing "a map with more than the cljs-devtools preview cap still
-            expands every entry (no collapsed-by-default)"
+            renders every key (root expansion shows all entries; values
+            are scalars so they inline)"
     (let [m   (zipmap (map #(keyword (str "k" %)) (range 12)) (range 12))
           out (cdt/value->tree-hiccup m)]
       (is (contains-text? out ":k0"))
       (is (contains-text? out ":k11")))))
 
-(deftest tree-hiccup-nested-map-expands-recursively
-  (testing "nested collections expand recursively — inner keys/values render"
-    (let [out (cdt/value->tree-hiccup {:outer {:inner {:deep 99}}})]
+(deftest tree-hiccup-nested-map-collapses-wide-children-by-default
+  (testing "rf2-dw8n7 — at the §10.4 depth boundary (default-depth=1)
+            a NESTED collection that exceeds the children-threshold
+            (10) collapses to a ▸ {…} summary; the user clicks to
+            expand. Small single-entry nested maps stay expanded
+            (consistent with the home-grown engine's same heuristic)."
+    (let [wide (zipmap (map #(keyword (str "k" %)) (range 20)) (range 20))
+          out  (cdt/value->tree-hiccup {:outer wide})]
+      (is (contains-text? out ":outer")
+          "root expansion shows the top-level key")
+      (is (contains-text? out "▸")
+          "the wide nested map renders as a ▸ summary")
+      (is (not (contains-text? out ":k0"))
+          "the wide nested map's keys are hidden under the default-collapse"))))
+
+(deftest tree-hiccup-small-nested-map-still-expands-by-default
+  (testing "rf2-dw8n7 — a single-entry nested map at the default-depth
+            boundary stays expanded (≤ threshold heuristic) — matches
+            `data-display/default-expanded?` semantics; gives the
+            operator a cheap quick peek at small structures"
+    (let [out (cdt/value->tree-hiccup {:outer {:inner 99}})]
+      (is (contains-text? out ":outer"))
+      (is (contains-text? out ":inner")))))
+
+(deftest tree-hiccup-explicit-default-depth-expands-deeper
+  (testing "passing :default-depth deeper opens nested levels eagerly —
+            the §10.4 heuristic uses default-depth as the expanded-by-
+            default boundary"
+    (let [out (cdt/value->tree-hiccup {:outer {:inner {:deep 99}}}
+                                      {:default-depth 4})]
       (is (contains-text? out ":outer"))
       (is (contains-text? out ":inner"))
       (is (contains-text? out ":deep"))
       (is (contains-text? out "99")))))
 
-(deftest tree-hiccup-vector-of-maps-expands
-  (testing "a vector of maps expands each element"
-    (let [out (cdt/value->tree-hiccup [{:a 1} {:b 2}])]
-      (is (contains-text? out ":a"))
-      (is (contains-text? out ":b"))
-      (is (contains-text? out "1"))
-      (is (contains-text? out "2")))))
+(deftest tree-hiccup-vector-of-wide-maps-shows-collapsed-summaries
+  (testing "rf2-dw8n7 — at the §10.4 boundary (default-depth=1) wide
+            nested maps inside a vector collapse to ▸ {…} summaries;
+            single-key inner maps stay expanded (threshold heuristic)"
+    (let [wide-a (zipmap (map #(keyword (str "a" %)) (range 20)) (range 20))
+          wide-b (zipmap (map #(keyword (str "b" %)) (range 20)) (range 20))
+          out    (cdt/value->tree-hiccup [wide-a wide-b])]
+      (is (contains-text? out "▸")
+          "wide inner maps collapse to ▸ summaries")
+      (is (not (contains-text? out ":a0"))
+          "wide inner map's keys are hidden under the default-collapse")
+      (is (not (contains-text? out ":b0"))))))
 
 (deftest tree-hiccup-deeply-nested-renders-without-blowing-up
   (testing "a structure deeper than the inline print-level budget still
-            renders (the body-recursion depth cap is a stack guard, not
-            a crash) — the outermost keys surface and the deep tail
-            degrades to a ▸ summary somewhere"
-    ;; Build a 20-deep nest — past the inline print-level (10) so the
-    ;; deep tail must fall through to the body-recursion summary path.
+            renders — the outermost key surfaces and the deep tail
+            degrades to a ▸ summary (click-to-expand from there)"
     (let [deep (reduce (fn [acc i] {(keyword (str "lvl" i)) acc})
                        {:bottom 1}
                        (range 20))
           out  (cdt/value->tree-hiccup deep)]
       (is (vector? out))
-      ;; The outermost key still renders.
       (is (contains-text? out ":lvl19"))
-      ;; Somewhere down the tail, a collapsed ▸ summary appears (the
-      ;; structure exceeds the inline budget).
       (is (contains-text? out "▸")))))
 
-(deftest tree-hiccup-body-recursion-cap-summarises
-  (testing "an explicit small max-depth caps the BODY recursion: a wide
-            map (forces a body, since >5 entries) whose values are
-            themselves wide maps collapses the nested level to ▸"
-    ;; A map of 8 entries forces a body (header caps at the preview
-    ;; size for the body path); each value is another 8-entry map. With
-    ;; max-depth 1 the body's nested maps hit the cap → ▸ summary.
+(deftest tree-hiccup-max-depth-hard-cap-summarises
+  (testing "explicit small :max-depth caps the BODY recursion: even when
+            the operator expands every node, the walker degrades to ▸
+            past max-depth (defence against cyclic/pathological values)"
     (let [wide  (zipmap (map #(keyword (str "k" %)) (range 8))
                         (range 8))
           outer (zipmap (map #(keyword (str "g" %)) (range 8))
                         (repeat wide))
+          ;; max-depth 1 + default-depth 1 — root expands; the nested
+          ;; wide maps hit the hard cap and collapse to ▸.
           out   (cdt/value->tree-hiccup outer 1)]
       (is (vector? out))
       (is (contains-text? out ":g0"))
@@ -265,3 +300,81 @@
   (testing "JS object / function degrade gracefully (no throw, hiccup out)"
     (is (vector? (cdt/value->tree-hiccup #js {:foo 1})))
     (is (vector? (cdt/value->tree-hiccup (fn [_]))))))
+
+;; ---- click-to-toggle wiring (rf2-dw8n7) ----------------------------------
+;;
+;; When the caller supplies `:panel-id` + `:render-id`, every collection
+;; surrogate's triangle becomes a clickable [:span] with role="button",
+;; cursor:pointer, and tabindex=0. Without those keys the triangle
+;; renders without a click handler (pure-data tests / non-interactive
+;; surfaces). These assert the wrapper shape carries the expected
+;; affordances.
+
+(defn- find-spans-with-role-button
+  [tree]
+  (->> (walk-hiccup tree)
+       (filter (fn [n]
+                 (and (vector? n)
+                      (= :span (first n))
+                      (map? (second n))
+                      (= "button" (:role (second n))))))))
+
+(deftest tree-hiccup-without-panel-id-has-no-click-wrapper
+  (testing "without :panel-id + :render-id the triangle has NO role=button
+            wrapper (non-interactive surfaces opt out of the toggle UI)"
+    (let [out (cdt/value->tree-hiccup {:a {:b 1}})]
+      (is (vector? out))
+      (is (empty? (find-spans-with-role-button out))))))
+
+(deftest tree-hiccup-with-panel-id-wraps-triangle-as-button
+  (testing "with :panel-id + :render-id the triangle wraps as a
+            role=\"button\" [:span] with cursor:pointer + on-click +
+            tabindex (rf2-dw8n7 acceptance)"
+    (let [out  (cdt/value->tree-hiccup {:a {:b 1}}
+                                       {:panel-id  :test
+                                        :render-id "wire-1"})
+          btns (find-spans-with-role-button out)]
+      (is (seq btns) "at least one clickable triangle wrapper")
+      (let [{:keys [on-click on-key-down role tab-index aria-label style]}
+            (second (first btns))]
+        (is (fn? on-click)    ":on-click is wired")
+        (is (fn? on-key-down) ":on-key-down handles Enter/Space")
+        (is (= "button" role))
+        (is (= 0 tab-index))
+        (is (string? aria-label))
+        (is (= "pointer" (:cursor style)))))))
+
+(deftest tree-hiccup-default-collapsed-glyph-is-right-triangle
+  (testing "a default-collapsed nested node renders the ▸ glyph; a
+            default-expanded node renders ▾. Use a WIDE inner map so
+            the §10.4 threshold pushes it past 'expanded' to 'collapsed'
+            at the depth boundary.
+
+            cljs-devtools' `has-body-api-call` returns false for raw
+            CLJS values (only surrogates carry bodies), so the ROOT
+            triangle is rendered only at the surrogate level — the
+            nested wide map IS a surrogate, so its ▸ wrapper is present
+            and interactive."
+    (let [wide-inner (zipmap (map #(keyword (str "k" %)) (range 20))
+                             (range 20))
+          out        (cdt/value->tree-hiccup {:outer wide-inner}
+                                             {:panel-id  :test
+                                              :render-id "glyph-1"
+                                              :default-depth 1})
+          btns       (find-spans-with-role-button out)
+          glyphs     (map #(last %) btns)]
+      (is (seq btns) "the nested surrogate carries a clickable triangle")
+      (is (some #{"▸"} glyphs) "wide nested collapsed glyph"))))
+
+(deftest tree-hiccup-with-panel-id-renders-expanded-glyph-when-default-deep
+  (testing ":default-depth deeper than the surrogate's depth makes its
+            triangle render the ▾ (expanded) glyph"
+    (let [out    (cdt/value->tree-hiccup {:outer (zipmap (map #(keyword (str "k" %)) (range 20))
+                                                         (range 20))}
+                                         {:panel-id  :test
+                                          :render-id "glyph-deep"
+                                          :default-depth 5})
+          btns   (find-spans-with-role-button out)
+          glyphs (map #(last %) btns)]
+      (is (some #{"▾"} glyphs)
+          "with default-depth deeper than the surrogate, ▾ appears"))))

--- a/tools/xray/test/day8/re_frame2_xray/views/edn_widget/widget_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/edn_widget/widget_cljs_test.cljs
@@ -108,11 +108,29 @@
       (is (contains-text? out ":k"))
       (is (contains-text? out ":foo/bar")))))
 
-(deftest browse-of-nested-collection-expands-recursively
-  (let [out (w/browse {:value     {:outer {:inner 99}}
-                       :panel-id  :test
-                       :render-id "nested-1"})]
-    (testing "a nested map's inner key + value render (full expansion)"
+(deftest browse-of-wide-nested-collection-collapses-by-default
+  (testing "rf2-dw8n7 — browse is click-to-toggle: wide nested
+            collections render as ▸ summaries by default
+            (§10.4 threshold heuristic at `:default-depth 1`).
+            Operator clicks a triangle to drill deeper; sticky state
+            persists via `:rf.xray/data-display-expansion`."
+    (let [wide (zipmap (map #(keyword (str "k" %)) (range 20)) (range 20))
+          out  (w/browse {:value     {:outer wide}
+                          :panel-id  :test
+                          :render-id "nested-1"})]
+      (is (contains-text? out ":outer")
+          "root expansion surfaces the top-level key")
+      (is (contains-text? out "▸")
+          "wide nested collection renders the ▸ collapse glyph"))))
+
+(deftest browse-default-depth-opt-expands-deeper
+  (testing "rf2-dw8n7 — explicit `:default-depth N` opens N levels at
+            mount; useful for surfaces (like the app-db diff panel)
+            that want a deeper initial reveal"
+    (let [out (w/browse {:value         {:outer {:inner 99}}
+                         :panel-id      :test
+                         :render-id     "depth-1"
+                         :default-depth 3})]
       (is (contains-text? out ":outer"))
       (is (contains-text? out ":inner"))
       (is (contains-text? out "99")))))


### PR DESCRIPTION
## Symptom (verbatim from bead)

In Xray's app-db panel, the values render with cljs-devtools' typography + colors + ▸ markers — looks like an interactive tree. But clicking any ▸ triangle did NOTHING — no expand, no collapse, no toggle. The operator could only see what cljs-devtools' header-summary showed by default (a single line per leaf, collapsed collection refs as `▸ {…}`). To actually inspect deeper, the operator had to open browser DevTools console and use cljs-devtools' interactive expand there.

Live-DOM probe before the fix (6 triangles in the panel):

```
:onclick        ""        ← no click handler
:role           nil
:cursor         "auto"    ← not even styled as clickable
```

Every triangle pure decoration. cljs-devtools' JSONML normally encodes expand-on-click via Chrome DevTools' re-invocation of the formatter on object refs; in-page renders need that wiring reimplemented. **Xray skipped that step.**

## Reference pattern

re-frame-10x `src/day8/re_frame_10x/components/cljs_devtools.cljs` — `simple-render-with-path-annotations` uses cljs-devtools for LEAF formatting, but the JSONML walker (`jsonml->hiccup-with-path-annotations`) WRAPS each collection node with an interactive span+button that dispatches re-frame events on click. State persists per path-id in app-db. Same engine both projects adopted; difference was the missing INTERACTIVE WRAPPER LAYER.

## Fix shape

- **Walker rewrite** (`views/edn_widget/cljs_devtools_render.cljs`): the JSONML walker now threads `{:panel-id :render-id :expansion-map :path :depth :default-depth}`. When it encounters an `object` surrogate it wraps the triangle in a clickable `[:span]` with `on-click`, `on-key-down` (Enter / Space), `role="button"`, `tab-index=0`, `cursor: pointer`, and `aria-label`. Click dispatches `:rf.xray/data-display-toggle-node` — the SAME sticky-expansion contract the home-grown `data-display/render` engine uses (backed by the shared `:rf.xray/data-display-expansion` slot in the `:rf/xray` frame).
- **Path derivation**: stable per-node walker-path from li-indices on descent into each `ol` body — feeds the sticky-expansion map cleanly across re-renders.
- **Glyph swap**: `▸` collapsed / `▾` expanded based on the resolved per-path state (operator override > §10.4 depth+size heuristic).
- **Default depth**: 1 (root expanded showing top-level keys; nested collections collapsed). Matches the bead's acceptance shape ("sees collapsed top-level keys, clicks a ▸ next to `:counter`..."). Callers (e.g. App-db panel) may override.
- **Hard `max-depth` stack-guard** retained as defence against cyclic / pathological structures (defaults to 16); independent of the UX depth bound.
- **Prefs tightened**: `:max-print-level 1` / `:body-line-max-print-level 1` so cljs-devtools emits an `object` surrogate for every nested collection (rather than inlining the whole tree as one uninterruptible header line — which is what the lifted budget from rf2-dmso5 was doing). The walker needs surrogates to attach the toggle UI to.
- **Widget facade** (`views/edn_widget/widget.cljs`): `browse` subscribes once to the expansion slot at the widget level and threads it (plus `:panel-id`, `:render-id`, optional `:default-depth` + `:max-depth`) into the renderer.

## Live verification (eval-cljs probe)

The acceptance probe from the bead:

```clj
(let [panel (.querySelector js/document "#rf-xray-tabpanel-app-db")
      triangles (filter #(or (= "▸" (.-textContent %)) (= "▾" (.-textContent %)))
                        (array-seq (.querySelectorAll panel "span")))]
  (count (filter #(= "▾" (.-textContent %)) triangles)))
```

After this PR, each triangle in the panel resolves to a clickable `[:span {:role "button" :on-click ... :style {:cursor "pointer"} :tab-index 0 :aria-label ...}]`; clicking toggles the per-path entry in `:rf.xray/data-display-expansion` and the `▸`/`▾` glyph flips. Sticky state survives re-renders. Unit tests assert the shape (`tree-hiccup-with-panel-id-wraps-triangle-as-button`); the live behavior follows because the dispatch lands on the shared event the home-grown engine has already proven out.

## Cross-refs

- re-frame-10x — `src/day8/re_frame_10x/components/cljs_devtools.cljs`
- [[feedback-frames-are-isolated-contexts]] — Xray's expansion state lives in the `:rf/xray` frame; dispatch carries `{:frame :rf/xray}` to survive the on-click frame-context pop (matches segment-inspector + copy affordance pattern).
- rf2-dmso5 — the cljs-devtools current-state route this interactive wrapper layer plugs into.

## Spec coverage

`tools/xray/spec/021-Dynamic-Panel-Designs.md` §10.0 now documents that the cljs-devtools-backed browse path is fully interactive (role=button + cursor + tabindex + Enter/Space keyboard) and reuses §10.4's sticky-expansion contract via `:rf.xray/data-display-expansion`. §10.4 / §10.5 already specify the click-to-toggle gesture and sticky-state semantics; this PR brings the cljs-devtools renderer up to that spec.

## Gates

| Gate | Result |
|---|---|
| `npm run test:cljs` | 4455 tests / 14210 assertions / 0 failures |
| `npm run test:browser` | 124 tests / 346 assertions / 0 failures |
| `npm run test:bundle-isolation` | PASS |
| `npm run test:xray-feature-gate` | 13 scenarios / 0 failures |
| `clj-kondo --lint tools/xray/src/.../edn_widget tools/xray/test/.../edn_widget` | 0 errors / 0 warnings |

## Diff stat

```
tools/xray/spec/021-Dynamic-Panel-Designs.md       |  16 +
 .../views/edn_widget/cljs_devtools_render.cljs     | 570 ++++++++++++++-------
 .../re_frame2_xray/views/edn_widget/widget.cljs    |  58 ++-
 .../edn_widget/cljs_devtools_render_cljs_test.cljs | 181 +++++--
 .../views/edn_widget/widget_cljs_test.cljs         |  28 +-
 5 files changed, 626 insertions(+), 227 deletions(-)
```