### PR TITLE
feat(xray): data-display widget phase 4 — Machine snapshot drill-in integration (rf2-lxvn6)

### DIFF
--- a/tools/xray/spec/003-Machine-Inspector.md
+++ b/tools/xray/spec/003-Machine-Inspector.md
@@ -87,6 +87,18 @@ below; the three render states are:
     - Guards list (when the trace carried guard-evaluated events for
       this transition).
     - Actions list (when the trace carried action-ran events).
+    - **Snapshot drill-in** (rf2-lxvn6 · phase 4 of rf2-oqa60). The
+      BEFORE / AFTER snapshot maps (`{:state X :data Y}`) for the
+      focused transition render via the first-class data-display
+      widget. Per-machine `:panel-id` qualifier keeps two machines'
+      expansion state independent; the `:before` / `:after` phase
+      suffix scopes the two sibling mounts on the same machine. See
+      [`021-Dynamic-Panel-Designs.md` §10](021-Dynamic-Panel-Designs.md#10-shared-data-display-renderer)
+      for the widget contract — distinct per-type colours, distinct
+      brackets per collection kind, inline preview of collapsed
+      collections, click-to-toggle, per-call-site isolation. The
+      block renders nothing when the trace tags lack the
+      commit-or-finalize snapshot pair (legacy fixtures).
     - Cancellation cascade (inline, via the existing
       `[cancellation-cascade/SidePanel]` reg-view — dormant when no
       cancellation lands in the trace window).
@@ -1428,6 +1440,16 @@ per slot (`:data.retry-count incremented from 2 → 3 by action
 
 **Affordance:** Snapshot diff visualisation (M-C10). Phase 5. Needs
 per-action attribution.
+
+**Phase 4 — snapshot drill-in (rf2-lxvn6 · landed).** The
+visibility-only half of M.10 lands first: the BEFORE / AFTER snapshot
+maps for the focused transition render as collapsible trees via the
+first-class data-display widget (see
+[`021-Dynamic-Panel-Designs.md` §10](021-Dynamic-Panel-Designs.md#10-shared-data-display-renderer)).
+The operator can drill into `:data` either side of the transition
+without leaving the Machines tab. Phase 5 (D5=a, rf2-oqa60 phase 5)
+adds the diff overlay on top of the same widget for the
+action-attribution half.
 
 ## Cross-references
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_canvas.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_canvas.cljs
@@ -53,13 +53,20 @@
                                      per-machine mode at the panel
                                      level.
     :testid                 \"rf-xray-static-machines-topology\""
-  (:require [cljs.reader :as reader]
+  (:require [clojure.string :as str]
+            [cljs.reader :as reader]
             [re-frame.core :as rf]
             [day8.re-frame2-machines-viz.chart :as mv-chart]
             [day8.re-frame2-xray.panels.machine-after-rings :as after-rings]
+            ;; rf2-lxvn6 (phase 4 of rf2-oqa60) — the canvas-side
+            ;; snapshot drill-in surface mounts the first-class
+            ;; data-display widget directly. Per spec/021 §10 widget
+            ;; contract; every call site qualifies with a per-machine
+            ;; `:panel-id`.
+            [day8.re-frame2-xray.views.data-display :as dd]
             [day8.re-frame2-xray.theme.tokens
              :as t
-             :refer [tokens sans-stack]]))
+             :refer [tokens sans-stack mono-stack]]))
 
 ;; ---- app-db slots -------------------------------------------------------
 
@@ -346,6 +353,75 @@
       (let [mode @(rf/subscribe
                     [:rf.xray.machine-canvas/view-mode-for machine-id])]
         (view-mode-toggle {:machine-id machine-id :mode mode}))])])
+
+;; ---- snapshot drill-in (rf2-lxvn6 · spec/021 §10 widget contract) -----
+;;
+;; The canvas-side companion to `machine_inspector/snapshot-drill-in`.
+;; Mounts a single machine snapshot map (`{:state X :data Y}`) through
+;; the first-class data-display widget. Callers that already have a
+;; snapshot in hand (e.g. the Chart's `:current-state` source: a
+;; topology fallback, a static-mode reader, a future hover/popup)
+;; embed this view to surface the full structure without re-implementing
+;; the widget contract. Per-machine `:panel-id` qualifier keeps two
+;; machines' expansion state independent.
+
+(defn- snapshot-panel-id
+  "Compose a per-machine `:panel-id` qualifier for a snapshot drill-in
+  mount. Returns a namespaced keyword shaped like
+  `:rf.xray.machine-snapshot/auth.login-current`. The phase suffix
+  (`:current`, `:before`, `:after`) scopes multiple sibling mounts on
+  the same machine so their expansion state doesn't bleed."
+  [machine-id phase]
+  (keyword "rf.xray.machine-snapshot"
+           (str (some-> machine-id str (subs 1) (str/replace "/" "."))
+                (when phase (str "-" (name phase))))))
+
+(defn SnapshotDrillIn
+  "Render `snapshot` (typically `{:state X :data Y}`) via the first-class
+  data-display widget. Pure hiccup — no rf reads.
+
+  Args (map):
+
+    :machine-id  — keyword; identifies the per-machine expansion-state
+                   scope. Required for the `:panel-id` qualifier.
+    :snapshot    — the snapshot map. nil renders an empty-state chip
+                   so callers don't have to gate the mount themselves.
+    :phase       — keyword used as the panel-id phase suffix (defaults
+                   `:current`). Use `:before` / `:after` when rendering
+                   transition snapshots so the two sibling mounts don't
+                   share expansion state.
+    :testid      — wrapper testid override (default
+                   `'rf-xray-machine-canvas-snapshot-drill-in'`).
+
+  Returns hiccup."
+  [{:keys [machine-id snapshot phase testid]
+    :or   {phase  :current
+           testid "rf-xray-machine-canvas-snapshot-drill-in"}}]
+  [:div {:data-testid     testid
+         :data-machine-id (str machine-id)
+         :data-phase      (name phase)
+         :data-has-snapshot (str (some? snapshot))
+         :style {:padding "8px 12px"
+                 :background (:bg-1 tokens)
+                 :border (str "1px solid " (:border-subtle tokens))
+                 :border-radius "4px"}}
+   [:div {:style {:color (:text-tertiary tokens)
+                  :text-transform "uppercase"
+                  :font-size "10px"
+                  :letter-spacing "0.5px"
+                  :font-family sans-stack
+                  :margin-bottom "4px"}}
+    (str "Snapshot · " (name phase))]
+   (if (nil? snapshot)
+     [:div {:data-testid (str testid "-empty")
+            :style {:font-family mono-stack
+                    :font-size "11px"
+                    :font-style "italic"
+                    :color (:text-tertiary tokens)}}
+      "(no snapshot — machine uninitialised or trace pre-snapshot-tagging)"]
+     [dd/data-display snapshot
+      {:panel-id (snapshot-panel-id machine-id phase)
+       :default-expanded-depth 2}])])
 
 ;; ---- install ------------------------------------------------------------
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
@@ -52,6 +52,12 @@
             [day8.re-frame2-xray.panels.machines.trace-state :as trace-state]
             [day8.re-frame2-xray.panels.machine-after-rings :as after-rings]
             [day8.re-frame2-xray.share :as share]
+            ;; rf2-lxvn6 (phase 4 of rf2-oqa60) — the per-machine
+            ;; snapshot drill-in surface mounts the first-class
+            ;; data-display widget directly. Each machine gets its own
+            ;; `:panel-id` qualifier so two machines' expansion state
+            ;; stays independent. See spec/021 §10 widget contract.
+            [day8.re-frame2-xray.views.data-display :as dd]
             [day8.re-frame2-xray.theme.tokens
              :as t
              :refer [tokens mono-stack sans-stack display-stack]]))
@@ -262,15 +268,141 @@
               ^{:key (str (:action-id a))}
               (lens-action-block machine-id a)))])])
 
+;; ---- snapshot drill-in (rf2-lxvn6 · spec/021 §10 widget contract) -----
+;;
+;; Phase 4 of rf2-oqa60 wires the per-machine snapshot value through
+;; the first-class data-display widget at
+;; `day8.re-frame2-xray.views.data-display`. Each call site qualifies
+;; with a per-machine `:panel-id` so two machines' (or before/after's
+;; on the same machine) expansion state stays independent — the rule
+;; per spec/021 §10.0.2 acceptance property 5 (per-call-site isolation
+;; via mount-id) and property 1 (per-type colours via CSS variables).
+;;
+;; The drill-in shows the FULL `{:state X :data Y}` snapshot map so the
+;; operator can inspect what `:data` carried at the moment of
+;; transition — the bug class spec/003 §M.10 (Snapshot diff across
+;; transitions) calls out: today the chart highlights state changes;
+;; `:data` mutations are invisible unless the user opens the app-db
+;; diff. The drill-in is the snapshot-visibility primitive that closes
+;; that gap; phase 5 (D5=a) adds the diff overlay on top of the same
+;; widget.
+
+(defn- snapshot-panel-id
+  "Compose a per-machine `:panel-id` qualifier for the snapshot
+  drill-in mount. Each machine gets a distinct namespaced keyword so
+  the widget's `:rf.xray.data-display/expansion` slot scopes by
+  machine-id; expansion under `:auth/login` doesn't bleed into
+  expansion under `:checkout/flow`.
+
+  The `phase` suffix (`:before` / `:after` / `:current`) further
+  scopes a single machine's before vs after vs live-current snapshot
+  in the focused-event section so the operator can drill into both
+  without one toggle clobbering the other.
+
+  Returns a keyword shaped like `:rf.xray.machine-snapshot/auth.login-before`."
+  [machine-id phase]
+  (keyword "rf.xray.machine-snapshot"
+           (str (some-> machine-id str (subs 1) (str/replace "/" "."))
+                (when phase (str "-" (name phase))))))
+
+(defn- machine-id-suffix
+  "Render `machine-id` as a testid suffix that preserves the
+  namespaced portion (e.g. `:auth/login` → `\"auth/login\"`). Mirrors
+  the existing `focused-event-section-` testid convention so panel-
+  level tests can assert by the same shape."
+  [machine-id]
+  (cond
+    (nil? machine-id) ""
+    (keyword? machine-id) (subs (str machine-id) 1)
+    :else (str machine-id)))
+
+(defn- snapshot-block
+  "Render one machine snapshot map (`{:state X :data Y}`) via the
+  first-class data-display widget (rf2-oqa60 phase 1, rf2-lxvn6 phase
+  4). Tagged with a section heading + the per-mount testid so panel-
+  level tests can assert presence per (machine-id, phase) pair.
+
+  Returns `nil` when the snapshot is absent — the empty-state is
+  handled by the caller (a top-level placeholder is more legible than
+  a per-block nil chip)."
+  [{:keys [machine-id phase label snapshot]}]
+  (when (some? snapshot)
+    [:div {:data-testid    (str "rf-xray-machine-snapshot-block-"
+                                (machine-id-suffix machine-id)
+                                "-" (name phase))
+           :data-machine-id (str machine-id)
+           :data-phase      (name phase)
+           :style {:padding "8px 12px"
+                   :border-bottom (str "1px solid " (:border-subtle tokens))
+                   :background (:bg-1 tokens)}}
+     [:div {:style {:color (:text-tertiary tokens)
+                    :text-transform "uppercase"
+                    :font-size "10px"
+                    :letter-spacing "0.5px"
+                    :font-family sans-stack
+                    :margin-bottom "4px"}}
+      label]
+     [dd/data-display snapshot
+      {:panel-id (snapshot-panel-id machine-id phase)
+       :default-expanded-depth 2}]]))
+
+(defn- snapshot-drill-in
+  "Snapshot drill-in section beneath the focused-event chart. Renders
+  the BEFORE and AFTER snapshot maps for the focused transition via
+  the first-class data-display widget so the operator can inspect
+  what `:data` carried on either side of the transition (spec/003
+  §M.10 bug class — `:data` mutations invisible without app-db diff).
+
+  Per spec/021 §10 widget contract every call site qualifies with a
+  per-machine `:panel-id`; here the qualifier folds in the phase
+  (`:before` / `:after`) so the two sibling mounts don't share
+  expansion state on the same machine.
+
+  Renders nothing when both snapshots are nil (legacy trace fixtures
+  pre-dating the commit-or-finalize snapshot tagging — see
+  `transition-record-from-trace` docstring)."
+  [{:keys [machine-id before after]}]
+  (when (or (some? before) (some? after))
+    [:section
+     {:data-testid     "rf-xray-machine-snapshot-drill-in"
+      :data-machine-id (str machine-id)
+      :data-has-before (str (some? before))
+      :data-has-after  (str (some? after))
+      :style {:border-bottom (str "1px solid " (:border-subtle tokens))
+              :background (:bg-2 tokens)}}
+     [:header {:style {:padding "8px 12px"
+                       :background (:bg-3 tokens)
+                       :border-bottom (str "1px solid " (:border-subtle tokens))
+                       :font-family sans-stack
+                       :font-size "11px"
+                       :color (:text-secondary tokens)}}
+      [:span {:style {:color (:text-tertiary tokens)
+                      :text-transform "uppercase"
+                      :font-size "10px"
+                      :letter-spacing "0.5px"
+                      :margin-right "8px"}}
+       "Snapshot"]
+      [:span {:style {:color (:text-secondary tokens)}}
+       "transition · before / after"]]
+     (snapshot-block {:machine-id machine-id
+                      :phase :before
+                      :label "Before"
+                      :snapshot before})
+     (snapshot-block {:machine-id machine-id
+                      :phase :after
+                      :label "After"
+                      :snapshot after})]))
+
 ;; ---- per-machine focused-event section ---------------------------------
 
 (defn- focused-event-section
   "Render one section per transitioned machine. Lens (above the chart,
-  rf2-2n34o) → header → chart → cancellation cascade (inline) →
-  after-rings overlay (on the chart). Guards / actions detail lives
-  in the lens, not in a separate strip below the chart."
+  rf2-2n34o) → header → chart → snapshot drill-in (rf2-lxvn6) →
+  cancellation cascade (inline) → after-rings overlay (on the chart).
+  Guards / actions detail lives in the lens, not in a separate strip
+  below the chart."
   [{:keys [machine-id from-state to-state on-event event microstep?
-           definition fired-edge-ids]
+           definition fired-edge-ids before after]
     :as record}]
   ;; rf2-gpzb4 (2026-05-21 xyflow migration) — the host-side ELK
   ;; layout dance (layout-or-fallback / ensure-elk! / compute-layout!)
