### PR TITLE
fix(xray): chrome bugs cluster -- narrow-viewport ribbon wrap + stale theme label (rf2-axpq2 + rf2-pfx4u)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/settings/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/settings/view.cljs
@@ -625,13 +625,26 @@
 (defn- theme-section []
   (let [theme            @(rf/subscribe [:rf.xray/setting :theme nil])
         use-system?      @(rf/subscribe [:rf.xray/setting
-                                         :general :use-system-colors?])]
+                                         :general :use-system-colors?])
+        ;; rf2-pfx4u — the "(default)" annotation is derived from the
+        ;; canonical default in `config/default-settings`, not hard-coded
+        ;; against `:dark`. The prior labels paired the annotation with
+        ;; Dark while the actual default is `:light` (per
+        ;; `config.cljc :theme :light` and `effects/apply-theme!` which
+        ;; falls back to `:light` when no theme is set) — the Figma
+        ;; authority reference also opens on Light. Sourcing the marker
+        ;; from config keeps the label in lock-step with the default and
+        ;; survives any future flip without a separate copy-edit.
+        default-theme    (:theme config/default-settings)]
     [:div {:data-testid "rf-xray-settings-section-theme"}
      [:h2 {:style (section-heading-style)} "Theme"]
      [:div {:style (field-style)}
       [:span {:style (label-style)} "Colour theme"]
-      (for [[t label] [[:dark  "Dark (default)"]
-                       [:light "Light"]]]
+      (for [[t base-label] [[:dark  "Dark"]
+                            [:light "Light"]]
+            :let [label (if (= t default-theme)
+                          (str base-label " (default)")
+                          base-label)]]
         ^{:key t}
         [:label {:style {:display "flex" :align-items "center" :gap "8px"
                          :cursor "pointer"

--- a/tools/xray/src/day8/re_frame2_xray/shell.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/shell.cljs
@@ -1110,9 +1110,24 @@
      ;; was dropped (A4); the cluster now leads with the `Events` label.
      ;; rf2-pjjwh retired the focus button + focus-chip with the focus
      ;; feature.
+     ;; rf2-axpq2 — `:flex-wrap "nowrap"` on the LEFT cluster. The prior
+     ;; `wrap` caused the [+] add-pill (the cluster's last child) to wrap
+     ;; onto a second line at ~420px viewports, where it overflowed the
+     ;; fixed 34px chrome-ribbon height and got vertically occluded by the
+     ;; events-ribbon below — click-blocked. The Figma authority chrome-
+     ;; ribbon does NOT wrap (`design-reference/xray_devtools_reference
+     ;; .cljs` `chrome-ribbon` uses plain non-wrapping flex). Keeping
+     ;; nowrap lets the cluster overflow horizontally instead — the [+]
+     ;; stays inline at y=ribbon-centre and remains hit-testable until it
+     ;; runs past the viewport edge.
      [:div {:data-testid "rf-xray-ribbon-selectors"
             :style {:display "flex" :align-items "center" :gap "13px"
-                    :flex-wrap "wrap"}}
+                    :flex-wrap "nowrap"
+                    ;; The cluster is allowed to shrink but its children
+                    ;; carry `white-space: nowrap` so they stay legible;
+                    ;; horizontal overflow goes off-screen rather than
+                    ;; wrapping into the row below.
+                    :min-width "0"}}
       ;; rf2-xawwb — `Event History` label leads the left cluster (Figma-
       ;; Make surface renamed `Events` → `Event History`). White ink on the
       ;; dark chrome band (`chrome-ribbon-text`).

--- a/tools/xray/test/day8/re_frame2_xray/settings/popup_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/settings/popup_cljs_test.cljs
@@ -17,6 +17,7 @@
   `shell_cljs_test.cljs` so the test surface stays Reagent-free
   on the assertion side."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.substrate.plain-atom :as plain-atom]
@@ -144,6 +145,50 @@
       ;; reachable without flipping the OS-level switch.
       (is (find-by-testid rendered "rf-xray-settings-use-system-colors")
           "Use system colors toggle renders in the Theme section"))))
+
+(deftest theme-label-matches-actual-default
+  (testing "rf2-pfx4u — the `(default)` annotation in the Theme section
+            labels MUST sit next to the actually-default option per
+            `config/default-settings`, not be hard-coded against Dark.
+            The default is `:light` (Figma authority + `config.cljc`
+            + `effects/apply-theme!` fallback), so the Light label
+            carries `(default)` and the Dark label does NOT.
+
+            Asserted by walking the radio's parent `<label>` and
+            asking `text-content` for the visible copy. The parent
+            label is the SECOND ancestor of the `<input>` — the
+            tree shape is `[:label ... [:input {...}] \"Dark\"]`."
+    (setup!)
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/settings-open])
+      (rf/dispatch-sync [:rf.xray/settings-select-tab :theme]))
+    (rf/with-frame :rf/xray
+      (let [rendered    (popup/Modal)
+            section     (find-by-testid rendered "rf-xray-settings-section-theme")
+            ;; the visible copy of each radio's row is the concatenation
+            ;; of strings in the section that share its sibling line;
+            ;; checking via `text-content` on the section is the
+            ;; simplest faithful read of what the operator sees.
+            section-txt (th/text-content section)
+            default-theme (:theme config/default-settings)]
+        ;; the canonical default must be `:light` (Figma authority).
+        ;; Pinning this here means a future flip of the default
+        ;; surfaces as a deliberate edit to this test, not as a silent
+        ;; label drift.
+        (is (= :light default-theme)
+            "config/default-settings :theme is :light (Figma authority)")
+        ;; the `(default)` annotation sits next to Light, not Dark.
+        (is (re-find #"Light \(default\)" section-txt)
+            "Light option is labelled `Light (default)` (rf2-pfx4u)")
+        (is (not (re-find #"Dark \(default\)" section-txt))
+            "Dark option is NOT labelled `Dark (default)` — the prior stale label is gone (rf2-pfx4u)")
+        ;; Dark still surfaces as a `Dark` label (base copy preserved
+        ;; — only the `(default)` marker moved). Use a substring check
+        ;; rather than `\bDark\b` because the section's text-content
+        ;; concatenates sibling strings without separators (the radio
+        ;; rows render adjacent, so the joined leaves read `DarkLight`).
+        (is (str/includes? section-txt "Dark")
+            "Dark option still labelled `Dark` (without the default marker)")))))
 
 ;; ---- Tab switching ------------------------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs
@@ -392,6 +392,39 @@
         (is (nil? (:border-left style))
             "chrome ribbon root has no :border-left in its inline style")))))
 
