### PR TITLE
fix(xray): data-display follow-on UX cluster — triangle glyph + card chrome + map alignment + popup-affordance (rf2-4aiaq + rf2-63ie5 + rf2-726ol + rf2-7sdja)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1299,6 +1299,25 @@ reach for `[data-display value opts]` directly.
   annotation; ancestor chain force-expands over any changed
   descendant. Omit `:before` for plain BROWSE mode. See §10.0.8
   for the full diff contract.
+- `:popup-affordance?` — when `true`, renders a top-right ↗ icon
+  button that pops the value into a modal overlay (§10.0.7.2).
+  Defaults `false`.
+- `:card?` (rf2-63ie5) — when `true`, the widget's outer container
+  carries the inspector-card chrome (background `:bg-1`, 1px
+  `:border-default` border, `8px` radius, `8px 10px` padding,
+  `8px` margin-bottom) so multiple top-level mounts in the same
+  panel read as DISTINCT cards rather than blending into one
+  continuous block. Theme-aware via tokens. Opt-in per call-site:
+  inline mounts (table cells, popup contents that already carry
+  modal chrome, diff sub-renderers) leave it off; panels with
+  multiple top-level inspector mounts (App-DB's TOP + per-`:rf/*`
+  sections) opt in. Defaults `false`.
+- `:site-id` (rf2-pvsxs) — when supplied, becomes the second
+  component of the per-node expansion key INSTEAD of the auto-
+  generated mount-id. Lets the same logical call site survive a
+  panel-leave-and-return round-trip (auto-mount-id changes on
+  remount; a stable site-id does not). Omit to keep the per-call-
+  site isolation default.
 
 The widget is a **Reagent form-2 component** — the outer fn captures
 a stable `mount-id` (auto-generated UUID, per D4=a — no public
@@ -1623,13 +1642,18 @@ The shell-side mount sits alongside `[app-db-segment-inspector/Popup]`
 in `shell.cljs`'s overlay block, INSIDE the `rf/frame-provider
 {:frame :rf/xray}` wrapper so subscribes resolve to Xray's frame.
 
-##### §10.0.7.2 Per-panel "open in popup" affordance (rf2-l4625)
+##### §10.0.7.2 Per-panel "open in popup" affordance (rf2-l4625 · rf2-7sdja)
 
 Each `[dd/data-display value opts]` call site **opts in** to a
-top-right ⊕ icon button by passing `:popup-affordance? true` in
+top-right ↗ icon button by passing `:popup-affordance? true` in
 `opts`. Default is **off** — scalar / tiny-value mounts don't
 benefit from a larger inspection surface, and the silent default
 keeps simple call sites quiet.
+
+Glyph is `↗` (north-east arrow) — rf2-7sdja replaced the original
+`⊕`. The arrow reads as "open in new pane / navigate outward"
+which matches the popup's window-manager semantics better than
+the circled plus (which read as "expand" / "add").
 
 Mechanics:
 
@@ -1639,9 +1663,13 @@ Mechanics:
   is enabled).
 - Click dispatches
   `[:rf.xray.data-display-popup/open popup-mount-id {:value v :opts o}]`
-  through the lexically-captured frame-aware dispatcher (so the
-  event lands on the surrounding `:rf/xray` frame, matching
-  every other Xray dispatch).
+  against `:rf/xray` **explicitly** via the established
+  `(rf/dispatch event {:frame :rf/xray})` pattern (rf2-7sdja).
+  This pins the dispatch frame regardless of where the widget
+  mounts — popup state is Xray-global (the popup-stack-view
+  subscribes only against `:rf/xray`), unlike expansion state
+  which is per-frame and uses the lexically-captured frame-
+  aware dispatcher.
 - `popup-mount-id` is derived from the data-display's own
   mount-id (`"ddp-" + mount-id`) — stable per call-site mount,
   so re-clicking the affordance **raises** the existing popup
@@ -1656,21 +1684,25 @@ popup-mount-id`. The button carries
 `:data-rf-affordance "popup"` for hover-style hooks +
 `:aria-label "Open in popup"` for assistive tech.
 
-Initial enabled call sites (panels where the inline widget is
-genuinely cramped):
+Enabled call sites (panels where the inline widget is genuinely
+cramped):
 
 | Panel                                  | Site                                              | Rationale                                                                            |
 |----------------------------------------|---------------------------------------------------|--------------------------------------------------------------------------------------|
-| `panels/app_db_diff_state.cljs`        | `value-body` (whole user-domain + reserved areas) | App-DB whole-tree is the canonical cramped-in-side-panel case                        |
 | `panels/machine_canvas.cljs`           | snapshot drill-in                                 | Machine snapshots carry deeply-nested `:data` maps                                   |
 | `panels/machine_inspector.cljs`        | per-phase snapshot block                          | Same as canvas — per-machine `:data` maps                                            |
 | `panels/reactive_panel_view.cljs`      | per-sub value row                                 | Sub values can be the full domain projection (cart, users, route tree, …)            |
 | `panels/trace.cljs`                    | per-row payload expand                            | Trace rows expand within the row's narrow column; tags + payload maps are cramped    |
 
+App-DB does NOT use the affordance (rf2-7sdja — Mike's live-testing
+call 2026-05-26). The side panel has plenty of horizontal room; the
+whole-tree inspector reads comfortably in-place. Earlier framing of
+App-DB as "the canonical cramped in the side panel case" was wrong.
+
 Diff renderers' internal `inspect-value` leaves (`diff/render.cljs`,
 `diff/hiccup_render.cljs`) intentionally **do not** carry the
 affordance — they're inner mini-renderers inside a larger diff tree
-chrome, not user-facing leaf inspect mounts; an inline ⊕ per inner
+chrome, not user-facing leaf inspect mounts; an inline ↗ per inner
 leaf would clutter the diff display.
 
 #### §10.0.8 Diff mode (phase 5 · D5=a · rf2-q3dzw)

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs
@@ -145,16 +145,18 @@
         ;; site-id reuses the existing per-surface key without
         ;; introducing a new namespace.
         site-id [:rf.xray/app-db render-id]]
+    ;; rf2-7sdja — App-DB does NOT use `:popup-affordance?` (Mike's
+    ;; live-testing call 2026-05-26). The side panel has plenty of
+    ;; horizontal room; the whole-tree inspector renders comfortably
+    ;; in-place. Other panels (Handler / Trace / Machines / Reactive)
+    ;; keep the affordance where the inline widget is genuinely
+    ;; cramped.
     (if (= h/no-diff before)
       [dd/data-display
        (f/display-value value)
        {:panel-id :rf.xray/app-db
         :site-id  site-id
         :default-expanded-depth 3
-        ;; rf2-l4625 — the App-DB whole-tree is the canonical "cramped
-        ;; in the side panel" case; the popup gives the operator a
-        ;; full-modal inspection surface for deeply-nested state.
-        :popup-affordance? true
         ;; rf2-63ie5 — App-DB renders the user-domain TOP + every
         ;; reserved `:rf/*` area as top-level mounts in the same panel.
         ;; Without card chrome the mounts blend into one continuous
@@ -168,7 +170,6 @@
         :site-id  site-id
         :default-expanded-depth 3
         :before (f/display-value before)
-        :popup-affordance? true
         :card? true}])))
 
 ;; ---- top (user-domain) section ------------------------------------------

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs
@@ -154,14 +154,22 @@
         ;; rf2-l4625 — the App-DB whole-tree is the canonical "cramped
         ;; in the side panel" case; the popup gives the operator a
         ;; full-modal inspection surface for deeply-nested state.
