### PR TITLE
docs(spec): pair-mcp spec drift catch-up — :resolved-build-id + tail-build + trace-window/watch-epochs + discover-app (rf2-l3k8j + rf2-7bpm4 + rf2-6xlmv + rf2-31oq3)

### DIFF
--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -232,7 +232,7 @@ load-bearing: each carries different recovery semantics.
 
 | Dialect       | Meaning                                                            | Example reasons                                                                              |
 |---------------|--------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
-| **Bare**      | Per-call validation / runtime failure (the normal tool body ran)   | `:invalid-kind`, `:missing-path`, `:not-an-event-vector`, `:path-not-found`, `:unknown-tool`, `:runtime-not-preloaded`, `:eval-error`, `:<verb>-failed` (e.g. `:snapshot-failed`, `:dispatch-failed`) |
+| **Bare**      | Per-call validation / runtime failure (the normal tool body ran)   | `:invalid-kind`, `:missing-path`, `:not-an-event-vector`, `:path-not-found`, `:unknown-tool`, `:runtime-not-preloaded`, `:eval-error`, `:timed-out`, `:probe-errored`, `:<verb>-failed` (e.g. `:snapshot-failed`, `:dispatch-failed`) |
 | `:rf.error/*` | Operator-gated denial OR shared cross-MCP error vocabulary — the server refused **without touching nREPL** because a boot-flag / resource cap rejected the call before the tool body ran, OR the call ran but failed in a way that warrants the shared cross-MCP error vocabulary (rf2-xn4f9: `:rf.error/eval-cljs-rejected` + `:rf.error/eval-cljs-timeout` are bare-shaped per-call failures but adopt the namespace so an agent host can pattern-match the eval-cljs error cluster as one family) | `:rf.error/eval-cljs-disabled`, `:rf.error/eval-cljs-rejected`, `:rf.error/eval-cljs-timeout`, `:rf.error/concurrent-stream-limit`, `:rf.error/stream-abuse-detected` |
 | `:rf.mcp/*`   | Wire-replacement-marker family (otherwise reserved for substitution markers like `:rf.mcp/overflow`, `:rf.mcp/dedup-table`, `:rf.mcp/cache-hit`, `:rf.mcp/summary`, `:rf.mcp/diff-from`). One carve-out as a `:reason` value: `:rf.mcp/cursor-stale` — cursor-staleness is detected at the wire boundary itself (the cursor envelope), not via tool body or boot gate, so it shares the `:rf.mcp/*` prefix with the rest of the wire-boundary vocabulary | `:rf.mcp/cursor-stale` (the only `:rf.mcp/*` `:reason` value) |
 
@@ -973,9 +973,69 @@ value changes from its pre-call value. Times out after `wait-ms`.
 **Args**: `probe` (string — a CLJS form whose value should change
 after the reload), `wait-ms` (integer, default 5000), `build` (string).
 
