### PR TITLE
feat(xray): universalise 3-mode toggle across App-DB + Machine Inspector + SUBSCRIPTIONS (rf2-yqjrd)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1571,6 +1571,54 @@ shards). Other modes keep their existing defaults.
 + theme/density case. To see what R5 looks like, see story
 `diff-mode-3/r5-wholly-new-subtree`.
 
+#### §9.1.5.2 Universal three-mode toggle adoption (rf2-yqjrd)
+
+Per Mike's pair-debug 2026-05-27 the toggle established in §9.1.5.1
+applies to **every Xray surface that surfaces a `(before, after)`
+data view**, not just the HANDLER step's `:db` sub-section. The
+adoption uses ONE shared widget at
+`day8.re-frame2-xray.views.diff-mode-toggle/diff-mode-toggle` so the
+operator sees the same `[diff][full][full+diff]` button-bar shape
+regardless of panel.
+
+**Affected surfaces** (post-rf2-yqjrd):
+
+| Surface                           | Mode slot                              | Default |
+|-----------------------------------|----------------------------------------|---------|
+| Epoch HANDLER step `:db`          | `:rf.xray.epoch/db-view-mode`          | `:full+diff` |
+| App-DB panel (panel-wide)         | `:rf.xray.app-db/view-mode`            | `:full+diff` |
+| Machine Inspector snapshot drill-in | `:rf.xray.machine-inspector/view-mode` | `:full+diff` |
+| Epoch SUBSCRIPTIONS step value cells | `:rf.xray.epoch/subs-value-mode`     | `:full+diff` |
+
+Per-surface mode behaviour follows the same vocabulary as §9.1.5.1's
+HANDLER `:db`:
+
+- `:diff` — pure-diff lens (flat path-prefixed change list).
+- `:full` — pure-data lens (live current-state, no `:before`).
+- `:full+diff` — mode-3 combined lens (full tree + R1-R8 grammar
+  annotations against `:before`).
+
+**Per-surface storage**: every surface registers its own sub +
+event pair so the modes are independent (operator's App-DB choice
+doesn't override the Machine Inspector choice).
+
+**Retired by rf2-yqjrd**:
+
+- The Machine Inspector's prior Before/After CSS-Grid side-by-side
+  layout (rf2-3d987 issue #3 chrome). Mode-3 (`:full+diff`)
+  carries the same meanings — full AFTER state + diff context +
+  comparison — in a single unified mount via the R1-R8 grammar.
+- Per-section auto-routing in App-DB (the `:before` sentinel
+  branch). Replaced by an explicit panel-wide toggle so the
+  operator chooses the lens.
+
+**Note on Story snapshot identity**: the bead (rf2-yqjrd) listed
+Story snapshot as a fourth surface. Investigation 2026-05-27:
+Story's `snapshot-identity` (per rf2-zfy1e) is a content-hash
+string consumed by visual-regression services — there's no value-
+diff UI surface in Story to retire. The universal toggle adoption
+is therefore limited to the three Xray surfaces above.
+
 ### §9.1.6 Numbered cascade chrome
 
 Per the bead body's §Visual Structure:

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff.cljs
@@ -47,14 +47,34 @@
             [day8.re-frame2-xray.panels.app-db-diff-state :as state]
             [day8.re-frame2-xray.panels.app-db-diff-subs :as subs]
             [day8.re-frame2-xray.theme.tokens
-             :refer [tokens sans-stack]]))
+             :refer [tokens sans-stack]]
+            [day8.re-frame2-xray.views.diff-mode-toggle :as diff-mode]))
 
 (rf/reg-view Panel
   "The app-db tab's root view — a current-state inspector sectioned by
-  reserved `:rf/*` area."
+  reserved `:rf/*` area.
+
+  rf2-yqjrd — carries the universal three-mode toggle
+  `[diff][full][full+diff]` at the top. The toggle drives every
+  section's rendering uniformly:
+
+  - `:diff`      — pure-diff lens at the top of the panel (flat path
+                   list of changes the focused epoch produced).
+                   Per-section bodies are suppressed.
+  - `:full`      — every section renders LIVE current-state with no
+                   `:before` threading (plain browse mode).
+  - `:full+diff` — every section renders LIVE current-state WITH the
+                   focused epoch's `:db-before` threaded so inline
+                   diff annotations paint (default; mode-3).
+
+  Mode persists in `:rf.xray.app-db/view-mode` on Xray's app-db so the
+  operator's preference survives focus shifts."
   []
-  (let [section-model @(rf/subscribe [:rf.xray/app-db-state])]
+  (let [mode          @(rf/subscribe [:rf.xray.app-db/view-mode])
+        section-model @(rf/subscribe [:rf.xray/app-db-state])
+        diff-triples  @(rf/subscribe [:rf.xray/selected-epoch-diff])]
     [:section {:data-testid "rf-xray-app-db-diff"
+               :data-view-mode (name mode)
                :style       {:height         "100%"
                              :display        "flex"
                              :flex-direction "column"
@@ -62,10 +82,32 @@
                              :color          (:text-primary tokens)
                              :font-family    sans-stack
                              :font-size      "14px"}}
+     ;; rf2-yqjrd — universal three-mode toggle. Sits at the top of the
+     ;; panel above the section list; one mode applies to every
+     ;; section's body. Frame-anchored to `:rf/xray` per the same
+     ;; rf2-p56sk / rf2-7sdja / rf2-kcaiz pattern the HANDLER `:db`
+     ;; toggle uses.
+     [:div {:style {:padding "12px 12px 0"
+                    :display "flex"
+                    :align-items "center"
+                    :gap "8px"}}
+      [:span {:style {:font-family sans-stack
+                      :font-size "11px"
+                      :font-weight 600
+                      :text-transform "uppercase"
+                      :letter-spacing "0.5px"
+                      :color (:text-secondary tokens)}}
+       "View"]
+      [diff-mode/diff-mode-toggle
+       {:mode mode
+        :testid "rf-xray-app-db-view-mode"
+        :on-change (fn [m]
+                     (rf/with-frame :rf/xray
+                       (rf/dispatch [:rf.xray.app-db/set-view-mode m])))}]]
      ;; rf2-6xezz — the L4 tab strip is the panel-name source-of-truth;
      ;; content starts immediately under the tab bar.
      [:div {:style {:flex 1 :overflow "auto"}}
-      (state/state-body section-model)]]))
+      (state/state-body section-model {:mode mode :diff-triples diff-triples})]]))
 
 (defn install!
   "Idempotent install for the app-db tab's Xray-side registrations.

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_events.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_events.cljs
@@ -21,6 +21,36 @@
     (fn [db _event]
       (dissoc db :focused-slice-path)))
 
