### PR TITLE
fix(skills): repoint retired 013-Trace-Bus link to 013-Trace-Consumer (rf2-13i3s)

### DIFF
--- a/skills/re-frame2-xray/references/panels.md
+++ b/skills/re-frame2-xray/references/panels.md
@@ -194,7 +194,7 @@ focus navigation.
 firing as expected?", "what order did these emit in?"
 
 Spec: [`021-Dynamic-Panel-Designs.md` §5](../../../tools/xray/spec/021-Dynamic-Panel-Designs.md)
-+ [`013-Trace-Bus.md`](../../../tools/xray/spec/013-Trace-Bus.md)
++ [`013-Trace-Consumer.md`](../../../tools/xray/spec/013-Trace-Consumer.md)
 + [`spec/009-Instrumentation.md`](../../../spec/009-Instrumentation.md);
 implementation at
 [`panels/trace.cljs`](../../../tools/xray/src/day8/re_frame2_xray/panels/trace.cljs).


### PR DESCRIPTION
## Context

`scripts/check_doc_slugs.py --verbose` was failing on `origin/main`
because `skills/re-frame2-xray/references/panels.md` linked to
`tools/xray/spec/013-Trace-Bus.md`, which was retired in commit
`ca715249f` (rf2-43koh). The spec was renamed to
`013-Trace-Consumer.md` because the trace contract is now described
from the consumer side.

## Change

One-line link repoint in the xray skill panels reference (line 197):
filename + link target both updated to `013-Trace-Consumer.md`.

## Gates

- `python scripts/check_doc_slugs.py --verbose` — clean (`no broken
  links.`)
- `python -m mkdocs build --strict` — exit 0; only pre-existing INFO
  messages unrelated to this change
- `python scripts/check_skill_redirect_anchors.py` — clean
- `python scripts/check_skill_mcp_drift.py` — clean

Closes rf2-13i3s.