### PR TITLE
feat(xray): epoch-panel shape follow-ups (3 beads — rf2-dwuq3 + rf2-xnb1x + rf2-xgeag)

### DIFF
--- a/spec/010-Schemas.md
+++ b/spec/010-Schemas.md
@@ -209,6 +209,10 @@ Tools and agents read these to:
 - Generate JSON Schema or OpenAPI from registered schemas — useful for cross-platform contracts.
 - Diff schemas across versions to detect breaking shape changes in app-db structure.
 
+### Tooling surface — Xray attachment (rf2-xgeag)
+
+The Xray Epoch panel attaches each schema violation to its owning pipeline step rather than collecting them in a trailing footnote. The five runtime boundaries (`:event` / `:cofx` / `:app-db` / `:fx-args` / `:sub-return`) map onto DISPATCH / matching COEFFECT / HANDLER / matching FX row / matching SUBSCRIPTIONS row respectively; hot-reload drift (which has no owning cascade step) rides on a standalone SCHEMA HOT-RELOAD tail step. When an `:app-db` violation carries `:rollback? true`, every step downstream of HANDLER renders muted and the HANDLER step surfaces a "cascade rolled back — downstream effects skipped" banner so the operator reads the blast radius at a glance. See [tools/xray/spec/021-Dynamic-Panel-Designs.md §9.1.10.3 Violation attachment contract](../tools/xray/spec/021-Dynamic-Panel-Designs.md) for the cascade-side rendering details; the substrate-side contract (the two trace ops + their tag shapes) is unchanged.
+
 ## Per-slot metadata vocabulary
 
 Inside the schema value passed to `reg-app-schema`, individual slots may carry per-slot metadata maps — the `{...}` properties map Malli accepts on every slot. The reserved per-slot key vocabulary is catalogued normatively in [Spec-Schemas §`:rf/app-schema-meta`](Spec-Schemas.md#rfapp-schema-meta); the reserved set is fixed-and-additive. Today's reserved keys are `:large?`, `:hint`, and (reserved-for-future) `:sensitive?`.

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/theme/tokens.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/theme/tokens.cljc
@@ -110,6 +110,9 @@
    :dim            "#6e7681"
    :hover          "#2a2a2a"
 
+   ;; violation wash (rf2-xgeag · key parity mirror with Xray)
+   :bg-violation   "#3a1f25"
+
    ;; functional categorical hues (spec/022 carve-out)
    ;; Two pink/violet-family hues — see Xray's `dark-palette` block for
    ;; rationale. The drift gate (rf2-z7ms8) requires these to match Xray's
@@ -203,6 +206,9 @@
    :success        "#1a7f37"
    :dim            "#8c959f"
    :hover          "#e8e8e8"
+
+   ;; violation wash (rf2-xgeag · key parity mirror with Xray)
+   :bg-violation   "#fde0e3"
 
    ;; functional categorical hues
    ;; Two pink/violet-family hues — see Xray's `light-palette` block for

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1328,7 +1328,7 @@ Each step renders a uppercase badge pill at its numbered circle:
 | `:FX`                 | `:orange`        | functional amber (post-commit irreversible) |
 | `:SUBSCRIPTIONS`      | `:magenta-pink`  | pink (rf2-cgm4f split from COEFFECT violet) |
 | `:VIEWS`              | `:success`       | green |
-| `:SCHEMA-VIOLATIONS`  | `:warning`       | warning amber (rf2-17vxj) |
+| `:SCHEMA-HOT-RELOAD`  | `:warning`       | warning amber (rf2-17vxj · renamed rf2-xgeag for the narrowed hot-reload-only scope) |
 
 > **Retired 2026-05-26 (pair-debug, rf2-zkiu5):** the prior `:CHILD-DISPATCHES`
 > + `:APP-DB-DIFF` rows were dropped. CHILD DISPATCHES (originally rf2-yx1ae,
@@ -1691,10 +1691,16 @@ steps from the per-row chips, not the sum. The per-row chip + the
 per-row `▲` long-step warning are the cascade's complete timing
 surface.
 
-### §9.1.10.3 Schema-violations section (rf2-17vxj)
+### §9.1.10.3 Violation attachment contract (rf2-17vxj · rf2-xgeag)
 
-A SCHEMA VIOLATIONS step is appended to the cascade when the
-focused epoch's trace stream carried at least one of:
+> **Reshaped pair-debug 2026-05-27 (rf2-xgeag).** The trailing
+> aggregate SCHEMA VIOLATIONS step retired in favour of per-step
+> inline attachment. Each violation now renders as a pink-wash
+> sub-block INSIDE its owning pipeline step — the operator reads
+> the failing boundary alongside the work it failed on rather than
+> jumping to a trailing footnote.
+
+The substrate still emits the same two trace ops:
 
 - `:rf.error/schema-validation-failure` — runtime per-boundary
   validation failure (app-db commit / cofx / sub-return / fx-args /
@@ -1706,28 +1712,84 @@ focused epoch's trace stream carried at least one of:
   `:pre-reload-schema`, `:post-reload-schema`, `:mismatching-value`,
   `:recovery`, `:sensitive?`.
 
-Both ops project into the same row schema, with `:kind` flagging
-the source. Section chrome is warning-tone (`:warning` colour
-token + `▲` glyph) — load-bearing without rising to alarmist
-`:error` tone. Per-row body:
+Both ops project into the same row schema (`schema-violation-row` —
+unchanged); only the aggregation moved.
 
-- `:where` label (e.g. `app-db commit`, `sub return`, `hot-reload`).
-- `:failing-id` (the registered name whose boundary failed).
-- `:path` (when present).
-- failing value via `edn/inspect-inline` (already redacted at the
-  substrate emit site when the slot is `:sensitive?`).
-- `rolled back` chip when `:rollback?` is true.
-- `recovery: <reason>` chip when `:rollback?` is false (the
-  cascade ran through despite the violation).
-- `(value redacted — slot declared :sensitive?)` marker when the
-  substrate redacted the value.
+#### Attachment mapping (the new contract)
 
-Header carries the violation count + a per-rollback split + an
-`open issues →` affordance that dispatches `[:rf.xray/select-tab
-:issues]` so the operator can pivot to the Issues panel for
-cross-session triage.
+| `:where` slot | Owning pipeline step                                | Granularity              |
+|---------------|-----------------------------------------------------|--------------------------|
+| `:event`      | DISPATCH                                            | step-level               |
+| `:cofx`       | COEFFECT step whose `:id` = `:failing-id`           | step-level (per cofx)    |
+| `:app-db`     | HANDLER                                             | step-level               |
+| `:fx-args`    | FX step, row whose `:fx-id` = `:failing-id`         | row-level (fallback step)|
+| `:sub-return` | SUBSCRIPTIONS step, row whose `:sub-id` = `:failing-id` | row-level (fallback step) |
+| `:hot-reload` | standalone SCHEMA HOT-RELOAD tail step              | step-level               |
 
-Section is conditional — omitted when no violation events fired.
+The projection pass `attach-violations` walks the
+`schema-violation-rows` once and binds each row onto its owning
+step (or the step's matching row for FX / SUBSCRIPTIONS); step
+maps gain a `:violations` slot, row maps gain their own
+`:violations` slot. The view's per-step renderers inject
+`(violation-blocks step-key violations)` under their primary
+body. Hot-reload drift has no owning cascade step so it rides
+on a STANDALONE `SCHEMA HOT-RELOAD` tail step (Option A from the
+bead body; the badge is renamed from the retired
+`SCHEMA-VIOLATIONS` to flag the narrowed scope).
+
+#### Sub-block visual contract
+
+Each violation renders as a pink-wash card under its host step
+carrying:
+
+- Title row — `⚠ SCHEMA VIOLATION` (warning glyph + title in
+  warning colour) with a right-aligned recovery chip
+  (`rolled back` / `fx skipped` / `returned nil` /
+  `logged + skipped`).
+- Headline — `<where-label> · <failing-id>` (e.g. `app-db commit
+  · :counter/inc`).
+- `path:` row (when present).
+- `value:` row — failing value via `ei/mini` (already redacted
+  upstream when `:sensitive?`).
+- Click-to-source actions — `↗ open <failing-id>` opens the
+  failing-handler registration; `↗ open schema <failing-id>`
+  opens the `reg-app-schema` declaration. Both degrade gracefully
+  to muted plain-text when the framework hasn't stamped the coord.
+- Full explain map (via `ei/mini`) when the substrate stamped one.
+
+Background = `:bg-violation` palette token (soft-rose on light,
+deep-rose-muted on dark — distinct from `:magenta-pink`
+SUBSCRIPTIONS chrome and from the retired aggregate step's
+`:warning` amber). Border in `:warning` for cross-theme legibility.
+
+#### Rollback blast-radius mute
+
+When the cascade carries an `:app-db` violation with
+`:rollback? true`, the projection's
+`mark-rolled-back-downstream` pass flags every step AFTER the
+HANDLER with `:rolled-back? true`. The view's pipeline wrapper
+applies a `:opacity 0.55` overlay to those steps, and the
+HANDLER step renders a one-line banner reading "↓ cascade
+rolled back — downstream effects skipped" immediately under its
+body. The operator sees the blast radius at a glance instead of
+reading FX rows that claim success for fx that never actually
+fired.
+
+#### What does NOT change
+
+- Substrate trace op shapes (`:rf.error/schema-validation-failure`
+  + `:rf.schema/violation`) — same.
+- Per-row data projected from those ops (`schema-violation-row`
+  + `schema-violation-rows`) — same.
+- The Issues panel's cross-session list — same.
+- Spec 010 (Schemas) boundary contract — unchanged; the
+  cascade-side presentation changes, the underlying contract is
+  identical. See spec/010 §Tooling surface — Xray attachment for
+  the cross-reference.
+
+Sections / step are conditional — `:violations` slot is absent
+when no violation attached to that step; the SCHEMA HOT-RELOAD
+tail step is OMITTED when no hot-reload drift fired.
 
 ### §9.1.10.6 FX section header + per-action attribution (rf2-uffov · rf2-m8ac9)
 

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1778,6 +1778,36 @@ step with N rows" to "N steps, one per injected cofx" (see §9.1.3
   :trace-id` are filtered before splitting (rf2-cq0ch). A cascade
   with no surviving user-cofx renders zero COEFFECT steps.
 
+### §9.1.10.8 FLOW step chrome (rf2-xnb1x · pair-debug 2026-05-27)
+
+The FLOW step was restructured from "one step with N rows" to
+"N steps, one per flow that recomputed", mirroring the COEFFECT
+per-cofx split (§9.1.10.7). The projection splats `flow-rows`
+into N first-class step maps in `project`'s cascade `concat`;
+each carries `:flow-id`, `:path`, `:before`, `:after`, and
+`:duration-ms` (when stamped). The aggregate `flow-step` defn
+retired with rf2-xnb1x.
+
+The accompanying view-layer chrome:
+
+- **Header** — `:FLOW` badge + flow-id button to the right of
+  the badge. The button is clickable when
+  `(rf/handler-meta :flow <id>)` returns a coordinate (click-to-source
+  jumps through the shared `:rf.xray/open-in-editor` allowlist —
+  see §9.1.11); otherwise the id renders as a plain coloured span.
+  An external-link glyph trails the id when source-jump is wired.
+- **Body** — `<glyph> [path] before → after` diff-style line,
+  left-aligned with the badge (no indent), reusing the COEFFECT
+  body styles (`coeffect-body-*`). Glyph is `~` for an update
+  (both before and after present) or `+` for a first-write (no
+  before). Values render through the edn-inspector `mini` widget.
+- **Verb dropped** — the prior `N flows recomputed` aggregate
+  verb is gone; the per-step expansion of flows makes the count
+  visible in the cascade numbering itself (operator scans left
+  rail; numbered circle count = flow count).
+- **Conditional emit unchanged** — a cascade with zero
+  `:rf.flow/computed` events renders zero FLOW steps.
+
 ### §9.1.10.5 App-db diff section — RETIRED 2026-05-26 (rf2-rrykz · rf2-zkiu5)
 
 > **Retired pair-debug 2026-05-26** in Mike's commit `ee9def224`. The

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1496,8 +1496,6 @@ trace.
 Per the bead body's §Visual Structure:
 
 - Container: padding `21px`, overflow auto, full height.
-- Header text: "The computational timeline for the event"
-  (muted, `margin-bottom: 21px`).
 - Pipeline: left margin `55px` to accommodate numbered circles.
 - Vertical line: absolute-positioned, 1px width, starts at `13px`
   from top, positioned at `-34px` from the content column's left
@@ -1666,7 +1664,7 @@ and silently rendered empty rows. The binding inventory:
 | `:views` | `:rf.view/rendered` (NOT the simpler `:rf.view/render` marker) | `:rf.view/id`, `:rf.view/deref-subs`, `:rf.view/elapsed-ms`, `:rf.view/mount?`, `:rf.view/triggered-by` (rf2-6djth aligned the read against the rich marker) |
 | `:views` unmounted (rf2-gmw1i) | `:rf.view/unmounted` (already emitted by `re-frame.views/emit-view-unmounted!` per rf2-9hoos + rf2-te71r) | `:rf.view/id`, `:rf.view/render-key`, `:frame`. Surfaced via `projection/unmounted-views-rows`; the VIEWS step carries an optional `:unmounted-rows` slot (omit-by-absence when none fired). The step renders an UNMOUNTED sub-section when populated and reads `N re-rendered; M unmounted` in its header. |
 
-### §9.1.10.2 Per-step elapsed time + cascade total (rf2-nqt3d)
+### §9.1.10.2 Per-step elapsed time (rf2-nqt3d · rf2-dwuq3)
 
 Each step row carries `:duration-ms` (a number when the substrate
 stamped it; nil otherwise). The view paints it as a right-aligned
@@ -1674,27 +1672,24 @@ monospace chip on every step's header — pure-data via
 `projection/format-duration-ms`, which formats `0.1ms` / `12ms` /
 `1.2s` per scale.
 
-Pure-data aggregations layered on top of the projected step vector
-drive the cascade-level chrome:
+Per-row predicate driving long-step chrome:
 
 | Helper | Returns | Used for |
 |--------|---------|----------|
-| `projection/cascade-total-ms steps` | number (sum of `:duration-ms`) or nil | top-of-cascade summary chip total |
 | `projection/long-step? step` | boolean (`:duration-ms > 16ms`) | per-step warning chrome |
-| `projection/long-step-count steps` | integer | summary chip secondary count |
 
 `projection/long-step-threshold-ms` is **16ms** — one display frame
 at 60Hz, the natural marker for "this single step will visibly
 jank the next paint". Crossing the threshold paints the chip in the
-warning tone with a `▲` glyph; the cascade-summary chip surfaces a
-secondary `N over 16ms` count when any step is long. Below
-threshold the chip is muted with no glyph — alarmist `✗` chrome
-would crowd the cascade on the common case where one step is
-naturally heavy.
+warning tone with a `▲` glyph. Below threshold the chip is muted
+with no glyph — alarmist `✗` chrome would crowd the cascade on the
+common case where one step is naturally heavy.
 
-The summary chip elides when no step carries a numeric duration
-(cold-start records, fixtures synthesised without timing); the
-cascade renders normally.
+The top-of-pipeline `cascade total: <N>ms` summary chip was
+retired post-rf2-nqt3d (rf2-dwuq3) — the operator reads heavy
+steps from the per-row chips, not the sum. The per-row chip + the
+per-row `▲` long-step warning are the cascade's complete timing
+surface.
 
 ### §9.1.10.3 Schema-violations section (rf2-17vxj)
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/badge.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/badge.cljc
@@ -76,8 +76,11 @@
   HANDLER + FLOW share `:accent` — the Figma export's single-accent
   identity (rf2-ad7zx.13).
 
-  rf2-17vxj — SCHEMA-VIOLATIONS pulls `:warning` so the section
-  reads as load-bearing without rising to `:error`'s alarmist tone.
+  rf2-17vxj — SCHEMA-VIOLATIONS pulled `:warning` for the aggregate
+  trailing step. rf2-xgeag retired the aggregate; the per-step
+  violation sub-block lives inline now. Hot-reload drift carries
+  on a standalone SCHEMA-HOT-RELOAD tail step (same `:warning`
+  token; renamed badge to flag the narrowed scope).
   rf2-yx1ae — CHILD-DISPATCHES pulls `:text-tertiary` (the same muted
   grey as DISPATCH — same hue family, same cascade-link semantics).
   rf2-rrykz — APP-DB-DIFF pulls `:accent` (the same blue as HANDLER /
@@ -89,7 +92,7 @@
    :FX                :orange
    :SUBSCRIPTIONS     :magenta-pink
    :VIEWS             :success
-   :SCHEMA-VIOLATIONS :warning
+   :SCHEMA-HOT-RELOAD :warning
    :CHILD-DISPATCHES  :text-tertiary
    :APP-DB-DIFF       :accent})
 
@@ -103,7 +106,7 @@
    :FX                ":fx"
    :SUBSCRIPTIONS     "SUBSCRIPTIONS"
    :VIEWS             "VIEWS"
-   :SCHEMA-VIOLATIONS "SCHEMA VIOLATIONS"
+   :SCHEMA-HOT-RELOAD "SCHEMA HOT-RELOAD"
    :CHILD-DISPATCHES  "DISPATCHED EVENTS"
    :APP-DB-DIFF       "APP-DB DIFF"})
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/icons.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/icons.cljc
@@ -54,33 +54,12 @@
   []
   corner-down-right-svg)
 
-;; ---- Warning triangle ---------------------------------------------------
-
-(def ^:private alert-triangle-svg
-  "Lucide `alert-triangle` icon as a hiccup-shaped svg. 13×13
-  square, `viewBox 0 0 24 24`, `stroke: currentColor`. Used by the
-  SCHEMA-VIOLATIONS section header (rf2-17vxj) to signal warning
-  chrome without rising to the alarmist `:error` tone of an `✗`."
-  [:svg {:width            "13"
-         :height           "13"
-         :viewBox          "0 0 24 24"
-         :fill             "none"
-         :stroke           "currentColor"
-         :stroke-width     "2"
-         :stroke-linecap   "round"
-         :stroke-linejoin  "round"
-         :aria-hidden      "true"
-         :focusable        "false"}
-   [:path {:d "M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z"}]
-   [:line {:x1 "12" :y1 "9"  :x2 "12" :y2 "13"}]
-   [:line {:x1 "12" :y1 "17" :x2 "12.01" :y2 "17"}]])
-
-(defn alert-triangle
-  "Render the lucide `alert-triangle` glyph (rf2-17vxj). Inherits
-  colour from the enclosing element via `currentColor` so the
-  glyph rides the warning-tone section header."
-  []
-  alert-triangle-svg)
+;; ---- Warning triangle (retired with rf2-xgeag) --------------------------
+;;
+;; The `alert-triangle` SVG was used by the now-retired aggregate
+;; SCHEMA-VIOLATIONS step's header (rf2-17vxj). With rf2-xgeag's
+;; inline sub-block + tail-step shape the title row uses the Unicode
+;; `⚠` glyph inline; no SVG required.
 
 ;; ---- Arrow right (cascade-link) -----------------------------------------
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -1099,18 +1099,184 @@
           :when (contains? schema-violation-ops (op ev))]
       (schema-violation-row ev))))
 
-(defn schema-violations-step
-  "Build the SCHEMA-VIOLATIONS step row, or nil when no violations
-  fired (the step is OMITTED — conditional). Header carries the
-  total count + a per-rollback split so the operator can tell at a
-  glance whether the cascade was REJECTED by the validator."
-  [events]
-  (let [rows (schema-violation-rows events)]
-    (when (seq rows)
-      {:step      :schema-violations
-       :badge     :SCHEMA-VIOLATIONS
-       :rows      rows
-       :rollbacks (count (filter :rollback? rows))})))
+;; rf2-xgeag — the trailing SCHEMA-VIOLATIONS aggregate step retired
+;; pair-debug 2026-05-27. Violations now attach to their owning
+;; pipeline step via `attach-violations`; hot-reload drift (no
+;; owning cascade step) rides on a standalone `:schema-hot-reload`
+;; step. The per-row data (`schema-violation-rows`) is unchanged —
+;; only the aggregation + view shape moved.
+
+;; Per the attachment mapping in the rf2-xgeag bead body:
+;;
+;;   :where slot    | owning step
+;;   ---------------|-----------------------------------------------
+;;   :event         | DISPATCH (one step)
+;;   :cofx          | COEFFECT step matching :failing-id against :id
+;;   :app-db        | HANDLER (the step's HEADER, surfaces above :db)
+;;   :fx-args       | FX step (row-level :fx-id match)
+;;   :sub-return    | SUBSCRIPTIONS step (row-level :sub-id match)
+;;   :hot-reload    | standalone :schema-hot-reload step (Option A)
+
+(defn- attach-step-violation
+  "Append `row` to `step`'s `:violations` vec when `step` is non-nil."
+  [step row]
+  (when step
+    (update step :violations (fnil conj []) row)))
+
+(defn- attach-row-violation
+  "Update `row`'s `:violations` vec, appending `violation`."
+  [row violation]
+  (update row :violations (fnil conj []) violation))
+
+(defn- attach-to-fx-row
+  "When `step` is the FX step + the violation's `:failing-id` matches
+  an `fx-id` in the step's `:rows`, attach the violation to that
+  row's `:violations` vec. Otherwise attach to the step-level
+  `:violations`. Returns the updated step."
+  [step row]
+  (let [fx-id (:failing-id row)]
+    (if (some #(= fx-id (:fx-id %)) (:rows step))
+      (update step :rows
+              (fn [rows]
+                (mapv (fn [r]
+                        (if (= fx-id (:fx-id r))
+                          (attach-row-violation r row)
+                          r))
+                      rows)))
+      (attach-step-violation step row))))
+
+(defn- attach-to-sub-row
+  "When `step` is the SUBSCRIPTIONS step + the violation's `:failing-id`
+  matches a `sub-id` in the step's `:rows`, attach to that row.
+  Otherwise attach to the step-level `:violations` (per the bead's
+  edge case: indirect recompute outside the cascade's surfaced rows)."
+  [step row]
+  (let [sub-id (:failing-id row)]
+    (if (some #(= sub-id (:sub-id %)) (:rows step))
+      (update step :rows
+              (fn [rows]
+                (mapv (fn [r]
+                        (if (= sub-id (:sub-id r))
+                          (attach-row-violation r row)
+                          r))
+                      rows)))
+      (attach-step-violation step row))))
+
+(defn- index-of
+  "First index in `coll` for which `pred` is truthy, or nil."
+  [pred coll]
+  (first (keep-indexed (fn [i x] (when (pred x) i)) coll)))
+
+(defn attach-violations
+  "Take a projected step vector + a vec of schema-violation rows (post-
+  `schema-violation-rows`) and return the step vector with each
+  violation attached to its owning step (per the rf2-xgeag
+  attachment mapping). Returns `steps` unchanged when `rows` is
+  empty.
+
+  The hot-reload subset is NOT attached here — those violations have
+  no owning cascade step and ride a standalone SCHEMA-HOT-RELOAD
+  step appended via `hot-reload-step`."
+  [steps rows]
+  (if (empty? rows)
+    steps
+    (reduce
+      (fn [s row]
+        (case (:where row)
+          :event
+          (let [i (index-of #(= :dispatch (:step %)) s)]
+            (if i
+              (update s i attach-step-violation row)
+              s))
+
+          :cofx
+          (let [fid (:failing-id row)
+                i   (index-of #(and (= :coeffect (:step %))
+                                    (= fid (:id %))) s)]
+            (if i
+              (update s i attach-step-violation row)
+              ;; Fallback: attach to the FIRST COEFFECT step so the
+              ;; violation still surfaces (the operator at least
+              ;; sees it nested in the cofx region of the cascade
+              ;; rather than disappearing).
+              (if-let [j (index-of #(= :coeffect (:step %)) s)]
+                (update s j attach-step-violation row)
+                s)))
+
+          :app-db
+          (let [i (index-of #(= :handler (:step %)) s)]
+            (if i
+              (update s i attach-step-violation row)
+              s))
+
+          :fx-args
+          (let [i (index-of #(= :fx (:step %)) s)]
+            (if i
+              (update s i attach-to-fx-row row)
+              s))
+
+          :sub-return
+          (let [i (index-of #(= :subscriptions (:step %)) s)]
+            (if i
+              (update s i attach-to-sub-row row)
+              s))
+
+          ;; hot-reload + unknowns: untouched here; ride the
+          ;; standalone hot-reload step.
+          s))
+      steps
+      (remove #(= :hot-reload (:where %)) rows))))
+
+(defn hot-reload-step
+  "Build the standalone SCHEMA-HOT-RELOAD step from the hot-reload-
+  subset of `schema-violation-rows`. Returns nil when no hot-reload
+  drift fired (the step is OMITTED — conditional). Option A from
+  the rf2-xgeag bead body: hot-reload violations have no owning
+  cascade step so they ride at the END of the cascade rather than
+  attaching to a pipeline step they don't belong to.
+
+  The step carries the SAME `:schema-hot-reload` step keyword + a
+  dedicated `:SCHEMA-HOT-RELOAD` badge, NOT the retired
+  `:SCHEMA-VIOLATIONS` aggregate badge."
+  [rows]
+  (let [hot (filterv #(= :hot-reload (:where %)) rows)]
+    (when (seq hot)
+      {:step  :schema-hot-reload
+       :badge :SCHEMA-HOT-RELOAD
+       :rows  hot})))
+
+(defn cascade-rolled-back?
+  "True iff any `:app-db` schema violation in `rows` carries
+  `:rollback? true`. The view layer reads this off the cascade
+  context to visually mute every step DOWNSTREAM of the rollback
+  point (FX / SUBSCRIPTIONS / VIEWS) so the operator reads 'the
+  rest of this cascade didn't really run' at a glance."
+  [rows]
+  (boolean
+    (some (fn [r]
+            (and (= :app-db (:where r))
+                 (true? (:rollback? r))))
+          rows)))
+
+(defn mark-rolled-back-downstream
+  "When the cascade carries an `:app-db` rollback violation, mark
+  every step downstream of the HANDLER (FX / SUBSCRIPTIONS / VIEWS /
+  any standalone hot-reload tail) with `:rolled-back? true`. The
+  view paints those steps with mute chrome + a 'cascade rolled
+  back here ↓' indicator at the rollback point. Pure fn over the
+  step vector."
+  [steps rows]
+  (if (cascade-rolled-back? rows)
+    (let [handler-idx (index-of #(= :handler (:step %)) steps)]
+      (if (number? handler-idx)
+        (vec
+          (map-indexed (fn [i step]
+                         (if (> i handler-idx)
+                           (assoc step :rolled-back? true)
+                           step))
+                       steps))
+        steps))
+    steps))
 
 ;; ---- APP-DB DIFF step — REMOVED pair-debug 2026-05-26 --------------------
 ;;
@@ -1325,7 +1491,8 @@
                                  (some? duration-ms)
                                  (assoc :duration-ms duration-ms)))
                              (flow-rows events))
-            steps     (vec
+            violations (schema-violation-rows events)
+            base-steps (vec
                         (concat
                           [(dispatch-row events fallback)]
                           cofx-steps
@@ -1342,12 +1509,16 @@
                            ;; `:dispatch-n` / `:dispatch-later` fx entry.
                            (subscriptions-step events)
                            (views-step events)
-                           ;; rf2-17vxj — schema violations ride at the end of
-                           ;; the cascade so the operator sees the boundary
-                           ;; check that may have rolled back THIS cascade
-                           ;; AFTER reading the steps that drove it.
-                           (schema-violations-step events)]))]
-        (filterv some? steps)))))
+                           ;; rf2-xgeag — hot-reload drift rides on a
+                           ;; standalone tail step (Option A). All
+                           ;; OTHER violations attach to their owning
+                           ;; pipeline step via `attach-violations`
+                           ;; below.
+                           (hot-reload-step violations)]))
+            present    (filterv some? base-steps)
+            attached   (attach-violations present violations)
+            steps      (mark-rolled-back-downstream attached violations)]
+        steps))))
 
 (defn number-steps
   "Stamp each step with a sequential `:step-number` (1..N). The view
@@ -1638,11 +1809,14 @@
   - rf2-17vxj: + SCHEMA-VIOLATIONS (warning chrome, conditional).
   - rf2-yx1ae: + CHILD-DISPATCHES (cascade-link section, conditional).
   - rf2-rrykz: + APP-DB-DIFF (state-mutation lens, conditional).
+  - rf2-xgeag: SCHEMA-VIOLATIONS retired (violations attach to owning
+    pipeline step inline); + SCHEMA-HOT-RELOAD for the hot-reload-only
+    standalone tail step (drift has no owning cascade step).
 
   The view's badge resolver bails to `:text-tertiary` on an unknown
   badge, so adding to this set is purely additive."
   #{:DISPATCH :COEFFECT :HANDLER :FLOW :FX :SUBSCRIPTIONS :VIEWS
-    :SCHEMA-VIOLATIONS :CHILD-DISPATCHES :APP-DB-DIFF})
+    :SCHEMA-HOT-RELOAD :CHILD-DISPATCHES :APP-DB-DIFF})
 
 (defn valid-badge?
   "Predicate — `:badge` keyword is a member of `badge-set`."

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -750,16 +750,13 @@
          :after       (common/tag-of ev :result)
          :duration-ms (common/tag-of ev :elapsed-ms)}))))
 
-(defn flow-step
-  "Top-level FLOW step (single row carrying the flow-rows). nil when no
-  flows fired (the step is OMITTED from the cascade — conditional
-  rendering per the bead body)."
-  [events]
-  (let [rows (flow-rows events)]
-    (when (seq rows)
-      {:step  :flow
-       :badge :FLOW
-       :rows  rows})))
+;; rf2-xnb1x — FLOW is splatted into ONE step per flow that fired
+;; (mirror of the COEFFECT per-cofx split). Each step map carries the
+;; row's slots directly; the cascade reads the count of FLOW steps
+;; the same way it reads the count of COEFFECT steps — one numbered
+;; circle per first-class entry. The `flow-step` aggregate retired
+;; with rf2-xnb1x; the splicing in `project` consumes `flow-rows`
+;; directly.
 
 ;; ---- FX step -------------------------------------------------------------
 
@@ -1311,28 +1308,45 @@
                                  (some? duration-ms)
                                  (assoc :duration-ms duration-ms)))
                              cofx-rows)
+            ;; rf2-xnb1x — one FLOW step per flow that fired (mirror
+            ;; of the cofx-steps splat above). The operator counts
+            ;; flows by counting numbered circles in the cascade
+            ;; rather than counting rows inside a single aggregate
+            ;; step. `flow-rows` projection (per-row data) is
+            ;; unchanged; the aggregation shape was the only thing
+            ;; that changed.
+            flow-steps (mapv (fn [{:keys [flow-id path before after duration-ms]}]
+                               (cond-> {:step    :flow
+                                        :badge   :FLOW
+                                        :flow-id flow-id
+                                        :path    path
+                                        :before  before
+                                        :after   after}
+                                 (some? duration-ms)
+                                 (assoc :duration-ms duration-ms)))
+                             (flow-rows events))
             steps     (vec
                         (concat
                           [(dispatch-row events fallback)]
                           cofx-steps
-                          [(handler-row events event-id db-before db-after)
-                       ;; APP-DB DIFF removed pair-debug 2026-05-26 —
-                       ;; redundant with the HANDLER step's `:db`
-                       ;; sub-section's [diff][all] toggle which
-                       ;; surfaces the same data IN-context.
-                       (flow-step events)
-                       (fx-step events)
-                       ;; CHILD DISPATCHES step removed pair-debug
-                       ;; 2026-05-26 — redundant with the FX step which
-                       ;; already surfaces each `:dispatch` /
-                       ;; `:dispatch-n` / `:dispatch-later` fx entry.
-                       (subscriptions-step events)
-                       (views-step events)
-                       ;; rf2-17vxj — schema violations ride at the end of
-                       ;; the cascade so the operator sees the boundary
-                       ;; check that may have rolled back THIS cascade
-                       ;; AFTER reading the steps that drove it.
-                       (schema-violations-step events)]))]
+                          [(handler-row events event-id db-before db-after)]
+                          ;; APP-DB DIFF removed pair-debug 2026-05-26 —
+                          ;; redundant with the HANDLER step's `:db`
+                          ;; sub-section's [diff][all] toggle which
+                          ;; surfaces the same data IN-context.
+                          flow-steps
+                          [(fx-step events)
+                           ;; CHILD DISPATCHES step removed pair-debug
+                           ;; 2026-05-26 — redundant with the FX step which
+                           ;; already surfaces each `:dispatch` /
+                           ;; `:dispatch-n` / `:dispatch-later` fx entry.
+                           (subscriptions-step events)
+                           (views-step events)
+                           ;; rf2-17vxj — schema violations ride at the end of
+                           ;; the cascade so the operator sees the boundary
+                           ;; check that may have rolled back THIS cascade
+                           ;; AFTER reading the steps that drove it.
+                           (schema-violations-step events)]))]
         (filterv some? steps)))))
 
 (defn number-steps

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -1391,28 +1391,6 @@
   (let [ms (:duration-ms step)]
     (and (number? ms) (> ms long-step-threshold-ms))))
 
-(defn cascade-total-ms
-  "Sum of every step's `:duration-ms` over the projected step vector,
-  or nil when no step carries a numeric duration. Pure aggregation;
-  the view renders this in the cascade-summary chip at the top of
-  the panel.
-
-  Per rf2-nqt3d the summary is the operator's first read — the
-  cascade total tells them whether to even start drilling per-step.
-  Returns a number (so the chip can format via
-  `format-duration-ms`)."
-  [steps]
-  (let [nums (keep :duration-ms steps)]
-    (when (seq nums)
-      (reduce + 0 nums))))
-
-(defn long-step-count
-  "Count of projected steps whose `:duration-ms` exceeds the long-step
-  threshold. Drives the cascade-summary's secondary chip
-  (`N step over 16ms`)."
-  [steps]
-  (count (filter long-step? steps)))
-
 (defn event-display
   "Render the dispatched event vector as a one-line monospace string
   for the DISPATCH row's target slot."

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -93,6 +93,7 @@
 (def ^:private bg-1-colour         (:bg-1            tokens))
 (def ^:private bg-2-colour         (:bg-2            tokens))
 (def ^:private bg-3-colour         (:bg-3            tokens))
+(def ^:private bg-violation-colour (:bg-violation    tokens))
 (def ^:private border-subtle-colour  (:border-subtle  tokens))
 (def ^:private border-default-colour (:border-default tokens))
 
@@ -939,97 +940,131 @@
 (def ^:private unmounted-id-span-style
   disposed-id-span-style)
 
-;; -- SCHEMA VIOLATIONS ----------------------------------------------------
+;; -- SCHEMA VIOLATION sub-block (rf2-xgeag) -------------------------------
+;;
+;; Pink-wash sub-block that rides INSIDE its owning pipeline step's
+;; body. The aggregate trailing SCHEMA-VIOLATIONS step retired with
+;; rf2-xgeag in favour of this attached shape — the operator reads
+;; the failing boundary inline with the work it failed on. Hot-reload
+;; drift still rides a standalone tail step (no owning cascade step
+;; exists); see `render-schema-hot-reload-step`.
 
-(def ^:private schema-violation-row-style
+(def ^:private schema-violation-block-style
   {:display        "flex"
    :flex-direction "column"
-   :gap            "3px"
-   :padding        "5px 8px"
-   :background     bg-3-colour
-   :border-left    (str "2px solid " warning-colour)
-   :margin-bottom  "5px"
-   :border-radius  "0 3px 3px 0"
+   :gap            "5px"
+   :padding        "8px 10px"
+   :margin         "5px 0"
+   :background     bg-violation-colour
+   :border         (str "1px solid " warning-colour)
+   :border-radius  "3px"
    :font-family    mono-stack
    :font-size      "12px"})
 
-(def ^:private schema-violation-head-style
+(def ^:private schema-violation-title-style
   {:display     "flex"
    :align-items "center"
    :gap         "8px"
-   :flex-wrap   "wrap"})
-
-(def ^:private schema-violation-where-style
-  {:color          warning-colour
-   :font-weight    700
+   :color       warning-colour
+   :font-weight 700
+   :font-size   "11px"
    :text-transform "uppercase"
-   :font-size      "10px"
    :letter-spacing "0.5px"})
 
-(def ^:private schema-violation-id-style
+(def ^:private schema-violation-title-spacer-style
+  {:flex 1})
+
+(def ^:private schema-violation-recovery-chip-style
+  {:padding        "2px 6px"
+   :border-radius  "3px"
+   :background     bg-3-colour
+   :color          text-secondary-colour
+   :font-size      "10px"
+   :font-weight    600
+   :text-transform "lowercase"
+   :letter-spacing "0.3px"})
+
+(def ^:private schema-violation-rollback-chip-style
+  (assoc schema-violation-recovery-chip-style
+         :background error-colour
+         :color      white-colour
+         :text-transform "uppercase"))
+
+(def ^:private schema-violation-headline-style
+  {:color       text-primary-colour
+   :font-weight 600})
+
+(def ^:private schema-violation-headline-id-style
   {:color accent-colour})
 
-(def ^:private schema-violation-rollback-style
-  {:padding        "2px 5px"
-   :border-radius  "3px"
-   :background     error-colour
-   :color          white-colour
-   :font-size      "10px"
-   :font-weight    700
-   :text-transform "uppercase"
-   :letter-spacing "0.5px"})
+(def ^:private schema-violation-line-style
+  {:display "flex" :gap "8px" :align-items "baseline"})
 
-(def ^:private schema-violation-recovery-style
-  {:color      text-tertiary-colour
-   :font-size  "10px"
-   :font-style "italic"})
+(def ^:private schema-violation-line-label-style
+  {:color       text-tertiary-colour
+   :min-width   "65px"
+   :font-size   "11px"})
 
-(def ^:private schema-violation-path-style
-  {:color text-tertiary-colour :padding-left "16px"})
-
-(def ^:private schema-violation-value-style
-  {:color        text-primary-colour
-   :padding-left "16px"
-   :word-break   "break-word"})
+(def ^:private schema-violation-line-value-style
+  {:color      text-primary-colour
+   :word-break "break-word"})
 
 (def ^:private schema-violation-sensitive-style
-  {:color        text-tertiary-colour
-   :font-style   "italic"
-   :font-size    "10px"
-   :padding-left "16px"})
+  {:color      text-tertiary-colour
+   :font-style "italic"
+   :font-size  "10px"})
 
-(def ^:private schema-violation-explain-style
-  {:color        text-secondary-colour
-   :padding-left "16px"
-   :font-size    "11px"})
+(def ^:private schema-violation-action-link-style
+  {:background    "transparent"
+   :border        "none"
+   :padding       0
+   :margin        0
+   :color         accent-colour
+   :cursor        "pointer"
+   :font-family   mono-stack
+   :font-size     "11px"
+   :display       "inline-flex"
+   :align-items   "center"
+   :gap           "4px"
+   :text-align    "left"})
 
-(def ^:private schema-violations-verb-style
-  {:display     "inline-flex"
-   :align-items "center"
-   :gap         "8px"
+(def ^:private schema-violation-actions-style
+  {:display     "flex"
+   :gap         "16px"
    :flex-wrap   "wrap"})
 
-(def ^:private schema-violations-count-style
-  {:display     "inline-flex"
+(def ^:private schema-violation-explain-toggle-style
+  {:background  "transparent"
+   :border      "none"
+   :padding     0
+   :margin      0
+   :color       text-tertiary-colour
+   :cursor      "pointer"
+   :font-family mono-stack
+   :font-size   "11px"
+   :text-align  "left"})
+
+(def ^:private schema-violation-explain-body-style
+  {:color text-secondary-colour
+   :font-size "11px"
+   :background bg-2-colour
+   :border border-subtle-1px
+   :border-radius "3px"
+   :padding "6px 8px"})
+
+(def ^:private rolled-back-mute-style
+  {:opacity 0.55})
+
+(def ^:private rolled-back-banner-style
+  {:display     "flex"
    :align-items "center"
-   :gap         "4px"
-   :color       warning-colour})
-
-(def ^:private schema-violations-rollback-count-style
-  {:color error-colour :font-weight 700})
-
-(def ^:private schema-violations-open-issues-style
-  {:background     "transparent"
-   :border         border-default-1px
-   :border-radius  "3px"
-   :color          text-secondary-colour
-   :cursor         "pointer"
-   :font-family    sans-stack
-   :font-size      "10px"
-   :padding        "2px 8px"
-   :margin-left    "8px"
-   :text-transform "uppercase"
-   :letter-spacing "0.5px"})
+   :gap         "8px"
+   :margin-top  "5px"
+   :padding     "4px 8px"
+   :color       error-colour
+   :font-family sans-stack
+   :font-size   "11px"
+   :font-style  "italic"})
 
 ;; -- CHILD DISPATCHES -----------------------------------------------------
 
@@ -1199,6 +1234,15 @@
                             badge-pill-text-overlay))}
      label]))
 
+;; rf2-xgeag — violation sub-block + rolled-back banner are defined
+;; further down the file (in the §SCHEMA VIOLATION sub-block section)
+;; but each step renderer above attaches a `(violation-blocks ...)`
+;; sub-block to its body. Forward-declared here so the namespace
+;; compiles in source order without warnings.
+(declare violation-blocks)
+(declare violation-block)
+(declare rolled-back-banner)
+
 (defn- numbered-circle
   "Render the numbered circle — 21px diameter, painted in the step's
   badge colour with white numerals. Positioned absolutely at -44px
@@ -1363,7 +1407,7 @@
   text otherwise. The external-link icon rides INSIDE the button
   as a secondary cue so the affordance reads as a single labelled
   link rather than a label-with-trailing-icon."
-  [{:keys [source coord duration-ms step-number] :as step}]
+  [{:keys [source coord duration-ms step-number violations] :as step}]
   [:div {:data-testid "rf-xray-epoch-step-dispatch"
          :data-step-kw "dispatch"}
    (numbered-circle step-number :DISPATCH)
@@ -1377,7 +1421,9 @@
       :testid "rf-xray-epoch-dispatch"
       :duration-ms duration-ms}
      nil)
-   (dispatch-body step)])
+   (dispatch-body step)
+   ;; rf2-xgeag — `:event` boundary violations attach to DISPATCH.
+   (violation-blocks :dispatch violations)])
 
 ;; ---- COEFFECT step -------------------------------------------------------
 
@@ -1449,7 +1495,7 @@
   injecting N user-defined cofx; system-injected cofx (e.g.
   framework-auto `:db`, `:event`) are filtered at projection time
   (rf2-cq0ch + the `system-cofx-ids` set)."
-  [{:keys [id value step-number]}]
+  [{:keys [id value step-number violations]}]
   (let [cofx-meta  (when (keyword? id)
                      (try (rf/handler-meta :cofx id)
                           (catch :default _ nil)))
@@ -1502,7 +1548,10 @@
       [:span {:style coeffect-body-path-style}
        (str "[" (proj/ns-keyword id) "]")]
       [:span {:style coeffect-body-value-style}
-       [ei/mini value 80]]]]))
+       [ei/mini value 80]]]
+     ;; rf2-xgeag — `:cofx` boundary violations attach to the matching
+     ;; COEFFECT step by cofx-id.
+     (violation-blocks :coeffect violations)]))
 
 ;; ---- HANDLER step --------------------------------------------------------
 
@@ -2314,21 +2363,32 @@
   2026-05-26: the verb (reg-event-db / reg-event-fx / reg-event-ctx
   / reg-machine flavour label) is the click-to-source hyperlink;
   the event-id is NOT repeated in the HANDLER line because the
-  DISPATCH step's header already names it."
-  [{:keys [flavour event-id duration-ms step-number] :as step}]
-  [:div {:data-testid "rf-xray-epoch-step-handler"
-         :data-step-kw "handler"
-         :data-handler-flavour (when flavour (name flavour))}
-   (numbered-circle step-number :HANDLER)
-   (step-header
-     {:step :handler
-      :badge :HANDLER
-      :verb (handler-verb-link flavour event-id)
-      :expandable? false
-      :testid "rf-xray-epoch-handler"
-      :duration-ms duration-ms}
-     nil)
-   (handler-body step)])
+  DISPATCH step's header already names it.
+
+  rf2-xgeag — `:app-db` boundary violations attach here as pink
+  sub-blocks (the handler is what wrote the bad app-db); when any
+  carries `:rollback? true` the downstream cascade gets muted via
+  the projection's `mark-rolled-back-downstream` pass."
+  [{:keys [flavour event-id duration-ms step-number violations]
+    :as step}]
+  (let [rolled-back? (boolean (some :rollback? violations))]
+    [:div {:data-testid "rf-xray-epoch-step-handler"
+           :data-step-kw "handler"
+           :data-handler-flavour (when flavour (name flavour))
+           :data-rolled-back (str rolled-back?)}
+     (numbered-circle step-number :HANDLER)
+     (step-header
+       {:step :handler
+        :badge :HANDLER
+        :verb (handler-verb-link flavour event-id)
+        :expandable? false
+        :testid "rf-xray-epoch-handler"
+        :duration-ms duration-ms}
+       nil)
+     (handler-body step)
+     (violation-blocks :handler violations)
+     (when rolled-back?
+       (rolled-back-banner))]))
 
 ;; ---- FLOW step -----------------------------------------------------------
 
@@ -2456,6 +2516,17 @@
           [:span {:style fx-row-attribution-phase-style}
            (str "(" (name phase) ")")])])]))
 
+(defn- fx-row-with-violations
+  "Render one fx row + any violations attached to that row (rf2-xgeag).
+  Per-row attachment matches when the projection's `attach-to-fx-row`
+  resolved the violation's `:failing-id` against an `fx-id` in the
+  FX step's `:rows`."
+  [idx row]
+  [:div {:key (str "fx-row-" idx)
+         :data-testid (str "rf-xray-epoch-fx-row-wrapper-" idx)}
+   (fx-row-view idx row)
+   (violation-blocks (keyword (str "fx-row-" idx)) (:violations row))])
+
 (defn render-fx-step
   "Render the FX step (only present when fx-handlers fired).
 
@@ -2463,8 +2534,13 @@
   succeeded, K threw)` is dropped — the row glyphs (✓/✗) already
   convey per-fx outcome; the count summary is noise in the
   step header. Threw-count surfaces as a chip only if non-zero so
-  the operator still sees errors at-a-glance."
-  [{:keys [rows step-number threw]}]
+  the operator still sees errors at-a-glance.
+
+  rf2-xgeag — `:fx-args` boundary violations attach per-row when
+  `:failing-id` matches an fx-id; otherwise they attach to the
+  step-level `:violations` slot (rendered at the foot of the
+  step)."
+  [{:keys [rows step-number threw violations]}]
   (let [k (or threw 0)]
     [:div {:data-testid "rf-xray-epoch-step-fx"
            :data-step-kw "fx"
@@ -2484,7 +2560,8 @@
         :testid "rf-xray-epoch-fx"}
        nil)
      [:div {:style margin-top-5-style}
-      (map-indexed fx-row-view rows)]]))
+      (map-indexed fx-row-with-violations rows)]
+     (violation-blocks :fx violations)]))
 
 ;; ---- SUBSCRIPTIONS step --------------------------------------------------
 
