### PR TITLE
docs(framework): re-word frame-bound-fn docstring post-rf2-atqkg supersession (rf2-x005l)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -790,8 +790,9 @@
   "Higher-order callback wrapper: take an existing fn `f` and return a
   new fn that re-establishes `*current-frame*` for `f`'s body. The
   captured frame value is closed over — no dynamic-var read at call
-  time, no fragility across the React click-handler / setTimeout /
-  Promise.then / requestAnimationFrame microtask boundary.
+  time, so the wrapped fn dispatches into the captured frame even when
+  it fires after the surrounding `with-frame` / `frame-provider`
+  lexical scope has unwound.
 
   Two arities:
     (frame-bound-fn f)            — capture `(current-frame)` at wrap time.
@@ -799,27 +800,47 @@
                                     `with-frame` or frame-provider needed
                                     at wrap time.
 
-  This is the canonical pattern for React onClick / onKeyDown / onChange
-  callbacks that need to dispatch to a non-default frame. Pair with
-  the `bound-fn` macro (the macro form is sugar over this fn when you
-  want both `fn` syntax and frame-capture in one step).
+  Use `frame-bound-fn` when a callback is constructed in one
+  synchronous moment (a render-fn, an event handler body, a module
+  install! routine) but invoked LATER, across an async boundary that
+  unwinds the `*current-frame*` dynamic binding:
+
+    - `setTimeout` / `setInterval` callbacks
+    - `Promise.then` / `js/await` continuations
+    - `requestAnimationFrame` ticks
+    - WebSocket / EventSource `onmessage` handlers
+    - Worker `postMessage` handlers
+    - IntersectionObserver / MutationObserver callbacks
+    - Custom event subscribers, deferred fns, third-party callback APIs
+
+  Pair with the `bound-fn` macro — the macro form is sugar over this fn
+  when you want both `fn` syntax and frame-capture in one step.
 
   Example (Reagent / UIx / Helix view body, all substrates):
 
       (rf/reg-view MyToggle [mode]
-        (let [on-click (rf/frame-bound-fn
-                         (fn [_e new-mode]
-                           (rf/dispatch [:set-mode new-mode])))]
-          [:button {:on-click #(on-click % :all)} \"all\"]))
+        (let [on-message (rf/frame-bound-fn
+                           (fn [msg] (rf/dispatch [:ws/incoming msg])))]
+          (ws/subscribe! on-message)
+          [:div \"streaming…\"]))
 
-  Why this is more robust than `(rf/dispatch [...] {:frame :id})` at
-  the call site: the explicit-opt pattern is correct but discipline-
-  dependent — every dispatch site must remember to thread the opt, and
-  the bug class (rf2-7sdja popup, rf2-kcaiz zoom, rf2-p56sk subs-toggle,
-  rf2-tvu99 epoch :db toggle) keeps cycling because the discipline
-  fails. `frame-bound-fn` makes the surface impossible to misuse: the
-  callback ALWAYS dispatches in the wrapped frame, regardless of how
-  many dispatches happen inside it or how deep the call chain goes."
+  Why `frame-bound-fn` over threading `(rf/dispatch [...] {:frame :id})`
+  at the call site: explicit-opt threading is verbose at every dispatch
+  site and brittle when `*current-frame*` is genuinely lost across an
+  async boundary (the callback fires AFTER the surrounding `with-frame`
+  has unwound). `frame-bound-fn` captures the frame at wrap time and
+  closes over it, so the callback always dispatches in the wrapped
+  frame regardless of how deep the async chain goes.
+
+  See also spec/006 §Lazy-seq deref tracking (Reagent adapter) for an
+  adjacent but DIFFERENT bug class — \"view doesn't update on click\"
+  that looks superficially like \"frame lost across React onClick\" but
+  is actually a Reagent reactive-tracking failure (a lazy `(for ...)`
+  in a `reg-view` body whose elements deref subscriptions must be
+  realised with `doall` / `mapv` / `into` inside the render scope).
+  Reach for `frame-bound-fn` when you have a genuine async-boundary
+  case; reach for `doall` when you have a reactive-tracking case. Per
+  rf2-atqkg the two are not interchangeable."
   ([f]
    (let [frame (current-frame)]
      (fn [& args]

--- a/spec/002-Frames.md
+++ b/spec/002-Frames.md
@@ -606,7 +606,9 @@ Example (Xray's HANDLER `:db` view-mode toggle, the bead's bug-class instance):
        [:button {:on-click #(on-click % m)} (name m)])]))
 ```
 
-Without `frame-bound-fn`, every dispatch site needs `{:frame :rf/xray}` opt explicitly — a per-call discipline that has repeatedly failed (sibling beads rf2-7sdja popup, rf2-kcaiz zoom, rf2-p56sk subs-toggle, rf2-tvu99 epoch :db toggle). The wrap makes the surface impossible to misuse: the callback ALWAYS dispatches in the wrapped frame, regardless of how many dispatches happen inside it or how deep the call chain goes.
+Without `frame-bound-fn`, every dispatch site needs `{:frame :rf/xray}` opt explicitly — verbose at every callsite, and brittle in any case where `*current-frame*` is genuinely lost across an async boundary that fires after the surrounding `with-frame` / `frame-provider` has unwound. The wrap captures the frame at construction time and closes over it: the callback ALWAYS dispatches in the wrapped frame, regardless of how many dispatches happen inside it or how deep the async / call chain goes.
+
+> **See also**: [006 §Lazy-seq deref tracking (Reagent adapter)](006-ReactiveSubstrate.md#lazy-seq-deref-tracking-reagent-adapter-rf2-atqkg) for an adjacent but DIFFERENT bug class — "view doesn't update on click" that looks superficially like "frame lost across React onClick" but is actually a Reagent reactive-tracking failure. Reach for `frame-bound-fn` when you have a genuine async-boundary case (timer, promise, websocket); reach for `doall` / `mapv` when a `(for …)` in a `reg-view` body holds the deref. Per rf2-atqkg the two failure modes are not interchangeable.
 
 #### Other async callbacks (timers, promises, websocket messages)
 


### PR DESCRIPTION
Closes rf2-x005l.

PR #2200 (rf2-tvu99) shipped `rf/frame-bound-fn` with a docstring that framed the helper as defence against a frame-routing discipline-failure bug class — citing rf2-7sdja popup, rf2-kcaiz zoom, rf2-p56sk subs-toggle, and rf2-tvu99 epoch :db toggle. Per **rf2-atqkg** (corrected diagnosis from pair-debug 2026-05-26), those four beads were **NOT** discipline failures: they were Reagent lazy-seq deref tracking failures. The dispatches landed in the correct frame the entire time; the views just didn't re-render because the sub-derefs occurred outside Reagent's reactive scope.

The PR's commit body acknowledged the supersession but the docstring inside the same PR contradicted it. This commit re-words the docstring (and the matching paragraph in spec/002 §React click-handler routing) so the canonical surface no longer teaches the wrong mental model.

## Before

> Why this is more robust than `(rf/dispatch [...] {:frame :id})` at the call site: the explicit-opt pattern is correct but discipline-dependent — every dispatch site must remember to thread the opt, and the bug class (rf2-7sdja popup, rf2-kcaiz zoom, rf2-p56sk subs-toggle, rf2-tvu99 epoch :db toggle) keeps cycling because the discipline fails. `frame-bound-fn` makes the surface impossible to misuse: the callback ALWAYS dispatches in the wrapped frame, regardless of how many dispatches happen inside it or how deep the call chain goes.

Implicit framing: "reach for `frame-bound-fn` whenever a React click handler routes badly." Wrong reflex — most "view doesn't update on click" symptoms are lazy-seq tracking failures, not frame-routing failures.

## After

The new docstring keeps `frame-bound-fn` as a legitimate utility for callsites that genuinely need wrap-time frame capture, and lists the canonical async-boundary use cases:

- `setTimeout` / `setInterval` callbacks
- `Promise.then` / `js/await` continuations
- `requestAnimationFrame` ticks
- WebSocket / EventSource `onmessage` handlers
- Worker `postMessage` handlers
- IntersectionObserver / MutationObserver callbacks
- Custom event subscribers, deferred fns, third-party callback APIs

The rationale paragraph becomes:

> Why `frame-bound-fn` over threading `(rf/dispatch [...] {:frame :id})` at the call site: explicit-opt threading is verbose at every dispatch site and brittle when `*current-frame*` is genuinely lost across an async boundary (the callback fires AFTER the surrounding `with-frame` has unwound). `frame-bound-fn` captures the frame at wrap time and closes over it, so the callback always dispatches in the wrapped frame regardless of how deep the async chain goes.

And the "see also" cross-ref routes readers landing here on a view-doesn't-update bug to the actual fix surface:

> See also spec/006 §Lazy-seq deref tracking (Reagent adapter) for an adjacent but DIFFERENT bug class — "view doesn't update on click" that looks superficially like "frame lost across React onClick" but is actually a Reagent reactive-tracking failure (a lazy `(for ...)` in a `reg-view` body whose elements deref subscriptions must be realised with `doall` / `mapv` / `into` inside the render scope). Reach for `frame-bound-fn` when you have a genuine async-boundary case; reach for `doall` when you have a reactive-tracking case. Per rf2-atqkg the two are not interchangeable.

The example in the docstring also moved from an onClick toggle (which would be served better by lazy-seq realisation per rf2-atqkg) to a websocket subscriber, which is a genuine async-boundary case.

The matching paragraph in spec/002 §React click-handler routing got the same rework: drops the four bead citations, keeps `frame-bound-fn` as the right tool for genuine async boundaries, and links to spec/006 §Lazy-seq deref tracking.

## What does NOT change

- `frame-bound-fn` the fn — implementation, arities, semantics
- The `bound-fn` macro — wraps the same machinery
- The 7 regression tests in `core_frame_bound_fn_test.cljs`
- spec/006 §Lazy-seq deref tracking — already correct

## Acceptance

- [x] Docstring no longer cites rf2-7sdja / rf2-kcaiz / rf2-p56sk / rf2-tvu99 as discipline-failure examples
- [x] Docstring documents legitimate async-boundary use cases (setTimeout, Promise.then, websocket onmessage, …)
- [x] Cross-refs spec/006 §Lazy-seq deref tracking (rf2-atqkg) as the adjacent bug class
- [x] CLJS tests green (`npm run test:cljs` — 4838 tests / 15716 assertions, 0 fail)
- [x] JVM tests green (`scripts/test-jvm-implementation.sh` — all artefacts pass)