### PR TITLE
fix(xray): remove redundant App-DB inspector-card hairlines (rf2-jcdvo)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_helpers.cljc
@@ -267,10 +267,14 @@
 ;;     `:rf/system-ids`, `:rf/pending-navigation`, and `:rf/elision`
 ;;     are singletons.
 ;;
-;; If a reserved area is ABSENT or empty the section still renders — as
-;; an empty-state placeholder — so the developer always sees the full
-;; reserved inventory and learns which areas are unpopulated rather than
-;; wondering whether the panel dropped them.
+;; Empty / absent reserved areas are FILTERED at projection time
+;; (rf2-jcdvo) — `current-state-sections` omits any area that is
+;; absent / nil / present-but-empty. The operator sees only areas
+;; that actually carry state; the panel is no longer cluttered with
+;; six labelled "No machines registered." / "No active route." /
+;; etc. placeholder cards. The TOP user-domain section ALWAYS renders
+;; (it is the panel's anchor; an empty user-domain app-db is itself
+;; meaningful operator information).
 
 (def reserved-area-order
   "Render order for the reserved-area sections (after the user-domain
@@ -369,12 +373,34 @@
                 :value {…}}
                …]}
 
-  One area entry per reserved `:rf/*` key (in `reserved-area-order`),
-  ALWAYS present even when absent/empty — `:empty?` flags the
-  empty-state so the renderer draws a blank section rather than omitting
-  it. Map-of-instances areas (`map-of-instances-areas`) carry
-  `:kind :instances` + an `:instances` vector (one entry per id);
-  every other reserved area is `:kind :singleton` + a `:value`.
+  One area entry per POPULATED reserved `:rf/*` key (in
+  `reserved-area-order`). Map-of-instances areas
+  (`map-of-instances-areas`) carry `:kind :instances` + an `:instances`
+  vector (one entry per id); every other reserved area is
+  `:kind :singleton` + a `:value`.
+
+  ## Empty-area filtering (rf2-jcdvo)
+
+  Empty / absent reserved areas are OMITTED from `:areas` entirely. An
+  area is empty when:
+
+    - the reserved key is absent from the db, OR
+    - the value is `nil`, OR
+    - the value is a present-but-empty collection (`{}` pending-nav,
+      `{}` registry, `#{}` system-ids), OR
+    - (for `:rf/machines` / `:rf/spawned`) the registry contains no
+      instance ids.
+
+  The renderer is the only consumer that needs the `:empty?` flag, and
+  it never draws an empty section now (the placeholder cards added
+  visual noise — six labelled 'No X' cards mostly saying 'nothing
+  here'). Populated areas still carry `:empty? false` for callers that
+  inspect the model shape; the slot is preserved for symmetry.
+
+  The TOP user-domain section is NOT filtered — it always appears in
+  the renderer's output, even when the user-domain app-db is empty
+  (it's the panel's anchor; an empty user-domain app-db is itself
+  meaningful operator information).
 
   ## Inline diff (spec/021 §4.3, rf2-ad7zx.11)
 
@@ -406,28 +432,34 @@
                     (user-domain-db before-db)
                     no-diff)
       :areas (vec
-               (for [area reserved-area-order]
-                 (let [present?    (contains? db area)
-                       area-value  (get db area)]
-                   (if (contains? map-of-instances-areas area)
-                     (let [instances (instances-of area-value
-                                                    (before-area area))]
-                       {:area      area
-                        :kind      :instances
-                        :empty?    (empty? instances)
-                        :instances instances})
-                     {:area   area
-                      :kind   :singleton
-                      ;; A singleton is empty when the key is absent, or
-                      ;; present-but-nil, or present-but-empty-collection
-                      ;; (e.g. `{}` pending-nav). Scalars / non-empty
-                      ;; collections are non-empty.
-                      :empty? (or (not present?)
-                                  (nil? area-value)
-                                  (and (coll? area-value)
-                                       (empty? area-value)))
-                      :value  area-value
-                      :before (before-area area)}))))})))
+               (for [area reserved-area-order
+                     :let [present?   (contains? db area)
+                           area-value (get db area)
+                           entry      (if (contains? map-of-instances-areas area)
+                                        (let [instances (instances-of area-value
+                                                                       (before-area area))]
+                                          {:area      area
+                                           :kind      :instances
+                                           :empty?    (empty? instances)
+                                           :instances instances})
+                                        {:area   area
+                                         :kind   :singleton
+                                         ;; A singleton is empty when the key is absent, or
+                                         ;; present-but-nil, or present-but-empty-collection
+                                         ;; (e.g. `{}` pending-nav). Scalars / non-empty
+                                         ;; collections are non-empty.
+                                         :empty? (or (not present?)
+                                                     (nil? area-value)
+                                                     (and (coll? area-value)
+                                                          (empty? area-value)))
+                                         :value  area-value
+                                         :before (before-area area)})]
+                     ;; rf2-jcdvo — empty areas are omitted from :areas;
+                     ;; the renderer never draws labelled "No X" placeholder
+                     ;; cards. The TOP user-domain section (above) is the
+                     ;; only always-rendered slot.
+                     :when (not (:empty? entry))]
+                 entry))})))
 
 ;; ---- 'Show me when this changed' walker ---------------------------------
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs
@@ -6,16 +6,22 @@
   `app-db-diff-helpers/current-state-sections` produces:
 
     - a TOP section — the app-db MINUS every reserved `:rf/*` key (the
-      user-domain app-db).
-    - one section per reserved `:rf/*` area (per spec/Conventions.md
-      §Reserved app-db keys). Map-of-instances areas (`:rf/machines`,
-      `:rf/spawned`) FAN OUT to one named sub-section per instance —
-      section title = the instance id (e.g. `:title/flow`). Singleton
-      slices (`:rf/route`, `:rf/system-ids`, `:rf/pending-navigation`,
-      `:rf/elision`) render as one section each.
+      user-domain app-db). ALWAYS renders, even when empty.
+    - one section per POPULATED reserved `:rf/*` area (per
+      spec/Conventions.md §Reserved app-db keys). Map-of-instances
+      areas (`:rf/machines`, `:rf/spawned`) FAN OUT to one named
+      sub-section per instance — section title = the instance id (e.g.
+      `:title/flow`). Singleton slices (`:rf/route`, `:rf/system-ids`,
+      `:rf/pending-navigation`, `:rf/elision`) render as one section
+      each.
 
