### PR TITLE
feat(xray): COEFFECTS row two-line shape per spec/021 §2.2 (rf2-ge2oe.1)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/event_detail.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/event_detail.cljs
@@ -538,34 +538,62 @@
       m)))
 
 (defn- coeffect-row
-  "One COEFFECTS row: `<id>  <chip?>  <value>`. Per rf2-xw7mj the
-  cofx-id renders alongside an `external-link` click-to-source chip
-  whenever the registered `reg-cofx` carries a captured source-coord
-  (`(rf/handler-meta :cofx id)`); the chip is omitted when the registry
-  lookup yields no `:file` (e.g. framework-default cofx or one
-  registered without coord capture). Matches the Figma authority's
-  click-to-source treatment for COEFFECTS coeffect-name links."
+  "One COEFFECTS row, rendered in the two-line diff-idiom shape per
+  spec/021 §2.2 (lines 295-300) + design-reference §2 COEFFECTS:
+
+      :now ↗
+        + [:now]  #inst \"2026-05-23T12:30:05.123Z\"
+      :session ↗
+        + [:session]  {:user-id 42, :token \"...\"}
+
+  Line 1 is the id-row — `<id> <chip?>` rendered in the accent (link)
+  colour, with the unified `external-link` click-to-source chip beside
+  the id when the registered cofx carries a captured source-coord
+  (rf2-xw7mj). Line 2 is the add-row — `+ [<id>] <value>` in the same
+  EDN-diff idiom APP-DB CHANGES (`+ [path] value`) + AFTER INTERCEPTORS
+  (`ctx-delta-row`) use: `+` glyph in `:green`, `[<id>]` path-form
+  repetition in `:text-tertiary`, value in `:text-primary` rendered via
+  the §10 EDN widget. The path-form repetition is intentional — it
+  teaches that each user-injected coeffect adds the value at `[<id>]`
+  in the handler's coeffects map, the diff-glyph ties COEFFECTS visually
+  to APP-DB CHANGES (both are 'added to ctx' lines), and the indent
+  scales gracefully to multi-line / nested values where the prior
+  single-line shape crammed the value next to the id."
   [id value]
   (let [suffix     (interceptor-testid-suffix id)
         cofx-meta  (when (keyword? id) (rf/handler-meta :cofx id))
         coord      (when (and cofx-meta (string? (:file cofx-meta)))
                      {:file (:file cofx-meta) :line (:line cofx-meta)})]
     [:div {:data-testid (str "rf-xray-event-detail-coeffect-row-" suffix)
-           :style {:display "flex"
-                   :align-items "flex-start"
-                   :padding "2px 0"}}
-     [:span {:style {:display      "inline-flex"
-                     :align-items  "center"
-                     :color        (:accent tokens)
-                     :min-width    "180px"
-                     :margin-right "12px"}}
+           :style {:padding "2px 0"}}
+     ;; Line 1 — id + click-to-source chip (link styling).
+     [:div {:style {:display      "inline-flex"
+                    :align-items  "center"
+                    :color        (:accent tokens)}}
       (pr-str id)
       (coord-chip coord (str "rf-xray-event-detail-coeffect-open-chip-" suffix))]
-     [:span {:style {:color (:text-primary tokens)
-                     :min-width 0
-                     :flex 1
-                     :word-break "break-word"}}
-      (edn/inspect value (str "event-detail/coeffect/" suffix))]]))
+     ;; Line 2 — `+ [<id>]  <value>` add-row, mirroring the diff-glyph
+     ;; idiom shared with APP-DB CHANGES / AFTER INTERCEPTORS / FLOWS.
+     [:div {:data-testid (str "rf-xray-event-detail-coeffect-add-row-" suffix)
+            :style {:display      "flex"
+                    :align-items  "flex-start"
+                    :padding      "1px 0 1px 24px"}}
+      [:span {:data-testid (str "rf-xray-event-detail-coeffect-add-glyph-" suffix)
+              :style {:color       (:green tokens)
+                      :font-weight 700
+                      :margin-right "8px"
+                      :min-width   "10px"}}
+       "+"]
+      [:span {:data-testid (str "rf-xray-event-detail-coeffect-add-path-" suffix)
+              :style {:color        (:text-tertiary tokens)
+                      :margin-right "8px"
+                      :min-width    "0"}}
+       (str "[" (pr-str id) "]")]
+      [:span {:style {:color      (:text-primary tokens)
+                      :min-width  0
+                      :flex       1
+                      :word-break "break-word"}}
+       (edn/inspect value (str "event-detail/coeffect/" suffix))]]]))
 
 (defn- coeffects-body
   "Step COEFFECTS body — one row per user-injected coeffect. Returns

--- a/tools/xray/test/day8/re_frame2_xray/panels/event_detail_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/event_detail_cljs_test.cljs
@@ -1316,6 +1316,59 @@
         (is (some? (find-by-testid tree "rf-xray-event-detail-coeffect-row-local-storage"))
             ":local-storage row rendered")))))
 
