### PR TITLE
feat(xray): epoch-panel additions cluster (6 beads — rf2-nqt3d + 5 more)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1522,6 +1522,33 @@ cross-session triage.
 
 Section is conditional — omitted when no violation events fired.
 
+### §9.1.10.5 App-db diff section (rf2-rrykz)
+
+An APP-DB DIFF step rides immediately after HANDLER when the
+cascade mutated app-db. The section answers the most fundamental
+"what happened?" question — what changed in app-db this cascade —
+as a top-level cascade element rather than buried in the HANDLER
+body.
+
+Two surfaces coexist by design:
+
+- HANDLER body's `:db-diff` slot — **attribution** lens ("this
+  handler caused these changes"). Renders the same diff inline
+  with the source code block, machine block, and `:fx` slot.
+- APP-DB DIFF step — **state-mutation** lens ("these are app-db's
+  changes this cascade"). Renders as its own numbered step with
+  the header carrying the change-count split.
+
+Same data (`:rf.event/db-changed-paths` on `:rf.event/db-changed`),
+two chrome treatments. The pre-roll for "show me app-db deltas"
+now matches every cascade — same shape, same place.
+
+Header: `N paths changed (+M / ~K / -L)` (added / modified /
+removed split). Per-row chrome mirrors HANDLER's `db-diff-line`
+(glyph + path + value(s)).
+
+Section is conditional — omitted when no app-db mutation fired.
+
 ### §9.1.10.4 Cascading-dispatches section (rf2-yx1ae)
 
 A CHILD-DISPATCHES step rides between FX and SUBSCRIPTIONS when the

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1500,6 +1500,52 @@ cross-session triage.
 
 Section is conditional — omitted when no violation events fired.
 
+### §9.1.10.4 Cascading-dispatches section (rf2-yx1ae)
+
+A CHILD-DISPATCHES step rides between FX and SUBSCRIPTIONS when the
+handler returned dispatch-family fx (`:dispatch`, `:dispatch-n`,
+`:dispatch-later`). The section surfaces the parent→child cascade
+link inline so the operator can pivot to a child epoch's view
+directly.
+
+Projection source: the handler's returned `:rf.event/fx` payload on
+`:rf.fx/do-fx` (Spec 009). The projector normalises the three
+substrate shapes into a uniform row schema:
+
+- `:dispatch [:e/x]`                    → `{:event [:e/x] :delay-ms nil :via :dispatch}`
+- `:dispatch-n [[:a] [:b]]`             → one row per element with `:via :dispatch-n`
+- `:dispatch-later {:ms 250 :dispatch [:r]}` → `{:event [:r] :delay-ms 250 :via :dispatch-later}`
+- `:dispatch-later [{…} {…}]`           → one row per element
+
+Per-row chrome:
+
+- `:via` chip (`dispatch` / `dispatch-n` / `dispatch-later` — muted
+  uppercase label).
+- The child event vector (operator's primary read).
+- `+<N>ms` delay chip for `:dispatch-later`.
+- Jump-to button when the child cascade is in the epoch buffer;
+  muted `not in buffer` marker otherwise.
+
+The child-epoch resolution lives in `projection/find-child-epoch`,
+which scans the `:rf.xray/epoch-history` for records whose
+`:parent-dispatch-id` matches THIS cascade's `:dispatch-id`. The
+substrate pins the parent link on the child's epoch-record per
+Spec-Schemas §`:rf/epoch-record` + Spec 009 §Dispatch correlation.
+When the trigger-event matches exactly we prefer that record; on
+sibling collisions the first child under the same parent-id is
+returned so the operator still has a forwarding link.
+
+Jump-to dispatches `[:rf.xray/select-epoch <child-epoch-id>]`
+(the shared spine shim from `xray.epoch/install!`) so the focus
+flips to the child cascade and the panel re-renders against the
+child's pipeline.
+
+The composite sub `:rf.xray/epoch-pipeline` now also exposes
+`:dispatch-id` + `:epoch-history` so the view's per-row resolver
+runs without a secondary subscription in the hot path.
+
+Section is conditional — omitted when no dispatch-family fx fired.
+
 ### §9.1.11 Cross-panel navigation
 
 Every click-to-source affordance in the cascade flows through the

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1301,19 +1301,22 @@ empty-state line. This matches the §2.2 dynamic-numbering contract
 from the Event lens — both panels share the same "absence is
 silence" rhythm.
 
-### §9.1.4 Badge taxonomy (the 7-badge inventory)
+### §9.1.4 Badge taxonomy (the 10-badge inventory)
 
 Each step renders a uppercase badge pill at its numbered circle:
 
 | Badge | Token | Hue family |
 |-------|-------|------------|
-| `:DISPATCH`      | `:text-tertiary` | muted grey |
-| `:COEFFECT`      | `:magenta`       | purple |
-| `:HANDLER`       | `:accent`        | blue (single Xray accent) |
-| `:FLOW`          | `:accent`        | blue (paired with HANDLER) |
-| `:FX`            | `:orange`        | functional amber (post-commit irreversible) |
-| `:SUBSCRIPTIONS` | `:magenta`       | pink/magenta family |
-| `:VIEWS`         | `:success`       | green |
+| `:DISPATCH`           | `:text-tertiary` | muted grey |
+| `:COEFFECT`           | `:magenta`       | purple |
+| `:HANDLER`            | `:accent`        | blue (single Xray accent) |
+| `:FLOW`               | `:accent`        | blue (paired with HANDLER) |
+| `:FX`                 | `:orange`        | functional amber (post-commit irreversible) |
+| `:SUBSCRIPTIONS`      | `:magenta`       | pink/magenta family |
+| `:VIEWS`              | `:success`       | green |
+| `:SCHEMA-VIOLATIONS`  | `:warning`       | warning amber (rf2-17vxj) |
+| `:CHILD-DISPATCHES`   | `:text-tertiary` | muted grey (same as DISPATCH — cascade-link semantics, rf2-yx1ae) |
+| `:APP-DB-DIFF`        | `:accent`        | blue (state-mutation lens, rf2-rrykz) |
 
 The inventory is LOCKED — the projection's `badge-set` enforces
 that every emitted step's `:badge` is a member, and the view's
@@ -1458,6 +1461,44 @@ naturally heavy.
 The summary chip elides when no step carries a numeric duration
 (cold-start records, fixtures synthesised without timing); the
 cascade renders normally.
+
+### §9.1.10.3 Schema-violations section (rf2-17vxj)
+
+A SCHEMA VIOLATIONS step is appended to the cascade when the
+focused epoch's trace stream carried at least one of:
+
+- `:rf.error/schema-validation-failure` — runtime per-boundary
+  validation failure (app-db commit / cofx / sub-return / fx-args /
+  event payload). Tags: `:where`, `:path`, `:value`, `:failing-id`,
+  `:rollback?`, `:explain`, `:sensitive?`.
+- `:rf.schema/violation` — hot-reload drift: a re-registration
+  changed the schema at `(frame-id, path)` and the live app-db
+  value fails the new schema. Tags: `:path`, `:frame`,
+  `:pre-reload-schema`, `:post-reload-schema`, `:mismatching-value`,
+  `:recovery`, `:sensitive?`.
+
+Both ops project into the same row schema, with `:kind` flagging
+the source. Section chrome is warning-tone (`:warning` colour
+token + `▲` glyph) — load-bearing without rising to alarmist
+`:error` tone. Per-row body:
+
+- `:where` label (e.g. `app-db commit`, `sub return`, `hot-reload`).
+- `:failing-id` (the registered name whose boundary failed).
+- `:path` (when present).
+- failing value via `edn/inspect-inline` (already redacted at the
+  substrate emit site when the slot is `:sensitive?`).
+- `rolled back` chip when `:rollback?` is true.
+- `recovery: <reason>` chip when `:rollback?` is false (the
+  cascade ran through despite the violation).
+- `(value redacted — slot declared :sensitive?)` marker when the
+  substrate redacted the value.
+
+Header carries the violation count + a per-rollback split + an
+`open issues →` affordance that dispatches `[:rf.xray/select-tab
+:issues]` so the operator can pivot to the Issues panel for
+cross-session triage.
+
+Section is conditional — omitted when no violation events fired.
 
 ### §9.1.11 Cross-panel navigation
 

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1522,6 +1522,29 @@ cross-session triage.
 
 Section is conditional — omitted when no violation events fired.
 
+### §9.1.10.6 FX section header + per-action attribution (rf2-uffov)
+
+The FX step has rendered per-fx rows since rf2-sc3r1. rf2-uffov
+extends it with:
+
+- **Header outcome split** — `N fired (M succeeded, K threw,
+  L skipped)`. Counters are projection-side aggregations of the
+  per-row `:status` keyword (`:ok / :overridden → :succeeded`,
+  `:error → :threw`, `:skipped → :skipped`). The view consumes
+  the projected counters directly so the header reads as
+  at-a-glance correctness.
+- **Per-action attribution** — when the cascade was driven by a
+  machine handler, each FX row that maps to a fx-id emitted by an
+  action's outcome `:fx` slot carries `:attributed-to {:action-id
+  …, :phase …}` (rf2-9c27r + this bead). The view renders an
+  italic `← <action-id> (<phase>)` chip alongside the row so the
+  operator reads `fx X emitted by action Y in phase Z` in one
+  line. Best-effort: first-attribution wins when the same fx-id
+  is emitted by multiple actions in the same cascade (cascade
+  order).
+- **Conditional emit unchanged** — section omits when no fx-handler
+  events fired.
+
 ### §9.1.10.5 App-db diff section (rf2-rrykz)
 
 An APP-DB DIFF step rides immediately after HANDLER when the

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1324,30 +1324,52 @@ colour resolver bails to `:text-tertiary` on an unknown badge so a
 future taxonomy extension paints something but tests catch the
 omission.
 
-### §9.1.5 Handler-type adaptation (rf2-82a0u prerequisites)
+### §9.1.5 Handler-type adaptation (rf2-82a0u prerequisites · rf2-9c27r full design)
 
 The HANDLER step's body adapts to the handler's flavour, discovered
 from the trace stream:
 
 - **`:reg-event-db`** — `:db` diff only (the simplest case).
 - **`:reg-event-fx`** — `:db` diff + per-fx-entry block.
-- **`:reg-machine`** — full machine block: transition summary
-  (machine-id + before/after state vectors), guard rows
-  (`:pass / :fail / :threw` outcomes), per-phase lifecycle rows
-  (phases drawn from the closed set
-  `:exit / :transition / :entry / :always / :after-action /
-  :initial-entry / :destroy-exit`, per rf2-82a0u's `:phase` stamp
-  on `:rf.machine/action-ran`), and timer-cancellation rows
-  (reasons drawn from the closed set
-  `:on-exit / :on-destroy / :on-resolution / :on-supersede /
-  :on-frame-destroy`, per the unified `:rf.machine.timer/cancelled`
-  trace).
+- **`:reg-machine`** — the full machine block per the rf2-9c27r
+  design doc, with all seven sub-sections (rf2-9c27r):
+
+  1. **TRANSITION** — `before-state → after-state`, machine-id,
+     event vector, microstep count (one `:rf.machine/transition` per
+     macrostep — Spec 005 §Trace events).
+  2. **GUARDS** — per-guard row from `:rf.machine/guard-evaluated`:
+     guard-id + `:outcome` from the closed set `:pass / :fail /
+     :threw` (rf2-82a0u).
+  3. **LIFECYCLE** — phase-grouped rows from `:rf.machine/action-ran`
+     (rf2-82a0u — every emit carries `:phase` from the closed set
+     `:exit / :transition / :entry / :always / :after-action /
+     :initial-entry / :destroy-exit`). Each row carries action-id,
+     outcome, and **per-action fx attribution** when the action's
+     outcome map carried `:fx` — the operator reads `action X
+     emitted fx Y` inline (rf2-9c27r §7 folds the FX sub-section
+     into LIFECYCLE for compactness).
+  4. **AFTER TIMERS** — armed + cancelled rows with
+     `:rf.machine.timer/cancelled` `:reason` from the closed set
+     `:on-exit / :on-destroy / :on-resolution / :on-supersede /
+     :on-frame-destroy`.
+  5. **DATA REDUCTION** — `:data` before / after via
+     `edn/inspect-inline`. Source: the `:before / :after` snapshots
+     on `:rf.machine/transition`; the projection hoists `:data-before
+     / :data-after` from those maps. Elides when before == after.
+  6. **SNAPSHOT DIFF** — full snapshot before / after via
+     `edn/inspect-inline`. Source: same trace; renders the WHOLE
+     snapshot map (state vector + data map + parallel-region tags)
+     so the operator can drill into any slot. Elides when snapshots
+     are identical.
+  7. **FX** — per-action attribution folded into LIFECYCLE (above).
+     The HANDLER step's top-level `:fx` slot still surfaces the
+     handler's returned fx for completeness.
 
 The flavour discriminator runs at projection time as a pure-data
 check against the trace stream — no spec read, no registry lookup,
 no replay. The substrate enhancements in #2155 (rf2-82a0u) are the
-prerequisite that lets the LIFECYCLE / TIMERS sub-blocks read
-directly off the trace.
+prerequisite that lets the LIFECYCLE / TIMERS / DATA REDUCTION /
+SNAPSHOT DIFF sub-blocks read directly off the trace.
 
 ### §9.1.6 Numbered cascade chrome
 

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1429,6 +1429,36 @@ and silently rendered empty rows. The binding inventory:
 | `:subscriptions` | `:rf.sub/run` / `:rf.sub/skip` | `:rf.sub/id`, `:rf.sub/query-v`, `:rf.sub/value-changed?`, `:rf.sub/prev-value`, `:rf.sub/value`, `:rf.sub/cascade?`, `:rf.sub/cause-sub`, `:rf.sub/elapsed-ms` (rf2-kfh1v aligned the reads against these) |
 | `:views` | `:rf.view/rendered` (NOT the simpler `:rf.view/render` marker) | `:rf.view/id`, `:rf.view/deref-subs`, `:rf.view/elapsed-ms`, `:rf.view/mount?`, `:rf.view/triggered-by` (rf2-6djth aligned the read against the rich marker) |
 
+### §9.1.10.2 Per-step elapsed time + cascade total (rf2-nqt3d)
+
+Each step row carries `:duration-ms` (a number when the substrate
+stamped it; nil otherwise). The view paints it as a right-aligned
+monospace chip on every step's header — pure-data via
+`projection/format-duration-ms`, which formats `0.1ms` / `12ms` /
+`1.2s` per scale.
+
+Pure-data aggregations layered on top of the projected step vector
+drive the cascade-level chrome:
+
+| Helper | Returns | Used for |
+|--------|---------|----------|
+| `projection/cascade-total-ms steps` | number (sum of `:duration-ms`) or nil | top-of-cascade summary chip total |
+| `projection/long-step? step` | boolean (`:duration-ms > 16ms`) | per-step warning chrome |
+| `projection/long-step-count steps` | integer | summary chip secondary count |
+
+`projection/long-step-threshold-ms` is **16ms** — one display frame
+at 60Hz, the natural marker for "this single step will visibly
+jank the next paint". Crossing the threshold paints the chip in the
+warning tone with a `▲` glyph; the cascade-summary chip surfaces a
+secondary `N over 16ms` count when any step is long. Below
+threshold the chip is muted with no glyph — alarmist `✗` chrome
+would crowd the cascade on the common case where one step is
+naturally heavy.
+
+The summary chip elides when no step carries a numeric duration
+(cold-start records, fixtures synthesised without timing); the
+cascade renders normally.
+
 ### §9.1.11 Cross-panel navigation
 
 Every click-to-source affordance in the cascade flows through the

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/badge.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/badge.cljc
@@ -63,27 +63,40 @@
   COEFFECT, `:magenta` for SUBSCRIPTIONS) per the bead body — the
   view differentiates them with their text label rather than a
   hue split; the project's palette doesn't carry a separate pink hue
-  and adding one for this single use site would erode the palette's
+  and adding to it for this single use site would erode the palette's
   single-source-of-truth posture (per spec/022). HANDLER + FLOW share
-  `:accent` — the Figma export's single-accent identity (rf2-ad7zx.13)."
-  {:DISPATCH      :text-tertiary
-   :COEFFECT      :magenta
-   :HANDLER       :accent
-   :FLOW          :accent
-   :FX            :orange
-   :SUBSCRIPTIONS :magenta
-   :VIEWS         :success})
+  `:accent` — the Figma export's single-accent identity (rf2-ad7zx.13).
+
+  rf2-17vxj — SCHEMA-VIOLATIONS pulls `:warning` so the section
+  reads as load-bearing without rising to `:error`'s alarmist tone.
+  rf2-yx1ae — CHILD-DISPATCHES pulls `:text-tertiary` (the same muted
+  grey as DISPATCH — same hue family, same cascade-link semantics).
+  rf2-rrykz — APP-DB-DIFF pulls `:accent` (the same blue as HANDLER /
+  FLOW — same state-mutation lens semantics)."
+  {:DISPATCH          :text-tertiary
+   :COEFFECT          :magenta
+   :HANDLER           :accent
+   :FLOW              :accent
+   :FX                :orange
+   :SUBSCRIPTIONS     :magenta
+   :VIEWS             :success
+   :SCHEMA-VIOLATIONS :warning
+   :CHILD-DISPATCHES  :text-tertiary
+   :APP-DB-DIFF       :accent})
 
 (def ^:private badge->label
   "Map from badge keyword → uppercase label rendered in the badge
   pill. Pure data."
-  {:DISPATCH      "DISPATCH"
-   :COEFFECT      "COEFFECT"
-   :HANDLER       "HANDLER"
-   :FLOW          "FLOW"
-   :FX            "FX"
-   :SUBSCRIPTIONS "SUBSCRIPTIONS"
-   :VIEWS         "VIEWS"})
+  {:DISPATCH          "DISPATCH"
+   :COEFFECT          "COEFFECT"
+   :HANDLER           "HANDLER"
+   :FLOW              "FLOW"
+   :FX                "FX"
+   :SUBSCRIPTIONS     "SUBSCRIPTIONS"
+   :VIEWS             "VIEWS"
+   :SCHEMA-VIOLATIONS "SCHEMA VIOLATIONS"
+   :CHILD-DISPATCHES  "DISPATCHED EVENTS"
+   :APP-DB-DIFF       "APP-DB DIFF"})
 
 (defn token-key
   "Return the theme-token KEYWORD for `badge` (e.g. `:accent` for

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/icons.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/icons.cljc
@@ -53,3 +53,58 @@
   a component."
   []
   corner-down-right-svg)
+
+;; ---- Warning triangle ---------------------------------------------------
+
+(def ^:private alert-triangle-svg
+  "Lucide `alert-triangle` icon as a hiccup-shaped svg. 13×13
+  square, `viewBox 0 0 24 24`, `stroke: currentColor`. Used by the
+  SCHEMA-VIOLATIONS section header (rf2-17vxj) to signal warning
+  chrome without rising to the alarmist `:error` tone of an `✗`."
+  [:svg {:width            "13"
+         :height           "13"
+         :viewBox          "0 0 24 24"
+         :fill             "none"
+         :stroke           "currentColor"
+         :stroke-width     "2"
+         :stroke-linecap   "round"
+         :stroke-linejoin  "round"
+         :aria-hidden      "true"
+         :focusable        "false"}
+   [:path {:d "M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z"}]
+   [:line {:x1 "12" :y1 "9"  :x2 "12" :y2 "13"}]
+   [:line {:x1 "12" :y1 "17" :x2 "12.01" :y2 "17"}]])
+
+(defn alert-triangle
+  "Render the lucide `alert-triangle` glyph (rf2-17vxj). Inherits
+  colour from the enclosing element via `currentColor` so the
+  glyph rides the warning-tone section header."
+  []
+  alert-triangle-svg)
+
+;; ---- Arrow right (cascade-link) -----------------------------------------
+
+(def ^:private arrow-right-svg
+  "Lucide `arrow-right` icon as a hiccup-shaped svg. 13×13 square,
+  `viewBox 0 0 24 24`, `stroke: currentColor`. Used by the
+  CHILD-DISPATCHES section (rf2-yx1ae) for the per-child 'jump to'
+  affordance — the arrow signals 'follow this dispatch to the
+  child cascade'."
+  [:svg {:width            "13"
+         :height           "13"
+         :viewBox          "0 0 24 24"
+         :fill             "none"
+         :stroke           "currentColor"
+         :stroke-width     "2"
+         :stroke-linecap   "round"
+         :stroke-linejoin  "round"
+         :aria-hidden      "true"
+         :focusable        "false"}
+   [:line     {:x1 "5" :y1 "12" :x2 "19" :y2 "12"}]
+   [:polyline {:points "12 5 19 12 12 19"}]])
+
+(defn arrow-right
+  "Render the lucide `arrow-right` glyph (rf2-yx1ae). Inherits
+  colour from the enclosing element via `currentColor`."
+  []
+  arrow-right-svg)

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -587,6 +587,120 @@
        :rows      rows
        :rollbacks (count (filter :rollback? rows))})))
 
+;; ---- CHILD DISPATCHES step (rf2-yx1ae) -----------------------------------
+;;
+;; When a handler returns `:dispatch / :dispatch-n / :dispatch-later`
+;; fx, the cascade triggers child cascades — each child rides its own
+;; epoch-record. The CHILD-DISPATCHES section surfaces those children
+;; off THIS cascade's returned fx so the operator sees them inline.
+;;
+;; Source: the `:rf.event/fx` payload on `:rf.fx/do-fx` (the handler's
+;; returned fx map / vec — Spec 009 §`:rf.fx/do-fx`). We harvest ONLY
+;; the dispatch-family fx (`:dispatch / :dispatch-n / :dispatch-later`);
+;; other fx are the FX step's concern.
+;;
+;; Each row carries the child event vector + optional delay; the view
+;; layer joins this against the epoch-history at render time to find
+;; the child cascade's `:epoch-id` for the "jump to" affordance
+;; (children that have aged out of the ring buffer render with the
+;; "not in buffer" marker — the row still surfaces the event vector).
+
+(defn- normalise-child-dispatch
+  "Coerce a dispatch / dispatch-later fx arg into row fragments. Four
+  substrate shapes per Spec 009 / re-frame.fx:
+
+    1. `:dispatch [:event/x 7]`              → one row
+    2. `:dispatch-n [[:a] [:b]]`             → one row per element
+    3. `:dispatch-later {:ms 250 :dispatch [:retry]}` → one row + delay
+    4. `:dispatch-later [{:ms 250 :dispatch …} {:ms 500 :dispatch …}]`
+                                             → one row per element
+
+  Returns a vec of `{:event vec :delay-ms num-or-nil}` maps."
+  [fx-id value]
+  (case fx-id
+    :dispatch
+    (when (vector? value)
+      [{:event value :delay-ms nil}])
+
+    :dispatch-n
+    (when (sequential? value)
+      (vec (for [e value
+                 :when (vector? e)]
+             {:event e :delay-ms nil})))
+
+    :dispatch-later
+    (cond
+      (map? value)
+      (when (vector? (:dispatch value))
+        [{:event    (:dispatch value)
+          :delay-ms (or (:ms value) (:delay-ms value))}])
+      (sequential? value)
+      (vec (for [e value
+                 :when (and (map? e) (vector? (:dispatch e)))]
+             {:event (:dispatch e) :delay-ms (or (:ms e) (:delay-ms e))})))
+
+    nil))
+
+(def child-dispatch-fx-ids
+  "Closed set of fx-ids that produce child cascades (rf2-yx1ae)."
+  #{:dispatch :dispatch-n :dispatch-later})
+
+(defn child-dispatch-rows
+  "Project this cascade's child dispatches into rows (rf2-yx1ae).
+
+  Walks the `:rf.fx/do-fx` `:rf.event/fx` payload; harvests only the
+  dispatch-family entries. Each row carries:
+
+    :event    — the child's event vector
+    :delay-ms — delay (for `:dispatch-later`) or nil
+    :via      — the fx-id that emitted the row (`:dispatch /
+                 :dispatch-n / :dispatch-later`)
+
+  Empty vec when no dispatch-family fx fired."
+  [events]
+  (let [entries (fx-entries events)]
+    (vec
+      (for [{:keys [fx-id value]} entries
+            :when (contains? child-dispatch-fx-ids fx-id)
+            row (or (normalise-child-dispatch fx-id value) [])
+            :when (vector? (:event row))]
+        (assoc row :via fx-id)))))
+
+(defn child-dispatches-step
+  "Build the CHILD-DISPATCHES step row, or nil when no dispatch-family
+  fx fired (the step is OMITTED — conditional)."
+  [events]
+  (let [rows (child-dispatch-rows events)]
+    (when (seq rows)
+      {:step  :child-dispatches
+       :badge :CHILD-DISPATCHES
+       :rows  rows})))
+
+(defn find-child-epoch
+  "Resolve a child epoch's `:epoch-id` against the epoch-history given
+  THIS cascade's `:dispatch-id` + the child's event vector (rf2-yx1ae).
+
+  The parent→child link is the substrate-canonical
+  `:rf.trace/parent-dispatch-id` slot on the child's
+  `:rf.event/dispatched` trace (carrying THIS cascade's
+  `:dispatch-id` — Spec 009 §Dispatch correlation). The epoch-record
+  pins this on `:parent-dispatch-id` (Spec-Schemas §`:rf/epoch-record`,
+  rf2-rly4a).
+
+  We prefer matches with both `:parent-dispatch-id` AND a matching
+  trigger-event; when the trigger-event doesn't match (a sibling
+  dispatch with the same parent), the row falls back to whichever
+  child rides the same parent dispatch-id. Returns the matched
+  epoch's `:epoch-id` or nil when no child epoch is in the buffer
+  yet (or has aged out)."
+  [epoch-history parent-dispatch-id child-event]
+  (when (and (some? parent-dispatch-id) (vector? child-event))
+    (let [candidates (filter #(= parent-dispatch-id (:parent-dispatch-id %))
+                             epoch-history)
+          exact      (some #(when (= child-event (:trigger-event %)) %)
+                           candidates)]
+      (:epoch-id (or exact (first candidates))))))
+
 ;; ---- top-level projection ------------------------------------------------
 
 (defn project
@@ -646,6 +760,12 @@
                        (handler-row events event-id)
                        (flow-step events)
                        (fx-step events)
+                       ;; rf2-yx1ae — child dispatches sit after FX (they
+                       ;; are themselves fx, but a dedicated section makes
+                       ;; the parent→child cascade-link affordance the
+                       ;; primary read; the FX step still surfaces every
+                       ;; fx for completeness).
+                       (child-dispatches-step events)
                        (subscriptions-step events)
                        (views-step events)
                        ;; rf2-17vxj — schema violations ride at the end of

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -238,29 +238,51 @@
 
   Each row carries `:action-id`, `:phase`, `:outcome`, optional
   `:threw?` + `:exception` (action-throw path emits
-  `:outcome :rf.error/action-threw` + an `:exception` slot). Rendered
-  in trace order — the substrate emits in execution order
-  (exit → transition → entry → always …)."
+  `:outcome :rf.error/action-threw` + an `:exception` slot), and
+  optional `:fx` (per-action fx attribution per rf2-9c27r — the
+  vector of `[fx-id args]` the action returned in its outcome map's
+  `:fx` slot). Rendered in trace order — the substrate emits in
+  execution order (exit → transition → entry → always …)."
   [events]
   (vec
     (for [ev (filter-op events :rf.machine/action-ran)]
-      {:action-id (common/tag-of ev :action-id)
-       :phase     (common/tag-of ev :phase)
-       :outcome   (common/tag-of ev :outcome)
-       :threw?    (= :rf.error/action-threw (common/tag-of ev :outcome))
-       :exception (common/tag-of ev :exception)
-       :input     (common/tag-of ev :input)})))
+      (let [outcome (common/tag-of ev :outcome)
+            ;; Per-action fx attribution (rf2-9c27r) — when the
+            ;; action returned a map carrying `:fx`, surface the
+            ;; tuple list so the LIFECYCLE row can show which fx
+            ;; the operator should attribute to this action.
+            action-fx (when (map? outcome) (:fx outcome))
+            action-data (when (map? outcome) (:data outcome))]
+        (cond-> {:action-id (common/tag-of ev :action-id)
+                 :phase     (common/tag-of ev :phase)
+                 :outcome   outcome
+                 :threw?    (= :rf.error/action-threw outcome)
+                 :exception (common/tag-of ev :exception)
+                 :input     (common/tag-of ev :input)}
+          (seq action-fx) (assoc :fx (vec action-fx))
+          (some? action-data) (assoc :data-write action-data))))))
 
 (defn- machine-transition-row
   "Project the `:rf.machine/transition` event (one per macrostep) into a
-  summary `{:machine-id :before :after :microsteps}` row. nil when no
-  transition trace fired."
+  summary `{:machine-id :before :after :microsteps :event :data-before
+            :data-after}` row. nil when no transition trace fired.
+
+  Per Spec 005 §Trace events the `:before` / `:after` slots carry
+  the full machine snapshot maps (`:state` + `:data` + …); the row
+  hoists `:data-before` / `:data-after` for the rf2-9c27r DATA
+  REDUCTION sub-section so the view layer doesn't re-walk the
+  snapshot map."
   [events]
   (when-let [ev (find-op events :rf.machine/transition)]
-    {:machine-id (common/tag-of ev :machine-id)
-     :before     (common/tag-of ev :before)
-     :after      (common/tag-of ev :after)
-     :microsteps (common/tag-of ev :microsteps)}))
+    (let [before (common/tag-of ev :before)
+          after  (common/tag-of ev :after)]
+      {:machine-id   (common/tag-of ev :machine-id)
+       :event        (common/tag-of ev :event)
+       :before       before
+       :after        after
+       :data-before  (when (map? before) (:data before))
+       :data-after   (when (map? after)  (:data after))
+       :microsteps   (common/tag-of ev :microsteps)})))
 
 (defn- machine-guard-rows
   "Project the `:rf.machine/guard-evaluated` stream into rows. Each

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -505,6 +505,88 @@
        :badge :VIEWS
        :rows  rows})))
 
+;; ---- SCHEMA VIOLATIONS step ----------------------------------------------
+;;
+;; rf2-17vxj — surface schema violations that fired during this epoch.
+;; Two trace operations carry violations:
+;;
+;;   :rf.error/schema-validation-failure — runtime per-event boundary
+;;     check (app-db / cofx / sub-return / fx-args). Tags:
+;;       :where       — `:app-db | :cofx | :sub-return | :fx-args | …`
+;;       :path        — `[k k …]` (where applicable)
+;;       :value       — failing value (already redacted to `:rf/redacted`
+;;                       when slot was `:sensitive?`)
+;;       :failing-id  — the handler / cofx / sub / fx whose boundary
+;;                       failed
+;;       :rollback?   — true when app-db was rolled back
+;;       :explain     — Malli explain data (optional)
+;;
+;;   :rf.schema/violation — hot-reload check: a re-registration changed
+;;     the schema at a `(frame-id, path)` AND the live `app-db` value at
+;;     `path` fails the new schema. Tags:
+;;       :path / :frame
+;;       :pre-reload-schema / :post-reload-schema
+;;       :mismatching-value (or `:rf/redacted`)
+;;       :recovery — `:logged-and-skipped`
+;;       :sensitive?
+;;
+;; Surfaced when the cascade carried at least one of either op.
+
+(def schema-violation-ops
+  "Closed set of trace ops the SCHEMA-VIOLATIONS step harvests
+  (rf2-17vxj). The runtime per-boundary failure and the hot-reload
+  drift check ride distinct ops + tag shapes; both project into the
+  same row schema with `:kind` flagging the source."
+  #{:rf.error/schema-validation-failure
+    :rf.schema/violation})
+
+(defn- schema-violation-row
+  "Project one schema-violation trace event into the per-row data
+  shape (rf2-17vxj). Empty / nil values are kept absent so the view
+  can elide slots cleanly."
+  [ev]
+  (let [op-kw (op ev)
+        tags  (:tags ev)]
+    (cond-> {:kind        op-kw
+             :where       (or (:where tags)
+                              (when (= :rf.schema/violation op-kw) :hot-reload))
+             :path        (:path tags)
+             :failing-id  (or (:failing-id tags)
+                              (when (= :rf.schema/violation op-kw)
+                                (:frame tags)))
+             :value       (or (:value tags) (:mismatching-value tags))
+             :explain     (:explain tags)
+             :rollback?   (boolean (:rollback? tags))
+             :recovery    (:recovery tags)
+             :sensitive?  (boolean (:sensitive? tags))}
+      (= :rf.schema/violation op-kw)
+      (assoc :pre-reload-schema  (:pre-reload-schema tags)
+             :post-reload-schema (:post-reload-schema tags)
+             :frame              (:frame tags)))))
+
+(defn schema-violation-rows
+  "Walk every schema-violation trace event in `events` (both runtime
+  per-event validation failures + hot-reload drift) into a vec of
+  per-row maps (rf2-17vxj). Empty vec when none fired."
+  [events]
+  (vec
+    (for [ev events
+          :when (contains? schema-violation-ops (op ev))]
+      (schema-violation-row ev))))
+
+(defn schema-violations-step
+  "Build the SCHEMA-VIOLATIONS step row, or nil when no violations
+  fired (the step is OMITTED — conditional). Header carries the
+  total count + a per-rollback split so the operator can tell at a
+  glance whether the cascade was REJECTED by the validator."
+  [events]
+  (let [rows (schema-violation-rows events)]
+    (when (seq rows)
+      {:step      :schema-violations
+       :badge     :SCHEMA-VIOLATIONS
+       :rows      rows
+       :rollbacks (count (filter :rollback? rows))})))
+
 ;; ---- top-level projection ------------------------------------------------
 
 (defn project
@@ -565,7 +647,12 @@
                        (flow-step events)
                        (fx-step events)
                        (subscriptions-step events)
-                       (views-step events)]]
+                       (views-step events)
+                       ;; rf2-17vxj — schema violations ride at the end of
+                       ;; the cascade so the operator sees the boundary
+                       ;; check that may have rolled back THIS cascade
+                       ;; AFTER reading the steps that drove it.
+                       (schema-violations-step events)]]
         (filterv some? steps)))))
 
 (defn number-steps
@@ -744,12 +831,20 @@
 ;; ---- public mapping table -----------------------------------------------
 
 (def badge-set
-  "The 7 badges produced by the projection — every projected step's
-  `:badge` is a member of this set. Catalogued separately so tests
-  + the view's colour resolver have one authoritative inventory.
+  "The badge inventory produced by the projection — every projected
+  step's `:badge` is a member of this set. Catalogued separately so
+  tests + the view's colour resolver have one authoritative inventory.
 
-  Per the bead body's badge taxonomy (rf2-sc3r1)."
-  #{:DISPATCH :COEFFECT :HANDLER :FLOW :FX :SUBSCRIPTIONS :VIEWS})
+  - Original 7 (rf2-sc3r1): DISPATCH · COEFFECT · HANDLER · FLOW · FX ·
+    SUBSCRIPTIONS · VIEWS.
+  - rf2-17vxj: + SCHEMA-VIOLATIONS (warning chrome, conditional).
+  - rf2-yx1ae: + CHILD-DISPATCHES (cascade-link section, conditional).
+  - rf2-rrykz: + APP-DB-DIFF (state-mutation lens, conditional).
+
+  The view's badge resolver bails to `:text-tertiary` on an unknown
+  badge, so adding to this set is purely additive."
+  #{:DISPATCH :COEFFECT :HANDLER :FLOW :FX :SUBSCRIPTIONS :VIEWS
+    :SCHEMA-VIOLATIONS :CHILD-DISPATCHES :APP-DB-DIFF})
 
 (defn valid-badge?
   "Predicate — `:badge` keyword is a member of `badge-set`."

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -609,6 +609,66 @@
        :rows      rows
        :rollbacks (count (filter :rollback? rows))})))
 
+;; ---- APP-DB DIFF step (rf2-rrykz) ----------------------------------------
+;;
+;; The `:rf.event/db-changed` trace (Spec 009) carries the changed-
+;; paths vector under `:rf.event/db-changed-paths` — each element
+;; is `[path before after change-kind]`. The HANDLER step's
+;; `:db-diff` slot has read this since rf2-sc3r1 (carrying the
+;; same data); the APP-DB DIFF step is a dedicated section so the
+;; operator's "what changed in app-db?" question lands the same
+;; pre-roll as any cascade, separately from the HANDLER body.
+;;
+;; The two surfaces coexist intentionally — HANDLER's diff is an
+;; attribution-row (which handler caused this change), the APP-DB
+;; DIFF step is the canonical "state-mutation" lens (parallel to
+;; the App-DB Diff panel).
+;;
+;; Conditional: rendered only when the cascade actually mutated
+;; app-db.
+
+(defn- categorise-diff-path
+  "Classify one `[path before after change-kind]` triple into
+  `:added / :modified / :removed`. Defaults from before/after
+  nullity when `change-kind` is absent (older fixtures)."
+  [[_path before after change-kind]]
+  (cond
+    (= change-kind :added)    :added
+    (= change-kind :removed)  :removed
+    (= change-kind :modified) :modified
+    (and (nil? before) (some? after))   :added
+    (and (some? before) (nil? after))   :removed
+    :else                                :modified))
+
+(defn app-db-diff-step
+  "Build the APP-DB DIFF step row (rf2-rrykz). nil when the cascade
+  mutated no app-db paths (the step is OMITTED — conditional).
+
+  Reads the same `:rf.event/db-changed-paths` payload the HANDLER
+  step's `:db-diff` slot does — no re-derivation. Each row:
+
+    {:path <path-vec> :before <val> :after <val> :change <kind>}
+
+  Header counters split into `:added / :modified / :removed` so
+  the view can render `N changes (+M / ~K / -L)` at a glance."
+  [events]
+  (let [paths (db-diff-paths events)]
+    (when (seq paths)
+      (let [rows  (mapv (fn [triple]
+                          (let [[p before after change-kind] triple]
+                            {:path    p
+                             :before  before
+                             :after   after
+                             :change  (or change-kind (categorise-diff-path triple))}))
+                        paths)
+            kinds (frequencies (map :change rows))]
+        {:step     :app-db-diff
+         :badge    :APP-DB-DIFF
+         :rows     rows
+         :added    (get kinds :added    0)
+         :modified (get kinds :modified 0)
+         :removed  (get kinds :removed  0)}))))
+
 ;; ---- CHILD DISPATCHES step (rf2-yx1ae) -----------------------------------
 ;;
 ;; When a handler returns `:dispatch / :dispatch-n / :dispatch-later`
@@ -780,6 +840,12 @@
                           :badge :COEFFECT
                           :rows  cofx-rows})
                        (handler-row events event-id)
+                       ;; rf2-rrykz — APP-DB DIFF rides immediately after
+                       ;; HANDLER so the "what mutated in app-db?" lens
+                       ;; lands right after the attribution-row (the
+                       ;; HANDLER body's :db-diff). Same data, different
+                       ;; chrome — one cross-cascade canonical.
+                       (app-db-diff-step events)
                        (flow-step events)
                        (fx-step events)
                        ;; rf2-yx1ae — child dispatches sit after FX (they

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -384,7 +384,15 @@
   "Project the `:rf.fx/handled` / `:rf.fx/override-applied` /
   `:rf.fx/skipped-on-platform` stream into per-handler rows. Each row
   carries `:fx-id`, `:status` (`:ok / :overridden / :skipped /
-  :error`), `:args`, and `:duration-ms`."
+  :error`), `:args`, and `:duration-ms`.
+
+  Per rf2-uffov: each row also carries `:attributed-to` (the
+  machine action that emitted the fx) when the cascade was driven
+  by a machine handler — sourced from `:rf.machine/action-ran`'s
+  `:outcome :fx` slot (rf2-9c27r). The attribution is best-effort:
+  matched by `(= fx-id (first fx-tuple))` against the action's
+  emitted fx vector. When a fx-id is emitted by multiple actions
+  in the same cascade, the FIRST attribution wins (cascade order)."
   [events]
   (let [status-fn (fn [op-kw]
                     (case op-kw
@@ -393,27 +401,69 @@
                       :rf.fx/skipped-on-platform   :skipped
                       :rf.error/fx-handler-exception :error
                       :rf.error/no-such-fx         :error
-                      :ok))]
+                      :ok))
+        ;; Per rf2-uffov — build the per-action fx attribution map
+        ;; once for this projection pass. Each entry maps a fx-id
+        ;; (the first element of the action's emitted fx tuple) to
+        ;; the FIRST machine action that emitted it. This is the
+        ;; per-action attribution surfaced on the FX section's rows.
+        attribution-map
+        (reduce
+          (fn [acc ev]
+            (if (and (= :rf.machine/action-ran (op ev))
+                     (map? (common/tag-of ev :outcome)))
+              (let [{:keys [fx]} (common/tag-of ev :outcome)
+                    action-id    (common/tag-of ev :action-id)
+                    phase        (common/tag-of ev :phase)]
+                (reduce
+                  (fn [a entry]
+                    (let [fx-id (cond
+                                  (and (vector? entry) (pos? (count entry)))
+                                  (first entry)
+                                  (keyword? entry) entry)]
+                      (if (and fx-id (not (contains? a fx-id)))
+                        (assoc a fx-id {:action-id action-id :phase phase})
+                        a)))
+                  acc
+                  (or fx [])))
+              acc))
+          {}
+          events)]
     (vec
       (for [ev events
-            :let [o (op ev)]
+            :let [o (op ev)
+                  fx-id (common/tag-of ev :rf.fx/id)]
             :when (or (= "rf.fx" (op-ns ev))
                       (contains? #{:rf.error/fx-handler-exception
                                    :rf.error/no-such-fx} o))]
-        {:fx-id       (common/tag-of ev :rf.fx/id)
-         :status      (status-fn o)
-         :args        (common/tag-of ev :rf.fx/args)
-         :duration-ms (common/tag-of ev :duration-ms)}))))
+        (cond-> {:fx-id       fx-id
+                 :status      (status-fn o)
+                 :args        (common/tag-of ev :rf.fx/args)
+                 :duration-ms (common/tag-of ev :duration-ms)}
+          (get attribution-map fx-id)
+          (assoc :attributed-to (get attribution-map fx-id)))))))
 
 (defn fx-step
   "FX step row (one row aggregating every fx-handler invocation). nil
-  when no fx-handler events fired (the step is OMITTED — conditional)."
+  when no fx-handler events fired (the step is OMITTED — conditional).
+
+  Per rf2-uffov the step carries header counters splitting the rows
+  by outcome — `N fired (M succeeded, K threw)`. The view consumes
+  these directly so the header reads as 'at-a-glance correctness'."
   [events]
   (let [rows (fx-rows events)]
     (when (seq rows)
-      {:step  :fx
-       :badge :FX
-       :rows  rows})))
+      (let [by-status  (frequencies (map :status rows))
+            succeeded  (+ (get by-status :ok 0)
+                          (get by-status :overridden 0))
+            skipped    (get by-status :skipped 0)
+            threw      (get by-status :error 0)]
+        {:step      :fx
+         :badge     :FX
+         :rows      rows
+         :succeeded succeeded
+         :skipped   skipped
+         :threw     threw}))))
 
 ;; ---- SUBSCRIPTIONS step --------------------------------------------------
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -594,6 +594,58 @@
       :else        (let [rounded (/ (Math/round (double (* ms 10))) 10.0)]
                      (str rounded "ms")))))
 
