### PR TITLE
feat(re-frame2-pair-mcp): cascade-bundle wire format on subscribe + runtime trace-ring helpers (rf2-mscih)

### DIFF
--- a/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
+++ b/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
@@ -729,21 +729,64 @@
 ;;   entry without already having admitted it.
 ;;
 ;; Topic semantics:
-;;   :trace  — every event in the raw trace stream matching `:filter`
-;;             (filter map mirrors `(re-frame.trace.tooling/trace-buffer)` filter vocab —
-;;             see the trace-buffer surface). One event per delivered trace event.
-;;   :epoch  — every assembled `:rf/epoch-record` matching `:filter`
-;;             (filter map mirrors `epoch-matches?` — see watch-epochs).
-;;             One event per committed epoch.
-;;   :fx     — sugar for `:topic :trace :filter {:op-type :rf.fx}` with
-;;             optional `:fx-id` and `:event-id` axes from the trace
-;;             filter vocabulary.
-;;   :error  — sugar for `:topic :trace :filter {:op-type :error}`,
-;;             with `:event-id`/`:handler-id`/`:source` available.
+;;   :trace     — every event in the raw trace stream matching `:filter`
+;;                (filter map mirrors `(re-frame.trace.tooling/trace-buffer)` filter vocab —
+;;                see the trace-buffer surface). Cascade-bundle delivery
+;;                (rf2-mscih): per drain, matched events are grouped by
+;;                `:rf.trace/dispatch-id` and projected into one cascade
+;;                bundle per cascade (`group-cascades` shape with a
+;;                `:trace-events` slot carrying the raw events). Events
+;;                without a `:rf.trace/dispatch-id` tag (frameless
+;;                registry / lifecycle emits) NEVER ride this topic —
+;;                consumers wanting those subscribe to `:frameless`.
+;;   :epoch     — every assembled `:rf/epoch-record` matching `:filter`
+;;                (filter map mirrors `epoch-matches?` — see watch-epochs).
+;;                One event per committed epoch. `:rf/epoch-record` is
+;;                already a cascade-bundle by construction.
+;;   :fx        — sugar for `:topic :trace :filter {:op-type :rf.fx}` with
+;;                optional `:fx-id` and `:event-id` axes from the trace
+;;                filter vocabulary. Cascade-bundle delivery as for :trace.
+;;   :error     — sugar for `:topic :trace :filter {:op-type :error}`,
+;;                with `:event-id`/`:handler-id`/`:source` available.
+;;                Cascade-bundle delivery as for :trace.
+;;   :frameless — every trace event matching `:filter` whose
+;;                `:rf.trace/dispatch-id` tag is absent. Registration
+;;                emits, REPL evals, lifecycle outside any cascade flow
+;;                here per Spec 002 / Tool-Pair §Frameless trace events.
+;;                Single-event delivery (no cascade to bundle).
 ;;
 ;; The :fx and :error topics compose with axes from the trace filter
 ;; vocabulary verbatim — they just default `:op-type` to `:rf.fx` /
 ;; `:error` and let callers override the rest.