@@ -2649,7 +2726,7 @@
   `with-frame :rf/xray` envelope (matches the HANDLER `[diff][all]`
   toggle pattern). Both halves are anchored so toggle writes + reads
   hit the same app-db regardless of host frame-provider."
-  [{:keys [rows disposed-rows step-number]}]
+  [{:keys [rows disposed-rows step-number violations]}]
   (let [mode          @(rf/subscribe :rf/xray
                                      [:rf.xray.epoch/subs-filter-mode])
         visible-rows  (case mode
@@ -2660,7 +2737,8 @@
                         ;; renders an empty filter.
                         (filterv :changed? rows))
         n             (count rows)
-        l             (count disposed-rows)]
+        l             (count disposed-rows)
+        per-row-vio   (filter (fn [r] (seq (:violations r))) rows)]
     [:div {:data-testid "rf-xray-epoch-step-subscriptions"
            :data-step-kw "subscriptions"}
      (numbered-circle step-number :SUBSCRIPTIONS)
@@ -2684,7 +2762,16 @@
      (when (pos? n)
        (subscriptions-table visible-rows))
      (when (pos? l)
-       (disposed-subs-table disposed-rows))]))
+       (disposed-subs-table disposed-rows))
+     ;; rf2-xgeag — `:sub-return` boundary violations. Per-row
+     ;; attachments are rendered below their matching sub row;
+     ;; step-level violations (indirect recomputes that don't
+     ;; surface a row) ride at the foot.
+     (for [row per-row-vio]
+       (violation-blocks
+         (keyword (str "sub-row-" (some-> row :sub-id name)))
+         (:violations row)))
+     (violation-blocks :subscriptions violations)]))
 
 ;; ---- VIEWS step ----------------------------------------------------------
 
