### PR TITLE
feat(xray): resize handle on events-list ↔ L4-panel seam (rf2-t2dsh)

### DIFF
--- a/tools/xray/spec/007-UX-IA.md
+++ b/tools/xray/spec/007-UX-IA.md
@@ -64,7 +64,7 @@ the left because normal layout owns the relationship.
 ┌─────────────────────────────────────────────────────────────────────────┐
 │ LAYER 1  Two ribbons — chrome (~32px) + events ribbon (~36px) (rf2-4vp5j)│  scope + spine controls
 ├─────────────────────────────────────────────────────────────────────────┤
-│ LAYER 2  Event list (4-col table; 6 rows default; resize bottom edge)   │  the spine / timeline
+│ LAYER 2  Event list (4-col table; 6 rows default; resize via L2/L3 seam)│  the spine / timeline
 ├─────────────────────────────────────────────────────────────────────────┤
 │ LAYER 3  Tab bar (40px) — 7 tabs                                        │  projection selector
 ├─────────────────────────────────────────────────────────────────────────┤
@@ -86,8 +86,9 @@ the five-region layout + `ChromeRibbon` / `EventsRibbon` / `EventList`):
 │ timer  │ :poll/tick      │ 12:30:07.001   │  0.2 ms                      │
 │ view   │ :user/profile   │ 12:30:07.892   │  0.6 ms                      │
 │ machine│ :title/loaded   │ 12:30:08.234   │  0.3 ms                      │
-│ view   │ :form/submit    │ 12:30:09.456   │  1.8 ms     ↕ resize edge     │
-├─────────────────────────────────────────────────────────────────────────┤   drag bottom edge
+│ view   │ :form/submit    │ 12:30:09.456   │  1.8 ms                      │
+╞═════════════════════════════════════════════════════════════════════════╡   L2/L3 seam — drag ↕ to resize
+├─────────────────────────────────────────────────────────────────────────┤
 │ [Event]  app-db   Views   Trace   Machine   Routes   Issues              │              L3 — 7 tabs
 ├─────────────────────────────────────────────────────────────────────────┤
 │ — Event tab content for the focused event —                             │   L4 — fills the rest
@@ -111,10 +112,11 @@ The four layers, top to bottom:
    the chrome ribbon's mode dropdown toggles Dynamic ↔ Static (a separate axis). Anatomy in
    §The L1 ribbon below.
 2. **L2 — Event list.** A **four-column table** (`source · event id · timestamp · duration`);
-   **6 rows visible by default**, the **bottom edge a drag handle for vertical resize**;
-   latest-on-bottom; virtualised; sticky header. The active/focused row takes a subtle
-   background; functional semantic markers (redaction / issue / pin) ride as subtle per-row
-   signals (§Event-list rows). The spine sub `:rf.xray/focus` reads from this layer.
+   **6 rows visible by default**, with **the L2/L3 seam acting as the drag handle for
+   vertical resize** (§Splitter affordance); latest-on-bottom; virtualised; sticky header.
+   The active/focused row takes a subtle background; functional semantic markers
+   (redaction / issue / pin) ride as subtle per-row signals (§Event-list rows). The spine
+   sub `:rf.xray/focus` reads from this layer.
 3. **L3 — Tab bar (40px).** Seven tabs in the order the Figma export fixes:
    **Event · app-db · Views · Trace · Machine · Routes · Issues**. Letter mnemonics:
    `e` `a` `v` `t` `m` `r` `i`. Each tab renders its **label only** (no `◉`/`○` glyph — Figma
@@ -249,6 +251,80 @@ Unrecognised keys bubble normally so the surrounding chrome's
 `Ctrl+Shift+C` / `?` / `Esc` shortcuts remain reachable from the
 handle's focus position.
 
+### Splitter affordance — the L2/L3 seam (rf2-t2dsh)
+
+The horizontal boundary between the **L2 event list** and the **L3 tab
+bar** is a draggable resize affordance. The seam SHALL:
+
+- Show `cursor: row-resize` on hover anywhere along the seam
+- Drag-to-update the event-list height with global pointer-capture
+  (mouse, touch, and pen unified through pointer events;
+  `touch-action: none` so a touch-drag does not pan the page)
+- Clamp height to `[48px, viewport×0.7]` — 48px == 2 rows + chrome,
+  the documented L2 minimum; 70% leaves a 30% sliver for L1 chrome +
+  L3 tab bar + L4 detail panel
+- Persist via `configure! :rf.xray/settings :general :events-list-height-px`
+  (round-trips through localStorage with the rest of the Settings
+  map; see [`015-Configuration.md`](./015-Configuration.md))
+- Reset to default height (200px) on double-click
+
+The click-area is a **full-width 8px horizontal strip** so the
+operator can grab the seam from any X coordinate; the visible
+affordance is a 1px accent hairline at 33% alpha along the seam
+centre, intensifying to ~55% alpha on hover (light + dark themes
+both route through `--rf-xray-accent` — the treatment lands
+consistently in both).
+
+#### Disposition of the prior corner-grip
+
+The previous affordance was the browser-native `:resize "vertical"`
+declaration on the L2 list — a tiny 16px corner-grip at the bottom-
+right of the list. That affordance was **retired** in rf2-t2dsh:
+
+- no persistence (height reset to 200px on every reload)
+- no keyboard surface (mouse/touch only)
+- tiny corner hit-target (~16×16px) — invisible to a user who hasn't
+  hovered the exact corner
+- inconsistent with the panel-width handle's interaction model (drag
+  + reset + keyboard arrows)
+
+The L2 list's inline style no longer carries `:resize`; the seam
+handle is the sole vertical-resize surface. Per pre-alpha posture
+(no back-compat shims) the swap is a hard cut.
+
+#### Keyboard contract
+
+The seam is keyboard-reachable (`tabindex="0"`, `role="separator"`,
+`aria-orientation="horizontal"`, live `aria-valuenow` for the current
+height). Bindings:
+
+| Key | Action |
+|---|---|
+| `ArrowDown` | Grow list by 8px (matches drag-down semantics) |
+| `ArrowUp` | Shrink list by 8px |
+| `Shift+ArrowDown` | Grow by 32px (coarse step) |
+| `Shift+ArrowUp` | Shrink by 32px |
+| `Home` | Snap to upper clamp (registry applies the 70vh bound) |
+| `End` | Snap to lower clamp (registry applies the 48px floor) |
+| `Enter` / `Space` | Reset to default (matches double-click) |
+
+Unrecognised keys bubble normally — the surrounding chrome's
+`Ctrl+Shift+C` / `?` / `Esc` shortcuts remain reachable from the
+handle's focus position.
+
+#### Rendering
+
+The seam-handle is one DOM node mounted between `event-list` and
+`tab-bar` (DOM-order asserted by `events-list-seam-cljs-test`). The
+testid is `rf-xray-event-list-seam`. Styles are Xray-owned — no
+consumer CSS surface; the seam appears automatically as part of the
+4-layer chrome.
+
+The seam rides on the Dynamic surface composer (`surface-composer`
+→ `dynamic-chrome`); Static mode renders a different surface
+(`static-shell/surface`) that doesn't carry an L2 event list, so
+the seam is absent there without an explicit check.
+
 ## The L1 ribbon — two ribbons (rf2-4vp5j)
 
 Layer 1 is **two stacked ribbons**, splitting scope SELECTORS from
@@ -340,9 +416,10 @@ needs (redaction / issue / pin) survive as a subtle per-row tint or trailing mar
 as the primary row structure. Full click behaviour + hover tooltip in
 [`018-Event-Spine.md`](./018-Event-Spine.md) §4.
 
-**6 rows visible by default; the bottom edge is a drag handle for vertical resize** (drag down
-to show more history). The header row is sticky; on hover/selection the row takes a subtle
-background (`hover` / `bg-active`) — the active/focused row is the spine's `:rf.xray/focus`.
+**6 rows visible by default; the L2/L3 seam is a drag handle for vertical resize** (drag
+down to show more history — see §Splitter affordance for the full mechanics). The header
+row is sticky; on hover/selection the row takes a subtle background (`hover` / `bg-active`)
+— the active/focused row is the spine's `:rf.xray/focus`.
 
 ### Columns (left → right)
 