+  ;; ---- App-DB panel view-mode toggle (rf2-yqjrd) ----
+  ;;
+  ;; Three-mode toggle `[diff][full][full+diff]` that drives every section
+  ;; (top + per-`:rf/*` area) in the App-DB panel. Per pair-debug
+  ;; 2026-05-27 the same shape every Xray diff surface uses — shared
+  ;; widget in `views.diff-mode-toggle`.
+  ;;
+  ;; - `:diff`      — pure-diff lens: flat path-prefixed change list for
+  ;;                  the focused epoch. Same source as the Epoch
+  ;;                  HANDLER step's `:diff` view; same flat rows.
+  ;; - `:full`      — pure-data lens: every section renders the LIVE
+  ;;                  current-state value with no `:before` (plain
+  ;;                  browse, no inline diff annotations).
+  ;; - `:full+diff` — combined lens (mode-3): every section renders the
+  ;;                  full current-state value WITH inline diff
+  ;;                  annotations against the focused epoch's
+  ;;                  `:db-before`. Default per pair-debug 2026-05-27 —
+  ;;                  the operator's most-useful default; shape + delta
+  ;;                  together.
+  ;;
+  ;; Mode persists via `:rf.xray.app-db/view-mode` so the operator's
+  ;; preference survives focus shifts.
+  (rf/reg-sub :rf.xray.app-db/view-mode
+    (fn [db _query]
+      (get db :app-db-panel-view-mode :full+diff)))
+
+  (rf/reg-event-db :rf.xray.app-db/set-view-mode
+    (fn [db [_ mode]]
+      (assoc db :app-db-panel-view-mode mode)))
+
   (rf/reg-fx :rf.xray.fx/copy-to-clipboard
     (fn [_ctx {:keys [text]}]
       (try

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs
@@ -307,18 +307,177 @@
 
 ;; ---- panel body ----------------------------------------------------------
 
+;; ---- flat-diff lens (rf2-yqjrd `:diff` mode) ----------------------------
+;;
+;; When the panel's mode toggle is `:diff` the body renders ONE flat path-
+;; prefixed change list across the entire app-db (not per-section). The
+;; rows are sourced from `:rf.xray/selected-epoch-diff` (the same triples
+;; the Epoch HANDLER step's `:diff` view + MCP exporter consume) so the
+;; App-DB panel's pure-diff lens reads identically to every other Xray
+;; surface's diff lens.
+
+(defn- flat-diff-glyph
+  "Render the leading glyph for a `[path before after change-kind]`
+  triple — `+` added · `−` removed · `~` modified. Mirrors the
+  glyph palette the Epoch HANDLER `:diff` rows use so the two
+  surfaces share visual grammar."
+  [change-kind]
+  (case change-kind
+    :added    "+"
+    :removed  "−"
+    :modified "~"
+    "~"))
+
+(defn- flat-diff-glyph-colour
+  [glyph]
+  (case glyph
+    "+" (:success tokens)
+    "−" (:error tokens)
+    (:warning tokens)))
+
+(defn- flat-diff-line
+  "Render one `[path before after change-kind]` triple. Same shape as
+  the Epoch HANDLER `:diff` row but scoped to the App-DB panel testid
+  prefix."
+  [[path before after change-kind] idx]
+  (let [glyph        (flat-diff-glyph change-kind)
+        glyph-colour (flat-diff-glyph-colour glyph)]
+    [:div {:key (str "app-db-diff-row-" idx)
+           :data-testid (str "rf-xray-app-db-diff-row-" idx)
+           :style {:display "flex"
+                   :gap "8px"
+                   :align-items "baseline"
+                   :font-family mono-stack
+                   :font-size "12px"
+                   :padding "2px 12px"
+                   :flex-wrap "wrap"}}
+     [:span {:style {:color glyph-colour :font-weight 700 :min-width "1ch"}}
+      glyph]
+     [:span {:style {:color (:text-secondary tokens)
+                     :word-break "break-word"}}
+      (pr-str path)]
+     (when (= "~" glyph)
+       [:<>
+        [:span {:style {:color (:text-tertiary tokens)
+                        :text-decoration "line-through"}}
+         [ei/mini before 40]]
+        [:span {:style {:color (:text-tertiary tokens)}} "→"]
+        [:span {:style {:color (:success tokens)}}
+         [ei/mini after 40]]])
+     (when (= "+" glyph)
+       [:span {:style {:color (:success tokens) :flex 1 :min-width 0}}
+        [ei/mini after 80]])
+     (when (= "−" glyph)
+       [:span {:style {:color (:error tokens)
+                       :text-decoration "line-through"
+                       :flex 1 :min-width 0}}
+        [ei/mini before 80]])]))
+
+(defn- flat-diff-body
+  "Render the `:diff` mode body — header + one row per change. When
+  `diff-triples` is empty an italic `(no changes)` placeholder
+  appears in place of rows."
+  [diff-triples]
+  (let [empty? (empty? diff-triples)]
+    [:section {:data-testid "rf-xray-app-db-diff-flat"
+               :data-empty (str empty?)
+               :style {:padding "12px 0 4px"}}
+     [:h3 {:style {:display "flex"
+                   :align-items "center"
+                   :gap "8px"
+                   :margin "0 12px 8px"
+                   :font-family sans-stack
+                   :font-size "11px"
+                   :font-weight 600
+                   :text-transform "uppercase"
+                   :letter-spacing "0.5px"
+                   :color (:text-secondary tokens)}}
+      [:span "diff"]
+      [:span {:style {:color (:text-tertiary tokens)
+                      :font-weight 400
+                      :text-transform "none"
+                      :letter-spacing "normal"}}
+       (if empty?
+         "— (no changes)"
+         (str (count diff-triples) " path"
+              (when (not= 1 (count diff-triples)) "s")))]]
+     (when-not empty?
+       (into [:div]
+             (for [[i row] (map-indexed vector diff-triples)]
+               (flat-diff-line row i))))]))
+
+;; ---- panel body ----------------------------------------------------------
+
+(defn- sections-body
+  "Render the section list for the `:full` / `:full+diff` modes. When
+  `diff?` is true each section threads its `:before` pre-image so
+  changed nodes carry inline `← changed` annotations. When false
+  every section renders as plain current-state browse (no `:before`
+  threaded; the renderer falls back to the `h/no-diff` sentinel)."
+  [{:keys [top areas] :as model} diff?]
+  (let [before-top (if diff? (get model :before-top h/no-diff) h/no-diff)]
+    (into [:div {:data-testid "rf-xray-app-db-state"
+                 :data-mode-diff (str (boolean diff?))}
+           (top-section top before-top)]
+          (for [{:keys [area] :as area-entry} areas]
+            (with-meta
+              (area-section
+                (if diff? area-entry (dissoc area-entry :before
+                                             :instances)))
+              {:key (pr-str area)})))))
+
+(defn- strip-instance-befores
+  "When the mode is `:full` (no diff) strip every `:before` from the
+  per-instance entries of a map-of-instances area so the renderer's
+  diff branch never triggers. Singleton areas drop their top-level
+  `:before` via `dissoc` in `sections-body`; map-of-instances areas
+  need this deeper walk because the `:before` lives one level down."
+  [areas]
+  (mapv
+    (fn [{:keys [kind instances] :as entry}]
+      (if (and (= kind :instances) (seq instances))
+        (assoc entry :instances
+               (mapv (fn [inst] (dissoc inst :before)) instances))
+        entry))
+    areas))
+
 (defn state-body
   "Render the full current-state inspector body for the section model
-  `current-state-sections` produces: the TOP user-domain section
-  followed by one section group per POPULATED reserved `:rf/*` area
-  (in `:areas` order; rf2-jcdvo — empty areas are filtered at
-  projection time so only data-bearing cards reach the renderer).
-  Each section threads its `:before` pre-image so changed nodes carry
-  the inline `← changed` annotation (spec/021 §4.3). Pure hiccup;
-  nil-safe (a nil model degrades to an empty TOP + no areas)."
-  [{:keys [top areas] :as model}]
-  (into [:div {:data-testid "rf-xray-app-db-state"}
-         (top-section top (get model :before-top h/no-diff))]
-        (for [{:keys [area] :as area-entry} areas]
-          (with-meta (area-section area-entry)
-                     {:key (pr-str area)}))))
+  `current-state-sections` produces.
+
+  rf2-yqjrd — accepts an opts map with `:mode` (`:diff` / `:full` /
+  `:full+diff`) and `:diff-triples` (the flat-row source for the
+  `:diff` lens). When opts are omitted (1-arity legacy call) the
+  body renders in the prior `:full+diff` shape — section list with
+  `:before` threaded — so any direct caller that pre-dates the
+  toggle keeps its behaviour. Production callers (the Panel view
+  above) always pass the mode.
+
+  Mode behaviour:
+
+  - `:diff`      — flat path-prefixed change list (one row per
+                   change). Section list suppressed; the operator
+                   sees only what changed.
+  - `:full`      — section list rendered with no `:before` threaded
+                   (plain browse, no inline diff annotations on any
+                   section).
+  - `:full+diff` — section list rendered with each section's
+                   `:before` threaded so inline diff annotations
+                   paint (spec/021 §4.3 default).
+
+  Pure hiccup; nil-safe (a nil model degrades to an empty TOP + no
+  areas)."
+  ([model] (state-body model nil))
+  ([{:keys [top areas] :as model} {:keys [mode diff-triples]
+                                   :or   {mode :full+diff}}]
+   (case mode
+     :diff
+     (flat-diff-body (or diff-triples []))
+
+     :full
+     (sections-body
+       (assoc model :areas (strip-instance-befores (or areas [])))
+       false)
+
+     ;; :full+diff (default) — existing inline-diff behaviour.
+     (sections-body model true))))

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -58,6 +58,7 @@
             [day8.re-frame2-xray.panels.epoch.icons :as icons]
             [day8.re-frame2-xray.panels.epoch.projection :as proj]
             [day8.re-frame2-xray.panels.shared.coord-chip :as coord-chip]
+            [day8.re-frame2-xray.views.diff-mode-toggle :as diff-mode]
             [day8.re-frame2-xray.views.edn-inspector :as ei]
             [day8.re-frame2-xray.views.edn-widget.widget :as edn]
             [day8.re-frame2-xray.theme.tokens
@@ -2221,58 +2222,25 @@
         "<source not yet captured>"])]))
 
 (defn- db-view-mode-toggle
-  "Three-button toggle bar `[diff][full][full+diff]` for the HANDLER
-  `:db` sub-section. Active button paints in `:accent`; inactive
-  buttons are transparent with muted text. Click dispatches
-  `:rf.xray.epoch/set-db-view-mode`.
+  "Thin wrapper around the shared `views.diff-mode-toggle/diff-mode-toggle`
+  widget (rf2-yqjrd extraction of the rf2-n2jig toggle). The button-bar
+  chrome + per-mode labels + R1-R8 grammar default mode (`:full+diff`)
+  all live in the shared widget; this wrapper supplies the surface-
+  specific testid prefix + the `:rf/xray` frame-anchored dispatch
+  (matches the rf2-p56sk / rf2-7sdja / rf2-kcaiz frame-leak fix
+  pattern — toggle's home app-db is Xray regardless of host frame).
 
-  rf2-n2jig — replaces the two-button `[diff][all]` toggle. The new
-  mode-3 `:full+diff` is the operator's most-useful default (shape +
-  delta in one read); per-mode labels:
-
-  - `diff` — flat path-prefixed change list (what changed).
-  - `full` — full data tree, no diff chrome (the shape; renamed
-             from `all` for clarity).
-  - `full+diff` — full tree WITH inline diff annotations (R1-R8
-             grammar per findings doc; mode-3 default)."
+  Per the universalisation bead, every Xray surface that surfaces a
+  diff-mode toggle does so through this same shared widget so the
+  operator sees ONE button-bar shape across App-DB / Machine
+  Inspector / SUBSCRIPTIONS / HANDLER `:db`."
   [mode]
-  [:span {:data-testid "rf-xray-epoch-handler-db-view-mode"
-          :data-mode (name mode)
-          :style mode-toggle-bar-style}
-   (for [m [:diff :full :full+diff]
-         :let [active? (= mode m)
-               ;; Use a sanitised name for the testid so the `+` in
-               ;; `:full+diff` doesn't end up in a CSS selector
-               ;; downstream.
-               testid-suffix (case m
-                               :full+diff "full-with-diff"
-                               (name m))]]
-     ^{:key (name m)}
-     [:button {:data-testid (str "rf-xray-epoch-handler-db-view-" testid-suffix)
-               :aria-pressed (str active?)
-               :on-click (fn [e]
-                           (.stopPropagation e)
-                           ;; `with-frame :rf/xray` pins the dispatch
-                           ;; target so the sub running in :rf/xray
-                           ;; sees the write. The `{:frame :rf/xray}`
-                           ;; opts envelope SHOULD route the same way
-                           ;; but doesn't through React's click
-                           ;; context-pop (same class as rf2-7sdja /
-                           ;; rf2-kcaiz / rf2-p56sk frame-leak bugs).
-                           ;; Matches the pattern in `core.cljs` at
-                           ;; `set-target-frame!`.
-                           (rf/with-frame :rf/xray
-                             (rf/dispatch
-                               [:rf.xray.epoch/set-db-view-mode m])))
-               :style (if active?
-                        mode-toggle-button-active-style
-                        mode-toggle-button-inactive-style)}
-      ;; Label — `full+diff` uses a `+` joiner per Mike's pair-debug
-      ;; 2026-05-27 grammar locking (the literal symbol is the cue).
-      (case m
-        :diff      "diff"
-        :full      "full"
-        :full+diff "full+diff")])])
+  [diff-mode/diff-mode-toggle
+   {:mode      mode
+    :testid    "rf-xray-epoch-handler-db-view-mode"
+    :on-change (fn [m]
+                 (rf/with-frame :rf/xray
+                   (rf/dispatch [:rf.xray.epoch/set-db-view-mode m])))}])
 
 (defn- handler-db-diff-block
   "Render the HANDLER step's `:db` sub-section (rf2-93436 / design
@@ -2650,11 +2618,68 @@
                         subs-filter-button-inactive-style)}
       (name m)])])
 