-**Returns**: `{:ok? true :t <ms> :soft? false}` on a real change, or
-`{:ok? false :reason :timed-out}` on timeout. If `probe` is omitted,
-falls back to a 300ms soft delay (matches the bash version).
+**Returns**: one of four envelope shapes (rf2-36awg; impl:
+[`src/re_frame2_pair_mcp/tools/tail_build.cljs`](../src/re_frame2_pair_mcp/tools/tail_build.cljs)
+lines 79-137):
+
+1. **Success (probe supplied) — probe value changed within the
+   deadline** (lines 117-123):
+
+    ```clojure
+    {:ok?          true
+     :t            <ms>
+     :soft?        false
+     :probe-values {:initial <v>   ; pre-poll value of the probe form
+                    :final   <v>}} ; final value at completion
+    ```
+
+   `:probe-values` confirms the comparison drove completion — callers
+   read both ends rather than guessing which transition fired.
+
+2. **Timeout (probe supplied) — value never differed from initial
+   within `wait-ms`** (lines 105-111):
+
+    ```clojure
+    {:ok?          false
+     :reason       :timed-out
+     :timed-out?   true
+     :probe-values {:initial <v>   ; pre-poll value of the probe form
+                    :final   <v>}  ; last value the polling loop saw
+     :note         "Probe value did not change within wait-ms. Possible
+                    causes: (a) compile error in shadow stalled the
+                    rebuild, (b) probe form returns the same value
+                    before and after the reload, (c) probe form errored
+                    — check :probe-values to disambiguate."}
+    ```
+
+   With both ends visible the operator distinguishes "compile didn't
+   land" from "probe form returns the same value before and after"
+   without an extra round-trip.
+
+3. **Probe errored on initial evaluation** (lines 134-137):
+
+    ```clojure
+    {:ok?         false
+     :reason      :probe-errored
+     :probe-error "<stringified exception message>"
+     :note        "Probe form raised an exception on every iteration.
+                   The form is likely malformed."}
+    ```
+
+   Distinct from `:timed-out` — the probe form itself threw, so no
+   before/after delta could be measured. Almost always a malformed
+   probe (typo, dotted-form host interop against a missing var, etc.).
+
+4. **No probe supplied — soft delay** (lines 79-84):
+
+    ```clojure
+    {:ok?   true
+     :t     <ms>
+     :soft? true
+     :note  "No probe supplied; waited a 300ms fixed delay."}
+    ```
+
+   Matches the bash shim's behaviour. The `:probe-values` slot does
+   NOT appear in this envelope; tests pin its absence.
 
 ## snapshot
 

--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -232,7 +232,7 @@ load-bearing: each carries different recovery semantics.
 
 | Dialect       | Meaning                                                            | Example reasons                                                                              |
 |---------------|--------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
-| **Bare**      | Per-call validation / runtime failure (the normal tool body ran)   | `:invalid-kind`, `:missing-path`, `:not-an-event-vector`, `:path-not-found`, `:unknown-tool`, `:runtime-not-preloaded`, `:eval-error`, `:timed-out`, `:probe-errored`, `:<verb>-failed` (e.g. `:snapshot-failed`, `:dispatch-failed`) |
+| **Bare**      | Per-call validation / runtime failure (the normal tool body ran)   | `:invalid-kind`, `:missing-path`, `:not-an-event-vector`, `:path-not-found`, `:unknown-tool`, `:runtime-not-preloaded`, `:nrepl-unreachable`, `:build-not-running`, `:no-runtime-connected`, `:runtime-loaded-but-preload-missing`, `:eval-error`, `:timed-out`, `:probe-errored`, `:<verb>-failed` (e.g. `:snapshot-failed`, `:dispatch-failed`) |
 | `:rf.error/*` | Operator-gated denial OR shared cross-MCP error vocabulary — the server refused **without touching nREPL** because a boot-flag / resource cap rejected the call before the tool body ran, OR the call ran but failed in a way that warrants the shared cross-MCP error vocabulary (rf2-xn4f9: `:rf.error/eval-cljs-rejected` + `:rf.error/eval-cljs-timeout` are bare-shaped per-call failures but adopt the namespace so an agent host can pattern-match the eval-cljs error cluster as one family) | `:rf.error/eval-cljs-disabled`, `:rf.error/eval-cljs-rejected`, `:rf.error/eval-cljs-timeout`, `:rf.error/concurrent-stream-limit`, `:rf.error/stream-abuse-detected` |
 | `:rf.mcp/*`   | Wire-replacement-marker family (otherwise reserved for substitution markers like `:rf.mcp/overflow`, `:rf.mcp/dedup-table`, `:rf.mcp/cache-hit`, `:rf.mcp/summary`, `:rf.mcp/diff-from`). One carve-out as a `:reason` value: `:rf.mcp/cursor-stale` — cursor-staleness is detected at the wire boundary itself (the cursor envelope), not via tool body or boot gate, so it shares the `:rf.mcp/*` prefix with the rest of the wire-boundary vocabulary | `:rf.mcp/cursor-stale` (the only `:rf.mcp/*` `:reason` value) |
 
@@ -285,15 +285,50 @@ first every session.
 **Args**: `build` (string, optional, default `"app"`).
 
 **Returns**: an `:ok? true` map with `:debug-enabled?`, `:frames`,
