### PR TITLE
fix(xray): edn-inspector zoom-affordance click carries :rf/xray frame envelope (rf2-kcaiz)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
@@ -2284,28 +2284,57 @@
   the absolute path from the original root (composed by the caller as
   `(into zoom-path-prefix path)`).
 
-  `dispatch-fn` is the lexically-captured frame-aware dispatcher (so the
-  event lands on the same frame the widget is mounted under). `panel-id`
-  + `mount-id` (or `site-id`) key the zoom slot. `absolute-path` is the
-  vec the reducer stores verbatim.
+  ## Dispatch asymmetry (rf2-kcaiz — same class as rf2-7sdja)
+
+  The zoom-to event dispatches against `:rf/xray` EXPLICITLY via the
+  established `(rf/dispatch event {:frame :rf/xray})` pattern. The
+  zoom slot lives in `:rf/xray`'s app-db (see `zoom-slot` docstring);
+  every consumer of `:zoomable? true` mounts inside Xray. Routing the
+  dispatch through the lexically-captured `dispatch-fn` looked safe
+  because the surrounding `reg-view` body inherits `:rf/xray` from
+  React context — but React's synthetic-event timing pops the frame
+  context before the click fires, so the dispatch leaks to
+  `:rf/default`. Pinning the frame at call time fixes it.
+
+  Same root cause as rf2-7sdja (popup-affordance) + rf2-y59tb (triangle
+  toggle) — every dispatch crossing the React/event boundary must carry
+  the `{:frame :rf/xray}` envelope at call time.
+
+  The `dispatch-fn` parameter is retained as a no-op for back-compat
+  with the existing render-call site shape. Production callers should
+  pass `nil` — `zoom-affordance-button` ignores it and dispatches
+  directly.
 
   Public so unit tests can drive the button without mounting."
-  [{:keys [dispatch-fn panel-id mount-id absolute-path testid]}]
-  (let [dispatch-fn (or dispatch-fn rf/dispatch*)]
-    [:button
-     {:data-testid        testid
-      :data-rf-affordance "zoom"
-      :aria-label         "Zoom into this node"
-      :title              "Zoom into this node"
-      :on-click           (fn [^js e]
-                            (when e
-                              (.preventDefault e)
-                              (.stopPropagation e))
-                            (dispatch-fn
-                              [:rf.xray.edn-inspector/zoom-to
-                               panel-id mount-id (vec absolute-path)]))
-      :style              zoom-affordance-button-style}
-     zoom-affordance-glyph]))
+  [{:keys [panel-id mount-id absolute-path testid]}]
+  ;; Note: callers historically supplied `:dispatch-fn`; we ignore it
+  ;; per the rf2-kcaiz fix (see docstring above). The key is left in
+  ;; the destructuring contract to keep the call-site shape stable.
+  [:button
+   {:data-testid        testid
+    :data-rf-affordance "zoom"
+    :aria-label         "Zoom into this node"
+    :title              "Zoom into this node"
+    :on-click           (fn [^js e]
+                          (when e
+                            (.preventDefault e)
+                            (.stopPropagation e))
+                          ;; rf2-kcaiz — zoom state is Xray-global.
+                          ;; Pin the dispatch frame to `:rf/xray`
+                          ;; regardless of the surrounding mount
+                          ;; frame so the zoom-slot subscription
+                          ;; (which only reads `:rf/xray`'s app-db)
+                          ;; sees the write. Without this pin the
+                          ;; dispatch leaks to `:rf/default`
+                          ;; because React synthetic-event timing
+                          ;; pops the frame context before the
+                          ;; click handler fires.
+                          (rf/dispatch
+                            [:rf.xray.edn-inspector/zoom-to
+                             panel-id mount-id (vec absolute-path)]
+                            {:frame :rf/xray}))
+    :style              zoom-affordance-button-style}
+   zoom-affordance-glyph])
 
 (defn- breadcrumb-segment-label
   "Render a single path-segment label using the syntax-palette colour

--- a/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs
@@ -2452,20 +2452,71 @@
     (is (zero? (count all-zoom-buttons))
         "with :zoomable? off no node emits a zoom affordance")))
 
