### PR TITLE
fix(xray): data-display click-toggle — reg-view + first-click invert visible state (rf2-y59tb)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1344,16 +1344,33 @@ re-break what phase 1 lands. All five are tested in
 4. **Click-to-toggle actually toggles.** Each node carries a stable
    `data-testid` derived from `[panel-id mount-id path]`; the `▸`
    span's `:on-click` dispatches
-   `[:rf.xray.data-display/toggle-node panel-id mount-id path]`
-   (with the `{:frame :rf/xray}` envelope because React's click
-   handler fires after the frame context pops). The reducer writes
-   `{:expanded? bool}` into the per-node entry in
+   `[:rf.xray.data-display/toggle-node panel-id mount-id path rendered-expanded?]`
+   via the **lexically-injected frame-aware dispatcher** — the widget
+   is `reg-view`-registered (per rf2-y59tb) so its body's `dispatch`
+   closure inherits the surrounding `frame-provider` from React
+   context. Mounted under `:rf/xray` (App-DB panel) the click lands
+   in `:rf/xray`'s app-db; under any other frame it lands in that
+   frame's app-db. No explicit `{:frame :rf/xray}` envelope — the
+   frame is captured by `reg-view` at mount.
+
+   The fifth payload slot — `rendered-expanded?` — is the visible
+   state at the click site (the value `resolve-expanded?` returned
+   for the path on the current render). The reducer inverts from it
+   when no override exists, so the FIRST click always flips what the
+   user sees. Without this the reducer's "no override → first click
+   opens" branch is a silent no-op on default-expanded paths
+   (top-level triangles render expanded BEFORE any click, so storing
+   `:expanded? true` repeats the rendered state — rf2-y59tb Bug B).
+
+   The reducer writes `{:expanded? bool}` into the per-node entry in
    `:rf.xray.data-display/expansion`. Next render reads the slot via
    `:rf.xray.data-display/expansion` subscription, the path's
    entry exists, the renderer picks `:expanded?` over the default
