### PR TITLE
fix(xray): realise lazy-seq render-bodies to keep Reagent's reactive tracking (rf2-atqkg)

### DIFF
--- a/spec/006-ReactiveSubstrate.md
+++ b/spec/006-ReactiveSubstrate.md
@@ -1071,6 +1071,31 @@ The tracking is "when source X changes, recompute everyone who depends on X" —
 
 In CLJS dev-mode tests, you often want sub computation without tracking: `(compute-sub [:total] db-value)` runs the sub's body against a static `app-db` value and returns the computed result. Pure function. No Reagent, no reactions. This is the "JVM-runnable" path that [008-Testing](008-Testing.md) and [011-SSR](011-SSR.md) use.
 
+### Lazy-seq deref tracking (Reagent adapter; rf2-atqkg)
+
+The Reagent adapter (and any React-shaped adapter whose render-time deref tracking uses a thread-local / dynamic-var reactive scope) only watches `@(rf/subscribe …)` derefs that fire **while the parent reg-view's render-fn is on the stack**. A `(for [x xs] [child …])` form returns a *lazy seq*; if the seq is still unrealised at the moment the render-fn returns, every deref hiding in its body fires later — when React eventually walks the hiccup — at which point the reactive scope is gone and Reagent doesn't register the dependency. Symptom: the app-db slot flips, the sub recomputes, the view does NOT re-render until an external repaint forces a fresh render-pass. Reagent surfaces the case with a console warning at render time:
+
+```
+Reactive deref not supported in lazy seq, it should be wrapped in doall: (…)
+```
+
+The fix is to **realise the seq inside the render-fn** so derefs reachable through it fire while the reactive scope is still live. Three idiomatic shapes, pick whichever reads cleanest at the call site:
+
+```clojure
+;; (1) doall — minimum change, keeps the (for …) shape
+(doall (for [row @some-sub] [row-view row]))
+
+;; (2) mapv — eager vector; reads well when no :when / :let / :while
+(mapv row-view @some-sub)
+
+;; (3) into … with-transducer or fragment — eager, composes with siblings
+(into [:<>] (map row-view) @some-sub)
+```
+
+Pure helpers called from inside the seq's body inherit the same rule: any `@(rf/subscribe …)` reachable transitively from a *function call* (not a `[component args]` Reagent component-vector — those get their own reactive scope when React mounts them) MUST be reachable through a realised seq. Reagent components ride their own reactive scopes; raw render helpers ride the parent's. The audit shape is "follow every plain-fn call inside a `(for …)` body; if any of them — directly or via further helpers — derefs a sub, the `for` MUST be realised".
+
+This is a Reagent-substrate concern, not a core-framework one. Non-React substrates that wire reactivity through hooks (UIx, Helix) use `use-subscribe` per-call-site, which captures the dependency at hook-call time regardless of when the surrounding seq realises — they are immune to the lazy-seq trap by construction. Core's `compute-sub` is pure and orthogonal: no tracking, no scope.
+
 ## SSR-specific behaviour
 
 Per [011](011-SSR.md), the server-side render path doesn't use the adapter's reactivity machinery at all. The flow:

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -2347,15 +2347,29 @@
                     :width       "1px"
                     :background  (:border-default tokens)
                     :pointer-events "none"}}]
-     ;; Steps
-     (for [[i step] (map-indexed vector steps)]
-       ^{:key (str "step-" (:step step) "-" i)}
-       [:div {:data-testid (str "rf-xray-epoch-pipeline-step-" (:step-number step))
-              :data-step (when (:step step) (name (:step step)))
-              :style {:position     "relative"
-                      :margin-bottom "23px"
-                      :min-height   "21px"}}
-        (render-step step ctx)])]]))
+     ;; Steps — `doall` forces the lazy `for` to realise INSIDE the
+     ;; reg-view's render scope (rf2-atqkg). `render-step` returns
+     ;; hiccup whose descendants (e.g. `handler-db-diff-block`,
+     ;; `render-subscriptions-step`) deref subs directly via
+     ;; `@(rf/subscribe …)`. Reagent only tracks derefs that fire
+     ;; while the parent reg-view's reactive context is live; a
+     ;; lazy seq realised AFTER the render pass leaves those derefs
+     ;; outside the scope, so sub-value changes don't trigger a
+     ;; re-render (symptom: the operator clicks `[diff][all]`, the
+     ;; sub flips in app-db, the cascade reads the new value, but
+     ;; the panel hiccup stays stale). `doall` plus the `(for …)`
+     ;; preserves the original code shape; the realised seq lets
+     ;; Reagent see every nested deref at render time. See spec/006
+     ;; §Lazy-seq deref tracking.
+     (doall
+       (for [[i step] (map-indexed vector steps)]
+         ^{:key (str "step-" (:step step) "-" i)}
+         [:div {:data-testid (str "rf-xray-epoch-pipeline-step-" (:step-number step))
+                :data-step (when (:step step) (name (:step step)))
+                :style {:position     "relative"
+                        :margin-bottom "23px"
+                        :min-height   "21px"}}
+          (render-step step ctx)]))]]))
 
 ;; ---- empty states --------------------------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -954,3 +954,82 @@
       (is (some? ev))
       (is (pos? (count (mini-mounts ev)))
           "the dispatched-event slot mounts a mini-render"))))
