### PR TITLE
fix(xray): Machine panel 8 layout fixes — spacing/side-by-side/collapsible/hierarchy (rf2-3d987)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_canvas.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_canvas.cljs
@@ -82,6 +82,14 @@
   [db machine-id]
   (get-in db [slot-root :view-mode-by-id machine-id] :canvas))
 
+(defn- chart-collapsed-of
+  "Read the persisted chart-collapsed flag for `machine-id`. Defaults
+  to `false` — rf2-3d987 issue #4 fix: chart is expanded by default so
+  first-time operators see the topology; persisting per-machine lets
+  the operator hide chart real-estate to give the snapshot pair room."
+  [db machine-id]
+  (boolean (get-in db [slot-root :chart-collapsed-by-id machine-id] false)))
+
 ;; ---- localStorage round-trip --------------------------------------------
 
 (def storage-key
@@ -89,6 +97,14 @@
   Mirrors `static.machines.persistence/sub-mode-key`'s posture: one
   bare EDN slot keyed by machine-id keyword."
   "xray.machine-canvas.view-mode-by-id")
+
+(def chart-collapsed-storage-key
+  "Canonical localStorage key for the per-machine chart-collapsed flag
+  map (rf2-3d987 issue #4). Same posture as `storage-key`: one EDN
+  map keyed by machine-id. Persisting per-machine lets one machine's
+  Chart be collapsed (snapshot pair foregrounded) while another's
+  Chart stays expanded."
+  "xray.machine-canvas.chart-collapsed-by-id")
 
 (defn- storage-available? []
   (and (exists? js/window)
@@ -136,6 +152,31 @@
                 parsed)))
       (catch :default _ {}))))
 
+(defn save-chart-collapsed-by-id!
+  "Persist the chart-collapsed-by-id map to localStorage (rf2-3d987
+  issue #4). Empty/nil clears the slot."
+  [m]
+  (if (or (nil? m) (and (map? m) (empty? m)))
+    (remove-raw! chart-collapsed-storage-key)
+    (write-raw! chart-collapsed-storage-key (pr-str m)))
+  nil)
+
+(defn load-chart-collapsed-by-id
+  "Read + normalise the persisted chart-collapsed map. Returns `{}`
+  when the slot is absent / unparseable. Values normalise to booleans
+  (truthy → `true`, anything else → `false`)."
+  []
+  (when-let [raw (read-raw chart-collapsed-storage-key)]
+    (try
+      (let [parsed (reader/read-string raw)]
+        (when (map? parsed)
+          (into {}
+                (keep (fn [[k v]]
+                        (when (keyword? k)
+                          [k (boolean v)])))
+                parsed)))
+      (catch :default _ {}))))
+
 ;; ---- subs ---------------------------------------------------------------
 
 (defn- install-subs! []
@@ -145,7 +186,15 @@
 
   (rf/reg-sub :rf.xray.machine-canvas/view-mode-by-id
     (fn [db _]
-      (get-in db [slot-root :view-mode-by-id] {}))))
+      (get-in db [slot-root :view-mode-by-id] {})))
+
+  (rf/reg-sub :rf.xray.machine-canvas/chart-collapsed-for
+    (fn [db [_ machine-id]]
+      (chart-collapsed-of db machine-id)))
+
+  (rf/reg-sub :rf.xray.machine-canvas/chart-collapsed-by-id
+    (fn [db _]
+      (get-in db [slot-root :chart-collapsed-by-id] {}))))
 
 ;; ---- events -------------------------------------------------------------
 
@@ -160,14 +209,39 @@
 
   (rf/reg-event-db :rf.xray.machine-canvas/hydrate-view-modes
     (fn [db [_ by-id]]
-      (assoc-in db [slot-root :view-mode-by-id] (or by-id {})))))
+      (assoc-in db [slot-root :view-mode-by-id] (or by-id {}))))
+
+  ;; rf2-3d987 issue #4 — toggle the per-machine chart-collapsed flag.
+  ;; `mode` is :collapsed / :expanded / :toggle. Persists the post-mutation
+  ;; map to localStorage so the operator's choice survives reloads.
+  (rf/reg-event-fx :rf.xray.machine-canvas/set-chart-collapsed
+    (fn [{:keys [db]} [_ {:keys [machine-id mode]}]]
+      (let [current (chart-collapsed-of db machine-id)
+            next    (case mode
+                      :collapsed true
+                      :expanded  false
+                      :toggle    (not current)
+                      (boolean mode))
+            db'     (assoc-in db [slot-root :chart-collapsed-by-id machine-id]
+                              next)
+            by-id   (get-in db' [slot-root :chart-collapsed-by-id])]
+        {:db db'
+         :rf.xray.machine-canvas/persist-chart-collapsed by-id})))
+
+  (rf/reg-event-db :rf.xray.machine-canvas/hydrate-chart-collapsed
+    (fn [db [_ by-id]]
+      (assoc-in db [slot-root :chart-collapsed-by-id] (or by-id {})))))
 
 ;; ---- fx -----------------------------------------------------------------
 
 (defn- install-fx! []
   (rf/reg-fx :rf.xray.machine-canvas/persist-view-mode
     (fn [_ctx by-id]
-      (save-view-mode-by-id! by-id))))
+      (save-view-mode-by-id! by-id)))
+
+  (rf/reg-fx :rf.xray.machine-canvas/persist-chart-collapsed
+    (fn [_ctx by-id]
+      (save-chart-collapsed-by-id! by-id))))
 
 ;; ---- hydration ----------------------------------------------------------
 
@@ -175,6 +249,10 @@
   (let [by-id (load-view-mode-by-id)]
     (when (seq by-id)
       (rf/dispatch [:rf.xray.machine-canvas/hydrate-view-modes by-id]
+                   {:frame :rf/xray})))
+  (let [by-id (load-chart-collapsed-by-id)]
+    (when (seq by-id)
+      (rf/dispatch [:rf.xray.machine-canvas/hydrate-chart-collapsed by-id]
                    {:frame :rf/xray}))))
 
 ;; ---- view-mode toggle ---------------------------------------------------

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
@@ -60,7 +60,36 @@
             [day8.re-frame2-xray.views.edn-inspector :as ei]
             [day8.re-frame2-xray.theme.tokens
              :as t
-             :refer [tokens mono-stack sans-stack display-stack]]))
+             :refer [tokens mono-stack sans-stack display-stack spacing]]))
+
+;; ---- shared layout constants (rf2-3d987) ------------------------------
+;;
+;; The Machine panel's 8 layout fixes (rf2-3d987) split header styling
+;; into two tiers — OUTER (section header at the top of focused-event-
+;; section; ribbon background, larger font) and NESTED (sub-section
+;; headers inside the same section; lighter chrome, smaller font,
+;; bottom-border separator instead of full-ribbon background). Issue #7
+;; fix: nested headers MUST be visually distinguishable from outer
+;; headers so the operator's eye reads hierarchy at a glance.
+;;
+;; Both tiers consume tokens (`tokens` map · CSS variables) so the
+;; light/dark theme toggle continues to flip palette in lockstep.
+
+(def ^:private nested-header-base-style
+  "Style map for any sub-section header NESTED inside the outer
+  focused-event-section. Per rf2-3d987 issue #7 these headers use a
+  smaller font, no ribbon background, and a bottom-border separator —
+  so the operator can tell a nested header from the outer section
+  header at a glance."
+  {:padding "6px 12px"
+   :background "transparent"
+   :border-bottom (str "1px solid " (:border-subtle tokens))
+   :font-family sans-stack
+   :font-size "11px"
+   :color (:text-secondary tokens)
+   :display "flex"
+   :align-items "center"
+   :gap "8px"})
 
 ;; ---- safe-name helper ---------------------------------------------------
 
