### PR TITLE
perf(xray): hoist Event-detail styles + extract shared coord-chip (rf2-xjgdk)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/diff/hiccup_render.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/diff/hiccup_render.cljs
@@ -37,6 +37,226 @@
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens mono-stack sans-stack]]))
 
+;; ---- hoisted row-level styles (rf2-xjgdk · audit F5) -------------------
+;;
+;; Hiccup-diff renderers walk per element + per attr + per child;
+;; allocating fresh `:style` maps per node makes deep trees expensive.
+;; The maps below capture the static shape once; op-keyed colour
+;; variation is applied as a tiny `assoc`-overlay where it varies.
+
+(def ^:private key-label-keyed-style
+  {:color        (:accent tokens)
+   :font-family  mono-stack
+   :font-size    "11px"
+   :margin-right "6px"})
+
+(def ^:private key-label-indexed-style
+  {:color        (:text-tertiary tokens)
+   :font-family  mono-stack
+   :font-size    "11px"
+   :margin-right "6px"})
+
+(def ^:private gutter-row-style-base
+  "Outer gutter row — only the `:border-left` varies per call."
+  {:display      "flex"
+   :align-items  "flex-start"
+   :gap          "4px"
+   :padding      "2px 0"
+   :padding-left "6px"})
+
+(def ^:private gutter-glyph-style-base
+  "Per-row glyph span — only `:color` varies."
+  {:flex        "0 0 14px"
+   :font-family mono-stack
+   :font-size   "12px"
+   :font-weight 700
+   :text-align  "center"
+   :user-select "none"})
+
+(def ^:private gutter-body-style
+  {:flex 1 :min-width 0})
+
+;; --- attr-row shapes ---------------------------------------------------
+
+(def ^:private attr-same-row-style
+  {:display     "flex"
+   :gap         "6px"
+   :color       (:text-tertiary tokens)
+   :font-family mono-stack
+   :font-size   "12px"})
+
+(def ^:private attr-key-accent-style
+  {:color (:accent tokens)})
+
+(def ^:private attr-key-mono-style
+  {:color       (:accent tokens)
+   :font-family mono-stack
+   :font-size   "12px"})
+
+(def ^:private attr-row-flex-style
+  {:display "flex" :gap "6px"})
+
+(def ^:private attr-row-flex-strike-style
+  {:display "flex" :gap "6px" :text-decoration "line-through"})
+
+(def ^:private attr-row-flex-wrap-style
+  {:display "flex" :flex-wrap "wrap" :gap "6px" :align-items "baseline"})
+
+(def ^:private attr-value-added-style
+  {:color       (:green tokens)
+   :font-family mono-stack
+   :font-size   "12px"})
+
+(def ^:private attr-value-removed-style
+  {:color       (:red tokens)
+   :font-family mono-stack
+   :font-size   "12px"})
+
+(def ^:private attr-value-before-strike-style
+  {:color           (:text-tertiary tokens)
+   :font-family     mono-stack
+   :font-size       "12px"
+   :text-decoration "line-through"})
+
+(def ^:private attr-arrow-style
+  {:color       (:text-tertiary tokens)
+   :font-family mono-stack
+   :font-size   "12px"})
+
+(def ^:private attr-value-modified-after-style
+  {:color       (:yellow tokens)
+   :font-family mono-stack
+   :font-size   "12px"})
+
+(def ^:private fn-ref-changed-chip-style
+  {:color       (:accent tokens)
+   :font-family mono-stack
+   :font-size   "11px"
+   :font-style  "italic"})
+
+(def ^:private unknown-op-style
+  {:color (:red tokens)})
+
+(def ^:private attrs-container-style
+  {:padding-left "12px"
+   :margin       "2px 0"})
+
+(def ^:private children-container-style
+  {:padding-left "12px"
+   :border-left  (str "1px solid " (:border-subtle tokens))
+   :margin       "2px 0"})
+
+;; --- element header + outer element-changed row -----------------------
+
+(def ^:private element-row-style
+  {:display        "flex"
+   :flex-direction "column"
+   :margin         "2px 0"})
+
+(def ^:private element-header-flex-style
+  {:display     "flex"
+   :align-items "baseline"
+   :gap         "6px"
+   :font-family mono-stack
+   :font-size   "12px"
+   :color       (:text-primary tokens)})
+
+(def ^:private element-tag-style
+  {:color (:text-tertiary tokens)})
+
+(def ^:private element-changed-marker-style
+  {:color       (:text-tertiary tokens)
+   :font-family sans-stack
+   :font-size   "11px"})
+
+;; --- element-moved row -------------------------------------------------
+
+(def ^:private moved-row-style
+  {:display        "flex"
+   :flex-direction "column"
+   :margin         "2px 0"})
+
+(def ^:private moved-body-style
+  {:display     "flex"
+   :flex-wrap   "wrap"
+   :gap         "6px"
+   :align-items "baseline"
+   :font-family mono-stack
+   :font-size   "12px"})
+
+(def ^:private moved-label-style
+  {:color       (:accent tokens)
+   :font-weight 600})
+
+(def ^:private moved-meta-style
+  {:color      (:text-tertiary tokens)
+   :font-size  "11px"
+   :font-style "italic"})
+
+(def ^:private moved-value-style
+  {:color (:text-secondary tokens)})
+
+;; --- scalar leaf rows --------------------------------------------------
+
+(def ^:private leaf-same-row-style
+  {:display     "flex"
+   :gap         "6px"
+   :color       (:text-tertiary tokens)
+   :font-family mono-stack
+   :font-size   "12px"})
+
+(def ^:private leaf-row-flex-style
+  {:display "flex" :gap "6px"})
+
+(def ^:private leaf-row-flex-strike-style
+  {:display "flex" :gap "6px" :text-decoration "line-through"})
+
+(def ^:private leaf-row-flex-wrap-style
+  {:display "flex" :flex-wrap "wrap" :gap "6px" :align-items "baseline"})
+
+(def ^:private leaf-value-added-style
+  {:color       (:green tokens)
+   :font-family mono-stack
+   :font-size   "12px"})
+
+(def ^:private leaf-value-removed-style
+  {:color       (:red tokens)
+   :font-family mono-stack
+   :font-size   "12px"})
+
+(def ^:private leaf-value-before-strike-style
+  {:color           (:text-tertiary tokens)
+   :font-family     mono-stack
+   :font-size       "12px"
+   :text-decoration "line-through"})
+
+(def ^:private leaf-arrow-style
+  {:color       (:text-tertiary tokens)
+   :font-family mono-stack
+   :font-size   "12px"})
+
+(def ^:private leaf-value-modified-after-style
+  {:color       (:yellow tokens)
+   :font-family mono-stack
+   :font-size   "12px"})
+
+(def ^:private leaf-fn-ref-changed-row-style
+  {:display     "flex"
+   :gap         "6px"
+   :align-items "baseline"
+   :font-family mono-stack
+   :font-size   "12px"
+   :color       (:accent tokens)
+   :font-style  "italic"})
+
+;; --- root wrapper ------------------------------------------------------
+
+(def ^:private root-wrapper-style
+  {:font-family mono-stack
+   :font-size   "12px"
+   :color       (:text-primary tokens)
+   :line-height "1.5"})
+
 ;; ---- node-key helper ---------------------------------------------------
 
 (defn- node-key-for
@@ -50,17 +270,11 @@
   [node]
   (cond
     (some? (:key node))
-    [:span {:style {:color       (:accent tokens)
-                    :font-family mono-stack
-                    :font-size   "11px"
-                    :margin-right "6px"}}
+    [:span {:style key-label-keyed-style}
      (str ":key " (pr-str (:key node)))]
 
     (some? (:index node))
-    [:span {:style {:color       (:text-tertiary tokens)
-                    :font-family mono-stack
-                    :font-size   "11px"
-                    :margin-right "6px"}}
+    [:span {:style key-label-indexed-style}
      (str "[" (:index node) "]")]
 
     :else nil))
@@ -75,23 +289,15 @@
       :default-expanded-depth 1}]))
 
 (defn- gutter
-  "Coloured-glyph + left-border wrapper for an annotated row."
+  "Coloured-glyph + left-border wrapper for an annotated row. The two
+  per-op-variant pixels (`:border-left` tone, glyph `:color`) ride on
+  hoisted base styles."
   [glyph tone body]
-  [:div {:style {:display      "flex"
-                 :align-items  "flex-start"
-                 :gap          "4px"
-                 :padding      "2px 0"
-                 :padding-left "6px"
-                 :border-left  (str "3px solid " tone)}}
-   [:span {:style {:flex          "0 0 14px"
-                   :color         tone
-                   :font-family   mono-stack
-                   :font-size     "12px"
-                   :font-weight   700
-                   :text-align    "center"
-                   :user-select   "none"}}
+  [:div {:style (assoc gutter-row-style-base
+                       :border-left (str "3px solid " tone))}
+   [:span {:style (assoc gutter-glyph-style-base :color tone)}
     glyph]
-   [:div {:style {:flex 1 :min-width 0}}
+   [:div {:style gutter-body-style}
     body]])
 
 ;; ---- annotated-attrs rendering -----------------------------------------
@@ -107,76 +313,49 @@
         nkey  (str parent-key "/attr/" (pr-str k))]
     (case op
       :same
-      [:div {:style {:display "flex" :gap "6px"
-                     :color (:text-tertiary tokens)
-                     :font-family mono-stack :font-size "12px"}}
-       [:span {:style {:color (:accent tokens)}} (pr-str k)]
+      [:div {:style attr-same-row-style}
+       [:span {:style attr-key-accent-style} (pr-str k)]
        (inspect-value (:value attr-node) nkey)]
 
       :added
       (gutter "+" (:green tokens)
-              [:div {:style {:display "flex" :gap "6px"}}
-               [:span {:style {:color (:accent tokens)
-                               :font-family mono-stack
-                               :font-size "12px"}}
+              [:div {:style attr-row-flex-style}
+               [:span {:style attr-key-mono-style}
                 (pr-str k)]
-               [:span {:style {:color (:green tokens)
-                               :font-family mono-stack
-                               :font-size "12px"}}
+               [:span {:style attr-value-added-style}
                 (inspect-value (:value attr-node) nkey)]])
 
       :removed
       (gutter "-" (:red tokens)
-              [:div {:style {:display "flex" :gap "6px"
-                             :text-decoration "line-through"}}
-               [:span {:style {:color (:accent tokens)
-                               :font-family mono-stack
-                               :font-size "12px"}}
+              [:div {:style attr-row-flex-strike-style}
+               [:span {:style attr-key-mono-style}
                 (pr-str k)]
-               [:span {:style {:color (:red tokens)
-                               :font-family mono-stack
-                               :font-size "12px"}}
+               [:span {:style attr-value-removed-style}
                 (inspect-value (:value attr-node) nkey)]])
 
       :modified
       (gutter "~" (:yellow tokens)
-              [:div {:style {:display "flex" :flex-wrap "wrap" :gap "6px"
-                             :align-items "baseline"}}
-               [:span {:style {:color (:accent tokens)
-                               :font-family mono-stack
-                               :font-size "12px"}}
+              [:div {:style attr-row-flex-wrap-style}
+               [:span {:style attr-key-mono-style}
                 (pr-str k)]
-               [:span {:style {:color (:text-tertiary tokens)
-                               :font-family mono-stack
-                               :font-size "12px"
-                               :text-decoration "line-through"}}
+               [:span {:style attr-value-before-strike-style}
                 (inspect-value (:before attr-node) (str nkey "/before"))]
-               [:span {:style {:color (:text-tertiary tokens)
-                               :font-family mono-stack
-                               :font-size "12px"}}
+               [:span {:style attr-arrow-style}
                 "→"]
-               [:span {:style {:color (:yellow tokens)
-                               :font-family mono-stack
-                               :font-size "12px"}}
+               [:span {:style attr-value-modified-after-style}
                 (inspect-value (:after attr-node) (str nkey "/after"))]])
 
       :fn-ref-changed
       (gutter "◴" (:accent tokens)
-              [:div {:style {:display "flex" :gap "6px"
-                             :align-items "baseline"}}
-               [:span {:style {:color (:accent tokens)
-                               :font-family mono-stack
-                               :font-size "12px"}}
+              [:div {:style attr-row-flex-wrap-style}
+               [:span {:style attr-key-mono-style}
                 (pr-str k)]
                [:span {:data-testid "rf-xray-diff-fn-ref-changed-chip"
-                       :style {:color (:accent tokens)
-                               :font-family mono-stack
-                               :font-size "11px"
-                               :font-style "italic"}}
+                       :style fn-ref-changed-chip-style}
                 "(fn ref changed)"]])
 
       ;; Fallback — unknown op (defensive).
-      [:span {:style {:color (:red tokens)}}
+      [:span {:style unknown-op-style}
        (str "unknown attr op: " (pr-str op))])))
 
 (defn- render-attrs-diff
@@ -188,8 +367,7 @@
         changed (filter #(not= :same (hd/op-of %)) kids)]
     (when (seq changed)
       (into [:div {:data-testid "rf-xray-diff-hiccup-attrs"
-                   :style {:padding-left "12px"
-                           :margin "2px 0"}}]
+                   :style attrs-container-style}]
             (for [c changed]
               ^{:key (pr-str (:key c))}
               (render-attr-row c parent-key))))))
@@ -202,10 +380,7 @@
   [children-diff surface parent-path depth]
   (when (seq children-diff)
     (into [:div {:data-testid "rf-xray-diff-hiccup-children"
-                 :style {:padding-left "12px"
-                         :border-left (str "1px solid "
-                                           (:border-subtle tokens))
-                         :margin "2px 0"}}]
+                 :style children-container-style}]
           (map-indexed
             (fn [i c]
               (let [k    (or (:key c) (:index c) i)
@@ -220,11 +395,9 @@
   "Render `[tag attrs-summary …]` as the per-element row label. The
   attrs detail rolls out below."
   [tag attrs-count children-count node-label]
-  [:div {:style {:display "flex" :align-items "baseline" :gap "6px"
-                 :font-family mono-stack :font-size "12px"
-                 :color (:text-primary tokens)}}
+  [:div {:style element-header-flex-style}
    (when node-label node-label)
-   [:span {:style {:color (:text-tertiary tokens)}}
+   [:span {:style element-tag-style}
     (str "[" (pr-str tag)
          (when (pos? attrs-count) " {…}")
          (when (pos? children-count) " …")
@@ -241,18 +414,12 @@
         any-changes? (or (some #(not= :same (hd/op-of %)) (:children attrs-diff))
                          (some #(not= :same (hd/op-of %)) children-diff))]
     [:div {:data-testid (str "rf-xray-diff-hiccup-element-" nkey)
-           :style {:display "flex"
-                   :flex-direction "column"
-                   :margin "2px 0"}}
-     [:div {:style {:display "flex" :align-items "baseline" :gap "6px"
-                    :font-family mono-stack :font-size "12px"
-                    :color (:text-primary tokens)}}
+           :style element-row-style}
+     [:div {:style element-header-flex-style}
       (key-or-index-label node)
       (element-header tag attrs-count kids-count nil)
       (when any-changes?
-        [:span {:style {:color (:text-tertiary tokens)
-                        :font-family sans-stack
-                        :font-size "11px"}}
+        [:span {:style element-changed-marker-style}
          "◴ changed"])]
      (render-attrs-diff attrs-diff nkey)
      (render-children-diff children-diff surface path depth)]))
@@ -264,22 +431,15 @@
   (let [{:keys [value key from-index to-index inner-diff]} node
         nkey (node-key-for surface path)]
     [:div {:data-testid "rf-xray-diff-hiccup-moved"
-           :style {:display "flex"
-                   :flex-direction "column"
-                   :margin "2px 0"}}
+           :style moved-row-style}
      (gutter "↻" (:accent tokens)
-             [:div {:style {:display "flex" :flex-wrap "wrap" :gap "6px"
-                            :align-items "baseline"
-                            :font-family mono-stack :font-size "12px"}}
+             [:div {:style moved-body-style}
               (key-or-index-label node)
-              [:span {:style {:color (:accent tokens)
-                              :font-weight 600}}
+              [:span {:style moved-label-style}
                (str "moved")]
-              [:span {:style {:color (:text-tertiary tokens)
-                              :font-size "11px"
-                              :font-style "italic"}}
+              [:span {:style moved-meta-style}
                (str "(was at index " from-index ", now at " to-index ")")]
-              [:span {:style {:color (:text-secondary tokens)}}
+              [:span {:style moved-value-style}
                (inspect-value value nkey)]])
      (when inner-diff
        (render-hiccup-annotated inner-diff surface
@@ -289,63 +449,43 @@
 
 (defn- render-same-leaf
   [node nkey]
-  [:div {:style {:display "flex" :gap "6px"
-                 :color (:text-tertiary tokens)
-                 :font-family mono-stack :font-size "12px"}}
+  [:div {:style leaf-same-row-style}
    (key-or-index-label node)
    (inspect-value (:value node) nkey)])
 
 (defn- render-added-leaf
   [node nkey]
   (gutter "+" (:green tokens)
-          [:div {:style {:display "flex" :gap "6px"}}
+          [:div {:style leaf-row-flex-style}
            (key-or-index-label node)
-           [:span {:style {:color (:green tokens)
-                           :font-family mono-stack
-                           :font-size "12px"}}
+           [:span {:style leaf-value-added-style}
             (inspect-value (:value node) nkey)]]))
 
 (defn- render-removed-leaf
   [node nkey]
   (gutter "-" (:red tokens)
-          [:div {:style {:display "flex" :gap "6px"
-                         :text-decoration "line-through"}}
+          [:div {:style leaf-row-flex-strike-style}
            (key-or-index-label node)
-           [:span {:style {:color (:red tokens)
-                           :font-family mono-stack
-                           :font-size "12px"}}
+           [:span {:style leaf-value-removed-style}
             (inspect-value (:value node) nkey)]]))
 
 (defn- render-modified-leaf
   [node nkey]
   (gutter "~" (:yellow tokens)
-          [:div {:style {:display "flex" :flex-wrap "wrap" :gap "6px"
-                         :align-items "baseline"}}
+          [:div {:style leaf-row-flex-wrap-style}
            (key-or-index-label node)
-           [:span {:style {:color (:text-tertiary tokens)
-                           :font-family mono-stack
-                           :font-size "12px"
-                           :text-decoration "line-through"}}
+           [:span {:style leaf-value-before-strike-style}
             (inspect-value (:before node) (str nkey "/before"))]
-           [:span {:style {:color (:text-tertiary tokens)
-                           :font-family mono-stack
-                           :font-size "12px"}}
+           [:span {:style leaf-arrow-style}
             "→"]
-           [:span {:style {:color (:yellow tokens)
-                           :font-family mono-stack
-                           :font-size "12px"}}
+           [:span {:style leaf-value-modified-after-style}
             (inspect-value (:after node) (str nkey "/after"))]]))
 
 (defn- render-fn-ref-changed-leaf
   [node nkey]
   (gutter "◴" (:accent tokens)
           [:div {:data-testid "rf-xray-diff-fn-ref-changed-chip"
-                 :style {:display "flex" :gap "6px"
-                         :align-items "baseline"
-                         :font-family mono-stack
-                         :font-size "12px"
-                         :color (:accent tokens)
-                         :font-style "italic"}}
+                 :style leaf-fn-ref-changed-row-style}
            (key-or-index-label node)
            "(fn ref changed)"]))
 
@@ -377,7 +517,7 @@
       :removed         (render-removed-leaf  node nkey)
       :modified        (render-modified-leaf node nkey)
       ;; Fallback — shouldn't happen for well-formed input.
-      [:span {:style {:color (:red tokens)}}
+      [:span {:style unknown-op-style}
        (str "unknown hiccup op: " (pr-str op))])))
 
 (defn render-root
@@ -387,8 +527,5 @@
    (render-root annotated surface []))
   ([annotated surface path]
    [:div {:data-testid "rf-xray-diff-hiccup-root"
-          :style {:font-family mono-stack
-                  :font-size "12px"
-                  :color (:text-primary tokens)
-                  :line-height "1.5"}}
+          :style root-wrapper-style}
     (render-hiccup-annotated annotated surface path 0)]))

--- a/tools/xray/src/day8/re_frame2_xray/diff/render.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/diff/render.cljs
@@ -77,6 +77,224 @@
   than this. Below the threshold, render inline so context stays."
   3)
 
+;; ---- hoisted row-level styles (rf2-xjgdk · audit F5) -------------------
+;;
+;; The diff renderer iterates per `breadcrumb` segment + per annotated
+;; tree row; a typical render walks 5 sections × 30 changed paths × 3
+;; styled spans per row (~450 `:style` allocations). The maps below
+;; hoist the per-iteration shape to ns-load constants so each row
+;; reuses a single reference. Per-op colour variation is applied as a
+;; tiny `assoc`-overlay where needed. Token reads resolve at ns-load
+;; (`tokens` is a static const map per spec/007-UX-IA §CSS
+;; custom-property surface) so theme switching still rides the CSS
+;; vars seam, not Clojure value swaps.
+
+(def ^:private header-button-style-base
+  {:background    "transparent"
+   :border        (str "1px solid " (:border-default tokens))
+   :padding       "1px 6px"
+   :border-radius "4px"
+   :cursor        "pointer"
+   :font-family   sans-stack
+   :font-size     "10px"})
+
+(def ^:private breadcrumb-empty-style
+  {:color (:accent tokens)})
+
+(def ^:private breadcrumb-container-style
+  {:color     (:accent tokens)
+   :display   "inline-flex"
+   :flex-wrap "wrap"
+   :gap       "2px"})
+
+(def ^:private breadcrumb-segment-style
+  {:cursor                 "pointer"
+   :color                  (:accent tokens)
+   :text-decoration        "underline"
+   :text-decoration-style  "dotted"
+   :text-underline-offset  "2px"
+   :text-decoration-color  (:border-default tokens)})
+
+(def ^:private origin-tag-chip-base-style
+  "Per-section origin-tag chip — only `:color` varies per kind."
+  {:display       "inline-flex"
+   :align-items   "center"
+   :gap           "4px"
+   :padding       "1px 6px"
+   :background    (:bg-2 tokens)
+   :border        (str "1px solid " (:border-subtle tokens))
+   :border-radius "3px"
+   :font-family   mono-stack
+   :font-size     "10px"
+   :font-weight   600
+   :user-select   "none"
+   :cursor        "help"})
+
+(def ^:private breadcrumb-header-style
+  {:position       "sticky"
+   :top            0
+   :z-index        1
+   :display        "flex"
+   :align-items    "center"
+   :flex-wrap      "wrap"
+   :gap            "8px"
+   :padding        "6px 12px"
+   :background     (:bg-3 tokens)
+   :border-bottom  (str "1px solid " (:border-subtle tokens))
+   :font-family    mono-stack
+   :font-size      "12px"
+   :color          (:text-primary tokens)
+   :font-weight    600})
+
+(def ^:private breadcrumb-affordances-style
+  {:display     "inline-flex"
+   :gap         "4px"
+   :align-items "center"})
+
+(def ^:private breadcrumb-changes-summary-style
+  {:font-family sans-stack
+   :font-size   "11px"
+   :color       (:text-tertiary tokens)
+   :font-weight 400
+   :margin-left "auto"})
+
+(def ^:private gutter-row-style-base
+  "Outer flex container for a single annotated row — only the
+  `:border-left` colour varies per op."
+  {:display      "flex"
+   :align-items  "flex-start"
+   :gap          "4px"
+   :padding      "2px 0"
+   :padding-left "6px"})
+
+(def ^:private gutter-glyph-style-base
+  "Per-row glyph span — only `:color` varies per op."
+  {:flex        "0 0 14px"
+   :font-family mono-stack
+   :font-size   "12px"
+   :font-weight 700
+   :text-align  "center"
+   :user-select "none"})
+
+(def ^:private gutter-body-style
+  {:flex 1 :min-width 0})
+
+(def ^:private key-label-style
+  {:color        (:accent tokens)
+   :font-family  mono-stack
+   :font-size    "12px"
+   :margin-right "6px"})
+
+(def ^:private leaf-row-style
+  "Per-leaf row container — shared by added / removed / modified /
+  same renderers. The leaf-specific colour/strikethrough lives inside
+  the leaf's value span."
+  {:display     "flex"
+   :flex-wrap   "wrap"
+   :align-items "baseline"
+   :gap         "6px"})
+
+(def ^:private removed-leaf-row-style
+  (assoc leaf-row-style :text-decoration "line-through"))
+
+(def ^:private modified-before-value-style
+  {:color           (:text-tertiary tokens)
+   :font-family     mono-stack
+   :font-size       "12px"
+   :text-decoration "line-through"})
+
+(def ^:private modified-arrow-style
+  {:color       (:text-tertiary tokens)
+   :font-family mono-stack
+   :font-size   "12px"})
+
+(def ^:private modified-after-value-style
+  {:color       (:yellow tokens)
+   :font-family mono-stack
+   :font-size   "12px"})
+
+(def ^:private added-leaf-value-style
+  {:color       (:green tokens)
+   :font-family mono-stack
+   :font-size   "12px"})
+
+(def ^:private removed-leaf-value-style
+  {:color       (:red tokens)
+   :font-family mono-stack
+   :font-size   "12px"})
+
+(def ^:private same-leaf-row-style
+  (assoc leaf-row-style :color (:text-tertiary tokens)))
+
+(def ^:private unchanged-chip-style
+  {:display       "inline-flex"
+   :align-items   "center"
+   :gap           "6px"
+   :padding       "2px 8px"
+   :background    (:bg-2 tokens)
+   :border-radius "3px"
+   :color         (:text-tertiary tokens)
+   :font-family   mono-stack
+   :font-size     "11px"
+   :font-style    "italic"})
+
+(def ^:private container-row-style
+  {:display        "flex"
+   :flex-direction "column"
+   :margin         "2px 0"})
+
+(def ^:private container-header-style
+  {:display     "flex"
+   :align-items "baseline"
+   :gap         "6px"
+   :font-family mono-stack
+   :font-size   "12px"
+   :color       (:text-primary tokens)})
+
+(def ^:private container-tag-glyph-style
+  {:color (:text-tertiary tokens)})
+
+(def ^:private container-summary-style
+  {:color       (:text-tertiary tokens)
+   :font-family sans-stack
+   :font-size   "11px"})
+
+(def ^:private container-body-expanded-style
+  {:padding-left "12px"
+   :border-left  (str "1px solid " (:border-subtle tokens))})
+
+(def ^:private container-body-collapsed-style
+  {:padding-left "12px"})
+
+(def ^:private container-body-collapsed-caption-style
+  {:color       (:text-tertiary tokens)
+   :font-family sans-stack
+   :font-size   "11px"
+   :font-style  "italic"})
+
+(def ^:private section-base-style
+  {:margin        "8px 12px"
+   :background    (:bg-3 tokens)
+   :border        (str "1px solid " (:border-subtle tokens))
+   :border-radius "4px"
+   :overflow      "hidden"})
+
+(def ^:private section-body-style
+  {:padding     "8px 12px"
+   :font-family mono-stack
+   :font-size   "12px"
+   :color       (:text-primary tokens)
+   :line-height "1.5"})
+
+(def ^:private diff-empty-style
+  {:padding     "12px"
+   :color       (:text-tertiary tokens)
+   :font-family sans-stack
+   :font-size   "12px"})
+
+(def ^:private unknown-op-style
+  {:color (:red tokens)})
+
 ;; ---- gutter / colour mapping --------------------------------------------
 
 (def ^:private op->gutter-glyph
@@ -134,15 +352,8 @@
   [{:keys [testid label colour on-click]}]
   [:button {:data-testid testid
             :on-click    on-click
-            :style       {:background    "transparent"
-                          :color         (or colour (:text-secondary tokens))
-                          :border        (str "1px solid "
-                                              (:border-default tokens))
-                          :padding       "1px 6px"
-                          :border-radius "4px"
-                          :cursor        "pointer"
-                          :font-family   sans-stack
-                          :font-size     "10px"}}
+            :style       (assoc header-button-style-base
+                                :color (or colour (:text-secondary tokens)))}
    label])
 
 (defn- breadcrumb-segments
@@ -161,14 +372,11 @@
   (if (empty? section-path)
     [:span {:data-testid (str "rf-xray-diff-section-path-"
                               (pr-str section-path))
-            :style       {:color (:accent tokens)}}
+            :style       breadcrumb-empty-style}
      "(root)"]
     (into [:span {:data-testid (str "rf-xray-diff-section-path-"
                                     (pr-str section-path))
-                  :style       {:color (:accent tokens)
-                                :display "inline-flex"
-                                :flex-wrap "wrap"
-                                :gap "2px"}}]
+                  :style       breadcrumb-container-style}]
           (for [i (range (count section-path))]
             (let [seg        (nth section-path i)
                   prefix     (vec (take (inc i) section-path))
@@ -184,12 +392,7 @@
                       :on-click    on-click
                       :title       (str "Inspect app-db at "
                                         (pr-str prefix))
-                      :style       {:cursor          "pointer"
-                                    :color           (:accent tokens)
-                                    :text-decoration "underline"
-                                    :text-decoration-style "dotted"
-                                    :text-underline-offset "2px"
-                                    :text-decoration-color (:border-default tokens)}}
+                      :style       breadcrumb-segment-style}
                (pr-str seg)])))))
 
 ;; ---- rf2-s8r6c — per-section origin tag chip ---------------------------
@@ -264,20 +467,7 @@
                               (pr-str section-path))
             :data-origin kind
             :title       (origin-tag-tooltip tag)
-            :style       {:display       "inline-flex"
-                          :align-items   "center"
-                          :gap           "4px"
-                          :padding       "1px 6px"
-                          :background    (:bg-2 tokens)
-                          :border        (str "1px solid "
-                                              (:border-subtle tokens))
-                          :border-radius "3px"
-                          :color         colour
-                          :font-family   mono-stack
-                          :font-size     "10px"
-                          :font-weight   600
-                          :user-select   "none"
-                          :cursor        "help"}}
+            :style       (assoc origin-tag-chip-base-style :color colour)}
      label]))
 
 (defn breadcrumb
@@ -332,21 +522,7 @@
          path-vec      (vec section-path)]
      [:header {:data-testid (str "rf-xray-diff-section-header-"
                                  (pr-str section-path))
-               :style {:position       "sticky"
-                       :top            0
-                       :z-index        1
-                       :display        "flex"
-                       :align-items    "center"
-                       :flex-wrap      "wrap"
-                       :gap            "8px"
-                       :padding        "6px 12px"
-                       :background     (:bg-3 tokens)
-                       :border-bottom  (str "1px solid "
-                                            (:border-subtle tokens))
-                       :font-family    mono-stack
-                       :font-size      "12px"
-                       :color          (:text-primary tokens)
-                       :font-weight    600}}
+               :style breadcrumb-header-style}
       (breadcrumb-segments section-path)
       ;; rf2-s8r6c — origin-tag chip identifying the writer(s) for the
       ;; paths under this section. Always rendered when `origin-tag`
@@ -366,9 +542,7 @@
       ;; superseded by the clickable-segment inspector popup.
       [:div {:data-testid (str "rf-xray-diff-section-affordances-"
                                (pr-str section-path))
-             :style       {:display     "inline-flex"
-                           :gap         "4px"
-                           :align-items "center"}}
+             :style       breadcrumb-affordances-style}
        (header-button
          {:testid   (str "rf-xray-diff-section-show-when-"
                          (pr-str section-path))
@@ -390,11 +564,7 @@
                                    subtree-value]
                                   {:frame :rf/xray})})]
       (when (pos? total-changes)
-        [:span {:style {:font-family sans-stack
-                        :font-size "11px"
-                        :color (:text-tertiary tokens)
-                        :font-weight 400
-                        :margin-left "auto"}}
+        [:span {:style breadcrumb-changes-summary-style}
          (str "◴ "
               total-changes
               (if (= total-changes 1) " change" " changes"))])])))
@@ -404,34 +574,25 @@
 (declare render-annotated)
 
 (defn- gutter
-  "Coloured-glyph + left-border wrapper for a single annotated row."
+  "Coloured-glyph + left-border wrapper for a single annotated row.
+  The two op-keyed colour reads (`gutter-colour`, used for both the
+  left-border and the glyph) are interpolated into a single string and
+  the static row + glyph shape come from ns-top defs."
   [op body]
-  [:div {:style {:display      "flex"
-                 :align-items  "flex-start"
-                 :gap          "4px"
-                 :padding      "2px 0"
-                 :padding-left "6px"
-                 :border-left  (str "3px solid " (gutter-colour op))}}
-   [:span {:style {:flex          "0 0 14px"
-                   :color         (gutter-colour op)
-                   :font-family   mono-stack
-                   :font-size     "12px"
-                   :font-weight   700
-                   :text-align    "center"
-                   :user-select   "none"}}
-    (or (op->gutter-glyph op) " ")]
-   [:div {:style {:flex 1 :min-width 0}}
-    body]])
+  (let [colour (gutter-colour op)]
+    [:div {:style (assoc gutter-row-style-base
+                         :border-left (str "3px solid " colour))}
+     [:span {:style (assoc gutter-glyph-style-base :color colour)}
+      (or (op->gutter-glyph op) " ")]
+     [:div {:style gutter-body-style}
+      body]]))
 
 (defn- key-label
   "Render the `:key` or `:index` slot for a child as `:k ` / `2 ` so
   the value sits inline with its identifier."
   [child]
   (when-let [k (at/child-key child)]
-    [:span {:style {:color       (:accent tokens)
-                    :font-family mono-stack
-                    :font-size   "12px"
-                    :margin-right "6px"}}
+    [:span {:style key-label-style}
      (str (pr-str k) " ")]))
 
 (defn- inspect-value
@@ -459,42 +620,27 @@
   (design §3.1.2 — 'side-by-side vs unified')."
   [node node-key]
   (let [{:keys [before after]} node]
-    [:div {:style {:display "flex" :flex-wrap "wrap" :align-items "baseline"
-                   :gap "6px"}}
+    [:div {:style leaf-row-style}
      (key-label node)
-     [:span {:style {:color (:text-tertiary tokens)
-                     :font-family mono-stack
-                     :font-size "12px"
-                     :text-decoration "line-through"}}
+     [:span {:style modified-before-value-style}
       (inspect-value before (str node-key "/before"))]
-     [:span {:style {:color (:text-tertiary tokens)
-                     :font-family mono-stack
-                     :font-size "12px"}}
+     [:span {:style modified-arrow-style}
       "→"]
-     [:span {:style {:color (:yellow tokens)
-                     :font-family mono-stack
-                     :font-size "12px"}}
+     [:span {:style modified-after-value-style}
       (inspect-value after (str node-key "/after"))]]))
 
 (defn- render-added-leaf
   [node node-key]
-  [:div {:style {:display "flex" :flex-wrap "wrap" :align-items "baseline"
-                 :gap "6px"}}
+  [:div {:style leaf-row-style}
    (key-label node)
-   [:span {:style {:color (:green tokens)
-                   :font-family mono-stack
-                   :font-size "12px"}}
+   [:span {:style added-leaf-value-style}
     (inspect-value (:value node) node-key)]])
 
 (defn- render-removed-leaf
   [node node-key]
-  [:div {:style {:display "flex" :flex-wrap "wrap" :align-items "baseline"
-                 :gap "6px"
-                 :text-decoration "line-through"}}
+  [:div {:style removed-leaf-row-style}
    (key-label node)
-   [:span {:style {:color (:red tokens)
-                   :font-family mono-stack
-                   :font-size "12px"}}
+   [:span {:style removed-leaf-value-style}
     (inspect-value (:value node) node-key)]])
 
 (defn- unchanged-chip
@@ -502,16 +648,7 @@
   unchanged-subtrees default (§5.3)."
   [n container-tag]
   [:div {:data-testid "rf-xray-diff-unchanged-chip"
-         :style {:display       "inline-flex"
-                 :align-items   "center"
-                 :gap           "6px"
-                 :padding       "2px 8px"
-                 :background    (:bg-2 tokens)
-                 :border-radius "3px"
-                 :color         (:text-tertiary tokens)
-                 :font-family   mono-stack
-                 :font-size     "11px"
-                 :font-style    "italic"}}
+         :style unchanged-chip-style}
    (str "(" n
         (case container-tag
           :map " entries unchanged"
@@ -525,9 +662,7 @@
   collapse threshold). Uses the data-inspector but with greyed-out
   colour."
   [node node-key]
-  [:div {:style {:display "flex" :flex-wrap "wrap" :align-items "baseline"
-                 :gap "6px"
-                 :color (:text-tertiary tokens)}}
+  [:div {:style same-leaf-row-style}
    (key-label node)
    (inspect-value (:value node) node-key)])
 
@@ -550,27 +685,17 @@
         same-kids      (filter #(= :same (at/op-of %)) children)
         many-same?     (> (count same-kids) collapse-unchanged-threshold)]
     [:div {:data-testid (str "rf-xray-diff-container-" node-key)
-           :style {:display "flex"
-                   :flex-direction "column"
-                   :margin "2px 0"}}
+           :style container-row-style}
      ;; Header — key (if any) + container summary chip.
-     [:div {:style {:display "flex" :align-items "baseline"
-                    :gap "6px"
-                    :font-family mono-stack
-                    :font-size "12px"
-                    :color (:text-primary tokens)}}
+     [:div {:style container-header-style}
       (key-label node)
-      [:span {:style {:color (:text-tertiary tokens)}}
+      [:span {:style container-tag-glyph-style}
        (case tag :map "{…}" :vec "[…]" :set "#{…}" "…")]
-      [:span {:style {:color (:text-tertiary tokens)
-                      :font-family sans-stack
-                      :font-size "11px"}}
+      [:span {:style container-summary-style}
        (str "◴ " (children-summary-changed-count child-summary) " changed")]]
      ;; Body — either auto-expanded (depth-budgeted) or chip-collapsed.
      (if auto-expand?
-       [:div {:style {:padding-left "12px"
-                      :border-left (str "1px solid "
-                                        (:border-subtle tokens))}}
+       [:div {:style container-body-expanded-style}
         ;; Changed children — render each with appropriate gutter.
         (into [:div]
               (map-indexed
@@ -599,11 +724,8 @@
        ;; Past depth budget — collapse the whole container to a chip
        ;; with a click-to-expand affordance handled by inspector's
        ;; existing toggle.
-       [:div {:style {:padding-left "12px"}}
-        [:span {:style {:color (:text-tertiary tokens)
-                        :font-family sans-stack
-                        :font-size "11px"
-                        :font-style "italic"}}
+       [:div {:style container-body-collapsed-style}
+        [:span {:style container-body-collapsed-caption-style}
          (str "(" (children-summary-changed-count child-summary)
               " nested changes — expand by drilling: "
               (case tag :map "map" :vec "vec" :set "set" "value") ")")]
@@ -647,7 +769,7 @@
         :removed  (gutter :removed  (render-removed-leaf  node node-key))
         :same     (render-same-inline node node-key)
         ;; Fallback — shouldn't happen for well-formed input.
-        [:span {:style {:color (:red tokens)}}
+        [:span {:style unknown-op-style}
          (str "unknown op: " (pr-str op))]))))
 
 ;; ---- section + panel ---------------------------------------------------
@@ -691,12 +813,6 @@
                          (:child-summary subtree)
                          nil)
          after-value   (subtree->after-value subtree)
-         base-style    {:margin         "8px 12px"
-                        :background     (:bg-3 tokens)
-                        :border         (str "1px solid "
-                                             (:border-subtle tokens))
-                        :border-radius  "4px"
-                        :overflow       "hidden"}
          flash-style   (when flash?
                          ;; Duration is interpolated through the
                          ;; `--rf-xray-motion-scale` seam (rf2-5kfxe.5
@@ -712,13 +828,11 @@
                                " ease-out forwards")})]
      [:section {:data-testid (str "rf-xray-diff-section-"
                                   (pr-str path))
-                :style (merge base-style flash-style)}
+                :style (if flash-style
+                         (merge section-base-style flash-style)
+                         section-base-style)}
       (breadcrumb path child-summary after-value origin-tag extra-affordance)
-      [:div {:style {:padding "8px 12px"
-                     :font-family mono-stack
-                     :font-size "12px"
-                     :color (:text-primary tokens)
-                     :line-height "1.5"}}
+      [:div {:style section-body-style}
        (render-annotated subtree path [] surface 0)]])))
 
 (defn render-sections
@@ -745,10 +859,7 @@
                              extra-affordance-fn] :as _opts}]
    (if (empty? sections)
      [:div {:data-testid "rf-xray-diff-empty"
-            :style {:padding "12px"
-                    :color (:text-tertiary tokens)
-                    :font-family sans-stack
-                    :font-size "12px"}}
+            :style diff-empty-style}
       "No structural changes in the selected epoch."]
      (let [origin-for (fn [section-path]
                         (when (or (seq flow-writes) (seq diff-triples))

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -57,6 +57,7 @@
             [day8.re-frame2-xray.panels.epoch.badge :as badge]
             [day8.re-frame2-xray.panels.epoch.icons :as icons]
             [day8.re-frame2-xray.panels.epoch.projection :as proj]
+            [day8.re-frame2-xray.panels.shared.coord-chip :as coord-chip]
             [day8.re-frame2-xray.views.edn-inspector :as ei]
             [day8.re-frame2-xray.views.edn-widget.widget :as edn]
             [day8.re-frame2-xray.theme.tokens
@@ -213,30 +214,11 @@
           "▲"])
        (proj/format-duration-ms duration-ms)])))
 
-(defn- coord-chip
-  "External-link affordance — opens the editor at `coord` via the
-  cross-panel `:rf.xray/open-in-editor` event. Returns nil when
-  `coord` has no `:file`."
-  [coord testid]
-  (when (and (map? coord) (seq (:file coord)))
-    [:button {:data-testid testid
-              :aria-label  "open in editor"
-              :title       "open in editor"
-              :on-click    (fn [e]
-                             (.stopPropagation e)
-                             (rf/dispatch [:rf.xray/open-in-editor
-                                           {:source-coord coord}]
-                                          {:frame :rf/xray}))
-              :style       {:background      "transparent"
-                            :color           "inherit"
-                            :border          "none"
-                            :padding         "0 4px"
-                            :margin-left     "4px"
-                            :cursor          "pointer"
-                            :display         "inline-flex"
-                            :align-items     "center"
-                            :line-height     1}}
-     (icons/external-link)]))
+;; coord-chip moved to `panels.shared.coord-chip/coord-chip` (rf2-xjgdk
+;; audit L2 — the icon-only chip was duplicated across panels; one
+;; canonical home + per-site overlays now). The Epoch panel renders
+;; with the default `:color "inherit"` + `:margin-left "4px"` knobs,
+;; which match this panel's prior shape exactly.
 
 (defn- step-header
   "Render a step's header row — badge pill + verb/label + optional
@@ -1641,8 +1623,8 @@
           [:span {:style {:color (:text-tertiary tokens)
                           :font-style "italic"}}
            "<anonymous view>"])
-        (coord-chip (view-coord view-id)
-                    (str "rf-xray-epoch-view-row-coord-" i))]
+        (coord-chip/coord-chip (view-coord view-id)
+                               (str "rf-xray-epoch-view-row-coord-" i))]
        (when (number? duration-ms)
          [:span {:style {:color (:text-tertiary tokens)
                          :margin-left "8px"

--- a/tools/xray/src/day8/re_frame2_xray/panels/event_detail.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/event_detail.cljs
@@ -93,6 +93,7 @@
             [day8.re-frame2-xray.panels.overflow-indicator :as overflow]
             [day8.re-frame2-xray.panels.managed-fx-helpers :as managed-fx-h]
             [day8.re-frame2-xray.panels.managed-fx-template :as managed-fx]
+            [day8.re-frame2-xray.panels.shared.coord-chip :as coord-chip]
             [day8.re-frame2-xray.spine :as spine]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens mono-stack sans-stack]]
@@ -387,48 +388,354 @@
                        :color       (:text-secondary tokens)}}
         (str duration-ms "ms")]])))
 
+;; ---- hoisted row-level styles (rf2-xjgdk · audit F4) -------------------
+;;
+;; The Event lens renders a handful of row types many times per epoch —
+;; APP-DB CHANGES can produce 20-50 `db-change-row`s per cascade, FLOWS
+;; and AFTER INTERCEPTORS easily 10+ each. Allocating fresh `:style`
+;; maps inside each render produces ~200-250 garbage maps per panel
+;; render. Hoisting the static shape to ns-top defs collapses each row
+;; render to a single map reference plus, where colour varies, a tiny
+;; `assoc`-overlay. Mirrors the rf2-5venq Trace + rf2-qx414 Cancellation
+;; pattern.
+;;
+;; Token reads (`(:bg-1 tokens)` etc.) resolve at ns-load — `tokens` is
+;; a static const map (spec/007-UX-IA §CSS custom-property surface);
+;; theme switching is handled by the CSS-vars seam, not by rebinding
+;; the Clojure value. The maps below are therefore safe to capture
+;; once, at compile time, and reuse on every render in both light and
+;; dark modes.
+
+;; --- §3 step DISPATCH ----------------------------------------------------
+
+(def ^:private dispatch-event-vector-box-style
+  {:background    (:bg-3 tokens)
+   :border        (str "1px solid " (:border-subtle tokens))
+   :border-radius "3px"
+   :padding       "5px 8px"
+   :overflow-x    "auto"
+   :min-width     "0"})
+
+(def ^:private dispatch-from-row-style
+  {:display      "flex"
+   :align-items  "baseline"
+   :gap          "6px"
+   :margin-top   "6px"
+   :font-family  mono-stack
+   :font-size    "12px"})
+
+(def ^:private dispatch-from-caption-style
+  {:color (:text-tertiary tokens)})
+
+(def ^:private dispatch-source-link-style
+  {:color           (:accent tokens)
+   :text-decoration "underline"
+   :text-decoration-style "dotted"
+   :text-underline-offset "2px"
+   :display         "inline-flex"
+   :align-items     "center"
+   :gap             "4px"})
+
+(def ^:private dispatch-source-plain-style
+  {:color (:text-secondary tokens)})
+
+;; --- §4 step COEFFECTS — coeffect-row ------------------------------------
+
+(def ^:private coeffect-row-style
+  {:padding "2px 0"})
+
+(def ^:private coeffect-id-line-style
+  {:display      "inline-flex"
+   :align-items  "center"
+   :color        (:accent tokens)})
+
+(def ^:private coeffect-add-row-style
+  {:display      "flex"
+   :align-items  "flex-start"
+   :padding      "1px 0 1px 24px"})
+
+(def ^:private coeffect-add-glyph-style
+  {:color        (:green tokens)
+   :font-weight  700
+   :margin-right "8px"
+   :min-width    "10px"})
+
+(def ^:private coeffect-add-path-style
+  {:color        (:text-tertiary tokens)
+   :margin-right "8px"
+   :min-width    "0"})
+
+(def ^:private coeffect-add-value-style
+  {:color      (:text-primary tokens)
+   :min-width  0
+   :flex       1
+   :word-break "break-word"})
+
+;; --- §5 AFTER INTERCEPTORS — interceptor-row + ctx-delta-row ------------
+
+(def ^:private interceptor-row-style
+  {:padding "2px 0"})
+
+(def ^:private interceptor-row-header-style
+  {:display     "flex"
+   :align-items "center"})
+
+(def ^:private interceptor-id-style
+  {:color        (:accent tokens)
+   :margin-right "12px"
+   :min-width    "180px"})
+
+(def ^:private interceptor-coord-style
+  {:color (:text-secondary tokens)})
+
+(def ^:private interceptor-coord-absent-style
+  {:color       (:text-tertiary tokens)
+   :font-style  "italic"
+   :font-size   "11px"})
+
+(def ^:private ctx-delta-block-style
+  {:padding "2px 0 4px 0"})
+
+(def ^:private ctx-delta-row-style
+  {:display     "flex"
+   :align-items "flex-start"
+   :padding     "1px 0 1px 24px"
+   :font-family mono-stack
+   :font-size   "11px"})
+
+(def ^:private ctx-delta-glyph-base-style
+  {:font-weight  700
+   :margin-right "8px"
+   :min-width    "10px"})
+
+(def ^:private ctx-delta-segment-style
+  {:color        (:text-tertiary tokens)
+   :margin-right "8px"
+   :min-width    "0"})
+
+(def ^:private ctx-delta-value-style
+  {:color      (:text-primary tokens)
+   :min-width  "0"
+   :flex       1
+   :word-break "break-word"})
+
+;; --- §6 APP-DB CHANGES — db-change-row + overlays -----------------------
+
+(def ^:private db-change-row-style
+  {:display     "flex"
+   :align-items "baseline"
+   :flex-wrap   "wrap"
+   :gap         "8px"
+   :padding     "2px 0"})
+
+(def ^:private db-change-glyph-base-style
+  {:flex        "0 0 12px"
+   :font-family mono-stack
+   :font-weight 700
+   :text-align  "center"
+   :user-select "none"})
+
+(def ^:private db-change-path-base-style
+  {:font-family mono-stack})
+
+(def ^:private db-change-modified-cell-style
+  {:display     "inline-flex"
+   :align-items "baseline"
+   :flex-wrap   "wrap"
+   :gap         "6px"
+   :min-width   0})
+
+(def ^:private db-change-modified-before-style
+  {:color           (:text-tertiary tokens)
+   :text-decoration "line-through"})
+
+(def ^:private db-change-modified-arrow-style
+  {:color (:text-tertiary tokens)})
+
+(def ^:private db-change-modified-after-style
+  {:color (:text-primary tokens)})
+
+(def ^:private db-change-added-value-style
+  {:color (:text-primary tokens) :min-width 0})
+
+;; --- §7 FLOWS — flow-row -------------------------------------------------
+
+(def ^:private flow-row-style-flat
+  "Outer `flow-row` container — top-level (un-chained) flow."
+  {:padding      "4px 0"
+   :padding-left "0"})
+
+(def ^:private flow-row-style-chained
+  "Outer `flow-row` container — chained flow (`↳ via …`) is indented."
+  {:padding      "4px 0"
+   :padding-left "20px"})
+
+(def ^:private flow-row-header-style
+  {:display     "flex"
+   :align-items "center"
+   :gap         "8px"
+   :flex-wrap   "wrap"})
+
+(def ^:private flow-row-glyph-base-style
+  {:font-weight 600
+   :font-size   "12px"})
+
+(def ^:private flow-row-id-style
+  {:display     "inline-flex"
+   :align-items "center"
+   :color       (:accent tokens)
+   :font-weight 600
+   :min-width   "160px"})
+
+(def ^:private flow-row-via-style
+  {:color       (:text-tertiary tokens)
+   :font-family sans-stack
+   :font-style  "italic"
+   :font-size   "11px"})
+
+(def ^:private flow-row-line-style
+  "Shared shape for the `wrote` + `read` lines under the header."
+  {:display     "flex"
+   :align-items "flex-start"
+   :padding     "2px 0 2px 24px"})
+
+(def ^:private flow-row-line-label-style
+  {:color        (:text-tertiary tokens)
+   :margin-right "10px"
+   :min-width    "48px"
+   :font-family  sans-stack
+   :font-size    "11px"})
+
+(def ^:private flow-row-write-path-style
+  {:color        (:accent tokens)
+   :margin-right "12px"})
+
+(def ^:private flow-row-write-value-style
+  {:color     (:text-primary tokens)
+   :min-width 0
+   :flex      1})
+
+(def ^:private flow-row-read-paths-container-style
+  {:color      (:text-secondary tokens)
+   :flex       1
+   :word-break "break-word"})
+
+(def ^:private flow-row-read-path-style
+  {:color        (:accent tokens)
+   :margin-right "8px"})
+
+(def ^:private flow-row-read-absent-style
+  {:color      (:text-tertiary tokens)
+   :font-style "italic"
+   :font-size  "11px"})
+
+;; --- §8 FX — fx-handler-row ---------------------------------------------
+
+(def ^:private fx-handler-row-style
+  {:padding "4px 0"})
+
+(def ^:private fx-handler-row-inner-style
+  {:display     "flex"
+   :align-items "center"
+   :gap         "10px"
+   :flex-wrap   "wrap"})
+
+(def ^:private fx-handler-id-style
+  {:color     (:accent tokens)
+   :min-width "160px"})
+
+(def ^:private fx-handler-status-base-style
+  {:font-weight 600 :font-size "11px"})
+
+(def ^:private fx-managed-record-style
+  {:margin "6px 0 4px 16px"})
+
+;; --- §3 EVENT HANDLER — handler-returned-effects-block ------------------
+
+(def ^:private handler-returned-effects-style
+  {:margin-top "8px"
+   :padding    "6px 0 0 16px"
+   :border-top (str "1px dashed " (:border-subtle tokens))})
+
+(def ^:private handler-returned-effects-caption-style
+  {:color         (:text-tertiary tokens)
+   :font-family   sans-stack
+   :font-size     "11px"
+   :margin-bottom "4px"})
+
+(def ^:private handler-returned-section-style
+  {:padding     "1px 0"
+   :font-family mono-stack
+   :font-size   "11px"})
+
+(def ^:private handler-returned-key-row-style
+  {:display     "flex"
+   :align-items "baseline"
+   :gap         "8px"})
+
+(def ^:private handler-returned-key-label-style
+  {:color     (:accent tokens)
+   :min-width "32px"})
+
+(def ^:private handler-returned-db-value-style
+  {:color     (:text-primary tokens)
+   :flex      1
+   :min-width 0})
+
+(def ^:private handler-returned-db-absent-style
+  {:color      (:text-tertiary tokens)
+   :font-style "italic"})
+
+(def ^:private handler-returned-fx-summary-style
+  {:color (:text-tertiary tokens)})
+
+(def ^:private handler-returned-fx-row-style
+  {:padding "1px 0 1px 40px"
+   :color   (:text-secondary tokens)})
+
+;; --- cascade-list-row (empty-state list) --------------------------------
+
+(def ^:private cascade-list-row-style
+  {:padding       "8px 12px"
+   :border-bottom (str "1px solid " (:border-subtle tokens))
+   :cursor        "pointer"
+   :font-family   mono-stack
+   :font-size     "13px"
+   :color         (:text-primary tokens)})
+
+(def ^:private cascade-list-dispatch-id-style
+  {:color        (:accent tokens)
+   :margin-right "8px"})
+
+(def ^:private cascade-list-frame-style
+  {:color        (:text-tertiary tokens)
+   :margin-right "8px"})
+
 ;; ---- step DISPATCH (spec/021 §2.2 step 1) ------------------------------
 
-(defn- coord-chip
-  "Reusable 'open in editor' click-to-source affordance. Renders the
-  Figma authority's `external-link` lucide SVG glyph (13px, currentColor
-  stroke, inline with the surrounding link text); nothing when `coord`
-  has no `:file`. Dispatches `:rf.xray/open-in-editor` with the
-  structured coord; the trace collector thereby records the click + the
-  editor handler resolves the URI through the rf2-cm93v allowlist.
+;; coord-chip moved to `panels.shared.coord-chip/coord-chip` (rf2-xjgdk
+;; audit L2 — the icon-only chip was duplicated across panels; one
+;; canonical home + per-site overlays now). The Event lens renders its
+;; chips with the `:accent`-coloured + `6px`-margin overlay below,
+;; matching this panel's prior shape exactly. Per rf2-xw7mj the lucide
+;; `external-link` glyph remains unified across every click-to-source
+;; site in the Event lens (DISPATCH FROM, COEFFECTS rows, EVENT
+;; HANDLER coord, AFTER INTERCEPTORS rows, FLOWS rows) so the
+;; affordance reads as one vocabulary.
 
-  Per rf2-xw7mj the glyph is unified across every click-to-source site
-  in the Event lens (DISPATCH FROM, COEFFECTS rows, EVENT HANDLER
-  coord, AFTER INTERCEPTORS rows, FLOWS rows) so the affordance reads
-  as one vocabulary. The previous unicode `↗` arrow is superseded
-  here; the SVG mirrors the lucide-icons family the Figma authority
-  ships across the rest of the devtool chrome.
+(def ^:private event-chip-opts
+  "Per-site overlay for the Event-lens coord-chip — `:accent` colour
+  (stands alone in a `:text-primary` row) + `6px` left margin (slightly
+  wider tap target than the Epoch idiom)."
+  {:color       (:accent tokens)
+   :margin-left "6px"})
 
-  Accessibility: rendered as a `<button>` (so it's tab-focusable +
-  activates on Enter / Space natively); the SVG itself carries
-  `aria-hidden=\"true\"` so screen readers read the button's
-  `aria-label` (\"open in editor\") rather than walking the path
-  geometry."
+(defn- event-coord-chip
+  "Event-lens chip — thin wrapper that fixes the per-site overlay so
+  call-sites read `(event-coord-chip coord testid)` like the prior
+  inline `defn-`."
   [coord testid]
-  (when (and (map? coord) (seq (:file coord)))
-    [:button {:data-testid testid
-              :aria-label  "open in editor"
-              :title       "open in editor"
-              :on-click    (fn [e]
-                             (.stopPropagation e)
-                             (rf/dispatch [:rf.xray/open-in-editor
-                                           {:source-coord coord}]
-                                          {:frame :rf/xray}))
-              :style       {:background      "transparent"
-                            :color           (:accent tokens)
-                            :border          "none"
-                            :padding         "0 4px"
-                            :margin-left     "6px"
-                            :cursor          "pointer"
-                            :display         "inline-flex"
-                            :align-items     "center"
-                            :line-height     1}}
-     (icons/external-link)]))
+  (coord-chip/coord-chip coord testid event-chip-opts))
 
 (defn- dispatch-body
   "Step DISPATCH body — the dispatched event vector + the `FROM:
@@ -494,7 +801,7 @@
                         :color (:accent tokens)
                         :font-family mono-stack}}
          label
-         (coord-chip coord "rf-xray-event-detail-dispatch-open-chip")]
+         (event-coord-chip coord "rf-xray-event-detail-dispatch-open-chip")]
         ;; No call-site coord — plain muted source text, no link.
         [:span {:data-testid "rf-xray-event-detail-dispatch-from"
                 :style {:color (:text-secondary tokens)
@@ -565,34 +872,22 @@
         coord      (when (and cofx-meta (string? (:file cofx-meta)))
                      {:file (:file cofx-meta) :line (:line cofx-meta)})]
     [:div {:data-testid (str "rf-xray-event-detail-coeffect-row-" suffix)
-           :style {:padding "2px 0"}}
+           :style coeffect-row-style}
      ;; Line 1 — id + click-to-source chip (link styling).
-     [:div {:style {:display      "inline-flex"
-                    :align-items  "center"
-                    :color        (:accent tokens)}}
+     [:div {:style coeffect-id-line-style}
       (pr-str id)
-      (coord-chip coord (str "rf-xray-event-detail-coeffect-open-chip-" suffix))]
+      (event-coord-chip coord (str "rf-xray-event-detail-coeffect-open-chip-" suffix))]
      ;; Line 2 — `+ [<id>]  <value>` add-row, mirroring the diff-glyph
      ;; idiom shared with APP-DB CHANGES / AFTER INTERCEPTORS / FLOWS.
      [:div {:data-testid (str "rf-xray-event-detail-coeffect-add-row-" suffix)
-            :style {:display      "flex"
-                    :align-items  "flex-start"
-                    :padding      "1px 0 1px 24px"}}
+            :style coeffect-add-row-style}
       [:span {:data-testid (str "rf-xray-event-detail-coeffect-add-glyph-" suffix)
-              :style {:color       (:green tokens)
-                      :font-weight 700
-                      :margin-right "8px"
-                      :min-width   "10px"}}
+              :style coeffect-add-glyph-style}
        "+"]
       [:span {:data-testid (str "rf-xray-event-detail-coeffect-add-path-" suffix)
-              :style {:color        (:text-tertiary tokens)
-                      :margin-right "8px"
-                      :min-width    "0"}}
+              :style coeffect-add-path-style}
        (str "[" (pr-str id) "]")]
-      [:span {:style {:color      (:text-primary tokens)
-                      :min-width  0
-                      :flex       1
-                      :word-break "break-word"}}
+      [:span {:style coeffect-add-value-style}
        (edn/inspect value (str "event-detail/coeffect/" suffix))]]]))
 
 (defn- coeffects-body
@@ -653,24 +948,12 @@
   (let [glyph    (ctx-delta-op->glyph op)
         colour   (get tokens (ctx-delta-op->colour-key op))]
     [:div {:data-testid (str "rf-xray-event-detail-icpt-delta-row-" testid-suffix)
-           :style {:display "flex"
-                   :align-items "flex-start"
-                   :padding "1px 0 1px 24px"
-                   :font-family mono-stack
-                   :font-size "11px"}}
-     [:span {:style {:color colour
-                     :font-weight 700
-                     :margin-right "8px"
-                     :min-width "10px"}}
+           :style ctx-delta-row-style}
+     [:span {:style (assoc ctx-delta-glyph-base-style :color colour)}
       glyph]
-     [:span {:style {:color (:text-tertiary tokens)
-                     :margin-right "8px"
-                     :min-width "0"}}
+     [:span {:style ctx-delta-segment-style}
       (str (name segment) "/" (pr-str k))]
-     [:span {:style {:color (:text-primary tokens)
-                     :min-width "0"
-                     :flex 1
-                     :word-break "break-word"}}
+     [:span {:style ctx-delta-value-style}
       display-value]]))
 
 (defn- format-changed-value
@@ -715,7 +998,7 @@
           rows      (mapcat per-seg segments)]
       (when (seq rows)
         (into [:div {:data-testid (str "rf-xray-event-detail-icpt-delta-" icpt-suffix)
-                     :style {:padding "2px 0 4px 0"}}]
+                     :style ctx-delta-block-style}]
               (map-indexed
                 (fn [i row] (with-meta row {:key (str i)}))
                 rows))))))
@@ -726,22 +1009,17 @@
         display (format-coord-display coord)
         suffix  (interceptor-testid-suffix id)]
     [:div {:data-testid (str "rf-xray-event-detail-interceptor-row-" suffix)
-           :style {:padding "2px 0"}}
-     [:div {:style {:display "flex"
-                    :align-items "center"}}
-      [:span {:style {:color (:accent tokens)
-                      :margin-right "12px"
-                      :min-width "180px"}}
+           :style interceptor-row-style}
+     [:div {:style interceptor-row-header-style}
+      [:span {:style interceptor-id-style}
        (pr-str id)]
       (if display
-        [:span {:style {:color (:text-secondary tokens)}}
+        [:span {:style interceptor-coord-style}
          display]
-        [:span {:style {:color (:text-tertiary tokens)
-                        :font-style "italic"
-                        :font-size "11px"}}
+        [:span {:style interceptor-coord-absent-style}
          "rf2 std-interceptor"])
-      (coord-chip coord
-                  (str "rf-xray-event-detail-interceptor-open-chip-" suffix))]
+      (event-coord-chip coord
+                        (str "rf-xray-event-detail-interceptor-open-chip-" suffix))]
      ;; Per rf2-9dk9y: render the per-:after ctx-delta block below the
      ;; row when the substrate captured one — using the EDN-diff
      ;; +/~/- idiom shared with APP-DB CHANGES. Absent (`nil` delta)
@@ -859,30 +1137,18 @@
         cascade-id (:dispatch-id cascade)]
     (when (or db-pres? (seq fx-vec))
       [:div {:data-testid "rf-xray-event-detail-handler-returned-effects"
-             :style {:margin-top "8px"
-                     :padding "6px 0 0 16px"
-                     :border-top (str "1px dashed " (:border-subtle tokens))}}
+             :style handler-returned-effects-style}
        [:div {:data-testid "rf-xray-event-detail-handler-returned-effects-caption"
-              :style {:color (:text-tertiary tokens)
-                      :font-family sans-stack
-                      :font-size "11px"
-                      :margin-bottom "4px"}}
+              :style handler-returned-effects-caption-style}
         "↳ returned effects (pre-commit)"]
        (when db-pres?
          [:div {:data-testid "rf-xray-event-detail-handler-returned-db"
-                :style {:padding "1px 0"
-                        :font-family mono-stack
-                        :font-size "11px"}}
-          [:div {:style {:display "flex"
-                         :align-items "baseline"
-                         :gap "8px"}}
-           [:span {:style {:color (:accent tokens)
-                           :min-width "32px"}} ":db"]
+                :style handler-returned-section-style}
+          [:div {:style handler-returned-key-row-style}
+           [:span {:style handler-returned-key-label-style} ":db"]
            (if (some? t1-trace)
              [:span {:data-testid "rf-xray-event-detail-handler-returned-db-value"
-                     :style {:color    (:text-primary tokens)
-                             :flex     1
-                             :min-width 0}}
+                     :style handler-returned-db-value-style}
               (edn/inspect t1-db
                            (str "event-detail/handler-returned-db/"
                                 (or cascade-id "x")))]
@@ -890,20 +1156,14 @@
              ;; or a trace recorded pre-rf2-ta0y7). The committed value
              ;; still reads naturally one step down under APP-DB CHANGES.
              [:span {:data-testid "rf-xray-event-detail-handler-returned-db-absent"
-                     :style {:color (:text-tertiary tokens)
-                             :font-style "italic"}}
+                     :style handler-returned-db-absent-style}
               "pending — see APP-DB CHANGES below for the committed diff"])]])
        (when (seq fx-vec)
          (into [:div {:data-testid "rf-xray-event-detail-handler-returned-fx"
-                      :style {:padding "1px 0"
-                              :font-family mono-stack
-                              :font-size "11px"}}
-                [:div {:style {:display "flex"
-                               :align-items "baseline"
-                               :gap "8px"}}
-                 [:span {:style {:color (:accent tokens)
-                                 :min-width "32px"}} ":fx"]
-                 [:span {:style {:color (:text-tertiary tokens)}}
+                      :style handler-returned-section-style}
+                [:div {:style handler-returned-key-row-style}
+                 [:span {:style handler-returned-key-label-style} ":fx"]
+                 [:span {:style handler-returned-fx-summary-style}
                   (str (count fx-vec) " entr"
                        (if (= 1 (count fx-vec)) "y" "ies")
                        " — see FX below for what ran")]]]
@@ -913,8 +1173,7 @@
                      (with-meta
                        [:div {:data-testid (str "rf-xray-event-detail-handler-returned-fx-row-"
                                                  (interceptor-testid-suffix fx-id))
-                              :style {:padding "1px 0 1px 40px"
-                                      :color (:text-secondary tokens)}}
+                              :style handler-returned-fx-row-style}
                         (pr-str pair)]
                        {:key (str i)})))
                  fx-vec)))])))
