### PR TITLE
feat(core): per-frame trace rings with cascade-keyed retention + B4 dedup-by-shape (rf2-8uwce)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -1115,16 +1115,31 @@
 
 #?(:clj
    (do
-     (def ^{:doc "Return the trace ring buffer's current contents,
-       oldest-first. Opts filter the result; the buffer is the substrate
-       behind `re-frame-10x` and other dev tools. JVM-only alias —
-       CLJS callers use `re-frame.trace.tooling/trace-buffer` directly.
-       Per Spec 009 §Retain-N trace ring buffer."}
+     (def ^{:doc "Return the named frame's cascade-keyed trace ring,
+       oldest-first. Two arities:
+
+         (rf/trace-buffer frame-id)
+           Returns cascade bundles by default — one entry per retained
+           cascade with the cascade's `:dispatch-id`, raw `:trace-events`,
+           and the projected six-domino slots (`:event`, `:dispatched`,
+           `:handler`, `:fx`, `:effects`, `:subs`, `:renders`, `:other`).
+
+         (rf/trace-buffer frame-id opts)
+           `opts` is a filter map. `{:flat true}` returns raw trace
+           events instead of cascade bundles. The full filter
+           vocabulary lives in Spec 009 §Filter vocabulary.
+
+       Returns `[]` for a destroyed or never-registered frame, and `[]`
+       in production (the ring is never allocated under
+       `goog.DEBUG=false`). JVM-only alias — CLJS callers use
+       `re-frame.trace.tooling/trace-buffer` directly. Per Spec 009
+       §Per-frame trace rings (cascade-keyed, dev-only)."}
        trace-buffer           trace/trace-buffer)
-     (def ^{:doc "Empty the trace ring buffer. Tooling uses this between
-       sessions. No-op in production. JVM-only alias — CLJS callers use
-       `re-frame.trace.tooling/clear-trace-buffer!` directly. Per Spec 009
-       §Retain-N trace ring buffer."}
+     (def ^{:doc "Empty the named frame's cascade-keyed trace ring.
+       Tooling uses this between sessions. No-op for an unknown frame,
+       no-op in production. JVM-only alias — CLJS callers use
+       `re-frame.trace.tooling/clear-trace-buffer!` directly. Per Spec
+       009 §`trace-buffer` API."}
        clear-trace-buffer!    trace/clear-trace-buffer!)))
 
 (def ^{:doc "Register an always-on event-emit listener `f` under `id`.
@@ -1300,7 +1315,12 @@
 (defn configure
   "Configure a process-level runtime knob. v1 keys:
     :epoch-history {:depth N}                       ring depth (default 50; 0 disables)
-    :trace-buffer  {:depth N}                       ring depth (default 200; 0 disables)
+    :trace-buffer  {:cascades-retained N}           per-frame trace-ring cascade count
+                                                    (default 50; 0 disables retention).
+                                                    Applied to `:rf/default` and to every
+                                                    frame that did not set its own
+                                                    `:rf.trace/cascades-retained` metadata.
+                                                    Per Spec 009 §Per-frame trace rings.
     :sub-cache     {:grace-period-ms N}             dispose grace (default 50ms)
     :elision       {:rf.size/threshold-bytes N}     wire-elision size threshold
                                                     (default 16384; 0 disables runtime
@@ -1311,8 +1331,8 @@
 
   `:trace-buffer` routes through the `re-frame.trace.tooling` sibling
   ns (per rf2-qwm0a). Production builds that never load the tooling
-  sibling silently no-op on this key — the buffer + listener
-  machinery is DCE'd anyway."
+  sibling silently no-op on this key — the ring + listener machinery
+  is DCE'd anyway."
   [knob opts]
   (case knob
     :epoch-history (when-let [f (late-bind/get-fn :epoch/configure!)]

--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -66,6 +66,13 @@
   []
   (or *current-frame* :rf/default))
 
+;; Per Spec 009 §Per-frame trace rings (rf2-g1b2m / rf2-8uwce): publish
+;; the in-flight frame-id through `late-bind` so the trace tooling
+;; sibling can route emit-site trace events to their owning frame's
+;; ring. Returns nil when no cascade is in flight (frameless emits).
+;; The hook is sticky (rf2-f72pd) and read on every push-to-ring!.
+(late-bind/set-fn! :frame/current-frame-id (fn [] *current-frame*))
+
 (defn resolve-current-frame
   "Resolve the active frame at a no-explicit-frame call site. The
   3-tier resolution chain — dynamic var → React context → `:rf/default` —
@@ -304,6 +311,18 @@
     ;; registration and re-registration so a hot-reload can flip it
     ;; either way; `trace.cljc` owns the canonical set + predicate.
     (trace/set-frame-no-emit! id (true? (:rf.trace/frame-no-emit? config)))
+    ;; Per Spec 009 §Retention contract (rf2-g1b2m / rf2-8uwce): apply
+    ;; the per-frame `:rf.trace/cascades-retained` override at
+    ;; registration time. Honoured on BOTH first registration and re-
+    ;; registration so a hot-reload can flip it either way. When the
+    ;; key is absent the frame inherits the process-default. Routed via
+    ;; late-bind so production CLJS bundles (where trace.tooling is
+    ;; not loaded) short-circuit cleanly — the trace-ring machinery is
+    ;; dev-only and there's nothing to configure in prod.
+    (when (contains? config :rf.trace/cascades-retained)
+      (when-let [set-retained! (late-bind/get-fn-cached
+                                :trace.tooling/set-frame-cascades-retained!)]
+        (set-retained! id (:rf.trace/cascades-retained config))))
     (let [existing (get @frames id)]
       (cond
         ;; First registration: create everything.
@@ -600,6 +619,14 @@
         ;; per rf2-tfw3).
         (safe-call-hook! :flows/teardown-on-frame-destroy! id)
         (emit-frame-destroyed-trace! id)
+        ;; Per Spec 009 §Per-frame trace rings (rf2-g1b2m / rf2-8uwce):
+        ;; release the destroyed frame's cascade-keyed ring so no
+        ;; residual trace events leak across the frame lifecycle. Fired
+        ;; AFTER `:rf.frame/destroyed` emits so the destroyed trace
+        ;; itself (which is frameless and bypasses the ring anyway)
+        ;; still flows through the live stream cleanly. Routed via
+        ;; late-bind so production CLJS bundles (no trace.tooling) no-op.
+        (safe-call-hook! :trace.tooling/release-frame-ring! id)
         (dissoc-frame! id)
         (unregister-frame! id)
         (notify-epoch-listeners! id)

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -619,6 +619,36 @@
     :design-bead "rf2-r1ciy"
     :description "Drop a trace listener. Sibling of `:trace.tooling/register-listener!` — same rf2-r1ciy seam."}
 
+   ;; ---- re-frame.trace.tooling — per-frame trace rings (rf2-g1b2m / rf2-8uwce) ----
+   ;;
+   ;; The four hooks below carry the per-frame ring + B4 dedup machinery
+   ;; introduced by rf2-g1b2m / rf2-8uwce. They're consulted from
+   ;; `re-frame.frame/reg-frame` + `destroy-frame!` (lifecycle) and
+   ;; `re-frame.registrar/register!` / `unregister!` / `clear-kind!`
+   ;; (B4 dedup). All routed via late-bind so production CLJS bundles
+   ;; that never load `re-frame.trace.tooling` short-circuit cleanly
+   ;; — the ring + dedup machinery is dev-only and DCEs out wholesale.
+   {:key         :trace.tooling/dedup-allow?
+    :producer-ns 're-frame.trace.tooling
+    :design-bead "rf2-g1b2m"
+    :description "B4 hot-reload dedup-by-shape gate. Registrar emits consult this to suppress unchanged re-emits (`(operation, kind, id, meta) -> allow?`). Identical shape on re-register → false; changed shape or no prior entry → true."}
+   {:key         :trace.tooling/clear-dedup-table!
+    :producer-ns 're-frame.trace.tooling
+    :design-bead "rf2-g1b2m"
+    :description "Reset the B4 dedup table. `re-frame.registrar/clear-all!` calls this so test fixtures start from a clean slate. Production builds (no tooling sibling) no-op."}
+   {:key         :trace.tooling/release-frame-ring!
+    :producer-ns 're-frame.trace.tooling
+    :design-bead "rf2-g1b2m"
+    :description "Frame-destroy ring cleanup. `re-frame.frame/destroy-frame!` invokes this once the destroyed-trace has fired so the destroyed frame leaves no residual ring state in memory."}
+   {:key         :trace.tooling/set-frame-cascades-retained!
+    :producer-ns 're-frame.trace.tooling
+    :design-bead "rf2-g1b2m"
+    :description "Apply a per-frame `:rf.trace/cascades-retained` override. `re-frame.frame/reg-frame` invokes this when the config carries the key; raises / lowers the ring's slot cap, trimming evictions in-place when lowering."}
+   {:key         :frame/current-frame-id
+    :producer-ns 're-frame.frame
+    :design-bead "rf2-g1b2m"
+    :description "Read the currently-bound frame id from `re-frame.frame/*current-frame*`. Consulted by `re-frame.trace.tooling/push-to-ring!` as the routing fallback when the trace event itself does not carry a `:frame` tag (e.g. sub recompute / view render emits inside an in-flight cascade)."}
+
    ;; ---- re-frame.trace.cascade (rf2-931pm — focused-event-only cascade-DAG aggregator) ----
    ;;
    ;; The three hooks let `re-frame.epoch/settle!` reach the aggregator

--- a/implementation/core/src/re_frame/registrar.cljc
+++ b/implementation/core/src/re_frame/registrar.cljc
@@ -128,6 +128,22 @@
   (when-let [f (late-bind/get-fn-cached :trace/emit!)]
     (f :rf.registry operation tags)))
 
+(defn- dedup-allow?
+  "Consult the B4 hot-reload dedup-by-shape table (per Spec 009
+  §Hot-reload dedup — re-emits suppressed by shape, rf2-g1b2m). Returns
+  true if the emit should proceed; false if the prior emit for this
+  `(kind, id)` already carried an identical shape (so this re-emit
+  carries no new signal).
+
+  When the trace.tooling sibling is not loaded (production CLJS counter
+  bundle), the late-bind lookup returns nil and we allow-by-default —
+  the surrounding `interop/debug-enabled?` gate elides the whole branch
+  anyway in :advanced + goog.DEBUG=false builds."
+  [operation kind id meta]
+  (if-let [f (late-bind/get-fn-cached :trace.tooling/dedup-allow?)]
+    (f operation kind id meta)
+    true))
+
 (defn- emit-warning!
   "Invoke `:trace/emit!` with the `:warning` op-type. Sibling to
   `emit!` (which uses `:rf.registry`). Callers MUST wrap invocations in
@@ -305,21 +321,36 @@
         ;; The `interop/debug-enabled?` gate stays OUTERMOST so
         ;; `:advanced + goog.DEBUG=false` constant-folds the entire
         ;; branch (per Spec 009 §Production builds).
+        ;;
+        ;; Per Spec 009 §Hot-reload dedup — re-emits suppressed by shape
+        ;; (B4 ruling, rf2-g1b2m): consult the dedup table. Identical
+        ;; shape on re-register (a hot-reload that didn't actually
+        ;; change the handler) emits ZERO trace events; a real edit
+        ;; emits exactly one `:rf.registry/handler-replaced`. The
+        ;; sibling collision-warning is gated on the same allow signal
+        ;; — a suppressed hot-reload re-emit must not surface the
+        ;; collision warning either.
         (when interop/debug-enabled?
-          (emit! :rf.registry/handler-replaced
-                 {:kind kind :id id :different-fn? different?})
-          ;; Per Spec 001 §Re-registration of a different function —
-          ;; collision warning (rf2-45kaz). Fires alongside
-          ;; handler-replaced when the fn-identity actually changed,
-          ;; with the same per-(kind, id) suppression discipline so
-          ;; the dev stream stays readable across hot-reload churn.
-          (maybe-emit-collision! kind id previous metadata)))
+          (when (dedup-allow? :rf.registry/handler-replaced kind id metadata)
+            (emit! :rf.registry/handler-replaced
+                   {:kind kind :id id :different-fn? different?})
+            ;; Per Spec 001 §Re-registration of a different function —
+            ;; collision warning (rf2-45kaz). Fires alongside
+            ;; handler-replaced when the fn-identity actually changed,
+            ;; with the same per-(kind, id) suppression discipline so
+            ;; the dev stream stays readable across hot-reload churn.
+            (maybe-emit-collision! kind id previous metadata))))
       ;; First-time registration — emit handler-registered per Spec 009
       ;; §:op-type vocabulary. Hot-reload tools (10x, re-frame-pair) use
-      ;; this to track when fresh ids appear in the registry.
+      ;; this to track when fresh ids appear in the registry. The B4
+      ;; dedup table is also consulted here so the FIRST emit per
+      ;; (kind, id) records the baseline shape for subsequent re-emit
+      ;; suppression (rf2-g1b2m). A first registration always allows
+      ;; (no prior entry to compare against).
       :else
       (when interop/debug-enabled?
-        (emit! :rf.registry/handler-registered {:kind kind :id id})))
+        (when (dedup-allow? :rf.registry/handler-registered kind id metadata)
+          (emit! :rf.registry/handler-registered {:kind kind :id id}))))
     ;; Per Spec 001 §`:doc` is dev-warned when absent (rf2-45kaz). Fires
     ;; on every reg-* call whose final metadata-map carries no usable
     ;; `:doc`, once per (kind, id) within the runtime process. Production
@@ -350,9 +381,15 @@
     ;; Per Spec 009 §:op-type vocabulary: :rf.registry/handler-cleared
     ;; fires on explicit removal so hot-reload tools can update their
     ;; views. Only emit when something was actually present.
+    ;;
+    ;; Per Spec 009 §Hot-reload dedup (B4 ruling, rf2-g1b2m): a clear
+    ;; of an id the dedup table thinks is already absent (a double-
+    ;; clear) is suppressed. The first clear records the `::cleared`
+    ;; sentinel; subsequent re-clears emit nothing.
     (when interop/debug-enabled?
       (when previous
-        (emit! :rf.registry/handler-cleared {:kind kind :id id}))))
+        (when (dedup-allow? :rf.registry/handler-cleared kind id nil)
+          (emit! :rf.registry/handler-cleared {:kind kind :id id})))))
   nil)
 
 (defn clear-kind!
@@ -371,10 +408,13 @@
     (swap! collision-warned   clear-kind)
     ;; Per Spec 009 §:op-type vocabulary: :rf.registry/handler-cleared
     ;; fires for each id so consumers see consistent registry transitions.
+    ;; B4 dedup (rf2-g1b2m): a clear-of-a-cleared id is suppressed; the
+    ;; first clear records the `::cleared` sentinel.
     (when interop/debug-enabled?
       (when (seq previous-ids)
         (doseq [id previous-ids]
-          (emit! :rf.registry/handler-cleared {:kind kind :id id})))))
+          (when (dedup-allow? :rf.registry/handler-cleared kind id nil)
+            (emit! :rf.registry/handler-cleared {:kind kind :id id}))))))
   nil)
 
 (defn clear-all!
@@ -384,7 +424,14 @@
   `:rf.warning/missing-doc` and `:rf.warning/registration-collision`
   so each test case starts from a clean diagnostic state — without
   this, a test that re-registers an already-warned (kind, id) pair
-  would silently miss the warning under suppression."
+  would silently miss the warning under suppression.
+
+  Per Spec 009 §Hot-reload dedup (B4 ruling, rf2-g1b2m): also clears
+  the dev-only `:rf.registry/*` dedup-by-shape table via the
+  trace.tooling sibling's clearance hook — a test fixture targeting
+  the registry must start each case from a clean dedup slate so the
+  first emit for any `(kind, id)` proceeds (otherwise the table from
+  the prior test would silently suppress the new test's first emit)."
   []
   (reset! kind->id->metadata {})
   (reset! missing-doc-warned #{})
@@ -392,6 +439,13 @@
   ;; Also clear the always-on error-coord parallel registry (rf2-3un2g)
   ;; so test cases start from a clean state on both surfaces.
   (source-coords/forget-error-coords!)
+  ;; Clear the B4 dedup table when the trace.tooling sibling is loaded.
+  ;; Production CLJS bundles that never load trace.tooling silently
+  ;; no-op here — the dedup hook is unbound and there's no table to
+  ;; clear anyway.
+  (when interop/debug-enabled?
+    (when-let [clear! (late-bind/get-fn-cached :trace.tooling/clear-dedup-table!)]
+      (clear!)))
   nil)
 
 ;; ---- lookup ---------------------------------------------------------------

--- a/implementation/core/src/re_frame/trace/tooling.cljc
+++ b/implementation/core/src/re_frame/trace/tooling.cljc
@@ -2,35 +2,56 @@
   "Trace tooling sibling of `re-frame.trace` — carries the public
   dev-tooling surface (`register-listener!` / `unregister-listener!` /
   `clear-listeners!` / `trace-buffer` / `clear-trace-buffer!` /
-  `configure-trace-buffer!` / `configure`) and the buffer / listener
-  state they operate on.
+  `configure-trace-buffer!` / `configure`) and the per-frame
+  cascade-keyed trace rings + listener state.
 
-  Per rf2-qwm0a (audit rf2-53tcf §Part 4 P1): `re-frame.trace` itself
-  carries only the hot emit fast path (`emit!` / `emit-error!` /
-  `*handler-scope*` + bracket macros). The listener registry + ring
-  buffer + filter predicate are tooling concerns; production counter
-  bundles never touch them. Splitting them off lets `:advanced` +
-  `goog.DEBUG=false` DCE this ns wholesale (it's only loaded when a
-  test fixture, tool, or dev-preload `:require`s it).
+  ## Per-frame trace rings (rf2-g1b2m / rf2-8uwce)
 
-  Per rf2-ic1sv: registration fns dropped their `-trace-` infix —
-  the namespace already says `trace`. `re-frame.trace/register-listener!`
-  is the canonical app-facing surface (re-frame.core re-exports via
-  trace alias); CLJS production builds rely on user-side `goog.DEBUG`
-  gating around register calls so the entire registration site DCE's.
+  Each frame owns its own cascade-keyed ring. Storage shape (per frame):
 
-  Wiring: at ns load this ns publishes `:trace.tooling/deliver!`
-  through `re-frame.late-bind` — `re-frame.trace/deliver!` looks the
-  hook up at emit time and fans the event out to the buffer + every
-  registered listener. Absent the load, the lookup returns nil and the
-  trace fast path skips the fan-out (production behaviour).
+      {:cascades-retained N             ;; the per-frame ring depth
+       :cascade-order [<dispatch-id> ...]  ;; oldest-first cascade slots
+       :cascades {<dispatch-id> [<event> ...]}}
 
-  Public surface for tools / tests:
-    - `register-listener!` / `unregister-listener!` / `clear-listeners!`
-    - `trace-buffer` / `clear-trace-buffer!` / `configure-trace-buffer!`
-    - `configure` (generic config dispatch — currently `:trace-buffer`).
+  - The unit of retention is the cascade (one `:rf.trace/dispatch-id` =
+    one slot). When cascade #N+1 arrives, the OLDEST cascade slot (and
+    every trace event emitted under its `:dispatch-id`) is evicted as a
+    unit.
+  - `:cascades-retained` defaults to 50; per-frame override via
+    `:rf.trace/cascades-retained` on `reg-frame`.
+  - `:cascades-retained 0` disables retention (no slots allocated; the
+    live stream still fires).
+  - Frameless emits (no `:rf.trace/dispatch-id` in scope) **skip the
+    rings entirely** (B3 ruling, rf2-g1b2m, 2026-05-25); they stream
+    live to registered listeners only.
 
