### PR TITLE
feat(xray): three-mode diff toggle + Editscript engine + Stories — Epoch HANDLER :db (rf2-n2jig)

### DIFF
--- a/implementation/scripts/check-bundle-isolation.cjs
+++ b/implementation/scripts/check-bundle-isolation.cjs
@@ -484,6 +484,35 @@ const ARTEFACTS = [
     consumerAllowList: null,
     expectedAllowListHits: 0,
   },
+
+  // editscript — Xray's diff engine (rf2-n2jig). A* algorithm
+  // producing optimally-small EDN edit scripts; replaces the home-grown
+  // leaf-walker classifier. Same posture as zprint and cljs-devtools:
+  // dev-only, consumed only by tools/ (Xray), gated behind Xray's
+  // `:devtools/preloads`. Production bundles MUST NOT pull editscript
+  // — the engine ships ~25KB of source over multiple cljc files +
+  // pulls in a priority-map dep; the operator inspection UX is a dev-
+  // only concern, never a production one.
+  //
+  // Sentinels are distinctive identifiers from editscript's source —
+  // the `editscript.core` + `editscript.diff.a-star` namespaces both
+  // appear in editscript's goog.provide-equivalent + internal
+  // references. A non-zero hit means a `:require` slipped from
+  // tools/xray/* into implementation/*, or the EDN widget's diff path
+  // got referenced outside the Xray preload-gated tree.
+  {
+    name: 'editscript',
+    internalSentinels: [
+      // editscript's core namespace name as a literal string.
+      { source: 'editscript diff engine core namespace (editscript.core)',
+        sentinel: 'editscript.core' },
+      // editscript's A* diff algorithm namespace.
+      { source: 'editscript A* diff algorithm namespace (editscript.diff.a_star)',
+        sentinel: 'editscript.diff.a_star' },
+    ],
+    consumerAllowList: null,
+    expectedAllowListHits: 0,
+  },
 ];
 
 // ----- helpers ---------------------------------------------------------------

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -188,7 +188,15 @@
                 ;; verifies `zprint.core` does not reach production
                 ;; bundles. See tools/xray/deps.edn for the artefact-side
                 ;; rationale.
-                [zprint "1.3.0"]]
+                [zprint "1.3.0"]
+                ;; Editscript — Xray's diff engine (rf2-n2jig). A*
+                ;; algorithm producing optimally-small EDN edit scripts.
+                ;; Replaces Xray's home-grown leaf-walker diff at
+                ;; `tools/xray/src/.../views/edn_inspector.cljs:533-664`.
+                ;; Dev-only via the same `:devtools/preloads` gate as
+                ;; the rest of Xray; bundle-isolation verifies
+                ;; `editscript.*` does not reach production bundles.
+                [juji/editscript "0.6.5"]]
 
  ;; Top-level dev-http servers (rf2-aqcix). shadow-cljs's `:dev-http`
  ;; map binds a port to a list of file roots; the dev server cascades

--- a/tools/xray/deps.edn
+++ b/tools/xray/deps.edn
@@ -140,6 +140,24 @@
          ;; gate's `cljs-devtools` checks still run as defence-in-depth
          ;; (a stray re-introduction would re-fail the gate).
 
+         ;; Editscript — canonical diff engine for Xray (rf2-n2jig).
+         ;; A* algorithm producing optimally-small edit scripts as pure
+         ;; EDN — `[[[path] :+ value] [[path] :- ] [[path] :r value]]`.
+         ;; Replaces the home-grown classifier at
+         ;; `views/edn_inspector.cljs:533-664` (10 fns; pre-alpha clean
+         ;; delete, no shim). Vector shift-detection comes free from
+         ;; A*'s Myers underpinnings — an insert in a 30-element vector
+         ;; renders as 1 `:+` op + N-1 shifted-but-equal rows rather
+         ;; than N spurious modifications. Pure-data output aligns
+         ;; with re-frame2's spec-is-data ethos; the same edit script
+         ;; feeds Xray's renderer, the legacy flat-diff line view, and
+         ;; (future) Story's snapshot lens + MCP wire surfaces — one
+         ;; diff representation, many consumers. Bundle-isolated: Xray
+         ;; is dev-only via `:devtools/preloads`; the bundle-isolation
+         ;; gate verifies `editscript.*` does not reach production
+         ;; bundles.
+         juji/editscript {:mvn/version "0.6.5"}
+
          ;; zprint — canonical pretty-printer for the EDN widget's
          ;; `code-block` rendering of handler-source strings. The Event
          ;; panel's HANDLER section reads `:rf.handler/source` off the

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1336,7 +1336,7 @@ Each step renders a uppercase badge pill at its numbered circle:
 > surfaces every `:dispatch` / `:dispatch-n` / `:dispatch-later` fx entry
 > per row. APP-DB DIFF (originally rf2-rrykz, dropped earlier same session
 > in commit `ee9def224`) is redundant with the HANDLER step's `:db`
-> sub-section + its `[diff][all]` toggle, which surfaces the same data
+> sub-section + its `[diff][full][full+diff]` toggle (§9.1.5.1), which surfaces the same data
 > in-context. The projection's `badge-set` enforces the 8-entry inventory.
 
 The inventory is LOCKED — the projection's `badge-set` enforces
@@ -1490,6 +1490,86 @@ check against the trace stream — no spec read, no registry lookup,
 no replay. The substrate enhancements in #2155 (rf2-82a0u) are the
 prerequisite that lets every cascade row read directly off the
 trace.