@@ -956,7 +1215,7 @@
          (if event-id
            (str "no registration found for " (pr-str event-id))
            "no handler registered")])
-      (coord-chip coord "rf-xray-event-detail-handler-open-chip")]
+      (event-coord-chip coord "rf-xray-event-detail-handler-open-chip")]
      (handler-source-line meta)
      (handler-returned-effects-block cascade)]))
 
@@ -1048,16 +1307,12 @@
         colour (fx-status-colour status)
         suffix (interceptor-testid-suffix fx-id)]
     [:div {:data-testid (str "rf-xray-event-detail-effects-ran-row-" suffix)
-           :style {:padding "4px 0"}}
-     [:div {:style {:display "flex"
-                    :align-items "center"
-                    :gap "10px"
-                    :flex-wrap "wrap"}}
-      [:span {:style {:color (:accent tokens)
-                      :min-width "160px"}}
+           :style fx-handler-row-style}
+     [:div {:style fx-handler-row-inner-style}
+      [:span {:style fx-handler-id-style}
        (pr-str fx-id)]
       (when duration-ms (tier-dot duration-ms))
-      [:span {:style {:color colour :font-weight 600 :font-size "11px"}}
+      [:span {:style (assoc fx-handler-status-base-style :color colour)}
        (case status
          :ok          "✓ handled"
          :overridden  "◑ overridden"
@@ -1069,7 +1324,7 @@
      (when managed-fx-record
        [:div {:data-testid (str "rf-xray-event-detail-effects-ran-managed-fx-"
                                  (or id "x"))
-              :style {:margin "6px 0 4px 16px"}}
+              :style fx-managed-record-style}
         (managed-fx/record-panel managed-fx-record)])]))
 
 (defn- fx-post-commit-caption
@@ -1278,83 +1533,49 @@
                      {:file (:file flow-meta) :line (:line flow-meta)})]
     [:div {:data-testid (str "rf-xray-event-detail-flow-row-" suffix)
            :data-via    (str via?)
-           :style {:padding     "4px 0"
-                   :padding-left (if via? "20px" "0")}}
+           :style (if via? flow-row-style-chained flow-row-style-flat)}
      ;; Header line: glyph + flow-id + via attribution
-     [:div {:style {:display     "flex"
-                    :align-items "center"
-                    :gap         "8px"
-                    :flex-wrap   "wrap"}}
+     [:div {:style flow-row-header-style}
       [:span {:data-testid (str "rf-xray-event-detail-flow-row-glyph-" suffix)
-              :style {:color       (if via?
+              :style (assoc flow-row-glyph-base-style
+                            :color (if via?
                                      (:text-secondary tokens)
-                                     (:text-tertiary tokens))
-                      :font-weight 600
-                      :font-size   "12px"}}
+                                     (:text-tertiary tokens)))}
        (if via? "↳" "▸")]
       [:span {:data-testid (str "rf-xray-event-detail-flow-row-id-" suffix)
-              :style {:display     "inline-flex"
-                      :align-items "center"
-                      :color       (:accent tokens)
-                      :font-weight 600
-                      :min-width   "160px"}}
+              :style flow-row-id-style}
        (pr-str flow-id)
-       (coord-chip coord (str "rf-xray-event-detail-flow-open-chip-" suffix))]
+       (event-coord-chip coord (str "rf-xray-event-detail-flow-open-chip-" suffix))]
       (when via?
         [:span {:data-testid (str "rf-xray-event-detail-flow-row-via-" suffix)
-                :style {:color       (:text-tertiary tokens)
-                        :font-family sans-stack
-                        :font-style  "italic"
-                        :font-size   "11px"}}
+                :style flow-row-via-style}
          (str "via "
               (string/join
                 ", "
                 (map pr-str via-flow-ids)))])]
      ;; wrote line
      [:div {:data-testid (str "rf-xray-event-detail-flow-row-wrote-" suffix)
-            :style {:display      "flex"
-                    :align-items  "flex-start"
-                    :padding      "2px 0 2px 24px"}}
-      [:span {:style {:color       (:text-tertiary tokens)
-                      :margin-right "10px"
-                      :min-width   "48px"
-                      :font-family sans-stack
-                      :font-size   "11px"}}
-       "wrote"]
+            :style flow-row-line-style}
+      [:span {:style flow-row-line-label-style} "wrote"]
       [:span {:data-testid (str "rf-xray-event-detail-flow-row-write-path-" suffix)
-              :style {:color       (:accent tokens)
-                      :margin-right "12px"}}
+              :style flow-row-write-path-style}
        (pr-str write-path)]
