### PR TITLE
fix(xray): retire orphan tests + sync registry snapshot (rf2-xu5iv)

### DIFF
--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/badge_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/badge_cljs_test.cljc
@@ -24,13 +24,24 @@
         (is (re-find #"var\(--rf-xray-" c)
             (str "expected CSS variable for " b ", got " c))))))
 
-(deftest badge-labels-uppercase-test
-  (testing "every badge label is the uppercase keyword name"
+(deftest badge-labels-resolve-test
+  (testing "every badge label resolves to a non-blank string.
+
+  Labels are uppercase keyword names by default (DISPATCH, COEFFECT,
+  HANDLER, ...). Labels that lead with `:` are EDN-key-style and
+  render through `badge-pill`'s mono-font, no-uppercase path
+  (post-rf2-xu5iv: `:FX` now renders as `\":fx\"` per commit
+  862288aca's badge-styling change). Both styles are valid; this
+  test just pins that every badge has a label."
     (doseq [b proj/badge-set]
       (let [l (badge/label b)]
-        (is (string? l))
-        (is (= (str/upper-case l) l)
-            (str "badge label for " b " not uppercase: " l))))))
+        (is (string? l)
+            (str "badge label for " b " is a string"))
+        (is (seq l)
+            (str "badge label for " b " is non-blank"))
+        (is (or (= (str/upper-case l) l)
+                (str/starts-with? l ":"))
+            (str "badge label for " b " is uppercase OR EDN-key style: " l))))))
 
 (deftest token-key-fallback-test
   (testing "unknown badge falls back to :text-tertiary"

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -283,14 +283,23 @@
 ;; ---- HANDLER -------------------------------------------------------------
 
 (deftest handler-row-reg-event-db-test
-  (testing "no fx + no machine = reg-event-db flavour"
+  (testing "no fx + no machine = reg-event-db flavour.
+
+  Post pair-debug 2026-05-26 (commit ee9def224): `handler-row` reads
+  the JIT-diff off explicit `db-before` / `db-after` snapshots; the
+  2-arg form here supplies nil/nil and yields an empty `:db-diff`
+  regardless of any trace-tag-stamped paths on the events. The
+  `:rrykz`-era assertion `(= 1 (count :db-diff))` against
+  `db-changed-paths` tags is removed — those tags are not what the
+  current `handler-row` reads."
     (let [r (proj/handler-row [(db-changed-ev [[[:counter] 5 6 :modified]])]
                               :counter-inc)]
       (is (= :handler (:step r)))
       (is (= :HANDLER (:badge r)))
       (is (= :reg-event-db (:flavour r)))
       (is (= :counter-inc (:event-id r)))
-      (is (= 1 (count (:db-diff r))))
+      (is (= [] (:db-diff r))
+          "2-arg form supplies nil db-before/after → empty :db-diff")
       (is (= [] (:fx r))))))
 
 (deftest handler-row-reg-event-fx-test
@@ -524,18 +533,28 @@
 ;; ---- top-level project --------------------------------------------------
 
 (deftest project-minimal-test
-  (testing "minimal epoch (dispatch + handler + app-db-diff for the
-            db mutation, no cofx/flow/fx/sub/view)"
+  (testing "minimal epoch (dispatch + handler, no cofx/flow/fx/sub/view).
+
+  Post pair-debug 2026-05-26 (commit ee9def224 / 862288aca): the
+  standalone APP-DB DIFF step (rf2-rrykz) was retired — the HANDLER
+  step's `:db` sub-section with `[diff][all]` toggle surfaces the
+  same data in-context. The minimal cascade is now :dispatch +
+  :handler only."
     (let [rec   (record [(dispatched-ev [:counter-inc] :ui nil)
                          (db-changed-ev [[[:counter] 5 6 :modified]])])
           steps (proj/project rec)]
-      (is (= 3 (count steps))
-          "rf2-rrykz appends :app-db-diff for any cascade that mutated app-db")
-      (is (= [:dispatch :handler :app-db-diff] (mapv :step steps))))))
+      (is (= 2 (count steps)))
+      (is (= [:dispatch :handler] (mapv :step steps))))))
 
 (deftest project-full-pipeline-test
-  (testing "full epoch with every step + app-db-diff + child-dispatches
-            (handler returned `:dispatch` fx)"
+  (testing "full epoch with every cascade step.
+
+  Post pair-debug 2026-05-26 (commits ee9def224 / eccb6db1b /
+  862288aca): both standalone APP-DB DIFF (rf2-rrykz) and CHILD
+  DISPATCHES (rf2-yx1ae) steps were retired. APP-DB DIFF folds into
+  the HANDLER `:db` `[diff][all]` toggle; CHILD DISPATCHES is
+  redundant with the FX step which already surfaces every
+  `:dispatch` / `:dispatch-n` / `:dispatch-later` fx entry."
     (let [rec   (record [(dispatched-ev [:cart/checkout] :ui nil)
                          (cofx-run-ev :session {:user 1})
                          (do-fx-ev {:db {} :http/post {:url "/x"}})
@@ -547,11 +566,10 @@
                          (view-render-ev ::cart-view [:total])])
           steps (proj/project rec)
           kws   (mapv :step steps)]
-      (is (= [:dispatch :coeffect :handler :app-db-diff :flow :fx
+      (is (= [:dispatch :coeffect :handler :flow :fx
               :subscriptions :views]
-             kws)
-          "rf2-rrykz appends :app-db-diff between :handler and :flow")
-      (is (= 8 (count steps))))))
+             kws))
+      (is (= 7 (count steps))))))
 
 (deftest project-numbered-test
   (testing "number-steps assigns sequential 1..N regardless of omissions"
@@ -725,56 +743,25 @@
       (is (= 0 (:rollbacks s))
           "no rollback-true rows in this fixture"))))
 
