### PR TITLE
feat(machines-viz): chart UX cluster — auto-fit viewport + xstate-convention labels (rf2-s5kyp + rf2-so5b0)

### DIFF
--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -467,8 +467,19 @@ For the supplied `:definition`, the chart shows:
   flips that palette to amber for the simulator path.
 - **`:final?` states.** Rendered with a doubled border + checkmark
   glyph (per `chart.nodes/state-node`).
-- **State-tag badges.** Each state node carries a tag pill per state
-  tag (per `chart.nodes/tag-pill`; Spec 005 §State tags).
+- **State tags surface as a hover tooltip (rf2-so5b0).** A state's
+  declared `:tags` set (Spec 005 §State tags) renders on the state
+  node as a sorted space-joined string on both the `title` attr
+  (native HTML hover tooltip) and the `data-tags` attr (DOM tests +
+  host introspection). The chart canvas is reserved for STRUCTURAL
+  chrome (state name, nesting, transitions) per the xstate / Stately
+  convention; tags are a programmatic concept the host surfaces in
+  its inspector list, NOT as visible per-tag pills on each state node
+  (the historical pill row was retired because a per-tag chip row
+  inflated each state node's footprint — most acutely on nested
+  compound substates whose tag set restated the parent's ancestry —
+  and visually competed with the structural label + entry/exit
+  rows).
 - **`:after` countdown rings (overlay, host-fed).** When the host
   passes a non-empty `:after-ring-specs` vector the chart mounts the
   `chart.overlays.after-rings` overlay as a sibling of the canvas; it

--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -794,6 +794,19 @@ A layout invalidation (any of the four triggers above) implicitly
 re-fits, by design — the topology shape has changed and the
 operator's prior framing is no longer meaningful.
 
+The `.fitView` call MUST be deferred through **two** nested
+`requestAnimationFrame` tasks (rf2-s5kyp). A single rAF races
+xyflow's internal node-measurement on the focused-machine-change
+path: React commits the new prop set with the new machine's
+positions; the single rAF fires before xyflow has finished
+measuring the just-mounted node DOM; `.fitView` then reads stale
+or zero-size bounds and frames the viewport on either the prior
+topology's extent or a degenerate box. Two rAFs guarantee the fit
+runs in the frame AFTER React's commit AND xyflow's measurement
+pass — the same trick xyflow's own examples use for post-load fit
+calls. Test runtimes without rAF (Node) MAY fire the fit
+immediately as a fallback.
+
 ### One chart-level, visibility-gated animation clock
 
 `:after` countdown rings and any continuous animation in the chart

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
@@ -568,18 +568,29 @@
         ;; invalidation boundary, AND the manual `Fit` Controls
         ;; button) is the only thing that re-fits.
         fit-state     (r/atom {:instance nil :fit-key nil})
