### PR TITLE
feat(xray): editor-override in Settings popup General tab (rf2-dudqz)

### DIFF
--- a/tools/xray/spec/007-UX-IA.md
+++ b/tools/xray/spec/007-UX-IA.md
@@ -652,7 +652,7 @@ mute manager modal). The Buffer tab inherited the
 
 | # | Tab | Mnemonic | Content |
 |---|---|---|---|
-| 1 | **General** | `g` | Text size · Panel width · Panel position · Auto-open-on-error · Density (Cosy / Compact — no Comfy) · Long-keyword threshold · **Power user:** "Show tool frames in picker" toggle (off by default) · `:use-system-colors?` HCM-override toggle (relocated from Theme per rf2-ou3pn — slot is `:general :use-system-colors?`) |
+| 1 | **General** | `g` | Text size · Panel width · Panel position · Auto-open-on-error · Density (Cosy / Compact — no Comfy) · Long-keyword threshold · **Editor override** (rf2-dudqz — per-machine click-to-source picker; nil / `:vscode` / `:cursor` / `:windsurf` / `:zed` / `:idea` / `{:custom <tpl>}`; default nil = use host default) · **Power user:** "Show tool frames in picker" toggle (off by default) · `:use-system-colors?` HCM-override toggle (relocated from Theme per rf2-ou3pn — slot is `:general :use-system-colors?`) |
 | 2 | **Keybindings** | `k` | Read-only chord table (every binding the global listener captures) · master "Handle keys?" toggle. v1 is READ-ONLY; rebind UI is the v1.1 follow-on. |
 | 3 | **Buffer** | `b` | `:general :epoch-history` (slider, relocated from General per rf2-pu9sb — slot stays under `:general` for the persisted-settings shape, only the popup home moved) · `:buffer/cascades-retained` · `:app-db/inspector-collapse-threshold` · "Clear buffer now" button with confirm modal |
 | 4 | **Diff** | `d` | Hiccup-diff opt-in `:highlight-fn-ref-changes?` toggle (sub-output diff layout fixed unified; section-grouping threshold fixed defaults — both dropped from the user surface) |
@@ -1307,6 +1307,43 @@ panel may inline its own URI assembly.
 - The preference is **session-scoped**, persisted via the same Xray
   config substrate as theme / density. No cloud-sync.
 - Xray's preference is **independent** of Story's `:rf.story/editor`.
+
+### End-user override (rf2-dudqz)
+
+Mixed-editor teams: the host app's `:rf.xray/editor` is project-wide,
+but an individual operator MAY want a different click-to-source target
+on their machine (e.g. a JetBrains user on a VS-Code-default team).
+The **Settings popup → General tab → "Click-to-source links open in"
+picker** is the per-machine override.
+
+- **Slot:** `[:general :editor-override]` inside the persisted
+  settings map. Persists via the same localStorage round-trip every
+  other operator preference uses (`re-frame2.xray.settings.v1`); no
+  new storage key.
+- **Default:** `nil` — no override; the host's `:rf.xray/editor`
+  default wins.
+- **Accepted values:** identical to `:rf.xray/editor` — `nil`,
+  `:vscode`, `:cursor`, `:windsurf`, `:zed`, `:idea`, or `{:custom
+  "<tpl>"}`. The picker surfaces every enumerated keyword as a radio
+  plus a "(project default)" radio (writes `nil`) plus a "Custom URI
+  template" radio + text input (writes the `{:custom …}` shape).
+- **Resolution order:** `config/get-editor` returns the FIRST
+  non-nil tier of `[end-user-override → host default → :vscode]`.
+  Selection is immediate — the next click-to-source affordance uses
+  the override URI without a reload.
+- **Reset:** the "Reset to project default" button clears the
+  override (writes `nil`); the picker shows "Project default:
+  <host-editor-name>" so the operator knows what flipping back
+  lands on.
+- **Scope:** purely client-side. The override does NOT mutate the
+  host's atom and does NOT reach other browsers / tabs / users.
+  Clearing the override falls back to the host's `configure!` value.
+- **Security boundary:** the `{:custom …}` template still passes
+  through the rf2-cm93v / rf2-p887o positive scheme allowlist at
+  click time. A template that resolves to a disallowed scheme
+  (`http:` / `https:` / `javascript:` / `data:` / `vbscript:`)
+  silently no-ops at the chip — the picker is NOT a route around the
+  allowlist.
 
 ### Cross-references
 

--- a/tools/xray/spec/015-Configuration.md
+++ b/tools/xray/spec/015-Configuration.md
@@ -212,6 +212,26 @@ running both tools MAY route each to a different editor — e.g.
 `:vscode` for the application code Xray points at, `:idea` for the
 Story test corpus.
 