-      [:span {:style {:color    (:text-primary tokens)
-                      :min-width 0
-                      :flex     1}}
+      [:span {:style flow-row-write-value-style}
        (edn/inspect result
                           (str "event-detail/flow/"
                                (or trace-id "x")
                                "/result"))]]
      ;; read line — placeholder when registry lookup failed (flow cleared)
      [:div {:data-testid (str "rf-xray-event-detail-flow-row-read-" suffix)
-            :style {:display     "flex"
-                    :align-items "flex-start"
-                    :padding     "2px 0 2px 24px"}}
-      [:span {:style {:color       (:text-tertiary tokens)
-                      :margin-right "10px"
-                      :min-width   "48px"
-                      :font-family sans-stack
-                      :font-size   "11px"}}
-       "read"]
+            :style flow-row-line-style}
+      [:span {:style flow-row-line-label-style} "read"]
       (if (seq read-paths)
-        (into [:span {:style {:color (:text-secondary tokens)
-                              :flex 1
-                              :word-break "break-word"}}]
+        (into [:span {:style flow-row-read-paths-container-style}]
               (for [p read-paths]
-                [:span {:style {:color (:accent tokens)
-                                :margin-right "8px"}}
+                [:span {:style flow-row-read-path-style}
                  (pr-str p)]))
         [:span {:data-testid (str "rf-xray-event-detail-flow-row-read-absent-" suffix)
-                :style {:color       (:text-tertiary tokens)
-                        :font-style  "italic"
-                        :font-size   "11px"}}
+                :style flow-row-read-absent-style}
          "input paths unavailable (flow may have been cleared)"])]]))
 
 (defn- flows-reshape-summary
@@ -1587,39 +1808,24 @@
         path-label (f/format-edn (vec path))]
     [:div {:data-testid (str "rf-xray-event-detail-db-change-row-" suffix)
            :data-op     (name op)
-           :style {:display      "flex"
-                   :align-items  "baseline"
-                   :flex-wrap    "wrap"
-                   :gap          "8px"
-                   :padding      "2px 0"}}
+           :style db-change-row-style}
      [:span {:data-testid (str "rf-xray-event-detail-db-change-glyph-" suffix)
-             :style {:flex        "0 0 12px"
-                     :color       tone
-                     :font-family mono-stack
-                     :font-weight 700
-                     :text-align  "center"
-                     :user-select "none"}}
+             :style (assoc db-change-glyph-base-style :color tone)}
       glyph]
      [:span {:data-testid (str "rf-xray-event-detail-db-change-path-" suffix)
-             :style {:color       tone
-                     :font-family mono-stack}}
+             :style (assoc db-change-path-base-style :color tone)}
       path-label]
      (case op
        :modified
-       [:span {:style {:display     "inline-flex"
-                       :align-items "baseline"
-                       :flex-wrap   "wrap"
-                       :gap         "6px"
-                       :min-width   0}}
-        [:span {:style {:color           (:text-tertiary tokens)
-                        :text-decoration "line-through"}}
+       [:span {:style db-change-modified-cell-style}
+        [:span {:style db-change-modified-before-style}
          (edn/inspect-inline before)]
-        [:span {:style {:color (:text-tertiary tokens)}} "→"]
-        [:span {:style {:color (:text-primary tokens)}}
+        [:span {:style db-change-modified-arrow-style} "→"]
+        [:span {:style db-change-modified-after-style}
          (edn/inspect-inline after)]]
 
        :added
-       [:span {:style {:color (:text-primary tokens) :min-width 0}}
+       [:span {:style db-change-added-value-style}
         (edn/inspect-inline after)]
 
        ;; :removed — path alone (spec/021 line 229: `- [path]`).
@@ -1864,16 +2070,11 @@
         :on-click   #(rf/dispatch
                        [:rf.xray/select-dispatch-id dispatch-id frame]
                        {:frame :rf/xray})
-        :style      {:padding      "8px 12px"
-                     :border-bottom (str "1px solid " (:border-subtle tokens))
-                     :cursor       "pointer"
-                     :font-family  mono-stack
-                     :font-size    "13px"
-                     :color        (:text-primary tokens)}}
-   [:span {:style {:color (:accent tokens) :margin-right "8px"}}
+        :style      cascade-list-row-style}
+   [:span {:style cascade-list-dispatch-id-style}
     (str "#" dispatch-id)]
    (when frame
-     [:span {:style {:color (:text-tertiary tokens) :margin-right "8px"}}
+     [:span {:style cascade-list-frame-style}
       (str frame)])
    (format-edn (or event :ungrouped))])
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/shared/coord_chip.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/shared/coord_chip.cljs
@@ -1,0 +1,113 @@
+(ns day8.re-frame2-xray.panels.shared.coord-chip
+  "Shared `coord-chip` — the canonical 'open in editor' icon-only chip
+  used across panels (Epoch, Event-detail, future surfaces).
+
+  ## Why this exists (rf2-xjgdk, audit L2)
+
+  Before rf2-xjgdk two near-identical icon-only chip components lived
+  as private `defn-`s in `panels/epoch/view.cljs` and
+  `panels/event_detail.cljs`. The hiccup was 99% the same — a
+  `<button>` carrying the lucide `external-link` glyph, dispatching
+  `[:rf.xray/open-in-editor {:source-coord coord}]` on the `:rf/xray`
+  frame, hidden when the coord has no `:file`. Only two pixel knobs
+  varied:
+
+  - **`:color`** — Epoch used `\"inherit\"` (the chip rides whatever
+    text colour its parent set); Event-detail used `(:accent tokens)`.
+  - **`:margin-left`** — Epoch `4px`, Event-detail `6px`.
+
+  Folding the two into one shared component removes the duplication
+  and makes UX changes to the open-in-editor affordance a one-file
+  edit. Per the bead the Epoch panel's coord-chip (rf2-ehd8v +
+  rf2-80u5a) is the canonical version; this ns mirrors its shape and
+  exposes the two knobs as options.
+
+  ## Style hoist (rf2-xjgdk, audit F4)
+
+  The chip's button style is hoisted to a ns-top `def` so a single
+  immutable map is reused across every chip render rather than
+  allocating a fresh map per call. The two pixel knobs are resolved
+  at call-time via a tiny `assoc` overlay (still cheap — no nested
+  map traversal).
+
+  ## What this chip is NOT
+
+  `open_in_editor/open-chip` is a SEPARATE surface: it renders an
+  `<a href=\"…\">` anchor with the URI pre-resolved against
+  `editor-uri/editor-uri` (used by demo surfaces + the standalone
+  static page). The button chip here dispatches via the trace bus so
+  the click is observable as a first-class operation on the
+  `:rf/xray` frame, and the URI resolution happens inside the
+  `:rf.xray/open-in-editor` reg-event-fx → `:rf.editor/open` reg-fx
+  pipeline. Both surfaces co-exist by design (rf2-evgf5 / rf2-g5q8d
+  decision)."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-xray.panels.event.icons :as icons]
+            [day8.re-frame2-xray.theme.tokens :refer [tokens]]))
+
+;; ---- hoisted style maps -------------------------------------------------
+
+(def ^:private chip-style-base
+  "Base style for the open-in-editor chip's `<button>`. The `:color`
+  and `:margin-left` are overlaid per call (the only two pixel knobs
+  that vary between call-sites). Resolved at ns-load — `tokens` is a
+  static const map (spec/007-UX-IA §CSS custom-property surface)."
+  {:background  "transparent"
+   :border      "none"
+   :padding     "0 4px"
+   :cursor      "pointer"
+   :display     "inline-flex"
+   :align-items "center"
+   :line-height 1})
+
+;; ---- public chip --------------------------------------------------------
+
+(defn coord-chip
+  "Render the canonical 'open in editor' icon-only chip — a tab-focusable
+  `<button>` carrying the lucide `external-link` glyph. Returns `nil`
+  when `coord` lacks a `:file` (so call-sites can drop the chip
+  cleanly).
+
+  Clicking dispatches `[:rf.xray/open-in-editor {:source-coord coord}]`
+  on the `:rf/xray` frame; the trace bus records the click, the
+  `:rf.editor/open` fx resolves the URI through the rf2-cm93v
+  allowlist, and `Location.assign` fires.
+
+  Accessibility: the chip is a `<button>` (so Enter / Space activate
+  natively), `aria-label` reads 'open in editor', and the inline SVG
+  carries `aria-hidden=\"true\"` so screen readers walk the label,
+  not the path geometry.
+
+  Arguments:
+
+  - `coord` — the source-coord map `{:file :line :column :ns}`. Nil
+    or any value without a `:file` returns nil.
+  - `testid` — a stable `data-testid` for the chip; call-sites suffix
+    it with their row's stable suffix.
+  - `opts` (optional) — pixel-knob overrides:
+    - `:color`        — chip colour. Defaults to `\"inherit\"` (rides
+                        whatever text colour the parent set, the Epoch
+                        idiom). Pass `(:accent tokens)` for the
+                        Event-detail idiom where the chip stands
+                        alone in a `:text-primary` row.
+    - `:margin-left`  — chip left-margin. Defaults to `\"4px\"`. Pass
+                        `\"6px\"` to match Event-detail's slightly
+                        wider tap target."
+  ([coord testid]
+   (coord-chip coord testid nil))
+  ([coord testid {:keys [color margin-left]
+                  :or   {color       "inherit"
+                         margin-left "4px"}}]
+   (when (and (map? coord) (seq (:file coord)))
+     [:button {:data-testid testid
+               :aria-label  "open in editor"
+               :title       "open in editor"
+               :on-click    (fn [e]
+                              (.stopPropagation e)
+                              (rf/dispatch [:rf.xray/open-in-editor
+                                            {:source-coord coord}]
+                                           {:frame :rf/xray}))
+               :style       (assoc chip-style-base
+                                   :color       color
+                                   :margin-left margin-left)}
+      (icons/external-link)])))