-   heuristic, the triangle swaps `▸` → `▾`, and the body becomes
-   visible. This is the property rf2-dw8n7 / rf2-oswhk failed to
-   deliver under the cljs-devtools-layered approach.
+   heuristic, the triangle swaps `▸` → `▾` (or vice versa), and the
+   body becomes visible (or hidden). This is the property rf2-dw8n7 /
+   rf2-oswhk failed to deliver under the cljs-devtools-layered
+   approach; rf2-y59tb closed the remaining frame-leak + first-click
+   gap on top of the rf2-oqa60 widget rebuild.
 
 5. **Per-call-site isolation.** Two `[data-display]` mounts in the
    same panel receive distinct `mount-id`s (auto-generated UUID per

--- a/tools/xray/src/day8/re_frame2_xray/views/data_display.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/data_display.cljs
@@ -129,18 +129,27 @@
   (fn [db _] (get db expansion-slot)))
 
 (rf/reg-event-db :rf.xray.data-display/toggle-node
-  (fn [db [_ panel-id mount-id path]]
+  (fn [db [_ panel-id mount-id path rendered-expanded?]]
+    ;; rf2-y59tb — first click MUST invert the currently-visible state.
+    ;;
+    ;; The widget renders `default-expanded` paths (top-level nodes,
+    ;; depth ≤ `default-expanded-depth`) open BEFORE the user clicks,
+    ;; even though no override is stored. If the reducer flipped from
+    ;; a hard-coded assumption (e.g. "first click opens") it would
+    ;; emit the same state the user already sees — a silent no-op on
+    ;; the first click.
+    ;;
+    ;; The dispatch payload now carries `rendered-expanded?` — the
+    ;; value `resolve-expanded?` returned for this path on the last
+    ;; render (i.e. what the user currently sees). When no override
+    ;; is stored the reducer flips from that visible state; when an
+    ;; override IS stored it flips the override (idempotent given a
+    ;; consistent dispatcher).
     (let [k       (expansion-key panel-id mount-id path)
-          ;; current is either nil (default — no override) or
-          ;; {:expanded? bool}. Toggle inverts whatever is stored;
-          ;; when nothing's stored we flip from the SUPPLIED default
-          ;; (passed via the dispatch payload) so the first click on
-          ;; a collapsed default opens it, and on an expanded
-          ;; default closes it.
           current (get-in db [expansion-slot k])
           next?   (if (contains? current :expanded?)
                     (not (boolean (:expanded? current)))
-                    true)] ;; first click opens — common case
+                    (not (boolean rendered-expanded?)))]
       (assoc-in db [expansion-slot k] {:expanded? next?}))))
 
 (rf/reg-event-db :rf.xray.data-display/set-node
@@ -706,16 +715,25 @@
        (when (seq path) (str "-" (str/join "/" (map pr-str path))))))
 
 (defn- on-toggle
-  "Build the click handler for a node's `▸`/`▾` glyph. Dispatches the
-  toggle event WITH the frame envelope so the event lands on `:rf/xray`
-  not `:rf/default` (React click pops the frame context)."
-  [panel-id mount-id path]
+  "Build the click handler for a node's `▸`/`▾` glyph.
+  Dispatches the toggle event via `dispatch-fn` — the lexically-
+  injected frame-aware dispatcher that `reg-view` binds inside the
+  widget's render body. The dispatcher inherits the surrounding
+  frame from React context (rf2-y59tb), so the event lands on the
+  same frame the widget is mounted under (`:rf/xray` in the App-DB
+  panel, `:rf/default` in a standalone playground).
+
+  The payload carries `rendered-expanded?` — the current visible
+  state of this node — so the reducer can invert from what the user
+  sees on the first click (rf2-y59tb Bug B). Without it, default-
+  expanded paths would silently no-op on the first click."
+  [dispatch-fn panel-id mount-id path rendered-expanded?]
   (fn [^js e]
     (when e
       (.preventDefault e)
       (.stopPropagation e))
-    (rf/dispatch [:rf.xray.data-display/toggle-node panel-id mount-id path]
-                 {:frame :rf/xray})))
+    (dispatch-fn [:rf.xray.data-display/toggle-node
+                  panel-id mount-id path rendered-expanded?])))
 
 (defn- collapsed-summary
   "Right-of-triangle summary for a collapsed collection. Shows an
@@ -737,11 +755,14 @@
    - depth — for the default-expand heuristic
    - expansion-map — snapshot from the expansion-slot subscription
    - opts — `:default-expanded-depth`, `:max-depth`, `:max-inline-width`
+   - dispatch-fn — frame-aware dispatcher captured by the surrounding
+                   `reg-view` body (rf2-y59tb); falls back to `rf/dispatch`
+                   when called outside a registered view (test/REPL).
    - diff? / before — when diff? true the renderer paints gutter rows,
                       annotates changed leaves, and force-expands the
                       ancestor chain over any changed descendant."
   [{:keys [value kind panel-id mount-id path depth expansion-map opts
-           diff? before]}]
+           dispatch-fn diff? before]}]
   (let [{:keys [default-expanded-depth max-depth max-inline-width]
          :or {default-expanded-depth 2 max-depth 16 max-inline-width 60}} opts
         cnt           (child-count value kind)
@@ -770,7 +791,19 @@
                                    (children-of value))
                            (<= (count (inline-preview-string value 5 max-inline-width))
                                max-inline-width))
-        toggle-fn     (on-toggle panel-id mount-id path)
+        ;; `dispatch-fn` is supplied by the reg-view'd outer body so
+        ;; the toggle dispatch carries the surrounding frame. Tests
+        ;; that drive render-node directly without mounting fall back
+        ;; to the global dispatcher's fn form (`rf/dispatch` is a
+        ;; macro — use `rf/dispatch*` for HoF callers).
+        dispatch-fn   (or dispatch-fn rf/dispatch*)
+        ;; rendered-expanded? is the visible state at this node —
+        ;; the depth-capped placeholder is always shown collapsed
+        ;; (▸), and we use the computed `expanded?` for the rest.
+        ;; Threading it into `on-toggle` lets the reducer invert from
+        ;; the visible state on the first click.
+        toggle-fn     (on-toggle dispatch-fn panel-id mount-id path
+                                 (boolean (and expanded? (not depth-capped?))))
         children      (when (and (not empty?) (not depth-capped?) expanded? (not inline-fit?))
                         (children-of value))]
     [:div {:data-testid (testid-for panel-id mount-id path)
@@ -931,6 +964,7 @@
                                                 :path child-path
                                                 :depth (inc depth)
                                                 :expansion-map expansion-map
+                                                :dispatch-fn dispatch-fn
                                                 :opts opts})
                                   {:key (str "v-" (pr-str k))})]))
                   child-pairs)))])
@@ -1042,8 +1076,15 @@
   `::missing`, the node is rendered as `:added`; when `value` is
   `::missing`, as `:removed`.
 
