### PR TITLE
feat(xray): default IXrayDataDisplay formatters for uuid + inst (rf2-x16b1)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1429,6 +1429,8 @@ Phases 2-5 file as separate beads chained off rf2-oqa60:
   see §10.0.7
 - Phase 7 (rf2-0qrcr) — `IXrayDataDisplay` custom-formatters
   protocol (D7=a) — see §10.0.6
+- Phase 7 follow-on (rf2-x16b1) — curated default formatters
+  for `uuid` + `inst` (uri deferred) — see §10.0.9
 
 #### §10.0.5 Code-block (separate surface)
 
@@ -1749,6 +1751,64 @@ no chip-reveal leakage.
    (`diff-forces-ancestor-chain-open-over-changed-descendant`).
 6. The public widget's outer container carries `data-rf-mode
    "diff"` when `:before` is supplied; `"browse"` otherwise.
+
+#### §10.0.9 Default `IXrayDataDisplay` formatters (rf2-x16b1)
+
+The phase-7 protocol seam (§10.0.6) ships zero default impls — every
+consuming app would have to register the same boilerplate for the
+common types where the raw repr is genuinely cramped. rf2-x16b1
+ships a curated set of opinionated default formatters, loaded
+automatically when `views.data-display` is required.
+
+**Coverage** — the curated set is deliberately small. Each type
+included carries a clear win over `pr-str`; the rest stay on the
+built-in dispatch.
+
+| Type           | Header (collapsed)            | Body (expanded)              | Title (hover)        |
+|----------------|-------------------------------|------------------------------|----------------------|
+| `cljs.core/UUID` | `#uuid "…<last-8>"`         | `#uuid "<full-36-char>"`     | full canonical form  |
+| `js/Date` (`inst?`) | `#inst "<relative>"`     | `#inst "<ISO-8601>"`         | full ISO             |
+
+**Relative-time formatter** — pure-data buckets, no library dep:
+
+- `< 5s`                   → `just now`
+- `< 60s`                  → `Ns ago` / `in Ns`
+- `< 60m`                  → `Nm ago` / `in Nm`
+- `< 24h`                  → `Nh ago` / `in Nh`
+- `< 30d`                  → `Nd ago` / `in Nd`
+- else                     → `YYYY-MM-DD`
+
+The 30-day upper bound on relative-time avoids `247d ago` reading
+as precise when the eye actually wants the ISO date. Both
+directions are symmetric — past (`Nm ago`) and future (`in Nm`) —
+so scheduled-event timestamps read naturally.
+
+**URI heuristic — deliberately deferred.** CLJS has no built-in
+`uri?` predicate, and extending `js/String` so non-URL strings can
+return `nil` from the protocol path would route every string in
+every render through the seam — invasive on a fundamental type
+for a marginal win. Domain URI wrappers (`goog.Uri`, project-
+specific types) can opt in via `extend-type` per the standard
+contract. The seam-via-extension stays the project-owned escape
+hatch.
+
+**Consumer precedence** — consumers who `extend-type` the same
+types win. CLJS protocol dispatch is not class-hierarchy-based;
+the most-recently-loaded impl is the one that fires. The bundled
+defaults are inert when a consumer takes the seam for a type they
+own. Regression-anchored by
+`consumer-extension-wins-over-default-on-its-own-type` in
+`tools/xray/test/day8/re_frame2_xray/views/data_display_default_formatters_cljs_test.cljs`.
+
+**Surface** — `day8.re-frame2-xray.views.data-display-default-formatters`.
+Public for tests + reference:
+
+- `format-relative` — pure-data inst bucketing against a pinned `now`
+- `render-uuid-header` / `render-uuid-body`
+- `render-inst-header` / `render-inst-body`
+
+The ns is required for side-effect (the `extend-type` forms) from
+`views.data-display` itself — no call-site registration needed.
 
 ### §10.1 Capabilities (LOCKED per B.9 super-prompt)
 

