### PR TITLE
fix(xray): epoch-panel polish cluster 3 (3 beads — pill colours + handler source link + edn-inspector pervasive)

### DIFF
--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/theme/tokens.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/theme/tokens.cljc
@@ -111,11 +111,15 @@
    :hover          "#2a2a2a"
 
    ;; functional categorical hues (spec/022 carve-out)
+   ;; Two pink/violet-family hues — see Xray's `dark-palette` block for
+   ;; rationale. The drift gate (rf2-z7ms8) requires these to match Xray's
+   ;; values; this mirror is updated alongside rf2-cgm4f.
    :green          "#3fb950"
    :yellow         "#d29922"
    :orange         "#FB923C"
    :red            "#F87171"
-   :magenta        "#E879F9"
+   :magenta        "#a855f7"   ; violet-500 — was #E879F9 pre-rf2-cgm4f
+   :magenta-pink   "#ec4899"   ; pink-500 — added rf2-cgm4f
    :info           "#79c0ff"
 
    ;; syntax-highlighter palette (rf2-79ojx · One Dark / Atom One Dark)
@@ -201,11 +205,15 @@
    :hover          "#e8e8e8"
 
    ;; functional categorical hues
+   ;; Two pink/violet-family hues — see Xray's `light-palette` block for
+   ;; rationale. The drift gate (rf2-z7ms8) requires these to match Xray's
+   ;; values; this mirror is updated alongside rf2-cgm4f.
    :green          "#1a7f37"
    :yellow         "#9a6700"
    :orange         "#C2570F"
    :red            "#C84444"
-   :magenta        "#B146C2"
+   :magenta        "#9333ea"   ; violet-600 — was #B146C2 pre-rf2-cgm4f
+   :magenta-pink   "#db2777"   ; pink-600 — added rf2-cgm4f
    :info           "#0550ae"
 
    ;; syntax-highlighter palette (rf2-79ojx · One Light / Atom One Light)

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/badge.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/badge.cljc
@@ -37,18 +37,24 @@
 ;;
 ;;     #8c959f                — `:text-tertiary` (the muted grey already
 ;;                              in the palette)
-;;     #a855f7                — :magenta (close enough hue family)
+;;     #a855f7                — :magenta (violet-500; the COEFFECT mock
+;;                              hue. The dark `:magenta` token's hex was
+;;                              tuned to this exact value in rf2-cgm4f so
+;;                              the badge and the mock match — and the
+;;                              shared `:magenta` consumers (redacted
+;;                              sentinel chip, filter "out" mode, etc.)
+;;                              continue to read a violet-family hue.)
 ;;     var(--devtools-active) — `:accent` (the single blue identity)
 ;;     rgb(154,103,0)         — :orange (functional amber, perf-slow
 ;;                              tier — close enough hue for the FX
 ;;                              step's irreversible/post-commit signal)
-;;     #ec4899                — :magenta-pink (we ship :magenta, which
-;;                              spans the pink/purple family on both
-;;                              themes; the COEFFECT badge above also
-;;                              reads magenta, so we differentiate
-;;                              SUBSCRIPTIONS by reading :magenta with
-;;                              a slightly different lookup to keep
-;;                              the two distinct at a glance)
+;;     #ec4899                — :magenta-pink (the SUBSCRIPTIONS mock
+;;                              hue, added as a new palette token in
+;;                              rf2-cgm4f so the SUBSCRIPTIONS pill is
+;;                              visually distinct from COEFFECT's
+;;                              violet-magenta. Pre-rf2-cgm4f both pills
+;;                              collapsed onto `:magenta` and the eye
+;;                              couldn't separate them at a glance.)
 ;;     var(--devtools-success) — `:success` / `:green`
 ;;
 ;; The 7-badge inventory is binding: the view never paints a badge
@@ -59,13 +65,16 @@
   `tokens/tokens` so the badge background reads off the active
   theme's CSS variable (one badge across light + dark).
 
-  Two badges intentionally pull magenta-family tokens (`:magenta` for
-  COEFFECT, `:magenta` for SUBSCRIPTIONS) per the bead body — the
-  view differentiates them with their text label rather than a
-  hue split; the project's palette doesn't carry a separate pink hue
-  and adding to it for this single use site would erode the palette's
-  single-source-of-truth posture (per spec/022). HANDLER + FLOW share
-  `:accent` — the Figma export's single-accent identity (rf2-ad7zx.13).
+  COEFFECT pulls `:magenta` (violet `#a855f7`); SUBSCRIPTIONS pulls
+  `:magenta-pink` (`#ec4899`). The two were collapsed onto the same
+  token pre-rf2-cgm4f and operators couldn't separate them at a
+  glance — Mike-ruled 2026-05-26: visual distinguishability earns
+  one extra palette token. The two hues map onto the original mock's
+  assignment, which the implementer had folded for palette-minimality
+  reasons that the mock didn't actually support.
+
+  HANDLER + FLOW share `:accent` — the Figma export's single-accent
+  identity (rf2-ad7zx.13).
 
   rf2-17vxj — SCHEMA-VIOLATIONS pulls `:warning` so the section
   reads as load-bearing without rising to `:error`'s alarmist tone.
@@ -78,7 +87,7 @@
    :HANDLER           :accent
    :FLOW              :accent
    :FX                :orange
