### PR TITLE
refactor(adapters): macro-generate React-shared deftest forwarders (rf2-6hphn)

### DIFF
--- a/implementation/adapters/helix/test/re_frame/adapter/helix_react_shared_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_react_shared_cljs_test.cljs
@@ -10,17 +10,29 @@
   there is exactly one suite source. Parity sibling:
   `uix_react_shared_cljs_test.cljs`.
 
-  Coverage forwarded: dispose MUSTs 1–4 + best-effort poison tolerance
-  (G3), source-coord DOM stamping incl. the format-shape split (G2),
-  view-id tagging, frame-context-corrupted (G4), warn-once fire-once +
-  per-id (G5), and the write-after-destroy guard (rf2-sx77q); plus, per
-  rf2-p4736, the rest of the UIx/Helix twin clusters: render-time parity
-  (hot-reload re-register, anonymous render-key, wrap-view callable),
-  reg-event metadata-interceptor warnings, render-to-string + late-bind
-  chain wiring, the late-bind hook publication set + directory
-  cross-check, chained clear-warn-once-caches!, the routing pipeline,
-  the headless runtime slice, :rf.view/rendered, make-derived-value
-  per-arity + watch-baseline, and managed-HTTP.
+  Per rf2-6hphn the ~50 deftest forwarders previously hand-paired
+  between this file and `uix_react_shared_cljs_test.cljs` are now
+  generated from a single `test-specs` literal in
+  `re-frame.adapter.react-shared-suite-tests` (a `.clj` compile-time
+  macro ns, mirroring the conformance-fixtures pattern). Both entry
+  files reduce to: an adapter `:require`, a fixture, a `cfg` map, and
+  one macro call. Adding a new shared assertion no longer requires two
+  hand-copied edits — append `[name assert-name]` to `test-specs` and
+  both adapters pick it up on next compile.
+
+  Coverage forwarded (see `test-specs` in the macro ns for the
+  canonical, in-source list — grep-discoverable from there):
+  dispose MUSTs 1–4 + best-effort poison tolerance (G3), source-coord
+  DOM stamping incl. the format-shape split (G2), view-id tagging,
+  frame-context-corrupted (G4), warn-once fire-once + per-id (G5), the
+  write-after-destroy guard (rf2-sx77q); plus, per rf2-p4736, the rest
+  of the UIx/Helix twin clusters: render-time parity (hot-reload
+  re-register, anonymous render-key, wrap-view callable), reg-event
+  metadata-interceptor warnings, render-to-string + late-bind chain
+  wiring, the late-bind hook publication set + directory cross-check,
+  chained clear-warn-once-caches!, the routing pipeline, the headless
+  runtime slice, :rf.view/rendered, make-derived-value per-arity +
+  watch-baseline, managed-HTTP, and the cross-Spec headless subset.
 
   The async *current-frame*-across-dispatch contract (rf2-l5q3) is
   forwarded from a dedicated entry pair carrying a map-form fixture —
@@ -33,10 +45,13 @@
   node-vs-browser component-element parameterisation; tracked separately.
 
   ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
-  (:require [cljs.test :refer-macros [deftest use-fixtures]]
+  (:require [cljs.test :refer-macros [use-fixtures]]
             [re-frame.adapter.helix :as helix-adapter]
-            [re-frame.adapter.react-shared-suite :as suite]
-            [re-frame.test-support :as test-support]))
+            [re-frame.adapter.react-shared-suite]
+            [re-frame.test-support :as test-support])
+  (:require-macros
+   [re-frame.adapter.react-shared-suite-tests
+    :refer [define-react-shared-suite-tests!]]))
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture
@@ -52,126 +67,8 @@
    :set-emitter!     helix-adapter/set-hiccup-emitter!
    :render-to-string (:render-to-string helix-adapter/adapter)})
 
