### PR TITLE
fix(xray): edn-inspector large-sentinel detection uses :rf.size/large-elided (rf2-ndb13)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs
@@ -23,7 +23,8 @@
   The new widget owns the WHOLE contract — browse + diff + mini —
   CLJS-aware type detection, distinct bracket styling per collection
   kind, click-to-toggle expansion stored in re-frame app-db, first-
-  class sentinel chrome (`:rf/redacted`, `:rf/large`). After phase 5
+  class sentinel chrome (`:rf/redacted`, `:rf.size/large-elided`).
+  After phase 5
   (rf2-q3dzw, D5=a per rf2-sndui) diff also routes through this same
   widget via the `:before` opt — the legacy `edn-inspector.render`
   engine is gone.

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
@@ -16,9 +16,9 @@
   - `views/edn-widget/widget` — superseded for current-state browse
     (phase 1 wires the App-DB panel here directly; phases 2-5 migrate
     the remaining call sites).
-  - `theme/data-inspector` — sentinels (`:rf/redacted`, `:rf/large`)
-    become first-class types INSIDE this widget; the chrome wrapper
-    goes away (D3=a per rf2-sndui).
+  - `theme/data-inspector` — sentinels (`:rf/redacted`,
+    `:rf.size/large-elided`) become first-class types INSIDE this
+    widget; the chrome wrapper goes away (D3=a per rf2-sndui).
   - `edn-inspector/render` — diff renderer subsumed (phase 5; D5=a per
     rf2-sndui). The diff path is now an opt-in mode on this same
     widget — pass `:before` to render with gutter glyphs +
@@ -321,12 +321,15 @@
   (= :rf/redacted v))
 
 (defn large-sentinel?
-  "`{:rf/large {:bytes N :head s}}` size-elision sentinel."
+  "`{:rf.size/large-elided <body>}` size-elision sentinel per Spec 015.
+  `<body>` carries `:path :bytes :type :reason :hint :handle` (plus
+  optional `:digest` when `:include-digests?` is set on the elision
+  walk). Emitted by `implementation/core/src/re_frame/elision.cljc`."
   [v]
   (and (map? v)
        (= 1 (count v))
        (let [[k m] (first v)]
-         (and (= :rf/large k) (map? m)))))
+         (and (= :rf.size/large-elided k) (map? m)))))
 
 (defn redacted+size-sentinel?
   "Combined `{:rf/redacted {:bytes N}}` — sensitive + size-aware."
@@ -732,10 +735,18 @@
                          :margin-left "4px"}}
           (str "· " bytes " bytes")])])
     :sentinel-large