-`:coord-annotation-enabled?`, `:build-id`. Or `:ok? false` with a
-`:reason` keyword if a precondition fails. The most common
-precondition failure on a fresh app is
-`:reason :runtime-not-preloaded` — the runtime ships into the app
-via shadow-cljs `:preloads`; the server probes
+`:coord-annotation-enabled?`, `:build-id`. On success the resolved
+build-id is cached on the conn-atom (`:resolved-build-id`, rf2-l9ixp);
+subsequent tool calls may omit the `:build` arg — see
+[`API.md` §Build-id resolution](./API.md#build-id-resolution).
+
+On a precondition failure the response is `:ok? false` with a
+`:reason` keyword. The runtime ships into the app via shadow-cljs
+`:preloads`; the server probes
 `js/globalThis.__re_frame2_pair_runtime` (the load-time mirror the
-preload installs) and refuses with a setup hint when missing. There
-is no fallback inject path; see the skill's SKILL.md §Setup for the
-two-line preload entry.
+preload installs). When the marker is missing the failure-path
+diagnostic ladder (rf2-7tgfk; impl:
+[`src/re_frame2_pair_mcp/tools/probe.cljs`](../src/re_frame2_pair_mcp/tools/probe.cljs)
+`diagnose-preload-failure!`, lines 181-271) walks four rungs to name
+the underlying cause rather than always blaming the preload:
+
+### Failure-path diagnostic ladder (rf2-7tgfk)
+
+| `:reason` | Fires when | Hint shape |
+|---|---|---|
+| `:nrepl-unreachable` | JVM `jvm-eval` round-trip fails — the nREPL socket is dead even though the MCP server is up. Most often: the shadow-cljs JVM stopped, or restarted and left the MCP server holding a stale socket. (probe.cljs lines 207-210) | "Restart `shadow-cljs watch` and retry; the MCP server reconnects on the next tool call." |
+| `:build-not-running` | nREPL is reachable but shadow's `active-builds` doesn't include the targeted build. Carries `:running-builds` enumerating what IS up. Almost always a `--build` typo or operator targeted the wrong dev build. (probe.cljs lines 215-219) | "shadow-cljs is running `[<other-build>]` but not `<target>`. Pass `--build=<other-build>` (or set `SHADOW_CLJS_BUILD_ID`)…" |
+| `:no-runtime-connected` | Build IS running but the cljs-eval round-trip returns blank — no browser tab has connected, or the tab's WebSocket has dropped. Carries `:running-builds`. (probe.cljs lines 233-237) | "build `<id>` is running but no CLJS runtime is currently connected… Open the app in a browser tab — or if a tab IS open, reload the page so the runtime reconnects." |
+| `:runtime-loaded-but-preload-missing` | A CLJS runtime is alive but the `__re_frame2_pair_runtime` marker is absent. The original meaning of the legacy `:runtime-not-preloaded` reason — the preload entry IS what to add. (probe.cljs lines 242-245) | "re-frame2-pair.runtime is not loaded into this build. Add the preload entry to your shadow-cljs.edn… See skills/re-frame2-pair/SKILL.md (§Setup)." |
+
+Each rung carries `:build` (the targeted id) plus a targeted
+`:hint`; `:build-not-running` and `:no-runtime-connected` also carry
+`:running-builds` so the operator's next move is one keystroke
+away.
+
+The ladder costs one extra JVM round-trip (active-builds
+enumeration) plus a CLJS-eval discriminator on the failure path —
+~50ms total. The probe cache (rf2-sjpx0) means a healthy session pays
+nothing.
+
+### Fallback: `:runtime-not-preloaded`
+
+When the ladder itself errors (e.g. a transient nREPL failure mid-
+diagnosis), the response degrades to the original blanket
+`:reason :runtime-not-preloaded` with the generic preload hint
+(probe.cljs lines 266-271). Reserved as the degradation case; the
+ladder's four named reasons cover the common path.
+
+There is no fallback inject path; see the skill's SKILL.md §Setup for
+the two-line preload entry.
 
 ## Universal: server launch flags
 

