### PR TITLE
fix(xray): epoch-panel bug-fixes cluster (6 beads — rf2-93a7s + 5 more)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1400,6 +1400,7 @@ verbatim; no DOM concern bleeds into the data layer.
 |-----|-------|--------|
 | `:rf.xray/epoch-pipeline` | `:rf.xray/focus` · `:rf.xray/epoch-history` (via the shared `panels.shared.focus-resolver`) | `{:status :no-focus | :focused | :epoch-evicted, :epoch-id, :record, :steps}` |
 | `:rf.xray.epoch/expanded-rows` | `:epoch-panel-expanded-rows` slot | `#{[step-kw row-id] …}` |
+| `:rf.xray.epoch/subs-show-unchanged?` | `:epoch-panel-subs-show-unchanged?` slot | boolean (rf2-kfh1v — SUBSCRIPTIONS step filters unchanged rows by default; this flag opts in to seeing all) |
 
 ### §9.1.10 Events
 
@@ -1407,6 +1408,26 @@ verbatim; no DOM concern bleeds into the data layer.
 |-------|--------|
 | `:rf.xray.epoch/toggle-row-expand step-kw row-id` | flip the row's pair in `:epoch-panel-expanded-rows` |
 | `:rf.xray.epoch/clear-row-expand` | drop the expansion set |
+| `:rf.xray.epoch/toggle-subs-show-unchanged` | flip the SUBSCRIPTIONS show-unchanged flag (rf2-kfh1v) |
+
+### §9.1.10.1 Substrate tag dependencies (the trace-stamp contract)
+
+The projection is a pure-data fn over the focused epoch's `:trace-events`.
+Each step row reads ONE OR MORE substrate-emitted tags; the panel only
+renders the slot when its driving tag is present. The 6-bead bug-fix
+sweep (2026-05-26) aligned every projection read with the substrate's
+canonical tag names — earlier reads against legacy names returned nil
+and silently rendered empty rows. The binding inventory:
+
+| Step | Trace operation | Canonical tags |
+|------|-----------------|----------------|
+| `:dispatch` | `:rf.event/dispatched` | `:rf.event/v` (event vector — rf2-93a7s), `:source`, `:rf.trace/call-site` |
+| `:coeffect` | `:rf.cofx/run` (preferred) or `:rf.event/run-end` `:rf.event/coeffects` (fallback) | `:rf.cofx/id`, `:rf.cofx/value` — SYSTEM defaults `:db / :event / :frame / :source / :trace-id` are filtered (rf2-cq0ch) |
+| `:handler` source | `(rf/handler-meta :event id)` → `:rf.handler/source` (rf2-66wis · NOT a trace read — registrar meta) |
+| `:flow` | `:rf.flow/recomputed` | `:rf.flow/id`, `:rf.flow/path`, `:rf.flow/before`, `:rf.flow/after` |
+| `:fx` | `:rf.fx/handled` / `:rf.fx/override-applied` / `:rf.fx/skipped-on-platform` | `:rf.fx/id`, `:rf.fx/args`, `:duration-ms` |
+| `:subscriptions` | `:rf.sub/run` / `:rf.sub/skip` | `:rf.sub/id`, `:rf.sub/query-v`, `:rf.sub/value-changed?`, `:rf.sub/prev-value`, `:rf.sub/value`, `:rf.sub/cascade?`, `:rf.sub/cause-sub`, `:rf.sub/elapsed-ms` (rf2-kfh1v aligned the reads against these) |
+| `:views` | `:rf.view/rendered` (NOT the simpler `:rf.view/render` marker) | `:rf.view/id`, `:rf.view/deref-subs`, `:rf.view/elapsed-ms`, `:rf.view/mount?`, `:rf.view/triggered-by` (rf2-6djth aligned the read against the rich marker) |
 
 ### §9.1.11 Cross-panel navigation
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -98,16 +98,38 @@
 
 ;; ---- COEFFECT rows -------------------------------------------------------
 
