### PR TITLE
feat(xray): Epoch machine-cascade surfaces inline-fn source (rf2-wwc3j)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1399,16 +1399,48 @@ member of `machine-cascade-trace-ops` as a row in the same order:
   - `:transition` → `N microstep(s)` (the headline)
   - `:timer` → `· cancelled (<reason>)`
 
-**Per-row body — interleaved source code (always visible).** For
-`:action` and `:guard` rows the body renders the source form pulled
-from the registered machine spec (`(rf/handler-meta :machine
-event-id) → :rf/machine → [:actions <id>] | [:guards <id>]`) via
+**Per-row body — interleaved source code (always visible).** Every
+cascade row carries source visibility (rf2-wwc3j extends rf2-u69j7's
+named-only coverage to inline-fn / transition / timer rows). The body
+renders the source form pulled from the registered machine spec via
 `edn/code-block` (clojure-syntax highlight; same widget the HANDLER
-source block uses). Always visible by default per the bead body's
-"interleaved source code" requirement — the operator reads what ran
-AND its code at the same vertical position without expand/collapse
-gestures. Source-missing fallback renders a muted `<source not yet
-captured>` placeholder so the slot is consistently present.
+source block uses). Source-key dispatch (`projection/cascade-row-
+source-key`) returns the spec-path tuple under which the macro
+stamped the per-element source-coord (rf2-8bp3):
+
+| Row kind | id flavour              | spec-path key                                         |
+|----------|-------------------------|-------------------------------------------------------|
+| `:action`| keyword `action-id`     | `[:actions <id>]` (definition-site stamp)             |
+| `:action`| inline-fn, `:entry`     | `[:states <target-state>... :entry]`                  |
+| `:action`| inline-fn, `:exit`      | `[:states <source-state>... :exit]`                   |
+| `:action`| inline-fn, `:transition`| `[:states <source-state>... :on <event> :action]`     |
+| `:guard` | keyword `guard-id`      | `[:guards <id>]` (definition-site stamp)              |
+| `:guard` | inline-fn               | `[:states <source-state>... :on <event> :guard]`      |
+| `:transition` | —                  | `[:states <source-state>... :on <event>]`             |
+| `:timer` | —                       | `[:states <state>...]` (parent state-node, D1 shape)  |
+
+The per-row `:source-state` / `:target-state` / `:event-id` slots are
+stamped by `machine-cascade-rows`'s `enrich-cascade-rows` pass —
+walks the cascade in trace order and for each non-transition row
+copies the surrounding `:transition` row's `:from-state` / `:to-state`
+/ `:event` (substrate emits actions BEFORE the macrostep's
+`:transition` emit; the next transition ahead is the surrounding
+one). Multi-microstep cascades carry one transition emit per
+macrostep — intermediate-state inline-fns fall back to the
+headline state; source-key resolution degrades to the macrostep's
+source/target.
+
+For `:transition` rows, the body renders the transition map literal
+(EDN). For `:timer` rows, the body is elided (the parent state-node
+is too verbose to render verbatim); the click-to-source chip on the
+verb is the primary affordance, opening the operator on the state
+that owns the `:after` slot.
+
+Always visible by default per the bead body's "interleaved source
+code" requirement — the operator reads what ran AND its code at the
+same vertical position without expand/collapse gestures. Source-
+missing fallback renders a muted `<source not yet captured>`
+placeholder so the slot is consistently present.
 
 **Per-row outcome detail.** Action rows surface inline:
 