@@ -2825,11 +2912,17 @@
      (when (pos? m)
        (unmounted-views-table unmounted-rows))]))
 
-;; ---- SCHEMA-VIOLATIONS step (rf2-17vxj) ----------------------------------
+;; ---- SCHEMA VIOLATION sub-block (rf2-xgeag) -----------------------------
+;;
+;; The violation sub-block rides INSIDE its owning pipeline step's
+;; body. Each step renderer (DISPATCH / COEFFECT / HANDLER / FX /
+;; SUBSCRIPTIONS) injects `(violation-blocks (:violations step))`
+;; under its primary body; FX / SUBSCRIPTIONS additionally inject
+;; per-row blocks via the row's own `:violations` slot.
 
 (defn- schema-violation-where-label
-  "Render a violation's `:where` slot as a UI label (rf2-17vxj). Closed
-  set is per Spec 008 / 010; defaults to the keyword name."
+  "Render a violation's `:where` slot as a UI label. Closed set per
+  Spec 008 / 010; defaults to the keyword name."
   [where]
   (case where
     :app-db      "app-db commit"
@@ -2840,102 +2933,195 @@
     :hot-reload  "schema hot-reload"
     (when (keyword? where) (name where))))
 
-(defn- schema-violation-row-view
-  "Render one schema-violation row (rf2-17vxj). Per-row fields:
+(defn- violation-recovery-label
+  "Render the recovery posture chip on a violation's title bar."
+  [where rollback? recovery]
+  (cond
+    rollback?              "rolled back"
+    (= where :fx-args)     "fx skipped"
+    (= where :sub-return)  "returned nil"
+    (= where :hot-reload)  "logged + skipped"
+    (keyword? recovery)    (name recovery)
+    :else                  nil))
 
-    - `:where` label
-    - `:failing-id` / `:frame` (the registered name whose boundary failed)
-    - `:path` (the db / payload path, when available)
-    - failing value via `edn/inspect-inline` (already redacted at the
-      substrate emit site when `:sensitive?`)
-    - `:rollback?` chip when the cascade was rejected"
-  [idx {:keys [where failing-id path value rollback? recovery sensitive?
-               kind explain] :as _row}]
-  [:div {:key (str "schema-violation-" idx)
-         :data-testid (str "rf-xray-epoch-schema-violation-row-" idx)
-         :data-violation-kind (when kind (name kind))
-         :data-rollback (str (boolean rollback?))
-         :style schema-violation-row-style}
-   ;; head row: where + failing-id + rollback chip
-   [:div {:style schema-violation-head-style}
-    [:span {:data-testid (str "rf-xray-epoch-schema-violation-where-" idx)
-            :style schema-violation-where-style}
-     (schema-violation-where-label where)]
-    (when failing-id
-      [:span {:data-testid (str "rf-xray-epoch-schema-violation-id-" idx)
-              :style schema-violation-id-style}
-       (proj/ns-keyword failing-id)])
-    (when rollback?
-      [:span {:data-testid (str "rf-xray-epoch-schema-violation-rollback-" idx)
-              :title "this cascade was rolled back"
-              :style schema-violation-rollback-style}
-       "rolled back"])
-    (when (and recovery (not rollback?))
-      [:span {:style schema-violation-recovery-style}
-       (str "recovery: " (name recovery))])]
-   ;; path (when present)
-   (when (sequential? path)
-     [:div {:data-testid (str "rf-xray-epoch-schema-violation-path-" idx)
-            :style schema-violation-path-style}
-      (proj/path-display path)])
-   ;; failing value
-   (when (some? value)
-     [:div {:data-testid (str "rf-xray-epoch-schema-violation-value-" idx)
-            :style schema-violation-value-style}
-      (edn/inspect-inline value)])
-   ;; sensitive marker (the substrate already redacted; surface that the
-   ;; value WAS redacted so the operator doesn't read the placeholder
-   ;; as the actual failing value)
-   (when sensitive?
-     [:div {:style schema-violation-sensitive-style}
-      "(value redacted — slot declared :sensitive?)"])
-   ;; explain detail (Malli explain map, when stamped) — rf2-8w8er
-   ;; routes through `mini` so the explain map's keyword keys + value
-   ;; tokens carry syntax-token chrome rather than plain pr-str text.
-   (when (some? explain)
-     [:div {:data-testid (str "rf-xray-epoch-schema-violation-explain-" idx)
-            :style schema-violation-explain-style}
-      [ei/mini explain 120]])])
+(defn- violation-open-source-action
+  "Click-to-source button. `coord` is `{:file :line}` or nil; when
+  nil renders a muted plain-text fallback (graceful degrade — the
+  framework may not yet stamp coords for some surfaces)."
+  [{:keys [label coord testid]}]
+  (if (and (map? coord) (string? (:file coord)) (seq (:file coord)))
+    [:button {:data-testid testid
+              :aria-label  (str "open " (:file coord)
+                                (when (:line coord)
+                                  (str ":" (:line coord)))
+                                " in editor")
+              :title       (str "open " (:file coord)
+                                (when (:line coord)
+                                  (str ":" (:line coord)))
+                                " in editor")
+              :on-click    (fn [e]
+                             (.stopPropagation e)
+                             (rf/dispatch [:rf.xray/open-in-editor
+                                           {:source-coord coord}]
+                                          {:frame :rf/xray}))
+              :style schema-violation-action-link-style}
+     (icons/external-link)
+     label]
+    [:span {:data-testid testid
+            :style (assoc schema-violation-action-link-style
+                          :color text-tertiary-colour
+                          :cursor "default")}
+     label]))
 
