### PR TITLE
fix(xray): data-display UX cluster — palette + hit-box + map layout + expansion persistence (rf2-79ojx + rf2-tzvk9 + rf2-1bra5 + rf2-pvsxs)

### DIFF
--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/theme/tokens.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/theme/tokens.cljc
@@ -118,13 +118,21 @@
    :magenta        "#E879F9"
    :info           "#79c0ff"
 
-   ;; syntax-highlighter palette (rf2-93jp0) — mirrored from Xray's
-   ;; dark-palette so the `xray-and-machines-viz-dark-palettes-match-
-   ;; key-set` drift gate stays green. Tokens are Xray-source-highlighter
-   ;; surface; the chart itself does not read them.
-   :syntax-keyword "#ff7b72"
-   :syntax-string  "#a5d6ff"
-   :syntax-number  "#79c0ff"
+   ;; syntax-highlighter palette (rf2-79ojx · One Dark / Atom One Dark)
+   ;; mirrored from Xray's dark-palette so the `xray-and-machines-viz-
+   ;; dark-palettes-match-key-set` drift gate stays green. Tokens are
+   ;; Xray-source-highlighter + data-display surface; the chart itself
+   ;; does not read them. See Xray's `tokens.cljc` for the palette
+   ;; rationale (CLJS-editor-syntax-highlight scheme — keyword magenta /
+   ;; string green / number orange / boolean gold / nil grey).
+   :syntax-keyword     "#c678dd"
+   :syntax-string      "#98c379"
+   :syntax-number      "#d19a66"
+   :syntax-boolean     "#e5c07b"
+   :syntax-nil         "#7f848e"
+   :syntax-symbol      "#61afef"
+   :syntax-builtin     "#61afef"
+   :syntax-punctuation "#abb2bf"
 
    :red-deep       "#a83a3a"
    :white          "#ffffff"})
@@ -187,15 +195,18 @@
    :magenta        "#B146C2"
    :info           "#0550ae"
 
-   ;; syntax-highlighter palette (rf2-93jp0) — light-palette mirror of
-   ;; Xray's syntax tokens. The light drift gate (`xray-and-machines-
-   ;; viz-light-palettes-match-values`) is shared-key equality, so
-   ;; mirroring keeps the two palettes symmetric and lets a future
-   ;; embed of machines-viz that DOES want to colour code surfaces find
-   ;; the same Figma palette under the same token name.
-   :syntax-keyword "#cf222e"
-   :syntax-string  "#0a3069"
-   :syntax-number  "#0550ae"
+   ;; syntax-highlighter palette (rf2-79ojx · One Light / Atom One Light)
+   ;; mirrored from Xray's light-palette so the light drift gate
+   ;; (`xray-and-machines-viz-light-palettes-match-values`) stays green.
+   ;; See Xray's `tokens.cljc` for the palette rationale.
+   :syntax-keyword     "#a626a4"
+   :syntax-string      "#50a14f"
+   :syntax-number      "#986801"
+   :syntax-boolean     "#c18401"
+   :syntax-nil         "#a0a1a7"
+   :syntax-symbol      "#4078f2"
+   :syntax-builtin     "#4078f2"
+   :syntax-punctuation "#383a42"
 
    :red-deep       "#9A3030"
    :white          "#ffffff"})

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs
@@ -137,11 +137,19 @@
   (§10.4). The keyword-accent is already orange (owned by
   rf2-ad7zx.3)."
   [value before render-id]
-  (let [_node-key (str "app-db-state/" render-id)]
+  (let [_node-key (str "app-db-state/" render-id)
+        ;; rf2-pvsxs — stable `:site-id` so expansion overrides survive
+        ;; a tab-switch round-trip. `render-id` already identifies the
+        ;; logical surface (e.g. "top" for the user-domain section, an
+        ;; area name for the per-:rf/* sections), so passing it AS the
+        ;; site-id reuses the existing per-surface key without
+        ;; introducing a new namespace.
+        site-id [:rf.xray/app-db render-id]]
     (if (= h/no-diff before)
       [dd/data-display
        (f/display-value value)
        {:panel-id :rf.xray/app-db
+        :site-id  site-id
         :default-expanded-depth 3
         ;; rf2-l4625 — the App-DB whole-tree is the canonical "cramped
         ;; in the side panel" case; the popup gives the operator a
@@ -150,6 +158,7 @@
       [dd/data-display
        (f/display-value value)
        {:panel-id :rf.xray/app-db
+        :site-id  site-id
         :default-expanded-depth 3
         :before (f/display-value before)
         :popup-affordance? true}])))

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_canvas.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_canvas.cljs
@@ -421,6 +421,10 @@
       "(no snapshot — machine uninitialised or trace pre-snapshot-tagging)"]
      [dd/data-display snapshot
       {:panel-id (snapshot-panel-id machine-id phase)
+       ;; rf2-pvsxs — machine + phase are stable identifiers; the
+       ;; operator's drill-into-data choices survive a Machines tab
+       ;; leave-and-return round-trip.
+       :site-id  [:rf.xray.machines/snapshot machine-id phase]
        :default-expanded-depth 2
        ;; rf2-l4625 — machine snapshots routinely carry deeply-nested
        ;; `:data` maps; the popup gives the operator a full-modal

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
@@ -344,6 +344,10 @@
       label]
      [dd/data-display snapshot
       {:panel-id (snapshot-panel-id machine-id phase)
+       ;; rf2-pvsxs — machine + phase are stable identifiers; the
+       ;; operator's drill-into-data choices survive a Machines tab
+       ;; leave-and-return round-trip.
+       :site-id  [:rf.xray.machines/inspector-snapshot machine-id phase]
        :default-expanded-depth 2
        ;; rf2-l4625 — machine snapshots routinely carry deeply-nested
        ;; `:data` maps; the popup gives the operator a full-modal

--- a/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_view.cljs
@@ -486,6 +486,11 @@
        [:div {:data-testid (str row-testid "-value")
               :style {:padding-left "4px"}}
         [dd/data-display value {:panel-id (sub-value-panel-id sub-id)
+                                ;; rf2-pvsxs — sub-id is stable across
+                                ;; cascades; the operator's expansion
+                                ;; choices survive a tab leave-and-
+                                ;; return round-trip.
+                                :site-id  [:rf.xray.reactive/sub sub-id]
                                 :default-expanded-depth 2
                                 ;; rf2-l4625 — sub values can be the
                                 ;; full domain projection (cart, users,

--- a/tools/xray/src/day8/re_frame2_xray/panels/trace.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/trace.cljs
@@ -130,6 +130,10 @@
                        :border-radius "0 0 4px 4px"}}
    [dd/data-display raw
     {:panel-id (keyword "rf.xray.trace" (str "row-" id))
+     ;; rf2-pvsxs — trace rows survive tab leave-and-return because
+     ;; the trace event-id is itself stable; the `:site-id` reuses it
+     ;; so the operator's expansion choices persist across tab churn.
+     :site-id  [:rf.xray.trace/row id]
      :default-expanded-depth 1
      ;; rf2-l4625 — trace rows expand within the row's narrow column;
      ;; tags + payload maps are routinely cramped. Popup gives the

--- a/tools/xray/src/day8/re_frame2_xray/theme/tokens.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/theme/tokens.cljc
@@ -127,25 +127,49 @@
    :magenta        "#E879F9"
    :info           "#79c0ff"   ; cool categorical blue ≠ accent (Figma syntax-number)
 
-   ;; ── syntax-highlighter palette (rf2-93jp0 · Figma `.syntax-*` block) ──
-   ;; Dedicated tokens for the in-bundle Clojure source-text highlighter
-   ;; (`views/edn_widget/widget.cljs`), mirrored 1:1 from the Figma
-   ;; authority's `.syntax-keyword` / `.syntax-string` / `.syntax-number`
-   ;; CSS classes. Catalogued as their own token family (rather than
-   ;; reusing semantic `:red`/`:green`/`:info`) so syntax hues can evolve
-   ;; independently of the semantic palette — a future "function-name"
-   ;; or "macro" hue lands here without rippling through error/success
-   ;; surfaces.
+   ;; ── syntax-highlighter palette (rf2-79ojx · One Dark / Calva default) ──
+   ;; Dedicated tokens for CLJS-value rendering in the data-display widget
+   ;; (`views/data_display.cljs`) AND the in-bundle Clojure source-text
+   ;; highlighter (`views/edn_widget/widget.cljs`). One palette, shared by
+   ;; both surfaces, so a `:foo` keyword in the source-text panel paints
+   ;; the same hue as `:foo` rendered as a value in the App-DB panel.
    ;;
-   ;; The pre-rf2-93jp0 mapping reused `:accent` for BOTH `:keyword` and
-   ;; `:builtin`, so `:foo` and `reg-event-db` painted identically — a
-   ;; monochromatic look against a real editor. Splitting `:syntax-
-   ;; keyword` off (red family, per Figma) gives keywords vs builtins a
-   ;; first-class visual distinction; the builtin highlight stays on
-   ;; `:accent` (the chrome blue) and now reads as macro-call emphasis.
-   :syntax-keyword "#ff7b72"   ; Figma .dark .syntax-keyword (salmon-red)
-   :syntax-string  "#a5d6ff"   ; Figma .dark .syntax-string  (sky-blue)
-   :syntax-number  "#79c0ff"   ; Figma .dark .syntax-number  (cool-blue, = :info)
+   ;; ## Palette base (rf2-79ojx)
+   ;;
+   ;; Derives from the **One Dark / Atom One Dark** palette — the lineage
+   ;; behind Calva's default theme + Cursive's Material/One Dark + the
+   ;; VS Code "Atom One" family. CLJS programmers' eyes are trained on
+   ;; this hue family (keywords magenta, strings green, numbers orange,
+   ;; constants gold), so the inspector reads as syntax-highlighted at a
+   ;; glance instead of demanding the eye decode a hue-distinct scheme.
+   ;;
+   ;; The pre-rf2-79ojx mapping inherited GitHub Primer's blue-heavy
+   ;; `.syntax-*` palette — keywords salmon-red (an outlier), strings AND
+   ;; numbers both in the blue family. Three of five scalar types painted
+   ;; in the same hue with only luminance varying; the inspector looked
+   ;; monochrome to a programmer whose eye expects keyword magenta + number
+   ;; orange + string green.
+   ;;
+   ;; ## Hue families — the five scalar types MUST span at least four
+   ;;
+   ;; - keyword  → magenta (purple family) — `:foo` keyword tokens
+   ;; - string   → green                   — `"hello"` strings
+   ;; - number   → orange                  — `42`, `3.14`
+   ;; - boolean  → gold (yellow family)    — `true`/`false` (constants)
+   ;; - nil      → grey (neutral)          — deliberately muted (absence)
+   ;;
+   ;; Three additional tokens carry editor-convention hues for surfaces
+   ;; that need them: `:syntax-symbol` (blue — identifiers / `'sym`),
+   ;; `:syntax-builtin` (blue, slightly distinct — macro-call emphasis),
+   ;; and `:syntax-punctuation` (muted near-text — brackets, commas).
+   :syntax-keyword "#c678dd"   ; One Dark .keyword (magenta)
+   :syntax-string  "#98c379"   ; One Dark .string  (green)
+   :syntax-number  "#d19a66"   ; One Dark .number  (orange)
+   :syntax-boolean "#e5c07b"   ; One Dark .constant (gold; "constants" family)
+   :syntax-nil     "#7f848e"   ; One Dark .comment-ish dim (grey, AAA on bg-1)
+   :syntax-symbol  "#61afef"   ; One Dark .function/variable (blue)
+   :syntax-builtin "#61afef"   ; One Dark .function/variable (blue) — macro emphasis
+   :syntax-punctuation "#abb2bf" ; One Dark .text (near-foreground; subtle)
 
    ;; ── deep variants (rf2-5kfxe.4) ──
    ;; Darker variant of `:red` used as a danger-button background. The
