### PR TITLE
docs(xray): align Settings popup spec with 4-tab v1 — Theme/Filters retired (rf2-9t5ll)

### DIFF
--- a/tools/xray/spec/007-UX-IA.md
+++ b/tools/xray/spec/007-UX-IA.md
@@ -642,19 +642,22 @@ underneath. Closes on `Esc`, click outside, or click `✕`. Settings
 persist immediately on change (no Apply/Cancel — every toggle writes
 through to `(xray-config/configure! …)` on commit).
 
-Six inner tabs (top tab strip, body below) — Mike 2026-05-19 §0ter.4
-walkthrough locks the list (rf2-ttnst):
+Four inner tabs (top tab strip, body below) — Mike 2026-05-19 §0ter.4
+walkthrough originally locked six (rf2-ttnst); the Theme tab was
+retired per rf2-ou3pn (top-ribbon sun/moon icon is now the canonical
+light/dark affordance) and the Filters tab per rf2-wknb3 (full pill
+management lives in the ribbon filter strip + per-pill edit popup +
+mute manager modal). The Buffer tab inherited the
+`:general :epoch-history` slider per rf2-pu9sb:
 
 | # | Tab | Mnemonic | Content |
 |---|---|---|---|
-| 1 | **General** | `g` | Text size · Panel width · Panel position · Auto-open-on-error · Density (Cosy / Compact — no Comfy) · Long-keyword threshold · **Power user:** "Show tool frames in picker" toggle (off by default) |
-| 2 | **Theme** | `t` | Dark / Light (a single GitHub-blue accent in both modes, per §Colour system; per-tab default-expansion knob dropped) |
-| 3 | **Filters** | `f` | Active filter pills mirror · auto-filter-UI quick-open |
-| 4 | **Keybindings** | `k` | Read-only chord table (every binding the global listener captures) · master "Handle keys?" toggle. v1 is READ-ONLY; rebind UI is the v1.1 follow-on. |
-| 5 | **Buffer** | `b` | `:general :epoch-history` (slider, relocated from General per rf2-pu9sb — slot stays under `:general` for the persisted-settings shape, only the popup home moved) · `:buffer/cascades-retained` · `:app-db/inspector-collapse-threshold` · "Clear buffer now" button with confirm modal |
-| 6 | **Diff** | `d` | Hiccup-diff opt-in `:highlight-fn-ref-changes?` toggle (sub-output diff layout fixed unified; section-grouping threshold fixed defaults — both dropped from the user surface) |
+| 1 | **General** | `g` | Text size · Panel width · Panel position · Auto-open-on-error · Density (Cosy / Compact — no Comfy) · Long-keyword threshold · **Power user:** "Show tool frames in picker" toggle (off by default) · `:use-system-colors?` HCM-override toggle (relocated from Theme per rf2-ou3pn — slot is `:general :use-system-colors?`) |
+| 2 | **Keybindings** | `k` | Read-only chord table (every binding the global listener captures) · master "Handle keys?" toggle. v1 is READ-ONLY; rebind UI is the v1.1 follow-on. |
+| 3 | **Buffer** | `b` | `:general :epoch-history` (slider, relocated from General per rf2-pu9sb — slot stays under `:general` for the persisted-settings shape, only the popup home moved) · `:buffer/cascades-retained` · `:app-db/inspector-collapse-threshold` · "Clear buffer now" button with confirm modal |
+| 4 | **Diff** | `d` | Hiccup-diff opt-in `:highlight-fn-ref-changes?` toggle (sub-output diff layout fixed unified; section-grouping threshold fixed defaults — both dropped from the user surface) |
 
-**Inner-tab mnemonics** (g / t / f / k / b / d) — bare-letter
+**Inner-tab mnemonics** (g / k / b / d) — bare-letter
 keystrokes captured at the dialog level while the modal is open.
 The dialog's `on-key-down` stops propagation on every consumed key,
 and the global keydown listener gates spine bindings on a
@@ -664,10 +667,12 @@ spine. Mnemonics are suppressed while the focused element is an
 `<input>` / `<textarea>` / `<select>` / contenteditable surface so
 typing into numeric knobs is not interrupted.
 