+;; ---- timing aggregation (rf2-nqt3d) -------------------------------------
+;;
+;; Per-step `:duration-ms` is stamped at projection time (each step row
+;; reads its substrate-emitted duration off the matching trace event:
+;; `:rf.event/run-end` for HANDLER, `:rf.fx/handled` for FX rows, etc).
+;; The cascade total + long-step predicate are pure aggregations over
+;; the already-projected step rows so the view layer never re-walks the
+;; trace stream for chrome decisions.
+
+(def long-step-threshold-ms
+  "Threshold above which a single step is rendered with long-step
+  warning chrome. 16ms = one display frame at 60Hz — the natural
+  marker per the bead body's `N ms` slot (worker picks; documented
+  here as the contract).
+
+  Crossing 16ms in any single step means the cascade will visibly
+  jank the next paint, so the operator wants the row chromed as
+  load-bearing for perf debugging. Subtler than an `:error` glyph —
+  the spec body's posture is 'subtle, not alarmist'."
+  16)
+
+(defn long-step?
+  "True iff `step`'s `:duration-ms` exceeds `long-step-threshold-ms`.
+  Pure predicate over a projected step row; the view consumes this
+  to decide whether to paint the long-step warning chrome on the
+  duration chip."
+  [step]
+  (let [ms (:duration-ms step)]
+    (and (number? ms) (> ms long-step-threshold-ms))))
+
+(defn cascade-total-ms
+  "Sum of every step's `:duration-ms` over the projected step vector,
+  or nil when no step carries a numeric duration. Pure aggregation;
+  the view renders this in the cascade-summary chip at the top of
+  the panel.
+
+  Per rf2-nqt3d the summary is the operator's first read — the
+  cascade total tells them whether to even start drilling per-step.
+  Returns a number (so the chip can format via
+  `format-duration-ms`)."
+  [steps]
+  (let [nums (keep :duration-ms steps)]
+    (when (seq nums)
+      (reduce + 0 nums))))
+
+(defn long-step-count
+  "Count of projected steps whose `:duration-ms` exceeds the long-step
+  threshold. Drives the cascade-summary's secondary chip
+  (`N step over 16ms`)."
+  [steps]
+  (count (filter long-step? steps)))
+
 (defn event-display
   "Render the dispatched event vector as a one-line monospace string
   for the DISPATCH row's target slot."

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -432,7 +432,11 @@
   phases render dimmed `(none)` so the model reads as the full
   exit → transition → entry shape even when one phase carries no
   actions (the panel doubles as a teaching surface — bead body §What
-  this panel teaches)."
+  this panel teaches).
+
+  Per rf2-9c27r each row also surfaces per-action fx attribution
+  when the action returned a map carrying `:fx` — the operator can
+  trace each fx back to its emitting action without spec-walking."
   [lifecycle-rows]
   (let [grouped (proj/group-lifecycle-by-phase lifecycle-rows)
         phases  [:exit :transition :entry :always
@@ -457,28 +461,138 @@
                        :margin-bottom "2px"}}
          (proj/phase-label phase)]
         (for [[i row] (map-indexed vector rows)]
-          [:div {:key (str "lc-" i)
+          ^{:key (str "lc-" (name phase) "-" i)}
+          [:div {:data-testid (str "rf-xray-epoch-handler-phase-" (name phase) "-row-" i)
                  :style {:display "flex"
-                         :gap "8px"
+                         :flex-direction "column"
                          :padding "1px 0"
                          :color (if (:threw? row) (:error tokens)
                                     (:text-primary tokens))}}
-           [:span {:style {:color (:text-tertiary tokens)}} "↓"]
-           [:span (proj/ns-keyword (:action-id row))]
-           (when (:threw? row)
-             [:span {:style {:color (:error tokens) :margin-left "8px"}}
-              "(threw)"])])])]))
+           [:div {:style {:display "flex" :gap "8px" :align-items "center"}}
+            [:span {:style {:color (:text-tertiary tokens)}} "↓"]
+            [:span (proj/ns-keyword (:action-id row))]
+            (when (:threw? row)
+              [:span {:style {:color (:error tokens) :margin-left "8px"}}
+               "(threw)"])]
+           ;; rf2-9c27r — per-action fx attribution
+           (when (seq (:fx row))
+             [:div {:data-testid (str "rf-xray-epoch-handler-phase-" (name phase) "-fx-" i)
+                    :style {:padding-left "21px"
+                            :color (:text-tertiary tokens)
+                            :font-size "11px"}}
+              (for [[j entry] (map-indexed vector (:fx row))
+                    :let [[fx-id _args] (if (vector? entry) entry [entry nil])]]
+                ^{:key (str "lc-fx-" (name phase) "-" i "-" j)}
+                [:div {:style {:display "inline-flex"
+                               :align-items "center"
+                               :gap "4px"
+                               :margin-right "8px"}}
+                 "→ fx "
+                 [:span {:style {:color (:accent tokens)}}
+                  (proj/ns-keyword fx-id)]])])])])]))
+
+(defn- machine-data-reduction-block
+  "Render the DATA REDUCTION sub-section (rf2-9c27r §5). Renders
+  `:data` before / after via `edn/inspect`. Elides when both sides
+  are absent / identical."
+  [{:keys [data-before data-after]}]
+  (when (or (some? data-before) (some? data-after))
+    (when (not= data-before data-after)
+      [:div {:data-testid "rf-xray-epoch-handler-machine-data-reduction"
+             :style {:padding "3px 0 3px 16px"}}
+       (sub-header "data reduction")
+       [:div {:style {:display "flex"
+                      :gap "13px"
+                      :padding-left "16px"
+                      :font-family mono-stack
+                      :font-size "12px"
+                      :flex-wrap "wrap"}}
+        [:div {:data-testid "rf-xray-epoch-handler-machine-data-before"
+               :style {:flex 1 :min-width "120px"}}
+         [:div {:style {:color (:text-tertiary tokens)
+                        :font-size "10px"
+                        :text-transform "uppercase"
+                        :letter-spacing "0.5px"
+                        :margin-bottom "2px"}}
+          "before"]
+         [:div {:style {:color (:error tokens)}}
+          (edn/inspect-inline data-before)]]
+        [:div {:data-testid "rf-xray-epoch-handler-machine-data-after"
+               :style {:flex 1 :min-width "120px"}}
+         [:div {:style {:color (:text-tertiary tokens)
+                        :font-size "10px"
+                        :text-transform "uppercase"
+                        :letter-spacing "0.5px"
+                        :margin-bottom "2px"}}
+          "after"]
+         [:div {:style {:color (:success tokens)}}
+          (edn/inspect-inline data-after)]]]])))
+
+(defn- machine-snapshot-diff-block
+  "Render the SNAPSHOT DIFF sub-section (rf2-9c27r §6). The Spec 005
+  snapshot is the full `{:state … :data … …}` map; we render
+  `before` + `after` via `edn/inspect` so the operator can drill into
+  any slot (data, state, parallel-region tags). Elides when the
+  snapshots are identical."
+  [{:keys [before after]}]
+  (when (and (some? before) (some? after) (not= before after))
+    [:div {:data-testid "rf-xray-epoch-handler-machine-snapshot-diff"
+           :style {:padding "3px 0 3px 16px"}}
+     (sub-header "snapshot diff")
+     [:div {:style {:display "flex"
+                    :gap "13px"
+                    :padding-left "16px"
+                    :flex-wrap "wrap"}}
+      [:div {:data-testid "rf-xray-epoch-handler-machine-snapshot-before"
+             :style {:flex 1 :min-width "120px"
+                     :font-family mono-stack
+                     :font-size "12px"}}
+       [:div {:style {:color (:text-tertiary tokens)
+                      :font-size "10px"
+                      :text-transform "uppercase"
+                      :letter-spacing "0.5px"
+                      :margin-bottom "2px"}}
+        "before"]
+       [:div {:style {:color (:error tokens) :word-break "break-word"}}
+        (edn/inspect-inline before)]]
+      [:div {:data-testid "rf-xray-epoch-handler-machine-snapshot-after"
+             :style {:flex 1 :min-width "120px"
+                     :font-family mono-stack
+                     :font-size "12px"}}
+       [:div {:style {:color (:text-tertiary tokens)
+                      :font-size "10px"
+                      :text-transform "uppercase"
+                      :letter-spacing "0.5px"
+                      :margin-bottom "2px"}}
+        "after"]
+       [:div {:style {:color (:success tokens) :word-break "break-word"}}
+        (edn/inspect-inline after)]]]]))
 
 (defn- machine-block
   "Render the machine-handler-specific extras (transition summary,
-  guards, lifecycle, timer cancellations). Per the bead body §HANDLER
-  (Step 4) machine handler branch — uses the rf2-82a0u trace
-  enhancements (phase + outcome + reason)."
+  guards, lifecycle, timer cancellations, data reduction, snapshot
+  diff). Per the bead body §HANDLER (Step 4) machine handler branch —
+  uses the rf2-82a0u trace enhancements (phase + outcome + reason).
+
+  Per rf2-9c27r the section now carries all 7 sub-sections per the
+  design doc:
+
+    1. TRANSITION — `before-state → after-state`, event, microsteps
+    2. GUARDS — per-guard pass/fail/threw outcomes
+    3. LIFECYCLE — phase-grouped action rows with per-action fx
+       attribution
+    4. AFTER TIMERS — armed/cancelled with reasons
+    5. DATA REDUCTION — `:data` before / after via edn-inspector
+    6. SNAPSHOT DIFF — full snapshot before / after
+    7. FX — per-action fx attribution surfaces inline in LIFECYCLE
+       (rather than as a sibling sub-section) so the operator reads
+       'action X emitted fx Y' in one line."
   [{:keys [transition guards lifecycle timers]}]
   [:div {:data-testid "rf-xray-epoch-handler-machine"}
    ;; Transition summary
    (when transition
-     [:div {:style {:padding "3px 0 3px 16px"
+     [:div {:data-testid "rf-xray-epoch-handler-machine-transition"
+            :style {:padding "3px 0 3px 16px"
                     :font-family mono-stack
                     :font-size "12px"
                     :color (:text-primary tokens)}}
@@ -490,13 +604,24 @@
       [:div {:style {:padding-left "16px"}}
        (let [before (or (some-> (:before transition) :state) (:before transition))
              after  (or (some-> (:after transition) :state) (:after transition))]
-         (str (pr-str before) " → " (pr-str after)))]])
+         (str (pr-str before) " → " (pr-str after)))]
+      ;; rf2-9c27r — microsteps + event slots ride alongside the
+      ;; before→after pair so the operator can tell at a glance how
+      ;; many always-microsteps fired + which event drove the cascade.
+      (when (number? (:microsteps transition))
+        [:div {:data-testid "rf-xray-epoch-handler-machine-microsteps"
+               :style {:padding-left "16px"
+                       :color (:text-tertiary tokens)
+                       :font-size "10px"}}
+         (str (:microsteps transition) " microstep"
+              (when (not= 1 (:microsteps transition)) "s"))])])
    ;; Guards
    (when (seq guards)
      [:div {:style {:padding "3px 0 3px 16px"}}
       (sub-header "guards" (str (count guards) " evaluated"))
       (for [[i {:keys [guard-id outcome]}] (map-indexed vector guards)]
         [:div {:key (str "g-" i)
+               :data-testid (str "rf-xray-epoch-handler-guard-row-" i)
                :style {:display "flex"
                        :gap "8px"
                        :padding "1px 0 1px 21px"
@@ -516,7 +641,7 @@
          [:span (proj/ns-keyword guard-id)]
          [:span {:style {:color (:text-tertiary tokens) :margin-left "8px"}}
           (when (keyword? outcome) (name outcome))]])])
-   ;; Lifecycle
+   ;; Lifecycle (with per-action fx attribution — rf2-9c27r)
    (when (seq lifecycle)
      (machine-lifecycle-block lifecycle))
    ;; Timers
@@ -537,7 +662,13 @@
             (str delay "ms")])
          [:span {:style {:color (:text-tertiary tokens) :font-style "italic"
                          :margin-left "8px"}}
-          (proj/timer-reason-label reason)]])])])
+          (proj/timer-reason-label reason)]])])
+   ;; rf2-9c27r — DATA REDUCTION + SNAPSHOT DIFF sub-sections, fed
+   ;; by the `:data-before / :data-after` + `:before / :after`
+   ;; slots the projection hoists off the `:rf.machine/transition`
+   ;; trace.
+   (machine-data-reduction-block transition)
+   (machine-snapshot-diff-block transition)])
 
 ;; ---- handler source --------------------------------------------------
 ;;

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -869,8 +869,12 @@
 
   Argument order matches `map-indexed`'s `(f idx item)` convention
   (rf2-cq0ch — companion swap with `coeffect-row-view` /
-  `flow-row-view`)."
-  [idx {:keys [fx-id status args duration-ms]}]
+  `flow-row-view`).
+
+  Per rf2-uffov: when the row carries `:attributed-to`, a muted
+  `← <action-id>` attribution chip rides alongside so the operator
+  reads `fx X emitted by action Y` in one line."
+  [idx {:keys [fx-id status args duration-ms attributed-to]}]
   (let [glyph    (case status
                    :ok          "✓"
                    :overridden  "↺"
@@ -886,12 +890,14 @@
     [:div {:key (str "fx-" idx)
            :data-testid (str "rf-xray-epoch-fx-row-" idx)
            :data-fx-status (when (keyword? status) (name status))
+           :data-fx-attributed (str (some? attributed-to))
            :style {:display "flex"
                    :align-items "flex-start"
                    :gap "8px"
                    :padding "2px 0"
                    :font-family mono-stack
-                   :font-size "12px"}}
+                   :font-size "12px"
+                   :flex-wrap "wrap"}}
      [:span {:style {:color colour :font-weight 700}} glyph]
      [:span {:style {:color (:accent tokens)}}
       (proj/ns-keyword fx-id)]
@@ -903,24 +909,62 @@
        [:span {:style {:color (:text-tertiary tokens)
                        :margin-left "8px"
                        :white-space "nowrap"}}
-        (proj/format-duration-ms duration-ms)])]))
+        (proj/format-duration-ms duration-ms)])
+     ;; rf2-uffov — per-action attribution chip (for machine cascades)
+     (when-let [{:keys [action-id phase]} attributed-to]
+       [:span {:data-testid (str "rf-xray-epoch-fx-row-attribution-" idx)
+               :title (str "emitted by " (proj/ns-keyword action-id)
+                           (when phase (str " (" (name phase) " action)")))
+               :style {:color (:text-tertiary tokens)
+                       :font-size "10px"
+                       :margin-left "auto"
+                       :white-space "nowrap"
+                       :display "inline-flex"
+                       :align-items "center"
+                       :gap "4px"
+                       :font-style "italic"}}
+        [:span {:aria-hidden true} "←"]
+        (proj/ns-keyword action-id)
+        (when phase
+          [:span {:style {:color (:text-tertiary tokens)}}
+           (str "(" (name phase) ")")])])]))
 
 (defn render-fx-step
-  "Render the FX step (only present when fx-handlers fired)."
-  [{:keys [rows step-number]}]
-  [:div {:data-testid "rf-xray-epoch-step-fx"
-         :data-step-kw "fx"}
-   (numbered-circle step-number :FX)
-   (step-header
-     {:step :fx
-      :badge :FX
-      :verb (str (count rows) " side-effect"
-                 (when (not= 1 (count rows)) "s"))
-      :expandable? false
-      :testid "rf-xray-epoch-fx"}
-     nil)
-   [:div {:style {:margin-top "5px"}}
-    (map-indexed fx-row-view rows)]])
+  "Render the FX step (only present when fx-handlers fired).
+
+  Per rf2-uffov: header carries the outcome split — `N fired (M
+  succeeded, K threw)` — so the operator reads at-a-glance
+  correctness without scanning every row's glyph. The `:succeeded`
+  count rolls `:ok + :overridden`; `:skipped` rides as its own
+  chip when non-zero."
+  [{:keys [rows step-number succeeded skipped threw]}]
+  (let [n (count rows)
+        m (or succeeded n)
+        k (or threw 0)
+        s (or skipped 0)]
+    [:div {:data-testid "rf-xray-epoch-step-fx"
+           :data-step-kw "fx"
+           :data-fx-threw (str k)}
+     (numbered-circle step-number :FX)
+     (step-header
+       {:step :fx
+        :badge :FX
+        :verb [:span {:style {:display "inline-flex" :align-items "center"
+                              :gap "8px" :flex-wrap "wrap"}}
+               (str n " fired (" m " succeeded")
+               (when (pos? k)
+                 [:span {:style {:color (:error tokens)
+                                 :font-weight 700}}
+                  (str ", " k " threw")])
+               (when (pos? s)
+                 [:span {:style {:color (:text-tertiary tokens)}}
+                  (str ", " s " skipped")])
+               ")"]
+        :expandable? false
+        :testid "rf-xray-epoch-fx"}
+       nil)
+     [:div {:style {:margin-top "5px"}}
+      (map-indexed fx-row-view rows)]]))
 
 ;; ---- SUBSCRIPTIONS step --------------------------------------------------
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -1304,6 +1304,82 @@
    [:div {:style {:margin-top "5px"}}
     (map-indexed schema-violation-row-view rows)]])
 