### PR DESCRIPTION
## What

Audit-driven perf + dedup pass on the Event-lens + diff-render surfaces.

## Style hoist (audit F4 + F5)

Per-row renderers and diff-walk shapes route through ns-top hoisted style defs instead of allocating fresh `:style` maps on every render. Per-op colour variation is applied as a tiny `assoc`-overlay on a shared base map.

`:style { ... }` site counts before -> after:

| file                          | before | after | delta |
|------------------------------|-------:|------:|------:|
| `panels/event_detail.cljs`    |     98 |    41 |   -57 |
| `diff/render.cljs`            |     26 |     0 |   -26 |
| `diff/hiccup_render.cljs`     |     46 |     0 |   -46 |
| **TOTAL**                     | **170** | **41** | **-129** |

Acceptance target was `<=100`. Achieved 41.

## Allocation savings per render

Representative Event-panel render (30 changed paths + 5 flows + 10 after-interceptors):

| section                | per-row sites | rows | maps now allocated |
|------------------------|--------------:|-----:|-------------------:|
| APP-DB CHANGES          |             4 |   30 |       0 (was 120) |
| FLOWS                   |            ~10 |    5 |       0 (was 50) |
| AFTER INTERCEPTORS      |             ~5 |   10 |       0 (was 50) |
| Diff sections (5 x 30)  |             3 |  150 |       0 (was 450) |

