### PR TITLE
fix(xray): cancellation-cascade reads canonical :rf.trace/dispatch-id (rf2-kducz)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/cancellation_cascade_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/cancellation_cascade_helpers.cljc
@@ -225,7 +225,7 @@
      :actor-id       (or (:actor-id tags) (:machine-id tags) (:spawned-id tags))
      :correlation-id (or (:request-id tags) (:correlation-id tags))
      :trace-id       (:id ev)
-     :dispatch-id    (:dispatch-id tags)}))
+     :dispatch-id    (:rf.trace/dispatch-id tags)}))
 
 (defn- teardown-row
   "Build one child-teardown row from a destroy trace event."
@@ -240,7 +240,7 @@
      :last-state     (:last-state tags)
      :inflight-count nil  ;; populated downstream from the gathered aborts
      :trace-id       (:id ev)
-     :dispatch-id    (:dispatch-id tags)}))
+     :dispatch-id    (:rf.trace/dispatch-id tags)}))
 
 (defn- decision-row
   "Build the parent-decision row from a `:rf.event/dispatched` trace

--- a/tools/xray/test/day8/re_frame2_xray/panels/cancellation_cascade_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/cancellation_cascade_helpers_cljs_test.cljc
@@ -200,6 +200,59 @@
       (is (= :actor-destroyed (-> c :effect-aborts first :cancel-cause)))
       (is (= 20 (:total-elapsed-ms c))))))
 
+;; ---- (2) extract-cascade: dispatch-id projection (rf2-kducz) ----------
+
+(deftest extract-projects-canonical-dispatch-id-onto-rows
+  (testing "row projection lifts :rf.trace/dispatch-id (the canonical
+            substrate tag) into the row's :dispatch-id slot — guards
+            against the rf2-kducz regression where rows read the bare
+            `:dispatch-id` tag (always nil) and grouping silently
+            degraded to the wall-clock heuristic"
+    (let [buf [(dispatched-ev [:auth/logout]
+                              {:dispatch-id 42 :time 1000 :id 1})
+               (destroy-ev {:machine-id :user-session
+                            :dispatch-id 42 :time 1010 :id 2})
+               (http-abort-ev {:request-id :req-1
+                               :actor-id :user-session
+                               :dispatch-id 42
+                               :time 1020 :id 3})]
+          c   (h/extract-cascade buf)]
+      (testing "decision row carries the canonical dispatch-id"
+        (is (= 42 (-> c :parent-decision :dispatch-id))))
+      (testing "teardown row carries the canonical dispatch-id"
+        (is (= 1 (count (:child-teardowns c))))
+        (is (= 42 (-> c :child-teardowns first :dispatch-id))))
+      (testing "abort row carries the canonical dispatch-id"
+        (is (= 1 (count (:effect-aborts c))))
+        (is (= 42 (-> c :effect-aborts first :dispatch-id)))))))
+
+(deftest extract-ignores-non-canonical-dispatch-id-tag
+  (testing "an abort whose ONLY dispatch-id slot is the bare (non-canonical)
+            `:dispatch-id` key MUST NOT correlate by dispatch-id —
+            the substrate emits the canonical `:rf.trace/dispatch-id`
+            and the reader must not accept the bare key as a fallback
+            (otherwise drift between substrate and consumer is masked).
+            Such an abort can still ride along via the wall-clock window."
+    (let [anchor (destroy-ev {:machine-id :user-session :dispatch-id 7
+                              :time 1000 :id 1})
+          ;; Build an abort whose canonical tag is missing but a bare
+          ;; `:dispatch-id` tag matches the anchor. The reader must
+          ;; project nil — not 7 — into the abort row's :dispatch-id.
+          abort  (-> (http-abort-ev {:request-id :r1
+                                     :actor-id :user-session
+                                     :time 1010 :id 2})
+                     (update :tags dissoc :rf.trace/dispatch-id)
+                     (assoc-in [:tags :dispatch-id] 7))
+          c      (h/extract-cascade [anchor abort])
+          row    (first (:effect-aborts c))]
+      ;; The abort still rides via the wall-clock fallback, but its
+      ;; projected :dispatch-id reflects the CANONICAL tag (absent
+      ;; here), not the bare key.
+      (is (some? row) "abort gathered via wall-clock proximity")
+      (is (nil? (:dispatch-id row))
+          "row :dispatch-id is nil because the canonical tag is absent
+           — the reader must not silently accept the bare `:dispatch-id`"))))
+
 ;; ---- (2) extract-cascade: many aborts ----------------------------------
 
 (deftest extract-many-aborts-sorted
@@ -342,7 +395,7 @@
                ;; missing from tags; proximity gathers it.
                (-> (http-abort-ev {:request-id :r1 :actor-id :user-session
                                    :time 1015 :id 2})
-                   (update :tags dissoc :dispatch-id))]
+                   (update :tags dissoc :rf.trace/dispatch-id))]
           c   (h/extract-cascade buf)]
       (is (= 1 (count (:effect-aborts c)))))))
 


