### PR TITLE
feat(xray): data-display widget phase 3 — Sub panel value inspector integration (rf2-e46qs)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -493,8 +493,14 @@ Quoted from the super-prompt (A.3):
 The L2 row's `🌊 flow-recomputed` badge surfaces flows as a cross-epoch signal; per-epoch flow
 detail lives in Event panel step 4.
 
-Below the graph, two list sections record the epoch's reactive teardown (Figma design):
+Below the graph, three list sections complete the panel:
 
+- **SUB VALUES** (rf2-e46qs phase 3 of rf2-oqa60) — one row per RUN sub this cascade carrying
+  its current value through the first-class data-display widget (`[dd/data-display value opts]`,
+  §10). Each row uses a stable per-sub `:panel-id` qualifier under `:rf.xray.reactive-sub-value`
+  so two sub-row expansions are independent. Subs whose value carries no `:value` slot (privacy
+  redaction / pre-attribution) render a muted no-value placeholder rather than mounting the
+  widget with `nil`. Memoised skips (`:recomputed?` false) are omitted — only RUN subs surface.
 - **UNMOUNTED VIEWS** — views whose component unmounted this epoch (one row each: view name +
   `unmounted` tag; a small `error`-tinted swatch as the row marker).
 - **DESTROYED SUBSCRIPTIONS** — subs cleaned up when their last reader unmounted (one row each:
@@ -1366,7 +1372,19 @@ adapter + dep are dropped.
 Phases 2-5 file as separate beads chained off rf2-oqa60:
 
 - Phase 2 — Trace per-event detail integration
-- Phase 3 — Sub value inspector integration
+- Phase 3 (rf2-e46qs) — **Sub value inspector integration.** The
+  Views panel (`reactive-panel-view`) renders a `SUB VALUES` section
+  beneath the flow graph. Each RUN sub gets one row carrying its
+  current cascade value through `[dd/data-display value opts]`
+  DIRECTLY (no `edn/inspect` / `edn/browse` facade hop). Each row's
+  `:panel-id` is a STABLE per-sub keyword namespaced under
+  `:rf.xray.reactive-sub-value` (folded from the sub-id), so two
+  sub-row expansions are independent. Sub-runs that carry no `:value`
+  slot (privacy redaction / pre-attribution) render a muted no-value
+  placeholder instead of mounting the widget with `nil` — distinct
+  from a sub whose value actually IS `nil`. Memoised skips
+  (`:recomputed?` false) are omitted from the inspector; only RUN
+  subs surface.
 - Phase 4 — Machine snapshot drill-in integration
 - Phase 5 — Diff renderer subsumption (D5=a; replaces
   `data-display/render-tree` and deletes `theme.data-inspector`)

--- a/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_subs.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_subs.cljs
@@ -73,9 +73,17 @@
                             :readers [...]} ...]
          :sub-readers     {<sub-id> [<view-id> ...] ...}
          :view-rows       [{:view-id _ :action _ :reason {...} :coord _} ...]
+         :sub-values      [{:sub-id _ :changed? _ :has-value? _ :value _
+                             :coord _? :slug _} ...]
          :counts          {:subs-ran N :subs-skipped N
                            :views-rendered N
+                           :sub-values N
                            :flows-recomputed N}}
+
+  `:sub-values` (rf2-e46qs phase 3) drives the SUB VALUES inspector
+  section beneath the flow graph — one row per RUN sub with its current
+  cascade value, surfaced through the first-class data-display widget
+  (spec/021 §10).
 
   `:sub-readers` (rf2-y23uw) is the shared-subscription edge map — for
   each sub-id, the views that deref'd it this cascade ('which views read
@@ -96,7 +104,8 @@
 
   `install!` registers `:rf.xray/reactive-data` + the panel-local
   disclosure-toggle state slot. Idempotent."
-  (:require [re-frame.core :as rf]
+  (:require [clojure.string :as string]
+            [re-frame.core :as rf]
             [re-frame.subs.tooling :as subs-tooling]))
 
 ;; ---- pure helpers (exposed for test) ------------------------------------