@@ -226,21 +250,25 @@
    :magenta        "#B146C2"
    :info           "#0550ae"   ; cool categorical blue ≠ accent (Figma syntax-number)
 
-   ;; ── syntax-highlighter palette (rf2-93jp0 · Figma `.syntax-*` block) ──
-   ;; Light-theme mirror of the dark-palette `:syntax-*` family. Each
-   ;; hex is taken 1:1 from the Figma authority's CSS string:
+   ;; ── syntax-highlighter palette (rf2-79ojx · One Light / Atom-One-Light) ──
+   ;; Light-theme mirror of the dark-palette `:syntax-*` family, taken
+   ;; from the **Atom One Light** companion to One Dark (Calva's default
+   ;; light theme inherits the same family). Each hex is darkness-shifted
+   ;; to clear WCAG AA on the white canvas while keeping the same hue
+   ;; family as the dark variant so a user toggling themes sees the
+   ;; SAME semantic colour assignment (magenta keywords / green strings /
+   ;; orange numbers / gold booleans / grey nil).
    ;;
-   ;;     .syntax-keyword { color: #cf222e; }
-   ;;     .syntax-string  { color: #0a3069; }
-   ;;     .syntax-number  { color: #0550ae; }
-   ;;
-   ;; (See `dark-palette` `:syntax-*` for the rationale — the rf2-93jp0
-   ;; split exists so keywords and builtins paint distinct hues; this
-   ;; block holds the LIGHT-theme half of that contract so the class
-   ;; toggle on the shell root resolves either palette at paint time.)
-   :syntax-keyword "#cf222e"   ; Figma .syntax-keyword (deep red)
-   :syntax-string  "#0a3069"   ; Figma .syntax-string  (deep navy)
-   :syntax-number  "#0550ae"   ; Figma .syntax-number  (Github blue, = :info)
+   ;; See `dark-palette` `:syntax-*` for the rationale + the hue-family
+   ;; contract (the five scalar types must span at least four families).
+   :syntax-keyword "#a626a4"   ; One Light .keyword (magenta)
+   :syntax-string  "#50a14f"   ; One Light .string  (green)
+   :syntax-number  "#986801"   ; One Light .number  (orange, AA on white)
+   :syntax-boolean "#c18401"   ; One Light .constant (gold; "constants" family)
+   :syntax-nil     "#a0a1a7"   ; One Light .comment-ish dim (grey)
+   :syntax-symbol  "#4078f2"   ; One Light .function/variable (blue)
+   :syntax-builtin "#4078f2"   ; One Light .function/variable (blue)
+   :syntax-punctuation "#383a42" ; One Light .text (near-foreground; subtle)
 
    ;; ── deep variants ──
    ;; On the light canvas the danger button stays close to the

--- a/tools/xray/src/day8/re_frame2_xray/views/data_display.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/data_display.cljs
@@ -40,6 +40,14 @@
 
   - `:panel-id`     (optional, default `:rf.xray.data-display/anon`)
                     distinguishes per-panel expansion state.
+  - `:site-id`      (optional, rf2-pvsxs) — when supplied, becomes the
+                    second component of the per-node expansion key
+                    INSTEAD of the auto-generated mount-id. Lets the
+                    same logical call site survive a panel-leave-and-
+                    return round-trip (auto-mount-id changes on remount;
+                    a stable site-id does not). Omit to keep the per-
+                    call-site isolation default (two `[data-display]`
+                    mounts side-by-side stay independent).
   - `:default-expanded-depth` (optional, default 2) — first-render
                     expansion depth before operator clicks.
   - `:max-inline-width` (optional, default 60) — character budget
@@ -71,12 +79,20 @@
   Drop the `:render-id` arg from the old facade — mount-id is now
   auto-generated internally per D4=a (rf2-sndui).
 
-  ## Per-call-site isolation
+  ## Per-call-site isolation (rf2-sndui D4=a · rf2-pvsxs opt-out)
 
   Each `[data-display …]` mount auto-assigns a UUID `mount-id` on
   first render (captured in a form-2 outer `let`). Two mounts side-
   by-side in the same panel get independent expansion state. The
-  expansion key is `[panel-id mount-id path]`.
+  expansion key is `[panel-id mount-id path]` by default.
+
+  When the same logical call site needs to SURVIVE a remount (e.g.
+  the App-DB tab unmounts on tab-switch and re-mounts on return),
+  pass a stable `:site-id` in `opts`. The expansion key becomes
+  `[panel-id site-id path]` — independent of remount cadence. The
+  cost is opt-in: a consumer that passes the SAME `:site-id` from
+  two mount sites would have them share expansion state. Per-call-
+  site isolation is the default; persistence-across-unmount is opt-in.
 
   ## Why pure hiccup + no Reagent direct
 
@@ -1461,7 +1477,7 @@
     (fn render-data-display
       [value & rest-args]
       (let [opts          (first rest-args)
-            {:keys [panel-id default-expanded-depth max-inline-width
+            {:keys [panel-id site-id default-expanded-depth max-inline-width
                     max-depth before popup-affordance?]
              :or   {panel-id :rf.xray.data-display/anon
                     default-expanded-depth 2
@@ -1469,6 +1485,21 @@
                     max-depth 16
                     popup-affordance? false}} opts
             diff?         (contains? opts :before)
+            ;; rf2-pvsxs — `site-id` (when supplied) opt-out of the
+            ;; per-call-site mount-id isolation. The expansion-key's
+            ;; second slot reads `site-id` instead of the auto-mount-
+            ;; id, so a panel that leaves AND returns to the same
+            ;; surface (e.g. App-DB tab switching) finds its prior
+            ;; overrides under a stable key. When omitted, behaviour
+            ;; is unchanged — auto-mount-id keeps per-call-site
+            ;; isolation for naive callers (two `[data-display]`
+            ;; mounts side-by-side toggle independently).
+            ;;
+            ;; The choice is per-consumer-panel: App-DB / Handler /
+            ;; Trace pass a stable :site-id derived from their
+            ;; cascade epoch + slot role; throw-away surfaces (popup
+            ;; previews, table-cell minis) omit it.
+            effective-id  (or site-id mount-id)
             ;; `subscribe` is the lexical frame-aware closure
             ;; injected by `reg-view` — reads the expansion-slot
             ;; from the surrounding frame's app-db (e.g. `:rf/xray`).
@@ -1482,6 +1513,7 @@
             popup-mount-id (str "ddp-" mount-id)]
         [:div {:data-testid     container-id
                :data-rf-mount-id mount-id
+               :data-rf-site-id  (when site-id (pr-str site-id))
                :data-rf-mode    (if diff? "diff" "browse")
                :data-rf-popup-affordance? (when popup-affordance? "1")
                :style {:font-family mono-stack
@@ -1499,7 +1531,13 @@
                        :before (if diff? before ::missing)
                        :diff? diff?
                        :panel-id panel-id
-                       :mount-id mount-id
+                       ;; rf2-pvsxs — `mount-id` slot in render-node's
+                       ;; key carries the EFFECTIVE id (site-id if
+                       ;; supplied; auto-mount-id otherwise). Callbacks
+                       ;; deep in the recursion thread the same value,
+                       ;; so toggle dispatches store + read overrides
+                       ;; under the persistence-friendly key.
+                       :mount-id effective-id
                        :path []
                        :depth 0
                        :expansion-map expansion-map

--- a/tools/xray/src/day8/re_frame2_xray/views/data_display.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/data_display.cljs
@@ -736,6 +736,73 @@
        "-" mount-id
        (when (seq path) (str "-" (str/join "/" (map pr-str path))))))
 
+;; rf2-tzvk9 — triangle expand/collapse glyph carries an explicit
+;; ≥24×24 click target. The glyph itself stays visually subordinate
+;; (font-size 14px, dimmed `:text-secondary`); padding inside the
+;; existing key-column gutter grows the hit-box without shifting the
+;; surrounding layout. Public via the value so tests can assert the
+;; computed-width contract without re-deriving the magic numbers.
+;;
+;; Why these numbers — getBoundingClientRect on `inline-flex` + the
+;; padding/font-size below resolves to approximately 26×24px in
+;; Chromium at the shell's default 13px root font-size:
+;;
+;;   width  ≈ font-size(14) * glyph-advance(~0.7) + padding-l(4) +
+;;            padding-r(4)                                ≈ 26px
+;;   height ≈ font-size(14) * line-height(1.4)            ≈ 19.6px
+;;            + padding-t(4) + padding-b(4)               ≈ 27.6px
+;;
+;; Both axes clear the 24px WCAG-2.2-flavour comfortable-mouse-target
+;; threshold called out in the bead.
+
+(def triangle-min-target-px
+  "Minimum click-target width/height the triangle must register
+  (rf2-tzvk9). The CLJS-unit-test surface asserts the padding +
+  font-size combination resolves to at least this many CSS pixels
+  along both axes.
+
+  Public so external surfaces (regression tests, design audits) can
+  read the contract without re-deriving the number."
+  24)
+
+(def triangle-style
+  "Inline-style map applied to every expand/collapse triangle (`▸`
+  / `▾`) the data-display widget renders (rf2-tzvk9). One source of
+  truth so every triangle gets the SAME hit-box — three call sites
+  (depth-capped, expanded ▾, collapsed ▸) and one diff-mode variant
+  share this.
+
+  Layout rationale:
+
+  - `inline-flex` + `align-items center` + `justify-content center`
+    centres the glyph inside the padded box so the click target is
+    visually balanced.
+  - `min-width` + `min-height` pin the hit-box to ≥24px in both axes
+    even if the glyph's natural metrics fall short (Chromium renders
+    `▸` slightly narrower than `▾`).
+  - `padding 4px 8px` grows the hit-box WITHOUT pushing the key
+    column right — the padding sits inside the existing 4-6px gap
+    between the triangle and the first key.
+  - `font-size 14px` overrides the widget's inherited 12px so the
+    glyph is more visible AND the natural metrics grow the hit-box.
+    Bumping by ~2px keeps the glyph subordinate to surrounding data.
+  - `line-height 1` collapses inline leading so the height comes
+    purely from font + padding, not from inherited 1.4 leading.
+
+  The colour stays on the subdued `:text-secondary` token — the
+  glyph's job is to be *findable*, not loud."
+  {:cursor          "pointer"
+   :user-select     "none"
+   :display         "inline-flex"
+   :align-items     "center"
+   :justify-content "center"
+   :min-width       (str triangle-min-target-px "px")
+   :min-height      (str triangle-min-target-px "px")
+   :padding         "4px 8px"
+   :font-size       "14px"
+   :line-height     1
+   :color           (:text-secondary tokens)})
+
 (defn- on-toggle
   "Build the click handler for a node's `▸`/`▾` glyph.
   Dispatches the toggle event via `dispatch-fn` — the lexically-
@@ -848,15 +915,16 @@
 
         ;; Depth-capped — render the placeholder ellipsis, click expands one level.
         depth-capped?
-        [:span {:style {:display "inline-flex" :align-items "baseline" :gap "4px"}}
+        [:span {:style {:display "inline-flex" :align-items "center" :gap "4px"}}
          [:span {:on-click   toggle-fn
                  :role       "button"
                  :tabindex   0
                  :aria-expanded false
                  :data-testid (str (testid-for panel-id mount-id path) "-toggle")
-                 :style {:cursor "pointer"
-                         :user-select "none"
-                         :color (:text-secondary tokens)}}
+                 ;; rf2-tzvk9 — ≥24×24 click target via the shared
+                 ;; `triangle-style` (padding + font-size + min-width/
+                 ;; -height).
+                 :style triangle-style}
           "▸"]
          (bracket kind :open value)
          [:span {:style (token-style :text-tertiary)} "…"]
@@ -893,28 +961,28 @@
 
         ;; Default — toggle glyph + open bracket (when expanded) OR summary.
         expanded?
-        [:span {:style {:display "inline-flex" :align-items "baseline" :gap "4px"}}
+        [:span {:style {:display "inline-flex" :align-items "center" :gap "4px"}}
          [:span {:on-click   toggle-fn
                  :role       "button"
                  :tabindex   0
                  :aria-expanded true
                  :data-testid (str (testid-for panel-id mount-id path) "-toggle")
-                 :style {:cursor "pointer"
-                         :user-select "none"
-                         :color (:text-secondary tokens)}}
+                 ;; rf2-tzvk9 — ≥24×24 click target via the shared
+                 ;; `triangle-style`.
+                 :style triangle-style}
           "▾"]
          (bracket kind :open value)]
 
         :else
-        [:span {:style {:display "inline-flex" :align-items "baseline" :gap "6px"}}
+        [:span {:style {:display "inline-flex" :align-items "center" :gap "6px"}}
          [:span {:on-click   toggle-fn
                  :role       "button"
                  :tabindex   0
                  :aria-expanded false
                  :data-testid (str (testid-for panel-id mount-id path) "-toggle")
-                 :style {:cursor "pointer"
-                         :user-select "none"
-                         :color (:text-secondary tokens)}}
+                 ;; rf2-tzvk9 — ≥24×24 click target via the shared
+                 ;; `triangle-style`.
+                 :style triangle-style}
           "▸"]
          (collapsed-summary value kind)])]
 

--- a/tools/xray/src/day8/re_frame2_xray/views/data_display.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/data_display.cljs
@@ -95,12 +95,12 @@
 
   | Leaf type        | Token              | Bracket style            |
   |------------------|--------------------|--------------------------|
-  | nil              | `:text-tertiary`   | n/a                      |
-  | boolean          | `:syntax-keyword`  | n/a                      |
+  | nil              | `:syntax-nil`      | n/a                      |
+  | boolean          | `:syntax-boolean`  | n/a                      |
   | integer / float  | `:syntax-number`   | n/a                      |
   | string           | `:syntax-string`   | n/a                      |
-  | keyword          | `:accent`          | n/a                      |
-  | symbol           | `:magenta`         | n/a                      |
+  | keyword          | `:syntax-keyword`  | n/a                      |
+  | symbol           | `:syntax-symbol`   | n/a                      |
   | uuid / regex     | `:info`            | n/a                      |
   | inst / date      | `:info`            | n/a                      |
   | fn               | `:text-tertiary`   | (italic)                 |
@@ -112,7 +112,12 @@
   | set              | `:text-secondary`  | `#{` `}`                 |
   | map-entry        | `:accent`          | `[` `]` (accent tone)    |
   | record           | `:info`            | `#user.Rec{` `}`         |
-  | js object        | `:text-tertiary`   | `#object[` `]`           |"
+  | js object        | `:text-tertiary`   | `#object[` `]`           |
+
+  Per rf2-79ojx the per-type tokens were renamed + the palette retuned
+  to an editor-syntax-highlight scheme (One Dark / One Light). Five
+  scalar types now span four hue families: keyword magenta, string
+  green, number orange, boolean gold, nil grey."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
             [day8.re-frame2-xray.theme.tokens
@@ -436,13 +441,13 @@
   [v]
   (case (collection-kind v)
     :nil      [:span {:data-rf-type "nil"
-                      :style (token-style :text-tertiary)} "nil"]
+                      :style (token-style :syntax-nil)} "nil"]
     :boolean  [:span {:data-rf-type "boolean"
-                      :style (token-style :syntax-keyword)} (str v)]
+                      :style (token-style :syntax-boolean)} (str v)]
     :keyword  [:span {:data-rf-type "keyword"
-                      :style (token-style :accent)} (str v)]
+                      :style (token-style :syntax-keyword)} (str v)]
     :symbol   [:span {:data-rf-type "symbol"
-                      :style (token-style :magenta)} (str v)]
+                      :style (token-style :syntax-symbol)} (str v)]
     :string   [:span {:data-rf-type "string"
                       :style (token-style :syntax-string)} (str-pad-quote v)]
     :number   [:span {:data-rf-type "number"
@@ -698,11 +703,11 @@
   Used to label children inside a container."
   [k]
   (cond
-    (keyword? k) [:span {:style (token-style :accent)} (str k)]
+    (keyword? k) [:span {:style (token-style :syntax-keyword)} (str k)]
     (string? k)  [:span {:style (token-style :syntax-string)} (str-pad-quote k)]
     (number? k)  [:span {:style (token-style :syntax-number)} (str k)]
-    (symbol? k)  [:span {:style (token-style :magenta)} (str k)]
-    (nil? k)     [:span {:style (token-style :text-tertiary)} "nil"]
+    (symbol? k)  [:span {:style (token-style :syntax-symbol)} (str k)]
+    (nil? k)     [:span {:style (token-style :syntax-nil)} "nil"]
     :else        [:span {:style (token-style :text-primary)}
                   (try (pr-str k) (catch :default _ (str k)))]))
 

--- a/tools/xray/src/day8/re_frame2_xray/views/data_display.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/data_display.cljs
@@ -383,18 +383,29 @@
   glyph) so non-diff renders share the same hiccup shape as diff
   renders.
 