-  Per Spec 009 §Retain-N trace ring buffer and §The listener API."
+  ## B4 hot-reload dedup-by-shape (rf2-g1b2m)
+
+  A dev-only process-scoped dedup table tracks the last-emitted
+  `:rf.registry/*` shape per `(kind, id)`. Identical shape on re-emit
+  = suppress; changed shape = exactly one trace fires. The table is
+  cleared by `clear-listeners!` and `clear-trace-rings!`. Per Spec
+  009 §Hot-reload dedup — re-emits suppressed by shape.
+
+  Per rf2-qwm0a: `re-frame.trace` itself carries only the hot emit fast
+  path (`emit!` / `emit-error!` / `*handler-scope*` + bracket macros).
+  The listener registry + ring storage + filter predicate are tooling
+  concerns; production counter bundles never touch them.
+
+  Wiring: at ns load this ns publishes the following hooks through
+  `re-frame.late-bind`:
+    - `:trace.tooling/deliver!`            (emit-time fan-out)
+    - `:trace.tooling/dedup-allow?`        (B4 dedup check at registrar
+                                            emit sites)
+    - `:trace.tooling/release-frame-ring!` (frame-destroy cleanup)
+    - `:trace.tooling/configure-trace-buffer!`
+    - `:trace.tooling/register-listener!` / `:trace.tooling/unregister-listener!`
+
+  Absent the load (production CLJS bundles that never `:require` this
+  ns), every lookup returns nil and the trace fast path / registrar
+  short-circuit cleanly.
+
+  Per Spec 009 §Per-frame trace rings."
   (:require [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]))
 
@@ -52,184 +73,544 @@
   (swap! listeners dissoc id)
   nil)
 
+(declare clear-dedup-table!)
+
 (defn clear-listeners!
+  "Drop every registered listener. Also clears the B4 hot-reload
+  dedup-by-shape table per Spec 009 §Hot-reload dedup — the dedup
+  table is dev-only state, process-scoped, and `clear-listeners!` /
+  test-runtime reset fixtures are the canonical clearance points."
   []
   (reset! listeners {})
+  (clear-dedup-table!)
   nil)
 
-;; ---- retain-N trace ring buffer (dev-only) -------------------------------
+;; ---- per-frame cascade-keyed trace rings (dev-only) ---------------------
+;;
+;; Storage shape (per Spec 009 §Per-frame trace rings):
+;;
+;;   trace-rings  = {<frame-id> {:cascades-retained N
+;;                               :cascade-order [<dispatch-id> ...]
+;;                               :cascades       {<dispatch-id> [<event>...]}}}
+;;
+;; - `:cascade-order` is the oldest-first vector of `:dispatch-id`s
+;;   currently held in this frame's ring; eviction pops the head.
+;; - `:cascades` is a flat map from `:dispatch-id` → trace events
+;;   emitted under that dispatch, in arrival order.
+;; - The slot count is bounded by `:cascades-retained` (default 50).
+;; - Frames lazily allocate slots on first emit. Apps with one frame
+;;   pay one slot of ring overhead.
 
-(def ^:private default-buffer-depth
-  "Per Spec 009 §Retain-N trace ring buffer: default 200 events —
-  enough for one drained cascade plus prior history without per-frame
-  memory pressure."
-  200)
+(def ^:private default-cascades-retained
+  "Per Spec 009 §Per-frame trace rings — the per-frame retention default
+  when neither `:rf.trace/cascades-retained` on `reg-frame` nor
+  `(configure :trace-buffer ...)` supplies one. 50 cascades — enough to
+  cover a short interactive session without per-frame memory pressure."
+  50)
 
-(defonce ^:private buffer-depth (atom default-buffer-depth))
+(defonce ^:private trace-rings (atom {}))
 
-(defonce ^:private trace-buffer-state
-  ;; The buffer is a plain vector held under an atom. Append is conj+slice;
-  ;; the slot count caps memory. depth=0 disables the buffer entirely (the
-  ;; delivery path still works — see configure-trace-buffer!).
-  (atom []))
+;; Process-default cascades-retained — applies to `:rf/default` and any
+;; frame that did not set per-frame `:rf.trace/cascades-retained` metadata.
+;; Per Spec 009 §Retention contract — the single knob.
+(defonce ^:private process-cascades-retained (atom default-cascades-retained))
 
