### PR TITLE
feat(xray): Epoch machine-handler cascade — time-ordered + code-interleaved (rf2-u69j7)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1331,52 +1331,117 @@ colour resolver bails to `:text-tertiary` on an unknown badge so a
 future taxonomy extension paints something but tests catch the
 omission.
 
-### §9.1.5 Handler-type adaptation (rf2-82a0u prerequisites · rf2-9c27r full design)
+### §9.1.5 Handler-type adaptation (rf2-82a0u prerequisites · rf2-u69j7 cascade redesign)
 
 The HANDLER step's body adapts to the handler's flavour, discovered
 from the trace stream:
 
 - **`:reg-event-db`** — `:db` diff only (the simplest case).
 - **`:reg-event-fx`** — `:db` diff + per-fx-entry block.
-- **`:reg-machine`** — the full machine block per the rf2-9c27r
-  design doc, with all seven sub-sections (rf2-9c27r):
+- **`:reg-machine`** — **TIME-ORDERED MACHINE CASCADE** per rf2-u69j7.
 
-  1. **TRANSITION** — `before-state → after-state`, machine-id,
-     event vector, microstep count (one `:rf.machine/transition` per
-     macrostep — Spec 005 §Trace events).
-  2. **GUARDS** — per-guard row from `:rf.machine/guard-evaluated`:
-     guard-id + `:outcome` from the closed set `:pass / :fail /
-     :threw` (rf2-82a0u).
-  3. **LIFECYCLE** — phase-grouped rows from `:rf.machine/action-ran`
-     (rf2-82a0u — every emit carries `:phase` from the closed set
-     `:exit / :transition / :entry / :always / :after-action /
-     :initial-entry / :destroy-exit`). Each row carries action-id,
-     outcome, and **per-action fx attribution** when the action's
-     outcome map carried `:fx` — the operator reads `action X
-     emitted fx Y` inline (rf2-9c27r §7 folds the FX sub-section
-     into LIFECYCLE for compactness).
-  4. **AFTER TIMERS** — armed + cancelled rows with
-     `:rf.machine.timer/cancelled` `:reason` from the closed set
-     `:on-exit / :on-destroy / :on-resolution / :on-supersede /
-     :on-frame-destroy`.
-  5. **DATA REDUCTION** — `:data` before / after via
-     `edn/inspect-inline`. Source: the `:before / :after` snapshots
-     on `:rf.machine/transition`; the projection hoists `:data-before
-     / :data-after` from those maps. Elides when before == after.
-  6. **SNAPSHOT DIFF** — full snapshot before / after via
-     `edn/inspect-inline`. Source: same trace; renders the WHOLE
-     snapshot map (state vector + data map + parallel-region tags)
-     so the operator can drill into any slot. Elides when snapshots
-     are identical.
-  7. **FX** — per-action attribution folded into LIFECYCLE (above).
-     The HANDLER step's top-level `:fx` slot still surfaces the
-     handler's returned fx for completeness.
+#### Machine cascade (rf2-u69j7)
+
+**Stance.** The pre-rf2-u69j7 layout grouped machine activity into 7
+category sub-sections (TRANSITION / GUARDS / LIFECYCLE / AFTER-TIMERS
+/ DATA REDUCTION / SNAPSHOT DIFF / FX). That was a roll-up — the
+operator had to scroll up/down across categories to reconstruct what
+actually fired in what order. The redesign replaces the category-
+grouped layout with a single **time-ordered cascade view**: one row
+per substrate emit, ordered by the trace buffer's insertion order.
+
+**Order is the substrate's.** The substrate already emits in cascade
+order (guards → exit actions → transition → entry actions → always →
+after-action → timer-cancels — Spec 005 §Trace events + rf2-82a0u).
+The panel never re-sorts; it walks `:trace-events` and surfaces every
+member of `machine-cascade-trace-ops` as a row in the same order:
+
+  | Trace op                          | Row `:kind`     |
+  |-----------------------------------|------------------|
+  | `:rf.machine/guard-evaluated`     | `:guard`         |
+  | `:rf.machine/action-ran`          | `:action`        |
+  | `:rf.machine/transition`          | `:transition`    |
+  | `:rf.machine.timer/cancelled`     | `:timer`         |
+
+**Per-row chrome.** Each row carries:
+
+- **Step ordinal** (1..N) — left-rail compact monospace chip.
+- **Kind pill** — colour-coded (`:guard / :action / :transition /
+  :timer`) — see `badge.cljc` for the hue assignments.
+- **Phase chip** (`:action` rows only) — one of the rf2-82a0u closed
+  set `:exit / :transition / :entry / :always / :after-action /
+  :initial-entry / :destroy-exit`.
+- **Verb** — the action-id / guard-id / transition headline / timer
+  state, rendered as a click-to-source button when the machine spec's
+  `:rf.machine/source-coords` index (rf2-8bp3) carries a `{:file :line}`
+  for the row's spec-path. Falls back to a plain coloured span when
+  no coord was captured.
+- **Duration chip** — right-aligned monospace; paints long-step
+  warning chrome (`▲` + warning tone) when `:duration-ms` exceeds
+  `projection/long-step-threshold-ms` (16ms — one 60Hz frame).
+- **Outcome chip** — kind-specific:
+  - `:guard` → `✓ pass / ▲ fail / ✗ threw`
+  - `:action` → `✓ ok / ✗ threw`
+  - `:transition` → `N microstep(s)` (the headline)
+  - `:timer` → `· cancelled (<reason>)`
+
+**Per-row body — interleaved source code (always visible).** For
+`:action` and `:guard` rows the body renders the source form pulled
+from the registered machine spec (`(rf/handler-meta :machine
+event-id) → :rf/machine → [:actions <id>] | [:guards <id>]`) via
+`edn/code-block` (clojure-syntax highlight; same widget the HANDLER
+source block uses). Always visible by default per the bead body's
+"interleaved source code" requirement — the operator reads what ran
+AND its code at the same vertical position without expand/collapse
+gestures. Source-missing fallback renders a muted `<source not yet
+captured>` placeholder so the slot is consistently present.
+
+**Per-row outcome detail.** Action rows surface inline:
+
+- **`↳ data Δ`** — when the action returned a `:data` map, the delta
+  the action contributed (via `ei/mini`).
+- **`↳ fx`** — per-action fx-id chips for each effect the action
+  emitted (same data the FX step's `:attributed-to` chip surfaces,
+  now visible IN the action's row).
+- **`✗ threw`** — when the action threw, an error chip + exception
+  message.
+
+Transition rows surface the `state {:from} → {:to}` chrome with the
+event vector that drove the cascade. Timer rows surface only the
+header (no inline body — cancellations are housekeeping).
+
+**Empty-state correctness** (acceptance #4 — rf2-u69j7). A vanilla
+`reg-event-db` cascade (or any non-`:reg-machine` flavour) renders
+the existing pipeline UNCHANGED — the cascade view is gated on
+`:flavour = :reg-machine`. The redesign is machine-specific.
+
+**Why this lands cleanly.** The cascade view composes with existing
+Epoch infrastructure:
+
+- `proj/long-step-threshold-ms` (16ms — rf2-nqt3d) drives the per-row
+  duration chip's warning chrome.
+- `ei/mini` (rf2-8w8er) renders every CLJS value (data write, fx
+  args, state vectors) so the cascade syntax-tokens match the rest
+  of the panel.
+- The shared `coord-chip` affordance (rf2-80u5a / rf2-ehd8v) is the
+  source-link grammar; the cascade-row verb-link reuses the same
+  `:rf.xray/open-in-editor` dispatch.
+
+**The legacy category-grouped sub-sections are REPLACED, not
+augmented** (per Mike, pre-alpha posture). The full state-change
+story is now told inline by the cascade: transitions render their
+`from → to` snapshots; actions render their data-write + fx
+attribution + source body; no separate DATA REDUCTION / SNAPSHOT
+DIFF block lands. The FX section's per-action `:attributed-to`
+chip stays in place (the FX step is the post-commit lens; the
+cascade row is the action-attribution lens — same data, two
+surfaces).
 
 The flavour discriminator runs at projection time as a pure-data
 check against the trace stream — no spec read, no registry lookup,
 no replay. The substrate enhancements in #2155 (rf2-82a0u) are the
-prerequisite that lets the LIFECYCLE / TIMERS / DATA REDUCTION /
-SNAPSHOT DIFF sub-blocks read directly off the trace.
+prerequisite that lets every cascade row read directly off the
+trace.
 
 ### §9.1.6 Numbered cascade chrome
 
@@ -1456,6 +1521,7 @@ and silently rendered empty rows. The binding inventory:
 | `:dispatch` | `:rf.event/dispatched` | `:rf.event/v` (event vector — rf2-93a7s), `:source`, `:rf.trace/call-site` |
 | `:coeffect` | `:rf.cofx/run` (preferred) or `:rf.event/run-end` `:rf.event/coeffects` (fallback) | `:rf.cofx/id`, `:rf.cofx/value` — SYSTEM defaults `:db / :event / :frame / :source / :trace-id` are filtered (rf2-cq0ch). **Projection splits each surviving cofx into its own numbered step** (rf2-s1jw4 · pair-debug 2026-05-26): `cofx-steps` is a `mapv` over `cofx-rows` producing `{:step :coeffect :badge :COEFFECT :id <kw> :value <v>}` per entry, spliced into the steps vec before HANDLER. |
 | `:handler` source | `(rf/handler-meta :event id)` → `:rf.handler/source` (rf2-66wis · NOT a trace read — registrar meta) |
+| `:handler` machine cascade (rf2-u69j7) | `:rf.machine/guard-evaluated` · `:rf.machine/action-ran` · `:rf.machine/transition` · `:rf.machine.timer/cancelled` (closed set: `machine-cascade-trace-ops`) | guard rows read `:guard-id`, `:outcome` (closed set `:pass / :fail / :threw` — rf2-82a0u); action rows read `:action-id`, `:phase` (closed set `:exit / :transition / :entry / :always / :after-action / :initial-entry / :destroy-exit` — rf2-82a0u), `:outcome` (rich map; `:fx` + `:data` hoisted onto the row), `:input`, `:exception`; transition rows read `:machine-id`, `:event`, `:before`, `:after`, `:microsteps` (state vectors hoisted off `:before`/`:after`); timer rows read `:state`, `:delay`, `:reason` (closed set `:on-exit / :on-destroy / :on-resolution / :on-supersede / :on-frame-destroy` — rf2-82a0u). Source-coord lookup reads `(rf/handler-meta :machine id) → :rf/machine → :rf.machine/source-coords` (rf2-8bp3), keyed by `[:actions <id>] | [:guards <id>]`. |
 | `:flow` | `:rf.flow/recomputed` | `:rf.flow/id`, `:rf.flow/path`, `:rf.flow/before`, `:rf.flow/after` |
 | `:fx` | `:rf.fx/handled` / `:rf.fx/override-applied` / `:rf.fx/skipped-on-platform` | `:rf.fx/id`, `:rf.fx/args`, `:duration-ms` |
 | `:subscriptions` | `:rf.sub/run` / `:rf.sub/skip` | `:rf.sub/id`, `:rf.sub/query-v`, `:rf.sub/value-changed?`, `:rf.sub/prev-value`, `:rf.sub/value`, `:rf.sub/cascade?`, `:rf.sub/cause-sub`, `:rf.sub/elapsed-ms` (rf2-kfh1v aligned the reads against these) |

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/badge.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/badge.cljc
@@ -174,3 +174,170 @@
   (if-let [n (get fib k)]
     (str n "px")
     "0"))
+
+;; ---- Machine-cascade row badges (rf2-u69j7) -----------------------------
+;;
+;; The machine-cascade view (rf2-u69j7) renders one row per substrate
+;; emit (`:rf.machine/guard-evaluated`, `:rf.machine/action-ran`,
+;; `:rf.machine/transition`, `:rf.machine.timer/cancelled`). Each row
+;; carries a small badge — the row's KIND (`:guard / :action / :transition
+;; / :timer`) — and, for `:action` rows, a PHASE chip (one of the rf2-82a0u
+;; closed set: `:exit / :transition / :entry / :always / :after-action /
+;; :initial-entry / :destroy-exit`).
+;;
+;; The kind / phase chrome is intentionally muted — the row's source
+;; code body is the punchline; the chip exists to make scanning across
+;; rows for "which phase fired here?" possible without parsing the
+;; verb. Hue assignments:
+;;
+;;   :guard       — :text-tertiary (muted grey; guards are sentinels
+;;                                  the cascade reads BEFORE the
+;;                                  state change)
+;;   :action      — :accent (the same blue HANDLER pulls; actions ARE
+;;                           the handler's body)
+;;   :transition  — :magenta (the same hue COEFFECT pulls; transitions
+;;                            are state changes — the heart of the
+;;                            machine handler)
+;;   :timer       — :warning (after-timer cancellations ride at the
+;;                            warning tone — they're consequential
+;;                            but not errors)
+;;
+;; Phase chips (`:exit / :transition / :entry / :always / :after-action
+;; / :initial-entry / :destroy-exit`) ride at the muted `:text-tertiary`
+;; tone — they're refinement on the `:action` row's primary chrome.
+
+(def ^:private cascade-kind->token-key
+  "Map from machine-cascade row `:kind` keyword → theme-token keyword
+  (rf2-u69j7). The view's row-badge resolver reads off this table."
+  {:guard       :text-tertiary
+   :action      :accent
+   :transition  :magenta
+   :timer       :warning})
+
+(def ^:private cascade-kind->label
+  "Map from machine-cascade row `:kind` keyword → uppercase label
+  rendered in the row's kind chip (rf2-u69j7)."
+  {:guard       "GUARD"
+   :action      "ACTION"
+   :transition  "TRANSITION"
+   :timer       "TIMER"})
+
+(defn cascade-kind-token-key
+  "Theme-token keyword for a cascade row's `:kind` (rf2-u69j7). Falls
+  back to `:text-tertiary` for unknown kinds so the view always paints
+  something."
+  [kind]
+  (get cascade-kind->token-key kind :text-tertiary))
+
+(defn cascade-kind-colour
+  "CSS-variable string for a cascade row's `:kind` (rf2-u69j7)."
+  [kind]
+  (get tokens/tokens (cascade-kind-token-key kind)
+       (get tokens/tokens :text-tertiary)))
+
+(defn cascade-kind-label
+  "Uppercase label string for a cascade row's `:kind` (rf2-u69j7).
+  Falls back to `(str/upper-case (name kind))` for unknown kinds so
+  the cascade still paints text on a taxonomy extension."
+  [kind]
+  (or (get cascade-kind->label kind)
+      (when (keyword? kind) (str/upper-case (name kind)))
+      "?"))
+
+(def cascade-kind-set
+  "Closed set of cascade row kinds the view paints chrome for
+  (rf2-u69j7). New kinds extend the projection's
+  `machine-cascade-trace-ops` AND this set in lockstep."
+  #{:guard :action :transition :timer})
+
+(defn cascade-kind?
+  "Predicate — `kind` keyword is a member of `cascade-kind-set`."
+  [kind]
+  (contains? cascade-kind-set kind))
+
+;; ---- Action-phase chips (rf2-u69j7 + rf2-82a0u closed set) --------------
+
+(def ^:private cascade-phase->label
+  "Map from machine-cascade `:action` row's `:phase` keyword →
+  short label rendered in the per-row phase chip (rf2-u69j7).
+  Closed set per rf2-82a0u."
+  {:exit            "exit"
+   :transition      "transition"
+   :entry           "entry"
+   :always          "always"
+   :after-action    "after-action"
+   :initial-entry   "initial-entry"
+   :destroy-exit    "destroy-exit"})
+
+(defn cascade-phase-label
+  "Short label string for a cascade `:action` row's `:phase`
+  (rf2-u69j7). Pure-data; the view reads off this table for the
+  per-row phase chip."
+  [phase]
+  (or (get cascade-phase->label phase)
+      (when (keyword? phase) (name phase))
+      ""))
+
+(def cascade-phase-set
+  "Closed set of phases the substrate stamps on `:rf.machine/action-ran`
+  trace events (rf2-82a0u). Tests + the view's chip-rendering bail-out
+  read this set."
+  #{:exit :transition :entry :always
+    :after-action :initial-entry :destroy-exit})
+
+(defn cascade-phase?
+  "Predicate — `phase` keyword is a member of `cascade-phase-set`
+  (rf2-82a0u)."
+  [phase]
+  (contains? cascade-phase-set phase))
+
+;; ---- Outcome chip resolver (rf2-u69j7) ----------------------------------
+;;
+;; Each cascade row carries a thin outcome chip — `pass | fail | threw`
+;; for guards, `ok | threw` for actions, `cancelled (<reason>)` for
+;; timers, `N microstep(s)` for transitions. The chip colour rides
+;; the outcome keyword (success / warning / error) so the operator can
+;; eye-scan a long cascade for failures without reading every label.
+
+(defn cascade-outcome-token-key
+  "Theme-token keyword for a cascade row's outcome glyph + chip
+  colour (rf2-u69j7). Pure-data; the view's outcome-chrome resolver
+  keys off this table.
+
+  Maps:
+    :pass      → :success    (✓ green)
+    :ok        → :success    (✓ green)
+    :fail      → :warning    (▲ amber — fail is expected behaviour for
+                              gating guards; not alarmist)
+    :threw     → :error      (✗ red — threw is a bug)
+    :cancelled → :text-tertiary  (· muted — cancellation is housekeeping)
+
+  Falls back to `:text-tertiary` for unknown outcomes so the chip
+  paints something even on a taxonomy extension."
+  [outcome]
+  (case outcome
+    :pass      :success
+    :ok        :success
+    :fail      :warning
+    :threw     :error
+    :cancelled :text-tertiary
+    :text-tertiary))
+
+(defn cascade-outcome-glyph
+  "Single-char outcome glyph for a cascade row (rf2-u69j7). Pure-data;
+  the view's per-row outcome chip composes the glyph + label.
+
+  Maps:
+    :pass / :ok → \"✓\"
+    :fail       → \"▲\"
+    :threw      → \"✗\"
+    :cancelled  → \"·\"
+    default     → \"·\""
+  [outcome]
+  (case outcome
+    :pass      "✓"
+    :ok        "✓"
+    :fail      "▲"
+    :threw     "✗"
+    :cancelled "·"
+    "·"))

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -347,6 +347,178 @@
        :delay      (common/tag-of ev :delay)
        :reason     (common/tag-of ev :reason)})))
 
+;; ---- machine cascade (time-ordered) -- rf2-u69j7 ------------------------
+;;
+;; The pre-rf2-u69j7 machine-handler render grouped the substrate's per-event
+;; emit stream into 7 categories (TRANSITION / GUARDS / LIFECYCLE / AFTER-
+;; TIMERS / DATA-REDUCTION / SNAPSHOT-DIFF / FX). That layout buried the
+;; CASCADE — the operator had to read TRANSITION (top), then scroll down to
+;; LIFECYCLE, then back up to GUARDS, to reconstruct what actually happened
+;; in what order. The substrate already emits in cascade order (guards →
+;; exit actions → transition → entry actions → always → …); the projection
+;; just needs to thread the same INSERTION ORDER into a single row vector.
+;;
+;; The cascade row vector replaces the category-grouped `:machine` map
+;; entirely (rf2-u69j7). One row per substrate emit that participated in
+;; the machine cascade:
+;;
+;;   :rf.machine/guard-evaluated     → row :kind :guard
+;;   :rf.machine/action-ran          → row :kind :action  (carries :phase)
+;;   :rf.machine/transition          → row :kind :transition
+;;   :rf.machine.timer/cancelled     → row :kind :timer
+;;
+;; Each row carries enough data for the view to render its phase + outcome
+;; + source-coord + duration + interleaved code body WITHOUT a second pass
+;; over the trace stream.
+
+(def machine-cascade-trace-ops
+  "Closed set of trace ops the cascade projection harvests in trace order
+  (rf2-u69j7). Each op maps to a row :kind via `op->row-kind`. New ops
+  must be added here AND in the `op->row-kind` table; the view's
+  unknown-kind bail-out keeps drift visible."
+  #{:rf.machine/guard-evaluated
+    :rf.machine/action-ran
+    :rf.machine/transition
+    :rf.machine.timer/cancelled})
+
+(def ^:private op->row-kind
+  "Map a machine trace op → cascade-row `:kind` keyword (rf2-u69j7).
+  The view's badge / chrome resolver keys off `:kind`."
+  {:rf.machine/guard-evaluated  :guard
+   :rf.machine/action-ran       :action
+   :rf.machine/transition       :transition
+   :rf.machine.timer/cancelled  :timer})
+
+(defn- guard-cascade-row
+  "Build a cascade row from a `:rf.machine/guard-evaluated` trace event
+  (rf2-u69j7). Outcome is one of `:pass / :fail / :threw` (rf2-82a0u
+  closed set)."
+  [ev]
+  (cond-> {:kind        :guard
+           :guard-id    (common/tag-of ev :guard-id)
+           :outcome     (common/tag-of ev :outcome)
+           :duration-ms (common/tag-of ev :duration-ms)
+           :machine-id  (common/tag-of ev :machine-id)}
+    (common/tag-of ev :spec-path)
+    (assoc :spec-path (common/tag-of ev :spec-path))
+    (common/tag-of ev :exception)
+    (assoc :exception (common/tag-of ev :exception))))
+
+(defn- action-cascade-row
+  "Build a cascade row from a `:rf.machine/action-ran` trace event
+  (rf2-u69j7). Each row carries `:phase` (rf2-82a0u closed set:
+  `:exit / :transition / :entry / :always / :after-action /
+  :initial-entry / :destroy-exit`), the action-id, the input snapshot,
+  per-action fx attribution, the data-write the action returned, and
+  the threw? signal."
+  [ev]
+  (let [outcome     (common/tag-of ev :outcome)
+        action-fx   (when (map? outcome) (:fx outcome))
+        action-data (when (map? outcome) (:data outcome))]
+    (cond-> {:kind        :action
+             :action-id   (common/tag-of ev :action-id)
+             :phase       (common/tag-of ev :phase)
+             :outcome     outcome
+             :threw?      (= :rf.error/action-threw outcome)
+             :duration-ms (common/tag-of ev :duration-ms)
+             :machine-id  (common/tag-of ev :machine-id)
+             :input       (common/tag-of ev :input)}
+      (common/tag-of ev :exception)
+      (assoc :exception (common/tag-of ev :exception))
+      (seq action-fx)
+      (assoc :fx (vec action-fx))
+      (some? action-data)
+      (assoc :data-write action-data))))
+
+(defn- transition-cascade-row
+  "Build a cascade row from a `:rf.machine/transition` trace event
+  (rf2-u69j7). Hoists `:from-state` / `:to-state` off the `:before` /
+  `:after` snapshot maps; preserves `:event` + `:microsteps` for the
+  view's transition chrome (`{:from} → {:to}`, `{n} microstep(s)`).
+
+  Per Spec 005 §Trace events the substrate fires ONE transition emit
+  per macrostep — so the cascade carries at most one `:transition`
+  row, and it lands AFTER the exit-phase actions + the transition-
+  phase actions (substrate emit order)."
+  [ev]
+  (let [before (common/tag-of ev :before)
+        after  (common/tag-of ev :after)]
+    {:kind         :transition
+     :machine-id   (common/tag-of ev :machine-id)
+     :event        (common/tag-of ev :event)
+     :before       before
+     :after        after
+     :from-state   (when (map? before) (:state before))
+     :to-state     (when (map? after)  (:state after))
+     :data-before  (when (map? before) (:data before))
+     :data-after   (when (map? after)  (:data after))
+     :microsteps   (common/tag-of ev :microsteps)
+     :duration-ms  (common/tag-of ev :duration-ms)}))
+
+(defn- timer-cascade-row
+  "Build a cascade row from a `:rf.machine.timer/cancelled` trace event
+  (rf2-u69j7). Carries the cancelled state, the original delay, and
+  the closed-set `:reason` (rf2-82a0u: `:on-exit / :on-destroy /
+  :on-resolution / :on-supersede / :on-frame-destroy`)."
+  [ev]
+  {:kind        :timer
+   :machine-id  (common/tag-of ev :machine-id)
+   :state       (common/tag-of ev :state)
+   :delay       (common/tag-of ev :delay)
+   :reason      (common/tag-of ev :reason)
+   :duration-ms (common/tag-of ev :duration-ms)})
+
+(defn- ev->cascade-row
+  "Dispatch one trace event to its cascade-row builder. Returns nil for
+  events whose op is not in `machine-cascade-trace-ops` (the caller
+  filters but the helper double-guards so a future op insertion is a
+  one-line table change)."
+  [ev]
+  (case (op ev)
+    :rf.machine/guard-evaluated  (guard-cascade-row ev)
+    :rf.machine/action-ran       (action-cascade-row ev)
+    :rf.machine/transition       (transition-cascade-row ev)
+    :rf.machine.timer/cancelled  (timer-cascade-row ev)
+    nil))
+
+(defn machine-cascade-rows
+  "Project the focused epoch's machine-related trace events into a
+  single time-ordered cascade row vector (rf2-u69j7). Each row carries
+  enough data for the view to render its phase / outcome / source-coord
+  / duration / interleaved code body WITHOUT a second pass over the
+  trace stream.
+
+  ORDER COMES FROM SUBSTRATE INSERTION ORDER — the substrate already
+  emits guards / exit actions / transition / entry actions / always /
+  after-action / timer-cancels in cascade order (Spec 005 §Trace events
+  + rf2-82a0u). We just walk the same `:trace-events` vector in order
+  and surface every `machine-cascade-trace-ops` member as a row. The
+  view layer numbers rows 1..N via `:step` (assigned here, contiguous
+  over only the rows that fired).
+
+  Returns an empty vec when no machine-cascade events fired (vanilla
+  reg-event-db / reg-event-fx cascades — the redesign is
+  machine-specific and the empty vec drives the view's empty-state
+  branch off the prior handler-step rendering unchanged)."
+  [events]
+  (vec
+    (map-indexed
+      (fn [i row]
+        (assoc row :step (inc i) :trace-index i))
+      (keep ev->cascade-row
+            (filter (fn [ev] (contains? machine-cascade-trace-ops (op ev)))
+                    events)))))
+
+(defn machine-cascade-total-ms
+  "Sum of every cascade row's `:duration-ms` (rf2-u69j7). nil when no
+  row carries a numeric duration; the view elides the chip in that
+  case. Pure-data aggregation; the view layer never re-walks the
+  trace stream for chrome decisions."
+  [cascade-rows]
+  (let [nums (keep :duration-ms cascade-rows)]
+    (when (seq nums)
+      (reduce + 0 nums))))
+
 (defn- run-end-tags
   "Tags off the `:rf.event/run-end` trace — carries the handler's
   finalised duration + flavour-discriminating slots. Empty map when no
@@ -393,10 +565,20 @@
                      :fx          (or (fx-entries events) [])}]
     (cond-> base
       (= :reg-machine flavour)
-      (assoc :machine {:transition  (machine-transition-row events)
-                       :guards      (machine-guard-rows events)
-                       :lifecycle   (machine-lifecycle-rows events)
-                       :timers      (machine-timer-rows events)})))))
+      (assoc :machine
+             ;; rf2-u69j7 — `:cascade` is the time-ordered row vector the
+             ;; view layer renders. The legacy category-grouped slots
+             ;; (`:transition / :guards / :lifecycle / :timers`) are KEPT
+             ;; on the row as projection-side derived data so test fixtures
+             ;; + callers that pre-date the cascade redesign still read
+             ;; the substrate's per-category aggregations cleanly. The
+             ;; view layer reads ONLY `:cascade` post-rf2-u69j7; the
+             ;; legacy slots ride the row as a pure-data convenience.
+             {:cascade     (machine-cascade-rows events)
+              :transition  (machine-transition-row events)
+              :guards      (machine-guard-rows events)
+              :lifecycle   (machine-lifecycle-rows events)
+              :timers      (machine-timer-rows events)})))))
 
 ;; ---- FLOW step -----------------------------------------------------------
 
@@ -1083,6 +1265,65 @@
             (update acc (or (:phase row) :unknown) (fnil conj []) row))
           {}
           (or lifecycle-rows [])))
+
+(defn cascade-row-label
+  "Render a cascade row's human-readable verb (rf2-u69j7). Used by the
+  view's per-row header. Pure-data; the view never reaches into a
+  row's slots to compute its label."
+  [{:keys [kind action-id guard-id phase from-state to-state state reason
+           machine-id]}]
+  (case kind
+    :guard       (str "guard " (ns-keyword guard-id))
+    :action      (str (when phase (str (name phase) " "))
+                      "action " (ns-keyword action-id))
+    :transition  (str "transition "
+                      (when machine-id
+                        (str (ns-keyword machine-id) " · "))
+                      (if from-state (pr-str from-state) "?")
+                      " → "
+                      (if to-state (pr-str to-state) "?"))
+    :timer       (str "timer " (when state (pr-str state))
+                      (when reason (str " · " (name reason))))
+    (str (when kind (name kind)))))
+
+(defn cascade-row-source-key
+  "Spec-path tuple used to look up a cascade row's source-coord on the
+  registered machine's `:rf.machine/source-coords` index (rf2-8bp3).
+  Returns nil for rows whose kind has no spec-path mapping (e.g.
+  `:transition`, `:timer`). Pure-data; the view layer reuses this for
+  the coord lookup so the source-link affordance reads off ONE
+  authoritative key."
+  [{:keys [kind action-id guard-id]}]
+  (case kind
+    :action (when action-id [:actions action-id])
+    :guard  (when guard-id  [:guards guard-id])
+    nil))
+
+(defn cascade-outcome-label
+  "Render a cascade row's outcome for the view's outcome chip
+  (rf2-u69j7). Pure-data.
+
+    :guard       → `pass | fail | threw`
+    :action      → `ok | threw` (the action's outcome map is rich;
+                                 the chip carries only the headline)
+    :transition  → `→ N microstep(s)` (the headline reads off
+                                       `:microsteps`)
+    :timer       → `cancelled (<reason>)`"
+  [{:keys [kind outcome threw? microsteps reason]}]
+  (case kind
+    :guard      (if (keyword? outcome) (name outcome) nil)
+    :action     (cond
+                  threw?                "threw"
+                  (= :ok outcome)       "ok"
+                  (map? outcome)        "ok"
+                  (keyword? outcome)    (name outcome)
+                  :else                 nil)
+    :transition (when (number? microsteps)
+                  (str microsteps " microstep"
+                       (when (not= 1 microsteps) "s")))
+    :timer      (str "cancelled"
+                     (when reason (str " (" (name reason) ")")))
+    nil))
 
 ;; ---- spec helpers --------------------------------------------------------
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -663,261 +663,526 @@
                    :word-break "break-word"}}
     [ei/mini value 80]]])
 
-(defn- machine-lifecycle-block
-  "Render the per-phase lifecycle rows for a machine handler. Empty
-  phases render dimmed `(none)` so the model reads as the full
-  exit → transition → entry shape even when one phase carries no
-  actions (the panel doubles as a teaching surface — bead body §What
-  this panel teaches).
+;; ---- Machine cascade view (rf2-u69j7) -----------------------------------
+;;
+;; Pre-rf2-u69j7 the machine-handler-section rendered 7 categories
+;; (TRANSITION / GUARDS / LIFECYCLE / AFTER-TIMERS / DATA REDUCTION /
+;; SNAPSHOT DIFF / FX). The operator had to read top-to-bottom + cross-
+;; reference categories to reconstruct what fired in what order.
+;;
+;; The redesign (rf2-u69j7) replaces the category-grouped layout with a
+;; single TIME-ORDERED CASCADE. One row per substrate emit, ordered by
+;; trace-event INSERTION ORDER — the substrate already emits guards →
+;; exit actions → transition → entry actions → always → after-action
+;; → timer-cancels in cascade order, so no re-sort is needed.
+;;
+;; Each row renders:
+;;   - Step ordinal (1..N) in a compact left-rail.
+;;   - Kind chip (`GUARD / ACTION / TRANSITION / TIMER`) — colour-coded.
+;;   - Phase chip (action rows only — `:exit / :transition / :entry /
+;;     :always / :after-action / :initial-entry / :destroy-exit`).
+;;   - Verb (action-id / guard-id / transition labels / timer state),
+;;     a click-to-source button via shared `coord-chip` style when
+;;     the machine spec carries the per-element source-coord
+;;     (rf2-8bp3 / rf2-80u5a / rf2-ehd8v).
+;;   - Duration chip (right-aligned, with long-step warning when
+;;     `:duration-ms > 16ms` per rf2-nqt3d).
+;;   - Outcome chip — `✓ pass / ▲ fail / ✗ threw` for guards;
+;;     `✓ ok / ✗ threw` for actions; `→ N microstep(s)` for the
+;;     transition; `· cancelled (<reason>)` for timers.
+;;   - Body: source code (ALWAYS VISIBLE per the bead body's
+;;     "interleaved source code" requirement) + outcome detail
+;;     (per-action fx attribution + data-write delta for actions;
+;;     before→after snapshot for the transition).
 
-  Per rf2-9c27r each row also surfaces per-action fx attribution
-  when the action returned a map carrying `:fx` — the operator can
-  trace each fx back to its emitting action without spec-walking."
-  [lifecycle-rows]
-  (let [grouped (proj/group-lifecycle-by-phase lifecycle-rows)
-        phases  [:exit :transition :entry :always
-                 :after-action :initial-entry :destroy-exit]]
-    [:div {:data-testid "rf-xray-epoch-handler-machine-lifecycle"
-           :style {:margin-top "5px"}}
-     (sub-header "lifecycle"
-                 (str (count lifecycle-rows) " action"
-                      (when (not= 1 (count lifecycle-rows)) "s")))
-     (for [phase phases
-           :let [rows (get grouped phase)]
-           :when (seq rows)]
-       [:div {:key (str "phase-" (name phase))
-              :data-testid (str "rf-xray-epoch-handler-phase-" (name phase))
-              :style {:padding "2px 0 2px 21px"
+(defn- cascade-row-coord
+  "Lift a `{:file :line}` source-coord from the registered machine's
+  `:rf.machine/source-coords` index (rf2-8bp3) for a cascade row. The
+  index key is `[:actions <id>]` / `[:guards <id>]` per rf2-8bp3.
+  Returns nil when no coord was captured (production builds, fixture
+  fn-form machines)."
+  [machine-meta row]
+  (when-let [k (proj/cascade-row-source-key row)]
+    (let [idx (or (get-in machine-meta [:rf/machine :rf.machine/source-coords])
+                  (:rf.machine/source-coords machine-meta))
+          c   (get idx k)]
+      (when (and (map? c) (string? (:file c)) (seq (:file c)))
+        {:file (:file c) :line (:line c)}))))
+
+(defn- cascade-row-source-form
+  "Lift the source form (a CLJS fn literal or sugar form) for a cascade
+  row's action/guard from the registered machine spec (rf2-u69j7).
+  The form lives in the spec map at `[:actions <id>]` / `[:guards
+  <id>]`. Returns nil for kinds without a definition site
+  (`:transition`, `:timer`)."
+  [machine-meta row]
+  (when-let [k (proj/cascade-row-source-key row)]
+    (let [spec (or (:rf/machine machine-meta)
+                   (:machine-spec machine-meta)
+                   (:rf.machine/spec machine-meta))]
+      (get-in spec k))))
+
+(defn- cascade-outcome-chip
+  "Render the outcome chip for a cascade row (rf2-u69j7). Pulls glyph
+  + label from the `panels.epoch.badge` table; colour from
+  `cascade-outcome-token-key`."
+  [outcome label-override]
+  (when (or (some? outcome) label-override)
+    (let [glyph        (badge/cascade-outcome-glyph outcome)
+          token-key    (badge/cascade-outcome-token-key outcome)
+          colour       (get tokens token-key (:text-tertiary tokens))
+          label-string (or label-override
+                           (when (keyword? outcome) (name outcome)))]
+      [:span {:data-testid (str "rf-xray-epoch-machine-cascade-outcome-"
+                                (when (keyword? outcome) (name outcome)))
+              :style {:display "inline-flex"
+                      :align-items "center"
+                      :gap "4px"
+                      :color colour
                       :font-family mono-stack
-                      :font-size "12px"}}
-        [:div {:style {:color (:text-tertiary tokens)
-                       :font-size "10px"
-                       :text-transform "uppercase"
-                       :letter-spacing "0.5px"
-                       :margin-bottom "2px"}}
-         (proj/phase-label phase)]
-        (for [[i row] (map-indexed vector rows)]
-          ^{:key (str "lc-" (name phase) "-" i)}
-          [:div {:data-testid (str "rf-xray-epoch-handler-phase-" (name phase) "-row-" i)
-                 :style {:display "flex"
-                         :flex-direction "column"
-                         :padding "1px 0"
-                         :color (if (:threw? row) (:error tokens)
-                                    (:text-primary tokens))}}
-           [:div {:style {:display "flex" :gap "8px" :align-items "center"}}
-            [:span {:style {:color (:text-tertiary tokens)}} "↓"]
-            [:span (proj/ns-keyword (:action-id row))]
-            (when (:threw? row)
-              [:span {:style {:color (:error tokens) :margin-left "8px"}}
-               "(threw)"])]
-           ;; rf2-9c27r — per-action fx attribution
-           (when (seq (:fx row))
-             [:div {:data-testid (str "rf-xray-epoch-handler-phase-" (name phase) "-fx-" i)
-                    :style {:padding-left "21px"
-                            :color (:text-tertiary tokens)
-                            :font-size "11px"}}
-              (for [[j entry] (map-indexed vector (:fx row))
-                    :let [[fx-id _args] (if (vector? entry) entry [entry nil])]]
-                ^{:key (str "lc-fx-" (name phase) "-" i "-" j)}
-                [:div {:style {:display "inline-flex"
-                               :align-items "center"
-                               :gap "4px"
-                               :margin-right "8px"}}
-                 "→ fx "
-                 [:span {:style {:color (:accent tokens)}}
-                  (proj/ns-keyword fx-id)]])])])])]))
+                      :font-size "11px"
+                      :font-weight 600
+                      :white-space "nowrap"}}
+       [:span {:aria-hidden true :style {:font-weight 700}} glyph]
+       (when label-string label-string)])))
 
-(defn- machine-data-reduction-block
-  "Render the DATA REDUCTION sub-section (rf2-9c27r §5). Renders
-  `:data` before / after via `edn/inspect`. Elides when both sides
-  are absent / identical."
-  [{:keys [data-before data-after]}]
-  (when (or (some? data-before) (some? data-after))
-    (when (not= data-before data-after)
-      [:div {:data-testid "rf-xray-epoch-handler-machine-data-reduction"
-             :style {:padding "3px 0 3px 16px"}}
-       (sub-header "data reduction")
-       [:div {:style {:display "flex"
-                      :gap "13px"
-                      :padding-left "16px"
+(defn- cascade-phase-chip
+  "Render the phase pill for an `:action` cascade row (rf2-u69j7).
+  Renders nothing for non-action rows. The pill is intentionally
+  muted (`:text-tertiary` + 10px) — the action verb is the headline;
+  the phase is refinement."
+  [phase]
+  (when (badge/cascade-phase? phase)
+    [:span {:data-testid (str "rf-xray-epoch-machine-cascade-phase-"
+                              (name phase))
+            :style {:display "inline-flex"
+                    :align-items "center"
+                    :background (:bg-3 tokens)
+                    :color (:text-tertiary tokens)
+                    :border (str "1px solid " (:border-subtle tokens))
+                    :border-radius "2px"
+                    :padding "1px 5px"
+                    :font-family mono-stack
+                    :font-size "10px"
+                    :font-weight 600
+                    :letter-spacing "0.3px"
+                    :white-space "nowrap"}}
+     (badge/cascade-phase-label phase)]))
+
+(defn- cascade-kind-pill
+  "Render the kind pill (`GUARD / ACTION / TRANSITION / TIMER`) on a
+  cascade row's header (rf2-u69j7). Smaller than the top-level badge
+  pill — the cascade is rendered INSIDE the HANDLER step's body and
+  the per-row chip is a refinement on the HANDLER badge above it."
+  [kind]
+  [:span {:data-testid (str "rf-xray-epoch-machine-cascade-kind-"
+                            (when (keyword? kind) (name kind)))
+          :style {:display "inline-flex"
+                  :align-items "center"
+                  :background (badge/cascade-kind-colour kind)
+                  :color (:white tokens)
+                  :font-family sans-stack
+                  :font-size "9px"
+                  :font-weight 700
+                  :padding "2px 5px"
+                  :border-radius "2px"
+                  :letter-spacing "0.5px"
+                  :text-transform "uppercase"
+                  :line-height 1
+                  :white-space "nowrap"}}
+   (badge/cascade-kind-label kind)])
+
+(defn- cascade-row-ordinal
+  "Render the row's 1..N step ordinal on the left rail (rf2-u69j7).
+  Compact monospace chip — keeps the cascade scannable across many
+  rows without clipping into the rest of the row's chrome."
+  [step]
+  [:span {:data-testid (str "rf-xray-epoch-machine-cascade-ordinal-" step)
+          :aria-label  (str "cascade step " step)
+          :style {:display "inline-flex"
+                  :align-items "center"
+                  :justify-content "center"
+                  :min-width "21px"
+                  :height "16px"
+                  :padding "0 4px"
+                  :background (:bg-3 tokens)
+                  :color (:text-tertiary tokens)
+                  :font-family mono-stack
+                  :font-size "10px"
+                  :font-weight 700
+                  :border-radius "2px"
+                  :white-space "nowrap"}}
+   (str step)])
+
+(defn- cascade-row-verb-link
+  "Render a cascade row's verb (action-id / guard-id / transition
+  label / timer state) as a click-to-source button when the machine
+  spec carries the per-element source-coord (rf2-8bp3); falls back to
+  a plain coloured span otherwise.
+
+  rf2-80u5a / rf2-ehd8v — the affordance reads the same `<label> + ↗`
+  shape as the HANDLER step's verb so the operator's eye trains on
+  ONE source-link grammar across the panel."
+  [row coord verb-string]
+  (let [clickable? (and (map? coord) (seq (:file coord)))]
+    (if clickable?
+      [:button {:data-testid (str "rf-xray-epoch-machine-cascade-verb-link-"
+                                  (:step row))
+                :aria-label  (str "open " (:file coord)
+                                  (when (:line coord)
+                                    (str ":" (:line coord)))
+                                  " in editor")
+                :title       (str "open " (:file coord)
+                                  (when (:line coord)
+                                    (str ":" (:line coord)))
+                                  " in editor")
+                :on-click    (fn [e]
+                               (.stopPropagation e)
+                               (rf/dispatch [:rf.xray/open-in-editor
+                                             {:source-coord coord}]
+                                            {:frame :rf/xray}))
+                :style {:background "transparent"
+                        :border     "none"
+                        :padding    0
+                        :margin     0
+                        :color      (:accent tokens)
+                        :cursor     "pointer"
+                        :font-family mono-stack
+                        :font-size  "12px"
+                        :font-weight 600
+                        :text-decoration "underline"
+                        :text-decoration-style "dotted"
+                        :text-underline-offset "2px"
+                        :display    "inline-flex"
+                        :align-items "center"
+                        :gap        "4px"
+                        :white-space "nowrap"}}
+       verb-string
+       (icons/external-link)]
+      [:span {:data-testid (str "rf-xray-epoch-machine-cascade-verb-"
+                                (:step row))
+              :style {:color       (:text-primary tokens)
                       :font-family mono-stack
-                      :font-size "12px"
-                      :flex-wrap "wrap"}}
-        [:div {:data-testid "rf-xray-epoch-handler-machine-data-before"
-               :style {:flex 1 :min-width "120px"}}
-         [:div {:style {:color (:text-tertiary tokens)
-                        :font-size "10px"
-                        :text-transform "uppercase"
-                        :letter-spacing "0.5px"
-                        :margin-bottom "2px"}}
-          "before"]
-         [:div {:style {:color (:error tokens)}}
-          (edn/inspect-inline data-before)]]
-        [:div {:data-testid "rf-xray-epoch-handler-machine-data-after"
-               :style {:flex 1 :min-width "120px"}}
-         [:div {:style {:color (:text-tertiary tokens)
-                        :font-size "10px"
-                        :text-transform "uppercase"
-                        :letter-spacing "0.5px"
-                        :margin-bottom "2px"}}
-          "after"]
-         [:div {:style {:color (:success tokens)}}
-          (edn/inspect-inline data-after)]]]])))
+                      :font-size   "12px"
+                      :font-weight 600
+                      :white-space "nowrap"}}
+       verb-string])))
 
-(defn- machine-snapshot-diff-block
-  "Render the SNAPSHOT DIFF sub-section (rf2-9c27r §6). The Spec 005
-  snapshot is the full `{:state … :data … …}` map; we render
-  `before` + `after` via `edn/inspect` so the operator can drill into
-  any slot (data, state, parallel-region tags). Elides when the
-  snapshots are identical."
-  [{:keys [before after]}]
-  (when (and (some? before) (some? after) (not= before after))
-    [:div {:data-testid "rf-xray-epoch-handler-machine-snapshot-diff"
-           :style {:padding "3px 0 3px 16px"}}
-     (sub-header "snapshot diff")
+(defn- cascade-row-source-body
+  "Render the source code body for a cascade row (rf2-u69j7). Always
+  visible per the bead body's 'interleaved source code' requirement —
+  the operator reads what ran AND its code at the same vertical
+  position without scrolling.
+
+  - For `:action` / `:guard` rows that resolve a source form (via
+    `cascade-row-source-form` reading the registered machine spec),
+    render the form through the canonical `edn/code-block` widget
+    (the same widget the HANDLER step uses).
+  - When no source form is captured (production builds with
+    `goog.DEBUG=false`, fixture machines that pre-date the
+    source-coord stamping pass), render a muted placeholder so the
+    operator sees the slot consistently.
+  - `:transition` / `:timer` rows have no definition site — they ARE
+    the substrate's chrome, not user code. The body slot elides for
+    those kinds.
+
+  rf2-66wis / rf2-93jp0 — `edn/code-block` paints clojure-syntax
+  tokens with the same per-token palette as the Figma authority's
+  `.syntax-*` classes, so the cascade code body matches the HANDLER
+  step's source body."
+  [row source-form]
+  (when (contains? #{:action :guard} (:kind row))
+    [:div {:data-testid (str "rf-xray-epoch-machine-cascade-source-"
+                             (:step row))
+           :style {:margin    "5px 0 3px 0"
+                   :padding-left "8px"
+                   :border-left (str "2px solid " (:border-subtle tokens))
+                   :min-width 0}}
+     (if (some? source-form)
+       (edn/code-block
+         {:source (pr-str source-form)
+          :lang   :clojure
+          :testid (str "rf-xray-epoch-machine-cascade-source-body-"
+                       (:step row))})
+       [:span {:data-testid (str "rf-xray-epoch-machine-cascade-source-missing-"
+                                 (:step row))
+               :style {:font-style "italic"
+                       :font-family mono-stack
+                       :font-size  "11px"
+                       :color      (:text-tertiary tokens)}}
+        "<source not yet captured>"])]))
+
+(defn- cascade-row-action-outcome-details
+  "Render the per-action outcome details for an `:action` cascade row
+  (rf2-u69j7). Three slots ride below the row's source body:
+
+  - DATA Δ — when the action returned a `:data` write, surface the
+    delta the action contributed (rf2-9c27r-style per-action
+    attribution, now inline rather than buried in a category roll-up).
+  - FX — when the action returned a `:fx` list, surface each emitted
+    fx-id (per-action attribution; same data as the FX step's
+    `:attributed-to` chip, now visible IN the action's row).
+  - EXCEPTION — when the action threw, surface the exception message
+    (the cascade halts on the first throw — Spec 005 §Errors).
+
+  Each slot elides cleanly when the underlying data is absent so the
+  row stays minimal for actions that ran without side-effects."
+  [row]
+  (let [{:keys [data-write fx threw? exception]} row]
+    (when (or data-write (seq fx) threw?)
+      [:div {:data-testid (str "rf-xray-epoch-machine-cascade-outcome-"
+                               (:step row))
+             :style {:padding "2px 0 4px 21px"
+                     :display "flex"
+                     :flex-direction "column"
+                     :gap "2px"
+                     :font-family mono-stack
+                     :font-size "11px"}}
+       ;; Per-action DATA Δ — the data the action wrote into the
+       ;; snapshot. Surface as `↳ data Δ <map>` so the cascade
+       ;; row tells the operator 'this action wrote …' without
+       ;; reading the post-cascade snapshot diff.
+       (when (some? data-write)
+         [:div {:data-testid (str "rf-xray-epoch-machine-cascade-data-write-"
+                                  (:step row))
+                :style {:display "flex"
+                        :gap "6px"
+                        :align-items "flex-start"
+                        :color (:text-secondary tokens)}}
+          [:span {:style {:color (:success tokens) :font-weight 700}} "↳"]
+          [:span {:style {:color (:text-tertiary tokens)}} "data Δ"]
+          [:span {:style {:color (:text-primary tokens) :min-width 0 :flex 1
+                          :word-break "break-word"}}
+           [ei/mini data-write 80]]])
+       ;; Per-action FX attribution — each fx-id the action emitted
+       ;; in its outcome's `:fx` slot. The view layer already
+       ;; surfaces these via the FX step's `:attributed-to` chip;
+       ;; this row carries the SAME data inline so the operator can
+       ;; read 'action X emitted fx Y' in one place without crossing
+       ;; the cascade.
+       (when (seq fx)
+         [:div {:data-testid (str "rf-xray-epoch-machine-cascade-fx-"
+                                  (:step row))
+                :style {:display "flex"
+                        :gap "6px"
+                        :align-items "flex-start"
+                        :flex-wrap "wrap"}}
+          [:span {:style {:color (:accent tokens) :font-weight 700}} "↳"]
+          [:span {:style {:color (:text-tertiary tokens)}} "fx"]
+          (for [[j entry] (map-indexed vector fx)
+                :let [[fx-id _args] (if (vector? entry) entry [entry nil])]]
+            ^{:key (str "cascade-fx-" (:step row) "-" j)}
+            [:span {:data-testid (str "rf-xray-epoch-machine-cascade-fx-"
+                                      (:step row) "-" j)
+                    :style {:color (:accent tokens)
+                            :margin-right "6px"}}
+             (proj/ns-keyword fx-id)])])
+       ;; Threw path — the action halted the cascade. Surface a
+       ;; compact error chip so the operator can pivot to the
+       ;; exception body via the Issues panel.
+       (when threw?
+         [:div {:data-testid (str "rf-xray-epoch-machine-cascade-threw-"
+                                  (:step row))
+                :style {:display "flex"
+                        :gap "6px"
+                        :align-items "flex-start"
+                        :color (:error tokens)}}
+          [:span {:style {:font-weight 700}} "✗"]
+          [:span {:style {:font-weight 600}} "threw"]
+          (when exception
+            [:span {:style {:color (:text-secondary tokens)
+                            :font-style "italic"}}
+             (str " — "
+                  (or (when (some? exception)
+                        (.-message ^js exception))
+                      (str exception)))])])])))
+
+(defn- cascade-row-transition-details
+  "Render the transition's `from → to` chrome under a `:transition`
+  cascade row (rf2-u69j7). Pulls the state vectors off the
+  `:from-state` / `:to-state` slots the projection hoisted from the
+  trace's `:before` / `:after` snapshots."
+  [row]
+  (let [{:keys [from-state to-state event microsteps]} row]
+    (when (or from-state to-state event microsteps)
+      [:div {:data-testid (str "rf-xray-epoch-machine-cascade-transition-"
+                               (:step row))
+             :style {:padding "3px 0 4px 21px"
+                     :display "flex"
+                     :flex-direction "column"
+                     :gap "2px"
+                     :font-family mono-stack
+                     :font-size "11px"}}
+       (when (or from-state to-state)
+         [:div {:data-testid (str "rf-xray-epoch-machine-cascade-from-to-"
+                                  (:step row))
+                :style {:display "inline-flex"
+                        :align-items "center"
+                        :gap "6px"
+                        :flex-wrap "wrap"}}
+          [:span {:style {:color (:text-tertiary tokens)}} "state"]
+          [:span {:style {:color (:error tokens)}} [ei/mini from-state 30]]
+          [:span {:style {:color (:text-tertiary tokens)}} "→"]
+          [:span {:style {:color (:success tokens)}} [ei/mini to-state 30]]])
+       (when (vector? event)
+         [:div {:data-testid (str "rf-xray-epoch-machine-cascade-trigger-"
+                                  (:step row))
+                :style {:display "inline-flex"
+                        :align-items "center"
+                        :gap "6px"
+                        :color (:text-secondary tokens)}}
+          [:span {:style {:color (:text-tertiary tokens)}} "event"]
+          [ei/mini event 40]])])))
+
+(defn- cascade-row-view
+  "Render one cascade row (rf2-u69j7). Layout:
+
+      [#step] [KIND] [phase?] verb (↗ source)    duration · outcome
+      ─┐ source code (always visible, monospace, syntax-highlighted)
+        ↳ data Δ  …
+        ↳ fx …
+
+  The row's `:kind` keys all the chrome variants: `:action` rides the
+  full layout (phase chip + source body + outcome details);
+  `:guard` rides a thinner layout (source body, no phase chip);
+  `:transition` rides the state-change layout (no source body,
+  state-vector before/after); `:timer` rides a minimal layout (no
+  source body, no phase chip, just the kind + state + reason)."
+  [machine-meta row]
+  (let [{:keys [kind step phase duration-ms outcome threw?]} row
+        coord       (cascade-row-coord machine-meta row)
+        source-form (cascade-row-source-form machine-meta row)
+        verb        (proj/cascade-row-label row)
+        outcome-lbl (proj/cascade-outcome-label row)
+        long?       (and (number? duration-ms)
+                         (> duration-ms proj/long-step-threshold-ms))]
+    [:div {:key (str "cascade-row-" step)
+           :data-testid (str "rf-xray-epoch-machine-cascade-row-" step)
+           :data-cascade-kind (when (keyword? kind) (name kind))
+           :data-cascade-phase (when (keyword? phase) (name phase))
+           :data-cascade-long-step (str (boolean long?))
+           :style {:display "flex"
+                   :flex-direction "column"
+                   :padding "5px 0 5px 0"
+                   :border-bottom (str "1px solid " (:border-subtle tokens))}}
+     ;; Header row: ordinal + kind pill + phase chip + verb + duration + outcome
      [:div {:style {:display "flex"
-                    :gap "13px"
-                    :padding-left "16px"
+                    :align-items "center"
+                    :gap "6px"
                     :flex-wrap "wrap"}}
-      [:div {:data-testid "rf-xray-epoch-handler-machine-snapshot-before"
-             :style {:flex 1 :min-width "120px"
-                     :font-family mono-stack
-                     :font-size "12px"}}
-       [:div {:style {:color (:text-tertiary tokens)
-                      :font-size "10px"
-                      :text-transform "uppercase"
-                      :letter-spacing "0.5px"
-                      :margin-bottom "2px"}}
-        "before"]
-       [:div {:style {:color (:error tokens) :word-break "break-word"}}
-        (edn/inspect-inline before)]]
-      [:div {:data-testid "rf-xray-epoch-handler-machine-snapshot-after"
-             :style {:flex 1 :min-width "120px"
-                     :font-family mono-stack
-                     :font-size "12px"}}
-       [:div {:style {:color (:text-tertiary tokens)
-                      :font-size "10px"
-                      :text-transform "uppercase"
-                      :letter-spacing "0.5px"
-                      :margin-bottom "2px"}}
-        "after"]
-       [:div {:style {:color (:success tokens) :word-break "break-word"}}
-        (edn/inspect-inline after)]]]]))
+      (cascade-row-ordinal step)
+      (cascade-kind-pill kind)
+      (when (= :action kind)
+        (cascade-phase-chip phase))
+      (cascade-row-verb-link row coord verb)
+      ;; Right-aligned: duration + outcome chip
+      [:span {:style {:margin-left "auto"
+                      :display "inline-flex"
+                      :align-items "center"
+                      :gap "8px"
+                      :flex-wrap "nowrap"}}
+       (duration-chip duration-ms)
+       (cascade-outcome-chip
+         (cond
+           (= :guard kind)      outcome
+           (and (= :action kind) threw?)  :threw
+           (= :action kind)     :ok
+           (= :timer kind)      :cancelled
+           :else                nil)
+         (when (or (= :transition kind) (and (= :guard kind) outcome-lbl))
+           outcome-lbl))]]
+     ;; Source code body (always visible per rf2-u69j7) — actions + guards only
+     (cascade-row-source-body row source-form)
+     ;; Per-row outcome details — kind-specific
+     (case kind
+       :action     (cascade-row-action-outcome-details row)
+       :transition (cascade-row-transition-details row)
+       nil)]))
+
+(defn- machine-cascade-view
+  "Render the time-ordered machine-handler cascade (rf2-u69j7). Replaces
+  the pre-rf2-u69j7 category-grouped layout (TRANSITION / GUARDS /
+  LIFECYCLE / AFTER-TIMERS / DATA REDUCTION / SNAPSHOT DIFF / FX) with
+  a single time-ordered row stream.
+
+  The cascade is REQUIRED non-empty for machine handlers — the
+  substrate emits at least one `:rf.machine/transition` per macrostep
+  (`make-machine-handler`'s emit shape). The empty-state branch is
+  defensive only (fixtures that synthesise a machine handler without
+  any cascade events).
+
+  Header carries:
+  - `N step(s)` count (compact summary at a glance).
+  - Cascade total ms (sum of per-row `:duration-ms`); elides when no
+    row carries a duration.
+
+  Each row is rendered via `cascade-row-view` — see its docstring
+  for the per-row layout grammar."
+  [machine-meta cascade-rows]
+  (let [n     (count cascade-rows)
+        total (proj/machine-cascade-total-ms cascade-rows)]
+    [:div {:data-testid "rf-xray-epoch-handler-machine-cascade"
+           :data-cascade-row-count (str n)
+           :style {:margin-top "8px"
+                   :display "flex"
+                   :flex-direction "column"}}
+     (sub-header "cascade"
+                 [:span {:style {:display "inline-flex"
+                                 :align-items "center"
+                                 :gap "8px"
+                                 :font-family mono-stack
+                                 :font-size "11px"}}
+                  (str n " step"
+                       (when (not= 1 n) "s"))
+                  (when (number? total)
+                    [:span {:data-testid "rf-xray-epoch-machine-cascade-total"
+                            :style {:color (:text-tertiary tokens)}}
+                     (str "· " (proj/format-duration-ms total))])])
+     (if (zero? n)
+       [:div {:data-testid "rf-xray-epoch-handler-machine-cascade-empty"
+              :style {:padding "5px 0 5px 21px"
+                      :font-family mono-stack
+                      :font-size "11px"
+                      :font-style "italic"
+                      :color (:text-tertiary tokens)}}
+        "— (no machine cascade events fired)"]
+       (into [:div {:data-testid "rf-xray-epoch-handler-machine-cascade-rows"
+                    :style {:display "flex"
+                            :flex-direction "column"
+                            :border-top (str "1px solid " (:border-subtle tokens))
+                            :margin-top "3px"}}]
+             (for [row cascade-rows]
+               (cascade-row-view machine-meta row))))]))
 
 (defn- machine-block
-  "Render the machine-handler-specific extras (transition summary,
-  guards, lifecycle, timer cancellations, data reduction, snapshot
-  diff). Per the bead body §HANDLER (Step 4) machine handler branch —
-  uses the rf2-82a0u trace enhancements (phase + outcome + reason).
+  "Render the machine-handler section as a SINGLE TIME-ORDERED CASCADE
+  (rf2-u69j7). Replaces the pre-rf2-u69j7 category-grouped layout
+  (TRANSITION / GUARDS / LIFECYCLE / AFTER-TIMERS / DATA REDUCTION /
+  SNAPSHOT DIFF / FX) with one cascade view: each row interleaves
+  source code with the row's phase + duration + outcome (per Mike's
+  authority — Bead rf2-u69j7).
 
-  Per rf2-9c27r the section now carries all 7 sub-sections per the
-  design doc:
+  Order comes from the substrate's `:rf.machine/action-ran` /
+  `:rf.machine/guard-evaluated` / `:rf.machine/transition` /
+  `:rf.machine.timer/cancelled` trace events' INSERTION ORDER in the
+  epoch buffer — the substrate already emits them in cascade order
+  (Spec 005 §Trace events + rf2-82a0u). The projection's
+  `machine-cascade-rows` is a pure-data walk over the events; this
+  view layer is a faithful render of that vector.
 
-    1. TRANSITION — `before-state → after-state`, event, microsteps
-    2. GUARDS — per-guard pass/fail/threw outcomes
-    3. LIFECYCLE — phase-grouped action rows with per-action fx
-       attribution
-    4. AFTER TIMERS — armed/cancelled with reasons
-    5. DATA REDUCTION — `:data` before / after via edn-inspector
-    6. SNAPSHOT DIFF — full snapshot before / after
-    7. FX — per-action fx attribution surfaces inline in LIFECYCLE
-       (rather than as a sibling sub-section) so the operator reads
-       'action X emitted fx Y' in one line."
-  [{:keys [transition guards lifecycle timers]}]
-  [:div {:data-testid "rf-xray-epoch-handler-machine"}
-   ;; Transition summary
-   (when transition
-     [:div {:data-testid "rf-xray-epoch-handler-machine-transition"
-            :style {:padding "3px 0 3px 16px"
-                    :font-family mono-stack
-                    :font-size "12px"
-                    :color (:text-primary tokens)}}
-      [:div {:style {:color (:text-tertiary tokens)
-                     :font-size "10px"
-                     :text-transform "uppercase"
-                     :letter-spacing "0.5px"}}
-       (str "transition · " (proj/ns-keyword (:machine-id transition)))]
-      [:div {:style {:padding-left "16px"
-                     :display "inline-flex"
-                     :align-items "center"
-                     :gap "6px"
-                     :flex-wrap "wrap"}}
-       ;; rf2-8w8er — state before/after render through `mini` so
-       ;; the state vector's keywords paint magenta, scalars orange,
-       ;; etc. — matching how every other Xray panel renders state.
-       (let [before (or (some-> (:before transition) :state) (:before transition))
-             after  (or (some-> (:after transition) :state) (:after transition))]
-         [:<>
-          [:span {:style {:color (:error tokens)}} [ei/mini before 40]]
-          [:span {:style {:color (:text-tertiary tokens)}} "→"]
-          [:span {:style {:color (:success tokens)}} [ei/mini after 40]]])]
-      ;; rf2-9c27r — microsteps + event slots ride alongside the
-      ;; before→after pair so the operator can tell at a glance how
-      ;; many always-microsteps fired + which event drove the cascade.
-      (when (number? (:microsteps transition))
-        [:div {:data-testid "rf-xray-epoch-handler-machine-microsteps"
-               :style {:padding-left "16px"
-                       :color (:text-tertiary tokens)
-                       :font-size "10px"}}
-         (str (:microsteps transition) " microstep"
-              (when (not= 1 (:microsteps transition)) "s"))])])
-   ;; Guards
-   (when (seq guards)
-     [:div {:style {:padding "3px 0 3px 16px"}}
-      (sub-header "guards" (str (count guards) " evaluated"))
-      (for [[i {:keys [guard-id outcome]}] (map-indexed vector guards)]
-        [:div {:key (str "g-" i)
-               :data-testid (str "rf-xray-epoch-handler-guard-row-" i)
-               :style {:display "flex"
-                       :gap "8px"
-                       :padding "1px 0 1px 21px"
-                       :font-family mono-stack
-                       :font-size "12px"}}
-         [:span {:style {:color (case outcome
-                                  :pass (:success tokens)
-                                  :fail (:warning tokens)
-                                  :threw (:error tokens)
-                                  (:text-tertiary tokens))
-                         :font-weight 700}}
-          (case outcome
-            :pass  "✓"
-            :fail  "✗"
-            :threw "!"
-            "·")]
-         [:span (proj/ns-keyword guard-id)]
-         [:span {:style {:color (:text-tertiary tokens) :margin-left "8px"}}
-          (when (keyword? outcome) (name outcome))]])])
-   ;; Lifecycle (with per-action fx attribution — rf2-9c27r)
-   (when (seq lifecycle)
-     (machine-lifecycle-block lifecycle))
-   ;; Timers
-   (when (seq timers)
-     [:div {:style {:padding "3px 0 3px 16px"}}
-      (sub-header "after-timers" (str (count timers) " cancelled"))
-      (for [[i {:keys [state delay reason]}] (map-indexed vector timers)]
-        [:div {:key (str "t-" i)
-               :style {:display "flex"
-                       :gap "8px"
-                       :padding "1px 0 1px 21px"
-                       :font-family mono-stack
-                       :font-size "12px"}}
-         [:span {:style {:color (:warning tokens)}} "✗"]
-         ;; rf2-8w8er — state vector through `mini` so the machine
-         ;; state syntax-token chrome reads consistently with every
-         ;; other Xray state-rendering surface.
-         [:span [ei/mini state 40]]
-         (when (number? delay)
-           [:span {:style {:color (:text-tertiary tokens)}}
-            (str delay "ms")])
-         [:span {:style {:color (:text-tertiary tokens) :font-style "italic"
-                         :margin-left "8px"}}
-          (proj/timer-reason-label reason)]])])
-   ;; rf2-9c27r — DATA REDUCTION + SNAPSHOT DIFF sub-sections, fed
-   ;; by the `:data-before / :data-after` + `:before / :after`
-   ;; slots the projection hoists off the `:rf.machine/transition`
-   ;; trace.
-   (machine-data-reduction-block transition)
-   (machine-snapshot-diff-block transition)])
+  The legacy category-grouped sub-sections (TRANSITION / GUARDS /
+  LIFECYCLE / AFTER-TIMERS / DATA REDUCTION / SNAPSHOT DIFF / FX) are
+  REPLACED, not augmented (per Mike: 'pre-alpha; no back-compat
+  shim'). The full state-change story is now told inline by the
+  cascade — transitions render their `from → to` state vectors;
+  actions render their data-write + fx attribution + source code
+  body."
+  [{:keys [cascade] :as _machine-row} event-id]
+  (let [machine-meta (when (some? event-id)
+                       (try (rf/handler-meta :machine event-id)
+                            (catch :default _ nil)))]
+    [:div {:data-testid "rf-xray-epoch-handler-machine"}
+     (machine-cascade-view machine-meta (or cascade []))]))
 
 ;; ---- handler source --------------------------------------------------
 ;;
@@ -1223,9 +1488,10 @@
     [:div {:data-testid "rf-xray-epoch-handler-body"}
      ;; Source / machine spec block — rf2-66wis
      (handler-source-block flavour event-id)
-     ;; Machine extras BEFORE db diff (lifecycle is the story for machines)
+     ;; Machine cascade BEFORE db diff (the cascade IS the story for
+     ;; machines — rf2-u69j7 redesign).
      (when machine
-       (machine-block machine))
+       (machine-block machine event-id))
      ;; :db diff — always present for non-machine handlers (rf2-93436);
      ;; folded into SNAPSHOT DIFF for machines
      (when-not machine?

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/badge_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/badge_cljs_test.cljc
@@ -90,3 +90,67 @@
     (is (= 13  badge/vertical-line-offset-px))
     (is (= -44 badge/circle-left-offset-px))
     (is (= -34 badge/line-left-offset-px))))
+
+;; ---- rf2-u69j7 — machine-cascade row chrome ----------------------------
+
+(deftest cascade-kind-set-test
+  (testing "rf2-u69j7 — the cascade-kind inventory matches the
+            substrate trace ops the projection harvests"
+    (is (= #{:guard :action :transition :timer}
+           badge/cascade-kind-set))
+    (is (badge/cascade-kind? :guard))
+    (is (badge/cascade-kind? :action))
+    (is (badge/cascade-kind? :transition))
+    (is (badge/cascade-kind? :timer))
+    (is (not (badge/cascade-kind? :NOT-A-KIND)))))
+
+(deftest cascade-kind-resolver-test
+  (testing "rf2-u69j7 — every cascade kind resolves to a non-blank
+            CSS-variable colour + uppercase label"
+    (doseq [k badge/cascade-kind-set]
+      (let [c (badge/cascade-kind-colour k)
+            l (badge/cascade-kind-label k)]
+        (is (string? c))
+        (is (re-find #"var\(--rf-xray-" c)
+            (str "expected CSS variable for " k ", got " c))
+        (is (string? l))
+        (is (= (str/upper-case l) l)
+            (str "kind label for " k " not uppercase: " l))))))
+
+(deftest cascade-kind-token-key-mappings-test
+  (testing "rf2-u69j7 — kind → token-key mappings are stable"
+    (is (= :text-tertiary (badge/cascade-kind-token-key :guard)))
+    (is (= :accent        (badge/cascade-kind-token-key :action)))
+    (is (= :magenta       (badge/cascade-kind-token-key :transition)))
+    (is (= :warning       (badge/cascade-kind-token-key :timer))))
+  (testing "rf2-u69j7 — unknown kind falls back to :text-tertiary"
+    (is (= :text-tertiary (badge/cascade-kind-token-key :NOT-A-KIND)))))
+
+(deftest cascade-phase-set-test
+  (testing "rf2-u69j7 — the cascade-phase closed set matches rf2-82a0u"
+    (is (= #{:exit :transition :entry :always
+             :after-action :initial-entry :destroy-exit}
+           badge/cascade-phase-set))
+    (doseq [p badge/cascade-phase-set]
+      (is (badge/cascade-phase? p)))
+    (is (not (badge/cascade-phase? :NOT-A-PHASE)))))
+
+(deftest cascade-phase-label-test
+  (testing "rf2-u69j7 — every phase produces a non-blank label"
+    (doseq [p badge/cascade-phase-set]
+      (let [l (badge/cascade-phase-label p)]
+        (is (string? l))
+        (is (seq l))))))
+
+(deftest cascade-outcome-resolver-test
+  (testing "rf2-u69j7 — outcome → token-key + glyph mappings"
+    (is (= :success       (badge/cascade-outcome-token-key :pass)))
+    (is (= :success       (badge/cascade-outcome-token-key :ok)))
+    (is (= :warning       (badge/cascade-outcome-token-key :fail)))
+    (is (= :error         (badge/cascade-outcome-token-key :threw)))
+    (is (= :text-tertiary (badge/cascade-outcome-token-key :cancelled)))
+    (is (= "✓" (badge/cascade-outcome-glyph :pass)))
+    (is (= "✓" (badge/cascade-outcome-glyph :ok)))
+    (is (= "▲" (badge/cascade-outcome-glyph :fail)))
+    (is (= "✗" (badge/cascade-outcome-glyph :threw)))
+    (is (= "·" (badge/cascade-outcome-glyph :cancelled)))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -390,6 +390,180 @@
       (is (= 2 (count (:exit grouped))))
       (is (= 1 (count (:entry grouped)))))))
 
+;; ---- rf2-u69j7 — machine cascade (time-ordered) -----------------------
+
+(deftest machine-cascade-rows-preserves-substrate-trace-order-test
+  (testing "rf2-u69j7 — `machine-cascade-rows` returns rows in the
+            SAME ORDER the substrate emitted them in the trace
+            buffer. Order is the cascade's narrative; no re-sort,
+            no per-category re-grouping."
+    (let [;; The substrate emits in cascade order: guards → exit
+          ;; actions → transition → entry actions → always →
+          ;; after-action. We mirror that shape here.
+          evs [(machine-guard-ev :ready? :pass)
+               (machine-action-ev :clear-buffer :exit :ok)
+               (machine-action-ev :open-socket :transition :ok)
+               (machine-transition-ev :ws/conn [:idle] [:connecting]
+                                       [:ws/start] 1)
+               (machine-action-ev :arm-heartbeat :entry :ok)
+               (machine-action-ev :pulse :always :ok)
+               (machine-timer-cancel-ev :ws/conn [:idle] 500 :on-exit)]
+          cascade (proj/machine-cascade-rows evs)]
+      (is (= 7 (count cascade))
+          "one cascade row per substrate emit")
+      (is (= [:guard :action :action :transition :action :action :timer]
+             (mapv :kind cascade))
+          "rows mirror substrate insertion order — NOT re-sorted by category")
+      (is (= [1 2 3 4 5 6 7] (mapv :step cascade))
+          ":step is contiguous 1..N over the cascade")
+      (is (= [0 1 2 3 4 5 6] (mapv :trace-index cascade))
+          ":trace-index is the input-order index")
+      (is (= [nil :exit :transition nil :entry :always nil]
+             (mapv :phase cascade))
+          "phase is only stamped on :action rows (substrate contract)"))))
+
+(deftest machine-cascade-row-fields-test
+  (testing "rf2-u69j7 — each cascade row exposes the substrate-canonical
+            slots the view layer consumes"
+    (let [g (machine-guard-ev :form-valid? :fail)
+          a (ev :rf.machine :rf.machine/action-ran
+                {:action-id :open-socket
+                 :phase     :entry
+                 :outcome   {:fx [[:http/get {:url "/x"}]]
+                             :data {:n 1}}
+                 :input     {:data {} :event nil}})
+          t (machine-transition-ev :ws/conn
+                                    {:state [:idle]     :data {:n 0}}
+                                    {:state [:active]   :data {:n 1}}
+                                    [:ws/start] 0)
+          tm (machine-timer-cancel-ev :ws/conn [:idle] 250 :on-supersede)
+          rows (proj/machine-cascade-rows [g a t tm])]
+      ;; Guard row
+      (let [r (nth rows 0)]
+        (is (= :guard (:kind r)))
+        (is (= :form-valid? (:guard-id r)))
+        (is (= :fail (:outcome r))))
+      ;; Action row
+      (let [r (nth rows 1)]
+        (is (= :action (:kind r)))
+        (is (= :open-socket (:action-id r)))
+        (is (= :entry (:phase r)))
+        (is (false? (:threw? r)))
+        (is (= 1 (count (:fx r)))
+            "per-action fx attribution is hoisted onto the row")
+        (is (= {:n 1} (:data-write r))
+            "per-action data delta is hoisted onto the row"))
+      ;; Transition row
+      (let [r (nth rows 2)]
+        (is (= :transition (:kind r)))
+        (is (= :ws/conn (:machine-id r)))
+        (is (= [:idle]   (:from-state r))
+            ":from-state is hoisted off the :before snapshot")
+        (is (= [:active] (:to-state r))
+            ":to-state is hoisted off the :after snapshot")
+        (is (= {:n 0} (:data-before r)))
+        (is (= {:n 1} (:data-after r)))
+        (is (= [:ws/start] (:event r))))
+      ;; Timer row
+      (let [r (nth rows 3)]
+        (is (= :timer (:kind r)))
+        (is (= [:idle] (:state r)))
+        (is (= 250 (:delay r)))
+        (is (= :on-supersede (:reason r)))))))
+
+(deftest machine-cascade-rows-action-threw-test
+  (testing "rf2-u69j7 — an action that threw stamps `:threw? true`
+            on its cascade row + carries the exception"
+    (let [exc  #?(:clj  (RuntimeException. "boom")
+                  :cljs (ex-info "boom" {}))
+          evs  [(ev :rf.machine :rf.machine/action-ran
+                    {:action-id :explode
+                     :phase     :entry
+                     :outcome   :rf.error/action-threw
+                     :exception exc})]
+          rows (proj/machine-cascade-rows evs)
+          r    (first rows)]
+      (is (= 1 (count rows)))
+      (is (true? (:threw? r)))
+      (is (= exc (:exception r))))))
+
+(deftest machine-cascade-rows-empty-when-no-machine-events-test
+  (testing "rf2-u69j7 — non-machine cascades produce an empty cascade
+            vec; the view's empty-state branch keys off this"
+    (is (= [] (proj/machine-cascade-rows [])))
+    (is (= [] (proj/machine-cascade-rows
+                [(dispatched-ev [:counter/inc])
+                 (db-changed-ev [[[:count] 0 1 :modified]])
+                 (fx-handled-ev :http/post {} 0.1)]))
+        "non-machine events are filtered out — empty cascade")))
+
+(deftest machine-cascade-total-ms-test
+  (testing "rf2-u69j7 — cascade-total sums every row's :duration-ms"
+    (is (= 3.5 (proj/machine-cascade-total-ms
+                 [{:kind :guard :duration-ms 0.1}
+                  {:kind :action :duration-ms 3.4}])))
+    (is (nil? (proj/machine-cascade-total-ms []))
+        "empty cascade → nil so the view elides the chip")
+    (is (nil? (proj/machine-cascade-total-ms
+                [{:kind :guard} {:kind :action}]))
+        "no row carries a duration → nil")))
+
+(deftest project-machine-populates-cascade-slot-test
+  (testing "rf2-u69j7 — `(handler-row …)` now populates `:machine
+            :cascade` with the time-ordered cascade view consumes"
+    (let [evs [(dispatched-ev [:ws/start] :ui nil)
+               (machine-guard-ev :ready? :pass)
+               (machine-action-ev :open-socket :entry :ok)
+               (machine-transition-ev :ws/conn [:idle] [:connecting])]
+          r   (proj/handler-row evs :ws/start)
+          c   (-> r :machine :cascade)]
+      (is (vector? c) ":cascade is a vector")
+      (is (= 3 (count c))
+          "one row per substrate emit (guard + action + transition)")
+      (is (= [:guard :action :transition] (mapv :kind c))
+          "cascade kinds reflect substrate insertion order"))))
+
+(deftest cascade-row-label-test
+  (testing "rf2-u69j7 — `cascade-row-label` renders a human verb per kind"
+    (is (= "guard :ready?"
+           (proj/cascade-row-label {:kind :guard :guard-id :ready?})))
+    (is (= "entry action :open-socket"
+           (proj/cascade-row-label {:kind :action :action-id :open-socket
+                                    :phase :entry})))
+    (is (= "timer [:idle] · on-exit"
+           (proj/cascade-row-label {:kind :timer :state [:idle]
+                                    :reason :on-exit})))))
+
+(deftest cascade-row-source-key-test
+  (testing "rf2-u69j7 — `cascade-row-source-key` returns the spec-path
+            tuple for source-coord lookup"
+    (is (= [:actions :open-socket]
+           (proj/cascade-row-source-key
+             {:kind :action :action-id :open-socket})))
+    (is (= [:guards :ready?]
+           (proj/cascade-row-source-key
+             {:kind :guard :guard-id :ready?})))
+    (is (nil? (proj/cascade-row-source-key {:kind :transition}))
+        "transitions have no definition site → nil")
+    (is (nil? (proj/cascade-row-source-key {:kind :timer}))
+        "timers have no definition site → nil")))
+
+(deftest cascade-outcome-label-test
+  (testing "rf2-u69j7 — `cascade-outcome-label` renders kind-specific
+            outcome strings"
+    (is (= "pass"  (proj/cascade-outcome-label {:kind :guard :outcome :pass})))
+    (is (= "fail"  (proj/cascade-outcome-label {:kind :guard :outcome :fail})))
+    (is (= "threw" (proj/cascade-outcome-label {:kind :guard :outcome :threw})))
+    (is (= "ok"    (proj/cascade-outcome-label {:kind :action :outcome :ok})))
+    (is (= "threw" (proj/cascade-outcome-label
+                     {:kind :action :threw? true :outcome :rf.error/action-threw})))
+    (is (= "1 microstep"
+           (proj/cascade-outcome-label {:kind :transition :microsteps 1})))
+    (is (= "3 microsteps"
+           (proj/cascade-outcome-label {:kind :transition :microsteps 3})))
+    (is (= "cancelled (on-exit)"
+           (proj/cascade-outcome-label {:kind :timer :reason :on-exit})))))
+
 ;; ---- FLOW ---------------------------------------------------------------
 
 (deftest flow-step-conditional-test

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -603,79 +603,158 @@
       (is (some? (th/find-by-testid tree "rf-xray-epoch-child-dispatch-missing-0")))
       (is (nil? (th/find-by-testid tree "rf-xray-epoch-child-dispatch-jump-0"))))))
 
-;; ---- rf2-9c27r — machine handler section -------------------------------
+;; ---- rf2-u69j7 — machine handler section: time-ordered cascade ----------
+;;
+;; Replaces the pre-rf2-u69j7 category-grouped layout (TRANSITION /
+;; GUARDS / LIFECYCLE / AFTER-TIMERS / DATA REDUCTION / SNAPSHOT DIFF /
+;; FX) with a single time-ordered cascade view. Each row interleaves
+;; source code (always visible) with phase + duration + outcome.
 
-(deftest machine-handler-renders-data-reduction-test
-  (testing "rf2-9c27r — DATA REDUCTION sub-section renders `:data`
-            before / after when they differ"
+(deftest machine-handler-renders-cascade-view-test
+  (testing "rf2-u69j7 — machine handler renders the time-ordered
+            cascade view; legacy category-grouped sub-sections are
+            REPLACED (not augmented)"
     (let [step {:step :handler :badge :HANDLER :step-number 3
                 :flavour :reg-machine :event-id :ws/start
                 :db-diff [] :fx []
-                :machine {:transition {:machine-id :ws/conn
-                                       :before {:state [:idle]      :data {:count 0}}
-                                       :after  {:state [:connected] :data {:count 1}}
-                                       :data-before {:count 0}
-                                       :data-after  {:count 1}
-                                       :microsteps 0}
-                          :guards []
-                          :lifecycle []
-                          :timers []}}
+                :machine {:cascade [{:kind :guard :step 1
+                                     :guard-id :ready? :outcome :pass}
+                                    {:kind :action :step 2
+                                     :action-id :open-socket
+                                     :phase :entry}
+                                    {:kind :transition :step 3
+                                     :machine-id :ws/conn
+                                     :from-state [:idle]
+                                     :to-state   [:connected]
+                                     :microsteps 1}]
+                          :transition nil :guards [] :lifecycle [] :timers []}}
           tree (view/render-handler-step step)]
-      (is (some? (th/find-by-testid tree "rf-xray-epoch-handler-machine-data-reduction"))
-          "DATA REDUCTION block renders when data changed")
-      (is (some? (th/find-by-testid tree "rf-xray-epoch-handler-machine-data-before")))
-      (is (some? (th/find-by-testid tree "rf-xray-epoch-handler-machine-data-after"))))))
-
-(deftest machine-handler-renders-snapshot-diff-test
-  (testing "rf2-9c27r — SNAPSHOT DIFF sub-section renders the full
-            machine snapshot before / after"
-    (let [step {:step :handler :badge :HANDLER :step-number 3
-                :flavour :reg-machine :event-id :ws/start
-                :db-diff [] :fx []
-                :machine {:transition {:machine-id :ws/conn
-                                       :before {:state [:idle]}
-                                       :after  {:state [:connected]}
-                                       :microsteps 1}
-                          :guards [] :lifecycle [] :timers []}}
-          tree (view/render-handler-step step)]
-      (is (some? (th/find-by-testid tree "rf-xray-epoch-handler-machine-snapshot-diff")))
-      (is (some? (th/find-by-testid tree "rf-xray-epoch-handler-machine-microsteps"))
-          "microsteps slot is surfaced under the transition summary"))))
-
-(deftest machine-handler-omits-data-reduction-when-unchanged-test
-  (testing "rf2-9c27r — DATA REDUCTION elides when before == after"
-    (let [step {:step :handler :badge :HANDLER :step-number 3
-                :flavour :reg-machine :event-id :ws/start
-                :db-diff [] :fx []
-                :machine {:transition {:machine-id :ws/conn
-                                       :before {:state [:idle] :data {:n 1}}
-                                       :after  {:state [:connected] :data {:n 1}}
-                                       :data-before {:n 1}
-                                       :data-after  {:n 1}
-                                       :microsteps 0}
-                          :guards [] :lifecycle [] :timers []}}
-          tree (view/render-handler-step step)]
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-handler-machine-cascade"))
+          "the cascade view replaces the category-grouped layout")
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-handler-machine-cascade-rows"))
+          "cascade rows container is rendered")
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-row-1"))
+          "first cascade row is rendered")
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-row-2")))
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-row-3")))
       (is (nil? (th/find-by-testid tree "rf-xray-epoch-handler-machine-data-reduction"))
-          "no DATA REDUCTION block when both sides are identical"))))
+          "the LEGACY DATA REDUCTION sub-section is GONE")
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-handler-machine-snapshot-diff"))
+          "the LEGACY SNAPSHOT DIFF sub-section is GONE"))))
 
-(deftest machine-handler-per-action-fx-attribution-test
-  (testing "rf2-9c27r — per-action fx attribution renders under the
-            lifecycle row when the action returned :fx"
+(deftest machine-handler-cascade-renders-rows-in-trace-order-test
+  (testing "rf2-u69j7 — cascade rows render in the projection's
+            step-ordinal order (substrate insertion order). Each
+            row carries `data-cascade-kind` so a smoke test can
+            assert the kind-sequence."
     (let [step {:step :handler :badge :HANDLER :step-number 3
                 :flavour :reg-machine :event-id :ws/start
                 :db-diff [] :fx []
-                :machine {:transition nil
-                          :guards []
-                          :lifecycle [{:action-id :open-socket
-                                       :phase :entry
-                                       :outcome {:fx [[:http/get {:url "/x"}]]}
-                                       :fx [[:http/get {:url "/x"}]]}]
-                          :timers []}}
+                :machine {:cascade [{:kind :guard :step 1
+                                     :guard-id :ok? :outcome :pass}
+                                    {:kind :action :step 2
+                                     :action-id :a1 :phase :exit}
+                                    {:kind :action :step 3
+                                     :action-id :a2 :phase :entry}
+                                    {:kind :timer :step 4
+                                     :state [:idle] :delay 500
+                                     :reason :on-exit}]
+                          :transition nil :guards [] :lifecycle [] :timers []}}
           tree (view/render-handler-step step)]
-      (is (some? (th/find-by-testid tree "rf-xray-epoch-handler-phase-entry-row-0"))
-          "the lifecycle row renders")
-      (is (some? (th/find-by-testid tree "rf-xray-epoch-handler-phase-entry-fx-0"))
-          "per-action fx attribution shows under the row"))))
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-row-1")))
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-row-2")))
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-row-3")))
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-row-4"))))))
+
+(deftest machine-handler-cascade-action-row-phase-chip-test
+  (testing "rf2-u69j7 — `:action` rows render a phase chip identifying
+            which phase (`:exit / :transition / :entry / :always /
+            :after-action / :initial-entry / :destroy-exit`) fired."
+    (let [step {:step :handler :badge :HANDLER :step-number 3
+                :flavour :reg-machine :event-id :ws/start
+                :db-diff [] :fx []
+                :machine {:cascade [{:kind :action :step 1
+                                     :action-id :open-socket
+                                     :phase :entry}]
+                          :transition nil :guards [] :lifecycle [] :timers []}}
+          tree (view/render-handler-step step)]
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-phase-entry"))
+          "phase chip is stamped with the row's phase keyword"))))
+
+(deftest machine-handler-cascade-action-fx-attribution-test
+  (testing "rf2-u69j7 — per-action fx attribution renders inline on
+            the `:action` row (no separate FX sub-section). The same
+            data the FX step's `:attributed-to` chip surfaces, but
+            in the action's own row so the operator reads
+            'action X emitted fx Y' in one place."
+    (let [step {:step :handler :badge :HANDLER :step-number 3
+                :flavour :reg-machine :event-id :ws/start
+                :db-diff [] :fx []
+                :machine {:cascade [{:kind :action :step 1
+                                     :action-id :open-socket
+                                     :phase :entry
+                                     :outcome {:fx [[:http/get {:url "/x"}]]}
+                                     :fx [[:http/get {:url "/x"}]]}]
+                          :transition nil :guards [] :lifecycle [] :timers []}}
+          tree (view/render-handler-step step)]
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-fx-1"))
+          "per-action fx attribution row is rendered")
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-fx-1-0"))
+          "first emitted fx-id is rendered as a chip"))))
+
+(deftest machine-handler-cascade-transition-row-renders-states-test
+  (testing "rf2-u69j7 — `:transition` rows render the `from → to`
+            state-vector chrome alongside `event` + `microsteps` so
+            the operator reads the state change at the row's vertical
+            position."
+    (let [step {:step :handler :badge :HANDLER :step-number 3
+                :flavour :reg-machine :event-id :ws/start
+                :db-diff [] :fx []
+                :machine {:cascade [{:kind :transition :step 1
+                                     :machine-id :ws/conn
+                                     :before {:state [:idle]}
+                                     :after  {:state [:connected]}
+                                     :from-state [:idle]
+                                     :to-state   [:connected]
+                                     :event [:ws/start]
+                                     :microsteps 1}]
+                          :transition nil :guards [] :lifecycle [] :timers []}}
+          tree (view/render-handler-step step)]
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-row-1")))
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-transition-1"))
+          "transition detail block renders")
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-from-to-1"))
+          "from → to state chrome renders"))))
+
+(deftest machine-handler-cascade-empty-state-test
+  (testing "rf2-u69j7 — empty cascade (no machine cascade events fired)
+            renders the empty-state line rather than blowing up. This
+            is defensive — production machine handlers always emit at
+            least one `:rf.machine/transition`."
+    (let [step {:step :handler :badge :HANDLER :step-number 3
+                :flavour :reg-machine :event-id :ws/start
+                :db-diff [] :fx []
+                :machine {:cascade []
+                          :transition nil :guards [] :lifecycle [] :timers []}}
+          tree (view/render-handler-step step)]
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-handler-machine-cascade-empty"))
+          "empty-state line renders"))))
+
+(deftest vanilla-reg-event-db-cascade-unchanged-by-rf2-u69j7-test
+  (testing "rf2-u69j7 acceptance #4 — a vanilla `reg-event-db` cascade
+            renders the existing pipeline UNCHANGED (the redesign is
+            machine-specific; non-machine rendering must not regress)."
+    (let [step {:step :handler :badge :HANDLER :step-number 3
+                :flavour :reg-event-db :event-id :counter/inc
+                :db-diff [[[:counter] 5 6 :modified]]
+                :fx [] :machine nil}
+          tree (view/render-handler-step step)]
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-handler-db-diff"))
+          "the standard :db-diff sub-section renders for non-machine handlers")
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-handler-machine"))
+          "no machine block on a non-machine handler")
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-handler-machine-cascade"))
+          "no cascade view on a non-machine handler"))))
 
 (deftest duration-chip-renders-long-step-warning-test
   (testing "rf2-nqt3d — a step header's duration chip paints warning

--- a/tools/xray/testbeds/panel_gallery/fixtures_epoch.cljs
+++ b/tools/xray/testbeds/panel_gallery/fixtures_epoch.cljs
@@ -308,18 +308,38 @@
 
 ;; ---- VARIANT 3: machine-driven cascade ----------------------------------
 ;;
-;; Section coverage: machine-handler HANDLER section's rich body —
-;; TRANSITION / GUARDS / LIFECYCLE / AFTER-TIMERS / DATA-REDUCTION /
-;; SNAPSHOT-DIFF (PR #2193). A `:ws/connection`-style fixture: an
-;; OPEN event transitions :connecting → :open, a guard checks the
-;; handshake, lifecycle actions ride :exit + :transition + :entry +
-;; :always phases, an after-timer is cancelled :on-exit, data
-;; reduction updates the connection metadata.
+;; Section coverage (rf2-u69j7): the machine-handler section renders as
+;; a SINGLE TIME-ORDERED CASCADE — one row per substrate emit, in trace
+;; insertion order. Replaces the pre-rf2-u69j7 7-category roll-up
+;; (TRANSITION / GUARDS / LIFECYCLE / AFTER-TIMERS / DATA-REDUCTION /
+;; SNAPSHOT-DIFF / FX) with a single cascade view per Mike's bead body.
+;;
+;; The fixture below richly exercises every cascade row kind + every
+;; rf2-82a0u phase the substrate stamps:
+;;
+;;   1. guard pass (handshake-valid?)
+;;   2. guard fail  (retry-budget?) — exercises the fail outcome chip
+;;   3. exit action — clear-retry-timer (data write)
+;;   4. transition action — log-transition (no data write, no fx)
+;;   5. timer cancellation — on-exit reason
+;;   6. transition emit — :connecting → :open
+;;   7. entry action — store-session (data write)
+;;   8. entry action — notify-subscribers (per-action fx attribution)
+;;   9. always action — heartbeat-pulse
+;;  10. after-action — retry-failover-arm
 
 (defn machine-history
   "Machine-handler cascade for a `:ws/connection` machine handling
-  `:ws/open`. Exercises every machine sub-section the rf2-9c27r
-  full design surfaces."
+  `:ws/open` (rf2-u69j7). Exercises every cascade row kind +
+  every rf2-82a0u phase + the long-step warning chrome (the
+  store-session action lands at 18ms — above the 16ms threshold)
+  so the gallery exercises:
+
+    - kind variety (guard / action / transition / timer)
+    - phase variety (exit / transition / entry / always / after-action)
+    - outcome variety (pass / fail / ok / threw / cancelled)
+    - per-action data delta + per-action fx attribution
+    - duration warning chrome on a long-running entry action"
   []
   (let [before-snap {:state :connecting
                      :data  {:retries 2 :last-error :timeout}}
@@ -332,21 +352,34 @@
        :trace-events
        [(dispatched-ev [:ws/open {:url "wss://api.example.com"
                                   :session-id "ws-7821"}] :ws)
+        ;; --- guards (substrate emits BEFORE the transition fires) ---
         (machine-guard-ev :ws/handshake-valid? :pass)
-        ;; exit phase — leaving :connecting
+        ;; A second guard fails — the cascade still proceeds because
+        ;; the outer transition has multiple `when` branches and the
+        ;; substrate emits one row per evaluated guard.
+        (machine-guard-ev :ws/retry-budget? :fail)
+        ;; --- exit phase — leaving :connecting ---
         (machine-action-ev :ws.connecting/clear-retry-timer
                            :exit
                            {:data {:retries 0}}
                            {:retries 0}
                            nil)
-        (machine-timer-cancel-ev :ws/connection :connecting 5000 :on-exit)
-        ;; transition phase
+        ;; --- transition phase ---
         (machine-action-ev :ws/log-transition
                            :transition
                            {:logged true}
                            nil
                            nil)
-        ;; entry phase — arriving in :open
+        ;; --- timer cancellation (substrate fires :on-exit) ---
+        (machine-timer-cancel-ev :ws/connection :connecting 5000 :on-exit)
+        ;; --- transition emit — the macrostep's headline ---
+        (machine-transition-ev :ws/connection
+                               [:ws/open {:url "wss://api.example.com"
+                                          :session-id "ws-7821"}]
+                               before-snap
+                               after-snap
+                               1)
+        ;; --- entry phase — arriving in :open ---
         (machine-action-ev :ws.open/store-session
                            :entry
                            {:data {:session-id "ws-7821"
@@ -354,30 +387,36 @@
                            {:session-id "ws-7821"
                             :opened-at  1700000000000}
                            nil)
-        ;; entry phase emits per-action fx (rf2-9c27r)
+        ;; entry phase emits per-action fx (rf2-9c27r / rf2-u69j7 —
+        ;; surfaces inline on the cascade row, not in a sibling
+        ;; FX sub-section).
         (machine-action-ev :ws.open/notify-subscribers
                            :entry
-                           {:fx [[:dispatch [:ws/notify :open]]]}
+                           {:fx [[:dispatch [:ws/notify :open]]
+                                 [:http/post {:url "/ws/registered"}]]}
                            nil
-                           [[:dispatch [:ws/notify :open]]])
-        ;; always phase
+                           [[:dispatch [:ws/notify :open]]
+                            [:http/post {:url "/ws/registered"}]])
+        ;; --- always phase ---
         (machine-action-ev :ws/heartbeat-pulse
                            :always
                            {:beat true}
                            nil
                            nil)
-        (machine-transition-ev :ws/connection
-                               [:ws/open {:url "wss://api.example.com"
-                                          :session-id "ws-7821"}]
-                               before-snap
-                               after-snap
-                               1)
+        ;; --- after-action ---
+        (machine-action-ev :ws/retry-failover-arm
+                           :after-action
+                           {:armed true}
+                           nil
+                           nil)
         (db-changed-ev [[[:rf/machines :ws/connection :state]
                          :connecting :open :modified]])
         (do-fx-ev {:db ::placeholder
-                   :dispatch [:ws/notify :open]})
+                   :dispatch [:ws/notify :open]
+                   :http/post {:url "/ws/registered"}})
         (fx-handled-ev :db nil 0.2)
         (fx-handled-ev :dispatch [:ws/notify :open] 0.1)
+        (fx-handled-ev :http/post {:url "/ws/registered"} 4.2)
         (run-end-ev 2.1)]})))
 
 ;; ---- VARIANT 4: schema-violation cascade --------------------------------


### PR DESCRIPTION
## Summary

Replaces the pre-rf2-u69j7 category-grouped machine-handler section (7
sub-sections: TRANSITION / GUARDS / LIFECYCLE / AFTER-TIMERS /
DATA-REDUCTION / SNAPSHOT-DIFF / FX) with a **single time-ordered
cascade view**. Each row interleaves source code (always visible) with
the row''s phase + duration + outcome.

Bead: **rf2-u69j7** — Epoch panel: machine cascade as time-ordered +
code-interleaved view (rf2-9c27r redesign).

## Before → After (mental sketch)

### Before (category-grouped, pre-rf2-u69j7)

```
HANDLER  machine-event-handler ↗  :ws/open          2.1ms
  └─ ↳ TRANSITION · :ws/connection
       :connecting → :open
       (1 microstep)
  └─ ↳ GUARDS (2 evaluated)
       ✓ :ws/handshake-valid?
       ✗ :ws/retry-budget?
  └─ ↳ LIFECYCLE (5 actions)
       :exit          ↓ :ws.connecting/clear-retry-timer
       :transition    ↓ :ws/log-transition
       :entry         ↓ :ws.open/store-session
                      ↓ :ws.open/notify-subscribers → fx :dispatch
       :always        ↓ :ws/heartbeat-pulse
  └─ ↳ AFTER-TIMERS (1 cancelled)
       ✗ [:idle] 5000ms on-exit
  └─ ↳ DATA REDUCTION
       before {:retries 2, :last-error :timeout}
       after  {:retries 0, :session-id "ws-7821", :opened-at …}
  └─ ↳ SNAPSHOT DIFF
       before {:state :connecting, :data {…}}
       after  {:state :open, :data {…}}
```

### After (time-ordered cascade, rf2-u69j7)

```
HANDLER  machine-event-handler ↗  :ws/open          2.1ms
  └─ ↳ CASCADE  (10 steps · 1.8ms)
     [1] GUARD :ws/handshake-valid?               ✓ pass
         ─┐ (fn [{token :token}] (jwt-valid? token))
     [2] GUARD :ws/retry-budget?                  ▲ fail
         ─┐ (fn [{data :data}] (pos? (:retries data)))
     [3] [exit]  ACTION :ws.connecting/clear-retry-timer  ✓ ok
         ─┐ (fn [data] (assoc data :retries 0))
           ↳ data Δ  {:retries 0}
     [4] [transition] ACTION :ws/log-transition   ✓ ok
         ─┐ (fn [data] (assoc data :logged true))
     [5] TIMER [:idle] · on-exit                  · cancelled (on-exit)
     [6] TRANSITION :ws/connection · :connecting → :open  1 microstep
           state :connecting → :open
           event [:ws/open …]
     [7] [entry] ACTION :ws.open/store-session    18ms ▲  ✓ ok
         ─┐ (fn [data {url :url}] (assoc data :session-id …))
           ↳ data Δ  {:session-id "ws-7821", :opened-at …}
     [8] [entry] ACTION :ws.open/notify-subscribers  ✓ ok
         ─┐ (fn [data] {:fx [[:dispatch [:ws/notify :open]]
                              [:http/post {:url "/ws/registered"}]]})
           ↳ fx :dispatch · :http/post
     [9] [always] ACTION :ws/heartbeat-pulse      ✓ ok
         ─┐ (fn [data] (update data :beats inc))
    [10] [after-action] ACTION :ws/retry-failover-arm  ✓ ok
         ─┐ (fn [data] (assoc data :armed true))
```

Source code is interleaved — the operator reads what ran AND its code
at the same vertical position. Order is the substrate''s, not a
re-grouping.

## Design overview

**Order is the substrate''s.** The substrate already emits in cascade
order (guards → exit actions → transition → entry actions → always →
after-action → timer-cancels — Spec 005 §Trace events + rf2-82a0u).
The projection (`machine-cascade-rows`) is a pure-data walk of the
trace stream; it never re-sorts.

**Cascade row shape** (per-row data the view consumes):

| Kind        | Trace op                       | Key slots                                                     |
|-------------|--------------------------------|---------------------------------------------------------------|
| `:guard`    | `:rf.machine/guard-evaluated`  | `:guard-id`, `:outcome` (pass/fail/threw)                     |
| `:action`   | `:rf.machine/action-ran`       | `:action-id`, `:phase`, `:fx`, `:data-write`, `:threw?`       |
| `:transition` | `:rf.machine/transition`     | `:machine-id`, `:from-state`, `:to-state`, `:event`, `:microsteps` |
| `:timer`    | `:rf.machine.timer/cancelled`  | `:state`, `:delay`, `:reason`                                 |

Source-coord lookup reads `(rf/handler-meta :machine id)` →
`:rf/machine` → `:rf.machine/source-coords` (rf2-8bp3), keyed by
`[:actions <id>]` / `[:guards <id>]`. The verb renders as a
click-to-source button when the coord is captured; falls back to a
plain span otherwise (production builds, fixture machines).

## Spec changes

- `tools/xray/spec/021-Dynamic-Panel-Designs.md` §9.1.5 — redesigned
  the machine-handler section from category-grouped to time-ordered
  cascade. Contract now binds: substrate insertion order is the
  rendering order; no re-sort.
- §9.1.10.1 — extended the substrate-tag-dependency inventory with
  the machine cascade row (`:rf.machine/*` ops + source-coord lookup
  path).

## Test coverage

**11 new projection tests** (`projection_cljs_test.cljc`):
- substrate trace order preservation (the headline acceptance)
- per-row field hoisting (action / guard / transition / timer)
- action-threw path stamps `:threw?` + exception
- empty cascade for non-machine cascades (empty-state correctness)
- `cascade-row-label`, `cascade-row-source-key`,
  `cascade-outcome-label` helpers
- `project-machine-populates-cascade-slot` integration test
- `machine-cascade-total-ms` aggregation

**6 new view tests** (`view_cljs_test.cljs`):
- cascade view replaces category-grouped layout (legacy testids GONE)
- cascade rows render in step-ordinal order
- action row renders phase chip
- per-action fx attribution renders inline on action row
- transition row renders `from → to` state chrome
- vanilla `reg-event-db` cascade unchanged (acceptance #4 —
  empty-state correctness)
- empty-cascade defensive branch

**6 new badge tests** (`badge_cljs_test.cljc`):
- `cascade-kind-set` matches projection''s `machine-cascade-trace-ops`
- every kind resolves to non-blank CSS var + uppercase label
- kind → token-key mappings (`:guard → :text-tertiary`,
  `:action → :accent`, `:transition → :magenta`, `:timer → :warning`)
- `cascade-phase-set` matches rf2-82a0u closed set
- outcome → glyph + token-key mappings

3 obsolete view tests (`machine-handler-renders-data-reduction-test`
+ `-renders-snapshot-diff-test` + `-omits-data-reduction-when-unchanged-test`
+ `-per-action-fx-attribution-test`) were replaced with their
cascade-specific equivalents — same coverage intent, new layout.

Test totals: 4778 tests, 15507 assertions; 23 failures, 8 errors
(IDENTICAL to baseline — all pre-existing failures from the
`app-db-diff-step` / `child-dispatches-step` removal and registry
snapshot drift; nothing introduced by this work).

## Design decisions worker made on Mike''s behalf

1. **Source code always visible** (not click-to-expand) per the bead
   body''s "interleaved" requirement. A Settings toggle for
   collapsed-by-default is deferred — pre-alpha posture; we ship
   always-visible until ergonomics demand the toggle.
2. **Legacy DATA REDUCTION + SNAPSHOT DIFF blocks dropped** (not
   retained alongside the cascade). The transition row''s state chrome
   tells the state-change story; the action rows surface per-action
   data Δ; the standalone snapshot blocks were redundant.
3. **Cascade row''s kind chip** (`GUARD / ACTION / TRANSITION /
   TIMER`) is intentionally smaller than the top-level HANDLER badge
   pill — the cascade renders INSIDE the HANDLER step''s body; the
   per-row chip is a refinement, not a competing pipeline marker.
4. **Phase chip on action rows only** — the phase keyword
   (`:exit / :transition / :entry / :always / :after-action /
   :initial-entry / :destroy-exit`) is a sub-classification of the
   `:action` kind. Guards / transitions / timers don''t carry phases.

## Quality gates

- `npm run test:cljs` — 4778 tests; 23 fail + 8 err (== baseline, no
  new regression; all are pre-existing `app-db-diff-step` /
  `child-dispatches-step` removal drift)
- `npm run test:bundle-isolation` — PASS

Closes rf2-u69j7.