+(deftest chrome-ribbon-left-cluster-does-not-wrap
+  (testing "rf2-axpq2 — the chrome ribbon's LEFT cluster must NOT carry
+            `:flex-wrap \"wrap\"`. At narrow viewports (~420px) wrapping
+            pushed the [+] add-pill (the cluster's last child) onto a
+            second line that overflowed the fixed 34px ribbon height,
+            where it was vertically occluded by the events-ribbon below
+            and click-blocked. The Figma authority chrome-ribbon does NOT
+            wrap (`design-reference/xray_devtools_reference.cljs`
+            `chrome-ribbon` uses plain non-wrapping flex), so the LEFT
+            cluster keeps the [+] inline at y=ribbon-centre and lets the
+            cluster overflow horizontally when necessary."
+    (xray-setup!)
+    (rf/with-frame :rf/xray
+      (let [ribbon    (shell/ribbon nil)
+            selectors (find-by-testid ribbon "rf-xray-ribbon-selectors")
+            style     (:style (second selectors))]
+        (is (some? selectors)
+            "the LEFT cluster (rf-xray-ribbon-selectors) renders")
+        (is (not= "wrap" (:flex-wrap style))
+            "the LEFT cluster must NOT wrap (rf2-axpq2) — `wrap` pushes the [+] add-pill into an occluded second row at narrow viewports")
+        ;; positive assertion: nowrap is explicit so future edits that drop
+        ;; the prop entirely also stay safe (flex's default is nowrap, but
+        ;; making it explicit documents the intent + survives lint sweeps
+        ;; that re-shape style maps).
+        (is (= "nowrap" (:flex-wrap style))
+            "the LEFT cluster sets `:flex-wrap \"nowrap\"` explicitly")
+        ;; the [+] add-pill button MUST live inside the LEFT cluster so it
+        ;; rides the same flex row — if it migrated out of the selectors
+        ;; cluster the wrap-occlusion failure mode could reappear in a
+        ;; different shape.
+        (is (some? (find-by-testid selectors "rf-xray-filter-add"))
+            "the [+] add-pill is nested INSIDE the LEFT cluster (so the nowrap covers it)")))))
+
 (deftest events-ribbon-carries-warning-and-committed-pills
   (testing "rf2-3f2di A5/A6 — reconciled to the authority reference
             events-ribbon (bar-2). It carries the `N events filtered out`


### PR DESCRIPTION
Two concrete bugs from the rf2-ad7zx EPIC (Xray L&F) `2026-05-24` residual-gaps list, fixed together because both touch the Xray chrome/shell surface.

## rf2-axpq2 -- chrome-ribbon wrap doesn't block `[+]` add-pill click at narrow viewports

**Symptom.** At ~420px viewports the chrome ribbon's LEFT cluster (`rf-xray-ribbon-selectors`) wrapped its content, pushing the `[+]` add-pill (the cluster's last child) onto a second line. The second line overflowed the fixed 34px chrome-ribbon height and got vertically occluded by the events-ribbon below -- click-blocked.

**Fix.** Drop `:flex-wrap "wrap"` on the LEFT cluster (it was the only place wrap was used). The Figma authority chrome-ribbon (`design-reference/xray_devtools_reference.cljs` `chrome-ribbon`) uses plain non-wrapping flex, so this brings the impl into line. With `:flex-wrap "nowrap"` + `:min-width "0"` the cluster now overflows horizontally instead, keeping the `[+]` at `y=ribbon-centre` and hit-testable until it runs past the viewport edge.

**Test coverage.** `chrome-ribbon-left-cluster-does-not-wrap` (in `tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs`) asserts:
- the LEFT cluster's inline style sets `:flex-wrap "nowrap"` explicitly
- `wrap` is NOT present (the regression mode is specifically `wrap`)
- the `[+]` add-pill (`rf-xray-filter-add`) is nested INSIDE the LEFT cluster so the nowrap applies to the click target

## rf2-pfx4u -- theme label matches actual default

**Symptom.** The Settings popup's Theme section labelled the Dark option as `Dark (default)`, but the actual default theme is `:light` -- per `config/default-settings` (`:theme :light`, with comment `light default per the authority reference`), per `effects/apply-theme!` (falls back to `:light` when no theme is set), and per the Figma authority reference (which opens on Light). The "default" annotation was sitting next to the wrong option.

**Fix.** Derive the `(default)` annotation from `config/default-settings` rather than baking it into the label string. The base labels are now `Dark` and `Light`; the loop appends `(default)` to whichever option matches `(:theme config/default-settings)`. The label stays in lock-step with the actual runtime default, and any future flip of the default flows through without a separate copy-edit.

**Test coverage.** `theme-label-matches-actual-default` (in `tools/xray/test/day8/re_frame2_xray/settings/popup_cljs_test.cljs`) asserts:
- `config/default-settings :theme` is `:light` (pinned so a future flip surfaces as a deliberate edit here, not silent label drift)
- the visible copy contains `Light (default)`
- the visible copy does NOT contain `Dark (default)` -- the stale label is gone
- the bare `Dark` label is still present (base copy preserved)

## Gates

- `npm run test:cljs` -- pass (4 pre-existing failures in `edn-inspector` are unrelated to this PR; filed as rf2-pdeeb)
- `npm run test:browser` -- 124 tests / 346 assertions / 0 failures
- `clojure -M:test` (tools/xray JVM) -- 859 tests / 3199 assertions / 0 failures
- `npm run test:xray-feature-gate` -- 13 scenarios / 0 failures
- `clj-kondo --lint tools/xray/src tools/xray/test` -- 0 errors

## Cross-reference

Both bugs are children of EPIC rf2-ad7zx (Xray L&F -- Figma redesign + residual gaps), specifically from the `2026-05-24` residual-gaps list. The chrome ribbon now matches the Figma authority's non-wrapping layout end-to-end, and the theme label is sourced from the canonical default.