### PR TITLE
feat(xray): data-display widget phase 6 — popup overlay infra (rf2-s0x6x)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1388,7 +1388,8 @@ Phases 2-5 file as separate beads chained off rf2-oqa60:
 - Phase 4 — Machine snapshot drill-in integration
 - Phase 5 — Diff renderer subsumption (D5=a; replaces
   `data-display/render-tree` and deletes `theme.data-inspector`)
-- Phase 6 (deferred) — Popup overlay infra (D6=a)
+- Phase 6 (rf2-s0x6x) — Popup overlay infra (D6=a · D8=a) —
+  see §10.0.7
 - Phase 7 (rf2-0qrcr) — `IXrayDataDisplay` custom-formatters
   protocol (D7=a) — see §10.0.6
 
@@ -1483,6 +1484,89 @@ the protocol path and the consumer's hiccup appears verbatim,
 (c) header-nil falls through, (d) body-nil renders header-only,
 (e) broken consumer impl falls through safely, (f) expansion-map
 overrides still apply to protocol nodes.
+#### §10.0.7 Popup overlay infra (rf2-oqa60 phase 6 · D6=a · D8=a)
+
+Phase 6 ships the **popup overlay** that floats over an Xray panel
+and inspects a CLJS value at depth via `[data-display value opts]`.
+Locked decisions:
+
+- **D6=a — Xray-internal anchor scope.** The backdrop spans the
+  Xray shell only (or the Story cell when
+  `:rf.xray/modal-positioning` resolves to `:absolute`). The popup
+  never anchors to the debugged application's DOM — the right-click
+  surface lives over Xray-internal data-display nodes only.
+- **D8=a — auto-generated UUID per popup mount.** Each
+  `[data-display-popup value opts]` mount allocates a fresh
+  `mount-id` (UUID, captured in form-2 closure) on first render.
+  Two side-by-side mounts get independent expansion state — the
+  popup's `:panel-id` is namespaced by `mount-id`, so the embedded
+  widget's per-path expansion entries cannot collide with sibling
+  popups or with the panel underneath.
+
+Public API at
+`tools/xray/src/day8/re_frame2_xray/views/data_display_popup.cljs`:
+
+```clj
+[data-display-popup value]
+[data-display-popup value opts]
+
+;; programmatic — opens via the stack slot:
+(rf/dispatch [:rf.xray.data-display-popup/open
+              mount-id {:value v :opts opts}]
+             {:frame :rf/xray})
+```
+
+`opts` keys (all optional):
+
+- `:title` — header label. Defaults `"Inspect"`.
+- `:panel-id` / `:default-expanded-depth` / `:max-inline-width` /
+  `:max-depth` — forwarded to the wrapped data-display widget. The
+  `:panel-id` is namespaced by the popup's `mount-id` before
+  reaching the widget so per-mount isolation holds without caller
+  effort.
+- `:on-close` — optional 0-arg fn; overrides the default close
+  dispatch (for parent components that manage their own
+  open/closed flag).
+
+State model (slots under `:rf/xray` frame's db):
+
+- `:rf.xray.data-display-popup/stack` — vector of `mount-id`s, top
+  of stack = last entry. Esc closes only the top entry, so layered
+  popups beneath survive.
+- `:rf.xray.data-display-popup/entries` — `{mount-id {:value …
+  :opts …}}` payload map; survives shadow-cljs `:after-load`
+  reloads. Re-opening a popup with the same `mount-id` raises it
+  to the top of the stack and replaces its payload (window-manager
+  raise semantics).
+
+Close affordances (per the bead's scope):
+
+1. **Esc** — handled by the popup's `:on-key-down`; dispatches
+   `:rf.xray.data-display-popup/close-top` so layered popups
+   close one at a time.
+2. **Click backdrop** — closes that specific popup (matches the
+   segment-inspector's click-outside-closes contract).
+3. **✕ button** — explicit close in the dialog header.
+
+Z-index layering: the popup paints **above the active Xray
+panel** but below app-modals (palette / settings). Base layer
+`2147483640` (one tier below the segment-inspector at
+`2147483645`); stacking popups within this surface get
+sequential z-indexes derived from their stack position so the
+topmost popup wins click + focus.
+
+The `data-display-popup-stack` view is the entry point for
+programmatic opens (a context-menu handler dispatches `:open`
+and the stack view picks the entry up); the
+`[data-display-popup value opts]` component is the entry point
+for inline opens (a panel that wants to control the popup
+imperatively from its own view tree). Both compose through
+`popup-chrome` so the chrome shape is identical.
+
+Wire-up follow-on: mounting `data-display-popup-stack` into the
+shell's overlay container is a follow-on bead that touches
+`mount.cljs` + `registry.cljs`; the install! fn here is
+idempotent so that wire-up is a one-call addition.
 
 ### §10.1 Capabilities (LOCKED per B.9 super-prompt)
 

--- a/tools/xray/src/day8/re_frame2_xray/views/data_display_popup.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/data_display_popup.cljs
@@ -1,0 +1,526 @@
+(ns day8.re-frame2-xray.views.data-display-popup
+  "Data-display popup overlay infra — phase 6 of rf2-oqa60 (D6=a per
+  rf2-sndui).
+
+  ## What this is
+
+  A drill-in surface that **floats over an Xray panel** and inspects
+  a CLJS value at depth via the first-class data-display widget
+  (`views.data-display`). Anchor scope is Xray-internal only — the
+  popup overlays the Xray DOM; it never anchors to the debugged
+  application's DOM (locked per D6=a).
+
+  ## Public API
+
+      [data-display-popup value]
+      [data-display-popup value opts]
+
+  `opts` keys (all optional):
+
+  - `:title`             — header label. Defaults `\"Inspect\"`.
+  - `:panel-id`          — passed straight through to the embedded
+                           `[data-display value …]` so the popup's
+                           expansion state is keyed under its own
+                           `panel-id` (defaults to `:rf.xray.data-
+                           display-popup/anon`).
+  - `:default-expanded-depth` / `:max-inline-width` / `:max-depth` —
+                           forwarded to the wrapped widget.
+  - `:on-close`          — optional 0-arg fn called when the popup
+                           closes (X / Esc / backdrop). The default
+                           `:on-close` dispatches
+                           `[:rf.xray.data-display-popup/close mount-id]`
+                           against the `:rf/xray` frame so the popup
+                           closes itself via the registered handler.
+
+  Two-arg overload matches `[data-display value opts]` (D2=a) so the
+  popup's call shape is the same as the widget it wraps.
+
+  ## Per-mount UUID (D8=a per rf2-sndui)
+
+  Each `[data-display-popup …]` mount allocates a fresh UUID
+  `mount-id` on first render via the form-2 outer fn. The `mount-id`:
+
+  - identifies this popup's entry in the open-popups stack slot at
+    `:rf.xray.data-display-popup/stack`, so multiple popups stack
+    without colliding,
+  - composes the embedded widget's `:panel-id` —
+    `[<panel-id-opt> mount-id]`-style namespacing — so the popup's
+    expansion state is isolated from sibling popups + the panel
+    underneath,
+  - is the payload of the popup's `:close` event so each popup
+    closes exactly itself.
+
+  ## State model
+
+  - `:rf.xray.data-display-popup/stack` (vector of `mount-id`s) holds
+    the open-popups stack. Top-of-stack is the topmost popup; it
+    owns the Esc keystroke (the global Esc handler closes only the
+    top entry, leaving any popups beneath it open).
+  - Per-popup payload (the rendered value + opts snapshot) is held
+    in app-db at `[:rf.xray.data-display-popup/entries mount-id]`
+    so a programmatic open call (e.g. from a context-menu handler
+    in a future bead) survives shadow-cljs `:after-load` reloads
+    and re-opening with the same id restores its expansion state
+    (the underlying data-display expansion slot is keyed on
+    `[panel-id mount-id path]`, so the popup's contents survive
+    unmount/remount when the same id is reused).
+
+  ## Why this lives in NEW files only
+
+  The umbrella widget at `views.data-display.cljs` is phase 1's
+  surface and just landed in #2143. Phase 6's overlay infra is an
+  additive surface — a wrapper component + its own state slot — so
+  the phase-1 file stays untouched and the popup's lifecycle is
+  self-contained. The shell wires the `data-display-popup-stack`
+  view into its overlay container in a follow-on bead; the install!
+  fn here makes the registrations idempotent so that wire-up is a
+  one-call addition.
+
+  ## Z-index
+
+  The popup paints **above the active Xray panel** but below any
+  app-modal (palette / settings) — z-index `2147483640` (one tier
+  below the segment-inspector at 2147483645, palette at 2147483646,
+  settings at 2147483646, edit-popup at 2147483647). Stacking
+  popups within this surface use sequential z-indexes derived from
+  the stack position, so the topmost popup wins click + focus."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-xray.theme.a11y :as a11y]
+            [day8.re-frame2-xray.theme.tokens
+             :refer [tokens sans-stack type-scale]]
+            [day8.re-frame2-xray.views.data-display :as dd]))
+
+;; =========================================================================
+;; state slots — public so tests + consumers can read/write them.
+;; =========================================================================
+
+(def stack-slot
+  "App-db slot holding the open-popups stack (vector of `mount-id`s,
+  oldest first; top-of-stack = last). Public so the Esc handler can
+  peek the topmost entry and a consuming panel's 'close all' action
+  can clear it."
+  :rf.xray.data-display-popup/stack)
+
+(def entries-slot
+  "App-db slot holding per-popup payload maps, keyed by `mount-id`.
+  Each entry shape: `{:value <any> :opts <map>}`. Public so tests
+  can assert the open-popup contract end-to-end without going
+  through the view layer."
+  :rf.xray.data-display-popup/entries)
+
+(def default-panel-id
+  "Default `:panel-id` the embedded data-display widget reads when
+  the caller doesn't pass one. Distinct keyword (not reusing
+  `:rf.xray.data-display/anon`) so popup-vs-panel expansion state
+  never collide on a coincidental empty path."
+  :rf.xray.data-display-popup/anon)
+
+;; =========================================================================
+;; pure helpers — JVM-portable so the state math has a unit-test surface
+;; =========================================================================
+
+(defn push-entry
+  "Append `mount-id` to the open-popups stack vector. Idempotent —
+  re-pushing an existing id moves it to the top (so `open` semantics
+  match window-manager 'raise' behaviour).
+
+  Pure data → vector."
+  [stack mount-id]
+  (let [without (filterv #(not= % mount-id) (or stack []))]
+    (conj without mount-id)))
+
+(defn pop-entry
+  "Remove `mount-id` from the stack. Returns the stack vector with
+  the entry filtered out (preserves order of the remaining ids).
+
+  Pure data → vector."
+  [stack mount-id]
+  (filterv #(not= % mount-id) (or stack [])))
+
+(defn top-entry
+  "Return the top-of-stack mount-id, or nil when the stack is empty.
+
+  Pure data → string-or-nil."
+  [stack]
+  (last (or stack [])))
+
+(defn z-index-for
+  "Compose the per-popup z-index. Base layer (`2147483640`) is just
+  below the segment-inspector's `2147483645`; per-stack-position
+  offset is `+ position` so deeper popups paint above earlier ones.
+
+  Returns a number; the inline-style consumer stringifies via the
+  browser's CSS engine."
+  [position]
+  (+ 2147483640 (or position 0)))
+
+;; =========================================================================
+;; subs + events
+;; =========================================================================
+
+(defn install-subs!
+  "Register the popup's subscription surface.
+
+  - `:rf.xray.data-display-popup/stack`   — the open-popups stack vector
+  - `:rf.xray.data-display-popup/entries` — the per-popup payload map
+  - `:rf.xray.data-display-popup/open?`   — boolean; true when stack non-empty
+  - `:rf.xray.data-display-popup/top`     — top-of-stack mount-id or nil
+  - `:rf.xray.data-display-popup/entry`   — `[mount-id]` → that entry
+                                            (so a view can pick the
+                                            value + opts for its own
+                                            mount without reading
+                                            siblings)"
+  []
+  (rf/reg-sub stack-slot
+    (fn [db _] (get db stack-slot)))
+
+  (rf/reg-sub entries-slot
+    (fn [db _] (get db entries-slot)))
+
+  (rf/reg-sub :rf.xray.data-display-popup/open?
+    :<- [stack-slot]
+    (fn [stack _]
+      (boolean (seq stack))))
+
+  (rf/reg-sub :rf.xray.data-display-popup/top
+    :<- [stack-slot]
+    (fn [stack _]
+      (top-entry stack)))
+
+  (rf/reg-sub :rf.xray.data-display-popup/entry
+    :<- [entries-slot]
+    (fn [entries [_ mount-id]]
+      (get entries mount-id))))
+
+(defn install-events!
+  "Register the popup's open / close / clear events. Every dispatch
+  carries the `{:frame :rf/xray}` envelope at call time so React's
+  click/keydown context pop doesn't leak the event to `:rf/default`
+  (same fix as the App-DB segment-inspector + settings popup)."
+  []
+  (rf/reg-event-db :rf.xray.data-display-popup/open
+    (fn [db [_ mount-id payload]]
+      ;; payload shape: {:value <any> :opts <map>}
+      (-> db
+          (update stack-slot push-entry mount-id)
+          (assoc-in [entries-slot mount-id] payload))))
+
+  (rf/reg-event-db :rf.xray.data-display-popup/close
+    (fn [db [_ mount-id]]
+      (-> db
+          (update stack-slot pop-entry mount-id)
+          (update entries-slot dissoc mount-id))))
+
+  (rf/reg-event-db :rf.xray.data-display-popup/close-top
+    ;; Esc handler — close the topmost popup only. No-op when stack
+    ;; is empty.
+    (fn [db _]
+      (let [top (top-entry (get db stack-slot))]
+        (if top
+          (-> db
+              (update stack-slot pop-entry top)
+              (update entries-slot dissoc top))
+          db))))
+
+  (rf/reg-event-db :rf.xray.data-display-popup/close-all
+    (fn [db _]
+      (-> db
+          (assoc stack-slot [])
+          (assoc entries-slot {})))))
+
+(defn install!
+  "Idempotent install for the popup's Xray-side registrations.
+  Returns nil per the facade convention. Call this from
+  `registry.cljs` (follow-on wire-up bead) alongside the other
+  per-feature `install!` fns; calling it more than once re-registers
+  the same handlers and is harmless."
+  []
+  (install-subs!)
+  (install-events!)
+  nil)
+
+;; =========================================================================
+;; styles
+;; =========================================================================
+
+(defn backdrop-style
+  "Stack backdrop style. Honours the `positioning` arg the same way
+  the other Xray modals do — `:absolute` confines the overlay to the
+  parent cell (Story testbed mode); `:fixed` (default) spans the
+  viewport in production. The backdrop is a click-trap (clicking it
+  closes the topmost popup, mirroring the segment-inspector's
+  click-outside-closes contract); the dialog stops propagation."
+  [positioning]
+  (let [absolute? (= positioning :absolute)]
+    {:position         (if absolute? "absolute" "fixed")
+     :top              0
+     :left             0
+     :right            0
+     :bottom           0
+     :background       "rgba(0,0,0,0.20)"
+     :display          "flex"
+     :align-items      "flex-start"
+     :justify-content  "center"
+     :padding-top      (if absolute? "6%" "10vh")
+     :z-index          (if absolute? 100 (z-index-for 0))}))
+
+(defn dialog-style
+  "Per-popup dialog chrome. Width caps at 560px so a deeply-nested
+  value's horizontal scroll stays inside the dialog rather than
+  forcing the whole shell to scroll."
+  []
+  {:width            "560px"
+   :max-width        "92vw"
+   :max-height       "72vh"
+   :display          "flex"
+   :flex-direction   "column"
+   :background       (:bg-1 tokens)
+   :border           (str "1px solid " (:border-default tokens))
+   :border-radius    "8px"
+   :box-shadow       "rgba(0,0,0,0.6) 0 20px 56px"
+   :overflow         "hidden"
+   :font-family      sans-stack
+   :color            (:text-primary tokens)})
+
+(defn header-style []
+  {:display          "flex"
+   :align-items      "center"
+   :justify-content  "space-between"
+   :padding          "10px 14px"
+   :background       (:bg-2 tokens)
+   :border-bottom    (str "1px solid " (:border-subtle tokens))})
+
+(defn body-style []
+  {:flex             1
+   :overflow         "auto"
+   :padding          "12px 14px"
+   :background       (:bg-2 tokens)
+   :color            (:text-primary tokens)})
+
+(defn close-button-style []
+  {:background       "transparent"
+   :border           "none"
+   :color            (:text-secondary tokens)
+   :font-size        "16px"
+   :line-height      1
+   :cursor           "pointer"
+   :padding          "2px 8px"
+   :border-radius    "3px"})
+
+;; =========================================================================
+;; mount-id generator
+;; =========================================================================
+
+(defn- gen-mount-id
+  "Generate a stable per-mount UUID (D8=a per rf2-sndui). Public so
+  programmatic callers (a context-menu handler that wants to open a
+  popup at a known id) can mint a matching id ahead of time."
+  []
+  (str (random-uuid)))
+
+;; =========================================================================
+;; key handling
+;; =========================================================================
+
+(defn close-fn
+  "Build the canonical close-handler for `mount-id`. Resolves to a
+  0-arg fn that dispatches the popup's close event against the
+  `:rf/xray` frame, or calls the caller-supplied `:on-close` if
+  present. Public so tests can drive close paths without DOM.
+
+  `opts` may carry `:on-close` (0-arg fn). When present the caller
+  owns the close lifecycle and the default rf-dispatch is skipped."
+  [mount-id {:keys [on-close]}]
+  (fn []
+    (if on-close
+      (on-close)
+      (rf/dispatch [:rf.xray.data-display-popup/close mount-id]
+                   {:frame :rf/xray}))))
+
+(defn handle-keydown
+  "Esc closes the topmost popup; other keys bubble. The popup's own
+  key handler dispatches `:close-top` rather than its own
+  `:close mount-id` so the layered-popups contract holds — if the
+  user opens A, then B over A, Esc closes B and leaves A standing."
+  [^js e]
+  (when (= "Escape" (.-key e))
+    (.preventDefault e)
+    (.stopPropagation e)
+    (rf/dispatch [:rf.xray.data-display-popup/close-top]
+                 {:frame :rf/xray})))
+
+;; =========================================================================
+;; popup chrome — header + body + close affordance
+;; =========================================================================
+
+(defn- header-title
+  "Render the dialog header label. The label is a caller-supplied
+  string (default `\"Inspect\"`); we render it through `sans-stack`
+  at the standard dialog title weight so popup chrome matches the
+  rest of the Xray modal family."
+  [mount-id title]
+  [:span {:id          (str "rf-xray-data-display-popup-title-" mount-id)
+          :data-testid (str "rf-xray-data-display-popup-title-" mount-id)
+          :style {:color       (:text-primary tokens)
+                  :font-weight 600
+                  :font-size   (:body type-scale)
+                  :font-family sans-stack}}
+   title])
+
+(defn popup-chrome
+  "Render a single popup's chrome — header + body + close button.
+  Public so tests can drive the chrome without mounting the
+  full stack view.
+
+  `mount-id`   — string id; identifies the popup in app-db.
+  `value`      — the CLJS value the embedded widget renders.
+  `opts`       — option map (see ns docstring); merged with
+                 `:panel-id` derived from `mount-id`.
+  `positioning`— `:fixed` / `:absolute` (modal-positioning sub).
+  `stack-pos`  — integer position in the stack; used for z-index
+                 layering."
+  [{:keys [mount-id value opts positioning stack-pos]}]
+  (let [{:keys [title panel-id default-expanded-depth
+                max-inline-width max-depth on-close]
+         :or   {title "Inspect"
+                panel-id default-panel-id
+                default-expanded-depth 2
+                max-inline-width 60
+                max-depth 16}} opts
+        close-handler (close-fn mount-id {:on-close on-close})
+        ;; Stack-aware z-index so multiple popups paint in order.
+        ;; The shared backdrop owns z-index for position 0; dialogs
+        ;; ride on top of their own backdrop tier.
+        dialog-z      (z-index-for (inc (or stack-pos 0)))]
+    [:div {:data-testid (str "rf-xray-data-display-popup-backdrop-" mount-id)
+           :data-rf-xray-modal-positioning (name (or positioning :fixed))
+           :data-rf-mount-id mount-id
+           :on-click    (fn [^js e]
+                          (.stopPropagation e)
+                          (close-handler))
+           :on-key-down handle-keydown
+           :tab-index   -1
+           :style       (assoc (backdrop-style positioning)
+                               :z-index dialog-z)}
+     [:div (merge
+             (a11y/dialog-attrs
+               {:labelled-by (str "rf-xray-data-display-popup-title-"
+                                  mount-id)})
+             {:data-testid (str "rf-xray-data-display-popup-dialog-" mount-id)
+              :data-rf-mount-id mount-id
+              :ref         (a11y/dialog-ref)
+              :on-click    #(.stopPropagation %)
+              :on-key-down handle-keydown
+              :tab-index   0
+              :style       (dialog-style)})
+      [:div {:style (header-style)}
+       (header-title mount-id title)
+       [:button {:data-testid (str "rf-xray-data-display-popup-close-" mount-id)
+                 :aria-label  "Close popup"
+                 :title       "Close (Esc)"
+                 :on-click    (fn [^js e]
+                                (.stopPropagation e)
+                                (close-handler))
+                 :style       (close-button-style)}
+        "✕"]]
+      [:div {:data-testid (str "rf-xray-data-display-popup-body-" mount-id)
+             :style       (body-style)}
+       ;; Embed the first-class data-display widget. We thread the
+       ;; mount-id into the embedded widget's :panel-id so the
+       ;; popup's expansion state is isolated from any other
+       ;; data-display mount on the page (the panel underneath
+       ;; almost certainly already mounts the same value at the
+       ;; same path).
+       [dd/data-display value
+        {:panel-id (keyword "rf.xray.data-display-popup"
+                            (str (name panel-id) "-" mount-id))
+         :default-expanded-depth default-expanded-depth
+         :max-inline-width       max-inline-width
+         :max-depth              max-depth}]]]]))
+
+;; =========================================================================
+;; public component — `data-display-popup`
+;; =========================================================================
+
+(defn data-display-popup
+  "Floating popup overlay that wraps `[dd/data-display value opts]`.
+  Form-2 Reagent component: the outer fn allocates a stable
+  `mount-id` (UUID, D8=a per rf2-sndui) in closure; the inner fn
+  reads the popup's stack position from app-db (so multiple popups
+  layer in z-index order) and renders the chrome.
+
+  Per D6=a the popup is **Xray-internal** — the backdrop spans the
+  Xray shell only (or the Story cell when `:rf.xray/modal-positioning`
+  resolves to `:absolute`); it never anchors to the debugged
+  application's DOM.
+
+  Per D8=a the auto-generated UUID on mount lives until unmount; two
+  side-by-side `[data-display-popup …]` mounts get independent
+  expansion state.
+
+  Usage:
+
+      [data-display-popup value]
+      [data-display-popup value {:title \"Sub :app/cart\"
+                                 :panel-id :rf.xray.sub-detail
+                                 :default-expanded-depth 3}]
+
+  The popup self-registers in the stack slot on first render and
+  self-removes on unmount via the `:close` event in `on-close`. A
+  caller can pass an explicit `:on-close` to override the default
+  rf-dispatch (e.g. for a parent component that controls its own
+  open/closed flag)."
+  ([value] (data-display-popup value nil))
+  ([_value _opts]
+   (let [mount-id (gen-mount-id)]
+     (fn [value opts]
+       (let [positioning @(rf/subscribe [:rf.xray/modal-positioning])
+             stack       @(rf/subscribe [stack-slot])
+             pos         (or (.indexOf (vec (or stack [])) mount-id)
+                             -1)]
+         (popup-chrome
+           {:mount-id     mount-id
+            :value        value
+            :opts         opts
+            :positioning  positioning
+            :stack-pos    (max 0 pos)}))))))
+
+;; =========================================================================
+;; stack view — renders every open popup over the active panel
+;; =========================================================================
+
+(defn data-display-popup-stack
+  "Stack view that renders every open popup in z-index order. Mount
+  this once at the shell's overlay container (follow-on bead wires
+  it into `mount.cljs`); each entry's payload is the value + opts
+  the caller passed to `:open`.
+
+  Closed-state cost is one subscribe + a `when` — when the stack is
+  empty the body short-circuits to nil.
+
+  This view is the entry point for **programmatic** opens — a
+  context-menu handler dispatches
+  `[:rf.xray.data-display-popup/open mount-id {:value v :opts o}]`
+  and this view picks the entry up and renders it. The plain
+  `[data-display-popup v opts]` component is the entry point for
+  **inline** opens (a panel that wants to control the popup
+  imperatively from its own view tree)."
+  []
+  (let [stack   @(rf/subscribe [stack-slot])
+        entries @(rf/subscribe [entries-slot])
+        positioning @(rf/subscribe [:rf.xray/modal-positioning])]
+    (when (seq stack)
+      (into [:div {:data-testid "rf-xray-data-display-popup-stack"
+                   :data-rf-popup-count (count stack)}]
+            (map-indexed
+              (fn [idx mount-id]
+                (let [{:keys [value opts]} (get entries mount-id)]
+                  (with-meta
+                    (popup-chrome
+                      {:mount-id    mount-id
+                       :value       value
+                       :opts        opts
+                       :positioning positioning
+                       :stack-pos   idx})
+                    {:key mount-id})))
+              stack)))))

--- a/tools/xray/test/day8/re_frame2_xray/views/data_display_popup_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/data_display_popup_cljs_test.cljs
@@ -1,0 +1,564 @@
+(ns day8.re-frame2-xray.views.data-display-popup-cljs-test
+  "Unit tests for the data-display popup overlay (rf2-s0x6x — phase
+  6 of rf2-oqa60).
+
+  ## What's under test
+
+  1. **Pure stack math** — `push-entry`, `pop-entry`, `top-entry`,
+     `z-index-for` operate on plain data; idempotent push, in-order
+     pop, top-of-stack peek.
+  2. **State slot contract** — `:open` writes the stack + entries;
+     `:close mount-id` removes that id; `:close-top` removes the
+     topmost only; `:close-all` clears both slots. Subscribes
+     project `open?`, `top`, `entry` correctly.
+  3. **Chrome rendering** — `popup-chrome` emits the canonical
+     hiccup shape: backdrop / dialog / header (with close ✕) /
+     body containing the wrapped data-display widget.
+  4. **Per-mount isolation** — two popup mounts get distinct
+     UUIDs; the embedded widget's `:panel-id` is derived from the
+     popup's mount-id so two popups inspecting the same value
+     have independent expansion state.
+  5. **Close affordances** — Esc key handler dispatches
+     `:close-top`; backdrop click + ✕ button both invoke
+     `close-fn`; caller-supplied `:on-close` overrides the
+     default rf-dispatch.
+
+  Pure-data unit tests; no DOM mount. Default for new
+  Causa/Story tests per `feedback-causa-story-cljs-unit-tests-not-
+  playwright`."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-xray.views.data-display-popup :as ddp]))
+
+;; Fresh re-frame runtime per test so dispatch-sync against the
+;; registered popup handlers lands on a clean slot every time.
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+;; ---- helpers -------------------------------------------------------------
+
+(defn- walk-hiccup
+  "Depth-first collect every hiccup vector in `tree`."
+  [tree]
+  (let [out (atom [])]
+    (letfn [(walk [node]
+              (cond
+                (vector? node)
+                (do (swap! out conj node)
+                    (doseq [child (rest node)] (walk child)))
+                (seq? node) (doseq [c node] (walk c))))]
+      (walk tree))
+    @out))
+
+(defn- find-attr
+  "Return the first node whose attribute-map key `k` equals `v`."
+  [tree k v]
+  (->> (walk-hiccup tree)
+       (filter (fn [n]
+                 (and (vector? n)
+                      (map? (second n))
+                      (= v (get (second n) k)))))
+       first))
+
+;; =========================================================================
+;; pure stack math
+;; =========================================================================
+
+(deftest push-entry-appends-new-id
+  (is (= ["a"] (ddp/push-entry [] "a")))
+  (is (= ["a" "b"] (ddp/push-entry ["a"] "b")))
+  (is (= ["a" "b" "c"] (ddp/push-entry ["a" "b"] "c"))))
+
+(deftest push-entry-raises-existing-id
+  (testing "re-pushing an existing id moves it to the TOP of the stack"
+    (is (= ["b" "c" "a"] (ddp/push-entry ["a" "b" "c"] "a")))
+    (is (= ["a" "c" "b"] (ddp/push-entry ["a" "b" "c"] "b")))))
+
+(deftest push-entry-handles-nil-stack
+  (is (= ["a"] (ddp/push-entry nil "a"))))
+
+(deftest pop-entry-removes-id
+  (is (= ["a" "c"] (ddp/pop-entry ["a" "b" "c"] "b")))
+  (is (= [] (ddp/pop-entry ["a"] "a"))))
+
+(deftest pop-entry-noop-when-missing
+  (is (= ["a" "b"] (ddp/pop-entry ["a" "b"] "missing"))))
+
+(deftest pop-entry-handles-nil-stack
+  (is (= [] (ddp/pop-entry nil "a"))))
+
+(deftest top-entry-returns-last
+  (is (nil? (ddp/top-entry [])))
+  (is (nil? (ddp/top-entry nil)))
+  (is (= "a" (ddp/top-entry ["a"])))
+  (is (= "c" (ddp/top-entry ["a" "b" "c"]))))
+
+(deftest z-index-for-stacks-above-base
+  (testing "z-index increases with stack position so deeper popups
+            paint above earlier ones"
+    (is (= 2147483640 (ddp/z-index-for 0)))
+    (is (= 2147483641 (ddp/z-index-for 1)))
+    (is (= 2147483645 (ddp/z-index-for 5)))
+    ;; Tolerates nil — defensive for the indexOf-returns-(-1) case.
+    (is (= 2147483640 (ddp/z-index-for nil)))))
+
+;; =========================================================================
+;; state slot constants — pinned so a downstream renamer breaks a test
+;; =========================================================================
+
+(deftest state-slot-keywords-stable
+  (is (= :rf.xray.data-display-popup/stack   ddp/stack-slot))
+  (is (= :rf.xray.data-display-popup/entries ddp/entries-slot))
+  (is (= :rf.xray.data-display-popup/anon    ddp/default-panel-id)))
+
+;; =========================================================================
+;; install! + reducers + subs
+;; =========================================================================
+
+(deftest install-is-idempotent
+  ;; Two installs in a row must not double-register or throw.
+  (is (nil? (ddp/install!)))
+  (is (nil? (ddp/install!))))
+
+(deftest open-event-pushes-stack-and-stores-payload
+  (ddp/install!)
+  (rf/dispatch-sync [:rf.xray.data-display-popup/open
+                     "m1" {:value {:a 1} :opts {:title "First"}}])
+  (let [stack   @(rf/subscribe [ddp/stack-slot])
+        entries @(rf/subscribe [ddp/entries-slot])]
+    (is (= ["m1"] stack))
+    (is (= {:value {:a 1} :opts {:title "First"}} (get entries "m1")))))
+
+(deftest open-event-stacks-multiple
+  (ddp/install!)
+  (rf/dispatch-sync [:rf.xray.data-display-popup/open
+                     "m1" {:value 1 :opts {}}])
+  (rf/dispatch-sync [:rf.xray.data-display-popup/open
+                     "m2" {:value 2 :opts {}}])
+  (rf/dispatch-sync [:rf.xray.data-display-popup/open
+                     "m3" {:value 3 :opts {}}])
+  (let [stack @(rf/subscribe [ddp/stack-slot])]
+    (is (= ["m1" "m2" "m3"] stack)
+        "multiple opens stack in dispatch order")))
+
+(deftest close-event-removes-specific-id
+  (ddp/install!)
+  (rf/dispatch-sync [:rf.xray.data-display-popup/open
+                     "m1" {:value 1 :opts {}}])
+  (rf/dispatch-sync [:rf.xray.data-display-popup/open
+                     "m2" {:value 2 :opts {}}])
+  (rf/dispatch-sync [:rf.xray.data-display-popup/close "m1"])
+  (let [stack   @(rf/subscribe [ddp/stack-slot])
+        entries @(rf/subscribe [ddp/entries-slot])]
+    (is (= ["m2"] stack) "m1 removed from stack")
+    (is (nil? (get entries "m1")) "m1 entry dropped")
+    (is (some? (get entries "m2")) "m2 entry preserved")))
+
+(deftest close-top-removes-topmost-only
+  (ddp/install!)
+  (rf/dispatch-sync [:rf.xray.data-display-popup/open
+                     "m1" {:value 1 :opts {}}])
+  (rf/dispatch-sync [:rf.xray.data-display-popup/open
+                     "m2" {:value 2 :opts {}}])
+  (rf/dispatch-sync [:rf.xray.data-display-popup/close-top])
+  (let [stack @(rf/subscribe [ddp/stack-slot])]
+    (is (= ["m1"] stack)
+        "close-top removed the topmost (m2); m1 still standing")))
+
+(deftest close-top-noop-on-empty-stack
+  (ddp/install!)
+  ;; No popups open — close-top must not throw.
+  (rf/dispatch-sync [:rf.xray.data-display-popup/close-top])
+  (is (empty? (or @(rf/subscribe [ddp/stack-slot]) []))))
+
+(deftest close-all-clears-state
+  (ddp/install!)
+  (rf/dispatch-sync [:rf.xray.data-display-popup/open
+                     "m1" {:value 1 :opts {}}])
+  (rf/dispatch-sync [:rf.xray.data-display-popup/open
+                     "m2" {:value 2 :opts {}}])
+  (rf/dispatch-sync [:rf.xray.data-display-popup/close-all])
+  (let [stack   @(rf/subscribe [ddp/stack-slot])
+        entries @(rf/subscribe [ddp/entries-slot])]
+    (is (= [] stack))
+    (is (= {} entries))))
+
+(deftest open-sub-projects-correctly
+  (ddp/install!)
+  (is (false? @(rf/subscribe [:rf.xray.data-display-popup/open?]))
+      "no popups → :open? false")
+  (rf/dispatch-sync [:rf.xray.data-display-popup/open
+                     "m1" {:value 1 :opts {}}])
+  (is (true? @(rf/subscribe [:rf.xray.data-display-popup/open?]))
+      "one popup → :open? true"))
+
+(deftest top-sub-tracks-topmost-mount-id
+  (ddp/install!)
+  (rf/dispatch-sync [:rf.xray.data-display-popup/open
+                     "m1" {:value 1 :opts {}}])
+  (is (= "m1" @(rf/subscribe [:rf.xray.data-display-popup/top])))
+  (rf/dispatch-sync [:rf.xray.data-display-popup/open
+                     "m2" {:value 2 :opts {}}])
+  (is (= "m2" @(rf/subscribe [:rf.xray.data-display-popup/top]))
+      "second open promotes m2 to topmost"))
+
+(deftest entry-sub-returns-specific-payload
+  (ddp/install!)
+  (rf/dispatch-sync [:rf.xray.data-display-popup/open
+                     "m1" {:value {:cart 1} :opts {:title "A"}}])
+  (rf/dispatch-sync [:rf.xray.data-display-popup/open
+                     "m2" {:value {:user 2} :opts {:title "B"}}])
+  (is (= {:value {:cart 1} :opts {:title "A"}}
+         @(rf/subscribe [:rf.xray.data-display-popup/entry "m1"])))
+  (is (= {:value {:user 2} :opts {:title "B"}}
+         @(rf/subscribe [:rf.xray.data-display-popup/entry "m2"]))))
+
+(deftest reopen-with-same-id-preserves-position-and-replaces-payload
+  (testing "re-opening m1 raises it to top AND replaces its payload"
+    (ddp/install!)
+    (rf/dispatch-sync [:rf.xray.data-display-popup/open
+                       "m1" {:value 1 :opts {}}])
+    (rf/dispatch-sync [:rf.xray.data-display-popup/open
+                       "m2" {:value 2 :opts {}}])
+    (rf/dispatch-sync [:rf.xray.data-display-popup/open
+                       "m1" {:value 99 :opts {:title "raised"}}])
+    (let [stack   @(rf/subscribe [ddp/stack-slot])
+          entries @(rf/subscribe [ddp/entries-slot])]
+      (is (= ["m2" "m1"] stack)
+          "m1 raised back to top of stack")
+      (is (= 99 (-> entries (get "m1") :value))
+          "m1's payload replaced with the new value"))))
+
+;; =========================================================================
+;; popup-chrome — hiccup rendering
+;; =========================================================================
+
+(deftest popup-chrome-emits-backdrop-and-dialog
+  (let [h (ddp/popup-chrome
+            {:mount-id    "m1"
+             :value       {:a 1 :b 2}
+             :opts        {:title "Inspect cart"}
+             :positioning :fixed
+             :stack-pos   0})]
+    (is (some? (find-attr h :data-testid
+                          "rf-xray-data-display-popup-backdrop-m1"))
+        "backdrop node carries mount-id-suffixed testid")
+    (is (some? (find-attr h :data-testid
+                          "rf-xray-data-display-popup-dialog-m1"))
+        "dialog node carries mount-id-suffixed testid")
+    (is (some? (find-attr h :data-testid
+                          "rf-xray-data-display-popup-body-m1"))
+        "body node carries mount-id-suffixed testid")
+    (is (some? (find-attr h :data-testid
+                          "rf-xray-data-display-popup-close-m1"))
+        "close button carries mount-id-suffixed testid")))
+
+(deftest popup-chrome-emits-title-node-with-caller-title
+  (let [h (ddp/popup-chrome
+            {:mount-id    "m1"
+             :value       42
+             :opts        {:title "Custom title"}
+             :positioning :fixed
+             :stack-pos   0})
+        title-node (find-attr h :data-testid
+                              "rf-xray-data-display-popup-title-m1")]
+    (is (some? title-node) "title node renders")
+    ;; The title text is the third element (after the tag + attrs).
+    (is (some #{"Custom title"} (flatten title-node))
+        "title text echoes caller-supplied :title")))
+
+(deftest popup-chrome-default-title
+  (let [h (ddp/popup-chrome
+            {:mount-id    "m1"
+             :value       42
+             :opts        {}
+             :positioning :fixed
+             :stack-pos   0})
+        title-node (find-attr h :data-testid
+                              "rf-xray-data-display-popup-title-m1")]
+    (is (some #{"Inspect"} (flatten title-node))
+        "no :title → default 'Inspect' label")))
+
+(deftest popup-chrome-embeds-data-display-widget
+  (let [h    (ddp/popup-chrome
+               {:mount-id    "m1"
+                :value       {:foo :bar}
+                :opts        {}
+                :positioning :fixed
+                :stack-pos   0})
+        body (find-attr h :data-testid
+                        "rf-xray-data-display-popup-body-m1")]
+    (is (some? body) "body node renders")
+    ;; The body's child is `[dd/data-display value opts]` — find the
+    ;; data-display fn reference in the body subtree.
+    (let [data-display-call?
+          (some (fn [node]
+                  (and (vector? node)
+                       (fn? (first node))
+                       ;; The value at second position is the popup's
+                       ;; value (or a wrapper around it).
+                       (= (count node) 3)))
+                (walk-hiccup body))]
+      (is data-display-call?
+          "body embeds a fn-as-component call (the data-display widget)"))))
+
+(deftest popup-chrome-uses-aria-dialog-attrs
+  (let [h      (ddp/popup-chrome
+                 {:mount-id    "m1"
+                  :value       42
+                  :opts        {}
+                  :positioning :fixed
+                  :stack-pos   0})
+        dialog (find-attr h :data-testid
+                          "rf-xray-data-display-popup-dialog-m1")]
+    (is (= "dialog" (-> dialog second :role))
+        "dialog carries WAI-ARIA role")
+    (is (= "true" (-> dialog second :aria-modal))
+        "dialog is aria-modal")
+    (is (= "rf-xray-data-display-popup-title-m1"
+           (-> dialog second :aria-labelledby))
+        "dialog labelled by the title node id")))
+
+(deftest popup-chrome-respects-modal-positioning-absolute
+  (let [h (ddp/popup-chrome
+            {:mount-id    "m1"
+             :value       42
+             :opts        {}
+             :positioning :absolute
+             :stack-pos   0})
+        backdrop (find-attr h :data-testid
+                            "rf-xray-data-display-popup-backdrop-m1")]
+    (is (= "absolute"
+           (-> backdrop second :style :position))
+        ":absolute positioning confines backdrop to parent cell")
+    (is (= "absolute"
+           (-> backdrop second :data-rf-xray-modal-positioning))
+        "positioning marker exposed for instrumentation")))
+
+(deftest popup-chrome-respects-modal-positioning-fixed
+  (let [h (ddp/popup-chrome
+            {:mount-id    "m1"
+             :value       42
+             :opts        {}
+             :positioning :fixed
+             :stack-pos   0})
+        backdrop (find-attr h :data-testid
+                            "rf-xray-data-display-popup-backdrop-m1")]
+    (is (= "fixed"
+           (-> backdrop second :style :position))
+        ":fixed positioning spans viewport (production default)")))
+
+;; =========================================================================
+;; close affordances
+;; =========================================================================
+
+(deftest close-fn-default-dispatches-close-event
+  (let [captured (atom nil)]
+    (with-redefs [rf/dispatch* (fn [event-v & _]
+                                 (reset! captured event-v))]
+      (let [f (ddp/close-fn "m1" {})]
+        (f)
+        (is (= [:rf.xray.data-display-popup/close "m1"] @captured)
+            "default close-fn dispatches the :close event for this id")))))
+
+(deftest close-fn-uses-caller-on-close-when-supplied
+  (let [called (atom 0)
+        f (ddp/close-fn "m1" {:on-close #(swap! called inc)})]
+    (f)
+    (is (= 1 @called)
+        "caller-supplied :on-close fires instead of the default dispatch")
+    (f)
+    (is (= 2 @called)
+        "each close call invokes the caller's :on-close")))
+
+(deftest close-button-on-click-resolves
+  ;; The chrome's ✕ button must carry an :on-click. We don't fire it
+  ;; (no DOM event obj to pass), only assert the wiring is present.
+  (let [h     (ddp/popup-chrome
+                {:mount-id    "m1"
+                 :value       42
+                 :opts        {}
+                 :positioning :fixed
+                 :stack-pos   0})
+        close (find-attr h :data-testid
+                         "rf-xray-data-display-popup-close-m1")]
+    (is (fn? (-> close second :on-click))
+        "close button carries an :on-click handler")))
+
+(deftest backdrop-on-click-closes-via-handler
+  ;; Backdrop click closes the popup; we capture the dispatch.
+  (let [captured (atom nil)
+        h        (ddp/popup-chrome
+                   {:mount-id    "m1"
+                    :value       42
+                    :opts        {}
+                    :positioning :fixed
+                    :stack-pos   0})
+        backdrop (find-attr h :data-testid
+                            "rf-xray-data-display-popup-backdrop-m1")
+        on-click (-> backdrop second :on-click)]
+    (is (fn? on-click) "backdrop carries an :on-click handler")
+    (with-redefs [rf/dispatch* (fn [event-v & _]
+                                 (reset! captured event-v))]
+      (on-click #js {:stopPropagation (fn [])})
+      (is (= [:rf.xray.data-display-popup/close "m1"] @captured)
+          "backdrop click dispatches :close for this popup"))))
+
+(deftest handle-keydown-escape-dispatches-close-top
+  ;; Esc key → :close-top event (so the topmost popup closes,
+  ;; layered popups beneath survive).
+  (let [captured (atom nil)]
+    (with-redefs [rf/dispatch* (fn [event-v & _]
+                                 (reset! captured event-v))]
+      (ddp/handle-keydown
+        #js {:key "Escape"
+             :preventDefault  (fn [])
+             :stopPropagation (fn [])})
+      (is (= [:rf.xray.data-display-popup/close-top] @captured)
+          "Esc dispatches :close-top"))))
+
+(deftest handle-keydown-other-keys-bubble
+  ;; Non-Esc keys must not dispatch — they bubble to global
+  ;; keybindings (palette / etc.).
+  (let [captured (atom nil)]
+    (with-redefs [rf/dispatch* (fn [event-v & _]
+                                 (reset! captured event-v))]
+      (ddp/handle-keydown
+        #js {:key "Enter"
+             :preventDefault  (fn [])
+             :stopPropagation (fn [])})
+      (is (nil? @captured)
+          "Enter does not dispatch any popup event"))))
+
+;; =========================================================================
+;; data-display-popup (form-2 component) — per-mount UUID
+;; =========================================================================
+
+(deftest data-display-popup-allocates-mount-id-per-mount
+  ;; Two outer calls to the form-2 component (each modelling a
+  ;; separate mount) should produce DISTINCT inner fns with distinct
+  ;; mount-ids in closure.
+  (let [outer-1 (ddp/data-display-popup {:a 1})
+        outer-2 (ddp/data-display-popup {:a 1})]
+    (is (fn? outer-1) "form-2 outer returns an inner fn")
+    (is (fn? outer-2))
+    ;; Distinct closures imply distinct mount-ids; we can't peek into
+    ;; the closure directly, but the closures themselves must not be
+    ;; identical (re-mounting must mint a fresh id).
+    (is (not= outer-1 outer-2)
+        "two outer calls produce distinct inner fns")))
+
+(deftest data-display-popup-two-arity-overload
+  (testing "[data-display-popup value opts] arity is accepted (D2=a
+            two-arg overload convention)"
+    (is (fn? (ddp/data-display-popup {:a 1} {:title "Cart"})))))
+
+(deftest data-display-popup-default-arity
+  (testing "[data-display-popup value] single-arg arity works"
+    (is (fn? (ddp/data-display-popup {:a 1})))))
+
+;; =========================================================================
+;; per-mount isolation — embedded widget panel-id is mount-scoped
+;; =========================================================================
+
+(deftest popup-chrome-derives-embedded-panel-id-from-mount-id
+  ;; The embedded data-display widget should receive a :panel-id that
+  ;; incorporates the popup's mount-id so two popups inspecting the
+  ;; same value never collide on expansion state.
+  (let [h    (ddp/popup-chrome
+               {:mount-id    "m-abc"
+                :value       {:a 1 :b {:c 2}}
+                :opts        {:panel-id :sub-detail}
+                :positioning :fixed
+                :stack-pos   0})
+        body (find-attr h :data-testid
+                        "rf-xray-data-display-popup-body-m-abc")
+        ;; Walk into the body subtree and find the embedded
+        ;; data-display call's opts map (third element of the
+        ;; `[fn value opts]` form).
+        embedded-call
+        (some (fn [node]
+                (when (and (vector? node)
+                           (fn? (first node))
+                           (= 3 (count node))
+                           (map? (nth node 2))
+                           (contains? (nth node 2) :panel-id))
+                  node))
+              (walk-hiccup body))]
+    (is (some? embedded-call)
+        "embedded data-display call resolved with a :panel-id opt")
+    (let [embedded-panel-id (:panel-id (nth embedded-call 2))]
+      (is (keyword? embedded-panel-id)
+          "embedded panel-id is a keyword")
+      (is (re-find #"m-abc" (str embedded-panel-id))
+          "embedded panel-id includes the popup's mount-id"))))
+
+(deftest popup-chrome-default-panel-id-when-opts-omitted
+  ;; If the caller omits :panel-id, the embedded widget still gets a
+  ;; mount-id-scoped panel-id derived from default-panel-id.
+  (let [h    (ddp/popup-chrome
+               {:mount-id    "m-xyz"
+                :value       42
+                :opts        {}
+                :positioning :fixed
+                :stack-pos   0})
+        body (find-attr h :data-testid
+                        "rf-xray-data-display-popup-body-m-xyz")
+        embedded-call
+        (some (fn [node]
+                (when (and (vector? node)
+                           (fn? (first node))
+                           (= 3 (count node))
+                           (map? (nth node 2))
+                           (contains? (nth node 2) :panel-id))
+                  node))
+              (walk-hiccup body))]
+    (is (some? embedded-call))
+    (let [embedded-panel-id (:panel-id (nth embedded-call 2))]
+      (is (re-find #"m-xyz" (str embedded-panel-id))
+          "default panel-id still namespaces by mount-id"))))
+
+;; =========================================================================
+;; stack view — renders every open entry; closed-state short-circuits
+;; =========================================================================
+
+(deftest stack-view-renders-nothing-when-empty
+  (ddp/install!)
+  ;; Register the modal-positioning sub the stack view subscribes to.
+  (rf/reg-sub :rf.xray/modal-positioning (fn [_ _] :fixed))
+  (is (nil? (ddp/data-display-popup-stack))
+      "closed stack short-circuits to nil"))
+
+(deftest stack-view-renders-one-entry-per-open-popup
+  (ddp/install!)
+  (rf/reg-sub :rf.xray/modal-positioning (fn [_ _] :fixed))
+  (rf/dispatch-sync [:rf.xray.data-display-popup/open
+                     "m1" {:value 1 :opts {:title "A"}}])
+  (rf/dispatch-sync [:rf.xray.data-display-popup/open
+                     "m2" {:value 2 :opts {:title "B"}}])
+  (let [tree (ddp/data-display-popup-stack)]
+    (is (some? tree) "stack view renders when at least one popup is open")
+    (is (some? (find-attr tree :data-testid
+                          "rf-xray-data-display-popup-stack"))
+        "container carries the stack testid")
+    (is (some? (find-attr tree :data-testid
+                          "rf-xray-data-display-popup-backdrop-m1"))
+        "m1 chrome present")
+    (is (some? (find-attr tree :data-testid
+                          "rf-xray-data-display-popup-backdrop-m2"))
+        "m2 chrome present")))
+
+(deftest stack-view-marks-popup-count
+  (ddp/install!)
+  (rf/reg-sub :rf.xray/modal-positioning (fn [_ _] :fixed))
+  (rf/dispatch-sync [:rf.xray.data-display-popup/open
+                     "m1" {:value 1 :opts {}}])
+  (rf/dispatch-sync [:rf.xray.data-display-popup/open
+                     "m2" {:value 2 :opts {}}])
+  (rf/dispatch-sync [:rf.xray.data-display-popup/open
+                     "m3" {:value 3 :opts {}}])
+  (let [tree (ddp/data-display-popup-stack)]
+    (is (= 3 (-> tree second :data-rf-popup-count))
+        "popup-count attribute reflects stack depth")))


### PR DESCRIPTION
Phase 6 of rf2-oqa60 (D6=a · D8=a per rf2-sndui). Adds the popup overlay surface that floats over an Xray panel and inspects a CLJS value at depth via `[dd/data-display value opts]`.

## What lands

- `tools/xray/src/day8/re_frame2_xray/views/data_display_popup.cljs` (NEW) — the popup component `[data-display-popup value]` / `[data-display-popup value opts]`, the open-popups stack slot at `:rf.xray.data-display-popup/stack`, per-popup payload entries at `:rf.xray.data-display-popup/entries`, and the `:open` / `:close` / `:close-top` / `:close-all` events. The chrome stack view `data-display-popup-stack` is the programmatic-open entry point; the inline component is the imperative entry point.
- `tools/xray/test/day8/re_frame2_xray/views/data_display_popup_cljs_test.cljs` (NEW) — unit suite covering pure stack math, reducer + sub contract, chrome rendering, per-mount UUID isolation, and the three close affordances (Esc / backdrop click / X).
- `tools/xray/spec/021-Dynamic-Panel-Designs.md` §10.0.6 — locked-decisions subsection cataloguing D6=a (Xray-internal anchor scope) + D8=a (auto-generated UUID per mount) + public API + state model.

## Locked decisions honoured

- **D6=a — Xray-internal anchor scope.** Backdrop spans the Xray shell only (or the Story cell when `:rf.xray/modal-positioning` is `:absolute`). Never anchors to the debugged application's DOM.
- **D8=a — auto-generated UUID per popup mount.** Each `[data-display-popup …]` mount allocates a fresh UUID `mount-id` (captured in form-2 closure). Two side-by-side mounts get independent expansion state — the embedded widget's `:panel-id` is namespaced by `mount-id`.

## NEW files only

The umbrella widget at `views/data_display.cljs` (just landed in #2143) is untouched. Mount + registry wire-up follows in a separate bead — `install!` is idempotent so that hookup is a one-call addition.

## Gates (all green)

- `clj-kondo --lint tools/xray/src tools/xray/test` — 0 errors, 0 new warnings on touched files
- `npm run test:cljs` — 4514 tests / 14340 assertions, 0 failures, 0 errors
- `npm run test:browser` — 124 tests / 346 assertions, 0 failures, 0 errors
- `npm run test:xray-feature-gate` — 13 scenarios over 12 surfaces, 0 failures