### PR TITLE
perf(xray): Trace panel focused-cascade scan to layer-3 sub (rf2-wcfsy)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/trace.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/trace.cljs
@@ -630,12 +630,13 @@
   []
   (let [{:keys [envelope outcome bands empty-kind] :as _data}
         @(rf/subscribe [:rf.xray/trace-feed])
-        cascades        @(rf/subscribe [:rf.xray/cascades])
+        ;; rf2-wcfsy — focused-cascade is a layer-3 composite over
+        ;; `:rf.xray/cascades` + `:rf.xray/focus`, NOT an inline scan in
+        ;; the render body. The composite memoises on its two input
+        ;; signals so the scan only re-runs when cascades / focus
+        ;; actually change (rather than every Panel render).
         focus           @(rf/subscribe [:rf.xray/focus])
-        focused-id      (:dispatch-id focus)
-        focused-cascade (when focused-id
-                          (some #(when (= focused-id (:dispatch-id %)) %)
-                                cascades))
+        focused-cascade @(rf/subscribe [:rf.xray.trace/focused-cascade])
         expanded-ids    @(rf/subscribe [:rf.xray/trace-expanded-row-ids])
         collapsed-bands @(rf/subscribe [:rf.xray/trace-collapsed-band-ids])]
     [:section {:data-testid "rf-xray-trace"
@@ -728,6 +729,35 @@
             record         (focus/find-epoch-record focus-epoch-id
                                                     epoch-history)]
         (h/project-feed-from-epoch record focus-status))))