### PR DESCRIPTION
## Defect (rf2-kducz)

`tools/xray/src/day8/re_frame2_xray/panels/cancellation_cascade_helpers.cljc` was reading the bare `:dispatch-id` tag at two row-projection call sites (`abort-row` L228, `teardown-row` L243). The substrate stamps the canonical `:rf.trace/dispatch-id` per Spec 009 §Dispatch correlation and `re-frame.router/dispatch-event`. Both reads returned nil for every real-substrate event; the projected `:dispatch-id` row field was silently nil, masking the deterministic-correlation primitive the visualiser advertises and degrading busy-frame grouping to the 100ms wall-clock heuristic.

## Defect class — third audit-confirmed projection-tag drift

Surfaced by the rf2-33cqr correctness audit (HIGH severity). Sibling beads on `panels/epoch/projection.cljc` (rf2-yhgk8 / slnce / ipaza / w2r4p) queue behind rf2-u69j7. Cross-checked against `panels/trace_helpers.cljc:691` which reads the canonical tag correctly — the bug is local drift, not a renaming.

## Fix scope

- `abort-row`: `(:dispatch-id tags)` → `(:rf.trace/dispatch-id tags)`
- `teardown-row`: `(:dispatch-id tags)` → `(:rf.trace/dispatch-id tags)`

Row schema keeps the bare `:dispatch-id` consumer-facing key (per the bead's allowance); only the **read off the trace tags** moves to canonical.

## Fixture-co-bug status

Searched `tools/xray/testbeds/panel_gallery/` and both cancellation-cascade test files. The cancellation-cascade fixtures (helpers test + panel cljs test) **already stamp** the canonical `:rf.trace/dispatch-id` on every event shape — no input-side fixture co-bug for this panel.

One silent test co-bug **was** present and is fixed: `extract-wall-clock-fallback` did `(update :tags dissoc :dispatch-id)` thinking it stripped the canonical tag — it was a no-op against canonical-shape input. Now correctly dissocs `:rf.trace/dispatch-id`.

(`panel_gallery/fixtures.cljs` stamps `:dispatch-id` for non-cancellation panels — out of scope here; those are other panels' surfaces.)

## Regression test coverage

Two new tests in `cancellation_cascade_helpers_cljs_test.cljc`:

1. **`extract-projects-canonical-dispatch-id-onto-rows`** — pins that decision-row, teardown-row, and abort-row all project the canonical-shape input's dispatch-id (`42`) into the row's `:dispatch-id` field. **Would have failed before this fix** (every row's `:dispatch-id` was nil).
2. **`extract-ignores-non-canonical-dispatch-id-tag`** — pins the reverse direction: an abort whose ONLY dispatch-id slot is the bare `:dispatch-id` key MUST NOT be projected as if it were canonical. Prevents the next drift event from being silently re-introduced through a permissive fallback read.

## Quality gates

- `npm run test:cljs` — cancellation-cascade tests pass (helpers: 28 tests / 80 assertions JVM; cljs panel: 13 tests / 30 assertions). Pre-existing failures on origin/main in `panels/epoch/*`, `badge_cljs_test`, and `registry_cljs_test` are untouched by this change (rf2-u69j7 + concurrent registry-snapshot drift territory).
- `npm run test:browser` — 124 / 0 failures.
- `npm run test:bundle-isolation` — green; tools/xray bundle still isolated.