+(defn- subs-value-cell
+  "Render the `changed` cell for one sub recomputation row using the
+  universal three-mode toggle (rf2-yqjrd).
+
+  `mode` is the panel-wide `:rf.xray.epoch/subs-value-mode` keyword:
+
+  - `:diff`      — `✓ before → after` row (the prior shape; surfaces
+                   only the value pair via `mini`).
+  - `:full`      — `✓` + AFTER value via the edn-inspector widget
+                   (no diff chrome). Used when the operator wants to
+                   see the freshly-computed value alone.
+  - `:full+diff` — `✓` + AFTER value via the edn-inspector with
+                   BEFORE threaded as the `:before` pre-image so the
+                   R1-R8 grammar paints inline `← changed from X`
+                   annotations. Default per pair-debug 2026-05-27.
+
+  Unchanged rows (`:changed? false`) render the muted `✗` tick
+  regardless of mode (no value, nothing to diff)."
+  [{:keys [sub-id changed? before after]} mode idx]
+  (if changed?
+    (case mode
+      :full
+      [:div {:style subs-changed-row-style}
+       [:span {:style subs-changed-tick-style} "✓"]
+       [:div {:style {:flex 1 :min-width 0}}
+        [ei/edn-inspector after
+         {:panel-id :rf.xray.epoch/subs-value
+          :site-id  [:rf.xray.epoch/subs-value sub-id idx :full]
+          :default-expanded-depth 2}]]]
+
+      :full+diff
+      [:div {:style subs-changed-row-style}
+       [:span {:style subs-changed-tick-style} "✓"]
+       [:div {:style {:flex 1 :min-width 0}}
+        [ei/edn-inspector after
+         (cond-> {:panel-id :rf.xray.epoch/subs-value
+                  :site-id  [:rf.xray.epoch/subs-value sub-id idx :full+diff]
+                  :default-expanded-depth 3
+                  :full-with-diff? true}
+           (some? before) (assoc :before before))]]]
+
+      ;; :diff (default fallback) — preserve the prior shape.
+      [:div {:style subs-changed-row-style}
+       [:span {:style subs-changed-tick-style} "✓"]
+       (when (some? before)
+         [:span {:style diff-before-style} [ei/mini before 24]])
+       (when (and (some? before) (some? after))
+         [:span {:style cascade-detail-label-style} "→"])
+       (when (some? after)
+         [:span {:style diff-after-success-style} [ei/mini after 24]])])
+    [:span {:style subs-unchanged-tick-style} "✗"]))
+
 (defn- subscriptions-table
   "Render the SUBSCRIPTIONS table — 3 columns (sub / inputs / changed).
-  Per the bead body's §SUBSCRIPTIONS (Step 7) shape (rf2-kfh1v)."
-  [rows]
+  Per the bead body's §SUBSCRIPTIONS (Step 7) shape (rf2-kfh1v).
+
+  rf2-yqjrd — the `changed` cell now routes through `subs-value-cell`
+  so the universal three-mode toggle drives value rendering. `mode`
+  carries the resolved `:rf.xray.epoch/subs-value-mode` keyword."
+  [rows mode]
   [:div {:data-testid "rf-xray-epoch-subscriptions-table"
+         :data-subs-value-mode (when (keyword? mode) (name mode))
          :style subscriptions-table-style}
    ;; header
    [:div {:style table-header-row-style}
@@ -2662,10 +2687,10 @@
     [:div {:style subs-th-35-style} "inputs"]
     [:div {:style subs-th-30-style} "changed"]]
    ;; rows
-   (for [[i {:keys [sub-id sub-vec inputs changed? before after]}] (map-indexed vector rows)]
+   (for [[i {:keys [sub-id sub-vec inputs] :as row}] (map-indexed vector rows)]
      [:div {:key (str "sub-" i)
             :data-testid (str "rf-xray-epoch-sub-row-" i)
-            :data-sub-changed (str (boolean changed?))
+            :data-sub-changed (str (boolean (:changed? row)))
             :style (if (< i (dec (count rows)))
                      subs-row-style-with-border
                      subs-row-style)}
@@ -2690,18 +2715,7 @@
          (some? inputs) [ei/mini inputs 40]
          :else          "app-db")]
       [:div {:style subs-cell-changed-style}
-       (if changed?
-         [:div {:style subs-changed-row-style}
-          [:span {:style subs-changed-tick-style} "✓"]
-          ;; rf2-8w8er — before/after through `mini` so numbers
-          ;; paint orange, keywords magenta, etc.
-          (when (some? before)
-            [:span {:style diff-before-style} [ei/mini before 24]])
-          (when (and (some? before) (some? after))
-            [:span {:style cascade-detail-label-style} "→"])
-          (when (some? after)
-            [:span {:style diff-after-success-style} [ei/mini after 24]])]
-         [:span {:style subs-unchanged-tick-style} "✗"])]])])
+       (subs-value-cell row mode i)]])])
 
 (defn- dispose-reason-label
   "Render a `:rf.sub/dispose` `:reason` keyword as a UI label
@@ -2775,6 +2789,8 @@
   [{:keys [rows disposed-rows step-number violations]}]
   (let [mode          @(rf/subscribe :rf/xray
                                      [:rf.xray.epoch/subs-filter-mode])
+        value-mode    @(rf/subscribe :rf/xray
+                                     [:rf.xray.epoch/subs-value-mode])
         visible-rows  (case mode
                         :all       rows
                         :unchanged (filterv (complement :changed?) rows)
@@ -2799,6 +2815,19 @@
         :verb [:span {:style subs-verb-style}
                (when (pos? n)
                  (subs-filter-button-bar mode))
+               ;; rf2-yqjrd — universal three-mode toggle drives how each
+               ;; `:changed?` row's value cell renders. Orthogonal to the
+               ;; row-filter button bar above. Same shared widget every
+               ;; other Xray diff surface uses (Epoch HANDLER `:db`,
+               ;; App-DB, Machine Inspector snapshot).
+               (when (pos? n)
+                 [diff-mode/diff-mode-toggle
+                  {:mode      value-mode
+                   :testid    "rf-xray-epoch-subscriptions-value-mode"
+                   :on-change (fn [m]
+                                (rf/with-frame :rf/xray
+                                  (rf/dispatch
+                                    [:rf.xray.epoch/set-subs-value-mode m])))}])
                (when (pos? l)
                  [:span {:style subs-disposed-count-style}
                   (str l " disposed")])]
@@ -2806,7 +2835,7 @@
         :testid "rf-xray-epoch-subscriptions"}
        nil)
      (when (pos? n)
-       (subscriptions-table visible-rows))
+       (subscriptions-table visible-rows value-mode))
      (when (pos? l)
        (disposed-subs-table disposed-rows))
      ;; rf2-xgeag — `:sub-return` boundary violations. Per-row

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch_panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch_panel.cljs
@@ -207,6 +207,34 @@
     (fn [db [_ mode]]
       (assoc db :epoch-panel-db-view-mode mode)))
 
+  ;; ---- SUBSCRIPTIONS value view-mode toggle (rf2-yqjrd) ------------
+  ;;
+  ;; Universal three-mode toggle for the per-row sub-value rendering in
+  ;; the SUBSCRIPTIONS step. Orthogonal to the existing
+  ;; `:rf.xray.epoch/subs-filter-mode` row-filter (`:all` / `:changed` /
+  ;; `:unchanged`) — the filter governs WHICH rows render; this view-
+  ;; mode governs HOW each `:changed?` row's value cell renders.
+  ;;
+  ;; - `:diff`      — pure-diff lens: `before → after` glyph row (the
+  ;;                  prior shape; surfaces only the value pair).
+  ;; - `:full`      — pure-data lens: AFTER value alone via the
+  ;;                  edn-inspector widget; no BEFORE comparison.
+  ;; - `:full+diff` — combined lens (mode-3): AFTER value via the
+  ;;                  edn-inspector with BEFORE threaded as the diff
+  ;;                  pre-image so inline `← changed from X`
+  ;;                  annotations paint. Default per pair-debug
+  ;;                  2026-05-27.
+  ;;
+  ;; Mode persists via `:rf.xray.epoch/subs-value-mode` so the
+  ;; operator's preference survives focus shifts.
+  (rf/reg-sub :rf.xray.epoch/subs-value-mode
+    (fn [db _query]
+      (get db :epoch-panel-subs-value-mode :full+diff)))
+
+  (rf/reg-event-db :rf.xray.epoch/set-subs-value-mode
+    (fn [db [_ mode]]
+      (assoc db :epoch-panel-subs-value-mode mode)))
+
   ;; ---- L4 tab registration ----------------------------------------------
   ;;
   ;; The Epoch tab lands between Machines (order 4) and Routing

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
@@ -45,6 +45,7 @@
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
             [day8.re-frame2-machines-viz.chart.layout :as chart-layout]
+            [day8.re-frame2-xray.diff.engine :as diff-engine]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
             [day8.re-frame2-xray.panels.cancellation-cascade :as cancellation-cascade]
             [day8.re-frame2-xray.panels.machine-canvas :as machine-canvas]
@@ -57,6 +58,7 @@
             ;; edn-inspector widget directly. Each machine gets its own
             ;; `:panel-id` qualifier so two machines' expansion state
             ;; stays independent. See spec/021 §10 widget contract.
+            [day8.re-frame2-xray.views.diff-mode-toggle :as diff-mode]
             [day8.re-frame2-xray.views.edn-inspector :as ei]
             [day8.re-frame2-xray.theme.tokens
              :as t
@@ -454,139 +456,223 @@
     (keyword? machine-id) (subs (str machine-id) 1)
     :else (str machine-id)))
 