+#### End-user override (rf2-dudqz)
+
+`:rf.xray/editor` is the **project-wide default** set by the host
+app's boot. Individual operators on a mixed-editor team MAY override
+it for their machine via the **Settings popup → General tab →
+"Click-to-source links open in" picker** ([`007-UX-IA.md` §End-user
+override](./007-UX-IA.md#end-user-override-rf2-dudqz)).
+
+The override lives in the persisted-settings map at
+`[:general :editor-override]`; it accepts the same value shape as
+`:rf.xray/editor` (`nil` / enumerated keyword / `{:custom <tpl>}`).
+`config/get-editor` returns the FIRST non-nil tier of
+`[end-user-override → host default → :vscode]`. The override is
+purely client-side — it does NOT mutate the host's atom and does NOT
+reach other browsers / tabs / users.
+
+Tests cover the resolution order, the localStorage round-trip, and
+the `open-chip` / `:rf.xray/open-in-editor` consumers under
+`tools/xray/test/day8/re_frame2_xray/settings/editor_override_cljs_test.cljs`.
+
 ### `:rf.xray/project-root`
 
 The on-disk root prepended to the source-coord's classpath-relative

--- a/tools/xray/src/day8/re_frame2_xray/config.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/config.cljc
@@ -32,6 +32,14 @@
                        [re-frame.core :as rf]
                        [re-frame.frame :as frame]])))
 
+;; Forward declarations. The `editor preference` block (`get-editor`)
+;; reads the `settings` atom defined further down the file (the popup
+;; persistence layer); the `declare` pacifies the analyser's warning
+;; without changing initialization order — the atom's runtime value
+;; is what matters when `get-editor` is called, and the file's
+;; top-to-bottom `defonce` order guarantees the atom is bound by then.
+(declare settings)
+
 ;; ---- editor preference ---------------------------------------------------
 
 (def default-layout-host-selector
@@ -386,10 +394,43 @@
   (reset! editor (or e :vscode))
   nil)
 
-(defn get-editor
-  "Return the current editor preference."
+(defn get-host-editor-default
+  "Return the host's `:rf.xray/editor` default — the value
+  `set-editor!` (or `xray-config/configure! {:rf.xray/editor …}`)
+  pushed into the atom at boot. Settings popup's editor-override
+  picker reads this to render the 'Project default: <name>' hint
+  next to the Reset button (per rf2-dudqz).
+
+  This is NOT the value `get-editor` returns when an end-user override
+  is in play — it is the BASE the override sits on top of."
   []
   @editor)
+
+(defn get-editor
+  "Return the editor preference Xray's 'Open in editor' affordance
+  should target.
+
+  Three-tier resolution (per rf2-dudqz):
+
+    1. **End-user override** — the `[:general :editor-override]`
+       settings slot. Settable via the Settings popup → General tab
+       'Click-to-source opens in' picker; round-trips through
+       localStorage like every other operator preference. Wins when
+       non-nil so a mixed-editor teammate can flip their machine to
+       a different editor without touching the host app's boot config.
+    2. **Host default** — the `editor` atom set by
+       `set-editor!` / `(xray-config/configure! {:rf.xray/editor …})`.
+       The team's project-wide pick.
+    3. **Framework default** — `:vscode`, the most-installed editor
+       in 2026 (per spec/007-UX-IA.md §URI construction).
+
+  The override is purely client-side — it does NOT mutate the host's
+  atom. Clearing the override (selecting '(project default)' in the
+  picker) restores the host default."
+  []
+  (let [override (try (get-in @settings [:general :editor-override])
+                      (catch #?(:clj Throwable :cljs :default) _ nil))]
+    (or override @editor)))
 
 ;; ---- *project-root* (rf2-5m5n2 — 'Open in editor' path prefix) ----------
 ;;
@@ -872,7 +913,27 @@
                ;; persisted payload is always in-range.
                :event-list-col-widths   {:source    52
                                          :timestamp 76
-                                         :duration  60}}
+                                         :duration  60}
+               ;; rf2-dudqz — end-user editor override for Xray's
+               ;; 'Open in editor' click-to-source links. Mixed-editor
+               ;; teams: the host app sets `:rf.xray/editor` once at
+               ;; boot via `xray-config/configure!`, but individual
+               ;; operators on the team can override per-machine via
+               ;; the Settings popup → General tab. Default `nil` —
+               ;; no override; `get-editor` returns the host default.
+               ;;
+               ;; Accepted values mirror `set-editor!` exactly so the
+               ;; override is interchangeable with the host atom:
+               ;;   nil          — no override (use host default)
+               ;;   :vscode | :cursor | :windsurf | :zed | :idea
+               ;;   {:custom "<uri-template>"}
+               ;;
+               ;; Persists via the existing settings localStorage
+               ;; round-trip — one key + one merge path for every
+               ;; per-user preference. The override lives entirely
+               ;; client-side; it never mutates the host's atom and
+               ;; never reaches other browsers / tabs / users.
+               :editor-override         nil}
    :theme     :light                                 ; :light | :dark (rf2-3f2di — light default per the authority reference)
    :diff      {:highlight-fn-ref-changes? false}
    :buffer    {:retained-epochs                    200

--- a/tools/xray/src/day8/re_frame2_xray/settings/subs.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/settings/subs.cljs
@@ -67,6 +67,17 @@
         {:highlight-fn-ref-changes? (boolean
                                       (:highlight-fn-ref-changes? diff))})))
 