-;; ---- rf2-rrykz — app-db diff section ----------------------------------
-
-(deftest app-db-diff-step-conditional-test
-  (testing "rf2-rrykz — no db-changed event → step OMITTED"
-    (is (nil? (proj/app-db-diff-step []))))
-
-  (testing "rf2-rrykz — empty changed-paths → step OMITTED"
-    (is (nil? (proj/app-db-diff-step [(db-changed-ev [])]))))
-
-  (testing "rf2-rrykz — db mutation present → step rendered"
-    (let [s (proj/app-db-diff-step
-              [(db-changed-ev [[[:count]    0   1   :modified]
-                               [[:cart 0]   nil "x" :added]
-                               [[:old]      5   nil :removed]])])]
-      (is (= :app-db-diff (:step s)))
-      (is (= :APP-DB-DIFF (:badge s)))
-      (is (= 3 (count (:rows s))))
-      (is (= 1 (:added s)))
-      (is (= 1 (:modified s)))
-      (is (= 1 (:removed s))))))
-
-(deftest app-db-diff-row-fields-test
-  (testing "rf2-rrykz — each row carries `:path / :before / :after / :change`"
-    (let [s (proj/app-db-diff-step
-              [(db-changed-ev [[[:count] 0 1 :modified]])])
-          r (-> s :rows first)]
-      (is (= [:count] (:path r)))
-      (is (= 0 (:before r)))
-      (is (= 1 (:after r)))
-      (is (= :modified (:change r))))))
-
-(deftest project-includes-app-db-diff-after-handler-test
-  (testing "rf2-rrykz — top-level project emits APP-DB-DIFF immediately
-            after HANDLER so the state-mutation lens lands next to the
-            attribution row"
-    (let [rec   (record [(dispatched-ev [:counter/inc] :ui nil)
-                         (db-changed-ev [[[:count] 0 1 :modified]])])
-          steps (proj/project rec)
-          kws   (mapv :step steps)]
-      (is (some #{:app-db-diff} kws))
-      (is (= (.indexOf kws :app-db-diff)
-             (inc (.indexOf kws :handler)))
-          ":app-db-diff rides immediately after :handler")))
-
-  (testing "rf2-rrykz — no app-db mutation → step absent"
-    (let [rec   (record [(dispatched-ev [:counter/inc] :ui nil)])
-          steps (proj/project rec)]
-      (is (not-any? #(= :app-db-diff (:step %)) steps)))))
+;; ---- rf2-rrykz — app-db diff section — RETIRED 2026-05-26 -------------
+;;
+;; The standalone APP-DB DIFF step + `proj/app-db-diff-step` fn were
+;; removed in commit 862288aca / ee9def224. The HANDLER step's `:db`
+;; `[diff][all]` toggle surfaces the same data in-context. Tests for
+;; the retired surface are deleted; HANDLER `:db` coverage rides on
+;; `handler-row-reg-event-db-test` + `view_cljs_test.cljs` HANDLER
+;; tests (rf2-93436 — `:db diff` sub-section always-present).
 
 ;; ---- rf2-yx1ae — child dispatches section -----------------------------
+;;
+;; The standalone CHILD-DISPATCHES step was removed from the top-level
+;; cascade in commit eccb6db1b (redundant with FX which already
+;; surfaces every `:dispatch` / `:dispatch-n` / `:dispatch-later` fx
+;; entry). The pure-data fns (`child-dispatch-rows`,
+;; `child-dispatches-step`, `find-child-epoch`) survive as low-level
+;; helpers — their tests remain. The `project-includes-child-
+;; dispatches-step-test` (which asserted the step is part of the
+;; cascade) is retired.
 
 (deftest child-dispatch-rows-from-dispatch-test
   (testing "rf2-yx1ae — `:dispatch [:e/x]` projects one row"
@@ -841,23 +828,10 @@
       (is (nil? (proj/find-child-epoch history nil [:e/x 7]))
           "nil parent-id → nil"))))
 
-(deftest project-includes-child-dispatches-step-test
-  (testing "rf2-yx1ae — top-level project emits CHILD-DISPATCHES after FX
-            and before SUBSCRIPTIONS when dispatch fx fired"
-    (let [rec   (record [(dispatched-ev [:counter/inc] :ui nil)
-                         (do-fx-ev {:dispatch [:other/event 1]})
-                         (db-changed-ev [])])
-          steps (proj/project rec)
-          step-kws (mapv :step steps)]
-      (is (some #{:child-dispatches} step-kws)
-          "CHILD-DISPATCHES is present")
-      (is (< (.indexOf step-kws :handler)
-             (.indexOf step-kws :child-dispatches))
-          ":child-dispatches rides AFTER :handler")
-      (when (some #{:fx} step-kws)
-        (is (< (.indexOf step-kws :fx)
-               (.indexOf step-kws :child-dispatches))
-            ":child-dispatches rides AFTER :fx when :fx is also emitted")))))
+;; `project-includes-child-dispatches-step-test` retired in rf2-xu5iv
+;; (commit eccb6db1b dropped the CHILD-DISPATCHES step from the
+;; top-level cascade). See comment header above the child-dispatch
+;; helpers section.
 
 (deftest project-includes-schema-violations-step-test
   (testing "rf2-17vxj — top-level project emits SCHEMA-VIOLATIONS at

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -47,17 +47,21 @@
         (is (string/includes? header-text "ui"))))))
 
 (deftest handler-flavour-renders-once-test
-  (testing "rf2-9jvx1 — HANDLER header carries the flavour + event-id
-            once; the body's pre-rf2-9jvx1 stand-alone flavour row is
-            removed. Body's first slot is the source block (rf2-66wis),
-            not a flavour pill."
+  (testing "rf2-9jvx1 — HANDLER header carries the flavour-verb; the
+            body's pre-rf2-9jvx1 stand-alone flavour row is removed.
+            Body's first slot is the source block (rf2-66wis), not a
+            flavour pill.
+
+            Post pair-debug 2026-05-26 (commit ee9def224): the verb
+            is now the click-to-source hyperlink. The event-id is no
+            longer repeated in the HANDLER header (the DISPATCH step's
+            header already names it) — that assertion is retired."
     (let [step {:step :handler :badge :HANDLER :step-number 3
                 :flavour :reg-event-db :event-id :no-such/handler
                 :db-diff [] :fx [] :machine nil}
           tree (view/render-handler-step step)
           header-text (text-of tree "rf-xray-epoch-handler-header")]
       (is (string/includes? header-text "reg-event-db"))
-      (is (string/includes? header-text ":no-such/handler"))
       ;; The body's first slot is now the source block — never a
       ;; duplicate flavour pill.
       (is (some? (th/find-by-testid tree "rf-xray-epoch-handler-source"))
@@ -132,21 +136,26 @@
 ;; ---- rf2-cq0ch — COEFFECT body --------------------------------------
 
 (deftest coeffect-body-renders-labelled-value-test
-  (testing "rf2-cq0ch — each user-injected cofx renders the id +
-            value via the canonical edn-inspector. No cryptic
-            `+[]nil` line."
+  (testing "rf2-cq0ch — a user-injected cofx renders the id + value
+            via the canonical edn-inspector. No cryptic `+[]nil` line.
+
+            Post pair-debug 2026-05-26 (commit ee9def224): the
+            projection emits ONE COEFFECT step PER injected cofx
+            (replacing the prior single step with N `:rows`).
+            `view/render-coeffect-step` takes a single step map
+            with `:id` + `:value`; the previous `:rows`-bearing
+            shape is retired. This test pins the per-cofx render."
     (let [step {:step :coeffect :badge :COEFFECT :step-number 2
-                :rows [{:id :session :value {:user-id 42}}
-                       {:id :rf/now :value "2026-05-26T00:00:00"}]}
-          tree (view/render-coeffect-step step)]
-      (is (some? (th/find-by-testid tree "rf-xray-epoch-coeffect-row-0")))
-      (is (some? (th/find-by-testid tree "rf-xray-epoch-coeffect-row-1")))
-      (let [r0-id    (text-of tree "rf-xray-epoch-coeffect-row-id-0")
-            r0-value (text-of tree "rf-xray-epoch-coeffect-row-value-0")
-            r1-id    (text-of tree "rf-xray-epoch-coeffect-row-id-1")]
-        (is (string/includes? r0-id ":session"))
-        (is (string/includes? r0-value "42"))
-        (is (string/includes? r1-id ":rf/now"))))))
+                :id :session :value {:user-id 42}}
+          tree (view/render-coeffect-step step)
+          id-text    (text-of tree "rf-xray-epoch-coeffect-id-session")
+          value-text (text-of tree "rf-xray-epoch-coeffect-value-session")]
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-step-coeffect-session"))
+          "the per-cofx step wrapper renders with the cofx-id in its testid")
+      (is (string/includes? (or id-text "") ":session")
+          "the cofx-id is surfaced in the header")
+      (is (string/includes? (or value-text "") "42")
+          "the cofx value renders in the body"))))
 
 ;; ---- rf2-kfh1v — SUBSCRIPTIONS rows + filter -------------------------
 
@@ -485,8 +494,17 @@
 ;; ---- rf2-uffov — FX section header + per-action attribution ----------
 
 (deftest fx-step-header-shows-outcome-split-test
-  (testing "rf2-uffov — FX step header reads
-            `N fired (M succeeded, K threw)`"
+  (testing "rf2-uffov — FX step header surfaces the threw-count when
+            non-zero, beside the subdued `(side effects)` caption.
+
+            Post pair-debug 2026-05-26 (commits 862288aca / adaabb8aa):
+            the prior `N fired (M succeeded, K threw)` verb was
+            dropped — the per-row ✓/✗ glyphs already convey per-fx
+            outcome; the count summary was noise. The header now
+            renders a subdued `(side effects)` caption beside the
+            badge, with a red `K threw` chip only when fx errored.
+            `N fired` + `M succeeded` are no longer surfaced in the
+            header."
     (let [step {:step :fx :badge :FX :step-number 4
                 :rows [{:fx-id :db :status :ok}
                        {:fx-id :http/get :status :ok}
@@ -494,9 +512,10 @@
                 :succeeded 2 :threw 1 :skipped 0}
           tree (view/render-fx-step step)
           header (text-of tree "rf-xray-epoch-fx-header")]
-      (is (string/includes? header "3 fired"))
-      (is (string/includes? header "2 succeeded"))
-      (is (string/includes? header "1 threw")))))
+      (is (string/includes? header "(side effects)")
+          "the subdued caption rides beside the badge")
+      (is (string/includes? header "1 threw")
+          "threw-count chip surfaces in the header when non-zero"))))
 
 (deftest fx-row-shows-attribution-chip-test
   (testing "rf2-uffov — when an FX row carries :attributed-to, the
@@ -520,38 +539,12 @@
           tree (view/render-fx-step step)]
       (is (nil? (th/find-by-testid tree "rf-xray-epoch-fx-row-attribution-0"))))))
 
-;; ---- rf2-rrykz — app-db diff section ---------------------------------
-
-(deftest app-db-diff-step-renders-rows-test
-  (testing "rf2-rrykz — APP-DB DIFF step renders one row per changed
-            path with the change kind reflected on the row data attr"
-    (let [step {:step :app-db-diff :badge :APP-DB-DIFF :step-number 4
-                :rows [{:path [:count] :before 0 :after 1 :change :modified}
-                       {:path [:new]   :before nil :after "v" :change :added}
-                       {:path [:gone]  :before 5 :after nil :change :removed}]
-                :added 1 :modified 1 :removed 1}
-          tree (view/render-app-db-diff-step step)]
-      (is (some? (th/find-by-testid tree "rf-xray-epoch-step-app-db-diff")))
-      (is (= 3 (count (th/find-by-testid-prefix
-                        tree "rf-xray-epoch-app-db-diff-row-"))))
-      (let [header (text-of tree "rf-xray-epoch-app-db-diff-header")]
-        (is (string/includes? header "3 paths changed"))
-        (is (string/includes? header "+1 / ~1 / -1"))))))
-
-(deftest app-db-diff-row-shows-path-and-values-test
-  (testing "rf2-rrykz — :modified row shows before → after"
-    (let [step {:step :app-db-diff :badge :APP-DB-DIFF :step-number 4
-                :rows [{:path [:counter :value] :before 5 :after 6
-                        :change :modified}]
-                :added 0 :modified 1 :removed 0}
-          tree (view/render-app-db-diff-step step)
-          row  (th/find-by-testid tree "rf-xray-epoch-app-db-diff-row-0")]
-      (is (some? row))
-      (let [txt (th/text-content row)]
-        (is (string/includes? txt "[:counter :value]")
-            "path is visible")
-        (is (string/includes? txt "5"))
-        (is (string/includes? txt "6"))))))
+;; ---- rf2-rrykz — app-db diff section — RETIRED 2026-05-26 -------------
+;;
+;; The `view/render-app-db-diff-step` fn was deleted in commit
+;; 862288aca along with the standalone APP-DB DIFF projection step.
+;; HANDLER `:db` `[diff][all]` toggle covers the same surface
+;; in-context (tests for that ride in the rf2-93436 section above).
 
 ;; ---- rf2-yx1ae — child-dispatches section -----------------------------
 
@@ -724,42 +717,17 @@
         (is (nil? (th/find-by-testid tree "rf-xray-epoch-handler-source-placeholder"))
             "no placeholder when source IS captured")))))
 
