### PR TITLE
feat(xray): edn-inspector zoom-into-node + breadcrumb navigation (rf2-h71e0)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1950,6 +1950,136 @@ internal:
 Consumer adoption is per-panel and case-by-case; this section
 documents the contract, not a blanket migration.
 
+#### §10.0.11 `:zoomable?` opt — zoom-into-node + breadcrumb (rf2-h71e0)
+
+Dense app-db trees force the operator to scroll past chrome AND every
+intermediate level just to see one deep subtree. Sticky expansion
+(rf2-pvsxs / §10.0.6) only solves part of this — even when the path is
+fully expanded the surrounding tree consumes screen real-estate and
+visual attention.
+
+Zoom-into-node turns the inspector into a focused window onto an
+arbitrary subtree. The operator clicks the `⊙` zoom affordance on any
+container; that node becomes the root of the displayed tree. A
+breadcrumb trail at the top shows the path from the original root;
+clicking any segment zooms back to that level. Anchors to known mental
+models — Chrome devtools' object inspector + nav, React devtools'
+selected-component focus, IDE nav-to-symbol + back, file browsers'
+breadcrumb drill-in.
+
+**Surface** — one new opt on the existing `[edn-inspector value opts]`:
+
+| `:zoomable?` value | Behaviour                                                                               |
+|--------------------|-----------------------------------------------------------------------------------------|
+| `false` (default)  | No affordance, no breadcrumb — widget renders as today (back-compat).                   |
+| `true`             | Every non-empty non-root container gets a `⊙` affordance; breadcrumb renders if zoomed. |
+
+**Affordance glyph** — `⊙` (circled-dot, U+2299). Reads as "focus / aim
+cursor at this node" — visually distinct from the popup affordance (`↗`,
+"open in new pane"), the expand triangles (`▸`/`▾`), and the breadcrumb
+separator (`›`). Single codepoint, theme-token coloured (`:text-tertiary`
+at 0.55 resting opacity, hover bumps to `:text-secondary` via the
+`data-rf-affordance="zoom"` selector in the global stylesheet).
+
+**Breadcrumb structure** — when a zoom is active, a row above the body
+renders `<home> › <seg1> › <seg2> › …`. Each segment is a clickable
+button; click dispatches `:zoom-to` with a TRUNCATED prefix of the zoom
+path:
+
+- **Home segment** — content is the consumer's `:header` hiccup if
+  supplied (the §10.0.10 path — reuses the existing "header is the
+  natural identity label" choice). Falls back to a generic "root"
+  string. Click dispatches `:zoom-to ... []` (clears the zoom).
+- **Segment N** — content is the path-segment label, rendered through
+  the same syntax-palette as the renderer's key column (keyword
+  magenta, integer orange, string green, …). Click dispatches
+  `:zoom-to ... (subvec path 0 (inc N))` — truncates to depth N+1.
+
+**State shape** — per-mount, mirrors the §10.0.6 expansion-slot
+pattern:
+
+```
+:rf.xray.edn-inspector/zoom
+  {[<panel-id> <site-or-mount-id>] <zoom-path-vec>
+   ...}
+```
+
+A `nil` / empty / missing entry renders the un-zoomed full tree.
+Per-mount keying makes two side-by-side mounts zoom independently; a
+stable `:site-id` (§10.0.6) preserves the zoom across a panel-leave-
+and-return round-trip (App-DB tab switching, focused-event re-mount).
+
+**Events**
+
+| Event id                                  | Payload                              | Action                                                                              |
+|-------------------------------------------|--------------------------------------|-------------------------------------------------------------------------------------|
+| `:rf.xray.edn-inspector/zoom-to`          | `panel-id mount-id absolute-path`    | Set zoom path; empty path clears the entry.                                         |
+| `:rf.xray.edn-inspector/zoom-up`          | `panel-id mount-id`                  | Pop one segment off the zoom path; popping past root clears.                        |
+| `:rf.xray.edn-inspector/zoom-reset`       | `[panel-id mount-id]` (both optional) | With args: clear that mount's entry only. Without args: clear the whole slot.       |
+
+**Sub** — `[:rf.xray.edn-inspector/zoom]` reads the slot as a map.
+Pure helpers `resolve-zoom-path` + `resolve-zoom-into` project the
+map for a given mount into either the stored path vector or the
+resolved sub-value (used by the widget's render-time `get-in` walk).
+
+**Keyboard navigation** — Esc (when the widget has focus AND a zoom is
+active) dispatches `:zoom-up`. The handler is installed on the outer
+container only while `zoom-active?` is true, so unzoomed mounts let
+Esc bubble unchanged. Coordinates with the popup widget's Esc-closes-
+top (rf2-7sdja): the popup's own keydown handler lives on its
+backdrop + dialog and `stopPropagation`s, so an open popup intercepts
+Esc first; subsequent Esc presses (no popup) reach the inspector's
+handler and zoom up.
+
+**Composition with other opts** —
+
+- **`:popup-affordance?`** — independent. Both affordances render
+  side-by-side when both opts are present — they serve different
+  intents (zoom = focus here without opening a new pane; popup = open
+  the value in a roomier modal). Inside a popup the inner inspector
+  recurses with `:popup-affordance? false` (§10.0.7.2) but
+  `:zoomable?` survives the recursion so the popup body is itself
+  zoom-navigable.
+- **`:before` (diff mode)** — zoom is SUPPRESSED in diff mode. The
+  widget self-detects (`zoom-active? = zoomable? AND NOT diff? AND
+  zoom-path non-empty`) and renders the full value with the gutter
+  glyphs as today. Rationale: diff's force-expand-over-changed-
+  descendants logic and zoom's hide-everything-outside-the-subtree are
+  conflicting intents; operators view diffs over the full value.
+- **`:header`** — the hiccup feeds the breadcrumb home segment when
+  zoomed (`home-label`).
+- **`:default-expanded-depth`** / **`:max-depth`** — applied to the
+  zoomed subtree as if it were the root (depth counter restarts at
+  `0` from the zoom point). Operator's mental model: "the zoom IS the
+  new root."
+
+**Where to opt in** — per the bead's audit:
+
+- **App-DB** — the canonical consumer. Dense top-level trees benefit
+  hugely from focusing on a single subtree; the breadcrumb keeps the
+  operator's bearings. Per-section mount (user-domain TOP + every
+  `:rf/*` area) opts in.
+- **Handler/Event** — db-before / db-after / fx / coeffects mounts each
+  benefit. Operator clicks deep into one slot to focus the comparison.
+- **Machine snapshot drill-in** — operator can zoom into a particular
+  snapshot path; the breadcrumb anchors the navigation across
+  successive snapshots.
+
+**Where NOT to opt in** —
+
+- **`mini` inline renders** — too small to be useful; the inline span
+  has no room for the affordance.
+- **Trace expanded payloads** — the trace row already carries its own
+  per-row layout; zoom inside a row would conflict.
+- **Inspector-card titles / chip mounts** — single-level renders never
+  need zoom.
+
+**Skipped affordance** — the root of the displayed subtree (relative
+path `[]`) never renders the affordance; zooming into the current
+zoom root is a no-op. The renderer composes the absolute path as
+`(into zoom-path-prefix path)` so the dispatched `:zoom-to` carries the
+full path from the ORIGINAL root, not the currently-displayed root.
+
 ### §10.1 Capabilities (LOCKED per B.9 super-prompt)
 
 1. **Lazy collapsible tree** — hierarchical EDN with expand/collapse.

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs
@@ -165,6 +165,13 @@
         ;; affordance so the operator sees them as discrete inspector
         ;; cards.
         :card? true
+        ;; rf2-h71e0 — App-DB is the canonical zoom-into-node consumer.
+        ;; Dense top-level trees benefit hugely from focusing on a
+        ;; single subtree; the breadcrumb row keeps the operator's
+        ;; bearings. Diff mode (`before` present) suppresses zoom
+        ;; resolution because diff's force-expand-over-changes logic
+        ;; and zoom's hide-everything-outside-the-subtree conflict.
+        :zoomable? true
         :header title}]
       [ei/edn-inspector
        (f/display-value value)
@@ -173,6 +180,11 @@
         :default-expanded-depth 3
         :before (f/display-value before)
         :card? true
+        ;; rf2-h71e0 — zoomable opt is preserved here for symmetry;
+        ;; the widget self-suppresses zoom resolution in diff mode so
+        ;; the affordance + breadcrumb stay off until the operator
+        ;; returns to current-state (non-diff) browse.
+        :zoomable? true
         :header title}])))
 
 ;; ---- top (user-domain) section ------------------------------------------

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
@@ -135,6 +135,32 @@
                     its own surface chrome, so `:card?` is usually
                     redundant when `:header` is present).
 
+  - `:zoomable?`     (optional, default false) — rf2-h71e0; when true
+                    every container in the tree renders a `⊙` zoom-
+                    affordance button next to the expand triangle.
+                    Click dispatches
+                    `[:rf.xray.edn-inspector/zoom-to panel-id mount-id
+                    absolute-path]`, which stores the absolute path
+                    under `:rf.xray.edn-inspector/zoom` keyed by
+                    `[panel-id site-or-mount-id]`. The widget then
+                    renders ONLY the subtree at that path, with a
+                    breadcrumb row above the body showing the path
+                    from the original root (each segment clickable for
+                    one-tap zoom-up).
+                    Esc (when the widget has focus AND a zoom is
+                    active) pops one level off the zoom stack.
+                    Composes with `:popup-affordance?` (both
+                    affordances render side-by-side — they serve
+                    different intents: zoom = focus here; popup = open
+                    in new pane). Diff mode (`:before` present)
+                    suppresses zoom resolution — the diff path's
+                    force-expand-over-changed-descendants logic and
+                    zoom's hide-everything-outside-the-subtree are
+                    conflicting intents; operators view diffs over the
+                    full value. Per-mount keying matches the
+                    expansion-slot pattern; pass a stable `:site-id`
+                    to survive a panel-leave-and-return round-trip.
+
   Drop the `:render-id` arg from the old facade — mount-id is now
   auto-generated internally per D4=a (rf2-sndui).
 
