### PR TITLE
docs(examples): drop stale .spec.cjs references across remaining example READMEs (rf2-1rbwn)

### DIFF
--- a/examples/TESTING.md
+++ b/examples/TESTING.md
@@ -19,7 +19,7 @@ surfaces change and in the scheduled/manual expensive workflow.
 | Command                            | What it runs                                                                                                        | Where the orchestrator lives                                                                                                |
 |------------------------------------|---------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------|
 | `npm run test:browser`             | The shadow-cljs `:browser-test` bundle — every `*-cljs-test` namespace, including example wrappers (`re-frame.nine-states-cljs-test`, `re-frame.realworld-cljs-test`, ...). All of them load into a single Chromium page. | [`implementation/scripts/serve-and-run-browser-tests.cjs`](../implementation/scripts/serve-and-run-browser-tests.cjs)        |
-| `npm run test:examples`            | Per-example shadow-cljs builds compiled into `out/examples/<name>/`, each served as its own page, exercised by the example's Playwright spec (`<name>.spec.cjs`). | [`scripts/serve-and-run-examples-tests.cjs`](scripts/serve-and-run-examples-tests.cjs)                                       |
+| `npm run test:examples`            | The three adapter-level smokes at `implementation/adapters/{reagent,uix,helix}/testbed/spec.cjs` — mount + dispatch + assert per substrate. Per rf2-8cevm the `examples/` tree itself is test-free; this orchestrator drives the adapter smokes only. | [`scripts/serve-and-run-examples-tests.cjs`](scripts/serve-and-run-examples-tests.cjs)                                       |
 
 The two surfaces are independent:
 
@@ -27,8 +27,9 @@ The two surfaces are independent:
   namespace that is `:require`'d by a `*-cljs-test` wrapper is loaded into
   the same JS runtime and runs against a single shared DOM. This is where
   ns-load side effects bite.
-- `test:examples` is **N bundles, N pages, N specs**. Each example owns
-  its own runtime — no cross-example interaction is possible.
+- `test:examples` is **N bundles, N pages, N specs** — one per adapter
+  testbed. Each adapter owns its own runtime; no cross-adapter
+  interaction is possible.
 
 ## Server-ownership contract (`test:browser`)
 
@@ -179,19 +180,21 @@ bundle, in the same page, with the same shared `#app` mount point. If
 mount-isolation discipline holds, the new example will not affect any
 sibling's tests.
 
-## Adding a new `test:examples` example
+## Adding a new example to `test:examples`
 
-A new example added to the per-example Playwright surface needs:
+Per the test-free examples policy (rf2-8cevm) the `examples/` tree
+itself carries no Playwright specs; `test:examples` drives only the
+three adapter testbeds at
+`implementation/adapters/{reagent,uix,helix}/testbed/`. **Do NOT add
+a `*.spec.cjs` under `examples/`.**
 
-1. A shadow-cljs build target (`:examples/<name>`) in
-   [`implementation/shadow-cljs.edn`](../implementation/shadow-cljs.edn).
-2. A hand-written `index.html` next to the example's `core.cljs`.
-3. A Playwright spec (`<name>.spec.cjs`) alongside.
-4. An entry in the `EXAMPLES` table inside
-   [`scripts/serve-and-run-examples-tests.cjs`](scripts/serve-and-run-examples-tests.cjs).
+If a new framework contract needs end-to-end browser coverage that
+the existing gates (`test:cljs`, `test:xray-feature-gate`,
+`test:bundle-isolation`, `test:perf-bundle`, mcp-conformance) don't
+already provide, extend the appropriate gate — or, for a genuinely
+new cross-cutting surface, add a top-level `testbeds/<surface>/`
+with its own `spec.cjs`.
 
-Because each example owns its own page under `test:examples`, the
-mount-isolation discipline above is not load-bearing for this surface
-— but the same `(defonce react-root (atom nil))` shape is still the
-convention so the same `core.cljs` can be required by a `test:browser`
-wrapper later without rewriting.
+The `(defonce react-root (atom nil))` mount-isolation shape above is
+still the convention for any example's `core.cljs` so it can be
+required by a `test:browser` wrapper later without rewriting.