+;; ---- APP-DB DIFF step (rf2-rrykz) ---------------------------------------
+
+(defn- app-db-diff-row-view
+  "Render one app-db diff row (rf2-rrykz). Per-row chrome mirrors the
+  HANDLER step's existing `db-diff-line` posture (+ for added, ~ for
+  modified, - for removed)."
+  [idx {:keys [path before after change]}]
+  (let [glyph (case change
+                :added    "+"
+                :removed  "-"
+                :modified "~"
+                "~")
+        glyph-colour (case change
+                       :added    (:success tokens)
+                       :removed  (:error tokens)
+                       (:warning tokens))]
+    [:div {:key (str "app-db-diff-" idx)
+           :data-testid (str "rf-xray-epoch-app-db-diff-row-" idx)
+           :data-change (when (keyword? change) (name change))
+           :style {:display      "flex"
+                   :align-items  "flex-start"
+                   :gap          "8px"
+                   :padding      "2px 0"
+                   :font-family  mono-stack
+                   :font-size    "12px"}}
+     [:span {:style {:color glyph-colour :font-weight 700}} glyph]
+     [:span {:style {:color (:text-tertiary tokens) :white-space "nowrap"}}
+      (proj/path-display path)]
+     (case change
+       :added
+       [:span {:style {:color (:success tokens) :min-width 0 :flex 1
+                       :word-break "break-word"}}
+        (proj/truncate (pr-str after) 80)]
+
+       :removed
+       [:span {:style {:color (:error tokens) :min-width 0 :flex 1
+                       :word-break "break-word"}}
+        (proj/truncate (pr-str before) 80)]
+
+       ;; modified (default)
+       [:<>
+        [:span {:style {:color (:error tokens)}}
+         (proj/truncate (pr-str before) 40)]
+        [:span {:style {:color (:text-tertiary tokens)}} "→"]
+        [:span {:style {:color (:success tokens)}}
+         (proj/truncate (pr-str after) 40)]])]))
+
+(defn render-app-db-diff-step
+  "Render the APP-DB DIFF step (rf2-rrykz — only present when the
+  cascade mutated app-db).
+
+  Header carries the change-count split `N changes (+M / ~K / -L)`
+  so the operator reads structure at a glance. Per-row body is
+  the same diff-line posture HANDLER's `:db-diff` uses (same data,
+  different lens — HANDLER attributes, APP-DB DIFF surfaces)."
+  [{:keys [rows added modified removed step-number]}]
+  [:div {:data-testid "rf-xray-epoch-step-app-db-diff"
+         :data-step-kw "app-db-diff"}
+   (numbered-circle step-number :APP-DB-DIFF)
+   (step-header
+     {:step :app-db-diff
+      :badge :APP-DB-DIFF
+      :verb [:span {:style {:display "inline-flex" :align-items "center"
+                            :gap "8px" :flex-wrap "wrap"}}
+             (str (count rows) " path"
+                  (when (not= 1 (count rows)) "s") " changed")
+             [:span {:style {:color (:text-tertiary tokens)
+                             :font-size "10px"
+                             :font-family mono-stack}}
+              (str "(+" added " / ~" modified " / -" removed ")")]]
+      :expandable? false
+      :testid "rf-xray-epoch-app-db-diff"}
+     nil)
+   [:div {:style {:margin-top "5px"}}
+    (map-indexed app-db-diff-row-view rows)]])
+
 ;; ---- CHILD DISPATCHES step (rf2-yx1ae) ----------------------------------
 
 (defn- child-dispatch-via-label
@@ -1445,6 +1521,7 @@
     :views             (render-views-step step)
     :schema-violations (render-schema-violations-step step)
     :child-dispatches  (render-child-dispatches-step step ctx)
+    :app-db-diff       (render-app-db-diff-step step)
     nil))
 
 ;; ---- pipeline view -------------------------------------------------------

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -1015,21 +1015,181 @@
      nil)
    (views-table rows)])
 