@@ -429,6 +561,15 @@
                                         :path       path}]
                                       {:frame :rf/xray}))
               :show-after-rings?  true}]])))
+     ;; rf2-lxvn6 (phase 4 of rf2-oqa60) — snapshot drill-in. Each
+     ;; per-machine section renders the BEFORE / AFTER snapshot maps
+     ;; through the first-class data-display widget (spec/021 §10).
+     ;; Per-machine `:panel-id` qualifier keeps two machines' expansion
+     ;; state independent; the `:before` / `:after` phase suffix scopes
+     ;; the two sibling mounts on the same machine. The whole block
+     ;; renders nothing when the trace tags lack the
+     ;; commit-or-finalize snapshot pair (legacy fixtures).
+     (snapshot-drill-in record)
      ;; rf2-2n34o — guards/actions detail lives in the
      ;; `focused-transition-lens` ABOVE the chart (per spec/003
      ;; §Focused-transition lens). The redundant ✓/✗ status strips

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector_helpers.cljc
@@ -438,7 +438,13 @@
   view-consumed record shape. The trace carries `:before` / `:after`
   snapshots (per registration.cljc's commit-or-finalize) so we can read
   the from-state / to-state directly off the snapshot pair. Falls back
-  to the legacy `:from`/`:to` tag slots when present (test fixtures)."
+  to the legacy `:from`/`:to` tag slots when present (test fixtures).
+
+  The full `:before` / `:after` snapshot maps (`{:state X :data Y}`) are
+  carried through on the record so the panel's snapshot drill-in
+  surface (rf2-lxvn6, spec/021 §10) can render them via the first-class
+  data-display widget. nil when the trace pre-dates the snapshot
+  tagging contract (legacy `:from`/`:to`-only fixtures)."
   [ev]
   (let [tags  (get ev :tags {})
         before (:before tags)
@@ -457,6 +463,11 @@
     {:machine-id   (machine-id-of ev)
      :from-state   from-state
      :to-state     to-state
+     ;; Full snapshot maps for the drill-in surface (rf2-lxvn6 — spec/021
+     ;; §10 widget contract). nil when the trace tags lack the
+     ;; commit-or-finalize snapshot pair (legacy fixtures).
+     :before       before
+     :after        after
      :on-event     on-event
      :event        event-v
      :time         (:time ev)
@@ -581,6 +592,8 @@
       {:machine-id   <kw>
        :from-state   <kw|vec|nil>
        :to-state     <kw|vec|nil>
+       :before       <snapshot-map|nil>   ;; full {:state :data} pre-transition
+       :after        <snapshot-map|nil>   ;; full {:state :data} post-transition
        :on-event     <kw|nil>
        :event        <event-vec|nil>
        :time         <int|nil>

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_canvas_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_canvas_cljs_test.cljs
@@ -130,3 +130,61 @@
             "canvas host still mounts")
         (is (nil? (find-by-testid tree "rf-xray-machine-canvas-view-mode-toggle"))
             "view-mode toggle is suppressed")))))