+
+  ;; ---- focused cascade (rf2-wcfsy) -----------------------------------
+  ;;
+  ;; Layer-3 composite over `:rf.xray/cascades` + `:rf.xray/focus`. The
+  ;; Trace panel reads this directly instead of scanning the cascades
+  ;; vector in its render body (the previous shape: a linear
+  ;; `(some #(when (= focused-id (:dispatch-id %)) %) cascades)` that
+  ;; ran on every Panel render — O(N) over the cascades vector, defeats
+  ;; memoisation because the result was reconstructed per render).
+  ;;
+  ;; As a layer-3 composite the scan only re-runs when its input
+  ;; signals (cascades or focus) actually change. The result is the
+  ;; same record `(some #(= focused-id (:dispatch-id %)) cascades)`
+  ;; would return — so the downstream `cascade-status-bar` call site
+  ;; continues to work verbatim.
+  ;;
+  ;; Why both input subs are still subscribed in the Panel: the Panel
+  ;; passes `focus` itself (not just the focused-cascade) into
+  ;; `cascade-status-bar`, so it still needs the focus signal. The
+  ;; cascades sub feeds many other panels (L2 list, Issues ribbon, …);
+  ;; reg-sub de-dupes the underlying signal so subscribing here costs
+  ;; nothing extra.
+  (rf/reg-sub :rf.xray.trace/focused-cascade
+    :<- [:rf.xray/cascades]
+    :<- [:rf.xray/focus]
+    (fn [[cascades focus] _query]
+      (let [focused-id (:dispatch-id focus)]
+        (when focused-id
+          (some #(when (= focused-id (:dispatch-id %)) %) cascades)))))
 
   ;; ---- per-row inline payload expansion (spec/023 §3) ----------------
   ;;

--- a/tools/xray/test/day8/re_frame2_xray/panels/trace_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/trace_view_cljs_test.cljs
@@ -49,6 +49,7 @@
             [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]
+            [day8.re-frame2-xray.trace-collector :as trace-collector]
             [day8.re-frame2-xray.panels.trace :as trace]))
 
 ;; ---- fixtures -----------------------------------------------------------
@@ -143,6 +144,8 @@
     (registry/register-xray-handlers!)
     (is (some? (registrar/handler :sub :rf.xray/trace-feed))
         ":rf.xray/trace-feed sub registered")
+    (is (some? (registrar/handler :sub :rf.xray.trace/focused-cascade))
+        ":rf.xray.trace/focused-cascade layer-3 sub registered (rf2-wcfsy)")
     (is (some? (registrar/handler :sub :rf.xray/trace-expanded-row-ids))
         ":rf.xray/trace-expanded-row-ids sub registered")
     (is (some? (registrar/handler :sub :rf.xray/trace-collapsed-band-ids))
@@ -521,6 +524,87 @@
       (let [feed @(rf/subscribe [:rf.xray/trace-feed])]
         (is (= #{3 4 5} (set (map :id (:rows feed)))))
         (is (= 2 (:epoch-id feed)))))))
+
+;; ---- (4b) focused-cascade layer-3 sub (rf2-wcfsy) ----------------------
+;;
+;; The Trace panel reads the focused cascade record via the layer-3
+;; composite `:rf.xray.trace/focused-cascade` rather than scanning the
+;; full cascades vector inline in its render body. The sub composes
+;; over `:rf.xray/cascades` + `:rf.xray/focus`; its result is the
+;; cascade whose `:dispatch-id` matches the focus' `:dispatch-id`, or
+;; nil when no focus is pinned.
+
+(defn- mk-cascade-trace
+  "Seed a synthetic `:rf.event/dispatched` trace event into Xray's
+  trace buffer so `group-cascades` yields one cascade record per
+  dispatch-id. Mirrors the seeding pattern in registry_cljs_test.cljs
+  so the data-layer pipe matches production."
+  [dispatch-id event-vec]
+  (trace-collector/seed-trace-for-test!
+    {:operation :rf.event/dispatched
+     :op-type   :rf.event
+     :id        dispatch-id
+     :time      (* dispatch-id 1000)
+     :tags      {:rf.trace/dispatch-id dispatch-id
+                 :rf.event/v           event-vec
+                 :rf.trace/event-id    (first event-vec)
+                 :frame                :rf/default}}))
+
+(deftest focused-cascade-sub-nil-when-cascades-empty
+  (testing "rf2-wcfsy — with no cascades + no focus the composite
+            returns nil (the inline scan's
+            `(when focused-id ...)` guard preserved). The spine
+            composer auto-snaps focus to head only when cascades
+            exist, so the truly-empty case is the structural nil
+            path."
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (is (= 0 (count @(rf/subscribe [:rf.xray/cascades])))
+          "no cascades in the input signal")
+      (is (nil? (:dispatch-id @(rf/subscribe [:rf.xray/focus])))
+          "no focus pinned + no head → focused-id is nil")
+      (is (nil? @(rf/subscribe [:rf.xray.trace/focused-cascade]))
+          "focused-id nil → composite returns nil"))))
+
+(deftest focused-cascade-sub-returns-matching-cascade
+  (testing "rf2-wcfsy — when focus is pinned the composite returns the
+            cascade whose :dispatch-id matches focus :dispatch-id;
+            same record-shape the previous inline scan returned"
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (mk-cascade-trace 1 [:cart/add])
+      (mk-cascade-trace 2 [:cart/remove])
+      (mk-cascade-trace 3 [:checkout/start])
+      (focus! 2)
+      (let [result @(rf/subscribe [:rf.xray.trace/focused-cascade])]
+        (is (some? result) "the focused cascade record is returned")
+        (is (= 2 (:dispatch-id result))
+            "the returned cascade's :dispatch-id matches the focus")
+        (is (= [:cart/remove] (:event result))
+            "the returned record carries the cascade's :event vector")))))
+
+(deftest focused-cascade-sub-nil-when-focus-misses
+  (testing "rf2-wcfsy — focus pinned to a :dispatch-id that's not in
+            the cascades vector → nil (the previous inline scan's
+            `some` returned nil in this case; same shape)"
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (mk-cascade-trace 1 [:cart/add])
+      (focus! 999)
+      (is (nil? @(rf/subscribe [:rf.xray.trace/focused-cascade]))
+          "focused-id with no matching cascade → nil"))))
+
+(deftest focused-cascade-sub-rescopes-on-refocus
+  (testing "rf2-wcfsy — refocusing changes the returned cascade
+            record (reactivity wired through the composite signals)"
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (mk-cascade-trace 1 [:cart/add])
+      (mk-cascade-trace 2 [:cart/remove])
+      (focus! 1)
+      (is (= 1 (:dispatch-id @(rf/subscribe [:rf.xray.trace/focused-cascade]))))
+      (focus! 2)
+      (is (= 2 (:dispatch-id @(rf/subscribe [:rf.xray.trace/focused-cascade])))))))
 
 ;; ---- (5) row interactions -----------------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -368,6 +368,14 @@
    ;; removed with rf2-td380 + rf2-gkczt. The feed now projects the arc
    ;; shape (envelope + 4 phase bands) per spec/023 (rf2-l2f2g).
    :rf.xray/trace-feed