-(defn render-schema-violations-step
-  "Render the SCHEMA VIOLATIONS step (rf2-17vxj — only present when
-  the cascade carried `:rf.error/schema-validation-failure` or
-  `:rf.schema/violation` trace events).
+(defn- violation-kind-coord
+  "Resolve a `(rf/handler-meta <kind> <id>)` coord, returning
+  `{:file :line}` or nil. Catches CLJS errors so missing kinds /
+  ids never bubble; rendering must degrade gracefully."
+  [kind id]
+  (when (keyword? id)
+    (let [m (try (rf/handler-meta kind id)
+                 (catch :default _ nil))]
+      (when (and m (string? (:file m)))
+        {:file (:file m) :line (:line m)}))))
 
-  Header carries the violation count + a per-rollback split + a
-  click-affordance that navigates to the Issues panel for full
-  triage (the per-row data shows the cascade-local view; Issues
-  holds the cross-session list)."
-  [{:keys [rows rollbacks step-number]}]
-  [:div {:data-testid "rf-xray-epoch-step-schema-violations"
-         :data-step-kw "schema-violations"
-         :data-rollback-count (str (or rollbacks 0))}
-   (numbered-circle step-number :SCHEMA-VIOLATIONS)
+(defn- where->handler-kind
+  "Map a violation's `:where` slot to the registrar kind whose
+  source-coord we want to open. nil for slots with no canonical kind."
+  [where]
+  (case where
+    :event       :event
+    :cofx        :cofx
+    :app-db      :event   ;; the event handler that wrote the bad app-db
+    :fx-args     :fx
+    :sub-return  :sub
+    nil))
+
+(defn violation-block
+  "Render one schema-violation sub-block (rf2-xgeag). Pink-wash card
+  carrying:
+
+    - Title (⚠ SCHEMA VIOLATION) + right-aligned recovery chip
+    - Headline (`<where-label> · <failing-id>`)
+    - Path (when present)
+    - Failing value (already redacted upstream when `:sensitive?`)
+    - Two click-to-source links (failing handler + schema name)
+    - Full-explain map (rendered inline via `ei/mini`)"
+  [step-key idx {:keys [where failing-id path value sensitive?
+                        rollback? recovery explain kind] :as _row}]
+  (let [where-label    (schema-violation-where-label where)
+        recovery-label (violation-recovery-label where rollback? recovery)
+        handler-kind   (where->handler-kind where)
+        handler-coord  (when handler-kind
+                         (violation-kind-coord handler-kind failing-id))
+        schema-coord   (violation-kind-coord :schema failing-id)
+        testid-base    (str "rf-xray-epoch-violation-" (name (or step-key :unknown)) "-" idx)]
+    [:div {:key (str "violation-" step-key "-" idx)
+           :data-testid testid-base
+           :data-violation-where (when where (name where))
+           :data-violation-kind (when kind (name kind))
+           :data-rollback (str (boolean rollback?))
+           :style schema-violation-block-style}
+     ;; Title bar
+     [:div {:style schema-violation-title-style}
+      [:span {:aria-hidden true} "⚠"]
+      [:span {:data-testid (str testid-base "-title")} "SCHEMA VIOLATION"]
+      [:span {:style schema-violation-title-spacer-style}]
+      (when recovery-label
+        [:span {:data-testid (str testid-base "-recovery")
+                :style (if rollback?
+                         schema-violation-rollback-chip-style
+                         schema-violation-recovery-chip-style)}
+         recovery-label])]
+     ;; Headline
+     [:div {:data-testid (str testid-base "-headline")
+            :style schema-violation-headline-style}
+      where-label
+      (when failing-id
+        [:<>
+         [:span " · "]
+         [:span {:style schema-violation-headline-id-style}
+          (proj/ns-keyword failing-id)]])]
+     ;; Path
+     (when (sequential? path)
+       [:div {:data-testid (str testid-base "-path")
+              :style schema-violation-line-style}
+        [:span {:style schema-violation-line-label-style} "path:"]
+        [:span {:style schema-violation-line-value-style}
+         (proj/path-display path)]])
+     ;; Failing value
+     (when (some? value)
+       [:div {:data-testid (str testid-base "-value")
+              :style schema-violation-line-style}
+        [:span {:style schema-violation-line-label-style} "value:"]
+        [:span {:style schema-violation-line-value-style}
+         [ei/mini value 80]]])
+     ;; Sensitive marker
+     (when sensitive?
+       [:div {:style schema-violation-sensitive-style}
+        "(value redacted — slot declared :sensitive?)"])
+     ;; Click-to-source actions
+     (when (or handler-kind schema-coord)
+       [:div {:style schema-violation-actions-style}
+        (when handler-kind
+          (violation-open-source-action
+            {:label  (str "open " (when failing-id (proj/ns-keyword failing-id)))
+             :coord  handler-coord
+             :testid (str testid-base "-open-handler")}))
+        (when (some? failing-id)
+          (violation-open-source-action
+            {:label  (str "open schema " (proj/ns-keyword failing-id))
+             :coord  schema-coord
+             :testid (str testid-base "-open-schema")}))])
+     ;; Full explain map
+     (when (some? explain)
+       [:div {:data-testid (str testid-base "-explain")
+              :style schema-violation-explain-body-style}
+        [ei/mini explain 120]])]))
+
+(defn violation-blocks
+  "Render every violation in `violations` as a sub-block inside the
+  current step's body. `step-key` is the owning step keyword (used
+  for stable test ids). nil-safe."
+  [step-key violations]
+  (when (seq violations)
+    [:div {:data-testid (str "rf-xray-epoch-violations-" (name step-key))}
+     (map-indexed (fn [i v] (violation-block step-key i v))
+                  violations)]))
+
+(defn- rolled-back-banner
+  "One-line banner shown immediately under the HANDLER step body
+  when the cascade is rolled-back, signposting the downstream-mute
+  treatment to the operator."
+  []
+  [:div {:data-testid "rf-xray-epoch-rolled-back-banner"
+         :style rolled-back-banner-style}
+   [:span {:aria-hidden true} "↓"]
+   "cascade rolled back — downstream effects skipped"])
+
+;; ---- SCHEMA HOT-RELOAD step (rf2-xgeag — was SCHEMA-VIOLATIONS) --------
+
+(defn render-schema-hot-reload-step
+  "Render the standalone SCHEMA HOT-RELOAD step (rf2-xgeag · Option A).
+  Carries ONLY hot-reload drift rows — those have no owning cascade
+  step so they ride at the END of the cascade. Each row renders as
+  a pink sub-block via `violation-block` for visual consistency
+  with the per-step attachments."
+  [{:keys [rows step-number]}]
+  [:div {:data-testid "rf-xray-epoch-step-schema-hot-reload"
+         :data-step-kw "schema-hot-reload"}
+   (numbered-circle step-number :SCHEMA-HOT-RELOAD)
    (step-header
-     {:step :schema-violations
-      :badge :SCHEMA-VIOLATIONS
-      :verb [:span {:style schema-violations-verb-style}
-             [:span {:style schema-violations-count-style}
-              (icons/alert-triangle)
-              (str (count rows) " violation"
-                   (when (not= 1 (count rows)) "s"))]
-             (when (pos? (or rollbacks 0))
-               [:span {:style schema-violations-rollback-count-style}
-                (str rollbacks " rollback"
-                     (when (not= 1 rollbacks) "s"))])
-             [:button {:data-testid "rf-xray-epoch-schema-violations-open-issues"
-                       :aria-label "open the Issues panel for full triage"
-                       :on-click (fn [e]
-                                   (.stopPropagation e)
-                                   (rf/dispatch [:rf.xray/select-tab :issues]
-                                                {:frame :rf/xray}))
-                       :style schema-violations-open-issues-style}
-              "open issues →"]]
+     {:step :schema-hot-reload
+      :badge :SCHEMA-HOT-RELOAD
+      :verb (str (count rows) " hot-reload drift"
+                 (when (not= 1 (count rows)) "s"))
       :expandable? false
-      :testid "rf-xray-epoch-schema-violations"}
+      :testid "rf-xray-epoch-schema-hot-reload"}
      nil)
    [:div {:style margin-top-5-style}
-    (map-indexed schema-violation-row-view rows)]])
+    (map-indexed (fn [i row]
+                   (violation-block :hot-reload i row))
+                 rows)]])
 
 ;; ---- APP-DB DIFF step — REMOVED pair-debug 2026-05-26 -------------------
 ;;