~670 fewer per-render allocations on a typical event-detail + app-db-diff render.

Token reads resolve at ns-load — `tokens` is a static const map and theme switching rides the CSS vars seam (per spec/007-UX-IA), not Clojure value rebinding — so the hoist is safe across light + dark modes.

## Shared coord-chip extraction (audit L2)

New file: `tools/xray/src/day8/re_frame2_xray/panels/shared/coord_chip.cljs`.

Previously the icon-only "open in editor" chip lived as ~99%-identical private `defn-`s in `panels/epoch/view.cljs` and `panels/event_detail.cljs`. Only two pixel knobs varied:

- `:color`      : `"inherit"` (Epoch) vs `(:accent tokens)` (Event-detail)
- `:margin-left`: `"4px"`     (Epoch) vs `"6px"`            (Event-detail)

The shared chip takes optional `:color` + `:margin-left` overrides; Event-detail routes through a small `event-coord-chip` wrapper that fixes the per-site overlay. Epoch uses the default and reads identical to its prior shape.

The chip's button style is itself hoisted to ns-top — both panels now share a single map reference. A future UX iteration on the open-in-editor affordance becomes a one-file change.

The separate `open_in_editor/open-chip` anchor surface (used by demo + static page) is intentionally untouched — it dispatches via `editor-uri` pre-resolved `<a href>` rather than the trace-bus button click path, and the two surfaces co-exist by design (rf2-evgf5 / rf2-g5q8d decision).

## Test surface

`data-testid`s preserved on every chip and row, so existing test selectors continue to target the same DOM nodes.

## Quality gates

- `npm run test:cljs`              — 4773 tests, 0 failures
- `npm run test:browser`           — 124 tests / 353 assertions, 0 failures
- `npm run test:bundle-isolation`  — PASS
- `npm run test:xray-feature-gate` — 13 scenarios, 0 failures

## Files

- `tools/xray/src/day8/re_frame2_xray/panels/shared/coord_chip.cljs` (new)
- `tools/xray/src/day8/re_frame2_xray/panels/event_detail.cljs`
- `tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs`
- `tools/xray/src/day8/re_frame2_xray/diff/render.cljs`
- `tools/xray/src/day8/re_frame2_xray/diff/hiccup_render.cljs`

Closes rf2-xjgdk.