### PR TITLE
feat(machines-viz): events-as-nodes paradigm + compound state nesting (rf2-qo5xy)

### DIFF
--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -176,7 +176,113 @@ parser's transition count) so a visual-regression test can pin
 parity at every stage of the parser → projector → DOM chain — the
 silent-drop bug cannot recur at any layer without failing the gate.
 
-### Multi-event label collapse — one arrow, N stacked labels (rf2-j10sm Phase 2, B)
+### Events as nodes — Stately graph view paradigm (rf2-qo5xy)
+
+**This is a paradigm-shift section.** Pre-rf2-qo5xy the chart painted
+transitions as edge labels between state boxes: `event [guard] /
+action` floated on the line. Multiple candidates, long action names,
+or stacked siblings degraded legibility quickly, and action
+attribution was always a second-class citizen of the line text.
+
+Stately Studio's graph view paints each transition as its own box —
+`source-state → event-node → (optional) target-state`. The event box
+carries the event name (header), an optional `[guard]` chip, and `+
+action` pills for action attribution. Internal transitions (no
+`:target`) get the event box but no outgoing edge — they read as
+"this dispatches an action and we hang here". rf2-qo5xy adopts that
+paradigm: every parsed transition emits exactly one xyflow node of
+`type "rf2-event"` (registered in `chart.nodes/node-types`) plus one
+or two edges, with these structural rules:
+
+| Parsed transition shape | Event-node | Inbound edge | Outbound edge |
+|---|---|---|---|
+| `:on {:e :target}` — regular external | yes | state → ev-node | ev-node → target |
+| `:on {:e :same-state}` — external self-transition | yes | state → ev-node | ev-node → state |
+| `:on {:e {:action :a}}` — INTERNAL (no `:target`) | yes (`:internal true`) | state → ev-node | **none** |
+| `:after {1000 ...}` — timer | yes (`:variant "after"`, `:afterMs 1000`) | state → ev-node | ev-node → target |
+| `:always [{:target ...}]` | yes (`:variant "always"`) | state → ev-node | ev-node → target |
+| Wildcard `:*` | yes (`:eventId nil`, not user-fireable) | state → ev-node | ev-node → target |
+
+The event-node carries everything the legacy edge `:data` used to
+carry: `:eventLabel` (the `chart.layout/event-segment` glyph-aware
+text), `:guard` (string), `:action` (string), `:variant` (`:on` /
+`:after` / `:always`), `:eventId` (raw fireable keyword for the
+on-chart sim — nil for `:after` / `:always` / wildcard), `:fromPath`
+/ `:toPath`, `:focused`, `:fired`, `:internal`, `:machineLevel`,
+`:onClick` (the host-supplied callback), `:afterMs`, `:chart`
+(resolved visual-constants).
+
+The inbound + outbound edges carry the structural / styling state
+that used to live on the single state→state edge: `:active`,
+`:focused`, `:fired`, `:crossHierarchy`, elk-routed `:points` on the
+outbound edge. The `:eventLabel` slot on these edges is empty (the
+event-node holds the visible text). Edge ids: `<spec-edge-id>__in` /
+`<spec-edge-id>__out`. Event-node ids: `event__<spec-edge-id>` via
+`chart.projection/event-node-id`.
+
+elkjs lays out event-nodes as siblings of their source state's
+parent container: an event declared inside a compound substate nests
+inside that compound; a region-local event nests inside its region
+container. The layout engine treats them as ordinary layered-graph
+children with explicit incoming/outgoing edges — no new layout
+algorithm.
+
+#### Convention glyphs (rf2-qo5xy)
+
+The event-node header renders the variant glyph an operator who
+knows xstate/Stately reads in 30 seconds (per the bead's §Shift 4):
+
+| Glyph | Variant | Source |
+|---|---|---|
+| `↳`   | initial-marker | `chart.nodes/initial-marker` (paired with the filled-dot source) |
+| `⌚ <ms>ms` | `:after`-delay event-node | `chart.layout/event-segment` |
+| `∞`   | `:always` event-node | `chart.layout/event-segment` |
+| `+ <name>` | action pill (entry / exit / transition) | `chart.nodes/action-pill` + `chart.nodes.event-node` |
+| `[name]` | guard chip | `chart.nodes.event-node` |
+| filled dot | initial-marker source | `chart.nodes/initial-marker` |
+
+#### Active state on box border
+
+The active-state affordance lives on the state-box BORDER (the
+state-node's `:border` colour + `:box-shadow` ring), not on
+duplicate text tags. Compound and region containers light the same
+way when any descendant leaf is active (G4 / rf2-80rm2, preserved
+under the paradigm shift). The legacy "tags row inside the state
+box" (rf2-a2b55) is unchanged — those are user-declared semantic
+`:tags`, distinct from active-state highlight.
+
+#### Context corner panel (rf2-qo5xy)
+
+The chart accepts an optional `:machine-data` prop — the machine's
+current `:data` map (the `:rf.machine/data` slot from the snapshot).
+When non-nil + non-empty, the chart paints a small read-only panel
+in the top-LEFT corner of the canvas showing each `(key, value)`
+pair so the operator sees the live context without leaving the
+chart. The panel is presentation-only — the host owns the data
+projection; the chart paints whatever shape it receives. nil / empty
+→ no panel.
+
+#### Legacy paradigm sections below
+
+The remaining sections in this spec (label collapse, edge label
+geometry, cross-hierarchy label placement, etc.) describe the
+RENDERING of the inbound / outbound edges in the events-as-nodes
+paradigm. The structural model `source-state → event-node →
+target-state` supersedes the pre-rf2-qo5xy single-edge model in
+every other respect; where the legacy sections describe edge
+behaviour, read "edge" as "inbound or outbound edge attached to an
+event-node" unless explicitly stated otherwise.
+
+### Multi-event label collapse — one arrow, N stacked labels (rf2-j10sm Phase 2, B — SUPERSEDED by rf2-qo5xy)
+
+> rf2-qo5xy events-as-nodes paradigm SUPERSEDES this section's
+> collapse-to-one-arc convention: each event now projects as its own
+> first-class `rf2-event` node, so two transitions A→B emit two
+> distinct event-nodes (no collapse). The text below is preserved
+> for context — the rf2-j10sm rationale (legibility of N transitions
+> on one source/target pair) is honoured by the new paradigm in a
+> different way (each event-node is its own scannable box rather
+> than one of N stacked labels on a shared arrow).
 
 N transitions sharing a `[source target]` pair render as **ONE** arrow
 with **N vertically-stacked event labels** — the xstate/Stately
@@ -444,17 +550,20 @@ The overlay callbacks (`:on-spawn-child-click`, `:on-after-ring-hover`,
 
 For the supplied `:definition`, the chart shows:
 
-- **A directional state-chart.** Nodes are states (compound states
+- **A directional state-chart — events-as-nodes paradigm
+  (rf2-qo5xy).** State boxes are first-class nodes (compound states
   nested visually via xyflow sub-flows; `{:type :parallel}` machines
   render every region as a distinct orthogonal zone — see
   [§Parallel-region rendering](#parallel-region-rendering-rf2-lkwev-xyflow-phase-2)).
-  Edges are transitions, labelled with their triggering event id;
-  `:after` edges read `⌚ <delay>ms` and `:always` edges read `∞`
-  (per `chart.layout/event-segment`, the Stately graph view glyph
-  conventions — rf2-a2b55). When a transition declares an `:action`,
-  the action renders as a `+ <action-name>` pill on a separate row
-  below the event line (the action no longer joins the event-line
-  text as `/ action`).
+  Each transition projects as ITS OWN `rf2-event` xyflow node sitting
+  between the source state and the (optional) target state, the
+  paradigm Stately Studio's graph view paints. The event-node carries
+  the event header (`event-id`, or `⌚ <ms>` for `:after`, or `∞` for
+  `:always` per `chart.layout/event-segment`, rf2-a2b55), an optional
+  `[guard]` chip, and a `+ <action>` pill row when the transition
+  declares an action. Internal transitions (omit `:target`) emit an
+  inbound edge into the event-node but no outbound (Stately
+  convention — "runs an action and we hang here").
 - **The current state highlights.** When `:current-state` is set every
   active leaf carries a static active tint + bolder stroke. A flat /
   compound snapshot has one active leaf; a **parallel** snapshot (a

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
@@ -164,19 +164,39 @@
   + positions each orthogonal zone and its states; flat machines get
   the original single-level child list. The root `layoutOptions` are
   computed by the pure `elk-layout-options` (cross-hierarchy switch +
-  direction + host overrides) and `clj->js`-ed here."
+  direction + host overrides) and `clj->js`-ed here.
+
+  rf2-qo5xy — the events-as-nodes paradigm decomposes each parsed
+  transition into TWO elk edges: source-state → event-node and
+  event-node → target-state (the second omitted for internal
+  transitions). elkjs lays out the synthetic event-node alongside
+  the source state's siblings (per `projection/->elk-children`); the
+  resulting positions land in `:positions` keyed by the event-node id
+  (`projection/event-node-id`) and the chart's xyflow projection picks
+  them up."
   [{:keys [edges] :as parsed} direction layout-options]
   #js {:id "root"
        :layoutOptions (clj->js (elk-layout-options parsed layout-options
                                                    direction))
        :children (clj->js (projection/->elk-children parsed))
        :edges (clj->js
-                (mapv (fn [e]
-                        {:id (:id e)
-                         :sources [(:source e)]
-                         :targets [(:target e)]
-                         :labels [{:text (:event-label e)}]})
-                      edges))})
+                (vec
+                  (mapcat
+                    (fn [e]
+                      (let [ev-id (projection/event-node-id e)]
+                        (cond-> [{:id      (str (:id e) "__in")
+                                  :sources [(:source e)]
+                                  :targets [ev-id]
+                                  :labels  [{:text ""}]}]
+                          ;; Internal self-transitions (omit :target) have
+                          ;; no outgoing edge — the event-node 'hangs and
+                          ;; ends' per the Stately convention.
+                          (not (:internal? e))
+                          (conj {:id      (str (:id e) "__out")
+                                 :sources [ev-id]
+                                 :targets [(:target e)]
+                                 :labels  [{:text ""}]}))))
+                    edges)))})
 
 (defn elk-edge-points
   "rf2-cz8v6 (G2) — lift one elk edge's routed bend-points into a flat
@@ -535,6 +555,15 @@
     :overlay-tick      — opaque value the host bumps to force the
                          spawn-all + cascade overlays to re-measure +
                          repaint (mirrors `:after-ring-tick`).
+    :machine-data      — rf2-qo5xy. Optional CLJS map of the current
+                         machine `:data` (`:rf.machine/data`). When
+                         supplied the chart paints a small read-only
+                         panel in the top-LEFT corner of the canvas
+                         showing each `(key, value)` pair so the
+                         operator sees the live `:data` without leaving
+                         the chart (Stately graph view convention). nil
+                         → no panel. The panel is purely presentation —
+                         the host owns the data projection.
     :testid            — root wrapper `data-testid`; defaults to
                          `\"rf-mv-chart\"` so tests + hosts find it."
   [_initial-props]
@@ -602,6 +631,7 @@
                  on-after-ring-hover on-after-ring-leave
                  spawn-all-join on-spawn-child-click
                  cancellation-cascade overlay-tick
+                 machine-data
                  testid]
           :or   {direction         :tb
                  height            "100%"
@@ -919,6 +949,65 @@
              ;; (the overlay is a no-op).
              [label-collisions/LabelCollisionsOverlay
               {:tick (or after-ring-tick overlay-tick)}]
+             ;; rf2-qo5xy — `:machine-data` corner panel. The Stately
+             ;; graph view paints the machine's current `:data` /
+             ;; context as a top-left panel so the operator reads it
+             ;; alongside the topology. Presentation-only: the host
+             ;; supplies the map; the chart paints whatever shape it is
+             ;; (the panel does no destructuring, just pr-str on each
+             ;; value). Hidden when nil / empty so a machine with no
+             ;; `:data` declared (or a host that hasn't wired it) does
+             ;; not paint an empty box.
+             (when (and machine-data (seq machine-data))
+               [:div {:data-testid (str testid "-machine-data-panel")
+                      :data-key-count (str (count machine-data))
+                      :role "complementary"
+                      :aria-label (str "Machine context for "
+                                       (when machine-id (name machine-id)))
+                      :style {:position      "absolute"
+                              :top           "8px"
+                              :left          "8px"
+                              :z-index       6
+                              :max-width     "260px"
+                              :max-height    "40%"
+                              :overflow      "auto"
+                              :padding       "8px 10px"
+                              :font-family   tokens/mono-stack
+                              :font-size     "11px"
+                              :line-height   1.4
+                              :color         (:text-primary tokens/tokens)
+                              :background    (tokens/with-alpha :bg-2 0.92)
+                              :border        (str "1px solid "
+                                                  (tokens/with-alpha :border-default 0.6))
+                              :border-radius "4px"}}
+                [:div {:style {:font-family    tokens/sans-stack
+                               :font-size      "9px"
+                               :font-weight    700
+                               :letter-spacing "0.06em"
+                               :text-transform "uppercase"
+                               :color          (:text-tertiary tokens/tokens)
+                               :margin-bottom  "4px"}}
+                 "Context"]
+                (for [[k v] (seq machine-data)]
+                  ^{:key (pr-str k)}
+                  [:div {:data-testid (str testid "-machine-data-key-"
+                                           (if (keyword? k) (name k) (str k)))
+                         :data-key (pr-str k)
+                         :style {:display "flex"
+                                 :gap     "6px"
+                                 :align-items "baseline"
+                                 :white-space "nowrap"
+                                 :overflow "hidden"
+                                 :text-overflow "ellipsis"}}
+                   [:span {:style {:color (:accent tokens/tokens)
+                                   :font-weight 600}}
+                    (if (keyword? k) (name k) (str k))]
+                   [:span {:style {:color (:text-tertiary tokens/tokens)}}
+                    ":"]
+                   [:span {:style {:color (:text-secondary tokens/tokens)
+                                   :overflow "hidden"
+                                   :text-overflow "ellipsis"}}
+                    (pr-str v)]])])
              ;; rf2-4lyvh — ELK layout-failure indicator. When
              ;; `compute-layout!` surfaces a `:layout-error` slot the
              ;; chart would otherwise render every node stacked at

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes.cljs
@@ -50,6 +50,8 @@
   (:require ["@xyflow/react" :as xyflow]
             [clojure.string :as str]
             [reagent.core :as r]
+            [day8.re-frame2-machines-viz.chart.nodes.event-node
+             :as event-node]
             [day8.re-frame2-machines-viz.chart.nodes.parallel-region-node
              :as parallel-region-node]
             [day8.re-frame2-machines-viz.chart.projection :as projection]
@@ -469,16 +471,36 @@
 ;; ---- initial marker node ------------------------------------------------
 
 (defn initial-marker
-  "Reagent component for the machine's initial-state marker — a
-  small filled dot. Rendered as a tiny xyflow node with an outgoing
-  edge into the initial state."
+  "Reagent component for the machine's initial-state marker — a filled
+  dot followed by the `↳` glyph (Stately graph view convention,
+  rf2-qo5xy). Rendered as a tiny xyflow node with an outgoing edge
+  into the initial state.
+
+  Pre-rf2-qo5xy the marker was JUST the filled dot; the bead's
+  paradigm-shift checklist calls for the `↳` glyph as an additional
+  affordance an operator who knows xstate/Stately reads in 30
+  seconds — 'this is THE initial state' rather than 'a state node
+  with an upstream marker'. Composing the glyph on the marker
+  (rather than as separate node) keeps the topology hop short and
+  the elk layered layout pleasant."
   [^js _props]
   (r/as-element
     [:div {:data-testid "rf-mv-chart-initial-marker"
-           :style {:width            "12px"
-                   :height           "12px"
-                   :border-radius    "50%"
-                   :background       (:accent tokens/tokens)}}
+           :style {:display          "inline-flex"
+                   :align-items      "center"
+                   :gap              "4px"}}
+     [:div {:data-testid "rf-mv-chart-initial-marker-dot"
+            :style {:width            "10px"
+                    :height           "10px"
+                    :border-radius    "50%"
+                    :background       (:accent tokens/tokens)}}]
+     [:span {:data-testid "rf-mv-chart-initial-marker-glyph"
+             :style {:font-family   mono-stack
+                     :font-size     "14px"
+                     :font-weight   600
+                     :line-height   "1"
+                     :color         (:accent tokens/tokens)}}
+      "↳"]
      [:> Handle {:type "source" :position pos-right
                  :style {:opacity 0}}]]))
 
@@ -495,9 +517,15 @@
   "The `nodeTypes` prop value for `<ReactFlow>`. Returns a fresh
   plain-JS object on every call — xyflow caches by reference, so
   callers SHOULD memoise this map at component-construction time
-  to avoid re-render churn."
+  to avoid re-render churn.
+
+  rf2-qo5xy — `rf2-event` joins the registered set: events render as
+  first-class xyflow nodes (one per spec transition) rather than as
+  edge LABELS between state boxes. Same node-type pattern the state /
+  compound / region nodes use."
   []
   #js {"state"           state-node
        "compound"        compound-node
        "parallel-region" parallel-region-node/parallel-region-node
-       "initial-marker"  initial-marker})
+       "initial-marker"  initial-marker
+       "rf2-event"       event-node/event-node})

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes/event_node.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes/event_node.cljs
@@ -1,0 +1,247 @@
+(ns day8.re-frame2-machines-viz.chart.nodes.event-node
+  "Custom xyflow node for an EVENT — the central artefact of the
+  events-as-nodes paradigm (rf2-qo5xy).
+
+  ## Why this exists
+
+  Pre-rf2-qo5xy the chart painted transitions as edge LABELS between
+  state boxes: `event [guard] / action` floated on the line. Multiple
+  candidates, long action names, or several stacked siblings degraded
+  legibility quickly, and action attribution was always a second-class
+  citizen of the line text.
+
+  Stately's graph view paints each transition as its OWN box —
+  `source-state → event-node → (optional) target-state`. The event
+  box carries the event name (header), an optional `[guard]` chip,
+  and `+ action` pills for action attribution. Internal transitions
+  (no `:target`) get the event box but no outgoing edge — they read
+  as 'this dispatches an action and hangs here'.
+
+  rf2-qo5xy adopts that paradigm: every spec transition emits exactly
+  one xyflow node of `type \"rf2-event\"` plus one or two edges.
+
+  ## What this owns
+
+  Just the event-box chrome:
+
+    - Header line with the event name (or `⌚ <ms>` for `:after`,
+      or `∞` for `:always`).
+    - Optional `[guard]` chip when the transition declares one.
+    - `+ <action>` pill row when the transition declares one or more
+      actions.
+    - Source + target xyflow `Handle`s on the cardinal sides so the
+      incoming (source-state → event) and outgoing (event → target-
+      state) edges anchor cleanly.
+
+  Geometry + typography read off the resolved density's
+  `visual-constants` map threaded through `:data {:chart ...}` —
+  same pattern the state-node + edge components use. No hex literals
+  appear in this ns; all colour goes through `theme/tokens`."
+  (:require ["@xyflow/react" :as xyflow]
+            [reagent.core :as r]
+            [day8.re-frame2-machines-viz.theme.tokens
+             :as tokens
+             :refer [mono-stack sans-stack]]
+            [day8.re-frame2-machines-viz.visual-constants :as vc]))
+
+(def ^:private Handle   (.-Handle xyflow))
+(def ^:private Position (.-Position xyflow))
+(def ^:private pos-top    (.-Top Position))
+(def ^:private pos-right  (.-Right Position))
+(def ^:private pos-bottom (.-Bottom Position))
+(def ^:private pos-left   (.-Left Position))
+
+(defn- chart-constants
+  "Recover the resolved visual-constants map off an event-node's `:data`
+  (`(.-chart d)`). xyflow `clj->js`-es the CLJS map into a JS object, so
+  recover it with kebab-keyword keys. Falls back to `vc/chart-regular`
+  when absent (legacy / direct construction)."
+  [^js d]
+  (let [c (.-chart d)]
+    (if (some? c)
+      (js->clj c :keywordize-keys true)
+      vc/chart-regular)))
+
+(defn- variant-glyph
+  "rf2-qo5xy — convention-glyph variants for the event-node header. The
+  three xstate/Stately conventions:
+
+    - `:after`  → `⌚` clock glyph + `<ms>` (e.g. `⌚ 1000ms`)
+    - `:always` → `∞` continuation glyph
+    - `:on`     → the event keyword's name (with namespace when present)"
+  [{:keys [variant after-ms event-label]}]
+  (case variant
+    :after  (str "⌚ " after-ms "ms")
+    :always "∞"
+    event-label))
+
+(defn event-node
+  "Reagent component for an event-node. The xyflow chart projector
+  emits ONE event-node per spec transition (event-as-node paradigm,
+  rf2-qo5xy): state → event-node → (optional) target state.
+
+  Reads from `:data`:
+
+    :eventLabel    — visible header text (already the event-segment
+                     string from `chart.layout/event-segment` —
+                     namespace/name handled there).
+    :variant       — `:on` / `:after` / `:always`. Drives the header
+                     glyph.
+    :afterMs       — `:after`-delay in ms (`:after` variant only).
+    :guard         — guard name as a string, or nil.
+    :action        — action name as a string, or nil.
+    :focused       — focused-event lens hit; emphasised border.
+    :fired         — this event fired THIS epoch; FIRED treatment.
+    :clickable     — host wired an on-click for this event (the
+                     on-chart sim path).
+    :eventId       — raw fireable event keyword the host receives on
+                     click; nil for `:after` / `:always` (inert).
+    :machineLevel  — top-level :on fallback transition every state
+                     inherits.
+    :internal      — internal self-transition (no :target). Visual
+                     hint: dashed border ring under the header (the
+                     'this action runs and we hang here' affordance).
+    :chart         — resolved visual-constants for the active density."
+  [^js props]
+  (let [d           (.-data props)
+        vc          (chart-constants d)
+        event-label (or (.-eventLabel d) "")
+        variant     (keyword (or (.-variant d) "on"))
+        after-ms    (.-afterMs d)
+        guard       (.-guard d)
+        action      (.-action d)
+        focused?    (boolean (.-focused d))
+        fired?      (boolean (.-fired d))
+        internal?   (boolean (.-internal d))
+        machine-level? (boolean (.-machineLevel d))
+        on-click    (.-onClick d)
+        event-id    (.-eventId d)
+        from-path   (.-fromPath d)
+        to-path     (.-toPath d)
+        clickable?  (and (fn? on-click) (some? event-id))
+        header      (variant-glyph {:variant     variant
+                                    :after-ms    after-ms
+                                    :event-label event-label})
+        {:keys [corner-radius stroke-width stroke-width-emphasis
+                edge-label-px action-pill-height action-pill-pad-x
+                action-pill-px action-pill-radius action-pill-row-gap]} vc
+        emphasised? (or focused? fired?)
+        stroke-w    (if emphasised? stroke-width-emphasis stroke-width)
+        stroke-col  (cond
+                      fired?    (:accent tokens/tokens)
+                      focused?  (:info tokens/tokens)
+                      :else     (tokens/with-alpha :border-default 0.7))
+        fill        (cond
+                      fired?    (tokens/with-alpha :accent 0.12)
+                      focused?  (tokens/with-alpha :info 0.10)
+                      clickable? (tokens/with-alpha :yellow 0.06)
+                      :else      (tokens/with-alpha :bg-3 0.6))]
+    (r/as-element
+      [:div {:data-testid (str "rf-mv-chart-event-" (.-id props))
+             :data-node-id (.-id props)
+             :data-event-id (when event-id (str event-id))
+             :data-variant (name variant)
+             :data-variant-after (str (= :after variant))
+             :data-variant-always (str (= :always variant))
+             :data-internal (str internal?)
+             :data-machine-level (str machine-level?)
+             :data-fired (str fired?)
+             :data-focused (str focused?)
+             :data-clickable (str clickable?)
+             :data-after-ms (when after-ms (str after-ms))
+             :data-guard (when guard (str guard))
+             :data-action (when action (str action))
+             :data-from-path (when from-path (pr-str from-path))
+             :data-to-path (when to-path (pr-str to-path))
+             :role (when clickable? "button")
+             :title (when clickable? (str "Send " event-id))
+             :on-click (when clickable?
+                         (fn [ev]
+                           (.stopPropagation ev)
+                           (on-click
+                             #js {:eventId  event-id
+                                  :fromPath from-path
+                                  :toPath   to-path})))
+             :style {:position       "relative"
+                     :display        "inline-flex"
+                     :flex-direction "column"
+                     :align-items    "center"
+                     :justify-content "center"
+                     :gap            "3px"
+                     :min-width      "84px"
+                     :min-height     "30px"
+                     :padding        "4px 10px"
+                     :background     fill
+                     :border         (str stroke-w "px "
+                                          (if internal? "dashed" "solid")
+                                          " " stroke-col)
+                     :border-radius  (str (max 4 (- corner-radius 2)) "px")
+                     :font-family    sans-stack
+                     :font-size      (str edge-label-px "px")
+                     :font-weight    (if emphasised? 600 500)
+                     :color          (:text-primary tokens/tokens)
+                     :cursor         (if clickable? "pointer" "default")
+                     :user-select    "none"
+                     :box-shadow     (when emphasised?
+                                       (str "0 0 0 2px "
+                                            (tokens/with-alpha
+                                              (if fired? :accent :info) 0.15)))
+                     :animation      (when fired?
+                                       "mv-chart-transition-glow 720ms ease-out infinite")
+                     :transition     "border-color 120ms ease, background 120ms ease"}}
+       ;; Header line: event name / ⌚ <ms> / ∞ + optional [guard] chip.
+       [:span {:data-testid (str "rf-mv-chart-event-header-" (.-id props))
+               :data-event-line (cond-> header
+                                  guard (str " [" guard "]"))
+               :style {:font-family mono-stack
+                       :white-space "nowrap"
+                       :line-height "1.1"}}
+        header
+        (when guard
+          [:span {:data-testid (str "rf-mv-chart-event-guard-" (.-id props))
+                  :data-guard guard
+                  :style {:margin-left "4px"
+                          :color (:advisory tokens/tokens)
+                          :font-family mono-stack}}
+           (str "[" guard "]")])]
+       ;; Action pill (`+ <action-name>`) — Stately graph view convention.
+       (when action
+         [:span {:data-testid (str "rf-mv-chart-event-action-" (.-id props))
+                 :data-action action
+                 :style {:display          "inline-flex"
+                         :align-items      "center"
+                         :height           (str action-pill-height "px")
+                         :padding          (str "0 " action-pill-pad-x "px")
+                         :margin-top       (str action-pill-row-gap "px")
+                         :background       (tokens/with-alpha :advisory 0.18)
+                         :border           (str "1px solid "
+                                                (tokens/with-alpha :advisory 0.6))
+                         :border-radius    (str action-pill-radius "px")
+                         :font-family      mono-stack
+                         :font-size        (str action-pill-px "px")
+                         :font-weight      500
+                         :color            (:advisory tokens/tokens)
+                         :line-height      "1"
+                         :white-space      "nowrap"}}
+          (str "+ " action)])
+       ;; Machine-level annotation — a small subscript chip so the
+       ;; operator can see at a glance that this event-handler is
+       ;; inherited from the machine's top-level :on (not declared on
+       ;; the source state).
+       (when machine-level?
+         [:span {:data-testid (str "rf-mv-chart-event-machine-level-" (.-id props))
+                 :style {:font-family sans-stack
+                         :font-size   (str (max 8 (- action-pill-px 1)) "px")
+                         :font-weight 600
+                         :color       (tokens/with-alpha :text-tertiary 0.85)
+                         :letter-spacing "0.04em"
+                         :text-transform "uppercase"}}
+          "machine-level"])
+       ;; xyflow attachment points. Handles on every side so elkjs can
+       ;; pick the cleanest anchor based on the routed direction.
+       [:> Handle {:type "target" :position pos-top    :style {:opacity 0}}]
+       [:> Handle {:type "target" :position pos-left   :id "left"
+                   :style {:opacity 0}}]
+       [:> Handle {:type "source" :position pos-bottom :style {:opacity 0}}]
+       [:> Handle {:type "source" :position pos-right  :id "right"
+                   :style {:opacity 0}}]])))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
@@ -65,6 +65,19 @@
 
 ;; ---- elk.js children projection ----------------------------------------
 