-   :SUBSCRIPTIONS     :magenta
+   :SUBSCRIPTIONS     :magenta-pink
    :VIEWS             :success
    :SCHEMA-VIOLATIONS :warning
    :CHILD-DISPATCHES  :text-tertiary

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -57,6 +57,7 @@
             [day8.re-frame2-xray.panels.epoch.badge :as badge]
             [day8.re-frame2-xray.panels.epoch.icons :as icons]
             [day8.re-frame2-xray.panels.epoch.projection :as proj]
+            [day8.re-frame2-xray.views.edn-inspector :as ei]
             [day8.re-frame2-xray.views.edn-widget.widget :as edn]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens mono-stack sans-stack]]))
@@ -303,25 +304,34 @@
 ;; ---- DISPATCH step -------------------------------------------------------
 
 (defn dispatch-body
-  "Render the DISPATCH step's expanded body — the event vector as a
-  boxed monospace block. Per the bead body's §DISPATCH (Step 1).
+  "Render the DISPATCH step's expanded body — the event vector via the
+  canonical edn-inspector widget. Per the bead body's §DISPATCH
+  (Step 1).
 
   Per rf2-9jvx1 the body no longer repeats the `from <source>` line —
   the header already carries that descriptor; the body is detail-only.
-  The click-to-source affordance rides on the header (rf2-93a7s)."
+  The click-to-source affordance rides on the header (rf2-93a7s).
+
+  Per rf2-8w8er (subsumes rf2-nszcv) the event vector renders through
+  the first-class `edn-inspector` widget so keywords paint magenta,
+  numbers orange, strings green (rf2-79ojx palette), with
+  width-aware inline/tree behaviour, sticky expansion, click-to-zoom,
+  and sentinel chrome (`:rf/redacted`, `:rf.size/large-elided`). Pre-
+  fix the body was plain text — the operator saw the dispatch event
+  styled DIFFERENTLY in the Event panel (inspector-styled) vs the
+  Epoch panel (plain) for the same value."
   [{:keys [event]}]
   (when (vector? event)
     [:div {:data-testid "rf-xray-epoch-dispatch-event"
-           :style {:font-family   mono-stack
-                   :font-size     "12px"
-                   :color         (:text-primary tokens)
-                   :background    (:bg-3 tokens)
+           :style {:background    (:bg-3 tokens)
                    :border        (str "1px solid " (:border-subtle tokens))
                    :border-radius "3px"
                    :padding       "5px 8px"
                    :margin-top    "5px"
                    :overflow-x    "auto"}}
-     (proj/event-display event)]))
+     [ei/edn-inspector event {:site-id "epoch-dispatch-event"
+                              :card?   false
+                              :zoomable? true}]]))
 
 (defn- dispatch-source-label
   "Render the dispatch source label — `<source>` text. When the
@@ -467,7 +477,13 @@
 
 (defn- db-diff-line
   "Render one db-diff entry (`~ [path] before → after` /
-  `+ [path] value` / `- [path]`)."
+  `+ [path] value` / `- [path]`).
+
+  Per rf2-8w8er the before / after values render through the
+  edn-inspector `mini` widget so keywords, numbers, strings, and
+  sentinels paint with their canonical syntax-token chrome rather
+  than as plain `pr-str` text. The diff-glyph + path label stay
+  plain — they are signalling cues, not CLJS values."
   [[path before after change-kind] idx]
   (let [glyph (case change-kind
                 :added    "+"
@@ -495,17 +511,21 @@
      (when (= "~" glyph)
        [:<>
         [:span {:style {:color (:error tokens)}}
-         (proj/truncate (pr-str before) 40)]
+         [ei/mini before 40]]
         [:span {:style {:color (:text-tertiary tokens)}} "→"]
         [:span {:style {:color (:success tokens)}}
-         (proj/truncate (pr-str after) 40)]])
+         [ei/mini after 40]]])
      (when (= "+" glyph)
        [:span {:style {:color (:success tokens) :min-width 0 :flex 1
                        :word-break "break-word"}}
-        (proj/truncate (pr-str after) 80)])]))
+        [ei/mini after 80]])]))
 
 (defn- fx-entry-line
-  "Render one fx entry inside the HANDLER step's :fx sub-block."
+  "Render one fx entry inside the HANDLER step's :fx sub-block.
+
+  Per rf2-8w8er the fx value routes through the edn-inspector `mini`
+  widget so its scalars / keywords / collections paint with the
+  canonical syntax-token chrome rather than plain `pr-str` text."
   [{:keys [fx-id value]} idx]
   [:div {:key (str "fx-entry-" idx)
          :data-testid (str "rf-xray-epoch-handler-fx-row-" idx)
@@ -519,7 +539,7 @@
     (proj/ns-keyword fx-id)]
    [:span {:style {:color (:text-primary tokens) :min-width 0 :flex 1
                    :word-break "break-word"}}
-    (proj/truncate (pr-str value) 80)]])
+    [ei/mini value 80]]])
 
 (defn- machine-lifecycle-block
   "Render the per-phase lifecycle rows for a machine handler. Empty
@@ -695,10 +715,20 @@
                      :text-transform "uppercase"
                      :letter-spacing "0.5px"}}
        (str "transition · " (proj/ns-keyword (:machine-id transition)))]