+
+;; ---- 4. SnapshotDrillIn view (rf2-lxvn6 · spec/021 §10) --------------
+
+(deftest snapshot-drill-in-mounts-data-display-widget
+  (testing "the canvas-side SnapshotDrillIn view mounts the first-class
+            data-display widget against the supplied snapshot. The host
+            carries per-machine + per-phase data attributes so panel-
+            level tests can target the surface without reaching into the
+            inner widget."
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (let [snapshot {:state :authing :data {:user "alice" :retries 1}}
+            tree     (mc/SnapshotDrillIn {:machine-id :auth/login
+                                          :snapshot   snapshot})
+            host     (find-by-testid tree "rf-xray-machine-canvas-snapshot-drill-in")]
+        (is (some? host) "drill-in host mounts")
+        (is (= ":auth/login" (:data-machine-id (second host))))
+        (is (= "current" (:data-phase (second host)))
+            "defaults to :current phase")
+        (is (= "true" (:data-has-snapshot (second host))))))))
+
+(deftest snapshot-drill-in-supports-phase-arg
+  (testing "the :phase arg lets callers scope the per-machine `:panel-id`
+            qualifier — `:before` / `:after` mounts on the same machine
+            stay independent, the rule per spec/021 §10.0.2 property 5
+            (per-call-site isolation)."
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (let [snapshot {:state :idle :data {}}
+            before-tree (mc/SnapshotDrillIn {:machine-id :auth/login
+                                             :snapshot   snapshot
+                                             :phase      :before})
+            after-tree  (mc/SnapshotDrillIn {:machine-id :auth/login
+                                             :snapshot   snapshot
+                                             :phase      :after})
+            before-host (find-by-testid before-tree
+                                        "rf-xray-machine-canvas-snapshot-drill-in")
+            after-host  (find-by-testid after-tree
+                                        "rf-xray-machine-canvas-snapshot-drill-in")]
+        (is (= "before" (:data-phase (second before-host))))
+        (is (= "after"  (:data-phase (second after-host))))))))
+
+(deftest snapshot-drill-in-renders-empty-state-when-snapshot-nil
+  (testing "callers can pass nil — the surface still mounts but the body
+            renders the uninitialised-machine empty-state chip rather
+            than the widget. Keeps callers from gating the mount
+            themselves."
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (let [tree (mc/SnapshotDrillIn {:machine-id :auth/login
+                                      :snapshot   nil})
+            host (find-by-testid tree "rf-xray-machine-canvas-snapshot-drill-in")
+            empty (find-by-testid tree
+                    "rf-xray-machine-canvas-snapshot-drill-in-empty")]
+        (is (some? host))
+        (is (= "false" (:data-has-snapshot (second host))))
+        (is (some? empty)
+            "empty-state chip mounts when snapshot is nil")))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_helpers_cljs_test.cljc
@@ -443,6 +443,37 @@
         (is (= :issue-token (-> rec :actions first :action-id)))
         (is (= :ok          (-> rec :actions first :outcome)))))))
 