-(defn- snapshot-block
-  "Render one machine snapshot map (`{:state X :data Y}`) via the
-  first-class edn-inspector widget (rf2-oqa60 phase 1, rf2-lxvn6 phase
-  4). Tagged with a section heading + the per-mount testid so panel-
-  level tests can assert presence per (machine-id, phase) pair.
+(defn- snapshot-flat-diff-rows
+  "Project the (before, after) snapshot pair through the shared
+  Editscript engine to a flat list of `[path before after change-kind]`
+  triples — the same shape the App-DB / Epoch HANDLER `:diff` lens
+  consumes. Used by the Machine Inspector's `:diff` mode (rf2-yqjrd).
 
-  rf2-3d987 issue #3: each column carries its own internal header
-  (`Before` / `After`) so the side-by-side layout (CSS grid in the
-  caller) reads as two diff-able columns. The grouping header in
-  `snapshot-drill-in` drops the `before / after` suffix since it's now
-  visually obvious from the two columns.
+  Returns an empty vector when no Editscript edits surface (identical
+  snapshots) so the renderer can paint a `— (no changes)` placeholder."
+  [before after]
+  (let [proj (diff-engine/project before after)
+        rows (:flat-rows proj)]
+    (mapv (fn [{:keys [path op before after]}]
+            (let [kind (case op
+                         :added    :added
+                         :removed  :removed
+                         :modified :modified
+                         :modified)]
+              [path before after kind]))
+          rows)))
 
-  When `before-snapshot` is supplied (the AFTER block receives the
-  BEFORE snapshot as the diff pre-image), the inspector renders in
-  diff mode — changed leaves get the `← changed from X` annotation
-  and the row chrome (wash + stripe) marks added / modified /
-  removed paths. The BEFORE block does not get a pre-image (it's the
-  baseline; there's nothing to diff against).
-
-  Returns `nil` when the snapshot is absent — the empty-state is
-  handled by the caller (a top-level placeholder is more legible than
-  a per-block nil chip)."
-  [{:keys [machine-id phase label snapshot before-snapshot]}]
-  (when (some? snapshot)
-    [:div {:data-testid    (str "rf-xray-machine-snapshot-block-"
-                                (machine-id-suffix machine-id)
-                                "-" (name phase))
+(defn- snapshot-flat-diff-body
+  "Render the `:diff` lens for the snapshot drill-in — flat path-
+  prefixed rows showing the Editscript projection of `(before, after)`.
+  Mirrors the App-DB `:diff` body shape so the operator sees the same
+  flat-list grammar regardless of surface."
+  [{:keys [machine-id before after]}]
+  (let [rows  (snapshot-flat-diff-rows before after)
+        empty? (empty? rows)]
+    [:div {:data-testid (str "rf-xray-machine-snapshot-diff-"
+                             (machine-id-suffix machine-id))
            :data-machine-id (str machine-id)
-           :data-phase      (name phase)
-           ;; Issue #2 (option b): match the outer section's `bg-2`
-           ;; rather than the brighter `bg-1` so the snapshot pair
-           ;; reads as continuation of the body, not as a second card
-           ;; layer. The outer bordered section provides the card chrome.
+           :data-empty (str empty?)
            :style {:padding "8px 12px"
                    :background (:bg-2 tokens)
                    :min-width 0}}
-     ;; Issue #3 — per-column internal header (`Before` / `After`).
-     ;; Carries the same upper-case caption styling that earlier nested
-     ;; in the outer ribbon but now serves as the column label.
-     [:div {:style {:color (:text-tertiary tokens)
-                    :text-transform "uppercase"
-                    :font-size "10px"
-                    :letter-spacing "0.5px"
-                    :font-family sans-stack
-                    :font-weight 700
-                    :margin-bottom "4px"}}
-      label]
+     (if empty?
+       [:div {:style {:font-family sans-stack
+                      :font-size "11px"
+                      :font-style "italic"
+                      :color (:text-tertiary tokens)}}
+        "— (no changes)"]
+       (into [:div {:style {:font-family mono-stack
+                            :font-size "12px"}}]
+             (for [[i [path before-v after-v kind]] (map-indexed vector rows)]
+               (let [glyph        (case kind
+                                    :added    "+"
+                                    :removed  "−"
+                                    :modified "~"
+                                    "~")
+                     glyph-colour (case glyph
+                                    "+" (:success tokens)
+                                    "−" (:error tokens)
+                                    (:warning tokens))]
+                 [:div {:key (str "row-" i)
+                        :data-testid (str "rf-xray-machine-snapshot-diff-row-"
+                                          (machine-id-suffix machine-id) "-" i)
+                        :style {:display "flex"
+                                :gap "8px"
+                                :align-items "baseline"
+                                :padding "2px 0"
+                                :flex-wrap "wrap"}}
+                  [:span {:style {:color glyph-colour :font-weight 700 :min-width "1ch"}}
+                   glyph]
+                  [:span {:style {:color (:text-secondary tokens)
+                                  :word-break "break-word"}}
+                   (pr-str path)]
+                  (when (= "~" glyph)
+                    [:<>
+                     [:span {:style {:color (:text-tertiary tokens)
+                                     :text-decoration "line-through"}}
+                      [ei/mini before-v 40]]
+                     [:span {:style {:color (:text-tertiary tokens)}} "→"]
+                     [:span {:style {:color (:success tokens)}}
+                      [ei/mini after-v 40]]])
+                  (when (= "+" glyph)
+                    [:span {:style {:color (:success tokens) :flex 1 :min-width 0}}
+                     [ei/mini after-v 80]])
+                  (when (= "−" glyph)
+                    [:span {:style {:color (:error tokens)
+                                    :text-decoration "line-through"
+                                    :flex 1 :min-width 0}}
+                     [ei/mini before-v 80]])]))))]))
+
+(defn- snapshot-block
+  "Render a machine snapshot map (`{:state X :data Y}`) via the
+  first-class edn-inspector widget (rf2-oqa60 phase 1, rf2-lxvn6 phase
+  4). One mount; the view-mode toggle (rf2-yqjrd) drives whether
+  `:before` is threaded as the diff pre-image.
+
+  Replaces the prior side-by-side Before/After grid (retired
+  2026-05-27 per rf2-yqjrd) — mode-3 (`:full+diff`) carries the same
+  meanings the two-column layout did (full state + diff context +
+  comparison) in a single unified surface, and the `:diff` mode
+  carries the pure-diff lens for operators who want only the
+  changes.
+
+  Mode behaviour:
+
+  - `:full`      — render the AFTER snapshot with no `:before` (plain
+                   browse).
+  - `:full+diff` — render the AFTER snapshot with `:before` threaded
+                   so changed leaves carry inline `← changed from X`
+                   annotations + row chrome (added/modified/removed).
+                   Default.
+  - `:diff`      — render via `snapshot-flat-diff-body` (handled by
+                   `snapshot-drill-in`, not here).
+
+  Renders `nil` when the snapshot is absent."
+  [{:keys [machine-id snapshot before-snapshot mode]}]
+  (when (some? snapshot)
+    [:div {:data-testid    (str "rf-xray-machine-snapshot-block-"
+                                (machine-id-suffix machine-id))
+           :data-machine-id (str machine-id)
+           :data-view-mode  (when (keyword? mode) (name mode))
+           ;; Issue #2 (option b): match the outer section's `bg-2`
+           ;; rather than the brighter `bg-1` so the snapshot reads as
+           ;; continuation of the body, not as a second card layer.
+           :style {:padding "8px 12px"
+                   :background (:bg-2 tokens)
+                   :min-width 0}}
      [ei/edn-inspector snapshot
-      (cond-> {:panel-id (snapshot-panel-id machine-id phase)
-               ;; rf2-pvsxs — machine + phase are stable identifiers; the
-               ;; operator's drill-into-data choices survive a Machines tab
-               ;; leave-and-return round-trip.
-               :site-id  [:rf.xray.machines/inspector-snapshot machine-id phase]
-               :default-expanded-depth 2
-               ;; rf2-l4625 — machine snapshots routinely carry deeply-nested
-               ;; `:data` maps; the popup gives the operator a full-modal
-               ;; inspection surface alongside the per-machine drill-in.
+      (cond-> {:panel-id (snapshot-panel-id machine-id :after)
+               ;; rf2-pvsxs — machine + phase identifiers; the operator's
+               ;; drill-into-data choices survive a Machines tab leave-
+               ;; and-return round-trip. `:after` is the canonical phase
+               ;; suffix for the single-mount post-rf2-yqjrd shape (the
+               ;; old `:before` mount was retired with the side-by-side
+               ;; grid).
+               :site-id  [:rf.xray.machines/inspector-snapshot machine-id :after]
+               :default-expanded-depth (case mode :full+diff 3 2)
+               ;; rf2-l4625 — machine snapshots routinely carry deeply-
+               ;; nested `:data` maps; the popup gives the operator a
+               ;; full-modal inspection surface alongside the per-
+               ;; machine drill-in.
                :popup-affordance? true}
-        ;; Diff mode kicks in when the AFTER block carries the BEFORE
-        ;; snapshot as its pre-image — the widget paints the row
-        ;; chrome (added / modified / removed) + the inline
-        ;; `← changed from X` annotations against the changed paths.
-        (some? before-snapshot) (assoc :before before-snapshot))]]))
+        ;; Mode-3: thread the BEFORE snapshot as the diff pre-image so
+        ;; the widget paints inline `← changed from X` annotations.
+        ;; Mode `:full` skips the threading — pure-data browse.
+        (and (= mode :full+diff) (some? before-snapshot))
+        (assoc :before before-snapshot :full-with-diff? true))]]))
+
+(defn- snapshot-mode-toggle
+  "Three-button toggle bar `[diff][full][full+diff]` for the snapshot
+  drill-in (rf2-yqjrd). Shared widget; dispatches frame-anchored to
+  `:rf/xray` per the rf2-p56sk / rf2-7sdja pattern."
+  [mode]
+  [diff-mode/diff-mode-toggle
+   {:mode      mode
+    :testid    "rf-xray-machine-snapshot-view-mode"
+    :on-change (fn [m]
+                 (rf/with-frame :rf/xray
+                   (rf/dispatch [:rf.xray.machine-inspector/set-view-mode m])))}])
 
 (defn- snapshot-drill-in
   "Snapshot drill-in section beneath the focused-event chart. Renders
-  the BEFORE and AFTER snapshot maps for the focused transition via
-  the first-class edn-inspector widget so the operator can inspect
-  what `:data` carried on either side of the transition (spec/003
-  §M.10 bug class — `:data` mutations invisible without app-db diff).
+  the focused-transition snapshot via the first-class edn-inspector
+  widget so the operator can inspect what `:data` carried on either
+  side of the transition (spec/003 §M.10 bug class — `:data` mutations
+  invisible without app-db diff).
+
+  rf2-yqjrd — RETIRES the prior Before/After side-by-side grid
+  (rf2-3d987 issue #3). The two-column layout is replaced by a SINGLE
+  mount + the universal three-mode toggle `[diff][full][full+diff]`.
+  Mode-3 (`:full+diff`, default) carries the same meanings the side-
+  by-side did — full AFTER state + diff context + comparison against
+  BEFORE — in one unified surface via the R1-R8 grammar (rf2-n2jig).
+  The `:diff` mode adds a pure-diff lens (flat path list) for
+  operators who want only the changes. Pre-alpha posture; no shim.
 
   Per spec/021 §10 widget contract every call site qualifies with a
-  per-machine `:panel-id`; here the qualifier folds in the phase
-  (`:before` / `:after`) so the two sibling mounts don't share
-  expansion state on the same machine.
+  per-machine `:panel-id`; the post-rf2-yqjrd shape uses a single
+  `:after`-phase qualifier (the second mount + its `:before`
+  qualifier retired with the side-by-side grid).
 
-  rf2-3d987 issue #2 (option b): no second card layer — body uses the
-  outer section's `bg-2` so the snapshot pair reads as a continuation
-  of the body. Issue #3: Before / After render side-by-side in a CSS
-  Grid (`repeat(auto-fit, minmax(360px, 1fr))`) when the section is
-  ≥ ~720px wide; falls back to stacked when narrower. Each column
-  carries its own header (`Before` / `After`); the grouping header
-  drops the `before / after` suffix. Issue #5: weight differential on
-  the section label (`<strong>Snapshot</strong>`). Issue #7: nested
-  header uses the lighter-chrome style (no ribbon background, smaller
-  font, bottom-border separator).
-
-  Renders nothing when both snapshots are nil (legacy trace fixtures
-  pre-dating the commit-or-finalize snapshot tagging — see
+  Renders nothing when the AFTER snapshot is absent (legacy trace
+  fixtures pre-dating the commit-or-finalize snapshot tagging — see
   `transition-record-from-trace` docstring)."
   [{:keys [machine-id before after]}]
   (when (or (some? before) (some? after))
-    [:section
-     {:data-testid     "rf-xray-machine-snapshot-drill-in"
-      :data-machine-id (str machine-id)
-      :data-has-before (str (some? before))
-      :data-has-after  (str (some? after))
-      :style {:background (:bg-2 tokens)}}
-     ;; Issue #7 — nested-header treatment: borderless ribbon, smaller
-     ;; font, bottom-border separator. Issue #5 — `<strong>` weight
-     ;; differential lets the eye pick out `Snapshot` from the
-     ;; `transition` qualifier.
-     [:header {:data-testid "rf-xray-machine-snapshot-drill-in-header"
-               :style nested-header-base-style}
-      [:strong {:style {:color (:text-tertiary tokens)
-                        :text-transform "uppercase"
-                        :font-size "10px"
-                        :letter-spacing "0.5px"
-                        :font-weight 700}}
-       "Snapshot"]
-      [:span {:style {:color (:text-tertiary tokens)}} "·"]
-      [:span {:style {:color (:text-secondary tokens)}}
-       "transition"]]
-     ;; Issue #3 — Before/After side-by-side via CSS Grid auto-fit.
-     ;; At viewport ≥ ~720px wide (two 360px minmax tracks) the columns
-     ;; render side-by-side; narrower fits collapse to single-column
-     ;; stack automatically. `min-width 0` on the children prevents
-     ;; inspector content from forcing the column wider than its track.
-     [:div {:data-testid "rf-xray-machine-snapshot-drill-in-grid"
-            :style {:display "grid"
-                    :grid-template-columns
-                    "repeat(auto-fit, minmax(360px, 1fr))"
-                    :gap (:gap-2 spacing)
-                    :padding (:gap-2 spacing)}}
-      (snapshot-block {:machine-id machine-id
-                       :phase :before
-                       :label "Before"
-                       :snapshot before})
-      (snapshot-block {:machine-id machine-id
-                       :phase :after
-                       :label "After"
-                       :snapshot after
-                       :before-snapshot before})]]))
+    (let [mode @(rf/subscribe :rf/xray
+                              [:rf.xray.machine-inspector/view-mode])]
+      [:section
+       {:data-testid     "rf-xray-machine-snapshot-drill-in"
+        :data-machine-id (str machine-id)
+        :data-has-before (str (some? before))
+        :data-has-after  (str (some? after))
+        :data-view-mode  (when (keyword? mode) (name mode))
+        :style {:background (:bg-2 tokens)}}
+       ;; Header carries the section label + the universal three-mode
+       ;; toggle. Same shape as the Epoch HANDLER `:db` and App-DB
+       ;; panel headers post-rf2-yqjrd.
+       [:header {:data-testid "rf-xray-machine-snapshot-drill-in-header"
+                 :style (assoc nested-header-base-style
+                               :display "flex"
+                               :align-items "center"
+                               :gap "8px")}
+        [:strong {:style {:color (:text-tertiary tokens)
+                          :text-transform "uppercase"
+                          :font-size "10px"
+                          :letter-spacing "0.5px"
+                          :font-weight 700}}
+         "Snapshot"]
+        [:span {:style {:color (:text-tertiary tokens)}} "·"]
+        [:span {:style {:color (:text-secondary tokens)}}
+         "transition"]
+        (snapshot-mode-toggle mode)]
+       ;; Body — pure-diff lens vs single-mount snapshot, driven by mode.
+       (case mode
+         :diff
+         (snapshot-flat-diff-body {:machine-id machine-id
+                                   :before before
+                                   :after  after})
+
+         (snapshot-block {:machine-id machine-id
+                          :snapshot   (or after before)
+                          :before-snapshot before
+                          :mode mode}))])))
 
 ;; ---- per-machine focused-event section ---------------------------------
 
@@ -1108,6 +1194,20 @@
   `static.machines.sim` — installed via
   `static.machines.panel/install!` further down the registry."
   []
+  ;; ---- Machine Inspector snapshot view-mode toggle (rf2-yqjrd) -----
+  ;;
+  ;; Universal three-mode toggle for the snapshot drill-in section.
+  ;; Replaces the prior Before/After side-by-side grid — one mount,
+  ;; one toggle, same R1-R8 grammar every other Xray diff surface
+  ;; uses (rf2-n2jig).
+  (rf/reg-sub :rf.xray.machine-inspector/view-mode
+    (fn [db _query]
+      (get db :machine-inspector-view-mode :full+diff)))
+
+  (rf/reg-event-db :rf.xray.machine-inspector/set-view-mode
+    (fn [db [_ mode]]
+      (assoc db :machine-inspector-view-mode mode)))
+
   ;; Registered-machine vector (reads `(rf/machines)`).
   (rf/reg-sub :rf.xray/registered-machines
     (fn [db _query]

--- a/tools/xray/src/day8/re_frame2_xray/views/diff_mode_toggle.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/diff_mode_toggle.cljs
@@ -1,0 +1,248 @@
+(ns day8.re-frame2-xray.views.diff-mode-toggle
+  "Shared three-mode diff toggle `[diff][full][full+diff]` (rf2-yqjrd).
+
+  ## What this is
+
+  ONE button-bar component that every Xray surface uses to switch
+  between the three lenses on a value that has both a `before` and an
+  `after`:
+
+  - `:diff`      — flat path-prefixed change list. The pure-diff lens.
+                   Operator sees ONLY what changed.
+  - `:full`      — full data tree, no diff chrome. The pure-data lens.
+                   Operator sees the entire `after` value with no
+                   annotations.
+  - `:full+diff` — mode-3 — the full data tree WITH inline diff
+                   annotations (gutter glyphs, row washes, R3 `[N∆]`
+                   chips, R4 vertical rails, R5/6/7/8 grammar). Shape +
+                   delta in one read. Default for the operator's most-
+                   useful view.
+
+  ## Why a shared widget
+
+  Per rf2-yqjrd Mike's pair-debug 2026-05-27: every Xray surface that
+  shows `(before, after)` data should use the SAME mode toggle + the
+  SAME Editscript-backed engine. One affordance, one rendering
+  pipeline, one mental model — regardless of which panel the operator
+  is in (Epoch HANDLER `:db`, App-DB, Machine Inspector snapshot,
+  SUBSCRIPTIONS sub-value).
+
+  Foundation bead rf2-n2jig (#2230) shipped the toggle + engine for
+  Epoch HANDLER `:db`. This widget extracts the toggle component
+  verbatim so the other surfaces in this bead's scope adopt it
+  uniformly instead of re-implementing.
+
+  ## Public API
+
+      [diff-mode-toggle
+       {:mode       <keyword>   ;; current mode :diff / :full / :full+diff
+        :on-change  (fn [mode]) ;; called on click; pure fn (callers
+                                ;; bridge to rf/dispatch as needed)
+        :testid     <str>       ;; data-testid prefix for the bar + buttons
+        ;; optional —
+        :modes      <vec>       ;; defaults to [:diff :full :full+diff]
+       }]
+
+  Returns a hiccup `<span>` with three buttons. Active button paints
+  in `:accent` token colour; inactive buttons are transparent with
+  muted text. The widget is stateless chrome — the caller owns the
+  mode value (typically via a sub) and the dispatch (typically via
+  `with-frame :rf/xray`).
+
+  ## Per-surface storage convention
+
+  Each surface registers its own sub + event for the mode keyword:
+
+      :rf.xray.<surface>/diff-mode        ;; sub returning the keyword
+      :rf.xray.<surface>/set-diff-mode    ;; event-db setting the keyword
+
+  Existing per-surface persistence (e.g. the Epoch panel's
+  `:epoch-panel-db-view-mode` slot) is preserved verbatim — this
+  widget is the chrome, not the storage. See `reg-mode-sub+event!`
+  below for a one-call helper that installs the standard pair.
+
+  ## Frame-anchor pattern (rf2-p56sk / rf2-7sdja)
+
+  Toggle state lives in the Xray app-db. The caller's `on-change`
+  must dispatch with `(rf/with-frame :rf/xray …)` (or the
+  `{:frame :rf/xray}` opts envelope where it works) so the dispatch
+  hits the same app-db the sub reads from regardless of which host
+  frame's React-context the click landed in. This widget does NOT
+  embed the frame-anchor — the caller composes it because the right
+  frame depends on where the toggle's home app-db lives (Xray for
+  every current consumer; future tools may differ).
+
+  Pure hiccup; substrate-agnostic. JVM-load-safe (no React imports;
+  no `:require` of `re-frame.core`)."
+  (:require [day8.re-frame2-xray.theme.tokens
+             :refer [tokens sans-stack]]
+            [re-frame.core :as rf]))
+
+;; =========================================================================
+;; styles
+;; =========================================================================
+;;
+;; Hoisted at ns-load so React's reconciler sees stable object identities
+;; (rf2-zlk6h). `tokens` resolves to `var(--rf-xray-*)` strings — theme
+;; switching rides the CSS-variable seam.
+
+(def ^:private mode-toggle-bar-style
+  {:display       "inline-flex"
+   :align-items   "center"
+   :gap           0
+   :border        (str "1px solid " (:border-subtle tokens))
+   :border-radius "3px"
+   :overflow      "hidden"
+   :margin-left   "8px"
+   :line-height   1})
+
+(def ^:private mode-toggle-button-base-style
+  {:border         "none"
+   :padding        "2px 8px"
+   :font-family    sans-stack
+   :font-size      "10px"
+   :font-weight    700
+   :text-transform "uppercase"
+   :letter-spacing "0.5px"
+   :cursor         "pointer"
+   :line-height    1})
+
+(def ^:private mode-toggle-button-active-style
+  (assoc mode-toggle-button-base-style
+         :background (:accent tokens)
+         :color      (:white tokens)))
+
+(def ^:private mode-toggle-button-inactive-style
+  (assoc mode-toggle-button-base-style
+         :background "transparent"
+         :color      (:text-secondary tokens)))
+
+;; =========================================================================
+;; mode keywords
+;; =========================================================================
+
+(def default-modes
+  "Canonical mode order for the three-button bar — `[diff][full][full+diff]`.
+  Per Mike's pair-debug 2026-05-27 the operator's eye reads left → right:
+  least-rich (just-what-changed) → richest (full tree + annotations).
+  Surfaces may override but should not depart from this ordering."
+  [:diff :full :full+diff])
+
+(def default-default-mode
+  "The widget's recommended default mode keyword across every surface
+  per pair-debug 2026-05-27: mode-3 is the operator's most-useful
+  lens because it carries shape + delta in one read. Surfaces with
+  no `before` available (e.g. SUBSCRIPTIONS first-run rows, App-DB
+  cold-boot) fall back to `:full` automatically — that's a render-time
+  policy not a default-mode override."
+  :full+diff)
+
+(defn mode-label
+  "Render the human-readable button label for a mode keyword. The
+  literal `+` in `:full+diff` is intentional per the findings-doc
+  grammar lock — the symbol IS the cue (combining two lenses)."
+  [m]
+  (case m
+    :diff      "diff"
+    :full      "full"
+    :full+diff "full+diff"
+    (name m)))
+
+(defn mode-testid-suffix
+  "Sanitised testid suffix — the `+` in `:full+diff` is not a valid
+  CSS selector tail downstream, so substitute a hyphenated alias.
+  All other mode keywords use their `name`."
+  [m]
+  (case m
+    :full+diff "full-with-diff"
+    (name m)))
+
+;; =========================================================================
+;; widget
+;; =========================================================================
+
+(defn diff-mode-toggle
+  "Three-button toggle bar `[diff][full][full+diff]` (rf2-yqjrd / rf2-n2jig).
+
+  Stateless chrome — the caller owns `:mode` (typically a sub) and the
+  `:on-change` dispatch (typically `(rf/with-frame :rf/xray (rf/dispatch
+  [:rf.xray.<surface>/set-diff-mode mode]))`).
+
+  Returns a `<span>` with the three buttons; active button paints in
+  `:accent`, inactive buttons are transparent with muted text.
+
+  Opts:
+
+  - `:mode`       — current mode keyword (`:diff` / `:full` / `:full+diff`).
+                    The widget renders the matching button as `:active`.
+  - `:on-change`  — `(fn [next-mode])`, called with the chosen mode
+                    keyword on button click. Pure surface — the caller
+                    chooses how to bridge to `rf/dispatch` (including
+                    any `with-frame :rf/xray` envelope).
+  - `:testid`     — data-testid prefix used for the bar + per-button
+                    testids. The bar gets `<testid>` verbatim; buttons
+                    get `<testid>-<mode-suffix>` (e.g. `…-diff`,
+                    `…-full`, `…-full-with-diff`).
+  - `:modes`      — optional ordered vector of mode keywords. Defaults to
+                    `[:diff :full :full+diff]`. Surfaces that want to
+                    omit a mode (rare; mode-3 is the canonical full
+                    bar) pass a subset.
+
+  rf2-yqjrd — extracted from `panels.epoch.view/db-view-mode-toggle`
+  (rf2-n2jig) so every Xray surface consumes the same chrome verbatim."
+  [{:keys [mode on-change testid modes]
+    :or   {modes default-modes}}]
+  [:span {:data-testid testid
+          :data-mode (when (keyword? mode) (name mode))
+          :style mode-toggle-bar-style}
+   (for [m modes
+         :let [active? (= mode m)]]
+     ^{:key (name m)}
+     [:button {:data-testid (str testid "-" (mode-testid-suffix m))
+               :aria-pressed (str active?)
+               :on-click (fn [e]
+                           (.stopPropagation e)
+                           (on-change m))
+               :style (if active?
+                        mode-toggle-button-active-style
+                        mode-toggle-button-inactive-style)}
+      (mode-label m)])])
+
+;; =========================================================================
+;; helpers — per-surface sub + event registration
+;; =========================================================================
+
+(defn reg-mode-sub+event!
+  "Register the canonical sub + event pair for a per-surface diff
+  mode. Idempotent across hot-reload (re-registering replaces).
+
+  `surface-id` is a namespaced keyword like `:rf.xray.app-db` or
+  `:rf.xray.machine-inspector`. The fn registers:
+
+      <surface-id>/diff-mode       ;; sub returning the keyword (default
+                                   ;; mode `:full+diff`)
+      <surface-id>/set-diff-mode   ;; event-db setting the keyword
+
+  The mode is stored under a derived slot keyword
+  `<surface-namespace>/<surface-name>-diff-mode` so two surfaces'
+  modes don't collide.
+
+  Mode persists in Xray's app-db so the operator's preference survives
+  focus shifts (rf2-n2jig). Use `:reset` opt-out for transient surfaces."
+  [surface-id & [{:keys [default-mode]
+                  :or   {default-mode default-default-mode}}]]
+  (let [sub-id   (keyword (namespace surface-id)
+                          (str (name surface-id) "/diff-mode"))
+        event-id (keyword (namespace surface-id)
+                          (str "set-" (name surface-id) "-diff-mode"))
+        slot     (keyword (namespace surface-id)
+                          (str (name surface-id) "-diff-mode"))]
+    (rf/reg-sub sub-id
+      (fn [db _]
+        (get db slot default-mode)))
+    (rf/reg-event-db event-id
+      (fn [db [_ mode]]
+        (assoc db slot mode)))
+    {:sub-id   sub-id
+     :event-id event-id
+     :slot     slot}))

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -1165,12 +1165,21 @@
           "the fx row's args mount a mini-render"))))
 
 (deftest subscriptions-values-route-through-mini-test
-  (testing "rf2-8w8er — SUBSCRIPTIONS row renders sub-vec + before /
-            after values through `ei/mini` so the table cells light
-            up with syntax-token chrome rather than plain `pr-str`."
+  (testing "rf2-8w8er + rf2-yqjrd — SUBSCRIPTIONS row renders sub-vec
+            + before / after values through `ei/mini` so the table
+            cells light up with syntax-token chrome rather than plain
+            `pr-str`. The mini-mount triad applies to the `:diff`
+            value-mode (the prior shape); the new `:full` /
+            `:full+diff` modes route through the full edn-inspector
+            instead. Test pins both halves: setting the value-mode
+            to `:diff` recovers the original assertion."
     (epoch-orchestrator/install!)
     (frame/reg-frame :rf/xray {})
     (rf/with-frame :rf/xray
+      ;; rf2-yqjrd — flip the value-mode to `:diff` so the per-row
+      ;; cell renders via `mini` instead of the new edn-inspector
+      ;; mount that `:full+diff` (default) uses.
+      (rf/dispatch-sync [:rf.xray.epoch/set-subs-value-mode :diff])
       (let [step {:step :subscriptions :badge :SUBSCRIPTIONS :step-number 5
                   :rows [{:sub-id :counter/total :sub-vec [:counter/total]
                           :inputs nil :changed? true :before 5 :after 6}]

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_view_cljs_test.cljs
@@ -566,10 +566,8 @@
       (focus-epoch! 1)
       (let [tree   (machine-inspector/Panel)
             drill  (find-by-testid tree "rf-xray-machine-snapshot-drill-in")
-            before (find-by-testid
-                     tree "rf-xray-machine-snapshot-block-auth/login-before")
-            after  (find-by-testid
-                     tree "rf-xray-machine-snapshot-block-auth/login-after")]
+            block  (find-by-testid
+                     tree "rf-xray-machine-snapshot-block-auth/login")]
         (is (some? drill)
             "drill-in section mounts when before/after snapshots are present")
         (is (= ":auth/login" (:data-machine-id (second drill)))
@@ -578,14 +576,14 @@
             "before snapshot presence surfaced on the host")
         (is (= "true" (:data-has-after (second drill)))
             "after snapshot presence surfaced on the host")
-        (is (some? before)
-            "BEFORE snapshot block renders")
-        (is (some? after)
-            "AFTER snapshot block renders")
-        (is (= "before" (:data-phase (second before)))
-            "BEFORE block carries the :before phase tag")
-        (is (= "after" (:data-phase (second after)))
-            "AFTER block carries the :after phase tag")))))
+        ;; rf2-yqjrd — the side-by-side Before/After grid retired; a
+        ;; SINGLE mount renders the AFTER snapshot with the three-mode
+        ;; toggle controlling whether BEFORE is threaded as the diff
+        ;; pre-image. The two `-before` / `-after` blocks collapse to
+        ;; one `rf-xray-machine-snapshot-block-<machine-id>` mount.
+        (is (some? block)
+            "single snapshot block renders post-rf2-yqjrd (replaces
+             the prior Before/After side-by-side grid)")))))
 
 (defn- find-popup-affordance-containers
   "Walk hiccup (already expand-tree'd by the find-by-testid helper) and
@@ -683,12 +681,13 @@
             "before-presence surface reflects the missing :before slot")
         (is (= "true" (:data-has-after (second drill)))
             "after-presence surface reflects the present :after slot")
-        (is (nil? (find-by-testid
-                    tree "rf-xray-machine-snapshot-block-auth/login-before"))
-            "BEFORE block is omitted when its snapshot is nil")
+        ;; rf2-yqjrd — single mount; the AFTER snapshot's block paints
+        ;; even when BEFORE is missing. Mode-3 (`:full+diff`, the
+        ;; default) gracefully degrades to plain browse when no
+        ;; pre-image is threaded.
         (is (some? (find-by-testid
-                     tree "rf-xray-machine-snapshot-block-auth/login-after"))
-            "AFTER block renders when its snapshot is present")))))
+                     tree "rf-xray-machine-snapshot-block-auth/login"))
+            "AFTER-only path renders the single snapshot block")))))
 
 ;; ---- (5) per-machine prev/next nav -------------------------------------
 