-;; ---- rf2-ehd8v — HANDLER source carries file:line + [open] ----------
-
-(deftest handler-source-renders-file-line-and-open-affordance-test
-  (testing "rf2-ehd8v — when the handler-meta carries :file + :line the
-            HANDLER source sub-header renders `file:line` text and a
-            clickable `[open]` button next to the SOURCE label.
-            Reuses the cross-panel coord-chip (same affordance Static
-            Handler + Event panels ship)."
-    (rf/with-frame :rf/default
-      (rf/reg-event-db :rf.test.epoch.view/ehd8v-srctest-handler
-                       {:rf.handler/source "(reg-event-db :rf.test.epoch.view/ehd8v-srctest-handler\n  (fn [db _] (update db :n inc)))"
-                        :file "src/app/counter.cljs"
-                        :line 42}
-                       (fn [db _] db))
-      (let [step {:step :handler :badge :HANDLER :step-number 3
-                  :flavour :reg-event-db
-                  :event-id :rf.test.epoch.view/ehd8v-srctest-handler
-                  :db-diff [] :fx [] :machine nil}
-            tree (view/render-handler-step step)
-            coord (th/find-by-testid tree "rf-xray-epoch-handler-source-coord")
-            text  (th/find-by-testid tree "rf-xray-epoch-handler-source-coord-text")
-            open  (th/find-by-testid tree "rf-xray-epoch-handler-source-open")]
-        (is (some? coord)
-            "the source-coord chrome row is present alongside the label")
-        (is (some? text)
-            "the file:line text element is present")
-        (is (string/includes? (or (th/text-content text) "") "src/app/counter.cljs")
-            "the file path appears in the text")
-        (is (string/includes? (or (th/text-content text) "") "42")
-            "the line number appears in the text")
-        (is (some? open)
-            "the [open] coord-chip is present when :file is captured")
-        (is (= :button (first open))
-            "the open affordance is a real button (clickable)")
-        (is (fn? (:on-click (second open)))
-            "the open button has a click handler")))))
+;; ---- rf2-ehd8v — HANDLER source `file:line + [open]` ----------------
+;;
+;; The dedicated `file:line + [open]` sub-header alongside the SOURCE
+;; label was retired in commit ee9def224. The HANDLER step's verb
+;; itself (e.g. `reg-event-fx`) IS now the click-to-source hyperlink
+;; (`handler-verb-link` in view.cljs); the source-block leads with the
+;; code body directly. The positive-affordance test
+;; (`handler-source-renders-file-line-and-open-affordance-test`) is
+;; retired; the absence-of-affordance check below stays — those
+;; testids are still nil now (no affordance means nothing rendered),
+;; which is still the correct contract.
 
 (deftest handler-source-elides-affordance-when-coord-absent-test
   (testing "rf2-ehd8v — when no handler-meta is registered for the
@@ -890,18 +858,10 @@
       (is (>= (count (mini-mounts subs)) 2)
           "subs-read column mounts one mini per consumed sub"))))
 