+(deftest coeffect-row-renders-two-line-diff-idiom-shape
+  (testing "rf2-ge2oe.1 — per spec/021 §2.2 (lines 295-300) +
+            design-reference §2 COEFFECTS, each user-injected coeffect
+            renders as a TWO-LINE block:
+              line 1 — `<id> ↗`  (id + click-to-source chip)
+              line 2 — `+ [<id>]  <value>`  (diff-glyph idiom)
+            mirroring the `+ [path] value` shape APP-DB CHANGES + AFTER
+            INTERCEPTORS use. The single-line shape was impl drift."
+    (seed-buffer!
+      (cascade-evs 100 [:cart/restore] 0
+                   {:coeffects {:now "2026-05-18T19:00:00Z"}}))
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/select-dispatch-id 100])
+      (let [tree (event-detail/Panel)]
+        (is (some? (find-by-testid tree "rf-xray-event-detail-coeffect-row-now"))
+            "line 1 (id-row) still rendered with the original testid")
+        (is (some? (find-by-testid tree "rf-xray-event-detail-coeffect-add-row-now"))
+            "line 2 (add-row) rendered with the new testid")
+        (is (some? (find-by-testid tree "rf-xray-event-detail-coeffect-add-glyph-now"))
+            "`+` diff-glyph rendered on line 2")
+        (is (= "+"
+               (let [glyph (find-by-testid
+                             tree "rf-xray-event-detail-coeffect-add-glyph-now")]
+                 (last glyph)))
+            "diff-glyph is the `+` (added) marker, matching APP-DB CHANGES")
+        (let [path-node (find-by-testid
+                          tree "rf-xray-event-detail-coeffect-add-path-now")]
+          (is (some? path-node)
+              "path-form `[<id>]` rendered on line 2")
+          (is (= "[:now]" (last path-node))
+              "path-form encodes the cofx id in vector brackets — signals
+               'value lives at this path in ctx', matching the
+               `+ [path] value` shape of APP-DB CHANGES"))))))
+
+(deftest coeffect-row-add-row-renders-for-qualified-keyword-ids
+  (testing "rf2-ge2oe.1 — the two-line shape's per-row testid suffix
+            uses the same `interceptor-testid-suffix` scheme the line-1
+            row uses, so qualified-keyword cofx ids (e.g. :auth/token)
+            still match through to the add-row + glyph + path testids."
+    (seed-buffer!
+      (cascade-evs 100 [:checkout/submit] 0
+                   {:coeffects {:auth/token "tok-abc"}}))
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/select-dispatch-id 100])
+      (let [tree (event-detail/Panel)]
+        (is (some? (find-by-testid tree "rf-xray-event-detail-coeffect-add-row-auth/token")))
+        (is (some? (find-by-testid tree "rf-xray-event-detail-coeffect-add-glyph-auth/token")))
+        (let [path-node (find-by-testid
+                          tree "rf-xray-event-detail-coeffect-add-path-auth/token")]
+          (is (some? path-node))
+          (is (= "[:auth/token]" (last path-node))
+              "path-form preserves qualified-keyword rendering"))))))
+
 (deftest coeffect-row-renders-external-link-chip-when-cofx-has-source-coord
   (testing "rf2-xw7mj — when the registered cofx carries a captured
             source-coord on its handler-meta, the COEFFECTS row renders


### PR DESCRIPTION
Closes rf2-ge2oe.1.

Surfaced by the rf2-ge2oe audit. The Event panel's COEFFECTS section
rendered single-line `<id ↗>  <value>`; spec/021 §2.2 (lines 295-300) +
`tools/xray/design-reference/xray_devtools_reference.cljs` (lines 429-
449) call for a two-line block per coeffect:

```
:now ↗
  + [:now]      #inst "2026-05-23T12:30:05.123Z"
:session ↗
  + [:session]  {:user-id 42, :token "..."}
```

i.e. id-row on line 1 (link styling + click-to-source chip) + a
`+ [<id>]  <value>` add-row on line 2 in the EDN-diff idiom shared
with APP-DB CHANGES (`+ [path] value`) and AFTER INTERCEPTORS
(`ctx-delta-row`).

## Why

The single-line shape collapsed three signal-carrying pieces of the
design idiom:

- The `+` glyph that links COEFFECTS visually to APP-DB CHANGES (both
  are "added to ctx" lines).
- The `[<id>]` path-form repetition that mirrors APP-DB CHANGES + AFTER
  INTERCEPTORS ctx-delta + FLOWS write-paths.
- The visual breathing room of the two-line layout — scales gracefully
  to multi-line / nested values where the prior shape crammed the value
  next to the id.

## Style tokens

Match the diff-idiom convention already used by `ctx-delta-row`:
`:green` for the `+` glyph, `:text-tertiary` for `[<id>]`,
`:text-primary` for the value rendered through the §10 EDN widget.

## Helper reuse

No shared helper was factored. The diff-glyph idiom across APP-DB
CHANGES / AFTER INTERCEPTORS / FLOWS / COEFFECTS varies enough in shape
(`[segment/key]` vs `[<path>]` vs `[<id>]` vs `wrote/read` per-flow
prefix) that a single primitive would obscure the per-section
specifics. Per the bead's "keep minimal — this is one cosmetic fix,
not a refactor", `coeffect-row` grew inline.

## Testids

Line 1 keeps the existing outer testid (`coeffect-row-<suffix>`) + the
existing chip testid (`coeffect-open-chip-<suffix>`), so prior tests
are unaffected. Line 2 adds three new testids under the same
`interceptor-testid-suffix` scheme:

- `rf-xray-event-detail-coeffect-add-row-<suffix>`
- `rf-xray-event-detail-coeffect-add-glyph-<suffix>`
- `rf-xray-event-detail-coeffect-add-path-<suffix>`

## Tests

Added:

- `coeffect-row-renders-two-line-diff-idiom-shape` — asserts both
  row testids + the `+` glyph + the `[<id>]` path-form content.
- `coeffect-row-add-row-renders-for-qualified-keyword-ids` — asserts
  the testid suffix scheme + path-form rendering survives for
  qualified-keyword cofx ids.

Existing rendering / chip / qualified-keyword / silent-by-default
tests continue to pass.

## Gates

- `npm run test:cljs` — green for event-detail (4 pre-existing
  edn-inspector alignment failures from rf2-pdeeb being addressed in
  parallel; not on this surface).
- `clojure -M:test` from `tools/xray/` — 859 tests, 0 failures.
- `npm run test:xray-feature-gate` — 13 scenarios, 0 failures.