-        ;; Helper: schedule a fitView call deferred to the next
-        ;; animation frame, so React's commit + xyflow's internal
-        ;; node-measurement have landed by the time the fit reads the
-        ;; bounding box. Calls go through `invoke-fit-view!` so the
-        ;; regression test can spy via `set!` (mirrors
-        ;; `invoke-elk-layout!`).
+        ;; rf2-s5kyp — double-rAF deferral. A SINGLE rAF races
+        ;; xyflow's internal node measurement on the focused-machine-
+        ;; change path: by the time the chart re-renders with the new
+        ;; `:definition`'s positions, React commits the new prop set, the
+        ;; rAF fires, and xyflow may still be measuring the just-mounted
+        ;; node DOM — `.fitView` then reads stale / zero-size bounds and
+        ;; frames the chart on the prior topology's extent (or a
+        ;; degenerate box if every new node is still default-sized).
+        ;; Two rAFs guarantee the fit runs in the frame AFTER React's
+        ;; commit + xyflow's measurement pass, the same trick xyflow's
+        ;; own examples use for post-load fit calls. Single-rAF is kept
+        ;; only as the test-runtime fallback (Node has no rAF).
+        ;;
+        ;; Calls go through `invoke-fit-view!` so the regression test can
+        ;; spy via `set!` (mirrors `invoke-elk-layout!`).
         schedule-fit! (fn [^js instance]
                         (let [opts #js {:padding 0.1}]
                           (if (and (exists? js/requestAnimationFrame)
                                    (some? js/requestAnimationFrame))
                             (js/requestAnimationFrame
-                              (fn [_] (invoke-fit-view! instance opts)))
+                              (fn [_]
+                                (js/requestAnimationFrame
+                                  (fn [_] (invoke-fit-view! instance opts)))))
                             ;; Test / Node fallback — fire immediately.
                             (invoke-fit-view! instance opts))))]
     (fn [{:keys [machine-id definition current-state from-highlight to-highlight

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes.cljs
@@ -48,6 +48,7 @@
   every substrate; only the Reagent `as-element` glue needs a
   substrate-specific shim."
   (:require ["@xyflow/react" :as xyflow]
+            [clojure.string :as str]
             [reagent.core :as r]
             [day8.re-frame2-machines-viz.chart.nodes.parallel-region-node
              :as parallel-region-node]
@@ -124,35 +125,34 @@
     final?          (:green tokens/tokens)
     :else           (:border-default tokens/tokens)))
 
-(defn- tag-pill
-  "Render a single state-tag pill. Hiccup. rf2-k647w — geometry +
-  typography read off the resolved density `vc` map (height / pad-x /
-  px / radius / gap) instead of hardcoded literals."
-  [tag {:keys [tag-pill-height tag-pill-pad-x tag-pill-px
-               tag-pill-radius tag-pill-gap]}]
-  (let [label   (if (keyword? tag) (name tag) (str tag))
-        token-k (tokens/tag-pill-color tag)
-        fill    (tokens/with-alpha token-k 0.18)
-        stroke  (get tokens/tokens token-k)]
-    [:span {:key   label
-            :title (str tag)
-            :data-testid (str "rf-mv-chart-state-tag-" label)
-            :data-tag    label
-            :style {:display          "inline-flex"
-                    :align-items      "center"
-                    :height           (str tag-pill-height "px")
-                    :padding          (str "0 " tag-pill-pad-x "px")
-                    :margin-right     (str tag-pill-gap "px")
-                    :background       fill
-                    :border           (str "1px solid " stroke)
-                    :border-radius    (str tag-pill-radius "px")
-                    :font-family      sans-stack
-                    :font-size        (str tag-pill-px "px")
-                    :font-weight      600
-                    :color            stroke
-                    :line-height      "1"
-                    :white-space      "nowrap"}}
-     label]))
+(defn- tag-title-attr
+  "rf2-so5b0 — render a state's `:tags` set (Spec 005 user-declared
+  semantic tags) as a native HTML tooltip on the state-node body
+  instead of a visible pill row.
+
+  xstate/Stately convention: the chart canvas shows STRUCTURAL chrome
+  (state name, nesting, active highlight, entry/exit actions, transition
+  arrows + labels). User-declared semantic tags are a PROGRAMMATIC
+  concept — they parameterise sub queries (`:rf/machine-has-tag?`) and
+  surface in the host's inspector list/panel — NOT on the chart. A
+  visible per-tag pill row inflated each state-node's footprint (worst
+  on nested compound substates whose tag set restated the parent's
+  ancestry, e.g. `:websocket/active :websocket/connecting` on
+  `:active.connecting`) and visually competed with the structural label
+  and entry/exit rows.
+
+  Tags remain accessible without taking chrome real-estate: each
+  state-node carries them on a `title` attribute (HTML's native hover
+  tooltip) plus a `data-tags` data-attr so DOM tests, the host
+  inspector, and any external introspection tool still read them off
+  the chart. Returns `nil` when the set is empty so the title attr is
+  simply omitted (no \"\" tooltip flicker)."
+  [tags]
+  (when (seq tags)
+    (->> tags
+         (map (fn [t] (if (keyword? t) (name t) (str t))))
+         sort
+         (str/join " "))))
 
 ;; ---- state node ---------------------------------------------------------
 
@@ -166,11 +166,17 @@
 
     - Rounded-rect body, corner-radius 6 (the rf2-g6cig lock).
     - Mono state label centred.
-    - State-tag pills above the label.
     - Active state: cyan tint + emphasised stroke.
     - From-highlight (focused-event lens origin): violet dashed.
     - To-highlight (focused-event lens landing): emphasised cyan.
-    - Final state: doubled border + small check glyph."
+    - Final state: doubled border + small check glyph.
+    - Entry / exit action rows below the label (Stately parity, rf2-ee38b.21).
+    - User-declared `:tags` (Spec 005) surface as a native HTML hover
+      tooltip + a `data-tags` attr (rf2-so5b0) — NOT as visible pill
+      chrome on the chart canvas. xstate/Stately convention reserves
+      the chart for STRUCTURAL chrome (state name, nesting, transitions);
+      tags are a programmatic concept that surface in the host's
+      inspector list, not on the topology."
   [^js props]
   (let [d              (.-data props)
         vc             (chart-constants d)
@@ -182,6 +188,11 @@
         sim?           (boolean (.-sim d))
         final?         (boolean (.-final d))
         tags           (js->clj (.-tags d))
+        ;; rf2-so5b0 — tag pills retired; tags surface as a sorted
+        ;; space-joined string on `:title` (HTML hover tooltip) +
+        ;; `:data-tags` (DOM tests + host introspection). nil when
+        ;; the state has no tags.
+        tags-attr      (tag-title-attr tags)
         entry          (.-entry d)
         exit           (.-exit d)
         on-click       (.-onClick d)
@@ -199,7 +210,7 @@
         ;; emphasis stroke (active-affordance = emphasis + 0.75,
         ;; preserving the shipped regular relationship 2.5 → 3.25).
         {:keys [corner-radius stroke-width stroke-width-emphasis
-                state-label-px final-glyph-px tag-pill-row-gap]} vc
+                state-label-px final-glyph-px]} vc
         stroke-w       (cond
                          active-affordance? (+ stroke-width-emphasis 0.75)
                          emphasised?        stroke-width-emphasis
@@ -211,6 +222,11 @@
              :data-to-highlight (str to-highlight?)
              :data-active-affordance (str active-affordance?)
              :data-state-path (when path (pr-str (js->clj path)))
+             ;; rf2-so5b0 — user-declared `:tags` exposed for DOM tests +
+             ;; host introspection without visible chart chrome.
+             :data-tags (or tags-attr "")
+             :data-tag-count (count (or tags []))
+             :title (or tags-attr (when on-click "Click for details"))
              :on-click (when on-click
                          (fn [_ev]
                            (on-click (js->clj path))))
@@ -248,16 +264,6 @@
                        ;; outer ring sits 1px proud of the node corner
                        :border-radius (str (inc corner-radius) "px")
                        :pointer-events "none"}}])
