### PR TITLE
docs(README): repoint day8/re-frame2-template + day8/reagent-slim URLs to in-tree relative paths (rf2-ho866)

### DIFF
--- a/examples/reagent/counter_slim_and_fast/README.md
+++ b/examples/reagent/counter_slim_and_fast/README.md
@@ -1,9 +1,9 @@
 # counter-slim-and-fast — slim-substrate counter
 
 The canonical counter (`examples/reagent/counter/`) re-mounted on the
-[`day8/reagent-slim`](https://github.com/day8/reagent-slim) rewrite
-rather than stock `day8/re-frame2-reagent` (the thin bridge over
-stock Reagent). The user-visible behaviour is identical to the
+[`day8/reagent-slim`](../../../implementation/adapters/reagent-slim/)
+rewrite rather than stock `day8/re-frame2-reagent` (the thin bridge
+over stock Reagent). The user-visible behaviour is identical to the
 canonical counter; the difference is the substrate beneath.
 
 Every user-facing Reagent import points at `reagent2.*` instead of

--- a/migration/from-clj-new-template/README.md
+++ b/migration/from-clj-new-template/README.md
@@ -5,9 +5,11 @@
 > previous-generation re-frame2 app via the retired
 > `clojure -X:project/new :template re-frame2` invocation
 > (`day8/clj-template.re-frame2` on Clojars). The current template
-> is `day8/re-frame2-template` — a deps-new template distributed as
-> a git-coord on
-> [`github.com/day8/re-frame2-template`](https://github.com/day8/re-frame2-template).
+> is `day8/re-frame2-template` — a deps-new template living in-tree
+> at [`tools/template/`](../../tools/template/) and distributed as
+> a git-coord (planned external repo
+> `github.com/day8/re-frame2-template` — see
+> [`tools/template/spec/005-Repo-Split.md`](../../tools/template/spec/005-Repo-Split.md)).
 
 ## TL;DR
 
@@ -40,8 +42,9 @@ clj-new-era Mustache-only substitution shape.
 ### The distribution channel
 
 **Clojars → git-coord.** The published artefact is no longer
-`day8/clj-template.re-frame2` on Clojars; it is a tagged commit on
-[`github.com/day8/re-frame2-template`](https://github.com/day8/re-frame2-template).
+`day8/clj-template.re-frame2` on Clojars; it is a tagged commit of
+the [`tools/template/`](../../tools/template/) artefact (planned
+external repo `github.com/day8/re-frame2-template`).
 `clojure -Tnew create` resolves the template via deps-new's
 git-coord lookup (`io.github.*` triggers an auto-git-clone of the
 named GitHub repo).

--- a/skills/re-frame2-setup/README.md
+++ b/skills/re-frame2-setup/README.md
@@ -16,8 +16,9 @@ Once the counter mounts, the author switches to the main `re-frame2` skill (for 
 re-frame2 also ships a one-command project generator —
 `day8/re-frame2-template`, a [deps-new](https://github.com/seancorfield/deps-new)
 template living under [`tools/template/`](../../tools/template/) in
-the monorepo today (final home:
-[`github.com/day8/re-frame2-template`](https://github.com/day8/re-frame2-template)).
+the monorepo today (planned external home
+`github.com/day8/re-frame2-template` — see
+[`tools/template/spec/005-Repo-Split.md`](../../tools/template/spec/005-Repo-Split.md)).
 Invoke as `clojure -Tnew create :template io.github.day8/re-frame2-template :name acme/my-app`.
 The two routes are complementary, not redundant:
 

--- a/tools/template/README.md
+++ b/tools/template/README.md
@@ -19,11 +19,11 @@
 > [`VERSION`](./VERSION) carries the template's own version sequence
 > (independent of the framework-wide repo-root `VERSION`).
 >
-> **Repo home:** the template's permanent home is
-> [`github.com/day8/re-frame2-template`](https://github.com/day8/re-frame2-template).
-> It lives under `tools/template/` in the re-frame2 monorepo while the
-> rebuild settles (rf2-dolpf §4); the split out to the external repo is
-> a Mike-operator handoff. The deps-new coord shifts from
+> **Repo home:** the template currently lives in-tree at
+> [`tools/template/`](./) in the re-frame2 monorepo while the rebuild
+> settles (rf2-dolpf §4). Its planned permanent home is the external
+> repo `github.com/day8/re-frame2-template`; the split out to that
+> external repo is a Mike-operator handoff. The deps-new coord shifts from
 > `day8/re-frame2-template` (current `:local/root` shape, monorepo) to
 > `io.github.day8/re-frame2-template` (git-coord, external repo) once
 > the split completes — see [`spec/005-Repo-Split.md`](./spec/005-Repo-Split.md)


### PR DESCRIPTION
## What

Repoints external 404 GitHub URLs in 4 READMEs to the in-tree artefacts that exist today.

| Before | After |
|---|---|
| `examples/reagent/counter_slim_and_fast/README.md` L4 — `[day8/reagent-slim](https://github.com/day8/reagent-slim)` | `[day8/reagent-slim](../../../implementation/adapters/reagent-slim/)` |
| `migration/from-clj-new-template/README.md` L10 — `[github.com/day8/re-frame2-template](https://github.com/day8/re-frame2-template)` | `[tools/template/](../../tools/template/)` + planned-external clarification + spec cross-ref |
| `migration/from-clj-new-template/README.md` L44 — `[github.com/day8/re-frame2-template](https://github.com/day8/re-frame2-template)` | `[tools/template/](../../tools/template/)` + planned-external clarification |
| `skills/re-frame2-setup/README.md` L20 — `[github.com/day8/re-frame2-template](https://github.com/day8/re-frame2-template)` | inlined "planned external home" prose + spec cross-ref (already linked `tools/template/` on adjacent line) |
| `tools/template/README.md` L23 — `[github.com/day8/re-frame2-template](https://github.com/day8/re-frame2-template)` | `[tools/template/](./)` (this README IS the in-tree home; clarified external repo is planned) |

## Why

Per Mike's ruling 2026-05-26 (rf2-ho866):

> (d) repoint external 404 URLs to in-tree relative links. The artefacts EXIST in-tree (day8/re-frame2-template → tools/template/; day8/reagent-slim → implementation/adapters/reagent-slim/). The 404s are only against external GitHub repo URLs that haven't been created yet (rf2-dolpf for template; parallel work for reagent-slim). Repointing makes nav work now AND preserves forward-ref intent via coord names in prose. When splits land, search-replace repoints to new external repos.

Artefact coord names (`day8/re-frame2-template`, `day8/reagent-slim`) remain in prose as the maven-style coords; only hyperlink targets change. Prose is softened where it leaned heavily on the "external repo" idiom — one-clause clarification, no over-rewriting.

## What is NOT changed

Spec content describing the planned external split is unchanged — those are normative migration plans (rf2-dolpf §4 / rf2-7jgkv) and intentionally reference the post-split external repo URL:

- `tools/template/spec/003-DepsNew-Rebuild-Plan.md` — migration plan
- `tools/template/spec/005-Repo-Split.md` — the spec for the split itself (includes one active hyperlink at L186 inside a fenced code block showing the post-split redirect README template — intentional)
- `tools/template/spec/README.md` — spec index referencing 005

Plain-text mentions of the artefact coord (e.g., `README.md:236` layout map) are also unchanged — they are coord names, not hyperlinks.

## Gates

- `python scripts/check_doc_slugs.py --verbose` — `no broken links.` (376 markdown files scanned)
- `python -m mkdocs build --strict` — `Documentation built in 8.90 seconds`
- Negative grep `git grep -nE '\]\(https://github\.com/day8/(re-frame2-template|reagent-slim)' -- '*.md'` returns only the intentional spec-example match at `tools/template/spec/005-Repo-Split.md:186`

## Bead

Closes rf2-ho866 (decision bead — mayor closes after merge).