### PR TITLE
feat(xray): panel-gallery gallery_edn_inspector + fixtures (rf2-hp4ow)

### DIFF
--- a/tools/xray/testbeds/panel_gallery/core.cljs
+++ b/tools/xray/testbeds/panel_gallery/core.cljs
@@ -72,7 +72,13 @@
             ;; Chrome follow-on galleries — rf2-mpn8m settings popup,
             ;; rf2-kbrkx auto-filter pill / edit-popup.
             [panel-gallery.gallery-settings]
-            [panel-gallery.gallery-filters]))
+            [panel-gallery.gallery-filters]
+            ;; Widget galleries — rf2-hp4ow edn-inspector isolation
+            ;; coverage. The widget is exercised indirectly by every
+            ;; L4 panel that mounts it; this gallery gives it a
+            ;; dedicated harness with one variant per input shape /
+            ;; opts combination.
+            [panel-gallery.gallery-edn-inspector]))
 
 ;; ============================================================================
 ;; LANDING — the URL `/` view (no `#/stories` hash)

--- a/tools/xray/testbeds/panel_gallery/fixtures_edn_inspector.cljs
+++ b/tools/xray/testbeds/panel_gallery/fixtures_edn_inspector.cljs
@@ -1,0 +1,341 @@
+(ns panel-gallery.fixtures-edn-inspector
+  "Pure fixture builders for the edn-inspector widget gallery
+  (rf2-hp4ow — widget-isolation coverage).
+
+  The edn-inspector widget (`day8.re-frame2-xray.views.edn-inspector`)
+  is exercised indirectly by every L4 panel that mounts it — App-DB,
+  Reactive, Trace, Machines, Issues, Routing all route their CLJS
+  value rendering through it. The dedicated gallery here gives the
+  widget its own isolated surface: one variant per value shape /
+  opts combination, side-by-side, so an operator can scan the
+  renderer's response without the surrounding panel chrome.
+
+  ## Fixture shape
+
+  Each builder returns a map:
+
+      {:value   <cljs-value>          ;; the value the widget renders
+       :opts    {<opts-key> <val>}    ;; optional; passed verbatim
+       :before  <cljs-value>}         ;; optional; switches to diff mode
+
+  The variant fires a single testbed-only seed event
+  (`:panel-gallery.edn-inspector/seed!`) into the variant frame
+  carrying the fixture map; the gallery's `:panel-gallery.edn-
+  inspector/Panel` view subscribes to that slot and renders
+  `[edn-inspector value (assoc opts :before before)]` (diff mode
+  engages automatically when `:before` is present).
+
+  ## Coverage axes
+
+  - **Scalars** — every leaf type the widget classifies via
+    `collection-kind` (string, number, keyword, symbol, nil,
+    boolean) so the syntax-highlight palette is visible at a
+    glance.
+  - **Maps** — small / medium / large / nested + the size-elision
+    sentinel.
+  - **Vectors / lists / seqs / sets** — each container kind exercises
+    its own bracket pair + colour token.
+  - **Records** — the `#user.Rec{...}` header path.
+  - **UUID + inst** — the default `IXrayEdnInspector` formatters
+    (`edn-inspector-default-formatters`) render compact headers +
+    full bodies.
+  - **Diff mode** — before/after pairs that surface `:added`,
+    `:modified`, `:removed`, and `:same` rows via the rf2-zuh1e
+    `children-of-pair` walk.
+  - **Opts demos** — one variant per individual opt
+    (`:zoomable?`, `:popup-affordance?`, `:card?` + `:header`,
+    `:site-id`, `:default-expanded-depth`, large-sentinel
+    routing) so the visual effect of each switch is isolated.")
+
+;; =========================================================================
+;; record type — used by the record fixture below
+;; =========================================================================
+;;
+;; Declared at ns-load so the record renders consistently across reloads;
+;; `defrecord` is idempotent at the same shape so shadow-cljs hot-reload
+;; survives.
+
+(defrecord GalleryUser [id name email])
+
+;; =========================================================================
+;; scalar fixtures
+;; =========================================================================
+
+(defn scalar-mix
+  "Vector of every scalar kind the widget classifies. Rendered as a
+  top-level container so each leaf renders side-by-side and the
+  per-type colour token is visible at a glance."
+  []
+  {:value [;; nil — `:syntax-nil` token
+           nil
+           ;; boolean — `:syntax-boolean` token
+           true
+           false
+           ;; integer + float — `:syntax-number` token
+           42
+           -7
+           3.14159
+           ;; string — `:syntax-string` token
+           "hello"
+           "with \"escaped\" quotes"
+           ;; keyword — `:syntax-keyword` token
+           :simple
+           :ns/qualified
+           ;; symbol — `:syntax-symbol` token
+           'plain-sym
+           'my.ns/qualified-sym]
+   :opts  {:default-expanded-depth 4}})
+
+;; =========================================================================
+;; map fixtures — small / medium / large / nested
+;; =========================================================================
+
+(defn map-small
+  "Three-key map. Inline-preview territory — the widget's width-aware
+  heuristic should keep it on one line under default measurements."
+  []
+  {:value {:counter 5
+           :name    "Ada"
+           :active? true}})
+
+(defn map-medium
+  "Twelve-key flat map. Wide enough to force expansion past the
+  default `:max-inline-width`, narrow enough to fit comfortably
+  on one screen."
+  []
+  {:value (into {} (for [i (range 12)]
+                     [(keyword (str "k-" i)) (* i 10)]))})
+
+(defn map-large
+  "Fifty-key flat map. Exercises the expanded-body scroll behaviour."
+  []
+  {:value (into {} (for [i (range 50)]
+                     [(keyword (str "metric-" i)) (str "value-" i)]))})
+
+(defn map-nested
+  "Six-level nested map. Exercises the depth ceiling — at depth ≥ 8
+  the widget renders `▸ {…N keys}` summaries; ancestors up to that
+  depth open by default under the rf2-kbdk8 width-aware heuristic."
+  []
+  {:value {:tenant {:acme {:department {:engineering {:team {:platform
+                                                              {:project :xray
+                                                               :status :active
+                                                               :leads ["Ada" "Grace"]}}}}}}}})
+
+(defn map-large-elided
+  "Single-key map whose only entry is the `:rf.size/large-elided`
+  sentinel (per Spec 015). The widget routes this through the
+  sentinel chip renderer rather than the regular map path."
+  []
+  {:value {:rf.size/large-elided {:source        :app-db
+                                  :path          [:report/cache :report-42]
+                                  :original-size 12480293
+                                  :bytes         12480293
+                                  :handle        :report/payload-42
+                                  :reason        :over-budget}}})
+
+;; =========================================================================
+;; container fixtures — vector / list / seq / set
+;; =========================================================================
+
+(defn vector-mixed
+  "Vector whose elements span every scalar kind plus a nested map."
+  []
+  {:value [:apple "pear" 42 nil true {:id 7 :name "Ada"}]})
+
+(defn list-of-events
+  "List of event vectors — the canonical shape Xray's Event tab
+  feeds the widget."
+  []
+  {:value (list [:counter/inc]
+                [:user/sign-in {:email "ada@example.com"}]
+                [:cart/add-item :apple 2]
+                [:rf/route-change {:path "/cart"}])})
+
+(defn lazy-seq-fib
+  "Realised prefix of an infinite fibonacci seq. The widget never
+  forces a lazy tail — `count` on a lazy-seq is realised lazily
+  too, but the fixture takes the first 12 elements so the renderer
+  walks a finite seq."
+  []
+  {:value (let [fib (fn fib [a b] (lazy-seq (cons a (fib b (+ a b)))))]
+            (take 12 (fib 0 1)))})
+
+(defn set-of-tags
+  "Set of keyword tags — exercises the `#{...}` bracket pair +
+  unordered-iteration path."
+  []
+  {:value #{:dev :prod :staging :beta :alpha :internal :public :legacy}})
+
+;; =========================================================================
+;; record fixture
+;; =========================================================================
+
+(defn record-instance
+  "Single `GalleryUser` record. The widget renders the header
+  `#panel-gallery.fixtures-edn-inspector.GalleryUser{...}` and lays
+  the slots out below."
+  []
+  {:value (->GalleryUser 7 "Ada Lovelace" "ada@example.com")})
+
+;; =========================================================================
+;; uuid + inst fixtures — default IXrayEdnInspector formatters
+;; =========================================================================
+
+(defn uuid-instance
+  "Single random UUID. The default formatter renders a compact
+  `#uuid \"…<last-8>\"` header (rf2-x16b1)."
+  []
+  {:value (random-uuid)})
+
+(defn inst-instances
+  "Mixed insts spanning the formatter's relative-time bucketing —
+  recent, hours-ago, days-ago, ISO-fallback. The default formatter
+  picks the bucket based on `(.getTime (js/Date.))` at render
+  time (rf2-x16b1)."
+  []
+  {:value (let [now      (.getTime (js/Date.))
+                ms-per-h (* 60 60 1000)
+                ms-per-d (* 24 ms-per-h)]
+            {:recent (js/Date. (- now 3000))                  ;; ~ just now / 3s ago
+             :mins   (js/Date. (- now (* 5 60 1000)))         ;; 5m ago
+             :hours  (js/Date. (- now (* 3 ms-per-h)))        ;; 3h ago
+             :days   (js/Date. (- now (* 5 ms-per-d)))        ;; 5d ago
+             :iso    (js/Date. (- now (* 200 ms-per-d)))      ;; ISO fallback
+             :future (js/Date. (+ now (* 2 60 1000)))})})     ;; in 2m
+
+;; =========================================================================
+;; diff fixtures — :before + :after pairs
+;; =========================================================================
+;;
+;; Each diff fixture surfaces a different `children-of-pair` op
+;; (rf2-zuh1e): added, modified, removed, same. Diff mode renders
+;; gutter glyphs (`+`/`-`/`~`/`◴`) + `← changed from <prior>`
+;; annotations on modified leaves.
+
+(defn diff-map-mixed-ops
+  "Diff pair surfacing every op-tag in a single map: `:added` (new
+  `:flash`), `:modified` (scalar bump + nested name change),
+  `:removed` (`:legacy-flag` dropped), `:same` (untouched user/id)."
+  []
+  {:before {:counter     5
+            :user        {:id 7 :name "Ada"}
+            :legacy-flag true}
+   :value  {:counter 6
+            :user    {:id 7 :name "Ada Lovelace"}
+            :flash   {:level :ok :text "Order placed"}}})
+
+(defn diff-vector-element-changes
+  "Diff pair on a vector — `:added` (new tail item), `:modified`
+  (middle item's `:qty` bumped), `:same` (head item unchanged).
+  Vector diffs walk pair-wise so position matters."
+  []
+  {:before [{:id :apple :qty 1}
+            {:id :pear  :qty 1}]
+   :value  [{:id :apple :qty 1}
+            {:id :pear  :qty 3}
+            {:id :grape :qty 2}]})
+
+(defn diff-deep-children-changed
+  "Diff pair where the change sits six levels deep. Ancestor chain
+  force-expands over a changed descendant; the `◴` (children-changed)
+  glyph paints the gutter for every intermediate map."
+  []
+  (let [path  [:tenant :acme :department :eng :team :platform :project :xray :status]
+        deep  (fn [v] (assoc-in {} path v))]
+    {:before (deep :idle)
+     :value  (deep :active)}))
+
+;; =========================================================================
+;; opts-demo fixtures
+;; =========================================================================
+;;
+;; One fixture per opt the widget exposes. Each pins a single visual
+;; difference — switching ONE opt and renders the same underlying
+;; value so the eye can isolate the change.
+
+(defn opts-base-value
+  "The shared base value reused across opts-demo variants. Wide
+  enough to surface every opt's visual effect (the popup affordance
+  sits over content; the card chrome wraps it; the header ribbon
+  labels it; zoom needs a non-trivial subtree to zoom into)."
+  []
+  {:cart    {:items    [{:id :apple :qty 1}
+                        {:id :pear  :qty 2}
+                        {:id :grape :qty 3}]
+             :discount "SAVE10"
+             :totals   {:subtotal 23.50
+                        :tax      2.35
+                        :total    25.85}}
+   :user    {:id 7 :name "Ada Lovelace" :email "ada@example.com"}
+   :session {:expires-at 1735689600000
+             :renewed?   true}})
+
+(defn opts-zoomable
+  "`:zoomable? true` — each container gains a `⊙` zoom-affordance
+  button next to the expand triangle (rf2-h71e0)."
+  []
+  {:value (opts-base-value)
+   :opts  {:zoomable? true}})
+
+(defn opts-popup-affordance
+  "`:popup-affordance? true` — a `↗` icon button sits at the
+  widget's top-right corner (rf2-l4625)."
+  []
+  {:value (opts-base-value)
+   :opts  {:popup-affordance? true}})
+
+(defn opts-card
+  "`:card? true` — the outer container picks up the inspector-card
+  chrome (rf2-63ie5): `:bg-1` background, `1px` border, `8px`
+  radius."
+  []
+  {:value (opts-base-value)
+   :opts  {:card? true}})
+
+(defn opts-header
+  "`:header \"Shopping cart snapshot\"` — opt-in three-shade card
+  chrome with a labelled ribbon (rf2-okq7p)."
+  []
+  {:value (opts-base-value)
+   :opts  {:header "Shopping cart snapshot"}})
+
+(defn opts-header-hiccup
+  "`:header` as composed hiccup — the widget treats the value as
+  opaque hiccup so consumers can mix label + chip + affordance
+  (rf2-okq7p)."
+  []
+  {:value (opts-base-value)
+   :opts  {:header [:span
+                    [:strong {:style {:font-size "13px"}} "Shopping cart"]
+                    [:code {:style {:margin-left "8px"
+                                    :padding "1px 6px"
+                                    :background "rgba(127,127,127,0.18)"
+                                    :border-radius "3px"
+                                    :font-size "11px"}}
+                     ":rf/cart"]]}})
+
+(defn opts-site-id
+  "`:site-id :gallery.demo` — stable site-id survives a remount
+  (rf2-pvsxs)."
+  []
+  {:value (opts-base-value)
+   :opts  {:site-id :panel-gallery.edn-inspector/site-demo}})
+
+(defn opts-shallow-depth
+  "`:default-expanded-depth 1` — legacy depth-driven behaviour
+  (rf2-kbdk8). The widget collapses everything past depth 1, so
+  deeper nodes render as `▸ {…N keys}` summaries."
+  []
+  {:value (opts-base-value)
+   :opts  {:default-expanded-depth 1}})
+
+(defn opts-combined
+  "Composed opts (`:header` + `:popup-affordance?` + `:zoomable?`)
+  — all three affordances coexist (header ribbon up top, popup
+  arrow at top-right, zoom triangle on every container)."
+  []
+  {:value (opts-base-value)
+   :opts  {:header            "All affordances at once"
+           :popup-affordance? true
+           :zoomable?         true}})

--- a/tools/xray/testbeds/panel_gallery/gallery_edn_inspector.cljs
+++ b/tools/xray/testbeds/panel_gallery/gallery_edn_inspector.cljs
@@ -1,0 +1,299 @@
+(ns panel-gallery.gallery-edn-inspector
+  "Story coverage for the **edn-inspector widget**
+  (rf2-hp4ow — widget-isolation gallery).
+
+  The edn-inspector widget (`day8.re-frame2-xray.views.edn-inspector`)
+  is the single renderer behind every Xray surface that shows a CLJS
+  value: App-DB, Trace per-event payload, Reactive sub value,
+  Machines snapshot drill-in, Routing diff. Every L4 panel gallery
+  therefore exercises it indirectly. This gallery exercises it
+  *directly* — one variant per input shape / opts combination,
+  with no surrounding panel chrome — so the widget's response to
+  scalars, containers, sentinels, records, uuid/inst, diff mode,
+  and the full opts surface (`:zoomable?`, `:popup-affordance?`,
+  `:card?`, `:header`, `:site-id`, `:default-expanded-depth`) is
+  visible in isolation.
+
+  ## Frame isolation
+
+  Story wraps every variant in `[frame-provider {:frame variant-id}]`.
+  Each variant fires a testbed-only `:panel-gallery.edn-inspector/seed!`
+  event that stores its fixture under `:panel-gallery.edn-inspector
+  /fixture` in the variant frame's app-db. The registered view
+  (`:panel-gallery.edn-inspector/Panel`, mounted via `panel-views`)
+  subscribes to that slot, destructures `{:value :before :opts}`,
+  and renders `[edn-inspector value (assoc opts :before before)]`.
+
+  Each variant therefore observes its own fixture in isolation — no
+  two variants share state, and the widget's own expansion / zoom
+  slots (`:rf.xray.edn-inspector/expansion`, `…/zoom`) likewise live
+  on the variant frame so two side-by-side cards don't share
+  expansion overrides.
+
+  ## Why testbed-local seed event
+
+  The widget itself ships no public seed event for `:value` — its
+  inputs come from the call site as Reagent args. The gallery would
+  otherwise have to pass `:args` through Story's `args` resolver,
+  which works but conflicts with the dominant convention in this
+  testbed (`:rf.xray/sync-trace-buffer`,
+  `:rf.xray/sync-epoch-history` — all L4 gallery namespaces seed
+  via events). A small testbed-local reducer (registered here,
+  idempotent under namespace reload) keeps the surface uniform
+  across all eight gallery namespaces."
+  (:require [re-frame.core :as rf]
+            [re-frame.story :as story]
+            [panel-gallery.fixtures-edn-inspector :as fixtures]
+            [panel-gallery.panel-views :as panel-views]))
+
+;; =========================================================================
+;; testbed-local seed event + sub
+;; =========================================================================
+;;
+;; Stored on the variant frame's app-db; the registered view subscribes
+;; from inside the variant's frame-provider so reads + writes resolve to
+;; the same frame.
+
+(def fixture-slot
+  ":panel-gallery.edn-inspector/fixture — variant-frame slot carrying
+  the active fixture map `{:value :before :opts}`. Public so the
+  gallery view and the sub can share the keyword without typo drift."
+  :panel-gallery.edn-inspector/fixture)
+
+(rf/reg-event-db :panel-gallery.edn-inspector/seed!
+  (fn [db [_ fixture]]
+    (assoc db fixture-slot fixture)))
+
+(rf/reg-sub fixture-slot
+  (fn [db _] (get db fixture-slot)))
+
+(defn register-gallery-view! []
+  (panel-views/register!))
+
+(defn register-all!
+  "Register the edn-inspector widget Story surface. Idempotent
+  under `install-canonical-vocabulary!` resets so the namespace is
+  reloadable."
+  []
+  (story/install-canonical-vocabulary!)
+  (register-gallery-view!)
+
+  (story/reg-tag :feature/xray-edn-inspector
+    {:axis :feature
+     :doc  "Xray edn-inspector widget — first-class CLJS-value
+            renderer (`day8.re-frame2-xray.views.edn-inspector`)."})
+
+  (story/reg-story :story.xray.edn-inspector
+    {:doc        "Visual gallery of the edn-inspector widget under
+                 varying input shapes + opts combinations. One
+                 variant per shape / opts pin; side-by-side in the
+                 workspace so the renderer's response is visible at
+                 a glance."
+     :component  :panel-gallery.edn-inspector/Panel
+     :tags       #{:dev :feature/xray-edn-inspector}
+     :substrates #{:reagent}})
+
+  ;; ----- scalars ------------------------------------------------------
+  (story/reg-variant :story.xray.edn-inspector/scalar-mix
+    {:doc        "Every scalar kind the widget classifies — nil,
+                 booleans, ints, floats, strings (with escape),
+                 simple + qualified keywords, plain + qualified
+                 symbols. Pins the syntax-highlight palette."
+     :events     [[:panel-gallery.edn-inspector/seed! (fixtures/scalar-mix)]]
+     :tags       #{:dev :state/small}
+     :substrates #{:reagent}})
+
+  ;; ----- maps ---------------------------------------------------------
+  (story/reg-variant :story.xray.edn-inspector/map-small
+    {:doc        "Three-key map. Inline-preview territory."
+     :events     [[:panel-gallery.edn-inspector/seed! (fixtures/map-small)]]
+     :tags       #{:dev :state/small}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.edn-inspector/map-medium
+    {:doc        "Twelve-key flat map. Wide enough to force
+                 expansion past `:max-inline-width`."
+     :events     [[:panel-gallery.edn-inspector/seed! (fixtures/map-medium)]]
+     :tags       #{:dev :state/medium}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.edn-inspector/map-large
+    {:doc        "Fifty-key flat map. Exercises the expanded-body
+                 scroll behaviour."
+     :events     [[:panel-gallery.edn-inspector/seed! (fixtures/map-large)]]
+     :tags       #{:dev :state/large}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.edn-inspector/map-nested
+    {:doc        "Six-level nested map. Exercises the depth ceiling
+                 — deeper nodes render `▸ {…N keys}` summaries
+                 (rf2-kbdk8)."
+     :events     [[:panel-gallery.edn-inspector/seed! (fixtures/map-nested)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.edn-inspector/map-large-elided
+    {:doc        "Single-key map carrying the `:rf.size/large-elided`
+                 sentinel (Spec 015). Widget routes through the
+                 sentinel chip renderer."
+     :events     [[:panel-gallery.edn-inspector/seed! (fixtures/map-large-elided)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- containers ---------------------------------------------------
+  (story/reg-variant :story.xray.edn-inspector/vector-mixed
+    {:doc        "Vector of mixed-scalar elements + a nested map.
+                 Pins the `[ ]` bracket pair colour."
+     :events     [[:panel-gallery.edn-inspector/seed! (fixtures/vector-mixed)]]
+     :tags       #{:dev :state/small}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.edn-inspector/list-of-events
+    {:doc        "List of event vectors. Pins the `( )` bracket
+                 pair colour."
+     :events     [[:panel-gallery.edn-inspector/seed! (fixtures/list-of-events)]]
+     :tags       #{:dev :state/small}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.edn-inspector/lazy-seq-fib
+    {:doc        "Realised prefix of an infinite fib lazy-seq.
+                 Widget walks a finite seq — no force-of-tail."
+     :events     [[:panel-gallery.edn-inspector/seed! (fixtures/lazy-seq-fib)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.edn-inspector/set-of-tags
+    {:doc        "Eight-element keyword set. Pins the `#{ }`
+                 bracket pair + unordered-iteration path."
+     :events     [[:panel-gallery.edn-inspector/seed! (fixtures/set-of-tags)]]
+     :tags       #{:dev :state/small}
+     :substrates #{:reagent}})
+
+  ;; ----- record -------------------------------------------------------
+  (story/reg-variant :story.xray.edn-inspector/record-instance
+    {:doc        "Single `GalleryUser` defrecord. Header renders
+                 `#…GalleryUser{…}`; slots lay out below."
+     :events     [[:panel-gallery.edn-inspector/seed! (fixtures/record-instance)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- uuid + inst (default IXrayEdnInspector formatters) -----------
+  (story/reg-variant :story.xray.edn-inspector/uuid
+    {:doc        "Single random UUID. Default formatter (rf2-x16b1)
+                 renders compact `#uuid \"…<last-8>\"` header with
+                 full canonical form on hover + expand."
+     :events     [[:panel-gallery.edn-inspector/seed! (fixtures/uuid-instance)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.edn-inspector/insts
+    {:doc        "Five insts spanning the default formatter's
+                 relative-time bucketing — just-now, mins ago,
+                 hours ago, days ago, ISO fallback (>30d), future."
+     :events     [[:panel-gallery.edn-inspector/seed! (fixtures/inst-instances)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- diff mode ----------------------------------------------------
+  (story/reg-variant :story.xray.edn-inspector/diff-map-mixed-ops
+    {:doc        "Diff pair surfacing every op in one map:
+                 `:added` (new `:flash`), `:modified` (`:counter`
+                 bump + nested `:name` change), `:removed`
+                 (`:legacy-flag`), `:same` (untouched `:user/id`).
+                 Pins the gutter-glyph + colour ladder under
+                 rf2-zuh1e's `children-of-pair` walk."
+     :events     [[:panel-gallery.edn-inspector/seed! (fixtures/diff-map-mixed-ops)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.edn-inspector/diff-vector-element-changes
+    {:doc        "Diff on a vector — `:added` tail, `:modified`
+                 middle element, `:same` head. Pair-walk respects
+                 position."
+     :events     [[:panel-gallery.edn-inspector/seed! (fixtures/diff-vector-element-changes)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.edn-inspector/diff-deep-children-changed
+    {:doc        "Deep diff: change sits six levels down. Ancestor
+                 chain force-expands; intermediate maps paint the
+                 `◴` children-changed glyph in the gutter."
+     :events     [[:panel-gallery.edn-inspector/seed! (fixtures/diff-deep-children-changed)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- opts demos ---------------------------------------------------
+  (story/reg-variant :story.xray.edn-inspector/opts-zoomable
+    {:doc        "`:zoomable? true` (rf2-h71e0) — each container
+                 gains a `⊙` zoom button beside the expand triangle."
+     :events     [[:panel-gallery.edn-inspector/seed! (fixtures/opts-zoomable)]]
+     :tags       #{:dev :feature/opts}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.edn-inspector/opts-popup-affordance
+    {:doc        "`:popup-affordance? true` (rf2-l4625) — `↗` icon
+                 button sits at the widget's top-right corner."
+     :events     [[:panel-gallery.edn-inspector/seed! (fixtures/opts-popup-affordance)]]
+     :tags       #{:dev :feature/opts}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.edn-inspector/opts-card
+    {:doc        "`:card? true` (rf2-63ie5) — outer container picks
+                 up inspector-card chrome (bg, border, radius)."
+     :events     [[:panel-gallery.edn-inspector/seed! (fixtures/opts-card)]]
+     :tags       #{:dev :feature/opts}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.edn-inspector/opts-header
+    {:doc        "`:header \"…\"` (rf2-okq7p) — three-shade card
+                 chrome with a string ribbon label."
+     :events     [[:panel-gallery.edn-inspector/seed! (fixtures/opts-header)]]
+     :tags       #{:dev :feature/opts}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.edn-inspector/opts-header-hiccup
+    {:doc        "`:header [:span …]` (rf2-okq7p) — composed
+                 hiccup ribbon (label + code chip)."
+     :events     [[:panel-gallery.edn-inspector/seed! (fixtures/opts-header-hiccup)]]
+     :tags       #{:dev :feature/opts}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.edn-inspector/opts-site-id
+    {:doc        "`:site-id` (rf2-pvsxs) — stable site-id survives
+                 a remount. Visually identical to the unkeyed
+                 mount; the difference shows on remount cadence."
+     :events     [[:panel-gallery.edn-inspector/seed! (fixtures/opts-site-id)]]
+     :tags       #{:dev :feature/opts}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.edn-inspector/opts-shallow-depth
+    {:doc        "`:default-expanded-depth 1` (rf2-kbdk8) — legacy
+                 depth-driven behaviour. Depth ≥ 1 renders
+                 `▸ {…N keys}` collapsed summaries."
+     :events     [[:panel-gallery.edn-inspector/seed! (fixtures/opts-shallow-depth)]]
+     :tags       #{:dev :feature/opts}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.edn-inspector/opts-combined
+    {:doc        "Composed opts — `:header` + `:popup-affordance?`
+                 + `:zoomable?` together. Pins the affordance
+                 layout when all three coexist."
+     :events     [[:panel-gallery.edn-inspector/seed! (fixtures/opts-combined)]]
+     :tags       #{:dev :feature/opts}
+     :substrates #{:reagent}})
+
+  ;; ----- workspace ----------------------------------------------------
+  (story/reg-workspace :Workspace.xray.edn-inspector/all
+    {:doc      "All edn-inspector widget variants in one auto-grid.
+                Scroll to see the renderer's response across scalar
+                / map (small / medium / large / nested / sentinel)
+                / vector / list / lazy-seq / set / record / uuid /
+                inst / diff (mixed-ops / vector / deep) / opts
+                (zoomable / popup / card / header / header-hiccup
+                / site-id / shallow-depth / combined)."
+     :layout   :variants-grid
+     :story    :story.xray.edn-inspector
+     :columns  2
+     :tags     #{:dev}}))
+
+(register-all!)

--- a/tools/xray/testbeds/panel_gallery/panel_views.cljs
+++ b/tools/xray/testbeds/panel_gallery/panel_views.cljs
@@ -59,7 +59,8 @@
             [day8.re-frame2-xray.panels.trace :as trace]
             [day8.re-frame2-xray.panels.reactive-panel :as reactive-panel]
             [day8.re-frame2-xray.shell :as shell]
-            [day8.re-frame2-xray.theme.tokens :refer [tokens]]))
+            [day8.re-frame2-xray.theme.tokens :refer [tokens]]
+            [day8.re-frame2-xray.views.edn-inspector :as edn-inspector]))
 
 (def ^:private card-style
   "Card chrome around an embedded panel — gives the variants-grid a
@@ -142,6 +143,40 @@
          :data-testid "panel-gallery-issues-card"}
    [issues-ribbon/Panel]])
 
+;; ---- widget gallery (rf2-hp4ow) -----------------------------------------
+;;
+;; The edn-inspector is a widget, not a tab — but the panel-views
+;; convention is the cleanest mounting surface for it too. The
+;; variant frame's fixture slot is read by the gallery ns's
+;; `:panel-gallery.edn-inspector/fixture` sub (declared in
+;; `gallery_edn_inspector.cljs`); we read it here via a string keyword
+;; rather than a namespace alias so this ns has no compile-time
+;; dependency on the gallery namespace (the reverse direction —
+;; gallery → panel-views — is the dependency edge we keep).
+
+(defn- edn-inspector-tab-panel
+  "Embedded mount of the edn-inspector widget. Reads the variant
+  frame's `:panel-gallery.edn-inspector/fixture` slot, destructures
+  `{:value :before :opts}`, and renders the widget with diff mode
+  engaged when `:before` is present."
+  [_args]
+  (let [fixture @(rf/subscribe [:panel-gallery.edn-inspector/fixture])
+        {:keys [value before opts]} fixture
+        merged-opts (cond-> (or opts {})
+                      (some? before) (assoc :before before))]
+    [:div {:style       card-style
+           :data-testid "panel-gallery-edn-inspector-card"}
+     (if (some? fixture)
+       [edn-inspector/edn-inspector value merged-opts]
+       [:div {:style {:padding "16px"
+                      :color (:text-tertiary tokens)
+                      :font-family "system-ui, sans-serif"
+                      :font-size "12px"}}
+        "No fixture seeded into "
+        [:code ":panel-gallery.edn-inspector/fixture"]
+        " — variant `:events` did not run, or this view is mounted
+        outside a variant frame."])]))
+
 ;; ---- full chrome wrapper -------------------------------------------------
 
 (defn- chrome-shell
@@ -188,5 +223,6 @@
   (rf/reg-view* :panel-gallery.machines/Panel machines-tab-panel)
   (rf/reg-view* :panel-gallery.routing/Panel  routing-tab-panel)
   (rf/reg-view* :panel-gallery.issues/Panel   issues-tab-panel)
+  (rf/reg-view* :panel-gallery.edn-inspector/Panel edn-inspector-tab-panel)
   (rf/reg-view* :panel-gallery.chrome/Shell   chrome-shell)
   nil)


### PR DESCRIPTION
**Bead:** [rf2-hp4ow](.beads/) — Xray panel-gallery testbed: add `gallery_edn_inspector.cljs` (widget isolation coverage).

The edn-inspector widget (`day8.re-frame2-xray.views.edn-inspector`) is exercised indirectly today via every L4 panel that mounts it (App-DB, Reactive, Trace, Machines, Issues, Routing). This adds a dedicated gallery surface so the widget can be reviewed in isolation across the full input axis + opts surface.

## Variants covered

**Scalars** (`scalar-mix`) — nil, booleans, ints, floats, strings (with escapes), simple + qualified keywords, plain + qualified symbols. Pins the syntax-highlight palette.

**Maps** —
- `map-small` (3 keys, inline-preview territory)
- `map-medium` (12 flat keys, forces expansion)
- `map-large` (50 flat keys, exercises scroll behaviour)
- `map-nested` (6-level deep, exercises the rf2-kbdk8 depth ceiling)
- `map-large-elided` (`:rf.size/large-elided` sentinel routing — Spec 015)

**Containers** —
- `vector-mixed` — mixed scalars + nested map (`[ ]` bracket pair)
- `list-of-events` — list of event vectors (`( )` bracket pair)
- `lazy-seq-fib` — realised prefix of an infinite fib lazy-seq
- `set-of-tags` — keyword set (`#{ }` bracket pair, unordered iteration)

**Records** — `record-instance` (`GalleryUser` defrecord; `#…GalleryUser{…}` header path).

**UUID + inst** (default `IXrayEdnInspector` formatters, rf2-x16b1) —
- `uuid` — compact `#uuid "…<last-8>"` header
- `insts` — relative-time bucketing (just-now, mins, hours, days, ISO fallback >30d, future)

**Diff mode** (`children-of-pair` walk, rf2-zuh1e) —
- `diff-map-mixed-ops` — every op in one map: `:added` (new `:flash`), `:modified` (counter bump + nested name), `:removed` (`:legacy-flag`), `:same` (untouched `:user/id`)
- `diff-vector-element-changes` — `:added` tail, `:modified` middle, `:same` head
- `diff-deep-children-changed` — change 6 levels deep; ancestor chain force-expands with `◴` gutter glyph

**Opts demos** — one variant per individual opt + a combined variant:
- `opts-zoomable` (`:zoomable?` rf2-h71e0)
- `opts-popup-affordance` (`:popup-affordance?` rf2-l4625)
- `opts-card` (`:card?` rf2-63ie5)
- `opts-header` (`:header "…"` rf2-okq7p)
- `opts-header-hiccup` (`:header [:span …]` rf2-okq7p)
- `opts-site-id` (`:site-id` rf2-pvsxs)
- `opts-shallow-depth` (`:default-expanded-depth 1` rf2-kbdk8)
- `opts-combined` (`:header` + `:popup-affordance?` + `:zoomable?`)

A workspace `:Workspace.xray.edn-inspector/all` (`:variants-grid`, 2 columns) gathers all variants for side-by-side review.

## Registration pattern

Follows the dominant convention used by the 7 L4 tab galleries:

1. `fixtures_edn_inspector.cljs` — pure data builders, each returning `{:value :opts :before}`.
2. `gallery_edn_inspector.cljs` — registers tag / story / variants / workspace, plus a testbed-local `:panel-gallery.edn-inspector/seed!` event + sub that stores the fixture under `:panel-gallery.edn-inspector/fixture` on the variant frame.
3. `panel_views.cljs` — adds `:panel-gallery.edn-inspector/Panel` view that subscribes to the fixture slot and renders `[edn-inspector value (assoc opts :before before)]` (diff mode engages automatically when `:before` is present).
4. `core.cljs` — `:require`s the new gallery namespace so `register-all!` fires at boot.

Each variant fires its seed event into the variant frame; widget expansion / zoom state lives on the variant frame too, so two side-by-side cards do not share state.

**No source files under `tools/xray/src/` change** — this is testbed-only.

## Quality gates

```
npm run test:cljs              → 4698 tests / 15165 assertions / 0 failures, 0 errors
npm run test:browser           → 124 tests / 353 assertions / 0 failures, 0 errors
npm run test:bundle-isolation  → PASS bundle-isolation + PASS uix-helix-reagent-free
npx shadow-cljs compile testbeds/panel-gallery → clean
  (only the pre-existing machines-viz `event-node-id` warning, unrelated)
```

## Screenshots note

Light + dark theme rendering verifies via the existing chrome / app-db galleries (the widget reads CSS-variable tokens; both themes resolve at paint time without per-theme code paths). No new screenshots needed for this PR — the gallery becomes the screenshot surface.