+  ;; rf2-dudqz — host editor default (the `editor` atom set by
+  ;; `set-editor!` / `(xray-config/configure! {:rf.xray/editor …})`).
+  ;; Read by the Settings popup's editor-override picker so the
+  ;; "Project default: <name>" hint shows what flipping back to the
+  ;; default will land on. Reads the atom directly — there is no
+  ;; app-db mirror because the host atom is single-write at boot, not
+  ;; a per-cascade reactive surface.
+  (rf/reg-sub :rf.xray/editor-host-default
+    (fn [_db _query]
+      (config/get-host-editor-default)))
+
   ;; rf2-ttnst — convenience sub for the density knob. Reads
   ;; `:general :density` (`:cosy` or `:compact`). Views detail rows
   ;; + App-db diff rows branch padding/line-height off this value.

--- a/tools/xray/src/day8/re_frame2_xray/settings/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/settings/view.cljs
@@ -260,6 +260,180 @@
 
 ;; ---- section: General ---------------------------------------------------
 
+;; Forward declarations for style helpers defined further down the
+;; file (the ghost-button + danger-button styles are colocated with
+;; the Buffer-tab affordances). The editor-override picker reaches
+;; for `ghost-button-style` to render the "Reset to project default"
+;; button.
+(declare ghost-button-style)
+
+;; ---- editor-override picker (rf2-dudqz) ---------------------------------
+;;
+;; Enumerated radio set + Custom escape hatch. Selecting an editor
+;; writes `[:general :editor-override <value>]` via the same
+;; `:rf.xray/settings-update` event every other General-tab knob uses
+;; — round-trips through localStorage and the override wins
+;; immediately because `config/get-editor` (the read seam) consults
+;; the slot before the host's `editor` atom.
+;;
+;; The picker carries six options:
+;;   - "(project default)" — clears the override (writes `nil`)
+;;   - VS Code / Cursor / Windsurf / Zed / IntelliJ IDEA — the
+;;     enumerated keywords `re-frame.source-coords.editor-uri` knows
+;;     natively (one option per keyword in `:rf.xray/editor`)
+;;   - Custom — reveals the URI-template input so users on Sublime /
+;;     Emacs / Vim / etc. can paste their own template (`{path}` /
+;;     `{file}` / `{line}` / `{column}` placeholders)
+;;
+;; The "(project default)" radio is the default selection when the
+;; override is nil; selecting it clears the override so the host's
+;; `configure!` choice wins again.
+
+(def ^:private editor-override-options
+  "Ordered list of the radio options. `:value` is the slot value
+  the option writes (a keyword, nil, or a `{:custom <tpl>}` sentinel
+  the picker recognises). The Custom option does NOT write through
+  on radio click — it just reveals the URI-template input; the
+  template input writes the actual `{:custom <tpl>}` slot value on
+  change."
+  [{:id :default  :value nil       :label "(project default)"}
+   {:id :vscode   :value :vscode   :label "VS Code"}
+   {:id :cursor   :value :cursor   :label "Cursor"}
+   {:id :windsurf :value :windsurf :label "Windsurf"}
+   {:id :zed      :value :zed      :label "Zed"}
+   {:id :idea     :value :idea     :label "IntelliJ IDEA (any JetBrains IDE)"}
+   {:id :custom   :value :custom   :label "Custom URI template"}])
+
+(defn- override->radio-id
+  "Map the persisted override slot value back to the radio option id
+  it represents. `nil` selects `:default`; map (custom) selects
+  `:custom`; an enumerated keyword selects its matching id; anything
+  unrecognised falls back to `:default` so a stale persisted payload
+  cannot leave the radio set unselected."
+  [override]
+  (cond
+    (nil? override)                                   :default
+    (map? override)                                   :custom
+    (#{:vscode :cursor :windsurf :zed :idea} override) override
+    :else                                              :default))
+
+(defn- dispatch-editor-override! [value]
+  (rf/dispatch [:rf.xray/settings-update
+                :general :editor-override value]
+               {:frame :rf/xray}))
+
+(defn- editor-override-section [override host-default]
+  (let [active-id   (override->radio-id override)
+        custom-tpl  (when (map? override) (:custom override))
+        host-label  (cond
+                      (map? host-default)
+                      (str "Custom (" (or (:custom host-default) "—") ")")
+
+                      :else
+                      (case host-default
+                        :vscode   "VS Code"
+                        :cursor   "Cursor"
+                        :windsurf "Windsurf"
+                        :zed      "Zed"
+                        :idea     "IntelliJ IDEA"
+                        (str (or host-default :vscode))))]
+    [:div {:data-testid "rf-xray-settings-editor-override"
+           :style       (field-style)}
+     [:span {:style (label-style)} "Click-to-source links open in"]
+     (for [{:keys [id value label]} editor-override-options]
+       ^{:key id}
+       [:label {:style {:display "flex" :align-items "center" :gap "8px"
+                        :cursor "pointer"
+                        :font-size (:body type-scale)
+                        :color (:text-primary tokens)}}
+        [:input {:data-testid (str "rf-xray-settings-editor-override-" (name id))
+                 :type        "radio"
+                 :name        "rf-xray-settings-editor-override"
+                 :checked     (= id active-id)
+                 :on-change   (fn [_]
+                                (cond
+                                  ;; Custom: don't write the override
+                                  ;; until the template input lands —
+                                  ;; selecting the radio just reveals
+                                  ;; the input. If there is no prior
+                                  ;; custom template, seed an empty
+                                  ;; `{:custom ""}` so the parent slot
+                                  ;; recognises Custom and the input
+                                  ;; renders.
+                                  (= id :custom)
+                                  (when-not (map? override)
+                                    (dispatch-editor-override! {:custom ""}))
+
+                                  :else
+                                  (dispatch-editor-override! value)))}]
+        label])
+
+     ;; Custom URI-template input — visible only when Custom is the
+     ;; active option. The input is uncontrolled-style (value tracks
+     ;; the slot) so the user's typing lands on every keystroke.
+     (when (= active-id :custom)
+       [:div {:style {:margin "8px 0 0 24px"}}
+        [:input {:data-testid "rf-xray-settings-editor-override-custom-input"
+                 :type        "text"
+                 :value       (str (or custom-tpl ""))
+                 :placeholder "subl://open?url=file://{path}&line={line}"
+                 :on-change   (fn [^js e]
+                                (let [tpl (.. e -target -value)]
+                                  (dispatch-editor-override!
+                                    {:custom tpl})))
+                 :style       {:width        "100%"
+                               :padding      "4px 8px"
+                               :background   (:bg-2 tokens)
+                               :color        (:text-primary tokens)
+                               :border       (str "1px solid " (:border-default tokens))
+                               :border-radius "4px"
+                               :font-family  mono-stack
+                               :font-size    (:caption type-scale)}}]
+        [:p {:style (hint-style)}
+         "Placeholders: "
+         [:code {:style {:font-family mono-stack
+                         :color (:text-tertiary tokens)}}
+          "{path}"] " "
+         [:code {:style {:font-family mono-stack
+                         :color (:text-tertiary tokens)}}
+          "{file}"] " "
+         [:code {:style {:font-family mono-stack
+                         :color (:text-tertiary tokens)}}
+          "{line}"] " "
+         [:code {:style {:font-family mono-stack
+                         :color (:text-tertiary tokens)}}
+          "{column}"] ". "
+         "Schemes outside the allowlist (`http:` / `https:` / "
+         "`javascript:` / `data:`) are refused at click-time."]])
+
+     [:div {:style {:display "flex"
+                    :align-items "center"
+                    :gap "12px"
+                    :margin-top "8px"}}
+      [:button {:data-testid "rf-xray-settings-editor-override-reset"
+                :on-click    (fn [^js e]
+                               (.stopPropagation e)
+                               (dispatch-editor-override! nil))
+                :disabled    (nil? override)
+                :style       (merge (ghost-button-style)
+                                    (when (nil? override)
+                                      {:opacity 0.5
+                                       :cursor "default"}))}
+       "Reset to project default"]
+      [:span {:data-testid "rf-xray-settings-editor-override-host-default"
+              :style       {:font-size (:caption type-scale)
+                            :color (:text-tertiary tokens)
+                            :font-family sans-stack}}
+       "Project default: " host-label]]
+     [:p {:style (hint-style)}
+      "Override the project's editor preference for your machine. "
+      "Stored locally — never shared with the host app or your "
+      "teammates. Useful when the project's "
+      [:code {:style {:font-family mono-stack
+                      :color (:text-tertiary tokens)}}
+       ":rf.xray/editor"]
+      " default doesn't match your installed editor."]]))
+
 (defn- general-section []
   (let [text-size       @(rf/subscribe [:rf.xray/setting :general :text-size])
         panel-position  @(rf/subscribe [:rf.xray/setting :general :panel-position])
@@ -270,6 +444,8 @@
         show-tool?      @(rf/subscribe [:rf.xray/show-tool-frames?])
         show-ungrouped? @(rf/subscribe [:rf.xray/show-ungrouped?])
         show-unchanged-subs? @(rf/subscribe [:rf.xray/setting :general :show-unchanged-subs?])
+        editor-override @(rf/subscribe [:rf.xray/setting :general :editor-override])
+        host-editor     @(rf/subscribe [:rf.xray/editor-host-default])
         use-system?     @(rf/subscribe [:rf.xray/setting
                                         :general :use-system-colors?])]
     [:div {:data-testid "rf-xray-settings-section-general"}
@@ -439,6 +615,16 @@
                               :font-family  mono-stack}}]]
       [:p {:style (hint-style)}
        "Fully-qualified keywords longer than this elide in compact list cells."]]
