### PR TITLE
feat(xray): data-display widget phase 2 — Trace panel per-event detail integration (rf2-hhtbl)

### DIFF
--- a/tools/xray/spec/023-Trace-Panel.md
+++ b/tools/xray/spec/023-Trace-Panel.md
@@ -53,7 +53,7 @@ Columns: **Δt · area badge · what-happened · target/detail · duration**.
 - **what-happened** — the per-area verb (§5).
 - **target/detail** — the op's subject: event vector, `fx-id → arg`, `sub-id  old→new`, `view-id ← cause-sub`, route id, path, etc.
 - **duration** — a number in **ms**, or `—` when the substrate supplies no timing (§6).
-- **Row click → expand** the full raw trace-event EDN inline (`:op-type` · `:operation` · `:tags` · timing · `:rf.trace/dispatch-id` …) via Xray's existing expandable data-inspector (the shared data-display renderer — [`021`](./021-Dynamic-Panel-Designs.md) §10). Each row independently collapsible.
+- **Row click → expand** the full raw trace-event EDN inline (`:op-type` · `:operation` · `:tags` · timing · `:rf.trace/dispatch-id` …) via the first-class data-display widget — the canonical CLJS-value renderer (the shared widget contract — [`021`](./021-Dynamic-Panel-Designs.md) §10, in particular §10.0 + §10.0.2 acceptance properties). The trace panel calls `[dd/data-display value {:panel-id :rf.xray.trace/row-<id> …}]` directly (no facade hop); each row independently collapsible (the per-row `panel-id` qualifier scopes expansion state to that row, on top of the widget's own per-mount UUID).
 
 ## §4 Phase → op-family placement
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/trace.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/trace.cljs
@@ -39,8 +39,8 @@
   Errors / warnings are cross-cutting (spec/023 §7) — they render inline
   at their chronological point within whatever band they occurred,
   emphasised so failures stand out. Clicking any row expands its raw
-  trace-event EDN inline (spec/023 §3) via the shared cljs-devtools
-  browse renderer.
+  trace-event EDN inline (spec/023 §3) via the first-class data-display
+  widget (spec/021 §10 / `views.data-display`).
 
   ## Design system (PR #2089 · Handler panel idiom)
 
@@ -90,6 +90,7 @@
             [day8.re-frame2-xray.panels.trace-helpers :as h]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens mono-stack sans-stack]]
+            [day8.re-frame2-xray.views.data-display :as dd]
             [day8.re-frame2-xray.views.edn-widget.widget :as edn]))
 
 ;; ---- row grid template (spec/023 §3 · §14) -----------------------------
@@ -105,24 +106,31 @@
 
 ;; ---- payload renderer (spec/023 §3) -------------------------------------
 ;;
-;; Row click → expand the full raw trace-event EDN inline via Xray's
-;; existing expandable data-inspector (the shared cljs-devtools browse
-;; renderer). Each row gets its own `:render-id` so the rendered
-;; container's testid is unique per row.
+;; Row click → expand the full raw trace-event EDN inline via the
+;; first-class data-display widget (spec/021 §10 widget contract /
+;; spec/023 §3 row click → expand). The widget owns its own per-mount
+;; expansion state keyed by `[panel-id mount-id path]`, so two rows
+;; expanded simultaneously each keep an independent expansion tree.
+;;
+;; Per rf2-hhtbl (rf2-oqa60 phase 2) this call site invokes
+;; `[dd/data-display value opts]` directly — no facade hop through
+;; `edn/browse`. The per-row `panel-id` qualifier embeds the row id so
+;; two simultaneously-expanded rows can't collide on expansion state
+;; even if their mount-ids alias (and the auto-id guarantees they
+;; won't — this is belt-and-braces).
 
 (defn- render-payload
   "Per-row payload renderer — the raw `:operation` · `:tags` · timing ·
-  `:rf.trace/dispatch-id` trace-event EDN (spec/023 §3), wired through
-  the EDN widget's current-state `browse` (cljs-devtools)."
+  `:rf.trace/dispatch-id` trace-event EDN (spec/023 §3), rendered via
+  the first-class data-display widget."
   [{:keys [id raw] :as _row}]
   [:div {:data-testid (str "rf-xray-trace-row-" id "-payload")
          :style       {:padding       "6px 16px 10px 56px"
                        :background    (:bg-1 tokens)
                        :border-radius "0 0 4px 4px"}}
-   (edn/browse
-     {:value     raw
-      :panel-id  :trace
-      :render-id (str "trace-row-" id)})])
+   [dd/data-display raw
+    {:panel-id (keyword "rf.xray.trace" (str "row-" id))
+     :default-expanded-depth 1}]])
 
 ;; ---- per-path db-changed diff rows (spec/023 §APP-DB CHANGES) -----------
 ;;

