### PR TITLE
feat(xray): data-display widget phase 7 — IXrayDataDisplay protocol (rf2-0qrcr)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1389,8 +1389,8 @@ Phases 2-5 file as separate beads chained off rf2-oqa60:
 - Phase 5 — Diff renderer subsumption (D5=a; replaces
   `data-display/render-tree` and deletes `theme.data-inspector`)
 - Phase 6 (deferred) — Popup overlay infra (D6=a)
-- Phase 7 (optional) — `IXrayDataDisplay` custom-formatters
-  protocol (D7=a)
+- Phase 7 (rf2-0qrcr) — `IXrayDataDisplay` custom-formatters
+  protocol (D7=a) — see §10.0.6
 
 #### §10.0.5 Code-block (separate surface)
 
@@ -1401,6 +1401,88 @@ devtools never owned this, and the in-bundle tokenizer + zprint
 pre-format pipeline survives the rf2-oqa60 cut-over unchanged).
 Token colours follow the Figma `.syntax-*` block: keywords red,
 strings blue/green, numbers blue, comments muted-italic.
+
+#### §10.0.6 `IXrayDataDisplay` custom-formatters protocol (phase 7 · D7=a · rf2-0qrcr)
+
+Phase 7 of rf2-oqa60 opens a single extension seam on the closed
+phase-1 renderer for consuming applications that carry domain types
+the built-in classifier has no better fallback for than `pr-str`.
+
+**Surface** — `day8.re-frame2-xray.views.data-display-protocol`:
+
+```clj
+(defprotocol IXrayDataDisplay
+  (-xray-render-header [v opts])
+  (-xray-render-body   [v opts]))
+```
+
+**Contract**:
+
+- `-xray-render-header` returns hiccup for the node's header row
+  (the row that sits next to the toggle glyph, or the inline-fit
+  content). Returning `nil` falls through to the built-in renderer
+  for the whole node — consumers can selectively opt out per value.
+- `-xray-render-body` returns hiccup for the expanded body, or
+  `nil` for a header-only render (no expanded body, no toggle).
+
+`opts` carries the same per-node context the built-in renderer
+sees — `:panel-id`, `:mount-id`, `:path`, `:depth`,
+`:expansion-map`, plus the per-widget `:default-expanded-depth` /
+`:max-inline-width` / `:max-depth`. The original argument map is
+also threaded under `:node-opts` for consumers that want to recurse
+the built-in renderer on sub-values via `data-display/render-node`.
+
+**Dispatch order** (in `render-node`):
+
+1. `(satisfies? IXrayDataDisplay v)` → consult the protocol.
+2. `-xray-render-header v opts` returns nil → fall through to the
+   built-in container / scalar dispatch.
+3. Otherwise wrap the header (+ optional body) in the standard
+   widget chrome — same `data-testid` shape `[panel-id mount-id
+   path]` as built-in nodes so panel-level toggle / reset
+   affordances address protocol nodes uniformly.
+
+**Safety** — the wrapper catches exceptions thrown by consumer
+impls. A broken third-party formatter falls through to the
+built-in renderer rather than blanking the inspector.
+
+**Boundary** — the protocol is the ONLY public extension seam
+in the widget. Consumers do NOT extend interactions through this
+protocol (the locked B.9 / rf2-sndui model ships exactly one
+path-click interaction); the seam is purely for value rendering.
+
+**Worked example** — a domain `Money` type that wants to render
+as a single chip with the amount + currency, but expand to show
+the underlying ledger entries:
+
+```clj
+(ns my-app.domain.money
+  (:require [day8.re-frame2-xray.views.data-display-protocol
+             :refer [IXrayDataDisplay]]))
+
+(deftype Money [amount currency ledger]
+  IXrayDataDisplay
+  (-xray-render-header [_ _opts]
+    [:span {:style {:color    "var(--rf-xray-syntax-number)"
+                    :padding  "0 6px"
+                    :background "color-mix(in srgb, var(--rf-xray-syntax-number) 12%, transparent)"
+                    :border-radius "3px"}}
+     (str amount " " currency)])
+  (-xray-render-body [_ opts]
+    [day8.re-frame2-xray.views.data-display/render-node
+     (assoc opts :value ledger)]))
+```
+
+Mounted via `[data-display some-money-instance]` — the chip shows
+collapsed; click expands to the ledger as a normal map view.
+
+**Tests** — `tools/xray/test/day8/re_frame2_xray/views/data_display_protocol_cljs_test.cljs`
+pins: (a) built-in types still route through the built-in dispatch
+(no protocol path leakage), (b) protocol-implementing types take
+the protocol path and the consumer's hiccup appears verbatim,
+(c) header-nil falls through, (d) body-nil renders header-only,
+(e) broken consumer impl falls through safely, (f) expansion-map
+overrides still apply to protocol nodes.
 
 ### §10.1 Capabilities (LOCKED per B.9 super-prompt)
 