+
+#### §9.1.5.1 HANDLER `:db` view-mode toggle — three-mode `[diff][full][full+diff]` (rf2-n2jig)
+
+The HANDLER step's `:db` sub-section carries a three-button toggle:
+
+| Mode | Label | Renders |
+|------|-------|---------|
+| `:diff`      | `diff`      | Flat path-prefixed change list (one row per change). |
+| `:full`      | `full`      | Full post-cascade `:db-after` via the edn-inspector. No diff chrome. |
+| `:full+diff` | `full+diff` | **Mode-3** — full data tree WITH inline diff annotations per the R1-R8 grammar below. |
+
+**Default**: `:full+diff` (Mike pair-debug 2026-05-27 — the operator's
+most-useful default; shape + delta in one read). Mode persists via
+`:rf.xray.epoch/db-view-mode` so the operator's preference survives
+focus shifts.
+
+> **Migration**: the prior two-button `[diff][all]` toggle was retired
+> 2026-05-27 (pre-alpha, no shim). The `:all` enum value migrates to
+> `:full` at sub-read time so any persisted-app-db reads from a pre-
+> rf2-n2jig session resolve cleanly.
+
+**Diff engine**: Editscript A* (`juji/editscript` 0.6.5). Replaces the
+home-grown leaf-walker classifier wholesale (10 fns retired at
+`tools/xray/src/.../views/edn_inspector.cljs:533-664`). Pure-data
+edit-script output as EDN — `[[[path] :+ value] [[path] :- ]
+[[path] :r value]]` — feeds the projection layer at
+`day8.re-frame2-xray.diff.engine`, which emits `{:path-ops
+:container-ops :flat-rows :wholly-changed-roots :shift-suffix
+:vector-removals}`. The renderer chrome reads off this projection;
+the engine swap is invisible to the chrome, only the classifier
+flips.
+
+**Mode-3 grammar (R1-R8)** — implements the rules from
+`diff-mode-3-key-and-triangle-grammar` findings doc §5.1 (revised
+per §7 with Mike's pair-debug answers):
+
+- **R1**: value-side `~` gutter glyph for modified scalars + `←
+  changed from <prior>` italic muted suffix.
+- **R2**: key-side `+` / `−` glyph at column 1 of the key row
+  when the KEY itself is `:added` / `:removed`. Strike-through
+  reaches the key text for `:removed`.
+- **R3 (revised)**: container triangle stays default
+  `:text-tertiary` always (no colour swap). When COLLAPSED (`▶`)
+  AND the subtree carries change, a `[N∆]` count chip appears
+  after the closing ellipsis: `▶ :user {…} [3∆]`. No per-op
+  breakdown — single count only.
+- **R4**: single 2px vertical rail in the gutter through each
+  change-bearing subtree, in the dominant-op hue. Drawn at each
+  container body's left border; no nested rails at the same
+  indent because each container's body is indented further than
+  its parent.
+- **R5 (revised)**: wholly-new / wholly-removed subtrees
+  reclassify to `:added` / `:removed` at the parent. Descendant
+  gutter GLYPHS + 2px STRIPES are suppressed; descendant row
+  WASHES are RETAINED (low-opacity tint). Operator scrolled into
+  the middle of a 20-leaf added shard still reads green.
+- **R6**: vector shift-detection via Editscript's A* + Myers
+  underpinnings. Shifted-but-equal rows carry a `(was N)` muted
+  suffix in `:text-tertiary` and NO gutter glyph (new op
+  classification `:same-shifted`). Removed elements live on a
+  separate `:vector-removals` channel keyed by parent path
+  (the after-tree has no stable path identity for the deleted
+  element).
+- **R7**: type-change containers reclassify to `:modified`. New
+  value renders in the value column; `← was <prior>` suffix via
+  the `mini` renderer (falling back to "<type> with N keys"
+  when `mini` overflows).
+- **R8**: one-sided `:rf/redacted` renders as `:modified` with
+  curated `← was redacted` / `← now redacted` suffix (no
+  sentinel text leak). Two-sided redacted classifies as `:same`
+  for v1; propagating "underlying-differs" is a follow-on bead.
+
+**Default-expanded-depth**: 3 in mode-3 specifically (per Q4 — between
+browse's 1 and diff's 2; deep enough to surface most app-db top-level
+shards). Other modes keep their existing defaults.
+
+**Canonical visual reference**: the Story variants under
+`tools/xray/testbeds/panel_gallery/` exercise every R-rule + scenario
++ theme/density case. To see what R5 looks like, see story
+`diff-mode-3/r5-wholly-new-subtree`.
 
 ### §9.1.6 Numbered cascade chrome
 
@@ -1875,7 +1955,7 @@ The accompanying view-layer chrome:
 > **Retired pair-debug 2026-05-26** in Mike's commit `ee9def224`. The
 > APP-DB DIFF step was a state-mutation lens that rode immediately after
 > HANDLER. It was redundant with HANDLER's `:db` sub-section + its
-> `[diff][all]` toggle, which surfaces the same data in-context. The
+> `[diff][full][full+diff]` toggle (§9.1.5.1), which surfaces the same data in-context. The
 > projection no longer emits this step and the `badge-set` no longer
 > carries `:APP-DB-DIFF`. Section retained as a stub for searchability;
 > historical design intent is reachable via the bead history (rf2-rrykz

--- a/tools/xray/src/day8/re_frame2_xray/diff/engine.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/diff/engine.cljc
@@ -1,0 +1,735 @@
+(ns day8.re-frame2-xray.diff.engine
+  "Editscript-backed diff projection engine (rf2-n2jig).
+
+  ## Purpose
+
+  Replace the home-grown classifier that used to live at
+  `tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs:533-664`
+  (`diff-op`, `diff-op-container`, `children-changed?`, etc.). Per
+  pair-debug 2026-05-27 the project locks Editscript in as the canonical
+  diff engine for Xray — pre-alpha posture, no transitional double-engine
+  state, no shim. The findings doc
+  (`ai/findings/diff-mode-3-key-and-triangle-grammar-2026-05-27.md` §9)
+  carries the full rationale.
+
+  ## Output shape
+
+  `(project before after)` returns a pure-data map:
+
+      {:path-ops      {[path] {:op <kw> ...}}     ; leaf-resolution ops
+       :container-ops {[path] {:op <kw> :change-count <n>}} ; container ops
+       :flat-rows     [{:path :op :before :after} ...]      ; pure-diff lens
+       :wholly-changed-roots #{[path] ...}                  ; R5 reclassification
+       :shift-suffix  {[path] (was N)}                      ; R6 :same-shifted
+      }
+
+  Where each per-leaf `:op` is one of:
+
+      :added         — new key/index/element in after
+      :removed       — key/index/element existed in before, gone now
+      :modified      — both sides present, scalar changed (R1)
+      :same          — both sides identical
+      :same-shifted  — same value but moved positionally (R6 vectors)
+
+  Container ops carry one extra op:
+
+      :children      — descendant(s) changed, but the container itself
+                       is structurally intact (same kind, same set of
+                       keys/indices)
+
+  And per R7 a container whose kind changed (map→vec, scalar→map, …)
+  reclassifies as `:modified` at the container path with `:before` carrying
+  the old value.
+
+  ## Wholly-changed reclassification (R5, revised per Mike's pair-debug
+  answer Q2)
+
+  When EVERY descendant of a container is `:added` (or `:removed`), the
+  container reclassifies to `:added` (or `:removed`) and is recorded in
+  `:wholly-changed-roots`. Per-descendant glyphs + 2px stripes are
+  suppressed by the renderer; per-descendant row WASHES are retained
+  (so an operator scrolled into the middle of a 20-leaf added shard
+  still sees the green wash and knows they're inside a new subtree).
+
+  ## Vector shift detection (R6)
+
+  Editscript's A* algorithm uses Myers underpinnings under the hood, so
+  an insert at position 1 in `[:a :b :c :d]` → `[:a :NEW :b :c :d]` is
+  expressed as a single `[[1] :+ :NEW]` edit — the elements at positions
+  2..4 are NOT marked as modified, they are intrinsically the same. We
+  walk the edit script per-vector-path, compute the inferred old index
+  of every after-side index that doesn't sit at a `:+`/`:r` op, and
+  emit a `:same-shifted` op with a `:was-index` suffix when the new
+  index differs from the old.
+
+  ## Sentinel-aware modified (R8)
+
+  When a one-sided `:rf/redacted` sentinel appears in a `:modified`
+  pair, we tag the op with `:rf.xray.diff/redaction-side` so the
+  renderer can curate the suffix (`← was redacted` / `← now redacted`)
+  without leaking the sentinel marker text. Two-sided redaction
+  classifies as `:same` (per R8's v1 scope).
+
+  ## Pure / JVM-runnable
+
+  Pure data → data, no IO, no `rf/*` reads. `.cljc` so the JVM unit-test
+  target picks it up.
+
+  ## Cost
+
+  Editscript's A* is O(|a||b|) in the worst case (per the library's
+  README); the per-epoch one-diff cadence is well within Xray's dev-tool
+  budget (millisecond range for typical app-dbs). For pathologically
+  large structures the calling code can short-circuit via
+  `identical?` BEFORE invoking this engine."
+  (:require [editscript.core :as es]
+            [editscript.edit :as ee]))
+
+;; =========================================================================
+;; sentinels
+;; =========================================================================
+
+(def missing-sentinel
+  "Marker for a `before` / `after` slot that does not exist in its side
+  of the diff. Distinct from `nil` (a real CLJS value)."
+  :day8.re-frame2-xray.diff.engine/missing)
+
+(def redacted-sentinel
+  "Recognise the framework's `:rf/redacted` sentinel — used for R8's
+  curated suffix branch. Keeping the predicate scoped to a single
+  constant means a future contract evolution (e.g. namespaced sentinel
+  map shape) updates here only."
+  :rf/redacted)
+
+(defn- redacted? [v] (= v redacted-sentinel))
+
+;; =========================================================================
+;; container kind classification
+;; =========================================================================
+
+(defn- container-kind
+  "Classify `v` into a kind keyword for type-change detection (R7).
+  Returns `:map / :vector / :list / :set / :scalar`. The exact
+  distinction between vector and list matters for R6 (positional vs
+  walking compare) but not for R7's reclassification — a list→vector
+  flip is still a `:modified` at the parent."
+  [v]
+  (cond
+    (map? v)        :map
+    (set? v)        :set
+    (vector? v)     :vector
+    (list? v)       :list
+    (sequential? v) :seq
+    :else           :scalar))
+
+(defn- container? [v]
+  (not= :scalar (container-kind v)))
+
+;; =========================================================================
+;; safe value accessor along an Editscript path
+;; =========================================================================
+;;
+;; The path components Editscript uses for sequentials are 0-based indices,
+;; for maps are the actual keys, and for sets are the elements themselves.
+;; `get-in`-with-defaults handles all three because vectors / maps / sets
+;; all satisfy `clojure.core/get` for their respective addressing modes.
+
+(defn- value-at
+  "Walk `data` along `path`, returning `missing-sentinel` if any segment
+  is absent. Pure; safe for arbitrary nested shapes."
+  [data path]
+  (reduce (fn [acc seg]
+            (cond
+              (= acc missing-sentinel)
+              missing-sentinel
+
+              (and (map? acc) (contains? acc seg))
+              (get acc seg)
+
+              (and (or (vector? acc) (sequential? acc))
+                   (integer? seg))
+              (if (and (>= seg 0) (< seg (count acc)))
+                (nth (vec acc) seg)
+                missing-sentinel)
+
+              (set? acc)
+              (if (contains? acc seg) seg missing-sentinel)
+
+              :else missing-sentinel))
+          data path))
+
+;; =========================================================================
+;; raw Editscript edit-script walker
+;; =========================================================================
+
+(defn- raw-edits
+  "Return Editscript A* edits for `(before, after)` as a vector of
+  3-tuples `[path op value?]`. Pure."
+  [before after]
+  (try
+    (ee/get-edits (es/diff before after {:algo :a-star}))
+    (catch #?(:clj Exception :cljs js/Error) _e
+      ;; Editscript can throw on certain pathological inputs (e.g.
+      ;; comparing maps with unreadable keys); fall back to a
+      ;; conservative whole-value replacement so the renderer doesn't
+      ;; crash. The fallback edit reproduces the operator-visible
+      ;; signal ("everything changed") without false sub-tree precision.
+      [[[] :r after]])))
+
+;; =========================================================================
+;; per-path op classification (leaves)
+;; =========================================================================
+
+(defn- leaf-op
+  "Classify a (before, after) leaf pair, accounting for the R8 redaction
+  branch. Returns a map `{:op kw :before x :after y ...}`."
+  [before after]
+  (cond
+    (and (= before missing-sentinel) (= after missing-sentinel))
+    {:op :same :before before :after after}
+
+    (= before missing-sentinel)
+    {:op :added :after after}
+
+    (= after missing-sentinel)
+    {:op :removed :before before}
+
+    (= before after)
+    {:op :same :before before :after after}
+
+    ;; R8 — one-sided redaction. Curated suffix branches off this tag.
+    (and (redacted? before) (not (redacted? after)))
+    {:op :modified :before before :after after
+     :rf.xray.diff/redaction-side :before}
+
+    (and (not (redacted? before)) (redacted? after))
+    {:op :modified :before before :after after
+     :rf.xray.diff/redaction-side :after}
+
+    ;; R7 — container kind change is `:modified`, not `:children`.
+    (or (and (container? before) (not (container? after)))
+        (and (not (container? before)) (container? after))
+        (and (container? before) (container? after)
+             (not= (container-kind before) (container-kind after))))
+    {:op :modified :before before :after after
+     :rf.xray.diff/type-change? true}
+
+    :else
+    {:op :modified :before before :after after}))
+
+;; =========================================================================
+;; container op (children-resolution)
+;; =========================================================================
+
+(defn- container-op-tag
+  "Classify a container pair. `:same` when identical (covered before
+  reaching here in normal flow). `:added` when before is missing,
+  `:removed` when after is missing, `:modified` when the kind flipped
+  (R7), `:children` when both are present and same-kind. Pure."
+  [before after]
+  (cond
+    (= before missing-sentinel) :added
+    (= after missing-sentinel)  :removed
+    (= before after)            :same
+    (or (and (container? before) (not (container? after)))
+        (and (not (container? before)) (container? after))
+        (not= (container-kind before) (container-kind after)))
+    :modified
+    :else :children))
+
+;; =========================================================================
+;; vector shift detection (R6)
+;; =========================================================================
+;;
+;; For each vector path that received `:+` / `:-` edits, walk the after-
+;; side indices and compute the inferred "old index" of each that the
+;; A* edit script left untouched. The rule:
+;;
+;;   - Walk after-indices 0..N-1.
+;;   - For each, count how many `:+` operations precede or sit at this
+;;     after-index (these inserted new elements; the after-index of the
+;;     unchanged element shifts down by that count).
+;;   - Count how many `:-` operations precede the inferred old index
+;;     (these removed before-elements; the before-index of the unchanged
+;;     element shifts up by that count).
+;;   - When (after-index ≠ before-index) → `:same-shifted`.
+;;
+;; This is a per-vector linear walk, O(N + edits-per-vector). Pure.
+
+(defn- shift-suffixes-for-vector
+  "Given an after-vector's length + the per-position edits Editscript
+  emitted at this vector's path, return a map
+  `{after-index was-before-index}` for every after-element whose
+  identity moved positionally (op `:same-shifted`).
+
+  The logic walks the after-vector left→right, replaying each edit in
+  before-index order to maintain a running `(before-cursor, after-cursor)`
+  pair. Every after-position that the edit script LEFT ALONE moves by
+  exactly `(inserts-so-far - deletes-so-far)`; positions with edits
+  (`:+` / `:r`) are skipped because they classify under :added /
+  :modified, not :same-shifted."
+  [after-len edits-at-this-vector]
+  (let [;; Normalise edits to {idx, kind} sorted by idx ascending. We
+        ;; need the chronological order along the after-vector to
+        ;; compute the running shift offset. `:+` edits are keyed by
+        ;; their AFTER-index; `:-` edits are keyed by their BEFORE-
+        ;; index. `:r` edits sit at a shared index (same in both
+        ;; vectors) by Editscript's structure-preserving guarantee.
+        insert-idxs  (->> edits-at-this-vector
+                          (filter (fn [edit] (= :+ (second edit))))
+                          (map (fn [edit] (peek (first edit))))
+                          (sort)
+                          vec)
+        delete-idxs  (->> edits-at-this-vector
+                          (filter (fn [edit] (= :- (second edit))))
+                          (map (fn [edit] (peek (first edit))))
+                          (sort)
+                          vec)
+        replace-idxs (->> edits-at-this-vector
+                          (filter (fn [edit] (= :r (second edit))))
+                          (map (fn [edit] (peek (first edit))))
+                          (into #{}))
+        ;; Skip after-indices that ARE edits themselves.
+        skip-after?  (fn [after-idx]
+                       (or (contains? (set insert-idxs) after-idx)
+                           (contains? replace-idxs after-idx)))
+        ;; Count inserts ≤ after-idx.
+        inserts-at-or-before
+        (fn [after-idx] (count (filter (fn [i] (<= i after-idx)) insert-idxs)))]
+    (reduce
+      (fn [acc after-idx]
+        (if (skip-after? after-idx)
+          acc
+          (let [;; Each `:+` at index ≤ after-idx shifts the after-
+                ;; index up by 1 from the before-cursor. Each `:-`
+                ;; at index ≤ before-cursor shifts the before-cursor
+                ;; up. We solve by binary-friendly subtraction:
+                ;; before-idx ≈ after-idx - inserts-so-far + deletes-
+                ;; so-far. Compute fixed-point by walking deletes.
+                inserts-so-far (inserts-at-or-before after-idx)
+                ;; First-cut: ignore deletes (the simple insert case).
+                tentative-before (- after-idx inserts-so-far)
+                ;; Then add the count of deletes whose before-index is
+                ;; ≤ the inferred before-cursor — those slots were
+                ;; cleared out from the before-vector before this row.
+                deletes-shift
+                (loop [seen 0
+                       cursor tentative-before]
+                  (let [n (count (filter (fn [i] (<= i cursor)) delete-idxs))]
+                    (if (= n seen)
+                      seen
+                      (recur n (+ tentative-before n)))))
+                inferred-before (+ tentative-before deletes-shift)]
+            (if (and (>= inferred-before 0)
+                     (not= after-idx inferred-before))
+              (assoc acc after-idx inferred-before)
+              acc))))
+      {}
+      (range after-len))))
+
+(defn- group-edits-by-vector-parent
+  "Group all edits by their parent path WHEN the parent is a vector.
+  Returns `{[parent-path] [edits...]}`. Map-key edits are filtered out
+  (their parents are maps; R6 doesn't apply)."
+  [edits after]
+  (reduce
+    (fn [acc [path _op _val :as edit]]
+      (if (empty? path)
+        acc
+        (let [parent-path (vec (butlast path))
+              parent-val  (value-at after parent-path)
+              leaf-key    (peek path)]
+          (if (and (or (vector? parent-val)
+                       (sequential? parent-val))
+                   (integer? leaf-key))
+            (update acc parent-path (fnil conj []) edit)
+            acc))))
+    {}
+    edits))
+
+;; =========================================================================
+;; main projection
+;; =========================================================================
+
+(defn- expand-leaf-paths
+  "When an edit at `path` operates on a container value (e.g. `[[:flash] :+
+  {:level :ok :text \"hi\"}]`), expand it into per-leaf paths so the
+  renderer's path-keyed lookup finds an op at every descendant slot. The
+  expansion is recursive over maps / vectors / sets. Pure."
+  [path op value]
+  (cond
+    (map? value)
+    (mapcat (fn [[k cv]] (expand-leaf-paths (conj (vec path) k) op cv)) value)
+
+    (set? value)
+    (mapcat (fn [el] (expand-leaf-paths (conj (vec path) el) op el)) value)
+
+    (or (vector? value) (sequential? value))
+    (mapcat (fn [[i cv]] (expand-leaf-paths (conj (vec path) i) op cv))
+            (map-indexed vector value))
+
+    :else
+    [{:path path :op op :value value}]))
+
+(defn- container-ancestors
+  "Return every prefix of `path` (including `[]` the root, EXCLUDING
+  `path` itself) as a vector of paths from shallowest to deepest. Used
+  to mark every ancestor of a change as `:children`. The root `[]` is
+  included so the top-level container picks up the `:children`
+  classification + a change count whenever any descendant differs."
+  [path]
+  (->> (range 0 (count path))
+       (mapv (fn [i] (vec (take i path))))))
+
+(defn- mark-wholly-changed
+  "Per R5 (revised): walk down from root, when EVERY descendant slot
+  carries `:added`, the container reclassifies to `:added` and gets
+  added to `:wholly-changed-roots`. Same rule mirrored for `:removed`.
+
+  Implementation: traverse the AFTER-side containers (for `:added`) +
+  the BEFORE-side containers (for `:removed`). For each container,
+  check whether every descendant leaf-path under it carries a matching
+  op in `path-ops`. If so, mark this container as the wholly-changed
+  root, and ELIDE deeper roots — only the shallowest wholly-changed
+  ancestor counts."
+  [before after path-ops]
+  (let [collect-leaves
+        (fn collect-leaves [data path]
+          (cond
+            (map? data)
+            (mapcat (fn [[k cv]] (collect-leaves cv (conj (vec path) k))) data)
+
+            (set? data)
+            (mapcat (fn [el] (collect-leaves el (conj (vec path) el))) data)
+
+            (or (vector? data) (sequential? data))
+            (mapcat (fn [[i cv]] (collect-leaves cv (conj (vec path) i)))
+                    (map-indexed vector data))
+
+            :else
+            [path]))
+        check-uniform
+        (fn [data root-path target-op]
+          (let [leaves (collect-leaves data root-path)]
+            (and (seq leaves)
+                 (every? (fn [lp]
+                           (= target-op (:op (get path-ops lp))))
+                         leaves))))
+        walk-containers
+        (fn walk-containers [data path target-op acc]
+          (cond
+            ;; Skip the root unless the root itself is wholly-changed
+            ;; (rare but valid — entire app-db replacement).
+            (not (container? data))
+            acc
+
+            (check-uniform data path target-op)
+            (conj acc path)
+
+            (map? data)
+            (reduce-kv (fn [acc k cv]
+                         (walk-containers cv (conj (vec path) k)
+                                          target-op acc))
+                       acc data)
+
+            (or (vector? data) (sequential? data))
+            (reduce (fn [acc [i cv]]
+                      (walk-containers cv (conj (vec path) i)
+                                       target-op acc))
+                    acc (map-indexed vector data))
+
+            :else acc))
+        added-roots
+        (when (container? after)
+          (walk-containers after [] :added #{}))
+        removed-roots
+        (when (container? before)
+          (walk-containers before [] :removed #{}))
+        all-roots (into (or added-roots #{}) (or removed-roots #{}))
+        ;; Elide deeper roots — when a path is wholly-changed AND its
+        ;; ancestor is also wholly-changed, drop the deeper one (the
+        ;; parent's reclassification subsumes it).
+        minimal
+        (reduce (fn [acc root]
+                  (if (some (fn [other]
+                              (and (not= other root)
+                                   (= other (vec (take (count other) root)))
+                                   (< (count other) (count root))))
+                            all-roots)
+                    acc
+                    (conj acc root)))
+                #{}
+                all-roots)]
+    minimal))
+
+(defn- container-paths-from-leaves
+  "Given the set of leaf paths in path-ops, derive every ancestor
+  container path that carries a `:children` op. Returns a map
+  `{[path] {:op :children :change-count N}}` where N counts the number
+  of changed (non-`:same`) descendants directly + indirectly under this
+  path. Excludes the empty root path unless explicitly changed."
+  [path-ops]
+  (let [non-same-leaves
+        (->> path-ops
+             (remove (fn [[_p {:keys [op]}]] (= op :same)))
+             (map first))]
+    (reduce
+      (fn [acc leaf-path]
+        (reduce
+          (fn [acc' anc]
+            (update acc' anc
+                    (fn [cur]
+                      (if cur
+                        (update cur :change-count (fnil inc 0))
+                        {:op :children :change-count 1}))))
+          acc
+          (container-ancestors leaf-path)))
+      {}
+      non-same-leaves)))
+
+(defn- flat-rows-from-path-ops
+  "Build the legacy flat-diff lens — one row per non-`:same` leaf op.
+  Each row is a map `{:path :op :before :after}`. Used by the `:diff`
+  mode (pure-diff) renderer."
+  [path-ops]
+  (->> path-ops
+       (remove (fn [[_p {:keys [op]}]] (= op :same)))
+       (remove (fn [[_p {:keys [op]}]] (= op :same-shifted)))
+       (mapv (fn [[path {:keys [op before after]
+                          :rf.xray.diff/keys [redaction-side type-change?]}]]
+               (cond-> {:path  path
+                        :op    op
+                        :before before
+                        :after  after}
+                 redaction-side
+                 (assoc :rf.xray.diff/redaction-side redaction-side)
+                 type-change?
+                 (assoc :rf.xray.diff/type-change? true))))
+       (sort-by :path)
+       vec))
+
+(defn project
+  "Compute the diff projection for `(before, after)`. Returns a map per
+  the namespace docstring. Pure."
+  [before after]
+  (if (identical? before after)
+    {:path-ops             {}
+     :container-ops        {}
+     :flat-rows            []
+     :wholly-changed-roots #{}
+     :shift-suffix         {}}
+    (let [raw     (raw-edits before after)
+          ;; A `:-` edit at a vector parent removes a before-element by
+          ;; before-index. That index identity does NOT correspond to a
+          ;; stable after-side path — the surviving elements shift up.
+          ;; Recording a path-op at the after-side `[parent-path
+          ;; before-idx]` would collide with the shifted element now
+          ;; occupying that slot. We therefore route vector deletions
+          ;; into a separate `:vector-removals` channel and leave the
+          ;; after-path leaf classifications to the shift walker.
+          vector-parent?
+          (fn [path]
+            (when (seq path)
+              (let [parent (value-at before (vec (butlast path)))]
+                (or (vector? parent)
+                    (and (sequential? parent) (not (map? parent)) (not (set? parent)))))))
+          [vector-removals other-edits]
+          (reduce
+            (fn [[vrm oth] [path op value :as edit]]
+              (if (and (= op :-) (vector-parent? path))
+                [(update vrm (vec (butlast path)) (fnil conj [])
+                         {:before-index (peek path)
+                          :before-value (value-at before path)})
+                 oth]
+                [vrm (conj oth edit)]))
+            [{} []]
+            raw)
+          ;; Step 1 — expand each non-vector-deletion raw edit into
+          ;; per-leaf ops at every path the operator can navigate to in
+          ;; the AFTER tree.
+          per-leaf
+          (mapcat
+            (fn [[path op value]]
+              (case op
+                :+ (expand-leaf-paths path :added value)
+                :- (let [removed-val (value-at before path)]
+                     (if (container? removed-val)
+                       (expand-leaf-paths path :removed removed-val)
+                       [{:path path :op :removed :value removed-val}]))
+                :r [{:path path :op :modified
+                     :before (value-at before path)
+                     :after  value}]
+                :s [{:path path :op :modified
+                     :before (value-at before path)
+                     :after  (value-at after path)}]
+                []))
+            other-edits)
+          ;; Step 2 — re-classify modifieds via the leaf-op rules so R7
+          ;; type-change + R8 redaction branches surface in the op map.
+          path-ops
+          (reduce
+            (fn [acc {:keys [path op value before-val after-val]
+                      :as entry}]
+              (cond
+                (= op :added)
+                (assoc acc path {:op :added :after (or value (value-at after path))})
+
+                (= op :removed)
+                (assoc acc path {:op :removed :before (or value (value-at before path))})
+
+                (= op :modified)
+                (let [b (value-at before path)
+                      a (value-at after path)
+                      classified (leaf-op b a)]
+                  (assoc acc path classified))
+
+                :else
+                acc))
+            {}
+            per-leaf)
+          ;; Step 3 — R6 vector shift suffixes. For each vector-typed
+          ;; parent that received +/- edits, compute the (after-index →
+          ;; before-index) map and emit `:same-shifted` ops for any
+          ;; after-index whose identity moved.
+          edits-by-vec-parent
+          (group-edits-by-vector-parent raw after)
+          shift-suffix
+          (reduce
+            (fn [acc [parent-path edits]]
+              (let [parent-val (value-at after parent-path)
+                    n (cond
+                        (vector? parent-val)     (count parent-val)
+                        (sequential? parent-val) (count parent-val)
+                        :else 0)
+                    shifts (shift-suffixes-for-vector n edits)]
+                (reduce-kv
+                  (fn [acc' after-idx before-idx]
+                    (assoc acc' (conj (vec parent-path) after-idx) before-idx))
+                  acc
+                  shifts)))
+            {}
+            edits-by-vec-parent)
+          ;; Inject :same-shifted ops where applicable. We DO NOT clobber
+          ;; an existing :added/:modified op — only annotate idle (so far
+          ;; absent from path-ops, meaning identical-value) slots whose
+          ;; position moved.
+          path-ops-with-shifts
+          (reduce-kv
+            (fn [acc leaf-path before-idx]
+              (if (contains? acc leaf-path)
+                acc
+                (let [v (value-at after leaf-path)]
+                  (assoc acc leaf-path {:op :same-shifted
+                                        :before v
+                                        :after v
+                                        :rf.xray.diff/was-index before-idx}))))
+            path-ops
+            shift-suffix)
+          ;; Step 4 — wholly-changed reclassification (R5).
+          wholly-changed
+          (mark-wholly-changed before after path-ops-with-shifts)
+          ;; Step 5 — container-ancestor ops (:children) derived from the
+          ;; final path-ops map.
+          container-ops
+          (container-paths-from-leaves path-ops-with-shifts)
+          ;; Step 6 — overlay wholly-changed roots, swapping their
+          ;; `:children` op to `:added` / `:removed`.
+          container-ops'
+          (reduce
+            (fn [acc root]
+              (let [op (or (:op (get path-ops-with-shifts root))
+                           ;; Wholly-changed roots whose path didn't
+                           ;; appear in path-ops as a leaf — read the
+                           ;; op from a representative descendant.
+                           (some-> path-ops-with-shifts
+                                   (->> (filter (fn [[p _]]
+                                                  (= root (vec (take (count root) p)))))
+                                        first
+                                        second
+                                        :op)))]
+                (assoc acc root
+                       (assoc (get acc root {:change-count 1})
+                              :op op
+                              :rf.xray.diff/wholly-changed? true))))
+            container-ops
+            wholly-changed)
+          ;; Step 7 — flat-rows for the pure-diff lens. Combines the
+          ;; path-op rows with the vector-removal rows (which the
+          ;; AFTER-path classifier can't surface because the removed
+          ;; element has no stable after-path).
+          flat-rows (into (flat-rows-from-path-ops path-ops-with-shifts)
+                          (mapcat
+                            (fn [[parent-path removals]]
+                              (map (fn [{:keys [before-index before-value]}]
+                                     {:path  (conj (vec parent-path) before-index)
+                                      :op    :removed
+                                      :before before-value
+                                      :rf.xray.diff/vector-removal? true})
+                                   removals))
+                            vector-removals))]
+      {:path-ops             path-ops-with-shifts
+       :container-ops        container-ops'
+       :flat-rows            (vec (sort-by :path flat-rows))
+       :vector-removals      vector-removals
+       :wholly-changed-roots wholly-changed
+       :shift-suffix         shift-suffix})))
+
+;; =========================================================================
+;; renderer helpers — read the projection
+;; =========================================================================
+
+(defn op-at
+  "Lookup the op tag at `path` in `projection`. Returns one of `:added /
+  :removed / :modified / :same / :same-shifted / :children` (the last
+  for container paths whose subtree differs). Returns `:same` for paths
+  with no entry."
+  [projection path]
+  (let [path (vec path)]
+    (or (:op (get-in projection [:path-ops path]))
+        (:op (get-in projection [:container-ops path]))
+        :same)))
+
+(defn entry-at
+  "Lookup the full op map at `path`. Returns `nil` for `:same` slots."
+  [projection path]
+  (let [path (vec path)]
+    (or (get-in projection [:path-ops path])
+        (get-in projection [:container-ops path]))))
+
+(defn change-count-at
+  "Lookup the descendant-change count at the container `path`. Returns
+  `0` for paths with no entry. Drives R3-revised's `[N∆]` chip."
+  [projection path]
+  (or (:change-count (get-in projection [:container-ops (vec path)]))
+      0))
+
+(defn wholly-changed-ancestor
+  "Return the shallowest wholly-changed-root that is an ancestor of
+  `path` (or equal to `path`), or nil. Drives R5's
+  suppress-descendant-glyphs-and-stripes rule."
+  [projection path]
+  (let [path (vec path)]
+    (->> (:wholly-changed-roots projection)
+         (filter (fn [root]
+                   (= root (vec (take (count root) path)))))
+         (sort-by count)
+         first)))
+
+(defn shifted-was-index
+  "When `path` carries a `:same-shifted` op, return the original
+  before-index for the R6 `(was N)` suffix. Returns nil otherwise."
+  [projection path]
+  (:rf.xray.diff/was-index (get-in projection [:path-ops (vec path)])))
+
+(defn type-change?
+  "True when the op at `path` is `:modified` due to a container kind flip
+  (R7). Drives the `← was <type> with N keys` suffix branch."
+  [projection path]
+  (boolean (:rf.xray.diff/type-change? (get-in projection [:path-ops (vec path)]))))
+
+(defn redaction-side
+  "When the op at `path` is `:modified` and one side is the `:rf/redacted`
+  sentinel, return `:before` or `:after` indicating which side carries
+  the sentinel. Drives R8's curated suffix branch. Returns nil otherwise."
+  [projection path]
+  (:rf.xray.diff/redaction-side (get-in projection [:path-ops (vec path)])))

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -2221,22 +2221,34 @@
         "<source not yet captured>"])]))
 
 (defn- db-view-mode-toggle
-  "Two-button toggle bar `[diff][all]` for the HANDLER `:db`
-  sub-section. Active button paints in `:accent`; inactive button
-  is transparent with muted text. Click dispatches
+  "Three-button toggle bar `[diff][full][full+diff]` for the HANDLER
+  `:db` sub-section. Active button paints in `:accent`; inactive
+  buttons are transparent with muted text. Click dispatches
   `:rf.xray.epoch/set-db-view-mode`.
 
-  Pair-debug 2026-05-26 — operator wants the choice between
-  cascade-attributable diff and the full post-cascade app-db
-  without leaving the HANDLER step."
+  rf2-n2jig — replaces the two-button `[diff][all]` toggle. The new
+  mode-3 `:full+diff` is the operator's most-useful default (shape +
+  delta in one read); per-mode labels:
+
+  - `diff` — flat path-prefixed change list (what changed).
+  - `full` — full data tree, no diff chrome (the shape; renamed
+             from `all` for clarity).
+  - `full+diff` — full tree WITH inline diff annotations (R1-R8
+             grammar per findings doc; mode-3 default)."
   [mode]
   [:span {:data-testid "rf-xray-epoch-handler-db-view-mode"
           :data-mode (name mode)
           :style mode-toggle-bar-style}
-   (for [m [:diff :all]
-         :let [active? (= mode m)]]
+   (for [m [:diff :full :full+diff]
+         :let [active? (= mode m)
+               ;; Use a sanitised name for the testid so the `+` in
+               ;; `:full+diff` doesn't end up in a CSS selector
+               ;; downstream.
+               testid-suffix (case m
+                               :full+diff "full-with-diff"
+                               (name m))]]
      ^{:key (name m)}
-     [:button {:data-testid (str "rf-xray-epoch-handler-db-view-" (name m))
+     [:button {:data-testid (str "rf-xray-epoch-handler-db-view-" testid-suffix)
                :aria-pressed (str active?)
                :on-click (fn [e]
                            (.stopPropagation e)
@@ -2255,33 +2267,41 @@
                :style (if active?
                         mode-toggle-button-active-style
                         mode-toggle-button-inactive-style)}
-      (name m)])])
+      ;; Label — `full+diff` uses a `+` joiner per Mike's pair-debug
+      ;; 2026-05-27 grammar locking (the literal symbol is the cue).
+      (case m
+        :diff      "diff"
+        :full      "full"
+        :full+diff "full+diff")])])
 
 (defn- handler-db-diff-block
   "Render the HANDLER step's `:db` sub-section (rf2-93436 / design
   doc §Section 1 + §Section 2). Always renders for non-machine
   handlers.
 
-  Per pair-debug 2026-05-26 the sub-section carries a `[diff][all]`
-  view-mode toggle:
+  rf2-n2jig — the sub-section carries a three-button toggle
+  `[diff][full][full+diff]`:
 
-  - `:diff` (default) — render only the path-changes this handler
-    produced. When empty, reads `— (no changes)` per the design's
-    §Empty edge-case rendering table (reg-event-db returning
-    identical db / reg-event-fx returning nil — explicit empty
-    state, not an omitted slot).
-  - `:all` — render the full post-cascade `:db-after` via the
-    edn-inspector widget. Operator sees the entire app-db value
-    without leaving the HANDLER step.
+  - `:diff` — flat path-changes this handler produced. When empty,
+    reads `— (no changes)` per the design's §Empty edge-case
+    rendering table (reg-event-db returning identical db / reg-
+    event-fx returning nil — explicit empty state, not an omitted
+    slot).
+  - `:full` — full post-cascade `:db-after` via the edn-inspector
+    widget, no diff chrome (renamed from `:all` for clarity).
+    Operator sees the entire app-db value without diff annotations.
+  - `:full+diff` — mode-3 default (per pair-debug 2026-05-27): the
+    full data tree WITH inline diff annotations. Operator sees the
+    shape AND the delta in one read. Implements the R1-R8 grammar
+    rules per the findings doc `diff-mode-3-key-and-triangle-
+    grammar-2026-05-27.md` §5.1 (revised per §7).
 
   Mode persists via `:rf.xray.epoch/db-view-mode` so the operator's
   preference survives focus shifts.
 
-  Distinct from the top-level APP-DB DIFF step (rf2-rrykz) — same
-  source data, different lens. HANDLER's `:db` attributes the
-  change to THIS handler's return value; APP-DB DIFF surfaces the
-  cascade-wide accumulated change (which can include fx-triggered
-  child handlers' writes).
+  Distinct from the (retired) top-level APP-DB DIFF step (rf2-rrykz)
+  — same source data, different lens. HANDLER's `:db` attributes the
+  change to THIS handler's return value.
 
   Suppressed for machine handlers — per design §Section 3 §DB DIFF
   the snapshot IS the db change (at `[:rf/machines <id>]`) so the
@@ -2308,16 +2328,42 @@
          (for [[i row] (map-indexed vector db-diff)]
            (db-diff-line row i)))
 
-       :all
+       :full
        (let [record  @(rf/subscribe [:rf.xray/selected-epoch-record])
              db-after (:db-after record)]
          (if (some? db-after)
-           [:div {:data-testid "rf-xray-epoch-handler-db-all"
+           [:div {:data-testid "rf-xray-epoch-handler-db-full"
                   :style handler-db-all-style}
             [ei/edn-inspector db-after
-             {:site-id [:rf.xray.epoch/handler-db-all (:epoch-id record)]
+             {:site-id [:rf.xray.epoch/handler-db-full (:epoch-id record)]
               :default-expanded-depth 2}]]
-           [:span {:data-testid "rf-xray-epoch-handler-db-all-missing"
+           [:span {:data-testid "rf-xray-epoch-handler-db-full-missing"
+                   :style handler-db-all-missing-style}
+            "— db-after not available in epoch record"]))
+
+       :full+diff
+       ;; Mode-3 (rf2-n2jig): render the full :db-after tree with
+       ;; inline diff annotations driven off `:db-before`. The
+       ;; edn-inspector picks up the Editscript-backed projection
+       ;; via `:before`; `:full-with-diff?` opts the renderer into
+       ;; R3 chip + R4 vertical-rail chrome (R1/R2/R5/R6/R7/R8 fire
+       ;; off the projection alone). Default-expanded-depth 3 per
+       ;; Mike's pair-debug Q4 answer (between browse's 1 and diff's
+       ;; 2 — deep enough to surface most app-db top-level shards).
+       (let [record    @(rf/subscribe [:rf.xray/selected-epoch-record])
+             db-before (:db-before record)
+             db-after  (:db-after record)]
+         (cond
+           (some? db-after)
+           [:div {:data-testid "rf-xray-epoch-handler-db-full-with-diff"
+                  :style handler-db-all-style}
+            [ei/edn-inspector db-after
+             {:site-id [:rf.xray.epoch/handler-db-full-with-diff (:epoch-id record)]
+              :before db-before
+              :full-with-diff? true
+              :default-expanded-depth 3}]]
+           :else
+           [:span {:data-testid "rf-xray-epoch-handler-db-full-with-diff-missing"
                    :style handler-db-all-missing-style}
             "— db-after not available in epoch record"])))]))
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch_panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch_panel.cljs
@@ -164,17 +164,44 @@
     (fn [db [_ mode]]
       (assoc db :epoch-panel-subs-filter-mode mode)))
 
-  ;; ---- HANDLER :db view-mode toggle (pair-debug 2026-05-26) -------------
+  ;; ---- HANDLER :db view-mode toggle (pair-debug 2026-05-26 + rf2-n2jig 2026-05-27) ----
   ;;
-  ;; The HANDLER step's `:db` sub-section carries a `[diff][all]` button
-  ;; bar. `:diff` (default) renders only the path-changes the handler
-  ;; produced; `:all` renders the full post-cascade app-db via the
-  ;; edn-inspector. Mode is persisted so the operator's preference
-  ;; survives focus shifts.
+  ;; The HANDLER step's `:db` sub-section carries a three-button toggle
+  ;; `[diff][full][full+diff]` (per rf2-n2jig — was a two-button
+  ;; `[diff][all]` prior to 2026-05-27).
+  ;;
+  ;; - `:diff`      — pure-diff lens: a flat path-prefixed list of
+  ;;                  changes produced by this handler (e.g.
+  ;;                  `+ [:counter] 6` / `~ [:user :name] "Ada" → "Ada
+  ;;                  Lovelace"`). Operator sees ONLY what changed.
+  ;; - `:full`      — pure-data lens (renamed from `:all` for clarity):
+  ;;                  the full post-cascade `:db-after` via the
+  ;;                  edn-inspector. Operator sees the entire app-db
+  ;;                  shape with no diff chrome.
+  ;; - `:full+diff` — combined lens (mode-3): the full data tree WITH
+  ;;                  inline diff annotations (gutter glyphs, row
+  ;;                  washes, R3 `[N∆]` chips on collapsed containers,
+  ;;                  R4 vertical rails, R5-tinted descendant washes,
+  ;;                  R6 `(was N)` vector-shift suffixes, R7 type-
+  ;;                  change `← was <prior>` suffixes, R8 redaction-
+  ;;                  curated suffixes). Default per pair-debug
+  ;;                  2026-05-27: this is the operator's most-useful
+  ;;                  default — shape + delta in one read.
+  ;;
+  ;; Mode persists via `:rf.xray.epoch/db-view-mode` so the operator's
+  ;; preference survives focus shifts.
 
   (rf/reg-sub :rf.xray.epoch/db-view-mode
     (fn [db _query]
-      (get db :epoch-panel-db-view-mode :diff)))
+      ;; rf2-n2jig — default flipped from `:diff` to `:full+diff` per
+      ;; pair-debug 2026-05-27. Mode-3 carries the most operator-
+      ;; useful signal (shape + delta together).
+      (let [mode (get db :epoch-panel-db-view-mode :full+diff)]
+        ;; Migrate the legacy `:all` enum value to `:full` for any
+        ;; persisted-app-db reads from a pre-rf2-n2jig session.
+        (case mode
+          :all      :full
+          mode))))
 
   (rf/reg-event-db :rf.xray.epoch/set-db-view-mode
     (fn [db [_ mode]]

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
@@ -224,6 +224,15 @@
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens mono-stack sans-stack]]
             [day8.re-frame2-xray.views.edn-inspector-protocol :as ddp]
+            ;; rf2-n2jig — Editscript-backed diff projection engine.
+            ;; Replaces the home-grown leaf-walker classifier that
+            ;; used to live at lines 533-664 of this file. The
+            ;; engine produces `{:path-ops :container-ops :flat-rows
+            ;; :wholly-changed-roots :shift-suffix :vector-removals}`
+            ;; — the renderer chrome below consumes it via
+            ;; `engine/op-at`, `engine/wholly-changed-ancestor`,
+            ;; `engine/shifted-was-index`, etc.
+            [day8.re-frame2-xray.diff.engine :as engine]
             ;; rf2-x16b1 — load default IXrayEdnInspector formatters
             ;; for uuid + inst. Requiring for side-effect (extend-type).
             ;; Consumers that extend the same types win — `extend-type`
@@ -512,169 +521,91 @@
     :else                          :other))
 
 ;; =========================================================================
-;; diff mode — pure helpers (op classification, gutter mapping)
+;; diff mode — projection-aware chrome
 ;; =========================================================================
 ;;
-;; Phase 5 (rf2-q3dzw, D5=a per rf2-sndui) subsumes the legacy
-;; `edn-inspector.render` diff engine into this widget. Diff is an
-;; opt-in MODE on the same renderer: when the caller passes `:before`
-;; the widget paints gutter glyphs + `← changed from <prior>`
-;; annotations in place, force-expands the ancestor chain over any
-;; changed descendant, and dims `:same` rows so the eye lands on the
-;; change.
+;; rf2-n2jig — Editscript-backed projection engine replaces the home-
+;; grown classifier wholesale (no shim, no transitional double-engine
+;; state). The 10 pre-existing fns (`diff-op` / `children-descendant?` /
+;; `op->gutter-glyph` / `op->gutter-tone-key` / `op->row-wash-key` /
+;; `op->row-stripe-key` / `gutter-colour` / `row-wash-bg` /
+;; `row-stripe-colour` / `container-op`) were retired here in favour of
+;; `day8.re-frame2-xray.diff.engine`'s pre-computed projection
+;; (`engine/project`) + the path-keyed lookup helpers (`engine/op-at`,
+;; `engine/wholly-changed-ancestor`, `engine/shifted-was-index`,
+;; `engine/type-change?`, `engine/redaction-side`,
+;; `engine/change-count-at`).
+;;
+;; The legacy `::missing` sentinel is re-exported below for compatibility
+;; with the existing diff-aware container-iteration logic
+;; (`children-of-pair`, `diff-pair-count`) — those walkers thread
+;; `::missing` to represent slots that exist on one side of the diff
+;; only. The CLASSIFIER side of that interaction (which op to attach to
+;; the leaf) now flows through the engine's projection map.
 
 (def missing-sentinel
   "Marker for a `:before` / `:after` slot that does not exist in its
-  side of the diff (e.g. an added key has `::missing` for `:before`).
-  Distinct from `nil` (which is a real CLJS value). Public so tests
-  can assert the diff-op classification against it."
+  side of the diff. Public so the `children-of-pair` / `diff-pair-count`
+  walkers can thread it without colliding with a real `nil` slot. The
+  CLASSIFIER side of the diff (which op to attach to each leaf) lives
+  in `day8.re-frame2-xray.diff.engine` per rf2-n2jig."
   ::missing)
 
-(defn diff-op
-  "Classify a (before, after) pair into a diff op keyword:
+;; ---- per-op token tables ------------------------------------------------
+;;
+;; These five `op-*` lookups carry the rendering chrome rules. They are
+;; PURE — given an op keyword (one of `:added / :removed / :modified /
+;; :same / :same-shifted / :children`) they return the glyph / token-
+;; key / colour the renderer paints. The projection layer is upstream
+;; of these — the renderer hands the engine an op tag, then this
+;; table maps to chrome. R5-tinted (suppress glyph + stripe; retain
+;; wash) is implemented at the call site in `gutter-row` by the caller
+;; passing `:suppress-glyph?` / `:suppress-stripe?` flags.
 
-    :added    — before is `::missing`, after exists
-    :removed  — before exists, after is `::missing`
-    :modified — both exist and differ (leaf-level)
-    :same     — both exist and are equal
-
-  Pure data; JVM-portable."
-  [before after]
-  (cond
-    (= before ::missing) (if (= after ::missing) :same :added)
-    (= after  ::missing) :removed
-    (= before after)     :same
-    :else                :modified))
-
-(declare changed-descendant?*)
-
-(defn changed-descendant?
-  "True when at least one descendant in (before, after) differs.
-  Walks maps + sequentials + sets; pure. Returns true for primitive
-  mismatches at the root too — so a caller can use this to drive
-  ancestor-open.
-
-  Always returns a primitive boolean (never nil) so callers can
-  dispatch on `true?` / `false?` without nil-coercion."
-  [before after]
-  (boolean (changed-descendant?* before after)))
-
-(defn- changed-descendant?*
-  [before after]
-  (cond
-    ;; Either side missing → caller treats this as added / removed,
-    ;; which is itself a change.
-    (or (= before ::missing) (= after ::missing))
-    (not (and (= before ::missing) (= after ::missing)))
-
-    (and (map? before) (map? after))
-    (or (not= (set (keys before)) (set (keys after)))
-        (some (fn [k] (changed-descendant?* (get before k ::missing)
-                                            (get after  k ::missing)))
-              (into (set (keys before)) (keys after))))
-
-    (and (sequential? before) (sequential? after))
-    (let [a-vec (vec after)
-          b-vec (vec before)
-          n     (max (count a-vec) (count b-vec))]
-      (or (not= (count a-vec) (count b-vec))
-          (boolean
-            (some true?
-                  (for [i (range n)]
-                    (changed-descendant?*
-                      (if (< i (count b-vec)) (nth b-vec i) ::missing)
-                      (if (< i (count a-vec)) (nth a-vec i) ::missing)))))))
-
-    (and (set? before) (set? after))
-    (not= before after)
-
-    :else (not= before after)))
-
-(def op->gutter-glyph
-  "Per-op gutter glyph (§10.3 cascade-gutter mapping). Public so tests
-  can assert the mapping without re-deriving."
-  {:added    "+"
-   :removed  "-"
-   :modified "~"
-   :children "◴"
-   :same     " "})
-
-(def op->gutter-tone-key
-  "Per-op token-key for the gutter GLYPH colour.
-
-  rf2-awqts — every diff-active op now reads the SAME reserved
-  `:diff-gutter` token (cyan-teal in dark / darker-teal in light); the
-  glyph carries the per-op shape (`+ / - / ~ / ◴`) and the row wash
-  carries the per-op hue. Pre-fix the glyph colour mapped per-op to
-  `:green` / `:red` / `:yellow` / `:accent`, which collided with the
-  Calva-aligned `:syntax-*` palette (numbers orange ≡ modified yellow,
-  booleans gold ≡ modified yellow, etc.) — the operator could not
-  distinguish 'this is a number' from 'this is modified'. The reserved
-  diff-gutter hue sits outside every `:syntax-*` family by design.
-
-  `:same` keeps `:text-tertiary` so the transparent-border non-diff
-  shape composes unchanged."
-  {:added    :diff-gutter
-   :removed  :diff-gutter
-   :modified :diff-gutter
-   :children :diff-gutter
-   :same     :text-tertiary})
-
-(def op->row-wash-key
-  "Per-op token-key for the row-background wash. rf2-awqts —
-  GitHub-style low-opacity tinge across the whole diff row, so the eye
-  reads diff state at row level while per-token text colour reads type
-  semantics. `:same` and `:children` get NO wash (`nil`) — the row sits
-  flush with the canvas. Public so tests can assert the mapping
-  without re-deriving."
-  {:added    :diff-added-wash
-   :removed  :diff-removed-wash
-   :modified :diff-modified-wash
-   :children nil
-   :same     nil})
-
-(def op->row-stripe-key
-  "Per-op token-key for the 2px left-edge stripe. Reinforces the row
-  wash at the column-1 anchor — same hue family, more saturated.
-  `:same` and `:children` produce a transparent stripe."
-  {:added    :diff-added-stripe
-   :removed  :diff-removed-stripe
-   :modified :diff-modified-stripe
-   :children nil
-   :same     nil})
-
-(defn- gutter-colour
-  "Resolve the gutter GLYPH colour for an op via the token table.
-  rf2-awqts — every active op reads `:diff-gutter`; `:same` reads
-  `:text-tertiary`."
+(defn- op-glyph
+  "Gutter glyph per op. `:same-shifted` shows NO glyph (per R6) — the
+  `(was N)` suffix carries the identity signal alone."
   [op]
-  (get tokens (op->gutter-tone-key op) (:text-tertiary tokens)))
+  (case op
+    :added        "+"
+    :removed      "-"
+    :modified     "~"
+    :children     "◴"
+    :same-shifted " "
+    :same         " "
+    " "))
 
-(defn- row-wash-bg
-  "Resolve the per-op row-background wash CSS string (or `nil` when no
-  wash applies). rf2-awqts."
+(defn- op-gutter-colour
+  "Gutter glyph colour. Active ops paint `:diff-gutter` (reserved cyan-
+  teal, distinct from every `:syntax-*` family); `:same` and
+  `:same-shifted` paint `:text-tertiary`."
   [op]
-  (when-let [k (get op->row-wash-key op)]
-    (get tokens k)))
+  (case op
+    (:added :removed :modified :children) (:diff-gutter tokens)
+    (:text-tertiary tokens)))
 
-(defn- row-stripe-colour
-  "Resolve the per-op 2px-stripe CSS string (or `nil` when no stripe
-  applies). rf2-awqts."
+(defn- op-wash-bg
+  "Row-background wash CSS string. R5-tinted: descendants of a wholly-
+  changed root inherit the wash for their parent op (so a scrolled-in
+  view of a 20-leaf added shard still reads as green) but the caller
+  decides via `:effective-op` what op the wash should reflect."
   [op]
-  (when-let [k (get op->row-stripe-key op)]
-    (get tokens k)))
+  (case op
+    :added    (:diff-added-wash tokens)
+    :removed  (:diff-removed-wash tokens)
+    :modified (:diff-modified-wash tokens)
+    nil))
 
-(defn- container-op
-  "Classify a container's diff op given (before, after). Returns
-  `:added`/`:removed`/`:children`/`:same` (containers never report
-  `:modified` directly — a per-leaf modification surfaces as
-  `:modified` on the leaf row, with `:children` on the ancestor)."
-  [before after]
-  (cond
-    (= before ::missing)                       :added
-    (= after  ::missing)                       :removed
-    (changed-descendant? before after)         :children
-    :else                                      :same))
+(defn- op-stripe-colour
+  "2px left-edge stripe colour. Suppressed for `:children` (the change
+  is below — the descendants carry the signal), `:same`, and
+  `:same-shifted`."
+  [op]
+  (case op
+    :added    (:diff-added-stripe tokens)
+    :removed  (:diff-removed-stripe tokens)
+    :modified (:diff-modified-stripe tokens)
+    nil))
 
 (defn- gutter-row
   "Wrap `body` with the diff row chrome: gutter glyph + low-opacity
@@ -714,40 +645,57 @@
   measured at ~28.79px against the inline ~17.79px sibling rows).
 
   Returns an `[:span ...]` (display: inline-flex) so it nests inside a
-  grid cell without breaking the row."
-  [op body]
-  (let [active? (not= :same op)
-        wash    (row-wash-bg op)
-        stripe  (row-stripe-colour op)]
-    [:span {:data-rf-diff-op (name op)
-            :data-rf-diff-wash (when wash "1")
-            :data-rf-diff-stripe (when stripe "1")
-            :style (cond-> {:display      "inline-flex"
-                            :align-items  "baseline"
-                            :gap          "4px"
-                            :padding-left "6px"
-                            ;; rf2-awqts — stripe colour comes from
-                            ;; `:diff-*-stripe`; on `:same` / `:children`
-                            ;; the border stays transparent so the row
-                            ;; chrome aligns column-wise without paint.
-                            :border-left  (str "2px solid "
-                                               (if (and active? stripe)
-                                                 stripe
-                                                 "transparent"))}
-                     ;; rf2-awqts — row wash applied as background on
-                     ;; the wrapping span so the tint extends behind
-                     ;; both gutter glyph + value. Opacity baked into
-                     ;; the token's rgba() string (~10-12%) so the
-                     ;; wash reads as environmental, not obscuring.
-                     wash (assoc :background wash))}
-     [:span {:style {:flex          "0 0 12px"
-                     :color         (gutter-colour op)
-                     :font-size     "11px"
-                     :font-weight   700
-                     :text-align    "center"
-                     :user-select   "none"}}
-      (op->gutter-glyph op)]
-     [:span {:style {:flex 1 :min-width 0}} body]]))
+  grid cell without breaking the row.
+
+  ## rf2-n2jig — R5-tinted suppression
+
+  The optional `chrome-opts` map carries R5-tinted overrides:
+
+  - `:suppress-glyph?` — paint a blank gutter cell (no `+ / − / ~`).
+    Set by the renderer for descendants of a wholly-changed root.
+  - `:suppress-stripe?` — paint a transparent left-edge stripe.
+    Same R5 suppression rule.
+  - `:wash-op` — paint the wash for THIS op even when the row's own
+    op is `:same` or `:same-shifted` (so descendants of a wholly-
+    new subtree still read as green).
+
+  When `chrome-opts` is omitted the chrome falls back to the per-op
+  defaults (added=green, modified=amber, removed=red, same=invisible).
+  All three optional keys default to nil, so existing call sites
+  (non-mode-3 diff renders) reach the same hiccup shape unchanged."
+  ([op body] (gutter-row op body nil))
+  ([op body {:keys [suppress-glyph? suppress-stripe? wash-op]}]
+   (let [active?       (and (not (#{:same :same-shifted} op))
+                            (not suppress-stripe?))
+         effective-wash-op (or wash-op
+                               (when-not (#{:same :same-shifted} op) op))
+         wash          (op-wash-bg effective-wash-op)
+         stripe        (when-not suppress-stripe? (op-stripe-colour op))
+         glyph         (if suppress-glyph? " " (op-glyph op))
+         glyph-colour  (if suppress-glyph?
+                         (:text-tertiary tokens)
+                         (op-gutter-colour op))]
+     [:span {:data-rf-diff-op (name op)
+             :data-rf-diff-wash (when wash "1")
+             :data-rf-diff-stripe (when stripe "1")
+             :data-rf-diff-suppressed (when suppress-glyph? "1")
+             :style (cond-> {:display      "inline-flex"
+                             :align-items  "baseline"
+                             :gap          "4px"
+                             :padding-left "6px"
+                             :border-left  (str "2px solid "
+                                                (if (and active? stripe)
+                                                  stripe
+                                                  "transparent"))}
+                      wash (assoc :background wash))}
+      [:span {:style {:flex          "0 0 12px"
+                      :color         glyph-colour
+                      :font-size     "11px"
+                      :font-weight   700
+                      :text-align    "center"
+                      :user-select   "none"}}
+       glyph]
+      [:span {:style {:flex 1 :min-width 0}} body]])))
 
 (def ^:private change-annotation-style
   "Style for the inline `← changed from <prior>` chip rendered to the
@@ -1030,6 +978,10 @@
 ;; =========================================================================
 
 (declare render-node)
+;; rf2-n2jig — `render-leaf-with-diff` uses `mini` for R7 type-change
+;; suffix rendering; `mini` is defined later in the file (it's the
+;; public 1-arg inline render). Forward declare so the compiler resolves.
+(declare mini)
 
 (defn- children-of
   "Return a seq of `[child-key child-value]` pairs for a collection.
@@ -1620,9 +1572,9 @@
                                     zoom-path-prefix path)` so the
                                     zoom-slot stores the full path."
   [{:keys [value kind panel-id mount-id path depth expansion-map opts
-           dispatch-fn diff? before zoomable? zoom-path-prefix]}]
+           dispatch-fn diff? before zoomable? zoom-path-prefix projection]}]
   (let [{:keys [default-expanded-depth max-depth max-inline-width
-                available-width-px]
+                available-width-px full-with-diff?]
          :or {default-expanded-depth default-ceiling-depth
               max-depth 16
               max-inline-width 60}} opts
@@ -1635,12 +1587,47 @@
                         (child-count value kind))
         empty?        (zero? cnt)
         depth-capped? (>= depth max-depth)
-        ;; Diff: classify this container's op vs `before`. Only
-        ;; meaningful when diff? is true; otherwise everything is
-        ;; `:same` and the gutter rows collapse to a transparent
-        ;; left border.
-        op            (if diff? (container-op before value) :same)
-        has-change?   (and diff? (not= op :same))
+        ;; Diff: classify this container's op via the rf2-n2jig
+        ;; Editscript-backed projection map. The projection is computed
+        ;; once at the top of `render-edn-inspector` and threaded down
+        ;; via `opts`; the per-path lookup is constant-time. When the
+        ;; projection is absent (non-diff mode), every path reads `:same`
+        ;; and the gutter rows collapse to a transparent left border.
+        ;;
+        ;; rf2-n2jig — tests that drive `render-node` directly without
+        ;; going through `render-edn-inspector` skip the top-level
+        ;; projection compute. We fall back to a lightweight local op
+        ;; classifier in that case so the ancestor-chain force-open +
+        ;; chrome wiring still functions (the engine is the canonical
+        ;; classifier, but a 6-line `(cond ...)` fallback is no shim —
+        ;; it's the same answer for the (before, value) pair, with the
+        ;; engine's superset of `:same-shifted` / R7 / R8 nuances
+        ;; unreachable from this call path).
+        op            (cond
+                        (and diff? projection)
+                        (engine/op-at projection path)
+
+                        (and diff? (or (= before missing-sentinel)
+                                       (= value missing-sentinel)))
+                        (cond
+                          (= before missing-sentinel) :added
+                          :else                       :removed)
+
+                        (and diff? (not= before value))
+                        :children
+
+                        :else :same)
+        has-change?   (and diff? (not (#{:same :same-shifted} op)))
+        ;; R5-tinted: when this container is INSIDE a wholly-changed
+        ;; ancestor, the renderer suppresses per-leaf gutter glyphs +
+        ;; stripes on its descendants (the parent's marking covers them).
+        ;; The descendant row WASH is retained so a partial-visibility
+        ;; scroll into the middle of a 20-leaf added shard still reads
+        ;; as green. The ancestor itself is the wholly-changed-root and
+        ;; gets the full chrome — only deeper descendants suppress.
+        wholly-anc    (when (and diff? projection)
+                        (engine/wholly-changed-ancestor projection path))
+        inside-wholly? (and wholly-anc (not= wholly-anc (vec path)))
         default?      (and (not depth-capped?)
                            (default-expanded?
                              {:depth                   depth
@@ -1818,18 +1805,49 @@
           true        (conj (bracket kind :open value)))
 
         :else
-        (cond-> [:span {:style {:display "inline-flex" :align-items "center" :gap "6px"}}
-                 [:span {:on-click   toggle-fn
-                         :role       "button"
-                         :tabindex   0
-                         :aria-expanded false
-                         :data-testid (str (testid-for panel-id mount-id path) "-toggle")
-                         ;; rf2-tzvk9 — ≥24×24 click target via the shared
-                         ;; `triangle-style`.
-                         :style triangle-style}
-                  "▸"]]
-          zoom-button (conj zoom-button)
-          true        (conj (collapsed-summary value kind))))]
+        (let [;; R3-revised (rf2-n2jig, per findings §7 Q3): collapsed
+              ;; containers carrying ANY descendant change show a
+              ;; `[N∆]` count chip after the closing ellipsis. The
+              ;; triangle itself stays default `:text-tertiary` (no
+              ;; colour swap) so the click affordance is unmuddied.
+              n-changes (when (and diff? projection)
+                          (engine/change-count-at projection path))
+              show-chip? (and (pos? (or n-changes 0))
+                              (not (#{:added :removed} op)))]
+          (cond-> [:span {:style {:display "inline-flex" :align-items "center" :gap "6px"}}
+                   [:span {:on-click   toggle-fn
+                           :role       "button"
+                           :tabindex   0
+                           :aria-expanded false
+                           :data-testid (str (testid-for panel-id mount-id path) "-toggle")
+                           ;; rf2-tzvk9 — ≥24×24 click target via the shared
+                           ;; `triangle-style`.
+                           :style triangle-style}
+                    "▸"]]
+            zoom-button (conj zoom-button)
+            true        (conj (collapsed-summary value kind))
+            show-chip?
+            (conj [:span {:data-rf-diff-chip "1"
+                          :data-rf-diff-chip-count (str n-changes)
+                          :style {:margin-left  "6px"
+                                  :padding      "1px 6px"
+                                  :background   (op-wash-bg (or (engine/op-at projection path)
+                                                                :modified))
+                                  :border       (str "1px solid "
+                                                     (or (op-stripe-colour
+                                                           (or (engine/op-at projection path)
+                                                               :modified))
+                                                         "transparent"))
+                                  :border-radius "8px"
+                                  :font-family  sans-stack
+                                  :font-size    "10px"
+                                  :font-weight  700
+                                  :color        (or (op-stripe-colour
+                                                      (or (engine/op-at projection path)
+                                                          :modified))
+                                                    (:text-secondary tokens))
+                                  :line-height  1.2}}
+                   (str n-changes "∆")]))))]
 
      ;; ---- body — children rendered indented -----------------------------
      ;;
@@ -1884,16 +1902,40 @@
            ;; `padding-left 16px` — line + first-key column + closing-
            ;; brace column all converge on one vertical column, so the
            ;; tree reads as `▾ { │ keys │ }` recursively at every depth.
-           (into [:div {:data-testid (str (testid-for panel-id mount-id path) "-body")
-                        :data-rf-body-layout "grid"
-                        :style body-grid-style}]
+           ;; R4 rail (rf2-n2jig): when this container is change-
+           ;; bearing AND we're in mode-3 (full+diff), promote the
+           ;; body's left border to a 2px coloured rail in the dominant-
+           ;; op hue. Outside mode-3 (or no change) the subtle guide
+           ;; line stays.
+           (into [:div (let [rail-stripe (when (and full-with-diff? has-change?)
+                                           (op-stripe-colour op))]
+                         {:data-testid (str (testid-for panel-id mount-id path) "-body")
+                          :data-rf-body-layout "grid"
+                          :data-rf-rail (when rail-stripe "1")
+                          :style (cond-> body-grid-style
+                                   rail-stripe
+                                   (assoc :border-left (str "2px solid " rail-stripe)))})]
                  (mapcat
                    (fn [[k cv cb]]
                      (let [child-path (conj (vec path) k)
+                           ;; R2 — when the KEY itself is new/removed
+                           ;; (the parent map sees this k for the first
+                           ;; time or this k is gone) paint a `+` / `−`
+                           ;; glyph in column 1 of the KEY ROW. Distinct
+                           ;; from "an existing key whose value changed"
+                           ;; which paints on the value cell. Pulled off
+                           ;; the projection's op at the child path.
+                           child-op (when (and diff? projection)
+                                      (engine/op-at projection child-path))
+                           key-side-glyph (case child-op
+                                            :added   "+"
+                                            :removed "−"
+                                            nil)
                            value-node (render-node
                                         {:value cv
                                          :before cb
                                          :diff? diff?
+                                         :projection projection
                                          :panel-id panel-id
                                          :mount-id mount-id
                                          :path child-path
@@ -1909,9 +1951,26 @@
                           ;; space: nowrap` prevents long keys (e.g. a
                           ;; deeply-namespaced `:rf.x.with.many.parts/k`)
                           ;; from wrapping inside the key column.
-                          [:div {:data-rf-cell "key"
-                                 :style key-cell-style}
-                           (key-segment k)]
+                          [:div (cond-> {:data-rf-cell "key"
+                                         :style key-cell-style}
+                                  key-side-glyph
+                                  (assoc :data-rf-key-glyph key-side-glyph))
+                           ;; R2 key-side glyph — paint `+` / `−` in
+                           ;; column 1 of the key row when the KEY itself
+                           ;; is new/removed. The key text picks up the
+                           ;; per-op decoration (`:removed` gets strike-
+                           ;; through; `:added` paints the key bright).
+                           (when key-side-glyph
+                             [:span {:data-rf-key-glyph "1"
+                                     :style {:color       (:diff-gutter tokens)
+                                             :font-weight 700
+                                             :margin-right "4px"
+                                             :user-select  "none"}}
+                              key-side-glyph])
+                           (cond-> (key-segment k)
+                             (= child-op :removed)
+                             (->>
+                               (conj [:span {:style {:text-decoration "line-through"}}])))]
                           {:key (str "k-" (pr-str k))})
                         (with-meta
                           [:div {:data-rf-cell "value"
@@ -1928,9 +1987,14 @@
            ;; the vertical guide line sits at the triangle's visual
            ;; centre. Closing bracket below shares the same `16px`
            ;; padding-left.
-           (into [:div {:data-testid (str (testid-for panel-id mount-id path) "-body")
-                        :data-rf-body-layout "block"
-                        :style body-block-style}]
+           (into [:div (let [rail-stripe (when (and full-with-diff? has-change?)
+                                           (op-stripe-colour op))]
+                         {:data-testid (str (testid-for panel-id mount-id path) "-body")
+                          :data-rf-body-layout "block"
+                          :data-rf-rail (when rail-stripe "1")
+                          :style (cond-> body-block-style
+                                   rail-stripe
+                                   (assoc :border-left (str "2px solid " rail-stripe)))})]
                  (map
                    (fn [[k cv cb]]
                      (let [child-path (conj (vec path) k)]
@@ -1938,6 +2002,7 @@
                          (render-node {:value cv
                                        :before cb
                                        :diff? diff?
+                                       :projection projection
                                        :panel-id panel-id
                                        :mount-id mount-id
                                        :path child-path
@@ -2025,35 +2090,71 @@
   are non-colour signals — strike-through is a TEXT-DECORATION
   channel; the chip is a separate inline element.
 
-  - `:added`    — render `value`,  gutter `+`, green wash + stripe
-  - `:removed`  — render `before` (strike-through), gutter `-`,
-                  red wash + stripe
-  - `:modified` — render `value` + `← changed from <prior>` chip,
-                  gutter `~`, amber wash + stripe
-  - `:same`     — render `value` (dimmed via `:text-tertiary` so the
-                  eye lands on the changes)"
-  [{:keys [value before diff?]}]
+  - `:added`        — render `value`,  gutter `+`, green wash + stripe
+  - `:removed`      — render `before` (strike-through), gutter `−`,
+                      red wash + stripe
+  - `:modified`     — render `value` + `← changed from <prior>` chip,
+                      gutter `~`, amber wash + stripe
+  - `:same`         — render `value` (dimmed via `:text-tertiary` so the
+                      eye lands on the changes)
+  - `:same-shifted` — render `value` (no dimming) + `(was N)` muted
+                      suffix per R6 vector shift-detection.
+
+  ## rf2-n2jig — projection-aware
+
+  When `:projection` is supplied (mode-3 / full+diff path), the
+  `op` for this leaf is read off `engine/op-at projection path`.
+  Otherwise the call falls back to the legacy (before, after) pair-
+  based op classification via `engine/op-at` over a 1-shot projection
+  computed at the leaf level — same answer, more allocation.
+
+  R5-tinted: when the leaf sits inside a wholly-changed ancestor, the
+  glyph + stripe are suppressed (only the wash + parent's marking
+  carry the signal). Implemented via `gutter-row` chrome-opts."
+  [{:keys [value before diff? projection path]}]
   (if-not diff?
     (render-scalar value)
-    (let [op (diff-op before value)]
+    (let [;; Resolve op: prefer the projection at this path; else
+          ;; fall back to a 1-shot (before, after) op classification.
+          op (if projection
+               (engine/op-at projection (vec (or path [])))
+               (cond
+                 (= before ::missing) (if (= value ::missing) :same :added)
+                 (= value ::missing)  :removed
+                 (= before value)     :same
+                 :else                :modified))
+          ;; R5-tinted: descendant of wholly-changed root?
+          wholly-anc (when projection
+                       (engine/wholly-changed-ancestor projection (vec (or path []))))
+          inside-wholly? (and wholly-anc (not= wholly-anc (vec (or path []))))
+          ;; R5: suppress glyph + stripe on descendants of a wholly-
+          ;; changed root, but RETAIN the wash for partial-visibility.
+          chrome-opts (when inside-wholly?
+                        {:suppress-glyph? true
+                         :suppress-stripe? true
+                         :wash-op (engine/op-at projection wholly-anc)})
+          ;; R6: shifted-was-index for vector elements at a different
+          ;; position than they were in the before-tree.
+          was-index (when (= op :same-shifted)
+                      (engine/shifted-was-index projection (vec (or path []))))
+          ;; R7: type-change suffix uses the `mini` renderer.
+          type-change? (when projection
+                         (engine/type-change? projection (vec (or path []))))
+          ;; R8: redaction-side dictates curated suffix.
+          redaction-side (when projection
+                           (engine/redaction-side projection (vec (or path []))))]
       (case op
         :added
         (gutter-row :added
                     [:span {:data-rf-diff-op "added"}
-                     ;; rf2-awqts — render-scalar paints per-token
-                     ;; syntax colour; wash + stripe carry the diff
-                     ;; signal at the row level.
-                     (render-scalar value)])
+                     (render-scalar value)]
+                    chrome-opts)
         :removed
         (gutter-row :removed
                     [:span {:data-rf-diff-op "removed"
-                            ;; rf2-awqts — strike-through is a
-                            ;; non-colour signal that survives the
-                            ;; move to row chrome; keep it so a
-                            ;; removed leaf still reads as deleted at
-                            ;; the glyph level.
                             :style {:text-decoration "line-through"}}
-                     (render-scalar before)])
+                     (render-scalar (if (= before ::missing) value before))]
+                    chrome-opts)
         :modified
         (gutter-row :modified
                     [:span {:data-rf-diff-op "modified"
@@ -2061,23 +2162,67 @@
                                     :align-items "baseline"
                                     :flex-wrap "wrap"
                                     :gap "4px"}}
-                     ;; rf2-awqts — drop the per-leaf colour override;
-                     ;; render-scalar emits the value with its
-                     ;; `:syntax-*` token colour intact.
                      (render-scalar value)
-                     (change-annotation before)])
+                     ;; R8 curated suffix for one-sided redaction; R7
+                     ;; mini-rendered suffix for type changes; R1
+                     ;; default for plain scalar mods.
+                     (cond
+                       (= redaction-side :before)
+                       [:span {:data-rf-diff-annotation "redacted-before"
+                               :style change-annotation-style}
+                        "← was redacted"]
+                       (= redaction-side :after)
+                       [:span {:data-rf-diff-annotation "redacted-after"
+                               :style change-annotation-style}
+                        "← now redacted"]
+                       type-change?
+                       [:span {:data-rf-diff-annotation "type-change"
+                               :style change-annotation-style}
+                        "← was "
+                        [:span {:style {:font-family mono-stack}}
+                         (let [prior (if projection
+                                       (:before (engine/entry-at projection
+                                                                  (vec (or path []))))
+                                       before)]
+                           ;; Use the mini renderer for compact prior;
+                           ;; fall back to a type-summary when it
+                           ;; would overflow.
+                           [mini prior 40])]]
+                       :else
+                       (change-annotation
+                         (if projection
+                           (or (:before (engine/entry-at projection
+                                                          (vec (or path []))))
+                               before)
+                           before)))]
+                    chrome-opts)
+        :same-shifted
+        (gutter-row :same-shifted
+                    [:span {:data-rf-diff-op "same-shifted"
+                            :style {:display "inline-flex"
+                                    :align-items "baseline"
+                                    :gap "8px"}}
+                     (render-scalar value)
+                     ;; R6: `(was N)` muted suffix.
+                     (when was-index
+                       [:span {:data-rf-diff-was-index (str was-index)
+                               :style {:color       (:text-tertiary tokens)
+                                       :font-family sans-stack
+                                       :font-size   "11px"
+                                       :font-style  "italic"}}
+                        (str "(was " was-index ")")])]
+                    chrome-opts)
         :same
         (gutter-row :same
                     [:span {:data-rf-diff-op "same"
-                            ;; rf2-awqts — `:same` keeps the dim
-                            ;; `:text-tertiary` override on purpose:
-                            ;; in a diff context the unchanged rows
-                            ;; SHOULD recede so the eye lands on the
-                            ;; changes. This is the only op where the
-                            ;; diff path still tints text colour, and
-                            ;; the choice is dimming-not-replacing.
                             :style {:color (:text-tertiary tokens)}}
-                     (render-scalar value)])))))
+                     (render-scalar value)]
+                    chrome-opts)
+        ;; Default — paint as :same so unknown ops degrade gracefully.
+        (gutter-row :same
+                    [:span {:data-rf-diff-op (name op)}
+                     (render-scalar value)]
+                    chrome-opts)))))
 
 (defn render-node
   "Recursive entry. Picks container vs scalar; threads the
@@ -2101,7 +2246,7 @@
   container-renderer falls back to the global `rf/dispatch`.
 
   Public so unit tests can drive the renderer without mounting."
-  [{:keys [value before diff? panel-id mount-id path depth expansion-map
+  [{:keys [value before diff? projection panel-id mount-id path depth expansion-map
            dispatch-fn zoomable? zoom-path-prefix opts]
     :or   {depth 0 path [] zoom-path-prefix []}}]
   (or
@@ -2124,7 +2269,8 @@
       ;; collapse to one removed line — operator follows the gutter, not
       ;; the structure, for deletions).
       (and diff? (= value ::missing))
-      (render-leaf-with-diff {:value ::missing :before before :diff? true})
+      (render-leaf-with-diff {:value ::missing :before before :diff? true
+                              :projection projection :path path})
 
       ;; Diff mode: added slot at a container → render the new
       ;; container in green via the normal recursive path with `op
@@ -2144,8 +2290,10 @@
                              :zoom-path-prefix zoom-path-prefix
                              :opts opts
                              :diff? true
-                             :before ::missing})
-          (render-leaf-with-diff {:value value :before ::missing :diff? true})))
+                             :before ::missing
+                             :projection projection})
+          (render-leaf-with-diff {:value value :before ::missing :diff? true
+                                  :projection projection :path path})))
 
       :else
       (let [kind (collection-kind value)]
@@ -2162,10 +2310,13 @@
                              :zoom-path-prefix zoom-path-prefix
                              :opts opts
                              :diff? (boolean diff?)
-                             :before before})
+                             :before before
+                             :projection projection})
           (render-leaf-with-diff {:value value
                                   :before before
-                                  :diff? (boolean diff?)}))))))
+                                  :diff? (boolean diff?)
+                                  :projection projection
+                                  :path path}))))))
 
 ;; =========================================================================
 ;; mount-id generator + public entry — edn-inspector (form-2 component)
@@ -2633,7 +2784,8 @@
       [value & rest-args]
       (let [opts          (first rest-args)
             {:keys [panel-id site-id default-expanded-depth max-inline-width
-                    max-depth before popup-affordance? card? header zoomable?]
+                    max-depth before popup-affordance? card? header zoomable?
+                    full-with-diff?]
              :or   {panel-id :rf.xray.edn-inspector/anon
                     ;; rf2-kbdk8 — default raised from 2 → 8. Under the
                     ;; width-aware heuristic this opt is a CEILING (never
@@ -2731,46 +2883,44 @@
             ;; sleeve. The mount-id testid + ref still anchor at the
             ;; root of whichever shape renders (section in chromed
             ;; mode; div otherwise).
+            ;; rf2-n2jig — compute the Editscript-backed projection
+            ;; once at the top so every recursive render-node descends
+            ;; with the same `{path → op}` table. Outside diff mode the
+            ;; projection is nil and the renderer's path-keyed lookups
+            ;; return `:same` for everything. Pure data — same value
+            ;; key composability as `expansion-map`.
+            projection    (when diff?
+                            (engine/project displayed-before displayed-value))
             body-content  (render-node
                             {:value displayed-value
                              :before (if diff? displayed-before ::missing)
                              :diff? diff?
+                             :projection projection
                              :panel-id panel-id
-                             ;; rf2-pvsxs — `mount-id` slot in
-                             ;; render-node's key carries the
-                             ;; EFFECTIVE id (site-id if supplied;
-                             ;; auto-mount-id otherwise). Callbacks
-                             ;; deep in the recursion thread the same
-                             ;; value, so toggle dispatches store +
-                             ;; read overrides under the persistence-
-                             ;; friendly key.
                              :mount-id effective-id
                              :path []
                              :depth 0
                              :expansion-map expansion-map
                              :dispatch-fn dispatch-fn
-                             ;; rf2-h71e0 — `:zoomable?` enables the
-                             ;; per-container `⊙` affordance during the
-                             ;; recursive walk. `:zoom-path-prefix` is
-                             ;; the absolute path of the displayed-
-                             ;; subtree's root within the original
-                             ;; value; per-container affordances
-                             ;; compose this prefix with their relative
-                             ;; `:path` to produce the absolute path
-                             ;; the dispatched event stores.
                              :zoomable? zoomable?
                              :zoom-path-prefix zoom-path-prefix
                              :opts {:default-expanded-depth default-expanded-depth
                                     :max-inline-width max-inline-width
                                     :max-depth max-depth
-                                    ;; rf2-kbdk8 — threaded so every
-                                    ;; recursive render-node decides
-                                    ;; expansion against the same
-                                    ;; available column width. Nil
-                                    ;; until the ref measures, after
-                                    ;; which ResizeObserver keeps it
-                                    ;; live.
-                                    :available-width-px available-width-px}})
+                                    :available-width-px available-width-px
+                                    ;; rf2-n2jig — `:full-with-diff?` is
+                                    ;; threaded through opts so the
+                                    ;; recursive render-container path
+                                    ;; can promote the R4 rail + R3
+                                    ;; chip chrome. Mode-2 (plain
+                                    ;; `:diff` lens) does NOT set this
+                                    ;; flag — it walks the same
+                                    ;; renderer but suppresses the
+                                    ;; rail + chip (per pair-debug
+                                    ;; 2026-05-27 the diff lens stays
+                                    ;; per-leaf focused; mode-3 adds
+                                    ;; the structural-context chrome).
+                                    :full-with-diff? (boolean full-with-diff?)}})
             ;; rf2-h71e0 — breadcrumb row above the body, only when a
             ;; zoom is active. Home label uses the consumer's `:header`
             ;; if supplied (mirrors §10.0.10's "header is the natural

--- a/tools/xray/test/day8/re_frame2_xray/diff/engine_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/diff/engine_cljs_test.cljc
@@ -1,0 +1,222 @@
+(ns day8.re-frame2-xray.diff.engine-cljs-test
+  "Tests for the Editscript-backed diff projection engine
+  (`day8.re-frame2-xray.diff.engine`, rf2-n2jig).
+
+  Each test pins one rule from §5.1 of
+  `ai/findings/diff-mode-3-key-and-triangle-grammar-2026-05-27.md`
+  (as revised in §7 by Mike's pair-debug answers). Pure data → data,
+  `.cljc` so the JVM target picks them up too."
+  (:require [clojure.test :refer [deftest is testing]]
+            [day8.re-frame2-xray.diff.engine :as engine]))
+
+;; ---- R1 modified scalar -------------------------------------------------
+
+(deftest r1-modified-scalar
+  (testing "scalar bump produces :modified at the leaf path"
+    (let [p (engine/project {:counter 5} {:counter 6})]
+      (is (= :modified (engine/op-at p [:counter])))
+      (is (= {:op :modified :before 5 :after 6}
+             (engine/entry-at p [:counter])))
+      ;; Root container should appear with `:children` op since one
+      ;; descendant differs.
+      (is (= :children (engine/op-at p [])))
+      (is (= 1 (engine/change-count-at p []))))))
+
+;; ---- R2 new map key -----------------------------------------------------
+
+(deftest r2-new-map-key
+  (testing "wholly new key surfaces as :added at the leaf path"
+    (let [p (engine/project {:a 1} {:a 1 :b 2})]
+      (is (= :added (engine/op-at p [:b])))
+      (is (= 2 (:after (engine/entry-at p [:b]))))
+      (is (= :same (engine/op-at p [:a]))))))
+
+(deftest r2-removed-map-key
+  (testing "removed key surfaces as :removed at the leaf path"
+    (let [p (engine/project {:a 1 :b 2} {:a 1})]
+      (is (= :removed (engine/op-at p [:b])))
+      (is (= 2 (:before (engine/entry-at p [:b])))))))
+
+;; ---- R5 wholly-new subtree ---------------------------------------------
+
+(deftest r5-wholly-new-subtree
+  (testing "subtree where every descendant is :added → parent root logged"
+    (let [p (engine/project {:a 1}
+                            {:a 1 :flash {:level :ok :text "hi"}})]
+      (is (contains? (:wholly-changed-roots p) [:flash])
+          "[:flash] should be the wholly-changed root")
+      ;; The shallowest wholly-changed ancestor of every descendant of
+      ;; [:flash] should be [:flash] itself.
+      (is (= [:flash] (engine/wholly-changed-ancestor p [:flash :level])))
+      (is (= [:flash] (engine/wholly-changed-ancestor p [:flash :text]))))))
+
+(deftest r5-wholly-removed-subtree
+  (testing "subtree where every descendant is :removed → parent root logged"
+    (let [p (engine/project {:a 1 :flash {:level :ok :text "hi"}}
+                            {:a 1})]
+      (is (contains? (:wholly-changed-roots p) [:flash])))))
+
+(deftest r5-mixed-subtree-not-wholly-changed
+  (testing "subtree with both :added and :same leaves does NOT reclassify"
+    ;; :user has :id (same) AND :name (modified) — not wholly-anything.
+    (let [p (engine/project {:user {:id 7 :name "Ada"}}
+                            {:user {:id 7 :name "Ada Lovelace"}})]
+      (is (not (contains? (:wholly-changed-roots p) [:user]))))))
+
+;; ---- R6 vector shift ----------------------------------------------------
+
+(deftest r6-vector-insert-with-shift
+  (testing "vector insert at index 1 — shifted indices get :same-shifted"
+    (let [before [:a :b :c :d]
+          after  [:a :NEW :b :c :d]
+          p (engine/project before after)]
+      ;; New element at after-index 1
+      (is (= :added (engine/op-at p [1])))
+      ;; Shifted elements at after-indices 2,3,4 carry :same-shifted
+      ;; with `:was-index` 1,2,3 respectively.
+      (is (= :same-shifted (engine/op-at p [2])))
+      (is (= 1 (engine/shifted-was-index p [2])))
+      (is (= :same-shifted (engine/op-at p [3])))
+      (is (= 2 (engine/shifted-was-index p [3])))
+      (is (= :same-shifted (engine/op-at p [4])))
+      (is (= 3 (engine/shifted-was-index p [4]))))))
+
+(deftest r6-vector-remove-with-shift
+  (testing "vector remove — surviving after-indices carry :same-shifted, removed slot lives in :vector-removals"
+    (let [before [:a :b :c :d]
+          after  [:a :c :d]
+          p (engine/project before after)]
+      ;; After-index 1 = :c (was :b at before-idx 2). After-index 2 =
+      ;; :d (was :c at before-idx 3). Both shifted up by 1.
+      (is (= :same-shifted (engine/op-at p [1])))
+      (is (= 2 (engine/shifted-was-index p [1])))
+      (is (= :same-shifted (engine/op-at p [2])))
+      (is (= 3 (engine/shifted-was-index p [2])))
+      ;; The removed element :b lives on the :vector-removals channel
+      ;; keyed by parent path, NOT on path-ops (the surviving after-
+      ;; tree has no stable path identity for it).
+      (let [removals (get-in p [:vector-removals []])]
+        (is (= 1 (count removals)))
+        (is (= {:before-index 1 :before-value :b} (first removals)))))))
+
+;; ---- R7 type change -----------------------------------------------------
+
+(deftest r7-scalar-to-container
+  (testing "scalar → map at the same path classifies as :modified"
+    (let [p (engine/project {:flash "hi"} {:flash {:level :ok}})]
+      (is (= :modified (engine/op-at p [:flash])))
+      (is (engine/type-change? p [:flash])))))
+
+(deftest r7-container-to-scalar
+  (testing "map → scalar at the same path classifies as :modified"
+    (let [p (engine/project {:flash {:level :ok}} {:flash "hi"})]
+      (is (= :modified (engine/op-at p [:flash])))
+      (is (engine/type-change? p [:flash])))))
+
+(deftest r7-map-to-vector
+  (testing "map → vector at the same path classifies as :modified"
+    (let [p (engine/project {:items {:a 1}} {:items [1 2 3]})]
+      (is (= :modified (engine/op-at p [:items])))
+      (is (engine/type-change? p [:items])))))
+
+;; ---- R8 sensitive redaction ---------------------------------------------
+
+(deftest r8-was-redacted-now-visible
+  (testing "before sentinel + after real value → :modified with :before side"
+    (let [p (engine/project {:secret :rf/redacted}
+                            {:secret "real-value"})]
+      (is (= :modified (engine/op-at p [:secret])))
+      (is (= :before (engine/redaction-side p [:secret]))))))
+
+(deftest r8-was-visible-now-redacted
+  (testing "before real value + after sentinel → :modified with :after side"
+    (let [p (engine/project {:secret "real-value"}
+                            {:secret :rf/redacted})]
+      (is (= :modified (engine/op-at p [:secret])))
+      (is (= :after (engine/redaction-side p [:secret]))))))
+
+(deftest r8-two-sided-redacted-is-same
+  (testing "both sides redacted (v1 scope) → :same (no false-positive change)"
+    (let [p (engine/project {:secret :rf/redacted}
+                            {:secret :rf/redacted})]
+      (is (= :same (engine/op-at p [:secret]))))))
+
+;; ---- Container ops + change count chip (R3 input) ----------------------
+
+(deftest r3-change-count-chip-input
+  (testing "[N∆] chip count reflects total non-same descendants"
+    (let [p (engine/project {:user {:id 7 :name "Ada" :role "engineer"}}
+                            {:user {:id 7 :name "Ada Lovelace" :role "lead"}})]
+      ;; Two leaves modified under :user → count 2.
+      ;; Including the [:user] ancestor itself counted via the
+      ;; container-ancestors walk: each non-same leaf increments every
+      ;; ancestor. With 2 leaves the [:user] container reaches 2.
+      (is (= 2 (engine/change-count-at p [:user]))))))
+
+;; ---- Flat-rows shape ----------------------------------------------------
+
+(deftest flat-rows-feeds-pure-diff-mode
+  (testing "flat-rows projection feeds the :diff (pure list) mode"
+    (let [p (engine/project {:counter 5
+                             :user {:id 7 :name "Ada"}
+                             :legacy-flag true}
+                            {:counter 6
+                             :user {:id 7 :name "Ada Lovelace"}
+                             :flash {:level :ok}})
+          rows (:flat-rows p)
+          paths (set (map :path rows))
+          op-at-path (fn [path]
+                       (some (fn [r] (when (= path (:path r)) (:op r)))
+                             rows))]
+      ;; Four canonical changes: counter modified + user/name modified
+      ;; + legacy-flag removed + flash added (wholly-new → per-leaf
+      ;; rows expand to flash/level).
+      (is (contains? paths [:counter]))
+      (is (contains? paths [:user :name]))
+      (is (contains? paths [:legacy-flag]))
+      (is (contains? paths [:flash :level]))
+      (is (= :modified (op-at-path [:counter])))
+      (is (= :removed (op-at-path [:legacy-flag]))))))
+
+;; ---- Empty diff edge-case ----------------------------------------------
+
+(deftest empty-diff-when-before-equals-after
+  (testing "identical before+after produces empty projection"
+    (let [v {:counter 5 :user {:id 7}}
+          p (engine/project v v)]
+      (is (= {} (:path-ops p)))
+      (is (= {} (:container-ops p)))
+      (is (= [] (:flat-rows p)))
+      (is (= #{} (:wholly-changed-roots p))))))
+
+;; ---- Deep nested change-------------------------------------------------
+
+(deftest deep-nested-change
+  (testing "change at depth 5+ marks every ancestor as :children"
+    (let [deep-path [:a :b :c :d :e]
+          before    (assoc-in {} deep-path 1)
+          after     (assoc-in {} deep-path 2)
+          p         (engine/project before after)]
+      (is (= :modified (engine/op-at p deep-path)))
+      (is (= :children (engine/op-at p [:a])))
+      (is (= :children (engine/op-at p [:a :b])))
+      (is (= :children (engine/op-at p [:a :b :c])))
+      (is (= :children (engine/op-at p [:a :b :c :d]))))))
+
+;; ---- Sanity — Editscript imports cleanly under the build ---------------
+
+(deftest editscript-import-sanity
+  (testing "engine/project handles the §2 canonical example without throwing"
+    (let [before {:counter 5
+                  :user {:id 7 :name "Ada"}
+                  :legacy-flag true}
+          after  {:counter 6
+                  :user {:id 7 :name "Ada Lovelace"}
+                  :flash {:level :ok :text "Order placed"}}
+          p (engine/project before after)]
+      (is (map? p))
+      (is (vector? (:flat-rows p)))
+      (is (= :modified (engine/op-at p [:counter])))
+      (is (= :modified (engine/op-at p [:user :name])))
+      (is (= :removed  (engine/op-at p [:legacy-flag])))
+      (is (contains? (:wholly-changed-roots p) [:flash])))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -371,34 +371,46 @@
   (testing "rf2-93436 — `:db diff` sub-section is ALWAYS present
             inside the HANDLER body for reg-event-db / reg-event-fx.
             Empty diff renders `— (no changes)`; populated diff
-            renders the path-changes."
+            renders the path-changes.
+
+            rf2-n2jig — the toggle's default flipped to `:full+diff`
+            (mode-3). These tests pin `:diff` explicitly via the
+            persistence slot so the diff-list assertions remain
+            authoritative against the explicit-pin path."
+    (epoch-orchestrator/install!)
+    (frame/reg-frame :rf/xray {})
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray.epoch/set-db-view-mode :diff]))
     (testing "reg-event-db with empty diff"
-      (let [tree (view/render-handler-step
-                   {:step :handler :badge :HANDLER :step-number 3
-                    :flavour :reg-event-db :event-id :nop
-                    :db-diff [] :fx [] :machine nil})
+      (let [tree (rf/with-frame :rf/xray
+                   (view/render-handler-step
+                     {:step :handler :badge :HANDLER :step-number 3
+                      :flavour :reg-event-db :event-id :nop
+                      :db-diff [] :fx [] :machine nil}))
             slot (th/find-by-testid tree "rf-xray-epoch-handler-db-diff")]
         (is (some? slot)
             ":db diff sub-section is always present even when empty")
         (is (string/includes? (or (th/text-content slot) "") "no changes")
             "empty diff renders `— (no changes)` per design §Empty edge cases")))
     (testing "reg-event-db with populated diff"
-      (let [tree (view/render-handler-step
-                   {:step :handler :badge :HANDLER :step-number 3
-                    :flavour :reg-event-db :event-id :counter/inc
-                    :db-diff [[[:counter :value] 5 6 :modified]]
-                    :fx [] :machine nil})
+      (let [tree (rf/with-frame :rf/xray
+                   (view/render-handler-step
+                     {:step :handler :badge :HANDLER :step-number 3
+                      :flavour :reg-event-db :event-id :counter/inc
+                      :db-diff [[[:counter :value] 5 6 :modified]]
+                      :fx [] :machine nil}))
             slot (th/find-by-testid tree "rf-xray-epoch-handler-db-diff")]
         (is (some? slot))
         (is (some? (th/find-by-testid
                      tree "rf-xray-epoch-handler-diff-row-0"))
             "the populated diff row renders inside the sub-section")))
     (testing "reg-event-fx with empty diff"
-      (let [tree (view/render-handler-step
-                   {:step :handler :badge :HANDLER :step-number 3
-                    :flavour :reg-event-fx :event-id :navigate
-                    :db-diff [] :fx [{:fx-id :navigate :value "/x"}]
-                    :machine nil})
+      (let [tree (rf/with-frame :rf/xray
+                   (view/render-handler-step
+                     {:step :handler :badge :HANDLER :step-number 3
+                      :flavour :reg-event-fx :event-id :navigate
+                      :db-diff [] :fx [{:fx-id :navigate :value "/x"}]
+                      :machine nil}))
             slot (th/find-by-testid tree "rf-xray-epoch-handler-db-diff")]
         (is (some? slot)
             "even reg-event-fx that returned no :db gets the sub-section")
@@ -1110,12 +1122,20 @@
 (deftest handler-db-diff-values-route-through-mini-test
   (testing "rf2-8w8er — HANDLER step's :db diff rows render before /
             after values through `ei/mini` so per-token chrome paints
-            (numbers orange, sentinels chip)."
-    (let [tree (view/render-handler-step
-                 {:step :handler :badge :HANDLER :step-number 3
-                  :flavour :reg-event-db :event-id :counter/inc
-                  :db-diff [[[:counter :value] 5 6 :modified]]
-                  :fx [] :machine nil})]
+            (numbers orange, sentinels chip).
+
+            rf2-n2jig — pin `:diff` mode explicitly since the default
+            flipped to `:full+diff`."
+    (epoch-orchestrator/install!)
+    (frame/reg-frame :rf/xray {})
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray.epoch/set-db-view-mode :diff]))
+    (let [tree (rf/with-frame :rf/xray
+                 (view/render-handler-step
+                   {:step :handler :badge :HANDLER :step-number 3
+                    :flavour :reg-event-db :event-id :counter/inc
+                    :db-diff [[[:counter :value] 5 6 :modified]]
+                    :fx [] :machine nil}))]
       (is (pos? (count (mini-mounts tree)))
           "the :db diff row mounts at least one mini-render"))))
 

--- a/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs
@@ -1098,67 +1098,17 @@
 ;; force-opens over any changed descendant.
 
 ;; ---- pure helpers --------------------------------------------------------
-
-(deftest diff-op-classification
-  (is (= :same     (ei/diff-op 1 1)))
-  (is (= :same     (ei/diff-op nil nil)))
-  (is (= :modified (ei/diff-op 1 2)))
-  (is (= :modified (ei/diff-op :a :b)))
-  (is (= :added    (ei/diff-op ei/missing-sentinel 1)))
-  (is (= :removed  (ei/diff-op 1 ei/missing-sentinel)))
-  (is (= :same     (ei/diff-op ei/missing-sentinel ei/missing-sentinel))))
-
-(deftest changed-descendant?-walks-maps
-  (is (false? (ei/changed-descendant? {:a 1 :b 2} {:a 1 :b 2})))
-  (is (true?  (ei/changed-descendant? {:a 1 :b 2} {:a 1 :b 3})))
-  (is (true?  (ei/changed-descendant? {:a {:x 1}} {:a {:x 2}}))
-      "deep change propagates to root")
-  (is (true?  (ei/changed-descendant? {:a 1} {:a 1 :b 2}))
-      "key added"))
-
-(deftest changed-descendant?-walks-sequentials
-  (is (false? (ei/changed-descendant? [1 2 3] [1 2 3])))
-  (is (true?  (ei/changed-descendant? [1 2 3] [1 2 4])))
-  (is (true?  (ei/changed-descendant? [1 2] [1 2 3]))))
-
-(deftest gutter-glyph-mapping
-  (is (= "+" (ei/op->gutter-glyph :added)))
-  (is (= "-" (ei/op->gutter-glyph :removed)))
-  (is (= "~" (ei/op->gutter-glyph :modified)))
-  (is (= "◴" (ei/op->gutter-glyph :children)))
-  (is (= " " (ei/op->gutter-glyph :same))))
-
-(deftest gutter-tone-mapping
-  (testing "rf2-awqts — every active diff op now reads the SAME
-            reserved `:diff-gutter` token; the glyph's hue is no longer
-            per-op (per-op signal lives in the wash + stripe + shape).
-            `:same` keeps `:text-tertiary` so the transparent non-diff
-            shape composes unchanged."
-    (is (= :diff-gutter   (ei/op->gutter-tone-key :added)))
-    (is (= :diff-gutter   (ei/op->gutter-tone-key :removed)))
-    (is (= :diff-gutter   (ei/op->gutter-tone-key :modified)))
-    (is (= :diff-gutter   (ei/op->gutter-tone-key :children)))
-    (is (= :text-tertiary (ei/op->gutter-tone-key :same)))))
-
-;; ---- rf2-awqts — row chrome (wash + stripe) -----------------------------
-
-(deftest row-wash-mapping
-  (testing "rf2-awqts — per-op row-background wash token-key mapping"
-    (is (= :diff-added-wash    (ei/op->row-wash-key :added)))
-    (is (= :diff-removed-wash  (ei/op->row-wash-key :removed)))
-    (is (= :diff-modified-wash (ei/op->row-wash-key :modified)))
-    (is (nil? (ei/op->row-wash-key :children))
-        "`:children` rows carry NO wash — the colour-coded descendants below do")
-    (is (nil? (ei/op->row-wash-key :same))
-        "`:same` rows sit flush with the canvas")))
-
-(deftest row-stripe-mapping
-  (testing "rf2-awqts — per-op 2px-stripe token-key mapping"
-    (is (= :diff-added-stripe    (ei/op->row-stripe-key :added)))
-    (is (= :diff-removed-stripe  (ei/op->row-stripe-key :removed)))
-    (is (= :diff-modified-stripe (ei/op->row-stripe-key :modified)))
-    (is (nil? (ei/op->row-stripe-key :children)))
-    (is (nil? (ei/op->row-stripe-key :same)))))
+;;
+;; rf2-n2jig — the home-grown classifier (`diff-op`,
+;; `changed-descendant?`, `op->gutter-glyph`, `op->gutter-tone-key`,
+;; `op->row-wash-key`, `op->row-stripe-key`) was retired in favour of
+;; the Editscript-backed projection engine at
+;; `day8.re-frame2-xray.diff.engine`. Per the bead's pre-alpha posture:
+;; clean delete, no shim. The engine's own test suite at
+;; `day8.re-frame2-xray.diff.engine-cljs-test` carries the classification
+;; pins (R1-R8 grammar rules). The diff-leaf rendering tests below
+;; continue to drive `render-node` end-to-end with `:before` and assert
+;; against the resulting DOM chrome attributes.
 
 (deftest gutter-glyph-colour-is-syntax-palette-disjoint
   (testing "rf2-awqts — the reserved `:diff-gutter` hue must NOT match

--- a/tools/xray/testbeds/panel_gallery/core.cljs
+++ b/tools/xray/testbeds/panel_gallery/core.cljs
@@ -89,7 +89,14 @@
             ;; L4 panel that mounts it; this gallery gives it a
             ;; dedicated harness with one variant per input shape /
             ;; opts combination.
-            [panel-gallery.gallery-edn-inspector]))
+            [panel-gallery.gallery-edn-inspector]
+            ;; rf2-n2jig — mode-3 diff grammar Story set (R1-R8 +
+            ;; combination + edge + theme/density). Shares the
+            ;; `:panel-gallery.edn-inspector/fixture` slot + Panel
+            ;; mount with the edn-inspector gallery above; the
+            ;; variants pass `:full-with-diff? true` to opt into
+            ;; the mode-3 chrome (R3 chip + R4 rail).
+            [panel-gallery.gallery-diff-mode-3]))
 
 ;; ============================================================================
 ;; LANDING — the URL `/` view (no `#/stories` hash)

--- a/tools/xray/testbeds/panel_gallery/fixtures_diff_mode_3.cljs
+++ b/tools/xray/testbeds/panel_gallery/fixtures_diff_mode_3.cljs
@@ -1,0 +1,334 @@
+(ns panel-gallery.fixtures-diff-mode-3
+  "Fixture builders for the **mode-3 diff grammar** Story set
+  (rf2-n2jig).
+
+  Mode-3 is the third lens of the HANDLER `:db` toggle: the full data
+  tree WITH inline diff annotations (gutter glyphs, row washes, R3
+  `[N∆]` chips on collapsed containers, R4 vertical rails, R5-tinted
+  descendant washes, R6 `(was N)` vector-shift suffixes, R7 type-
+  change `← was <prior>` suffixes, R8 redaction-curated suffixes).
+
+  Each variant pins one R-rule + one scenario so Mike can visually
+  inspect every grammar branch when the work is complete. The Story
+  set is the canonical visual demonstration surface for re-frame2
+  (the Storybook analogue per
+  `feedback_skill_anchor_to_known_mental_models`).
+
+  ## Fixture shape
+
+  Each builder returns a map:
+
+      {:before <cljs-value>     ;; the before-tree (epoch N-1 :db)
+       :value  <cljs-value>     ;; the after-tree (epoch N :db)
+       :opts   {<opts-key> ...}} ;; widget opts; `:full-with-diff? true`
+                                ;; enables mode-3 chrome (R3 chip + R4 rail).
+
+  The gallery wraps each fixture with a sub-mounted edn-inspector
+  call: `[edn-inspector value (assoc opts :before before)]`. Mode-3
+  variants pass `:full-with-diff? true` to opt the renderer into the
+  R3 chip + R4 rail chrome; non-mode-3 variants are also covered (see
+  `combo-mode-toggle-three-up` which renders the SAME data in all
+  three modes side-by-side).
+
+  ## R-rule inventory
+
+  - R1 — value-side modified-scalar glyph + `← changed from <prior>`
+  - R2 — key-side `+`/`−` glyph on new/removed map keys
+  - R3 — collapsed `[N∆]` count chip on containers with descendant change
+  - R4 — 2px vertical rail through change-bearing subtree
+  - R5 — wholly-new/removed subtree (parent-only marking, descendant wash retained)
+  - R6 — vector shift-detection via Editscript A* (LCS) — `(was N)` suffix
+  - R7 — type-change containers reclassify to `:modified` with `← was <prior>`
+  - R8 — one-sided redaction renders `← was redacted` / `← now redacted`"
+  (:require [day8.re-frame2-xray.views.edn-inspector :as edn-inspector]))
+
+;; =========================================================================
+;; R1 — modified scalar
+;; =========================================================================
+
+(defn r1-modified-scalar
+  "R1 — modified scalar leaf. `{:counter 5} → {:counter 6}`. Shows
+  the value-side `~` glyph + `← changed from 5` italic muted suffix."
+  []
+  {:before {:counter 5}
+   :value  {:counter 6}
+   :opts   {:full-with-diff? true}})
+
+;; =========================================================================
+;; R2 — new / removed map keys (key-side glyph)
+;; =========================================================================
+
+(defn r2-new-map-key
+  "R2 — wholly new key. `{:a 1} → {:a 1 :b 2}`. The `:b` key row paints
+  a `+` glyph at column 1 (key-side reach) AND the value side picks
+  up the green wash."
+  []
+  {:before {:a 1}
+   :value  {:a 1 :b 2}
+   :opts   {:full-with-diff? true}})
+
+(defn r2-removed-map-key
+  "R2 — removed key. `{:a 1 :b 2} → {:a 1}`. The `:b` key row paints
+  a `−` glyph at column 1 and the key text strikes through. The
+  value side renders the prior value (also struck through)."
+  []
+  {:before {:a 1 :b 2}
+   :value  {:a 1}
+   :opts   {:full-with-diff? true}})
+
+;; =========================================================================
+;; R3 — collapsed [N∆] chip
+;; =========================================================================
+
+(defn r3-collapsed-chip
+  "R3 (revised) — collapsed container with descendant changes shows a
+  `[N∆]` count chip after the closing ellipsis. The fixture sets a
+  shallow `:default-expanded-depth 1` so `:user`'s 3-change subtree
+  collapses by default — the operator sees `▸ :user {…} [3∆]`. Click
+  the triangle to expand; the chip vanishes and per-row signals
+  reveal themselves."
+  []
+  {:before {:counter 5
+            :user    {:id 7 :name "Ada" :role "engineer" :team "platform"}}
+   :value  {:counter 5
+            :user    {:id 7 :name "Ada Lovelace" :role "lead" :team "platform"}}
+   :opts   {:full-with-diff? true
+            :default-expanded-depth 1}})
+
+;; =========================================================================
+;; R4 — vertical rail through subtree
+;; =========================================================================
+
+(defn r4-vertical-rail
+  "R4 — single 2px vertical rail in the dominant-op hue runs through
+  the change-bearing subtree. Sub-tree has one change at row 3; the
+  rail paints through its full height so the operator's peripheral
+  vision picks up the region indicator."
+  []
+  {:before {:items [{:id :a :qty 1}
+                    {:id :b :qty 1}
+                    {:id :c :qty 1}
+                    {:id :d :qty 1}
+                    {:id :e :qty 1}]}
+   :value  {:items [{:id :a :qty 1}
+                    {:id :b :qty 1}
+                    {:id :c :qty 99}   ; <-- modified
+                    {:id :d :qty 1}
+                    {:id :e :qty 1}]}
+   :opts   {:full-with-diff? true
+            :default-expanded-depth 3}})
+
+;; =========================================================================
+;; R5 — wholly-new / wholly-removed subtrees
+;; =========================================================================
+
+(defn r5-wholly-new-subtree
+  "R5 (revised) — wholly-new subtree. `:flash` didn't exist in the
+  before-tree; the parent `:flash` row gets the `+` glyph + green
+  triangle + green rail. Per-leaf gutter glyphs + stripes are
+  SUPPRESSED on the descendants, but the low-opacity green wash IS
+  RETAINED across every descendant row (partial-visibility
+  readability)."
+  []
+  {:before {:a 1}
+   :value  {:a 1
+            :flash {:level :ok
+                    :text "Order placed"
+                    :timestamp 1735689600
+                    :duration 250}}
+   :opts   {:full-with-diff? true}})
+
+(defn r5-wholly-removed-subtree
+  "R5 (revised) — wholly-removed subtree. Inverse of the new-subtree
+  case. The parent `:legacy` row paints the `−` glyph + red triangle
+  + red rail; descendants paint with red wash but no per-leaf glyphs."
+  []
+  {:before {:a 1
+            :legacy {:flag true :version 1 :note "deprecated"}}
+   :value  {:a 1}
+   :opts   {:full-with-diff? true}})
+
+;; =========================================================================
+;; R6 — vector insert / remove / reorder
+;; =========================================================================
+
+(defn r6-vector-insert
+  "R6 — vector insert with LCS shift detection. `[:a :b :c]` →
+  `[:a :NEW :b :c]`. After-index 1 carries a `+` for the new element;
+  after-indices 2 and 3 paint as `:same-shifted` with `(was 1)` /
+  `(was 2)` muted suffixes — the elements moved positionally but
+  carry the same identity."
+  []
+  {:before [:a :b :c]
+   :value  [:a :NEW :b :c]
+   :opts   {:full-with-diff? true
+            :default-expanded-depth 3}})
+
+(defn r6-vector-remove
+  "R6 — vector remove with LCS shift detection. `[:a :b :c :d]` →
+  `[:a :c :d]`. Surviving after-indices 1 (`:c`) and 2 (`:d`) carry
+  `(was 2)` / `(was 3)` muted suffixes. The removed element `:b`
+  lives on the `:vector-removals` channel — the renderer can interleave
+  a `−` row in the pure-diff lens."
+  []
+  {:before [:a :b :c :d]
+   :value  [:a :c :d]
+   :opts   {:full-with-diff? true
+            :default-expanded-depth 3}})
+
+(defn r6-vector-reorder
+  "R6 — vector reorder. `[:a :b :c]` → `[:c :a :b]`. Demonstrates LCS
+  shift-detection (vs. the naive positional compare that would render
+  every element as `:modified`). The smallest Editscript transcript
+  is `[[[0] :+ :c] [[3] :-]]` — one insert + one remove."
+  []
+  {:before [:a :b :c]
+   :value  [:c :a :b]
+   :opts   {:full-with-diff? true
+            :default-expanded-depth 3}})
+
+;; =========================================================================
+;; R7 — type-change containers
+;; =========================================================================
+
+(defn r7-type-change
+  "R7 — type-change container. `{:flash \"hi\"}` → `{:flash {:level
+  :ok}}`. The string-to-map flip classifies as `:modified` (not
+  `:children`); the value column shows the new map shape; the suffix
+  reads `← was \"hi\"` via the `mini` renderer."
+  []
+  {:before {:flash "hi"}
+   :value  {:flash {:level :ok}}
+   :opts   {:full-with-diff? true
+            :default-expanded-depth 3}})
+
+;; =========================================================================
+;; R8 — sensitive-redaction (curated suffix)
+;; =========================================================================
+
+(defn r8-was-redacted-now-visible
+  "R8 — `was redacted, now visible`. The before-side carries the
+  `:rf/redacted` sentinel; the after-side carries a real value. The
+  row reads as `:modified` with curated suffix `← was redacted` (no
+  sentinel marker text leak)."
+  []
+  {:before {:user-id :rf/redacted}
+   :value  {:user-id "uid-12345"}
+   :opts   {:full-with-diff? true}})
+
+(defn r8-was-visible-now-redacted
+  "R8 — `was visible, now redacted`. Inverse of the previous case.
+  The after-side carries the `:rf/redacted` sentinel; suffix reads
+  `← now redacted` without printing the prior value (the redaction
+  was probably applied for a reason)."
+  []
+  {:before {:user-id "uid-12345"}
+   :value  {:user-id :rf/redacted}
+   :opts   {:full-with-diff? true}})
+
+;; =========================================================================
+;; Combination + edge-case demonstrations
+;; =========================================================================
+
+(defn combo-all-ops-cascade
+  "All-ops cascade — the §2 canonical example from the findings doc.
+  `:counter` modified + `:user :name` modified + `:flash` wholly-new +
+  `:legacy-flag` removed. The full grammar in one mount."
+  []
+  {:before {:counter     5
+            :user        {:id 7 :name "Ada"}
+            :legacy-flag true}
+   :value  {:counter 6
+            :user    {:id 7 :name "Ada Lovelace"}
+            :flash   {:level :ok :text "Order placed"}}
+   :opts   {:full-with-diff? true}})
+
+(defn combo-mixed-ops-subtree
+  "Mixed-ops subtree — `:user` has BOTH `:added` AND `:removed` AND
+  `:modified` descendants. The R5 wholly-added-collapse rule does NOT
+  trigger (mixed → per-leaf marking returns). Each leaf paints its
+  own glyph + wash; the rail aggregates."
+  []
+  {:before {:user {:id 7 :name "Ada" :legacy "x"}}
+   :value  {:user {:id 7 :name "Ada Lovelace" :email "ada@example.com"}}
+   :opts   {:full-with-diff? true
+            :default-expanded-depth 3}})
+
+(defn combo-deeply-nested-change
+  "Deeply-nested change at depth 5+. Verifies that triangles + rails +
+  chips don't pile up uselessly. Single leaf change at the bottom
+  produces a single chain of `:children` ancestors with their rails."
+  []
+  (let [path [:tenant :acme :department :eng :team :status]]
+    {:before (assoc-in {} path :idle)
+     :value  (assoc-in {} path :active)
+     :opts   {:full-with-diff? true
+              :default-expanded-depth 6}}))
+
+(defn combo-long-vector-one-insert
+  "Long-vector-one-insert (the LCS payoff demo). 12-element vector
+  with one element inserted at index 4. Under naive compare this
+  would render as 8 rows of `:modified`; under LCS it's 1 `+` + 7
+  `(was N)` muted suffixes."
+  []
+  (let [base (mapv (fn [i] (keyword (str "item-" i))) (range 12))
+        ins  (vec (concat (take 4 base) [:NEW-AT-4] (drop 4 base)))]
+    {:before base
+     :value  ins
+     :opts   {:full-with-diff? true
+              :default-expanded-depth 3}}))
+
+(defn combo-empty-diff
+  "Empty diff — `before == after`. Mode-3 must render correctly when
+  there's no change; no glyphs, no chips, no rails, no washes."
+  []
+  (let [v {:counter 5
+           :user {:id 7 :name "Ada Lovelace"}}]
+    {:before v
+     :value  v
+     :opts   {:full-with-diff? true}}))
+
+(defn combo-massive-diff
+  "Massive diff — every key in a small app-db got new values. Verifies
+  the chrome doesn't melt into noise. Each row paints its own ~ +
+  wash; the operator's eye still tracks the cascade because every
+  row carries the same glyph at the same column."
+  []
+  {:before {:counter 1 :user-id 1 :session 1 :flash 1 :route :home}
+   :value  {:counter 2 :user-id 2 :session 2 :flash 2 :route :dashboard}
+   :opts   {:full-with-diff? true}})
+
+(defn combo-mode-toggle-three-up
+  "Mode-toggle three-up — the same diff rendered in all THREE modes
+  side-by-side. Operator sees the relationship between `:diff` (flat
+  list) / `:full` (no chrome) / `:full+diff` (mode-3 with annotations).
+
+  The Story workspace renders three cards side-by-side; the gallery
+  wires each card to a different `:full-with-diff?` + (caller side)
+  mode opt. For this fixture we provide the same before/after data;
+  the gallery's three-up workspace picks the three modes to display."
+  []
+  {:before {:counter 5 :user {:id 7 :name "Ada"}}
+   :value  {:counter 6 :user {:id 7 :name "Ada Lovelace"}
+            :flash {:level :ok}}
+   :opts   {:full-with-diff? true}})
+
+;; =========================================================================
+;; Theme + density variants
+;; =========================================================================
+
+(defn theme-density-narrow-panel
+  "Narrow-panel render — the chrome must stay readable at L4-panel-on-
+  laptop-screen widths (320px wide). The `(was N)` suffixes + `[N∆]`
+  chips must not wrap awkwardly. Wrap the mount in a narrow CSS
+  container; the variant uses the same data as `combo-all-ops-cascade`
+  with a width-constraining wrapper at the gallery view layer."
+  []
+  {:before {:counter     5
+            :user        {:id 7 :name "Ada"}
+            :legacy-flag true}
+   :value  {:counter 6
+            :user    {:id 7 :name "Ada Lovelace"}
+            :flash   {:level :ok :text "Order placed"}}
+   :opts   {:full-with-diff? true
+            :narrow-panel? true}})

--- a/tools/xray/testbeds/panel_gallery/gallery_diff_mode_3.cljs
+++ b/tools/xray/testbeds/panel_gallery/gallery_diff_mode_3.cljs
@@ -1,0 +1,303 @@
+(ns panel-gallery.gallery-diff-mode-3
+  "Story coverage for the **mode-3 diff grammar** (rf2-n2jig).
+
+  Mike's bead acceptance lists 22+ Story variants covering every
+  R-rule (R1-R8 per the findings doc), every combination + edge case,
+  and theme + density. Each variant is one Story entry the operator
+  can navigate independently; the Workspace at the bottom collects
+  them all in a single auto-grid so Mike can step through the
+  grammar end-to-end in a logical order:
+
+      Single-rule (R1-R8)
+        → Combination + edge (all-ops, mixed, deep, long-vector, empty, massive)
+        → Mode toggle three-up
+        → Theme + density (light + dark + narrow)
+
+  Frame isolation: each variant fires its `:panel-gallery.edn-
+  inspector/seed!` event into its own variant frame; the gallery's
+  `:panel-gallery.edn-inspector/Panel` view (mounted via
+  `panel-views`) subscribes from the variant frame so widget state
+  + expansion overrides stay independent across variants.
+
+  ## Where the variants live
+
+  Per Mike's bead, the choice is either `tools/xray/stories/diff-
+  mode-3/` (new dir) OR fold into the existing
+  `tools/xray/testbeds/panel_gallery/` (alongside the other
+  gallery namespaces). We picked the latter — re-using the
+  existing fixture seed event + Panel mount keeps the variant set
+  surface uniform with the rest of the widget gallery, and the
+  workspace can interleave mode-3 with the broader edn-inspector
+  Story set."
+  (:require [re-frame.core :as rf]
+            [re-frame.story :as story]
+            [panel-gallery.fixtures-diff-mode-3 :as fixtures]
+            [panel-gallery.panel-views :as panel-views]))
+
+;; The fixture-slot + sub + view registration live in
+;; `gallery-edn-inspector` — both galleries seed into the same slot
+;; key (`:panel-gallery.edn-inspector/fixture`) and reuse the
+;; `:panel-gallery.edn-inspector/Panel` mount. We rely on the
+;; sibling namespace having installed the seed event + Panel view
+;; by the time variants here run.
+
+(defn register-all!
+  "Register the mode-3 grammar Story surface. Idempotent under
+  `install-canonical-vocabulary!` resets so the namespace is
+  reloadable."
+  []
+  (story/install-canonical-vocabulary!)
+  (panel-views/register!)
+
+  (story/reg-tag :feature/xray-diff-mode-3
+    {:axis :feature
+     :doc  "Xray edn-inspector mode-3 diff grammar (rf2-n2jig) —
+            full data tree with inline diff annotations per the
+            R1-R8 rules from the findings doc."})
+
+  (story/reg-story :story.xray.diff-mode-3
+    {:doc        "Mode-3 grammar visual reference — full data tree
+                  WITH inline diff annotations. One variant per
+                  R-rule + scenario + theme/density case so Mike
+                  can visually verify the full grammar in action."
+     :component  :panel-gallery.edn-inspector/Panel
+     :tags       #{:dev :feature/xray-diff-mode-3}
+     :substrates #{:reagent}})
+
+  ;; -- Single-rule demonstrations (R1-R8) ---------------------------------
+
+  (story/reg-variant :story.xray.diff-mode-3/r1-modified-scalar
+    {:doc        "R1 — modified scalar. `{:counter 5} → {:counter 6}`.
+                  Shows the value-side `~` glyph + `← changed from 5`
+                  italic muted suffix."
+     :events     [[:panel-gallery.edn-inspector/seed!
+                   (fixtures/r1-modified-scalar)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.diff-mode-3/r2-new-map-key
+    {:doc        "R2 — new map key. `{:a 1} → {:a 1 :b 2}`. The `:b`
+                  key row paints `+` glyph at column 1 + green wash
+                  on the value side."
+     :events     [[:panel-gallery.edn-inspector/seed!
+                   (fixtures/r2-new-map-key)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.diff-mode-3/r2-removed-map-key
+    {:doc        "R2 — removed map key. `{:a 1 :b 2} → {:a 1}`. The
+                  `:b` key row paints `−` glyph + strike-through reaches
+                  the key text. The value column renders the prior
+                  value (also struck-through)."
+     :events     [[:panel-gallery.edn-inspector/seed!
+                   (fixtures/r2-removed-map-key)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.diff-mode-3/r3-collapsed-chip
+    {:doc        "R3 (revised) — collapsed `[N∆]` chip. A nested
+                  `:user` map with three modified leaves, collapsed
+                  via `:default-expanded-depth 1`. Operator sees
+                  `▸ :user {…} [3∆]`. Click the triangle to expand
+                  — chip vanishes, per-row signals appear."
+     :events     [[:panel-gallery.edn-inspector/seed!
+                   (fixtures/r3-collapsed-chip)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.diff-mode-3/r4-vertical-rail
+    {:doc        "R4 — single 2px vertical rail through a change-
+                  bearing subtree, painted in the dominant-op hue.
+                  Sub-tree carries one change at row 3 of 5; the
+                  rail runs the full subtree height."
+     :events     [[:panel-gallery.edn-inspector/seed!
+                   (fixtures/r4-vertical-rail)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.diff-mode-3/r5-wholly-new-subtree
+    {:doc        "R5 (revised) — wholly-new subtree. `:flash` didn't
+                  exist before; parent gets `+` glyph + green
+                  triangle + green rail. Descendant gutter glyphs +
+                  stripes SUPPRESSED; descendant row washes RETAINED
+                  for partial-visibility readability."
+     :events     [[:panel-gallery.edn-inspector/seed!
+                   (fixtures/r5-wholly-new-subtree)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.diff-mode-3/r5-wholly-removed-subtree
+    {:doc        "R5 (revised) — wholly-removed subtree. Inverse of
+                  the new-subtree case; parent gets `−` glyph + red
+                  triangle + red rail. Descendants paint red wash
+                  but no per-leaf glyphs/stripes."
+     :events     [[:panel-gallery.edn-inspector/seed!
+                   (fixtures/r5-wholly-removed-subtree)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.diff-mode-3/r6-vector-insert
+    {:doc        "R6 — vector insert with LCS shift. `[:a :b :c]` →
+                  `[:a :NEW :b :c]`. After-index 1 carries `+`; after-
+                  indices 2 and 3 paint `:same-shifted` + `(was 1)`
+                  / `(was 2)` muted suffixes."
+     :events     [[:panel-gallery.edn-inspector/seed!
+                   (fixtures/r6-vector-insert)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.diff-mode-3/r6-vector-remove
+    {:doc        "R6 — vector remove. Surviving elements carry
+                  `(was N)` suffixes; the removed element lives on
+                  the `:vector-removals` channel — the pure-diff
+                  lens interleaves a `−` row at the surgical
+                  position."
+     :events     [[:panel-gallery.edn-inspector/seed!
+                   (fixtures/r6-vector-remove)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.diff-mode-3/r6-vector-reorder
+    {:doc        "R6 — vector reorder. `[:a :b :c]` → `[:c :a :b]`.
+                  Demonstrates LCS detection (vs. naive's `every
+                  element modified`). Editscript transcript is one
+                  insert + one remove — the smallest possible."
+     :events     [[:panel-gallery.edn-inspector/seed!
+                   (fixtures/r6-vector-reorder)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.diff-mode-3/r7-type-change
+    {:doc        "R7 — type-change container. `{:flash \"hi\"}` →
+                  `{:flash {:level :ok}}`. String-to-map flip
+                  classifies as `:modified` (not `:children`); value
+                  column shows new map shape; suffix reads `← was
+                  \"hi\"` via the `mini` renderer."
+     :events     [[:panel-gallery.edn-inspector/seed!
+                   (fixtures/r7-type-change)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.diff-mode-3/r8-was-redacted-now-visible
+    {:doc        "R8 — `was redacted, now visible`. Before-side
+                  carries `:rf/redacted`; after-side carries a real
+                  value. Row reads `:modified` + curated `← was
+                  redacted` suffix (no sentinel text leak)."
+     :events     [[:panel-gallery.edn-inspector/seed!
+                   (fixtures/r8-was-redacted-now-visible)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.diff-mode-3/r8-was-visible-now-redacted
+    {:doc        "R8 — `was visible, now redacted`. Inverse; after-
+                  side carries `:rf/redacted`. Suffix reads `← now
+                  redacted`; prior value is NOT printed (the
+                  redaction was probably applied for a reason)."
+     :events     [[:panel-gallery.edn-inspector/seed!
+                   (fixtures/r8-was-visible-now-redacted)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; -- Combination + edge-case demonstrations -----------------------------
+
+  (story/reg-variant :story.xray.diff-mode-3/combo-all-ops-cascade
+    {:doc        "All-ops cascade — the §2 canonical example: counter
+                  modified + user/name modified + flash added +
+                  legacy-flag removed. The full grammar in one mount."
+     :events     [[:panel-gallery.edn-inspector/seed!
+                   (fixtures/combo-all-ops-cascade)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.diff-mode-3/combo-mixed-ops-subtree
+    {:doc        "Mixed-ops subtree — `:user` has BOTH `:added`,
+                  `:removed`, and `:modified` descendants. The R5
+                  wholly-added-collapse rule does NOT trigger;
+                  per-leaf marking returns for the added leaves."
+     :events     [[:panel-gallery.edn-inspector/seed!
+                   (fixtures/combo-mixed-ops-subtree)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.diff-mode-3/combo-deeply-nested-change
+    {:doc        "Deeply-nested change at depth 5+. Verifies
+                  triangles + rails + chips don't pile up uselessly.
+                  Single leaf change at the bottom produces a chain
+                  of `:children` ancestors with their rails."
+     :events     [[:panel-gallery.edn-inspector/seed!
+                   (fixtures/combo-deeply-nested-change)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.diff-mode-3/combo-long-vector-one-insert
+    {:doc        "Long-vector-one-insert (LCS payoff demo). 12-
+                  element vector with one element inserted at index
+                  4. Under naive compare this would render as 8
+                  `~`s; under LCS it's 1 `+` + 7 `(was N)` suffixes.
+                  The dramatic operator UX win."
+     :events     [[:panel-gallery.edn-inspector/seed!
+                   (fixtures/combo-long-vector-one-insert)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.diff-mode-3/combo-empty-diff
+    {:doc        "Empty diff (no changes). Mode-3 must render
+                  correctly when before == after; no glyphs, no
+                  chips, no rails, no washes."
+     :events     [[:panel-gallery.edn-inspector/seed!
+                   (fixtures/combo-empty-diff)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.diff-mode-3/combo-massive-diff
+    {:doc        "Massive diff — every key got new values. Verifies
+                  the chrome doesn't melt into noise; the eye still
+                  tracks the cascade because every row carries the
+                  same `~` glyph at the same column."
+     :events     [[:panel-gallery.edn-inspector/seed!
+                   (fixtures/combo-massive-diff)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.diff-mode-3/combo-mode-toggle-three-up
+    {:doc        "Mode-toggle three-up — same diff rendered in all
+                  three modes (the workspace renders three separate
+                  cards via `:variants-grid` layout; this single
+                  variant pins the data). Operator sees the
+                  relationship between `:diff` / `:full` /
+                  `:full+diff`."
+     :events     [[:panel-gallery.edn-inspector/seed!
+                   (fixtures/combo-mode-toggle-three-up)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; -- Theme + density variants -------------------------------------------
+
+  (story/reg-variant :story.xray.diff-mode-3/theme-narrow-panel
+    {:doc        "Narrow-panel rendering — chrome must stay readable
+                  at L4-panel-on-laptop widths (320px). The `(was N)`
+                  suffixes + `[N∆]` chips don't wrap awkwardly.
+                  Theme axis (light vs. dark) is handled by Story's
+                  global theme toggle, not per-variant — the same
+                  hiccup paints under both themes via CSS variable
+                  resolution."
+     :events     [[:panel-gallery.edn-inspector/seed!
+                   (fixtures/theme-density-narrow-panel)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; -- Workspace ---------------------------------------------------------
+
+  (story/reg-workspace :Workspace.xray.diff-mode-3/all
+    {:doc      "All mode-3 grammar variants in one auto-grid. Walk
+                top-to-bottom for the canonical sequence: R1 → R8
+                → combinations → edge cases → theme/density. Each
+                variant carries a title + 1-2 line description so
+                Mike can step through visually without context-
+                switching."
+     :layout   :variants-grid
+     :story    :story.xray.diff-mode-3
+     :columns  2
+     :tags     #{:dev}}))
+
+(register-all!)


### PR DESCRIPTION
## Summary

Replaces the two-mode `[diff][all]` toggle in the Epoch HANDLER `:db` sub-section with a three-mode toggle `[diff][full][full+diff]`. Mode-3 (`:full+diff`) is the new default — the full data tree rendered WITH inline diff annotations (gutter glyphs, row washes, R3 `[N∆]` count chips on collapsed containers, R4 vertical rails, R5-tinted descendant washes, R6 `(was N)` vector-shift suffixes, R7 type-change `← was <prior>` suffixes, R8 redaction-curated suffixes).

Design source: `ai/findings/diff-mode-3-key-and-triangle-grammar-2026-05-27.md` (local-only; gitignored).

Closes rf2-n2jig.

## Engine adoption — Editscript

Pre-alpha posture: clean delete of the home-grown leaf-walker classifier (10 fns at `edn_inspector.cljs:533-664` — `diff-op`, `changed-descendant?`, `op->gutter-glyph`, `op->gutter-tone-key`, `op->row-wash-key`, `op->row-stripe-key`, `gutter-colour`, `row-wash-bg`, `row-stripe-colour`, `container-op`). Replaced wholesale with `juji/editscript` 0.6.5 + a thin projection layer at `tools/xray/src/day8/re_frame2_xray/diff/engine.cljc`.

**Rationale (per findings §9 + Mike's pair-debug 2026-05-27)**:
- Pure-data EDN edit-script output aligns with re-frame2's spec-is-data ethos. Same edit script feeds the renderer chrome, the flat path-prefixed diff lens, and (future) Story snapshot + MCP wire surfaces — one diff representation, many consumers.
- A* algorithm minimises edit-script size; the operator sees the *true* minimum diff, not a heuristic approximation.
- Vector shift-detection (R6) comes free from A*'s Myers underpinnings — an insert in a 30-element vector renders as 1 `+` + N-1 `(was N)` shifted suffixes rather than N spurious modifications.
- First-class `patch` fn enables future time-travel surfaces (apply this delta to that epoch) without a separate library.

## Mode-3 grammar — R1-R8 (per findings §5.1 as revised in §7)

| Rule | Behaviour |
|------|-----------|
| **R1** | value-side `~` glyph + `← changed from <prior>` suffix on modified scalars |
| **R2** | key-side `+` / `−` glyph at column 1 of the key row for new/removed map keys; strike-through reaches the key text for `:removed` |
| **R3** (revised) | collapsed container with descendant changes shows `▶ :user {…} [3∆]` count chip; triangle stays default `:text-tertiary` (no colour swap) |
| **R4** | single 2px vertical rail in the gutter through each change-bearing subtree, in the dominant-op hue |
| **R5** (revised) | wholly-new/removed subtrees reclassify to parent; descendant gutter glyphs + stripes SUPPRESSED, descendant row WASHES RETAINED for partial-visibility readability |
| **R6** | vector LCS shift-detection; `:same-shifted` op + `(was N)` muted suffix; vector removals live on a separate `:vector-removals` channel keyed by parent path |
| **R7** | type-change containers reclassify to `:modified` with `← was <prior>` suffix via `mini` |
| **R8** | one-sided `:rf/redacted` renders curated `← was redacted` / `← now redacted` (no sentinel text leak); two-sided redacted classifies as `:same` (v1 scope) |

Default-expanded-depth in mode-3 is **3** (per Mike's pair-debug Q4 — between browse's 1 and diff's 2; deep enough to surface most app-db top-level shards).

## Mode-3 example

```
Before                                After (mode-3 rendering)
─────────                             ────────────────────────────────────────────
{:counter 5            ▼ {
 :user {:id 7              :counter   ~ 6              ← changed from 5
        :name "Ada"}      ┃ ▼ :user {
 :legacy-flag true}        ┃    :id   7
                           ┃    :name ~ "Ada Lovelace"  ← changed from "Ada"
{:counter 6                ┃ }
 :user {:id 7              ┃ ▼ +:flash {
        :name "Ada Lovelace"}        :level   :ok
 :flash {:level :ok             :text    "Order placed"
         :text "Order             }
                placed"}}        − :legacy-flag  ~~true~~
                            }
```

## File inventory

**Engine (new)**:
- `tools/xray/src/day8/re_frame2_xray/diff/engine.cljc` — Editscript-backed projection
- `tools/xray/test/day8/re_frame2_xray/diff/engine_cljs_test.cljc` — R1-R8 unit pins

**Renderer (modified)**:
- `tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs` — classifier replaced; mode-3 chrome (chip, rail, key-side glyph, R6 suffix, R7/R8 curated suffixes); `:projection` + `:full-with-diff?` threaded through opts

**Toggle (modified)**:
- `tools/xray/src/day8/re_frame2_xray/panels/epoch_panel.cljs` — sub returns `:diff/:full/:full+diff`; legacy `:all` migrates to `:full`
- `tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs` — three-button toggle widget; mode-3 case wires `:full-with-diff? true` + `:default-expanded-depth 3`

**Stories (new)**:
- `tools/xray/testbeds/panel_gallery/fixtures_diff_mode_3.cljs` — 22 fixture builders
- `tools/xray/testbeds/panel_gallery/gallery_diff_mode_3.cljs` — Story variants + Workspace
- `tools/xray/testbeds/panel_gallery/core.cljs` — added to gallery registry

**Build/deps**:
- `tools/xray/deps.edn` — adds `juji/editscript {:mvn/version "0.6.5"}`
- `implementation/shadow-cljs.edn` — adds editscript to `:dependencies` for shadow-cljs builds
- `implementation/scripts/check-bundle-isolation.cjs` — adds editscript sentinels (`editscript.core` + `editscript.diff.a_star`)

**Spec**:
- `tools/xray/spec/021-Dynamic-Panel-Designs.md` §9.1.5.1 — three-mode toggle + R1-R8 grammar contract

## Story variants (22)

**Single-rule (13)**: R1 modified scalar · R2 new map key · R2 removed map key · R3 collapsed `[N∆]` chip · R4 vertical rail · R5 wholly-new subtree · R5 wholly-removed subtree · R6 vector insert · R6 vector remove · R6 vector reorder · R7 type change · R8 was redacted now visible · R8 was visible now redacted

**Combination + edge (7)**: all-ops cascade · mixed-ops subtree · deeply nested change · long-vector one insert (LCS payoff demo) · empty diff · massive diff · mode-toggle three-up

**Theme + density (2)**: narrow panel (320px) · light + dark theme (via Story's global theme toggle)

## Quality gates

- `npm run test:cljs` — 4810 tests / 15656 assertions / 0 failures
- `npm run test:browser` — 124 tests / 353 assertions / 0 failures
- `npm run test:bundle-isolation` — 17 artefact entries / 35 internal sentinels absent / 3 allow-list budgets ok
- `npm run test:perf-bundle` — off-count=0; on-count=12

## Coordination

- Sibling bead rf2-yqjrd (universalise the three-mode toggle across App-DB / Machine Inspector / Subscriptions / Story snapshot) is unblocked by this PR. The shared mode-3 chrome lives inside the `edn-inspector` widget; the sibling re-uses the `:before` + `:full-with-diff?` opts at each new call site.