@@ -1421,8 +1453,10 @@ captured>` placeholder so the slot is consistently present.
   message.
 
 Transition rows surface the `state {:from} → {:to}` chrome with the
-event vector that drove the cascade. Timer rows surface only the
-header (no inline body — cancellations are housekeeping).
+event vector that drove the cascade plus the transition-map source
+body (rf2-wwc3j). Timer rows surface only the header + click-to-
+source chip (no inline body — cancellations are housekeeping; the
+chip routes to the `:after`-bearing state node).
 
 **Empty-state correctness** (acceptance #4 — rf2-u69j7). A vanilla
 `reg-event-db` cascade (or any non-`:reg-machine` flavour) renders

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -485,6 +485,130 @@
     :rf.machine.timer/cancelled  (timer-cascade-row ev)
     nil))
 
+;; ---- inline-fn source-path enrichment (rf2-wwc3j) ----------------------
+;;
+;; Cascade rows arriving from the substrate carry no `:state-id` / `:event-id`
+;; — those are implicit in the macrostep that surrounds them. To resolve
+;; the spec-path under which the macro stamped a per-element source-coord
+;; (rf2-8bp3), we walk the cascade and stamp each non-transition row with
+;; the surrounding transition's source/target state + event-id:
+;;
+;;   :exit / :transition / :destroy-exit   → :source-state of the surrounding transition
+;;   :entry / :initial-entry / :always /
+;;   :after-action                          → :target-state of the surrounding transition
+;;
+;; The "surrounding transition" is the next `:rf.machine/transition` row in
+;; cascade order (substrate emits actions BEFORE the transition emit; for
+;; the post-macrostep cascade, the prior transition emit's :after is used
+;; as a fallback when no following transition exists).
+;;
+;; This is best-effort: multi-microstep cascades carry one transition emit
+;; per macrostep (the headline rollup), so intermediate-state inline-fn
+;; entries fall back to the macrostep's headline state. Source resolution
+;; falls through to nil for those cases — the existing source-missing
+;; placeholder renders in the view (graceful degradation; correct for the
+;; common flat / single-microstep case).
+
+(defn- state-keyword-or-leaf
+  "Coerce a state form (keyword or vector path) to its leaf keyword. Used
+  as the state-id key in spec-path tuples for flat machines."
+  [state]
+  (cond
+    (keyword? state)            state
+    (and (vector? state)
+         (seq state))           (last state)
+    :else                       nil))
+
+(defn- state-vector
+  "Coerce a state form (keyword or vector path) to its full vector path.
+  Used when constructing hierarchical spec-paths (`[:states :outer :states
+  :inner]`)."
+  [state]
+  (cond
+    (vector? state) (vec state)
+    (keyword? state) [state]
+    :else            nil))
+
+(defn state-spec-path-prefix
+  "Build the spec-path prefix for a state form. Flat: `:foo` →
+  `[:states :foo]`. Hierarchical: `[:a :b]` → `[:states :a :states :b]`.
+  Used by `cascade-row-source-key` to construct inline-fn slot keys.
+
+  Returns nil for empty / nil states (defensive — the cascade row's
+  source-key lookup elides cleanly when the spec-path can't be built)."
+  [state]
+  (when-let [v (state-vector state)]
+    (when (seq v)
+      (vec (mapcat (fn [s] [:states s]) v)))))
+
+(defn- event-id-of
+  "Lift the event-id (first element of the event vector) off a transition
+  row or trace-derived event vector. Used as the `:on <event-id>` key in
+  spec-path tuples for transition / inline-guard / inline-action rows."
+  [event]
+  (when (and (vector? event) (seq event) (keyword? (first event)))
+    (first event)))
+
+(defn- enrich-cascade-rows
+  "Stamp `:source-state` / `:target-state` / `:event-id` onto each
+  cascade row (rf2-wwc3j). Used by `cascade-row-source-key` to construct
+  inline-fn / transition / timer spec-path tuples.
+
+  ALGORITHM. Walk the cascade rows in order, partitioning at each
+  `:transition` row. Each partition's non-transition rows share the
+  enclosing transition's source/target state + event-id. The transition
+  row itself carries the same info on its own slots.
+
+  Edge cases:
+  - Pre-transition rows (before any `:transition` emit) — `:initial-entry`
+    bootstrap cascade. Use the FIRST upcoming transition's `:before` as
+    source-state and the FIRST upcoming transition's `:after` as target-
+    state. When no transition fires (cascade emitted no transition row),
+    leave the slots nil.
+  - Post-transition rows (after the last `:transition` emit) — usually
+    timer-cancels emitted after macrostep commit; fall back to the
+    preceding transition's `:after` for both source and target.
+  - Rows on a phase that maps to nil (e.g. `:always` with no transition
+    in the cascade) — keep slots nil; source lookup degrades gracefully."
+  [rows]
+  (let [v   (vec rows)
+        n   (count v)
+        ;; For each row index, find the surrounding transition row:
+        ;; prefer the NEXT transition ahead (substrate emits actions
+        ;; before the transition), else fall back to the most recent
+        ;; preceding transition (post-commit timer-cancels).
+        next-tx (loop [i 0 prior nil acc (transient (vec (repeat n nil)))]
+                  (if (>= i n)
+                    (persistent! acc)
+                    (let [row (nth v i)
+                          surrounding (cond
+                                        (= :transition (:kind row)) row
+                                        :else (or
+                                                (some #(when (= :transition (:kind %)) %)
+                                                      (subvec v i))
+                                                prior))]
+                      (recur (inc i)
+                             (if (= :transition (:kind row)) row prior)
+                             (assoc! acc i surrounding)))))]
+    (mapv
+      (fn [row tx]
+        (if (= :transition (:kind row))
+          (cond-> row
+            (some? (:from-state row))
+            (assoc :source-state (:from-state row))
+            (some? (:to-state row))
+            (assoc :target-state (:to-state row))
+            (some? (:event row))
+            (assoc :event-id (event-id-of (:event row))))
+          (cond-> row
+            (and tx (some? (:from-state tx)))
+            (assoc :source-state (:from-state tx))
+            (and tx (some? (:to-state tx)))
+            (assoc :target-state (:to-state tx))
+            (and tx (some? (:event tx)))
+            (assoc :event-id (event-id-of (:event tx))))))
+      rows next-tx)))
+
 (defn machine-cascade-rows
   "Project the focused epoch's machine-related trace events into a
   single time-ordered cascade row vector (rf2-u69j7). Each row carries
@@ -500,18 +624,25 @@
   view layer numbers rows 1..N via `:step` (assigned here, contiguous
   over only the rows that fired).
 
+  Per rf2-wwc3j: post-build each row is enriched with `:source-state` /
+  `:target-state` / `:event-id` derived from the surrounding `:transition`
+  emit. These slots feed `cascade-row-source-key` so inline-fn `:entry` /
+  `:exit` / `:guard` / transition / timer rows can resolve their spec-
+  path tuple under `:rf.machine/source-coords` (rf2-8bp3).
+
   Returns an empty vec when no machine-cascade events fired (vanilla
   reg-event-db / reg-event-fx cascades — the redesign is
   machine-specific and the empty vec drives the view's empty-state
   branch off the prior handler-step rendering unchanged)."
   [events]
-  (vec
-    (map-indexed
-      (fn [i row]
-        (assoc row :step (inc i) :trace-index i))
-      (keep ev->cascade-row
-            (filter (fn [ev] (contains? machine-cascade-trace-ops (op ev)))
-                    events)))))
+  (let [base (vec
+               (map-indexed
+                 (fn [i row]
+                   (assoc row :step (inc i) :trace-index i))
+                 (keep ev->cascade-row
+                       (filter (fn [ev] (contains? machine-cascade-trace-ops (op ev)))
+                               events))))]
+    (enrich-cascade-rows base)))
 
 (defn machine-cascade-total-ms
   "Sum of every cascade row's `:duration-ms` (rf2-u69j7). nil when no
@@ -1381,15 +1512,82 @@
 (defn cascade-row-source-key
   "Spec-path tuple used to look up a cascade row's source-coord on the
   registered machine's `:rf.machine/source-coords` index (rf2-8bp3).
-  Returns nil for rows whose kind has no spec-path mapping (e.g.
-  `:transition`, `:timer`). Pure-data; the view layer reuses this for
-  the coord lookup so the source-link affordance reads off ONE
-  authoritative key."
-  [{:keys [kind action-id guard-id]}]
-  (case kind
-    :action (when action-id [:actions action-id])
-    :guard  (when guard-id  [:guards guard-id])
-    nil))
+  Pure-data; the view layer reuses this for the coord lookup so the
+  source-link affordance reads off ONE authoritative key.
+
+  Dispatch (rf2-u69j7 baseline + rf2-wwc3j inline-fn extensions):
+
+  - `:action` with a keyword `:action-id` → `[:actions <id>]`
+    (definition-site stamp; the named-handler path).
+  - `:action` with an inline `:action-id` (fn) — derive from the row's
+    `:phase` + state slot (`:source-state` / `:target-state`, stamped
+    by `enrich-cascade-rows`):
+    - `:entry` / `:initial-entry` → `[:states <state>... :entry]`
+      (target-state)
+    - `:exit` / `:destroy-exit`   → `[:states <state>... :exit]`
+      (source-state)
+    - `:transition`               → `[:states <state>... :on <event> :action]`
+      (source-state + event-id)
+    - `:always`                   → `[:states <state>... :always 0 :action]`
+      (best-effort: index 0; richer index resolution requires
+      substrate-side carrier of the always-index, deferred)
+    - `:after-action`             → `[:states <state>... :after :action]`
+      (best-effort: timer fn-form path; the macro doesn't yet stamp
+      per-delay `:after` coords; D2 follow-on bead handles richer index).
+  - `:guard` with a keyword `:guard-id` → `[:guards <id>]`
+    (definition-site stamp; the named-guard path).
+  - `:guard` with an inline `:guard-id` (fn) — derive from state +
+    event-id:
+    `[:states <state>... :on <event> :guard]` (best-effort: no vector
+    transition-option index — for the common single-map transition).
+  - `:transition` → `[:states <from-state>... :on <event>]`
+    (the transition map's spec-path; opens the operator on the
+    transition literal in the spec).
+  - `:timer` → `[:states <state>...]`
+    (D1 minimum-viable: the parent state's source-coord chip; richer
+    per-`:after` coord is the D2 follow-on bead's surface)."
+  [{:keys [kind action-id guard-id phase source-state target-state event-id]
+    timer-state :state}]
+  (let [source-prefix (state-spec-path-prefix source-state)
+        target-prefix (state-spec-path-prefix target-state)
+        timer-prefix  (state-spec-path-prefix timer-state)]
+    (case kind
+      :action
+      (cond
+        ;; Named-handler path (keyword id) — definition-site stamp.
+        (keyword? action-id) [:actions action-id]
+        ;; Inline-fn path — slot stamp under the relevant state.
+        (contains? #{:entry :initial-entry} phase)
+        (when target-prefix (conj target-prefix :entry))
+        (contains? #{:exit :destroy-exit} phase)
+        (when source-prefix (conj source-prefix :exit))
+        (= :transition phase)
+        (when (and source-prefix event-id)
+          (conj source-prefix :on event-id :action))
+        (= :always phase)
+        (when source-prefix (conj source-prefix :always 0 :action))
+        (= :after-action phase)
+        (when source-prefix (conj source-prefix :after :action))
+        :else nil)
+
+      :guard
+      (cond
+        (keyword? guard-id) [:guards guard-id]
+        :else
+        (when (and source-prefix event-id)
+          (conj source-prefix :on event-id :guard)))
+
+      :transition
+      (when (and source-prefix event-id)
+        (conj source-prefix :on event-id))
+
+      :timer
+      ;; The row's `:state` is the cancelled state vector (substrate
+      ;; payload). D1 minimum-viable shape: point at the parent state's
+      ;; spec-path so the operator orients on the `:after`-bearing node.
+      (or timer-prefix source-prefix target-prefix)
+
+      nil)))
 
 (defn cascade-outcome-label
   "Render a cascade row's outcome for the view's outcome chip

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -1671,18 +1671,52 @@
       (when (and (map? c) (string? (:file c)) (seq (:file c)))
         {:file (:file c) :line (:line c)}))))
 
+(defn- machine-spec-from-meta
+  "Lift the machine spec map from a `handler-meta` lookup return. The
+  registrar stores the spec under `:rf/machine` (the wrapper shape); the
+  legacy `:machine-spec` / `:rf.machine/spec` keys are fallbacks for
+  fixture-emitted shapes used in unit tests."
+  [machine-meta]
+  (or (:rf/machine machine-meta)
+      (:machine-spec machine-meta)
+      (:rf.machine/spec machine-meta)
+      machine-meta))
+
 (defn- cascade-row-source-form
-  "Lift the source form (a CLJS fn literal or sugar form) for a cascade
-  row's action/guard from the registered machine spec (rf2-u69j7).
-  The form lives in the spec map at `[:actions <id>]` / `[:guards
-  <id>]`. Returns nil for kinds without a definition site
-  (`:transition`, `:timer`)."
+  "Lift the source form for a cascade row from the registered machine
+  spec (rf2-u69j7 baseline + rf2-wwc3j inline-fn extensions). The form
+  resolves at `cascade-row-source-key`'s spec-path tuple:
+
+  - Named guard/action rows: `[:guards <id>]` / `[:actions <id>]`.
+    Prefer the captured PR-STR source string under
+    `:rf.machine/handler-source` (rf2-ypu5i; macro stamps source strings
+    at compile time). Falls back to the runtime value at the spec path
+    (a compiled fn object) when no source-string was captured (production
+    builds, fixture fn-form machines).
+  - Inline-fn `:entry` / `:exit` / `:guard` / `:action` rows: the spec
+    path returns the runtime value at that slot — a compiled fn object
+    or, when the user wrote a keyword reference (`:entry :enter-a`),
+    that keyword (the caller's render path will dispatch on shape).
+  - Transition rows: the spec path returns the transition map literal
+    (a renderable EDN map).
+  - Timer rows: the spec path returns the entire state-node map (the
+    `:after`-bearing node); too verbose to render verbatim, so the
+    caller elides the body and renders only the click-to-source chip.
+
+  Returns nil for rows whose source-key is nil (no spec-path could be
+  derived — e.g. transition rows with no `:event-id`)."
   [machine-meta row]
   (when-let [k (proj/cascade-row-source-key row)]
-    (let [spec (or (:rf/machine machine-meta)
-                   (:machine-spec machine-meta)
-                   (:rf.machine/spec machine-meta))]
-      (get-in spec k))))
+    (let [spec        (machine-spec-from-meta machine-meta)
+          ;; rf2-ypu5i — named-handler source-string preferred for
+          ;; `[:actions <id>]` / `[:guards <id>]`. The macro stamps
+          ;; pr-str strings under `:rf.machine/handler-source` so the
+          ;; render is real source text, not a fn-object pr-str.
+          named-src   (case (and (= 2 (count k)) (first k))
+                        :actions (get-in spec [:rf.machine/handler-source :actions (second k)])
+                        :guards  (get-in spec [:rf.machine/handler-source :guards  (second k)])
+                        nil)]
+      (or named-src (get-in spec k)))))
 
 (defn- cascade-outcome-chip
   "Render the outcome chip for a cascade row (rf2-u69j7). Pulls glyph
@@ -1770,43 +1804,71 @@
               :style cascade-verb-plain-style}
        verb-string])))
 
-(defn- cascade-row-source-body
-  "Render the source code body for a cascade row (rf2-u69j7). Always
-  visible per the bead body's 'interleaved source code' requirement —
-  the operator reads what ran AND its code at the same vertical
-  position without scrolling.
+(defn- source-form->string
+  "Coerce a cascade-row source-form value into a printable Clojure
+  source string for `edn/code-block`. Per rf2-wwc3j the source-form may
+  arrive in one of several shapes:
 
-  - For `:action` / `:guard` rows that resolve a source form (via
-    `cascade-row-source-form` reading the registered machine spec),
-    render the form through the canonical `edn/code-block` widget
-    (the same widget the HANDLER step uses).
+  - String — already a captured pr-str (rf2-ypu5i `:rf.machine/handler-
+    source` value). Return as-is.
+  - Keyword — the user wrote a named-ref slot (`:entry :enter-a`).
+    Render the keyword form; downstream the named-id slot's own row
+    carries the body proper.
+  - Map (the transition map literal or a state-node) — pr-str renders
+    the EDN.
+  - Anything else (a compiled fn object) — fall back to pr-str. In
+    production CLJS builds this surfaces a `#object[...]` token; the
+    operator can still pivot to the click-to-source affordance.
+
+  Returns nil for nil input so the caller can render the source-missing
+  placeholder."
+  [source-form]
+  (cond
+    (nil? source-form) nil
+    (string? source-form) source-form
+    :else (pr-str source-form)))
+
+(defn- cascade-row-source-body
+  "Render the source code body for a cascade row (rf2-u69j7 baseline +
+  rf2-wwc3j inline-fn extensions). Always visible per the bead body's
+  'interleaved source code' requirement — the operator reads what ran
+  AND its code at the same vertical position without scrolling.
+
+  - `:action` / `:guard` rows: render the captured source form (named-
+    handler pr-str string OR inline-fn slot value) through the
+    canonical `edn/code-block` widget.
+  - `:transition` rows (rf2-wwc3j): render the transition map literal
+    (renderable EDN). This is the bead's 'delight shape' for the
+    transition cascade — the operator reads the `{:target :guard
+    :action}` form inline.
+  - `:timer` rows: no body (the spec value at the parent state path is
+    a verbose state-node map; the click-to-source chip on the verb is
+    the primary affordance).
   - When no source form is captured (production builds with
-    `goog.DEBUG=false`, fixture machines that pre-date the
-    source-coord stamping pass), render a muted placeholder so the
-    operator sees the slot consistently.
-  - `:transition` / `:timer` rows have no definition site — they ARE
-    the substrate's chrome, not user code. The body slot elides for
-    those kinds.
+    `goog.DEBUG=false`, fixture machines that pre-date the source-
+    coord stamping pass), render a muted placeholder so the operator
+    sees the slot consistently.
 
   rf2-66wis / rf2-93jp0 — `edn/code-block` paints clojure-syntax
   tokens with the same per-token palette as the Figma authority's
   `.syntax-*` classes, so the cascade code body matches the HANDLER
   step's source body."
   [row source-form]
