### PR TITLE
docs(examples): drop stale spec.cjs references in nine_states + websocket READMEs (rf2-u5mzf + rf2-0x8ss)

### DIFF
--- a/examples/reagent/nine_states/README.md
+++ b/examples/reagent/nine_states/README.md
@@ -100,7 +100,7 @@ The example is wired into the canonical examples harness. From `implementation/`
 npm run test:examples
 ```
 
-That compiles every example (this one builds under shadow-cljs id `examples/nine-states`), stages its `index.html` into `out/examples/nine-states/`, serves the lot, and runs the Playwright smoke spec at [`nine_states.spec.cjs`](nine_states.spec.cjs).
+That compiles every example (this one builds under shadow-cljs id `examples/nine-states`), stages its `index.html` into `out/examples/nine-states/`, and serves the lot.
 
 To iterate on the source alone, watch the build directly from `implementation/`:
 

--- a/examples/reagent/websocket/README.md
+++ b/examples/reagent/websocket/README.md
@@ -25,7 +25,6 @@
 | `views.cljs` | UI — status pill driven by tags, lifecycle buttons, send form, request/subscribe/server-push demo trio, inbox. |
 | `schema.cljs` | Malli schemas for the connection-machine snapshot, the `:data` slice, and the `[:messages]` slice. |
 | `index.html` | Minimal harness. |
-| `websocket.spec.cjs` | Playwright smoke — drives the connect / request-reply / server-push / drop-and-reconnect path. |
 | `test/websocket/connection_test.cljs` | Headless tests: initial state, happy-path lifecycle, offline-queue + drain, reconnect cascade, max-retries → `:failed`, connection-epoch staleness, `:ws/refresh-token`, clean `:ws/disconnect`. |
 | `test/websocket/messages_test.cljs` | Headless tests: request-reply correlation, server-push routing, subscription tracking, `[:messages :received]` newest-first invariant. |
 
@@ -58,7 +57,7 @@ The example is wired into the canonical examples harness. From `implementation/`
 npm run test:examples
 ```
 
-That compiles every example (this one builds under shadow-cljs id `examples/websocket`), stages its `index.html` into `out/examples/websocket/`, serves the lot on port 8030, and runs [`websocket.spec.cjs`](websocket.spec.cjs) against it.
+That compiles every example (this one builds under shadow-cljs id `examples/websocket`), stages its `index.html` into `out/examples/websocket/`, and serves the lot on port 8030.
 
 To iterate on the source alone, watch the build directly from `implementation/`:
 


### PR DESCRIPTION
Closes rf2-u5mzf and rf2-0x8ss — both example READMEs linked to per-example `.spec.cjs` files that no longer exist. The `examples/` tree was locked test-free under rf2-8cevm (Mike directive 2026-05-19); smoke coverage is exactly one per-adapter spec at `implementation/adapters/<name>/testbed/spec.cjs`.

## Decision: option (b) — drop the testing detail, no replacement link

The dispatch brief offered two options:
- (a) point at the per-adapter Reagent smoke (`implementation/adapters/reagent/testbed/spec.cjs`)
- (b) trim the testing clause; the detail belongs in the framework docs

Went with (b). Per-example READMEs should describe what the example demonstrates, not where its tests live. The test-free policy + per-adapter smoke story is already documented authoritatively in `examples/README.md`; duplicating it (let alone half-duplicating it) per example would be noise. Pre-alpha posture: keep READMEs focused.

## Changes

- `examples/reagent/nine_states/README.md` (rf2-u5mzf): trim L103's trailing `runs the Playwright smoke spec at [`nine_states.spec.cjs`](nine_states.spec.cjs)` clause; sentence now ends after `serves the lot`.
- `examples/reagent/websocket/README.md` (rf2-0x8ss): drop the file-layout table row for `websocket.spec.cjs` (L28) **and** trim L61's `runs [`websocket.spec.cjs`](websocket.spec.cjs) against it` clause; sentence now ends after `serves the lot on port 8030`.

## Gates

- `python scripts/check_doc_slugs.py --verbose` — pass (376 markdown files; no broken links)
- `mkdocs build --strict` — pass (exit 0; INFOs only, all pre-existing and unrelated)
- Negative gate: `git grep -n '\.spec\.cjs' examples/reagent/nine_states examples/reagent/websocket` — zero matches

## Out of scope

Other example READMEs (`boot/`, `counter_slim_and_fast/`, `long_running_work/`, `7Guis/`, `ssr/`) also reference `.spec.cjs` paths in varying degrees; those are not in scope for these two beads and may warrant their own follow-up sweep.