@@ -211,31 +240,45 @@
   `h/pick-focused-transition` — see Dynamic-mode rule, rf2-8og3k) and
   renders the Target Machine Instance / TRANSITION / GUARDS RUN /
   ACTIONS RUN block in the normative order. Pure hiccup — fn-source is
-  resolved via `rf/handler-meta` which is a pure registrar lookup."
+  resolved via `rf/handler-meta` which is a pure registrar lookup.
+
+  rf2-3d987 issue #6 (option b): lens is metadata about the focused
+  transition — chrome dims relative to the interactive chart so the
+  operator's eye reads `chart = primary, lens = secondary`. Same body
+  background as the rest of the section interior (`bg-2`); padding-only
+  separation; section labels carry weight differential per issue #5."
   [{:keys [machine-id from-state to-state guards actions]}]
   [:div {:data-testid "rf-xray-machine-focused-transition-lens"
          :data-machine-id (str machine-id)
          :data-guard-count (str (count guards))
          :data-action-count (str (count actions))
-         :style {:padding "12px 14px"
-                 :background (:bg-1 tokens)
-                 :border-bottom (str "1px solid " (:border-subtle tokens))
+         ;; Issue #6 option (b) — secondary-metadata treatment. No
+         ;; coloured body (matches the section's `bg-2`); slightly
+         ;; smaller mono font; lighter default text colour. The lens
+         ;; reads as supplementary rather than co-equal with the chart.
+         :style {:padding "10px 14px"
+                 :background "transparent"
                  :font-family mono-stack
-                 :font-size "12px"
-                 :color (:text-primary tokens)
+                 :font-size "11px"
+                 :color (:text-secondary tokens)
                  :line-height 1.55}}
    [:div {:data-testid "rf-xray-machine-lens-target-instance"
           :style {:margin-bottom "6px"}}
-    [:span {:style {:color (:text-tertiary tokens)}}
-     "Target Machine Instance: "]
+    [:span {:style {:color (:text-tertiary tokens)
+                    :font-weight 600}}
+     "Target Machine Instance"]
+    [:span {:style {:color (:text-tertiary tokens)}} " · "]
     [:span {:style {:color (:magenta tokens)}}
      (h/format-machine-id machine-id)]]
    [:div {:data-testid "rf-xray-machine-lens-transition"
           :style {:margin "4px 0"}}
-    [:div {:style {:color (:text-tertiary tokens)
-                   :text-transform "uppercase"
-                   :font-size "10px"
-                   :letter-spacing "0.5px"}}
+    ;; Issue #5 — `<strong>` weight differential on the section
+    ;; label so the eye picks it out from the path that follows.
+    [:strong {:style {:color (:text-tertiary tokens)
+                      :text-transform "uppercase"
+                      :font-size "10px"
+                      :letter-spacing "0.5px"
+                      :font-weight 700}}
      "Transition"]
     [:div {:style {:padding-left "16px"}}
      [:span {:style {:color (:text-secondary tokens)}}
@@ -246,10 +289,11 @@
    (when (seq guards)
      [:div {:data-testid "rf-xray-machine-lens-guards-run"
             :style {:margin "4px 0"}}
-      [:div {:style {:color (:text-tertiary tokens)
-                     :text-transform "uppercase"
-                     :font-size "10px"
-                     :letter-spacing "0.5px"}}
+      [:strong {:style {:color (:text-tertiary tokens)
+                       :text-transform "uppercase"
+                       :font-size "10px"
+                       :letter-spacing "0.5px"
+                       :font-weight 700}}
        "Guards Run"]
       (into [:div]
             (for [g guards]
@@ -258,10 +302,11 @@
    (when (seq actions)
      [:div {:data-testid "rf-xray-machine-lens-actions-run"
             :style {:margin "4px 0"}}
-      [:div {:style {:color (:text-tertiary tokens)
-                     :text-transform "uppercase"
-                     :font-size "10px"
-                     :letter-spacing "0.5px"}}
+      [:strong {:style {:color (:text-tertiary tokens)
+                       :text-transform "uppercase"
+                       :font-size "10px"
+                       :letter-spacing "0.5px"
+                       :font-weight 700}}
        "Actions Run"]
       (into [:div]
             (for [a actions]
@@ -322,6 +367,12 @@
   4). Tagged with a section heading + the per-mount testid so panel-
   level tests can assert presence per (machine-id, phase) pair.
 
+  rf2-3d987 issue #3: each column carries its own internal header
+  (`Before` / `After`) so the side-by-side layout (CSS grid in the
+  caller) reads as two diff-able columns. The grouping header in
+  `snapshot-drill-in` drops the `before / after` suffix since it's now
+  visually obvious from the two columns.
+
   Returns `nil` when the snapshot is absent — the empty-state is
   handled by the caller (a top-level placeholder is more legible than
   a per-block nil chip)."
@@ -332,14 +383,22 @@
                                 "-" (name phase))
            :data-machine-id (str machine-id)
            :data-phase      (name phase)
+           ;; Issue #2 (option b): match the outer section's `bg-2`
+           ;; rather than the brighter `bg-1` so the snapshot pair
+           ;; reads as continuation of the body, not as a second card
+           ;; layer. The outer bordered section provides the card chrome.
            :style {:padding "8px 12px"
-                   :border-bottom (str "1px solid " (:border-subtle tokens))
-                   :background (:bg-1 tokens)}}
+                   :background (:bg-2 tokens)
+                   :min-width 0}}
+     ;; Issue #3 — per-column internal header (`Before` / `After`).
+     ;; Carries the same upper-case caption styling that earlier nested
+     ;; in the outer ribbon but now serves as the column label.
      [:div {:style {:color (:text-tertiary tokens)
                     :text-transform "uppercase"
                     :font-size "10px"
                     :letter-spacing "0.5px"
                     :font-family sans-stack
+                    :font-weight 700
                     :margin-bottom "4px"}}
       label]
      [ei/edn-inspector snapshot
@@ -366,6 +425,17 @@
   (`:before` / `:after`) so the two sibling mounts don't share
   expansion state on the same machine.
 
+  rf2-3d987 issue #2 (option b): no second card layer — body uses the
+  outer section's `bg-2` so the snapshot pair reads as a continuation
+  of the body. Issue #3: Before / After render side-by-side in a CSS
+  Grid (`repeat(auto-fit, minmax(360px, 1fr))`) when the section is
+  ≥ ~720px wide; falls back to stacked when narrower. Each column
+  carries its own header (`Before` / `After`); the grouping header
+  drops the `before / after` suffix. Issue #5: weight differential on
+  the section label (`<strong>Snapshot</strong>`). Issue #7: nested
+  header uses the lighter-chrome style (no ribbon background, smaller
+  font, bottom-border separator).
+
   Renders nothing when both snapshots are nil (legacy trace fixtures
   pre-dating the commit-or-finalize snapshot tagging — see
   `transition-record-from-trace` docstring)."
@@ -376,41 +446,137 @@
       :data-machine-id (str machine-id)
       :data-has-before (str (some? before))
       :data-has-after  (str (some? after))
-      :style {:border-bottom (str "1px solid " (:border-subtle tokens))
-              :background (:bg-2 tokens)}}
-     [:header {:style {:padding "8px 12px"
-                       :background (:bg-3 tokens)
-                       :border-bottom (str "1px solid " (:border-subtle tokens))
-                       :font-family sans-stack
-                       :font-size "11px"
-                       :color (:text-secondary tokens)}}
-      [:span {:style {:color (:text-tertiary tokens)
-                      :text-transform "uppercase"
-                      :font-size "10px"
-                      :letter-spacing "0.5px"
-                      :margin-right "8px"}}
+      :style {:background (:bg-2 tokens)}}
+     ;; Issue #7 — nested-header treatment: borderless ribbon, smaller
+     ;; font, bottom-border separator. Issue #5 — `<strong>` weight
+     ;; differential lets the eye pick out `Snapshot` from the
+     ;; `transition` qualifier.
+     [:header {:data-testid "rf-xray-machine-snapshot-drill-in-header"
+               :style nested-header-base-style}
+      [:strong {:style {:color (:text-tertiary tokens)
+                        :text-transform "uppercase"
+                        :font-size "10px"
+                        :letter-spacing "0.5px"
+                        :font-weight 700}}
        "Snapshot"]
+      [:span {:style {:color (:text-tertiary tokens)}} "·"]
       [:span {:style {:color (:text-secondary tokens)}}
-       "transition · before / after"]]
-     (snapshot-block {:machine-id machine-id
-                      :phase :before
-                      :label "Before"
-                      :snapshot before})
-     (snapshot-block {:machine-id machine-id
-                      :phase :after
-                      :label "After"
-                      :snapshot after})]))
+       "transition"]]
+     ;; Issue #3 — Before/After side-by-side via CSS Grid auto-fit.
+     ;; At viewport ≥ ~720px wide (two 360px minmax tracks) the columns
+     ;; render side-by-side; narrower fits collapse to single-column
+     ;; stack automatically. `min-width 0` on the children prevents
+     ;; inspector content from forcing the column wider than its track.
+     [:div {:data-testid "rf-xray-machine-snapshot-drill-in-grid"
+            :style {:display "grid"
+                    :grid-template-columns
+                    "repeat(auto-fit, minmax(360px, 1fr))"
+                    :gap (:gap-2 spacing)
+                    :padding (:gap-2 spacing)}}
+      (snapshot-block {:machine-id machine-id
+                       :phase :before
+                       :label "Before"
+                       :snapshot before})
+      (snapshot-block {:machine-id machine-id
+                       :phase :after
+                       :label "After"
+                       :snapshot after})]]))
 
 ;; ---- per-machine focused-event section ---------------------------------
+
+(defn- chart-collapse-toggle
+  "Inline ▾ / ▸ button that toggles the chart-collapsed state for the
+  per-machine focused-event-section (rf2-3d987 issue #4). Persisted
+  via `machine-canvas`'s chart-collapsed-by-id slot (localStorage round-
+  trip identical to view-mode-by-id) so the operator's choice survives
+  reloads.
+
+  `collapsed?` is the current state; click flips it via the
+  `:set-chart-collapsed` event with mode `:toggle`."
+  [{:keys [machine-id collapsed?]}]
+  [:button
+   {:data-testid (str "rf-xray-machine-chart-toggle-"
+                      (machine-id-suffix machine-id))
+    :data-machine-id (str machine-id)
+    :data-collapsed (str (boolean collapsed?))
+    :aria-expanded (str (not collapsed?))
+    :title (if collapsed?
+             "Expand chart"
+             "Collapse chart (frees space for the snapshot pair)")
+    :on-click (fn [_]
+                (rf/dispatch
+                  [:rf.xray.machine-canvas/set-chart-collapsed
+                   {:machine-id machine-id :mode :toggle}]
+                  {:frame :rf/xray}))
+    :style {:background "transparent"
+            :border "none"
+            :color (:text-secondary tokens)
+            :font-family sans-stack
+            :font-size "11px"
+            :font-weight 600
+            :padding "2px 6px"
+            :cursor "pointer"
+            :border-radius "4px"
+            :display "inline-flex"
+            :align-items "center"
+            :gap "6px"}}
+   [:span {:style {:font-size "10px"}}
+    (if collapsed? "▸" "▾")]
+   [:span "Chart"]])
+
+(defn- chart-collapsed-summary
+  "One-line summary that replaces the expanded chart when the operator
+  collapses it (rf2-3d987 issue #4). Communicates topology
+  shape (node-count / transition-count) so the operator sees the chart
+  is still here, just hidden."
+  [{:keys [machine-id definition]}]
+  (let [states     (:states definition)
+        node-count (count states)
+        ;; Each state's `:on` map is a `{event target-or-vec}` entry;
+        ;; a state may also carry `:after` (one entry) producing
+        ;; transitions to a single target. Conservative count: sum
+        ;; the `:on` cardinalities plus 1 per `:after` (when present).
+        transitions
+        (reduce
+          (fn [acc [_state-id m]]
+            (+ acc (count (or (:on m) {})) (if (:after m) 1 0)))
+          0
+          states)]
+    [:div {:data-testid (str "rf-xray-machine-chart-collapsed-summary-"
+                             (machine-id-suffix machine-id))
+           :data-machine-id (str machine-id)
+           :data-node-count (str node-count)
+           :data-transition-count (str transitions)
+           :style {:padding "8px 12px"
+                   :background (:bg-1 tokens)
+                   :font-family sans-stack
+                   :font-size "11px"
+                   :color (:text-tertiary tokens)
+                   :font-style "italic"}}
+     (str "Machine topology · " node-count " "
+          (if (= 1 node-count) "node" "nodes") " · "
+          transitions " "
+          (if (= 1 transitions) "transition" "transitions")
+          " · click ▸ to expand")]))
 
 (defn- focused-event-section
   "Render one section per transitioned machine. Lens (above the chart,
   rf2-2n34o) → header → chart → snapshot drill-in (rf2-lxvn6) →
   cancellation cascade (inline) → after-rings overlay (on the chart).
   Guards / actions detail lives in the lens, not in a separate strip
-  below the chart."
+  below the chart.
+
+  rf2-3d987 layout fixes:
+   - issue #1: `gap: 8px` between sibling sub-panels via flex gap.
+   - issue #4: chart is collapsible via the per-machine
+     `:chart-collapsed` flag; toggle in the chart's nested header.
+   - issue #5: outer header uses `<strong>` weight differential on the
+     machine-id (already there) + the path uses an arrow separator.
+   - issue #7: nested headers use lighter chrome than the outer header.
+   - issue #8: outer margin bumped to 16px so the section has visible
+     breathing room from the panel host edge."
   [{:keys [machine-id from-state to-state on-event event microstep?
-           definition fired-edge-ids before after]
+           definition fired-edge-ids]
     :as record}]
   ;; rf2-gpzb4 (2026-05-21 xyflow migration) — the host-side ELK
   ;; layout dance (layout-or-fallback / ensure-elk! / compute-layout!)
@@ -419,7 +585,9 @@
   ;; node-ids for the focused-event lens highlight.
   (let [from-id    (when from-state (chart-layout/highlight-id from-state))
         to-id      (when to-state   (chart-layout/highlight-id to-state))
-        engine     "xyflow+elkjs"]
+        engine     "xyflow+elkjs"
+        collapsed? @(rf/subscribe
+                      [:rf.xray.machine-canvas/chart-collapsed-for machine-id])]
     [:section
      {:data-testid (str "rf-xray-machine-focused-event-section-"
                         (when machine-id
@@ -429,18 +597,29 @@
       :data-to-state (str to-state)
       :data-on-event (str on-event)
       :data-microstep (str (boolean microstep?))
+      :data-chart-collapsed (str collapsed?)
       ;; rf2-zdfbm — the topology is the panel's centrepiece, so the
       ;; section grows to fill the focused-event host's available
       ;; height. A flex column lets the canvas chart (`flex 1` below)
       ;; expand into the panel instead of sitting in a fixed 320px box.
-      :style {:margin "12px"
+      ;;
+      ;; rf2-3d987 issue #1 — `gap` on the flex column gives every
+      ;; sibling sub-panel (lens / chart / snapshot drill-in /
+      ;; cascade) visible breathing room. Background shows through
+      ;; the gap so three concerns no longer read as one wall of grey.
+      ;;
+      ;; rf2-3d987 issue #8 — outer margin bumped from 12px → 16px so
+      ;; the section has visible breathing room from the panel host
+      ;; edge at every viewport width.
+      :style {:margin (:gap-4 spacing)
               :border (str "1px solid " (:border-default tokens))
               :border-radius "4px"
               :background (:bg-2 tokens)
               :flex "1 1 0"
               :min-height 0
               :display "flex"
-              :flex-direction "column"}}
+              :flex-direction "column"
+              :gap (:gap-2 spacing)}}
      ;; Right-click on the per-machine section header fires
      ;; `:rf.xray/filter-by-machine` with this section's machine-id
      ;; (rf2-piye4) — drops a typed `:machine` IN pill into the ribbon
@@ -453,15 +632,18 @@
                                       [:rf.xray/filter-by-machine machine-id]
                                       {:frame :rf/xray})))
                :title "Right-click to filter the event list to this machine"
+               ;; OUTER header — ribbon background + slightly larger
+               ;; font than nested headers (issue #7 differential).
                :style {:padding "10px 12px"
                        :display "flex"
                        :align-items "center"
                        :gap "10px"
-                       :border-bottom (str "1px solid " (:border-subtle tokens))
                        :background (:bg-3 tokens)
                        :font-family mono-stack
-                       :font-size "12px"
-                       :color (:text-primary tokens)}}
+                       :font-size "13px"
+                       :color (:text-primary tokens)
+                       :border-top-left-radius "4px"
+                       :border-top-right-radius "4px"}}
       (when microstep?
         [:span {:style {:color (:text-tertiary tokens) :font-size "10px"}}
          "↳"])
@@ -520,6 +702,11 @@
              "Chart hidden in List view — flip to Canvas to inspect the topology."]]
 
            ;; default — :canvas
