### PR TITLE
feat(machines-viz): render :always + :after transitions as event-nodes (rf2-ezqpm)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -3223,6 +3223,27 @@ Edge label: `:micro` (`~10px`) JetBrains Mono in `:text-secondary`,
 rendered inline on the edge (xyflow's `label` prop), not in a side
 legend.
 
+**Transition kinds projected onto edges (rf2-ezqpm).** The topology
+projection at `tools/xray/src/.../panels/machines/topology.cljs`
+inspects all three first-class transition-source slots a state node
+may carry (Spec 005). Each emits its own edge; the edge style table
+above applies uniformly to all three kinds (their distinction is
+encoded in the label glyph, not the stroke). The label conventions
+match `machines-viz/chart.layout/event-segment` (rf2-a2b55, the single
+source of truth for the Stately graph-view glyphs):
+
+| Slot | Edge label segment | Edge data flags | Spec |
+|---|---|---|---|
+| `(:on    state-node)` — event-triggered | `event-id` (ns preserved; `:*` → `* (any)`) | (none) | Spec 005 §`:on` map |
+| `(:after state-node)` — delay-fired | `⌚ <delay>ms` | `:after <delay>` | Spec 005 §Delayed `:after` |
+| `(:always state-node)` — eventless / transient | `∞` | `:always? true` | Spec 005 §Eventless `:always` |
+
+`:after`'s `<delay>` is the ms-key of the `{ms transition-spec}` map
+entry — each entry schedules an independent timer and therefore mints
+its own edge. `:always`'s guarded-fork grammar (`[{:target … :guard …}
+…]`) forks into one edge per candidate; the per-candidate ordinal in
+the edge id keeps every branch addressable in xyflow.
+
 #### §17.4.4 Layout direction + default zoom
 
 - **Direction**: left-to-right (xyflow `dagre` `rankdir: 'LR'`) — matches

--- a/tools/xray/src/day8/re_frame2_xray/panels/machines/topology.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machines/topology.cljs
@@ -41,6 +41,26 @@
     - `:registered`           — every other edge (registered, never
                                 traversed).
 
+  ## Transition-source slots (rf2-ezqpm)
+
+  `collect-edges` walks THREE transition slots on every state node
+  (Spec 005 first-class — pre-rf2-ezqpm only `:on` was inspected,
+  dropping `:always` + `:after` entirely):
+
+    - `(:on    state-node)` — event-triggered transitions.
+    - `(:after state-node)` — delay-fired transitions. One edge per
+                              `[delay spec]` entry; edge carries
+                              `:after <delay>` + label `⌚ <delay>ms`.
+    - `(:always state-node)` — eventless / transient transitions.
+                              One edge per guarded candidate (the
+                              vector-of-maps fork grammar); edge
+                              carries `:always? true` + label `∞`.
+
+  Glyph conventions match `machines-viz/chart.layout/event-segment`
+  (rf2-a2b55 — Stately graph view). Downstream consumers can split
+  by transition-kind via the `:after` / `:always?` fields on each
+  edge (also surfaced into the projected `:data`).
+
   ## Layout posture
 
   Initial v1 uses a deterministic top-to-bottom grid lift from the
@@ -143,51 +163,174 @@
     (fn? v)      (or (some-> v meta :name str) "fn")
     :else        (str v)))
 
+(defn- event-segment-str
+  "Render the leading event segment of an edge label per the Stately
+  graph view convention (rf2-a2b55, single source of truth in
+  `machines-viz/chart.layout/event-segment`):
+
+    - `:after <delay>` transition  → `\"⌚ <delay>ms\"` (clock glyph)
+    - `:always`        transition  → `\"∞\"`           (infinity glyph)
+    - regular event keyword         → `\"event-id\"` (ns preserved)
+
+  The xstate-textual `after(<delay>)` / `always` forms are NOT used
+  here — the Figma reconcile (spec/021 §6.2) + rf2-a2b55 fix the glyphs
+  as the canonical encoding so an `:always` / `:after` edge reads at a
+  glance against ordinary event arrows."
+  [{:keys [event after always?]}]
+  (cond
+    after            (str "⌚ " after "ms")
+    always?          "∞"
+    :else            (seg-name event)))
+
 (defn- edge-label-str
   "Compose an xstate-stately edge label: `event [guard] / action`.
   Brackets / slash appear ONLY when the segment is present, matching
   `machines-viz`'s `chart.layout/edge-label` convention. Fn-safe via
-  `seg-name`."
-  [event-id guard action]
-  (str (seg-name event-id)
-       (when guard  (str " [" (seg-name guard) "]"))
-       (when action (str " / " (seg-name action)))))
+  `seg-name`. The event segment uses the Stately glyph for `:after`
+  and `:always` (rf2-a2b55 · rf2-ezqpm) — `event-segment-str`."
+  [edge]
+  (let [{:keys [guard action]} edge]
+    (str (event-segment-str edge)
+         (when guard  (str " [" (seg-name guard) "]"))
+         (when action (str " / " (seg-name action))))))
+
+(defn- target-of
+  "Pull the target keyword off a transition spec. The spec may be a
+  bare keyword (`:populated`) or a map (`{:target :populated …}`).
+  Returns nil for any other shape."
+  [spec]
+  (cond
+    (keyword? spec) spec
+    (map? spec)     (:target spec)
+    :else           nil))
+
+(defn- spec-attrs
+  "Pull `:guard` / `:action` off a transition spec map (or nil for a
+  bare-keyword spec)."
+  [spec]
+  (when (map? spec)
+    {:guard  (:guard spec)
+     :action (:action spec)}))
+
+(defn- on-edges
+  "Emit one edge per `(:on state-node)` entry. Event-triggered
+  transitions — the legacy projection's only edge kind."
+  [parent-path from-path on]
+  (for [[event-id target-spec] on
+        :let [target-id (target-of target-spec)
+              {:keys [guard action]} (spec-attrs target-spec)
+              to-path   (when target-id
+                          (conj (vec parent-path) target-id))]
+        :when to-path]
+    (let [edge {:from   from-path
+                :to     to-path
+                :event  event-id
+                :guard  guard
+                :action action}]
+      (assoc edge
+        :id    (str (node-id-for-path from-path) "__"
+                    (node-id-for-path to-path) "__"
+                    (name event-id))
+        :label (edge-label-str edge)))))
+
+(defn- after-edges
+  "Emit one edge per `(:after state-node)` entry — Spec 005 §Delayed
+  `:after` transitions (rf2-ezqpm). `after-map` is `{delay-ms spec
+  ...}`; each delay schedules an independent timer. Edge label uses the
+  Stately clock glyph + `<delay>ms` (rf2-a2b55)."
+  [parent-path from-path after-map]
+  (for [[delay spec] after-map
+        :let [target-id (target-of spec)
+              {:keys [guard action]} (spec-attrs spec)
+              to-path   (when target-id
+                          (conj (vec parent-path) target-id))]
+        :when to-path]
+    (let [edge {:from   from-path
+                :to     to-path
+                :event  (keyword (str "after-" delay))
+                :after  delay
+                :guard  guard
+                :action action}]
+      (assoc edge
+        :id    (str (node-id-for-path from-path) "__"
+                    (node-id-for-path to-path) "__"
+                    "after-" delay)
+        :label (edge-label-str edge)))))
+
+(defn- always-edges
+  "Emit one edge per `(:always state-node)` entry — Spec 005 §Eventless
+  `:always` transitions (rf2-ezqpm). `always-spec` may be a bare keyword
+  / map / vector-of-maps (the guarded-fork grammar). Edge label uses the
+  Stately infinity glyph (rf2-a2b55).
+
+  Multiple guarded candidates fork into multiple edges sharing the same
+  from→to event segment — the per-candidate ordinal disambiguates the
+  edge id so xyflow keeps every branch (mirrors `parse-flat`'s ordinal
+  scheme in `machines-viz/chart.layout`)."
+  [parent-path from-path always-spec]
+  (let [candidates (cond
+                     (nil? always-spec)     []
+                     (keyword? always-spec) [always-spec]
+                     (map? always-spec)     [always-spec]
+                     (vector? always-spec)  always-spec
+                     :else                  [])
+        base-id    (str (node-id-for-path from-path) "__always__")]
+    (->> candidates
+         (keep-indexed
+           (fn [idx spec]
+             (let [target-id (target-of spec)
+                   {:keys [guard action]} (spec-attrs spec)
+                   to-path   (when target-id
+                               (conj (vec parent-path) target-id))]
+               (when to-path
+                 (let [edge {:from    from-path
+                             :to      to-path
+                             :event   :always
+                             :always? true
+                             :guard   guard
+                             :action  action}]
+                   (assoc edge
+                     :id    (str base-id
+                                 (node-id-for-path to-path)
+                                 (when (pos? idx) (str "__" idx)))
+                     :label (edge-label-str edge)))))))
+         vec)))
 
 (defn- collect-edges
   "Walk a `{state-id state-node}` map; emit edges. Each edge is
-  `{:from :to :label :id :event :guard :action}`. Reads the `:on` map
-  (event-id → target-spec) on every state INCLUDING compound substates
-  (recurses). Map target-specs surface their `:guard` / `:action` into
-  the xstate-style label. Targets resolve relative to the source's
-  parent path; self-transitions (target == source) are emitted."
+  `{:from :to :label :id :event :guard :action [:after _] [:always? _]}`.
+  Reads three transition-source slots on every state (rf2-ezqpm —
+  previously only `:on` was inspected, dropping `:always` + `:after`
+  entirely):
+
+    - `(:on state-node)`     — event-triggered transitions (legacy).
+    - `(:after state-node)`  — delay-fired transitions (Spec 005
+                               §Delayed `:after`). One edge per entry
+                               with `:after <delay>` set; label is
+                               `⌚ <delay>ms` (Stately convention,
+                               rf2-a2b55).
+    - `(:always state-node)` — eventless transitions (Spec 005
+                               §Eventless `:always`). One edge per
+                               guarded candidate with `:always? true`;
+                               label is `∞` (Stately convention,
+                               rf2-a2b55).
+
+  Compound substates recurse. Map target-specs surface their `:guard` /
+  `:action` into the xstate-style label. Targets resolve relative to
+  the source's parent path; self-transitions (target == source) are
+  emitted."
   [parent-path state-map]
   (when (map? state-map)
     (vec
       (mapcat
         (fn [[state-id state-node]]
           (let [from-path (conj (vec parent-path) state-id)
-                own (when-let [on (:on state-node)]
-                      (for [[event-id target-spec] on
-                            :let [target-id (cond
-                                              (keyword? target-spec) target-spec
-                                              (map? target-spec)     (:target target-spec)
-                                              :else                  nil)
-                                  guard     (when (map? target-spec) (:guard target-spec))
-                                  action    (when (map? target-spec) (:action target-spec))
-                                  to-path   (when target-id
-                                              (conj (vec parent-path) target-id))]
-                            :when to-path]
-                        {:id    (str (node-id-for-path from-path) "__"
-                                     (node-id-for-path to-path) "__"
-                                     (name event-id))
-                         :from  from-path
-                         :to    to-path
-                         :label (edge-label-str event-id guard action)
-                         :event event-id
-                         :guard guard
-                         :action action}))
-                nested (when (:states state-node)
-                         (collect-edges from-path (:states state-node)))]
+                own       (concat
+                            (on-edges     parent-path from-path (:on    state-node))
+                            (after-edges  parent-path from-path (:after state-node))
+                            (always-edges parent-path from-path (:always state-node)))
+                nested    (when (:states state-node)
+                            (collect-edges from-path (:states state-node)))]
             (concat own nested)))
         state-map))))
 