-      [:div {:style {:padding-left "16px"}}
+      [:div {:style {:padding-left "16px"
+                     :display "inline-flex"
+                     :align-items "center"
+                     :gap "6px"
+                     :flex-wrap "wrap"}}
+       ;; rf2-8w8er — state before/after render through `mini` so
+       ;; the state vector's keywords paint magenta, scalars orange,
+       ;; etc. — matching how every other Xray panel renders state.
        (let [before (or (some-> (:before transition) :state) (:before transition))
              after  (or (some-> (:after transition) :state) (:after transition))]
-         (str (pr-str before) " → " (pr-str after)))]
+         [:<>
+          [:span {:style {:color (:error tokens)}} [ei/mini before 40]]
+          [:span {:style {:color (:text-tertiary tokens)}} "→"]
+          [:span {:style {:color (:success tokens)}} [ei/mini after 40]]])]
       ;; rf2-9c27r — microsteps + event slots ride alongside the
       ;; before→after pair so the operator can tell at a glance how
       ;; many always-microsteps fired + which event drove the cascade.
@@ -750,7 +780,10 @@
                        :font-family mono-stack
                        :font-size "12px"}}
          [:span {:style {:color (:warning tokens)}} "✗"]
-         [:span (str (pr-str state))]
+         ;; rf2-8w8er — state vector through `mini` so the machine
+         ;; state syntax-token chrome reads consistently with every
+         ;; other Xray state-rendering surface.
+         [:span [ei/mini state 40]]
          (when (number? delay)
            [:span {:style {:color (:text-tertiary tokens)}}
             (str delay "ms")])
@@ -1011,14 +1044,15 @@
       [:span {:style {:color (:warning tokens) :font-weight 700}} "~"]
       [:span {:style {:color (:text-tertiary tokens)}}
        (proj/path-display path)]
+      ;; rf2-8w8er — before/after render through the edn-inspector
+      ;; `mini` widget so per-token syntax chrome paints (numbers
+      ;; orange, keywords magenta, sentinels chip).
       (when (some? before)
-        [:span {:style {:color (:error tokens)}}
-         (proj/truncate (pr-str before) 30)])
+        [:span {:style {:color (:error tokens)}} [ei/mini before 30]])
       (when (and (some? before) (some? after))
         [:span {:style {:color (:text-tertiary tokens)}} "→"])
       (when (some? after)
-        [:span {:style {:color (:success tokens)}}
-         (proj/truncate (pr-str after) 30)])])])
+        [:span {:style {:color (:success tokens)}} [ei/mini after 30]])])])
 
 (defn render-flow-step
   "Render the FLOW step (only present when flows fired)."
@@ -1077,10 +1111,12 @@
      [:span {:style {:color colour :font-weight 700}} glyph]
      [:span {:style {:color (:accent tokens)}}
       (proj/ns-keyword fx-id)]
+     ;; rf2-8w8er — args render through `mini` so the fx-call surface
+     ;; lights up with syntax-token colour rather than plain text.
      (when (some? args)
        [:span {:style {:color (:text-primary tokens) :min-width 0 :flex 1
                        :word-break "break-word"}}
-        (proj/truncate (pr-str args) 80)])
+        [ei/mini args 80]])
      (when (number? duration-ms)
        [:span {:style {:color (:text-tertiary tokens)
                        :margin-left "8px"
@@ -1203,35 +1239,43 @@
       [:div {:style {:flex "1 1 35%" :padding "5px 8px" :min-width 0
                      :font-family mono-stack :font-size "12px"
                      :word-break "break-word"}}
+       ;; rf2-8w8er — sub-vec renders through `mini` so the vector's
+       ;; keywords paint magenta, scalars orange, etc. Sub-id-only
+       ;; fallback keeps the keyword-token chrome via `mini` too.
        [:span {:style {:color (:accent tokens) :display "inline-flex"
                        :align-items "center" :gap "4px"}}
-        (or (when (vector? sub-vec) (pr-str sub-vec))
-            (proj/ns-keyword sub-id))
+        (if (vector? sub-vec)
+          [ei/mini sub-vec 40]
+          [ei/mini sub-id 40])
         (icons/external-link)]]
       [:div {:style {:flex "1 1 35%" :padding "5px 8px" :min-width 0
                      :font-family mono-stack :font-size "12px"
                      :color (:text-tertiary tokens)
                      :word-break "break-word"}}
+       ;; rf2-8w8er — each input keyword routes through `mini` so
+       ;; the input column lights up as keywords, not plain text.
+       ;; "app-db" stays as a label (it's a source descriptor, not
+       ;; a CLJS value).
        (cond
          (vector? inputs)
          (into [:div {:style {:display "flex" :flex-direction "column" :gap "2px"}}]
-               (map (fn [i] [:div (proj/ns-keyword i)]) inputs))
-         inputs (proj/ns-keyword inputs)
-         :else  "app-db")]
+               (map (fn [i] [:div [ei/mini i 40]]) inputs))
+         (some? inputs) [ei/mini inputs 40]
+         :else          "app-db")]
       [:div {:style {:flex "1 1 30%" :padding "5px 8px" :min-width 0
                      :font-family mono-stack :font-size "12px"}}
        (if changed?
          [:div {:style {:display "flex" :gap "6px" :flex-wrap "wrap"
                         :align-items "center"}}
           [:span {:style {:color (:success tokens) :font-weight 700}} "✓"]
+          ;; rf2-8w8er — before/after through `mini` so numbers
+          ;; paint orange, keywords magenta, etc.
           (when (some? before)
-            [:span {:style {:color (:error tokens)}}
-             (proj/truncate (pr-str before) 24)])
+            [:span {:style {:color (:error tokens)}} [ei/mini before 24]])
           (when (and (some? before) (some? after))
             [:span {:style {:color (:text-tertiary tokens)}} "→"])
           (when (some? after)
-            [:span {:style {:color (:success tokens)}}
-             (proj/truncate (pr-str after) 24)])]
+            [:span {:style {:color (:success tokens)}} [ei/mini after 24]])]
          [:span {:style {:color (:text-tertiary tokens) :font-weight 700}} "✗"])]])])
 
 (defn render-subscriptions-step
@@ -1363,13 +1407,17 @@
                      :font-family mono-stack :font-size "12px"
                      :color (:text-tertiary tokens)
                      :word-break "break-word"}}