@@ -354,13 +431,14 @@ background (`hover` / `bg-active`) — the active/focused row is the spine's `:r
 | **duration** | how long the event took to process, e.g. `0.4 ms` | mono, muted |
 
 ```
-┌ Event list  (6 rows default · drag bottom edge ↕ to resize) ───────────┐
+┌ Event list  (6 rows default · drag L2/L3 seam ↕ to resize) ─────────────┐
 │ source │ event id          │ timestamp      │ duration                  │
 │ fx     │ :title/flow       │ 12:30:05.123   │  1.2 ms                   │
 │ view   │ :counter-inc      │ 12:30:06.456   │  0.4 ms   ← focused row    │
 │ timer  │ :poll/tick        │ 12:30:07.001   │  0.2 ms                   │
 │ machine│ :title/loaded     │ 12:30:08.234   │  0.3 ms                   │
-│  …                                            ↕ resize edge             │
+│  …                                                                       │
+╞═════════════════════════════════════════════════════════════════════════╡   ↕ L2/L3 seam (drag to resize)
 └──────────────────────────────────────────────────────────────────────────┘
 ```
 

--- a/tools/xray/src/day8/re_frame2_xray/config.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/config.cljc
@@ -102,6 +102,71 @@
   rather than a side-effect of dragging the handle off the left edge."
   0.9)
 
+;; ---- L2 event-list vertical resize (rf2-t2dsh) ---------------------------
+;;
+;; The seam between the L2 event list and the L3 tab bar is a draggable
+;; row-resize affordance. The height value persists through the same
+;; Settings round-trip as the panel-width; floor + ceiling clamp so the
+;; list cannot collapse below two rows + chrome (the documented L2 min)
+;; and cannot expand so far that the L4 detail panel disappears.
+;;
+;; The earlier browser-native `:resize \"vertical\"` corner-grip was
+;; retired in rf2-t2dsh: it carried no persistence, no keyboard
+;; affordance, and a tiny corner hit-target. The seam matches the
+;; left-edge panel-width handle's interaction model so all resize
+;; surfaces share one mental model (drag the seam, double-click to
+;; reset, keyboard arrows for fine step).
+
+(def default-events-list-height-px
+  "Default L2 event-list height in pixels (rf2-t2dsh). 200px == 8 rows
+  × 22px + 7 × 2px gap + 8px outer padding, matching the rf2-htik0
+  Bug 2 tightened rhythm. The drag handle on the L2/L3 seam writes the
+  live value back through `:rf.xray/set-events-list-height-px`, which
+  clamps + persists + writes the inline `height` style on the next
+  paint."
+  200)
+
+(def min-events-list-height-px
+  "Lower clamp for the L2/L3 seam drag handle (rf2-t2dsh). 48px ==
+  2 rows + chrome, matching the previously documented `min-height`
+  ceiling that kept the list operable when dragged tight."
+  48)
+
+(def max-events-list-height-fraction
+  "Upper clamp for the L2/L3 seam drag handle expressed as a fraction
+  of the viewport height (rf2-t2dsh). 0.7 leaves a 30% sliver for the
+  L1 chrome + L3 tab bar + L4 detail panel — full-viewport L2 isn't a
+  documented mode; clamping prevents the user dragging the seam below
+  the bottom of the viewport, which would orphan the L3/L4 surfaces."
+  0.7)
+
+(def events-list-height-keyboard-step-px
+  "Keyboard fine step for an arrow-key press on the L2/L3 seam handle.
+  Mirrors the panel resize handle's 8px convention so all resize
+  surfaces share one fine-step rhythm."
+  8)
+
+(def events-list-height-keyboard-coarse-multiplier
+  "Multiplier for Shift+arrow on the L2/L3 seam handle. 8 × 4 = 32px
+  per press for coarse traversal — mirrors the panel resize handle."
+  4)
+
+(defn clamp-events-list-height-px
+  "Pure helper: clamp `px` to the seam handle's [min, viewport×0.7]
+  range (rf2-t2dsh). Pass `viewport-height-px` explicitly so the helper
+  stays CLJC-pure and JVM-testable (no implicit `window.innerHeight`
+  reach). Non-numeric input falls back to `default-events-list-height-px`
+  so a malformed persisted payload never leaves the list at an
+  unusable size."
+  [px viewport-height-px]
+  (if-not (number? px)
+    default-events-list-height-px
+    (let [max-px (long (* (or viewport-height-px 1000)
+                          max-events-list-height-fraction))
+          floor  min-events-list-height-px
+          ceil   (max floor max-px)]
+      (long (-> px (max floor) (min ceil))))))
+
 (def default-accent-css-var
   "Name of the CSS custom property carrying Xray's accent colour (the
   GitHub blue `#539bf5` from `theme/tokens.cljc` / `spec/007-UX-IA.md`
@@ -767,6 +832,7 @@
   {:general   {:text-size              13              ; px — slider range 10–18
                :panel-position         :right-rail     ; :right-rail | :popout | :fullscreen
                :panel-width-px         default-panel-width-px ; rf2-x8h9y resize handle
+               :events-list-height-px  default-events-list-height-px ; rf2-t2dsh L2/L3 seam handle
                :auto-open-on-error?    false
                :density                :cosy           ; #{:cosy :compact}
                :show-tool-frames?      false

--- a/tools/xray/src/day8/re_frame2_xray/registry.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/registry.cljs
@@ -248,6 +248,54 @@
         {:fx [[:dispatch [:rf.xray/set-panel-width-px
                           config/default-panel-width-px]]]}))
 
+    ;; ---- L2 event-list height (rf2-t2dsh seam resize handle) -----
+    ;;
+    ;; The L2/L3 seam carries a row-resize drag handle that drives the
+    ;; events-list height. Mirrors the panel-width-px shape above:
+    ;;
+    ;;   - `:rf.xray/events-list-height-px` reads from the settings
+    ;;     map; the L2 list's inline `:height` style binds to it so
+    ;;     drag updates re-paint immediately.
+    ;;   - `:rf.xray/set-events-list-height-px` clamps to
+    ;;     [min, viewport×0.7] before persisting, mirroring the
+    ;;     panel-width clamp at write-time.
+    ;;   - `:rf.trace/no-emit?` matches the panel-width handler — drag
+    ;;     emits one dispatch per pixel of motion; trace-buffering them
+    ;;     would flood the bus with shape no panel consumes.
+    ;;
+    ;; Per rf2-t2dsh the prior browser-native `:resize \"vertical\"`
+    ;; corner-grip on the L2 list was RETIRED — it carried no
+    ;; persistence, no keyboard affordance, and a tiny corner hit-
+    ;; target. The seam matches the panel-width handle's interaction
+    ;; model so all resize surfaces share one mental model.
+    (rf/reg-sub :rf.xray/events-list-height-px
+      (fn [db _query]
+        (or (get-in db [:settings :general :events-list-height-px])
+            (config/get-setting :general :events-list-height-px)
+            config/default-events-list-height-px)))
+
+    (rf/reg-event-db :rf.xray/set-events-list-height-px
+      {:rf.trace/no-emit? true}
+      (fn [db [_ px]]
+        (let [viewport (or (when (exists? js/window)
+                             (.-innerHeight js/window))
+                           1000)
+              clamped  (config/clamp-events-list-height-px px viewport)]
+          ;; Dual-write: same pattern the panel-width handler uses
+          ;; (config atom drives localStorage round-trip; app-db slot
+          ;; drives reactive re-render).
+          (config/update-setting! :general :events-list-height-px clamped)
+          (assoc-in db [:settings :general :events-list-height-px] clamped))))
+
+    ;; Reset to default — bound to the seam handle's double-click +
+    ;; Enter/Space keyboard binding. Routes through the same write
+    ;; surface so persistence stays consistent.
+    (rf/reg-event-fx :rf.xray/reset-events-list-height
+      {:rf.trace/no-emit? true}
+      (fn [_ _event]
+        {:fx [[:dispatch [:rf.xray/set-events-list-height-px
+                          config/default-events-list-height-px]]]}))
+
     ;; ---- L2 event-list resizable column widths (rf2-6ni62) -------
     ;;
     ;; The L2 event-list carries four columns — `event-id` (flex),

--- a/tools/xray/src/day8/re_frame2_xray/resize_handle.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/resize_handle.cljs
@@ -1,8 +1,22 @@
 (ns day8.re-frame2-xray.resize-handle
-  "Left-edge horizontal resize handle for the Xray shell (rf2-x8h9y +
-  rf2-70u8q auto-inject contract).
+  "Resize affordances for the Xray shell: the LEFT-edge panel-width
+  `Handle` (rf2-x8h9y + rf2-70u8q auto-inject contract) and the
+  L2/L3 seam `SeamHandle` (rf2-t2dsh) that drives the event-list
+  height.
 
-  ## What this is
+  ## Two handles, one mental model
+
+  Both handles mirror the same drag mechanics (document-level
+  pointer capture, unified mouse / touch / pen via pointer events,
+  body-cursor override during drag), the same UX (drag + double-
+  click reset + keyboard arrows + Home/End clamps), and the same
+  persistence (dispatch through a `:rf.xray/set-*` event that
+  clamps at write-time + round-trips through the Settings map +
+  localStorage). The only axis difference is the cursor (`col-resize`
+  vs `row-resize`) and which CSS variable / inline style consumes
+  the persisted value.
+
+  ## What `Handle` is
 
   A 6px-wide vertical strip pinned to the LEFT edge of the shell in
   `:right-rail` (`:inline`) mode. The user drags it (mouse, touch, or
@@ -11,6 +25,19 @@
   survives reload via localStorage. Double-click resets to
   `config/default-panel-width-px` (560px). Keyboard-navigable via
   arrow keys (8px step; 32px with Shift) and Home / End (clamp ends).
+
+  ## What `SeamHandle` is
+
+  A full-width 8px-tall horizontal strip mounted between the L2 event
+  list and the L3 tab bar in `dynamic-chrome`. Drag DOWN grows the
+  list; drag UP shrinks it. Live height persists through the Settings
+  map under `:general :events-list-height-px`. Double-click resets to
+  `config/default-events-list-height-px` (200px). Keyboard surface
+  mirrors the panel-width handle except for axis (`ArrowDown` /
+  `ArrowUp` instead of left/right). The handle REPLACES the previous
+  browser-native `:resize \"vertical\"` corner-grip on the L2 list,
+  which had no persistence, no keyboard surface, and a tiny corner
+  hit-target.
 
   ## Auto-inject contract (rf2-70u8q)
 
@@ -413,3 +440,257 @@
                                    [:rf.xray/reset-panel-width]
                                    {:frame :rf/xray}))
              :style            (handle-style)}])))
