### PR TITLE
feat(tools): adopt per-frame trace-buffer signature in xray-runtime + pair-runtime (rf2-q03j7)

### DIFF
--- a/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
+++ b/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
@@ -1136,14 +1136,25 @@
 
 (defn cascade-of
   "Reconstruct the cascade tree from a root `:dispatch-id` by walking
-   `:rf.event/dispatched` traces in the buffer for matching :parent links.
-   Returns a tree of {:dispatch-id <id> :event <ev> :children [...]}.
+   `:rf.event/dispatched` traces in the per-frame trace rings for
+   matching :parent links. Returns a tree of
+   `{:dispatch-id <id> :event <ev> :children [...]}`.
 
-   Note: this walks the in-memory trace buffer (default depth 200 events
-   per `(rf/configure :trace-buffer {:depth N})`). For long cascades use
-   `(rf/configure :trace-buffer {:depth ...})` to widen the window."
+   Per rf2-g1b2m / rf2-8uwce the trace ring is per-frame and
+   cascade-keyed. A single cascade can fan out across frames (per
+   Spec 002 §Cross-frame dispatch) — every emit on every frame
+   shares the same `:rf.trace/dispatch-id`, so cross-frame
+   reconstruction iterates every registered frame's flat-event
+   stream and merges. Per-frame depth is configurable via
+   `(rf/configure :trace-buffer {:cascades-retained N})`."
   [root-dispatch-id]
-  (let [events     (trace-tooling/trace-buffer {:operation :rf.event/dispatched})
+  (let [;; Per-frame rings, flat-event escape hatch — merge across
+        ;; frames so cross-frame cascades reconstruct correctly.
+        events     (into []
+                         (mapcat #(trace-tooling/trace-buffer
+                                    %
+                                    {:operation :rf.event/dispatched :flat true}))
+                         (rf/frame-ids))
         by-parent  (group-by #(get-in % [:tags :rf.trace/parent-dispatch-id]) events)
         node       (fn node [did]
                      (let [ev (some (fn [e] (when (= did (get-in e [:tags :rf.trace/dispatch-id])) e))
@@ -1654,8 +1665,10 @@
                                 {})]
                   {:ids ids :state state})
     :epochs     (vec (rf/epoch-history frame-id))
-    ;; The retain-N trace ring buffer is global; filter by frame.
-    :traces     (vec (trace-tooling/trace-buffer {:frame frame-id}))
+    ;; Per rf2-g1b2m / rf2-8uwce the trace ring is per-frame; the
+    ;; first arg IS the frame-id and `{:flat true}` returns raw events
+    ;; (the legacy flat-stream shape this slot has always emitted).
+    :traces     (vec (trace-tooling/trace-buffer frame-id {:flat true}))
     nil))
 
 (defn- snapshot-frame

--- a/skills/re-frame2-pair/tests/runtime/snapshot_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/snapshot_test.clj
@@ -52,9 +52,15 @@
 (defn stub-sub-cache [fid] (get-in fixture-frames [fid :sub-cache]))
 (defn stub-epoch-history [fid] (get-in fixture-frames [fid :epochs]))
 (defn stub-machines [] [:auth :session]) ;; global registrar surface
-(defn stub-trace-buffer [opts]
- (let [fid (:frame opts)]
- (filter #(= fid (get-in % [:tags :frame]))
+(defn stub-trace-buffer
+ "Per rf2-g1b2m / rf2-8uwce the framework's `trace-buffer` is now
+ per-frame and cascade-keyed; the frame-id is the required first arg
+ and `{:flat true}` selects the legacy flat-event shape. This stub
+ mirrors the new signature so the snapshot slice's KEEP-IN-SYNC
+ parallel-impl stays accurate."
+ ([frame-id] (stub-trace-buffer frame-id {}))
+ ([frame-id _opts]
+ (filter #(= frame-id (get-in % [:tags :frame]))
  (mapcat (fn [[_ slices]] (:traces slices)) fixture-frames))))
 
 ;; Mirror of preload/re_frame2_pair/runtime.cljs §Coarse-grained snapshot.
@@ -70,7 +76,11 @@
  :machines {:ids (vec (stub-machines))
  :state (or (get (stub-get-frame-db frame-id) :rf/machines) {})}
  :epochs (vec (stub-epoch-history frame-id))
- :traces (vec (stub-trace-buffer {:frame frame-id}))
+ ;; Per rf2-g1b2m / rf2-8uwce the trace ring is per-frame; the
+ ;; first arg IS the frame-id and `{:flat true}` returns raw
+ ;; events (the legacy flat-stream shape this slot has always
+ ;; emitted).
+ :traces (vec (stub-trace-buffer frame-id {:flat true}))
  nil))
 
 (defn- snapshot-frame [frame-id slices]

--- a/tools/xray/src/day8/re_frame2_xray/runtime.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/runtime.cljs
@@ -216,26 +216,42 @@
 
 (defn get-trace-buffer
   "Tool: `get-trace-buffer`. Return a slice of the trace stream by
-  filter; forwards to `(trace-tooling/trace-buffer opts)`. Filter keys are the
-  canonical Spec 009 filter vocabulary (`:operation`, `:op-type`,
-  `:since`, `:frame`, `:severity`, `:event-id`, `:handler-id`,
-  `:source`, `:origin`, `:dispatch-id`, `:since-ms`, `:between`,
-  `:pred`).
+  filter; forwards to `(trace-tooling/trace-buffer frame-id opts)`.
+  Filter keys are the canonical Spec 009 filter vocabulary
+  (`:operation`, `:op-type`, `:since`, `:severity`, `:event-id`,
+  `:handler-id`, `:source`, `:origin`, `:dispatch-id`, `:since-ms`,
+  `:between`, `:pred`).
 
-  Returns `{:ok? true :events <vec> :count <n>}`. Each event is routed
-  through `elide-wire-value` so sensitive / large values are scrubbed
-  at the wire boundary (MUST-inventory rows #2 / #15 / #19)."
+  Per rf2-g1b2m / rf2-8uwce the ring is now per-frame and cascade-
+  keyed. `:frame` selects the frame (defaults to the sole-registered
+  one via `resolve-frame`); the response emits raw trace events (via
+  `{:flat true}`) so the legacy flat-event consumer shape is
+  preserved. Cascade-bundle reads land in a follow-on bead — this
+  tool is the historical flat-events surface and stays so.
+
+  Returns `{:ok? true :events <vec> :count <n> :frame <frame-id>}`
+  on success, or `{:ok? false :reason :no-frame-resolved ...}` when
+  ambiguous. Each event is routed through `elide-wire-value` so
+  sensitive / large values are scrubbed at the wire boundary
+  (MUST-inventory rows #2 / #15 / #19)."
   ([] (get-trace-buffer {}))
   ([opts]
-   (let [{:keys [include-sensitive? include-large?]} opts
-         filter-opts (dissoc opts :include-sensitive? :include-large?)
-         events      (trace-tooling/trace-buffer filter-opts)
-         scrubbed    (mapv #(elide % {:include-sensitive? include-sensitive?
-                                      :include-large?     include-large?})
-                           events)]
-     {:ok?    true
-      :events scrubbed
-      :count  (count scrubbed)})))
+   (let [{:keys [frame include-sensitive? include-large?]} opts
+         fid (resolve-frame frame)]
+     (if (nil? fid)
+       {:ok? false :reason :no-frame-resolved
+        :hint "Pass :frame :foo or register at least one frame."}
+       (let [filter-opts (-> opts
+                             (dissoc :frame :include-sensitive? :include-large?)
+                             (assoc :flat true))
+             events      (trace-tooling/trace-buffer fid filter-opts)
+             scrubbed    (mapv #(elide % {:include-sensitive? include-sensitive?
+                                          :include-large?     include-large?})
+                               events)]
+         {:ok?    true
+          :frame  fid
+          :events scrubbed
+          :count  (count scrubbed)})))))
 
 (defn get-epoch-history
   "Tool: `get-epoch-history`. Per-frame epoch history (vector of
@@ -374,6 +390,12 @@
   the issue-tier `:op-type`s (`:error`, `:warning`,
   `:rf.schema/violation`, `:rf.hydration/mismatch`).
 
+  Per rf2-g1b2m / rf2-8uwce trace rings are per-frame; iterate every
+  registered frame and merge — issues fired across multiple frames
+  during a single cascade reconstruct correctly. `:flat true` opts
+  into the raw flat-event shape so the existing issue filter walks
+  the same vocabulary.
+
   Returns `{:ok? true :issues <vec>}`. Routes through
   `elide-wire-value` per MUST-inventory row #2."
   ([] (get-issues {}))
@@ -382,8 +404,13 @@
          issue-op-types #{:error :warning
                           :rf.schema/violation
                           :rf.hydration/mismatch}
-         events  (trace-tooling/trace-buffer {})
-         issues  (filterv #(contains? issue-op-types (:op-type %)) events)
+         ;; Per-frame ring: merge across frames so cross-frame issues
+         ;; (e.g. an error landing in :stories while :rf/default is
+         ;; the operating frame) still surface here.
+         events   (into []
+                        (mapcat #(trace-tooling/trace-buffer % {:flat true}))
+                        (rf/frame-ids))
+         issues   (filterv #(contains? issue-op-types (:op-type %)) events)
          scrubbed (mapv #(elide % {:include-sensitive? include-sensitive?
                                    :include-large?     include-large?})
                         issues)]

--- a/tools/xray/test/day8/re_frame2_xray/runtime_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/runtime_cljs_test.cljs
@@ -325,3 +325,55 @@
       (is (true? (:ok? result)))
       (is (vector? (:epochs result)))
       (is (= 0 (:count result))))))
