### PR TITLE
refactor(xray): data-display width-aware expansion + diff row chrome + rename to edn-inspector (rf2-kbdk8 + rf2-awqts + rf2-h4fce)

### DIFF
--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -178,8 +178,8 @@
                 [com.pitch/uix.dom  "1.4.4"]
                 [lilactown/helix   "0.2.2"]
                 ;; rf2-oqa60 phase 1 — binaryage/devtools dep dropped.
-                ;; Xray's first-class data-display widget
-                ;; (`views/data-display`) replaces the cljs-devtools-
+                ;; Xray's first-class edn-inspector widget
+                ;; (`views/edn-inspector`) replaces the cljs-devtools-
                 ;; backed value renderer with a roll-your-own CLJS
                 ;; tree walker; the impedance-mismatch bug class
                 ;; (rf2-dw8n7, rf2-oswhk) goes away with the dep.

--- a/skills/re-frame2-xray/README.md
+++ b/skills/re-frame2-xray/README.md
@@ -20,7 +20,7 @@ Xray is the **human-facing** panel; for an AI agent surface against the running 
 - `SKILL.md` — the skill itself
 - `references/launch-modes.md` — full launch-mode decision tree (preload vs `init!`, suppress-auto-open, `:rf.xray/layout-host-selector`, host-CSS-variable resize, pop-out lifecycle, wired hotkeys)
 - `references/panels.md` — the full tab tour in depth (7 Dynamic event-spine tabs + 5 Static registry-browse tabs, deeper "open it when…" guidance)
-- `references/shared-components.md` — the components every L4 panel reuses (`data_display/render`, `film_strip/header`, `focus_resolver`) + the tab-icon / L2-badge / cross-panel-arrow glyph reference
+- `references/shared-components.md` — the components every L4 panel reuses (`edn_inspector/render`, `film_strip/header`, `focus_resolver`) + the tab-icon / L2-badge / cross-panel-arrow glyph reference
 - `evals/evals.json` — trigger-eval fixtures (should-trigger + should-not-trigger entries, per skill-creator's description-optimisation contract)
 - `.claude-plugin/plugin.json` — Claude Code Plugin packaging metadata
 - `package.json` — npm packaging metadata (skill is also distributable as an Agent Skill)

--- a/skills/re-frame2-xray/references/panels.md
+++ b/skills/re-frame2-xray/references/panels.md
@@ -106,7 +106,7 @@ Two-zone layout (§021 §4.2):
 - **DIFF zone** — changed paths for the focused epoch (`← changed`,
  `← changed from <prior>`, `← added`). Narrow, dense, scannable.
 - **STATE zone** — the full db at end of epoch, rendered via the
- shared lazy-tree data-display (depth-3-collapsed default per §021
+ shared lazy-tree edn-inspector (depth-3-collapsed default per §021
  §10.4) with diff annotations inline.
 
 **Downstream-subs hover popover** (§021 §4.4) — hover any changed path
@@ -293,7 +293,7 @@ Per-epoch errors + warnings + schema violations + hydration mismatches +
 perf-budget overruns + app console errors/warns, unified.
 **Focused-epoch scoped** (§021 §8.1). Each issue renders as a 4-6 row
 block (severity · op-key · handler / schema · message · path / ex-data)
-with the ex-data laid out via the shared data-display renderer at
+with the ex-data laid out via the shared edn-inspector renderer at
 depth-2-expanded.
 
 **Head-fallback contract** — when the L2 spine is at head (no
@@ -357,7 +357,7 @@ than a single dispatch.
 
 ## Shared components + iconography
 
-The three components every L4 panel reuses (`data_display/render`,
+The three components every L4 panel reuses (`edn_inspector/render`,
 `film_strip/header`, `focus_resolver`) and the full tab-icon / L2-badge /
 cross-panel-arrow glyph reference live in
 [`shared-components.md`](shared-components.md).

--- a/skills/re-frame2-xray/references/shared-components.md
+++ b/skills/re-frame2-xray/references/shared-components.md
@@ -8,11 +8,11 @@ each panel's perspective.
 
 Three components are consumed by every (or nearly every) L4 panel.
 
-### `data_display/render`
+### `edn_inspector/render`
 
 The single canonical data renderer — lazy collapsible tree + inline
 diff highlighting + keyword accent + clickable paths. Lives at
-[`tools/xray/src/day8/re_frame2_xray/data_display/render.cljs`](../../../tools/xray/src/day8/re_frame2_xray/data_display/render.cljs)
+[`tools/xray/src/day8/re_frame2_xray/edn_inspector/render.cljs`](../../../tools/xray/src/day8/re_frame2_xray/edn_inspector/render.cljs)
 per §021 §10. Every panel that shows data — app-db, Event coeffects /
 returned effects, Views sub values, Issues `ex-data` — goes through this
 renderer (§021 §10.6 — binding).
@@ -29,7 +29,7 @@ force ancestor chain open · per-panel `:default-depth` override (app-db
 defaults depth-3-collapsed; Event payload defaults depth-2-expanded).
 
 Operator expansion state persists in app-db
-(`:rf.xray.data-display/expansion {<path>}`) per epoch + path.
+(`:rf.xray.edn-inspector/expansion {<path>}`) per epoch + path.
 
 ### `film_strip/header`
 

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/theme/tokens.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/theme/tokens.cljc
@@ -135,6 +135,19 @@
    :syntax-punctuation "#abb2bf"
 
    :red-deep       "#a83a3a"
+
+   ;; diff row chrome (rf2-awqts) — mirrored from Xray's dark-palette
+   ;; so the key-set drift gate stays green. The chart doesn't read
+   ;; these tokens directly (diff signalling is Xray-specific), but
+   ;; mirroring keeps the two palette surfaces symmetric.
+   :diff-gutter          "#5fbcb6"
+   :diff-added-wash      "#3fb9501a"
+   :diff-modified-wash   "#d299221f"
+   :diff-removed-wash    "#f851491a"
+   :diff-added-stripe    "#3fb950"
+   :diff-modified-stripe "#d29922"
+   :diff-removed-stripe  "#f85149"
+
    :white          "#ffffff"})
 
 (def light-palette
@@ -209,6 +222,17 @@
    :syntax-punctuation "#383a42"
 
    :red-deep       "#9A3030"
+
+   ;; diff row chrome (rf2-awqts) — mirrored from Xray's light-palette
+   ;; per the dark-palette pattern above.
+   :diff-gutter          "#178f86"
+   :diff-added-wash      "#1a7f371a"
+   :diff-modified-wash   "#9a67001f"
+   :diff-removed-wash    "#c844441a"
+   :diff-added-stripe    "#1a7f37"
+   :diff-modified-stripe "#9a6700"
+   :diff-removed-stripe  "#cf222e"
+
    :white          "#ffffff"})
 
 (def palettes

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/theme/tokens.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/theme/tokens.cljc
@@ -121,7 +121,7 @@
    ;; syntax-highlighter palette (rf2-79ojx · One Dark / Atom One Dark)
    ;; mirrored from Xray's dark-palette so the `xray-and-machines-viz-
    ;; dark-palettes-match-key-set` drift gate stays green. Tokens are
-   ;; Xray-source-highlighter + data-display surface; the chart itself
+   ;; Xray-source-highlighter + edn-inspector surface; the chart itself
    ;; does not read them. See Xray's `tokens.cljc` for the palette
    ;; rationale (CLJS-editor-syntax-highlight scheme — keyword magenta /
    ;; string green / number orange / boolean gold / nil grey).

--- a/tools/xray/deps.edn
+++ b/tools/xray/deps.edn
@@ -132,7 +132,7 @@
          day8/reagent-slim {:local/root "../../implementation/adapters/reagent-slim"}
 
          ;; rf2-oqa60 phase 1 — binaryage/devtools dep dropped. The
-         ;; first-class `views/data-display` widget replaces the
+         ;; first-class `views/edn-inspector` widget replaces the
          ;; cljs-devtools-backed renderer with a roll-your-own CLJS
          ;; tree walker. The impedance-mismatch bug class (rf2-dw8n7,
          ;; rf2-oswhk) goes away with the dep. The bundle-isolation

--- a/tools/xray/spec/003-Machine-Inspector.md
+++ b/tools/xray/spec/003-Machine-Inspector.md
@@ -89,11 +89,11 @@ below; the three render states are:
     - Actions list (when the trace carried action-ran events).
     - **Snapshot drill-in** (rf2-lxvn6 · phase 4 of rf2-oqa60). The
       BEFORE / AFTER snapshot maps (`{:state X :data Y}`) for the
-      focused transition render via the first-class data-display
+      focused transition render via the first-class edn-inspector
       widget. Per-machine `:panel-id` qualifier keeps two machines'
       expansion state independent; the `:before` / `:after` phase
       suffix scopes the two sibling mounts on the same machine. See
-      [`021-Dynamic-Panel-Designs.md` §10](021-Dynamic-Panel-Designs.md#10-shared-data-display-renderer)
+      [`021-Dynamic-Panel-Designs.md` §10](021-Dynamic-Panel-Designs.md#10-shared-edn-inspector-renderer)
       for the widget contract — distinct per-type colours, distinct
       brackets per collection kind, inline preview of collapsed
       collections, click-to-toggle, per-call-site isolation. The
@@ -1444,8 +1444,8 @@ per-action attribution.
 **Phase 4 — snapshot drill-in (rf2-lxvn6 · landed).** The
 visibility-only half of M.10 lands first: the BEFORE / AFTER snapshot
 maps for the focused transition render as collapsible trees via the
-first-class data-display widget (see
-[`021-Dynamic-Panel-Designs.md` §10](021-Dynamic-Panel-Designs.md#10-shared-data-display-renderer)).
+first-class edn-inspector widget (see
+[`021-Dynamic-Panel-Designs.md` §10](021-Dynamic-Panel-Designs.md#10-shared-edn-inspector-renderer)).
 The operator can drill into `:data` either side of the transition
 without leaving the Machines tab. Phase 5 (D5=a, rf2-oqa60 phase 5)
 adds the diff overlay on top of the same widget for the

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -6,7 +6,7 @@ locked Static/Dynamic linguistic pairing per the polished super-prompt.
 "Dynamic" = what's happening across epochs; "Static" = what's registered
 before any event fires.)
 Co-drafted by Mike + mayor; this doc is the implementer's reference
-for the **per-panel content layout**, **shared data-display renderer**,
+for the **per-panel content layout**, **shared edn-inspector renderer**,
 **locked decisions**, and **substrate gaps** that the redesign implies.
 
 Canonical foundation: `ai/prompts/xray-interface-adjustments.md`
@@ -496,7 +496,7 @@ detail lives in Event panel step 4.
 Below the graph, three list sections complete the panel:
 
 - **SUB VALUES** (rf2-e46qs phase 3 of rf2-oqa60) — one row per RUN sub this cascade carrying
-  its current value through the first-class data-display widget (`[dd/data-display value opts]`,
+  its current value through the first-class edn-inspector widget (`[ei/edn-inspector value opts]`,
   §10). Each row uses a stable per-sub `:panel-id` qualifier under `:rf.xray.reactive-sub-value`
   so two sub-row expansions are independent. Subs whose value carries no `:value` slot (privacy
   redaction / pre-attribution) render a muted no-value placeholder rather than mounting the
@@ -795,7 +795,7 @@ that Event + Reactive summarise. NOT aggregate across epochs (per §1.2).
 **Density note** (per §0). Each op renders as a single mono row in **plain language**
 (`relative-timestamp · op-family colour-band · readable description · duration`) — so a
 30-op epoch reads as a 30-line scroll. The raw `:operation` + tag-map is **expandable detail**
-via click, reusing the shared data-display renderer's `browse` (cljs-devtools) variant (§10),
+via click, reusing the shared edn-inspector renderer's `browse` (cljs-devtools) variant (§10),
 not the default line. Lines-per-screen target ~30-60.
 
 ### §5.2 Scope + layout (reworked — rf2-o6yqq + rf2-td380 + rf2-gkczt)
@@ -863,7 +863,7 @@ with the focused cascade's lifecycle-status colour (settled-success /
 errored / stale / paused / in-flight), driven by the same
 `event-status-colour` fn the L2 rows + Event header dot consume — one
 lifecycle vocabulary across the whole devtool. Expanded payload uses the
-data-display renderer's `browse` variant (§10).
+edn-inspector renderer's `browse` variant (§10).
 
 **Empty states** (focus-resolver statuses + the empty-epoch case):
 `:no-events` ("No events.") · `:no-focus` ("No focused event.",
@@ -1247,7 +1247,7 @@ keeps the dogfood in Story.
 
 ---
 
-## §10 Shared data-display renderer
+## §10 Shared edn-inspector renderer
 
 The renderer is **ONE canonical component used everywhere data appears**
 — App-db's huge nested map, the Event panel's coeffects slice + returned
@@ -1255,36 +1255,36 @@ effects, the View panel's sub values, Trace ops' expanded payloads,
 Issues `ex-data`. Operator learns one interaction pattern; applies it
 everywhere.
 
-### §10.0 First-class data-display widget (rf2-oqa60 phase 1)
+### §10.0 First-class edn-inspector widget (rf2-oqa60 phase 1)
 
 Per Mike-direction 2026-05-25 (rf2-sndui ratification `b a a a a a a a`)
-the renderer is the **first-class data-display widget** at
-`day8.re-frame2-xray.views.data-display`. It is a roll-your-own
+the renderer is the **first-class edn-inspector widget** at
+`day8.re-frame2-xray.views.edn-inspector`. It is a roll-your-own
 CLJS-value-to-hiccup tree walker (~900 LoC after phase 5) that
 owns the WHOLE contract — **browse + diff + mini** — as a single
 source of truth: classifies every CLJS type natively, owns its own
 sticky-expansion app-db slot, ships first-class chrome for the
 spec/015 sentinels, and renders inline diff annotations when a
 `:before` opt is supplied. The cljs-devtools dep is dropped
-(rf2-oqa60); the legacy `data-display.render` engine +
+(rf2-oqa60); the legacy `edn-inspector.render` engine +
 `theme.data-inspector` chrome ns are deleted in phase 5 (rf2-q3dzw).
 The EDN-widget facade at `views.edn-widget.widget` is retained as a
 thin delegate so existing call sites compile; new call sites should
-reach for `[data-display value opts]` directly.
+reach for `[edn-inspector value opts]` directly.
 
 #### §10.0.1 Public API
 
 ```clj
-[data-display value]                         ;; browse mode
-[data-display value opts]                    ;; browse / diff per opts
-[data-display-diff before after]             ;; diff convenience
-[data-display-diff before after opts]
+[edn-inspector value]                         ;; browse mode
+[edn-inspector value opts]                    ;; browse / diff per opts
+[edn-inspector-diff before after]             ;; diff convenience
+[edn-inspector-diff before after opts]
 ```
 
 `opts` keys (all optional):
 
 - `:panel-id` — distinguishes per-panel expansion state. Defaults
-  `:rf.xray.data-display/anon`.
+  `:rf.xray.edn-inspector/anon`.
 - `:default-expanded-depth` — first-render expansion depth before
   operator clicks. Defaults `2`.
 - `:max-inline-width` — character budget before forced-vertical
@@ -1322,7 +1322,7 @@ reach for `[data-display value opts]` directly.
 The widget is a **Reagent form-2 component** — the outer fn captures
 a stable `mount-id` (auto-generated UUID, per D4=a — no public
 `render-id` arg) in closure; the inner fn subscribes to the
-expansion slot and renders. Two `[data-display v opts]` mounts in
+expansion slot and renders. Two `[edn-inspector v opts]` mounts in
 the same panel each receive a distinct `mount-id`, so their
 expansion state is independent.
 
@@ -1338,7 +1338,7 @@ sentinel routing in; the legacy `inspect-inline` is dropped):
 
 Five properties the unit gate pins so a future renderer change can't
 re-break what phase 1 lands. All five are tested in
-`tools/xray/test/day8/re_frame2_xray/views/data_display_cljs_test.cljs`.
+`tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs`.
 
 1. **Per-type colours via CSS variables.** Each leaf type maps to a
    distinct token (keyword `:accent`, string `:syntax-string`,
@@ -1363,7 +1363,7 @@ re-break what phase 1 lands. All five are tested in
 4. **Click-to-toggle actually toggles.** Each node carries a stable
    `data-testid` derived from `[panel-id mount-id path]`; the `▸`
    span's `:on-click` dispatches
-   `[:rf.xray.data-display/toggle-node panel-id mount-id path rendered-expanded?]`
+   `[:rf.xray.edn-inspector/toggle-node panel-id mount-id path rendered-expanded?]`
    via the **lexically-injected frame-aware dispatcher** — the widget
    is `reg-view`-registered (per rf2-y59tb) so its body's `dispatch`
    closure inherits the surrounding `frame-provider` from React
@@ -1382,8 +1382,8 @@ re-break what phase 1 lands. All five are tested in
    `:expanded? true` repeats the rendered state — rf2-y59tb Bug B).
 
    The reducer writes `{:expanded? bool}` into the per-node entry in
-   `:rf.xray.data-display/expansion`. Next render reads the slot via
-   `:rf.xray.data-display/expansion` subscription, the path's
+   `:rf.xray.edn-inspector/expansion`. Next render reads the slot via
+   `:rf.xray.edn-inspector/expansion` subscription, the path's
    entry exists, the renderer picks `:expanded?` over the default
    heuristic, the triangle swaps `▸` → `▾` (or vice versa), and the
    body becomes visible (or hidden). This is the property rf2-dw8n7 /
@@ -1391,7 +1391,7 @@ re-break what phase 1 lands. All five are tested in
    approach; rf2-y59tb closed the remaining frame-leak + first-click
    gap on top of the rf2-oqa60 widget rebuild.
 
-5. **Per-call-site isolation.** Two `[data-display]` mounts in the
+5. **Per-call-site isolation.** Two `[edn-inspector]` mounts in the
    same panel receive distinct `mount-id`s (auto-generated UUID per
    mount; captured in form-2 closure). Toggling a path under
    mount-A leaves the identical path under mount-B untouched.
@@ -1411,7 +1411,7 @@ the renderer, not separate chrome wrappers:
 
 The legacy `theme.data-inspector` ns is **deleted** in phase 5
 (rf2-q3dzw, D5=a) — sentinel chrome lives entirely inside the
-data-display widget now.
+edn-inspector widget now.
 
 #### §10.0.4 Phased rollout
 
@@ -1426,7 +1426,7 @@ Phases 2-5 file as separate beads chained off rf2-oqa60:
 - Phase 3 (rf2-e46qs) — **Sub value inspector integration.** The
   Views panel (`reactive-panel-view`) renders a `SUB VALUES` section
   beneath the flow graph. Each RUN sub gets one row carrying its
-  current cascade value through `[dd/data-display value opts]`
+  current cascade value through `[ei/edn-inspector value opts]`
   DIRECTLY (no `edn/inspect` / `edn/browse` facade hop). Each row's
   `:panel-id` is a STABLE per-sub keyword namespaced under
   `:rf.xray.reactive-sub-value` (folded from the sub-id), so two
@@ -1440,13 +1440,13 @@ Phases 2-5 file as separate beads chained off rf2-oqa60:
 - Phase 5 (rf2-q3dzw) — **Diff renderer subsumption (D5=a per
   rf2-sndui).** Diff is now an opt-in MODE on the same widget —
   pass `:before` in opts. The legacy
-  `data-display.render` engine (`render-tree`) and the
+  `edn-inspector.render` engine (`render-tree`) and the
   `theme.data-inspector` chrome ns are DELETED with this phase.
   The widget owns the whole `browse + diff + mini` contract as a
   single source of truth — see §10.0.8 for the full diff contract.
 - Phase 6 (rf2-s0x6x) — Popup overlay infra (D6=a · D8=a) —
   see §10.0.7
-- Phase 7 (rf2-0qrcr) — `IXrayDataDisplay` custom-formatters
+- Phase 7 (rf2-0qrcr) — `IXrayEdnInspector` custom-formatters
   protocol (D7=a) — see §10.0.6
 - Phase 7 follow-on (rf2-x16b1) — curated default formatters
   for `uuid` + `inst` (uri deferred) — see §10.0.9
@@ -1461,16 +1461,16 @@ pre-format pipeline survives the rf2-oqa60 cut-over unchanged).
 Token colours follow the Figma `.syntax-*` block: keywords red,
 strings blue/green, numbers blue, comments muted-italic.
 
-#### §10.0.6 `IXrayDataDisplay` custom-formatters protocol (phase 7 · D7=a · rf2-0qrcr)
+#### §10.0.6 `IXrayEdnInspector` custom-formatters protocol (phase 7 · D7=a · rf2-0qrcr)
 
 Phase 7 of rf2-oqa60 opens a single extension seam on the closed
 phase-1 renderer for consuming applications that carry domain types
 the built-in classifier has no better fallback for than `pr-str`.
 
-**Surface** — `day8.re-frame2-xray.views.data-display-protocol`:
+**Surface** — `day8.re-frame2-xray.views.edn-inspector-protocol`:
 
 ```clj
-(defprotocol IXrayDataDisplay
+(defprotocol IXrayEdnInspector
   (-xray-render-header [v opts])
   (-xray-render-body   [v opts]))
 ```
@@ -1489,11 +1489,11 @@ sees — `:panel-id`, `:mount-id`, `:path`, `:depth`,
 `:expansion-map`, plus the per-widget `:default-expanded-depth` /
 `:max-inline-width` / `:max-depth`. The original argument map is
 also threaded under `:node-opts` for consumers that want to recurse
-the built-in renderer on sub-values via `data-display/render-node`.
+the built-in renderer on sub-values via `edn-inspector/render-node`.
 
 **Dispatch order** (in `render-node`):
 
-1. `(satisfies? IXrayDataDisplay v)` → consult the protocol.
+1. `(satisfies? IXrayEdnInspector v)` → consult the protocol.
 2. `-xray-render-header v opts` returns nil → fall through to the
    built-in container / scalar dispatch.
 3. Otherwise wrap the header (+ optional body) in the standard
@@ -1516,11 +1516,11 @@ the underlying ledger entries:
 
 ```clj
 (ns my-app.domain.money
-  (:require [day8.re-frame2-xray.views.data-display-protocol
-             :refer [IXrayDataDisplay]]))
+  (:require [day8.re-frame2-xray.views.edn-inspector-protocol
+             :refer [IXrayEdnInspector]]))
 
 (deftype Money [amount currency ledger]
-  IXrayDataDisplay
+  IXrayEdnInspector
   (-xray-render-header [_ _opts]
     [:span {:style {:color    "var(--rf-xray-syntax-number)"
                     :padding  "0 6px"
@@ -1528,14 +1528,14 @@ the underlying ledger entries:
                     :border-radius "3px"}}
      (str amount " " currency)])
   (-xray-render-body [_ opts]
-    [day8.re-frame2-xray.views.data-display/render-node
+    [day8.re-frame2-xray.views.edn-inspector/render-node
      (assoc opts :value ledger)]))
 ```
 
-Mounted via `[data-display some-money-instance]` — the chip shows
+Mounted via `[edn-inspector some-money-instance]` — the chip shows
 collapsed; click expands to the ledger as a normal map view.
 
-**Tests** — `tools/xray/test/day8/re_frame2_xray/views/data_display_protocol_cljs_test.cljs`
+**Tests** — `tools/xray/test/day8/re_frame2_xray/views/edn_inspector_protocol_cljs_test.cljs`
 pins: (a) built-in types still route through the built-in dispatch
 (no protocol path leakage), (b) protocol-implementing types take
 the protocol path and the consumer's hiccup appears verbatim,
@@ -1545,16 +1545,16 @@ overrides still apply to protocol nodes.
 #### §10.0.7 Popup overlay infra (rf2-oqa60 phase 6 · D6=a · D8=a)
 
 Phase 6 ships the **popup overlay** that floats over an Xray panel
-and inspects a CLJS value at depth via `[data-display value opts]`.
+and inspects a CLJS value at depth via `[edn-inspector value opts]`.
 Locked decisions:
 
 - **D6=a — Xray-internal anchor scope.** The backdrop spans the
   Xray shell only (or the Story cell when
   `:rf.xray/modal-positioning` resolves to `:absolute`). The popup
   never anchors to the debugged application's DOM — the right-click
-  surface lives over Xray-internal data-display nodes only.
+  surface lives over Xray-internal edn-inspector nodes only.
 - **D8=a — auto-generated UUID per popup mount.** Each
-  `[data-display-popup value opts]` mount allocates a fresh
+  `[edn-inspector-popup value opts]` mount allocates a fresh
   `mount-id` (UUID, captured in form-2 closure) on first render.
   Two side-by-side mounts get independent expansion state — the
   popup's `:panel-id` is namespaced by `mount-id`, so the embedded
@@ -1562,14 +1562,14 @@ Locked decisions:
   popups or with the panel underneath.
 
 Public API at
-`tools/xray/src/day8/re_frame2_xray/views/data_display_popup.cljs`:
+`tools/xray/src/day8/re_frame2_xray/views/edn_inspector_popup.cljs`:
 
 ```clj
-[data-display-popup value]
-[data-display-popup value opts]
+[edn-inspector-popup value]
+[edn-inspector-popup value opts]
 
 ;; programmatic — opens via the stack slot:
-(rf/dispatch [:rf.xray.data-display-popup/open
+(rf/dispatch [:rf.xray.edn-inspector-popup/open
               mount-id {:value v :opts opts}]
              {:frame :rf/xray})
 ```
@@ -1578,7 +1578,7 @@ Public API at
 
 - `:title` — header label. Defaults `"Inspect"`.
 - `:panel-id` / `:default-expanded-depth` / `:max-inline-width` /
-  `:max-depth` — forwarded to the wrapped data-display widget. The
+  `:max-depth` — forwarded to the wrapped edn-inspector widget. The
   `:panel-id` is namespaced by the popup's `mount-id` before
   reaching the widget so per-mount isolation holds without caller
   effort.
@@ -1588,10 +1588,10 @@ Public API at
 
 State model (slots under `:rf/xray` frame's db):
 
-- `:rf.xray.data-display-popup/stack` — vector of `mount-id`s, top
+- `:rf.xray.edn-inspector-popup/stack` — vector of `mount-id`s, top
   of stack = last entry. Esc closes only the top entry, so layered
   popups beneath survive.
-- `:rf.xray.data-display-popup/entries` — `{mount-id {:value …
+- `:rf.xray.edn-inspector-popup/entries` — `{mount-id {:value …
   :opts …}}` payload map; survives shadow-cljs `:after-load`
   reloads. Re-opening a popup with the same `mount-id` raises it
   to the top of the stack and replaces its payload (window-manager
@@ -1600,7 +1600,7 @@ State model (slots under `:rf/xray` frame's db):
 Close affordances (per the bead's scope):
 
 1. **Esc** — handled by the popup's `:on-key-down`; dispatches
-   `:rf.xray.data-display-popup/close-top` so layered popups
+   `:rf.xray.edn-inspector-popup/close-top` so layered popups
    close one at a time.
 2. **Click backdrop** — closes that specific popup (matches the
    segment-inspector's click-outside-closes contract).
@@ -1613,20 +1613,20 @@ panel** but below app-modals (palette / settings). Base layer
 sequential z-indexes derived from their stack position so the
 topmost popup wins click + focus.
 
-The `data-display-popup-stack` view is the entry point for
+The `edn-inspector-popup-stack` view is the entry point for
 programmatic opens (a context-menu handler dispatches `:open`
 and the stack view picks the entry up); the
-`[data-display-popup value opts]` component is the entry point
+`[edn-inspector-popup value opts]` component is the entry point
 for inline opens (a panel that wants to control the popup
 imperatively from its own view tree). Both compose through
 `popup-chrome` so the chrome shape is identical.
 
 ##### §10.0.7.1 Shell mount (rf2-l4625)
 
-The `data-display-popup-stack` view mounts **once** at the Xray
+The `edn-inspector-popup-stack` view mounts **once** at the Xray
 shell root, alongside the other modal stacks (palette, settings,
 segment-inspector, …). The stack view reads
-`:rf.xray.data-display-popup/stack` + `:rf.xray.data-display-popup/entries`
+`:rf.xray.edn-inspector-popup/stack` + `:rf.xray.edn-inspector-popup/entries`
 and renders the popup chrome for every active mount-id in z-index
 order; it short-circuits to `nil` when the stack is empty (closed-
 state cost: one subscribe + a `when`-gate).
@@ -1634,7 +1634,7 @@ state cost: one subscribe + a `when`-gate).
 Registration is a single line in `registry.cljs`:
 
 ```clj
-(data-display-popup/install!)
+(edn-inspector-popup/install!)
 ```
 
 …idempotent per the orchestrator's `compare-and-set!` sentinel.
@@ -1644,7 +1644,7 @@ in `shell.cljs`'s overlay block, INSIDE the `rf/frame-provider
 
 ##### §10.0.7.2 Per-panel "open in popup" affordance (rf2-l4625 · rf2-7sdja)
 
-Each `[dd/data-display value opts]` call site **opts in** to a
+Each `[ei/edn-inspector value opts]` call site **opts in** to a
 top-right ↗ icon button by passing `:popup-affordance? true` in
 `opts`. Default is **off** — scalar / tiny-value mounts don't
 benefit from a larger inspection surface, and the silent default
@@ -1658,11 +1658,11 @@ the circled plus (which read as "expand" / "add").
 Mechanics:
 
 - The affordance renders a `:button` positioned absolutely at
-  the top-right of the data-display widget's outer container
+  the top-right of the edn-inspector widget's outer container
   (the container gets `position: relative` when the affordance
   is enabled).
 - Click dispatches
-  `[:rf.xray.data-display-popup/open popup-mount-id {:value v :opts o}]`
+  `[:rf.xray.edn-inspector-popup/open popup-mount-id {:value v :opts o}]`
   against `:rf/xray` **explicitly** via the established
   `(rf/dispatch event {:frame :rf/xray})` pattern (rf2-7sdja).
   This pins the dispatch frame regardless of where the widget
@@ -1670,16 +1670,16 @@ Mechanics:
   subscribes only against `:rf/xray`), unlike expansion state
   which is per-frame and uses the lexically-captured frame-
   aware dispatcher.
-- `popup-mount-id` is derived from the data-display's own
+- `popup-mount-id` is derived from the edn-inspector's own
   mount-id (`"ddp-" + mount-id`) — stable per call-site mount,
   so re-clicking the affordance **raises** the existing popup
   rather than spawning a duplicate (matches
-  `data-display-popup/push-entry` window-manager semantics).
+  `edn-inspector-popup/push-entry` window-manager semantics).
 - The opts forwarded to the popup carry
   `:popup-affordance? false` so the popup's embedded
-  data-display does not recurse the affordance inside itself.
+  edn-inspector does not recurse the affordance inside itself.
 
-Stable testid: `"rf-xray-data-display-popup-affordance-" +
+Stable testid: `"rf-xray-edn-inspector-popup-affordance-" +
 popup-mount-id`. The button carries
 `:data-rf-affordance "popup"` for hover-style hooks +
 `:aria-label "Open in popup"` for assistive tech.
@@ -1709,7 +1709,7 @@ leaf would clutter the diff display.
 
 Phase 5 closes the "diff renderer as separate engine" pattern. The
 pre-rf2-q3dzw shape composed two separate engines:
-`data-display.render` walked before/after pairs to paint gutter rows,
+`edn-inspector.render` walked before/after pairs to paint gutter rows,
 delegating leaf-value rendering to `theme.data-inspector/inspect`.
 That seam left two ns'es to keep in sync — every time the inspector
 gained a new type classification (sentinel chrome, type colours,
@@ -1723,8 +1723,8 @@ expand/collapse, AND applies diff annotations — one source of truth.
 **Surface**:
 
 ```clj
-[data-display value {:before before-value …}]
-[data-display-diff before after opts]
+[edn-inspector value {:before before-value …}]
+[edn-inspector-diff before after opts]
 ```
 
 **Diff ops**:
@@ -1737,8 +1737,8 @@ expand/collapse, AND applies diff annotations — one source of truth.
 | `:children` | container with changed descendant         | `◴`   | `:accent`      |
 | `:same`     | values equal                              | ` `   | `:text-tertiary` |
 
-The op classification is pure data via `dd/diff-op` (public for
-tests). The `::missing` marker (`dd/missing-sentinel`) distinguishes
+The op classification is pure data via `ei/diff-op` (public for
+tests). The `::missing` marker (`ei/missing-sentinel`) distinguishes
 "slot absent on this side of the diff" from a real `nil` value.
 
 **Gutter row**: each diff'd node renders inside a `gutter-row`
@@ -1770,7 +1770,7 @@ chrome regardless of mode. A modified `:rf/redacted` slot still
 renders as the magenta chip + `← changed from <prior>` annotation;
 no chip-reveal leakage.
 
-**Test pins** — `tools/xray/test/day8/re_frame2_xray/views/data_display_cljs_test.cljs`:
+**Test pins** — `tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs`:
 
 1. `diff-op` classifies the canonical 4 ops + `:same`.
 2. `changed-descendant?` walks maps + sequentials + returns
@@ -1784,13 +1784,13 @@ no chip-reveal leakage.
 6. The public widget's outer container carries `data-rf-mode
    "diff"` when `:before` is supplied; `"browse"` otherwise.
 
-#### §10.0.9 Default `IXrayDataDisplay` formatters (rf2-x16b1)
+#### §10.0.9 Default `IXrayEdnInspector` formatters (rf2-x16b1)
 
 The phase-7 protocol seam (§10.0.6) ships zero default impls — every
 consuming app would have to register the same boilerplate for the
 common types where the raw repr is genuinely cramped. rf2-x16b1
 ships a curated set of opinionated default formatters, loaded
-automatically when `views.data-display` is required.
+automatically when `views.edn-inspector` is required.
 
 **Coverage** — the curated set is deliberately small. Each type
 included carries a clear win over `pr-str`; the rest stay on the
@@ -1830,9 +1830,9 @@ the most-recently-loaded impl is the one that fires. The bundled
 defaults are inert when a consumer takes the seam for a type they
 own. Regression-anchored by
 `consumer-extension-wins-over-default-on-its-own-type` in
-`tools/xray/test/day8/re_frame2_xray/views/data_display_default_formatters_cljs_test.cljs`.
+`tools/xray/test/day8/re_frame2_xray/views/edn_inspector_default_formatters_cljs_test.cljs`.
 
-**Surface** — `day8.re-frame2-xray.views.data-display-default-formatters`.
+**Surface** — `day8.re-frame2-xray.views.edn-inspector-default-formatters`.
 Public for tests + reference:
 
 - `format-relative` — pure-data inst bucketing against a pinned `now`
@@ -1840,7 +1840,7 @@ Public for tests + reference:
 - `render-inst-header` / `render-inst-body`
 
 The ns is required for side-effect (the `extend-type` forms) from
-`views.data-display` itself — no call-site registration needed.
+`views.edn-inspector` itself — no call-site registration needed.
 
 ### §10.1 Capabilities (LOCKED per B.9 super-prompt)
 
@@ -1944,7 +1944,7 @@ defaults to depth-3-collapsed; Event payload defaults to depth-2-expanded
 because event payloads are typically shallow + small).
 
 Per-node operator override (sticky): clicking expand/collapse persists
-to `:rf.xray.data-display/expansion {<path>}` so the operator's
+to `:rf.xray.edn-inspector/expansion {<path>}` so the operator's
 disclosure choices survive epoch navigation. **No right-click reset**
 (per §10.5 — right-click context menus are explicitly out). Reset by
 navigating to a new focused epoch (the sticky override is per-epoch +
@@ -1978,15 +1978,15 @@ menus are explicitly OUT. Operator learns one gesture; applies it everywhere.
 These were on earlier drafts and have been removed. Future beads that
 re-propose them must re-open the B.9 lock with the mayor first.
 
-### §10.6 Cross-panel data-display consistency
+### §10.6 Cross-panel edn-inspector consistency
 
 All panels use the same renderer. Implementations MUST go through
-`tools/xray/src/day8/re_frame2_xray/views/data_display.cljs` (the
+`tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs` (the
 first-class widget — rf2-oqa60 phase 1). Per-panel renderers are
-`[data-display value opts]` invocations that configure
+`[edn-inspector value opts]` invocations that configure
 `:default-expanded-depth` / `:panel-id` / `:max-inline-width`. The
 operator's expansion state lives in one app-db slot
-(`:rf.xray.data-display/expansion`) keyed by
+(`:rf.xray.edn-inspector/expansion`) keyed by
 `[panel-id mount-id path]` — the mount-id auto-generated per
 component instance so two mounts in the same panel are isolated.
 
@@ -1994,16 +1994,16 @@ Phase 1 wires the App-DB panel through the new widget directly; the
 remaining surfaces (Trace, Sub, Machine, Issues) reach through the
 legacy `views.edn-widget.widget` facade for now, which delegates to
 the new widget. Phases 2-4 migrate each surface to call
-`[data-display …]` directly. Phase 5 (rf2-q3dzw) **completes** the
+`[edn-inspector …]` directly. Phase 5 (rf2-q3dzw) **completes** the
 subsumption: diff is now an opt-in mode on the same widget
-(`:before` opt) and the legacy `data-display.render` engine +
+(`:before` opt) and the legacy `edn-inspector.render` engine +
 `theme.data-inspector` chrome ns are DELETED. The widget owns the
 whole `browse + diff + mini` contract as one source of truth.
 
 ### §10.7 Evicted-epoch placeholder
 
 When the operator scrubs onto an epoch evicted from the buffer, every
-data-display in every panel renders the same placeholder:
+edn-inspector in every panel renders the same placeholder:
 
 ```
 ┌─ epoch #12 ──────────────────────────────────────────────────────────┐
@@ -2159,8 +2159,8 @@ real beads after approving this doc.
 
 ### Xray panel beads
 
-- **rf2-?????** — *Xray: shared data-display renderer.* New ns
-  `data_display/render.cljs` per §10. Lazy tree, inline diff,
+- **rf2-?????** — *Xray: shared edn-inspector renderer.* New ns
+  `edn_inspector/render.cljs` per §10. Lazy tree, inline diff,
   keyword-accent, clickable-paths, expansion-state app-db slot. All
   panels rebind to this renderer. Includes evicted-epoch placeholder.
 
@@ -2182,7 +2182,7 @@ real beads after approving this doc.
 - **rf2-?????** — *Xray: Trace panel — focused-epoch scoping + film-
   strip.* Re-scope Trace panel to focused `:dispatch-id` (drop any
   aggregate-across-epochs view). Add `[◀ Prev] [Next ▶]` header. Reuse
-  data-display renderer for expanded payloads.
+  edn-inspector renderer for expanded payloads.
 
 - **rf2-?????** — *Xray: Machines panel — topology-always-visible
   empty-state.* When focused epoch has no machine transition, still
@@ -2398,7 +2398,7 @@ becoming a grid of boxes.
 |---|---|
 | Around the L4 panel itself (`:bg-2` on `:bg-1`, 1px `:border-default`) | Between sibling rows in a dense list (use `:gap-1` vertical rhythm only) |
 | Around each xyflow / SVG canvas (1px `:border-default`) | Between pipeline steps in §2.2 (the numbered rail IS the divider) |
-| Between reserved-area sections in App-db (1px `:border-subtle`, full width) | Inside the data-display tree (indentation IS the structure) |
+| Between reserved-area sections in App-db (1px `:border-subtle`, full width) | Inside the edn-inspector tree (indentation IS the structure) |
 | Around hover popovers (1px `:border-default` + 4px shadow) | Between cells of an inline KV row (whitespace alone) |
 | Around xyflow group/parent nodes (1px solid; 1px dashed for parallel-region containers) | Between L4 tabs (the L3 tab strip handles this) |
 
@@ -2461,7 +2461,7 @@ the panel itself.)
 - `→` (right arrow) — used as a transition glyph in machine-state
   rows (`:populated → :submitting`). `:text-primary`, mono inline.
 
-**Tree-disclosure glyphs** (data-display renderer · §10.2):
+**Tree-disclosure glyphs** (edn-inspector renderer · §10.2):
 
 - `▾` expanded · `▸` collapsed — both `:text-secondary`, 11px
 - `·` leaf-row indent — `:text-tertiary`, 11px
@@ -2733,9 +2733,9 @@ already drafted in §13.
   `package.json` (~50-80KB gzipped, MIT). Gates: Machines panel
   redesign (§6).
 
-- **rf2-?????** — *Xray: data-display renderer component — lazy tree
+- **rf2-?????** — *Xray: edn-inspector renderer component — lazy tree
   + inline diff + keyword accent + clickable paths.* New ns
-  `tools/xray/src/day8/re_frame2_xray/data_display/render.cljs` per
+  `tools/xray/src/day8/re_frame2_xray/edn_inspector/render.cljs` per
   §10 + §17.1.3 palette mapping + §17.2 interaction-state matrix. The
   only path-interaction is cross-panel propagation (§10.5). Gates: all
   Dynamic panels.

--- a/tools/xray/spec/023-Trace-Panel.md
+++ b/tools/xray/spec/023-Trace-Panel.md
@@ -17,7 +17,7 @@ Cross-refs:
 - [`013-Trace-Consumer.md`](./013-Trace-Consumer.md) — the trace-bus + collector contract this panel reads
 - [`016-Auxiliary-Panels.md`](./016-Auxiliary-Panels.md) — the sibling per-tab content contracts (Issues, Routing, Flows)
 - [`018-Event-Spine.md`](./018-Event-Spine.md) — the `:rf.xray/focus` spine contract + 4-layer chrome
-- [`021-Dynamic-Panel-Designs.md`](./021-Dynamic-Panel-Designs.md) — §3 Views · §5 implemented Trace · §10 shared data-display renderer
+- [`021-Dynamic-Panel-Designs.md`](./021-Dynamic-Panel-Designs.md) — §3 Views · §5 implemented Trace · §10 shared edn-inspector renderer
 - [`003-Machine-Inspector.md`](./003-Machine-Inspector.md) — the Machine panel this panel's MACHINE rows jump to
 
 Owner: tools/xray.
@@ -53,7 +53,7 @@ Columns: **Δt · area badge · what-happened · target/detail · duration**.
 - **what-happened** — the per-area verb (§5).
 - **target/detail** — the op's subject: event vector, `fx-id → arg`, `sub-id  old→new`, `view-id ← cause-sub`, route id, path, etc.
 - **duration** — a number in **ms**, or `—` when the substrate supplies no timing (§6).
-- **Row click → expand** the full raw trace-event EDN inline (`:op-type` · `:operation` · `:tags` · timing · `:rf.trace/dispatch-id` …) via the first-class data-display widget — the canonical CLJS-value renderer (the shared widget contract — [`021`](./021-Dynamic-Panel-Designs.md) §10, in particular §10.0 + §10.0.2 acceptance properties). The trace panel calls `[dd/data-display value {:panel-id :rf.xray.trace/row-<id> …}]` directly (no facade hop); each row independently collapsible (the per-row `panel-id` qualifier scopes expansion state to that row, on top of the widget's own per-mount UUID).
+- **Row click → expand** the full raw trace-event EDN inline (`:op-type` · `:operation` · `:tags` · timing · `:rf.trace/dispatch-id` …) via the first-class edn-inspector widget — the canonical CLJS-value renderer (the shared widget contract — [`021`](./021-Dynamic-Panel-Designs.md) §10, in particular §10.0 + §10.0.2 acceptance properties). The trace panel calls `[ei/edn-inspector value {:panel-id :rf.xray.trace/row-<id> …}]` directly (no facade hop); each row independently collapsible (the per-row `panel-id` qualifier scopes expansion state to that row, on top of the widget's own per-mount UUID).
 
 ## §4 Phase → op-family placement
 

--- a/tools/xray/src/day8/re_frame2_xray/diff/hiccup_render.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/diff/hiccup_render.cljs
@@ -31,9 +31,9 @@
             [day8.re-frame2-xray.diff.hiccup :as hd]
             [day8.re-frame2-xray.panels.app-db-diff-format :as f]
             ;; rf2-q3dzw phase 5 — leaf values route through the
-            ;; first-class data-display widget. The legacy
+            ;; first-class edn-inspector widget. The legacy
             ;; `theme.data-inspector` ns is deleted.
-            [day8.re-frame2-xray.views.data-display :as dd]
+            [day8.re-frame2-xray.views.edn-inspector :as ei]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens mono-stack sans-stack]]))
 
@@ -70,7 +70,7 @@
   (let [pid (keyword "rf.xray.diff-section"
                      (-> node-key
                          (string/replace #"[^A-Za-z0-9._-]+" "_")))]
-    [dd/data-display (f/display-value v)
+    [ei/edn-inspector (f/display-value v)
      {:panel-id pid
       :default-expanded-depth 1}]))
 

--- a/tools/xray/src/day8/re_frame2_xray/diff/render.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/diff/render.cljs
@@ -21,9 +21,9 @@
     - Collapse `:same` subtrees into `(N entries unchanged)` chips
     - `:modified` leaves render inline `before → after`
 
-  ## Reuses the data-display widget
+  ## Reuses the edn-inspector widget
 
-  Falls through to `views.data-display/data-display` for the value
+  Falls through to `views.edn-inspector/edn-inspector` for the value
   content of every annotated leaf (rf2-q3dzw phase 5 migration —
   pre-phase-5 this routed through `theme.data-inspector/inspect`).
   Just adds the dispatch wrapper: given an annotated node, dispatch
@@ -32,8 +32,8 @@
 
   ## Per-node expand-state
 
-  The data-display widget owns its own expansion slot
-  (`:rf.xray.data-display/expansion`) keyed by
+  The edn-inspector widget owns its own expansion slot
+  (`:rf.xray.edn-inspector/expansion`) keyed by
   `[panel-id mount-id path]`. Per-node `panel-id` for a diff render
   is a stable per-surface keyword namespaced under
   `:rf.xray.diff-section/` (folded from the surface + section path)
@@ -41,7 +41,7 @@
 
   ## Sentinel handling
 
-  Sentinels are first-class types INSIDE the data-display widget
+  Sentinels are first-class types INSIDE the edn-inspector widget
   (D3=a per rf2-sndui) — the diff layer never overrides them. The
   diff layer's chrome (gutter colour + glyph) wraps the rendered
   value without altering its sentinel chrome."
@@ -57,9 +57,9 @@
             [day8.re-frame2-xray.panels.app-db-diff-format :as f]
             [day8.re-frame2-xray.panels.app-db-diff-helpers :as h]
             ;; rf2-q3dzw phase 5 — leaf values route through the
-            ;; first-class data-display widget. The legacy
+            ;; first-class edn-inspector widget. The legacy
             ;; `theme.data-inspector` ns is deleted.
-            [day8.re-frame2-xray.views.data-display :as dd]
+            [day8.re-frame2-xray.views.edn-inspector :as ei]
             [day8.re-frame2-xray.theme.tokens
              :as t
              :refer [tokens mono-stack sans-stack]]))
@@ -435,7 +435,7 @@
      (str (pr-str k) " ")]))
 
 (defn- inspect-value
-  "Render a value via the first-class data-display widget. Wraps the
+  "Render a value via the first-class edn-inspector widget. Wraps the
   invocation with a unique `:panel-id` so the expansion slot doesn't
   collide with sibling renders.
 
@@ -450,7 +450,7 @@
         pid (keyword "rf.xray.diff-section"
                      (-> node-key
                          (string/replace #"[^A-Za-z0-9._-]+" "_")))]
-    [dd/data-display (f/display-value v)
+    [ei/edn-inspector (f/display-value v)
      {:panel-id pid
       :default-expanded-depth 1}]))
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs
@@ -17,15 +17,15 @@
   Every reserved area renders even when absent/empty — an empty-state
   placeholder — so the developer sees the full reserved inventory.
 
-  ## Current-state render — first-class data-display widget (rf2-oqa60)
+  ## Current-state render — first-class edn-inspector widget (rf2-oqa60)
 
-  Values render through the first-class `views/data-display` widget.
+  Values render through the first-class `views/edn-inspector` widget.
   The new widget owns the WHOLE contract — browse + diff + mini —
   CLJS-aware type detection, distinct bracket styling per collection
   kind, click-to-toggle expansion stored in re-frame app-db, first-
   class sentinel chrome (`:rf/redacted`, `:rf/large`). After phase 5
   (rf2-q3dzw, D5=a per rf2-sndui) diff also routes through this same
-  widget via the `:before` opt — the legacy `data-display.render`
+  widget via the `:before` opt — the legacy `edn-inspector.render`
   engine is gone.
 
   The widget has NO ⎘ copy affordance (deferred to follow-on beads —
@@ -48,7 +48,7 @@
   Each section carries a `:before` slice (from the cascade's `db-before`,
   threaded by `app-db-diff-helpers/current-state-sections`'s 2-arity).
   When a pre-image is present and differs, the value body routes
-  through the data-display widget's DIFF mode (rf2-q3dzw phase 5,
+  through the edn-inspector widget's DIFF mode (rf2-q3dzw phase 5,
   D5=a) — passing `:before` paints inline `← changed from X`
   annotations in place on changed nodes and force-expands the
   ancestor chain so the operator never expands to find a change. When
@@ -61,10 +61,10 @@
             [day8.re-frame2-xray.panels.app-db-diff-helpers :as h]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens mono-stack sans-stack]]
-            ;; The first-class data-display widget owns the WHOLE
+            ;; The first-class edn-inspector widget owns the WHOLE
             ;; contract — browse + diff — as a single source of truth
             ;; (rf2-q3dzw phase 5, D5=a per rf2-sndui).
-            [day8.re-frame2-xray.views.data-display :as dd]))
+            [day8.re-frame2-xray.views.edn-inspector :as ei]))
 
 ;; ---- shared section chrome ----------------------------------------------
 
@@ -127,7 +127,7 @@
 
   When `before` is the `h/no-diff` sentinel (no pre-image threaded —
   LIVE at boot / 1-arity model) the value renders in BROWSE mode via
-  the first-class data-display widget — a plain current-state tree.
+  the first-class edn-inspector widget — a plain current-state tree.
 
   When a real pre-image is present the value renders in DIFF mode via
   the SAME widget (rf2-q3dzw phase 5), passing `:before` so the
@@ -152,7 +152,7 @@
     ;; keep the affordance where the inline widget is genuinely
     ;; cramped.
     (if (= h/no-diff before)
-      [dd/data-display
+      [ei/edn-inspector
        (f/display-value value)
        {:panel-id :rf.xray/app-db
         :site-id  site-id
@@ -164,7 +164,7 @@
         ;; affordance so the operator sees them as discrete inspector
         ;; cards.
         :card? true}]
-      [dd/data-display
+      [ei/edn-inspector
        (f/display-value value)
        {:panel-id :rf.xray/app-db
         :site-id  site-id

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_canvas.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_canvas.cljs
@@ -60,10 +60,10 @@
             [day8.re-frame2-xray.panels.machine-after-rings :as after-rings]
             ;; rf2-lxvn6 (phase 4 of rf2-oqa60) — the canvas-side
             ;; snapshot drill-in surface mounts the first-class
-            ;; data-display widget directly. Per spec/021 §10 widget
+            ;; edn-inspector widget directly. Per spec/021 §10 widget
             ;; contract; every call site qualifies with a per-machine
             ;; `:panel-id`.
-            [day8.re-frame2-xray.views.data-display :as dd]
+            [day8.re-frame2-xray.views.edn-inspector :as ei]
             [day8.re-frame2-xray.theme.tokens
              :as t
              :refer [tokens sans-stack mono-stack]]))
@@ -358,7 +358,7 @@
 ;;
 ;; The canvas-side companion to `machine_inspector/snapshot-drill-in`.
 ;; Mounts a single machine snapshot map (`{:state X :data Y}`) through
-;; the first-class data-display widget. Callers that already have a
+;; the first-class edn-inspector widget. Callers that already have a
 ;; snapshot in hand (e.g. the Chart's `:current-state` source: a
 ;; topology fallback, a static-mode reader, a future hover/popup)
 ;; embed this view to surface the full structure without re-implementing
@@ -378,7 +378,7 @@
 
 (defn SnapshotDrillIn
   "Render `snapshot` (typically `{:state X :data Y}`) via the first-class
-  data-display widget. Pure hiccup — no rf reads.
+  edn-inspector widget. Pure hiccup — no rf reads.
 
   Args (map):
 
@@ -419,7 +419,7 @@
                     :font-style "italic"
                     :color (:text-tertiary tokens)}}
       "(no snapshot — machine uninitialised or trace pre-snapshot-tagging)"]
-     [dd/data-display snapshot
+     [ei/edn-inspector snapshot
       {:panel-id (snapshot-panel-id machine-id phase)
        ;; rf2-pvsxs — machine + phase are stable identifiers; the
        ;; operator's drill-into-data choices survive a Machines tab

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
@@ -54,10 +54,10 @@
             [day8.re-frame2-xray.share :as share]
             ;; rf2-lxvn6 (phase 4 of rf2-oqa60) — the per-machine
             ;; snapshot drill-in surface mounts the first-class
-            ;; data-display widget directly. Each machine gets its own
+            ;; edn-inspector widget directly. Each machine gets its own
             ;; `:panel-id` qualifier so two machines' expansion state
             ;; stays independent. See spec/021 §10 widget contract.
-            [day8.re-frame2-xray.views.data-display :as dd]
+            [day8.re-frame2-xray.views.edn-inspector :as ei]
             [day8.re-frame2-xray.theme.tokens
              :as t
              :refer [tokens mono-stack sans-stack display-stack]]))
@@ -271,8 +271,8 @@
 ;; ---- snapshot drill-in (rf2-lxvn6 · spec/021 §10 widget contract) -----
 ;;
 ;; Phase 4 of rf2-oqa60 wires the per-machine snapshot value through
-;; the first-class data-display widget at
-;; `day8.re-frame2-xray.views.data-display`. Each call site qualifies
+;; the first-class edn-inspector widget at
+;; `day8.re-frame2-xray.views.edn-inspector`. Each call site qualifies
 ;; with a per-machine `:panel-id` so two machines' (or before/after's
 ;; on the same machine) expansion state stays independent — the rule
 ;; per spec/021 §10.0.2 acceptance property 5 (per-call-site isolation
@@ -290,7 +290,7 @@
 (defn- snapshot-panel-id
   "Compose a per-machine `:panel-id` qualifier for the snapshot
   drill-in mount. Each machine gets a distinct namespaced keyword so
-  the widget's `:rf.xray.data-display/expansion` slot scopes by
+  the widget's `:rf.xray.edn-inspector/expansion` slot scopes by
   machine-id; expansion under `:auth/login` doesn't bleed into
   expansion under `:checkout/flow`.
 
@@ -318,7 +318,7 @@
 
 (defn- snapshot-block
   "Render one machine snapshot map (`{:state X :data Y}`) via the
-  first-class data-display widget (rf2-oqa60 phase 1, rf2-lxvn6 phase
+  first-class edn-inspector widget (rf2-oqa60 phase 1, rf2-lxvn6 phase
   4). Tagged with a section heading + the per-mount testid so panel-
   level tests can assert presence per (machine-id, phase) pair.
 
@@ -342,7 +342,7 @@
                     :font-family sans-stack
                     :margin-bottom "4px"}}
       label]
-     [dd/data-display snapshot
+     [ei/edn-inspector snapshot
       {:panel-id (snapshot-panel-id machine-id phase)
        ;; rf2-pvsxs — machine + phase are stable identifiers; the
        ;; operator's drill-into-data choices survive a Machines tab
@@ -357,7 +357,7 @@
 (defn- snapshot-drill-in
   "Snapshot drill-in section beneath the focused-event chart. Renders
   the BEFORE and AFTER snapshot maps for the focused transition via
-  the first-class data-display widget so the operator can inspect
+  the first-class edn-inspector widget so the operator can inspect
   what `:data` carried on either side of the transition (spec/003
   §M.10 bug class — `:data` mutations invisible without app-db diff).
 
@@ -571,7 +571,7 @@
               :show-after-rings?  true}]])))
      ;; rf2-lxvn6 (phase 4 of rf2-oqa60) — snapshot drill-in. Each
      ;; per-machine section renders the BEFORE / AFTER snapshot maps
-     ;; through the first-class data-display widget (spec/021 §10).
+     ;; through the first-class edn-inspector widget (spec/021 §10).
      ;; Per-machine `:panel-id` qualifier keeps two machines' expansion
      ;; state independent; the `:before` / `:after` phase suffix scopes
      ;; the two sibling mounts on the same machine. The whole block

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector_helpers.cljc
@@ -443,7 +443,7 @@
   The full `:before` / `:after` snapshot maps (`{:state X :data Y}`) are
   carried through on the record so the panel's snapshot drill-in
   surface (rf2-lxvn6, spec/021 §10) can render them via the first-class
-  data-display widget. nil when the trace pre-dates the snapshot
+  edn-inspector widget. nil when the trace pre-dates the snapshot
   tagging contract (legacy `:from`/`:to`-only fixtures)."
   [ev]
   (let [tags  (get ev :tags {})

--- a/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_subs.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_subs.cljs
@@ -82,7 +82,7 @@
 
   `:sub-values` (rf2-e46qs phase 3) drives the SUB VALUES inspector
   section beneath the flow graph — one row per RUN sub with its current
-  cascade value, surfaced through the first-class data-display widget
+  cascade value, surfaced through the first-class edn-inspector widget
   (spec/021 §10).
 
   `:sub-readers` (rf2-y23uw) is the shared-subscription edge map — for

--- a/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_view.cljs
@@ -35,7 +35,7 @@
 
   - **SUB VALUES** (rf2-e46qs phase 3 of rf2-oqa60) — one row per RUN
     sub this cascade; each row's value renders through the first-class
-    data-display widget (`views.data-display`, spec/021 §10) DIRECTLY
+    edn-inspector widget (`views.edn-inspector`, spec/021 §10) DIRECTLY
     — no `edn/inspect` / `edn/browse` facade hop. Per-row stable
     `:panel-id` (`:rf.xray.reactive-sub-value/<sub-id>`) so two sub-row
     expansions never share state.
@@ -73,11 +73,11 @@
             [day8.re-frame2-xray.theme.tokens :as tk
              :refer [tokens mono-stack sans-stack]]
             ;; rf2-e46qs phase 3 — per-sub value inspector renders
-            ;; through the first-class data-display widget (spec/021
+            ;; through the first-class edn-inspector widget (spec/021
             ;; §10) directly. Each sub-value mount gets its own stable
             ;; per-sub `:panel-id` so two sub-row expansions are
             ;; independent (acceptance #2).
-            [day8.re-frame2-xray.views.data-display :as dd]))
+            [day8.re-frame2-xray.views.edn-inspector :as ei]))
 
 ;; ---- section chrome -----------------------------------------------------
 
@@ -416,8 +416,8 @@
 ;; ---- SUB VALUES inspector section (rf2-e46qs phase 3 of rf2-oqa60) -----
 ;;
 ;; One row per RUN sub this cascade, surfacing the sub's current value
-;; through the first-class data-display widget (`views.data-display`,
-;; spec/021 §10). Each row mounts `[dd/data-display value opts]`
+;; through the first-class edn-inspector widget (`views.edn-inspector`,
+;; spec/021 §10). Each row mounts `[ei/edn-inspector value opts]`
 ;; directly — no `edn/inspect` / `edn/browse` facade hop.
 ;;
 ;; Per-row `:panel-id` (acceptance #2) is a STABLE per-sub keyword built
@@ -426,7 +426,7 @@
 ;; rf2-sndui), so a re-render preserves the operator's drill-downs.
 
 (defn- sub-value-panel-id
-  "Stable per-sub `:panel-id` for the data-display mount. The sub-id
+  "Stable per-sub `:panel-id` for the edn-inspector mount. The sub-id
   (a keyword in the standard case) is folded into a namespaced kw under
   `:rf.xray.reactive-sub-value` so its expansion slot is isolated from
   every other panel-id in the app-db expansion map. Acceptance #2 —
@@ -444,7 +444,7 @@
 
 (defn- sub-value-row
   "Render one SUB VALUES row — the sub's id + its current value through
-  `[dd/data-display]`. Changed subs read in the accent tone; unchanged
+  `[ei/edn-inspector]`. Changed subs read in the accent tone; unchanged
   subs read dimmed (consistent with the flow-graph node encoding).
 
   `:has-value?` false → the sub-run carried no `:value` slot (privacy
@@ -485,7 +485,7 @@
      (if has-value?
        [:div {:data-testid (str row-testid "-value")
               :style {:padding-left "4px"}}
-        [dd/data-display value {:panel-id (sub-value-panel-id sub-id)
+        [ei/edn-inspector value {:panel-id (sub-value-panel-id sub-id)
                                 ;; rf2-pvsxs — sub-id is stable across
                                 ;; cascades; the operator's expansion
                                 ;; choices survive a tab leave-and-
@@ -508,14 +508,14 @@
 
 (defn- sub-values-section
   "Render the SUB VALUES inspector section beneath the flow graph. One
-  row per RUN sub; rows render their value through `[dd/data-display]`
+  row per RUN sub; rows render their value through `[ei/edn-inspector]`
   directly (rf2-e46qs phase 3 of rf2-oqa60). The section is omitted
   entirely when the cascade ran no subs — the flow graph's empty
   placeholder already covers the no-cascade case.
 
   Row hiccup is produced by INLINING `sub-value-row` (function call,
   not a `[sub-value-row …]` Reagent component form) so the
-  `[dd/data-display value opts]` mount surfaces in the panel's hiccup
+  `[ei/edn-inspector value opts]` mount surfaces in the panel's hiccup
   tree directly — testable without a React render — and the React
   reconciler still keys each row via the `^{:key …}` metadata on the
   inlined `[:div …]`."
@@ -599,7 +599,7 @@
           (section-label "flow" "Reactive Flow" {:title-case? true})
           (flow-graph data)]
          ;; rf2-e46qs phase 3 — SUB VALUES inspector (per-sub
-         ;; value rendered through the first-class data-display
+         ;; value rendered through the first-class edn-inspector
          ;; widget; spec/021 §10).
          (sub-values-section data)
          (unmounted-views-section data)

--- a/tools/xray/src/day8/re_frame2_xray/panels/trace.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/trace.cljs
@@ -39,8 +39,8 @@
   Errors / warnings are cross-cutting (spec/023 §7) — they render inline
   at their chronological point within whatever band they occurred,
   emphasised so failures stand out. Clicking any row expands its raw
-  trace-event EDN inline (spec/023 §3) via the first-class data-display
-  widget (spec/021 §10 / `views.data-display`).
+  trace-event EDN inline (spec/023 §3) via the first-class edn-inspector
+  widget (spec/021 §10 / `views.edn-inspector`).
 
   ## Design system (PR #2089 · Handler panel idiom)
 
@@ -90,7 +90,7 @@
             [day8.re-frame2-xray.panels.trace-helpers :as h]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens mono-stack sans-stack]]
-            [day8.re-frame2-xray.views.data-display :as dd]
+            [day8.re-frame2-xray.views.edn-inspector :as ei]
             [day8.re-frame2-xray.views.edn-widget.widget :as edn]))
 
 ;; ---- row grid template (spec/023 §3 · §14) -----------------------------
@@ -107,13 +107,13 @@
 ;; ---- payload renderer (spec/023 §3) -------------------------------------
 ;;
 ;; Row click → expand the full raw trace-event EDN inline via the
-;; first-class data-display widget (spec/021 §10 widget contract /
+;; first-class edn-inspector widget (spec/021 §10 widget contract /
 ;; spec/023 §3 row click → expand). The widget owns its own per-mount
 ;; expansion state keyed by `[panel-id mount-id path]`, so two rows
 ;; expanded simultaneously each keep an independent expansion tree.
 ;;
 ;; Per rf2-hhtbl (rf2-oqa60 phase 2) this call site invokes
-;; `[dd/data-display value opts]` directly — no facade hop through
+;; `[ei/edn-inspector value opts]` directly — no facade hop through
 ;; `edn/browse`. The per-row `panel-id` qualifier embeds the row id so
 ;; two simultaneously-expanded rows can't collide on expansion state
 ;; even if their mount-ids alias (and the auto-id guarantees they
@@ -122,13 +122,13 @@
 (defn- render-payload
   "Per-row payload renderer — the raw `:operation` · `:tags` · timing ·
   `:rf.trace/dispatch-id` trace-event EDN (spec/023 §3), rendered via
-  the first-class data-display widget."
+  the first-class edn-inspector widget."
   [{:keys [id raw] :as _row}]
   [:div {:data-testid (str "rf-xray-trace-row-" id "-payload")
          :style       {:padding       "6px 16px 10px 56px"
                        :background    (:bg-1 tokens)
                        :border-radius "0 0 4px 4px"}}
-   [dd/data-display raw
+   [ei/edn-inspector raw
     {:panel-id (keyword "rf.xray.trace" (str "row-" id))
      ;; rf2-pvsxs — trace rows survive tab leave-and-return because
      ;; the trace event-id is itself stable; the `:site-id` reuses it

--- a/tools/xray/src/day8/re_frame2_xray/registry.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/registry.cljs
@@ -33,24 +33,24 @@
   (:require [re-frame.core :as rf]
             [re-frame.trace.projection :as projection]
             [day8.re-frame2-xray.config :as config]
-            ;; Load the first-class data-display widget ns so its
+            ;; Load the first-class edn-inspector widget ns so its
             ;; top-level `reg-sub` / `reg-event-db` calls land in
             ;; the registrar at orchestrator-load time. The widget
-            ;; owns `:rf.xray.data-display/*` events/subs and is the
+            ;; owns `:rf.xray.edn-inspector/*` events/subs and is the
             ;; SINGLE source of truth for browse + diff + mini
-            ;; (rf2-q3dzw phase 5; legacy `data-display.render` +
+            ;; (rf2-q3dzw phase 5; legacy `edn-inspector.render` +
             ;; `theme.data-inspector` ns'es are deleted).
-            [day8.re-frame2-xray.views.data-display]
+            [day8.re-frame2-xray.views.edn-inspector]
             ;; rf2-l4625 — popup overlay infra. `install!` registers
             ;; the stack/entries subs + open/close/close-top/close-all
             ;; events at orchestrator-load time. The stack VIEW mount
             ;; lives in `shell.cljs`; per-panel "open in popup"
-            ;; affordances flow through `[dd/data-display value
+            ;; affordances flow through `[ei/edn-inspector value
             ;; {:popup-affordance? true …}]` and dispatch
-            ;; `:rf.xray.data-display-popup/open` against the surrounding
+            ;; `:rf.xray.edn-inspector-popup/open` against the surrounding
             ;; `:rf/xray` frame.
-            [day8.re-frame2-xray.views.data-display-popup
-             :as data-display-popup]
+            [day8.re-frame2-xray.views.edn-inspector-popup
+             :as edn-inspector-popup]
             [day8.re-frame2-xray.defaults :as defaults]
             [day8.re-frame2-xray.epoch :as epoch]
             [day8.re-frame2-xray.filters :as filters]
@@ -606,13 +606,13 @@
     (open-in-editor/install!)
     (palette/install!)
     (settings-popup/install!)
-    ;; rf2-l4625 — data-display popup overlay (subs + events). The
+    ;; rf2-l4625 — edn-inspector popup overlay (subs + events). The
     ;; stack view is mounted in `shell.cljs` alongside the other modal
     ;; mounts; per-panel "open in popup" affordances pass through
-    ;; `[dd/data-display value {:popup-affordance? true …}]` and
-    ;; dispatch the `:rf.xray.data-display-popup/open` event registered
+    ;; `[ei/edn-inspector value {:popup-affordance? true …}]` and
+    ;; dispatch the `:rf.xray.edn-inspector-popup/open` event registered
     ;; here.
-    (data-display-popup/install!)
+    (edn-inspector-popup/install!)
     ;; Filters install AFTER `:rf.xray/active-filters` + the
     ;; add-filter / remove-filter events above are registered (the
     ;; filters facade adds `:rf.xray/filtered-cascades` + the edit-

--- a/tools/xray/src/day8/re_frame2_xray/shell.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/shell.cljs
@@ -129,8 +129,8 @@
             [day8.re-frame2-xray.resize-handle :as resize-handle]
             [day8.re-frame2-xray.settings.popup :as settings-popup]
             [day8.re-frame2-xray.share-modal :as share-modal]
-            [day8.re-frame2-xray.views.data-display-popup
-             :as data-display-popup]
+            [day8.re-frame2-xray.views.edn-inspector-popup
+             :as edn-inspector-popup]
             [day8.re-frame2-xray.spine-filters :as spine-filters]
             [day8.re-frame2-xray.static.mode-pill :as mode-pill]
             [day8.re-frame2-xray.static.shell :as static-shell]
@@ -2380,10 +2380,10 @@
     ;; gate.
     [app-db-segment-inspector/Popup]
     ;; Data-display popup stack (rf2-l4625) — overlay surface for the
-    ;; "open in popup" affordance on per-panel `[dd/data-display]`
-    ;; mounts. Reads `:rf.xray.data-display-popup/stack` + `/entries`;
+    ;; "open in popup" affordance on per-panel `[ei/edn-inspector]`
+    ;; mounts. Reads `:rf.xray.edn-inspector-popup/stack` + `/entries`;
     ;; renders nothing when the stack is empty (closed-state cost is
     ;; one subscribe + a when-gate). Mount discipline matches the
     ;; other modal stacks: shell-root mount so the stack's subscribes
     ;; resolve through the shell's `:rf/xray` frame-provider.
-    [data-display-popup/data-display-popup-stack]]]))
+    [edn-inspector-popup/edn-inspector-popup-stack]]]))

--- a/tools/xray/src/day8/re_frame2_xray/theme/tokens.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/theme/tokens.cljc
@@ -179,6 +179,39 @@
    ;; stays AA-grade.
    :red-deep       "#a83a3a"
 
+   ;; ── diff row chrome (rf2-awqts) ──
+   ;; Diff signalling moved off the per-token text-colour channel so
+   ;; type semantics (`:syntax-*`) stay legible inside changed rows.
+   ;; Operator's eye reads diff at row-level (gutter glyph + wash +
+   ;; stripe); syntax at token-level (numbers orange, booleans gold,
+   ;; keywords magenta, etc.). Matches GitHub's diff convention:
+   ;; changed lines get a green/red wash; code inside keeps its
+   ;; syntax highlighting.
+   ;;
+   ;; `:diff-gutter` — single reserved hue for the `~/+/-/◴` gutter
+   ;; glyphs. Cyan-teal sits OUTSIDE every `:syntax-*` family (no
+   ;; magenta / green / orange / gold / blue collision) so the
+   ;; operator never confuses "this is a number" with "this changed".
+   ;;
+   ;; `:diff-*-wash` — low-opacity row backgrounds tinted per op.
+   ;; Stripe family carries the saturated 2px left-edge accent in the
+   ;; same hue family — reinforces the row-level signal at the
+   ;; column-1 anchor without competing with text colour.
+   ;; Wash values use 8-digit hex (#RRGGBBAA) so the palette-hex-map
+   ;; invariant holds — the var-resolution gate (rf2-on4cm) requires
+   ;; every value match `^#[0-9A-Fa-f]+$`. Alpha bytes:
+   ;;   `1a` = 26/255 ≈ 10%  (added / removed)
+   ;;   `1f` = 31/255 ≈ 12%  (modified — slightly stronger to clear
+   ;;                         the operator's foveal threshold on the
+   ;;                         most-common diff op)
+   :diff-gutter         "#5fbcb6"           ; cyan-teal (no syntax-* collision)
+   :diff-added-wash     "#3fb9501a"          ; :green   @ ~10%
+   :diff-modified-wash  "#d299221f"          ; :yellow  @ ~12%
+   :diff-removed-wash   "#f851491a"          ; :red     @ ~10%
+   :diff-added-stripe   "#3fb950"            ; :green   solid
+   :diff-modified-stripe "#d29922"           ; :yellow  solid
+   :diff-removed-stripe "#f85149"            ; :red     solid (= :error)
+
    ;; Universal white — readable on the brand/mode accent + the deep
    ;; reds. Catalogued here so the few "white text on coloured
    ;; surface" spots (primary / danger buttons) flow through tokens
@@ -274,6 +307,23 @@
    ;; On the light canvas the danger button stays close to the
    ;; semantic red — depth is signalled by saturation, not lightness.
    :red-deep       "#9A3030"
+
+   ;; ── diff row chrome (rf2-awqts) ──
+   ;; Light-theme mirror of the dark-palette diff tokens. See the dark
+   ;; palette's `:diff-*` block for the contract + rationale.
+   ;; `:diff-gutter` darkens to clear WCAG AA on the white canvas;
+   ;; wash opacities stay around 10-12% so the tinge reads as an
+   ;; environmental cue, not as obscuring the text.
+   ;; 8-digit hex (#RRGGBBAA) for the wash values per the dark-palette
+   ;; pattern; light-theme wash colours land 10-12% over a near-white
+   ;; canvas so even a 10% green reads with operator-noticeable tinge.
+   :diff-gutter         "#178f86"           ; teal (darker for AA on white)
+   :diff-added-wash     "#1a7f371a"          ; :green  @ ~10%
+   :diff-modified-wash  "#9a67001f"          ; :yellow @ ~12%
+   :diff-removed-wash   "#c844441a"          ; :red    @ ~10%
+   :diff-added-stripe   "#1a7f37"            ; :green  solid
+   :diff-modified-stripe "#9a6700"           ; :yellow solid
+   :diff-removed-stripe "#cf222e"            ; :red    solid (= :error)
 
    :white          "#ffffff"})
 

--- a/tools/xray/src/day8/re_frame2_xray/theme/tokens.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/theme/tokens.cljc
@@ -128,8 +128,8 @@
    :info           "#79c0ff"   ; cool categorical blue ≠ accent (Figma syntax-number)
 
    ;; ── syntax-highlighter palette (rf2-79ojx · One Dark / Calva default) ──
-   ;; Dedicated tokens for CLJS-value rendering in the data-display widget
-   ;; (`views/data_display.cljs`) AND the in-bundle Clojure source-text
+   ;; Dedicated tokens for CLJS-value rendering in the edn-inspector widget
+   ;; (`views/edn_inspector.cljs`) AND the in-bundle Clojure source-text
    ;; highlighter (`views/edn_widget/widget.cljs`). One palette, shared by
    ;; both surfaces, so a `:foo` keyword in the source-text panel paints
    ;; the same hue as `:foo` rendered as a value in the App-DB panel.

--- a/tools/xray/src/day8/re_frame2_xray/views/data_display.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/data_display.cljs
@@ -443,17 +443,69 @@
    :same     " "})
 
 (def op->gutter-tone-key
-  "Per-op token-key for the gutter glyph + 3px left border colour."
-  {:added    :green
-   :removed  :red
-   :modified :yellow
-   :children :accent
+  "Per-op token-key for the gutter GLYPH colour.
+
+  rf2-awqts — every diff-active op now reads the SAME reserved
+  `:diff-gutter` token (cyan-teal in dark / darker-teal in light); the
+  glyph carries the per-op shape (`+ / - / ~ / ◴`) and the row wash
+  carries the per-op hue. Pre-fix the glyph colour mapped per-op to
+  `:green` / `:red` / `:yellow` / `:accent`, which collided with the
+  Calva-aligned `:syntax-*` palette (numbers orange ≡ modified yellow,
+  booleans gold ≡ modified yellow, etc.) — the operator could not
+  distinguish 'this is a number' from 'this is modified'. The reserved
+  diff-gutter hue sits outside every `:syntax-*` family by design.
+
+  `:same` keeps `:text-tertiary` so the transparent-border non-diff
+  shape composes unchanged."
+  {:added    :diff-gutter
+   :removed  :diff-gutter
+   :modified :diff-gutter
+   :children :diff-gutter
    :same     :text-tertiary})
 
+(def op->row-wash-key
+  "Per-op token-key for the row-background wash. rf2-awqts —
+  GitHub-style low-opacity tinge across the whole diff row, so the eye
+  reads diff state at row level while per-token text colour reads type
+  semantics. `:same` and `:children` get NO wash (`nil`) — the row sits
+  flush with the canvas. Public so tests can assert the mapping
+  without re-deriving."
+  {:added    :diff-added-wash
+   :removed  :diff-removed-wash
+   :modified :diff-modified-wash
+   :children nil
+   :same     nil})
+
+(def op->row-stripe-key
+  "Per-op token-key for the 2px left-edge stripe. Reinforces the row
+  wash at the column-1 anchor — same hue family, more saturated.
+  `:same` and `:children` produce a transparent stripe."
+  {:added    :diff-added-stripe
+   :removed  :diff-removed-stripe
+   :modified :diff-modified-stripe
+   :children nil
+   :same     nil})
+
 (defn- gutter-colour
-  "Resolve the gutter colour for an op via the token table."
+  "Resolve the gutter GLYPH colour for an op via the token table.
+  rf2-awqts — every active op reads `:diff-gutter`; `:same` reads
+  `:text-tertiary`."
   [op]
   (get tokens (op->gutter-tone-key op) (:text-tertiary tokens)))
+
+(defn- row-wash-bg
+  "Resolve the per-op row-background wash CSS string (or `nil` when no
+  wash applies). rf2-awqts."
+  [op]
+  (when-let [k (get op->row-wash-key op)]
+    (get tokens k)))
+
+(defn- row-stripe-colour
+  "Resolve the per-op 2px-stripe CSS string (or `nil` when no stripe
+  applies). rf2-awqts."
+  [op]
+  (when-let [k (get op->row-stripe-key op)]
+    (get tokens k)))
 
 (defn- container-op
   "Classify a container's diff op given (before, after). Returns
@@ -468,10 +520,31 @@
     :else                                      :same))
 
 (defn- gutter-row
-  "Wrap `body` with the diff gutter (3px left border + glyph). When
-  the op is `:same` the wrapper is invisible (transparent border, blank
-  glyph) so non-diff renders share the same hiccup shape as diff
-  renders.
+  "Wrap `body` with the diff row chrome: gutter glyph + low-opacity
+  row-background wash + 2px left-edge stripe (rf2-awqts).
+
+  ## What lives on what channel
+
+  - **Gutter glyph colour** (`:diff-gutter`, reserved cyan-teal) —
+    NEVER changes per op; carries 'this is a diff row' semantic.
+    Distinct from every `:syntax-*` family so per-token text colour
+    (`:syntax-number` orange, `:syntax-boolean` gold, `:syntax-
+    keyword` magenta, etc.) stays UNCONFLATED with diff state.
+  - **Gutter glyph shape** (`+ / - / ~ / ◴`) — per-op semantic.
+  - **Row wash** (low-alpha background tint per op) — added=green,
+    modified=amber, removed=red. ~10-12% opacity reads as
+    environmental, not obscuring.
+  - **Left-edge stripe** (2px saturated per-op accent) — reinforces
+    the row signal at the column-1 anchor without competing with text
+    colour.
+  - **Per-token text colour** — preserved as the `:syntax-*` palette
+    output; the diff path no longer overrides it.
+
+  When the op is `:same` the wrapper is invisible (transparent stripe,
+  no wash, blank glyph) so non-diff renders share the same hiccup
+  shape as diff renders. `:children` op (ancestor of a changed
+  descendant) gets the gutter glyph but NO wash + NO stripe — the
+  changed descendants below carry the colour-coded signal.
 
   ## rf2-1bra5 — inline-flex, not flex
 
@@ -486,16 +559,30 @@
   Returns an `[:span ...]` (display: inline-flex) so it nests inside a
   grid cell without breaking the row."
   [op body]
-  (let [active? (not= :same op)]
+  (let [active? (not= :same op)
+        wash    (row-wash-bg op)
+        stripe  (row-stripe-colour op)]
     [:span {:data-rf-diff-op (name op)
-            :style {:display      "inline-flex"
-                    :align-items  "baseline"
-                    :gap          "4px"
-                    :padding-left "6px"
-                    :border-left  (str "3px solid "
-                                       (if active?
-                                         (gutter-colour op)
-                                         "transparent"))}}
+            :data-rf-diff-wash (when wash "1")
+            :data-rf-diff-stripe (when stripe "1")
+            :style (cond-> {:display      "inline-flex"
+                            :align-items  "baseline"
+                            :gap          "4px"
+                            :padding-left "6px"
+                            ;; rf2-awqts — stripe colour comes from
+                            ;; `:diff-*-stripe`; on `:same` / `:children`
+                            ;; the border stays transparent so the row
+                            ;; chrome aligns column-wise without paint.
+                            :border-left  (str "2px solid "
+                                               (if (and active? stripe)
+                                                 stripe
+                                                 "transparent"))}
+                     ;; rf2-awqts — row wash applied as background on
+                     ;; the wrapping span so the tint extends behind
+                     ;; both gutter glyph + value. Opacity baked into
+                     ;; the token's rgba() string (~10-12%) so the
+                     ;; wash reads as environmental, not obscuring.
+                     wash (assoc :background wash))}
      [:span {:style {:flex          "0 0 12px"
                      :color         (gutter-colour op)
                      :font-family   mono-stack
@@ -1535,16 +1622,30 @@
             body])]))))
 
 (defn- render-leaf-with-diff
-  "Render a scalar leaf, wrapped in the diff gutter when `diff?` is
-  truthy. Returns hiccup `[:div ...]` for diff renders (so the gutter
-  row can layout) or the bare `[:span ...]` for non-diff (so inline
-  composition continues to work).
+  "Render a scalar leaf, wrapped in the diff row chrome when `diff?`
+  is truthy. Returns hiccup; the gutter-row wrapper paints wash +
+  stripe + glyph at the row level while the inner `render-scalar`
+  paints per-token syntax colour at the token level.
 
-  - `:added`    — render `value`   in green, gutter `+`
-  - `:removed`  — render `before`  in red, strike-through, gutter `-`
-  - `:modified` — render `value`   in yellow + `← changed from <prior>`
-                  chip, gutter `~`
-  - `:same`     — render `value` (dimmed when `diff?` is true so the
+  rf2-awqts — per-token text colour is PRESERVED across all diff ops.
+  Pre-fix `:added` overrode to `:green` text, `:removed` to `:red`,
+  `:modified` to `:yellow` — those clashed with the Calva-aligned
+  `:syntax-*` palette (numbers orange ≡ modified yellow, booleans
+  gold ≡ modified yellow). Now the row chrome (wash + stripe + glyph)
+  carries the diff signal; the scalar's `:syntax-*` colour reads
+  type semantics unchanged.
+
+  Op-specific text decorations (e.g. `:removed` strike-through, the
+  `← changed from <prior>` chip on `:modified`) survive because they
+  are non-colour signals — strike-through is a TEXT-DECORATION
+  channel; the chip is a separate inline element.
+
+  - `:added`    — render `value`,  gutter `+`, green wash + stripe
+  - `:removed`  — render `before` (strike-through), gutter `-`,
+                  red wash + stripe
+  - `:modified` — render `value` + `← changed from <prior>` chip,
+                  gutter `~`, amber wash + stripe
+  - `:same`     — render `value` (dimmed via `:text-tertiary` so the
                   eye lands on the changes)"
   [{:keys [value before diff?]}]
   (if-not diff?
@@ -1554,14 +1655,20 @@
         :added
         (gutter-row :added
                     [:span {:data-rf-diff-op "added"
-                            :style {:color (:green tokens)
-                                    :font-family mono-stack}}
+                            :style {:font-family mono-stack}}
+                     ;; rf2-awqts — render-scalar paints per-token
+                     ;; syntax colour; wash + stripe carry the diff
+                     ;; signal at the row level.
                      (render-scalar value)])
         :removed
         (gutter-row :removed
                     [:span {:data-rf-diff-op "removed"
-                            :style {:color (:red tokens)
-                                    :font-family mono-stack
+                            :style {:font-family mono-stack
+                                    ;; rf2-awqts — strike-through is a
+                                    ;; non-colour signal that survives
+                                    ;; the move to row chrome; keep it
+                                    ;; so a removed leaf still reads as
+                                    ;; deleted at the glyph level.
                                     :text-decoration "line-through"}}
                      (render-scalar before)])
         :modified
@@ -1570,14 +1677,23 @@
                             :style {:display "inline-flex"
                                     :align-items "baseline"
                                     :flex-wrap "wrap"
-                                    :gap "4px"}}
-                     [:span {:style {:color (:yellow tokens)
-                                     :font-family mono-stack}}
-                      (render-scalar value)]
+                                    :gap "4px"
+                                    :font-family mono-stack}}
+                     ;; rf2-awqts — drop the per-leaf colour override;
+                     ;; render-scalar emits the value with its
+                     ;; `:syntax-*` token colour intact.
+                     (render-scalar value)
                      (change-annotation before)])
         :same
         (gutter-row :same
                     [:span {:data-rf-diff-op "same"
+                            ;; rf2-awqts — `:same` keeps the dim
+                            ;; `:text-tertiary` override on purpose:
+                            ;; in a diff context the unchanged rows
+                            ;; SHOULD recede so the eye lands on the
+                            ;; changes. This is the only op where the
+                            ;; diff path still tints text colour, and
+                            ;; the choice is dimming-not-replacing.
                             :style {:color (:text-tertiary tokens)
                                     :font-family mono-stack}}
                      (render-scalar value)])))))

--- a/tools/xray/src/day8/re_frame2_xray/views/data_display.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/data_display.cljs
@@ -48,10 +48,24 @@
                     a stable site-id does not). Omit to keep the per-
                     call-site isolation default (two `[data-display]`
                     mounts side-by-side stay independent).
-  - `:default-expanded-depth` (optional, default 2) — first-render
-                    expansion depth before operator clicks.
-  - `:max-inline-width` (optional, default 60) — character budget
-                    before forced-vertical layout.
+  - `:default-expanded-depth` (optional, default 8) — rf2-kbdk8: now an
+                    EXPAND CEILING rather than a trigger. The widget
+                    NEVER auto-expands past this depth — deeper nodes
+                    render as a `▸ {…N keys}` collapsed summary unless
+                    the operator clicks. Under the width-aware
+                    heuristic shallow nodes inline whenever their full
+                    `pr-str` fits the measured column; the depth ceiling
+                    only protects against pathological wide-and-deep
+                    auto-expansion when measurements are unavailable.
+                    Default raised from 2 → 8 to reflect the new
+                    semantic; tests that explicitly pass
+                    `:default-expanded-depth 2` (or any number) get the
+                    legacy depth-driven behaviour unchanged when no
+                    width measurement has arrived.
+  - `:max-inline-width` (optional, default 60) — character budget for
+                    the COLLAPSED-PREVIEW one-liner (`▸ {:a 1, :b 2,
+                    …}` style); leaves the width-aware inline decision
+                    to `available-width-px` (the measured column).
   - `:max-depth` (optional, default 16) — hard cap on recursion
                     depth; deeper levels render `{…}` collapsed.
   - `:before` (optional) — when supplied, the widget renders in DIFF
@@ -216,6 +230,48 @@
 (rf/reg-event-db :rf.xray.data-display/reset-expansion
   (fn [db _]
     (dissoc db expansion-slot)))
+
+;; =========================================================================
+;; available-width capture — per-mount measurement for the width-aware
+;; expansion heuristic (rf2-kbdk8)
+;; =========================================================================
+;;
+;; The widget measures its container's `clientWidth` via a `:ref` callback
+;; and stores the result keyed by `mount-id` under this app-db slot. A
+;; ResizeObserver, installed when the container element mounts, updates the
+;; slot whenever the panel resizes — wider → more collections render inline;
+;; narrower → more expand.
+;;
+;; Per-mount keying lets two sibling mounts in the same panel record
+;; different widths without colliding (e.g. a multi-column comparison panel
+;; where each column hosts its own inspector).
+;;
+;; When no measurement is yet present (first render before the ref fires,
+;; or a programmatic test render that doesn't mount), the widget falls
+;; back to the legacy strict inline-fit gate — the heuristic improvement
+;; is additive and graceful.
+
+(def widths-slot
+  "App-db slot holding the per-mount measured container widths in CSS
+  pixels (map of `mount-id` → integer). Public so tests + consuming
+  panels can drive measurements deterministically without spinning up a
+  real DOM."
+  :rf.xray.data-display/widths)
+
+(rf/reg-sub widths-slot
+  (fn [db _] (get db widths-slot)))
+
+(rf/reg-event-db :rf.xray.data-display/set-width
+  (fn [db [_ mount-id width-px]]
+    (if (and (string? mount-id) (number? width-px) (pos? width-px))
+      (assoc-in db [widths-slot mount-id] (long width-px))
+      db)))
+
+(rf/reg-event-db :rf.xray.data-display/clear-width
+  (fn [db [_ mount-id]]
+    (if (and (string? mount-id) (some-> db (get widths-slot) (contains? mount-id)))
+      (update db widths-slot dissoc mount-id)
+      db)))
 
 (defn resolve-expanded?
   "Pure projection — given the per-render expansion map, the path,
@@ -756,22 +812,136 @@
     :else        [:span {:style (token-style :text-primary)}
                   (try (pr-str k) (catch :default _ (str k)))]))
 
-(defn- default-expanded?
-  "Pure depth/size heuristic — shallow nodes expand, deep + wide
-  nodes collapse. The operator's sticky override wins via
-  `resolve-expanded?`.
+;; =========================================================================
+;; width-aware expansion heuristic (rf2-kbdk8)
+;; =========================================================================
+;;
+;; The closed-renderer's auto-expansion was depth-driven — any container
+;; within `default-expanded-depth` opened automatically regardless of how
+;; trivially its inline form would fit the available column width. Result:
+;; short values rendered as 8-9 row trees that consumed ~9× the vertical
+;; real-estate of their inline equivalents.
+;;
+;; The new heuristic flips the test: render inline FIRST when the value's
+;; estimated inline width fits the available column (with a small safety
+;; margin); only fall back to tree-expand when the inline form would
+;; overflow. `default-expanded-depth` is repurposed as a CEILING — never
+;; auto-expand past depth N even when the inline form overflows; show a
+;; collapsed-summary instead. The operator's sticky override and diff-
+;; mode's force-open-over-changed-descendant rule still win.
+;;
+;; Width is estimated by `(* char-count mono-char-width-px)` — JetBrains
+;; Mono / Source Code Pro at the inspector's 12px size carries an
+;; ~7.2px-wide M-advance; rounding up to 7px gives a slightly conservative
+;; estimate (real strings render a hair narrower, so the inline gate is
+;; slightly stricter than the actual fit — never the reverse, which would
+;; cause horizontal overflow).
+;;
+;; A `safety-margin-px` of 16px guards against edge-case wrap (a few extra
+;; pixels for the closing bracket, gutter, scroll-bar reserve). Tested live
+;; against the Handler panel dispatch-section mount (rf2-kbdk8 bead body):
+;; the 81-char `[:ws/connection [:rf.machine.timer/after-elapsed 2501
+;; [:active :authenticating]]]` value at ~570px estimate fits trivially in
+;; the 966px column and now renders inline at one row (was 148px / 8-9 rows).
+
+(def mono-char-width-px
+  "Monospace M-advance in CSS pixels at the inspector's 12px font size.
+  JetBrains Mono / Source Code Pro / DejaVu Sans Mono all sit in the
+  7.0-7.3px range; 7px is the rounded-up conservative pick so the inline
+  fit-gate slightly under-estimates the available room, never over-
+  estimates. Public so tests can pin the math without re-deriving it."
+  7)
+
+(def safety-margin-px
+  "Pixel headroom reserved against the measured `available-width` before
+  the inline gate fires. Covers the closing bracket, key-column gutter
+  for nested rows, optional scrollbar reserve. 16px is the pre-alpha
+  pick — tuned by eye against running panels (rf2-kbdk8). Public for the
+  same reason as `mono-char-width-px`."
+  16)
+
+(def default-ceiling-depth
+  "Replacement default for the `:default-expanded-depth` opt under the
+  width-aware heuristic (rf2-kbdk8). The opt is now a CEILING beyond
+  which the widget never auto-expands even if the inline form overflows
+  — it shows a collapsed `▸ {…N keys}` summary instead. The old default
+  of 2 functioned as a TRIGGER (expand the first two levels regardless
+  of fit); the new default 8 lets the width heuristic do its job at
+  shallow depths while still protecting against pathological deep
+  auto-expansion in rare cases.
+
+  Public so tests can assert the new default without re-deriving it."
+  8)
+
+(defn estimated-inline-px
+  "Estimate the inline-rendered width of `value` in CSS pixels. Pure
+  function — `pr-str` length × `mono-char-width-px`. Returns 0 when
+  `pr-str` throws (cyclic value, broken pr-method). Public so tests
+  + future width-aware callers can probe the estimate without re-
+  deriving the math."
+  [value]
+  (try
+    (* mono-char-width-px (count (pr-str value)))
+    (catch :default _ 0)))
+
+(defn would-fit-inline?
+  "True when the estimated inline width of `value` fits the
+  `available-width-px` with the safety margin. When `available-width-
+  px` is `nil` / non-positive (no measurement yet), returns `false` so
+  the widget falls back to the legacy strict inline-fit gate.
+
+  Pure function — no DOM, no rf reads. Public so tests can drive the
+  decision deterministically."
+  [value available-width-px]
+  (boolean
+    (and (number? available-width-px)
+         (pos? available-width-px)
+         (<= (+ (estimated-inline-px value) safety-margin-px)
+             available-width-px))))
+
+(defn default-expanded?
+  "Pure depth/size/width heuristic — collections render inline when
+  their estimated inline form fits the available column width; deeper
+  / wider collections expand to tree form. The operator's sticky
+  override wins via `resolve-expanded?`.
 
   In diff mode, a container with a changed descendant force-expands
   regardless of depth — operator never has to drill to find the
-  change (spec/021 §10.4)."
-  [{:keys [depth child-count default-expanded-depth
+  change (spec/021 §10.4).
+
+  rf2-kbdk8: `default-expanded-depth` is the EXPAND CEILING — never
+  auto-expand past depth N (show a collapsed summary instead). When no
+  available-width is yet measured the legacy depth-driven path runs as
+  the fallback so unit tests + first-paint behaviour stay deterministic."
+  [{:keys [depth child-count default-expanded-depth available-width-px value
            has-changed-descendant?]
-    :or   {default-expanded-depth 2}}]
+    :or   {default-expanded-depth default-ceiling-depth}}]
   (cond
-    has-changed-descendant?                 true
-    (<= depth (dec default-expanded-depth)) true
-    (= depth default-expanded-depth)        (<= (or child-count 0) 10)
-    :else                                   false))
+    has-changed-descendant?
+    true
+
+    ;; Width-aware path — once a measurement exists, width drives the
+    ;; decision. Containers that fit inline DON'T auto-expand (caller's
+    ;; `inline-fit?` gate picks up the slack and renders the inline form);
+    ;; containers that DON'T fit auto-expand up to the ceiling, then show
+    ;; a collapsed summary beyond.
+    (and (number? available-width-px) (pos? available-width-px))
+    (cond
+      (would-fit-inline? value available-width-px) false
+      (<= depth (dec default-expanded-depth))      true
+      :else                                        false)
+
+    ;; Legacy depth-driven fallback for the no-measurement path. Kept
+    ;; deterministic so unit tests that drive `render-node` without a
+    ;; mount measurement reproduce the historical behaviour.
+    (<= depth (dec default-expanded-depth))
+    true
+
+    (= depth default-expanded-depth)
+    (<= (or child-count 0) 10)
+
+    :else
+    false))
 
 (defn- testid-for
   "Compose a stable data-testid for a node — `[panel-id mount-id path]`."
@@ -892,6 +1062,87 @@
             :data-rf-preview "1"}
      preview]))
 
+;; =========================================================================
+;; recursive inline rendering — width-aware path (rf2-kbdk8)
+;; =========================================================================
+;;
+;; When the value's estimated inline width fits the available column
+;; (computed by `would-fit-inline?`), the widget renders the WHOLE thing
+;; inline as a one-line hiccup span — including nested containers. The
+;; legacy strict inline-fit gate (≤3 children + all-scalars) is kept as a
+;; pre-measurement fallback so unit tests without a width measurement
+;; reproduce the historical behaviour; once a measurement exists the
+;; recursive renderer takes over and handles the deep-but-skinny case.
+;;
+;; Per-token syntax colour is preserved through the recursion — scalars
+;; route through `render-scalar`; brackets pick up their kind's tone-key;
+;; the comma separator stays on `:text-tertiary` so structure punctuation
+;; reads as secondary chrome. No expansion state, no toggle — once the
+;; whole tree fits inline the entire value is already visible; the
+;; operator's `▸` / `▾` interaction lives on the surrounding container
+;; widget (top-level mount), not on every nested child.
+
+(declare render-inline-recursive)
+
+(defn- render-inline-pair
+  "Render a single map / record entry `[k v]` as a key+value sequence
+  for the inline render path. Returns a seq of hiccup fragments (no
+  enclosing span — caller weaves separators)."
+  [k v]
+  [(key-segment k)
+   [:span {:style (token-style :text-tertiary)} " "]
+   (render-inline-recursive v)])
+
+(defn render-inline-recursive
+  "Render `value` as a single-line inline hiccup `[:span ...]`. Handles
+  nested containers by recursing — brackets, separators, and scalars
+  all paint with their full syntax-palette colour.
+
+  Pure function — no expansion state, no rf reads, no toggle. Safe to
+  call recursively to any depth (the width gate in
+  `render-container` ensures only width-fitting values reach this
+  path, so the recursion is naturally bounded by the operator's
+  measured column).
+
+  Public for unit tests."
+  [value]
+  (let [kind (collection-kind value)]
+    (cond
+      (not (container? kind))
+      (render-scalar value)
+
+      :else
+      (let [{:keys [open close tone-key]} (delim kind)
+            open-bracket
+            (cond->> open
+              (= kind :record) (str (record-tag value)))
+            bracket-span
+            (fn [text]
+              [:span {:style {:color       (get tokens tone-key)
+                              :font-family mono-stack}
+                      :data-rf-bracket "1"}
+               text])
+            sep
+            [:span {:style (token-style :text-tertiary)} ", "]
+            labelled? (#{:map :record :map-entry} kind)
+            pairs     (children-of value)
+            item-children
+            (apply concat
+                   (map-indexed
+                     (fn [i [k cv]]
+                       (let [prefix (when (pos? i) [sep])
+                             body   (if labelled?
+                                      (render-inline-pair k cv)
+                                      [(render-inline-recursive cv)])]
+                         (concat prefix body)))
+                     pairs))]
+        (into [:span {:data-rf-inline    "1"
+                      :data-rf-kind      (name kind)
+                      :style {:font-family mono-stack
+                              :white-space "nowrap"}}
+               (bracket-span open-bracket)]
+              (concat item-children [(bracket-span close)]))))))
+
 (defn- render-container
   "Render a map / vector / list / set / record / map-entry container.
 
@@ -909,8 +1160,11 @@
                       ancestor chain over any changed descendant."
   [{:keys [value kind panel-id mount-id path depth expansion-map opts
            dispatch-fn diff? before]}]
-  (let [{:keys [default-expanded-depth max-depth max-inline-width]
-         :or {default-expanded-depth 2 max-depth 16 max-inline-width 60}} opts
+  (let [{:keys [default-expanded-depth max-depth max-inline-width
+                available-width-px]
+         :or {default-expanded-depth default-ceiling-depth
+              max-depth 16
+              max-inline-width 60}} opts
         cnt           (child-count value kind)
         empty?        (zero? cnt)
         depth-capped? (>= depth max-depth)
@@ -925,18 +1179,38 @@
                              {:depth                   depth
                               :child-count             cnt
                               :default-expanded-depth  default-expanded-depth
-                              :has-changed-descendant? has-change?}))
+                              :has-changed-descendant? has-change?
+                              :available-width-px      available-width-px
+                              :value                   value}))
         expanded?     (and (not empty?)
                            (not depth-capped?)
                            (resolve-expanded? expansion-map panel-id mount-id path default?))
-        inline-fit?   (and (not empty?)
-                           (not has-change?) ; never inline-fit a changed container
-                           (<= cnt 3)
-                           (every? (fn [[_ cv]]
-                                     (not (container? (collection-kind cv))))
-                                   (children-of value))
-                           (<= (count (inline-preview-string value 5 max-inline-width))
-                               max-inline-width))
+        ;; rf2-kbdk8 — width-aware inline-fit. When a measurement exists
+        ;; and the whole value's pr-str fits the available column, render
+        ;; the FULL tree inline (recursively). The legacy strict gate
+        ;; (≤3 children + all-scalars) remains as the pre-measurement
+        ;; fallback so unit tests + first-paint behaviour stay
+        ;; deterministic.
+        width-fits?   (and (not empty?)
+                           (not has-change?)
+                           (not depth-capped?)
+                           (would-fit-inline? value available-width-px))
+        legacy-inline? (and (not empty?)
+                            (not has-change?)
+                            (<= cnt 3)
+                            (every? (fn [[_ cv]]
+                                      (not (container? (collection-kind cv))))
+                                    (children-of value))
+                            (<= (count (inline-preview-string value 5 max-inline-width))
+                                max-inline-width))
+        ;; Sticky-override-aware: if the operator EXPLICITLY toggled this
+        ;; node open (`:expanded? true`), respect that — the inline gate
+        ;; only fires when the operator hasn't overridden.
+        operator-expanded?
+        (let [override (get expansion-map (expansion-key panel-id mount-id path))]
+          (and (contains? override :expanded?) (boolean (:expanded? override))))
+        inline-fit?   (and (not operator-expanded?)
+                           (or width-fits? legacy-inline?))
         ;; `dispatch-fn` is supplied by the reg-view'd outer body so
         ;; the toggle dispatch carries the surrounding frame. Tests
         ;; that drive render-node directly without mounting fall back
@@ -991,30 +1265,38 @@
         ;; bracket on one row, NO toggle (already exposed). Maps /
         ;; records render `key value` pairs; sequentials render values
         ;; only; sets render values only (no labelled key).
+        ;;
+        ;; rf2-kbdk8 — when `width-fits?` fires (a measurement is in play
+        ;; and the FULL pr-str fits the available column), defer to
+        ;; `render-inline-recursive` which handles nested containers in
+        ;; the same inline span. The legacy strict path (scalar-only
+        ;; children) still feeds the pre-measurement fallback.
         inline-fit?
-        (let [labelled? (#{:map :record :map-entry} kind)
-              pairs     (children-of value)]
-          (into [:span {:style {:display "inline-flex"
-                                :align-items "baseline"
-                                :flex-wrap "wrap"
-                                :gap "4px"}}
-                 (bracket kind :open value)]
-                (concat
-                  (apply concat
-                         (map-indexed
-                           (fn [i [k cv]]
-                             (let [sep (when (pos? i)
-                                         [:span {:style (token-style :text-tertiary)} ", "])
-                                   ks  (when labelled? (key-segment k))
-                                   sp  (when labelled?
-                                         [:span {:style (token-style :text-tertiary)} " "])]
-                               (cond-> []
-                                 sep (conj sep)
-                                 ks  (conj ks)
-                                 sp  (conj sp)
-                                 true (conj (render-scalar cv)))))
-                           pairs))
-                  [(bracket kind :close value)])))
+        (if width-fits?
+          (render-inline-recursive value)
+          (let [labelled? (#{:map :record :map-entry} kind)
+                pairs     (children-of value)]
+            (into [:span {:style {:display "inline-flex"
+                                  :align-items "baseline"
+                                  :flex-wrap "wrap"
+                                  :gap "4px"}}
+                   (bracket kind :open value)]
+                  (concat
+                    (apply concat
+                           (map-indexed
+                             (fn [i [k cv]]
+                               (let [sep (when (pos? i)
+                                           [:span {:style (token-style :text-tertiary)} ", "])
+                                     ks  (when labelled? (key-segment k))
+                                     sp  (when labelled?
+                                           [:span {:style (token-style :text-tertiary)} " "])]
+                                 (cond-> []
+                                   sep (conj sep)
+                                   ks  (conj ks)
+                                   sp  (conj sp)
+                                   true (conj (render-scalar cv)))))
+                             pairs))
+                    [(bracket kind :close value)]))))
 
         ;; Default — toggle glyph + open bracket (when expanded) OR summary.
         expanded?
@@ -1578,14 +1860,64 @@
         ;; recursive render-node descents) threads this closure so the
         ;; dispatch carries the right frame even when fired long after
         ;; render unwinds.
-        dispatch-fn dispatch]
+        dispatch-fn dispatch
+        ;; rf2-kbdk8 — width measurement state captured in the form-2
+        ;; closure so the ResizeObserver + ref callback persist across
+        ;; re-renders. `observer` holds the per-mount ResizeObserver
+        ;; instance (or nil before/after the lifecycle); `last-width`
+        ;; debounces redundant dispatches by remembering the last
+        ;; measurement we wrote — `clientWidth` returns fractional
+        ;; pixels rounded by the browser, so identical measurements
+        ;; arrive verbatim and should not churn the app-db slot.
+        observer    (atom nil)
+        last-width  (atom nil)
+        measure-and-dispatch
+        (fn [^js el]
+          (when el
+            (let [w (.-clientWidth el)]
+              (when (and (number? w) (pos? w) (not= @last-width w))
+                (reset! last-width w)
+                (dispatch-fn
+                  [:rf.xray.data-display/set-width mount-id w])))))
+        container-ref
+        (fn [^js el]
+          (cond
+            ;; Mount — measure once, install the observer.
+            (and el (nil? @observer))
+            (do
+              (measure-and-dispatch el)
+              (when (exists? js/ResizeObserver)
+                (let [obs (js/ResizeObserver.
+                            (fn [_entries]
+                              (measure-and-dispatch el)))]
+                  (.observe obs el)
+                  (reset! observer obs))))
+
+            ;; Unmount — tear down observer, clear the slot. The slot
+            ;; clear matters because the same mount-id may not recur
+            ;; (each fresh mount allocates a UUID); leaving stale entries
+            ;; in app-db is a slow leak.
+            (and (nil? el) @observer)
+            (do
+              (try (.disconnect ^js @observer)
+                   (catch :default _ nil))
+              (reset! observer nil)
+              (reset! last-width nil)
+              (dispatch-fn
+                [:rf.xray.data-display/clear-width mount-id]))))]
     (fn render-data-display
       [value & rest-args]
       (let [opts          (first rest-args)
             {:keys [panel-id site-id default-expanded-depth max-inline-width
                     max-depth before popup-affordance? card?]
              :or   {panel-id :rf.xray.data-display/anon
-                    default-expanded-depth 2
+                    ;; rf2-kbdk8 — default raised from 2 → 8. Under the
+                    ;; width-aware heuristic this opt is a CEILING (never
+                    ;; auto-expand past depth N), not a TRIGGER. The
+                    ;; legacy depth-driven path keeps the same number as
+                    ;; the maximum auto-open depth so deep tests still
+                    ;; reach their leaves before the measurement arrives.
+                    default-expanded-depth default-ceiling-depth
                     max-inline-width 60
                     max-depth 16
                     popup-affordance? false
@@ -1610,6 +1942,13 @@
             ;; injected by `reg-view` — reads the expansion-slot
             ;; from the surrounding frame's app-db (e.g. `:rf/xray`).
             expansion-map @(subscribe [expansion-slot])
+            ;; rf2-kbdk8 — read the measured container width keyed by
+            ;; THIS mount's id. Nil on the first render (the ref hasn't
+            ;; fired yet); subsequent renders see the width and the
+            ;; width-aware heuristic kicks in. ResizeObserver keeps the
+            ;; slot live across panel resizes.
+            widths        @(subscribe [widths-slot])
+            available-width-px (get widths mount-id)
             container-id  (str "rf-xray-data-display-"
                                (name panel-id) "-" mount-id)
             ;; Stable popup-mount-id derived from THIS data-display's
@@ -1623,6 +1962,13 @@
                :data-rf-mode    (if diff? "diff" "browse")
                :data-rf-popup-affordance? (when popup-affordance? "1")
                :data-rf-card     (when card? "1")
+               :data-rf-available-width-px (when available-width-px
+                                             (str available-width-px))
+               ;; rf2-kbdk8 — `:ref` callback drives the measurement.
+               ;; Captured once in the form-2 closure; React calls the
+               ;; same fn on mount + unmount so the observer's lifecycle
+               ;; mirrors the widget's DOM lifecycle.
+               :ref             container-ref
                :style (cond-> {:font-family mono-stack
                                :font-size   "12px"
                                :color       (:text-primary tokens)
@@ -1667,7 +2013,13 @@
                        :dispatch-fn dispatch-fn
                        :opts {:default-expanded-depth default-expanded-depth
                               :max-inline-width max-inline-width
-                              :max-depth max-depth}})]))))
+                              :max-depth max-depth
+                              ;; rf2-kbdk8 — threaded so every recursive
+                              ;; render-node decides expansion against
+                              ;; the same available column width. Nil
+                              ;; until the ref measures, after which
+                              ;; ResizeObserver keeps it live.
+                              :available-width-px available-width-px}})]))))
 
 (defn data-display-diff
   "Diff convenience — `[data-display-diff before after]` or

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
@@ -1,5 +1,5 @@
-(ns day8.re-frame2-xray.views.data-display
-  "Xray's first-class data-display widget — roll-your-own CLJS-value
+(ns day8.re-frame2-xray.views.edn-inspector
+  "Xray's first-class edn-inspector widget — roll-your-own CLJS-value
   renderer (rf2-oqa60 phase 1).
 
   ## What this is
@@ -19,7 +19,7 @@
   - `theme/data-inspector` — sentinels (`:rf/redacted`, `:rf/large`)
     become first-class types INSIDE this widget; the chrome wrapper
     goes away (D3=a per rf2-sndui).
-  - `data-display/render` — diff renderer subsumed (phase 5; D5=a per
+  - `edn-inspector/render` — diff renderer subsumed (phase 5; D5=a per
     rf2-sndui). The diff path is now an opt-in mode on this same
     widget — pass `:before` to render with gutter glyphs +
     `← changed from <prior>` annotations.
@@ -28,17 +28,17 @@
 
   ## Public API
 
-      [data-display value]                ;; browse (no diff)
-      [data-display value opts]           ;; browse / diff
-      [data-display-diff before after]    ;; diff convenience
-      [data-display-diff before after opts]
+      [edn-inspector value]                ;; browse (no diff)
+      [edn-inspector value opts]           ;; browse / diff
+      [edn-inspector-diff before after]    ;; diff convenience
+      [edn-inspector-diff before after opts]
 
       [mini value]              ;; one-line inline (no expansion)
       [mini value max-len]      ;; with width cap
 
   `opts` keys:
 
-  - `:panel-id`     (optional, default `:rf.xray.data-display/anon`)
+  - `:panel-id`     (optional, default `:rf.xray.edn-inspector/anon`)
                     distinguishes per-panel expansion state.
   - `:site-id`      (optional, rf2-pvsxs) — when supplied, becomes the
                     second component of the per-node expansion key
@@ -46,7 +46,7 @@
                     same logical call site survive a panel-leave-and-
                     return round-trip (auto-mount-id changes on remount;
                     a stable site-id does not). Omit to keep the per-
-                    call-site isolation default (two `[data-display]`
+                    call-site isolation default (two `[edn-inspector]`
                     mounts side-by-side stay independent).
   - `:default-expanded-depth` (optional, default 8) — rf2-kbdk8: now an
                     EXPAND CEILING rather than a trigger. The widget
@@ -81,7 +81,7 @@
                     true the widget renders a top-right ↗ icon button
                     (rf2-7sdja — was ⊕; ↗ reads as 'open in new pane')
                     that dispatches
-                    `[:rf.xray.data-display-popup/open mount-id payload]`
+                    `[:rf.xray.edn-inspector-popup/open mount-id payload]`
                     against `:rf/xray` explicitly (popup state is
                     Xray-global, not per-frame — rf2-7sdja). The popup-
                     mount-id is derived from this widget's own mount-
@@ -113,7 +113,7 @@
 
   ## Per-call-site isolation (rf2-sndui D4=a · rf2-pvsxs opt-out)
 
-  Each `[data-display …]` mount auto-assigns a UUID `mount-id` on
+  Each `[edn-inspector …]` mount auto-assigns a UUID `mount-id` on
   first render (captured in a form-2 outer `let`). Two mounts side-
   by-side in the same panel get independent expansion state. The
   expansion key is `[panel-id mount-id path]` by default.
@@ -130,7 +130,7 @@
 
   Substrate-agnostic — downstream adapters (Reagent, UIx, Helix) all
   see the same hiccup. The mount-id capture uses Reagent form-2
-  semantics in `data-display` itself (rf2 substrate is currently
+  semantics in `edn-inspector` itself (rf2 substrate is currently
   Reagent in tools); the rest of the renderer is pure data
   transformations + `rf/subscribe` reads.
 
@@ -170,25 +170,25 @@
             [re-frame.core :as rf]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens mono-stack sans-stack]]
-            [day8.re-frame2-xray.views.data-display-protocol :as ddp]
-            ;; rf2-x16b1 — load default IXrayDataDisplay formatters
+            [day8.re-frame2-xray.views.edn-inspector-protocol :as ddp]
+            ;; rf2-x16b1 — load default IXrayEdnInspector formatters
             ;; for uuid + inst. Requiring for side-effect (extend-type).
             ;; Consumers that extend the same types win — `extend-type`
             ;; installs the most-recently-loaded impl.
-            [day8.re-frame2-xray.views.data-display-default-formatters]))
+            [day8.re-frame2-xray.views.edn-inspector-default-formatters]))
 
 ;; =========================================================================
-;; expansion state — lives in :rf.xray.data-display/expansion under :rf/xray
+;; expansion state — lives in :rf.xray.edn-inspector/expansion under :rf/xray
 ;; =========================================================================
 
 (def expansion-slot
   "App-db slot holding the per-node expansion overrides. Public so
   the consuming panel's reset affordance can clear it.
 
-  Distinct from the legacy `:rf.xray/data-display-expansion` slot
-  used by `data-display/render` — keeping them separate lets the old
+  Distinct from the legacy `:rf.xray/edn-inspector-expansion` slot
+  used by `edn-inspector/render` — keeping them separate lets the old
   engine and the new widget coexist during the phased rollout."
-  :rf.xray.data-display/expansion)
+  :rf.xray.edn-inspector/expansion)
 
 (defn expansion-key
   "Compose the per-node expansion key. Pure data, JVM-portable."
@@ -198,7 +198,7 @@
 (rf/reg-sub expansion-slot
   (fn [db _] (get db expansion-slot)))
 
-(rf/reg-event-db :rf.xray.data-display/toggle-node
+(rf/reg-event-db :rf.xray.edn-inspector/toggle-node
   (fn [db [_ panel-id mount-id path rendered-expanded?]]
     ;; rf2-y59tb — first click MUST invert the currently-visible state.
     ;;
@@ -222,12 +222,12 @@
                     (not (boolean rendered-expanded?)))]
       (assoc-in db [expansion-slot k] {:expanded? next?}))))
 
-(rf/reg-event-db :rf.xray.data-display/set-node
+(rf/reg-event-db :rf.xray.edn-inspector/set-node
   (fn [db [_ panel-id mount-id path expanded?]]
     (assoc-in db [expansion-slot (expansion-key panel-id mount-id path)]
               {:expanded? (boolean expanded?)})))
 
-(rf/reg-event-db :rf.xray.data-display/reset-expansion
+(rf/reg-event-db :rf.xray.edn-inspector/reset-expansion
   (fn [db _]
     (dissoc db expansion-slot)))
 
@@ -256,18 +256,18 @@
   pixels (map of `mount-id` → integer). Public so tests + consuming
   panels can drive measurements deterministically without spinning up a
   real DOM."
-  :rf.xray.data-display/widths)
+  :rf.xray.edn-inspector/widths)
 
 (rf/reg-sub widths-slot
   (fn [db _] (get db widths-slot)))
 
-(rf/reg-event-db :rf.xray.data-display/set-width
+(rf/reg-event-db :rf.xray.edn-inspector/set-width
   (fn [db [_ mount-id width-px]]
     (if (and (string? mount-id) (number? width-px) (pos? width-px))
       (assoc-in db [widths-slot mount-id] (long width-px))
       db)))
 
-(rf/reg-event-db :rf.xray.data-display/clear-width
+(rf/reg-event-db :rf.xray.edn-inspector/clear-width
   (fn [db [_ mount-id]]
     (if (and (string? mount-id) (some-> db (get widths-slot) (contains? mount-id)))
       (update db widths-slot dissoc mount-id)
@@ -359,7 +359,7 @@
 ;; =========================================================================
 ;;
 ;; Phase 5 (rf2-q3dzw, D5=a per rf2-sndui) subsumes the legacy
-;; `data-display.render` diff engine into this widget. Diff is an
+;; `edn-inspector.render` diff engine into this widget. Diff is an
 ;; opt-in MODE on the same renderer: when the caller passes `:before`
 ;; the widget paints gutter glyphs + `← changed from <prior>`
 ;; annotations in place, force-expands the ancestor chain over any
@@ -652,7 +652,7 @@
                  (if (and nm (seq nm)) (str "#fn[" nm "]") "#fn"))]
     :sentinel-redacted
     [:span {:data-rf-type "rf-redacted"
-            :data-testid  "rf-xray-data-display-redacted"
+            :data-testid  "rf-xray-edn-inspector-redacted"
             :title        "Redacted — not revealable (spec/015)"
             :style {:display       "inline-flex"
                     :align-items   "center"
@@ -672,7 +672,7 @@
     :sentinel-redacted-size
     (let [{:keys [bytes]} (val (first v))]
       [:span {:data-rf-type "rf-redacted-size"
-              :data-testid  "rf-xray-data-display-redacted-size"
+              :data-testid  "rf-xray-edn-inspector-redacted-size"
               :title        "Redacted with size — not revealable (spec/015)"
               :style {:display       "inline-flex"
                       :align-items   "center"
@@ -695,7 +695,7 @@
     :sentinel-large
     (let [{:keys [bytes head]} (val (first v))]
       [:span {:data-rf-type "rf-large"
-              :data-testid  "rf-xray-data-display-large"
+              :data-testid  "rf-xray-edn-inspector-large"
               :title        (when head (str "Head preview: " head))
               :style {:display       "inline-flex"
                       :align-items   "center"
@@ -1033,7 +1033,7 @@
 (defn- testid-for
   "Compose a stable data-testid for a node — `[panel-id mount-id path]`."
   [panel-id mount-id path]
-  (str "rf-xray-data-display-"
+  (str "rf-xray-edn-inspector-"
        (name (or panel-id :anon))
        "-" mount-id
        (when (seq path) (str "-" (str/join "/" (map pr-str path))))))
@@ -1078,7 +1078,7 @@
 
 (def triangle-style
   "Inline-style map applied to every expand/collapse triangle (`▸`
-  / `▾`) the data-display widget renders (rf2-tzvk9). One source of
+  / `▾`) the edn-inspector widget renders (rf2-tzvk9). One source of
   truth so every triangle gets the SAME hit-box — three call sites
   (depth-capped, expanded ▾, collapsed ▸) and one diff-mode variant
   share this.
@@ -1135,7 +1135,7 @@
     (when e
       (.preventDefault e)
       (.stopPropagation e))
-    (dispatch-fn [:rf.xray.data-display/toggle-node
+    (dispatch-fn [:rf.xray.edn-inspector/toggle-node
                   panel-id mount-id path rendered-expanded?])))
 
 (defn- collapsed-summary
@@ -1580,7 +1580,7 @@
         (let [{:keys [close]} (delim kind)] close)])]))
 
 (defn- render-protocol-node
-  "Render a value that satisfies `IXrayDataDisplay` via the consumer's
+  "Render a value that satisfies `IXrayEdnInspector` via the consumer's
   protocol methods. Returns hiccup wrapping the consumer's header
   (and optional body) in the standard widget chrome — same testid
   + container-shape contract as the built-in renderer so panel
@@ -1703,7 +1703,7 @@
   expansion-map snapshot down. Returns hiccup. Pure projection of
   (value, expansion-map, opts) — no `rf/subscribe` calls in here.
 
-  Consults `IXrayDataDisplay` at the head — if `value` satisfies the
+  Consults `IXrayEdnInspector` at the head — if `value` satisfies the
   protocol AND the consumer's `-xray-render-header` returns non-nil
   hiccup, the protocol path wins. Otherwise falls through to the
   built-in container / scalar dispatch (phase 7 / rf2-0qrcr).
@@ -1728,7 +1728,7 @@
     ;; result falls through to built-ins. Bound to the same testid
     ;; contract as the built-in renderer so panel chrome doesn't shift.
     (when (and (not= value ::missing)
-               (ddp/satisfies-xray-data-display? value))
+               (ddp/satisfies-xray-edn-inspector? value))
       (render-protocol-node {:value value
                              :panel-id panel-id
                              :mount-id mount-id
@@ -1783,7 +1783,7 @@
                                   :diff? (boolean diff?)}))))))
 
 ;; =========================================================================
-;; mount-id generator + public entry — data-display (form-2 component)
+;; mount-id generator + public entry — edn-inspector (form-2 component)
 ;; =========================================================================
 
 (defn- gen-mount-id
@@ -1798,13 +1798,13 @@
 ;; popup affordance — opt-in "open in popup" control (rf2-l4625)
 ;; =========================================================================
 ;;
-;; When a `[data-display value opts]` call site passes
+;; When a `[edn-inspector value opts]` call site passes
 ;; `:popup-affordance? true` in `opts`, the widget renders a small icon
 ;; button positioned at the top-right of the container. Click dispatches
 ;; the popup's `:open` event with a stable popup-mount-id derived from
-;; the data-display's own mount-id — so re-clicking just raises the
+;; the edn-inspector's own mount-id — so re-clicking just raises the
 ;; existing popup (window-manager "raise" semantics matching
-;; `data-display-popup/push-entry`).
+;; `edn-inspector-popup/push-entry`).
 ;;
 ;; Opt-in (not always-on): scalar / tiny-value mounts don't benefit from
 ;; a larger inspection surface. Panels enable the affordance where the
@@ -1819,7 +1819,7 @@
 ;;
 ;; The affordance dispatches the OPEN event id literally — no `require`
 ;; on the popup ns from here, which would form a cycle (the popup ns
-;; requires data-display). The event id keyword is the public contract.
+;; requires edn-inspector). The event id keyword is the public contract.
 
 (def ^:private popup-affordance-button-style
   {:position      "absolute"
@@ -1852,13 +1852,13 @@
   The popup OPEN event dispatches against `:rf/xray` EXPLICITLY via
   the established `(rf/dispatch event {:frame :rf/xray})` pattern
   (matches `settings/view.cljs` + `app_db_segment_inspector.cljs`).
-  Other data-display dispatches (`:rf.xray.data-display/toggle-node`)
+  Other edn-inspector dispatches (`:rf.xray.edn-inspector/toggle-node`)
   use the lexically-captured `dispatch-fn` because expansion state is
   per-frame — the widget can be mounted in any frame and the toggle
   dispatch must land in the SURROUNDING frame's app-db so the
   expansion-slot subscription sees the write.
 
-  Popup state is different: the popup stack-view (`data-display-popup-
+  Popup state is different: the popup stack-view (`edn-inspector-popup-
   stack` in `shell.cljs`) is mounted inside `[rf/frame-provider
   {:frame :rf/xray}]` and subscribes ONLY against `:rf/xray`'s
   app-db. If a popup-open dispatch leaks to `:rf/default` (or any
@@ -1877,7 +1877,7 @@
   router."
   [_dispatch-fn popup-mount-id value opts]
   [:button
-   {:data-testid             (str "rf-xray-data-display-popup-affordance-"
+   {:data-testid             (str "rf-xray-edn-inspector-popup-affordance-"
                                   popup-mount-id)
     :data-rf-affordance      "popup"
     :data-rf-popup-mount-id  popup-mount-id
@@ -1895,14 +1895,14 @@
                                ;; subscribes against `:rf/xray`)
                                ;; sees the write.
                                (rf/dispatch
-                                 [:rf.xray.data-display-popup/open
+                                 [:rf.xray.edn-inspector-popup/open
                                   popup-mount-id
                                   {:value value
                                    :opts  (-> (or opts {})
                                               ;; Don't recurse the
                                               ;; affordance inside the
                                               ;; popup's embedded
-                                              ;; data-display.
+                                              ;; edn-inspector.
                                               (assoc :popup-affordance? false))}]
                                  {:frame :rf/xray}))
     :style                   popup-affordance-button-style}
@@ -1912,11 +1912,11 @@
    ;; aria-label / title — the glyph swap is visual only.
    "↗"])
 
-(rf/reg-view data-display
-  "First-class data-display widget — single source of truth for
+(rf/reg-view edn-inspector
+  "First-class edn-inspector widget — single source of truth for
   browse + diff + mini.
 
-  Pass `[data-display value]` or `[data-display value opts]`. The
+  Pass `[edn-inspector value]` or `[edn-inspector value opts]`. The
   `opts` map carries `:panel-id`, `:default-expanded-depth`,
   `:max-inline-width`, `:max-depth`, `:before` — see the ns
   docstring for the full key inventory.
@@ -1924,7 +1924,7 @@
   - Browse mode (default): no `:before` opt; the widget renders
     `value` with expand/collapse + sticky operator overrides.
   - Diff mode: pass `:before` in `opts` (or use the
-    `data-display-diff` 3-arg convenience). The widget renders
+    `edn-inspector-diff` 3-arg convenience). The widget renders
     `value` as the AFTER side with gutter glyphs +
     `← changed from <prior>` annotations, force-expands the
     ancestor chain over any changed descendant, and dims `:same`
@@ -1940,14 +1940,14 @@
   independent expansion state via the auto-id.
 
   Per-call-site isolation is the key correctness property here: two
-  `[data-display value]` mounts in the same panel must NOT share
+  `[edn-inspector value]` mounts in the same panel must NOT share
   expansion state. The form-2 closure delivers that — the outer body
   runs once per mount.
 
   ## rf2-y59tb — `reg-view`-registered so dispatch / subscribe inherit
   the surrounding frame
 
-  Before this fix `data-display` was a plain `defn`. Plain Reagent fns
+  Before this fix `edn-inspector` was a plain `defn`. Plain Reagent fns
   do not consult the `frame-provider` React context, so when the
   widget mounted under `:rf/xray` (App-DB panel) toggle dispatches and
   expansion-slot subscribes routed to `:rf/default` instead — the
@@ -1961,10 +1961,10 @@
   through `render-node` opts so callbacks deep in the recursion
   carry the same frame.
 
-  Call sites continue to read `[dd/data-display value opts]` — the
-  macro defs the `data-display` Var to the registered render fn, so
+  Call sites continue to read `[ei/edn-inspector value opts]` — the
+  macro defs the `edn-inspector` Var to the registered render fn, so
   the public API is unchanged. Call sites that omit `opts`
-  (`[dd/data-display value]`) flow the same way; Reagent passes the
+  (`[ei/edn-inspector value]`) flow the same way; Reagent passes the
   positional args from the hiccup vector to both the outer and inner
   fn, and the inner fn tolerates `opts=nil` via the destructure's
   `:or` defaults."
@@ -1994,7 +1994,7 @@
               (when (and (number? w) (pos? w) (not= @last-width w))
                 (reset! last-width w)
                 (dispatch-fn
-                  [:rf.xray.data-display/set-width mount-id w])))))
+                  [:rf.xray.edn-inspector/set-width mount-id w])))))
         container-ref
         (fn [^js el]
           (cond
@@ -2020,13 +2020,13 @@
               (reset! observer nil)
               (reset! last-width nil)
               (dispatch-fn
-                [:rf.xray.data-display/clear-width mount-id]))))]
-    (fn render-data-display
+                [:rf.xray.edn-inspector/clear-width mount-id]))))]
+    (fn render-edn-inspector
       [value & rest-args]
       (let [opts          (first rest-args)
             {:keys [panel-id site-id default-expanded-depth max-inline-width
                     max-depth before popup-affordance? card?]
-             :or   {panel-id :rf.xray.data-display/anon
+             :or   {panel-id :rf.xray.edn-inspector/anon
                     ;; rf2-kbdk8 — default raised from 2 → 8. Under the
                     ;; width-aware heuristic this opt is a CEILING (never
                     ;; auto-expand past depth N), not a TRIGGER. The
@@ -2046,7 +2046,7 @@
             ;; surface (e.g. App-DB tab switching) finds its prior
             ;; overrides under a stable key. When omitted, behaviour
             ;; is unchanged — auto-mount-id keeps per-call-site
-            ;; isolation for naive callers (two `[data-display]`
+            ;; isolation for naive callers (two `[edn-inspector]`
             ;; mounts side-by-side toggle independently).
             ;;
             ;; The choice is per-consumer-panel: App-DB / Handler /
@@ -2065,12 +2065,12 @@
             ;; slot live across panel resizes.
             widths        @(subscribe [widths-slot])
             available-width-px (get widths mount-id)
-            container-id  (str "rf-xray-data-display-"
+            container-id  (str "rf-xray-edn-inspector-"
                                (name panel-id) "-" mount-id)
-            ;; Stable popup-mount-id derived from THIS data-display's
+            ;; Stable popup-mount-id derived from THIS edn-inspector's
             ;; own mount-id so re-clicking the affordance "raises" the
             ;; existing popup rather than spawning a duplicate
-            ;; (matches `data-display-popup/push-entry` semantics).
+            ;; (matches `edn-inspector-popup/push-entry` semantics).
             popup-mount-id (str "ddp-" mount-id)]
         [:div {:data-testid     container-id
                :data-rf-mount-id mount-id
@@ -2137,15 +2137,15 @@
                               ;; ResizeObserver keeps it live.
                               :available-width-px available-width-px}})]))))
 
-(defn data-display-diff
-  "Diff convenience — `[data-display-diff before after]` or
-  `[data-display-diff before after opts]`. Equivalent to
-  `[data-display after (assoc opts :before before)]`. Use when the
+(defn edn-inspector-diff
+  "Diff convenience — `[edn-inspector-diff before after]` or
+  `[edn-inspector-diff before after opts]`. Equivalent to
+  `[edn-inspector after (assoc opts :before before)]`. Use when the
   call site reads more naturally with both halves of the diff at the
   callsite head."
-  ([before after] (data-display-diff before after nil))
+  ([before after] (edn-inspector-diff before after nil))
   ([before after opts]
-   [data-display after (assoc (or opts {}) :before before)]))
+   [edn-inspector after (assoc (or opts {}) :before before)]))
 
 ;; =========================================================================
 ;; mini — one-line inline rendering (D2=a: 2-arg overload, sentinel-aware)
@@ -2167,7 +2167,7 @@
          truncated (if (<= (count pr-text) max-len)
                      pr-text
                      (str (subs pr-text 0 max-len) "…"))]
-     [:span {:data-testid "rf-xray-data-display-mini"
+     [:span {:data-testid "rf-xray-edn-inspector-mini"
              :data-rf-mini "1"
              :title pr-text
              :style {:font-family mono-stack

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_inspector_default_formatters.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_inspector_default_formatters.cljs
@@ -1,10 +1,10 @@
-(ns day8.re-frame2-xray.views.data-display-default-formatters
-  "Default `IXrayDataDisplay` formatters for common CLJS types
+(ns day8.re-frame2-xray.views.edn-inspector-default-formatters
+  "Default `IXrayEdnInspector` formatters for common CLJS types
   (rf2-x16b1 · follow-on to rf2-0qrcr phase 7).
 
   ## Why this exists
 
-  Phase 7 of rf2-oqa60 shipped the `IXrayDataDisplay` protocol as the
+  Phase 7 of rf2-oqa60 shipped the `IXrayEdnInspector` protocol as the
   single extension seam for the closed phase-1 renderer. The widget
   ships ZERO default protocol implementations — consuming apps must
   opt in per domain type via `extend-type`.
@@ -41,13 +41,13 @@
 
   ## Loading
 
-  This namespace is `:require`d by `views.data-display` itself —
+  This namespace is `:require`d by `views.edn-inspector` itself —
   loading the renderer also loads the defaults. No call-site
   registration needed.
 
   ## Precedence
 
-  Consumers who extend `IXrayDataDisplay` on the same types (e.g. a
+  Consumers who extend `IXrayEdnInspector` on the same types (e.g. a
   project that wants its own uuid rendering) **win** — `extend-type`
   installs the most-recently-loaded impl. The bundled defaults are
   inert if a consumer has already extended the type. (CLJS protocol
@@ -56,7 +56,7 @@
 
   ## Why not extend in the protocol ns
 
-  The protocol ns (`data-display-protocol`) stays a pure contract
+  The protocol ns (`edn-inspector-protocol`) stays a pure contract
   surface — defprotocol + safe accessors + nothing else. Default
   formatters are a separate concern: opinionated UI choices that
   could plausibly be swapped out by a consumer's preferred
@@ -65,8 +65,8 @@
   artefact."
   (:require [day8.re-frame2-xray.theme.tokens
              :refer [tokens mono-stack]]
-            [day8.re-frame2-xray.views.data-display-protocol
-             :refer [IXrayDataDisplay]]))
+            [day8.re-frame2-xray.views.edn-inspector-protocol
+             :refer [IXrayEdnInspector]]))
 
 ;; =========================================================================
 ;; styles — read CSS-variable tokens so light/dark themes resolve at paint
@@ -107,7 +107,7 @@
    (str "#uuid \"" v "\"")])
 
 (extend-type cljs.core/UUID
-  IXrayDataDisplay
+  IXrayEdnInspector
   (-xray-render-header [v _opts] (render-uuid-header v))
   (-xray-render-body   [v _opts] (render-uuid-body v)))
 
@@ -210,6 +210,6 @@
    (str "#inst \"" (iso-string v) "\"")])
 
 (extend-type js/Date
-  IXrayDataDisplay
+  IXrayEdnInspector
   (-xray-render-header [v _opts] (render-inst-header v))
   (-xray-render-body   [v _opts] (render-inst-body v)))

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_inspector_popup.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_inspector_popup.cljs
@@ -1,25 +1,25 @@
-(ns day8.re-frame2-xray.views.data-display-popup
+(ns day8.re-frame2-xray.views.edn-inspector-popup
   "Data-display popup overlay infra — phase 6 of rf2-oqa60 (D6=a per
   rf2-sndui).
 
   ## What this is
 
   A drill-in surface that **floats over an Xray panel** and inspects
-  a CLJS value at depth via the first-class data-display widget
-  (`views.data-display`). Anchor scope is Xray-internal only — the
+  a CLJS value at depth via the first-class edn-inspector widget
+  (`views.edn-inspector`). Anchor scope is Xray-internal only — the
   popup overlays the Xray DOM; it never anchors to the debugged
   application's DOM (locked per D6=a).
 
   ## Public API
 
-      [data-display-popup value]
-      [data-display-popup value opts]
+      [edn-inspector-popup value]
+      [edn-inspector-popup value opts]
 
   `opts` keys (all optional):
 
   - `:title`             — header label. Defaults `\"Inspect\"`.
   - `:panel-id`          — passed straight through to the embedded
-                           `[data-display value …]` so the popup's
+                           `[edn-inspector value …]` so the popup's
                            expansion state is keyed under its own
                            `panel-id` (defaults to `:rf.xray.data-
                            display-popup/anon`).
@@ -28,20 +28,20 @@
   - `:on-close`          — optional 0-arg fn called when the popup
                            closes (X / Esc / backdrop). The default
                            `:on-close` dispatches
-                           `[:rf.xray.data-display-popup/close mount-id]`
+                           `[:rf.xray.edn-inspector-popup/close mount-id]`
                            against the `:rf/xray` frame so the popup
                            closes itself via the registered handler.
 
-  Two-arg overload matches `[data-display value opts]` (D2=a) so the
+  Two-arg overload matches `[edn-inspector value opts]` (D2=a) so the
   popup's call shape is the same as the widget it wraps.
 
   ## Per-mount UUID (D8=a per rf2-sndui)
 
-  Each `[data-display-popup …]` mount allocates a fresh UUID
+  Each `[edn-inspector-popup …]` mount allocates a fresh UUID
   `mount-id` on first render via the form-2 outer fn. The `mount-id`:
 
   - identifies this popup's entry in the open-popups stack slot at
-    `:rf.xray.data-display-popup/stack`, so multiple popups stack
+    `:rf.xray.edn-inspector-popup/stack`, so multiple popups stack
     without colliding,
   - composes the embedded widget's `:panel-id` —
     `[<panel-id-opt> mount-id]`-style namespacing — so the popup's
@@ -52,26 +52,26 @@
 
   ## State model
 
-  - `:rf.xray.data-display-popup/stack` (vector of `mount-id`s) holds
+  - `:rf.xray.edn-inspector-popup/stack` (vector of `mount-id`s) holds
     the open-popups stack. Top-of-stack is the topmost popup; it
     owns the Esc keystroke (the global Esc handler closes only the
     top entry, leaving any popups beneath it open).
   - Per-popup payload (the rendered value + opts snapshot) is held
-    in app-db at `[:rf.xray.data-display-popup/entries mount-id]`
+    in app-db at `[:rf.xray.edn-inspector-popup/entries mount-id]`
     so a programmatic open call (e.g. from a context-menu handler
     in a future bead) survives shadow-cljs `:after-load` reloads
     and re-opening with the same id restores its expansion state
-    (the underlying data-display expansion slot is keyed on
+    (the underlying edn-inspector expansion slot is keyed on
     `[panel-id mount-id path]`, so the popup's contents survive
     unmount/remount when the same id is reused).
 
   ## Why this lives in NEW files only
 
-  The umbrella widget at `views.data-display.cljs` is phase 1's
+  The umbrella widget at `views.edn-inspector.cljs` is phase 1's
   surface and just landed in #2143. Phase 6's overlay infra is an
   additive surface — a wrapper component + its own state slot — so
   the phase-1 file stays untouched and the popup's lifecycle is
-  self-contained. The shell wires the `data-display-popup-stack`
+  self-contained. The shell wires the `edn-inspector-popup-stack`
   view into its overlay container in a follow-on bead; the install!
   fn here makes the registrations idempotent so that wire-up is a
   one-call addition.
@@ -88,7 +88,7 @@
             [day8.re-frame2-xray.theme.a11y :as a11y]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens sans-stack type-scale]]
-            [day8.re-frame2-xray.views.data-display :as dd]))
+            [day8.re-frame2-xray.views.edn-inspector :as ei]))
 
 ;; =========================================================================
 ;; state slots — public so tests + consumers can read/write them.
@@ -99,21 +99,21 @@
   oldest first; top-of-stack = last). Public so the Esc handler can
   peek the topmost entry and a consuming panel's 'close all' action
   can clear it."
-  :rf.xray.data-display-popup/stack)
+  :rf.xray.edn-inspector-popup/stack)
 
 (def entries-slot
   "App-db slot holding per-popup payload maps, keyed by `mount-id`.
   Each entry shape: `{:value <any> :opts <map>}`. Public so tests
   can assert the open-popup contract end-to-end without going
   through the view layer."
-  :rf.xray.data-display-popup/entries)
+  :rf.xray.edn-inspector-popup/entries)
 
 (def default-panel-id
-  "Default `:panel-id` the embedded data-display widget reads when
+  "Default `:panel-id` the embedded edn-inspector widget reads when
   the caller doesn't pass one. Distinct keyword (not reusing
-  `:rf.xray.data-display/anon`) so popup-vs-panel expansion state
+  `:rf.xray.edn-inspector/anon`) so popup-vs-panel expansion state
   never collide on a coincidental empty path."
-  :rf.xray.data-display-popup/anon)
+  :rf.xray.edn-inspector-popup/anon)
 
 ;; =========================================================================
 ;; pure helpers — JVM-portable so the state math has a unit-test surface
@@ -161,11 +161,11 @@
 (defn install-subs!
   "Register the popup's subscription surface.
 
-  - `:rf.xray.data-display-popup/stack`   — the open-popups stack vector
-  - `:rf.xray.data-display-popup/entries` — the per-popup payload map
-  - `:rf.xray.data-display-popup/open?`   — boolean; true when stack non-empty
-  - `:rf.xray.data-display-popup/top`     — top-of-stack mount-id or nil
-  - `:rf.xray.data-display-popup/entry`   — `[mount-id]` → that entry
+  - `:rf.xray.edn-inspector-popup/stack`   — the open-popups stack vector
+  - `:rf.xray.edn-inspector-popup/entries` — the per-popup payload map
+  - `:rf.xray.edn-inspector-popup/open?`   — boolean; true when stack non-empty
+  - `:rf.xray.edn-inspector-popup/top`     — top-of-stack mount-id or nil
+  - `:rf.xray.edn-inspector-popup/entry`   — `[mount-id]` → that entry
                                             (so a view can pick the
                                             value + opts for its own
                                             mount without reading
@@ -177,17 +177,17 @@
   (rf/reg-sub entries-slot
     (fn [db _] (get db entries-slot)))
 
-  (rf/reg-sub :rf.xray.data-display-popup/open?
+  (rf/reg-sub :rf.xray.edn-inspector-popup/open?
     :<- [stack-slot]
     (fn [stack _]
       (boolean (seq stack))))
 
-  (rf/reg-sub :rf.xray.data-display-popup/top
+  (rf/reg-sub :rf.xray.edn-inspector-popup/top
     :<- [stack-slot]
     (fn [stack _]
       (top-entry stack)))
 
-  (rf/reg-sub :rf.xray.data-display-popup/entry
+  (rf/reg-sub :rf.xray.edn-inspector-popup/entry
     :<- [entries-slot]
     (fn [entries [_ mount-id]]
       (get entries mount-id))))
@@ -198,20 +198,20 @@
   click/keydown context pop doesn't leak the event to `:rf/default`
   (same fix as the App-DB segment-inspector + settings popup)."
   []
-  (rf/reg-event-db :rf.xray.data-display-popup/open
+  (rf/reg-event-db :rf.xray.edn-inspector-popup/open
     (fn [db [_ mount-id payload]]
       ;; payload shape: {:value <any> :opts <map>}
       (-> db
           (update stack-slot push-entry mount-id)
           (assoc-in [entries-slot mount-id] payload))))
 
-  (rf/reg-event-db :rf.xray.data-display-popup/close
+  (rf/reg-event-db :rf.xray.edn-inspector-popup/close
     (fn [db [_ mount-id]]
       (-> db
           (update stack-slot pop-entry mount-id)
           (update entries-slot dissoc mount-id))))
 
-  (rf/reg-event-db :rf.xray.data-display-popup/close-top
+  (rf/reg-event-db :rf.xray.edn-inspector-popup/close-top
     ;; Esc handler — close the topmost popup only. No-op when stack
     ;; is empty.
     (fn [db _]
@@ -222,7 +222,7 @@
               (update entries-slot dissoc top))
           db))))
 
-  (rf/reg-event-db :rf.xray.data-display-popup/close-all
+  (rf/reg-event-db :rf.xray.edn-inspector-popup/close-all
     (fn [db _]
       (-> db
           (assoc stack-slot [])
@@ -334,7 +334,7 @@
   (fn []
     (if on-close
       (on-close)
-      (rf/dispatch [:rf.xray.data-display-popup/close mount-id]
+      (rf/dispatch [:rf.xray.edn-inspector-popup/close mount-id]
                    {:frame :rf/xray}))))
 
 (defn handle-keydown
@@ -346,7 +346,7 @@
   (when (= "Escape" (.-key e))
     (.preventDefault e)
     (.stopPropagation e)
-    (rf/dispatch [:rf.xray.data-display-popup/close-top]
+    (rf/dispatch [:rf.xray.edn-inspector-popup/close-top]
                  {:frame :rf/xray})))
 
 ;; =========================================================================
@@ -359,8 +359,8 @@
   at the standard dialog title weight so popup chrome matches the
   rest of the Xray modal family."
   [mount-id title]
-  [:span {:id          (str "rf-xray-data-display-popup-title-" mount-id)
-          :data-testid (str "rf-xray-data-display-popup-title-" mount-id)
+  [:span {:id          (str "rf-xray-edn-inspector-popup-title-" mount-id)
+          :data-testid (str "rf-xray-edn-inspector-popup-title-" mount-id)
           :style {:color       (:text-primary tokens)
                   :font-weight 600
                   :font-size   (:body type-scale)
@@ -392,7 +392,7 @@
         ;; The shared backdrop owns z-index for position 0; dialogs
         ;; ride on top of their own backdrop tier.
         dialog-z      (z-index-for (inc (or stack-pos 0)))]
-    [:div {:data-testid (str "rf-xray-data-display-popup-backdrop-" mount-id)
+    [:div {:data-testid (str "rf-xray-edn-inspector-popup-backdrop-" mount-id)
            :data-rf-xray-modal-positioning (name (or positioning :fixed))
            :data-rf-mount-id mount-id
            :on-click    (fn [^js e]
@@ -404,9 +404,9 @@
                                :z-index dialog-z)}
      [:div (merge
              (a11y/dialog-attrs
-               {:labelled-by (str "rf-xray-data-display-popup-title-"
+               {:labelled-by (str "rf-xray-edn-inspector-popup-title-"
                                   mount-id)})
-             {:data-testid (str "rf-xray-data-display-popup-dialog-" mount-id)
+             {:data-testid (str "rf-xray-edn-inspector-popup-dialog-" mount-id)
               :data-rf-mount-id mount-id
               :ref         (a11y/dialog-ref)
               :on-click    #(.stopPropagation %)
@@ -415,7 +415,7 @@
               :style       (dialog-style)})
       [:div {:style (header-style)}
        (header-title mount-id title)
-       [:button {:data-testid (str "rf-xray-data-display-popup-close-" mount-id)
+       [:button {:data-testid (str "rf-xray-edn-inspector-popup-close-" mount-id)
                  :aria-label  "Close popup"
                  :title       "Close (Esc)"
                  :on-click    (fn [^js e]
@@ -423,27 +423,27 @@
                                 (close-handler))
                  :style       (close-button-style)}
         "✕"]]
-      [:div {:data-testid (str "rf-xray-data-display-popup-body-" mount-id)
+      [:div {:data-testid (str "rf-xray-edn-inspector-popup-body-" mount-id)
              :style       (body-style)}
-       ;; Embed the first-class data-display widget. We thread the
+       ;; Embed the first-class edn-inspector widget. We thread the
        ;; mount-id into the embedded widget's :panel-id so the
        ;; popup's expansion state is isolated from any other
-       ;; data-display mount on the page (the panel underneath
+       ;; edn-inspector mount on the page (the panel underneath
        ;; almost certainly already mounts the same value at the
        ;; same path).
-       [dd/data-display value
-        {:panel-id (keyword "rf.xray.data-display-popup"
+       [ei/edn-inspector value
+        {:panel-id (keyword "rf.xray.edn-inspector-popup"
                             (str (name panel-id) "-" mount-id))
          :default-expanded-depth default-expanded-depth
          :max-inline-width       max-inline-width
          :max-depth              max-depth}]]]]))
 
 ;; =========================================================================
-;; public component — `data-display-popup`
+;; public component — `edn-inspector-popup`
 ;; =========================================================================
 
-(defn data-display-popup
-  "Floating popup overlay that wraps `[dd/data-display value opts]`.
+(defn edn-inspector-popup
+  "Floating popup overlay that wraps `[ei/edn-inspector value opts]`.
   Form-2 Reagent component: the outer fn allocates a stable
   `mount-id` (UUID, D8=a per rf2-sndui) in closure; the inner fn
   reads the popup's stack position from app-db (so multiple popups
@@ -455,13 +455,13 @@
   application's DOM.
 
   Per D8=a the auto-generated UUID on mount lives until unmount; two
-  side-by-side `[data-display-popup …]` mounts get independent
+  side-by-side `[edn-inspector-popup …]` mounts get independent
   expansion state.
 
   Usage:
 
-      [data-display-popup value]
-      [data-display-popup value {:title \"Sub :app/cart\"
+      [edn-inspector-popup value]
+      [edn-inspector-popup value {:title \"Sub :app/cart\"
                                  :panel-id :rf.xray.sub-detail
                                  :default-expanded-depth 3}]
 
@@ -470,7 +470,7 @@
   caller can pass an explicit `:on-close` to override the default
   rf-dispatch (e.g. for a parent component that controls its own
   open/closed flag)."
-  ([value] (data-display-popup value nil))
+  ([value] (edn-inspector-popup value nil))
   ([_value _opts]
    (let [mount-id (gen-mount-id)]
      (fn [value opts]
@@ -489,7 +489,7 @@
 ;; stack view — renders every open popup over the active panel
 ;; =========================================================================
 
-(defn data-display-popup-stack
+(defn edn-inspector-popup-stack
   "Stack view that renders every open popup in z-index order. Mount
   this once at the shell's overlay container (follow-on bead wires
   it into `mount.cljs`); each entry's payload is the value + opts
@@ -500,9 +500,9 @@
 
   This view is the entry point for **programmatic** opens — a
   context-menu handler dispatches
-  `[:rf.xray.data-display-popup/open mount-id {:value v :opts o}]`
+  `[:rf.xray.edn-inspector-popup/open mount-id {:value v :opts o}]`
   and this view picks the entry up and renders it. The plain
-  `[data-display-popup v opts]` component is the entry point for
+  `[edn-inspector-popup v opts]` component is the entry point for
   **inline** opens (a panel that wants to control the popup
   imperatively from its own view tree)."
   []
@@ -510,7 +510,7 @@
         entries @(rf/subscribe [entries-slot])
         positioning @(rf/subscribe [:rf.xray/modal-positioning])]
     (when (seq stack)
-      (into [:div {:data-testid "rf-xray-data-display-popup-stack"
+      (into [:div {:data-testid "rf-xray-edn-inspector-popup-stack"
                    :data-rf-popup-count (count stack)}]
             (map-indexed
               (fn [idx mount-id]

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_inspector_protocol.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_inspector_protocol.cljs
@@ -1,5 +1,5 @@
-(ns day8.re-frame2-xray.views.data-display-protocol
-  "Custom-formatters protocol for the Xray data-display widget
+(ns day8.re-frame2-xray.views.edn-inspector-protocol
+  "Custom-formatters protocol for the Xray edn-inspector widget
   (rf2-oqa60 phase 7 · rf2-0qrcr · D7=a per rf2-sndui ruling).
 
   ## Why this exists
@@ -14,7 +14,7 @@
 
   This protocol opens an extension seam *without* opening the
   internals of the renderer. A consuming type implements
-  `IXrayDataDisplay`; the widget checks `satisfies?` at the top of
+  `IXrayEdnInspector`; the widget checks `satisfies?` at the top of
   every `render-node` call and, if true, defers to the consumer's
   two methods. Otherwise the closed renderer's built-in dispatch
   runs unchanged.
@@ -41,11 +41,11 @@
   ignore everything they don't need; they SHOULD honour `:path` /
   `:panel-id` / `:mount-id` if they want their own toggle behaviour
   to compose with the widget's expansion slot (`expansion-key`
-  in `data-display.cljs` is the public composer).
+  in `edn-inspector.cljs` is the public composer).
 
   ## Fall-through
 
-  - `(satisfies? IXrayDataDisplay v)` false → built-in renderer.
+  - `(satisfies? IXrayEdnInspector v)` false → built-in renderer.
   - `render-header` returns `nil` → built-in renderer for this
     node (skips the protocol entirely for the node, including
     the body).
@@ -59,7 +59,7 @@
 
   ## Boundary
 
-  The protocol is the ONLY public extension seam in the data-display
+  The protocol is the ONLY public extension seam in the edn-inspector
   widget. Per the locked B.9 / rf2-sndui interaction model the
   widget itself ships exactly one path-click interaction; consumers
   do NOT extend interactions through this protocol — only the
@@ -71,8 +71,8 @@
   the normative description + a worked example."
   )
 
-(defprotocol IXrayDataDisplay
-  "Custom-formatters protocol for the Xray data-display widget.
+(defprotocol IXrayEdnInspector
+  "Custom-formatters protocol for the Xray edn-inspector widget.
   Consumers implement this on their domain types to override how
   the widget renders them. See the ns docstring for the contract.
 
@@ -92,20 +92,20 @@
   arbitrary errors from consumer impls so a broken third-party
   formatter can never blank the whole inspector."
   [v opts]
-  (when (satisfies? IXrayDataDisplay v)
+  (when (satisfies? IXrayEdnInspector v)
     (try (-xray-render-header v opts)
          (catch :default _ nil))))
 
 (defn xray-render-body
   "Safe accessor — see `xray-render-header`."
   [v opts]
-  (when (satisfies? IXrayDataDisplay v)
+  (when (satisfies? IXrayEdnInspector v)
     (try (-xray-render-body v opts)
          (catch :default _ nil))))
 
-(defn satisfies-xray-data-display?
-  "Predicate convenience — true iff `v` satisfies `IXrayDataDisplay`.
+(defn satisfies-xray-edn-inspector?
+  "Predicate convenience — true iff `v` satisfies `IXrayEdnInspector`.
   Exists so callers don't need to `:refer` the protocol symbol when
   all they need is the gate."
   [v]
-  (satisfies? IXrayDataDisplay v))
+  (satisfies? IXrayEdnInspector v))

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_widget/widget.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_widget/widget.cljs
@@ -1,6 +1,6 @@
 (ns day8.re-frame2-xray.views.edn-widget.widget
   "Canonical Xray EDN widget facade — thin wrapper over the first-
-  class `views.data-display` widget.
+  class `views.edn-inspector` widget.
 
   ## Purpose
 
@@ -13,17 +13,17 @@
   ## One engine, one facade (post-rf2-q3dzw)
 
   After phase 5 (D5=a per rf2-sndui, rf2-q3dzw) the WHOLE contract —
-  browse + diff + mini — lives in `views.data-display` as one
+  browse + diff + mini — lives in `views.edn-inspector` as one
   renderer. This facade is a thin delegate that the legacy `edn/*`
   call sites still reach through; new call sites should use
-  `[data-display value opts]` directly.
+  `[edn-inspector value opts]` directly.
 
   Previous shape (pre-rf2-oqa60) composed two engines:
-  `data-display.render` (diff-aware tree walker) and
+  `edn-inspector.render` (diff-aware tree walker) and
   `cljs-devtools-render` (binaryage/cljs-devtools-backed formatters).
   Phase 1 (rf2-oqa60) shipped the roll-your-own browse path; phase 5
   (rf2-q3dzw) subsumed the diff engine into the same widget and
-  deleted the legacy `data-display.render` + `theme.data-inspector`
+  deleted the legacy `edn-inspector.render` + `theme.data-inspector`
   ns'es.
 
   ## Public API
@@ -54,18 +54,18 @@
             [re-frame.core :as rf]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens mono-stack]]
-            ;; The first-class data-display widget owns the WHOLE
+            ;; The first-class edn-inspector widget owns the WHOLE
             ;; contract — browse, diff, mini, sentinel chrome — as a
             ;; single source of truth (phase 5 / rf2-q3dzw,
             ;; D5=a per rf2-sndui).
-            [day8.re-frame2-xray.views.data-display :as dd]
+            [day8.re-frame2-xray.views.edn-inspector :as ei]
             [zprint.core :as zprint]))
 
-;; ---- subscription bridge — superseded by the new data-display widget ----
+;; ---- subscription bridge — superseded by the new edn-inspector widget ----
 ;;
 ;; Pre-rf2-oqa60 this section glued the cljs-devtools walker to the
 ;; shared expansion slot. With the phase 1 cut-over the new widget at
-;; `views.data-display` owns its own `:rf.xray.data-display/expansion`
+;; `views.edn-inspector` owns its own `:rf.xray.edn-inspector/expansion`
 ;; slot + toggle/reset events; the facade delegates and the cljs-
 ;; devtools-render adapter is deleted.
 
@@ -136,22 +136,22 @@
 ;;
 ;; Per Mike-direction rf2-9wsdy ("one widget, many call sites") every
 ;; panel-side EDN render flows through this namespace. Per rf2-oqa60
-;; phase 1 the facade delegates to the first-class `views.data-display`
+;; phase 1 the facade delegates to the first-class `views.edn-inspector`
 ;; widget — the same engine handles every type (scalars, collections,
 ;; sentinels) so this thin wrapper no longer needs sentinel-routing
-;; branches. Phases 2-4 migrate call sites to call `dd/data-display`
+;; branches. Phases 2-4 migrate call sites to call `ei/edn-inspector`
 ;; directly; this facade is the bridge through that transition.
 
 (defn inspect
   "Sentinel-aware current-state rendering for one value — the canonical
   L4 detail-panel renderer. Routes through the first-class
-  data-display widget (rf2-oqa60 phase 1) which classifies every type
+  edn-inspector widget (rf2-oqa60 phase 1) which classifies every type
   natively, including the spec/015 sentinels (`:rf/redacted` and
   `:rf/large`) as first-class chip chrome (D3=a per rf2-sndui).
 
   Phase 1 delegates the legacy facade to the new widget so existing
   call sites compile unchanged; phases 2-4 migrate each surface
-  (Trace, Sub, Machine) to call `data-display/data-display` directly.
+  (Trace, Sub, Machine) to call `edn-inspector/edn-inspector` directly.
 
   Single-arg form picks a default panel-id; two-arg / three-arg forms
   accept a node-key string (passed through as a stable per-mount
@@ -164,7 +164,7 @@
   ([v] (inspect v "root" nil))
   ([v node-key] (inspect v node-key nil))
   ([v node-key _opts]
-   [dd/data-display v
+   [ei/edn-inspector v
     {:panel-id (keyword (str "rf.xray.inspect/" node-key))
      :default-expanded-depth 3}]))
 
@@ -174,21 +174,21 @@
   render their chip chrome via the new widget's `mini` overload; all
   other values render as a colour-coded one-liner."
   [v]
-  (dd/mini v))
+  (ei/mini v))
 
 ;; ---- variant: browse -----------------------------------------------------
 
 (defn browse
   "Render `:value` as a current-state tree via the first-class
-  data-display widget.
+  edn-inspector widget.
 
   Each collection node renders a `▸` / `▾` triangle that dispatches
-  `:rf.xray.data-display/toggle-node` against the per-mount path —
+  `:rf.xray.edn-inspector/toggle-node` against the per-mount path —
   operator drill-downs persist across re-renders in the
-  `:rf.xray.data-display/expansion` slot.
+  `:rf.xray.edn-inspector/expansion` slot.
 
   Diff semantics are an opt-in mode on the SAME widget — call `diff`
-  below (or pass `:before` to `dd/data-display` directly).
+  below (or pass `:before` to `ei/edn-inspector` directly).
 
   Required: `:value`.
   Optional: `:panel-id` (defaults `:rf.xray/browse`),
@@ -204,7 +204,7 @@
   [{:keys [value panel-id render-id default-depth max-depth]
     :or   {default-depth 1
            max-depth     16}}]
-  [dd/data-display value
+  [ei/edn-inspector value
    {:panel-id (or panel-id
                   (keyword (str "rf.xray.browse/" (or render-id "anon"))))
     :default-expanded-depth default-depth
@@ -219,14 +219,14 @@
   leaves. Returns hiccup.
 
   After phase 5 (rf2-q3dzw, D5=a per rf2-sndui) diff is an opt-in
-  MODE on the same `views.data-display` widget — this facade just
+  MODE on the same `views.edn-inspector` widget — this facade just
   threads the `:before` opt through to the widget.
 
   Required: `:before :after :panel-id :render-id`.
   Optional: `:default-depth` (defaults to 2 per §10.4)."
   [{:keys [before after panel-id render-id default-depth]
     :or   {default-depth 2}}]
-  [dd/data-display after
+  [ei/edn-inspector after
    {:panel-id (or (when (keyword? panel-id) panel-id)
                   (keyword (str "rf.xray.diff/"
                                 (or (when panel-id (name panel-id))
@@ -239,13 +239,13 @@
 
 (defn mini
   "One-liner inline rendering of `value` via the first-class
-  data-display widget (rf2-oqa60 phase 1). Returns hiccup
+  edn-inspector widget (rf2-oqa60 phase 1). Returns hiccup
   `[:span ...]` so callers embed inline. Sentinels (`:rf/redacted`,
   `:rf/large`) keep their chip chrome inline; other values render as
   a colour-coded inline-preview."
   ([value] (mini value 80))
   ([value max-len]
-   (dd/mini value max-len)))
+   (ei/mini value max-len)))
 
 ;; ---- code-block (handler / interceptor source rendering) ----------------
 ;;

--- a/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_state_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_state_cljs_test.cljs
@@ -238,19 +238,19 @@
 ;; ---- inline diff annotation (spec/021 §4.3 · rf2-ad7zx.11) ---------------
 ;;
 ;; When a section's `:before` pre-image differs from its `:value`, the
-;; value body routes through the data-display widget's DIFF mode
+;; value body routes through the edn-inspector widget's DIFF mode
 ;; (rf2-q3dzw phase 5) — passing `:before` paints the inline
 ;; `← changed from X` annotation in place. With no pre-image (the
 ;; no-diff sentinel) the body stays in BROWSE mode (no annotation).
 ;;
 ;; The widget itself is exercised by
-;; `tools/xray/test/day8/re_frame2_xray/views/data_display_cljs_test.cljs`
+;; `tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs`
 ;; (and the diff-mode tests below). These section-level tests assert
 ;; the section CALLS the widget in the right mode — i.e. with `:before`
 ;; threaded through when the pre-image differs, omitted when not.
 
-(defn- find-data-display-mounts
-  "Walk the hiccup tree and collect every `[dd/data-display value opts]`
+(defn- find-edn-inspector-mounts
+  "Walk the hiccup tree and collect every `[ei/edn-inspector value opts]`
   mount. Returns a vec of `{:value :opts}` maps so tests can assert
   against the threaded opts (in particular `:before`)."
   [tree]
@@ -269,14 +269,14 @@
 
 (deftest changed-value-carries-inline-changed-annotation
   (testing "a changed user-domain value renders in DIFF mode — the
-            section threads `:before` into the data-display widget so
+            section threads `:before` into the edn-inspector widget so
             it paints the inline `← changed from <prior>` annotation"
     (let [model    (h/current-state-sections {:counter 2} {:counter 1})
           tree     (state/state-body model)
           top      (find-by-testid tree "rf-xray-app-db-state-top")
-          mounts   (find-data-display-mounts top)
+          mounts   (find-edn-inspector-mounts top)
           diff-mts (filter #(contains? (:opts %) :before) mounts)]
-      (is (seq mounts) "top section mounts the data-display widget")
+      (is (seq mounts) "top section mounts the edn-inspector widget")
       (is (seq diff-mts)
           "the mount carries a `:before` opt — i.e. the widget renders
            in DIFF mode for the changed value")
@@ -293,7 +293,7 @@
           tree     (state/state-body model)
           flow     (find-by-testid
                      tree "rf-xray-app-db-state-instance-:rf/machines-:title/flow")
-          mounts   (find-data-display-mounts flow)
+          mounts   (find-edn-inspector-mounts flow)
           diff-mts (filter #(contains? (:opts %) :before) mounts)]
       (is (seq diff-mts) "the instance section renders in DIFF mode")
       (is (= {:state :idle} (-> diff-mts first :opts :before))
@@ -306,8 +306,8 @@
     (let [model  (h/current-state-sections
                    {:counter 2 :rf/route {:id :home}})
           tree   (state/state-body model)
-          mounts (find-data-display-mounts tree)]
-      (is (seq mounts) "the panel mounts data-display widget instances")
+          mounts (find-edn-inspector-mounts tree)]
+      (is (seq mounts) "the panel mounts edn-inspector widget instances")
       (is (every? #(not (contains? (:opts %) :before)) mounts)
           "no mount carries a `:before` opt — no diff annotation
            without a pre-image"))))
@@ -319,8 +319,8 @@
 ;; whole-tree inspector reads comfortably in place. These tests pin the
 ;; absence of the opt so a stray re-introduction trips the gate.
 
-(deftest data-display-mounts-omit-popup-affordance-opt
-  (testing "rf2-7sdja — no `[dd/data-display ...]` mount the App-DB
+(deftest edn-inspector-mounts-omit-popup-affordance-opt
+  (testing "rf2-7sdja — no `[ei/edn-inspector ...]` mount the App-DB
             panel produces carries `:popup-affordance? true`; the App-
             DB tree renders comfortably in-place and the affordance
             would be unnecessary noise (Mike's live-testing call
@@ -329,8 +329,8 @@
                    {:counter 2 :rf/route {:id :home}
                     :rf/machines {:auth {:state :idle}}})
           tree   (state/state-body model)
-          mounts (find-data-display-mounts tree)]
-      (is (seq mounts) "the panel mounts data-display widget instances")
+          mounts (find-edn-inspector-mounts tree)]
+      (is (seq mounts) "the panel mounts edn-inspector widget instances")
       (is (not-any? #(true? (:popup-affordance? (:opts %))) mounts)
           "no mount opts in to the popup affordance"))))
 
@@ -339,7 +339,7 @@
             ALSO omit the popup affordance opt"
     (let [model  (h/current-state-sections {:counter 2} {:counter 1})
           tree   (state/state-body model)
-          mounts (find-data-display-mounts tree)
+          mounts (find-edn-inspector-mounts tree)
           diff-mts (filter #(contains? (:opts %) :before) mounts)]
       (is (seq diff-mts) "diff-mode mounts present")
       (is (not-any? #(true? (:popup-affordance? (:opts %))) diff-mts)
@@ -353,7 +353,7 @@
 ;; a distinct inspector-card affordance.
 
 (deftest browse-mode-mounts-carry-card-opt
-  (testing "rf2-63ie5 — every `[dd/data-display ...]` mount the App-DB
+  (testing "rf2-63ie5 — every `[ei/edn-inspector ...]` mount the App-DB
             panel produces (BROWSE mode, 1-arity / no-diff) carries
             `:card? true` so each top-level mount reads as a discrete
             inspector card"
@@ -361,8 +361,8 @@
                    {:counter 2 :rf/route {:id :home}
                     :rf/machines {:auth {:state :idle}}})
           tree   (state/state-body model)
-          mounts (find-data-display-mounts tree)]
-      (is (seq mounts) "the panel mounts data-display widget instances")
+          mounts (find-edn-inspector-mounts tree)]
+      (is (seq mounts) "the panel mounts edn-inspector widget instances")
       (is (every? #(true? (:card? (:opts %))) mounts)
           "every browse-mode mount opts in to the card chrome"))))
 
@@ -372,7 +372,7 @@
             diff mode and applies to every top-level App-DB mount"
     (let [model  (h/current-state-sections {:counter 2} {:counter 1})
           tree   (state/state-body model)
-          mounts (find-data-display-mounts tree)
+          mounts (find-edn-inspector-mounts tree)
           diff-mts (filter #(contains? (:opts %) :before) mounts)]
       (is (seq diff-mts) "diff-mode mounts present")
       (is (every? #(true? (:card? (:opts %))) diff-mts)

--- a/tools/xray/test/day8/re_frame2_xray/panels/app_db_segment_inspector_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/app_db_segment_inspector_cljs_test.cljs
@@ -65,7 +65,7 @@
     (let [result (apply (first tree) (rest tree))]
       ;; Form-2 Reagent components return an inner fn; re-call with
       ;; the same args (Reagent's re-render contract). rf2-oqa60 —
-      ;; the data-display widget is form-2 to stabilise mount-id.
+      ;; the edn-inspector widget is form-2 to stabilise mount-id.
       (expand-tree
         (if (fn? result)
           (apply result (rest tree))

--- a/tools/xray/test/day8/re_frame2_xray/panels/event_detail_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/event_detail_cljs_test.cljs
@@ -1818,7 +1818,7 @@
         (is (= "0" (min-width source-div))
             "the handler-source container keeps the shrink-permission to the pre")))))
 
-;; ---- (14) DB CHANGES step — app-db diff via data-display renderer -----
+;; ---- (14) DB CHANGES step — app-db diff via edn-inspector renderer -----
 
 (deftest db-changes-step-present-in-pipeline-no-committed-footer
   (testing "rf2-ad7zx.5 — the DB CHANGES step (spec/021 §2.2 step 4) is

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_canvas_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_canvas_cljs_test.cljs
@@ -133,9 +133,9 @@
 
 ;; ---- 4. SnapshotDrillIn view (rf2-lxvn6 · spec/021 §10) --------------
 
-(deftest snapshot-drill-in-mounts-data-display-widget
+(deftest snapshot-drill-in-mounts-edn-inspector-widget
   (testing "the canvas-side SnapshotDrillIn view mounts the first-class
-            data-display widget against the supplied snapshot. The host
+            edn-inspector widget against the supplied snapshot. The host
             carries per-machine + per-phase data attributes so panel-
             level tests can target the surface without reaching into the
             inner widget."
@@ -194,11 +194,11 @@
 ;; Machine snapshots routinely carry deeply-nested `:data` maps; the
 ;; popup gives the operator a full-modal inspection surface alongside
 ;; the per-machine drill-in. The canvas-side SnapshotDrillIn mount
-;; passes `:popup-affordance? true` through to `[dd/data-display]`.
+;; passes `:popup-affordance? true` through to `[ei/edn-inspector]`.
 
-(defn- find-data-display-mounts
+(defn- find-edn-inspector-mounts
   "Walk hiccup, collect every `[fn ...]` mount whose 3rd-arg looks like
-  a data-display opts map. Returns `{:value :opts}` maps."
+  a edn-inspector opts map. Returns `{:value :opts}` maps."
   [tree]
   (let [out (atom [])]
     (letfn [(walk [n]
@@ -213,16 +213,16 @@
       (walk tree))
     @out))
 
-(deftest snapshot-drill-in-data-display-carries-popup-affordance
+(deftest snapshot-drill-in-edn-inspector-carries-popup-affordance
   (testing "rf2-l4625 — the canvas-side SnapshotDrillIn passes
-            `:popup-affordance? true` to the embedded data-display so
+            `:popup-affordance? true` to the embedded edn-inspector so
             the operator can pop the snapshot into the popup overlay"
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
       (let [snapshot {:state :authing :data {:user "alice" :retries 1}}
             tree     (mc/SnapshotDrillIn {:machine-id :auth/login
                                           :snapshot   snapshot})
-            mounts   (find-data-display-mounts tree)]
-        (is (seq mounts) "data-display widget mounted")
+            mounts   (find-edn-inspector-mounts tree)]
+        (is (seq mounts) "edn-inspector widget mounted")
         (is (every? #(true? (:popup-affordance? (:opts %))) mounts)
             "every mount opts in to the popup affordance")))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_helpers_cljs_test.cljc
@@ -447,7 +447,7 @@
   ;; rf2-lxvn6 (phase 4 of rf2-oqa60) — the per-transition record
   ;; carries the full `:before` / `:after` snapshot maps so the panel's
   ;; snapshot drill-in surface (spec/021 §10 widget contract) can
-  ;; render them via the first-class data-display widget. The two
+  ;; render them via the first-class edn-inspector widget. The two
   ;; slots are nil when the trace tags lack the commit-or-finalize
   ;; snapshot pair (legacy fixtures).
   (testing "the record exposes :before and :after snapshot maps when

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_view_cljs_test.cljs
@@ -544,7 +544,7 @@
 (deftest snapshot-drill-in-renders-before-and-after-snapshots
   (testing "the focused-event section's snapshot drill-in surface mounts
             the BEFORE and AFTER snapshots through the first-class
-            data-display widget (rf2-oqa60 phase 1 · rf2-lxvn6 phase 4).
+            edn-inspector widget (rf2-oqa60 phase 1 · rf2-lxvn6 phase 4).
             Per spec/021 §10 the per-machine `:panel-id` qualifier keeps
             two machines' expansion state independent; the `:before` /
             `:after` phase suffix scopes the two sibling mounts on the
@@ -589,7 +589,7 @@
 
 (defn- find-popup-affordance-containers
   "Walk hiccup (already expand-tree'd by the find-by-testid helper) and
-  collect every data-display container that carries
+  collect every edn-inspector container that carries
   `:data-rf-popup-affordance? \"1\"` (the widget surfaces the opt as a
   data-attr on its outer `:div`)."
   [tree]
@@ -598,8 +598,8 @@
                  (= "1" (:data-rf-popup-affordance? (second n)))))
           (tree-seq (some-fn vector? seq?) seq tree)))
 
-(deftest snapshot-drill-in-data-display-carries-popup-affordance
-  (testing "rf2-l4625 — every snapshot drill-in data-display mount in
+(deftest snapshot-drill-in-edn-inspector-carries-popup-affordance
+  (testing "rf2-l4625 — every snapshot drill-in edn-inspector mount in
             the Machine Inspector panel passes
             `:popup-affordance? true` so the operator can pop the
             snapshot into the popup overlay. After expansion the widget's
@@ -626,7 +626,7 @@
         (is (some? drill) "drill-in section mounts")
         (is (seq containers)
             "drill-in surfaces the popup-affordance attr on its
-             data-display containers")))))
+             edn-inspector containers")))))
 
 (deftest snapshot-drill-in-suppressed-when-legacy-trace-lacks-snapshots
   (testing "legacy trace fixtures that pre-date the commit-or-finalize

--- a/tools/xray/test/day8/re_frame2_xray/panels/reactive_panel_subs_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/reactive_panel_subs_cljs_test.cljs
@@ -427,8 +427,8 @@
 ;; ===========================================================================
 ;;
 ;; The SUB VALUES section beneath the flow graph renders each RUN sub's
-;; current cascade value through the first-class data-display widget
-;; (`views.data-display`). The projection layer here surfaces a
+;; current cascade value through the first-class edn-inspector widget
+;; (`views.edn-inspector`). The projection layer here surfaces a
 ;; `:sub-values` slot — one row per RUN sub, carrying the sub-id, the
 ;; changed/unchanged flag, an explicit `:has-value?` presence flag (so a
 ;; redacted/absent value is distinguishable from an actual `nil`), the

--- a/tools/xray/test/day8/re_frame2_xray/panels/reactive_panel_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/reactive_panel_view_cljs_test.cljs
@@ -21,8 +21,8 @@
             [day8.re-frame2-xray.panels.reactive-panel :as facade]
             [day8.re-frame2-xray.panels.reactive-panel-view :as view]
             ;; rf2-e46qs phase 3 — assert the SUB VALUES row mounts
-            ;; `[dd/data-display value opts]` directly (no facade hop).
-            [day8.re-frame2-xray.views.data-display :as dd]))
+            ;; `[ei/edn-inspector value opts]` directly (no facade hop).
+            [day8.re-frame2-xray.views.edn-inspector :as ei]))
 
 (defn- has-testid? [tree testid]
   (some? (th/find-by-testid tree testid)))
@@ -331,18 +331,18 @@
 ;; ---- SUB VALUES inspector (rf2-e46qs phase 3 of rf2-oqa60) -----------
 ;;
 ;; Each ran sub renders its current cascade value through the
-;; first-class `[dd/data-display value opts]` widget DIRECTLY (no
+;; first-class `[ei/edn-inspector value opts]` widget DIRECTLY (no
 ;; `edn/inspect` / `edn/browse` facade hop). Acceptance:
 ;;
-;;   1. Each sub's value renders via `[dd/data-display]` directly.
+;;   1. Each sub's value renders via `[ei/edn-inspector]` directly.
 ;;   2. Stable per-sub `:panel-id` qualifier so two sub-row expansions
 ;;      are independent.
-;;   3. Existing rf2-oqa60 phase 1 data-display testid contract holds
-;;      (`rf-xray-data-display-<panel-id>-<mount-id>...`).
+;;   3. Existing rf2-oqa60 phase 1 edn-inspector testid contract holds
+;;      (`rf-xray-edn-inspector-<panel-id>-<mount-id>...`).
 
 (deftest sub-values-section-renders-with-row-per-ran-sub
   (testing "rf2-e46qs — the SUB VALUES section lists one row per ran sub
-            and surfaces the data-display widget per row."
+            and surfaces the edn-inspector widget per row."
     (facade/install!)
     (frame/reg-frame :rf/xray {})
     (seed-reactive-data!
@@ -370,28 +370,28 @@
 ;; ---- raw hiccup helpers (rf2-e46qs) -----------------------------------
 ;;
 ;; `re-frame.test-helpers/find-by-testid` walks via `expand-tree`, which
-;; AUTO-INVOKES every function component (including `dd/data-display`'s
+;; AUTO-INVOKES every function component (including `ei/edn-inspector`'s
 ;; form-2 outer fn → inner fn). That's the right default for assertions
 ;; about WHAT renders — but here we need to assert WHAT IS MOUNTED, not
-;; the expansion: the data-display literal `[dd/data-display value
+;; the expansion: the edn-inspector literal `[ei/edn-inspector value
 ;; opts]` is the contract surface we're locking. So we walk the raw,
 ;; un-expanded hiccup.
 
 (defn- raw-find-dd-mount
   "Walk the raw hiccup tree (no function-component expansion) and
-  return the first `[dd/data-display value opts]` vector under a node
+  return the first `[ei/edn-inspector value opts]` vector under a node
   with `data-testid == testid`, or nil. Mirrors `find-by-testid` for
   the gate node; under the gate node we look at unexpanded children
-  (the literal data-display form survives because we never call the
+  (the literal edn-inspector form survives because we never call the
   walker that would invoke it)."
   [tree testid]
   (letfn [(walk [node]
             (cond
               (and (vector? node)
-                   (or (= dd/data-display (first node))
+                   (or (= ei/edn-inspector (first node))
                        ;; symbol-bound name preserves identity in some
                        ;; advanced builds
-                       (= 'day8.re-frame2-xray.views.data-display/data-display
+                       (= 'day8.re-frame2-xray.views.edn-inspector/edn-inspector
                           (first node))))
               node
 
@@ -411,10 +411,10 @@
               :else          nil))]
     (gate tree)))
 
-(deftest sub-values-row-mounts-data-display-widget-directly
+(deftest sub-values-row-mounts-edn-inspector-widget-directly
   (testing "rf2-e46qs acceptance #1 — each row mounts the first-class
-            `[dd/data-display value opts]` widget DIRECTLY (no `edn/`
-            facade hop). The literal data-display form lives in the
+            `[ei/edn-inspector value opts]` widget DIRECTLY (no `edn/`
+            facade hop). The literal edn-inspector form lives in the
             unexpanded panel hiccup — the contract surface."
     (facade/install!)
     (frame/reg-frame :rf/xray {})
@@ -428,14 +428,14 @@
           dd   (raw-find-dd-mount
                  tree "rf-xray-reactive-sub-value-row-_cart_state-value")]
       (is (some? dd)
-          "the row mounts [dd/data-display value opts] directly")
+          "the row mounts [ei/edn-inspector value opts] directly")
       (is (= {:items [1 2 3]} (nth dd 1 nil))
           "value flows through as the second arg")
       (is (map? (nth dd 2 nil))
           "opts map rides the third arg"))))
 
 (deftest sub-values-row-uses-stable-per-sub-panel-id
-  (testing "rf2-e46qs acceptance #2 — each row's data-display mount
+  (testing "rf2-e46qs acceptance #2 — each row's edn-inspector mount
             carries a STABLE per-sub `:panel-id` so two sub-row
             expansions are independent. The panel-id is namespaced
             under `:rf.xray.reactive-sub-value` and folds the sub-id."
@@ -466,8 +466,8 @@
           "panel-id is namespaced under :rf.xray.reactive-sub-value")
       (is (= "rf.xray.reactive-sub-value" (namespace pid-b))))))
 
-(deftest sub-values-row-data-display-carries-popup-affordance
-  (testing "rf2-l4625 — each sub-value row's data-display mount carries
+(deftest sub-values-row-edn-inspector-carries-popup-affordance
+  (testing "rf2-l4625 — each sub-value row's edn-inspector mount carries
             `:popup-affordance? true` so the operator can pop a sub's
             value into the popup overlay (sub values are commonly the
             full domain projection — cart, route tree, …)"
@@ -489,7 +489,7 @@
 (deftest sub-values-row-no-value-renders-placeholder
   (testing "rf2-e46qs — a sub-run without a `:value` key (redaction /
             pre-attribution) renders the muted no-value placeholder; no
-            data-display widget mount (rather than mounting with `nil`,
+            edn-inspector widget mount (rather than mounting with `nil`,
             which would be indistinguishable from a sub whose actual
             value IS nil)."
     (facade/install!)
@@ -505,7 +505,7 @@
           "the no-value placeholder renders for redacted/absent")
       (is (nil? (th/find-by-testid
                   tree "rf-xray-reactive-sub-value-row-_cart_secret-value"))
-          "no data-display mount when the value is absent"))))
+          "no edn-inspector mount when the value is absent"))))
 
 (deftest sub-values-section-omitted-when-no-ran-subs
   (testing "rf2-e46qs — empty `:sub-values` → the SUB VALUES section is

--- a/tools/xray/test/day8/re_frame2_xray/panels/trace_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/trace_view_cljs_test.cljs
@@ -567,8 +567,8 @@
 (deftest expanded-row-renders-raw-edn-payload
   (testing "spec/023 §3 — when a row's :id is in the expanded set, the
             raw trace-event EDN renders below the row via the first-class
-            data-display widget (rf2-hhtbl phase 2: direct
-            `[dd/data-display value opts]`, no facade hop)"
+            edn-inspector widget (rf2-hhtbl phase 2: direct
+            `[ei/edn-inspector value opts]`, no facade hop)"
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
       (seed-history!
@@ -587,19 +587,19 @@
         ;; with a per-row panel-id qualifier (`:rf.xray.trace/row-<id>`)
         ;; so two simultaneously-expanded rows can't share expansion
         ;; state. The widget's `testid-for` uses `(name panel-id)`, so
-        ;; the container testid resolves to `rf-xray-data-display-row-13-<uuid>`.
+        ;; the container testid resolves to `rf-xray-edn-inspector-row-13-<uuid>`.
         (let [dd-nodes (filter (fn [n]
                                  (and (vector? n)
                                       (map? (second n))
                                       (some-> (:data-testid (second n))
-                                              (.startsWith "rf-xray-data-display-row-13-"))))
+                                              (.startsWith "rf-xray-edn-inspector-row-13-"))))
                                (hiccup-seq tree))]
           (is (seq dd-nodes)
-              "data-display widget mounted for the expanded row with the per-row panel-id qualifier"))))))
+              "edn-inspector widget mounted for the expanded row with the per-row panel-id qualifier"))))))
 
 (deftest expanded-row-uses-per-row-panel-id-qualifier
   (testing "rf2-hhtbl phase 2 — two simultaneously-expanded rows each
-            mount the data-display widget with a DISTINCT per-row
+            mount the edn-inspector widget with a DISTINCT per-row
             panel-id qualifier (`:rf.xray.trace/row-<id>` rendered as
             `row-<id>` in the testid via `(name ...)`) so their
             expansion state can't collide. Combined with the widget's
@@ -624,25 +624,25 @@
                                         (:data-testid (second n)))))
                               (filter #(and (string? %)
                                             (.startsWith ^String %
-                                                         "rf-xray-data-display-row-")))
+                                                         "rf-xray-edn-inspector-row-")))
                               (into #{}))
-            row-41-hits  (filter #(.startsWith ^String % "rf-xray-data-display-row-41-")
+            row-41-hits  (filter #(.startsWith ^String % "rf-xray-edn-inspector-row-41-")
                                  dd-testids)
-            row-42-hits  (filter #(.startsWith ^String % "rf-xray-data-display-row-42-")
+            row-42-hits  (filter #(.startsWith ^String % "rf-xray-edn-inspector-row-42-")
                                  dd-testids)]
         (is (seq row-41-hits)
-            "row 41's data-display container carries the :rf.xray.trace/row-41 qualifier")
+            "row 41's edn-inspector container carries the :rf.xray.trace/row-41 qualifier")
         (is (seq row-42-hits)
-            "row 42's data-display container carries the :rf.xray.trace/row-42 qualifier")
+            "row 42's edn-inspector container carries the :rf.xray.trace/row-42 qualifier")
         (is (not= (first row-41-hits) (first row-42-hits))
-            "the two rows mount distinct data-display containers")))))
+            "the two rows mount distinct edn-inspector containers")))))
 
-(deftest expanded-row-data-display-carries-popup-affordance
+(deftest expanded-row-edn-inspector-carries-popup-affordance
   (testing "rf2-l4625 — the expanded-row payload mount passes
-            `:popup-affordance? true` to the data-display widget so
+            `:popup-affordance? true` to the edn-inspector widget so
             the operator can pop a trace event's full EDN into the
             popup overlay (trace rows are narrow column space). After
-            `expand-tree` the data-display widget's outer `:div` carries
+            `expand-tree` the edn-inspector widget's outer `:div` carries
             `:data-rf-popup-affordance? \"1\"` when the opt is set."
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
@@ -656,7 +656,7 @@
       (let [tree     (trace/Panel)
             payload  (find-by-testid tree "rf-xray-trace-row-51-payload")
             ;; Walk the payload subtree (which is itself the result of
-            ;; `expand-tree`-ing) and find the data-display widget's
+            ;; `expand-tree`-ing) and find the edn-inspector widget's
             ;; outer container — it carries the `data-rf-popup-affordance?`
             ;; attribute when the opt is enabled.
             dd-containers
@@ -667,7 +667,7 @@
                     (hiccup-seq payload))]
         (is (some? payload) "expanded-row payload renders")
         (is (seq dd-containers)
-            "data-display container surfaces the popup-affordance attr")))))
+            "edn-inspector container surfaces the popup-affordance attr")))))
 
 (deftest source-coord-click-fires-open-in-editor
   (testing "clicking the source-coord ↗ fires :rf.xray/open-in-editor;

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -117,25 +117,25 @@
    ;; rf2-okvit — app-db tab current-state inspector section model.
    :rf.xray/app-db-state
    :rf.xray/cascades
-   ;; First-class data-display widget owns the WHOLE renderer contract
-   ;; — browse + diff + mini — via `:rf.xray.data-display/*` events &
+   ;; First-class edn-inspector widget owns the WHOLE renderer contract
+   ;; — browse + diff + mini — via `:rf.xray.edn-inspector/*` events &
    ;; subs (rf2-oqa60 phase 1 + rf2-q3dzw phase 5). The pre-rf2-q3dzw
-   ;; sibling slots (`:rf.xray/data-display-{expansion,node-state}`
+   ;; sibling slots (`:rf.xray/edn-inspector-{expansion,node-state}`
    ;; and `:rf.xray.data-inspector/{expansion,all-expansion}`) are
-   ;; deleted with the legacy `data-display.render` +
+   ;; deleted with the legacy `edn-inspector.render` +
    ;; `theme.data-inspector` engines.
-   :rf.xray.data-display/expansion
+   :rf.xray.edn-inspector/expansion
    ;; rf2-kbdk8 — per-mount measured container widths for the width-aware
    ;; expansion heuristic. Keyed by mount-id; updated via ResizeObserver
    ;; in the widget's ref callback.
-   :rf.xray.data-display/widths
-   ;; rf2-l4625 — data-display popup overlay subs (stack + entries +
+   :rf.xray.edn-inspector/widths
+   ;; rf2-l4625 — edn-inspector popup overlay subs (stack + entries +
    ;; projection subs for open? / top / per-mount-id entry).
-   :rf.xray.data-display-popup/stack
-   :rf.xray.data-display-popup/entries
-   :rf.xray.data-display-popup/open?
-   :rf.xray.data-display-popup/top
-   :rf.xray.data-display-popup/entry
+   :rf.xray.edn-inspector-popup/stack
+   :rf.xray.edn-inspector-popup/entries
+   :rf.xray.edn-inspector-popup/open?
+   :rf.xray.edn-inspector-popup/top
+   :rf.xray.edn-inspector-popup/entry
    ;; rf2-59e7k — Cancellation-cascade visualiser subs (Machines
    ;; tab side-panel + Trace popover). Per
    ;; `tools/xray/spec/019-Cross-Cutting-Insight.md` §M.3.
@@ -370,8 +370,8 @@
   (sorted-set
    ;; (Pre-rf2-q3dzw `:rf.xray.data-inspector/*` events covered per-
    ;; row toggle/set + large-value confirm flow; the ns is deleted
-   ;; with phase 5 and the data-display widget's
-   ;; `:rf.xray.data-display/*` events cover the same surface. Large-
+   ;; with phase 5 and the edn-inspector widget's
+   ;; `:rf.xray.edn-inspector/*` events cover the same surface. Large-
    ;; blob confirm chrome moves to the popup phase, D6=a.)
    ;; rf2-ad7zx.9 — the `:rf.xray.issues/toggle-severity` /
    ;; `toggle-prefix` / `clear-filters` events were dropped with the
@@ -400,24 +400,24 @@
    :rf.xray/copy-path-to-clipboard
    :rf.xray/copy-share-url-to-clipboard
    :rf.xray/copy-value-to-clipboard
-   ;; First-class data-display widget events (sticky-expansion +
+   ;; First-class edn-inspector widget events (sticky-expansion +
    ;; reset). Per `tools/xray/spec/021-Dynamic-Panel-Designs.md` §10.4.
    ;; The pre-rf2-q3dzw flat-shape sibling events
-   ;; (`:rf.xray/data-display-*`) are deleted with the legacy
-   ;; `data-display.render` engine in phase 5.
-   :rf.xray.data-display/reset-expansion
-   :rf.xray.data-display/set-node
-   :rf.xray.data-display/toggle-node
+   ;; (`:rf.xray/edn-inspector-*`) are deleted with the legacy
+   ;; `edn-inspector.render` engine in phase 5.
+   :rf.xray.edn-inspector/reset-expansion
+   :rf.xray.edn-inspector/set-node
+   :rf.xray.edn-inspector/toggle-node
    ;; rf2-kbdk8 — width-aware heuristic events. set-width records the
    ;; ResizeObserver measurement; clear-width is dispatched on unmount.
-   :rf.xray.data-display/set-width
-   :rf.xray.data-display/clear-width
-   ;; rf2-l4625 — data-display popup overlay events (open / close /
+   :rf.xray.edn-inspector/set-width
+   :rf.xray.edn-inspector/clear-width
+   ;; rf2-l4625 — edn-inspector popup overlay events (open / close /
    ;; close-top / close-all).
-   :rf.xray.data-display-popup/open
-   :rf.xray.data-display-popup/close
-   :rf.xray.data-display-popup/close-top
-   :rf.xray.data-display-popup/close-all
+   :rf.xray.edn-inspector-popup/open
+   :rf.xray.edn-inspector-popup/close
+   :rf.xray.edn-inspector-popup/close-top
+   :rf.xray.edn-inspector-popup/close-all
    :rf.xray/delete-edit-popup
    :rf.xray/edit-popup-set-mode
    :rf.xray/edit-popup-set-pattern
@@ -458,7 +458,7 @@
    ;; retired — xyflow owns zoom/pan/fit internally).
    :rf.xray.machine-canvas/hydrate-view-modes
    :rf.xray.machine-canvas/set-view-mode
-   ;; (Pre-rf2-q3dzw the legacy `data-display.render` engine emitted
+   ;; (Pre-rf2-q3dzw the legacy `edn-inspector.render` engine emitted
    ;; `:rf.xray/navigate-to-path` from its clickable-path glyphs and
    ;; registered a default no-op handler. The new widget ships ZERO
    ;; path-click interactions in phase 1 — the locked B.9 / rf2-sndui

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -125,6 +125,10 @@
    ;; deleted with the legacy `data-display.render` +
    ;; `theme.data-inspector` engines.
    :rf.xray.data-display/expansion
+   ;; rf2-kbdk8 — per-mount measured container widths for the width-aware
+   ;; expansion heuristic. Keyed by mount-id; updated via ResizeObserver
+   ;; in the widget's ref callback.
+   :rf.xray.data-display/widths
    ;; rf2-l4625 — data-display popup overlay subs (stack + entries +
    ;; projection subs for open? / top / per-mount-id entry).
    :rf.xray.data-display-popup/stack
@@ -404,6 +408,10 @@
    :rf.xray.data-display/reset-expansion
    :rf.xray.data-display/set-node
    :rf.xray.data-display/toggle-node
+   ;; rf2-kbdk8 — width-aware heuristic events. set-width records the
+   ;; ResizeObserver measurement; clear-width is dispatched on unmount.
+   :rf.xray.data-display/set-width
+   :rf.xray.data-display/clear-width
    ;; rf2-l4625 — data-display popup overlay events (open / close /
    ;; close-top / close-all).
    :rf.xray.data-display-popup/open

--- a/tools/xray/test/day8/re_frame2_xray/static/flows/panel_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/flows/panel_cljs_test.cljs
@@ -25,7 +25,7 @@
             [day8.re-frame2-xray.static.flows.panel :as panel]
             [day8.re-frame2-xray.test-support :as xray-test-support]
             [day8.re-frame2-xray.trace-collector :as trace-collector]
-            [day8.re-frame2-xray.views.data-display :as dd]))
+            [day8.re-frame2-xray.views.edn-inspector :as ei]))
 
 ;; ---- fixture ------------------------------------------------------------
 
@@ -47,7 +47,7 @@
     (let [result (apply (first tree) (rest tree))]
       ;; Form-2 Reagent components return an inner fn; call it with
       ;; the same args (per Reagent's re-render contract) to obtain
-      ;; the rendered hiccup. rf2-oqa60 — the data-display widget is
+      ;; the rendered hiccup. rf2-oqa60 — the edn-inspector widget is
       ;; form-2 so the mount-id stays stable across re-renders.
       (expand-tree
         (if (fn? result)
@@ -310,8 +310,8 @@
 (deftest input-output-render-through-edn-widget
   (testing "rf2-2kwhw + rf2-oqa60 — input + output paths render via the
             shared EDN widget, which post-rf2-oqa60 phase 1 delegates
-            to the first-class data-display widget. The rendered tree
-            contains `rf-xray-data-display-*` container testids."
+            to the first-class edn-inspector widget. The rendered tree
+            contains `rf-xray-edn-inspector-*` container testids."
     (setup-xray!)
     (rf/with-frame :rf/xray
       (rf/dispatch-sync
@@ -319,6 +319,6 @@
          sample-flows])
       (let [tree (panel/Panel)
             widget-nodes (find-all-by-testid-prefix
-                           tree "rf-xray-data-display-")]
+                           tree "rf-xray-edn-inspector-")]
         (is (seq widget-nodes)
-            "at least one data-display widget container present")))))
+            "at least one edn-inspector widget container present")))))

--- a/tools/xray/test/day8/re_frame2_xray/static/routes/panel_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/routes/panel_cljs_test.cljs
@@ -70,7 +70,7 @@
     (let [result (apply (first node) (rest node))]
       ;; Form-2 Reagent components return an inner fn; re-call with
       ;; the same args (per Reagent's re-render contract) to obtain
-      ;; the rendered hiccup. rf2-oqa60 — the data-display widget is
+      ;; the rendered hiccup. rf2-oqa60 — the edn-inspector widget is
       ;; form-2 so the mount-id stays stable across re-renders.
       (expand-children
         (if (fn? result)
@@ -436,7 +436,7 @@
 (deftest expand-meta-renders-through-edn-widget-with-copy
   (testing "rf2-2kwhw + rf2-oqa60 — the registrar-meta block routes
             through the shared EDN widget; phase 1 delegates to the
-            first-class data-display widget. The copy affordance is
+            first-class edn-inspector widget. The copy affordance is
             deferred to the popup phase (D6=a) — phase 1 has no copy
             chrome on the new widget, so this test now smokes the
             widget wiring only."
@@ -448,8 +448,8 @@
                         {:frame :rf/xray})
       (let [tree (panel/Panel)
             widget (find-all-by-testid-prefix
-                     tree "rf-xray-data-display-")]
+                     tree "rf-xray-edn-inspector-")]
         (is (some? (find-by-testid tree "rf-xray-static-routes-meta-route/cart"))
             "meta block wrapper preserved")
         (is (seq widget)
-            "registrar meta renders through the data-display widget")))))
+            "registrar meta renders through the edn-inspector widget")))))

--- a/tools/xray/test/day8/re_frame2_xray/static/schemas/panel_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/schemas/panel_cljs_test.cljs
@@ -31,7 +31,7 @@
     (let [result (apply (first tree) (rest tree))]
       ;; Form-2 Reagent components return an inner fn; re-call with
       ;; the same args (Reagent's re-render contract). rf2-oqa60 —
-      ;; data-display is form-2 to stabilise mount-id.
+      ;; edn-inspector is form-2 to stabilise mount-id.
       (expand-tree
         (if (fn? result)
           (apply result (rest tree))
@@ -293,7 +293,7 @@
 (deftest schema-edn-renders-through-widget-with-copy
   (testing "rf2-2kwhw + rf2-oqa60 — the Malli schema renders via the
             shared EDN widget; phase 1 delegates to the first-class
-            data-display widget. The copy affordance is deferred to
+            edn-inspector widget. The copy affordance is deferred to
             the popup phase (D6=a) — phase 1 has no copy chrome on
             the new widget."
     (setup-xray!)
@@ -303,5 +303,5 @@
          sample-registry])
       (let [tree (panel/Panel)
             widget (find-all-by-testid-prefix
-                     tree "rf-xray-data-display-")]
-        (is (seq widget) "schema values render through the data-display widget")))))
+                     tree "rf-xray-edn-inspector-")]
+        (is (seq widget) "schema values render through the edn-inspector widget")))))

--- a/tools/xray/test/day8/re_frame2_xray/theme/var_resolution_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/theme/var_resolution_cljs_test.cljs
@@ -49,7 +49,7 @@
             [day8.re-frame2-xray.panels.event.event-status-colour :as event-status]
             [day8.re-frame2-xray.panels.issues-ribbon-helpers :as issues-h]
             [day8.re-frame2-xray.panels.trace-helpers :as trace-h]
-            [day8.re-frame2-xray.views.data-display :as dd]
+            [day8.re-frame2-xray.views.edn-inspector :as ei]
             [day8.re-frame2-xray.theme.perf-tier :as perf-tier]
             [day8.re-frame2-xray.theme.tokens :as tokens]))
 
@@ -262,9 +262,9 @@
   ;; of a `var(--rf-xray-…)` reference (no hex digits in the var name).
   #"#[0-9A-Fa-f]{3,8}\b")
 
-(deftest data-display-rendered-hiccup-has-no-palette-hex-literals
+(deftest edn-inspector-rendered-hiccup-has-no-palette-hex-literals
   (testing "rf2-on4cm — the canonical L4-panel value renderer
-            (`views/data-display/render-node`) emits hiccup whose
+            (`views/edn-inspector/render-node`) emits hiccup whose
             every `:style` colour value flows through a CSS variable.
             Walk the rendered tree across a representative mix of
             values (collection, keyword, string, number, nil,
@@ -273,7 +273,7 @@
             new inline-style site is added with a hardcoded hex.
 
             Migrated rf2-q3dzw phase 5: the legacy
-            `theme/data-inspector` is deleted; the data-display
+            `theme/data-inspector` is deleted; the edn-inspector
             widget is now the single source of truth."
     (doseq [v [{:a 1 :b 2 :c [1 2 3]}      ; map + nested vec
                [:foo :bar {:baz nil}]      ; vector with primitives + map
@@ -286,7 +286,7 @@
                :rf/redacted                ; redacted sentinel
                {:rf/large {:bytes 1234     ; large sentinel
                            :head "abc"}}]]
-      (let [tree (dd/render-node {:value v
+      (let [tree (ei/render-node {:value v
                                   :panel-id :rf.xray/var-resolution-test
                                   :mount-id "test"
                                   :path []

--- a/tools/xray/test/day8/re_frame2_xray/views/data_display_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/data_display_cljs_test.cljs
@@ -1469,3 +1469,220 @@
           "background reads through `:bg-1` (CSS-var or hex per theme)")
       (is (= (str "1px solid " (:border-default tokens)) (:border style))
           "border reads through `:border-default` (CSS-var or hex per theme)"))))
+
+;; =========================================================================
+;; rf2-kbdk8 — width-aware expansion heuristic
+;; =========================================================================
+;;
+;; The heuristic flips the auto-expand decision: render inline when the
+;; value's estimated pr-str width fits the measured column with a small
+;; safety margin; otherwise expand to tree. `default-expanded-depth` is
+;; repurposed as a CEILING beyond which the widget never auto-expands.
+;;
+;; These tests pin the pure decision functions (estimated-inline-px,
+;; would-fit-inline?, default-expanded? width-aware branch) and the
+;; render-container integration:
+;;
+;;   - width-aware default? returns false when value fits the column;
+;;     true (within ceiling) when it doesn't.
+;;   - operator's sticky override still wins (a width-fitting node the
+;;     operator explicitly opened renders expanded, not inline).
+;;   - diff mode's force-open over changed descendants still fires.
+;;   - the recursive inline renderer paints nested containers in one
+;;     line with full syntax-palette colour.
+
+(deftest mono-char-width-and-safety-margin-are-stable
+  (testing "rf2-kbdk8 — width-estimation constants exposed for tests"
+    (is (= 7 dd/mono-char-width-px)
+        "7px M-advance is the conservative pick for JetBrains Mono 12px")
+    (is (= 16 dd/safety-margin-px)
+        "16px safety margin covers closing bracket + gutter")
+    (is (= 8 dd/default-ceiling-depth)
+        "new default `:default-expanded-depth` is 8 (CEILING, not trigger)")))
+
+(deftest estimated-inline-px-multiplies-pr-str-by-mono-advance
+  (testing "rf2-kbdk8 — char-count × 7px estimate"
+    (is (= (* 7 (count (pr-str {:a 1})))
+           (dd/estimated-inline-px {:a 1}))
+        "pure function — char count × mono-char-width-px")
+    (is (= (* 7 (count "nil"))
+           (dd/estimated-inline-px nil))
+        "scalars route through the same pr-str pathway")
+    ;; Long compound values get proportionally wider estimates — the
+    ;; bead's example (~81-char nested value) lands around ~570px.
+    (let [big-value [:ws/connection [:rf.machine.timer/after-elapsed
+                                     2501 [:active :authenticating]]]]
+      (is (= (* 7 (count (pr-str big-value)))
+             (dd/estimated-inline-px big-value))
+          "nested compound value estimate matches pr-str-length × 7"))))
+
+(deftest would-fit-inline-fits-when-estimate-plus-margin-le-available
+  (testing "rf2-kbdk8 — `would-fit-inline?` gate"
+    ;; A short value pr-strs to ~10 chars × 7px = 70px + 16px margin = 86px.
+    (let [v {:a 1}]
+      (is (dd/would-fit-inline? v 200)
+          "200px column trivially fits a 10-char value")
+      (is (not (dd/would-fit-inline? v 50))
+          "50px column rejects even short values"))
+    ;; The bead's worked example: ~81-char nested value in a 966px column.
+    (let [big-but-fitting (apply str (repeat 80 "x"))]
+      (is (dd/would-fit-inline? big-but-fitting 966)
+          "~570px estimate trivially fits 966px column"))
+    (is (not (dd/would-fit-inline? {:a 1} nil))
+        "nil available-width falls back to legacy strict gate")
+    (is (not (dd/would-fit-inline? {:a 1} 0))
+        "zero or negative width is treated as no measurement")))
+
+(deftest default-expanded-width-aware-branch
+  (testing "rf2-kbdk8 — width-aware `default-expanded?` flips the verdict"
+    ;; A 2-key map fits in 600px easily — should NOT auto-expand (the
+    ;; inline-fit gate picks it up instead).
+    (is (false? (dd/default-expanded?
+                  {:depth 0 :child-count 2 :value {:a 1 :b 2}
+                   :available-width-px 600})))
+    ;; A long string-keyed map that overflows 200px should auto-expand
+    ;; (within the ceiling).
+    (let [wide-v {:a "much-longer-than-the-budget"
+                  :b "another-overflowing-string"
+                  :c "and-yet-more-data"}]
+      (is (true? (dd/default-expanded?
+                   {:depth 0 :child-count 3 :value wide-v
+                    :available-width-px 100}))))
+    ;; Beyond the ceiling, the width-aware branch falls back to false
+    ;; (collapsed summary instead of auto-expanding pathologically deep).
+    (let [wide-v {:a "much-longer-than-the-budget"
+                  :b "another-overflowing-string"}]
+      (is (false? (dd/default-expanded?
+                    {:depth 9 :child-count 2 :value wide-v
+                     :default-expanded-depth 8
+                     :available-width-px 100}))))
+    ;; Diff mode's force-open over changed descendants still beats width
+    (let [v {:a "wide string that overflows"}]
+      (is (true? (dd/default-expanded?
+                   {:depth 0 :child-count 1 :value v
+                    :available-width-px 1000
+                    :has-changed-descendant? true}))
+          "changed-descendant rule beats width-fits for diff readability"))))
+
+(deftest default-expanded-no-measurement-fallback
+  (testing "rf2-kbdk8 — when no measurement yet (nil available-width-px)
+            the legacy depth-driven path runs unchanged so unit tests +
+            first-paint behaviour stay deterministic"
+    ;; depth 0, default-expanded-depth 2 → expanded (legacy behaviour).
+    (is (true? (dd/default-expanded?
+                 {:depth 0 :child-count 2 :value {:a 1 :b 2}
+                  :default-expanded-depth 2})))
+    ;; depth 5, default-expanded-depth 2 → collapsed (legacy behaviour).
+    (is (false? (dd/default-expanded?
+                  {:depth 5 :child-count 2 :value {:a 1 :b 2}
+                   :default-expanded-depth 2})))))
+
+(deftest render-container-width-fit-renders-inline-recursively
+  (testing "rf2-kbdk8 — when measured width fits the value's pr-str,
+            the renderer emits the FULL value (including nested
+            containers) on one inline span — no expand glyph, no
+            multi-row tree"
+    ;; ~60-char nested value vs 800px column.
+    (let [v {:tag :foo :payload [:active :authenticating]}
+          h (dd/render-node {:value v
+                             :panel-id :p :mount-id "m" :path []
+                             :depth 0 :expansion-map {}
+                             :opts {:default-expanded-depth 2
+                                    :available-width-px 800}})
+          text (collect-text h)]
+      ;; No toggle glyph — the whole thing is already visible.
+      (is (not (re-find #"▾|▸" text))
+          "width-fit inline render carries no expand/collapse glyph")
+      ;; All scalars present in the one-line render.
+      (is (re-find #":tag" text))
+      (is (re-find #":payload" text))
+      (is (re-find #":active" text))
+      (is (re-find #":authenticating" text)))))
+
+(deftest render-container-too-wide-expands-to-tree
+  (testing "rf2-kbdk8 — when measured width is too narrow for the
+            value's pr-str, the renderer falls back to the tree form
+            (▾ glyph + indented body)"
+    (let [v {:a "much-longer-than-the-budget"
+             :b "another-overflowing-string"
+             :c "and-yet-more-data"
+             :d "and-yet-still-more"
+             :e "the-final-overflow"}
+          h (dd/render-node {:value v
+                             :panel-id :p :mount-id "m" :path []
+                             :depth 0 :expansion-map {}
+                             :opts {:default-expanded-depth 8
+                                    :available-width-px 100}})
+          text (collect-text h)]
+      ;; Toggle glyph present — narrow column triggers tree form.
+      (is (re-find #"▾" text)
+          "narrow-column overflow renders expanded tree")
+      (is (re-find #":a" text))
+      (is (re-find #":e" text)))))
+
+(deftest render-container-respects-operator-override-over-width-fit
+  (testing "rf2-kbdk8 — operator's explicit expand override wins even
+            when the value would naturally render inline; the operator
+            sees what they clicked, not the heuristic's verdict"
+    (let [v {:tag :foo :n 1}
+          k0 (dd/expansion-key :p "m" [])
+          h (dd/render-node {:value v
+                             :panel-id :p :mount-id "m" :path []
+                             :depth 0
+                             :expansion-map {k0 {:expanded? true}}
+                             :opts {:default-expanded-depth 2
+                                    :available-width-px 800}})
+          text (collect-text h)]
+      ;; Operator clicked-open → expanded tree, not inline.
+      (is (re-find #"▾" text)
+          "operator override beats the width-fits inline path")
+      (is (re-find #":tag" text)))))
+
+(deftest render-inline-recursive-paints-nested-containers
+  (testing "rf2-kbdk8 — the recursive inline renderer emits one-line
+            hiccup that includes nested brackets, separators, scalars"
+    (let [v {:k1 1 :k2 [:a :b]}
+          h (dd/render-inline-recursive v)
+          text (collect-text h)]
+      (is (re-find #":k1" text))
+      (is (re-find #":k2" text))
+      ;; Nested vector's brackets present.
+      (is (re-find #"\[" text))
+      (is (re-find #"\]" text))
+      ;; Outer map brackets present.
+      (is (re-find #"\{" text))
+      (is (re-find #"\}" text))
+      ;; Scalars from the nested vector.
+      (is (re-find #":a" text))
+      (is (re-find #":b" text)))))
+
+(deftest width-slot-set-and-clear-events
+  (testing "rf2-kbdk8 — set-width / clear-width app-db reducers"
+    (rf/dispatch-sync [:rf.xray.data-display/set-width "m" 600])
+    (let [widths @(rf/subscribe [dd/widths-slot])]
+      (is (= 600 (get widths "m"))
+          "set-width writes a positive measurement to the slot"))
+    ;; Bad inputs are ignored (no app-db churn).
+    (rf/dispatch-sync [:rf.xray.data-display/set-width "m2" -5])
+    (rf/dispatch-sync [:rf.xray.data-display/set-width nil 100])
+    (let [widths @(rf/subscribe [dd/widths-slot])]
+      (is (nil? (get widths "m2")) "negative width is rejected")
+      (is (nil? (get widths nil))  "nil mount-id is rejected"))
+    ;; Cleanup
+    (rf/dispatch-sync [:rf.xray.data-display/clear-width "m"])
+    (let [after-clear @(rf/subscribe [dd/widths-slot])]
+      (is (nil? (get after-clear "m"))
+          "clear-width removes the entry"))))
+
+(deftest widget-emits-ref-callback-and-available-width-attr
+  (testing "rf2-kbdk8 — the outer container carries a `:ref` callback
+            (function) for the ResizeObserver lifecycle, plus a data-
+            attribute carrying the current measurement (or absent when
+            not yet measured)"
+    (let [h (invoke-data-display {:a 1} {:panel-id :rf.xray/app-db})
+          attrs (-> h second)]
+      (is (fn? (:ref attrs))
+          "outer container carries a ref callback (mount/unmount hook)")
+      ;; No measurement yet → attribute absent / nil.
+      (is (nil? (:data-rf-available-width-px attrs))
+          "data-rf-available-width-px absent until the ref fires"))))

--- a/tools/xray/test/day8/re_frame2_xray/views/data_display_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/data_display_cljs_test.cljs
@@ -1062,11 +1062,109 @@
   (is (= " " (dd/op->gutter-glyph :same))))
 
 (deftest gutter-tone-mapping
-  (is (= :green     (dd/op->gutter-tone-key :added)))
-  (is (= :red       (dd/op->gutter-tone-key :removed)))
-  (is (= :yellow    (dd/op->gutter-tone-key :modified)))
-  (is (= :accent    (dd/op->gutter-tone-key :children)))
-  (is (= :text-tertiary (dd/op->gutter-tone-key :same))))
+  (testing "rf2-awqts — every active diff op now reads the SAME
+            reserved `:diff-gutter` token; the glyph's hue is no longer
+            per-op (per-op signal lives in the wash + stripe + shape).
+            `:same` keeps `:text-tertiary` so the transparent non-diff
+            shape composes unchanged."
+    (is (= :diff-gutter   (dd/op->gutter-tone-key :added)))
+    (is (= :diff-gutter   (dd/op->gutter-tone-key :removed)))
+    (is (= :diff-gutter   (dd/op->gutter-tone-key :modified)))
+    (is (= :diff-gutter   (dd/op->gutter-tone-key :children)))
+    (is (= :text-tertiary (dd/op->gutter-tone-key :same)))))
+
+;; ---- rf2-awqts — row chrome (wash + stripe) -----------------------------
+
+(deftest row-wash-mapping
+  (testing "rf2-awqts — per-op row-background wash token-key mapping"
+    (is (= :diff-added-wash    (dd/op->row-wash-key :added)))
+    (is (= :diff-removed-wash  (dd/op->row-wash-key :removed)))
+    (is (= :diff-modified-wash (dd/op->row-wash-key :modified)))
+    (is (nil? (dd/op->row-wash-key :children))
+        "`:children` rows carry NO wash — the colour-coded descendants below do")
+    (is (nil? (dd/op->row-wash-key :same))
+        "`:same` rows sit flush with the canvas")))
+
+(deftest row-stripe-mapping
+  (testing "rf2-awqts — per-op 2px-stripe token-key mapping"
+    (is (= :diff-added-stripe    (dd/op->row-stripe-key :added)))
+    (is (= :diff-removed-stripe  (dd/op->row-stripe-key :removed)))
+    (is (= :diff-modified-stripe (dd/op->row-stripe-key :modified)))
+    (is (nil? (dd/op->row-stripe-key :children)))
+    (is (nil? (dd/op->row-stripe-key :same)))))
+
+(deftest gutter-glyph-colour-is-syntax-palette-disjoint
+  (testing "rf2-awqts — the reserved `:diff-gutter` hue must NOT match
+            any `:syntax-*` token. Pre-fix the per-op gutter colour
+            mapped through `:green` / `:red` / `:yellow` / `:accent`
+            which collided with `:syntax-string` / `:syntax-number` /
+            `:syntax-boolean` etc., conflating type semantics with
+            diff state. The new reserved hue (cyan-teal in dark,
+            darker-teal in light) sits outside every `:syntax-*`
+            family by design."
+    (doseq [palette [dark-palette light-palette]]
+      (let [gutter (:diff-gutter palette)
+            syntax-hexes #{(:syntax-keyword palette)
+                           (:syntax-string  palette)
+                           (:syntax-number  palette)
+                           (:syntax-boolean palette)
+                           (:syntax-nil     palette)
+                           (:syntax-symbol  palette)
+                           (:syntax-builtin palette)
+                           (:syntax-punctuation palette)}]
+        (is (not (contains? syntax-hexes gutter))
+            (str "diff-gutter " gutter " collides with a syntax-* token "
+                 "in palette " (if (= palette dark-palette) :dark :light)))))))
+
+(deftest diff-leaf-preserves-syntax-token-colour
+  (testing "rf2-awqts — per-token text colour PRESERVED across `:added`
+            and `:modified` ops. Pre-fix the diff path overrode to
+            `:green` / `:yellow` text colour which clashed with the
+            Calva-aligned syntax palette (numbers orange ≡ modified
+            yellow); now the row chrome (wash + stripe + glyph)
+            carries the diff signal."
+    ;; :added — number value keeps `:syntax-number` orange
+    (let [h (dd/render-node {:value 42 :before ::dd/missing :diff? true
+                             :panel-id :p :mount-id "m" :path [] :depth 0
+                             :expansion-map {} :opts {}})
+          node (find-attr h :data-rf-type "number")]
+      (is (some? node) "number scalar rendered inside the gutter row")
+      (is (= (:syntax-number tokens) (-> node second :style :color))
+          ":syntax-number token preserved on the added scalar"))
+    ;; :modified — boolean keeps `:syntax-boolean` gold
+    (let [h (dd/render-node {:value true :before false :diff? true
+                             :panel-id :p :mount-id "m" :path [] :depth 0
+                             :expansion-map {} :opts {}})
+          node (find-attr h :data-rf-type "boolean")]
+      (is (some? node) "boolean scalar rendered inside the gutter row")
+      (is (= (:syntax-boolean tokens) (-> node second :style :color))
+          ":syntax-boolean token preserved on the modified scalar"))))
+
+(deftest diff-row-wrapper-carries-wash-and-stripe-attrs
+  (testing "rf2-awqts — diff row wrapper carries data-attributes so
+            tests + DOM inspectors can confirm the wash + stripe are
+            applied per op"
+    (let [h (dd/render-node {:value 42 :before ::dd/missing :diff? true
+                             :panel-id :p :mount-id "m" :path [] :depth 0
+                             :expansion-map {} :opts {}})
+          wrapper (find-attr h :data-rf-diff-op "added")]
+      (is (some? wrapper))
+      (is (= "1" (:data-rf-diff-wash  (second wrapper)))
+          "added row carries wash attr")
+      (is (= "1" (:data-rf-diff-stripe (second wrapper)))
+          "added row carries stripe attr")
+      (is (= (:diff-added-wash tokens) (-> wrapper second :style :background))
+          "wash background reads through the diff-added-wash token"))
+    ;; :same — no wash, no stripe attrs
+    (let [h (dd/render-node {:value 42 :before 42 :diff? true
+                             :panel-id :p :mount-id "m" :path [] :depth 0
+                             :expansion-map {} :opts {}})
+          wrapper (find-attr h :data-rf-diff-op "same")]
+      (is (some? wrapper))
+      (is (nil? (:data-rf-diff-wash  (second wrapper)))
+          ":same row has no wash")
+      (is (nil? (:data-rf-diff-stripe (second wrapper)))
+          ":same row has no stripe"))))
 
 ;; ---- diff mode — modified-leaf annotation --------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs
@@ -1,5 +1,5 @@
-(ns day8.re-frame2-xray.views.data-display-cljs-test
-  "Unit tests for the first-class data-display widget (rf2-oqa60
+(ns day8.re-frame2-xray.views.edn-inspector-cljs-test
+  "Unit tests for the first-class edn-inspector widget (rf2-oqa60
   phase 1).
 
   ## What's under test
@@ -15,7 +15,7 @@
   5. **Click-to-toggle** — toggle event flips the per-path expansion;
      dispatch carries the canonical event shape; expanded state
      swaps the glyph `▸` → `▾` and renders the body.
-  6. **Per-call-site isolation** — two `[data-display]` mounts get
+  6. **Per-call-site isolation** — two `[edn-inspector]` mounts get
      independent `mount-id`s; toggling one path in mount-A leaves
      mount-B's same path untouched.
   7. **Sentinels** (`:rf/redacted`, `:rf/large`, combined) render
@@ -27,7 +27,7 @@
             [re-frame.core :as rf]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
-            [day8.re-frame2-xray.views.data-display :as dd]
+            [day8.re-frame2-xray.views.edn-inspector :as ei]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens dark-palette light-palette]]))
 
@@ -77,37 +77,37 @@
 ;; ---- collection-kind classification -------------------------------------
 
 (deftest classify-scalars
-  (is (= :nil      (dd/collection-kind nil)))
-  (is (= :boolean  (dd/collection-kind true)))
-  (is (= :boolean  (dd/collection-kind false)))
-  (is (= :keyword  (dd/collection-kind :foo)))
-  (is (= :keyword  (dd/collection-kind :ns/foo)))
-  (is (= :symbol   (dd/collection-kind 'sym)))
-  (is (= :string   (dd/collection-kind "hi")))
-  (is (= :number   (dd/collection-kind 42)))
-  (is (= :number   (dd/collection-kind 3.14)))
-  (is (= :uuid     (dd/collection-kind (random-uuid))))
-  (is (= :regex    (dd/collection-kind #"abc")))
-  (is (= :fn       (dd/collection-kind (fn [x] x)))))
+  (is (= :nil      (ei/collection-kind nil)))
+  (is (= :boolean  (ei/collection-kind true)))
+  (is (= :boolean  (ei/collection-kind false)))
+  (is (= :keyword  (ei/collection-kind :foo)))
+  (is (= :keyword  (ei/collection-kind :ns/foo)))
+  (is (= :symbol   (ei/collection-kind 'sym)))
+  (is (= :string   (ei/collection-kind "hi")))
+  (is (= :number   (ei/collection-kind 42)))
+  (is (= :number   (ei/collection-kind 3.14)))
+  (is (= :uuid     (ei/collection-kind (random-uuid))))
+  (is (= :regex    (ei/collection-kind #"abc")))
+  (is (= :fn       (ei/collection-kind (fn [x] x)))))
 
 (deftest classify-collections
-  (is (= :map     (dd/collection-kind {:a 1})))
-  (is (= :vector  (dd/collection-kind [1 2 3])))
-  (is (= :list    (dd/collection-kind '(1 2 3))))
-  (is (= :set     (dd/collection-kind #{1 2 3})))
-  (is (= :seq     (dd/collection-kind (map inc [1 2 3]))))
-  (is (= :map     (dd/collection-kind {})))
-  (is (= :vector  (dd/collection-kind []))))
+  (is (= :map     (ei/collection-kind {:a 1})))
+  (is (= :vector  (ei/collection-kind [1 2 3])))
+  (is (= :list    (ei/collection-kind '(1 2 3))))
+  (is (= :set     (ei/collection-kind #{1 2 3})))
+  (is (= :seq     (ei/collection-kind (map inc [1 2 3]))))
+  (is (= :map     (ei/collection-kind {})))
+  (is (= :vector  (ei/collection-kind []))))
 
 (deftest classify-sentinels
   (testing "redacted bare keyword"
-    (is (= :sentinel-redacted (dd/collection-kind :rf/redacted))))
+    (is (= :sentinel-redacted (ei/collection-kind :rf/redacted))))
   (testing "large wrapper"
     (is (= :sentinel-large
-           (dd/collection-kind {:rf/large {:bytes 200 :head "abc"}}))))
+           (ei/collection-kind {:rf/large {:bytes 200 :head "abc"}}))))
   (testing "redacted-with-size wrapper"
     (is (= :sentinel-redacted-size
-           (dd/collection-kind {:rf/redacted {:bytes 200}})))))
+           (ei/collection-kind {:rf/redacted {:bytes 200}})))))
 
 ;; ---- scalar rendering ----------------------------------------------------
 
@@ -115,24 +115,24 @@
   ;; rf2-79ojx — keywords paint via `:syntax-keyword` (magenta), NOT
   ;; `:accent` (chrome blue). The previous mapping put 3 of 5 scalar
   ;; types in the same blue family.
-  (let [h (dd/render-scalar :foo)]
+  (let [h (ei/render-scalar :foo)]
     (is (= :span (first h)))
     (is (= (:syntax-keyword tokens) (-> h second :style :color)))
     (is (= ":foo" (collect-text h)))))
 
 (deftest scalar-string-uses-syntax-string-and-quotes
-  (let [h (dd/render-scalar "hello")]
+  (let [h (ei/render-scalar "hello")]
     (is (= (:syntax-string tokens) (-> h second :style :color)))
     (is (= "\"hello\"" (collect-text h)))))
 
 (deftest scalar-number-uses-syntax-number
-  (let [h (dd/render-scalar 42)]
+  (let [h (ei/render-scalar 42)]
     (is (= (:syntax-number tokens) (-> h second :style :color)))
     (is (= "42" (collect-text h)))))
 
 (deftest scalar-boolean-distinct-from-number
-  (let [h-true (dd/render-scalar true)
-        h-num  (dd/render-scalar 1)]
+  (let [h-true (ei/render-scalar true)
+        h-num  (ei/render-scalar 1)]
     (is (= "true" (collect-text h-true)))
     (is (not= (-> h-true second :style :color)
               (-> h-num  second :style :color))
@@ -141,18 +141,18 @@
 (deftest scalar-nil-uses-syntax-nil
   ;; rf2-79ojx — nil paints via its own dedicated `:syntax-nil` token
   ;; (deliberately muted grey, "absence" reads as faded).
-  (let [h (dd/render-scalar nil)]
+  (let [h (ei/render-scalar nil)]
     (is (= (:syntax-nil tokens) (-> h second :style :color)))
     (is (= "nil" (collect-text h)))))
 
 (deftest scalar-symbol-uses-syntax-symbol
   ;; rf2-79ojx — symbols paint via `:syntax-symbol` (blue), distinct
   ;; from the magenta now used for keywords.
-  (let [h (dd/render-scalar 'sym)]
+  (let [h (ei/render-scalar 'sym)]
     (is (= (:syntax-symbol tokens) (-> h second :style :color)))))
 
 (deftest scalar-fn-renders-with-italic
-  (let [h (dd/render-scalar (fn [x] x))]
+  (let [h (ei/render-scalar (fn [x] x))]
     (is (re-find #"^#fn" (collect-text h)))
     (is (= "italic" (-> h second :style :font-style)))))
 
@@ -250,24 +250,24 @@
 ;; ---- sentinel rendering --------------------------------------------------
 
 (deftest redacted-sentinel-chrome
-  (let [h (dd/render-scalar :rf/redacted)
+  (let [h (ei/render-scalar :rf/redacted)
         all (collect-text h)]
-    (is (some? (find-attr h :data-testid "rf-xray-data-display-redacted")))
+    (is (some? (find-attr h :data-testid "rf-xray-edn-inspector-redacted")))
     (is (re-find #"redacted" all))
     (is (= (:magenta tokens) (-> h second :style :color)))))
 
 (deftest large-sentinel-chrome
-  (let [h (dd/render-scalar {:rf/large {:bytes 5000 :head "preview"}})
+  (let [h (ei/render-scalar {:rf/large {:bytes 5000 :head "preview"}})
         all (collect-text h)]
-    (is (some? (find-attr h :data-testid "rf-xray-data-display-large")))
+    (is (some? (find-attr h :data-testid "rf-xray-edn-inspector-large")))
     (is (re-find #"large" all))
     (is (re-find #"5000" all))
     (is (= (:yellow tokens) (-> h second :style :color)))))
 
 (deftest redacted-size-sentinel-chrome
-  (let [h (dd/render-scalar {:rf/redacted {:bytes 200}})
+  (let [h (ei/render-scalar {:rf/redacted {:bytes 200}})
         all (collect-text h)]
-    (is (some? (find-attr h :data-testid "rf-xray-data-display-redacted-size")))
+    (is (some? (find-attr h :data-testid "rf-xray-edn-inspector-redacted-size")))
     (is (re-find #"200" all))
     (is (= (:magenta tokens) (-> h second :style :color)))))
 
@@ -276,12 +276,12 @@
 (deftest inline-preview-map-all-fit
   (testing "small map fits inline as `{:a 1, :b 2}`"
     (is (= "{:a 1, :b 2}"
-           (dd/inline-preview-string {:a 1 :b 2} 3 80)))))
+           (ei/inline-preview-string {:a 1 :b 2} 3 80)))))
 
 (deftest inline-preview-map-overflow-fallback
   (testing "map that doesn't fit shows a partial OR `{…N keys}` fallback"
     (let [big (zipmap (map #(keyword (str "k" %)) (range 50)) (range 50))
-          s   (dd/inline-preview-string big 3 20)]
+          s   (ei/inline-preview-string big 3 20)]
       ;; Implementation may take any of: full first N (if fits),
       ;; partial preview with `…`, or the `{…50 keys}` fallback. ALL
       ;; outputs must:
@@ -294,66 +294,66 @@
 
 (deftest inline-preview-vector
   (is (= "[1, 2, 3]"
-         (dd/inline-preview-string [1 2 3] 3 80))))
+         (ei/inline-preview-string [1 2 3] 3 80))))
 
 (deftest inline-preview-set
-  (let [s   (dd/inline-preview-string #{:a :b} 3 80)]
+  (let [s   (ei/inline-preview-string #{:a :b} 3 80)]
     ;; Set iteration order is unspecified; assert shape.
     (is (re-find #"^#\{" s))
     (is (re-find #"\}$" s))))
 
 (deftest inline-preview-vector-with-more
   (testing "vector with more elements than max-elements gets `…`"
-    (let [s (dd/inline-preview-string [1 2 3 4 5] 3 80)]
+    (let [s (ei/inline-preview-string [1 2 3 4 5] 3 80)]
       (is (re-find #"…" s)))))
 
 ;; ---- bracket styling -----------------------------------------------------
 
 (deftest bracket-characters-per-kind
-  (is (= "{"  (-> dd/delim :map      :open)) "map opens with {")
-  (is (= "}"  (-> dd/delim :map      :close)))
-  (is (= "["  (-> dd/delim :vector   :open)) "vector opens with [")
-  (is (= "]"  (-> dd/delim :vector   :close)))
-  (is (= "#{" (-> dd/delim :set      :open)) "set opens with #{")
-  (is (= "("  (-> dd/delim :list     :open)) "list opens with (")
-  (is (= "["  (-> dd/delim :map-entry :open)) "map-entry uses [ chars")
+  (is (= "{"  (-> ei/delim :map      :open)) "map opens with {")
+  (is (= "}"  (-> ei/delim :map      :close)))
+  (is (= "["  (-> ei/delim :vector   :open)) "vector opens with [")
+  (is (= "]"  (-> ei/delim :vector   :close)))
+  (is (= "#{" (-> ei/delim :set      :open)) "set opens with #{")
+  (is (= "("  (-> ei/delim :list     :open)) "list opens with (")
+  (is (= "["  (-> ei/delim :map-entry :open)) "map-entry uses [ chars")
   (testing "map-entry brackets use a DIFFERENT colour token than vector"
-    (is (not= (-> dd/delim :vector :tone-key)
-              (-> dd/delim :map-entry :tone-key))
+    (is (not= (-> ei/delim :vector :tone-key)
+              (-> ei/delim :map-entry :tone-key))
         "map-entry and vector share chars but MUST use distinct colours")))
 
 ;; ---- expansion-key shape -------------------------------------------------
 
 (deftest expansion-key-shape
   (is (= [:app-db "mid-1" [:cart :items 0]]
-         (dd/expansion-key :app-db "mid-1" [:cart :items 0])))
+         (ei/expansion-key :app-db "mid-1" [:cart :items 0])))
   (is (= [:app-db "mid-1" [:a]]
-         (dd/expansion-key :app-db "mid-1" '(:a)))
+         (ei/expansion-key :app-db "mid-1" '(:a)))
       "path always coerced to a vector"))
 
 (deftest expansion-slot-keyword
   ;; The slot key is part of the public contract — keep it stable.
-  (is (= :rf.xray.data-display/expansion dd/expansion-slot)))
+  (is (= :rf.xray.edn-inspector/expansion ei/expansion-slot)))
 
 ;; ---- resolve-expanded? ---------------------------------------------------
 
 (deftest resolve-expanded-uses-override
   (let [path [:a :b]
-        k    (dd/expansion-key :p "m" path)]
+        k    (ei/expansion-key :p "m" path)]
     (testing "no override → default"
-      (is (true?  (dd/resolve-expanded? {} :p "m" path true)))
-      (is (false? (dd/resolve-expanded? {} :p "m" path false))))
+      (is (true?  (ei/resolve-expanded? {} :p "m" path true)))
+      (is (false? (ei/resolve-expanded? {} :p "m" path false))))
     (testing "override wins"
-      (is (true?  (dd/resolve-expanded? {k {:expanded? true}}
+      (is (true?  (ei/resolve-expanded? {k {:expanded? true}}
                                         :p "m" path false)))
-      (is (false? (dd/resolve-expanded? {k {:expanded? false}}
+      (is (false? (ei/resolve-expanded? {k {:expanded? false}}
                                         :p "m" path true))))))
 
 ;; ---- click-to-toggle integration -----------------------------------------
 ;;
 ;; The widget's toggle path: clicking the `▸` glyph dispatches
-;; `:rf.xray.data-display/toggle-node panel-id mount-id path`. The
-;; reducer flips the per-path entry under `:rf.xray.data-display/expansion`.
+;; `:rf.xray.edn-inspector/toggle-node panel-id mount-id path`. The
+;; reducer flips the per-path entry under `:rf.xray.edn-inspector/expansion`.
 ;; A subsequent render against the new app-db state must show `▾` and
 ;; render the body.
 
@@ -370,15 +370,15 @@
     ;; Case A — default-collapsed (e.g. deep path). Visible state
     ;; is collapsed → dispatch carries `false` → first click stores
     ;; `:expanded? true` (opens). Second click inverts to `false`.
-    (rf/dispatch-sync [:rf.xray.data-display/reset-expansion])
-    (rf/dispatch-sync [:rf.xray.data-display/toggle-node panel-id mount-id path false])
-    (let [snapshot @(rf/subscribe [dd/expansion-slot])
-          k         (dd/expansion-key panel-id mount-id path)]
+    (rf/dispatch-sync [:rf.xray.edn-inspector/reset-expansion])
+    (rf/dispatch-sync [:rf.xray.edn-inspector/toggle-node panel-id mount-id path false])
+    (let [snapshot @(rf/subscribe [ei/expansion-slot])
+          k         (ei/expansion-key panel-id mount-id path)]
       (is (= true (get-in snapshot [k :expanded?]))
           "default-collapsed: first click stores :expanded? true (opens)"))
-    (rf/dispatch-sync [:rf.xray.data-display/toggle-node panel-id mount-id path true])
-    (let [snapshot @(rf/subscribe [dd/expansion-slot])
-          k         (dd/expansion-key panel-id mount-id path)]
+    (rf/dispatch-sync [:rf.xray.edn-inspector/toggle-node panel-id mount-id path true])
+    (let [snapshot @(rf/subscribe [ei/expansion-slot])
+          k         (ei/expansion-key panel-id mount-id path)]
       (is (= false (get-in snapshot [k :expanded?]))
           "second toggle inverts the stored override to false"))
 
@@ -388,21 +388,21 @@
     ;; regression the bug fixed; before the fix the reducer would
     ;; emit `{:expanded? true}` — same as the rendered state —
     ;; producing a silent no-op on the first click.
-    (rf/dispatch-sync [:rf.xray.data-display/reset-expansion])
-    (rf/dispatch-sync [:rf.xray.data-display/toggle-node panel-id mount-id path true])
-    (let [snapshot @(rf/subscribe [dd/expansion-slot])
-          k         (dd/expansion-key panel-id mount-id path)]
+    (rf/dispatch-sync [:rf.xray.edn-inspector/reset-expansion])
+    (rf/dispatch-sync [:rf.xray.edn-inspector/toggle-node panel-id mount-id path true])
+    (let [snapshot @(rf/subscribe [ei/expansion-slot])
+          k         (ei/expansion-key panel-id mount-id path)]
       (is (= false (get-in snapshot [k :expanded?]))
           "default-expanded: first click stores :expanded? false (collapses)"))
 
     ;; Reset cleans the slot.
-    (rf/dispatch-sync [:rf.xray.data-display/reset-expansion])
-    (is (nil? @(rf/subscribe [dd/expansion-slot])))))
+    (rf/dispatch-sync [:rf.xray.edn-inspector/reset-expansion])
+    (is (nil? @(rf/subscribe [ei/expansion-slot])))))
 
 ;; ---- render-node — container/scalar dispatch -----------------------------
 
 (deftest render-node-scalar-passes-through
-  (let [h (dd/render-node {:value 42
+  (let [h (ei/render-node {:value 42
                            :panel-id :p
                            :mount-id "m"
                            :path []
@@ -413,7 +413,7 @@
     (is (= "42" (collect-text h)))))
 
 (deftest render-node-empty-map-no-toggle
-  (let [h (dd/render-node {:value {}
+  (let [h (ei/render-node {:value {}
                            :panel-id :p
                            :mount-id "m"
                            :path []
@@ -428,7 +428,7 @@
 
 (deftest render-node-map-default-expanded
   ;; default-expanded-depth = 2 → depth 0 should be expanded.
-  (let [h (dd/render-node {:value {:a 1 :b 2}
+  (let [h (ei/render-node {:value {:a 1 :b 2}
                            :panel-id :p
                            :mount-id "m"
                            :path []
@@ -446,7 +446,7 @@
 
 (deftest render-node-deep-map-default-collapsed
   (let [v {:level1 {:level2 {:level3 {:level4 {:level5 42}}}}}
-        h (dd/render-node {:value v
+        h (ei/render-node {:value v
                            :panel-id :p
                            :mount-id "m"
                            :path []
@@ -465,8 +465,8 @@
   ;; A 5-entry map doesn't inline-fit, so the toggle ▾ + body are
   ;; both rendered.
   (let [v2 {:a 1 :b {:c 2} :d 3 :e 4 :f 5}
-        k0 (dd/expansion-key :p "m" [])
-        h  (dd/render-node {:value v2
+        k0 (ei/expansion-key :p "m" [])
+        h  (ei/render-node {:value v2
                             :panel-id :p
                             :mount-id "m"
                             :path []
@@ -479,9 +479,9 @@
 
 (deftest render-node-collapsed-shows-preview-not-body
   (let [v {:level1 {:level2 {:level3 {:deep 1}}}}
-        k0 (dd/expansion-key :p "m" [:level1 :level2])
+        k0 (ei/expansion-key :p "m" [:level1 :level2])
         ;; Force the nested map at [:level1 :level2] CLOSED.
-        h  (dd/render-node {:value v
+        h  (ei/render-node {:value v
                             :panel-id :p
                             :mount-id "m"
                             :path []
@@ -496,12 +496,12 @@
   ;; The header carries the toggle span; when expanded? we see ▾,
   ;; when collapsed we see ▸.
   (let [v   {:a 1 :b 2 :c 3 :d 4 :e 5}  ;; too big to inline-fit
-        k0  (dd/expansion-key :p "m" [])
-        h-expanded   (dd/render-node {:value v :panel-id :p :mount-id "m"
+        k0  (ei/expansion-key :p "m" [])
+        h-expanded   (ei/render-node {:value v :panel-id :p :mount-id "m"
                                       :path [] :depth 0
                                       :expansion-map {k0 {:expanded? true}}
                                       :opts {:default-expanded-depth 0}})
-        h-collapsed  (dd/render-node {:value v :panel-id :p :mount-id "m"
+        h-collapsed  (ei/render-node {:value v :panel-id :p :mount-id "m"
                                       :path [] :depth 0
                                       :expansion-map {k0 {:expanded? false}}
                                       :opts {:default-expanded-depth 0}})
@@ -512,7 +512,7 @@
     (is (not (re-find #"▾" text-collapsed)))))
 
 (deftest render-node-includes-data-testid
-  (let [h  (dd/render-node {:value {:a 1}
+  (let [h  (ei/render-node {:value {:a 1}
                             :panel-id :app-db
                             :mount-id "m-42"
                             :path []
@@ -520,7 +520,7 @@
                             :expansion-map {}
                             :opts {}})]
     (is (some? (find-attr h :data-testid
-                          "rf-xray-data-display-app-db-m-42")))))
+                          "rf-xray-edn-inspector-app-db-m-42")))))
 
 ;; ---- rf2-tzvk9 — triangle hit-box ≥24×24 ---------------------------------
 ;;
@@ -541,23 +541,23 @@
   (testing "rf2-tzvk9 — the shared triangle-style declares ≥24px min-
             width AND min-height so the computed hit-box meets the
             comfortable-mouse-target threshold"
-    (is (>= (parse-px (:min-width  dd/triangle-style)) 24)
+    (is (>= (parse-px (:min-width  ei/triangle-style)) 24)
         ":min-width ≥24px")
-    (is (>= (parse-px (:min-height dd/triangle-style)) 24)
+    (is (>= (parse-px (:min-height ei/triangle-style)) 24)
         ":min-height ≥24px")
-    (is (= "pointer" (:cursor dd/triangle-style))
+    (is (= "pointer" (:cursor ei/triangle-style))
         "still registers as clickable")
-    (is (= "none"    (:user-select dd/triangle-style))
+    (is (= "none"    (:user-select ei/triangle-style))
         "no accidental text selection on the glyph")
-    (is (= "inline-flex" (:display dd/triangle-style))
+    (is (= "inline-flex" (:display ei/triangle-style))
         "inline-flex so min-width/min-height are honoured")
-    (is (= "center"  (:align-items     dd/triangle-style))
+    (is (= "center"  (:align-items     ei/triangle-style))
         "glyph centred vertically inside the hit-box")
-    (is (= "center"  (:justify-content dd/triangle-style))
+    (is (= "center"  (:justify-content ei/triangle-style))
         "glyph centred horizontally inside the hit-box")))
 
 (deftest triangle-min-target-px-is-24
-  (is (= 24 dd/triangle-min-target-px)
+  (is (= 24 ei/triangle-min-target-px)
       "the public contract pin: 24px in both axes"))
 
 (deftest triangle-style-font-size-is-22px
@@ -565,7 +565,7 @@
             preferred 22-24px band per Mike's live A/B 2026-05-26).
             14px was hit-box-adequate but read as hairline against
             the inspector chrome."
-    (is (= "22px" (:font-size dd/triangle-style))
+    (is (= "22px" (:font-size ei/triangle-style))
         "triangle glyph renders at 22px so the eye registers it as the
          primary expand/collapse affordance, not a hairline accent")))
 
@@ -574,47 +574,47 @@
   ;; default-expanded-depth) and verify the ▸ toggle span carries
   ;; the shared `triangle-style`.
   (let [v   {:a 1 :b 2 :c 3 :d 4 :e 5}
-        h   (dd/render-node {:value v
+        h   (ei/render-node {:value v
                              :panel-id :test :mount-id "m"
                              :path [] :depth 5
                              :expansion-map {}
                              :opts {:default-expanded-depth 1}})
         tog (find-attr h :data-testid
-                       "rf-xray-data-display-test-m-toggle")]
+                       "rf-xray-edn-inspector-test-m-toggle")]
     (is (some? tog) "collapsed renders carry a toggle span")
     (let [s (-> tog second :style)]
-      (is (= dd/triangle-style s)
+      (is (= ei/triangle-style s)
           "collapsed ▸ uses the shared triangle-style verbatim"))))
 
 (deftest expanded-triangle-uses-shared-triangle-style
   (let [v   {:a 1 :b 2 :c 3 :d 4 :e 5}
-        k0  (dd/expansion-key :test "m" [])
-        h   (dd/render-node {:value v
+        k0  (ei/expansion-key :test "m" [])
+        h   (ei/render-node {:value v
                              :panel-id :test :mount-id "m"
                              :path [] :depth 0
                              :expansion-map {k0 {:expanded? true}}
                              :opts {:default-expanded-depth 0}})
         tog (find-attr h :data-testid
-                       "rf-xray-data-display-test-m-toggle")]
+                       "rf-xray-edn-inspector-test-m-toggle")]
     (is (some? tog) "expanded renders carry a toggle span")
     (let [s (-> tog second :style)]
-      (is (= dd/triangle-style s)
+      (is (= ei/triangle-style s)
           "expanded ▾ uses the shared triangle-style verbatim"))))
 
 (deftest depth-capped-triangle-uses-shared-triangle-style
   ;; A node past :max-depth renders as `▸ {…}` with the same triangle.
   (let [;; nesting depth past max-depth=1 → depth-capped path.
         v   {:a {:b {:c {:d 1}}}}
-        h   (dd/render-node {:value v
+        h   (ei/render-node {:value v
                              :panel-id :test :mount-id "m"
                              :path [] :depth 0
                              :expansion-map {}
                              :opts {:default-expanded-depth 5 :max-depth 1}})
         tog (find-attr h :data-testid
-                       "rf-xray-data-display-test-m-toggle")]
+                       "rf-xray-edn-inspector-test-m-toggle")]
     (is (some? tog) "depth-capped renders still carry a toggle span")
     (let [s (-> tog second :style)]
-      (is (= dd/triangle-style s)
+      (is (= ei/triangle-style s)
           "depth-capped triangle uses the shared triangle-style"))))
 
 ;; ---- rf2-1bra5 — map body layout: column-align + inline scalars ---------
@@ -644,13 +644,13 @@
     ;; Map MUST be too big to inline-fit (cnt > 3) so the body
     ;; container renders.
     (let [v {:short 1 :very-very-long-key 2 :third 3 :fourth 4}
-          k0 (dd/expansion-key :p "m" [])
-          h  (dd/render-node {:value v
+          k0 (ei/expansion-key :p "m" [])
+          h  (ei/render-node {:value v
                               :panel-id :p :mount-id "m"
                               :path [] :depth 0
                               :expansion-map {k0 {:expanded? true}}
                               :opts {:default-expanded-depth 0}})
-          body (find-attr h :data-testid "rf-xray-data-display-p-m-body")]
+          body (find-attr h :data-testid "rf-xray-edn-inspector-p-m-body")]
       (is (some? body) "expanded map renders a body container")
       (let [s (-> body second :style)]
         (is (= "grid" (:display s))
@@ -670,13 +670,13 @@
             across rows. NOT wrapped in a per-row flex container."
     (let [;; >3 keys so inline-fit gate fails and the body emits.
           v {:a 1 :b 2 :c 3 :d 4}
-          k0 (dd/expansion-key :p "m" [])
-          h  (dd/render-node {:value v
+          k0 (ei/expansion-key :p "m" [])
+          h  (ei/render-node {:value v
                               :panel-id :p :mount-id "m"
                               :path [] :depth 0
                               :expansion-map {k0 {:expanded? true}}
                               :opts {:default-expanded-depth 0}})
-          body (find-attr h :data-testid "rf-xray-data-display-p-m-body")
+          body (find-attr h :data-testid "rf-xray-edn-inspector-p-m-body")
           key-cells   (->> (walk-hiccup body)
                            (filter #(= "key"   (get (second %) :data-rf-cell))))
           value-cells (->> (walk-hiccup body)
@@ -690,13 +690,13 @@
             (map / record / map-entry); sequentials have no key column."
     ;; >3 items so inline-fit gate fails and the body emits.
     (let [v [10 20 30 40]
-          k0 (dd/expansion-key :p "m" [])
-          h  (dd/render-node {:value v
+          k0 (ei/expansion-key :p "m" [])
+          h  (ei/render-node {:value v
                               :panel-id :p :mount-id "m"
                               :path [] :depth 0
                               :expansion-map {k0 {:expanded? true}}
                               :opts {:default-expanded-depth 0}})
-          body (find-attr h :data-testid "rf-xray-data-display-p-m-body")]
+          body (find-attr h :data-testid "rf-xray-edn-inspector-p-m-body")]
       (is (some? body) "expanded vector renders a body container")
       (let [s (-> body second :style)]
         (is (not= "grid" (:display s))
@@ -711,7 +711,7 @@
             Pre-fix the block wrapper inside the per-row flex container
             forced the value below the key (wrap → two-line rows)."
     (let [;; Force a :same diff row — both sides equal scalars.
-          h (dd/render-node {:value 1
+          h (ei/render-node {:value 1
                              :before 1
                              :diff? true
                              :panel-id :p :mount-id "m" :path [] :depth 0
@@ -732,7 +732,7 @@
             render as inline spans, never as a block element that
             would push the value below its key."
     (doseq [v [42 true false "hello" :foo 'sym nil]]
-      (let [h (dd/render-node {:value v
+      (let [h (ei/render-node {:value v
                                :panel-id :p :mount-id "m"
                                :path [] :depth 0
                                :expansion-map {} :opts {}})]
@@ -748,13 +748,13 @@
     (let [v {:scalar-1 1
              :scalar-2 "two"
              :nested   {:inner 99}}
-          k0 (dd/expansion-key :p "m" [])
-          h  (dd/render-node {:value v
+          k0 (ei/expansion-key :p "m" [])
+          h  (ei/render-node {:value v
                               :panel-id :p :mount-id "m"
                               :path [] :depth 0
                               :expansion-map {k0 {:expanded? true}}
                               :opts {:default-expanded-depth 0}})
-          body (find-attr h :data-testid "rf-xray-data-display-p-m-body")
+          body (find-attr h :data-testid "rf-xray-edn-inspector-p-m-body")
           ;; Filter ONLY this body's direct cells, not the nested
           ;; map's cells.
           direct-children (rest (rest body))]
@@ -770,13 +770,13 @@
             column-alignment + inline-composition; vertical density is
             unchanged."
     (let [v {:a 1 :b 2 :c 3 :d 4}
-          k0 (dd/expansion-key :p "m" [])
-          h  (dd/render-node {:value v
+          k0 (ei/expansion-key :p "m" [])
+          h  (ei/render-node {:value v
                               :panel-id :p :mount-id "m"
                               :path [] :depth 0
                               :expansion-map {k0 {:expanded? true}}
                               :opts {:default-expanded-depth 0}})
-          body (find-attr h :data-testid "rf-xray-data-display-p-m-body")]
+          body (find-attr h :data-testid "rf-xray-edn-inspector-p-m-body")]
       (is (= "0" (-> body second :style :row-gap))))))
 
 ;; ---- toggle handler shape ------------------------------------------------
@@ -798,7 +798,7 @@
           ;; checks fail (`(<= 5 0)` false; `(= 5 1)` false) → the
           ;; heuristic returns false → path renders ▸ (collapsed).
           v   {:a 1 :b 2 :c 3 :d 4 :e 5}
-          h   (dd/render-node {:value v
+          h   (ei/render-node {:value v
                                :panel-id :test
                                :mount-id "m1"
                                :path [:x]
@@ -809,11 +809,11 @@
                                :opts {:default-expanded-depth 1}})
           ;; Find the toggle span by data-testid suffix.
           tog (find-attr h :data-testid
-                         "rf-xray-data-display-test-m1-:x-toggle")
+                         "rf-xray-edn-inspector-test-m1-:x-toggle")
           on-click (-> tog second :on-click)]
       (is (fn? on-click) "toggle glyph must carry an :on-click")
       (when on-click (on-click nil))
-      (is (= [:rf.xray.data-display/toggle-node :test "m1" [:x] false]
+      (is (= [:rf.xray.edn-inspector/toggle-node :test "m1" [:x] false]
              @captured)
           "default-collapsed render → payload carries rendered? false")))
 
@@ -824,7 +824,7 @@
           ;; - `(<= 0 (dec 2))` true → default-expanded? returns true
           ;; - path renders ▾, toggle dispatches rendered? true.
           v   {:a 1 :b 2 :c 3 :d 4 :e 5}
-          h   (dd/render-node {:value v
+          h   (ei/render-node {:value v
                                :panel-id :test
                                :mount-id "m2"
                                :path []
@@ -834,17 +834,17 @@
                                               (reset! captured event-v))
                                :opts {:default-expanded-depth 2}})
           tog (find-attr h :data-testid
-                         "rf-xray-data-display-test-m2-toggle")
+                         "rf-xray-edn-inspector-test-m2-toggle")
           on-click (-> tog second :on-click)]
       (is (fn? on-click) "toggle glyph must carry an :on-click")
       (when on-click (on-click nil))
-      (is (= [:rf.xray.data-display/toggle-node :test "m2" [] true]
+      (is (= [:rf.xray.edn-inspector/toggle-node :test "m2" [] true]
              @captured)
           "default-expanded render → payload carries rendered? true"))))
 
 ;; ---- rf2-pvsxs — opt-in `:site-id` for cross-mount persistence ----------
 ;;
-;; By default, two `[data-display value]` mounts in the same panel get
+;; By default, two `[edn-inspector value]` mounts in the same panel get
 ;; independent expansion state via the auto-mount-id (rf2-sndui D4=a).
 ;; The cost — only visible in the panel-leave-and-return workflow —
 ;; is that the same logical site loses state on every unmount, because
@@ -856,7 +856,7 @@
 ;; `:site-id`. The expansion-key's second component reads `:site-id`
 ;; when supplied, falling back to auto-mount-id when omitted.
 
-(deftest data-display-uses-site-id-when-supplied-as-expansion-key-id
+(deftest edn-inspector-uses-site-id-when-supplied-as-expansion-key-id
   ;; Two mounts with the SAME `:site-id` and the SAME path must write
   ;; their override to the SAME expansion-key, so the second mount sees
   ;; the first mount's choice.
@@ -865,24 +865,24 @@
         path     [:cart :items]
         ;; First mount → simulate a toggle dispatch carrying rendered? true
         ;; (i.e. visible state is expanded; first click should collapse).
-        _        (rf/dispatch-sync [:rf.xray.data-display/reset-expansion])
-        _        (rf/dispatch-sync [:rf.xray.data-display/toggle-node
+        _        (rf/dispatch-sync [:rf.xray.edn-inspector/reset-expansion])
+        _        (rf/dispatch-sync [:rf.xray.edn-inspector/toggle-node
                                     panel-id site-id path true])
-        k        (dd/expansion-key panel-id site-id path)
-        snapshot @(rf/subscribe [dd/expansion-slot])]
+        k        (ei/expansion-key panel-id site-id path)
+        snapshot @(rf/subscribe [ei/expansion-slot])]
     (is (= false (get-in snapshot [k :expanded?]))
         "override is stored under [panel-id site-id path], independent
          of any auto-generated mount-id")
-    (rf/dispatch-sync [:rf.xray.data-display/reset-expansion])))
+    (rf/dispatch-sync [:rf.xray.edn-inspector/reset-expansion])))
 
-(deftest data-display-public-widget-routes-site-id-to-render-key
+(deftest edn-inspector-public-widget-routes-site-id-to-render-key
   ;; The public widget threads `:site-id` (when present) into the
   ;; `mount-id` slot of every render-node descent so the toggle handler
   ;; dispatches against the stable id, NOT the auto-mount-id. Verified
   ;; by mounting the widget twice with the SAME site-id and a value
   ;; that needs expansion; the testid carrying the stable id must
   ;; appear on both renders.
-  (let [outer (dd/data-display {:a 1 :b 2 :c 3 :d 4} {:panel-id :p
+  (let [outer (ei/edn-inspector {:a 1 :b 2 :c 3 :d 4} {:panel-id :p
                                                       :site-id  [:my-site "x"]
                                                       :default-expanded-depth 0})
         inner1 (outer {:a 1 :b 2 :c 3 :d 4} {:panel-id :p
@@ -896,12 +896,12 @@
     (is (= (pr-str [:my-site "x"]) (get attrs :data-rf-site-id))
         ":data-rf-site-id attribute carries the literal site-id")))
 
-(deftest data-display-without-site-id-keeps-per-call-site-isolation
+(deftest edn-inspector-without-site-id-keeps-per-call-site-isolation
   ;; The acceptance contract: when `:site-id` is omitted, behaviour is
   ;; UNCHANGED — auto-mount-id keeps two side-by-side mounts independent.
   ;; This guards the rf2-sndui D4=a default.
-  (let [outer1 (dd/data-display {:a 1} {:panel-id :p})
-        outer2 (dd/data-display {:a 1} {:panel-id :p})
+  (let [outer1 (ei/edn-inspector {:a 1} {:panel-id :p})
+        outer2 (ei/edn-inspector {:a 1} {:panel-id :p})
         inner1 (outer1 {:a 1} {:panel-id :p})
         inner2 (outer2 {:a 1} {:panel-id :p})
         m1     (get (second inner1) :data-rf-mount-id)
@@ -924,25 +924,25 @@
   (let [panel-id :rf.xray/app-db
         site-id  [:rf.xray/app-db "top"]
         path     [:nested :deep]
-        _        (rf/dispatch-sync [:rf.xray.data-display/reset-expansion])
+        _        (rf/dispatch-sync [:rf.xray.edn-inspector/reset-expansion])
         ;; Step 1 — open the path (rendered? false → store true).
-        _        (rf/dispatch-sync [:rf.xray.data-display/toggle-node
+        _        (rf/dispatch-sync [:rf.xray.edn-inspector/toggle-node
                                     panel-id site-id path false])
-        k        (dd/expansion-key panel-id site-id path)
+        k        (ei/expansion-key panel-id site-id path)
         ;; "Unmount" — no state cleanup needed; the expansion slot
         ;; survives Reagent unmount because it's in app-db.
         ;; "Remount" — same site-id is passed at the new mount; the
         ;; renderer's resolve-expanded? reads the same key.
-        snapshot-after-remount @(rf/subscribe [dd/expansion-slot])]
+        snapshot-after-remount @(rf/subscribe [ei/expansion-slot])]
     (is (= true (get-in snapshot-after-remount [k :expanded?]))
         "expansion override survives the simulated unmount-and-remount cycle
          when the consumer passes a stable :site-id")
     ;; Per the resolve-expanded? helper, this should also yield true
     ;; regardless of the default-expanded heuristic.
-    (is (true? (dd/resolve-expanded? snapshot-after-remount
+    (is (true? (ei/resolve-expanded? snapshot-after-remount
                                      panel-id site-id path false))
         "resolve-expanded? honours the stored override at the site-id key")
-    (rf/dispatch-sync [:rf.xray.data-display/reset-expansion])))
+    (rf/dispatch-sync [:rf.xray.edn-inspector/reset-expansion])))
 
 (deftest two-mounts-with-distinct-site-ids-still-isolate
   ;; Two consumers using DIFFERENT :site-ids must STILL isolate, even
@@ -952,16 +952,16 @@
         s1       [:site/a]
         s2       [:site/b]
         path     []
-        k1       (dd/expansion-key panel-id s1 path)
-        k2       (dd/expansion-key panel-id s2 path)]
-    (rf/dispatch-sync [:rf.xray.data-display/reset-expansion])
-    (rf/dispatch-sync [:rf.xray.data-display/toggle-node panel-id s1 path true])
-    (let [snapshot @(rf/subscribe [dd/expansion-slot])]
+        k1       (ei/expansion-key panel-id s1 path)
+        k2       (ei/expansion-key panel-id s2 path)]
+    (rf/dispatch-sync [:rf.xray.edn-inspector/reset-expansion])
+    (rf/dispatch-sync [:rf.xray.edn-inspector/toggle-node panel-id s1 path true])
+    (let [snapshot @(rf/subscribe [ei/expansion-slot])]
       (is (= false (get-in snapshot [k1 :expanded?]))
           "site/a's override is stored")
       (is (nil? (get snapshot k2))
           "site/b's slot is untouched — distinct :site-ids isolate"))
-    (rf/dispatch-sync [:rf.xray.data-display/reset-expansion])))
+    (rf/dispatch-sync [:rf.xray.edn-inspector/reset-expansion])))
 
 ;; ---- per-call-site isolation ---------------------------------------------
 
@@ -969,16 +969,16 @@
   (let [v {:a 1 :b 2 :c 3 :d 4 :e 5}
         m1 "mount-1"
         m2 "mount-2"
-        k1 (dd/expansion-key :p m1 [])
-        k2 (dd/expansion-key :p m2 [])
+        k1 (ei/expansion-key :p m1 [])
+        k2 (ei/expansion-key :p m2 [])
         ;; mount-1 is force-expanded; mount-2 is force-collapsed.
         emap {k1 {:expanded? true}
               k2 {:expanded? false}}
-        h1 (dd/render-node {:value v :panel-id :p :mount-id m1
+        h1 (ei/render-node {:value v :panel-id :p :mount-id m1
                             :path [] :depth 0
                             :expansion-map emap
                             :opts {:default-expanded-depth 0}})
-        h2 (dd/render-node {:value v :panel-id :p :mount-id m2
+        h2 (ei/render-node {:value v :panel-id :p :mount-id m2
                             :path [] :depth 0
                             :expansion-map emap
                             :opts {:default-expanded-depth 0}})]
@@ -990,32 +990,32 @@
 
 (deftest map-entry-bracket-tone-distinct-from-vector
   (testing "map-entry uses :accent tone; vector uses :text-secondary"
-    (is (= :accent          (-> dd/delim :map-entry :tone-key)))
-    (is (= :text-secondary  (-> dd/delim :vector    :tone-key)))
-    (is (not= (-> dd/delim :vector :tone-key)
-              (-> dd/delim :map-entry :tone-key)))))
+    (is (= :accent          (-> ei/delim :map-entry :tone-key)))
+    (is (= :text-secondary  (-> ei/delim :vector    :tone-key)))
+    (is (not= (-> ei/delim :vector :tone-key)
+              (-> ei/delim :map-entry :tone-key)))))
 
 ;; ---- mini one-liner ------------------------------------------------------
 
 (deftest mini-scalar-keyword
-  (let [h (dd/mini :foo)
+  (let [h (ei/mini :foo)
         all (collect-text h)]
     (is (re-find #":foo" all))))
 
 (deftest mini-map-shows-inline-preview
-  (let [h (dd/mini {:a 1 :b 2} 80)
+  (let [h (ei/mini {:a 1 :b 2} 80)
         all (collect-text h)]
     (is (re-find #":a" all))
     (is (re-find #":b" all))))
 
 (deftest mini-sentinel-redacted
-  (let [h (dd/mini :rf/redacted)
+  (let [h (ei/mini :rf/redacted)
         all (collect-text h)]
     (is (re-find #"redacted" all))))
 
 (deftest mini-truncates-to-max-len
   (let [long-str (apply str (repeat 200 "x"))
-        h (dd/mini long-str 20)
+        h (ei/mini long-str 20)
         title (-> h second :title)]
     ;; Title carries the full pr-str; visible content is truncated.
     (is (some? title) "title attribute carries full value")))
@@ -1024,7 +1024,7 @@
 ;; Diff mode (rf2-q3dzw phase 5 · D5=a per rf2-sndui)
 ;; =========================================================================
 ;;
-;; The diff path subsumes the legacy `data-display.render` engine —
+;; The diff path subsumes the legacy `edn-inspector.render` engine —
 ;; passing `:before` switches the widget into diff mode where each
 ;; node renders with a left-gutter glyph + colour and `:modified`
 ;; leaves carry a `← changed from <prior>` annotation. Ancestor chain
@@ -1033,33 +1033,33 @@
 ;; ---- pure helpers --------------------------------------------------------
 
 (deftest diff-op-classification
-  (is (= :same     (dd/diff-op 1 1)))
-  (is (= :same     (dd/diff-op nil nil)))
-  (is (= :modified (dd/diff-op 1 2)))
-  (is (= :modified (dd/diff-op :a :b)))
-  (is (= :added    (dd/diff-op dd/missing-sentinel 1)))
-  (is (= :removed  (dd/diff-op 1 dd/missing-sentinel)))
-  (is (= :same     (dd/diff-op dd/missing-sentinel dd/missing-sentinel))))
+  (is (= :same     (ei/diff-op 1 1)))
+  (is (= :same     (ei/diff-op nil nil)))
+  (is (= :modified (ei/diff-op 1 2)))
+  (is (= :modified (ei/diff-op :a :b)))
+  (is (= :added    (ei/diff-op ei/missing-sentinel 1)))
+  (is (= :removed  (ei/diff-op 1 ei/missing-sentinel)))
+  (is (= :same     (ei/diff-op ei/missing-sentinel ei/missing-sentinel))))
 
 (deftest changed-descendant?-walks-maps
-  (is (false? (dd/changed-descendant? {:a 1 :b 2} {:a 1 :b 2})))
-  (is (true?  (dd/changed-descendant? {:a 1 :b 2} {:a 1 :b 3})))
-  (is (true?  (dd/changed-descendant? {:a {:x 1}} {:a {:x 2}}))
+  (is (false? (ei/changed-descendant? {:a 1 :b 2} {:a 1 :b 2})))
+  (is (true?  (ei/changed-descendant? {:a 1 :b 2} {:a 1 :b 3})))
+  (is (true?  (ei/changed-descendant? {:a {:x 1}} {:a {:x 2}}))
       "deep change propagates to root")
-  (is (true?  (dd/changed-descendant? {:a 1} {:a 1 :b 2}))
+  (is (true?  (ei/changed-descendant? {:a 1} {:a 1 :b 2}))
       "key added"))
 
 (deftest changed-descendant?-walks-sequentials
-  (is (false? (dd/changed-descendant? [1 2 3] [1 2 3])))
-  (is (true?  (dd/changed-descendant? [1 2 3] [1 2 4])))
-  (is (true?  (dd/changed-descendant? [1 2] [1 2 3]))))
+  (is (false? (ei/changed-descendant? [1 2 3] [1 2 3])))
+  (is (true?  (ei/changed-descendant? [1 2 3] [1 2 4])))
+  (is (true?  (ei/changed-descendant? [1 2] [1 2 3]))))
 
 (deftest gutter-glyph-mapping
-  (is (= "+" (dd/op->gutter-glyph :added)))
-  (is (= "-" (dd/op->gutter-glyph :removed)))
-  (is (= "~" (dd/op->gutter-glyph :modified)))
-  (is (= "◴" (dd/op->gutter-glyph :children)))
-  (is (= " " (dd/op->gutter-glyph :same))))
+  (is (= "+" (ei/op->gutter-glyph :added)))
+  (is (= "-" (ei/op->gutter-glyph :removed)))
+  (is (= "~" (ei/op->gutter-glyph :modified)))
+  (is (= "◴" (ei/op->gutter-glyph :children)))
+  (is (= " " (ei/op->gutter-glyph :same))))
 
 (deftest gutter-tone-mapping
   (testing "rf2-awqts — every active diff op now reads the SAME
@@ -1067,31 +1067,31 @@
             per-op (per-op signal lives in the wash + stripe + shape).
             `:same` keeps `:text-tertiary` so the transparent non-diff
             shape composes unchanged."
-    (is (= :diff-gutter   (dd/op->gutter-tone-key :added)))
-    (is (= :diff-gutter   (dd/op->gutter-tone-key :removed)))
-    (is (= :diff-gutter   (dd/op->gutter-tone-key :modified)))
-    (is (= :diff-gutter   (dd/op->gutter-tone-key :children)))
-    (is (= :text-tertiary (dd/op->gutter-tone-key :same)))))
+    (is (= :diff-gutter   (ei/op->gutter-tone-key :added)))
+    (is (= :diff-gutter   (ei/op->gutter-tone-key :removed)))
+    (is (= :diff-gutter   (ei/op->gutter-tone-key :modified)))
+    (is (= :diff-gutter   (ei/op->gutter-tone-key :children)))
+    (is (= :text-tertiary (ei/op->gutter-tone-key :same)))))
 
 ;; ---- rf2-awqts — row chrome (wash + stripe) -----------------------------
 
 (deftest row-wash-mapping
   (testing "rf2-awqts — per-op row-background wash token-key mapping"
-    (is (= :diff-added-wash    (dd/op->row-wash-key :added)))
-    (is (= :diff-removed-wash  (dd/op->row-wash-key :removed)))
-    (is (= :diff-modified-wash (dd/op->row-wash-key :modified)))
-    (is (nil? (dd/op->row-wash-key :children))
+    (is (= :diff-added-wash    (ei/op->row-wash-key :added)))
+    (is (= :diff-removed-wash  (ei/op->row-wash-key :removed)))
+    (is (= :diff-modified-wash (ei/op->row-wash-key :modified)))
+    (is (nil? (ei/op->row-wash-key :children))
         "`:children` rows carry NO wash — the colour-coded descendants below do")
-    (is (nil? (dd/op->row-wash-key :same))
+    (is (nil? (ei/op->row-wash-key :same))
         "`:same` rows sit flush with the canvas")))
 
 (deftest row-stripe-mapping
   (testing "rf2-awqts — per-op 2px-stripe token-key mapping"
-    (is (= :diff-added-stripe    (dd/op->row-stripe-key :added)))
-    (is (= :diff-removed-stripe  (dd/op->row-stripe-key :removed)))
-    (is (= :diff-modified-stripe (dd/op->row-stripe-key :modified)))
-    (is (nil? (dd/op->row-stripe-key :children)))
-    (is (nil? (dd/op->row-stripe-key :same)))))
+    (is (= :diff-added-stripe    (ei/op->row-stripe-key :added)))
+    (is (= :diff-removed-stripe  (ei/op->row-stripe-key :removed)))
+    (is (= :diff-modified-stripe (ei/op->row-stripe-key :modified)))
+    (is (nil? (ei/op->row-stripe-key :children)))
+    (is (nil? (ei/op->row-stripe-key :same)))))
 
 (deftest gutter-glyph-colour-is-syntax-palette-disjoint
   (testing "rf2-awqts — the reserved `:diff-gutter` hue must NOT match
@@ -1124,7 +1124,7 @@
             yellow); now the row chrome (wash + stripe + glyph)
             carries the diff signal."
     ;; :added — number value keeps `:syntax-number` orange
-    (let [h (dd/render-node {:value 42 :before ::dd/missing :diff? true
+    (let [h (ei/render-node {:value 42 :before ::ei/missing :diff? true
                              :panel-id :p :mount-id "m" :path [] :depth 0
                              :expansion-map {} :opts {}})
           node (find-attr h :data-rf-type "number")]
@@ -1132,7 +1132,7 @@
       (is (= (:syntax-number tokens) (-> node second :style :color))
           ":syntax-number token preserved on the added scalar"))
     ;; :modified — boolean keeps `:syntax-boolean` gold
-    (let [h (dd/render-node {:value true :before false :diff? true
+    (let [h (ei/render-node {:value true :before false :diff? true
                              :panel-id :p :mount-id "m" :path [] :depth 0
                              :expansion-map {} :opts {}})
           node (find-attr h :data-rf-type "boolean")]
@@ -1144,7 +1144,7 @@
   (testing "rf2-awqts — diff row wrapper carries data-attributes so
             tests + DOM inspectors can confirm the wash + stripe are
             applied per op"
-    (let [h (dd/render-node {:value 42 :before ::dd/missing :diff? true
+    (let [h (ei/render-node {:value 42 :before ::ei/missing :diff? true
                              :panel-id :p :mount-id "m" :path [] :depth 0
                              :expansion-map {} :opts {}})
           wrapper (find-attr h :data-rf-diff-op "added")]
@@ -1156,7 +1156,7 @@
       (is (= (:diff-added-wash tokens) (-> wrapper second :style :background))
           "wash background reads through the diff-added-wash token"))
     ;; :same — no wash, no stripe attrs
-    (let [h (dd/render-node {:value 42 :before 42 :diff? true
+    (let [h (ei/render-node {:value 42 :before 42 :diff? true
                              :panel-id :p :mount-id "m" :path [] :depth 0
                              :expansion-map {} :opts {}})
           wrapper (find-attr h :data-rf-diff-op "same")]
@@ -1169,7 +1169,7 @@
 ;; ---- diff mode — modified-leaf annotation --------------------------------
 
 (deftest diff-modified-leaf-emits-changed-from-annotation
-  (let [h (dd/render-node {:value 2
+  (let [h (ei/render-node {:value 2
                            :before 1
                            :diff? true
                            :panel-id :p :mount-id "m" :path [] :depth 0
@@ -1182,7 +1182,7 @@
 (deftest diff-modified-nested-leaf-annotates
   (let [v {:cart {:items {:total 71.00}}}
         b {:cart {:items {:total 48.00}}}
-        h (dd/render-node {:value v
+        h (ei/render-node {:value v
                            :before b
                            :diff? true
                            :panel-id :p :mount-id "m" :path [] :depth 0
@@ -1195,8 +1195,8 @@
 ;; ---- diff mode — added / removed -----------------------------------------
 
 (deftest diff-added-leaf-renders-in-green
-  (let [h (dd/render-node {:value 2
-                           :before dd/missing-sentinel
+  (let [h (ei/render-node {:value 2
+                           :before ei/missing-sentinel
                            :diff? true
                            :panel-id :p :mount-id "m" :path [] :depth 0
                            :expansion-map {}
@@ -1206,7 +1206,7 @@
         "added leaf carries the diff-op marker")))
 
 (deftest diff-removed-leaf-shows-prior-value
-  (let [h (dd/render-node {:value dd/missing-sentinel
+  (let [h (ei/render-node {:value ei/missing-sentinel
                            :before 1
                            :diff? true
                            :panel-id :p :mount-id "m" :path [] :depth 0
@@ -1223,7 +1223,7 @@
   ;; would normally collapse the parents — force-expand wins.
   (let [v {:a {:b {:c {:d {:e 2}}}}}
         b {:a {:b {:c {:d {:e 1}}}}}
-        h (dd/render-node {:value v
+        h (ei/render-node {:value v
                            :before b
                            :diff? true
                            :panel-id :p :mount-id "m" :path [] :depth 0
@@ -1236,7 +1236,7 @@
 ;; ---- diff mode — same nodes dim ------------------------------------------
 
 (deftest diff-same-leaf-uses-text-tertiary
-  (let [h (dd/render-node {:value 1
+  (let [h (ei/render-node {:value 1
                            :before 1
                            :diff? true
                            :panel-id :p :mount-id "m" :path [] :depth 0
@@ -1250,11 +1250,11 @@
 
 ;; ---- diff mode — public widget exposes mode marker -----------------------
 
-(deftest data-display-diff-mode-marker-on-container
+(deftest edn-inspector-diff-mode-marker-on-container
   ;; The public widget's outer container carries `data-rf-mode` =
   ;; "diff" when `:before` is supplied so panels / tests can target
   ;; the diff variant.
-  (let [outer (dd/data-display {:a 2} {:before {:a 1}})
+  (let [outer (ei/edn-inspector {:a 2} {:before {:a 1}})
         ;; outer is the form-2 closure that returns a fn — call it
         ;; with the same args to get the inner hiccup.
         inner (outer {:a 2} {:before {:a 1}})]
@@ -1263,16 +1263,16 @@
     (is (some? (get (second inner) :data-rf-mount-id))
         "mount-id still auto-generated")))
 
-(deftest data-display-browse-mode-marker-on-container
-  (let [outer (dd/data-display {:a 1})
+(deftest edn-inspector-browse-mode-marker-on-container
+  (let [outer (ei/edn-inspector {:a 1})
         inner (outer {:a 1} nil)]
     (is (= "browse" (get (second inner) :data-rf-mode))
         "browse-mode marker present without :before")))
 
-(deftest data-display-diff-convenience-threads-before
-  ;; The `[data-display-diff before after]` form-2 wrapper should
-  ;; produce the same shape as `[data-display after {:before before}]`.
-  (let [h (dd/data-display-diff {:a 1} {:a 2})]
+(deftest edn-inspector-diff-convenience-threads-before
+  ;; The `[edn-inspector-diff before after]` form-2 wrapper should
+  ;; produce the same shape as `[edn-inspector after {:before before}]`.
+  (let [h (ei/edn-inspector-diff {:a 1} {:a 2})]
     (is (vector? h))
     (is (fn? (first h)))
     (is (= {:a 2} (nth h 1)))
@@ -1284,7 +1284,7 @@
 ;;
 ;; Two independent bugs covered here:
 ;;
-;;   Bug A — `data-display` was a plain `defn`, so dispatches from
+;;   Bug A — `edn-inspector` was a plain `defn`, so dispatches from
 ;;     its click handlers did NOT carry the surrounding frame; toggle
 ;;     events landed on `:rf/default` while the App-DB panel mounted
 ;;     the widget under `:rf/xray`. The expansion-slot mutation ended
@@ -1297,17 +1297,17 @@
 ;;     first click stored `:expanded? true` — the same value the path
 ;;     already rendered with — producing a silent no-op.
 
-(deftest data-display-is-reg-view-registered
+(deftest edn-inspector-is-reg-view-registered
   (testing "rf2-y59tb Bug A — the public widget is registered via
             `reg-view` so dispatches + subscribes inherit the
             surrounding frame from React context. Without this the
             App-DB panel's `:rf/xray` mount routes toggle dispatches
             to `:rf/default`. The registration is present in the
             view registry under the auto-derived namespaced id."
-    (is (some? (rf/view :day8.re-frame2-xray.views.data-display/data-display))
-        "data-display is registered under its ns/sym id")))
+    (is (some? (rf/view :day8.re-frame2-xray.views.edn-inspector/edn-inspector))
+        "edn-inspector is registered under its ns/sym id")))
 
-(deftest data-display-toggle-dispatches-to-mount-frame
+(deftest edn-inspector-toggle-dispatches-to-mount-frame
   ;; rf2-y59tb Bug A regression guard — the click handler dispatches
   ;; through the lexically-injected frame-aware dispatcher. We
   ;; simulate the inner render by calling `render-node` with a
@@ -1317,7 +1317,7 @@
   ;; route to `:rf/default`).
   (let [captured (atom nil)
         v       {:a 1 :b 2 :c 3 :d 4 :e 5}
-        h       (dd/render-node {:value v
+        h       (ei/render-node {:value v
                                  :panel-id :app-db
                                  :mount-id "m"
                                  :path []
@@ -1327,13 +1327,13 @@
                                                 (reset! captured event-v))
                                  :opts {:default-expanded-depth 0}})
         tog     (find-attr h :data-testid
-                           "rf-xray-data-display-app-db-m-toggle")
+                           "rf-xray-edn-inspector-app-db-m-toggle")
         on-click (-> tog second :on-click)]
     (is (fn? on-click))
     (when on-click (on-click nil))
     (is (some? @captured)
         "toggle handler invoked the threaded dispatch-fn (not rf/dispatch)")
-    (is (= :rf.xray.data-display/toggle-node (first @captured))
+    (is (= :rf.xray.edn-inspector/toggle-node (first @captured))
         "canonical event id")))
 
 (deftest first-click-collapses-default-expanded-path
@@ -1346,14 +1346,14 @@
   (let [panel-id :rf.xray/app-db
         mount-id "m1"
         path     [:top-level]]
-    (rf/dispatch-sync [:rf.xray.data-display/reset-expansion])
-    (rf/dispatch-sync [:rf.xray.data-display/toggle-node
+    (rf/dispatch-sync [:rf.xray.edn-inspector/reset-expansion])
+    (rf/dispatch-sync [:rf.xray.edn-inspector/toggle-node
                        panel-id mount-id path true])
-    (let [snapshot @(rf/subscribe [dd/expansion-slot])
-          k         (dd/expansion-key panel-id mount-id path)]
+    (let [snapshot @(rf/subscribe [ei/expansion-slot])
+          k         (ei/expansion-key panel-id mount-id path)]
       (is (= false (get-in snapshot [k :expanded?]))
           "default-expanded → first click collapses (rendered? true → stored false)"))
-    (rf/dispatch-sync [:rf.xray.data-display/reset-expansion])))
+    (rf/dispatch-sync [:rf.xray.edn-inspector/reset-expansion])))
 
 (deftest first-click-expands-default-collapsed-path
   ;; rf2-y59tb Bug B regression guard — the symmetric case. A deep
@@ -1363,14 +1363,14 @@
   (let [panel-id :rf.xray/app-db
         mount-id "m1"
         path     [:deep :nested :node]]
-    (rf/dispatch-sync [:rf.xray.data-display/reset-expansion])
-    (rf/dispatch-sync [:rf.xray.data-display/toggle-node
+    (rf/dispatch-sync [:rf.xray.edn-inspector/reset-expansion])
+    (rf/dispatch-sync [:rf.xray.edn-inspector/toggle-node
                        panel-id mount-id path false])
-    (let [snapshot @(rf/subscribe [dd/expansion-slot])
-          k         (dd/expansion-key panel-id mount-id path)]
+    (let [snapshot @(rf/subscribe [ei/expansion-slot])
+          k         (ei/expansion-key panel-id mount-id path)]
       (is (= true (get-in snapshot [k :expanded?]))
           "default-collapsed → first click expands (rendered? false → stored true)"))
-    (rf/dispatch-sync [:rf.xray.data-display/reset-expansion])))
+    (rf/dispatch-sync [:rf.xray.edn-inspector/reset-expansion])))
 
 (deftest second-click-inverts-stored-override
   ;; Once an override is stored the reducer ignores the rendered?
@@ -1380,21 +1380,21 @@
   (let [panel-id :rf.xray/app-db
         mount-id "m1"
         path     [:x]
-        k         (dd/expansion-key panel-id mount-id path)]
-    (rf/dispatch-sync [:rf.xray.data-display/reset-expansion])
+        k         (ei/expansion-key panel-id mount-id path)]
+    (rf/dispatch-sync [:rf.xray.edn-inspector/reset-expansion])
     ;; First click on default-expanded → stored false.
-    (rf/dispatch-sync [:rf.xray.data-display/toggle-node panel-id mount-id path true])
-    (is (= false (get-in @(rf/subscribe [dd/expansion-slot]) [k :expanded?])))
+    (rf/dispatch-sync [:rf.xray.edn-inspector/toggle-node panel-id mount-id path true])
+    (is (= false (get-in @(rf/subscribe [ei/expansion-slot]) [k :expanded?])))
     ;; Second click — the rendered? slot is now `false` (override is
     ;; false) but the reducer flips the OVERRIDE, not the payload.
-    (rf/dispatch-sync [:rf.xray.data-display/toggle-node panel-id mount-id path false])
-    (is (= true (get-in @(rf/subscribe [dd/expansion-slot]) [k :expanded?]))
+    (rf/dispatch-sync [:rf.xray.edn-inspector/toggle-node panel-id mount-id path false])
+    (is (= true (get-in @(rf/subscribe [ei/expansion-slot]) [k :expanded?]))
         "second click inverts stored override → true")
     ;; Third click flips again.
-    (rf/dispatch-sync [:rf.xray.data-display/toggle-node panel-id mount-id path true])
-    (is (= false (get-in @(rf/subscribe [dd/expansion-slot]) [k :expanded?]))
+    (rf/dispatch-sync [:rf.xray.edn-inspector/toggle-node panel-id mount-id path true])
+    (is (= false (get-in @(rf/subscribe [ei/expansion-slot]) [k :expanded?]))
         "third click inverts stored override → false")
-    (rf/dispatch-sync [:rf.xray.data-display/reset-expansion])))
+    (rf/dispatch-sync [:rf.xray.edn-inspector/reset-expansion])))
 
 ;; ---- rf2-63ie5 — inspector card chrome on top-level mounts ---------------
 ;;
@@ -1403,20 +1403,20 @@
 ;; multiple top-level mounts (App-DB's TOP + per-`:rf/*` areas) read as
 ;; distinct cards. Default off preserves inline / nested behaviour.
 
-(defn- invoke-data-display
+(defn- invoke-edn-inspector
   "Form-2 unrolling — run the outer fn, then the inner fn with the same
   args to get the rendered hiccup."
   [value opts]
-  (let [outer (dd/data-display value opts)]
+  (let [outer (ei/edn-inspector value opts)]
     (outer value opts)))
 
 (deftest card-opt-off-by-default
   (testing "rf2-63ie5 — without `:card?` (or with `false`) the outer
             container carries NO card chrome (background, border,
             radius, padding, margin all absent)"
-    (let [h-default (invoke-data-display {:a 1} {:panel-id :rf.xray/app-db})
+    (let [h-default (invoke-edn-inspector {:a 1} {:panel-id :rf.xray/app-db})
           style-default (-> h-default second :style)
-          h-false   (invoke-data-display {:a 1}
+          h-false   (invoke-edn-inspector {:a 1}
                                           {:panel-id :rf.xray/app-db
                                            :card? false})
           style-false (-> h-false second :style)]
@@ -1434,7 +1434,7 @@
   (testing "rf2-63ie5 — `:card? true` adds background/border/radius/
             padding/margin to the outer container so the mount reads
             as a distinct inspector card"
-    (let [h (invoke-data-display {:a 1} {:panel-id :rf.xray/app-db
+    (let [h (invoke-edn-inspector {:a 1} {:panel-id :rf.xray/app-db
                                           :card? true})
           style (-> h second :style)]
       (is (= (:bg-1 tokens) (:background-color style))
@@ -1449,9 +1449,9 @@
 (deftest card-opt-carries-data-attr
   (testing "rf2-63ie5 — the outer container publishes `:data-rf-card`
             when card chrome is on; absent when off"
-    (let [h-on  (invoke-data-display {:a 1}
+    (let [h-on  (invoke-edn-inspector {:a 1}
                                       {:panel-id :rf.xray/app-db :card? true})
-          h-off (invoke-data-display {:a 1} {:panel-id :rf.xray/app-db})]
+          h-off (invoke-edn-inspector {:a 1} {:panel-id :rf.xray/app-db})]
       (is (= "1" (:data-rf-card (second h-on)))
           "card-on publishes :data-rf-card=1 for testbed assertion")
       (is (nil? (:data-rf-card (second h-off)))
@@ -1490,8 +1490,8 @@
             left edge, which is approximately the centre of the 22px
             triangle box (~31-34px wide, centre at ~16px)"
     (let [v   {:counter 1 :async nil :machine-ui {:open? true}}
-          k0  (dd/expansion-key :test "m" [])
-          h   (dd/render-node {:value v
+          k0  (ei/expansion-key :test "m" [])
+          h   (ei/render-node {:value v
                                :panel-id :test :mount-id "m"
                                :path [] :depth 0
                                :expansion-map {k0 {:expanded? true}}
@@ -1514,9 +1514,9 @@
           ;; ≤3 children) so both outer + inner expand-render.
           v   {:a 1 :b 2 :c 3 :d 4
                :nested {:x 1 :y 2 :z 3 :w 4}}
-          k0  (dd/expansion-key :test "m" [])
-          k1  (dd/expansion-key :test "m" [:nested])
-          h   (dd/render-node
+          k0  (ei/expansion-key :test "m" [])
+          k1  (ei/expansion-key :test "m" [:nested])
+          h   (ei/render-node
                 {:value v
                  :panel-id :test :mount-id "m"
                  :path [] :depth 0
@@ -1539,8 +1539,8 @@
     (let [;; 4 elements + a nested container defeats inline-fit so the
           ;; block body actually renders.
           v   [1 2 3 4 {:x :y}]
-          k0  (dd/expansion-key :test "m" [])
-          h   (dd/render-node {:value v
+          k0  (ei/expansion-key :test "m" [])
+          h   (ei/render-node {:value v
                                :panel-id :test :mount-id "m"
                                :path [] :depth 0
                                :expansion-map {k0 {:expanded? true}}
@@ -1560,7 +1560,7 @@
             light + dark themes resolve at paint time without a re-
             render. This test pins the inline-style values to the
             same token-keyed map the rest of the widget consumes."
-    (let [h (invoke-data-display {:a 1} {:panel-id :rf.xray/app-db
+    (let [h (invoke-edn-inspector {:a 1} {:panel-id :rf.xray/app-db
                                           :card? true})
           style (-> h second :style)]
       (is (= (:bg-1 tokens) (:background-color style))
@@ -1591,51 +1591,51 @@
 
 (deftest mono-char-width-and-safety-margin-are-stable
   (testing "rf2-kbdk8 — width-estimation constants exposed for tests"
-    (is (= 7 dd/mono-char-width-px)
+    (is (= 7 ei/mono-char-width-px)
         "7px M-advance is the conservative pick for JetBrains Mono 12px")
-    (is (= 16 dd/safety-margin-px)
+    (is (= 16 ei/safety-margin-px)
         "16px safety margin covers closing bracket + gutter")
-    (is (= 8 dd/default-ceiling-depth)
+    (is (= 8 ei/default-ceiling-depth)
         "new default `:default-expanded-depth` is 8 (CEILING, not trigger)")))
 
 (deftest estimated-inline-px-multiplies-pr-str-by-mono-advance
   (testing "rf2-kbdk8 — char-count × 7px estimate"
     (is (= (* 7 (count (pr-str {:a 1})))
-           (dd/estimated-inline-px {:a 1}))
+           (ei/estimated-inline-px {:a 1}))
         "pure function — char count × mono-char-width-px")
     (is (= (* 7 (count "nil"))
-           (dd/estimated-inline-px nil))
+           (ei/estimated-inline-px nil))
         "scalars route through the same pr-str pathway")
     ;; Long compound values get proportionally wider estimates — the
     ;; bead's example (~81-char nested value) lands around ~570px.
     (let [big-value [:ws/connection [:rf.machine.timer/after-elapsed
                                      2501 [:active :authenticating]]]]
       (is (= (* 7 (count (pr-str big-value)))
-             (dd/estimated-inline-px big-value))
+             (ei/estimated-inline-px big-value))
           "nested compound value estimate matches pr-str-length × 7"))))
 
 (deftest would-fit-inline-fits-when-estimate-plus-margin-le-available
   (testing "rf2-kbdk8 — `would-fit-inline?` gate"
     ;; A short value pr-strs to ~10 chars × 7px = 70px + 16px margin = 86px.
     (let [v {:a 1}]
-      (is (dd/would-fit-inline? v 200)
+      (is (ei/would-fit-inline? v 200)
           "200px column trivially fits a 10-char value")
-      (is (not (dd/would-fit-inline? v 50))
+      (is (not (ei/would-fit-inline? v 50))
           "50px column rejects even short values"))
     ;; The bead's worked example: ~81-char nested value in a 966px column.
     (let [big-but-fitting (apply str (repeat 80 "x"))]
-      (is (dd/would-fit-inline? big-but-fitting 966)
+      (is (ei/would-fit-inline? big-but-fitting 966)
           "~570px estimate trivially fits 966px column"))
-    (is (not (dd/would-fit-inline? {:a 1} nil))
+    (is (not (ei/would-fit-inline? {:a 1} nil))
         "nil available-width falls back to legacy strict gate")
-    (is (not (dd/would-fit-inline? {:a 1} 0))
+    (is (not (ei/would-fit-inline? {:a 1} 0))
         "zero or negative width is treated as no measurement")))
 
 (deftest default-expanded-width-aware-branch
   (testing "rf2-kbdk8 — width-aware `default-expanded?` flips the verdict"
     ;; A 2-key map fits in 600px easily — should NOT auto-expand (the
     ;; inline-fit gate picks it up instead).
-    (is (false? (dd/default-expanded?
+    (is (false? (ei/default-expanded?
                   {:depth 0 :child-count 2 :value {:a 1 :b 2}
                    :available-width-px 600})))
     ;; A long string-keyed map that overflows 200px should auto-expand
@@ -1643,20 +1643,20 @@
     (let [wide-v {:a "much-longer-than-the-budget"
                   :b "another-overflowing-string"
                   :c "and-yet-more-data"}]
-      (is (true? (dd/default-expanded?
+      (is (true? (ei/default-expanded?
                    {:depth 0 :child-count 3 :value wide-v
                     :available-width-px 100}))))
     ;; Beyond the ceiling, the width-aware branch falls back to false
     ;; (collapsed summary instead of auto-expanding pathologically deep).
     (let [wide-v {:a "much-longer-than-the-budget"
                   :b "another-overflowing-string"}]
-      (is (false? (dd/default-expanded?
+      (is (false? (ei/default-expanded?
                     {:depth 9 :child-count 2 :value wide-v
                      :default-expanded-depth 8
                      :available-width-px 100}))))
     ;; Diff mode's force-open over changed descendants still beats width
     (let [v {:a "wide string that overflows"}]
-      (is (true? (dd/default-expanded?
+      (is (true? (ei/default-expanded?
                    {:depth 0 :child-count 1 :value v
                     :available-width-px 1000
                     :has-changed-descendant? true}))
@@ -1667,11 +1667,11 @@
             the legacy depth-driven path runs unchanged so unit tests +
             first-paint behaviour stay deterministic"
     ;; depth 0, default-expanded-depth 2 → expanded (legacy behaviour).
-    (is (true? (dd/default-expanded?
+    (is (true? (ei/default-expanded?
                  {:depth 0 :child-count 2 :value {:a 1 :b 2}
                   :default-expanded-depth 2})))
     ;; depth 5, default-expanded-depth 2 → collapsed (legacy behaviour).
-    (is (false? (dd/default-expanded?
+    (is (false? (ei/default-expanded?
                   {:depth 5 :child-count 2 :value {:a 1 :b 2}
                    :default-expanded-depth 2})))))
 
@@ -1682,7 +1682,7 @@
             multi-row tree"
     ;; ~60-char nested value vs 800px column.
     (let [v {:tag :foo :payload [:active :authenticating]}
-          h (dd/render-node {:value v
+          h (ei/render-node {:value v
                              :panel-id :p :mount-id "m" :path []
                              :depth 0 :expansion-map {}
                              :opts {:default-expanded-depth 2
@@ -1706,7 +1706,7 @@
              :c "and-yet-more-data"
              :d "and-yet-still-more"
              :e "the-final-overflow"}
-          h (dd/render-node {:value v
+          h (ei/render-node {:value v
                              :panel-id :p :mount-id "m" :path []
                              :depth 0 :expansion-map {}
                              :opts {:default-expanded-depth 8
@@ -1723,8 +1723,8 @@
             when the value would naturally render inline; the operator
             sees what they clicked, not the heuristic's verdict"
     (let [v {:tag :foo :n 1}
-          k0 (dd/expansion-key :p "m" [])
-          h (dd/render-node {:value v
+          k0 (ei/expansion-key :p "m" [])
+          h (ei/render-node {:value v
                              :panel-id :p :mount-id "m" :path []
                              :depth 0
                              :expansion-map {k0 {:expanded? true}}
@@ -1740,7 +1740,7 @@
   (testing "rf2-kbdk8 — the recursive inline renderer emits one-line
             hiccup that includes nested brackets, separators, scalars"
     (let [v {:k1 1 :k2 [:a :b]}
-          h (dd/render-inline-recursive v)
+          h (ei/render-inline-recursive v)
           text (collect-text h)]
       (is (re-find #":k1" text))
       (is (re-find #":k2" text))
@@ -1756,19 +1756,19 @@
 
 (deftest width-slot-set-and-clear-events
   (testing "rf2-kbdk8 — set-width / clear-width app-db reducers"
-    (rf/dispatch-sync [:rf.xray.data-display/set-width "m" 600])
-    (let [widths @(rf/subscribe [dd/widths-slot])]
+    (rf/dispatch-sync [:rf.xray.edn-inspector/set-width "m" 600])
+    (let [widths @(rf/subscribe [ei/widths-slot])]
       (is (= 600 (get widths "m"))
           "set-width writes a positive measurement to the slot"))
     ;; Bad inputs are ignored (no app-db churn).
-    (rf/dispatch-sync [:rf.xray.data-display/set-width "m2" -5])
-    (rf/dispatch-sync [:rf.xray.data-display/set-width nil 100])
-    (let [widths @(rf/subscribe [dd/widths-slot])]
+    (rf/dispatch-sync [:rf.xray.edn-inspector/set-width "m2" -5])
+    (rf/dispatch-sync [:rf.xray.edn-inspector/set-width nil 100])
+    (let [widths @(rf/subscribe [ei/widths-slot])]
       (is (nil? (get widths "m2")) "negative width is rejected")
       (is (nil? (get widths nil))  "nil mount-id is rejected"))
     ;; Cleanup
-    (rf/dispatch-sync [:rf.xray.data-display/clear-width "m"])
-    (let [after-clear @(rf/subscribe [dd/widths-slot])]
+    (rf/dispatch-sync [:rf.xray.edn-inspector/clear-width "m"])
+    (let [after-clear @(rf/subscribe [ei/widths-slot])]
       (is (nil? (get after-clear "m"))
           "clear-width removes the entry"))))
 
@@ -1777,7 +1777,7 @@
             (function) for the ResizeObserver lifecycle, plus a data-
             attribute carrying the current measurement (or absent when
             not yet measured)"
-    (let [h (invoke-data-display {:a 1} {:panel-id :rf.xray/app-db})
+    (let [h (invoke-edn-inspector {:a 1} {:panel-id :rf.xray/app-db})
           attrs (-> h second)]
       (is (fn? (:ref attrs))
           "outer container carries a ref callback (mount/unmount hook)")

--- a/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_default_formatters_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_default_formatters_cljs_test.cljs
@@ -1,5 +1,5 @@
-(ns day8.re-frame2-xray.views.data-display-default-formatters-cljs-test
-  "Unit tests for the default `IXrayDataDisplay` formatters
+(ns day8.re-frame2-xray.views.edn-inspector-default-formatters-cljs-test
+  "Unit tests for the default `IXrayEdnInspector` formatters
   (rf2-x16b1 · follow-on to rf2-0qrcr phase 7).
 
   ## What's under test
@@ -12,7 +12,7 @@
      form so hover reveals the long uuid.
   3. **Inst (js/Date) header + body** — relative-time header against
      a pinned `now`, ISO body, title carries the full ISO.
-  4. **Render-node integration** — mounting `[data-display some-uuid]`
+  4. **Render-node integration** — mounting `[edn-inspector some-uuid]`
      routes through the protocol path (asserted via
      `:data-rf-protocol \"1\"`); same for inst.
   5. **Consumer override wins** — a consumer's `extend-type` against
@@ -24,11 +24,11 @@
   (:require [cljs.test :refer-macros [deftest is use-fixtures]]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
-            [day8.re-frame2-xray.views.data-display :as dd]
-            [day8.re-frame2-xray.views.data-display-default-formatters
+            [day8.re-frame2-xray.views.edn-inspector :as ei]
+            [day8.re-frame2-xray.views.edn-inspector-default-formatters
              :as ddf]
-            [day8.re-frame2-xray.views.data-display-protocol
-             :refer [IXrayDataDisplay]]))
+            [day8.re-frame2-xray.views.edn-inspector-protocol
+             :refer [IXrayEdnInspector]]))
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
@@ -136,7 +136,7 @@
         "expanded body shows the full canonical uuid")))
 
 (deftest uuid-renders-through-protocol-path-when-mounted
-  (let [h (dd/render-node {:value sample-uuid
+  (let [h (ei/render-node {:value sample-uuid
                            :panel-id :test
                            :mount-id "m1"
                            :path []
@@ -153,7 +153,7 @@
 (deftest uuid-body-rendered-when-expanded
   ;; Default-expanded? on protocol nodes is true (see render-protocol-node),
   ;; so the body container appears without operator interaction.
-  (let [h (dd/render-node {:value sample-uuid
+  (let [h (ei/render-node {:value sample-uuid
                            :panel-id :test
                            :mount-id "m2"
                            :path []
@@ -191,7 +191,7 @@
 
 (deftest inst-renders-through-protocol-path-when-mounted
   (let [d (js/Date. epoch-2026)
-        h (dd/render-node {:value d
+        h (ei/render-node {:value d
                            :panel-id :test
                            :mount-id "m3"
                            :path []
@@ -205,7 +205,7 @@
 
 (deftest inst-body-rendered-when-expanded
   (let [d (js/Date. epoch-2026)
-        h (dd/render-node {:value d
+        h (ei/render-node {:value d
                            :panel-id :test
                            :mount-id "m4"
                            :path []
@@ -222,7 +222,7 @@
 ;; =========================================================================
 
 (deftype MyWrappedUUID [uuid]
-  IXrayDataDisplay
+  IXrayEdnInspector
   (-xray-render-header [_ _opts]
     [:span {:data-testid "custom-uuid-header"} "custom-uuid"])
   (-xray-render-body [_ _opts]
@@ -234,7 +234,7 @@
   ;; the contract: defaults are inert when a consumer takes the seam
   ;; for a type they own.
   (let [v (MyWrappedUUID. (random-uuid))
-        h (dd/render-node {:value v
+        h (ei/render-node {:value v
                            :panel-id :test
                            :mount-id "m5"
                            :path []

--- a/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_popup_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_popup_cljs_test.cljs
@@ -1,5 +1,5 @@
-(ns day8.re-frame2-xray.views.data-display-popup-cljs-test
-  "Unit tests for the data-display popup overlay (rf2-s0x6x — phase
+(ns day8.re-frame2-xray.views.edn-inspector-popup-cljs-test
+  "Unit tests for the edn-inspector popup overlay (rf2-s0x6x — phase
   6 of rf2-oqa60).
 
   ## What's under test
@@ -13,7 +13,7 @@
      project `open?`, `top`, `entry` correctly.
   3. **Chrome rendering** — `popup-chrome` emits the canonical
      hiccup shape: backdrop / dialog / header (with close ✕) /
-     body containing the wrapped data-display widget.
+     body containing the wrapped edn-inspector widget.
   4. **Per-mount isolation** — two popup mounts get distinct
      UUIDs; the embedded widget's `:panel-id` is derived from the
      popup's mount-id so two popups inspecting the same value
@@ -30,7 +30,7 @@
             [re-frame.core :as rf]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
-            [day8.re-frame2-xray.views.data-display-popup :as ddp]))
+            [day8.re-frame2-xray.views.edn-inspector-popup :as ddp]))
 
 ;; Fresh re-frame runtime per test so dispatch-sync against the
 ;; registered popup handlers lands on a clean slot every time.
@@ -109,9 +109,9 @@
 ;; =========================================================================
 
 (deftest state-slot-keywords-stable
-  (is (= :rf.xray.data-display-popup/stack   ddp/stack-slot))
-  (is (= :rf.xray.data-display-popup/entries ddp/entries-slot))
-  (is (= :rf.xray.data-display-popup/anon    ddp/default-panel-id)))
+  (is (= :rf.xray.edn-inspector-popup/stack   ddp/stack-slot))
+  (is (= :rf.xray.edn-inspector-popup/entries ddp/entries-slot))
+  (is (= :rf.xray.edn-inspector-popup/anon    ddp/default-panel-id)))
 
 ;; =========================================================================
 ;; install! + reducers + subs
@@ -124,7 +124,7 @@
 
 (deftest open-event-pushes-stack-and-stores-payload
   (ddp/install!)
-  (rf/dispatch-sync [:rf.xray.data-display-popup/open
+  (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
                      "m1" {:value {:a 1} :opts {:title "First"}}])
   (let [stack   @(rf/subscribe [ddp/stack-slot])
         entries @(rf/subscribe [ddp/entries-slot])]
@@ -133,11 +133,11 @@
 
 (deftest open-event-stacks-multiple
   (ddp/install!)
-  (rf/dispatch-sync [:rf.xray.data-display-popup/open
+  (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
                      "m1" {:value 1 :opts {}}])
-  (rf/dispatch-sync [:rf.xray.data-display-popup/open
+  (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
                      "m2" {:value 2 :opts {}}])
-  (rf/dispatch-sync [:rf.xray.data-display-popup/open
+  (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
                      "m3" {:value 3 :opts {}}])
   (let [stack @(rf/subscribe [ddp/stack-slot])]
     (is (= ["m1" "m2" "m3"] stack)
@@ -145,11 +145,11 @@
 
 (deftest close-event-removes-specific-id
   (ddp/install!)
-  (rf/dispatch-sync [:rf.xray.data-display-popup/open
+  (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
                      "m1" {:value 1 :opts {}}])
-  (rf/dispatch-sync [:rf.xray.data-display-popup/open
+  (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
                      "m2" {:value 2 :opts {}}])
-  (rf/dispatch-sync [:rf.xray.data-display-popup/close "m1"])
+  (rf/dispatch-sync [:rf.xray.edn-inspector-popup/close "m1"])
   (let [stack   @(rf/subscribe [ddp/stack-slot])
         entries @(rf/subscribe [ddp/entries-slot])]
     (is (= ["m2"] stack) "m1 removed from stack")
@@ -158,11 +158,11 @@
 
 (deftest close-top-removes-topmost-only
   (ddp/install!)
-  (rf/dispatch-sync [:rf.xray.data-display-popup/open
+  (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
                      "m1" {:value 1 :opts {}}])
-  (rf/dispatch-sync [:rf.xray.data-display-popup/open
+  (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
                      "m2" {:value 2 :opts {}}])
-  (rf/dispatch-sync [:rf.xray.data-display-popup/close-top])
+  (rf/dispatch-sync [:rf.xray.edn-inspector-popup/close-top])
   (let [stack @(rf/subscribe [ddp/stack-slot])]
     (is (= ["m1"] stack)
         "close-top removed the topmost (m2); m1 still standing")))
@@ -170,16 +170,16 @@
 (deftest close-top-noop-on-empty-stack
   (ddp/install!)
   ;; No popups open — close-top must not throw.
-  (rf/dispatch-sync [:rf.xray.data-display-popup/close-top])
+  (rf/dispatch-sync [:rf.xray.edn-inspector-popup/close-top])
   (is (empty? (or @(rf/subscribe [ddp/stack-slot]) []))))
 
 (deftest close-all-clears-state
   (ddp/install!)
-  (rf/dispatch-sync [:rf.xray.data-display-popup/open
+  (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
                      "m1" {:value 1 :opts {}}])
-  (rf/dispatch-sync [:rf.xray.data-display-popup/open
+  (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
                      "m2" {:value 2 :opts {}}])
-  (rf/dispatch-sync [:rf.xray.data-display-popup/close-all])
+  (rf/dispatch-sync [:rf.xray.edn-inspector-popup/close-all])
   (let [stack   @(rf/subscribe [ddp/stack-slot])
         entries @(rf/subscribe [ddp/entries-slot])]
     (is (= [] stack))
@@ -187,42 +187,42 @@
 
 (deftest open-sub-projects-correctly
   (ddp/install!)
-  (is (false? @(rf/subscribe [:rf.xray.data-display-popup/open?]))
+  (is (false? @(rf/subscribe [:rf.xray.edn-inspector-popup/open?]))
       "no popups → :open? false")
-  (rf/dispatch-sync [:rf.xray.data-display-popup/open
+  (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
                      "m1" {:value 1 :opts {}}])
-  (is (true? @(rf/subscribe [:rf.xray.data-display-popup/open?]))
+  (is (true? @(rf/subscribe [:rf.xray.edn-inspector-popup/open?]))
       "one popup → :open? true"))
 
 (deftest top-sub-tracks-topmost-mount-id
   (ddp/install!)
-  (rf/dispatch-sync [:rf.xray.data-display-popup/open
+  (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
                      "m1" {:value 1 :opts {}}])
-  (is (= "m1" @(rf/subscribe [:rf.xray.data-display-popup/top])))
-  (rf/dispatch-sync [:rf.xray.data-display-popup/open
+  (is (= "m1" @(rf/subscribe [:rf.xray.edn-inspector-popup/top])))
+  (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
                      "m2" {:value 2 :opts {}}])
-  (is (= "m2" @(rf/subscribe [:rf.xray.data-display-popup/top]))
+  (is (= "m2" @(rf/subscribe [:rf.xray.edn-inspector-popup/top]))
       "second open promotes m2 to topmost"))
 
 (deftest entry-sub-returns-specific-payload
   (ddp/install!)
-  (rf/dispatch-sync [:rf.xray.data-display-popup/open
+  (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
                      "m1" {:value {:cart 1} :opts {:title "A"}}])
-  (rf/dispatch-sync [:rf.xray.data-display-popup/open
+  (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
                      "m2" {:value {:user 2} :opts {:title "B"}}])
   (is (= {:value {:cart 1} :opts {:title "A"}}
-         @(rf/subscribe [:rf.xray.data-display-popup/entry "m1"])))
+         @(rf/subscribe [:rf.xray.edn-inspector-popup/entry "m1"])))
   (is (= {:value {:user 2} :opts {:title "B"}}
-         @(rf/subscribe [:rf.xray.data-display-popup/entry "m2"]))))
+         @(rf/subscribe [:rf.xray.edn-inspector-popup/entry "m2"]))))
 
 (deftest reopen-with-same-id-preserves-position-and-replaces-payload
   (testing "re-opening m1 raises it to top AND replaces its payload"
     (ddp/install!)
-    (rf/dispatch-sync [:rf.xray.data-display-popup/open
+    (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
                        "m1" {:value 1 :opts {}}])
-    (rf/dispatch-sync [:rf.xray.data-display-popup/open
+    (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
                        "m2" {:value 2 :opts {}}])
-    (rf/dispatch-sync [:rf.xray.data-display-popup/open
+    (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
                        "m1" {:value 99 :opts {:title "raised"}}])
     (let [stack   @(rf/subscribe [ddp/stack-slot])
           entries @(rf/subscribe [ddp/entries-slot])]
@@ -243,16 +243,16 @@
              :positioning :fixed
              :stack-pos   0})]
     (is (some? (find-attr h :data-testid
-                          "rf-xray-data-display-popup-backdrop-m1"))
+                          "rf-xray-edn-inspector-popup-backdrop-m1"))
         "backdrop node carries mount-id-suffixed testid")
     (is (some? (find-attr h :data-testid
-                          "rf-xray-data-display-popup-dialog-m1"))
+                          "rf-xray-edn-inspector-popup-dialog-m1"))
         "dialog node carries mount-id-suffixed testid")
     (is (some? (find-attr h :data-testid
-                          "rf-xray-data-display-popup-body-m1"))
+                          "rf-xray-edn-inspector-popup-body-m1"))
         "body node carries mount-id-suffixed testid")
     (is (some? (find-attr h :data-testid
-                          "rf-xray-data-display-popup-close-m1"))
+                          "rf-xray-edn-inspector-popup-close-m1"))
         "close button carries mount-id-suffixed testid")))
 
 (deftest popup-chrome-emits-title-node-with-caller-title
@@ -263,7 +263,7 @@
              :positioning :fixed
              :stack-pos   0})
         title-node (find-attr h :data-testid
-                              "rf-xray-data-display-popup-title-m1")]
+                              "rf-xray-edn-inspector-popup-title-m1")]
     (is (some? title-node) "title node renders")
     ;; The title text is the third element (after the tag + attrs).
     (is (some #{"Custom title"} (flatten title-node))
@@ -277,11 +277,11 @@
              :positioning :fixed
              :stack-pos   0})
         title-node (find-attr h :data-testid
-                              "rf-xray-data-display-popup-title-m1")]
+                              "rf-xray-edn-inspector-popup-title-m1")]
     (is (some #{"Inspect"} (flatten title-node))
         "no :title → default 'Inspect' label")))
 
-(deftest popup-chrome-embeds-data-display-widget
+(deftest popup-chrome-embeds-edn-inspector-widget
   (let [h    (ddp/popup-chrome
                {:mount-id    "m1"
                 :value       {:foo :bar}
@@ -289,11 +289,11 @@
                 :positioning :fixed
                 :stack-pos   0})
         body (find-attr h :data-testid
-                        "rf-xray-data-display-popup-body-m1")]
+                        "rf-xray-edn-inspector-popup-body-m1")]
     (is (some? body) "body node renders")
-    ;; The body's child is `[dd/data-display value opts]` — find the
-    ;; data-display fn reference in the body subtree.
-    (let [data-display-call?
+    ;; The body's child is `[ei/edn-inspector value opts]` — find the
+    ;; edn-inspector fn reference in the body subtree.
+    (let [edn-inspector-call?
           (some (fn [node]
                   (and (vector? node)
                        (fn? (first node))
@@ -301,8 +301,8 @@
                        ;; value (or a wrapper around it).
                        (= (count node) 3)))
                 (walk-hiccup body))]
-      (is data-display-call?
-          "body embeds a fn-as-component call (the data-display widget)"))))
+      (is edn-inspector-call?
+          "body embeds a fn-as-component call (the edn-inspector widget)"))))
 
 (deftest popup-chrome-uses-aria-dialog-attrs
   (let [h      (ddp/popup-chrome
@@ -312,12 +312,12 @@
                   :positioning :fixed
                   :stack-pos   0})
         dialog (find-attr h :data-testid
-                          "rf-xray-data-display-popup-dialog-m1")]
+                          "rf-xray-edn-inspector-popup-dialog-m1")]
     (is (= "dialog" (-> dialog second :role))
         "dialog carries WAI-ARIA role")
     (is (= "true" (-> dialog second :aria-modal))
         "dialog is aria-modal")
-    (is (= "rf-xray-data-display-popup-title-m1"
+    (is (= "rf-xray-edn-inspector-popup-title-m1"
            (-> dialog second :aria-labelledby))
         "dialog labelled by the title node id")))
 
@@ -329,7 +329,7 @@
              :positioning :absolute
              :stack-pos   0})
         backdrop (find-attr h :data-testid
-                            "rf-xray-data-display-popup-backdrop-m1")]
+                            "rf-xray-edn-inspector-popup-backdrop-m1")]
     (is (= "absolute"
            (-> backdrop second :style :position))
         ":absolute positioning confines backdrop to parent cell")
@@ -345,7 +345,7 @@
              :positioning :fixed
              :stack-pos   0})
         backdrop (find-attr h :data-testid
-                            "rf-xray-data-display-popup-backdrop-m1")]
+                            "rf-xray-edn-inspector-popup-backdrop-m1")]
     (is (= "fixed"
            (-> backdrop second :style :position))
         ":fixed positioning spans viewport (production default)")))
@@ -360,7 +360,7 @@
                                  (reset! captured event-v))]
       (let [f (ddp/close-fn "m1" {})]
         (f)
-        (is (= [:rf.xray.data-display-popup/close "m1"] @captured)
+        (is (= [:rf.xray.edn-inspector-popup/close "m1"] @captured)
             "default close-fn dispatches the :close event for this id")))))
 
 (deftest close-fn-uses-caller-on-close-when-supplied
@@ -383,7 +383,7 @@
                  :positioning :fixed
                  :stack-pos   0})
         close (find-attr h :data-testid
-                         "rf-xray-data-display-popup-close-m1")]
+                         "rf-xray-edn-inspector-popup-close-m1")]
     (is (fn? (-> close second :on-click))
         "close button carries an :on-click handler")))
 
@@ -397,13 +397,13 @@
                     :positioning :fixed
                     :stack-pos   0})
         backdrop (find-attr h :data-testid
-                            "rf-xray-data-display-popup-backdrop-m1")
+                            "rf-xray-edn-inspector-popup-backdrop-m1")
         on-click (-> backdrop second :on-click)]
     (is (fn? on-click) "backdrop carries an :on-click handler")
     (with-redefs [rf/dispatch* (fn [event-v & _]
                                  (reset! captured event-v))]
       (on-click #js {:stopPropagation (fn [])})
-      (is (= [:rf.xray.data-display-popup/close "m1"] @captured)
+      (is (= [:rf.xray.edn-inspector-popup/close "m1"] @captured)
           "backdrop click dispatches :close for this popup"))))
 
 (deftest handle-keydown-escape-dispatches-close-top
@@ -416,7 +416,7 @@
         #js {:key "Escape"
              :preventDefault  (fn [])
              :stopPropagation (fn [])})
-      (is (= [:rf.xray.data-display-popup/close-top] @captured)
+      (is (= [:rf.xray.edn-inspector-popup/close-top] @captured)
           "Esc dispatches :close-top"))))
 
 (deftest handle-keydown-other-keys-bubble
@@ -433,15 +433,15 @@
           "Enter does not dispatch any popup event"))))
 
 ;; =========================================================================
-;; data-display-popup (form-2 component) — per-mount UUID
+;; edn-inspector-popup (form-2 component) — per-mount UUID
 ;; =========================================================================
 
-(deftest data-display-popup-allocates-mount-id-per-mount
+(deftest edn-inspector-popup-allocates-mount-id-per-mount
   ;; Two outer calls to the form-2 component (each modelling a
   ;; separate mount) should produce DISTINCT inner fns with distinct
   ;; mount-ids in closure.
-  (let [outer-1 (ddp/data-display-popup {:a 1})
-        outer-2 (ddp/data-display-popup {:a 1})]
+  (let [outer-1 (ddp/edn-inspector-popup {:a 1})
+        outer-2 (ddp/edn-inspector-popup {:a 1})]
     (is (fn? outer-1) "form-2 outer returns an inner fn")
     (is (fn? outer-2))
     ;; Distinct closures imply distinct mount-ids; we can't peek into
@@ -450,21 +450,21 @@
     (is (not= outer-1 outer-2)
         "two outer calls produce distinct inner fns")))
 
-(deftest data-display-popup-two-arity-overload
-  (testing "[data-display-popup value opts] arity is accepted (D2=a
+(deftest edn-inspector-popup-two-arity-overload
+  (testing "[edn-inspector-popup value opts] arity is accepted (D2=a
             two-arg overload convention)"
-    (is (fn? (ddp/data-display-popup {:a 1} {:title "Cart"})))))
+    (is (fn? (ddp/edn-inspector-popup {:a 1} {:title "Cart"})))))
 
-(deftest data-display-popup-default-arity
-  (testing "[data-display-popup value] single-arg arity works"
-    (is (fn? (ddp/data-display-popup {:a 1})))))
+(deftest edn-inspector-popup-default-arity
+  (testing "[edn-inspector-popup value] single-arg arity works"
+    (is (fn? (ddp/edn-inspector-popup {:a 1})))))
 
 ;; =========================================================================
 ;; per-mount isolation — embedded widget panel-id is mount-scoped
 ;; =========================================================================
 
 (deftest popup-chrome-derives-embedded-panel-id-from-mount-id
-  ;; The embedded data-display widget should receive a :panel-id that
+  ;; The embedded edn-inspector widget should receive a :panel-id that
   ;; incorporates the popup's mount-id so two popups inspecting the
   ;; same value never collide on expansion state.
   (let [h    (ddp/popup-chrome
@@ -474,9 +474,9 @@
                 :positioning :fixed
                 :stack-pos   0})
         body (find-attr h :data-testid
-                        "rf-xray-data-display-popup-body-m-abc")
+                        "rf-xray-edn-inspector-popup-body-m-abc")
         ;; Walk into the body subtree and find the embedded
-        ;; data-display call's opts map (third element of the
+        ;; edn-inspector call's opts map (third element of the
         ;; `[fn value opts]` form).
         embedded-call
         (some (fn [node]
@@ -488,7 +488,7 @@
                   node))
               (walk-hiccup body))]
     (is (some? embedded-call)
-        "embedded data-display call resolved with a :panel-id opt")
+        "embedded edn-inspector call resolved with a :panel-id opt")
     (let [embedded-panel-id (:panel-id (nth embedded-call 2))]
       (is (keyword? embedded-panel-id)
           "embedded panel-id is a keyword")
@@ -505,7 +505,7 @@
                 :positioning :fixed
                 :stack-pos   0})
         body (find-attr h :data-testid
-                        "rf-xray-data-display-popup-body-m-xyz")
+                        "rf-xray-edn-inspector-popup-body-m-xyz")
         embedded-call
         (some (fn [node]
                 (when (and (vector? node)
@@ -528,37 +528,37 @@
   (ddp/install!)
   ;; Register the modal-positioning sub the stack view subscribes to.
   (rf/reg-sub :rf.xray/modal-positioning (fn [_ _] :fixed))
-  (is (nil? (ddp/data-display-popup-stack))
+  (is (nil? (ddp/edn-inspector-popup-stack))
       "closed stack short-circuits to nil"))
 
 (deftest stack-view-renders-one-entry-per-open-popup
   (ddp/install!)
   (rf/reg-sub :rf.xray/modal-positioning (fn [_ _] :fixed))
-  (rf/dispatch-sync [:rf.xray.data-display-popup/open
+  (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
                      "m1" {:value 1 :opts {:title "A"}}])
-  (rf/dispatch-sync [:rf.xray.data-display-popup/open
+  (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
                      "m2" {:value 2 :opts {:title "B"}}])
-  (let [tree (ddp/data-display-popup-stack)]
+  (let [tree (ddp/edn-inspector-popup-stack)]
     (is (some? tree) "stack view renders when at least one popup is open")
     (is (some? (find-attr tree :data-testid
-                          "rf-xray-data-display-popup-stack"))
+                          "rf-xray-edn-inspector-popup-stack"))
         "container carries the stack testid")
     (is (some? (find-attr tree :data-testid
-                          "rf-xray-data-display-popup-backdrop-m1"))
+                          "rf-xray-edn-inspector-popup-backdrop-m1"))
         "m1 chrome present")
     (is (some? (find-attr tree :data-testid
-                          "rf-xray-data-display-popup-backdrop-m2"))
+                          "rf-xray-edn-inspector-popup-backdrop-m2"))
         "m2 chrome present")))
 
 (deftest stack-view-marks-popup-count
   (ddp/install!)
   (rf/reg-sub :rf.xray/modal-positioning (fn [_ _] :fixed))
-  (rf/dispatch-sync [:rf.xray.data-display-popup/open
+  (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
                      "m1" {:value 1 :opts {}}])
-  (rf/dispatch-sync [:rf.xray.data-display-popup/open
+  (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
                      "m2" {:value 2 :opts {}}])
-  (rf/dispatch-sync [:rf.xray.data-display-popup/open
+  (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
                      "m3" {:value 3 :opts {}}])
-  (let [tree (ddp/data-display-popup-stack)]
+  (let [tree (ddp/edn-inspector-popup-stack)]
     (is (= 3 (-> tree second :data-rf-popup-count))
         "popup-count attribute reflects stack depth")))

--- a/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_popup_wireup_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_popup_wireup_cljs_test.cljs
@@ -1,25 +1,25 @@
-(ns day8.re-frame2-xray.views.data-display-popup-wireup-cljs-test
-  "Wire-up tests for the data-display popup affordance + shell mount
+(ns day8.re-frame2-xray.views.edn-inspector-popup-wireup-cljs-test
+  "Wire-up tests for the edn-inspector popup affordance + shell mount
   (rf2-l4625, follow-on from phase 6 / rf2-s0x6x).
 
   ## What's under test
 
-  1. **Widget-level affordance** — when `[dd/data-display value
+  1. **Widget-level affordance** — when `[ei/edn-inspector value
      {:popup-affordance? true …}]` is mounted, the rendered hiccup
      carries a `:button` node with the canonical testid
-     `rf-xray-data-display-popup-affordance-ddp-<mount-id>`. The
+     `rf-xray-edn-inspector-popup-affordance-ddp-<mount-id>`. The
      button's on-click dispatches
-     `[:rf.xray.data-display-popup/open …]` through the supplied
+     `[:rf.xray.edn-inspector-popup/open …]` through the supplied
      dispatch-fn with the widget's value + a sanitised opts map
-     (re-entry into the popup's own data-display does NOT re-enable
+     (re-entry into the popup's own edn-inspector does NOT re-enable
      the affordance).
   2. **Opt-in default off** — without `:popup-affordance?` (or with
      `false`) the widget renders NO affordance button.
-  3. **Shell mount** — `data-display-popup-stack` short-circuits to
+  3. **Shell mount** — `edn-inspector-popup-stack` short-circuits to
      nil when the stack is empty and renders the chrome for every
      active mount-id when the stack is non-empty.
   4. **Registry install** — `registry.cljs` calls
-     `data-display-popup/install!` so the open/close events resolve
+     `edn-inspector-popup/install!` so the open/close events resolve
      through `rf/dispatch-sync` post-registration.
 
   Driving the on-click through a captured dispatch-fn stub avoids the
@@ -34,8 +34,8 @@
             [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]
-            [day8.re-frame2-xray.views.data-display :as dd]
-            [day8.re-frame2-xray.views.data-display-popup :as ddp]))
+            [day8.re-frame2-xray.views.edn-inspector :as ei]
+            [day8.re-frame2-xray.views.edn-inspector-popup :as ddp]))
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture
@@ -66,11 +66,11 @@
             node))
         (hiccup-seq tree)))
 
-(defn- invoke-data-display
+(defn- invoke-edn-inspector
   "Form-2 unrolling — call the outer fn, then call the inner fn with
   the same args to get the rendered hiccup."
   [value opts]
-  (let [outer (dd/data-display value opts)]
+  (let [outer (ei/edn-inspector value opts)]
     (outer value opts)))
 
 ;; =========================================================================
@@ -78,10 +78,10 @@
 ;; =========================================================================
 
 (deftest popup-affordance-opt-in-renders-button
-  (testing "rf2-l4625 — `[dd/data-display value {:popup-affordance? true}]`
+  (testing "rf2-l4625 — `[ei/edn-inspector value {:popup-affordance? true}]`
             renders a top-right ↗ icon button (rf2-7sdja — glyph was
             ⊕; ↗ reads as 'open in new pane')"
-    (let [h (invoke-data-display
+    (let [h (invoke-edn-inspector
               {:cart [1 2 3]}
               {:panel-id :rf.xray/app-db :popup-affordance? true})
           btn (find-affordance h)]
@@ -97,10 +97,10 @@
 (deftest popup-affordance-default-off
   (testing "rf2-l4625 — without `:popup-affordance?` (or with `false`)
             the widget renders NO affordance button"
-    (let [h-default (invoke-data-display
+    (let [h-default (invoke-edn-inspector
                      {:cart [1 2 3]}
                      {:panel-id :rf.xray/app-db})
-          h-false   (invoke-data-display
+          h-false   (invoke-edn-inspector
                      {:cart [1 2 3]}
                      {:panel-id :rf.xray/app-db
                       :popup-affordance? false})]
@@ -112,7 +112,7 @@
 (deftest popup-affordance-button-carries-stable-testid
   (testing "rf2-l4625 — the button testid includes the per-mount popup
             id (`ddp-<mount-id>`) so panel-level tests can target it"
-    (let [outer (dd/data-display {:a 1}
+    (let [outer (ei/edn-inspector {:a 1}
                                  {:panel-id :rf.xray/app-db
                                   :popup-affordance? true})
           inner-h (outer {:a 1} {:panel-id :rf.xray/app-db
@@ -120,7 +120,7 @@
           container (second inner-h)
           mount-id  (:data-rf-mount-id container)
           expected-testid
-          (str "rf-xray-data-display-popup-affordance-ddp-" mount-id)
+          (str "rf-xray-edn-inspector-popup-affordance-ddp-" mount-id)
           btn (find-by-testid inner-h expected-testid)]
       (is (some? mount-id) "container has a mount-id")
       (is (some? btn) "button found by the expected testid")
@@ -132,10 +132,10 @@
   (testing "rf2-l4625 — when the affordance is enabled the outer
             container carries `position: relative` so the absolute-
             positioned button anchors correctly"
-    (let [h-on  (invoke-data-display
+    (let [h-on  (invoke-edn-inspector
                   {:a 1} {:panel-id :rf.xray/app-db
                           :popup-affordance? true})
-          h-off (invoke-data-display
+          h-off (invoke-edn-inspector
                   {:a 1} {:panel-id :rf.xray/app-db})]
       (is (= "relative" (-> h-on second :style :position))
           "affordance-on → outer container is position: relative")
@@ -163,10 +163,10 @@
 
 (deftest popup-affordance-button-onclick-dispatches-against-xray-frame
   (testing "rf2-7sdja — clicking the affordance dispatches
-            `[:rf.xray.data-display-popup/open popup-mount-id payload]`
+            `[:rf.xray.edn-inspector-popup/open popup-mount-id payload]`
             against `:rf/xray` EXPLICITLY (popup state is Xray-global,
             not per-frame — pinned via `{:frame :rf/xray}` opts)"
-    (let [btn (dd/popup-affordance-button
+    (let [btn (ei/popup-affordance-button
                 ;; `dispatch-fn` parameter is a no-op post rf2-7sdja —
                 ;; pass nil to make the new contract obvious.
                 nil
@@ -177,14 +177,14 @@
           on-click (:on-click (second btn))
           {:keys [event opts]} (with-rf-dispatch-spy on-click)
           [event-id mount-id payload] event]
-      (is (= :rf.xray.data-display-popup/open event-id)
+      (is (= :rf.xray.edn-inspector-popup/open event-id)
           "canonical event id")
       (is (= "ddp-abc" mount-id)
           "popup-mount-id flows through as second positional arg")
       (is (= {:cart [1 2 3]} (:value payload))
           "value flows through as `:value`")
       (is (false? (:popup-affordance? (:opts payload)))
-          "the popup's embedded data-display does NOT re-enable the
+          "the popup's embedded edn-inspector does NOT re-enable the
            affordance (no recursion)")
       (is (= :rf.xray/app-db (:panel-id (:opts payload)))
           "other opts (`:panel-id`, `:default-expanded-depth`) survive")
@@ -199,7 +199,7 @@
   (testing "rf2-l4625 — when the caller supplies no opts, the affordance
             still produces a sane payload (just `:popup-affordance? false`
             in the popup's downstream opts map)"
-    (let [btn (dd/popup-affordance-button nil "ddp-x" {:k :v} nil)
+    (let [btn (ei/popup-affordance-button nil "ddp-x" {:k :v} nil)
           on-click (:on-click (second btn))
           {:keys [event opts]} (with-rf-dispatch-spy on-click)
           payload (nth event 2)]
@@ -210,7 +210,7 @@
           "rf2-7sdja — `:rf/xray` frame still pinned even with nil opts"))))
 
 ;; =========================================================================
-;; shell mount — `data-display-popup-stack` view
+;; shell mount — `edn-inspector-popup-stack` view
 ;; =========================================================================
 
 (defn- setup-xray-frame! []
@@ -220,7 +220,7 @@
 (deftest popup-stack-view-empty-when-stack-empty
   (setup-xray-frame!)
   (rf/with-frame :rf/xray
-    (let [tree (ddp/data-display-popup-stack)]
+    (let [tree (ddp/edn-inspector-popup-stack)]
       (is (nil? tree)
           "stack view returns nil when no popups are open (closed-state
            cost is one subscribe + a when-gate)"))))
@@ -231,30 +231,30 @@
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
       (rf/dispatch-sync
-        [:rf.xray.data-display-popup/open
+        [:rf.xray.edn-inspector-popup/open
          "m1" {:value {:foo :bar}
                :opts  {:title "Inspect cart"}}])
-      (let [tree (ddp/data-display-popup-stack)]
+      (let [tree (ddp/edn-inspector-popup-stack)]
         (is (some? tree) "stack view returns hiccup when stack non-empty")
-        (is (some? (find-by-testid tree "rf-xray-data-display-popup-stack"))
+        (is (some? (find-by-testid tree "rf-xray-edn-inspector-popup-stack"))
             "outer stack container present")
         (is (some? (find-by-testid tree
-                                   "rf-xray-data-display-popup-backdrop-m1"))
+                                   "rf-xray-edn-inspector-popup-backdrop-m1"))
             "popup chrome rendered for m1")))))
 
 (deftest popup-stack-view-renders-each-active-mount
   (testing "rf2-l4625 — every mount-id on the stack gets a chrome"
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
-      (rf/dispatch-sync [:rf.xray.data-display-popup/open
+      (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
                          "m1" {:value 1 :opts {}}])
-      (rf/dispatch-sync [:rf.xray.data-display-popup/open
+      (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
                          "m2" {:value 2 :opts {}}])
-      (let [tree (ddp/data-display-popup-stack)]
+      (let [tree (ddp/edn-inspector-popup-stack)]
         (is (some? (find-by-testid tree
-                                   "rf-xray-data-display-popup-backdrop-m1")))
+                                   "rf-xray-edn-inspector-popup-backdrop-m1")))
         (is (some? (find-by-testid tree
-                                   "rf-xray-data-display-popup-backdrop-m2")))))))
+                                   "rf-xray-edn-inspector-popup-backdrop-m2")))))))
 
 ;; =========================================================================
 ;; registry wiring
@@ -267,7 +267,7 @@
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
       (rf/dispatch-sync
-        [:rf.xray.data-display-popup/open
+        [:rf.xray.edn-inspector-popup/open
          "smoke" {:value :hi :opts {:title "Smoke"}}])
       (let [stack @(rf/subscribe [ddp/stack-slot])]
         (is (= ["smoke"] stack)

--- a/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_protocol_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_protocol_cljs_test.cljs
@@ -1,5 +1,5 @@
-(ns day8.re-frame2-xray.views.data-display-protocol-cljs-test
-  "Unit tests for the IXrayDataDisplay custom-formatters protocol
+(ns day8.re-frame2-xray.views.edn-inspector-protocol-cljs-test
+  "Unit tests for the IXrayEdnInspector custom-formatters protocol
   (rf2-oqa60 phase 7 · rf2-0qrcr).
 
   ## What's under test
@@ -9,7 +9,7 @@
      path — `:data-rf-protocol` is absent.
 
   2. **Protocol-implementing types use the protocol methods.** A
-     deftype that implements `IXrayDataDisplay` short-circuits the
+     deftype that implements `IXrayEdnInspector` short-circuits the
      built-in dispatch; the consumer's `-xray-render-header` output
      appears verbatim in the rendered hiccup.
 
@@ -29,9 +29,9 @@
   (:require [cljs.test :refer-macros [deftest is use-fixtures]]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
-            [day8.re-frame2-xray.views.data-display :as dd]
-            [day8.re-frame2-xray.views.data-display-protocol :as ddp
-             :refer [IXrayDataDisplay]]))
+            [day8.re-frame2-xray.views.edn-inspector :as ei]
+            [day8.re-frame2-xray.views.edn-inspector-protocol :as ddp
+             :refer [IXrayEdnInspector]]))
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
@@ -75,7 +75,7 @@
 
 ;; A type that satisfies the protocol with both header + body.
 (deftype FullCustom [tag payload]
-  IXrayDataDisplay
+  IXrayEdnInspector
   (-xray-render-header [_ _opts]
     [:span {:data-testid "custom-header"
             :data-custom-tag (str tag)} (str "#" tag)])
@@ -84,27 +84,27 @@
 
 ;; A type that only customises the header.
 (deftype HeaderOnly [label]
-  IXrayDataDisplay
+  IXrayEdnInspector
   (-xray-render-header [_ _opts]
     [:span {:data-testid "header-only"} (str "h:" label)])
   (-xray-render-body [_ _opts] nil))
 
 ;; A type that opts-out by returning nil header.
 (deftype OptsOut [inner]
-  IXrayDataDisplay
+  IXrayEdnInspector
   (-xray-render-header [_ _opts] nil)
   (-xray-render-body [_ _opts] [:span "ignored body"]))
 
 ;; A consumer impl that THROWS — the safe accessor must catch.
 (deftype Broken []
-  IXrayDataDisplay
+  IXrayEdnInspector
   (-xray-render-header [_ _opts] (throw (ex-info "boom" {})))
   (-xray-render-body [_ _opts] (throw (ex-info "boom" {}))))
 
 ;; ---- 1. built-in dispatch untouched -------------------------------------
 
 (deftest plain-map-does-not-pick-up-protocol-path
-  (let [h (dd/render-node {:value {:a 1 :b 2}
+  (let [h (ei/render-node {:value {:a 1 :b 2}
                            :panel-id :test
                            :mount-id "m1"
                            :path []
@@ -117,7 +117,7 @@
         "plain map renders via built-in :map dispatch")))
 
 (deftest plain-vector-does-not-pick-up-protocol-path
-  (let [h (dd/render-node {:value [1 2 3]
+  (let [h (ei/render-node {:value [1 2 3]
                            :panel-id :test
                            :mount-id "m1"
                            :path []
@@ -128,7 +128,7 @@
     (is (some? (find-attr h :data-rf-kind "vector")))))
 
 (deftest plain-scalar-does-not-pick-up-protocol-path
-  (let [h (dd/render-node {:value 42
+  (let [h (ei/render-node {:value 42
                            :panel-id :test
                            :mount-id "m1"
                            :path []
@@ -140,7 +140,7 @@
 (deftest sentinel-does-not-pick-up-protocol-path
   ;; Sentinels are first-class types — they must stay on the built-in
   ;; dispatch, not be accidentally diverted by the protocol seam.
-  (let [h (dd/render-node {:value :rf/redacted
+  (let [h (ei/render-node {:value :rf/redacted
                            :panel-id :test
                            :mount-id "m1"
                            :path []
@@ -154,7 +154,7 @@
 
 (deftest full-custom-renders-via-protocol-header-and-body
   (let [v (FullCustom. "Account" "data-here")
-        h (dd/render-node {:value v
+        h (ei/render-node {:value v
                            :panel-id :test
                            :mount-id "m1"
                            :path []
@@ -174,7 +174,7 @@
 
 (deftest protocol-node-carries-stable-testid
   (let [v (FullCustom. "Account" "data")
-        h (dd/render-node {:value v
+        h (ei/render-node {:value v
                            :panel-id :test
                            :mount-id "m99"
                            :path [:k]
@@ -182,7 +182,7 @@
                            :expansion-map {}
                            :opts {}})]
     (is (some? (find-attr h :data-testid
-                          "rf-xray-data-display-test-m99-:k"))
+                          "rf-xray-edn-inspector-test-m99-:k"))
         "protocol node carries the same `[panel-id mount-id path]` testid as built-in nodes")))
 
 ;; ---- 3. header-nil fall-through to built-ins ----------------------------
@@ -194,7 +194,7 @@
   ;; the right outcome — the consumer explicitly opted out, the
   ;; widget shouldn't second-guess.
   (let [v (OptsOut. "inner")
-        h (dd/render-node {:value v
+        h (ei/render-node {:value v
                            :panel-id :test
                            :mount-id "m1"
                            :path []
@@ -210,7 +210,7 @@
 
 (deftest body-nil-renders-header-only
   (let [v (HeaderOnly. "tag")
-        h (dd/render-node {:value v
+        h (ei/render-node {:value v
                            :panel-id :test
                            :mount-id "m1"
                            :path []
@@ -223,7 +223,7 @@
         "consumer header rendered")
     ;; No body container — the testid suffix `-body` is absent.
     (is (nil? (find-attr h :data-testid
-                         "rf-xray-data-display-test-m1--body"))
+                         "rf-xray-edn-inspector-test-m1--body"))
         "no body container rendered when body-fn returns nil")))
 
 ;; ---- 5. broken consumer impl: safe catch --------------------------------
@@ -234,7 +234,7 @@
   ;; falls through to built-ins (which renders the deftype via
   ;; the :other / pr-str fallback).
   (let [v (Broken.)
-        h (dd/render-node {:value v
+        h (ei/render-node {:value v
                            :panel-id :test
                            :mount-id "m1"
                            :path []
@@ -251,8 +251,8 @@
 (deftest expansion-map-collapses-protocol-body
   (let [v (FullCustom. "Account" "data")
         ;; Force-collapsed via the expansion-map override.
-        k (dd/expansion-key :test "m1" [])
-        h (dd/render-node {:value v
+        k (ei/expansion-key :test "m1" [])
+        h (ei/render-node {:value v
                            :panel-id :test
                            :mount-id "m1"
                            :path []
@@ -268,7 +268,7 @@
 ;; ---- 7. predicate convenience -------------------------------------------
 
 (deftest satisfies-predicate
-  (is (true?  (ddp/satisfies-xray-data-display? (FullCustom. "x" "y"))))
-  (is (false? (ddp/satisfies-xray-data-display? {:a 1})))
-  (is (false? (ddp/satisfies-xray-data-display? 42)))
-  (is (false? (ddp/satisfies-xray-data-display? nil))))
+  (is (true?  (ddp/satisfies-xray-edn-inspector? (FullCustom. "x" "y"))))
+  (is (false? (ddp/satisfies-xray-edn-inspector? {:a 1})))
+  (is (false? (ddp/satisfies-xray-edn-inspector? 42)))
+  (is (false? (ddp/satisfies-xray-edn-inspector? nil))))

--- a/tools/xray/test/day8/re_frame2_xray/views/edn_widget/widget_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/edn_widget/widget_cljs_test.cljs
@@ -1,8 +1,8 @@
 (ns day8.re-frame2-xray.views.edn-widget.widget-cljs-test
   "Tests for the Xray EDN widget facade — post-rf2-oqa60 phase 1.
 
-  After the data-display rebuild the facade is a thin delegate over
-  `views.data-display`; tests for the prior cljs-devtools routing /
+  After the edn-inspector rebuild the facade is a thin delegate over
+  `views.edn-inspector`; tests for the prior cljs-devtools routing /
   copy-affordance behaviour are deleted with the cljs-devtools cut-over.
 
   This file now exercises ONLY the surfaces the facade still owns
@@ -52,21 +52,21 @@
 ;; ---- facade delegation --------------------------------------------------
 ;;
 ;; Post-rf2-oqa60 the facade returns a Reagent component form 2:
-;; `[dd/data-display value opts]` for browse / inspect, and a hiccup
+;; `[ei/edn-inspector value opts]` for browse / inspect, and a hiccup
 ;; vector for mini. The dispatcher returns hiccup. The test surface
 ;; that mattered (sentinel chrome, type colours, click-to-toggle)
-;; lives in `views/data_display_cljs_test.cljs`.
+;; lives in `views/edn_inspector_cljs_test.cljs`.
 
-(deftest browse-returns-data-display-mount-form
+(deftest browse-returns-edn-inspector-mount-form
   (let [out (w/browse {:value     {:a 1 :b 2}
                        :panel-id  :test
                        :render-id "b1"})]
     (testing "browse returns a Reagent component invocation"
       (is (vector? out))
-      ;; First element is the data-display fn (a Var).
+      ;; First element is the edn-inspector fn (a Var).
       (is (fn? (first out)) "first element is a function ref"))))
 
-(deftest inspect-returns-data-display-mount-form
+(deftest inspect-returns-edn-inspector-mount-form
   (let [out (w/inspect :hello "node-key")]
     (is (vector? out))
     (is (fn? (first out)))))
@@ -74,7 +74,7 @@
 (deftest mini-returns-span-shape
   (let [out (w/mini :hello)]
     (is (= :span (first out)))
-    (is (= "rf-xray-data-display-mini" (get (second out) :data-testid)))))
+    (is (= "rf-xray-edn-inspector-mini" (get (second out) :data-testid)))))
 
 ;; ---- code-block tokenizer ------------------------------------------------
 
@@ -270,7 +270,7 @@
   (let [out (w/render {:value     {:a 1}
                        :panel-id  :test
                        :render-id "dispatch-1"})]
-    ;; browse delegates to dd/data-display; the dispatcher returns
+    ;; browse delegates to ei/edn-inspector; the dispatcher returns
     ;; the same shape as `browse` — a [function opts] reagent form.
     (is (vector? out))))
 
@@ -280,7 +280,7 @@
                        :after     {:a 2}
                        :panel-id  :test
                        :render-id "dispatch-2"})]
-    ;; Post-rf2-q3dzw: diff delegates to dd/data-display with a
+    ;; Post-rf2-q3dzw: diff delegates to ei/edn-inspector with a
     ;; `:before` opt. The dispatcher returns the same shape as
     ;; `diff` — a [function value opts] Reagent form. Assert the
     ;; threaded `:before` lands on the opts so we don't regress the


### PR DESCRIPTION
@
Three sequenced changes against the same widget surface, packaged as one PR so the diffs read cleanly per commit.

## Commit 1 — feat(xray): width-aware expansion heuristic (rf2-kbdk8)

**Symptom.** The closed-renderer auto-expansion was depth-driven — any container within `default-expanded-depth` opened automatically regardless of how trivially its inline form would fit the available column width. Measured live: 81-char nested vector rendered as a 148px / 8-9 row tree in a 966px column where its 570px inline equivalent trivially fits. ~9× vertical waste pervasive across every panel.

**Fix.** Flip the test: render inline FIRST when the values estimated inline width fits the available column (with a 16px safety margin); only fall back to tree-expand when the inline form would overflow. `default-expanded-depth` repurposed as a CEILING — never auto-expand past depth N (collapsed summary instead). Default raised 2 → 8 to reflect the new semantic.

Width measurement: per-mount ResizeObserver via the outer containers `:ref` callback writes `clientWidth` to an app-db slot keyed by mount-id; the inner body subscribes and threads `available-width-px` through every recursive render-node call. ResizeObserver tears down + the slot entry clears on unmount so theres no slow leak.

Width estimate: `(* (count (pr-str value)) 7px)` — JetBrains Mono M-advance at 12px sits in the 7.0-7.3px range; 7px is the conservative rounded-up pick.

Composition kept intact: operators sticky expand override wins; diff modes force-open over changed descendants fires; per-token syntax palette preserved through the recursive inline renderer.

**Tests.** Constants pinned (`mono-char-width-px`, `safety-margin-px`, `default-ceiling-depth`); pure-decision functions (`estimated-inline-px`, `would-fit-inline?`, `default-expanded?` width-aware branch); render-container integration (width-fit emits inline / too-wide expands to tree / operator override beats width-fits); recursive inline renderer; set-width / clear-width reducers; `:ref` callback presence on the outer container.

## Commit 2 — refactor(xray): diff state → row chrome (rf2-awqts)

**Symptom.** Diff text-colour overrides clashed with the Calva-aligned `:syntax-*` palette. Live measurement (pair-debug 2026-05-26): `~` gutter `rgb(154, 103, 0)` dark orange; `:syntax-number` value `rgb(152, 104, 1)` dark orange — essentially identical. Operator scanning a row with an orange thing in it could not tell "this is a number" from "this is modified".

**Fix.** Move diff signalling off the per-token text-colour channel onto row chrome — GitHub diff convention:

1. **Reserved gutter glyph hue** (`:diff-gutter`, cyan-teal in dark / darker-teal in light). Chromatic-distance-disjoint from every `:syntax-*` family — no magenta / green / orange / gold / blue collision. Every active op reads the SAME reserved hue; per-op signal carried by the glyph SHAPE (`+/-/~/◴`), the wash, and the stripe.
2. **Per-op row wash** (low-opacity 8-digit hex): `:diff-added-wash` green @ ~10%, `:diff-modified-wash` amber @ ~12%, `:diff-removed-wash` red @ ~10%. `:children` + `:same` get NO wash.
3. **2px left-edge stripe** in the saturated per-op hue. Reinforces the row signal at the column-1 anchor without competing with text colour.

Per-token text colour PRESERVED across `:added` and `:modified` — the diff path no longer overrides to `:green` / `:yellow`. `:removed` keeps strike-through (a non-colour signal); `:same` keeps `:text-tertiary` dimming so unchanged rows recede.

Palette additions in both dark + light. Machines-viz mirrors the key-set to keep the rf2-z7ms8 drift gate green.

**Tests.** `gutter-tone-mapping` updated to `:diff-gutter`; new `row-wash-mapping` / `row-stripe-mapping` pin the new token maps; `gutter-glyph-colour-is-syntax-palette-disjoint` verifies the reserved hue does NOT collide with any `:syntax-*` token in either palette; `diff-leaf-preserves-syntax-token-colour` pins `:syntax-number` on added scalars + `:syntax-boolean` on modified scalars (the canonical regression).

## Commit 3 — refactor(xray): rename data-display → edn-inspector (rf2-h4fce)

**Intent.** The widget at `views/data_display.cljs` was misnamed. `edn-inspector` reads better:
- "inspector" is the dominant ecosystem-wide name for this widget class (Chrome devtools "object inspector", cljs-devtools, vscode "variables" panel) — anchors to a known mental model.
- "edn" signals the data format (keywords, namespaced keywords, sets, records, sentinels) — not a generic JSON viewer.
- "display" was passive — the widget is interactive (expand/collapse, popup, diff mode, sticky state, width-aware inline rendering).

Pre-alpha posture: clean cut, no alias namespace, no event-id alias map. Everything moves in this commit.

**Scope.** Coordinated rename across 4 source files (`data_display*.cljs` → `edn_inspector*.cljs`), 5 test files, 13 consumer panels + tests, spec docs (`tools/xray/spec/{003,021,023}-*.md`), skills (`skills/re-frame2-xray/*`), the `dd` :require alias → `ei`, every event-id / sub-id / app-db slot / testid prefix.

Why the rename comes last: commits 1 + 2 read cleanly against the existing `data-display` names; commit 3 is a pure structural sweep that touches every reference.

**Negative gate.** `git grep -nE data-display|data_display|DataDisplay tools/xray spec test skill` returns 0 hits.

## Gates

- `npm run test:cljs` — 4580 tests, 0 failures
- `npm run test:browser` — 124 tests, 0 failures
- `clojure -M:test` in `tools/xray` — 859 JVM tests, 0 failures
- `npm run test:bundle-isolation` — PASS
- `npm run test:xray-feature-gate` — 13/13 scenarios
- `clj-kondo --lint tools/xray/src tools/xray/test` — 0 errors

Closes rf2-kbdk8, rf2-awqts, rf2-h4fce.
@