-  Every reserved area renders even when absent/empty — an empty-state
-  placeholder — so the developer sees the full reserved inventory.
+  rf2-jcdvo — empty / absent reserved areas are FILTERED at projection
+  time (`current-state-sections` omits any `:empty?` entry). The
+  operator sees only areas that actually carry state; the panel is no
+  longer cluttered with six labelled 'No X' placeholder cards. As
+  state accrues (e.g. operator triggers navigation that populates
+  `:rf/pending-navigation`), the corresponding card appears
+  automatically — visibility is data-driven.
 
   ## Current-state render — first-class edn-inspector widget (rf2-oqa60)
 
@@ -33,15 +39,22 @@
   unaffected on surfaces still wired to it (Trace, segment-inspector,
   Event lens, Static panels) until phases 2-4 migrate them.
 
-  ## Flat-hairline layout (spec/021 §4.2-4.3, Figma · rf2-ad7zx.11)
+  ## Inspector-card layout (rf2-63ie5 + rf2-okq7p, post-rf2-jcdvo)
 
-  Reconciled to `tools/xray/design-reference/xray_devtools_reference.cljs`
-  (the `app-db-panel` component):
-  sections render FLAT — an uppercase caption label over the value body,
-  with adjacent sections separated by a 1px hairline (`border-t`), NOT
-  bordered cards. The old `:bg-3` card + radius + per-section header-rule
-  chrome is gone; the panel reads as one continuous scroll keyed by
-  caption labels.
+  Each section's value body renders through the first-class edn-inspector
+  widget with `:card? true` (rf2-63ie5) and a header ribbon (rf2-okq7p),
+  giving each top-level mount discrete inspector-card chrome — border +
+  radius + background + header. Adjacent cards self-separate via that
+  chrome + the inter-card vertical gap; rf2-jcdvo dropped the redundant
+  inter-section hairline that competed with the card borders for the
+  eye's attention.
+
+  Empty reserved-area sections are FILTERED at projection time
+  (`current-state-sections` omits any `:empty?` entry). The operator
+  sees only areas that actually carry state — no labelled 'No machines
+  registered.' / 'No active route.' placeholder cards. The TOP
+  user-domain section ALWAYS renders (it is the panel's anchor; an
+  empty user-domain app-db is itself meaningful operator information).
 
   ## Inline `← changed` annotation (spec/021 §4.3)
 
@@ -69,22 +82,20 @@
 ;; ---- shared section chrome ----------------------------------------------
 
 (defn- section-shell
-  "A flat current-state section (spec/021 §4.2, Figma). `title` is hiccup
-  (so callers can colour the reserved-area / instance-id label);
-  `testid` hooks the section for tests; `body` is the section's content
-  hiccup; `first?` suppresses the leading hairline on the panel's top
-  section.
+  "A current-state section wrapper. `title` is hiccup (so callers can
+  colour the reserved-area / instance-id label); `testid` hooks the
+  section for tests; `body` is the section's content hiccup;
+  `hide-header?` suppresses the section-shell H3 (used when the body's
+  own card chrome carries its own header ribbon — the common case post-
+  rf2-okq7p).
 