+  `:dispatch-fn` (optional) is the frame-aware dispatcher captured by
+  the surrounding `reg-view` body (rf2-y59tb) so toggle clicks land on
+  the same frame the widget is mounted under. Tests / programmatic
+  callers that drive render-node without a mount can omit it — the
+  container-renderer falls back to the global `rf/dispatch`.
+
   Public so unit tests can drive the renderer without mounting."
-  [{:keys [value before diff? panel-id mount-id path depth expansion-map opts]
+  [{:keys [value before diff? panel-id mount-id path depth expansion-map
+           dispatch-fn opts]
     :or   {depth 0 path []}}]
   (or
     ;; Protocol seam (rf2-0qrcr) — light-touch satisfies? gate; nil
@@ -1080,6 +1121,7 @@
                              :path path
                              :depth depth
                              :expansion-map expansion-map
+                             :dispatch-fn dispatch-fn
                              :opts opts
                              :diff? true
                              :before ::missing})
@@ -1095,6 +1137,7 @@
                              :path path
                              :depth depth
                              :expansion-map expansion-map
+                             :dispatch-fn dispatch-fn
                              :opts opts
                              :diff? (boolean diff?)
                              :before before})
@@ -1114,7 +1157,7 @@
   []
   (str (random-uuid)))
 
