### PR TITLE
feat(framework): dispatch :source default :unknown + new :frame-init kind (rf2-hxj0d)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -344,14 +344,38 @@
           ;; The signal for "inside a handler" is `*current-frame*`
           ;; being bound — the router binds it in `process-event!`
           ;; for the duration of the cascade.
+          ;; Per rf2-hxj0d: stamp the frame-init dispatch with
+          ;; `:source :frame-init` so the Epoch panel's DISPATCH step
+          ;; renders "from frame-init" instead of being mislabelled
+          ;; via the previous `:ui` default. Additionally, capture the
+          ;; `reg-frame` call-site coord as `:rf.trace/call-site` so
+          ;; the click-to-source affordance jumps to the
+          ;; `(rf/reg-frame :foo {:on-create [...]})` line. The macro
+          ;; form of `reg-frame` (via `defreg-macro`) binds
+          ;; `*pending-coords*`, which `source-coords/merge-coords`
+          ;; merges directly INTO `config` as `:ns`/`:file`/`:line`/
+          ;; `:column` — so the call-site is already on the config
+          ;; map, no separate capture path needed. Gated on
+          ;; `interop/debug-enabled?` so production CLJS builds DCE
+          ;; the call-site read.
           (when-let [on-create (:on-create config)]
-            (if *current-frame*
-              ;; Handler-created child frame: async-queue on the child.
-              (when-let [dispatch (late-bind/get-fn :router/dispatch!)]
-                (dispatch on-create {:frame id}))
-              ;; Top-level (no in-flight cascade): synchronous, as before.
-              (when-let [dispatch-sync (late-bind/get-fn :router/dispatch-sync!)]
-                (dispatch-sync on-create {:frame id}))))
+            (let [init-opts (cond-> {:frame  id
+                                     :source :frame-init}
+                              (and interop/debug-enabled?
+                                   (or (:file config) (:line config)))
+                              (assoc :rf.trace/call-site
+                                     (cond-> {}
+                                       (:ns     config) (assoc :ns     (:ns     config))
+                                       (:file   config) (assoc :file   (:file   config))
+                                       (:line   config) (assoc :line   (:line   config))
+                                       (:column config) (assoc :column (:column config)))))]
+              (if *current-frame*
+                ;; Handler-created child frame: async-queue on the child.
+                (when-let [dispatch (late-bind/get-fn :router/dispatch!)]
+                  (dispatch on-create init-opts))
+                ;; Top-level (no in-flight cascade): synchronous, as before.
+                (when-let [dispatch-sync (late-bind/get-fn :router/dispatch-sync!)]
+                  (dispatch-sync on-create init-opts)))))
           (trace/emit! :rf.frame :rf.frame/created
                        {:frame id :config config})
           id)

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -79,7 +79,14 @@
     :fx-overrides       per-call fx-id-to-fx-id remapping
     :interceptor-overrides
     :trace-id           tooling
-    :source             :ui :timer :http :repl :machine ...
+    :source             trigger-kind classifier — closed set
+                        `:ui :frame-init :fx :machine :dispatch-later
+                        :test :unknown`. Default `:unknown` per
+                        rf2-hxj0d (changed from `:ui` to avoid false
+                        attribution of unstamped dispatches as
+                        UI-driven). UI handler call-sites stamp
+                        `:source :ui` explicitly; other origins
+                        stamp per the documented vocabulary.
     :origin             actor identity tag (:app default; :pair, :story,
                         :test, ... per Spec 002 §Dispatch origin tagging)
     :rf/dispatch-origin closed-enum functional source per Xray A.5 /
@@ -155,7 +162,17 @@
              :fx-overrides           (merge *fx-overrides* (:fx-overrides opts {}))
              :interceptor-overrides  (:interceptor-overrides opts {})
              :trace-id               (:trace-id opts)
-             :source                 (:source opts :ui)
+             ;; Per rf2-hxj0d: default `:source` is `:unknown` —
+             ;; previously defaulted to `:ui`, which silently
+             ;; misattributed every unstamped dispatch (frame-init,
+             ;; internal continuations, REPL eval) as UI-driven. UI
+             ;; handler call-sites stamp `:source :ui` explicitly; the
+             ;; `:on-create` frame-init dispatch (frame.cljc) stamps
+             ;; `:source :frame-init`; fx-emit dispatches (fx.cljc)
+             ;; inherit the parent's `:source`; tests / REPL stamp
+             ;; their own kind. `:unknown` surfaces "we lost track"
+             ;; rather than fabricating an origin.
+             :source                 (:source opts :unknown)
              :origin                 (:origin opts :app)
              ;; Per rf2-t1lxr: the closed-enum functional source per
              ;; Xray A.5 / Spec 009 §Dispatch-origin tagging. The 10-value