@@ -1006,12 +1005,13 @@
         (is (= expected-bg (:background style))
             "drill-in body uses :bg-2 — same as outer section, no card-in-card")))))
 
-(deftest rf2-3d987-issue-3-before-after-side-by-side-grid
-  (testing "rf2-3d987 issue #3: Before/After render in a CSS grid that
-            auto-fits side-by-side at the wider viewport and falls back
-            to stacked when narrower. Pinned via the
-            `grid-template-columns: repeat(auto-fit, minmax(...)` shape
-            on the snapshot-drill-in's inner grid container."
+(deftest rf2-yqjrd-snapshot-drill-in-three-mode-toggle
+  (testing "rf2-yqjrd — the Before/After side-by-side grid retired in
+            favour of a SINGLE mount + the universal three-mode toggle
+            `[diff][full][full+diff]`. The toggle paints in the
+            drill-in header; the single mount shows the AFTER snapshot
+            with the BEFORE snapshot threaded as the diff pre-image
+            when mode is `:full+diff` (default)."
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
       (override-machines!    [:auth/login])
@@ -1021,25 +1021,24 @@
           :trace-events
           [{:id 1 :time 10 :operation :rf.machine/transition
             :tags {:machine-id :auth/login
-                   :before {:state :idle :data {}}
-                   :after  {:state :authing :data {}}
+                   :before {:state :idle :data {:user nil}}
+                   :after  {:state :authing :data {:user "alice"}}
                    :event [:auth/submit] :rf.trace/dispatch-id "d-1"}}]}])
       (focus-epoch! 1)
-      (let [tree (machine-inspector/Panel)
-            grid (find-by-testid
-                   tree "rf-xray-machine-snapshot-drill-in-grid")
-            style (style-of grid)
-            cols  (:grid-template-columns style)]
-        (is (some? grid)
-            "snapshot-drill-in carries an inner grid container")
-        (is (= "grid" (:display style))
-            "container uses display: grid")
-        (is (and (string? cols)
-                 (str/includes? cols "auto-fit")
-                 (str/includes? cols "minmax"))
-            (str "grid-template-columns uses auto-fit + minmax so the "
-                 "layout collapses to one column when narrow — got "
-                 (pr-str cols)))))))
+      (let [tree   (machine-inspector/Panel)
+            drill  (find-by-testid tree "rf-xray-machine-snapshot-drill-in")
+            toggle (find-by-testid
+                     tree "rf-xray-machine-snapshot-view-mode")]
+        (is (some? drill)
+            "drill-in section mounts")
+        (is (some? toggle)
+            "three-mode toggle paints in the drill-in header")
+        (is (= "full+diff" (:data-mode (second toggle)))
+            "default mode is :full+diff per pair-debug 2026-05-27")
+        ;; The grid container retired with the side-by-side layout.
+        (is (nil? (find-by-testid
+                    tree "rf-xray-machine-snapshot-drill-in-grid"))
+            "the side-by-side grid container is retired")))))
 
 (deftest rf2-3d987-issue-4-chart-collapsible-toggle-and-state
   (testing "rf2-3d987 issue #4: the chart sub-panel carries a collapse

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -170,6 +170,14 @@
    ;; toggle slot. Persists the operator's preferred view-mode for
    ;; the HANDLER step's `:db` sub-section. Defaults to `:diff`.
    :rf.xray.epoch/db-view-mode
+   ;; rf2-yqjrd — SUBSCRIPTIONS value-mode toggle. Orthogonal to the
+   ;; row-filter `:subs-filter-mode`; governs how each `:changed?`
+   ;; row's value cell renders (`:diff` / `:full` / `:full+diff`).
+   :rf.xray.epoch/subs-value-mode
+   ;; rf2-yqjrd — App-DB panel universal view-mode toggle slot.
+   :rf.xray.app-db/view-mode
+   ;; rf2-yqjrd — Machine Inspector snapshot view-mode toggle slot.
+   :rf.xray.machine-inspector/view-mode
    :rf.xray/event-detail
    :rf.xray/filtered-cascades
    ;; rf2-jvghz — model behind the L2 'N hidden by filters' indicator
@@ -474,6 +482,12 @@
    ;; toggle write event. Sets the persisted view-mode slot the
    ;; `:rf.xray.epoch/db-view-mode` sub reads.
    :rf.xray.epoch/set-db-view-mode
+   ;; rf2-yqjrd — universal three-mode toggle write events. Each
+   ;; surface registers its own pair so per-surface mode persistence
+   ;; stays isolated.
+   :rf.xray.epoch/set-subs-value-mode
+   :rf.xray.app-db/set-view-mode
+   :rf.xray.machine-inspector/set-view-mode
    :rf.xray/epoch-recorded
    ;; rf2-piye4 — typed-predicate filter events. Each appends a
    ;; typed `{:kind <kw> :params {…}}` IN pill from a right-click

--- a/tools/xray/testbeds/panel_gallery/core.cljs
+++ b/tools/xray/testbeds/panel_gallery/core.cljs
@@ -96,7 +96,13 @@
             ;; mount with the edn-inspector gallery above; the
             ;; variants pass `:full-with-diff? true` to opt into
             ;; the mode-3 chrome (R3 chip + R4 rail).
-            [panel-gallery.gallery-diff-mode-3]))
+            [panel-gallery.gallery-diff-mode-3]
+            ;; rf2-yqjrd — universalised three-mode toggle adoption
+            ;; across App-DB / Machine Inspector / SUBSCRIPTIONS
+            ;; surfaces. Sibling to the foundation gallery above —
+            ;; this one rides the actual panel views so the toggle
+            ;; appears in its native chrome.
+            [panel-gallery.gallery-diff-mode-universal]))
 
 ;; ============================================================================
 ;; LANDING — the URL `/` view (no `#/stories` hash)