-  (when (contains? #{:action :guard} (:kind row))
-    [:div {:data-testid (str "rf-xray-epoch-machine-cascade-source-"
-                             (:step row))
-           :style cascade-row-source-style}
-     (if (some? source-form)
-       (edn/code-block
-         {:source (pr-str source-form)
-          :lang   :clojure
-          :testid (str "rf-xray-epoch-machine-cascade-source-body-"
-                       (:step row))})
-       [:span {:data-testid (str "rf-xray-epoch-machine-cascade-source-missing-"
-                                 (:step row))
-               :style cascade-row-source-missing-style}
-        "<source not yet captured>"])]))
+  (when (contains? #{:action :guard :transition} (:kind row))
+    (let [src-str (source-form->string source-form)]
+      [:div {:data-testid (str "rf-xray-epoch-machine-cascade-source-"
+                               (:step row))
+             :style cascade-row-source-style}
+       (if (some? src-str)
+         (edn/code-block
+           {:source src-str
+            :lang   :clojure
+            :testid (str "rf-xray-epoch-machine-cascade-source-body-"
+                         (:step row))})
+         [:span {:data-testid (str "rf-xray-epoch-machine-cascade-source-missing-"
+                                   (:step row))
+                 :style cascade-row-source-missing-style}
+          "<source not yet captured>"])])))
 
 (defn- cascade-row-action-outcome-details
   "Render the per-action outcome details for an `:action` cascade row

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -657,7 +657,7 @@
 
 (deftest cascade-row-source-key-test
   (testing "rf2-u69j7 — `cascade-row-source-key` returns the spec-path
-            tuple for source-coord lookup"
+            tuple for source-coord lookup (named cases)"
     (is (= [:actions :open-socket]
            (proj/cascade-row-source-key
              {:kind :action :action-id :open-socket})))
@@ -665,9 +665,168 @@
            (proj/cascade-row-source-key
              {:kind :guard :guard-id :ready?})))
     (is (nil? (proj/cascade-row-source-key {:kind :transition}))
-        "transitions have no definition site → nil")
+        "transitions with no state/event context → nil")
     (is (nil? (proj/cascade-row-source-key {:kind :timer}))
-        "timers have no definition site → nil")))
+        "timers with no state context → nil")))
+
+;; ---- rf2-wwc3j — inline-fn / transition / timer source-key extensions -----
+
+(deftest cascade-row-source-key-inline-entry-action-test
+  (testing "rf2-wwc3j — inline-fn `:entry` action resolves to its
+            target-state's `[:states <s> :entry]` slot"
+    (let [inline-fn (fn [_] {})]
+      (is (= [:states :connected :entry]
+             (proj/cascade-row-source-key
+               {:kind :action :action-id inline-fn :phase :entry
+                :target-state :connected}))
+          "flat machine: entry action under target-state slot")
+      (is (= [:states :connected :entry]
+             (proj/cascade-row-source-key
+               {:kind :action :action-id inline-fn :phase :entry
+                :target-state [:connected]}))
+          "vector target-state coerces to the same path")
+      (is (= [:states :outer :states :inner :entry]
+             (proj/cascade-row-source-key
+               {:kind :action :action-id inline-fn :phase :entry
+                :target-state [:outer :inner]}))
+          "hierarchical target-state expands to nested :states path"))))
+
+(deftest cascade-row-source-key-inline-exit-action-test
+  (testing "rf2-wwc3j — inline-fn `:exit` action resolves to its
+            source-state's `[:states <s> :exit]` slot"
+    (let [inline-fn (fn [_] {})]
+      (is (= [:states :idle :exit]
+             (proj/cascade-row-source-key
+               {:kind :action :action-id inline-fn :phase :exit
+                :source-state :idle})))
+      (is (= [:states :idle :exit]
+             (proj/cascade-row-source-key
+               {:kind :action :action-id inline-fn :phase :destroy-exit
+                :source-state :idle}))
+          ":destroy-exit phase also maps to the :exit slot"))))
+
+(deftest cascade-row-source-key-inline-transition-action-test
+  (testing "rf2-wwc3j — inline-fn transition `:action` resolves to
+            `[:states <src> :on <event> :action]`"
+    (let [inline-fn (fn [_] {})]
+      (is (= [:states :idle :on :submit :action]
+             (proj/cascade-row-source-key
+               {:kind :action :action-id inline-fn :phase :transition
+                :source-state :idle :event-id :submit}))))))
+
+(deftest cascade-row-source-key-inline-guard-test
+  (testing "rf2-wwc3j — inline-fn `:guard` resolves to
+            `[:states <src> :on <event> :guard]`"
+    (let [inline-fn (fn [_] true)]
+      (is (= [:states :idle :on :submit :guard]
+             (proj/cascade-row-source-key
+               {:kind :guard :guard-id inline-fn
+                :source-state :idle :event-id :submit}))
+          "inline guard on a state's :on transition")
+      (is (nil? (proj/cascade-row-source-key
+                  {:kind :guard :guard-id inline-fn
+                   :source-state :idle}))
+          "missing event-id → nil (the source-key cannot be built)"))))
+
+(deftest cascade-row-source-key-transition-row-test
+  (testing "rf2-wwc3j — `:transition` row resolves to `[:states <src>
+            :on <event>]` so the click-through opens the transition map
+            literal in the spec"
+    (is (= [:states :idle :on :submit]
+           (proj/cascade-row-source-key
+             {:kind :transition :source-state :idle :event-id :submit})))
+    (is (= [:states :outer :states :inner :on :go]
+           (proj/cascade-row-source-key
+             {:kind :transition :source-state [:outer :inner]
+              :event-id :go}))
+        "hierarchical from-state expands to nested :states path")
+    (is (nil? (proj/cascade-row-source-key
+                {:kind :transition :source-state :idle}))
+        "missing event-id → nil")))
+
+(deftest cascade-row-source-key-timer-row-test
+  (testing "rf2-wwc3j — `:timer` row resolves to `[:states <state>]`
+            (D1 minimum-viable: parent state's source-coord chip)"
+    (is (= [:states :idle]
+           (proj/cascade-row-source-key
+             {:kind :timer :state :idle})))
+    (is (= [:states :idle]
+           (proj/cascade-row-source-key
+             {:kind :timer :state [:idle]})))
+    (is (nil? (proj/cascade-row-source-key {:kind :timer}))
+        "missing state → nil")))
+
+(deftest cascade-row-source-key-named-shadows-inline-test
+  (testing "rf2-wwc3j — a named action-id keyword always wins over the
+            inline derivation (the existing definition-site path covers
+            the named case end-to-end)"
+    (is (= [:actions :open-socket]
+           (proj/cascade-row-source-key
+             {:kind :action :action-id :open-socket :phase :entry
+              :target-state :connected}))
+        ":action-id keyword → definition-site path, ignores :phase / :target-state")
+    (is (= [:guards :ready?]
+           (proj/cascade-row-source-key
+             {:kind :guard :guard-id :ready? :source-state :idle
+              :event-id :submit}))
+        ":guard-id keyword → definition-site path, ignores :source-state / :event-id")))
+
+(deftest machine-cascade-rows-enriches-rows-with-states-test
+  (testing "rf2-wwc3j — `machine-cascade-rows` stamps `:source-state` /
+            `:target-state` / `:event-id` onto each non-transition row
+            from the surrounding transition emit so inline-fn source-
+            key lookup can resolve spec-path tuples"
+    (let [evs [(machine-guard-ev :ready? :pass)
+               (machine-action-ev :clear-buffer :exit :ok)
+               (machine-action-ev :open-socket :entry :ok)
+               (machine-transition-ev :ws/conn
+                                       {:state :idle :data {}}
+                                       {:state :connected :data {}}
+                                       [:ws/start] 0)]
+          rows (proj/machine-cascade-rows evs)]
+      (is (= :idle      (-> rows (nth 0) :source-state))
+          "guard row carries the source-state from the surrounding transition")
+      (is (= :connected (-> rows (nth 0) :target-state))
+          "guard row carries the target-state from the surrounding transition")
+      (is (= :ws/start  (-> rows (nth 0) :event-id))
+          "guard row carries the event-id (first elem of :event)")
+      (is (= :idle      (-> rows (nth 1) :source-state))
+          "exit-phase action carries source-state")
+      (is (= :connected (-> rows (nth 2) :target-state))
+          "entry-phase action carries target-state")
+      (is (= :idle      (-> rows (nth 3) :source-state))
+          "transition row stamps its own :source-state from :from-state")
+      (is (= :connected (-> rows (nth 3) :target-state))
+          "transition row stamps its own :target-state from :to-state"))))
+
+(deftest machine-cascade-rows-no-transition-leaves-state-slots-nil-test
+  (testing "rf2-wwc3j — when the cascade fires no transition row
+            (e.g. a guard-only failed cascade), state-slots remain nil"
+    (let [evs [(machine-guard-ev :ready? :fail)]
+          rows (proj/machine-cascade-rows evs)]
+      (is (nil? (:source-state (first rows)))
+          "no surrounding transition → no source-state stamp")
+      (is (nil? (:event-id (first rows)))))))
+
+(deftest state-spec-path-prefix-test
+  (testing "rf2-wwc3j — `state-spec-path-prefix` coerces a state form
+            into the spec-path prefix the macro's source-coord index uses"
+    (is (= [:states :idle]
+           (proj/state-spec-path-prefix :idle))
+        "flat keyword state → [:states <id>]")
+    (is (= [:states :idle]
+           (proj/state-spec-path-prefix [:idle]))
+        "1-element vector state → [:states <id>]")
+    (is (= [:states :outer :states :inner]
+           (proj/state-spec-path-prefix [:outer :inner]))
+        "hierarchical vector → nested :states prefix")
+    (is (= [:states :a :states :b :states :c]
+           (proj/state-spec-path-prefix [:a :b :c]))
+        "deep hierarchical vector → fully-nested :states prefix")
+    (is (nil? (proj/state-spec-path-prefix nil))
+        "nil state → nil")
+    (is (nil? (proj/state-spec-path-prefix []))
+        "empty vector → nil")))
 
 (deftest cascade-outcome-label-test
   (testing "rf2-u69j7 — `cascade-outcome-label` renders kind-specific

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -888,6 +888,124 @@
       (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-from-to-1"))
           "from → to state chrome renders"))))
 
+;; ---- rf2-wwc3j — inline-fn / transition source-body rendering ------------
+
+(deftest cascade-row-renders-inline-entry-source-body-test
+  (testing "rf2-wwc3j — an inline-fn `:entry` action row renders an
+            always-visible source-body the same way named actions do.
+            The fixture registers a machine with an inline `:entry`
+            slot; the row carries the resolved fn object as :action-id
+            (substrate behaviour); the view layer pulls the spec value
+            at `[:states <s> :entry]` via the rf2-wwc3j source-key
+            extension."
+    (rf/with-frame :rf/default
+      (let [inline-fn (fn [_ctx] {})]
+        (rf/reg-event-fx :rf2-wwc3j.view/inline-entry
+                         {:rf/machine? true
+                          :rf/machine {:initial :a
+                                       :states  {:a {:entry inline-fn
+                                                     :on    {:go :b}}
+                                                 :b {}}}}
+                         (fn [_ _] {}))
+        (let [step {:step :handler :badge :HANDLER :step-number 3
+                    :flavour :reg-machine
+                    :event-id :rf2-wwc3j.view/inline-entry
+                    :db-diff [] :fx []
+                    :machine {:cascade [{:kind :action :step 1
+                                         :action-id inline-fn
+                                         :phase :entry
+                                         :target-state :a
+                                         :source-state :a
+                                         :event-id :go}]
+                              :transition nil :guards [] :lifecycle [] :timers []}}
+              tree (view/render-handler-step step)]
+          (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-row-1"))
+              "inline-entry row renders")
+          (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-source-1"))
+              "source slot is present (rf2-wwc3j inline-fn surfacing)"))))))
+
+(deftest cascade-row-renders-inline-guard-source-body-test
+  (testing "rf2-wwc3j — an inline-fn `:guard` row renders a source-body
+            slot from the spec value at `[:states <s> :on <ev> :guard]`."
+    (rf/with-frame :rf/default
+      (let [inline-guard (fn [_ctx] true)]
+        (rf/reg-event-fx :rf2-wwc3j.view/inline-guard
+                         {:rf/machine? true
+                          :rf/machine {:initial :idle
+                                       :states  {:idle {:on {:submit {:target :done
+                                                                       :guard inline-guard}}}
+                                                 :done {}}}}
+                         (fn [_ _] {}))
+        (let [step {:step :handler :badge :HANDLER :step-number 3
+                    :flavour :reg-machine
+                    :event-id :rf2-wwc3j.view/inline-guard
+                    :db-diff [] :fx []
+                    :machine {:cascade [{:kind :guard :step 1
+                                         :guard-id inline-guard
+                                         :outcome :pass
+                                         :source-state :idle
+                                         :event-id :submit}]
+                              :transition nil :guards [] :lifecycle [] :timers []}}
+              tree (view/render-handler-step step)]
+          (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-row-1")))
+          (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-source-1"))
+              "inline-guard source slot is present"))))))
+
+(deftest cascade-transition-row-renders-source-body-test
+  (testing "rf2-wwc3j — a `:transition` row renders the transition map
+            literal as a source body (the bead's `:delight shape` for
+            transitions: render the EDN form inline)."
+    (rf/with-frame :rf/default
+      (rf/reg-event-fx :rf2-wwc3j.view/transition-row
+                       {:rf/machine? true
+                        :rf/machine {:initial :idle
+                                     :states  {:idle {:on {:go {:target :done}}}
+                                               :done {}}}}
+                       (fn [_ _] {}))
+      (let [step {:step :handler :badge :HANDLER :step-number 3
+                  :flavour :reg-machine
+                  :event-id :rf2-wwc3j.view/transition-row
+                  :db-diff [] :fx []
+                  :machine {:cascade [{:kind :transition :step 1
+                                       :machine-id :rf2-wwc3j.view/transition-row
+                                       :from-state :idle
+                                       :to-state   :done
+                                       :event [:go]
+                                       :source-state :idle
+                                       :target-state :done
+                                       :event-id :go
+                                       :microsteps 1}]
+                            :transition nil :guards [] :lifecycle [] :timers []}}
+            tree (view/render-handler-step step)]
+        (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-row-1")))
+        (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-source-1"))
+            "transition source slot is present (renders the transition map)")))))
+
+(deftest cascade-timer-row-elides-source-body-test
+  (testing "rf2-wwc3j — `:timer` rows render the click-to-source coord
+            chip on the verb but elide the inline source-body slot
+            (the parent state-node value is too verbose to render
+            verbatim)."
+    (rf/with-frame :rf/default
+      (rf/reg-event-fx :rf2-wwc3j.view/timer-row
+                       {:rf/machine? true
+                        :rf/machine {:initial :idle
+                                     :states  {:idle {:after {500 {:target :done}}}
+                                               :done {}}}}
+                       (fn [_ _] {}))
+      (let [step {:step :handler :badge :HANDLER :step-number 3
+                  :flavour :reg-machine
+                  :event-id :rf2-wwc3j.view/timer-row
+                  :db-diff [] :fx []
+                  :machine {:cascade [{:kind :timer :step 1
+                                       :state :idle :delay 500
+                                       :reason :on-exit}]
+                            :transition nil :guards [] :lifecycle [] :timers []}}
+            tree (view/render-handler-step step)]
+        (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-row-1")))
+        (is (nil? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-source-1"))
+            "timer rows have no inline source-body slot")))))
+
 (deftest machine-handler-cascade-empty-state-test
   (testing "rf2-u69j7 — empty cascade (no machine cascade events fired)
             renders the empty-state line rather than blowing up. This


### PR DESCRIPTION
Closes rf2-wwc3j. Extends rf2-u69j7's machine-cascade view to surface source for every cascade row kind/flavour, not just named guards + named actions.

## Per-row-kind source-surfacing coverage

| Row kind      | id flavour                | spec-path key                                         | source-body |
|---------------|---------------------------|-------------------------------------------------------|-------------|
| `:action`     | keyword `action-id`       | `[:actions <id>]`                                     | yes (named pr-str) |
| `:action`     | inline-fn, `:entry`       | `[:states <target>... :entry]`                        | yes (fn-form) |
| `:action`     | inline-fn, `:exit`        | `[:states <source>... :exit]`                         | yes (fn-form) |
| `:action`     | inline-fn, `:transition`  | `[:states <source>... :on <event> :action]`           | yes (fn-form) |
| `:guard`      | keyword `guard-id`        | `[:guards <id>]`                                      | yes (named pr-str) |
| `:guard`      | inline-fn                 | `[:states <source>... :on <event> :guard]`            | yes (fn-form) |
| `:transition` | —                         | `[:states <source>... :on <event>]`                   | yes (transition map) |
| `:timer`      | —                         | `[:states <state>...]` (D1 minimum-viable)            | no (verb chip only) |

## How

- `projection/cascade-row-source-key` dispatches on inline cases using `:source-state` / `:target-state` / `:event-id` slots.
- `projection/machine-cascade-rows` post-builds via new `enrich-cascade-rows` that stamps state/event slots by correlating each non-transition row with the surrounding `:rf.machine/transition` emit (substrate emits actions before the macrostep transition; the next transition ahead is the surrounding one).
- `view/cascade-row-source-form` prefers `:rf.machine/handler-source` (rf2-ypu5i pr-str strings) for definition-site paths; falls back to the spec value at the path for inline-fn / transition rows.
- `view/cascade-row-source-body` now renders for `:action` / `:guard` / `:transition` rows (timer rows elide).

## File inventory

- `tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc` — `cascade-row-source-key` extension; new `state-spec-path-prefix` / `enrich-cascade-rows`.
- `tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs` — `cascade-row-source-form` routes through `:rf.machine/handler-source` then spec value; `cascade-row-source-body` extends to `:transition`; new `source-form->string` coercion helper.
- `tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc` — 10 new tests, 31 new assertions (inline / transition / timer source-key dispatch; `enrich-cascade-rows` correlation; `state-spec-path-prefix` flat + hierarchical).
- `tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs` — 4 new tests (inline-entry / inline-guard / transition source-body rendering; timer-row body elision).
- `tools/xray/spec/021-Dynamic-Panel-Designs.md` — §9.1.5 updated: per-row-kind coverage table + `enrich-cascade-rows` correlation contract.

## Test deltas

- xray JVM tests: 941 → 951 (10 new), 3631 → 3662 assertions (31 new).
- CLJS tests: 4838 → 4848 (10 projection) → 4852 (4 view) baseline; post-rebase 4770 (main retired some).
- Bundle isolation: PASS (16 artefact entries; 33 sentinels absent; 3 budgets ok).
- Browser tests: 124 tests, 353 assertions, 0 failures.

## Compatibility

- **rf2-zlk6h**: no new inline styles — reuses hoisted `cascade-row-source-style` / `cascade-row-source-missing-style`.
- **rf2-atqkg**: `enrich-cascade-rows` uses `mapv` (eager) + explicit `loop`/`recur`; no lazy seqs around sub derefs.

## Follow-ons (out of scope for this bead)

- D2 (richer timer per-`:after` coord) — bead description leaves this deferrable; D1 minimum-viable (parent state-node coord chip) ships here.
- Substrate extension to `walk-machine-handler-source` to capture inline-fn pr-str strings under spec-path keys — would let inline-fn rows render real source text rather than fn-object pr-str. Worth filing as a follow-on substrate bead.