### PR TITLE
feat(xray): edn-inspector header+body card chrome via opt-in :header hiccup (rf2-okq7p)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1312,6 +1312,14 @@ reach for `[edn-inspector value opts]` directly.
   modal chrome, diff sub-renderers) leave it off; panels with
   multiple top-level inspector mounts (App-DB's TOP + per-`:rf/*`
   sections) opt in. Defaults `false`.
+- `:header` (rf2-okq7p) — when supplied (string or hiccup), the
+  widget renders the three-shade card chrome from §10.0.10
+  (outer `<section>` + `<header>` ribbon + body sleeve) modelled on
+  the Machine panel's `focused-event-section`. `nil` (default)
+  renders inline with no section wrapper. Consumers supply a label
+  string for simple cases or hiccup for composite headers (label +
+  code chip + per-inspector affordances). See §10.0.10 for the
+  three-shade ramp + composition rules.
 - `:site-id` (rf2-pvsxs) — when supplied, becomes the second
   component of the per-node expansion key INSTEAD of the auto-
   generated mount-id. Lets the same logical call site survive a
@@ -1841,6 +1849,106 @@ Public for tests + reference:
 
 The ns is required for side-effect (the `extend-type` forms) from
 `views.edn-inspector` itself — no call-site registration needed.
+
+#### §10.0.10 `:header` opt — three-shade card chrome (rf2-okq7p)
+
+Consumer panels routinely mount multiple top-level `edn-inspector`s
+side by side: App-DB has three (counter-app db, machine-app db, route
+params); Handler/Event has up to five per epoch (event vector, db-
+before, db-after, fx, coeffects). Without per-mount labelling the eye
+has to *read the value* to figure out which inspector is which. The
+Machine panel already solves the same problem via a card aesthetic —
+white-bordered `<section>` + darker-grey `<header>` ribbon labelling
+the section + lighter-grey body containing the content — and the
+operator likes that pattern. `:header` lifts the aesthetic into the
+widget so any consumer panel can opt in per mount.
+
+**Surface** — one new opt on the existing `[edn-inspector value opts]`:
+
+| `:header` value     | Behaviour                                                          |
+|---------------------|--------------------------------------------------------------------|
+| `nil` (default)     | No section wrapper — single-div render (back-compat).              |
+| string              | `<section>` + `<header>` ribbon containing the string.             |
+| hiccup vector       | `<section>` + `<header>` ribbon containing the hiccup verbatim.    |
+
+The widget treats the hiccup as opaque — no parsing, no required shape.
+Consumer panels supply whatever they want (label + code chip + per-
+inspector affordances):
+
+```clj
+[ei/edn-inspector counter-db
+ {:panel-id :rf.xray/app-db
+  :site-id  :app-db/counter
+  :header   [:span
+             [:strong "Counter app"]
+             " · "
+             [:code ":rf/default"]
+             [:button {:on-click reset-counter!} "reset"]]}]
+```
+
+**Three-shade structure** — measured live against the Machine panel's
+`focused-event-section` (pair-debug 2026-05-26) and codified through
+the existing token table — no new tokens introduced:
+
+```
+<section> :bg-2 (light: #ffffff)
+          1px solid :border-default
+          4px border-radius
+          margin-bottom 8px
+  <header> :bg-3 (light: #e8e8e8)
+           padding 10px 12px
+           border-bottom 1px solid :border-subtle
+    <!-- the :header value renders here -->
+  <div>   :bg-1 (light: #f5f5f5)
+          padding 12px
+    <!-- the actual edn-inspector tree renders here -->
+```
+
+The three-shade ramp (`:bg-2` outer / `:bg-3` header / `:bg-1` body)
+reads as a single card with a distinct label band rather than one
+continuous block. Theme-aware via the existing `tokens` map — both
+light and dark resolve at paint time without a re-render.
+
+**Composition with other opts** —
+
+- **`:popup-affordance?`** — the affordance icon button stays at the
+  section's top-right corner. The section establishes the positioning
+  context (`position: relative`).
+- **`:card?`** (rf2-63ie5) — `:header` provides its own surface chrome,
+  so `:card?` is usually redundant when `:header` is present.
+  Independent for back-compat; consumers normally pick one.
+- **Width measurement / `:ref` / mount-id testid** — when `:header`
+  fires, the measurement ref + container testid + `data-rf-mount-id`
+  + `data-rf-mode` all migrate to the section so existing DOM-level
+  consumers (tests, panel-gallery selectors) keep their selectors
+  working against `data-testid container-id` regardless of which
+  shape rendered.
+
+**Where to opt in** — per the bead's audit, panels with multiple top-
+level inspector mounts that benefit from labelling:
+
+- **App-DB** — counter-app db / machine-app db / routes (three labels).
+- **Handler/Event** — event vector / db-before / db-after / fx /
+  coeffects (per-slot labels).
+- **Issues** — ex-data inspector (when present alongside other
+  inspectors in the same panel).
+- **Routes** — per top-level slot.
+
+**Where NOT to opt in** — the inspector is already nested in a
+labelled container or the mount is inline / table-cell / popup-
+internal:
+
+- **Machines panel** — sub-panels already carry the header+body
+  pattern; nesting would be card-in-card.
+- **Views panel** — already wrapped in its own card chrome.
+- **Trace panel** — expanded payloads sit inside a trace row that
+  already carries chrome.
+- **Popup contents** — the popup overlay supplies modal chrome; the
+  inner `edn-inspector` recurses with `:popup-affordance? false`
+  (§10.0.7.2) and would equally suppress its own card.
+
+Consumer adoption is per-panel and case-by-case; this section
+documents the contract, not a blanket migration.
 
 ### §10.1 Capabilities (LOCKED per B.9 super-prompt)
 

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
@@ -107,6 +107,33 @@
                     panels with multiple top-level inspector mounts
                     (App-DB's TOP + per-`:rf/*` sections; Handler's
                     side-by-side event-detail mounts) opt in.