+       ;; rf2-8w8er — each sub-id (keyword or sub-vector) renders
+       ;; through `mini` so the column reads as syntax-highlighted
+       ;; tokens (keywords magenta, vectors with their bracket
+       ;; chrome) rather than plain pr-str / `:foo` text.
        (cond
          (and (sequential? subs-read) (seq subs-read))
          (into [:div {:style {:display "flex" :flex-direction "column" :gap "2px"}}]
                (for [s subs-read]
-                 [:div (if (vector? s) (pr-str s) (proj/ns-keyword s))]))
+                 [:div [ei/mini s 60]]))
          (some? subs-read)
-         (proj/ns-keyword subs-read)
+         [ei/mini subs-read 60]
          :else
          [:span {:style {:font-style "italic"}} "(none)"])]])])
 
@@ -1484,13 +1532,15 @@
                     :font-size "10px"
                     :padding-left "16px"}}
       "(value redacted — slot declared :sensitive?)"])
-   ;; explain detail (Malli explain map, when stamped)
+   ;; explain detail (Malli explain map, when stamped) — rf2-8w8er
+   ;; routes through `mini` so the explain map's keyword keys + value
+   ;; tokens carry syntax-token chrome rather than plain pr-str text.
    (when (some? explain)
      [:div {:data-testid (str "rf-xray-epoch-schema-violation-explain-" idx)
             :style {:color (:text-secondary tokens)
                     :padding-left "16px"
                     :font-size "11px"}}
-      (proj/truncate (pr-str explain) 120)])])
+      [ei/mini explain 120]])])
 
 (defn render-schema-violations-step
   "Render the SCHEMA VIOLATIONS step (rf2-17vxj — only present when
@@ -1575,24 +1625,26 @@
      [:span {:style {:color glyph-colour :font-weight 700}} glyph]
      [:span {:style {:color (:text-tertiary tokens) :white-space "nowrap"}}
       (proj/path-display path)]
+     ;; rf2-8w8er — added/removed/modified values render through
+     ;; `mini` so per-token syntax chrome paints. Matches the HANDLER
+     ;; step's :db-diff posture so the two diff surfaces read
+     ;; identically.
      (case change
        :added
        [:span {:style {:color (:success tokens) :min-width 0 :flex 1
                        :word-break "break-word"}}
-        (proj/truncate (pr-str after) 80)]
+        [ei/mini after 80]]
 
        :removed
        [:span {:style {:color (:error tokens) :min-width 0 :flex 1
                        :word-break "break-word"}}
-        (proj/truncate (pr-str before) 80)]
+        [ei/mini before 80]]
 
        ;; modified (default)
        [:<>
-        [:span {:style {:color (:error tokens)}}
-         (proj/truncate (pr-str before) 40)]
+        [:span {:style {:color (:error tokens)}} [ei/mini before 40]]
         [:span {:style {:color (:text-tertiary tokens)}} "→"]
-        [:span {:style {:color (:success tokens)}}
-         (proj/truncate (pr-str after) 40)]])]))
+        [:span {:style {:color (:success tokens)}} [ei/mini after 40]]])]))
 
 (defn render-app-db-diff-step
   "Render the APP-DB DIFF step (rf2-rrykz — only present when the
@@ -1666,13 +1718,14 @@
                      :letter-spacing "0.5px"
                      :font-weight 600}}
       (child-dispatch-via-label via)]