--- a/examples/reagent/boot/README.md
+++ b/examples/reagent/boot/README.md
@@ -68,17 +68,19 @@ initialisation graph. The boot sequence is:
 
 ## Running it
 
-The example is wired into the standard shadow-cljs and Playwright
-infrastructure:
+The example builds via shadow-cljs:
 
 ```sh
 # From the implementation directory:
 npx shadow-cljs compile examples/boot
 
 # Then from the repo root:
-npm run test:examples       # Playwright smoke
 npm run test:cljs           # Headless boot machine tests
 ```
+
+Per the test-free examples policy (rf2-8cevm) there is no per-example
+Playwright spec; real-regression coverage lives in `npm run test:cljs`
+and the framework gates (see [`examples/README.md`](../../README.md)).
 
 ## Files
 
@@ -90,7 +92,6 @@ schema.cljs             — Malli schemas (BootSnapshot, Config, Flags, ...)
 test/boot/boot_test.cljs — headless tests (machine progression, deps
                           resolution, failure path)
 index.html
-boot.spec.cjs           — Playwright smoke
 ```
 
 ## Cross-references

--- a/examples/reagent/counter_slim_and_fast/README.md
+++ b/examples/reagent/counter_slim_and_fast/README.md
@@ -39,9 +39,7 @@ the changed-surface CI job is `cljs-reagent-slim-bundle-isolation` in
 `.github/workflows/test.yml`.
 
 The slim adapter is also a drop-in for the bridge at the
-behavioural level: same clicks, same counts. The Playwright spec
-runs the exact assertions as the canonical counter's spec —
-initial render shows 5, `+` → 6, two `-` → 4.
+behavioural level: same clicks, same counts.
 
 ## Files
 
@@ -49,26 +47,25 @@ initial render shows 5, `+` → 6, two `-` → 4.
 counter_slim_and_fast/
   core.cljs                          mount + events/subs/view + SSR exercise
   index.html                         minimal host page
-  counter_slim_and_fast.spec.cjs     Playwright smoke (drop-in parity with counter)
   README.md                          this file
 ```
 
 The bundle-isolation verifier is adapter-owned rather than a general
 human-facing example test and lives under `implementation/scripts/`.
 
+Per the test-free examples policy (rf2-8cevm) there is no per-example
+Playwright spec; real-regression coverage lives in the substrate
+contract tests (`npm run test:cljs`) and the framework gates (see
+[`examples/README.md`](../../README.md)).
+
 ## How to run
 
-The example is wired into the canonical examples harness. From
+To iterate against the source, watch the build directly from
 `implementation/`:
 
 ```bash
-npm run test:examples
+shadow-cljs watch examples/counter-slim-and-fast
 ```
-
-That compiles every example (this one builds under shadow-cljs id
-`examples/counter-slim-and-fast`), stages its `index.html` into
-`out/examples/counter-slim-and-fast/`, serves the lot on port 8030,
-and runs the Playwright smoke spec.
 
 The Reagent Slim bundle-isolation contract is exercised separately
 when slim-related paths change, and in the nightly/manual expensive
@@ -78,17 +75,6 @@ workflow. To run it locally:
 # From implementation/ — release both bundles, then grep.
 npm run test:reagent-slim:bundle-isolation
 ```
-
-To iterate on the source alone, watch the build directly from
-`implementation/`:
-
-```bash
-shadow-cljs watch examples/counter-slim-and-fast
-```
-
-(Run `npm run test:examples` once first so
-`out/examples/counter-slim-and-fast/index.html` is staged; subsequent
-watch builds reuse it.)
 
 ## Cross-references
 

--- a/examples/reagent/long_running_work/README.md
+++ b/examples/reagent/long_running_work/README.md
@@ -98,11 +98,15 @@ examples/reagent/long_running_work/
                   fires the unmount cascade)
   schema.cljs     malli schemas for the parent + child snapshots
   index.html      static host page (mounted by core/run)
-  long_running_work.spec.cjs   Playwright smoke
   test/long_running_work/
     worker_test.cljs           headless fixtures
   README.md       this file
 ```
+
+Per the test-free examples policy (rf2-8cevm) there is no per-example
+Playwright spec; real-regression coverage lives in the substrate
+contract tests (`npm run test:cljs`) and the framework gates (see
+[`examples/README.md`](../../README.md)).
 
 The integration test that wraps the headless fixtures lives at
 [`implementation/adapters/reagent/test/re_frame/long_running_work_cljs_test.cljs`](../../../implementation/adapters/reagent/test/re_frame/long_running_work_cljs_test.cljs).