-  Returns a `[:div ...]` hiccup; embed directly in flex parents."
+  ## rf2-1bra5 — inline-flex, not flex
+
+  Switched from `display: flex` (block-level) to `inline-flex` so a
+  diff'd scalar leaf composes inline with its preceding key inside a
+  map-row grid. Pre-fix the block-level `<div>` forced the leaf onto
+  its own line (the per-row flex container couldn't keep the key+value
+  on one line — `flex-wrap: wrap` pushed the wide block-div below the
+  key, producing the `:show-parity?` / `:threshold` two-line rows Mike
+  measured at ~28.79px against the inline ~17.79px sibling rows).
+
+  Returns an `[:span ...]` (display: inline-flex) so it nests inside a
+  grid cell without breaking the row."
   [op body]
   (let [active? (not= :same op)]
-    [:div {:data-rf-diff-op (name op)
-           :style {:display      "flex"
-                   :align-items  "flex-start"
-                   :gap          "4px"
-                   :padding-left "6px"
-                   :border-left  (str "3px solid "
-                                      (if active?
-                                        (gutter-colour op)
-                                        "transparent"))}}
+    [:span {:data-rf-diff-op (name op)
+            :style {:display      "inline-flex"
+                    :align-items  "baseline"
+                    :gap          "4px"
+                    :padding-left "6px"
+                    :border-left  (str "3px solid "
+                                       (if active?
+                                         (gutter-colour op)
+                                         "transparent"))}}
      [:span {:style {:flex          "0 0 12px"
                      :color         (gutter-colour op)
                      :font-family   mono-stack
@@ -403,7 +414,7 @@
                      :text-align    "center"
                      :user-select   "none"}}
       (op->gutter-glyph op)]
-     [:div {:style {:flex 1 :min-width 0}} body]]))
+     [:span {:style {:flex 1 :min-width 0}} body]]))
 
 (defn- change-annotation
   "Inline `← changed from <prior>` chip rendered to the right of a
@@ -993,71 +1004,132 @@
      ;; lets the child's recursion render its own gutter row / inline
      ;; `← changed from <prior>` annotation; the parent's `:children`
      ;; row supplies the ancestor-open + ◴ glyph context.
+     ;;
+     ;; rf2-1bra5 — map / record bodies use CSS Grid (max-content 1fr) so
+     ;; values column-align across rows. Pre-fix each row was its own
+     ;; flex container with key + value sized independently → ragged
+     ;; value column. With grid every row's key sits in column 1 (sized
+     ;; to the widest key in THIS map; nested maps compute their own
+     ;; column-1 width independently) and every row's value sits at the
+     ;; single column-2 left edge.
+     ;;
+     ;; Sequentials (vectors / lists / sets / seqs) keep the per-row
+     ;; block flow — values are emitted bare (no key column), so a
+     ;; grid template wouldn't add anything.
      (when (seq children)
-       [:div {:data-testid (str (testid-for panel-id mount-id path) "-body")
-              :style {:padding-left "14px"
-                      :margin-left  "5px"
-                      :border-left  (str "1px solid " (:border-subtle tokens))}}
-        ;; In diff mode, also surface keys that exist ONLY in `before`
-        ;; (i.e. removed slots) as struck-through rows. We do that by
-        ;; iterating a unified key set when the kind is :map (the
-        ;; common app-db case); sequentials use index alignment.
-        (let [child-pairs
-              (cond
-                (and diff? (= kind :map) (map? before))
-                ;; Map: walk union of keys; carry both v and b per key.
-                (let [all-keys (vec (into (set (keys value)) (keys before)))]
-                  (for [k all-keys]
-                    [k (get value k ::missing) (get before k ::missing)]))
+       (let [labelled?    (#{:map :record :map-entry} kind)
+             child-pairs
+             (cond
+               (and diff? (= kind :map) (map? before))
+               ;; Map: walk union of keys; carry both v and b per key.
+               (let [all-keys (vec (into (set (keys value)) (keys before)))]
+                 (for [k all-keys]
+                   [k (get value k ::missing) (get before k ::missing)]))
 
-                (and diff? (#{:vector :list :seq} kind) (sequential? before))
-                ;; Sequential: index-align; treat extra trailing items.
-                (let [a-vec (vec value)
-                      b-vec (vec before)
-                      n     (max (count a-vec) (count b-vec))]
-                  (for [i (range n)]
-                    [i
-                     (if (< i (count a-vec)) (nth a-vec i) ::missing)
-                     (if (< i (count b-vec)) (nth b-vec i) ::missing)]))
+               (and diff? (#{:vector :list :seq} kind) (sequential? before))
+               ;; Sequential: index-align; treat extra trailing items.
+               (let [a-vec (vec value)
+                     b-vec (vec before)
+                     n     (max (count a-vec) (count b-vec))]
+                 (for [i (range n)]
+                   [i
+                    (if (< i (count a-vec)) (nth a-vec i) ::missing)
+                    (if (< i (count b-vec)) (nth b-vec i) ::missing)]))
 
-                :else
-                ;; Non-diff path, or diff with no comparable structure
-                ;; on the `before` side — render the present children as-is.
-                (for [[k cv] children]
-                  [k cv (if diff? ::missing ::missing)]))]
-          (into [:<>]
-                (map
-                  (fn [[k cv cb]]
-                    (let [child-path (conj (vec path) k)
-                          ;; For maps we tag the child as a map-entry so
-                          ;; the renderer can pick the map-entry bracket.
-                          ;; For sets the child is rendered without a key.
-                          labelled?  (and (not (#{:set :seq :list :vector} kind))
-                                          ;; sets / sequentials don't carry labelled keys
-                                          (#{:map :record :map-entry} kind))]
-                      [:div {:key (pr-str k)
-                             :style {:display "flex"
-                                     :align-items "baseline"
-                                     :gap "6px"
-                                     :flex-wrap "wrap"
-                                     :padding "0px 0"}}
-                       (when labelled?
-                         (list
-                           (with-meta (key-segment k)            {:key (str "k-" (pr-str k))})
-                           (with-meta [:span {:style (token-style :text-tertiary)} " "]
-                             {:key (str "s-" (pr-str k))})))
-                       (with-meta (render-node {:value cv
-                                                :before cb
-                                                :diff? diff?
-                                                :panel-id panel-id
-                                                :mount-id mount-id
-                                                :path child-path
-                                                :depth (inc depth)
-                                                :expansion-map expansion-map
-                                                :dispatch-fn dispatch-fn
-                                                :opts opts})
-                                  {:key (str "v-" (pr-str k))})]))
-                  child-pairs)))])
+               :else
+               ;; Non-diff path, or diff with no comparable structure
+               ;; on the `before` side — render the present children as-is.
+               (for [[k cv] children]
+                 [k cv (if diff? ::missing ::missing)]))]
+         (if labelled?
+           ;; --- CSS Grid body for labelled-key kinds ---
+           ;; Each row contributes key (col 1) + value (col 2) as direct
+           ;; grid children. `column-gap` provides the key-to-value
+           ;; spacing (8px = old per-row :gap "6px" rounded to a 4-step).
+           ;; `row-gap 0` keeps rows tight against the canvas density.
+           ;;
+           ;; `align-items: baseline` aligns the key and value text
+           ;; baselines per row — short keys with tall values (e.g. a
+           ;; nested map's bracket) hang on the same baseline as the
+           ;; key. Falls back gracefully when a value is a multi-line
+           ;; container — the value cell grows down, the key stays
+           ;; baseline-aligned to the value's first line.
+           (into [:div {:data-testid (str (testid-for panel-id mount-id path) "-body")
+                        :data-rf-body-layout "grid"
+                        :style {:padding-left         "14px"
+                                :margin-left          "5px"
+                                :border-left          (str "1px solid "
+                                                           (:border-subtle tokens))
+                                :display              "grid"
+                                :grid-template-columns "max-content 1fr"
+                                :column-gap           "8px"
+                                :row-gap              "0"
+                                :align-items          "baseline"}}]
+                 (mapcat
+                   (fn [[k cv cb]]
+                     (let [child-path (conj (vec path) k)
+                           value-node (render-node
+                                        {:value cv
+                                         :before cb
+                                         :diff? diff?
+                                         :panel-id panel-id
+                                         :mount-id mount-id
+                                         :path child-path
+                                         :depth (inc depth)
+                                         :expansion-map expansion-map
+                                         :dispatch-fn dispatch-fn
+                                         :opts opts})]
+                       [(with-meta
+                          ;; Key cell — uses `div` so the grid baseline
+                          ;; aligns predictably across rows. `white-
+                          ;; space: nowrap` prevents long keys (e.g. a
+                          ;; deeply-namespaced `:rf.x.with.many.parts/k`)
+                          ;; from wrapping inside the key column.
+                          [:div {:data-rf-cell "key"
+                                 :style {:white-space "nowrap"}}
+                           (key-segment k)]
+                          {:key (str "k-" (pr-str k))})
+                        (with-meta
+                          ;; Value cell — `div` so nested containers
+                          ;; (their own block-level expanded body)
+                          ;; place inside this cell without span-vs-
+                          ;; block validation issues. `min-width 0`
+                          ;; protects against overflow when the value
+                          ;; is wider than the grid column allotment
+                          ;; (the `1fr` track stretches but won't
+                          ;; shrink below the value's intrinsic width
+                          ;; without this).
+                          [:div {:data-rf-cell "value"
+                                 :style {:min-width 0}}
+                           value-node]
+                          {:key (str "v-" (pr-str k))})]))
+                   child-pairs))
+           ;; --- Block body for sequentials (vector / list / set / seq) ---
+           ;; Each child renders bare (no key column). Per-row block flow
+           ;; — each entry sits below the previous; nested containers
+           ;; recurse with their own grid/block decision.
+           (into [:div {:data-testid (str (testid-for panel-id mount-id path) "-body")
+                        :data-rf-body-layout "block"
+                        :style {:padding-left "14px"
+                                :margin-left  "5px"
+                                :border-left  (str "1px solid "
+                                                   (:border-subtle tokens))}}]
+                 (map
+                   (fn [[k cv cb]]
+                     (let [child-path (conj (vec path) k)]
+                       (with-meta
+                         (render-node {:value cv
+                                       :before cb
+                                       :diff? diff?
+                                       :panel-id panel-id
+                                       :mount-id mount-id
+                                       :path child-path
+                                       :depth (inc depth)
+                                       :expansion-map expansion-map
+                                       :dispatch-fn dispatch-fn
+                                       :opts opts})
+                         {:key (str "v-" (pr-str k))})))
+                   child-pairs)))))
 
      ;; ---- close bracket (only when expanded + body present) -------------
      (when (and expanded? (not empty?) (not depth-capped?) (not inline-fit?))

--- a/tools/xray/test/day8/re_frame2_xray/views/data_display_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/data_display_cljs_test.cljs
@@ -608,6 +608,168 @@
       (is (= dd/triangle-style s)
           "depth-capped triangle uses the shared triangle-style"))))
 
+;; ---- rf2-1bra5 — map body layout: column-align + inline scalars ---------
+;;
+;; Two related bugs in the live App-DB panel:
+;;
+;;   Bug 1 — some scalar rows wrapped (`:show-parity?` + newline + `true`)
+;;     while sibling scalar rows on the same map rendered inline. The
+;;     wrapped rows measured 28.79px; the inline rows 17.79px. The
+;;     render-path divergence was the `gutter-row` wrapping diff'd
+;;     leaves in a BLOCK div (`display: flex`) inside a `flex-wrap:
+;;     wrap` per-row container — the wide div wrapped below the key.
+;;
+;;   Bug 2 — values don't column-align across rows of the same map. Each
+;;     row was its own `display: flex` so the value followed whatever
+;;     gap landed after the key — different keys produced different
+;;     value x-coordinates, a ragged value-column left edge.
+;;
+;; Fix: CSS Grid (`max-content 1fr`) for the body container, with key +
+;; value emitted as direct grid children. The `gutter-row` wrapper
+;; switches from block-level `flex` to `inline-flex` so a diff'd leaf
+;; composes inline with its preceding key.
+
+(deftest map-body-uses-css-grid-layout
+  (testing "rf2-1bra5 — labelled-kind bodies use grid with
+            max-content+1fr columns so values column-align across rows"
+    ;; Map MUST be too big to inline-fit (cnt > 3) so the body
+    ;; container renders.
+    (let [v {:short 1 :very-very-long-key 2 :third 3 :fourth 4}
+          k0 (dd/expansion-key :p "m" [])
+          h  (dd/render-node {:value v
+                              :panel-id :p :mount-id "m"
+                              :path [] :depth 0
+                              :expansion-map {k0 {:expanded? true}}
+                              :opts {:default-expanded-depth 0}})
+          body (find-attr h :data-testid "rf-xray-data-display-p-m-body")]
+      (is (some? body) "expanded map renders a body container")
+      (let [s (-> body second :style)]
+        (is (= "grid" (:display s))
+            "labelled-kind body uses CSS grid")
+        (is (re-find #"max-content" (str (:grid-template-columns s)))
+            "grid template uses max-content for the key column")
+        (is (re-find #"1fr" (str (:grid-template-columns s)))
+            "grid template uses 1fr for the value column")
+        (is (= "8px" (:column-gap s))
+            "key→value separation is the canonical 8px (gap-2 step)")
+        (is (= "baseline" (:align-items s))
+            "key + value baselines align per row")))))
+
+(deftest map-body-row-emits-key-and-value-as-direct-grid-children
+  (testing "rf2-1bra5 — each row contributes two direct grid children
+            (key cell + value cell) so the grid resolves columns
+            across rows. NOT wrapped in a per-row flex container."
+    (let [;; >3 keys so inline-fit gate fails and the body emits.
+          v {:a 1 :b 2 :c 3 :d 4}
+          k0 (dd/expansion-key :p "m" [])
+          h  (dd/render-node {:value v
+                              :panel-id :p :mount-id "m"
+                              :path [] :depth 0
+                              :expansion-map {k0 {:expanded? true}}
+                              :opts {:default-expanded-depth 0}})
+          body (find-attr h :data-testid "rf-xray-data-display-p-m-body")
+          key-cells   (->> (walk-hiccup body)
+                           (filter #(= "key"   (get (second %) :data-rf-cell))))
+          value-cells (->> (walk-hiccup body)
+                           (filter #(= "value" (get (second %) :data-rf-cell))))]
+      (is (= 4 (count key-cells))   "four map rows → four key cells")
+      (is (= 4 (count value-cells)) "four map rows → four value cells"))))
+
+(deftest sequential-body-still-uses-block-layout
+  (testing "rf2-1bra5 — sequentials (vectors / lists / sets / seqs)
+            keep block layout. Grid only applies to labelled-key kinds
+            (map / record / map-entry); sequentials have no key column."
+    ;; >3 items so inline-fit gate fails and the body emits.
+    (let [v [10 20 30 40]
+          k0 (dd/expansion-key :p "m" [])
+          h  (dd/render-node {:value v
+                              :panel-id :p :mount-id "m"
+                              :path [] :depth 0
+                              :expansion-map {k0 {:expanded? true}}
+                              :opts {:default-expanded-depth 0}})
+          body (find-attr h :data-testid "rf-xray-data-display-p-m-body")]
+      (is (some? body) "expanded vector renders a body container")
+      (let [s (-> body second :style)]
+        (is (not= "grid" (:display s))
+            "sequentials do not use grid layout (no key column)")
+        (is (= "block" (or (:data-rf-body-layout (second body))
+                            "block"))
+            "vector body is the block-layout variant")))))
+
+(deftest gutter-row-is-inline-flex-not-block
+  (testing "rf2-1bra5 root-cause fix — gutter-row wraps diff'd leaves
+            in inline-flex SPAN (not block-level DIV with display: flex).
+            Pre-fix the block wrapper inside the per-row flex container
+            forced the value below the key (wrap → two-line rows)."
+    (let [;; Force a :same diff row — both sides equal scalars.
+          h (dd/render-node {:value 1
+                             :before 1
+                             :diff? true
+                             :panel-id :p :mount-id "m" :path [] :depth 0
+                             :expansion-map {} :opts {}})
+          ;; The gutter wrapper carries the data-rf-diff-op attr.
+          row (->> (walk-hiccup h)
+                   (filter #(some? (get (second %) :data-rf-diff-op)))
+                   first)]
+      (is (some? row) "diff render emits the gutter wrapper")
+      (is (= :span (first row))
+          "gutter wrapper is a SPAN (inline element), not a DIV")
+      (is (= "inline-flex" (-> row second :style :display))
+          "gutter wrapper is inline-flex so it composes inline with
+           a preceding key"))))
+
+(deftest scalar-leaves-render-as-inline-spans-in-non-diff-mode
+  (testing "rf2-1bra5 Bug 1 — plain scalars (numbers, booleans, etc.)
+            render as inline spans, never as a block element that
+            would push the value below its key."
+    (doseq [v [42 true false "hello" :foo 'sym nil]]
+      (let [h (dd/render-node {:value v
+                               :panel-id :p :mount-id "m"
+                               :path [] :depth 0
+                               :expansion-map {} :opts {}})]
+        (is (= :span (first h))
+            (str "scalar " (pr-str v) " renders as a [:span] inline"))))))
+
+(deftest map-with-mixed-scalar-and-container-values-grid-layout
+  (testing "rf2-1bra5 — mixed-kind map (some scalars, some nested
+            containers) renders the body as ONE grid where every key
+            sits in column 1 and every value (scalar OR nested) sits in
+            column 2. The nested container's own expanded body is its
+            own (independent) grid inside the parent's value cell."
+    (let [v {:scalar-1 1
+             :scalar-2 "two"
+             :nested   {:inner 99}}
+          k0 (dd/expansion-key :p "m" [])
+          h  (dd/render-node {:value v
+                              :panel-id :p :mount-id "m"
+                              :path [] :depth 0
+                              :expansion-map {k0 {:expanded? true}}
+                              :opts {:default-expanded-depth 0}})
+          body (find-attr h :data-testid "rf-xray-data-display-p-m-body")
+          ;; Filter ONLY this body's direct cells, not the nested
+          ;; map's cells.
+          direct-children (rest (rest body))]
+      (is (= "grid" (-> body second :style :display))
+          "outer body uses grid")
+      ;; 3 rows × 2 cells = 6 direct grid children.
+      (is (= 6 (count direct-children))
+          "3 rows × (key + value) = 6 direct grid cells"))))
+
+(deftest map-body-row-gap-is-zero-for-density
+  (testing "rf2-1bra5 — row-gap stays 0 so the inspector keeps the
+            workstation-dense layout it ships today. The fix is the
+            column-alignment + inline-composition; vertical density is
+            unchanged."
+    (let [v {:a 1 :b 2 :c 3 :d 4}
+          k0 (dd/expansion-key :p "m" [])
+          h  (dd/render-node {:value v
+                              :panel-id :p :mount-id "m"
+                              :path [] :depth 0
+                              :expansion-map {k0 {:expanded? true}}
+                              :opts {:default-expanded-depth 0}})
+          body (find-attr h :data-testid "rf-xray-data-display-p-m-body")]
+      (is (= "0" (-> body second :style :row-gap))))))
+
 ;; ---- toggle handler shape ------------------------------------------------
 
 (deftest toggle-handler-dispatches-canonical-event

--- a/tools/xray/test/day8/re_frame2_xray/views/data_display_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/data_display_cljs_test.cljs
@@ -522,6 +522,92 @@
     (is (some? (find-attr h :data-testid
                           "rf-xray-data-display-app-db-m-42")))))
 
+;; ---- rf2-tzvk9 — triangle hit-box ≥24×24 ---------------------------------
+;;
+;; The expand/collapse triangles (▾ / ▸) measured ~6.6×16.8px in the live
+;; widget — far below Fitts's-Law-friendly mouse-target sizing. Mike's
+;; live measurement on http://localhost:8031/counter App-DB panel.
+;; The fix uses a shared `triangle-style` with padding + font-size +
+;; min-width/min-height so every triangle on every code path gets the
+;; same ≥24×24 hit-box.
+
+(defn- parse-px
+  "Parse `'24px'` → 24. Returns nil for non-px strings."
+  [s]
+  (when (and (string? s) (re-find #"^\d+(\.\d+)?px$" s))
+    (js/parseFloat s)))
+
+(deftest triangle-style-pins-min-target-to-24px-in-both-axes
+  (testing "rf2-tzvk9 — the shared triangle-style declares ≥24px min-
+            width AND min-height so the computed hit-box meets the
+            comfortable-mouse-target threshold"
+    (is (>= (parse-px (:min-width  dd/triangle-style)) 24)
+        ":min-width ≥24px")
+    (is (>= (parse-px (:min-height dd/triangle-style)) 24)
+        ":min-height ≥24px")
+    (is (= "pointer" (:cursor dd/triangle-style))
+        "still registers as clickable")
+    (is (= "none"    (:user-select dd/triangle-style))
+        "no accidental text selection on the glyph")
+    (is (= "inline-flex" (:display dd/triangle-style))
+        "inline-flex so min-width/min-height are honoured")
+    (is (= "center"  (:align-items     dd/triangle-style))
+        "glyph centred vertically inside the hit-box")
+    (is (= "center"  (:justify-content dd/triangle-style))
+        "glyph centred horizontally inside the hit-box")))
+
+(deftest triangle-min-target-px-is-24
+  (is (= 24 dd/triangle-min-target-px)
+      "the public contract pin: 24px in both axes"))
+
+(deftest collapsed-triangle-uses-shared-triangle-style
+  ;; Force a default-collapsed render (large map at depth past
+  ;; default-expanded-depth) and verify the ▸ toggle span carries
+  ;; the shared `triangle-style`.
+  (let [v   {:a 1 :b 2 :c 3 :d 4 :e 5}
+        h   (dd/render-node {:value v
+                             :panel-id :test :mount-id "m"
+                             :path [] :depth 5
+                             :expansion-map {}
+                             :opts {:default-expanded-depth 1}})
+        tog (find-attr h :data-testid
+                       "rf-xray-data-display-test-m-toggle")]
+    (is (some? tog) "collapsed renders carry a toggle span")
+    (let [s (-> tog second :style)]
+      (is (= dd/triangle-style s)
+          "collapsed ▸ uses the shared triangle-style verbatim"))))
+
+(deftest expanded-triangle-uses-shared-triangle-style
+  (let [v   {:a 1 :b 2 :c 3 :d 4 :e 5}
+        k0  (dd/expansion-key :test "m" [])
+        h   (dd/render-node {:value v
+                             :panel-id :test :mount-id "m"
+                             :path [] :depth 0
+                             :expansion-map {k0 {:expanded? true}}
+                             :opts {:default-expanded-depth 0}})
+        tog (find-attr h :data-testid
+                       "rf-xray-data-display-test-m-toggle")]
+    (is (some? tog) "expanded renders carry a toggle span")
+    (let [s (-> tog second :style)]
+      (is (= dd/triangle-style s)
+          "expanded ▾ uses the shared triangle-style verbatim"))))
+
+(deftest depth-capped-triangle-uses-shared-triangle-style
+  ;; A node past :max-depth renders as `▸ {…}` with the same triangle.
+  (let [;; nesting depth past max-depth=1 → depth-capped path.
+        v   {:a {:b {:c {:d 1}}}}
+        h   (dd/render-node {:value v
+                             :panel-id :test :mount-id "m"
+                             :path [] :depth 0
+                             :expansion-map {}
+                             :opts {:default-expanded-depth 5 :max-depth 1}})
+        tog (find-attr h :data-testid
+                       "rf-xray-data-display-test-m-toggle")]
+    (is (some? tog) "depth-capped renders still carry a toggle span")
+    (let [s (-> tog second :style)]
+      (is (= dd/triangle-style s)
+          "depth-capped triangle uses the shared triangle-style"))))
+
 ;; ---- toggle handler shape ------------------------------------------------
 
 (deftest toggle-handler-dispatches-canonical-event

--- a/tools/xray/test/day8/re_frame2_xray/views/data_display_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/data_display_cljs_test.cljs
@@ -28,7 +28,8 @@
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.views.data-display :as dd]
-            [day8.re-frame2-xray.theme.tokens :refer [tokens]]))
+            [day8.re-frame2-xray.theme.tokens
+             :refer [tokens dark-palette light-palette]]))
 
 ;; Fresh re-frame runtime per test so the click-to-toggle integration
 ;; test can fire `dispatch-sync` against the registered event handlers
@@ -110,10 +111,13 @@
 
 ;; ---- scalar rendering ----------------------------------------------------
 
-(deftest scalar-keyword-uses-accent
+(deftest scalar-keyword-uses-syntax-keyword
+  ;; rf2-79ojx — keywords paint via `:syntax-keyword` (magenta), NOT
+  ;; `:accent` (chrome blue). The previous mapping put 3 of 5 scalar
+  ;; types in the same blue family.
   (let [h (dd/render-scalar :foo)]
     (is (= :span (first h)))
-    (is (= (:accent tokens) (-> h second :style :color)))
+    (is (= (:syntax-keyword tokens) (-> h second :style :color)))
     (is (= ":foo" (collect-text h)))))
 
 (deftest scalar-string-uses-syntax-string-and-quotes
@@ -134,19 +138,114 @@
               (-> h-num  second :style :color))
         "boolean and number must use DIFFERENT theme tokens")))
 
-(deftest scalar-nil-uses-text-tertiary
+(deftest scalar-nil-uses-syntax-nil
+  ;; rf2-79ojx — nil paints via its own dedicated `:syntax-nil` token
+  ;; (deliberately muted grey, "absence" reads as faded).
   (let [h (dd/render-scalar nil)]
-    (is (= (:text-tertiary tokens) (-> h second :style :color)))
+    (is (= (:syntax-nil tokens) (-> h second :style :color)))
     (is (= "nil" (collect-text h)))))
 
-(deftest scalar-symbol-uses-magenta
+(deftest scalar-symbol-uses-syntax-symbol
+  ;; rf2-79ojx — symbols paint via `:syntax-symbol` (blue), distinct
+  ;; from the magenta now used for keywords.
   (let [h (dd/render-scalar 'sym)]
-    (is (= (:magenta tokens) (-> h second :style :color)))))
+    (is (= (:syntax-symbol tokens) (-> h second :style :color)))))
 
 (deftest scalar-fn-renders-with-italic
   (let [h (dd/render-scalar (fn [x] x))]
     (is (re-find #"^#fn" (collect-text h)))
     (is (= "italic" (-> h second :style :font-style)))))
+
+;; ---- rf2-79ojx — scalar hue-family contract ------------------------------
+;;
+;; The five scalar types (keyword / string / number / boolean / nil) MUST
+;; span at least four hue families. CLJS programmers' eyes are trained on
+;; editor syntax-highlight palettes (One Dark / Calva / Cursive default),
+;; where keywords + strings + numbers paint in clearly distinct hues. The
+;; pre-rf2-79ojx mapping put 3 of 5 in the blue family with only luminance
+;; varying — the inspector looked monochrome.
+;;
+;; "Hue family" here is the dominant RGB channel of the hex (whichever of
+;; R/G/B has the largest value, with a tie tolerance for grey). The
+;; contract holds in BOTH dark + light palettes.
+
+(defn- hex->rgb
+  "Parse a `#rrggbb` hex string into a `[r g b]` int triple. Cljs-only."
+  [hex]
+  (let [s (subs hex 1)]
+    [(js/parseInt (subs s 0 2) 16)
+     (js/parseInt (subs s 2 4) 16)
+     (js/parseInt (subs s 4 6) 16)]))
+
+(defn- dominant-channel
+  "Classify a hex into a hue family: :red / :green / :blue / :yellow /
+  :magenta / :cyan / :orange / :grey. Approximation good enough to
+  separate 5 distinct CLJS-editor hues. Grey when max-min < 28 (very
+  desaturated)."
+  [hex]
+  (let [[r g b] (hex->rgb hex)
+        mx (max r g b)
+        mn (min r g b)]
+    (cond
+      (< (- mx mn) 28) :grey
+      (and (= mx r) (>= g (* 0.6 r)) (< b (* 0.5 r))) :orange ; warm red+green
+      (and (= mx r) (>= b (* 0.55 r)))                :magenta ; red + blue
+      (and (= mx g) (>= r (* 0.75 g)))                :yellow  ; red ≈ green
+      (= mx r)                                        :red
+      (= mx g)                                        :green
+      (= mx b)                                        :blue
+      :else                                           :grey)))
+
+(deftest scalar-hue-families-span-at-least-four-dark
+  ;; rf2-79ojx acceptance #2 — five scalar tokens span ≥4 hue families
+  ;; in the dark palette. Renames are token-keyword level; this asserts
+  ;; the actual hex values.
+  (let [families (set (map #(dominant-channel (get dark-palette %))
+                           [:syntax-keyword :syntax-string :syntax-number
+                            :syntax-boolean :syntax-nil]))]
+    (is (>= (count families) 4)
+        (str "5 scalar types must span ≥4 hue families; got " families))
+    (is (not= families #{:blue})
+        "no monochrome blue palette")
+    (is (contains? families :grey)
+        "nil reads as deliberately muted grey")))
+
+(deftest scalar-hue-families-span-at-least-four-light
+  ;; Light-theme mirror. Same contract.
+  (let [families (set (map #(dominant-channel (get light-palette %))
+                           [:syntax-keyword :syntax-string :syntax-number
+                            :syntax-boolean :syntax-nil]))]
+    (is (>= (count families) 4)
+        (str "5 scalar types must span ≥4 hue families; got " families))
+    (is (not= families #{:blue})
+        "no monochrome blue palette")))
+
+(deftest no-two-scalar-tokens-share-the-same-blue-family
+  ;; The specific regression: pre-rf2-79ojx had keyword(:accent) +
+  ;; number(:syntax-number) + string(:syntax-string) all in the blue
+  ;; family. Guard against re-introducing the collision.
+  (let [scalar-keys [:syntax-keyword :syntax-string :syntax-number
+                     :syntax-boolean :syntax-nil]
+        dark-blues  (filter #(= :blue (dominant-channel (get dark-palette %)))
+                            scalar-keys)
+        light-blues (filter #(= :blue (dominant-channel (get light-palette %)))
+                            scalar-keys)]
+    (is (<= (count dark-blues) 1)
+        (str "≤1 dark-palette scalar may be in the blue family; got "
+             (vec dark-blues)))
+    (is (<= (count light-blues) 1)
+        (str "≤1 light-palette scalar may be in the blue family; got "
+             (vec light-blues)))))
+
+(deftest scalar-tokens-are-defined-in-both-palettes
+  ;; Every scalar token must exist in both palettes — the theme toggle
+  ;; can't fall back to undefined.
+  (doseq [k [:syntax-keyword :syntax-string :syntax-number
+             :syntax-boolean :syntax-nil :syntax-symbol]]
+    (is (re-find #"^#[0-9a-fA-F]{6}$" (get dark-palette k))
+        (str k " defined in dark-palette as a 6-digit hex"))
+    (is (re-find #"^#[0-9a-fA-F]{6}$" (get light-palette k))
+        (str k " defined in light-palette as a 6-digit hex"))))
 
 ;; ---- sentinel rendering --------------------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/views/data_display_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/data_display_cljs_test.cljs
@@ -833,6 +833,127 @@
              @captured)
           "default-expanded render → payload carries rendered? true"))))
 
+;; ---- rf2-pvsxs — opt-in `:site-id` for cross-mount persistence ----------
+;;
+;; By default, two `[data-display value]` mounts in the same panel get
+;; independent expansion state via the auto-mount-id (rf2-sndui D4=a).
+;; The cost — only visible in the panel-leave-and-return workflow —
+;; is that the same logical site loses state on every unmount, because
+;; the second mount allocates a new auto-mount-id.
+;;
+;; Opt-in `:site-id` fixes this without breaking the isolation default:
+;; consumers that want their expansion state to SURVIVE a remount pass
+;; a stable identifier (e.g. `[:app-db-frame frame-id]`) as the
+;; `:site-id`. The expansion-key's second component reads `:site-id`
+;; when supplied, falling back to auto-mount-id when omitted.
+
+(deftest data-display-uses-site-id-when-supplied-as-expansion-key-id
+  ;; Two mounts with the SAME `:site-id` and the SAME path must write
+  ;; their override to the SAME expansion-key, so the second mount sees
+  ;; the first mount's choice.
+  (let [panel-id :p
+        site-id  [:my-stable-site "alpha"]
+        path     [:cart :items]
+        ;; First mount → simulate a toggle dispatch carrying rendered? true
+        ;; (i.e. visible state is expanded; first click should collapse).
+        _        (rf/dispatch-sync [:rf.xray.data-display/reset-expansion])
+        _        (rf/dispatch-sync [:rf.xray.data-display/toggle-node
+                                    panel-id site-id path true])
+        k        (dd/expansion-key panel-id site-id path)
+        snapshot @(rf/subscribe [dd/expansion-slot])]
+    (is (= false (get-in snapshot [k :expanded?]))
+        "override is stored under [panel-id site-id path], independent
+         of any auto-generated mount-id")
+    (rf/dispatch-sync [:rf.xray.data-display/reset-expansion])))
+
+(deftest data-display-public-widget-routes-site-id-to-render-key
+  ;; The public widget threads `:site-id` (when present) into the
+  ;; `mount-id` slot of every render-node descent so the toggle handler
+  ;; dispatches against the stable id, NOT the auto-mount-id. Verified
+  ;; by mounting the widget twice with the SAME site-id and a value
+  ;; that needs expansion; the testid carrying the stable id must
+  ;; appear on both renders.
+  (let [outer (dd/data-display {:a 1 :b 2 :c 3 :d 4} {:panel-id :p
+                                                      :site-id  [:my-site "x"]
+                                                      :default-expanded-depth 0})
+        inner1 (outer {:a 1 :b 2 :c 3 :d 4} {:panel-id :p
+                                              :site-id  [:my-site "x"]
+                                              :default-expanded-depth 0})
+        attrs  (second inner1)]
+    ;; The container attrs carry both the auto-mount-id (debugging) AND
+    ;; the literal site-id (for inspection / Storybook-tier targeting).
+    (is (some? (get attrs :data-rf-mount-id))
+        "auto-mount-id still present (for debugging)")
+    (is (= (pr-str [:my-site "x"]) (get attrs :data-rf-site-id))
+        ":data-rf-site-id attribute carries the literal site-id")))
+
+(deftest data-display-without-site-id-keeps-per-call-site-isolation
+  ;; The acceptance contract: when `:site-id` is omitted, behaviour is
+  ;; UNCHANGED — auto-mount-id keeps two side-by-side mounts independent.
+  ;; This guards the rf2-sndui D4=a default.
+  (let [outer1 (dd/data-display {:a 1} {:panel-id :p})
+        outer2 (dd/data-display {:a 1} {:panel-id :p})
+        inner1 (outer1 {:a 1} {:panel-id :p})
+        inner2 (outer2 {:a 1} {:panel-id :p})
+        m1     (get (second inner1) :data-rf-mount-id)
+        m2     (get (second inner2) :data-rf-mount-id)]
+    (is (some? m1))
+    (is (some? m2))
+    (is (not= m1 m2)
+        "two mounts with no :site-id get DIFFERENT auto-mount-ids → independent expansion state")
+    (is (nil? (get (second inner1) :data-rf-site-id))
+        "no :site-id supplied → no data-rf-site-id attribute")))
+
+(deftest cross-mount-persistence-survives-unmount-and-remount
+  ;; The canonical rf2-pvsxs scenario: mount widget → expand a path →
+  ;; unmount → remount with the SAME :site-id → the path is STILL
+  ;; expanded. Simulate via:
+  ;;   1. dispatch a toggle that opens [:nested :deep] for site-id Σ
+  ;;   2. confirm the override is stored under [panel Σ [:nested :deep]]
+  ;;   3. "remount" simulated by computing the lookup key with the same Σ
+  ;;   4. confirm the override resolves to `true` (expanded)
+  (let [panel-id :rf.xray/app-db
+        site-id  [:rf.xray/app-db "top"]
+        path     [:nested :deep]
+        _        (rf/dispatch-sync [:rf.xray.data-display/reset-expansion])
+        ;; Step 1 — open the path (rendered? false → store true).
+        _        (rf/dispatch-sync [:rf.xray.data-display/toggle-node
+                                    panel-id site-id path false])
+        k        (dd/expansion-key panel-id site-id path)
+        ;; "Unmount" — no state cleanup needed; the expansion slot
+        ;; survives Reagent unmount because it's in app-db.
+        ;; "Remount" — same site-id is passed at the new mount; the
+        ;; renderer's resolve-expanded? reads the same key.
+        snapshot-after-remount @(rf/subscribe [dd/expansion-slot])]
+    (is (= true (get-in snapshot-after-remount [k :expanded?]))
+        "expansion override survives the simulated unmount-and-remount cycle
+         when the consumer passes a stable :site-id")
+    ;; Per the resolve-expanded? helper, this should also yield true
+    ;; regardless of the default-expanded heuristic.
+    (is (true? (dd/resolve-expanded? snapshot-after-remount
+                                     panel-id site-id path false))
+        "resolve-expanded? honours the stored override at the site-id key")
+    (rf/dispatch-sync [:rf.xray.data-display/reset-expansion])))
+
+(deftest two-mounts-with-distinct-site-ids-still-isolate
+  ;; Two consumers using DIFFERENT :site-ids must STILL isolate, even
+  ;; though both opt out of the auto-mount-id default. This is the
+  ;; per-call-site contract restated in :site-id space.
+  (let [panel-id :p
+        s1       [:site/a]
+        s2       [:site/b]
+        path     []
+        k1       (dd/expansion-key panel-id s1 path)
+        k2       (dd/expansion-key panel-id s2 path)]
+    (rf/dispatch-sync [:rf.xray.data-display/reset-expansion])
+    (rf/dispatch-sync [:rf.xray.data-display/toggle-node panel-id s1 path true])
+    (let [snapshot @(rf/subscribe [dd/expansion-slot])]
+      (is (= false (get-in snapshot [k1 :expanded?]))
+          "site/a's override is stored")
+      (is (nil? (get snapshot k2))
+          "site/b's slot is untouched — distinct :site-ids isolate"))
+    (rf/dispatch-sync [:rf.xray.data-display/reset-expansion])))
+
 ;; ---- per-call-site isolation ---------------------------------------------
 
 (deftest two-mounts-independent-via-distinct-mount-ids


### PR DESCRIPTION
Four P2 bugs against the new `views/data-display` widget — all surfaced by Mike's live testing on http://localhost:8031/counter App-DB panel (pair-debug session 2026-05-26). Same widget surface, four sequential commits in one PR.

## Symptom → fix → coverage, per bead

### rf2-79ojx — adopt CLJS-syntax-highlight palette

**Symptom (live measurement):**

| Element class | Computed colour | Hue family |
|---|---|---|
| Keyword keys / values | `rgb(9, 105, 218)` blue | blue |
| Numbers (typed) | `rgb(5, 80, 174)` darker blue | blue |
| Strings (typed) | `rgb(10, 48, 105)` very dark blue | blue |
| Booleans (typed) | `rgb(207, 34, 46)` red | red |
| Nil (typed) | `rgb(140, 149, 159)` grey | grey |

Three of five scalar types in the same blue hue family — to a CLJS programmer's eye the inspector read as monochrome rather than syntax-highlighted.

**Fix approach:** Adopt the **One Dark / Atom One Dark** palette (with **One Light** mirror), the lineage behind Calva's default theme + Cursive's Material One Dark + the VS Code Atom One family. Five scalar tokens now span four hue families: keyword magenta, string green, number orange, boolean gold, nil grey. The fix surfaced a tokens-vs-widget coupling (the bead anticipated this) — the widget's `render-scalar` + `key-segment` now route through the per-type `:syntax-*` tokens consistently. The `machines-viz` tokens mirror per the rf2-z7ms8 drift gate.

**Test coverage:**
- `scalar-keyword-uses-syntax-keyword` / `scalar-nil-uses-syntax-nil` / `scalar-symbol-uses-syntax-symbol` (renames)
- `scalar-hue-families-span-at-least-four-{dark,light}` (chromatic-distance via dominant-RGB-channel)
- `no-two-scalar-tokens-share-the-same-blue-family` (specific regression guard)
- `scalar-tokens-are-defined-in-both-palettes`

### rf2-tzvk9 — triangle hit-box ≥24px

**Symptom (live measurement):** triangle width **6.6px** × height 16.8px → click target ~110 sq px, **5× smaller than the 24×24 comfortable mouse-target minimum** called out alongside the WCAG 2.2 AAA touch-target guidance.

**Fix approach:** Shared `triangle-style` map applied at every triangle render site (depth-capped, expanded ▾, collapsed ▸). Single source of truth so the contract is uniform across all three code paths. `inline-flex` + center align/justify, `min-width`/`min-height` 24px, `padding 4px 8px`, `font-size 14px`, `line-height 1`. Combined target: ~26×27.6px in Chromium at the shell's default 13px root font-size. Colour stays on the subdued `:text-secondary` token — the glyph's job is findable, not loud. Padding sits inside the existing key-column gutter so it doesn't disturb the rf2-1bra5 column-alignment fix landing in the same PR.

**Test coverage:**
- `triangle-style-pins-min-target-to-24px-in-both-axes`
- `triangle-min-target-px-is-24` (public contract pin)
- `{collapsed,expanded,depth-capped}-triangle-uses-shared-triangle-style` (contract holds across the call graph)

### rf2-1bra5 — map layout: column-align values + inline-wrap rows

**Symptom (live measurement):** Two related layout bugs.

Bug 1 — some scalar rows wrapped, others stayed inline:

| Row | Height | Layout |
|---|---|---|
| `:value ~1← changed from 0` | 17.79px | one line |
| `:last-clicked ~1779742091688← changed from nil` | 17.79px | one line |
| `:show-parity?  true` | **28.79px** | two lines |
| `:threshold  5` | **28.79px** | two lines |

Counter-intuitive: diff-annotated rows render inline; simpler rows wrap. Root cause: `gutter-row` wraps diff-leaves in BLOCK-level `<div>` (`display: flex`) inside the per-row `flex-wrap: wrap` container — the wide block-div wraps below the key.

Bug 2 — values don't column-align across rows of the same map (each row is its own `display: flex` so values follow whatever gap landed after the key, producing a ragged value-column left edge).

**Fix approach:** Two coordinated changes:

1. Map / record / map-entry bodies use **CSS Grid** with `grid-template-columns: max-content 1fr`. Each row contributes its key + value as DIRECT grid children (not a per-row container). `max-content` auto-resolves to the widest key in THIS map (nested maps compute their own column-1 width independently). `column-gap: 8px`; `row-gap: 0` preserves the workstation-dense layout.
2. `gutter-row` switches from block-level `flex` to `inline-flex` (span, not div). A diff'd leaf now composes inline with its preceding key inside the row's grid cell.

Sequentials (vectors / lists / sets / seqs) keep block layout — no key column, no grid needed.

**Test coverage:**
- `map-body-uses-css-grid-layout` (display/grid + max-content+1fr template)
- `map-body-row-emits-key-and-value-as-direct-grid-children`
- `sequential-body-still-uses-block-layout`
- `gutter-row-is-inline-flex-not-block`
- `scalar-leaves-render-as-inline-spans-in-non-diff-mode`
- `map-with-mixed-scalar-and-container-values-grid-layout` (nested-isolation)
- `map-body-row-gap-is-zero-for-density`

### rf2-pvsxs — expansion state survives panel-leave-and-return

**Symptom:** Leave a tab (App-DB or Handler) → return → all expand/collapse choices reset to default-expanded-depth. The expansion slot is keyed by `[panel-id mount-id path]`; the form-2 outer fn allocates a fresh auto-mount-id on every remount; the new mount-id misses the orphaned overrides under the old one.

This is the rf2-sndui D4=a per-call-site isolation default — the cost is exactly this panel-leave-and-return workflow.

**Fix approach:** Opt-in additive `:site-id` opt. When supplied, the expansion key's second component reads `:site-id` instead of the auto-mount-id. When omitted, behaviour is unchanged (per-call-site isolation preserved). Five consumer panels updated with stable site-id derivations:

```clj
;; App-DB                  → [:rf.xray/app-db render-id]
;; Trace rows              → [:rf.xray.trace/row event-id]
;; Reactive sub values     → [:rf.xray.reactive/sub sub-id]
;; Machine canvas snapshot → [:rf.xray.machines/snapshot machine-id phase]
;; Machine inspector       → [:rf.xray.machines/inspector-snapshot machine-id phase]
```

**Decisions documented in the commit message:**

- mini-variant mounts stay on auto-mount-id (ephemeral; persistence would risk stale orphans)
- legacy diff renderer (`diff/render.cljs`, `diff/hiccup_render.cljs`) + edn_widget facade already encode stable ids in panel-id, so site-id is a no-op there
- orphan-prune affordance deferred (low priority; reset event already wired)
- popup widget's embedded data-display keeps its popup-mount-id-qualified panel-id (popups are short-lived)

**Test coverage:**
- `data-display-uses-site-id-when-supplied-as-expansion-key-id`
- `data-display-public-widget-routes-site-id-to-render-key`
- `data-display-without-site-id-keeps-per-call-site-isolation` (rf2-sndui D4=a default guarded)
- `cross-mount-persistence-survives-unmount-and-remount` (the canonical scenario)
- `two-mounts-with-distinct-site-ids-still-isolate`

## Gates

- `cd tools/xray && clojure -M:test` → 859 tests, 3122 assertions, 0 failures
- `cd implementation && npx shadow-cljs compile node-test && node out/node-test.js` → 4554 tests, 14526 assertions, 0 failures
- `cd implementation && npm run test:bundle-isolation` → PASS (16 artefact entries; 33 internal sentinels absent)
- `cd implementation && npm run test:perf-bundle` → PASS (off-count=0; on-count=12)
- `clj-kondo --lint tools/xray/src tools/xray/test` → 0 errors, 93 pre-existing warnings (none from this PR)
- `cd tools/machines-viz && clojure -M:test` → 286 tests, 689 assertions, 0 failures

## References

- All 4 beads filed Mike-live 2026-05-25 / 2026-05-26 from pair-debug sessions
- rf2-79ojx + rf2-tzvk9 + rf2-1bra5 + rf2-pvsxs
- All touch the same widget surface — sequenced in one PR to avoid intra-PR merge conflicts on `tools/xray/src/.../views/data_display.cljs`