### PR TITLE
docs(README): repoint 404 chrome-devtools-mcp URL in pair-mcp README (rf2-tyek9)

### DIFF
--- a/tools/re-frame2-pair-mcp/README.md
+++ b/tools/re-frame2-pair-mcp/README.md
@@ -541,7 +541,7 @@ the surface:
 
 | Layer | Server | Tools |
 |---|---|---|
-| Browser substrate | [Chrome DevTools MCP](https://github.com/anthropics/chrome-devtools-mcp) or [Playwright MCP](https://github.com/microsoft/playwright-mcp) | Click, type, navigate, screenshot, viewport |
+| Browser substrate | [Chrome DevTools MCP](https://github.com/ChromeDevTools/chrome-devtools-mcp) or [Playwright MCP](https://github.com/microsoft/playwright-mcp) | Click, type, navigate, screenshot, viewport |
 | re-frame2 runtime | **re-frame2-pair-mcp** (this artefact) | `dispatch`, `snapshot`, `get-path`, `subscribe`, `eval-cljs`, … |
 
 Browser-substrate ops and re-frame2-runtime ops are different


### PR DESCRIPTION
## What

`tools/re-frame2-pair-mcp/README.md:544` cited
`https://github.com/anthropics/chrome-devtools-mcp`, which returns
**404**. The canonical "Chrome DevTools MCP" lives at
[`ChromeDevTools/chrome-devtools-mcp`](https://github.com/ChromeDevTools/chrome-devtools-mcp)
— Google Chrome DevTools' official MCP server, published as the
`chrome-devtools-mcp` npm package. Repoint the link in the
"Co-install with browser-substrate MCP servers" comparison table.

## URL investigation

| URL | Status |
|---|---|
| `anthropics/chrome-devtools-mcp` | 404 (cited, broken) |
| `chromedevtools/devtools-mcp` | 404 |
| `GoogleChromeLabs/chrome-devtools-mcp` | 404 |
| **`ChromeDevTools/chrome-devtools-mcp`** | **200** (correct target) |

Repo README confirms identity: *"Chrome DevTools for agents
(`chrome-devtools-mcp`) lets your coding agent ... control and
inspect a live Chrome browser. It acts as a Model-Context-Protocol
(MCP) server"* — exactly the role the comparison table describes.

## Decision

Path (a) from the bead body — found the correct URL, repointed.

## Gates

- `python scripts/check_doc_slugs.py --verbose` — no broken links
- `mkdocs build --strict` — exit 0

## Refs

- bd: rf2-tyek9
- Discovered from: rf2-oavap (external-URL HEAD-check sweep)