+           ;; rf2-3d987 issue #4 — collapsible chart. The chart wrapper
+           ;; carries its own nested header with a ▾/▸ toggle. When
+           ;; collapsed the chart is replaced by a one-line summary
+           ;; so the snapshot pair sits within the operator's foveal
+           ;; band without scrolling.
            [:div {:data-testid "rf-xray-machine-focused-event-chart"
                   :data-layout-engine engine
                   :data-machine-id (str machine-id)
@@ -532,6 +719,7 @@
                   :data-fired-edge-ids (str/join
                                          " " (sort (set fired-edge-ids)))
                   :data-view-mode "canvas"
+                  :data-chart-collapsed (str collapsed?)
                   ;; rf2-zdfbm — fill the section's available height so the
                   ;; topology chart (`machine-canvas/Chart` is `height
                   ;; 100%`) expands into the panel rather than collapsing
@@ -539,36 +727,59 @@
                   ;; chart grow inside the flex-column section; the
                   ;; min-height floor keeps xyflow's non-zero-parent-
                   ;; height requirement satisfied when the panel is short.
-                  :style {:padding "12px"
-                          :background (:bg-1 tokens)
-                          :overflow "hidden"
-                          :flex "1 1 0"
-                          :min-height "320px"
-                          :display "flex"
-                          :flex-direction "column"
-                          ;; position-relative so the after-rings overlay
-                          ;; can absolute-position itself over the chart SVG.
-                          :position "relative"}}
-            ;; rf2-y3l8z — the chart is now wrapped in an interactive
-            ;; viewport adapter (zoom/pan/fit + view-mode toggle +
-            ;; controls toolbar). The adapter owns the after-rings
-            ;; overlay so they stay co-located with the canvas.
-            [machine-canvas/Chart
-             {:definition         definition
-              :machine-id         machine-id
-              :from-highlight     from-state
-              :to-highlight       to-state
-              ;; rf2-qeemm (G3) — the focused epoch's traversed edges paint
-              ;; the FIRED treatment on the live chart (canonical ids from
-              ;; `extract-fired-edge-ids`, attached to the section record).
-              :fired-edge-ids     fired-edge-ids
-              :on-state-click     (fn [path]
-                                    (rf/dispatch
-                                      [:rf.xray/machine-state-clicked
-                                       {:machine-id machine-id
-                                        :path       path}]
-                                      {:frame :rf/xray}))
-              :show-after-rings?  true}]])))
+                  ;;
+                  ;; When collapsed the wrapper drops `flex 1` + the
+                  ;; min-height floor so the row only consumes header +
+                  ;; summary height — freeing screen real-estate for the
+                  ;; snapshot pair below (issue #4).
+                  :style (merge
+                           {:background (:bg-2 tokens)
+                            :display "flex"
+                            :flex-direction "column"
+                            :overflow "hidden"
+                            :position "relative"}
+                           (if collapsed?
+                             {:flex "0 0 auto"}
+                             {:flex "1 1 0"
+                              :min-height "320px"}))}
+            ;; Nested header (issue #7 — lighter chrome, smaller font,
+            ;; bottom-border separator). Carries the ▾ / ▸ toggle.
+            [:header {:data-testid "rf-xray-machine-focused-event-chart-header"
+                      :style nested-header-base-style}
+             (chart-collapse-toggle
+               {:machine-id machine-id :collapsed? collapsed?})]
+            (if collapsed?
+              (chart-collapsed-summary
+                {:machine-id machine-id :definition definition})
+              [:div {:style {:flex "1 1 0"
+                             :min-height 0
+                             :padding "12px"
+                             :background (:bg-1 tokens)
+                             :display "flex"
+                             :flex-direction "column"
+                             ;; position-relative so the after-rings overlay
+                             ;; can absolute-position itself over the chart SVG.
+                             :position "relative"}}
+               ;; rf2-y3l8z — the chart is now wrapped in an interactive
+               ;; viewport adapter (zoom/pan/fit + view-mode toggle +
+               ;; controls toolbar). The adapter owns the after-rings
+               ;; overlay so they stay co-located with the canvas.
+               [machine-canvas/Chart
+                {:definition         definition
+                 :machine-id         machine-id
+                 :from-highlight     from-state
+                 :to-highlight       to-state
+                 ;; rf2-qeemm (G3) — the focused epoch's traversed edges paint
+                 ;; the FIRED treatment on the live chart (canonical ids from
+                 ;; `extract-fired-edge-ids`, attached to the section record).
+                 :fired-edge-ids     fired-edge-ids
+                 :on-state-click     (fn [path]
+                                       (rf/dispatch
+                                         [:rf.xray/machine-state-clicked
+                                          {:machine-id machine-id
+                                           :path       path}]
+                                         {:frame :rf/xray}))
+                 :show-after-rings?  true}]])])))
      ;; rf2-lxvn6 (phase 4 of rf2-oqa60) — snapshot drill-in. Each
      ;; per-machine section renders the BEFORE / AFTER snapshot maps
      ;; through the first-class edn-inspector widget (spec/021 §10).

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_canvas_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_canvas_cljs_test.cljs
@@ -45,7 +45,9 @@
   (rf/with-frame :rf/xray
     (testing "every machine-canvas sub resolves through rf/subscribe"
       (doseq [q-v [[:rf.xray.machine-canvas/view-mode-for :m]
-                   [:rf.xray.machine-canvas/view-mode-by-id]]]
+                   [:rf.xray.machine-canvas/view-mode-by-id]
+                   [:rf.xray.machine-canvas/chart-collapsed-for :m]
+                   [:rf.xray.machine-canvas/chart-collapsed-by-id]]]
         (is (some? (rf/subscribe q-v))
             (str q-v " must resolve through rf/subscribe"))))))
 