+;; ---- SCHEMA-VIOLATIONS step (rf2-17vxj) ----------------------------------
+
+(defn- schema-violation-where-label
+  "Render a violation's `:where` slot as a UI label (rf2-17vxj). Closed
+  set is per Spec 008 / 010; defaults to the keyword name."
+  [where]
+  (case where
+    :app-db      "app-db commit"
+    :cofx        "coeffect"
+    :sub-return  "sub return"
+    :fx-args     "fx args"
+    :event       "event payload"
+    :hot-reload  "schema hot-reload"
+    (when (keyword? where) (name where))))
+
+(defn- schema-violation-row-view
+  "Render one schema-violation row (rf2-17vxj). Per-row fields:
+
+    - `:where` label
+    - `:failing-id` / `:frame` (the registered name whose boundary failed)
+    - `:path` (the db / payload path, when available)
+    - failing value via `edn/inspect-inline` (already redacted at the
+      substrate emit site when `:sensitive?`)
+    - `:rollback?` chip when the cascade was rejected"
+  [idx {:keys [where failing-id path value rollback? recovery sensitive?
+               kind explain] :as _row}]
+  [:div {:key (str "schema-violation-" idx)
+         :data-testid (str "rf-xray-epoch-schema-violation-row-" idx)
+         :data-violation-kind (when kind (name kind))
+         :data-rollback (str (boolean rollback?))
+         :style {:display "flex"
+                 :flex-direction "column"
+                 :gap "3px"
+                 :padding "5px 8px"
+                 :background    (:bg-3 tokens)
+                 :border-left   (str "2px solid " (:warning tokens))
+                 :margin-bottom "5px"
+                 :border-radius "0 3px 3px 0"
+                 :font-family   mono-stack
+                 :font-size     "12px"}}
+   ;; head row: where + failing-id + rollback chip
+   [:div {:style {:display "flex"
+                  :align-items "center"
+                  :gap "8px"
+                  :flex-wrap "wrap"}}
+    [:span {:data-testid (str "rf-xray-epoch-schema-violation-where-" idx)
+            :style {:color       (:warning tokens)
+                    :font-weight 700
+                    :text-transform "uppercase"
+                    :font-size   "10px"
+                    :letter-spacing "0.5px"}}
+     (schema-violation-where-label where)]
+    (when failing-id
+      [:span {:data-testid (str "rf-xray-epoch-schema-violation-id-" idx)
+              :style {:color (:accent tokens)}}
+       (proj/ns-keyword failing-id)])
+    (when rollback?
+      [:span {:data-testid (str "rf-xray-epoch-schema-violation-rollback-" idx)
+              :title "this cascade was rolled back"
+              :style {:padding "2px 5px"
+                      :border-radius "3px"
+                      :background (:error tokens)
+                      :color (:white tokens)
+                      :font-size "10px"
+                      :font-weight 700
+                      :text-transform "uppercase"
+                      :letter-spacing "0.5px"}}
+       "rolled back"])
+    (when (and recovery (not rollback?))
+      [:span {:style {:color (:text-tertiary tokens)
+                      :font-size "10px"
+                      :font-style "italic"}}
+       (str "recovery: " (name recovery))])]
+   ;; path (when present)
+   (when (sequential? path)
+     [:div {:data-testid (str "rf-xray-epoch-schema-violation-path-" idx)
+            :style {:color (:text-tertiary tokens)
+                    :padding-left "16px"}}
+      (proj/path-display path)])
+   ;; failing value
+   (when (some? value)
+     [:div {:data-testid (str "rf-xray-epoch-schema-violation-value-" idx)
+            :style {:color (:text-primary tokens)
+                    :padding-left "16px"
+                    :word-break "break-word"}}
+      (edn/inspect-inline value)])
+   ;; sensitive marker (the substrate already redacted; surface that the
+   ;; value WAS redacted so the operator doesn't read the placeholder
+   ;; as the actual failing value)
+   (when sensitive?
+     [:div {:style {:color (:text-tertiary tokens)
+                    :font-style "italic"
+                    :font-size "10px"
+                    :padding-left "16px"}}
+      "(value redacted — slot declared :sensitive?)"])
+   ;; explain detail (Malli explain map, when stamped)
+   (when (some? explain)
+     [:div {:data-testid (str "rf-xray-epoch-schema-violation-explain-" idx)
+            :style {:color (:text-secondary tokens)
+                    :padding-left "16px"
+                    :font-size "11px"}}
+      (proj/truncate (pr-str explain) 120)])])
+
+(defn render-schema-violations-step
+  "Render the SCHEMA VIOLATIONS step (rf2-17vxj — only present when
+  the cascade carried `:rf.error/schema-validation-failure` or
+  `:rf.schema/violation` trace events).
+
+  Header carries the violation count + a per-rollback split + a
+  click-affordance that navigates to the Issues panel for full
+  triage (the per-row data shows the cascade-local view; Issues
+  holds the cross-session list)."
+  [{:keys [rows rollbacks step-number]}]
+  [:div {:data-testid "rf-xray-epoch-step-schema-violations"
+         :data-step-kw "schema-violations"
+         :data-rollback-count (str (or rollbacks 0))}
+   (numbered-circle step-number :SCHEMA-VIOLATIONS)
+   (step-header
+     {:step :schema-violations
+      :badge :SCHEMA-VIOLATIONS
+      :verb [:span {:style {:display "inline-flex" :align-items "center"
+                            :gap "8px" :flex-wrap "wrap"}}
+             [:span {:style {:display "inline-flex"
+                             :align-items "center"
+                             :gap "4px"
+                             :color (:warning tokens)}}
+              (icons/alert-triangle)
+              (str (count rows) " violation"
+                   (when (not= 1 (count rows)) "s"))]
+             (when (pos? (or rollbacks 0))
+               [:span {:style {:color (:error tokens)
+                               :font-weight 700}}
+                (str rollbacks " rollback"
+                     (when (not= 1 rollbacks) "s"))])
+             [:button {:data-testid "rf-xray-epoch-schema-violations-open-issues"
+                       :aria-label "open the Issues panel for full triage"
+                       :on-click (fn [e]
+                                   (.stopPropagation e)
+                                   (rf/dispatch [:rf.xray/select-tab :issues]
+                                                {:frame :rf/xray}))
+                       :style {:background "transparent"
+                               :border (str "1px solid " (:border-default tokens))
+                               :border-radius "3px"
+                               :color (:text-secondary tokens)
+                               :cursor "pointer"
+                               :font-family sans-stack
+                               :font-size "10px"
+                               :padding "2px 8px"
+                               :margin-left "8px"
+                               :text-transform "uppercase"
+                               :letter-spacing "0.5px"}}
+              "open issues →"]]
+      :expandable? false
+      :testid "rf-xray-epoch-schema-violations"}
+     nil)
+   [:div {:style {:margin-top "5px"}}
+    (map-indexed schema-violation-row-view rows)]])
+
 ;; ---- step dispatcher -----------------------------------------------------
 
 (defn- render-step
   "Dispatch a step row to its renderer. Returns hiccup; nil for
   unknown step kinds (defensive — every step the projection produces
-  is in the seven-step inventory)."
+  is in the canonical inventory; rf2-17vxj added SCHEMA-VIOLATIONS,
+  rf2-yx1ae added CHILD-DISPATCHES, rf2-rrykz added APP-DB-DIFF)."
   [step]
   (case (:step step)
-    :dispatch       (render-dispatch-step step)
-    :coeffect       (render-coeffect-step step)
-    :handler        (render-handler-step step)
-    :flow           (render-flow-step step)
-    :fx             (render-fx-step step)
-    :subscriptions  (render-subscriptions-step step)
-    :views          (render-views-step step)
+    :dispatch          (render-dispatch-step step)
+    :coeffect          (render-coeffect-step step)
+    :handler           (render-handler-step step)
+    :flow              (render-flow-step step)
+    :fx                (render-fx-step step)
+    :subscriptions     (render-subscriptions-step step)
+    :views             (render-views-step step)
+    :schema-violations (render-schema-violations-step step)
     nil))
 
 ;; ---- pipeline view -------------------------------------------------------

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -130,18 +130,41 @@
 (defn- duration-chip
   "Right-aligned duration chip rendered alongside a step's header.
   Returns nil for non-number durations so the view can elide the
-  slot when the substrate didn't stamp one."
+  slot when the substrate didn't stamp one.
+
+  Per rf2-nqt3d the chip carries a subtle long-step warning when
+  the duration exceeds 16ms (one 60Hz frame). The warning is
+  conveyed by a warning-tone colour + a small `▲` marker —
+  alarmist `✗` chrome would crowd the cascade with noise on the
+  common case where one step is naturally heavy."
   [duration-ms]
   (when (number? duration-ms)
-    [:span {:data-testid "rf-xray-epoch-duration"
-            :style {:color       (:text-tertiary tokens)
-                    :font-family mono-stack
-                    :font-size   "11px"
-                    :font-weight 500
-                    :white-space "nowrap"
-                    :margin-left "auto"
-                    :padding-left "8px"}}
-     (proj/format-duration-ms duration-ms)]))
+    (let [long? (> duration-ms proj/long-step-threshold-ms)]
+      [:span {:data-testid (if long?
+                             "rf-xray-epoch-duration-long"
+                             "rf-xray-epoch-duration")
+              :data-long-step (str long?)
+              :title (when long?
+                       (str "step exceeded "
+                            proj/long-step-threshold-ms
+                            "ms (one 60Hz frame)"))
+              :style {:color       (if long?
+                                     (:warning tokens)
+                                     (:text-tertiary tokens))
+                      :font-family mono-stack
+                      :font-size   "11px"
+                      :font-weight (if long? 700 500)
+                      :white-space "nowrap"
+                      :margin-left "auto"
+                      :padding-left "8px"
+                      :display     "inline-flex"
+                      :align-items "center"
+                      :gap         "4px"}}
+       (when long?
+         [:span {:aria-hidden true
+                 :style {:font-size "10px"}}
+          "▲"])
+       (proj/format-duration-ms duration-ms)])))
 
 (defn- coord-chip
   "External-link affordance — opens the editor at `coord` via the
@@ -1011,6 +1034,63 @@
 
 ;; ---- pipeline view -------------------------------------------------------
 
+(defn cascade-summary
+  "Render the cascade-summary chip at the top of the pipeline (rf2-nqt3d).
+
+  Two pieces of information:
+
+    1. **Cascade total** — sum of every projected step's `:duration-ms`,
+       formatted via `format-duration-ms`. Operator's first read —
+       'how heavy was this whole cascade'.
+    2. **Long-step count** — number of steps whose `:duration-ms`
+       exceeded `proj/long-step-threshold-ms` (16ms — one 60Hz frame).
+       Rendered with warning tone when > 0; absent when 0.
+
+  Returns nil when the cascade carries no durations (cold start
+  records, fixtures synthesised without timing). The view elides
+  the slot rather than rendering `total: —`."
+  [steps]
+  (let [total       (proj/cascade-total-ms steps)
+        long-count  (proj/long-step-count steps)]
+    (when (number? total)
+      [:div {:data-testid "rf-xray-epoch-cascade-summary"
+             :data-long-step-count (str long-count)
+             :style {:display       "flex"
+                     :align-items   "center"
+                     :gap           "13px"
+                     :margin-bottom "13px"
+                     :padding       "5px 8px"
+                     :border        (str "1px solid " (:border-subtle tokens))
+                     :border-radius "3px"
+                     :background    (:bg-3 tokens)
+                     :font-family   sans-stack
+                     :font-size     "11px"
+                     :color         (:text-secondary tokens)}}
+       [:span {:style {:color (:text-tertiary tokens)
+                       :text-transform "uppercase"
+                       :letter-spacing "0.5px"
+                       :font-weight 600
+                       :font-size "10px"}}
+        "cascade total"]
+       [:span {:data-testid "rf-xray-epoch-cascade-summary-total"
+               :style {:color       (:text-primary tokens)
+                       :font-family mono-stack
+                       :font-weight 700}}
+        (proj/format-duration-ms total)]
+       (when (pos? long-count)
+         [:span {:data-testid "rf-xray-epoch-cascade-summary-long-count"
+                 :title       (str long-count " step"
+                                   (when (not= 1 long-count) "s")
+                                   " over " proj/long-step-threshold-ms "ms")
+                 :style {:color (:warning tokens)
+                         :font-family mono-stack
+                         :margin-left "auto"
+                         :display "inline-flex"
+                         :align-items "center"
+                         :gap "4px"}}
+          [:span {:aria-hidden true :style {:font-size "10px"}} "▲"]
+          (str long-count " over " proj/long-step-threshold-ms "ms")])])))
+
 (defn pipeline-view
   "Render the numbered pipeline cascade for `steps` (already
   numbered via `project-numbered`). Each step renders as a
@@ -1026,10 +1106,15 @@
                      13px from top, positioned at -34px from left edge
       Row spacing: 13px vertical gap between entries"
   [steps]
-  [:div {:data-testid "rf-xray-epoch-pipeline"
-         :style {:position    "relative"
-                 :padding-left "55px"
-                 :padding-top  "0"}}
+  [:div {:data-testid "rf-xray-epoch-pipeline-container"}
+   ;; rf2-nqt3d — cascade-summary chip rides above the numbered
+   ;; cascade. When the projection carries no durations the chip
+   ;; elides; the cascade still renders normally.
+   (cascade-summary steps)
+   [:div {:data-testid "rf-xray-epoch-pipeline"
+          :style {:position    "relative"
+                  :padding-left "55px"
+                  :padding-top  "0"}}
    ;; The vertical rail — absolute-positioned line behind the
    ;; numbered circles. Top = numbered-circle radius (so the line
    ;; starts at the centre of step-1's circle); bottom = the foot
@@ -1051,7 +1136,7 @@
             :style {:position     "relative"
                     :margin-bottom "13px"
                     :min-height   "21px"}}
-      (render-step step)])])
+      (render-step step)])]])
 
 ;; ---- empty states --------------------------------------------------------
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -1173,14 +1173,137 @@
    [:div {:style {:margin-top "5px"}}
     (map-indexed schema-violation-row-view rows)]])
 