--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -889,6 +889,45 @@ see §Structural dedup at the top of this catalogue), `build` (string).
 
 **Returns**: `{:ok? true :window-ms N :until-ms T :count K :limit L :epochs-mode :diff|:full :epochs [...] :has-more? bool :estimated-remaining N :next-cursor "<base64>"|nil}`.
 
+When the window surfaces zero matches but the per-frame epoch-history
+is non-empty, the envelope additionally carries an `:advisory` slot —
+see §Empty-result advisory below.
+
+### Empty-result advisory (rf2-fb4hn)
+
+When the response would carry `:count 0` but the operating frame's
+per-frame epoch-history is non-empty, the envelope carries an
+`:advisory` slot distinguishing "nothing happened" from "events exist
+but fell outside the time window" (impl:
+[`src/re_frame2_pair_mcp/tools/trace_window.cljs`](../src/re_frame2_pair_mcp/tools/trace_window.cljs)
+lines 130-142):
+
+```clojure
+{:advisory {:reason            :window-excludes-history
+            :frame             <frame-id>
+            :epochs-in-history N
+            :window-ms         N
+            :hint              "N epochs exist in the per-frame history
+                                but none fell inside the last <window>ms
+                                window. Widen :ms (e.g. 60000), or use
+                                `snapshot :include [:epochs]` to inspect
+                                the full history."}}
+```
+
+The advisory fires when **both** ratchets hold: `:count` is zero (the
+slot operators read to decide "nothing happened") and the per-frame
+ring depth is positive (events exist). Without it the operator
+routinely misread an empty window as "the MCP isn't capturing my
+events" — the 2026-05-25 pair-debug session referenced in PR #2120
+named the misread cost. With it, the operator either widens `:ms` or
+pivots to `snapshot :include [:epochs]` for unbounded historical
+inspection.
+
+The slot is omitted when matches exist or when the frame's history is
+genuinely empty (a fresh runtime with no dispatches). Agents
+pattern-match presence to decide whether the empty result needs a
+follow-up call.
+
 ### Diff-encoded `:db-after` (rf2-1wdzp + rf2-qeous)
 
 By default (`epochs-mode "diff"`), each epoch's `:db-after` is replaced
@@ -960,10 +999,62 @@ threshold.
 
 **Returns**: `{:ok? true :matches [...] :limit L :count K :head-id "..." :id-aged-out? bool :epochs-mode :diff|:full :has-more? bool :estimated-remaining N :next-cursor "<base64>"|nil}`.
 
+When the call surfaces zero matches but the per-frame epoch-history is
+non-empty, the envelope additionally carries an `:advisory` slot —
+see §Empty-result advisory below.
+
 Each match has its `:db-after` diff-encoded against its own
 `:db-before` by default (rf2-1wdzp); pass `epochs-mode "full"` for
 the legacy full-pair shape. See `trace-window` above for the wire
 shape and rationale.
+
+### Empty-result advisory (rf2-fb4hn)
+
+When the response would carry `:count 0` but the operating frame's
+per-frame epoch-history is non-empty, the envelope carries an
+`:advisory` slot distinguishing two distinct empty-result causes
+(impl: [`src/re_frame2_pair_mcp/tools/watch_epochs.cljs`](../src/re_frame2_pair_mcp/tools/watch_epochs.cljs)
+lines 139-165):
+
+**Case A — `:no-events-since-id`** (zero `:count`, zero new epochs
+since `:since-id`, non-empty history). The caller's `:since-id` sits
+at or past the head; no events have landed since.
+
+```clojure
+{:advisory {:reason            :no-events-since-id
+            :frame             <frame-id>
+            :epochs-in-history N
+            :requested-id      <since-id>
+            :hint              "Per-frame history holds N epochs but
+                                none have landed since the supplied
+                                :since-id. Dispatch an event to advance
+                                the head, or omit :since-id to see the
+                                full ring."}}
+```
+
+**Case B — `:pred-excludes-history`** (zero `:count`, positive new
+epochs since `:since-id`). Events landed but `:pred` filtered them
+all out.
+
+```clojure
+{:advisory {:reason            :pred-excludes-history
+            :frame             <frame-id>
+            :epochs-in-history N
+            :epochs-since-id   N
+            :hint              "N epochs landed since the requested id
+                                but the :pred filter excluded all of
+                                them. Drop / widen :pred, or use
+                                trace-window for an unfiltered view."}}
+```
+
+The two cases share the impl's pattern: ratchet on `:count 0` first,
+then pick the explainer from runtime-side `:since-count` /
+`:history-count` counts so the tool body picks the right advisory from
+one nREPL round-trip. The advisory is omitted when matches exist or
+when the frame's history is genuinely empty. Agents pattern-match on
+`:reason` inside the advisory to choose the next step — restart with
+no `:since-id`, widen the `:pred`, or pivot to `trace-window` for an
+unfiltered view.
 
 ## tail-build
 