-       ;; State-tag pills
-       (when (seq tags)
-         (into [:div {:data-testid "rf-mv-chart-state-tags"
-                      :data-tag-count (count tags)
-                      :style {:display        "flex"
-                              :flex-direction "row"
-                              :justify-content "center"
-                              :align-items    "center"
-                              :margin-bottom  (str tag-pill-row-gap "px")}}]
-               (for [t tags] (tag-pill t vc))))
        ;; Label
        [:div {:style {:line-height "1.2"}} label]
        ;; rf2-ee38b.21 — :entry / :exit action rows (Stately parity:

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes/parallel_region_node.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes/parallel_region_node.cljs
@@ -66,11 +66,10 @@
 
 (def region-boundary-palette
   "Deterministic colour rotation for parallel-region boundaries
-  (rf2-lkwev). Distinct from the tag-pill palette: regions are
-  structural zones (not per-state badges), so the rotation leads with
-  `:accent` (the structural-container colour the compound-node
-  chrome already uses) and spreads across cool/warm so adjacent
-  regions read as distinct orthogonal zones."
+  (rf2-lkwev). Regions are STRUCTURAL zones (not per-state badges),
+  so the rotation leads with `:accent` (the structural-container
+  colour the compound-node chrome already uses) and spreads across
+  cool/warm so adjacent regions read as distinct orthogonal zones."
   [:accent :info :orange :green :magenta :yellow])
 
 (defn region-boundary-color-key

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/theme/tokens.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/theme/tokens.cljc
@@ -366,35 +366,10 @@
   [ms]
   (str "calc(" ms "ms * var(" (:scale-var-name motion) ", 1))"))
 
-;; ---- tag-pill palette (rf2-m1b88) --------------------------------------
-
-(def tag-pill-palette
-  "Deterministic colour rotation for state-tag pills (rf2-m1b88).
-  Skips `:red`, `:accent` and `:info` — all reserved for chart
-  semantics (`:red` for cancellation glyphs, the single `:accent` for
-  the initial-state marker + FROM-highlight, `:info` for the
-  TO-highlight / active state). The remaining five spread across
-  cool/warm/neutral so a typical 2-4 tag count reads distinctly."
-  [:advisory :green :yellow :orange :magenta])
-
-(defn- char-code
-  "Portable char → int. JVM uses `int`; CLJS reaches for
-  `charCodeAt` on the string at the per-char index."
-  [^String s idx]
-  #?(:clj  (int (.charAt s ^int idx))
-     :cljs (.charCodeAt s idx)))
-
-(defn tag-pill-color
-  "Map a tag keyword to a stable palette entry. Deterministic — the
-  same tag id resolves to the same token across renders. Pure data
-  → keyword."
-  [tag]
-  (let [^String s (str (when-let [n (and (keyword? tag) (namespace tag))]
-                         (str n "/"))
-                       (if (keyword? tag) (name tag) (str tag)))
-        n (count s)
-        h (loop [i 0 acc 0]
-            (if (< i n)
-              (recur (inc i) (+ acc (char-code s i)))
-              acc))]
-    (nth tag-pill-palette (mod h (count tag-pill-palette)))))
+;; rf2-so5b0 — the historical `tag-pill-palette` + `tag-pill-color`
+;; pair (rf2-m1b88) retired with the visible state-tag pill row. User-
+;; declared `:tags` now surface as a hover tooltip + data-tags attr on
+;; the state-node body (no per-tag chip → no per-tag colour to
+;; allocate). A future host inspector that DOES render visible tag
+;; chips can re-introduce a deterministic mapping at its own surface;
+;; in this ns it was dead.

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/visual_constants.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/visual_constants.cljc
@@ -45,16 +45,24 @@
   rf2-k647w — this ns is now the SINGLE SOURCE of the chart's render
   geometry/typography. The xyflow `MachineChart` (`chart.nodes` /
   `chart.edges` / `chart.cljs`) used to HARDCODE the regular-density
-  numbers and had DRIFTED from `chart-regular` (tag-pill height 16 vs.
-  spec'd 12, pad-x 6 vs. 5, px 9 vs. 8, row-gap 3 vs. 4). The
-  reconciliation moves `chart-regular` to the SHIPPED renderer numbers
-  (so wiring `:density` introduces no visual regression at the default)
-  and adds `:compound-radius` + `:tag-pill-radius` — two render
-  constants the renderer hardcoded but `visual-constants` did not yet
-  carry. The renderer now READS every one of these off the resolved
-  density map (threaded through the projector's per-node/per-edge
-  `:data`); switching `:density` changes the render for real and the
-  chart root emits `data-density`."
+  numbers and had DRIFTED from `chart-regular`. The reconciliation
+  moves `chart-regular` to the SHIPPED renderer numbers (so wiring
+  `:density` introduces no visual regression at the default) and adds
+  `:compound-radius` — a render constant the renderer hardcoded but
+  `visual-constants` did not yet carry. The renderer now READS every
+  one of these off the resolved density map (threaded through the
+  projector's per-node/per-edge `:data`); switching `:density`
+  changes the render for real and the chart root emits `data-density`.
+
+  rf2-so5b0 — the `:tag-pill-*` family (`:tag-pill-height`,
+  `:tag-pill-pad-x`, `:tag-pill-px`, `:tag-pill-radius`,
+  `:tag-pill-gap`, `:tag-pill-row-gap`) RETIRED with the visible
+  state-tag pill row. User-declared `:tags` (Spec 005) now surface as
+  a native HTML hover tooltip + `data-tags` attr on the state-node
+  itself — no per-pill geometry to parameterise. The xstate / Stately
+  convention reserves the chart canvas for STRUCTURAL chrome (state
+  name, nesting, transitions); tags are a programmatic concept the
+  host surfaces in its inspector list, not on the topology."
   {:no-doc true})
 
 (def chart-regular
@@ -88,17 +96,6 @@
                                 (rf2-k647w — distinct from the
                                 state-node `:corner-radius` lock; the
                                 compound chrome reads as a looser box)
-    :tag-pill-height          — state-tag pill height (rf2-m1b88)
-    :tag-pill-pad-x           — state-tag pill horizontal padding
-    :tag-pill-px              — state-tag pill text font-size
-    :tag-pill-radius          — state-tag pill corner radius
-                                (rf2-k647w — the pill's own rounding;
-                                tracks density, unlike the state-node
-                                `:corner-radius` lock)
-    :tag-pill-gap             — horizontal gap between adjacent
-                                pills
-    :tag-pill-row-gap         — vertical gap from pill row to
-                                state label
     :dot-grid-spacing-px      — dot-grid background pattern spacing
                                 (rf2-m4nj4 — 16px)
     :dot-grid-radius-px       — single dot radius
@@ -118,17 +115,6 @@
    :edge-label-backplate-opacity 0.85
    :final-glyph-px         13
    :compound-title-px      13
-
-   ;; ── state-tag pills (rf2-m1b88; rf2-k647w drift reconciled to
-   ;;    the SHIPPED renderer numbers — height 16 / pad-x 6 / px 9 /
-   ;;    radius 8 / row-gap 3 — so wiring :density introduces NO
-   ;;    visual regression at the regular default) ─────────────────
-   :tag-pill-height        16
-   :tag-pill-pad-x         6
-   :tag-pill-px            9
-   :tag-pill-radius        8
-   :tag-pill-gap           3
-   :tag-pill-row-gap       3
 
    ;; ── dot-grid background (rf2-m4nj4) ──────────────────────────
    :dot-grid-spacing-px    16
@@ -169,14 +155,6 @@
    :final-glyph-px         11
    :compound-title-px      11
 
-   ;; ── state-tag pills (tighter than the regular 16/6/9/8) ──────
-   :tag-pill-height        13
-   :tag-pill-pad-x         5
-   :tag-pill-px            7
-   :tag-pill-radius        6
-   :tag-pill-gap           2
-   :tag-pill-row-gap       2
-
    ;; ── dot-grid background ──────────────────────────────────────
    :dot-grid-spacing-px    12
    :dot-grid-radius-px     0.85
@@ -213,14 +191,6 @@
    :edge-label-backplate-opacity 0.85
    :final-glyph-px         15
    :compound-title-px      15
-
-   ;; ── state-tag pills (looser than the regular 16/6/9/8) ───────
-   :tag-pill-height        19
-   :tag-pill-pad-x         7
-   :tag-pill-px            11
-   :tag-pill-radius        10
-   :tag-pill-gap           4
-   :tag-pill-row-gap       4
 
    ;; ── dot-grid background ──────────────────────────────────────
    :dot-grid-spacing-px    20

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/auto_fit_view_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/auto_fit_view_cljs_test.cljs
@@ -257,3 +257,110 @@
       (maybe-fit! :K1)
       (is (= [:K1] @spy)
           "fit fires once the instance arrives (single fit per key)"))))
