### PR TITLE
feat(scripts): mayor pre-commit hook refuses commits to worker-tracked surfaces (rf2-ydl2p)

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -104,6 +104,23 @@ or gitignored), interrupt the worker, preserve the edits into the worker
 worktree, then restore the mayor checkout — only specific known files; never
 broad destructive resets.
 
+**Mayor-side commit guard (rf2-ydl2p).** A pre-commit hook installed in
+the mayor's `.git/hooks/pre-commit` refuses commits that touch
+worker-tracked surfaces (anything outside the small allow-list:
+`.beads/issues.jsonl` + root `MEMORY.md`). The hook is gated by a
+sentinel file at `<git-common-dir>/mayor-marker` so it activates ONLY
+in the mayor checkout — worker worktrees see a no-op because their
+per-worktree git dir has no marker. Install with
+`sh scripts/install-git-hooks.sh` or
+`pwsh -ExecutionPolicy Bypass -File scripts/install-git-hooks.ps1`. See
+[`scripts/git-hooks/README.md`](../../scripts/git-hooks/README.md) for
+the marker pattern, permitted/refused surfaces, and the
+`--no-verify`/disable escape hatches. This is a commit-time
+complement to the edit-time guard at
+`scripts/assert-worker-worktree.ps1` — if a worker's edit guard is
+bypassed (e.g. PowerShell cwd leak), the commit guard catches the
+attempt from the other side.
+
 **TODO (leak-mitigation escalation).** If this strengthened reminder proves
 insufficient and the leak continues to happen, escalate to one of:
 

--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -113,7 +113,7 @@ in the mayor checkout — worker worktrees see a no-op because their
 per-worktree git dir has no marker. Install with
 `sh scripts/install-git-hooks.sh` or
 `pwsh -ExecutionPolicy Bypass -File scripts/install-git-hooks.ps1`. See