+(def event-node-elk-width
+  "elk.js layout width for an event-node — narrower than a state node
+  so two adjacent events do not crowd the state row, but wide enough
+  for the `event-segment` text + optional `[guard]` chip + `+ action`
+  pill (rf2-qo5xy)."
+  120)
+
+(def event-node-elk-height
+  "elk.js layout height for an event-node — taller than a single text
+  line so the action-pill row has space underneath the header
+  (rf2-qo5xy)."
+  46)
+
 (defn elk-child
   "Build a single elk.js child descriptor for a parsed node (a plain
   CLJS map; `chart`'s `->elk-input` `clj->js`-es the whole tree)."
@@ -74,8 +87,20 @@
    :height (if (:compound? n) compound-node-min-height state-node-min-height)
    :labels [{:text (:label n)}]})
 
+(defn elk-event-child
+  "rf2-qo5xy — build an elk.js child descriptor for a SYNTHETIC
+  event-node. The events-as-nodes paradigm inserts one of these per
+  spec transition (between source state and target state); elkjs lays
+  it out alongside the source state's siblings inside the source's
+  parent container."
+  [parsed-edge]
+  {:id     (event-node-id parsed-edge)
+   :width  event-node-elk-width
+   :height event-node-elk-height
+   :labels [{:text (or (:event-label parsed-edge) "")}]})
+
 (defn ->elk-children
-  "Project parsed nodes into elk.js's `children` shape.
+  "Project parsed nodes + parsed edges into elk.js's `children` shape.
 
   Nesting is keyed on `:parent-id`: parallel-region states (rf2-lkwev)
   AND compound substates carry it, so BOTH nest UNDER their container
@@ -86,20 +111,46 @@
   compound, lays out correctly. Each container (region OR compound) gets
   its own `elk.algorithm`/`elk.padding` so the header strip has room and
   the zone gets a clean internal layout; top-level nodes are laid out at
-  the root."
-  [{:keys [nodes]}]
-  (let [by-parent (group-by :parent-id nodes)
+  the root.
+
+  rf2-qo5xy — synthetic event-nodes (one per parsed edge) sit alongside
+  state-nodes as elk children of the SOURCE state's parent container
+  (top-level when the source has no parent). elk then lays them out
+  with the layered algorithm — events flow naturally between states
+  per the events-as-nodes paradigm. They carry no children of their
+  own."
+  [{:keys [nodes edges]}]
+  (let [node-by-id (into {} (map (juxt :id identity)) nodes)
+        ;; The event-node's parent container == the source state's
+        ;; parent. Top-level when the source has no `:parent-id`.
+        event-children
+        (mapv (fn [e]
+                (let [src (get node-by-id (:source e))
+                      pid (:parent-id src)]
+                  (cond-> (elk-event-child e)
+                    pid (assoc ::event-parent pid))))
+              edges)
+        by-parent (group-by :parent-id nodes)
+        events-by-parent (group-by ::event-parent event-children)
         build (fn build [n]
-                (let [kids (get by-parent (:id n))]
+                (let [state-kids (get by-parent (:id n) [])
+                      event-kids (get events-by-parent (:id n) [])
+                      kids       (concat state-kids event-kids)]
                   (cond-> (elk-child n)
                     (seq kids)
-                    (assoc :children (mapv build kids)
-                           ;; Container lays out its own children;
-                           ;; padding leaves top room for the header strip
-                           ;; (region label / compound title).
+                    (assoc :children (->> kids
+                                          (mapv (fn [k]
+                                                  (if (contains? k ::event-parent)
+                                                    ;; Strip the helper-only key
+                                                    ;; before handing to elk.
+                                                    (dissoc k ::event-parent)
+                                                    (build k)))))
                            :layoutOptions {"elk.algorithm" "layered"
-                                           "elk.padding"   "[top=34,left=14,bottom=14,right=14]"}))))]
-    (mapv build (get by-parent nil))))
+                                           "elk.padding"   "[top=34,left=14,bottom=14,right=14]"}))))
+        top-state-children (mapv build (get by-parent nil))
+        top-event-children (->> (get events-by-parent nil [])
+                                (mapv #(dissoc % ::event-parent)))]
+    (vec (concat top-state-children top-event-children))))
 
 ;; ---- graph projection (parsed + positions → xyflow nodes/edges) ---------
 