-     ;; event vector (primary)
+     ;; event vector (primary) — rf2-8w8er routes through `mini` so
+     ;; the dispatched event vector carries syntax-token chrome.
      [:span {:data-testid (str "rf-xray-epoch-child-dispatch-event-" idx)
              :style {:color (:text-primary tokens)
                      :min-width 0
                      :flex 1
                      :word-break "break-word"}}
-      (pr-str event)]
+      [ei/mini event 80]]
      ;; delay chip (for :dispatch-later)
      (when (number? delay-ms)
        [:span {:data-testid (str "rf-xray-epoch-child-dispatch-delay-" idx)

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -800,6 +800,29 @@
       (:spec meta)
       (:rf.machine/spec meta)))
 
+(defn- coord-from-handler-meta
+  "Lift a `{:file :line}` source-coord off a registered handler's meta
+  map (`rf/handler-meta` return shape). Returns nil when the meta
+  carries no `:file` (production builds, registrations that pre-date
+  the coord-annotation pass).
+
+  rf2-ehd8v — shared by the HANDLER source-block (event + machine
+  handlers) so the `file:line + [open]` affordance reads the same
+  shape both render-paths use."
+  [m]
+  (when (and m (string? (:file m)) (seq (:file m)))
+    {:file (:file m) :line (:line m)}))
+
+(defn- source-coord-display
+  "Render a structured source-coord `{:file :line}` as the display
+  string `\"file:line\"` (or just `\"file\"`). nil when the coord
+  lacks `:file`. Mirrors `event_detail/format-coord-display` so the
+  HANDLER source row reads the same chrome the Event panel ships."
+  [{:keys [file line]}]
+  (when (and (string? file) (seq file))
+    (cond-> file
+      line (str ":" line))))
+
 (defn- handler-source-block
   "Render the source-code block under the HANDLER header. Three
   cases:
@@ -810,18 +833,41 @@
        `edn/code-block` (clojure-syntax highlight).
     3. Otherwise — render a clear `<source not yet captured>`
        placeholder so the slot is always present (operator learns
-       where to look + when the substrate didn't stamp)."
+       where to look + when the substrate didn't stamp).
+
+  rf2-ehd8v — the `SOURCE` / `MACHINE SPEC` sub-header carries a
+  `file:line` chrome + `[open]` affordance when the handler's
+  registered meta carries `:file` / `:line`. The open-button reuses
+  `coord-chip` — the same click-to-source machinery the DISPATCH
+  source-label (rf2-80u5a) + the VIEWS row coord chip already ride.
+  When coord-annotation is unavailable (production builds, fn-form
+  registrations without `:file` meta) the chrome simply elides — no
+  broken / dead-link affordance."
   [flavour event-id]
   (let [machine? (= :reg-machine flavour)
         meta     (when (some? event-id)
                    (try (rf/handler-meta (if machine? :machine :event) event-id)
                         (catch :default _ nil)))
         spec     (when machine? (machine-spec-value meta))
-        src      (when-not machine? (handler-source-string meta))]
+        src      (when-not machine? (handler-source-string meta))
+        coord    (coord-from-handler-meta meta)
+        coord-display (source-coord-display coord)
+        header-trailing
+        (when coord-display
+          [:span {:data-testid "rf-xray-epoch-handler-source-coord"
+                  :style {:display     "inline-flex"
+                          :align-items "center"
+                          :gap         "0"}}
+           [:span {:data-testid "rf-xray-epoch-handler-source-coord-text"
+                   :title       coord-display
+                   :style {:color       (:text-tertiary tokens)
+                           :font-family mono-stack}}
+            coord-display]
+           (coord-chip coord "rf-xray-epoch-handler-source-open")])]
     [:div {:data-testid "rf-xray-epoch-handler-source"
            :style {:margin-top "8px"
                    :min-width  "0"}}
-     (sub-header (if machine? "machine spec" "source"))
+     (sub-header (if machine? "machine spec" "source") header-trailing)
      (cond
        (and machine? (some? spec))
        [:div {:data-testid "rf-xray-epoch-handler-source-spec"

--- a/tools/xray/src/day8/re_frame2_xray/theme/tokens.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/theme/tokens.cljc
@@ -124,7 +124,18 @@
    :yellow         "#d29922"
    :orange         "#FB923C"   ; functional amber — long-task / perf-slow tier
    :red            "#F87171"
-   :magenta        "#E879F9"
+   ;; Two pink/violet-family hues differentiated by hue, not just lightness
+   ;; (rf2-cgm4f). The original Epoch-panel mock split COEFFECT (violet
+   ;; #a855f7) and SUBSCRIPTIONS (pink #ec4899); pre-rf2-cgm4f both were
+   ;; collapsed onto the lighter fuchsia `#E879F9`, which made the two
+   ;; pipeline pills near-indistinguishable. Mike-ruled 2026-05-26: the
+   ;; visual-distinguishability win earns one new token. Other consumers
+   ;; (redacted sentinel chip, filter "out" mode, palette frame indicator,
+   ;; diff colour, static-routes/schemas letter chips, machine-inspector)
+   ;; read `:magenta` as the "exotic / categorical" hue — `#a855f7` reads
+   ;; the same role with marginally more purple saturation.
+   :magenta        "#a855f7"   ; violet-500 — Epoch COEFFECT mock; redacted sentinel
+   :magenta-pink   "#ec4899"   ; pink-500 — Epoch SUBSCRIPTIONS mock (rf2-cgm4f)
    :info           "#79c0ff"   ; cool categorical blue ≠ accent (Figma syntax-number)
 
    ;; ── syntax-highlighter palette (rf2-79ojx · One Dark / Calva default) ──
@@ -280,7 +291,13 @@
    :yellow         "#9a6700"
    :orange         "#C2570F"   ; functional amber — long-task / perf-slow tier
    :red            "#C84444"
-   :magenta        "#B146C2"
+   ;; Two pink/violet-family hues for the rf2-cgm4f Epoch-pill split — see
+   ;; the dark-palette `:magenta` / `:magenta-pink` block for rationale.
+   ;; Light values are darkness-shifted to clear WCAG AA on the white canvas
+   ;; while keeping the same hue family as the dark variants so a theme
+   ;; toggle preserves the semantic colour assignment.
+   :magenta        "#9333ea"   ; violet-600 — AA on white; mock #a855f7 hue family
+   :magenta-pink   "#db2777"   ; pink-600 — AA on white; mock #ec4899 hue family
    :info           "#0550ae"   ; cool categorical blue ≠ accent (Figma syntax-number)
 
    ;; ── syntax-highlighter palette (rf2-79ojx · One Light / Atom-One-Light) ──

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/badge_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/badge_cljs_test.cljc
@@ -41,6 +41,25 @@
     (is (= :orange (badge/token-key :FX)))
     (is (= :success (badge/token-key :VIEWS)))))
 
+(deftest coeffect-and-subscriptions-pull-distinct-tokens-test
+  ;; rf2-cgm4f — pre-fix both badges shared `:magenta`, so the
+  ;; pipeline pills were near-indistinguishable in the live panel.
+  ;; The 5 pipeline pills (DISPATCH / COEFFECT / HANDLER /
+  ;; SUBSCRIPTIONS / VIEWS) MUST map to 5 distinct theme tokens.
+  (testing "COEFFECT pulls a different token-key from SUBSCRIPTIONS"
+    (is (not= (badge/token-key :COEFFECT)
+              (badge/token-key :SUBSCRIPTIONS))
+        "COEFFECT and SUBSCRIPTIONS must be visually distinct"))
+  (testing "COEFFECT pulls :magenta (violet — mock #a855f7)"
+    (is (= :magenta (badge/token-key :COEFFECT))))
+  (testing "SUBSCRIPTIONS pulls :magenta-pink (pink — mock #ec4899)"
+    (is (= :magenta-pink (badge/token-key :SUBSCRIPTIONS))))
+  (testing "the five core pipeline pills carry five distinct token keys"
+    (let [core-pills #{:DISPATCH :COEFFECT :HANDLER :SUBSCRIPTIONS :VIEWS}
+          token-keys (set (map badge/token-key core-pills))]
+      (is (= 5 (count token-keys))
+          (str "expected 5 distinct token-keys, got " token-keys)))))
+
 (deftest fib-px-test
   (testing "fibonacci helper resolves to px strings"
     (is (= "3px"  (badge/fib-px :f3)))

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -791,3 +791,127 @@
 ;; see core/test/.../source_coords_test.clj) while the source-spec
 ;; lookup walks the `:machine` slot, so a tight machine-path coord test
 ;; would have to re-create both halves of that side-table dance.
+
+;; ---- rf2-8w8er (subsumes rf2-nszcv) — values route through edn-inspector
+
+(defn- mini-mounts
+  "Return every `[ei/mini ...]` hiccup mount under `tree`. Anchors on
+  the `:data-rf-mini` attribute the widget stamps onto every render."
+  [tree]
+  (th/find-all-by-attr tree :data-rf-mini "1"))
+
+(defn- ei-mounts
+  "Return every full-widget `[ei/edn-inspector ...]` mount under
+  `tree`. Anchors on the data-testid suffix the widget stamps onto
+  every render (`*-inspector` testid form)."
+  [tree]
+  (th/find-by-testid-prefix tree "rf-xray-edn-inspector"))
+
+(deftest dispatch-event-routes-through-edn-inspector-test
+  (testing "rf2-8w8er (subsumes rf2-nszcv) — DISPATCH event vector
+            renders through the canonical edn-inspector widget so the
+            event-id keyword + args paint with the canonical
+            syntax-token chrome (keyword magenta, number orange,
+            string green). Pre-fix the body was plain text via
+            `proj/event-display`."
+    (let [tree (view/render-dispatch-step
+                 {:step :dispatch :badge :DISPATCH :step-number 1
+                  :event [:counter/inc 7 "x"] :source :ui :coord nil})]
+      (is (pos? (count (ei-mounts tree)))
+          "the DISPATCH body mounts at least one edn-inspector widget"))))
+
+(deftest handler-db-diff-values-route-through-mini-test
+  (testing "rf2-8w8er — HANDLER step's :db diff rows render before /
+            after values through `ei/mini` so per-token chrome paints
+            (numbers orange, sentinels chip)."
+    (let [tree (view/render-handler-step
+                 {:step :handler :badge :HANDLER :step-number 3
+                  :flavour :reg-event-db :event-id :counter/inc
+                  :db-diff [[[:counter :value] 5 6 :modified]]
+                  :fx [] :machine nil})]
+      (is (pos? (count (mini-mounts tree)))
+          "the :db diff row mounts at least one mini-render"))))
+
+(deftest handler-fx-values-route-through-mini-test
+  (testing "rf2-8w8er — HANDLER step's :fx entries render the value
+            through `ei/mini`."
+    (let [tree (view/render-handler-step
+                 {:step :handler :badge :HANDLER :step-number 3
+                  :flavour :reg-event-fx :event-id :do/it
+                  :db-diff []
+                  :fx [{:fx-id :http/post :value {:url "/x" :body {:n 1}}}]
+                  :machine nil})
+          fx-row (th/find-by-testid tree "rf-xray-epoch-handler-fx-row-0")]
+      (is (some? fx-row))
+      (is (pos? (count (mini-mounts fx-row)))
+          "the fx value mounts a mini-render"))))
+
+(deftest fx-step-args-route-through-mini-test
+  (testing "rf2-8w8er — FX step row's args render through `ei/mini`."
+    (let [tree (view/render-fx-step
+                 {:step :fx :badge :FX :step-number 4
+                  :rows [{:fx-id :http/get :status :ok :args {:url "/x"}}]
+                  :succeeded 1 :threw 0 :skipped 0})
+          row  (th/find-by-testid tree "rf-xray-epoch-fx-row-0")]
+      (is (some? row))
+      (is (pos? (count (mini-mounts row)))
+          "the fx row's args mount a mini-render"))))
+
+(deftest subscriptions-values-route-through-mini-test
+  (testing "rf2-8w8er — SUBSCRIPTIONS row renders sub-vec + before /
+            after values through `ei/mini` so the table cells light
+            up with syntax-token chrome rather than plain `pr-str`."
+    (epoch-orchestrator/install!)
+    (frame/reg-frame :rf/xray {})
+    (rf/with-frame :rf/xray
+      (let [step {:step :subscriptions :badge :SUBSCRIPTIONS :step-number 5
+                  :rows [{:sub-id :counter/total :sub-vec [:counter/total]
+                          :inputs nil :changed? true :before 5 :after 6}]
+                  :changed 1 :unchanged 0}
+            tree (view/render-subscriptions-step step)
+            row  (th/find-by-testid tree "rf-xray-epoch-sub-row-0")]
+        (is (some? row))
+        ;; sub-vec + before + after = 3 minimum mini mounts in the row
+        (is (>= (count (mini-mounts row)) 3)
+            "row mounts ≥3 mini-renders (sub-vec + before + after)")))))
+
+(deftest views-subs-read-routes-through-mini-test
+  (testing "rf2-8w8er — VIEWS row's subs-read list renders each sub-id
+            through `ei/mini` so the consumed-subs column reads as
+            syntax-highlighted tokens rather than plain `pr-str`."
+    (let [step {:step :views :badge :VIEWS :step-number 6
+                :rows [{:view-id :app.counter/Counter
+                        :subs-read [[:counter/total] [:counter/threshold]]
+                        :duration-ms 1.2}]}
+          tree (view/render-views-step step)
+          subs (th/find-by-testid tree "rf-xray-epoch-view-row-subs-0")]
+      (is (some? subs))
+      ;; 2 consumed subs → 2 mini mounts
+      (is (>= (count (mini-mounts subs)) 2)
+          "subs-read column mounts one mini per consumed sub"))))
+
+(deftest app-db-diff-values-route-through-mini-test
+  (testing "rf2-8w8er — APP-DB DIFF rows render before / after through
+            `ei/mini` so per-token chrome paints consistently with the
+            HANDLER :db diff."
+    (let [tree (view/render-app-db-diff-step
+                 {:step :app-db-diff :badge :APP-DB-DIFF :step-number 4
+                  :rows [{:path [:count] :before 0 :after 1 :change :modified}]
+                  :added 0 :modified 1 :removed 0})
+          row  (th/find-by-testid tree "rf-xray-epoch-app-db-diff-row-0")]
+      (is (some? row))
+      (is (>= (count (mini-mounts row)) 2)
+          "modified row mounts ≥2 mini-renders (before + after)"))))
+
+(deftest child-dispatches-event-routes-through-mini-test
+  (testing "rf2-8w8er — CHILD-DISPATCHES row renders the event vector
+            through `ei/mini`."
+    (let [step {:step :child-dispatches :badge :CHILD-DISPATCHES
+                :step-number 5
+                :rows [{:event [:other/x 1] :via :dispatch}]}
+          ctx  {:dispatch-id 1 :epoch-history []}
+          tree (view/render-child-dispatches-step step ctx)
+          ev   (th/find-by-testid tree "rf-xray-epoch-child-dispatch-event-0")]
+      (is (some? ev))
+      (is (pos? (count (mini-mounts ev)))
+          "the dispatched-event slot mounts a mini-render"))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -723,3 +723,71 @@
             "the code-block widget mounts under the source slot")
         (is (nil? (th/find-by-testid tree "rf-xray-epoch-handler-source-placeholder"))
             "no placeholder when source IS captured")))))
+
+;; ---- rf2-ehd8v — HANDLER source carries file:line + [open] ----------
+
+(deftest handler-source-renders-file-line-and-open-affordance-test
+  (testing "rf2-ehd8v — when the handler-meta carries :file + :line the
+            HANDLER source sub-header renders `file:line` text and a
+            clickable `[open]` button next to the SOURCE label.
+            Reuses the cross-panel coord-chip (same affordance Static
+            Handler + Event panels ship)."
+    (rf/with-frame :rf/default
+      (rf/reg-event-db :rf.test.epoch.view/ehd8v-srctest-handler
+                       {:rf.handler/source "(reg-event-db :rf.test.epoch.view/ehd8v-srctest-handler\n  (fn [db _] (update db :n inc)))"
+                        :file "src/app/counter.cljs"
+                        :line 42}
+                       (fn [db _] db))
+      (let [step {:step :handler :badge :HANDLER :step-number 3
+                  :flavour :reg-event-db
+                  :event-id :rf.test.epoch.view/ehd8v-srctest-handler
+                  :db-diff [] :fx [] :machine nil}
+            tree (view/render-handler-step step)
+            coord (th/find-by-testid tree "rf-xray-epoch-handler-source-coord")
+            text  (th/find-by-testid tree "rf-xray-epoch-handler-source-coord-text")
+            open  (th/find-by-testid tree "rf-xray-epoch-handler-source-open")]
+        (is (some? coord)
+            "the source-coord chrome row is present alongside the label")
+        (is (some? text)
+            "the file:line text element is present")
+        (is (string/includes? (or (th/text-content text) "") "src/app/counter.cljs")
+            "the file path appears in the text")
+        (is (string/includes? (or (th/text-content text) "") "42")
+            "the line number appears in the text")
+        (is (some? open)
+            "the [open] coord-chip is present when :file is captured")
+        (is (= :button (first open))
+            "the open affordance is a real button (clickable)")
+        (is (fn? (:on-click (second open)))
+            "the open button has a click handler")))))
+
+(deftest handler-source-elides-affordance-when-coord-absent-test
+  (testing "rf2-ehd8v — when no handler-meta is registered for the
+            event-id (unregistered handler, production builds with
+            goog.DEBUG=false where source-coords elide), the
+            file:line text + [open] button simply do not render. No
+            broken / dead-link affordance.
+
+            Reg-event-* macros automatically stamp :file/:line at
+            expansion time, so the empty-coord state is most cleanly
+            reproduced by pointing at an event-id with no registered
+            handler at all."
+    (rf/with-frame :rf/default
+      (let [step {:step :handler :badge :HANDLER :step-number 3
+                  :flavour :reg-event-db
+                  :event-id :rf.test.epoch.view/ehd8v-never-registered
+                  :db-diff [] :fx [] :machine nil}
+            tree (view/render-handler-step step)]
+        (is (nil? (th/find-by-testid tree "rf-xray-epoch-handler-source-coord"))
+            "no coord-row when :file meta is absent")
+        (is (nil? (th/find-by-testid tree "rf-xray-epoch-handler-source-open"))
+            "no [open] affordance without a coord")))))
+
+;; Machine-handler path is exercised by the rf2-66wis tests above; the
+;; coord-resolution is a shared helper (`coord-from-handler-meta`) so the
+;; event-handler test above pins the affordance shape, and the machine
+;; render-path inherits it without a separate test. Reg-machine stamps
+;; source coords under the `:event` kind (Spec 005 §Registration —
+;; see core/test/.../source_coords_test.clj) while the source-spec
+;; lookup walks the `:machine` slot, so a tight machine-path coord test
+;; would have to re-create both halves of that side-table dance.


### PR DESCRIPTION
Three Epoch-panel polish beads in order of smallest cleanup → biggest correctness fix.

## rf2-cgm4f — split COEFFECT / SUBSCRIPTIONS pill colours
P3 [bug]. Pre-fix both pills resolved through `:magenta` and rendered as the same fuchsia, leaving the 5 pipeline pills with only 4 distinct hues. Restored the original mock''s split: COEFFECT keeps `:magenta` (re-tuned to violet `#a855f7` / `#9333ea`), SUBSCRIPTIONS routes to a new `:magenta-pink` token (`#ec4899` / `#db2777`). Light + dark variants both AA on their canvases. Drift-gate-mirrored into `tools/machines-viz/`''s tokens.

## rf2-ehd8v — HANDLER source carries `file:line` + `[open]`
P2 [bug]. The HANDLER step rendered the source code (rf2-66wis) but exposed no `file:line` hint and no click-through to the editor — operators couldn''t answer "where is this handler defined?" without spec-walking. Added per design doc §Section 1. Reuses the cross-panel `coord-chip` widget (rf2-80u5a''s click-to-source machinery the DISPATCH source labels + VIEWS row coord chips already ship), so the affordance is consistent across the Xray shell. Elides cleanly when coord-annotation is unavailable (production builds, fn-form handlers).

## rf2-8w8er (subsumes rf2-nszcv) — route all values through edn-inspector
P1 [bug]. The Epoch panel was the lone Xray outlier rendering value-shaped data as plain `pr-str` text. Every other panel (App-DB, Handler, Trace, Machines, Issues, Routing) already routed through `edn-inspector` / `mini` — operators saw the SAME value styled differently in DIFFERENT panels of the same tool. Swept every value-shaped emit to the inspector:

- DISPATCH body → `ei/edn-inspector` (with `:site-id`, `:zoomable?`, `:card? false`)
- HANDLER step → `ei/mini` for :db-diff before/after, :fx values, machine transition states, after-timer states
- FLOW step → `ei/mini` for before/after
- FX step → `ei/mini` for row args
- SUBSCRIPTIONS step → `ei/mini` for sub-vec, input keywords, before/after value cells
- VIEWS step → `ei/mini` for each consumed sub
- SCHEMA VIOLATIONS step → `ei/mini` for the Malli explain map
- APP-DB DIFF step → `ei/mini` for added/removed/modified values
- CHILD DISPATCHES step → `ei/mini` for the dispatched event vector

Section labels + registered-handler IDs stay plain text — they''re hyperlink-styled references, not value-shaped data. Source code stays in `edn/code-block`.

## Test delta
+ 11 new tests (`tools/xray/test/.../epoch/view_cljs_test.cljs` × 9 +
  `tools/xray/test/.../epoch/badge_cljs_test.cljc` × 2). Test count
  4747 → 4758; assertion count 15353 → 15399. All gates green:
- `npm run test:cljs` — 0 failures
- `npm run test:browser` — 0 failures (124 tests / 353 assertions)
- `npm run test:bundle-isolation` — 16 entries / 33 sentinels absent / 3 budgets ok; 3 substrate bundles reagent-free where appropriate

## Notes on composition
The `ei/mini` swap was mechanical — every old `pr-str` arg flowed straight into the widget''s value slot, and the surrounding span coloring continues to work alongside the inspector''s syntax-token chrome. The `[ei/edn-inspector]` swap for DISPATCH composes cleanly with the surrounding `bg-3` boxed container (no card chrome conflict). The click-to-source machinery from rf2-80u5a composed without modification — `coord-chip` was already general over the source-coord shape, so dropping it next to the HANDLER source-header was a one-line addition.

Closes rf2-cgm4f, rf2-ehd8v, rf2-8w8er, rf2-nszcv (subsumed).