-**Dropped from earlier drafts** (per the same 2026-05-19 walkthrough):
+**Dropped from earlier drafts** (per the same 2026-05-19 walkthrough plus post-#2186 retirements):
 
 | Dropped | Rationale |
 |---|---|
+| **Theme tab** (rf2-ou3pn) | Top-ribbon sun/moon icon (`ribbon-theme-toggle` in `shell.cljs`) is the canonical light/dark affordance; both surfaces dispatched the identical `[:rf.xray/settings-update :theme nil <kw>]` event, so the popup copy was pure redundancy. The `:use-system-colors?` HCM-override toggle relocated to **General → Power user** — the setting slot has always been `:general :use-system-colors?`; only its cosmetic home in the Theme section is gone with the tab. |
+| **Filters tab** (rf2-wknb3) | Full pill management lives in the top-ribbon filter strip (`filters/pills.cljs`, per [`018-Event-Spine.md`](./018-Event-Spine.md) §7), the per-pill edit popup (`filters/edit_popup.cljs`), and the mute manager modal (rf2-ikuwt). The settings tab's only widget was an "Open auto-filter UI" button dispatching `:rf.xray.filters/open` — an event with no handler registered anywhere — plus a static explainer paragraph. With the management surfaces all canonical elsewhere, the discoverability pointer was redundant. |
 | Actions tab + factory-reset BIG RED BUTTON | Factory-reset stays code-only (`config/reset-settings!`) — a destructive UI button has no use case the confirm modal beneath "Clear buffer" does not already cover. |
 | Density Comfy tier | Two tiers cover the rhythm need; the third was a styling-pass aspiration with no observed demand. |
 | Per-tab default expansion (`:bookish` / `:dense`) | Each tab owns its expansion default; no global knob. |

--- a/tools/xray/spec/016-Auxiliary-Panels.md
+++ b/tools/xray/spec/016-Auxiliary-Panels.md
@@ -660,18 +660,26 @@ and FROM/TO nav transitions. The App-db slice pin is the raw-data
 echo for users who want to inspect the slice alongside other app-db
 state.
 
-### Settings popup — full 6-tab catalogue
+### Historical — 6-tab aspiration superseded by 4-tab v1
 
 rf2-ttnst (Mike 2026-05-19 §0ter.4 walkthrough; shipped via PR #1518)
-locked the Settings popup at **6 tabs**: **General · Theme · Filters ·
-Keybindings · Buffer · Diff**. The locked inventory plus per-tab
-content sits in [`007-UX-IA.md` §Settings popup](./007-UX-IA.md#settings-popup-modal-overlay)
+originally locked the Settings popup at **6 tabs**: **General · Theme ·
+Filters · Keybindings · Buffer · Diff**. Post-#2186 the popup ships
+**4 tabs**: **General · Keybindings · Buffer · Diff** — the Theme tab
+was retired per rf2-ou3pn (top-ribbon sun/moon icon is the canonical
+light/dark affordance) and the Filters tab per rf2-wknb3 (full pill
+management lives in the ribbon strip + per-pill edit popup + mute
+manager modal). The Buffer tab inherited the `:general :epoch-history`
+slider per rf2-pu9sb. The locked 4-tab inventory plus per-tab content
+sits in [`007-UX-IA.md` §Settings popup](./007-UX-IA.md#settings-popup-modal-overlay)
 (the canonical UX surface) and [`018-Event-Spine.md` §9](./018-Event-Spine.md#9-settings-popup)
-(the architectural contract). This Vision block historically catalogued
-a different 8-row aspiration (Theme / Density / Editor / Trace v1 +
-Keybindings / Buffer / Popout / Actions future); it is superseded.
+(the architectural contract). The v1 reality is also captured earlier
+in this document — see §Settings popup — v1 ships above. This Vision
+block historically catalogued a different 8-row aspiration (Theme /
+Density / Editor / Trace v1 + Keybindings / Buffer / Popout / Actions
+future); it is superseded.
 
-What landed under rf2-ttnst that the earlier aspiration did not anticipate:
+What landed under rf2-ttnst (and the subsequent retirements) that the earlier aspiration did not anticipate:
 
 - **Density** folds into **General** (no separate tab).
 - **Editor** + **Trace** fold into **General** as power-user knobs.

--- a/tools/xray/spec/018-Event-Spine.md
+++ b/tools/xray/spec/018-Event-Spine.md
@@ -1271,57 +1271,47 @@ suites pin the panel render bodies post-reseed.
 
 1. Settings is **transient** — open, tweak, close — not browsed. Modals fit transient workflows; panels fit ongoing reference.
 2. Modal **preserves the user's last-active tab** — they don't lose context.
-3. Dedicated panel would force a tab-bar slot — tab count would creep back up (6 is hard-won; adding Settings would make 7).
+3. Dedicated panel would force a tab-bar slot — tab count would creep back up (the L1 tab inventory is hard-won; adding Settings would make one more).
 4. Modal pattern matches Cmd-K palette (also transient overlay) — consistent affordance class.
 
 ### Wireframe
 
 ```
 ┌─ Settings ───────────────────────────────────────────────────  ✕  ┐
+│ [ General ] [ Keybindings ] [ Buffer ] [ Diff ]                    │
 │                                                                    │
-│ ◉ Filters                                                          │
-│ ○ View                                                             │
-│ ○ Keybindings                                                      │
-│ ○ Buffer                                                           │
-│ ○ Popout                                                           │
-│ ○ Actions                                                          │
+│ ─ General ──────────────────────────────────────────────────────   │
 │                                                                    │
-│ ─ Filters ──────────────────────────────────────────────────────  │
+│ Text size              [────●────]  13 px                          │
+│ Panel width            [────●────]  480 px                         │
+│ Panel position         ◉ Right rail  ○ Popout  ○ Fullscreen        │
+│ Density                ◉ Cosy        ○ Compact                     │
+│ Auto-open on error     ☐                                           │
+│ Long-keyword threshold [────●────]  60 chars                       │
 │                                                                    │
-│ Active filters (5)                                                 │
-│   [+ :auth/* ✎]  [× :mouse-move ✎]  [+ http ✎]                    │
-│   [× :anim-frame ✎]  [× :pointer-move ✎]                          │
-│   [Clear all] [Add pill]                                           │
-│                                                                    │
-│ Recommended filters                                                │
-│   ☐ :mouse-move        (pointer-coord events; high volume)        │
-│   ☐ :anim-frame        (requestAnimationFrame ticks)              │
-│   ☐ :resize            (window resize coalescing)                  │
-│   ☐ :pointermove       (modern pointer events)                     │
-│   ☐ :scroll            (scroll events; often debounce-triggered)  │
-│   [Apply selected]   [Apply all]                                   │
-│                                                                    │
-│ Auto-hide error overrides? ◉ Yes  ○ No                            │
-│   When ON, OUT-matched events that ERROR still surface on the list │
+│ ── Power user ──                                                   │
+│ ☐ Show tool frames in picker                                       │
+│ ☐ Use system colors  (HCM override; :general :use-system-colors?)  │
 │                                                                    │
 └────────────────────────────────────────────────────────────────────┘
 ```
 
-### Sections (left-rail navigation; right-pane content)
+A top tab strip (NOT left-rail navigation) drives which body section
+renders. Tabs are equal-weight; **General** is the default-on-open.
+
+### Sections (top tab strip; per-tab body)
 
 | Section | Content |
 |---|---|
-| **Filters** (default) | Active filter pills (mirror of ribbon pills; edit/delete) · Recommended-filters quick-add · auto-hide-error-overrides toggle · advanced pattern-editor for complex globs |
-| **View** | Theme: `◉ Dark · ○ Light · ○ Dim` · Density: `◉ Cosy 28px · ○ Compact 22px` (event-list row height; the `:comfy` tier was dropped per 015 §Density) · Long-keyword treatment threshold (chars) · **`── Power user ──` divider · "Show tool frames in picker" toggle** (OFF by default; reveals `:rf/xray` etc. in ribbon picker; only useful when debugging Xray itself) |
-| **Keybindings** | Table of `Action / Chord / Edit` rows; per-row chord editor (click chord cell → focus, press new chord); reset-to-defaults button per row + global; `Handle keys?` master toggle |
-| **Buffer** | `:general :epoch-history <int>` (slider, default 50, range 10–500; slot stays under `:general` per rf2-pu9sb — only the popup home moved into Buffer) · `:buffer/cascades-retained <int>` (default 50) · `:app-db/inspector-collapse-threshold <int>` (default 20) · "Clear buffer now" button |
-| **Popout** | `:popout/width <px>` (default 800) · `:popout/height <px>` (default 600) · `:popout/position <:right :left :centre>` (default `:right`) · "Open in popout now" button (= `o`) |
-| **Actions** | `[factory-reset!]` BIG RED BUTTON · "Reset to fresh-install state — clears filters, pins, keybindings, theme. Buffer kept." Confirmation modal on click. Plus: "Reset filters only" / "Reset keybindings only" / "Clear pinned cascades" finer-grained reset buttons. |
+| **General** (default) | Text-size slider · Panel-width slider · Panel-position radio (`:right-rail` / `:popout` / `:fullscreen`) · Density radio (`:cosy` / `:compact`; the `:comfy` tier was dropped per 015 §Density) · Auto-open-on-error checkbox · Long-keyword treatment threshold · **`── Power user ──` divider · "Show tool frames in picker" toggle** (OFF by default; reveals `:rf/xray` etc. in ribbon picker; only useful when debugging Xray itself) · `:use-system-colors?` HCM-override toggle (relocated from Theme per rf2-ou3pn — slot stays `:general :use-system-colors?`) |
+| **Keybindings** | Read-only chord table (every binding the global keydown listener captures) · `Handle keys?` master toggle. v1 ships READ-ONLY; the per-row chord editor + reset-to-defaults UI is the v1.1 follow-on. |
+| **Buffer** | `:general :epoch-history <int>` (slider, default 50, range 10–500; slot stays under `:general` per rf2-pu9sb — only the popup home moved into Buffer) · `:buffer/cascades-retained <int>` (default 50) · `:app-db/inspector-collapse-threshold <int>` (default 20) · "Clear buffer now" button (confirm modal) |
+| **Diff** | Hiccup-diff opt-in `:highlight-fn-ref-changes?` toggle (sub-output diff layout fixed unified; section-grouping threshold fixed defaults — both dropped from the user surface) |
 
 ### v1 ships
 
-**v1 ships four sections, NOT six** (rf2-9poxq + rf2-jh9ws +
-rf2-ttnst + rf2-ou3pn + rf2-wknb3): **General**, **Keybindings**,
+**v1 ships four sections** (rf2-9poxq + rf2-jh9ws + rf2-ttnst +
+rf2-ou3pn + rf2-wknb3 + rf2-pu9sb): **General**, **Keybindings**,
 **Buffer**, **Diff** — a top tab strip (not left-rail nav) drives
 which body section renders. Defaults: auto-open-on-error OFF,
 panel-position `:right-rail`, theme `:light` (Figma authority;
@@ -1330,24 +1320,26 @@ key `re-frame2.xray.settings.v1` (single nested map, one round-trip
 through `pr-str`). Full per-knob inventory + persistence rationale +
 auto-open-watcher semantics are in
 [`016-Auxiliary-Panels.md`](016-Auxiliary-Panels.md) §Settings popup
-— v1 ships. (A Telemetry tab shipped briefly with the initial popup
-landing but was removed per rf2-jh9ws — Xray transmits no telemetry
-and the toggle was a broken affordance. The Theme tab was retired
-per rf2-ou3pn — the ribbon's sun/moon icon dispatches the same
-`[:rf.xray/settings-update :theme nil <kw>]` event the popup radio
-used to drive; the popup copy was pure redundancy. The Filters tab
-was retired per rf2-wknb3 — full pill management lives in the
-ribbon strip + per-pill edit popup + mute manager modal; the
-popup's tab was a discoverability pointer whose only widget
-dispatched an unregistered event.)
+— v1 ships.
 
-The Popout and Actions sections (rows of the table above) are
-**full §9 catalogue intent** and remain the target for follow-on
-beads; Keybindings, Buffer, and Diff already ship per rf2-ttnst +
-rf2-i39w2. The Filters tab is no longer part of v1 — full pill
-management lives in the ribbon strip + per-pill edit popup + mute
-manager modal; re-implementing it in two places would invite drift
-(retired per rf2-wknb3).
+**Retirements from the earlier 6-tab aspiration:**
+
+- A **Telemetry** tab shipped briefly with the initial popup landing
+  (rf2-9poxq) but was removed per rf2-jh9ws — Xray transmits no
+  telemetry and the toggle was a broken affordance.
+- The **Theme** tab was retired per rf2-ou3pn — the top-ribbon
+  sun/moon icon dispatches the same
+  `[:rf.xray/settings-update :theme nil <kw>]` event the popup radio
+  used to drive; the popup copy was pure redundancy. The HCM-override
+  `:use-system-colors?` toggle relocated to **General → Power user**.
+- The **Filters** tab was retired per rf2-wknb3 — full pill
+  management lives in the ribbon strip + per-pill edit popup + mute
+  manager modal; the popup's tab was a discoverability pointer whose
+  only widget dispatched an unregistered event.
+- **Popout** folded into General's Panel-position radio — no own tab.
+- **Actions** dropped — factory-reset stays code-only
+  (`config/reset-settings!`); the "Clear buffer now" affordance under
+  the Buffer tab covers the only destructive op users have asked for.
 
 ### "Show tool frames in picker" toggle
 


### PR DESCRIPTION
## Why

Three Xray spec files carried stale 6-tab Settings popup inventories. Post-#2186 the popup ships **4 tabs**: **General · Keybindings · Buffer · Diff**.

- Theme tab retired per **rf2-ou3pn** — top-ribbon sun/moon icon is the canonical light/dark affordance (both surfaces dispatched the identical `[:rf.xray/settings-update :theme nil <kw>]` event, so the popup copy was pure redundancy).
- Filters tab retired per **rf2-wknb3** — full pill management lives in the ribbon strip + per-pill edit popup + mute manager modal.
- Buffer tab inherited the `:general :epoch-history` slider per **rf2-pu9sb**.

Impl docstring is authoritative (`tools/xray/src/day8/re_frame2_xray/settings/popup.cljs:13-18`): "Four inner tabs: General | Keybindings | Buffer | Diff".

## Section changes

### `tools/xray/spec/007-UX-IA.md` §Settings popup (lines ~635-680)

- Replace "Six inner tabs" + 6-row table with the 4-tab inventory (General · Keybindings · Buffer · Diff).
- Move the `:use-system-colors?` HCM-override toggle from the retired Theme tab into General → Power user (slot stays `:general :use-system-colors?`).
- Add **Theme** + **Filters** rows to "Dropped from earlier drafts" with rf2-ou3pn / rf2-wknb3 cites + retirement rationale.
- Update mnemonics from `g / t / f / k / b / d` to `g / k / b / d`.

### `tools/xray/spec/018-Event-Spine.md` §9 Settings popup (lines ~1277-1342)

- Replace the stale 6-section wireframe (Filters / View / Keybindings / Buffer / Popout / Actions left-rail) with the **4-tab v1 wireframe**: top tab strip `[ General ] [ Keybindings ] [ Buffer ] [ Diff ]`, General body shown.
- Replace the 6-row Sections table with a 4-row table (General · Keybindings · Buffer · Diff). Drop the "View" row (folded into General per rf2-ttnst), Filters row (retired per rf2-wknb3), Popout row (folded into General Panel-position), Actions row (dropped — factory-reset stays code-only).
- Update "v1 ships" paragraph: drop "NOT six" hedging now that the wireframe matches the prose; add rf2-pu9sb to the cite list.
- Reframe the Telemetry / Theme / Filters / Popout / Actions copy as a bullet list under **"Retirements from the earlier 6-tab aspiration"** for readability.
- Update §3 modal-vs-panel rationale: "6 is hard-won; adding Settings would make 7" → "the L1 tab inventory is hard-won; adding Settings would make one more" (the count claim was about L1 tabs, not Settings tabs).

### `tools/xray/spec/016-Auxiliary-Panels.md` §Vision (lines ~663-696)

- Retitle "Settings popup — full 6-tab catalogue" → **"Historical — 6-tab aspiration superseded by 4-tab v1"**.
- Add the post-#2186 4-tab reality at the head of the section; cross-link to the v1 capture earlier in the same file (§Settings popup — v1 ships at lines ~462-487).
- Keep the historical 8-row aspiration narrative for spec provenance.

## Cross-refs

- **rf2-ou3pn** — Theme tab retired (ribbon sun/moon icon canonical)
- **rf2-wknb3** — Filters tab retired (ribbon strip + edit popup + mute manager modal)
- **rf2-pu9sb** — `:general :epoch-history` slider relocated to Buffer tab (slot stayed under `:general`)
- **rf2-ttnst** — original 6-tab walkthrough (now superseded)
- **rf2-tawqp** — `ai/findings/xray-spec-drift-audit-2026-05-26.md` D5 audit that flagged this drift

## Quality gates

- `cd implementation && npm run test:cljs` — **4753 tests / 15445 assertions / 0 failures / 0 errors**.
- mkdocs build not relevant — `tools/xray/spec/*` files are not in mkdocs scope (`mkdocs.yml` references only `docs/xray/*`).

Closes rf2-9t5ll.