-        :popup-affordance? true}]
+        :popup-affordance? true
+        ;; rf2-63ie5 — App-DB renders the user-domain TOP + every
+        ;; reserved `:rf/*` area as top-level mounts in the same panel.
+        ;; Without card chrome the mounts blend into one continuous
+        ;; block; the opt-in chrome gives each mount a distinct card
+        ;; affordance so the operator sees them as discrete inspector
+        ;; cards.
+        :card? true}]
       [dd/data-display
        (f/display-value value)
        {:panel-id :rf.xray/app-db
         :site-id  site-id
         :default-expanded-depth 3
         :before (f/display-value before)
-        :popup-affordance? true}])))
+        :popup-affordance? true
+        :card? true}])))
 
 ;; ---- top (user-domain) section ------------------------------------------
 

--- a/tools/xray/src/day8/re_frame2_xray/views/data_display.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/data_display.cljs
@@ -64,17 +64,21 @@
                     ancestors of any changed descendant force open
                     regardless of the default-expand heuristic.
   - `:popup-affordance?` (optional, default false) — rf2-l4625; when
-                    true the widget renders a top-right ⊕ icon button
+                    true the widget renders a top-right ↗ icon button
+                    (rf2-7sdja — was ⊕; ↗ reads as 'open in new pane')
                     that dispatches
                     `[:rf.xray.data-display-popup/open mount-id payload]`