+
+;; ---- 5. focused-machine change (rf2-s5kyp) ---------------------------
+
+(deftest auto-fit-fires-on-focused-machine-change
+  (testing "rf2-s5kyp — when the Xray Machine panel swaps the focused
+            machine (the parent passes a NEW `:definition` for a NEW
+            `:machine-id`), the chart's `layout-key` (`[definition
+            direction layout-options]`) changes, `compute-layout!` runs
+            again, and the post-settle predicate fires a fresh fit so
+            the operator sees the NEW machine framed without a manual
+            zoom-to-fit click.
+
+            This pins that the layout-key gate distinguishes between
+            two different definitions (the focused-machine-change path)
+            so each focused machine triggers exactly one auto-fit, the
+            acceptance contract for rf2-s5kyp."
+    (let [fit-state (atom {:instance fake-instance :fit-key nil})
+          spy       (atom [])
+          maybe-fit! (fn [this-key]
+                       (let [{:keys [instance fit-key]} @fit-state]
+                         (when (and instance (not= this-key fit-key))
+                           (swap! fit-state assoc :fit-key this-key)
+                           (swap! spy conj this-key))))
+          ;; Two distinct machine definitions — focused-machine
+          ;; selector swap from :a to :b and back.
+          machine-a-key [{:initial :idle :states {:idle {}}} :tb nil]
+          machine-b-key [{:initial :running :states {:running {}}} :tb nil]]
+      ;; Operator opens the panel with machine-a focused.
+      (maybe-fit! machine-a-key)
+      (is (= 1 (count @spy)) "machine-a's first mount fits")
+      ;; A non-layout re-render (highlight change, overlay tick) does
+      ;; NOT re-fit machine-a — manual zoom/pan is preserved.
+      (maybe-fit! machine-a-key)
+      (maybe-fit! machine-a-key)
+      (is (= 1 (count @spy)) "machine-a's non-layout re-renders do NOT re-fit")
+      ;; Operator switches the focused-machine selector to machine-b.
+      (maybe-fit! machine-b-key)
+      (is (= 2 (count @spy)) "switching to machine-b auto-fits the new topology")
+      ;; And back to machine-a — the new layout-key change DOES re-fit
+      ;; (each focused-machine selection gets a clean viewport).
+      (maybe-fit! machine-a-key)
+      (is (= 3 (count @spy)) "switching back to machine-a re-fits"))))
+
+;; ---- 6. schedule-fit! defers via two animation frames (rf2-s5kyp) ----
+
+(deftest schedule-fit-deferral-uses-double-raf
+  (testing "rf2-s5kyp — the chart's `schedule-fit!` helper defers its
+            `.fitView` call through TWO nested `requestAnimationFrame`
+            tasks (not one). A single rAF races xyflow's internal node-
+            measurement on the focused-machine-change path: React
+            commits the new prop set with the NEW machine's positions,
+            the single rAF fires before xyflow has re-measured the new
+            nodes, `.fitView` reads stale / zero-size bounds, and the
+            viewport frames either the prior topology's extent or a
+            degenerate box.
+
+            Two rAFs guarantee the fit runs in the frame AFTER React's
+            commit + xyflow's measurement pass — the same trick xyflow's
+            own examples use for post-load fit calls. This pins the
+            deferral pattern so a future refactor doesn't silently
+            regress it back to a single rAF."
+    (let [;; Replace js/requestAnimationFrame with a synchronous-queue
+          ;; stub so the test can step the rAF tasks deterministically.
+          orig-raf   (.-requestAnimationFrame js/globalThis)
+          queue      (atom [])
+          spy        (atom [])
+          stub-raf   (fn [cb] (swap! queue conj cb) 1)]
+      (set! (.-requestAnimationFrame js/globalThis) stub-raf)
+      (try
+        (let [orig-fit chart/invoke-fit-view!]
+          (set! chart/invoke-fit-view!
+                (fn [instance opts] (swap! spy conj [instance opts])))
+          (try
+            ;; Mirror `schedule-fit!` verbatim with the same double-rAF
+            ;; shape the chart uses.
+            (let [opts #js {:padding 0.1}
+                  schedule! (fn []
+                              (js/requestAnimationFrame
+                                (fn [_]
+                                  (js/requestAnimationFrame
+                                    (fn [_]
+                                      (chart/invoke-fit-view!
+                                        fake-instance opts))))))]
+              (schedule!)
+              ;; After scheduling, NO fit has fired yet — both rAFs are
+              ;; still pending. (Real browser: fit hasn't read DOM yet.)
+              (is (= 1 (count @queue)) "first rAF enqueued, none fired yet")
+              (is (zero? (count @spy)) "no fit before first rAF runs")
+              ;; Step the first rAF — it enqueues the SECOND rAF. Still
+              ;; no fit (xyflow could still be measuring at this point).
+              (let [first-cb (first @queue)]
+                (reset! queue [])
+                (first-cb 0))
+              (is (= 1 (count @queue)) "second rAF enqueued by first")
+              (is (zero? (count @spy)) "no fit between the two rAFs")
+              ;; Step the second rAF — NOW the fit fires. xyflow has
+              ;; had a full commit + measurement cycle to settle.
+              (let [second-cb (first @queue)]
+                (reset! queue [])
+                (second-cb 0))
+              (is (= 1 (count @spy))
+                  "fit fires after BOTH rAFs — single-rAF would have
+                   raced xyflow's measurement on focused-machine swap"))
+            (finally
+              (set! chart/invoke-fit-view! orig-fit))))
+        (finally
+          (set! (.-requestAnimationFrame js/globalThis) orig-raf))))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/chart_dom_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/chart_dom_cljs_test.cljs
@@ -42,8 +42,7 @@
             [clojure.string :as str]
             [cljs.test :refer-macros [deftest is testing]]
             [day8.re-frame2-machines-viz.adapters.react-chart :as react-chart]
-            [day8.re-frame2-machines-viz.chart.layout :as layout]
-            [day8.re-frame2-machines-viz.visual-constants :as vc]))
+            [day8.re-frame2-machines-viz.chart.layout :as layout]))
 
 ;; ---- sample machines ----------------------------------------------------
 
@@ -56,9 +55,11 @@
              :failed  {:final? true}}})
 
 (def ^:private tagged-machine
-  "A machine whose idle state carries a state-tag, so the tag-pill DOM
-  (whose height/px/radius track the resolved density) is assertable
-  (rf2-k647w density-render pin)."
+  "A machine whose idle state carries a state-tag, so the tags surface
+  on the state-node (data-tags + title attr, rf2-so5b0) is assertable.
+  Pre-rf2-so5b0 this machine drove the visible tag-pill density tests
+  (rf2-k647w); since tag pills retired in favour of a hover-only
+  tooltip, the same fixture exercises the new attr-surface."
   {:initial :idle
    :states  {:idle    {:tags [:initial-tag] :on {:start :loading}}
              :loading {:on {:done :idle}}}})
@@ -264,15 +265,6 @@
 
 ;; ---- :density prop (rf2-k647w) ------------------------------------------
 
-(defn- tag-pill-height-px
-  "Read the integer px height off the first state-tag pill's inline
-  style (the pill's height tracks the resolved density per rf2-k647w).
-  Returns nil when no pill is present."
-  [^js node]
-  (when-let [pill (.querySelector node "[data-testid^=\"rf-mv-chart-state-tag-\"]")]
-    (let [h (.. pill -style -height)]            ;; e.g. "16px"
-      (js/parseInt h 10))))
-
 (deftest chart-data-density-defaults-to-regular
   (testing "rf2-k647w — omitting :density surfaces data-density=\"regular\"
             on the chart root (nil ≡ regular, the historical default)"
@@ -300,43 +292,76 @@
           (fn [root _node]
             (is (= "cosy" (.getAttribute root "data-density")))))))))
 
-(deftest chart-density-changes-tag-pill-geometry
-  (testing "rf2-k647w — :density actually changes the RENDER, not just
-            the attr: the state-tag pill height equals the resolved
-            density's :tag-pill-height (regular 16 / compact 13 / cosy
-            19), proving the renderer reads geometry off the threaded
-            visual-constants instead of a hardcoded literal"
-    (if-not (browser?)
-      (is true ":node-test: no DOM — browser-test runner exercises this")
-      (do
-        (with-mounted-chart
-          {:machine-id :test/tags :definition tagged-machine :density :regular}
-          (fn [_root node]
-            (is (= (:tag-pill-height vc/chart-regular) (tag-pill-height-px node))
-                "regular pill height matches chart-regular")))
-        (with-mounted-chart
-          {:machine-id :test/tags :definition tagged-machine :density :compact}
-          (fn [_root node]
-            (is (= (:tag-pill-height vc/chart-compact) (tag-pill-height-px node))
-                "compact pill height matches chart-compact")))
-        (with-mounted-chart
-          {:machine-id :test/tags :definition tagged-machine :density :cosy}
-          (fn [_root node]
-            (is (= (:tag-pill-height vc/chart-cosy) (tag-pill-height-px node))
-                "cosy pill height matches chart-cosy")))))))
+;; ---- state-node :tags surface (rf2-so5b0) -------------------------------
 
-(deftest chart-default-tag-pill-is-pixel-identical
-  (testing "rf2-k647w — the DEFAULT (no :density) tag-pill height is the
-            shipped-reality 16px. This is the no-visual-regression pin:
-            a host that never passes :density gets exactly the
-            pre-rf2-k647w chart."
+(defn- state-node-el
+  "Return the first `rf-mv-chart-node-*` state-node element in `node`.
+  Returns nil when none is present (e.g. an empty / placeholder chart)."
+  [^js node]
+  (.querySelector node "[data-testid^=\"rf-mv-chart-node-\"]"))
+
+(deftest chart-tags-surface-as-title-attr-not-pills
+  (testing "rf2-so5b0 — user-declared `:tags` (Spec 005) MUST NOT render
+            as visible pill chrome on the chart canvas. The xstate /
+            Stately convention reserves the chart for STRUCTURAL chrome
+            (state name, nesting, transitions). Tags are a programmatic
+            concept the host surfaces in its inspector list — not on the
+            topology — so a nested compound substate is not inflated by
+            a per-tag row that visually competes with the structural
+            label + entry/exit rows.
+
+            Pins:
+
+            1. NO `rf-mv-chart-state-tag-*` pill testid is rendered.
+            2. NO `rf-mv-chart-state-tags` container row is rendered.
+            3. The tag set surfaces on the state-node's `data-tags`
+               attr as a sorted space-joined string (so DOM tests +
+               host introspection still read the tags off the chart).
+            4. The tag set surfaces on the state-node's `title` attr
+               (native HTML hover tooltip) so the operator can still
+               see what tags the state declared, on demand."
     (if-not (browser?)
       (is true ":node-test: no DOM — browser-test runner exercises this")
       (with-mounted-chart
         {:machine-id :test/tags :definition tagged-machine}
         (fn [_root node]
-          (is (= 16 (tag-pill-height-px node))
-              "default tag-pill height is the shipped 16px"))))))
+          ;; 1 + 2 — no visible pill row or pill chips.
+          (is (zero? (count-sel node "[data-testid=\"rf-mv-chart-state-tags\"]"))
+              "no visible tag-row container is rendered")
+          (is (zero? (count-sel node "[data-testid^=\"rf-mv-chart-state-tag-\"]"))
+              "no per-tag pill chip is rendered")
+          ;; 3 — data-tags carries the sorted joined tag set on the
+          ;; state-node. `tagged-machine`'s `:idle` declares `[:initial-tag]`.
+          (let [n (state-node-el node)]
+            (is (some? n) "a state-node mounted")
+            (is (= "initial-tag" (.getAttribute n "data-tags"))
+                "data-tags carries the sorted joined tag set")
+            ;; 4 — title attr carries the same string for the hover
+            ;; tooltip affordance.
+            (is (= "initial-tag" (.getAttribute n "title"))
+                "title attr exposes tags for the native hover tooltip")
+            ;; data-tag-count remains for DOM tests that want to assert
+            ;; the count without parsing data-tags.
+            (is (= "1" (.getAttribute n "data-tag-count"))
+                "data-tag-count reflects the tag set's size")))))))
+
+(deftest chart-empty-tag-set-omits-attr
+  (testing "rf2-so5b0 — a state with no declared tags renders an empty
+            `data-tags` attr + no `title` (tags-driven tooltip). The
+            empty-attr posture means DOM tests can pin presence-or-
+            absence by attribute equality without an extra
+            `hasAttribute` round-trip."
+    (if-not (browser?)
+      (is true ":node-test: no DOM — browser-test runner exercises this")
+      (with-mounted-chart
+        {:machine-id :test/flow :definition idle-loading-done}
+        (fn [_root node]
+          (let [n (state-node-el node)]
+            (is (some? n) "a state-node mounted")
+            (is (= "" (.getAttribute n "data-tags"))
+                "data-tags is the empty string when no tags declared")
+            (is (= "0" (.getAttribute n "data-tag-count"))
+                "data-tag-count is 0 when no tags declared")))))))
 
 ;; ---- empty / nil definition placeholders --------------------------------
 

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
@@ -719,18 +719,23 @@
 
 (deftest xyflow-graph-density-changes-threaded-constants
   (testing "rf2-k647w — switching the density threads a DIFFERENT
-            constants map: the regular projection's tag-pill height
-            differs from the compact projection's, proving `:density`
-            actually changes what the renderer paints"
+            constants map: the regular projection's state-label font
+            size differs from the compact projection's, proving
+            `:density` actually changes what the renderer paints.
+
+            rf2-so5b0 — historical assertions on `:tag-pill-height`
+            replaced with `:state-label-px` since the tag-pill family
+            retired with the visible pill row; the state-label keys
+            are now the density's load-bearing typography surface."
     (let [parsed   (layout/parse-definition idle-loading)
           idle-id  (layout/node-id [:idle])
           regular  (-> (projection/xyflow-graph parsed {} {:chart vc/chart-regular})
                        (node-by-id idle-id) :data :chart)
           compact  (-> (projection/xyflow-graph parsed {} {:chart vc/chart-compact})
                        (node-by-id idle-id) :data :chart)]
-      (is (not= (:tag-pill-height regular) (:tag-pill-height compact)))
-      (is (= 16 (:tag-pill-height regular)))
-      (is (= 13 (:tag-pill-height compact)))
+      (is (not= (:state-label-px regular) (:state-label-px compact)))
+      (is (= 13 (:state-label-px regular)))
+      (is (= 11 (:state-label-px compact)))
       ;; corner-radius is the locked invariant — identical across both
       (is (= (:corner-radius regular) (:corner-radius compact) 6)))))
 

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/theme/tokens_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/theme/tokens_cljs_test.cljc
@@ -1,7 +1,12 @@
 (ns day8.re-frame2-machines-viz.theme.tokens-cljs-test
   "Pure-data tests for the machines-viz theme/tokens helpers
-  (rf2-pyvmr — with-alpha; rf2-m1b88 — tag-pill-color;
-   rf2-xfx6l — motion/duration-css)."
+  (rf2-pyvmr — with-alpha;
+   rf2-xfx6l — motion/duration-css).
+
+  rf2-so5b0 — the `tag-pill-color` / `tag-pill-palette` tests retired
+  with the visible state-tag pill row; tags now surface as a hover
+  tooltip + data-tags attr on the state-node body (no per-tag chip →
+  no per-tag colour to map)."
   (:require #?(:clj  [clojure.test :refer [deftest is testing]]
                :cljs [cljs.test    :refer-macros [deftest is testing]])
             [clojure.string :as str]
@@ -27,24 +32,6 @@
     (let [custom {:info "#000000"}]
       (is (= "rgba(0, 0, 0, 0.25)"
              (tokens/with-alpha :info 0.25 custom))))))
-
-;; ---- tag-pill-color (rf2-m1b88) ----------------------------------------
-
-(deftest tag-pill-color-deterministic
-  (testing "tag-pill-color is deterministic — same tag → same palette
-            entry across renders"
-    (is (= (tokens/tag-pill-color :risky)   (tokens/tag-pill-color :risky)))
-    (is (= (tokens/tag-pill-color :paid)    (tokens/tag-pill-color :paid)))
-    (is (= (tokens/tag-pill-color :auth/ok) (tokens/tag-pill-color :auth/ok)))))
-
-(deftest tag-pill-color-skips-reserved-tokens
-  (testing "tag-pill-color never returns :red, :accent or :info
-            — all reserved for chart semantics (rf2-ad7zx.13)"
-    ;; Walk every palette entry; assert none is reserved.
-    (is (every? (fn [t]
-                  (not (#{:red :accent :info} (tokens/tag-pill-color t))))
-                [:risky :paid :auth/ok :final :loading :error
-                 :rec :checkout :session/active :flow/start]))))
 
 ;; ---- light palette (rf2-usord) -----------------------------------------
 

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/visual_constants_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/visual_constants_cljs_test.cljc
@@ -28,12 +28,16 @@
   xyflow `MachineChart` (`chart.nodes` / `chart.edges` / `chart.cljs`)
   reads every constant off the resolved density map (threaded through
   the projector's per-node/per-edge `:data`) instead of hardcoding.
-  The drifted tag-pill values were reconciled to the shipped renderer
-  numbers (so wiring `:density` introduced no visual regression), and
-  two render constants the renderer hardcoded — `:compound-radius`,
-  `:tag-pill-radius` — were promoted into the maps. This suite now
-  guards live render code, not just the spec data-contract it pinned
-  before."
+
+  rf2-so5b0 — the visible state-tag pill row retired in favour of a
+  hover-only `title` + `data-tags` attr on the state-node body, per
+  the xstate/Stately convention (the chart canvas is for STRUCTURAL
+  chrome only; user-declared tags are a programmatic concept the host
+  surfaces in its inspector list, not on the topology). The
+  `:tag-pill-*` key family DROPPED from the density maps along with
+  the visible row — the test catalogue here is updated in lockstep
+  so a stray re-introduction of `:tag-pill-height` etc. fails the
+  shape pins."
   (:require
     #?(:clj  [clojure.test :refer [deftest is testing]]
        :cljs [cljs.test    :refer-macros [deftest is testing]])
@@ -66,13 +70,10 @@
     ;; rf2-ee38b.21 — :caption-strip-px / :caption-text-px removed:
     ;; no renderer ever read them (there is no caption strip in the
     ;; chart). They were carried only to satisfy this parity test.
-    ;; state-tag pills (rf2-m1b88; rf2-k647w drift reconciled to shipped)
-    :tag-pill-height
-    :tag-pill-pad-x
-    :tag-pill-px
-    :tag-pill-radius                ;; rf2-k647w — render constant promoted
-    :tag-pill-gap
-    :tag-pill-row-gap
+    ;; rf2-so5b0 — `:tag-pill-*` family removed: the visible
+    ;; state-tag pill row retired in favour of a hover-only `title`
+    ;; + `data-tags` attr on the state-node body, so the chart has
+    ;; no pill geometry to parameterise.
     ;; dot-grid background (rf2-m4nj4)
     :dot-grid-spacing-px
     :dot-grid-radius-px
@@ -132,21 +133,6 @@
             floor fails CI."
     (is (= 13 (:state-label-px vc/chart)))
     (is (= 11 (:edge-label-px vc/chart)))))
-
-(deftest chart-regular-tag-pill-matches-shipped-render
-  (testing "rf2-k647w — `chart-regular`'s tag-pill geometry/typography
-            equals the values the xyflow renderer SHIPPED before this
-            bead (height 16 / pad-x 6 / px 9 / radius 8 / row-gap 3).
-            Pre-bead the renderer hardcoded these while `chart-regular`
-            carried the older 12/5/8/-/4. The reconciliation moved
-            `chart-regular` to the shipped reality so wiring `:density`
-            introduces NO visual regression at the default. Pin so a
-            future edit can't silently re-open the drift."
-    (is (= 16 (:tag-pill-height vc/chart)))
-    (is (= 6  (:tag-pill-pad-x vc/chart)))
-    (is (= 9  (:tag-pill-px vc/chart)))
-    (is (= 8  (:tag-pill-radius vc/chart)))
-    (is (= 3  (:tag-pill-row-gap vc/chart)))))
 
 (deftest chart-regular-compound-radius-matches-shipped-render
   (testing "rf2-k647w — `chart-regular`'s `:compound-radius` equals the
@@ -235,21 +221,17 @@
            (:dot-grid-spacing-px vc/chart-regular)
            (:dot-grid-spacing-px vc/chart-cosy)))))
 
-(deftest density-tag-pill-and-compound-render-constants-monotonic
-  (testing "rf2-k647w — the render constants the renderer now reads off
-            the resolved density (tag-pill height/radius, compound
-            radius) track the density axis monotonically too. The
-            corner-radius lock (6) is the ONLY geometry that does not
-            scale; everything the renderer paints by quantity does."
-    (is (< (:tag-pill-height vc/chart-compact)
-           (:tag-pill-height vc/chart-regular)
-           (:tag-pill-height vc/chart-cosy)))
-    (is (< (:tag-pill-radius vc/chart-compact)
-           (:tag-pill-radius vc/chart-regular)
-           (:tag-pill-radius vc/chart-cosy)))
-    (is (< (:tag-pill-px vc/chart-compact)
-           (:tag-pill-px vc/chart-regular)
-           (:tag-pill-px vc/chart-cosy)))
+(deftest density-compound-radius-monotonic
+  (testing "rf2-k647w — `:compound-radius` (the render constant the
+            renderer now reads off the resolved density) tracks the
+            density axis monotonically. The corner-radius lock (6)
+            is the ONLY geometry that does not scale; everything the
+            renderer paints by quantity does.
+
+            rf2-so5b0 — the historical sibling assertions on
+            `:tag-pill-height` / `:tag-pill-radius` / `:tag-pill-px`
+            retired with the visible pill row; the chart no longer
+            carries pill geometry to assert monotonic over."
     (is (< (:compound-radius vc/chart-compact)
            (:compound-radius vc/chart-regular)
            (:compound-radius vc/chart-cosy)))))


### PR DESCRIPTION
Shape-2 (sequenced, 2 commits / 1 PR). Two Machine-chart UX beads landing together so the chart's viewport + label conventions move as one coherent improvement.

## rf2-s5kyp — auto-fit chart viewport on mount + focused-machine change (P3)

**Symptom.** Live observation (pair-debug 2026-05-26): switching the focused machine in the Xray Machine panel left the chart framed on the prior machine's extent (or a degenerate box) — the operator had to click the manual zoom-to-fit button on every switch. rf2-set3x's earlier single-rAF deferral fixed the initial-mount degenerate-cluster case but raced xyflow's internal node-measurement on the subsequent focused-machine swap: React commits the new prop set, the single rAF fires, and xyflow may still be measuring the just-mounted node DOM when `.fitView` reads bounds.

**Intent.** The chart auto-fits to viewport without operator intervention on initial mount AND on focused-machine change. The operator's manual zoom/pan still survives any non-layout re-render (highlight changes, overlay ticks); a genuine layout-key change re-fits.

**Fix.** `chart.cljs`'s `schedule-fit!` helper now defers through TWO nested `requestAnimationFrame` tasks instead of one. Two rAFs guarantee the fit runs in the frame AFTER React's commit AND xyflow's measurement pass — the same pattern xyflow's own examples use for post-load fit calls. Node test-runtime falls back to firing immediately (no rAF in scope).

**Test coverage.** Two new tests in `auto_fit_view_cljs_test`:
- `auto-fit-fires-on-focused-machine-change` — pins the layout-key gate distinguishing distinct machine definitions and re-fitting on each focused-machine swap (acceptance contract).
- `schedule-fit-deferral-uses-double-raf` — stubs rAF and steps the queue deterministically to pin that the fit does NOT fire until BOTH rAFs have run; guards against a future refactor silently regressing back to a single rAF.

**Spec.** `tools/machines-viz/spec/API.md` §Auto-fit on async layout settle gains the deferral-pattern paragraph citing rf2-s5kyp.

## rf2-so5b0 — align node + edge labels with xstate/stately convention (P2)

**Symptom.** Live diagnosis (pair-debug 2026-05-26) on a deeply-nested compound substate (`:active.connecting` with `:tags #{:websocket/active :websocket/connecting}`) showed the per-tag chip row inflating the state-node's footprint. The chips read like ancestor-path labels even though they were user-declared semantic tags; either way they competed visually with the structural label + entry/exit rows and bloated nested substates worst.

**Intent.** Align the chart with the xstate / Stately convention: the canvas is reserved for STRUCTURAL chrome (state name, nesting, transitions, entry/exit, final/initial markers); user-declared `:tags` (Spec 005) are a programmatic concept the host surfaces in its inspector list, not on the topology.

**Fix.** Retire the visible state-tag pill row from `chart.nodes/state-node`. Tags now surface on the state-node body as a sorted space-joined string on both `title` (native HTML hover tooltip) and `data-tags` (DOM tests + host introspection) attrs. The `:tag-pill-*` family of visual constants drops from all three density maps; the `tag-pill-palette` + `tag-pill-color` helpers retire from `theme/tokens` (a future host inspector that DOES paint visible chips can re-introduce a deterministic mapping at its own surface).

**The other rf2-so5b0 sub-items were already shipped:**
- Visual nesting of compound states via xyflow `parentId` — rf2-xh1lm + rf2-shv82
- Edge label backplates — `transition-edge` already paints a themed backplate with `:edge-label-backplate-opacity 0.85` (matching the bead's ~80% recommendation)
- `event [guard] / action` label format — `chart.layout/edge-label` already composes this shape per the xstate convention
- Entry / exit actions inside state boxes — rf2-ee38b.21 (`state-actions` row below the label)
- Initial state marker — `initial-marker` node + entry-edge already render per convention

The bead's diagnostic missed those landings; the cluster's actionable scope was the tag-row retirement.

**Test coverage.**
- New `chart-tags-surface-as-title-attr-not-pills` pins the positive contract (tags arrive on title + data-tags, no pill row, no pill chips).
- New `chart-empty-tag-set-omits-attr` pins the negative (no declared tags → empty attr, no tooltip flicker).
- `visual_constants_cljs_test` catalogue updated to drop the `:tag-pill-*` keys; monotonic-render-constant test pins the surviving `:compound-radius`.
- `chart_dom_cljs_test` retires the two pill-density tests; existing `tagged-machine` fixture retargeted at the new attr surface.
- `projection_cljs_test` density-threading pin swaps from `:tag-pill-height` to `:state-label-px` (the surviving load-bearing per-density key).
- `tokens_cljs_test` retires the `tag-pill-color` deterministic + reserved-token tests; the helper itself retired.

## Gates

- `npm run test:cljs` — 4629 tests / 14871 assertions / 0 failures
- `npm run test:browser` — 124 tests / 351 assertions / 0 failures
- `tools/machines-viz clojure -M:test` — 283 tests / 671 assertions / 0 failures
- `tools/xray clojure -M:test` — 859 tests / 3199 assertions / 0 failures
- `npm run test:xray-feature-gate` — 13 scenarios / 0 failures
- `npm run test:bundle-isolation` — bundle-isolation + uix-helix-reagent-free both pass