-;; ---- dispose lifecycle (Spec 006) -----------------------------------------
-
-(deftest dispose-clears-hiccup-emitter        (suite/assert-dispose-clears-hiccup-emitter cfg))
-(deftest dispose-clear-warn-idempotent        (suite/assert-clear-warn-idempotent-post-dispose cfg))
-(deftest dispose-post-delegation-throws       (suite/assert-post-dispose-delegation-throws cfg))
-(deftest dispose-idempotent-no-roots          (suite/assert-dispose-idempotent-no-roots cfg))
-(deftest dispose-clears-sub-caches            (suite/assert-dispose-clears-sub-caches cfg))
-(deftest dispose-walk-best-effort             (suite/assert-dispose-walk-best-effort cfg))
-
-;; ---- source-coord DOM stamping (Spec 006) ---------------------------------
-
-(deftest source-coord-annotates-dom-root      (suite/assert-source-coord-annotates-dom-root cfg))
-(deftest source-coord-merges-with-attrs       (suite/assert-source-coord-merges-with-attrs cfg))
-(deftest source-coord-user-supplied-wins      (suite/assert-source-coord-user-supplied-wins cfg))
-(deftest source-coord-fragment-exempt         (suite/assert-source-coord-fragment-exempt cfg))
-(deftest source-coord-format-shape            (suite/assert-source-coord-format-shape cfg))
-
-;; ---- view-id (data-rf-view) stamping (Spec 006) ---------------------------
-
-(deftest view-id-tags-dom-root                (suite/assert-view-id-tags-dom-root cfg))
-(deftest view-id-fragment-exempt              (suite/assert-view-id-fragment-exempt cfg))
-(deftest view-id-user-supplied-wins           (suite/assert-view-id-user-supplied-wins cfg))
-(deftest wrap-view-injects-explicit-coords    (suite/assert-wrap-view-injects-explicit-coords cfg))
-
-;; ---- frame-context corrupted (Spec 009) -----------------------------------
-
-(deftest frame-context-corrupted              (suite/assert-frame-context-corrupted cfg))
-
-;; ---- warn-once fires-once (Spec 006) --------------------------------------
-
-(deftest warn-once-fires-once                 (suite/assert-warn-once-fires-once cfg))
-(deftest warn-once-per-id-not-global          (suite/assert-warn-once-per-id-not-global cfg))
-
-;; ---- write-after-destroy guard (rf2-ft2b) ---------------------------------
-
-(deftest write-after-destroy-guard            (suite/assert-write-after-destroy-guard cfg))
-
-;; ---- render-time parity (rf2-v1y7 / *_parity) -----------------------------
-
-(deftest parity-view-re-register-rerender     (suite/assert-view-re-register-causes-rerender cfg))
-(deftest parity-current-render-key-anon        (suite/assert-current-render-key-anonymous-fallback cfg))
-(deftest parity-wrap-view-callable             (suite/assert-wrap-view-callable-dispatches-to-user-fn cfg))
-
-;; ---- reg-event metadata-interceptor warnings (rf2-bbea / *_events) --------
-
-(deftest events-warns-on-meta-interceptors    (suite/assert-reg-event-warns-on-meta-interceptors cfg))
-(deftest events-positional-stays-silent        (suite/assert-reg-event-positional-interceptors-silent cfg))
-
-;; ---- render-to-string + late-bind chain (rf2-y9spn / *_render_to_string) ---
-
-(deftest rts-throws-with-no-emitter            (suite/assert-render-to-string-throws-with-no-emitter cfg))
-(deftest rts-returns-html-after-install        (suite/assert-render-to-string-returns-html-after-direct-install cfg))
-(deftest rts-published-through-chain           (suite/assert-set-hiccup-emitter-published-through-chain cfg))
-
-;; ---- late-bind hook publication set (rf2-jz15y / *_late_bind_publication) --
-
-(deftest late-bind-publishes-expected-set      (suite/assert-adapter-publishes-expected-hook-set cfg))
-(deftest late-bind-cross-checked-directory      (suite/assert-adapter-hooks-cross-checked-against-directory cfg))
-
-;; ---- chained clear-warn-once-caches! (rf2-ovbxk / *_clear_warn_once_chain) -
-
-(deftest clear-warn-chain-empties-cache        (suite/assert-chained-clear-warn-once-empties-cache cfg))
-(deftest clear-warn-direct-resets-cache         (suite/assert-clear-warned-non-dom-roots-resets-directly cfg))
-
-;; ---- routing pipeline (Spec 012 / *_routing) ------------------------------
-
-(deftest routing-handle-url-change             (suite/assert-routing-handle-url-change cfg))
-(deftest routing-multi-frame                    (suite/assert-routing-multi-frame cfg))
-
-;; ---- headless runtime slice (*_runtime) -----------------------------------
-
-(deftest runtime-dispatch-sync                 (suite/assert-dispatch-sync cfg))
-(deftest runtime-sub-chain                      (suite/assert-sub-chain cfg))
-(deftest runtime-with-frame                     (suite/assert-with-frame-binds-current-frame cfg))
-(deftest runtime-bound-fn                        (suite/assert-bound-fn-captures-frame cfg))
-(deftest runtime-multi-frame-isolation          (suite/assert-multi-frame-state-isolation cfg))
-(deftest runtime-reactive-sub                    (suite/assert-reactive-sub-tracks-changes cfg))
-(deftest runtime-sub-hot-reload                  (suite/assert-sub-hot-reload cfg))
-(deftest runtime-machine-transition              (suite/assert-machine-transition cfg))
-(deftest runtime-sub-exception-recovers          (suite/assert-sub-exception-recovers-to-nil cfg))
-
-;; ---- :rf.view/rendered op (rf2-25zo2 / *_view_rendered_op) -----------------
-
-(deftest view-rendered-fires-on-render         (suite/assert-rf-view-rendered-fires-on-render cfg))
-(deftest view-rendered-attribution-in-cascade   (suite/assert-rf-view-rendered-attribution-in-cascade cfg))
-
-;; ---- make-derived-value per-arity (rf2-eoy63 / *_make_derived_value_arity) -
-
-(deftest derived-value-arities                 (suite/assert-derived-value-arities cfg))
-
-;; ---- derived-value watch-baseline (rf2-66hb / *_derived_value_baseline) ----
-
-(deftest derived-baseline-projections          (suite/assert-derived-baseline-projections cfg))
-(deftest derived-baseline-sequence              (suite/assert-derived-baseline-sequence cfg))
-(deftest derived-baseline-multi-source          (suite/assert-derived-baseline-multi-source cfg))
-
-;; ---- managed HTTP (Spec 014 / *_http_managed) -----------------------------
-
-(deftest http-canned-success-default-reply     (suite/assert-http-canned-success-default-reply cfg))
-(deftest http-canned-failure-on-failure         (suite/assert-http-canned-failure-on-failure cfg))
-(deftest http-canned-success-on-success         (suite/assert-http-canned-success-on-success cfg))
-(deftest http-silenced-reply                     (suite/assert-http-silenced-reply cfg))
-(deftest http-with-managed-request-stubs         (suite/assert-http-with-managed-request-stubs cfg))
-(deftest http-with-managed-request-stubs-failure (suite/assert-http-with-managed-request-stubs-failure cfg))
-(deftest http-multi-frame-reply-isolation        (suite/assert-http-multi-frame-reply-isolation cfg))
-
-;; ---- Cross-Spec interactions (headless subset / *_cross_spec) --------------
-
-(deftest xspec-frame-destroy-active-machines   (suite/assert-xspec-frame-destroy-with-active-machines cfg))
-(deftest xspec-machine-microstep-subscribe      (suite/assert-xspec-machine-microstep-subscribe cfg))
-(deftest xspec-boot-order-adapter-ready          (suite/assert-xspec-boot-order-adapter-ready cfg))
-(deftest xspec-machines-under-ssr                (suite/assert-xspec-machines-under-ssr cfg))
-(deftest xspec-route-not-found-ssr               (suite/assert-xspec-route-not-found-ssr cfg))
-(deftest xspec-headless-frame-resolution         (suite/assert-xspec-headless-frame-resolution-chain cfg))
-(deftest xspec-machine-action-throws             (suite/assert-xspec-machine-action-throws cfg))
-(deftest xspec-machine-fx-handler-throws         (suite/assert-xspec-machine-fx-handler-throws cfg))
-(deftest xspec-hot-reload-machine-action         (suite/assert-xspec-hot-reload-machine-action cfg))
-(deftest xspec-dispatch-sync-from-handler        (suite/assert-xspec-dispatch-sync-from-handler-raises cfg))
-(deftest xspec-time-travel-revert                (suite/assert-xspec-time-travel-revert cfg))
-(deftest xspec-server-error-projection           (suite/assert-xspec-server-error-projection cfg))
-(deftest xspec-hot-reload-sub-mid-cascade        (suite/assert-xspec-hot-reload-sub-mid-cascade cfg))
-(deftest xspec-portable-story-fx-override        (suite/assert-xspec-portable-story-fx-override cfg))
-(deftest xspec-adapter-already-installed         (suite/assert-xspec-adapter-already-installed cfg))
+;; Emit one (deftest name (re-frame.adapter.react-shared-suite/assert-name cfg))
+;; per row in `react-shared-suite-tests/test-specs`. The macro ns owns
+;; the single source of truth for the forwarder list; both UIx and
+;; Helix entry files inline the same generated deftests at compile time.
+(define-react-shared-suite-tests! cfg)

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_react_shared_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_react_shared_cljs_test.cljs
@@ -9,17 +9,29 @@
   drift on the shared contracts: a gap on one is a gap on both because
   there is exactly one suite source.
 