+(def system-cofx-ids
+  "Coeffect ids the substrate auto-injects on every event handler — the
+  user did not register them via `reg-cofx` and the operator does not
+  benefit from seeing them. Filtered out of the COEFFECT step at
+  projection time (rf2-cq0ch).
+
+  Mirrors `re-frame.fx/framework-coeffect-keys`; the substrate already
+  filters these out of the `:rf.event/run-end :rf.event/coeffects`
+  stamp (rf2-9dk9y), but we filter here too as a belt-and-braces
+  defence — older runtimes / test fixtures that supply a raw cofx-map
+  through the fallback still get clean output."
+  #{:db :event :frame :source :trace-id})
+
+(defn- user-cofx?
+  "True iff `id` is a user-defined coeffect (i.e. not a system-injected
+  default). Used to gate per-row visibility."
+  [id]
+  (and (some? id) (not (contains? system-cofx-ids id))))
+
 (defn- coeffect-rows-from-runs
   "Walk every `:rf.cofx/run` event (rf2-hhh92) and project one row per
   user-injected coeffect — each row carries the cofx id and the value
-  it added to ctx. Empty seq when no `:rf.cofx/run` events fired."
+  it added to ctx. Empty seq when no `:rf.cofx/run` events fired.
+
+  System-injected defaults (`:db`, `:event`, `:frame`, `:source`,
+  `:trace-id`) are filtered out per rf2-cq0ch."
   [events]
   (vec
     (for [ev (filter-op events :rf.cofx/run)
           :let [id    (common/tag-of ev :rf.cofx/id)
                 value (common/tag-of ev :rf.cofx/value)]
-          :when (some? id)]
+          :when (user-cofx? id)]
       {:step        :coeffect
        :badge       :COEFFECT
        :id          id
@@ -119,22 +141,30 @@
   trace's `:rf.event/coeffects` stamp (rf2-9dk9y). The substrate places
   the user-injected subset there so events that return only `:db`
   still surface their cofx. Returns a vec of rows in map order; this
-  fallback is used only when no granular `:rf.cofx/run` events exist."
+  fallback is used only when no granular `:rf.cofx/run` events exist.
+
+  System-injected defaults are filtered out per rf2-cq0ch (belt-and-
+  braces — the substrate already filters at the run-end emit site)."
   [events]
   (when-let [run-end (find-op events :rf.event/run-end)]
     (let [m (common/tag-of run-end :rf.event/coeffects)]
       (when (map? m)
-        (vec (for [[id value] m]
+        (vec (for [[id value] m
+                   :when (user-cofx? id)]
                {:step  :coeffect
                 :badge :COEFFECT
                 :id    id
                 :value value}))))))
 
 (defn coeffect-rows
-  "All COEFFECT rows for the epoch — one per user-injected coeffect.
+  "All COEFFECT rows for the epoch — one per USER-defined coeffect
+  (system defaults like `:db` / `:event` are filtered out — rf2-cq0ch).
   Prefers granular `:rf.cofx/run` events; falls back to the run-end
   coeffect stamp when no granular events exist (older runtimes / test
-  fixtures). Returns an empty vec when neither surface is present."
+  fixtures). Returns an empty vec when neither surface is present, or
+  when every coeffect is system-injected — the latter is the typical
+  reg-event-db case where the operator gains nothing from a `:db`
+  presence-pill."
   [events]
   (let [granular (coeffect-rows-from-runs events)]
     (if (seq granular)

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -75,14 +75,25 @@
   "Build the step-1 DISPATCH row from the epoch's `:rf.event/dispatched`
   trace. Returns nil when the epoch carries no dispatched trace (test
   fixtures that synthesise an epoch from a literal `:event` vector
-  surface this path)."
+  surface this path).
+
+  Per rf2-93a7s the event vector is read from the substrate's canonical
+  `:rf.event/v` tag (see `re-frame.router/emit-dispatched-trace`). The
+  pre-rf2-93a7s read against `:event` silently returned `nil` for
+  every dispatched event because the substrate has never stamped under
+  that name; the result was a DISPATCH step with no event-vector body.
+  Legacy `:event` + `(:event ev)` reads are retained as fallbacks for
+  fixture compatibility."
   [events fallback-event]
   (let [ev (find-op events :rf.event/dispatched)]
     (cond
       ev
       {:step        :dispatch
        :badge       :DISPATCH
-       :event       (or (common/tag-of ev :event) (:event ev) fallback-event)
+       :event       (or (common/tag-of ev :rf.event/v)
+                        (common/tag-of ev :event)
+                        (:event ev)
+                        fallback-event)
        :source      (or (common/tag-of ev :source)
                         (common/tag-of ev :rf.event/source))
        :coord       (or (common/tag-of ev :rf.trace/call-site)
@@ -482,10 +493,14 @@
   (let [events    (or (:trace-events epoch-record) [])
         event-id  (or (:event-id epoch-record)
                       (when-let [ev (find-op events :rf.event/dispatched)]
-                        (let [v (or (common/tag-of ev :event) (:event ev))]
+                        (let [v (or (common/tag-of ev :rf.event/v)
+                                    (common/tag-of ev :event)
+                                    (:event ev))]
                           (when (vector? v) (first v)))))
         fallback  (or (when-let [ev (find-op events :rf.event/dispatched)]
-                        (or (common/tag-of ev :event) (:event ev)))
+                        (or (common/tag-of ev :rf.event/v)
+                            (common/tag-of ev :event)
+                            (:event ev)))
                       (:event epoch-record))]
     (if (and (empty? events) (nil? fallback))
       ;; Truly empty epoch: no dispatched trace, no fallback event,

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -398,40 +398,73 @@
 (defn subscription-rows
   "Project `:rf.sub/run` events into rows. Each row carries:
 
-      :sub-id      — the sub vector's first element (the registered id)
-      :sub-vec     — the full sub query vector (`[:foo arg1 arg2]`)
-      :inputs      — the sub's input keywords (for input-fn subs)
-      :changed?    — true iff the sub's output value differed from
-                     the prior run (`:rf.sub/changed?` tag)
-      :before / :after — the sub's prior/new values when stamped
-      :duration-ms — the sub's recompute duration
+      :sub-id      — the registered sub id (`:rf.sub/id` tag).
+      :sub-vec     — the full sub query vector (`:rf.sub/query-v` tag).
+      :inputs      — the sub's input-signal query-vectors (when stamped).
+                     For layer-2+ subs the substrate stamps the
+                     upstream `:rf.sub/cause-sub` (the input whose
+                     value changed); layer-1 subs read app-db directly
+                     and surface as `:db`.
+      :changed?    — true iff the sub's output value differed from the
+                     prior run (`:rf.sub/value-changed?` tag).
+      :before      — the prior value (`:rf.sub/prev-value` tag).
+      :after       — the freshly-computed value (`:rf.sub/value` tag).
+      :cascade?    — true for layer-2+ recomputes (an upstream SUB drove
+                     this re-run); false for layer-1 subs.
+      :duration-ms — the sub's recompute duration (`:rf.sub/elapsed-ms` tag).
 
-  Pure projection; the view layer renders the row table."
+  Per rf2-kfh1v the tag names match the substrate emit-site
+  (`re-frame.subs.memo`); pre-rf2-kfh1v the projection read against
+  legacy names (`:rf.sub/query`, `:rf.sub/changed?`, `:rf.sub/before`)
+  that the substrate has never stamped — every payload slot returned
+  nil → every row showed `app-db ✗` with no id."
   [events]
   (let [evs (filterv #(or (= :rf.sub/run (op %))
                           (= :rf.sub/skip (op %)))
                      events)]
     (vec
       (for [ev evs
-            :let [sub-vec (or (common/tag-of ev :rf.sub/query)
-                              (common/tag-of ev :query))]]
-        {:sub-id      (when (vector? sub-vec) (first sub-vec))
+            :let [sub-vec (or (common/tag-of ev :rf.sub/query-v)
+                              (common/tag-of ev :rf.sub/query)
+                              (common/tag-of ev :query))
+                  sub-id  (or (common/tag-of ev :rf.sub/id)
+                              (when (vector? sub-vec) (first sub-vec)))
+                  cause   (common/tag-of ev :rf.sub/cause-sub)
+                  cascade? (common/tag-of ev :rf.sub/cascade?)]]
+        {:sub-id      sub-id
          :sub-vec     sub-vec
-         :inputs      (common/tag-of ev :rf.sub/inputs)
-         :changed?    (boolean (common/tag-of ev :rf.sub/changed?))
-         :before      (common/tag-of ev :rf.sub/before)
-         :after       (common/tag-of ev :rf.sub/after)
-         :duration-ms (common/tag-of ev :duration-ms)}))))
+         :inputs      (or cause
+                          (common/tag-of ev :rf.sub/inputs))
+         :changed?    (boolean
+                        (or (common/tag-of ev :rf.sub/value-changed?)
+                            (common/tag-of ev :rf.sub/changed?)))
+         :before      (or (common/tag-of ev :rf.sub/prev-value)
+                          (common/tag-of ev :rf.sub/before))
+         :after       (or (common/tag-of ev :rf.sub/value)
+                          (common/tag-of ev :rf.sub/after))
+         :cascade?    (boolean cascade?)
+         :duration-ms (or (common/tag-of ev :rf.sub/elapsed-ms)
+                          (common/tag-of ev :duration-ms))}))))
 
 (defn subscriptions-step
   "SUBSCRIPTIONS step row. nil when no `:rf.sub/*` events fired (the
-  step is OMITTED — conditional)."
+  step is OMITTED — conditional).
+
+  Per rf2-kfh1v the step header counts split the rows by
+  `:changed?` so the operator sees `N recomputed (M changed,
+  K unchanged)` at a glance — the unchanged rows are hidden behind
+  a toggle in the view, the count makes the toggle's value
+  predictable."
   [events]
   (let [rows (subscription-rows events)]
     (when (seq rows)
-      {:step  :subscriptions
-       :badge :SUBSCRIPTIONS
-       :rows  rows})))
+      (let [changed   (count (filter :changed? rows))
+            unchanged (- (count rows) changed)]
+        {:step      :subscriptions
+         :badge     :SUBSCRIPTIONS
+         :rows      rows
+         :changed   changed
+         :unchanged unchanged}))))
 
 ;; ---- VIEWS step ----------------------------------------------------------
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -436,21 +436,35 @@
 ;; ---- VIEWS step ----------------------------------------------------------
 
 (defn view-rows
-  "Project `:rf.view/render` events into rows. Each row carries the
-  view id + the subs it read during the render."
+  "Project view-render events into rows. Each row carries the view-id,
+  the subs the view dereffed during this render, and the wall-clock
+  duration of the render-fn.
+
+  Per rf2-6djth the projection reads `:rf.view/rendered` (the rich
+  per-render marker — rf2-25zo2 / rf2-9hoos / rf2-8wrzz.1) rather than
+  the simpler `:rf.view/render` marker; only `:rf.view/rendered`
+  carries `:rf.view/id`, `:rf.view/deref-subs`, and `:rf.view/elapsed-ms`.
+  The pre-rf2-6djth read against the bare `render` marker returned nil
+  for every payload slot, hence the VIEWS step rendered a count with
+  no per-row detail. Legacy `:view-id` / `:subs-read` reads are
+  retained as fixture-compatibility fallbacks."
   [events]
   (vec
-    (for [ev (filter-op events :rf.view/render)]
-      {:view-id     (or (common/tag-of ev :rf.view/id)
-                        (common/tag-of ev :view-id))
-       :subs-read   (or (common/tag-of ev :rf.view/subs)
-                        (common/tag-of ev :subs-read)
-                        [])
-       :duration-ms (common/tag-of ev :duration-ms)})))
+    (for [ev (filter-op events :rf.view/rendered)]
+      {:view-id      (or (common/tag-of ev :rf.view/id)
+                         (common/tag-of ev :view-id))
+       :subs-read    (or (common/tag-of ev :rf.view/deref-subs)
+                         (common/tag-of ev :rf.view/subs)
+                         (common/tag-of ev :subs-read)
+                         [])
+       :mount?       (common/tag-of ev :rf.view/mount?)
+       :triggered-by (common/tag-of ev :rf.view/triggered-by)
+       :duration-ms  (or (common/tag-of ev :rf.view/elapsed-ms)
+                         (common/tag-of ev :duration-ms))})))
 
 (defn views-step
-  "VIEWS step row. nil when no `:rf.view/render` events fired (the
-  step is OMITTED — conditional)."
+  "VIEWS step row. nil when no view-render events fired (the step is
+  OMITTED — conditional)."
   [events]
   (let [rows (view-rows events)]
     (when (seq rows)

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -57,6 +57,7 @@
             [day8.re-frame2-xray.panels.epoch.badge :as badge]
             [day8.re-frame2-xray.panels.epoch.icons :as icons]
             [day8.re-frame2-xray.panels.epoch.projection :as proj]
+            [day8.re-frame2-xray.views.edn-widget.widget :as edn]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens mono-stack sans-stack]]))
 