-(defn data-display
+(rf/reg-view data-display
   "First-class data-display widget — single source of truth for
   browse + diff + mini.
 
@@ -1132,10 +1175,10 @@
     ancestor chain over any changed descendant, and dims `:same`
     rows.
 
-  Form-2 Reagent component: the outer fn allocates a stable
-  `mount-id` in closure; the inner fn subscribes to the expansion
-  slot, threads the snapshot through the recursive renderer, and
-  returns hiccup.
+  Form-2 component: the outer body allocates a stable `mount-id`
+  in closure; the inner fn subscribes to the expansion slot,
+  threads the snapshot through the recursive renderer, and returns
+  hiccup.
 
   Per D4=a (rf2-sndui) the public API does NOT take a `:render-id` —
   mount-id is generated internally. Two simultaneous mounts get
@@ -1143,40 +1186,77 @@
 
   Per-call-site isolation is the key correctness property here: two
   `[data-display value]` mounts in the same panel must NOT share
-  expansion state. The form-2 closure delivers that — the outer fn
-  runs once per mount."
-  ([value] (data-display value nil))
-  ([_value _opts]
-   (let [mount-id (gen-mount-id)]
-     (fn [value opts]
-       (let [{:keys [panel-id default-expanded-depth max-inline-width
-                     max-depth before]
-              :or   {panel-id :rf.xray.data-display/anon
-                     default-expanded-depth 2
-                     max-inline-width 60
-                     max-depth 16}} opts
-             diff?         (contains? opts :before)
-             expansion-map @(rf/subscribe [expansion-slot])
-             container-id  (str "rf-xray-data-display-"
-                                (name panel-id) "-" mount-id)]
-         [:div {:data-testid     container-id
-                :data-rf-mount-id mount-id
-                :data-rf-mode    (if diff? "diff" "browse")
-                :style {:font-family mono-stack
-                        :font-size   "12px"
-                        :color       (:text-primary tokens)
-                        :line-height 1.4}}
-          (render-node {:value value
-                        :before (if diff? before ::missing)
-                        :diff? diff?
-                        :panel-id panel-id
-                        :mount-id mount-id
-                        :path []
-                        :depth 0
-                        :expansion-map expansion-map
-                        :opts {:default-expanded-depth default-expanded-depth
-                               :max-inline-width max-inline-width
-                               :max-depth max-depth}})])))))
+  expansion state. The form-2 closure delivers that — the outer body
+  runs once per mount.
+
+  ## rf2-y59tb — `reg-view`-registered so dispatch / subscribe inherit
+  the surrounding frame
+
+  Before this fix `data-display` was a plain `defn`. Plain Reagent fns
+  do not consult the `frame-provider` React context, so when the
+  widget mounted under `:rf/xray` (App-DB panel) toggle dispatches and
+  expansion-slot subscribes routed to `:rf/default` instead — the
+  click landed in the wrong frame's app-db and the rendering sub
+  never saw it. Same root cause as `ribbon-theme-toggle` (rf2-uu3lp).
+
+  The `reg-view` registration makes the component
+  `:contextType frame-context`-aware: dispatch / subscribe both
+  resolve to whatever frame the enclosing `frame-provider` puts in
+  scope. The lexical `dispatch` injected by the macro is threaded
+  through `render-node` opts so callbacks deep in the recursion
+  carry the same frame.
+
+  Call sites continue to read `[dd/data-display value opts]` — the
+  macro defs the `data-display` Var to the registered render fn, so
+  the public API is unchanged. Call sites that omit `opts`
+  (`[dd/data-display value]`) flow the same way; Reagent passes the
+  positional args from the hiccup vector to both the outer and inner
+  fn, and the inner fn tolerates `opts=nil` via the destructure's
+  `:or` defaults."
+  [_value & _opts]
+  (let [mount-id    (gen-mount-id)
+        ;; Capture the frame-aware dispatcher lexically. The closure
+        ;; binds to the surrounding frame the outer body runs under;
+        ;; every callback the inner renderer creates (toggle handlers,
+        ;; recursive render-node descents) threads this closure so the
+        ;; dispatch carries the right frame even when fired long after
+        ;; render unwinds.
+        dispatch-fn dispatch]
+    (fn render-data-display
+      [value & rest-args]
+      (let [opts          (first rest-args)
+            {:keys [panel-id default-expanded-depth max-inline-width
+                    max-depth before]
+             :or   {panel-id :rf.xray.data-display/anon
+                    default-expanded-depth 2
+                    max-inline-width 60
+                    max-depth 16}} opts
+            diff?         (contains? opts :before)
+            ;; `subscribe` is the lexical frame-aware closure
+            ;; injected by `reg-view` — reads the expansion-slot
+            ;; from the surrounding frame's app-db (e.g. `:rf/xray`).
+            expansion-map @(subscribe [expansion-slot])
+            container-id  (str "rf-xray-data-display-"
+                               (name panel-id) "-" mount-id)]
+        [:div {:data-testid     container-id
+               :data-rf-mount-id mount-id
+               :data-rf-mode    (if diff? "diff" "browse")
+               :style {:font-family mono-stack
+                       :font-size   "12px"
+                       :color       (:text-primary tokens)
+                       :line-height 1.4}}
+         (render-node {:value value
+                       :before (if diff? before ::missing)
+                       :diff? diff?
+                       :panel-id panel-id
+                       :mount-id mount-id
+                       :path []
+                       :depth 0
+                       :expansion-map expansion-map
+                       :dispatch-fn dispatch-fn
+                       :opts {:default-expanded-depth default-expanded-depth
+                              :max-inline-width max-inline-width
+                              :max-depth max-depth}})]))))
 
 (defn data-display-diff
   "Diff convenience — `[data-display-diff before after]` or

--- a/tools/xray/test/day8/re_frame2_xray/views/data_display_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/data_display_cljs_test.cljs
@@ -259,25 +259,43 @@
 ;; render the body.
 
 (deftest toggle-event-flips-expansion-state
+  ;; rf2-y59tb — the toggle reducer now inverts from the
+  ;; current rendered-expanded? state (passed in the dispatch
+  ;; payload) when no override is stored, then inverts the stored
+  ;; override on subsequent clicks. This is the load-bearing
+  ;; correctness contract: first click MUST invert the visible
+  ;; state, not jump to a hard-coded "first click opens" value.
   (let [panel-id :test
         mount-id "m-1"
         path     [:a]]
-    ;; Drive the reducer via re-frame's dispatch-sync against the
-    ;; runtime fixture set up at the top of the ns. The first toggle
-    ;; opens the node (no override → fresh `true`); the second toggle
-    ;; inverts to `false`. `reset-expansion` clears the slot.
+    ;; Case A — default-collapsed (e.g. deep path). Visible state
+    ;; is collapsed → dispatch carries `false` → first click stores
+    ;; `:expanded? true` (opens). Second click inverts to `false`.
     (rf/dispatch-sync [:rf.xray.data-display/reset-expansion])
-    (rf/dispatch-sync [:rf.xray.data-display/toggle-node panel-id mount-id path])
+    (rf/dispatch-sync [:rf.xray.data-display/toggle-node panel-id mount-id path false])
     (let [snapshot @(rf/subscribe [dd/expansion-slot])
           k         (dd/expansion-key panel-id mount-id path)]
       (is (= true (get-in snapshot [k :expanded?]))
-          "first toggle on a fresh slot opens the node"))
-    ;; Second toggle inverts.
-    (rf/dispatch-sync [:rf.xray.data-display/toggle-node panel-id mount-id path])
+          "default-collapsed: first click stores :expanded? true (opens)"))
+    (rf/dispatch-sync [:rf.xray.data-display/toggle-node panel-id mount-id path true])
     (let [snapshot @(rf/subscribe [dd/expansion-slot])
           k         (dd/expansion-key panel-id mount-id path)]
       (is (= false (get-in snapshot [k :expanded?]))
-          "second toggle inverts to closed"))
+          "second toggle inverts the stored override to false"))
+
+    ;; Case B — default-expanded (e.g. top-level path). Visible
+    ;; state is expanded → dispatch carries `true` → first click
+    ;; stores `:expanded? false` (collapses). This is the
+    ;; regression the bug fixed; before the fix the reducer would
+    ;; emit `{:expanded? true}` — same as the rendered state —
+    ;; producing a silent no-op on the first click.
+    (rf/dispatch-sync [:rf.xray.data-display/reset-expansion])
+    (rf/dispatch-sync [:rf.xray.data-display/toggle-node panel-id mount-id path true])
+    (let [snapshot @(rf/subscribe [dd/expansion-slot])
+          k         (dd/expansion-key panel-id mount-id path)]
+      (is (= false (get-in snapshot [k :expanded?]))
+          "default-expanded: first click stores :expanded? false (collapses)"))
+
     ;; Reset cleans the slot.
     (rf/dispatch-sync [:rf.xray.data-display/reset-expansion])
     (is (nil? @(rf/subscribe [dd/expansion-slot])))))