--- a/tools/xray/src/day8/re_frame2_xray/views/data_display.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/data_display.cljs
@@ -91,7 +91,8 @@
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
             [day8.re-frame2-xray.theme.tokens
-             :refer [tokens mono-stack]]))
+             :refer [tokens mono-stack]]
+            [day8.re-frame2-xray.views.data-display-protocol :as ddp]))
 
 ;; =========================================================================
 ;; expansion state — lives in :rf.xray.data-display/expansion under :rf/xray
@@ -718,25 +719,80 @@
                       :font-family mono-stack}}
         (let [{:keys [close]} (delim kind)] close)])]))
 
+(defn- render-protocol-node
+  "Render a value that satisfies `IXrayDataDisplay` via the consumer's
+  protocol methods. Returns hiccup wrapping the consumer's header
+  (and optional body) in the standard widget chrome — same testid
+  + container-shape contract as the built-in renderer so panel
+  layout doesn't shift between protocol + built-in nodes.
+
+  Returns `nil` if the consumer's `-xray-render-header` returns
+  `nil` — the caller treats that as a fall-through to the built-in
+  renderer (header-nil means \"I don't actually want to customise
+  this node\")."
+  [{:keys [value panel-id mount-id path expansion-map] :as node-opts}]
+  (let [proto-opts (assoc node-opts :node-opts node-opts)
+        header     (ddp/xray-render-header value proto-opts)]
+    (when (some? header)
+      (let [body          (ddp/xray-render-body value proto-opts)
+            default?      true
+            expanded?     (and (some? body)
+                               (resolve-expanded? expansion-map panel-id
+                                                  mount-id path default?))]
+        [:div {:data-testid      (testid-for panel-id mount-id path)
+               :data-rf-kind     "protocol"
+               :data-rf-protocol "1"
+               :data-rf-expanded (if expanded? "1" "0")
+               :style {:font-family mono-stack
+                       :line-height 1.4}}
+         [:div {:style {:display "flex"
+                        :align-items "baseline"
+                        :gap "4px"
+                        :flex-wrap "wrap"}}
+          header]
+         (when (and expanded? (some? body))
+           [:div {:data-testid (str (testid-for panel-id mount-id path) "-body")
+                  :style {:padding-left "14px"
+                          :margin-left  "5px"
+                          :border-left  (str "1px solid " (:border-subtle tokens))}}
+            body])]))))
+
 (defn render-node
   "Recursive entry. Picks container vs scalar; threads the
   expansion-map snapshot down. Returns hiccup. Pure projection of
   (value, expansion-map, opts) — no `rf/subscribe` calls in here.
 
+  Consults `IXrayDataDisplay` at the head — if `value` satisfies the
+  protocol AND the consumer's `-xray-render-header` returns non-nil
+  hiccup, the protocol path wins. Otherwise falls through to the
+  built-in container / scalar dispatch (phase 7 / rf2-0qrcr).
+
   Public so unit tests can drive the renderer without mounting."
   [{:keys [value panel-id mount-id path depth expansion-map opts]
     :or   {depth 0 path []}}]
-  (let [kind (collection-kind value)]
-    (if (container? kind)
-      (render-container {:value value
-                         :kind kind
-                         :panel-id panel-id
-                         :mount-id mount-id
-                         :path path
-                         :depth depth
-                         :expansion-map expansion-map
-                         :opts opts})
-      (render-scalar value))))
+  (or
+    ;; Protocol seam (rf2-0qrcr) — light-touch satisfies? gate; nil
+    ;; result falls through to built-ins. Bound to the same testid
+    ;; contract as the built-in renderer so panel chrome doesn't shift.
+    (when (ddp/satisfies-xray-data-display? value)
+      (render-protocol-node {:value value
+                             :panel-id panel-id
+                             :mount-id mount-id
+                             :path path
+                             :depth depth
+                             :expansion-map expansion-map
+                             :opts opts}))
+    (let [kind (collection-kind value)]
+      (if (container? kind)
+        (render-container {:value value
+                           :kind kind
+                           :panel-id panel-id
+                           :mount-id mount-id
+                           :path path
+                           :depth depth
+                           :expansion-map expansion-map
+                           :opts opts})
+        (render-scalar value)))))
 
 ;; =========================================================================
 ;; mount-id generator + public entry — data-display (form-2 component)

