### PR TITLE
fix(xray): panel-gallery fixture — :rf.event/coeffects stamp moves to :rf.event/run-end per rf2-9dk9y (rf2-ge2oe.2)

### DIFF
--- a/tools/xray/testbeds/panel_gallery/fixtures.cljs
+++ b/tools/xray/testbeds/panel_gallery/fixtures.cljs
@@ -433,11 +433,14 @@
   (event-lens-simple-buffer))
 
 (defn event-lens-with-coeffects-buffer
-  "Event lens fixture exercising the COEFFECTS section (rf2-jhhqt).
-  Stamps two user-injected coeffects (`:now` + `:local-storage`) onto
-  the `:rf.fx/do-fx` trace's `:tags :coeffects` slot — the substrate
-  filter has already excluded the framework defaults (`:db` `:event`
-  `:frame` `:source` `:trace-id`)."
+  "Event lens fixture exercising the COEFFECTS section (rf2-jhhqt,
+  rf2-9dk9y). Stamps two user-injected coeffects (`:now` +
+  `:local-storage`) onto the `:rf.event/run-end` trace's
+  `:tags :rf.event/coeffects` slot — the substrate filter has already
+  excluded the framework defaults (`:db` `:event` `:frame` `:source`
+  `:trace-id`). Per rf2-9dk9y the stamp lives on `:run-end`, not
+  `:do-fx`, because do-fx never fires for handlers that return only
+  `:db` and no `:fx`."
   []
   (let [dispatch-id 110
         id-base     60
@@ -448,13 +451,13 @@
             :rf.trace/call-site
             {:file "src/cart/events.cljs" :line 211})
      {:id (+ id-base 2) :op-type :rf.event :operation :rf.event/run-end
-      :tags (assoc tag :rf.trace/phase :run-end :duration-ms 7)}
-     {:id (+ id-base 3) :op-type :rf.fx :operation :rf.fx/do-fx
-      :tags (assoc tag :rf.event/fx [[:db nil]]
-                       :rf.event/db-present? true
+      :tags (assoc tag :rf.trace/phase :run-end :duration-ms 7
                        :rf.event/coeffects {:now "2026-05-18T19:00:00Z"
                                    :local-storage {:user/last-cart-id "cart-42"
                                                    :user/wishlist-ids #{"sku-9"}}})}
+     {:id (+ id-base 3) :op-type :rf.fx :operation :rf.fx/do-fx
+      :tags (assoc tag :rf.event/fx [[:db nil]]
+                       :rf.event/db-present? true)}
      {:id (+ id-base 4) :op-type :rf.fx :operation :rf.fx/handled
       :tags (assoc tag :rf.fx/id :db :duration-ms 1)}]))
 

--- a/tools/xray/testbeds/panel_gallery/gallery_event.cljs
+++ b/tools/xray/testbeds/panel_gallery/gallery_event.cljs
@@ -272,14 +272,16 @@
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
 
-  ;; ----- 18. event-lens user-injected COEFFECTS (rf2-jhhqt) ------------
+  ;; ----- 18. event-lens user-injected COEFFECTS (rf2-jhhqt, rf2-9dk9y) -
   (story/reg-variant :story.xray.event/lens-with-coeffects
     {:doc        "Event lens with the §3 COEFFECTS section populated by
                  two user-injected coeffects (`:now` + `:local-storage`)
-                 stamped on `:rf.fx/do-fx :tags :coeffects`. The
-                 substrate has already filtered the framework defaults
-                 (`:db` `:event` `:frame` `:source` `:trace-id`) so the
-                 panel just renders what arrived."
+                 stamped on `:rf.event/run-end :tags :rf.event/coeffects`
+                 (rf2-9dk9y — the stamp lives on run-end, not do-fx,
+                 because do-fx never fires for handlers that return only
+                 `:db`). The substrate has already filtered the
+                 framework defaults (`:db` `:event` `:frame` `:source`
+                 `:trace-id`) so the panel just renders what arrived."
      :events     [[:rf.xray/sync-trace-buffer (fixtures/event-lens-with-coeffects-buffer)]
                   [:rf.xray/select-dispatch-id 110 nil]]
      :tags       #{:dev :state/small}


### PR DESCRIPTION
## Summary

Per audit bead **rf2-ge2oe.2**: the `event-lens-with-coeffects-buffer` fixture in panel_gallery was still stamping `:rf.event/coeffects` on the `:rf.fx/do-fx` trace. Per **rf2-9dk9y** the substrate stamp moved to `:rf.event/run-end` (because do-fx never fires for handlers that return only `:db` and no `:fx`).

Consequence: the `:story.xray.event/lens-with-coeffects` gallery variant silently rendered no COEFFECTS section — defeating its documented purpose.

## Change

`tools/xray/testbeds/panel_gallery/fixtures.cljs`:
- Move `:rf.event/coeffects` from the do-fx trace (id-base+3) onto the run-end trace (id-base+2).
- Update fn docstring to cite rf2-9dk9y and the new stamp location.

`tools/xray/testbeds/panel_gallery/gallery_event.cljs`:
- Update the `:story.xray.event/lens-with-coeffects` variant `:doc` to reference the new stamp location.

## Rationale

- Impl reference (`tools/xray/src/day8/re_frame2_xray/panels/event_detail.cljs:536`) reads from the cascade's `:handler` slot (= run-end trace) — confirms the contract.
- CLJS gold-standard helper `cascade-evs` in `event_detail_cljs_test.cljs:105` already stamps `:rf.event/coeffects` on run-end.
- No production impact, no test impact — gallery-only fixture drift.

## Acceptance

- Gallery variant `:story.xray.event/lens-with-coeffects` will now render the COEFFECTS section with `:now` + `:local-storage` rows.
- Fixture + variant doc updated to reference `:rf.event/run-end` (rf2-9dk9y).

## Gates

- `cd tools/xray && clojure -M:test` — 859 tests / 3199 assertions / 0 failures
- `npm run test:xray-feature-gate` — 13 scenarios / 0 failures
- `npm run test:cljs` — passes on rebased branch (the 4 edn-inspector layout failures observed earlier were already fixed upstream by `4aa5252fe`; my diff only touches gallery files)

Closes rf2-ge2oe.2.