+
+;; ---- rf2-atqkg — pipeline-view realises step-seq inside reactive scope ---
+;;
+;; Regression test for the reactive-tracking failure the bead pins: the
+;; pipeline's `(for [[i step] …] …)` MUST be realised inside
+;; `pipeline-view`'s return value so that any `@(rf/subscribe …)` deref
+;; reached transitively by `render-step` (e.g. `handler-db-diff-block`'s
+;; `:rf.xray.epoch/db-view-mode` read at view.cljs L1416, or
+;; `render-subscriptions-step`'s `:rf.xray.epoch/subs-show-unchanged?`
+;; read at view.cljs L1802) fires while the parent reg-view's reactive
+;; scope is still live. A lazy seq realised AFTER the reg-view returns
+;; leaves the derefs OUTSIDE that scope — Reagent doesn't watch them,
+;; sub-value changes don't trigger re-render, and the operator sees a
+;; click "do nothing" until an external repaint forces the panel back
+;; through render.
+;;
+;; The structural invariant we pin here: the steps-seq inside the inner
+;; `[:div :data-testid "rf-xray-epoch-pipeline"]` is either a vector
+;; (eager) OR a *realised* lazy seq. Lazy-but-unrealised at the moment
+;; `pipeline-view` returns is the bug shape.
+
+(defn- pipeline-steps-seq
+  "Locate the step-seq returned by `pipeline-view`. The view returns:
+
+      [:div {:data-testid \"rf-xray-epoch-pipeline-container\"}
+       (cascade-summary …)
+       [:div {:data-testid \"rf-xray-epoch-pipeline\" …}
+        [:div {:data-testid \"rf-xray-epoch-rail\" …}]
+        <steps-seq>]]
+
+  We walk the top-level tree directly (NOT via `find-by-testid`, which
+  realises lazy seqs as a side-effect of walking) and return the
+  step-seq child verbatim so the caller can probe its `realized?`
+  state."
+  [tree]
+  (let [inner (some (fn [node]
+                      (when (and (vector? node)
+                                 (= "rf-xray-epoch-pipeline"
+                                    (some-> node th/attrs :data-testid)))
+                        node))
+                    ;; Walk top-level children of the container only;
+                    ;; we want the inner pipeline div without forcing
+                    ;; realisation of the step-seq itself.
+                    (rest tree))]
+    (when inner
+      ;; The inner div's children are [div-attrs rail-div steps-seq];
+      ;; steps-seq is the last child.
+      (last inner))))
+
+(deftest pipeline-view-realises-step-seq-rf2-atqkg-test
+  (testing "rf2-atqkg — `pipeline-view` returns its step-seq REALISED
+            so descendant sub derefs (e.g. handler-db-diff-block's
+            `:rf.xray.epoch/db-view-mode` read) fire during the parent
+            reg-view's reactive scope. An unrealised lazy seq at this
+            position is the rf2-atqkg bug shape (Reagent emits the
+            `Reactive deref not supported in lazy seq, it should be
+            wrapped in doall` console warning at render time)."
+    (let [steps [{:step :dispatch :badge :DISPATCH :step-number 1
+                  :event [:counter/inc] :source :ui :coord nil}
+                 {:step :handler :badge :HANDLER :step-number 2
+                  :flavour :reg-event-db :event-id :counter/inc
+                  :db-diff [[[:counter :value] 5 6 :modified]]
+                  :fx [] :machine nil}]
+          tree  (view/pipeline-view steps)
+          step-seq (pipeline-steps-seq tree)]
+      (is (some? step-seq)
+          "the inner pipeline div carries a step-seq child")
+      ;; Either a vector (eager build) or a realised lazy seq is fine.
+      ;; An unrealised lazy seq is the bug.
+      (is (or (vector? step-seq)
+              (not (instance? cljs.core/LazySeq step-seq))
+              (realized? step-seq))
+          (str "pipeline-view's step-seq MUST be realised at return-time. "
+               "Got: "
+               (cond
+                 (vector? step-seq) "vector (eager)"
+                 (instance? cljs.core/LazySeq step-seq)
+                 (str "LazySeq, realized?=" (realized? step-seq))
+                 :else (str "type=" (type step-seq))))))))


### PR DESCRIPTION
## Why — Reagent reactive-tracking failure, not a framework frame-routing bug

Supersedes **rf2-tvu99**'s React-click-frame-leak hypothesis. PR #2200
(rf2-tvu99 lift) proved the framework's dispatch routing is correct:
`:frame` is captured at enqueue and carried verbatim through the
queue. The symptom Mike pair-debugged on 2026-05-26 — click the
HANDLER `:db` `[diff][all]` toggle, observe the sub flips to `:all`
in app-db, but the panel keeps rendering `data-db-view-mode="diff"`
— was a **Reagent reactive-tracking failure**, not a routing failure.

The four "frame-leak" patches that landed earlier this session
(rf2-7sdja popup-affordance, rf2-kcaiz zoom-affordance,
rf2-p56sk "Show unchanged", + the HANDLER `:db` toggle) all
happened to incidentally realise a lazy seq (via `doall` / `mapv`
/ a wrapping `with-frame` that forced a fresh render pass) and so
worked by accident. The real bug surface is **one site** in the
Epoch panel.

## Root cause

`pipeline-view` (epoch/view.cljs L2351) returned its step list as
an unrealised `(for [[i step] (map-indexed vector steps)] …)` lazy
seq:

```clojure
;; BEFORE (broken)
[:div {:data-testid "rf-xray-epoch-pipeline" …}
 [:div {:data-testid "rf-xray-epoch-rail" …}]
 (for [[i step] (map-indexed vector steps)]
   ^{:key (str "step-" (:step step) "-" i)}
   [:div {…} (render-step step ctx)])]
```

`render-step` calls render-handler-step → handler-body →
`handler-db-diff-block`, which derefs `@(rf/subscribe
[:rf.xray.epoch/db-view-mode])` (L1416) and, in the `:all` branch,
`@(rf/subscribe [:rf.xray/selected-epoch-record])` (L1437).
`render-subscriptions-step` similarly derefs `:rf.xray.epoch/
subs-show-unchanged?` (L1802).

Reagent only tracks `@(rf/subscribe …)` derefs that fire while the
parent reg-view's render-fn is on the stack. The lazy `(for …)`
isn't walked until React mounts the hiccup — AFTER the render-fn
returns, AFTER the reactive scope ends. Reagent emits the canonical
warning at render time:

```
Reactive deref not supported in lazy seq, it should be wrapped in
doall: (…)
```

(Mike observed the warning on entry to the Epoch tab during the
pair-debug; the pattern reference is rf2-tvu99's PR #2200 body.)

## Fix

Wrap the for in `doall`:

```clojure
;; AFTER
(doall
  (for [[i step] (map-indexed vector steps)]
    ^{:key (str "step-" (:step step) "-" i)}
    [:div {…} (render-step step ctx)]))
```

`doall` forces realisation inside `pipeline-view`'s render scope.
Every transitive sub deref reachable through `render-step` now fires
while Reagent's tracking is live; the subs register correctly on
the parent reg-view's reactive scope; sub-value changes trigger a
re-render as expected.

## Per-site audit log

The bead requires auditing every panel `(for …)` over sub-derefed
data. I walked every `(for [...] …)` in `tools/xray/src/.../panels/`
+ `views/` + `shell.cljs` + `frame_switcher.cljs` + `palette/` +
`settings/` + `filters/`. Single-site root cause confirmed:

| Site | File:line | Body | Status |
|---|---|---|---|
| `pipeline-view` outer for | `panels/epoch/view.cljs:2351` | `(render-step step ctx)` reaches sub derefs at L1416 / L1437 / L1802 | **FIXED — wrapped in `doall`** |
| `cascade-fx-row` for | `panels/epoch/view.cljs:954` | pure hiccup — `[:span …]` | safe |
| `machine-cascade-view` for | `panels/epoch/view.cljs:1136` | `(cascade-row-view …)` — pure | already `into [:div …]` (eager) |
| `db-view-mode-toggle` for | `panels/epoch/view.cljs:1353` | 2-element fixed seq, plain `[:button …]` | safe (no inner sub derefs; deref happens in the caller's scope) |
| `handler-db-diff-block` `:diff` for | `panels/epoch/view.cljs:1433` | `(db-diff-line row i)` — pure | safe (no transitive sub derefs); also now inside the outer doall |
| `handler-body` `:fx` for | `panels/epoch/view.cljs:1487` | `(fx-entry-line entry i)` — pure | safe |
| `render-fx-step` `map-indexed` | `panels/epoch/view.cljs:1673` | `fx-row-view` — pure | safe |
| `subscriptions-table` rows for | `panels/epoch/view.cljs:1725` | inline hiccup | safe |
| `views-table` rows for | `panels/epoch/view.cljs:1864` | inline hiccup | safe |
| `views-table` subs-read for | `panels/epoch/view.cljs:1911` | inline `[:div [ei/mini s 60]]` | already `into [:div …]` (eager) |
| `routing.cljs/route-table-section` | `panels/routing.cljs:372` | calls `route-table-row` | already `into [:<>] …` (eager) |
| `reactive_panel_view.cljs` `*-section` | `panels/reactive_panel_view.cljs:413/435/593` | inline hiccup or `list-row` components | already `into [:div …]` (eager) |
| `app_db_diff_state.cljs` `instances-area` / `state-body` | `panels/app_db_diff_state.cljs:271/322` | calls renderers | already `into [:div …]` (eager) |
| `trace.cljs/db-diff-section` for | `panels/trace.cljs:266` | calls `db-diff-row` — pure | already `into [:div …]` (eager) |
| `trace.cljs` band-rows / envelope-rows for | `panels/trace.cljs:512/563` | `(op-row row …)` — `op-row` is pure, no sub derefs | safe — also the parent Panel reg-view derefs ALL needed subs at L632-640 before calling these |
| `shell.cljs` tab-button for | `shell.cljs:2022` | `[tab-button (assoc tab …)]` — `tab-button` is a Reagent component vector, gets its own reactive scope | safe |
| `shell.cljs` event-cascades for | `shell.cljs:1884` | `[event-row …]` — Reagent component vector | already `into [:ul …]` (eager) |
| `frame_switcher.cljs` frames for | `frame_switcher.cljs:405` | inline hiccup | safe |
| `event_detail.cljs` various for | various | all top-level subs derefed at the reg-view body (L1880/L1881/L2110); inner fors emit pure hiccup | safe |

(Static panels, edn-inspector internals, filters edit-popup, settings, palette, etc. were also walked — none of the lazy `(for …)` forms reach a sub deref through a plain function call.)

## Regression test

`tools/xray/test/.../panels/epoch/view_cljs_test.cljs` —
`pipeline-view-realises-step-seq-rf2-atqkg-test`:

```clojure
(deftest pipeline-view-realises-step-seq-rf2-atqkg-test
  ;; assert that pipeline-view's step-seq is either a vector or a
  ;; realised LazySeq at return-time. Unrealised LazySeq is the bug.
  (let [steps    [<dispatch step> <handler step with :db-diff>]
        tree     (view/pipeline-view steps)
        step-seq (pipeline-steps-seq tree)]
    (is (or (vector? step-seq)
            (not (instance? cljs.core/LazySeq step-seq))
            (realized? step-seq))
        "pipeline-view's step-seq MUST be realised at return-time")))
```

`pipeline-steps-seq` walks the top-level tree directly (NOT via
`find-by-testid`, which expands function-components and forces
realisation as a side-effect of walking) so the assertion sees the
seq's state at the moment `pipeline-view` returned.

## Spec note

`spec/006-ReactiveSubstrate.md` gets a new subsection
"Lazy-seq deref tracking (Reagent adapter; rf2-atqkg)" under
§Subscription topology vs subscription tracking. Documents:

- the Reagent reactive-scope rule (`@(rf/subscribe …)` derefs are
  watched only while the parent reg-view's render-fn is on the stack)
- the canonical Reagent warning ("Reactive deref not supported in
  lazy seq, it should be wrapped in doall")
- three idiomatic fix shapes (`doall` / `mapv` / `into [:<>] …`)
- the plain-fn vs Reagent-component rule (component vectors ride
  their own reactive scope; raw helpers ride the parent's)
- the non-React-substrate immunity: UIx + Helix's `use-subscribe`
  hook captures dependencies at hook-call time, independent of seq
  realisation; the lazy-seq trap is Reagent-substrate-specific

## Quality gates

- `npm run test:cljs` — 4799 tests / 15586 assertions, **0 failures, 0 errors**
- `npm run test:browser` — 124 tests / 353 assertions, **0 failures, 0 errors**
- `npm run test:bundle-isolation` — PASS bundle-isolation + uix-helix-reagent-free

## Retired-misdiagnosis note

rf2-tvu99 was the *symptom is real, hypothesis is wrong* class. PR
#2200 (rf2-tvu99 lift) landed `frame-bound-fn` + spec/002 docs which
remain correct + load-bearing for legitimate frame-context concerns
— they just weren't the right tool for THIS symptom. The four
already-merged "frame-leak" patches (rf2-7sdja / rf2-kcaiz /
rf2-p56sk + the prior HANDLER `:db` toggle hack) all stay landed —
they each pin a slightly-different concrete behaviour at their own
site, and none of them break. They simply weren't doing what their
PR bodies claimed.

Closes rf2-atqkg.