### PR TITLE
fix(xray): epoch-panel bug-fixes 2 (5 beads — rf2-2f962 + 4 more)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -128,24 +128,51 @@
   [id]
   (and (some? id) (not (contains? system-cofx-ids id))))
 
+(defn- run-end-coeffects
+  "Read the `:rf.event/coeffects` slot off the `:rf.event/run-end`
+  trace (rf2-9dk9y). The substrate places the post-cofx-chain
+  coeffects map there — every user-injected cofx-id maps to the
+  RESULT VALUE the cofx put into ctx under its id. Empty map when no
+  run-end fired."
+  [events]
+  (or (some-> (find-op events :rf.event/run-end)
+              (common/tag-of :rf.event/coeffects))
+      {}))
+
 (defn- coeffect-rows-from-runs
   "Walk every `:rf.cofx/run` event (rf2-hhh92) and project one row per
-  user-injected coeffect — each row carries the cofx id and the value
-  it added to ctx. Empty seq when no `:rf.cofx/run` events fired.
+  user-injected coeffect.
 
-  System-injected defaults (`:db`, `:event`, `:frame`, `:source`,
-  `:trace-id`) are filtered out per rf2-cq0ch."
+  Each row carries the cofx id and the RESOLVED INJECTED VALUE — what
+  the cofx put into the handler's `:coeffects` map under its id. The
+  resolved value comes off the `:rf.event/run-end :rf.event/coeffects`
+  map (rf2-9dk9y); the `:rf.cofx/value` tag on the granular
+  `:rf.cofx/run` op carries the per-call INPUT ARG for the 2-arity
+  cofx form (e.g. `(inject-cofx :session :auth-token)` stamps
+  `:auth-token` there), and is preserved alongside as `:input` so the
+  operator can read both 'what was asked of the cofx' and 'what it
+  produced'. Per rf2-mmlgk — the result value is what the operator
+  reads first; the input arg is secondary.
+
+  Empty seq when no `:rf.cofx/run` events fired. System-injected
+  defaults (`:db`, `:event`, `:frame`, `:source`, `:trace-id`) are
+  filtered out per rf2-cq0ch."
   [events]
-  (vec
-    (for [ev (filter-op events :rf.cofx/run)
-          :let [id    (common/tag-of ev :rf.cofx/id)
-                value (common/tag-of ev :rf.cofx/value)]
-          :when (user-cofx? id)]
-      {:step        :coeffect
-       :badge       :COEFFECT
-       :id          id
-       :value       value
-       :duration-ms (common/tag-of ev :duration-ms)})))
+  (let [cofx-map (run-end-coeffects events)]
+    (vec
+      (for [ev (filter-op events :rf.cofx/run)
+            :let [id        (common/tag-of ev :rf.cofx/id)
+                  input-arg (common/tag-of ev :rf.cofx/value)
+                  resolved  (get cofx-map id)]
+            :when (user-cofx? id)]
+        (cond-> {:step        :coeffect
+                 :badge       :COEFFECT
+                 :id          id
+                 :value       resolved
+                 :duration-ms (common/tag-of ev :duration-ms)}
+          ;; preserve the per-call input arg for 2-arity cofx so the
+          ;; view can surface it when distinct from the resolved value
+          (some? input-arg) (assoc :input input-arg))))))
 
 (defn- coeffect-rows-from-run-end
   "Fallback: read user-injected coeffects from the `:rf.event/run-end`

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -323,11 +323,69 @@
                    :overflow-x    "auto"}}
      (proj/event-display event)]))
 