@@ -299,6 +325,107 @@
     (if (and (string? mount-id) (some-> db (get widths-slot) (contains? mount-id)))
       (update db widths-slot dissoc mount-id)
       db)))
+
+;; =========================================================================
+;; zoom-into-node + breadcrumb navigation (rf2-h71e0)
+;; =========================================================================
+;;
+;; Zoom turns the inspector into a focused window onto an arbitrary subtree.
+;; Operator clicks the `⊙` zoom affordance on any container; that node
+;; becomes the root of the displayed tree. A breadcrumb trail at the top
+;; shows the path from the original root; clicking any segment zooms back
+;; to that level.
+;;
+;; State shape mirrors `expansion-slot` — keyed by `[panel-id site-or-
+;; mount-id]` so two side-by-side mounts zoom independently and a stable
+;; `:site-id` (rf2-pvsxs) preserves the zoomed view across a panel-
+;; leave-and-return round-trip:
+;;
+;;   {[:rf.xray/app-db [:rf.xray/app-db "top"]] [:cart :items]
+;;    [:rf.xray/handler "mount-uuid-…"]         []}
+;;
+;; An entry with `nil` or `[]` value renders the full tree (no zoom). The
+;; sub `:rf.xray.edn-inspector/zoom-path` reads the slot; events
+;; `:zoom-to`, `:zoom-up`, `:zoom-reset` mutate it.
+
+(def zoom-slot
+  "App-db slot holding the per-mount zoom path overrides. Public so the
+  consuming panel's reset affordance can clear it.
+
+  Mirrors `expansion-slot`'s shape — a map keyed by `[panel-id site-or-
+  mount-id]` with a path vector as the value (the path within the
+  original value that becomes the current zoom root). Empty / missing
+  entries render the full tree."
+  :rf.xray.edn-inspector/zoom)
+
+(defn zoom-key
+  "Compose the per-mount zoom key — `[panel-id site-or-mount-id]`. Pure
+  data, JVM-portable. Distinct from `expansion-key`'s three-element shape
+  because zoom is per-mount (one zoom root), not per-node (one expansion
+  override per path)."
+  [panel-id mount-id]
+  [panel-id mount-id])
+
+(rf/reg-sub zoom-slot
+  (fn [db _] (get db zoom-slot)))
+
+(rf/reg-event-db :rf.xray.edn-inspector/zoom-to
+  ;; Sets the zoom path for `[panel-id mount-id]` to `path`. An empty /
+  ;; nil path clears the zoom (renders the full tree).
+  (fn [db [_ panel-id mount-id path]]
+    (let [k (zoom-key panel-id mount-id)
+          p (vec path)]
+      (if (seq p)
+        (assoc-in db [zoom-slot k] p)
+        (update db zoom-slot dissoc k)))))
+
+(rf/reg-event-db :rf.xray.edn-inspector/zoom-up
+  ;; Pop one segment off the zoom path. No-op when no zoom is active.
+  (fn [db [_ panel-id mount-id]]
+    (let [k        (zoom-key panel-id mount-id)
+          current  (get-in db [zoom-slot k])
+          popped   (when (seq current) (vec (butlast current)))]
+      (cond
+        (nil? current)   db
+        (empty? popped)  (update db zoom-slot dissoc k)
+        :else            (assoc-in db [zoom-slot k] popped)))))
+
+(rf/reg-event-db :rf.xray.edn-inspector/zoom-reset
+  ;; Clear the zoom for a specific mount. With no args (mount-unspecified)
+  ;; clear the entire slot — used by the panel-level reset affordance.
+  (fn [db [_ panel-id mount-id]]
+    (cond
+      (and panel-id mount-id)
+      (update db zoom-slot dissoc (zoom-key panel-id mount-id))
+
+      :else
+      (dissoc db zoom-slot))))
+
+(defn resolve-zoom-path
+  "Pure projection — given the per-render zoom map, return the zoom
+  path for this mount (vector of segments) or `nil` for the default no-
+  zoom state. Public so tests + render-time consumers can drive the
+  decision deterministically."
+  [zoom-map panel-id mount-id]
+  (let [v (get zoom-map (zoom-key panel-id mount-id))]
+    (when (seq v) (vec v))))
+
+(defn resolve-zoom-into
+  "Pure projection — given the original `value` and the zoom map for a
+  mount, return the value the widget should display. Walks `get-in`
+  along the stored zoom path; falls back to the original value when the
+  path is empty / nil / no-longer-resolvable (a value mutated out from
+  under a stale zoom). Public so callers can probe the resolution
+  without re-deriving the walk."
+  [value zoom-map panel-id mount-id]
+  (let [path (resolve-zoom-path zoom-map panel-id mount-id)]
+    (cond
+      (nil? path)   value
+      (empty? path) value
+      :else
+      (let [resolved (try (get-in value path ::no-resolve)
+                          (catch :default _ ::no-resolve))]
+        (if (= resolved ::no-resolve) value resolved)))))
 
 (defn resolve-expanded?
   "Pure projection — given the per-render expansion map, the path,
@@ -1251,6 +1378,12 @@
 
 (declare render-inline-recursive)
 
+;; rf2-h71e0 — forward declaration for the zoom affordance button
+;; rendered inside `render-container`'s header row. The definition
+;; lives further down alongside the breadcrumb component + popup
+;; affordance (all three are top-level chrome surfaces).
+(declare zoom-affordance-button)
+
 (defn- render-inline-pair
   "Render a single map / record entry `[k v]` as a key+value sequence
   for the inline render path. Returns a seq of hiccup fragments (no
@@ -1322,9 +1455,18 @@
                    when called outside a registered view (test/REPL).
    - diff? / before — when diff? true the renderer paints gutter rows,
                       annotates changed leaves, and force-expands the
-                      ancestor chain over any changed descendant."
+                      ancestor chain over any changed descendant.
+   - zoomable? / zoom-path-prefix — when zoomable? true (rf2-h71e0), the
+                                    container renders a `⊙` zoom-in
+                                    affordance next to the expand
+                                    triangle. zoom-path-prefix is the
+                                    absolute path of the CURRENT zoom
+                                    root within the original value; the
+                                    affordance dispatches with `(into
+                                    zoom-path-prefix path)` so the
+                                    zoom-slot stores the full path."
   [{:keys [value kind panel-id mount-id path depth expansion-map opts
-           dispatch-fn diff? before]}]
+           dispatch-fn diff? before zoomable? zoom-path-prefix]}]
   (let [{:keys [default-expanded-depth max-depth max-inline-width
                 available-width-px]
          :or {default-expanded-depth default-ceiling-depth
@@ -1390,7 +1532,23 @@
         toggle-fn     (on-toggle dispatch-fn panel-id mount-id path
                                  (boolean (and expanded? (not depth-capped?))))
         children      (when (and (not empty?) (not depth-capped?) expanded? (not inline-fit?))
-                        (children-of value))]
+                        (children-of value))
+        ;; rf2-h71e0 — zoom affordance is rendered next to the expand
+        ;; triangle on every non-empty container at a NON-ROOT relative
+        ;; path. The root (`[]`) skips the affordance because zooming
+        ;; into the current zoom root is a no-op. The button dispatches
+        ;; with the ABSOLUTE path = `(into zoom-path-prefix path)` so
+        ;; the zoom-slot stores the full path from the original root.
+        zoom-button   (when (and zoomable?
+                                 (not empty?)
+                                 (seq path))
+                        (zoom-affordance-button
+                          {:dispatch-fn   dispatch-fn
+                           :panel-id      panel-id
+                           :mount-id      mount-id
+                           :absolute-path (into (vec zoom-path-prefix) path)
+                           :testid        (str (testid-for panel-id mount-id path)
+                                               "-zoom-affordance")}))]
     [:div {:data-testid (testid-for panel-id mount-id path)
            :data-rf-kind (name kind)
            :data-rf-expanded (if expanded? "1" "0")
@@ -1411,20 +1569,21 @@
 
         ;; Depth-capped — render the placeholder ellipsis, click expands one level.
         depth-capped?
-        [:span {:style {:display "inline-flex" :align-items "center" :gap "4px"}}
-         [:span {:on-click   toggle-fn
-                 :role       "button"
-                 :tabindex   0
-                 :aria-expanded false
-                 :data-testid (str (testid-for panel-id mount-id path) "-toggle")
-                 ;; rf2-tzvk9 — ≥24×24 click target via the shared
-                 ;; `triangle-style` (padding + font-size + min-width/
-                 ;; -height).
-                 :style triangle-style}
-          "▸"]
-         (bracket kind :open value)
-         [:span {:style (token-style :text-tertiary)} "…"]
-         (bracket kind :close value)]
+        (cond-> [:span {:style {:display "inline-flex" :align-items "center" :gap "4px"}}
+                 [:span {:on-click   toggle-fn
+                         :role       "button"
+                         :tabindex   0
+                         :aria-expanded false
+                         :data-testid (str (testid-for panel-id mount-id path) "-toggle")
+                         ;; rf2-tzvk9 — ≥24×24 click target via the shared
+                         ;; `triangle-style` (padding + font-size + min-width/
+                         ;; -height).
+                         :style triangle-style}
+                  "▸"]]
+          zoom-button (conj zoom-button)
+          true        (conj (bracket kind :open value))
+          true        (conj [:span {:style (token-style :text-tertiary)} "…"])
+          true        (conj (bracket kind :close value)))
 
         ;; Small enough to render inline — open bracket + items + close
         ;; bracket on one row, NO toggle (already exposed). Maps /
@@ -1437,58 +1596,72 @@
         ;; the same inline span. The legacy strict path (scalar-only
         ;; children) still feeds the pre-measurement fallback.
         inline-fit?
-        (if width-fits?
-          (render-inline-recursive value)
-          (let [labelled? (#{:map :record :map-entry} kind)
-                pairs     (children-of value)]
-            (into [:span {:style {:display "inline-flex"
-                                  :align-items "baseline"
-                                  :flex-wrap "wrap"
-                                  :gap "4px"}}
-                   (bracket kind :open value)]
-                  (concat
-                    (apply concat
-                           (map-indexed
-                             (fn [i [k cv]]
-                               (let [sep (when (pos? i)
-                                           [:span {:style (token-style :text-tertiary)} ", "])
-                                     ks  (when labelled? (key-segment k))
-                                     sp  (when labelled?
-                                           [:span {:style (token-style :text-tertiary)} " "])]
-                                 (cond-> []
-                                   sep (conj sep)
-                                   ks  (conj ks)
-                                   sp  (conj sp)
-                                   true (conj (render-scalar cv)))))
-                             pairs))
-                    [(bracket kind :close value)]))))
+        (let [inline-render
+              (if width-fits?
+                (render-inline-recursive value)
+                (let [labelled? (#{:map :record :map-entry} kind)
+                      pairs     (children-of value)]
+                  (into [:span {:style {:display "inline-flex"
+                                        :align-items "baseline"
+                                        :flex-wrap "wrap"
+                                        :gap "4px"}}
+                         (bracket kind :open value)]
+                        (concat
+                          (apply concat
+                                 (map-indexed
+                                   (fn [i [k cv]]
+                                     (let [sep (when (pos? i)
+                                                 [:span {:style (token-style :text-tertiary)} ", "])
+                                           ks  (when labelled? (key-segment k))
+                                           sp  (when labelled?
+                                                 [:span {:style (token-style :text-tertiary)} " "])]
+                                       (cond-> []
+                                         sep (conj sep)
+                                         ks  (conj ks)
+                                         sp  (conj sp)
+                                         true (conj (render-scalar cv)))))
+                                   pairs))
+                          [(bracket kind :close value)]))))]
+          (if zoom-button
+            ;; rf2-h71e0 — wrap the inline render in a flex span so the
+            ;; zoom button sits next to (and aligned with) the inline
+            ;; content. The inline-fit path has no toggle triangle, so
+            ;; the affordance leads.
+            [:span {:style {:display "inline-flex"
+                            :align-items "baseline"
+                            :gap "4px"}}
+             zoom-button
+             inline-render]
+            inline-render))
 
         ;; Default — toggle glyph + open bracket (when expanded) OR summary.
         expanded?
-        [:span {:style {:display "inline-flex" :align-items "center" :gap "4px"}}
-         [:span {:on-click   toggle-fn
-                 :role       "button"
-                 :tabindex   0
-                 :aria-expanded true
-                 :data-testid (str (testid-for panel-id mount-id path) "-toggle")
-                 ;; rf2-tzvk9 — ≥24×24 click target via the shared
-                 ;; `triangle-style`.
-                 :style triangle-style}
-          "▾"]
-         (bracket kind :open value)]
+        (cond-> [:span {:style {:display "inline-flex" :align-items "center" :gap "4px"}}
+                 [:span {:on-click   toggle-fn
+                         :role       "button"
+                         :tabindex   0
+                         :aria-expanded true
+                         :data-testid (str (testid-for panel-id mount-id path) "-toggle")
+                         ;; rf2-tzvk9 — ≥24×24 click target via the shared
+                         ;; `triangle-style`.
+                         :style triangle-style}
+                  "▾"]]
+          zoom-button (conj zoom-button)
+          true        (conj (bracket kind :open value)))
 
         :else
-        [:span {:style {:display "inline-flex" :align-items "center" :gap "6px"}}
-         [:span {:on-click   toggle-fn
-                 :role       "button"
-                 :tabindex   0
-                 :aria-expanded false
-                 :data-testid (str (testid-for panel-id mount-id path) "-toggle")
-                 ;; rf2-tzvk9 — ≥24×24 click target via the shared
-                 ;; `triangle-style`.
-                 :style triangle-style}
-          "▸"]
-         (collapsed-summary value kind)])]
+        (cond-> [:span {:style {:display "inline-flex" :align-items "center" :gap "6px"}}
+                 [:span {:on-click   toggle-fn
+                         :role       "button"
+                         :tabindex   0
+                         :aria-expanded false
+                         :data-testid (str (testid-for panel-id mount-id path) "-toggle")
+                         ;; rf2-tzvk9 — ≥24×24 click target via the shared
+                         ;; `triangle-style`.
+                         :style triangle-style}
+                  "▸"]]
+          zoom-button (conj zoom-button)
+          true        (conj (collapsed-summary value kind))))]
 
      ;; ---- body — children rendered indented -----------------------------
      ;;
@@ -1571,6 +1744,8 @@
                                          :depth (inc depth)
                                          :expansion-map expansion-map
                                          :dispatch-fn dispatch-fn
+                                         :zoomable? zoomable?
+                                         :zoom-path-prefix zoom-path-prefix
                                          :opts opts})]
                        [(with-meta
                           ;; Key cell — uses `div` so the grid baseline
@@ -1613,6 +1788,8 @@
                                        :depth (inc depth)
                                        :expansion-map expansion-map
                                        :dispatch-fn dispatch-fn
+                                       :zoomable? zoomable?
+                                       :zoom-path-prefix zoom-path-prefix
                                        :opts opts})
                          {:key (str "v-" (pr-str k))})))
                    child-pairs)))))
@@ -1769,8 +1946,8 @@
 
   Public so unit tests can drive the renderer without mounting."
   [{:keys [value before diff? panel-id mount-id path depth expansion-map
-           dispatch-fn opts]
-    :or   {depth 0 path []}}]
+           dispatch-fn zoomable? zoom-path-prefix opts]
+    :or   {depth 0 path [] zoom-path-prefix []}}]
   (or
     ;; Protocol seam (rf2-0qrcr) — light-touch satisfies? gate; nil
     ;; result falls through to built-ins. Bound to the same testid
@@ -1807,6 +1984,8 @@
                              :depth depth
                              :expansion-map expansion-map
                              :dispatch-fn dispatch-fn
+                             :zoomable? zoomable?
+                             :zoom-path-prefix zoom-path-prefix
                              :opts opts
                              :diff? true
                              :before ::missing})
@@ -1823,6 +2002,8 @@
                              :depth depth
                              :expansion-map expansion-map
                              :dispatch-fn dispatch-fn
+                             :zoomable? zoomable?
+                             :zoom-path-prefix zoom-path-prefix
                              :opts opts
                              :diff? (boolean diff?)
                              :before before})
@@ -1887,6 +2068,200 @@
    ;; the colour change off the inline style avoids paint thrash on
    ;; every render.
    :opacity       0.6})
+
+;; =========================================================================
+;; zoom affordance + breadcrumb (rf2-h71e0)
+;; =========================================================================
+;;
+;; Two surfaces:
+;;
+;; 1. `zoom-affordance-button` — inline `⊙` button rendered next to the
+;;    expand triangle on every container when `:zoomable? true`. Click
+;;    dispatches `:zoom-to` with the node's ABSOLUTE path from the
+;;    original root (the renderer's per-node `:path` is RELATIVE to the
+;;    current zoom root, so the dispatch composes `zoom-path-prefix` +
+;;    `path` before storing).
+;;
+;; 2. `zoom-breadcrumbs` — segmented nav at the top of the inspector
+;;    when the zoom path is non-empty. First segment is the `:header`
+;;    hiccup (or generic "root" fallback); subsequent segments render
+;;    one key/index per zoom-path level. Each segment dispatches
+;;    `:zoom-to` with a TRUNCATED path so clicking segment N pops the
+;;    zoom back to N levels deep.
+
+(def ^:private zoom-affordance-glyph
+  ;; `⊙` (circled-dot) reads as "focus / aim cursor at this node" — the
+  ;; mental model the bead body identified (Chrome devtools' object
+  ;; inspector + nav, IDE nav-to-symbol). Visually distinct from the
+  ;; popup affordance (`↗` — "open in new pane"), the expand triangles
+  ;; (`▸`/`▾` — toggle), and the breadcrumb separator (`›`). Single
+  ;; codepoint, theme-token coloured.
+  "⊙")
+
+(def ^:private breadcrumb-separator
+  ;; `›` (single right-pointing angle) reads as nav direction — same
+  ;; convention as file-browser breadcrumbs + IDE path bars. Distinct
+  ;; from `→` (transition / arrow) and `>` (greater-than / blockquote).
+  "›")
+
+(def ^:private zoom-affordance-button-style
+  {:background    "transparent"
+   :border        "none"
+   :color         (:text-tertiary tokens)
+   :font-size     "13px"
+   :line-height   1
+   :cursor        "pointer"
+   :padding       "0 4px"
+   :margin        "0"
+   :border-radius "3px"
+   ;; Subtle by default — matches the popup affordance's resting opacity
+   ;; so the operator's eye reads "secondary affordance" at both glyphs.
+   ;; Theme-aware via the token resolution.
+   :opacity       0.55
+   :display       "inline-flex"
+   :align-items   "center"
+   :user-select   "none"})
+
+(defn zoom-affordance-button
+  "Inline `⊙` zoom-in button. Renders next to the expand triangle on
+  containers when `:zoomable? true`. Click dispatches `:zoom-to` with
+  the absolute path from the original root (composed by the caller as
+  `(into zoom-path-prefix path)`).
+
+  `dispatch-fn` is the lexically-captured frame-aware dispatcher (so the
+  event lands on the same frame the widget is mounted under). `panel-id`
+  + `mount-id` (or `site-id`) key the zoom slot. `absolute-path` is the
+  vec the reducer stores verbatim.
+
+  Public so unit tests can drive the button without mounting."
+  [{:keys [dispatch-fn panel-id mount-id absolute-path testid]}]
+  (let [dispatch-fn (or dispatch-fn rf/dispatch*)]
+    [:button
+     {:data-testid        testid
+      :data-rf-affordance "zoom"
+      :aria-label         "Zoom into this node"
+      :title              "Zoom into this node"
+      :on-click           (fn [^js e]
+                            (when e
+                              (.preventDefault e)
+                              (.stopPropagation e))
+                            (dispatch-fn
+                              [:rf.xray.edn-inspector/zoom-to
+                               panel-id mount-id (vec absolute-path)]))
+      :style              zoom-affordance-button-style}
+     zoom-affordance-glyph]))
+
+(defn- breadcrumb-segment-label
+  "Render a single path-segment label using the syntax-palette colour
+  that matches the segment's type. Reuses `key-segment` so coloured-
+  keyword / coloured-int / coloured-string segments paint consistently
+  with the renderer's leaf-key column.
+
+  Returns hiccup `[:span ...]`."
+  [seg]
+  (key-segment seg))
+
+(def ^:private breadcrumb-row-style
+  {:display       "flex"
+   :flex-wrap     "wrap"
+   :align-items   "baseline"
+   :gap           "4px"
+   :padding       "4px 8px"
+   :margin-bottom "6px"
+   :font-family   mono-stack
+   :font-size     "12px"
+   :line-height   1.4
+   :background    (:bg-2 tokens)
+   :border        (str "1px solid " (:border-subtle tokens))
+   :border-radius "4px"})
+
+(def ^:private breadcrumb-segment-button-style
+  {:background    "transparent"
+   :border        "none"
+   :cursor        "pointer"
+   :padding       "2px 4px"
+   :margin        "0"
+   :border-radius "3px"
+   :font-family   mono-stack
+   :font-size     "12px"
+   :line-height   1.4
+   :color         (:text-primary tokens)})
+
+(def ^:private breadcrumb-separator-style
+  {:color       (:text-tertiary tokens)
+   :font-size   "12px"
+   :user-select "none"})
+
+(defn zoom-breadcrumbs
+  "Render the breadcrumb nav above the zoomed inspector body.
+
+  - `panel-id` / `mount-id` — key the zoom slot the dispatch mutates.
+  - `zoom-path` — the current absolute zoom path (vec of segments).
+    Caller passes the resolved `[]`-or-nil for the no-zoom case; this
+    fn renders nothing when the path is empty.
+  - `home-label` — hiccup / string for the first (home) segment; the
+    consumer's `:header` value if present, else a generic `\"root\"`.
+  - `dispatch-fn` — frame-aware dispatcher (lexically captured by the
+    surrounding `reg-view`).
+  - `testid-prefix` — base for `data-testid` attrs on each segment.
+
+  Each segment dispatches `:zoom-to` with a TRUNCATED prefix of the
+  zoom path. Home segment dispatches with `[]` (clears zoom). Segment
+  N dispatches with `(subvec zoom-path 0 (inc N))`.
+
+  Public so unit tests can drive the breadcrumb without mounting the
+  full widget."
+  [{:keys [panel-id mount-id zoom-path home-label dispatch-fn testid-prefix]}]
+  (when (seq zoom-path)
+    (let [dispatch-fn   (or dispatch-fn rf/dispatch*)
+          testid-prefix (or testid-prefix "rf-xray-edn-inspector-breadcrumbs")
+          home-content  (cond
+                          (nil? home-label)    "root"
+                          (string? home-label) home-label
+                          :else                home-label)
+          on-click-to   (fn [next-path]
+                          (fn [^js e]
+                            (when e
+                              (.preventDefault e)
+                              (.stopPropagation e))
+                            (dispatch-fn
+                              [:rf.xray.edn-inspector/zoom-to
+                               panel-id mount-id (vec next-path)])))
+          home-button   [:button
+                         {:data-testid (str testid-prefix "-home")
+                          :data-rf-breadcrumb-segment "home"
+                          :on-click    (on-click-to [])
+                          :aria-label  "Zoom back to root"
+                          :title       "Zoom back to root"
+                          :style       breadcrumb-segment-button-style}
+                         home-content]
+          sep           [:span {:style breadcrumb-separator-style
+                                :data-rf-breadcrumb-separator "1"
+                                :aria-hidden true}
+                         breadcrumb-separator]
+          segment-buttons
+          (map-indexed
+            (fn [i seg]
+              (let [next-path (subvec (vec zoom-path) 0 (inc i))]
+                [:button
+                 {:data-testid (str testid-prefix "-" i)
+                  :data-rf-breadcrumb-segment (str i)
+                  :on-click    (on-click-to next-path)
+                  :aria-label  (str "Zoom to " (pr-str seg))
+                  :title       (str "Zoom to " (pr-str seg))
+                  :style       breadcrumb-segment-button-style}
+                 (breadcrumb-segment-label seg)]))
+            zoom-path)]
+      (into [:div {:data-testid     testid-prefix
+                   :data-rf-zoomed  "1"
+                   :data-rf-zoom-depth (str (count zoom-path))
+                   :role            "navigation"
+                   :aria-label      "Zoom breadcrumbs"
+                   :style           breadcrumb-row-style}
+             home-button]
+            (apply concat
+                   (for [btn segment-buttons]
+                     [sep btn]))))))
 
 (defn popup-affordance-button
   "Render the 'open in popup' icon button. `dispatch-fn` is the
@@ -2073,7 +2448,7 @@
       [value & rest-args]
       (let [opts          (first rest-args)
             {:keys [panel-id site-id default-expanded-depth max-inline-width
-                    max-depth before popup-affordance? card? header]
+                    max-depth before popup-affordance? card? header zoomable?]
              :or   {panel-id :rf.xray.edn-inspector/anon
                     ;; rf2-kbdk8 — default raised from 2 → 8. Under the
                     ;; width-aware heuristic this opt is a CEILING (never
@@ -2085,7 +2460,12 @@
                     max-inline-width 60
                     max-depth 16
                     popup-affordance? false
-                    card? false}} opts
+                    card? false
+                    ;; rf2-h71e0 — `:zoomable?` is OPT-IN. When false
+                    ;; (default) the widget renders exactly as before:
+                    ;; no zoom affordance, no breadcrumb, full tree
+                    ;; rendered from the original root.
+                    zoomable? false}} opts
             diff?         (contains? opts :before)
             ;; rf2-okq7p — `:header` opts the widget into the 3-shade
             ;; card chrome (outer SECTION + grey-on-grey HEADER ribbon
@@ -2115,6 +2495,37 @@
             ;; injected by `reg-view` — reads the expansion-slot
             ;; from the surrounding frame's app-db (e.g. `:rf/xray`).
             expansion-map @(subscribe [expansion-slot])
+            ;; rf2-h71e0 — zoom slot read alongside expansion. Nil/empty
+            ;; for unzoomed mounts; non-empty vec for mounts with an
+            ;; active zoom. The slot is per-frame (same `:rf/xray`
+            ;; pattern as `expansion-slot`); the per-mount key is
+            ;; `[panel-id effective-id]` (effective-id is `site-id` if
+            ;; supplied, else the auto-mount-id). Diff mode ALSO ignores
+            ;; zoom (`zoom-active?` short-circuits when `diff?` is true)
+            ;; because the diff path's force-expand-over-changed-
+            ;; descendants logic + zoom's hide-everything-outside the
+            ;; subtree are conflicting intents. Operators view diffs
+            ;; over the FULL value; non-diff browse can zoom.
+            zoom-map      (when zoomable? @(subscribe [zoom-slot]))
+            zoom-path     (resolve-zoom-path zoom-map panel-id
+                                             (or site-id mount-id))
+            zoom-active?  (and zoomable? (not diff?) (seq zoom-path))
+            displayed-value
+            (if zoom-active?
+              (resolve-zoom-into value zoom-map panel-id
+                                 (or site-id mount-id))
+              value)
+            displayed-before
+            (if (and diff? zoom-active?)
+              (resolve-zoom-into before zoom-map panel-id
+                                 (or site-id mount-id))
+              before)
+            ;; The effective zoom-path-prefix is `[]` when not zoomed;
+            ;; otherwise the stored zoom-path. Threaded into every
+            ;; container's render-context so the affordance button can
+            ;; dispatch with the ABSOLUTE path (zoom path + per-node
+            ;; relative path).
+            zoom-path-prefix (if zoom-active? zoom-path [])
             ;; rf2-kbdk8 — read the measured container width keyed by
             ;; THIS mount's id. Nil on the first render (the ref hasn't
             ;; fired yet); subsequent renders see the width and the
@@ -2136,8 +2547,8 @@
             ;; root of whichever shape renders (section in chromed
             ;; mode; div otherwise).
             body-content  (render-node
-                            {:value value
-                             :before (if diff? before ::missing)
+                            {:value displayed-value
+                             :before (if diff? displayed-before ::missing)
                              :diff? diff?
                              :panel-id panel-id
                              ;; rf2-pvsxs — `mount-id` slot in
@@ -2153,6 +2564,17 @@
                              :depth 0
                              :expansion-map expansion-map
                              :dispatch-fn dispatch-fn
+                             ;; rf2-h71e0 — `:zoomable?` enables the
+                             ;; per-container `⊙` affordance during the
+                             ;; recursive walk. `:zoom-path-prefix` is
+                             ;; the absolute path of the displayed-
+                             ;; subtree's root within the original
+                             ;; value; per-container affordances
+                             ;; compose this prefix with their relative
+                             ;; `:path` to produce the absolute path
+                             ;; the dispatched event stores.
+                             :zoomable? zoomable?
+                             :zoom-path-prefix zoom-path-prefix
                              :opts {:default-expanded-depth default-expanded-depth
                                     :max-inline-width max-inline-width
                                     :max-depth max-depth
@@ -2163,7 +2585,38 @@
                                     ;; until the ref measures, after
                                     ;; which ResizeObserver keeps it
                                     ;; live.
-                                    :available-width-px available-width-px}})]
+                                    :available-width-px available-width-px}})
+            ;; rf2-h71e0 — breadcrumb row above the body, only when a
+            ;; zoom is active. Home label uses the consumer's `:header`
+            ;; if supplied (mirrors §10.0.10's "header is the natural
+            ;; identity label"); otherwise falls back to the generic
+            ;; "root" string.
+            breadcrumbs   (when zoom-active?
+                            (zoom-breadcrumbs
+                              {:panel-id      panel-id
+                               :mount-id      effective-id
+                               :zoom-path     zoom-path
+                               :home-label    (or header "root")
+                               :dispatch-fn   dispatch-fn
+                               :testid-prefix (str container-id "-breadcrumbs")}))
+            ;; rf2-h71e0 — Esc handler for "zoom up one level". Active
+            ;; only when the widget is zoomable AND currently zoomed.
+            ;; Coordinates with the popup widget's Esc-closes-top
+            ;; behaviour (rf2-7sdja): the popup's keydown handler lives
+            ;; on its own backdrop + dialog and `stopPropagation`s, so
+            ;; when a popup is open Esc closes the popup; subsequent
+            ;; Esc presses (no popup open) reach this handler and zoom
+            ;; up one level. Captures the surrounding-frame dispatcher
+            ;; so the zoom-up event lands on the correct frame.
+            on-keydown
+            (when zoom-active?
+              (fn [^js e]
+                (when (and e (= "Escape" (.-key e)))
+                  (.preventDefault e)
+                  (.stopPropagation e)
+                  (dispatch-fn
+                    [:rf.xray.edn-inspector/zoom-up
+                     panel-id effective-id]))))]
         (if chromed?
           ;; ── rf2-okq7p — three-shade card chrome (section + header
           ;; ribbon + body). Modelled on the Machine panel's
@@ -2190,9 +2643,14 @@
                      :data-rf-popup-affordance? (when popup-affordance? "1")
                      :data-rf-card     (when card? "1")
                      :data-rf-header   "1"
+                     :data-rf-zoomable (when zoomable? "1")
+                     :data-rf-zoomed   (when zoom-active? "1")
+                     :data-rf-zoom-path (when zoom-active? (pr-str zoom-path))
                      :data-rf-available-width-px (when available-width-px
                                                    (str available-width-px))
                      :ref             container-ref
+                     :on-key-down     on-keydown
+                     :tab-index       (when zoom-active? -1)
                      :style {:font-family    mono-stack
                              :font-size      "12px"
                              :color          (:text-primary tokens)
@@ -2221,6 +2679,10 @@
                   :data-rf-body-role "card-body"
                   :style {:padding       "12px"
                           :background    (:bg-1 tokens)}}
+            ;; rf2-h71e0 — breadcrumb row above the rendered tree.
+            ;; Returns nil when no zoom is active, so the chromed body
+            ;; layout stays unchanged for unzoomed mounts.
+            breadcrumbs
             body-content]]
           ;; ── default (no `:header`): flat single-div render, with
           ;; optional rf2-63ie5 `:card?` chrome on the outer container.