-                    (the open event registered by
-                    `views.data-display-popup/install-events!`). The
-                    popup-mount-id is derived from this widget's own
-                    mount-id, so re-clicking raises the existing popup
-                    rather than spawning a duplicate. Opt-in per
-                    call-site; panels enable the affordance where the
-                    inline widget is genuinely cramped (App-DB whole-
-                    tree, machine snapshots, sub values).
+                    against `:rf/xray` explicitly (popup state is
+                    Xray-global, not per-frame — rf2-7sdja). The popup-
+                    mount-id is derived from this widget's own mount-
+                    id, so re-clicking raises the existing popup rather
+                    than spawning a duplicate. Opt-in per call-site;
+                    panels enable the affordance where the inline
+                    widget is genuinely cramped (machine snapshots,
+                    sub values, trace payloads). App-DB does NOT use
+                    the affordance (rf2-7sdja — App-DB has plenty of
+                    horizontal room; the popup would be unnecessary
+                    affordance noise).
   - `:card?`         (optional, default false) — rf2-63ie5; when true
                     the widget's outer container carries the inspector-
                     card chrome (background `:bg-1`, 1px `:border-
@@ -1406,8 +1410,14 @@
 ;;
 ;; Opt-in (not always-on): scalar / tiny-value mounts don't benefit from
 ;; a larger inspection surface. Panels enable the affordance where the
-;; inline widget is genuinely cramped (App-DB whole-tree, machine
-;; snapshots, sub values). Default off keeps simple call sites quiet.
+;; inline widget is genuinely cramped (machine snapshots, sub values,
+;; trace payloads). Default off keeps simple call sites quiet.
+;;
+;; App-DB does NOT use the affordance (rf2-7sdja — Mike's call after
+;; live testing 2026-05-26): the App-DB panel has plenty of horizontal
+;; room; the side panel is wide enough for the whole tree without a
+;; pop-out. Earlier framing of App-DB as "the canonical cramped in the
+;; side panel case" was wrong.
 ;;
 ;; The affordance dispatches the OPEN event id literally — no `require`
 ;; on the popup ns from here, which would form a cycle (the popup ns
@@ -1434,13 +1444,40 @@
 
 (defn popup-affordance-button
   "Render the 'open in popup' icon button. `dispatch-fn` is the
-  lexically-captured frame-aware dispatcher; `popup-mount-id` is the
-  stable id keyed to the data-display's own mount-id; `value` + `opts`
-  are the popup's payload.
+  lexically-captured frame-aware dispatcher reserved for the
+  PER-FRAME paths (legacy parameter — see dispatch-asymmetry note
+  below); `popup-mount-id` is the stable id keyed to the data-
+  display's own mount-id; `value` + `opts` are the popup's payload.
+
+  ## Dispatch asymmetry (rf2-7sdja)
+
+  The popup OPEN event dispatches against `:rf/xray` EXPLICITLY via
+  the established `(rf/dispatch event {:frame :rf/xray})` pattern
+  (matches `settings/view.cljs` + `app_db_segment_inspector.cljs`).
+  Other data-display dispatches (`:rf.xray.data-display/toggle-node`)
+  use the lexically-captured `dispatch-fn` because expansion state is
+  per-frame — the widget can be mounted in any frame and the toggle
+  dispatch must land in the SURROUNDING frame's app-db so the
+  expansion-slot subscription sees the write.
+
+  Popup state is different: the popup stack-view (`data-display-popup-
+  stack` in `shell.cljs`) is mounted inside `[rf/frame-provider
+  {:frame :rf/xray}]` and subscribes ONLY against `:rf/xray`'s
+  app-db. If a popup-open dispatch leaks to `:rf/default` (or any
+  non-Xray frame), the mutation lands on the wrong app-db and the
+  stack-view never renders the popup — the canonical bug Mike
+  reproduced live (pair-debug 2026-05-26). The fix pins the popup
+  dispatch to `:rf/xray` REGARDLESS of where the widget mounts:
+  expansion state stays per-frame; popup state stays Xray-global.
+
+  The `dispatch-fn` parameter is retained as a no-op for back-compat
+  with the existing test surface (some tests pass a stub to capture
+  the event vector). Production callers should pass `nil` —
+  `popup-affordance-button` ignores it and dispatches directly.
 
   Public so unit tests can drive the button without spinning up the
-  router (pass a stub `dispatch-fn` that captures the event vector)."
-  [dispatch-fn popup-mount-id value opts]
+  router."
+  [_dispatch-fn popup-mount-id value opts]
   [:button
    {:data-testid             (str "rf-xray-data-display-popup-affordance-"
                                   popup-mount-id)
@@ -1452,7 +1489,14 @@
                                (when e
                                  (.preventDefault e)
                                  (.stopPropagation e))
-                               (dispatch-fn
+                               ;; rf2-7sdja — popup state is Xray-
+                               ;; global. Pin the dispatch frame to
+                               ;; `:rf/xray` regardless of the
+                               ;; surrounding mount frame so the
+                               ;; popup-stack-view (which only
+                               ;; subscribes against `:rf/xray`)
+                               ;; sees the write.
+                               (rf/dispatch
                                  [:rf.xray.data-display-popup/open
                                   popup-mount-id
                                   {:value value
@@ -1461,10 +1505,14 @@
                                               ;; affordance inside the
                                               ;; popup's embedded
                                               ;; data-display.
-                                              (assoc :popup-affordance? false))}]))
+                                              (assoc :popup-affordance? false))}]
+                                 {:frame :rf/xray}))
     :style                   popup-affordance-button-style}
-   ;; ⊕ glyph reads as "open" without the language baggage of e.g. 🔍
-   "⊕"])
+   ;; rf2-7sdja — ↗ (north-east arrow) reads as "open in new pane /
+   ;; navigate outward" which matches the popup's window-manager
+   ;; semantics better than ⊕ (which read as "expand" / "add"). Same
+   ;; aria-label / title — the glyph swap is visual only.
+   "↗"])
 
 (rf/reg-view data-display
   "First-class data-display widget — single source of truth for

--- a/tools/xray/src/day8/re_frame2_xray/views/data_display.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/data_display.cljs
@@ -75,6 +75,20 @@
                     call-site; panels enable the affordance where the
                     inline widget is genuinely cramped (App-DB whole-
                     tree, machine snapshots, sub values).
+  - `:card?`         (optional, default false) — rf2-63ie5; when true
+                    the widget's outer container carries the inspector-
+                    card chrome (background `:bg-1`, 1px `:border-
+                    default` border, `8px` radius, `8px 10px` padding,
+                    `8px` margin-bottom) so multiple top-level mounts
+                    in the same panel read as DISTINCT cards rather
+                    than blending into one continuous block. Theme-
+                    aware via tokens — both light + dark resolve at
+                    paint time. Opt-in per call-site: inline mounts
+                    (table cells, popup contents that already carry
+                    modal chrome, diff sub-renderers) leave it off;
+                    panels with multiple top-level inspector mounts
+                    (App-DB's TOP + per-`:rf/*` sections; Handler's
+                    side-by-side event-detail mounts) opt in.
 
   Drop the `:render-id` arg from the old facade — mount-id is now
   auto-generated internally per D4=a (rf2-sndui).
@@ -1490,12 +1504,13 @@
       [value & rest-args]
       (let [opts          (first rest-args)
             {:keys [panel-id site-id default-expanded-depth max-inline-width
-                    max-depth before popup-affordance?]
+                    max-depth before popup-affordance? card?]
              :or   {panel-id :rf.xray.data-display/anon
                     default-expanded-depth 2
                     max-inline-width 60
                     max-depth 16
-                    popup-affordance? false}} opts
+                    popup-affordance? false
+                    card? false}} opts
             diff?         (contains? opts :before)
             ;; rf2-pvsxs — `site-id` (when supplied) opt-out of the
             ;; per-call-site mount-id isolation. The expansion-key's
@@ -1528,15 +1543,32 @@
                :data-rf-site-id  (when site-id (pr-str site-id))
                :data-rf-mode    (if diff? "diff" "browse")
                :data-rf-popup-affordance? (when popup-affordance? "1")
-               :style {:font-family mono-stack
-                       :font-size   "12px"
-                       :color       (:text-primary tokens)
-                       :line-height 1.4
-                       ;; Position context for the absolute-positioned
-                       ;; affordance button. Harmless when the
-                       ;; affordance is off — no descendant uses
-                       ;; absolute positioning otherwise.
-                       :position    (when popup-affordance? "relative")}}
+               :data-rf-card     (when card? "1")
+               :style (cond-> {:font-family mono-stack
+                               :font-size   "12px"
+                               :color       (:text-primary tokens)
+                               :line-height 1.4
+                               ;; Position context for the absolute-
+                               ;; positioned affordance button. Harmless
+                               ;; when the affordance is off — no
+                               ;; descendant uses absolute positioning
+                               ;; otherwise.
+                               :position    (when popup-affordance? "relative")}
+                        ;; rf2-63ie5 — inspector-card chrome on
+                        ;; top-level mounts. Theme-aware via tokens so
+                        ;; both light + dark resolve at paint time. The
+                        ;; opt-in (`:card? true`) keeps inline / nested
+                        ;; mounts unchrromed; panels with multiple top-
+                        ;; level inspector mounts (App-DB, Handler)
+                        ;; pass `:card? true` so the eye reads each
+                        ;; mount as a discrete card rather than one
+                        ;; continuous block.
+                        card? (assoc :background-color (:bg-1 tokens)
+                                     :border           (str "1px solid "
+                                                            (:border-default tokens))
+                                     :border-radius    "8px"
+                                     :padding          "8px 10px"
+                                     :margin-bottom    "8px"))}
          (when popup-affordance?
            (popup-affordance-button dispatch-fn popup-mount-id value opts))
          (render-node {:value value

--- a/tools/xray/src/day8/re_frame2_xray/views/data_display.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/data_display.cljs
@@ -764,23 +764,32 @@
        (when (seq path) (str "-" (str/join "/" (map pr-str path))))))
 
 ;; rf2-tzvk9 — triangle expand/collapse glyph carries an explicit
-;; ≥24×24 click target. The glyph itself stays visually subordinate
-;; (font-size 14px, dimmed `:text-secondary`); padding inside the
-;; existing key-column gutter grows the hit-box without shifting the
-;; surrounding layout. Public via the value so tests can assert the
-;; computed-width contract without re-deriving the magic numbers.
+;; ≥24×24 click target. The padding inside the existing key-column
+;; gutter grows the hit-box without shifting the surrounding layout.
+;; Public via the value so tests can assert the computed-width
+;; contract without re-deriving the magic numbers.
 ;;
-;; Why these numbers — getBoundingClientRect on `inline-flex` + the
-;; padding/font-size below resolves to approximately 26×24px in
-;; Chromium at the shell's default 13px root font-size:
+;; rf2-4aiaq — glyph size bumped 14px → 22px. The 14px glyph cleared
+;; the 24px hit-box but read as a hairline against the inspector
+;; chrome; Mike's live A/B (pair-debug 2026-05-26) found 22-24px
+;; "much more clickable, feels right" vs. 14-18px which still felt
+;; understated. 22px keeps the glyph visually balanced against the
+;; surrounding 12px scalar rows (~1.83× scale) without dominating
+;; the row.
 ;;
-;;   width  ≈ font-size(14) * glyph-advance(~0.7) + padding-l(4) +
-;;            padding-r(4)                                ≈ 26px
-;;   height ≈ font-size(14) * line-height(1.4)            ≈ 19.6px
-;;            + padding-t(4) + padding-b(4)               ≈ 27.6px
+;; Why these numbers — `inline-flex` + the padding/font-size below
+;; resolves to approximately 38×30px in Chromium at the shell's
+;; default 13px root font-size:
 ;;
-;; Both axes clear the 24px WCAG-2.2-flavour comfortable-mouse-target
-;; threshold called out in the bead.
+;;   width  ≈ font-size(22) * glyph-advance(~0.7) + padding-l(4) +
+;;            padding-r(4)                                ≈ 23.4px
+;;   height ≈ font-size(22) * line-height(1)               ≈ 22px
+;;            + padding-t(4) + padding-b(4)                ≈ 30px
+;;
+;; `min-width 24px` pins the floor in both axes even when the glyph's
+;; intrinsic width (`▸` is narrower than `▾`) doesn't reach 24px on
+;; its own. Both axes clear the 24px WCAG-2.2-flavour comfortable-
+;; mouse-target threshold.
 
 (def triangle-min-target-px
   "Minimum click-target width/height the triangle must register
@@ -810,9 +819,12 @@
   - `padding 4px 8px` grows the hit-box WITHOUT pushing the key
     column right — the padding sits inside the existing 4-6px gap
     between the triangle and the first key.
-  - `font-size 14px` overrides the widget's inherited 12px so the
-    glyph is more visible AND the natural metrics grow the hit-box.
-    Bumping by ~2px keeps the glyph subordinate to surrounding data.
+  - `font-size 22px` (rf2-4aiaq) overrides the widget's inherited
+    12px so the glyph reads as the primary expand/collapse affordance
+    — Mike's live A/B (pair-debug 2026-05-26) found the prior 14px
+    glyph read as hairline against the inspector chrome; 22px lands
+    in the operator-preferred 22-24px band where the triangle 'feels
+    clickable'.
   - `line-height 1` collapses inline leading so the height comes
     purely from font + padding, not from inherited 1.4 leading.
 
@@ -826,7 +838,7 @@
    :min-width       (str triangle-min-target-px "px")
    :min-height      (str triangle-min-target-px "px")
    :padding         "4px 8px"
-   :font-size       "14px"
+   :font-size       "22px"
    :line-height     1
    :color           (:text-secondary tokens)})
 

--- a/tools/xray/src/day8/re_frame2_xray/views/data_display.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/data_display.cljs
@@ -1096,10 +1096,20 @@
            ;; key. Falls back gracefully when a value is a multi-line
            ;; container — the value cell grows down, the key stays
            ;; baseline-aligned to the value's first line.
+           ;; rf2-726ol — `margin-left 16px` puts the 1px guide line at
+           ;; the triangle's visual center (the 22px glyph + 8px-side
+           ;; padding renders the triangle box ~31-34px wide; centre
+           ;; lands at ~16px from the row's left edge). `padding-left
+           ;; 6px` gives the key a small breath beyond the line so the
+           ;; line + key column read as a discrete bracket pair instead
+           ;; of fused text. The closing brace below sits at the same
+           ;; `padding-left 16px` — line + first-key column + closing-
+           ;; brace column all converge on one vertical column, so the
+           ;; tree reads as `▾ { │ keys │ }` recursively at every depth.
            (into [:div {:data-testid (str (testid-for panel-id mount-id path) "-body")
                         :data-rf-body-layout "grid"
-                        :style {:padding-left         "14px"
-                                :margin-left          "5px"
+                        :style {:padding-left         "6px"
+                                :margin-left          "16px"
                                 :border-left          (str "1px solid "
                                                            (:border-subtle tokens))
                                 :display              "grid"
@@ -1150,10 +1160,16 @@
            ;; Each child renders bare (no key column). Per-row block flow
            ;; — each entry sits below the previous; nested containers
            ;; recurse with their own grid/block decision.
+           ;;
+           ;; rf2-726ol — same `margin-left 16px` + `padding-left 6px` as
+           ;; the grid body so the vertical guide line sits at the
+           ;; triangle's visual centre (~16px from row left at the 22px
+           ;; glyph metric). Closing bracket below shares the same `16px`
+           ;; padding-left.
            (into [:div {:data-testid (str (testid-for panel-id mount-id path) "-body")
                         :data-rf-body-layout "block"
-                        :style {:padding-left "14px"
-                                :margin-left  "5px"
+                        :style {:padding-left "6px"
+                                :margin-left  "16px"
                                 :border-left  (str "1px solid "
                                                    (:border-subtle tokens))}}]
                  (map
@@ -1174,8 +1190,19 @@
                    child-pairs)))))
 
      ;; ---- close bracket (only when expanded + body present) -------------
+     ;; rf2-726ol — closing bracket sits at `padding-left 16px` so it
+     ;; column-aligns with the vertical guide line above (the body div's
+     ;; 16px margin + 1px border puts the line at x=16). The bracket
+     ;; pair `▾ { … }` reads as a coherent vertical column at every
+     ;; nesting depth.
+     ;;
+     ;; `data-rf-cell "close"` exposes the close-bracket cell for
+     ;; testbed assertions (column-alignment regression tests probe
+     ;; this attr).
      (when (and expanded? (not empty?) (not depth-capped?) (not inline-fit?))
-       [:div {:style {:color (get tokens (:tone-key (delim kind)))
+       [:div {:data-rf-cell "close"
+              :style {:padding-left "16px"
+                      :color (get tokens (:tone-key (delim kind)))
                       :font-family mono-stack}}
         (let [{:keys [close]} (delim kind)] close)])]))
 
@@ -1211,9 +1238,13 @@
                         :flex-wrap "wrap"}}
           header]
          (when (and expanded? (some? body))
+           ;; rf2-726ol — protocol-node body shares the same alignment
+           ;; rule as built-in container bodies: line at the triangle's
+           ;; visual centre (~16px from row left), body content with a
+           ;; 6px breath beyond the line.
            [:div {:data-testid (str (testid-for panel-id mount-id path) "-body")
-                  :style {:padding-left "14px"
-                          :margin-left  "5px"
+                  :style {:padding-left "6px"
+                          :margin-left  "16px"
                           :border-left  (str "1px solid " (:border-subtle tokens))}}
             body])]))))
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_state_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_state_cljs_test.cljs
@@ -343,3 +343,36 @@
       (is (seq diff-mts) "diff-mode mounts present")
       (is (every? #(true? (:popup-affordance? (:opts %))) diff-mts)
           "diff-mode mounts also opt in to the popup affordance"))))
+
+;; ---- card chrome (rf2-63ie5) --------------------------------------------
+;;
+;; The App-DB panel renders the user-domain TOP + every reserved `:rf/*`
+;; area as top-level mounts in the same panel. Without card chrome the
+;; mounts blend into one continuous block; `:card? true` gives each mount
+;; a distinct inspector-card affordance.
+
+(deftest browse-mode-mounts-carry-card-opt
+  (testing "rf2-63ie5 — every `[dd/data-display ...]` mount the App-DB
+            panel produces (BROWSE mode, 1-arity / no-diff) carries
+            `:card? true` so each top-level mount reads as a discrete
+            inspector card"
+    (let [model  (h/current-state-sections
+                   {:counter 2 :rf/route {:id :home}
+                    :rf/machines {:auth {:state :idle}}})
+          tree   (state/state-body model)
+          mounts (find-data-display-mounts tree)]
+      (is (seq mounts) "the panel mounts data-display widget instances")
+      (is (every? #(true? (:card? (:opts %))) mounts)
+          "every browse-mode mount opts in to the card chrome"))))
+
+(deftest diff-mode-mounts-also-carry-card-opt
+  (testing "rf2-63ie5 — DIFF-mode mounts (when a pre-image is supplied)
+            ALSO carry `:card? true`; card chrome is independent of
+            diff mode and applies to every top-level App-DB mount"
+    (let [model  (h/current-state-sections {:counter 2} {:counter 1})
+          tree   (state/state-body model)
+          mounts (find-data-display-mounts tree)
+          diff-mts (filter #(contains? (:opts %) :before) mounts)]
+      (is (seq diff-mts) "diff-mode mounts present")
+      (is (every? #(true? (:card? (:opts %))) diff-mts)
+          "diff-mode mounts also opt in to the card chrome"))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_state_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_state_cljs_test.cljs
@@ -312,37 +312,38 @@
           "no mount carries a `:before` opt — no diff annotation
            without a pre-image"))))
 
-;; ---- popup affordance (rf2-l4625) ---------------------------------------
+;; ---- popup affordance (rf2-7sdja) ---------------------------------------
 ;;
-;; The App-DB tab is the canonical cramped-in-side-panel inspection
-;; surface; every data-display mount carries `:popup-affordance? true`
-;; so the operator can pop the whole tree into the modal popup overlay.
-;; These tests assert the opt rides every mount the value-body produces.
+;; App-DB does NOT use `:popup-affordance?` (Mike's call 2026-05-26 from
+;; live testing). The side panel has plenty of horizontal room; the
+;; whole-tree inspector reads comfortably in place. These tests pin the
+;; absence of the opt so a stray re-introduction trips the gate.
 
-(deftest data-display-mounts-carry-popup-affordance-opt
-  (testing "rf2-l4625 — every `[dd/data-display ...]` mount the App-DB
-            panel produces carries `:popup-affordance? true` so the
-            operator can open the value in the popup overlay"
+(deftest data-display-mounts-omit-popup-affordance-opt
+  (testing "rf2-7sdja — no `[dd/data-display ...]` mount the App-DB
+            panel produces carries `:popup-affordance? true`; the App-
+            DB tree renders comfortably in-place and the affordance
+            would be unnecessary noise (Mike's live-testing call
+            2026-05-26)"
     (let [model  (h/current-state-sections
                    {:counter 2 :rf/route {:id :home}
                     :rf/machines {:auth {:state :idle}}})
           tree   (state/state-body model)
           mounts (find-data-display-mounts tree)]
       (is (seq mounts) "the panel mounts data-display widget instances")
-      (is (every? #(true? (:popup-affordance? (:opts %))) mounts)
-          "every mount opts in to the popup affordance"))))
+      (is (not-any? #(true? (:popup-affordance? (:opts %))) mounts)
+          "no mount opts in to the popup affordance"))))
 
-(deftest diff-mode-mounts-also-carry-popup-affordance-opt
-  (testing "rf2-l4625 — DIFF-mode mounts (when a pre-image is supplied)
-            ALSO carry the popup affordance opt; the operator can pop
-            either current-state OR diff trees"
+(deftest diff-mode-mounts-also-omit-popup-affordance-opt
+  (testing "rf2-7sdja — DIFF-mode mounts (when a pre-image is supplied)
+            ALSO omit the popup affordance opt"
     (let [model  (h/current-state-sections {:counter 2} {:counter 1})
           tree   (state/state-body model)
           mounts (find-data-display-mounts tree)
           diff-mts (filter #(contains? (:opts %) :before) mounts)]
       (is (seq diff-mts) "diff-mode mounts present")
-      (is (every? #(true? (:popup-affordance? (:opts %))) diff-mts)
-          "diff-mode mounts also opt in to the popup affordance"))))
+      (is (not-any? #(true? (:popup-affordance? (:opts %))) diff-mts)
+          "diff-mode mounts also omit the popup affordance"))))
 
 ;; ---- card chrome (rf2-63ie5) --------------------------------------------
 ;;

--- a/tools/xray/test/day8/re_frame2_xray/views/data_display_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/data_display_cljs_test.cljs
@@ -560,6 +560,15 @@
   (is (= 24 dd/triangle-min-target-px)
       "the public contract pin: 24px in both axes"))
 
+(deftest triangle-style-font-size-is-22px
+  (testing "rf2-4aiaq — triangle glyph font-size is 22px (operator-
+            preferred 22-24px band per Mike's live A/B 2026-05-26).
+            14px was hit-box-adequate but read as hairline against
+            the inspector chrome."
+    (is (= "22px" (:font-size dd/triangle-style))
+        "triangle glyph renders at 22px so the eye registers it as the
+         primary expand/collapse affordance, not a hairline accent")))
+
 (deftest collapsed-triangle-uses-shared-triangle-style
   ;; Force a default-collapsed render (large map at depth past
   ;; default-expanded-depth) and verify the ▸ toggle span carries

--- a/tools/xray/test/day8/re_frame2_xray/views/data_display_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/data_display_cljs_test.cljs
@@ -1297,3 +1297,78 @@
     (is (= false (get-in @(rf/subscribe [dd/expansion-slot]) [k :expanded?]))
         "third click inverts stored override → false")
     (rf/dispatch-sync [:rf.xray.data-display/reset-expansion])))
+
+;; ---- rf2-63ie5 — inspector card chrome on top-level mounts ---------------
+;;
+;; `:card? true` opts the widget's outer container into the inspector-card
+;; chrome (background, border, radius, padding, margin) so panels with
+;; multiple top-level mounts (App-DB's TOP + per-`:rf/*` areas) read as
+;; distinct cards. Default off preserves inline / nested behaviour.
+
+(defn- invoke-data-display
+  "Form-2 unrolling — run the outer fn, then the inner fn with the same
+  args to get the rendered hiccup."
+  [value opts]
+  (let [outer (dd/data-display value opts)]
+    (outer value opts)))
+
+(deftest card-opt-off-by-default
+  (testing "rf2-63ie5 — without `:card?` (or with `false`) the outer
+            container carries NO card chrome (background, border,
+            radius, padding, margin all absent)"
+    (let [h-default (invoke-data-display {:a 1} {:panel-id :rf.xray/app-db})
+          style-default (-> h-default second :style)
+          h-false   (invoke-data-display {:a 1}
+                                          {:panel-id :rf.xray/app-db
+                                           :card? false})
+          style-false (-> h-false second :style)]
+      (doseq [[label style] [["default" style-default] ["explicit false" style-false]]]
+        (is (nil? (:background-color style))
+            (str label ": no background"))
+        (is (nil? (:border style))
+            (str label ": no border"))
+        (is (nil? (:border-radius style))
+            (str label ": no border-radius"))
+        (is (nil? (:margin-bottom style))
+            (str label ": no margin-bottom"))))))
+
+(deftest card-opt-applies-card-chrome
+  (testing "rf2-63ie5 — `:card? true` adds background/border/radius/
+            padding/margin to the outer container so the mount reads
+            as a distinct inspector card"
+    (let [h (invoke-data-display {:a 1} {:panel-id :rf.xray/app-db
+                                          :card? true})
+          style (-> h second :style)]
+      (is (= (:bg-1 tokens) (:background-color style))
+          "background reads `:bg-1` (theme-aware)")
+      (is (= (str "1px solid " (:border-default tokens)) (:border style))
+          "1px border in `:border-default` (theme-aware)")
+      (is (= "8px" (:border-radius style)) "radius 8px")
+      (is (= "8px 10px" (:padding style)) "padding 8px 10px")
+      (is (= "8px" (:margin-bottom style))
+          "margin-bottom 8px gaps adjacent cards"))))
+
+(deftest card-opt-carries-data-attr
+  (testing "rf2-63ie5 — the outer container publishes `:data-rf-card`
+            when card chrome is on; absent when off"
+    (let [h-on  (invoke-data-display {:a 1}
+                                      {:panel-id :rf.xray/app-db :card? true})
+          h-off (invoke-data-display {:a 1} {:panel-id :rf.xray/app-db})]
+      (is (= "1" (:data-rf-card (second h-on)))
+          "card-on publishes :data-rf-card=1 for testbed assertion")
+      (is (nil? (:data-rf-card (second h-off)))
+          "card-off omits the attribute"))))
+
+(deftest card-opt-theme-aware-via-tokens
+  (testing "rf2-63ie5 — the card chrome reads from the live `tokens`
+            map (a CSS-variable shim per `theme/tokens.cljc`) so both
+            light + dark themes resolve at paint time without a re-
+            render. This test pins the inline-style values to the
+            same token-keyed map the rest of the widget consumes."
+    (let [h (invoke-data-display {:a 1} {:panel-id :rf.xray/app-db
+                                          :card? true})
+          style (-> h second :style)]
+      (is (= (:bg-1 tokens) (:background-color style))
+          "background reads through `:bg-1` (CSS-var or hex per theme)")
+      (is (= (str "1px solid " (:border-default tokens)) (:border style))
+          "border reads through `:border-default` (CSS-var or hex per theme)"))))

--- a/tools/xray/test/day8/re_frame2_xray/views/data_display_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/data_display_cljs_test.cljs
@@ -1359,6 +1359,103 @@
       (is (nil? (:data-rf-card (second h-off)))
           "card-off omits the attribute"))))
 
+;; ---- rf2-726ol — map column alignment (triangle / line / keys / close) --
+;;
+;; The map body's left padding + margin position the vertical guide line
+;; at the triangle's visual centre (~16px from the row's left edge at
+;; the 22px glyph metric — rf2-4aiaq). Keys sit 6px past the line. The
+;; closing brace sits at the same `padding-left 16px` so the triangle /
+;; line / keys / closing-brace converge on one column structure.
+
+(defn- find-body-divs
+  "Return every body-div the renderer emits (every node whose
+  `:data-rf-body-layout` is non-nil)."
+  [tree]
+  (filter (fn [node]
+            (and (vector? node)
+                 (map? (second node))
+                 (some? (:data-rf-body-layout (second node)))))
+          (walk-hiccup tree)))
+
+(defn- find-close-divs
+  "Return every closing-bracket div (cells with `data-rf-cell \"close\"`)."
+  [tree]
+  (filter (fn [node]
+            (and (vector? node)
+                 (map? (second node))
+                 (= "close" (:data-rf-cell (second node)))))
+          (walk-hiccup tree)))
+
+(deftest map-body-guide-line-at-triangle-center
+  (testing "rf2-726ol — the body div's `margin-left 16px` + `border-left
+            1px` puts the vertical guide line at x=16px from the row's
+            left edge, which is approximately the centre of the 22px
+            triangle box (~31-34px wide, centre at ~16px)"
+    (let [v   {:counter 1 :async nil :machine-ui {:open? true}}
+          k0  (dd/expansion-key :test "m" [])
+          h   (dd/render-node {:value v
+                               :panel-id :test :mount-id "m"
+                               :path [] :depth 0
+                               :expansion-map {k0 {:expanded? true}}
+                               :opts {:default-expanded-depth 0}})
+          bodies (find-body-divs h)]
+      (is (seq bodies) "expanded map renders body div(s)")
+      (doseq [body bodies]
+        (let [style (:style (second body))]
+          (is (= "16px" (:margin-left style))
+              "body's margin-left puts the 1px border at x=16 (= triangle centre)")
+          (is (= "6px" (:padding-left style))
+              "keys sit 6px past the line for a small breath"))))))
+
+(deftest closing-brace-aligns-with-guide-line
+  (testing "rf2-726ol — the closing-bracket div sits at `padding-left
+            16px`, the same x-position as the vertical guide line, so
+            the bracket pair `▾ { … }` reads as a coherent vertical
+            column at every nesting depth"
+    (let [;; 4+ keys in each map defeats inline-fit (which requires
+          ;; ≤3 children) so both outer + inner expand-render.
+          v   {:a 1 :b 2 :c 3 :d 4
+               :nested {:x 1 :y 2 :z 3 :w 4}}
+          k0  (dd/expansion-key :test "m" [])
+          k1  (dd/expansion-key :test "m" [:nested])
+          h   (dd/render-node
+                {:value v
+                 :panel-id :test :mount-id "m"
+                 :path [] :depth 0
+                 :expansion-map {k0 {:expanded? true}
+                                 k1 {:expanded? true}}
+                 :opts {:default-expanded-depth 0}})
+          closes (find-close-divs h)]
+      (is (= 2 (count closes))
+          "outer + inner expanded maps each contribute a close-brace cell")
+      (doseq [c closes]
+        (let [style (:style (second c))]
+          (is (= "16px" (:padding-left style))
+              "close-brace `padding-left 16px` matches the guide-line x"))))))
+
+(deftest block-body-shares-alignment-with-grid-body
+  (testing "rf2-726ol — sequential (vector / list / set) bodies use the
+            same `margin-left 16px` + `padding-left 6px` as map bodies
+            so a vector's guide line / first item / closing bracket all
+            converge on the same column structure"
+    (let [;; 4 elements + a nested container defeats inline-fit so the
+          ;; block body actually renders.
+          v   [1 2 3 4 {:x :y}]
+          k0  (dd/expansion-key :test "m" [])
+          h   (dd/render-node {:value v
+                               :panel-id :test :mount-id "m"
+                               :path [] :depth 0
+                               :expansion-map {k0 {:expanded? true}}
+                               :opts {:default-expanded-depth 0}})
+          bodies (find-body-divs h)
+          block-bodies (filter #(= "block" (:data-rf-body-layout (second %)))
+                               bodies)]
+      (is (seq block-bodies)
+          "vector container emits a block-layout body when expanded")
+      (let [style (:style (second (first block-bodies)))]
+        (is (= "16px" (:margin-left style)) "same 16px margin as grid body")
+        (is (= "6px"  (:padding-left style)) "same 6px padding as grid body")))))
+
 (deftest card-opt-theme-aware-via-tokens
   (testing "rf2-63ie5 — the card chrome reads from the live `tokens`
             map (a CSS-variable shim per `theme/tokens.cljc`) so both

--- a/tools/xray/test/day8/re_frame2_xray/views/data_display_popup_wireup_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/data_display_popup_wireup_cljs_test.cljs
@@ -79,7 +79,8 @@
 
 (deftest popup-affordance-opt-in-renders-button
   (testing "rf2-l4625 — `[dd/data-display value {:popup-affordance? true}]`
-            renders a top-right ⊕ button"
+            renders a top-right ↗ icon button (rf2-7sdja — glyph was
+            ⊕; ↗ reads as 'open in new pane')"
     (let [h (invoke-data-display
               {:cart [1 2 3]}
               {:panel-id :rf.xray/app-db :popup-affordance? true})
@@ -89,7 +90,9 @@
       (is (= "Open in popup" (:aria-label (second btn)))
           "button carries the canonical aria-label")
       (is (fn? (:on-click (second btn)))
-          "button carries an on-click handler"))))
+          "button carries an on-click handler")
+      (is (= "↗" (last btn))
+          "rf2-7sdja — glyph is ↗ (north-east arrow), not ⊕"))))
 
 (deftest popup-affordance-default-off
   (testing "rf2-l4625 — without `:popup-affordance?` (or with `false`)
@@ -143,50 +146,68 @@
 ;; widget-level affordance — on-click dispatch contract via stub
 ;; =========================================================================
 
-(deftest popup-affordance-button-onclick-dispatches-canonical-event
-  (testing "rf2-l4625 — clicking the affordance dispatches
+(defn- with-rf-dispatch-spy
+  "Drive a click against a stubbed `rf/dispatch*` (the fn-form the
+  `dispatch` macro expands to) so the test can inspect the dispatched
+  event vector + opts WITHOUT spinning up the router. Returns
+  `{:event ... :opts ...}` captured at click. Per rf2-7sdja — the
+  post-fix `popup-affordance-button` calls `rf/dispatch` directly with
+  `{:frame :rf/xray}` opts (not the lexically-captured dispatch-fn)."
+  [on-click]
+  (let [captured (atom nil)]
+    (with-redefs [rf/dispatch* (fn
+                                 ([ev]      (reset! captured {:event ev :opts nil}))
+                                 ([ev opts] (reset! captured {:event ev :opts opts})))]
+      (on-click nil))
+    @captured))
+
+(deftest popup-affordance-button-onclick-dispatches-against-xray-frame
+  (testing "rf2-7sdja — clicking the affordance dispatches
             `[:rf.xray.data-display-popup/open popup-mount-id payload]`
-            through the supplied dispatch-fn"
-    (let [captured (atom nil)
-          stub-dispatch (fn [event-v] (reset! captured event-v))
-          btn (dd/popup-affordance-button
-                stub-dispatch
+            against `:rf/xray` EXPLICITLY (popup state is Xray-global,
+            not per-frame — pinned via `{:frame :rf/xray}` opts)"
+    (let [btn (dd/popup-affordance-button
+                ;; `dispatch-fn` parameter is a no-op post rf2-7sdja —
+                ;; pass nil to make the new contract obvious.
+                nil
                 "ddp-abc"
                 {:cart [1 2 3]}
                 {:panel-id :rf.xray/app-db :default-expanded-depth 3
                  :popup-affordance? true})
-          on-click (:on-click (second btn))]
-      ;; Simulate click — pass nil event so the handler skips the
-      ;; preventDefault/stopPropagation guarded by `(when e …)`.
-      (on-click nil)
-      (let [[event-id mount-id payload] @captured]
-        (is (= :rf.xray.data-display-popup/open event-id)
-            "canonical event id")
-        (is (= "ddp-abc" mount-id)
-            "popup-mount-id flows through as second positional arg")
-        (is (= {:cart [1 2 3]} (:value payload))
-            "value flows through as `:value`")
-        (is (false? (:popup-affordance? (:opts payload)))
-            "the popup's embedded data-display does NOT re-enable the
-             affordance (no recursion)")
-        (is (= :rf.xray/app-db (:panel-id (:opts payload)))
-            "other opts (`:panel-id`, `:default-expanded-depth`) survive")
-        (is (= 3 (:default-expanded-depth (:opts payload))))))))
+          on-click (:on-click (second btn))
+          {:keys [event opts]} (with-rf-dispatch-spy on-click)
+          [event-id mount-id payload] event]
+      (is (= :rf.xray.data-display-popup/open event-id)
+          "canonical event id")
+      (is (= "ddp-abc" mount-id)
+          "popup-mount-id flows through as second positional arg")
+      (is (= {:cart [1 2 3]} (:value payload))
+          "value flows through as `:value`")
+      (is (false? (:popup-affordance? (:opts payload)))
+          "the popup's embedded data-display does NOT re-enable the
+           affordance (no recursion)")
+      (is (= :rf.xray/app-db (:panel-id (:opts payload)))
+          "other opts (`:panel-id`, `:default-expanded-depth`) survive")
+      (is (= 3 (:default-expanded-depth (:opts payload))))
+      (is (= :rf/xray (:frame opts))
+          "rf2-7sdja — popup dispatch pins frame to `:rf/xray`
+           explicitly so the popup-stack-view (which only subscribes
+           against `:rf/xray`) sees the write regardless of which
+           frame the widget is mounted under"))))
 
 (deftest popup-affordance-button-onclick-preserves-nil-opts
   (testing "rf2-l4625 — when the caller supplies no opts, the affordance
             still produces a sane payload (just `:popup-affordance? false`
             in the popup's downstream opts map)"
-    (let [captured (atom nil)
-          stub-dispatch (fn [event-v] (reset! captured event-v))
-          btn (dd/popup-affordance-button stub-dispatch "ddp-x"
-                                          {:k :v} nil)
-          on-click (:on-click (second btn))]
-      (on-click nil)
-      (let [payload (nth @captured 2)]
-        (is (= {:k :v} (:value payload)))
-        (is (false? (:popup-affordance? (:opts payload)))
-            "even with nil opts the recursion guard fires")))))
+    (let [btn (dd/popup-affordance-button nil "ddp-x" {:k :v} nil)
+          on-click (:on-click (second btn))
+          {:keys [event opts]} (with-rf-dispatch-spy on-click)
+          payload (nth event 2)]
+      (is (= {:k :v} (:value payload)))
+      (is (false? (:popup-affordance? (:opts payload)))
+          "even with nil opts the recursion guard fires")
+      (is (= :rf/xray (:frame opts))
+          "rf2-7sdja — `:rf/xray` frame still pinned even with nil opts"))))
 
 ;; =========================================================================
 ;; shell mount — `data-display-popup-stack` view


### PR DESCRIPTION
Follow-on cluster of 4 P1/P2 bugs Mike surfaced from live testing after #2170 merged. Each commit addresses one bead; all four touch the same widget surface (`tools/xray/src/day8/re_frame2_xray/views/data_display.cljs` + adjacent CSS/tokens + the App-DB consumer) so sequencing in one PR avoids intra-worker conflict on the shared file.

All Mike-filed from pair-debug session 2026-05-26.

## rf2-4aiaq — triangle glyph 14px → 22px (P2 BUG)

**Symptom.** Post-rf2-tzvk9 the triangle hit-box cleared 24×24 but the glyph itself stayed at 14px — it read as a hairline against the inspector chrome. Mike's live A/B (2026-05-26) found 22-24px "much more clickable, feels right".

**Fix.** Bump `triangle-style :font-size` 14px → 22px in `data_display.cljs`. Hit-box stays ≥24px (min-width/min-height + 4px 8px padding). Wrapping inline-flex spans still align via `:align-items center` so the bracket / scalar baseline stays centred against the larger triangle.

**Test.** Pin `(:font-size dd/triangle-style)` to `"22px"` so future tuning goes through a deliberate spec change.

## rf2-63ie5 — inspector card chrome on top-level mounts (P2)

**Symptom.** App-DB renders the user-domain TOP + every reserved `:rf/*` area as transparent top-level data-display mounts; visually they blend into one continuous block with no visual separation.

**Decision.** Explicit `:card?` opt (default `false`) on the widget. Mirrors the existing `:popup-affordance?` / `:site-id` opt-in pattern — pre-alpha posture favours explicit-over-magic.

**Fix.** When `:card? true`, the widget`s outer container picks up `:background :bg-1`, `:border 1px :border-default`, `:border-radius 8px`, `:padding 8px 10px`, `:margin-bottom 8px`. Token-driven so light + dark themes resolve at paint time. Outer publishes `:data-rf-card "1"` for testbed assertion. Wired into App-DB`s browse + diff mounts. Other panels (Machines, Reactive, Trace) already wrap each mount in their own parent card chrome; skipped per the bead`s "skip where the panel only renders one" guidance.

**Tests.** Widget-level: card opt applies/omits chrome, publishes data-attr, tokens resolve through the theme map. Consumer-level (App-DB): every browse-mode and diff-mode mount carries `:card? true`.

## rf2-726ol — map column alignment: triangle/line/keys/brace (P2 BUG)

**Symptom.** The expanded map body had three misalignment issues that made the structure hard to follow: vertical guide line was offset from the triangle that opens it (line at x=5, triangle centre at ~16px with the rf2-4aiaq 22px glyph); map keys started further right than the line; closing `}` sat at the outer levels column-0 with no column reference.

**Fix.** Rebuild the body div`s left padding around the triangle`s centre:

- `margin-left 16px` (was 5px) puts the 1px border-left at x=16, approximately the centre of the 22px triangle box (~31-34px wide with the rf2-4aiaq glyph + 4px 8px padding).
- `padding-left 6px` (was 14px) gives the keys a small breath past the line.
- The closing-bracket div picks up `padding-left 16px` (had none before) so the close-brace x matches the guide line. The close div also publishes `data-rf-cell "close"` for testbed assertion.

Applied uniformly to the labelled-key grid body, the sequential block body, AND the protocol-node body so every container depth follows the same rule. Composes with rf2-4aiaq + rf2-63ie5.

**Tests.** Body`s `margin-left 16px` + `padding-left 6px` pinned; close-brace `padding-left 16px` pinned at both outer and nested depths; sequential block body shares the same metrics.

## rf2-7sdja — popup-affordance fix + drop from App-DB + ⊕→↗ glyph (P1 BUG)

**Symptom.** Mike reproduced live that clicking the ⊕ popup-affordance on App-DBs data-display mounts did nothing. Probe isolated the bug to the dispatch path — invoking the on-click did not land the dispatch in any frame`s app-db, but the popup machinery itself worked end-to-end when driven by an explicit `dispatch-sync` from `eval-cljs`.

**Root cause (documented in the popup-affordance-button docstring).** Asymmetry between two dispatch-state shapes in the same widget:

- **Expansion state is per-frame** — the data-display widget can be mounted in any frame; the toggle dispatch must land in the SURROUNDING frame`s app-db so the expansion-slot subscription (which runs in the same frame) sees the write. The lexically-captured frame-aware dispatcher is the right tool here.
- **Popup state is Xray-global** — the popup-stack-view lives inside `[rf/frame-provider {:frame :rf/xray}]` in shell.cljs and subscribes ONLY against `:rf/xray`. If the popup-open dispatch leaks to any other frame, the mutation lands on the wrong app-db and the stack-view never renders.

The previous code dispatched the popup-open event through the same lexically-captured dispatcher the toggle uses — works WHEN the widget mounts under `:rf/xray` (the captured frame matches), fails silently otherwise. The captured-frame path is the wrong abstraction for popup state regardless of which frame it happens to be at any given moment.

**Fix (three parts).**

1. **Pin popup dispatch to `:rf/xray` explicitly.** The on-click now calls `(rf/dispatch event {:frame :rf/xray})` directly, matching the established envelope pattern (`settings/view.cljs`, `app_db_segment_inspector.cljs`). The `dispatch-fn` parameter on `popup-affordance-button` is retained as a back-compat no-op for tests; production callers pass `nil`.
2. **Drop the affordance from App-DB.** Per Mikes call: the side panel has plenty of horizontal room; the whole-tree inspector renders comfortably in-place. The earlier framing of App-DB as "the canonical cramped-in-side-panel case" was wrong. Other panels (Machines, Reactive, Trace) keep the affordance where the inline widget is genuinely cramped.
3. **Glyph ⊕ → ↗.** The north-east arrow reads as "open in new pane / navigate outward" — matches the popups window-manager semantics better than the circled plus (which reads as "expand" / "add"). `aria-label` + `title` unchanged.

**Tests.** On-click dispatch tests rewritten to stub `rf/dispatch*` (the fn the macro expands to) and assert both the canonical event vector AND the `{:frame :rf/xray}` opts. Glyph-↗ assertion added. App-DB consumer tests flipped from `(every? popup-affordance?)` to `(not-any?)` so the drop is regression-pinned. `spec/021` §10.0.1 + §10.0.7.2 updated to document ↗, the explicit `:rf/xray` dispatch pattern, the App-DB drop, plus added `:card?` + `:popup-affordance?` + `:site-id` opts to the §10.0.1 inventory (they were live in code, not in spec).

## Gates

- `npm run test:cljs` — 4564 tests / 14562 assertions / 0 failures
- `clojure -M:test` (xray JVM) — 859 tests / 3122 assertions / 0 failures
- `npm run test:browser` — 124 tests / 346 assertions / 0 failures
- `npm run test:xray-feature-gate` — 13 scenarios / 0 failures
- `npm run test:bundle-isolation` — PASS (16 entries / 33 sentinels / 3 budgets)
- `clj-kondo --lint tools/xray/src tools/xray/test` — 0 errors

## References

- Bead trail: rf2-4aiaq · rf2-63ie5 · rf2-726ol · rf2-7sdja
- Live pair-debug session: 2026-05-26
- Touched files: `tools/xray/src/day8/re_frame2_xray/views/data_display.cljs`, `tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs`, `tools/xray/spec/021-Dynamic-Panel-Designs.md`, plus the matching `tools/xray/test/...` files.