-[`scripts/git-hooks/README.md`](../../scripts/git-hooks/README.md) for
+[`scripts/git-hooks/README.md`](https://github.com/day8/re-frame2/blob/main/scripts/git-hooks/README.md) for
 the marker pattern, permitted/refused surfaces, and the
 `--no-verify`/disable escape hatches. This is a commit-time
 complement to the edit-time guard at

--- a/scripts/git-hooks/README.md
+++ b/scripts/git-hooks/README.md
@@ -1,0 +1,134 @@
+# scripts/git-hooks/
+
+Source of truth for the re-frame2-managed git hooks plus their library
+helpers and tests. The installer (`scripts/install-git-hooks.sh` /
+`.ps1`) stages the marker-bracketed blocks below into the repo's hooks
+directory (`<git-common-dir>/hooks/`) — idempotently and without
+disturbing beads-managed segments (`bd hooks install`).
+
+## Contents
+
+| Path | Purpose |
+|------|---------|
+| `post-merge` | Advisory: warn after `git pull` brings down MCP-source changes that invalidate the local server binary. **rf2-6jj3r.** |
+| `pre-commit` | Refuse commits in the MAYOR checkout that touch worker-tracked surfaces. **rf2-ydl2p.** |
+| `lib/check-stale-mcp-binary.sh` | POSIX-sh library used by `post-merge`. |
+| `lib/check-mayor-commit-boundary.sh` | POSIX-sh library used by `pre-commit`. |
+| `test-pre-commit.sh` | Library unit tests + sandboxed end-to-end smoke for the pre-commit hook. |
+
+## The mayor-marker pattern (pre-commit hook)
+
+The `pre-commit` hook is **mayor-only**. It MUST be a no-op in worker
+worktrees. Activation is gated by a marker file at
+`<git-common-dir>/mayor-marker`:
+
+- **Mayor checkout** — `git rev-parse --git-dir` returns the common dir
+  (e.g. `C:/Users/miket/code/re-frame2/.git`). The marker lives there,
+  so the hook activates and runs the commit-boundary check.
+
+- **Worker worktrees** — `git rev-parse --git-dir` returns a
+  per-worktree git dir at `<common>/worktrees/<name>/`. No marker file
+  is present there, so the hook short-circuits to a no-op.
+
+This is the canonical way to distinguish "primary worktree" from
+"linked worktrees" without hardcoding paths. Worker hooks share the
+common hooks directory via `git worktree add`'s defaults, but each
+worker has its own per-worktree git dir — exactly what we need.
+
+### Why a marker file and not a hardcoded path?
+
+The bead (rf2-ydl2p) considered two options:
+
+- **A.** Hardcode the mayor path `C:\Users\miket\code\re-frame2`.
+  Simple; fragile if Mike clones elsewhere; OS-coupled.
+- **B.** Mark the mayor checkout with a sentinel file (this design).
+  Portable, self-documenting, easy to disable (just delete the file).
+
+We picked **B**.
+
+### Permitted vs refused surfaces
+
+The hook uses an **allow-list**: any staged path not in the permitted
+list is refused.
+
+**Permitted in mayor commits:**
+
+| Path | Reason |
+|------|--------|
+| `.beads/issues.jsonl` | bd closure / state edits |
+| `MEMORY.md` | optional operator-memory file at repo root (if present) |
+
+**Refused in mayor commits** (anything else, including):
+
+- `implementation/` — framework + adapter src/test
+- `tools/` — devtools (xray, story, machines-viz, re-frame2-pair-mcp, ...)
+- `spec/` — spec tree
+- `docs/` — guide + operational docs
+- `examples/`
+- `skills/`
+- `scripts/` — the scripts themselves (workers commit changes to scripts via worktrees too)
+- `migration/`
+- `testbeds/`, `README.md`, top-level files — any path NOT in the
+  permitted allow-list
+
+`.gitignore`'d paths cannot normally reach the staged diff (git
+excludes them before `git add` even sees them). A `git add --force`
+bypass would still be caught here because gitignore membership is not
+part of the allow-list — that is deliberate.
+
+### Disabling the hook
+
+If you need to disable the hook temporarily (e.g. to investigate a
+false positive), delete the marker:
+
+```sh
+rm "$(git rev-parse --git-common-dir)/mayor-marker"
+```
+
+The hook then no-ops and the mayor checkout behaves like a worker
+worktree from the hook's POV. Re-running the installer reinstates the
+marker.
+
+For a single commit, `git commit --no-verify` also bypasses the hook
+(standard git behaviour; reserved for genuine operator overrides).
+
+## Testing
+
+```sh
+# Library unit tests + sandboxed end-to-end smoke.
+sh scripts/git-hooks/test-pre-commit.sh
+```
+
+The smoke test builds a throwaway repo + worktree pair under
+`$TMPDIR`, installs the hook + marker manually, and exercises all four
+acceptance scenarios from rf2-ydl2p:
+
+1. Mayor commit with only `.beads/issues.jsonl` staged → passes
+2. Mayor commit with `tools/xray/foo.cljs` staged → refused
+3. Worker worktree commit with source staged → passes (hook no-op)
+4. Mayor commit with mixed staged paths → refused (any-refused triggers)
+
+## Discovery context
+
+The pre-commit hook landed in response to rf2-oswhk (#2136),
+2026-05-25: a worker tool call committed to the mayor checkout's local
+main because of a PowerShell cwd leak — `cwd` defaulted to the project
+implementation directory rather than tracking a prior `cd`. The worker
+noticed, recovered, and re-committed via Bash in the worker worktree.
+The bogus commit carried only a bd `--claim` flip — no source damage —
+but it COULD have carried real worker-tracked source diffs.
+
+The existing `scripts/assert-worker-worktree.ps1` catches **edit**
+attempts (workers gate edits on `WORKTREE_ROOT`). It does NOT catch
+**commit** attempts. The pre-commit hook closes that gap from the
+other side: even if a worker bypasses the edit guard via some side
+channel, the mayor's pre-commit will refuse the commit.
+
+## Cross-refs
+
+- **rf2-6jj3r (#2113)** — post-merge stale-binary hook + installer
+  pattern this hook extends.
+- **rf2-oswhk (#2136)** — near-mishap that surfaced the gap.
+- **`scripts/assert-worker-worktree.ps1`** — the edit-time complement.
+- **`docs/the-mayor-method/`** — the worker dispatch contract this hook
+  enforces.

--- a/scripts/git-hooks/lib/check-mayor-commit-boundary.sh
+++ b/scripts/git-hooks/lib/check-mayor-commit-boundary.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env sh
+# scripts/git-hooks/lib/check-mayor-commit-boundary.sh
+#
+# Library for the mayor pre-commit hook (rf2-ydl2p). Inspects a list of
+# staged paths (newline-separated on stdin) and prints a refusal block to
+# stderr if any of them sit outside the small allow-list of "mayor may
+# commit" surfaces. Exit code:
+#
+#   0  no refused paths (commit may proceed)
+#   1  one or more refused paths (commit must be aborted)
+#
+# This file is intentionally a pure shell library (no `set -e`, no global
+# state mutations) so the test runner in
+# `scripts/git-hooks/test-pre-commit.sh` can invoke it with synthetic
+# stdin streams and assert against stdout / stderr / exit.
+#
+# Cross-platform: POSIX sh; runs under Git Bash on Windows, macOS, Linux.
+# No bashisms (`[[`, arrays, `<<<`). Tested under `sh`, `bash`, `dash`.
+#
+# Discovery context: rf2-oswhk (#2136), worker acb252dc, 2026-05-25 — an
+# initial commit attempt via PowerShell landed on the mayor checkout's
+# local main because PowerShell `cwd` defaulted to the implementation
+# directory rather than tracking a prior `cd`. Worker noticed + recovered,
+# but the bogus commit could have carried real source diffs.
+#
+# Edit-time guard: scripts/assert-worker-worktree.ps1 (existing).
+# Commit-time guard: this library + scripts/git-hooks/pre-commit (rf2-ydl2p).
+
+# ----------------------------------------------------------------------------
+# Permitted surfaces in mayor commits.
+#
+# The contract is allow-list, not deny-list: any staged path not matched
+# below is refused.
+#
+#   - .beads/issues.jsonl                — bd closure / state edits
+#   - MEMORY.md (root)                   — optional operator-memory file
+#
+# Gitignored paths cannot normally reach the staged diff at all (git
+# excludes them before `git add` even sees them); a `git add --force`
+# bypass would still be caught here because gitignore membership is not
+# part of this allow-list. That is deliberate — if Mike force-adds
+# something gitignored from the mayor, it is almost certainly a mistake.
+# ----------------------------------------------------------------------------
+
+# is_permitted_mayor_path PATH
+#
+# Returns 0 (permitted) if PATH is one of the small allow-list of paths
+# the mayor checkout may commit. Returns 1 (refused) otherwise.
+#
+# Paths are matched verbatim against the strings git emits from
+# `git diff --cached --name-only` (forward slashes, repo-relative, no
+# leading `./`).
+is_permitted_mayor_path() {
+  case "$1" in
+    .beads/issues.jsonl) return 0 ;;
+    MEMORY.md)           return 0 ;;
+    *)                   return 1 ;;
+  esac
+}
+
+# check_mayor_commit_boundary
+#
+# Reads newline-separated staged paths from stdin. Prints a refusal block
+# to stderr listing the refused paths if any are not in the allow-list.
+# Returns 1 if any refused paths were seen, 0 otherwise.
+check_mayor_commit_boundary() {
+  staged_paths=$(cat)
+  if [ -z "$staged_paths" ]; then
+    # Empty commit (e.g. `git commit --allow-empty`). Nothing to refuse.
+    return 0
+  fi
+
+  # Collect refused paths into a tmpfile so we can count and re-emit them
+  # in the error block. Using a file (not a variable) keeps POSIX-sh
+  # subshell semantics from eating our state in the read loop.
+  refused_file=$(mktemp "${TMPDIR:-/tmp}/rf2-precommit-XXXXXX")
+  # Best-effort cleanup; ignore failures (e.g. if mktemp returned a path
+  # we somehow can't unlink).
+  trap 'rm -f "$refused_file"' EXIT INT TERM HUP
+
+  printf '%s\n' "$staged_paths" | while IFS= read -r p; do
+    [ -z "$p" ] && continue
+    if ! is_permitted_mayor_path "$p"; then
+      printf '%s\n' "$p" >> "$refused_file"
+    fi
+  done
+
+  if [ ! -s "$refused_file" ]; then
+    rm -f "$refused_file"
+    trap - EXIT INT TERM HUP
+    return 0
+  fi
+
+  # At least one refused path. Emit the error block.
+  printf '\n' >&2
+  printf 'ERROR: mayor checkout cannot commit to worker-tracked surfaces.\n' >&2
+  printf '\n' >&2
+  printf '  Staged files in refused zones:\n' >&2
+  while IFS= read -r p; do
+    [ -n "$p" ] && printf '    %s\n' "$p" >&2
+  done < "$refused_file"
+  printf '\n' >&2
+  printf '  Permitted in mayor commits:\n' >&2
+  printf '    .beads/issues.jsonl  (bd closures)\n' >&2
+  printf '    MEMORY.md            (operator-memory file, if present)\n' >&2
+  printf '\n' >&2
+  printf '  Any source / spec / test / doc / script change must originate\n' >&2
+  printf '  from a worker worktree under\n' >&2
+  printf '  C:\\Users\\miket\\code\\re-frame2-worktrees\\<descriptive>-<BEAD_ID>.\n' >&2
+  printf '\n' >&2
+  printf '  See docs/the-mayor-method/ for the worker dispatch contract.\n' >&2
+  printf '\n' >&2
+
+  rm -f "$refused_file"
+  trap - EXIT INT TERM HUP
+  return 1
+}

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -1,0 +1,69 @@
+#!/usr/bin/env sh
+# .git/hooks/pre-commit (re-frame2-managed segment)
+#
+# Refuses commits in the MAYOR checkout that touch worker-tracked surfaces
+# (rf2-ydl2p). Mayor commits are allowed only for `.beads/issues.jsonl` and
+# the optional root `MEMORY.md`; any source/spec/test/doc/script change
+# must originate from a worker worktree under
+# `C:\Users\miket\code\re-frame2-worktrees\`.
+#
+# Activation is gated by a marker file (default `.git/mayor-marker`) that
+# the installer drops into the mayor checkout's git common dir at install
+# time. Worker worktrees share the same hooks directory (git's default
+# for `git worktree add`) but do NOT share their per-worktree `.git/`
+# directory — so the marker is only visible from the mayor's git dir, and
+# this hook becomes a no-op everywhere else.
+#
+# Installed by scripts/install-git-hooks.sh (POSIX) or .ps1 (Windows).
+# Source of truth: scripts/git-hooks/pre-commit.
+#
+# Discovery context: rf2-oswhk (#2136) near-mishap, 2026-05-25 — a worker
+# tool call landed a commit on the mayor checkout's local main because of
+# a PowerShell cwd leak. This commit-time guard complements the edit-time
+# guard at scripts/assert-worker-worktree.ps1.
+#
+# Cross-platform: runs under Git Bash on Windows, macOS, Linux. POSIX sh.
+
+# --- BEGIN re-frame2 mayor commit boundary (rf2-ydl2p) ---
+# Managed by scripts/install-git-hooks.sh. Do not edit between markers.
+{
+  # Locate the per-worktree git dir (NOT the shared common dir). Git
+  # invokes hooks with the worktree-specific GIT_DIR set; we re-derive it
+  # defensively in case a wrapper changed the environment.
+  _rf2_git_dir=$(git rev-parse --git-dir 2>/dev/null) || _rf2_git_dir=""
+  _rf2_marker=""
+  if [ -n "$_rf2_git_dir" ]; then
+    # `--git-dir` may be relative (e.g. ".git") when invoked from the
+    # worktree root; resolve to absolute against the toplevel so the
+    # marker check is unambiguous.
+    case "$_rf2_git_dir" in
+      /*|[A-Za-z]:[\\/]*) _rf2_marker="$_rf2_git_dir/mayor-marker" ;;
+      *)
+        _rf2_top=$(git rev-parse --show-toplevel 2>/dev/null) || _rf2_top=""
+        if [ -n "$_rf2_top" ]; then
+          _rf2_marker="$_rf2_top/$_rf2_git_dir/mayor-marker"
+        fi
+        ;;
+    esac
+  fi
+
+  if [ -n "$_rf2_marker" ] && [ -f "$_rf2_marker" ]; then
+    # We are in the mayor checkout. Run the commit-boundary check.
+    _rf2_repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || _rf2_repo_root=""
+    if [ -n "$_rf2_repo_root" ]; then
+      _rf2_lib="$_rf2_repo_root/scripts/git-hooks/lib/check-mayor-commit-boundary.sh"
+      if [ -f "$_rf2_lib" ]; then
+        # shellcheck source=lib/check-mayor-commit-boundary.sh
+        . "$_rf2_lib"
+        _rf2_staged=$(git diff --cached --name-only 2>/dev/null)
+        if ! printf '%s\n' "$_rf2_staged" | check_mayor_commit_boundary; then
+          unset _rf2_git_dir _rf2_marker _rf2_top _rf2_repo_root _rf2_lib _rf2_staged
+          exit 1
+        fi
+      fi
+    fi
+  fi
+
+  unset _rf2_git_dir _rf2_marker _rf2_top _rf2_repo_root _rf2_lib _rf2_staged
+} || true
+# --- END re-frame2 mayor commit boundary (rf2-ydl2p) ---

--- a/scripts/git-hooks/test-pre-commit.sh
+++ b/scripts/git-hooks/test-pre-commit.sh
@@ -1,0 +1,313 @@
+#!/usr/bin/env sh
+# scripts/git-hooks/test-pre-commit.sh
+#
+# Smoke + library tests for the mayor pre-commit hook (rf2-ydl2p).
+#
+# Two layers:
+#
+#   1. Library unit tests — invoke
+#      scripts/git-hooks/lib/check-mayor-commit-boundary.sh directly with
+#      synthetic stdin streams and assert against stdout / stderr / exit.
+#
+#   2. End-to-end smoke — build a throwaway git repo + worktree pair in
+#      $TMPDIR, install the hook + marker as the installer would, and
+#      drive `git commit` on each side to verify the four acceptance
+#      scenarios from rf2-ydl2p:
+#
+#        (a) mayor commit with only .beads/issues.jsonl staged -> passes
+#        (b) mayor commit with tools/xray/foo.cljs staged       -> refused
+#        (c) worker worktree commit with source staged          -> passes
+#        (d) mayor commit with mixed staged paths               -> refused
+#
+# Usage:
+#   sh scripts/git-hooks/test-pre-commit.sh
+#
+# Exit code: 0 if all scenarios pass, 1 otherwise.
+
+set -eu
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+# $0 lives at scripts/git-hooks/test-pre-commit.sh; repo root is two up.
+REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+LIB="$REPO_ROOT/scripts/git-hooks/lib/check-mayor-commit-boundary.sh"
+HOOK="$REPO_ROOT/scripts/git-hooks/pre-commit"
+
+fail_count=0
+pass_count=0
+
+pass() {
+  pass_count=$((pass_count + 1))
+  printf '  PASS  %s\n' "$1"
+}
+
+fail() {
+  fail_count=$((fail_count + 1))
+  printf '  FAIL  %s\n' "$1" >&2
+}
+
+# ----------------------------------------------------------------------------
+# Layer 1: library unit tests.
+# ----------------------------------------------------------------------------
+
+printf '\n[1] check-mayor-commit-boundary.sh library tests\n'
+
+# Source the lib in a subshell wrapper so the trap inside does not affect us.
+run_lib() {
+  # stdin: newline-separated paths
+  # stdout: lib stdout (should be empty)
+  # stderr: lib stderr (the refusal block on refused)
+  # echoes the exit code on stdout's last line for easy capture.
+  (
+    . "$LIB"
+    check_mayor_commit_boundary
+    echo "EXIT=$?"
+  )
+}
+
+# Test 1a: empty stdin -> exit 0, no stderr.
+out=$(printf '' | run_lib 2>/tmp/rf2-precommit-test.err) || true
+case "$out" in
+  *EXIT=0*)
+    if [ ! -s /tmp/rf2-precommit-test.err ]; then
+      pass "empty staged list -> exit 0, no stderr"
+    else
+      fail "empty staged list -> stderr non-empty"
+      cat /tmp/rf2-precommit-test.err >&2
+    fi
+    ;;
+  *) fail "empty staged list -> wrong exit: $out" ;;
+esac
+
+# Test 1b: only .beads/issues.jsonl -> exit 0.
+out=$(printf '.beads/issues.jsonl\n' | run_lib 2>/tmp/rf2-precommit-test.err) || true
+case "$out" in
+  *EXIT=0*) pass "only .beads/issues.jsonl staged -> exit 0" ;;
+  *) fail ".beads/issues.jsonl staged -> wrong exit: $out"
+     cat /tmp/rf2-precommit-test.err >&2
+     ;;
+esac
+
+# Test 1c: only MEMORY.md -> exit 0.
+out=$(printf 'MEMORY.md\n' | run_lib 2>/tmp/rf2-precommit-test.err) || true
+case "$out" in
+  *EXIT=0*) pass "only MEMORY.md staged -> exit 0" ;;
+  *) fail "MEMORY.md staged -> wrong exit: $out" ;;
+esac
+
+# Test 1d: tools/xray/foo.cljs -> exit 1 + error block on stderr.
+out=$(printf 'tools/xray/foo.cljs\n' | run_lib 2>/tmp/rf2-precommit-test.err) || true
+case "$out" in
+  *EXIT=1*)
+    if grep -q 'mayor checkout cannot commit' /tmp/rf2-precommit-test.err \
+       && grep -q 'tools/xray/foo.cljs' /tmp/rf2-precommit-test.err; then
+      pass "tools/xray/foo.cljs -> refused with error block"
+    else
+      fail "tools/xray/foo.cljs -> exited 1 but stderr missing expected text"
+      cat /tmp/rf2-precommit-test.err >&2
+    fi
+    ;;
+  *) fail "tools/xray/foo.cljs -> wrong exit: $out" ;;
+esac
+
+# Test 1e: mixed permitted + refused -> exit 1 (any-refused triggers).
+# The refused listing should contain tools/xray/foo.cljs but NOT
+# .beads/issues.jsonl. (.beads appears once more in the "Permitted in
+# mayor commits" footer, which is expected — we test the refused-listing
+# section by extracting the lines between "Staged files in refused
+# zones:" and the blank-line-then-"Permitted" separator.)
+out=$(printf '.beads/issues.jsonl\ntools/xray/foo.cljs\n' | run_lib 2>/tmp/rf2-precommit-test.err) || true
+case "$out" in
+  *EXIT=1*)
+    refused_listing=$(awk '
+      /Staged files in refused zones:/ {flag=1; next}
+      /Permitted in mayor commits:/    {flag=0}
+      flag {print}
+    ' /tmp/rf2-precommit-test.err)
+    if printf '%s' "$refused_listing" | grep -q 'tools/xray/foo.cljs' \
+       && ! printf '%s' "$refused_listing" | grep -q '\.beads/issues\.jsonl'; then
+      pass "mixed staged -> refused listing contains only the refused path"
+    else
+      fail "mixed staged -> refused, but listing wrong"
+      printf '----- refused listing -----\n%s\n----- end -----\n' \
+        "$refused_listing" >&2
+    fi
+    ;;
+  *) fail "mixed staged -> wrong exit: $out" ;;
+esac
+
+# Test 1f: many surface examples all refused.
+cases='implementation/core/src/re_frame/core.cljc
+tools/xray/src/foo.cljs
+spec/009-Instrumentation.md
+docs/guide/index.md
+examples/reagent/counter/main.cljs
+skills/re-frame2-pair/SKILL.md
+scripts/install-git-hooks.sh
+migration/from-re-frame-v1/README.md
+testbeds/parallel-frames/spec.cjs
+README.md'
+out=$(printf '%s\n' "$cases" | run_lib 2>/tmp/rf2-precommit-test.err) || true
+case "$out" in
+  *EXIT=1*)
+    refused_all=1
+    for p in implementation/core/src/re_frame/core.cljc \
+             tools/xray/src/foo.cljs \
+             spec/009-Instrumentation.md \
+             docs/guide/index.md \
+             examples/reagent/counter/main.cljs \
+             skills/re-frame2-pair/SKILL.md \
+             scripts/install-git-hooks.sh \
+             migration/from-re-frame-v1/README.md \
+             testbeds/parallel-frames/spec.cjs \
+             README.md; do
+      if ! grep -q "$p" /tmp/rf2-precommit-test.err; then
+        refused_all=0
+        fail "expected refused path absent from stderr: $p"
+      fi
+    done
+    if [ "$refused_all" = "1" ]; then
+      pass "all worker-tracked surface samples refused"
+    fi
+    ;;
+  *) fail "broad refused set -> wrong exit: $out" ;;
+esac
+
+rm -f /tmp/rf2-precommit-test.err
+
+# ----------------------------------------------------------------------------
+# Layer 2: end-to-end smoke via throwaway repo + worktree.
+# ----------------------------------------------------------------------------
+
+printf '\n[2] end-to-end smoke (mayor + worker worktree)\n'
+
+# Build the sandbox in $TMPDIR; clean on exit.
+SANDBOX=$(mktemp -d "${TMPDIR:-/tmp}/rf2-precommit-sandbox-XXXXXX")
+trap 'rm -rf "$SANDBOX"' EXIT INT TERM HUP
+
+MAYOR="$SANDBOX/mayor"
+WORKER="$SANDBOX/worker"
+
+(
+  mkdir -p "$MAYOR"
+  cd "$MAYOR"
+  git init -q -b main
+  git config user.email 'precommit-test@example.invalid'
+  git config user.name 'precommit-test'
+  git config commit.gpgsign false
+  # Seed commit so we can create a worktree.
+  mkdir -p .beads
+  printf '{"id":"seed","title":"seed"}\n' > .beads/issues.jsonl
+  git add .beads/issues.jsonl
+  git commit -q -m 'seed'
+  # Add a worker worktree.
+  git worktree add -q -b worker/test "$WORKER"
+) >/dev/null
+
+# Install the hook + lib + marker into the mayor's common dir hooks dir.
+# We mimic the installer minimally — just copy the canonical files into
+# place and drop the marker. That keeps the smoke test focused on hook
+# behaviour rather than re-testing the installer.
+COMMON_DIR=$(git -C "$MAYOR" rev-parse --git-common-dir)
+case "$COMMON_DIR" in /*|[A-Za-z]:[\\/]*) ;; *) COMMON_DIR="$MAYOR/$COMMON_DIR" ;; esac
+HOOKS_DIR="$COMMON_DIR/hooks"
+mkdir -p "$HOOKS_DIR"
+# The hook expects the lib at <repo-root>/scripts/git-hooks/lib/...; in
+# this sandbox the "repo root" is $MAYOR, so we ship the lib there too.
+mkdir -p "$MAYOR/scripts/git-hooks/lib"
+cp "$LIB" "$MAYOR/scripts/git-hooks/lib/"
+cp "$HOOK" "$HOOKS_DIR/pre-commit"
+chmod +x "$HOOKS_DIR/pre-commit"
+printf 'sandbox marker\n' > "$COMMON_DIR/mayor-marker"
+
+# Run a scenario inside a subshell; capture exit status via temp file so
+# `set -e` in the parent doesn't abort on a non-zero subshell exit.
+run_scenario() {
+  rc_file="$1"
+  shift
+  : > /tmp/rf2-pc-smoke.err
+  ( "$@" 2>/tmp/rf2-pc-smoke.err ) && echo 0 > "$rc_file" || echo $? > "$rc_file"
+}
+
+# Scenario (a): mayor commit with only .beads/issues.jsonl -> passes.
+scenario_a() {
+  cd "$MAYOR"
+  printf '{"id":"a","title":"a"}\n' > .beads/issues.jsonl
+  git add .beads/issues.jsonl
+  git commit -q -m 'mayor: bd closure (a)'
+}
+rc_a=$(mktemp); run_scenario "$rc_a" scenario_a
+if [ "$(cat "$rc_a")" = "0" ]; then
+  pass "(a) mayor commit: .beads/issues.jsonl only -> passed"
+else
+  fail "(a) mayor commit with permitted path was refused (exit $(cat "$rc_a"))"
+  cat /tmp/rf2-pc-smoke.err >&2 || true
+fi
+rm -f "$rc_a"
+
+# Scenario (b): mayor commit touching tools/xray/foo.cljs -> refused.
+scenario_b() {
+  cd "$MAYOR"
+  mkdir -p tools/xray
+  echo '(ns foo)' > tools/xray/foo.cljs
+  git add tools/xray/foo.cljs
+  git commit -q -m 'mayor: refused'
+}
+rc_b=$(mktemp); run_scenario "$rc_b" scenario_b
+if [ "$(cat "$rc_b")" != "0" ] && grep -q 'mayor checkout cannot commit' /tmp/rf2-pc-smoke.err; then
+  pass "(b) mayor commit: tools/xray/foo.cljs -> refused (exit $(cat "$rc_b"))"
+  # Reset stage so subsequent tests aren't polluted.
+  ( cd "$MAYOR" && git reset -q HEAD && rm -rf tools ) || true
+else
+  fail "(b) refused-zone mayor commit was NOT blocked (exit $(cat "$rc_b"))"
+  cat /tmp/rf2-pc-smoke.err >&2 || true
+fi
+rm -f "$rc_b"
+
+# Scenario (c): worker worktree commit with source staged -> passes
+# (hook is no-op there because no mayor-marker in the worker's git-dir).
+scenario_c() {
+  cd "$WORKER"
+  mkdir -p tools/xray
+  echo '(ns bar)' > tools/xray/bar.cljs
+  git add tools/xray/bar.cljs
+  git commit -q -m 'worker: source change'
+}
+rc_c=$(mktemp); run_scenario "$rc_c" scenario_c
+if [ "$(cat "$rc_c")" = "0" ]; then
+  pass "(c) worker commit: tools/xray/bar.cljs -> passed (hook no-op)"
+else
+  fail "(c) worker commit was refused (hook should no-op without marker) (exit $(cat "$rc_c"))"
+  cat /tmp/rf2-pc-smoke.err >&2 || true
+fi
+rm -f "$rc_c"
+
+# Scenario (d): mayor commit with mixed (.beads/issues.jsonl + refused) -> refused.
+scenario_d() {
+  cd "$MAYOR"
+  mkdir -p tools/xray
+  echo '(ns mix)' > tools/xray/mix.cljs
+  printf '{"id":"d","title":"d"}\n' > .beads/issues.jsonl
+  git add .beads/issues.jsonl tools/xray/mix.cljs
+  git commit -q -m 'mayor: mixed'
+}
+rc_d=$(mktemp); run_scenario "$rc_d" scenario_d
+if [ "$(cat "$rc_d")" != "0" ] && grep -q 'tools/xray/mix.cljs' /tmp/rf2-pc-smoke.err; then
+  pass "(d) mayor mixed commit -> refused (any-refused triggers) (exit $(cat "$rc_d"))"
+  ( cd "$MAYOR" && git reset -q HEAD && rm -rf tools ) || true
+else
+  fail "(d) mixed-zone mayor commit was NOT blocked (exit $(cat "$rc_d"))"
+  cat /tmp/rf2-pc-smoke.err >&2 || true
+fi
+rm -f "$rc_d"
+
+rm -f /tmp/rf2-pc-smoke.err
+
+# ----------------------------------------------------------------------------
+# Summary
+# ----------------------------------------------------------------------------
+
+printf '\nSummary: %d passed, %d failed\n' "$pass_count" "$fail_count"
+if [ "$fail_count" -ne 0 ]; then
+  exit 1
+fi
+exit 0

--- a/scripts/install-git-hooks.ps1
+++ b/scripts/install-git-hooks.ps1
@@ -1,11 +1,21 @@
 #requires -Version 5
 # scripts/install-git-hooks.ps1 — Windows-friendly mirror of
-# scripts/install-git-hooks.sh (rf2-6jj3r).
+# scripts/install-git-hooks.sh.
 #
 # Same behaviour: idempotent install of the re-frame2-managed segments
-# of the repo's git hooks. The hook scripts themselves are POSIX sh
+# of the repo's git hooks, plus the mayor-marker file that gates the
+# pre-commit hook (rf2-ydl2p). The hook scripts themselves are POSIX sh
 # (Git on Windows ships a `sh.exe` from the Git Bash bundle that runs
 # hooks); this installer just stages them into <gitdir>/hooks.
+#
+# Installs:
+#   - post-merge       (rf2-6jj3r) MCP-staleness advisory warning.
+#   - pre-commit       (rf2-ydl2p) refuses commits in the MAYOR checkout
+#                       that touch worker-tracked surfaces.
+#   - mayor-marker     (rf2-ydl2p) sentinel at <common-dir>/mayor-marker;
+#                       hook activation gate. Worker worktrees have a
+#                       distinct per-worktree git dir, so they never see
+#                       this marker and the pre-commit hook no-ops there.
 #
 # Usage:
 #   powershell -ExecutionPolicy Bypass -File scripts/install-git-hooks.ps1
@@ -21,31 +31,52 @@ $ErrorActionPreference = 'Stop'
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $repoRoot  = (Resolve-Path (Join-Path $scriptDir '..')).Path
 $srcDir    = Join-Path $scriptDir 'git-hooks'
-$hooksDir  = (& git -C $repoRoot rev-parse --git-common-dir).Trim()
-if (-not [System.IO.Path]::IsPathRooted($hooksDir)) {
-    $hooksDir = Join-Path $repoRoot $hooksDir
+$commonDir = (& git -C $repoRoot rev-parse --git-common-dir).Trim()
+if (-not [System.IO.Path]::IsPathRooted($commonDir)) {
+    $commonDir = Join-Path $repoRoot $commonDir
 }
-$hooksDir = Join-Path $hooksDir 'hooks'
+$hooksDir = Join-Path $commonDir 'hooks'
 New-Item -ItemType Directory -Force -Path $hooksDir | Out-Null
 
-$beginMark = '# --- BEGIN re-frame2 MCP-staleness check (rf2-6jj3r) ---'
-$endMark   = '# --- END re-frame2 MCP-staleness check (rf2-6jj3r) ---'
+# Per-hook marker pairs. Keys are hook names; values are @(BEGIN, END).
+$hookMarkers = @{
+    'post-merge' = @(
+        '# --- BEGIN re-frame2 MCP-staleness check (rf2-6jj3r) ---',
+        '# --- END re-frame2 MCP-staleness check (rf2-6jj3r) ---'
+    )
+    'pre-commit' = @(
+        '# --- BEGIN re-frame2 mayor commit boundary (rf2-ydl2p) ---',
+        '# --- END re-frame2 mayor commit boundary (rf2-ydl2p) ---'
+    )
+}
 
 function Get-MarkerBlock {
-    param([string]$Path)
+    param(
+        [string]$Path,
+        [string]$BeginMark,
+        [string]$EndMark
+    )
     $lines = Get-Content -LiteralPath $Path
     $out = New-Object System.Collections.Generic.List[string]
     $inBlock = $false
     foreach ($line in $lines) {
-        if ($line -eq $beginMark) { $inBlock = $true }
+        if ($line -eq $BeginMark) { $inBlock = $true }
         if ($inBlock) { $out.Add($line) }
-        if ($line -eq $endMark) { $inBlock = $false }
+        if ($line -eq $EndMark) { $inBlock = $false }
     }
     return ($out -join "`n")
 }
 
 function Install-Hook {
     param([string]$HookName)
+
+    $marks     = $hookMarkers[$HookName]
+    if (-not $marks) {
+        Write-Error "install-git-hooks: unknown hook name: $HookName"
+    }
+    $beginMark = $marks[0]
+    $endMark   = $marks[1]
+
     $src = Join-Path $srcDir $HookName
     $dst = Join-Path $hooksDir $HookName
 
@@ -53,7 +84,7 @@ function Install-Hook {
         Write-Error "install-git-hooks: missing source $src"
     }
 
-    $sourceBlock = Get-MarkerBlock -Path $src
+    $sourceBlock = Get-MarkerBlock -Path $src -BeginMark $beginMark -EndMark $endMark
     if ([string]::IsNullOrWhiteSpace($sourceBlock)) {
         Write-Error "install-git-hooks: source $src has no marker block"
     }
@@ -76,7 +107,7 @@ function Install-Hook {
 
     $existing = Get-Content -LiteralPath $dst -Raw
     if ($existing -match [regex]::Escape($beginMark)) {
-        $existingBlock = Get-MarkerBlock -Path $dst
+        $existingBlock = Get-MarkerBlock -Path $dst -BeginMark $beginMark -EndMark $endMark
         if ($existingBlock -eq $sourceBlock) {
             if (-not $Check) {
                 Write-Output "install-git-hooks: $dst up to date"
@@ -109,8 +140,51 @@ function Install-Hook {
     Write-Output "install-git-hooks: appended block to $dst"
 }
 
+function Install-MayorMarker {
+    # Drops <common-dir>/mayor-marker. The marker is the activation gate
+    # for the pre-commit hook (rf2-ydl2p). It lives in the mayor's
+    # per-worktree git dir (== common dir for the primary worktree);
+    # worker worktrees have a distinct per-worktree git dir at
+    # <common>/worktrees/<name>/ and therefore see no marker -> hook no-ops.
+    $markerPath = Join-Path $commonDir 'mayor-marker'
+    $markerContent = @"
+re-frame2 mayor checkout marker (rf2-ydl2p).
+Presence of this file in <git-dir> activates the pre-commit hook that
+refuses commits to worker-tracked surfaces. Managed by
+scripts/install-git-hooks.ps1; safe to delete (the hook then no-ops and
+this checkout behaves like a worker worktree from the hook's POV).
+"@
+    # Normalise to LF and trailing-newline so sh and ps1 installers agree.
+    $expected = ($markerContent -replace "`r`n","`n").TrimEnd("`n") + "`n"
+
+    if (-not (Test-Path -LiteralPath $markerPath)) {
+        if ($Check) {
+            Write-Error "install-git-hooks: mayor-marker missing at $markerPath"
+        }
+        [System.IO.File]::WriteAllText($markerPath, $expected, (New-Object System.Text.UTF8Encoding $false))
+        Write-Output "install-git-hooks: installed mayor-marker at $markerPath"
+        return
+    }
+
+    $current = Get-Content -LiteralPath $markerPath -Raw
+    $currentNorm = ($current -replace "`r`n","`n")
+    if ($currentNorm -eq $expected) {
+        if (-not $Check) {
+            Write-Output "install-git-hooks: mayor-marker up to date"
+        }
+        return
+    }
+    if ($Check) {
+        Write-Error "install-git-hooks: mayor-marker content drifted at $markerPath"
+    }
+    [System.IO.File]::WriteAllText($markerPath, $expected, (New-Object System.Text.UTF8Encoding $false))
+    Write-Output "install-git-hooks: refreshed mayor-marker at $markerPath"
+}
+
 try {
     Install-Hook -HookName 'post-merge'
+    Install-Hook -HookName 'pre-commit'
+    Install-MayorMarker
 }
 catch {
     if ($Check) {

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,15 +1,19 @@
 #!/usr/bin/env sh
-# scripts/install-git-hooks.sh — install re-frame2 repo git hooks (rf2-6jj3r).
+# scripts/install-git-hooks.sh — install re-frame2 repo git hooks.
 #
 # Idempotent. Safe to run repeatedly. Co-exists with `bd hooks install`
 # (beads-managed segments use their own BEGIN/END BEADS INTEGRATION
 # markers; this script's segments use BEGIN/END re-frame2 markers and
 # never touch beads segments).
 #
-# Today this installs only `post-merge`, which warns when a `git pull`
-# brings down MCP-source changes that invalidate the local
-# tools/re-frame2-pair-mcp/out/server.js binary. Future re-frame2 repo
-# hooks register here.
+# Installs:
+#   - post-merge  (rf2-6jj3r) MCP-staleness advisory warning.
+#   - pre-commit  (rf2-ydl2p) refuses commits in the MAYOR checkout that
+#                 touch worker-tracked surfaces. Activation gated by a
+#                 marker file at `<git-common-dir>/mayor-marker`, which
+#                 this installer also drops (it lives in the mayor's git
+#                 dir, so worker worktrees — which share hooks but not
+#                 their per-worktree git dir — see a no-op hook).
 #
 # Usage:
 #   scripts/install-git-hooks.sh           # install/refresh
@@ -28,12 +32,26 @@ SRC_DIR="$SCRIPT_DIR/git-hooks"
 # git stores hooks under <gitdir>/hooks; in worktrees that's the main
 # repo's hook dir (worktrees share core.hooksPath by default), so use
 # `git rev-parse --git-common-dir` to land in the right place.
-HOOKS_DIR=$(git -C "$REPO_ROOT" rev-parse --git-common-dir)/hooks
+COMMON_DIR=$(git -C "$REPO_ROOT" rev-parse --git-common-dir)
+HOOKS_DIR="$COMMON_DIR/hooks"
 mkdir -p "$HOOKS_DIR"
 
-# Marker pair (must match what the hook source files carry).
-BEGIN_MARK='# --- BEGIN re-frame2 MCP-staleness check (rf2-6jj3r) ---'
-END_MARK='# --- END re-frame2 MCP-staleness check (rf2-6jj3r) ---'
+# Marker pair per hook (must match what the hook source files carry).
+# `hook_markers <hook_name>` echoes `BEGIN<TAB>END`; consumers split on TAB.
+hook_markers() {
+  case "$1" in
+    post-merge)
+      printf '# --- BEGIN re-frame2 MCP-staleness check (rf2-6jj3r) ---\t# --- END re-frame2 MCP-staleness check (rf2-6jj3r) ---\n'
+      ;;
+    pre-commit)
+      printf '# --- BEGIN re-frame2 mayor commit boundary (rf2-ydl2p) ---\t# --- END re-frame2 mayor commit boundary (rf2-ydl2p) ---\n'
+      ;;
+    *)
+      printf 'install-git-hooks: unknown hook name: %s\n' "$1" >&2
+      return 1
+      ;;
+  esac
+}
 
 MODE="install"
 if [ $# -gt 0 ] && [ "$1" = "--check" ]; then
@@ -44,6 +62,11 @@ install_hook() {
   hook_name="$1"
   src="$SRC_DIR/$hook_name"
   dst="$HOOKS_DIR/$hook_name"
+
+  # Resolve per-hook markers.
+  marker_line=$(hook_markers "$hook_name") || return 1
+  BEGIN_MARK=$(printf '%s' "$marker_line" | awk -F'\t' '{print $1}')
+  END_MARK=$(printf '%s' "$marker_line" | awk -F'\t' '{print $2}')
 
   if [ ! -f "$src" ]; then
     printf 'install-git-hooks: missing source %s\n' "$src" >&2
@@ -127,8 +150,58 @@ install_hook() {
   esac
 }
 
+install_mayor_marker() {
+  # Always drop the marker into <common-dir>/mayor-marker. The marker is
+  # the activation gate for the pre-commit hook (rf2-ydl2p). It lives in
+  # the mayor's per-worktree git dir (== common dir for the primary
+  # worktree); worker worktrees have their own per-worktree git dir at
+  # <common>/worktrees/<name> and therefore see no marker -> hook no-ops.
+  marker_path="$COMMON_DIR/mayor-marker"
+  marker_content='re-frame2 mayor checkout marker (rf2-ydl2p).
+Presence of this file in <git-dir> activates the pre-commit hook that
+refuses commits to worker-tracked surfaces. Managed by
+scripts/install-git-hooks.sh; safe to delete (the hook then no-ops and
+this checkout behaves like a worker worktree from the hook'\''s POV).
+'
+
+  if [ ! -f "$marker_path" ]; then
+    case "$MODE" in
+      check)
+        printf 'install-git-hooks: mayor-marker missing at %s\n' "$marker_path" >&2
+        return 1
+        ;;
+      install)
+        printf '%s' "$marker_content" > "$marker_path"
+        printf 'install-git-hooks: installed mayor-marker at %s\n' "$marker_path"
+        return 0
+        ;;
+    esac
+  fi
+
+  current=$(cat "$marker_path")
+  expected=$(printf '%s' "$marker_content")
+  if [ "$current" = "$expected" ]; then
+    [ "$MODE" = "install" ] && printf 'install-git-hooks: mayor-marker up to date\n'
+    return 0
+  fi
+
+  case "$MODE" in
+    check)
+      printf 'install-git-hooks: mayor-marker content drifted at %s\n' "$marker_path" >&2
+      return 1
+      ;;
+    install)
+      printf '%s' "$marker_content" > "$marker_path"
+      printf 'install-git-hooks: refreshed mayor-marker at %s\n' "$marker_path"
+      return 0
+      ;;
+  esac
+}
+
 rc=0
 install_hook post-merge || rc=$?
+install_hook pre-commit || rc=$?
+install_mayor_marker || rc=$?
 
 if [ "$MODE" = "check" ] && [ "$rc" -ne 0 ]; then
   printf '\nRun scripts/install-git-hooks.sh to install.\n' >&2


### PR DESCRIPTION
## Summary

Defence-in-depth complement to scripts/assert-worker-worktree.ps1: a pre-commit hook installed in the **mayor** checkout refuses any staged diff whose paths fall outside the small allow-list of mayor-permitted surfaces (.beads/issues.jsonl + optional root MEMORY.md). The edit-time guard catches worker edit attempts; this catches commit attempts that bypass it.

## Discovery context

rf2-oswhk (#2136) near-mishap, 2026-05-25: worker acb252dc committed a bd --claim flip to the mayor's local main because PowerShell's cwd defaulted to the implementation directory rather than tracking a prior cd. Worker noticed + recovered (reset mayor back to origin/main; re-committed via Bash in the worker). The bogus commit only carried a bd state flip — no source/test/spec damage — but it COULD have carried real worker-tracked source changes.

## The gap

scripts/assert-worker-worktree.ps1 (rf2-mfi1s) catches **edit** attempts (worker scripts gate edits on WORKTREE_ROOT). It does NOT catch **commit** attempts. A worker that bypasses the edit guard via a separate code path (PowerShell cwd leak, Bash pwd shifting between tool calls, etc.) can write a commit into the mayor checkout's main branch.

## Design

- **Hook source**: scripts/git-hooks/pre-commit + library scripts/git-hooks/lib/check-mayor-commit-boundary.sh. POSIX sh throughout; mirrors the rf2-6jj3r (#2113) post-merge pattern.
- **Marker-file activation gate** at <git-common-dir>/mayor-marker (option **B** from the bead). The mayor's git-dir == common-dir, so the marker is visible there and the hook activates. Worker worktrees have per-worktree git dirs at <common>/worktrees/<name>/, so the marker is invisible and the hook no-ops. Picked over hardcoded path for portability.
- **Allow-list, not deny-list**: any staged path not in the permitted list is refused.

## Permitted vs refused

| Path | Status |
|------|--------|
| .beads/issues.jsonl | Permitted (bd closures) |
| MEMORY.md (root, if present) | Permitted (operator-memory file) |
| implementation/, tools/, spec/, docs/, examples/, skills/, scripts/, migration/, testbeds/, README.md, *anything else* | Refused |

Gitignored paths cannot normally reach the staged diff (git excludes them before git add sees them); git add --force is still caught here because gitignore membership is not part of the allow-list. Deliberate.

## Installer extension

scripts/install-git-hooks.sh + scripts/install-git-hooks.ps1 now install **both** the post-merge hook (rf2-6jj3r) and the new pre-commit hook, plus drop the mayor-marker. Per-hook marker pairs let each block be refreshed independently. Idempotent. --check / -Check reports drift.

## Tests

scripts/git-hooks/test-pre-commit.sh covers two layers:

- **Layer 1**: library unit tests via synthetic stdin against check-mayor-commit-boundary.sh.
- **Layer 2**: end-to-end smoke in a throwaway repo + worktree pair, exercising all four acceptance scenarios:
  - (a) mayor commit with only .beads/issues.jsonl staged → passes
  - (b) mayor commit with tools/xray/foo.cljs staged → refused with error block
  - (c) worker worktree commit with source staged → passes (hook no-op via missing marker)
  - (d) mayor commit with mixed (.beads/issues.jsonl + refused) → refused (any-refused triggers)

**Result**: 10/10 pass.

## Gate results

```
bash -n scripts/git-hooks/pre-commit                                   # syntax OK
bash -n scripts/git-hooks/lib/check-mayor-commit-boundary.sh           # syntax OK
bash -n scripts/install-git-hooks.sh                                   # syntax OK
bash -n scripts/git-hooks/test-pre-commit.sh                           # syntax OK
pwsh -NoProfile -Command 'parse install-git-hooks.ps1'                 # parse OK
bash scripts/git-hooks/test-pre-commit.sh                              # 10/10 PASS
```

Also exercised the full installer end-to-end in a sandboxed repo: first-install drops both hooks + marker, --check after install reports clean, second install reports up-to-date (idempotent). PowerShell installer mirrors the same flow.

## Spec touch

Updated docs/the-mayor-method/dispatch-prompt-template.md with a short note announcing the mayor-side commit guard, alongside the existing edit-time guard discussion. Spec tree (spec/) unchanged because the worker dispatch contract lives in docs/the-mayor-method/ and the hook is defence-in-depth, not a new contract surface.

## Cross-refs

- rf2-6jj3r (#2113) — post-merge stale-binary hook + installer pattern this extends.
- rf2-oswhk (#2136) — near-mishap that surfaced the gap.
- scripts/assert-worker-worktree.ps1 (rf2-mfi1s) — the edit-time complement.
- docs/the-mayor-method/ — the worker dispatch contract this hook enforces.