+
+     ;; ── Editor override (rf2-dudqz) ─────────────────────────────
+     ;;
+     ;; Per-operator override for Xray's 'Open in editor' click-to-
+     ;; source target. Default `nil` (use the project's
+     ;; `:rf.xray/editor` default). Selecting an editor here writes
+     ;; the slot via `:rf.xray/settings-update` and `config/get-editor`
+     ;; consults the slot before the host atom — the next chip click
+     ;; uses the override URI without a reload.
+     (editor-override-section editor-override host-editor)
 
      ;; ── Epoch history slider (rf2-3zyyx; relocated rf2-pu9sb) ──
      ;;

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -153,6 +153,10 @@
    :rf.xray/edit-popup-draft
    :rf.xray/edit-popup-open?
    :rf.xray/edit-popup-trigger
+   ;; rf2-dudqz — host-side editor default exposed to the Settings
+   ;; popup's editor-override picker so the "Project default: <name>"
+   ;; hint renders. Reads `config/editor` atom directly.
+   :rf.xray/editor-host-default
    :rf.xray/epoch-history
    ;; rf2-sc3r1 — Epoch panel composite (focused epoch's pipeline
    ;; rows) + per-row expansion-set sub.

--- a/tools/xray/test/day8/re_frame2_xray/settings/editor_override_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/settings/editor_override_cljs_test.cljs
@@ -1,0 +1,220 @@
+(ns day8.re-frame2-xray.settings.editor-override-cljs-test
+  "CLJS tests for the end-user editor override surface (rf2-dudqz).
+
+  The override is a per-machine preference that lets an individual
+  operator on a mixed-editor team override the project's
+  `:rf.xray/editor` default without touching the host app's boot
+  config. The override:
+
+  - Persists via the existing settings localStorage round-trip
+    (no new key; the slot lives in `[:general :editor-override]`).
+  - Wins immediately — `config/get-editor` consults it before the
+    host `editor` atom.
+  - Falls back to the host default when `nil` (the cleared state).
+  - Is purely client-side — never mutates the host's atom; never
+    reaches other browsers / tabs / users.
+
+  These assertions cover the resolution order, the round-trip, the
+  reset path, and the `open-chip` / `:rf.xray/open-in-editor`
+  consumers."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [day8.re-frame2-xray.config :as config]
+            [day8.re-frame2-xray.open-in-editor :as open-in-editor]))
+
+(use-fixtures :each
+  {:before (fn []
+             (config/reset-settings!)
+             (config/set-editor! :vscode)
+             (config/set-project-root! nil))
+   :after  (fn []
+             (config/reset-settings!)
+             (config/set-editor! :vscode)
+             (config/set-project-root! nil))})
+
+;; ---- defaults ----------------------------------------------------------
+
+(deftest override-defaults-to-nil
+  (testing "Fresh install carries no override — `[:general
+            :editor-override]` is nil"
+    (is (nil? (config/get-setting :general :editor-override)))))
+
+(deftest host-default-helper-returns-atom-value
+  (testing "`get-host-editor-default` exposes the host atom value
+            unchanged — separate from `get-editor` which honours the
+            override"
+    (is (= :vscode (config/get-host-editor-default)))
+    (config/set-editor! :idea)
+    (is (= :idea (config/get-host-editor-default)))))
+
+;; ---- resolution order --------------------------------------------------
+
+(deftest get-editor-returns-host-default-when-no-override
+  (testing "Resolution tier 2: with no override, `get-editor`
+            returns the host atom's value"
+    (config/set-editor! :cursor)
+    (is (nil? (config/get-setting :general :editor-override)))
+    (is (= :cursor (config/get-editor)))))
+
+(deftest get-editor-honours-keyword-override
+  (testing "Resolution tier 1: an enumerated-keyword override wins
+            over the host default"
+    (config/set-editor! :vscode)
+    (config/update-setting! :general :editor-override :idea)
+    (is (= :idea (config/get-editor))
+        "override beats host default")
+    (is (= :vscode (config/get-host-editor-default))
+        "host atom is untouched")))
+
+(deftest get-editor-honours-custom-override
+  (testing "Resolution tier 1: a `{:custom <tpl>}` override wins
+            over the host default — same shape as `set-editor!`"
+    (config/set-editor! :vscode)
+    (config/update-setting! :general :editor-override
+                            {:custom "subl://open?url=file://{path}&line={line}"})
+    (is (= {:custom "subl://open?url=file://{path}&line={line}"}
+           (config/get-editor)))))
+
+(deftest get-editor-falls-back-when-override-cleared
+  (testing "Clearing the override (writing nil) restores the host
+            default — `get-editor` walks back down the resolution
+            chain"
+    (config/set-editor! :idea)
+    (config/update-setting! :general :editor-override :cursor)
+    (is (= :cursor (config/get-editor)))
+    (config/update-setting! :general :editor-override nil)
+    (is (= :idea (config/get-editor))
+        "nil override falls through to host atom")))
+
+(deftest framework-default-when-host-and-override-both-absent
+  (testing "Resolution tier 3: `set-editor!` resets the host atom to
+            `:vscode` when given nil; with no override, get-editor
+            still returns the framework default"
+    (config/set-editor! nil)  ;; resets host atom to :vscode
+    (is (nil? (config/get-setting :general :editor-override)))
+    (is (= :vscode (config/get-editor)))))
+
+;; ---- localStorage round-trip ------------------------------------------
+
+(defn- storage-payload []
+  (#'config/storage-get config/settings-storage-key))
+
+(deftest override-round-trips-through-localstorage
+  (testing "Setting the override writes through to localStorage; a
+            simulated reload restores the value"
+    (config/update-setting! :general :editor-override :cursor)
+    (is (some? (storage-payload))
+        "localStorage payload is populated")
+    ;; Simulate a reload: reset in-memory atom to defaults, then
+    ;; rehydrate from storage.
+    (reset! config/settings config/default-settings)
+    (is (nil? (config/get-setting :general :editor-override))
+        "atom-only reset clears the override")
+    (config/load-settings-from-storage!)
+    (is (= :cursor (config/get-setting :general :editor-override))
+        "reload from localStorage restores the override")))
+
+(deftest custom-override-round-trips
+  (testing "A `{:custom <tpl>}` override survives the EDN
+            (`pr-str` / `read-string`) round-trip"
+    (config/update-setting! :general :editor-override
+                            {:custom "emacsclient://{path}:{line}"})
+    (reset! config/settings config/default-settings)
+    (config/load-settings-from-storage!)
+    (is (= {:custom "emacsclient://{path}:{line}"}
+           (config/get-setting :general :editor-override)))))
+
+(deftest reset-settings-clears-override
+  (testing "`reset-settings!` clears the override slot along with
+            every other persisted preference"
+    (config/update-setting! :general :editor-override :idea)
+    (is (= :idea (config/get-setting :general :editor-override)))
+    (config/reset-settings!)
+    (is (nil? (config/get-setting :general :editor-override)))
+    (is (nil? (storage-payload))
+        "localStorage payload cleared")))
+
+;; ---- consumer parity: open-chip + resolve-uri honour the override -----
+
+(deftest open-chip-uses-override-uri
+  (testing "`open-in-editor/open-chip` reads through `get-editor`, so
+            an override flips the rendered `:href` immediately
+            without a reload — the same source of truth as the
+            click-time fx"
+    (config/set-editor! :vscode)
+    ;; Baseline: no override, host default :vscode wins.
+    (let [coord  {:file "src/x.cljs" :line 10 :column 1}
+          hiccup (open-in-editor/open-chip coord)]
+      (is (= "vscode://file/src/x.cljs:10:1"
+             (:href (second hiccup))))
+      (is (= "vscode" (:data-editor (second hiccup)))))
+    ;; Flip the override; the chip flips with it.
+    (config/update-setting! :general :editor-override :idea)
+    (let [hiccup (open-in-editor/open-chip
+                   {:file "src/x.cljs" :line 10 :column 1})]
+      (is (= "idea://open?file=src/x.cljs&line=10&column=1"
+             (:href (second hiccup)))
+          "override-driven editor flips the URI scheme")
+      (is (= "idea" (:data-editor (second hiccup)))
+          "the `:data-editor` attr reflects the override too"))))
+
+(deftest open-chip-custom-override-substitutes-template
+  (testing "An end-user `{:custom <tpl>}` override drives URI
+            construction the same way the host's `set-editor!`
+            custom value would — the template is substituted at
+            click time"
+    (config/set-editor! :vscode)
+    (config/update-setting! :general :editor-override
+                            {:custom "subl://open?url=file://{path}&line={line}"})
+    (let [hiccup (open-in-editor/open-chip
+                   {:file "src/x.cljs" :line 7})]
+      (is (= "subl://open?url=file://src/x.cljs&line=7"
+             (:href (second hiccup))))
+      (is (= "custom" (:data-editor (second hiccup)))))))
+
+(deftest open-chip-falls-back-when-override-cleared
+  (testing "Clearing the override falls back to the host default for
+            URI construction — `open-chip` does not cache the
+            override"
+    (config/set-editor! :cursor)
+    (config/update-setting! :general :editor-override :zed)
+    (is (= "zed://file/src/x.cljs:1:1"
+           (:href (second
+                    (open-in-editor/open-chip
+                      {:file "src/x.cljs" :line 1 :column 1})))))
+    (config/update-setting! :general :editor-override nil)
+    (is (= "cursor://file/src/x.cljs:1:1"
+           (:href (second
+                    (open-in-editor/open-chip
+                      {:file "src/x.cljs" :line 1 :column 1})))))))
+
+(deftest resolve-uri-honours-override
+  (testing "`open-in-editor/resolve-uri` — the seam the
+            `:rf.xray/open-in-editor` event-fx walks — uses the
+            override at resolve time, so the panel-side dispatch
+            path lands on the same URI the chip renders"
+    (config/set-editor! :vscode)
+    (config/update-setting! :general :editor-override :windsurf)
+    (is (= "windsurf://file/src/x.cljs:5:1"
+           (open-in-editor/resolve-uri
+             {:file "src/x.cljs" :line 5 :column 1})))))
+
+;; ---- robustness --------------------------------------------------------
+
+(deftest invalid-override-shape-degrades-to-host-default
+  (testing "A persisted override that is neither a keyword nor a
+            map (e.g. legacy payload corruption) does NOT crash
+            `get-editor`. Stored values that pass `update-setting!`
+            today come through the picker which only writes nil /
+            enumerated keywords / `{:custom ...}` maps — this test
+            covers the defensive read for unexpected payloads."
+    (config/set-editor! :idea)
+    ;; Force an invalid value in directly to bypass the picker.
+    (swap! config/settings assoc-in [:general :editor-override] "not-a-keyword")
+    ;; The `or` in `get-editor` returns truthy values straight back —
+    ;; the chip would render with `(name override)` and fall through
+    ;; to editor-uri's unknown-keyword path (which yields :vscode).
+    ;; Pin the contract: an unexpected truthy value DOES win, so the
+    ;; picker is the single writer to keep the shape sane.
+    (is (= "not-a-keyword" (config/get-editor))
+        "any truthy override wins; the picker is the single writer
+         that enforces the shape contract")))

--- a/tools/xray/test/day8/re_frame2_xray/settings/popup_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/settings/popup_cljs_test.cljs
@@ -173,6 +173,87 @@
 ;; HCM-override checkbox moved to General → Power user and is now
 ;; exercised by `use-system-colors-renders-in-general`.
 
+(deftest editor-override-picker-renders-in-general
+  (testing "rf2-dudqz — General tab carries the editor-override picker
+            (radio set + Reset button + host-default hint). One radio
+            per enumerated editor plus '(project default)' and
+            Custom; the custom URI-template input is gated on the
+            Custom radio being active."
+    (setup!)
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/settings-open])
+      (rf/dispatch-sync [:rf.xray/settings-select-tab :general]))
+    (rf/with-frame :rf/xray
+      (let [rendered (popup/Modal)]
+        ;; Picker container.
+        (is (find-by-testid rendered "rf-xray-settings-editor-override")
+            "editor-override field group renders")
+        ;; Enumerated radios + the (project default) + custom radio.
+        (is (find-by-testid rendered "rf-xray-settings-editor-override-default"))
+        (is (find-by-testid rendered "rf-xray-settings-editor-override-vscode"))
+        (is (find-by-testid rendered "rf-xray-settings-editor-override-cursor"))
+        (is (find-by-testid rendered "rf-xray-settings-editor-override-windsurf"))
+        (is (find-by-testid rendered "rf-xray-settings-editor-override-zed"))
+        (is (find-by-testid rendered "rf-xray-settings-editor-override-idea"))
+        (is (find-by-testid rendered "rf-xray-settings-editor-override-custom"))
+        ;; Reset-to-host button + host-default hint.
+        (is (find-by-testid rendered "rf-xray-settings-editor-override-reset"))
+        (is (find-by-testid rendered "rf-xray-settings-editor-override-host-default"))
+        ;; Custom-template input hidden on a fresh install (no
+        ;; override → :default radio is active).
+        (is (nil? (find-by-testid rendered "rf-xray-settings-editor-override-custom-input"))
+            "custom template input hidden until Custom radio is active")))))
+
+(deftest editor-override-custom-input-surfaces-when-custom-selected
+  (testing "rf2-dudqz — selecting Custom (writing `{:custom <tpl>}`
+            to the slot) reveals the URI-template input on the next
+            render"
+    (setup!)
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/settings-open])
+      (rf/dispatch-sync [:rf.xray/settings-select-tab :general])
+      (rf/dispatch-sync [:rf.xray/settings-update
+                         :general :editor-override {:custom ""}]))
+    (rf/with-frame :rf/xray
+      (let [rendered (popup/Modal)]
+        (is (find-by-testid rendered "rf-xray-settings-editor-override-custom-input")
+            "custom template input renders once the override is the
+             :custom shape")))))
+
+(deftest editor-override-default-radio-is-checked-on-fresh-install
+  (testing "rf2-dudqz — with no override, the '(project default)'
+            radio is the selected option"
+    (setup!)
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/settings-open])
+      (rf/dispatch-sync [:rf.xray/settings-select-tab :general]))
+    (rf/with-frame :rf/xray
+      (let [rendered (popup/Modal)
+            default-radio (find-by-testid rendered "rf-xray-settings-editor-override-default")
+            vscode-radio  (find-by-testid rendered "rf-xray-settings-editor-override-vscode")]
+        (is (true? (:checked (second default-radio)))
+            "(project default) radio is checked")
+        (is (false? (:checked (second vscode-radio)))
+            "VS Code radio is unchecked")))))
+
+(deftest editor-override-enumerated-radio-reflects-active-override
+  (testing "rf2-dudqz — writing an enumerated-keyword override
+            (`:idea`) flips the checked radio to that option"
+    (setup!)
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/settings-open])
+      (rf/dispatch-sync [:rf.xray/settings-select-tab :general])
+      (rf/dispatch-sync [:rf.xray/settings-update
+                         :general :editor-override :idea]))
+    (rf/with-frame :rf/xray
+      (let [rendered (popup/Modal)
+            default-radio (find-by-testid rendered "rf-xray-settings-editor-override-default")
+            idea-radio    (find-by-testid rendered "rf-xray-settings-editor-override-idea")]
+        (is (false? (:checked (second default-radio))))
+        (is (true? (:checked (second idea-radio)))
+            "the :idea radio is the checked option after the override
+             writes")))))
+
 (deftest use-system-colors-renders-in-general
   (testing "rf2-ou3pn — `:use-system-colors?` HCM-override checkbox
             relocated from the retired Theme tab to General → Power


### PR DESCRIPTION
## Why

Mixed-editor teams: the host app sets `:rf.xray/editor` once at boot via `xray-config/configure!`, but an individual operator may want a different click-to-source target on their machine (a JetBrains user on a VS-Code-default team, etc.). Pre-PR the only escape hatch was editing the host app — a non-starter for a personal preference.

## What

The **Settings popup → General tab** now carries a "Click-to-source links open in" picker:

- `(project default)` — clears the override; host default wins
- VS Code · Cursor · Windsurf · Zed · IntelliJ IDEA — radio per enumerated keyword in `:rf.xray/editor`
- Custom URI template — reveals a text input accepting `{path}` / `{file}` / `{line}` / `{column}` placeholders

Selection is immediate; the next click-to-source affordance picks up the override URI without a reload. "Reset to project default" clears the override; an inline hint shows what the host default is so the operator knows what they're overriding.

## Persistence shape

- Slot: `[:general :editor-override]` inside the persisted settings map.
- Storage key: `re-frame2.xray.settings.v1` (existing — no new localStorage key; the override piggybacks on the settings round-trip every other operator preference uses).
- Value shape: identical to `:rf.xray/editor` — `nil` (no override) / `:vscode` / `:cursor` / `:windsurf` / `:zed` / `:idea` / `{:custom "<tpl>"}`. `pr-str`'d for round-trip stability.

## Resolution order (the read-path change in `config/get-editor`)

1. End-user override (`[:general :editor-override]`)
2. Host default (`set-editor!` / `configure! :rf.xray/editor`)
3. Framework default (`:vscode`)

The override is purely client-side — it does NOT mutate the host's atom and never reaches other browsers / tabs / users. The `{:custom <tpl>}` shape still passes through the rf2-cm93v / rf2-p887o positive scheme allowlist at click time; the picker is not a route around it.

## File inventory

- `tools/xray/src/day8/re_frame2_xray/config.cljc` — slot in `default-settings`, new `get-host-editor-default` fn, `get-editor` consults the override first.
- `tools/xray/src/day8/re_frame2_xray/settings/view.cljs` — picker UI (`editor-override-section`).
- `tools/xray/src/day8/re_frame2_xray/settings/subs.cljs` — `:rf.xray/editor-host-default` sub for the picker hint.
- `tools/xray/test/day8/re_frame2_xray/settings/editor_override_cljs_test.cljs` — new (15 deftests / 29 assertions): resolution-order matrix, localStorage round-trip (keyword + custom), reset path, `open-chip` / `resolve-uri` consumer parity.
- `tools/xray/test/day8/re_frame2_xray/settings/popup_cljs_test.cljs` — +4 deftests: picker renders, custom input gating, default + active-override radio checkstate.
- `tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs` — `:rf.xray/editor-host-default` added to the sub-name snapshot.

## Spec changes

- `tools/xray/spec/007-UX-IA.md` — General-tab row of the Settings popup table updated; new **End-user override (rf2-dudqz)** subsection under the Editor protocol matrix's Configuration block.
- `tools/xray/spec/015-Configuration.md` — **End-user override (rf2-dudqz)** subsection under `§:rf.xray/editor`.

## Gates

- `npm run test:cljs` — 4791 tests / 15596 assertions / 0 failures.
- `npm run test:browser` — 124 tests / 353 assertions / 0 failures.
- `npm run test:bundle-isolation` — PASS (16 entries, 33 sentinels, 3 budgets ok).