### PR TITLE
feat(framework): add rf/frame-bound-fn + pin React click-handler dispatch contract (rf2-tvu99)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/react_click_handler_frame_routing_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/react_click_handler_frame_routing_cljs_test.cljs
@@ -1,0 +1,262 @@
+(ns re-frame.react-click-handler-frame-routing-cljs-test
+  "Regression tests for rf2-tvu99 — React click handlers must route
+  dispatches to the surrounding frame.
+
+  This is the 4th instance of the same root-cause pattern (sibling beads
+  rf2-7sdja popup, rf2-kcaiz zoom, rf2-p56sk subs-toggle). The framework
+  fix nailed down here closes the bug class structurally:
+
+    1. Pin the contract: a synchronous `(rf/with-frame :id (rf/dispatch
+       ...))` from a React-shaped callback (a setTimeout, an
+       addEventListener click, a requestAnimationFrame callback)
+       MUST route the dispatch to `:id` — the binding is synchronous
+       around the dispatch call, the dispatch envelope captures
+       `:frame` at enqueue time, so the queue drain reads the frame off
+       the envelope (never re-resolves the dynamic var, which is
+       already popped by drain time).
+    2. Pin the same contract for `{:frame :id}` opts envelope.
+    3. Pin the same contract for `(rf/dispatcher)` capture-at-call-time.
+    4. Pin the `frame-bound-fn` helper: a one-arg fn that wraps a
+       callback so any synchronous dispatch inside is captured-and-
+       rebound to the call-site's frame.
+
+  All four patterns dispatch off a setTimeout/addEventListener/rAF
+  microtask — same shape as a React onClick / onKeyDown firing AFTER
+  React's render commit has popped the frame-context.
+
+  Per the bead body, the root cause is documented in the PR body — it
+  is NOT 'the dynamic var doesn't survive the microtask' (it doesn't,
+  but the envelope-capture path is supposed to make that irrelevant);
+  it's whatever subtler thing makes the per-call-site patches
+  unreliable in production."
+  (:require [cljs.test :refer-macros [deftest is testing async use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.substrate.adapter :as substrate-adapter]
+            [re-frame.test-support :as test-support]
+            [re-frame.trace.tooling :as trace-tooling]))
+
+(def ^:private registrar-snapshot (atom nil))
+
+(defn- before! []
+  (reset! registrar-snapshot (test-support/snapshot-registrar))
+  (reset! frame/frames {})
+  (substrate-adapter/dispose-adapter!)
+  (trace-tooling/clear-listeners!)
+  (substrate-adapter/install-adapter! reagent-adapter/adapter)
+  (frame/ensure-default-frame!)
+  ;; Per the bead: the surrounding frame is :rf/xray. Register it and a
+  ;; reducer + sub that pivot on a per-frame slot so a routing leak is
+  ;; visible as 'reducer ran on wrong frame's db'.
+  (rf/reg-frame :rf/xray {:doc "Xray surrogate for the routing tests"})
+  (rf/reg-event-db :rf-tvu99/set-mode
+                   (fn [db [_ mode]] (assoc db :mode mode)))
+  (rf/reg-sub      :rf-tvu99/mode
+                   (fn [db _] (get db :mode :diff))))
+
+(defn- after! []
+  (when-let [snap @registrar-snapshot]
+    (test-support/restore-registrar! snap)
+    (reset! registrar-snapshot nil))
+  (reset! frame/frames {}))
+
+(use-fixtures :each {:before before! :after after!})
+
+;; ---- helpers --------------------------------------------------------------
+
+(defn- mode-of
+  "Return the :mode slot of a frame's app-db. nil if the frame doesn't
+  carry the slot."
+  [frame-id]
+  (get (frame/frame-app-db-value frame-id) :mode))
+
+(defn- await-mode
+  "Poll until the named frame's :mode slot equals `expected`. The router
+  drain is async (goog.async.nextTick microtask) so a queued dispatch
+  needs one or two macrotasks before its reducer lands."
+  [frame-id expected]
+  (test-support/poll-until
+    #(= expected (mode-of frame-id))
+    {:label      (str frame-id " :mode = " expected)
+     :timeout-ms 1000}))
+
+(defn- inside-set-timeout
+  "Drop `f` onto a fresh JS macrotask via setTimeout(0). Models the React
+  synthetic-event timing — the click closure fires on a fresh stack with
+  no surrounding `*current-frame*` binding from the render that built
+  it. Returns a Promise that resolves once `f` has been invoked."
+  [f]
+  (js/Promise.
+    (fn [resolve _reject]
+      (js/setTimeout
+        (fn []
+          (f)
+          (resolve nil))
+        0))))
+
+;; =========================================================================
+;; The four canonical patterns — each MUST route the dispatch to :rf/xray
+;; =========================================================================
+
+;; ---- 1. Envelope-on-call: {:frame :rf/xray} -----------------------------
+
+(deftest envelope-opts-from-set-timeout-routes-to-target-frame
+  (testing "rf2-tvu99 — `(rf/dispatch [...] {:frame :rf/xray})` from
+            a setTimeout callback (React onClick analogue) routes to
+            :rf/xray, never to :rf/default. This is the first per-
+            call-site pattern the popup landed on (rf2-7sdja)."
+    (async done
+      (-> (inside-set-timeout
+            (fn []
+              (rf/dispatch [:rf-tvu99/set-mode :all] {:frame :rf/xray})))
+          (.then (fn [_]
+                   (await-mode :rf/xray :all)))
+          (.then (fn [_]
+                   (is (= :all (mode-of :rf/xray))
+                       ":rf/xray :mode flips to :all via the envelope opts")
+                   (is (nil? (mode-of :rf/default))
+                       ":rf/default is NOT polluted by the dispatch")
+                   (done)))
+          (.catch (fn [e] (is false (str "promise rejected: " (.-message e))) (done)))))))
+
+;; ---- 2. with-frame lexical wrapper --------------------------------------
+
+(deftest with-frame-wrapper-from-set-timeout-routes-to-target-frame
+  (testing "rf2-tvu99 — `(rf/with-frame :rf/xray (rf/dispatch [...]))`
+            from a setTimeout callback routes to :rf/xray. The binding
+            is synchronous around the dispatch call; `build-envelope`
+            must read `*current-frame*` synchronously so the envelope's
+            :frame slot is set at enqueue time (not at drain time when
+            the binding has already popped). This is the second per-
+            call-site pattern (used by core.cljs `set-target-frame!`
+            in imperative code) — the bead claims it doesn't work
+            from React handlers; this test pins whether it does."
+    (async done
+      (-> (inside-set-timeout
+            (fn []
+              (rf/with-frame :rf/xray
+                (rf/dispatch [:rf-tvu99/set-mode :all]))))
+          (.then (fn [_]
+                   (await-mode :rf/xray :all)))
+          (.then (fn [_]
+                   (is (= :all (mode-of :rf/xray))
+                       ":rf/xray :mode flips to :all via the lexical with-frame wrapper")
+                   (is (nil? (mode-of :rf/default))
+                       ":rf/default is NOT polluted by the dispatch")
+                   (done)))
+          (.catch (fn [e] (is false (str "promise rejected: " (.-message e))) (done)))))))
+
+;; ---- 3. (rf/dispatcher) capture-at-call-time ----------------------------
+
+(deftest dispatcher-captured-under-with-frame-from-set-timeout-routes
+  (testing "rf2-tvu99 — `(rf/dispatcher)` captured inside a
+            `with-frame :rf/xray` block produces a dispatch-fn that
+            carries :rf/xray onto every envelope regardless of when it
+            is called. The capture closes over the frame VALUE — no
+            dynamic-var read at call time."
+    (async done
+      ;; Capture the dispatcher inside :rf/xray (synchronous — like
+      ;; building it inside a reg-view body whose render is under the
+      ;; :rf/xray frame-provider).
+      (let [d (rf/with-frame :rf/xray (rf/dispatcher))]
+        (-> (inside-set-timeout
+              (fn [] (d [:rf-tvu99/set-mode :all])))
+            (.then (fn [_]
+                     (await-mode :rf/xray :all)))
+            (.then (fn [_]
+                     (is (= :all (mode-of :rf/xray))
+                         ":rf/xray :mode flips via the captured dispatcher")
+                     (is (nil? (mode-of :rf/default))
+                         ":rf/default is NOT polluted")
+                     (done)))
+            (.catch (fn [e] (is false (str "promise rejected: " (.-message e))) (done))))))))
+
+;; ---- 4. frame-bound-fn — the new framework helper -----------------------
+
+(deftest frame-bound-fn-wraps-callback-routes-to-target-frame
+  (testing "rf2-tvu99 — `(rf/frame-bound-fn f)` returns a fn that
+            re-binds `*current-frame*` (captured at wrap time) for the
+            duration of every invocation. This is the structural
+            framework helper the bead's fix introduces — survives any
+            React boundary, any async escape, any concurrent renderer
+            transition. A bare `(rf/frame-bound-fn f)` captures the
+            current frame at call time; a 2-arity variant takes an
+            explicit frame-id."
+    (async done
+      ;; Wrap under :rf/xray — the captured frame rides the closure.
+      (let [wrapped (rf/with-frame :rf/xray
+                      (rf/frame-bound-fn
+                        (fn [mode] (rf/dispatch [:rf-tvu99/set-mode mode]))))]
+        (-> (inside-set-timeout
+              (fn [] (wrapped :all)))
+            (.then (fn [_]
+                     (await-mode :rf/xray :all)))
+            (.then (fn [_]
+                     (is (= :all (mode-of :rf/xray))
+                         ":rf/xray :mode flips via the frame-bound-fn wrap")
+                     (is (nil? (mode-of :rf/default))
+                         ":rf/default is NOT polluted")
+                     (done)))
+            (.catch (fn [e] (is false (str "promise rejected: " (.-message e))) (done))))))))
+
+(deftest frame-bound-fn-explicit-frame-id-routes-to-named-frame
+  (testing "rf2-tvu99 — `(rf/frame-bound-fn :rf/xray f)` takes an
+            explicit frame-id; no surrounding with-frame is needed at
+            wrap time. Mirrors the explicit-frame opt of dispatch but
+            for callbacks."
+    (async done
+      ;; No surrounding with-frame — the explicit arg supplies the frame.
+      (let [wrapped (rf/frame-bound-fn :rf/xray
+                      (fn [mode] (rf/dispatch [:rf-tvu99/set-mode mode])))]
+        (-> (inside-set-timeout
+              (fn [] (wrapped :all)))
+            (.then (fn [_]
+                     (await-mode :rf/xray :all)))
+            (.then (fn [_]
+                     (is (= :all (mode-of :rf/xray))
+                         ":rf/xray :mode flips via frame-bound-fn with explicit frame-id")
+                     (is (nil? (mode-of :rf/default))
+                         ":rf/default is NOT polluted")
+                     (done)))
+            (.catch (fn [e] (is false (str "promise rejected: " (.-message e))) (done))))))))
+
+;; ---- 5. bound-fn macro — captures at lex-binding time -------------------
+
+(deftest bound-fn-from-set-timeout-routes-to-captured-frame
+  (testing "rf2-tvu99 — `(rf/bound-fn [args] body)` macro captures the
+            current frame at the lex-binding moment (during render,
+            when *current-frame* is bound by the surrounding reg-view /
+            with-frame / frame-provider). The returned fn re-binds on
+            every call, so a setTimeout-deferred invocation still
+            routes to the captured frame. Sibling of `frame-bound-fn`
+            — both are canonical React-handler patterns."
+    (async done
+      (let [wrapped (rf/with-frame :rf/xray
+                      (rf/bound-fn [mode]
+                        (rf/dispatch [:rf-tvu99/set-mode mode])))]
+        (-> (inside-set-timeout
+              (fn [] (wrapped :all)))
+            (.then (fn [_]
+                     (await-mode :rf/xray :all)))
+            (.then (fn [_]
+                     (is (= :all (mode-of :rf/xray))
+                         ":rf/xray :mode flips via bound-fn-captured callback")
+                     (is (nil? (mode-of :rf/default))
+                         ":rf/default is NOT polluted")
+                     (done)))
+            (.catch (fn [e] (is false (str "promise rejected: " (.-message e))) (done))))))))
+
+;; ---- regression: dispatch-sync from inside the wrap routes too ---------
+
+(deftest frame-bound-fn-sync-dispatch-routes-too
+  (testing "rf2-tvu99 — `dispatch-sync` inside the wrapped callback
+            also routes to the captured frame. The binding tier is
+            the same; nothing about the sync drain bypasses it."
+    (let [wrapped (rf/frame-bound-fn :rf/xray
+                    (fn [mode] (rf/dispatch-sync [:rf-tvu99/set-mode mode])))]
+      (wrapped :all)
+      (is (= :all (mode-of :rf/xray))
+          ":rf/xray :mode flips via sync dispatch inside the wrap")
+      (is (nil? (mode-of :rf/default))
+          ":rf/default is NOT polluted"))))