@@ -113,9 +117,6 @@ Same wrapping pattern as `nine-states-cljs-test` and `realworld-cljs-test`.
 From `implementation/`:
 
 ```bash
-# Playwright smoke (compiles, stages, serves, runs the .spec.cjs).
-npm run test:examples
-
 # Headless cljs-test (runs all the *-cljs-test under
 # implementation/adapters/reagent/test/, including the long-running-work
 # integration).

--- a/examples/reagent/long_running_work/test/long_running_work/worker_test.cljs
+++ b/examples/reagent/long_running_work/test/long_running_work/worker_test.cljs
@@ -27,8 +27,7 @@
         :cancel event arrives via the view's r/with-let cleanup
         rather than the user clicking Cancel. The headless test
         synthesises the same dispatch and asserts the same
-        cascade. The view-level wiring is exercised by the
-        Playwright smoke (long_running_work.spec.cjs)."
+        cascade."
   (:require [cljs.test :refer-macros [is]]
             [re-frame.core :as rf]
             [long-running-work.worker])
@@ -183,11 +182,10 @@
 ;; The view's r/with-let cleanup dispatches [:work/flow [:cancel]]
 ;; on component unmount. From the parent machine's perspective this
 ;; is identical to a user-driven Cancel button click — the headless
-;; test exercises that contract by dispatching the same event.
-;;
-;; The Playwright spec (long_running_work.spec.cjs) exercises the
-;; *actual* React unmount path against a live browser; this test
-;; pins the machine-side invariant.
+;; test exercises that contract by dispatching the same event. This
+;; test pins the machine-side invariant; the React-side wiring is
+;; covered by the view code itself (`r/with-let` cleanup is a
+;; Reagent idiom, not a re-frame2 contract).
 
 (defn test-parent-unmount-cascade []
   (with-frame [f (new-frame)]

--- a/examples/reagent/ssr/deps.edn
+++ b/examples/reagent/ssr/deps.edn
@@ -1,8 +1,10 @@
-;; rf2-j3dlc — live-SSR browser smoke test harness.
+;; rf2-j3dlc — live-SSR Ring harness deps (Jetty + ssr-handler).
 ;;
-;; This deps.edn is consumed ONLY by examples/scripts/serve-and-run-examples-tests.cjs
-;; via `clojure -X:live-ssr-server` to spin up a real Jetty + ssr-handler
-;; for the browser-driven live-SSR Playwright spec (ssr-live.spec.cjs).
+;; Stands up a real Jetty + ssr-handler via `clojure -X:live-ssr-server`
+;; for ad-hoc local exploration of the live-SSR path. Per the test-free
+;; examples policy (rf2-8cevm) there is no per-example Playwright spec
+;; consuming this harness; the SSR + ssr-ring contracts are exercised
+;; by their JVM unit tests under `implementation/ssr-ring/test/...`.
 ;;
 ;; Pulls in the SSR + ssr-ring artefacts via :local/root so the published-
 ;; artefact coordinate graph (implementation/deps.edn) is untouched (that

--- a/examples/reagent/ssr/server.clj
+++ b/examples/reagent/ssr/server.clj
@@ -1,10 +1,12 @@
 (ns ssr.server
-  "Live SSR Ring server for the Playwright `ssr-live.spec.cjs` smoke
-   test (rf2-j3dlc).
+  "Live SSR Ring harness — Jetty + ssr-handler bring-up (rf2-j3dlc).
 
-   Companion to the existing `ssr.spec.cjs` smoke. That spec exercises
-   the hydration path against PRE-BAKED server-shaped HTML staged from
-   `index.html`. This namespace stands up a REAL live SSR handler:
+   Per the test-free examples policy (rf2-8cevm) there is no per-example
+   Playwright spec consuming this server. It remains as an ad-hoc local
+   harness for exploring the live-SSR path against a real handler; the
+   SSR + ssr-ring contracts are exercised by JVM unit tests under
+   `implementation/ssr-ring/test/...`. This namespace stands up a REAL
+   live SSR handler:
 
    - Boot the SSR adapter (`re-frame.ssr/adapter`).
    - Load `ssr.core` (registers events / views / fx).
@@ -19,8 +21,7 @@
    - Run Jetty on the configured port, in this process.
 
    Exec entrypoint: `clojure -X:live-ssr-server :port 8031`. Stays alive
-   until the orchestrator tears the process down (per
-   examples/scripts/serve-and-run-examples-tests.cjs).
+   until killed.
 
    Boundaries:
    - JVM-side Ring/SSR e2e details (header round-trip, cookie wire,


### PR DESCRIPTION
Follow-on to #2157 (rf2-u5mzf + rf2-0x8ss) which fixed 2 of 7 example READMEs. Sweeps the remaining stale `.spec.cjs` references across the example tree per the test-free examples policy (rf2-8cevm, Mike directive 2026-05-19).

## Per-file decisions

| File | Decision | Action |
|------|----------|--------|
| `examples/reagent/boot/README.md` | stale → fixed | dropped file-listing line + reworded "Running it" block |
| `examples/reagent/counter_slim_and_fast/README.md` | stale → fixed | dropped file-listing line + replaced `test:examples` run instructions with `shadow-cljs watch`; collapsed duplicate watch block |
| `examples/reagent/long_running_work/README.md` | stale → fixed | dropped file-listing line + dropped `npm run test:examples` invocation in "How to run" |
| `examples/reagent/long_running_work/test/long_running_work/worker_test.cljs` | stale → fixed | dropped two prose mentions of a Playwright spec that no longer exists |
| `examples/reagent/ssr/deps.edn` | stale → fixed | reframed comment: harness is now ad-hoc local exploration, no Playwright spec consumes it |
| `examples/reagent/ssr/server.clj` | stale → fixed | reworded docstring to drop two `.spec.cjs` references and the orchestrator hand-off claim |
| `examples/TESTING.md` | stale → fixed | rewrote `test:examples` table row + "Adding a new test:examples example" section to match the actual adapter-smokes shape and test-free policy |
| `examples/reagent/7Guis/README.md` | intentional → kept | already correctly explains the test-free rule |
| `examples/README.md` | intentional → kept | authoritative source of the test-free rule |
| `examples/scripts/run-examples-tests.cjs` | intentional → kept | walker discovery logic (still picks up `*.spec.cjs` for adapter testbeds) |
| `examples/scripts/serve-and-run-examples-tests.cjs` | intentional → kept | policy comment explaining the retirement |

## Final sweep

```
$ git grep -nE '\.spec\.cjs' examples/
examples/README.md:16:    run-examples-tests.cjs              <-- Playwright runner (walks SPEC_ROOTS, picks up *.spec.cjs / spec.cjs)
examples/README.md:54: ... test-free rule (intentional) ...
examples/README.md:138: ... test-free rule (intentional) ...
examples/README.md:164: ... test-free rule (intentional) ...
examples/TESTING.md:189: ... test-free rule (intentional) ...
examples/reagent/7Guis/README.md:15: ... test-free rule (intentional) ...
examples/scripts/run-examples-tests.cjs:65: ... walker logic (intentional) ...
examples/scripts/run-examples-tests.cjs:108: ... walker logic (intentional) ...
examples/scripts/run-examples-tests.cjs:132: ... walker logic (intentional) ...
examples/scripts/run-examples-tests.cjs:135: ... walker logic (intentional) ...
examples/scripts/serve-and-run-examples-tests.cjs:121: ... policy comment (intentional) ...
```

All remaining hits are intentional: either authoritative explanations of the test-free rule, or the JS runner's walker logic (which still picks up `spec.cjs` at the per-adapter testbed roots).

## Gates

- `python scripts/check_doc_slugs.py --verbose` — 376 files scanned, no broken links
- `mkdocs build --strict` — exit 0
- `git grep -nE '\.spec\.cjs' examples/` — only intentional refs remain (see above)

## Out-of-scope follow-up

The `examples/reagent/ssr/server.clj` + `deps.edn` live-SSR Ring harness is dead code — no Playwright spec consumes it anymore. This PR minimally reworded the docstrings; full deletion (or repurposing as a documented local-only exploration target) is a follow-up decision for the mayor.

Closes rf2-1rbwn.