+
+;; ---------------------------------------------------------------------------
+;; (10) get-trace-buffer adopts per-frame rings (rf2-q03j7).
+;; ---------------------------------------------------------------------------
+;;
+;; Per rf2-g1b2m / rf2-8uwce the framework's trace ring is per-frame and
+;; cascade-keyed. `get-trace-buffer` is the Xray-runtime MCP accessor for
+;; the historical flat-events shape; it now resolves a frame-id, requires
+;; one (refuses on ambiguity), and forwards `{:flat true}` to the
+;; framework so the existing flat-event consumer shape is preserved.
+
+(deftest get-trace-buffer-resolves-sole-frame
+  (testing "`get-trace-buffer` resolves the sole-registered frame
+            without an explicit `:frame` arg (post per-frame ring
+            adoption rf2-q03j7) and returns the historical flat-event
+            shape via the framework's `{:flat true}` opt"
+    (rf/reg-event-db :test/just-dispatch
+      (fn [db _] (assoc db :touched? true)))
+    (rf/dispatch-sync [:test/just-dispatch])
+    (let [result (runtime/get-trace-buffer)]
+      (is (true? (:ok? result))
+          "single-frame resolution succeeds without explicit :frame")
+      (is (= :rf/default (:frame result))
+          "the sole frame is the resolved frame")
+      (is (vector? (:events result))
+          "events is a vector (flat-event shape, not cascade bundles)")
+      (is (number? (:count result))))))
+
+(deftest get-trace-buffer-refuses-ambiguous-frame
+  (testing "with no frames registered (or ambiguous resolution), the
+            accessor surfaces a structured `:no-frame-resolved` refusal
+            rather than guessing — per-frame ring API requires a
+            frame-id (rf2-q03j7)"
+    (frame/destroy-frame! :rf/default)
+    (let [result (runtime/get-trace-buffer)]
+      (is (false? (:ok? result)))
+      (is (= :no-frame-resolved (:reason result))))))
+
+(deftest get-issues-walks-every-frame
+  (testing "`get-issues` iterates every registered frame's flat-event
+            stream and merges, so cross-frame issues fired during a
+            multi-frame cascade still surface (rf2-q03j7 — per-frame
+            ring adoption)"
+    ;; Smoke test: with no errors emitted, the result is structured
+    ;; correctly even though events is empty. The merge-across-frames
+    ;; semantics is the load-bearing contract here; an empty event
+    ;; vector is a sufficient witness that the form runs cleanly
+    ;; against the new per-frame trace-buffer signature.
+    (let [result (runtime/get-issues)]
+      (is (true? (:ok? result)))
+      (is (vector? (:issues result)))
+      (is (number? (:count result))))))