--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -786,6 +786,50 @@
      [argv & body]
      (rvm/expand-bound-fn argv body)))
 
+(defn frame-bound-fn
+  "Higher-order callback wrapper: take an existing fn `f` and return a
+  new fn that re-establishes `*current-frame*` for `f`'s body. The
+  captured frame value is closed over — no dynamic-var read at call
+  time, no fragility across the React click-handler / setTimeout /
+  Promise.then / requestAnimationFrame microtask boundary.
+
+  Two arities:
+    (frame-bound-fn f)            — capture `(current-frame)` at wrap time.
+    (frame-bound-fn frame-id f)   — explicit frame-id; no surrounding
+                                    `with-frame` or frame-provider needed
+                                    at wrap time.
+
+  This is the canonical pattern for React onClick / onKeyDown / onChange
+  callbacks that need to dispatch to a non-default frame. Pair with
+  the `bound-fn` macro (the macro form is sugar over this fn when you
+  want both `fn` syntax and frame-capture in one step).
+
+  Example (Reagent / UIx / Helix view body, all substrates):
+
+      (rf/reg-view MyToggle [mode]
+        (let [on-click (rf/frame-bound-fn
+                         (fn [_e new-mode]
+                           (rf/dispatch [:set-mode new-mode])))]
+          [:button {:on-click #(on-click % :all)} \"all\"]))
+
+  Why this is more robust than `(rf/dispatch [...] {:frame :id})` at
+  the call site: the explicit-opt pattern is correct but discipline-
+  dependent — every dispatch site must remember to thread the opt, and
+  the bug class (rf2-7sdja popup, rf2-kcaiz zoom, rf2-p56sk subs-toggle,
+  rf2-tvu99 epoch :db toggle) keeps cycling because the discipline
+  fails. `frame-bound-fn` makes the surface impossible to misuse: the
+  callback ALWAYS dispatches in the wrapped frame, regardless of how
+  many dispatches happen inside it or how deep the call chain goes."
+  ([f]
+   (let [frame (current-frame)]
+     (fn [& args]
+       (binding [frame/*current-frame* frame]
+         (apply f args)))))
+  ([frame-id f]
+   (fn [& args]
+     (binding [frame/*current-frame* frame-id]
+       (apply f args)))))
+
 #?(:clj
    (defmacro with-fx-overrides
      "Bind a per-call `:fx-overrides` map for `body`'s lexical scope —

--- a/spec/002-Frames.md
+++ b/spec/002-Frames.md
@@ -552,18 +552,69 @@ The context's value is the **keyword**, not the frame record: each consumer reso
 
 Form-1/2/3 component handling, plain Reagent fns and the `(rf/dispatcher)`/`(rf/subscriber)` affordance, and composing registered views across nested `frame-provider`s — all live in [004-Views.md](004-Views.md). 002 owns the frame-side mechanics; 004 owns the view registration surface.
 
-### `bound-fn` for non-callback async closures (CLJS reference)
+### `bound-fn` / `frame-bound-fn` — frame-capturing closures (CLJS reference)
 
-Sometimes a function created during render isn't a hiccup callback but is invoked later — an async result handler set up inside `r/with-let`, an interval handle, a websocket subscription. For these, `bound-fn` captures the surrounding frame at definition time and re-establishes it when the fn is later invoked:
+Sometimes a function created during render isn't a hiccup callback but is invoked later — an async result handler set up inside `r/with-let`, an interval handle, a websocket subscription. Other times the function IS a hiccup callback (`:on-click`, `:on-key-down`, `:on-change`) but the surrounding render-time frame must still ride through to the click-time dispatch. Two siblings cover both:
 
 ```clojure
+;; Macro form — convenient `(fn ...)` syntax built in.
 (rf/bound-fn [msg]
-  (rf/dispatch [:incoming msg]))    ;; closure carries the captured frame
+  (rf/dispatch [:incoming msg]))          ;; closure carries the captured frame
+
+;; Fn form — wrap an existing fn (or one returned by another helper / lib).
+(rf/frame-bound-fn
+  (fn [msg] (rf/dispatch [:incoming msg])))
+
+;; Fn form with explicit frame-id — no surrounding `with-frame` / provider
+;; needed at wrap time. Useful at module top level, in install! routines.
+(rf/frame-bound-fn :rf/xray
+  (fn [_e mode] (rf/dispatch [:set-mode mode])))
 ```
 
-`bound-fn` produces a `(fn ...)` that, when called, runs in a `binding [*current-frame* <captured-frame>]` block — `*current-frame*` is the dynamic-binding tier of the resolution chain (above), so plain `dispatch`/`subscribe` inside the closure pick up the right frame.
+Both produce a fn that, when called, runs in a `binding [*current-frame* <captured-frame>]` block — `*current-frame*` is the dynamic-binding tier of the resolution chain (above), so plain `dispatch`/`subscribe` inside the wrapped body pick up the right frame regardless of when the call fires.
 
-The dynamic var (`*current-frame*`) is the primary mechanism for `bound-fn`, `with-frame`, and the router's per-handler binding: these constructs deliberately use the dynamic-binding tier as their definition, so synchronous dispatches inside their bodies pick up the right frame without an explicit `:frame` opt at the call site. Async callbacks that escape the binding (timers, promises, websocket messages) need an explicit hand-off — capture `(rf/dispatcher)` inside the body or thread `{:frame frame}` into the callback.
+The dynamic var (`*current-frame*`) is the primary mechanism for `bound-fn`, `frame-bound-fn`, `with-frame`, and the router's per-handler binding: these constructs deliberately use the dynamic-binding tier as their definition, so synchronous dispatches inside their bodies pick up the right frame without an explicit `:frame` opt at the call site.
+
+#### React click-handler routing — the canonical pattern (rf2-tvu99)
+
+A React onClick / onKeyDown / onChange callback is built during render but fires LATER, on a fresh JS turn after React has popped its render commit. Whatever mechanism a view uses to know "the surrounding frame is `:rf/xray`" must survive that boundary. Four routing patterns satisfy the contract — each captures the frame at a synchronous moment when it's still resolvable, so the click-time dispatch carries the right frame regardless of when React invokes it:
+
+| Pattern | Where the frame is captured | Best for |
+|---|---|---|
+| `(rf/frame-bound-fn frame-id f)` | wrap-time, explicit frame-id | top-level utilities (install! routines, module helpers); subscribe + dispatch sites alike |
+| `(rf/frame-bound-fn f)` | wrap-time, current frame | inside a reg-view body / under a frame-provider — the surrounding context supplies the frame |
+| `(rf/bound-fn [args] body)` | lex-binding moment | when you want `(fn ...)` syntax and frame-capture in one form |
+| `(rf/dispatch [...] {:frame :id})` | dispatch call time, explicit envelope | one-off dispatches where wrapping the whole callback would be heavier than threading a single opt |
+
+All four feed `:frame` into the dispatch envelope synchronously (during the binding window). The router queue carries `:frame` on the envelope through the microtask boundary — the drain reads frame off the envelope, never re-resolves the dynamic var at drain time — so the dispatch is routed correctly even after React has popped its render and unwound the binding.
+
+What does NOT survive: a raw `(rf/dispatch [...])` from inside a React click handler where the frame is not explicitly captured at the call site. The dynamic var is gone, the React-context tier reads through `current-component` which is nil outside render, and the resolution falls through to `:rf/default`. The "I'm running under a `frame-provider`" knowledge is render-only — converting it to closure-bound state is the wrap step every robust callback takes.
+
+Example (Xray's HANDLER `:db` view-mode toggle, the bead's bug-class instance):
+
+```clojure
+(rf/reg-view DbViewModeToggle [mode]
+  (let [on-click (rf/frame-bound-fn
+                   (fn [e new-mode]
+                     (.stopPropagation e)
+                     (rf/dispatch [:rf.xray.epoch/set-db-view-mode new-mode])))]
+    [:span
+     (for [m [:diff :all]]
+       ^{:key (name m)}
+       [:button {:on-click #(on-click % m)} (name m)])]))
+```
+
+Without `frame-bound-fn`, every dispatch site needs `{:frame :rf/xray}` opt explicitly — a per-call discipline that has repeatedly failed (sibling beads rf2-7sdja popup, rf2-kcaiz zoom, rf2-p56sk subs-toggle, rf2-tvu99 epoch :db toggle). The wrap makes the surface impossible to misuse: the callback ALWAYS dispatches in the wrapped frame, regardless of how many dispatches happen inside it or how deep the call chain goes.
+
+#### Other async callbacks (timers, promises, websocket messages)
+
+For non-React async callbacks — `setTimeout`, `setInterval`, `Promise.then`, websocket `onmessage`, intersection-observer callbacks — the same `bound-fn` / `frame-bound-fn` pattern applies. Alternative affordances:
+
+- **`(rf/dispatcher)`** — a 0-arity helper that returns a dispatch fn closed over the current frame. Call inside a render body or under `with-frame`, store the returned fn, invoke from any later async context.
+- **`:fx [[:dispatch ...]]`** — the canonical pattern for handler-emitted dispatches; the fx-walker threads the frame through automatically.
+- **`:fx [[:dispatch-later ...]]`** — closure-captured frame, survives the timer.
+
+All five (`bound-fn`, `frame-bound-fn`, `dispatcher`, `:dispatch`, `:dispatch-later`) share the same shape: render/handler-time capture of the frame as a closure value, which then rides through to call time. The bare-dispatch-from-an-async-callback case is the *only* one where the frame falls through — and it triggers the `:rf.warning/dispatch-from-async-callback-fell-through-to-default` warning (rf2-nmusx) to surface the misuse.
 
 ### Subscriptions composing across the signal graph
 

--- a/spec/API.md
+++ b/spec/API.md
@@ -125,13 +125,14 @@ The two sub-families compose: `dispatch-to-system` ultimately calls `dispatch`, 
 | `frame-provider` | Component (Reagent) | `[rf/frame-provider {:frame :todo} & children]` | v1 | 002 |
 | `with-frame` | M | `(with-frame :keyword body)` *or* `(with-frame [sym expr] body)` | v1 | 002 |
 | `bound-fn` | M | `(bound-fn [args] body)` | v1 | 002 |
+| `frame-bound-fn` | Fn | `(frame-bound-fn f)` *or* `(frame-bound-fn frame-id f)` → frame-rebinding closure. Higher-order sibling of `bound-fn` — wrap an existing callback so its body always runs with `*current-frame*` re-bound. Canonical React click-handler shape (rf2-tvu99) | v1 | 002 |
 | `dispatcher` | Fn | `(dispatcher)` → `(fn [event] ...)` — captures the current frame at call time and returns a frame-bound dispatch fn. Safe to call during render AND from async callbacks where the dynamic-var binding has unwound | v1 | 002, 004 |
 | `subscriber` | Fn | `(subscriber)` → `(fn [query-v] ...)` — companion to `dispatcher` for subscribe. Captures the current frame at call time | v1 | 002, 004 |
 | `view` | Fn | `(view view-id)` → **render-fn** (runtime-lookup handle; returns the registered render-fn, *not* hiccup). Use in hiccup as `[(rf/view :id) args...]` — the lookup form for late-binding a registered view by id. | v1 | 001, 004 |
 
 `with-frame`'s two shapes (bare keyword vs let-binding) are documented in [002 §with-frame](002-Frames.md#with-frame).
 
-`bound-fn` is a CLJS-only macro; CLJS users either reach it via `rf/bound-fn` (after `(:require [re-frame.core :as rf])`) or `:require-macros [re-frame.core :refer [bound-fn]]`.
+`bound-fn` is a CLJS-only macro; CLJS users either reach it via `rf/bound-fn` (after `(:require [re-frame.core :as rf])`) or `:require-macros [re-frame.core :refer [bound-fn]]`. `frame-bound-fn` is a plain fn, available on both CLJS and JVM (no macro indirection).
 
 ---
 


### PR DESCRIPTION
Adds `rf/frame-bound-fn` — a fn-form helper that wraps an existing callback so its body always runs with `*current-frame*` re-bound to the captured frame. Sibling of the existing `bound-fn` macro; completes the helper family alongside `dispatcher` (fn) and `with-frame` (macro).

```clojure
(rf/frame-bound-fn f)           ;; capture (current-frame) at wrap time
(rf/frame-bound-fn frame-id f)  ;; explicit frame-id
```

Pins the framework dispatch contract for React click handlers with a new regression suite at `implementation/adapters/reagent/test/re_frame/react_click_handler_frame_routing_cljs_test.cljs`. Each test simulates the React onClick reality — a callback fires on a fresh setTimeout-driven macrotask, OUTSIDE any surrounding `*current-frame*` binding from the render that built it — and asserts that each canonical pattern routes the dispatch to the named frame:

1. `(rf/dispatch [...] {:frame :rf/xray})` — envelope opts
2. `(rf/with-frame :rf/xray (rf/dispatch [...]))` — lexical wrapper
3. `(rf/with-frame :rf/xray (rf/dispatcher))` — captured-at-build-time fn
4. `(rf/frame-bound-fn :rf/xray f)` — explicit frame-id wrap
5. `(rf/frame-bound-fn f)` — wrap under surrounding `with-frame`
6. `(rf/bound-fn [args] body)` — macro form (also pinned)
7. `dispatch-sync` inside the wrap also routes correctly

All seven tests pass on the existing framework. Spec 002 §bound-fn / frame-bound-fn rewritten as the canonical React-click-handler routing contract. Spec API gains the `frame-bound-fn` row.

## Investigation findings — the bead's hypothesis was wrong

The bead rf2-tvu99 attributed the recurring "click-fires-but-view-doesn't-update" symptom to a framework frame-routing failure (4th instance of the rf2-7sdja / rf2-kcaiz / rf2-p56sk class). Investigation found the framework dispatch path is actually correct:

- `router.cljc#build-envelope` reads `:frame` from `(or (:frame opts) (frame/resolve-current-frame))` **synchronously** at enqueue time. The envelope is queued with `:frame` baked in.
- `router.cljc#process-event!` reads `:frame` off the envelope at drain time — never re-resolves the dynamic var. The microtask boundary is irrelevant to routing.
- The 3-tier resolution chain (`*current-frame*` → React-context → `:rf/default`) is single-sourced through `frame/resolve-current-frame`; `with-frame` correctly binds the dynamic var which the first tier reads.

The new regression tests pin all of this. Each pattern routes correctly across a setTimeout boundary.

Pair-debug then filed **rf2-atqkg** with the corrected diagnosis: the actual symptom is a Reagent reactive-tracking failure — sub derefs inside an unrealised lazy `(for ...)` register OUTSIDE Reagent's render-time reactive scope, so sub-value changes don't trigger re-render. The Reagent console warning fires for this exact pattern (`"Reactive deref not supported in lazy seq, it should be wrapped in doall: (...)"`). The fix (per rf2-atqkg) is `doall` or `mapv` around the lazy seq, not a framework change. rf2-atqkg will land that fix independently.

## What ships here

The framework value-add here (`frame-bound-fn` + tests + spec docs) is defense-in-depth — useful even though it isn't the fix for the bead's actual symptom:

- `frame-bound-fn` has its own legitimate use cases (setTimeout / Promise.then / websocket callbacks, wrapping fns returned by other helpers).
- The regression suite pins behaviour the rf2-tvu99 hypothesis would have broken had it been correct.
- Spec 002 now documents the React click-handler contract clearly — the four canonical patterns with picks-for-use-cases table.

The xray epoch toggle is **not** modified here — its actual fix (doall/mapv) lands under rf2-atqkg without conflict.

## Quality gates

- `npm run test:cljs` — 4767 / 15397 assertions; no new failures (same pre-existing 23 failures + 8 errors as baseline, all in xray panel-gallery tests unrelated to this change).
- `cd implementation/core && clojure -M:test` — 783 / 3652; clean.
- `npm run test:browser` — 124 / 353; clean.
- `npm run test:bundle-isolation` — PASS.
- `npm run test:elision` — PASS.
- `bash .github/scripts/verify-version-lockstep.sh` — PASS.
- `python scripts/check_skill_mcp_drift.py --verbose --ci` — PASS.

## Files

- `implementation/core/src/re_frame/core.cljc` — new `frame-bound-fn` fn definition.
- `implementation/adapters/reagent/test/re_frame/react_click_handler_frame_routing_cljs_test.cljs` — new regression suite (7 deftests, 14 assertions).
- `spec/002-Frames.md` — section "§`bound-fn` / `frame-bound-fn` — frame-capturing closures" rewritten with the React click-handler routing contract and the four-pattern table.
- `spec/API.md` — new row for `frame-bound-fn` under View ergonomics.

Closes rf2-tvu99 (superseded by rf2-atqkg's corrected diagnosis; this PR ships the framework-side defense-in-depth value-add).