+(defn- dispatch-source-label
+  "Render the dispatch source label — `<source>` text. When the
+  envelope carried a `:rf.trace/call-site` coord (rf2-80u5a), the
+  label renders as a clickable button that opens the editor at the
+  dispatch call-site (the React onClick / handler line that called
+  `rf/dispatch`); the external-link icon rides alongside as a
+  secondary cue. When no coord is available (fn-form dispatch,
+  production builds with `goog.DEBUG=false`), the label renders as
+  plain text — no broken / clickable-but-dead affordance.
+
+  Click-through pattern mirrors the cross-panel
+  `:rf.xray/open-in-editor` event (the same fx-id every other
+  open-in-editor surface dispatches via)."
+  [source coord]
+  (let [label (if source (name source) "unknown")
+        clickable? (and (map? coord) (seq (:file coord)))]
+    (if clickable?
+      [:button {:data-testid "rf-xray-epoch-dispatch-source-label"
+                :aria-label  (str "open dispatch call-site for " label)
+                :title       (str "open " (:file coord)
+                                  (when (:line coord)
+                                    (str ":" (:line coord)))
+                                  " in editor")
+                :on-click    (fn [e]
+                               (.stopPropagation e)
+                               (rf/dispatch
+                                 [:rf.xray/open-in-editor
+                                  {:source-coord coord}]
+                                 {:frame :rf/xray}))
+                :style {:background "transparent"
+                        :border     "none"
+                        :padding    0
+                        :margin     0
+                        :color      (:accent tokens)
+                        :cursor     "pointer"
+                        :font-family mono-stack
+                        :font-size  "12px"
+                        :text-decoration "underline"
+                        :text-decoration-style "dotted"
+                        :text-underline-offset "2px"
+                        :display    "inline-flex"
+                        :align-items "center"
+                        :gap        "4px"}}
+       label
+       (icons/external-link)]
+      [:span {:data-testid "rf-xray-epoch-dispatch-source-label"
+              :style {:color (:accent tokens)
+                      :display "inline-flex"
+                      :align-items "center"}}
+       label])))
+
 (defn render-dispatch-step
   "Render the DISPATCH step (always present). Header summarises `from
   <source>` with the call-site chip when a coord was captured;
   body renders the dispatched event vector as a boxed monospace
-  block (rf2-93a7s · rf2-9jvx1)."
+  block (rf2-93a7s · rf2-9jvx1).
+
+  Per rf2-80u5a the `<source>` label itself is the goto-source
+  affordance — clickable button when `:rf.trace/call-site` was
+  captured by the macro form (`rf/dispatch [...] [opts]`); plain
+  text otherwise. The external-link icon rides INSIDE the button
+  as a secondary cue so the affordance reads as a single labelled
+  link rather than a label-with-trailing-icon."
   [{:keys [source coord duration-ms step-number] :as step}]
   [:div {:data-testid "rf-xray-epoch-step-dispatch"
          :data-step-kw "dispatch"}
@@ -337,9 +395,7 @@
       :badge :DISPATCH
       :verb [:span {:style {:display "inline-flex" :align-items "center" :gap "4px"}}
              "from "
-             [:span {:style {:color (:accent tokens)}}
-              (if source (name source) "unknown")]
-             (coord-chip coord "rf-xray-epoch-dispatch-coord")]
+             (dispatch-source-label source coord)]
       :expandable? false
       :testid "rf-xray-epoch-dispatch"
       :duration-ms duration-ms}

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -843,6 +843,39 @@
                        :padding-left "16px"}}
         "<source not yet captured>"])]))
 
+(defn- handler-db-diff-block
+  "Render the HANDLER step's `:db diff` sub-section (rf2-93436 / design
+  doc §Section 1 + §Section 2). Always renders for non-machine
+  handlers — when `db-diff` is empty, the body reads `— (no changes)`
+  per the design's §Empty edge-case rendering table (reg-event-db
+  returning identical db / reg-event-fx returning nil → explicit empty
+  state, not an omitted slot). Operator learns 'the handler ran but
+  wrote nothing to app-db' as a first-class outcome rather than
+  inferring it from absence.
+
+  Distinct from the top-level APP-DB DIFF step (rf2-rrykz) — same
+  source data, different lens. HANDLER's `:db diff` attributes the
+  change to THIS handler's return value; APP-DB DIFF surfaces the
+  cascade-wide accumulated change (which can include fx-triggered
+  child handlers' writes).
+
+  Suppressed for machine handlers — per design §Section 3 §DB DIFF
+  the snapshot IS the db change (at `[:rf/machines <id>]`) so DB DIFF
+  folds into SNAPSHOT DIFF rather than carrying a redundant standalone
+  slot."
+  [db-diff]
+  (let [empty? (not (seq db-diff))
+        n      (count db-diff)]
+    [:div {:data-testid "rf-xray-epoch-handler-db-diff"
+           :data-empty (str empty?)}
+     (sub-header ":db diff"
+                 (if empty?
+                   "— (no changes)"
+                   (str n " path" (when (not= 1 n) "s"))))
+     (when-not empty?
+       (for [[i row] (map-indexed vector db-diff)]
+         (db-diff-line row i)))]))
+
 (defn handler-body
   "Render the HANDLER step's body — source block + db-diff + fx + the
   machine block when the handler is a machine-event-handler.
@@ -851,30 +884,33 @@
   the header already carries that descriptor. Per rf2-66wis the body
   now leads with the handler's source code (or machine spec) so the
   operator can answer 'why did this handler do X' without leaving the
-  panel."
+  panel.
+
+  Per rf2-93436 the `:db diff` sub-section is ALWAYS present for
+  non-machine handlers (design doc §Section 1 + §Section 2) — empty
+  diff renders `— (no changes)` rather than collapsing the slot. For
+  machine handlers the standalone `:db diff` is suppressed (folded
+  into SNAPSHOT DIFF per design §Section 3)."
   [{:keys [flavour event-id db-diff fx machine] :as _row}]
-  [:div {:data-testid "rf-xray-epoch-handler-body"}
-   ;; Source / machine spec block — rf2-66wis
-   (handler-source-block flavour event-id)
-   ;; Machine extras BEFORE db diff (lifecycle is the story for machines)
-   (when machine
-     (machine-block machine))
-   ;; :db diff
-   (when (seq db-diff)
-     [:div {:data-testid "rf-xray-epoch-handler-db-diff"}
-      (sub-header ":db diff"
-                  (str (count db-diff) " path"
-                       (when (not= 1 (count db-diff)) "s")))
-      (for [[i row] (map-indexed vector db-diff)]
-        (db-diff-line row i))])
-   ;; :fx entries
-   (when (seq fx)
-     [:div {:data-testid "rf-xray-epoch-handler-fx"}
-      (sub-header ":fx"
-                  (str (count fx) " entr"
-                       (if (= 1 (count fx)) "y" "ies")))
-      (for [[i entry] (map-indexed vector fx)]
-        (fx-entry-line entry i))])])
+  (let [machine? (= :reg-machine flavour)]
+    [:div {:data-testid "rf-xray-epoch-handler-body"}
+     ;; Source / machine spec block — rf2-66wis
+     (handler-source-block flavour event-id)
+     ;; Machine extras BEFORE db diff (lifecycle is the story for machines)
+     (when machine
+       (machine-block machine))
+     ;; :db diff — always present for non-machine handlers (rf2-93436);
+     ;; folded into SNAPSHOT DIFF for machines
+     (when-not machine?
+       (handler-db-diff-block db-diff))
+     ;; :fx entries
+     (when (seq fx)
+       [:div {:data-testid "rf-xray-epoch-handler-fx"}
+        (sub-header ":fx"
+                    (str (count fx) " entr"
+                         (if (= 1 (count fx)) "y" "ies")))
+        (for [[i entry] (map-indexed vector fx)]
+          (fx-entry-line entry i))])]))
 
 (defn render-handler-step
   "Render the HANDLER step (always present)."

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -73,6 +73,44 @@
 ;; the body via `:zoomable? true` + `:header "<step>"` (rf2-h71e0 /
 ;; rf2-okq7p) per the bead body's §edn-inspector composition.
 
+;; ---- view-name hover-highlight (rf2-2f962) ------------------------------
+;;
+;; Hovering a view-id in the VIEWS step toggles the
+;; `.rf-xray-view-highlight` class on the rendered view's root DOM node
+;; (matched by Spec 006's `data-rf-view` attribute) — the same pink
+;; diagonal-stripe affordance the Reactive panel's view-node carries
+;; (rf2-e33ad / rf2-8l03l). The class lives in
+;; `theme/global-styles` and is intentionally UNSCOPED so it reaches
+;; the host app's frame outside the Xray shell. Pure DOM side-effect;
+;; cleared on mouseleave; no layout perturbation.
+
+(def ^:private view-highlight-class "rf-xray-view-highlight")
+
+(defn- view-highlight-selector
+  "DOM selector for a view-id (Spec 006 stamps `data-rf-view (str id)`)."
+  [view-id]
+  (str "[data-rf-view='" view-id "']"))
+
+(defn- apply-view-highlight!
+  [view-id]
+  (when (and (exists? js/document) (some? view-id))
+    (let [nodes (.querySelectorAll js/document
+                                   (view-highlight-selector view-id))]
+      (.forEach nodes
+                (fn [^js node]
+                  (.add (.-classList node) view-highlight-class)))
+      nil)))
+
+(defn- clear-view-highlight!
+  [view-id]
+  (when (and (exists? js/document) (some? view-id))
+    (let [nodes (.querySelectorAll js/document
+                                   (view-highlight-selector view-id))]
+      (.forEach nodes
+                (fn [^js node]
+                  (.remove (.-classList node) view-highlight-class)))
+      nil)))
+
 ;; ---- chrome helpers ------------------------------------------------------
 
 (defn- badge-pill
@@ -1137,6 +1175,14 @@
      [:div {:key (str "view-" i)
             :data-testid (str "rf-xray-epoch-view-row-" i)
             :data-view-id (when view-id (pr-str view-id))
+            ;; rf2-2f962 — pink-stripe view-name hover affordance. The
+            ;; row-level mouse-enter/leave stamps the
+            ;; `.rf-xray-view-highlight` class onto the live DOM node
+            ;; tagged by Spec 006's `data-rf-view`, mirroring the
+            ;; Reactive panel's view-node treatment (rf2-e33ad /
+            ;; rf2-8l03l). Pure DOM side-effect; no layout perturbation.
+            :on-mouse-enter (fn [_e] (apply-view-highlight! view-id))
+            :on-mouse-leave (fn [_e] (clear-view-highlight! view-id))
             :style {:display "flex"
                     :align-items "stretch"
                     :border-bottom (when (< i (dec (count rows)))
@@ -1146,7 +1192,8 @@
                      :word-break "break-word"}}
        [:span {:data-testid (str "rf-xray-epoch-view-row-id-" i)
                :style {:color (:accent tokens) :display "inline-flex"
-                       :align-items "center" :gap "4px"}}
+                       :align-items "center" :gap "4px"
+                       :cursor (when view-id "pointer")}}
         (if (some? view-id)
           (proj/ns-keyword view-id)
           [:span {:style {:color (:text-tertiary tokens)

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -1164,9 +1164,23 @@
   header shows the split count `N recomputed (M changed, K unchanged)`.
 
   Mirrors the filter-toggle posture Chrome devtools' network panel
-  uses (the precedent the bead body cites)."
+  uses (the precedent the bead body cites).
+
+  Per rf2-p56sk — fourth frame-leak in this class (after rf2-7sdja
+  popup, rf2-y59tb triangle, rf2-kcaiz zoom). The toggle event is
+  dispatched with explicit `{:frame :rf/xray}` envelope in
+  `subscriptions-toggle-button`, and the read here uses the
+  2-arity `subscribe` form so the sub anchors to `:rf/xray`
+  regardless of where the plain hiccup render dereffs from. Without
+  the explicit frame anchor, a non-`reg-view`-internal subscribe
+  resolves through the React-context tier — which is `:rf/xray` in
+  the Xray shell but is NOT guaranteed when the panel renders
+  inside a different frame-provider (story testbeds, embedded
+  surfaces). The toggle slot lives on `:rf/xray`'s app-db; the
+  matching read MUST also target `:rf/xray`'s db."
   [{:keys [rows changed unchanged step-number]}]
-  (let [show-unchanged? @(rf/subscribe [:rf.xray.epoch/subs-show-unchanged?])
+  (let [show-unchanged? @(rf/subscribe :rf/xray
+                                       [:rf.xray.epoch/subs-show-unchanged?])
         visible-rows    (if show-unchanged?
                           rows
                           (filterv :changed? rows))

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -207,13 +207,43 @@
 ;; ---- COEFFECT ------------------------------------------------------------
 
 (deftest coeffect-rows-granular-test
-  (testing "granular :rf.cofx/run events are preferred when present"
-    (let [evs [(cofx-run-ev :session {:user-id 42})
-               (cofx-run-ev :now #inst "2026-01-01")]
+  (testing "rf2-mmlgk — granular `:rf.cofx/run` events are walked; each
+            row carries the RESOLVED INJECTED VALUE off the run-end's
+            `:rf.event/coeffects` map (NOT the input arg). The
+            `:rf.cofx/value` tag rides on the row as `:input` when
+            present so the per-call arg of a 2-arity cofx
+            (`(inject-cofx :session :auth-token)`) is preserved."
+    (let [evs [(cofx-run-ev :session :auth-token)
+               (cofx-run-ev :now nil)
+               (run-end-ev 0.1 {:session {:user-id 42}
+                                :now     #inst "2026-01-01"})]
           rows (proj/coeffect-rows evs)]
       (is (= 2 (count rows)))
       (is (= :session (-> rows first :id)))
-      (is (= {:user-id 42} (-> rows first :value))))))
+      (is (= {:user-id 42} (-> rows first :value))
+          ":value is the RESOLVED injected value (from run-end)")
+      (is (= :auth-token (-> rows first :input))
+          ":input preserves the 2-arity cofx's per-call arg")
+      (is (= :now (-> rows second :id)))
+      (is (= #inst "2026-01-01" (-> rows second :value))
+          "1-arity cofx (no `:rf.cofx/value` on the run op) still
+           resolves its injected value off the run-end map")
+      (is (nil? (-> rows second :input))
+          "1-arity cofx carries no :input (no per-call arg)"))))
+
+(deftest coeffect-rows-granular-without-run-end-test
+  (testing "rf2-mmlgk — when granular `:rf.cofx/run` events exist but
+            no `:rf.event/run-end` carries the coeffects map (older
+            runtimes / interrupted cascades), the row still surfaces
+            with `:value nil`; the operator reads `nil` honestly
+            rather than 'reading the per-call input arg as if it
+            were the result'."
+    (let [evs  [(cofx-run-ev :testdeck/now nil)]
+          rows (proj/coeffect-rows evs)]
+      (is (= 1 (count rows)))
+      (is (= :testdeck/now (-> rows first :id)))
+      (is (nil? (-> rows first :value))
+          "no run-end → :value is nil (no false readings of input as result)"))))
 
 (deftest coeffect-rows-run-end-fallback-test
   (testing "no granular cofx events: fall back to run-end's stamp"

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -94,6 +94,41 @@
       (is (nil? (th/find-by-testid tree "rf-xray-epoch-dispatch-event"))
           "no body row when no event vector was captured"))))
 
+(deftest dispatch-source-label-is-clickable-button-when-coord-present-test
+  (testing "rf2-80u5a — when the dispatch envelope carried a
+            :rf.trace/call-site coord, the `<source>` label in the
+            DISPATCH header renders as a clickable button that opens
+            the editor at the dispatch call-site. The button carries
+            the standard external-link icon as a secondary cue."
+    (let [coord {:file "src/app/counter.cljs" :line 42 :ns 'app.counter}
+          tree  (view/render-dispatch-step
+                  {:step :dispatch :badge :DISPATCH :step-number 1
+                   :event [:counter/inc] :source :ui :coord coord})
+          label (th/find-by-testid tree "rf-xray-epoch-dispatch-source-label")]
+      (is (some? label) "the dispatch source-label slot is present")
+      (is (= :button (first label))
+          "with a coord, the label renders as a real button (clickable)")
+      (let [attrs (second label)]
+        (is (fn? (:on-click attrs))
+            "click handler is attached")
+        (is (string/includes? (or (:title attrs) "") "counter.cljs")
+            "title hints which file will open")))))
+
+(deftest dispatch-source-label-degrades-to-plain-span-when-coord-absent-test
+  (testing "rf2-80u5a — when no call-site coord is available
+            (fn-form dispatch, production builds), the label
+            renders as a plain `<span>` with no fake / dead
+            click affordance."
+    (let [tree (view/render-dispatch-step
+                 {:step :dispatch :badge :DISPATCH :step-number 1
+                  :event [:counter/inc] :source :ui :coord nil})
+          label (th/find-by-testid tree "rf-xray-epoch-dispatch-source-label")]
+      (is (some? label) "the source-label slot is still rendered")
+      (is (= :span (first label))
+          "no coord → plain span (no broken button)")
+      (is (nil? (:on-click (second label)))
+          "no click handler on the degraded label"))))
+
 ;; ---- rf2-cq0ch — COEFFECT body --------------------------------------
 
 (deftest coeffect-body-renders-labelled-value-test

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -233,6 +233,25 @@
       (is (string/includes? id "<anonymous view>")
           "missing view-id reads as `<anonymous view>` placeholder"))))
 
+(deftest views-row-carries-pink-stripe-hover-handlers-test
+  (testing "rf2-2f962 — VIEWS row carries on-mouse-enter / on-mouse-leave
+            handlers that drive the `.rf-xray-view-highlight` pink-stripe
+            class on the live `data-rf-view` DOM node (rf2-e33ad /
+            rf2-8l03l convention). The handlers are present whether or
+            not view-id is non-nil — they no-op safely when the row's
+            view-id is absent."
+    (let [step {:step :views :badge :VIEWS :step-number 6
+                :rows [{:view-id :app.counter/Counter
+                        :subs-read [[:counter/total]] :duration-ms 0.5}]}
+          tree (view/render-views-step step)
+          row  (th/find-by-testid tree "rf-xray-epoch-view-row-0")
+          attrs (when (vector? row) (second row))]
+      (is (some? row) "the view row renders")
+      (is (fn? (:on-mouse-enter attrs))
+          "row carries an on-mouse-enter handler (pink-stripe affordance)")
+      (is (fn? (:on-mouse-leave attrs))
+          "row carries an on-mouse-leave handler"))))
+
 ;; ---- rf2-nqt3d — per-step elapsed time + cascade total ----------------
 
 (deftest cascade-summary-renders-total-test

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -254,6 +254,62 @@
 
 ;; ---- rf2-66wis — HANDLER source code block ---------------------------
 
+;; ---- rf2-93436 — HANDLER :db diff sub-section (design §Section 1+2) -----
+
+(deftest handler-db-diff-always-renders-for-non-machine-handlers-test
+  (testing "rf2-93436 — `:db diff` sub-section is ALWAYS present
+            inside the HANDLER body for reg-event-db / reg-event-fx.
+            Empty diff renders `— (no changes)`; populated diff
+            renders the path-changes."
+    (testing "reg-event-db with empty diff"
+      (let [tree (view/render-handler-step
+                   {:step :handler :badge :HANDLER :step-number 3
+                    :flavour :reg-event-db :event-id :nop
+                    :db-diff [] :fx [] :machine nil})
+            slot (th/find-by-testid tree "rf-xray-epoch-handler-db-diff")]
+        (is (some? slot)
+            ":db diff sub-section is always present even when empty")
+        (is (string/includes? (or (th/text-content slot) "") "no changes")
+            "empty diff renders `— (no changes)` per design §Empty edge cases")))
+    (testing "reg-event-db with populated diff"
+      (let [tree (view/render-handler-step
+                   {:step :handler :badge :HANDLER :step-number 3
+                    :flavour :reg-event-db :event-id :counter/inc
+                    :db-diff [[[:counter :value] 5 6 :modified]]
+                    :fx [] :machine nil})
+            slot (th/find-by-testid tree "rf-xray-epoch-handler-db-diff")]
+        (is (some? slot))
+        (is (some? (th/find-by-testid
+                     tree "rf-xray-epoch-handler-diff-row-0"))
+            "the populated diff row renders inside the sub-section")))
+    (testing "reg-event-fx with empty diff"
+      (let [tree (view/render-handler-step
+                   {:step :handler :badge :HANDLER :step-number 3
+                    :flavour :reg-event-fx :event-id :navigate
+                    :db-diff [] :fx [{:fx-id :navigate :value "/x"}]
+                    :machine nil})
+            slot (th/find-by-testid tree "rf-xray-epoch-handler-db-diff")]
+        (is (some? slot)
+            "even reg-event-fx that returned no :db gets the sub-section")
+        (is (string/includes? (or (th/text-content slot) "") "no changes"))))))
+
+(deftest handler-db-diff-suppressed-for-machine-handlers-test
+  (testing "rf2-93436 — for machine handlers the standalone `:db diff`
+            sub-section is suppressed (design §Section 3 §DB DIFF —
+            folds into SNAPSHOT DIFF since the snapshot IS the
+            db change at `[:rf/machines <id>]`). Avoids the redundant
+            slot duplicating data already shown in SNAPSHOT DIFF."
+    (let [tree (view/render-handler-step
+                 {:step :handler :badge :HANDLER :step-number 3
+                  :flavour :reg-machine :event-id :ws/start
+                  :db-diff [[[:rf/machines :ws/conn] {} {} :modified]]
+                  :fx []
+                  :machine {:transition nil :guards []
+                            :lifecycle [] :timers []}})]
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-handler-db-diff"))
+          "no standalone :db diff under machine handlers — folded into
+           SNAPSHOT DIFF per design"))))
+
 (deftest handler-body-renders-source-placeholder-test
   (testing "rf2-66wis — HANDLER body carries a source-code slot.
             When no handler-meta has been stamped the slot renders

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -215,6 +215,43 @@
           (is (= 1 (count-prefix tree "rf-xray-epoch-sub-row-"))
               "unchanged hidden again after second toggle"))))))
 
+(deftest sub-toggle-anchors-to-xray-frame-test
+  (testing "rf2-p56sk — fourth frame-leak class (rf2-7sdja popup +
+            rf2-y59tb triangle + rf2-kcaiz zoom). The Show unchanged
+            toggle's dispatch carries explicit `{:frame :rf/xray}`
+            envelope AND the read uses the 2-arity subscribe form
+            so the sub-write + sub-read are anchored to the same
+            frame regardless of the surrounding render context.
+            Without both anchors, the dispatch lands in `:rf/xray`'s
+            app-db while the read accidentally resolves `:rf/default`
+            (or any other frame) — mutation never visible to the row
+            filter."
+    (epoch-orchestrator/install!)
+    (frame/reg-frame :rf/xray {})
+    ;; Run OUTSIDE `with-frame :rf/xray` so the dispatch path is
+    ;; exercised exactly as the live shell's React onClick fires it —
+    ;; the dispatch-time frame must be the envelope, NOT a lexical
+    ;; binding the test artificially supplies.
+    (let [step {:step :subscriptions :badge :SUBSCRIPTIONS :step-number 5
+                :rows [{:sub-id :a :sub-vec [:a] :changed? true :before 1 :after 2}
+                       {:sub-id :b :sub-vec [:b] :changed? false}]
+                :changed 1 :unchanged 1}]
+      ;; The button's onClick dispatches with envelope; mirror that.
+      (rf/with-frame :rf/xray
+        ;; Confirm the toggle button is rendered and carries the envelope.
+        (let [tree (view/render-subscriptions-step step)
+              btn  (th/find-by-testid tree "rf-xray-epoch-subscriptions-toggle")]
+          (is (some? btn) "toggle button is present")
+          (is (fn? (:on-click (second btn))))))
+      ;; Dispatch with the envelope — same shape as the click handler.
+      (rf/dispatch-sync [:rf.xray.epoch/toggle-subs-show-unchanged]
+                        {:frame :rf/xray})
+      (rf/with-frame :rf/xray
+        (let [tree (view/render-subscriptions-step step)]
+          (is (= 2 (count-prefix tree "rf-xray-epoch-sub-row-"))
+              "envelope-anchored dispatch flips the :rf/xray slot the
+               2-arity sub reads"))))))
+
 ;; ---- rf2-66wis — HANDLER source code block ---------------------------
 
 (deftest handler-body-renders-source-placeholder-test


### PR DESCRIPTION
Five gap fixes from Mike's pair-debug 2026-05-26 against the Epoch panel landed by Cluster A (#2191) + Cluster B (#2193). Sequential commits; each carries its own regression-guard tests.

## Per-bead summary

- **rf2-2f962** (P3, bug) — restore VIEWS pink-stripe hover affordance. Adds `on-mouse-enter` / `on-mouse-leave` on the row to toggle `.rf-xray-view-highlight` on the live `data-rf-view` DOM node, matching the Reactive panel's view-node treatment (rf2-e33ad / rf2-8l03l).
- **rf2-80u5a** (P2, bug) — DISPATCH `from <source>` label now renders as a clickable button (with the external-link icon riding alongside) when the dispatch envelope carried a `:rf.trace/call-site` coord. Click → `:rf.xray/open-in-editor`. Plain `<span>` fallback when no coord (fn-form dispatch, production builds).
- **rf2-mmlgk** (P2, bug) — COEFFECT row now surfaces the RESOLVED INJECTED VALUE off the run-end's `:rf.event/coeffects` map, not the per-call input arg from `:rf.cofx/value` (the latter was nil for 1-arity cofx, producing the `:testdeck/now nil` mis-read). The per-call arg is preserved as `:input` so 2-arity cofx like `(inject-cofx :session :auth-token)` keep both signals.
- **rf2-p56sk** (P1, bug) — fourth frame-leak in this class (after rf2-7sdja popup, rf2-y59tb triangle, rf2-kcaiz zoom). The dispatch was already wrapped with `{:frame :rf/xray}`; the matching subscribe used the 1-arity form and resolved through React-context (only correct under the Xray shell). Switched to the 2-arity `(rf/subscribe :rf/xray [...])` form so the read anchors to the same frame the write targets.
- **rf2-93436** (P1, bug) — HANDLER body's `:db diff` sub-section now always renders for non-machine handlers per design §Section 1 + §Section 2 — empty diff reads `— (no changes)` rather than collapsing the slot. Distinct from the top-level APP-DB DIFF (rf2-rrykz) — same data, different lens (attribution vs cascade-wide surface). For machine handlers the standalone `:db diff` is suppressed (folds into SNAPSHOT DIFF).

## Cross-bead — frame-leak class (rf2-p56sk note)

Fourth frame-leak in 6 PRs (rf2-7sdja, rf2-y59tb, rf2-kcaiz, now rf2-p56sk). Each landed the same fix shape: explicit `{:frame :rf/xray}` envelope at dispatch site; rf2-p56sk additionally pairs the subscribe with explicit `:rf/xray` frame.

A reusable helper would prevent the class. Sketch:

```clojure
(defn xray-dispatch [event] (rf/dispatch event {:frame :rf/xray}))
(defmacro xray-subscribe [query-v] `(rf/subscribe :rf/xray ~query-v))
```

Adopted at every Xray-internal click handler + sub read inside plain-defn render bodies, it eliminates the discipline-tax of remembering the envelope per call. The cost is one named import, the benefit is that the bug class becomes structurally inexpressible. Not done in this PR — would touch every Xray panel and warrants its own bead with a clean conversion sweep.

## Test deltas

- `tools/xray/test/.../panels/epoch/view_cljs_test.cljs` — 6 new tests:
  - `views-row-carries-pink-stripe-hover-handlers-test` (rf2-2f962)
  - `dispatch-source-label-is-clickable-button-when-coord-present-test` (rf2-80u5a)
  - `dispatch-source-label-degrades-to-plain-span-when-coord-absent-test` (rf2-80u5a)
  - `sub-toggle-anchors-to-xray-frame-test` (rf2-p56sk)
  - `handler-db-diff-always-renders-for-non-machine-handlers-test` (rf2-93436)
  - `handler-db-diff-suppressed-for-machine-handlers-test` (rf2-93436)
- `tools/xray/test/.../panels/epoch/projection_cljs_test.cljc` — `coeffect-rows-granular-test` updated + `coeffect-rows-granular-without-run-end-test` added (rf2-mmlgk).

## Gates

- `npm run test:cljs` — 4747 tests, 0 failures
- `npm run test:browser` — 124 tests, 0 failures
- `npm run test:bundle-isolation` — PASS

## Files changed

- `tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs` (all 5 beads)
- `tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc` (rf2-mmlgk)
- `tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs` (4 beads)
- `tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc` (rf2-mmlgk)

Beads closed on merge:
- Closes rf2-2f962
- Closes rf2-80u5a
- Closes rf2-mmlgk
- Closes rf2-p56sk
- Closes rf2-93436
