### PR TITLE
feat(xray): wire data-display popup into shell + per-panel open-in-popup affordances (rf2-l4625)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1600,10 +1600,76 @@ for inline opens (a panel that wants to control the popup
 imperatively from its own view tree). Both compose through
 `popup-chrome` so the chrome shape is identical.
 
-Wire-up follow-on: mounting `data-display-popup-stack` into the
-shell's overlay container is a follow-on bead that touches
-`mount.cljs` + `registry.cljs`; the install! fn here is
-idempotent so that wire-up is a one-call addition.
+##### §10.0.7.1 Shell mount (rf2-l4625)
+
+The `data-display-popup-stack` view mounts **once** at the Xray
+shell root, alongside the other modal stacks (palette, settings,
+segment-inspector, …). The stack view reads
+`:rf.xray.data-display-popup/stack` + `:rf.xray.data-display-popup/entries`
+and renders the popup chrome for every active mount-id in z-index
+order; it short-circuits to `nil` when the stack is empty (closed-
+state cost: one subscribe + a `when`-gate).
+
+Registration is a single line in `registry.cljs`:
+
+```clj
+(data-display-popup/install!)
+```
+
+…idempotent per the orchestrator's `compare-and-set!` sentinel.
+The shell-side mount sits alongside `[app-db-segment-inspector/Popup]`
+in `shell.cljs`'s overlay block, INSIDE the `rf/frame-provider
+{:frame :rf/xray}` wrapper so subscribes resolve to Xray's frame.
+
+##### §10.0.7.2 Per-panel "open in popup" affordance (rf2-l4625)
+
+Each `[dd/data-display value opts]` call site **opts in** to a
+top-right ⊕ icon button by passing `:popup-affordance? true` in
+`opts`. Default is **off** — scalar / tiny-value mounts don't
+benefit from a larger inspection surface, and the silent default
+keeps simple call sites quiet.
+
+Mechanics:
+
+- The affordance renders a `:button` positioned absolutely at
+  the top-right of the data-display widget's outer container
+  (the container gets `position: relative` when the affordance
+  is enabled).
+- Click dispatches
+  `[:rf.xray.data-display-popup/open popup-mount-id {:value v :opts o}]`
+  through the lexically-captured frame-aware dispatcher (so the
+  event lands on the surrounding `:rf/xray` frame, matching
+  every other Xray dispatch).
+- `popup-mount-id` is derived from the data-display's own
+  mount-id (`"ddp-" + mount-id`) — stable per call-site mount,
+  so re-clicking the affordance **raises** the existing popup
+  rather than spawning a duplicate (matches
+  `data-display-popup/push-entry` window-manager semantics).
+- The opts forwarded to the popup carry
+  `:popup-affordance? false` so the popup's embedded
+  data-display does not recurse the affordance inside itself.
+
+Stable testid: `"rf-xray-data-display-popup-affordance-" +
+popup-mount-id`. The button carries
+`:data-rf-affordance "popup"` for hover-style hooks +
+`:aria-label "Open in popup"` for assistive tech.
+
+Initial enabled call sites (panels where the inline widget is
+genuinely cramped):
+
+| Panel                                  | Site                                              | Rationale                                                                            |
+|----------------------------------------|---------------------------------------------------|--------------------------------------------------------------------------------------|
+| `panels/app_db_diff_state.cljs`        | `value-body` (whole user-domain + reserved areas) | App-DB whole-tree is the canonical cramped-in-side-panel case                        |
+| `panels/machine_canvas.cljs`           | snapshot drill-in                                 | Machine snapshots carry deeply-nested `:data` maps                                   |
+| `panels/machine_inspector.cljs`        | per-phase snapshot block                          | Same as canvas — per-machine `:data` maps                                            |
+| `panels/reactive_panel_view.cljs`      | per-sub value row                                 | Sub values can be the full domain projection (cart, users, route tree, …)            |
+| `panels/trace.cljs`                    | per-row payload expand                            | Trace rows expand within the row's narrow column; tags + payload maps are cramped    |
+
+Diff renderers' internal `inspect-value` leaves (`diff/render.cljs`,
+`diff/hiccup_render.cljs`) intentionally **do not** carry the
+affordance — they're inner mini-renderers inside a larger diff tree
+chrome, not user-facing leaf inspect mounts; an inline ⊕ per inner
+leaf would clutter the diff display.
 
 #### §10.0.8 Diff mode (phase 5 · D5=a · rf2-q3dzw)
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs
@@ -142,12 +142,17 @@
       [dd/data-display
        (f/display-value value)
        {:panel-id :rf.xray/app-db
-        :default-expanded-depth 3}]
+        :default-expanded-depth 3
+        ;; rf2-l4625 — the App-DB whole-tree is the canonical "cramped
+        ;; in the side panel" case; the popup gives the operator a
+        ;; full-modal inspection surface for deeply-nested state.
+        :popup-affordance? true}]
       [dd/data-display
        (f/display-value value)
        {:panel-id :rf.xray/app-db
         :default-expanded-depth 3
-        :before (f/display-value before)}])))
+        :before (f/display-value before)
+        :popup-affordance? true}])))
 
 ;; ---- top (user-domain) section ------------------------------------------
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_canvas.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_canvas.cljs
@@ -421,7 +421,11 @@
       "(no snapshot — machine uninitialised or trace pre-snapshot-tagging)"]
      [dd/data-display snapshot
       {:panel-id (snapshot-panel-id machine-id phase)
-       :default-expanded-depth 2}])])
+       :default-expanded-depth 2
+       ;; rf2-l4625 — machine snapshots routinely carry deeply-nested
+       ;; `:data` maps; the popup gives the operator a full-modal
+       ;; inspection surface.
+       :popup-affordance? true}])])
 
 ;; ---- install ------------------------------------------------------------
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
@@ -344,7 +344,11 @@
       label]
      [dd/data-display snapshot
       {:panel-id (snapshot-panel-id machine-id phase)
-       :default-expanded-depth 2}]]))
+       :default-expanded-depth 2
+       ;; rf2-l4625 — machine snapshots routinely carry deeply-nested
+       ;; `:data` maps; the popup gives the operator a full-modal
+       ;; inspection surface alongside the per-machine drill-in.
+       :popup-affordance? true}]]))
 
 (defn- snapshot-drill-in
   "Snapshot drill-in section beneath the focused-event chart. Renders

--- a/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_view.cljs
@@ -486,7 +486,13 @@
        [:div {:data-testid (str row-testid "-value")
               :style {:padding-left "4px"}}
         [dd/data-display value {:panel-id (sub-value-panel-id sub-id)
-                                :default-expanded-depth 2}]]
+                                :default-expanded-depth 2
+                                ;; rf2-l4625 — sub values can be the
+                                ;; full domain projection (cart, users,
+                                ;; route tree, …); the popup gives the
+                                ;; operator a full-modal inspection
+                                ;; surface for cramped values.
+                                :popup-affordance? true}]]
        [:div {:data-testid (str row-testid "-no-value")
               :style {:padding-left "4px"
                       :color (:text-tertiary tokens)

--- a/tools/xray/src/day8/re_frame2_xray/panels/trace.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/trace.cljs
@@ -130,7 +130,11 @@
                        :border-radius "0 0 4px 4px"}}
    [dd/data-display raw
     {:panel-id (keyword "rf.xray.trace" (str "row-" id))
-     :default-expanded-depth 1}]])
+     :default-expanded-depth 1
+     ;; rf2-l4625 — trace rows expand within the row's narrow column;
+     ;; tags + payload maps are routinely cramped. Popup gives the
+     ;; operator a full-modal inspection surface.
+     :popup-affordance? true}]])
 
 ;; ---- per-path db-changed diff rows (spec/023 §APP-DB CHANGES) -----------
 ;;

--- a/tools/xray/src/day8/re_frame2_xray/registry.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/registry.cljs
@@ -41,6 +41,16 @@
             ;; (rf2-q3dzw phase 5; legacy `data-display.render` +
             ;; `theme.data-inspector` ns'es are deleted).
             [day8.re-frame2-xray.views.data-display]
+            ;; rf2-l4625 — popup overlay infra. `install!` registers
+            ;; the stack/entries subs + open/close/close-top/close-all
+            ;; events at orchestrator-load time. The stack VIEW mount
+            ;; lives in `shell.cljs`; per-panel "open in popup"
+            ;; affordances flow through `[dd/data-display value
+            ;; {:popup-affordance? true …}]` and dispatch
+            ;; `:rf.xray.data-display-popup/open` against the surrounding
+            ;; `:rf/xray` frame.
+            [day8.re-frame2-xray.views.data-display-popup
+             :as data-display-popup]
             [day8.re-frame2-xray.defaults :as defaults]
             [day8.re-frame2-xray.epoch :as epoch]
             [day8.re-frame2-xray.filters :as filters]
@@ -596,6 +606,13 @@
     (open-in-editor/install!)
     (palette/install!)
     (settings-popup/install!)
+    ;; rf2-l4625 — data-display popup overlay (subs + events). The
+    ;; stack view is mounted in `shell.cljs` alongside the other modal
+    ;; mounts; per-panel "open in popup" affordances pass through
+    ;; `[dd/data-display value {:popup-affordance? true …}]` and
+    ;; dispatch the `:rf.xray.data-display-popup/open` event registered
+    ;; here.
+    (data-display-popup/install!)
     ;; Filters install AFTER `:rf.xray/active-filters` + the
     ;; add-filter / remove-filter events above are registered (the
     ;; filters facade adds `:rf.xray/filtered-cascades` + the edit-

--- a/tools/xray/src/day8/re_frame2_xray/shell.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/shell.cljs
@@ -129,6 +129,8 @@
             [day8.re-frame2-xray.resize-handle :as resize-handle]
             [day8.re-frame2-xray.settings.popup :as settings-popup]
             [day8.re-frame2-xray.share-modal :as share-modal]
+            [day8.re-frame2-xray.views.data-display-popup
+             :as data-display-popup]
             [day8.re-frame2-xray.spine-filters :as spine-filters]
             [day8.re-frame2-xray.static.mode-pill :as mode-pill]
             [day8.re-frame2-xray.static.shell :as static-shell]
@@ -2376,4 +2378,12 @@
     ;; popup's subscribes resolve through the shell's `:rf/xray`
     ;; frame-provider; closed-state cost is one subscribe + a when-
     ;; gate.
-    [app-db-segment-inspector/Popup]]]))
+    [app-db-segment-inspector/Popup]
+    ;; Data-display popup stack (rf2-l4625) — overlay surface for the
+    ;; "open in popup" affordance on per-panel `[dd/data-display]`
+    ;; mounts. Reads `:rf.xray.data-display-popup/stack` + `/entries`;
+    ;; renders nothing when the stack is empty (closed-state cost is
+    ;; one subscribe + a when-gate). Mount discipline matches the
+    ;; other modal stacks: shell-root mount so the stack's subscribes
+    ;; resolve through the shell's `:rf/xray` frame-provider.
+    [data-display-popup/data-display-popup-stack]]]))

--- a/tools/xray/src/day8/re_frame2_xray/views/data_display.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/data_display.cljs
@@ -55,6 +55,18 @@
                     inline `← changed from <prior>` annotation;
                     ancestors of any changed descendant force open
                     regardless of the default-expand heuristic.
+  - `:popup-affordance?` (optional, default false) — rf2-l4625; when
+                    true the widget renders a top-right ⊕ icon button
+                    that dispatches
+                    `[:rf.xray.data-display-popup/open mount-id payload]`
+                    (the open event registered by
+                    `views.data-display-popup/install-events!`). The
+                    popup-mount-id is derived from this widget's own
+                    mount-id, so re-clicking raises the existing popup
+                    rather than spawning a duplicate. Opt-in per
+                    call-site; panels enable the affordance where the
+                    inline widget is genuinely cramped (App-DB whole-
+                    tree, machine snapshots, sub values).
 
   Drop the `:render-id` arg from the old facade — mount-id is now
   auto-generated internally per D4=a (rf2-sndui).
@@ -1157,6 +1169,80 @@
   []
   (str (random-uuid)))
 
+;; =========================================================================
+;; popup affordance — opt-in "open in popup" control (rf2-l4625)
+;; =========================================================================
+;;
+;; When a `[data-display value opts]` call site passes
+;; `:popup-affordance? true` in `opts`, the widget renders a small icon
+;; button positioned at the top-right of the container. Click dispatches
+;; the popup's `:open` event with a stable popup-mount-id derived from
+;; the data-display's own mount-id — so re-clicking just raises the
+;; existing popup (window-manager "raise" semantics matching
+;; `data-display-popup/push-entry`).
+;;
+;; Opt-in (not always-on): scalar / tiny-value mounts don't benefit from
+;; a larger inspection surface. Panels enable the affordance where the
+;; inline widget is genuinely cramped (App-DB whole-tree, machine
+;; snapshots, sub values). Default off keeps simple call sites quiet.
+;;
+;; The affordance dispatches the OPEN event id literally — no `require`
+;; on the popup ns from here, which would form a cycle (the popup ns
+;; requires data-display). The event id keyword is the public contract.
+
+(def ^:private popup-affordance-button-style
+  {:position      "absolute"
+   :top           "2px"
+   :right         "2px"
+   :background    "transparent"
+   :border        "none"
+   :color         (:text-tertiary tokens)
+   :font-size     "12px"
+   :line-height   1
+   :cursor        "pointer"
+   :padding       "2px 6px"
+   :border-radius "3px"
+   ;; Subtle by default — hover bumps colour up to text-secondary via
+   ;; the data-rf-affordance="popup" hook in the global stylesheet
+   ;; (theme/global-styles.cljs reads the attribute selector). Keeping
+   ;; the colour change off the inline style avoids paint thrash on
+   ;; every render.
+   :opacity       0.6})
+
+(defn popup-affordance-button
+  "Render the 'open in popup' icon button. `dispatch-fn` is the
+  lexically-captured frame-aware dispatcher; `popup-mount-id` is the
+  stable id keyed to the data-display's own mount-id; `value` + `opts`
+  are the popup's payload.
+
+  Public so unit tests can drive the button without spinning up the
+  router (pass a stub `dispatch-fn` that captures the event vector)."
+  [dispatch-fn popup-mount-id value opts]
+  [:button
+   {:data-testid             (str "rf-xray-data-display-popup-affordance-"
+                                  popup-mount-id)
+    :data-rf-affordance      "popup"
+    :data-rf-popup-mount-id  popup-mount-id
+    :aria-label              "Open in popup"
+    :title                   "Open in popup"
+    :on-click                (fn [^js e]
+                               (when e
+                                 (.preventDefault e)
+                                 (.stopPropagation e))
+                               (dispatch-fn
+                                 [:rf.xray.data-display-popup/open
+                                  popup-mount-id
+                                  {:value value
+                                   :opts  (-> (or opts {})
+                                              ;; Don't recurse the
+                                              ;; affordance inside the
+                                              ;; popup's embedded
+                                              ;; data-display.
+                                              (assoc :popup-affordance? false))}]))
+    :style                   popup-affordance-button-style}
+   ;; ⊕ glyph reads as "open" without the language baggage of e.g. 🔍
+   "⊕"])
+
 (rf/reg-view data-display
   "First-class data-display widget — single source of truth for
   browse + diff + mini.
@@ -1226,25 +1312,39 @@
       [value & rest-args]
       (let [opts          (first rest-args)
             {:keys [panel-id default-expanded-depth max-inline-width
-                    max-depth before]
+                    max-depth before popup-affordance?]
              :or   {panel-id :rf.xray.data-display/anon
                     default-expanded-depth 2
                     max-inline-width 60
-                    max-depth 16}} opts
+                    max-depth 16
+                    popup-affordance? false}} opts
             diff?         (contains? opts :before)
             ;; `subscribe` is the lexical frame-aware closure
             ;; injected by `reg-view` — reads the expansion-slot
             ;; from the surrounding frame's app-db (e.g. `:rf/xray`).
             expansion-map @(subscribe [expansion-slot])
             container-id  (str "rf-xray-data-display-"
-                               (name panel-id) "-" mount-id)]
+                               (name panel-id) "-" mount-id)
+            ;; Stable popup-mount-id derived from THIS data-display's
+            ;; own mount-id so re-clicking the affordance "raises" the
+            ;; existing popup rather than spawning a duplicate
+            ;; (matches `data-display-popup/push-entry` semantics).
+            popup-mount-id (str "ddp-" mount-id)]
         [:div {:data-testid     container-id
                :data-rf-mount-id mount-id
                :data-rf-mode    (if diff? "diff" "browse")
+               :data-rf-popup-affordance? (when popup-affordance? "1")
                :style {:font-family mono-stack
                        :font-size   "12px"
                        :color       (:text-primary tokens)
-                       :line-height 1.4}}
+                       :line-height 1.4
+                       ;; Position context for the absolute-positioned
+                       ;; affordance button. Harmless when the
+                       ;; affordance is off — no descendant uses
+                       ;; absolute positioning otherwise.
+                       :position    (when popup-affordance? "relative")}}
+         (when popup-affordance?
+           (popup-affordance-button dispatch-fn popup-mount-id value opts))
          (render-node {:value value
                        :before (if diff? before ::missing)
                        :diff? diff?

--- a/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_state_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_state_cljs_test.cljs
@@ -311,3 +311,35 @@
       (is (every? #(not (contains? (:opts %) :before)) mounts)
           "no mount carries a `:before` opt — no diff annotation
            without a pre-image"))))
+
+;; ---- popup affordance (rf2-l4625) ---------------------------------------
+;;
+;; The App-DB tab is the canonical cramped-in-side-panel inspection
+;; surface; every data-display mount carries `:popup-affordance? true`
+;; so the operator can pop the whole tree into the modal popup overlay.
+;; These tests assert the opt rides every mount the value-body produces.
+
+(deftest data-display-mounts-carry-popup-affordance-opt
+  (testing "rf2-l4625 — every `[dd/data-display ...]` mount the App-DB
+            panel produces carries `:popup-affordance? true` so the
+            operator can open the value in the popup overlay"
+    (let [model  (h/current-state-sections
+                   {:counter 2 :rf/route {:id :home}
+                    :rf/machines {:auth {:state :idle}}})
+          tree   (state/state-body model)
+          mounts (find-data-display-mounts tree)]
+      (is (seq mounts) "the panel mounts data-display widget instances")
+      (is (every? #(true? (:popup-affordance? (:opts %))) mounts)
+          "every mount opts in to the popup affordance"))))
+
+(deftest diff-mode-mounts-also-carry-popup-affordance-opt
+  (testing "rf2-l4625 — DIFF-mode mounts (when a pre-image is supplied)
+            ALSO carry the popup affordance opt; the operator can pop
+            either current-state OR diff trees"
+    (let [model  (h/current-state-sections {:counter 2} {:counter 1})
+          tree   (state/state-body model)
+          mounts (find-data-display-mounts tree)
+          diff-mts (filter #(contains? (:opts %) :before) mounts)]
+      (is (seq diff-mts) "diff-mode mounts present")
+      (is (every? #(true? (:popup-affordance? (:opts %))) diff-mts)
+          "diff-mode mounts also opt in to the popup affordance"))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_canvas_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_canvas_cljs_test.cljs
@@ -188,3 +188,41 @@
         (is (= "false" (:data-has-snapshot (second host))))
         (is (some? empty)
             "empty-state chip mounts when snapshot is nil")))))
+
+;; ---- (5) popup affordance (rf2-l4625) ----------------------------------
+;;
+;; Machine snapshots routinely carry deeply-nested `:data` maps; the
+;; popup gives the operator a full-modal inspection surface alongside
+;; the per-machine drill-in. The canvas-side SnapshotDrillIn mount
+;; passes `:popup-affordance? true` through to `[dd/data-display]`.
+
+(defn- find-data-display-mounts
+  "Walk hiccup, collect every `[fn ...]` mount whose 3rd-arg looks like
+  a data-display opts map. Returns `{:value :opts}` maps."
+  [tree]
+  (let [out (atom [])]
+    (letfn [(walk [n]
+              (cond
+                (vector? n)
+                (do (when (and (fn? (first n)) (>= (count n) 3)
+                               (map? (nth n 2))
+                               (contains? (nth n 2) :panel-id))
+                      (swap! out conj {:value (nth n 1) :opts (nth n 2)}))
+                    (doseq [c (rest n)] (walk c)))
+                (seq? n) (doseq [c n] (walk c))))]
+      (walk tree))
+    @out))
+
+(deftest snapshot-drill-in-data-display-carries-popup-affordance
+  (testing "rf2-l4625 — the canvas-side SnapshotDrillIn passes
+            `:popup-affordance? true` to the embedded data-display so
+            the operator can pop the snapshot into the popup overlay"
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (let [snapshot {:state :authing :data {:user "alice" :retries 1}}
+            tree     (mc/SnapshotDrillIn {:machine-id :auth/login
+                                          :snapshot   snapshot})
+            mounts   (find-data-display-mounts tree)]
+        (is (seq mounts) "data-display widget mounted")
+        (is (every? #(true? (:popup-affordance? (:opts %))) mounts)
+            "every mount opts in to the popup affordance")))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_view_cljs_test.cljs
@@ -587,6 +587,47 @@
         (is (= "after" (:data-phase (second after)))
             "AFTER block carries the :after phase tag")))))
 
+(defn- find-popup-affordance-containers
+  "Walk hiccup (already expand-tree'd by the find-by-testid helper) and
+  collect every data-display container that carries
+  `:data-rf-popup-affordance? \"1\"` (the widget surfaces the opt as a
+  data-attr on its outer `:div`)."
+  [tree]
+  (filter (fn [n]
+            (and (vector? n) (map? (second n))
+                 (= "1" (:data-rf-popup-affordance? (second n)))))
+          (tree-seq (some-fn vector? seq?) seq tree)))
+
+(deftest snapshot-drill-in-data-display-carries-popup-affordance
+  (testing "rf2-l4625 — every snapshot drill-in data-display mount in
+            the Machine Inspector panel passes
+            `:popup-affordance? true` so the operator can pop the
+            snapshot into the popup overlay. After expansion the widget's
+            outer `:div` surfaces the opt as a `data-rf-popup-affordance?`
+            attribute."
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (override-machines!    [:auth/login])
+      (override-definitions! {:auth/login fixture-definition})
+      (override-epoch-history!
+        [{:epoch-id 1
+          :trace-events
+          [{:id 1 :time 10 :operation :rf.machine/transition
+            :tags {:machine-id :auth/login
+                   :before     {:state :idle
+                                :data  {:user nil :retries 0}}
+                   :after      {:state :authing
+                                :data  {:user "alice" :retries 1}}
+                   :event      [:auth/submit] :rf.trace/dispatch-id "d-1"}}]}])
+      (focus-epoch! 1)
+      (let [tree       (machine-inspector/Panel)
+            drill      (find-by-testid tree "rf-xray-machine-snapshot-drill-in")
+            containers (find-popup-affordance-containers drill)]
+        (is (some? drill) "drill-in section mounts")
+        (is (seq containers)
+            "drill-in surfaces the popup-affordance attr on its
+             data-display containers")))))
+
 (deftest snapshot-drill-in-suppressed-when-legacy-trace-lacks-snapshots
   (testing "legacy trace fixtures that pre-date the commit-or-finalize
             snapshot pair (only `:from`/`:to` keys, no `:before`/`:after`

--- a/tools/xray/test/day8/re_frame2_xray/panels/reactive_panel_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/reactive_panel_view_cljs_test.cljs
@@ -466,6 +466,26 @@
           "panel-id is namespaced under :rf.xray.reactive-sub-value")
       (is (= "rf.xray.reactive-sub-value" (namespace pid-b))))))
 
+(deftest sub-values-row-data-display-carries-popup-affordance
+  (testing "rf2-l4625 — each sub-value row's data-display mount carries
+            `:popup-affordance? true` so the operator can pop a sub's
+            value into the popup overlay (sub values are commonly the
+            full domain projection — cart, route tree, …)"
+    (facade/install!)
+    (frame/reg-frame :rf/xray {})
+    (seed-reactive-data!
+      {:has-cascade? true :frame :rf/app :focus {:current :ep-1}
+       :counts {} :level-1-subs [] :level-2-subs [] :view-rows []
+       :sub-values [{:sub-id :cart/state :slug "_cart_state"
+                     :changed? true :has-value? true
+                     :value {:items [1 2 3]}}]})
+    (let [tree (view/reactive-panel)
+          dd   (raw-find-dd-mount
+                 tree "rf-xray-reactive-sub-value-row-_cart_state-value")
+          opts (nth dd 2 nil)]
+      (is (true? (:popup-affordance? opts))
+          "row mount opts in to the popup affordance"))))
+
 (deftest sub-values-row-no-value-renders-placeholder
   (testing "rf2-e46qs — a sub-run without a `:value` key (redaction /
             pre-attribution) renders the muted no-value placeholder; no

--- a/tools/xray/test/day8/re_frame2_xray/panels/trace_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/trace_view_cljs_test.cljs
@@ -637,6 +637,38 @@
         (is (not= (first row-41-hits) (first row-42-hits))
             "the two rows mount distinct data-display containers")))))
 
