### PR TITLE
fix(xray): restore cljs-devtools colors + actually-toggling triangles + commas in app-db panel (rf2-oswhk; #2134 regression)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1296,6 +1296,33 @@ drill-downs persist across re-renders + epoch navigation per
 panel defaults to `:default-depth 3` for the diff render path,
 matching the re-frame-10x look).
 
+#### §10.0a Acceptance contract for the cljs-devtools walker (rf2-oswhk)
+
+Three properties the unit gate pins so a future renderer change can't
+re-break what rf2-oswhk repaired:
+
+1. **Per-token cljs-devtools palette preserved end-to-end.** The walker
+   keeps cljs-devtools' templated leaf-markup driving each scalar's
+   colour: keyword `rgba(136,19,145,1)` (magenta), integer
+   `rgba(28,0,207,1)` (blue), string `rgba(196,26,22,1)` (red), nil
+   `rgba(128,128,128,1)` (gray), boolean `rgba(0,153,153,1)` (teal).
+   Never replace cljs-devtools' header / body markup with a custom
+   per-leaf renderer — wrap surrogate refs only.
+2. **Click actually toggles.** Each surrogate's walker path is unique
+   across sibling surrogates (positional path-segment per descent —
+   matching re-frame-10x's `(conj indexed-path i)` walk). A click on
+   one triangle MUST toggle that triangle only; siblings stay put.
+3. **Expanded renders BODY, not HEADER + BODY.** When a surrogate is
+   expanded the triangle is followed by cljs-devtools' `body-api-call`
+   output (the `[:standard-ol [:standard-li ...]]` rows). The
+   collapsed-shape's `{…}` ellipsis must NOT survive next to the body.
+   re-frame-10x's `data-structure` is the reference (`src/day8/
+   re_frame_10x/components/cljs_devtools.cljs`).
+
+Unit tests pinning each property live in
+`tools/xray/test/day8/re_frame2_xray/views/edn_widget/cljs_devtools_render_cljs_test.cljs`
++ `widget_cljs_test.cljs`.
+
 ### §10.1 Capabilities (LOCKED per B.9 super-prompt)
 
 1. **Lazy collapsible tree** — hierarchical EDN with expand/collapse.

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_widget/cljs_devtools_render.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_widget/cljs_devtools_render.cljs
@@ -242,10 +242,12 @@
 
   The triangle is a `[:span]` with `:on-click` dispatching
   `:rf.xray/data-display-toggle-node` against this surrogate's
-  walker-path. When expanded, the header line is followed by the
-  surrogate's body indented underneath (recursing through the walker
-  with a deeper path). When collapsed, only the one-line header
-  renders.
+  walker-path. When EXPANDED the triangle is followed by cljs-devtools'
+  BODY (the recursive child rows). When COLLAPSED the triangle is
+  followed by cljs-devtools' HEADER (the one-line `{…}` summary). Body
+  OR header — never both (rf2-oswhk). re-frame-10x's
+  `data-structure` / `data-structure-with-path-annotations` use the
+  same shape — see `src/day8/re_frame_10x/components/cljs_devtools.cljs`.
 
   Defaults: §10.4 heuristic — depth ≤ default-depth → expanded; below
   the body's child-count threshold at the boundary → still expanded;
@@ -259,7 +261,10 @@
   `cljs-devtools` models a value's expandable rows as a surrogate whose
   `body-api-call` returns an `[\"ol\" ...]` of `[\"li\" ...]` lines;
   each line embeds child values as further `object` references — so
-  recursing on `body-api-call` walks the whole structure."
+  recursing on `body-api-call` walks the whole structure with the
+  type-aware colour palette intact (keyword magenta, number blue,
+  string red, nil gray, boolean teal — cljs-devtools' canonical
+  Chrome-console scheme)."
   [obj {:keys [depth max-depth panel-id render-id path
                expansion-map default-depth]
         :as opts}]
@@ -341,30 +346,33 @@
                            [:span {:style {:color (:text-tertiary tokens)
                                            :margin-right "2px"}}
                             glyph])
-            ;; Surrogates inside the surrogate's header / body represent
-            ;; CHILDREN of this node — they live at depth+1 in the value
-            ;; tree, so the walker descends with the bumped depth (and
-            ;; the per-li path additions the walker layers on top). This
-            ;; is what keeps the default-expansion heuristic honest for
-            ;; deeply nested values — without the bump, inline surrogates
-            ;; in the parent's header all read as depth=parent and the
-            ;; heuristic over-expands.
+            ;; Surrogates inside the surrogate's body represent CHILDREN
+            ;; of this node — they live at depth+1 in the value tree, so
+            ;; the walker descends with the bumped depth. The path is
+            ;; reset for the inner walk: the body's own li-indices form
+            ;; the path segments inside, on top of THIS surrogate's path
+            ;; already in `:path`. The walker's :path → child-index
+            ;; tracking re-establishes uniqueness as we descend.
             inner-opts   (assoc opts :depth (inc depth))]