--- a/tools/xray/test/day8/re_frame2_xray/panels/trace_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/trace_view_cljs_test.cljs
@@ -566,7 +566,9 @@
 
 (deftest expanded-row-renders-raw-edn-payload
   (testing "spec/023 §3 — when a row's :id is in the expanded set, the
-            raw trace-event EDN renders below the row via cljs-devtools"
+            raw trace-event EDN renders below the row via the first-class
+            data-display widget (rf2-hhtbl phase 2: direct
+            `[dd/data-display value opts]`, no facade hop)"
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
       (seed-history!
@@ -581,18 +583,59 @@
       (let [tree (trace/Panel)]
         (is (some? (find-by-testid tree "rf-xray-trace-row-13-payload"))
             "payload renders when row expanded")
-        ;; rf2-oqa60 phase 1 — the EDN widget facade delegates to the
-        ;; first-class data-display widget; the browse container now
-        ;; carries a `rf-xray-data-display-*` testid (the per-mount
-        ;; mount-id is auto-generated UUID, so we assert by prefix).
+        ;; rf2-hhtbl phase 2 — the per-row payload renders the widget
+        ;; with a per-row panel-id qualifier (`:rf.xray.trace/row-<id>`)
+        ;; so two simultaneously-expanded rows can't share expansion
+        ;; state. The widget's `testid-for` uses `(name panel-id)`, so
+        ;; the container testid resolves to `rf-xray-data-display-row-13-<uuid>`.
         (let [dd-nodes (filter (fn [n]
                                  (and (vector? n)
                                       (map? (second n))
                                       (some-> (:data-testid (second n))
-                                              (.startsWith "rf-xray-data-display-"))))
+                                              (.startsWith "rf-xray-data-display-row-13-"))))
                                (hiccup-seq tree))]
           (is (seq dd-nodes)
-              "data-display widget mounted for the expanded row"))))))
+              "data-display widget mounted for the expanded row with the per-row panel-id qualifier"))))))
+
+(deftest expanded-row-uses-per-row-panel-id-qualifier
+  (testing "rf2-hhtbl phase 2 — two simultaneously-expanded rows each
+            mount the data-display widget with a DISTINCT per-row
+            panel-id qualifier (`:rf.xray.trace/row-<id>` rendered as
+            `row-<id>` in the testid via `(name ...)`) so their
+            expansion state can't collide. Combined with the widget's
+            auto-generated per-mount UUID this gives belt-and-braces
+            isolation."
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (seed-history!
+        [(mk-epoch 1 1
+                   [(mk-trace {:id 41 :op-type :rf.event :operation :rf.event/dispatched
+                               :time 100 :dispatch-id 1 :source :ui})
+                    (mk-trace {:id 42 :op-type :rf.fx :operation :rf.fx/handled
+                               :time 110 :dispatch-id 1})])])
+      (focus! 1)
+      ;; Expand both rows at once.
+      (rf/dispatch-sync [:rf.xray/toggle-trace-row-expand 41])
+      (rf/dispatch-sync [:rf.xray/toggle-trace-row-expand 42])
+      (let [tree         (trace/Panel)
+            dd-testids   (->> (hiccup-seq tree)
+                              (keep (fn [n]
+                                      (when (and (vector? n) (map? (second n)))
+                                        (:data-testid (second n)))))
+                              (filter #(and (string? %)
+                                            (.startsWith ^String %
+                                                         "rf-xray-data-display-row-")))
+                              (into #{}))
+            row-41-hits  (filter #(.startsWith ^String % "rf-xray-data-display-row-41-")
+                                 dd-testids)
+            row-42-hits  (filter #(.startsWith ^String % "rf-xray-data-display-row-42-")
+                                 dd-testids)]
+        (is (seq row-41-hits)
+            "row 41's data-display container carries the :rf.xray.trace/row-41 qualifier")
+        (is (seq row-42-hits)
+            "row 42's data-display container carries the :rf.xray.trace/row-42 qualifier")
+        (is (not= (first row-41-hits) (first row-42-hits))
+            "the two rows mount distinct data-display containers")))))
 
 (deftest source-coord-click-fires-open-in-editor
   (testing "clicking the source-coord ↗ fires :rf.xray/open-in-editor;


### PR DESCRIPTION
Phase 2 of rf2-oqa60 — migrate the Trace panel's per-event raw-EDN
payload renderer onto the first-class data-display widget.

## What changes

The Trace panel's per-row payload renderer (`render-payload` in
`tools/xray/src/day8/re_frame2_xray/panels/trace.cljs`) now calls
`[dd/data-display value {:panel-id :rf.xray.trace/row-<id> …}]`
directly. The facade hop through `edn/browse` is dropped for this
call site.

The per-row `panel-id` qualifier (`:rf.xray.trace/row-<id>`) scopes
expansion state to each row on top of the widget's own auto-generated
per-mount UUID — two simultaneously-expanded rows each mount the
widget with a distinct container testid (`rf-xray-data-display-row-<id>-<uuid>`)
and can't share expansion state.

`edn/inspect-inline` is still used by the db-diff sub-rows
(`db-diff-row`) — that's a separate concern (the per-path
modified-value before→after one-liners) and out of scope for this
phase.

## Spec touch

`tools/xray/spec/023-Trace-Panel.md` §3 — note the direct widget
call and cross-link spec/021 §10 widget contract (§10.0 + §10.0.2
acceptance properties).

## Tests

- `expanded-row-renders-raw-edn-payload` — updated to assert the new
  per-row testid prefix `rf-xray-data-display-row-<id>-`.
- `expanded-row-uses-per-row-panel-id-qualifier` — new smoke test
  asserting two simultaneously-expanded rows mount distinct
  data-display containers with row-specific panel-ids
  (the rf2-hhtbl acceptance — independent expansion state per row).

## Gates

- `clj-kondo --lint tools/xray/src tools/xray/test` — 0 errors
- `npm run test:cljs` — 4475 tests / 14259 assertions / 0 failures
- `npm run test:browser` — 124 tests / 346 assertions / 0 failures
- `npm run test:xray-feature-gate` — 13 scenarios / 0 failures

Bead: rf2-hhtbl.