+(defn- with-rf-dispatch-spy
+  "Drive a click against a stubbed `rf/dispatch*` (the fn-form the
+  `dispatch` macro expands to) so the test can inspect the dispatched
+  event vector + opts WITHOUT spinning up the router. Returns
+  `{:event ... :opts ...}` captured at click. Per rf2-kcaiz — the
+  post-fix `zoom-affordance-button` calls `rf/dispatch` directly with
+  `{:frame :rf/xray}` opts (mirrors rf2-7sdja popup-affordance fix)."
+  [on-click]
+  (let [captured (atom nil)]
+    (with-redefs [rf/dispatch* (fn
+                                 ([ev]      (reset! captured {:event ev :opts nil}))
+                                 ([ev opts] (reset! captured {:event ev :opts opts})))]
+      (on-click nil))
+    @captured))
+
 (deftest zoom-affordance-button-dispatches-zoom-to-with-absolute-path
-  (let [dispatched (atom nil)
-        dispatch   (fn [ev] (reset! dispatched ev))
-        h          (ei/zoom-affordance-button
-                     {:dispatch-fn   dispatch
-                      :panel-id      :p
-                      :mount-id      "m"
-                      :absolute-path [:a :b :c]
-                      :testid        "rf-xray-edn-inspector-zoom-aff"})
-        on-click   (-> h second :on-click)]
+  (let [h        (ei/zoom-affordance-button
+                   {;; `:dispatch-fn` is a no-op post rf2-kcaiz —
+                    ;; pass nil to make the new contract obvious.
+                    :dispatch-fn   nil
+                    :panel-id      :p
+                    :mount-id      "m"
+                    :absolute-path [:a :b :c]
+                    :testid        "rf-xray-edn-inspector-zoom-aff"})
+        on-click (-> h second :on-click)
+        {:keys [event]} (with-rf-dispatch-spy on-click)]
     (is (some? on-click) "button carries an on-click handler")
-    (on-click nil) ;; safe — handler guards `when e`
-    (is (= [:rf.xray.edn-inspector/zoom-to :p "m" [:a :b :c]] @dispatched)
+    (is (= [:rf.xray.edn-inspector/zoom-to :p "m" [:a :b :c]] event)
         "click dispatches the canonical zoom-to event with the absolute path")))
+
+(deftest zoom-affordance-button-onclick-dispatches-against-xray-frame
+  ;; rf2-kcaiz — mirrors the rf2-7sdja popup-affordance regression
+  ;; guard. The zoom-affordance click handler MUST pin the dispatch
+  ;; frame to `:rf/xray` at call time, because React synthetic-event
+  ;; timing pops the surrounding frame context before the click fires
+  ;; (so a lexically-captured frame-aware dispatcher would leak the
+  ;; dispatch to `:rf/default`). This test asserts the envelope.
+  (testing "rf2-kcaiz — clicking the zoom-affordance dispatches
+            `[:rf.xray.edn-inspector/zoom-to ...]` against `:rf/xray`
+            EXPLICITLY (zoom state is Xray-global — pinned via
+            `{:frame :rf/xray}` opts)"
+    (let [h        (ei/zoom-affordance-button
+                     {:dispatch-fn   nil
+                      :panel-id      :rf.xray/app-db
+                      :mount-id      "m-1"
+                      :absolute-path [:cart :items 0]
+                      :testid        "x"})
+          on-click (-> h second :on-click)
+          {:keys [event opts]} (with-rf-dispatch-spy on-click)
+          [event-id panel-id mount-id path] event]
+      (is (= :rf.xray.edn-inspector/zoom-to event-id)
+          "canonical event id")
+      (is (= :rf.xray/app-db panel-id)
+          "panel-id flows through as second positional arg")
+      (is (= "m-1" mount-id)
+          "mount-id flows through as third positional arg")
+      (is (= [:cart :items 0] path)
+          "absolute path flows through as fourth positional arg")
+      (is (= :rf/xray (:frame opts))
+          "rf2-kcaiz — zoom dispatch pins frame to `:rf/xray`
+           explicitly so the zoom-slot subscription (which only
+           reads `:rf/xray`'s app-db) sees the write regardless of
+           which frame the widget is mounted under. Same class of
+           fix as rf2-7sdja (popup-affordance) + rf2-y59tb (triangle
+           toggle)."))))
 
 (deftest zoom-affordance-composes-prefix-and-relative-path
   ;; The renderer threads the absolute path = (into zoom-path-prefix path)
@@ -2486,8 +2537,7 @@
                            :zoomable? true
                            :zoom-path-prefix [:rf/machines]
                            :opts {:default-expanded-depth 8}})
-        affordance (find-attr h :data-rf-affordance "zoom")
-        dispatched (atom nil)]
+        affordance (find-attr h :data-rf-affordance "zoom")]
     (is (some? affordance)
         "the recursive walker emits a zoom affordance on the displayed root's
          children even when `:zoom-path-prefix` is non-empty")
@@ -2498,15 +2548,17 @@
     ;; composition.
     (let [composed (vec (concat [:rf/machines] [:ws/connection]))
           h2       (ei/zoom-affordance-button
-                     {:dispatch-fn   (fn [ev] (reset! dispatched ev))
+                     {:dispatch-fn   nil
                       :panel-id      :p
                       :mount-id      "m"
                       :absolute-path composed
-                      :testid        "x"})]
-      ((-> h2 second :on-click) nil)
+                      :testid        "x"})
+          {:keys [event opts]} (with-rf-dispatch-spy (-> h2 second :on-click))]
       (is (= [:rf.xray.edn-inspector/zoom-to :p "m" [:rf/machines :ws/connection]]
-             @dispatched)
-          "the dispatched path is the absolute path = prefix + relative"))))
+             event)
+          "the dispatched path is the absolute path = prefix + relative")
+      (is (= :rf/xray (:frame opts))
+          "rf2-kcaiz — composed-path dispatch is ALSO pinned to `:rf/xray`"))))
 
 ;; ---- breadcrumb ----------------------------------------------------------
 


