### PR TITLE
docs(spec/005): reconcile machine-schema prose post-rf2-jbbp7 (rf2-mr1ei)

### DIFF
--- a/spec/005-StateMachines.md
+++ b/spec/005-StateMachines.md
@@ -151,7 +151,7 @@ Why the locked path — the load-bearing reason is [Goal 2 — Frame state rever
 
 > **Cost: feature-locality.** Putting machine snapshots under a reserved global subtree means they don't sit alongside their feature's own app-db slice. A user inspecting `[:auth ...]` won't see the auth flow's machine snapshot there — it lives at `[:rf/machines :auth/login-flow]`. This is a real cost. We accept it because the wins (uniform tool support, atomic revertibility per [Goal 2 of 000-Vision](000-Vision.md#frame-state-revertibility), host-independent storage scheme, automatic SSR hydration / persistence / undo) require *one* structural location for machine state. Tooling can present a feature-local view (10x's app-db panel can render a "Machines" section adjacent to the feature's data) without compromising the storage scheme.
 
-The runtime composes `:rf/machines`'s schema automatically from the registered machines' `:data` schemas — `(rf/app-schema-at [:rf/machines])` returns `[:map-of :keyword :rf/machine-snapshot]`, and per-machine entries refine `:rf/machine-snapshot` against the registered machine's declared `:data` shape.
+The runtime composes `:rf/machines`'s schema from the registered machines' `:schema` slots (per [§Schema validation](#schema-validation), the surface shipped under rf2-jbbp7): `(rf/app-schema-at [:rf/machines])` returns `[:map-of :keyword :rf/machine-snapshot]`, and per-machine entries refine `:rf/machine-snapshot` against each machine's declared `:schema` (which describes the `:data` shape). Violations surface at the `:where :machine-data` boundary — row 7 of the per-step recovery table per [Spec 010 §Per-step recovery](010-Schemas.md#per-step-recovery).
 
 ### What the Single Store gives us for free
 
@@ -162,7 +162,7 @@ Because every machine's snapshot lives in `app-db` at `[:rf/machines <id>]` — 
 - **SSR hydration.** The `:rf/hydrate` event replaces `app-db` with the server-supplied payload (per [011](011-SSR.md)); machine snapshots ride along with the rest of the state — no separate hydration channel.
 - **Persistence.** Writing `app-db` to localStorage / IndexedDB / a server endpoint serialises machines too. Reloading deserialises them back into `[:rf/machines <id>]` and the next event sees them.
 - **Conformance fixtures.** A fixture's `:fixture/expect :final-app-db` covers machine state without needing a machine-specific assertion.
-- **Schema validation.** `(rf/reg-app-schema [:rf/machines] ...)` validates the whole machine map; per-machine `:data` schemas refine it (per [§Where snapshots live](#where-snapshots-live)).
+- **Schema validation.** `(rf/reg-app-schema [:rf/machines] ...)` validates the whole machine map; per-machine `:schema` slots refine it against each machine's `:data` shape at the `:where :machine-data` boundary (per [§Schema validation](#schema-validation), shipped under rf2-jbbp7; row 7 of [Spec 010 §Per-step recovery](010-Schemas.md#per-step-recovery)).
 - **Trace replay.** Tool-Pair epochs replay events against `:db-before` to reproduce a session; machine transitions replay along with everything else because their state is in the db.
 - **Snapshot-and-restore.** The epoch surface (`epoch/restore-epoch` + `epoch/reset-frame-db!`) captures `app-db` and reapplies it; machines come back with the rest of state.
 
@@ -421,7 +421,7 @@ Consumers route on `:where` — the existing Issues triage, Xray projections, sc
 
 **Production builds.** Per [010 §Production builds](010-Schemas.md#production-builds), the validation site is gated by `re-frame.interop/debug-enabled?` and DCEs to a no-op under `:advanced` + `goog.DEBUG=false`. The boundary is dev-only by default; apps needing production validation at system boundaries reach for the `:rf.schema/at-boundary` interceptor on the specific events that ingest untrusted machine `:data` (e.g. an SSR-hydrate that restores machine snapshots from the wire).
 
-**Cross-reference.** Per [010 §Per-step recovery row 7](010-Schemas.md#per-step-recovery), this boundary is row 7 of the per-step recovery table; the `:where :machine-data` value is the closed-set extension to [Spec-Schemas §`SchemaValidationTags`](Spec-Schemas.md#per-category-tags-schemas). The aspirational paragraphs at [§Where snapshots live](#where-snapshots-live) and the §What the Single Store gives us for free Schema-validation bullet become factual with this surface; the sibling bead (rf2-mr1ei) reconciles the prose.
+**Cross-reference.** Per [010 §Per-step recovery row 7](010-Schemas.md#per-step-recovery), this boundary is row 7 of the per-step recovery table; the `:where :machine-data` value is the closed-set extension to [Spec-Schemas §`SchemaValidationTags`](Spec-Schemas.md#per-category-tags-schemas). The two paragraphs at [§Where snapshots live](#where-snapshots-live) (schema composition) and in §What the Single Store gives us for free (the Schema-validation bullet) describe this surface as fact.
 
 ### Trace events — guard evaluations and action runs
 


### PR DESCRIPTION
## Why

rf2-jbbp7 (#2227, merged) shipped `:schema` on `reg-machine` plus the `:where :machine-data` validation boundary, and added a new §Schema validation subsection to spec/005. Two foundational paragraphs in spec/005 that previously described the feature *aspirationally* are now factual. This PR rewords them so they describe the shipped behaviour and cross-reference the new section + Spec 010 §Per-step recovery row 7.

Surface: `spec/005-StateMachines.md` only.

## Paragraph 1 — §Where snapshots live (line 154)

**Before:**

> The runtime composes `:rf/machines`'s schema automatically from the registered machines' `:data` schemas — `(rf/app-schema-at [:rf/machines])` returns `[:map-of :keyword :rf/machine-snapshot]`, and per-machine entries refine `:rf/machine-snapshot` against the registered machine's declared `:data` shape.

**After:**

> The runtime composes `:rf/machines`'s schema from the registered machines' `:schema` slots (per §Schema validation, the surface shipped under rf2-jbbp7): `(rf/app-schema-at [:rf/machines])` returns `[:map-of :keyword :rf/machine-snapshot]`, and per-machine entries refine `:rf/machine-snapshot` against each machine's declared `:schema` (which describes the `:data` shape). Violations surface at the `:where :machine-data` boundary — row 7 of the per-step recovery table per Spec 010 §Per-step recovery.

## Paragraph 2 — §What the Single Store gives us for free (line 165)

**Before:**

> - **Schema validation.** `(rf/reg-app-schema [:rf/machines] ...)` validates the whole machine map; per-machine `:data` schemas refine it (per §Where snapshots live).

**After:**

> - **Schema validation.** `(rf/reg-app-schema [:rf/machines] ...)` validates the whole machine map; per-machine `:schema` slots refine it against each machine's `:data` shape at the `:where :machine-data` boundary (per §Schema validation, shipped under rf2-jbbp7; row 7 of Spec 010 §Per-step recovery).

## Drive-by — §Schema validation cross-reference (line 424)

The §Schema validation subsection ended with a forward-reference to "the sibling bead (rf2-mr1ei) reconciles the prose" and called the paragraphs above "aspirational". With this PR the prose IS reconciled, so the closing paragraph now describes the two prose sites as factual references rather than aspirational ones queued for follow-up.

## Acceptance

- [x] spec/005:154 prose describes shipped `:schema` registration → composed app-schema behaviour as fact
- [x] spec/005:165 Schema-validation bullet describes shipped behaviour
- [x] Both paragraphs cross-ref rf2-jbbp7 work + the new §Schema validation subsection
- [x] Cross-references to Spec 010 §Per-step recovery row 7 added at both sites
- [x] `python scripts/check_doc_slugs.py` exits 0
- [x] `python -m mkdocs build --strict` exits 0

Closes rf2-mr1ei.