-(defn- push-to-buffer!
-  "Append ev to the ring buffer, evicting the oldest entry when the slot
-  count is exceeded. No-op when the configured depth is 0."
+(defn- empty-ring [retained]
+  {:cascades-retained retained
+   :cascade-order     []
+   :cascades          {}})
+
+(defn- effective-retained
+  "Return the cascades-retained value for `frame-id`. Honours an
+  existing per-frame override (`set-frame-cascades-retained!`'s prior
+  write) before falling back to the process default."
+  [rings frame-id]
+  (or (get-in rings [frame-id :cascades-retained])
+      @process-cascades-retained))
+
+(defn set-frame-cascades-retained!
+  "Apply a per-frame `:rf.trace/cascades-retained` override (called
+  from `frame.cljc`'s `reg-frame` when the config carries the key).
+  Trims existing slots if the new value is lower than current
+  occupancy; raising keeps existing cascades and grows the slot cap.
+
+  Per Spec 009 §Lowering cascades-retained on a populated ring."
+  [frame-id retained]
+  (when (and interop/debug-enabled? (number? retained) (not (neg? retained)))
+    (swap! trace-rings
+           (fn [rings]
+             (let [existing (get rings frame-id)
+                   order    (or (:cascade-order existing) [])
+                   cascades (or (:cascades existing) {})]
+               (cond
+                 ;; retained = 0: drop everything; slot persists with depth 0
+                 ;; so reads return [] cleanly.
+                 (zero? retained)
+                 (assoc rings frame-id
+                        (empty-ring 0))
+
+                 ;; Trim if existing order exceeds the new cap.
+                 (> (count order) retained)
+                 (let [drop-n     (- (count order) retained)
+                       evicted    (subvec order 0 drop-n)
+                       kept-order (subvec order drop-n)]
+                   (assoc rings frame-id
+                          {:cascades-retained retained
+                           :cascade-order     kept-order
+                           :cascades          (apply dissoc cascades evicted)}))
+
+                 :else
+                 (assoc-in rings [frame-id :cascades-retained] retained))))))
+  nil)
+
+(defn release-frame-ring!
+  "Drop `frame-id`'s ring and per-frame retention setting entirely.
+  Called from `destroy-frame!` so a destroyed frame leaves no residual
+  ring state in memory. Per Spec 002 §Destroy and Spec 009 §Per-frame
+  trace rings."
+  [frame-id]
+  (when interop/debug-enabled?
+    (swap! trace-rings dissoc frame-id))
+  nil)
+
+(defn- push-to-ring!
+  "Append `ev` to its frame's cascade-keyed ring. Frameless emits (no
+  `:rf.trace/dispatch-id` in scope) bypass the ring entirely per the
+  B3 ruling — they stream live to listeners only and are never retained.
+
+  Routing chain for the destination frame-id:
+    1. `:frame` under `:tags` (the router stamps it on most in-cascade
+       emits).
+    2. Top-level `:frame` on the envelope.
+    3. The late-bound `:frame/current-frame-id` hook (published by
+       `re-frame.frame` at ns-load) — covers sub recompute / view
+       render emits where the call site doesn't stamp `:frame` but the
+       in-flight cascade's `frame/*current-frame*` is bound.
+
+  No-op in production (production never reaches the emit site)."
   [ev]
   (when interop/debug-enabled?
-    (let [depth @buffer-depth]
-      (when (pos? depth)
-        (swap! trace-buffer-state
-               (fn [v]
-                 (let [v' (conj v ev)
-                       n  (count v')]
-                   (if (> n depth)
-                     (subvec v' (- n depth))
-                     v'))))))))
+    (let [dispatch-id (get-in ev [:tags :rf.trace/dispatch-id])
+          frame-id    (or (get-in ev [:tags :frame])
+                          (:frame ev)
+                          (when-let [current-frame
+                                     (late-bind/get-fn-cached :frame/current-frame-id)]
+                            (current-frame)))]
+      ;; Frameless emits (no in-flight cascade) skip the ring. The B3
+      ;; ruling is that frameless events stream live to listeners only
+      ;; and are never retained. A `:dispatch-id` without a resolvable
+      ;; frame-id (extremely rare — would require a manual emit from
+      ;; outside any framework boundary) also skips the ring; there is
+      ;; nowhere to put it.
+      (when (and dispatch-id frame-id)
+        (swap! trace-rings
+               (fn [rings]
+                 (let [retained (effective-retained rings frame-id)]
+                   (if (zero? retained)
+                     ;; Disabled-but-live: live stream still fires
+                     ;; (push-to-ring! is one step in the pipeline);
+                     ;; just don't allocate.
+                     (assoc rings frame-id (empty-ring 0))
+                     (let [existing (get rings frame-id (empty-ring retained))
+                           order    (:cascade-order existing)
+                           cascades (:cascades existing)
+                           known?   (contains? cascades dispatch-id)
+                           order'   (if known? order (conj order dispatch-id))
+                           cascades' (update cascades dispatch-id
+                                             (fnil conj []) ev)
+                           ;; Evict oldest cascade slots while over cap.
+                           [order'' cascades'']
+                           (loop [o order' c cascades']
+                             (if (> (count o) retained)
+                               (let [oldest (first o)]
+                                 (recur (subvec o 1) (dissoc c oldest)))
+                               [o c]))]
+                       (assoc rings frame-id
+                              {:cascades-retained retained
+                               :cascade-order     order''
+                               :cascades          cascades''}))))))))))
+
+;; ---- B4 hot-reload dedup-by-shape (process-scoped) ----------------------
+;;
+;; Per Spec 009 §Hot-reload dedup — re-emits suppressed by shape.
+;; The dedup table is `{(kind, id) → <shape>}` and is consulted by the
+;; registrar via the `:trace.tooling/dedup-allow?` late-bind hook.
+;; Identical shape on re-emit → suppressed; changed shape (or no prior
+;; entry) → allowed.
+;;
+;; Shape composition:
+;;   - For `:rf.registry/handler-registered`: the registration's
+;;     `:handler-fn` identity + the metadata fields that affect the
+;;     observable contract (`:doc`, `:schema`, `:interceptors`, `:tags`,
+;;     plus per-kind extras carried directly on the meta map).
+;;   - For `:rf.registry/handler-replaced`: same shape composed from the
+;;     new metadata. Re-emit suppressed iff matches the prior entry.
+;;   - For `:rf.registry/handler-cleared`: the shape is the sentinel
+;;     `:rf.trace.tooling/cleared`. A second clear-of-a-cleared id
+;;     (e.g. a double-clear) is suppressed.
+;;
+;; The same dedup keys both `:rf.registry/handler-registered` and
+;; `:rf.registry/handler-replaced` (the registrar already routes
+;; first-time vs re-registration to the right operation). Hot-reload
+;; that re-evaluates a namespace with unchanged handlers emits ZERO
+;; trace events from the registrar.
+
+(defonce ^:private dedup-table (atom {}))
+
+(defn- handler-shape
+  "Compute a value representing the observable shape of a registration's
+  metadata. Used to decide whether a re-emit is genuinely a change.
+
+  Excludes source-coord keys (`:ns` / `:file` / `:line` / `:column`) —
+  source-coord drift across a hot-reload is expected and not a
+  user-visible change. Includes everything that affects the runtime
+  contract (`:handler-fn` identity, `:doc`, `:schema`, `:interceptors`,
+  `:tags`, plus the full set of remaining meta keys as a hash).
+
+  Returns a small map suitable for `=` comparison."
+  [meta]
+  (let [strip (dissoc meta :ns :file :line :column)
+        ;; Hash the residual meta-map (after pulling out the high-signal
+        ;; slots) so semantically-equivalent meta maps compare equal
+        ;; without an O(n) compare each time.
+        residual (dissoc strip :handler-fn :doc :schema :interceptors :tags)]
+    {:handler-fn   (:handler-fn meta)
+     :doc          (:doc meta)
+     :schema       (:schema meta)
+     :interceptors (:interceptors meta)
+     :tags         (:tags meta)
+     :residual     (hash residual)}))
+
+(defn dedup-allow?
+  "Return true iff emitting `operation` for `[kind id]` is a genuine
+  change (or has no prior entry). Updates the dedup table side-effecting:
+
+  - `:rf.registry/handler-registered` / `:rf.registry/handler-replaced` —
+    compute the new shape; allow iff the stored shape differs (or absent).
+    On allow, record the new shape under `[kind id]`.
+  - `:rf.registry/handler-cleared` — allow iff the stored shape is NOT
+    already `::cleared`. On allow, record `::cleared` so a subsequent
+    re-clear is suppressed.
+
+  Dev-only — no-op (returns true, allow-by-default) in production. The
+  registrar's emit sites stay gated on `interop/debug-enabled?` so prod
+  never reaches this fn at all.
+
+  Per Spec 009 §Hot-reload dedup."
+  [operation kind id meta]
+  (cond
+    (not interop/debug-enabled?) true
+
+    (or (= operation :rf.registry/handler-registered)
+        (= operation :rf.registry/handler-replaced))
+    (let [k         [kind id]
+          new-shape (handler-shape meta)
+          prev      (get @dedup-table k)]
+      (if (= prev new-shape)
+        false
+        (do (swap! dedup-table assoc k new-shape)
+            true)))
+
+    (= operation :rf.registry/handler-cleared)
+    (let [k    [kind id]
+          prev (get @dedup-table k)]
+      (if (= prev ::cleared)
+        false
+        (do (swap! dedup-table assoc k ::cleared)
+            true)))
+
+    :else true))
+
+(defn clear-dedup-table!
+  "Reset the B4 dedup-by-shape table to empty. Called by
+  `clear-listeners!` and `clear-trace-rings!` so test-runtime reset
+  fixtures don't leak dedup state across runs.
+
+  Per Spec 009 §Hot-reload dedup — \"the dedup table is cleared by
+  `clear-listeners!` / test-runtime reset fixtures\"."
+  []
+  (reset! dedup-table {})
+  nil)
+
+;; ---- trace-buffer reader -------------------------------------------------
+;;
+;; Per Spec 009 §`trace-buffer` API — per-frame, cascade bundles by
+;; default. `:flat true` opt returns raw trace events.
+
+(defn- effects-bucket?
+  [{:keys [op-type operation]}]
+  (and (= op-type :rf.fx) (not= operation :rf.fx/do-fx)))
+
+(defn- subs-bucket?
+  [{:keys [op-type]}]
+  (= op-type :rf.sub))
+
+(defn- renders-bucket?
+  [{:keys [op-type operation]}]
+  (and (= op-type :rf.view) (= operation :rf.view/render)))
+
+(defn- handler-marker?
+  [{:keys [op-type operation]}]
+  (and (= op-type :rf.event)
+       (or (= operation :rf.event/run-start)
+           (= operation :rf.event/run-end))))
+
+(defn- dispatched-marker?
+  [{:keys [op-type operation]}]
+  (and (= op-type :rf.event) (= operation :rf.event/dispatched)))
+
+(defn- fx-marker?
+  [{:keys [operation]}]
+  (= operation :rf.fx/do-fx))
+
+(defn- cascade-bundle
+  "Project the events for one cascade into a Spec 009 cascade-bundle
+  (the `group-cascades` shape, per-cascade)."
+  [frame-id dispatch-id events]
+  (let [base {:dispatch-id  dispatch-id
+              :frame        frame-id
+              :trace-events events
+              :event        nil
+              :dispatched   nil
+              :handler      nil
+              :fx           nil
+              :effects      []
+              :subs         []
+              :renders      []
+              :other        []
+              :parent-dispatch-id nil}]
+    (reduce (fn [acc ev]
+              (cond
+                (dispatched-marker? ev)
+                (assoc acc
+                       :event              (get-in ev [:tags :rf.event/v])
+                       :dispatched         ev
+                       :parent-dispatch-id (get-in ev [:tags :rf.trace/parent-dispatch-id]))
+
+                (handler-marker? ev) (assoc acc :handler ev)
+                (fx-marker? ev)      (assoc acc :fx ev)
+                (effects-bucket? ev) (update acc :effects conj ev)
+                (subs-bucket? ev)    (update acc :subs conj ev)
+                (renders-bucket? ev) (update acc :renders conj ev)
+                :else                (update acc :other conj ev)))
+            base
+            events)))
+
+(defn- match-cascade?
+  "Filter a cascade bundle against the cascade-level filter keys."
+  [bundle {:keys [event-id origin dispatch-id since-ms between pred]}]
+  (let [[t0 t1] (when (and (sequential? between)
+                           (= 2 (count between)))
+                  between)
+        events  (:trace-events bundle)
+        ;; A cascade's "time" is its earliest event's time (where present)
+        first-time (some :time events)]
+    (and (or (nil? event-id)
+             (= event-id (first (:event bundle))))
+         (or (nil? origin)
+             (when-let [d (:dispatched bundle)]
+               (= origin (get-in d [:tags :rf.event/origin]))))
+         (or (nil? dispatch-id)
+             (= dispatch-id (:dispatch-id bundle)))
+         (or (nil? since-ms)
+             (and (number? first-time) (> first-time since-ms)))
+         (or (nil? t0)
+             (and (number? first-time)
+                  (<= t0 first-time t1)))
+         (or (nil? pred) (pred bundle)))))
+
+(defn- match-event?
+  "Filter a raw trace event against the event-level filter keys."
+  [ev {:keys [operation op-type since severity event-id handler-id source
+              origin dispatch-id since-ms between sensitive? pred]
+       :as opts}]
+  (let [rf-dispatch-origin (:rf/dispatch-origin opts)
+        [t0 t1] (when (and (sequential? between)
+                           (= 2 (count between)))
+                  between)]
+    (and (or (nil? operation) (= operation (:operation ev)))
+         (or (nil? op-type)   (= op-type   (:op-type ev)))
+         (or (nil? since)     (and (number? (:id ev)) (> (:id ev) since)))
+         (or (nil? severity)  (= severity (:op-type ev)))
+         (or (nil? event-id)
+             (= event-id (get-in ev [:tags :rf.trace/event-id])))
+         (or (nil? handler-id)
+             (= handler-id (get-in ev [:tags :handler-id])))
+         (or (nil? source)
+             (= source (or (:source ev)
+                           (get-in ev [:tags :source]))))
+         (or (nil? origin)
+             (= origin (get-in ev [:tags :rf.event/origin])))
+         (or (nil? rf-dispatch-origin)
+             (= rf-dispatch-origin
+                (get-in ev [:tags :rf/dispatch-origin])))
+         (or (nil? dispatch-id)
+             (= dispatch-id (get-in ev [:tags :rf.trace/dispatch-id])))
+         (or (nil? since-ms)
+             (and (number? (:time ev)) (> (:time ev) since-ms)))
+         (or (nil? t0)
+             (and (number? (:time ev)) (<= t0 (:time ev) t1)))
+         (or (nil? sensitive?)
+             (= (true? sensitive?) (true? (:sensitive? ev))))
+         (or (nil? pred) (pred ev)))))
+
+(defn- frame-ring-cascades
+  "Materialise `frame-id`'s ring as an oldest-first vector of cascade
+  bundles. Returns an empty vector when the frame has no recorded
+  cascades (including the destroyed-frame / unknown-frame case per
+  Spec 009 §Reads against a destroyed / missing frame)."
+  [rings frame-id]
+  (if-let [ring (get rings frame-id)]
+    (let [order    (:cascade-order ring)
+          cascades (:cascades ring)]
+      (mapv (fn [dispatch-id]
+              (cascade-bundle frame-id dispatch-id (get cascades dispatch-id)))
+            order))
+    []))
+
+(defn- frame-ring-flat-events
+  "Materialise `frame-id`'s ring as an oldest-first vector of raw trace
+  events (the `:flat true` opt-in shape)."
+  [rings frame-id]
+  (if-let [ring (get rings frame-id)]
+    (let [order    (:cascade-order ring)
+          cascades (:cascades ring)]
+      (into [] (mapcat (fn [did] (get cascades did))) order))
+    []))
 
 (defn trace-buffer
-  "Return the trace ring buffer's current contents, oldest first.
+  "Per-frame trace ring reader. Returns the named frame's retained
+  cascades, oldest-first.
 
-  With opts, filters the result. Recognised keys (all compose AND-wise;
-  an absent key means \"no constraint on that axis\"):
+  Two arities:
+    (trace-buffer frame-id)        — cascade bundles (default)
+    (trace-buffer frame-id opts)   — opts filter map
 
-    :operation     — keep only events with this :operation value.
-    :op-type       — keep only events with this :op-type value.
-    :since         — keep only events whose :id is strictly greater than
-                     this. Useful for cursor-based polling.
-    :frame         — keep only events whose `:tags :frame` (or top-level
-                     :frame fallback) matches.
-    :severity      — keep only events whose :op-type matches one of
-                     `:error` / `:warning` / `:info`. Synonym for
-                     `:op-type` restricted to the three severity tiers.
-    :event-id      — keep only events whose `:tags :event-id` matches.
-                     The event-id is the first element of the dispatched
-                     event vector (e.g. `:user/login`).
-    :handler-id    — keep only events whose `:tags :handler-id` matches.
-                     Carried on `:rf.error/handler-exception` and other
-                     handler-scoped emits.
-    :source        — keep only events whose :source (top-level, hoisted
-                     from `:tags :source` by `emit!`) matches. Source
-                     identifies the trigger origin — one of `:ui` /
-                     `:timer` / `:http` / `:repl` / `:machine` /
-                     `:ssr-hydration`. Matched against the top-level slot.
-    :origin        — keep only events whose `:tags :origin` matches.
-                     Origin tags the actor that issued the dispatch
-                     (`:app` / `:pair` / `:story` / `:test` / ...) per
-                     Spec 002 §Dispatch origin tagging.
-    :rf/dispatch-origin — keep only events whose `:tags :rf/dispatch-origin`
-                     matches the closed-enum value (one of `:user`,
-                     `:router`, `:websocket`, `:http`, `:ssr`,
-                     `:fx-emit`, `:timer`, `:test-harness`, `:tool`,
-                     `:internal`) per Spec 009 §Dispatch-origin tagging
-                     (rf2-t1lxr). Distinct from `:origin` (actor identity)
-                     and `:source` (trigger kind).
-    :dispatch-id   — keep only events whose `:tags :dispatch-id` matches.
-                     Cascade-wide post rf2-g6ih4 — every emit inside a
-                     drain carries the in-flight cascade's dispatch-id.
-    :since-ms      — keep only events whose :time is strictly greater
-                     than this numeric host-clock timestamp.
-    :between       — `[t0 t1]` two-element vector — keep only events
-                     whose :time falls in [t0, t1] inclusive.
-    :sensitive?    — boolean. Match the top-level `:sensitive?` field
-                     (per Spec 009 §Privacy filter-vocab row, rf2-isdwf).
-                     Pass `false` to exclude sensitive events; pass
-                     `true` to select only sensitive events. Absent ⇒
-                     no constraint.
-    :pred          — `(fn [ev] -> truthy)` arbitrary predicate. Receives
-                     the full event map. Returning truthy keeps the event.
+  Cascade-bundle shape:
+    {:dispatch-id <id>
+     :frame       <frame-id>
+     :trace-events [<ev> ...]
+     :event       <event-vector or nil>
+     :dispatched  <:rf.event/dispatched event or nil>
+     :handler     <:rf.event/run-end event or nil>
+     :fx          <:rf.fx/do-fx event or nil>
+     :effects     [...]
+     :subs        [...]
+     :renders     [...]
+     :other       [...]
+     :parent-dispatch-id <causal-parent-id or nil>}
 
-  Filters compose: every supplied key must match. Returns an empty vector
-  in production (the buffer never receives events when interop/debug-enabled?
-  is false at compile time).
+  Opt keys recognised (per Spec 009 §Filter vocabulary):
+    :flat true      — return raw trace events (oldest-first) instead
+                      of cascade bundles. The escape hatch for callers
+                      with pre-existing flat-stream code.
+    :operation      — (:flat-only) exact :operation match
+    :op-type        — (:flat-only) exact :op-type match
+    :since          — (:flat-only) :id strictly greater than this
+    :severity       — (:flat-only) :op-type ∈ #{:error :warning :info}
+    :handler-id     — (:flat-only) :tags :handler-id match
+    :source         — (:flat-only) :source match
+    :sensitive?     — (:flat-only) :sensitive? match
+    :rf/dispatch-origin — (:flat-only) :tags :rf/dispatch-origin match
+    :event-id       — cascade :event first-element OR (:flat) :tags :rf.trace/event-id
+    :origin         — cascade root :rf.event/origin OR (:flat) per-event
+    :dispatch-id    — cascade :dispatch-id OR (:flat) per-event
+    :since-ms       — cascade earliest-time OR (:flat) per-event :time
+    :between [t0 t1]— same axis, window
+    :pred           — arbitrary predicate, receives bundle or event
 
-  Per Spec 009 §Retain-N trace ring buffer."
-  ([] (trace-buffer {}))
-  ([opts]
+  Returns `[]` for a destroyed / never-registered frame (per Spec 009
+  §Reads against a destroyed / missing frame) and `[]` in production
+  (the ring is never allocated under `goog.DEBUG=false`).
+
+  Per Spec 009 §`trace-buffer` API."
+  ([frame-id] (trace-buffer frame-id {}))
+  ([frame-id opts]
    (if-not interop/debug-enabled?
      []
-     (let [{:keys [operation op-type since frame
-                   severity event-id handler-id source origin
-                   dispatch-id since-ms between pred]} opts
-           sensitive-filter (:sensitive? opts)
-           ;; Per rf2-t1lxr: the closed-enum functional-source filter axis.
-           ;; Read directly via the namespaced key — `:keys` destructuring
-           ;; doesn't accept namespaced keys without `:as`-binding bulk so
-           ;; we lift it explicitly.
-           rf-dispatch-origin (:rf/dispatch-origin opts)
-           [between-t0 between-t1] (when (and (sequential? between)
-                                              (= 2 (count between)))
-                                     between)
-           predicate
-           (fn [ev]
-             (and (or (nil? operation) (= operation (:operation ev)))
-                  (or (nil? op-type)   (= op-type   (:op-type ev)))
-                  (or (nil? since)     (and (number? (:id ev))
-                                            (> (:id ev) since)))
-                  (or (nil? frame)
-                      (= frame (or (:frame ev)
-                                   (get-in ev [:tags :frame]))))
-                  (or (nil? severity) (= severity (:op-type ev)))
-                  (or (nil? event-id)
-                      (= event-id (get-in ev [:tags :rf.trace/event-id])))
-                  (or (nil? handler-id)
-                      (= handler-id (get-in ev [:tags :handler-id])))
-                  (or (nil? source)
-                      (= source (or (:source ev)
-                                    (get-in ev [:tags :source]))))
-                  (or (nil? origin)
-                      (= origin (get-in ev [:tags :rf.event/origin])))
-                  (or (nil? rf-dispatch-origin)
-                      (= rf-dispatch-origin
-                         (get-in ev [:tags :rf/dispatch-origin])))
-                  (or (nil? dispatch-id)
-                      (= dispatch-id (get-in ev [:tags :rf.trace/dispatch-id])))
-                  (or (nil? since-ms)
-                      (and (number? (:time ev))
-                           (> (:time ev) since-ms)))
-                  (or (nil? between-t0)
-                      (and (number? (:time ev))
-                           (<= between-t0 (:time ev) between-t1)))
-                  ;; Top-level `:sensitive?` is hoisted (NOT nested
-                  ;; under `:tags`). Match against the top-level slot
-                  ;; only; absent reads as false.
-                  (or (nil? sensitive-filter)
-                      (= (true? sensitive-filter)
-                         (true? (:sensitive? ev))))
-                  (or (nil? pred) (pred ev))))]
-       (filterv predicate @trace-buffer-state)))))
+     (let [rings @trace-rings]
+       (if (:flat opts)
+         (filterv #(match-event? % opts) (frame-ring-flat-events rings frame-id))
+         (filterv #(match-cascade? % opts) (frame-ring-cascades rings frame-id)))))))
 
 (defn clear-trace-buffer!
-  "Empty the ring buffer. Tooling uses this between sessions. No-op in
-  production. Per Spec 009 §Retain-N trace ring buffer."
+  "Empty the named frame's cascade-keyed ring. Tooling uses this between
+  sessions. No-op for an unknown frame, no-op in production. Per Spec
+  009 §`trace-buffer` API."
+  [frame-id]
+  (when interop/debug-enabled?
+    (swap! trace-rings
+           (fn [rings]
+             (if (contains? rings frame-id)
+               (let [retained (effective-retained rings frame-id)]
+                 (assoc rings frame-id (empty-ring retained)))
+               rings))))
+  nil)
+
+(defn clear-trace-rings!
+  "Drop EVERY frame's ring + reset the process-default
+  cascades-retained back to its initial value + clear the B4 dedup
+  table. Test-fixture / `clear-all!`-shaped helper — symmetric with
+  the listener registry's `clear-listeners!`. Production no-op."
   []
   (when interop/debug-enabled?
-    (reset! trace-buffer-state []))
+    (reset! trace-rings {})
+    (reset! process-cascades-retained default-cascades-retained)
+    (clear-dedup-table!))
   nil)
 
 (defn configure-trace-buffer!
-  "Set the ring buffer's depth. depth=0 disables the buffer (the delivery
-  path still works). The new depth applies on the next append; existing
-  entries are trimmed to fit immediately. No-op in production.
+  "Apply a process-default ring depth. Per Spec 009 §Retention contract:
 
-  Per Spec 009 §Retain-N trace ring buffer."
-  [{:keys [depth]}]
-  (when (and interop/debug-enabled? (number? depth) (not (neg? depth)))
-    (reset! buffer-depth depth)
-    (swap! trace-buffer-state
-           (fn [v]
-             (let [n (count v)]
-               (cond
-                 (zero? depth) []
-                 (> n depth)   (subvec v (- n depth))
-                 :else         v)))))
+      (configure :trace-buffer {:cascades-retained N})
+
+  Sets the per-process default that applies to `:rf/default` and to
+  every frame that did not set its own `:rf.trace/cascades-retained`
+  metadata. Frames with explicit per-frame metadata are NOT overridden.
+
+  When `:cascades-retained 0`, the ring is disabled but the surface
+  remains live. Per Spec 009 §Cascades-retained-zero semantics.
+
+  No-op in production. Returns nil."
+  [{:keys [cascades-retained]}]
+  (when (and interop/debug-enabled?
+             (number? cascades-retained)
+             (not (neg? cascades-retained)))
+    (reset! process-cascades-retained cascades-retained)
+    ;; Apply the new default to any frame whose ring did not set its own
+    ;; per-frame retention — those frames inherit the default.
+    (swap! trace-rings
+           (fn [rings]
+             (reduce-kv
+              (fn [acc frame-id ring]
+                (let [own-set? (some? (get-in rings [frame-id :cascades-retained]))]
+                  (if own-set?
+                    acc
+                    (let [order   (:cascade-order ring)
+                          cascades (:cascades ring)]
+                      (cond
+                        (zero? cascades-retained)
+                        (assoc acc frame-id (empty-ring 0))
+
+                        (> (count order) cascades-retained)
+                        (let [drop-n     (- (count order) cascades-retained)
+                              kept-order (subvec order drop-n)
+                              evicted    (subvec order 0 drop-n)]
+                          (assoc acc frame-id
+                                 {:cascades-retained cascades-retained
+                                  :cascade-order     kept-order
+                                  :cascades          (apply dissoc cascades evicted)}))
+
+                        :else
+                        (assoc-in acc [frame-id :cascades-retained] cascades-retained))))))
+              rings
+              rings))))
   nil)
 
 (defn configure
   "Generic config dispatch. Recognises :trace-buffer; future config knobs
-  add cases here. Per Spec 009 §Retain-N trace ring buffer
-  (`(rf/configure :trace-buffer {:depth N})`)."
+  add cases here. Per Spec 009 §Per-frame trace rings
+  (`(rf/configure :trace-buffer {:cascades-retained N})`)."
   [k opts]
   (case k
     :trace-buffer (configure-trace-buffer! opts)
@@ -239,17 +620,17 @@
 ;;
 ;; `re-frame.trace/deliver!` looks this up via late-bind and calls it
 ;; once per emitted event (after the epoch-capture fan-out). Centralising
-;; the buffer-push + listener fan-out in one hook keeps trace.cljc free
-;; of any reference to the buffer state or listener atom — so a
+;; the ring-push + listener fan-out in one hook keeps trace.cljc free
+;; of any reference to the rings state or listener atom — so a
 ;; production build that never `:requires` this ns DCEs the whole body.
 
 (defn- deliver-to-tooling!
-  "Push `event` onto the ring buffer (if depth > 0) and fan it out to
-  every registered listener. Listener throws are isolated. No-op in
-  production (interop/debug-enabled? gate inside push-to-buffer! and at
-  the emit call site)."
+  "Push `event` onto its in-flight frame's cascade-keyed ring (when the
+  cascade has a `:dispatch-id` and a `:frame`; frameless emits skip the
+  ring per the B3 ruling), then fan out to every registered listener.
+  Listener throws are isolated. No-op in production."
   [event]
-  (push-to-buffer! event)
+  (push-to-ring! event)
   (doseq [[_ f] @listeners]
     (try
       (f event)
@@ -260,7 +641,7 @@
 ;; `re-frame.core/configure :trace-buffer` routes through this hook so
 ;; consumer call sites don't have to thread the tooling-ns require
 ;; into the host's boot path. Keeping just THIS one knob hook (vs the
-;; full set the listener / buffer surface uses) is deliberate: the
+;; full set the listener / ring surface uses) is deliberate: the
 ;; per-fn hooks would each pay a keyword-intern cost in every
 ;; consumer of `re-frame.core`, even when the wrappers' bodies were
 ;; dead code (the keyword constructor runs at module init).
@@ -276,12 +657,20 @@
 ;; category. The listener-install must run only when the tooling sibling
 ;; is loaded (otherwise the trace fan-out is dead anyway and there's
 ;; nothing to observe), so we route through late-bind here — identical
-;; pattern to `:trace.tooling/deliver!` above. CLJS production builds
-;; that never load this ns short-circuit the install (the lookup
-;; returns nil and `fire-on-destroy-event!` skips the listener dance).
+;; pattern to `:trace.tooling/deliver!` above.
 
-(late-bind/set-fn! :trace.tooling/register-listener! register-listener!)
-(late-bind/set-fn! :trace.tooling/unregister-listener!   unregister-listener!)
+(late-bind/set-fn! :trace.tooling/register-listener!   register-listener!)
+(late-bind/set-fn! :trace.tooling/unregister-listener! unregister-listener!)
+
+;; Per rf2-g1b2m / rf2-8uwce — published hooks for B4 dedup-by-shape
+;; (consulted by the registrar at emit time) and frame-destroy ring
+;; cleanup (consulted by `destroy-frame!` per Spec 002 §Destroy).
+
+(late-bind/set-fn! :trace.tooling/dedup-allow?        dedup-allow?)
+(late-bind/set-fn! :trace.tooling/clear-dedup-table!  clear-dedup-table!)
+(late-bind/set-fn! :trace.tooling/release-frame-ring! release-frame-ring!)
+(late-bind/set-fn! :trace.tooling/set-frame-cascades-retained!
+                   set-frame-cascades-retained!)
 
 ;; ---- bundle-isolation sentinel ------------------------------------------
 ;;

--- a/implementation/core/test/re_frame/configure_test.clj
+++ b/implementation/core/test/re_frame/configure_test.clj
@@ -7,14 +7,20 @@
 
     :epoch-history  — Tool-Pair epoch ring depth (deferred to the
                        day8/re-frame2-epoch artefact via late-bind)
-    :trace-buffer   — retain-N trace ring buffer depth (Spec 009)
+    :trace-buffer   — per-frame cascade-keyed trace ring depth — sets
+                       the process-default `:cascades-retained` that
+                       applies to `:rf/default` and any frame that did
+                       not set its own `:rf.trace/cascades-retained`
+                       metadata (Spec 009 §Per-frame trace rings;
+                       rf2-g1b2m)
     :sub-cache      — sub-cache deferred-disposal grace period (Spec 006)
     :elision        — wire-elision runtime size threshold (Spec 009)
 
   This test pins the keys that ARE configurable and asserts that
   everything else is a silent no-op — `configure` returns `nil` and
-  does not throw. Per-frame settings (e.g. SSR error projection) live
-  on the frame's metadata, not on this surface."
+  does not throw. Per-frame settings (e.g. SSR error projection,
+  `:rf.trace/cascades-retained`) live on the frame's metadata, not on
+  this surface."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
@@ -24,6 +30,7 @@
             [re-frame.subs.cache :as subs-cache]
             [re-frame.elision :as elision]
             [re-frame.trace :as trace]
+            [re-frame.trace.tooling :as trace-tooling]
             [re-frame.substrate.plain-atom :as plain-atom]))
 
 (defn reset-runtime [test-fn]
@@ -32,24 +39,24 @@
   (reset! flows/flows {})
   (reset! schemas/schemas-by-frame {})
   (trace/clear-listeners!)
-  (rf/clear-trace-buffer!)
+  (trace-tooling/clear-trace-rings!)
   (rf/init! plain-atom/adapter)
   (try (test-fn)
        (finally
          ;; Restore defaults so we do not leak tweaks into other suites.
-         (rf/configure :trace-buffer {:depth 200})
+         (rf/configure :trace-buffer {:cascades-retained 50})
          (subs-cache/configure! {:grace-period-ms 50})
          (rf/configure :elision {:rf.size/threshold-bytes 16384}))))
 
 (use-fixtures :each reset-runtime)
 
 (deftest configure-known-keys-take-effect
-  (testing ":trace-buffer is wired"
-    (rf/configure :trace-buffer {:depth 7})
+  (testing ":trace-buffer cascades-retained is wired"
+    (rf/configure :trace-buffer {:cascades-retained 7})
     (rf/reg-event-db :ping (fn [db _] db))
     (dotimes [_ 20] (rf/dispatch-sync [:ping]))
-    (is (<= (count (rf/trace-buffer)) 7)
-        ":trace-buffer {:depth 7} caps retained events at 7"))
+    (is (<= (count (rf/trace-buffer :rf/default)) 7)
+        ":trace-buffer {:cascades-retained 7} caps retained cascades at 7"))
   (testing ":sub-cache is wired"
     (rf/configure :sub-cache {:grace-period-ms 123})
     (is (= 123 (:grace-period-ms (subs-cache/current-config)))
@@ -74,14 +81,14 @@
   (testing "an unknown key does not perturb the known-key state"
     ;; Set known keys to non-default values, then attempt unknown keys,
     ;; then assert known-key state is unchanged.
-    (rf/configure :trace-buffer {:depth 11})
+    (rf/configure :trace-buffer {:cascades-retained 11})
     (rf/configure :sub-cache    {:grace-period-ms 71})
     (rf/configure :strict-subs  true)
     (rf/configure :ssr          {:public-error-id :nope})
     (rf/configure :no-such-key  {})
     (rf/reg-event-db :ping (fn [db _] db))
     (dotimes [_ 30] (rf/dispatch-sync [:ping]))
-    (is (<= (count (rf/trace-buffer)) 11)
-        ":trace-buffer depth survived bracketing unknown-key calls")
+    (is (<= (count (rf/trace-buffer :rf/default)) 11)
+        ":trace-buffer cascades-retained survived bracketing unknown-key calls")
     (is (= 71 (:grace-period-ms (subs-cache/current-config)))
         ":sub-cache grace-period survived bracketing unknown-key calls")))

--- a/implementation/core/test/re_frame/elision_probe.cljs
+++ b/implementation/core/test/re_frame/elision_probe.cljs
@@ -59,12 +59,12 @@
   (trace-tooling/register-listener! ::probe (fn [_ev] nil))
   (rf/emit-trace-event! :event :rf.probe/touched {:source :probe})
   (trace-tooling/unregister-listener! ::probe)
-  ;; rf2-smee — trace ring buffer (Spec 009 §Retain-N).  These public
-  ;; entry points must elide their bodies in production.
-  (trace-tooling/configure-trace-buffer! {:depth 50})
-  (let [_buf (trace-tooling/trace-buffer {:op-type :event})]
+  ;; rf2-g1b2m / rf2-8uwce — per-frame cascade-keyed trace rings (Spec 009).
+  ;; These public entry points must elide their bodies in production.
+  (trace-tooling/configure-trace-buffer! {:cascades-retained 50})
+  (let [_buf (trace-tooling/trace-buffer :rf/default {:op-type :rf.event :flat true})]
     nil)
-  (trace-tooling/clear-trace-buffer!))
+  (trace-tooling/clear-trace-buffer! :rf/default))
 
 ;; ---- schemas surface ------------------------------------------------------
 

--- a/implementation/core/test/re_frame/jvm_prod_gate_integration_test.clj
+++ b/implementation/core/test/re_frame/jvm_prod_gate_integration_test.clj
@@ -32,7 +32,7 @@
       (rf/reg-event-db :prod-gate/inc
                        (fn [db _] (update db :n (fnil inc 0))))
       (rf/dispatch-sync [:prod-gate/inc])
-      (is (empty? (trace/trace-buffer))
+      (is (empty? (trace/trace-buffer :rf/default))
           "trace buffer is empty under disabled gate — no event
            landed despite dispatch firing"))))
 

--- a/implementation/core/test/re_frame/sensitive_stamping_test.clj
+++ b/implementation/core/test/re_frame/sensitive_stamping_test.clj
@@ -124,8 +124,8 @@
             top-level `:sensitive?` field. Now that the handler-meta
             annotation has been removed, the stamp is schema-derived
             only: a sensitive app-schema slot drives it."
-  (rf/clear-trace-buffer!)
-  (rf/configure :trace-buffer {:depth 100})
+  (rf/clear-trace-buffer! :rf/default)
+  (rf/configure :trace-buffer {:cascades-retained 100})
   (rf/reg-app-schema [:auth]
                      [:map [:password {:sensitive? true} :string]])
   (rf/reg-event-db :sensitive/buf
@@ -135,9 +135,9 @@
                    (fn [db _] db))
   (rf/dispatch-sync [:sensitive/buf {:password "x"}])
   (rf/dispatch-sync [:plain/buf])
-  (let [all   (rf/trace-buffer)
-        sens  (rf/trace-buffer {:sensitive? true})
-        plain (rf/trace-buffer {:sensitive? false})]
+  (let [all   (rf/trace-buffer :rf/default {:flat true})
+        sens  (rf/trace-buffer :rf/default {:flat true :sensitive? true})
+        plain (rf/trace-buffer :rf/default {:flat true :sensitive? false})]
     (is (pos? (count sens)) "schema-driven sensitive events present in the buffer")
     (is (pos? (count plain)))
     (is (= (count all) (+ (count sens) (count plain))))

--- a/implementation/core/test/re_frame/trace_buffer_test.clj
+++ b/implementation/core/test/re_frame/trace_buffer_test.clj
@@ -1,17 +1,16 @@
 (ns re-frame.trace-buffer-test
-  "Spec 009 §Retain-N trace ring buffer + §Dispatch correlation, plus
-  Spec 002 §Dispatch origin tagging.
+  "Per-frame cascade-keyed trace ring tests (rf2-g1b2m spec + rf2-8uwce
+  impl).
 
-  rf2-smee — three deliverables in one suite:
-    1. Trace ring buffer: append, filter, depth/eviction, clear, elision.
-    2. :rf.trace/dispatch-id allocation + :rf.trace/parent-dispatch-id linkage (top-level
-       dispatches have no parent; dispatches issued from within an fx
-       handler inherit the in-flight event's :rf.trace/dispatch-id).
-    3. :origin opt: defaults to :app, opt overrides to anything else,
-       lands on the :rf.event/dispatched trace under :tags :origin.
+  Three deliverables in one suite:
+    1. Per-frame ring: cascade-bundle reads, `:flat` opt, eviction by
+       cascade, filter vocab, configure knob, clear, elision.
+    2. `:rf.trace/dispatch-id` allocation + parent-dispatch-id linkage.
+    3. `:origin` / `:rf/dispatch-origin` opts ride trace events.
 
-  JVM-only by intent — the trace + router machinery is platform-agnostic
-  and CLJS adds no signal."
+  Per Spec 009 §Per-frame trace rings (cascade-keyed, dev-only) and
+  §Dispatch correlation. JVM-only by intent — the trace + router
+  machinery is platform-agnostic and CLJS adds no signal."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
@@ -20,10 +19,7 @@
             [re-frame.flows :as flows]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.trace :as trace]
-            ;; rf2-qwm0a — load the tooling sibling so the late-bind
-            ;; hooks behind `trace/clear-listeners!` / `rf/trace-buffer`
-            ;; / `rf/configure :trace-buffer` / etc. are registered.
-            [re-frame.trace.tooling]))
+            [re-frame.trace.tooling :as trace-tooling]))
 
 ;; ---- fixtures --------------------------------------------------------------
 
@@ -33,551 +29,546 @@
   (reset! flows/flows {})
   (reset! schemas/schemas-by-frame {})
   (trace/clear-listeners!)
-  (rf/clear-trace-buffer!)
-  ;; rf2-2qaqh — the frame-level trace-emission gate (the trace-disabled
-  ;; frame set) is process-sticky and is NOT unwound by `reset! frames`,
-  ;; so clear it between tests to avoid a tool-frame flag bleeding forward.
+  (trace-tooling/clear-trace-rings!)
   (trace/clear-frame-no-emit!)
-  ;; Restore default depth between tests so a depth-tweaking test does
-  ;; not bleed configuration into the next.
-  (rf/configure :trace-buffer {:depth 200})
+  ;; Restore default cascades-retained between tests so a depth-tweaking
+  ;; test does not bleed configuration into the next.
+  (rf/configure :trace-buffer {:cascades-retained 50})
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
   (test-fn))
 
 (use-fixtures :each reset-runtime)
 
-;; ---- helpers ---------------------------------------------------------------
+;; ---- helpers --------------------------------------------------------------
+
+(defn- flat-events
+  "Per-frame raw trace events for the named frame, oldest-first."
+  ([frame-id] (rf/trace-buffer frame-id {:flat true}))
+  ([frame-id opts] (rf/trace-buffer frame-id (assoc opts :flat true))))
 
 (defn- dispatched-events
-  "Return only the :event :rf.event/dispatched events from a buffer/coll."
+  "Filter raw events down to `:rf.event/dispatched` only."
   [evs]
   (filterv #(and (= :rf.event (:op-type %))
                  (= :rf.event/dispatched (:operation %)))
            evs))
 
-;; ---- 1. Ring buffer --------------------------------------------------------
+;; ---- 1. Per-frame ring -----------------------------------------------------
 
-(deftest trace-buffer-appends-events
-  (testing "every emit! lands in the ring buffer"
+(deftest trace-buffer-appends-events-as-cascades
+  (testing "every emit lands in its frame's ring, grouped by :dispatch-id"
     (rf/reg-event-db :ping (fn [db _] (assoc db :seen? true)))
     (rf/dispatch-sync [:ping])
-    (let [buf (rf/trace-buffer)]
-      (is (vector? buf) "trace-buffer returns a vector")
-      (is (seq buf) "buffer has entries after a dispatch")
-      ;; The :rf.event/dispatched envelope is the most reliable signal.
-      (is (some #(= :rf.event/dispatched (:operation %)) buf)
-          "the :rf.event/dispatched trace lands in the buffer"))))
+    (let [cascades (rf/trace-buffer :rf/default)]
+      (is (vector? cascades) "trace-buffer returns a vector")
+      (is (seq cascades) "ring has at least one cascade after a dispatch")
+      (let [c (first cascades)]
+        (is (number? (:dispatch-id c)) "cascade carries its :dispatch-id")
+        (is (= :rf/default (:frame c)) "cascade carries the frame-id")
+        (is (= [:ping] (:event c)) "cascade carries the event vector")
+        (is (vector? (:trace-events c)) "cascade carries the raw events")
+        (is (seq (:trace-events c)) "trace-events is non-empty")
+        (is (some? (:dispatched c)) "cascade carries the :rf.event/dispatched event")))))
 
-(deftest trace-buffer-filters
-  (testing "filter by :operation, :op-type, :since, :frame compose"
+(deftest trace-buffer-flat-returns-raw-events
+  (testing "{:flat true} returns the raw event stream"
     (rf/reg-event-db :ping (fn [db _] db))
     (rf/dispatch-sync [:ping])
-    (rf/dispatch-sync [:ping])
-    (let [all       (rf/trace-buffer)
-          dispatched (rf/trace-buffer {:operation :rf.event/dispatched})]
-      (is (seq dispatched))
-      (is (every? #(= :rf.event/dispatched (:operation %)) dispatched)
-          ":operation filter narrows to one operation")
-      (is (<= (count dispatched) (count all)))
-      (let [event-only (rf/trace-buffer {:op-type :rf.event})]
-        (is (every? #(= :rf.event (:op-type %)) event-only)
-            ":op-type filter narrows to the discriminator")))
-    (testing ":since filters strictly greater than the given id"
-      (let [pre-id (-> (rf/trace-buffer) last :id)]
-        (rf/dispatch-sync [:ping])
-        (let [after (rf/trace-buffer {:since pre-id})]
-          (is (seq after))
-          (is (every? #(> (:id %) pre-id) after)))))
-    (testing ":frame filter matches via :tags :frame"
-      ;; Both default-frame and a named frame produce events; the named
-      ;; frame's events should be the only match.
-      (rf/reg-frame :tb/scope {:doc "scoped frame"})
-      (rf/clear-trace-buffer!)
-      (rf/reg-event-db :scoped (fn [db _] db))
-      (rf/dispatch-sync [:scoped] {:frame :tb/scope})
-      (rf/dispatch-sync [:ping])
-      (let [scoped (rf/trace-buffer {:frame :tb/scope})]
-        (is (seq scoped))
-        (is (every? #(= :tb/scope
-                        (or (:frame %) (get-in % [:tags :frame])))
-                    scoped))))
-    (testing "filters compose"
-      (let [combo (rf/trace-buffer {:operation :rf.event/dispatched
-                                    :op-type   :rf.event})]
-        (is (every? #(and (= :rf.event/dispatched (:operation %))
-                          (= :rf.event (:op-type %)))
-                    combo))))))
-
-(deftest trace-buffer-respects-depth
-  (testing "configure :trace-buffer {:depth N} caps the slot count"
-    (rf/configure :trace-buffer {:depth 5})
-    (rf/reg-event-db :spam (fn [db _] db))
-    (dotimes [_ 30] (rf/dispatch-sync [:spam]))
-    (let [buf (rf/trace-buffer)]
-      (is (<= (count buf) 5)
-          (str "buffer should not exceed configured depth; got " (count buf)))
-      (is (pos? (count buf))
-          "buffer should still have the most recent slots populated")))
-  (testing "depth=0 disables the buffer"
-    (rf/configure :trace-buffer {:depth 0})
-    (rf/clear-trace-buffer!)
-    (rf/reg-event-db :spam (fn [db _] db))
-    (dotimes [_ 5] (rf/dispatch-sync [:spam]))
-    (is (= [] (rf/trace-buffer))
-        "with depth 0, no events accumulate")))
-
-(deftest trace-buffer-clear
-  (testing "clear-trace-buffer! empties the buffer"
-    (rf/reg-event-db :ping (fn [db _] db))
-    (rf/dispatch-sync [:ping])
-    (is (seq (rf/trace-buffer)))
-    (rf/clear-trace-buffer!)
-    (is (= [] (rf/trace-buffer)))))
-
-(deftest trace-buffer-rides-debug-flag
-  (testing "the buffer machinery is wrapped in interop/debug-enabled?"
-    ;; This is a structural check rather than a runtime simulation: the
-    ;; production-elision contract is that no buffer state mutates when
-    ;; the flag is false at compile time. We assert the source contains
-    ;; the gate at the right call sites; combined with the existing
-    ;; trace-test envelope coverage, this protects the elision contract.
-    ;;
-    ;; Per rf2-qwm0a the buffer + filter-predicate body live in
-    ;; re-frame.trace.tooling (the sibling ns split off so production
-    ;; counter bundles DCE them); the `re-frame.trace/trace-buffer` etc.
-    ;; wrappers delegate through late-bind hooks and return [] when the
-    ;; tooling ns is absent. The gate check lives in the tooling source.
-    (let [src (slurp "src/re_frame/trace/tooling.cljc")]
-      (is (re-find #"\(defn-? push-to-buffer![\s\S]*?interop/debug-enabled\?" src)
-          "push-to-buffer! is gated on interop/debug-enabled?")
-      (is (re-find #"\(defn-? trace-buffer[\s\S]*?interop/debug-enabled\?" src)
-          "trace-buffer reader returns [] under the same gate")
-      (is (re-find #"\(defn-? clear-trace-buffer![\s\S]*?interop/debug-enabled\?" src)
-          "clear-trace-buffer! is gated")
-      (is (re-find #"\(defn-? configure-trace-buffer![\s\S]*?interop/debug-enabled\?" src)
-          "configure-trace-buffer! is gated"))))
-
-;; ---- 2. :rf.trace/dispatch-id correlation -------------------------------------------
-
-(deftest dispatch-id-allocated-on-every-dispatch
-  (testing "every :rf.event/dispatched trace carries a numeric :rf.trace/dispatch-id under :tags"
-    (rf/reg-event-db :ping (fn [db _] db))
-    (rf/dispatch-sync [:ping])
-    (rf/dispatch-sync [:ping])
-    (let [evs (dispatched-events (rf/trace-buffer))
-          ids (map #(get-in % [:tags :rf.trace/dispatch-id]) evs)]
+    (let [evs (flat-events :rf/default)]
+      (is (vector? evs))
       (is (seq evs))
-      (is (every? some? ids)
-          "every :rf.event/dispatched has a :rf.trace/dispatch-id")
-      (is (every? number? ids)
-          ":rf.trace/dispatch-id values are numeric (counter-shaped)")
-      (is (= (count (distinct ids)) (count ids))
-          ":rf.trace/dispatch-id values are unique within a process"))))
+      (is (some #(= :rf.event/dispatched (:operation %)) evs)
+          "the :rf.event/dispatched trace lands in the flat stream"))))
 
-(deftest top-level-dispatch-has-no-parent
-  (testing "a dispatch issued from outside any in-flight event has no :rf.trace/parent-dispatch-id"
-    (rf/reg-event-db :standalone (fn [db _] db))
-    (rf/dispatch-sync [:standalone])
-    (let [ev (->> (rf/trace-buffer)
-                  dispatched-events
-                  (filter #(= [:standalone] (get-in % [:tags :rf.event/v])))
-                  first)]
-      (is ev "the :rf.event/dispatched trace was emitted")
-      (is (nil? (get-in ev [:tags :rf.trace/parent-dispatch-id]))
-          "top-level dispatch has no :rf.trace/parent-dispatch-id"))))
+;; ---- 1b. Cascade-keyed eviction ------------------------------------------
 
-(deftest fx-dispatch-inherits-parent-dispatch-id
-  (testing "a dispatch issued from inside an event's fx walk inherits the parent's :rf.trace/dispatch-id"
-    (rf/reg-event-fx :outer (fn [_ _]
-                              {:fx [[:dispatch [:inner]]]}))
-    (rf/reg-event-db :inner (fn [db _] (assoc db :inner? true)))
-    (rf/dispatch-sync [:outer])
-    (let [evs   (dispatched-events (rf/trace-buffer))
-          outer (->> evs
-                     (filter #(= [:outer] (get-in % [:tags :rf.event/v])))
-                     first)
-          inner (->> evs
-                     (filter #(= [:inner] (get-in % [:tags :rf.event/v])))
-                     first)]
-      (is outer "outer :rf.event/dispatched present")
-      (is inner "inner :rf.event/dispatched present")
-      (is (number? (get-in outer [:tags :rf.trace/dispatch-id])))
-      (is (nil?    (get-in outer [:tags :rf.trace/parent-dispatch-id]))
-          "outer (top-level) has no parent")
-      (is (= (get-in outer [:tags :rf.trace/dispatch-id])
-             (get-in inner [:tags :rf.trace/parent-dispatch-id]))
-          "inner's :rf.trace/parent-dispatch-id == outer's :rf.trace/dispatch-id"))))
+(deftest cascade-keyed-eviction
+  (testing "ring evicts by CASCADE slot, not by raw event count"
+    (rf/configure :trace-buffer {:cascades-retained 3})
+    (rf/reg-event-db :ping (fn [db _] db))
+    (dotimes [_ 10] (rf/dispatch-sync [:ping]))
+    (let [cascades (rf/trace-buffer :rf/default)]
+      (is (= 3 (count cascades))
+          (str "ring caps at 3 cascade slots; got " (count cascades))))))
 
-;; ---- 1b. Extended filter vocabulary (rf2-97ah0) ----------------------------
+(deftest cascade-burst-cannot-evict-prior-cascades
+  (testing "a single cascade's burst of :rf.sub/skip-like noise can't displace OTHER cascades"
+    (rf/configure :trace-buffer {:cascades-retained 5})
+    (rf/reg-event-db :ping (fn [db _] db))
+    ;; Run 5 cascades; emit a small burst of synthetic events under
+    ;; cascade #3 (simulating a sub-skip flood inside one event).
+    (dotimes [_ 5] (rf/dispatch-sync [:ping]))
+    (let [cs        (rf/trace-buffer :rf/default)
+          target    (nth cs 2) ;; the middle one
+          target-id (:dispatch-id target)]
+      (binding [trace/*handler-scope*
+                (trace/->HandlerScope nil nil target-id false false)]
+        ;; Re-emit 200 trace events under the same in-flight cascade.
+        ;; This pushes 200 events into one slot — but the slot count
+        ;; stays at 5, so no other cascade is evicted.
+        (dotimes [_ 200]
+          (trace/emit! :rf.sub :rf.sub/skip
+                       {:rf.sub/id :foo :frame :rf/default})))
+      (let [cs-after (rf/trace-buffer :rf/default)]
+        (is (= 5 (count cs-after))
+            "still 5 cascades")
+        (is (some #(= target-id (:dispatch-id %)) cs-after)
+            "the targeted cascade is still present")
+        ;; The targeted cascade's :trace-events grew without bound.
+        (let [t (first (filter #(= target-id (:dispatch-id %)) cs-after))]
+          (is (> (count (:trace-events t)) 200)
+              "the cascade's events grew under the burst (cascade has no event-count cap)"))))))
+
+;; ---- 1c. Per-frame isolation ---------------------------------------------
+
+(deftest frame-isolation-cascade-bursts-dont-cross-rings
+  (testing "a burst of cascades in one frame cannot evict cascades in another"
+    (rf/configure :trace-buffer {:cascades-retained 3})
+    (rf/reg-frame :app/main {:doc "ordinary application frame"})
+    (rf/reg-event-db :work (fn [db _] db))
+    (rf/dispatch-sync [:work] {:frame :app/main})
+    (let [pre (rf/trace-buffer :app/main)]
+      (is (= 1 (count pre))
+          "single cascade in :app/main"))
+    ;; Run a flood of cascades against :rf/default — the ring cap is 3
+    ;; so :rf/default's ring rotates, but :app/main's ring stays intact.
+    (dotimes [_ 50] (rf/dispatch-sync [:work]))
+    (let [main-cs    (rf/trace-buffer :app/main)
+          default-cs (rf/trace-buffer :rf/default)]
+      (is (= 1 (count main-cs))
+          ":app/main's ring is untouched by :rf/default's flood")
+      (is (<= (count default-cs) 3)
+          ":rf/default's ring stays within its slot cap"))))
+
+;; ---- 1d. Frameless emits skip the ring (B3) ------------------------------
+
+(deftest frameless-emits-bypass-the-ring
+  (testing "trace events emitted OUTSIDE any cascade never land in any ring"
+    ;; Emit with no handler-scope and no frame.
+    (binding [trace/*handler-scope* nil]
+      (trace/emit! :rf.registry :rf.registry/handler-registered
+                   {:kind :event :id :synthetic/probe}))
+    ;; The registration trace is frameless (no `:dispatch-id`) — it
+    ;; should appear in NO frame's ring.
+    (is (empty? (rf/trace-buffer :rf/default))
+        ":rf/default's ring did NOT pick up the frameless emit")
+    (rf/reg-frame :probe/scope {:doc "scope"})
+    (is (empty? (rf/trace-buffer :probe/scope))
+        ":probe/scope's ring did NOT pick up the frameless emit either")))
+
+(deftest registration-emits-are-frameless
+  (testing "registering a handler at top level is a frameless emit"
+    (rf/clear-trace-buffer! :rf/default)
+    ;; reg-event-db is a frameless emit — no in-flight cascade.
+    (rf/reg-event-db :synthetic/probe (fn [db _] db))
+    (is (empty? (rf/trace-buffer :rf/default))
+        "registration didn't grow any ring")))
+
+;; ---- 1e. cascades-retained knob ------------------------------------------
+
+(deftest per-frame-cascades-retained-override
+  (testing ":rf.trace/cascades-retained on reg-frame applies per-frame"
+    (rf/configure :trace-buffer {:cascades-retained 5})
+    (rf/reg-frame :tb/deep {:rf.trace/cascades-retained 200
+                            :doc "deep diagnostics"})
+    (rf/reg-frame :tb/shallow {:doc "shallow — default applies"})
+    (rf/reg-event-db :tb/spam (fn [db _] db))
+    (dotimes [_ 100] (rf/dispatch-sync [:tb/spam] {:frame :tb/deep}))
+    (dotimes [_ 100] (rf/dispatch-sync [:tb/spam] {:frame :tb/shallow}))
+    (is (= 100 (count (rf/trace-buffer :tb/deep)))
+        ":tb/deep retained all 100 cascades (200-deep ring)")
+    (is (= 5 (count (rf/trace-buffer :tb/shallow)))
+        ":tb/shallow capped at 5 (inherited the process-default of 5)")))
+
+(deftest cascades-retained-zero-disables-retention
+  (testing "{:cascades-retained 0} disables the ring; surface stays live"
+    (rf/configure :trace-buffer {:cascades-retained 0})
+    (rf/reg-event-db :ping (fn [db _] db))
+    (dotimes [_ 5] (rf/dispatch-sync [:ping]))
+    (is (= [] (rf/trace-buffer :rf/default))
+        "no cascades retained when retention is 0")
+    ;; A registered listener still fires under depth=0.
+    (let [recv (atom [])]
+      (rf/register-listener! ::probe (fn [ev] (swap! recv conj ev)))
+      (rf/dispatch-sync [:ping])
+      (rf/unregister-listener! ::probe)
+      (is (seq @recv)
+          "live stream continues firing under cascades-retained 0"))))
+
+;; ---- 1f. clear-trace-buffer! and frame-destroy --------------------------
+
+(deftest clear-trace-buffer-clears-only-the-named-frame
+  (testing "clear-trace-buffer! is per-frame"
+    (rf/reg-frame :app/a {:doc "a"})
+    (rf/reg-frame :app/b {:doc "b"})
+    (rf/reg-event-db :ping (fn [db _] db))
+    (rf/dispatch-sync [:ping] {:frame :app/a})
+    (rf/dispatch-sync [:ping] {:frame :app/b})
+    (is (seq (rf/trace-buffer :app/a)))
+    (is (seq (rf/trace-buffer :app/b)))
+    (rf/clear-trace-buffer! :app/a)
+    (is (= [] (rf/trace-buffer :app/a)) ":app/a's ring is empty")
+    (is (seq (rf/trace-buffer :app/b)) ":app/b's ring is intact")))
+
+(deftest frame-destroy-clears-the-rings
+  (testing "destroy-frame! releases the destroyed frame's ring"
+    (rf/reg-frame :app/transient {:doc "short-lived"})
+    (rf/reg-event-db :ping (fn [db _] db))
+    (rf/dispatch-sync [:ping] {:frame :app/transient})
+    (is (seq (rf/trace-buffer :app/transient))
+        "ring has content before destroy")
+    (frame/destroy-frame! :app/transient)
+    (is (= [] (rf/trace-buffer :app/transient))
+        "ring is empty after frame destroy")))
+
+(deftest read-against-unknown-frame-returns-empty
+  (testing "trace-buffer for a never-registered frame returns []"
+    (is (= [] (rf/trace-buffer :no-such-frame)))
+    (is (= [] (rf/trace-buffer :no-such-frame {:flat true})))))
+
+;; ---- 1g. Filter vocabulary (event-level, :flat true) ---------------------
+
+(deftest trace-buffer-filter-operation
+  (rf/reg-event-db :ping (fn [db _] db))
+  (rf/dispatch-sync [:ping])
+  (let [dispatched (flat-events :rf/default {:operation :rf.event/dispatched})]
+    (is (seq dispatched))
+    (is (every? #(= :rf.event/dispatched (:operation %)) dispatched))))
+
+(deftest trace-buffer-filter-op-type
+  (rf/reg-event-db :ping (fn [db _] db))
+  (rf/dispatch-sync [:ping])
+  (let [event-only (flat-events :rf/default {:op-type :rf.event})]
+    (is (seq event-only))
+    (is (every? #(= :rf.event (:op-type %)) event-only))))
+
+(deftest trace-buffer-filter-since
+  (rf/reg-event-db :ping (fn [db _] db))
+  (rf/dispatch-sync [:ping])
+  (let [pre-id (-> (flat-events :rf/default) last :id)]
+    (rf/dispatch-sync [:ping])
+    (let [after (flat-events :rf/default {:since pre-id})]
+      (is (seq after))
+      (is (every? #(> (:id %) pre-id) after)))))
 
 (deftest trace-buffer-filter-severity
-  (testing ":severity filters by :op-type tier (:error / :warning / :info)"
-    ;; :rf.error/no-such-handler is a reliable :op-type :error emit.
+  (testing ":severity :error narrows to :op-type :error events"
     (rf/dispatch-sync [:no-such-event-handler])
-    (let [errs (rf/trace-buffer {:severity :error})]
+    (let [errs (flat-events :rf/default {:severity :error})]
       (is (seq errs))
-      (is (every? #(= :error (:op-type %)) errs)
-          ":severity :error narrows to :op-type :error events"))
-    (testing ":severity :warning narrows to :op-type :warning"
-      (let [warns (rf/trace-buffer {:severity :warning})]
-        (is (every? #(= :warning (:op-type %)) warns)
-            (if (seq warns)
-              ":severity :warning narrows correctly"
-              ":severity :warning returns empty when no warnings"))))
-    (testing ":severity composes with :frame"
-      (rf/reg-frame :tb/sev-scope {:doc "severity-scope"})
-      (rf/clear-trace-buffer!)
-      (rf/dispatch-sync [:no-such-event-handler] {:frame :tb/sev-scope})
-      (let [scoped (rf/trace-buffer {:severity :error :frame :tb/sev-scope})]
-        (is (every? #(and (= :error (:op-type %))
-                          (= :tb/sev-scope (or (:frame %)
-                                               (get-in % [:tags :frame]))))
-                    scoped))))))
+      (is (every? #(= :error (:op-type %)) errs)))))
 
 (deftest trace-buffer-filter-event-id
-  (testing ":event-id filters by :tags :rf.trace/event-id"
-    (rf/reg-event-db :ev/alpha (fn [db _] db))
-    (rf/reg-event-db :ev/beta  (fn [db _] db))
-    (rf/dispatch-sync [:ev/alpha])
-    (rf/dispatch-sync [:ev/beta])
-    (let [alpha (rf/trace-buffer {:event-id :ev/alpha})]
-      (is (seq alpha))
-      (is (every? #(= :ev/alpha (get-in % [:tags :rf.trace/event-id])) alpha)
-          ":event-id filter narrows to one event-id"))
-    (let [beta (rf/trace-buffer {:event-id :ev/beta})]
-      (is (seq beta))
-      (is (every? #(= :ev/beta (get-in % [:tags :rf.trace/event-id])) beta)))))
+  (rf/reg-event-db :ev/alpha (fn [db _] db))
+  (rf/reg-event-db :ev/beta  (fn [db _] db))
+  (rf/dispatch-sync [:ev/alpha])
+  (rf/dispatch-sync [:ev/beta])
+  (let [alpha (flat-events :rf/default {:event-id :ev/alpha})]
+    (is (seq alpha))
+    (is (every? #(= :ev/alpha (get-in % [:tags :rf.trace/event-id])) alpha))))
 
 (deftest trace-buffer-filter-handler-id
-  (testing ":handler-id filters by :tags :handler-id"
-    ;; :rf.error/handler-exception carries :handler-id under :tags.
-    (rf/reg-event-db :ev/throws
-                     (fn [_db _] (throw (ex-info "boom" {}))))
-    (try
-      (rf/dispatch-sync [:ev/throws])
-      (catch Throwable _ nil))
-    (let [hits (rf/trace-buffer {:handler-id :ev/throws})]
-      (is (seq hits) "at least one event carries :handler-id :ev/throws")
-      (is (every? #(= :ev/throws (get-in % [:tags :handler-id])) hits)))))
+  (rf/reg-event-db :ev/throws (fn [_db _] (throw (ex-info "boom" {}))))
+  (try (rf/dispatch-sync [:ev/throws]) (catch Throwable _ nil))
+  (let [hits (flat-events :rf/default {:handler-id :ev/throws})]
+    (is (seq hits))
+    (is (every? #(= :ev/throws (get-in % [:tags :handler-id])) hits))))
 
 (deftest trace-buffer-filter-source
-  (testing ":source filters by top-level :source slot (hoisted from :tags)"
-    (rf/reg-event-db :ping (fn [db _] db))
-    (rf/dispatch-sync [:ping] {:source :repl})
-    (rf/dispatch-sync [:ping] {:source :timer})
-    (let [repl-evs (rf/trace-buffer {:source :repl})]
-      (is (seq repl-evs))
-      (is (every? #(= :repl (or (:source %) (get-in % [:tags :source])))
-                  repl-evs)
-          ":source filter matches top-level slot"))
-    (let [timer-evs (rf/trace-buffer {:source :timer})]
-      (is (seq timer-evs))
-      (is (every? #(= :timer (or (:source %) (get-in % [:tags :source])))
-                  timer-evs)))))
+  (rf/reg-event-db :ping (fn [db _] db))
+  (rf/dispatch-sync [:ping] {:source :repl})
+  (rf/dispatch-sync [:ping] {:source :timer})
+  (let [repl-evs (flat-events :rf/default {:source :repl})]
+    (is (seq repl-evs))
+    (is (every? #(= :repl (or (:source %) (get-in % [:tags :source])))
+                repl-evs))))
 
 (deftest trace-buffer-filter-origin
-  (testing ":origin filters by :tags :origin"
-    (rf/reg-event-db :ping (fn [db _] db))
-    (rf/dispatch-sync [:ping] {:origin :pair})
-    (rf/dispatch-sync [:ping] {:origin :story})
-    (let [pair-evs (rf/trace-buffer {:origin :pair})]
-      (is (seq pair-evs))
-      (is (every? #(= :pair (get-in % [:tags :rf.event/origin])) pair-evs)
-          ":origin :pair narrows to pair-issued cascades"))
-    (let [story-evs (rf/trace-buffer {:origin :story})]
-      (is (seq story-evs))
-      (is (every? #(= :story (get-in % [:tags :rf.event/origin])) story-evs)))))
+  (rf/reg-event-db :ping (fn [db _] db))
+  (rf/dispatch-sync [:ping] {:origin :pair})
+  (rf/dispatch-sync [:ping] {:origin :story})
+  (let [pair-evs (flat-events :rf/default {:origin :pair})]
+    (is (seq pair-evs))
+    (is (every? #(= :pair (get-in % [:tags :rf.event/origin])) pair-evs))))
 
-(deftest trace-buffer-filter-dispatch-id
-  (testing ":rf.trace/dispatch-id narrows to one cascade (rf2-g6ih4 cascade-wide tag)"
-    (rf/reg-event-db :ping (fn [db _] db))
-    (rf/dispatch-sync [:ping])
-    (rf/dispatch-sync [:ping])
-    (let [first-dispatch (->> (rf/trace-buffer)
-                              dispatched-events
-                              first)
-          target-id      (get-in first-dispatch [:tags :rf.trace/dispatch-id])
-          slice          (rf/trace-buffer {:dispatch-id target-id})]
-      (is (number? target-id))
-      (is (seq slice))
-      (is (every? #(= target-id (get-in % [:tags :rf.trace/dispatch-id])) slice)
-          "every event in the slice carries the same :rf.trace/dispatch-id"))))
+(deftest trace-buffer-filter-dispatch-id-flat
+  (rf/reg-event-db :ping (fn [db _] db))
+  (rf/dispatch-sync [:ping])
+  (rf/dispatch-sync [:ping])
+  (let [first-dispatch (->> (flat-events :rf/default)
+                            dispatched-events
+                            first)
+        target-id      (get-in first-dispatch [:tags :rf.trace/dispatch-id])
+        slice          (flat-events :rf/default {:dispatch-id target-id})]
+    (is (number? target-id))
+    (is (seq slice))
+    (is (every? #(= target-id (get-in % [:tags :rf.trace/dispatch-id])) slice))))
 
 (deftest trace-buffer-filter-since-ms
-  (testing ":since-ms filters by :time host-clock millisecond bound"
-    (rf/reg-event-db :ping (fn [db _] db))
+  (rf/reg-event-db :ping (fn [db _] db))
+  (rf/dispatch-sync [:ping])
+  (let [pre-time (-> (flat-events :rf/default) last :time)]
+    (Thread/sleep 5)
     (rf/dispatch-sync [:ping])
-    (let [pre-time (-> (rf/trace-buffer) last :time)]
-      ;; Timer-semantics sleep (rf2-ka3n6): we are asserting :since-ms
-      ;; filtering against the host clock — the test contract requires
-      ;; that the next event's :time is strictly greater. NOT replaceable
-      ;; by a deterministic-gate helper; the clock advancement IS the
-      ;; thing under test.
-      (Thread/sleep 5)
-      (rf/dispatch-sync [:ping])
-      (let [after (rf/trace-buffer {:since-ms pre-time})]
-        (is (seq after))
-        (is (every? #(> (:time %) pre-time) after)
-            ":since-ms keeps events strictly after the timestamp")))))
+    (let [after (flat-events :rf/default {:since-ms pre-time})]
+      (is (seq after))
+      (is (every? #(> (:time %) pre-time) after)))))
 
 (deftest trace-buffer-filter-between
-  (testing ":between [t0 t1] filters to a time window (inclusive)"
-    (rf/reg-event-db :ping (fn [db _] db))
-    (rf/dispatch-sync [:ping])
-    (let [t0 (-> (rf/trace-buffer) first :time)
-          t1 (-> (rf/trace-buffer) last  :time)
-          win (rf/trace-buffer {:between [t0 t1]})]
-      (is (seq win))
-      (is (every? #(<= t0 (:time %) t1) win)
-          "every event in the window falls in [t0, t1]"))
-    (testing ":between with a window that excludes everything yields []"
-      (let [win (rf/trace-buffer {:between [0 1]})]
-        (is (= [] win))))))
+  (rf/reg-event-db :ping (fn [db _] db))
+  (rf/dispatch-sync [:ping])
+  (let [t0 (-> (flat-events :rf/default) first :time)
+        t1 (-> (flat-events :rf/default) last  :time)
+        win (flat-events :rf/default {:between [t0 t1]})]
+    (is (seq win))
+    (is (every? #(<= t0 (:time %) t1) win)))
+  (let [win (flat-events :rf/default {:between [0 1]})]
+    (is (= [] win))))
+
+(deftest trace-buffer-filter-sensitive
+  (testing ":sensitive? filter matches top-level slot"
+    (rf/reg-event-db :ev/x {:rf/sensitive? true} (fn [db _] db))
+    (rf/reg-event-db :ev/y (fn [db _] db))
+    (rf/dispatch-sync [:ev/x])
+    (rf/dispatch-sync [:ev/y])
+    (let [sens   (flat-events :rf/default {:sensitive? true})
+          plain  (flat-events :rf/default {:sensitive? false})]
+      (is (seq sens) "at least one sensitive event")
+      (is (every? #(true? (:sensitive? %)) sens))
+      (is (seq plain) "at least one non-sensitive event")
+      (is (every? #(not (true? (:sensitive? %))) plain)))))
 
 (deftest trace-buffer-filter-pred
-  (testing ":pred applies an arbitrary predicate"
+  (rf/reg-event-db :ping (fn [db _] db))
+  (rf/dispatch-sync [:ping])
+  (let [evs (flat-events :rf/default
+                         {:pred (fn [ev] (#{:rf.event :error} (:op-type ev)))})]
+    (is (seq evs))
+    (is (every? #(#{:rf.event :error} (:op-type %)) evs))))
+
+;; ---- 1h. Cascade-bundle filters ------------------------------------------
+
+(deftest trace-buffer-cascade-filter-event-id
+  (rf/reg-event-db :ev/alpha (fn [db _] db))
+  (rf/reg-event-db :ev/beta  (fn [db _] db))
+  (rf/dispatch-sync [:ev/alpha])
+  (rf/dispatch-sync [:ev/beta])
+  (let [alpha (rf/trace-buffer :rf/default {:event-id :ev/alpha})]
+    (is (seq alpha))
+    (is (every? #(= :ev/alpha (first (:event %))) alpha))))
+
+(deftest trace-buffer-cascade-filter-dispatch-id
+  (rf/reg-event-db :ping (fn [db _] db))
+  (rf/dispatch-sync [:ping])
+  (rf/dispatch-sync [:ping])
+  (let [cs        (rf/trace-buffer :rf/default)
+        target-id (:dispatch-id (first cs))
+        narrowed  (rf/trace-buffer :rf/default {:dispatch-id target-id})]
+    (is (= 1 (count narrowed))
+        ":dispatch-id narrows cascade-bundle reads to one cascade")
+    (is (= target-id (:dispatch-id (first narrowed))))))
+
+(deftest trace-buffer-cascade-filter-origin
+  (rf/reg-event-db :ping (fn [db _] db))
+  (rf/dispatch-sync [:ping] {:origin :pair})
+  (rf/dispatch-sync [:ping] {:origin :story})
+  (let [pair (rf/trace-buffer :rf/default {:origin :pair})]
+    (is (seq pair))
+    (is (every? #(= :pair (get-in % [:dispatched :tags :rf.event/origin])) pair))))
+
+;; ---- 2. :dispatch-id correlation -----------------------------------------
+
+(deftest dispatch-id-allocated-on-every-dispatch
+  (testing "every :rf.event/dispatched trace carries a numeric :rf.trace/dispatch-id"
     (rf/reg-event-db :ping (fn [db _] db))
     (rf/dispatch-sync [:ping])
-    (let [errors-and-events (rf/trace-buffer {:pred (fn [ev]
-                                                      (#{:rf.event :error}
-                                                       (:op-type ev)))})]
-      (is (seq errors-and-events))
-      (is (every? #(#{:rf.event :error} (:op-type %)) errors-and-events)
-          ":pred narrows to events matching the predicate"))
-    (testing ":pred composes with named axes"
-      (let [evs (rf/trace-buffer {:op-type :rf.event
-                                  :pred    (fn [ev]
-                                             (= :rf.event/dispatched
-                                                (:operation ev)))})]
-        (is (every? #(and (= :rf.event (:op-type %))
-                          (= :rf.event/dispatched (:operation %)))
-                    evs))))))
-
-(deftest trace-buffer-filters-compose-and-wise
-  (testing "every filter axis composes; supplying many narrows further"
-    (rf/reg-event-db :ev/x (fn [db _] db))
-    (rf/dispatch-sync [:ev/x] {:origin :pair :source :repl})
-    ;; :rf.event/dispatched carries :origin and :source (via top-level hoist)
-    ;; but NOT :event-id (it carries the full :event vector). :event-id
-    ;; lives on :rf.event/db-changed and on error emits. Compose four axes
-    ;; that all coexist on :rf.event/dispatched.
-    (let [evs (rf/trace-buffer {:op-type   :rf.event
-                                :operation :rf.event/dispatched
-                                :origin    :pair
-                                :source    :repl})]
+    (rf/dispatch-sync [:ping])
+    (let [evs (dispatched-events (flat-events :rf/default))
+          ids (map #(get-in % [:tags :rf.trace/dispatch-id]) evs)]
       (is (seq evs))
-      (is (every? #(and (= :rf.event           (:op-type %))
-                        (= :rf.event/dispatched (:operation %))
-                        (= :pair            (get-in % [:tags :rf.event/origin]))
-                        (= :repl            (or (:source %)
-                                                (get-in % [:tags :source]))))
-                  evs)
-          "all four axes match simultaneously"))
-    (testing ":event-id composes with the other axes on :rf.event/db-changed"
-      (let [evs (rf/trace-buffer {:operation :rf.event/db-changed
-                                  :event-id  :ev/x
-                                  :origin    :pair})]
-        (is (every? #(and (= :rf.event/db-changed (:operation %))
-                          (= :ev/x            (get-in % [:tags :rf.trace/event-id]))
-                          (= :pair            (get-in % [:tags :rf.event/origin])))
-                    evs))))))
+      (is (every? some? ids))
+      (is (every? number? ids))
+      (is (= (count (distinct ids)) (count ids))))))
 
-;; ---- 3. :origin opt --------------------------------------------------------
+(deftest top-level-dispatch-has-no-parent
+  (rf/reg-event-db :standalone (fn [db _] db))
+  (rf/dispatch-sync [:standalone])
+  (let [ev (->> (flat-events :rf/default)
+                dispatched-events
+                (filter #(= [:standalone] (get-in % [:tags :rf.event/v])))
+                first)]
+    (is ev)
+    (is (nil? (get-in ev [:tags :rf.trace/parent-dispatch-id])))))
+
+(deftest fx-dispatch-inherits-parent-dispatch-id
+  (rf/reg-event-fx :outer (fn [_ _] {:fx [[:dispatch [:inner]]]}))
+  (rf/reg-event-db :inner (fn [db _] (assoc db :inner? true)))
+  (rf/dispatch-sync [:outer])
+  (let [evs   (dispatched-events (flat-events :rf/default))
+        outer (->> evs
+                   (filter #(= [:outer] (get-in % [:tags :rf.event/v])))
+                   first)
+        inner (->> evs
+                   (filter #(= [:inner] (get-in % [:tags :rf.event/v])))
+                   first)]
+    (is outer)
+    (is inner)
+    (is (= (get-in outer [:tags :rf.trace/dispatch-id])
+           (get-in inner [:tags :rf.trace/parent-dispatch-id])))))
+
+;; ---- 3. :origin opt -------------------------------------------------------
 
 (deftest origin-defaults-to-app
-  (testing "no :origin opt → :tags :origin = :app"
-    (rf/reg-event-db :ping (fn [db _] db))
-    (rf/dispatch-sync [:ping])
-    (let [ev (->> (rf/trace-buffer)
-                  dispatched-events
-                  (filter #(= [:ping] (get-in % [:tags :rf.event/v])))
-                  first)]
-      (is ev)
-      (is (= :app (get-in ev [:tags :rf.event/origin]))
-          "default :origin is :app per Spec 002 §Dispatch origin tagging"))))
+  (rf/reg-event-db :ping (fn [db _] db))
+  (rf/dispatch-sync [:ping])
+  (let [ev (->> (flat-events :rf/default)
+                dispatched-events
+                (filter #(= [:ping] (get-in % [:tags :rf.event/v])))
+                first)]
+    (is ev)
+    (is (= :app (get-in ev [:tags :rf.event/origin])))))
 
 (deftest origin-opt-overrides-default
-  (testing ":origin :pair lands on the trace event"
-    (rf/reg-event-db :ping (fn [db _] db))
-    (rf/dispatch-sync [:ping] {:origin :pair})
-    (let [ev (->> (rf/trace-buffer)
-                  dispatched-events
-                  (filter #(= [:ping] (get-in % [:tags :rf.event/v])))
-                  first)]
-      (is ev)
-      (is (= :pair (get-in ev [:tags :rf.event/origin]))
-          ":origin :pair lifted onto :tags :origin"))))
+  (rf/reg-event-db :ping (fn [db _] db))
+  (rf/dispatch-sync [:ping] {:origin :pair})
+  (let [ev (->> (flat-events :rf/default)
+                dispatched-events
+                (filter #(= [:ping] (get-in % [:tags :rf.event/v])))
+                first)]
+    (is ev)
+    (is (= :pair (get-in ev [:tags :rf.event/origin])))))
 
-(deftest origin-distinct-from-source
-  (testing ":origin and :source ride independently"
-    (rf/reg-event-db :ping (fn [db _] db))
-    (rf/dispatch-sync [:ping] {:origin :pair :source :repl})
-    (let [ev (->> (rf/trace-buffer)
-                  dispatched-events
-                  (filter #(= [:ping] (get-in % [:tags :rf.event/v])))
-                  first)]
-      (is ev)
-      (is (= :pair (get-in ev [:tags :rf.event/origin]))   ":origin lands under :tags :origin")
-      ;; :source is hoisted to top-level by emit!, per the existing contract.
-      (is (= :repl (:source ev))                  ":source is hoisted to top-level"))))
-
-;; ---- 4. :rf/dispatch-origin opt (rf2-t1lxr) -------------------------------
+;; ---- 4. :rf/dispatch-origin opt -----------------------------------------
 
 (deftest dispatch-origin-defaults-to-user
-  (testing "no :rf/dispatch-origin opt → :tags :rf/dispatch-origin = :user"
-    (rf/reg-event-db :ping (fn [db _] db))
-    (rf/dispatch-sync [:ping])
-    (let [ev (->> (rf/trace-buffer)
-                  dispatched-events
-                  (filter #(= [:ping] (get-in % [:tags :rf.event/v])))
-                  first)]
-      (is ev)
-      (is (= :user (get-in ev [:tags :rf/dispatch-origin]))
-          "default :rf/dispatch-origin is :user per Spec 009 §Dispatch-origin tagging"))))
+  (rf/reg-event-db :ping (fn [db _] db))
+  (rf/dispatch-sync [:ping])
+  (let [ev (->> (flat-events :rf/default)
+                dispatched-events
+                (filter #(= [:ping] (get-in % [:tags :rf.event/v])))
+                first)]
+    (is ev)
+    (is (= :user (get-in ev [:tags :rf/dispatch-origin])))))
 
 (deftest dispatch-origin-opt-overrides-default
-  (testing ":rf/dispatch-origin :tool lands on the trace event"
-    (rf/reg-event-db :ping (fn [db _] db))
-    (rf/dispatch-sync [:ping] {:rf/dispatch-origin :tool})
-    (let [ev (->> (rf/trace-buffer)
-                  dispatched-events
-                  (filter #(= [:ping] (get-in % [:tags :rf.event/v])))
-                  first)]
-      (is ev)
-      (is (= :tool (get-in ev [:tags :rf/dispatch-origin]))
-          ":rf/dispatch-origin :tool lifted onto :tags :rf/dispatch-origin"))))
-
-(deftest dispatch-origin-distinct-from-origin-and-source
-  (testing ":rf/dispatch-origin / :origin / :source ride independently"
-    (rf/reg-event-db :ping (fn [db _] db))
-    (rf/dispatch-sync [:ping] {:rf/dispatch-origin :tool
-                               :origin             :pair
-                               :source             :repl})
-    (let [ev (->> (rf/trace-buffer)
-                  dispatched-events
-                  (filter #(= [:ping] (get-in % [:tags :rf.event/v])))
-                  first)]
-      (is ev)
-      (is (= :tool (get-in ev [:tags :rf/dispatch-origin])))
-      (is (= :pair (get-in ev [:tags :rf.event/origin])))
-      (is (= :repl (:source ev))))))
+  (rf/reg-event-db :ping (fn [db _] db))
+  (rf/dispatch-sync [:ping] {:rf/dispatch-origin :tool})
+  (let [ev (->> (flat-events :rf/default)
+                dispatched-events
+                (filter #(= [:ping] (get-in % [:tags :rf.event/v])))
+                first)]
+    (is ev)
+    (is (= :tool (get-in ev [:tags :rf/dispatch-origin])))))
 
 (deftest dispatch-origin-fx-emit-on-cascade
-  (testing "child dispatches emitted by :dispatch fx are tagged :fx-emit
-            regardless of the parent's :rf/dispatch-origin"
-    (rf/reg-event-fx :parent
-      (fn [_ _] {:fx [[:dispatch [:child]]]}))
+  (testing "child dispatches emitted by :dispatch fx are tagged :fx-emit"
+    (rf/reg-event-fx :parent (fn [_ _] {:fx [[:dispatch [:child]]]}))
     (rf/reg-event-db :child (fn [db _] db))
     (rf/dispatch-sync [:parent] {:rf/dispatch-origin :user})
-    (let [parent-ev (->> (rf/trace-buffer)
-                          dispatched-events
-                          (filter #(= [:parent] (get-in % [:tags :rf.event/v])))
-                          first)
-          child-ev  (->> (rf/trace-buffer)
-                          dispatched-events
-                          (filter #(= [:child] (get-in % [:tags :rf.event/v])))
-                          first)]
+    (let [parent-ev (->> (flat-events :rf/default)
+                         dispatched-events
+                         (filter #(= [:parent] (get-in % [:tags :rf.event/v])))
+                         first)
+          child-ev  (->> (flat-events :rf/default)
+                         dispatched-events
+                         (filter #(= [:child] (get-in % [:tags :rf.event/v])))
+                         first)]
       (is parent-ev)
       (is child-ev)
-      (is (= :user (get-in parent-ev [:tags :rf/dispatch-origin]))
-          "parent carries the explicit :user opt")
-      (is (= :fx-emit (get-in child-ev [:tags :rf/dispatch-origin]))
-          "child overrides to :fx-emit — origin is the IMMEDIATE source,
-           lineage rides on :rf.trace/parent-dispatch-id"))))
+      (is (= :user (get-in parent-ev [:tags :rf/dispatch-origin])))
+      (is (= :fx-emit (get-in child-ev [:tags :rf/dispatch-origin]))))))
 
-(deftest trace-buffer-filter-dispatch-origin
-  (testing ":rf/dispatch-origin filters by :tags :rf/dispatch-origin"
-    (rf/reg-event-db :ping (fn [db _] db))
-    (rf/dispatch-sync [:ping] {:rf/dispatch-origin :tool})
-    (rf/dispatch-sync [:ping] {:rf/dispatch-origin :router})
-    (let [tool-evs (rf/trace-buffer {:rf/dispatch-origin :tool})]
-      (is (seq tool-evs))
-      (is (every? #(= :tool (get-in % [:tags :rf/dispatch-origin])) tool-evs)
-          ":rf/dispatch-origin :tool narrows to tool-issued cascades"))
-    (let [router-evs (rf/trace-buffer {:rf/dispatch-origin :router})]
-      (is (seq router-evs))
-      (is (every? #(= :router (get-in % [:tags :rf/dispatch-origin])) router-evs)))))
-
-;; ---- 5. Frame-level trace-emission gate (rf2-2qaqh) ------------------------
-;;
-;; A tool / inspector frame registered with `:rf.trace/frame-no-emit? true`
-;; (e.g. Xray's `:rf/xray`) produces NO trace — its own reactivity must
-;; not flood the shared ring buffer it inspects. The frame-scoped sibling
-;; of the handler-scoped `:rf.trace/no-emit?` (Spec 009 §Trace-emission
-;; opt-out). The gate keys on the event's `:frame` tag, single-sourced via
-;; `trace/frame-trace-disabled?`.
+;; ---- 5. Frame-level trace-emission gate (rf2-2qaqh) ----------------------
 
 (deftest tool-frame-emits-no-trace
   (testing "a frame registered :rf.trace/frame-no-emit? true grows the ring by 0"
     (rf/reg-frame :tool/inspector {:rf.trace/frame-no-emit? true})
     (rf/reg-event-db :tool/work (fn [db _] (assoc db :ran? true)))
-    (rf/clear-trace-buffer!)
-    (is (= [] (rf/trace-buffer))
-        "buffer empty after clear (the :frame/created emit was suppressed too)")
-    ;; Drive a full cascade ON the tool frame: dispatch, db-change, the
-    ;; whole drain. None of it should reach the ring.
+    (rf/clear-trace-buffer! :tool/inspector)
     (rf/dispatch-sync [:tool/work] {:frame :tool/inspector})
-    (is (= [] (rf/trace-buffer))
+    (is (= [] (rf/trace-buffer :tool/inspector))
         "no trace event from a trace-disabled frame's cascade reaches the ring")))
 
 (deftest app-frame-emits-trace-while-tool-frame-silent
-  (testing "an app frame's cascade DOES grow the ring; the tool frame's does NOT"
+  (testing "an app frame's cascade DOES grow its ring; the tool frame's does NOT"
     (rf/reg-frame :tool/inspector {:rf.trace/frame-no-emit? true})
     (rf/reg-frame :app/main {:doc "ordinary application frame"})
     (rf/reg-event-db :work (fn [db _] (assoc db :ran? true)))
-    (rf/clear-trace-buffer!)
-    ;; Interleave: tool-frame noise must never displace app-frame signal.
+    (rf/clear-trace-buffer! :app/main)
+    (rf/clear-trace-buffer! :tool/inspector)
     (dotimes [_ 20] (rf/dispatch-sync [:work] {:frame :tool/inspector}))
     (rf/dispatch-sync [:work] {:frame :app/main})
-    (let [buf (rf/trace-buffer)]
-      (is (seq buf) "app-frame cascade produced trace")
-      (is (every? #(not= :tool/inspector
-                         (or (:frame %) (get-in % [:tags :frame])))
-                  buf)
-          "NO event in the ring is tagged with the trace-disabled frame")
-      (is (some #(= :app/main (or (:frame %) (get-in % [:tags :frame]))) buf)
-          "the app-frame events survived (not evicted by tool noise)"))))
+    (is (seq (rf/trace-buffer :app/main))
+        "app-frame cascade produced a trace cascade in its own ring")
+    (is (= [] (rf/trace-buffer :tool/inspector))
+        "tool-frame's ring stays empty")))
 
-(deftest tool-frame-self-instrumentation-does-not-saturate-ring
-  (testing "the rf2-2qaqh scenario: heavy tool-frame churn cannot evict app events"
-    (rf/configure :trace-buffer {:depth 50})
-    (rf/reg-frame :tool/inspector {:rf.trace/frame-no-emit? true})
-    (rf/reg-frame :app/main {:doc "app"})
-    (rf/reg-event-db :work (fn [db _] db))
-    (rf/dispatch-sync [:work] {:frame :app/main})
-    (rf/clear-trace-buffer!)
-    ;; Seed one app cascade, then bury it under far more tool-frame churn
-    ;; than the ring depth — pre-fix this evicted the app event entirely.
-    (rf/dispatch-sync [:work] {:frame :app/main})
-    (dotimes [_ 500] (rf/dispatch-sync [:work] {:frame :tool/inspector}))
-    (let [buf (rf/trace-buffer)]
-      (is (some #(= :app/main (or (:frame %) (get-in % [:tags :frame]))) buf)
-          "the app-frame event is STILL in the ring after 500 tool dispatches")
-      (is (empty? (rf/trace-buffer {:frame :tool/inspector}))
-          "zero tool-frame events in the ring"))))
+;; ---- 6. B4 hot-reload dedup-by-shape ------------------------------------
 
-(deftest frame-no-emit-flag-clears-on-re-registration
-  (testing "re-registering a frame WITHOUT the flag re-enables its trace"
-    (rf/reg-frame :flip/frame {:rf.trace/frame-no-emit? true})
-    (rf/reg-event-db :work (fn [db _] db))
-    (is (trace/frame-trace-disabled? :flip/frame)
-        "predicate reports the flag is set")
-    (rf/clear-trace-buffer!)
-    (rf/dispatch-sync [:work] {:frame :flip/frame})
-    (is (= [] (rf/trace-buffer)) "trace suppressed while flag set")
-    ;; Surgical re-registration drops the flag → trace re-enabled.
-    (rf/reg-frame :flip/frame {:doc "now a normal frame"})
-    (is (not (trace/frame-trace-disabled? :flip/frame))
-        "predicate reports the flag cleared on re-registration")
-    (rf/clear-trace-buffer!)
-    (rf/dispatch-sync [:work] {:frame :flip/frame})
-    (is (seq (rf/trace-buffer)) "trace flows again once the flag is cleared")))
+(deftest hot-reload-unchanged-handler-emits-zero-traces
+  (testing "re-registering an identical handler emits ZERO traces (B4 dedup)"
+    (let [handler-fn (fn [db _] db)]
+      (rf/reg-event-db :ev/hot {:doc "hot"} handler-fn)
+      (rf/clear-trace-buffer! :rf/default)
+      ;; Identical re-registration — same fn, same meta. B4: zero emits.
+      (rf/reg-event-db :ev/hot {:doc "hot"} handler-fn)
+      (rf/reg-event-db :ev/hot {:doc "hot"} handler-fn)
+      (rf/reg-event-db :ev/hot {:doc "hot"} handler-fn)
+      (is (= [] (rf/trace-buffer :rf/default {:flat true
+                                              :op-type :rf.registry}))
+          "no :rf.registry/* traces from idempotent hot-reload"))))
 
-(deftest frame-trace-disabled-predicate-is-single-sourced
-  (testing "set-frame-no-emit! / frame-trace-disabled? toggle the canonical set"
-    (is (not (trace/frame-trace-disabled? :probe/frame)))
-    (trace/set-frame-no-emit! :probe/frame true)
-    (is (trace/frame-trace-disabled? :probe/frame))
-    (trace/set-frame-no-emit! :probe/frame false)
-    (is (not (trace/frame-trace-disabled? :probe/frame)))))
+(deftest hot-reload-changed-handler-emits-one-trace
+  (testing "re-registering a CHANGED handler emits exactly one :rf.registry/handler-replaced"
+    (let [recv (atom [])]
+      (rf/register-listener! ::probe
+                             (fn [ev]
+                               (when (= :rf.registry/handler-replaced
+                                        (:operation ev))
+                                 (swap! recv conj ev))))
+      (rf/reg-event-db :ev/hot {:doc "v1"} (fn [db _] (assoc db :v 1)))
+      (reset! recv [])
+      ;; Real edit — different handler-fn body.
+      (rf/reg-event-db :ev/hot {:doc "v1"} (fn [db _] (assoc db :v 2)))
+      (rf/unregister-listener! ::probe)
+      (is (= 1 (count @recv))
+          "exactly one :rf.registry/handler-replaced emitted on real edit")
+      (is (= :ev/hot (-> @recv first :tags :id))))))
+
+(deftest hot-reload-dedup-clears-on-reset
+  (testing "clear-listeners! (and clear-trace-rings!) reset the dedup table"
+    (let [handler-fn (fn [db _] db)
+          recv (atom [])]
+      ;; Register, then identical re-register — dedup suppresses.
+      (rf/reg-event-db :ev/cycle {:doc "doc"} handler-fn)
+      (rf/reg-event-db :ev/cycle {:doc "doc"} handler-fn) ;; suppressed
+      ;; Reset dedup state, then re-register the SAME handler — should
+      ;; now emit again because the table is fresh.
+      (rf/clear-listeners!)
+      (rf/register-listener! ::probe
+                             (fn [ev]
+                               (when (and (= :rf.registry (:op-type ev))
+                                          (= :ev/cycle (-> ev :tags :id)))
+                                 (swap! recv conj ev))))
+      (rf/reg-event-db :ev/cycle {:doc "doc"} handler-fn)
+      (rf/unregister-listener! ::probe)
+      (is (seq @recv)
+          "post-clear re-registration emits at least one registry trace"))))
+
+(deftest hot-reload-dedup-per-kind-id
+  (testing "dedup is per-(kind, id) — separate ids don't interfere"
+    (let [recv (atom [])]
+      (rf/register-listener! ::probe
+                             (fn [ev]
+                               (when (= :rf.registry (:op-type ev))
+                                 (swap! recv conj ev))))
+      (rf/reg-event-db :a {:doc "a"} (fn [db _] db))
+      (rf/reg-event-db :b {:doc "b"} (fn [db _] db))
+      (rf/unregister-listener! ::probe)
+      ;; Different ids never share dedup state — both initial
+      ;; registrations are first-time emits.
+      (let [a-emits (filter #(= :a (-> % :tags :id)) @recv)
+            b-emits (filter #(= :b (-> % :tags :id)) @recv)]
+        (is (seq a-emits) "first :a registration emits")
+        (is (seq b-emits) "first :b registration emits")))))

--- a/implementation/core/test/re_frame/trace_bus_elision_prod_test.cljs
+++ b/implementation/core/test/re_frame/trace_bus_elision_prod_test.cljs
@@ -50,8 +50,8 @@
     (rf/dispatch-sync [:prod-bus/inc])
     (rf/dispatch-sync [:prod-bus/inc])
     ;; trace-buffer's body is gated; under prod it returns nil.
-    (is (or (nil? (trace-tooling/trace-buffer))
-            (empty? (trace-tooling/trace-buffer)))
+    (is (or (nil? (trace-tooling/trace-buffer :rf/default))
+            (empty? (trace-tooling/trace-buffer :rf/default)))
         "trace-buffer is nil or empty under :advanced + goog.DEBUG=false
          — buffer surface elides while the handler still runs")
     ;; Cross-check: the handler DID run — only the trace surface elided.
@@ -65,13 +65,13 @@
             returns nil silently — apps that boot with a
             configure-trace-buffer call do not crash under :advanced,
             but the requested depth has no effect."
-    (is (nil? (trace-tooling/configure-trace-buffer! {:depth 256}))
+    (is (nil? (trace-tooling/configure-trace-buffer! {:cascades-retained 256}))
         "configure-trace-buffer! returns nil consistently under prod")
     ;; Subsequent dispatches still do not push to the buffer.
     (rf/reg-event-db :prod-bus/touch (fn [db _] db))
     (rf/dispatch-sync [:prod-bus/touch])
-    (is (or (nil? (trace-tooling/trace-buffer))
-            (empty? (trace-tooling/trace-buffer)))
+    (is (or (nil? (trace-tooling/trace-buffer :rf/default))
+            (empty? (trace-tooling/trace-buffer :rf/default)))
         "buffer remains empty after configure + dispatch under prod")))
 
 (deftest clear-trace-buffer-is-noop-under-prod
@@ -80,7 +80,7 @@
             a session-reset (re-frame-10x's `Clear` button) do not
             crash on a production bundle that happens to load
             re-frame.trace.tooling for non-buffer surfaces."
-    (is (nil? (trace-tooling/clear-trace-buffer!))
+    (is (nil? (trace-tooling/clear-trace-buffer! :rf/default))
         "clear-trace-buffer! returns nil under prod")))
 
 (deftest trace-emit-direct-call-does-not-populate-buffer-under-prod
@@ -89,8 +89,8 @@
             elides before any deliver-to-buffer call site is reached."
     (trace/emit! :info :rf.prod-bus/direct {:should "never appear"})
     (trace/emit! :event :rf.prod-bus/sample {:also "never appear"})
-    (is (or (nil? (trace-tooling/trace-buffer))
-            (empty? (trace-tooling/trace-buffer)))
+    (is (or (nil? (trace-tooling/trace-buffer :rf/default))
+            (empty? (trace-tooling/trace-buffer :rf/default)))
         "buffer remains empty after direct emit calls under prod")))
 
 (deftest trace-configure-is-noop-under-prod
@@ -99,5 +99,5 @@
             that boot via `(re-frame.core/configure :trace-buffer ...)`
             do not crash under :advanced; the requested config is
             silently dropped."
-    (is (nil? (rf/configure :trace-buffer {:depth 64}))
+    (is (nil? (rf/configure :trace-buffer {:cascades-retained 64}))
         "configure :trace-buffer returns nil under prod")))

--- a/implementation/core/test/re_frame/trace_listener_test.clj
+++ b/implementation/core/test/re_frame/trace_listener_test.clj
@@ -48,7 +48,7 @@
   (reset! flows/flows {})
   (reset! schemas/schemas-by-frame {})
   (trace/clear-listeners!)
-  (rf/clear-trace-buffer!)
+  (re-frame.trace.tooling/clear-trace-rings!)
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
   (test-fn))
@@ -105,24 +105,47 @@
 
 (deftest one-call-per-emitted-event
   (testing "the listener is invoked once per emitted event — no batching, no debounce"
-    (let [calls (atom 0)]
+    (let [calls (atom 0)
+          seen  (atom [])]
       (rf/reg-event-db :ping (fn [db _] db))
-      ;; Register the listener and clear the buffer in the same window so
-      ;; we measure only the events emitted AFTER both are in place. The
-      ;; contract is "one listener call per emitted event from this point".
-      (rf/clear-trace-buffer!)
-      (rf/register-listener! ::counter (fn [_ev] (swap! calls inc)))
+      (rf/clear-trace-buffer! :rf/default)
+      (rf/register-listener! ::counter (fn [ev]
+                                         (swap! calls inc)
+                                         (swap! seen conj (:id ev))))
       ;; A single dispatch produces multiple trace events (run-start,
       ;; run-end, dispatched, do-fx, ...). Each must be delivered in its
       ;; own listener call.
       (rf/dispatch-sync [:ping])
-      (let [n @calls
-            buf-count (count (rf/trace-buffer))]
-        (is (pos? n))
-        (is (= n buf-count)
-            (str "listener call count (" n ") must equal emitted-event count ("
-                 buf-count ") — the listener fires once per event")))
+      (let [n   @calls
+            ids @seen]
+        (is (pos? n)
+            "listener fired at least once during the cascade")
+        (is (= n (count ids))
+            "every invocation carried a distinct event (no duplicate calls)")
+        (is (= (count ids) (count (distinct ids)))
+            "each event was delivered exactly once — no batching, no dedup-by-listener"))
       (rf/unregister-listener! ::counter))))
+
+(deftest in-cascade-emits-land-in-the-ring
+  (testing "every IN-CASCADE listener event also appears in the frame's ring
+            (frameless emits ride the live stream only — per B3 ruling rf2-g1b2m).
+            For a pure dispatch-sync where all emits carry the cascade's
+            `:dispatch-id`, the ring should mirror the listener stream."
+    (let [seen (atom [])]
+      (rf/reg-event-db :ping (fn [db _] db))
+      (rf/clear-trace-buffer! :rf/default)
+      (rf/register-listener! ::record (fn [ev] (swap! seen conj ev)))
+      (rf/dispatch-sync [:ping])
+      (rf/unregister-listener! ::record)
+      ;; Partition the listener stream by in-cascade-ness — events with
+      ;; a `:rf.trace/dispatch-id` should land in the ring; others
+      ;; (e.g. post-cascade epoch emits, registration emits) skip it.
+      (let [in-cascade  (filter #(get-in % [:tags :rf.trace/dispatch-id]) @seen)
+            ring-events (rf/trace-buffer :rf/default {:flat true})]
+        (is (seq in-cascade)
+            "at least one in-cascade emit was delivered")
+        (is (= (count in-cascade) (count ring-events))
+            "ring holds exactly the in-cascade events — no more, no less")))))
 
 ;; ---- 3. Event-emission order ---------------------------------------------
 

--- a/implementation/flows/test/re_frame/flows_test.clj
+++ b/implementation/flows/test/re_frame/flows_test.clj
@@ -1013,22 +1013,36 @@
         ":right carries :shared in its per-frame registry too")))
 
 ;; ---------------------------------------------------------------------------
-;; 9c. :rf.registry/handler-replaced :different-fn? reflects real body
-;;     swaps for :flow re-registrations (rf2-v5ttb).
+;; 9c. :rf.registry/handler-replaced reflects real :flow body swaps and
+;;     is suppressed by shape on idempotent reloads.
 ;;
-;; Pre-fix the registrar's `:different-fn?` calculation compared
-;; `(:handler-fn previous)` against `(:handler-fn metadata)` but the
-;; flows registration site stored the body under `:output` only — so
-;; both reads were nil for every flow re-registration and
-;; `:different-fn?` was always `false`. Tools (re-frame-10x's flow
-;; panel, Xray, re-frame2-pair) branching on `:different-fn? true` missed every
-;; real flow-body change. Fix: `reg-flow` now stamps `:handler-fn`
-;; alongside `:output` so the cross-kind registrar trace surface Spec
-;; 001 standardises works for flows too.
+;; Two layered contracts converge here:
+;;
+;;   (1) rf2-v5ttb — `:handler-fn` must be stamped on the flow registry
+;;       metadata so the registrar's `:different-fn?` calculation
+;;       actually compares the flow body across re-registrations.
+;;       Pre-fix the registrar compared `(:handler-fn previous)` to
+;;       `(:handler-fn metadata)` but the flows registration site stored
+;;       the body under `:output` only — both reads were nil and
+;;       `:different-fn?` was always `false`. `reg-flow` now stamps
+;;       `:handler-fn` alongside `:output` so the cross-kind registrar
+;;       trace surface (Spec 001) works for flows too.
+;;
+;;   (2) rf2-g1b2m — Spec 009 B4 ruling, hot-reload dedup by shape
+;;       (#2135 spec landing, #2139 impl). The registrar consults the
+;;       trace.tooling dedup-by-shape table on every emit: identical
+;;       shape on re-register emits ZERO `:rf.registry/handler-replaced`
+;;       events; a real body change emits exactly one. This supersedes
+;;       the rf2-v5ttb-era "every re-registration emits one" assertion
+;;       for identity reloads.
+;;
+;; Together: identity reload → 0 emits (B4 dedup-suppressed); real
+;; `:output` body swap → 1 emit with `:different-fn? true` (rf2-v5ttb
+;; stamping makes the comparison meaningful).
 ;; ---------------------------------------------------------------------------
 
 (deftest flow-hot-reload-different-fn?-reflects-real-body-swap
-  (testing "Per rf2-v5ttb: :rf.registry/handler-replaced :different-fn? is true on a real :output swap, false on identity reload"
+  (testing "Per rf2-v5ttb (`:handler-fn` stamping) + rf2-g1b2m B4 dedup-by-shape: a real `:output` swap emits one `:rf.registry/handler-replaced` with `:different-fn? true`; an identity reload is suppressed (0 emits)."
     (let [captured (atom [])]
       (re-frame.trace/register-listener!
         ::handler-replaced-recorder
@@ -1041,17 +1055,11 @@
                         :inputs [[:n]]
                         :output body-v1
                         :path   [:doubled]})
-          ;; Idempotent re-registration — same fn identity. :different-fn? must be false.
-          (rf/reg-flow {:id     :double
-                        :inputs [[:n]]
-                        :output body-v1
-                        :path   [:doubled]})
-          (is (= 1 (count @captured))
-              "one :rf.registry/handler-replaced fired for the second registration")
-          (is (false? (-> @captured first :tags :different-fn?))
-              ":different-fn? false on identity re-registration (idempotent reload)")
-          ;; Now re-register with a NEW fn — :different-fn? must be true.
-          (reset! captured [])
+          ;; (a) Real body swap — different `:handler-fn` identity, so
+          ;; the B4 dedup table sees a shape change and allows the emit.
+          ;; Exactly one `:rf.registry/handler-replaced` fires with
+          ;; `:different-fn? true` (rf2-v5ttb made the comparison
+          ;; meaningful by stamping `:handler-fn` on the flow metadata).
           (rf/reg-flow {:id     :double
                         :inputs [[:n]]
                         :output (fn [n] (* 100 n))
@@ -1059,7 +1067,31 @@
           (is (= 1 (count @captured))
               "one :rf.registry/handler-replaced fired for the body-swap registration")
           (is (true? (-> @captured first :tags :different-fn?))
-              ":different-fn? true on real body change (rf2-v5ttb fix)"))
+              ":different-fn? true on real body change (rf2-v5ttb fix)")
+          ;; (b) Idempotent reload — re-register with the SAME fn
+          ;; identity as the previous registration. The B4 dedup table
+          ;; (rf2-g1b2m) has already recorded that shape, so the re-emit
+          ;; is suppressed: ZERO `:rf.registry/handler-replaced` events.
+          ;; This supersedes the prior rf2-v5ttb-era assertion of "one
+          ;; emit with `:different-fn? false`" for the idempotent case.
+          (reset! captured [])
+          (let [body-v2 (fn [n] (* 3 n))]
+            (rf/reg-flow {:id     :double
+                          :inputs [[:n]]
+                          :output body-v2
+                          :path   [:doubled]})
+            ;; First registration of `body-v2` shape is genuine — allow.
+            (is (= 1 (count @captured))
+                "baseline emit for the new shape so the dedup table records it")
+            (reset! captured [])
+            ;; Now re-register IDENTICALLY — same fn identity, same
+            ;; meta. B4 dedup must suppress.
+            (rf/reg-flow {:id     :double
+                          :inputs [[:n]]
+                          :output body-v2
+                          :path   [:doubled]})
+            (is (empty? @captured)
+                "B4 dedup-by-shape (rf2-g1b2m) suppresses the re-emit for an identity reload — 0 :rf.registry/handler-replaced events")))
         (finally
           (re-frame.trace/unregister-listener! ::handler-replaced-recorder))))))
 


### PR DESCRIPTION
Implements the framework half of the per-frame trace ring design landed in [rf2-g1b2m's spec PR (#2135)](https://github.com/day8/re-frame2/pull/2135).

Per Spec 009 §Per-frame trace rings (cascade-keyed, dev-only) and Spec 002 §What lives in a frame.

## Acceptance criteria

1. **Per-frame routing — sub `:skip` traces in `:rf/xray` don't appear in `:rf/default`'s ring.** Each frame owns its own cascade-keyed ring; emit-site routing reads `:rf.trace/dispatch-id` from `*handler-scope*` and the destination frame-id from the `:frame` tag (with a `:frame/current-frame-id` late-bind fallback for sub recompute / view render emits whose call sites don't stamp `:frame`). Test: `frame-isolation-cascade-bursts-dont-cross-rings`.
2. **Cascade-keyed eviction — cascade A's burst of `:skip`s can't evict cascade B's traces.** The ring slot is the cascade. One `:rf.trace/dispatch-id` consumes one slot regardless of how many trace events were emitted under it. Test: `cascade-burst-cannot-evict-prior-cascades`.
3. **Frameless skip (B3) — frameless emits never appear in any ring.** Registration emits and any emit with no `:dispatch-id` in scope bypass the rings entirely; they stream live to listeners only. Tests: `frameless-emits-bypass-the-ring`, `registration-emits-are-frameless`.
4. **B4 shape-dedup — unchanged hot-reload emits zero traces; changed shape emits one `:rf.registry/handler-replaced`.** A process-scoped dedup table tracks the last-emitted `(kind, id)` shape (handler-fn identity + `:doc` + `:schema` + `:interceptors` + `:tags` + residual-meta hash, modulo source-coord drift). The registrar consults the dedup gate via the new `:trace.tooling/dedup-allow?` late-bind hook. Tests: `hot-reload-unchanged-handler-emits-zero-traces`, `hot-reload-changed-handler-emits-one-trace`, `hot-reload-dedup-clears-on-reset`, `hot-reload-dedup-per-kind-id`.
5. **Configure knob — `(rf/reg-frame :my-frame {:rf.trace/cascades-retained 200})` retains 200 cascades for `:my-frame`.** Per-frame override applied at registration via `:trace.tooling/set-frame-cascades-retained!` hook; the process default applies elsewhere via `(rf/configure :trace-buffer {:cascades-retained N})`. Tests: `per-frame-cascades-retained-override`, `cascade-keyed-eviction`, `cascades-retained-zero-disables-retention`.
6. **`clear-trace-buffer!` clears only the named frame's ring.** Per-frame isolation. Test: `clear-trace-buffer-clears-only-the-named-frame`.
7. **Frame destroy clears that frame's ring (no residual memory).** `destroy-frame!` invokes `:trace.tooling/release-frame-ring!` AFTER the `:rf.frame/destroyed` trace fires; the destroyed frame leaves no ring state in memory. Test: `frame-destroy-clears-the-rings`.

## Mechanisms

### B3 (frameless skip)
`push-to-ring!` in `re-frame.trace.tooling` reads the cascade's `:dispatch-id` from the event's `:tags`. When absent, the event is frameless — it returns immediately. No `:rf/global` ring, no fallback slot, no shared bucket. Frameless emits stream live to registered listeners only.

### B4 (dedup-by-shape)
The dedup table is `{[kind id] <shape>}` where shape captures the contract-relevant fields of the registration meta. Identical shape → suppress. Changed shape → record + allow. Clear-of-a-cleared id → suppress. The table is cleared on `clear-listeners!`, `clear-trace-rings!`, and `registrar/clear-all!`. Production CLJS bundles never load `trace.tooling` so the late-bind hook is unbound and the registrar's allow-by-default branch keeps the emit gate elision-safe.

### Frame-destroy ring cleanup
A new step in `destroy-frame!`'s teardown recipe — between the `:flows/teardown-on-frame-destroy!` hook and `dissoc-frame!`, the `:trace.tooling/release-frame-ring!` hook is fired so the destroyed frame's `{:cascade-order ... :cascades ...}` map is dropped from `trace-rings`. The hook is routed via late-bind, so production CLJS bundles short-circuit cleanly.

## API changes

- `(rf/trace-buffer frame-id)` — frame-id is now required (was zero-arg).
- `(rf/trace-buffer frame-id opts)` — `{:flat true}` returns the raw event stream; the default is cascade bundles.
- `(rf/clear-trace-buffer! frame-id)` — takes a frame-id arg now.
- `(rf/configure :trace-buffer {:cascades-retained N})` — was `{:depth N}`. Pre-alpha, no back-compat shim.
- `:rf.trace/cascades-retained` on `reg-frame` is the per-frame override.

Tools-side adoption (cascade-bundle wire format) is blocked-on by [rf2-q03j7](https://github.com/day8/re-frame2/issues/q03j7); pair-mcp / story-mcp / xray rings are not migrated by this PR.

## New late-bind hooks

Added to `re-frame.late_bind.directory`:
- `:trace.tooling/dedup-allow?` — B4 emit gate
- `:trace.tooling/clear-dedup-table!` — reset on test fixture
- `:trace.tooling/release-frame-ring!` — frame-destroy cleanup
- `:trace.tooling/set-frame-cascades-retained!` — per-frame override
- `:frame/current-frame-id` — emit-site routing fallback

## Gate results

| Gate | Result |
|---|---|
| JVM core tests | 777 tests, 3613 assertions, 0 failures, 0 errors |
| CLJS node tests | 4485 tests, 14266 assertions, 0 failures, 0 errors |
| CLJS browser tests | 124 tests, 346 assertions, 0 failures, 0 errors |
| Elision probe | 38/38 absent in prod; 38/38 present in control |
| Bundle isolation | pass (trace.tooling does not leak into production bundles) |
| Xray feature gate (nightly-full sweep) | 13/13 scenarios pass |
| clj-kondo | 0 errors |

## Spec-impl alignment

This bead implements an already-landed spec. No deviations from #2135 / Spec 009 §Per-frame trace rings were required. One small spec inconsistency observed: `spec/Tool-Pair.md` line 382 still describes `(rf/trace-buffer opts)` as a registry-wide opts-only form, which conflicts with the rf2-g1b2m-landed `(rf/trace-buffer frame-id)` / `(rf/trace-buffer frame-id opts)` shape; Spec 009 is the load-bearing reference and the impl matches it. (No follow-on bead filed yet — happy to file one if desired.)

## Refs

- Spec: #2135 (rf2-g1b2m).
- Impl bead: rf2-8uwce.
- Consumer follow-on (tools adopt cascade-bundle wire format): rf2-q03j7.