--- a/tools/xray/src/day8/re_frame2_xray/views/data_display.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/data_display.cljs
@@ -117,7 +117,12 @@
             [re-frame.core :as rf]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens mono-stack sans-stack]]
-            [day8.re-frame2-xray.views.data-display-protocol :as ddp]))
+            [day8.re-frame2-xray.views.data-display-protocol :as ddp]
+            ;; rf2-x16b1 — load default IXrayDataDisplay formatters
+            ;; for uuid + inst. Requiring for side-effect (extend-type).
+            ;; Consumers that extend the same types win — `extend-type`
+            ;; installs the most-recently-loaded impl.
+            [day8.re-frame2-xray.views.data-display-default-formatters]))
 
 ;; =========================================================================
 ;; expansion state — lives in :rf.xray.data-display/expansion under :rf/xray

--- a/tools/xray/src/day8/re_frame2_xray/views/data_display_default_formatters.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/data_display_default_formatters.cljs
@@ -1,0 +1,215 @@
+(ns day8.re-frame2-xray.views.data-display-default-formatters
+  "Default `IXrayDataDisplay` formatters for common CLJS types
+  (rf2-x16b1 · follow-on to rf2-0qrcr phase 7).
+
+  ## Why this exists
+
+  Phase 7 of rf2-oqa60 shipped the `IXrayDataDisplay` protocol as the
+  single extension seam for the closed phase-1 renderer. The widget
+  ships ZERO default protocol implementations — consuming apps must
+  opt in per domain type via `extend-type`.
+
+  For common Clojure(Script) types where the raw repr is genuinely
+  cramped or unhelpful, shipping opinionated defaults serves the
+  primary lenses of CLARITY and ELEGANCE without forcing every app
+  to repeat the same boilerplate. Mike's 2026-05-26 ruling: ship the
+  curated set `uuid + inst (+ uri)`.
+
+  ## Coverage
+
+  - **`cljs.core/UUID`** — header compacts to `#uuid \"…last8\"`
+    with a `title` carrying the full canonical 36-char form on hover;
+    body expands to the full canonical form. Built-in scalar repr
+    `#uuid \"<full>\"` is correct but visually noisy in long lists of
+    uuids — the compact-with-hover form scans an inspector at a
+    glance, the full form drops in on expand.
+
+  - **`js/Date`** (i.e. `inst?` instances in CLJS) — header renders
+    a friendly relative-time string (`just now`, `3m ago`, `2h ago`,
+    `5d ago`, `in 3m`, ISO date for older than 30 days) with the
+    full ISO carried on `title`; body expands to the ISO string.
+    The relative-time formatter is a ~30-line pure function with no
+    library dependency — see `format-relative` below.
+
+  - **URI heuristic** — deliberately **NOT** shipped. CLJS has no
+    built-in `uri?` predicate; extending `js/String` so non-URL
+    strings can return `nil` would route every string through the
+    protocol seam, which is invasive on a fundamental type. Domain
+    URI types (`goog.Uri`, project-specific wrappers) can opt in
+    via `extend-type` per the standard contract. Documented in
+    spec/021 §10.0.9.
+
+  ## Loading
+
+  This namespace is `:require`d by `views.data-display` itself —
+  loading the renderer also loads the defaults. No call-site
+  registration needed.
+
+  ## Precedence
+
+  Consumers who extend `IXrayDataDisplay` on the same types (e.g. a
+  project that wants its own uuid rendering) **win** — `extend-type`
+  installs the most-recently-loaded impl. The bundled defaults are
+  inert if a consumer has already extended the type. (CLJS protocol
+  dispatch is not class-hierarchy-based, so there is no `:default`
+  ambiguity.)
+
+  ## Why not extend in the protocol ns
+
+  The protocol ns (`data-display-protocol`) stays a pure contract
+  surface — defprotocol + safe accessors + nothing else. Default
+  formatters are a separate concern: opinionated UI choices that
+  could plausibly be swapped out by a consumer's preferred
+  conventions. Keeping them in a sibling ns keeps the contract crisp
+  and lets the defaults be diff'd / replaced / studied as a single
+  artefact."
+  (:require [day8.re-frame2-xray.theme.tokens
+             :refer [tokens mono-stack]]
+            [day8.re-frame2-xray.views.data-display-protocol
+             :refer [IXrayDataDisplay]]))
+
+;; =========================================================================
+;; styles — read CSS-variable tokens so light/dark themes resolve at paint
+;; =========================================================================
+
+(defn- token-style
+  [token-key]
+  {:color       (get tokens token-key)
+   :font-family mono-stack})
+
+;; =========================================================================
+;; UUID — compact header `#uuid "…<last-8>"`, full body
+;; =========================================================================
+
+(defn- uuid-compact-tail
+  "Take the last 8 hex chars of a canonical uuid string. Pure data.
+  Used to build the `#uuid \"…<tail>\"` collapsed header."
+  [s]
+  (let [n (count s)]
+    (if (>= n 8) (subs s (- n 8)) s)))
+
+(defn render-uuid-header
+  "Build the collapsed-header hiccup for a uuid. Public for tests."
+  [v]
+  (let [s    (str v)
+        tail (uuid-compact-tail s)]
+    [:span {:data-rf-type        "uuid"
+            :data-rf-default-fmt "uuid"
+            :title               (str "#uuid \"" s "\"")
+            :style               (token-style :info)}
+     (str "#uuid \"…" tail "\"")]))
+
+(defn render-uuid-body
+  "Build the expanded-body hiccup for a uuid. Public for tests."
+  [v]
+  [:span {:data-rf-default-fmt-body "uuid"
+          :style                    (token-style :info)}
+   (str "#uuid \"" v "\"")])
+
+(extend-type cljs.core/UUID
+  IXrayDataDisplay
+  (-xray-render-header [v _opts] (render-uuid-header v))
+  (-xray-render-body   [v _opts] (render-uuid-body v)))
+
+;; =========================================================================
+;; inst (js/Date) — relative-time header, ISO body
+;; =========================================================================
+
+(def ^:private MS_PER_SECOND 1000)
+(def ^:private MS_PER_MINUTE (* 60 MS_PER_SECOND))
+(def ^:private MS_PER_HOUR   (* 60 MS_PER_MINUTE))
+(def ^:private MS_PER_DAY    (* 24 MS_PER_HOUR))
+(def ^:private MS_PER_30_DAYS (* 30 MS_PER_DAY))
+
+(defn- pad2
+  "Zero-pad a non-negative integer to 2 chars."
+  [n]
+  (if (< n 10) (str "0" n) (str n)))
+
+(defn- iso-date-only
+  "`YYYY-MM-DD` from a js/Date in UTC. Used as the fallback when a
+  date is older than 30 days — the relative-time formatter caps at
+  `30d ago` to avoid implying false precision for ancient dates."
+  [^js d]
+  (str (.getUTCFullYear d) "-"
+       (pad2 (inc (.getUTCMonth d))) "-"
+       (pad2 (.getUTCDate d))))
+
+(defn format-relative
+  "Format a js/Date as a relative-time string against `now-ms`. Pure
+  function — pass `now-ms` so tests can pin the reference.
+
+  Bucketing:
+
+  - `< 5s`           → `just now`
+  - `< 60s`          → `Ns ago` / `in Ns`
+  - `< 60m`          → `Nm ago` / `in Nm`
+  - `< 24h`          → `Nh ago` / `in Nh`
+  - `< 30d`          → `Nd ago` / `in Nd`
+  - else             → ISO date `YYYY-MM-DD`
+
+  The `in N…` future-tense form catches scheduled-event timestamps;
+  the `30d` upper bound on relative-time avoids `247d ago` reading
+  as precise when the eye actually wants `2025-09-12`.
+
+  Public for tests."
+  [^js d now-ms]
+  (let [t      (.getTime d)
+        diff   (- now-ms t)
+        abs    (Math/abs diff)
+        future? (neg? diff)]
+    (cond
+      (< abs (* 5 MS_PER_SECOND))
+      "just now"
+
+      (< abs MS_PER_MINUTE)
+      (let [n (.floor js/Math (/ abs MS_PER_SECOND))]
+        (if future? (str "in " n "s") (str n "s ago")))
+
+      (< abs MS_PER_HOUR)
+      (let [n (.floor js/Math (/ abs MS_PER_MINUTE))]
+        (if future? (str "in " n "m") (str n "m ago")))
+
+      (< abs MS_PER_DAY)
+      (let [n (.floor js/Math (/ abs MS_PER_HOUR))]
+        (if future? (str "in " n "h") (str n "h ago")))
+
+      (< abs MS_PER_30_DAYS)
+      (let [n (.floor js/Math (/ abs MS_PER_DAY))]
+        (if future? (str "in " n "d") (str n "d ago")))
+
+      :else
+      (iso-date-only d))))
+
+(defn- iso-string
+  "ISO-8601 string for a js/Date. Uses the built-in `.toISOString` —
+  always UTC, always `YYYY-MM-DDTHH:mm:ss.sssZ`."
+  [^js d]
+  (try (.toISOString d)
+       (catch :default _ (str d))))
+
+(defn render-inst-header
+  "Build the collapsed-header hiccup for an inst. Public for tests.
+  `now-ms` is the reference for the relative-time formatter; in the
+  protocol-method path it defaults to `(.getTime (js/Date.))`."
+  ([v] (render-inst-header v (.getTime (js/Date.))))
+  ([v now-ms]
+   (let [iso (iso-string v)
+         rel (format-relative v now-ms)]
+     [:span {:data-rf-type        "inst"
+             :data-rf-default-fmt "inst"
+             :title               iso
+             :style               (token-style :info)}
+      (str "#inst \"" rel "\"")])))
+
+(defn render-inst-body
+  "Build the expanded-body hiccup for an inst. Public for tests."
+  [v]
+  [:span {:data-rf-default-fmt-body "inst"
+          :style                    (token-style :info)}
+   (str "#inst \"" (iso-string v) "\"")])
+
+(extend-type js/Date
+  IXrayDataDisplay
+  (-xray-render-header [v _opts] (render-inst-header v))
+  (-xray-render-body   [v _opts] (render-inst-body v)))