-(deftest app-db-diff-values-route-through-mini-test
-  (testing "rf2-8w8er — APP-DB DIFF rows render before / after through
-            `ei/mini` so per-token chrome paints consistently with the
-            HANDLER :db diff."
-    (let [tree (view/render-app-db-diff-step
-                 {:step :app-db-diff :badge :APP-DB-DIFF :step-number 4
-                  :rows [{:path [:count] :before 0 :after 1 :change :modified}]
-                  :added 0 :modified 1 :removed 0})
-          row  (th/find-by-testid tree "rf-xray-epoch-app-db-diff-row-0")]
-      (is (some? row))
-      (is (>= (count (mini-mounts row)) 2)
-          "modified row mounts ≥2 mini-renders (before + after)"))))
+;; `app-db-diff-values-route-through-mini-test` retired in rf2-xu5iv
+;; (commit 862288aca dropped `view/render-app-db-diff-step` along with
+;; the projection step). HANDLER `:db` diff mini-mount coverage rides
+;; on `handler-db-diff-values-route-through-mini-test` above.
 
 (deftest child-dispatches-event-routes-through-mini-test
   (testing "rf2-8w8er — CHILD-DISPATCHES row renders the event vector

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -160,6 +160,10 @@
    :rf.xray.epoch/expanded-rows
    ;; rf2-kfh1v — Epoch panel SUBSCRIPTIONS show-unchanged flag.
    :rf.xray.epoch/subs-show-unchanged?
+   ;; pair-debug 2026-05-26 (ee9def224) — HANDLER `:db` `[diff][all]`
+   ;; toggle slot. Persists the operator's preferred view-mode for
+   ;; the HANDLER step's `:db` sub-section. Defaults to `:diff`.
+   :rf.xray.epoch/db-view-mode
    :rf.xray/event-detail
    :rf.xray/filtered-cascades
    ;; rf2-jvghz — model behind the L2 'N hidden by filters' indicator
@@ -448,6 +452,10 @@
    :rf.xray.epoch/clear-row-expand
    ;; rf2-kfh1v — Epoch panel SUBSCRIPTIONS show-unchanged toggle.
    :rf.xray.epoch/toggle-subs-show-unchanged
+   ;; pair-debug 2026-05-26 (ee9def224) — HANDLER `:db` `[diff][all]`
+   ;; toggle write event. Sets the persisted view-mode slot the
+   ;; `:rf.xray.epoch/db-view-mode` sub reads.
+   :rf.xray.epoch/set-db-view-mode
    :rf.xray/epoch-recorded
    ;; rf2-piye4 — typed-predicate filter events. Each appends a
    ;; typed `{:kind <kw> :params {…}}` IN pill from a right-click


### PR DESCRIPTION
Resolves the 23F/8E baseline on `origin/main` that has been blocking
the merge queue. None of the failures are regressions — they
accumulated from Mike pair-debug commits (`ee9def224` / `adaabb8aa` /
`eccb6db1b` / `862288aca`) that retired Epoch-panel sections without
updating tests.

Workers PR #2200 / #2202 / #2203 / #2204 / #2205 all flagged these
failures as "pre-existing baseline."

## Per-failure categorisation

| Test | Cluster | Cause | Action |
|------|---------|-------|--------|
| `badge-labels-uppercase-test` | Stale assertion | `:FX` label changed to `":fx"` (EDN-key style) in `862288aca` | Renamed to `badge-labels-resolve-test`; assertion now allows uppercase OR EDN-key labels |
| `handler-row-reg-event-db-test` | Stale assertion | `handler-row` reads JIT-diff off explicit `db-before/after`; 2-arg form yields empty `:db-diff` (`ee9def224`) | Removed `(= 1 (count :db-diff))` assertion that read against the `:rf.event/db-changed-paths` tag |
| `project-minimal-test` | Stale assertion | APP-DB DIFF step retired (`862288aca`) | Expected cascade is `[:dispatch :handler]` |
| `project-full-pipeline-test` | Stale assertion | APP-DB DIFF + CHILD DISPATCHES steps retired (`eccb6db1b` / `862288aca`) | Expected cascade drops both steps |
| `app-db-diff-step-conditional-test` | Orphan | `proj/app-db-diff-step` fn deleted (`862288aca`) | Deleted |
| `app-db-diff-row-fields-test` | Orphan | Same | Deleted |
| `project-includes-app-db-diff-after-handler-test` | Orphan | Step no longer in cascade | Deleted |
| `project-includes-child-dispatches-step-test` | Orphan | Step no longer in cascade (`eccb6db1b`) | Deleted |
| `handler-flavour-renders-once-test` | Stale assertion | Verb no longer echoes event-id (`ee9def224`) | Dropped `:no-such/handler` substring check |
| `coeffect-body-renders-labelled-value-test` | Stale assertion | Projection emits ONE step PER cofx; view takes `:id`+`:value` not `:rows` (`ee9def224`) | Fixture + testids updated to per-cofx shape |
| `fx-step-header-shows-outcome-split-test` | Stale assertion | `N fired / M succeeded / K threw` verb dropped (`862288aca`/`adaabb8aa`); header now `(side effects)` + conditional red threw chip | Assertions updated |
| `app-db-diff-step-renders-rows-test` | Orphan | `view/render-app-db-diff-step` fn deleted (`862288aca`) | Deleted |
| `app-db-diff-row-shows-path-and-values-test` | Orphan | Same | Deleted |
| `app-db-diff-values-route-through-mini-test` | Orphan | Same | Deleted |
| `handler-source-renders-file-line-and-open-affordance-test` | Orphan | SOURCE sub-header retired; verb itself is the goto-source affordance now (`ee9def224`) | Deleted (partner `*-elides-*` test kept — its nil assertions still hold) |
| `registry-registers-each-xray-event-once` | Stale snapshot | Orchestrator registers `:rf.xray.epoch/set-db-view-mode` (`ee9def224`); snapshot missed it | Added to `all-event-names` |
| `registry-snapshot-matches-expected-set` | Stale snapshot | Same + `:rf.xray.epoch/db-view-mode` sub | Added both to `all-event-names` + `all-sub-names` |

## Quality gates

- `npm run test:cljs`: **0F/0E** (was 23F/8E)
- `npm run test:browser`: **0F/0E**
- `npm run test:bundle-isolation`: PASS

## Scope

Test-cleanup only. No source under `tools/xray/src/**` was touched;
no new tests added (per the bead's acceptance criterion 5). The
`:rf.xray.epoch/db-view-mode` sub + `set-db-view-mode` event were
already registered by `ee9def224` — only the snapshot needed syncing.

## Coordination

- PR #2203 (Epoch machine-cascade redesign) is open and adds new
  tests in `panels/epoch/`. This PR's scope is orthogonal — orphan
  retirement + snapshot sync. No file-level conflicts expected; if
  any, they are mechanical (this PR deletes `app-db-diff-*` tests
  in projection + view test files; #2203 modifies the same files).
- PR #2204 (sub-dispose framework) is on a different surface; no
  overlap.

bd: rf2-xu5iv