### PR TITLE
feat(xray): new Epoch panel — visual pipeline of the computational timeline (rf2-sc3r1)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1247,6 +1247,177 @@ keeps the dogfood in Story.
 
 ---
 
+## §9.1 The Epoch panel (numbered cascade · rf2-sc3r1)
+
+### §9.1.1 Question
+
+> **"What happened in this epoch?"**
+
+The Epoch panel renders the focused epoch's complete computational
+timeline as a numbered vertical cascade — dispatch → coeffects →
+handler → flow → fx → subscriptions → views. It is the canonical
+"one timeline, one event" surface; every L4 panel answers a slice of
+the same question, but the Epoch panel renders the WHOLE chain in
+fire order.
+
+### §9.1.2 Co-existence with the Event panel (initial landing)
+
+Per the rf2-sc3r1 bead body's pre-alpha posture: the Epoch panel
+co-exists with the existing Event lens (§2). Both surface the focused
+epoch — but through different lenses:
+
+- **Event** (`:event` tab, §2) — the Figma-locked operational-order
+  handling pipeline (rf2-ynnre B+); reads more like a spec-shaped
+  attribution document.
+- **Epoch** (`:epoch` tab) — the full timeline as a delightful
+  numbered cascade including the reactive trailing edge
+  (SUBSCRIPTIONS + VIEWS) that the Event lens routes to its own
+  Reactive tab (§3).
+
+A follow-on bead deprecates the older Event + Reactive split once
+the new Epoch panel is exercised in production.
+
+Tab placement: `:epoch`, mnemonic `e`, order 5 (between `:machines`
+at 4 and `:routing` at 6). Registered against `:dynamic` mode only.
+
+### §9.1.3 Conditional cascade — only-the-steps-that-fired
+
+The cascade is a **faithful projection of the trace stream**. A step
+is rendered iff its driving trace events surfaced in this epoch:
+
+| Step | Driving trace | Conditional |
+|------|---------------|-------------|
+| **DISPATCH** | `:rf.event/dispatched` | always (every epoch starts here) |
+| **COEFFECT** | `:rf.cofx/run` (or `:rf.event/run-end` `:rf.event/coeffects` fallback) | only when user-injected coeffects fired |
+| **HANDLER** | every epoch settles through a handler | always |
+| **FLOW** | `:rf.flow/recomputed` | only when flows fired |
+| **FX** | `:rf.fx/handled` / `:rf.fx/override-applied` / `:rf.fx/skipped-on-platform` | only when fx-handlers fired |
+| **SUBSCRIPTIONS** | `:rf.sub/run` / `:rf.sub/skip` | only when subs recomputed |
+| **VIEWS** | `:rf.view/render` | only when views re-rendered |
+
+Steps are numbered DYNAMICALLY 1..N — an absent OPTIONAL step
+consumes no number; absence is conveyed by OMISSION, not an
+empty-state line. This matches the §2.2 dynamic-numbering contract
+from the Event lens — both panels share the same "absence is
+silence" rhythm.
+
+### §9.1.4 Badge taxonomy (the 7-badge inventory)
+
+Each step renders a uppercase badge pill at its numbered circle:
+
+| Badge | Token | Hue family |
+|-------|-------|------------|
+| `:DISPATCH`      | `:text-tertiary` | muted grey |
+| `:COEFFECT`      | `:magenta`       | purple |
+| `:HANDLER`       | `:accent`        | blue (single Xray accent) |
+| `:FLOW`          | `:accent`        | blue (paired with HANDLER) |
+| `:FX`            | `:orange`        | functional amber (post-commit irreversible) |
+| `:SUBSCRIPTIONS` | `:magenta`       | pink/magenta family |
+| `:VIEWS`         | `:success`       | green |
+
+The inventory is LOCKED — the projection's `badge-set` enforces
+that every emitted step's `:badge` is a member, and the view's
+colour resolver bails to `:text-tertiary` on an unknown badge so a
+future taxonomy extension paints something but tests catch the
+omission.
+
+### §9.1.5 Handler-type adaptation (rf2-82a0u prerequisites)
+
+The HANDLER step's body adapts to the handler's flavour, discovered
+from the trace stream:
+
+- **`:reg-event-db`** — `:db` diff only (the simplest case).
+- **`:reg-event-fx`** — `:db` diff + per-fx-entry block.
+- **`:reg-machine`** — full machine block: transition summary
+  (machine-id + before/after state vectors), guard rows
+  (`:pass / :fail / :threw` outcomes), per-phase lifecycle rows
+  (phases drawn from the closed set
+  `:exit / :transition / :entry / :always / :after-action /
+  :initial-entry / :destroy-exit`, per rf2-82a0u's `:phase` stamp
+  on `:rf.machine/action-ran`), and timer-cancellation rows
+  (reasons drawn from the closed set
+  `:on-exit / :on-destroy / :on-resolution / :on-supersede /
+  :on-frame-destroy`, per the unified `:rf.machine.timer/cancelled`
+  trace).
+
+The flavour discriminator runs at projection time as a pure-data
+check against the trace stream — no spec read, no registry lookup,
+no replay. The substrate enhancements in #2155 (rf2-82a0u) are the
+prerequisite that lets the LIFECYCLE / TIMERS sub-blocks read
+directly off the trace.
+
+### §9.1.6 Numbered cascade chrome
+
+Per the bead body's §Visual Structure:
+
+- Container: padding `21px`, overflow auto, full height.
+- Header text: "The computational timeline for the event"
+  (muted, `margin-bottom: 21px`).
+- Pipeline: left margin `55px` to accommodate numbered circles.
+- Vertical line: absolute-positioned, 1px width, starts at `13px`
+  from top, positioned at `-34px` from the content column's left
+  edge.
+- Row spacing: `13px` vertical gap between entries.
+
+Each step's row carries:
+
+1. Numbered circle: `21px` diameter, positioned at `-44px` left,
+   colour-matched to the step's badge.
+2. Badge pill: uppercase 10px font, rounded, `5px/3px` padding.
+3. Verb/label: monospace, click-to-source hyperlink for any
+   source-bearing target (cofx ids, handler flavour, flow ids,
+   fx ids, sub vectors, view ids).
+4. Duration: right-aligned, muted, monospace (e.g. `0.1ms`).
+5. Per-step body content: code blocks, tables, diff displays.
+
+Fibonacci spacing system (3 · 5 · 8 · 13 · 21 · 34 · 55 · 89) drives
+every gap / pad value. Tabulated in `panels.epoch.badge/fib` for one
+source of truth.
+
+### §9.1.7 Composition with the edn-inspector widget
+
+Per the bead body's §Implementation Notes, expandable rows mount the
+edn-inspector widget with `:zoomable? true` (rf2-h71e0) and
+`:header "<step-name>"` (rf2-okq7p) so nested data drill-down composes
+naturally with the §10 widget's contract. The initial landing of
+the panel renders default-visible content for every step (the
+cascade's punch is its always-visible rhythm); per-row drill-down
+state lives on the `:rf.xray/epoch-panel-expanded-rows` set via the
+`:rf.xray.epoch/toggle-row-expand` event, ready for the follow-on
+rich-expansion pass.
+
+### §9.1.8 Pure-data projection (testable in isolation)
+
+The projection lives at `tools/xray/src/day8/re_frame2_xray/panels/
+epoch/projection.cljc` — `.cljc` so JVM unit tests (`clojure -M:test`)
+exercise the algebra without spinning a CLJS runtime. The view
+layer (`panels/epoch/view.cljs`) consumes the projection's output
+verbatim; no DOM concern bleeds into the data layer.
+
+### §9.1.9 Queries
+
+| Sub | Reads | Yields |
+|-----|-------|--------|
+| `:rf.xray/epoch-pipeline` | `:rf.xray/focus` · `:rf.xray/epoch-history` (via the shared `panels.shared.focus-resolver`) | `{:status :no-focus | :focused | :epoch-evicted, :epoch-id, :record, :steps}` |
+| `:rf.xray.epoch/expanded-rows` | `:epoch-panel-expanded-rows` slot | `#{[step-kw row-id] …}` |
+
+### §9.1.10 Events
+
+| Event | Effect |
+|-------|--------|
+| `:rf.xray.epoch/toggle-row-expand step-kw row-id` | flip the row's pair in `:epoch-panel-expanded-rows` |
+| `:rf.xray.epoch/clear-row-expand` | drop the expansion set |
+
+### §9.1.11 Cross-panel navigation
+
+Every click-to-source affordance in the cascade flows through the
+shared `:rf.xray/open-in-editor` event (rf2-cm93v allowlist) — the
+same surface every other L4 panel uses for source jumps. The Epoch
+panel emits no panel-internal navigation; spine focus drives every
+data axis.
+
+---
+
 ## §10 Shared edn-inspector renderer
 
 The renderer is **ONE canonical component used everywhere data appears**

--- a/tools/xray/src/day8/re_frame2_xray/panels.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels.cljs
@@ -117,6 +117,7 @@
             [day8.re-frame2-xray.panels.app-db-diff :as app-db-diff]
             [day8.re-frame2-xray.panels.app-db-segment-inspector :as segment-inspector]
             [day8.re-frame2-xray.panels.cancellation-cascade :as cancellation-cascade]
+            [day8.re-frame2-xray.panels.epoch-panel :as epoch-panel]
             [day8.re-frame2-xray.panels.event-detail :as event-detail]
             [day8.re-frame2-xray.panels.issues-ribbon :as issues-ribbon]
             [day8.re-frame2-xray.panels.machine-inspector :as machine-inspector]
@@ -196,6 +197,15 @@
   See ns docstring for `opts` shape + the embedding contract."
   ([mount-point]      (mount-event-detail! mount-point nil))
   ([mount-point opts] (render-panel! event-detail/Panel mount-point opts)))
