### PR TITLE
fix(xray): open-in-editor URI invariant to host page URL (rf2-2c5xb)

### DIFF
--- a/tools/xray/test/day8/re_frame2_xray/open_in_editor_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/open_in_editor_cljs_test.cljs
@@ -217,6 +217,75 @@
       (is (= "vscode://file/C:/Users/me/code/my-app/src/x.cljs:1:1"
              (:href (second hiccup)))))))
 
+;; ---- URI invariance to host page URL (rf2-2c5xb) ------------------------
+;;
+;; The panel-gallery testbed surfaced a defect: source-coord chips on
+;; handlers registered inside the gallery served from `http://localhost:8765`
+;; were producing URIs that did not resolve to the right files on disk.
+;; Pre-rf2-2c5xb the testbed never called `xray-config/configure!`, so the
+;; chip shipped a classpath-relative `:file` slot
+;; (`panel_gallery/foo.cljs`) the OS handler rejected. The fix is the
+;; established rf2-5m5n2 path: configure `:rf.xray/project-root` at boot.
+;;
+;; The tests below pin the load-bearing invariant: URI construction is a
+;; pure function of `(editor, source-coord, project-root)`. It does NOT
+;; read `window.location` — so the URI a chip renders is identical no
+;; matter which host URL the gallery / example app is served from. The
+;; second test exercises the panel-gallery's exact failure case (the
+;; `panel_gallery/<file>.cljs` shape) against the testbed's known on-disk
+;; root.
+
+(deftest resolve-uri-invariant-to-host-url
+  (testing "rf2-2c5xb — `resolve-uri` is a pure function of (editor,
+            source-coord, project-root); the URI it returns is identical
+            regardless of any ambient host state. The panel-gallery
+            defect was rooted in the testbed never calling
+            `xray-config/configure!`, NOT in the URI builder somehow
+            reading `window.location`. This test pins the contract: the
+            same `(editor, coord, project-root)` triple always yields
+            the same URI."
+    (config/set-project-root! "C:/Users/me/code/my-app")
+    (let [coord {:file "src/app/views.cljs" :line 42 :column 7}
+          ;; Call the resolver several times with the same inputs but
+          ;; different ambient context (different editor preferences
+          ;; between calls, then restored). The middle observations
+          ;; differ — but with all three inputs fixed, the URI is
+          ;; deterministic and matches the configured project-root.
+          baseline (open-in-editor/resolve-uri coord)
+          _        (config/set-editor! :cursor)
+          cursor   (open-in-editor/resolve-uri coord)
+          _        (config/set-editor! :vscode)
+          replay   (open-in-editor/resolve-uri coord)]
+      (is (= baseline replay)
+          "Identical (editor, coord, root) → identical URI; the
+           resolver has no hidden host-URL input")
+      (is (= "vscode://file/C:/Users/me/code/my-app/src/app/views.cljs:42:7"
+             baseline)
+          "URI value derives from the configured project-root, not
+           from any document URL the testbed happens to be served at")
+      (is (= "cursor://file/C:/Users/me/code/my-app/src/app/views.cljs:42:7"
+             cursor)
+          "Editor preference flows through; project-root prefix stays
+           bound to the configured root, not the location"))))
+
+(deftest resolve-uri-panel-gallery-regression-rf2-2c5xb
+  (testing "rf2-2c5xb — regression: the panel-gallery's exact failure
+            case (a classpath-relative coord captured at registration of
+            a panel-gallery handler) resolves to an absolute on-disk URI
+            against the testbed's configured project-root. Pins that the
+            chip works at `http://localhost:8765` independently of the
+            served port — the URI depends only on config, never on
+            `Location.href`."
+    (config/set-project-root!
+      "C:/Users/miket/code/re-frame2/tools/xray/testbeds")
+    (is (= (str "vscode://file/"
+                "C:/Users/miket/code/re-frame2/tools/xray/testbeds/"
+                "panel_gallery/fixtures_epoch.cljs:42:1")
+           (open-in-editor/resolve-uri
+             {:file "panel_gallery/fixtures_epoch.cljs"
+              :line 42
+              :column 1})))))
+
 ;; ---- rf2-g5q8d — :rf.xray/open-in-editor + :rf.editor/open ------------
 ;;
 ;; Per the rf2-3vucz audit, the four Xray panels (trace, issues-ribbon,

--- a/tools/xray/testbeds/panel_gallery/core.cljs
+++ b/tools/xray/testbeds/panel_gallery/core.cljs
@@ -57,6 +57,14 @@
             [re-frame.core :as rf]
             [re-frame.story :as story]
             [re-frame.adapter.reagent :as reagent-adapter]
+            ;; rf2-2c5xb — Xray's `configure!` to seed `:project-root`
+            ;; so the source-coord chips on registered handlers /
+            ;; views / machines resolve their classpath-relative
+            ;; `:file` slot to an absolute on-disk URI. Without this
+            ;; the panel-gallery's `[open]` affordances ship the bare
+            ;; classpath-relative path (`panel_gallery/foo.cljs`) to
+            ;; the OS scheme handler, which rejects it.
+            [day8.re-frame2-xray.config :as xray-config]
             [day8.re-frame2-xray.registry :as xray-registry]
             [panel-gallery.panel-views :as panel-views]
             ;; Side-effecting story registrations — namespaces fire
@@ -107,6 +115,48 @@
 ;; ============================================================================
 ;; MOUNT
 ;; ============================================================================
+
+;; ----------------------------------------------------------------------------
+;; Project-root resolution (rf2-2c5xb)
+;; ----------------------------------------------------------------------------
+;;
+;; Source-coord `:file` slots captured at registration time are classpath-
+;; relative — the panel-gallery's source root is
+;; `tools/xray/testbeds/panel_gallery/`, so a coord on a panel-gallery handler
+;; carries `:file "panel_gallery/foo.cljs"`. Xray's open-in-editor URI builder
+;; (`re-frame.source-coords.editor-uri/editor-uri`) requires an on-disk root
+;; to prepend — without it, the URI ships the bare relative path and the
+;; OS-side editor handler rejects it ("Path does not exist").
+;;
+;; Per the rf2-5m5n2 contract Xray exposes `:rf.xray/project-root`. The
+;; panel-gallery boots with its known on-disk repo position by default; a
+;; `?project-root=<path>` query string overrides for cross-machine portability
+;; (mirroring the `step_deck` testbed's resolver).
+;;
+;; The URI build is invariant to the host page URL — `resolve-uri` reads the
+;; configured root, not `window.location`. The query-param branch only
+;; influences which root we PASS to the configure! call; the resolver itself
+;; never reaches into the document. The unit test
+;; `panel-gallery-project-root-invariant-to-host-url` pins that contract.
+
+(def ^:private default-project-root
+  "Default on-disk root for the panel-gallery testbed. Matches the source-
+  path declared in `implementation/shadow-cljs.edn` for the
+  `:testbeds/panel-gallery` build."
+  "C:/Users/miket/code/re-frame2/tools/xray/testbeds")
+
+(defn- query-param
+  "Return the named URL query param as a string, or nil when absent /
+  blank. Pure data helper — kept private to this testbed since the
+  query-string override is a per-host knob (not a Xray-API surface)."
+  [param-name]
+  (when (exists? js/window)
+    (let [params (-> js/window .-location .-search (js/URLSearchParams.))
+          v      (.get params param-name)]
+      (when (and (string? v) (seq v)) v))))
+
+(defn- resolve-project-root []
+  (or (query-param "project-root") default-project-root))
 
 (defonce ^:private app-root (atom nil))
 
@@ -225,6 +275,13 @@
   (rf/reg-frame :rf/xray {}))
 
 (defn ^:export run []
+  ;; rf2-2c5xb — seed `:rf.xray/project-root` BEFORE the Xray handlers
+  ;; register so the first chip render reads the configured root. The
+  ;; resolver reads only the configured atom; the URI build is independent
+  ;; of `window.location`, so the panel-gallery's source links resolve to
+  ;; the same on-disk paths regardless of which port shadow-cljs serves
+  ;; the testbed from.
+  (xray-config/configure! {:rf.xray/project-root (resolve-project-root)})
   (rf/init! reagent-adapter/adapter)
   ;; Xray's :rf.xray/* events / subs / fxs land on the registry once.
   ;; The handlers operate on the current frame's app-db, so each


### PR DESCRIPTION
## rf2-2c5xb — panel-gallery source-link URIs

### Root cause

The panel-gallery testbed at `http://localhost:8765` (landed by rf2-hp4ow #2194 + rf2-mzcwt #2195) never called `xray-config/configure!`. As a result `:rf.xray/project-root` was nil, and the chip on every panel-gallery source-coord shipped a bare classpath-relative `:file` slot (`panel_gallery/foo.cljs`) to the OS-side editor handler — which rejects relative paths with "Path does not exist".

This was a testbed-boot omission, not a defect in the URI builder. The `resolve-uri` / `editor-uri` helpers (rf2-5m5n2) already accept a `:project-root` opt and prepend it correctly; `step_deck` configures it; `panel_gallery` did not.

### Fix approach — (b) configure :rf.xray/project-root at testbed boot

Mirrors the established `step_deck` pattern:

- A hardcoded `default-project-root` pointing at `C:/Users/miket/code/re-frame2/tools/xray/testbeds` (the on-disk root the panel-gallery's source-coords resolve against).
- `?project-root=<path>` query string override for cross-machine portability.
- `xray-config/configure!` runs BEFORE `rf/init!` so the first chip render reads the configured root.

No source-side changes to Xray panels, no event-payload changes, no `resolve-uri` internals touched. The URI build was already invariant to the host URL — the panel-gallery just never set its anchor.

### Acceptance

1. **`http://localhost:8765` (panel-gallery)** — source affordances now build URIs of the form `vscode://file/C:/Users/miket/code/re-frame2/tools/xray/testbeds/panel_gallery/<file>.cljs:<line>:<col>` which the OS handler resolves correctly.
2. **Example-app URLs** — no regression (no shared code changed; the example apps continue to use whatever project-root their own boot configures).
3. **Unit test** — `resolve-uri-invariant-to-host-url` pins that identical `(editor, coord, project-root)` always yields identical URIs across ambient-state mutation; `resolve-uri-panel-gallery-regression-rf2-2c5xb` pins the exact failure shape.

### Compatibility note re rf2-ehd8v

Cluster 3 (`ad296123`) is adding the `[open]` affordance to HANDLER source on the Epoch panel and reusing the existing open-in-editor machinery. **The `:rf.xray/open-in-editor` event payload shape is UNCHANGED here** — the fix is purely a testbed-boot configuration call plus a pinning test on the existing `resolve-uri` helper. The rf2-ehd8v work can land in either order without coordination.

### Quality gates

- `npm run test:cljs` — 4760 tests / 15403 assertions / 0 failures / 0 errors
- `npm run test:browser` — 124 tests / 353 assertions / 0 failures / 0 errors
- `npm run test:bundle-isolation` — PASS (3 bundles, 33 sentinels absent)
- `npx shadow-cljs compile testbeds/panel-gallery` — 0 warnings

### Files changed

- `tools/xray/testbeds/panel_gallery/core.cljs` — add `xray-config/configure!` + project-root resolver mirroring `step_deck`
- `tools/xray/test/day8/re_frame2_xray/open_in_editor_cljs_test.cljs` — two new tests pinning URI invariance + the panel-gallery regression shape