-        (if expanded?
+        (if (and expanded? (some? body))
+          ;; Expanded: triangle + BODY. cljs-devtools' body emits
+          ;; `[:standard-ol [:standard-li <name-tag> <value-markup>]
+          ;;                [:standard-li <name-tag> <value-markup>] ...]`
+          ;; — one row per child, with the value-markup carrying the
+          ;; per-token colour palette via the templating system. Per
+          ;; re-frame-10x: we render the body INSTEAD of the header
+          ;; under the triangle, so the visible content is the deeper
+          ;; structure rather than the redundant `{…}` summary.
           [:span {:style {:font-family mono-stack}}
-           [:span {:style {:display "block"}}
-            triangle
-            [:span (jsonml->hiccup header inner-opts)]]
-           (when (some? body)
-             [:div {:style {:padding-left "14px"
-                            :border-left  (str "1px solid " (:border-subtle tokens))
-                            :margin-left  "2px"}}
-              (jsonml->hiccup body inner-opts)])]
-          ;; Collapsed: triangle + one-line header summary side-by-side.
+           triangle
+           (jsonml->hiccup body inner-opts)]
+          ;; Collapsed: triangle + one-line header summary
+          ;; (`{…}` / `[…]` etc., emitted by `header-api-call` because
+          ;; `:max-print-level 1` clamps the inline depth).
           [:span {:style {:font-family mono-stack
                           :color       (:text-secondary tokens)}}
            triangle
-           [:span (jsonml->hiccup header inner-opts)]])))))
+           (jsonml->hiccup header inner-opts)])))))
 
 (defn- render-object
   "Route an `object` reference to the interactive expanding renderer
@@ -432,10 +440,14 @@
   collapsed to a one-line `▸ {…}` summary otherwise. `annotation`
   (cljs-devtools' path-marker) wraps its children in a bare `[:span]`.
 
-  When walking an `\"ol\"` body, each `\"li\"` child gets a per-row
-  path segment so nested object refs inside it can derive their own
-  walker path (used as the sticky-expansion key). Other container tags
-  (div / span / table / tr / td) just pass `opts` through verbatim.
+  Every child gets a per-position path segment so each nested `object`
+  reference resolves to a UNIQUE `[panel-id render-id path]` key for
+  the sticky-expansion map (rf2-oswhk). Pre-fix the walker only added
+  path segments inside `\"ol\"` containers — so the n sibling
+  surrogates inside a single map's header all hashed to the same key
+  and a click on one toggled them all. Now every descent appends a
+  positional index (the child's index in its parent JSONML array),
+  mirroring re-frame-10x's `(conj indexed-path i)` walk.
 
   Single-arg arity renders header-only (no expansion). The opts arity
   threads `{:expand? :depth :max-depth :panel-id :render-id
@@ -444,14 +456,37 @@
   ([jsonml] (jsonml->hiccup jsonml {:expand? false :depth 0 :max-depth 0
                                     :path []}))
   ([jsonml opts]
-   (let [walk-container
-         (fn walk-container [tag-name attrs children-fn]
+   (let [walk-known
+         (fn walk-known [tag-name attrs children-getter child-cnt]
+           ;; `children-getter` is a fn that returns the i-th child (JS
+           ;; array `aget` or CLJS-vector `nth` — abstracted so the same
+           ;; loop handles both wrappers). Path segment per child so
+           ;; sibling surrogates resolve to distinct expansion keys.
            (let [style (attrs-style->map attrs)
                  base  [(keyword tag-name)
-                        {:style (assoc style :font-family mono-stack)}]
-                 li?   (= tag-name "li")
-                 ol?   (or (= tag-name "ol") (= tag-name "ul"))]
-             (children-fn base li? ol?)))]
+                        {:style (assoc style :font-family mono-stack)}]]
+             (loop [i 2 acc base child-idx 0]
+               (if (>= i child-cnt)
+                 acc
+                 (let [c          (children-getter i)
+                       child-opts (assoc opts :path
+                                         (child-path (:path opts) child-idx))]
+                   (recur (inc i)
+                          (conj acc (jsonml->hiccup c child-opts))
+                          (inc child-idx)))))))
+         walk-fallback
+         (fn walk-fallback [children-getter child-cnt]
+           ;; Annotation + unknown tags: a bare `[:span]` wrapper, with
+           ;; path-segment indexing matching the known-tag walk.
+           (loop [i 2 acc [:span {}] child-idx 0]
+             (if (>= i child-cnt)
+               acc
+               (let [c          (children-getter i)
+                     child-opts (assoc opts :path
+                                       (child-path (:path opts) child-idx))]
+                 (recur (inc i)
+                        (conj acc (jsonml->hiccup c child-opts))
+                        (inc child-idx))))))]
      (cond
        (nil? jsonml)     nil
        (number? jsonml)  jsonml
@@ -460,68 +495,40 @@
        ;; JSONML is a JS array of [tag attrs ...children]. ClojureScript's
        ;; `array?` predicate identifies the JS array shape.
        (array? jsonml)
-       (let [tag-name   (aget jsonml 0)
-             attrs      (aget jsonml 1)
-             child-cnt  (.-length jsonml)]
+       (let [tag-name  (aget jsonml 0)
+             attrs     (aget jsonml 1)
+             child-cnt (.-length jsonml)
+             get-child (fn [i] (aget jsonml i))]
          (cond
            (contains? known-tags tag-name)
-           (walk-container
-             tag-name attrs
-             (fn [base _li? ol?]
-               (loop [i 2 acc base li-idx 0]
-                 (if (>= i child-cnt)
-                   acc
-                   (let [c           (aget jsonml i)
-                         child-opts  (if ol?
-                                       (assoc opts :path (child-path (:path opts) li-idx))
-                                       opts)
-                         next-li-idx (if ol? (inc li-idx) li-idx)]
-                     (recur (inc i)
-                            (conj acc (jsonml->hiccup c child-opts))
-                            next-li-idx))))))
+           (walk-known tag-name attrs get-child child-cnt)
 
            (= tag-name "object")
            (render-object attrs opts)
 
-           (= tag-name "annotation")
-           (loop [i 2 acc [:span {}]]
-             (if (>= i child-cnt)
-               acc
-               (recur (inc i) (conj acc (jsonml->hiccup (aget jsonml i) opts)))))
-
+           ;; annotation + unknown tags share the bare-span fallback.
            :else
-           ;; Unknown tag — fall back to a plain span so the markup
-           ;; doesn't disappear silently.
-           (loop [i 2 acc [:span {}]]
-             (if (>= i child-cnt)
-               acc
-               (recur (inc i) (conj acc (jsonml->hiccup (aget jsonml i) opts)))))))
+           (walk-fallback get-child child-cnt)))
 
        ;; Some JSONML producers wrap their content in a CLJS vector
        ;; instead of a JS array (e.g. when re-routed through edn->js).
        ;; Walk those too.
        (vector? jsonml)
-       (let [[tag-name attrs & children] jsonml]
+       (let [[tag-name attrs & children] jsonml
+             children-vec (vec children)
+             child-cnt    (+ 2 (count children-vec))
+             ;; Position 0=tag, 1=attrs, 2+ = children — match the JS
+             ;; array layout so `i` indexes the same positions.
+             get-child    (fn [i] (nth children-vec (- i 2) nil))]
          (cond
            (contains? known-tags tag-name)
-           (walk-container
-             tag-name attrs
-             (fn [base _li? ol?]
-               (loop [acc base remaining children li-idx 0]
-                 (if (empty? remaining)
-                   acc
-                   (let [c           (first remaining)
-                         child-opts  (if ol?
-                                       (assoc opts :path (child-path (:path opts) li-idx))
-                                       opts)
-                         next-li-idx (if ol? (inc li-idx) li-idx)]
-                     (recur (conj acc (jsonml->hiccup c child-opts))
-                            (rest remaining)
-                            next-li-idx))))))
+           (walk-known tag-name attrs get-child child-cnt)
 
-           (= tag-name "object") (render-object attrs opts)
+           (= tag-name "object")
+           (render-object attrs opts)
 
-           :else (into [:span {}] (map #(jsonml->hiccup % opts)) children)))
+           :else
+           (walk-fallback get-child child-cnt)))
 
        :else
        (try (pr-str jsonml) (catch :default _ (str jsonml)))))))

--- a/tools/xray/test/day8/re_frame2_xray/views/edn_widget/cljs_devtools_render_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/edn_widget/cljs_devtools_render_cljs_test.cljs
@@ -20,6 +20,7 @@
 
   Pure-data scope — no DOM mount; hiccup-shape assertions only."
   (:require [cljs.test :refer-macros [deftest is testing]]
+            [clojure.string :as str]
             [day8.re-frame2-xray.views.edn-widget.cljs-devtools-render
              :as cdt]))
 
@@ -378,3 +379,249 @@
           glyphs (map #(last %) btns)]
       (is (some #{"▾"} glyphs)
           "with default-depth deeper than the surrogate, ▾ appears"))))
+
+;; ---- regression tests (rf2-oswhk) ---------------------------------------
+;;
+;; rf2-dw8n7 (#2134) wired click-to-toggle but two visual regressions
+;; slipped past the unit gate:
+;;
+;;   1. SHARED PATHS — every sibling `["object" ...]` surrogate inside a
+;;      single map's HEADER (inline view) walked with `:path []` because
+;;      the walker only appended path-segments inside an `"ol"` body.
+;;      Two siblings hashed to the same expansion-map key and a click
+;;      on one toggled them all. Click-to-toggle appeared broken because
+;;      the next click immediately re-toggled the shared slot.
+;;   2. EXPANDED RENDER SHOWED HEADER + BODY — the prior render emitted
+;;      both cljs-devtools' header (the `{…}` inline summary, kept
+;;      inline by `:max-print-level 1`) AND the body rows recursively.
+;;      The effect was a visual `{:counter ▾{…}0[:value 0]1[...]...}`
+;;      rather than re-frame-10x's clean expanded shape (where the
+;;      body replaces the header under the ▾ triangle).
+;;
+;; The fix mirrors re-frame-10x's `data-structure` /
+;; `data-structure-with-path-annotations` shape: every walker child
+;; gets a positional path segment (so sibling surrogates have distinct
+;; keys); when EXPANDED render the BODY, when COLLAPSED render the
+;; HEADER — never both. The cljs-devtools JSONML walker keeps driving
+;; the leaf-token markup so the canonical Chrome-console palette
+;; (keyword magenta / integer blue / string red / nil gray / boolean
+;; teal) survives intact end-to-end.
+
+(defn- walk-styled-spans
+  "Return every `[:span attrs ...]` node whose `:style` map carries a
+  `:color`, paired with the concatenated text content of the span."
+  [tree]
+  (let [out (atom [])]
+    (letfn [(text-of [n]
+              (cond
+                (string? n) n
+                (number? n) (str n)
+                (vector? n) (apply str (map text-of (rest n)))
+                (seq? n)    (apply str (map text-of n))
+                :else       ""))
+            (walk [n]
+              (when (vector? n)
+                (let [attrs (second n)]
+                  (when (and (= :span (first n))
+                             (map? attrs)
+                             (some-> attrs :style :color))
+                    (swap! out conj
+                           {:color (-> attrs :style :color)
+                            :text  (apply str (map text-of (drop 2 n)))})))
+                (doseq [c (rest n)]
+                  (cond
+                    (vector? c) (walk c)
+                    (seq? c)    (doseq [x c] (walk x))))))]
+      (walk tree)
+      @out)))
+
+(defn- walk-leaf-strings
+  "Walk the tree, collecting every leaf-string (and number→string) in
+  order. Useful for asserting structural shape via a concatenated
+  string."
+  [tree]
+  (let [out (atom [])]
+    (letfn [(walk [n]
+              (cond
+                (string? n) (swap! out conj n)
+                (number? n) (swap! out conj (str n))
+                (vector? n) (doseq [c (rest n)] (walk c))
+                (seq? n)    (doseq [c n] (walk c))))]
+      (walk tree)
+      @out)))
+
+(defn- color-of-leaf
+  "Return the `:color` style of the span whose concatenated content
+  equals `target-text`. Used to assert per-token colour preservation."
+  [tree target-text]
+  (->> (walk-styled-spans tree)
+       (filter #(= target-text (:text %)))
+       first
+       :color))
+
+(defn- find-toggle-buttons
+  [tree]
+  (filter (fn [n]
+            (and (vector? n)
+                 (= :span (first n))
+                 (map? (second n))
+                 (= "button" (:role (second n)))))
+          (walk-hiccup tree)))
+
+(deftest scalar-tokens-keep-cljs-devtools-palette
+  ;; Regression 2 — pre-fix every scalar inside the app-db panel
+  ;; collapsed to `--rf-xray-text-primary` because the prior worker
+  ;; effectively replaced cljs-devtools' templated markup with a custom
+  ;; renderer. The fix keeps the JSONML walker driving cljs-devtools'
+  ;; templated body markup so each scalar inherits the canonical
+  ;; Chrome-console palette.
+  (let [v   {:k    :foo/bar
+             :n    42
+             :s    "hello"
+             :nl   nil
+             :b    true}
+        ;; Default-depth high so the body is rendered (where each
+        ;; scalar appears via cljs-devtools' body-line markup with the
+        ;; per-token style spans).
+        out (cdt/value->tree-hiccup
+              v {:panel-id      :app-db
+                 :render-id     "scalar-colours"
+                 :default-depth 4})]
+    (testing "keyword paints magenta (cljs-devtools :keyword-style)"
+      (is (= "rgba(136,19,145,1)" (color-of-leaf out ":foo/bar"))))
+    (testing "integer paints blue (cljs-devtools :integer-style)"
+      (is (= "rgba(28,0,207,1)"   (color-of-leaf out "42"))))
+    (testing "string paints red (cljs-devtools :string-style)"
+      (is (= "rgba(196,26,22,1)"  (color-of-leaf out "\"hello\""))))
+    (testing "nil paints gray (cljs-devtools :nil-style)"
+      (is (= "rgba(128,128,128,1)" (color-of-leaf out "nil"))))
+    (testing "boolean paints teal (cljs-devtools :bool-style)"
+      (is (= "rgba(0,153,153,1)"   (color-of-leaf out "true"))))))
+
+(deftest sibling-surrogates-resolve-to-distinct-paths
+  ;; Regression 1 — pre-fix, two sibling collections inside a single
+  ;; map (e.g. `{:outer {…large} :tail {…large}}`) both walked with
+  ;; `:path []` so a click on one triangle toggled both. The fix
+  ;; appends a positional child-index to the path for every walker
+  ;; descent so siblings disambiguate.
+  (let [v    {:outer (zipmap (map #(keyword (str "k" %)) (range 20))
+                             (range 20))
+              :tail  (zipmap (map #(keyword (str "t" %)) (range 20))
+                             (range 20))}
+        out  (cdt/value->tree-hiccup
+               v {:panel-id      :p
+                  :render-id     "siblings"
+                  :default-depth 1})
+        btns (find-toggle-buttons out)
+        ids  (map #(:data-testid (second %)) btns)]
+    (testing "two distinct toggle triangles for the two wide siblings"
+      (is (>= (count btns) 2)
+          (str "expected ≥2 toggle triangles, got " (count btns))))
+    (testing "every sibling triangle gets its own data-testid"
+      (is (= (count ids) (count (set ids)))
+          (str "duplicate toggle ids (siblings collide on path): "
+               (pr-str ids))))))
+
+(deftest expansion-map-override-flips-collapsed-to-expanded
+  ;; Regression 1 (consequence) — the toggle dispatches
+  ;; `[:rf.xray/data-display-toggle-node panel-id render-id path]` and
+  ;; the handler writes `{[panel-id render-id path] {:expanded? true}}`
+  ;; into the expansion slot. The re-render reads that map and flips
+  ;; the surrogate's glyph. Pre-fix the click landed on path `[]`
+  ;; which the walker never resolved consistently. This test
+  ;; round-trips: extract the surrogate's path from its data-testid,
+  ;; build an expansion-map override at THAT path, re-render — the
+  ;; same surrogate must flip from ▸ to ▾.
+  (let [wide  (zipmap (map #(keyword (str "k" %)) (range 20)) (range 20))
+        v     {:outer wide}
+        out-1 (cdt/value->tree-hiccup
+                v {:panel-id      :p
+                   :render-id     "override"
+                   :default-depth 1})
+        btns-1 (find-toggle-buttons out-1)
+        ;; data-testid format:
+        ;; `rf-xray-edn-widget-toggle-<panel>-<render-id>-<a>/<b>/...`
+        ;; — split off the path tail and parse each segment back to int.
+        testid-1     (-> btns-1 first second :data-testid)
+        path-prefix  "rf-xray-edn-widget-toggle-p-override-"
+        path-suffix  (subs testid-1 (count path-prefix))
+        path-vec     (mapv #(js/parseInt % 10)
+                           (str/split path-suffix #"/"))
+        out-2 (cdt/value->tree-hiccup
+                v {:panel-id      :p
+                   :render-id     "override"
+                   :default-depth 1
+                   :expansion-map {[:p "override" path-vec]
+                                   {:expanded? true}}})
+        btns-2 (find-toggle-buttons out-2)
+        glyphs-2 (map last btns-2)]
+    (testing "wide nested map collapses to ▸ by default"
+      (is (= ["▸"] (map last btns-1))))
+    (testing "the same surrogate flips to ▾ when its expansion-map slot is set"
+      (is (some #{"▾"} glyphs-2)
+          (str "expected ▾ in " (pr-str glyphs-2)
+               " for override path " (pr-str path-vec))))))
+
+(deftest expanded-render-shows-body-not-header
+  ;; Regression 2 — pre-fix, expanded rendered both the cljs-devtools
+  ;; HEADER (the `{…}` inline summary, kept inline by
+  ;; `:max-print-level 1`) AND the BODY rows. The fix renders body OR
+  ;; header — never both. With a small (≤ threshold) inner map at the
+  ;; default depth, the inner IS expanded; its rendered text MUST NOT
+  ;; contain `{…}` (the cljs-devtools clamped-header ellipsis — that
+  ;; was the pre-fix smoking gun).
+  (let [v   {:counter {:value 0 :last 1 :name "x"}}
+        out (cdt/value->tree-hiccup
+              v {:panel-id      :app-db
+                 :render-id     "expanded-shape"
+                 :default-depth 4})
+        joined (apply str (walk-leaf-strings out))]
+    (testing "the expanded body shows the actual keys/values"
+      (is (re-find #":value" joined))
+      (is (re-find #":last"  joined))
+      (is (re-find #":name"  joined)))
+    (testing "no redundant {…} header summary survives next to the body"
+      (is (not (re-find #"\{…\}" joined))
+          (str "expanded body should not carry the cljs-devtools "
+               "header ellipsis (`{…}`); got " joined)))))
+
+(deftest collapsed-render-shows-header-not-body
+  ;; The complement — when COLLAPSED, the body rows must not surface;
+  ;; we show only the cljs-devtools header summary (`▸ {…}`).
+  (let [wide (zipmap (map #(keyword (str "k" %)) (range 20)) (range 20))
+        v    {:outer wide}
+        out  (cdt/value->tree-hiccup
+               v {:panel-id      :app-db
+                  :render-id     "collapsed-shape"
+                  :default-depth 1})
+        joined (apply str (walk-leaf-strings out))]
+    (testing "collapsed nested map renders the ▸ summary header"
+      (is (re-find #"▸"     joined))
+      (is (re-find #"\{…\}" joined)))
+    (testing "no body keys leak through when collapsed"
+      (is (not (re-find #":k0" joined))
+          (str "collapsed view should not surface the body's keys; "
+               "got " joined)))))
+
+(deftest collapsed-inline-header-keeps-cljs-devtools-commas
+  ;; Regression 3 — cljs-devtools' inline header for a small map
+  ;; renders comma+space separators between key-value pairs
+  ;; (`{:a 1, :b 2, :c 3}`). The previous worker's REPLACEMENT
+  ;; renderer dropped these (operator saw `{:value 0:last-clicked
+  ;; nil...}` end-to-end). The fix keeps cljs-devtools driving the
+  ;; inline header so the commas survive.
+  (let [v   {:a 1 :b 2 :c 3}
+        out (cdt/value->tree-hiccup v {:panel-id      :app-db
+                                       :render-id     "commas"
+                                       :default-depth 4})
+        joined (apply str (walk-leaf-strings out))]
+    (testing "key+value pairs appear in the rendered text"
+      (is (re-find #":a"  joined))
+      (is (re-find #":b"  joined))
+      (is (re-find #":c"  joined)))
+    (testing "comma+space separators between key-value pairs"
+      (is (re-find #", :b" joined)
+          (str "expected comma between :a and :b; got " joined))
+      (is (re-find #", :c" joined)
+          (str "expected comma between :b and :c; got " joined)))))
+

--- a/tools/xray/test/day8/re_frame2_xray/views/edn_widget/widget_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/edn_widget/widget_cljs_test.cljs
@@ -135,6 +135,81 @@
       (is (contains-text? out ":inner"))
       (is (contains-text? out "99")))))
 
+(deftest browse-toggle-event-flips-rerender-end-to-end
+  ;; rf2-oswhk regression — pre-fix the triangle's :on-click fired the
+  ;; dispatch fine, but TWO bugs meant the click had no visible effect:
+  ;;
+  ;;   1. every sibling surrogate walked with the same `:path []`, so
+  ;;      writing one slot in the expansion-map toggled *every* triangle
+  ;;      at that fake-empty path simultaneously — net "click → nothing
+  ;;      changes" feel because the operator was actually toggling many
+  ;;      slots and undoing them on the next click,
+  ;;   2. expanded rendering showed `▾{…}<body>` (both the cljs-devtools
+  ;;      header summary AND the body), so even when toggle worked the
+  ;;      visible text barely changed.
+  ;;
+  ;; This test pins the END-TO-END contract: render → extract the
+  ;; surrogate's actual walker-path from its `data-testid` →
+  ;; dispatch-sync the toggle event for THAT path (in the `:rf/xray`
+  ;; frame, matching what the click handler does) → re-render → assert
+  ;; the glyph flipped to ▾ AND the body keys surfaced.
+  (frame/reg-frame :rf/xray {})
+  (rf/with-frame :rf/xray
+    (let [wide        (zipmap (map #(keyword (str "k" %)) (range 20))
+                              (range 20))
+          v           {:outer wide}
+          out-1       (w/browse {:value     v
+                                 :panel-id  :test
+                                 :render-id "tflow"})
+          tris-1      (->> (walk-hiccup out-1)
+                           (filter (fn [n]
+                                     (and (vector? n)
+                                          (= :span (first n))
+                                          (= "button" (-> n second :role))))))
+          tri         (first tris-1)
+          glyph-1     (last tri)
+          ;; Pull the surrogate's actual path back out of the testid so
+          ;; the dispatched event lands on the SAME slot the renderer
+          ;; reads — this is exactly what the on-click does in practice.
+          testid-1    (-> tri second :data-testid)
+          path-suffix (subs testid-1
+                            (count "rf-xray-edn-widget-toggle-test-tflow-"))
+          path-vec    (mapv #(js/parseInt % 10) (str/split path-suffix #"/"))]
+      (testing "pre-toggle: wide nested collapses to ▸"
+        (is (= "▸" glyph-1)))
+      (rf/dispatch-sync [:rf.xray/data-display-toggle-node
+                         :test "tflow" path-vec])
+      ;; Re-render after the toggle.
+      (let [out-2    (w/browse {:value     v
+                                :panel-id  :test
+                                :render-id "tflow"})
+            tris-2   (->> (walk-hiccup out-2)
+                          (filter (fn [n]
+                                    (and (vector? n)
+                                         (= :span (first n))
+                                         (= "button" (-> n second :role))))))
+            glyphs-2 (map last tris-2)
+            txt-2    (let [out (atom "")]
+                       (letfn [(scan [n]
+                                 (cond
+                                   (string? n) (swap! out str n)
+                                   (number? n) (swap! out str n)
+                                   (vector? n) (doseq [c (rest n)] (scan c))
+                                   (seq? n)    (doseq [c n] (scan c))))]
+                         (scan out-2)
+                         @out))]
+        (testing "after toggle the surrogate flips to ▾"
+          (is (some #{"▾"} glyphs-2)
+              (str "expected ▾ after toggle; got " (pr-str glyphs-2))))
+        (testing "the body keys surface (rendering switched from header
+                  `{…}` to the body's `<li>` rows)"
+          (is (re-find #":k0" txt-2))
+          (is (re-find #":k1" txt-2)))
+        (testing "no redundant `{…}` ellipsis next to the body when expanded"
+          (is (not (re-find #"\{…\}" txt-2))
+              (str "expanded render should not carry the cljs-devtools "
+                   "header ellipsis; got " txt-2)))))))
+
 (deftest browse-of-non-collection-routes-through-cljs-devtools
   (let [out (w/browse {:value     :foo/bar
                        :panel-id  :test


### PR DESCRIPTION
## Three regressions from #2134 (rf2-dw8n7)

1. **Click-to-collapse was broken** — every collection rendered fully-expanded by default; clicking ▾ had no effect (text content identical after the click).
2. **cljs-devtools per-token colors lost** — keywords gained an accent + dotted underline but lost their canonical magenta; numbers / strings / nil / booleans all rendered in `--rf-xray-text-primary` (single neutral color).
3. **Commas between key-value pairs disappeared** — rendered as `{:counter ▾{:value 0:last-clicked nil…}}` instead of `{:counter ▾{:value 0, :last-clicked nil, …}}`.

## What #2134's worker did wrong

The bead's diagnosis framed it as "replaced cljs-devtools' renderer rather than wrapped it." The actual finding (verified by hiccup probes against the running build) is more interesting: **the colours were still being preserved through the JSONML walker** — the regression was a different two-bug combo that *looked* like a colour regression:

1. **Sibling surrogates shared the same expansion-map key.** The walker only appended a path segment inside an `"ol"` body, so every `["object" …]` surrogate inside a single map's HEADER walked with `:path []`. The toggle event wrote one slot — `[panel-id render-id []]` — and the next render read that same slot for every sibling triangle. A click toggled the shared slot; the next click toggled it back. Operator's experience: "clicks do nothing."

2. **Expanded rendering emitted header AND body.** With `:max-print-level 1` clamping cljs-devtools to inline only one level (necessary so the walker has surrogate refs to wrap), cljs-devtools' header for a nested collection is the `{…}` ellipsis. The pre-fix render emitted that `{…}` summary AND the body's `<li>` rows beneath the triangle — visually `▾{…}<body>` instead of just `▾<body>`. re-frame-10x's [`data-structure-with-path-annotations`](https://github.com/day8/re-frame-10x/blob/master/src/day8/re_frame_10x/components/cljs_devtools.cljs) renders body OR header — never both.

The `{…}` ellipsis stays in the `text-tertiary` color the collapsed triangle adopts. With it bleeding into every "expanded" rendering, the operator's eye reads "everything's grey" against the keyword-accent visible elsewhere on the panel — which is what looked like a colour-palette regression.

## Fix shape — how cljs-devtools' walker is preserved and only surrogate refs get wrapped

Mirrors re-frame-10x's [`data-structure-with-path-annotations`](https://github.com/day8/re-frame-10x/blob/master/src/day8/re_frame_10x/components/cljs_devtools.cljs) exactly:

- **`jsonml->hiccup`** now appends a positional child-index to `:path` for EVERY descent (known-tag walks, annotation walks, vector-shape walks, JS-array walks unified through one path-tracking loop). Sibling surrogates resolve to distinct expansion-map keys.
- **`render-object-interactive`** renders the cljs-devtools BODY when expanded (the `[:standard-ol [:standard-li …]]` rows with per-row type-aware colour markup intact) and the cljs-devtools HEADER when collapsed (the `{…}` summary). Body or header — never both. cljs-devtools' templated leaf-markup is preserved end-to-end.

## Hiccup-probe verification (before/after)

Same probe shape as the bead's eval-cljs gates, run at the pure-data layer:

**Toggle round-trip** — render → extract surrogate's path from its `data-testid` → dispatch-sync toggle for that path (with `{:frame :rf/xray}`) → re-render:

- BEFORE: all sibling triangles hashed to `data-testid: rf-xray-edn-widget-toggle-p-p-probe-` (empty path suffix). One click toggled the shared slot; ALL triangles flipped together. From there, the next click flipped them all back.
- AFTER: each sibling carries a UNIQUE path suffix (e.g. `…-0/3`, `…-0/7`). A click toggles exactly the clicked surrogate.

**Expanded render** — `{:counter {:value 0 :last 1 :name "x"}}` at `default-depth 4`:

- BEFORE: `{:counter ▾{…}0[:value 0]1[:last 1]2[:name "x"]}` — `{…}` ellipsis bleeds into the expanded view.
- AFTER: `{:counter ▾0[:value 0]1[:last 1]2[:name "x"]}` — no redundant ellipsis; body replaces header under the triangle.

**Per-token palette** — every scalar surfaces with its cljs-devtools colour intact through the body markup:

| token   | colour                  |
|---------|-------------------------|
| keyword | `rgba(136,19,145,1)` (magenta) |
| integer | `rgba(28,0,207,1)` (blue)      |
| string  | `rgba(196,26,22,1)` (red)      |
| nil     | `rgba(128,128,128,1)` (gray)   |
| boolean | `rgba(0,153,153,1)` (teal)     |

**Commas** — `{:a 1 :b 2 :c 3}` rendered inline contains `:a 1, :b 2, :c 3` — comma+space separators survive (they come from cljs-devtools' canonical header markup, which the walker now preserves wholesale).

## Spec coverage

`tools/xray/spec/021-Dynamic-Panel-Designs.md` §10.0a — new acceptance contract pinning the three properties so a future renderer change can't re-break them:

1. Per-token cljs-devtools palette preserved end-to-end.
2. Click actually toggles (per-sibling paths unique).
3. Expanded renders body, not header + body.

## Cross-refs

- #2134 (rf2-dw8n7) — regressed commit (its PR body cites the re-frame-10x walker as the reference; this PR pins the same reference).
- [re-frame-10x `cljs_devtools.cljs`](https://github.com/day8/re-frame-10x/blob/master/src/day8/re_frame_10x/components/cljs_devtools.cljs) — canonical `data-structure-with-path-annotations` (body OR header, never both; per-child path index).

## Tests

Pure-data regression guards in `tools/xray/test/day8/re_frame2_xray/views/edn_widget/cljs_devtools_render_cljs_test.cljs`:

- `scalar-tokens-keep-cljs-devtools-palette` — each scalar type asserts the exact cljs-devtools colour string.
- `sibling-surrogates-resolve-to-distinct-paths` — two wide nested siblings carry distinct `data-testid` paths.
- `expansion-map-override-flips-collapsed-to-expanded` — round-trips the surrogate path through the expansion-map; the same surrogate flips from ▸ to ▾.
- `expanded-render-shows-body-not-header` — no `{…}` ellipsis next to the body when expanded.
- `collapsed-render-shows-header-not-body` — body keys do not leak when collapsed.
- `collapsed-inline-header-keeps-cljs-devtools-commas` — `, :b` and `, :c` survive in the inline header for a small map.

End-to-end toggle-flow test in `tools/xray/test/day8/re_frame2_xray/views/edn_widget/widget_cljs_test.cljs`:

- `browse-toggle-event-flips-rerender-end-to-end` — render → extract surrogate's path from its `data-testid` → `dispatch-sync` the toggle for that path (in `:rf/xray` frame) → re-render → assert the glyph flipped + body keys surfaced + no `{…}` ellipsis bleeds through.

## Gates

- `clj-kondo --lint tools/xray/src tools/xray/test` — 0 errors.
- `npm run test:cljs` — 4492 tests / 14292 assertions / 0 failures.
- `npm run test:browser` — 124 tests / 346 assertions / 0 failures.
- `npm run test:xray-feature-gate` — 13 scenarios / 0 failures.
- `npm run test:bundle-isolation` — PASS.