@@ -3040,8 +3226,10 @@
 (defn- render-step
   "Dispatch a step row to its renderer. Returns hiccup; nil for
   unknown step kinds (defensive — every step the projection produces
-  is in the canonical inventory; rf2-17vxj added SCHEMA-VIOLATIONS,
-  rf2-yx1ae added CHILD-DISPATCHES, rf2-rrykz added APP-DB-DIFF).
+  is in the canonical inventory; rf2-17vxj added SCHEMA-VIOLATIONS
+  later retired by rf2-xgeag in favour of inline attachment + a
+  hot-reload-only tail step; rf2-yx1ae added CHILD-DISPATCHES;
+  rf2-rrykz added APP-DB-DIFF).
 
   `ctx` carries the cascade-level pieces a row may need (e.g. the
   parent `:dispatch-id` + the `:epoch-history` slice for the
@@ -3056,7 +3244,7 @@
     :fx                (render-fx-step step)
     :subscriptions     (render-subscriptions-step step)
     :views             (render-views-step step)
-    :schema-violations (render-schema-violations-step step)
+    :schema-hot-reload (render-schema-hot-reload-step step)
     :child-dispatches  (render-child-dispatches-step step ctx)
     ;; :app-db-diff removed pair-debug 2026-05-26 — see comment above.
     nil))
@@ -3115,7 +3303,14 @@
          ^{:key (str "step-" (:step step) "-" i)}
          [:div {:data-testid (str "rf-xray-epoch-pipeline-step-" (:step-number step))
                 :data-step (when (:step step) (name (:step step)))
-                :style pipeline-step-style}
+                :data-rolled-back (str (boolean (:rolled-back? step)))
+                ;; rf2-xgeag — when an `:app-db` violation rolled back
+                ;; the cascade, every step downstream of HANDLER paints
+                ;; with mute chrome so the operator sees the blast
+                ;; radius at-a-glance.
+                :style (if (:rolled-back? step)
+                         (merge pipeline-step-style rolled-back-mute-style)
+                         pipeline-step-style)}
           (render-step step ctx)]))]]))
 
 ;; ---- empty states --------------------------------------------------------

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -1099,44 +1099,6 @@
    :font-size  "10px"
    :font-style "italic"})
 