@@ -122,6 +173,26 @@
   inspector, not as an edge in this chart."
   [edge]
   (if (:after edge) "after" "transition"))
+
+(defn event-variant
+  "rf2-qo5xy — bucket a parsed edge by its event variant for the
+  events-as-nodes paradigm: `:after` (clock glyph), `:always`
+  (infinity glyph), or `:on` (regular event keyword). Pure data → keyword."
+  [edge]
+  (cond
+    (:after edge)   :after
+    (:always? edge) :always
+    :else           :on))
+
+(defn event-node-id
+  "rf2-qo5xy — stable string id for an event-node. The xyflow node
+  inserted between the source state and the (optional) target state
+  in the events-as-nodes paradigm. Derived from the canonical edge-id
+  (`chart.layout/edge-id`) so two transitions sharing source/target/
+  event/guard/action keep distinct event-node ids — the same
+  collision-tiebreak `chart.layout/parse-flat` applies."
+  [edge]
+  (str "event__" (:id edge)))
 
 (defn xyflow-graph
   "Project the parsed graph + a `{node-id position}` map into the
@@ -344,181 +415,213 @@
                            :extent   "parent"))))
               (sort-by #(if (or (:region? %) (:compound? %)) 0 1) nodes))
 
-        ;; rf2-j10sm (Phase 2, B) — multi-event same-`[source target]`
-        ;; collapse (the xstate/Stately convention). N edges with the
-        ;; same source + target (e.g. 3 self-loops on `:disconnected`,
-        ;; or 2 parallel transitions A→B on different events) render as
-        ;; ONE arrow with N stacked event labels rather than N
-        ;; overlapping arrows + N overlapping labels.
+        ;; rf2-qo5xy — events-as-nodes paradigm. Each parsed transition
+        ;; emits ONE event-node (xyflow `type "rf2-event"`) plus one or
+        ;; two edges:
         ;;
-        ;; Compute, in two passes:
+        ;;   source-state ─→ event-node ─→ target-state  (regular external)
+        ;;   source-state ─→ event-node                 (internal: no :target)
         ;;
-        ;;   sibling-counts — `{[source target] N}` for every pair the
-        ;;     projection emits. Read by the edge renderer to space the
-        ;;     stacked labels (and by `:data-sibling-count`).
-        ;;   sibling-index-of — per-pair monotone counter (0..N-1) that
-        ;;     hands each edge its slot in the stack in emission order.
-        ;;     Only the leader (`:siblingIndex 0`) paints the SVG path +
-        ;;     arrowhead; siblings render just their label, vertically
-        ;;     offset.
+        ;; Pre-rf2-qo5xy the chart painted transitions as edge LABELS
+        ;; between state boxes (event + guard + action floated on the
+        ;; line). The events-as-nodes paradigm hoists the event into a
+        ;; first-class box so the action attribution (+ guard chip)
+        ;; reads cleanly even with several stacked candidates — the
+        ;; Stately graph view convention (rf2-qo5xy bead §Shift 1).
         ;;
-        ;; This SUPERSEDES the rf2-shv82 self-loop perimeter fan: a
-        ;; self-loop is just a same-pair case (source == target), and
-        ;; stacked labels on ONE loop arc are visually cleaner than N
-        ;; loops fanned around the perimeter. `loop-index` collapses to
-        ;; 0 for every self-loop now (no fan); the fan slots are
-        ;; reserved for a future "explicit fan" affordance that doesn't
-        ;; collapse labels (none planned). The historical single-self-
-        ;; loop case (one loop on a node) is unchanged: siblingCount 1,
-        ;; loop-index 0, leader paints the loop in slot 0.
-        sibling-key       (juxt :source :target)
-        sibling-counts    (frequencies (map sibling-key edges))
-        sibling-index-of
-        (let [seen (volatile! {})]
-          (fn [e]
-            (let [k (sibling-key e)
-                  n (get @seen k 0)]
-              (vswap! seen assoc k (inc n))
-              n)))
-        ;; rf2-shv82 (Issue 3) — flag cross-hierarchy edges (source and
-        ;; target sit in different parent containers). The label-
-        ;; positioning logic uses this to anchor the label near the
-        ;; SOURCE-SIDE first bend point (just outside the container the
-        ;; edge exits) instead of at the routed midpoint, which can land
-        ;; far from the visual origin for a deeply-nested cross-hierarchy
-        ;; edge (Stately Studio's convention).
+        ;; The legacy single-edge `:edges` shape (state → state with
+        ;; event/guard/action on the label) is dropped: tests that used
+        ;; to assert on the edge `:data {:eventLabel ...}` now address
+        ;; the event-node's `:data {:eventLabel ...}` instead. The
+        ;; cross-hierarchy / sibling / self-loop / fired / focused
+        ;; treatments still apply to the incoming + outgoing edges, but
+        ;; the visible label rides on the event-node.
         cross-hierarchy?-of
-        (fn [e]
-          (let [src-parent (get parent-of (:source e))
-                tgt-parent (get parent-of (:target e))]
-            (and (not= (:source e) (:target e))
+        (fn [src tgt]
+          (let [src-parent (get parent-of src)
+                tgt-parent (get parent-of tgt)]
+            (and (not= src tgt)
                  (not= src-parent tgt-parent))))
-        proj-edges
+        ;; Per-edge derived values + the event-node descriptor for the
+        ;; current parsed transition.
+        edge-descriptors
         (mapv (fn [e]
-                (let [from-active? (or (contains? active-ids (:source e))
-                                       (contains? active-ids (:target e)))
+                (let [src          (:source e)
+                      tgt          (:target e)
+                      from-active? (or (contains? active-ids src)
+                                       (contains? active-ids tgt))
                       focused?     (and (some? from-highlight-id)
                                         (some? to-highlight-id)
-                                        (= (:source e) from-highlight-id)
-                                        (= (:target e) to-highlight-id))
-                      ;; rf2-qeemm (G3) — the edge fired THIS epoch when its
-                      ;; canonical id ∈ `:fired-edge-ids` (matched directly,
-                      ;; not by endpoint node-ids like `focused?`). The set
-                      ;; is the host's `extract-fired-edge-ids` result, whose
-                      ;; ids agree with `(:id e)` by construction.
+                                        (= src from-highlight-id)
+                                        (= tgt to-highlight-id))
                       fired?       (contains? fired-edge-ids (:id e))
-                      ;; A self-transition (source == target) renders as a
-                      ;; loop, not a degenerate near-zero bezier; the edge
-                      ;; component reads the `:selfLoop` flag.
-                      self-loop?   (= (:source e) (:target e))
-                      ;; rf2-j10sm (Phase 2, B) — sibling slot in the merged
-                      ;; multi-event group. Drives label stacking +
-                      ;; leader/follower path painting in `transition-edge`.
-                      sibling-index (sibling-index-of e)
-                      sibling-count (get sibling-counts (sibling-key e) 1)
-                      ;; rf2-shv82 (Issue 2) → rf2-j10sm (Phase 2, B) — the
-                      ;; self-loop perimeter fan is superseded by the
-                      ;; multi-event collapse: all self-loops on one source
-                      ;; share ONE loop arc with stacked labels. loop-index
-                      ;; is now always 0 for a self-loop (the historical
-                      ;; single-self-loop slot); the fan code path is
-                      ;; preserved in `edge-path` but is exercised only by
-                      ;; the projection-bypassing test corpus.
-                      loop-index   (when self-loop? 0)
-                      ;; rf2-shv82 (Issue 3) — cross-hierarchy flag for the
-                      ;; label-placement adjustment in `edge-path`.
-                      cross-hier?  (cross-hierarchy?-of e)
-                      ;; rf2-qeemm (G3) — the fired-this-epoch arrowhead reads
-                      ;; in the FIRED hue (`:accent`, distinct from the
-                      ;; focused/active `:info`); fired wins over focused/active
-                      ;; so a traversed edge stands out as "what just happened".
-                      ;; Palette delegated to Figma (no new token).
-                      marker-color (cond
-                                     fired?                  (:accent tokens/tokens)
-                                     (or focused? from-active?) (:info tokens/tokens)
-                                     :else                   (:border-default tokens/tokens))
+                      self-loop?   (= src tgt)
+                      internal?    (boolean (:internal? e))
                       ;; A `:*` wildcard `:on` arm is a real transition
-                      ;; but NOT a fireable event (Spec 005 §Wildcard —
-                      ;; it matches "any otherwise-unhandled event").
-                      ;; Excluding it keeps `:eventId` nil so the on-chart
-                      ;; sim can't dispatch a literal `[:* ...]` (same
-                      ;; inert posture as `:after` / `:always`).
+                      ;; but NOT a fireable event (Spec 005 §Wildcard).
                       fireable?    (and (nil? (:after e))
                                         (not (:always? e))
                                         (keyword? (:event e))
                                         (not= :* (:event e)))
                       event-id     (when fireable? (:event e))
-                      ;; rf2-cz8v6 (G2) — elk's routed bend-points for
-                      ;; this edge (absolute coords). Self-loops keep
-                      ;; their dedicated loop path, so they never carry
-                      ;; points even if elk emitted a degenerate route.
-                      points       (when-not self-loop?
-                                     (get edge-points (:id e)))]
-                  {:id     (:id e)
-                   :source (:source e)
-                   :target (:target e)
-                   :type   (choose-edge-type e)
-                   :markerEnd {:type "arrowclosed"
-                               :color marker-color
-                               :width 18
-                               :height 18}
-                   :data   {:eventLabel (:event-label e)
-                            ;; rf2-a2b55 — Stately graph view convention: the
-                            ;; visible label paints the event + guard on ONE
-                            ;; line, with the action as a `+ <action>` pill on
-                            ;; a separate row BELOW it. `:eventLineLabel` is
-                            ;; the visible-line text (`event [guard]`, no
-                            ;; `/ action`); `:eventLabel` keeps the full
-                            ;; `event [guard] / action` form for the
-                            ;; `data-event` attr + host introspection +
-                            ;; label-collision-overlay path.
-                            :eventLineLabel (layout/event-line e)
-                            :active     from-active?
-                            :focused    focused?
-                            ;; rf2-qeemm (G3) — fired-this-epoch flag the
-                            ;; edge component reads to paint the FIRED
-                            ;; treatment + surface `data-fired`.
-                            :fired      fired?
-                            :afterMs    (:after e)
-                            :guard      (layout/name-of (:guard e))
-                            :action     (layout/name-of (:action e))
-                            :selfLoop   self-loop?
-                            ;; rf2-shv82 (Issue 2) → rf2-j10sm (Phase 2, B)
-                            ;; — `loopIndex` is 0 for every self-loop now
-                            ;; (the fan is superseded by the multi-event
-                            ;; collapse) and nil for non-self-loops.
-                            :loopIndex  loop-index
-                            ;; rf2-j10sm (Phase 2, B) — slot in the merged
-                            ;; same-`[source target]` group + per-group
-                            ;; total. The renderer pins these and uses them
-                            ;; to stack labels + suppress non-leader paths.
-                            :siblingIndex sibling-index
-                            :siblingCount sibling-count
-                            ;; rf2-shv82 (Issue 3) — cross-hierarchy flag
-                            ;; for the label-position shift in `edge-path`
-                            ;; (source-side bend point instead of midpoint).
-                            :crossHierarchy cross-hier?
-                            ;; rf2-cz8v6 (G2) — elk's routed bend-points
-                            ;; (a `[{:x :y} …]` vector in absolute /
-                            ;; flow coords) when elk computed a route;
-                            ;; the edge component draws a smooth poly-
-                            ;; path THROUGH them (around nested
-                            ;; containers). nil → the bezier fallback.
-                            :points       points
-                            ;; rf2-ee38b.21 — an internal self-transition
-                            ;; (omit :target) runs only :action; the
-                            ;; renderer draws it as a self-loop with no
-                            ;; exit/entry re-trigger affordance.
-                            :internal     (boolean (:internal? e))
-                            ;; A machine-level (top-level :on) fallback
-                            ;; transition every state inherits.
-                            :machineLevel (boolean (:machine-level? e))
-                            :eventId    event-id
-                            :fromPath   (:from-path e)
-                            :toPath     (:to-path e)
-                            :onClick    on-edge-click
-                            :chart      chart}}))
+                      variant      (event-variant e)
+                      ev-node-id   (event-node-id e)
+                      ;; The event-node nests inside the SAME parent
+                      ;; container as the source state (parent-id chain
+                      ;; preserved). elkjs lays it out alongside other
+                      ;; siblings; xyflow's `parentId` sub-flow does the
+                      ;; rest. Top-level states leave `:parent-id` nil.
+                      parent-id    (get parent-of src)
+                      cross-hier?  (cross-hierarchy?-of src tgt)
+                      points       (get edge-points (:id e))]
+                  {:edge      e
+                   :event-id  event-id
+                   :variant   variant
+                   :ev-node-id ev-node-id
+                   :parent-id parent-id
+                   :focused?  focused?
+                   :fired?    fired?
+                   :from-active? from-active?
+                   :self-loop? self-loop?
+                   :internal? internal?
+                   :cross-hier? cross-hier?
+                   :points    points}))
               edges)
+        ;; Event-nodes — one per parsed transition. The xyflow node
+        ;; renderer (`chart.nodes.event-node`) paints the event header
+        ;; (`event-segment` glyph), the `[guard]` chip, and the
+        ;; `+ <action>` pill row.
+        event-nodes
+        (mapv (fn [{:keys [edge variant ev-node-id parent-id
+                           focused? fired? internal? event-id]}]
+                (let [src (:source edge)
+                      src-pos (get positions src {:x 0 :y 0})
+                      ev-pos  (get positions ev-node-id
+                                   ;; Pre-layout fallback: a small offset
+                                   ;; from the source so a no-layout
+                                   ;; render does not stack everything at
+                                   ;; the origin.
+                                   {:x (+ (:x src-pos) 0)
+                                    :y (+ (:y src-pos) 80)})]
+                  (cond-> {:id        ev-node-id
+                           :type      "rf2-event"
+                           :position  {:x (:x ev-pos) :y (:y ev-pos)}
+                           :data      {:eventLabel  (layout/event-segment edge)
+                                       :variant     (name variant)
+                                       :afterMs     (:after edge)
+                                       :guard       (layout/name-of (:guard edge))
+                                       :action      (layout/name-of (:action edge))
+                                       :focused     focused?
+                                       :fired       fired?
+                                       :internal    internal?
+                                       :machineLevel (boolean (:machine-level? edge))
+                                       :eventId     event-id
+                                       :fromPath    (:from-path edge)
+                                       :toPath      (:to-path edge)
+                                       :onClick     on-edge-click
+                                       :chart       chart}
+                           :draggable false
+                           :selectable false}
+                    ;; rf2-xh1lm — the event-node nests inside the same
+                    ;; parent the source state nests in, so a transition
+                    ;; declared on a compound substate's child sits inside
+                    ;; the compound container rather than leaking to the
+                    ;; root.
+                    parent-id
+                    (assoc :parentId parent-id
+                           :extent   "parent"))))
+              edge-descriptors)
+        ;; Inbound edges: source-state → event-node. One per parsed
+        ;; transition. No label rides on this edge (the event-node holds
+        ;; the event/guard/action text); the edge is structural —
+        ;; "this state handles this event".
+        inbound-edges
+        (mapv (fn [{:keys [edge ev-node-id from-active? focused? fired?
+                           cross-hier?]}]
+                {:id        (str (:id edge) "__in")
+                 :source    (:source edge)
+                 :target    ev-node-id
+                 :type      "transition"
+                 :markerEnd {:type "arrowclosed"
+                             :color (cond
+                                      fired?    (:accent tokens/tokens)
+                                      focused?  (:info tokens/tokens)
+                                      from-active? (:info tokens/tokens)
+                                      :else     (:border-default tokens/tokens))
+                             :width 14
+                             :height 14}
+                 :data      {:eventLabel ""
+                             :eventLineLabel ""
+                             :active     from-active?
+                             :focused    focused?
+                             :fired      fired?
+                             :afterMs    nil
+                             :guard      nil
+                             :action     nil
+                             :selfLoop   false
+                             :loopIndex  nil
+                             :siblingIndex 0
+                             :siblingCount 1
+                             :crossHierarchy cross-hier?
+                             :points     nil
+                             :internal   false
+                             :machineLevel (boolean (:machine-level? edge))
+                             :eventId    nil
+                             :fromPath   (:from-path edge)
+                             :toPath     (:to-path edge)
+                             :onClick    nil
+                             :chart      chart
+                             :inbound    true
+                             :eventNodeId ev-node-id
+                             :spec-edge-id (:id edge)}})
+              edge-descriptors)
+        ;; Outbound edges: event-node → target-state. Omitted for
+        ;; internal transitions (`:internal? true`) — the event-node
+        ;; hangs with no outgoing arrow per the Stately graph view
+        ;; convention for internal handlers ("runs an action, no state
+        ;; change").
+        outbound-edges
+        (->> edge-descriptors
+             (remove (fn [{:keys [internal?]}] internal?))
+             (mapv (fn [{:keys [edge ev-node-id focused? fired? from-active?
+                                cross-hier? points]}]
+                     {:id        (str (:id edge) "__out")
+                      :source    ev-node-id
+                      :target    (:target edge)
+                      :type      "transition"
+                      :markerEnd {:type "arrowclosed"
+                                  :color (cond
+                                           fired?    (:accent tokens/tokens)
+                                           focused?  (:info tokens/tokens)
+                                           from-active? (:info tokens/tokens)
+                                           :else     (:border-default tokens/tokens))
+                                  :width 18
+                                  :height 18}
+                      :data      {:eventLabel ""
+                                  :eventLineLabel ""
+                                  :active     from-active?
+                                  :focused    focused?
+                                  :fired      fired?
+                                  :afterMs    nil
+                                  :guard      nil
+                                  :action     nil
+                                  :selfLoop   false
+                                  :loopIndex  nil
+                                  :siblingIndex 0
+                                  :siblingCount 1
+                                  :crossHierarchy cross-hier?
+                                  :points     points
+                                  :internal   false
+                                  :machineLevel (boolean (:machine-level? edge))
+                                  :eventId    nil
+                                  :fromPath   (:from-path edge)
+                                  :toPath     (:to-path edge)
+                                  :onClick    nil
+                                  :chart      chart
+                                  :outbound   true
+                                  :eventNodeId ev-node-id
+                                  :spec-edge-id (:id edge)}})))
+        proj-edges (vec (concat inbound-edges outbound-edges))
 
         ;; Initial-state markers — a small filled dot wired into each
         ;; `:initial?` state via an unlabelled entry edge. xstate/SCXML
@@ -583,5 +686,11 @@
                                :eventId nil :fromPath nil :toPath nil
                                :onClick on-edge-click :chart chart}})
               initial-nodes)]