### PR DESCRIPTION
## Root cause

The zoom-affordance `⊙` button (added in rf2-h71e0) routed its `:zoom-to` dispatch through a lexically-captured frame-aware `dispatch-fn`. React synthetic-event timing pops the surrounding frame context before the click handler fires, so the dispatch leaked to `:rf/default` and the zoom-slot subscription (which reads `:rf/xray`'s app-db) never saw the write — clicking the affordance produced no visible effect.

Same class of bug as **rf2-7sdja** (popup-affordance click leak) and **rf2-y59tb** (triangle toggle frame leak), both already fixed. Comments in `edn_inspector.cljs` already document the contract: "every dispatch must carry the `{:frame :rf/xray}` envelope at call time."

## Fix shape

Mirror the rf2-7sdja pattern exactly: pin the dispatch frame at call time via `(rf/dispatch event {:frame :rf/xray})` rather than relying on the lexically-captured dispatcher. The `:dispatch-fn` parameter is retained as a no-op for call-site shape stability (matches the popup-affordance back-compat treatment).

## Test coverage

- Existing `zoom-affordance-button-dispatches-zoom-to-with-absolute-path` rewritten to use the `with-redefs rf/dispatch*` spy pattern (mirrors `popup-affordance-button-onclick-dispatches-against-xray-frame`).
- New `zoom-affordance-button-onclick-dispatches-against-xray-frame` test — dedicated regression guard asserting the dispatched envelope carries `{:frame :rf/xray}` explicitly.
- Existing `zoom-affordance-composes-prefix-and-relative-path` extended to also assert the envelope on the composed-path branch.

## Quality gates

- `npm run test:cljs` — 4683 tests, 0 failures, 0 errors
- `npm run test:bundle-isolation` — PASS

## Files changed

- `tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs` — pin zoom dispatch to `:rf/xray` at call time
- `tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs` — adopt spy pattern + add envelope-regression test

Closes rf2-kcaiz.