--- a/implementation/core/src/re_frame/test_support.cljc
+++ b/implementation/core/src/re_frame/test_support.cljc
@@ -403,10 +403,21 @@
          ;; :rf/dispatch-origin :test-harness so Xray's L2 timeline +
          ;; per-origin filters can discriminate test-driven cascades
          ;; from user-origin events. Caller may override.
-         dispatch-opts (cond-> {:frame frame-id :rf/dispatch-origin :test-harness}
+         ;;
+         ;; Per rf2-hxj0d: also stamp `:source :test` so the Epoch
+         ;; panel's DISPATCH step labels these dispatches as "from
+         ;; test" instead of "from unknown" (the new default).
+         ;; `:rf/dispatch-origin :test-harness` and `:source :test`
+         ;; both classify origin; together they let the operator
+         ;; filter either axis. Caller may override `:source` too.
+         dispatch-opts (cond-> {:frame frame-id
+                                :rf/dispatch-origin :test-harness
+                                :source :test}
                          (contains? opts :origin) (assoc :origin (:origin opts))
                          (contains? opts :rf/dispatch-origin)
-                         (assoc :rf/dispatch-origin (:rf/dispatch-origin opts)))]
+                         (assoc :rf/dispatch-origin (:rf/dispatch-origin opts))
+                         (contains? opts :source)
+                         (assoc :source (:source opts)))]
      (doseq [ev events]
        (router/dispatch-sync! ev dispatch-opts)
        (when after-each

--- a/spec/002-Frames.md
+++ b/spec/002-Frames.md
@@ -371,7 +371,7 @@ The hybrid `[<id> <map>]` shape for non-trivial events is canonical. Subscribe t
  :frame        :todo                   ;; resolved frame keyword
  :fx-overrides {:my-app/http stub-fn}  ;; per-dispatch fx replacements (master's dispatch-with)
  :trace-id     "..."                   ;; tooling/agent fields
- :source       :ui                     ;; trigger kind — the canonical enum is `:rf/dispatch-envelope`'s `:source` in [Spec-Schemas](Spec-Schemas.md#rfdispatch-envelope) (`:ui :timer :http :machine :repl :ssr-hydration :test :other`)
+ :source       :ui                     ;; trigger kind — the canonical enum is `:rf/dispatch-envelope`'s `:source` in [Spec-Schemas](Spec-Schemas.md#rfdispatch-envelope) (`:ui :frame-init :fx :machine :dispatch-later :timer :http :repl :ssr-hydration :test :unknown :other`); defaults to `:unknown` per rf2-hxj0d (previously `:ui`)
  :origin       :pair                   ;; actor identity — open vocabulary, defaults to `:app`; e.g. `:pair`, `:claude`, `:story`, `:test`
  :dispatched-at <ts>}
 ```
@@ -424,7 +424,9 @@ The dispatch opts map accepts an optional `:origin` key — a tag identifying th
 
 Pair-shaped tools and other tooling surfaces set `:origin` to filter their own activity in post-mortem trace views — "show me only the dispatches the pair tool issued during this session" becomes a one-key filter on the trace stream. User application code typically omits the opt; framework code (the SSR boot path, the router, the machine timer) sets it to a runtime-reserved value (`:rf/router`, `:rf/ssr`, etc.) where the distinction is useful.
 
-`:origin` is **distinct from `:source`** (the existing envelope key). `:source` describes the trigger kind — what *woke* the runtime; the canonical enum is `:rf/dispatch-envelope`'s `:source` in [Spec-Schemas](Spec-Schemas.md#rfdispatch-envelope) (`:ui`, `:timer`, `:http`, `:machine`, `:repl`, `:ssr-hydration`, `:test`, `:other`). `:origin` describes the actor identity — *who* issued the dispatch. Both can be set independently; tools commonly set `:origin :pair` and let `:source` default to `:repl`.
+`:origin` is **distinct from `:source`** (the existing envelope key). `:source` describes the trigger kind — what *woke* the runtime; the canonical enum is `:rf/dispatch-envelope`'s `:source` in [Spec-Schemas](Spec-Schemas.md#rfdispatch-envelope) (`:ui`, `:frame-init`, `:fx`, `:machine`, `:dispatch-later`, `:timer`, `:http`, `:repl`, `:ssr-hydration`, `:test`, `:unknown`, `:other`). `:origin` describes the actor identity — *who* issued the dispatch. Both can be set independently; tools commonly set `:origin :pair` and let `:source` default to `:unknown`.
+
+Per [rf2-hxj0d](https://github.com/day8/re-frame2/issues/rf2-hxj0d), the default `:source` value is **`:unknown`** — previously `:ui`, which silently misattributed every un-stamped dispatch (frame-init, REPL eval, internal continuation) as UI-driven. Frame-init dispatches (the `:on-create` event fired by `reg-frame`) explicitly stamp `:source :frame-init` and carry the `reg-frame` call-site coord under `:rf.trace/call-site` so click-to-source jumps to the `(rf/reg-frame ...)` line. UI handler call-sites that previously relied on the `:ui` default now either explicitly stamp `:source :ui` or render as `:unknown` — the framework no longer assumes UI provenance.
 
 ## View ergonomics (the hard part)
 

--- a/spec/009-Instrumentation.md
+++ b/spec/009-Instrumentation.md
@@ -82,7 +82,7 @@ When a tool (the pair tool, a story runner, the REPL, the SSR boot path) needs i
 
 `:rf.event/origin` is unconstrained at the framework level — tools and applications agree on values (`:pair`, `:claude`, `:story`, `:test`, etc.). The default is `:app`. User application code typically omits the opt; tool surfaces set it so post-mortem filters like "show me only the dispatches I (the pair tool) issued during this session" become a one-key filter on the trace stream.
 
-`:rf.event/origin` is **distinct from `:source`**: `:source` describes the *trigger kind* (`:ui` / `:timer` / `:http` / `:machine` / `:repl` / `:ssr-hydration`) and is essentially a "what woke the runtime?" axis; `:rf.event/origin` describes the *actor identity* (which tool or app subsystem emitted the dispatch) and is used for filtering. Tools may set both.
+`:rf.event/origin` is **distinct from `:source`**: `:source` describes the *trigger kind* (`:ui` / `:frame-init` / `:fx` / `:machine` / `:dispatch-later` / `:timer` / `:http` / `:repl` / `:ssr-hydration` / `:test` / `:unknown` / `:other`) and is essentially a "what woke the runtime?" axis; `:rf.event/origin` describes the *actor identity* (which tool or app subsystem emitted the dispatch) and is used for filtering. Tools may set both. The default `:source` is `:unknown` per [rf2-hxj0d](https://github.com/day8/re-frame2/issues/rf2-hxj0d) (previously `:ui`); see [Spec-Schemas §`:rf/dispatch-envelope`](Spec-Schemas.md#rfdispatch-envelope) for the canonical enum.
 
 ### Dispatch-origin tagging: `:rf/dispatch-origin`
 

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -99,7 +99,7 @@ Carried internally by every dispatch. User-facing event vector remains a vector;
    [:interceptor-overrides {:optional true} [:map-of :keyword :any]]
    [:interceptors          {:optional true} [:vector :any]]
    [:trace-id              {:optional true} :any]
-   [:source                {:optional true} [:enum :ui :timer :http :machine :repl :ssr-hydration :test :other]] ;; trigger kind
+   [:source                {:optional true} [:enum :ui :frame-init :fx :machine :dispatch-later :timer :http :repl :ssr-hydration :test :unknown :other]] ;; trigger kind — default `:unknown` (envelope-construction), per rf2-hxj0d
    [:origin                {:optional true} :keyword]                      ;; actor identity (default :app) — per [002 §Dispatch origin tagging]
    [:rf/dispatch-origin    {:optional true} [:enum :user :router :websocket :http :ssr :fx-emit :timer :test-harness :tool :internal]]  ;; closed-enum functional source (default :user) — per [009 §Dispatch-origin tagging]; per rf2-t1lxr
    [:dispatched-at         {:optional true} :any]])                        ;; CLJS reference may add an impl-specific timestamp; tools tolerate
@@ -121,7 +121,7 @@ The opts map a user passes to `(dispatch event opts)` / `(dispatch-sync event op
    [:interceptor-overrides {:optional true} [:map-of :keyword :any]]
    [:interceptors          {:optional true} [:vector :any]]
    [:trace-id              {:optional true} :any]
-   [:source                {:optional true} [:enum :ui :timer :http :machine :repl :ssr-hydration :test :other]]
+   [:source                {:optional true} [:enum :ui :frame-init :fx :machine :dispatch-later :timer :http :repl :ssr-hydration :test :unknown :other]]
    [:origin                {:optional true} :keyword]                       ;; actor identity tag — defaults to :app when omitted
    [:rf/dispatch-origin    {:optional true} [:enum :user :router :websocket :http :ssr :fx-emit :timer :test-harness :tool :internal]]])  ;; closed-enum functional source — defaults to :user when omitted (per rf2-t1lxr)
 ```


### PR DESCRIPTION
## Why

The dispatch envelope's `:source` opt defaulted to `:ui` (`router.cljc:158`), collapsing every un-stamped dispatch to a single value. Live evidence (pair-debug 2026-05-26): a `[:testdeck/initialise]` frame-init dispatch rendered as "from ui" in Xray's Epoch panel — operator misled about the actual origin.

## Fix shape

### Part 1 — Default `:source` is now `:unknown`

`router.cljc` envelope build: `(:source opts :ui)` → `(:source opts :unknown)`. Dispatches that don't stamp `:source` now render as "from unknown" — surfaces "we lost track" instead of fabricating a UI origin.

### Part 2 — `:frame-init` source kind + call-site capture

`frame.cljc` `reg-frame` (and `make-frame` / `reset-frame!` transitively) now stamps the `:on-create` dispatch with:

- `:source :frame-init` — the new vocabulary member
- `:rf.trace/call-site {:ns :file :line :column}` — read from the frame's config (the `reg-frame` macro merges `*pending-coords*` into the config map via `source-coords/merge-coords`, so the coord is already on hand — no new capture path)

Coord-capture is gated on `interop/debug-enabled?` so production CLJS builds DCE the call-site read.

`test_support.cljc dispatch-sequence` additionally stamps `:source :test` (a member of the existing vocabulary) so test-driven cascades classify cleanly under the new regime.

### Vocabulary changes

Expanded closed set on `:rf/dispatch-envelope` `:source` enum (in `spec/Spec-Schemas.md`):

`:ui :frame-init :fx :machine :dispatch-later :timer :http :repl :ssr-hydration :test :unknown :other`

Two new members: `:frame-init` (per the bead) and `:unknown` (the new default). The pre-existing members (`:ui :timer :http :machine :repl :ssr-hydration :test :other`) keep their meaning. The expanded vocabulary in the bead body (`:fx-emit`, `:fx`, `:dispatch-later`) lands here via the inheritance path — fx-emitted dispatches inherit the parent's `:source`, so the framework doesn't need to stamp them with a fresh kind. `:frame-destroy` was considered but deferred — `:on-destroy` dispatches default to `:unknown` for now (follow-up if operator value justifies).

## Coord-capture design choice (Part 2)

Picked option (a) — **no new macro needed**. The `reg-frame` defmacro (`core_reg_macros.cljc defreg-macro`) already binds `*pending-coords*`, which `source-coords/merge-coords` merges into the frame's config map. So the call-site coord is sitting in `config` as `{:ns :file :line :column}` keys by the time the `:on-create` dispatch fires. The fix is a 6-line read inside `reg-frame`'s `(when-let [on-create ...])` branch — no new macro, no stack-walking, no parallel registry.

Bead's option (d) "defer / leave it" was rejected as unnecessary — option (a) cost is trivial.

## File inventory

- `implementation/core/src/re_frame/router.cljc` — default change + docstring
- `implementation/core/src/re_frame/frame.cljc` — `:source :frame-init` + coord-capture on the `:on-create` dispatch
- `implementation/core/src/re_frame/test_support.cljc` — `dispatch-sequence` stamps `:source :test`
- `spec/Spec-Schemas.md` — `:rf/dispatch-envelope` + `:rf/dispatch-opts` `:source` enums expanded
- `spec/002-Frames.md` — envelope-shape comment + `:origin` vs `:source` paragraph: new vocab, new default, frame-init clarification
- `spec/009-Instrumentation.md` — `:source` vs `:rf.event/origin` paragraph: enum updated

## Downstream-tool implications

The Epoch panel projection (`tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc:98`) reads `:source` via `(common/tag-of ev :source)` — no hard-coded enum check; the new `:frame-init` / `:unknown` values flow through. The `dispatch-source-label` renderer (`panels/epoch/view.cljs:344-393`) does `(name source)` — `:frame-init` renders as "frame-init", `:unknown` as "unknown". No panel changes required.

Coord-capture surfaces the same `:rf.trace/call-site` slot the macro form of `rf/dispatch` uses, so the existing click-to-source affordance handles frame-init dispatches without additional plumbing.

## Test deltas

- CLJS: 4773 tests / 15444 assertions — green
- JVM implementation: all artefacts green (events, machines, schemas, routing, flows, http, ssr, ssr-ring, epoch)
- Elision probe: 38/38 absent in prod bundle; control 38/38 present
- Bundle isolation: 16 artefact entries / 33 internal sentinels absent / 3 allow-list budgets ok
- UIx + Helix Reagent-free: 6 sentinel checks pass

No existing test asserted `:source = :ui` as a default; all `:source :ui` references in tests fabricate synthetic envelopes for projection/rendering tests (unaffected).

## Coordination

Coordinated with rf2-xu5iv (already merged on `panels/epoch/` registry snapshot) — rebased on `origin/main` cleanly; no overlap.

Closes rf2-hxj0d.