-    {:nodes (into proj-nodes marker-nodes)
+    ;; rf2-qo5xy — order matters for xyflow: parent containers must
+    ;; precede any node that references them via `:parentId`. State /
+    ;; region / compound nodes are already sorted parent-first; the
+    ;; event-nodes nest into the same parents (we set `:parent-id` to
+    ;; the source state's parent), so appending them AFTER `proj-nodes`
+    ;; keeps the parent-before-child invariant.
+    {:nodes (vec (concat proj-nodes marker-nodes event-nodes))
      :edges (into proj-edges entry-edges)}))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/chart_dom_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/chart_dom_cljs_test.cljs
@@ -605,33 +605,32 @@
                           (= event     (:event e)))
                  (:id e))))))
 
-(deftest chart-fired-edge-renders-data-fired-on-the-right-edge
-  (testing "rf2-qeemm (G3) — passing :fired-edge-ids #{<idle→loading id>}
-            renders data-fired=\"true\" on THAT edge's label and
-            data-fired=\"false\" on every other edge label"
+(deftest chart-fired-event-node-renders-data-fired
+  (testing "rf2-qeemm (G3) + rf2-qo5xy — events-as-nodes paradigm:
+            passing :fired-edge-ids #{<idle→loading id>} marks the
+            matching event-node (xyflow `rf2-event`) with
+            data-fired=\"true\"; non-fired event-nodes carry
+            data-fired=\"false\"."
     (if-not (browser?)
       (is true ":node-test: no DOM — browser-test runner exercises this")
-      (let [start-id (canonical-edge-id idle-loading-done [:idle] [:loading] :start)]
+      (let [start-id (canonical-edge-id idle-loading-done [:idle] [:loading] :start)
+            fired-ev-id (str "event__" start-id)]
         (with-mounted-chart
           {:machine-id     :test/flow
            :definition     idle-loading-done
            :fired-edge-ids #{start-id}}
           (fn [_root node]
             (let [fired-el (.querySelector
-                             node (str "[data-testid=\"rf-mv-chart-edge-" start-id "\"]"))
-                  all      (array-seq
-                             (.querySelectorAll node "[data-testid^=\"rf-mv-chart-edge-\"]"))
-                  others   (remove #(= % fired-el) all)]
-              ;; edge labels mount on first commit (no layout dependency)
+                             node (str "[data-testid=\"rf-mv-chart-event-" fired-ev-id "\"]"))
+                  all-evs  (array-seq
+                             (.querySelectorAll node "[data-testid^=\"rf-mv-chart-event-\"]"))
+                  others   (remove #(= % fired-el) all-evs)]
               (when (some? fired-el)
-                (is (= "true" (.getAttribute fired-el "data-fired"))
-                    "the fired edge's label carries data-fired=true")
-                (is (every? #(= "false" (.getAttribute % "data-fired")) others)
-                    "no other edge label is marked fired"))
-              ;; structural invariant so the test is meaningful even if a
-              ;; label races the commit.
+                (is (= "true" (.getAttribute fired-el "data-fired")))
+                (is (every? #(or (= "false" (.getAttribute % "data-fired"))
+                                 (nil? (.getAttribute % "data-fired"))) others)))
               (is (number? (.-length (.querySelectorAll
-                                       node "[data-testid^=\"rf-mv-chart-edge-\"]")))))))))))
+                                       node "[data-testid^=\"rf-mv-chart-event-\"]")))))))))))
 
 (deftest chart-fired-edge-ids-surfaces-on-root
   (testing "rf2-qeemm (G3) — the chart root surfaces the sorted fired set

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
@@ -109,6 +109,28 @@
   [graph id]
   (first (filter #(= id (:id %)) (:nodes graph))))
 
+(defn- event-node-for
+  "rf2-qo5xy — find the event-node a projected graph emitted for a
+  given parsed-edge id. The events-as-nodes paradigm hoists each
+  transition into a `\"rf2-event\"` xyflow node; the legacy single-
+  edge state→state shape (with the event/guard/action on the edge
+  label) is gone."
+  [graph parsed-edge-id]
+  (first (filter #(and (= "rf2-event" (:type %))
+                       (= (str "event__" parsed-edge-id) (:id %)))
+                 (:nodes graph))))
+
+(defn- inbound-edge-for
+  "rf2-qo5xy — the source-state → event-node edge for a parsed-edge id."
+  [graph parsed-edge-id]
+  (edge-by-id graph (str parsed-edge-id "__in")))
+
+(defn- outbound-edge-for
+  "rf2-qo5xy — the event-node → target-state edge for a parsed-edge
+  id. nil for internal transitions (which emit no outbound edge)."
+  [graph parsed-edge-id]
+  (edge-by-id graph (str parsed-edge-id "__out")))
+
 ;; ---- choose-edge-type (G2) ---------------------------------------------
 
 (deftest choose-edge-type-plain-transition
@@ -517,23 +539,30 @@
       (is (true? (:active (:data e)))))))
 
 (deftest xyflow-graph-edge-focused-when-source-and-target-match-lens
-  (testing "an edge is `:focused` ONLY when source==from-highlight AND
-            target==to-highlight (the focused-event lens). A partial
-            match is not focused."
+  (testing "rf2-qo5xy — events-as-nodes paradigm: an inbound edge
+            (source-state → event-node) is `:focused` when the parsed
+            transition's source/target match the from/to lens. The
+            paired outbound edge (event-node → target-state) gets the
+            same focused flag so the WHOLE traversal lights up."
     (let [parsed (layout/parse-definition idle-loading)
           from   (layout/node-id [:idle])
           to     (layout/node-id [:loading])
+          start-edge (->> (:edges parsed)
+                          (filter #(= (:source %) from))
+                          first)
           graph  (projection/xyflow-graph parsed {}
                                           {:from-highlight-id from
                                            :to-highlight-id   to})
-          focused-edge (first (filter #(and (= (:source %) from)
-                                            (= (:target %) to))
-                                      (:edges graph)))
-          other-edges  (remove #(and (= (:source %) from)
-                                      (= (:target %) to))
-                               (:edges graph))]
-      (is (true? (:focused (:data focused-edge))))
-      (is (every? false? (map (comp :focused :data) other-edges))))))
+          in-edge  (inbound-edge-for  graph (:id start-edge))
+          out-edge (outbound-edge-for graph (:id start-edge))]
+      (is (some? in-edge)  "the inbound edge for the focused transition exists")
+      (is (some? out-edge) "and so does the outbound edge")
+      (is (true? (:focused (:data in-edge))))
+      (is (true? (:focused (:data out-edge))))
+      ;; Every OTHER edge is not focused.
+      (let [other-edges (remove #(#{(:id in-edge) (:id out-edge)} (:id %))
+                                (:edges graph))]
+        (is (every? false? (map (comp :focused :data) other-edges)))))))
 
 (deftest xyflow-graph-edge-not-focused-without-both-lens-ends
   (testing "with only ONE lens end set, no edge is focused (the
@@ -658,41 +687,46 @@
           idle   (node-by-id graph (layout/node-id [:idle]))]
       (is (= {:x 0 :y 0} (:position idle))))))
 