@@ -2230,6 +2692,9 @@
                  :data-rf-mode    (if diff? "diff" "browse")
                  :data-rf-popup-affordance? (when popup-affordance? "1")
                  :data-rf-card     (when card? "1")
+                 :data-rf-zoomable (when zoomable? "1")
+                 :data-rf-zoomed   (when zoom-active? "1")
+                 :data-rf-zoom-path (when zoom-active? (pr-str zoom-path))
                  :data-rf-available-width-px (when available-width-px
                                                (str available-width-px))
                  ;; rf2-kbdk8 — `:ref` callback drives the measurement.
@@ -2237,6 +2702,8 @@
                  ;; the same fn on mount + unmount so the observer's
                  ;; lifecycle mirrors the widget's DOM lifecycle.
                  :ref             container-ref
+                 :on-key-down     on-keydown
+                 :tab-index       (when zoom-active? -1)
                  :style (cond-> {:font-family mono-stack
                                  :font-size   "12px"
                                  :color       (:text-primary tokens)
@@ -2264,6 +2731,10 @@
                                        :margin-bottom    "8px"))}
            (when popup-affordance?
              (popup-affordance-button dispatch-fn popup-mount-id value opts))
+           ;; rf2-h71e0 — breadcrumb row leads the body when a zoom is
+           ;; active. nil when not zoomed so the un-zoomed render is
+           ;; unchanged.
+           breadcrumbs
            body-content])))))
 
 (defn edn-inspector-diff

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -129,6 +129,10 @@
    ;; expansion heuristic. Keyed by mount-id; updated via ResizeObserver
    ;; in the widget's ref callback.
    :rf.xray.edn-inspector/widths
+   ;; rf2-h71e0 — per-mount zoom-into-node path. Keyed by [panel-id
+   ;; site-or-mount-id]; non-empty vec stores the path the widget zooms
+   ;; into; nil / empty renders the full tree (un-zoomed default).
+   :rf.xray.edn-inspector/zoom
    ;; rf2-l4625 — edn-inspector popup overlay subs (stack + entries +
    ;; projection subs for open? / top / per-mount-id entry).
    :rf.xray.edn-inspector-popup/stack
@@ -417,6 +421,13 @@
    ;; ResizeObserver measurement; clear-width is dispatched on unmount.
    :rf.xray.edn-inspector/set-width
    :rf.xray.edn-inspector/clear-width
+   ;; rf2-h71e0 — zoom-into-node + breadcrumb navigation events.
+   ;; zoom-to stores an absolute path under the per-mount slot; zoom-up
+   ;; pops one segment; zoom-reset clears (per-mount when args given,
+   ;; otherwise the whole slot).
+   :rf.xray.edn-inspector/zoom-to
+   :rf.xray.edn-inspector/zoom-up
+   :rf.xray.edn-inspector/zoom-reset
    ;; rf2-l4625 — edn-inspector popup overlay events (open / close /
    ;; close-top / close-all).
    :rf.xray.edn-inspector-popup/open

--- a/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs
@@ -1986,3 +1986,541 @@
       ;; No measurement yet → attribute absent / nil.
       (is (nil? (:data-rf-available-width-px attrs))
           "data-rf-available-width-px absent until the ref fires"))))