-  Coverage forwarded: dispose MUSTs 1–4 + best-effort poison tolerance
-  (G3), source-coord DOM stamping incl. the format-shape split (G2),
-  view-id tagging, frame-context-corrupted (G4), warn-once fire-once +
-  per-id (G5), and the write-after-destroy guard (rf2-sx77q); plus, per
-  rf2-p4736, the rest of the UIx/Helix twin clusters: render-time parity
-  (hot-reload re-register, anonymous render-key, wrap-view callable),
-  reg-event metadata-interceptor warnings, render-to-string + late-bind
-  chain wiring, the late-bind hook publication set + directory
-  cross-check, chained clear-warn-once-caches!, the routing pipeline,
-  the headless runtime slice, :rf.view/rendered, make-derived-value
-  per-arity + watch-baseline, and managed-HTTP.
+  Per rf2-6hphn the ~50 deftest forwarders previously hand-paired
+  between this file and `helix_react_shared_cljs_test.cljs` are now
+  generated from a single `test-specs` literal in
+  `re-frame.adapter.react-shared-suite-tests` (a `.clj` compile-time
+  macro ns, mirroring the conformance-fixtures pattern). Both entry
+  files reduce to: an adapter `:require`, a fixture, a `cfg` map, and
+  one macro call. Adding a new shared assertion no longer requires two
+  hand-copied edits — append `[name assert-name]` to `test-specs` and
+  both adapters pick it up on next compile.
+
+  Coverage forwarded (see `test-specs` in the macro ns for the
+  canonical, in-source list — grep-discoverable from there):
+  dispose MUSTs 1–4 + best-effort poison tolerance (G3), source-coord
+  DOM stamping incl. the format-shape split (G2), view-id tagging,
+  frame-context-corrupted (G4), warn-once fire-once + per-id (G5), the
+  write-after-destroy guard (rf2-sx77q); plus, per rf2-p4736, the rest
+  of the UIx/Helix twin clusters: render-time parity (hot-reload
+  re-register, anonymous render-key, wrap-view callable), reg-event
+  metadata-interceptor warnings, render-to-string + late-bind chain
+  wiring, the late-bind hook publication set + directory cross-check,
+  chained clear-warn-once-caches!, the routing pipeline, the headless
+  runtime slice, :rf.view/rendered, make-derived-value per-arity +
+  watch-baseline, managed-HTTP, and the cross-Spec headless subset.
 
   The async *current-frame*-across-dispatch contract (rf2-l5q3) is
   forwarded from a dedicated entry pair carrying a map-form fixture —
@@ -32,10 +44,13 @@
   node-vs-browser component-element parameterisation; tracked separately.
 
   ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