-    (let [{:keys [bytes head]} (val (first v))]
-      [:span {:data-rf-type "rf-large"
+    ;; rf2-ndb13 — body keys per Spec 015 §Wire elision:
+    ;; `:path :bytes :type :reason :hint :handle`. `:type` is the
+    ;; original-value type tag (`:map :vector :string …`); `:hint`
+    ;; carries the schema-author's docstring; `:handle` is the
+    ;; structured fetch handle for a future drill-in affordance
+    ;; (deferred — see rf2-ndb13 "Out of scope").
+    (let [{:keys [bytes type hint]} (val (first v))]
+      [:span {:data-rf-type "rf-size-large-elided"
               :data-testid  "rf-xray-edn-inspector-large"
-              :title        (when head (str "Head preview: " head))
+              :title        (cond-> "Large value elided (spec/015)"
+                              type (str " · " (name type))
+                              hint (str "\n" hint))
               :style {:display       "inline-flex"
                       :align-items   "center"
                       :gap           "4px"

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_widget/widget.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_widget/widget.cljs
@@ -147,7 +147,8 @@
   L4 detail-panel renderer. Routes through the first-class
   edn-inspector widget (rf2-oqa60 phase 1) which classifies every type
   natively, including the spec/015 sentinels (`:rf/redacted` and
-  `:rf/large`) as first-class chip chrome (D3=a per rf2-sndui).
+  `:rf.size/large-elided`) as first-class chip chrome (D3=a per
+  rf2-sndui).
 
   Phase 1 delegates the legacy facade to the new widget so existing
   call sites compile unchanged; phases 2-4 migrate each surface
@@ -241,8 +242,8 @@
   "One-liner inline rendering of `value` via the first-class
   edn-inspector widget (rf2-oqa60 phase 1). Returns hiccup
   `[:span ...]` so callers embed inline. Sentinels (`:rf/redacted`,
-  `:rf/large`) keep their chip chrome inline; other values render as
-  a colour-coded inline-preview."
+  `:rf.size/large-elided`) keep their chip chrome inline; other values
+  render as a colour-coded inline-preview."
   ([value] (mini value 80))
   ([value max-len]
    (ei/mini value max-len)))

--- a/tools/xray/test/day8/re_frame2_xray/diff/annotated_tree_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/diff/annotated_tree_cljs_test.cljc
@@ -224,8 +224,19 @@
       (is (= "alice@example.com" (:after child))))))
 
 (deftest sentinel-large-same-both-sides
-  (testing "{:rf/large {:bytes N :head ...}} same both sides → :same"
-    (let [sentinel {:rf/large {:bytes 1024 :head "abc"}}
+  ;; rf2-ndb13 — sentinel shape is the spec/015 §Wire elision marker
+  ;; emitted by `implementation/core/src/re_frame/elision.cljc`. The
+  ;; diff op classification is opaque to the marker's body slots — any
+  ;; equal-both-sides value lands `:same` — but we use the framework-
+  ;; current shape so the corpus is uniform.
+  (testing "{:rf.size/large-elided <body>} same both sides → :same"
+    (let [sentinel {:rf.size/large-elided
+                    {:path   [:blob]
+                     :bytes  1024
+                     :type   :string
+                     :reason :schema
+                     :hint   nil
+                     :handle [:rf.elision/at [:blob]]}}
           tree (at/diff-tree sentinel sentinel)]
       (is (= :same (at/op-of tree))))))
 

--- a/tools/xray/test/day8/re_frame2_xray/theme/var_resolution_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/theme/var_resolution_cljs_test.cljs
@@ -284,8 +284,13 @@
                true                        ; boolean leaf
                nil                         ; nil leaf
                :rf/redacted                ; redacted sentinel
-               {:rf/large {:bytes 1234     ; large sentinel
-                           :head "abc"}}]]
+               {:rf.size/large-elided      ; large sentinel (spec/015)
+                {:path   [:blob]
+                 :bytes  1234
+                 :type   :string
+                 :reason :schema
+                 :hint   "preview hint"
+                 :handle [:rf.elision/at [:blob]]}}]]
       (let [tree (ei/render-node {:value v
                                   :panel-id :rf.xray/var-resolution-test
                                   :mount-id "test"

--- a/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs
@@ -18,8 +18,8 @@
   6. **Per-call-site isolation** — two `[edn-inspector]` mounts get
      independent `mount-id`s; toggling one path in mount-A leaves
      mount-B's same path untouched.
-  7. **Sentinels** (`:rf/redacted`, `:rf/large`, combined) render
-     their first-class chip chrome.
+  7. **Sentinels** (`:rf/redacted`, `:rf.size/large-elided`, combined)
+     render their first-class chip chrome.
 
   Pure-data unit tests; no DOM mount. Default for new Causa/Story
   tests per `feedback-causa-story-cljs-unit-tests-not-playwright`."
@@ -103,12 +103,42 @@
 (deftest classify-sentinels
   (testing "redacted bare keyword"
     (is (= :sentinel-redacted (ei/collection-kind :rf/redacted))))
-  (testing "large wrapper"
+  (testing "large wrapper — spec/015 §Wire elision shape"
+    ;; rf2-ndb13 — body keys per the framework's emission site
+    ;; (implementation/core/src/re_frame/elision.cljc): `:path :bytes
+    ;; :type :reason :hint :handle`.
     (is (= :sentinel-large
-           (ei/collection-kind {:rf/large {:bytes 200 :head "abc"}}))))
+           (ei/collection-kind
+             {:rf.size/large-elided {:path   [:big]
+                                     :bytes  200
+                                     :type   :string
+                                     :reason :schema
+                                     :hint   "preview hint"
+                                     :handle [:rf.elision/at [:big]]}}))))
   (testing "redacted-with-size wrapper"
     (is (= :sentinel-redacted-size
            (ei/collection-kind {:rf/redacted {:bytes 200}})))))
+
+(deftest large-sentinel-detects-spec-current-shape
+  ;; rf2-ndb13 — regression for stale-key bug. The predicate previously
+  ;; matched `:rf/large` (a key the framework no longer emits) and fell
+  ;; through generic map rendering for real markers. Lock in the
+  ;; spec-current key + pin the legacy key as a non-match.
+  (testing "spec-current `:rf.size/large-elided` wrapper is detected"
+    (is (true? (ei/large-sentinel?
+                 {:rf.size/large-elided {:path   [:p]
+                                         :bytes  1024
+                                         :type   :vector
+                                         :reason :schema
+                                         :hint   nil
+                                         :handle [:rf.elision/at [:p]]}}))))
+  (testing "legacy `:rf/large` shape is NOT detected (pre-alpha: no shim)"
+    (is (false? (ei/large-sentinel? {:rf/large {:bytes 1024 :head "abc"}}))))
+  (testing "ordinary one-key map is NOT detected"
+    (is (false? (ei/large-sentinel? {:not-a-sentinel {:bytes 1}}))))
+  (testing "non-map values are NOT detected"
+    (is (false? (ei/large-sentinel? :rf.size/large-elided)))
+    (is (false? (ei/large-sentinel? nil)))))
 
 ;; ---- scalar rendering ----------------------------------------------------
 
@@ -258,12 +288,48 @@
     (is (= (:magenta tokens) (-> h second :style :color)))))
 
 (deftest large-sentinel-chrome
-  (let [h (ei/render-scalar {:rf/large {:bytes 5000 :head "preview"}})
+  ;; rf2-ndb13 — marker shape is the framework-emitted spec/015 body:
+  ;; `:path :bytes :type :reason :hint :handle`.
+  (let [h (ei/render-scalar
+            {:rf.size/large-elided {:path   [:blob]
+                                    :bytes  5000
+                                    :type   :string
+                                    :reason :schema
+                                    :hint   "Upload preview"
+                                    :handle [:rf.elision/at [:blob]]}})
         all (collect-text h)]
     (is (some? (find-attr h :data-testid "rf-xray-edn-inspector-large")))
     (is (re-find #"large" all))
     (is (re-find #"5000" all))
     (is (= (:yellow tokens) (-> h second :style :color)))))
+
+(deftest large-sentinel-chrome-renders-when-marker-keys-missing
+  ;; rf2-ndb13 — defensive: the chip must render gracefully even if the
+  ;; emission side ever omits optional body slots. `:bytes` may be
+  ;; absent (no "· N bytes" segment); `:type` and `:hint` are optional
+  ;; (title degrades to the base sentence).
+  (testing "marker with only :path + :handle still renders the chip"
+    (let [h (ei/render-scalar
+              {:rf.size/large-elided {:path   [:x]
+                                      :handle [:rf.elision/at [:x]]}})]
+      (is (some? (find-attr h :data-testid "rf-xray-edn-inspector-large")))
+      (is (re-find #"large" (collect-text h))))))
+
+(deftest large-sentinel-not-rendered-as-plain-map
+  ;; rf2-ndb13 — the original symptom: real framework-emitted markers
+  ;; fell through to ordinary map rendering, exposing `:path :bytes
+  ;; :type :reason :hint :handle` as plain map keys. With the predicate
+  ;; pointed at the spec-current key, `collection-kind` MUST classify
+  ;; the marker as `:sentinel-large`, NOT `:map`.
+  (let [marker {:rf.size/large-elided {:path   [:blob]
+                                       :bytes  5000
+                                       :type   :string
+                                       :reason :schema
+                                       :hint   nil
+                                       :handle [:rf.elision/at [:blob]]}}]
+    (is (= :sentinel-large (ei/collection-kind marker))
+        "marker classifies as sentinel-large (not :map)")
+    (is (not= :map (ei/collection-kind marker)))))
 
 (deftest redacted-size-sentinel-chrome
   (let [h (ei/render-scalar {:rf/redacted {:bytes 200}})

--- a/tools/xray/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/xray/testbeds/feature_matrix/scenarios.cjs
@@ -1606,9 +1606,21 @@ async function runLargeDispatcher(page, state) {
   const traceEvents = await readTrace(page);
   await clickSidebar(page, 'app-db', 'rf-xray-app-db-diff');
   await expectVisible(page.locator('[data-testid="rf-xray-app-db-diff"]'), 5000);
+  // rf2-ndb13 — large markers render as first-class chip chrome inside
+  // the edn-inspector (the predicate previously mis-matched `:rf/large`
+  // and the marker fell through to ordinary map rendering, surfacing
+  // the `:rf.size/large-elided` keyword as plain text). With the
+  // predicate now keyed off the spec/015 marker, the chip appears under
+  // `[data-testid="rf-xray-edn-inspector-large"]`. Assert chip presence
+  // and absence of the raw payload — the two together cover "elision
+  // marker surfaced" and "raw value never leaks".
+  const largeChips = page.locator(
+    '[data-testid="rf-xray-app-db-diff"] [data-testid="rf-xray-edn-inspector-large"]',
+  );
+  const largeChipCount = await largeChips.count();
   const appDbText = ((await page.locator('[data-testid="rf-xray-app-db-diff"]').textContent()) || '').trim();
-  if (!appDbText.includes(':rf.size/large-elided')) {
-    failWithDetails('Large-value 20-dispatch load did not surface elision markers in App-DB Diff', {
+  if (largeChipCount === 0) {
+    failWithDetails('Large-value 20-dispatch load did not render elision chip chrome in App-DB Diff', {
       traceCount: traceEvents.length,
       tail: traceEvents.slice(-20),
       appDbText: appDbText.slice(0, 1200),


### PR DESCRIPTION
## What

Fix the edn-inspectors `large-sentinel?` predicate — it matched the stale key `:rf/large`, but the framework emits `:rf.size/large-elided` per spec/015 §Wire elision. Real markers fell through to ordinary map rendering, exposing body slots (`:path :bytes :type :reason :hint :handle`) as plain map keys instead of the `● large · N bytes` chip.

Not a crash risk — the LARGE value itself never crossed the wire (framework elides before the marker reaches Xray) — but the chip was dead code and the operators read was muddied by raw framework-internal slot names.

## Why

`bd show rf2-ndb13` — live-diagnosed 2026-05-26. Stale-key bug; pre-alpha posture means we drop `:rf/large` entirely (no shim).

## Changes

### Code
- `views/edn_inspector.cljs` — `large-sentinel?` keyed off `:rf.size/large-elided`; `:sentinel-large` chip destructures the spec/015 body (`:bytes :type :hint`) and surfaces the type + hint in the chip title.
- `views/edn_widget/widget.cljs`, `panels/app_db_diff_state.cljs` — docstring corpus aligned.

### Tests
- `views/edn_inspector_cljs_test.cljs` — `classify-sentinels` + `large-sentinel-chrome` use the spec-current marker shape. New `large-sentinel-detects-spec-current-shape` pins the legacy `:rf/large` as a NON-match (regression lock). New `large-sentinel-not-rendered-as-plain-map` asserts `collection-kind` classifies a real marker as `:sentinel-large` (not `:map`) — direct symptom-coverage for this bug.
- `diff/annotated_tree_cljs_test.cljc`, `theme/var_resolution_cljs_test.cljs` — corpus alignment.

### Feature gate
- `testbeds/feature_matrix/scenarios.cjs` (`runLargeDispatcher`) — the 20-event large value elision scenario previously asserted the literal `:rf.size/large-elided` text in the App-DB Diff DOM, which was only present BECAUSE of the bug (marker falling through to map render). Now asserts presence of the `rf-xray-edn-inspector-large` chip testid + absence of the raw payload — covers both "elision surfaced" and "raw value never leaks".

## Acceptance (per bead rf2-ndb13)

1. `large-sentinel?` detects spec-current `{:rf.size/large-elided <body>}` shape. ✓
2. `large-sentinel?` does NOT detect legacy `{:rf/large <body>}`. ✓
3. `collection-kind` classifies a framework-emitted marker as `:sentinel-large`. ✓
4. `:sentinel-large` chip renders bytes count + type (when present) instead of generic map. ✓
5. Live verification via feature-gate scenario `runLargeDispatcher` — chip surfaced, raw value not leaked. ✓
6. `mini` (inline one-liner) routes large sentinels through the chip via the existing `:sentinel-large` branch at line 2312 (unchanged — cascades through the fixed `collection-kind`). ✓
7. `:rf/redacted` and `{:rf/redacted {:bytes N}}` unchanged. ✓

## Out of scope

- `:handle` surfacing as a clickable drill-in affordance — separate UX bead.
- Spec docs (`tools/xray/spec/*.md`) still reference `:rf/large` in design copy; that corpus drift is documentation, not code, and warrants its own spec-sync bead. Filing separately.

## Gates run

- `npm run test:cljs` — 4604 tests / 14821 assertions, 0 failures
- `npm run test:browser` — 124 tests / 346 assertions, 0 failures
- `tools/xray` `clojure -M:test` — 859 tests / 3199 assertions, 0 failures
- `npm run test:xray-feature-gate` — 13 scenarios, 0 failures
- `clj-kondo --lint tools/xray/src tools/xray/test` — 0 errors

Closes rf2-ndb13.