### PR TITLE
docs(spec): align Tool-Pair cursor-stale language to :epoch-id everywhere (rf2-u8bgx)

### DIFF
--- a/spec/Tool-Pair.md
+++ b/spec/Tool-Pair.md
@@ -597,7 +597,7 @@ The MCP-server surfaces that stream the per-frame ring to off-box agents (`re-fr
 
 The cascade-bundle wire shape DIFFERS from the in-process `:flat true` opt-in by intent: in-process callers may need raw events for fine-grained per-emit logic; off-box agents need atomic cascade context per stream tick to stay within token budgets and to reason about cause→effect at a granularity that matches `:dispatch-id`. The bundle is the better default for LLM-shaped consumers; the `:flat` form is the escape hatch for in-process callers that already grouped raw streams themselves.
 
-Per cursor-pagination (rf2-kbqq3) and per-session cache (rf2-3rt1f) conventions in [§Wire-protocol mechanisms](#wire-protocol-mechanisms-mcp-tool-layer-not-framework) compose unchanged: a `:dispatch-id`-keyed cursor identifies the next cascade slot; a `:rf.mcp/cursor-stale` marker fires when the cursor's cascade has aged out of the ring; per-session response cache keys on app-db identity, not on cascade-id, so the cascade-bundle shape doesn't change its hit semantics.
+Per cursor-pagination (rf2-kbqq3) and per-session cache (rf2-3rt1f) conventions in [§Wire-protocol mechanisms](#wire-protocol-mechanisms-mcp-tool-layer-not-framework) compose unchanged: a `:epoch-id`-keyed cursor identifies the next epoch slot in `epoch-history`; a `:rf.mcp/cursor-stale` marker fires when the cursor's `:epoch-id` has aged out of `epoch-history`; per-session response cache keys on app-db root identity, so the cascade-bundle shape doesn't change its hit semantics.
 
 #### Frameless trace events — live channel only (rf2-g1b2m B3 ruling)
 


### PR DESCRIPTION
**Mike ruled 2026-05-25: `:epoch-id` everywhere.**

The prose at `spec/Tool-Pair.md` line 600 (§`watch-epochs` / `trace-window` consumer shape) described a `:dispatch-id`-keyed cursor identifying "the next cascade slot" — but the §MCP-side wire-marker vocabulary table four paragraphs later (line 660) already says `:rf.mcp/cursor-stale` fires when the cursor's `:epoch-id` aged out of the ring, which matches what `trace-window` / `watch-epochs` actually do (they paginate over `epoch-history`, keyed on `:epoch-id`).

The prose was aspirational, didn't match the shipped pair-mcp code, and didn't match the table. Pre-alpha posture: align to reality, no "future option" footnote — if a future tool paginates the cascade-keyed trace ring we add that surface then.

## Change

Single line in `spec/Tool-Pair.md`:

- `:epoch-id`-keyed cursor identifies the next **epoch slot in `epoch-history`** (was: `:dispatch-id`-keyed cursor identifies the next cascade slot).
- `:rf.mcp/cursor-stale` fires when the cursor's **`:epoch-id`** has aged out of **`epoch-history`** (was: when the cursor's cascade has aged out of the ring).
- Per-session response cache keys on app-db **root identity** (dropped the dangling "not on cascade-id" half — `cascade-id` was never a wire term).

## Not touched

- The line 660 table row — already correctly says `:epoch-id`.
- The `:rf.trace/dispatch-id` cascade-event correlation identifier — that namespace is still the right shape for cascade-keyed bundle merging; cursor framing is what changed.
- Any `.clj` / `.cljs` / `.cljc` code — shipped runtime is already correct.

## Downstream consumers sweep (`git grep cursor-stale`)

Already correctly framed on `:epoch-id` (or framework-neutral):

- `tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md` — § Cursor pagination, § Cursor staleness, § Cursor staleness on cascade-bundle streams. All keyed on `:epoch-id`.
- `skills/re-frame2-pair/references/wire-size-budget.md` — neutral "id aged out of the ring".
- `spec/Conventions.md` — `:rf.mcp/*` row mentions `:rf.mcp/cursor-stale` neutrally as "cursor age-out `:reason`".
- `tools/story-mcp/...` — describes its own (separate) cursor mechanism.

No further edits needed downstream.

## Gates

- `python -m mkdocs build --strict` — passed (built in 7.58 s).
- `python scripts/check_doc_slugs.py --verbose` — no broken links across 376 markdown files.
- `python scripts/check_skill_redirect_anchors.py` — exit 0.

Docs-only; no CLJS / CLJ test impact.

Closes rf2-u8bgx.