@@ -408,28 +426,65 @@
 ;; ---- toggle handler shape ------------------------------------------------
 
 (deftest toggle-handler-dispatches-canonical-event
-  (let [captured (atom nil)]
-    ;; rf/dispatch expands through `dispatch*`; intercept at the
-    ;; lower-level fn the same way the legacy data-display tests do.
-    (with-redefs [rf/dispatch* (fn [event-v & _]
-                                 (reset! captured event-v))]
-      ;; Force a non-inline-fit collection so the toggle glyph is rendered.
-      (let [v   {:a 1 :b 2 :c 3 :d 4 :e 5}
-            h   (dd/render-node {:value v
-                                 :panel-id :test
-                                 :mount-id "m1"
-                                 :path [:x]
-                                 :depth 0
-                                 :expansion-map {}
-                                 :opts {:default-expanded-depth 0}})
-            ;; Find the toggle span by data-testid suffix.
-            tog (find-attr h :data-testid
-                           "rf-xray-data-display-test-m1-:x-toggle")
-            on-click (-> tog second :on-click)]
-        (is (fn? on-click) "toggle glyph must carry an :on-click")
-        (when on-click (on-click nil))
-        (is (= [:rf.xray.data-display/toggle-node :test "m1" [:x]]
-               @captured))))))
+  ;; rf2-y59tb — the dispatch payload threads the rendered-
+  ;; expanded? state as a fifth slot so the reducer can invert
+  ;; from the user's visible state on the first click.
+  (testing "default-collapsed path: dispatched event carries rendered? false"
+    (let [captured (atom nil)
+          ;; render-node accepts an explicit dispatch-fn so tests
+          ;; can intercept the toggle dispatch without redef'ing
+          ;; the global rf/dispatch* (which is what the prior shape
+          ;; did before the reg-view fix). The :dispatch-fn slot is
+          ;; the same closure the reg-view'd outer body threads to
+          ;; carry frame context.
+          ;;
+          ;; default-expanded-depth=1, depth=5 → both depth-band
+          ;; checks fail (`(<= 5 0)` false; `(= 5 1)` false) → the
+          ;; heuristic returns false → path renders ▸ (collapsed).
+          v   {:a 1 :b 2 :c 3 :d 4 :e 5}
+          h   (dd/render-node {:value v
+                               :panel-id :test
+                               :mount-id "m1"
+                               :path [:x]
+                               :depth 5
+                               :expansion-map {}
+                               :dispatch-fn (fn [event-v]
+                                              (reset! captured event-v))
+                               :opts {:default-expanded-depth 1}})
+          ;; Find the toggle span by data-testid suffix.
+          tog (find-attr h :data-testid
+                         "rf-xray-data-display-test-m1-:x-toggle")
+          on-click (-> tog second :on-click)]
+      (is (fn? on-click) "toggle glyph must carry an :on-click")
+      (when on-click (on-click nil))
+      (is (= [:rf.xray.data-display/toggle-node :test "m1" [:x] false]
+             @captured)
+          "default-collapsed render → payload carries rendered? false")))
+
+  (testing "default-expanded path: dispatched event carries rendered? true"
+    (let [captured (atom nil)
+          ;; A >3-key map at depth 0 with default-expanded-depth 2:
+          ;; - inline-fit gate fails (cnt > 3 → not inline)
+          ;; - `(<= 0 (dec 2))` true → default-expanded? returns true
+          ;; - path renders ▾, toggle dispatches rendered? true.
+          v   {:a 1 :b 2 :c 3 :d 4 :e 5}
+          h   (dd/render-node {:value v
+                               :panel-id :test
+                               :mount-id "m2"
+                               :path []
+                               :depth 0
+                               :expansion-map {}
+                               :dispatch-fn (fn [event-v]
+                                              (reset! captured event-v))
+                               :opts {:default-expanded-depth 2}})
+          tog (find-attr h :data-testid
+                         "rf-xray-data-display-test-m2-toggle")
+          on-click (-> tog second :on-click)]
+      (is (fn? on-click) "toggle glyph must carry an :on-click")
+      (when on-click (on-click nil))
+      (is (= [:rf.xray.data-display/toggle-node :test "m2" [] true]
+             @captured)
+          "default-expanded render → payload carries rendered? true"))))
 
 ;; ---- per-call-site isolation ---------------------------------------------
 