--- a/tools/xray/testbeds/panel_gallery/gallery_diff_mode_universal.cljs
+++ b/tools/xray/testbeds/panel_gallery/gallery_diff_mode_universal.cljs
@@ -1,0 +1,187 @@
+(ns panel-gallery.gallery-diff-mode-universal
+  "Story coverage for the **universalised three-mode diff toggle**
+  (rf2-yqjrd).
+
+  Sibling to `gallery-diff-mode-3` (which covers the R1-R8 grammar
+  itself via the edn-inspector widget). This gallery exercises the
+  PER-SURFACE adoption — App-DB, Machine Inspector snapshot,
+  SUBSCRIPTIONS step value cells — so a reviewer can verify each
+  affected surface paints the same `[diff][full][full+diff]` button
+  bar with the same shared widget chrome.
+
+  ## Surfaces
+
+  - **App-DB panel** — universal panel-wide view-mode at the top.
+    Variants seed an epoch into the spine so the App-DB panel's
+    sections paint with diff annotations, then exercise each mode
+    keyword via the toggle.
+  - **Machine Inspector snapshot drill-in** — single mount + the
+    three-mode toggle (replacing the prior Before/After side-by-
+    side grid).
+  - **SUBSCRIPTIONS step value cells** — per-row value rendering
+    routed through the universal toggle.
+
+  ## Why a separate file from the foundation gallery
+
+  `gallery-diff-mode-3.cljs` (rf2-n2jig) covers the R-rule grammar
+  via the edn-inspector widget directly. This file's variants ride
+  the actual PANEL views (App-DB / Machine / SUBSCRIPTIONS) so the
+  reviewer sees the toggle in its native chrome surrounding — not
+  the standalone widget mount.
+
+  ## Note on Story snapshot identity
+
+  The bead (rf2-yqjrd) lists Story snapshot as a fourth surface.
+  Investigation 2026-05-27: Story's snapshot identity (per rf2-zfy1e)
+  is a content-hash string only — there's no value-diff UI surface
+  in Story to retire. The hash is consumed by visual-regression
+  services (Chromatic/Argos/Percy) as an opaque join key. No Story-
+  side toggle work was required; the universal toggle adoption is
+  limited to the three Xray surfaces above."
+  (:require [re-frame.core :as rf]
+            [re-frame.story :as story]
+            [panel-gallery.panel-views :as panel-views]))
+
+;; The gallery reuses the panel-views' registered `:Panel` views
+;; (App-DB, Machine Inspector, Epoch) — each variant seeds a focused-
+;; epoch state into the variant frame's :rf/xray app-db so the panel
+;; renders meaningfully.
+
+(defn register-all!
+  "Register the universalised three-mode toggle Story surface.
+  Idempotent under `install-canonical-vocabulary!` resets."
+  []
+  (story/install-canonical-vocabulary!)
+  (panel-views/register!)
+
+  (story/reg-tag :feature/xray-diff-mode-universal
+    {:axis :feature
+     :doc  "Xray universal three-mode toggle adoption (rf2-yqjrd) —
+            App-DB / Machine Inspector / SUBSCRIPTIONS surfaces all
+            consume the same `views.diff-mode-toggle` widget."})
+
+  ;; -- App-DB panel --------------------------------------------------------
+
+  (story/reg-story :story.xray.app-db/diff-mode
+    {:doc        "App-DB panel — universal three-mode toggle drives
+                  every section (TOP + per-:rf/* areas) uniformly."
+     :component  :panel-gallery.app-db/Panel
+     :tags       #{:dev :feature/xray-diff-mode-universal}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.app-db/diff-mode-full+diff
+    {:doc        "App-DB panel in `:full+diff` mode (default). Every
+                  section paints LIVE current-state with inline diff
+                  annotations against the focused epoch's `:db-before`.
+                  The mode-3 R1-R8 grammar applies to each section
+                  body."
+     :events     [;; Default mode — :full+diff. No mode seed needed.
+                  ]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.app-db/diff-mode-full
+    {:doc        "App-DB panel in `:full` mode. Every section paints
+                  LIVE current-state with NO `:before` threaded —
+                  plain browse, no diff chrome. Useful when the
+                  operator wants to inspect shape alone."
+     :events     [[:rf.xray.app-db/set-view-mode :full]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.app-db/diff-mode-diff
+    {:doc        "App-DB panel in `:diff` mode. Section list
+                  suppressed; one flat path-prefixed change list at
+                  the top. Same source as the Epoch HANDLER `:diff`
+                  view + the MCP exporter (`:rf.xray/selected-epoch-
+                  diff` triples)."
+     :events     [[:rf.xray.app-db/set-view-mode :diff]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; -- Machine Inspector snapshot drill-in --------------------------------
+
+  (story/reg-story :story.xray.machine-inspector/snapshot-diff-mode
+    {:doc        "Machine Inspector snapshot drill-in — single mount
+                  + three-mode toggle. Replaces the rf2-3d987 side-
+                  by-side Before/After grid."
+     :component  :panel-gallery.machines/Panel
+     :tags       #{:dev :feature/xray-diff-mode-universal}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.machine-inspector/snapshot-full+diff
+    {:doc        "Machine Inspector snapshot in `:full+diff` mode
+                  (default). Single mount; AFTER snapshot painted
+                  with BEFORE threaded as the diff pre-image so
+                  inline R1-R8 grammar annotations fire."
+     :events     []
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.machine-inspector/snapshot-full
+    {:doc        "Machine Inspector snapshot in `:full` mode. AFTER
+                  snapshot alone, no BEFORE comparison — plain
+                  browse of the post-transition state."
+     :events     [[:rf.xray.machine-inspector/set-view-mode :full]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.machine-inspector/snapshot-diff
+    {:doc        "Machine Inspector snapshot in `:diff` mode. Flat
+                  path-prefixed change list — same shape as App-DB
+                  and Epoch HANDLER `:diff` lenses."
+     :events     [[:rf.xray.machine-inspector/set-view-mode :diff]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; -- SUBSCRIPTIONS step value-cell ---------------------------------------
+
+  (story/reg-story :story.xray.epoch/subs-value-mode
+    {:doc        "Epoch SUBSCRIPTIONS step — per-row value cell
+                  routed through the universal three-mode toggle.
+                  Orthogonal to the existing `[all][changed]
+                  [unchanged]` row-filter button bar."
+     :component  :panel-gallery.epoch/Panel
+     :tags       #{:dev :feature/xray-diff-mode-universal}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.epoch/subs-value-full+diff
+    {:doc        "SUBSCRIPTIONS value cells in `:full+diff` mode
+                  (default). Each `:changed?` row's value cell
+                  paints the AFTER value via the edn-inspector with
+                  BEFORE threaded as the diff pre-image."
+     :events     []
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.epoch/subs-value-full
+    {:doc        "SUBSCRIPTIONS value cells in `:full` mode. Each
+                  `:changed?` row's value cell renders the AFTER
+                  value alone via the edn-inspector — no BEFORE
+                  comparison."
+     :events     [[:rf.xray.epoch/set-subs-value-mode :full]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.epoch/subs-value-diff
+    {:doc        "SUBSCRIPTIONS value cells in `:diff` mode — the
+                  pre-rf2-yqjrd shape: `✓ before → after` via the
+                  `mini` widget. Preserved as one mode of the new
+                  toggle so the prior compact rendering remains
+                  available."
+     :events     [[:rf.xray.epoch/set-subs-value-mode :diff]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; -- Workspace ----------------------------------------------------------
+
+  (story/reg-workspace :Workspace.xray.diff-mode-universal/all
+    {:doc      "All universalised three-mode toggle variants in one
+                auto-grid. Compare across surfaces — every panel
+                paints the same `[diff][full][full+diff]` button bar
+                with the same shared widget chrome."
+     :layout   :variants-grid
+     :columns  2
+     :tags     #{:dev}}))
+
+(register-all!)


### PR DESCRIPTION
Universalises the `[diff][full][full+diff]` button-bar pattern shipped by rf2-n2jig (#2230) across every Xray surface that surfaces a `(before, after)` data view. One affordance, one rendering pipeline, one mental model regardless of panel.

## Per-surface migration

### 1. App-DB panel
- Panel-wide three-mode toggle at the top (above the section list).
- `:diff` renders a flat path-prefixed change list (reusing `:rf.xray/selected-epoch-diff` triples — same source as the Epoch HANDLER `:diff` view + the MCP exporter).
- `:full` renders every section's body with no `:before` threaded (plain browse).
- `:full+diff` (default) retains the prior inline-diff behaviour with `:before` threaded so R1-R8 annotations paint per section.
- New `:rf.xray.app-db/view-mode` sub + `:rf.xray.app-db/set-view-mode` event registered in `app_db_diff_events.cljs`. `state-body` becomes 2-arity to accept the mode; the 1-arity legacy form still works for existing tests.

### 2. Machine Inspector snapshot drill-in
- **Retires the prior Before/After side-by-side CSS-Grid layout** (rf2-3d987 issue #3 chrome). Pre-alpha posture, no shim.
- Replaced by a SINGLE mount + the three-mode toggle in the drill-in header.
- Mode-3 (`:full+diff`, default) carries the same meanings the side-by-side did — full AFTER state + diff context + comparison — via the R1-R8 grammar.
- Mode `:diff` adds a pure-diff lens (flat rows via the shared Editscript engine — same shape as App-DB / Epoch HANDLER `:diff`).
- Mode `:full` shows the AFTER snapshot alone (no BEFORE comparison).
- New `:rf.xray.machine-inspector/view-mode` sub + `:rf.xray.machine-inspector/set-view-mode` event.

### 3. Epoch SUBSCRIPTIONS step
- Per-row value cells now route through the universal toggle, controlled by a new panel-wide `:rf.xray.epoch/subs-value-mode` slot.
- Orthogonal to the existing `[all][changed][unchanged]` row-filter button bar — the new toggle governs HOW each `:changed?` row's value cell renders, not WHICH rows render.
- Mode `:diff` preserves the prior `mini` widget pair-rendering (`✓ before → after`); `:full` / `:full+diff` route through the full `edn-inspector` widget.

### 4. Story snapshot
- **Investigation finding 2026-05-27**: Story's `snapshot-identity` (per rf2-zfy1e) is a **content-hash string only**, not a value-diff UI surface. The hash is consumed by visual-regression services (Chromatic / Argos / Percy / Lost Pixel) as an opaque join key.
- No Story-side toggle work was required; documented in `spec/021 §9.1.5.2` so future readers see the analysis.

## Shared widget

`tools/xray/src/day8/re_frame2_xray/views/diff_mode_toggle.cljs` (new, ~225 LoC). Extracted from `epoch/view.cljs`'s `db-view-mode-toggle` (rf2-n2jig). Public API:

```clojure
[diff-mode-toggle
 {:mode      <:diff | :full | :full+diff>
  :on-change (fn [next-mode])
  :testid    "rf-xray-..."}]
```

Stateless chrome — each surface owns its own sub + event for the mode keyword. `reg-mode-sub+event!` helper installs the standard pair for a surface-id; the surfaces in this bead use it via explicit `reg-sub` / `reg-event-db` so the slot key stays visible at the registration site.

## Retired machinery

- Machine Inspector's `snapshot-drill-in-grid` CSS-Grid container + per-phase Before/After block headers + per-phase `:panel-id` qualifier (the AFTER block now owns the only mount, with BEFORE threaded as `:before`). 
- The App-DB panel's auto-routing-on-`:before`-presence branch (made explicit via the mode).

## Stories

`tools/xray/testbeds/panel_gallery/gallery_diff_mode_universal.cljs` adds 10 variants across 3 stories — one variant per `[surface × mode]` combination. Reviewer can compare the toggle appearance + chrome side-by-side across surfaces in the workspace.

## Spec updates

- `tools/xray/spec/021-Dynamic-Panel-Designs.md` §9.1.5.2 documents the universalised adoption — per-surface storage table, retirements, Story-snapshot finding.

## Quality gates

- `test:cljs` — 4803 tests, 15628 assertions, 0 failures.
- `test:browser` — 124 tests, 353 assertions, 0 failures.
- `test:bundle-isolation` — 17 artefact entries, 35 internal sentinels absent.
- `test:perf-bundle` — off=0, on=12 (unchanged from main).

## Test deltas

- `machine_inspector_view_cljs_test`: two before/after block assertions collapse to a single `rf-xray-machine-snapshot-block-<machine-id>` assertion; the side-by-side grid test retires to a three-mode toggle test (verifies `rf-xray-machine-snapshot-view-mode` bar + default `:full+diff` mode + absence of the retired grid container).
- `registry_cljs_test`: smoke list +6 (3 subs + 3 events for the new per-surface mode slots).
- `view_cljs_test/subscriptions-values-route-through-mini-test`: pins `:rf.xray.epoch/subs-value-mode :diff` so the `mini` triad assertion stays meaningful under the new default.

## File inventory

- New: `tools/xray/src/day8/re_frame2_xray/views/diff_mode_toggle.cljs` (shared widget).
- New: `tools/xray/testbeds/panel_gallery/gallery_diff_mode_universal.cljs` (Stories).
- Modified: `tools/xray/src/day8/re_frame2_xray/panels/{app_db_diff,app_db_diff_events,app_db_diff_state,epoch_panel,machine_inspector}.cljs`, `panels/epoch/view.cljs`, `testbeds/panel_gallery/core.cljs`, `spec/021-Dynamic-Panel-Designs.md`.
- Test updates: `panels/epoch/view_cljs_test`, `panels/machine_inspector_view_cljs_test`, `registry_cljs_test`.

Closes rf2-yqjrd.