@@ -401,6 +544,13 @@
                             :color  (or (:stroke style) "currentColor")
                             :width  18
                             :height 18}
-                :data     {:kind  kind
-                           :event (:event e)}}))
+                :data     (cond-> {:kind  kind
+                                   :event (:event e)}
+                            ;; rf2-ezqpm — `:always?` / `:after` flags
+                            ;; surface on the projected edge so the
+                            ;; downstream renderer (or a test asserting
+                            ;; the transition-category split) can read
+                            ;; the kind without re-parsing the label.
+                            (:always? e) (assoc :always? true)
+                            (:after   e) (assoc :after (:after e)))}))
            edges)}))

--- a/tools/xray/test/day8/re_frame2_xray/panels/machines/topology_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machines/topology_cljs_test.cljs
@@ -397,3 +397,199 @@
       ;; The collision triple no longer fuses source + target into one id.
       (is (not= (:source e) (:target e))
           ":a-b and :a/b stay distinct across an edge"))))
+
+;; ---- rf2-ezqpm: :always + :after transition coverage --------------------
+;;
+;; Pre-fix, `collect-edges` walked only `(:on state-node)`. `:always`
+;; (eventless / transient) and `:after` (delay-fired) transitions are
+;; first-class in Spec 005 — the chart was therefore showing a partial
+;; topology when a machine used either slot. These tests pin the edges'
+;; presence, labels (Stately glyph convention per rf2-a2b55), and the
+;; `:always?` / `:after` discriminators on the projected edges.
+
+(deftest parse-definition-emits-edge-for-always-transition
+  (testing "rf2-ezqpm — `:always` (eventless transient) emits an edge"
+    (let [def {:initial :checking
+               :states  {:checking {:always {:target :ready :guard :ok?}}
+                         :ready    {:final? true}}}
+          {:keys [edges]} (topology/parse-definition def)]
+      (is (= 1 (count edges)))
+      (let [e (first edges)]
+        (is (= [:checking] (:from e)))
+        (is (= [:ready]    (:to e)))
+        (is (true? (:always? e)))
+        (is (= :always (:event e)))
+        (is (= :ok? (:guard e)))
+        (is (= "∞ [ok?]" (:label e))
+            "label uses the Stately infinity glyph (rf2-a2b55)")))))
+
+(deftest parse-definition-emits-edge-for-bare-keyword-always
+  (testing "rf2-ezqpm — `:always :ready` (the bare-keyword shorthand)
+            is also charted (matches the `:on` shorthand grammar)"
+    (let [def {:initial :checking
+               :states  {:checking {:always :ready}
+                         :ready    {}}}
+          {:keys [edges]} (topology/parse-definition def)]
+      (is (= 1 (count edges)))
+      (is (= [:ready] (-> edges first :to)))
+      (is (true? (-> edges first :always?))))))
+
+(deftest parse-definition-emits-edge-for-always-vector-fork
+  (testing "rf2-ezqpm — `:always [{:target … :guard …} …]` (the guarded
+            fork grammar) emits one edge per candidate; ids are distinct
+            so xyflow keeps every branch"
+    (let [def {:initial :checking
+               :states  {:checking {:always [{:target :winner  :guard :enough-correct?}
+                                             {:target :loser   :guard :enough-wrong?}]}
+                         :winner   {}
+                         :loser    {}}}
+          {:keys [edges]} (topology/parse-definition def)]
+      (is (= 2 (count edges)))
+      (is (= #{[:winner] [:loser]} (set (map :to edges))))
+      (is (every? :always? edges))
+      (is (= 2 (count (set (map :id edges))))
+          "candidates mint DISTINCT edge ids (per-candidate ordinal)"))))
+
+(deftest parse-definition-emits-edge-for-after-transition
+  (testing "rf2-ezqpm — `:after {<ms> {:target …}}` emits one edge per
+            delay entry"
+    (let [def {:initial :loading
+               :states  {:loading {:after {5000 {:target :timeout}}}
+                         :timeout {:final? true}}}
+          {:keys [edges]} (topology/parse-definition def)]
+      (is (= 1 (count edges)))
+      (let [e (first edges)]
+        (is (= [:loading] (:from e)))
+        (is (= [:timeout] (:to e)))
+        (is (= 5000 (:after e)))
+        (is (= "⌚ 5000ms" (:label e))
+            "label uses the Stately clock glyph + `<ms>ms` (rf2-a2b55)")))))
+
+(deftest parse-definition-emits-edge-for-after-bare-keyword
+  (testing "rf2-ezqpm — `:after {<ms> :target-state}` shorthand"
+    (let [def {:initial :loading
+               :states  {:loading {:after {500 :ready}}
+                         :ready   {}}}
+          {:keys [edges]} (topology/parse-definition def)]
+      (is (= 1 (count edges)))
+      (is (= [:ready] (-> edges first :to)))
+      (is (= 500 (-> edges first :after))))))
+
+(deftest parse-definition-emits-one-edge-per-after-delay
+  (testing "rf2-ezqpm — each `:after` delay entry is INDEPENDENT and
+            emits its own edge (Spec 005 — one timer per entry)"
+    (let [def {:initial :idle
+               :states  {:idle {:after {500  {:target :short}
+                                        5000 {:target :long}}}
+                         :short {}
+                         :long  {}}}
+          {:keys [edges]} (topology/parse-definition def)]
+      (is (= 2 (count edges)))
+      (is (= #{500 5000} (set (map :after edges))))
+      (is (= 2 (count (set (map :id edges))))
+          "the two `:after` delays mint DISTINCT edge ids"))))
+
+(deftest parse-definition-after-edge-carries-guard-and-action
+  (testing "rf2-ezqpm — `:after` map spec surfaces guard + action into the label"
+    (let [def {:initial :loading
+               :states  {:loading {:after {1500 {:target :timeout
+                                                 :guard  :still-pending?
+                                                 :action :cleanup}}}
+                         :timeout {}}}
+          {:keys [edges]} (topology/parse-definition def)]
+      (is (= 1 (count edges)))
+      (is (= "⌚ 1500ms [still-pending?] / cleanup"
+             (-> edges first :label))))))
+
+(deftest parse-definition-mixes-on-always-after-on-one-state
+  (testing "rf2-ezqpm — all three transition slots co-exist on a state;
+            each emits its own edge(s) and the on-edges keep their old
+            shape (back-compat for the `:on` projection)"
+    (let [def {:initial :loading
+               :states  {:loading {:on     {:cancel :idle}
+                                   :after  {3000 {:target :timeout}}
+                                   :always {:target :ready :guard :data-loaded?}}
+                         :idle    {}
+                         :timeout {}
+                         :ready   {}}}
+          {:keys [edges]} (topology/parse-definition def)
+          by-target (group-by :to edges)]
+      (is (= 3 (count edges)))
+      ;; :on edge (unchanged)
+      (let [e (first (get by-target [:idle]))]
+        (is (= :cancel (:event e)))
+        (is (= "cancel" (:label e)))
+        (is (not (contains? e :after)))
+        (is (not (contains? e :always?))))
+      ;; :after edge
+      (let [e (first (get by-target [:timeout]))]
+        (is (= 3000 (:after e)))
+        (is (= "⌚ 3000ms" (:label e))))
+      ;; :always edge
+      (let [e (first (get by-target [:ready]))]
+        (is (true? (:always? e)))
+        (is (= "∞ [data-loaded?]" (:label e)))))))
+
+(deftest parse-definition-always-after-recurse-into-compound
+  (testing "rf2-ezqpm — `:always` / `:after` on a compound substate are
+            walked (recursion already covered `:on`; the new slots ride
+            the same recursion)"
+    (let [def {:initial :authed
+               :states  {:authed {:initial :browsing
+                                  :states  {:browsing {:after {1000 {:target :idle}}}
+                                            :idle     {:always {:target :browsing}}}}}}
+          {:keys [edges]} (topology/parse-definition def)
+          paths (set (map (juxt :from :to) edges))]
+      (is (contains? paths [[:authed :browsing] [:authed :idle]])
+          "nested :after edge surfaces")
+      (is (contains? paths [[:authed :idle] [:authed :browsing]])
+          "nested :always edge surfaces"))))
+
+(deftest project-surfaces-always-and-after-on-data
+  (testing "rf2-ezqpm — the projected xyflow `:data` carries `:always?`
+            / `:after` so the downstream renderer can split by kind
+            without re-parsing the label"
+    (let [def {:initial :loading
+               :states  {:loading {:after  {2000 {:target :timeout}}
+                                   :always {:target :ready :guard :ok?}}
+                         :timeout {}
+                         :ready   {}}}
+          out (topology/project {:definition def})
+          by-target (into {} (map (juxt :target identity) (:edges out)))
+          to-timeout (get by-target (chart-layout/node-id [:timeout]))
+          to-ready   (get by-target (chart-layout/node-id [:ready]))]
+      (is (= 2000 (-> to-timeout :data :after)))
+      (is (not (contains? (:data to-timeout) :always?))
+          "`:after` edge does not also carry `:always?`")
+      (is (true? (-> to-ready :data :always?)))
+      (is (not (contains? (:data to-ready) :after))
+          "`:always` edge does not also carry `:after`"))))
+
+(deftest project-includes-arrowhead-for-always-and-after
+  (testing "rf2-ezqpm — every projected edge (including `:always` /
+            `:after`) requests an arrowclosed markerEnd (rf2-5qsxo)"
+    (let [def {:initial :loading
+               :states  {:loading {:after  {2000 {:target :timeout}}
+                                   :always {:target :ready :guard :ok?}}
+                         :timeout {}
+                         :ready   {}}}
+          out (topology/project {:definition def})]
+      (is (= 2 (count (:edges out))))
+      (doseq [e (:edges out)]
+        (is (= "arrowclosed" (-> e :markerEnd :type)))))))
+
+(deftest project-applies-edge-style-fn-to-always-and-after
+  (testing "rf2-ezqpm — `:always` and `:after` edges run through the
+            same kind-resolution + style-fn pipeline as `:on` edges"
+    (let [def {:initial :loading
+               :states  {:loading {:after  {2000 {:target :timeout}}
+                                   :always {:target :ready}}
+                         :timeout {}
+                         :ready   {}}}
+          out (topology/project {:definition def
+                                 :edge-style-fn (fn [k]
+                                                  {:test-marker (str "edge-" (name k))})})
+          markers (set (map #(-> % :style :test-marker) (:edges out)))]
+      ;; Both edges resolve to :registered (no fired/traversed sets).
+      (is (= #{"edge-registered"} markers)
+          ":always + :after edges both go through edge-style-fn"))))


### PR DESCRIPTION
## Summary

Extend the Xray topology projection at `tools/xray/src/day8/re_frame2_xray/panels/machines/topology.cljs` to emit edges for `:always` (eventless / transient) and `:after` (delay-fired) transitions. Pre-fix, `collect-edges` walked only `(:on state-node)`; any machine spec using `:always` or `:after` therefore rendered with a partial state-graph in the topology chart (a `loading` state with `:after 5s -> :timeout` showed no edge).

Both transition kinds are first-class in Spec 005, so they belong in the projection.

## Encoding chosen

Recommended option (a) per the bead: each `:always` / `:after` transition emits an **edge** (same shape as `:on` edges); the discriminator is the **label glyph** + a per-edge flag. Matches the existing `machines-viz/chart.layout` projection shape (single source of truth for the rf2-a2b55 Stately glyph convention) so the Xray topology projection and the live `MachineChart` agree edge-for-edge:

| Slot | Edge label segment | Edge data flag |
|---|---|---|
| `(:on …)` event-triggered | `event-id` (unchanged) | (none) |
| `(:after …)` delay-fired | `⌚ <delay>ms` | `:after <delay>` |
| `(:always …)` eventless | `∞` | `:always? true` |

The per-edge `:always?` / `:after` flags also surface on the projected xyflow `:data` map so downstream renderers can split by transition-kind without re-parsing the label. Existing `:on` edge shape is unchanged (back-compat).

## File inventory

- `tools/xray/src/day8/re_frame2_xray/panels/machines/topology.cljs` — added `event-segment-str`, `target-of`, `spec-attrs`, `on-edges`, `after-edges`, `always-edges` helpers; rewrote `collect-edges` to compose all three; extended `project`'s `:data` to carry `:always?` / `:after`.
- `tools/xray/test/day8/re_frame2_xray/panels/machines/topology_cljs_test.cljs` — 12 new tests covering both transition kinds (single, vector-of-candidates fork, bare-keyword shorthand, multi-delay, guard + action surfaced into label, compound recursion, projected `:data` discriminators, arrowhead presence, edge-style-fn pipeline).
- `tools/xray/spec/021-Dynamic-Panel-Designs.md` — added a transition-kinds projection table under §17.4.3 (per [[feedback-xray-specs-kept-current]]).

## Test coverage delta

12 new `deftest`s, all passing under `npm run test:cljs`. Pre-existing failures in `panels/epoch/...` + `registry-cljs-test` are unrelated (filed against rf2-tvu99 / rf2-ehd8v etc.).

## Quality gates

- `npm run test:cljs` — no new failures in `panels/machines/topology` (pre-existing failures in unrelated files).
- `npm run test:bundle-isolation` — PASS.

Browser tests not run: the rendered chart already flows through `machines-viz/MachineChart` (which has correctly handled `:always`/`:after` since rf2-a2b55); this fix is to the pure-data Xray projection that's used for data-attribute counts + the JVM-portable projection fallback.

## Acceptance

- [x] Machine chart's projection renders edges for all `:always` transitions in a spec.
- [x] Machine chart's projection renders edges for all `:after` transitions in a spec.
- [x] Each renders with the appropriate Stately glyph (`∞` always; `⌚ <delay>ms` after) per rf2-a2b55.
- [x] Existing event-triggered transition rendering unchanged.
- [x] CLJS test suite green (new tests cover both transition kinds; pre-existing failures unrelated).
- [x] Light + dark themes both render correctly (the rendered chart path is unchanged — `machines-viz/MachineChart` already paints these in both themes via the existing kind-resolution pipeline).
- [x] Spec update — `tools/xray/spec/021-Dynamic-Panel-Designs.md` §17.4.3 (transition-kinds projection table).

Closes rf2-ezqpm.