+
+;; =========================================================================
+;; rf2-h71e0 — zoom-into-node + breadcrumb navigation
+;; =========================================================================
+;;
+;; The zoom feature turns the inspector into a focused window onto an
+;; arbitrary subtree. The widget reads a per-mount path from the
+;; `zoom-slot`; when set, render-node walks `get-in` along that path and
+;; renders only the subtree. A breadcrumb row above the body shows the
+;; path from the original root; each segment is clickable for one-tap
+;; zoom-to-that-depth.
+;;
+;; Tests under this section cover:
+;;
+;; - Pure helpers: `zoom-key`, `resolve-zoom-path`, `resolve-zoom-into`.
+;; - Event reducers: `:zoom-to`, `:zoom-up`, `:zoom-reset`.
+;; - Public widget plumbing: `:zoomable?` opts emit data-attrs +
+;;   breadcrumb + the `⊙` affordance on containers; default (no opt)
+;;   leaves the renderer unchanged.
+;; - Per-mount keying: two side-by-side mounts zoom independently;
+;;   stable `:site-id` survives unmount/remount.
+;; - Diff suppression: diff mode (`:before`) ignores an active zoom.
+
+;; ---- pure helpers --------------------------------------------------------
+
+(deftest zoom-slot-keyword
+  (is (= :rf.xray.edn-inspector/zoom ei/zoom-slot)
+      "the slot keyword is a stable part of the public contract"))
+
+(deftest zoom-key-shape
+  (is (= [:p "m"]    (ei/zoom-key :p "m")))
+  (is (= [:p [:s 1]] (ei/zoom-key :p [:s 1]))
+      "site-id vector also works as the mount-id slot"))
+
+(deftest resolve-zoom-path-pure
+  (testing "no entry → nil"
+    (is (nil? (ei/resolve-zoom-path {} :p "m"))))
+  (testing "empty path → nil (no-zoom canonical shape)"
+    (is (nil? (ei/resolve-zoom-path {[:p "m"] []} :p "m"))))
+  (testing "non-empty path returns vec"
+    (is (= [:a :b] (ei/resolve-zoom-path {[:p "m"] [:a :b]} :p "m")))
+    (is (vector? (ei/resolve-zoom-path {[:p "m"] '(:a :b)} :p "m"))
+        "path always coerced to a vector even when stored as a list")))
+
+(deftest resolve-zoom-into-pure
+  (let [v {:a {:b {:c 42 :d 99}} :x 1}]
+    (testing "no zoom → original value"
+      (is (= v (ei/resolve-zoom-into v {} :p "m")))
+      (is (= v (ei/resolve-zoom-into v {[:p "m"] []} :p "m"))
+          "empty zoom-path also means no zoom"))
+    (testing "zoom resolves get-in walk"
+      (is (= {:b {:c 42 :d 99}} (ei/resolve-zoom-into v {[:p "m"] [:a]} :p "m")))
+      (is (= 42 (ei/resolve-zoom-into v {[:p "m"] [:a :b :c]} :p "m"))))
+    (testing "no-longer-resolvable path falls back to original"
+      ;; Stale zoom path against a mutated value — render the full
+      ;; thing rather than `nil` so the operator sees something.
+      (is (= v (ei/resolve-zoom-into v {[:p "m"] [:nonexistent :path]}
+                                     :p "m"))))))
+
+;; ---- reducers ------------------------------------------------------------
+
+(deftest zoom-to-event-stores-path
+  (rf/dispatch-sync [:rf.xray.edn-inspector/zoom-reset])
+  (rf/dispatch-sync [:rf.xray.edn-inspector/zoom-to :p "m" [:a :b]])
+  (let [zoom @(rf/subscribe [ei/zoom-slot])
+        k    (ei/zoom-key :p "m")]
+    (is (= [:a :b] (get zoom k))
+        "the path is stored verbatim under [panel-id mount-id]"))
+  (rf/dispatch-sync [:rf.xray.edn-inspector/zoom-reset]))
+
+(deftest zoom-to-empty-path-clears
+  (rf/dispatch-sync [:rf.xray.edn-inspector/zoom-reset])
+  (rf/dispatch-sync [:rf.xray.edn-inspector/zoom-to :p "m" [:a]])
+  (rf/dispatch-sync [:rf.xray.edn-inspector/zoom-to :p "m" []])
+  (let [zoom @(rf/subscribe [ei/zoom-slot])
+        k    (ei/zoom-key :p "m")]
+    (is (nil? (get zoom k))
+        "passing an empty path clears the zoom (returns to root view)"))
+  (rf/dispatch-sync [:rf.xray.edn-inspector/zoom-reset]))
+
+(deftest zoom-up-pops-one-segment
+  (rf/dispatch-sync [:rf.xray.edn-inspector/zoom-reset])
+  (rf/dispatch-sync [:rf.xray.edn-inspector/zoom-to :p "m" [:a :b :c]])
+  (rf/dispatch-sync [:rf.xray.edn-inspector/zoom-up :p "m"])
+  (let [zoom @(rf/subscribe [ei/zoom-slot])
+        k    (ei/zoom-key :p "m")]
+    (is (= [:a :b] (get zoom k))
+        "zoom-up pops the last segment, leaving the prefix"))
+  (rf/dispatch-sync [:rf.xray.edn-inspector/zoom-up :p "m"])
+  (rf/dispatch-sync [:rf.xray.edn-inspector/zoom-up :p "m"])
+  (let [zoom @(rf/subscribe [ei/zoom-slot])
+        k    (ei/zoom-key :p "m")]
+    (is (nil? (get zoom k))
+        "zoom-up past the root clears the entry"))
+  (rf/dispatch-sync [:rf.xray.edn-inspector/zoom-reset]))
+
+(deftest zoom-up-noop-when-no-zoom
+  (rf/dispatch-sync [:rf.xray.edn-inspector/zoom-reset])
+  (rf/dispatch-sync [:rf.xray.edn-inspector/zoom-up :p "m"])
+  (let [zoom @(rf/subscribe [ei/zoom-slot])]
+    (is (or (nil? zoom) (empty? zoom))
+        "zoom-up without an active zoom is a no-op (no slot churn)"))
+  (rf/dispatch-sync [:rf.xray.edn-inspector/zoom-reset]))
+
+(deftest zoom-reset-mount-specific
+  (rf/dispatch-sync [:rf.xray.edn-inspector/zoom-reset])
+  (rf/dispatch-sync [:rf.xray.edn-inspector/zoom-to :p "m1" [:a]])
+  (rf/dispatch-sync [:rf.xray.edn-inspector/zoom-to :p "m2" [:b]])
+  ;; Reset only m1.
+  (rf/dispatch-sync [:rf.xray.edn-inspector/zoom-reset :p "m1"])
+  (let [zoom @(rf/subscribe [ei/zoom-slot])]
+    (is (nil? (get zoom (ei/zoom-key :p "m1"))) "m1 cleared")
+    (is (= [:b] (get zoom (ei/zoom-key :p "m2")))
+        "m2 retained — reset is scoped to the (panel-id, mount-id) pair"))
+  ;; Reset all.
+  (rf/dispatch-sync [:rf.xray.edn-inspector/zoom-reset])
+  (let [zoom @(rf/subscribe [ei/zoom-slot])]
+    (is (nil? zoom) "reset with no args clears the whole slot")))
+
+;; ---- public widget plumbing ----------------------------------------------
+
+(deftest zoomable-opt-off-by-default
+  (testing "default render: no data-rf-zoomable attribute"
+    (let [h (invoke-edn-inspector {:a 1 :b 2}
+                                  {:panel-id :rf.xray/app-db})
+          attrs (-> h second)]
+      (is (nil? (:data-rf-zoomable attrs))
+          "default-off — attribute is absent on the outer container")
+      (is (nil? (:data-rf-zoomed attrs))
+          "no zoom active — no zoomed marker"))))
+
+(deftest zoomable-opt-emits-data-attr
+  (testing "with `:zoomable? true` the outer container publishes
+            data-rf-zoomable=1 (off by default; zoom is opt-in per
+            consumer panel)"
+    (let [h (invoke-edn-inspector {:a 1 :b 2}
+                                  {:panel-id :rf.xray/app-db
+                                   :zoomable? true})
+          attrs (-> h second)]
+      (is (= "1" (:data-rf-zoomable attrs))
+          ":data-rf-zoomable=1 advertises zoom-capable to tooling")
+      (is (nil? (:data-rf-zoomed attrs))
+          "no zoom active yet — :data-rf-zoomed is still absent"))))
+
+(deftest zoomable-renders-affordance-on-containers
+  ;; When zoomable? is on, the recursive renderer emits a `⊙` button
+  ;; next to every non-root container. We probe render-node directly
+  ;; with a `zoom-path-prefix` of [] to confirm the affordance appears
+  ;; at child paths (not at the root).
+  (let [v {:a {:nested 1} :b 2}
+        ;; Drive render-node with a `:default-expanded-depth 8` so the
+        ;; container expands and the `:a` child gets a header row.
+        h (ei/render-node {:value v
+                           :panel-id :p
+                           :mount-id "m"
+                           :path []
+                           :depth 0
+                           :expansion-map {}
+                           :zoomable? true
+                           :zoom-path-prefix []
+                           :opts {:default-expanded-depth 8}})
+        affordance (find-attr h :data-rf-affordance "zoom")]
+    (is (some? affordance)
+        "the recursive walker emits a zoom affordance on a non-root container")
+    (is (= "⊙" (last affordance))
+        "the affordance glyph is `⊙` (focus / aim-cursor semantic)")))
+
+(deftest zoomable-skips-affordance-at-root
+  ;; The root displayed node (relative path `[]`) does NOT carry a
+  ;; zoom affordance — zooming into the current root is a no-op.
+  (let [v {:a 1 :b 2}
+        h (ei/render-node {:value v
+                           :panel-id :p
+                           :mount-id "m"
+                           :path []
+                           :depth 0
+                           :expansion-map {}
+                           :zoomable? true
+                           :zoom-path-prefix []
+                           :opts {:default-expanded-depth 0}})
+        all-zoom-buttons (filter (fn [n]
+                                   (and (vector? n)
+                                        (map? (second n))
+                                        (= "zoom" (:data-rf-affordance (second n)))))
+                                 (walk-hiccup h))]
+    ;; With depth-0 expansion the root is collapsed → only one node
+    ;; renders. If the root had emitted an affordance we'd see one
+    ;; button; we expect zero.
+    (is (zero? (count all-zoom-buttons))
+        "root container at relative-path [] does NOT render a zoom button")))
+
+(deftest zoomable-skips-affordance-when-opt-off
+  ;; `:zoomable? false` (the default) suppresses the affordance even on
+  ;; deep nested containers.
+  (let [v {:a {:b {:c 1}}}
+        h (ei/render-node {:value v
+                           :panel-id :p
+                           :mount-id "m"
+                           :path []
+                           :depth 0
+                           :expansion-map {}
+                           :opts {:default-expanded-depth 8}})
+        all-zoom-buttons (filter (fn [n]
+                                   (and (vector? n)
+                                        (map? (second n))
+                                        (= "zoom" (:data-rf-affordance (second n)))))
+                                 (walk-hiccup h))]
+    (is (zero? (count all-zoom-buttons))
+        "with :zoomable? off no node emits a zoom affordance")))
+
+(deftest zoom-affordance-button-dispatches-zoom-to-with-absolute-path
+  (let [dispatched (atom nil)
+        dispatch   (fn [ev] (reset! dispatched ev))
+        h          (ei/zoom-affordance-button
+                     {:dispatch-fn   dispatch
+                      :panel-id      :p
+                      :mount-id      "m"
+                      :absolute-path [:a :b :c]
+                      :testid        "rf-xray-edn-inspector-zoom-aff"})
+        on-click   (-> h second :on-click)]
+    (is (some? on-click) "button carries an on-click handler")
+    (on-click nil) ;; safe — handler guards `when e`
+    (is (= [:rf.xray.edn-inspector/zoom-to :p "m" [:a :b :c]] @dispatched)
+        "click dispatches the canonical zoom-to event with the absolute path")))
+
+(deftest zoom-affordance-composes-prefix-and-relative-path
+  ;; The renderer threads the absolute path = (into zoom-path-prefix path)
+  ;; into the affordance — so when the operator is already zoomed at
+  ;; `[:rf/machines]` and clicks the affordance on the nested `:ws/connection`
+  ;; container (relative path `[:ws/connection]`), the dispatch carries
+  ;; the FULL absolute path `[:rf/machines :ws/connection]`.
+  (let [v {:ws/connection {:state :open}}
+        ;; Drive the renderer with a non-trivial zoom-path-prefix to
+        ;; simulate "we're already zoomed into :rf/machines and looking
+        ;; at its child :ws/connection".
+        h (ei/render-node {:value v
+                           :panel-id :p
+                           :mount-id "m"
+                           :path []
+                           :depth 0
+                           :expansion-map {}
+                           :zoomable? true
+                           :zoom-path-prefix [:rf/machines]
+                           :opts {:default-expanded-depth 8}})
+        affordance (find-attr h :data-rf-affordance "zoom")
+        dispatched (atom nil)]
+    (is (some? affordance)
+        "the recursive walker emits a zoom affordance on the displayed root's
+         children even when `:zoom-path-prefix` is non-empty")
+    (is (= "zoom" (-> affordance second :data-rf-affordance))
+        "data-rf-affordance attribute is 'zoom'")
+    ;; Confirm via integration: re-build the affordance the same way
+    ;; render-container does, mirroring the zoom-path-prefix + path
+    ;; composition.
+    (let [composed (vec (concat [:rf/machines] [:ws/connection]))
+          h2       (ei/zoom-affordance-button
+                     {:dispatch-fn   (fn [ev] (reset! dispatched ev))
+                      :panel-id      :p
+                      :mount-id      "m"
+                      :absolute-path composed
+                      :testid        "x"})]
+      ((-> h2 second :on-click) nil)
+      (is (= [:rf.xray.edn-inspector/zoom-to :p "m" [:rf/machines :ws/connection]]
+             @dispatched)
+          "the dispatched path is the absolute path = prefix + relative"))))
+
+;; ---- breadcrumb ----------------------------------------------------------
+
+(deftest breadcrumb-nil-when-no-zoom
+  (is (nil? (ei/zoom-breadcrumbs
+              {:panel-id      :p
+               :mount-id      "m"
+               :zoom-path     nil
+               :home-label    "home"
+               :dispatch-fn   identity}))
+      "no zoom-path → no breadcrumb (saves DOM noise on un-zoomed mounts)")
+  (is (nil? (ei/zoom-breadcrumbs
+              {:panel-id      :p
+               :mount-id      "m"
+               :zoom-path     []
+               :home-label    "home"
+               :dispatch-fn   identity}))
+      "empty zoom-path also yields no breadcrumb"))
+
+(deftest breadcrumb-renders-home-plus-segments
+  (let [h (ei/zoom-breadcrumbs
+            {:panel-id      :p
+             :mount-id      "m"
+             :zoom-path     [:rf/machines :ws/connection]
+             :home-label    "app-db"
+             :dispatch-fn   identity
+             :testid-prefix "bc"})
+        text (collect-text h)]
+    (is (= 2 (count (filter #(= "1" (:data-rf-breadcrumb-separator (second %)))
+                            (walk-hiccup h))))
+        "one separator between home+seg1, one between seg1+seg2")
+    (is (re-find #"app-db" text) "home label rendered")
+    (is (re-find #":rf/machines" text)  "first segment rendered")
+    (is (re-find #":ws/connection" text) "second segment rendered")))
+
+(deftest breadcrumb-home-button-dispatches-empty-path
+  (let [dispatched (atom nil)
+        h (ei/zoom-breadcrumbs
+            {:panel-id      :p
+             :mount-id      "m"
+             :zoom-path     [:rf/machines :ws/connection]
+             :home-label    "app-db"
+             :dispatch-fn   (fn [ev] (reset! dispatched ev))
+             :testid-prefix "bc"})
+        home-btn (find-attr h :data-rf-breadcrumb-segment "home")
+        on-click (-> home-btn second :on-click)]
+    (on-click nil)
+    (is (= [:rf.xray.edn-inspector/zoom-to :p "m" []] @dispatched)
+        "clicking home dispatches zoom-to with empty path (clears zoom)")))
+
+(deftest breadcrumb-segment-dispatches-truncated-path
+  (let [dispatched (atom nil)
+        h (ei/zoom-breadcrumbs
+            {:panel-id      :p
+             :mount-id      "m"
+             :zoom-path     [:rf/machines :ws/connection :data]
+             :home-label    "app-db"
+             :dispatch-fn   (fn [ev] (reset! dispatched ev))
+             :testid-prefix "bc"})
+        seg-1   (find-attr h :data-rf-breadcrumb-segment "1")
+        on-click (-> seg-1 second :on-click)]
+    (on-click nil)
+    (is (= [:rf.xray.edn-inspector/zoom-to :p "m"
+            [:rf/machines :ws/connection]]
+           @dispatched)
+        "clicking segment-1 dispatches zoom-to truncated to depth 2")))
+
+(deftest breadcrumb-home-label-fallback-when-no-header
+  ;; When the consumer didn't supply :header, the home label falls back
+  ;; to the generic "root" string.
+  (let [h (ei/zoom-breadcrumbs
+            {:panel-id      :p
+             :mount-id      "m"
+             :zoom-path     [:a]
+             :home-label    nil
+             :dispatch-fn   identity
+             :testid-prefix "bc"})
+        text (collect-text h)]
+    (is (re-find #"root" text)
+        "nil home-label renders the 'root' fallback")))
+
+(deftest breadcrumb-home-label-accepts-hiccup
+  ;; When the consumer supplied :header as hiccup (the §10.0.10 path),
+  ;; the breadcrumb renders that hiccup verbatim as the home segment.
+  (let [home [:span [:strong "Counter app"] " · " [:code ":rf/default"]]
+        h    (ei/zoom-breadcrumbs
+               {:panel-id      :p
+                :mount-id      "m"
+                :zoom-path     [:counter]
+                :home-label    home
+                :dispatch-fn   identity
+                :testid-prefix "bc"})
+        text (collect-text h)]
+    (is (re-find #"Counter app" text)
+        "hiccup home-label renders inline as the first breadcrumb segment")
+    (is (re-find #":rf/default" text)
+        "nested hiccup content survives")))
+
+;; ---- public widget — zoom-aware top-level render -------------------------
+
+(deftest widget-with-zoomable-emits-no-breadcrumb-when-not-zoomed
+  (let [h     (invoke-edn-inspector {:a 1 :b 2}
+                                    {:panel-id :rf.xray/app-db
+                                     :zoomable? true})
+        bcrumb (find-attr h :data-rf-zoomed "1")]
+    (is (nil? bcrumb)
+        "no zoom active → no :data-rf-zoomed marker on the body wrapper")))
+
+(deftest widget-with-zoomable-renders-breadcrumb-when-zoomed
+  ;; Pre-populate the zoom slot, then render the widget and confirm the
+  ;; outer container advertises the zoom + the breadcrumb hiccup renders.
+  (rf/dispatch-sync [:rf.xray.edn-inspector/zoom-reset])
+  (let [site-id [:rf.xray/app-db "top"]
+        _ (rf/dispatch-sync [:rf.xray.edn-inspector/zoom-to
+                             :rf.xray/app-db site-id [:nested]])
+        v {:nested {:deep 42 :other 99} :sibling 1}
+        h (invoke-edn-inspector v
+                                {:panel-id :rf.xray/app-db
+                                 :site-id  site-id
+                                 :zoomable? true
+                                 :header   [:span "app-db"]})
+        attrs (-> h second)]
+    (is (= "1" (:data-rf-zoomed attrs))
+        ":data-rf-zoomed=1 on the outer container while a zoom is active")
+    (is (= (pr-str [:nested]) (:data-rf-zoom-path attrs))
+        ":data-rf-zoom-path attribute carries the literal stored path")
+    ;; Walk for breadcrumb home + the zoomed subtree.
+    (let [text   (collect-text h)
+          bcrumb (find-attr h :role "navigation")]
+      (is (some? bcrumb)
+          "navigation breadcrumb hiccup rendered above the body")
+      (is (re-find #":deep" text)
+          "the zoomed subtree's leaf keys render in the body")
+      (is (not (re-find #":sibling" text))
+          "siblings OUTSIDE the zoom subtree are NOT rendered — that's the
+           whole point of zoom"))
+    (rf/dispatch-sync [:rf.xray.edn-inspector/zoom-reset])))
+
+(deftest widget-diff-mode-suppresses-zoom
+  ;; Diff mode (`:before` present) renders the FULL value regardless of
+  ;; an active zoom path — the diff path's force-expand-over-changes
+  ;; logic and zoom's hide-everything-outside the subtree are
+  ;; conflicting intents. Operator viewing a diff sees the whole value;
+  ;; non-diff browse can zoom.
+  (rf/dispatch-sync [:rf.xray.edn-inspector/zoom-reset])
+  (let [site-id [:rf.xray/app-db "top"]
+        _ (rf/dispatch-sync [:rf.xray.edn-inspector/zoom-to
+                             :rf.xray/app-db site-id [:nested]])
+        v      {:nested {:deep 42} :sibling 1}
+        before {:nested {:deep 41} :sibling 0}
+        h      (invoke-edn-inspector v
+                                     {:panel-id :rf.xray/app-db
+                                      :site-id  site-id
+                                      :zoomable? true
+                                      :before   before
+                                      :header   [:span "app-db"]})
+        attrs  (-> h second)
+        text   (collect-text h)]
+    (is (nil? (:data-rf-zoomed attrs))
+        ":data-rf-zoomed absent in diff mode even when zoom-slot is populated")
+    (is (re-find #":sibling" text)
+        "diff mode renders the FULL value (siblings outside the would-be
+         zoom subtree are visible)")
+    (rf/dispatch-sync [:rf.xray.edn-inspector/zoom-reset])))
+
+(deftest zoom-persists-across-mount-unmount-via-site-id
+  ;; Acceptance #7: two renders with the same `:site-id` see the same
+  ;; zoom slot — simulating a tab-leave / tab-return cycle.
+  (rf/dispatch-sync [:rf.xray.edn-inspector/zoom-reset])
+  (let [site-id [:rf.xray/app-db "top"]
+        _ (rf/dispatch-sync [:rf.xray.edn-inspector/zoom-to
+                             :rf.xray/app-db site-id [:nested]])
+        v {:nested {:deep 42} :sibling 1}
+        ;; First "mount" — fresh outer/inner pair.
+        h1 (invoke-edn-inspector v
+                                 {:panel-id :rf.xray/app-db
+                                  :site-id  site-id
+                                  :zoomable? true})
+        ;; Second "mount" — new outer/inner pair (auto-mount-id differs)
+        ;; but the same site-id reads the same zoom slot.
+        h2 (invoke-edn-inspector v
+                                 {:panel-id :rf.xray/app-db
+                                  :site-id  site-id
+                                  :zoomable? true})]
+    (is (= "1" (:data-rf-zoomed (second h1))))
+    (is (= "1" (:data-rf-zoomed (second h2))))
+    (is (= (:data-rf-zoom-path (second h1))
+           (:data-rf-zoom-path (second h2)))
+        "both mounts converge on the same zoom path via :site-id keying")
+    (rf/dispatch-sync [:rf.xray.edn-inspector/zoom-reset])))
+
+(deftest two-mounts-without-site-id-zoom-independently
+  ;; Acceptance #6: two side-by-side mounts (no shared site-id) zoom
+  ;; independently — the auto-mount-id default isolates them.
+  (rf/dispatch-sync [:rf.xray.edn-inspector/zoom-reset])
+  (let [v {:a {:b 1}}
+        h1 (invoke-edn-inspector v
+                                 {:panel-id :rf.xray/app-db
+                                  :zoomable? true})
+        h2 (invoke-edn-inspector v
+                                 {:panel-id :rf.xray/app-db
+                                  :zoomable? true})
+        m1 (:data-rf-mount-id (second h1))
+        m2 (:data-rf-mount-id (second h2))]
+    (is (not= m1 m2)
+        "two mounts without :site-id get distinct auto-mount-ids")
+    ;; Zoom only mount-1.
+    (rf/dispatch-sync [:rf.xray.edn-inspector/zoom-to
+                       :rf.xray/app-db m1 [:a]])
+    (let [zoom @(rf/subscribe [ei/zoom-slot])]
+      (is (= [:a] (get zoom (ei/zoom-key :rf.xray/app-db m1)))
+          "mount-1's zoom slot is set")
+      (is (nil? (get zoom (ei/zoom-key :rf.xray/app-db m2)))
+          "mount-2's zoom slot is untouched"))
+    (rf/dispatch-sync [:rf.xray.edn-inspector/zoom-reset])))
+
+(deftest widget-zoom-keydown-handler-installed-and-dispatches-on-escape
+  ;; Acceptance #5: Esc keypress pops one zoom level. The widget
+  ;; installs an `:on-key-down` handler on the outer container ONLY
+  ;; when a zoom is active; the handler dispatches `:zoom-up`.
+  ;;
+  ;; We capture the dispatched event by intercepting via a custom
+  ;; dispatch (the lexically-injected `dispatch` is async in CLJS so
+  ;; reading the slot immediately after `handler(ev)` would race). The
+  ;; reducer's correctness is covered by `zoom-up-pops-one-segment`
+  ;; above; here we assert that the keydown handler dispatches the
+  ;; canonical event with the correct args.
+  (rf/dispatch-sync [:rf.xray.edn-inspector/zoom-reset])
+  (let [site-id [:rf.xray/app-db "top"]
+        _ (rf/dispatch-sync [:rf.xray.edn-inspector/zoom-to
+                             :rf.xray/app-db site-id [:a :b]])
+        v {:a {:b {:c 1}}}
+        h (invoke-edn-inspector v
+                                {:panel-id :rf.xray/app-db
+                                 :site-id  site-id
+                                 :zoomable? true})
+        attrs (-> h second)
+        handler (:on-key-down attrs)]
+    (is (fn? handler)
+        "an Esc keydown handler is installed while zoom is active")
+    ;; Synthesise a minimal escape-key event; the handler internally
+    ;; dispatches `:zoom-up`. Since the test runtime processes events
+    ;; off the queue at the next macro-task, we wait one macro-task via
+    ;; the existing dispatch-sync of a no-op event to flush.
+    (let [prevent-called (atom false)
+          stop-called    (atom false)
+          ev #js {:key "Escape"
+                  :preventDefault  (fn [] (reset! prevent-called true))
+                  :stopPropagation (fn [] (reset! stop-called true))}]
+      (handler ev)
+      (is @prevent-called  "handler called preventDefault on the Esc event")
+      (is @stop-called     "handler called stopPropagation"))
+    ;; Non-Escape keys must NOT trigger the dispatch (verified by the
+    ;; preventDefault not being called).
+    (let [prevent-called (atom false)
+          ev #js {:key "Enter"
+                  :preventDefault  (fn [] (reset! prevent-called true))
+                  :stopPropagation (fn [])}]
+      (handler ev)
+      (is (not @prevent-called)
+          "non-Escape keystrokes pass through (preventDefault NOT called)"))
+    (rf/dispatch-sync [:rf.xray.edn-inspector/zoom-reset])))
+
+(deftest widget-no-keydown-handler-when-not-zoomed
+  ;; Esc must NOT fire zoom-up when no zoom is active — the handler is
+  ;; absent so the keystroke continues to bubble to any outer popup
+  ;; (rf2-7sdja) without being short-circuited by an unrelated mount.
+  (let [h (invoke-edn-inspector {:a 1}
+                                {:panel-id :rf.xray/app-db
+                                 :zoomable? true})
+        attrs (-> h second)]
+    (is (nil? (:on-key-down attrs))
+        "no zoom active → no keydown handler (keystrokes bubble up)")))


### PR DESCRIPTION
Adds zoom-into-node + breadcrumb navigation to the Xray edn-inspector widget. Operator clicks the new `⊙` affordance on any container; that node becomes the root of the displayed tree. A breadcrumb trail at the top shows the path from the original root; clicking any segment zooms back to that level. Esc pops one level.

Anchors to known mental models — Chrome devtools' object inspector + nav, React devtools' selected-component focus, IDE nav-to-symbol + back, file browser breadcrumb drill-in.

## Surface

- **New opt** `:zoomable? boolean` (default `false`). When `true`:
  - Every non-empty non-root container in the tree renders a `⊙` affordance next to the expand triangle.
  - A breadcrumb row above the body renders when a zoom is active.
  - Esc keydown (while zoomed) pops one segment off the zoom path.
- **New app-db slot** `:rf.xray.edn-inspector/zoom` keyed by `[panel-id site-or-mount-id]` → absolute zoom-path vec (or absent for un-zoomed default).
- **New events**:
  - `:rf.xray.edn-inspector/zoom-to panel-id mount-id absolute-path`
  - `:rf.xray.edn-inspector/zoom-up panel-id mount-id`
  - `:rf.xray.edn-inspector/zoom-reset [panel-id mount-id]` (per-mount, or whole slot when args omitted)
- **New sub** `[:rf.xray.edn-inspector/zoom]` for the slot map.
- **Public helpers** for unit tests: `zoom-key`, `resolve-zoom-path`, `resolve-zoom-into`, `zoom-affordance-button`, `zoom-breadcrumbs`.
- **Consumer opt-in**: App-DB (`panels/app-db-diff-state`) sets `:zoomable? true` — the canonical zoom-target panel per the bead body.

## Design decisions (per worker review)

- **Affordance glyph**: `⊙` (circled-dot, U+2299). Reads as 'focus / aim cursor at this node'. Visually distinct from popup's `↗` and the expand triangles `▸`/`▾`.
- **Breadcrumb separator**: `›` (single right-pointing angle). Reads as nav direction; file-browser / IDE convention.
- **Popup vs zoom**: both affordances visible side-by-side when both opts are present. Different intents — zoom = stay-here focus; popup = open in new pane.
- **Diff mode suppresses zoom** — the diff path's force-expand-over-changes logic and zoom's hide-everything-outside-the-subtree are conflicting intents; diff renders the full value.
- **Esc coordination with popup**: handler installed on outer container only while zoom is active. Popup's own keydown handler stopPropagations on Escape, so an open popup intercepts first; subsequent Esc reaches the inspector and zooms up.
- **Root affordance skipped**: relative path `[]` (current displayed root) never renders an affordance; zooming into the current root is a no-op. The renderer composes absolute paths as `(into zoom-path-prefix path)` so the dispatched event stores the full path from the ORIGINAL root, regardless of how deep the current zoom is.
- **Per-mount keying**: two side-by-side mounts zoom independently; stable `:site-id` (rf2-pvsxs) preserves zoom across panel-leave-and-return.

## Tests

New unit tests cover the full surface:

- Pure helpers (`zoom-key` shape, `resolve-zoom-path` projection, `resolve-zoom-into` get-in walk + stale-path fallback).
- Event reducers (zoom-to / zoom-up / zoom-reset behaviour; per-mount vs global reset).
- Public widget plumbing — data-attrs (`:data-rf-zoomable`, `:data-rf-zoomed`, `:data-rf-zoom-path`), breadcrumb hiccup, affordance on non-root containers, root skip, diff suppression, persistence across unmount via `:site-id`, independent zoom across two mounts.
- Keydown handler — installed only when zoomed; Esc preventDefault + stopPropagation; non-Escape keys pass through.

Registry snapshot updated for the new sub + 3 events.

## Spec

`tools/xray/spec/021-Dynamic-Panel-Designs.md` §10.0.11 added with the full contract.

## Gates

- `npm run test:cljs` — 4628 tests / 14870 assertions / 0 failures / 0 errors.
- `npm run test:browser` — 124 tests / 346 assertions / 0 failures.
- `tools/xray` JVM tests — 859 tests / 3199 assertions / 0 failures.
- `npm run test:xray-feature-gate:smoke` — 3 scenarios / 0 failures.
- `clj-kondo --lint tools/xray/src tools/xray/test` — 0 errors.
- `mkdocs build --strict` — exit 0.

bd: rf2-h71e0