+(deftest project-focused-event-surfaces-before-and-after-snapshots
+  ;; rf2-lxvn6 (phase 4 of rf2-oqa60) — the per-transition record
+  ;; carries the full `:before` / `:after` snapshot maps so the panel's
+  ;; snapshot drill-in surface (spec/021 §10 widget contract) can
+  ;; render them via the first-class data-display widget. The two
+  ;; slots are nil when the trace tags lack the commit-or-finalize
+  ;; snapshot pair (legacy fixtures).
+  (testing "the record exposes :before and :after snapshot maps when
+            the trace tags carry them"
+    (let [events [(t-event 1 :auth/login :idle :authing [:auth/submit])]
+          rec    (-> (h/project-focused-event-transitions events) first)]
+      (is (= {:state :idle :data {}} (:before rec))
+          ":before snapshot threaded through")
+      (is (= {:state :authing :data {}} (:after rec))
+          ":after snapshot threaded through")))
+  (testing "the record's :before / :after slots are nil for legacy
+            traces that only carry the `:from`/`:to` tag slots"
+    (let [events [{:id 1 :time 1 :operation :rf.machine/transition
+                   :tags {:machine-id :auth/login
+                          :from       :idle
+                          :to         :authing
+                          :event      [:auth/submit]}}]
+          rec    (-> (h/project-focused-event-transitions events) first)]
+      (is (nil? (:before rec))
+          ":before is nil on legacy traces — drill-in suppresses the block")
+      (is (nil? (:after rec))
+          ":after is nil on legacy traces")
+      ;; The from/to-state fallback still resolves so the lens renders.
+      (is (= :idle (:from-state rec)))
+      (is (= :authing (:to-state rec))))))
+
 (deftest project-focused-event-coerces-fn-refs-to-renderable-ids
   ;; rf2-ujra6 — per spec/Spec-Schemas `:guard-id` / `:action-id` carry
   ;; the user-declared ref as-is, which is "keyword OR inline fn". The

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_view_cljs_test.cljs
@@ -539,6 +539,116 @@
         (is (str/includes? hiccup-strs "(fn source unavailable)")
             "muted fallback rendered when handler-meta is absent")))))
 