+;; ---- CHILD DISPATCHES step (rf2-yx1ae) ----------------------------------
+
+(defn- child-dispatch-via-label
+  "Render the `:via` slot (the fx-id that emitted the row) as a UI
+  chip label (rf2-yx1ae)."
+  [via]
+  (case via
+    :dispatch        "dispatch"
+    :dispatch-n      "dispatch-n"
+    :dispatch-later  "dispatch-later"
+    (when (keyword? via) (name via))))
+
+(defn- child-dispatch-row-view
+  "Render one child-dispatch row. Carries:
+
+  - child event vector (the operator's primary read)
+  - `:via` chip (which fx-id emitted the row)
+  - `:delay-ms` chip (for `:dispatch-later`)
+  - jump-to button when the child epoch is in the buffer; otherwise
+    a muted `not in buffer` marker
+
+  rf2-yx1ae. The jump-to dispatches `:rf.xray/select-epoch` against
+  the resolved child `:epoch-id`."
+  [{:keys [dispatch-id epoch-history]} idx {:keys [event delay-ms via]}]
+  (let [child-epoch-id (proj/find-child-epoch epoch-history dispatch-id event)]
+    [:div {:key (str "child-dispatch-" idx)
+           :data-testid (str "rf-xray-epoch-child-dispatch-row-" idx)
+           :data-child-resolved (str (some? child-epoch-id))
+           :style {:display "flex"
+                   :align-items "center"
+                   :gap "8px"
+                   :padding "3px 0"
+                   :font-family mono-stack
+                   :font-size "12px"
+                   :flex-wrap "wrap"}}
+     ;; via fx-id chip (muted)
+     [:span {:data-testid (str "rf-xray-epoch-child-dispatch-via-" idx)
+             :style {:color (:text-tertiary tokens)
+                     :font-size "10px"
+                     :text-transform "uppercase"
+                     :letter-spacing "0.5px"
+                     :font-weight 600}}
+      (child-dispatch-via-label via)]
+     ;; event vector (primary)
+     [:span {:data-testid (str "rf-xray-epoch-child-dispatch-event-" idx)
+             :style {:color (:text-primary tokens)
+                     :min-width 0
+                     :flex 1
+                     :word-break "break-word"}}
+      (pr-str event)]
+     ;; delay chip (for :dispatch-later)
+     (when (number? delay-ms)
+       [:span {:data-testid (str "rf-xray-epoch-child-dispatch-delay-" idx)
+               :style {:color (:text-tertiary tokens)
+                       :font-size "10px"}}
+        (str "+" delay-ms "ms")])
+     ;; jump-to or "not in buffer"
+     (if child-epoch-id
+       [:button {:data-testid (str "rf-xray-epoch-child-dispatch-jump-" idx)
+                 :data-child-epoch-id (str child-epoch-id)
+                 :aria-label "jump to child cascade"
+                 :on-click (fn [e]
+                             (.stopPropagation e)
+                             (rf/dispatch [:rf.xray/select-epoch child-epoch-id]
+                                          {:frame :rf/xray}))
+                 :style {:background "transparent"
+                         :border (str "1px solid " (:border-default tokens))
+                         :border-radius "3px"
+                         :color (:accent tokens)
+                         :cursor "pointer"
+                         :font-family sans-stack
+                         :font-size "10px"
+                         :padding "2px 8px"
+                         :display "inline-flex"
+                         :align-items "center"
+                         :gap "4px"
+                         :text-transform "uppercase"
+                         :letter-spacing "0.5px"}}
+        (icons/arrow-right)
+        "jump"]
+       [:span {:data-testid (str "rf-xray-epoch-child-dispatch-missing-" idx)
+               :title "the child cascade has aged out of the epoch buffer (or has not yet completed)"
+               :style {:color (:text-tertiary tokens)
+                       :font-size "10px"
+                       :font-style "italic"}}
+        "not in buffer"])]))
+
+(defn render-child-dispatches-step
+  "Render the CHILD-DISPATCHES step (rf2-yx1ae — only present when
+  the handler returned dispatch-family fx).
+
+  Header: `N events dispatched` (per the bead's acceptance §4).
+  Per-row: event vector + via-fx chip + delay chip + jump-to
+  affordance (resolves child epoch via `proj/find-child-epoch`).
+
+  `ctx` carries this cascade's `:dispatch-id` + the
+  `:epoch-history` slice; the row-view uses both to find the
+  child's `:epoch-id`."
+  [{:keys [rows step-number]} ctx]
+  [:div {:data-testid "rf-xray-epoch-step-child-dispatches"
+         :data-step-kw "child-dispatches"}
+   (numbered-circle step-number :CHILD-DISPATCHES)
+   (step-header
+     {:step :child-dispatches
+      :badge :CHILD-DISPATCHES
+      :verb (str (count rows) " event"
+                 (when (not= 1 (count rows)) "s")
+                 " dispatched")
+      :expandable? false
+      :testid "rf-xray-epoch-child-dispatches"}
+     nil)
+   [:div {:style {:margin-top "5px"}}
+    (map-indexed (fn [idx row]
+                   (child-dispatch-row-view ctx idx row))
+                 rows)]])
+
 ;; ---- step dispatcher -----------------------------------------------------
+
+(declare render-child-dispatches-step)
 
 (defn- render-step
   "Dispatch a step row to its renderer. Returns hiccup; nil for
   unknown step kinds (defensive — every step the projection produces
   is in the canonical inventory; rf2-17vxj added SCHEMA-VIOLATIONS,
-  rf2-yx1ae added CHILD-DISPATCHES, rf2-rrykz added APP-DB-DIFF)."
-  [step]
+  rf2-yx1ae added CHILD-DISPATCHES, rf2-rrykz added APP-DB-DIFF).
+
+  `ctx` carries the cascade-level pieces a row may need (e.g. the
+  parent `:dispatch-id` + the `:epoch-history` slice for the
+  CHILD-DISPATCHES section's child-epoch resolution). Most steps
+  ignore it."
+  [step ctx]
   (case (:step step)
     :dispatch          (render-dispatch-step step)
     :coeffect          (render-coeffect-step step)
@@ -1190,6 +1313,7 @@
     :subscriptions     (render-subscriptions-step step)
     :views             (render-views-step step)
     :schema-violations (render-schema-violations-step step)
+    :child-dispatches  (render-child-dispatches-step step ctx)
     nil))
 
 ;; ---- pipeline view -------------------------------------------------------
@@ -1264,39 +1388,47 @@
       Pipeline: left margin 55px to accommodate numbered circles
       Vertical line: absolute positioned, 0.5px width, starts at
                      13px from top, positioned at -34px from left edge
-      Row spacing: 13px vertical gap between entries"
-  [steps]
-  [:div {:data-testid "rf-xray-epoch-pipeline-container"}
-   ;; rf2-nqt3d — cascade-summary chip rides above the numbered
-   ;; cascade. When the projection carries no durations the chip
-   ;; elides; the cascade still renders normally.
-   (cascade-summary steps)
-   [:div {:data-testid "rf-xray-epoch-pipeline"
-          :style {:position    "relative"
-                  :padding-left "55px"
-                  :padding-top  "0"}}
-   ;; The vertical rail — absolute-positioned line behind the
-   ;; numbered circles. Top = numbered-circle radius (so the line
-   ;; starts at the centre of step-1's circle); bottom = the foot
-   ;; of the last step's circle.
-   [:div {:data-testid "rf-xray-epoch-rail"
-          :aria-hidden true
-          :style {:position    "absolute"
-                  :left        (str (+ 55 badge/line-left-offset-px) "px")
-                  :top         (str badge/vertical-line-offset-px "px")
-                  :bottom      "13px"
-                  :width       "1px"
-                  :background  (:border-default tokens)
-                  :pointer-events "none"}}]
-   ;; Steps
-   (for [[i step] (map-indexed vector steps)]
-     ^{:key (str "step-" (:step step) "-" i)}
-     [:div {:data-testid (str "rf-xray-epoch-pipeline-step-" (:step-number step))
-            :data-step (when (:step step) (name (:step step)))
-            :style {:position     "relative"
-                    :margin-bottom "13px"
-                    :min-height   "21px"}}
-      (render-step step)])]])
+      Row spacing: 13px vertical gap between entries
+
+  `ctx` is an optional map carrying cascade-level pieces individual
+  step renderers may need (`:dispatch-id`, `:epoch-history` — used
+  by the CHILD-DISPATCHES section to resolve child epochs via
+  `proj/find-child-epoch`). Defaulted to `{}` for back-compat with
+  direct test callers."
+  ([steps]
+   (pipeline-view steps {}))
+  ([steps ctx]
+   [:div {:data-testid "rf-xray-epoch-pipeline-container"}
+    ;; rf2-nqt3d — cascade-summary chip rides above the numbered
+    ;; cascade. When the projection carries no durations the chip
+    ;; elides; the cascade still renders normally.
+    (cascade-summary steps)
+    [:div {:data-testid "rf-xray-epoch-pipeline"
+           :style {:position    "relative"
+                   :padding-left "55px"
+                   :padding-top  "0"}}
+     ;; The vertical rail — absolute-positioned line behind the
+     ;; numbered circles. Top = numbered-circle radius (so the line
+     ;; starts at the centre of step-1's circle); bottom = the foot
+     ;; of the last step's circle.
+     [:div {:data-testid "rf-xray-epoch-rail"
+            :aria-hidden true
+            :style {:position    "absolute"
+                    :left        (str (+ 55 badge/line-left-offset-px) "px")
+                    :top         (str badge/vertical-line-offset-px "px")
+                    :bottom      "13px"
+                    :width       "1px"
+                    :background  (:border-default tokens)
+                    :pointer-events "none"}}]
+     ;; Steps
+     (for [[i step] (map-indexed vector steps)]
+       ^{:key (str "step-" (:step step) "-" i)}
+       [:div {:data-testid (str "rf-xray-epoch-pipeline-step-" (:step-number step))
+              :data-step (when (:step step) (name (:step step)))
+              :style {:position     "relative"
+                      :margin-bottom "13px"
+                      :min-height   "21px"}}
+        (render-step step ctx)])]]))
 
 ;; ---- empty states --------------------------------------------------------
 
@@ -1325,7 +1457,8 @@
   the numbered cascade when steps are present; an empty-state when
   the focus carries no record or the record carries no trace events."
   []
-  (let [{:keys [status steps]} @(rf/subscribe [:rf.xray/epoch-pipeline])]
+  (let [{:keys [status steps dispatch-id epoch-history]}
+        @(rf/subscribe [:rf.xray/epoch-pipeline])]
     [:section {:data-testid "rf-xray-epoch-panel"
                :style {:height          "100%"
                        :display         "flex"
@@ -1344,7 +1477,9 @@
       (cond
         (= :focused status)
         (if (seq steps)
-          (pipeline-view steps)
+          (pipeline-view steps
+                         {:dispatch-id   dispatch-id
+                          :epoch-history epoch-history})
           (empty-state-view :no-events))
 
         :else

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch_panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch_panel.cljs
@@ -95,10 +95,18 @@
             record         (focus/find-epoch-record focus-epoch-id
                                                     epoch-history)
             steps          (when record (proj/project-numbered record))]
-        {:status   status
-         :epoch-id (or focus-epoch-id (:epoch-id record))
-         :record   record
-         :steps    (vec (or steps []))})))
+        {:status         status
+         :epoch-id       (or focus-epoch-id (:epoch-id record))
+         :record         record
+         ;; rf2-yx1ae — the CHILD-DISPATCHES section's view resolves
+         ;; child epoch-ids via `find-child-epoch` against this cascade's
+         ;; `:dispatch-id` + the epoch-history. Pinning them on the
+         ;; composite sub keeps the view side a pure render — no
+         ;; secondary sub against `:rf.xray/epoch-history` in the
+         ;; per-row hot path.
+         :dispatch-id    (:dispatch-id record)
+         :epoch-history  epoch-history
+         :steps          (vec (or steps []))})))
 
   ;; ---- per-row expand state ---------------------------------------------
   ;;

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -454,15 +454,18 @@
 ;; ---- top-level project --------------------------------------------------
 
 (deftest project-minimal-test
-  (testing "minimal epoch (dispatch + handler, no cofx/flow/fx/sub/view)"
+  (testing "minimal epoch (dispatch + handler + app-db-diff for the
+            db mutation, no cofx/flow/fx/sub/view)"
     (let [rec   (record [(dispatched-ev [:counter-inc] :ui nil)
                          (db-changed-ev [[[:counter] 5 6 :modified]])])
           steps (proj/project rec)]
-      (is (= 2 (count steps)))
-      (is (= [:dispatch :handler] (mapv :step steps))))))
+      (is (= 3 (count steps))
+          "rf2-rrykz appends :app-db-diff for any cascade that mutated app-db")
+      (is (= [:dispatch :handler :app-db-diff] (mapv :step steps))))))
 
 (deftest project-full-pipeline-test
-  (testing "full epoch with every step → 7 steps emitted"
+  (testing "full epoch with every step + app-db-diff + child-dispatches
+            (handler returned `:dispatch` fx)"
     (let [rec   (record [(dispatched-ev [:cart/checkout] :ui nil)
                          (cofx-run-ev :session {:user 1})
                          (do-fx-ev {:db {} :http/post {:url "/x"}})
@@ -472,10 +475,13 @@
                          (fx-handled-ev :http/post {} 12.0)
                          (sub-run-ev [:total] true 10 20)
                          (view-render-ev ::cart-view [:total])])
-          steps (proj/project rec)]
-      (is (= 7 (count steps)))
-      (is (= [:dispatch :coeffect :handler :flow :fx :subscriptions :views]
-             (mapv :step steps))))))
+          steps (proj/project rec)
+          kws   (mapv :step steps)]
+      (is (= [:dispatch :coeffect :handler :app-db-diff :flow :fx
+              :subscriptions :views]
+             kws)
+          "rf2-rrykz appends :app-db-diff between :handler and :flow")
+      (is (= 8 (count steps))))))
 
 (deftest project-numbered-test
   (testing "number-steps assigns sequential 1..N regardless of omissions"
@@ -648,6 +654,55 @@
           "both events project into rows")
       (is (= 0 (:rollbacks s))
           "no rollback-true rows in this fixture"))))