@@ -85,6 +87,64 @@
         (registrar/handler
           :fx :rf.xray.machine-canvas/persist-view-mode))
       "persist-view-mode fx is in the registrar"))
+
+;; ---- 2b. Chart-collapsed slot (rf2-3d987 issue #4) ---------------------
+
+(deftest chart-collapsed-defaults-to-false
+  (setup-xray-frame!)
+  (rf/with-frame :rf/xray
+    (let [collapsed? @(rf/subscribe
+                        [:rf.xray.machine-canvas/chart-collapsed-for :m])]
+      (is (= false collapsed?)
+          "rf2-3d987 issue #4 — unset slot defaults to false (expanded)"))))
+
+(deftest chart-collapsed-set-collapsed-and-toggle
+  (setup-xray-frame!)
+  (rf/with-frame :rf/xray
+    (rf/dispatch-sync
+      [:rf.xray.machine-canvas/set-chart-collapsed
+       {:machine-id :m :mode :collapsed}])
+    (is (= true @(rf/subscribe
+                   [:rf.xray.machine-canvas/chart-collapsed-for :m]))
+        ":mode :collapsed flips the slot to true")
+    (rf/dispatch-sync
+      [:rf.xray.machine-canvas/set-chart-collapsed
+       {:machine-id :m :mode :toggle}])
+    (is (= false @(rf/subscribe
+                    [:rf.xray.machine-canvas/chart-collapsed-for :m]))
+        ":mode :toggle inverts the slot")
+    (rf/dispatch-sync
+      [:rf.xray.machine-canvas/set-chart-collapsed
+       {:machine-id :m :mode :toggle}])
+    (is (= true @(rf/subscribe
+                   [:rf.xray.machine-canvas/chart-collapsed-for :m]))
+        "second :toggle inverts again")
+    (rf/dispatch-sync
+      [:rf.xray.machine-canvas/set-chart-collapsed
+       {:machine-id :m :mode :expanded}])
+    (is (= false @(rf/subscribe
+                    [:rf.xray.machine-canvas/chart-collapsed-for :m]))
+        ":mode :expanded flips the slot to false")))
+
+(deftest chart-collapsed-is-per-machine
+  (setup-xray-frame!)
+  (rf/with-frame :rf/xray
+    (rf/dispatch-sync
+      [:rf.xray.machine-canvas/set-chart-collapsed
+       {:machine-id :auth/login :mode :collapsed}])
+    (is (= true  @(rf/subscribe
+                    [:rf.xray.machine-canvas/chart-collapsed-for :auth/login])))
+    (is (= false @(rf/subscribe
+                    [:rf.xray.machine-canvas/chart-collapsed-for :checkout/flow]))
+        "rf2-3d987 issue #4 — per-machine slot, one machine's collapse
+         does not affect another's")))
+
+(deftest persist-chart-collapsed-fx-registered
+  (setup-xray-frame!)
+  (is (some?
+        (registrar/handler
+          :fx :rf.xray.machine-canvas/persist-chart-collapsed))
+      "persist-chart-collapsed fx is in the registrar"))
 
 ;; ---- 3. Chart view hiccup shape ---------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_view_cljs_test.cljs
@@ -935,3 +935,232 @@
             (is (some? (some-> (meta section) :key))
                 (str "focused-event-section carries :key meta — got "
                      (pr-str (meta section))))))))))