-(deftest xyflow-graph-edge-carries-after-ms-and-event-label
-  (testing "edge `:data` surfaces the after-ms duration + the composed
-            event label from the parsed edge"
-    (let [parsed (layout/parse-definition idle-loading)
-          graph  (projection/xyflow-graph parsed {} {})
-          after  (first (filter #(:afterMs (:data %)) (:edges graph)))]
-      (is (some? after) "the :after edge surfaces an :afterMs")
-      (is (= 1000 (:afterMs (:data after))))
-      (is (string? (:eventLabel (:data after)))))))
+(deftest xyflow-graph-event-node-carries-after-ms-and-event-label
+  (testing "rf2-qo5xy — events-as-nodes paradigm: the event-node
+            (not the edge) carries the `:afterMs` + the visible event
+            label. The `⌚`-prefixed segment (from chart.layout/event-
+            segment) rides on the event-node's `:eventLabel`."
+    (let [parsed     (layout/parse-definition idle-loading)
+          graph      (projection/xyflow-graph parsed {} {})
+          after-parsed (first (filter :after (:edges parsed)))
+          after-node (event-node-for graph (:id after-parsed))]
+      (is (some? after-parsed) "parser emitted an :after edge")
+      (is (some? after-node)   "projector emitted the matching event-node")
+      (is (= 1000 (:afterMs (:data after-node))))
+      (is (string? (:eventLabel (:data after-node))))
+      (is (= "after" (:variant (:data after-node)))
+          "the variant attribute identifies the `:after` event-node kind"))))
 
-(deftest xyflow-graph-edge-carries-event-line-label-without-action
-  (testing "rf2-a2b55 — Stately graph view convention: the visible edge
-            label paints `event [guard]` on one row and the action as a
-            `+ <action>` pill on a row below. `:eventLineLabel` is the
-            event-line text without the `/ action` suffix; `:eventLabel`
-            keeps the full `event [guard] / action` form for the
-            data-event attr + host introspection. Both fields ride the
-            edge `:data`."
-    (let [parsed (layout/parse-definition idle-loading)
-          graph  (projection/xyflow-graph parsed {} {})
-          ;; idle-loading's `:start` edge has no guard / no action
-          start  (first (filter #(re-find #"^start"
-                                          (or (:eventLabel (:data %)) ""))
-                                (:edges graph)))]
-      (is (some? start) "fixture has the :start edge")
-      (is (= "start" (:eventLabel (:data start)))
-          "without guard/action `:eventLabel` is just the event id")
-      (is (= "start" (:eventLineLabel (:data start)))
-          "without guard `:eventLineLabel` matches `:eventLabel`"))))
+(deftest xyflow-graph-event-node-eventLabel-is-event-segment
+  (testing "rf2-qo5xy — the event-node's `:eventLabel` is the raw
+            event-segment text from chart.layout/event-segment (e.g.
+            \"start\"); guard/action ride on dedicated `:guard` +
+            `:action` slots of the event-node payload."
+    (let [parsed     (layout/parse-definition idle-loading)
+          graph      (projection/xyflow-graph parsed {} {})
+          start-parsed (->> (:edges parsed)
+                            (filter #(= (:source %) (layout/node-id [:idle])))
+                            first)
+          ev-node    (event-node-for graph (:id start-parsed))]
+      (is (some? start-parsed) "parser emitted the :start edge")
+      (is (some? ev-node)      "projector emitted the matching event-node")
+      (is (= "start" (:eventLabel (:data ev-node)))
+          "no guard/action: the label is just the event segment")
+      (is (= "on" (:variant (:data ev-node)))
+          "regular :on event-node variant"))))
 
-(deftest xyflow-graph-edge-event-line-strips-action-suffix
-  (testing "rf2-a2b55 — when an edge has an :action, `:eventLineLabel`
-            keeps the event-only line (no `/ action`); the full label
-            text remains on `:eventLabel`. Tests the divergence point
-            between the two fields directly."
+(deftest xyflow-graph-event-node-surfaces-guard-and-action
+  (testing "rf2-qo5xy — when an edge declares a guard / action, the
+            event-node's `:data` carries them as separate strings (the
+            renderer paints the `[guard]` chip + `+ <action>` pill from
+            these). The legacy `event [guard] / action` text composition
+            is gone — each piece sits in its own slot."
     (let [m {:initial :idle
              :states  {:idle {:on {:submit {:target :loading
                                             :guard  :authed?
@@ -700,14 +734,12 @@
                        :loading {}}}
           parsed (layout/parse-definition m)
           graph  (projection/xyflow-graph parsed {} {})
-          submit (first (filter #(re-find #"^submit"
-                                          (or (:eventLabel (:data %)) ""))
-                                (:edges graph)))]
-      (is (some? submit) "fixture has the :submit edge")
-      (is (= "submit [authed?] / log-it" (:eventLabel (:data submit)))
-          "`:eventLabel` keeps the full xstate text form")
-      (is (= "submit [authed?]" (:eventLineLabel (:data submit)))
-          "`:eventLineLabel` strips the `/ action` suffix"))))
+          submit-parsed (first (:edges parsed))
+          ev-node       (event-node-for graph (:id submit-parsed))]
+      (is (some? ev-node) "the event-node was projected")
+      (is (= "submit"  (:eventLabel (:data ev-node))))
+      (is (= "authed?" (:guard      (:data ev-node))))
+      (is (= "log-it"  (:action     (:data ev-node)))))))
 
 (deftest xyflow-graph-entry-edge-carries-empty-event-line-label
   (testing "rf2-a2b55 — entry edges (initial-marker → leaf) have no
@@ -804,53 +836,54 @@
 ;; guard that wiring; the edge component's click behaviour is pinned at
 ;; the DOM layer (chart_dom).
 
-(deftest xyflow-graph-edge-carries-fireable-event-id
-  (testing "rf2-u422r — a plain `:on` transition edge carries its raw
-            fireable `:eventId` (the keyword the sim sends) + the
-            from/to paths on its `:data`"
+(deftest xyflow-graph-event-node-carries-fireable-event-id
+  (testing "rf2-u422r + rf2-qo5xy — the event-node (not an edge) carries
+            its fireable `:eventId` for the on-chart sim path; from/to
+            paths ride with it so the host can dispatch the originating
+            transition."
+    (let [parsed   (layout/parse-definition idle-loading)
+          graph    (projection/xyflow-graph parsed {} {})
+          start    (->> (:edges parsed)
+                        (filter #(= (:source %) (layout/node-id [:idle])))
+                        first)
+          ev-node  (event-node-for graph (:id start))]
+      (is (some? ev-node) "the start event-node was projected")
+      (is (= :start (:eventId (:data ev-node)))
+          "the raw fireable event keyword rides on the event-node")
+      (is (= [:idle]    (:fromPath (:data ev-node))))
+      (is (= [:loading] (:toPath   (:data ev-node)))))))
+
+(deftest xyflow-graph-after-and-always-event-nodes-not-fireable
+  (testing "rf2-u422r + rf2-qo5xy — `:after` + `:always` event-nodes
+            carry nil `:eventId` (the engine fires them automatically;
+            the host filters them out for clickability). Their variant
+            slot still identifies them as `:after` / `:always`."
     (let [parsed (layout/parse-definition idle-loading)
           graph  (projection/xyflow-graph parsed {} {})
-          start  (first (filter #(= (:source %) (layout/node-id [:idle]))
-                                (:edges graph)))]
-      (is (some? start) "fixture has the idle→loading :start edge")
-      (is (= :start (:eventId (:data start)))
-          "the raw fireable event keyword rides on the edge data")
-      (is (= [:idle] (:fromPath (:data start))))
-      (is (= [:loading] (:toPath (:data start)))))))
+          after-parsed  (first (filter :after   (:edges parsed)))
+          always-parsed (first (filter :always? (:edges parsed)))
+          after-node    (event-node-for graph (:id after-parsed))
+          always-node   (event-node-for graph (:id always-parsed))]
+      (is (some? after-node)  "fixture has an :after event-node")
+      (is (nil? (:eventId (:data after-node))) "not user-fireable")
+      (is (= "after" (:variant (:data after-node))))
+      (is (some? always-node) "fixture has an :always event-node")
+      (is (nil? (:eventId (:data always-node))) "not user-fireable")
+      (is (= "always" (:variant (:data always-node)))))))
 
-(deftest xyflow-graph-after-and-always-edges-are-not-fireable
-  (testing "rf2-u422r — `:after`-timer + `:always` eventless edges fire
-            automatically inside the engine, so they carry a nil
-            `:eventId` (the host filters them out — they are not
-            user-clickable on the chart)"
-    (let [parsed (layout/parse-definition idle-loading)
-          graph  (projection/xyflow-graph parsed {} {})
-          after  (first (filter #(:afterMs (:data %)) (:edges graph)))
-          ;; rf2-a2b55 — the `:always` edge's label segment renders as
-          ;; the Stately graph view infinity glyph (the guarded
-          ;; fixture renders "∞ [loaded?]").
-          always (first (filter #(re-find #"^∞"
-                                          (or (:eventLabel (:data %)) ""))
-                                (:edges graph)))]
-      (is (some? after) "fixture has an :after edge")
-      (is (nil? (:eventId (:data after)))
-          "the :after edge is not user-fireable")
-      (is (some? always) "fixture has an :always edge")
-      (is (nil? (:eventId (:data always)))
-          "the :always edge is not user-fireable"))))
-
-(deftest xyflow-graph-threads-on-edge-click-onto-every-edge
-  (testing "rf2-u422r — the host's `:on-edge-click` callback threads onto
-            EVERY edge's `:data {:onClick}` (the edge component decides
-            clickability from the presence of BOTH the callback + a
-            fireable event-id)"
+(deftest xyflow-graph-threads-on-edge-click-onto-every-event-node
+  (testing "rf2-u422r + rf2-qo5xy — the host's `:on-edge-click` (now
+            on-event-click) threads onto every event-node's
+            `:data {:onClick}` (the event-node component decides
+            clickability from the callback + fireable eventId pair)."
     (let [parsed   (layout/parse-definition idle-loading)
           captured (atom nil)
           cb       (fn [m] (reset! captured m))
-          graph    (projection/xyflow-graph parsed {} {:on-edge-click cb})]
-      (is (seq (:edges graph)))
-      (is (every? #(= cb (:onClick (:data %))) (:edges graph))
-          "every edge carries the same on-edge-click callback"))))
+          graph    (projection/xyflow-graph parsed {} {:on-edge-click cb})
+          ev-nodes (filter #(= "rf2-event" (:type %)) (:nodes graph))]
+      (is (seq ev-nodes))
+      (is (every? #(= cb (:onClick (:data %))) ev-nodes)
+          "every event-node carries the same on-event-click callback"))))
 
 (deftest xyflow-graph-omits-on-click-when-no-callback
   (testing "rf2-u422r — omitting `:on-edge-click` leaves `:onClick` nil
@@ -861,12 +894,17 @@
 
 ;; ---- ->elk-children (G3) -----------------------------------------------
 
-(deftest elk-children-flat-is-one-per-node
-  (testing "a flat machine projects one elk child per parsed node, each
-            with id + width/height floors + a label"
+(deftest elk-children-flat-is-state-plus-event-nodes
+  (testing "rf2-qo5xy — a flat machine projects one elk child per
+            parsed state node PLUS one synthetic event-node per parsed
+            transition (events-as-nodes paradigm). All children carry
+            id + width/height + label."
     (let [parsed   (layout/parse-definition idle-loading)
-          children (projection/->elk-children parsed)]
-      (is (= (count (:nodes parsed)) (count children)))
+          children (projection/->elk-children parsed)
+          n-states (count (:nodes parsed))
+          n-events (count (:edges parsed))]
+      (is (= (+ n-states n-events) (count children))
+          "states + events = total flat children")
       (is (every? :id children))
       (is (every? #(pos? (:width %)) children))
       (is (every? #(pos? (:height %)) children)))))
@@ -885,20 +923,23 @@
       (is (= projection/state-node-min-height (:height leaf))))))
 
 (deftest elk-children-parallel-nests-states-under-regions
-  (testing "rf2-lkwev — a parallel machine projects ONE elk child per
-            region (not per state); each region carries its own
-            layoutOptions + nests its states as :children so elkjs lays
-            them out inside the zone"
+  (testing "rf2-lkwev + rf2-qo5xy — a parallel machine projects ONE elk
+            top-level child per region (regions are the only top-level
+            structural containers); each region nests its states AND
+            the events declared inside as `:children`."
     (let [parsed   (layout/parse-definition parallel-machine)
-          children (projection/->elk-children parsed)]
-      ;; two regions → two top-level elk children
-      (is (= 2 (count children)))
-      (is (every? #(contains? % :layoutOptions) children))
-      (is (every? #(seq (:children %)) children))
-      ;; the audio region nests its two states
+          children (projection/->elk-children parsed)
+          regions  (filter #(re-find #"^region__" (:id %)) children)]
+      (is (= 2 (count regions))
+          "two regions land as top-level elk children")
+      (is (every? #(contains? % :layoutOptions) regions))
+      (is (every? #(seq (:children %)) regions))
+      ;; the audio region nests its two states + its two events
+      ;; (`:unmute` + `:mute`).
       (let [audio (first (filter #(= (layout/region-node-id :audio) (:id %))
-                                 children))]
-        (is (= 2 (count (:children audio))))))))
+                                 regions))]
+        (is (= 4 (count (:children audio)))
+            "2 states + 2 events nest under the audio region")))))
 
 (deftest elk-children-region-padding-leaves-header-room
   (testing "each region's elk.padding leaves top room for the header
@@ -953,15 +994,30 @@
       (is (not (contains? marker :parentNode))
           "rf2-xh1lm — the pre-v12 :parentNode key MUST NOT appear"))))
 
-(deftest xyflow-graph-flags-self-transition
-  (testing "rf2-54s5a — a source==target edge carries :data {:selfLoop true}"
+(deftest xyflow-graph-self-transition-routes-through-event-node
+  (testing "rf2-qo5xy — a self-transition (source == target in the
+            parsed graph) routes through its event-node like every
+            other transition: source-state → event-node → source-state.
+            The structural self-loop becomes a TWO-edge fork — the
+            event-node sits beside the state, both edges anchor on it.
+            Pre-rf2-qo5xy a self-loop was a single edge with selfLoop
+            true; the events-as-nodes paradigm dissolves that special
+            case (the visible loop arc is now the route around the
+            event-node)."
     (let [parsed   (layout/parse-definition self-loop-machine)
           graph    (projection/xyflow-graph parsed {} {})
-          self     (first (filter #(= (:source %) (:target %)) (:edges graph)))
-          non-self (first (filter #(not= (:source %) (:target %)) (:edges graph)))]
-      (is (some? self) "fixture has a self-transition")
-      (is (true?  (:selfLoop (:data self))))
-      (is (false? (:selfLoop (:data non-self)))))))
+          self     (first (filter #(= (:source %) (:target %))
+                                  (:edges parsed)))
+          in-edge  (inbound-edge-for  graph (:id self))
+          out-edge (outbound-edge-for graph (:id self))]
+      (is (some? self)     "fixture has a self-transition (parsed)")
+      (is (some? in-edge)  "the inbound edge survives projection")
+      (is (some? out-edge) "the outbound edge survives projection")
+      (is (= (:source self) (:source in-edge))  "inbound source == state")
+      (is (= (:source self) (:target out-edge)) "outbound target == state")
+      ;; Both edges connect through the same event-node.
+      (is (= (:target in-edge) (:source out-edge))
+          "inbound target == outbound source == event-node"))))
 
 (deftest xyflow-graph-compound-children-wire-parent-id
   (testing "rf2-54s5a + rf2-xh1lm — compound substates nest via xyflow
@@ -976,80 +1032,101 @@
       (is (not (contains? browsing :parentNode))
           "rf2-xh1lm — the pre-v12 :parentNode key MUST NOT appear"))))
 
-(deftest elk-children-nests-compound-substates
-  (testing "rf2-54s5a — a compound parent nests its substates as elk
-            :children (so they lay out inside the container)"
+(deftest elk-children-nests-compound-substates-and-events
+  (testing "rf2-54s5a + rf2-qo5xy — a compound parent nests its
+            substates AS WELL AS the event-nodes of any transition
+            whose source is inside the compound. State nodes count is
+            unchanged (2); event-nodes for `:checkout` (browsing → paying)
+            and `:done` (paying → browsing) sit inside too."
     (let [parsed   (layout/parse-definition compound-machine)
           children (projection/->elk-children parsed)
           by-id    (into {} (map (juxt :id identity) children))
           authed   (get by-id (layout/node-id [:authenticated]))]
       (is (some? authed) "compound parent is a top-level elk child")
-      (is (= 2 (count (:children authed)))
-          "browsing + paying nest inside"))))
+      (let [kid-types (group-by #(if (re-find #"^event__" (:id %))
+                                   :event :state)
+                                (:children authed))]
+        (is (= 2 (count (:state kid-types)))
+            "browsing + paying state-nodes nest inside")
+        (is (= 2 (count (:event kid-types)))
+            "two event-nodes (checkout + done) nest inside too")))))
 
 ;; ---- self-transitions / wildcard / machine-level :on (rf2-ee38b.21) ----
 
-(deftest xyflow-graph-same-state-projects-self-loop
-  (testing "rf2-ee38b.21 — `:target :same-state` projects a true
-            self-loop (source == target, :selfLoop true) into a REAL
-            node — not a dangling edge to a phantom :same-state node"
+(deftest xyflow-graph-same-state-projects-through-event-node
+  (testing "rf2-ee38b.21 + rf2-qo5xy — `:target :same-state` resolves
+            to source == target in the parsed graph; the projector
+            routes the transition through an event-node (no phantom
+            target node)."
     (let [parsed   (layout/parse-definition same-state-machine)
           graph    (projection/xyflow-graph parsed {} {})
           node-ids (set (map :id (:nodes graph)))
-          ;; the only non-entry edge is the :ping self-transition
-          ping     (first (remove #(:entry (:data %)) (:edges graph)))]
-      (is (some? ping))
-      (is (= (:source ping) (:target ping)) "source == target")
-      (is (true? (:selfLoop (:data ping))))
-      (is (contains? node-ids (:target ping))
-          "target is a real node, not a phantom :same-state"))))
+          ping     (first (:edges parsed))
+          in-edge  (inbound-edge-for  graph (:id ping))
+          out-edge (outbound-edge-for graph (:id ping))]
+      (is (= (:source ping) (:target ping)) "parsed: source == target")
+      (is (some? in-edge))
+      (is (some? out-edge))
+      (is (contains? node-ids (:target out-edge))
+          "the outbound target is a real node, not a phantom"))))
 
-(deftest xyflow-graph-internal-self-transition-flagged
-  (testing "rf2-ee38b.21 — an internal self-transition (omit :target)
-            projects a self-loop flagged `:internal true`"
-    (let [parsed (layout/parse-definition internal-self-machine)
-          graph  (projection/xyflow-graph parsed {} {})
-          tick   (first (remove #(:entry (:data %)) (:edges graph)))]
-      (is (some? tick))
-      (is (= (:source tick) (:target tick)))
-      (is (true? (:selfLoop (:data tick))))
-      (is (true? (:internal (:data tick)))))))
+(deftest xyflow-graph-internal-self-transition-emits-no-outbound
+  (testing "rf2-ee38b.21 + rf2-qo5xy — an internal self-transition
+            (omit :target) emits an inbound edge into the event-node
+            but NO outbound edge — the Stately convention 'runs an
+            action and we hang here'. The event-node carries
+            `:internal true`."
+    (let [parsed   (layout/parse-definition internal-self-machine)
+          graph    (projection/xyflow-graph parsed {} {})
+          tick     (first (:edges parsed))
+          ev-node  (event-node-for graph (:id tick))
+          in-edge  (inbound-edge-for  graph (:id tick))
+          out-edge (outbound-edge-for graph (:id tick))]
+      (is (true? (:internal? tick)) "parser flagged the internal transition")
+      (is (some? ev-node))
+      (is (true? (:internal (:data ev-node))))
+      (is (some? in-edge)  "inbound edge into the event-node is emitted")
+      (is (nil? out-edge)  "no outbound edge (internal hangs at the event-node)"))))
 
-(deftest xyflow-graph-wildcard-not-fireable
-  (testing "rf2-ee38b.21 — the `:*` wildcard edge carries a NIL :eventId
-            so the on-chart sim can't dispatch a literal `[:* ...]`
-            (same inert posture as :after / :always); the real `:start`
-            event stays fireable"
+(deftest xyflow-graph-wildcard-event-node-not-fireable
+  (testing "rf2-ee38b.21 + rf2-qo5xy — the `:*` wildcard transition's
+            event-node carries a NIL :eventId (not user-fireable on
+            the chart); the real `:start` event-node stays fireable."
     (let [parsed (layout/parse-definition wildcard-machine)
           graph  (projection/xyflow-graph parsed {} {})
+          ev-nodes (filter #(= "rf2-event" (:type %)) (:nodes graph))
           wild   (first (filter #(re-find #"\(any\)"
                                           (or (:eventLabel (:data %)) ""))
-                                (:edges graph)))
-          start  (first (filter #(= :start (:eventId (:data %)))
-                                (:edges graph)))]
-      (is (some? wild) "the wildcard edge is present")
-      (is (nil? (:eventId (:data wild))) "wildcard is NOT fireable")
-      (is (some? start) "the real :start edge stays fireable")
+                                ev-nodes))
+          start  (first (filter #(= :start (:eventId (:data %))) ev-nodes))]
+      (is (some? wild) "the wildcard event-node is present")
+      (is (nil? (:eventId (:data wild))))
+      (is (some? start) "the real :start event-node stays fireable")
       (is (= :start (:eventId (:data start)))))))
 
-(deftest xyflow-graph-machine-level-on-flagged
-  (testing "rf2-ee38b.21 — machine-level (top-level) :on fallback edges
-            project with `:machineLevel true` from every leaf"
+(deftest xyflow-graph-machine-level-event-nodes-flagged
+  (testing "rf2-ee38b.21 + rf2-qo5xy — machine-level (top-level) :on
+            fallback transitions project as event-nodes flagged
+            `:machineLevel true` (one per inheriting leaf)."
     (let [parsed (layout/parse-definition machine-level-on-machine)
           graph  (projection/xyflow-graph parsed {} {})
-          logout (filter #(= :logout (:eventId (:data %))) (:edges graph))]
-      (is (= 2 (count logout)) "one inherited edge per leaf")
+          ev-nodes (filter #(= "rf2-event" (:type %)) (:nodes graph))
+          logout (filter #(= :logout (:eventId (:data %))) ev-nodes)]
+      (is (= 2 (count logout)) "one inherited event-node per leaf")
       (is (every? #(true? (:machineLevel (:data %))) logout)))))
 
 (deftest xyflow-graph-state-only-transitions-not-machine-level
-  (testing "rf2-ee38b.21 — a normal state-local transition carries
-            `:machineLevel false`"
-    (let [parsed (layout/parse-definition idle-loading)
-          graph  (projection/xyflow-graph parsed {} {})
-          start  (first (filter #(= :start (:eventId (:data %))) (:edges graph)))]
-      (is (some? start))
-      (is (false? (:machineLevel (:data start))))
-      (is (false? (:internal (:data start)))))))
+  (testing "rf2-ee38b.21 + rf2-qo5xy — a normal state-local transition's
+            event-node carries `:machineLevel false`."
+    (let [parsed  (layout/parse-definition idle-loading)
+          graph   (projection/xyflow-graph parsed {} {})
+          start-p (->> (:edges parsed)
+                       (filter #(= :start (:event %)))
+                       first)
+          ev-node (event-node-for graph (:id start-p))]
+      (is (some? ev-node))
+      (is (false? (:machineLevel (:data ev-node))))
+      (is (false? (:internal     (:data ev-node)))))))
 
 ;; ---- entry / exit state actions (rf2-ee38b.21) -------------------------
 
@@ -1079,40 +1156,44 @@
 ;; across a container (§1.7 of `001-Topology-Parity.md`). These pins
 ;; guard the projection half at the cheap JVM layer.
 
-(deftest xyflow-graph-attaches-edge-points-to-matching-edge
-  (testing "rf2-cz8v6 (THE G2 CAPABILITY) — an edge whose id has an
-            entry in :edge-points carries that route on its
-            `:data {:points}` so the edge renders THROUGH the bend
-            points (not a straight/bezier shortcut)"
+(deftest xyflow-graph-attaches-edge-points-to-outbound-edge
+  (testing "rf2-cz8v6 + rf2-qo5xy — a parsed-edge's elk-routed bend-
+            points attach to the OUTBOUND edge (event-node → target
+            state). The visible curve `transition-edge` paints is the
+            event-node-to-state segment; the structurally-short
+            source-state-to-event-node segment keeps the bezier
+            fallback (a single straight handoff to the event-node)."
     (let [parsed   (layout/parse-definition idle-loading)
-          ;; the idle→loading :start edge
           start    (->> (:edges parsed)
                         (filter #(= (:source %) (layout/node-id [:idle])))
                         first)
           route    [{:x 0 :y 0} {:x 0 :y 50} {:x 80 :y 50} {:x 80 :y 100}]
           graph    (projection/xyflow-graph
                      parsed {} {:edge-points {(:id start) route}})
-          start-e  (edge-by-id graph (:id start))]
-      (is (some? start-e))
-      (is (= route (:points (:data start-e)))
-          "elk's routed bend-points ride on the edge data"))))
+          out-edge (outbound-edge-for graph (:id start))]
+      (is (some? out-edge))
+      (is (= route (:points (:data out-edge)))
+          "elk's routed bend-points ride on the outbound edge"))))
 
 (deftest xyflow-graph-edge-without-route-falls-back-to-nil-points
-  (testing "rf2-cz8v6 — a simple edge with no :edge-points entry carries
-            `:points nil`, so the edge component falls back to the
-            bezier path (the no-bend-point case)"
+  (testing "rf2-cz8v6 + rf2-qo5xy — outbound edges with no :edge-points
+            entry carry `:points nil` (bezier fallback). Inbound edges
+            never carry points (they are short handoffs into the
+            event-node)."
     (let [parsed (layout/parse-definition idle-loading)
-          ;; supply a route for ONE edge only; every other edge is bare
           start  (->> (:edges parsed)
                       (filter #(= (:source %) (layout/node-id [:idle])))
                       first)
           graph  (projection/xyflow-graph
                    parsed {} {:edge-points {(:id start) [{:x 0 :y 0} {:x 9 :y 9}]}})
-          others (remove #(= (:id %) (:id start))
-                         (remove #(:entry (:data %)) (:edges graph)))]
-      (is (seq others) "fixture has more than one transition edge")
-      (is (every? #(nil? (:points (:data %))) others)
-          "edges with no route entry carry nil points (bezier fallback)"))))
+          out-edges    (filter #(:outbound (:data %)) (:edges graph))
+          inbound-edges (filter #(:inbound  (:data %)) (:edges graph))
+          other-outs   (remove #(= (:id %) (str (:id start) "__out")) out-edges)]
+      (is (seq other-outs) "fixture has additional outbound edges")
+      (is (every? #(nil? (:points (:data %))) other-outs)
+          "outbound edges with no route entry carry nil points")
+      (is (every? #(nil? (:points (:data %))) inbound-edges)
+          "inbound edges never carry routed points"))))
 
 (deftest xyflow-graph-no-edge-points-leaves-all-points-nil
   (testing "rf2-cz8v6 — omitting :edge-points entirely (the pre-layout
@@ -1124,26 +1205,32 @@
       (is (every? #(nil? (:points (:data %))) (:edges graph))
           "no edge-points map → no routed edges"))))
 
-(deftest xyflow-graph-self-loop-never-carries-points
-  (testing "rf2-cz8v6 — a self-loop keeps its dedicated loop path: even
-            when elk emits a route for the self-edge id, the projector
-            drops it so :points stays nil (self-loops unchanged)"
+(deftest xyflow-graph-self-loop-outbound-can-carry-points
+  (testing "rf2-cz8v6 + rf2-qo5xy — the events-as-nodes paradigm
+            dissolves the legacy self-loop special case: a self-
+            transition's outbound edge (event-node → source-state)
+            is just a regular edge with elk-routed points. The visible
+            loop arc is the route around the event-node sibling."
     (let [parsed (layout/parse-definition self-loop-machine)
           self   (->> (:edges parsed)
                       (filter #(= (:source %) (:target %)))
                       first)
           graph  (projection/xyflow-graph
-                   parsed {} {:edge-points {(:id self) [{:x 0 :y 0} {:x 5 :y 5}]}})
-          self-e (edge-by-id graph (:id self))]
+                   parsed {} {:edge-points {(:id self)
+                                            [{:x 0 :y 0} {:x 5 :y 5} {:x 10 :y 0}]}})
+          out-edge (outbound-edge-for graph (:id self))]
       (is (some? self) "fixture has a self-transition")
-      (is (true? (:selfLoop (:data self-e))))
-      (is (nil? (:points (:data self-e)))
-          "a self-loop never carries elk points (it keeps its loop path)"))))
+      (is (some? out-edge) "outbound edge survives projection")
+      ;; The route attaches to the outbound edge (the visible loop
+      ;; arc) — no longer dropped as in the legacy single-edge model.
+      (is (= [{:x 0 :y 0} {:x 5 :y 5} {:x 10 :y 0}]
+             (:points (:data out-edge)))))))
 
 (deftest xyflow-graph-routed-edge-keeps-active-highlight
-  (testing "rf2-cz8v6 — G1's active-edge styling survives routing: an
-            edge that BOTH has a route AND touches the highlighted node
-            is `:active` (highlighted) AND carries its `:points`"
+  (testing "rf2-cz8v6 + rf2-qo5xy — G1's active-edge styling survives
+            routing through the event-node: an outbound edge whose
+            target is active carries both `:active true` and the elk
+            route on its `:data`."
     (let [parsed  (layout/parse-definition idle-loading)
           hi      (layout/node-id [:loading])
           start   (->> (:edges parsed)
@@ -1153,11 +1240,9 @@
           graph   (projection/xyflow-graph
                     parsed {} {:highlight-id hi
                                :edge-points  {(:id start) route}})
-          start-e (edge-by-id graph (:id start))]
-      (is (true? (:active (:data start-e)))
-          "the idle→loading edge still highlights (target is active)")
-      (is (= route (:points (:data start-e)))
-          "and still carries its elk route — highlight + routing coexist"))))
+          out-edge (outbound-edge-for graph (:id start))]
+      (is (true? (:active (:data out-edge))))
+      (is (= route (:points (:data out-edge)))))))
 
 ;; ---- fired-this-epoch edge highlight (rf2-qeemm, G3) -------------------
 ;;
@@ -1170,23 +1255,30 @@
 ;; `data-fired` attr. The match is by EDGE-ID (not endpoint node-ids like
 ;; `:focused`) so every traversed arm lights up.
 
-(deftest xyflow-graph-marks-fired-edge
-  (testing "rf2-qeemm (THE G3 CAPABILITY) — an edge whose id ∈
-            :fired-edge-ids gets `:fired true`; every other edge stays
-            `:fired false`"
+(deftest xyflow-graph-marks-fired-event-node-and-its-edges
+  (testing "rf2-qeemm + rf2-qo5xy — a parsed-edge id in :fired-edge-ids
+            marks BOTH the inbound + outbound edges AND the event-node
+            for that transition with `:fired true` (the whole
+            event-as-nodes structural fork lights up). Other edges /
+            event-nodes stay `:fired false`."
     (let [parsed   (layout/parse-definition idle-loading)
           start    (->> (:edges parsed)
                         (filter #(= (:source %) (layout/node-id [:idle])))
                         first)
           graph    (projection/xyflow-graph
                      parsed {} {:fired-edge-ids #{(:id start)}})
-          start-e  (edge-by-id graph (:id start))
-          others   (remove #(= (:id %) (:id start)) (:edges graph))]
-      (is (some? start) "fixture has the idle→loading edge")
-      (is (true? (:fired (:data start-e)))
-          "the fired edge is marked :fired")
-      (is (every? #(false? (:fired (:data %))) others)
-          "no other edge is marked fired (including entry edges)"))))
+          ev-node  (event-node-for graph (:id start))
+          in-edge  (inbound-edge-for  graph (:id start))
+          out-edge (outbound-edge-for graph (:id start))
+          other-ev (remove #(= (:id %) (:id ev-node))
+                           (filter #(= "rf2-event" (:type %)) (:nodes graph)))
+          other-ed (remove #(#{(:id in-edge) (:id out-edge)} (:id %))
+                           (:edges graph))]
+      (is (true? (:fired (:data ev-node))))
+      (is (true? (:fired (:data in-edge))))
+      (is (true? (:fired (:data out-edge))))
+      (is (every? #(false? (:fired (:data %))) other-ev))
+      (is (every? #(false? (:fired (:data %))) other-ed)))))
 
 (deftest xyflow-graph-no-fired-edge-ids-leaves-all-unfired
   (testing "rf2-qeemm — omitting :fired-edge-ids (the viewer / Story path,
@@ -1197,24 +1289,26 @@
       (is (every? #(false? (:fired (:data %))) (:edges graph))
           "no fired set → no fired edges"))))
 
-(deftest xyflow-graph-fired-collects-multiple-edges
-  (testing "rf2-qeemm — a set with N fired ids marks ALL N edges :fired
-            (an epoch with several microsteps lights every traversed arm)"
+(deftest xyflow-graph-fired-collects-multiple-event-nodes
+  (testing "rf2-qeemm + rf2-qo5xy — a set with N fired parsed-edge ids
+            marks N event-nodes + their inbound/outbound edges as
+            fired. An epoch with two traversed arms lights two
+            event-node forks."
     (let [parsed (layout/parse-definition idle-loading)
           start  (->> (:edges parsed)
                       (filter #(= (:source %) (layout/node-id [:idle])))
                       first)
-          ;; the :always loading→ready edge
           always (->> (:edges parsed)
                       (filter #(= (:target %) (layout/node-id [:ready])))
                       first)
           ids    #{(:id start) (:id always)}
           graph  (projection/xyflow-graph parsed {} {:fired-edge-ids ids})
-          fired  (set (map :id (filter #(:fired (:data %)) (:edges graph))))]
-      (is (some? start) "fixture has the :start edge")
-      (is (some? always) "fixture has the :always edge")
-      (is (= ids fired)
-          "exactly the two fired ids are marked, no more no fewer"))))
+          fired-ev-nodes (set (map :id (filter #(and (= "rf2-event" (:type %))
+                                                     (:fired (:data %)))
+                                               (:nodes graph))))]
+      (is (= #{(str "event__" (:id start)) (str "event__" (:id always))}
+             fired-ev-nodes)
+          "exactly the two event-nodes for the fired ids light up"))))
 
 (deftest xyflow-graph-fired-marker-colour-distinct
   (testing "rf2-qeemm — a fired edge's arrowhead colour differs from a
@@ -1236,9 +1330,9 @@
           "fired vs non-fired arrowheads are distinct colours"))))
 
 (deftest xyflow-graph-fired-coexists-with-active-and-routing
-  (testing "rf2-qeemm — :fired coexists with G1 :active + G2 routing on
-            the SAME edge: a fired edge that also touches an active node
-            AND carries an elk route keeps all three"
+  (testing "rf2-qeemm + rf2-qo5xy — :fired + :active + :points coexist
+            on the outbound edge of a fired transition that also
+            touches an active node and carries an elk route."
     (let [parsed  (layout/parse-definition idle-loading)
           hi      (layout/node-id [:loading])
           start   (->> (:edges parsed)
@@ -1249,29 +1343,32 @@
                     parsed {} {:highlight-id   hi
                                :edge-points    {(:id start) route}
                                :fired-edge-ids #{(:id start)}})
-          start-e (edge-by-id graph (:id start))]
-      (is (true? (:fired  (:data start-e))) "edge is fired")
-      (is (true? (:active (:data start-e))) "edge is still active (G1)")
-      (is (= route (:points (:data start-e))) "edge still carries its route (G2)"))))
+          out-edge (outbound-edge-for graph (:id start))]
+      (is (true? (:fired  (:data out-edge))))
+      (is (true? (:active (:data out-edge))))
+      (is (= route (:points (:data out-edge)))))))
 
-(deftest xyflow-graph-fired-is-edge-id-not-endpoint-matched
-  (testing "rf2-qeemm — :fired matches the EDGE id directly, NOT endpoint
-            node-ids like :focused. Passing only :fired-edge-ids (no
-            from/to lens) lights the fired edge while NO edge is :focused"
+(deftest xyflow-graph-fired-is-parsed-edge-id-not-endpoint-matched
+  (testing "rf2-qeemm + rf2-qo5xy — :fired matches the parsed-edge id
+            directly (via the event-node bridge), NOT endpoint node-ids
+            like :focused. Passing only :fired-edge-ids (no from/to
+            lens) lights the fired forks while no edge is :focused."
     (let [parsed  (layout/parse-definition idle-loading)
           start   (->> (:edges parsed)
                        (filter #(= (:source %) (layout/node-id [:idle])))
                        first)
           graph   (projection/xyflow-graph
                     parsed {} {:fired-edge-ids #{(:id start)}})
-          start-e (edge-by-id graph (:id start))]
-      (is (true? (:fired (:data start-e))) "the fired edge lights")
-      (is (every? #(false? (:focused (:data %))) (:edges graph))
-          "no from/to lens → no edge is focused (fired is independent)"))))
+          out-edge (outbound-edge-for graph (:id start))]
+      (is (true? (:fired (:data out-edge))))
+      (is (every? #(false? (:focused (:data %))) (:edges graph))))))
 
 (deftest xyflow-graph-entry-edges-carry-fired-false
-  (testing "rf2-qeemm — initial entry edges keep the every-edge :data
-            shape whole: they carry `:fired false` (never fired)"
+  (testing "rf2-qeemm — initial entry edges (initial-marker → state)
+            keep the every-edge :data shape whole: they carry
+            `:fired false` (never fired). Note: these are distinct
+            from the rf2-qo5xy state→event-node→state edges. The
+            entry-edge is the marker→state hop."
     (let [parsed (layout/parse-definition idle-loading)
           graph  (projection/xyflow-graph parsed {} {:fired-edge-ids #{"anything"}})
           entry  (first (filter #(:entry (:data %)) (:edges graph)))]
@@ -1312,56 +1409,68 @@
              :failed  {:on {:retry :active}}}})
 
 (deftest xyflow-graph-emits-edge-with-compound-as-target
-  (testing "rf2-shv82 (Issue 1) — `:idle --connect--> :active` mints an
-            edge whose target is the COMPOUND `:active`'s node-id; the
-            projector must NOT drop or filter it"
+  (testing "rf2-shv82 (Issue 1) + rf2-qo5xy — `:idle --connect--> :active`
+            mints an event-node + outbound edge whose target is the
+            COMPOUND `:active` node-id; the projector must not drop it."
     (let [parsed   (layout/parse-definition parent-level-transition-machine)
           graph    (projection/xyflow-graph parsed {} {})
           active-id (layout/node-id [:active])
-          edge     (first (filter #(and (= :connect (:eventId (:data %)))
-                                        (= (:target %) active-id))
-                                  (:edges graph)))]
-      (is (some? edge) "the compound-as-target edge survives projection")
-      (is (= (layout/node-id [:idle]) (:source edge))))))
+          connect  (first (filter #(= :connect (:event %)) (:edges parsed)))
+          ev-node  (event-node-for graph (:id connect))
+          out-edge (outbound-edge-for graph (:id connect))
+          in-edge  (inbound-edge-for  graph (:id connect))]
+      (is (some? ev-node))
+      (is (= active-id (:target out-edge))
+          "outbound edge targets the compound :active")
+      (is (= (layout/node-id [:idle]) (:source in-edge))
+          "inbound edge sources from :idle"))))
 
 (deftest xyflow-graph-emits-edge-with-compound-as-source
-  (testing "rf2-shv82 (Issue 1) — `:active --disconnect--> :idle` mints
-            an edge whose source is the COMPOUND `:active`'s node-id"
+  (testing "rf2-shv82 (Issue 1) + rf2-qo5xy — `:active --disconnect--> :idle`
+            mints an inbound edge whose source is the COMPOUND `:active`."
     (let [parsed (layout/parse-definition parent-level-transition-machine)
           graph  (projection/xyflow-graph parsed {} {})
           active-id (layout/node-id [:active])
-          edge   (first (filter #(and (= :disconnect (:eventId (:data %)))
-                                      (= (:source %) active-id))
-                                (:edges graph)))]
-      (is (some? edge) "the compound-as-source edge survives projection"))))
+          disc   (first (filter #(= :disconnect (:event %)) (:edges parsed)))
+          in-edge (inbound-edge-for graph (:id disc))]
+      (is (some? in-edge))
+      (is (= active-id (:source in-edge))))))
 
-(deftest xyflow-graph-emits-self-loop-on-compound
-  (testing "rf2-shv82 (Issue 1) — `:active --send--> :active` (a
-            compound self-transition) projects as a self-loop on the
-            compound node, flagged :selfLoop"
+(deftest xyflow-graph-emits-self-routing-on-compound
+  (testing "rf2-shv82 (Issue 1) + rf2-qo5xy — `:active --send--> {}`
+            (the compound's internal self-transition: omit :target,
+            just declare :action) projects as an event-node beside
+            the compound with an inbound edge from the compound but
+            NO outbound (internal transition convention)."
     (let [parsed (layout/parse-definition parent-level-transition-machine)
           graph  (projection/xyflow-graph parsed {} {})
           active-id (layout/node-id [:active])
-          edge   (first (filter #(and (= (:source %) active-id)
-                                      (= (:target %) active-id)
-                                      (= :send (:eventId (:data %))))
-                                (:edges graph)))]
-      (is (some? edge) "the compound self-loop survives projection")
-      (is (true? (:selfLoop (:data edge)))))))
+          send-e (first (filter #(= :send (:event %)) (:edges parsed)))
+          ev-node  (event-node-for     graph (:id send-e))
+          in-edge  (inbound-edge-for   graph (:id send-e))
+          out-edge (outbound-edge-for  graph (:id send-e))]
+      (is (true? (:internal? send-e))
+          "fixture sanity: :send is an internal self-transition")
+      (is (some? ev-node))
+      (is (true? (:internal (:data ev-node))))
+      (is (some? in-edge)  "inbound edge from compound exists")
+      (is (= active-id (:source in-edge))
+          "inbound source == :active compound")
+      (is (nil? out-edge)
+          "internal transition emits no outbound edge"))))
 
-(deftest xyflow-graph-emits-compound-endpoint-edges-survive-projection
-  (testing "rf2-shv82 (Issue 1) — every edge the parser emits also
-            appears in the projected graph; no edge involving a compound
-            endpoint is silently dropped at the projection layer (the
-            rf2-shv82 bug was DOM-layer; pin the contract here so a
-            future projection-layer filter would fail the test)"
+(deftest xyflow-graph-emits-compound-endpoint-event-nodes-survive-projection
+  (testing "rf2-shv82 (Issue 1) + rf2-qo5xy — every parsed edge mints
+            an event-node in the projected graph; no compound-endpoint
+            edge is silently dropped at the projection layer."
     (let [parsed (layout/parse-definition parent-level-transition-machine)
           graph  (projection/xyflow-graph parsed {} {})
           parsed-ids (set (map :id (:edges parsed)))
-          proj-ids   (set (map :id (remove #(:entry (:data %))
-                                           (:edges graph))))]
-      (is (= parsed-ids proj-ids)
-          "every parsed edge id appears in the projected edge ids"))))
+          ev-node-ids (set (map :id (filter #(= "rf2-event" (:type %))
+                                            (:nodes graph))))
+          expected (set (map #(str "event__" %) parsed-ids))]
+      (is (= expected ev-node-ids)
+          "every parsed edge id has a matching event-node"))))
 
 ;; ---- self-loop fan superseded by multi-event collapse (rf2-shv82 → rf2-j10sm)
 ;;
@@ -1385,102 +1494,78 @@
                          :disarm {:action :disarm-it}
                          :clear  {:action :clear-it}}}}})
 
-(deftest xyflow-graph-multi-self-loops-collapse-to-one-arc-with-stacked-labels
-  (testing "rf2-j10sm (Phase 2, B) — multiple self-loops on the same
-            source ALL share `:loopIndex 0` (one loop arc, not a fan of
-            N arcs); the per-event slot rides on `:siblingIndex`
-            (0..N-1) + `:siblingCount` N, so the renderer paints ONE
-            arc + N stacked event labels (xstate/Stately convention)"
+(deftest xyflow-graph-multi-self-events-each-get-own-event-node
+  (testing "rf2-qo5xy — multiple self-events on one source each project
+            as their own event-node (events-as-nodes paradigm). The
+            legacy sibling-collapse (one arc, N stacked labels) is
+            superseded — each event is its own first-class box, and
+            the action attribution rides on the event-node itself."
     (let [parsed (layout/parse-definition multi-self-loop-machine)
           graph  (projection/xyflow-graph parsed {} {})
-          self-loops (->> (:edges graph)
-                          (remove #(:entry (:data %)))
-                          (filter #(true? (:selfLoop (:data %)))))]
-      (is (= 3 (count self-loops)) "fixture has 3 self-loops on :idle")
-      (is (every? #(= 0 (:loopIndex (:data %))) self-loops)
-          "all 3 self-loops share loop-index 0 (one arc, no fan)")
-      (is (= [0 1 2] (sort (map #(:siblingIndex (:data %)) self-loops)))
-          "the 3 events get sibling slots 0/1/2 in the label stack")
-      (is (every? #(= 3 (:siblingCount (:data %))) self-loops)
-          "every sibling knows the group total"))))
+          ev-nodes (filter #(= "rf2-event" (:type %)) (:nodes graph))
+          on-idle  (filter (fn [e] (let [in (inbound-edge-for graph
+                                                              (subs (:id e)
+                                                                    (count "event__")))]
+                                     (= (:source in) (layout/node-id [:idle]))))
+                           ev-nodes)]
+      (is (= 3 (count on-idle))
+          "fixture has 3 events on :idle → 3 event-nodes")
+      (is (= #{:arm :disarm :clear}
+             (set (map #(:eventId (:data %)) on-idle))))
+      ;; The fixture's events ARE all internal (action only, no target),
+      ;; so each event-node anchors ONE inbound edge and NO outbound:
+      ;; 3 inbound, 0 outbound — the Stately convention for internal
+      ;; handlers ("runs an action and we hang here").
+      (let [inbound  (filter #(:inbound  (:data %)) (:edges graph))
+            outbound (filter #(:outbound (:data %)) (:edges graph))]
+        (is (= 3 (count inbound))
+            "3 inbound edges (one per internal self-event)")
+        (is (= 0 (count outbound))
+            "no outbound edges — these are internal transitions")))))
 
-(deftest xyflow-graph-single-self-loop-gets-index-zero
-  (testing "rf2-shv82 (Issue 2) — a single self-loop on a node gets
-            :loopIndex 0 (the historical top-right slot) AND siblingCount
-            1, so the single-self-loop case renders pixel-identical to
-            pre-collapse"
-    (let [parsed (layout/parse-definition self-loop-machine)
-          graph  (projection/xyflow-graph parsed {} {})
-          ping   (first (filter #(true? (:selfLoop (:data %))) (:edges graph)))]
+(deftest xyflow-graph-single-event-emits-one-event-node
+  (testing "rf2-qo5xy — a transition with exactly one event maps to one
+            event-node, one inbound edge, one outbound edge — the
+            paradigm's minimum unit."
+    (let [parsed   (layout/parse-definition self-loop-machine)
+          graph    (projection/xyflow-graph parsed {} {})
+          ping     (first (filter #(= (:source %) (:target %))
+                                  (:edges parsed)))
+          ev-node  (event-node-for graph (:id ping))
+          in-edge  (inbound-edge-for  graph (:id ping))
+          out-edge (outbound-edge-for graph (:id ping))]
       (is (some? ping))
-      (is (= 0 (:loopIndex (:data ping)))
-          "single self-loop gets slot 0 (historical position)")
-      (is (= 1 (:siblingCount (:data ping)))
-          "single-event case: siblingCount 1, no stacking")
-      (is (= 0 (:siblingIndex (:data ping)))
-          "the sole sibling is its own leader at slot 0"))))
+      (is (some? ev-node))
+      (is (some? in-edge))
+      (is (some? out-edge)))))
 
-(deftest xyflow-graph-non-self-loops-have-nil-loop-index
-  (testing "rf2-shv82 (Issue 2) — a normal transition (source != target)
-            carries `:loopIndex nil` (no perimeter slot to assign)"
-    (let [parsed (layout/parse-definition idle-loading)
-          graph  (projection/xyflow-graph parsed {} {})
-          non-self (filter #(false? (:selfLoop (:data %)))
-                           (remove #(:entry (:data %)) (:edges graph)))]
-      (is (seq non-self))
-      (is (every? #(nil? (:loopIndex (:data %))) non-self)
-          "non-self-loop edges carry no loop-index"))))
-
-(deftest xyflow-graph-self-loop-sibling-counter-is-per-source
-  (testing "rf2-j10sm (Phase 2, B) — the sibling counter resets per
-            `[source target]` pair. A node with 2 self-loops + another
-            with 1 self-loop reports independent sibling slots; the
-            second node's sibling starts at 0, not at 2."
-    (let [m {:initial :a
-             :states  {:a {:on {:a1 {} :a2 {}}}
-                       :b {:on {:b1 {}}}}}
-          parsed (layout/parse-definition m)
-          graph  (projection/xyflow-graph parsed {} {})
-          self-loops (filter #(true? (:selfLoop (:data %)))
-                             (remove #(:entry (:data %)) (:edges graph)))
-          by-source  (group-by :source self-loops)
-          a-sib  (sort (map #(:siblingIndex (:data %))
-                            (get by-source (layout/node-id [:a]))))
-          b-sib  (sort (map #(:siblingIndex (:data %))
-                            (get by-source (layout/node-id [:b]))))]
-      (is (= [0 1] a-sib) ":a has 2 self-loops in sibling slots 0/1")
-      (is (= [0]   b-sib) ":b's lone self-loop is at slot 0"))))
-
-(deftest xyflow-graph-multi-event-collapse-same-source-target-non-self-loop
-  (testing "rf2-j10sm (Phase 2, B) — the collapse applies to ANY
-            same-`[source target]` pair, not just self-loops. Two events
-            both transitioning A → B render as one arrow with two
-            stacked labels."
+(deftest xyflow-graph-multiple-events-on-same-source-target-pair
+  (testing "rf2-qo5xy — the events-as-nodes paradigm dissolves the
+            multi-event same-`[source target]` collapse: each event
+            becomes its own event-node, so two events both
+            transitioning A → B emit TWO event-nodes (with two
+            inbound + two outbound edges)."
     (let [m {:initial :a
              :states  {:a {:on {:go-fast :b :go-slow :b}}
                        :b {}}}
           parsed (layout/parse-definition m)
           graph  (projection/xyflow-graph parsed {} {})
-          a-to-b (->> (:edges graph)
-                      (remove #(:entry (:data %)))
-                      (filter #(and (= (:source %) (layout/node-id [:a]))
-                                    (= (:target %) (layout/node-id [:b])))))]
-      (is (= 2 (count a-to-b)) "fixture has two A→B edges")
-      (is (every? #(= 2 (:siblingCount (:data %))) a-to-b)
-          "both A→B siblings know the group total")
-      (is (= [0 1] (sort (map #(:siblingIndex (:data %)) a-to-b)))
-          "the two events take sibling slots 0 and 1"))))
+          ev-nodes (filter #(= "rf2-event" (:type %)) (:nodes graph))]
+      (is (= 2 (count ev-nodes))
+          "two events on :a → two event-nodes (no collapse)")
+      (is (= #{:go-fast :go-slow}
+             (set (map #(:eventId (:data %)) ev-nodes)))))))
 
-(deftest xyflow-graph-unique-pair-edge-is-its-own-sibling-leader
-  (testing "rf2-j10sm (Phase 2, B) — a singleton edge (the only edge
-            between its source/target) is its own leader: siblingIndex 0
-            + siblingCount 1, identical to the single-self-loop case"
-    (let [parsed (layout/parse-definition idle-loading)
-          graph  (projection/xyflow-graph parsed {} {})
-          start  (first (filter #(= :start (:eventId (:data %))) (:edges graph)))]
-      (is (some? start) "fixture has the idle→loading edge")
-      (is (= 1 (:siblingCount (:data start))))
-      (is (= 0 (:siblingIndex (:data start)))))))
+(deftest xyflow-graph-each-parsed-edge-yields-one-event-node
+  (testing "rf2-qo5xy — the projection invariant: parsed-edges count
+            equals event-nodes count. No collapse, no duplication."
+    (doseq [m [idle-loading compound-machine self-loop-machine
+               wildcard-machine machine-level-on-machine]]
+      (let [parsed   (layout/parse-definition m)
+            graph    (projection/xyflow-graph parsed {} {})
+            ev-nodes (filter #(= "rf2-event" (:type %)) (:nodes graph))]
+        (is (= (count (:edges parsed)) (count ev-nodes))
+            (str "fixture " m " mismatch"))))))
 
 ;; ---- cross-hierarchy label placement (rf2-shv82, Issue 3) --------------
 ;;
@@ -1499,45 +1584,46 @@
              :sibling {}}})
 
 (deftest xyflow-graph-flags-cross-hierarchy-edge
-  (testing "rf2-shv82 (Issue 3) — an edge whose source and target sit
-            in DIFFERENT parent containers gets :crossHierarchy true"
+  (testing "rf2-shv82 (Issue 3) + rf2-qo5xy — an outbound edge whose
+            source event-node and target state sit in DIFFERENT parent
+            containers gets :crossHierarchy true."
     (let [parsed (layout/parse-definition cross-hierarchy-machine)
           graph  (projection/xyflow-graph parsed {} {})
-          escape (first (filter #(= :escape (:eventId (:data %))) (:edges graph)))]
-      (is (some? escape))
-      (is (true? (:crossHierarchy (:data escape)))
+          escape (first (filter #(= :escape (:event %)) (:edges parsed)))
+          out-edge (outbound-edge-for graph (:id escape))]
+      (is (some? out-edge))
+      (is (true? (:crossHierarchy (:data out-edge)))
           "inner→sibling escapes the :outer container"))))
 
 (deftest xyflow-graph-same-parent-edge-not-cross-hierarchy
-  (testing "rf2-shv82 (Issue 3) — an edge between two siblings under the
-            SAME parent is NOT cross-hierarchy (both leaves share a
-            parent-id; the edge stays inside the container)"
+  (testing "rf2-shv82 (Issue 3) + rf2-qo5xy — an outbound edge between
+            two siblings under the SAME parent is NOT cross-hierarchy."
     (let [parsed (layout/parse-definition compound-machine)
           graph  (projection/xyflow-graph parsed {} {})
-          ;; :browsing --checkout--> :paying (both under :authenticated)
-          checkout (first (filter #(= :checkout (:eventId (:data %)))
-                                  (:edges graph)))]
-      (is (some? checkout))
-      (is (false? (:crossHierarchy (:data checkout)))
-          "two siblings under the same compound parent are NOT cross-hierarchy"))))
+          checkout (first (filter #(= :checkout (:event %)) (:edges parsed)))
+          out-edge (outbound-edge-for graph (:id checkout))]
+      (is (some? out-edge))
+      (is (false? (:crossHierarchy (:data out-edge)))))))
 
 (deftest xyflow-graph-flat-machine-no-cross-hierarchy
-  (testing "rf2-shv82 (Issue 3) — a flat machine has no containers, so
-            no edge is cross-hierarchy"
+  (testing "rf2-shv82 (Issue 3) + rf2-qo5xy — a flat machine has no
+            containers, so no outbound edge is cross-hierarchy."
     (let [parsed (layout/parse-definition idle-loading)
           graph  (projection/xyflow-graph parsed {} {})
-          non-entry (remove #(:entry (:data %)) (:edges graph))]
-      (is (seq non-entry))
-      (is (every? #(false? (:crossHierarchy (:data %))) non-entry)))))
+          out-edges (filter #(:outbound (:data %)) (:edges graph))]
+      (is (seq out-edges))
+      (is (every? #(false? (:crossHierarchy (:data %))) out-edges)))))
 
-(deftest xyflow-graph-self-loop-not-cross-hierarchy
-  (testing "rf2-shv82 (Issue 3) — a self-loop (source == target) is
-            never cross-hierarchy regardless of its container nesting"
+(deftest xyflow-graph-self-routing-not-cross-hierarchy
+  (testing "rf2-shv82 (Issue 3) + rf2-qo5xy — a self-routing transition
+            (source == target) is never cross-hierarchy regardless of
+            container nesting."
     (let [parsed (layout/parse-definition self-loop-machine)
           graph  (projection/xyflow-graph parsed {} {})
-          ping   (first (filter #(true? (:selfLoop (:data %))) (:edges graph)))]
-      (is (some? ping))
-      (is (false? (:crossHierarchy (:data ping)))))))
+          ping   (first (filter #(= (:source %) (:target %)) (:edges parsed)))
+          out-edge (outbound-edge-for graph (:id ping))]
+      (is (some? out-edge))
+      (is (false? (:crossHierarchy (:data out-edge)))))))
 
 (deftest xyflow-graph-entry-edges-carry-cross-hierarchy-false
   (testing "rf2-shv82 — entry edges keep the every-edge :data shape

--- a/tools/xray/spec/003-Machine-Inspector.md
+++ b/tools/xray/spec/003-Machine-Inspector.md
@@ -79,10 +79,12 @@ below; the three render states are:
     - Topology chart (**xyflow + elkjs** primitive — rf2-gpzb4 xyflow
       migration; the prior host-side ELK+SVG render is gone) with the
       FROM state drawn dashed/accent-violet and the TO state bold/cyan;
-      connecting edge emphasised. Custom Stately/xstate-style nodes +
-      edges (initial-state marker, compound-state nesting, self-loops,
-      `event [guard] / action` edge labels) per [`021-Dynamic-Panel-Designs.md`
-      §6 + §17.4](021-Dynamic-Panel-Designs.md). `:after` countdown
+      connecting edges emphasised. Custom Stately/xstate-style nodes
+      (initial-state marker with `↳`, compound-state nesting,
+      events-as-nodes per rf2-qo5xy — each transition projects as its
+      own `rf2-event` box between the source and target state, with
+      `[guard]` chip + `+ <action>` pills inside the event box; `⌚`
+      glyph for `:after`, `∞` for `:always`). `:after` countdown
       rings overlay armed timer states.
     - Guards list (when the trace carried guard-evaluated events for
       this transition).


### PR DESCRIPTION
## Paradigm shift: events-as-nodes per Stately graph view

Pre-rf2-qo5xy the Machine chart painted transitions as edge LABELS between state boxes (`event [guard] / action` floated on the line). Multiple candidates, long action names, or several stacked siblings degraded legibility quickly, and action attribution was always a second-class citizen of the line text.

Stately's graph view paints each transition as its OWN box — `source-state → event-node → (optional) target-state`. This PR adopts that paradigm.

Reference: `tools/machines-viz/design-reference/stately-graph-view.png` (landed in rf2-a2b55 / #2189).

## The four shifts

### Shift 1 — events as visual nodes, not edge labels

New custom xyflow node-type **`"rf2-event"`** (`chart.nodes.event-node`):

- Event header (event-id, or `⌚ <ms>` / `∞` for `:after` / `:always`).
- `[guard]` chip (when declared).
- `+ <action>` pill (when declared).
- Optional `machine-level` chip (top-level `:on` fallback inherited transitions).
- `:internal` variant gets a dashed border (no outbound edge — Stately convention).

Projector restructure (`chart.projection/xyflow-graph`):
- Each parsed transition → one event-node + one inbound edge (source-state → event-node) + one outbound edge (event-node → target-state).
- Internal transitions: no outbound edge.
- Event-node id: `event__<spec-edge-id>` (stable, derived from the canonical edge-id so collisions are impossible).
- Inbound edge id: `<spec-edge-id>__in` · outbound: `<spec-edge-id>__out`.

elkjs layout: `chart.projection/->elk-children` extended to include synthetic event-node children nested inside the source state's parent container; `chart.cljs/->elk-input` emits the two-edge decomposition so elkjs lays out the event-node alongside its source's siblings.

### Shift 2 — state boxes keep their structured internal layout

The rf2-a2b55 + rf2-so5b0 conventions are preserved: state name (top), tag pills below name, entry / exit action pills below tags. No regression.

### Shift 3 — hierarchy via visual nesting

`parentId` + `extent "parent"` were already wired (rf2-xh1lm). Event-nodes inherit the source state's parent so a transition declared inside a compound substate nests inside that compound. `org.eclipse.elk.hierarchyHandling INCLUDE_CHILDREN` carries cross-hierarchy edges across nesting levels (existing G5).

### Shift 4 — convention glyphs

| Glyph | Meaning | Source |
|---|---|---|
| `↳` | initial-marker glyph | `chart.nodes/initial-marker` (paired with the filled-dot source) |
| `⌚ <ms>ms` | `:after`-timer event-node | `chart.layout/event-segment` |
| `∞` | `:always` event-node | `chart.layout/event-segment` |
| `+ <name>` | action pill | `chart.nodes/action-pill` + `chart.nodes.event-node` |
| `[name]` | guard chip | `chart.nodes.event-node` |
| filled dot | initial-marker source | `chart.nodes/initial-marker` |

## Also lands

- **Context corner panel** — new `:machine-data` prop on `MachineChart`. When non-nil + non-empty, the chart paints a small read-only panel in the top-LEFT corner showing each `(key, value)` of the machine's current `:data` so the operator sees the live context without leaving the chart (Stately graph view convention). Presentation-only — the host owns the data projection.
- **Active-state on the box border** — confirmed: state-node's `:border` colour + `:box-shadow` ring carry the active affordance. No duplicate text tag.

## Spec changes

- `tools/machines-viz/spec/API.md` — new "Events as nodes — Stately graph view paradigm (rf2-qo5xy)" section mapping parsed-edge shapes to event-node + edge emissions; the legacy "multi-event label collapse" section marked SUPERSEDED.
- `tools/xray/spec/003-Machine-Inspector.md` — updated to reference the new paradigm (per [[feedback-xray-specs-kept-current]]).

## Tests

Projection tests rewritten to pin the new structural shape: assertions on event / guard / action / fired / focused / cross-hierarchy now address the event-node and inbound/outbound edges instead of the legacy single state-to-state edge. New helpers: `event-node-for`, `inbound-edge-for`, `outbound-edge-for`. chart_dom test for fired-edge rendering updated to look for the fired event-node testid.

## Quality gates

- `npm run test:cljs` — **4681 tests, 0 failures, 0 errors**.
- `npm run test:bundle-isolation` — bundle-isolation + uix-helix-reagent-free sentinels pass (no leak of `@xyflow/react` / elkjs / event-node into production bundles).

## Acceptance check coverage

1. Chart renders in the events-as-nodes paradigm. ✓
2. Compound states nest visually (parent-id chain preserved end-to-end via the existing rf2-xh1lm + rf2-lkwev wiring). ✓
3. Initial markers carry filled-dot + `↳` glyph. ✓
4. `:after` and `:always` event-nodes paint `⌚ <ms>` / `∞`. ✓
5. Action attribution legible — `+ <action>` pills inside event-nodes; entry / exit pills inside state boxes. ✓
6. Active-state highlight on state-box border (border colour + ring), not duplicate text. ✓
7. Light + dark themes — all colour goes through `theme/tokens` (no hex literals in new components). ✓
8. No regression of rf2-so5b0 + rf2-a2b55 conventions. ✓

## Worktree

`worker/machine-chart-events-as-nodes-rf2-qo5xy` (no edits outside the worker worktree — verified mid-session).