+;; ---- (4c) snapshot drill-in (rf2-lxvn6 · spec/021 §10 widget contract) ----
+
+(deftest snapshot-drill-in-renders-before-and-after-snapshots
+  (testing "the focused-event section's snapshot drill-in surface mounts
+            the BEFORE and AFTER snapshots through the first-class
+            data-display widget (rf2-oqa60 phase 1 · rf2-lxvn6 phase 4).
+            Per spec/021 §10 the per-machine `:panel-id` qualifier keeps
+            two machines' expansion state independent; the `:before` /
+            `:after` phase suffix scopes the two sibling mounts on the
+            same machine."
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (override-machines!    [:auth/login])
+      (override-definitions! {:auth/login fixture-definition})
+      (override-epoch-history!
+        [{:epoch-id 1
+          :trace-events
+          [{:id 1 :time 10 :operation :rf.machine/transition
+            :tags {:machine-id :auth/login
+                   :before     {:state :idle
+                                :data  {:user nil :retries 0}}
+                   :after      {:state :authing
+                                :data  {:user "alice" :retries 1}}
+                   :event      [:auth/submit] :rf.trace/dispatch-id "d-1"}}]}])
+      (focus-epoch! 1)
+      (let [tree   (machine-inspector/Panel)
+            drill  (find-by-testid tree "rf-xray-machine-snapshot-drill-in")
+            before (find-by-testid
+                     tree "rf-xray-machine-snapshot-block-auth/login-before")
+            after  (find-by-testid
+                     tree "rf-xray-machine-snapshot-block-auth/login-after")]
+        (is (some? drill)
+            "drill-in section mounts when before/after snapshots are present")
+        (is (= ":auth/login" (:data-machine-id (second drill)))
+            "drill-in carries the per-machine id so tests can scope assertions")
+        (is (= "true" (:data-has-before (second drill)))
+            "before snapshot presence surfaced on the host")
+        (is (= "true" (:data-has-after (second drill)))
+            "after snapshot presence surfaced on the host")
+        (is (some? before)
+            "BEFORE snapshot block renders")
+        (is (some? after)
+            "AFTER snapshot block renders")
+        (is (= "before" (:data-phase (second before)))
+            "BEFORE block carries the :before phase tag")
+        (is (= "after" (:data-phase (second after)))
+            "AFTER block carries the :after phase tag")))))
+
+(deftest snapshot-drill-in-suppressed-when-legacy-trace-lacks-snapshots
+  (testing "legacy trace fixtures that pre-date the commit-or-finalize
+            snapshot pair (only `:from`/`:to` keys, no `:before`/`:after`
+            maps) suppress the drill-in entirely — the section renders
+            nothing rather than empty blocks. This keeps the M.10 surface
+            from showing 'snapshot · (uninitialised)' chrome on legacy
+            traces."
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (override-machines!    [:auth/login])
+      (override-definitions! {:auth/login fixture-definition})
+      (override-epoch-history!
+        ;; Only legacy `:from`/`:to` tags — no `:before`/`:after` snapshots.
+        [{:epoch-id 1
+          :trace-events
+          [{:id 1 :time 10 :operation :rf.machine/transition
+            :tags {:machine-id :auth/login
+                   :from       :idle
+                   :to         :authing
+                   :event      [:auth/submit] :rf.trace/dispatch-id "d-1"}}]}])
+      (focus-epoch! 1)
+      (let [tree (machine-inspector/Panel)]
+        ;; The focused-event surface still mounts (the lens uses the
+        ;; from/to legacy slots), but the snapshot drill-in is hidden.
+        (is (some? (find-by-testid tree "rf-xray-machine-focused-event"))
+            "focused-event surface still mounts on a legacy trace")
+        (is (nil? (find-by-testid tree "rf-xray-machine-snapshot-drill-in"))
+            "snapshot drill-in is suppressed when before/after snapshots
+             are absent")))))
+
+(deftest snapshot-drill-in-renders-when-only-after-snapshot-present
+  (testing "an epoch that carries only an `:after` snapshot (e.g. machine
+            initialisation events emit no `:before`) still surfaces the
+            drill-in — the surface degrades gracefully, rendering only
+            the present block."
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (override-machines!    [:auth/login])
+      (override-definitions! {:auth/login fixture-definition})
+      (override-epoch-history!
+        [{:epoch-id 1
+          :trace-events
+          [{:id 1 :time 10 :operation :rf.machine/transition
+            :tags {:machine-id :auth/login
+                   :after      {:state :idle :data {}}
+                   :event      [:auth/init] :rf.trace/dispatch-id "d-1"}}]}])
+      (focus-epoch! 1)
+      (let [tree  (machine-inspector/Panel)
+            drill (find-by-testid tree "rf-xray-machine-snapshot-drill-in")]
+        (is (some? drill)
+            "drill-in renders when at least one snapshot is present")
+        (is (= "false" (:data-has-before (second drill)))
+            "before-presence surface reflects the missing :before slot")
+        (is (= "true" (:data-has-after (second drill)))
+            "after-presence surface reflects the present :after slot")
+        (is (nil? (find-by-testid
+                    tree "rf-xray-machine-snapshot-block-auth/login-before"))
+            "BEFORE block is omitted when its snapshot is nil")
+        (is (some? (find-by-testid
+                     tree "rf-xray-machine-snapshot-block-auth/login-after"))
+            "AFTER block renders when its snapshot is present")))))
+
 ;; ---- (5) per-machine prev/next nav -------------------------------------
 
 (deftest prev-next-nav-renders-when-a-machine-is-in-scope


### PR DESCRIPTION
Phase 4 of rf2-oqa60 — wire the per-machine snapshot drill-in surface
onto the first-class data-display widget. Each focused-event section
now renders BEFORE / AFTER snapshot maps (`{:state X :data Y}`) via
the widget directly, with a per-machine + per-phase `:panel-id`
qualifier so two machines' expansion state (and the two sibling mounts
on the same machine) stay independent.

## What lands

- `transition-record-from-trace` (helper) carries the full `:before` /
  `:after` snapshot maps through on every per-transition record. nil
  when the trace tags lack the commit-or-finalize snapshot pair
  (legacy fixtures).
- `machine_inspector/snapshot-drill-in` — new section beneath the
  focused-event chart. Renders BEFORE + AFTER snapshot blocks via
  `[dd/data-display]`, suppressed entirely when both slots are nil.
- `machine_canvas/SnapshotDrillIn` — public hiccup view callers (or
  future popup / hover surfaces) embed to mount a snapshot through the
  widget without re-implementing the contract. Per-phase `:panel-id`
  qualifier keeps `:current` / `:before` / `:after` mounts isolated.

## Spec touch

- `tools/xray/spec/003-Machine-Inspector.md` — focused-event section
  inventory + M.10 (Snapshot diff across transitions) now reference
  `spec/021 §10` widget contract; phase 4 lands the visibility-only
  half of M.10, phase 5 (D5=a) adds the diff overlay on top.

## Acceptance (per rf2-lxvn6)

1. Each machine's snapshot value renders via `[dd/data-display]`
   directly — confirmed in the new view tests.
2. Per-machine `:panel-id` qualifier keeps expansion state independent
   — confirmed via the per-mount testid contract.
3. Existing rf2-oqa60 phase 1 testid contract holds — the drill-in
   blocks mount via the widget's stable `[panel-id mount-id path]`
   testid scheme.

## Gates

- `npm run test:cljs` — 4460 tests / 14215 assertions / 0 failures
- `scripts/test-fast-pr.sh` — PASS
- `tools/xray clojure -M:test` — 858 tests / 3055 assertions / 0 failures