+
+;; ---- (6) rf2-3d987 layout fixes -----------------------------------------
+;;
+;; Pin the 8 cohesive layout changes (rf2-3d987) so a future refactor that
+;; quietly drops one of them has a test marker to fail against. The DOM-
+;; measurement assertions (sibling gap, side-by-side at ≥800px) live in
+;; the Playwright suite — these JVM tests pin the hiccup-level invariants.
+
+(defn- style-of
+  "Return the inline :style map of a hiccup node, or nil."
+  [node]
+  (when (and (vector? node) (map? (second node)))
+    (:style (second node))))
+
+(deftest rf2-3d987-issue-1-focused-event-section-has-gap
+  (testing "rf2-3d987 issue #1: focused-event-section's children must
+            sit on a flex column with a non-zero :gap so sibling sub-
+            panels (lens / chart / snapshot drill-in / cascade) get
+            visible breathing room rather than reading as one wall of
+            grey."
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (override-machines!    [:auth/login])
+      (override-definitions! {:auth/login fixture-definition})
+      (override-epoch-history!
+        [{:epoch-id 1
+          :trace-events
+          [{:id 1 :time 10 :operation :rf.machine/transition
+            :tags {:machine-id :auth/login
+                   :before {:state :idle :data {}}
+                   :after  {:state :authing :data {}}
+                   :event [:auth/submit] :rf.trace/dispatch-id "d-1"}}]}])
+      (focus-epoch! 1)
+      (let [tree    (machine-inspector/Panel)
+            section (find-by-testid
+                      tree "rf-xray-machine-focused-event-section-auth/login")
+            style   (style-of section)]
+        (is (some? section)   "focused-event-section mounts")
+        (is (= "flex" (:display style))   "section is a flex container")
+        (is (= "column" (:flex-direction style))
+            "section is a flex column")
+        (is (some? (:gap style))
+            "section carries a :gap so siblings get breathing room")))))
+
+(deftest rf2-3d987-issue-2-snapshot-drill-in-flat-no-second-card
+  (testing "rf2-3d987 issue #2 (option b): snapshot-drill-in matches
+            the outer section's `bg-2` so it reads as a continuation
+            of the body, not as a nested white card. The bordered
+            outer section already provides the card chrome."
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (override-machines!    [:auth/login])
+      (override-definitions! {:auth/login fixture-definition})
+      (override-epoch-history!
+        [{:epoch-id 1
+          :trace-events
+          [{:id 1 :time 10 :operation :rf.machine/transition
+            :tags {:machine-id :auth/login
+                   :before {:state :idle :data {}}
+                   :after  {:state :authing :data {}}
+                   :event [:auth/submit] :rf.trace/dispatch-id "d-1"}}]}])
+      (focus-epoch! 1)
+      (let [tree  (machine-inspector/Panel)
+            drill (find-by-testid tree "rf-xray-machine-snapshot-drill-in")
+            style (style-of drill)
+            ;; bg-2 token resolves to the var(--rf-xray-bg-2) CSS string.
+            expected-bg "var(--rf-xray-bg-2)"]
+        (is (some? drill)   "drill-in mounts")
+        (is (= expected-bg (:background style))
+            "drill-in body uses :bg-2 — same as outer section, no card-in-card")))))
+
+(deftest rf2-3d987-issue-3-before-after-side-by-side-grid
+  (testing "rf2-3d987 issue #3: Before/After render in a CSS grid that
+            auto-fits side-by-side at the wider viewport and falls back
+            to stacked when narrower. Pinned via the
+            `grid-template-columns: repeat(auto-fit, minmax(...)` shape
+            on the snapshot-drill-in's inner grid container."
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (override-machines!    [:auth/login])
+      (override-definitions! {:auth/login fixture-definition})
+      (override-epoch-history!
+        [{:epoch-id 1
+          :trace-events
+          [{:id 1 :time 10 :operation :rf.machine/transition
+            :tags {:machine-id :auth/login
+                   :before {:state :idle :data {}}
+                   :after  {:state :authing :data {}}
+                   :event [:auth/submit] :rf.trace/dispatch-id "d-1"}}]}])
+      (focus-epoch! 1)
+      (let [tree (machine-inspector/Panel)
+            grid (find-by-testid
+                   tree "rf-xray-machine-snapshot-drill-in-grid")
+            style (style-of grid)
+            cols  (:grid-template-columns style)]
+        (is (some? grid)
+            "snapshot-drill-in carries an inner grid container")
+        (is (= "grid" (:display style))
+            "container uses display: grid")
+        (is (and (string? cols)
+                 (str/includes? cols "auto-fit")
+                 (str/includes? cols "minmax"))
+            (str "grid-template-columns uses auto-fit + minmax so the "
+                 "layout collapses to one column when narrow — got "
+                 (pr-str cols)))))))
+
+(deftest rf2-3d987-issue-4-chart-collapsible-toggle-and-state
+  (testing "rf2-3d987 issue #4: the chart sub-panel carries a collapse
+            toggle button + the chart wrapper surfaces the per-machine
+            `:data-chart-collapsed` flag. Default state is expanded
+            (`false`); the toggle event flips the persisted slot."
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (override-machines!    [:auth/login])
+      (override-definitions! {:auth/login fixture-definition})
+      (override-epoch-history!
+        [{:epoch-id 1
+          :trace-events
+          [{:id 1 :time 10 :operation :rf.machine/transition
+            :tags {:machine-id :auth/login
+                   :before {:state :idle :data {}}
+                   :after  {:state :authing :data {}}
+                   :event [:auth/submit] :rf.trace/dispatch-id "d-1"}}]}])
+      (focus-epoch! 1)
+      ;; Default state — chart is expanded.
+      (let [tree    (machine-inspector/Panel)
+            wrapper (find-by-testid
+                      tree "rf-xray-machine-focused-event-chart")
+            toggle  (find-by-testid
+                      tree "rf-xray-machine-chart-toggle-auth/login")]
+        (is (some? wrapper)   "chart wrapper mounts")
+        (is (some? toggle)    "collapse toggle button mounts")
+        (is (= "false" (:data-chart-collapsed (second wrapper)))
+            "default state — chart is expanded")
+        (is (= "false" (:data-collapsed (second toggle)))
+            "toggle reflects expanded state")
+        (is (nil? (find-by-testid
+                    tree
+                    "rf-xray-machine-chart-collapsed-summary-auth/login"))
+            "collapsed summary is hidden while expanded"))
+      ;; Toggle → collapsed.
+      (rf/dispatch-sync
+        [:rf.xray.machine-canvas/set-chart-collapsed
+         {:machine-id :auth/login :mode :collapsed}])
+      (let [tree    (machine-inspector/Panel)
+            wrapper (find-by-testid
+                      tree "rf-xray-machine-focused-event-chart")
+            summary (find-by-testid
+                      tree
+                      "rf-xray-machine-chart-collapsed-summary-auth/login")]
+        (is (= "true" (:data-chart-collapsed (second wrapper)))
+            "wrapper reflects collapsed state after dispatch")
+        (is (some? summary)
+            "collapsed summary renders when chart is collapsed")))))
+
+(deftest rf2-3d987-issue-7-nested-header-differentiated-from-outer
+  (testing "rf2-3d987 issue #7: nested headers (chart-header,
+            snapshot-drill-in-header) use lighter chrome than the outer
+            focused-event-header. Pinned by: nested headers DO NOT carry
+            the outer `bg-3` ribbon background; they use a transparent
+            background + bottom-border separator + smaller font."
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (override-machines!    [:auth/login])
+      (override-definitions! {:auth/login fixture-definition})
+      (override-epoch-history!
+        [{:epoch-id 1
+          :trace-events
+          [{:id 1 :time 10 :operation :rf.machine/transition
+            :tags {:machine-id :auth/login
+                   :before {:state :idle :data {}}
+                   :after  {:state :authing :data {}}
+                   :event [:auth/submit] :rf.trace/dispatch-id "d-1"}}]}])
+      (focus-epoch! 1)
+      (let [tree    (machine-inspector/Panel)
+            outer   (find-by-testid
+                      tree "rf-xray-machine-focused-event-header")
+            nested-chart  (find-by-testid
+                            tree
+                            "rf-xray-machine-focused-event-chart-header")
+            nested-snap   (find-by-testid
+                            tree
+                            "rf-xray-machine-snapshot-drill-in-header")
+            outer-bg   (-> outer style-of :background)
+            chart-bg   (-> nested-chart style-of :background)
+            snap-bg    (-> nested-snap style-of :background)
+            outer-fs   (-> outer style-of :font-size)
+            chart-fs   (-> nested-chart style-of :font-size)
+            snap-fs    (-> nested-snap style-of :font-size)]
+        (is (some? outer)         "outer header mounts")
+        (is (some? nested-chart)  "chart nested header mounts")
+        (is (some? nested-snap)   "snapshot nested header mounts")
+        (is (= "var(--rf-xray-bg-3)" outer-bg)
+            "outer header keeps the ribbon background")
+        (is (= "transparent" chart-bg)
+            "chart nested header uses transparent background")
+        (is (= "transparent" snap-bg)
+            "snapshot nested header uses transparent background")
+        (is (not= outer-fs chart-fs)
+            "chart nested header font-size differs from outer")
+        (is (not= outer-fs snap-fs)
+            "snapshot nested header font-size differs from outer")))))
+
+(deftest rf2-3d987-issue-8-section-has-panel-breathing-room
+  (testing "rf2-3d987 issue #8: focused-event-section's outer margin
+            grew from 12px to 16px so the card has visible breathing
+            room from the panel host edge at every viewport width."
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (override-machines!    [:auth/login])
+      (override-definitions! {:auth/login fixture-definition})
+      (override-epoch-history!
+        [{:epoch-id 1
+          :trace-events
+          [{:id 1 :time 10 :operation :rf.machine/transition
+            :tags {:machine-id :auth/login
+                   :before {:state :idle :data {}}
+                   :after  {:state :authing :data {}}
+                   :event [:auth/submit] :rf.trace/dispatch-id "d-1"}}]}])
+      (focus-epoch! 1)
+      (let [tree    (machine-inspector/Panel)
+            section (find-by-testid
+                      tree "rf-xray-machine-focused-event-section-auth/login")
+            margin  (-> section style-of :margin)]
+        (is (some? section)   "section mounts")
+        (is (= "16px" margin)
+            (str "section uses the 16px (gap-4) margin so it has "
+                 "breathing room from the panel host edge — got "
+                 (pr-str margin)))))))

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -187,6 +187,11 @@
    ;; zoom/pan/fit internally).
    :rf.xray.machine-canvas/view-mode-by-id
    :rf.xray.machine-canvas/view-mode-for