+
+;; ---- rf2-rrykz — app-db diff section ----------------------------------
+
+(deftest app-db-diff-step-conditional-test
+  (testing "rf2-rrykz — no db-changed event → step OMITTED"
+    (is (nil? (proj/app-db-diff-step []))))
+
+  (testing "rf2-rrykz — empty changed-paths → step OMITTED"
+    (is (nil? (proj/app-db-diff-step [(db-changed-ev [])]))))
+
+  (testing "rf2-rrykz — db mutation present → step rendered"
+    (let [s (proj/app-db-diff-step
+              [(db-changed-ev [[[:count]    0   1   :modified]
+                               [[:cart 0]   nil "x" :added]
+                               [[:old]      5   nil :removed]])])]
+      (is (= :app-db-diff (:step s)))
+      (is (= :APP-DB-DIFF (:badge s)))
+      (is (= 3 (count (:rows s))))
+      (is (= 1 (:added s)))
+      (is (= 1 (:modified s)))
+      (is (= 1 (:removed s))))))
+
+(deftest app-db-diff-row-fields-test
+  (testing "rf2-rrykz — each row carries `:path / :before / :after / :change`"
+    (let [s (proj/app-db-diff-step
+              [(db-changed-ev [[[:count] 0 1 :modified]])])
+          r (-> s :rows first)]
+      (is (= [:count] (:path r)))
+      (is (= 0 (:before r)))
+      (is (= 1 (:after r)))
+      (is (= :modified (:change r))))))
+
+(deftest project-includes-app-db-diff-after-handler-test
+  (testing "rf2-rrykz — top-level project emits APP-DB-DIFF immediately
+            after HANDLER so the state-mutation lens lands next to the
+            attribution row"
+    (let [rec   (record [(dispatched-ev [:counter/inc] :ui nil)
+                         (db-changed-ev [[[:count] 0 1 :modified]])])
+          steps (proj/project rec)
+          kws   (mapv :step steps)]
+      (is (some #{:app-db-diff} kws))
+      (is (= (.indexOf kws :app-db-diff)
+             (inc (.indexOf kws :handler)))
+          ":app-db-diff rides immediately after :handler")))
+
+  (testing "rf2-rrykz — no app-db mutation → step absent"
+    (let [rec   (record [(dispatched-ev [:counter/inc] :ui nil)])
+          steps (proj/project rec)]
+      (is (not-any? #(= :app-db-diff (:step %)) steps)))))
 
 ;; ---- rf2-yx1ae — child dispatches section -----------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -111,10 +111,15 @@
          (assoc :rf.view/elapsed-ms elapsed-ms)))))
 
 (defn- machine-transition-ev
-  [machine-id before after]
-  (ev :rf.machine :rf.machine/transition {:machine-id machine-id
-                                          :before before
-                                          :after after}))
+  ([machine-id before after]
+   (machine-transition-ev machine-id before after nil 0))
+  ([machine-id before after event microsteps]
+   (ev :rf.machine :rf.machine/transition
+       (cond-> {:machine-id machine-id
+                :before before
+                :after after}
+         event       (assoc :event event)
+         microsteps  (assoc :microsteps microsteps)))))
 
 (defn- machine-guard-ev
   [guard-id outcome]
@@ -122,11 +127,13 @@
                                                :outcome outcome}))
 
 (defn- machine-action-ev
-  [action-id phase outcome]
-  (ev :rf.machine :rf.machine/action-ran {:action-id action-id
-                                          :phase phase
-                                          :outcome outcome
-                                          :input {:data {} :event nil}}))
+  ([action-id phase outcome]
+   (machine-action-ev action-id phase outcome nil))
+  ([action-id phase outcome data]
+   (ev :rf.machine :rf.machine/action-ran {:action-id action-id
+                                           :phase phase
+                                           :outcome outcome
+                                           :input {:data (or data {}) :event nil}})))
 
 (defn- machine-timer-cancel-ev
   [machine-id state delay reason]
@@ -281,6 +288,59 @@
       (is (= 2 (count (:lifecycle m))))
       (is (= 1 (count (:timers m))))
       (is (= :on-exit (-> m :timers first :reason))))))