-;; -- cascade-summary ------------------------------------------------------
-
-(def ^:private cascade-summary-style
-  {:display       "flex"
-   :align-items   "center"
-   :gap           "13px"
-   :margin-bottom "13px"
-   :padding       "5px 8px"
-   :border        border-subtle-1px
-   :border-radius "3px"
-   :background    bg-3-colour
-   :font-family   sans-stack
-   :font-size     "11px"
-   :color         text-secondary-colour})
-
-(def ^:private cascade-summary-label-style
-  {:color          text-tertiary-colour
-   :text-transform "uppercase"
-   :letter-spacing "0.5px"
-   :font-weight    600
-   :font-size      "10px"})
-
-(def ^:private cascade-summary-total-style
-  {:color       text-primary-colour
-   :font-family mono-stack
-   :font-weight 700})
-
-(def ^:private cascade-summary-long-style
-  {:color       warning-colour
-   :font-family mono-stack
-   :margin-left "auto"
-   :display     "inline-flex"
-   :align-items "center"
-   :gap         "4px"})
-
-(def ^:private cascade-summary-long-glyph-style
-  {:font-size "10px"})
-
 ;; -- pipeline -------------------------------------------------------------
 
 (def ^:private pipeline-host-style
@@ -1180,12 +1142,6 @@
 
 (def ^:private panel-scroll-style
   {:flex 1 :overflow "auto" :padding "21px"})
-
-(def ^:private panel-header-style
-  {:color         text-tertiary-colour
-   :font-family   sans-stack
-   :font-size     "11px"
-   :margin-bottom "21px"})
 
 ;; ---- expansion state helpers ---------------------------------------------
 ;;
@@ -3105,42 +3061,6 @@
 
 ;; ---- pipeline view -------------------------------------------------------
 
-(defn cascade-summary
-  "Render the cascade-summary chip at the top of the pipeline (rf2-nqt3d).
-
-  Two pieces of information:
-
-    1. **Cascade total** — sum of every projected step's `:duration-ms`,
-       formatted via `format-duration-ms`. Operator's first read —
-       'how heavy was this whole cascade'.
-    2. **Long-step count** — number of steps whose `:duration-ms`
-       exceeded `proj/long-step-threshold-ms` (16ms — one 60Hz frame).
-       Rendered with warning tone when > 0; absent when 0.
-
-  Returns nil when the cascade carries no durations (cold start
-  records, fixtures synthesised without timing). The view elides
-  the slot rather than rendering `total: —`."
-  [steps]
-  (let [total       (proj/cascade-total-ms steps)
-        long-count  (proj/long-step-count steps)]
-    (when (number? total)
-      [:div {:data-testid "rf-xray-epoch-cascade-summary"
-             :data-long-step-count (str long-count)
-             :style cascade-summary-style}
-       [:span {:style cascade-summary-label-style}
-        "cascade total"]
-       [:span {:data-testid "rf-xray-epoch-cascade-summary-total"
-               :style cascade-summary-total-style}
-        (proj/format-duration-ms total)]
-       (when (pos? long-count)
-         [:span {:data-testid "rf-xray-epoch-cascade-summary-long-count"
-                 :title       (str long-count " step"
-                                   (when (not= 1 long-count) "s")
-                                   " over " proj/long-step-threshold-ms "ms")
-                 :style cascade-summary-long-style}
-          [:span {:aria-hidden true :style cascade-summary-long-glyph-style} "▲"]
-          (str long-count " over " proj/long-step-threshold-ms "ms")])])))
-
 (defn pipeline-view
   "Render the numbered pipeline cascade for `steps` (already
   numbered via `project-numbered`). Each step renders as a
@@ -3165,10 +3085,6 @@
    (pipeline-view steps {}))
   ([steps ctx]
    [:div {:data-testid "rf-xray-epoch-pipeline-container"}
-    ;; rf2-nqt3d — cascade-summary chip rides above the numbered
-    ;; cascade. When the projection carries no durations the chip
-    ;; elides; the cascade still renders normally.
-    (cascade-summary steps)
     [:div {:data-testid "rf-xray-epoch-pipeline"
            :style pipeline-host-style}
      ;; The vertical rail — absolute-positioned line behind the
@@ -3229,9 +3145,6 @@
     [:section {:data-testid "rf-xray-epoch-panel"
                :style panel-root-style}
      [:div {:style panel-scroll-style}
-      [:div {:data-testid "rf-xray-epoch-panel-header"
-             :style panel-header-style}
-       "The computational timeline for the event"]
       (cond
         (= :focused status)
         (if (seq steps)

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -656,30 +656,9 @@
    :padding-left "16px"})
 
 ;; -- FLOW ------------------------------------------------------------------
-
-(def ^:private flow-row-style
-  {:padding "3px 0"})
-
-(def ^:private flow-row-id-style
-  {:display     "inline-flex"
-   :gap         "4px"
-   :font-family mono-stack
-   :font-size   "12px"
-   :color       accent-colour})
-
-(def ^:private flow-row-duration-style
-  {:color text-tertiary-colour :margin-left "8px"})
-
-(def ^:private flow-row-path-style
-  {:display     "flex"
-   :align-items "flex-start"
-   :gap         "8px"
-   :padding     "2px 0 2px 21px"
-   :font-family mono-stack
-   :font-size   "12px"})
-
-(def ^:private flow-row-warning-glyph-style
-  {:color warning-colour :font-weight 700})
+;;
+;; rf2-xnb1x — FLOW steps reuse the COEFFECT body styles (coeffect-body-*).
+;; The legacy per-row flow styles retired with the aggregate step shape.
 
 ;; -- FX --------------------------------------------------------------------
 
@@ -2353,52 +2332,76 @@
 
 ;; ---- FLOW step -----------------------------------------------------------
 
-(defn- flow-row-view
-  "Render one flow recompute row — id link + diff-style line.
-
-  Argument order matches `map-indexed`'s `(f idx item)` convention
-  (rf2-cq0ch — companion swap with `coeffect-row-view` / `fx-row-view`)."
-  [idx {:keys [flow-id path before after duration-ms]}]
-  [:div {:key (str "flow-" idx)
-         :data-testid (str "rf-xray-epoch-flow-row-" idx)
-         :style flow-row-style}
-   [:div {:style flow-row-id-style}
-    (proj/ns-keyword flow-id)
-    (icons/external-link)
-    (when (number? duration-ms)
-      [:span {:style flow-row-duration-style}
-       (proj/format-duration-ms duration-ms)])]
-   (when (sequential? path)
-     [:div {:style flow-row-path-style}
-      [:span {:style flow-row-warning-glyph-style} "~"]
-      [:span {:style cascade-detail-label-style}
-       (proj/path-display path)]
-      ;; rf2-8w8er — before/after render through the edn-inspector
-      ;; `mini` widget so per-token syntax chrome paints (numbers
-      ;; orange, keywords magenta, sentinels chip).
-      (when (some? before)
-        [:span {:style diff-before-style} [ei/mini before 30]])
-      (when (and (some? before) (some? after))
-        [:span {:style cascade-detail-label-style} "→"])
-      (when (some? after)
-        [:span {:style diff-after-success-style} [ei/mini after 30]])])])
-
 (defn render-flow-step
-  "Render the FLOW step (only present when flows fired)."
-  [{:keys [rows step-number]}]
-  [:div {:data-testid "rf-xray-epoch-step-flow"
-         :data-step-kw "flow"}
-   (numbered-circle step-number :FLOW)
-   (step-header
-     {:step :flow
-      :badge :FLOW
-      :verb (str (count rows) " flow"
-                 (when (not= 1 (count rows)) "s") " recomputed")
-      :expandable? false
-      :testid "rf-xray-epoch-flow"}
-     nil)
-   [:div {:style margin-top-5-style}
-    (map-indexed flow-row-view rows)]])
+  "Render one FLOW step — one PER flow that fired (rf2-xnb1x — mirror
+  of the COEFFECT per-cofx restructure from pair-debug 2026-05-26).
+  Each flow recompute gets its own numbered pipeline entry with the
+  flow-id rendered as the verb (clickable to source when the
+  registered flow carries `:file`/`:line` meta from `reg-flow`).
+
+  The projection emits N flow step maps for a cascade with N flow
+  recomputes; the body row renders the diff (path · before → after)
+  beneath the badge, left-aligned with no extra indent — same body
+  layout as the COEFFECT step."
+  [{:keys [flow-id path before after duration-ms step-number]}]
+  (let [flow-meta  (when (keyword? flow-id)
+                     (try (rf/handler-meta :flow flow-id)
+                          (catch :default _ nil)))
+        coord      (when (and flow-meta (string? (:file flow-meta)))
+                     {:file (:file flow-meta) :line (:line flow-meta)})
+        clickable? (and (map? coord) (seq (:file coord)))
+        label      (proj/ns-keyword flow-id)]
+    [:div {:data-testid (str "rf-xray-epoch-step-flow-" (name flow-id))
+           :data-step-kw "flow"
+           :data-flow-id (name flow-id)}
+     (numbered-circle step-number :FLOW)
+     (step-header
+       {:step :flow
+        :badge :FLOW
+        ;; Verb = flow-id (clickable when coord captured). Same
+        ;; affordance shape as the COEFFECT step's cofx-id hyperlink.
+        :verb (if clickable?
+                [:button {:data-testid (str "rf-xray-epoch-flow-id-" (name flow-id))
+                          :aria-label  (str "open " (:file coord)
+                                            (when (:line coord)
+                                              (str ":" (:line coord)))
+                                            " in editor")
+                          :title       (str "open " (:file coord)
+                                            (when (:line coord)
+                                              (str ":" (:line coord)))
+                                            " in editor")
+                          :on-click    (fn [e]
+                                         (.stopPropagation e)
+                                         (rf/dispatch
+                                           [:rf.xray/open-in-editor
+                                            {:source-coord coord}]
+                                           {:frame :rf/xray}))
+                          :style coeffect-verb-link-button-style}
+                 label
+                 (icons/external-link)]
+                [:span {:data-testid (str "rf-xray-epoch-flow-id-" (name flow-id))
+                        :style coeffect-verb-plain-style}
+                 label])
+        :expandable? false
+        :testid (str "rf-xray-epoch-flow-" (name flow-id))
+        :duration-ms duration-ms}
+       nil)
+     ;; Body — `[path] before → after` diff line, left-aligned with
+     ;; the badge (no extra indent). Mirrors the COEFFECT step's
+     ;; body layout (pair-debug 2026-05-26).
+     (when (sequential? path)
+       [:div {:data-testid (str "rf-xray-epoch-flow-value-" (name flow-id))
+              :style coeffect-body-style}
+        [:span {:style coeffect-body-plus-style}
+         (if (some? before) "~" "+")]
+        [:span {:style coeffect-body-path-style}
+         (proj/path-display path)]
+        (when (some? before)
+          [:span {:style diff-before-style} [ei/mini before 30]])
+        (when (and (some? before) (some? after))
+          [:span {:style coeffect-body-path-style} "→"])
+        (when (some? after)
+          [:span {:style coeffect-body-value-style} [ei/mini after 30]])])]))
 
 ;; ---- FX step -------------------------------------------------------------
 
@@ -2407,8 +2410,7 @@
   + truncated args.
 
   Argument order matches `map-indexed`'s `(f idx item)` convention
-  (rf2-cq0ch — companion swap with `coeffect-row-view` /
-  `flow-row-view`).
+  (rf2-cq0ch — companion swap with `coeffect-row-view`).
 
   Per rf2-uffov: when the row carries `:attributed-to`, a muted
   `← <action-id>` attribution chip rides alongside so the operator

--- a/tools/xray/src/day8/re_frame2_xray/theme/tokens.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/theme/tokens.cljc
@@ -114,6 +114,15 @@
    :dim            "#6e7681"   ; dimmed / inert / unchanged (Figma --devtools-unchanged)
    :hover          "#2a2a2a"   ; hover background (Figma --devtools-hover, = bg-3)
 
+   ;; ── violation wash (rf2-xgeag) ──
+   ;; Soft pink wash for the inline SCHEMA VIOLATION sub-block that
+   ;; rides under its owning pipeline step. Distinct from the
+   ;; `:magenta-pink` SUBSCRIPTIONS badge (a saturated chip) and from
+   ;; `:warning`'s amber (the retired aggregate step's chrome).
+   ;; The dark-theme value is a deeply muted rose — alert-grade
+   ;; without overpowering the cascade.
+   :bg-violation   "#3a1f25"   ; deep-rose-muted (dark)
+
    ;; ── functional categorical hues (spec/022 carve-out · spec 007) ──
    ;; These do REAL semantic work — perf tiers, machine state, route
    ;; side-channel, redaction, op-family legends — and are NOT collapsed
@@ -285,6 +294,11 @@
    :success        "#1a7f37"   ; Figma --devtools-success
    :dim            "#8c959f"   ; Figma --devtools-unchanged
    :hover          "#e8e8e8"   ; Figma --devtools-hover
+
+   ;; ── violation wash (rf2-xgeag) ──
+   ;; Light-theme mirror of the dark `:bg-violation`. A soft rose
+   ;; pink — alert-grade on white without overpowering the cascade.
+   :bg-violation   "#fde0e3"   ; soft-rose (light)
 
    ;; ── functional categorical hues (spec/022 carve-out · spec 007) ──
    :green          "#1a7f37"

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -18,8 +18,9 @@
        `:rf.event/run-end` stamp fallback.
     3. `handler-row` — flavour discrimination (reg-event-db /
        reg-event-fx / reg-machine) from the trace stream.
-    4. `flow-step` — conditional: present iff `:rf.flow/computed`
-       fired (rf2-yhgk8 — substrate-canonical op-name).
+    4. `flow-rows` — one row per `:rf.flow/computed` event;
+       `project` splats into N first-class FLOW steps in the
+       cascade (rf2-xnb1x, mirror of cofx per-step split).
     5. `fx-step` — conditional: present iff any `:rf.fx/*` event fired.
     6. `subscriptions-step` — conditional: present iff `:rf.sub/*`
        events fired.
@@ -846,16 +847,46 @@
 
 ;; ---- FLOW ---------------------------------------------------------------
 
-(deftest flow-step-conditional-test
-  (testing "no flow events → step is OMITTED"
-    (is (nil? (proj/flow-step []))))
+(deftest flow-steps-cascade-shape-test
+  (testing "rf2-xnb1x — no flow events → no FLOW step in the cascade"
+    (let [record {:trace-events [{:op-type   :rf.event
+                                  :operation :rf.event/dispatched
+                                  :tags      {:rf.event/event [:noop]}}]}
+          steps  (proj/project record)
+          flows  (filter #(= :flow (:step %)) steps)]
+      (is (empty? flows)
+          "zero flow events → no FLOW step rendered")))
 
-  (testing "flow event present → step is rendered"
-    (let [s (proj/flow-step [(flow-recomputed-ev :total-parity [:total] 5 6)])]
-      (is (= :flow (:step s)))
-      (is (= :FLOW (:badge s)))
-      (is (= 1 (count (:rows s))))
-      (is (= :total-parity (-> s :rows first :flow-id))))))
+  (testing "rf2-xnb1x — one flow event → ONE FLOW step"
+    (let [record {:trace-events [{:op-type   :rf.event
+                                  :operation :rf.event/dispatched
+                                  :tags      {:rf.event/event [:counter/inc]}}
+                                 (flow-recomputed-ev :total-parity [:total] 5 6)]}
+          steps  (proj/project record)
+          flows  (filter #(= :flow (:step %)) steps)]
+      (is (= 1 (count flows)))
+      (let [f (first flows)]
+        (is (= :flow         (:step f)))
+        (is (= :FLOW         (:badge f)))
+        (is (= :total-parity (:flow-id f)))
+        (is (= [:total]      (:path f)))
+        (is (= 5             (:before f)))
+        (is (= 6             (:after f))))))
+
+  (testing "rf2-xnb1x — N flow events → N first-class FLOW steps, each
+            carrying its own flow-id + path + before/after pair"
+    (let [record {:trace-events [{:op-type   :rf.event
+                                  :operation :rf.event/dispatched
+                                  :tags      {:rf.event/event [:checkout/begin]}}
+                                 (flow-recomputed-ev :cart/total [:cart :total] 120 195)
+                                 (flow-recomputed-ev :cart/n-items [:cart :n] 2 3)]}
+          steps  (proj/project record)
+          flows  (filter #(= :flow (:step %)) steps)]
+      (is (= 2 (count flows))
+          "two flow events → two FLOW steps (mirrors per-cofx COEFFECT split)")
+      (is (= [:cart/total :cart/n-items]
+             (mapv :flow-id flows))
+          "preserves substrate-order"))))
 
 (deftest flow-rows-reads-canonical-substrate-shape-test
   (testing "rf2-yhgk8 — substrate emits `:rf.flow/computed` with BARE

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -1256,7 +1256,8 @@
           steps (proj/project rec)]
       (is (every? proj/valid-badge? (map :badge steps)))
       (is (= 10 (count proj/badge-set))
-          "rf2-sc3r1 + rf2-17vxj + rf2-yx1ae + rf2-rrykz = 7 + 3 = 10 badges"))))
+          "rf2-sc3r1 7 + rf2-yx1ae + rf2-rrykz + rf2-xgeag (SCHEMA-HOT-RELOAD,
+           renamed from SCHEMA-VIOLATIONS) = 10 badges"))))
 
 ;; ---- formatting helpers --------------------------------------------------
 
@@ -1315,56 +1316,152 @@
     (is (false? (proj/long-step? {}))
         "missing duration returns false")))
 
-;; ---- rf2-17vxj — schema-violations step ---------------------------------
+;; ---- rf2-17vxj / rf2-xgeag — schema violations -------------------------
+;;
+;; rf2-xgeag retired the trailing aggregate SCHEMA-VIOLATIONS step in
+;; favour of per-step inline attachment + a hot-reload-only tail step.
+;; The per-row data shape (`schema-violation-rows`) is unchanged; only
+;; the aggregation moved.
 
-(deftest schema-violations-step-conditional-test
-  (testing "rf2-17vxj — no violation events → step is OMITTED"
-    (is (nil? (proj/schema-violations-step []))))
+(deftest schema-violation-rows-basic-test
+  (testing "no violation events → empty rows vec"
+    (is (= [] (proj/schema-violation-rows []))))
 
   (testing "rf2-17vxj — `:rf.error/schema-validation-failure` event
-            surfaces a row"
-    (let [s (proj/schema-violations-step
-              [(schema-violation-ev :app-db :counter/inc [:count]
-                                    "not-an-int" true)])]
-      (is (= :schema-violations (:step s)))
-      (is (= :SCHEMA-VIOLATIONS (:badge s)))
-      (is (= 1 (count (:rows s))))
-      (is (= 1 (:rollbacks s))
-          ":rollbacks counts rows where :rollback? is true")
-      (let [r (-> s :rows first)]
-        (is (= :app-db (:where r)))
-        (is (= :counter/inc (:failing-id r)))
-        (is (= [:count] (:path r)))
-        (is (= "not-an-int" (:value r)))
-        (is (true? (:rollback? r)))
-        (is (= :rf.error/schema-validation-failure (:kind r)))))))
+            surfaces a row with canonical fields"
+    (let [rows (proj/schema-violation-rows
+                 [(schema-violation-ev :app-db :counter/inc [:count]
+                                       "not-an-int" true)])]
+      (is (= 1 (count rows)))
+      (let [r (first rows)]
+        (is (= :app-db                                (:where r)))
+        (is (= :counter/inc                           (:failing-id r)))
+        (is (= [:count]                               (:path r)))
+        (is (= "not-an-int"                           (:value r)))
+        (is (true?                                    (:rollback? r)))
+        (is (= :rf.error/schema-validation-failure    (:kind r)))))))
 
-(deftest schema-violations-hot-reload-event-test
+(deftest schema-violation-rows-hot-reload-test
   (testing "rf2-17vxj — `:rf.schema/violation` event (hot-reload drift)
             also produces a row; `:where` defaults to `:hot-reload`"
-    (let [s (proj/schema-violations-step
-              [(schema-hot-reload-ev :rf/default [:count]
-                                     "not-an-int")])]
-      (is (= 1 (count (:rows s))))
-      (let [r (-> s :rows first)]
-        (is (= :hot-reload (:where r)))
+    (let [rows (proj/schema-violation-rows
+                 [(schema-hot-reload-ev :rf/default [:count]
+                                        "not-an-int")])]
+      (is (= 1 (count rows)))
+      (let [r (first rows)]
+        (is (= :hot-reload          (:where r)))
         (is (= :rf.schema/violation (:kind r)))
-        (is (= [:count] (:path r)))
-        (is (= "not-an-int" (:value r)))
-        (is (= :logged-and-skipped (:recovery r)))))))
+        (is (= [:count]             (:path r)))
+        (is (= "not-an-int"         (:value r)))
+        (is (= :logged-and-skipped  (:recovery r)))))))
 
-(deftest schema-violations-mixed-rows-test
-  (testing "rf2-17vxj — runtime + hot-reload events project into the
-            same row schema"
-    (let [s (proj/schema-violations-step
-              [(schema-violation-ev :sub-return :counter/total nil
-                                    {:bad :data})
-               (schema-hot-reload-ev :rf/default [:counter :n]
-                                     "boom")])]
-      (is (= 2 (count (:rows s)))
-          "both events project into rows")
-      (is (= 0 (:rollbacks s))
-          "no rollback-true rows in this fixture"))))
+(deftest hot-reload-step-conditional-test
+  (testing "rf2-xgeag — no hot-reload events → standalone step OMITTED"
+    (is (nil? (proj/hot-reload-step []))))
+
+  (testing "rf2-xgeag — hot-reload-only event surfaces the standalone
+            SCHEMA-HOT-RELOAD step"
+    (let [rows (proj/schema-violation-rows
+                 [(schema-hot-reload-ev :rf/default [:count] "boom")])
+          s    (proj/hot-reload-step rows)]
+      (is (= :schema-hot-reload (:step s)))
+      (is (= :SCHEMA-HOT-RELOAD (:badge s)))
+      (is (= 1 (count (:rows s))))))
+
+  (testing "rf2-xgeag — runtime-boundary violations are NOT routed to
+            the hot-reload step (they attach to their owning step)"
+    (let [rows (proj/schema-violation-rows
+                 [(schema-violation-ev :app-db :counter/inc [:count]
+                                       "not-an-int" true)])]
+      (is (nil? (proj/hot-reload-step rows))))))
+
+(deftest attach-violations-event-test
+  (testing "rf2-xgeag — `:event` violation attaches to the DISPATCH step"
+    (let [steps  [{:step :dispatch :badge :DISPATCH}
+                  {:step :handler  :badge :HANDLER}]
+          rows   [{:where :event :failing-id :counter/inc}]
+          out    (proj/attach-violations steps rows)]
+      (is (= 1 (count (:violations (first out)))))
+      (is (nil? (:violations (second out)))))))
+
+(deftest attach-violations-cofx-by-id-test
+  (testing "rf2-xgeag — `:cofx` violation attaches to the COEFFECT step
+            whose `:id` matches `:failing-id`"
+    (let [steps  [{:step :coeffect :badge :COEFFECT :id :session}
+                  {:step :coeffect :badge :COEFFECT :id :session/now}
+                  {:step :handler  :badge :HANDLER}]
+          rows   [{:where :cofx :failing-id :session/now}]
+          out    (proj/attach-violations steps rows)]
+      (is (nil? (:violations (nth out 0)))
+          "non-matching cofx step untouched")
+      (is (= 1 (count (:violations (nth out 1))))
+          "matching cofx step attached"))))
+
+(deftest attach-violations-app-db-to-handler-test
+  (testing "rf2-xgeag — `:app-db` violation attaches to the HANDLER step"
+    (let [steps  [{:step :dispatch :badge :DISPATCH}
+                  {:step :handler  :badge :HANDLER}]
+          rows   [{:where :app-db :failing-id :counter/inc :rollback? true}]
+          out    (proj/attach-violations steps rows)]
+      (is (nil? (:violations (first out))))
+      (is (= 1 (count (:violations (second out))))))))
+
+(deftest attach-violations-fx-row-test
+  (testing "rf2-xgeag — `:fx-args` violation attaches to the FX row whose
+            `:fx-id` matches `:failing-id`"
+    (let [steps  [{:step :fx :badge :FX
+                   :rows [{:fx-id :http/post :status :ok}
+                          {:fx-id :db        :status :ok}]}]
+          rows   [{:where :fx-args :failing-id :http/post}]
+          out    (proj/attach-violations steps rows)
+          fx     (first out)]
+      (is (= 1 (count (:violations (first  (:rows fx)))))
+          "http/post fx row has the attached violation")
+      (is (nil? (:violations (second (:rows fx))))
+          ":db fx row untouched"))))
+
+(deftest attach-violations-sub-row-test
+  (testing "rf2-xgeag — `:sub-return` violation attaches to the
+            SUBSCRIPTIONS row whose `:sub-id` matches `:failing-id`"
+    (let [steps  [{:step :subscriptions :badge :SUBSCRIPTIONS
+                   :rows [{:sub-id :user/profile}
+                          {:sub-id :cart/total}]}]
+          rows   [{:where :sub-return :failing-id :cart/total}]
+          out    (proj/attach-violations steps rows)
+          subs   (first out)]
+      (is (nil? (:violations (first  (:rows subs)))))
+      (is (= 1 (count (:violations (second (:rows subs)))))))))
+
+(deftest cascade-rolled-back?-test
+  (testing "rf2-xgeag — true iff any `:app-db` violation carries
+            `:rollback? true`"
+    (is (false? (proj/cascade-rolled-back? [])))
+    (is (false? (proj/cascade-rolled-back?
+                  [{:where :sub-return :rollback? true}]))
+        "non-app-db rollback doesn't count")
+    (is (false? (proj/cascade-rolled-back?
+                  [{:where :app-db :rollback? false}])))
+    (is (true?  (proj/cascade-rolled-back?
+                  [{:where :app-db :rollback? true}])))))
+
+(deftest mark-rolled-back-downstream-test
+  (testing "rf2-xgeag — rollback flags every step AFTER the HANDLER"
+    (let [steps [{:step :dispatch} {:step :handler}
+                 {:step :fx}       {:step :subscriptions}]
+          rows  [{:where :app-db :rollback? true}]
+          out   (proj/mark-rolled-back-downstream steps rows)]
+      (is (nil? (:rolled-back? (nth out 0))))
+      (is (nil? (:rolled-back? (nth out 1)))
+          "the HANDLER step itself is NOT muted (the violation
+           sub-block already shows the rollback in-place)")
+      (is (true? (:rolled-back? (nth out 2))))
+      (is (true? (:rolled-back? (nth out 3))))))
+
+  (testing "rf2-xgeag — no rollback → no `:rolled-back?` flags"
+    (let [steps [{:step :dispatch} {:step :handler} {:step :fx}]
+          rows  [{:where :sub-return :rollback? true}]
+          out   (proj/mark-rolled-back-downstream steps rows)]
+      (is (every? #(nil? (:rolled-back? %)) out)))))
 
 ;; ---- rf2-rrykz — app-db diff section — RETIRED 2026-05-26 -------------
 ;;
@@ -1456,19 +1553,36 @@
 ;; top-level cascade). See comment header above the child-dispatch
 ;; helpers section.
 
-(deftest project-includes-schema-violations-step-test
-  (testing "rf2-17vxj — top-level project emits SCHEMA-VIOLATIONS at
-            the END of the cascade when violations fired"
+(deftest project-attaches-app-db-violation-to-handler-test
+  (testing "rf2-xgeag — top-level `project` attaches `:app-db`
+            boundary violations to the HANDLER step inline and
+            mutes the downstream cascade with `:rolled-back? true`"
     (let [rec   (record [(dispatched-ev [:counter/inc] :ui nil)
                          (db-changed-ev [[[:count] 0 "boom" :modified]])
                          (schema-violation-ev :app-db :counter/inc
                                               [:count] "boom" true)])
-          steps (proj/project rec)]
-      (is (= :schema-violations (-> steps last :step))
-          "SCHEMA-VIOLATIONS rides at the end of the cascade")))
+          steps (proj/project rec)
+          handler (some #(when (= :handler (:step %)) %) steps)]
+      (is (some? handler))
+      (is (= 1 (count (:violations handler))))
+      (is (true? (-> handler :violations first :rollback?)))
+      (is (not-any? #(= :schema-violations (:step %)) steps)
+          "the retired aggregate SCHEMA-VIOLATIONS step never appears")
+      (is (not-any? #(= :schema-hot-reload (:step %)) steps)
+          "no hot-reload tail step when violation is runtime-boundary")))
 
-  (testing "rf2-17vxj — no violations → step absent"
+  (testing "rf2-xgeag — no violations → no attached `:violations` +
+            no `:rolled-back?` flags"
     (let [rec   (record [(dispatched-ev [:counter/inc] :ui nil)
                          (db-changed-ev [[[:count] 0 1 :modified]])])
           steps (proj/project rec)]
-      (is (not-any? #(= :schema-violations (:step %)) steps)))))
+      (is (every? #(nil? (:violations %)) steps))
+      (is (every? #(nil? (:rolled-back? %)) steps))))
+
+  (testing "rf2-xgeag — hot-reload drift rides on the standalone
+            SCHEMA-HOT-RELOAD tail step (Option A)"
+    (let [rec   (record [(dispatched-ev [:counter/inc] :ui nil)
+                         (schema-hot-reload-ev :rf/default
+                                               [:counter :n] "boom")])
+          steps (proj/project rec)]
+      (is (= :schema-hot-reload (-> steps last :step))))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -1284,28 +1284,6 @@
     (is (false? (proj/long-step? {}))
         "missing duration returns false")))
 
-(deftest cascade-total-ms-test
-  (testing "rf2-nqt3d — sum of every step's :duration-ms"
-    (is (= 12.5 (proj/cascade-total-ms [{:duration-ms 0.5}
-                                        {:duration-ms 12}])))
-    (is (nil? (proj/cascade-total-ms []))
-        "empty step vec returns nil so the view can elide the chip")
-    (is (nil? (proj/cascade-total-ms [{:step :dispatch} {:step :handler}]))
-        "no step carries a duration → nil")
-    (is (= 5 (proj/cascade-total-ms [{:step :dispatch}
-                                     {:duration-ms 5}
-                                     {:step :views}]))
-        "mixed presence: missing durations skipped, sum returned")))
-
-(deftest long-step-count-test
-  (testing "rf2-nqt3d — count of steps over the 16ms threshold"
-    (is (= 0 (proj/long-step-count [])))
-    (is (= 0 (proj/long-step-count [{:duration-ms 0.1}
-                                    {:duration-ms 10}])))
-    (is (= 2 (proj/long-step-count [{:duration-ms 18}
-                                    {:duration-ms 1}
-                                    {:duration-ms 50}])))))
-
 ;; ---- rf2-17vxj — schema-violations step ---------------------------------
 
 (deftest schema-violations-step-conditional-test

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -551,67 +551,67 @@
       (is (string/includes? header "1 unmounted")
           "header reads the unmount-only shape"))))
 
-;; ---- rf2-17vxj — schema-violations section ----------------------------
+;; ---- rf2-xgeag — inline violation sub-block + hot-reload tail step ----
 
-(deftest schema-violations-step-renders-rows-test
-  (testing "rf2-17vxj — SCHEMA VIOLATIONS step renders one row per
-            violation; rollback chip rides any rollback? row"
-    (let [step {:step :schema-violations :badge :SCHEMA-VIOLATIONS
+(deftest violation-block-renders-headline-+-fields-test
+  (testing "rf2-xgeag — `violation-block` renders the pink sub-block
+            with title, recovery chip, headline, path, and value rows"
+    (let [row  {:kind :rf.error/schema-validation-failure
+                :where :app-db
+                :failing-id :counter/inc
+                :path [:count]
+                :value "not-an-int"
+                :rollback? true
+                :sensitive? false}
+          tree (view/violation-block :handler 0 row)
+          base "rf-xray-epoch-violation-handler-0"]
+      (is (some? (th/find-by-testid tree base))
+          "the sub-block wrapper renders")
+      (let [title    (text-of tree (str base "-title"))
+            recovery (text-of tree (str base "-recovery"))
+            headline (text-of tree (str base "-headline"))
+            path     (text-of tree (str base "-path"))]
+        (is (string/includes? title "SCHEMA VIOLATION"))
+        (is (string/includes? recovery "rolled back"))
+        (is (string/includes? headline "app-db commit"))
+        (is (string/includes? headline ":counter/inc"))
+        (is (string/includes? path "[:count]"))))))
+
+(deftest violation-block-recovery-chip-test
+  (testing "rf2-xgeag — recovery chip surfaces a per-where label when
+            no rollback fired"
+    (let [tree (view/violation-block :fx 0
+                 {:where :fx-args :failing-id :http/post
+                  :rollback? false})
+          recovery (text-of tree "rf-xray-epoch-violation-fx-0-recovery")]
+      (is (string/includes? recovery "fx skipped"))))
+
+  (testing "rf2-xgeag — sub-return → 'returned nil'"
+    (let [tree (view/violation-block :subscriptions 0
+                 {:where :sub-return :failing-id :user/profile
+                  :rollback? false})
+          recovery (text-of tree
+                            "rf-xray-epoch-violation-subscriptions-0-recovery")]
+      (is (string/includes? recovery "returned nil")))))
+
+(deftest render-schema-hot-reload-step-test
+  (testing "rf2-xgeag — standalone SCHEMA HOT-RELOAD step renders one
+            sub-block per drift row + the badge label is the renamed
+            'SCHEMA HOT-RELOAD' (not the retired 'SCHEMA VIOLATIONS')"
+    (let [step {:step :schema-hot-reload :badge :SCHEMA-HOT-RELOAD
                 :step-number 8
-                :rows [{:kind :rf.error/schema-validation-failure
-                        :where :app-db
-                        :failing-id :counter/inc
-                        :path [:count]
-                        :value "not-an-int"
-                        :rollback? true
-                        :sensitive? false}
-                       {:kind :rf.schema/violation
+                :rows [{:kind :rf.schema/violation
                         :where :hot-reload
-                        :frame :rf/default
                         :failing-id :rf/default
                         :path [:count]
                         :value "boom"
-                        :recovery :logged-and-skipped
-                        :rollback? false
-                        :sensitive? false}]
-                :rollbacks 1}
-          tree (view/render-schema-violations-step step)]
-      (is (some? (th/find-by-testid tree "rf-xray-epoch-step-schema-violations"))
-          "the step wrapper renders")
-      (is (= 2 (count (th/find-by-testid-prefix
-                        tree "rf-xray-epoch-schema-violation-row-"))))
-      (is (some? (th/find-by-testid
-                   tree "rf-xray-epoch-schema-violation-rollback-0"))
-          "the rollback chip rides the rollback? row")
-      (is (nil? (th/find-by-testid
-                  tree "rf-xray-epoch-schema-violation-rollback-1"))
-          "no rollback chip on a clean recovery row")
-      (let [header (text-of tree "rf-xray-epoch-schema-violations-header")]
-        (is (string/includes? header "2 violation"))
-        (is (string/includes? header "1 rollback")))
-      (is (some? (th/find-by-testid
-                   tree "rf-xray-epoch-schema-violations-open-issues"))
-          "the open-issues affordance is present"))))
-
-(deftest schema-violations-row-shows-fields-test
-  (testing "rf2-17vxj — per-row body shows where + failing-id + path + value"
-    (let [step {:step :schema-violations :badge :SCHEMA-VIOLATIONS
-                :step-number 8
-                :rows [{:kind :rf.error/schema-validation-failure
-                        :where :sub-return
-                        :failing-id :counter/total
-                        :path [:total]
-                        :value {:bad :data}
-                        :rollback? false
-                        :sensitive? false}]
-                :rollbacks 0}
-          tree (view/render-schema-violations-step step)]
-      (let [where (text-of tree "rf-xray-epoch-schema-violation-where-0")
-            id    (text-of tree "rf-xray-epoch-schema-violation-id-0")
-            path  (text-of tree "rf-xray-epoch-schema-violation-path-0")]
-        (is (string/includes? where "sub return"))
-        (is (string/includes? id ":counter/total"))
-        (is (string/includes? path "[:total]"))))))
+                        :recovery :logged-and-skipped}]}
+          tree (view/render-schema-hot-reload-step step)]
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-step-schema-hot-reload")))
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-violation-hot-reload-0"))
+          "the drift row renders as a violation sub-block")
+      (let [header (text-of tree "rf-xray-epoch-schema-hot-reload-header")]
+        (is (string/includes? header "1 hot-reload drift"))))))
 
 ;; ---- rf2-uffov — FX section header + per-action attribution ----------
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -551,46 +551,6 @@
       (is (string/includes? header "1 unmounted")
           "header reads the unmount-only shape"))))
 
-;; ---- rf2-nqt3d — per-step elapsed time + cascade total ----------------
-
-(deftest cascade-summary-renders-total-test
-  (testing "rf2-nqt3d — cascade-summary chip carries the cascade total
-            formatted via `format-duration-ms`"
-    (let [tree (view/cascade-summary [{:step :dispatch :duration-ms 0.5}
-                                      {:step :handler  :duration-ms 12}])
-          chip (th/find-by-testid tree "rf-xray-epoch-cascade-summary")]
-      (is (some? chip) "the summary chip renders when any step carries a duration")
-      (is (string/includes? (th/text-content chip) "cascade total"))
-      (is (string/includes? (th/text-content chip) "13ms")
-          "total reads as the rounded sum of every step's :duration-ms"))))
-
-(deftest cascade-summary-elides-when-no-durations-test
-  (testing "rf2-nqt3d — projection without any duration returns nil so
-            the view never renders an empty `total: —` chip"
-    (let [tree (view/cascade-summary [{:step :dispatch}
-                                      {:step :handler}])]
-      (is (nil? tree)
-          "no durations → no summary chip (graceful-degrade)"))))
-
-(deftest cascade-summary-shows-long-step-count-test
-  (testing "rf2-nqt3d — when any step exceeds 16ms the summary surfaces
-            a warning-tone count chip"
-    (let [tree (view/cascade-summary [{:step :handler :duration-ms 12}
-                                      {:step :views   :duration-ms 25}
-                                      {:step :fx      :duration-ms 30}])
-          long-chip (th/find-by-testid tree "rf-xray-epoch-cascade-summary-long-count")]
-      (is (some? long-chip) "long-count chip present when any step is over 16ms")
-      (is (string/includes? (th/text-content long-chip) "2 over 16ms")
-          "count + threshold are visible in the chip text"))))
-
-(deftest cascade-summary-omits-long-count-when-zero-test
-  (testing "rf2-nqt3d — clean cascade (every step under threshold) → no
-            long-count chip in the summary"
-    (let [tree (view/cascade-summary [{:step :handler :duration-ms 0.5}
-                                      {:step :views   :duration-ms 1.2}])]
-      (is (nil? (th/find-by-testid tree "rf-xray-epoch-cascade-summary-long-count"))
-          "no long-count chip on a fast cascade"))))
-
 ;; ---- rf2-17vxj — schema-violations section ----------------------------
 
 (deftest schema-violations-step-renders-rows-test
@@ -1259,7 +1219,6 @@
   "Locate the step-seq returned by `pipeline-view`. The view returns:
 
       [:div {:data-testid \"rf-xray-epoch-pipeline-container\"}
-       (cascade-summary …)
        [:div {:data-testid \"rf-xray-epoch-pipeline\" …}
         [:div {:data-testid \"rf-xray-epoch-rail\" …}]
         <steps-seq>]]

--- a/tools/xray/testbeds/panel_gallery/fixtures_epoch.cljs
+++ b/tools/xray/testbeds/panel_gallery/fixtures_epoch.cljs
@@ -5,10 +5,12 @@
 
   `tools/xray/spec/021-Dynamic-Panel-Designs.md` §9.1 — the focused
   epoch's complete computational timeline as a numbered vertical
-  cascade: DISPATCH → COEFFECT → HANDLER → APP-DB DIFF → FLOW → FX →
-  CHILD DISPATCHES → SUBSCRIPTIONS → VIEWS → SCHEMA VIOLATIONS. Each
-  step is CONDITIONAL — only the steps whose driving trace events
-  surfaced get rendered (per
+  cascade: DISPATCH → COEFFECT (one per cofx) → HANDLER → FLOW
+  (one per flow, rf2-xnb1x) → FX → SUBSCRIPTIONS → VIEWS →
+  SCHEMA HOT-RELOAD (rf2-xgeag — hot-reload drift only;
+  runtime-boundary violations attach as inline sub-blocks under
+  their owning step). Each step is CONDITIONAL — only the steps
+  whose driving trace events surfaced get rendered (per
   `tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc`).
 
   The 10-entry badge inventory + 16ms long-step threshold ride on
@@ -262,8 +264,8 @@
   "`:rf.schema/violation` trace (rf2-17vxj) — the hot-reload drift
   check fires when a re-registration changed the schema at a
   `(frame-id, path)` AND the live `app-db` value at `path` fails the
-  new schema. Distinct from the runtime per-event failure; same
-  SCHEMA VIOLATIONS section."
+  new schema. Distinct from the runtime per-event failure; rides on
+  the standalone SCHEMA HOT-RELOAD tail step (rf2-xgeag · Option A)."
   [frame-id path mismatching-value]
   (ev :warning :rf.schema/violation
       {:frame              frame-id
@@ -463,16 +465,25 @@
 
 ;; ---- VARIANT 4: schema-violation cascade --------------------------------
 ;;
-;; Section coverage: SCHEMA VIOLATIONS step (warning chrome +
-;; `open issues →` button). Mix of runtime per-boundary failure
-;; (with rollback?) AND hot-reload drift to exercise both ops in
-;; `schema-violation-ops`.
+;; Section coverage: rf2-xgeag inline violation sub-blocks. Each
+;; runtime per-boundary failure attaches to its OWNING pipeline step
+;; (HANDLER for :app-db, FX row for :fx-args, SUBSCRIPTIONS row for
+;; :sub-return). Hot-reload drift rides on the standalone
+;; SCHEMA HOT-RELOAD tail step (Option A) since drift has no owning
+;; cascade step.
+;;
+;; The fixture covers the most operator-visible cases:
+;;   - `:app-db` rolled back → HANDLER sub-block + downstream mute
+;;   - `:fx-args` skipped    → FX row sub-block (per-row attachment)
+;;   - `:sub-return` nil     → SUBSCRIPTIONS row sub-block
+;;   - hot-reload drift      → tail SCHEMA HOT-RELOAD step
 
 (defn schema-violations-history
-  "Cascade where the app-db boundary check fired (validation failure
-  + rollback) AND a hot-reload drift surfaced. Exercises the
-  SCHEMA VIOLATIONS section's `:rollback?` chrome + the two
-  distinct row :kind sources."
+  "Cascade exercising the rf2-xgeag inline violation attachment. The
+  `:app-db` violation rolls back the cascade, muting the FX /
+  SUBSCRIPTIONS / VIEWS chrome downstream; the FX-args + sub-return
+  violations land on their matching rows; the hot-reload drift rides
+  on the tail SCHEMA HOT-RELOAD step."
   []
   (single-epoch-history
     {:epoch-id 4
@@ -481,13 +492,14 @@
      [(dispatched-ev [:counter/set "not-a-number"] :ui)
       ;; Validation failure: the handler tried to set :counter to
       ;; a string; the app-db boundary schema rejected the write
-      ;; and rolled the cascade back.
+      ;; and rolled the cascade back. Attaches to HANDLER + flips
+      ;; downstream steps muted.
       (schema-violation-ev :app-db :counter/set [:counter]
                            "not-a-number" true)
       ;; Hot-reload drift: a separate schema (the :user/profile
       ;; map) was re-registered tighter, and the live app-db value
-      ;; now fails the new shape. The framework logs and skips —
-      ;; the operator gets a warning row.
+      ;; now fails the new shape. Rides on the tail SCHEMA HOT-RELOAD
+      ;; step (Option A — drift has no owning cascade step).
       (schema-hot-reload-ev :rf/default [:user/profile :age] -3)
       (run-end-ev 0.3)]}))
 

--- a/tools/xray/testbeds/panel_gallery/fixtures_epoch.cljs
+++ b/tools/xray/testbeds/panel_gallery/fixtures_epoch.cljs
@@ -580,11 +580,16 @@
 ;; the cascade after the handler returns — the framework runs flows
 ;; at the outermost :after, transforming the pending :db before the
 ;; single deferred install (per `re-frame.flow`).
+;;
+;; rf2-xnb1x: the projection splats each flow into its OWN numbered
+;; FLOW step (mirror of the per-cofx COEFFECT split). This fixture
+;; renders THREE first-class FLOW steps in the cascade — operator
+;; counts flows by counting circles, not rows-in-a-step.
 
 (defn flows-history
   "Cascade triggering three downstream flows — `:cart/total`,
-  `:cart/item-count`, `:cart/badge`. Exercises the FLOW step's
-  per-row before/after rendering."
+  `:cart/item-count`, `:cart/badge`. Drives THREE numbered FLOW
+  steps in the cascade per the rf2-xnb1x per-flow split."
   []
   (single-epoch-history
     {:epoch-id 6

--- a/tools/xray/testbeds/panel_gallery/fixtures_epoch.cljs
+++ b/tools/xray/testbeds/panel_gallery/fixtures_epoch.cljs
@@ -548,15 +548,13 @@
 ;; Section coverage: 16ms long-step warning chrome — the `▲` glyph +
 ;; warning tone fires when any single step's `:duration-ms` exceeds
 ;; `proj/long-step-threshold-ms` (= 16). The fixture stamps a 42ms
-;; HANDLER (the cascade-driving duration) + a 28ms fx call, so the
-;; CASCADE-TOTAL chip lights up and two rows carry the long-step
-;; chrome.
+;; HANDLER (the cascade-driving duration) + a 28ms fx call, so two
+;; per-step duration chips carry the long-step chrome.
 
 (defn long-step-history
   "Cascade with a 42ms handler + 28ms fx — both above the 16ms
-  threshold. Drives the long-step warning chrome on the duration
-  chips + the cascade-summary's `N steps over 16ms` secondary
-  chip."
+  threshold. Drives the long-step warning chrome on the per-step
+  duration chips."
   []
   (single-epoch-history
     {:epoch-id 5

--- a/tools/xray/testbeds/panel_gallery/gallery_epoch.cljs
+++ b/tools/xray/testbeds/panel_gallery/gallery_epoch.cljs
@@ -17,7 +17,7 @@
   | `vanilla-db`           | DISPATCH · COEFFECT · HANDLER (db) · APP-DB DIFF · SUBSCRIPTIONS · VIEWS |
   | `reg-event-fx`         | DISPATCH · HANDLER (fx) · APP-DB DIFF · FX (✓ + ✗ + header counters) |
   | `machine-driven`       | DISPATCH · HANDLER (machine: TRANSITION · GUARDS · LIFECYCLE · AFTER-TIMERS · DATA-REDUCTION · SNAPSHOT-DIFF) · APP-DB DIFF · FX |
-  | `schema-violations`    | DISPATCH · HANDLER (db) · SCHEMA VIOLATIONS (runtime + hot-reload, with rollback) |
+  | `schema-violations`    | DISPATCH · HANDLER (db, with rolled-back app-db violation sub-block + downstream mute) · SCHEMA HOT-RELOAD tail (rf2-xgeag) |
   | `child-dispatches`     | DISPATCH · HANDLER (fx) · APP-DB DIFF · FX · CHILD DISPATCHES (resolved + not-in-buffer) |
   | `long-step`            | DISPATCH · HANDLER (fx, 42ms · long-step chrome) · APP-DB DIFF · FX (28ms long-step) · SUBSCRIPTIONS · VIEWS |
   | `flow-firing`          | DISPATCH · HANDLER (db) · APP-DB DIFF · FLOW · FX · SUBSCRIPTIONS · VIEWS |
@@ -111,9 +111,11 @@
   (story/reg-variant :story.xray.epoch/schema-violations
     {:doc        "Cascade where the app-db boundary check fired
                  (validation failure with rollback) AND a hot-reload
-                 drift surfaced. Exercises the SCHEMA VIOLATIONS
-                 section's warning chrome + the `open issues →`
-                 affordance + the rollback indicator (rf2-17vxj)."
+                 drift surfaced. Exercises the rf2-xgeag inline
+                 violation sub-block: the :app-db violation attaches
+                 to HANDLER with a pink sub-block + rolled-back banner,
+                 and downstream steps mute. The hot-reload drift rides
+                 on the standalone SCHEMA HOT-RELOAD tail step."
      :events     [[:rf.xray/sync-epoch-history (fixtures/schema-violations-history)]]
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})

--- a/tools/xray/testbeds/panel_gallery/gallery_epoch.cljs
+++ b/tools/xray/testbeds/panel_gallery/gallery_epoch.cljs
@@ -135,9 +135,9 @@
     {:doc        "Cascade with a 42ms handler + 28ms fx + 18ms view —
                  every duration over the 16ms `long-step-threshold-ms`.
                  Exercises the long-step warning chrome (`▲` glyph +
-                 warning tone) on per-step duration chips, plus the
-                 cascade-summary's `N steps over 16ms` secondary chip
-                 (rf2-nqt3d)."
+                 warning tone) on per-step duration chips (rf2-nqt3d
+                 per-row portion; the top-of-pipeline summary chip
+                 was retired by rf2-dwuq3)."
      :events     [[:rf.xray/sync-epoch-history (fixtures/long-step-history)]]
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})


### PR DESCRIPTION
Three-bead Shape-2 cluster against the Epoch panel, sequenced smallest → biggest.

## Beads

- **rf2-dwuq3** (P2 · refactor) — Retire the "computational timeline" subtitle + the top-of-pipeline `cascade total: <N>ms` chip (partial revert of rf2-nqt3d). Per-row duration chips + the `▲` long-step warning per row are kept. spec/021 §9.1.10.2 reshaped.
- **rf2-xnb1x** (P2 · feat) — One FLOW step per flow that fired, mirroring the per-cofx COEFFECT split. Operator counts flows by counting circles, not rows-in-a-step. Each FLOW step carries a click-to-source flow-id + diff body. spec/021 §9.1.10.8 added.
- **rf2-xgeag** (P2 · feat) — Attach schema violations to their owning pipeline step as pink-wash sub-blocks (DISPATCH / matching COEFFECT / HANDLER / matching FX row / matching SUBSCRIPTIONS row). Hot-reload drift rides a standalone SCHEMA HOT-RELOAD tail step (Option A). HANDLER renders a "cascade rolled back" banner + downstream-mute when an `:app-db` violation has `:rollback? true`. spec/021 §9.1.10.3 rewritten; spec/010 cross-ref paragraph added.

## File inventory

- `tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc`
- `tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs`
- `tools/xray/src/day8/re_frame2_xray/panels/epoch/badge.cljc`
- `tools/xray/src/day8/re_frame2_xray/panels/epoch/icons.cljc`
- `tools/xray/src/day8/re_frame2_xray/theme/tokens.cljc`
- `tools/machines-viz/src/day8/re_frame2_machines_viz/theme/tokens.cljc` (drift-gate `:bg-violation` mirror)
- `tools/xray/spec/021-Dynamic-Panel-Designs.md`
- `spec/010-Schemas.md`
- Tests: `tools/xray/test/.../panels/epoch/{projection,view}_cljs_test.{cljc,cljs}`
- Fixtures: `tools/xray/testbeds/panel_gallery/{fixtures,gallery}_epoch.cljs`

## Quality gates

- `npm run test:cljs` — 4772 tests / 15549 assertions, 0 failures / 0 errors
- `npm run test:browser` — 124 tests / 353 assertions, 0 failures / 0 errors
- `npm run test:bundle-isolation` — PASS

Per pre-alpha masterpiece posture (no back-compat shims). Per `bd` workflow: pre-claimed each bead; each commit references its bead id.