+   ;; rf2-3d987 issue #4 — chart-collapsed slot per machine, persisted
+   ;; alongside view-mode-by-id. Lets the operator hide the chart so
+   ;; the snapshot pair has room without scrolling.
+   :rf.xray.machine-canvas/chart-collapsed-by-id
+   :rf.xray.machine-canvas/chart-collapsed-for
    ;; rf2-a9cke — focused-event lens composite consumed by the
    ;; Machine Inspector + the cancellation-cascade SidePanel.
    :rf.xray/machine-transitions-for-focused-event
@@ -458,6 +463,9 @@
    ;; retired — xyflow owns zoom/pan/fit internally).
    :rf.xray.machine-canvas/hydrate-view-modes
    :rf.xray.machine-canvas/set-view-mode
+   ;; rf2-3d987 issue #4 — chart-collapsed events.
+   :rf.xray.machine-canvas/hydrate-chart-collapsed
+   :rf.xray.machine-canvas/set-chart-collapsed
    ;; (Pre-rf2-q3dzw the legacy `edn-inspector.render` engine emitted
    ;; `:rf.xray/navigate-to-path` from its clickable-path glyphs and
    ;; registered a default no-op handler. The new widget ships ZERO
@@ -655,6 +663,9 @@
    ;; localStorage on every `:set-view-mode` mutation so the user's
    ;; Canvas / List choice survives reloads.
    :rf.xray.machine-canvas/persist-view-mode
+   ;; rf2-3d987 issue #4 — chart-collapsed persistence side-effect. Same
+   ;; localStorage round-trip pattern as persist-view-mode.
+   :rf.xray.machine-canvas/persist-chart-collapsed
    ;; rf2-wm7z4 — palette pop-out side-effect. Lives under the
    ;; palette-specific prefix because it wraps a mount-layer pop-out
    ;; call that no other Xray surface invokes.


### PR DESCRIPTION
Closes rf2-3d987.

The Machine panel's focused-event-section establishes the header+body card aesthetic the operator likes, but 8 cohesive layout issues compounded to make it harder to read than it should be. Per the bead, landing them in one commit because the concerns are interlocking — fixing one without the others would look incoherent.

## The 8 fixes + worker decisions

**1. Spacing between sibling sub-panels.** focused-event-section is now a flex column with `gap: 8px` (`:gap-2` from spacing tokens). Lens / chart / snapshot drill-in / cancellation cascade now get visible breathing room instead of reading as one wall of grey.

**2. Card-in-card transition — worker chose option (b).** snapshot-drill-in now matches the outer section's `bg-2` so it reads as a continuation of the body, not as a nested white card. Operator's eye reads body → snapshot → body as one continuous surface. The bordered outer section provides the only card chrome layer. Rationale: ELEGANCE + CLARITY (masterpiece lens) — one card layer not two.

**3. Before/After side-by-side.** Snapshot blocks render in a CSS Grid (`repeat(auto-fit, minmax(360px, 1fr))`) that auto-fits two columns when the panel is ≥ ~720px wide and falls back to single-column stack when narrower. Each column carries its own internal header (`Before` / `After`); the grouping header drops the redundant `before / after` suffix per the bead.

**4. Collapsible chart.** Chart sub-panel gains a ▾/▸ toggle in its nested header. Default-expanded; click to collapse to a one-line summary (e.g. "Machine topology · 4 nodes · 5 transitions · click ▸ to expand"). State persisted via per-machine localStorage slot `xray.machine-canvas.chart-collapsed-by-id` mirroring the existing `view-mode-by-id` pattern (subs, events, fx, hydrate). Frees screen real-estate so the snapshot pair sits within the operator's foveal band without scrolling.

**5. Header weight differential.** Section labels (`Transition`, `Guards Run`, `Actions Run`, `Snapshot`, `Target Machine Instance`) now render inside `<strong>` with explicit `font-weight: 700` so the operator's eye picks them out from their qualifiers. Sequential meaning carries the `→` arrow separator where it was a `·` middle-dot before (transition path already used `→`).

**6. transition-lens distinguished as metadata — worker chose option (b).** The lens drops its `bg-1` body in favour of a transparent background (matches the section interior), uses a smaller mono font (11px vs 12px), and renders text in `:text-secondary` rather than `:text-primary`. Reads as supplementary metadata about the focused transition rather than co-equal with the interactive chart. Rationale: folding the lens into the outer header (option a) would crowd the header ribbon; secondary-metadata treatment communicates hierarchy clearly without changing where the lens lives semantically (spec/003 §Focused-transition lens still keeps it above the chart).

**7. Nested header differentiation — worker chose: transparent background + smaller font + bottom-border separator.** Every nested header (chart-header, snapshot-drill-in-header) now uses a single `nested-header-base-style` constant: transparent background, 11px font, `:border-subtle` bottom-border. The outer focused-event-header keeps its `bg-3` ribbon + 13px font (was 12px — bumped one notch) so hierarchy reads at a glance. Applied uniformly to all nested headers in the panel.

**8. Panel breathing room.** focused-event-section's outer margin grew from 12px to 16px (`:gap-4` from spacing tokens). The card no longer touches the panel host edge at any viewport width.

## Regression tests

Hiccup-level invariants pinned in CLJS tests (DOM measurement assertions on actual sibling gap / side-by-side computed style live in the Playwright suite — these JVM tests pin the wiring):

- `machine_inspector_view_cljs_test.cljs` — 6 new deftests, one per fix where observable:
  - `rf2-3d987-issue-1-focused-event-section-has-gap`
  - `rf2-3d987-issue-2-snapshot-drill-in-flat-no-second-card`
  - `rf2-3d987-issue-3-before-after-side-by-side-grid`
  - `rf2-3d987-issue-4-chart-collapsible-toggle-and-state`
  - `rf2-3d987-issue-7-nested-header-differentiated-from-outer`
  - `rf2-3d987-issue-8-section-has-panel-breathing-room`
- `machine_canvas_cljs_test.cljs` — 4 new deftests for the chart-collapsed slot: default false, set-collapsed/toggle/expanded transitions, per-machine isolation, `persist-chart-collapsed` fx registered. Plus the existing `registry-wires-canvas-subs` extended to assert the two new subs.
- `registry_cljs_test.cljs` — registry enumerations extended with the four new handlers + the new fx (so a future refactor that quietly removes one of them trips the test).

Issues #5 and #6 were not given dedicated tests — the weight differential is visual and the lens-metadata treatment is captured by manual inspection (Mike's live-test step). Adding text-style assertions on `<strong>` weight or specific font sizes inside the lens would be brittle without yielding signal beyond the visual.

## What does NOT change

- The xyflow chart implementation
- The Machine state-machine semantics
- The trace-event-driven snapshot computation
- The focused-event selection mechanism
- The edn-inspector widget contract (consumed unchanged at every mount site)
- The lens's data sources or ordering (Target Machine Instance / Transition / Guards Run / Actions Run — spec/003 §Focused-transition lens)
- Any external test data attributes that downstream tests depend on (`rf-xray-machine-focused-event-section-*`, `rf-xray-machine-focused-event-chart`, `rf-xray-machine-snapshot-drill-in`, `rf-xray-machine-snapshot-block-*` all unchanged in shape).

## Files changed

- `tools/xray/src/day8/re_frame2_xray/panels/machine_canvas.cljs` — chart-collapsed slot (subs/events/fx/persistence/hydration), parallel to view-mode-by-id.
- `tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs` — the 8 layout fixes + the `chart-collapse-toggle` / `chart-collapsed-summary` / `nested-header-base-style` building blocks.
- `tools/xray/test/day8/re_frame2_xray/panels/machine_canvas_cljs_test.cljs` — 4 new chart-collapsed slot tests; existing `registry-wires-canvas-subs` extended.
- `tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_view_cljs_test.cljs` — 6 new per-fix hiccup invariant tests.
- `tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs` — registry enumerations extended for the 4 new sub/event handlers + 1 new fx.

## Gates

- `clojure -M:test` (xray JVM): 859 tests, 3199 assertions, 0 failures
- `npm run test:cljs`: 4590 tests, 14806 assertions, 0 failures
- `npm run test:browser`: 124 tests, 346 assertions, 0 failures
- `npm run test:xray-feature-gate`: 13 scenarios, 0 failures (full nightly sweep)
- `npm run test:bundle-isolation`: PASS — 16 entries / 33 sentinels / 3 budgets
- `clj-kondo --lint tools/xray/src tools/xray/test`: 0 errors (warnings are pre-existing in unrelated files; 2 pre-existing `unused binding` warnings in `machine_inspector.cljs` are now resolved because the destructure narrowed).
