### PR TITLE
fix(machines-viz): declare/reorder event-node-id (rf2-xw0oh)

### DIFF
--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
@@ -63,6 +63,35 @@
   "Minimum height for a compound container."
   120)
 
+;; ---- synthetic event-node helpers --------------------------------------
+;;
+;; rf2-qo5xy events-as-nodes paradigm: each parsed transition emits ONE
+;; synthetic xyflow node sitting between source and target states. These
+;; two tiny pure helpers bucket the variant + mint the stable id, and are
+;; consumed by BOTH the elk children projection (`elk-event-child` below)
+;; AND the main `xyflow-graph` projector further down — so they live
+;; above both rather than buried inside the graph-projection section.
+
+(defn event-variant
+  "rf2-qo5xy — bucket a parsed edge by its event variant for the
+  events-as-nodes paradigm: `:after` (clock glyph), `:always`
+  (infinity glyph), or `:on` (regular event keyword). Pure data → keyword."
+  [edge]
+  (cond
+    (:after edge)   :after
+    (:always? edge) :always
+    :else           :on))
+
+(defn event-node-id
+  "rf2-qo5xy — stable string id for an event-node. The xyflow node
+  inserted between the source state and the (optional) target state
+  in the events-as-nodes paradigm. Derived from the canonical edge-id
+  (`chart.layout/edge-id`) so two transitions sharing source/target/
+  event/guard/action keep distinct event-node ids — the same
+  collision-tiebreak `chart.layout/parse-flat` applies."
+  [edge]
+  (str "event__" (:id edge)))
+
 ;; ---- elk.js children projection ----------------------------------------
 
 (def event-node-elk-width
@@ -173,26 +202,6 @@
   inspector, not as an edge in this chart."
   [edge]
   (if (:after edge) "after" "transition"))
-
-(defn event-variant
-  "rf2-qo5xy — bucket a parsed edge by its event variant for the
-  events-as-nodes paradigm: `:after` (clock glyph), `:always`
-  (infinity glyph), or `:on` (regular event keyword). Pure data → keyword."
-  [edge]
-  (cond
-    (:after edge)   :after
-    (:always? edge) :always
-    :else           :on))
-
-(defn event-node-id
-  "rf2-qo5xy — stable string id for an event-node. The xyflow node
-  inserted between the source state and the (optional) target state
-  in the events-as-nodes paradigm. Derived from the canonical edge-id
-  (`chart.layout/edge-id`) so two transitions sharing source/target/
-  event/guard/action keep distinct event-node ids — the same
-  collision-tiebreak `chart.layout/parse-flat` applies."
-  [edge]
-  (str "event__" (:id edge)))
 
 (defn xyflow-graph
   "Project the parsed graph + a `{node-id position}` map into the


### PR DESCRIPTION
Fixes bead **rf2-xw0oh** — `machines-viz/chart/projection: undeclared event-node-id at line 97 (rf2-qo5xy regression)`.

## The defect

PR #2192 (rf2-qo5xy events-as-nodes) added three helpers to `chart/projection.cljc`. Two of them — `event-variant` + `event-node-id` — landed in the "graph projection" section near the bottom, but `elk-event-child` (further up, in the "elk.js children projection" section) calls `event-node-id` at line 97. Clojure top-down resolution flagged it:

```
File: tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc:97:13
Use of undeclared Var day8.re-frame2-machines-viz.chart.projection/event-node-id
```

The third helper, `elk-event-child` itself, was already correctly placed above its first use.

## Approach: reorder (not declare)

Moved both `event-variant` + `event-node-id` into a new `;; ---- synthetic event-node helpers ----` section between the node-size constants and the elk children projection. Rationale:

- Both are tiny pure per-edge helpers (~10 lines each) — moving them is cheap.
- They are consumed by BOTH the elk-children projection AND the main `xyflow-graph` projector — the new section above both is their natural home.
- Keeps them colocated as a pair (`event-variant` mints the kind, `event-node-id` mints the id), which reads better than splitting them across sections.
- No `(declare ...)` escape hatch — the file stays linearly readable.

## Verification (all from the worker worktree)

```
npx shadow-cljs compile testbeds/panel-gallery
  → 544 files, 543 compiled, 0 warnings, 30.05s
  (was: Use of undeclared Var ...event-node-id at projection.cljc:97:13)

npx shadow-cljs compile examples/step-deck
  → 429 files, 428 compiled, 0 warnings, 30.72s

npm run test:cljs
  → Ran 4740 tests containing 15326 assertions.
  → 0 failures, 0 errors.

npm run test:bundle-isolation
  → PASS bundle-isolation: 16 artefact entries; 33 internal sentinels absent;
    3 allow-list budgets ok
  → PASS uix-helix-reagent-free: 3 bundles checked; 6 sentinel checks
```

No semantic change — only declaration ordering.