+  - `:header`        (optional, default nil) — rf2-okq7p; opt-in
+                    three-shade card chrome (outer `<section>` →
+                    `<header>` ribbon → body sleeve), modelled on the
+                    Machine panel's `focused-event-section`. `nil`
+                    renders inline as today. A string renders a
+                    plain-label ribbon. Hiccup renders whatever the
+                    consumer composes (label + code chip + per-
+                    inspector affordances). The widget treats the
+                    value as opaque hiccup — no parsing, no required
+                    shape.
+
+                    Aesthetic (light theme; dark mirrors via theme
+                    tokens): outer `<section>` paints `:bg-2`
+                    (#ffffff) with a `1px solid :border-default`
+                    border + `4px` radius; the `<header>` ribbon
+                    paints `:bg-3` (#e8e8e8) with `10px 12px`
+                    padding + a `1px solid :border-subtle` bottom
+                    rule; the body sleeve paints `:bg-1` (#f5f5f5)
+                    with `12px` padding. The three-shade ramp reads
+                    as a single card with a distinct label band
+                    rather than one continuous block.
+
+                    Composes with `:popup-affordance?` (the icon
+                    sits at the section's top-right corner) and
+                    with `:card?` (independent — `:header` provides
+                    its own surface chrome, so `:card?` is usually
+                    redundant when `:header` is present).
 
   Drop the `:render-id` arg from the old facade — mount-id is now
   auto-generated internally per D4=a (rf2-sndui).
@@ -2025,7 +2052,7 @@
       [value & rest-args]
       (let [opts          (first rest-args)
             {:keys [panel-id site-id default-expanded-depth max-inline-width
-                    max-depth before popup-affordance? card?]
+                    max-depth before popup-affordance? card? header]
              :or   {panel-id :rf.xray.edn-inspector/anon
                     ;; rf2-kbdk8 — default raised from 2 → 8. Under the
                     ;; width-aware heuristic this opt is a CEILING (never
@@ -2039,6 +2066,15 @@
                     popup-affordance? false
                     card? false}} opts
             diff?         (contains? opts :before)
+            ;; rf2-okq7p — `:header` opts the widget into the 3-shade
+            ;; card chrome (outer SECTION + grey-on-grey HEADER ribbon
+            ;; + body), modelled on the Machine panel's `focused-event-
+            ;; section`. `nil` (default) renders inline as before;
+            ;; string or hiccup wraps the render in the chrome with
+            ;; the supplied content as the header ribbon. Composable —
+            ;; the consumer panel decides whether each top-level
+            ;; inspector mount earns a label. See §10.0.10.
+            chromed?      (some? header)
             ;; rf2-pvsxs — `site-id` (when supplied) opt-out of the
             ;; per-call-site mount-id isolation. The expansion-key's
             ;; second slot reads `site-id` instead of the auto-mount-
@@ -2071,71 +2107,147 @@
             ;; own mount-id so re-clicking the affordance "raises" the
             ;; existing popup rather than spawning a duplicate
             ;; (matches `edn-inspector-popup/push-entry` semantics).
-            popup-mount-id (str "ddp-" mount-id)]
-        [:div {:data-testid     container-id
-               :data-rf-mount-id mount-id
-               :data-rf-site-id  (when site-id (pr-str site-id))
-               :data-rf-mode    (if diff? "diff" "browse")
-               :data-rf-popup-affordance? (when popup-affordance? "1")
-               :data-rf-card     (when card? "1")
-               :data-rf-available-width-px (when available-width-px
-                                             (str available-width-px))
-               ;; rf2-kbdk8 — `:ref` callback drives the measurement.
-               ;; Captured once in the form-2 closure; React calls the
-               ;; same fn on mount + unmount so the observer's lifecycle
-               ;; mirrors the widget's DOM lifecycle.
-               :ref             container-ref
-               :style (cond-> {:font-family mono-stack
-                               :font-size   "12px"
-                               :color       (:text-primary tokens)
-                               :line-height 1.4
-                               ;; Position context for the absolute-
-                               ;; positioned affordance button. Harmless
-                               ;; when the affordance is off — no
-                               ;; descendant uses absolute positioning
-                               ;; otherwise.
-                               :position    (when popup-affordance? "relative")}
-                        ;; rf2-63ie5 — inspector-card chrome on
-                        ;; top-level mounts. Theme-aware via tokens so
-                        ;; both light + dark resolve at paint time. The
-                        ;; opt-in (`:card? true`) keeps inline / nested
-                        ;; mounts unchrromed; panels with multiple top-
-                        ;; level inspector mounts (App-DB, Handler)
-                        ;; pass `:card? true` so the eye reads each
-                        ;; mount as a discrete card rather than one
-                        ;; continuous block.
-                        card? (assoc :background-color (:bg-1 tokens)
-                                     :border           (str "1px solid "
-                                                            (:border-default tokens))
-                                     :border-radius    "8px"
-                                     :padding          "8px 10px"
-                                     :margin-bottom    "8px"))}
-         (when popup-affordance?
-           (popup-affordance-button dispatch-fn popup-mount-id value opts))
-         (render-node {:value value
-                       :before (if diff? before ::missing)
-                       :diff? diff?
-                       :panel-id panel-id
-                       ;; rf2-pvsxs — `mount-id` slot in render-node's
-                       ;; key carries the EFFECTIVE id (site-id if
-                       ;; supplied; auto-mount-id otherwise). Callbacks
-                       ;; deep in the recursion thread the same value,
-                       ;; so toggle dispatches store + read overrides
-                       ;; under the persistence-friendly key.
-                       :mount-id effective-id
-                       :path []
-                       :depth 0
-                       :expansion-map expansion-map
-                       :dispatch-fn dispatch-fn
-                       :opts {:default-expanded-depth default-expanded-depth
-                              :max-inline-width max-inline-width
-                              :max-depth max-depth
-                              ;; rf2-kbdk8 — threaded so every recursive
-                              ;; render-node decides expansion against
-                              ;; the same available column width. Nil
-                              ;; until the ref measures, after which
-                              ;; ResizeObserver keeps it live.
-                              :available-width-px available-width-px}})]))))
+            popup-mount-id (str "ddp-" mount-id)
+            ;; rf2-okq7p — when `:header` is supplied we move the
+            ;; measurement + popup-positioning context out to the
+            ;; outer `<section>` so the body div stays a content
+            ;; sleeve. The mount-id testid + ref still anchor at the
+            ;; root of whichever shape renders (section in chromed
+            ;; mode; div otherwise).
+            body-content  (render-node
+                            {:value value
+                             :before (if diff? before ::missing)
+                             :diff? diff?
+                             :panel-id panel-id
+                             ;; rf2-pvsxs — `mount-id` slot in
+                             ;; render-node's key carries the
+                             ;; EFFECTIVE id (site-id if supplied;
+                             ;; auto-mount-id otherwise). Callbacks
+                             ;; deep in the recursion thread the same
+                             ;; value, so toggle dispatches store +
+                             ;; read overrides under the persistence-
+                             ;; friendly key.
+                             :mount-id effective-id
+                             :path []
+                             :depth 0
+                             :expansion-map expansion-map
+                             :dispatch-fn dispatch-fn
+                             :opts {:default-expanded-depth default-expanded-depth
+                                    :max-inline-width max-inline-width
+                                    :max-depth max-depth
+                                    ;; rf2-kbdk8 — threaded so every
+                                    ;; recursive render-node decides
+                                    ;; expansion against the same
+                                    ;; available column width. Nil
+                                    ;; until the ref measures, after
+                                    ;; which ResizeObserver keeps it
+                                    ;; live.
+                                    :available-width-px available-width-px}})]
+        (if chromed?
+          ;; ── rf2-okq7p — three-shade card chrome (section + header
+          ;; ribbon + body). Modelled on the Machine panel's
+          ;; `focused-event-section`: outer `<section>` paints the
+          ;; surface band (`:bg-2`, light: #ffffff), the `<header>`
+          ;; ribbon sits one shade darker (`:bg-3`, light: #e8e8e8),
+          ;; and the body sleeve sits one shade lighter (`:bg-1`,
+          ;; light: #f5f5f5). The three-shade ramp reads as a card
+          ;; with a distinct label band rather than one continuous
+          ;; block — consumer panels mounting multiple inspectors
+          ;; side-by-side (App-DB: counter db + machine db + routes;
+          ;; Handler: event + before + after + fx + coeffects) can
+          ;; label each mount without visual blending.
+          ;;
+          ;; The mount-id testid + ref + measurement plumbing migrate
+          ;; out to the section so DOM-level consumers (tests, panel-
+          ;; gallery selectors) keep their existing selectors working
+          ;; against `data-testid container-id` regardless of which
+          ;; shape rendered.
+          [:section {:data-testid     container-id
+                     :data-rf-mount-id mount-id
+                     :data-rf-site-id  (when site-id (pr-str site-id))
+                     :data-rf-mode    (if diff? "diff" "browse")
+                     :data-rf-popup-affordance? (when popup-affordance? "1")
+                     :data-rf-card     (when card? "1")
+                     :data-rf-header   "1"
+                     :data-rf-available-width-px (when available-width-px
+                                                   (str available-width-px))
+                     :ref             container-ref
+                     :style {:font-family    mono-stack
+                             :font-size      "12px"
+                             :color          (:text-primary tokens)
+                             :line-height    1.4
+                             :background-color (:bg-2 tokens)
+                             :border           (str "1px solid "
+                                                    (:border-default tokens))
+                             :border-radius    "4px"
+                             :overflow         "hidden"
+                             :margin-bottom    "8px"
+                             ;; Positioning context for the absolute-
+                             ;; positioned affordance button — moved
+                             ;; here so the affordance still sits at
+                             ;; the section's top-right corner.
+                             :position    (when popup-affordance? "relative")}}
+           (when popup-affordance?
+             (popup-affordance-button dispatch-fn popup-mount-id value opts))
+           [:header {:data-testid (str container-id "-header")
+                     :data-rf-header-role "ribbon"
+                     :style {:padding       "10px 12px"
+                             :background    (:bg-3 tokens)
+                             :border-bottom (str "1px solid "
+                                                 (:border-subtle tokens))
+                             :font-family   mono-stack
+                             :font-size     "12px"
+                             :color         (:text-primary tokens)
+                             :line-height   1.4}}
+            header]
+           [:div {:data-testid (str container-id "-body")
+                  :data-rf-body-role "card-body"
+                  :style {:padding       "12px"
+                          :background    (:bg-1 tokens)}}
+            body-content]]
+          ;; ── default (no `:header`): flat single-div render, with
+          ;; optional rf2-63ie5 `:card?` chrome on the outer container.
+          [:div {:data-testid     container-id
+                 :data-rf-mount-id mount-id
+                 :data-rf-site-id  (when site-id (pr-str site-id))
+                 :data-rf-mode    (if diff? "diff" "browse")
+                 :data-rf-popup-affordance? (when popup-affordance? "1")
+                 :data-rf-card     (when card? "1")
+                 :data-rf-available-width-px (when available-width-px
+                                               (str available-width-px))
+                 ;; rf2-kbdk8 — `:ref` callback drives the measurement.
+                 ;; Captured once in the form-2 closure; React calls
+                 ;; the same fn on mount + unmount so the observer's
+                 ;; lifecycle mirrors the widget's DOM lifecycle.
+                 :ref             container-ref
+                 :style (cond-> {:font-family mono-stack
+                                 :font-size   "12px"
+                                 :color       (:text-primary tokens)
+                                 :line-height 1.4
+                                 ;; Position context for the absolute-
+                                 ;; positioned affordance button.
+                                 ;; Harmless when the affordance is
+                                 ;; off — no descendant uses absolute
+                                 ;; positioning otherwise.
+                                 :position    (when popup-affordance? "relative")}
+                          ;; rf2-63ie5 — inspector-card chrome on
+                          ;; top-level mounts. Theme-aware via tokens
+                          ;; so both light + dark resolve at paint
+                          ;; time. The opt-in (`:card? true`) keeps
+                          ;; inline / nested mounts unchromed; panels
+                          ;; with multiple top-level inspector mounts
+                          ;; (App-DB, Handler) pass `:card? true` so
+                          ;; the eye reads each mount as a discrete
+                          ;; card rather than one continuous block.
+                          card? (assoc :background-color (:bg-1 tokens)
+                                       :border           (str "1px solid "
+                                                              (:border-default tokens))
+                                       :border-radius    "8px"
+                                       :padding          "8px 10px"
+                                       :margin-bottom    "8px"))}
+           (when popup-affordance?
+             (popup-affordance-button dispatch-fn popup-mount-id value opts))
+           body-content])))))
 
 (defn edn-inspector-diff
   "Diff convenience — `[edn-inspector-diff before after]` or

--- a/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs
@@ -23,7 +23,8 @@
 
   Pure-data unit tests; no DOM mount. Default for new Causa/Story
   tests per `feedback-causa-story-cljs-unit-tests-not-playwright`."
-  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+  (:require [clojure.string :as str]
+            [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
@@ -1567,6 +1568,207 @@
           "background reads through `:bg-1` (CSS-var or hex per theme)")
       (is (= (str "1px solid " (:border-default tokens)) (:border style))
           "border reads through `:border-default` (CSS-var or hex per theme)"))))
+
+;; ---- rf2-okq7p — :header opt + three-shade card chrome -------------------
+;;
+;; `:header` opts the widget into the Machine-panel-aesthetic three-shade
+;; card chrome: outer `<section>` (background `:bg-2`, 1px border, 4px
+;; radius) + `<header>` ribbon (`:bg-3`, padding 10px 12px) + body sleeve
+;; (`:bg-1`, padding 12px). Consumer panels mounting multiple inspectors
+;; side-by-side (App-DB 3 mounts; Handler event/before/after/fx/coeffects)
+;; pass a per-mount header so the eye reads each as a discrete labelled
+;; card rather than blending into one continuous block.
+;;
+;; Default (`:header` nil) — no `<section>` wrapper, single-div render
+;; (unchanged from rf2-63ie5's `:card?` semantics).
+
+(defn- find-tag
+  "Return the first hiccup vector in `tree` whose tag is `tag`."
+  [tree tag]
+  (->> (walk-hiccup tree)
+       (filter (fn [n] (and (vector? n) (= tag (first n)))))
+       first))
+
+(deftest header-opt-omitted-renders-no-section-wrapper
+  (testing "rf2-okq7p — without `:header` the widget emits a single
+            `<div>` root, with no `<section>` wrapper and no
+            `<header>` ribbon (back-compat with pre-rf2-okq7p mounts)"
+    (let [h (invoke-edn-inspector {:a 1} {:panel-id :rf.xray/app-db})]
+      (is (= :div (first h)) "root tag is `<div>`, not `<section>`")
+      (is (nil? (find-tag h :section)) "no `<section>` anywhere in tree")
+      (is (nil? (find-tag h :header)) "no `<header>` ribbon")
+      (is (nil? (:data-rf-header (second h)))
+          "outer div omits the `data-rf-header` flag"))))
+
+(deftest header-opt-explicit-nil-renders-no-section-wrapper
+  (testing "rf2-okq7p — `:header nil` is equivalent to omitting the opt
+            (no section wrapper)"
+    (let [h (invoke-edn-inspector {:a 1} {:panel-id :rf.xray/app-db
+                                          :header nil})]
+      (is (= :div (first h)) "root tag is `<div>`")
+      (is (nil? (find-tag h :section)) "no `<section>` wrapper"))))
+
+(deftest header-opt-string-renders-section-and-ribbon
+  (testing "rf2-okq7p — `:header \"label\"` wraps the render in a
+            `<section>` with a `<header>` ribbon containing the supplied
+            string"
+    (let [h (invoke-edn-inspector {:a 1} {:panel-id :rf.xray/app-db
+                                          :header "Counter app · :rf/default"})]
+      (is (= :section (first h)) "root tag is `<section>`")
+      (is (= "1" (:data-rf-header (second h)))
+          "section publishes `data-rf-header=1` for testbed assertion")
+      (let [hdr (find-tag h :header)]
+        (is (some? hdr) "section contains a `<header>` ribbon")
+        (is (= "ribbon" (:data-rf-header-role (second hdr)))
+            "header ribbon publishes its role for selectors")
+        (is (some #{"Counter app · :rf/default"} (rest hdr))
+            "header ribbon contains the supplied string verbatim")))))
+
+(deftest header-opt-hiccup-passes-through-opaquely
+  (testing "rf2-okq7p — `:header [hiccup]` renders the supplied vector as
+            the ribbon content unchanged (the widget treats hiccup as
+            opaque — no parsing, no required shape)"
+    (let [header-hiccup [:span
+                         [:strong "Counter app"]
+                         " · "
+                         [:code ":rf/default"]]
+          h (invoke-edn-inspector {:a 1} {:panel-id :rf.xray/app-db
+                                          :header header-hiccup})
+          hdr (find-tag h :header)]
+      (is (= :section (first h)) "root tag is `<section>`")
+      (is (some? hdr) "section contains a `<header>` ribbon")
+      (is (some #(= header-hiccup %) (rest hdr))
+          "header ribbon embeds the hiccup vector verbatim"))))
+
+(deftest header-opt-composite-hiccup-with-children
+  (testing "rf2-okq7p — composite hiccup with label + code + button
+            children flows through the ribbon unchanged. Mike's bead
+            spec called out this composability — header carries label +
+            chips + per-inspector affordances"
+    (let [clicked (atom 0)
+          header-hiccup [:span
+                         [:strong "machine-app"]
+                         " · "
+                         [:code ":step-deck"]
+                         [:button {:on-click (fn [_] (swap! clicked inc))}
+                          "reset"]]
+          h (invoke-edn-inspector {:counter 1}
+                                  {:panel-id :rf.xray/app-db
+                                   :header header-hiccup})
+          hdr (find-tag h :header)
+          ;; Hunt the button down inside the ribbon.
+          btn (->> (walk-hiccup hdr)
+                   (filter (fn [n] (and (vector? n) (= :button (first n)))))
+                   first)]
+      (is (some? btn) "composite header retains the embedded `<button>`")
+      ;; Pull the on-click handler off the button and exercise it —
+      ;; pass-through is genuine, not a structural diff in disguise.
+      (when btn
+        ((:on-click (second btn)) {})
+        (is (= 1 @clicked)
+            "the supplied on-click handler fires when the ribbon button
+             is clicked")))))
+
+(deftest header-opt-three-shade-chrome-via-tokens
+  (testing "rf2-okq7p — the section + header + body each read a distinct
+            shade from the live `tokens` map (`:bg-2` outer, `:bg-3`
+            header, `:bg-1` body). Theme-aware via CSS variables — both
+            light + dark resolve at paint time."
+    (let [h (invoke-edn-inspector {:a 1} {:panel-id :rf.xray/app-db
+                                          :header "Counter"})
+          section-style (-> h second :style)
+          hdr           (find-tag h :header)
+          hdr-style     (-> hdr second :style)
+          ;; Body div is the LAST top-level child of the section (the
+          ;; affordance + header come before it).
+          body          (->> (rest h)
+                             (filter (fn [n]
+                                       (and (vector? n)
+                                            (= :div (first n))
+                                            (= "card-body"
+                                               (:data-rf-body-role (second n))))))
+                             first)
+          body-style    (-> body second :style)]
+      (is (= (:bg-2 tokens) (:background-color section-style))
+          "outer section reads `:bg-2` (light: #ffffff / dark: bg-2 token)")
+      (is (= (str "1px solid " (:border-default tokens))
+             (:border section-style))
+          "outer border reads `:border-default`")
+      (is (= "4px" (:border-radius section-style))
+          "outer corner radius 4px (matches Machine panel)")
+      (is (= (:bg-3 tokens) (:background hdr-style))
+          "header ribbon reads `:bg-3` (light: #e8e8e8)")
+      (is (= "10px 12px" (:padding hdr-style))
+          "header ribbon padding 10px 12px (matches Machine panel)")
+      (is (= (str "1px solid " (:border-subtle tokens))
+             (:border-bottom hdr-style))
+          "header ribbon carries a `:border-subtle` bottom rule")
+      (is (= (:bg-1 tokens) (:background body-style))
+          "body sleeve reads `:bg-1` (light: #f5f5f5)")
+      (is (= "12px" (:padding body-style))
+          "body sleeve padding 12px"))))
+
+(deftest header-opt-preserves-mount-id-and-testid-on-section
+  (testing "rf2-okq7p — when the widget chromes itself, the mount-id +
+            container testid + ref + data-rf-mode flag move to the
+            section so existing test selectors keep working. The body's
+            edn-inspector tree still renders inside the body div."
+    (let [h (invoke-edn-inspector {:a 1 :b 2}
+                                  {:panel-id :rf.xray/app-db
+                                   :header "Counter"})
+          attrs (second h)]
+      (is (= :section (first h)) "root tag is `<section>`")
+      (is (some? (:data-testid attrs))
+          "section carries the container `data-testid` (same id contract)")
+      (is (some? (:data-rf-mount-id attrs))
+          "section carries the auto-generated `mount-id`")
+      (is (= "browse" (:data-rf-mode attrs))
+          "section carries the mode flag")
+      (is (fn? (:ref attrs))
+          "section carries the measurement ref callback"))))
+
+(deftest header-opt-renders-body-content-inside-body-sleeve
+  (testing "rf2-okq7p — the actual edn-inspector tree (collection-kind
+            scalars + brackets + body) lives inside the body sleeve, not
+            inside the header ribbon"
+    (let [h (invoke-edn-inspector {:counter 7}
+                                  {:panel-id :rf.xray/app-db
+                                   :header "Counter"})
+          body (->> (walk-hiccup h)
+                    (filter (fn [n]
+                              (and (vector? n)
+                                   (map? (second n))
+                                   (= "card-body"
+                                      (:data-rf-body-role (second n))))))
+                    first)]
+      (is (some? body) "section contains a body sleeve")
+      ;; The body should contain a representation of the `:counter` key
+      ;; somewhere in its subtree (collected as text leaves).
+      (is (str/includes? (collect-text body) ":counter")
+          "body sleeve renders the `:counter` key from the value")
+      (is (str/includes? (collect-text body) "7")
+          "body sleeve renders the numeric `7`"))))
+
+(deftest header-opt-keeps-popup-affordance-on-section
+  (testing "rf2-okq7p — when `:popup-affordance?` is on alongside
+            `:header`, the icon button still renders inside the section
+            (positioned at the section's top-right corner via the
+            outer `position: relative`)"
+    (let [h (invoke-edn-inspector {:a 1}
+                                  {:panel-id :rf.xray/app-db
+                                   :header "Counter"
+                                   :popup-affordance? true})
+          attrs (second h)
+          ;; Affordance button lives as a direct child of the section.
+          button (->> (rest h)
+                      (filter (fn [n] (and (vector? n) (= :button (first n)))))
+                      first)]
+      (is (= "relative" (:position (:style attrs)))
+          "section establishes positioning context for the absolute button")
+      (is (= "1" (:data-rf-popup-affordance? attrs))
+          "section publishes the affordance flag")
+      (is (some? button)
+          "section contains the popup affordance button as a direct child"))))
 
 ;; =========================================================================
 ;; rf2-kbdk8 — width-aware expansion heuristic


### PR DESCRIPTION
## Summary

Adds an opt-in `:header` arg to `[ei/edn-inspector value opts]` that wraps
the render in the Machine-panel three-shade card chrome: outer `<section>`
(`:bg-2`, 1px `:border-default`, 4px radius) + `<header>` ribbon (`:bg-3`,
padding 10px 12px, `:border-subtle` bottom rule) + body sleeve (`:bg-1`,
padding 12px).

Default (no `:header`): unchanged — single-div render with optional `:card?`
chrome from rf2-63ie5. Strings render as a plain-label ribbon; hiccup
renders verbatim — the widget treats the value as opaque so consumers
compose whatever they want (label + code chip + per-inspector affordances).

```clj
[ei/edn-inspector counter-db
 {:panel-id :rf.xray/app-db
  :site-id  :app-db/counter
  :header   [:span
             [:strong "Counter app"]
             " · "
             [:code ":rf/default"]
             [:button {:on-click reset-counter!} "reset"]]}]
```

## Token decisions

Reuses existing `:bg-*` ramp — no new tokens introduced. The three measured
shades from the Machine panel's `focused-event-section` already map cleanly:

| Layer  | Token            | Light hex | Dark hex |
|--------|------------------|-----------|----------|
| Outer  | `:bg-2`          | `#ffffff` | `#242424` |
| Header | `:bg-3`          | `#e8e8e8` | `#2a2a2a` |
| Body   | `:bg-1`          | `#f5f5f5` | `#1c1c1c` |

Border tokens reused unchanged: `:border-default` for the outer 1px stroke,
`:border-subtle` for the header-body rule.

## Consumer adoption

Deferred to per-panel follow-on beads per Mike's dispatch note — this bead
lands the contract; consumer panels (App-DB, Handler/Event, Issues, Routes)
opt in case-by-case. No collision with rf2-3d987 (Machine panel layout
fixes) — that worker touches `panels/machine_canvas.cljs`; this PR is
confined to `views/edn_inspector.cljs` + tests + spec.

## Spec

Spec/021 §10.0.10 documents the contract: default behaviour, string vs
hiccup forms, three-shade structure, composition with `:popup-affordance?` /
`:card?` / mount-id measurement plumbing, where to opt in, where not.

## Tests

Nine new tests in `edn_inspector_cljs_test.cljs` covering:

- `:header` omitted / nil → no `<section>` wrapper (back-compat)
- `:header "string"` → section + header + ribbon with the string
- `:header [hiccup]` → opaque pass-through
- composite hiccup with embedded button (`:on-click` fires end-to-end)
- three-shade chrome reads through tokens (`:bg-1` / `:bg-2` / `:bg-3`,
  matching Machine panel measurements)
- mount-id / testid / mode flag / ref migrate to the section so existing
  DOM-level selectors keep working
- body sleeve renders the edn tree (not the header ribbon)
- popup affordance still positions correctly on the section (`position:
  relative` migrates with it)

## Gates

- `npm run test:cljs` — 4589 tests / 14798 assertions / 0 failures
- `tools/xray clojure -M:test` — 859 tests / 3199 assertions / 0 failures
- `npm run test:browser` — 124 tests / 346 assertions / 0 failures
- `npm run test:xray-feature-gate` — 13/13 scenarios
- `clj-kondo` on edited files — 0 errors / 0 warnings
- `mkdocs build --strict` — clean

## Closes

rf2-okq7p