+
+(deftest machine-transition-row-hoists-data-snapshots-test
+  (testing "rf2-9c27r — `machine-transition-row` exposes `:data-before /
+            :data-after` from the `:before / :after` snapshots, plus the
+            `:event` + `:microsteps` slots for the design's TRANSITION sub"
+    (let [snap-before {:state [:idle]      :data {:count 0}}
+          snap-after  {:state [:connected] :data {:count 1}}
+          evs [(machine-transition-ev :ws/conn snap-before snap-after
+                                       [:ws/start] 2)
+               ;; action-ran event drives the :reg-machine flavour
+               ;; discriminator so handler-row populates the machine
+               ;; block (rf2-9c27r — the transition row only lands
+               ;; when the flavour is :reg-machine).
+               (machine-action-ev :open-socket :entry :ok)]
+          r   (proj/handler-row evs :ws/start)
+          mt  (-> r :machine :transition)]
+      (is (= [:ws/start]    (:event mt)))
+      (is (= 2              (:microsteps mt)))
+      (is (= snap-before    (:before mt)))
+      (is (= snap-after     (:after mt)))
+      (is (= {:count 0}     (:data-before mt))
+          ":data-before hoisted off the before snapshot")
+      (is (= {:count 1}     (:data-after mt))
+          ":data-after hoisted off the after snapshot"))))
+
+(deftest machine-action-fx-attribution-test
+  (testing "rf2-9c27r — when a lifecycle action returns a map carrying
+            `:fx`, the row exposes the per-action fx attribution"
+    (let [outcome {:fx [[:http/get {:url "/x"}]
+                        [:dispatch [:other]]]
+                   :data {:n 1}}
+          evs [(ev :rf.machine :rf.machine/action-ran
+                   {:action-id :open-socket
+                    :phase     :entry
+                    :outcome   outcome
+                    :input     {:data {} :event nil}})]
+          r   (proj/handler-row evs :ws/start)
+          row (-> r :machine :lifecycle first)]
+      (is (= 2 (count (:fx row)))
+          "per-action fx tuple list rides on the lifecycle row")
+      (is (= :http/get (-> row :fx (nth 0) first))
+          "first fx-id is :http/get")
+      (is (= {:n 1} (:data-write row))
+          "the action's :data write is also surfaced for attribution"))))
+
+(deftest machine-action-without-fx-omits-slot-test
+  (testing "rf2-9c27r — actions whose outcome carries no :fx leave the
+            `:fx` slot ABSENT (not nil) so the row stays minimal"
+    (let [evs [(machine-action-ev :open-socket :entry :ok)]
+          r   (proj/handler-row evs :ws/start)
+          row (-> r :machine :lifecycle first)]
+      (is (not (contains? row :fx))
+          ":fx slot absent on actions without per-action fx"))))
 
 (deftest machine-lifecycle-grouped-by-phase-test
   (testing "group-lifecycle-by-phase produces phase → rows map"

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -135,6 +135,25 @@
                                                :delay delay
                                                :reason reason}))
 
+(defn- schema-violation-ev
+  ([where failing-id path value]
+   (schema-violation-ev where failing-id path value nil))
+  ([where failing-id path value rollback?]
+   (ev :error :rf.error/schema-validation-failure
+       (cond-> {:where where
+                :failing-id failing-id
+                :path path
+                :value value}
+         (some? rollback?) (assoc :rollback? rollback?)))))
+
+(defn- schema-hot-reload-ev
+  [frame-id path mismatching-value]
+  (ev :warning :rf.schema/violation
+      {:frame frame-id
+       :path path
+       :mismatching-value mismatching-value
+       :recovery :logged-and-skipped}))
+
 (defn- record
   "Build a synthetic `:rf/epoch-record` for projection."
   ([events] (record events nil))
@@ -437,7 +456,8 @@
                          (view-render-ev ::v [:s])])
           steps (proj/project rec)]
       (is (every? proj/valid-badge? (map :badge steps)))
-      (is (= 7 (count proj/badge-set))))))
+      (is (= 10 (count proj/badge-set))
+          "rf2-sc3r1 + rf2-17vxj + rf2-yx1ae + rf2-rrykz = 7 + 3 = 10 badges"))))
 
 ;; ---- formatting helpers --------------------------------------------------
 
@@ -517,3 +537,71 @@
     (is (= 2 (proj/long-step-count [{:duration-ms 18}
                                     {:duration-ms 1}
                                     {:duration-ms 50}])))))
+
+;; ---- rf2-17vxj — schema-violations step ---------------------------------
+
+(deftest schema-violations-step-conditional-test
+  (testing "rf2-17vxj — no violation events → step is OMITTED"
+    (is (nil? (proj/schema-violations-step []))))
+
+  (testing "rf2-17vxj — `:rf.error/schema-validation-failure` event
+            surfaces a row"
+    (let [s (proj/schema-violations-step
+              [(schema-violation-ev :app-db :counter/inc [:count]
+                                    "not-an-int" true)])]
+      (is (= :schema-violations (:step s)))
+      (is (= :SCHEMA-VIOLATIONS (:badge s)))
+      (is (= 1 (count (:rows s))))
+      (is (= 1 (:rollbacks s))
+          ":rollbacks counts rows where :rollback? is true")
+      (let [r (-> s :rows first)]
+        (is (= :app-db (:where r)))
+        (is (= :counter/inc (:failing-id r)))
+        (is (= [:count] (:path r)))
+        (is (= "not-an-int" (:value r)))
+        (is (true? (:rollback? r)))
+        (is (= :rf.error/schema-validation-failure (:kind r)))))))
+
+(deftest schema-violations-hot-reload-event-test
+  (testing "rf2-17vxj — `:rf.schema/violation` event (hot-reload drift)
+            also produces a row; `:where` defaults to `:hot-reload`"
+    (let [s (proj/schema-violations-step
+              [(schema-hot-reload-ev :rf/default [:count]
+                                     "not-an-int")])]
+      (is (= 1 (count (:rows s))))
+      (let [r (-> s :rows first)]
+        (is (= :hot-reload (:where r)))
+        (is (= :rf.schema/violation (:kind r)))
+        (is (= [:count] (:path r)))
+        (is (= "not-an-int" (:value r)))
+        (is (= :logged-and-skipped (:recovery r)))))))
+
+(deftest schema-violations-mixed-rows-test
+  (testing "rf2-17vxj — runtime + hot-reload events project into the
+            same row schema"
+    (let [s (proj/schema-violations-step
+              [(schema-violation-ev :sub-return :counter/total nil
+                                    {:bad :data})
+               (schema-hot-reload-ev :rf/default [:counter :n]
+                                     "boom")])]
+      (is (= 2 (count (:rows s)))
+          "both events project into rows")
+      (is (= 0 (:rollbacks s))
+          "no rollback-true rows in this fixture"))))
+
+(deftest project-includes-schema-violations-step-test
+  (testing "rf2-17vxj — top-level project emits SCHEMA-VIOLATIONS at
+            the END of the cascade when violations fired"
+    (let [rec   (record [(dispatched-ev [:counter/inc] :ui nil)
+                         (db-changed-ev [[[:count] 0 "boom" :modified]])
+                         (schema-violation-ev :app-db :counter/inc
+                                              [:count] "boom" true)])
+          steps (proj/project rec)]
+      (is (= :schema-violations (-> steps last :step))
+          "SCHEMA-VIOLATIONS rides at the end of the cascade")))
+
+  (testing "rf2-17vxj — no violations → step absent"
+    (let [rec   (record [(dispatched-ev [:counter/inc] :ui nil)
+                         (db-changed-ev [[[:count] 0 1 :modified]])])
+          steps (proj/project rec)]
+      (is (not-any? #(= :schema-violations (:step %)) steps)))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -378,6 +378,46 @@
       (is (= 2 (count (:rows s))))
       (is (= :ok (-> s :rows first :status))))))
 
+;; ---- rf2-uffov — FX section header split + per-action attribution -----
+
+(deftest fx-step-header-counter-split-test
+  (testing "rf2-uffov — FX step header carries split counts
+            (succeeded / threw / skipped)"
+    (let [s (proj/fx-step
+              [(fx-handled-ev :db nil 0.1)
+               (fx-handled-ev :http/post {} 1.0)
+               (ev :error :rf.error/fx-handler-exception
+                   {:rf.fx/id :bad-fx})])]
+      (is (= 2 (:succeeded s))
+          ":ok rows roll into :succeeded")
+      (is (= 1 (:threw s))
+          ":error rows roll into :threw"))))
+
+(deftest fx-step-attribution-from-machine-actions-test
+  (testing "rf2-uffov — when a machine action's outcome :fx emits a
+            fx-id, the corresponding FX row carries :attributed-to"
+    (let [evs [(ev :rf.machine :rf.machine/action-ran
+                   {:action-id :open-socket
+                    :phase     :entry
+                    :outcome   {:fx [[:http/get {:url "/x"}]]}
+                    :input     {:data {} :event nil}})
+               (fx-handled-ev :http/get {:url "/x"} 5.0)]
+          s   (proj/fx-step evs)
+          row (-> s :rows first)]
+      (is (= :http/get (:fx-id row)))
+      (is (some? (:attributed-to row))
+          "FX row carries :attributed-to for machine-emitted fx")
+      (is (= :open-socket (-> row :attributed-to :action-id)))
+      (is (= :entry       (-> row :attributed-to :phase))))))
+
+(deftest fx-step-no-attribution-for-non-machine-cascades-test
+  (testing "rf2-uffov — pure reg-event-fx cascades have no per-action
+            attribution; the slot stays absent"
+    (let [s (proj/fx-step [(fx-handled-ev :db nil 0.1)])
+          row (-> s :rows first)]
+      (is (not (contains? row :attributed-to))
+          "no machine actions → no :attributed-to slot"))))
+
 ;; ---- SUBSCRIPTIONS ------------------------------------------------------
 
 (deftest subscriptions-step-conditional-test

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -589,6 +589,91 @@
       (is (= 0 (:rollbacks s))
           "no rollback-true rows in this fixture"))))
 
+;; ---- rf2-yx1ae — child dispatches section -----------------------------
+
+(deftest child-dispatch-rows-from-dispatch-test
+  (testing "rf2-yx1ae — `:dispatch [:e/x]` projects one row"
+    (let [rows (proj/child-dispatch-rows
+                 [(do-fx-ev {:dispatch [:e/x 7]})])]
+      (is (= 1 (count rows)))
+      (is (= [:e/x 7]   (-> rows first :event)))
+      (is (= :dispatch  (-> rows first :via)))
+      (is (nil? (-> rows first :delay-ms))))))
+
+(deftest child-dispatch-rows-from-dispatch-n-test
+  (testing "rf2-yx1ae — `:dispatch-n [[:a] [:b]]` projects one row each"
+    (let [rows (proj/child-dispatch-rows
+                 [(do-fx-ev {:dispatch-n [[:a] [:b 1]]})])]
+      (is (= 2 (count rows)))
+      (is (= [:a]   (-> rows (nth 0) :event)))
+      (is (= [:b 1] (-> rows (nth 1) :event)))
+      (is (every? #(= :dispatch-n (:via %)) rows)))))
+
+(deftest child-dispatch-rows-from-dispatch-later-test
+  (testing "rf2-yx1ae — `:dispatch-later {:ms 250 :dispatch [:retry]}`
+            projects one row with `:delay-ms`"
+    (let [rows (proj/child-dispatch-rows
+                 [(do-fx-ev {:dispatch-later {:ms 250 :dispatch [:retry]}})])]
+      (is (= 1 (count rows)))
+      (is (= [:retry] (-> rows first :event)))
+      (is (= 250 (-> rows first :delay-ms)))
+      (is (= :dispatch-later (-> rows first :via)))))
+
+  (testing "rf2-yx1ae — `:dispatch-later` accepts a vec form too"
+    (let [rows (proj/child-dispatch-rows
+                 [(do-fx-ev {:dispatch-later
+                             [{:ms 100 :dispatch [:a]}
+                              {:ms 500 :dispatch [:b]}]})])]
+      (is (= 2 (count rows)))
+      (is (= 100 (-> rows (nth 0) :delay-ms)))
+      (is (= 500 (-> rows (nth 1) :delay-ms))))))
+
+(deftest child-dispatches-step-conditional-test
+  (testing "rf2-yx1ae — no dispatch fx → step OMITTED"
+    (is (nil? (proj/child-dispatches-step
+                [(do-fx-ev {:http/post {:url "/x"}})]))))
+
+  (testing "rf2-yx1ae — dispatch fx present → step rendered"
+    (let [s (proj/child-dispatches-step
+              [(do-fx-ev {:dispatch [:e/x]})])]
+      (is (= :child-dispatches (:step s)))
+      (is (= :CHILD-DISPATCHES (:badge s)))
+      (is (= 1 (count (:rows s)))))))
+
+(deftest find-child-epoch-by-parent-dispatch-id-test
+  (testing "rf2-yx1ae — find-child-epoch matches on `:parent-dispatch-id`"
+    (let [history [{:epoch-id 11 :parent-dispatch-id 1 :trigger-event [:other]}
+                   {:epoch-id 12 :parent-dispatch-id 1 :trigger-event [:e/x 7]}
+                   {:epoch-id 13 :parent-dispatch-id 2 :trigger-event [:e/x 7]}]]
+      (is (= 12 (proj/find-child-epoch history 1 [:e/x 7]))
+          "exact trigger-event + parent-id match wins")
+      (is (= 11 (proj/find-child-epoch history 1 [:other]))
+          "exact match on a different sibling")
+      (is (nil? (proj/find-child-epoch history 99 [:e/x 7]))
+          "no parent-id match → nil")
+      (is (nil? (proj/find-child-epoch nil 1 [:e/x 7]))
+          "nil history → nil")
+      (is (nil? (proj/find-child-epoch history nil [:e/x 7]))
+          "nil parent-id → nil"))))
+
+(deftest project-includes-child-dispatches-step-test
+  (testing "rf2-yx1ae — top-level project emits CHILD-DISPATCHES after FX
+            and before SUBSCRIPTIONS when dispatch fx fired"
+    (let [rec   (record [(dispatched-ev [:counter/inc] :ui nil)
+                         (do-fx-ev {:dispatch [:other/event 1]})
+                         (db-changed-ev [])])
+          steps (proj/project rec)
+          step-kws (mapv :step steps)]
+      (is (some #{:child-dispatches} step-kws)
+          "CHILD-DISPATCHES is present")
+      (is (< (.indexOf step-kws :handler)
+             (.indexOf step-kws :child-dispatches))
+          ":child-dispatches rides AFTER :handler")
+      (when (some #{:fx} step-kws)
+        (is (< (.indexOf step-kws :fx)
+               (.indexOf step-kws :child-dispatches))
+            ":child-dispatches rides AFTER :fx when :fx is also emitted")))))
+
 (deftest project-includes-schema-violations-step-test
   (testing "rf2-17vxj — top-level project emits SCHEMA-VIOLATIONS at
             the END of the cascade when violations fired"

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -477,3 +477,43 @@
     (is (= "on-resolution"    (proj/timer-reason-label :on-resolution)))
     (is (= "on-supersede"     (proj/timer-reason-label :on-supersede)))
     (is (= "on-frame-destroy" (proj/timer-reason-label :on-frame-destroy)))))
+
+;; ---- rf2-nqt3d — per-step elapsed time + cascade total ------------------
+
+(deftest long-step-threshold-test
+  (testing "rf2-nqt3d — 16ms = one display frame at 60Hz; the threshold
+            documents the long-step warning boundary"
+    (is (= 16 proj/long-step-threshold-ms))))
+
+(deftest long-step-predicate-test
+  (testing "rf2-nqt3d — `long-step?` is true iff duration > 16ms"
+    (is (false? (proj/long-step? {:duration-ms 0.1})))
+    (is (false? (proj/long-step? {:duration-ms 16})))
+    (is (true?  (proj/long-step? {:duration-ms 16.1})))
+    (is (true?  (proj/long-step? {:duration-ms 250})))
+    (is (false? (proj/long-step? {:duration-ms nil}))
+        "nil duration is NOT a long step (the chip elides instead)")
+    (is (false? (proj/long-step? {}))
+        "missing duration returns false")))
+
+(deftest cascade-total-ms-test
+  (testing "rf2-nqt3d — sum of every step's :duration-ms"
+    (is (= 12.5 (proj/cascade-total-ms [{:duration-ms 0.5}
+                                        {:duration-ms 12}])))
+    (is (nil? (proj/cascade-total-ms []))
+        "empty step vec returns nil so the view can elide the chip")
+    (is (nil? (proj/cascade-total-ms [{:step :dispatch} {:step :handler}]))
+        "no step carries a duration → nil")
+    (is (= 5 (proj/cascade-total-ms [{:step :dispatch}
+                                     {:duration-ms 5}
+                                     {:step :views}]))
+        "mixed presence: missing durations skipped, sum returned")))
+
+(deftest long-step-count-test
+  (testing "rf2-nqt3d — count of steps over the 16ms threshold"
+    (is (= 0 (proj/long-step-count [])))
+    (is (= 0 (proj/long-step-count [{:duration-ms 0.1}
+                                    {:duration-ms 10}])))
+    (is (= 2 (proj/long-step-count [{:duration-ms 18}
+                                    {:duration-ms 1}
+                                    {:duration-ms 50}])))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -335,6 +335,44 @@
         (is (string/includes? id ":counter/total"))
         (is (string/includes? path "[:total]"))))))
 
+;; ---- rf2-uffov — FX section header + per-action attribution ----------
+
+(deftest fx-step-header-shows-outcome-split-test
+  (testing "rf2-uffov — FX step header reads
+            `N fired (M succeeded, K threw)`"
+    (let [step {:step :fx :badge :FX :step-number 4
+                :rows [{:fx-id :db :status :ok}
+                       {:fx-id :http/get :status :ok}
+                       {:fx-id :bad :status :error}]
+                :succeeded 2 :threw 1 :skipped 0}
+          tree (view/render-fx-step step)
+          header (text-of tree "rf-xray-epoch-fx-header")]
+      (is (string/includes? header "3 fired"))
+      (is (string/includes? header "2 succeeded"))
+      (is (string/includes? header "1 threw")))))
+
+(deftest fx-row-shows-attribution-chip-test
+  (testing "rf2-uffov — when an FX row carries :attributed-to, the
+            attribution chip renders alongside"
+    (let [step {:step :fx :badge :FX :step-number 4
+                :rows [{:fx-id :http/get :status :ok
+                        :attributed-to {:action-id :open-socket
+                                        :phase :entry}}]
+                :succeeded 1 :threw 0 :skipped 0}
+          tree (view/render-fx-step step)
+          chip (th/find-by-testid tree "rf-xray-epoch-fx-row-attribution-0")]
+      (is (some? chip) "the attribution chip is present")
+      (is (string/includes? (th/text-content chip) ":open-socket")
+          "the action-id rides the chip"))))
+
+(deftest fx-row-omits-attribution-chip-when-none-test
+  (testing "rf2-uffov — FX row without :attributed-to omits the chip"
+    (let [step {:step :fx :badge :FX :step-number 4
+                :rows [{:fx-id :db :status :ok}]
+                :succeeded 1 :threw 0 :skipped 0}
+          tree (view/render-fx-step step)]
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-fx-row-attribution-0"))))))
+
 ;; ---- rf2-rrykz — app-db diff section ---------------------------------
 
 (deftest app-db-diff-step-renders-rows-test

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -233,6 +233,68 @@
       (is (string/includes? id "<anonymous view>")
           "missing view-id reads as `<anonymous view>` placeholder"))))
 
+;; ---- rf2-nqt3d — per-step elapsed time + cascade total ----------------
+
+(deftest cascade-summary-renders-total-test
+  (testing "rf2-nqt3d — cascade-summary chip carries the cascade total
+            formatted via `format-duration-ms`"
+    (let [tree (view/cascade-summary [{:step :dispatch :duration-ms 0.5}
+                                      {:step :handler  :duration-ms 12}])
+          chip (th/find-by-testid tree "rf-xray-epoch-cascade-summary")]
+      (is (some? chip) "the summary chip renders when any step carries a duration")
+      (is (string/includes? (th/text-content chip) "cascade total"))
+      (is (string/includes? (th/text-content chip) "13ms")
+          "total reads as the rounded sum of every step's :duration-ms"))))
+
+(deftest cascade-summary-elides-when-no-durations-test
+  (testing "rf2-nqt3d — projection without any duration returns nil so
+            the view never renders an empty `total: —` chip"
+    (let [tree (view/cascade-summary [{:step :dispatch}
+                                      {:step :handler}])]
+      (is (nil? tree)
+          "no durations → no summary chip (graceful-degrade)"))))
+
+(deftest cascade-summary-shows-long-step-count-test
+  (testing "rf2-nqt3d — when any step exceeds 16ms the summary surfaces
+            a warning-tone count chip"
+    (let [tree (view/cascade-summary [{:step :handler :duration-ms 12}
+                                      {:step :views   :duration-ms 25}
+                                      {:step :fx      :duration-ms 30}])
+          long-chip (th/find-by-testid tree "rf-xray-epoch-cascade-summary-long-count")]
+      (is (some? long-chip) "long-count chip present when any step is over 16ms")
+      (is (string/includes? (th/text-content long-chip) "2 over 16ms")
+          "count + threshold are visible in the chip text"))))
+
+(deftest cascade-summary-omits-long-count-when-zero-test
+  (testing "rf2-nqt3d — clean cascade (every step under threshold) → no
+            long-count chip in the summary"
+    (let [tree (view/cascade-summary [{:step :handler :duration-ms 0.5}
+                                      {:step :views   :duration-ms 1.2}])]
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-cascade-summary-long-count"))
+          "no long-count chip on a fast cascade"))))
+
+(deftest duration-chip-renders-long-step-warning-test
+  (testing "rf2-nqt3d — a step header's duration chip paints warning
+            chrome when over 16ms"
+    (let [tree (view/render-handler-step
+                 {:step :handler :badge :HANDLER :step-number 3
+                  :flavour :reg-event-db :event-id :rf.test.epoch.view/slow-handler
+                  :db-diff [] :fx [] :machine nil
+                  :duration-ms 42})]
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-duration-long"))
+          "the long-duration testid is stamped on slow steps")
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-duration"))
+          "the bare-duration testid is NOT stamped on long steps")))
+
+  (testing "rf2-nqt3d — a fast step keeps the bare-duration chip"
+    (let [tree (view/render-handler-step
+                 {:step :handler :badge :HANDLER :step-number 3
+                  :flavour :reg-event-db :event-id :rf.test.epoch.view/fast-handler
+                  :db-diff [] :fx [] :machine nil
+                  :duration-ms 0.1})]
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-duration"))
+          "fast step keeps the standard duration testid"))))
+
 (deftest handler-body-renders-captured-source-test
   (testing "rf2-66wis — when the registrar carries an
             `:rf.handler/source`, the body renders it via the

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -335,6 +335,63 @@
         (is (string/includes? id ":counter/total"))
         (is (string/includes? path "[:total]"))))))
 
+;; ---- rf2-yx1ae — child-dispatches section -----------------------------
+
+(deftest child-dispatches-step-renders-rows-test
+  (testing "rf2-yx1ae — CHILD-DISPATCHES step renders one row per child
+            with via-chip + event vector"
+    (let [step {:step :child-dispatches :badge :CHILD-DISPATCHES
+                :step-number 5
+                :rows [{:event [:other/x 1] :via :dispatch :delay-ms nil}
+                       {:event [:retry]     :via :dispatch-later :delay-ms 250}]}
+          ctx  {:dispatch-id   1
+                :epoch-history [{:epoch-id 99 :parent-dispatch-id 1
+                                 :trigger-event [:other/x 1]}]}
+          tree (view/render-child-dispatches-step step ctx)]
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-step-child-dispatches")))
+      (is (= 2 (count (th/find-by-testid-prefix
+                        tree "rf-xray-epoch-child-dispatch-row-"))))
+      (let [header (text-of tree "rf-xray-epoch-child-dispatches-header")]
+        (is (string/includes? header "2 events dispatched")))
+      (let [via0 (text-of tree "rf-xray-epoch-child-dispatch-via-0")
+            via1 (text-of tree "rf-xray-epoch-child-dispatch-via-1")
+            ev0  (text-of tree "rf-xray-epoch-child-dispatch-event-0")
+            ev1  (text-of tree "rf-xray-epoch-child-dispatch-event-1")]
+        (is (string/includes? via0 "dispatch"))
+        (is (string/includes? via1 "dispatch-later"))
+        (is (string/includes? ev0  ":other/x"))
+        (is (string/includes? ev1  ":retry")))
+      ;; delay chip on the dispatch-later row only
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-child-dispatch-delay-1")))
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-child-dispatch-delay-0"))))))
+
+(deftest child-dispatches-jump-resolves-when-in-buffer-test
+  (testing "rf2-yx1ae — child epoch in the buffer renders a jump button
+            with the child's :epoch-id"
+    (let [step {:step :child-dispatches :badge :CHILD-DISPATCHES
+                :step-number 5
+                :rows [{:event [:other/x 1] :via :dispatch}]}
+          ctx  {:dispatch-id   1
+                :epoch-history [{:epoch-id 99 :parent-dispatch-id 1
+                                 :trigger-event [:other/x 1]}]}
+          tree (view/render-child-dispatches-step step ctx)]
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-child-dispatch-jump-0"))
+          "jump button is present when child is resolvable")
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-child-dispatch-missing-0"))
+          "no `not in buffer` marker when child is resolved"))))
+
+(deftest child-dispatches-missing-when-not-in-buffer-test
+  (testing "rf2-yx1ae — child not in buffer (aged out / never landed)
+            renders the muted `not in buffer` marker"
+    (let [step {:step :child-dispatches :badge :CHILD-DISPATCHES
+                :step-number 5
+                :rows [{:event [:other/x 1] :via :dispatch}]}
+          ctx  {:dispatch-id   1
+                :epoch-history []}
+          tree (view/render-child-dispatches-step step ctx)]
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-child-dispatch-missing-0")))
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-child-dispatch-jump-0"))))))
+
 (deftest duration-chip-renders-long-step-warning-test
   (testing "rf2-nqt3d — a step header's duration chip paints warning
             chrome when over 16ms"

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -335,6 +335,39 @@
         (is (string/includes? id ":counter/total"))
         (is (string/includes? path "[:total]"))))))
 
+;; ---- rf2-rrykz — app-db diff section ---------------------------------
+
+(deftest app-db-diff-step-renders-rows-test
+  (testing "rf2-rrykz — APP-DB DIFF step renders one row per changed
+            path with the change kind reflected on the row data attr"
+    (let [step {:step :app-db-diff :badge :APP-DB-DIFF :step-number 4
+                :rows [{:path [:count] :before 0 :after 1 :change :modified}
+                       {:path [:new]   :before nil :after "v" :change :added}
+                       {:path [:gone]  :before 5 :after nil :change :removed}]
+                :added 1 :modified 1 :removed 1}
+          tree (view/render-app-db-diff-step step)]
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-step-app-db-diff")))
+      (is (= 3 (count (th/find-by-testid-prefix
+                        tree "rf-xray-epoch-app-db-diff-row-"))))
+      (let [header (text-of tree "rf-xray-epoch-app-db-diff-header")]
+        (is (string/includes? header "3 paths changed"))
+        (is (string/includes? header "+1 / ~1 / -1"))))))
+
+(deftest app-db-diff-row-shows-path-and-values-test
+  (testing "rf2-rrykz — :modified row shows before → after"
+    (let [step {:step :app-db-diff :badge :APP-DB-DIFF :step-number 4
+                :rows [{:path [:counter :value] :before 5 :after 6
+                        :change :modified}]
+                :added 0 :modified 1 :removed 0}
+          tree (view/render-app-db-diff-step step)
+          row  (th/find-by-testid tree "rf-xray-epoch-app-db-diff-row-0")]
+      (is (some? row))
+      (let [txt (th/text-content row)]
+        (is (string/includes? txt "[:counter :value]")
+            "path is visible")
+        (is (string/includes? txt "5"))
+        (is (string/includes? txt "6"))))))
+
 ;; ---- rf2-yx1ae — child-dispatches section -----------------------------
 
 (deftest child-dispatches-step-renders-rows-test

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -273,6 +273,68 @@
       (is (nil? (th/find-by-testid tree "rf-xray-epoch-cascade-summary-long-count"))
           "no long-count chip on a fast cascade"))))
 
+;; ---- rf2-17vxj — schema-violations section ----------------------------
+
+(deftest schema-violations-step-renders-rows-test
+  (testing "rf2-17vxj — SCHEMA VIOLATIONS step renders one row per
+            violation; rollback chip rides any rollback? row"
+    (let [step {:step :schema-violations :badge :SCHEMA-VIOLATIONS
+                :step-number 8
+                :rows [{:kind :rf.error/schema-validation-failure
+                        :where :app-db
+                        :failing-id :counter/inc
+                        :path [:count]
+                        :value "not-an-int"
+                        :rollback? true
+                        :sensitive? false}
+                       {:kind :rf.schema/violation
+                        :where :hot-reload
+                        :frame :rf/default
+                        :failing-id :rf/default
+                        :path [:count]
+                        :value "boom"
+                        :recovery :logged-and-skipped
+                        :rollback? false
+                        :sensitive? false}]
+                :rollbacks 1}
+          tree (view/render-schema-violations-step step)]
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-step-schema-violations"))
+          "the step wrapper renders")
+      (is (= 2 (count (th/find-by-testid-prefix
+                        tree "rf-xray-epoch-schema-violation-row-"))))
+      (is (some? (th/find-by-testid
+                   tree "rf-xray-epoch-schema-violation-rollback-0"))
+          "the rollback chip rides the rollback? row")
+      (is (nil? (th/find-by-testid
+                  tree "rf-xray-epoch-schema-violation-rollback-1"))
+          "no rollback chip on a clean recovery row")
+      (let [header (text-of tree "rf-xray-epoch-schema-violations-header")]
+        (is (string/includes? header "2 violation"))
+        (is (string/includes? header "1 rollback")))
+      (is (some? (th/find-by-testid
+                   tree "rf-xray-epoch-schema-violations-open-issues"))
+          "the open-issues affordance is present"))))
+
+(deftest schema-violations-row-shows-fields-test
+  (testing "rf2-17vxj — per-row body shows where + failing-id + path + value"
+    (let [step {:step :schema-violations :badge :SCHEMA-VIOLATIONS
+                :step-number 8
+                :rows [{:kind :rf.error/schema-validation-failure
+                        :where :sub-return
+                        :failing-id :counter/total
+                        :path [:total]
+                        :value {:bad :data}
+                        :rollback? false
+                        :sensitive? false}]
+                :rollbacks 0}
+          tree (view/render-schema-violations-step step)]
+      (let [where (text-of tree "rf-xray-epoch-schema-violation-where-0")
+            id    (text-of tree "rf-xray-epoch-schema-violation-id-0")
+            path  (text-of tree "rf-xray-epoch-schema-violation-path-0")]
+        (is (string/includes? where "sub return"))
+        (is (string/includes? id ":counter/total"))
+        (is (string/includes? path "[:total]"))))))
+
 (deftest duration-chip-renders-long-step-warning-test
   (testing "rf2-nqt3d — a step header's duration chip paints warning
             chrome when over 16ms"

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -392,6 +392,80 @@
       (is (some? (th/find-by-testid tree "rf-xray-epoch-child-dispatch-missing-0")))
       (is (nil? (th/find-by-testid tree "rf-xray-epoch-child-dispatch-jump-0"))))))
 
+;; ---- rf2-9c27r — machine handler section -------------------------------
+
+(deftest machine-handler-renders-data-reduction-test
+  (testing "rf2-9c27r — DATA REDUCTION sub-section renders `:data`
+            before / after when they differ"
+    (let [step {:step :handler :badge :HANDLER :step-number 3
+                :flavour :reg-machine :event-id :ws/start
+                :db-diff [] :fx []
+                :machine {:transition {:machine-id :ws/conn
+                                       :before {:state [:idle]      :data {:count 0}}
+                                       :after  {:state [:connected] :data {:count 1}}
+                                       :data-before {:count 0}
+                                       :data-after  {:count 1}
+                                       :microsteps 0}
+                          :guards []
+                          :lifecycle []
+                          :timers []}}
+          tree (view/render-handler-step step)]
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-handler-machine-data-reduction"))
+          "DATA REDUCTION block renders when data changed")
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-handler-machine-data-before")))
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-handler-machine-data-after"))))))
+
+(deftest machine-handler-renders-snapshot-diff-test
+  (testing "rf2-9c27r — SNAPSHOT DIFF sub-section renders the full
+            machine snapshot before / after"
+    (let [step {:step :handler :badge :HANDLER :step-number 3
+                :flavour :reg-machine :event-id :ws/start
+                :db-diff [] :fx []
+                :machine {:transition {:machine-id :ws/conn
+                                       :before {:state [:idle]}
+                                       :after  {:state [:connected]}
+                                       :microsteps 1}
+                          :guards [] :lifecycle [] :timers []}}
+          tree (view/render-handler-step step)]
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-handler-machine-snapshot-diff")))
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-handler-machine-microsteps"))
+          "microsteps slot is surfaced under the transition summary"))))
+
+(deftest machine-handler-omits-data-reduction-when-unchanged-test
+  (testing "rf2-9c27r — DATA REDUCTION elides when before == after"
+    (let [step {:step :handler :badge :HANDLER :step-number 3
+                :flavour :reg-machine :event-id :ws/start
+                :db-diff [] :fx []
+                :machine {:transition {:machine-id :ws/conn
+                                       :before {:state [:idle] :data {:n 1}}
+                                       :after  {:state [:connected] :data {:n 1}}
+                                       :data-before {:n 1}
+                                       :data-after  {:n 1}
+                                       :microsteps 0}
+                          :guards [] :lifecycle [] :timers []}}
+          tree (view/render-handler-step step)]
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-handler-machine-data-reduction"))
+          "no DATA REDUCTION block when both sides are identical"))))
+
+(deftest machine-handler-per-action-fx-attribution-test
+  (testing "rf2-9c27r — per-action fx attribution renders under the
+            lifecycle row when the action returned :fx"
+    (let [step {:step :handler :badge :HANDLER :step-number 3
+                :flavour :reg-machine :event-id :ws/start
+                :db-diff [] :fx []
+                :machine {:transition nil
+                          :guards []
+                          :lifecycle [{:action-id :open-socket
+                                       :phase :entry
+                                       :outcome {:fx [[:http/get {:url "/x"}]]}
+                                       :fx [[:http/get {:url "/x"}]]}]
+                          :timers []}}
+          tree (view/render-handler-step step)]
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-handler-phase-entry-row-0"))
+          "the lifecycle row renders")
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-handler-phase-entry-fx-0"))
+          "per-action fx attribution shows under the row"))))
+
 (deftest duration-chip-renders-long-step-warning-test
   (testing "rf2-nqt3d — a step header's duration chip paints warning
             chrome when over 16ms"


### PR DESCRIPTION
6-bead cluster extending the Epoch panel (`tools/xray/src/day8/re_frame2_xray/panels/epoch/`) with new sections + section enhancements. Built on top of Cluster A (PR #2191), reads against the §9.1.10.1 substrate-tag-dependency inventory throughout.

## Per-bead summary (commit → bead → contract)

| Commit | Bead | Contract |
|--------|------|----------|
| `58e3d27` | rf2-nqt3d | per-step elapsed time + cascade total + 16ms long-step warning chrome |
| `4aedd09` | rf2-17vxj | SCHEMA VIOLATIONS section — `:rf.error/schema-validation-failure` + `:rf.schema/violation`, warning chrome, `open issues →` affordance |
| `8745ee0` | rf2-yx1ae | CHILD-DISPATCHES section — projects `:dispatch / :dispatch-n / :dispatch-later` fx into rows, resolves child epoch via `:parent-dispatch-id` lookup, `jump →` button |
| `1e3c4ae` | rf2-9c27r | machine handler section — full 7-sub-section design (DATA REDUCTION + SNAPSHOT DIFF added; per-action fx attribution folded into LIFECYCLE; `:event` + `:microsteps` on TRANSITION) |
| `47d03363` | rf2-rrykz | APP-DB DIFF section — dedicated step right after HANDLER; state-mutation lens parallel to HANDLER body's attribution lens |
| `cb2782b` | rf2-uffov | FX section — header `N fired (M succeeded, K threw)` split + per-action `← <action-id>` attribution chip on rows emitted by machine actions |

## Cross-bead unifications

- Badge taxonomy grows 7 → 10 (added `:SCHEMA-VIOLATIONS`, `:CHILD-DISPATCHES`, `:APP-DB-DIFF`). New badges land in one `badge.cljc` edit; the projection's `badge-set` enforces every emit is in the inventory.
- Per-action fx attribution lands once in projection (`fx-rows` builds a first-attribution-wins map from `:rf.machine/action-ran` outcomes) and feeds BOTH the LIFECYCLE block in HANDLER (rf2-9c27r) and the FX section's per-row chip (rf2-uffov). One source of truth.
- The composite sub `:rf.xray/epoch-pipeline` now also exposes `:dispatch-id` + `:epoch-history` so the CHILD-DISPATCHES rows resolve children without a secondary sub in the hot path.
- `pipeline-view` threads a per-cascade `ctx` map down through `render-step` so individual step renderers can read cascade-level state without back-references to the spine.

## Test deltas

- CLJS: 4700 → 4740 tests (+40 net after rebase; +42 added across the 6 beads, ~2 absorbed by upstream movement). All green.
- Browser: 124 tests, 0 failures.
- Bundle-isolation: counter + uix + helix bundles all pass; the new dev-only code is in `tools/xray/` and does not leak into production.

## Spec updates (021-Dynamic-Panel-Designs.md)

- §9.1.4 — badge taxonomy table expanded to the 10-badge inventory.
- §9.1.5 — promoted from rf2-82a0u prereq description to full 7-sub-section machine-handler design (rf2-9c27r).
- §9.1.10.2 — per-step elapsed time + cascade total + 16ms threshold rationale (rf2-nqt3d).
- §9.1.10.3 — schema-violations section (rf2-17vxj).
- §9.1.10.4 — cascading-dispatches section (rf2-yx1ae).
- §9.1.10.5 — app-db diff section + two-surface coexistence rationale (rf2-rrykz).
- §9.1.10.6 — FX section enhancements (rf2-uffov).

## Surprises / notes

- The 16ms long-step threshold is documented inline at `proj/long-step-threshold-ms`; the spec body justifies it as one-60Hz-frame so future bumps land in one place.
- For per-action fx attribution, when the same fx-id is emitted by multiple machine actions in the same cascade, the FIRST (cascade-order) attribution wins. Documented in `fx-rows` and §9.1.10.6.
- CHILD-DISPATCHES jump-to: when the child cascade has aged out of the buffer (or hasn't completed yet), the row falls back to a muted `not in buffer` marker. The acceptance criterion 4 ("Header count: `N events dispatched`") is met by the header verb literal.