### PR DESCRIPTION
Consumer adoption follow-on to **rf2-g1b2m** (spec #2135) + **rf2-8uwce** (core impl #2139). The new `trace-buffer` API takes `frame-id` as a required first arg and returns cascade bundles by default; `{:flat true}` returns raw trace events (the legacy flat-stream shape). Pre-alpha posture: no back-compat shim — every caller is fixed in place.

## Decomposition choice: (B) — ship the immediate breaking-change fix + file follow-ons

The bead description's *"may further decompose into per-tool beads"* sentence is the explicit permission. Two reasons the umbrella couldn't land cleanly in one PR:

- Xray's `trace_bus.cljc` retirement (the bead's first bullet — *"drop tools/xray/src/.../trace_bus.cljc"*) touches **60+ files** in `tools/xray/` that reference `trace-bus/*` symbols. The panel-side reactive surface re-wires from `(get db :trace-buffer)` to the per-frame ring; the mirror-sync coalescing path is load-bearing for parallel-frames E2E (rf2-wq6gx); the entire `filter-events` consumer vocabulary comes out of the framework. That's a separate architectural reshape.
- pair-mcp's cascade-bundle wire format is a wire-vocab change that needs its own `mcp-conformance/wire-vocab/` gate update + binary rebuild + spec/003-Tool-Catalogue.md wire-shape rewrite. Also a separate beast.