-  Renders FLAT — an uppercase caption label over the value body, no card
-  surface. Adjacent sections are separated by a 1px hairline drawn as a
-  `border-top` on every section after the first (Figma's `border-t`
-  dividers). Reuses Xray's token CSS variables so light/dark resolve."
-  [{:keys [testid title body first? hide-header?]}]
+  rf2-jcdvo dropped the inter-section hairline divider — each card's
+  own border + the inter-card vertical gap is sufficient visual
+  separation; the divider was redundant chrome that competed with the
+  card borders for the eye's attention."
+  [{:keys [testid title body hide-header?]}]
   [:section {:data-testid testid
-             :style       (cond-> {:padding "12px 12px 4px"}
-                            (not first?)
-                            (assoc :border-top
-                                   (str "1px solid " (:border-subtle tokens))))}
+             :style       {:padding "12px 12px 4px"}}
    (when-not hide-header?
      [:h3 {:style {:display         "flex"
                    :align-items     "center"
@@ -194,15 +205,19 @@
   user-domain app-db). Renders the whole user-domain value as a
   current-state / diff tree. Empty-state when the user-domain app-db is
   empty (e.g. boot value / reserved-keys-only db). `before` is the
-  prior user-domain value (or `h/no-diff`); `first?` suppresses the
-  panel-leading hairline."
-  ([top] (top-section top h/no-diff true))
-  ([top before first?]
+  prior user-domain value (or `h/no-diff`).
+
+  rf2-jcdvo — the TOP section ALWAYS renders, even when empty (it is
+  the panel's anchor; an empty user-domain app-db is itself meaningful
+  operator information). Empty reserved-area sections are filtered at
+  projection time and never reach the renderer; only the TOP carries
+  an empty-state body."
+  ([top] (top-section top h/no-diff))
+  ([top before]
    (let [title  [:span "app-db"]
          empty? (and (map? top) (empty? top))]
      (section-shell
        {:testid       "rf-xray-app-db-state-top"
-        :first?       first?
         :title        title
         :hide-header? (not empty?)
         :body         (if empty?
@@ -224,8 +239,8 @@
   reserved area — section title = the instance id. Used per machine
   (`:rf/machines`) and per parent (`:rf/spawned`). The instance carries
   its own `:before` pre-image so the body diff-annotates the changed
-  snapshot in place. Each instance section draws the leading hairline
-  (it is never the panel's first section — the TOP precedes it)."
+  snapshot in place. The section-shell H3 is suppressed — the
+  edn-inspector card's own header ribbon carries the title."
   [area {:keys [id value] :as inst}]
   (let [title [:span
                (area-label area)
@@ -237,7 +252,6 @@
     (section-shell
       {:testid       (str "rf-xray-app-db-state-instance-"
                           (pr-str area) "-" (pr-str id))
-       :first?       false
        :title        title
        :hide-header? true
        :body         (value-body value (get inst :before h/no-diff)
@@ -246,55 +260,42 @@
 
 (defn instances-area
   "Render a map-of-instances reserved area (`:rf/machines`,
-  `:rf/spawned`). Fans out to one `instance-section` per id. When the
-  registry is empty/absent, renders a single empty-state section so the
-  area is still visible in the inventory."
-  [{:keys [area empty? instances]}]
-  (if empty?
-    (section-shell
-      {:testid (str "rf-xray-app-db-state-area-" (pr-str area))
-       :first? false
-       :title  (area-label area)
-       :body   (empty-body
-                 (case area
-                   :rf/machines "No machines registered."
-                   :rf/spawned  "No spawned actors."
-                   "Empty."))})
-    (into [:div {:data-testid (str "rf-xray-app-db-state-area-" (pr-str area))}]
-          (for [{:keys [id] :as inst} instances]
-            (with-meta (instance-section area inst)
-                       {:key (pr-str id)})))))
+  `:rf/spawned`). Fans out to one `instance-section` per id.
+
+  rf2-jcdvo — empty registries are filtered at projection time
+  (`current-state-sections` omits `:empty?` entries) so this fn is
+  only invoked for populated registries; no empty-state branch."
+  [{:keys [area instances]}]
+  (into [:div {:data-testid (str "rf-xray-app-db-state-area-" (pr-str area))}]
+        (for [{:keys [id] :as inst} instances]
+          (with-meta (instance-section area inst)
+                     {:key (pr-str id)}))))
 
 (defn singleton-area
   "Render a singleton-slice reserved area (`:rf/route`,
   `:rf/system-ids`, `:rf/pending-navigation`, `:rf/elision`) as ONE
-  section. The section title is the singular slice name (e.g. `route`
-  for `:rf/route`). Empty/absent slices render the empty-state body;
-  populated slices carry their `:before` pre-image for the inline diff
-  annotation."
-  [{:keys [area empty? value] :as area-entry}]
+  section.
+
+  rf2-jcdvo — empty/absent slices are filtered at projection time
+  (`current-state-sections` omits `:empty?` entries) so this fn is
+  only invoked for populated slices; no empty-state branch. The
+  section-shell H3 is suppressed — the edn-inspector card's own header
+  ribbon carries the title."
+  [{:keys [area value] :as area-entry}]
   (let [title (area-label area)]
     (section-shell
       {:testid       (str "rf-xray-app-db-state-area-" (pr-str area))
-       :first?       false
        :title        title
-       :hide-header? (not empty?)
-       :body         (if empty?
-                       (empty-body
-                         (case area
-                           :rf/route              "No active route."
-                           :rf/system-ids         "No system-id bindings."
-                           :rf/pending-navigation "No navigation pending."
-                           :rf/elision            "No elision declarations."
-                           "Empty."))
-                       (value-body value (get area-entry :before h/no-diff)
-                                   (pr-str area)
-                                   title))})))
+       :hide-header? true
+       :body         (value-body value (get area-entry :before h/no-diff)
+                                 (pr-str area)
+                                 title)})))
 
 (defn area-section
   "Dispatch one reserved-area section entry (from
   `current-state-sections`'s `:areas`) to the matching renderer based
-  on its `:kind`."
+  on its `:kind`. Only invoked for non-empty areas — empty entries are
+  filtered at projection time (rf2-jcdvo)."
   [{:keys [kind] :as area-entry}]
   (case kind
     :instances (instances-area area-entry)
@@ -308,16 +309,15 @@
 (defn state-body
   "Render the full current-state inspector body for the section model
   `current-state-sections` produces: the TOP user-domain section
-  followed by one section group per reserved `:rf/*` area (in
-  `:areas` order). Adjacent sections are separated by 1px hairlines —
-  the TOP is the panel's first section (no leading hairline); every
-  reserved-area section after it draws the divider (spec/021 §4.2).
+  followed by one section group per POPULATED reserved `:rf/*` area
+  (in `:areas` order; rf2-jcdvo — empty areas are filtered at
+  projection time so only data-bearing cards reach the renderer).
   Each section threads its `:before` pre-image so changed nodes carry
   the inline `← changed` annotation (spec/021 §4.3). Pure hiccup;
   nil-safe (a nil model degrades to an empty TOP + no areas)."
   [{:keys [top areas] :as model}]
   (into [:div {:data-testid "rf-xray-app-db-state"}
-         (top-section top (get model :before-top h/no-diff) true)]
+         (top-section top (get model :before-top h/no-diff))]
         (for [{:keys [area] :as area-entry} areas]
           (with-meta (area-section area-entry)
                      {:key (pr-str area)}))))

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_subs.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_subs.cljs
@@ -323,8 +323,9 @@
   ;; sections render plain current-state — `current-state-sections`
   ;; falls back to its `no-diff` sentinel automatically.
   ;;
-  ;; nil-safe — an absent / empty db yields an empty TOP + every
-  ;; reserved area flagged `:empty?`.
+  ;; nil-safe — an absent / empty db yields an empty TOP + zero
+  ;; reserved-area entries (rf2-jcdvo — empty areas are filtered at
+  ;; projection time so the renderer never draws placeholder cards).
   (rf/reg-sub :rf.xray/app-db-state
     :<- [:rf.xray/target-frame-db]
     :<- [:rf.xray/selected-epoch-record]

--- a/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_cljs_test.cljs
@@ -6,9 +6,10 @@
   The app-db tab was redesigned from a diff view into a CURRENT-STATE
   inspector (re-frame-10x style), sectioned by reserved `:rf/*` area.
   The view-render tests assert the inspector shape (TOP user-domain
-  section, per-instance machine fan-out, singleton route, empty-state
-  for absent areas) via `app-db-diff-state/state-body` through the
-  Panel. The diff data subs (`:rf.xray/selected-epoch-diff` and the
+  section, per-instance machine fan-out, singleton route; rf2-jcdvo
+  — empty / absent reserved areas are filtered at projection time so
+  no placeholder cards reach the renderer) via
+  `app-db-diff-state/state-body` through the Panel. The diff data subs (`:rf.xray/selected-epoch-diff` and the
   composite `:rf.xray/app-db-diff`) survive for the Event tab diff
   surface + the redacted-modified count; their sub-level contracts are
   still pinned here.
@@ -582,9 +583,11 @@
         (is (some? (find-by-testid tree "rf-xray-app-db-state-area-:rf/route"))
             "route singleton section present")))))
 
-(deftest panel-renders-empty-reserved-areas
-  (testing "absent reserved areas still render (empty-state), not omitted
-            — the full :rf/* inventory is always visible"
+(deftest panel-omits-empty-reserved-areas
+  (testing "rf2-jcdvo — absent reserved areas are OMITTED from the
+            panel entirely; no placeholder cards. Visibility is
+            data-driven — a card appears when state accrues at that
+            slot, never as a persistent 'No X' placeholder."
     (seed-host-frame! {:counter 1})
     (registry/register-xray-handlers!)
     (frame/reg-frame :rf/xray {})
@@ -592,9 +595,9 @@
       (let [tree (app-db-diff/Panel)]
         (doseq [area [:rf/machines :rf/spawned :rf/route :rf/system-ids
                       :rf/pending-navigation :rf/elision]]
-          (is (some? (find-by-testid
-                       tree (str "rf-xray-app-db-state-area-" (pr-str area))))
-              (str "empty-state section present for " area)))))))
+          (is (nil? (find-by-testid
+                      tree (str "rf-xray-app-db-state-area-" (pr-str area))))
+              (str "no placeholder card for empty reserved area " area)))))))
 
 (deftest focus-slice-path-event-still-wired
   (testing "the :rf.xray/focus-slice-path event remains registered. UI

--- a/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_helpers_cljs_test.cljc
@@ -235,10 +235,16 @@
 ;;
 ;; The app-db tab is a CURRENT-STATE inspector. `current-state-sections`
 ;; splits the live app-db into:
-;;   - TOP: app-db MINUS reserved keys (user-domain).
-;;   - one section per reserved `:rf/*` area: machines/spawned fan out
-;;     one entry per instance id; route + the other slices are
-;;     singletons. Every area present even when empty (empty-state).
+;;   - TOP: app-db MINUS reserved keys (user-domain). ALWAYS present.
+;;   - one section per POPULATED reserved `:rf/*` area: machines/spawned
+;;     fan out one entry per instance id; route + the other slices are
+;;     singletons.
+;;
+;; rf2-jcdvo — empty / absent reserved areas are FILTERED at projection
+;; time (omitted from `:areas` entirely). The renderer never draws
+;; labelled "No X" placeholder cards; the operator sees only areas that
+;; actually carry state. The TOP user-domain section is the only
+;; always-rendered slot.
 
 (defn- area-by [model area]
   (some (fn [a] (when (= area (:area a)) a)) (:areas model)))
@@ -264,15 +270,23 @@
       (is (= {:counter 5 :user {:name "ada"}} (:top model))
           ":top excludes :rf/route"))))
 
-(deftest current-state-sections-enumerates-every-reserved-area
-  (testing "every reserved area appears in :areas exactly once, even when
-            absent from the db (empty-state)"
-    (let [model (h/current-state-sections {:counter 1})
+(deftest current-state-sections-enumerates-only-populated-areas
+  (testing "rf2-jcdvo — :areas contains ONLY populated reserved areas;
+            empty / absent areas are omitted entirely (no placeholder
+            cards in the rendered panel)"
+    (let [model (h/current-state-sections {:counter 1})]
+      (is (= [] (:areas model))
+          "a user-domain-only db produces zero reserved-area entries"))
+    (let [model (h/current-state-sections
+                  {:counter 1
+                   :rf/route    {:id :home}
+                   :rf/machines {:auth {:state :idle}}})
           areas (set (map :area (:areas model)))]
-      (is (= h/reserved-app-db-keys areas)
-          "the :areas cover the full reserved inventory")
-      (is (every? :empty? (:areas model))
-          "with no reserved slots in the db, every area is flagged :empty?"))))
+      (is (= #{:rf/machines :rf/route} areas)
+          "only the two populated areas appear; the other four reserved
+           slots are omitted")
+      (is (every? (complement :empty?) (:areas model))
+          "every entry in :areas is non-empty"))))
 
 (deftest current-state-sections-machines-fan-out-one-per-instance
   (testing ":rf/machines fans out to one instance entry per machine id —
@@ -297,16 +311,14 @@
       (is (= :instances (:kind area)))
       (is (= [:parent-a] (mapv :id (:instances area)))))))
 
-(deftest current-state-sections-empty-machines-registry-is-empty-state
-  (testing "an absent OR empty :rf/machines registry → :instances kind,
-            :empty? true, no instances (renders the empty-state section)"
-    (let [absent (area-by (h/current-state-sections {:counter 1}) :rf/machines)
-          empty  (area-by (h/current-state-sections {:rf/machines {}}) :rf/machines)]
-      (is (= :instances (:kind absent)))
-      (is (true? (:empty? absent)))
-      (is (= [] (:instances absent)))
-      (is (true? (:empty? empty))
-          "present-but-empty registry is still empty-state"))))
+(deftest current-state-sections-empty-machines-registry-is-omitted
+  (testing "rf2-jcdvo — an absent OR present-but-empty :rf/machines
+            registry is OMITTED from :areas entirely; no placeholder
+            card reaches the renderer"
+    (is (nil? (area-by (h/current-state-sections {:counter 1}) :rf/machines))
+        "absent :rf/machines → no area entry")
+    (is (nil? (area-by (h/current-state-sections {:rf/machines {}}) :rf/machines))
+        "present-but-empty registry → no area entry")))
 
 (deftest current-state-sections-route-is-singleton
   (testing ":rf/route is a SINGLE current-route slice → :singleton kind,
@@ -320,36 +332,41 @@
       (is (= route (:value area))
           "the section value is the whole current-route slice"))))
 
-(deftest current-state-sections-absent-route-is-empty-singleton
-  (testing "an absent :rf/route → :singleton kind, :empty? true (blank
-            section, not omitted)"
-    (let [area (area-by (h/current-state-sections {:counter 1}) :rf/route)]
-      (is (= :singleton (:kind area)))
-      (is (true? (:empty? area)))
-      (is (nil? (:value area))))))
+(deftest current-state-sections-absent-route-is-omitted
+  (testing "rf2-jcdvo — an absent :rf/route is OMITTED from :areas
+            entirely; no placeholder card reaches the renderer"
+    (is (nil? (area-by (h/current-state-sections {:counter 1}) :rf/route))
+        "absent :rf/route → no area entry")))
 
-(deftest current-state-sections-empty-singleton-collection-is-empty
-  (testing "a present-but-empty singleton collection (e.g. {} pending-nav)
-            is flagged :empty? so it renders the empty-state"
-    (let [area (area-by (h/current-state-sections {:rf/pending-navigation {}})
-                        :rf/pending-navigation)]
-      (is (= :singleton (:kind area)))
-      (is (true? (:empty? area))
-          "{} is empty-state"))))
+(deftest current-state-sections-empty-singleton-collection-is-omitted
+  (testing "rf2-jcdvo — a present-but-empty singleton collection
+            (e.g. {} pending-nav) is OMITTED from :areas entirely"
+    (is (nil? (area-by (h/current-state-sections {:rf/pending-navigation {}})
+                       :rf/pending-navigation))
+        "{} pending-navigation → no area entry")))
 
 (deftest current-state-sections-nil-and-empty-db-safe
-  (testing "nil-safe: nil / empty db yields an empty TOP + every reserved
-            area flagged empty"
+  (testing "rf2-jcdvo — nil-safe: nil / empty db yields an empty TOP +
+            ZERO reserved-area entries (every reserved area is empty so
+            every entry is filtered out)"
     (doseq [db [nil {}]]
       (let [model (h/current-state-sections db)]
         (is (= {} (:top model)))
-        (is (= h/reserved-app-db-keys (set (map :area (:areas model)))))
-        (is (every? :empty? (:areas model)))))))
+        (is (= [] (:areas model))
+            "no reserved-area entries — every reserved slot is empty so
+             every entry is filtered out at projection time")))))
 
 (deftest current-state-sections-area-order-is-stable
   (testing "areas render in `reserved-area-order` — machines + spawned
-            (the registries) lead, then the singleton slices"
-    (let [model (h/current-state-sections {})]
+            (the registries) lead, then the singleton slices. With every
+            reserved slot populated, all six appear in canonical order."
+    (let [db    {:rf/machines           {:auth {:state :idle}}
+                 :rf/spawned            {:parent {:invoke :child}}
+                 :rf/route              {:id :home}
+                 :rf/system-ids         #{:app}
+                 :rf/pending-navigation {:to :next}
+                 :rf/elision            {:declarations {}}}
+          model (h/current-state-sections db)]
       (is (= h/reserved-area-order (mapv :area (:areas model)))))))
 
 ;; ---- inline-diff section model (spec/021 §4.3, rf2-ad7zx.11) -------------

--- a/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_state_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_state_cljs_test.cljs
@@ -83,15 +83,16 @@
         (is (re-find #":title/flow" (pr-str flow-section))
             "section title carries the machine id")))))
 
-(deftest machines-empty-renders-single-empty-state-section
-  (testing "absent / empty :rf/machines → one empty-state area section,
-            NOT one-section-per-id (there are no ids)"
+(deftest machines-empty-is-omitted-entirely
+  (testing "rf2-jcdvo — absent / empty :rf/machines is OMITTED from the
+            rendered tree entirely (no placeholder card with 'No
+            machines registered.' copy)"
     (let [model (h/current-state-sections {:counter 1})
-          tree  (state/state-body model)
-          area  (find-by-testid tree "rf-xray-app-db-state-area-:rf/machines")]
-      (is (some? area) "machines area section is present even when empty")
-      (is (re-find #"No machines" (pr-str area))
-          "empty-state copy for machines"))))
+          tree  (state/state-body model)]
+      (is (nil? (find-by-testid tree "rf-xray-app-db-state-area-:rf/machines"))
+          "no machines area section in the tree")
+      (is (not (re-find #"No machines" (pr-str tree)))
+          "the dead 'No machines registered.' empty-state copy is gone"))))
 
 ;; ---- route singleton ----------------------------------------------------
 
@@ -105,39 +106,61 @@
       (is (some? (find-by-testid tree "rf-xray-app-db-state-area-:rf/route"))
           "route singleton section present"))))
 
-(deftest route-absent-renders-empty-section
-  (testing "absent :rf/route → singleton section in the empty-state
-            (blank, not omitted)"
+(deftest route-absent-is-omitted-entirely
+  (testing "rf2-jcdvo — absent :rf/route is OMITTED from the rendered
+            tree entirely (no placeholder card with 'No active route.'
+            copy)"
     (let [model (h/current-state-sections {:counter 1})
-          tree  (state/state-body model)
-          area  (find-by-testid tree "rf-xray-app-db-state-area-:rf/route")]
-      (is (some? area) "route section present even when no active route")
-      (is (re-find #"No active route" (pr-str area))
-          "route empty-state copy"))))
+          tree  (state/state-body model)]
+      (is (nil? (find-by-testid tree "rf-xray-app-db-state-area-:rf/route"))
+          "no route area section in the tree")
+      (is (not (re-find #"No active route" (pr-str tree)))
+          "the dead 'No active route.' empty-state copy is gone"))))
 
 ;; ---- full reserved inventory always present -----------------------------
 
-(deftest every-reserved-area-section-renders
-  (testing "the inventory is complete — every reserved :rf/* area has a
-            section even on an empty db (none omitted)"
+(deftest empty-db-renders-only-the-top-section
+  (testing "rf2-jcdvo — an empty db renders ONLY the TOP user-domain
+            section; every reserved-area card is omitted (data-driven
+            visibility — sections appear as state accrues, not as
+            persistent placeholders)"
     (let [model (h/current-state-sections {})
           tree  (state/state-body model)
           ids   (testids tree)]
-      ;; Singleton areas surface as `…-area-<key>`; machines/spawned do
-      ;; too when empty (single empty-state section).
+      (is (contains? ids "rf-xray-app-db-state-top")
+          "TOP is the panel's anchor — always renders")
       (doseq [area h/reserved-app-db-keys]
-        (is (contains? ids (str "rf-xray-app-db-state-area-" (pr-str area)))
-            (str "section present for reserved area " area))))))
+        (is (not (contains? ids (str "rf-xray-app-db-state-area-"
+                                     (pr-str area))))
+            (str "no placeholder card for empty reserved area " area))))))
+
+(deftest populated-reserved-areas-render
+  (testing "rf2-jcdvo — populated reserved areas render exactly as before
+            (only the empty-area filtering changed); each populated area
+            still gets a card the operator can read"
+    (let [model (h/current-state-sections
+                  {:counter 1
+                   :rf/route    {:id :home}
+                   :rf/machines {:auth {:state :idle}}})
+          tree  (state/state-body model)
+          ids   (testids tree)]
+      (is (contains? ids "rf-xray-app-db-state-area-:rf/route")
+          "populated route → area section present")
+      (is (contains? ids "rf-xray-app-db-state-instance-:rf/machines-:auth")
+          "populated machines → instance section present"))))
 
 ;; ---- nil-safety ---------------------------------------------------------
 
 (deftest state-body-nil-safe
-  (testing "nil / empty db model renders without throwing — TOP empty +
-            full reserved inventory empty-state"
+  (testing "rf2-jcdvo — nil / empty db model renders without throwing —
+            TOP empty + zero reserved-area cards (every reserved slot is
+            empty so every entry is filtered out at projection time)"
     (doseq [db [nil {}]]
       (let [tree (state/state-body (h/current-state-sections db))]
-        (is (some? (find-by-testid tree "rf-xray-app-db-state-top")))
-        (is (some? (find-by-testid tree "rf-xray-app-db-state-area-:rf/route")))))))
+        (is (some? (find-by-testid tree "rf-xray-app-db-state-top"))
+            "TOP is the panel's anchor — always renders")
+        (is (nil? (find-by-testid tree "rf-xray-app-db-state-area-:rf/route"))
+            "absent route → no placeholder card")))))
 
 ;; ---- affordance strip (rf2-kbxgj + rf2-ilubp) ---------------------------
 ;;
@@ -183,11 +206,14 @@
       (is (not-any? #(.endsWith % "-copy") ids)
           "no copy affordance on any app-db section value block"))))
 
-;; ---- flat-hairline structure (spec/021 §4.2, Figma · rf2-ad7zx.11) -------
+;; ---- section-shell chrome (rf2-jcdvo) ------------------------------------
 ;;
-;; Sections render FLAT — no bordered cards. The panel's first section
-;; (TOP) draws NO leading hairline; every section after it draws a 1px
-;; `border-top` hairline as the divider (the Figma `border-t` rule).
+;; rf2-jcdvo dropped the inter-section hairline divider — each card's
+;; own border (from the edn-inspector widget's `:card?` chrome) plus the
+;; inter-card vertical gap is sufficient visual separation. The
+;; section-shell wrapper draws padding only; no `border-top`, no
+;; `border`, no `background`, no `border-radius`. The card chrome lives
+;; inside the section body (the edn-inspector widget owns it).
 
 (defn- section-styles
   "Collect the inline `:style` map of every `<section>` node in the tree."
@@ -199,41 +225,55 @@
                           (map? (second node)))
                  (:style (second node)))))))
 
-(deftest sections-are-flat-not-cards
-  (testing "no section carries the old card chrome (bg / border-radius /
-            full 1px border); the flat layout uses caption + body only"
-    (let [model (h/current-state-sections
-                  {:counter 1
-                   :rf/route    {:id :home}
-                   :rf/machines {:title/flow {:state :idle}}})
-          tree  (state/state-body model)
+(deftest section-shells-draw-no-chrome
+  (testing "rf2-jcdvo — no `<section>` wrapper carries any chrome
+            (background / border / border-radius / border-top). The
+            section is a transparent padded container; the card chrome
+            lives inside the body via the edn-inspector widget's
+            `:card? true` opt"
+    (let [model  (h/current-state-sections
+                   {:counter 1
+                    :rf/route    {:id :home}
+                    :rf/machines {:title/flow {:state :idle}}})
+          tree   (state/state-body model)
           styles (section-styles tree)]
       (is (seq styles) "sections render")
       (doseq [s styles]
-        (is (nil? (:background s)) "no card background")
-        (is (nil? (:border-radius s)) "no card radius")
-        (is (nil? (:border s)) "no full card border (hairline is border-top)")))))
+        (is (nil? (:background s)) "no card background on section")
+        (is (nil? (:border-radius s)) "no card radius on section")
+        (is (nil? (:border s)) "no full border on section")
+        (is (nil? (:border-top s))
+            "rf2-jcdvo — no hairline border-top on any section")))))
 
-(deftest top-section-has-no-leading-hairline
-  (testing "the panel's first section (TOP) draws no leading hairline"
+(deftest top-section-draws-no-border-top
+  (testing "rf2-jcdvo — the TOP section's wrapper carries no border-top
+            (consistent with every other section now that the divider
+            was dropped)"
     (let [model (h/current-state-sections {:counter 1})
           tree  (state/state-body model)
           top   (find-by-testid tree "rf-xray-app-db-state-top")]
       (is (some? top))
       (is (nil? (:border-top (:style (second top))))
-          "TOP is first → no divider above it"))))
+          "TOP → no border-top divider"))))
 
-(deftest reserved-area-sections-draw-hairline-divider
-  (testing "every reserved-area section after the TOP draws a 1px
-            `border-top` hairline divider"
-    (let [model (h/current-state-sections {:counter 1})
-          tree  (state/state-body model)]
-      (doseq [area h/reserved-app-db-keys]
-        (let [sec (find-by-testid tree (str "rf-xray-app-db-state-area-"
-                                            (pr-str area)))]
-          (is (some? sec) (str "section present for " area))
-          (is (re-find #"1px solid" (str (:border-top (:style (second sec)))))
-              (str area " draws a 1px border-top hairline")))))))
+(deftest reserved-area-sections-draw-no-border-top
+  (testing "rf2-jcdvo — no populated reserved-area section draws a
+            hairline border-top divider above it (the card chrome alone
+            self-separates adjacent cards). With every reserved slot
+            populated, every section renders without a divider."
+    (let [model (h/current-state-sections
+                  {:rf/machines           {:title/flow {:state :idle}}
+                   :rf/spawned            {:parent     {:invoke :child}}
+                   :rf/route              {:id :home}
+                   :rf/system-ids         #{:app}
+                   :rf/pending-navigation {:to :next}
+                   :rf/elision            {:declarations {}}})
+          tree   (state/state-body model)
+          styles (section-styles tree)]
+      (is (seq styles) "sections render")
+      (doseq [s styles]
+        (is (nil? (:border-top s))
+            "no hairline divider on any section")))))
 
 ;; ---- inline diff annotation (spec/021 §4.3 · rf2-ad7zx.11) ---------------
 ;;


### PR DESCRIPTION
Bead: rf2-jcdvo

## Summary

Two visual-noise reductions on the App-DB panel — both driven by the
bead body + Mike's pair-debug append (2026-05-26).

### Drop redundant inter-section hairlines

`section-shell` drew a 1px `border-top` hairline between adjacent
sections (the pre-rf2-63ie5 flat-layout divider). Now that each card
carries its own chrome via the edn-inspector widget's `:card? true`
opt (rf2-63ie5) + header ribbon (rf2-okq7p), the hairline doubled up
with the card borders — operator's eye saw ` border + space + divider
+ space + border `.

Picked option (a) from the bead — drop the divider unconditionally.

### Hide empty reserved-area sections (additive)

Empty / absent reserved-area sections (`:rf/system-ids` "No system-id
bindings.", `:rf/route` "No active route.", etc.) cluttered the panel
with six labelled placeholder cards mostly saying 'nothing here',
obscuring the areas that actually carried state.

Picked option (a) — filter at projection time. `current-state-sections`
now omits any `:empty?` entry from `:areas`. The TOP user-domain
section always renders (it's the panel's anchor; an empty user-domain
app-db is itself meaningful operator information). Visibility is
data-driven — cards appear as state accrues.

The dead `empty-body` strings in `instances-area` / `singleton-area`
are removed; their branches are unreachable post-filter.

## Surface

- `tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs`
- `tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_helpers.cljc`
- `tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_subs.cljs` (docstring only)
- `tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_state_cljs_test.cljs`
- `tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_helpers_cljs_test.cljc`
- `tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_cljs_test.cljs`

`section-shell` is App-DB-local (`defn-`); no other panels affected.

## Tests

Tests inverted — what used to assert placeholder presence now asserts
placeholder absence + TOP-still-renders. Border-top tests inverted to
assert no hairline on any section. Added a `populated-reserved-areas-render`
positive case so the data-driven visibility is pinned both ways.

## Acceptance map

1. App-DB panel: no hairline divider lines between adjacent cards. (section-shells-draw-no-chrome / reserved-area-sections-draw-no-border-top)
2. Cards still read as visually distinct via their own card chrome. (browse-mode-mounts-carry-card-opt / diff-mode-mounts-also-carry-card-opt — pre-existing pins on `:card? true`)
3. Empty-state sections (when present) still read cleanly. N/A — empty reserved-area sections are now filtered out entirely; the TOP empty-state still works via `top-section-empty-when-no-user-domain-keys`.
4. `section-shell` is App-DB-local (`defn-`); no other panels touched.
5. Reserved-area sections marked `:empty? true` do NOT render. (panel-omits-empty-reserved-areas, route-absent-is-omitted-entirely, machines-empty-is-omitted-entirely)
6. As state accrues, the section appears automatically. (populated-reserved-areas-render asserts populated areas render; combined with #5)
7. TOP user-domain section ALWAYS renders, even if empty. (top-section-empty-when-no-user-domain-keys, state-body-nil-safe, empty-db-renders-only-the-top-section)
8. Dead empty-state body strings removed from `singleton-area` / `instances-area`.

## Gates

- `tools/xray` JVM tests: 859 tests / 3190 assertions, 0 failures
- `npm run test:cljs`: 4631 tests / 14861 assertions, 0 failures
- `npm run test:browser`: 124 tests / 346 assertions, 0 failures
- `npm run test:xray-feature-gate`: 13 scenarios, 0 failures
- `clj-kondo --lint tools/xray/src tools/xray/test`: 0 errors