### PR TITLE
fix(xray): edn-inspector diff renders removed-from-collection items (rf2-zuh1e)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
@@ -1049,6 +1049,149 @@
 (defn- container? [kind]
   (contains? #{:map :vector :list :set :seq :map-entry :record} kind))
 
+(defn children-of-pair
+  "Diff-aware children walk — return a seq of `[child-key after-value
+  before-value]` triples covering the UNION of `before` + `after` so
+  removed children (present in BEFORE, absent from AFTER) are visible
+  to the diff renderer (rf2-zuh1e).
+
+  Slots that don't exist in their side carry `::missing` (the same
+  `missing-sentinel` `diff-op` consumes), so the recursive renderer
+  routes through `render-leaf-with-diff`'s `:added` / `:removed` paths
+  unchanged.
+
+  Per collection kind:
+  - **Map / record** — AFTER's keys in their natural order, then
+    BEFORE-only keys appended at the end. Appended-at-end was picked
+    over interleaved-at-original-position because CLJS hash-maps don't
+    carry stable order across boundaries anyway (array-map vs hash-
+    map crossover, `dissoc` rehashing); appended-at-end is simple,
+    predictable, and reads as 'the post-image, then a deletions
+    section' in the rendered tree (rf2-zuh1e decision).
+  - **Vector / list / seq** — index-align up to the longer side's
+    count; trailing BEFORE-only positions render as `:removed`.
+  - **Set** — UNION of members, sorted by `pr-str` for stable render
+    (sets have no natural ordering).
+  - **Map-entry** — fixed two positions `[0 k] [1 v]`, with AFTER /
+    BEFORE per-side values.
+
+  When the BEFORE side's collection kind does not match AFTER's (e.g.
+  AFTER is a map, BEFORE is a vector), the function falls back to
+  AFTER's children only — the parent row's `:modified` classification
+  carries the structural-change signal and `← changed from <prior>`
+  renders the BEFORE side via `render-scalar`.
+
+  Returns `nil` when `kind` is not a container kind.
+
+  Public so tests + downstream renderers can probe the union without
+  re-deriving the walk."
+  [before after kind]
+  (case kind
+    (:map :record)
+    (let [a (when (map? after) after)
+          b (when (map? before) before)]
+      (cond
+        ;; Both maps: union of keys, AFTER-order then BEFORE-only.
+        (and a b)
+        (let [a-keys (vec (keys a))
+              a-key-set (set a-keys)
+              extra-keys (remove a-key-set (keys b))]
+          (concat
+            (for [k a-keys]
+              [k (get a k) (get b k ::missing)])
+            (for [k extra-keys]
+              [k ::missing (get b k)])))
+        ;; Only AFTER is a map (BEFORE missing / different kind): all-added.
+        a
+        (for [[k v] a]
+          [k v ::missing])
+        ;; Only BEFORE is a map (shouldn't normally happen — render-node
+        ;; routes value=::missing through render-leaf-with-diff). Defensive.
+        b
+        (for [[k v] b]
+          [k ::missing v])
+        :else nil))
+
+    (:vector :list :seq)
+    (let [a-vec (when (sequential? after)  (vec after))
+          b-vec (when (sequential? before) (vec before))]
+      (cond
+        (and a-vec b-vec)
+        (let [n (max (count a-vec) (count b-vec))]
+          (for [i (range n)]
+            [i
+             (if (< i (count a-vec)) (nth a-vec i) ::missing)
+             (if (< i (count b-vec)) (nth b-vec i) ::missing)]))
+        a-vec
+        (map-indexed (fn [i x] [i x ::missing]) a-vec)
+        b-vec
+        (map-indexed (fn [i x] [i ::missing x]) b-vec)
+        :else nil))
+
+    :set
+    (let [a (when (set? after)  after)
+          b (when (set? before) before)]
+      (cond
+        (and a b)
+        (let [members (vec (sort-by pr-str (into a b)))]
+          (for [x members]
+            [x
+             (if (contains? a x) x ::missing)
+             (if (contains? b x) x ::missing)]))
+        a (for [x a] [x x ::missing])
+        b (for [x b] [x ::missing x])
+        :else nil))
+
+    :map-entry
+    (let [a (when (map-entry?* after)  after)
+          b (when (map-entry?* before) before)]
+      (cond
+        (and a b)
+        (list [0 (first a) (first b)]
+              [1 (second a) (second b)])
+        a (list [0 (first a) ::missing] [1 (second a) ::missing])
+        b (list [0 ::missing (first b)] [1 ::missing (second b)])
+        :else nil))
+
+    nil))
+
+(defn- diff-pair-count
+  "Cheap union-aware child count for diff mode. Returns the number of
+  rows the union walk will emit so the header logic (`empty?` /
+  `expanded?` gating) reflects both sides. Falls back to AFTER's
+  `child-count` when the kinds don't line up. Pure."
+  [before after kind]
+  (case kind
+    (:map :record)
+    (let [a (when (map? after) after)
+          b (when (map? before) before)]
+      (cond
+        (and a b)
+        (let [a-keys (set (keys a))
+              extra  (count (remove a-keys (keys b)))]
+          (+ (count a) extra))
+        a (count a)
+        b (count b)
+        :else 0))
+    (:vector :list :seq)
+    (let [a (when (sequential? after)  after)
+          b (when (sequential? before) before)]
+      (cond
+        (and a b) (max (count (vec a)) (count (vec b)))
+        a (count (vec a))
+        b (count (vec b))
+        :else 0))
+    :set
+    (let [a (when (set? after)  after)
+          b (when (set? before) before)]
+      (cond
+        (and a b) (count (into a b))
+        a (count a)
+        b (count b)
+        :else 0))
+    :map-entry 2
+    0))
+
 (defn- child-count
   "Count children safely (don't realise lazy infinite seqs)."
   [v kind]
@@ -1483,7 +1626,13 @@
          :or {default-expanded-depth default-ceiling-depth
               max-depth 16
               max-inline-width 60}} opts
-        cnt           (child-count value kind)
+        ;; rf2-zuh1e — in diff mode `cnt` reflects the UNION of BEFORE +
+        ;; AFTER so an AFTER-side `{}` with a BEFORE side carrying keys
+        ;; still expands + renders the removed rows. Outside diff mode
+        ;; the original AFTER-only count drives the header.
+        cnt           (if diff?
+                        (diff-pair-count before value kind)
+                        (child-count value kind))
         empty?        (zero? cnt)
         depth-capped? (>= depth max-depth)
         ;; Diff: classify this container's op vs `before`. Only
@@ -1542,8 +1691,16 @@
         ;; the visible state on the first click.
         toggle-fn     (on-toggle dispatch-fn panel-id mount-id path
                                  (boolean (and expanded? (not depth-capped?))))
+        ;; rf2-zuh1e — in diff mode the body walks the UNION of BEFORE +
+        ;; AFTER children via `children-of-pair`. Plain browse keeps the
+        ;; original AFTER-only `children-of` walk. The pair-list shape
+        ;; differs (`[k v]` for browse vs `[k v b]` for diff) so the
+        ;; downstream child-pair construction below normalises into a
+        ;; uniform `[k v b]` triple for the recursive render call.
         children      (when (and (not empty?) (not depth-capped?) expanded? (not inline-fit?))
-                        (children-of value))
+                        (if diff?
+                          (children-of-pair before value kind)
+                          (children-of value)))
         ;; rf2-h71e0 — zoom affordance is rendered next to the expand
         ;; triangle on every non-empty container at a NON-ROOT relative
         ;; path. The root (`[]`) skips the affordance because zooming
@@ -1695,29 +1852,17 @@
      ;; grid template wouldn't add anything.
      (when (seq children)
        (let [labelled?    (#{:map :record :map-entry} kind)
+             ;; rf2-zuh1e — `children` is already the diff-aware triple
+             ;; `[k after-value before-value]` when `diff?` is true (from
+             ;; `children-of-pair`); plain browse hands back the legacy
+             ;; `[k v]` pair which we lift into a uniform triple with
+             ;; `::missing` on the `before` slot so the downstream
+             ;; `render-node` call site reads one shape.
              child-pairs
-             (cond
-               (and diff? (= kind :map) (map? before))
-               ;; Map: walk union of keys; carry both v and b per key.
-               (let [all-keys (vec (into (set (keys value)) (keys before)))]
-                 (for [k all-keys]
-                   [k (get value k ::missing) (get before k ::missing)]))
-
-               (and diff? (#{:vector :list :seq} kind) (sequential? before))
-               ;; Sequential: index-align; treat extra trailing items.
-               (let [a-vec (vec value)
-                     b-vec (vec before)
-                     n     (max (count a-vec) (count b-vec))]
-                 (for [i (range n)]
-                   [i
-                    (if (< i (count a-vec)) (nth a-vec i) ::missing)
-                    (if (< i (count b-vec)) (nth b-vec i) ::missing)]))
-
-               :else
-               ;; Non-diff path, or diff with no comparable structure
-               ;; on the `before` side — render the present children as-is.
+             (if diff?
+               children
                (for [[k cv] children]
-                 [k cv (if diff? ::missing ::missing)]))]
+                 [k cv ::missing]))]
          (if labelled?
            ;; --- CSS Grid body for labelled-key kinds ---
            ;; Each row contributes key (col 1) + value (col 2) as direct

--- a/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs
@@ -1346,6 +1346,196 @@
     (is (= {:a 1} (:before (nth h 2))))))
 
 ;; =========================================================================
+;; rf2-zuh1e — diff renders REMOVED items (children-of walks the union of
+;; BEFORE + AFTER, not just AFTER)
+;; =========================================================================
+;;
+;; Pre-fix the render-container body walked `(children-of value)` (AFTER
+;; only). Items present in BEFORE but absent from AFTER — the common
+;; `dissoc` / set-`disj` / vector-`pop` case — silently disappeared from
+;; the rendered tree. Now `children-of-pair` returns the UNION of BEFORE
+;; + AFTER triples; removed slots render with the existing rf2-awqts
+;; removed chrome (strike-through + red wash + `-` gutter glyph).
+
+(deftest children-of-pair-map-union
+  (testing "AFTER's keys in order then BEFORE-only keys appended"
+    (let [pairs (ei/children-of-pair {:a 1 :gone "g"} {:a 1 :added 9} :map)]
+      ;; Each triple is [k after-value before-value].
+      (is (= [:a 1 1]                        (nth (vec pairs) 0)))
+      (is (= [:added 9 ei/missing-sentinel]  (nth (vec pairs) 1)))
+      (is (= [:gone ei/missing-sentinel "g"] (nth (vec pairs) 2)))))
+  (testing "all-added when BEFORE not a map"
+    (let [pairs (vec (ei/children-of-pair nil {:a 1} :map))]
+      (is (= [:a 1 ei/missing-sentinel] (first pairs)))))
+  (testing "all-removed when AFTER empty"
+    (let [pairs (vec (ei/children-of-pair {:a 1 :b 2} {} :map))]
+      (is (= 2 (count pairs)))
+      (is (every? #(= ei/missing-sentinel (second %)) pairs))
+      (is (= #{:a :b} (set (map first pairs)))))))
+
+(deftest children-of-pair-vector-tail
+  (testing "BEFORE-tail items past AFTER render as removed slots"
+    (let [pairs (vec (ei/children-of-pair [:x :y :z] [:x] :vector))]
+      (is (= [0 :x :x]                       (nth pairs 0)))
+      (is (= [1 ei/missing-sentinel :y]      (nth pairs 1)))
+      (is (= [2 ei/missing-sentinel :z]      (nth pairs 2)))))
+  (testing "ADDED tail items appear too"
+    (let [pairs (vec (ei/children-of-pair [:x] [:x :y :z] :vector))]
+      (is (= [1 :y ei/missing-sentinel] (nth pairs 1)))
+      (is (= [2 :z ei/missing-sentinel] (nth pairs 2))))))
+
+(deftest children-of-pair-set-union-sorted
+  (testing "set members render alongside survivors; sort by pr-str"
+    (let [pairs (vec (ei/children-of-pair #{:a :b :ws/authenticating}
+                                          #{:a :b}
+                                          :set))
+          keys  (mapv first pairs)]
+      (is (= 3 (count pairs)))
+      ;; pr-str sort is stable: `:a` < `:b` < `:ws/authenticating`.
+      (is (= [:a :b :ws/authenticating] keys))
+      ;; The removed member's AFTER slot is ::missing; BEFORE side
+      ;; carries the prior value.
+      (is (= [:ws/authenticating ei/missing-sentinel :ws/authenticating]
+             (last pairs))
+          "removed-only member appears with after=::missing, before=value"))))
+
+(deftest diff-renders-removed-map-key
+  ;; Map dissoc case — `:tags` would also be a map at one level up,
+  ;; but the simplest assertion is at the top level: AFTER drops a key
+  ;; and the rendered hiccup carries the removed-chrome marker for
+  ;; that row.
+  (let [before {:a 1 :b 2}
+        after  {:a 1}
+        h (ei/render-node {:value after
+                           :before before
+                           :diff? true
+                           :panel-id :p :mount-id "m"
+                           :path [] :depth 0
+                           :expansion-map {}
+                           :opts {:default-expanded-depth 2}})
+        all (collect-text h)
+        s   (try (pr-str h) (catch :default _ ""))]
+    (is (re-find #":b" all)
+        "removed key :b still appears in the rendered hiccup")
+    (is (re-find #":a" all)
+        "surviving key :a still renders (no regression)")
+    (is (re-find #"data-rf-diff-op.*removed" s)
+        "a row carries the removed diff-op marker")
+    (is (re-find #"line-through" s)
+        "removed row carries the strike-through text-decoration")))
+
+(deftest diff-renders-fully-dissocd-map
+  ;; Edge case — AFTER is `{}` (all keys dropped). Pre-fix the empty
+  ;; AFTER short-circuited the header into the `{}` empty-bracket-pair
+  ;; render, hiding every removed row. Now the union count drives the
+  ;; header so the body still expands.
+  (let [before {:a 1 :b 2}
+        after  {}
+        h (ei/render-node {:value after
+                           :before before
+                           :diff? true
+                           :panel-id :p :mount-id "m"
+                           :path [] :depth 0
+                           :expansion-map {}
+                           :opts {:default-expanded-depth 2}})
+        all (collect-text h)]
+    (is (re-find #":a" all)
+        "both removed keys appear when AFTER is fully dissoc'd")
+    (is (re-find #":b" all))))
+
+(deftest diff-renders-removed-vector-tail
+  (let [before [:x :y :z]
+        after  [:x]
+        h (ei/render-node {:value after
+                           :before before
+                           :diff? true
+                           :panel-id :p :mount-id "m"
+                           :path [] :depth 0
+                           :expansion-map {}
+                           :opts {:default-expanded-depth 2}})
+        all (collect-text h)
+        s   (try (pr-str h) (catch :default _ ""))]
+    (is (re-find #":y" all) "popped tail item :y still appears")
+    (is (re-find #":z" all) "popped tail item :z still appears")
+    (is (re-find #"data-rf-diff-op.*removed" s)
+        "a row carries the removed diff-op marker")))
+
+(deftest diff-renders-removed-set-member
+  ;; Canonical machine-snapshot reproduction (rf2-zuh1e bead body):
+  ;; `:tags` set loses `:ws/authenticating`. Before this fix the AFTER
+  ;; column rendered with no indication anything was removed; now the
+  ;; struck-through row appears alongside the survivors.
+  (let [before #{:a :b :ws/authenticating}
+        after  #{:a :b}
+        h (ei/render-node {:value after
+                           :before before
+                           :diff? true
+                           :panel-id :p :mount-id "m"
+                           :path [] :depth 0
+                           :expansion-map {}
+                           :opts {:default-expanded-depth 2}})
+        all (collect-text h)
+        s   (try (pr-str h) (catch :default _ ""))]
+    (is (re-find #":ws/authenticating" all)
+        "removed set member rendered alongside survivors")
+    (is (re-find #"data-rf-diff-op.*removed" s)
+        "the removed-member row carries the removed diff-op marker")
+    (is (re-find #"line-through" s)
+        "the removed row carries strike-through text-decoration")))
+
+(deftest diff-renders-machine-snapshot-tags-transition
+  ;; Mike's live repro 2026-05-26 — a Machine snapshot transition
+  ;; `[:active :authenticating] → [:active :connected]` where `:tags`
+  ;; loses `:ws/authenticating`. The operator sees the post-image with
+  ;; the removed tag struck-through.
+  (let [before {:state [:active :authenticating]
+                :tags  #{:ws/authenticating :ws/online}
+                :context {:retries 0}}
+        after  {:state [:active :connected]
+                :tags  #{:ws/online}
+                :context {:retries 0}}
+        h (ei/render-node {:value after
+                           :before before
+                           :diff? true
+                           :panel-id :p :mount-id "m"
+                           :path [] :depth 0
+                           :expansion-map {}
+                           :opts {:default-expanded-depth 4}})
+        all (collect-text h)
+        s   (try (pr-str h) (catch :default _ ""))]
+    (is (re-find #":ws/authenticating" all)
+        "removed :tags member rendered with the AFTER column")
+    (is (re-find #":connected" all) "AFTER's :state member visible")
+    (is (re-find #":authenticating" all)
+        "BEFORE's :state member rendered via the modified-leaf annotation")
+    (is (re-find #"line-through" s)
+        "at least one row carries strike-through (the removed tag)")))
+
+(deftest diff-preserves-added-modified-same-rows
+  ;; No regression — added / modified / same rows still render
+  ;; alongside the new removed rows.
+  (let [before {:same 1   :modify 2 :gone "g"}
+        after  {:same 1   :modify 9 :added :new}
+        h (ei/render-node {:value after
+                           :before before
+                           :diff? true
+                           :panel-id :p :mount-id "m"
+                           :path [] :depth 0
+                           :expansion-map {}
+                           :opts {:default-expanded-depth 2}})
+        s   (try (pr-str h) (catch :default _ ""))]
+    (is (re-find #"data-rf-diff-op.*added" s)
+        "added row marker present")
+    (is (re-find #"data-rf-diff-op.*removed" s)
+        "removed row marker present")
+    (is (re-find #"data-rf-diff-op.*modified" s)
+        "modified row marker present")
+    (is (re-find #"data-rf-diff-op.*same" s)
+        "same row marker still present for unchanged rows")
+    (is (re-find #"← changed from 2" s)
+        "modified leaf still carries the change annotation")))
+
+;; =========================================================================
 ;; rf2-y59tb — frame-leak + first-click regression guards
 ;; =========================================================================
 ;;


### PR DESCRIPTION
## Root cause

Pre-fix `render-container`'s body walked `(children-of value)` (AFTER only) — items in BEFORE but absent from AFTER (the common `dissoc` / set-`disj` / vector-`pop` case) disappeared silently from the rendered tree. Mike's live repro 2026-05-26: a Machine snapshot transition `[:active :authenticating] -> [:active :connected]` where `:tags` lost `:ws/authenticating` — the operator saw the post-image with no indication anything was removed.

## Fix shape

New public helper `children-of-pair before after kind` returns enriched `[k after-value before-value]` triples covering the UNION of BEFORE + AFTER. Slots that don't exist in their side carry `::missing` (the same sentinel `diff-op` consumes), so the recursive `render-leaf-with-diff` paths route through the existing rf2-awqts removed chrome (strike-through + red wash + `-` gutter glyph) unchanged.

`diff-pair-count` is the union-aware counterpart of `child-count` so the header logic (`empty?`, `expanded?`, `inline-fit?`) reflects both sides — an AFTER-side `{}` with a BEFORE side full of keys now expands and renders the removed rows instead of short-circuiting to the empty-bracket-pair render. Non-diff browse keeps the original AFTER-only path unchanged.

### Per-kind merge strategy

- **Map / record** — AFTER keys in their natural order, BEFORE-only keys **appended at the end**. Picked over interleaved-at-original-position: CLJS hash-maps don't carry stable order across boundaries anyway (array-map vs hash-map crossover; `dissoc` rehashing), and appended-at-end is simple, predictable, and reads as "post-image, then a deletions section".
- **Vector / list / seq** — index-aligned up to `(max (count before) (count after))`; trailing BEFORE positions render as removed.
- **Set** — union of members, sorted by `pr-str` for stable render.
- **Map-entry** — fixed two positions with per-side values.

## Acceptance criteria coverage

| # | Criterion | Test |
|---|-----------|------|
| 1 | Machine-snapshot AFTER renders `:ws/authenticating` struck-through | `diff-renders-machine-snapshot-tags-transition`, `diff-renders-removed-set-member` |
| 2 | Fix applies uniformly to maps / vectors / sets | `diff-renders-removed-map-key`, `diff-renders-removed-vector-tail`, `diff-renders-removed-set-member` |
| 3 | Added items still render added (no regression) | `diff-preserves-added-modified-same-rows` |
| 4 | Modified items still carry `← changed from X` (no regression) | `diff-preserves-added-modified-same-rows` |
| 5 | Same items render dim under diff mode (preserved) | `diff-preserves-added-modified-same-rows` (existing `diff-same-leaf-uses-text-tertiary` already covers) |

Plus pure-data unit tests for the new helper: `children-of-pair-map-union`, `-vector-tail`, `-set-union-sorted`, and an edge-case test `diff-renders-fully-dissocd-map` for an AFTER-side `{}` that pre-fix would short-circuit to an empty-bracket-pair render.

## Test deltas

- `tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs` — 9 new `deftest`s (143 -> 152 in the file).

## Quality gates

- `cd implementation && npm run test:cljs` -> 4672 tests, 15047 assertions, **0 failures, 0 errors**.
- `npm run test:bundle-isolation` -> **PASS** (tools surface stays bundle-isolated from production examples builds).

## Changed files

- `tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs` — new `children-of-pair` + private `diff-pair-count`; threaded into `render-container` via the existing `diff?` flag (no opt-shape changes — `:zoomable?`, `:popup-affordance?`, `:card?`, `:header`, `:site-id` all preserved).
- `tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs` — 9 new tests under a new `rf2-zuh1e` section header.

## Cross-refs

Closes rf2-zuh1e. Composes cleanly with rf2-awqts (removed chrome — reused unchanged) and rf2-h71e0 (zoom + breadcrumb).