This PR ships the breaking-change fix that unbreaks the existing read paths NOW; the architectural reshapes flow through as their own beads with their own PRs.

**story-mcp** doesn't touch `trace-buffer` at all (its runtime walks variants + the recorder, not the trace ring) so it's out of scope and no follow-on is filed for it.

## Follow-on beads filed

- **rf2-43koh** — `refactor(xray)`: retire `trace_bus.cljc` and read directly from per-frame rings
- **rf2-mscih** — `feat(re-frame2-pair-mcp)`: cascade-bundle wire format on `trace-window` / `watch-epochs` / `subscribe`

Both depend on rf2-q03j7 (discovered-from). rf2-mscih benefits from rf2-43koh landing first (cleaner Xray surface to mirror) but isn't strictly blocked.

## Per-tool change summary

### `skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs`

1. `cascade-of` — iterates every registered frame, merges flat events across frames. Cross-frame cascades reconstruct correctly per Spec 002 §Cross-frame dispatch.
2. `snapshot-frame-slice :traces` — now `(trace-buffer frame-id {:flat true})`. Wire shape unchanged.

### `skills/re-frame2-pair/tests/runtime/snapshot_test.clj`

`stub-trace-buffer` parallel-impl stub gets the new `([frame-id] [frame-id opts])` signature. 9 existing tests pass against the new stub.

### `tools/xray/src/day8/re_frame2_xray/runtime.cljs`

1. `get-trace-buffer` — resolves a frame-id (refuses on ambiguity via `:no-frame-resolved`), forwards `{:flat true}` to the framework. Result echoes the resolved frame.
2. `get-issues` — iterates every registered frame's flat-event stream and merges.

### `tools/xray/test/day8/re_frame2_xray/runtime_cljs_test.cljs`

Three new tests pin the per-frame ring adoption contract:
- `get-trace-buffer-resolves-sole-frame`
- `get-trace-buffer-refuses-ambiguous-frame`
- `get-issues-walks-every-frame`

## Wire-format preservation note

`:rf.mcp/diff-from` / `:rf.mcp/dedup-table` / `:rf.mcp/cache-hit` semantics compose unchanged (cache-poisoning posture preserved per rf2-3rt1f). The cascade-bundle shape is a follow-on (rf2-mscih) and will ride BELOW these markers; this PR's flat-event shape is unchanged from the pre-rf2-g1b2m delivery semantics.

## Spec coverage

- `spec/Tool-Pair.md §Reading the per-frame trace ring` — already aligned in #2140 (rf2-3kaad).
- `spec/009-Instrumentation.md §Per-frame trace rings` — landed in #2135 (rf2-g1b2m).
- `tools/xray/spec/013-Trace-Bus.md` — already cross-refs `Per-frame trace rings`. Retirement/rewrite is rf2-43koh scope.
- `tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md` — cascade-bundle wire format is rf2-mscih scope.

## Gate results

| Gate | Result |
|---|---|
| clj-kondo (changed files) | 0 errors, pre-existing warnings only |
| JVM core | 777 tests, 3613 assertions, 0 failures |
| JVM implementation (full sweep) | all artefacts pass |
| JVM tools (full sweep) | all artefacts pass |
| CLJS node-test | 4495 tests, 14301 assertions, 0 failures |
| Xray feature gate (nightly-full) | 13/13 scenarios pass |
| Bundle-isolation | pass |
| pair-runtime snapshot test | 9 tests, 17 assertions, 0 failures |

## Cross-refs

- #2135 — rf2-g1b2m spec landing
- #2139 — rf2-8uwce core impl
- #2140 — rf2-3kaad spec/Tool-Pair drift fix
- rf2-43koh (follow-on filed)
- rf2-mscih (follow-on filed)