@@ -348,16 +357,27 @@
   using the static `sub-topology` snapshot (rf2-8ve8z).
 
   `subs-ran` is the `:sub-runs` projection slice (each entry carries
-  `:sub-id` + `:value-changed?`). `topology` is the
-  `re-frame.subs.tooling/sub-topology` map (`{sub-id {:inputs [...]
+  `:sub-id`, `:value-changed?`, `:value`, `:prev-value`). `topology` is
+  the `re-frame.subs.tooling/sub-topology` map (`{sub-id {:inputs [...]
   :ns :line :file}}`). `readers` (optional, rf2-y23uw) is the sub→readers
   map from `sub-readers` (`{sub-id [view-id ...]}`).
 
   Returns `{:level-1 [row ...] :level-2 [row ...]}` where each row:
 
-    Level 1: {:sub-id _ :changed? bool :coord {...}? :readers [view-id ...]}
+    Level 1: {:sub-id _ :changed? bool :coord {...}? :readers [view-id ...]
+              :has-value? bool :value <v>?}
     Level 2: {:sub-id _ :changed? bool :inputs [<input-sub-id> ...]
-              :coord {...}? :readers [view-id ...]}
+              :coord {...}? :readers [view-id ...]
+              :has-value? bool :value <v>?}
+
+  `:value` (rf2-e46qs phase 3) carries each sub's current cascade value
+  for the SUB VALUES inspector beneath the flow graph. The slot is
+  present iff `:value` rode the `:sub-runs` entry — captured by the
+  substrate when value attribution is on (Spec 009 §`:rf.sub/run`). A
+  `nil` value is still a value, so a presence flag `:has-value?` (true
+  iff the sub-run contained the `:value` key) accompanies it so the
+  inspector can distinguish `nil` from `:value`-absent (the privacy
+  redaction path drops the slot rather than emitting nil).
 
   `:readers` is the views that deref this sub THIS cascade — the
   shared-subscription edge (rf2-y23uw); absent when no rendered view read
@@ -377,19 +397,76 @@
                topo-entry (get topo sub-id)
                changed?   (boolean (:value-changed? sub-run))
                coord      (topology-coord topo-entry)
-               sub-rdrs   (get rdrs sub-id)]
+               sub-rdrs   (get rdrs sub-id)
+               has-value? (contains? sub-run :value)
+               value      (when has-value? (:value sub-run))]
            (if (level-1? topo-entry)
              (update acc :level-1 conj
                      (cond-> {:sub-id sub-id :changed? changed?}
-                       coord         (assoc :coord coord)
-                       (seq sub-rdrs) (assoc :readers (vec sub-rdrs))))
+                       coord          (assoc :coord coord)
+                       (seq sub-rdrs)  (assoc :readers (vec sub-rdrs))
+                       has-value?      (assoc :has-value? true :value value)))
              (update acc :level-2 conj
                      (cond-> {:sub-id sub-id :changed? changed?
                               :inputs (vec (:inputs topo-entry))}
-                       coord         (assoc :coord coord)
-                       (seq sub-rdrs) (assoc :readers (vec sub-rdrs)))))))
+                       coord          (assoc :coord coord)
+                       (seq sub-rdrs)  (assoc :readers (vec sub-rdrs))
+                       has-value?      (assoc :has-value? true :value value))))))
        {:level-1 [] :level-2 []}
        (or subs-ran [])))))
+
+;; ---- per-sub value inspector rows (rf2-e46qs phase 3) --------------------
+
+(defn sub-values
+  "Project the cascade's RUN subs into one row per sub for the SUB
+  VALUES inspector beneath the flow graph (spec/021 §10 — sub value
+  inspector phase 3 of rf2-oqa60).
+
+  Filters `:recomputed?` true — the subs that actually computed this
+  cascade and therefore have an authoritative current value to
+  inspect. Memoised skips (`:recomputed?` false) carry no fresh
+  value; they're omitted from the inspector to keep the section
+  focused on this cascade's actual recomputes. Pass either the raw
+  `:sub-runs` projection slice (mixed recomputed/skipped) or the
+  already-filtered `ran` slice — both produce the same output.
+
+  Each row:
+
+    {:sub-id     <kw/id>
+     :changed?   bool         ; :value-changed? on the sub-run
+     :has-value? bool         ; true iff the sub-run carried :value
+     :value      <v>          ; the sub's current cascade value
+     :coord      {:file :line :ns}?  ; jump-to-source coord
+     :slug       <string>}    ; testid suffix
+
+  `topology` is the static sub-topology snapshot — supplies the source
+  coord. Order preserved from `subs-ran`. nil-safe."
+  ([subs-ran] (sub-values subs-ran nil))
+  ([subs-ran topology]
+   (let [topo (or topology {})]
+     (into []
+           (comp
+             ;; Filter `:recomputed?` true — skipped (memo-hit) subs
+             ;; carry no fresh cascade value; the inspector is for
+             ;; recomputes only. Callers passing the already-filtered
+             ;; `ran` slice (every entry `:recomputed?` true by
+             ;; definition) flow through unchanged.
+             (filter :recomputed?)
+             (keep (fn [sub-run]
+                     (let [sub-id     (:sub-id sub-run)
+                           topo-entry (get topo sub-id)
+                           coord      (topology-coord topo-entry)
+                           has-value? (contains? sub-run :value)]
+                       (when sub-id
+                         (cond-> {:sub-id    sub-id
+                                  :changed?  (boolean (:value-changed? sub-run))
+                                  :has-value? has-value?
+                                  :slug      (string/replace
+                                               (str sub-id)
+                                               #"[^a-zA-Z0-9_]" "_")}
+                           has-value? (assoc :value (:value sub-run))
+                           coord      (assoc :coord coord)))))))
+           (or subs-ran [])))))
 
 ;; ---- record projection ----------------------------------------------------
 
@@ -430,7 +507,8 @@
          {:keys [level-1 level-2]} (partition-subs-by-level ran topology readers)
          v-rows        (view-rows trace-events changed-set)
          unmounted     (unmounted-views trace-events)
-         destroyed     (destroyed-subscriptions trace-events)]
+         destroyed     (destroyed-subscriptions trace-events)
+         sub-vals      (sub-values ran topology)]
      {:subs-ran        ran
       :subs-skipped    skipped
       :views-rendered  renders
@@ -440,12 +518,14 @@
       :view-rows       v-rows
       :unmounted-views unmounted
       :destroyed-subs  destroyed
+      :sub-values      sub-vals
       :counts          {:subs-ran         (count ran)
                         :subs-skipped     (count skipped)
                         :views-rendered   (count renders)
                         :view-rows        (count v-rows)
                         :unmounted-views  (count unmounted)
                         :destroyed-subs   (count destroyed)
+                        :sub-values       (count sub-vals)
                         :flows-recomputed flows-comp
                         :flows-skipped    flows-skipped}})))
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_view.cljs
@@ -31,9 +31,14 @@
   - **shared subscription** → a sub read by ≥2 views fans out to N view
     nodes; the node carries a `×N` annotation.
 
-  Below the graph two list sections record the epoch's reactive
-  teardown (Figma design):
+  Below the graph three list sections complete the panel:
 
+  - **SUB VALUES** (rf2-e46qs phase 3 of rf2-oqa60) — one row per RUN
+    sub this cascade; each row's value renders through the first-class
+    data-display widget (`views.data-display`, spec/021 §10) DIRECTLY
+    — no `edn/inspect` / `edn/browse` facade hop. Per-row stable
+    `:panel-id` (`:rf.xray.reactive-sub-value/<sub-id>`) so two sub-row
+    expansions never share state.
   - **UNMOUNTED VIEWS** — views whose component unmounted this epoch.
   - **DESTROYED SUBSCRIPTIONS** — subs cleaned up when their last reader
     unmounted (data-availability honest: empty until the sub-dispose op
@@ -66,7 +71,13 @@
             [re-frame.core :as rf]
             [day8.re-frame2-xray.panels.reactive-flow-graph :as graph]
             [day8.re-frame2-xray.theme.tokens :as tk
-             :refer [tokens mono-stack sans-stack]]))
+             :refer [tokens mono-stack sans-stack]]
+            ;; rf2-e46qs phase 3 — per-sub value inspector renders
+            ;; through the first-class data-display widget (spec/021
+            ;; §10) directly. Each sub-value mount gets its own stable
+            ;; per-sub `:panel-id` so two sub-row expansions are
+            ;; independent (acceptance #2).
+            [day8.re-frame2-xray.views.data-display :as dd]))
 
 ;; ---- section chrome -----------------------------------------------------
 
@@ -402,6 +413,112 @@
                   :font-family sans-stack :font-size "10px"}}
       "Subscriptions cleaned up when their last reader unmounted"]]))
 
+;; ---- SUB VALUES inspector section (rf2-e46qs phase 3 of rf2-oqa60) -----
+;;
+;; One row per RUN sub this cascade, surfacing the sub's current value
+;; through the first-class data-display widget (`views.data-display`,
+;; spec/021 §10). Each row mounts `[dd/data-display value opts]`
+;; directly — no `edn/inspect` / `edn/browse` facade hop.
+;;
+;; Per-row `:panel-id` (acceptance #2) is a STABLE per-sub keyword built
+;; from the sub-id: two sub-row expansions never share expansion state.
+;; The widget auto-generates a fresh `mount-id` per call site (D4=a,
+;; rf2-sndui), so a re-render preserves the operator's drill-downs.
+
+(defn- sub-value-panel-id
+  "Stable per-sub `:panel-id` for the data-display mount. The sub-id
+  (a keyword in the standard case) is folded into a namespaced kw under
+  `:rf.xray.reactive-sub-value` so its expansion slot is isolated from
+  every other panel-id in the app-db expansion map. Acceptance #2 —
+  multiple sub-row expansions are independent."
+  [sub-id]
+  (cond
+    (keyword? sub-id)
+    (keyword "rf.xray.reactive-sub-value"
+             (str (when-let [ns (namespace sub-id)] (str ns "_"))
+                  (name sub-id)))
+
+    :else
+    (keyword "rf.xray.reactive-sub-value"
+             (string/replace (pr-str sub-id) #"[^a-zA-Z0-9_]" "_"))))
+
+(defn- sub-value-row
+  "Render one SUB VALUES row — the sub's id + its current value through
+  `[dd/data-display]`. Changed subs read in the accent tone; unchanged
+  subs read dimmed (consistent with the flow-graph node encoding).
+
+  `:has-value?` false → the sub-run carried no `:value` slot (privacy
+  redaction or pre-attribution). The row renders a muted placeholder
+  rather than mounting the widget with `nil` (which would be
+  indistinguishable from a sub whose actual value is `nil`)."
+  [{:keys [sub-id slug changed? has-value? value coord]}]
+  (let [row-testid (str "rf-xray-reactive-sub-value-row-" slug)
+        click      (when coord (fn [e] (open-source! coord e)))]
+    [:div {:data-testid row-testid
+           :data-sub-changed (str (boolean changed?))
+           :style {:display       "flex"
+                   :flex-direction "column"
+                   :gap           "6px"
+                   :padding       "10px 14px"
+                   :border-top    (str "1px solid " (:border-subtle tokens))
+                   :font-family   mono-stack
+                   :font-size     "12px"}}
+     [:div {:style {:display "flex" :align-items "baseline" :gap "8px"}}
+      [:span (cond-> {:data-testid (str row-testid "-id")
+                      :style       {:color (if changed?
+                                             (:accent tokens)
+                                             (:dim tokens))
+                                    :font-weight (if changed? 600 400)}}
+               click (assoc :on-click click
+                            :style {:color (if changed?
+                                             (:accent tokens)
+                                             (:dim tokens))
+                                    :font-weight (if changed? 600 400)
+                                    :cursor "pointer"}))
+       (format-id sub-id)]
+      [:span {:style {:color (:text-tertiary tokens)
+                      :font-family sans-stack
+                      :font-size "10px"
+                      :letter-spacing "0.4px"
+                      :text-transform "uppercase"}}
+       (if changed? "changed" "unchanged")]]
+     (if has-value?
+       [:div {:data-testid (str row-testid "-value")
+              :style {:padding-left "4px"}}
+        [dd/data-display value {:panel-id (sub-value-panel-id sub-id)
+                                :default-expanded-depth 2}]]
+       [:div {:data-testid (str row-testid "-no-value")
+              :style {:padding-left "4px"
+                      :color (:text-tertiary tokens)
+                      :font-family sans-stack
+                      :font-size "11px"
+                      :font-style "italic"}}
+        "(value not captured — redacted or pre-attribution)"])]))
+
+(defn- sub-values-section
+  "Render the SUB VALUES inspector section beneath the flow graph. One
+  row per RUN sub; rows render their value through `[dd/data-display]`
+  directly (rf2-e46qs phase 3 of rf2-oqa60). The section is omitted
+  entirely when the cascade ran no subs — the flow graph's empty
+  placeholder already covers the no-cascade case.
+
+  Row hiccup is produced by INLINING `sub-value-row` (function call,
+  not a `[sub-value-row …]` Reagent component form) so the
+  `[dd/data-display value opts]` mount surfaces in the panel's hiccup
+  tree directly — testable without a React render — and the React
+  reconciler still keys each row via the `^{:key …}` metadata on the
+  inlined `[:div …]`."
+  [data]
+  (let [rows (:sub-values data)]
+    (when (seq rows)
+      [:section {:data-testid "rf-xray-reactive-sub-values-section"
+                 :style {:margin-top "24px"}}
+       (section-label "sub-values" "Sub Values")
+       (into [:div {:data-testid "rf-xray-reactive-sub-values-list"
+                    :style list-card-style}]
+             (for [{:keys [sub-id] :as row} rows]
+               (with-meta (sub-value-row row) {:key (str sub-id)})))])))
+
 ;; ---- legend ------------------------------------------------------------
 
 (defn- swatch
@@ -470,6 +587,10 @@
          [:section {:data-testid "rf-xray-reactive-flow-section"}
           (section-label "flow" "Reactive Flow" {:title-case? true})
           (flow-graph data)]
+         ;; rf2-e46qs phase 3 — SUB VALUES inspector (per-sub
+         ;; value rendered through the first-class data-display
+         ;; widget; spec/021 §10).
+         (sub-values-section data)
          (unmounted-views-section data)
          (destroyed-subs-section data)
          (legend)])]]))

--- a/tools/xray/test/day8/re_frame2_xray/panels/reactive_panel_subs_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/reactive_panel_subs_cljs_test.cljs
@@ -421,3 +421,124 @@
           p (subs/project-record record)]
       (is (= [:a :b] (mapv :sub-id (:level-1-subs p))))
       (is (empty? (:level-2-subs p))))))
+
+;; ===========================================================================
+;; SUB VALUES inspector (rf2-e46qs phase 3 of rf2-oqa60)
+;; ===========================================================================
+;;
+;; The SUB VALUES section beneath the flow graph renders each RUN sub's
+;; current cascade value through the first-class data-display widget
+;; (`views.data-display`). The projection layer here surfaces a
+;; `:sub-values` slot — one row per RUN sub, carrying the sub-id, the
+;; changed/unchanged flag, an explicit `:has-value?` presence flag (so a
+;; redacted/absent value is distinguishable from an actual `nil`), the
+;; `:value` itself (when present), the source `:coord` (for the
+;; jump-to-source affordance), and a CSS-safe `:slug` for the testid.
+;;
+;; Skipped subs (memo hits — `:recomputed?` false) are deliberately
+;; omitted: they carry no fresh value this cascade.
+
+(defn- sub-run-with-value
+  "Sub-run entry mirroring the substrate's `:sub-runs` projection: carries
+  `:recomputed?` + `:value-changed?` + an explicit `:value`. Use this
+  helper for the SUB VALUES inspector tests where the per-sub value
+  drives the inspector mount."
+  [sub-id recomputed? changed? value]
+  {:sub-id sub-id :query-v [sub-id]
+   :recomputed? recomputed? :value-changed? changed?
+   :value value})
+
+(deftest sub-values-projects-one-row-per-ran-sub
+  (testing "rf2-e46qs — one row per RUN sub; each carries the sub-id,
+            changed?, has-value? presence, the value, and a CSS-safe
+            testid slug."
+    (let [rows (subs/sub-values
+                 [(sub-run-with-value :cart/state true true {:items [1 2]})
+                  (sub-run-with-value :cart/total true false 0)])]
+      (is (= 2 (count rows)))
+      (is (= :cart/state (-> rows first :sub-id)))
+      (is (true? (-> rows first :changed?)))
+      (is (true? (-> rows first :has-value?)))
+      (is (= {:items [1 2]} (-> rows first :value)))
+      (is (string? (-> rows first :slug)))
+      (is (= "_cart_state" (-> rows first :slug))
+          "slug folds keyword punctuation to underscore for the testid"))))
+
+(deftest sub-values-skipped-subs-are-omitted
+  (testing "rf2-e46qs — `:recomputed?` false subs carry no fresh value
+            this cascade; the inspector projection excludes them."
+    (let [rows (subs/sub-values
+                 [(sub-run-with-value :cart/state true true {:a 1})
+                  (sub-run-with-value :cart/skipped false false :stale)])]
+      (is (= [:cart/state] (mapv :sub-id rows))
+          "the skipped (memo-hit) sub is omitted from the inspector"))))
+
+(deftest sub-values-honours-has-value-presence-distinct-from-nil
+  (testing "rf2-e46qs — a sub-run without a `:value` key (redacted /
+            pre-attribution) is `:has-value? false`; a sub-run with
+            `:value nil` is `:has-value? true` with `:value nil`. The
+            view layer renders the no-value placeholder for the former
+            and mounts the widget with `nil` for the latter."
+    (let [rows (subs/sub-values
+                 [{:sub-id :no/value :recomputed? true :value-changed? true}
+                  {:sub-id :explicit/nil :recomputed? true :value-changed? true
+                   :value nil}])]
+      (is (= 2 (count rows)))
+      (is (false? (-> rows first :has-value?))
+          "no `:value` key → `:has-value? false`")
+      (is (not (contains? (first rows) :value))
+          "no `:value` key → `:value` slot omitted from the row")
+      (is (true? (-> rows second :has-value?))
+          "explicit `:value nil` → `:has-value? true`")
+      (is (contains? (second rows) :value)
+          "explicit `:value nil` → row carries the `:value` slot")
+      (is (nil? (-> rows second :value))))))
+
+(deftest sub-values-carries-source-coord-from-topology
+  (testing "rf2-e46qs — the `:coord` slot rides from the static topology
+            snapshot so the inspector row can offer a jump-to-source
+            affordance. Absent topology → no `:coord` slot (degrade)."
+    (let [rows (subs/sub-values
+                 [(sub-run-with-value :cart/state true true {:a 1})]
+                 topology)]
+      (is (= "cart.cljs" (-> rows first :coord :file))))
+    (let [rows (subs/sub-values
+                 [(sub-run-with-value :cart/state true true {:a 1})]
+                 nil)]
+      (is (not (contains? (first rows) :coord))
+          "no topology → no `:coord` slot"))))
+
+(deftest sub-values-nil-safe
+  (testing "rf2-e46qs — nil / empty inputs project to an empty row vector."
+    (is (= [] (subs/sub-values nil)))
+    (is (= [] (subs/sub-values [])))
+    (is (= [] (subs/sub-values nil nil)))))
+
+(deftest project-record-emits-sub-values-slot
+  (testing "rf2-e46qs — project-record threads :sub-values into the
+            composite shape + its count rides the :counts map."
+    (let [record {:sub-runs [(sub-run-with-value :cart/state true true {:a 1})
+                             (sub-run-with-value :cart/total true false 0)
+                             (sub-run-with-value :cart/skip false false :stale)]}
+          p (subs/project-record record topology)]
+      (is (= [:cart/state :cart/total] (mapv :sub-id (:sub-values p)))
+          "the inspector projection rides on :sub-values")
+      (is (= 2 (-> p :counts :sub-values))
+          ":counts gets a :sub-values tally")
+      (is (true? (-> p :sub-values first :has-value?)))
+      (is (= {:a 1} (-> p :sub-values first :value))))))
+
+(deftest partition-subs-by-level-threads-value-onto-rows
+  (testing "rf2-e46qs — :value rides through partition-subs-by-level onto
+            both Level 1 and Level 2+ rows so the flow-graph layer has
+            access to the inspector data (e.g. for a future click-into-
+            node drill-down)."
+    (let [{:keys [level-1 level-2]}
+          (subs/partition-subs-by-level
+            [(sub-run-with-value :cart/state true true {:items [1 2]})
+             (sub-run-with-value :cart/total true true 42)]
+            topology)]
+      (is (= {:items [1 2]} (-> level-1 first :value)))
+      (is (true? (-> level-1 first :has-value?)))
+      (is (= 42 (-> level-2 first :value)))
+      (is (true? (-> level-2 first :has-value?))))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/reactive_panel_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/reactive_panel_view_cljs_test.cljs
@@ -19,7 +19,10 @@
             [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
             [day8.re-frame2-xray.panels.reactive-panel :as facade]
-            [day8.re-frame2-xray.panels.reactive-panel-view :as view]))
+            [day8.re-frame2-xray.panels.reactive-panel-view :as view]
+            ;; rf2-e46qs phase 3 — assert the SUB VALUES row mounts
+            ;; `[dd/data-display value opts]` directly (no facade hop).
+            [day8.re-frame2-xray.views.data-display :as dd]))
 
 (defn- has-testid? [tree testid]
   (some? (th/find-by-testid tree testid)))
@@ -324,3 +327,196 @@
       (is (re-find #"changed \(propagates" legend-text) "changed swatch labelled")
       (is (re-find #"no change \(short-circuits" legend-text) "no-change swatch labelled")
       (is (re-find #"unmounted / destroyed" legend-text) "teardown swatch labelled"))))
+
+;; ---- SUB VALUES inspector (rf2-e46qs phase 3 of rf2-oqa60) -----------
+;;
+;; Each ran sub renders its current cascade value through the
+;; first-class `[dd/data-display value opts]` widget DIRECTLY (no
+;; `edn/inspect` / `edn/browse` facade hop). Acceptance:
+;;
+;;   1. Each sub's value renders via `[dd/data-display]` directly.
+;;   2. Stable per-sub `:panel-id` qualifier so two sub-row expansions
+;;      are independent.
+;;   3. Existing rf2-oqa60 phase 1 data-display testid contract holds
+;;      (`rf-xray-data-display-<panel-id>-<mount-id>...`).
+
+(deftest sub-values-section-renders-with-row-per-ran-sub
+  (testing "rf2-e46qs — the SUB VALUES section lists one row per ran sub
+            and surfaces the data-display widget per row."
+    (facade/install!)
+    (frame/reg-frame :rf/xray {})
+    (seed-reactive-data!
+      {:has-cascade? true :frame :rf/app :focus {:current :ep-1}
+       :counts {} :level-1-subs [] :level-2-subs [] :view-rows []
+       :sub-values [{:sub-id :cart/state :slug "_cart_state"
+                     :changed? true :has-value? true
+                     :value {:items [{:id 1} {:id 2}]}}
+                    {:sub-id :cart/total :slug "_cart_total"
+                     :changed? false :has-value? true
+                     :value 42}]})
+    (let [tree (view/reactive-panel)]
+      (is (has-testid? tree "rf-xray-reactive-sub-values-section")
+          "the SUB VALUES section renders")
+      (is (= "Sub Values"
+             (text-of tree "rf-xray-reactive-section-sub-values-label"))
+          "the section heading renders 'Sub Values'")
+      (is (has-testid? tree "rf-xray-reactive-sub-values-list")
+          "the list card renders")
+      (is (has-testid? tree "rf-xray-reactive-sub-value-row-_cart_state")
+          "row renders for :cart/state")
+      (is (has-testid? tree "rf-xray-reactive-sub-value-row-_cart_total")
+          "row renders for :cart/total"))))
+
+;; ---- raw hiccup helpers (rf2-e46qs) -----------------------------------
+;;
+;; `re-frame.test-helpers/find-by-testid` walks via `expand-tree`, which
+;; AUTO-INVOKES every function component (including `dd/data-display`'s
+;; form-2 outer fn → inner fn). That's the right default for assertions
+;; about WHAT renders — but here we need to assert WHAT IS MOUNTED, not
+;; the expansion: the data-display literal `[dd/data-display value
+;; opts]` is the contract surface we're locking. So we walk the raw,
+;; un-expanded hiccup.
+
+(defn- raw-find-dd-mount
+  "Walk the raw hiccup tree (no function-component expansion) and
+  return the first `[dd/data-display value opts]` vector under a node
+  with `data-testid == testid`, or nil. Mirrors `find-by-testid` for
+  the gate node; under the gate node we look at unexpanded children
+  (the literal data-display form survives because we never call the
+  walker that would invoke it)."
+  [tree testid]
+  (letfn [(walk [node]
+            (cond
+              (and (vector? node)
+                   (or (= dd/data-display (first node))
+                       ;; symbol-bound name preserves identity in some
+                       ;; advanced builds
+                       (= 'day8.re-frame2-xray.views.data-display/data-display
+                          (first node))))
+              node
+
+              (vector? node) (some walk node)
+              (seq? node)    (some walk node)
+              :else          nil))
+
+          (gate [node]
+            (cond
+              (and (vector? node)
+                   (map? (second node))
+                   (= testid (:data-testid (second node))))
+              (walk node)
+
+              (vector? node) (some gate node)
+              (seq? node)    (some gate node)
+              :else          nil))]
+    (gate tree)))
+
+(deftest sub-values-row-mounts-data-display-widget-directly
+  (testing "rf2-e46qs acceptance #1 — each row mounts the first-class
+            `[dd/data-display value opts]` widget DIRECTLY (no `edn/`
+            facade hop). The literal data-display form lives in the
+            unexpanded panel hiccup — the contract surface."
+    (facade/install!)
+    (frame/reg-frame :rf/xray {})
+    (seed-reactive-data!
+      {:has-cascade? true :frame :rf/app :focus {:current :ep-1}
+       :counts {} :level-1-subs [] :level-2-subs [] :view-rows []
+       :sub-values [{:sub-id :cart/state :slug "_cart_state"
+                     :changed? true :has-value? true
+                     :value {:items [1 2 3]}}]})
+    (let [tree (view/reactive-panel)
+          dd   (raw-find-dd-mount
+                 tree "rf-xray-reactive-sub-value-row-_cart_state-value")]
+      (is (some? dd)
+          "the row mounts [dd/data-display value opts] directly")
+      (is (= {:items [1 2 3]} (nth dd 1 nil))
+          "value flows through as the second arg")
+      (is (map? (nth dd 2 nil))
+          "opts map rides the third arg"))))
+
+(deftest sub-values-row-uses-stable-per-sub-panel-id
+  (testing "rf2-e46qs acceptance #2 — each row's data-display mount
+            carries a STABLE per-sub `:panel-id` so two sub-row
+            expansions are independent. The panel-id is namespaced
+            under `:rf.xray.reactive-sub-value` and folds the sub-id."
+    (facade/install!)
+    (frame/reg-frame :rf/xray {})
+    (seed-reactive-data!
+      {:has-cascade? true :frame :rf/app :focus {:current :ep-1}
+       :counts {} :level-1-subs [] :level-2-subs [] :view-rows []
+       :sub-values [{:sub-id :cart/state :slug "_cart_state"
+                     :changed? true :has-value? true :value 1}
+                    {:sub-id :cart/total :slug "_cart_total"
+                     :changed? true :has-value? true :value 2}]})
+    (let [tree (view/reactive-panel)
+          extract-panel-id
+          (fn [slug]
+            (-> (raw-find-dd-mount
+                  tree (str "rf-xray-reactive-sub-value-row-"
+                            slug "-value"))
+                (nth 2 nil)
+                :panel-id))
+          pid-a (extract-panel-id "_cart_state")
+          pid-b (extract-panel-id "_cart_total")]
+      (is (keyword? pid-a) "panel-id is a keyword")
+      (is (keyword? pid-b))
+      (is (not= pid-a pid-b)
+          "two sub-rows get distinct panel-ids (independent expansion)")
+      (is (= "rf.xray.reactive-sub-value" (namespace pid-a))
+          "panel-id is namespaced under :rf.xray.reactive-sub-value")
+      (is (= "rf.xray.reactive-sub-value" (namespace pid-b))))))
+
+(deftest sub-values-row-no-value-renders-placeholder
+  (testing "rf2-e46qs — a sub-run without a `:value` key (redaction /
+            pre-attribution) renders the muted no-value placeholder; no
+            data-display widget mount (rather than mounting with `nil`,
+            which would be indistinguishable from a sub whose actual
+            value IS nil)."
+    (facade/install!)
+    (frame/reg-frame :rf/xray {})
+    (seed-reactive-data!
+      {:has-cascade? true :frame :rf/app :focus {:current :ep-1}
+       :counts {} :level-1-subs [] :level-2-subs [] :view-rows []
+       :sub-values [{:sub-id :cart/secret :slug "_cart_secret"
+                     :changed? true :has-value? false}]})
+    (let [tree (view/reactive-panel)]
+      (is (has-testid?
+            tree "rf-xray-reactive-sub-value-row-_cart_secret-no-value")
+          "the no-value placeholder renders for redacted/absent")
+      (is (nil? (th/find-by-testid
+                  tree "rf-xray-reactive-sub-value-row-_cart_secret-value"))
+          "no data-display mount when the value is absent"))))
+
+(deftest sub-values-section-omitted-when-no-ran-subs
+  (testing "rf2-e46qs — empty `:sub-values` → the SUB VALUES section is
+            entirely omitted (the flow-graph empty placeholder already
+            covers the no-cascade case; no need for a second empty)."
+    (facade/install!)
+    (frame/reg-frame :rf/xray {})
+    (seed-reactive-data!
+      {:has-cascade? true :frame :rf/app :focus {:current :ep-1}
+       :counts {} :level-1-subs [] :level-2-subs [] :view-rows []
+       :sub-values []})
+    (let [tree (view/reactive-panel)]
+      (is (nil? (th/find-by-testid tree "rf-xray-reactive-sub-values-section"))
+          "section is omitted when no ran subs"))))
+
+(deftest sub-values-row-tags-changed-state
+  (testing "rf2-e46qs — each row carries `data-sub-changed` so tests +
+            CSS can target changed vs unchanged sub-value rows."
+    (facade/install!)
+    (frame/reg-frame :rf/xray {})
+    (seed-reactive-data!
+      {:has-cascade? true :frame :rf/app :focus {:current :ep-1}
+       :counts {} :level-1-subs [] :level-2-subs [] :view-rows []
+       :sub-values [{:sub-id :s/changed :slug "_s_changed"
+                     :changed? true :has-value? true :value 1}
+                    {:sub-id :s/unchanged :slug "_s_unchanged"
+                     :changed? false :has-value? true :value 2}]})
+    (let [tree (view/reactive-panel)
+          changed (th/find-by-testid
+                    tree "rf-xray-reactive-sub-value-row-_s_changed")
+          unchanged (th/find-by-testid
+                      tree "rf-xray-reactive-sub-value-row-_s_unchanged")]
+      (is (= "true"  (get-in changed   [1 :data-sub-changed])))
+      (is (= "false" (get-in unchanged [1 :data-sub-changed]))))))


### PR DESCRIPTION
Phase 3 of [rf2-oqa60](https://github.com/day8/re-frame2/pull/2143). Migrates the Views panel (`reactive-panel-view`) per-sub VALUE inspection onto the first-class `views.data-display` widget — each sub renders through `[dd/data-display value opts]` directly, no `edn/inspect` / `edn/browse` facade hop.

## Acceptance (rf2-e46qs)

1. ✅ Each sub's value renders via `[dd/data-display]` directly.
2. ✅ Stable per-sub `:panel-id` qualifier so multiple sub-row expansions are independent (`:rf.xray.reactive-sub-value/<sub-id>` keyword namespace).
3. ✅ Existing rf2-oqa60 phase 1 testid contract holds — each row carries its own `rf-xray-reactive-sub-value-row-<slug>` testid; the widget's per-mount `rf-xray-data-display-<panel-id>-<mount-id>` container surfaces verbatim under each row.

## Shape

A new **SUB VALUES** section renders between the flow graph and the UNMOUNTED VIEWS section. One row per `:recomputed?` true sub this cascade; each row shows the sub-id (mode-accent on changed, dim on unchanged) + a changed/unchanged tag + the value tree via `[dd/data-display]`. Memoised skips are omitted (no fresh value to inspect). Sub-runs without a `:value` slot (privacy redaction / pre-attribution) render a muted no-value placeholder rather than mounting the widget with `nil` — distinct from a sub whose actual value IS nil.

## Files touched

- `tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_subs.cljs` — `partition-subs-by-level` threads `:value` + `:has-value?` onto L1 / L2+ rows; new `sub-values` projection; `project-record` composes the `:sub-values` slot + tally.
- `tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_view.cljs` — new `sub-values-section` + `sub-value-row` + `sub-value-panel-id` helpers, wired into the panel between the flow graph and the unmount/destroyed list sections.
- `tools/xray/spec/021-Dynamic-Panel-Designs.md` — §3.2 adds SUB VALUES to the three below-graph sections; §10.0.4 phase 3 line cross-links rf2-e46qs.
- `tools/xray/test/day8/re_frame2_xray/panels/reactive_panel_subs_cljs_test.cljs` — 7 new tests covering the projection.
- `tools/xray/test/day8/re_frame2_xray/panels/reactive_panel_view_cljs_test.cljs` — 6 new tests covering the section render + acceptance #1/#2. The acceptance #1/#2 tests walk the RAW (un-expanded) hiccup so the literal `[dd/data-display value opts]` form is observable; the default `find-by-testid` walker expands function components, hiding the contract surface.

## Gates

- `scripts/test-fast-pr.sh` PASS — core JVM, JS harness helpers, CLJS node integration (4466 tests / 14230 assertions / 0 failures).
- `python -m mkdocs build --strict` PASS.

## No collision with parallel workers

- rf2-43koh (trace_bus retire / trace_collector) landed on `main` before this branch rebased.
- rf2-hhtbl (phase 2 — Trace panel) operates on `panels/trace.cljs` — disjoint.
- rf2-lxvn6 (phase 4 — Machine inspector) operates on `panels/machine_*.cljs` — disjoint.

Depends on: rf2-oqa60 (phase 1, ✅ landed in #2143).