+
+;; ==========================================================================
+;; L2/L3 seam handle (rf2-t2dsh)
+;; ==========================================================================
+;;
+;; The horizontal seam between the L2 event list and the L3 tab bar is a
+;; row-resize affordance: hover anywhere along the seam and the cursor
+;; flips to `row-resize`; click-and-drag changes the event-list height.
+;; Mirrors the LEFT-edge panel-width handle's interaction model (drag,
+;; double-click to reset, keyboard arrows for fine step) so all resize
+;; surfaces in Xray read as one mental model.
+;;
+;; Per rf2-t2dsh this REPLACES the previous browser-native
+;; `:resize \"vertical\"` corner-grip on the L2 list — that affordance
+;; had no persistence, no keyboard surface, and a tiny corner hit-target.
+;; The seam runs the full width of the panel so the click-area is the
+;; whole horizontal seam, not a single 16px corner.
+;;
+;; Mechanics mirror `start-drag!` above (document-level pointer capture,
+;; pointer-events unification of mouse/touch/pen, body cursor override
+;; while dragging). The dispatch surface is
+;; `:rf.xray/set-events-list-height-px` which clamps at write-time per
+;; `config/clamp-events-list-height-px`.
+
+(defonce ^:private seam-drag-state
+  ;; Holds the active seam-drag snapshot. Same shape as `drag-state`
+  ;; above but with `:start-y` + `:start-height` for the vertical axis.
+  ;; defonce so a shadow-cljs :after-load mid-drag doesn't strand a
+  ;; half-installed listener.
+  (atom nil))
+
+(defn seam-dragging?
+  "Test seam — true iff an L2/L3 seam drag is in progress. Pure read
+  of the seam-drag-state atom. Used by the test suite to assert the
+  start/stop lifecycle."
+  []
+  (some? @seam-drag-state))
+
+(defn- seam-detach-document-listeners! []
+  (when-let [{:keys [on-move on-up on-cancel prev-cursor]} @seam-drag-state]
+    (when (and (exists? js/document) (.-removeEventListener js/document))
+      (try (.removeEventListener js/document "pointermove" on-move)
+           (catch :default _ nil))
+      (try (.removeEventListener js/document "pointerup" on-up)
+           (catch :default _ nil))
+      (try (.removeEventListener js/document "pointercancel" on-cancel)
+           (catch :default _ nil)))
+    (when (and (exists? js/document) (.-body js/document))
+      (set! (-> js/document .-body .-style .-cursor)
+            (or prev-cursor "")))
+    (reset! seam-drag-state nil)))
+
+(defn- seam-on-document-move [^js e]
+  (when-let [{:keys [start-y start-height]} @seam-drag-state]
+    ;; The seam sits BELOW the event-list and ABOVE the tab-bar. Drag
+    ;; DOWN (now-y > start-y) grows the list; drag UP shrinks it.
+    ;; dy = (now-y - start-y).
+    (let [dy         (- (.-pageY e) start-y)
+          new-height (+ start-height dy)]
+      (rf/dispatch [:rf.xray/set-events-list-height-px new-height]
+                   {:frame :rf/xray}))))
+
+(defn- seam-on-document-up [^js _e]
+  (seam-detach-document-listeners!))
+
+(defn- seam-on-document-cancel [^js _e]
+  (seam-detach-document-listeners!))
+
+(defn start-seam-drag!
+  "Begin an L2/L3 seam drag. Records the start-y + start-height
+  snapshot, then attaches the document-level move / up / cancel
+  listeners that drive the live update. Mirrors `start-drag!` above
+  for the vertical axis.
+
+  Exposed for the seam view's `:on-pointer-down` handler AND for the
+  test suite, which drives the lifecycle without a real DOM."
+  [^js e current-height]
+  (seam-detach-document-listeners!)
+  (let [start-y     (.-pageY e)
+        pointer-id  (.-pointerId e)
+        prev-cursor (when (and (exists? js/document)
+                               (.-body js/document))
+                      (-> js/document .-body .-style .-cursor))
+        on-move     seam-on-document-move
+        on-up       seam-on-document-up
+        on-cancel   seam-on-document-cancel]
+    (reset! seam-drag-state {:start-y      start-y
+                             :start-height (or current-height
+                                               config/default-events-list-height-px)
+                             :pointer-id   pointer-id
+                             :on-move      on-move
+                             :on-up        on-up
+                             :on-cancel    on-cancel
+                             :prev-cursor  prev-cursor})
+    (when (and (exists? js/document) (.-body js/document))
+      (set! (-> js/document .-body .-style .-cursor) "row-resize"))
+    (when (and (exists? js/document) (.-addEventListener js/document))
+      (try (.addEventListener js/document "pointermove" on-move)
+           (catch :default _ nil))
+      (try (.addEventListener js/document "pointerup" on-up)
+           (catch :default _ nil))
+      (try (.addEventListener js/document "pointercancel" on-cancel)
+           (catch :default _ nil)))
+    (try (.preventDefault e) (catch :default _ nil))))
+
+(defn seam-simulate-move!
+  "Test-only: drive the document-level pointermove handler for the
+  seam drag with a page-Y coordinate. No-op when no drag is in progress."
+  [page-y]
+  (when @seam-drag-state
+    (seam-on-document-move #js {:pageY page-y})))
+
+(defn seam-simulate-up!
+  "Test-only: drive the document-level pointerup handler for the seam
+  drag. No-op when no drag is in progress."
+  []
+  (when @seam-drag-state
+    (seam-on-document-up nil)))
+
+(defn seam-simulate-cancel!
+  "Test-only: drive the document-level pointercancel handler for the
+  seam drag. Covers the system-preempt path."
+  []
+  (when @seam-drag-state
+    (seam-on-document-cancel nil)))
+
+(defn handle-seam-keydown!
+  "Keyboard-navigable seam resize. Per spec/007-UX-IA.md §Splitter
+  affordance the seam handle MUST be operable without a pointer
+  device. Bindings:
+
+    ArrowDown          +8px  (grow list — drag-down semantics)
+    ArrowUp            -8px  (shrink)
+    Shift+ArrowDown    +32px (coarse grow)
+    Shift+ArrowUp      -32px (coarse shrink)
+    Home               +very-large step (clamp to upper bound)
+    End                -very-large step (clamp to lower bound)
+    Enter / Space      reset to default (matches double-click)
+
+  Mirrors the panel resize handle's keyboard contract — clamp lives in
+  the registry handler so we dispatch the desired height and let
+  `:rf.xray/set-events-list-height-px` apply the [min, viewport×0.7]
+  bounds.
+
+  Returns true iff the keypress was handled (so the caller can
+  `preventDefault` to suppress the default behavior — page scroll on
+  arrow keys, button activation on space). Other keypresses return
+  false and bubble normally."
+  [^js e current-height]
+  (let [key      (.-key e)
+        shift?   (.-shiftKey e)
+        step     (if shift?
+                   (* config/events-list-height-keyboard-step-px
+                      config/events-list-height-keyboard-coarse-multiplier)
+                   config/events-list-height-keyboard-step-px)
+        dispatch (fn [px]
+                   (rf/dispatch [:rf.xray/set-events-list-height-px px]
+                                {:frame :rf/xray}))]
+    (case key
+      "ArrowDown"   (do (dispatch (+ current-height step)) true)
+      "ArrowUp"     (do (dispatch (- current-height step)) true)
+      "Home"        (do (dispatch 10000) true)
+      "End"         (do (dispatch 0) true)
+      ("Enter" " ") (do (rf/dispatch [:rf.xray/reset-events-list-height]
+                                     {:frame :rf/xray})
+                        true)
+      false)))
+
+(def ^:private seam-base-height-px
+  "Click-area height for the L2/L3 seam handle (rf2-t2dsh). 8px is the
+  conventional comfortable hit-target for a horizontal splitter while
+  remaining a thin visual line. The always-visible hairline accent is
+  1px at 33% alpha; the click-area covers ±3px on either side so the
+  pointer doesn't need pixel-perfect aim. Mirrors the panel-width
+  handle's 6px strip — slightly taller because the surrounding chrome
+  is denser horizontally than vertically."
+  8)
+
+(defn- seam-handle-style
+  "Inline style for the L2/L3 seam-handle node. The handle is a
+  full-width 8px horizontal strip carrying `row-resize` cursor + an
+  always-visible 1px accent stripe at 33% alpha along the seam line.
+  The strip's hover treatment lives in `theme/global-styles/motion-css`
+  (the rule intensifies the stripe on hover; inline styles cannot
+  carry `:hover` pseudo-classes). Mirrors `handle-style` above for the
+  vertical axis."
+  []
+  {:flex            "0 0 auto"
+   :width           "100%"
+   :height          (str seam-base-height-px "px")
+   :margin          "0"
+   :padding         "0"
+   :cursor          "row-resize"
+   :background      "transparent"
+   ;; Hairline on the seam centre so the affordance is visible against
+   ;; either theme. 33% alpha of the single `:accent` (GitHub blue) —
+   ;; same intensity as the panel-width handle's hairline so the two
+   ;; affordances read as one family.
+   :box-shadow      (str "inset 0 4px 0 -3px " (t/with-alpha :accent 33))
+   ;; Disable native gestures during drag (text-select on mouse,
+   ;; page-pan on touch).
+   :touch-action    "none"
+   :user-select     "none"
+   ;; The seam is part of the L2 surface — give it a hairline footer
+   ;; that matches the list's border-bottom so the visual rhythm is
+   ;; preserved (the L2 list lost its own border-bottom when the seam
+   ;; was extracted; the seam IS the boundary).
+   :position        "relative"})
+
+(rf/reg-view SeamHandle
+  "Render the horizontal seam between the L2 event list and the L3 tab
+  bar as a draggable resize affordance (rf2-t2dsh). Always renders —
+  every mode that mounts the L2 list (Dynamic chrome only; Static mode
+  doesn't carry L2) renders the seam.
+
+  Per spec/007-UX-IA.md §Splitter affordance:
+    - hover anywhere along the seam → `row-resize` cursor
+    - click-and-drag from anywhere along the seam → resizes the list
+    - 8px click-area, hairline accent that intensifies on hover
+    - keyboard-navigable (arrow keys for fine step, Enter/Space to
+      reset)
+    - double-click resets to default
+
+  `reg-view`-wrapped per rf2-in6l2 so the inner subscribe routes
+  through React-context to `:rf/xray`."
+  []
+  (let [current-height @(rf/subscribe [:rf.xray/events-list-height-px])
+        viewport-h     (when (exists? js/window)
+                         (.-innerHeight js/window))
+        aria-max       (long (* (or viewport-h 1000)
+                                config/max-events-list-height-fraction))]
+    [:div {:data-testid      "rf-xray-event-list-seam"
+           :role             "separator"
+           :aria-orientation "horizontal"
+           :aria-label       "Resize events list"
+           :aria-valuemin    config/min-events-list-height-px
+           :aria-valuemax    aria-max
+           :aria-valuenow    current-height
+           :title            (str "Drag to resize events list · "
+                                  "double-click to reset · "
+                                  "arrow keys for fine resize (Shift = coarse) · "
+                                  "Enter to reset")
+           :tab-index        0
+           :on-pointer-down  (fn [^js e]
+                               (start-seam-drag! e current-height))
+           :on-key-down      (fn [^js e]
+                               (when (handle-seam-keydown! e current-height)
+                                 (try (.preventDefault e)
+                                      (catch :default _ nil))))
+           :on-double-click  (fn [^js _e]
+                               (rf/dispatch
+                                 [:rf.xray/reset-events-list-height]
+                                 {:frame :rf/xray}))
+           :style            (seam-handle-style)}]))

--- a/tools/xray/src/day8/re_frame2_xray/shell.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/shell.cljs
@@ -1772,10 +1772,17 @@
   (rf2-htik0 Bug 2 — was 28px row × 224px container; Xray is
   info-dense and the earlier rhythm wasted vertical canvas).
 
-  Container height: 8 rows × 22px + 7 × 2px gap + 8px outer padding
-  ≈ 200px. `min-height` drops to 48px (2 rows + chrome) so the
-  native vertical-resize handle can still squeeze the list down to
-  the L2/L3 drag spec minimum.
+  Container default height: 8 rows × 22px + 7 × 2px gap + 8px outer
+  padding ≈ 200px. The live height reads from
+  `:rf.xray/events-list-height-px` (rf2-t2dsh) so the L2/L3 seam
+  handle's drag writes lift the list reactively. `min-height` drops
+  to `config/min-events-list-height-px` (48px == 2 rows + chrome) —
+  the same floor the seam-handle clamp enforces.
+
+  Per rf2-t2dsh the bottom-right browser-native `:resize \"vertical\"`
+  corner-grip was retired — the seam handle that sits on the L2/L3
+  boundary is the single resize affordance now, carrying persistence
+  + keyboard + reset that the corner-grip lacked.
 
   Per spec/018 §6 sub-graph + rf2-ak4ms: reads `:rf.xray/filtered-
   cascades` (NOT raw `:rf.xray/cascades`) so the L1 ribbon's IN/OUT
@@ -1814,6 +1821,9 @@
         ;; widths map through to the header + every row so the two
         ;; surfaces never drift out of column alignment.
         col-widths     @(rf/subscribe [:rf.xray/event-list-col-widths])
+        ;; rf2-t2dsh — list height is driven by the L2/L3 seam handle.
+        ;; The sub returns a clamped px value; default == 200 px.
+        list-height-px @(rf/subscribe [:rf.xray/events-list-height-px])
         cascades       @(rf/subscribe [:rf.xray/filtered-cascades])
         ;; rf2-4vp5j — the hidden-by-filters message moved UP to the
         ;; events ribbon (`events-ribbon`); the L2 list no longer renders
@@ -1851,13 +1861,17 @@
      ;; events ribbon (above this list) rather than as an inline banner
      ;; here; the list is just the scroll container.
      [:div {:data-testid "rf-xray-event-list"
-            :style {:height        "200px"   ; 8 rows × 22px + gaps + padding (rf2-htik0)
-                    :min-height    "48px"    ; 2 rows minimum
+            :style {;; rf2-t2dsh — live height from the seam handle's
+                    ;; sub; default 200 px (8 rows × 22 px + gaps +
+                    ;; padding, per rf2-htik0). The `:resize` CSS rule
+                    ;; that used to ride here was retired in favour of
+                    ;; the seam-handle (Spec 007 §Splitter affordance).
+                    :height        (->px list-height-px)
+                    :min-height    (->px config/min-events-list-height-px)
                     :overflow-y    "auto"
                     :overflow-x    "hidden"
                     :background    (:bg-2 tokens)
                     :border-bottom (str "1px solid " (:border-subtle tokens))
-                    :resize        "vertical"   ; native vertical resize for the L2/L3 drag handle
                     :padding       "4px"
                     ;; rf2-ieg6d Bug 2 — Firefox standardised props for the
                     ;; slim scrollbar. WebKit/Blink pseudo-element rules ship
@@ -2161,6 +2175,12 @@
    [ribbon {}]
    [events-ribbon]
    [event-list]
+   ;; rf2-t2dsh — L2/L3 seam handle. Click-and-drag anywhere along the
+   ;; horizontal seam between the event list and the tab bar resizes
+   ;; the events list. Replaces the previous browser-native
+   ;; `:resize \"vertical\"` corner-grip per spec/007-UX-IA.md
+   ;; §Splitter affordance.
+   [resize-handle/SeamHandle]
    [tab-bar]
    [detail-panel]])
 

--- a/tools/xray/src/day8/re_frame2_xray/theme/global_styles.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/theme/global_styles.cljs
@@ -920,6 +920,33 @@
     "    transparent 3px,\n"
     "    transparent\n"
     "  ) !important;\n"
+    "}\n"
+    ;; rf2-t2dsh — L2/L3 seam handle hover treatment. The seam ships
+    ;; with an always-visible 1px accent hairline at 33% alpha (inline
+    ;; `box-shadow` in `resize_handle.cljs` §seam-handle-style). On
+    ;; hover the hairline intensifies to a 1px stripe along the seam
+    ;; centre so the affordance reads as draggable without depending
+    ;; on a JS pointer-move pre-flash. Light + dark themes route
+    ;; through the same `--rf-xray-accent` variable so the treatment
+    ;; lands consistently in both. Mirrors the column-divider hover
+    ;; rule above for the horizontal axis.
+    "[data-testid=\"rf-xray-event-list-seam\"] {\n"
+    "  transition: background-color calc(120ms * var(--rf-xray-motion-scale, 1)) ease-out;\n"
+    "}\n"
+    "[data-testid=\"rf-xray-event-list-seam\"]:hover {\n"
+    "  background: linear-gradient(\n"
+    "    to bottom,\n"
+    "    transparent 0,\n"
+    "    transparent 3px,\n"
+    "    color-mix(in srgb, var(--rf-xray-accent) 55%, transparent) 3px,\n"
+    "    color-mix(in srgb, var(--rf-xray-accent) 55%, transparent) 5px,\n"
+    "    transparent 5px,\n"
+    "    transparent\n"
+    "  ) !important;\n"
+    "}\n"
+    "[data-testid=\"rf-xray-event-list-seam\"]:focus-visible {\n"
+    "  outline: 2px solid var(--rf-xray-accent);\n"
+    "  outline-offset: -2px;\n"
     "}\n"))
 
 (defn- inject-motion-style!

--- a/tools/xray/test/day8/re_frame2_xray/events_list_seam_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/events_list_seam_cljs_test.cljs
@@ -1,0 +1,435 @@
+(ns day8.re-frame2-xray.events-list-seam-cljs-test
+  "CLJS tests for the L2/L3 events-list seam resize handle (rf2-t2dsh).
+
+  Asserts:
+    1. `SeamHandle` mounts with the documented testid, role, and ARIA
+       slots (`separator`, horizontal orientation, live `aria-valuenow`).
+    2. The shell tree carries the seam BETWEEN the event-list and the
+       tab-bar (DOM-order contract — the seam IS the boundary).
+    3. Drag lifecycle — `start-seam-drag!` flips `seam-dragging?` to
+       true, `seam-simulate-up!` flips it back. `seam-simulate-move!`
+       dispatches the set-events-list-height-px event with the start +
+       delta.
+    4. Drag math — drag DOWN grows the list; drag UP shrinks it.
+    5. Clamp at write-time — the registry's set-events-list-height-px
+       event clamps to [min, viewport×0.7] before persisting.
+    6. Double-click handler dispatches `:rf.xray/reset-events-list-
+       height` which restores the default.
+    7. Keyboard navigation — ArrowDown/Up, Shift+arrow coarse step,
+       Home/End clamp-overshoot, Enter/Space reset.
+    8. The L2 event-list reads its height from the sub — sub updates
+       lift the rendered :height style.
+    9. The previously-shipped `:resize \"vertical\"` corner-grip is
+       gone — the L2 list's inline style no longer carries
+       `:resize`. Documents the disposition of the prior affordance
+       (retired in favour of the seam).
+   10. The seam cursor is `row-resize` — the affordance hover signal."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-xray.config :as config]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.resize-handle :as resize-handle]
+            [day8.re-frame2-xray.shell :as shell]
+            [day8.re-frame2-xray.test-support :as xray-test-support]
+            [day8.re-frame2-xray.trace-collector :as trace-collector]))
+
+;; ---- fixture ------------------------------------------------------------
+
+(defn- xray-init! []
+  (xray-test-support/reset-all!)
+  (trace-collector/reset-for-test!)
+  (config/reset-settings!)
+  ;; Force-cleanup any stale seam-drag state from a previous test (the
+  ;; module-level defonce atom survives fixture reset).
+  (resize-handle/seam-simulate-up!))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn xray-init!}))
+
+(defn- setup! []
+  (registry/register-xray-handlers!)
+  (frame/reg-frame :rf/xray {}))
+
+;; ---- hiccup walker (mirrors shell_cljs_test) ---------------------------
+
+(declare expand-tree)
+
+(defn- expand-tree
+  [tree]
+  (cond
+    (and (vector? tree) (fn? (first tree)))
+    (expand-tree (apply (first tree) (rest tree)))
+
+    (vector? tree)
+    (mapv expand-tree tree)
+
+    (seq? tree)
+    (map expand-tree tree)
+
+    :else
+    tree))
+
+(defn- hiccup-seq [tree]
+  (let [expanded (expand-tree tree)]
+    (tree-seq (some-fn vector? seq?) seq expanded)))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(defn- all-testids
+  "Return the testids of every hiccup node in `tree` that carries one,
+  in pre-order. Used to assert DOM-order — the seam must sit between
+  `rf-xray-event-list` and `rf-xray-tab-bar`."
+  [tree]
+  (->> tree
+       hiccup-seq
+       (keep (fn [node]
+               (when (and (vector? node) (map? (second node)))
+                 (:data-testid (second node)))))))
+
+;; ---- SeamHandle component shape ----------------------------------------
+
+(deftest seam-handle-renders-with-aria-shape
+  (setup!)
+  (rf/with-frame :rf/xray
+    (let [tree (resize-handle/SeamHandle)
+          props (second tree)]
+      (is (some? tree)
+          "SeamHandle returns a hiccup tree")
+      (is (= "rf-xray-event-list-seam" (:data-testid props))
+          "testid is the documented contract")
+      (is (= "separator" (:role props))
+          "role is the WAI-ARIA separator pattern")
+      (is (= "horizontal" (:aria-orientation props))
+          "orientation is horizontal (row-resize seam)")
+      (is (= "Resize events list" (:aria-label props))
+          "label describes the operation")
+      (is (= 0 (:tab-index props))
+          "seam is keyboard-reachable via tab")
+      (is (number? (:aria-valuenow props))
+          "live aria-valuenow exposes the current height to AT")
+      (is (= config/min-events-list-height-px (:aria-valuemin props))
+          "aria-valuemin matches the published floor"))))
+
+(deftest seam-handle-style-uses-row-resize-cursor
+  (setup!)
+  (rf/with-frame :rf/xray
+    (let [tree (resize-handle/SeamHandle)
+          style (:style (second tree))]
+      (is (= "row-resize" (:cursor style))
+          "seam hover cursor signals vertical-axis resize")
+      (is (string? (:box-shadow style))
+          "always-visible hairline accent rides as inline box-shadow")
+      (is (= "none" (:touch-action style))
+          "touch-action: none disables native page-pan during drag")
+      (is (= "none" (:user-select style))
+          "user-select: none prevents text-lasso during drag"))))
+
+;; ---- shell DOM-order contract -------------------------------------------
+
+(deftest shell-mounts-seam-between-list-and-tab-bar
+  (testing "rf2-t2dsh — the seam handle sits between the L2 event list
+            and the L3 tab bar in DOM order. The seam IS the
+            boundary; placing it anywhere else (above the events-
+            ribbon, below the tab-bar) would break the click-and-drag
+            semantics."
+    (setup!)
+    (rf/with-frame :rf/xray
+      (let [tree    (shell/shell-view {:mode :inline})
+            testids (all-testids tree)
+            list-idx (.indexOf (clj->js testids) "rf-xray-event-list")
+            seam-idx (.indexOf (clj->js testids) "rf-xray-event-list-seam")
+            tabs-idx (.indexOf (clj->js testids) "rf-xray-tab-bar")]
+        (is (pos? list-idx) "L2 event-list present")
+        (is (pos? seam-idx) "L2/L3 seam present")
+        (is (pos? tabs-idx) "L3 tab-bar present")
+        (is (< list-idx seam-idx)
+            "seam appears AFTER the event-list in pre-order")
+        (is (< seam-idx tabs-idx)
+            "seam appears BEFORE the tab-bar in pre-order")))))
+
+(deftest l2-list-no-longer-carries-native-resize
+  (testing "rf2-t2dsh — the previous browser-native `:resize
+            \"vertical\"` corner-grip is retired. The L2 list's inline
+            style MUST NOT carry `:resize` — the seam handle is the
+            sole vertical-resize affordance."
+    (setup!)
+    (rf/with-frame :rf/xray
+      (let [tree  (shell/shell-view {:mode :inline})
+            list  (find-by-testid tree "rf-xray-event-list")
+            style (:style (second list))]
+        (is (some? list) "event-list container present")
+        (is (nil? (:resize style))
+            "no `:resize` declaration — corner-grip retired")))))
+
+;; ---- drag lifecycle -----------------------------------------------------
+
+(defn- stub-event
+  "Build a stub PointerEvent-shaped JS object carrying just the slots
+  the seam handle reads. `preventDefault` is a no-op stub so
+  `start-seam-drag!` can call it without throwing in the test runner."
+  [page-y]
+  #js {:pageY          page-y
+       :pointerId      1
+       :preventDefault (fn [])})
+
+(deftest seam-start-drag-flips-state
+  (setup!)
+  (is (false? (resize-handle/seam-dragging?))
+      "no drag in progress at fixture start")
+  (resize-handle/start-seam-drag! (stub-event 500) 200)
+  (is (true? (resize-handle/seam-dragging?))
+      "start-seam-drag! installed the global capture")
+  (resize-handle/seam-simulate-up!)
+  (is (false? (resize-handle/seam-dragging?))
+      "seam-simulate-up! tore down the capture"))
+
+(deftest seam-drag-down-grows-list
+  (setup!)
+  (let [dispatches (atom [])]
+    (with-redefs [rf/dispatch* (fn
+                                 ([ev]       (swap! dispatches conj ev) nil)
+                                 ([ev _opts] (swap! dispatches conj ev) nil))]
+      (resize-handle/start-seam-drag! (stub-event 500) 200)
+      ;; Drag DOWN by 100px (pageY 600 > start-y 500) — list grows by
+      ;; 100px → 300px target. The view's `dy = now-y - start-y`,
+      ;; so dy = 100, new-height = 300.
+      (resize-handle/seam-simulate-move! 600)
+      (resize-handle/seam-simulate-up!))
+    (let [height-events (filter #(= :rf.xray/set-events-list-height-px (first %))
+                                @dispatches)]
+      (is (seq height-events)
+          "set-events-list-height-px was dispatched at least once")
+      (is (some #(= 300 (second %)) height-events)
+          "drag down by 100px dispatched 300 (start 200 + 100 delta)"))))
+
+(deftest seam-drag-up-shrinks-list
+  (setup!)
+  (let [dispatches (atom [])]
+    (with-redefs [rf/dispatch* (fn
+                                 ([ev]       (swap! dispatches conj ev) nil)
+                                 ([ev _opts] (swap! dispatches conj ev) nil))]
+      (resize-handle/start-seam-drag! (stub-event 500) 250)
+      ;; Drag UP by 100px (pageY 400 < start-y 500) — list shrinks
+      ;; by 100px → 150px target. dy = -100, new-height = 150.
+      (resize-handle/seam-simulate-move! 400)
+      (resize-handle/seam-simulate-up!))
+    (let [height-events (filter #(= :rf.xray/set-events-list-height-px (first %))
+                                @dispatches)]
+      (is (some #(= 150 (second %)) height-events)
+          "drag up shrinks: 250 - 100 = 150"))))
+
+(deftest seam-pointer-cancel-tears-down
+  (setup!)
+  (resize-handle/start-seam-drag! (stub-event 500) 200)
+  (is (true? (resize-handle/seam-dragging?))
+      "drag installed")
+  (resize-handle/seam-simulate-cancel!)
+  (is (false? (resize-handle/seam-dragging?))
+      "pointercancel teardown path"))
+
+;; ---- clamp at write-time ------------------------------------------------
+
+(deftest set-events-list-height-event-clamps-to-floor
+  (setup!)
+  (rf/with-frame :rf/xray
+    (rf/dispatch-sync [:rf.xray/set-events-list-height-px 10]))
+  ;; 10 < 48 floor → clamps to 48.
+  (is (= config/min-events-list-height-px
+         (config/get-setting :general :events-list-height-px))
+      "sub-floor request snaps to min-events-list-height-px"))
+
+(deftest set-events-list-height-event-persists-in-range-value
+  (setup!)
+  (rf/with-frame :rf/xray
+    (rf/dispatch-sync [:rf.xray/set-events-list-height-px 320]))
+  (is (= 320 (config/get-setting :general :events-list-height-px))
+      "in-range value persists verbatim through the round-trip"))
+
+(deftest clamp-events-list-height-pure-helper-snaps-non-numeric
+  (testing "rf2-t2dsh — pure helper falls back to the default for
+            non-numeric input so a malformed persisted payload never
+            leaves the list at an unusable size."
+    (is (= config/default-events-list-height-px
+           (config/clamp-events-list-height-px "bogus" 1000))
+        "string input → default")
+    (is (= config/default-events-list-height-px
+           (config/clamp-events-list-height-px nil 1000))
+        "nil input → default")
+    (is (= 200 (config/clamp-events-list-height-px 200 1000))
+        "in-range numeric passes through")
+    (is (= config/min-events-list-height-px
+           (config/clamp-events-list-height-px -50 1000))
+        "negative → floor")
+    (is (= 700 (config/clamp-events-list-height-px 5000 1000))
+        "above ceiling → viewport × 0.7")))
+
+;; ---- double-click reset -------------------------------------------------
+
+(deftest reset-event-restores-default
+  (setup!)
+  (rf/with-frame :rf/xray
+    (rf/dispatch-sync [:rf.xray/set-events-list-height-px 360]))
+  (is (= 360 (config/get-setting :general :events-list-height-px))
+      "events-list-height-px is 360 after explicit set")
+  (rf/with-frame :rf/xray
+    (rf/dispatch-sync [:rf.xray/reset-events-list-height]))
+  (is (= config/default-events-list-height-px
+         (config/get-setting :general :events-list-height-px))
+      "reset event restored the default"))
+
+(deftest double-click-handler-dispatches-reset
+  (setup!)
+  (let [dispatches (atom [])]
+    (with-redefs [rf/dispatch* (fn
+                                 ([ev]       (swap! dispatches conj ev) nil)
+                                 ([ev _opts] (swap! dispatches conj ev) nil))]
+      (rf/with-frame :rf/xray
+        (let [tree    (resize-handle/SeamHandle)
+              handler (:on-double-click (second tree))]
+          (is (fn? handler)
+              "the seam node carries on-double-click")
+          (handler nil))))
+    (is (some #(= [:rf.xray/reset-events-list-height] %) @dispatches)
+        "double-click dispatched the reset event")))
+
+;; ---- keyboard navigation ------------------------------------------------
+
+(defn- stub-key-event [key shift?]
+  (let [prevented? (atom false)]
+    {:event #js {:key            key
+                 :shiftKey       shift?
+                 :preventDefault (fn [] (reset! prevented? true))}
+     :prevented? prevented?}))
+
+(deftest seam-keydown-arrow-down-grows
+  (setup!)
+  (let [dispatches (atom [])
+        {:keys [event]} (stub-key-event "ArrowDown" false)]
+    (with-redefs [rf/dispatch* (fn
+                                 ([ev]       (swap! dispatches conj ev) nil)
+                                 ([ev _opts] (swap! dispatches conj ev) nil))]
+      (resize-handle/handle-seam-keydown! event 200))
+    (is (some #(= [:rf.xray/set-events-list-height-px 208] %) @dispatches)
+        "ArrowDown adds the 8px fine step to current-height")))
+
+(deftest seam-keydown-arrow-up-shrinks
+  (setup!)
+  (let [dispatches (atom [])
+        {:keys [event]} (stub-key-event "ArrowUp" false)]
+    (with-redefs [rf/dispatch* (fn
+                                 ([ev]       (swap! dispatches conj ev) nil)
+                                 ([ev _opts] (swap! dispatches conj ev) nil))]
+      (resize-handle/handle-seam-keydown! event 200))
+    (is (some #(= [:rf.xray/set-events-list-height-px 192] %) @dispatches)
+        "ArrowUp subtracts the 8px fine step from current-height")))
+
+(deftest seam-keydown-shift-arrow-uses-coarse-step
+  (setup!)
+  (let [dispatches (atom [])
+        {:keys [event]} (stub-key-event "ArrowDown" true)]
+    (with-redefs [rf/dispatch* (fn
+                                 ([ev]       (swap! dispatches conj ev) nil)
+                                 ([ev _opts] (swap! dispatches conj ev) nil))]
+      (resize-handle/handle-seam-keydown! event 200))
+    (is (some #(= [:rf.xray/set-events-list-height-px 232] %) @dispatches)
+        "Shift+ArrowDown uses the 32px coarse step (8 × 4)")))
+
+(deftest seam-keydown-home-overshoots-to-upper-clamp
+  (setup!)
+  (let [dispatches (atom [])
+        {:keys [event]} (stub-key-event "Home" false)]
+    (with-redefs [rf/dispatch* (fn
+                                 ([ev]       (swap! dispatches conj ev) nil)
+                                 ([ev _opts] (swap! dispatches conj ev) nil))]
+      (resize-handle/handle-seam-keydown! event 200))
+    (is (some #(= :rf.xray/set-events-list-height-px (first %)) @dispatches)
+        "Home dispatched a set-events-list-height-px (registry clamps to ceiling)")))
+
+(deftest seam-keydown-end-undershoots-to-lower-clamp
+  (setup!)
+  (let [dispatches (atom [])
+        {:keys [event]} (stub-key-event "End" false)]
+    (with-redefs [rf/dispatch* (fn
+                                 ([ev]       (swap! dispatches conj ev) nil)
+                                 ([ev _opts] (swap! dispatches conj ev) nil))]
+      (resize-handle/handle-seam-keydown! event 200))
+    (is (some #(= :rf.xray/set-events-list-height-px (first %)) @dispatches)
+        "End dispatched a set-events-list-height-px (registry clamps to floor)")))
+
+(deftest seam-keydown-enter-dispatches-reset
+  (setup!)
+  (let [dispatches (atom [])
+        {:keys [event]} (stub-key-event "Enter" false)]
+    (with-redefs [rf/dispatch* (fn
+                                 ([ev]       (swap! dispatches conj ev) nil)
+                                 ([ev _opts] (swap! dispatches conj ev) nil))]
+      (resize-handle/handle-seam-keydown! event 200))
+    (is (some #(= [:rf.xray/reset-events-list-height] %) @dispatches)
+        "Enter dispatched the reset event")))
+
+(deftest seam-keydown-space-dispatches-reset
+  (setup!)
+  (let [dispatches (atom [])
+        {:keys [event]} (stub-key-event " " false)]
+    (with-redefs [rf/dispatch* (fn
+                                 ([ev]       (swap! dispatches conj ev) nil)
+                                 ([ev _opts] (swap! dispatches conj ev) nil))]
+      (resize-handle/handle-seam-keydown! event 200))
+    (is (some #(= [:rf.xray/reset-events-list-height] %) @dispatches)
+        "Space dispatched the reset event")))
+
+(deftest seam-keydown-unrecognised-key-no-op
+  (setup!)
+  (let [dispatches (atom [])
+        {:keys [event]} (stub-key-event "Tab" false)]
+    (with-redefs [rf/dispatch* (fn
+                                 ([ev]       (swap! dispatches conj ev) nil)
+                                 ([ev _opts] (swap! dispatches conj ev) nil))]
+      (is (false? (resize-handle/handle-seam-keydown! event 200))
+          "unrecognised key returns false (bubble normally)"))
+    (is (empty? @dispatches)
+        "no dispatches for unrecognised key")))
+
+;; ---- sub drives the L2 list height -------------------------------------
+
+(deftest list-height-tracks-sub-update
+  (testing "rf2-t2dsh — the L2 list's inline :height style reads from
+            the events-list-height-px sub. After a set-events-list-
+            height-px dispatch, the rendered tree carries the new
+            height literal (px-suffixed string)."
+    (setup!)
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/set-events-list-height-px 360]))
+    (rf/with-frame :rf/xray
+      (let [tree  (shell/shell-view {:mode :inline})
+            list  (find-by-testid tree "rf-xray-event-list")
+            style (:style (second list))]
+        (is (= "360px" (:height style))
+            "list :height updates to the persisted seam-handle value")))))
+
+(deftest events-list-height-sub-defaults-to-published-default
+  (setup!)
+  (rf/with-frame :rf/xray
+    (let [height @(rf/subscribe [:rf.xray/events-list-height-px])]
+      (is (= config/default-events-list-height-px height)
+          "fresh sub returns the published default"))))
+
+(deftest events-list-height-sub-tracks-update
+  (setup!)
+  (rf/with-frame :rf/xray
+    (rf/dispatch-sync [:rf.xray/set-events-list-height-px 280]))
+  (rf/with-frame :rf/xray
+    (let [height @(rf/subscribe [:rf.xray/events-list-height-px])]
+      (is (= 280 height)
+          "sub reflects the latest update"))))

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -309,6 +309,8 @@
    :rf.xray/panel-width-px
    ;; rf2-6ni62 — L2 event-list user-resizable column widths.
    :rf.xray/event-list-col-widths
+   ;; rf2-t2dsh — L2/L3 seam-handle event-list height.
+   :rf.xray/events-list-height-px
    ;; rf2-vbbq0 / rf2-0s2at — L2 row relative-time chip anchor (sub
    ;; composed off `:rf.xray/cascades` — dispatched-time of the most
    ;; recent cascade; flips on event arrival, not on a per-second tick).
@@ -536,6 +538,8 @@
    :rf.xray/reset-event-list-col-width
    ;; rf2-x8h9y — resize-handle double-click reset.
    :rf.xray/reset-panel-width
+   ;; rf2-t2dsh — L2/L3 seam-handle double-click reset.
+   :rf.xray/reset-events-list-height
    :rf.xray/reset-suppressed-counters
    :rf.xray/restore-from-share-url
    :rf.xray/save-edit-popup
@@ -602,6 +606,8 @@
    :rf.xray/set-event-list-col-width
    ;; rf2-x8h9y — resize-handle live update event.
    :rf.xray/set-panel-width-px
+   ;; rf2-t2dsh — L2/L3 seam-handle live update event.
+   :rf.xray/set-events-list-height-px
    ;; rf2-7hwwe — `:after` countdown rings now-ms override (test-only).
    :rf.xray/set-now-ms-override-for-test
    :rf.xray/set-registered-machines-override-for-test

--- a/tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs
@@ -1674,8 +1674,13 @@
             "row padding is the tightened 1px 6px (was 4px 8px)")))))
 
 (deftest event-list-container-height-matches-tight-rows
-  (testing "rf2-htik0 Bug 2 — container height stays at ~8 rows of the
-            new 22px row × 2px gap + padding (≈200px, was 224px)."
+  (testing "rf2-htik0 Bug 2 — container default height stays at ~8
+            rows of the new 22px row × 2px gap + padding (≈200px, was
+            224px). Post rf2-t2dsh the value reads from the
+            `:rf.xray/events-list-height-px` sub instead of the
+            literal — fresh xray-setup! resets settings to the
+            default, so the rendered style at `:height` is still the
+            default 200px."
     (xray-setup!)
     (rf/with-frame :rf/xray
       (let [tree  (shell/shell-view)


### PR DESCRIPTION
**Bead:** rf2-t2dsh — Xray: events-list resize handle should be on the horizontal split-bar, not the bottom-right corner

## Shape

The L2 event-list previously carried a browser-native `:resize "vertical"` declaration in its inline style — a tiny 16px corner-grip at the bottom-right. No persistence, no keyboard surface, inconsistent with the panel-width handle.

This PR replaces it with a proper draggable seam handle running the full width of the L2/L3 boundary. Click-and-drag anywhere along the seam resizes the events list.

## Before / After

**Before:** L2 list inline style carries `:resize "vertical"`; browser paints a small ~16×16px diagonal grip glyph at the list's bottom-right corner. Heightreverts to 200px on every reload. No keyboard surface.

**After:** Dedicated `SeamHandle` component mounted between `event-list` and `tab-bar` in `dynamic-chrome`:

- Full-width 8px horizontal click-area along the L2/L3 boundary
- `cursor: row-resize` on hover
- Always-visible 1px accent hairline at 33% alpha; intensifies to ~55% on hover (via `theme/global_styles/motion-css` — light + dark consistent through `--rf-xray-accent`)
- Drag down grows the list, drag up shrinks it
- Double-click → reset to 200px default
- Keyboard: ArrowDown/Up fine step (8px), Shift+Arrow coarse (32px), Home/End clamp ends, Enter/Space reset
- Persistence + clamp via `:rf.xray/{set,reset}-events-list-height-px` registry events; height clamps to `[48px, viewport×0.7]`; round-trips through the Settings map under `:general :events-list-height-px`
- ARIA: `role="separator"`, `aria-orientation="horizontal"`, live `aria-valuenow`

## Corner-affordance disposition: RETIRED

Pre-alpha posture (no back-compat shims). The `:resize "vertical"` declaration is removed from the L2 list's inline style — the seam handle is the sole vertical-resize surface. A double-handle (corner + seam) would be a UI anti-pattern; mirrors the rationale of spec/007 §Yield-to-consumer (one resize surface, not two).

## Spec change

`tools/xray/spec/007-UX-IA.md`:
- New `### Splitter affordance — the L2/L3 seam (rf2-t2dsh)` subsection alongside `§Resize affordance`. Covers click-area, clamp, persistence, retired corner-grip disposition, keyboard contract, rendering.
- 4-layer chrome diagram + L2 wireframe + the L2 section's narrative updated to refer to the seam.

## Test deltas

**New:** `tools/xray/test/day8/re_frame2_xray/events_list_seam_cljs_test.cljs` — 25 deftests covering:
- `SeamHandle` shape (testid, role, aria-orientation, aria-valuenow, tab-index, aria-valuemin)
- `row-resize` cursor + `touch-action: none` + `user-select: none`
- DOM-order contract — seam mounted between `rf-xray-event-list` and `rf-xray-tab-bar`
- corner-grip retirement — L2 list inline style no longer carries `:resize`
- drag lifecycle: down grows / up shrinks / pointercancel teardown
- clamp at write-time (sub-floor → floor, in-range passthrough, non-numeric → default, above-ceiling → viewport×0.7)
- double-click handler dispatches the reset event
- full keyboard surface: ArrowDown/Up, Shift+Arrow, Home/End, Enter, Space, unrecognised-key no-op
- sub-driven height re-render in the shell tree

**Updated:**
- `shell_cljs_test.cljs`: `event-list-container-height-matches-tight-rows` docstring updated (default value still 200px; assertion unchanged).
- `registry_cljs_test.cljs` snapshot: +1 sub (`:rf.xray/events-list-height-px`), +2 events (`:rf.xray/set-events-list-height-px`, `:rf.xray/reset-events-list-height`).

## File inventory

```
M tools/xray/src/day8/re_frame2_xray/config.cljc          (events-list-height defaults + clamp helper)
M tools/xray/src/day8/re_frame2_xray/registry.cljs        (sub + 2 events)
M tools/xray/src/day8/re_frame2_xray/resize_handle.cljs   (SeamHandle + drag mechanics + keyboard)
M tools/xray/src/day8/re_frame2_xray/shell.cljs           (mount + height-from-sub + no `:resize`)
M tools/xray/src/day8/re_frame2_xray/theme/global_styles.cljs (hover treatment + focus-visible)
M tools/xray/spec/007-UX-IA.md                            (Splitter affordance subsection)
A tools/xray/test/day8/re_frame2_xray/events_list_seam_cljs_test.cljs (25 deftests)
M tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs (docstring refresh)
M tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs (sub + event snapshot)
```

## Quality gates

- `npm run test:cljs`: 4838 tests / 15716 assertions / 0 failures / 0 errors
- `npm run test:browser`: 124 tests / 353 assertions / 0 failures / 0 errors
- `npm run test:bundle-isolation`: PASS (16 artefacts; 33 sentinels absent; 3 allow-list budgets ok)