@@ -287,34 +288,44 @@
 ;; ---- COEFFECT step -------------------------------------------------------
 
 (defn- coeffect-row-view
-  "Render one COEFFECT row (id link + diff-style add-row) per the bead
-  body's §COEFFECT shape."
-  [{:keys [id value] :as _row} idx]
+  "Render one COEFFECT row (id link + labelled value via edn-inspector)
+  per the bead body's §COEFFECT shape (rf2-cq0ch).
+
+  The injected value renders via the canonical edn-inspector widget —
+  scalars one-line through `edn/inspect-inline`; nested structures get
+  the labelled cofx-id header so the row reads `:rf/now <inst>` /
+  `:session {:user-id 42}` rather than the legacy cryptic
+  `+[]<value>` diff-row.
+
+  Argument order matches `map-indexed`'s `(f idx item)` calling
+  convention; the pre-rf2-cq0ch shape transposed these and silently
+  destructured a number as the row map (`_row` was the index, `idx`
+  the row map — hence the legacy `+[]nil` symptom)."
+  [idx {:keys [id value] :as _row}]
   [:div {:key (str "cofx-" idx)
          :data-testid (str "rf-xray-epoch-coeffect-row-" idx)
-         :style {:padding "3px 0"}}
-   ;; id link
-   [:div {:style {:display "inline-flex"
-                  :align-items "center"
-                  :gap "4px"
-                  :font-family mono-stack
-                  :font-size "12px"
-                  :color (:accent tokens)}}
+         :style {:padding "3px 0"
+                 :display "flex"
+                 :align-items "flex-start"
+                 :gap "8px"
+                 :font-family mono-stack
+                 :font-size "12px"}}
+   ;; id label
+   [:span {:data-testid (str "rf-xray-epoch-coeffect-row-id-" idx)
+           :style {:color (:accent tokens)
+                   :white-space "nowrap"
+                   :display "inline-flex"
+                   :align-items "center"
+                   :gap "4px"}}
     (proj/ns-keyword id)
     (icons/external-link)]
-   ;; diff-style add row
-   [:div {:style {:display      "flex"
-                  :align-items  "flex-start"
-                  :gap          "8px"
-                  :padding      "2px 0 2px 16px"
-                  :font-family  mono-stack
-                  :font-size    "12px"}}
-    [:span {:style {:color (:success tokens) :font-weight 700}} "+"]
-    [:span {:style {:color (:text-tertiary tokens) :white-space "nowrap"}}
-     (str "[" (proj/ns-keyword id) "]")]
-    [:span {:style {:color (:success tokens) :min-width 0 :flex 1
-                    :word-break "break-word"}}
-     (proj/truncate (pr-str value) 100)]]])
+   ;; injected value (labelled — no cryptic `+[]nil` line)
+   [:span {:data-testid (str "rf-xray-epoch-coeffect-row-value-" idx)
+           :style {:color (:text-primary tokens)
+                   :min-width 0
+                   :flex 1
+                   :word-break "break-word"}}
+    (edn/inspect-inline value)]])
 
 (defn render-coeffect-step
   "Render the COEFFECT step (single step with N rows — one per
@@ -559,8 +570,11 @@
 ;; ---- FLOW step -----------------------------------------------------------
 
 (defn- flow-row-view
-  "Render one flow recompute row — id link + diff-style line."
-  [{:keys [flow-id path before after duration-ms]} idx]
+  "Render one flow recompute row — id link + diff-style line.
+
+  Argument order matches `map-indexed`'s `(f idx item)` convention
+  (rf2-cq0ch — companion swap with `coeffect-row-view` / `fx-row-view`)."
+  [idx {:keys [flow-id path before after duration-ms]}]
   [:div {:key (str "flow-" idx)
          :data-testid (str "rf-xray-epoch-flow-row-" idx)
          :style {:padding "3px 0"}}
@@ -614,8 +628,12 @@
 
 (defn- fx-row-view
   "Render one fx-handler row inside the FX step — green check + fx-id
-  + truncated args."
-  [{:keys [fx-id status args duration-ms]} idx]
+  + truncated args.
+
+  Argument order matches `map-indexed`'s `(f idx item)` convention
+  (rf2-cq0ch — companion swap with `coeffect-row-view` /
+  `flow-row-view`)."
+  [idx {:keys [fx-id status args duration-ms]}]
   (let [glyph    (case status
                    :ok          "✓"
                    :overridden  "↺"

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -770,9 +770,33 @@
 
 ;; ---- SUBSCRIPTIONS step --------------------------------------------------
 
+(defn- subscriptions-toggle-button
+  "Render the `Show unchanged` toggle button — flips the
+  `:rf.xray.epoch/subs-show-unchanged?` slot on the Xray app-db.
+  When `show?` is true the label reads `Hide unchanged`."
+  [show? unchanged]
+  (when (pos? unchanged)
+    [:button {:data-testid "rf-xray-epoch-subscriptions-toggle"
+              :aria-pressed (str (boolean show?))
+              :on-click (fn [e]
+                          (.stopPropagation e)
+                          (rf/dispatch
+                            [:rf.xray.epoch/toggle-subs-show-unchanged]
+                            {:frame :rf/xray}))
+              :style {:background  "transparent"
+                      :border      (str "1px solid " (:border-default tokens))
+                      :border-radius "3px"
+                      :color       (:text-secondary tokens)
+                      :cursor      "pointer"
+                      :font-family sans-stack
+                      :font-size   "11px"
+                      :padding     "2px 8px"
+                      :margin-left "8px"}}
+     (if show? "Hide unchanged" "Show unchanged")]))
+
 (defn- subscriptions-table
   "Render the SUBSCRIPTIONS table — 3 columns (sub / inputs / changed).
-  Per the bead body's §SUBSCRIPTIONS (Step 7) shape."
+  Per the bead body's §SUBSCRIPTIONS (Step 7) shape (rf2-kfh1v)."
   [rows]
   [:div {:data-testid "rf-xray-epoch-subscriptions-table"
          :style {:margin-top "5px"
@@ -837,20 +861,40 @@
          [:span {:style {:color (:text-tertiary tokens) :font-weight 700}} "✗"])]])])
 
 (defn render-subscriptions-step
-  "Render the SUBSCRIPTIONS step (only present when subs recomputed)."
-  [{:keys [rows step-number]}]
-  [:div {:data-testid "rf-xray-epoch-step-subscriptions"
-         :data-step-kw "subscriptions"}
-   (numbered-circle step-number :SUBSCRIPTIONS)
-   (step-header
-     {:step :subscriptions
-      :badge :SUBSCRIPTIONS
-      :verb (str (count rows) " sub" (when (not= 1 (count rows)) "s")
-                 " recomputed")
-      :expandable? false
-      :testid "rf-xray-epoch-subscriptions"}
-     nil)
-   (subscriptions-table rows)])
+  "Render the SUBSCRIPTIONS step (only present when subs recomputed).
+
+  Per rf2-kfh1v unchanged-input rows are HIDDEN BY DEFAULT — most
+  subs recompute on a cascade but report no value change, so the
+  noisy `N rows of ✗` legacy display was crowding out the rows the
+  operator actually cares about. A `Show unchanged` toggle reveals
+  the full list; the toggle's state lives in
+  `:rf.xray.epoch/subs-show-unchanged?` on the Xray app-db. Step
+  header shows the split count `N recomputed (M changed, K unchanged)`.
+
+  Mirrors the filter-toggle posture Chrome devtools' network panel
+  uses (the precedent the bead body cites)."
+  [{:keys [rows changed unchanged step-number]}]
+  (let [show-unchanged? @(rf/subscribe [:rf.xray.epoch/subs-show-unchanged?])
+        visible-rows    (if show-unchanged?
+                          rows
+                          (filterv :changed? rows))
+        n               (count rows)
+        m               (or changed (count (filter :changed? rows)))
+        k               (or unchanged (- n m))]
+    [:div {:data-testid "rf-xray-epoch-step-subscriptions"
+           :data-step-kw "subscriptions"}
+     (numbered-circle step-number :SUBSCRIPTIONS)
+     (step-header
+       {:step :subscriptions
+        :badge :SUBSCRIPTIONS
+        :verb [:span {:style {:display "inline-flex" :align-items "center"
+                              :gap "8px" :flex-wrap "wrap"}}
+               (str n " recomputed (" m " changed, " k " unchanged)")
+               (subscriptions-toggle-button show-unchanged? k)]
+        :expandable? false
+        :testid "rf-xray-epoch-subscriptions"}
+       nil)
+     (subscriptions-table visible-rows)]))
 
 ;; ---- VIEWS step ----------------------------------------------------------
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -854,9 +854,25 @@
 
 ;; ---- VIEWS step ----------------------------------------------------------
 
+(defn- view-coord
+  "Pull the registered view's source coord off
+  `(rf/handler-meta :view view-id)`. Returns nil when no meta is
+  captured. Matches the reactive panel's resolver shape."
+  [view-id]
+  (when (some? view-id)
+    (let [m (try (rf/handler-meta :view view-id) (catch :default _ nil))]
+      (when (and m (string? (:file m)))
+        {:file (:file m) :line (:line m) :ns (:ns m)}))))
+
 (defn- views-table
   "Render the VIEWS table — 2 columns (views / subs). Per the bead
-  body's §VIEWS (Step 8) shape."
+  body's §VIEWS (Step 8) shape (rf2-6djth).
+
+  Each row carries:
+    - view-id (hyperlinked via the registrar's `:view` meta coord)
+    - duration (when stamped, rendered as a muted chip below the id)
+    - the subs the view dereffed during this render (one per line —
+      vectors via `pr-str`, scalars via `ns-keyword`)."
   [rows]
   [:div {:data-testid "rf-xray-epoch-views-table"
          :style {:margin-top "5px"
@@ -878,6 +894,7 @@
    (for [[i {:keys [view-id subs-read duration-ms]}] (map-indexed vector rows)]
      [:div {:key (str "view-" i)
             :data-testid (str "rf-xray-epoch-view-row-" i)
+            :data-view-id (when view-id (pr-str view-id))
             :style {:display "flex"
                     :align-items "stretch"
                     :border-bottom (when (< i (dec (count rows)))
@@ -885,28 +902,35 @@
       [:div {:style {:flex "1 1 50%" :padding "5px 8px" :min-width 0
                      :font-family mono-stack :font-size "12px"
                      :word-break "break-word"}}
-       [:span {:style {:color (:accent tokens) :display "inline-flex"
+       [:span {:data-testid (str "rf-xray-epoch-view-row-id-" i)
+               :style {:color (:accent tokens) :display "inline-flex"
                        :align-items "center" :gap "4px"}}
-        (proj/ns-keyword view-id)
-        (icons/external-link)]
+        (if (some? view-id)
+          (proj/ns-keyword view-id)
+          [:span {:style {:color (:text-tertiary tokens)
+                          :font-style "italic"}}
+           "<anonymous view>"])
+        (coord-chip (view-coord view-id)
+                    (str "rf-xray-epoch-view-row-coord-" i))]
        (when (number? duration-ms)
          [:span {:style {:color (:text-tertiary tokens)
                          :margin-left "8px"
                          :font-size "10px"}}
           (proj/format-duration-ms duration-ms)])]
-      [:div {:style {:flex "1 1 50%" :padding "5px 8px" :min-width 0
+      [:div {:data-testid (str "rf-xray-epoch-view-row-subs-" i)
+             :style {:flex "1 1 50%" :padding "5px 8px" :min-width 0
                      :font-family mono-stack :font-size "12px"
                      :color (:text-tertiary tokens)
                      :word-break "break-word"}}
        (cond
-         (sequential? subs-read)
+         (and (sequential? subs-read) (seq subs-read))
          (into [:div {:style {:display "flex" :flex-direction "column" :gap "2px"}}]
                (for [s subs-read]
                  [:div (if (vector? s) (pr-str s) (proj/ns-keyword s))]))
          (some? subs-read)
          (proj/ns-keyword subs-read)
          :else
-         "(none)")]])])
+         [:span {:style {:font-style "italic"}} "(none)"])]])])
 
 (defn render-views-step
   "Render the VIEWS step (only present when views re-rendered)."

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -241,53 +241,43 @@
 ;; ---- DISPATCH step -------------------------------------------------------
 
 (defn dispatch-body
-  "Render the DISPATCH step's expanded body — the event vector + the
-  source pill. Per the bead body's §DISPATCH (Step 1).
+  "Render the DISPATCH step's expanded body — the event vector as a
+  boxed monospace block. Per the bead body's §DISPATCH (Step 1).
 
-  Target line (event vector) is rendered as a boxed monospace block;
-  the FROM row carries an inline click-to-source link with the
-  external-link chip when a call-site coord was captured."
-  [{:keys [event source coord]}]
-  [:div
-   ;; Target — the dispatched event vector.
-   [:div {:data-testid "rf-xray-epoch-dispatch-event"
-          :style {:font-family   mono-stack
-                  :font-size     "12px"
-                  :color         (:text-primary tokens)
-                  :background    (:bg-3 tokens)
-                  :border        (str "1px solid " (:border-subtle tokens))
-                  :border-radius "3px"
-                  :padding       "5px 8px"
-                  :margin-top    "5px"
-                  :overflow-x    "auto"}}
-    (proj/event-display event)]
-   ;; FROM <source>
-   (when source
-     [:div {:data-testid "rf-xray-epoch-dispatch-source"
-            :style {:display      "flex"
-                    :align-items  "center"
-                    :gap          "4px"
-                    :margin-top   "5px"
-                    :font-family  sans-stack
-                    :font-size    "11px"
-                    :color        (:text-tertiary tokens)}}
-      "from "
-      [:span {:style {:color (:accent tokens) :font-family mono-stack}}
-       (name source)]
-      (coord-chip coord "rf-xray-epoch-dispatch-coord")])])
+  Per rf2-9jvx1 the body no longer repeats the `from <source>` line —
+  the header already carries that descriptor; the body is detail-only.
+  The click-to-source affordance rides on the header (rf2-93a7s)."
+  [{:keys [event]}]
+  (when (vector? event)
+    [:div {:data-testid "rf-xray-epoch-dispatch-event"
+           :style {:font-family   mono-stack
+                   :font-size     "12px"
+                   :color         (:text-primary tokens)
+                   :background    (:bg-3 tokens)
+                   :border        (str "1px solid " (:border-subtle tokens))
+                   :border-radius "3px"
+                   :padding       "5px 8px"
+                   :margin-top    "5px"
+                   :overflow-x    "auto"}}
+     (proj/event-display event)]))
 
 (defn render-dispatch-step
-  "Render the DISPATCH step (always present)."
-  [{:keys [source duration-ms step-number] :as step}]
+  "Render the DISPATCH step (always present). Header summarises `from
+  <source>` with the call-site chip when a coord was captured;
+  body renders the dispatched event vector as a boxed monospace
+  block (rf2-93a7s · rf2-9jvx1)."
+  [{:keys [source coord duration-ms step-number] :as step}]
   [:div {:data-testid "rf-xray-epoch-step-dispatch"
          :data-step-kw "dispatch"}
    (numbered-circle step-number :DISPATCH)
    (step-header
      {:step :dispatch
       :badge :DISPATCH
-      :verb [:span "from "
+      :verb [:span {:style {:display "inline-flex" :align-items "center" :gap "4px"}}
+             "from "
              [:span {:style {:color (:accent tokens)}}
-              (if source (name source) "unknown")]]
+              (if source (name source) "unknown")]
+             (coord-chip coord "rf-xray-epoch-dispatch-coord")]
       :expandable? false
       :testid "rf-xray-epoch-dispatch"
       :duration-ms duration-ms}
@@ -516,24 +506,14 @@
           (proj/timer-reason-label reason)]])])])
 
 (defn handler-body
-  "Render the HANDLER step's body — flavour label + db-diff + fx + the
-  machine block when the handler is a machine-event-handler."
-  [{:keys [flavour event-id db-diff fx machine] :as _row}]
+  "Render the HANDLER step's body — db-diff + fx + the machine block
+  when the handler is a machine-event-handler.
+
+  Per rf2-9jvx1 the flavour + event-id row is dropped from the body —
+  the header already carries that descriptor. The body is detail-only:
+  db-diff, fx entries, machine extras."
+  [{:keys [db-diff fx machine] :as _row}]
   [:div {:data-testid "rf-xray-epoch-handler-body"}
-   ;; Flavour + event-id
-   [:div {:style {:display      "flex"
-                  :align-items  "center"
-                  :gap          "6px"
-                  :margin-top   "5px"
-                  :font-family  mono-stack
-                  :font-size    "12px"
-                  :color        (:text-primary tokens)}}
-    [:span {:style {:color (:accent tokens)}}
-     (proj/handler-flavour-label flavour)]
-    (icons/external-link)
-    (when event-id
-      [:span {:style {:color (:text-tertiary tokens)}}
-       (proj/ns-keyword event-id)])]
    ;; Machine extras BEFORE db diff (lifecycle is the story for machines)
    (when machine
      (machine-block machine))

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -516,15 +516,98 @@
                          :margin-left "8px"}}
           (proj/timer-reason-label reason)]])])])
 
+;; ---- handler source --------------------------------------------------
+;;
+;; Per rf2-66wis the HANDLER body carries the registered handler's
+;; source code as a syntax-highlighted block under the header — same
+;; widget as the Event panel uses (rf2-n4ad0 routed to `edn/code-block`
+;; with the same per-token palette as the Figma authority's
+;; `.syntax-*` classes, rf2-93jp0). The substrate stamps source under
+;; the `:rf.handler/source` meta key (Spec 009 / rf2-xgfuy) via a
+;; DEBUG-gated macro; production goog.DEBUG=false builds carry no
+;; source, so the slot renders a clear placeholder rather than
+;; collapsing silently.
+;;
+;; For machine handlers the "source" is the machine spec — read via
+;; `rf/handler-meta :machine event-id`. The spec renders through the
+;; same `edn/inspect` widget every other top-level EDN map uses.
+
+(defn- handler-source-string
+  "Return the registered event-handler's source string from the
+  `:rf.handler/source` meta key, or nil when the substrate hasn't
+  captured one (production builds, registrations that pre-date the
+  coord-annotation pass)."
+  [meta]
+  (let [s (:rf.handler/source meta)]
+    (when (and (string? s) (seq s))
+      s)))
+
+(defn- machine-spec-value
+  "Return the registered machine handler's spec data. Read off the
+  `:machine-spec` slot (the substrate stashes the original
+  `(reg-machine id spec ...)` argument here) so the panel can render
+  it via the canonical edn-inspector."
+  [meta]
+  (or (:machine-spec meta)
+      (:spec meta)
+      (:rf.machine/spec meta)))
+
+(defn- handler-source-block
+  "Render the source-code block under the HANDLER header. Three
+  cases:
+
+    1. Machine handler — render the machine spec via the canonical
+       `edn/inspect` widget.
+    2. Event handler with a captured source string — render via
+       `edn/code-block` (clojure-syntax highlight).
+    3. Otherwise — render a clear `<source not yet captured>`
+       placeholder so the slot is always present (operator learns
+       where to look + when the substrate didn't stamp)."
+  [flavour event-id]
+  (let [machine? (= :reg-machine flavour)
+        meta     (when (some? event-id)
+                   (try (rf/handler-meta (if machine? :machine :event) event-id)
+                        (catch :default _ nil)))
+        spec     (when machine? (machine-spec-value meta))
+        src      (when-not machine? (handler-source-string meta))]
+    [:div {:data-testid "rf-xray-epoch-handler-source"
+           :style {:margin-top "8px"
+                   :min-width  "0"}}
+     (sub-header (if machine? "machine spec" "source"))
+     (cond
+       (and machine? (some? spec))
+       [:div {:data-testid "rf-xray-epoch-handler-source-spec"
+              :style {:padding-left "16px"}}
+        (edn/inspect spec)]
+
+       src
+       (edn/code-block
+         {:source src
+          :lang   :clojure
+          :testid "rf-xray-epoch-handler-source-body"})
+
+       :else
+       [:span {:data-testid "rf-xray-epoch-handler-source-placeholder"
+               :style {:font-style "italic"
+                       :font-family mono-stack
+                       :font-size   "11px"
+                       :color       (:text-tertiary tokens)
+                       :padding-left "16px"}}
+        "<source not yet captured>"])]))
+
 (defn handler-body
-  "Render the HANDLER step's body — db-diff + fx + the machine block
-  when the handler is a machine-event-handler.
+  "Render the HANDLER step's body — source block + db-diff + fx + the
+  machine block when the handler is a machine-event-handler.
 
   Per rf2-9jvx1 the flavour + event-id row is dropped from the body —
-  the header already carries that descriptor. The body is detail-only:
-  db-diff, fx entries, machine extras."
-  [{:keys [db-diff fx machine] :as _row}]
+  the header already carries that descriptor. Per rf2-66wis the body
+  now leads with the handler's source code (or machine spec) so the
+  operator can answer 'why did this handler do X' without leaving the
+  panel."
+  [{:keys [flavour event-id db-diff fx machine] :as _row}]
   [:div {:data-testid "rf-xray-epoch-handler-body"}
+   ;; Source / machine spec block — rf2-66wis
+   (handler-source-block flavour event-id)
    ;; Machine extras BEFORE db diff (lifecycle is the story for machines)
    (when machine
      (machine-block machine))

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch_panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch_panel.cljs
@@ -128,6 +128,22 @@
     (fn [db _event]
       (dissoc db :epoch-panel-expanded-rows)))
 
+  ;; ---- SUBSCRIPTIONS show-unchanged toggle (rf2-kfh1v) -----------------
+  ;;
+  ;; Per the bead body the SUBSCRIPTIONS step hides unchanged-input rows
+  ;; by default — N rows of mostly-unchanged subs is noisy. The operator
+  ;; opts in to see all rows via this flag (mirrors Chrome devtools'
+  ;; network panel's filter toggle). Slot lives on the Xray app-db so the
+  ;; preference survives focus shifts.
+
+  (rf/reg-sub :rf.xray.epoch/subs-show-unchanged?
+    (fn [db _query]
+      (boolean (get db :epoch-panel-subs-show-unchanged?))))
+
+  (rf/reg-event-db :rf.xray.epoch/toggle-subs-show-unchanged
+    (fn [db _event]
+      (update db :epoch-panel-subs-show-unchanged? not)))
+
   ;; ---- L4 tab registration ----------------------------------------------
   ;;
   ;; The Epoch tab lands between Machines (order 4) and Routing

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -93,9 +93,17 @@
                            :rf.sub/after after}))
 
 (defn- view-render-ev
-  [view-id subs-read]
-  (ev :rf.view :rf.view/render {:rf.view/id view-id
-                                :rf.view/subs subs-read}))
+  ([view-id subs-read]
+   (view-render-ev view-id subs-read nil))
+  ([view-id subs-read elapsed-ms]
+   ;; Per rf2-6djth the substrate stamps the rich per-render marker as
+   ;; `:rf.view/rendered` (not `:rf.view/render`) with `:rf.view/id` +
+   ;; `:rf.view/deref-subs`. Fixture mirrors substrate shape.
+   (ev :rf.view :rf.view/rendered
+       (cond-> {:rf.view/id          view-id
+                :rf.view/deref-subs  subs-read}
+         (some? elapsed-ms)
+         (assoc :rf.view/elapsed-ms elapsed-ms)))))
 
 (defn- machine-transition-ev
   [machine-id before after]
@@ -313,6 +321,22 @@
       (is (= :VIEWS (:badge s)))
       (is (= 1 (count (:rows s))))
       (is (= ::counter-view (-> s :rows first :view-id))))))
+
+(deftest views-step-reads-rich-rendered-marker-test
+  (testing "rf2-6djth — projection reads the substrate's rich
+            `:rf.view/rendered` marker (carries `:rf.view/id`,
+            `:rf.view/deref-subs`, `:rf.view/elapsed-ms`). The
+            previously-read `:rf.view/render` marker only carried
+            `:rf.view/render-key` — read against it the row had nil
+            view-id + empty subs-read"
+    (let [s   (proj/views-step
+                [(view-render-ev :app.counter/Counter
+                                 [[:counter/total] [:counter/threshold]]
+                                 1.2)])
+          row (-> s :rows first)]
+      (is (= :app.counter/Counter (:view-id row)))
+      (is (= [[:counter/total] [:counter/threshold]] (:subs-read row)))
+      (is (= 1.2 (:duration-ms row))))))
 
 ;; ---- top-level project --------------------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -173,6 +173,29 @@
   (testing "no cofx events + no run-end stamp returns empty vec"
     (is (= [] (proj/coeffect-rows [])))))
 
+(deftest coeffect-rows-skip-system-cofx-test
+  (testing "rf2-cq0ch — system-injected defaults (:db / :event / :frame /
+            :source / :trace-id) are filtered out at projection time"
+    (let [evs  (concat (mapv #(cofx-run-ev % nil) [:db :event :frame :source :trace-id])
+                       [(cofx-run-ev :session {:user-id 42})])
+          rows (proj/coeffect-rows evs)]
+      (is (= 1 (count rows)) "only the user-defined :session row survives")
+      (is (= :session (-> rows first :id)))))
+
+  (testing "rf2-cq0ch — fallback path also filters system defaults"
+    (let [evs  [(run-end-ev 0.1 {:db {} :event [:x] :session {:user-id 7}})]
+          rows (proj/coeffect-rows evs)]
+      (is (= 1 (count rows)))
+      (is (= :session (-> rows first :id)))))
+
+  (testing "rf2-cq0ch — pure reg-event-db (only system cofx) emits NO step"
+    (let [rec   (record [(dispatched-ev [:counter/inc] :ui nil)
+                         (cofx-run-ev :db nil)
+                         (db-changed-ev [[[:counter] 5 6 :modified]])])
+          steps (proj/project rec)]
+      (is (not-any? #(= :coeffect (:step %)) steps)
+          "no COEFFECT step is emitted when every cofx is system-injected"))))
+
 ;; ---- HANDLER -------------------------------------------------------------
 
 (deftest handler-row-reg-event-db-test

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -150,6 +150,21 @@
   (testing "no dispatched + no fallback returns nil"
     (is (nil? (proj/dispatch-row [] nil)))))
 
+(deftest dispatch-row-reads-canonical-event-v-tag-test
+  (testing "rf2-93a7s — the dispatched trace stamps the event vector at
+            the substrate-canonical `:rf.event/v` tag; the projection
+            must read that tag (the pre-rf2-93a7s read against `:event`
+            silently returned nil — DISPATCH step appeared without its
+            event-vector body)"
+    (let [ev {:op-type   :rf.event
+              :operation :rf.event/dispatched
+              :tags      {:rf.event/v [:counter/inc 7]
+                          :source     :ui}}
+          r  (proj/dispatch-row [ev] nil)]
+      (is (= [:counter/inc 7] (:event r))
+          "event vector resolves through :rf.event/v")
+      (is (= :ui (:source r))))))
+
 ;; ---- COEFFECT ------------------------------------------------------------
 
 (deftest coeffect-rows-granular-test

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -87,10 +87,15 @@
 
 (defn- sub-run-ev
   [sub-vec changed? before after]
-  (ev :rf.sub :rf.sub/run {:rf.sub/query sub-vec
-                           :rf.sub/changed? changed?
-                           :rf.sub/before before
-                           :rf.sub/after after}))
+  ;; Per rf2-kfh1v the substrate stamps `:rf.sub/id`, `:rf.sub/query-v`,
+  ;; `:rf.sub/value-changed?`, `:rf.sub/prev-value`, `:rf.sub/value` —
+  ;; NOT the legacy `:rf.sub/query` / `:rf.sub/changed?` / `:rf.sub/before`
+  ;; the projection used to read. Fixture mirrors substrate shape.
+  (ev :rf.sub :rf.sub/run {:rf.sub/id             (when (vector? sub-vec) (first sub-vec))
+                           :rf.sub/query-v        sub-vec
+                           :rf.sub/value-changed? changed?
+                           :rf.sub/prev-value     before
+                           :rf.sub/value          after}))
 
 (defn- view-render-ev
   ([view-id subs-read]
@@ -308,6 +313,35 @@
       (is (= 2 (count (:rows s))))
       (is (true? (-> s :rows first :changed?)))
       (is (false? (-> s :rows second :changed?))))))
+
+(deftest subscriptions-row-reads-canonical-substrate-tags-test
+  (testing "rf2-kfh1v — projection reads the substrate's canonical
+            `:rf.sub/id`, `:rf.sub/query-v`, `:rf.sub/value-changed?`,
+            `:rf.sub/prev-value`, `:rf.sub/value` tags (NOT the legacy
+            `:rf.sub/changed?` / `:rf.sub/before` / `:rf.sub/after`
+            shape the pre-rf2-kfh1v projection read against)"
+    (let [s (proj/subscriptions-step [(sub-run-ev [:counter/total] true 5 6)])
+          row (-> s :rows first)]
+      (is (= :counter/total (:sub-id row))
+          "sub-id is read from `:rf.sub/id`")
+      (is (= [:counter/total] (:sub-vec row))
+          "sub-vec is read from `:rf.sub/query-v`")
+      (is (true? (:changed? row))
+          "changed? is read from `:rf.sub/value-changed?`")
+      (is (= 5 (:before row))
+          "before is read from `:rf.sub/prev-value`")
+      (is (= 6 (:after row))
+          "after is read from `:rf.sub/value`"))))
+
+(deftest subscriptions-step-counts-changed-vs-unchanged-test
+  (testing "rf2-kfh1v — step header carries `changed` + `unchanged`
+            counts so the view can render `N recomputed (M changed,
+            K unchanged)` without re-walking the rows"
+    (let [s (proj/subscriptions-step [(sub-run-ev [:a] true 1 2)
+                                      (sub-run-ev [:b] false :x :x)
+                                      (sub-run-ev [:c] false :y :y)])]
+      (is (= 1 (:changed s)))
+      (is (= 2 (:unchanged s))))))
 
 ;; ---- VIEWS --------------------------------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -130,6 +130,39 @@
             (or (text-of tree "rf-xray-epoch-handler-source-placeholder") "")
             "<source not yet captured>")))))
 
+;; ---- rf2-6djth — VIEWS row carries view-id + subs ---------------------
+
+(deftest views-row-shows-id-and-subs-test
+  (testing "rf2-6djth — VIEWS table row shows the view-id + its
+            consumed subs. Per-row testids are stable and the body
+            text contains both halves."
+    (let [step {:step :views :badge :VIEWS :step-number 6
+                :rows [{:view-id :app.counter/Counter
+                        :subs-read [[:counter/total] [:counter/threshold]]
+                        :duration-ms 1.2}]}
+          tree (view/render-views-step step)
+          row  (th/find-by-testid tree "rf-xray-epoch-view-row-0")
+          id   (text-of tree "rf-xray-epoch-view-row-id-0")
+          subs (text-of tree "rf-xray-epoch-view-row-subs-0")]
+      (is (some? row) "the view row renders")
+      (is (string/includes? id ":app.counter/Counter")
+          "view-id is the leading element")
+      (is (string/includes? subs ":counter/total")
+          "consumed subs appear in the subs cell")
+      (is (string/includes? subs ":counter/threshold")
+          "every consumed sub renders, one per line"))))
+
+(deftest views-row-graceful-degrades-when-id-absent-test
+  (testing "rf2-6djth — a row whose view-id is nil renders an
+            anonymous-view placeholder rather than the bare keyword
+            colon"
+    (let [step {:step :views :badge :VIEWS :step-number 6
+                :rows [{:view-id nil :subs-read [] :duration-ms nil}]}
+          tree (view/render-views-step step)
+          id   (text-of tree "rf-xray-epoch-view-row-id-0")]
+      (is (string/includes? id "<anonymous view>")
+          "missing view-id reads as `<anonymous view>` placeholder"))))
+
 (deftest handler-body-renders-captured-source-test
   (testing "rf2-66wis — when the registrar carries an
             `:rf.handler/source`, the body renders it via the

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -7,6 +7,7 @@
   every step body."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [clojure.string :as string]
+            [re-frame.core :as rf]
             [re-frame.test-helpers :as th]
             [re-frame.test-support :as test-support]
             [re-frame.substrate.plain-atom :as plain-atom]
@@ -43,18 +44,29 @@
         (is (string/includes? header-text "ui"))))))
 
 (deftest handler-flavour-renders-once-test
-  (testing "rf2-9jvx1 — HANDLER header carries the flavour + event-id;
-            the body MUST NOT also render the same flavour pill"
+  (testing "rf2-9jvx1 — HANDLER header carries the flavour + event-id
+            once; the body's pre-rf2-9jvx1 stand-alone flavour row is
+            removed. Body's first slot is the source block (rf2-66wis),
+            not a flavour pill."
     (let [step {:step :handler :badge :HANDLER :step-number 3
-                :flavour :reg-event-db :event-id :counter/inc
+                :flavour :reg-event-db :event-id :no-such/handler
                 :db-diff [] :fx [] :machine nil}
           tree (view/render-handler-step step)
-          header-text (text-of tree "rf-xray-epoch-handler-header")
-          body-text   (text-of tree "rf-xray-epoch-handler-body")]
+          header-text (text-of tree "rf-xray-epoch-handler-header")]
       (is (string/includes? header-text "reg-event-db"))
-      (is (string/includes? header-text ":counter/inc"))
-      (is (not (string/includes? (or body-text "") "reg-event-db"))
-          "body MUST NOT duplicate the flavour pill"))))
+      (is (string/includes? header-text ":no-such/handler"))
+      ;; The body's first slot is now the source block — never a
+      ;; duplicate flavour pill.
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-handler-source"))
+          "the body leads with the source block (rf2-66wis)")
+      ;; Confirm the body never carries a redundant flavour-only span.
+      ;; The body text for an unknown handler resolves to the
+      ;; placeholder; it MUST NOT contain the bare flavour keyword.
+      (is (not (string/includes?
+                 (or (text-of tree "rf-xray-epoch-handler-source-placeholder")
+                     "")
+                 "reg-event-db"))
+          "the source-placeholder slot MUST NOT echo the flavour pill"))))
 
 ;; ---- rf2-93a7s — DISPATCH body shows the event vector ----------------
 
@@ -97,3 +109,41 @@
         (is (string/includes? r0-id ":session"))
         (is (string/includes? r0-value "42"))
         (is (string/includes? r1-id ":rf/now"))))))
+
+;; ---- rf2-66wis — HANDLER source code block ---------------------------
+
+(deftest handler-body-renders-source-placeholder-test
+  (testing "rf2-66wis — HANDLER body carries a source-code slot.
+            When no handler-meta has been stamped the slot renders
+            a clear `<source not yet captured>` placeholder rather
+            than collapsing silently — operator learns where to
+            look and when the substrate hasn't captured."
+    (let [step {:step :handler :badge :HANDLER :step-number 3
+                :flavour :reg-event-db :event-id :no-such/handler
+                :db-diff [] :fx [] :machine nil}
+          tree (view/render-handler-step step)]
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-handler-source"))
+          "the source slot is present even on graceful-degrade")
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-handler-source-placeholder"))
+          "no-source state renders the placeholder")
+      (is (string/includes?
+            (or (text-of tree "rf-xray-epoch-handler-source-placeholder") "")
+            "<source not yet captured>")))))
+
+(deftest handler-body-renders-captured-source-test
+  (testing "rf2-66wis — when the registrar carries an
+            `:rf.handler/source`, the body renders it via the
+            canonical `edn/code-block` widget"
+    (rf/with-frame :rf/default
+      (rf/reg-event-db :rf.test.epoch.view/srctest-handler
+                       {:rf.handler/source "(reg-event-db :rf.test.epoch.view/srctest-handler\n  (fn [db _] (assoc db :ok true)))"}
+                       (fn [db _] db))
+      (let [step {:step :handler :badge :HANDLER :step-number 3
+                  :flavour :reg-event-db
+                  :event-id :rf.test.epoch.view/srctest-handler
+                  :db-diff [] :fx [] :machine nil}
+            tree (view/render-handler-step step)]
+        (is (some? (th/find-by-testid tree "rf-xray-epoch-handler-source-body"))
+            "the code-block widget mounts under the source slot")
+        (is (nil? (th/find-by-testid tree "rf-xray-epoch-handler-source-placeholder"))
+            "no placeholder when source IS captured")))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -1,0 +1,57 @@
+(ns day8.re-frame2-xray.panels.epoch.view-cljs-test
+  "View-layer tests for the Epoch panel cascade (rf2-sc3r1 follow-ons).
+
+  Pure hiccup tests — each render-fn is exercised against a synthesised
+  step row and walked via the framework's hiccup walker. No DOM mount;
+  no substrate spin. Anchored on `data-testid`s the view stamps onto
+  every step body."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [clojure.string :as string]
+            [re-frame.test-helpers :as th]
+            [re-frame.test-support :as test-support]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [day8.re-frame2-xray.test-support :as xray-test-support]
+            [day8.re-frame2-xray.panels.epoch.view :as view]))
+
+;; ---- fixtures -----------------------------------------------------------
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn xray-test-support/reset-all!}))
+
+;; ---- helpers -----------------------------------------------------------
+
+(defn- text-of
+  [tree testid]
+  (some-> tree (th/find-by-testid testid) th/text-content))
+
+;; ---- rf2-9jvx1 — text-duplication audit --------------------------------
+
+(deftest dispatch-source-renders-once-test
+  (testing "rf2-9jvx1 — DISPATCH header carries `from <source>` once;
+            the body does NOT also render a `from` line"
+    (let [tree (view/render-dispatch-step
+                 {:step :dispatch :badge :DISPATCH :step-number 1
+                  :event [:counter/inc] :source :ui :coord nil})]
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-dispatch-event"))
+          "dispatch event vector renders in the body")
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-dispatch-source"))
+          "the body MUST NOT carry a duplicate `from <source>` row")
+      (let [header-text (text-of tree "rf-xray-epoch-dispatch-header")]
+        (is (string/includes? header-text "from"))
+        (is (string/includes? header-text "ui"))))))
+
+(deftest handler-flavour-renders-once-test
+  (testing "rf2-9jvx1 — HANDLER header carries the flavour + event-id;
+            the body MUST NOT also render the same flavour pill"
+    (let [step {:step :handler :badge :HANDLER :step-number 3
+                :flavour :reg-event-db :event-id :counter/inc
+                :db-diff [] :fx [] :machine nil}
+          tree (view/render-handler-step step)
+          header-text (text-of tree "rf-xray-epoch-handler-header")
+          body-text   (text-of tree "rf-xray-epoch-handler-body")]
+      (is (string/includes? header-text "reg-event-db"))
+      (is (string/includes? header-text ":counter/inc"))
+      (is (not (string/includes? (or body-text "") "reg-event-db"))
+          "body MUST NOT duplicate the flavour pill"))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -8,11 +8,14 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [clojure.string :as string]
             [re-frame.core :as rf]
+            [re-frame.frame :as frame]
             [re-frame.test-helpers :as th]
             [re-frame.test-support :as test-support]
             [re-frame.substrate.plain-atom :as plain-atom]
+            [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]
-            [day8.re-frame2-xray.panels.epoch.view :as view]))
+            [day8.re-frame2-xray.panels.epoch.view :as view]
+            [day8.re-frame2-xray.panels.epoch-panel :as epoch-orchestrator]))
 
 ;; ---- fixtures -----------------------------------------------------------
 
@@ -109,6 +112,73 @@
         (is (string/includes? r0-id ":session"))
         (is (string/includes? r0-value "42"))
         (is (string/includes? r1-id ":rf/now"))))))
+
+;; ---- rf2-kfh1v — SUBSCRIPTIONS rows + filter -------------------------
+
+(defn- count-prefix
+  [tree prefix]
+  (count (th/find-by-testid-prefix tree prefix)))
+
+(deftest sub-row-renders-sub-id-test
+  (testing "rf2-kfh1v — SUBSCRIPTIONS row leads with the sub-id /
+            sub-vec (operator can tell WHICH sub recomputed)"
+    (epoch-orchestrator/install!)
+    (frame/reg-frame :rf/xray {})
+    (rf/with-frame :rf/xray
+      (let [step {:step :subscriptions :badge :SUBSCRIPTIONS :step-number 5
+                  :rows [{:sub-id :counter/total :sub-vec [:counter/total]
+                          :inputs nil :changed? true :before 5 :after 6}]
+                  :changed 1 :unchanged 0}
+            tree (view/render-subscriptions-step step)
+            row  (th/find-by-testid tree "rf-xray-epoch-sub-row-0")]
+        (is (some? row) "the sub row renders")
+        (let [txt (th/text-content row)]
+          (is (string/includes? txt ":counter/total")
+              "sub-id is visible as the leading element"))))))
+
+(deftest sub-rows-hide-unchanged-by-default-test
+  (testing "rf2-kfh1v — unchanged rows are hidden by default;
+            a toggle reveals the full list"
+    (epoch-orchestrator/install!)
+    (frame/reg-frame :rf/xray {})
+    (rf/with-frame :rf/xray
+      (let [step {:step :subscriptions :badge :SUBSCRIPTIONS :step-number 5
+                  :rows [{:sub-id :a :sub-vec [:a] :changed? true :before 1 :after 2}
+                         {:sub-id :b :sub-vec [:b] :changed? false}
+                         {:sub-id :c :sub-vec [:c] :changed? false}]
+                  :changed 1 :unchanged 2}
+            tree (view/render-subscriptions-step step)]
+        (is (= 1 (count-prefix tree "rf-xray-epoch-sub-row-"))
+            "only the one changed row renders by default")
+        (let [header (text-of tree "rf-xray-epoch-subscriptions-header")]
+          (is (string/includes? header "1 changed")
+              "header shows the changed count")
+          (is (string/includes? header "2 unchanged")
+              "header shows the unchanged count")
+          (is (some? (th/find-by-testid
+                       tree "rf-xray-epoch-subscriptions-toggle"))
+              "the Show unchanged toggle is present when unchanged > 0"))))))
+
+(deftest sub-rows-reveal-after-toggle-test
+  (testing "rf2-kfh1v — toggling the show-unchanged flag reveals all
+            rows; toggling back hides them again"
+    (epoch-orchestrator/install!)
+    (frame/reg-frame :rf/xray {})
+    (rf/with-frame :rf/xray
+      (let [step {:step :subscriptions :badge :SUBSCRIPTIONS :step-number 5
+                  :rows [{:sub-id :a :sub-vec [:a] :changed? true :before 1 :after 2}
+                         {:sub-id :b :sub-vec [:b] :changed? false}]
+                  :changed 1 :unchanged 1}]
+        ;; flip the slot on
+        (rf/dispatch-sync [:rf.xray.epoch/toggle-subs-show-unchanged])
+        (let [tree (view/render-subscriptions-step step)]
+          (is (= 2 (count-prefix tree "rf-xray-epoch-sub-row-"))
+              "both rows render after toggle"))
+        ;; flip back off
+        (rf/dispatch-sync [:rf.xray.epoch/toggle-subs-show-unchanged])
+        (let [tree (view/render-subscriptions-step step)]
+          (is (= 1 (count-prefix tree "rf-xray-epoch-sub-row-"))
+              "unchanged hidden again after second toggle"))))))
 
 ;; ---- rf2-66wis — HANDLER source code block ---------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -55,3 +55,22 @@
       (is (string/includes? header-text ":counter/inc"))
       (is (not (string/includes? (or body-text "") "reg-event-db"))
           "body MUST NOT duplicate the flavour pill"))))
+
+;; ---- rf2-cq0ch — COEFFECT body --------------------------------------
+
+(deftest coeffect-body-renders-labelled-value-test
+  (testing "rf2-cq0ch — each user-injected cofx renders the id +
+            value via the canonical edn-inspector. No cryptic
+            `+[]nil` line."
+    (let [step {:step :coeffect :badge :COEFFECT :step-number 2
+                :rows [{:id :session :value {:user-id 42}}
+                       {:id :rf/now :value "2026-05-26T00:00:00"}]}
+          tree (view/render-coeffect-step step)]
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-coeffect-row-0")))
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-coeffect-row-1")))
+      (let [r0-id    (text-of tree "rf-xray-epoch-coeffect-row-id-0")
+            r0-value (text-of tree "rf-xray-epoch-coeffect-row-value-0")
+            r1-id    (text-of tree "rf-xray-epoch-coeffect-row-id-1")]
+        (is (string/includes? r0-id ":session"))
+        (is (string/includes? r0-value "42"))
+        (is (string/includes? r1-id ":rf/now"))))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -56,6 +56,29 @@
       (is (not (string/includes? (or body-text "") "reg-event-db"))
           "body MUST NOT duplicate the flavour pill"))))
 
+;; ---- rf2-93a7s — DISPATCH body shows the event vector ----------------
+
+(deftest dispatch-body-shows-event-vector-test
+  (testing "rf2-93a7s — DISPATCH body renders the dispatched event vector"
+    (let [tree (view/render-dispatch-step
+                 {:step :dispatch :badge :DISPATCH :step-number 1
+                  :event [:counter/inc 7] :source :ui :coord nil})
+          body (th/find-by-testid tree "rf-xray-epoch-dispatch-event")]
+      (is (some? body) "the body's event-vector slot is present")
+      (is (string/includes? (th/text-content body) ":counter/inc")
+          "event-id is visible in the body")
+      (is (string/includes? (th/text-content body) "7")
+          "the event args are visible too"))))
+
+(deftest dispatch-body-omits-event-when-absent-test
+  (testing "rf2-93a7s — empty event yields no event-vector slot
+            (graceful-degrade rather than rendering `[]` noise)"
+    (let [tree (view/render-dispatch-step
+                 {:step :dispatch :badge :DISPATCH :step-number 1
+                  :event nil :source :ui :coord nil})]
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-dispatch-event"))
+          "no body row when no event vector was captured"))))
+
 ;; ---- rf2-cq0ch — COEFFECT body --------------------------------------
 
 (deftest coeffect-body-renders-labelled-value-test

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -158,6 +158,8 @@
    ;; rows) + per-row expansion-set sub.
    :rf.xray/epoch-pipeline
    :rf.xray.epoch/expanded-rows
+   ;; rf2-kfh1v — Epoch panel SUBSCRIPTIONS show-unchanged flag.
+   :rf.xray.epoch/subs-show-unchanged?
    :rf.xray/event-detail
    :rf.xray/filtered-cascades
    ;; rf2-jvghz — model behind the L2 'N hidden by filters' indicator
@@ -444,6 +446,8 @@
    ;; rf2-sc3r1 — Epoch panel per-row expansion events.
    :rf.xray.epoch/toggle-row-expand
    :rf.xray.epoch/clear-row-expand
+   ;; rf2-kfh1v — Epoch panel SUBSCRIPTIONS show-unchanged toggle.
+   :rf.xray.epoch/toggle-subs-show-unchanged
    :rf.xray/epoch-recorded
    ;; rf2-piye4 — typed-predicate filter events. Each appends a
    ;; typed `{:kind <kw> :params {…}}` IN pill from a right-click


### PR DESCRIPTION
Six-bead cluster of Epoch-panel rendering fixes. The Epoch panel landed in #2185 with a number of projection / view defects observable in any non-trivial cascade — the most material ones were that the DISPATCH step never showed the event vector, the HANDLER step never showed source code, the VIEWS step never named the view, and the SUBSCRIPTIONS step never identified the sub. Three of those four traced to projection-side reads against the WRONG substrate tag names — the substrate stamps payload under canonical `:rf.event/v` / `:rf.sub/query-v` / `:rf.view/rendered` tags, and the projection was reading legacy `:event` / `:rf.sub/query` / `:rf.view/render` slots that have never been emitted. The reads silently returned nil and every render-slot collapsed to whitespace.

Per-bead summary (one commit per bead):

| # | Commit | Bead | Shape |
|---|--------|------|-------|
| 1 | `567068d72` | rf2-9jvx1 | Drop body duplication of header content (DISPATCH `from <source>` + HANDLER `<flavour>:event-id` rows removed from body — header carries them once) |
| 2 | `151145c1d` | rf2-cq0ch | COEFFECT step filters system-injected cofx (`:db / :event / :frame / :source / :trace-id`) at projection time + renders values via `edn/inspect-inline`. Also fixes a latent `map-indexed` arg-swap bug in `coeffect-row-view` / `flow-row-view` / `fx-row-view` that produced the cryptic `+[]nil` row symptom |
| 3 | `c299928d0` | rf2-93a7s | DISPATCH renders the event vector — projection reads `:rf.event/v` (the substrate-canonical tag) rather than the legacy `:event` slot |
| 4 | `2ebf24ff1` | rf2-66wis | HANDLER body shows source code via `edn/code-block` (`:rf.handler/source` meta read, same widget as the Event panel uses); machine handlers render the machine spec via `edn/inspect`; graceful-degrade placeholder when source isn''t captured |
| 5 | `b4d97723d` | rf2-6djth | VIEWS step reads the rich `:rf.view/rendered` marker (not the simpler `:rf.view/render` sentinel) — pulls `:rf.view/id`, `:rf.view/deref-subs`, `:rf.view/elapsed-ms`. View-id hyperlinks via `(rf/handler-meta :view view-id)` |
| 6 | `1eb7a26a2` | rf2-kfh1v | SUBSCRIPTIONS — projection reads `:rf.sub/id` / `:rf.sub/query-v` / `:rf.sub/value-changed?` / `:rf.sub/prev-value` / `:rf.sub/value` (substrate-canonical names); unchanged rows hidden by default with a `Show unchanged` toggle; header carries the `(M changed, K unchanged)` split count |
| 7 | `7044214b7` | docs | Spec/021 §9.1 substrate-tag-dependency inventory documenting the projection''s tag-read contract per step, plus the new sub/event for the SUBSCRIPTIONS filter |

## Cross-bead unifications spotted

- **The projection''s tag reads were systematically out-of-date.** Three of the six bugs (3, 5, 6) were the same shape: the projection read against a stale tag name and silently received nil. The new §9.1.10.1 spec table catalogues the substrate-canonical tag inventory per step so future drift catches at audit time.
- **The `map-indexed (f idx item)` calling convention.** `coeffect-row-view`, `flow-row-view`, and `fx-row-view` all transposed their args — the original landings had `[item idx]` and `map-indexed` passes `(f idx item)`. Caught while fixing bead 2; all three swapped to match the convention.

## Test deltas

- `test:cljs`: 4671 → 4688 tests (+17). 15035 → 15090 assertions (+55).
- `test:browser`: 124 tests, 351 assertions — unchanged. PASS.
- `test:bundle-isolation`: PASS (no new bundle entries; tools/xray stays isolated from production examples).

## Files touched

- `tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc` — tag-name alignment + system-cofx filter + show-unchanged split count
- `tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs` — body de-duplication + handler-source block + views table coord chip + subs filter + toggle button
- `tools/xray/src/day8/re_frame2_xray/panels/epoch_panel.cljs` — `:rf.xray.epoch/subs-show-unchanged?` sub + `:rf.xray.epoch/toggle-subs-show-unchanged` event
- `tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc` — 4 new tests + 1 fixture-shape update
- `tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs` — new file with 13 view-layer tests
- `tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs` — snapshot update for the new sub + event
- `tools/xray/spec/021-Dynamic-Panel-Designs.md` — §9.1.9/§9.1.10 + new §9.1.10.1 substrate-tag-dependency inventory

## Quality gates

- `npm run test:cljs` ✅
- `npm run test:browser` ✅
- `npm run test:bundle-isolation` ✅