@@ -647,3 +702,121 @@
     (is (fn? (first h)))
     (is (= {:a 2} (nth h 1)))
     (is (= {:a 1} (:before (nth h 2))))))
+
+;; =========================================================================
+;; rf2-y59tb — frame-leak + first-click regression guards
+;; =========================================================================
+;;
+;; Two independent bugs covered here:
+;;
+;;   Bug A — `data-display` was a plain `defn`, so dispatches from
+;;     its click handlers did NOT carry the surrounding frame; toggle
+;;     events landed on `:rf/default` while the App-DB panel mounted
+;;     the widget under `:rf/xray`. The expansion-slot mutation ended
+;;     up in the wrong frame's app-db, invisible to the surrounding
+;;     subscribe.
+;;
+;;   Bug B — the reducer's "no override → first click opens" logic
+;;     was wrong for paths the widget renders as default-expanded
+;;     (top-level triangles, depth ≤ default-expanded-depth). The
+;;     first click stored `:expanded? true` — the same value the path
+;;     already rendered with — producing a silent no-op.
+
+(deftest data-display-is-reg-view-registered
+  (testing "rf2-y59tb Bug A — the public widget is registered via
+            `reg-view` so dispatches + subscribes inherit the
+            surrounding frame from React context. Without this the
+            App-DB panel's `:rf/xray` mount routes toggle dispatches
+            to `:rf/default`. The registration is present in the
+            view registry under the auto-derived namespaced id."
+    (is (some? (rf/view :day8.re-frame2-xray.views.data-display/data-display))
+        "data-display is registered under its ns/sym id")))
+
+(deftest data-display-toggle-dispatches-to-mount-frame
+  ;; rf2-y59tb Bug A regression guard — the click handler dispatches
+  ;; through the lexically-injected frame-aware dispatcher. We
+  ;; simulate the inner render by calling `render-node` with a
+  ;; `dispatch-fn` (which is what the reg-view body threads from its
+  ;; outer-scope `dispatch` lexical binding); the handler MUST call
+  ;; our supplied dispatch-fn rather than `rf/dispatch` (which would
+  ;; route to `:rf/default`).
+  (let [captured (atom nil)
+        v       {:a 1 :b 2 :c 3 :d 4 :e 5}
+        h       (dd/render-node {:value v
+                                 :panel-id :app-db
+                                 :mount-id "m"
+                                 :path []
+                                 :depth 0
+                                 :expansion-map {}
+                                 :dispatch-fn (fn [event-v]
+                                                (reset! captured event-v))
+                                 :opts {:default-expanded-depth 0}})
+        tog     (find-attr h :data-testid
+                           "rf-xray-data-display-app-db-m-toggle")
+        on-click (-> tog second :on-click)]
+    (is (fn? on-click))
+    (when on-click (on-click nil))
+    (is (some? @captured)
+        "toggle handler invoked the threaded dispatch-fn (not rf/dispatch)")
+    (is (= :rf.xray.data-display/toggle-node (first @captured))
+        "canonical event id")))
+
+(deftest first-click-collapses-default-expanded-path
+  ;; rf2-y59tb Bug B regression guard — driven through dispatch-sync
+  ;; against the registered toggle reducer with the rendered-
+  ;; expanded? payload threaded. A default-expanded path passes
+  ;; `true` as the rendered state; the reducer must store
+  ;; `:expanded? false` (the inverted visible state), NOT
+  ;; `:expanded? true` (the prior "first click opens" no-op bug).
+  (let [panel-id :rf.xray/app-db
+        mount-id "m1"
+        path     [:top-level]]
+    (rf/dispatch-sync [:rf.xray.data-display/reset-expansion])
+    (rf/dispatch-sync [:rf.xray.data-display/toggle-node
+                       panel-id mount-id path true])
+    (let [snapshot @(rf/subscribe [dd/expansion-slot])
+          k         (dd/expansion-key panel-id mount-id path)]
+      (is (= false (get-in snapshot [k :expanded?]))
+          "default-expanded → first click collapses (rendered? true → stored false)"))
+    (rf/dispatch-sync [:rf.xray.data-display/reset-expansion])))
+
+(deftest first-click-expands-default-collapsed-path
+  ;; rf2-y59tb Bug B regression guard — the symmetric case. A deep
+  ;; path (past default-expanded-depth) renders collapsed by default.
+  ;; The toggle dispatch carries `false`; the reducer must store
+  ;; `:expanded? true` (opens the node) on the first click.
+  (let [panel-id :rf.xray/app-db
+        mount-id "m1"
+        path     [:deep :nested :node]]
+    (rf/dispatch-sync [:rf.xray.data-display/reset-expansion])
+    (rf/dispatch-sync [:rf.xray.data-display/toggle-node
+                       panel-id mount-id path false])
+    (let [snapshot @(rf/subscribe [dd/expansion-slot])
+          k         (dd/expansion-key panel-id mount-id path)]
+      (is (= true (get-in snapshot [k :expanded?]))
+          "default-collapsed → first click expands (rendered? false → stored true)"))
+    (rf/dispatch-sync [:rf.xray.data-display/reset-expansion])))
+
+(deftest second-click-inverts-stored-override
+  ;; Once an override is stored the reducer ignores the rendered?
+  ;; payload (the override IS the visible state) and inverts the
+  ;; stored boolean. This is the canonical toggle behaviour for
+  ;; clicks 2+ on the same path.
+  (let [panel-id :rf.xray/app-db
+        mount-id "m1"
+        path     [:x]
+        k         (dd/expansion-key panel-id mount-id path)]
+    (rf/dispatch-sync [:rf.xray.data-display/reset-expansion])
+    ;; First click on default-expanded → stored false.
+    (rf/dispatch-sync [:rf.xray.data-display/toggle-node panel-id mount-id path true])
+    (is (= false (get-in @(rf/subscribe [dd/expansion-slot]) [k :expanded?])))
+    ;; Second click — the rendered? slot is now `false` (override is
+    ;; false) but the reducer flips the OVERRIDE, not the payload.
+    (rf/dispatch-sync [:rf.xray.data-display/toggle-node panel-id mount-id path false])
+    (is (= true (get-in @(rf/subscribe [dd/expansion-slot]) [k :expanded?]))
+        "second click inverts stored override → true")
+    ;; Third click flips again.
+    (rf/dispatch-sync [:rf.xray.data-display/toggle-node panel-id mount-id path true])
+    (is (= false (get-in @(rf/subscribe [dd/expansion-slot]) [k :expanded?]))
+        "third click inverts stored override → false")
+    (rf/dispatch-sync [:rf.xray.data-display/reset-expansion])))