+(deftest expanded-row-data-display-carries-popup-affordance
+  (testing "rf2-l4625 — the expanded-row payload mount passes
+            `:popup-affordance? true` to the data-display widget so
+            the operator can pop a trace event's full EDN into the
+            popup overlay (trace rows are narrow column space). After
+            `expand-tree` the data-display widget's outer `:div` carries
+            `:data-rf-popup-affordance? \"1\"` when the opt is set."
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (seed-history!
+        [(mk-epoch 1 1
+                   [(mk-trace {:id 51 :op-type :rf.event
+                               :operation :rf.event/dispatched
+                               :dispatch-id 1 :source :ui :origin :app})])])
+      (focus! 1)
+      (rf/dispatch-sync [:rf.xray/toggle-trace-row-expand 51])
+      (let [tree     (trace/Panel)
+            payload  (find-by-testid tree "rf-xray-trace-row-51-payload")
+            ;; Walk the payload subtree (which is itself the result of
+            ;; `expand-tree`-ing) and find the data-display widget's
+            ;; outer container — it carries the `data-rf-popup-affordance?`
+            ;; attribute when the opt is enabled.
+            dd-containers
+            (filter (fn [n]
+                      (and (vector? n) (map? (second n))
+                           (= "1" (:data-rf-popup-affordance?
+                                    (second n)))))
+                    (hiccup-seq payload))]
+        (is (some? payload) "expanded-row payload renders")
+        (is (seq dd-containers)
+            "data-display container surfaces the popup-affordance attr")))))
+
 (deftest source-coord-click-fires-open-in-editor
   (testing "clicking the source-coord ↗ fires :rf.xray/open-in-editor;
             stopPropagation prevents the row's expand-toggle from firing"

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -125,6 +125,13 @@
    ;; deleted with the legacy `data-display.render` +
    ;; `theme.data-inspector` engines.
    :rf.xray.data-display/expansion
+   ;; rf2-l4625 — data-display popup overlay subs (stack + entries +
+   ;; projection subs for open? / top / per-mount-id entry).
+   :rf.xray.data-display-popup/stack
+   :rf.xray.data-display-popup/entries
+   :rf.xray.data-display-popup/open?
+   :rf.xray.data-display-popup/top
+   :rf.xray.data-display-popup/entry
    ;; rf2-59e7k — Cancellation-cascade visualiser subs (Machines
    ;; tab side-panel + Trace popover). Per
    ;; `tools/xray/spec/019-Cross-Cutting-Insight.md` §M.3.
@@ -397,6 +404,12 @@
    :rf.xray.data-display/reset-expansion
    :rf.xray.data-display/set-node
    :rf.xray.data-display/toggle-node
+   ;; rf2-l4625 — data-display popup overlay events (open / close /
+   ;; close-top / close-all).
+   :rf.xray.data-display-popup/open
+   :rf.xray.data-display-popup/close
+   :rf.xray.data-display-popup/close-top
+   :rf.xray.data-display-popup/close-all
    :rf.xray/delete-edit-popup
    :rf.xray/edit-popup-set-mode
    :rf.xray/edit-popup-set-pattern

--- a/tools/xray/test/day8/re_frame2_xray/views/data_display_popup_wireup_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/data_display_popup_wireup_cljs_test.cljs
@@ -1,0 +1,253 @@
+(ns day8.re-frame2-xray.views.data-display-popup-wireup-cljs-test
+  "Wire-up tests for the data-display popup affordance + shell mount
+  (rf2-l4625, follow-on from phase 6 / rf2-s0x6x).
+
+  ## What's under test
+
+  1. **Widget-level affordance** — when `[dd/data-display value
+     {:popup-affordance? true …}]` is mounted, the rendered hiccup
+     carries a `:button` node with the canonical testid
+     `rf-xray-data-display-popup-affordance-ddp-<mount-id>`. The
+     button's on-click dispatches
+     `[:rf.xray.data-display-popup/open …]` through the supplied
+     dispatch-fn with the widget's value + a sanitised opts map
+     (re-entry into the popup's own data-display does NOT re-enable
+     the affordance).
+  2. **Opt-in default off** — without `:popup-affordance?` (or with
+     `false`) the widget renders NO affordance button.
+  3. **Shell mount** — `data-display-popup-stack` short-circuits to
+     nil when the stack is empty and renders the chrome for every
+     active mount-id when the stack is non-empty.
+  4. **Registry install** — `registry.cljs` calls
+     `data-display-popup/install!` so the open/close events resolve
+     through `rf/dispatch-sync` post-registration.
+
+  Driving the on-click through a captured dispatch-fn stub avoids the
+  router's `next-tick` drain in node-test mode — the affordance's
+  contract is the event vector it dispatches, not the router round-
+  trip (that's already covered by the popup ns's own tests + the
+  registry-wiring test below)."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.test-support :as xray-test-support]
+            [day8.re-frame2-xray.views.data-display :as dd]
+            [day8.re-frame2-xray.views.data-display-popup :as ddp]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn (fn [] (xray-test-support/reset-all!))}))
+
+;; ---- helpers ------------------------------------------------------------
+
+(defn- hiccup-seq [tree]
+  (tree-seq (some-fn vector? seq?) seq tree))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(defn- find-affordance
+  "Walk the hiccup tree and return the first popup-affordance button,
+  or nil."
+  [tree]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= "popup" (:data-rf-affordance (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(defn- invoke-data-display
+  "Form-2 unrolling — call the outer fn, then call the inner fn with
+  the same args to get the rendered hiccup."
+  [value opts]
+  (let [outer (dd/data-display value opts)]
+    (outer value opts)))
+
+;; =========================================================================
+;; widget-level affordance — pure hiccup shape
+;; =========================================================================
+
+(deftest popup-affordance-opt-in-renders-button
+  (testing "rf2-l4625 — `[dd/data-display value {:popup-affordance? true}]`
+            renders a top-right ⊕ button"
+    (let [h (invoke-data-display
+              {:cart [1 2 3]}
+              {:panel-id :rf.xray/app-db :popup-affordance? true})
+          btn (find-affordance h)]
+      (is (some? btn)
+          "affordance button is present in the rendered hiccup")
+      (is (= "Open in popup" (:aria-label (second btn)))
+          "button carries the canonical aria-label")
+      (is (fn? (:on-click (second btn)))
+          "button carries an on-click handler"))))
+
+(deftest popup-affordance-default-off
+  (testing "rf2-l4625 — without `:popup-affordance?` (or with `false`)
+            the widget renders NO affordance button"
+    (let [h-default (invoke-data-display
+                     {:cart [1 2 3]}
+                     {:panel-id :rf.xray/app-db})
+          h-false   (invoke-data-display
+                     {:cart [1 2 3]}
+                     {:panel-id :rf.xray/app-db
+                      :popup-affordance? false})]
+      (is (nil? (find-affordance h-default))
+          "no affordance when opt is absent")
+      (is (nil? (find-affordance h-false))
+          "no affordance when opt is explicitly false"))))
+
+(deftest popup-affordance-button-carries-stable-testid
+  (testing "rf2-l4625 — the button testid includes the per-mount popup
+            id (`ddp-<mount-id>`) so panel-level tests can target it"
+    (let [outer (dd/data-display {:a 1}
+                                 {:panel-id :rf.xray/app-db
+                                  :popup-affordance? true})
+          inner-h (outer {:a 1} {:panel-id :rf.xray/app-db
+                                 :popup-affordance? true})
+          container (second inner-h)
+          mount-id  (:data-rf-mount-id container)
+          expected-testid
+          (str "rf-xray-data-display-popup-affordance-ddp-" mount-id)
+          btn (find-by-testid inner-h expected-testid)]
+      (is (some? mount-id) "container has a mount-id")
+      (is (some? btn) "button found by the expected testid")
+      (is (= (str "ddp-" mount-id)
+             (:data-rf-popup-mount-id (second btn)))
+          "button surfaces the popup-mount-id as a data attr too"))))
+
+(deftest popup-affordance-button-contributes-positioning-context
+  (testing "rf2-l4625 — when the affordance is enabled the outer
+            container carries `position: relative` so the absolute-
+            positioned button anchors correctly"
+    (let [h-on  (invoke-data-display
+                  {:a 1} {:panel-id :rf.xray/app-db
+                          :popup-affordance? true})
+          h-off (invoke-data-display
+                  {:a 1} {:panel-id :rf.xray/app-db})]
+      (is (= "relative" (-> h-on second :style :position))
+          "affordance-on → outer container is position: relative")
+      (is (nil? (-> h-off second :style :position))
+          "affordance-off → no positioning (no descendant uses absolute)"))))
+
+;; =========================================================================
+;; widget-level affordance — on-click dispatch contract via stub
+;; =========================================================================
+
+(deftest popup-affordance-button-onclick-dispatches-canonical-event
+  (testing "rf2-l4625 — clicking the affordance dispatches
+            `[:rf.xray.data-display-popup/open popup-mount-id payload]`
+            through the supplied dispatch-fn"
+    (let [captured (atom nil)
+          stub-dispatch (fn [event-v] (reset! captured event-v))
+          btn (dd/popup-affordance-button
+                stub-dispatch
+                "ddp-abc"
+                {:cart [1 2 3]}
+                {:panel-id :rf.xray/app-db :default-expanded-depth 3
+                 :popup-affordance? true})
+          on-click (:on-click (second btn))]
+      ;; Simulate click — pass nil event so the handler skips the
+      ;; preventDefault/stopPropagation guarded by `(when e …)`.
+      (on-click nil)
+      (let [[event-id mount-id payload] @captured]
+        (is (= :rf.xray.data-display-popup/open event-id)
+            "canonical event id")
+        (is (= "ddp-abc" mount-id)
+            "popup-mount-id flows through as second positional arg")
+        (is (= {:cart [1 2 3]} (:value payload))
+            "value flows through as `:value`")
+        (is (false? (:popup-affordance? (:opts payload)))
+            "the popup's embedded data-display does NOT re-enable the
+             affordance (no recursion)")
+        (is (= :rf.xray/app-db (:panel-id (:opts payload)))
+            "other opts (`:panel-id`, `:default-expanded-depth`) survive")
+        (is (= 3 (:default-expanded-depth (:opts payload))))))))
+
+(deftest popup-affordance-button-onclick-preserves-nil-opts
+  (testing "rf2-l4625 — when the caller supplies no opts, the affordance
+            still produces a sane payload (just `:popup-affordance? false`
+            in the popup's downstream opts map)"
+    (let [captured (atom nil)
+          stub-dispatch (fn [event-v] (reset! captured event-v))
+          btn (dd/popup-affordance-button stub-dispatch "ddp-x"
+                                          {:k :v} nil)
+          on-click (:on-click (second btn))]
+      (on-click nil)
+      (let [payload (nth @captured 2)]
+        (is (= {:k :v} (:value payload)))
+        (is (false? (:popup-affordance? (:opts payload)))
+            "even with nil opts the recursion guard fires")))))
+
+;; =========================================================================
+;; shell mount — `data-display-popup-stack` view
+;; =========================================================================
+
+(defn- setup-xray-frame! []
+  (registry/register-xray-handlers!)
+  (frame/reg-frame :rf/xray {}))
+
+(deftest popup-stack-view-empty-when-stack-empty
+  (setup-xray-frame!)
+  (rf/with-frame :rf/xray
+    (let [tree (ddp/data-display-popup-stack)]
+      (is (nil? tree)
+          "stack view returns nil when no popups are open (closed-state
+           cost is one subscribe + a when-gate)"))))
+
+(deftest popup-stack-view-renders-active-popup
+  (testing "rf2-l4625 — when one popup is open the stack view renders
+            its chrome (backdrop / dialog / body)"
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync
+        [:rf.xray.data-display-popup/open
+         "m1" {:value {:foo :bar}
+               :opts  {:title "Inspect cart"}}])
+      (let [tree (ddp/data-display-popup-stack)]
+        (is (some? tree) "stack view returns hiccup when stack non-empty")
+        (is (some? (find-by-testid tree "rf-xray-data-display-popup-stack"))
+            "outer stack container present")
+        (is (some? (find-by-testid tree
+                                   "rf-xray-data-display-popup-backdrop-m1"))
+            "popup chrome rendered for m1")))))
+
+(deftest popup-stack-view-renders-each-active-mount
+  (testing "rf2-l4625 — every mount-id on the stack gets a chrome"
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray.data-display-popup/open
+                         "m1" {:value 1 :opts {}}])
+      (rf/dispatch-sync [:rf.xray.data-display-popup/open
+                         "m2" {:value 2 :opts {}}])
+      (let [tree (ddp/data-display-popup-stack)]
+        (is (some? (find-by-testid tree
+                                   "rf-xray-data-display-popup-backdrop-m1")))
+        (is (some? (find-by-testid tree
+                                   "rf-xray-data-display-popup-backdrop-m2")))))))
+
+;; =========================================================================
+;; registry wiring
+;; =========================================================================
+
+(deftest registry-wires-popup-handlers
+  (testing "rf2-l4625 — `register-xray-handlers!` installs the popup
+            events so `:open` lands a real entry without a separate
+            install call from a test fixture"
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync
+        [:rf.xray.data-display-popup/open
+         "smoke" {:value :hi :opts {:title "Smoke"}}])
+      (let [stack @(rf/subscribe [ddp/stack-slot])]
+        (is (= ["smoke"] stack)
+            "open event resolved through the registry-installed handler")))))


### PR DESCRIPTION
Follow-on to phase 6 (#2149, rf2-s0x6x) which shipped the popup overlay infrastructure as a self-contained widget but didn't wire it into any panel.

## Approach: opt-in via `:popup-affordance? true` (default off)

Per the bead description ("each panel that renders [dd/data-display value opts] gets an opt-in 'open in popup' control"), the affordance is opt-in per call site rather than always-on. Scalar / tiny-value mounts don't benefit from a larger inspection surface; panels enable the affordance where the inline widget is genuinely cramped.

The affordance is implemented inside the `data-display` widget itself — when `:popup-affordance? true` is in opts, the widget renders a small top-right ⊕ icon button positioned absolutely over the rendered tree. Click dispatches `[:rf.xray.data-display-popup/open popup-mount-id {:value v :opts o}]` through the lexically-captured frame-aware dispatcher.

`popup-mount-id` is derived from the data-display's own mount-id (`"ddp-" + mount-id`) — stable per call-site mount, so re-clicking the affordance raises the existing popup rather than spawning a duplicate (matches `data-display-popup/push-entry` window-manager semantics).

The opts forwarded to the popup carry `:popup-affordance? false` so the popup's embedded data-display does not recurse the affordance inside itself.

## Shell mount

`data-display-popup-stack` mounts once at the shell root in `shell.cljs`, alongside the other modal stacks (palette, settings, segment-inspector, …). `registry.cljs` calls `data-display-popup/install!` so the open/close/close-top/close-all events resolve through `rf/dispatch-sync` post-registration.

## Panels updated

| Panel | Site | Rationale |
|-------|------|-----------|
| `panels/app_db_diff_state.cljs` | `value-body` (whole user-domain + reserved areas) | App-DB whole-tree is the canonical cramped-in-side-panel case |
| `panels/machine_canvas.cljs` | snapshot drill-in | Machine snapshots carry deeply-nested `:data` maps |
| `panels/machine_inspector.cljs` | per-phase snapshot block | Same as canvas |
| `panels/reactive_panel_view.cljs` | per-sub value row | Sub values can be the full domain projection |
| `panels/trace.cljs` | per-row payload expand | Trace rows expand within a narrow column |

The diff renderers' internal `inspect-value` leaves (`diff/render.cljs`, `diff/hiccup_render.cljs`) intentionally do NOT carry the affordance — they are inner mini-renderers inside a larger diff tree chrome, not user-facing leaf inspect mounts.

## Tests

- New file `tools/xray/test/day8/re_frame2_xray/views/data_display_popup_wireup_cljs_test.cljs` — widget-level affordance (opt-in default off, button shape, on-click dispatch contract via stub dispatcher), shell mount (empty / active), registry wiring.
- Per-panel affordance tests added inline to the existing panel test files (one `deftest` each).
- `registry_cljs_test.cljs` snapshot extended with the new 5 subs + 4 events.

## Spec/021 diff

`tools/xray/spec/021-Dynamic-Panel-Designs.md` §10.0.7.1 (shell mount) + §10.0.7.2 (per-panel affordance) — replaces the "wire-up follow-on" placeholder paragraph in §10.0.7.

## Gates

- `npm run test:cljs` — 4518 tests / 14337 assertions / 0 failures
- `npm run test:browser` — 124 tests / 346 assertions / 0 failures
- `npm run test:bundle-isolation` — PASS
- `npm run test:elision` — PASS
- `npm run test:xray-feature-gate` — 13/13 scenarios / 0 failures
- `(cd tools/xray && clojure -M:test)` — 859 tests / 3067 assertions / 0 failures
- `clj-kondo --lint tools/xray/src tools/xray/test` — 0 errors
- `mkdocs build --strict` — PASS

Closes rf2-l4625.