--- a/tools/xray/test/day8/re_frame2_xray/views/data_display_default_formatters_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/data_display_default_formatters_cljs_test.cljs
@@ -1,0 +1,249 @@
+(ns day8.re-frame2-xray.views.data-display-default-formatters-cljs-test
+  "Unit tests for the default `IXrayDataDisplay` formatters
+  (rf2-x16b1 · follow-on to rf2-0qrcr phase 7).
+
+  ## What's under test
+
+  1. **`format-relative` bucketing** — `just now`, `Ns ago`, `Nm ago`,
+     `Nh ago`, `Nd ago`, ISO-date for older than 30 days, and the
+     symmetric `in N…` future-tense buckets.
+  2. **UUID header + body** — compact `…last8` collapsed header,
+     full canonical body, title attribute on header carries the full
+     form so hover reveals the long uuid.
+  3. **Inst (js/Date) header + body** — relative-time header against
+     a pinned `now`, ISO body, title carries the full ISO.
+  4. **Render-node integration** — mounting `[data-display some-uuid]`
+     routes through the protocol path (asserted via
+     `:data-rf-protocol \"1\"`); same for inst.
+  5. **Consumer override wins** — a consumer's `extend-type` against
+     the same type takes precedence (CLJS protocol-dispatch contract).
+     This is the regression-anchor for the precedence guarantee in
+     the namespace docstring.
+
+  Pure-data unit tests; no DOM mount."
+  (:require [cljs.test :refer-macros [deftest is use-fixtures]]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-xray.views.data-display :as dd]
+            [day8.re-frame2-xray.views.data-display-default-formatters
+             :as ddf]
+            [day8.re-frame2-xray.views.data-display-protocol
+             :refer [IXrayDataDisplay]]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+;; ---- helpers ------------------------------------------------------------
+
+(defn- walk-hiccup
+  "Depth-first collect every hiccup vector in `tree`."
+  [tree]
+  (let [out (atom [])]
+    (letfn [(walk [node]
+              (cond
+                (vector? node)
+                (do (swap! out conj node)
+                    (doseq [child (rest node)] (walk child)))
+                (seq? node) (doseq [c node] (walk c))))]
+      (walk tree))
+    @out))
+
+(defn- find-attr
+  [tree k v]
+  (->> (walk-hiccup tree)
+       (filter (fn [n]
+                 (and (vector? n)
+                      (map? (second n))
+                      (= v (get (second n) k)))))
+       first))
+
+(defn- collect-text
+  [tree]
+  (let [out (atom [])]
+    (letfn [(walk [node]
+              (cond
+                (string? node) (swap! out conj node)
+                (vector? node) (doseq [c (rest node)] (walk c))
+                (seq? node)    (doseq [c node] (walk c))))]
+      (walk tree))
+    (apply str @out)))
+
+;; =========================================================================
+;; format-relative — pure-data bucketing
+;; =========================================================================
+
+(def ^:private epoch-2026 1764547200000) ;; 2026-01-01T00:00:00.000Z
+
+(defn- ms-ago [now ms] (js/Date. (- now ms)))
+(defn- ms-future [now ms] (js/Date. (+ now ms)))
+
+(deftest format-relative-just-now
+  (is (= "just now" (ddf/format-relative (js/Date. epoch-2026) epoch-2026)))
+  (is (= "just now" (ddf/format-relative (ms-ago epoch-2026 2000) epoch-2026))
+      "anything under 5s collapses to `just now`"))
+
+(deftest format-relative-seconds
+  (is (= "10s ago" (ddf/format-relative (ms-ago epoch-2026 10000) epoch-2026)))
+  (is (= "59s ago" (ddf/format-relative (ms-ago epoch-2026 59999) epoch-2026)))
+  (is (= "in 10s"  (ddf/format-relative (ms-future epoch-2026 10000) epoch-2026))))
+
+(deftest format-relative-minutes
+  (is (= "1m ago"  (ddf/format-relative (ms-ago epoch-2026 (* 60 1000)) epoch-2026)))
+  (is (= "3m ago"  (ddf/format-relative (ms-ago epoch-2026 (* 3 60 1000)) epoch-2026)))
+  (is (= "59m ago" (ddf/format-relative (ms-ago epoch-2026 (* 59 60 1000)) epoch-2026)))
+  (is (= "in 3m"   (ddf/format-relative (ms-future epoch-2026 (* 3 60 1000)) epoch-2026))))
+
+(deftest format-relative-hours
+  (is (= "1h ago"  (ddf/format-relative (ms-ago epoch-2026 (* 60 60 1000)) epoch-2026)))
+  (is (= "5h ago"  (ddf/format-relative (ms-ago epoch-2026 (* 5 60 60 1000)) epoch-2026)))
+  (is (= "23h ago" (ddf/format-relative (ms-ago epoch-2026 (* 23 60 60 1000)) epoch-2026)))
+  (is (= "in 2h"   (ddf/format-relative (ms-future epoch-2026 (* 2 60 60 1000)) epoch-2026))))
+
+(deftest format-relative-days
+  (is (= "1d ago"  (ddf/format-relative (ms-ago epoch-2026 (* 24 60 60 1000)) epoch-2026)))
+  (is (= "5d ago"  (ddf/format-relative (ms-ago epoch-2026 (* 5 24 60 60 1000)) epoch-2026)))
+  (is (= "29d ago" (ddf/format-relative (ms-ago epoch-2026 (* 29 24 60 60 1000)) epoch-2026)))
+  (is (= "in 7d"   (ddf/format-relative (ms-future epoch-2026 (* 7 24 60 60 1000)) epoch-2026))))
+
+(deftest format-relative-older-than-30-days
+  ;; Cap at 30d — beyond that, an ISO date is more honest than `247d ago`.
+  (let [d (ms-ago epoch-2026 (* 60 24 60 60 1000))   ;; 60 days back
+        s (ddf/format-relative d epoch-2026)]
+    (is (re-find #"^\d{4}-\d{2}-\d{2}$" s)
+        (str "older than 30d falls to ISO date; got: " s))))
+
+;; =========================================================================
+;; UUID — header + body
+;; =========================================================================
+
+(def ^:private sample-uuid (random-uuid))
+
+(deftest uuid-header-compact-tail
+  (let [h (ddf/render-uuid-header sample-uuid)
+        text (collect-text h)
+        attrs (second h)]
+    (is (re-find #"#uuid \"…[0-9a-f]{8}\"" text)
+        (str "compact header shows `#uuid \"…<8>\"`; got: " text))
+    (is (= (str "#uuid \"" sample-uuid "\"") (:title attrs))
+        "title attribute carries the full canonical form")
+    (is (= "uuid" (get attrs :data-rf-type)))
+    (is (= "uuid" (get attrs :data-rf-default-fmt)))))
+
+(deftest uuid-body-shows-full-form
+  (let [b (ddf/render-uuid-body sample-uuid)
+        text (collect-text b)]
+    (is (re-find (re-pattern (str "#uuid \"" sample-uuid "\"")) text)
+        "expanded body shows the full canonical uuid")))
+
+(deftest uuid-renders-through-protocol-path-when-mounted
+  (let [h (dd/render-node {:value sample-uuid
+                           :panel-id :test
+                           :mount-id "m1"
+                           :path []
+                           :depth 0
+                           :expansion-map {}
+                           :opts {}})]
+    (is (some? (find-attr h :data-rf-protocol "1"))
+        "uuid goes through the protocol path, not the built-in :uuid scalar")
+    (is (some? (find-attr h :data-rf-default-fmt "uuid"))
+        "default formatter's header is rendered")
+    (is (re-find #"#uuid \"…[0-9a-f]{8}\"" (collect-text h))
+        "compact form appears in rendered output")))
+
+(deftest uuid-body-rendered-when-expanded
+  ;; Default-expanded? on protocol nodes is true (see render-protocol-node),
+  ;; so the body container appears without operator interaction.
+  (let [h (dd/render-node {:value sample-uuid
+                           :panel-id :test
+                           :mount-id "m2"
+                           :path []
+                           :depth 0
+                           :expansion-map {}
+                           :opts {}})]
+    (is (some? (find-attr h :data-rf-default-fmt-body "uuid"))
+        "uuid body container rendered when expanded")
+    (is (re-find (re-pattern (str sample-uuid)) (collect-text h))
+        "full uuid appears in body text")))
+
+;; =========================================================================
+;; inst (js/Date) — header + body
+;; =========================================================================
+
+(deftest inst-header-relative-time
+  (let [now epoch-2026
+        d   (ms-ago now (* 3 60 1000))   ;; 3 min ago
+        h   (ddf/render-inst-header d now)
+        attrs (second h)
+        text  (collect-text h)]
+    (is (= "#inst \"3m ago\"" text)
+        (str "header renders #inst-style relative time; got: " text))
+    (is (= (.toISOString d) (:title attrs))
+        "title attribute carries the full ISO")
+    (is (= "inst" (get attrs :data-rf-type)))
+    (is (= "inst" (get attrs :data-rf-default-fmt)))))
+
+(deftest inst-body-shows-iso
+  (let [d (js/Date. epoch-2026)
+        b (ddf/render-inst-body d)
+        text (collect-text b)]
+    (is (re-find (re-pattern (str "#inst \"" (.toISOString d) "\"")) text)
+        "body shows the full ISO-8601 form")))
+
+(deftest inst-renders-through-protocol-path-when-mounted
+  (let [d (js/Date. epoch-2026)
+        h (dd/render-node {:value d
+                           :panel-id :test
+                           :mount-id "m3"
+                           :path []
+                           :depth 0
+                           :expansion-map {}
+                           :opts {}})]
+    (is (some? (find-attr h :data-rf-protocol "1"))
+        "inst goes through the protocol path")
+    (is (some? (find-attr h :data-rf-default-fmt "inst"))
+        "default formatter's inst header rendered")))
+
+(deftest inst-body-rendered-when-expanded
+  (let [d (js/Date. epoch-2026)
+        h (dd/render-node {:value d
+                           :panel-id :test
+                           :mount-id "m4"
+                           :path []
+                           :depth 0
+                           :expansion-map {}
+                           :opts {}})]
+    (is (some? (find-attr h :data-rf-default-fmt-body "inst"))
+        "inst body container rendered when expanded")
+    (is (re-find #"#inst \"\d{4}-\d{2}-\d{2}T" (collect-text h))
+        "ISO form appears in body text")))
+
+;; =========================================================================
+;; Consumer override wins — CLJS protocol-dispatch precedence
+;; =========================================================================
+
+(deftype MyWrappedUUID [uuid]
+  IXrayDataDisplay
+  (-xray-render-header [_ _opts]
+    [:span {:data-testid "custom-uuid-header"} "custom-uuid"])
+  (-xray-render-body [_ _opts]
+    [:span {:data-testid "custom-uuid-body"} "custom-uuid-body"]))
+
+(deftest consumer-extension-wins-over-default-on-its-own-type
+  ;; A consumer wrapping a uuid in their own type renders via their
+  ;; own protocol impl — not the default uuid formatter. This pins
+  ;; the contract: defaults are inert when a consumer takes the seam
+  ;; for a type they own.
+  (let [v (MyWrappedUUID. (random-uuid))
+        h (dd/render-node {:value v
+                           :panel-id :test
+                           :mount-id "m5"
+                           :path []
+                           :depth 0
+                           :expansion-map {}
+                           :opts {}})]
+    (is (some? (find-attr h :data-rf-protocol "1"))
+        "protocol path taken")
+    (is (some? (find-attr h :data-testid "custom-uuid-header"))
+        "consumer's header wins")
+    (is (nil? (find-attr h :data-rf-default-fmt "uuid"))
+        "default uuid formatter is NOT in the output for the consumer type")))


### PR DESCRIPTION
## Summary

Phase 7 of rf2-oqa60 (#2148) shipped the `IXrayDataDisplay` protocol
as the single extension seam on the closed phase-1 renderer but
landed **zero** default impls. rf2-x16b1 ships the curated default
set Mike ruled 2026-05-26 — **uuid + inst** (uri deferred).

Mike's ruling: `(a) curated default set — uuid + inst + uri`. URI
shipped as a deferral with rationale — see below.

## What lands

### `cljs.core/UUID`

- **Header** (collapsed): `#uuid "...<last-8>"` with `title`
  carrying the full canonical 36-char form on hover.
- **Body** (expanded): the full canonical form.

Built-in `:uuid` scalar (`#uuid "<full>"`) is correct but visually
noisy in long lists of uuids — the compact-with-hover form scans an
inspector at a glance; the full form drops in on expand.

### `js/Date` (i.e. `inst?` in CLJS)

- **Header** (collapsed): relative-time string against `now` (e.g.
  `#inst "3m ago"`, `#inst "5d ago"`, `#inst "2025-09-12"` for
  >30d) with `title` carrying the full ISO-8601.
- **Body** (expanded): the full ISO-8601 string.

#### Relative-time bucketing

Pure-data buckets, no library dep:

  - `< 5s`   → `just now`
  - `< 60s`  → `Ns ago` / `in Ns`
  - `< 60m`  → `Nm ago` / `in Nm`
  - `< 24h`  → `Nh ago` / `in Nh`
  - `< 30d`  → `Nd ago` / `in Nd`
  - else     → `YYYY-MM-DD`

The 30-day upper bound on relative-time avoids `247d ago` reading as
precise when the eye actually wants the ISO date. Symmetric
past/future so scheduled-event timestamps read naturally.

### URI — deliberately deferred

CLJS has no built-in `uri?` predicate. JVM `java.net.URI` /
`java.net.URL` have no CLJS counterpart. The widget runs in CLJS
(Xray browser context).

Three implementation paths were considered:

1. **String heuristic** — treat strings starting with
   `https?://` / `mailto:` / `ws://` etc. as URLs. Risks
   false positives + routes **every string in every render** through
   the protocol `satisfies?` check, then a header call that returns
   `nil` for non-URLs — invasive on a fundamental type for a
   marginal win.
2. **Marker protocol** (`IXrayURIish`) — adds boilerplate; the
   existing `IXrayDataDisplay` extension already covers this case
   for projects with domain URI wrappers.
3. **Defer** — domain URI types (`goog.Uri`, project wrappers) opt
   in via standard `extend-type`. Pre-alpha posture: ship the
   high-value cases; defer the marginal one.

I chose **defer**. Documented in spec/021 §10.0.9 as the rationale
+ escape-hatch pointer.

## File layout

New sibling ns:
`day8.re-frame2-xray.views.data-display-default-formatters`.

- The protocol ns (`views.data-display-protocol`) stays a pure
  contract surface — `defprotocol` + safe accessors + docstrings.
- The defaults are a separately-diffable artefact — opinionated UI
  that a consumer could plausibly want to read end-to-end or swap
  out wholesale.

`views.data-display` requires the new ns for side-effect so the
defaults load whenever the renderer does. No call-site
registration needed.

## Consumer precedence (regression-anchored)

CLJS protocol dispatch is not class-hierarchy-based; the
most-recently-loaded impl wins. A consuming app that
`extend-type`s `cljs.core/UUID` or `js/Date` with its own
formatter wins over the bundled defaults — the bundled impls
become inert for that type.

Anchored by
`consumer-extension-wins-over-default-on-its-own-type` in the new
test ns.

## Tests

13 new `deftest`s in
`tools/xray/test/day8/re_frame2_xray/views/data_display_default_formatters_cljs_test.cljs`:

- `format-relative` bucketing — just-now, seconds, minutes, hours,
  days, older-than-30d, both past + future
- `uuid` header (compact tail + title) + body (full canonical)
- `inst` header (relative + title ISO) + body (full ISO)
- `render-node` integration — `data-rf-protocol "1"` on the
  rendered hiccup proves the protocol path is taken for uuid + inst
- consumer-extension precedence — a custom impl on the same type
  wins over the default

## Spec

`tools/xray/spec/021-Dynamic-Panel-Designs.md` adds **§10.0.9
Default `IXrayDataDisplay` formatters (rf2-x16b1)** covering:

- the curated coverage table (uuid + inst)
- the relative-time scheme
- the URI deferral rationale
- the consumer-precedence guarantee
- the public formatter surface

The §10.0.4 phased-rollout summary gains a follow-on line citing
this work.

## Gates

- `npm run test:cljs` (in implementation/) — passes
- `npm run test:browser` (in implementation/) — passes (124 / 346)
- `clojure -M:test` (in tools/xray/) — passes (859 / 3067)
- `clj-kondo --lint tools/xray/src tools/xray/test` — 0 errors

mkdocs not run locally (no top-level `spec/` change; xray spec
lives under `tools/xray/spec/` which is not staged into the
mkdocs `docs_dir`).

Closes rf2-x16b1.