### PR DESCRIPTION
## Mission

Fix rf2-y59tb (P1 BUG): Xray data-display click-toggle broken — frame leak (Bug A) + first-click logic (Bug B).

Bead: rf2-y59tb. Both bugs were diagnosed live in a pair-debug session 2026-05-25 against the running step-deck testbed.

## Bug A — Frame leak via missing `reg-view`

`data-display` was a plain `defn`, so click-handler dispatches did NOT carry the surrounding frame from React context. When the App-DB panel mounted the widget under `:rf/xray`, toggle events routed to `:rf/default` — the expansion-slot mutation landed in the wrong frame's app-db and the rendering sub (running in `:rf/xray`'s reactive context) never saw it. Same root-cause class as `ribbon-theme-toggle` (rf2-uu3lp).

**Fix:** register `data-display` via `rf/reg-view`. The macro makes the component `:contextType frame-context`-aware so dispatch + subscribe resolve to whatever frame the enclosing `frame-provider` puts in scope. The lexical `dispatch` injected by `reg-view` is captured at mount time and threaded through `render-node` opts as `:dispatch-fn`, so toggle callbacks deep in the recursion carry the surrounding frame even when fired long after render unwinds.

The `{:frame :rf/xray}` envelope previously hard-coded in `on-toggle` is gone — the frame is captured by `reg-view` at mount, so the widget works correctly under any frame (`:rf/xray` for Xray panels, `:rf/default` for the standalone testbed, any other frame a downstream caller mounts under).