-  (:require [cljs.test :refer-macros [deftest use-fixtures]]
+  (:require [cljs.test :refer-macros [use-fixtures]]
             [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.adapter.react-shared-suite :as suite]
-            [re-frame.test-support :as test-support]))
+            [re-frame.adapter.react-shared-suite]
+            [re-frame.test-support :as test-support])
+  (:require-macros
+   [re-frame.adapter.react-shared-suite-tests
+    :refer [define-react-shared-suite-tests!]]))
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture
@@ -51,126 +66,8 @@
    :set-emitter!     uix-adapter/set-hiccup-emitter!
    :render-to-string (:render-to-string uix-adapter/adapter)})
 
-;; ---- dispose lifecycle (Spec 006) -----------------------------------------
-
-(deftest dispose-clears-hiccup-emitter        (suite/assert-dispose-clears-hiccup-emitter cfg))
-(deftest dispose-clear-warn-idempotent        (suite/assert-clear-warn-idempotent-post-dispose cfg))
-(deftest dispose-post-delegation-throws       (suite/assert-post-dispose-delegation-throws cfg))
-(deftest dispose-idempotent-no-roots          (suite/assert-dispose-idempotent-no-roots cfg))
-(deftest dispose-clears-sub-caches            (suite/assert-dispose-clears-sub-caches cfg))
-(deftest dispose-walk-best-effort             (suite/assert-dispose-walk-best-effort cfg))
-
-;; ---- source-coord DOM stamping (Spec 006) ---------------------------------
-
-(deftest source-coord-annotates-dom-root      (suite/assert-source-coord-annotates-dom-root cfg))
-(deftest source-coord-merges-with-attrs       (suite/assert-source-coord-merges-with-attrs cfg))
-(deftest source-coord-user-supplied-wins      (suite/assert-source-coord-user-supplied-wins cfg))
-(deftest source-coord-fragment-exempt         (suite/assert-source-coord-fragment-exempt cfg))
-(deftest source-coord-format-shape            (suite/assert-source-coord-format-shape cfg))
-
-;; ---- view-id (data-rf-view) stamping (Spec 006) ---------------------------
-
-(deftest view-id-tags-dom-root                (suite/assert-view-id-tags-dom-root cfg))
-(deftest view-id-fragment-exempt              (suite/assert-view-id-fragment-exempt cfg))
-(deftest view-id-user-supplied-wins           (suite/assert-view-id-user-supplied-wins cfg))
-(deftest wrap-view-injects-explicit-coords    (suite/assert-wrap-view-injects-explicit-coords cfg))
-
-;; ---- frame-context corrupted (Spec 009) -----------------------------------
-
-(deftest frame-context-corrupted              (suite/assert-frame-context-corrupted cfg))
-
-;; ---- warn-once fires-once (Spec 006) --------------------------------------
-
-(deftest warn-once-fires-once                 (suite/assert-warn-once-fires-once cfg))
-(deftest warn-once-per-id-not-global          (suite/assert-warn-once-per-id-not-global cfg))
-
-;; ---- write-after-destroy guard (rf2-ft2b) ---------------------------------
-
-(deftest write-after-destroy-guard            (suite/assert-write-after-destroy-guard cfg))
-
-;; ---- render-time parity (rf2-v1y7 / *_parity) -----------------------------
-
-(deftest parity-view-re-register-rerender     (suite/assert-view-re-register-causes-rerender cfg))
-(deftest parity-current-render-key-anon        (suite/assert-current-render-key-anonymous-fallback cfg))
-(deftest parity-wrap-view-callable             (suite/assert-wrap-view-callable-dispatches-to-user-fn cfg))
-
-;; ---- reg-event metadata-interceptor warnings (rf2-bbea / *_events) --------
-
-(deftest events-warns-on-meta-interceptors    (suite/assert-reg-event-warns-on-meta-interceptors cfg))
-(deftest events-positional-stays-silent        (suite/assert-reg-event-positional-interceptors-silent cfg))
-
-;; ---- render-to-string + late-bind chain (rf2-gc5v9 / *_render_to_string) --
-
-(deftest rts-throws-with-no-emitter            (suite/assert-render-to-string-throws-with-no-emitter cfg))
-(deftest rts-returns-html-after-install        (suite/assert-render-to-string-returns-html-after-direct-install cfg))
-(deftest rts-published-through-chain           (suite/assert-set-hiccup-emitter-published-through-chain cfg))
-
-;; ---- late-bind hook publication set (rf2-rrwwy / *_late_bind_publication) --
-
-(deftest late-bind-publishes-expected-set      (suite/assert-adapter-publishes-expected-hook-set cfg))
-(deftest late-bind-cross-checked-directory      (suite/assert-adapter-hooks-cross-checked-against-directory cfg))
-
-;; ---- chained clear-warn-once-caches! (rf2-e54wc / *_clear_warn_once_chain) -
-
-(deftest clear-warn-chain-empties-cache        (suite/assert-chained-clear-warn-once-empties-cache cfg))
-(deftest clear-warn-direct-resets-cache         (suite/assert-clear-warned-non-dom-roots-resets-directly cfg))
-
-;; ---- routing pipeline (Spec 012 / *_routing) ------------------------------
-
-(deftest routing-handle-url-change             (suite/assert-routing-handle-url-change cfg))
-(deftest routing-multi-frame                    (suite/assert-routing-multi-frame cfg))
-
-;; ---- headless runtime slice (*_runtime) -----------------------------------
-
-(deftest runtime-dispatch-sync                 (suite/assert-dispatch-sync cfg))
-(deftest runtime-sub-chain                      (suite/assert-sub-chain cfg))
-(deftest runtime-with-frame                     (suite/assert-with-frame-binds-current-frame cfg))
-(deftest runtime-bound-fn                        (suite/assert-bound-fn-captures-frame cfg))
-(deftest runtime-multi-frame-isolation          (suite/assert-multi-frame-state-isolation cfg))
-(deftest runtime-reactive-sub                    (suite/assert-reactive-sub-tracks-changes cfg))
-(deftest runtime-sub-hot-reload                  (suite/assert-sub-hot-reload cfg))
-(deftest runtime-machine-transition              (suite/assert-machine-transition cfg))
-(deftest runtime-sub-exception-recovers          (suite/assert-sub-exception-recovers-to-nil cfg))
-
-;; ---- :rf.view/rendered op (rf2-25zo2 / *_view_rendered_op) -----------------
-
-(deftest view-rendered-fires-on-render         (suite/assert-rf-view-rendered-fires-on-render cfg))
-(deftest view-rendered-attribution-in-cascade   (suite/assert-rf-view-rendered-attribution-in-cascade cfg))
-
-;; ---- make-derived-value per-arity (rf2-eoy63 / *_make_derived_value_arity) -
-
-(deftest derived-value-arities                 (suite/assert-derived-value-arities cfg))
-
-;; ---- derived-value watch-baseline (rf2-66hb / *_derived_value_baseline) ----
-
-(deftest derived-baseline-projections          (suite/assert-derived-baseline-projections cfg))
-(deftest derived-baseline-sequence              (suite/assert-derived-baseline-sequence cfg))
-(deftest derived-baseline-multi-source          (suite/assert-derived-baseline-multi-source cfg))
-
-;; ---- managed HTTP (Spec 014 / *_http_managed) -----------------------------
-
-(deftest http-canned-success-default-reply     (suite/assert-http-canned-success-default-reply cfg))
-(deftest http-canned-failure-on-failure         (suite/assert-http-canned-failure-on-failure cfg))
-(deftest http-canned-success-on-success         (suite/assert-http-canned-success-on-success cfg))
-(deftest http-silenced-reply                     (suite/assert-http-silenced-reply cfg))
-(deftest http-with-managed-request-stubs         (suite/assert-http-with-managed-request-stubs cfg))
-(deftest http-with-managed-request-stubs-failure (suite/assert-http-with-managed-request-stubs-failure cfg))
-(deftest http-multi-frame-reply-isolation        (suite/assert-http-multi-frame-reply-isolation cfg))
-
-;; ---- Cross-Spec interactions (headless subset / *_cross_spec) --------------
-
-(deftest xspec-frame-destroy-active-machines   (suite/assert-xspec-frame-destroy-with-active-machines cfg))
-(deftest xspec-machine-microstep-subscribe      (suite/assert-xspec-machine-microstep-subscribe cfg))
-(deftest xspec-boot-order-adapter-ready          (suite/assert-xspec-boot-order-adapter-ready cfg))
-(deftest xspec-machines-under-ssr                (suite/assert-xspec-machines-under-ssr cfg))
-(deftest xspec-route-not-found-ssr               (suite/assert-xspec-route-not-found-ssr cfg))
-(deftest xspec-headless-frame-resolution         (suite/assert-xspec-headless-frame-resolution-chain cfg))
-(deftest xspec-machine-action-throws             (suite/assert-xspec-machine-action-throws cfg))
-(deftest xspec-machine-fx-handler-throws         (suite/assert-xspec-machine-fx-handler-throws cfg))
-(deftest xspec-hot-reload-machine-action         (suite/assert-xspec-hot-reload-machine-action cfg))
-(deftest xspec-dispatch-sync-from-handler        (suite/assert-xspec-dispatch-sync-from-handler-raises cfg))
-(deftest xspec-time-travel-revert                (suite/assert-xspec-time-travel-revert cfg))
-(deftest xspec-server-error-projection           (suite/assert-xspec-server-error-projection cfg))
-(deftest xspec-hot-reload-sub-mid-cascade        (suite/assert-xspec-hot-reload-sub-mid-cascade cfg))
-(deftest xspec-portable-story-fx-override        (suite/assert-xspec-portable-story-fx-override cfg))
-(deftest xspec-adapter-already-installed         (suite/assert-xspec-adapter-already-installed cfg))
+;; Emit one (deftest name (re-frame.adapter.react-shared-suite/assert-name cfg))
+;; per row in `react-shared-suite-tests/test-specs`. The macro ns owns
+;; the single source of truth for the forwarder list; both UIx and
+;; Helix entry files inline the same generated deftests at compile time.
+(define-react-shared-suite-tests! cfg)