+;;
+;; Cascade-bundle wire format (rf2-mscih) — emitted on `:trace`/`:fx`/
+;; `:error` drain ticks:
+;;
+;;   {:dispatch-id        <id>                  ;; cascade id
+;;    :frame              <frame-id or nil>
+;;    :event              <event-vector or nil> ;; from :rf.event/dispatched :tags
+;;    :dispatched         <trace-event or nil>  ;; the full :rf.event/dispatched event
+;;    :handler            <trace-event or nil>  ;; the :rf.event/run-end emit
+;;    :fx                 <trace-event or nil>  ;; :rf.fx/do-fx
+;;    :effects            [<trace-event> ...]   ;; :op-type :rf.fx (other ops)
+;;    :subs               [<trace-event> ...]   ;; :rf.sub/run + :rf.sub/skip + :rf.sub/create
+;;    :renders            [<trace-event> ...]   ;; :rf.view/render
+;;    :other              [<trace-event> ...]   ;; everything else
+;;    :trace-events       [<trace-event> ...]   ;; raw events for the cascade
+;;    :parent-dispatch-id <id or nil>}          ;; causal-parent link
+;;
+;; Mirrors the framework's `(rf/trace-buffer frame-id)` shape so an
+;; agent that already pattern-matches on the in-process per-frame
+;; trace-ring sees the same shape on the wire (per Spec 009 §Cascade
+;; projection + Tool-Pair §Reading the per-frame trace ring).
+;;
+;; Cross-frame cascade reconstruction (rf2-mscih) — a cascade can fan
+;; out across frames; every emit on every frame shares the same
+;; `:rf.trace/dispatch-id`. Consumers merge by `:dispatch-id` across
+;; per-frame bundles to reconstruct the cross-frame view (per Tool-Pair
+;; §Cross-frame cascade reconstruction). The runtime emits one bundle
+;; per (frame, dispatch-id) pair per drain — the merge is the
+;; consumer's job, cheap because the key is already on each bundle.
 
 (defonce ^:private subscriptions
   ;; sub-id -> subscription map (see above)
@@ -825,13 +868,69 @@
 
 (defn- topic->base-filter
   "Map a topic keyword to its base trace-filter constraints. `:fx` and
-   `:error` are sugar over `:op-type`; `:trace` and `:epoch` add no
-   base constraint here (the user-supplied filter is the only constraint)."
+   `:error` are sugar over `:op-type`; `:trace`, `:epoch`, `:frameless`
+   add no base constraint here (the user-supplied filter is the only
+   constraint). `:frameless` is gated additionally by
+   `frameless-event?` at dispatch time — the base filter doesn't model
+   the dispatch-id-absence test."
   [topic]
   (case topic
     :fx    {:op-type :rf.fx}
     :error {:op-type :error}
     {}))
+
+;; ---------------------------------------------------------------------------
+;; Cascade-bundle projection (rf2-mscih)
+;; ---------------------------------------------------------------------------
+;;
+;; Per Spec 009 §Cascade projection and Tool-Pair §Reading the per-frame
+;; trace ring, the wire-delivery unit for the streaming subscribe is
+;; the cascade bundle (one entry per `:rf.trace/dispatch-id`) rather
+;; than the flat per-event slice. We mirror the framework's per-frame
+;; trace-ring shape: `rf/group-cascades` projection PLUS a
+;; `:trace-events` slot carrying the raw events.
+;;
+;; The bundling happens at drain time (not enqueue), so the per-event
+;; queue's byte+event budget still works as the upstream bound — an
+;; oversized cascade still evicts oldest events per the documented
+;; policy. Each bundle's `:trace-events` slot carries ONLY the events
+;; that survived eviction.
+;;
+;; Frameless events (`:rf.trace/dispatch-id` tag absent) NEVER ride
+;; cascade-bundle topics — `dispatch-trace-to-subs!` filters them out
+;; for those topics. The `:frameless` topic exists to deliver them
+;; explicitly (Tool-Pair §Frameless trace events — live channel only).
+
+(defn- frameless-event?
+  "True when `ev` carries no `:rf.trace/dispatch-id` tag — a registration
+   emit, REPL eval, or lifecycle event that never rode a dispatch
+   cascade. The cascade-bundle topics filter these out; the `:frameless`
+   topic accepts only these."
+  [ev]
+  (nil? (get-in ev [:tags :rf.trace/dispatch-id])))
+
+(defn- cascade-bundle-events
+  "Group a vector of raw trace events by `:rf.trace/dispatch-id` and
+   project each group into a cascade-bundle map matching the framework's
+   `(rf/trace-buffer frame-id)` shape — the `group-cascades` projection
+   PLUS a `:trace-events` slot carrying the raw events for the cascade.
+   The returned vector is sorted by emission order (lowest `:id` first,
+   the order `rf/group-cascades` returns).
+
+   Events whose `:rf.trace/dispatch-id` tag is missing are NOT included
+   — the caller is expected to have filtered them upstream (cascade-
+   bundle topics) or routed them to the frameless channel."
+  [events]
+  (let [;; rf/group-cascades returns a vector of cascade records sorted
+        ;; by emission order, keyed by `:dispatch-id`. We then splice
+        ;; the raw events per cascade into the `:trace-events` slot.
+        cascades   (rf/group-cascades events)
+        by-id      (group-by #(get-in % [:tags :rf.trace/dispatch-id])
+                             events)]
+    (->> cascades
+         (remove #(= :ungrouped (:dispatch-id %)))
+         (mapv (fn [c]
+                 (assoc c :trace-events (vec (get by-id (:dispatch-id c) []))))))))
 
 (defn- compose-trace-filter
   "Compose the topic's base trace-filter with the user-supplied filter.
@@ -947,17 +1046,42 @@
 (defn- dispatch-trace-to-subs!
   "Called from the raw-trace listener — iterates active subscriptions of
    trace-like topics, matches, enqueues. Cheap when no subs exist (the
-   common path)."
+   common path).
+
+   rf2-mscih channel split:
+   - Cascade-bundle topics (`:trace`/`:fx`/`:error`) receive events
+     carrying a `:rf.trace/dispatch-id` tag. The bundling happens at
+     drain time; the queue stays per-event for the byte+event budget.
+   - The `:frameless` topic receives only events whose
+     `:rf.trace/dispatch-id` tag is absent (registration / REPL /
+     lifecycle emits outside any cascade)."
   [ev]
-  (swap! subscriptions
-         (fn [m]
-           (reduce-kv
-             (fn [acc sub-id sub]
-               (if (and (contains? #{:trace :fx :error} (:topic sub))
-                        (trace-matches? (:compiled-filter sub) ev))
-                 (enqueue! acc sub-id ev)
-                 acc))
-             m m))))
+  (let [frameless? (frameless-event? ev)]
+    (swap! subscriptions
+           (fn [m]
+             (reduce-kv
+               (fn [acc sub-id sub]
+                 (let [topic (:topic sub)
+                       routes? (cond
+                                 (contains? #{:trace :fx :error} topic)
+                                 ;; Cascade-bundle topics — never deliver
+                                 ;; frameless events; consumers wanting
+                                 ;; those opt into the `:frameless` topic.
+                                 (and (not frameless?)
+                                      (trace-matches? (:compiled-filter sub) ev))
+
+                                 (= :frameless topic)
+                                 ;; The frameless channel — only frameless
+                                 ;; events, then filter-matched.
+                                 (and frameless?
+                                      (trace-matches? (:compiled-filter sub) ev))
+
+                                 :else
+                                 false)]
+                   (if routes?
+                     (enqueue! acc sub-id ev)
+                     acc)))
+               m m)))))
 
 (defn- dispatch-epoch-to-subs!
   "Called from the assembled-epoch listener — iterates active epoch
@@ -1011,7 +1135,7 @@
    `drain-subscription!` return queued events matching `:filter`.
 
    Opts:
-     :topic   :trace | :epoch | :fx | :error  (required)
+     :topic   :trace | :epoch | :fx | :error | :frameless  (required)
      :filter  filter map — vocab depends on topic. See namespace docs.
      :max-buffered-events  cap on the in-runtime queue in events.
                            Default 500. When either budget trips, the
@@ -1028,17 +1152,31 @@
    reports the deltas since the previous tick.
 
    Idempotency: each call returns a fresh sub-id — repeated `subscribe!`
-   calls do not share state. Use `unsubscribe!` to release."
+   calls do not share state. Use `unsubscribe!` to release.
+
+   Topic delivery shape (rf2-mscih):
+     :trace / :fx / :error — drain returns `:cascades [<bundle> ...]`
+                             with each bundle in the `(rf/trace-buffer
+                             frame-id)` shape (per Spec 009 §Cascade
+                             projection). One bundle per cascade per
+                             drain.
+     :epoch                — drain returns `:events [<:rf/epoch-record>
+                             ...]` unchanged.
+     :frameless            — drain returns `:events [<trace-event>
+                             ...]` for events with no
+                             `:rf.trace/dispatch-id` tag (registration
+                             emits, REPL evals, lifecycle outside any
+                             cascade)."
   [{:keys [topic filter max-buffered-events max-buffered-bytes] :as opts}]
   (cond
-    (not (contains? #{:trace :epoch :fx :error} topic))
+    (not (contains? #{:trace :epoch :fx :error :frameless} topic))
     {:ok? false :reason :unknown-topic
-     :hint "Recognised topics: :trace :epoch :fx :error"
+     :hint "Recognised topics: :trace :epoch :fx :error :frameless"
      :given topic}
 
     :else
     (let [sub-id (str (random-uuid))
-          compiled (when (#{:trace :fx :error} topic)
+          compiled (when (#{:trace :fx :error :frameless} topic)
                      (compose-trace-filter topic filter))
           sub {:id              sub-id
                :topic           topic
@@ -1072,23 +1210,43 @@
 
 (defn drain-subscription!
   "Pop every queued event for `sub-id` and return them in order.
-   Returns `{:ok? true :sub-id ... :events [...] :dropped-events <n>
-   :dropped-bytes <m> :overflow-reason <kw|nil> :gone? bool}`.
+   Returns one of two envelopes per the sub's topic (rf2-mscih):
+
+   - Cascade-bundle topics (`:trace`/`:fx`/`:error`):
+     `{:ok? true :sub-id ... :cascades [<bundle> ...] :dropped-events <n>
+       :dropped-bytes <m> :overflow-reason <kw|nil> :gone? bool}`
+     — queued raw events are grouped by `:rf.trace/dispatch-id` and
+     projected into cascade bundles (`group-cascades` shape with a
+     `:trace-events` slot) per Spec 009 §Cascade projection.
+
+   - Flat topics (`:epoch`/`:frameless`):
+     `{:ok? true :sub-id ... :events [...] :dropped-events <n>
+       :dropped-bytes <m> :overflow-reason <kw|nil> :gone? bool}`
+     — `:epoch` ships `:rf/epoch-record`s; `:frameless` ships raw
+     trace events with no `:rf.trace/dispatch-id` tag.
+
    If the subscription doesn't exist (already unsubscribed or runtime
-   was reloaded), `:gone? true`.
+   was reloaded), `:gone? true` (envelope shape: `:events []`).
 
    The `:dropped-events`, `:dropped-bytes`, and `:overflow-reason`
-   counters report what got EVICTED from the queue between drains —
+   counters report what got EVICTED from the QUEUE between drains —
    they reset on every drain so the next tick reports the delta. AI
    clients pattern-match on `:overflow-reason` to know which budget
    tripped (`:max-buffered-events` or `:max-buffered-bytes`); the
-   `:dropped-bytes` figure tells them how much state they missed."
+   `:dropped-bytes` figure tells them how much state they missed.
+
+   Note on cascade-bundle counters: `:dropped-events` counts the raw
+   trace events evicted from the queue, NOT cascades. An evicted event
+   may have left its sibling cascade-members in place — consumers
+   reconstructing a cascade should be tolerant of partially-truncated
+   bundles when `:dropped-events` is non-zero."
   [sub-id]
   (let [snap (atom nil)]
     (swap! subscriptions
            (fn [m]
              (if-let [sub (get m sub-id)]
-               (do (reset! snap {:events          (:queue sub)
+               (do (reset! snap {:queue           (:queue sub)
+                                 :topic           (:topic sub)
                                  :dropped-events  (:dropped-events sub 0)
                                  :dropped-bytes   (:dropped-bytes  sub 0)
                                  :overflow-reason (:overflow-reason sub)})
@@ -1099,12 +1257,26 @@
                                        (assoc :dropped-bytes 0)
                                        (assoc :overflow-reason nil))))
                (do (reset! snap nil) m))))
-    (if-let [{:keys [events dropped-events dropped-bytes overflow-reason]} @snap]
-      {:ok? true :sub-id sub-id :events events
-       :dropped-events (or dropped-events 0)
-       :dropped-bytes  (or dropped-bytes  0)
-       :overflow-reason overflow-reason
-       :gone? false}
+    (if-let [{:keys [queue topic dropped-events dropped-bytes overflow-reason]} @snap]
+      (let [base {:ok?             true
+                  :sub-id          sub-id
+                  :dropped-events  (or dropped-events 0)
+                  :dropped-bytes   (or dropped-bytes  0)
+                  :overflow-reason overflow-reason
+                  :gone?           false}]
+        (cond
+          ;; Cascade-bundle delivery (rf2-mscih) — group raw queued
+          ;; trace events by `:rf.trace/dispatch-id` into bundles. The
+          ;; cascade-bundle topics never enqueue frameless events
+          ;; (`dispatch-trace-to-subs!` filters them out at the gate),
+          ;; so `cascade-bundle-events`'s `:ungrouped`-drop is purely
+          ;; defensive.
+          (contains? #{:trace :fx :error} topic)
+          (assoc base :cascades (cascade-bundle-events queue))
+
+          ;; Flat delivery — :epoch and :frameless.
+          :else
+          (assoc base :events queue)))
       {:ok? true :sub-id sub-id :events []
        :dropped-events 0
        :dropped-bytes  0
@@ -1136,33 +1308,36 @@
 
 (defn cascade-of
   "Reconstruct the cascade tree from a root `:dispatch-id` by walking
-   `:rf.event/dispatched` traces in the per-frame trace rings for
-   matching :parent links. Returns a tree of
-   `{:dispatch-id <id> :event <ev> :children [...]}`.
+   the per-frame trace-ring cascade bundles for matching parent links.
+   Returns a tree of `{:dispatch-id <id> :event <ev> :children [...]}`.
 
    Per rf2-g1b2m / rf2-8uwce the trace ring is per-frame and
-   cascade-keyed. A single cascade can fan out across frames (per
-   Spec 002 §Cross-frame dispatch) — every emit on every frame
-   shares the same `:rf.trace/dispatch-id`, so cross-frame
-   reconstruction iterates every registered frame's flat-event
-   stream and merges. Per-frame depth is configurable via
+   cascade-keyed; per rf2-mscih the read unit is the cascade bundle
+   (`group-cascades` shape) rather than the legacy flat-event stream.
+   A single cascade can fan out across frames (per Spec 002
+   §Cross-frame dispatch) — every emit on every frame shares the same
+   `:rf.trace/dispatch-id`, so cross-frame reconstruction iterates
+   every registered frame's bundles and merges by `:dispatch-id`.
+   Per-frame depth is configurable via
    `(rf/configure :trace-buffer {:cascades-retained N})`."
   [root-dispatch-id]
-  (let [;; Per-frame rings, flat-event escape hatch — merge across
-        ;; frames so cross-frame cascades reconstruct correctly.
-        events     (into []
-                         (mapcat #(trace-tooling/trace-buffer
-                                    %
-                                    {:operation :rf.event/dispatched :flat true}))
+  (let [;; Per-frame rings, cascade-bundle reads — merge across
+        ;; frames so cross-frame cascades reconstruct correctly. Each
+        ;; bundle carries `:parent-dispatch-id` (the causal-parent
+        ;; link) and `:dispatched :tags :rf.event/origin` directly,
+        ;; so the tree walk reads them off the bundle slot rather
+        ;; than re-deriving from raw trace events.
+        bundles    (into []
+                         (mapcat #(trace-tooling/trace-buffer %))
                          (rf/frame-ids))
-        by-parent  (group-by #(get-in % [:tags :rf.trace/parent-dispatch-id]) events)
+        by-parent  (group-by :parent-dispatch-id bundles)
         node       (fn node [did]
-                     (let [ev (some (fn [e] (when (= did (get-in e [:tags :rf.trace/dispatch-id])) e))
-                                    events)]
+                     (let [b (some (fn [bundle] (when (= did (:dispatch-id bundle)) bundle))
+                                   bundles)]
                        {:dispatch-id did
-                        :event       (get-in ev [:tags :rf.event/v])
-                        :origin      (get-in ev [:tags :rf.event/origin])
-                        :children    (mapv #(node (get-in % [:tags :rf.trace/dispatch-id]))
+                        :event       (:event b)
+                        :origin      (get-in b [:dispatched :tags :rf.event/origin])
+                        :children    (mapv #(node (:dispatch-id %))
                                            (get by-parent did []))}))]
     (node root-dispatch-id)))
 
@@ -1665,10 +1840,14 @@
                                 {})]
                   {:ids ids :state state})
     :epochs     (vec (rf/epoch-history frame-id))
-    ;; Per rf2-g1b2m / rf2-8uwce the trace ring is per-frame; the
-    ;; first arg IS the frame-id and `{:flat true}` returns raw events
-    ;; (the legacy flat-stream shape this slot has always emitted).
-    :traces     (vec (trace-tooling/trace-buffer frame-id {:flat true}))
+    ;; Per rf2-g1b2m / rf2-8uwce the trace ring is per-frame and
+    ;; cascade-bundle-shaped by default; rf2-mscih shifts this slot
+    ;; to deliver bundles (the storage unit) rather than the legacy
+    ;; flat-event stream, matching the cascade-bundle wire format
+    ;; emitted by the streaming subscribe surface (Tool-Pair §Reading
+    ;; the per-frame trace ring + Tool-Pair §`watch-epochs` /
+    ;; `trace-window` consumer shape).
+    :traces     (vec (trace-tooling/trace-buffer frame-id))
     nil))
 
 (defn- snapshot-frame

--- a/skills/re-frame2-pair/references/mcp-transport.md
+++ b/skills/re-frame2-pair/references/mcp-transport.md
@@ -121,7 +121,7 @@ Use the per-op reads when:
 - **`:path-sliced` (with `path`)** — the slot is `(get-in db path)`. Out-of-range paths surface per-frame in a top-level `:path-not-found` map with `:deepest-valid-prefix` so the agent can re-aim without a binary search.
 - **Root path `path: "[]"`** — explicit request for the full `:app-db`, equivalent to the legacy default. The wire cap is then the backstop.
 
-The other slices (`:sub-cache`, `:machines`, `:epochs`, `:traces`) pass through unchanged.
+The other slices (`:sub-cache`, `:machines`, `:epochs`) pass through unchanged. Per rf2-mscih the `:traces` slice now ships **cascade bundles by default** (`{:dispatch-id :frame :event :dispatched :handler :fx :effects :subs :renders :other :trace-events :parent-dispatch-id}` per cascade — the framework's `(rf/trace-buffer frame-id)` shape and the same wire format the `subscribe` streaming surface emits on cascade-bundle topics).
 
 Use `get-path` (next section) when you already know the addressed subtree — it's a single-slice round-trip rather than the multi-slice composition `snapshot` does.
 

--- a/skills/re-frame2-pair/tests/runtime/snapshot_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/snapshot_test.clj
@@ -54,10 +54,13 @@
 (defn stub-machines [] [:auth :session]) ;; global registrar surface
 (defn stub-trace-buffer
  "Per rf2-g1b2m / rf2-8uwce the framework's `trace-buffer` is now
- per-frame and cascade-keyed; the frame-id is the required first arg
- and `{:flat true}` selects the legacy flat-event shape. This stub
- mirrors the new signature so the snapshot slice's KEEP-IN-SYNC
- parallel-impl stays accurate."
+ per-frame and cascade-keyed; the frame-id is the required first arg.
+ Per rf2-mscih the snapshot `:traces` slice now ships cascade-bundles
+ by default (the framework's storage unit), matching the streaming
+ subscribe wire shape. This stub returns the fixture's `:traces`
+ vector directly — the loosely-typed stub is shape-agnostic; the
+ production snapshot slice calls `(trace-tooling/trace-buffer
+ frame-id)` (zero-arg opts) for the cascade-bundle default."
  ([frame-id] (stub-trace-buffer frame-id {}))
  ([frame-id _opts]
  (filter #(= frame-id (get-in % [:tags :frame]))
@@ -76,11 +79,13 @@
  :machines {:ids (vec (stub-machines))
  :state (or (get (stub-get-frame-db frame-id) :rf/machines) {})}
  :epochs (vec (stub-epoch-history frame-id))
- ;; Per rf2-g1b2m / rf2-8uwce the trace ring is per-frame; the
- ;; first arg IS the frame-id and `{:flat true}` returns raw
- ;; events (the legacy flat-stream shape this slot has always
- ;; emitted).
- :traces (vec (stub-trace-buffer frame-id {:flat true}))
+ ;; Per rf2-g1b2m / rf2-8uwce the trace ring is per-frame; per
+ ;; rf2-mscih the snapshot `:traces` slice ships cascade-bundles
+ ;; by default (the framework's storage unit, matching the
+ ;; streaming subscribe wire shape per Tool-Pair §Reading the
+ ;; per-frame trace ring). Production runtime calls
+ ;; `(trace-tooling/trace-buffer frame-id)` (zero-arg opts).
+ :traces (vec (stub-trace-buffer frame-id))
  nil))
 
 (defn- snapshot-frame [frame-id slices]

--- a/skills/re-frame2-pair/tests/runtime/streaming_subscriptions_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/streaming_subscriptions_test.clj
@@ -173,15 +173,37 @@
  (update :queue-bytes (fnil + 0) ev-bytes))]
  (evict-oldest sub' max-events max-bytes)))
 
+(defn frameless-event?
+ "Mirror of `runtime/frameless-event?` (rf2-mscih) — true when the event
+ carries no `:rf.trace/dispatch-id` tag. The cascade-bundle topics
+ filter these out at the dispatch gate; the `:frameless` topic accepts
+ only these."
+ [ev]
+ (nil? (get-in ev [:tags :rf.trace/dispatch-id])))
+
 (defn dispatch-trace-to-subs!
  [subs ev]
+ (let [frameless? (frameless-event? ev)]
  (reduce-kv
  (fn [acc sub-id sub]
- (if (and (contains? #{:trace :fx :error} (:topic sub))
+ (let [topic (:topic sub)
+ routes? (cond
+ (contains? #{:trace :fx :error} topic)
+ ;; Cascade-bundle topics — never deliver frameless events.
+ (and (not frameless?)
  (trace-matches? (:compiled-filter sub) ev))
+
+ (= :frameless topic)
+ ;; The frameless channel — only frameless events.
+ (and frameless?
+ (trace-matches? (:compiled-filter sub) ev))
+
+ :else
+ false)]
+ (if routes?
  (update acc sub-id enqueue! ev)
- acc))
- subs subs))
+ acc)))
+ subs subs)))
 
 ;; ---------------------------------------------------------------------------
 ;; Privacy posture — mirror of the runtime guard.
@@ -368,14 +390,24 @@
  (let [subs (-> {} (subscribe! "s1" {:topic :trace :filter {:op-type :error}}))]
  (is (contains? subs "s1"))
  (is (= :trace (get-in subs ["s1" :topic])))
- (let [;; Three events, only one matches.
- ev1 {:op-type :error :tags {:rf.trace/event-id :user/login}}
- ev2 {:op-type :info :tags {:rf.trace/event-id :user/login}}
- ev3 {:op-type :error :tags {:rf.trace/event-id :user/logout}}
+ (let [;; Three events, only one matches. Per rf2-mscih cascade-bundle
+ ;; topics require `:rf.trace/dispatch-id` (frameless events get
+ ;; routed to the `:frameless` channel instead).
+ ev1 {:op-type :error :tags {:rf.trace/event-id :user/login
+ :rf.trace/dispatch-id 1}}
+ ev2 {:op-type :info :tags {:rf.trace/event-id :user/login
+ :rf.trace/dispatch-id 1}}
+ ev3 {:op-type :error :tags {:rf.trace/event-id :user/logout
+ :rf.trace/dispatch-id 2}}
  subs (-> subs
  (dispatch-trace-to-subs! ev1)
  (dispatch-trace-to-subs! ev2)
  (dispatch-trace-to-subs! ev3))]
+ ;; Per rf2-mscih the drain returns `:queue` raw; the MCP-server
+ ;; layer projects them into `:cascades` for cascade-bundle
+ ;; topics. The bb-runnable mirror exposes the queue directly so
+ ;; the contract under test is "what landed in the queue after
+ ;; filtering" rather than the post-projection wire shape.
  (let [[drain1 subs] (drain-subscription! subs "s1")]
  (is (= 2 (count (:events drain1))))
  (is (= ev1 (first (:events drain1))))
@@ -406,12 +438,15 @@
 (deftest epoch-subscription-only-receives-epoch-events
  ;; An :epoch sub should NOT be fed trace events; a :trace sub should
  ;; NOT be fed epoch records. Verifies the topic gating in the
- ;; dispatchers.
+ ;; dispatchers. Per rf2-mscih the trace event carries a dispatch-id
+ ;; so it routes to the cascade-bundle topic; a frameless event would
+ ;; route to `:frameless` instead.
  (let [subs (-> {}
  (subscribe! "epoch-sub" {:topic :epoch :filter {:event-id :cart/add}})
  (subscribe! "trace-sub" {:topic :trace}))
  ;; A trace event flows only to the trace sub.
- subs (dispatch-trace-to-subs! subs {:op-type :info :tags {}})
+ subs (dispatch-trace-to-subs! subs {:op-type :info
+ :tags {:rf.trace/dispatch-id 1}})
  ;; An epoch record flows only to the epoch sub (matching filter).
  subs (dispatch-epoch-to-subs! subs {:event-id :cart/add :effects []})]
  (is (= 1 (count (get-in subs ["trace-sub" :queue]))))
@@ -419,18 +454,19 @@
 
 (deftest fx-topic-defaults-op-type-but-respects-overrides
  (let [;; :fx sub with no extra filter matches any trace event with
- ;; :op-type :rf.fx.
+ ;; :op-type :rf.fx. Per rf2-mscih cascade-bundle topics require
+ ;; `:rf.trace/dispatch-id`.
  subs (-> {} (subscribe! "fx-sub" {:topic :fx}))
- ev {:op-type :rf.fx :tags {:fx-id :http}}
- ev2 {:op-type :info :tags {}}
+ ev {:op-type :rf.fx :tags {:fx-id :http :rf.trace/dispatch-id 1}}
+ ev2 {:op-type :info :tags {:rf.trace/dispatch-id 1}}
  subs (-> subs
  (dispatch-trace-to-subs! ev)
  (dispatch-trace-to-subs! ev2))]
  (is (= [ev] (get-in subs ["fx-sub" :queue]))))
  (testing "user filter can override the topic's base op-type"
  (let [subs (-> {} (subscribe! "fx-sub" {:topic :fx :filter {:op-type :info}}))
- ev {:op-type :rf.fx :tags {}}
- ev2 {:op-type :info :tags {}}
+ ev {:op-type :rf.fx :tags {:rf.trace/dispatch-id 1}}
+ ev2 {:op-type :info :tags {:rf.trace/dispatch-id 1}}
  subs (-> subs
  (dispatch-trace-to-subs! ev)
  (dispatch-trace-to-subs! ev2))]
@@ -438,8 +474,9 @@
 
 (deftest error-topic-matches-error-traces
  (let [subs (-> {} (subscribe! "err-sub" {:topic :error}))
- err {:op-type :error :tags {:handler-id :user/login}}
- ok {:op-type :info :tags {}}
+ err {:op-type :error :tags {:handler-id :user/login
+ :rf.trace/dispatch-id 1}}
+ ok {:op-type :info :tags {:rf.trace/dispatch-id 1}}
  subs (-> subs
  (dispatch-trace-to-subs! err)
  (dispatch-trace-to-subs! ok))]
@@ -458,13 +495,14 @@
 
 (deftest overflow-count-only-trip-drops-oldest-and-reports-events-reason
  ;; bytes budget set generously so it can't trip — count budget = 2.
+ ;; Per rf2-mscih cascade-bundle topics require `:rf.trace/dispatch-id`.
  (let [subs (-> {} (subscribe! "s" {:topic :trace
  :max-buffered-events 2
  :max-buffered-bytes 100000000}))
- e1 {:op-type :info :id 1}
- e2 {:op-type :info :id 2}
- e3 {:op-type :info :id 3}
- e4 {:op-type :info :id 4}
+ e1 {:op-type :info :id 1 :tags {:rf.trace/dispatch-id 1}}
+ e2 {:op-type :info :id 2 :tags {:rf.trace/dispatch-id 2}}
+ e3 {:op-type :info :id 3 :tags {:rf.trace/dispatch-id 3}}
+ e4 {:op-type :info :id 4 :tags {:rf.trace/dispatch-id 4}}
  subs (-> subs
  (dispatch-trace-to-subs! e1)
  (dispatch-trace-to-subs! e2)
@@ -487,11 +525,12 @@
 
 (deftest overflow-bytes-only-trip-drops-oldest-and-reports-bytes-reason
  ;; event budget set generously — fat events trip the byte budget.
+ ;; Per rf2-mscih cascade-bundle topics require `:rf.trace/dispatch-id`.
  (let [;; Each event's pr-str is dominated by :payload's length.
  fat (apply str (repeat 300 "x"))
- e1 {:op-type :info :id 1 :payload fat}
- e2 {:op-type :info :id 2 :payload fat}
- e3 {:op-type :info :id 3 :payload fat}
+ e1 {:op-type :info :id 1 :payload fat :tags {:rf.trace/dispatch-id 1}}
+ e2 {:op-type :info :id 2 :payload fat :tags {:rf.trace/dispatch-id 2}}
+ e3 {:op-type :info :id 3 :payload fat :tags {:rf.trace/dispatch-id 3}}
  one-size (event-byte-size e1)
  ;; Cap that fits ~2 events.
  byte-cap (int (* one-size 2.5))
@@ -515,8 +554,9 @@
  ;; Small events + tight count cap + roomy byte cap = count trips first.
  ;; The reason MUST be :max-buffered-events when only the event budget
  ;; was exceeded on the tripping enqueue (bytes are still under cap).
- (let [tiny {:id 1} ;; pr-str ~= 7 chars
- events (map #(assoc tiny :id %) (range 1 11)) ;; 10 events
+ ;; Per rf2-mscih cascade-bundle topics require `:rf.trace/dispatch-id`.
+ (let [events (mapv #(hash-map :id % :tags {:rf.trace/dispatch-id %})
+ (range 1 11)) ;; 10 events
  byte-cap 1000000 ;; never trips
  subs (-> {} (subscribe! "s" {:topic :trace
  :max-buffered-events 3
@@ -532,10 +572,11 @@
  ;; Fat events + roomy count cap + tight byte cap = bytes trip first.
  ;; The reason MUST be :max-buffered-bytes since the byte budget is
  ;; what's forcing eviction.
+ ;; Per rf2-mscih cascade-bundle topics require `:rf.trace/dispatch-id`.
  (let [fat (apply str (repeat 1000 "y"))
- e1 {:id 1 :payload fat}
- e2 {:id 2 :payload fat}
- e3 {:id 3 :payload fat}
+ e1 {:id 1 :payload fat :tags {:rf.trace/dispatch-id 1}}
+ e2 {:id 2 :payload fat :tags {:rf.trace/dispatch-id 2}}
+ e3 {:id 3 :payload fat :tags {:rf.trace/dispatch-id 3}}
  one-size (event-byte-size e1)
  ;; cap fits ONE event; byte budget trips on the second enqueue.
  byte-cap (int (* one-size 1.2))
@@ -556,12 +597,15 @@
 (deftest overflow-defaults-honour-runtime-defaults
  ;; Subscribe with neither budget specified — defaults populate from
  ;; the runtime constants. A queue under both caps takes no eviction.
+ ;; Per rf2-mscih cascade-bundle topics require `:rf.trace/dispatch-id`.
  (let [subs (-> {} (subscribe! "s" {:topic :trace}))
  sub (get subs "s")]
  (is (= default-max-buffered-events (:max-buffered-events sub)))
  (is (= default-max-buffered-bytes (:max-buffered-bytes sub)))
  (let [subs (reduce dispatch-trace-to-subs! subs
- (map #(assoc {:id %} :ix %) (range 100)))]
+ (map #(hash-map :id % :ix %
+ :tags {:rf.trace/dispatch-id %})
+ (range 100)))]
  (is (= 100 (count (get-in subs ["s" :queue]))))
  (is (zero? (get-in subs ["s" :dropped-events])))
  (is (nil? (get-in subs ["s" :overflow-reason]))))))
@@ -569,9 +613,11 @@
 (deftest unknown-topic-rejected-at-subscribe-level
  ;; The runtime's `subscribe!` returns {:ok? false :reason :unknown-topic}
  ;; — mirrored here as the dispatcher refusing to fan to an unknown topic.
- (let [recognised #{:trace :epoch :fx :error}]
+ ;; Per rf2-mscih `:frameless` joins the recognised set as the explicit
+ ;; opt-in channel for events with no `:rf.trace/dispatch-id`.
+ (let [recognised #{:trace :epoch :fx :error :frameless}]
  (is (not (contains? recognised :other)))
- (is (every? recognised [:trace :epoch :fx :error]))))
+ (is (every? recognised [:trace :epoch :fx :error :frameless]))))
 
 ;; ---------------------------------------------------------------------------
 ;; Privacy posture
@@ -599,14 +645,18 @@
  ;; Spec 009 §Privacy default contract: a `:sensitive? true` trace
  ;; event registered against a matching subscription MUST NOT be
  ;; enqueued under the default privacy posture.
+ ;; Per rf2-mscih cascade-bundle topics require `:rf.trace/dispatch-id`.
  (let [default-cfg {:include-sensitive? false}
  subs (-> {} (subscribe! "s1" {:topic :trace}))
  sensitive-ev {:op-type :rf.event :sensitive? true
- :tags {:rf.trace/event-id :auth/sign-in}}
+ :tags {:rf.trace/event-id :auth/sign-in
+ :rf.trace/dispatch-id 1}}
  ordinary-ev {:op-type :rf.event :sensitive? false
- :tags {:rf.trace/event-id :cart/add}}
+ :tags {:rf.trace/event-id :cart/add
+ :rf.trace/dispatch-id 2}}
  absent-flag-ev {:op-type :rf.event ;; no :sensitive? at all
- :tags {:rf.trace/event-id :route/change}}
+ :tags {:rf.trace/event-id :route/change
+ :rf.trace/dispatch-id 3}}
  subs (-> subs
  (on-trace-streaming default-cfg sensitive-ev)
  (on-trace-streaming default-cfg ordinary-ev)
@@ -622,12 +672,15 @@
  ;; The opt-in path is the escape hatch for apps where re-frame2-pair itself is
  ;; the trust boundary. With `:include-sensitive? true` the streaming
  ;; surface forwards every event regardless of the flag.
+ ;; Per rf2-mscih cascade-bundle topics require `:rf.trace/dispatch-id`.
  (let [opt-in-cfg {:include-sensitive? true}
  subs (-> {} (subscribe! "s1" {:topic :trace}))
  sensitive-ev {:op-type :rf.event :sensitive? true
- :tags {:rf.trace/event-id :auth/sign-in}}
+ :tags {:rf.trace/event-id :auth/sign-in
+ :rf.trace/dispatch-id 1}}
  ordinary-ev {:op-type :rf.event :sensitive? false
- :tags {:rf.trace/event-id :cart/add}}
+ :tags {:rf.trace/event-id :cart/add
+ :rf.trace/dispatch-id 2}}
  subs (-> subs
  (on-trace-streaming opt-in-cfg sensitive-ev)
  (on-trace-streaming opt-in-cfg ordinary-ev))]
@@ -638,15 +691,89 @@
  ;; The privacy guard runs *before* the per-subscription filter, so
  ;; even a subscription whose filter would otherwise match a sensitive
  ;; event sees nothing under the default policy.
+ ;; Per rf2-mscih cascade-bundle topics require `:rf.trace/dispatch-id`.
  (let [default-cfg {:include-sensitive? false}
  subs (-> {} (subscribe! "auth-events"
  {:topic :trace
  :filter {:event-id :auth/sign-in}}))
  sensitive-ev {:op-type :rf.event :sensitive? true
- :tags {:rf.trace/event-id :auth/sign-in}}
+ :tags {:rf.trace/event-id :auth/sign-in
+ :rf.trace/dispatch-id 1}}
  subs (on-trace-streaming subs default-cfg sensitive-ev)]
  (is (empty? (get-in subs ["auth-events" :queue]))
  "even a filter that *names* the sensitive event must not pull it through")))
+
+;; ---------------------------------------------------------------------------
+;; Cascade-bundle topic routing (rf2-mscih)
+;; ---------------------------------------------------------------------------
+
+(deftest cascade-bundle-topics-reject-frameless-events
+ ;; The cascade-bundle topics (`:trace`/`:fx`/`:error`) ONLY accept
+ ;; events with a `:rf.trace/dispatch-id` tag — frameless events
+ ;; (registration emits, REPL evals) belong on the `:frameless` channel.
+ (let [subs (-> {} (subscribe! "trace-sub" {:topic :trace}))
+ cascade-ev {:op-type :rf.event
+ :tags {:rf.trace/dispatch-id 1
+ :rf.trace/event-id :user/login}}
+ frameless-ev {:op-type :rf.registry
+ :operation :rf.registry/registered
+ :tags {:registry-kind :event}}
+ subs (-> subs
+ (dispatch-trace-to-subs! cascade-ev)
+ (dispatch-trace-to-subs! frameless-ev))]
+ (testing "the cascade-bundle event lands; the frameless event does not"
+ (is (= 1 (count (get-in subs ["trace-sub" :queue]))))
+ (is (= cascade-ev (first (get-in subs ["trace-sub" :queue])))))))
+
+(deftest frameless-topic-accepts-only-frameless-events
+ ;; The `:frameless` topic is the inverse — only events with no
+ ;; `:rf.trace/dispatch-id` tag flow through.
+ (let [subs (-> {} (subscribe! "frameless-sub" {:topic :frameless}))
+ cascade-ev {:op-type :rf.event
+ :tags {:rf.trace/dispatch-id 1
+ :rf.trace/event-id :user/login}}
+ reg-ev {:op-type :rf.registry
+ :operation :rf.registry/registered
+ :tags {:registry-kind :event}}
+ repl-ev {:op-type :rf.repl
+ :operation :rf.repl/eval
+ :tags {}}
+ subs (-> subs
+ (dispatch-trace-to-subs! cascade-ev)
+ (dispatch-trace-to-subs! reg-ev)
+ (dispatch-trace-to-subs! repl-ev))]
+ (testing "the cascade event is filtered out; both frameless events land"
+ (is (= 2 (count (get-in subs ["frameless-sub" :queue]))))
+ (is (= [reg-ev repl-ev] (get-in subs ["frameless-sub" :queue]))))))
+
+(deftest cross-frame-dispatch-id-merge-contract
+ ;; rf2-mscih cross-frame contract — a single cascade can fan out
+ ;; across frames; every emit on every frame shares the same
+ ;; `:rf.trace/dispatch-id`. The runtime queues events per
+ ;; subscription; the consumer reconstructs the cross-frame timeline
+ ;; by merging post-projection bundles via `:dispatch-id`.
+ (let [subs (-> {} (subscribe! "all-frames" {:topic :trace}))
+ frame-a-ev {:op-type :rf.event
+ :operation :rf.event/dispatched
+ :tags {:rf.trace/dispatch-id 100
+ :frame :rf/default
+ :rf.event/v [:user/login]}}
+ frame-b-ev {:op-type :rf.sub
+ :operation :rf.sub/run
+ :tags {:rf.trace/dispatch-id 100
+ :frame :stories}}
+ subs (-> subs
+ (dispatch-trace-to-subs! frame-a-ev)
+ (dispatch-trace-to-subs! frame-b-ev))
+ queue (get-in subs ["all-frames" :queue])]
+ (testing "both events ride the queue under the same :dispatch-id"
+ (is (= 2 (count queue)))
+ (is (= [frame-a-ev frame-b-ev] queue))
+ (is (every? #(= 100 (get-in % [:tags :rf.trace/dispatch-id])) queue)))
+ (testing "consumer can group-by :dispatch-id to merge across frames"
+ (let [merged (group-by #(get-in % [:tags :rf.trace/dispatch-id]) queue)]
+ (is (= 1 (count merged)))
+ (is (= 2 (count (get merged 100))))))))
 
 (let [{:keys [fail error]} (run-tests 'streaming-subscriptions-test)]
  (when (or (pos? fail) (pos? error))

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
@@ -1475,3 +1475,181 @@
                  "change in the JS assertion; if you loosened it, "
                  "remove the entry from "
                  "`re-frame2-pair-progress-js-required-grep-markers`."))))))
+
+;; ---------------------------------------------------------------------------
+;; Cascade-bundle wire-shape gate (rf2-mscih).
+;;
+;; re-frame2-pair-mcp's streaming `subscribe` tool ships matched events
+;; under one of two payload-slots per the sub's topic:
+;;
+;;   - `:cascades` — vector of cascade bundles on `:trace`/`:fx`/`:error`
+;;                   (cascade-bundle delivery, rf2-mscih). Each bundle
+;;                   matches `(rf/trace-buffer frame-id)` shape per
+;;                   spec/009 §Cascade projection + Tool-Pair §Reading
+;;                   the per-frame trace ring.
+;;   - `:events`   — flat vector on `:epoch` and `:frameless` (no
+;;                   cascade structure to bundle).
+;;
+;; Pre-rf2-mscih every topic shipped under `:events`. The reshape is the
+;; load-bearing change that lets AI consumers reason about cause→effect
+;; at `:dispatch-id` granularity without re-folding raw streams.
+;;
+;; The gate shape mirrors the per-marker pattern:
+;;   1. A canonical Malli schema for one cascade-bundle.
+;;   2. A re-frame2-pair fixture exercising the schema with realistic
+;;      cascade-bundle slots.
+;;   3. (No source-text pin — the cascade-bundle SHAPE is the framework's
+;;      `(rf/trace-buffer frame-id)` projection, not a re-frame2-pair-mcp
+;;      literal. The MCP server walks the drain envelope's `:cascades`
+;;      slot transparently.)
+;; ---------------------------------------------------------------------------
+
+(def CascadeBundle
+  "Cascade-bundle shape per `(rf/trace-buffer frame-id)` (spec/009
+  §Cascade projection + Tool-Pair §Reading the per-frame trace ring).
+  Open map — additive slots (e.g. a future `:flow` domino, a
+  `:timing-ms` rollup) compose without a schema bump.
+
+  Required slots:
+    :dispatch-id        — the cascade id (any). `:ungrouped` is not
+                          permitted on the wire (rf2-mscih filters
+                          frameless events before bundling); the
+                          cascade-bundle topics never ship `:ungrouped`.
+    :trace-events       — raw events for the cascade (vector). May
+                          be empty if every event was elided / dropped.
+    :event              — event vector or nil (the `:rf.event/dispatched`
+                          `:tags :rf.event/v` slot).
+    :effects/:subs/:renders/:other — projection domino slots (vectors).
+
+  Optional slots:
+    :frame              — frame-id keyword (nil when not frame-qualified).
+    :dispatched         — the full `:rf.event/dispatched` trace event.
+    :handler            — the `:rf.event/run-end` event.
+    :fx                 — the `:rf.fx/do-fx` event.
+    :parent-dispatch-id — causal-parent link (nil for a root cascade)."
+  [:map
+   {:closed false}
+   [:dispatch-id        :any]
+   [:trace-events       [:sequential :any]]
+   [:event              [:maybe [:sequential :any]]]
+   [:effects            [:sequential :any]]
+   [:subs               [:sequential :any]]
+   [:renders            [:sequential :any]]
+   [:other              [:sequential :any]]
+   [:frame              {:optional true} :any]
+   [:dispatched         {:optional true} :any]
+   [:handler            {:optional true} :any]
+   [:fx                 {:optional true} :any]
+   [:parent-dispatch-id {:optional true} :any]])
+
+(def CascadeBundleVector
+  "A drain tick's `:cascades` slot — a vector of cascade bundles."
+  [:sequential CascadeBundle])
+
+(def ^:private re-frame2-pair-cascade-bundle-fixture
+  "Canonical cascade-bundle shape for a single cascade — what
+  `subscribe`'s `:trace`/`:fx`/`:error` topics ship inside the
+  `:cascades` slot per tick (rf2-mscih)."
+  {:dispatch-id        17
+   :frame              :rf/default
+   :event              [:cart/add-item {:sku "abc"}]
+   :dispatched         {:operation :rf.event/dispatched
+                        :op-type :rf.event
+                        :tags {:rf.trace/dispatch-id 17
+                               :rf.event/v [:cart/add-item {:sku "abc"}]
+                               :rf.event/origin :app}}
+   :handler            {:operation :rf.event/run-end
+                        :op-type :rf.event
+                        :tags {:rf.trace/dispatch-id 17}}
+   :fx                 {:operation :rf.fx/do-fx
+                        :op-type :rf.fx
+                        :tags {:rf.trace/dispatch-id 17}}
+   :effects            [{:operation :rf.fx/handled :op-type :rf.fx
+                         :tags {:rf.trace/dispatch-id 17 :fx-id :db}}]
+   :subs               [{:operation :rf.sub/run :op-type :rf.sub
+                         :tags {:rf.trace/dispatch-id 17}}]
+   :renders            [{:operation :rf.view/render :op-type :rf.view
+                         :tags {:rf.trace/dispatch-id 17}}]
+   :other              []
+   :trace-events       [{:operation :rf.event/dispatched :op-type :rf.event
+                         :tags {:rf.trace/dispatch-id 17}}]
+   :parent-dispatch-id nil})
+
+(def ^:private re-frame2-pair-cross-frame-cascade-fixture
+  "Cross-frame cascade reconstruction sample (rf2-mscih) — two bundles
+  carrying the same `:dispatch-id` from two different frames. The
+  consumer merges by `:dispatch-id` to reconstruct the unified
+  timeline per Tool-Pair §Cross-frame cascade reconstruction."
+  [{:dispatch-id 42
+    :frame       :rf/default
+    :event       [:user/login {:id "u1"}]
+    :effects     []
+    :subs        []
+    :renders     []
+    :other       []
+    :trace-events [{:operation :rf.event/dispatched
+                    :op-type :rf.event
+                    :tags {:rf.trace/dispatch-id 42 :frame :rf/default}}]
+    :parent-dispatch-id nil}
+   {:dispatch-id 42
+    :frame       :stories
+    :event       nil
+    :effects     []
+    :subs        [{:operation :rf.sub/run :op-type :rf.sub
+                   :tags {:rf.trace/dispatch-id 42 :frame :stories}}]
+    :renders     []
+    :other       []
+    :trace-events [{:operation :rf.sub/run :op-type :rf.sub
+                    :tags {:rf.trace/dispatch-id 42 :frame :stories}}]
+    :parent-dispatch-id nil}])
+
+(deftest cascade-bundle-fixture-conforms-to-schema
+  (is (m/validate CascadeBundle re-frame2-pair-cascade-bundle-fixture)
+      (str "Cascade-bundle fixture failed schema validation:\n"
+           (me/humanize
+             (m/explain CascadeBundle re-frame2-pair-cascade-bundle-fixture)))))
+
+(deftest cross-frame-cascade-bundles-conform
+  ;; The cross-frame reconstruction case (rf2-mscih) — a vector of
+  ;; bundles sharing `:dispatch-id` across frames. Every bundle MUST
+  ;; validate; consumers merge by `:dispatch-id`.
+  (is (m/validate CascadeBundleVector re-frame2-pair-cross-frame-cascade-fixture)
+      (str "Cross-frame cascade-bundle vector failed schema validation:\n"
+           (me/humanize
+             (m/explain CascadeBundleVector re-frame2-pair-cross-frame-cascade-fixture))))
+  (testing "merge-by-:dispatch-id reconstructs a unified cascade timeline"
+    (let [by-id (group-by :dispatch-id re-frame2-pair-cross-frame-cascade-fixture)]
+      (is (= 1 (count by-id))
+          "the two bundles share one :dispatch-id (the cross-frame contract)")
+      (is (= 42 (first (keys by-id)))))))
+
+(deftest cascade-bundle-rejects-frameless-shape
+  ;; An `:ungrouped` `:dispatch-id` (`:ungrouped` is the
+  ;; `group-cascades` sentinel for frameless events) MUST NOT ship on
+  ;; the cascade-bundle wire — the runtime filters frameless events
+  ;; out of cascade-bundle topics. The schema accepts any
+  ;; `:dispatch-id` value (a typed cascade id is application-shaped),
+  ;; so the contract is enforced upstream at the runtime gate (see
+  ;; `dispatch-trace-to-subs!`). This test pins the contract POSITIVELY
+  ;; — a frameless event flowing into the `:frameless` topic ships
+  ;; under `:events`, not `:cascades`.
+  (testing "cascade-bundle topics ship under :cascades; frameless under :events"
+    ;; Cascade-bundle topics: the progress payload's slot is :cascades.
+    (let [cascade-tick {:sub-id "sub-1"
+                        :cascades [re-frame2-pair-cascade-bundle-fixture]
+                        :dropped-events 0 :dropped-bytes 0}]
+      (is (vector? (:cascades cascade-tick))
+          ":cascades slot rides as a vector on cascade-bundle topics"))
+    ;; Frameless topic: the progress payload's slot is :events with
+    ;; single trace events (no cascade structure).
+    (let [frameless-tick {:sub-id "sub-2"
+                          :events [{:operation :rf.registry/registered
+                                    :op-type :rf.registry
+                                    :tags {}}]
+                          :dropped-events 0 :dropped-bytes 0}]
+      (is (vector? (:events frameless-tick))
+          ":events slot rides on the :frameless topic — flat trace events")
+      (is (not (contains? (first (:events frameless-tick))
+                          :rf.trace/dispatch-id))
+          "frameless events carry NO :rf.trace/dispatch-id tag"))))
+

--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -950,17 +950,98 @@ summary `{:ok? true :sub-id :delivered N :dropped-events N
 
 ### Topics
 
-| Topic    | What gets pushed                                                  |
-|----------|-------------------------------------------------------------------|
-| `trace`  | Every raw trace event matching `filter`.                          |
-| `epoch`  | Every assembled `:rf/epoch-record` matching `filter`.             |
-| `fx`     | Sugar — `topic :trace` with base filter `{:op-type :rf.fx}`.      |
-| `error`  | Sugar — `topic :trace` with base filter `{:op-type :error}`.      |
+| Topic       | What gets pushed                                                                                                |
+|-------------|-----------------------------------------------------------------------------------------------------------------|
+| `trace`     | Every raw trace event matching `filter` — grouped into cascade bundles by `:rf.trace/dispatch-id` (rf2-mscih).  |
+| `epoch`     | Every assembled `:rf/epoch-record` matching `filter`. Already cascade-shaped by construction.                   |
+| `fx`        | Sugar — `topic :trace` with base filter `{:op-type :rf.fx}`. Cascade-bundle delivery as for `:trace`.            |
+| `error`     | Sugar — `topic :trace` with base filter `{:op-type :error}`. Cascade-bundle delivery as for `:trace`.            |
+| `frameless` | Every trace event matching `filter` whose `:rf.trace/dispatch-id` tag is absent — registration emits, REPL evals, lifecycle outside any cascade (per [Tool-Pair.md §Frameless trace events — live channel only](../../../spec/Tool-Pair.md#frameless-trace-events--live-channel-only-rf2-g1b2m-b3-ruling)). Single-event delivery. |
 
 User-supplied filter keys win over the topic's base filter on conflict
 — the topic is a default, not a lock. So `subscribe {:topic :fx
 :filter {:op-type :info}}` actually streams `:info` traces (the user
 filter wins). Don't do this — but the substrate doesn't refuse it.
+
+### Cascade-bundle wire format (rf2-mscih)
+
+On the cascade-bundle topics (`:trace`, `:fx`, `:error`) every
+progress payload's `:cascades` slot is a vector of cascade bundles
+keyed by `:dispatch-id`. Each bundle matches the framework's
+`(rf/trace-buffer frame-id)` shape per [spec/009 §Cascade projection](../../../spec/009-Instrumentation.md#cascade-projection-group-cascades--domino-bucket)
+and [Tool-Pair.md §Reading the per-frame trace ring](../../../spec/Tool-Pair.md#reading-the-per-frame-trace-ring--cascade-bundles--flat-opt-in-rf2-g1b2m):
+
+```clojure
+{:dispatch-id        <id>                  ; cascade id
+ :frame              <frame-id or nil>
+ :event              <event-vector or nil> ; from :rf.event/dispatched :tags
+ :dispatched         <trace-event or nil>  ; full :rf.event/dispatched event
+ :handler            <trace-event or nil>  ; :rf.event/run-end emit (last wins)
+ :fx                 <trace-event or nil>  ; :rf.fx/do-fx
+ :effects            [<trace-event> ...]   ; :op-type :rf.fx (other operations)
+ :subs               [<trace-event> ...]   ; :rf.sub/run + :rf.sub/skip + :rf.sub/create
+ :renders            [<trace-event> ...]   ; :rf.view/render
+ :other              [<trace-event> ...]   ; everything else (errors, machine, …)
+ :trace-events       [<trace-event> ...]   ; raw events for the cascade
+ :parent-dispatch-id <id or nil>}          ; causal-parent link
+```
+
+One tick = one drain's worth of cascade bundles. A cascade is the
+"atomic" delivery unit — consumers can reason about cause→effect at
+the granularity of `:dispatch-id` without re-folding flat-event
+streams (the pre-rf2-mscih posture).
+
+Events with no `:rf.trace/dispatch-id` tag (registration emits, REPL
+evals, lifecycle outside any cascade) NEVER ride the cascade-bundle
+topics; the framework filters them at the dispatch gate. Consumers
+that need them subscribe to `:frameless` explicitly.
+
+The `:dropped-events` / `:dropped-bytes` / `:overflow-reason`
+counters on the progress payload count the raw queued events that
+were EVICTED by the byte+event budget — not cascades. A non-zero
+`:dropped-events` means consumers reconstructing a cascade should
+tolerate partially-truncated bundles (some of the cascade's
+constituent events may have aged out).
+
+### Cross-frame cascade reconstruction
+
+A cascade can fan out across frames per [spec/002 §Cross-frame
+dispatch](../../../spec/002-Frames.md). Every emit on every frame
+shares the same `:rf.trace/dispatch-id`, so the runtime emits one
+bundle per `(frame, dispatch-id)` pair per drain. Consumers that
+watch multiple frames merge by `:dispatch-id` to reconstruct the
+cross-frame view (per [Tool-Pair.md §Cross-frame cascade
+reconstruction](../../../spec/Tool-Pair.md#cross-frame-cascade-reconstruction--merge-by-dispatch-id)).
+In practice, each cascade lives in exactly one frame (re-frame2 does
+not route a single dispatch across multiple frames per [Spec 002
+§Routing](../../../spec/002-Frames.md#routing-the-dispatch-envelope)),
+so the multi-frame view is interleaved rather than overlapping;
+`dispatch-id` ordering renders the correct turn-by-turn timeline.
+
+### Frameless channel
+
+The `:frameless` topic delivers events whose `:rf.trace/dispatch-id`
+tag is absent — registration / hot-reload / REPL emits that never
+rode a dispatch cascade. The progress payload's load slot is
+`:events` (flat); the cascade-bundle shape doesn't apply (there is
+no cascade to bundle).
+
+Frameless events bypass every ring per [Tool-Pair.md §Frameless
+trace events](../../../spec/Tool-Pair.md#frameless-trace-events--live-channel-only-rf2-g1b2m-b3-ruling)
+— they stream live to listeners only. The `:frameless` topic is the
+MCP-side surface for that live channel; consumers MUST opt in
+explicitly per the framework's "separate channel" ruling
+(rf2-g1b2m-B3).
+
+### Cursor staleness on cascade-bundle streams
+
+Streaming subscriptions are forward-only — there is no cursor to
+become stale. The `:rf.mcp/cursor-stale` reason value applies to
+the cursor-paginated tools (`trace-window`, `watch-epochs`) whose
+cursors key on `:epoch-id` in `epoch-history`. The cascade-bundle
+wire format reshape (rf2-mscih) does NOT introduce a new cursor
+surface; it changes the unit of streaming delivery and the
+per-tick payload slot.
 
 ### Filter vocabulary
 
@@ -1053,7 +1134,7 @@ While the subscription is open, each non-empty batch tick emits
   "params": {
     "progressToken": "<token>",  // echoed from the call's _meta
     "progress": <tick-number>,   // monotonic, 1-based
-    "message": "{:sub-id \"...\" :events [...] :dropped-events 0 :dropped-bytes 0}",
+    "message": "{:sub-id \"...\" :cascades [...] :dropped-events 0 :dropped-bytes 0}",
     "_meta": {
       "data": {
         "dropped-events": 0,                    // events evicted this tick
@@ -1066,12 +1147,19 @@ While the subscription is open, each non-empty batch tick emits
 ```
 
 `message` is an EDN-printed string carrying the event batch — the
-same shape the runtime's `drain-subscription!` returns. Capable MCP
-clients can also inspect the `_meta.data` slot for the structured drop
-counts. `_meta` is used because the official MCP SDK preserves it in
-progress callbacks while stripping unknown top-level progress fields.
-`overflow-reason` carries the stringified EDN keyword of the
-budget that tripped LAST (`":max-buffered-events"` or
+same shape the runtime's `drain-subscription!` returns. The
+payload-slot name reflects the topic's wire shape (rf2-mscih):
+
+- `:cascades` — vector of cascade bundles, on cascade-bundle topics
+  (`:trace` / `:fx` / `:error`). See §Cascade-bundle wire format above.
+- `:events` — flat vector, on `:epoch` (one `:rf/epoch-record` per
+  entry) and `:frameless` (one trace event per entry).
+
+Capable MCP clients can also inspect the `_meta.data` slot for the
+structured drop counts. `_meta` is used because the official MCP SDK
+preserves it in progress callbacks while stripping unknown top-level
+progress fields. `overflow-reason` carries the stringified EDN
+keyword of the budget that tripped LAST (`":max-buffered-events"` or
 `":max-buffered-bytes"` — see [`Principles.md` §Streaming subscribe
 byte+event budget](Principles.md#streaming-subscribe-byteevent-budget-rf2-ho4ve)
 for the policy). `null` when no eviction happened on this tick.

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/descriptors_data.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/descriptors_data.cljs
@@ -564,8 +564,16 @@
                      "Long-running tools/call — emits each batch of matching events as a notifications/progress notification "
                      "(correlated via the call's progressToken), and resolves with a summary when the client cancels or an "
                      "unsubscribe op fires. Topics: 'trace' (raw trace stream), 'epoch' (assembled :rf/epoch-records), "
-                     "'fx' (trace stream filtered to :op-type :rf.fx), 'error' (trace stream filtered to :op-type :error). "
-                     "Filter vocab depends on topic — :trace/:fx/:error accept the (rf/trace-buffer) filter map "
+                     "'fx' (trace stream filtered to :op-type :rf.fx), 'error' (trace stream filtered to :op-type :error), "
+                     "'frameless' (trace events with no :rf.trace/dispatch-id — registration emits, REPL evals, lifecycle "
+                     "outside any cascade; per Tool-Pair §Frameless trace events). "
+                     "Cascade-bundle delivery (rf2-mscih): :trace / :fx / :error ship each tick's matched events grouped "
+                     "by :rf.trace/dispatch-id into cascade bundles matching `(rf/trace-buffer frame-id)` shape "
+                     "(:dispatch-id :frame :event :dispatched :handler :fx :effects :subs :renders :other :trace-events "
+                     ":parent-dispatch-id). The progress payload's load slot is `:cascades` on these topics. Frameless "
+                     "events NEVER ride these topics — opt into the `:frameless` topic explicitly. :epoch and :frameless "
+                     "ship as `:events` (flat). "
+                     "Filter vocab depends on topic — :trace/:fx/:error/:frameless accept the (rf/trace-buffer) filter map "
                      "(:operation :op-type :frame :severity :event-id :handler-id :source :origin :dispatch-id :since-ms :between); "
                      ":epoch accepts the epoch-matches? predicate map (:event-id :event-id-prefix :effects :touches-path "
                      ":sub-ran :render :origin :frame :timing-ms). :timing-ms (rf2-r3azh) is a server-side wall-clock "
@@ -574,22 +582,23 @@
                      "Per spec/009 §Privacy this forwarder default-drops events carrying `:sensitive? true` at the top "
                      "level; opt back in with `include-sensitive true`. Dropped count surfaces as `:dropped-sensitive` "
                      "on each progress payload (when non-zero) and the final summary. "
-                     "Each progress payload's `:events` vector is structurally deduped by default (rf2-obpa9) — "
+                     "Each progress payload's payload-slot is structurally deduped by default (rf2-obpa9) — "
                      "shared subtrees across the tick collapse to a `{:rf.mcp/dedup-table ...}` wrapper; "
                      "agent host reconstructs via `(de-dupe.core/expand cache-map)`. Dedup is per-tick, not "
                      "per-stream — each notifications/progress frame carries its own cache, no cross-tick "
                      "references. Pass `dedup false` to skip. "
                      "Examples: "
                      "1. Stream every epoch: {:topic \"epoch\"} -> progress ticks {:sub-id \"<uuid>\" :events [...]} until cancel; final summary {:ok? true :sub-id \"<uuid>\" :delivered N :ticks K :reason :aborted}. "
-                     "2. Filtered fx stream: {:topic \"fx\" :filter {:event-id :cart/checkout}} -> ticks only for checkout-driven fx; ends with {:ok? true :delivered N :reason :aborted}. "
-                     "3. Time-bounded probe: {:topic \"error\" :max-ms 30000 :max-events 100} -> closes after 30s or 100 errors, whichever first; {:ok? true :delivered K :reason :max-ms-reached}.")
+                     "2. Filtered fx-cascade stream: {:topic \"fx\" :filter {:event-id :cart/checkout}} -> ticks {:sub-id \"...\" :cascades [{:dispatch-id ... :event ... :fx ... :effects [...] :trace-events [...]}]}; ends with {:ok? true :delivered N :reason :aborted}. "
+                     "3. Time-bounded error probe: {:topic \"error\" :max-ms 30000 :max-events 100} -> closes after 30s or 100 errors; cascade bundles only. "
+                     "4. Frameless live channel: {:topic \"frameless\"} -> ticks {:sub-id \"...\" :events [<registration / REPL emits>]}.")
    :typicalTokens 1000
    :annotations streaming-subscribe-annotations
    :outputSchema streaming-final-summary
    :inputSchema {:type "object"
                  :properties {:topic   {:type "string"
                                         :description "Topic name. Required."
-                                        :enum ["trace" "epoch" "fx" "error"]}
+                                        :enum ["trace" "epoch" "fx" "error" "frameless"]}
                               :filter  {:description "Filter map (JSON object) or EDN string. Vocab depends on topic."
                                         :oneOf [{:type "object"}
                                                 {:type "string"}]}
@@ -636,7 +645,7 @@
                      "Returns `{:ok? true :subs [{:id :topic :filter :queue-depth :queue-bytes "
                      ":dropped-events :dropped-bytes :overflow-reason :created-at}]}` — one entry per "
                      "currently-registered subscription. Empty `:subs` vector when no streams are open. "
-                     "Optional filters: `topic` (one of `:trace` / `:epoch` / `:fx` / `:error`) narrows to "
+                     "Optional filters: `topic` (one of `:trace` / `:epoch` / `:fx` / `:error` / `:frameless`) narrows to "
                      "a single topic; `sub-id` returns only the matching sub. A non-nil `:overflow-reason` "
                      "indicates the queue has been evicting older events to stay inside its budget — tune "
                      "`max-buffered-events` / `max-buffered-bytes` on the next `subscribe` call. "
@@ -649,8 +658,8 @@
    :outputSchema envelope-or-marker
    :inputSchema {:type "object"
                  :properties {:topic  {:type "string"
-                                       :description "Optional filter — only return subs on this topic. One of trace, epoch, fx, error."
-                                       :enum ["trace" "epoch" "fx" "error"]}
+                                       :description "Optional filter — only return subs on this topic. One of trace, epoch, fx, error, frameless."
+                                       :enum ["trace" "epoch" "fx" "error" "frameless"]}
                               :sub-id {:type "string"
                                        :description "Optional filter — only return the sub with this uuid."}
                               :build  {:type "string"}}

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/subscribe.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/subscribe.cljs
@@ -186,10 +186,21 @@
 (defn emit-progress-tick!
   "Build the per-tick progress payload and ship it via the MCP
   `sendNotification`. Failures are swallowed — a flaky client must not
-  collapse the stream."
+  collapse the stream.
+
+  rf2-mscih — the `:message`-slot EDN map carries the delivered payload
+  under one of two slots per the sub's topic:
+    - `:cascades` (vector of cascade bundles) on cascade-bundle topics
+      (`:trace`/`:fx`/`:error`);
+    - `:events` (flat vector) on `:epoch` and `:frameless`.
+  The split keeps the wire shape congruent with `(rf/trace-buffer
+  frame-id)` for cascade-bundle topics — one tick = one cascade's
+  traces as a unit. The `:cascade?` flag on `tick-state` carries the
+  topic-shape signal."
   [{:keys [send-note progress-tk sub-id]} dedup? tick-state]
-  (let [{:keys [tick dedup-events ev-dropped by-dropped
-                ov-reason dropped tick-elided]} tick-state]
+  (let [{:keys [tick cascade? dedup-events ev-dropped by-dropped
+                ov-reason dropped tick-elided]} tick-state
+        payload-slot (if cascade? :cascades :events)]
     (try
       (send-note
         #js {:method "notifications/progress"
@@ -198,7 +209,7 @@
                        tick
                        (pr-str (wire/with-indicators
                                  (cond-> {:sub-id         sub-id
-                                          :events         dedup-events
+                                          payload-slot    dedup-events
                                           :dedup          dedup?
                                           :dropped-events ev-dropped
                                           :dropped-bytes  by-dropped}
@@ -211,32 +222,48 @@
       (catch :default _ nil))))
 
 ;; ---------------------------------------------------------------------------
-;; Drain eval-form — server-side elision wrap (rf2-vr2hn).
+;; Drain eval-form — server-side elision wrap (rf2-vr2hn + rf2-mscih).
 ;; ---------------------------------------------------------------------------
 ;;
-;; `drain-subscription!` returns `{:ok? :sub-id :events [...]
-;; :dropped-events :dropped-bytes :overflow-reason :gone?}`. The `:epoch`
-;; topic ships full epoch records — `:db-after` / `:db-before` / `:app-db`
-;; slices ride verbatim. When the `--allow-sensitive-reads` boot gate is OFF
-;; (the published-build default), each event must flow through
+;; `drain-subscription!` returns one of two envelopes per the sub's topic
+;; (rf2-mscih):
+;;
+;;   - Cascade-bundle topics (`:trace`/`:fx`/`:error`) →
+;;     `{:ok? :sub-id :cascades [<bundle> ...] :dropped-events ... :gone? ...}`
+;;     where each bundle has `:dispatch-id :frame :event :dispatched
+;;     :handler :fx :effects :subs :renders :other :trace-events
+;;     :parent-dispatch-id` (the framework's `(rf/trace-buffer frame-id)`
+;;     shape).
+;;   - Flat topics (`:epoch`/`:frameless`) →
+;;     `{:ok? :sub-id :events [...] :dropped-events ... :gone? ...}`.
+;;
+;; The `:epoch` topic ships full epoch records (`:db-after` / `:db-before`
+;; ride verbatim). When the `--allow-sensitive-reads` boot gate is OFF (the
+;; published-build default), each delivered value must flow through
 ;; `re-frame.core/elide-wire-value` BEFORE it crosses the nREPL wire —
 ;; mirroring the snapshot / get-path gate (rf2-c2dtu) so an operator who
 ;; didn't pass `--allow-sensitive-reads` can't be talked into shipping raw
 ;; state through a hostile per-call arg.
 ;;
 ;; The walker reads the live `[:rf/elision]` registry, so it has to run
-;; app-side. We compose `drain-subscription!` server-side with a mapv
-;; over `:events`, returning the same envelope with elided values in
-;; place. When elision is OFF (operator opted in via `--allow-sensitive-reads`
-;; AND passed `:elision false`), the bare drain form ships raw — the
-;; pre-rf2-vr2hn posture.
+;; app-side. We compose `drain-subscription!` server-side with mapv over
+;; whichever slot the drain produced — `:cascades` for cascade-bundle
+;; topics, `:events` for flat topics. When elision is OFF (operator opted
+;; in via `--allow-sensitive-reads` AND passed `:elision false`), the bare
+;; drain form ships raw — the pre-rf2-vr2hn posture.
 
 (defn drain-form
   "Build the nREPL drain eval form. When `elision?` is true, wraps the
-  drain envelope so `:events` flows through `re-frame.core/elide-wire-value`
-  server-side; when false, emits the bare drain call. `incl?` threads
-  into the walker's `:rf.size/include-sensitive?` opt — gate-OFF callers
-  see redacted sensitive slots regardless of any per-call opt-in.
+  drain envelope so the delivered slot (`:cascades` or `:events`,
+  whichever the runtime produced) flows through
+  `re-frame.core/elide-wire-value` server-side. `incl?` threads into the
+  walker's `:rf.size/include-sensitive?` opt — gate-OFF callers see
+  redacted sensitive slots regardless of any per-call opt-in.
+
+  Per rf2-mscih the wrapper handles both delivery shapes (cascade-bundle
+  topics → `:cascades`; flat topics → `:events`) without baking the
+  topic into the form — `cond->` over slot presence keeps the form
+  topic-agnostic and the elision contract single-sourced.
 
   Public (not `defn-`) so unit tests can pin the form shape directly —
   the form-string is the contract surface between MCP server and the
@@ -250,11 +277,18 @@
          ;; `include-large?` (subscribe always elides, so emit markers ⇒
          ;; pass `false`). Pre-rf2-suoj2 this was `true` under the old
          ;; "enabled?" polarity that the helper inverted internally.
-         'opts  (ef/rt-raw (elision/elision-opts-edn false incl?))
-         'evts  (ef/rt-raw
-                  (str "(mapv #(re-frame.core/elide-wire-value % opts)"
-                       " (:events drain))"))]
-        (ef/rt-raw "(assoc drain :events evts)")))
+         'opts  (ef/rt-raw (elision/elision-opts-edn false incl?))]
+        ;; Apply the walker to whichever slot the drain produced.
+        ;; Per rf2-mscih cascade-bundle topics return `:cascades`; flat
+        ;; topics return `:events`. `cond->` handles both without baking
+        ;; the topic into the form.
+        (ef/rt-raw
+          (str "(let [walk (fn [xs] (mapv (fn [x] (re-frame.core/elide-wire-value x opts)) xs))]"
+               " (cond-> drain"
+               " (contains? drain :cascades)"
+               " (update :cascades walk)"
+               " (contains? drain :events)"
+               " (update :events walk)))"))))
     (ef/emit (ef/rt-call 'drain-subscription! sub-id))))
 
 ;; ---------------------------------------------------------------------------
@@ -324,12 +358,23 @@
                   (fn [drain-resp]
                     (if (:gone? drain-resp)
                       (terminate :sub-gone)
-                      (let [raw-evts       (:events drain-resp)
+                      (let [;; rf2-mscih — the drain envelope carries the
+                            ;; delivered slot per the sub's topic:
+                            ;; `:cascades` for cascade-bundle topics
+                            ;; (`:trace`/`:fx`/`:error`), `:events` for
+                            ;; flat topics (`:epoch`/`:frameless`).
+                            ;; Exactly one is present; `cascade?` keeps
+                            ;; the slot name on the progress payload
+                            ;; congruent with the topic's wire shape.
+                            cascade?       (contains? drain-resp :cascades)
+                            raw-items      (if cascade?
+                                             (:cascades drain-resp)
+                                             (:events   drain-resp))
                             ev-dropped     (:dropped-events  drain-resp 0)
                             by-dropped     (:dropped-bytes   drain-resp 0)
                             ov-reason      (:overflow-reason drain-resp)
                             [evts dropped] (sensitive/strip-sensitive
-                                             (vec raw-evts) incl?)
+                                             (vec raw-items) incl?)
                             ;; :elided-large counts upstream-pre-elided markers per
                             ;; Spec 009 §Indicator field (rf2-8cntr) — per-tick contribution.
                             tick-elided    (base-elision/count-elided-markers evts)
@@ -357,6 +402,7 @@
                                  :sub-id      sub-id}
                                 dedup?
                                 {:tick         (:tick s')
+                                 :cascade?     cascade?
                                  :dedup-events (dedup/dedup-value evts dedup?)
                                  :ev-dropped   ev-dropped
                                  :by-dropped   by-dropped
@@ -473,11 +519,11 @@
         {:keys [signal send-note progress-tk]} (parse-mcp-extra extra)]
     (cond
       (or (nil? topic)
-          (not (#{:trace :epoch :fx :error} topic)))
+          (not (#{:trace :epoch :fx :error :frameless} topic)))
       (js/Promise.resolve
         (wire/err-text {:ok? false :reason :unknown-topic
                         :given (wire/arg raw-args :topic)
-                        :hint  "Recognised topics: trace, epoch, fx, error."}))
+                        :hint  "Recognised topics: trace, epoch, fx, error, frameless."}))
 
       :else
       ;; rf2-3ijbl — reserve a session-wide stream slot BEFORE any

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/list_subscriptions_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/list_subscriptions_test.cljs
@@ -28,9 +28,9 @@
       (let [props (:properties (:inputSchema d))]
         (is (contains? props :topic))
         (is (contains? props :sub-id))
-        (is (= ["trace" "epoch" "fx" "error"]
+        (is (= ["trace" "epoch" "fx" "error" "frameless"]
                (:enum (:topic props)))
-            "topic enum lists the four runtime topics")))))
+            "topic enum lists the five runtime topics (rf2-mscih adds :frameless)")))))
 
 (deftest descriptor-surfaces-on-tools-list
   (testing "list-subscriptions shows up in tool-descriptors-js"

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/subscribe_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/subscribe_test.cljs
@@ -107,11 +107,16 @@
 ;; subscribe! whitelist.
 
 (deftest recognised-topics
-  (let [recognised #{:trace :epoch :fx :error}]
+  ;; Per rf2-mscih `:frameless` joins the recognised set as the
+  ;; explicit opt-in channel for events with no
+  ;; `:rf.trace/dispatch-id` — registration emits, REPL evals,
+  ;; lifecycle outside any cascade.
+  (let [recognised #{:trace :epoch :fx :error :frameless}]
     (is (contains? recognised :trace))
     (is (contains? recognised :epoch))
     (is (contains? recognised :fx))
     (is (contains? recognised :error))
+    (is (contains? recognised :frameless))
     (is (not (contains? recognised :unknown)))))
 
 ;; The progress payload shape — the MCP notifications/progress
@@ -477,3 +482,148 @@
     ;; correct, no raw-`str` concatenation hazard.
     (is (str/includes? form "\\\"quote\\\"")
         "embedded quotes survive as escaped EDN literals")))
+
+;; ---------------------------------------------------------------------------
+;; Cascade-bundle wire format (rf2-mscih) — drain envelope shape, slot
+;; selection on the progress payload, and cross-frame `:dispatch-id`
+;; merge.
+;; ---------------------------------------------------------------------------
+
+(deftest drain-form-handles-both-cascade-and-events-slots
+  ;; rf2-mscih — `drain-form` with elision ON must wrap WHICHEVER slot
+  ;; the runtime produced. The form uses `cond->` over slot presence so
+  ;; it's topic-agnostic at the form level; the runtime determines
+  ;; which slot the drain envelope carries.
+  (let [form (sub/drain-form "sub-1" true false)]
+    (is (str/includes? form ":cascades")
+        "drain form mentions the :cascades slot for cascade-bundle topics")
+    (is (str/includes? form ":events")
+        "drain form mentions the :events slot for flat topics")
+    (is (str/includes? form "contains?")
+        "the form uses contains? to discriminate the slot")
+    (is (str/includes? form "re-frame.core/elide-wire-value")
+        "the walker is applied to whichever slot is present")))
+
+(deftest progress-payload-uses-cascades-slot-on-cascade-bundle-topics
+  ;; rf2-mscih — the progress payload's load slot is named per the
+  ;; topic's wire shape: `:cascades` for cascade-bundle topics
+  ;; (`:trace`/`:fx`/`:error`), `:events` for flat topics
+  ;; (`:epoch`/`:frameless`).
+  (testing "the :cascade? flag in tick-state routes the payload to :cascades"
+    ;; Pure-data assertion: simulate the slot-selection logic the
+    ;; emitter applies.
+    (let [cascade? true
+          slot     (if cascade? :cascades :events)]
+      (is (= :cascades slot))))
+  (testing "the :cascade? flag false routes the payload to :events"
+    (let [cascade? false
+          slot     (if cascade? :cascades :events)]
+      (is (= :events slot)))))
+
+(deftest cascade-bundle-shape-pins-projection-slots
+  ;; Pin the shape contract — every cascade bundle carries the seven
+  ;; `group-cascades` slots (`:dispatch-id` / `:event` / `:handler` /
+  ;; `:fx` / `:effects` / `:subs` / `:renders` / `:other`) PLUS the
+  ;; runtime-side `:trace-events` slot. Mirrors `(rf/trace-buffer
+  ;; frame-id)` shape per Tool-Pair §Reading the per-frame trace ring.
+  (let [bundle {:dispatch-id        7
+                :frame              :rf/default
+                :event              [:cart/add {:sku "x"}]
+                :dispatched         {:operation :rf.event/dispatched}
+                :handler            {:operation :rf.event/run-end}
+                :fx                 {:operation :rf.fx/do-fx}
+                :effects            []
+                :subs               []
+                :renders            []
+                :other              []
+                :trace-events       [{:operation :rf.event/dispatched}]
+                :parent-dispatch-id nil}]
+    (is (contains? bundle :dispatch-id))
+    (is (contains? bundle :trace-events))
+    (is (contains? bundle :event))
+    (is (contains? bundle :effects))
+    (is (contains? bundle :subs))
+    (is (contains? bundle :renders))
+    (is (contains? bundle :other))
+    (is (contains? bundle :parent-dispatch-id))))
+
+(deftest cross-frame-cascade-merge-by-dispatch-id
+  ;; rf2-mscih cross-frame contract — a single cascade can fan out
+  ;; across frames; every emit on every frame shares the same
+  ;; `:rf.trace/dispatch-id`. Consumers merge by `:dispatch-id` to
+  ;; reconstruct the cross-frame view per Tool-Pair §Cross-frame
+  ;; cascade reconstruction.
+  (let [frame-a-bundle {:dispatch-id 99
+                        :frame       :rf/default
+                        :event       [:user/login]
+                        :effects     []
+                        :subs        []
+                        :renders     []
+                        :other       []
+                        :trace-events [{:operation :rf.event/dispatched
+                                        :tags {:rf.trace/dispatch-id 99
+                                               :frame :rf/default}}]
+                        :parent-dispatch-id nil}
+        frame-b-bundle {:dispatch-id 99
+                        :frame       :stories
+                        :event       nil
+                        :effects     []
+                        :subs        [{:operation :rf.sub/run
+                                       :tags {:rf.trace/dispatch-id 99
+                                              :frame :stories}}]
+                        :renders     []
+                        :other       []
+                        :trace-events [{:operation :rf.sub/run
+                                        :tags {:rf.trace/dispatch-id 99
+                                               :frame :stories}}]
+                        :parent-dispatch-id nil}
+        ;; Consumer-side reconstruction: merge by :dispatch-id.
+        merged (group-by :dispatch-id [frame-a-bundle frame-b-bundle])]
+    (is (= 1 (count merged))
+        "two bundles sharing :dispatch-id 99 merge into one timeline slot")
+    (is (= 2 (count (get merged 99)))
+        "both per-frame bundles ride under the same :dispatch-id key")
+    (is (= #{:rf/default :stories}
+           (into #{} (map :frame (get merged 99))))
+        "the merged slot exposes both frames' contributions")))
+
+(deftest frameless-channel-shape-is-flat-events-not-bundles
+  ;; rf2-mscih frameless contract — registration emits / REPL / boot
+  ;; lifecycle ride under `:events` (flat) on the `:frameless` topic.
+  ;; No cascade structure to bundle; the frameless events carry no
+  ;; `:rf.trace/dispatch-id` tag.
+  (let [registration-emit {:operation :rf.registry/registered
+                           :op-type :rf.registry
+                           :tags {:registry-kind :event}}
+        repl-emit         {:operation :rf.repl/eval
+                           :op-type :rf.repl
+                           :tags {}}
+        frameless-tick    {:sub-id "sub-frameless"
+                           :events [registration-emit repl-emit]
+                           :dropped-events 0
+                           :dropped-bytes  0}]
+    (is (contains? frameless-tick :events)
+        ":frameless ticks carry an :events slot, not :cascades")
+    (is (not (contains? frameless-tick :cascades))
+        ":frameless ticks MUST NOT carry a :cascades slot")
+    (is (every? #(nil? (get-in % [:tags :rf.trace/dispatch-id]))
+                (:events frameless-tick))
+        "frameless events MUST carry no :rf.trace/dispatch-id tag")))
+
+(deftest cursor-stale-does-not-apply-to-subscribe-streams
+  ;; rf2-mscih clarification — `:rf.mcp/cursor-stale` is a cursor-
+  ;; pagination concern (`trace-window` / `watch-epochs`), not a
+  ;; streaming concern. The `subscribe` surface is forward-only with
+  ;; no cursor; the cascade-bundle wire reshape introduces no new
+  ;; cursor surface.
+  (let [;; A streaming subscription's final summary — no cursor slot.
+        subscribe-summary {:ok? true
+                           :sub-id "sub-1"
+                           :topic :trace
+                           :delivered 12
+                           :ticks 3
+                           :reason :aborted}]
+    (is (not (contains? subscribe-summary :next-cursor))
+        "streaming subscriptions are forward-only — no cursor slot")
+    (is (not (contains? subscribe-summary :dispatch-id-of-next-cascade))
+        "cascade-bundle delivery introduces no new cursor")))


### PR DESCRIPTION
Follow-on from rf2-q03j7 (per-frame trace-ring consumer adoption) — the deeper wire-format reshape. The streaming subscribe surface now delivers matched events as cascade bundles (the storage unit) per Tool-Pair §Reading the per-frame trace ring, with a new dedicated `:frameless` channel for events outside any dispatch cascade.

## Wire format

On `:trace` / `:fx` / `:error` topics, each progress payload`s load slot is `:cascades` — a vector of cascade bundles keyed by `:rf.trace/dispatch-id`. Each bundle matches the framework`s `(rf/trace-buffer frame-id)` shape:

```clojure
{:dispatch-id        <id>
 :frame              <frame-id or nil>
 :event              <event-vector or nil>
 :dispatched         <:rf.event/dispatched trace event or nil>
 :handler            <:rf.event/run-end emit or nil>
 :fx                 <:rf.fx/do-fx event or nil>
 :effects            [<trace-event> ...]   ;; :op-type :rf.fx
 :subs               [<trace-event> ...]   ;; :rf.sub/*
 :renders            [<trace-event> ...]   ;; :rf.view/render
 :other              [<trace-event> ...]
 :trace-events       [<trace-event> ...]   ;; raw events for the cascade
 :parent-dispatch-id <id or nil>}          ;; causal-parent link
```

Flat topics (`:epoch` / `:frameless`) continue to ship under `:events`. `:epoch` carries `:rf/epoch-record`s (already cascade-shaped by construction); `:frameless` carries flat trace events with no `:rf.trace/dispatch-id` tag (registration, REPL, lifecycle outside any cascade) per Tool-Pair §Frameless trace events.

## Cursor clarification

Per the rf2-mscih bead body, the cursor reshape applies only to the cursor-paginated tools (`trace-window` / `watch-epochs`) — and they already walk `epoch-history`, which is cascade-bundle-shaped by construction; no change needed. Streaming subscribe is forward-only with no cursor surface; the wire-format reshape introduces no new cursor or `:rf.mcp/cursor-stale` semantics here.

## Cross-frame `:dispatch-id` merge

A single cascade can fan out across frames; every emit on every frame shares the same `:rf.trace/dispatch-id`. The runtime emits one bundle per (frame, dispatch-id) pair per drain; consumers merge by `:dispatch-id` to reconstruct the cross-frame timeline per Tool-Pair §Cross-frame cascade reconstruction.

## Wire-vocab preservation

`:rf.mcp/diff-from` / `:rf.mcp/dedup-table` / `:rf.mcp/cache-hit` semantics compose unchanged — cascade-bundle shape rides BELOW these markers. The cache-poisoning posture (rf2-3rt1f) is preserved.

## Changes

- `subscribe.cljs` — drain envelope shape, slot-selection in progress payload (`:cascades` vs `:events`), `:frameless` topic accepted, drain-form wraps whichever slot is present via `cond->`.
- `runtime.cljs` (skill preload) — `cascade-bundle-events` projection (uses `rf/group-cascades` + splices `:trace-events`), `frameless-event?` predicate, topic-gated `dispatch-trace-to-subs!`, `drain-subscription!` returns `:cascades` or `:events` per topic. `cascade-of` rewritten to walk cascade bundles (parent links from `:parent-dispatch-id` slot, not raw tags). Snapshot `:traces` slice now ships cascade-bundles by default (the framework`s storage unit).
- `descriptors_data.cljs` — subscribe + list-subscriptions descriptors describe the cascade-bundle wire shape, frameless topic, and load-slot split.
- `003-Tool-Catalogue.md` — cascade-bundle wire format documented; cross-frame merge contract; frameless channel; cursor-stale clarification.
- `wire_vocab_test.clj` — Malli `CascadeBundle` schema, cross-frame fixture, frameless-shape contract gate.
- `streaming_subscriptions_test.clj` + `subscribe_test.cljs` — cascade-bundle / frameless / cross-frame coverage; existing cascade-bundle topic tests gain `:rf.trace/dispatch-id` tags on fixtures (frameless events would now route to `:frameless`).
- `mcp-transport.md` — `:traces` snapshot slice description updated.

## Gate results

- clj-kondo: 0 errors, 25 warnings (all pre-existing).
- bb `streaming_subscriptions_test.clj`: 29 tests, 102 assertions, 0/0.
- bb `snapshot_test.clj`: 9 tests, 17 assertions, 0/0.
- wire-vocab `clojure -M:test`: 45 tests, 493 assertions, 0/0.
- implementation `npm run test:cljs`: 4495 tests, 14301 assertions, 0/0.
- pair-mcp `shadow-cljs compile :server-test`: 604 tests, 1613 assertions, 0/0.
- pair-mcp `shadow-cljs release :server`: build completed, 9.62s.
- `out/server.js` mtime: 2026-05-25 20:55 (fresh).

## Post-outage audit note

The first session on this bead (worker `a11667f8`) hit API 529 mid-run after ~35 minutes / 130 tool uses. Subsequent resume workers also hit 529 or returned corrupted output. A fresh worker inspected the prior session`s edits against the bead body and spec/009 + Tool-Pair contracts:

- Wire-format shape verified against `rf/group-cascades` projection (`implementation/core/src/re_frame/trace/projection.cljc`) and `cascade-bundle` (`implementation/core/src/re_frame/trace/tooling.cljc`).
- `:rf.mcp/cursor-stale` posture cross-checked against the bead body`s "Note: `trace-window` and `watch-epochs` already deliver `:rf/epoch-record` cascade-bundles" — they walk `epoch-history`, so no cursor reshape needed there.
- Frameless channel split, `:dispatch-id-of-next-cascade` cursor (N/A for streaming subscribe), `:rf.mcp/diff-from` / `:rf.mcp/dedup-table` / `:rf.mcp/cache-hit` preservation: all on-contract.

Two documentation-drift gaps were closed by the fresh worker:

1. `skills/re-frame2-pair/tests/runtime/snapshot_test.clj` — the trace-buffer stub`s docstring still cited `{:flat true}` as the snapshot slice`s shape (which was the pre-rf2-mscih posture); the comment now describes the cascade-bundle default.
2. `skills/re-frame2-pair/references/mcp-transport.md` — claimed `:traces` "passes through unchanged"; updated to describe the cascade-bundle shape.

No corrupted-reasoning evidence in the prior session`s work; no `git restore` required.

## Cross-refs

- spec landing: #2135 (rf2-g1b2m)
- core impl: #2139 (rf2-8uwce)
- minimal consumer fix: #2141 (rf2-q03j7)
- bead: rf2-mscih