+   ;; rf2-wcfsy — layer-3 composite over `:rf.xray/cascades` +
+   ;; `:rf.xray/focus`; returns the focused cascade record (or nil
+   ;; when no focus is pinned). Replaces an inline `some` scan that
+   ;; ran on every Trace-panel render — the composite memoises on
+   ;; its input signals so the scan only re-runs when cascades /
+   ;; focus actually change. Read by the Trace panel's
+   ;; `cascade-status-bar`.
+   :rf.xray.trace/focused-cascade
    ;; Reactive panel (rf2-wyvf2 · spec/021 §3 · renamed from Views per
    ;; §11.5; tab key stays `:views`, display label rebases). Reads the
    ;; focused cascade's `:trace-events` for the substrate ops landed in


### PR DESCRIPTION
Replaces the linear `some`-scan over `:rf.xray/cascades` in the Trace panel''s render body with a layer-3 composite sub `:rf.xray.trace/focused-cascade`. Source: rf2-qa75r audit finding F7.

## Shape comparison

### Before — linear scan in render body

```clojure
(let [cascades        @(rf/subscribe [:rf.xray/cascades])
      focus           @(rf/subscribe [:rf.xray/focus])
      focused-id      (:dispatch-id focus)
      focused-cascade (when focused-id
                        (some #(when (= focused-id (:dispatch-id %)) %)
                              cascades))]
  ...)
```

- O(N) walk over the cascades vector on every `Panel` render.
- Memoisation defeats: the `when` allocates a fresh result per render.
- Re-runs whenever the Panel re-renders — every dispatch in the host.

### After — layer-3 composite sub

```clojure
(rf/reg-sub :rf.xray.trace/focused-cascade
  :<- [:rf.xray/cascades]
  :<- [:rf.xray/focus]
  (fn [[cascades focus] _query]
    (let [focused-id (:dispatch-id focus)]
      (when focused-id
        (some #(when (= focused-id (:dispatch-id %)) %) cascades)))))
```

Panel body deref:

```clojure
focused-cascade @(rf/subscribe [:rf.xray.trace/focused-cascade])
```

## Reactivity rationale

The composite memoises on its two input signals (`cascades` + `focus`). The scan only re-runs when at least one of those signals changes identity — not on every Panel render. Same cascade record returned to the downstream `cascade-status-bar` call site, so the visual output is unchanged.

The Panel still subscribes to `:rf.xray/focus` because it passes the focus map itself (not just the focused cascade) into `cascade-status-bar`. The `:rf.xray/cascades` subscription is dropped from the Panel render body — the composite holds the only reference now. re-frame de-dupes the underlying signal so this costs nothing extra elsewhere.

## File inventory

- `tools/xray/src/day8/re_frame2_xray/panels/trace.cljs` — render body simplified; new `reg-sub :rf.xray.trace/focused-cascade` in `install!`.
- `tools/xray/test/day8/re_frame2_xray/panels/trace_view_cljs_test.cljs` — registry-wiring assertion + 4 new behavioural tests (nil when empty, returns matching cascade, nil when focus misses, rescopes on refocus).
- `tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs` — adds `:rf.xray.trace/focused-cascade` to the `all-sub-names` snapshot set (rf2-39n8h).

## Quality gates

- `npm run test:cljs` — 4803 tests / 15598 assertions / 0 failures.
- `npm run test:browser --grep trace` — 124 tests / 0 failures.
- `npm run test:bundle-isolation` — PASS.

Closes rf2-wcfsy.