### PR TITLE
feat(framework): :schema on reg-machine + :machine-data validation boundary (rf2-jbbp7)

### DIFF
--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -266,6 +266,10 @@
    {:key         :machines/update-snapshot-fx
     :producer-ns 're-frame.machines
     :description "Effect handler for the :rf.machine/update-snapshot snapshot-level escape hatch."}
+   {:key         :machines/validate-machine-data!
+    :producer-ns 're-frame.machines
+    :design-bead "rf2-jbbp7"
+    :description "Post-commit walker for the `:where :machine-data` boundary (Spec 005 §Schema validation, Spec 010 §Per-step recovery row 7). Iterates `[:rf/machines]`, validates each snapshot's `:data` against the registered machine's top-level `:schema`. Router AND-conjoins with `:schemas/validate-app-schema!` to gate the `:db` commit; a failure rolls the cascade back exactly like a `:where :app-db` violation."}
 
    ;; ---- re-frame.routing (rf2-k682) -----------------------------------------
    {:key         :routing/reg-route

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -414,6 +414,14 @@
   registered against THIS dispatch's frame only — sibling frames'
   schemas don't fire here.
 
+  Per rf2-jbbp7 / Spec 010 §Per-step recovery row 7: AND-conjoins the
+  app-db validator with `:machines/validate-machine-data!` (the
+  `:where :machine-data` boundary). The machine walker iterates
+  `[:rf/machines]` and validates each snapshot's `:data` against the
+  registered machine's top-level `:schema`. Both validators run on
+  every commit so the operator gets the full failure surface; the
+  conjunction means a `false` from either rolls back the cascade.
+
   Defensive truth-coercion: a host-thrown validator (e.g. a buggy
   user-supplied :schemas/set-schema-validator! fn) is caught and
   treated as `true` (no rollback) — the validator is failing on
@@ -421,16 +429,33 @@
   actual app-db state from the rest of the cascade. Real schema
   failures route through the in-band false return."
   [db-after event-id frame]
-  ;; Sticky hook (rf2-f72pd) — fires per-dispatch.
-  (if-let [validate (late-bind/get-fn-cached :schemas/validate-app-schema!)]
-    (try
-      ;; nil-coerce: pre-rf2-6m0se the fn returned nil on success.
-      ;; Treat nil as true (don't roll back) so a hosted port that
-      ;; still ships the older contract keeps working.
-      (let [r (validate db-after event-id frame)]
-        (if (nil? r) true r))
-      (catch #?(:clj Throwable :cljs :default) _ true))
-    true))
+  (let [app-ok?
+        ;; Sticky hook (rf2-f72pd) — fires per-dispatch.
+        (if-let [validate (late-bind/get-fn-cached :schemas/validate-app-schema!)]
+          (try
+            ;; nil-coerce: pre-rf2-6m0se the fn returned nil on success.
+            ;; Treat nil as true (don't roll back) so a hosted port that
+            ;; still ships the older contract keeps working.
+            (let [r (validate db-after event-id frame)]
+              (if (nil? r) true r))
+            (catch #?(:clj Throwable :cljs :default) _ true))
+          true)
+        machines-ok?
+        ;; Per rf2-jbbp7 — the machine-data boundary (Spec 005 §Schema
+        ;; validation). The hook is absent when the machines artefact
+        ;; isn't on the classpath; absent → true (no machines means no
+        ;; machine-data to validate).
+        (if-let [validate-md (late-bind/get-fn-cached
+                               :machines/validate-machine-data!)]
+          (try
+            (let [r (validate-md db-after event-id frame)]
+              (if (nil? r) true r))
+            (catch #?(:clj Throwable :cljs :default) _ true))
+          true)]
+    ;; Both must conform for the cascade to keep its commit; the per-
+    ;; failure traces have already been emitted independently so the
+    ;; operator sees every violation, not just the first.
+    (and app-ok? machines-ok?)))
 
 (defn- commit-db-effect!
   "Apply :db atomically: replace the app-db container, emit the

--- a/implementation/core/test/re_frame/elision_probe.cljs
+++ b/implementation/core/test/re_frame/elision_probe.cljs
@@ -334,22 +334,42 @@
   ;; DCEs the entire `:rf.machine/source-coords` literal — every spec-
   ;; element string fragment must elide.
   ;;
+  ;; Per rf2-jbbp7 the `:schema` key on `reg-machine` adds a second
+  ;; gated surface: the `re-frame.machines.data-validation` ns's
+  ;; emit-failure! body sits inside `(if interop/debug-enabled? ...)`
+  ;; and its " :data failed schema at boundary :where :machine-data "
+  ;; reason-string fragment must also elide under :advanced.
+  ;;
   ;; The probe roots reachability for the machines surface by:
   ;;   1. requiring re-frame.machines (forces ns body — the late-bind
   ;;      hook registration, the :rf/machine sub, the spawn / destroy
-  ;;      fx handlers — into the bundle);
+  ;;      fx handlers, the data-validation emit body — into the bundle);
   ;;   2. registering a machine via `rf/reg-machine` so the macro's
   ;;      gated source-coord-stamping branch is in reachable code, not
   ;;      just declared-but-dead.
+  ;;   3. registering a machine WITH `:schema` and forcing a violation
+  ;;      so the emit-failure! call site is reached in the control build
+  ;;      (DEBUG=true) and its sentinel string lands in the bundle.
   ;;
-  ;; The sentinel string is the keyword `:rf.machine/source-coords` (the
-  ;; spec map key the macro injects under the gate). It must NOT appear
-  ;; in the production bundle.
+  ;; The sentinel strings are `:rf.machine/source-coords` (macro-time
+  ;; source-coord stamp) and " :data failed schema at boundary
+  ;; :where :machine-data " (data-validation emit body). Both must NOT
+  ;; appear in the production bundle.
   (rf/reg-machine :rf.probe/machine
     {:initial :idle
      :guards  {:never? (fn [_] false)}
      :actions {:noop   (fn [_] {})}
-     :states  {:idle {:on {:tick {:target :idle :guard :never? :action :noop}}}}}))
+     :states  {:idle {:on {:tick {:target :idle :guard :never? :action :noop}}}}})
+  ;; Force a `:where :machine-data` failure to root the data-validation
+  ;; emit body for the elision control. The validator never installs
+  ;; (the spawn-time gate or post-commit gate emits + rejects), so the
+  ;; failing machine leaves no state behind.
+  (rf/reg-machine :rf.probe/machine-with-schema
+    {:initial :idle
+     :data    {:n 0}                                  ;; 0 violates pos-int?
+     :schema  [:map [:n pos-int?]]
+     :states  {:idle {}}})
+  (rf/dispatch-sync [:rf.probe/machine-with-schema [:noop]]))
 
 ;; ---- rf2-ts1a: call-site source-coord macros ------------------------------
 ;;

--- a/implementation/machines/deps.edn
+++ b/implementation/machines/deps.edn
@@ -34,6 +34,11 @@
  {:test {:extra-paths ["test"]
          :extra-deps  {;; rf2-try1x — silent-on-success reporter.
                        day8/re-frame2-test-quiet {:local/root "../test-quiet"}
+                       ;; rf2-jbbp7 — `:schema` validation tests reach the
+                       ;; default Malli validator via `re-frame.schemas.malli`.
+                       ;; Test-only dep so the artefact's production
+                       ;; classpath stays schemas-free.
+                       day8/re-frame2-schemas    {:local/root "../schemas"}
                        io.github.cognitect-labs/test-runner
                        {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
          :main-opts   ["-m" "re-frame.test-quiet.runner"]}

--- a/implementation/machines/src/re_frame/machines.cljc
+++ b/implementation/machines/src/re_frame/machines.cljc
@@ -44,6 +44,7 @@
   (:require [re-frame.frame :as frame]
             [re-frame.fx :as fx]
             [re-frame.late-bind :as late-bind]
+            [re-frame.machines.data-validation :as data-validation]
             [re-frame.machines.lifecycle-fx.destroy :as destroy]
             [re-frame.machines.lifecycle-fx.frame-destroy :as frame-destroy]
             [re-frame.machines.lifecycle-fx.registration :as registration]
@@ -76,6 +77,13 @@
 
 (def reg-machine*           registration/reg-machine*)
 (def make-machine-handler registration/make-machine-handler)
+;; Per rf2-jbbp7 — boundary-validation surface for the `:schema` key
+;; on `reg-machine` (Spec 005 §Schema validation, Spec 010 §Per-step
+;; recovery row 7). The post-commit walker validates every snapshot's
+;; `:data` against its registered machine's `:schema`; the spawn-time
+;; sibling validates a spawned actor's initial `:data` before install.
+(def validate-machine-data! data-validation/validate-machine-data!)
+(def validate-spawn-data!   data-validation/validate-spawn-data!)
 ;; The pure registration-time validator (Spec 005 §registration validators,
 ;; rf2-f9tu). Re-exported so the conformance corpus's `:reg-machine` Mode-B
 ;; call op can pin the registration-error taxonomy (Spec 009 §thrown-error
@@ -267,6 +275,11 @@
                    spawn-order/reset-all!)
 (late-bind/set-fn! :machines/spawn-fx               spawn-fx)
 (late-bind/set-fn! :machines/destroy-machine-fx     destroy-machine-fx)
+;; Per rf2-jbbp7 — the post-commit walker the router AND-conjoins with
+;; `validate-app-schema!` to gate the `:db` commit on the
+;; `:where :machine-data` boundary (Spec 005 §Schema validation, Spec
+;; 010 §Per-step recovery row 7).
+(late-bind/set-fn! :machines/validate-machine-data! validate-machine-data!)
 (late-bind/set-fn! :machines/spawn-all-init-fx      invoke-all-init-fx)
 (late-bind/set-fn! :machines/after-schedule-fx      after-schedule-fx)
 (late-bind/set-fn! :machines/after-cancel-fx        after-cancel-fx)

--- a/implementation/machines/src/re_frame/machines/data_validation.cljc
+++ b/implementation/machines/src/re_frame/machines/data_validation.cljc
@@ -1,0 +1,174 @@
+(ns re-frame.machines.data-validation
+  "Machine `:data` schema validation at the `:where :machine-data` boundary
+  (rf2-jbbp7).
+
+  Per Spec 005 §Schema validation: a machine spec may declare a
+  top-level `:schema` key whose value validates the machine's `:data`
+  slot. This namespace owns the boundary-validation call site.
+
+  Per Spec 010 §Per-step recovery row 7: validation failures emit
+  `:rf.error/schema-validation-failure` with `:where :machine-data`
+  and trigger full-cascade rollback (the router AND-conjoins this
+  validator's result with `validate-app-schema!`'s — a `false` from
+  either rolls back the `:db` commit).
+
+  The post-commit validator (`validate-machine-data!`) walks the
+  freshly-committed `:rf/machines` map, looks up each machine's spec
+  via `re-frame.machines/machine-meta`, and validates `(:data
+  snapshot)` against `(:schema spec)` through the schemas artefact's
+  registered validator-fn. Snapshots whose machine declares no
+  `:schema`, or for which `machine-meta` returns nil (spawned actor
+  whose host spec is gone), pass silently.
+
+  The spawn-time validator (`validate-spawn-data!`) is the sibling
+  call site for `spawn-fx`'s pre-install check — a spawned actor's
+  initial `:data` is validated before the snapshot lands in app-db so
+  a failing spawn never installs.
+
+  Both validators route through the schemas artefact's late-bind
+  hooks (`:schemas/validate-with-registered-fn` /
+  `:schemas/explain-with-registered-fn`) so an app that ships no
+  schemas artefact pays zero validation cost — the hot path
+  short-circuits at `(late-bind/get-fn-cached ...)` returning nil.
+
+  Per Spec 009 §Production builds the hot-path body lives inside
+  `(when interop/debug-enabled? ...)` so `:advanced` +
+  `goog.DEBUG=false` DCE-elides every literal reason string,
+  keyword, validator deref, and trace call."
+  (:require [re-frame.interop :as interop]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.trace :as trace]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+(defn- emit-failure!
+  "Emit `:rf.error/schema-validation-failure` with `:where :machine-data`
+  per the bead's trace-event shape. `phase` is one of `:macrostep` /
+  `:spawn` / `:bootstrap` — surfaces the lifecycle position to operators.
+
+  The trace tag carries:
+    :where           :machine-data
+    :failing-id      <machine-id>           — uniform error-emit alias
+    :machine-id      <machine-id>           — domain-specific synonym
+    :phase           :macrostep / :spawn / :bootstrap
+    :value           the failing :data map
+    :received        the failing :data map (parallels validate-app-schema!)
+    :schema          the registered schema (verbatim)
+    :explain         the registered explainer's output (or nil)
+    :rollback?       true (macrostep / bootstrap) / false (spawn — no commit)
+    :recovery        :no-recovery
+    :reason          one-sentence diagnostic
+
+  Per Spec 009 / Spec 010 the emit reuses the existing
+  `:rf.error/schema-validation-failure` op; the new `:where` value is
+  the only schema-side extension."
+  [machine-id phase data schema explanation rollback?]
+  (let [explain-fn (late-bind/get-fn-cached :schemas/explain-with-registered-fn)
+        explanation (or explanation
+                        (when explain-fn (explain-fn schema data)))]
+    (trace/emit-error! :rf.error/schema-validation-failure
+                       {:where      :machine-data
+                        :failing-id machine-id
+                        :machine-id machine-id
+                        :phase      phase
+                        :value      data
+                        :received   data
+                        :schema     schema
+                        :explain    explanation
+                        :rollback?  rollback?
+                        :recovery   :no-recovery
+                        :reason     (str "Machine "
+                                         machine-id
+                                         " :data failed schema at boundary :where :machine-data "
+                                         "(phase " phase ").")})))
+
+(defn validate-snapshot-data!
+  "Validate a single machine snapshot's `:data` against the registered
+  schema. Returns true on conform / no schema / no validator; false on
+  failure. Emits the boundary trace on failure with `phase` named.
+
+  Pure-ish — the emit is the side effect; the return value carries the
+  conform decision for the caller's rollback / skip-install plumbing.
+
+  Per the bead's recovery posture:
+    - `:phase :macrostep` and `:phase :bootstrap` → rollback? true
+      (the snapshot is already in app-db at validation time; the
+      router will restore the pre-handler db on a false return).
+    - `:phase :spawn` → rollback? false (the snapshot has not yet
+      installed; the spawn-fx caller skips the install on false)."
+  [machine-id snapshot schema phase]
+  (if-let [validate-fn (late-bind/get-fn-cached
+                         :schemas/validate-with-registered-fn)]
+    (let [data (:data snapshot)]
+      (if (validate-fn schema data)
+        true
+        (do (emit-failure! machine-id phase data schema nil
+                           (not= phase :spawn))
+            false)))
+    true))
+
+(defn validate-machine-data!
+  "Walk every snapshot under `[:rf/machines]` in `db` and validate its
+  `:data` against the registered machine's `:schema`. Returns true
+  iff every snapshot conformed (or carried no schema / no validator);
+  false on first failure with the per-snapshot trace already emitted.
+
+  The router calls this after `:db` commit alongside
+  `validate-app-schema!`; on `false` the router rolls back the
+  cascade (same mechanism as `:where :app-db` rollback).
+
+  Per Spec 009 §Production builds the body lives inside a
+  `(when interop/debug-enabled? ...)` gate so production builds
+  return `true` unconditionally."
+  [db event-id frame-id]
+  (if interop/debug-enabled?
+    (if-let [machine-meta (late-bind/get-fn-cached :machines/machine-meta)]
+      (let [snapshots (get db :rf/machines)]
+        (loop [entries (seq snapshots)
+               ok?     true]
+          (if-let [[machine-id snapshot] (first entries)]
+            (if-let [spec (machine-meta machine-id)]
+              (if-let [schema (:schema spec)]
+                (if (validate-snapshot-data! machine-id snapshot schema
+                                             :macrostep)
+                  (recur (next entries) ok?)
+                  ;; Per the validate-app-schema! pattern (rf2-wkxng): keep
+                  ;; walking so EVERY failing machine surfaces its own trace
+                  ;; (consumers see the full set), and return the conjoined
+                  ;; boolean so the router decides rollback deterministically.
+                  (recur (next entries) false))
+                (recur (next entries) ok?))
+              (recur (next entries) ok?))
+            ;; Bookkeeping shaped for the router's conjunction below —
+            ;; `event-id` and `frame-id` are accepted but unused at this
+            ;; boundary; the per-snapshot emit already names the machine.
+            ;; Same arity as `validate-app-schema!` so the late-bind hook
+            ;; the router consumes can be invoked uniformly.
+            (do
+              (identity event-id)
+              (identity frame-id)
+              ok?))))
+      true)
+    true))
+
+(defn validate-spawn-data!
+  "Sibling of `validate-machine-data!` for the `:rf.machine/spawn` install
+  path. Validates a freshly-built initial snapshot's `:data` against the
+  spawned actor's machine `:schema` BEFORE the snapshot lands in app-db.
+  Returns true on conform / no schema / no validator; false on failure
+  (caller skips the install).
+
+  Per the bead's recovery posture: a spawn failure does not commit, so
+  there is nothing to roll back — `:phase :spawn` emits with
+  `:rollback? false`.
+
+  Per Spec 009 §Production builds the body lives inside a
+  `(when interop/debug-enabled? ...)` gate so production builds
+  return `true` unconditionally — the install proceeds unvalidated
+  under `:advanced` + `goog.DEBUG=false`."
+  [spawned-id spec snapshot]
+  (if interop/debug-enabled?
+    (if-let [schema (:schema spec)]
+      (validate-snapshot-data! spawned-id snapshot schema :spawn)
+      true)
+    true))

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
@@ -21,6 +21,7 @@
   seed the join state at `[:rf/spawned <parent> <invoke-id>]`."
   (:require [re-frame.frame :as frame]
             [re-frame.late-bind :as late-bind]
+            [re-frame.machines.data-validation :as data-validation]
             [re-frame.machines.lifecycle-fx.registration :as registration]
             [re-frame.machines.parallel :as parallel]
             [re-frame.machines.spawn-order :as spawn-order]
@@ -101,43 +102,58 @@
 (defn- install-spawn!
   "Atomically install the spawned actor's initial snapshot, system-id
   binding, and runtime-owned spawn registry slot into the frame's
-  app-db. Returns nil — the side-effect IS the value. Emits the
+  app-db. Returns `:ok` on a successful install, `:rejected` when
+  schema validation rejects the spawned actor's initial `:data` (the
+  caller emitted the trace; the install is skipped). Emits the
   collision and system-id-bound traces when applicable.
 
   `db-after-alloc` is the post-id-allocation db computed by the caller
   (see `spawn-fx`); `swap-frame-db!`'s fn arg is discarded — the merge
   is applied on top of `db-after-alloc` so the caller's counter bump
   survives. Under Spec 002's single-drainer invariant the discarded
-  re-read is value-equal to the snapshot the caller already had."
+  re-read is value-equal to the snapshot the caller already had.
+
+  Per rf2-jbbp7: when the spawning machine's spec carries a `:schema`,
+  the freshly-built initial snapshot's `:data` is validated against
+  it before the snapshot lands. A failure emits
+  `:rf.error/schema-validation-failure :where :machine-data
+  :phase :spawn` and short-circuits the install — the actor never
+  starts. Sibling `:system-id` / `:rf/spawned` registrations are also
+  skipped so the rejected actor leaves no half-installed bookkeeping."
   [frame-id db-after-alloc spec spawned-id
    {:keys [system-id parent-id track?] invoke-id :spawn-id}]
   (let [initial-snap (when spec
                        (parallel/build-initial-snapshot
                          spec {:bootstrap-pending? true}))
         existing     (when system-id (get-in db-after-alloc [:rf/system-ids system-id]))]
-    (when (and system-id existing (not= existing spawned-id))
-      (trace/emit-error! :rf.error/system-id-collision
-                         {:frame             frame-id
-                          :system-id         system-id
-                          :existing-machine  existing
-                          :rebound-to        spawned-id
-                          :reason            (str ":system-id " system-id
-                                                  " was already bound to "
-                                                  existing
-                                                  "; rebinding to " spawned-id
-                                                  " (last-write-wins).")
-                          :recovery          :warned-and-replaced}))
-    (frame/swap-frame-db! frame-id
-                          (fn [_db]
-                            (cond-> db-after-alloc
-                              spec      (assoc-in [:rf/machines spawned-id] initial-snap)
-                              system-id (assoc-in [:rf/system-ids system-id] spawned-id)
-                              track?    (assoc-in [:rf/spawned parent-id invoke-id] spawned-id))))
-    (when system-id
-      (trace/emit! :rf.machine :rf.machine/system-id-bound
-                   {:frame      frame-id
-                    :system-id  system-id
-                    :machine-id spawned-id}))))
+    (if (and spec (not (data-validation/validate-spawn-data!
+                         spawned-id spec initial-snap)))
+      :rejected
+      (do
+        (when (and system-id existing (not= existing spawned-id))
+          (trace/emit-error! :rf.error/system-id-collision
+                             {:frame             frame-id
+                              :system-id         system-id
+                              :existing-machine  existing
+                              :rebound-to        spawned-id
+                              :reason            (str ":system-id " system-id
+                                                      " was already bound to "
+                                                      existing
+                                                      "; rebinding to " spawned-id
+                                                      " (last-write-wins).")
+                              :recovery          :warned-and-replaced}))
+        (frame/swap-frame-db! frame-id
+                              (fn [_db]
+                                (cond-> db-after-alloc
+                                  spec      (assoc-in [:rf/machines spawned-id] initial-snap)
+                                  system-id (assoc-in [:rf/system-ids system-id] spawned-id)
+                                  track?    (assoc-in [:rf/spawned parent-id invoke-id] spawned-id))))
+        (when system-id
+          (trace/emit! :rf.machine :rf.machine/system-id-bound
+                       {:frame      frame-id
+                        :system-id  system-id
+                        :machine-id spawned-id}))
+        :ok))))
 
 ;; ---- :rf.machine/spawn -----------------------------------------------------
 
@@ -224,30 +240,41 @@
     ;; from the frame's app-db (the hand-emitted-spawn fallback path),
     ;; `db-after-alloc` already carries the bumped counter — install the
     ;; snapshot on top of that.
-    (when old-db
-      (install-spawn! frame-id db-after-alloc spec'' spawned-id
-                      {:system-id system-id
-                       :parent-id parent-id
-                       :spawn-id invoke-id
-                       :track?    track?})
-      ;; Per rf2-vsigt — record the spawned actor in the frame's
-      ;; spawn-order channel so frame-destroy can walk in reverse-
-      ;; creation order per Spec 005 §Cross-Spec Interactions §1.
-      (spawn-order/record! frame-id spawned-id))
-    ;; (6) Fire the :start event into the new actor. Per rf2-ijm7,
-    ;; spawns that don't supply :start receive a synthetic
-    ;; [:rf.machine/spawned] so generic child machines can declare their
-    ;; first transition out of an :initial state at spec-write time.
-    (when-let [dispatch! (late-bind/get-fn :router/dispatch!)]
-      ;; Per rf2-t1lxr: machine-spawn :start dispatches are framework-
-      ;; internal lifecycle events — tag :rf/dispatch-origin :internal
-      ;; so Xray's L2 timeline can distinguish actor-bootstrap from
-      ;; user-origin events.
-      (let [start (:start args)
-            opts  {:frame frame-id :rf/dispatch-origin :internal}]
-        (if (some? start)
-          (dispatch! [spawned-id start] opts)
-          (dispatch! [spawned-id [:rf.machine/spawned]] opts))))
+    ;;
+    ;; Per rf2-jbbp7 the install path validates the spawned actor's
+    ;; initial `:data` against the machine's `:schema` (when declared)
+    ;; before landing the snapshot. A `:rejected` return short-circuits
+    ;; the spawn-order recording AND the `:start` dispatch — the actor
+    ;; never enters the runtime, and no parent state observes a
+    ;; half-installed child.
+    (let [install-result
+          (when old-db
+            (let [r (install-spawn! frame-id db-after-alloc spec'' spawned-id
+                                    {:system-id system-id
+                                     :parent-id parent-id
+                                     :spawn-id invoke-id
+                                     :track?    track?})]
+              (when (= r :ok)
+                ;; Per rf2-vsigt — record the spawned actor in the frame's
+                ;; spawn-order channel so frame-destroy can walk in reverse-
+                ;; creation order per Spec 005 §Cross-Spec Interactions §1.
+                (spawn-order/record! frame-id spawned-id))
+              r))]
+      (when-not (= install-result :rejected)
+        ;; (6) Fire the :start event into the new actor. Per rf2-ijm7,
+        ;; spawns that don't supply :start receive a synthetic
+        ;; [:rf.machine/spawned] so generic child machines can declare their
+        ;; first transition out of an :initial state at spec-write time.
+        (when-let [dispatch! (late-bind/get-fn :router/dispatch!)]
+          ;; Per rf2-t1lxr: machine-spawn :start dispatches are framework-
+          ;; internal lifecycle events — tag :rf/dispatch-origin :internal
+          ;; so Xray's L2 timeline can distinguish actor-bootstrap from
+          ;; user-origin events.
+          (let [start (:start args)
+                opts  {:frame frame-id :rf/dispatch-origin :internal}]
+            (if (some? start)
+              (dispatch! [spawned-id start] opts)
+              (dispatch! [spawned-id [:rf.machine/spawned]] opts))))))
     spawned-id))
 
 ;; ---- :rf.machine/spawn-all-init -------------------------------------------

--- a/implementation/machines/test/re_frame/machine_schema_test.clj
+++ b/implementation/machines/test/re_frame/machine_schema_test.clj
@@ -1,0 +1,241 @@
+(ns re-frame.machine-schema-test
+  "Per rf2-jbbp7. Verifies the `:schema` key on `reg-machine` and the
+  new `:where :machine-data` validation boundary.
+
+  The contract under test:
+
+   1. **Acceptance.** `reg-machine` accepts a top-level `:schema` key on
+      the machine spec; registration completes without error and the
+      registered spec carries the schema through `(rf/machine-meta id)`.
+
+   2. **Macrostep boundary.** After a transition action returns a new
+      `:data` that violates the schema, the runtime emits
+      `:rf.error/schema-validation-failure :where :machine-data` and
+      rolls back the entire cascade — `app-db` returns to its pre-event
+      value (so the violating snapshot never sticks).
+
+   3. **Initial-data validation (bootstrap).** A machine whose initial
+      `:data` violates the schema emits the same trace on its first
+      dispatch (the bootstrap commits the initial snapshot to app-db,
+      so the post-commit walker catches the typo).
+
+   4. **Spawn-time validation.** A spawned actor whose initial `:data`
+      violates the schema emits the same trace with `:phase :spawn`
+      and the install is skipped — the actor never enters the runtime.
+
+   5. **No schema → no validation.** Machines without `:schema` are
+      unaffected; the framework's existing behaviour is preserved.
+
+   6. **Tag payload.** Failures carry `:machine-id`, `:phase`, `:value`,
+      `:explain`, `:rollback?`, `:recovery` so the Xray attachment bead
+      (rf2-xgeag) and other downstream consumers have the full surface.
+
+  Tests use Malli schemas (the framework default validator)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.machines :as machines]
+            ;; The schemas artefact ships the registered-validator hot
+            ;; path the new `:where :machine-data` boundary routes
+            ;; through; the `.malli` adapter ns publishes Malli's
+            ;; validate/explain into the late-bind table.
+            [re-frame.schemas]
+            [re-frame.schemas.malli]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [re-frame.trace :as trace]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(defn- collect-traces!
+  "Run `f` while collecting every `:rf.error/schema-validation-failure`
+  trace event. Returns the captured trace events as a vector."
+  [f]
+  (let [traces (atom [])]
+    (rf/register-listener! ::collect (fn [ev] (swap! traces conj ev)))
+    (try (f)
+         (finally (rf/unregister-listener! ::collect)))
+    (filterv #(= :rf.error/schema-validation-failure (:operation %))
+             @traces)))
+
+;; ---- (1) acceptance: `:schema` is accepted on reg-machine ----------------
+
+(deftest reg-machine-accepts-schema-key
+  (testing "reg-machine completes registration when the spec carries :schema"
+    (let [DataSchema [:map [:n :int]]
+          spec       {:initial :idle
+                      :data    {:n 0}
+                      :schema  DataSchema
+                      :states  {:idle {}}}]
+      (rf/reg-machine :rf.machine-schema/accepted spec)
+      (let [meta (rf/machine-meta :rf.machine-schema/accepted)]
+        (is (some? meta) "machine-meta returns the registered spec")
+        (is (= DataSchema (:schema meta))
+            "the :schema key round-trips through machine-meta")))))
+
+;; ---- (2) macrostep boundary: action returns bad :data → rollback + emit --
+
+(deftest macrostep-violation-rolls-back-and-emits
+  (testing "an action returning bad :data triggers a :where :machine-data
+            trace AND rolls back the cascade"
+    (let [DataSchema [:map [:n pos-int?]]
+          spec       {:initial :idle
+                      :data    {:n 1}
+                      :schema  DataSchema
+                      :actions {:break (fn [_] {:data {:n 0}})}     ;; 0 violates pos-int?
+                      :states  {:idle {:on {:go {:target :ran
+                                                 :action :break}}}
+                                :ran  {}}}]
+      (rf/reg-machine :rf.machine-schema/macrostep spec)
+      ;; Bring the machine to life with an event that doesn't violate the schema —
+      ;; bootstrap settles to {:n 1} cleanly.
+      (rf/dispatch-sync [:rf.machine-schema/macrostep [:noop]])
+      (let [snap-before (get-in (rf/get-frame-db :rf/default)
+                                [:rf/machines :rf.machine-schema/macrostep])
+            db-before   (rf/get-frame-db :rf/default)
+            traces      (collect-traces!
+                          #(rf/dispatch-sync [:rf.machine-schema/macrostep [:go]]))
+            trace-ev    (first traces)
+            tag         (:tags trace-ev)]
+        (is (= 1 (count traces))
+            "exactly one :where :machine-data trace fired on the violating macrostep")
+        (is (= :machine-data (:where tag))
+            "trace's :where tag pins the new boundary")
+        (is (= :rf.machine-schema/macrostep (:machine-id tag))
+            "tag carries :machine-id identifying the failing machine")
+        (is (= :rf.machine-schema/macrostep (:failing-id tag))
+            "tag carries :failing-id alias for uniform error-emit projection")
+        (is (= :macrostep (:phase tag))
+            "tag's :phase pins the lifecycle position")
+        (is (= {:n 0} (:value tag))
+            "tag carries the offending :data value")
+        (is (true? (:rollback? tag))
+            "tag declares :rollback? true (commit was rolled back)")
+        ;; `:recovery` is hoisted onto the trace envelope (per rf2-twt7m),
+        ;; not inside `:tags` — mirrors the `:where :app-db` projection.
+        (is (= :no-recovery (:recovery trace-ev))
+            "trace envelope declares :no-recovery (consistent with :where :app-db)")
+        ;; Rollback restores pre-handler app-db.
+        (is (= db-before (rf/get-frame-db :rf/default))
+            "post-rollback app-db equals pre-handler app-db")
+        (is (= snap-before
+               (get-in (rf/get-frame-db :rf/default)
+                       [:rf/machines :rf.machine-schema/macrostep]))
+            "the machine's snapshot returns to its pre-handler value")))))
+
+;; ---- (3) bootstrap-time validation: initial :data violates --------------
+
+(deftest bootstrap-violation-emits-and-rolls-back
+  (testing "an initial :data that violates :schema emits + rolls back the
+            first dispatch's bootstrap commit"
+    (let [DataSchema [:map [:n pos-int?]]
+          ;; Typo: :n is 0 — violates pos-int? on bootstrap.
+          spec       {:initial :idle
+                      :data    {:n 0}
+                      :schema  DataSchema
+                      :states  {:idle {}}}]
+      (rf/reg-machine :rf.machine-schema/bootstrap spec)
+      (let [db-before (rf/get-frame-db :rf/default)
+            traces    (collect-traces!
+                        #(rf/dispatch-sync [:rf.machine-schema/bootstrap [:noop]]))
+            tag       (-> traces first :tags)]
+        (is (= 1 (count traces))
+            "exactly one boundary trace fires for the bootstrap violation")
+        (is (= :machine-data (:where tag)))
+        (is (= {:n 0} (:value tag)))
+        ;; Rollback drops the violating snapshot.
+        (is (nil? (get-in (rf/get-frame-db :rf/default)
+                          [:rf/machines :rf.machine-schema/bootstrap]))
+            "rolled back: the machine snapshot is not installed in app-db")
+        (is (= db-before (rf/get-frame-db :rf/default))
+            "rolled back: app-db unchanged")))))
+
+;; ---- (4) spawn-time validation: spawned actor's :data violates ----------
+
+(deftest spawn-violation-emits-and-skips-install
+  (testing "a spawned actor whose initial :data violates the schema is rejected
+            at install time; the snapshot never lands in app-db"
+    (let [ChildSchema [:map [:n pos-int?]]
+          ;; Child spec violates its own schema at bootstrap.
+          child-spec  {:initial :idle
+                       :data    {:n 0}
+                       :schema  ChildSchema
+                       :states  {:idle {}}}
+          parent-spec {:initial :starting
+                       :data    {}
+                       :states  {:starting
+                                 {:on {:go :spawning}}
+                                 :spawning
+                                 {:entry (fn [_]
+                                           {:fx [[:rf.machine/spawn
+                                                  {:spawn-id   :rf.machine-schema/spawned
+                                                   :definition child-spec}]]})}}}]
+      (rf/reg-machine :rf.machine-schema/spawn-parent parent-spec)
+      (rf/dispatch-sync [:rf.machine-schema/spawn-parent [:noop]])
+      (let [traces (collect-traces!
+                     #(rf/dispatch-sync [:rf.machine-schema/spawn-parent [:go]]))
+            tag    (-> traces first :tags)]
+        ;; The spawn-time validation emits exactly one :where :machine-data
+        ;; trace with :phase :spawn — no macrostep-phase trace fires for the
+        ;; rejected actor because its snapshot never lands in app-db.
+        (let [machine-data-traces (filter #(= :machine-data (-> % :tags :where)) traces)]
+          (is (= 1 (count machine-data-traces))
+              "exactly one :where :machine-data trace fires on spawn rejection"))
+        (is (= :machine-data (:where tag)))
+        (is (= :spawn (:phase tag))
+            ":phase :spawn distinguishes spawn-time from macrostep failures")
+        (is (false? (:rollback? tag))
+            "spawn-phase failure carries :rollback? false (nothing was committed)")
+        ;; The spawned actor's snapshot was never installed.
+        (is (nil? (get-in (rf/get-frame-db :rf/default)
+                          [:rf/machines :rf.machine-schema/spawned]))
+            "rejected spawn: snapshot is not in app-db")))))
+
+;; ---- (5) no schema → no validation (control) ------------------------------
+
+(deftest no-schema-no-validation
+  (testing "a machine without :schema runs without any :where :machine-data trace"
+    (let [spec {:initial :idle
+                :data    {:n "anything goes"}
+                :actions {:set-x (fn [_] {:data {:n 42}})}
+                :states  {:idle {:on {:go {:target :idle :action :set-x}}}}}]
+      (rf/reg-machine :rf.machine-schema/no-schema spec)
+      (let [traces (collect-traces!
+                     (fn []
+                       (rf/dispatch-sync [:rf.machine-schema/no-schema [:noop]])
+                       (rf/dispatch-sync [:rf.machine-schema/no-schema [:go]])))]
+        (is (empty? traces)
+            "no :where :machine-data trace for a no-schema machine")
+        ;; Sanity: the action ran and updated :data.
+        (is (= 42 (get-in (rf/get-frame-db :rf/default)
+                          [:rf/machines :rf.machine-schema/no-schema :data :n]))
+            "the no-schema machine's :data updates normally")))))
+
+;; ---- (6) tag payload completeness for downstream consumers ----------------
+
+(deftest tag-payload-carries-downstream-required-keys
+  (testing "the failure tag carries every key Xray's per-step attachment
+            consumes (rf2-xgeag) — :machine-id, :phase, :value, :explain,
+            :rollback?, :recovery, :reason"
+    (let [DataSchema [:map [:n pos-int?]]
+          spec       {:initial :idle
+                      :data    {:n 1}
+                      :schema  DataSchema
+                      :actions {:bad (fn [_] {:data {:n 0}})}
+                      :states  {:idle {:on {:go {:target :idle :action :bad}}}}}]
+      (rf/reg-machine :rf.machine-schema/payload spec)
+      (rf/dispatch-sync [:rf.machine-schema/payload [:noop]])
+      (let [traces   (collect-traces!
+                       #(rf/dispatch-sync [:rf.machine-schema/payload [:go]]))
+            trace-ev (first traces)
+            tag      (:tags trace-ev)]
+        (is (= :machine-data (:where tag)))
+        (is (= :rf.machine-schema/payload (:machine-id tag)))
+        (is (= :rf.machine-schema/payload (:failing-id tag)))
+        (is (= :macrostep (:phase tag)))
+        (is (contains? tag :value)        ":value present (Xray reads the failing slot)")
+        (is (contains? tag :explain)      ":explain present (Xray renders Malli explanation)")
+        (is (contains? tag :rollback?)    ":rollback? present (Xray's blast-radius muting)")
+        ;; `:recovery` rides the trace envelope, not :tags (rf2-twt7m).
+        (is (contains? trace-ev :recovery) ":recovery present on trace envelope")
+        (is (string? (:reason tag))       ":reason is a human-readable string")))))

--- a/implementation/scripts/check-elision.cjs
+++ b/implementation/scripts/check-elision.cjs
@@ -68,6 +68,13 @@ const DEV_ONLY_SENTINELS = [
   // re-frame.schemas — validate-fx! reason string.
   { source: 're-frame.schemas/validate-fx!',
     sentinel: ' args failed schema ' },
+  // re-frame.machines.data-validation — :where :machine-data reason
+  // string (rf2-jbbp7). The post-commit / spawn-time machine `:data`
+  // validators both sit inside `(when interop/debug-enabled? ...)`
+  // gates; the distinctive substring " :data failed schema at boundary
+  // :where :machine-data " must elide under :advanced + goog.DEBUG=false.
+  { source: 're-frame.machines.data-validation/emit-failure!',
+    sentinel: ' :data failed schema at boundary :where :machine-data ' },
   // re-frame.registrar — handler-replaced trace op (only emitted from a
   // gated branch in registrar/register!).  Keywords survive :advanced
   // as string literals; this is a structural sentinel.

--- a/spec/005-StateMachines.md
+++ b/spec/005-StateMachines.md
@@ -421,7 +421,7 @@ Consumers route on `:where` — the existing Issues triage, Xray projections, sc
 
 **Production builds.** Per [010 §Production builds](010-Schemas.md#production-builds), the validation site is gated by `re-frame.interop/debug-enabled?` and DCEs to a no-op under `:advanced` + `goog.DEBUG=false`. The boundary is dev-only by default; apps needing production validation at system boundaries reach for the `:rf.schema/at-boundary` interceptor on the specific events that ingest untrusted machine `:data` (e.g. an SSR-hydrate that restores machine snapshots from the wire).
 
-**Cross-reference.** Per [010 §Per-step recovery row 7](010-Schemas.md#per-step-recovery), this boundary is row 7 of the per-step recovery table; the `:where :machine-data` value is the closed-set extension to [Spec-Schemas §`SchemaValidationTags`](Spec-Schemas.md#schema-validation-tags). The aspirational paragraphs at [§Where snapshots live](#where-snapshots-live) and the §What the Single Store gives us for free Schema-validation bullet become factual with this surface; the sibling bead (rf2-mr1ei) reconciles the prose.
+**Cross-reference.** Per [010 §Per-step recovery row 7](010-Schemas.md#per-step-recovery), this boundary is row 7 of the per-step recovery table; the `:where :machine-data` value is the closed-set extension to [Spec-Schemas §`SchemaValidationTags`](Spec-Schemas.md#per-category-tags-schemas). The aspirational paragraphs at [§Where snapshots live](#where-snapshots-live) and the §What the Single Store gives us for free Schema-validation bullet become factual with this surface; the sibling bead (rf2-mr1ei) reconciles the prose.
 
 ### Trace events — guard evaluations and action runs
 

--- a/spec/005-StateMachines.md
+++ b/spec/005-StateMachines.md
@@ -175,6 +175,7 @@ A transition table is pure data. Top-level shape:
 ```clojure
 {:initial <fsm-keyword>                     ;; required — initial state
  :data    {<initial data>}                  ;; optional — initial data map
+ :schema  <validator-schema>                ;; optional — validates `:data` at the `:where :machine-data` boundary (see §Schema validation)
  :guards  {<keyword> <fn>, ...}             ;; optional — machine-local named guard impls
  :actions {<keyword> <fn>, ...}             ;; optional — machine-local named action impls
  :states  {<fsm-keyword> <state-node>, ...} ;; required
@@ -192,6 +193,7 @@ The snapshot's location in `app-db` is `[:rf/machines <id>]` — runtime-managed
 |---|---|---|
 | `:initial` | top-level | required — the initial FSM-keyword |
 | `:data` | top-level | optional — initial data map |
+| `:schema` | top-level | optional — validates the machine's `:data` slot at every macrostep boundary + at bootstrap; failures emit `:rf.error/schema-validation-failure :where :machine-data` and roll back the cascade. See [§Schema validation](#schema-validation). |
 | `:guards` | top-level | optional — `{<keyword> <fn>}` map of machine-local named guards; referenced by keyword from `:guard` slots |
 | `:actions` | top-level | optional — `{<keyword> <fn>}` map of machine-local named actions; referenced by keyword from `:action` / `:entry` / `:exit` slots |
 | `:meta` | top-level | optional — e.g. `:rf/snapshot-version` |
@@ -373,6 +375,53 @@ If the composition is reused, name it in the machine's `:actions` map:
 ```
 
 This is the design rule from above: imperative composition is fns, not data DSLs; named entries in the machine's `:actions` map add semantic content visualisers and AIs can read. Resolution is machine-scoped per [§Registration — the machine IS the event handler](#registration--the-machine-is-the-event-handler); unresolved references fail registration with `:rf.error/machine-unresolved-action`. Cross-machine reuse: define a Clojure var and reference it from each machine's `:actions` map.
+
+### Schema validation
+
+Per rf2-jbbp7, a machine spec MAY declare a top-level **`:schema`** key. The schema validates the machine's `:data` slot — the user-domain extended state. Mirrors how `:schema` rides on every other registration kind (`reg-event-*`, `reg-cofx`, `reg-fx`, `reg-sub`):
+
+```clojure
+(rf/reg-machine :drawer/editor
+  {:initial :idle
+   :data    {:circles [] :undo [] :redo []}
+   :schema  DrawerData                ;; validates :data
+   :guards  {...}
+   :actions {...}
+   :states  {...}})
+```
+
+The schema's job is exactly the user-domain `:data` shape. The snapshot's `:state` slot is already validated at registration time (a transition targeting an unknown state fails registration); the snapshot's reserved `:rf/*` slots are framework-owned.
+
+**Validation timing — the macrostep boundary.** `:data` is mutated at six sites (initial install, `:on-spawn-actions`, `:entry` actions, `:exit` actions, transition `:action`, `:always` / `:after` actions). The natural validation point is the **macrostep commit** — after the exit → transition-action → entry sequence settles and the runtime is about to write the new snapshot back to `app-db`. One validation per macrostep regardless of how many actions fired; the snapshot the framework would write is the value validated. This is the same lifecycle position as the existing `:where :app-db` check.
+
+**Initial-data installation.** At machine bootstrap the initial `:data` is installed into the snapshot. The bootstrap cascade fires the initial state's `:entry` actions on the first event, then commits — the macrostep validator catches both the bootstrap typo (`:data {:circles []}` declared but the schema requires `:cirles`) and any initial-`:entry` action that returns a violating `:data`.
+
+**Spawn-time validation.** A spawned actor's initial `:data` is validated **before the snapshot lands in app-db** (rather than at the next macrostep commit). A failing spawn never installs — the actor never enters the runtime, and no parent state observes a half-installed child. The failure emits with `:phase :spawn` and `:rollback? false` (no commit to roll back).
+
+**Failure trace.** The boundary reuses the existing `:rf.error/schema-validation-failure` op with a new `:where` value:
+
+```clojure
+{:op   :rf.error/schema-validation-failure
+ :tags {:where           :machine-data
+        :failing-id      <machine-id>           ;; uniform error-emit alias
+        :machine-id      <machine-id>           ;; domain-specific synonym
+        :phase           :macrostep             ;; or :spawn
+        :value           <failing-:data-map>    ;; redactable per Spec 010 §`:sensitive?`
+        :received        <failing-:data-map>    ;; parallels :where :app-db
+        :schema          <the registered schema verbatim>
+        :explain         <validator's explainer output>
+        :rollback?       true                   ;; false for :phase :spawn
+        :recovery        :no-recovery
+        :reason          "Machine <id> :data failed schema..."}}
+```
+
+Consumers route on `:where` — the existing Issues triage, Xray projections, schema-violation-row plumbing, and the per-step attachment bead (rf2-xgeag) all flow through one row shape with one new `:where` case.
+
+**Recovery — full-cascade rollback.** Machine state lives in `app-db`; the cascade's `:db-before` / `:db-after` capture the pre/post snapshot of EVERY machine along with the rest of `app-db`. A failure at the `:where :machine-data` boundary rolls back the entire commit (same mechanism the `:where :app-db` boundary uses). The framework cannot surgically roll back just one machine's macrostep without affecting other state mutations the handler performed; full-cascade rollback is the only consistent option. For the Epoch panel: same blast-radius muting treatment as `:where :app-db` rollback.
+
+**Production builds.** Per [010 §Production builds](010-Schemas.md#production-builds), the validation site is gated by `re-frame.interop/debug-enabled?` and DCEs to a no-op under `:advanced` + `goog.DEBUG=false`. The boundary is dev-only by default; apps needing production validation at system boundaries reach for the `:rf.schema/at-boundary` interceptor on the specific events that ingest untrusted machine `:data` (e.g. an SSR-hydrate that restores machine snapshots from the wire).
+
+**Cross-reference.** Per [010 §Per-step recovery row 7](010-Schemas.md#per-step-recovery), this boundary is row 7 of the per-step recovery table; the `:where :machine-data` value is the closed-set extension to [Spec-Schemas §`SchemaValidationTags`](Spec-Schemas.md#schema-validation-tags). The aspirational paragraphs at [§Where snapshots live](#where-snapshots-live) and the §What the Single Store gives us for free Schema-validation bullet become factual with this surface; the sibling bead (rf2-mr1ei) reconciles the prose.
 
 ### Trace events — guard evaluations and action runs
 

--- a/spec/010-Schemas.md
+++ b/spec/010-Schemas.md
@@ -49,6 +49,18 @@ Every registration accepts an optional `:schema` in its metadata map:
   (fn [coeffects _] (assoc coeffects :now (js/Date.))))
 ```
 
+Machines (per [005 §Schema validation](005-StateMachines.md#schema-validation)) carry `:schema` at the top of the machine spec — the value validates the machine's `:data` slot at every macrostep boundary and at bootstrap (per rf2-jbbp7):
+
+```clojure
+(rf/reg-machine :drawer/editor
+  {:initial :idle
+   :data    {:circles []}
+   :schema  DrawerData                ;; validates :data
+   :states  {...}})
+```
+
+A failure emits `:rf.error/schema-validation-failure :where :machine-data` and rolls back the cascade (per [§Per-step recovery row 7](#per-step-recovery)).
+
 ### `app-db` schemas — path-based
 
 Rather than one giant schema for the whole `app-db`, schemas are registered **at paths**:
@@ -129,6 +141,7 @@ For a single dispatched event, schema checks fire in this order:
 2. Cofx schemas (from `reg-cofx` `:schema`) — after each cofx injects, before the handler sees the merged context.
 3. Handler runs.
 4. `app-db` path schemas — at the single deferred `:db` install, validating the **flow-augmented** pending `:db` effect. By this point the flow transform has already rewritten the pending `:db` effect as the outermost `:after` (per [013 §Drain integration](013-Flows.md#drain-integration)), so the value validated and installed is the flow-augmented db, not the handler's raw `:db`.
+4a. Machine-`:data` schemas (from `reg-machine` `:schema`, per rf2-jbbp7) — alongside step 4 the runtime walks `[:rf/machines]` and validates each snapshot's `:data` against its registered machine's `:schema`. Both validators AND-conjoin: a `false` from either rolls back the `:db` commit. Per [005 §Schema validation](005-StateMachines.md#schema-validation).
 5. Effect schemas (from `reg-fx` `:schema`) — before each fx handler runs.
 6. Sub return-value schemas — after each materialisation/recompute that involves a schema'd sub.
 
@@ -144,6 +157,7 @@ A failure at any step aborts the dispatch with a structured error.
 | 4. `app-db` path | The **flow-augmented** pending `:db` value at a registered schema-bound path doesn't conform (validated at the single deferred install — flows have already run as the outermost `:after`). | Emit with `:where :app-db`; the trace tag carries `:rollback? true` and `:recovery :no-recovery`. The flow-augmented `:db` effect is **not installed** (no commit — `app-db` keeps its pre-event value) and the dispatch is treated as failed — no `:rf.event/db-changed` fires and `:fx` does **not** walk for this dispatch. The flow writes that were folded into the pending `:db` are discarded with it (they were never committed). Downstream queued events still drain (per run-to-completion). |
 | 5. Fx-args | A registered fx's args map doesn't conform to its `:schema`. | The **offending fx is skipped**; emit with `:where :fx-args`, `:fx-id`, `:fx-args`. Other fx in the same `:fx` vector continue to run (per the run-to-completion drain — fx are independent). The cascade does **not** halt; downstream events in the queue still drain. The skipped-fx outcome is `:recovery :skipped`, mirroring `:rf.fx/skipped-on-platform`. |
 | 6. Sub return-value | A schema'd sub's computed value doesn't conform. | Emit with `:where :sub-return`. Default recovery: `:replaced-with-default` — the sub returns `nil` to its consumer; views see no value. Strict mode re-raises. |
+| 7. Machine `:data` (per rf2-jbbp7) | A machine snapshot's `:data` slot — after a macrostep, at bootstrap, or at spawn-install time — doesn't conform to its registered `:schema` (declared on the `reg-machine` spec per [005 §Schema validation](005-StateMachines.md#schema-validation)). | Same as row 4 — full-cascade rollback at the macrostep/bootstrap boundary. Emit with `:where :machine-data`, `:failing-id` = `:machine-id` = the failing machine, `:phase :macrostep` (post-transition) or `:phase :bootstrap` (initial install) or `:phase :spawn` (pre-install rejection), `:value` = the offending `:data`, `:explain` = validator's explanation, `:rollback?` true (macrostep/bootstrap) or false (spawn — nothing committed), `:recovery :no-recovery`. The `:phase :spawn` failure short-circuits the spawn-install: the actor never enters the runtime, no sibling `:system-id` / `:rf/spawned` bookkeeping is recorded. |
 
 The fx-args recovery is "skip the offending fx, continue the rest" rather than "halt the dispatch" because a single broken fx (a typo in a `:url`, a missing required key) should not take down the rest of an event's effect cascade. The trace event names the failing fx; the rest of the page continues to render.
 

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -705,13 +705,17 @@ Common keys (`:category`, `:failing-id`, `:reason`, `:frame`) are inherited from
    [:category        [:= :rf.error/schema-validation-failure]]
    [:failing-id      :keyword]
    [:reason          {:optional true} :string]
-   [:where           [:enum :event :sub-return :app-db :fx-args :cofx :on-create]]
+   [:where           [:enum :event :sub-return :app-db :fx-args :cofx :on-create :machine-data]] ;; rf2-jbbp7 — :machine-data is the `reg-machine` :schema boundary (Spec 005 §Schema validation, Spec 010 §Per-step recovery row 7)
    [:path            {:optional true} [:vector :any]]
    [:value           {:optional true} :any]
    [:explain         {:optional true} :any]            ;; Malli explanation shape
    [:rf.sub/query-v  {:optional true} :any]            ;; (:where :sub-return only) caller-supplied query vector; redacted to :rf/redacted when sub is :sensitive? — see Spec/010
-   [:rollback?       {:optional true} :boolean]        ;; (:where :app-db only) true when :db was rolled back to pre-handler value
-   [:registered-path {:optional true} [:vector :any]]]) ;; (:where :app-db only) registration root; :path is the failing leaf — see Spec/010
+   [:rollback?       {:optional true} :boolean]        ;; (:where :app-db / :machine-data) true when :db was rolled back to pre-handler value; false for :where :machine-data :phase :spawn (nothing committed)
+   [:registered-path {:optional true} [:vector :any]]  ;; (:where :app-db only) registration root; :path is the failing leaf — see Spec/010
+   [:machine-id      {:optional true} :keyword]        ;; (:where :machine-data only) the failing machine's id; mirrors :failing-id for domain clarity. Per rf2-jbbp7.
+   [:phase           {:optional true} [:enum :macrostep :bootstrap :spawn]] ;; (:where :machine-data only) lifecycle position of the violation: :macrostep (post-transition commit), :bootstrap (initial :data install on the first dispatch), :spawn (pre-install spawn rejection). Per rf2-jbbp7.
+   [:received        {:optional true} :any]            ;; (:where :machine-data / :app-db / :event / :cofx / :sub-return / :fx-args) parallel to :value; the value the validator received. Per rf2-4fbsd.
+   [:schema          {:optional true} :any]])           ;; (:where :machine-data only) the registered schema verbatim, so consumers can render it inline next to the failing :data. Per rf2-jbbp7.
 
 (def DrainDepthExceededTags
   [:map


### PR DESCRIPTION
## Why

Today there is no first-class way to nominate a schema for a state machine's `:data` slot. Users can attach validation via `reg-app-schema [:rf/machines <id> :data] ...` but the schema lives apart from the machine spec, the failure surfaces as `:where :app-db` with a deeply-nested path, and the loose coupling reads as accidental rather than designed.

Worse, Spec 005 already commits to the behaviour as if it shipped — two paragraphs at §Where snapshots live + §What the Single Store gives us for free claim `:rf/machines`'s schema composes "automatically from the registered machines' `:data` schemas" but the grammar table lists no `:schema` slot. This bead adds the surface; the sibling reconciliation bead (rf2-mr1ei) removes the aspirational framing.

## API shape

Mirrors how `:schema` rides on every other registration kind:

```clojure
(rf/reg-machine :drawer/editor
  {:initial :idle
   :data    {:circles [] :undo [] :redo []}
   :schema  DrawerData                ;; validates :data
   :guards  {...}
   :actions {...}
   :states  {...}})
```

The schema validates the machine's user-domain `:data`. Reserved `:rf/*` slots are framework-owned and out of scope; `:state` is already validated at registration time via the existing state-id resolution.

## Boundary semantics

| Phase | When | Failure recovery |
|---|---|---|
| `:macrostep` | After a transition cascade commits (the post-handler db install) | Full cascade rollback — same mechanism as `:where :app-db` |
| `:bootstrap` | Initial-`:data` install on first dispatch (covered by the `:macrostep` walker — bootstrap is part of the first commit) | Full cascade rollback |
| `:spawn` | Before `spawn-fx` installs the spawned actor's snapshot | Install short-circuited; no rollback needed (nothing committed). Sibling `:system-id` / `:rf/spawned` bookkeeping is also skipped |

The new `:where :machine-data` value joins the `:rf.error/schema-validation-failure` :where enum. Tag carries `:machine-id`, `:phase`, `:value`, `:received`, `:schema`, `:explain`, `:rollback?`, `:recovery`, `:reason` — the full surface Xray's per-step attachment (rf2-xgeag) needs.

## Recovery is full-cascade rollback

Machine state lives in app-db; the cascade's `:db-before` / `:db-after` capture the pre/post snapshot of every machine. The framework cannot surgically roll back just one machine's macrostep, so a `:where :machine-data` failure rolls back the entire commit (matching `:where :app-db`).

Mechanism: the router's `run-post-commit-validation!` now AND-conjoins `:schemas/validate-app-schema!` with the new `:machines/validate-machine-data!`; a false from either triggers the existing app-db rollback path. The Epoch panel gets the same blast-radius muting for free.

## File inventory

**Framework**
- `implementation/machines/src/re_frame/machines/data_validation.cljc` (new) — boundary call sites
- `implementation/machines/src/re_frame/machines.cljc` — late-bind publication
- `implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc` — pre-install gate
- `implementation/core/src/re_frame/router.cljc` — AND-conjoin in post-commit validation
- `implementation/core/src/re_frame/late_bind/directory.cljc` — new hook entry

**Spec**
- `spec/005-StateMachines.md` — grammar table + new §Schema validation
- `spec/010-Schemas.md` — validation-order entry 4a + per-step recovery row 7 + where-schemas-attach
- `spec/Spec-Schemas.md` — `:where` enum extension + new optional tag keys

**Tests**
- `implementation/machines/test/re_frame/machine_schema_test.clj` (new) — 6 tests, 33 assertions

**Probes / dev**
- `implementation/core/test/re_frame/elision_probe.cljs` — extended to root the new reason-string sentinel
- `implementation/scripts/check-elision.cjs` — new sentinel
- `implementation/machines/deps.edn` — test-only dep on schemas

## Quality gates

- `bash scripts/test-jvm-implementation.sh` — full JVM sweep, 0 failures (machines 292 tests, schemas 192, core 792, all artefacts green)
- `npm run test:cljs` — 4770 tests / 15513 assertions, 0 failures
- `npm run test:elision` — production 39/39 absent, control 39/39 present
- `npm run test:bundle-isolation` — pass
- `re-frame.late-bind-drift-test` — pass (new hook in directory)

## Out of scope (follow-ons)

- rf2-mr1ei (sibling, BLOCKS-ON this) — reconcile the aspirational prose in spec/005:154 + 165
- rf2-xgeag — Xray Epoch panel per-step attachment will consume `:where :machine-data` as a new attachment site

Closes rf2-jbbp7.