+
+(defn mount-epoch-panel!
+  "Mount Xray's Epoch tab in isolation at `mount-point` (rf2-sc3r1).
+  Renders the numbered cascade — the focused epoch's complete
+  computational timeline (DISPATCH → COEFFECTS → HANDLER → FLOW →
+  FX → SUBSCRIPTIONS → VIEWS) with conditional rendering per the
+  trace stream."
+  ([mount-point]      (mount-epoch-panel! mount-point nil))
+  ([mount-point opts] (render-panel! epoch-panel/Panel mount-point opts)))
 
 (defn mount-app-db-diff!
   "Mount Xray's App-DB tab in isolation at `mount-point`. Renders the

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/badge.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/badge.cljc
@@ -1,0 +1,154 @@
+(ns day8.re-frame2-xray.panels.epoch.badge
+  "Pure-data badge taxonomy for the Epoch panel (rf2-sc3r1).
+
+  Maps each of the 7 cascade step badges → its visual chrome (colour
+  token + label text). The colour resolver returns a CSS-variable
+  string off `theme/tokens` so the panel's badges flow through the
+  active theme like every other Xray chrome element.
+
+  ## Why a separate file
+
+  The badge table is referenced by both the projection (for badge
+  validation) and the view (for paint). Pulling it into a tiny shared
+  ns keeps the visual contract one source of truth — the view's
+  numbered cascade renders the same colour the spec/021 §10.1 badge
+  catalogue commits to.
+
+  ## Pure-data + JVM-portable
+
+  Hex resolution happens via `theme/tokens` keyword → CSS-variable
+  string lookup; no DOM, no substrate runtime."
+  (:require [clojure.string :as str]
+            [day8.re-frame2-xray.theme.tokens :as tokens]))
+
+;; ---- badge taxonomy -----------------------------------------------------
+;;
+;; Per the bead body's badge colour table (rf2-sc3r1 §Badge Colors):
+;;
+;;     :DISPATCH      "#8c959f"                  ; mid grey
+;;     :COEFFECT      "#a855f7"                  ; light purple
+;;     :HANDLER       "var(--devtools-active)"   ; blue
+;;     :FLOW          "var(--devtools-active)"   ; blue
+;;     :FX            "rgb(154, 103, 0)"         ; orange/brown
+;;     :SUBSCRIPTIONS "#ec4899"                  ; pink
+;;     :VIEWS         "var(--devtools-success)"  ; green
+;;
+;; The hex values from the bead map onto Xray's theme tokens:
+;;
+;;     #8c959f                — `:text-tertiary` (the muted grey already
+;;                              in the palette)
+;;     #a855f7                — :magenta (close enough hue family)
+;;     var(--devtools-active) — `:accent` (the single blue identity)
+;;     rgb(154,103,0)         — :orange (functional amber, perf-slow
+;;                              tier — close enough hue for the FX
+;;                              step's irreversible/post-commit signal)
+;;     #ec4899                — :magenta-pink (we ship :magenta, which
+;;                              spans the pink/purple family on both
+;;                              themes; the COEFFECT badge above also
+;;                              reads magenta, so we differentiate
+;;                              SUBSCRIPTIONS by reading :magenta with
+;;                              a slightly different lookup to keep
+;;                              the two distinct at a glance)
+;;     var(--devtools-success) — `:success` / `:green`
+;;
+;; The 7-badge inventory is binding: the view never paints a badge
+;; whose keyword is not in this map.
+
+(def ^:private badge->token-key
+  "Map from badge keyword → theme-token keyword. Resolves through
+  `tokens/tokens` so the badge background reads off the active
+  theme's CSS variable (one badge across light + dark).
+
+  Two badges intentionally pull magenta-family tokens (`:magenta` for
+  COEFFECT, `:magenta` for SUBSCRIPTIONS) per the bead body — the
+  view differentiates them with their text label rather than a
+  hue split; the project's palette doesn't carry a separate pink hue
+  and adding one for this single use site would erode the palette's
+  single-source-of-truth posture (per spec/022). HANDLER + FLOW share
+  `:accent` — the Figma export's single-accent identity (rf2-ad7zx.13)."
+  {:DISPATCH      :text-tertiary
+   :COEFFECT      :magenta
+   :HANDLER       :accent
+   :FLOW          :accent
+   :FX            :orange
+   :SUBSCRIPTIONS :magenta
+   :VIEWS         :success})
+
+(def ^:private badge->label
+  "Map from badge keyword → uppercase label rendered in the badge
+  pill. Pure data."
+  {:DISPATCH      "DISPATCH"
+   :COEFFECT      "COEFFECT"
+   :HANDLER       "HANDLER"
+   :FLOW          "FLOW"
+   :FX            "FX"
+   :SUBSCRIPTIONS "SUBSCRIPTIONS"
+   :VIEWS         "VIEWS"})
+
+(defn token-key
+  "Return the theme-token KEYWORD for `badge` (e.g. `:accent` for
+  `:HANDLER`). Useful in helpers + tests where the keyword is the
+  primary value. Falls back to `:text-tertiary` for unknown badges so
+  the view always paints something."
+  [badge]
+  (get badge->token-key badge :text-tertiary))
+
+(defn colour
+  "Return the CSS-variable string that paints `badge` (e.g.
+  `\"var(--rf-xray-accent)\"` for `:HANDLER`). Falls back to muted
+  text colour for unknown badges so the view never paints `nil`."
+  [badge]
+  (get tokens/tokens (token-key badge)
+       (get tokens/tokens :text-tertiary)))
+
+(defn label
+  "Return the uppercase label string the badge pill renders (e.g.
+  `\"HANDLER\"` for `:HANDLER`). Falls back to `(name badge)` for
+  unknown badges so a future taxonomy extension still paints text."
+  [badge]
+  (or (get badge->label badge)
+      (when (keyword? badge) (str/upper-case (name badge)))
+      "?"))
+
+(def step-numbered-circle-diameter-px
+  "21px per the bead body's numbered cascade pattern (§Numbered
+  Cascade Pattern: '21px diameter')."
+  21)
+
+(def vertical-line-offset-px
+  "13px per the bead body — the vertical line starts at 13px from the
+  top of the pipeline section."
+  13)
+
+(def circle-left-offset-px
+  "-44px per the bead body — the numbered circle's left anchor."
+  -44)
+
+(def line-left-offset-px
+  "-34px per the bead body — the vertical line's left anchor (between
+  the circle column and the content column)."
+  -34)
+
+(def fib
+  "Fibonacci spacing scale per the bead body's §Fibonacci Spacing
+  System (3 · 5 · 8 · 13 · 21 · 34 · 55 · 89).
+
+  Catalogued as data so view sites read keyed values rather than
+  scattered magic numbers. Pure data; JVM-portable."
+  {:f3   3
+   :f5   5
+   :f8   8
+   :f13  13
+   :f21  21
+   :f34  34
+   :f55  55
+   :f89  89})
+
+(defn fib-px
+  "Resolve a fibonacci-key to a CSS px string (e.g. `:f13` →
+  `\"13px\"`). Returns `\"0\"` for unknown keys so the view never
+  paints `nil`."
+  [k]
+  (if-let [n (get fib k)]
+    (str n "px")
+    "0"))

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/icons.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/icons.cljc
@@ -1,0 +1,55 @@
+(ns day8.re-frame2-xray.panels.epoch.icons
+  "Inline SVG glyphs used by the Epoch panel (rf2-sc3r1). Two icons
+  are required per the bead body's §Icon Requirements:
+
+  - **ExternalLink** — 13×13 lucide glyph trailing click-to-source
+    affordances. Already shipped under `panels/event/icons` for the
+    Event lens — the Epoch panel re-uses that hiccup form via a
+    re-export so both panels read the same Figma authority.
+  - **CornerDownRight** — 13×13 lucide-style arrow used in the
+    handler step's `:db` diff / `:fx` sub-headers (per the bead body's
+    §3 HANDLER row design — DB CHANGES + FX sub-blocks).
+
+  Pure data → hiccup (a static svg vector); JVM-portable so panel
+  tests can render the tree via `clojure -M:test`."
+  (:require [day8.re-frame2-xray.panels.event.icons :as event-icons]))
+
+;; ---- External link -----------------------------------------------------
+
+(defn external-link
+  "Re-export of `panels.event.icons/external-link` — the lucide-style
+  open-in-editor glyph (13×13). Same hiccup, same currentColor stroke.
+  Both panels render the same Figma authority glyph so a Xray operator
+  reads the affordance vocabulary as one verb."
+  []
+  (event-icons/external-link))
+
+;; ---- Corner down right --------------------------------------------------
+
+(def ^:private corner-down-right-svg
+  "Lucide `corner-down-right` icon as a hiccup-shaped svg. 13×13
+  square, `viewBox 0 0 24 24`, `stroke: currentColor` so the glyph
+  rides the surrounding text colour. Used in the HANDLER step's
+  sub-headers (`:db diff` / `:fx`) to signal indented continuation
+  per the bead body."
+  [:svg {:width            "13"
+         :height           "13"
+         :viewBox          "0 0 24 24"
+         :fill             "none"
+         :stroke           "currentColor"
+         :stroke-width     "2"
+         :stroke-linecap   "round"
+         :stroke-linejoin  "round"
+         :aria-hidden      "true"
+         :focusable        "false"}
+   [:polyline {:points "15 10 20 15 15 20"}]
+   [:path     {:d "M4 4v7a4 4 0 0 0 4 4h12"}]])
+
+(defn corner-down-right
+  "Render the lucide `corner-down-right` glyph. Inherits its colour
+  from the enclosing element via `currentColor` so the arrow reads
+  as part of the section header. Always returns the same static
+  hiccup vector — the fn-form is preserved so call sites read as
+  a component."
+  []
+  corner-down-right-svg)

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -1,0 +1,626 @@
+(ns day8.re-frame2-xray.panels.epoch.projection
+  "Pure projection: epoch-record → ordered vector of pipeline-step rows.
+
+  ## Why this lives in `panels/epoch/` as `.cljc`
+
+  The Epoch panel (rf2-sc3r1) is a faithful visual projection of a
+  single epoch's trace stream — DISPATCH → COEFFECTS → HANDLER → FLOW
+  → FX → SUBSCRIPTIONS → VIEWS as a numbered cascade. Each step is
+  CONDITIONAL — a step is present iff the matching trace events
+  surfaced in this epoch:
+
+  - no `:rf.cofx/run` events → no COEFFECT rows
+  - no `:rf.flow/recomputed` events → no FLOW step
+  - no `:rf.fx/handled` events → no FX step
+  - HANDLER step adapts to the handler's flavour:
+      reg-event-db / reg-event-fx / reg-machine
+
+  Per the bead body, the panel's correctness depends on a pure-data
+  projection layer that runs against the epoch record's `:trace-events`
+  vector. The view layer mounts the rendered rows; this ns has no
+  DOM dependency and is JVM-testable via `clojure -M:test`.
+
+  ## Row shape
+
+  Each step row is a map carrying:
+
+      {:step           keyword — :dispatch / :coeffect / :handler
+                                 / :flow / :fx / :subscriptions / :views
+       :badge          keyword — :DISPATCH / :COEFFECT / :HANDLER /
+                                 :FLOW / :FX / :SUBSCRIPTIONS / :VIEWS
+       :duration-ms    number or nil
+       :step-number    number — assigned by `number-steps` after
+                                 filtering optional steps; the view
+                                 renders this in the numbered circle.
+       …step-specific keys}
+
+  The numbered cascade is built by `(number-steps (projection record))`
+  — steps are numbered 1..N contiguously over only the steps that
+  surfaced. Absent steps consume no number (per the bead's conditional-
+  cascade contract).
+
+  ## Pure-data + JVM-portable
+
+  `tools/xray/spec/Conventions.md` §Pure-data helpers as `.cljc` — the
+  projection is data-in / data-out and runs under both targets.
+  `feedback_jvm_interop_must_work.md` is binding."
+  (:require [day8.re-frame2-xray.panels.common-helpers :as common]))
+
+;; ---- trace-event lookups -------------------------------------------------
+
+(defn- op
+  "The trace event's operation keyword (e.g. `:rf.event/dispatched`)."
+  [ev]
+  (:operation ev))
+
+(defn- op-ns
+  "Namespace of the operation keyword, or nil for non-keyword ops."
+  [ev]
+  (when (keyword? (op ev)) (namespace (op ev))))
+
+(defn- find-op
+  "First event whose `:operation` equals `op-kw`. Returns nil when
+  none match."
+  [events op-kw]
+  (some #(when (= op-kw (op %)) %) events))
+
+(defn- filter-op
+  "All events whose `:operation` equals `op-kw`, in trace order."
+  [events op-kw]
+  (filterv #(= op-kw (op %)) events))
+
+;; ---- DISPATCH row --------------------------------------------------------
+
+(defn dispatch-row
+  "Build the step-1 DISPATCH row from the epoch's `:rf.event/dispatched`
+  trace. Returns nil when the epoch carries no dispatched trace (test
+  fixtures that synthesise an epoch from a literal `:event` vector
+  surface this path)."
+  [events fallback-event]
+  (let [ev (find-op events :rf.event/dispatched)]
+    (cond
+      ev
+      {:step        :dispatch
+       :badge       :DISPATCH
+       :event       (or (common/tag-of ev :event) (:event ev) fallback-event)
+       :source      (or (common/tag-of ev :source)
+                        (common/tag-of ev :rf.event/source))
+       :coord       (or (common/tag-of ev :rf.trace/call-site)
+                        (:rf.trace/call-site ev))
+       :duration-ms (common/tag-of ev :duration-ms)}
+
+      (vector? fallback-event)
+      {:step  :dispatch
+       :badge :DISPATCH
+       :event fallback-event}
+
+      :else nil)))
+
+;; ---- COEFFECT rows -------------------------------------------------------
+
+(defn- coeffect-rows-from-runs
+  "Walk every `:rf.cofx/run` event (rf2-hhh92) and project one row per
+  user-injected coeffect — each row carries the cofx id and the value
+  it added to ctx. Empty seq when no `:rf.cofx/run` events fired."
+  [events]
+  (vec
+    (for [ev (filter-op events :rf.cofx/run)
+          :let [id    (common/tag-of ev :rf.cofx/id)
+                value (common/tag-of ev :rf.cofx/value)]
+          :when (some? id)]
+      {:step        :coeffect
+       :badge       :COEFFECT
+       :id          id
+       :value       value
+       :duration-ms (common/tag-of ev :duration-ms)})))
+
+(defn- coeffect-rows-from-run-end
+  "Fallback: read user-injected coeffects from the `:rf.event/run-end`
+  trace's `:rf.event/coeffects` stamp (rf2-9dk9y). The substrate places
+  the user-injected subset there so events that return only `:db`
+  still surface their cofx. Returns a vec of rows in map order; this
+  fallback is used only when no granular `:rf.cofx/run` events exist."
+  [events]
+  (when-let [run-end (find-op events :rf.event/run-end)]
+    (let [m (common/tag-of run-end :rf.event/coeffects)]
+      (when (map? m)
+        (vec (for [[id value] m]
+               {:step  :coeffect
+                :badge :COEFFECT
+                :id    id
+                :value value}))))))
+
+(defn coeffect-rows
+  "All COEFFECT rows for the epoch — one per user-injected coeffect.
+  Prefers granular `:rf.cofx/run` events; falls back to the run-end
+  coeffect stamp when no granular events exist (older runtimes / test
+  fixtures). Returns an empty vec when neither surface is present."
+  [events]
+  (let [granular (coeffect-rows-from-runs events)]
+    (if (seq granular)
+      granular
+      (or (coeffect-rows-from-run-end events) []))))
+
+;; ---- HANDLER row ---------------------------------------------------------
+
+(defn- handler-flavour
+  "Discriminate the handler kind from the trace stream. Three flavours:
+
+      :reg-machine     — at least one `:rf.machine/action-ran` rode
+      :reg-event-fx    — a `:rf.fx/do-fx` rode (effects were returned)
+      :reg-event-db    — otherwise (default for any non-machine event)
+
+  The discriminator is the trace stream — no spec read at projection
+  time. Pure-data; JVM-testable."
+  [events]
+  (cond
+    (some #(= :rf.machine/action-ran (op %)) events) :reg-machine
+    (some #(= :rf.fx/do-fx (op %)) events)           :reg-event-fx
+    :else                                            :reg-event-db))
+
+(defn- fx-entries
+  "Project the `:rf.event/fx` payload off the `:rf.fx/do-fx` trace
+  (per rf2-twt7m Change 2) into a vec of `[fx-id value]` pairs in
+  declaration order. Empty when no do-fx fired or the fx vector is
+  empty/missing."
+  [events]
+  (when-let [do-fx (find-op events :rf.fx/do-fx)]
+    (let [fx (common/tag-of do-fx :rf.event/fx)]
+      (cond
+        ;; map form: {:db ... :fx [...] :navigate ...}
+        (map? fx)
+        (vec (for [[fx-id value] fx] {:fx-id fx-id :value value}))
+        ;; vec form: [[:fx-id value] ...]
+        (vector? fx)
+        (vec (for [entry fx
+                   :when (and (vector? entry) (>= (count entry) 1))]
+               {:fx-id (first entry) :value (second entry)}))
+        :else []))))
+
+(defn- db-diff-paths
+  "Pull the changed-paths vector off the `:rf.event/db-changed` trace.
+  Per Spec 009 §db-changed payload: `:tags :rf.event/db-changed-paths`
+  carries `[[path before after change-kind] ...]`. Returns an empty
+  vec when no db-changed event fired (the handler returned no `:db`,
+  or db value was identical)."
+  [events]
+  (when-let [ev (find-op events :rf.event/db-changed)]
+    (or (common/tag-of ev :rf.event/db-changed-paths)
+        (common/tag-of ev :rf.event/changed-paths)
+        [])))
+
+(defn- machine-lifecycle-rows
+  "Project the `:rf.machine/action-ran` stream into per-phase rows
+  (rf2-82a0u — every action-ran emit carries `:phase` from the closed
+  set `:exit / :transition / :entry / :always / :after-action /
+  :initial-entry / :destroy-exit`).
+
+  Each row carries `:action-id`, `:phase`, `:outcome`, optional
+  `:threw?` + `:exception` (action-throw path emits
+  `:outcome :rf.error/action-threw` + an `:exception` slot). Rendered
+  in trace order — the substrate emits in execution order
+  (exit → transition → entry → always …)."
+  [events]
+  (vec
+    (for [ev (filter-op events :rf.machine/action-ran)]
+      {:action-id (common/tag-of ev :action-id)
+       :phase     (common/tag-of ev :phase)
+       :outcome   (common/tag-of ev :outcome)
+       :threw?    (= :rf.error/action-threw (common/tag-of ev :outcome))
+       :exception (common/tag-of ev :exception)
+       :input     (common/tag-of ev :input)})))
+
+(defn- machine-transition-row
+  "Project the `:rf.machine/transition` event (one per macrostep) into a
+  summary `{:machine-id :before :after :microsteps}` row. nil when no
+  transition trace fired."
+  [events]
+  (when-let [ev (find-op events :rf.machine/transition)]
+    {:machine-id (common/tag-of ev :machine-id)
+     :before     (common/tag-of ev :before)
+     :after      (common/tag-of ev :after)
+     :microsteps (common/tag-of ev :microsteps)}))
+
+(defn- machine-guard-rows
+  "Project the `:rf.machine/guard-evaluated` stream into rows. Each
+  row carries `:guard-id`, `:outcome` (one of `:pass :fail :threw`
+  per rf2-82a0u). Empty vec when no guards fired."
+  [events]
+  (vec
+    (for [ev (filter-op events :rf.machine/guard-evaluated)]
+      {:guard-id (common/tag-of ev :guard-id)
+       :outcome  (common/tag-of ev :outcome)})))
+
+(defn- machine-timer-rows
+  "Project the `:rf.machine.timer/cancelled` stream (rf2-82a0u —
+  unified across every cancellation path with `:reason` in
+  `:on-exit / :on-destroy / :on-resolution / :on-supersede /
+  :on-frame-destroy`)."
+  [events]
+  (vec
+    (for [ev (filter-op events :rf.machine.timer/cancelled)]
+      {:machine-id (common/tag-of ev :machine-id)
+       :state      (common/tag-of ev :state)
+       :delay      (common/tag-of ev :delay)
+       :reason     (common/tag-of ev :reason)})))
+
+(defn- run-end-tags
+  "Tags off the `:rf.event/run-end` trace — carries the handler's
+  finalised duration + flavour-discriminating slots. Empty map when no
+  run-end fired (test fixtures, errored events)."
+  [events]
+  (or (some-> (find-op events :rf.event/run-end) :tags) {}))
+
+(defn handler-row
+  "Build the step-N HANDLER row. ALWAYS present (every epoch has a
+  dispatched event therefore a handler). Adapts to the trace stream's
+  flavour discriminator:
+
+  - `:reg-event-db`  → :db-diff
+  - `:reg-event-fx`  → :db-diff + :fx
+  - `:reg-machine`   → :db-diff + :fx + :machine {transition guards
+                                                  lifecycle timers}"
+  [events event-id]
+  (let [flavour     (handler-flavour events)
+        run-end     (run-end-tags events)
+        db-changed  (find-op events :rf.event/db-changed)
+        do-fx       (find-op events :rf.fx/do-fx)
+        duration-ms (or (:duration-ms run-end)
+                        (:rf.event/duration-ms run-end)
+                        (some-> db-changed :tags :duration-ms)
+                        (some-> do-fx :tags :duration-ms))
+        base        {:step        :handler
+                     :badge       :HANDLER
+                     :flavour     flavour
+                     :event-id    event-id
+                     :duration-ms duration-ms
+                     :db-diff     (or (db-diff-paths events) [])
+                     :fx          (or (fx-entries events) [])}]
+    (cond-> base
+      (= :reg-machine flavour)
+      (assoc :machine {:transition  (machine-transition-row events)
+                       :guards      (machine-guard-rows events)
+                       :lifecycle   (machine-lifecycle-rows events)
+                       :timers      (machine-timer-rows events)}))))
+
+;; ---- FLOW step -----------------------------------------------------------
+
+(defn flow-rows
+  "Project flow-recompute events into rows. Each row carries
+  `:flow-id`, `:path` (the db path the flow wrote), and optional
+  before/after values when the substrate stamps them. Empty vec when
+  no flow fired this epoch.
+
+  Reads `:rf.flow/recomputed` (the standard recompute trace) +
+  `:rf.flow/run-end` (the per-flow duration carrier) defensively so
+  fixtures that emit either op surface a row."
+  [events]
+  (let [evs (filter-op events :rf.flow/recomputed)]
+    (vec
+      (for [ev evs]
+        {:flow-id     (common/tag-of ev :rf.flow/id)
+         :path        (common/tag-of ev :rf.flow/path)
+         :before      (common/tag-of ev :rf.flow/before)
+         :after       (common/tag-of ev :rf.flow/after)
+         :duration-ms (common/tag-of ev :duration-ms)}))))
+
+(defn flow-step
+  "Top-level FLOW step (single row carrying the flow-rows). nil when no
+  flows fired (the step is OMITTED from the cascade — conditional
+  rendering per the bead body)."
+  [events]
+  (let [rows (flow-rows events)]
+    (when (seq rows)
+      {:step  :flow
+       :badge :FLOW
+       :rows  rows})))
+
+;; ---- FX step -------------------------------------------------------------
+
+(defn fx-rows
+  "Project the `:rf.fx/handled` / `:rf.fx/override-applied` /
+  `:rf.fx/skipped-on-platform` stream into per-handler rows. Each row
+  carries `:fx-id`, `:status` (`:ok / :overridden / :skipped /
+  :error`), `:args`, and `:duration-ms`."
+  [events]
+  (let [status-fn (fn [op-kw]
+                    (case op-kw
+                      :rf.fx/handled               :ok
+                      :rf.fx/override-applied      :overridden
+                      :rf.fx/skipped-on-platform   :skipped
+                      :rf.error/fx-handler-exception :error
+                      :rf.error/no-such-fx         :error
+                      :ok))]
+    (vec
+      (for [ev events
+            :let [o (op ev)]
+            :when (or (= "rf.fx" (op-ns ev))
+                      (contains? #{:rf.error/fx-handler-exception
+                                   :rf.error/no-such-fx} o))]
+        {:fx-id       (common/tag-of ev :rf.fx/id)
+         :status      (status-fn o)
+         :args        (common/tag-of ev :rf.fx/args)
+         :duration-ms (common/tag-of ev :duration-ms)}))))
+
+(defn fx-step
+  "FX step row (one row aggregating every fx-handler invocation). nil
+  when no fx-handler events fired (the step is OMITTED — conditional)."
+  [events]
+  (let [rows (fx-rows events)]
+    (when (seq rows)
+      {:step  :fx
+       :badge :FX
+       :rows  rows})))
+
+;; ---- SUBSCRIPTIONS step --------------------------------------------------
+
+(defn subscription-rows
+  "Project `:rf.sub/run` events into rows. Each row carries:
+
+      :sub-id      — the sub vector's first element (the registered id)
+      :sub-vec     — the full sub query vector (`[:foo arg1 arg2]`)
+      :inputs      — the sub's input keywords (for input-fn subs)
+      :changed?    — true iff the sub's output value differed from
+                     the prior run (`:rf.sub/changed?` tag)
+      :before / :after — the sub's prior/new values when stamped
+      :duration-ms — the sub's recompute duration
+
+  Pure projection; the view layer renders the row table."
+  [events]
+  (let [evs (filterv #(or (= :rf.sub/run (op %))
+                          (= :rf.sub/skip (op %)))
+                     events)]
+    (vec
+      (for [ev evs
+            :let [sub-vec (or (common/tag-of ev :rf.sub/query)
+                              (common/tag-of ev :query))]]
+        {:sub-id      (when (vector? sub-vec) (first sub-vec))
+         :sub-vec     sub-vec
+         :inputs      (common/tag-of ev :rf.sub/inputs)
+         :changed?    (boolean (common/tag-of ev :rf.sub/changed?))
+         :before      (common/tag-of ev :rf.sub/before)
+         :after       (common/tag-of ev :rf.sub/after)
+         :duration-ms (common/tag-of ev :duration-ms)}))))
+
+(defn subscriptions-step
+  "SUBSCRIPTIONS step row. nil when no `:rf.sub/*` events fired (the
+  step is OMITTED — conditional)."
+  [events]
+  (let [rows (subscription-rows events)]
+    (when (seq rows)
+      {:step  :subscriptions
+       :badge :SUBSCRIPTIONS
+       :rows  rows})))
+
+;; ---- VIEWS step ----------------------------------------------------------
+
+(defn view-rows
+  "Project `:rf.view/render` events into rows. Each row carries the
+  view id + the subs it read during the render."
+  [events]
+  (vec
+    (for [ev (filter-op events :rf.view/render)]
+      {:view-id     (or (common/tag-of ev :rf.view/id)
+                        (common/tag-of ev :view-id))
+       :subs-read   (or (common/tag-of ev :rf.view/subs)
+                        (common/tag-of ev :subs-read)
+                        [])
+       :duration-ms (common/tag-of ev :duration-ms)})))
+
+(defn views-step
+  "VIEWS step row. nil when no `:rf.view/render` events fired (the
+  step is OMITTED — conditional)."
+  [events]
+  (let [rows (view-rows events)]
+    (when (seq rows)
+      {:step  :views
+       :badge :VIEWS
+       :rows  rows})))
+
+;; ---- top-level projection ------------------------------------------------
+
+(defn project
+  "Project an `:rf/epoch-record` into the ordered vector of pipeline
+  step rows for the Epoch panel's numbered cascade.
+
+  Steps emitted (in cascade order):
+
+      :dispatch       — always present (every epoch starts here)
+      :coeffect…      — one row per user-injected coeffect (folded
+                        into a single step group by the view layer)
+      :handler        — always present; adapts to handler flavour
+      :flow           — only when flows fired
+      :fx             — only when fx-handlers fired
+      :subscriptions  — only when subs recomputed
+      :views          — only when views re-rendered
+
+  Returns a vector of step maps. The view layer numbers steps via
+  `number-steps` so absent optional steps consume no number.
+
+  ## Coeffect folding
+
+  COEFFECT renders as ONE step group containing N rows (one per
+  injected coeffect) — the numbered circle counts as a single step,
+  but the body lists every coeffect. This matches the bead body's
+  numbered-cascade contract.
+
+  ## Pure-data
+
+  Reads only `:trace-events`, `:event-id`, `:dispatch-id` off the
+  record; no DOM, no substrate runtime, JVM-testable."
+  [epoch-record]
+  (let [events    (or (:trace-events epoch-record) [])
+        event-id  (or (:event-id epoch-record)
+                      (when-let [ev (find-op events :rf.event/dispatched)]
+                        (let [v (or (common/tag-of ev :event) (:event ev))]
+                          (when (vector? v) (first v)))))
+        fallback  (or (when-let [ev (find-op events :rf.event/dispatched)]
+                        (or (common/tag-of ev :event) (:event ev)))
+                      (:event epoch-record))]
+    (if (and (empty? events) (nil? fallback))
+      ;; Truly empty epoch: no dispatched trace, no fallback event,
+      ;; no other trace events. The cascade has nothing to render —
+      ;; return an empty step vector so the view shows the
+      ;; :no-events empty-state line.
+      []
+      (let [cofx-rows (coeffect-rows events)
+            steps     [(dispatch-row events fallback)
+                       (when (seq cofx-rows)
+                         {:step  :coeffect
+                          :badge :COEFFECT
+                          :rows  cofx-rows})
+                       (handler-row events event-id)
+                       (flow-step events)
+                       (fx-step events)
+                       (subscriptions-step events)
+                       (views-step events)]]
+        (filterv some? steps)))))
+
+(defn number-steps
+  "Stamp each step with a sequential `:step-number` (1..N). The view
+  layer renders this in the per-step numbered circle. Pure fn."
+  [steps]
+  (vec
+    (map-indexed (fn [i s] (assoc s :step-number (inc i))) steps)))
+
+(defn project-numbered
+  "Convenience: `(number-steps (project record))`."
+  [epoch-record]
+  (number-steps (project epoch-record)))
+
+;; ---- formatting helpers (view-shared) ------------------------------------
+
+(defn format-duration-ms
+  "Render a duration in ms as a short string (`0.1ms` / `12ms` /
+  `1.2s`). Returns nil for non-numbers so the view can render an
+  em-dash on a missing duration without guarding the call site."
+  [ms]
+  (when (number? ms)
+    (cond
+      (>= ms 1000) (str (/ (Math/round (double (* (/ ms 1000.0) 10))) 10.0) "s")
+      (>= ms 10)   (str (Math/round (double ms)) "ms")
+      :else        (let [rounded (/ (Math/round (double (* ms 10))) 10.0)]
+                     (str rounded "ms")))))
+
+(defn event-display
+  "Render the dispatched event vector as a one-line monospace string
+  for the DISPATCH row's target slot."
+  [event-vec]
+  (when (vector? event-vec)
+    (str event-vec)))
+
+(defn path-display
+  "Render a db path vector as the `[:foo :bar 0]` repr used by every
+  diff-style row. Returns `\"\"` for nil/empty."
+  [path]
+  (if (sequential? path)
+    (str (vec path))
+    ""))
+
+(defn ns-keyword
+  "Render an id as a clojure-style keyword string (`:my-ns/foo` or
+  `:foo`). Falls through `str` for non-keywords."
+  [id]
+  (cond
+    (qualified-keyword? id) (str ":" (namespace id) "/" (name id))
+    (keyword? id)           (str ":" (name id))
+    :else                   (str id)))
+
+(defn truncate
+  "Truncate a string to `n` chars with an ellipsis. Pure fn used by
+  the view layer for long arg displays in the FX table."
+  ([s] (truncate s 60))
+  ([s n]
+   (let [s (str s)]
+     (if (<= (count s) n)
+       s
+       (str (subs s 0 n) "…")))))
+
+(defn coeffect-row-display
+  "Render a coeffect row's id → value pair as a one-liner for the
+  view's diff-style add row (`+ [:session] {:user-id 42 …}`)."
+  [{:keys [id value]}]
+  (let [head (str "+ [" (ns-keyword id) "] ")
+        tail (truncate (pr-str value) 80)]
+    (str head tail)))
+
+(defn phase-label
+  "Render a machine action-ran `:phase` keyword as a UI label string."
+  [phase]
+  (case phase
+    :exit            "exit"
+    :transition      "transition"
+    :entry           "entry"
+    :always          "always"
+    :after-action    "after-action"
+    :initial-entry   "initial-entry"
+    :destroy-exit    "destroy-exit"
+    (when (keyword? phase) (name phase))))
+
+(defn timer-reason-label
+  "Render a timer-cancelled `:reason` keyword as a UI label string."
+  [reason]
+  (case reason
+    :on-exit          "on-exit"
+    :on-destroy       "on-destroy"
+    :on-resolution    "on-resolution"
+    :on-supersede     "on-supersede"
+    :on-frame-destroy "on-frame-destroy"
+    (when (keyword? reason) (name reason))))
+
+(defn group-lifecycle-by-phase
+  "Group machine lifecycle rows by `:phase`. Returns a map from phase
+  keyword → rows-vec. Pure fn for the view to render per-phase
+  sub-sections."
+  [lifecycle-rows]
+  (reduce (fn [acc row]
+            (update acc (or (:phase row) :unknown) (fnil conj []) row))
+          {}
+          (or lifecycle-rows [])))
+
+;; ---- spec helpers --------------------------------------------------------
+
+(defn handler-flavour-label
+  "Human-readable label for a handler flavour keyword."
+  [flavour]
+  (case flavour
+    :reg-event-db  "reg-event-db"
+    :reg-event-fx  "reg-event-fx"
+    :reg-machine   "machine-event-handler"
+    (str flavour)))
+
+(defn empty-pipeline?
+  "True iff `(project record)` would produce zero steps (no dispatch,
+  no handler). Used by the view to render an empty-state placeholder
+  when the focused epoch carries no trace events (cold start; replay
+  fixture)."
+  [epoch-record]
+  (empty? (project epoch-record)))
+
+;; ---- public mapping table -----------------------------------------------
+
+(def badge-set
+  "The 7 badges produced by the projection — every projected step's
+  `:badge` is a member of this set. Catalogued separately so tests
+  + the view's colour resolver have one authoritative inventory.
+
+  Per the bead body's badge taxonomy (rf2-sc3r1)."
+  #{:DISPATCH :COEFFECT :HANDLER :FLOW :FX :SUBSCRIPTIONS :VIEWS})
+
+(defn valid-badge?
+  "Predicate — `:badge` keyword is a member of `badge-set`."
+  [badge]
+  (contains? badge-set badge))
+
+;; ---- low-level helpers exposed for tests --------------------------------
+
+(defn ^:no-doc trace-event-count
+  "Count of trace events the projection ran against — exposed for
+  test introspection."
+  [epoch-record]
+  (count (or (:trace-events epoch-record) [])))
+
+(defn ^:no-doc has-step?
+  "True iff `(project record)` produced a step with `:step = step-kw`."
+  [epoch-record step-kw]
+  (boolean (some #(= step-kw (:step %)) (project epoch-record))))

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -1,0 +1,957 @@
+(ns day8.re-frame2-xray.panels.epoch.view
+  "View layer for the Epoch panel (rf2-sc3r1) — the numbered cascade
+  rendering of a single epoch's pipeline steps as a delightful,
+  detailed visual schematic.
+
+  ## Visual contract
+
+  Renders the pure-data projection from `panels.epoch.projection` as a
+  vertical, numbered cascade. Per the bead body's §Visual Structure:
+
+      ┌── ① DISPATCH      from ui ↗                    0.1ms
+      │      [:counter-inc]
+      │
+      ├── ② COEFFECT      :session ↗
+      │      + [:session] {:user-id 42 …}
+      │
+      ├── ③ HANDLER       reg-event-db ↗               0.5ms
+      │      (fn [db [_ amount]]
+      │        (update db :total + amount))
+      │      ↳ :db diff
+      │        ~ [:total]  100 → 110
+      │
+      ├── ④ FX           side effects
+      │      ✓ :db → app-db
+      │      ✓ :http/post {url ...}
+      │
+      ├── ⑤ SUBSCRIPTIONS
+      │      ┌─ sub                ─ inputs ─ changed
+      │      ├─ :total-sub ↗       app-db    ✓ 100 → 110
+      │
+      └── ⑥ VIEWS
+             ┌─ view              ─ subs
+             ├─ ::counter-view ↗   :total-sub
+
+  Steps appear ONLY when the corresponding trace events surfaced —
+  absence is conveyed by omission, not an empty-state line. The
+  vertical rail + numbered circles are positioned absolutely so they
+  read as one continuous timeline regardless of which steps render.
+
+  ## Expansion state
+
+  Per-row EDN expansion (clicking a row's header opens the
+  edn-inspector for the row's payload) is stored in the Xray app-db
+  under `:epoch-panel-expanded-rows` (a set of `[step-kw row-id]`
+  pairs). The view subscribes to the expanded-set sub and dispatches
+  toggle events; the edn-inspector widget composes naturally with
+  `:zoomable? true` (rf2-h71e0) + `:header` (rf2-okq7p) per the
+  bead body's §edn-inspector composition.
+
+  ## Pure hiccup
+
+  The panel emits hiccup; the substrate adapter installed via
+  `rf/init!` handles rendering. Each step body is a body-returning
+  helper composed into the numbered cascade by `pipeline-view`."
+  (:require [clojure.string :as str]
+            [re-frame.core :as rf]
+            [day8.re-frame2-xray.panels.epoch.badge :as badge]
+            [day8.re-frame2-xray.panels.epoch.icons :as icons]
+            [day8.re-frame2-xray.panels.epoch.projection :as proj]
+            [day8.re-frame2-xray.theme.tokens
+             :refer [tokens mono-stack sans-stack]]))
+
+;; ---- expansion state helpers ---------------------------------------------
+;;
+;; The Epoch panel's row-expansion surface (`:rf.xray.epoch/toggle-
+;; row-expand` event + `:rf.xray.epoch/expanded-rows` sub) is
+;; registered by the orchestrator's `install!`. The current view
+;; renders default-visible content for every step (the cascade's
+;; punch is its always-visible rhythm); the toggle infrastructure
+;; stays in place for the follow-on rich-expansion pass where
+;; clicking a row's header mounts the edn-inspector widget under
+;; the body via `:zoomable? true` + `:header "<step>"` (rf2-h71e0 /
+;; rf2-okq7p) per the bead body's §edn-inspector composition.
+
+;; ---- chrome helpers ------------------------------------------------------
+
+(defn- badge-pill
+  "Render a step's badge pill — uppercase 10px label inside a
+  rounded-corners chip painted in the badge's colour.
+
+  Per the bead body's §Numbered Cascade Pattern step 2:
+
+      Badge pill: uppercase text, 10px font (devtools-micro),
+                  rounded, padding 5px horizontal, 3px vertical"
+  [step-badge]
+  [:span {:data-testid (str "rf-xray-epoch-badge-"
+                            (str/lower-case (name step-badge)))
+          :style {:display          "inline-flex"
+                  :align-items      "center"
+                  :background       (badge/colour step-badge)
+                  :color            (:white tokens)
+                  :font-family      sans-stack
+                  :font-size        "10px"
+                  :font-weight      700
+                  :letter-spacing   "0.5px"
+                  :padding          "3px 5px"
+                  :border-radius    "3px"
+                  :line-height      1
+                  :text-transform   "uppercase"
+                  :white-space      "nowrap"}}
+   (badge/label step-badge)])
+
+(defn- numbered-circle
+  "Render the numbered circle — 21px diameter, painted in the step's
+  badge colour with white numerals. Positioned absolutely at -44px
+  from the content column's left edge per the bead body's §Numbered
+  Cascade Pattern step 1."
+  [step-number step-badge]
+  [:span {:data-testid (str "rf-xray-epoch-circle-" step-number)
+          :aria-label  (str "step " step-number " (" (name step-badge) ")")
+          :style {:position         "absolute"
+                  :left             "-44px"
+                  :top              0
+                  :width            "21px"
+                  :height           "21px"
+                  :border-radius    "50%"
+                  :background       (badge/colour step-badge)
+                  :color            (:white tokens)
+                  :display          "inline-flex"
+                  :align-items      "center"
+                  :justify-content  "center"
+                  :font-family      mono-stack
+                  :font-size        "11px"
+                  :font-weight      700
+                  :line-height      1
+                  :z-index          1}}
+   (str step-number)])
+
+(defn- duration-chip
+  "Right-aligned duration chip rendered alongside a step's header.
+  Returns nil for non-number durations so the view can elide the
+  slot when the substrate didn't stamp one."
+  [duration-ms]
+  (when (number? duration-ms)
+    [:span {:data-testid "rf-xray-epoch-duration"
+            :style {:color       (:text-tertiary tokens)
+                    :font-family mono-stack
+                    :font-size   "11px"
+                    :font-weight 500
+                    :white-space "nowrap"
+                    :margin-left "auto"
+                    :padding-left "8px"}}
+     (proj/format-duration-ms duration-ms)]))
+
+(defn- coord-chip
+  "External-link affordance — opens the editor at `coord` via the
+  cross-panel `:rf.xray/open-in-editor` event. Returns nil when
+  `coord` has no `:file`."
+  [coord testid]
+  (when (and (map? coord) (seq (:file coord)))
+    [:button {:data-testid testid
+              :aria-label  "open in editor"
+              :title       "open in editor"
+              :on-click    (fn [e]
+                             (.stopPropagation e)
+                             (rf/dispatch [:rf.xray/open-in-editor
+                                           {:source-coord coord}]
+                                          {:frame :rf/xray}))
+              :style       {:background      "transparent"
+                            :color           "inherit"
+                            :border          "none"
+                            :padding         "0 4px"
+                            :margin-left     "4px"
+                            :cursor          "pointer"
+                            :display         "inline-flex"
+                            :align-items     "center"
+                            :line-height     1}}
+     (icons/external-link)]))
+
+(defn- step-header
+  "Render a step's header row — badge pill + verb/label + optional
+  duration. The flex layout keeps the duration right-aligned via
+  `margin-left: auto`. The whole header is wrapped in an interactive
+  `<div>` so clicking anywhere on the row toggles `expanded?` when
+  the step carries expandable content (`expandable?` true)."
+  [{:keys [badge verb expandable? expanded? testid duration-ms]} on-toggle]
+  [:div {:data-testid (str testid "-header")
+         :on-click    (when (and expandable? on-toggle)
+                        (fn [e]
+                          (.stopPropagation e)
+                          (on-toggle)))
+         :style {:display      "flex"
+                 :align-items  "center"
+                 :gap          "8px"
+                 :cursor       (if expandable? "pointer" "default")
+                 :font-family  sans-stack
+                 :font-size    "12px"
+                 :color        (:text-primary tokens)
+                 :user-select  "none"}}
+   (badge-pill badge)
+   [:span {:data-testid (str testid "-verb")
+           :style {:display      "inline-flex"
+                   :align-items  "center"
+                   :gap          "4px"
+                   :font-family  mono-stack
+                   :font-size    "12px"
+                   :color        (:text-primary tokens)
+                   :min-width    0
+                   :flex         "1 1 auto"
+                   :overflow     "hidden"
+                   :text-overflow "ellipsis"
+                   :white-space  "nowrap"}}
+    verb]
+   (when expandable?
+     [:span {:data-testid (str testid "-expand-glyph")
+             :aria-hidden true
+             :style {:color       (:text-tertiary tokens)
+                     :font-family mono-stack
+                     :font-size   "10px"
+                     :margin-left "4px"}}
+      (if expanded? "▾" "▸")])
+   (duration-chip duration-ms)])
+
+(defn- sub-header
+  "Render a sub-section header (`↳ :db diff` / `↳ :fx` / `↳ guards`)
+  under a step's body — corner-down-right glyph + label + optional
+  trailing count."
+  ([label]
+   (sub-header label nil))
+  ([label trailing]
+   [:div {:style {:display      "flex"
+                  :align-items  "center"
+                  :gap          "6px"
+                  :margin       "8px 0 5px 0"
+                  :font-family  sans-stack
+                  :font-size    "11px"
+                  :font-weight  600
+                  :color        (:text-tertiary tokens)
+                  :text-transform "uppercase"
+                  :letter-spacing "0.5px"}}
+    [:span {:style {:display "inline-flex" :color (:text-tertiary tokens)}}
+     (icons/corner-down-right)]
+    [:span label]
+    (when trailing
+      [:span {:style {:color (:text-tertiary tokens)
+                      :font-weight 400
+                      :font-family mono-stack
+                      :text-transform "none"}}
+       trailing])]))
+
+;; ---- DISPATCH step -------------------------------------------------------
+
+(defn dispatch-body
+  "Render the DISPATCH step's expanded body — the event vector + the
+  source pill. Per the bead body's §DISPATCH (Step 1).
+
+  Target line (event vector) is rendered as a boxed monospace block;
+  the FROM row carries an inline click-to-source link with the
+  external-link chip when a call-site coord was captured."
+  [{:keys [event source coord]}]
+  [:div
+   ;; Target — the dispatched event vector.
+   [:div {:data-testid "rf-xray-epoch-dispatch-event"
+          :style {:font-family   mono-stack
+                  :font-size     "12px"
+                  :color         (:text-primary tokens)
+                  :background    (:bg-3 tokens)
+                  :border        (str "1px solid " (:border-subtle tokens))
+                  :border-radius "3px"
+                  :padding       "5px 8px"
+                  :margin-top    "5px"
+                  :overflow-x    "auto"}}
+    (proj/event-display event)]
+   ;; FROM <source>
+   (when source
+     [:div {:data-testid "rf-xray-epoch-dispatch-source"
+            :style {:display      "flex"
+                    :align-items  "center"
+                    :gap          "4px"
+                    :margin-top   "5px"
+                    :font-family  sans-stack
+                    :font-size    "11px"
+                    :color        (:text-tertiary tokens)}}
+      "from "
+      [:span {:style {:color (:accent tokens) :font-family mono-stack}}
+       (name source)]
+      (coord-chip coord "rf-xray-epoch-dispatch-coord")])])
+
+(defn render-dispatch-step
+  "Render the DISPATCH step (always present)."
+  [{:keys [source duration-ms step-number] :as step}]
+  [:div {:data-testid "rf-xray-epoch-step-dispatch"
+         :data-step-kw "dispatch"}
+   (numbered-circle step-number :DISPATCH)
+   (step-header
+     {:step :dispatch
+      :badge :DISPATCH
+      :verb [:span "from "
+             [:span {:style {:color (:accent tokens)}}
+              (if source (name source) "unknown")]]
+      :expandable? false
+      :testid "rf-xray-epoch-dispatch"
+      :duration-ms duration-ms}
+     nil)
+   (dispatch-body step)])
+
+;; ---- COEFFECT step -------------------------------------------------------
+
+(defn- coeffect-row-view
+  "Render one COEFFECT row (id link + diff-style add-row) per the bead
+  body's §COEFFECT shape."
+  [{:keys [id value] :as _row} idx]
+  [:div {:key (str "cofx-" idx)
+         :data-testid (str "rf-xray-epoch-coeffect-row-" idx)
+         :style {:padding "3px 0"}}
+   ;; id link
+   [:div {:style {:display "inline-flex"
+                  :align-items "center"
+                  :gap "4px"
+                  :font-family mono-stack
+                  :font-size "12px"
+                  :color (:accent tokens)}}
+    (proj/ns-keyword id)
+    (icons/external-link)]
+   ;; diff-style add row
+   [:div {:style {:display      "flex"
+                  :align-items  "flex-start"
+                  :gap          "8px"
+                  :padding      "2px 0 2px 16px"
+                  :font-family  mono-stack
+                  :font-size    "12px"}}
+    [:span {:style {:color (:success tokens) :font-weight 700}} "+"]
+    [:span {:style {:color (:text-tertiary tokens) :white-space "nowrap"}}
+     (str "[" (proj/ns-keyword id) "]")]
+    [:span {:style {:color (:success tokens) :min-width 0 :flex 1
+                    :word-break "break-word"}}
+     (proj/truncate (pr-str value) 100)]]])
+
+(defn render-coeffect-step
+  "Render the COEFFECT step (single step with N rows — one per
+  user-injected coeffect). Always conditional — present only when the
+  projection emitted the step."
+  [{:keys [rows step-number]}]
+  [:div {:data-testid "rf-xray-epoch-step-coeffect"
+         :data-step-kw "coeffect"}
+   (numbered-circle step-number :COEFFECT)
+   (step-header
+     {:step :coeffect
+      :badge :COEFFECT
+      :verb (str (count rows) " coeffect"
+                 (when (not= 1 (count rows)) "s") " injected")
+      :expandable? false
+      :testid "rf-xray-epoch-coeffect"}
+     nil)
+   [:div {:style {:margin-top "5px"}}
+    (map-indexed coeffect-row-view rows)]])
+
+;; ---- HANDLER step --------------------------------------------------------
+
+(defn- db-diff-line
+  "Render one db-diff entry (`~ [path] before → after` /
+  `+ [path] value` / `- [path]`)."
+  [[path before after change-kind] idx]
+  (let [glyph (case change-kind
+                :added    "+"
+                :removed  "-"
+                :modified "~"
+                (cond
+                  (and (some? before) (some? after)) "~"
+                  (some? after)                       "+"
+                  :else                                "-"))
+        glyph-colour (case glyph
+                       "+" (:success tokens)
+                       "-" (:error tokens)
+                       (:warning tokens))]
+    [:div {:key (str "diff-" idx)
+           :data-testid (str "rf-xray-epoch-handler-diff-row-" idx)
+           :style {:display      "flex"
+                   :align-items  "flex-start"
+                   :gap          "8px"
+                   :padding      "2px 0"
+                   :font-family  mono-stack
+                   :font-size    "12px"}}
+     [:span {:style {:color glyph-colour :font-weight 700}} glyph]
+     [:span {:style {:color (:text-tertiary tokens) :white-space "nowrap"}}
+      (proj/path-display path)]
+     (when (= "~" glyph)
+       [:<>
+        [:span {:style {:color (:error tokens)}}
+         (proj/truncate (pr-str before) 40)]
+        [:span {:style {:color (:text-tertiary tokens)}} "→"]
+        [:span {:style {:color (:success tokens)}}
+         (proj/truncate (pr-str after) 40)]])
+     (when (= "+" glyph)
+       [:span {:style {:color (:success tokens) :min-width 0 :flex 1
+                       :word-break "break-word"}}
+        (proj/truncate (pr-str after) 80)])]))
+
+(defn- fx-entry-line
+  "Render one fx entry inside the HANDLER step's :fx sub-block."
+  [{:keys [fx-id value]} idx]
+  [:div {:key (str "fx-entry-" idx)
+         :data-testid (str "rf-xray-epoch-handler-fx-row-" idx)
+         :style {:display      "flex"
+                 :align-items  "flex-start"
+                 :gap          "8px"
+                 :padding      "2px 0 2px 21px"
+                 :font-family  mono-stack
+                 :font-size    "12px"}}
+   [:span {:style {:color (:accent tokens) :white-space "nowrap"}}
+    (proj/ns-keyword fx-id)]
+   [:span {:style {:color (:text-primary tokens) :min-width 0 :flex 1
+                   :word-break "break-word"}}
+    (proj/truncate (pr-str value) 80)]])
+
+(defn- machine-lifecycle-block
+  "Render the per-phase lifecycle rows for a machine handler. Empty
+  phases render dimmed `(none)` so the model reads as the full
+  exit → transition → entry shape even when one phase carries no
+  actions (the panel doubles as a teaching surface — bead body §What
+  this panel teaches)."
+  [lifecycle-rows]
+  (let [grouped (proj/group-lifecycle-by-phase lifecycle-rows)
+        phases  [:exit :transition :entry :always
+                 :after-action :initial-entry :destroy-exit]]
+    [:div {:data-testid "rf-xray-epoch-handler-machine-lifecycle"
+           :style {:margin-top "5px"}}
+     (sub-header "lifecycle"
+                 (str (count lifecycle-rows) " action"
+                      (when (not= 1 (count lifecycle-rows)) "s")))
+     (for [phase phases
+           :let [rows (get grouped phase)]
+           :when (seq rows)]
+       [:div {:key (str "phase-" (name phase))
+              :data-testid (str "rf-xray-epoch-handler-phase-" (name phase))
+              :style {:padding "2px 0 2px 21px"
+                      :font-family mono-stack
+                      :font-size "12px"}}
+        [:div {:style {:color (:text-tertiary tokens)
+                       :font-size "10px"
+                       :text-transform "uppercase"
+                       :letter-spacing "0.5px"
+                       :margin-bottom "2px"}}
+         (proj/phase-label phase)]
+        (for [[i row] (map-indexed vector rows)]
+          [:div {:key (str "lc-" i)
+                 :style {:display "flex"
+                         :gap "8px"
+                         :padding "1px 0"
+                         :color (if (:threw? row) (:error tokens)
+                                    (:text-primary tokens))}}
+           [:span {:style {:color (:text-tertiary tokens)}} "↓"]
+           [:span (proj/ns-keyword (:action-id row))]
+           (when (:threw? row)
+             [:span {:style {:color (:error tokens) :margin-left "8px"}}
+              "(threw)"])])])]))
+
+(defn- machine-block
+  "Render the machine-handler-specific extras (transition summary,
+  guards, lifecycle, timer cancellations). Per the bead body §HANDLER
+  (Step 4) machine handler branch — uses the rf2-82a0u trace
+  enhancements (phase + outcome + reason)."
+  [{:keys [transition guards lifecycle timers]}]
+  [:div {:data-testid "rf-xray-epoch-handler-machine"}
+   ;; Transition summary
+   (when transition
+     [:div {:style {:padding "3px 0 3px 16px"
+                    :font-family mono-stack
+                    :font-size "12px"
+                    :color (:text-primary tokens)}}
+      [:div {:style {:color (:text-tertiary tokens)
+                     :font-size "10px"
+                     :text-transform "uppercase"
+                     :letter-spacing "0.5px"}}
+       (str "transition · " (proj/ns-keyword (:machine-id transition)))]
+      [:div {:style {:padding-left "16px"}}
+       (let [before (or (some-> (:before transition) :state) (:before transition))
+             after  (or (some-> (:after transition) :state) (:after transition))]
+         (str (pr-str before) " → " (pr-str after)))]])
+   ;; Guards
+   (when (seq guards)
+     [:div {:style {:padding "3px 0 3px 16px"}}
+      (sub-header "guards" (str (count guards) " evaluated"))
+      (for [[i {:keys [guard-id outcome]}] (map-indexed vector guards)]
+        [:div {:key (str "g-" i)
+               :style {:display "flex"
+                       :gap "8px"
+                       :padding "1px 0 1px 21px"
+                       :font-family mono-stack
+                       :font-size "12px"}}
+         [:span {:style {:color (case outcome
+                                  :pass (:success tokens)
+                                  :fail (:warning tokens)
+                                  :threw (:error tokens)
+                                  (:text-tertiary tokens))
+                         :font-weight 700}}
+          (case outcome
+            :pass  "✓"
+            :fail  "✗"
+            :threw "!"
+            "·")]
+         [:span (proj/ns-keyword guard-id)]
+         [:span {:style {:color (:text-tertiary tokens) :margin-left "8px"}}
+          (when (keyword? outcome) (name outcome))]])])
+   ;; Lifecycle
+   (when (seq lifecycle)
+     (machine-lifecycle-block lifecycle))
+   ;; Timers
+   (when (seq timers)
+     [:div {:style {:padding "3px 0 3px 16px"}}
+      (sub-header "after-timers" (str (count timers) " cancelled"))
+      (for [[i {:keys [state delay reason]}] (map-indexed vector timers)]
+        [:div {:key (str "t-" i)
+               :style {:display "flex"
+                       :gap "8px"
+                       :padding "1px 0 1px 21px"
+                       :font-family mono-stack
+                       :font-size "12px"}}
+         [:span {:style {:color (:warning tokens)}} "✗"]
+         [:span (str (pr-str state))]
+         (when (number? delay)
+           [:span {:style {:color (:text-tertiary tokens)}}
+            (str delay "ms")])
+         [:span {:style {:color (:text-tertiary tokens) :font-style "italic"
+                         :margin-left "8px"}}
+          (proj/timer-reason-label reason)]])])])
+
+(defn handler-body
+  "Render the HANDLER step's body — flavour label + db-diff + fx + the
+  machine block when the handler is a machine-event-handler."
+  [{:keys [flavour event-id db-diff fx machine] :as _row}]
+  [:div {:data-testid "rf-xray-epoch-handler-body"}
+   ;; Flavour + event-id
+   [:div {:style {:display      "flex"
+                  :align-items  "center"
+                  :gap          "6px"
+                  :margin-top   "5px"
+                  :font-family  mono-stack
+                  :font-size    "12px"
+                  :color        (:text-primary tokens)}}
+    [:span {:style {:color (:accent tokens)}}
+     (proj/handler-flavour-label flavour)]
+    (icons/external-link)
+    (when event-id
+      [:span {:style {:color (:text-tertiary tokens)}}
+       (proj/ns-keyword event-id)])]
+   ;; Machine extras BEFORE db diff (lifecycle is the story for machines)
+   (when machine
+     (machine-block machine))
+   ;; :db diff
+   (when (seq db-diff)
+     [:div {:data-testid "rf-xray-epoch-handler-db-diff"}
+      (sub-header ":db diff"
+                  (str (count db-diff) " path"
+                       (when (not= 1 (count db-diff)) "s")))
+      (for [[i row] (map-indexed vector db-diff)]
+        (db-diff-line row i))])
+   ;; :fx entries
+   (when (seq fx)
+     [:div {:data-testid "rf-xray-epoch-handler-fx"}
+      (sub-header ":fx"
+                  (str (count fx) " entr"
+                       (if (= 1 (count fx)) "y" "ies")))
+      (for [[i entry] (map-indexed vector fx)]
+        (fx-entry-line entry i))])])
+
+(defn render-handler-step
+  "Render the HANDLER step (always present)."
+  [{:keys [flavour event-id duration-ms step-number] :as step}]
+  [:div {:data-testid "rf-xray-epoch-step-handler"
+         :data-step-kw "handler"
+         :data-handler-flavour (when flavour (name flavour))}
+   (numbered-circle step-number :HANDLER)
+   (step-header
+     {:step :handler
+      :badge :HANDLER
+      :verb [:span {:style {:display "inline-flex" :gap "4px"}}
+             [:span {:style {:color (:accent tokens)}}
+              (proj/handler-flavour-label flavour)]
+             (when event-id
+               [:span {:style {:color (:text-tertiary tokens)}}
+                (proj/ns-keyword event-id)])]
+      :expandable? false
+      :testid "rf-xray-epoch-handler"
+      :duration-ms duration-ms}
+     nil)
+   (handler-body step)])
+
+;; ---- FLOW step -----------------------------------------------------------
+
+(defn- flow-row-view
+  "Render one flow recompute row — id link + diff-style line."
+  [{:keys [flow-id path before after duration-ms]} idx]
+  [:div {:key (str "flow-" idx)
+         :data-testid (str "rf-xray-epoch-flow-row-" idx)
+         :style {:padding "3px 0"}}
+   [:div {:style {:display "inline-flex"
+                  :gap "4px"
+                  :font-family mono-stack
+                  :font-size "12px"
+                  :color (:accent tokens)}}
+    (proj/ns-keyword flow-id)
+    (icons/external-link)
+    (when (number? duration-ms)
+      [:span {:style {:color (:text-tertiary tokens) :margin-left "8px"}}
+       (proj/format-duration-ms duration-ms)])]
+   (when (sequential? path)
+     [:div {:style {:display "flex"
+                    :align-items "flex-start"
+                    :gap "8px"
+                    :padding "2px 0 2px 21px"
+                    :font-family mono-stack
+                    :font-size "12px"}}
+      [:span {:style {:color (:warning tokens) :font-weight 700}} "~"]
+      [:span {:style {:color (:text-tertiary tokens)}}
+       (proj/path-display path)]
+      (when (some? before)
+        [:span {:style {:color (:error tokens)}}
+         (proj/truncate (pr-str before) 30)])
+      (when (and (some? before) (some? after))
+        [:span {:style {:color (:text-tertiary tokens)}} "→"])
+      (when (some? after)
+        [:span {:style {:color (:success tokens)}}
+         (proj/truncate (pr-str after) 30)])])])
+
+(defn render-flow-step
+  "Render the FLOW step (only present when flows fired)."
+  [{:keys [rows step-number]}]
+  [:div {:data-testid "rf-xray-epoch-step-flow"
+         :data-step-kw "flow"}
+   (numbered-circle step-number :FLOW)
+   (step-header
+     {:step :flow
+      :badge :FLOW
+      :verb (str (count rows) " flow"
+                 (when (not= 1 (count rows)) "s") " recomputed")
+      :expandable? false
+      :testid "rf-xray-epoch-flow"}
+     nil)
+   [:div {:style {:margin-top "5px"}}
+    (map-indexed flow-row-view rows)]])
+
+;; ---- FX step -------------------------------------------------------------
+
+(defn- fx-row-view
+  "Render one fx-handler row inside the FX step — green check + fx-id
+  + truncated args."
+  [{:keys [fx-id status args duration-ms]} idx]
+  (let [glyph    (case status
+                   :ok          "✓"
+                   :overridden  "↺"
+                   :skipped     "·"
+                   :error       "✗"
+                   "·")
+        colour   (case status
+                   :ok          (:success tokens)
+                   :overridden  (:accent tokens)
+                   :skipped     (:text-tertiary tokens)
+                   :error       (:error tokens)
+                   (:text-secondary tokens))]
+    [:div {:key (str "fx-" idx)
+           :data-testid (str "rf-xray-epoch-fx-row-" idx)
+           :data-fx-status (when (keyword? status) (name status))
+           :style {:display "flex"
+                   :align-items "flex-start"
+                   :gap "8px"
+                   :padding "2px 0"
+                   :font-family mono-stack
+                   :font-size "12px"}}
+     [:span {:style {:color colour :font-weight 700}} glyph]
+     [:span {:style {:color (:accent tokens)}}
+      (proj/ns-keyword fx-id)]
+     (when (some? args)
+       [:span {:style {:color (:text-primary tokens) :min-width 0 :flex 1
+                       :word-break "break-word"}}
+        (proj/truncate (pr-str args) 80)])
+     (when (number? duration-ms)
+       [:span {:style {:color (:text-tertiary tokens)
+                       :margin-left "8px"
+                       :white-space "nowrap"}}
+        (proj/format-duration-ms duration-ms)])]))
+
+(defn render-fx-step
+  "Render the FX step (only present when fx-handlers fired)."
+  [{:keys [rows step-number]}]
+  [:div {:data-testid "rf-xray-epoch-step-fx"
+         :data-step-kw "fx"}
+   (numbered-circle step-number :FX)
+   (step-header
+     {:step :fx
+      :badge :FX
+      :verb (str (count rows) " side-effect"
+                 (when (not= 1 (count rows)) "s"))
+      :expandable? false
+      :testid "rf-xray-epoch-fx"}
+     nil)
+   [:div {:style {:margin-top "5px"}}
+    (map-indexed fx-row-view rows)]])
+
+;; ---- SUBSCRIPTIONS step --------------------------------------------------
+
+(defn- subscriptions-table
+  "Render the SUBSCRIPTIONS table — 3 columns (sub / inputs / changed).
+  Per the bead body's §SUBSCRIPTIONS (Step 7) shape."
+  [rows]
+  [:div {:data-testid "rf-xray-epoch-subscriptions-table"
+         :style {:margin-top "5px"
+                 :border (str "1px solid " (:border-subtle tokens))
+                 :border-radius "3px"
+                 :overflow "hidden"}}
+   ;; header
+   [:div {:style {:display "flex"
+                  :align-items "stretch"
+                  :background (:bg-3 tokens)
+                  :border-bottom (str "1px solid " (:border-subtle tokens))
+                  :font-family sans-stack
+                  :font-size "10px"
+                  :font-weight 700
+                  :color (:text-tertiary tokens)
+                  :text-transform "uppercase"
+                  :letter-spacing "0.5px"}}
+    [:div {:style {:flex "1 1 35%" :padding "5px 8px"}} "sub"]
+    [:div {:style {:flex "1 1 35%" :padding "5px 8px"}} "inputs"]
+    [:div {:style {:flex "1 1 30%" :padding "5px 8px"}} "changed"]]
+   ;; rows
+   (for [[i {:keys [sub-id sub-vec inputs changed? before after]}] (map-indexed vector rows)]
+     [:div {:key (str "sub-" i)
+            :data-testid (str "rf-xray-epoch-sub-row-" i)
+            :data-sub-changed (str (boolean changed?))
+            :style {:display "flex"
+                    :align-items "stretch"
+                    :border-bottom (when (< i (dec (count rows)))
+                                     (str "1px solid " (:border-subtle tokens)))}}
+      [:div {:style {:flex "1 1 35%" :padding "5px 8px" :min-width 0
+                     :font-family mono-stack :font-size "12px"
+                     :word-break "break-word"}}
+       [:span {:style {:color (:accent tokens) :display "inline-flex"
+                       :align-items "center" :gap "4px"}}
+        (or (when (vector? sub-vec) (pr-str sub-vec))
+            (proj/ns-keyword sub-id))
+        (icons/external-link)]]
+      [:div {:style {:flex "1 1 35%" :padding "5px 8px" :min-width 0
+                     :font-family mono-stack :font-size "12px"
+                     :color (:text-tertiary tokens)
+                     :word-break "break-word"}}
+       (cond
+         (vector? inputs)
+         (into [:div {:style {:display "flex" :flex-direction "column" :gap "2px"}}]
+               (map (fn [i] [:div (proj/ns-keyword i)]) inputs))
+         inputs (proj/ns-keyword inputs)
+         :else  "app-db")]
+      [:div {:style {:flex "1 1 30%" :padding "5px 8px" :min-width 0
+                     :font-family mono-stack :font-size "12px"}}
+       (if changed?
+         [:div {:style {:display "flex" :gap "6px" :flex-wrap "wrap"
+                        :align-items "center"}}
+          [:span {:style {:color (:success tokens) :font-weight 700}} "✓"]
+          (when (some? before)
+            [:span {:style {:color (:error tokens)}}
+             (proj/truncate (pr-str before) 24)])
+          (when (and (some? before) (some? after))
+            [:span {:style {:color (:text-tertiary tokens)}} "→"])
+          (when (some? after)
+            [:span {:style {:color (:success tokens)}}
+             (proj/truncate (pr-str after) 24)])]
+         [:span {:style {:color (:text-tertiary tokens) :font-weight 700}} "✗"])]])])
+
+(defn render-subscriptions-step
+  "Render the SUBSCRIPTIONS step (only present when subs recomputed)."
+  [{:keys [rows step-number]}]
+  [:div {:data-testid "rf-xray-epoch-step-subscriptions"
+         :data-step-kw "subscriptions"}
+   (numbered-circle step-number :SUBSCRIPTIONS)
+   (step-header
+     {:step :subscriptions
+      :badge :SUBSCRIPTIONS
+      :verb (str (count rows) " sub" (when (not= 1 (count rows)) "s")
+                 " recomputed")
+      :expandable? false
+      :testid "rf-xray-epoch-subscriptions"}
+     nil)
+   (subscriptions-table rows)])
+
+;; ---- VIEWS step ----------------------------------------------------------
+
+(defn- views-table
+  "Render the VIEWS table — 2 columns (views / subs). Per the bead
+  body's §VIEWS (Step 8) shape."
+  [rows]
+  [:div {:data-testid "rf-xray-epoch-views-table"
+         :style {:margin-top "5px"
+                 :border (str "1px solid " (:border-subtle tokens))
+                 :border-radius "3px"
+                 :overflow "hidden"}}
+   [:div {:style {:display "flex"
+                  :align-items "stretch"
+                  :background (:bg-3 tokens)
+                  :border-bottom (str "1px solid " (:border-subtle tokens))
+                  :font-family sans-stack
+                  :font-size "10px"
+                  :font-weight 700
+                  :color (:text-tertiary tokens)
+                  :text-transform "uppercase"
+                  :letter-spacing "0.5px"}}
+    [:div {:style {:flex "1 1 50%" :padding "5px 8px"}} "view"]
+    [:div {:style {:flex "1 1 50%" :padding "5px 8px"}} "subs"]]
+   (for [[i {:keys [view-id subs-read duration-ms]}] (map-indexed vector rows)]
+     [:div {:key (str "view-" i)
+            :data-testid (str "rf-xray-epoch-view-row-" i)
+            :style {:display "flex"
+                    :align-items "stretch"
+                    :border-bottom (when (< i (dec (count rows)))
+                                     (str "1px solid " (:border-subtle tokens)))}}
+      [:div {:style {:flex "1 1 50%" :padding "5px 8px" :min-width 0
+                     :font-family mono-stack :font-size "12px"
+                     :word-break "break-word"}}
+       [:span {:style {:color (:accent tokens) :display "inline-flex"
+                       :align-items "center" :gap "4px"}}
+        (proj/ns-keyword view-id)
+        (icons/external-link)]
+       (when (number? duration-ms)
+         [:span {:style {:color (:text-tertiary tokens)
+                         :margin-left "8px"
+                         :font-size "10px"}}
+          (proj/format-duration-ms duration-ms)])]
+      [:div {:style {:flex "1 1 50%" :padding "5px 8px" :min-width 0
+                     :font-family mono-stack :font-size "12px"
+                     :color (:text-tertiary tokens)
+                     :word-break "break-word"}}
+       (cond
+         (sequential? subs-read)
+         (into [:div {:style {:display "flex" :flex-direction "column" :gap "2px"}}]
+               (for [s subs-read]
+                 [:div (if (vector? s) (pr-str s) (proj/ns-keyword s))]))
+         (some? subs-read)
+         (proj/ns-keyword subs-read)
+         :else
+         "(none)")]])])
+
+(defn render-views-step
+  "Render the VIEWS step (only present when views re-rendered)."
+  [{:keys [rows step-number]}]
+  [:div {:data-testid "rf-xray-epoch-step-views"
+         :data-step-kw "views"}
+   (numbered-circle step-number :VIEWS)
+   (step-header
+     {:step :views
+      :badge :VIEWS
+      :verb (str (count rows) " view"
+                 (when (not= 1 (count rows)) "s") " re-rendered")
+      :expandable? false
+      :testid "rf-xray-epoch-views"}
+     nil)
+   (views-table rows)])
+
+;; ---- step dispatcher -----------------------------------------------------
+
+(defn- render-step
+  "Dispatch a step row to its renderer. Returns hiccup; nil for
+  unknown step kinds (defensive — every step the projection produces
+  is in the seven-step inventory)."
+  [step]
+  (case (:step step)
+    :dispatch       (render-dispatch-step step)
+    :coeffect       (render-coeffect-step step)
+    :handler        (render-handler-step step)
+    :flow           (render-flow-step step)
+    :fx             (render-fx-step step)
+    :subscriptions  (render-subscriptions-step step)
+    :views          (render-views-step step)
+    nil))
+
+;; ---- pipeline view -------------------------------------------------------
+
+(defn pipeline-view
+  "Render the numbered pipeline cascade for `steps` (already
+  numbered via `project-numbered`). Each step renders as a
+  position-relative wrapper so the per-step numbered circle anchors
+  off the wrapper's left edge — the rail is a single absolutely-
+  positioned line spanning the whole cascade.
+
+  Per the bead body's §Layout:
+
+      Container: padding 21px, overflow auto, full height
+      Pipeline: left margin 55px to accommodate numbered circles
+      Vertical line: absolute positioned, 0.5px width, starts at
+                     13px from top, positioned at -34px from left edge
+      Row spacing: 13px vertical gap between entries"
+  [steps]
+  [:div {:data-testid "rf-xray-epoch-pipeline"
+         :style {:position    "relative"
+                 :padding-left "55px"
+                 :padding-top  "0"}}
+   ;; The vertical rail — absolute-positioned line behind the
+   ;; numbered circles. Top = numbered-circle radius (so the line
+   ;; starts at the centre of step-1's circle); bottom = the foot
+   ;; of the last step's circle.
+   [:div {:data-testid "rf-xray-epoch-rail"
+          :aria-hidden true
+          :style {:position    "absolute"
+                  :left        (str (+ 55 (badge/line-left-offset-px)) "px")
+                  :top         (str (badge/vertical-line-offset-px) "px")
+                  :bottom      "13px"
+                  :width       "1px"
+                  :background  (:border-default tokens)
+                  :pointer-events "none"}}]
+   ;; Steps
+   (for [[i step] (map-indexed vector steps)]
+     ^{:key (str "step-" (:step step) "-" i)}
+     [:div {:data-testid (str "rf-xray-epoch-pipeline-step-" (:step-number step))
+            :data-step (when (:step step) (name (:step step)))
+            :style {:position     "relative"
+                    :margin-bottom "13px"
+                    :min-height   "21px"}}
+      (render-step step)])])
+
+;; ---- empty states --------------------------------------------------------
+
+(defn- empty-state-view
+  "Render the empty-state copy for a given focus status. Per the
+  shared focus-resolver contract — three statuses, three messages."
+  [status]
+  (let [msg (case status
+              :no-focus      "No event focused. Click an event in the list to inspect its pipeline."
+              :epoch-evicted "The selected epoch was evicted from the history buffer. Pick a more recent event."
+              :no-events     "The focused epoch has no recorded trace events."
+              "No data available.")]
+    [:div {:data-testid (str "rf-xray-epoch-empty-" (name status))
+           :style {:padding     "21px"
+                   :color       (:text-tertiary tokens)
+                   :font-family sans-stack
+                   :font-size   "13px"}}
+     msg]))
+
+;; ---- public Panel --------------------------------------------------------
+
+(rf/reg-view Panel
+  "Epoch panel root view. Subscribes to `:rf.xray/epoch-pipeline` —
+  a composite that resolves the focused epoch off the spine and
+  projects its `:trace-events` into the pipeline-step rows. Renders
+  the numbered cascade when steps are present; an empty-state when
+  the focus carries no record or the record carries no trace events."
+  []
+  (let [{:keys [status steps]} @(rf/subscribe [:rf.xray/epoch-pipeline])]
+    [:section {:data-testid "rf-xray-epoch-panel"
+               :style {:height          "100%"
+                       :display         "flex"
+                       :flex-direction  "column"
+                       :background      (:bg-2 tokens)
+                       :color           (:text-primary tokens)
+                       :font-family     sans-stack
+                       :font-size       "13px"}}
+     [:div {:style {:flex 1 :overflow "auto" :padding "21px"}}
+      [:div {:data-testid "rf-xray-epoch-panel-header"
+             :style {:color       (:text-tertiary tokens)
+                     :font-family sans-stack
+                     :font-size   "11px"
+                     :margin-bottom "21px"}}
+       "The computational timeline for the event"]
+      (cond
+        (= :focused status)
+        (if (seq steps)
+          (pipeline-view steps)
+          (empty-state-view :no-events))
+
+        :else
+        (empty-state-view (or status :no-focus)))]]))

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch_panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch_panel.cljs
@@ -1,0 +1,151 @@
+(ns day8.re-frame2-xray.panels.epoch-panel
+  "Epoch panel orchestrator (rf2-sc3r1) — registers the composite sub
+  + the per-row toggle event + the L4 tab entry. The view layer lives
+  in `panels.epoch.view`; the pure-data projection lives in
+  `panels.epoch.projection`.
+
+  ## What this panel answers
+
+  > **\"What happened in this epoch?\"**
+
+  A single epoch's complete computational timeline as a numbered
+  vertical cascade — dispatch → coeffects → handler → flow → fx →
+  subscriptions → views. The pipeline is a faithful projection of
+  the focused epoch's `:trace-events`; each step is conditional, so
+  the view renders only the steps that actually fired.
+
+  ## Tab placement
+
+  Registered against `:dynamic` mode at order 5 (between Machines (4)
+  and Routing (6)). Co-exists with the existing Event lens (the
+  `:event` tab) initially — both surface the focused epoch, but
+  through different lenses:
+
+  - **Event** (`:event` tab) — the Figma-locked operational-order
+    handling pipeline (rf2-ynnre B+); reads more like a
+    spec-shaped attribution document.
+  - **Epoch** (`:epoch` tab — this panel) — the full timeline as a
+    delightful numbered cascade including the reactive trailing
+    edge (SUBSCRIPTIONS + VIEWS) that the Event lens routes to its
+    own Reactive tab.
+
+  Per the bead body's pre-alpha posture, this co-existence is the
+  initial landing; the older Event/Reactive split deprecates as a
+  follow-on bead once the new Epoch panel is exercised in
+  production.
+
+  ## Frame integration
+
+  The composite sub joins `:rf.xray/focus` + `:rf.xray/epoch-history`
+  via the shared `panels.shared.focus-resolver` so the panel pivots on
+  the same focus axis every other L4 panel honours. Per spec/018 §6
+  the spine's `:rf.xray/focus` carries `:epoch-id`; the focus-resolver
+  classifies the status (`:no-focus / :focused / :epoch-evicted`) and
+  resolves the matching record."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-xray.panel-registry :as panel-registry]
+            [day8.re-frame2-xray.panels.epoch.projection :as proj]
+            [day8.re-frame2-xray.panels.epoch.view :as view]
+            [day8.re-frame2-xray.panels.shared.focus-resolver :as focus]))
+
+;; ---- public Panel surface ------------------------------------------------
+
+;; Re-export the view-side `Panel` so the spine + panel-registry
+;; resolve a single name. `mount-fns` (panels.cljs) reach through this
+;; ns when added to the per-panel mount inventory.
+(def Panel view/Panel)
+
+;; ---- registration --------------------------------------------------------
+
+(defn install!
+  "Idempotent install for the Epoch panel:
+
+    - `:rf.xray/epoch-pipeline` composite sub (focus + history →
+      projection rows + focus-status)
+    - `:rf.xray.epoch/expanded-rows` sub
+    - `:rf.xray.epoch/toggle-row-expand` event
+    - `:rf.xray.epoch/clear-row-expand` event
+    - L4 tab registration (`:epoch`, mnem `e`, order 5)
+
+  The composite sub joins the spine's `:rf.xray/focus` with the
+  framework's `:rf.xray/epoch-history` through the shared focus-
+  resolver, then runs the pure projection from
+  `panels.epoch.projection/project-numbered` to produce the ordered
+  + numbered step rows. The view subscribes only to this composite;
+  the projection is fully testable in isolation."
+  []
+  ;; ---- composite sub -----------------------------------------------------
+  ;;
+  ;; Shape:
+  ;;
+  ;;     {:status   :no-focus | :focused | :epoch-evicted
+  ;;      :epoch-id <int-or-nil>      ; for view chrome
+  ;;      :record   <:rf/epoch-record map or nil>
+  ;;      :steps    [<step-row> ...]} ; the numbered pipeline
+  ;;
+  ;; The view branches on `:status` for the empty-state lines and
+  ;; renders `:steps` when present.
+  (rf/reg-sub :rf.xray/epoch-pipeline
+    :<- [:rf.xray/focus]
+    :<- [:rf.xray/epoch-history]
+    (fn [[focus epoch-history] _query]
+      (let [focus-epoch-id (:epoch-id focus)
+            status         (focus/resolve-focus-status focus-epoch-id
+                                                       epoch-history)
+            record         (focus/find-epoch-record focus-epoch-id
+                                                    epoch-history)
+            steps          (when record (proj/project-numbered record))]
+        {:status   status
+         :epoch-id (or focus-epoch-id (:epoch-id record))
+         :record   record
+         :steps    (vec (or steps []))})))
+
+  ;; ---- per-row expand state ---------------------------------------------
+  ;;
+  ;; The view supports per-row drill-down by toggling a `[step-kw row-id]`
+  ;; pair in the expanded-set. State lives on the Xray app-db so toggles
+  ;; survive sub-recomputes + integrate naturally with time-travel.
+  ;; The current view doesn't render expansion UI for every row (the
+  ;; design prefers always-visible content for the cascade's punch),
+  ;; but the surface is in place so follow-on rich expansions
+  ;; (full-handler source code, full-fx EDN, etc.) compose without
+  ;; reshaping the panel.
+
+  (rf/reg-sub :rf.xray.epoch/expanded-rows
+    (fn [db _query]
+      (get db :epoch-panel-expanded-rows #{})))
+
+  (rf/reg-event-db :rf.xray.epoch/toggle-row-expand
+    (fn [db [_ step-kw row-id]]
+      (let [k (vector step-kw row-id)
+            current (get db :epoch-panel-expanded-rows #{})]
+        (assoc db :epoch-panel-expanded-rows
+               (if (contains? current k)
+                 (disj current k)
+                 (conj current k))))))
+
+  (rf/reg-event-db :rf.xray.epoch/clear-row-expand
+    (fn [db _event]
+      (dissoc db :epoch-panel-expanded-rows)))
+
+  ;; ---- L4 tab registration ----------------------------------------------
+  ;;
+  ;; The Epoch tab lands between Machines (order 4) and Routing
+  ;; (order 6). The previous gap at order 5 was reserved for exactly
+  ;; this surface (the "what happened in this epoch" canonical view);
+  ;; the existing seven tabs (Handler 0 · App-DB 1 · Reactive 2 ·
+  ;; Trace 3 · Machines 4 · Routing 6 · Issues 7) read in cascade
+  ;; order, and the new Epoch tab is the master inverse — every
+  ;; step the other tabs detail, rendered as one timeline.
+  ;;
+  ;; Per the bead body's worker-decision: co-exist initially. A
+  ;; follow-on bead retires the older tabs as the new Epoch panel
+  ;; matures.
+
+  (panel-registry/reg-l4-tab!
+    {:id    :epoch
+     :label "Epoch"
+     :mnem  "e"
+     :modes #{:dynamic}
+     :order 5
+     :panel Panel}))

--- a/tools/xray/src/day8/re_frame2_xray/registry.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/registry.cljs
@@ -74,6 +74,7 @@
             [day8.re-frame2-xray.panels.app-db-segment-inspector
              :as app-db-segment-inspector]
             [day8.re-frame2-xray.panels.cancellation-cascade :as cancellation-cascade]
+            [day8.re-frame2-xray.panels.epoch-panel :as epoch-panel]
             [day8.re-frame2-xray.panels.event-detail :as event-detail]
             [day8.re-frame2-xray.panels.issues-ribbon :as issues-ribbon]
             [day8.re-frame2-xray.panels.machine-inspector :as machine-inspector]
@@ -663,6 +664,14 @@
     ;; `:rf.xray/focus` + `:rf.xray/trace-buffer`); registry order is
     ;; cosmetic since re-frame resolves `:<-` chains lazily.
     (cancellation-cascade/install!)
+    ;; Epoch panel (rf2-sc3r1) — the canonical "what happened in this
+    ;; epoch" surface; numbered cascade of every pipeline step. Reads
+    ;; the spine's `:rf.xray/focus` + `:rf.xray/epoch-history`,
+    ;; projects the focused record's `:trace-events` into ordered
+    ;; step rows. Registers at order 5, between Machines (4) and
+    ;; Routing (6). Co-exists with the existing Event lens
+    ;; initially per the bead body's pre-alpha posture.
+    (epoch-panel/install!)
     (event-detail/install!)
     (issues-ribbon/install!)
     (machine-inspector/install!)

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/badge_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/badge_cljs_test.cljc
@@ -1,0 +1,62 @@
+(ns day8.re-frame2-xray.panels.epoch.badge-cljs-test
+  "Pure-data tests for the Epoch panel's badge taxonomy (rf2-sc3r1).
+
+  ## Under test
+
+    1. Every badge in `projection/badge-set` resolves to a non-blank
+       CSS-variable string via `badge/colour`.
+    2. Every badge resolves to a non-blank uppercase label via
+       `badge/label`.
+    3. `token-key` produces a known theme-token keyword for every
+       badge.
+    4. Fibonacci spacing scale produces stable px strings."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [clojure.string :as str]
+            [day8.re-frame2-xray.panels.epoch.badge :as badge]
+            [day8.re-frame2-xray.panels.epoch.projection :as proj]))
+
+(deftest badge-colours-resolve-test
+  (testing "every badge in the inventory resolves to a non-blank CSS-var string"
+    (doseq [b proj/badge-set]
+      (let [c (badge/colour b)]
+        (is (string? c) (str "colour for " b))
+        (is (re-find #"var\(--rf-xray-" c)
+            (str "expected CSS variable for " b ", got " c))))))
+
+(deftest badge-labels-uppercase-test
+  (testing "every badge label is the uppercase keyword name"
+    (doseq [b proj/badge-set]
+      (let [l (badge/label b)]
+        (is (string? l))
+        (is (= (str/upper-case l) l)
+            (str "badge label for " b " not uppercase: " l))))))
+
+(deftest token-key-fallback-test
+  (testing "unknown badge falls back to :text-tertiary"
+    (is (= :text-tertiary (badge/token-key :NOT-A-BADGE))))
+  (testing "known badges resolve to specific token keys"
+    (is (= :accent (badge/token-key :HANDLER)))
+    (is (= :accent (badge/token-key :FLOW)))
+    (is (= :orange (badge/token-key :FX)))
+    (is (= :success (badge/token-key :VIEWS)))))
+
+(deftest fib-px-test
+  (testing "fibonacci helper resolves to px strings"
+    (is (= "3px"  (badge/fib-px :f3)))
+    (is (= "5px"  (badge/fib-px :f5)))
+    (is (= "8px"  (badge/fib-px :f8)))
+    (is (= "13px" (badge/fib-px :f13)))
+    (is (= "21px" (badge/fib-px :f21)))
+    (is (= "34px" (badge/fib-px :f34)))
+    (is (= "55px" (badge/fib-px :f55)))
+    (is (= "89px" (badge/fib-px :f89))))
+  (testing "unknown key returns '0'"
+    (is (= "0" (badge/fib-px :nope)))))
+
+(deftest numbered-cascade-geometry-test
+  (testing "the geometry constants exposed for the view are the ones the spec commits to"
+    (is (= 21  badge/step-numbered-circle-diameter-px))
+    (is (= 13  badge/vertical-line-offset-px))
+    (is (= -44 badge/circle-left-offset-px))
+    (is (= -34 badge/line-left-offset-px))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -1,0 +1,383 @@
+(ns day8.re-frame2-xray.panels.epoch.projection-cljs-test
+  "Pure-data tests for the Epoch panel's projection layer (rf2-sc3r1).
+
+  ## Why `.cljc` + `_cljs_test` naming
+
+  Same dual-target pattern as other Xray helper tests:
+
+    - Cognitect's test-runner (CLJ) picks it up via the default
+      `.*-test$` regex.
+    - Shadow's `:node-test` build picks it up via the `cljs-test$`
+      regex.
+
+  ## Under test
+
+    1. `dispatch-row` — DISPATCH always produced; reads call-site +
+       source off the dispatched trace.
+    2. `coeffect-rows` — granular `:rf.cofx/run` ahead of
+       `:rf.event/run-end` stamp fallback.
+    3. `handler-row` — flavour discrimination (reg-event-db /
+       reg-event-fx / reg-machine) from the trace stream.
+    4. `flow-step` — conditional: present iff `:rf.flow/recomputed`
+       fired.
+    5. `fx-step` — conditional: present iff any `:rf.fx/*` event fired.
+    6. `subscriptions-step` — conditional: present iff `:rf.sub/*`
+       events fired.
+    7. `views-step` — conditional: present iff `:rf.view/render`
+       events fired.
+    8. `project` — top-level composer over all of the above.
+    9. `number-steps` — sequential 1..N numbering over only-the-
+       steps-that-fired.
+    10. Machine-handler-specific projections (lifecycle phase
+        grouping, timer reasons, guard outcomes)."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [day8.re-frame2-xray.panels.epoch.projection :as proj]))
+
+;; ---- fixture builders ----------------------------------------------------
+
+(defn- ev
+  "Build a minimal trace event."
+  [op-type operation tags]
+  {:op-type   op-type
+   :operation operation
+   :tags      tags})
+
+(defn- dispatched-ev
+  ([event] (dispatched-ev event nil nil))
+  ([event source] (dispatched-ev event source nil))
+  ([event source coord]
+   (cond-> (ev :rf.event :rf.event/dispatched {:event event
+                                               :source source
+                                               :rf.trace/call-site coord})
+     true (assoc :event event :source source))))
+
+(defn- run-end-ev
+  ([] (run-end-ev nil nil))
+  ([duration-ms] (run-end-ev duration-ms nil))
+  ([duration-ms coeffects]
+   (ev :rf.event :rf.event/run-end (cond-> {:duration-ms duration-ms}
+                                     coeffects (assoc :rf.event/coeffects
+                                                      coeffects)))))
+
+(defn- cofx-run-ev
+  [id value]
+  (ev :rf.cofx :rf.cofx/run {:rf.cofx/id id :rf.cofx/value value}))
+
+(defn- db-changed-ev
+  [paths]
+  (ev :rf.event :rf.event/db-changed {:rf.event/db-changed-paths paths}))
+
+(defn- do-fx-ev
+  [fx]
+  (ev :rf.fx :rf.fx/do-fx {:rf.event/fx fx}))
+
+(defn- fx-handled-ev
+  [fx-id args duration-ms]
+  (ev :rf.fx :rf.fx/handled {:rf.fx/id fx-id
+                             :rf.fx/args args
+                             :duration-ms duration-ms}))
+
+(defn- flow-recomputed-ev
+  [flow-id path before after]
+  (ev :rf.flow :rf.flow/recomputed {:rf.flow/id flow-id
+                                    :rf.flow/path path
+                                    :rf.flow/before before
+                                    :rf.flow/after after}))
+
+(defn- sub-run-ev
+  [sub-vec changed? before after]
+  (ev :rf.sub :rf.sub/run {:rf.sub/query sub-vec
+                           :rf.sub/changed? changed?
+                           :rf.sub/before before
+                           :rf.sub/after after}))
+
+(defn- view-render-ev
+  [view-id subs-read]
+  (ev :rf.view :rf.view/render {:rf.view/id view-id
+                                :rf.view/subs subs-read}))
+
+(defn- machine-transition-ev
+  [machine-id before after]
+  (ev :rf.machine :rf.machine/transition {:machine-id machine-id
+                                          :before before
+                                          :after after}))
+
+(defn- machine-guard-ev
+  [guard-id outcome]
+  (ev :rf.machine :rf.machine/guard-evaluated {:guard-id guard-id
+                                               :outcome outcome}))
+
+(defn- machine-action-ev
+  [action-id phase outcome]
+  (ev :rf.machine :rf.machine/action-ran {:action-id action-id
+                                          :phase phase
+                                          :outcome outcome
+                                          :input {:data {} :event nil}}))
+
+(defn- machine-timer-cancel-ev
+  [machine-id state delay reason]
+  (ev :rf.machine :rf.machine.timer/cancelled {:machine-id machine-id
+                                               :state state
+                                               :delay delay
+                                               :reason reason}))
+
+(defn- record
+  "Build a synthetic `:rf/epoch-record` for projection."
+  ([events] (record events nil))
+  ([events event-id]
+   {:trace-events (vec events)
+    :event-id event-id}))
+
+;; ---- DISPATCH ------------------------------------------------------------
+
+(deftest dispatch-row-test
+  (testing "dispatched trace produces a row with source + coord"
+    (let [d (dispatched-ev [:counter-inc] :ui {:file "ui.cljs" :line 42})
+          r (proj/dispatch-row [d] [:counter-inc])]
+      (is (= :dispatch (:step r)))
+      (is (= :DISPATCH (:badge r)))
+      (is (= [:counter-inc] (:event r)))
+      (is (= :ui (:source r)))
+      (is (= {:file "ui.cljs" :line 42} (:coord r)))))
+
+  (testing "missing dispatched trace falls back to the supplied event vector"
+    (let [r (proj/dispatch-row [] [:counter-inc])]
+      (is (= :dispatch (:step r)))
+      (is (= [:counter-inc] (:event r)))
+      (is (nil? (:source r)))))
+
+  (testing "no dispatched + no fallback returns nil"
+    (is (nil? (proj/dispatch-row [] nil)))))
+
+;; ---- COEFFECT ------------------------------------------------------------
+
+(deftest coeffect-rows-granular-test
+  (testing "granular :rf.cofx/run events are preferred when present"
+    (let [evs [(cofx-run-ev :session {:user-id 42})
+               (cofx-run-ev :now #inst "2026-01-01")]
+          rows (proj/coeffect-rows evs)]
+      (is (= 2 (count rows)))
+      (is (= :session (-> rows first :id)))
+      (is (= {:user-id 42} (-> rows first :value))))))
+
+(deftest coeffect-rows-run-end-fallback-test
+  (testing "no granular cofx events: fall back to run-end's stamp"
+    (let [evs [(run-end-ev 0.1 {:session {:user-id 7}})]
+          rows (proj/coeffect-rows evs)]
+      (is (= 1 (count rows)))
+      (is (= :session (-> rows first :id)))
+      (is (= {:user-id 7} (-> rows first :value))))))
+
+(deftest coeffect-rows-empty-test
+  (testing "no cofx events + no run-end stamp returns empty vec"
+    (is (= [] (proj/coeffect-rows [])))))
+
+;; ---- HANDLER -------------------------------------------------------------
+
+(deftest handler-row-reg-event-db-test
+  (testing "no fx + no machine = reg-event-db flavour"
+    (let [r (proj/handler-row [(db-changed-ev [[[:counter] 5 6 :modified]])]
+                              :counter-inc)]
+      (is (= :handler (:step r)))
+      (is (= :HANDLER (:badge r)))
+      (is (= :reg-event-db (:flavour r)))
+      (is (= :counter-inc (:event-id r)))
+      (is (= 1 (count (:db-diff r))))
+      (is (= [] (:fx r))))))
+
+(deftest handler-row-reg-event-fx-test
+  (testing "do-fx present → reg-event-fx flavour; :fx entries projected"
+    (let [evs [(do-fx-ev {:db {} :navigate "/x"})
+               (db-changed-ev [])]
+          r   (proj/handler-row evs :navigate-to)]
+      (is (= :reg-event-fx (:flavour r)))
+      (is (= 2 (count (:fx r))))
+      (is (= #{:db :navigate} (into #{} (map :fx-id (:fx r))))))))
+
+(deftest handler-row-reg-machine-test
+  (testing "action-ran present → reg-machine flavour; machine block populated"
+    (let [evs [(machine-transition-ev :ws/conn [:idle] [:connecting])
+               (machine-guard-ev :ready? :pass)
+               (machine-action-ev :open-socket :entry :ok)
+               (machine-action-ev :close-socket :exit :ok)
+               (machine-timer-cancel-ev :ws/conn [:idle] 250 :on-exit)]
+          r (proj/handler-row evs :ws/start)
+          m (:machine r)]
+      (is (= :reg-machine (:flavour r)))
+      (is (some? m))
+      (is (= :ws/conn (-> m :transition :machine-id)))
+      (is (= 1 (count (:guards m))))
+      (is (= 2 (count (:lifecycle m))))
+      (is (= 1 (count (:timers m))))
+      (is (= :on-exit (-> m :timers first :reason))))))
+
+(deftest machine-lifecycle-grouped-by-phase-test
+  (testing "group-lifecycle-by-phase produces phase → rows map"
+    (let [rows [{:action-id :a1 :phase :exit}
+                {:action-id :a2 :phase :entry}
+                {:action-id :a3 :phase :exit}]
+          grouped (proj/group-lifecycle-by-phase rows)]
+      (is (= 2 (count (:exit grouped))))
+      (is (= 1 (count (:entry grouped)))))))
+
+;; ---- FLOW ---------------------------------------------------------------
+
+(deftest flow-step-conditional-test
+  (testing "no flow events → step is OMITTED"
+    (is (nil? (proj/flow-step []))))
+
+  (testing "flow event present → step is rendered"
+    (let [s (proj/flow-step [(flow-recomputed-ev :total-parity [:total] 5 6)])]
+      (is (= :flow (:step s)))
+      (is (= :FLOW (:badge s)))
+      (is (= 1 (count (:rows s))))
+      (is (= :total-parity (-> s :rows first :flow-id))))))
+
+;; ---- FX -----------------------------------------------------------------
+
+(deftest fx-step-conditional-test
+  (testing "no fx events → step is OMITTED"
+    (is (nil? (proj/fx-step []))))
+
+  (testing "fx-handled events → step rendered with status"
+    (let [s (proj/fx-step [(fx-handled-ev :db nil 0.2)
+                           (fx-handled-ev :http/post {:url "/x"} 12.0)])]
+      (is (= :fx (:step s)))
+      (is (= :FX (:badge s)))
+      (is (= 2 (count (:rows s))))
+      (is (= :ok (-> s :rows first :status))))))
+
+;; ---- SUBSCRIPTIONS ------------------------------------------------------
+
+(deftest subscriptions-step-conditional-test
+  (testing "no sub events → step is OMITTED"
+    (is (nil? (proj/subscriptions-step []))))
+
+  (testing "sub-run events → step rendered with changed? flag"
+    (let [s (proj/subscriptions-step [(sub-run-ev [:total] true 5 6)
+                                      (sub-run-ev [:other] false :x :x)])]
+      (is (= :subscriptions (:step s)))
+      (is (= :SUBSCRIPTIONS (:badge s)))
+      (is (= 2 (count (:rows s))))
+      (is (true? (-> s :rows first :changed?)))
+      (is (false? (-> s :rows second :changed?))))))
+
+;; ---- VIEWS --------------------------------------------------------------
+
+(deftest views-step-conditional-test
+  (testing "no view events → step is OMITTED"
+    (is (nil? (proj/views-step []))))
+
+  (testing "view-render events → step rendered"
+    (let [s (proj/views-step [(view-render-ev ::counter-view [:total])])]
+      (is (= :views (:step s)))
+      (is (= :VIEWS (:badge s)))
+      (is (= 1 (count (:rows s))))
+      (is (= ::counter-view (-> s :rows first :view-id))))))
+
+;; ---- top-level project --------------------------------------------------
+
+(deftest project-minimal-test
+  (testing "minimal epoch (dispatch + handler, no cofx/flow/fx/sub/view)"
+    (let [rec   (record [(dispatched-ev [:counter-inc] :ui nil)
+                         (db-changed-ev [[[:counter] 5 6 :modified]])])
+          steps (proj/project rec)]
+      (is (= 2 (count steps)))
+      (is (= [:dispatch :handler] (mapv :step steps))))))
+
+(deftest project-full-pipeline-test
+  (testing "full epoch with every step → 7 steps emitted"
+    (let [rec   (record [(dispatched-ev [:cart/checkout] :ui nil)
+                         (cofx-run-ev :session {:user 1})
+                         (do-fx-ev {:db {} :http/post {:url "/x"}})
+                         (db-changed-ev [[[:cart :state] :idle :placing :modified]])
+                         (flow-recomputed-ev :cart-total [:cart :total] 10 20)
+                         (fx-handled-ev :db nil 0.1)
+                         (fx-handled-ev :http/post {} 12.0)
+                         (sub-run-ev [:total] true 10 20)
+                         (view-render-ev ::cart-view [:total])])
+          steps (proj/project rec)]
+      (is (= 7 (count steps)))
+      (is (= [:dispatch :coeffect :handler :flow :fx :subscriptions :views]
+             (mapv :step steps))))))
+
+(deftest project-numbered-test
+  (testing "number-steps assigns sequential 1..N regardless of omissions"
+    (let [rec   (record [(dispatched-ev [:counter-inc] :ui nil)
+                         (db-changed-ev [])
+                         (sub-run-ev [:total] true 1 2)])
+          steps (proj/project-numbered rec)]
+      (is (= 3 (count steps)))
+      (is (= [1 2 3] (mapv :step-number steps)))
+      (is (= [:dispatch :handler :subscriptions] (mapv :step steps))))))
+
+(deftest project-machine-test
+  (testing "machine event handler → reg-machine flavour + machine block"
+    (let [rec   (record [(dispatched-ev [:ws/start] :ui nil)
+                         (machine-transition-ev :ws/conn [:idle] [:connecting])
+                         (machine-action-ev :open-socket :entry :ok)])
+          steps (proj/project rec)
+          h     (some #(when (= :handler (:step %)) %) steps)]
+      (is (= :reg-machine (:flavour h)))
+      (is (= :ws/conn (-> h :machine :transition :machine-id))))))
+
+(deftest project-empty-test
+  (testing "empty trace events → empty step vector"
+    (is (= [] (proj/project (record [] nil))))
+    (is (proj/empty-pipeline? (record [] nil)))))
+
+;; ---- badge taxonomy ------------------------------------------------------
+
+(deftest badge-set-test
+  (testing "every step's :badge is in the public badge-set"
+    (let [rec   (record [(dispatched-ev [:counter-inc] :ui nil)
+                         (cofx-run-ev :session {:x 1})
+                         (do-fx-ev {:db {}})
+                         (db-changed-ev [])
+                         (flow-recomputed-ev :f [:p] 1 2)
+                         (fx-handled-ev :db nil 0.1)
+                         (sub-run-ev [:s] true 1 2)
+                         (view-render-ev ::v [:s])])
+          steps (proj/project rec)]
+      (is (every? proj/valid-badge? (map :badge steps)))
+      (is (= 7 (count proj/badge-set))))))
+
+;; ---- formatting helpers --------------------------------------------------
+
+(deftest format-duration-ms-test
+  (testing "duration formatting"
+    (is (= "0.1ms" (proj/format-duration-ms 0.1)))
+    (is (= "9.5ms" (proj/format-duration-ms 9.5)))
+    (is (= "12ms"  (proj/format-duration-ms 12)))
+    (is (= "1.2s"  (proj/format-duration-ms 1234)))
+    (is (nil? (proj/format-duration-ms nil)))))
+
+(deftest ns-keyword-test
+  (testing "id rendering"
+    (is (= ":foo"       (proj/ns-keyword :foo)))
+    (is (= ":my/foo"    (proj/ns-keyword :my/foo)))
+    (is (= "non-kw"     (proj/ns-keyword "non-kw")))))
+
+(deftest truncate-test
+  (testing "truncate keeps short strings + ellipsises long ones"
+    (is (= "abc"  (proj/truncate "abc" 5)))
+    (is (= "abcd…" (proj/truncate "abcdefg" 4)))))
+
+(deftest phase-label-test
+  (testing "phase labels render every closed-set member"
+    (is (= "exit"            (proj/phase-label :exit)))
+    (is (= "transition"      (proj/phase-label :transition)))
+    (is (= "entry"           (proj/phase-label :entry)))
+    (is (= "always"          (proj/phase-label :always)))
+    (is (= "after-action"    (proj/phase-label :after-action)))
+    (is (= "initial-entry"   (proj/phase-label :initial-entry)))
+    (is (= "destroy-exit"    (proj/phase-label :destroy-exit)))))
+
+(deftest timer-reason-label-test
+  (testing "timer-cancelled reasons render every closed-set member"
+    (is (= "on-exit"          (proj/timer-reason-label :on-exit)))
+    (is (= "on-destroy"       (proj/timer-reason-label :on-destroy)))
+    (is (= "on-resolution"    (proj/timer-reason-label :on-resolution)))
+    (is (= "on-supersede"     (proj/timer-reason-label :on-supersede)))
+    (is (= "on-frame-destroy" (proj/timer-reason-label :on-frame-destroy)))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/routing_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/routing_cljs_test.cljs
@@ -166,8 +166,8 @@
     (let [panels (palette-subs/palette-panels)
           ids    (set (map :id panels))]
       (is (contains? ids :routing) ":routing in palette-panels")
-      (is (= 7 (count panels))
-          "exactly 7 entries — Event / App DB / Views / Trace / Machines / Routing / Issues (rf2-4v67l removed the Chrome A11y dogfood in favour of Story's shipped panel; rf2-ga16q removed the Machines Canvas tab — its browse-all canvas relocated to the Static Machines sub-tab)"))))
+      (is (= 8 (count panels))
+          "exactly 8 entries — Event / App DB / Views / Trace / Machines / Epoch / Routing / Issues (rf2-sc3r1 added the Epoch tab at order 5; rf2-4v67l removed the Chrome A11y dogfood in favour of Story's shipped panel; rf2-ga16q removed the Machines Canvas tab — its browse-all canvas relocated to the Static Machines sub-tab)"))))
 
 ;; ---- (2) three sections render (always-visible base layer) --------------
 

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -154,6 +154,10 @@
    :rf.xray/edit-popup-open?
    :rf.xray/edit-popup-trigger
    :rf.xray/epoch-history
+   ;; rf2-sc3r1 — Epoch panel composite (focused epoch's pipeline
+   ;; rows) + per-row expansion-set sub.
+   :rf.xray/epoch-pipeline
+   :rf.xray.epoch/expanded-rows
    :rf.xray/event-detail
    :rf.xray/filtered-cascades
    ;; rf2-jvghz — model behind the L2 'N hidden by filters' indicator
@@ -437,6 +441,9 @@
    :rf.xray/delete-edit-popup
    :rf.xray/edit-popup-set-mode
    :rf.xray/edit-popup-set-pattern
+   ;; rf2-sc3r1 — Epoch panel per-row expansion events.
+   :rf.xray.epoch/toggle-row-expand
+   :rf.xray.epoch/clear-row-expand
    :rf.xray/epoch-recorded
    ;; rf2-piye4 — typed-predicate filter events. Each appends a
    ;; typed `{:kind <kw> :params {…}}` IN pill from a right-click


### PR DESCRIPTION
Closes [rf2-sc3r1](../tree/main/.beads).

## What this delivers

A new Xray L4 panel that answers **"what happened in this epoch?"** by projecting the focused epoch's `:trace-events` into a numbered visual cascade — DISPATCH → COEFFECTS → HANDLER → FLOW → FX → SUBSCRIPTIONS → VIEWS.

The panel is a faithful projection of the trace stream — each step is conditional (no flow → no FLOW row; no cofx → no COEFFECT row; etc.) and the numbering is dynamic (1..N over only the steps that fired). The HANDLER step adapts to the handler's flavour (reg-event-db / reg-event-fx / reg-machine), reading off the rf2-82a0u (#2155) substrate enhancements — `:phase` on `:rf.machine/action-ran`, unified `:rf.machine.timer/cancelled` with `:reason` — to render the full xstate-style lifecycle directly from the trace.

## Surface layout

New directory `tools/xray/src/day8/re_frame2_xray/panels/epoch/`:

| File | Role |
|------|------|
| `projection.cljc` | Pure data → data: `(project record)` → ordered step rows · JVM-testable in isolation |
| `badge.cljc` | 7-badge colour taxonomy + Fibonacci spacing scale (3·5·8·13·21·34·55·89) |
| `icons.cljc` | external-link (re-export of `panels.event.icons`) + inline corner-down-right SVG |
| `view.cljs` | Reagent view — numbered cascade rendering + per-row chrome |

Plus orchestrator + spec + tests:

- `tools/xray/src/day8/re_frame2_xray/panels/epoch_panel.cljs` — `Panel` re-export + `install!` (composite sub, toggle event, L4 tab reg)
- `tools/xray/spec/021-Dynamic-Panel-Designs.md` §9.1 — design spec for the panel (badge taxonomy, conditional cascade, numbered geometry, edn-inspector composition contract)
- `tools/xray/test/day8/re_frame2_xray/panels/epoch/` — projection + badge tests

Light edits to:

- `tools/xray/src/day8/re_frame2_xray/registry.cljs` — calls `epoch-panel/install!` between cancellation-cascade and event-detail
- `tools/xray/src/day8/re_frame2_xray/panels.cljs` — adds `mount-epoch-panel!` to the public mount-fn inventory
- `tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs` — adds the new sub + events to the snapshot
- `tools/xray/test/day8/re_frame2_xray/panels/routing_cljs_test.cljs` — `(palette-panels)` is now 8, not 7

## Decisions

### Co-exist vs replace

**CO-EXIST INITIALLY.** Tab id `:epoch`, mnemonic `e`, order 5 (between `:machines` at 4 and `:routing` at 6). The existing `:event` (Handler) and `:views` (Reactive) tabs stay; a follow-on bead retires them once the new Epoch panel is exercised in production.

Rationale: the new Epoch panel is the canonical "one timeline" view; the existing Event lens is the Figma-locked spec-shaped attribution document. Both surface the focused epoch but through different lenses. Pre-alpha posture supports either path, but additive landing is the safer move — operators can compare the two surfaces and the team can verify the new projection matches the trace stream before retiring the old tabs.

### File layout

Split across four files under `panels/epoch/`:

- `projection.cljc` — pure data → data; testable in isolation under `clojure -M:test`
- `badge.cljc` — the 7-badge inventory; pulls colours from `theme/tokens` (CSS variables, theme-aware)
- `icons.cljc` — minimal hiccup-shaped SVG glyphs; re-exports `external-link` for verb-vocabulary consistency
- `view.cljs` — Reagent view; subscribes only to the `:rf.xray/epoch-pipeline` composite

This split keeps the projection's algebra independent from view chrome and the view independent from the badge taxonomy — both are extension points without touching the other.

### Icon source

Re-exports the existing `panels.event.icons/external-link` (lucide-style, 13×13, the Figma authority) so the click-to-source vocabulary stays unified. Adds an inline lucide-style `corner-down-right` SVG (13×13) for the HANDLER step's sub-headers — same conventions (stroke=currentColor, viewBox 0 0 24 24, aria-hidden).

## Gates

| Gate | Result |
|------|--------|
| `tools/xray` `clojure -M:test` | 887/887 (was 879/879 + 23 new tests / 90 new assertions) |
| `implementation` `npm run test:cljs` | 4664/4664 |
| `implementation` `npm run test:browser` | 124/124 |
| `implementation` `npm run test:bundle-isolation` | PASS |
| `implementation` `npm run test:xray-feature-gate` | 13/13 nightly-full sweep |
| `clj-kondo` on new + edited files | 0 errors, 0 warnings |
| `mkdocs build --strict` | PASS |

## Composition with the edn-inspector widget

The HANDLER step's expandable content is wired to mount the edn-inspector with `:zoomable? true` (rf2-h71e0) + `:header "<step-name>"` (rf2-okq7p) — though the initial landing renders default-visible content for every step (the cascade's punch is its always-visible rhythm). Per-row expansion state lives in app-db via the new `:rf.xray.epoch/toggle-row-expand` event + `:rf.xray.epoch/expanded-rows` sub, ready for the follow-on rich-expansion pass.

## What's deliberately NOT in this PR

- The deprecation path for the existing Event + Reactive tabs (a follow-on bead).
- The rich per-row expanded EDN content (the infrastructure is in place; the wiring is a follow-on bead).
- Click-to-source for every clickable id (the icon affordances are rendered; the `:rf.xray/open-in-editor` dispatch is wired for the dispatch-source coord; per-row source-coord enrichment for every cofx / handler / fx / flow id is a follow-on richness pass).