Call-site shape unchanged: `[dd/data-display value opts]` continues to work because `reg-view` defs the symbol to `(rf/view :id)` (the registered render fn).

## Bug B — First-click logic wrong for default-expanded paths

The toggle reducer's "no override → first click opens" branch stored `:expanded? true` on the first click — but default-expanded paths (top-level triangles at depth ≤ default-expanded-depth) already render expanded BEFORE any click. The first click stored the same value the path already had: a silent no-op from the operator's view. The second click then correctly inverted to collapsed; the operator saw "first click does nothing; second click works".

**Fix:** the dispatch payload now carries the current rendered-expanded? state — the value `resolve-expanded?` returned for this path on the current render (the renderer knows it; the click handler is in the same `let` scope). The reducer, when no override exists, inverts from the rendered state. With an override stored the reducer inverts the stored override (clicks 2+).

Path **(a)** of the bead's three options: dispatch carries the context the click handler already has — the renderer just emitted the triangle, so it knows the visible state. Cleanest of the three; reducer stays simple (pure inversion); no need to re-derive default-expanded? at dispatch time.

## Decision summary

- **Bug A** — `reg-view`-registration of `data-display` itself. Preferred over the alternative explicit-frame-capture-in-plain-fn path because it aligns with how every other shared widget in `views/` handles the same concern (see `ribbon-theme-toggle`, `mode-pill`, `frame-switcher-view`, etc.), it removes the `{:frame :rf/xray}` hardcode (so the widget works under any frame), and the subscribe (`@(rf/subscribe [expansion-slot])`) inherits the same frame for free.
- **Bug B** — Path (a): dispatch carries `rendered-expanded?` alongside `[panel-id mount-id path]`. The click event already has full context at the emit site; reducer just inverts whatever was sent.

## Test coverage added

4 new regression tests + 2 existing tests updated:

- `data-display-is-reg-view-registered` — registry lookup asserts the public widget is `reg-view`-installed (Bug A presence check).
- `data-display-toggle-dispatches-to-mount-frame` — confirms the toggle handler calls the threaded `:dispatch-fn` (the reg-view-injected closure) rather than the global `rf/dispatch` (Bug A behavioural check).
- `first-click-collapses-default-expanded-path` — Bug B regression: rendered? true → stored false.
- `first-click-expands-default-collapsed-path` — symmetric: rendered? false → stored true.
- `second-click-inverts-stored-override` — once an override is stored the reducer inverts it regardless of the payload's rendered? slot.

Updated `toggle-event-flips-expansion-state` and `toggle-handler-dispatches-canonical-event` to match the new 5-slot dispatch payload.

## Spec update

`tools/xray/spec/021-Dynamic-Panel-Designs.md` §10.0.2 #4 — documents the reg-view registration + the rendered-expanded? payload slot. No other spec touched.

## Gates run

- `cd implementation && npm run test:cljs` → 4502 tests, 14287 assertions, 0 failures, 0 errors.
- `cd implementation && npm run test:browser` → 124 tests, 346 assertions, 0 failures, 0 errors.
- `cd tools/xray && clojure -M:test` → 859 tests, 3067 assertions, 0 failures, 0 errors.
- `clj-kondo --lint tools/xray/src tools/xray/test` → 0 errors (warnings are pre-existing, none in changed files).

## Files changed

- `tools/xray/src/day8/re_frame2_xray/views/data_display.cljs` — reducer signature, on-toggle signature, render-container threading, render-node threading, data-display via reg-view.
- `tools/xray/test/day8/re_frame2_xray/views/data_display_cljs_test.cljs` — updated 2 tests + 4 new regression tests.
- `tools/xray/spec/021-Dynamic-Panel-Designs.md` — §10.0.2 #4 updated.

Closes rf2-y59tb.