--- a/tools/xray/src/day8/re_frame2_xray/views/data_display_protocol.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/data_display_protocol.cljs
@@ -1,0 +1,111 @@
+(ns day8.re-frame2-xray.views.data-display-protocol
+  "Custom-formatters protocol for the Xray data-display widget
+  (rf2-oqa60 phase 7 · rf2-0qrcr · D7=a per rf2-sndui ruling).
+
+  ## Why this exists
+
+  Phase 1 (rf2-oqa60) shipped a *closed* renderer — it classifies
+  every built-in CLJS shape natively (maps, vectors, sets, records,
+  map-entries, sentinels, scalars). That covers the universe of
+  shapes Xray itself produces. Consuming applications, however, may
+  carry **domain types** (typed records, custom deftypes, opaque
+  wrappers around external library objects) that the closed renderer
+  has no better fallback for than `pr-str`.
+
+  This protocol opens an extension seam *without* opening the
+  internals of the renderer. A consuming type implements
+  `IXrayDataDisplay`; the widget checks `satisfies?` at the top of
+  every `render-node` call and, if true, defers to the consumer's
+  two methods. Otherwise the closed renderer's built-in dispatch
+  runs unchanged.
+
+  ## Contract
+
+      (render-header v opts)  ;; hiccup for the header row (inline,
+                              ;; collapsed-summary, or the open
+                              ;; bracket — whatever the consumer
+                              ;; wants visually at the node's head).
+                              ;; Returning nil falls back to the
+                              ;; built-in renderer for that node.
+
+      (render-body v opts)    ;; hiccup for the expanded body, or
+                              ;; nil for a header-only render.
+                              ;; The widget wraps the body in the
+                              ;; standard indented container
+                              ;; (left-rule + 14px padding).
+
+  Both methods receive the same `opts` map the widget itself
+  threads through `render-node` — `:panel-id`, `:mount-id`, `:path`,
+  `:depth`, `:expansion-map`, `:default-expanded-depth`,
+  `:max-inline-width`, `:max-depth`. Consumer impls are FREE to
+  ignore everything they don't need; they SHOULD honour `:path` /
+  `:panel-id` / `:mount-id` if they want their own toggle behaviour
+  to compose with the widget's expansion slot (`expansion-key`
+  in `data-display.cljs` is the public composer).
+
+  ## Fall-through
+
+  - `(satisfies? IXrayDataDisplay v)` false → built-in renderer.
+  - `render-header` returns `nil` → built-in renderer for this
+    node (skips the protocol entirely for the node, including
+    the body).
+  - `render-body` returns `nil` + header non-nil → header-only
+    render (no expanded body, no toggle).
+
+  This three-state fall-through lets a consumer override just the
+  header (e.g. add a custom tag) while still using the built-in
+  body, or vice versa, without splitting the protocol into four
+  methods.
+
+  ## Boundary
+
+  The protocol is the ONLY public extension seam in the data-display
+  widget. Per the locked B.9 / rf2-sndui interaction model the
+  widget itself ships exactly one path-click interaction; consumers
+  do NOT extend interactions through this protocol — only the
+  visual rendering of values.
+
+  ## Spec
+
+  See `tools/xray/spec/021-Dynamic-Panel-Designs.md` §10.0.6 for
+  the normative description + a worked example."
+  )
+
+(defprotocol IXrayDataDisplay
+  "Custom-formatters protocol for the Xray data-display widget.
+  Consumers implement this on their domain types to override how
+  the widget renders them. See the ns docstring for the contract.
+
+  Both methods MAY return `nil` to fall back to the built-in
+  renderer at that step."
+  (-xray-render-header [v opts]
+    "Return hiccup for the node's header (collapsed summary or
+    inline content). Nil falls through to the built-in renderer for
+    the whole node.")
+  (-xray-render-body [v opts]
+    "Return hiccup for the node's expanded body. Nil suppresses
+    the body (header-only render)."))
+
+(defn xray-render-header
+  "Safe accessor — returns the consumer's `-xray-render-header`
+  output, or nil if `v` does not satisfy the protocol. Catches
+  arbitrary errors from consumer impls so a broken third-party
+  formatter can never blank the whole inspector."
+  [v opts]
+  (when (satisfies? IXrayDataDisplay v)
+    (try (-xray-render-header v opts)
+         (catch :default _ nil))))
+
+(defn xray-render-body
+  "Safe accessor — see `xray-render-header`."
+  [v opts]
+  (when (satisfies? IXrayDataDisplay v)
+    (try (-xray-render-body v opts)
+         (catch :default _ nil))))
+
+(defn satisfies-xray-data-display?
+  "Predicate convenience — true iff `v` satisfies `IXrayDataDisplay`.
+  Exists so callers don't need to `:refer` the protocol symbol when
+  all they need is the gate."
+  [v]
+  (satisfies? IXrayDataDisplay v))

--- a/tools/xray/test/day8/re_frame2_xray/views/data_display_protocol_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/data_display_protocol_cljs_test.cljs
@@ -1,0 +1,274 @@
+(ns day8.re-frame2-xray.views.data-display-protocol-cljs-test
+  "Unit tests for the IXrayDataDisplay custom-formatters protocol
+  (rf2-oqa60 phase 7 · rf2-0qrcr).
+
+  ## What's under test
+
+  1. **Built-in types still render via the built-in dispatch.** A
+     plain CLJS map / vector / scalar must NOT pick up the protocol
+     path — `:data-rf-protocol` is absent.
+
+  2. **Protocol-implementing types use the protocol methods.** A
+     deftype that implements `IXrayDataDisplay` short-circuits the
+     built-in dispatch; the consumer's `-xray-render-header` output
+     appears verbatim in the rendered hiccup.
+
+  3. **Header-nil fall-through.** A consumer that returns nil from
+     `-xray-render-header` falls through to the built-in renderer
+     for that node.
+
+  4. **Body-nil suppresses body.** A consumer with header but nil
+     body renders header-only (no expanded body container).
+
+  5. **Toggle wiring still composes.** The protocol node carries the
+     same `data-testid` shape `[panel-id mount-id path]` as built-in
+     nodes, so a panel's reset / toggle affordances still address
+     it uniformly.
+
+  Pure-data unit tests; no DOM mount."
+  (:require [cljs.test :refer-macros [deftest is use-fixtures]]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-xray.views.data-display :as dd]
+            [day8.re-frame2-xray.views.data-display-protocol :as ddp
+             :refer [IXrayDataDisplay]]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+;; ---- helpers ------------------------------------------------------------
+
+(defn- walk-hiccup
+  "Depth-first collect every hiccup vector in `tree`."
+  [tree]
+  (let [out (atom [])]
+    (letfn [(walk [node]
+              (cond
+                (vector? node)
+                (do (swap! out conj node)
+                    (doseq [child (rest node)] (walk child)))
+                (seq? node) (doseq [c node] (walk c))))]
+      (walk tree))
+    @out))
+
+(defn- find-attr
+  [tree k v]
+  (->> (walk-hiccup tree)
+       (filter (fn [n]
+                 (and (vector? n)
+                      (map? (second n))
+                      (= v (get (second n) k)))))
+       first))
+
+(defn- collect-text
+  [tree]
+  (let [out (atom [])]
+    (letfn [(walk [node]
+              (cond
+                (string? node) (swap! out conj node)
+                (vector? node) (doseq [c (rest node)] (walk c))
+                (seq? node)    (doseq [c node] (walk c))))]
+      (walk tree))
+    (apply str @out)))
+
+;; ---- consumer types -----------------------------------------------------
+
+;; A type that satisfies the protocol with both header + body.
+(deftype FullCustom [tag payload]
+  IXrayDataDisplay
+  (-xray-render-header [_ _opts]
+    [:span {:data-testid "custom-header"
+            :data-custom-tag (str tag)} (str "#" tag)])
+  (-xray-render-body [_ _opts]
+    [:span {:data-testid "custom-body"} (str "body:" payload)]))
+
+;; A type that only customises the header.
+(deftype HeaderOnly [label]
+  IXrayDataDisplay
+  (-xray-render-header [_ _opts]
+    [:span {:data-testid "header-only"} (str "h:" label)])
+  (-xray-render-body [_ _opts] nil))
+
+;; A type that opts-out by returning nil header.
+(deftype OptsOut [inner]
+  IXrayDataDisplay
+  (-xray-render-header [_ _opts] nil)
+  (-xray-render-body [_ _opts] [:span "ignored body"]))
+
+;; A consumer impl that THROWS — the safe accessor must catch.
+(deftype Broken []
+  IXrayDataDisplay
+  (-xray-render-header [_ _opts] (throw (ex-info "boom" {})))
+  (-xray-render-body [_ _opts] (throw (ex-info "boom" {}))))
+
+;; ---- 1. built-in dispatch untouched -------------------------------------
+
+(deftest plain-map-does-not-pick-up-protocol-path
+  (let [h (dd/render-node {:value {:a 1 :b 2}
+                           :panel-id :test
+                           :mount-id "m1"
+                           :path []
+                           :depth 0
+                           :expansion-map {}
+                           :opts {}})]
+    (is (nil? (find-attr h :data-rf-protocol "1"))
+        "plain map MUST NOT render via the protocol path")
+    (is (some? (find-attr h :data-rf-kind "map"))
+        "plain map renders via built-in :map dispatch")))
+
+(deftest plain-vector-does-not-pick-up-protocol-path
+  (let [h (dd/render-node {:value [1 2 3]
+                           :panel-id :test
+                           :mount-id "m1"
+                           :path []
+                           :depth 0
+                           :expansion-map {}
+                           :opts {}})]
+    (is (nil? (find-attr h :data-rf-protocol "1")))
+    (is (some? (find-attr h :data-rf-kind "vector")))))
+
+(deftest plain-scalar-does-not-pick-up-protocol-path
+  (let [h (dd/render-node {:value 42
+                           :panel-id :test
+                           :mount-id "m1"
+                           :path []
+                           :depth 0
+                           :expansion-map {}
+                           :opts {}})]
+    (is (nil? (find-attr h :data-rf-protocol "1")))))
+
+(deftest sentinel-does-not-pick-up-protocol-path
+  ;; Sentinels are first-class types — they must stay on the built-in
+  ;; dispatch, not be accidentally diverted by the protocol seam.
+  (let [h (dd/render-node {:value :rf/redacted
+                           :panel-id :test
+                           :mount-id "m1"
+                           :path []
+                           :depth 0
+                           :expansion-map {}
+                           :opts {}})]
+    (is (nil? (find-attr h :data-rf-protocol "1")))
+    (is (some? (find-attr h :data-rf-type "rf-redacted")))))
+
+;; ---- 2. protocol-implementing types use the protocol --------------------
+
+(deftest full-custom-renders-via-protocol-header-and-body
+  (let [v (FullCustom. "Account" "data-here")
+        h (dd/render-node {:value v
+                           :panel-id :test
+                           :mount-id "m1"
+                           :path []
+                           :depth 0
+                           :expansion-map {}
+                           :opts {}})]
+    (is (some? (find-attr h :data-rf-protocol "1"))
+        "protocol path is taken")
+    (is (some? (find-attr h :data-testid "custom-header"))
+        "consumer's header hiccup is rendered")
+    (is (re-find #"#Account" (collect-text h))
+        "consumer's header text appears in output")
+    ;; default-expanded? on protocol nodes is true; body renders.
+    (is (some? (find-attr h :data-testid "custom-body"))
+        "consumer's body hiccup is rendered when expanded")
+    (is (re-find #"body:data-here" (collect-text h)))))
+
+(deftest protocol-node-carries-stable-testid
+  (let [v (FullCustom. "Account" "data")
+        h (dd/render-node {:value v
+                           :panel-id :test
+                           :mount-id "m99"
+                           :path [:k]
+                           :depth 0
+                           :expansion-map {}
+                           :opts {}})]
+    (is (some? (find-attr h :data-testid
+                          "rf-xray-data-display-test-m99-:k"))
+        "protocol node carries the same `[panel-id mount-id path]` testid as built-in nodes")))
+
+;; ---- 3. header-nil fall-through to built-ins ----------------------------
+
+(deftest header-nil-falls-through-to-built-ins
+  ;; OptsOut returns nil from header — but the underlying value isn't
+  ;; itself a built-in container/scalar; it's a deftype. The
+  ;; fall-through lands at the `:other` scalar case (pr-str). That's
+  ;; the right outcome — the consumer explicitly opted out, the
+  ;; widget shouldn't second-guess.
+  (let [v (OptsOut. "inner")
+        h (dd/render-node {:value v
+                           :panel-id :test
+                           :mount-id "m1"
+                           :path []
+                           :depth 0
+                           :expansion-map {}
+                           :opts {}})]
+    (is (nil? (find-attr h :data-rf-protocol "1"))
+        "header-nil opts out of the protocol path")
+    (is (some? (find-attr h :data-rf-type "other"))
+        "falls through to the :other scalar fallback")))
+
+;; ---- 4. body-nil renders header-only ------------------------------------
+
+(deftest body-nil-renders-header-only
+  (let [v (HeaderOnly. "tag")
+        h (dd/render-node {:value v
+                           :panel-id :test
+                           :mount-id "m1"
+                           :path []
+                           :depth 0
+                           :expansion-map {}
+                           :opts {}})]
+    (is (some? (find-attr h :data-rf-protocol "1"))
+        "protocol path is still taken (header is non-nil)")
+    (is (some? (find-attr h :data-testid "header-only"))
+        "consumer header rendered")
+    ;; No body container — the testid suffix `-body` is absent.
+    (is (nil? (find-attr h :data-testid
+                         "rf-xray-data-display-test-m1--body"))
+        "no body container rendered when body-fn returns nil")))
+
+;; ---- 5. broken consumer impl: safe catch --------------------------------
+
+(deftest broken-consumer-impl-falls-through-safely
+  ;; A consumer impl that throws must not blank the whole inspector.
+  ;; The safe accessor catches; the widget sees nil header and
+  ;; falls through to built-ins (which renders the deftype via
+  ;; the :other / pr-str fallback).
+  (let [v (Broken.)
+        h (dd/render-node {:value v
+                           :panel-id :test
+                           :mount-id "m1"
+                           :path []
+                           :depth 0
+                           :expansion-map {}
+                           :opts {}})]
+    (is (nil? (find-attr h :data-rf-protocol "1"))
+        "broken impl falls through to built-ins")
+    (is (some? (find-attr h :data-rf-type "other"))
+        "lands on the :other pr-str fallback")))
+
+;; ---- 6. expansion-map override still wins on protocol nodes -------------
+
+(deftest expansion-map-collapses-protocol-body
+  (let [v (FullCustom. "Account" "data")
+        ;; Force-collapsed via the expansion-map override.
+        k (dd/expansion-key :test "m1" [])
+        h (dd/render-node {:value v
+                           :panel-id :test
+                           :mount-id "m1"
+                           :path []
+                           :depth 0
+                           :expansion-map {k {:expanded? false}}
+                           :opts {}})]
+    (is (some? (find-attr h :data-rf-protocol "1")))
+    (is (some? (find-attr h :data-rf-expanded "0"))
+        "expansion-map override flips :data-rf-expanded to \"0\"")
+    (is (nil? (find-attr h :data-testid "custom-body"))
+        "body NOT rendered when expansion-map collapses the node")))
+
+;; ---- 7. predicate convenience -------------------------------------------
+
+(deftest satisfies-predicate
+  (is (true?  (ddp/satisfies-xray-data-display? (FullCustom. "x" "y"))))
+  (is (false? (ddp/satisfies-xray-data-display? {:a 1})))
+  (is (false? (ddp/satisfies-xray-data-display? 42)))
+  (is (false? (ddp/satisfies-xray-data-display? nil))))


### PR DESCRIPTION
## Summary

Phase 7 of rf2-oqa60 — D7=a per rf2-sndui ruling. Adds the `IXrayDataDisplay` custom-formatters protocol so consuming applications can plug into the widget`s renderer chain for their own domain types.

Closes-out the "we deferred this until needed" decision from phase 1 (#2143 shipped a closed renderer). The protocol is the ONLY public extension seam on the widget; consumers do NOT extend interactions through it (the locked B.9 / rf2-sndui interaction model ships exactly one path-click; this seam is purely for value rendering).

## What this adds

- **`tools/xray/src/day8/re_frame2_xray/views/data_display_protocol.cljs`** — new ns declaring `IXrayDataDisplay` with `-xray-render-header [v opts]` and `-xray-render-body [v opts]` methods. Plus safe accessors (`xray-render-header` / `xray-render-body`) that catch consumer exceptions so a broken third-party formatter cannot blank the inspector. Plus the `satisfies-xray-data-display?` predicate convenience.
- **`tools/xray/src/day8/re_frame2_xray/views/data_display.cljs`** — `render-node` consults the protocol at the head. If `(satisfies? IXrayDataDisplay v)` AND the consumer`s header is non-nil, the protocol path wins. Otherwise falls through to the built-in container / scalar dispatch unchanged. Three-state fall-through (no `satisfies?` / nil header / nil body) keeps consumers free to override just the visual aspects they want, and pins the same `[panel-id mount-id path]` `data-testid` shape so panel-level toggle / reset affordances address protocol nodes uniformly.
- **`tools/xray/spec/021-Dynamic-Panel-Designs.md` §10.0.6** — normative protocol description with a worked `Money` example. The §10.0.4 phased-rollout entry flips from "(optional)" to "(rf2-0qrcr)".
- **`tools/xray/test/day8/re_frame2_xray/views/data_display_protocol_cljs_test.cljs`** — seven property tests:
  1. Built-in types still render via the built-in dispatch (no protocol path leakage)
  2. Protocol-implementing types take the protocol path; consumer`s hiccup appears verbatim
  3. Header-nil falls through to built-ins
  4. Body-nil renders header-only (no body container, no toggle)
  5. Broken consumer impl (throws from header/body) falls through safely
  6. Expansion-map overrides still collapse protocol nodes (operator stays in control)
  7. `satisfies-xray-data-display?` predicate sanity

## Gates

- `clj-kondo --lint tools/xray/src tools/xray/test`: 0 errors, 0 new warnings on the changed surface
- `npm run test:cljs`: 4484 tests, 14287 assertions, 0 failures, 0 errors
- `npm run test:browser`: 124 tests, 346 assertions, 0 failures, 0 errors
- `npm run test:xray-feature-gate`: 13/13 scenarios, 0 failures

## Linked bead

rf2-0qrcr — phase 7 of rf2-oqa60.