--- a/tools/re-frame2-pair-mcp/spec/API.md
+++ b/tools/re-frame2-pair-mcp/spec/API.md
@@ -69,12 +69,47 @@ per the [MCP transport spec](https://modelcontextprotocol.io/specification/2025-
 
 | Variable | Default | Purpose |
 |---|---|---|
-| `SHADOW_CLJS_BUILD_ID` | `"app"` | Default build id passed to `cljs-eval`. Overridable per-op via the `build` argument. |
+| `SHADOW_CLJS_BUILD_ID` | `"app"` | Final-fallback build id passed to `cljs-eval`. See §Build-id resolution below for the full precedence ladder. |
 | `SHADOW_CLJS_NREPL_PORT` | (unset) | Explicit nREPL port; takes precedence over port-file discovery. |
 | `RE_FRAME2_PAIR_MCP_MAX_STREAMS` | `10` | Max concurrent open streaming subscriptions per session (rf2-3ijbl). |
 | `RE_FRAME2_PAIR_MCP_MAX_EVENTS_PER_SEC` | `100` | Per-session rate-limit on progress-notification ticks (rf2-3ijbl). |
 | `RE_FRAME2_PAIR_MCP_ABUSE_OVERFLOW_THRESHOLD` | `50` | Overflow events over the rolling window beyond which a stream is terminated for abuse (rf2-3ijbl). |
 | `RE_FRAME2_PAIR_MCP_ABUSE_WINDOW_MS` | `10000` | Rolling-window length for abuse detection, in milliseconds (rf2-3ijbl). |
+
+### Build-id resolution
+
+Every tool call needs a shadow-cljs build id to route over the nREPL
+socket. The server walks **three sources in precedence order** (rf2-l9ixp;
+impl: [`src/re_frame2_pair_mcp/tools/wire.cljs`](../src/re_frame2_pair_mcp/tools/wire.cljs)
+`arg-build`, lines 125-146):
+
+1. **Explicit `:build` MCP arg on the call.** Operator override always
+   wins; no surprise from the cache.
+2. **Session-scoped `:resolved-build-id` cache on the conn-atom.**
+   Populated by `discover-app` after a successful preload probe
+   (`wire/mark-resolved-build-id!`, `src/.../tools/wire.cljs` line 108;
+   call sites at `src/.../tools/discover_app.cljs` lines 32 / 42 / 57).
+   Removes the friction of repeating `build: foo` on every tool call
+   after a successful discover-app.
+3. **`SHADOW_CLJS_BUILD_ID` env var, defaulting to `:app`.** The
+   final fallback when neither (1) nor (2) is available.
+
+**Invalidation.** The cache resets on `nrepl/connect!`
+(`src/re_frame2_pair_mcp/nrepl.cljs` line 398) and `nrepl/close!`
+(line 416) — the operator may relaunch shadow-cljs against a different
+build id, so the next reconnect starts with no cached resolution.
+
+**Consequence for callers.** After a successful `discover-app {build:
+"my-app"}` (or a discover-app against the default build), subsequent
+tool calls in the same session may omit the `:build` arg even when
+`SHADOW_CLJS_BUILD_ID` is unset and would otherwise default to `:app`.
+The cached resolution carries through. Multi-build workspaces should
+discover-app once per build they intend to target.
+
+Distinct from the per-session **response** cache (rf2-3rt1f, see
+[`Principles.md`](./Principles.md) § Per-session response cache) —
+that one memoises full response payloads by (tool, args) hash within a
+session; this cache memoises only the resolved build-id.
 
 ### Launch flags
 


### PR DESCRIPTION
Four P2 spec-drift beads on the pair-mcp surface, all impl-already-shipped from PRs #2116 + #2120 and surfaced by the 24h spec/impl audit (rf2-zcq0x). Spec catches up to impl. **No code change.**

Sequenced as four commits specifically to share `003-Tool-Catalogue.md` cleanly — parallel landing would 3-way conflict on that one file.

## Commits

1. **`docs(spec): align pair-mcp API.md with wire.cljs session-scoped resolved-build-id cache (rf2-l3k8j)`** — adds §Build-id resolution under `API.md` enumerating the three-tier precedence `arg-build` walks (`src/.../tools/wire.cljs` lines 125-146): explicit `:build` arg → session-scoped `:resolved-build-id` cache → `SHADOW_CLJS_BUILD_ID` env / `:app`. Documents the cache lifecycle (populated by `wire/mark-resolved-build-id!` line 108; invalidated on `nrepl/connect!`/`close!` lines 398/416). Distinguishes from the per-session response cache (rf2-3rt1f).

2. **`docs(spec): align pair-mcp tail-build with tail_build.cljs probe-values + probe-errored envelopes (rf2-7bpm4)`** — rewrites §tail-build to enumerate the four envelope shapes from `src/.../tools/tail_build.cljs`:
   - Success + `:probe-values` (lines 117-123)
   - Timeout + `:probe-values` + note (lines 105-111)
   - `:probe-errored` + `:probe-error` (lines 134-137)
   - No-probe soft delay (lines 79-84)

   Also adds `:timed-out` + `:probe-errored` to the §Bare-reasons table enumeration.

3. **`docs(spec): align pair-mcp trace-window + watch-epochs with empty-result :advisory envelope (rf2-6xlmv)`** — adds §Empty-result advisory subsections under both tools:
   - trace-window: `:reason :window-excludes-history` (`src/.../tools/trace_window.cljs` lines 130-142)
   - watch-epochs: `:reason :no-events-since-id` + `:reason :pred-excludes-history` (`src/.../tools/watch_epochs.cljs` lines 139-165)

   Slot names match impl verbatim — `:epochs-in-history` / `:epochs-since-id` in the advisory map (distinct from `:history-count` / `:since-count` in the runtime envelope).

4. **`docs(spec): align pair-mcp discover-app with probe.cljs 4-rung diagnostic ladder (rf2-31oq3)`** — rewrites §discover-app's failure narrative to enumerate the four rungs `diagnose-preload-failure!` walks (`src/.../tools/probe.cljs` lines 181-271):
   - `:nrepl-unreachable` (lines 207-210)
   - `:build-not-running` + `:running-builds` (lines 215-219)
   - `:no-runtime-connected` (lines 233-237)
   - `:runtime-loaded-but-preload-missing` (lines 242-245)

   Retains `:runtime-not-preloaded` as the degradation fallback (lines 266-271). Adds the four new reasons to the §Bare-reasons table. Cross-refs success-path build-id cache to `API.md` §Build-id resolution (rf2-l3k8j companion).

## Authority

Impl is authority. Where the bead's quoted shape disagreed with impl (e.g. advisory slot names `:history-count` vs `:epochs-in-history`), impl wins.

## Gates

- `python scripts/check_doc_slugs.py --verbose` — pass (376 markdown files, no broken links)
- `python -m mkdocs build --strict` — pass

## Files changed

- `tools/re-frame2-pair-mcp/spec/API.md` (rf2-l3k8j)
- `tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md` (rf2-7bpm4 + rf2-6xlmv + rf2-31oq3 share the file; sequenced commits)

## Cross-refs

- Surfaced by the 24h spec/impl audit **rf2-zcq0x**.
- Companion impl PRs: **#2116** (rf2-l9ixp) for the cache; **#2120** for the three rf2-* impls (rf2-36awg / rf2-fb4hn / rf2-7tgfk).