--- a/implementation/core/test/re_frame/adapter/react_shared_suite_tests.clj
+++ b/implementation/core/test/re_frame/adapter/react_shared_suite_tests.clj
@@ -1,0 +1,264 @@
+(ns re-frame.adapter.react-shared-suite-tests
+  "Compile-time deftest generator for the per-adapter React-shared entry
+  files (UIx, Helix) — rf2-6hphn.
+
+  WHY THIS EXISTS. The parameterised shared suite
+  (`re-frame.adapter.react-shared-suite`, rf2-sx77q + rf2-p4736) made
+  every spine-shared assertion live ONCE as an `assert-*` defn — but the
+  per-adapter ENTRY files
+  (`uix_react_shared_cljs_test.cljs`,
+  `helix_react_shared_cljs_test.cljs`) still hand-paired ~50 `(deftest
+  name (suite/assert-name cfg))` lines each. Any new shared assertion
+  required two hand-copied edits; the failure mode was silent
+  single-adapter coverage if one entry file was forgotten. This macro
+  closes the residual drift surface: the test list lives ONCE here and
+  both entry files reduce to a single `(define-react-shared-suite-tests!
+  cfg)` call.
+
+  WHY A .clj MACRO. The CLJS test files consume this via
+  `:require-macros`. The pattern mirrors
+  `re-frame.conformance-fixtures` (the conformance-corpus compile-time
+  loader) — a sibling `.clj` ns in `core/test/` whose forms are inlined
+  into the .cljs caller's bytecode at compile time. No runtime cost; no
+  new build wiring required (the file lives under a source-path already
+  on the classpath).
+
+  GREP DISCOVERABILITY. `grep -rn 'deftest <name>'` on the codebase will
+  NOT find a literal deftest form for the suite-forwarders (they are
+  generated at expansion time). To preserve discoverability the
+  generated forms appear in this file's `test-specs` literal — grep
+  `deftest assert-xyz` against `react_shared_suite.cljs` finds the
+  assertion body (the actual source of truth), and grep `assert-xyz`
+  against this file finds the deftest-name pairing. The entry files
+  carry a header comment listing the generated test names so a code
+  reader landing in `uix_react_shared_cljs_test.cljs` sees the surface
+  at a glance.
+
+  ADDING A NEW SHARED ASSERTION.
+
+    1. Add `assert-foo` to `react_shared_suite.cljs`.
+    2. Append `[foo assert-foo]` (or with a section-comment line) to
+       `test-specs` below.
+    3. Both UIx and Helix pick the new test up automatically on next
+       compile — no entry-file edits, structurally no drift."
+  (:refer-clojure :exclude [test-specs]))
+
+;; ---------------------------------------------------------------------------
+;; Test-spec literal — the single source of truth for which suite-fns are
+;; forwarded into deftest forms. Section markers preserve the cluster
+;; layout the entry files used to carry, so a reader can scan the surface
+;; at a glance. `:section` rows are documentation only; `:test` rows emit
+;; a deftest.
+;;
+;; The clusters mirror `react_shared_suite.cljs`'s in-source ordering, so a
+;; suite-source diff and this spec-list diff align line-for-line.
+;; ---------------------------------------------------------------------------
+
+(def ^:private test-specs
+  [{:section "dispose lifecycle (Spec 006)"}
+   {:test 'dispose-clears-hiccup-emitter
+    :fn   'assert-dispose-clears-hiccup-emitter}
+   {:test 'dispose-clear-warn-idempotent
+    :fn   'assert-clear-warn-idempotent-post-dispose}
+   {:test 'dispose-post-delegation-throws
+    :fn   'assert-post-dispose-delegation-throws}
+   {:test 'dispose-idempotent-no-roots
+    :fn   'assert-dispose-idempotent-no-roots}
+   {:test 'dispose-clears-sub-caches
+    :fn   'assert-dispose-clears-sub-caches}
+   {:test 'dispose-walk-best-effort
+    :fn   'assert-dispose-walk-best-effort}
+
+   {:section "source-coord DOM stamping (Spec 006)"}
+   {:test 'source-coord-annotates-dom-root
+    :fn   'assert-source-coord-annotates-dom-root}
+   {:test 'source-coord-merges-with-attrs
+    :fn   'assert-source-coord-merges-with-attrs}
+   {:test 'source-coord-user-supplied-wins
+    :fn   'assert-source-coord-user-supplied-wins}
+   {:test 'source-coord-fragment-exempt
+    :fn   'assert-source-coord-fragment-exempt}
+   {:test 'source-coord-format-shape
+    :fn   'assert-source-coord-format-shape}
+
+   {:section "view-id (data-rf-view) stamping (Spec 006)"}
+   {:test 'view-id-tags-dom-root
+    :fn   'assert-view-id-tags-dom-root}
+   {:test 'view-id-fragment-exempt
+    :fn   'assert-view-id-fragment-exempt}
+   {:test 'view-id-user-supplied-wins
+    :fn   'assert-view-id-user-supplied-wins}
+   {:test 'wrap-view-injects-explicit-coords
+    :fn   'assert-wrap-view-injects-explicit-coords}
+
+   {:section "frame-context corrupted (Spec 009)"}
+   {:test 'frame-context-corrupted
+    :fn   'assert-frame-context-corrupted}
+
+   {:section "warn-once fires-once (Spec 006)"}
+   {:test 'warn-once-fires-once
+    :fn   'assert-warn-once-fires-once}
+   {:test 'warn-once-per-id-not-global
+    :fn   'assert-warn-once-per-id-not-global}
+
+   {:section "write-after-destroy guard (rf2-ft2b)"}
+   {:test 'write-after-destroy-guard
+    :fn   'assert-write-after-destroy-guard}
+
+   {:section "render-time parity (rf2-v1y7 / *_parity)"}
+   {:test 'parity-view-re-register-rerender
+    :fn   'assert-view-re-register-causes-rerender}
+   {:test 'parity-current-render-key-anon
+    :fn   'assert-current-render-key-anonymous-fallback}
+   {:test 'parity-wrap-view-callable
+    :fn   'assert-wrap-view-callable-dispatches-to-user-fn}
+
+   {:section "reg-event metadata-interceptor warnings (rf2-bbea / *_events)"}
+   {:test 'events-warns-on-meta-interceptors
+    :fn   'assert-reg-event-warns-on-meta-interceptors}
+   {:test 'events-positional-stays-silent
+    :fn   'assert-reg-event-positional-interceptors-silent}
+
+   {:section "render-to-string + late-bind chain (*_render_to_string)"}
+   {:test 'rts-throws-with-no-emitter
+    :fn   'assert-render-to-string-throws-with-no-emitter}
+   {:test 'rts-returns-html-after-install
+    :fn   'assert-render-to-string-returns-html-after-direct-install}
+   {:test 'rts-published-through-chain
+    :fn   'assert-set-hiccup-emitter-published-through-chain}
+
+   {:section "late-bind hook publication set (*_late_bind_publication)"}
+   {:test 'late-bind-publishes-expected-set
+    :fn   'assert-adapter-publishes-expected-hook-set}
+   {:test 'late-bind-cross-checked-directory
+    :fn   'assert-adapter-hooks-cross-checked-against-directory}
+
+   {:section "chained clear-warn-once-caches! (*_clear_warn_once_chain)"}
+   {:test 'clear-warn-chain-empties-cache
+    :fn   'assert-chained-clear-warn-once-empties-cache}
+   {:test 'clear-warn-direct-resets-cache
+    :fn   'assert-clear-warned-non-dom-roots-resets-directly}
+
+   {:section "routing pipeline (Spec 012 / *_routing)"}
+   {:test 'routing-handle-url-change
+    :fn   'assert-routing-handle-url-change}
+   {:test 'routing-multi-frame
+    :fn   'assert-routing-multi-frame}
+
+   {:section "headless runtime slice (*_runtime)"}
+   {:test 'runtime-dispatch-sync
+    :fn   'assert-dispatch-sync}
+   {:test 'runtime-sub-chain
+    :fn   'assert-sub-chain}
+   {:test 'runtime-with-frame
+    :fn   'assert-with-frame-binds-current-frame}
+   {:test 'runtime-bound-fn
+    :fn   'assert-bound-fn-captures-frame}
+   {:test 'runtime-multi-frame-isolation
+    :fn   'assert-multi-frame-state-isolation}
+   {:test 'runtime-reactive-sub
+    :fn   'assert-reactive-sub-tracks-changes}
+   {:test 'runtime-sub-hot-reload
+    :fn   'assert-sub-hot-reload}
+   {:test 'runtime-machine-transition
+    :fn   'assert-machine-transition}
+   {:test 'runtime-sub-exception-recovers
+    :fn   'assert-sub-exception-recovers-to-nil}
+
+   {:section ":rf.view/rendered op (rf2-25zo2 / *_view_rendered_op)"}
+   {:test 'view-rendered-fires-on-render
+    :fn   'assert-rf-view-rendered-fires-on-render}
+   {:test 'view-rendered-attribution-in-cascade
+    :fn   'assert-rf-view-rendered-attribution-in-cascade}
+
+   {:section "make-derived-value per-arity (rf2-eoy63 / *_make_derived_value_arity)"}
+   {:test 'derived-value-arities
+    :fn   'assert-derived-value-arities}
+
+   {:section "derived-value watch-baseline (rf2-66hb / *_derived_value_baseline)"}
+   {:test 'derived-baseline-projections
+    :fn   'assert-derived-baseline-projections}
+   {:test 'derived-baseline-sequence
+    :fn   'assert-derived-baseline-sequence}
+   {:test 'derived-baseline-multi-source
+    :fn   'assert-derived-baseline-multi-source}
+
+   {:section "managed HTTP (Spec 014 / *_http_managed)"}
+   {:test 'http-canned-success-default-reply
+    :fn   'assert-http-canned-success-default-reply}
+   {:test 'http-canned-failure-on-failure
+    :fn   'assert-http-canned-failure-on-failure}
+   {:test 'http-canned-success-on-success
+    :fn   'assert-http-canned-success-on-success}
+   {:test 'http-silenced-reply
+    :fn   'assert-http-silenced-reply}
+   {:test 'http-with-managed-request-stubs
+    :fn   'assert-http-with-managed-request-stubs}
+   {:test 'http-with-managed-request-stubs-failure
+    :fn   'assert-http-with-managed-request-stubs-failure}
+   {:test 'http-multi-frame-reply-isolation
+    :fn   'assert-http-multi-frame-reply-isolation}
+
+   {:section "Cross-Spec interactions (headless subset / *_cross_spec)"}
+   {:test 'xspec-frame-destroy-active-machines
+    :fn   'assert-xspec-frame-destroy-with-active-machines}
+   {:test 'xspec-machine-microstep-subscribe
+    :fn   'assert-xspec-machine-microstep-subscribe}
+   {:test 'xspec-boot-order-adapter-ready
+    :fn   'assert-xspec-boot-order-adapter-ready}
+   {:test 'xspec-machines-under-ssr
+    :fn   'assert-xspec-machines-under-ssr}
+   {:test 'xspec-route-not-found-ssr
+    :fn   'assert-xspec-route-not-found-ssr}
+   {:test 'xspec-headless-frame-resolution
+    :fn   'assert-xspec-headless-frame-resolution-chain}
+   {:test 'xspec-machine-action-throws
+    :fn   'assert-xspec-machine-action-throws}
+   {:test 'xspec-machine-fx-handler-throws
+    :fn   'assert-xspec-machine-fx-handler-throws}
+   {:test 'xspec-hot-reload-machine-action
+    :fn   'assert-xspec-hot-reload-machine-action}
+   {:test 'xspec-dispatch-sync-from-handler
+    :fn   'assert-xspec-dispatch-sync-from-handler-raises}
+   {:test 'xspec-time-travel-revert
+    :fn   'assert-xspec-time-travel-revert}
+   {:test 'xspec-server-error-projection
+    :fn   'assert-xspec-server-error-projection}
+   {:test 'xspec-hot-reload-sub-mid-cascade
+    :fn   'assert-xspec-hot-reload-sub-mid-cascade}
+   {:test 'xspec-portable-story-fx-override
+    :fn   'assert-xspec-portable-story-fx-override}
+   {:test 'xspec-adapter-already-installed
+    :fn   'assert-xspec-adapter-already-installed}])
+
+(def ^{:doc "Public seq of {:test name :fn assert-fn} maps a code reader
+  can `(require)` from a JVM REPL to list every generated test name.
+  Section rows are filtered out."}
+  generated-test-specs
+  (filterv :test test-specs))
+
+(defmacro define-react-shared-suite-tests!
+  "Emit one `cljs.test/deftest` per row in `test-specs`, forwarding the
+  per-adapter `cfg` map to the matching `re-frame.adapter.react-shared-suite/assert-*`
+  defn.
+
+  Usage (from a `.cljs` test entry file):
+
+      (:require-macros
+        [re-frame.adapter.react-shared-suite-tests
+         :refer [define-react-shared-suite-tests!]])
+
+      (def ^:private cfg { ... })
+
+      (define-react-shared-suite-tests! cfg)
+
+  The macro qualifies the assert-fn calls against
+  `re-frame.adapter.react-shared-suite` so the entry file only needs
+  to `:require` that suite ns (under any alias, or none — the qualifier
+  is the full ns symbol)."
+  [cfg-sym]
+  `(do
+     ~@(for [{:keys [test fn]} test-specs
+             :when             test]
+       `(cljs.test/deftest ~test
+          (~(symbol "re-frame.adapter.react-shared-suite" (name fn)) ~cfg-sym)))))


### PR DESCRIPTION
## Audit narrative

The UIx + Helix React-shared entry files (`uix_react_shared_cljs_test.cljs`,
`helix_react_shared_cljs_test.cljs`) were ~70-deftest twins differing only
by the adapter binding, the cfg map (~8 keys), and three legacy bead-id
references in section-header comments. The deftest names + suite-fn
call sites were byte-identical between the files.

The parameterised shared suite (`re-frame.adapter.react-shared-suite`,
rf2-sx77q + rf2-p4736) already made every assertion body live ONCE —
but the entry layer still hand-paired the forwarder list. The failure
mode: someone adds `assert-foo` to the suite, drops `(deftest foo
(suite/assert-foo cfg))` into one entry file, forgets the other. Silent
single-adapter coverage. Exactly the drift surface the shared suite was
created to eliminate, re-introduced at a thinner layer.

## Alternatives weighed

- **Outcome A — macro-generate the forwarder list.** Single source of
  truth for the test inventory; structurally impossible to ship a
  one-adapter forwarder. Cost: a layer of indirection — `grep "deftest
  dispose-clears-hiccup-emitter"` will not find a literal deftest form
  in the entry files anymore.
- **Outcome B — keep hand-pairing + add a drift verifier.** A JVM test
  reads both files and diffs the regex-extracted deftest blocks; CI
  fails if they drift. Catches the failure mode post-edit but does not
  prevent it; adds a JVM-side test and a CI gate.

## Decision (Outcome A)

The macro pays its rent because the shared suite already has ~70
assertions and is growing — the "remember to update two entry files"
tax compounds with every new assertion. The "single source of truth"
lens that justified rf2-sx77q applies recursively to the entry layer;
hand-paired forwarders left the contract weaker than it could be.
Grep-discoverability is mitigated by listing every generated test name
in the macro file's `test-specs` literal — a reader landing in either
entry file follows the macro's docstring to one inventory.

A drift verifier on top would be belt-and-braces; the macro is the fix.

## What changed

- **New**: `implementation/core/test/re_frame/adapter/react_shared_suite_tests.clj`
  — a `.clj` compile-time macro ns mirroring the existing
  `re-frame.conformance-fixtures` pattern. Owns the `test-specs`
  literal (the single source of truth for the forwarder list) and
  exposes `define-react-shared-suite-tests!` which emits one
  fully-qualified `(cljs.test/deftest name
  (re-frame.adapter.react-shared-suite/assert-name cfg))` per row.
- **Updated**: both entry files
  (`uix_react_shared_cljs_test.cljs`, `helix_react_shared_cljs_test.cljs`)
  drop the ~70-line deftest block in favour of a single
  `(define-react-shared-suite-tests! cfg)` call. The docstring carries
  the audit note and cross-references the macro ns.

Adding a new shared assertion is now a one-line edit: append `{:test
foo :fn assert-foo}` to `test-specs`. Both adapters pick it up
structurally on next compile.

## Gates

- `npm run test:cljs` — green (4525 tests / 14367 assertions / 0 failures)
- `npm run test:browser` — green (124 tests / 346 assertions / 0 failures)
- `clj-kondo` on the three changed files — clean (0 errors, 0 warnings;
  the 3 pre-existing warnings in `react_shared_suite.cljs` are unrelated
  and were present before this change)
- macro emits exactly 70 deftests per entry file (verified via JVM
  `(count generated-test-specs)`), matching the prior hand-paired count.

Closes rf2-6hphn.
