### PR TITLE
perf(xray): memoise diff-mode hot renders (rf2-4p1vl + rf2-4spyl)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_format.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_format.cljs
@@ -32,27 +32,102 @@
     (catch :default _
       (str v))))
 
-(defn display-value
-  "Return `v` with large string leaves replaced by a stable marker."
+(defn- needs-elision?
+  "Pre-scan `v` for any string leaf exceeding the display ceiling. When
+  no leaf needs elision the whole tree can pass through `display-value`
+  unchanged — preserving structural identity downstream (rf2-4spyl).
+
+  Short-circuits on the first hit: any large string anywhere in the
+  subtree returns `true` immediately."
+  [v]
+  (cond
+    (string? v)
+    (> (count v) display-large-string-threshold)
+
+    (map? v)
+    (some (fn [[_ value]] (needs-elision? value)) v)
+
+    (or (vector? v) (set? v) (sequential? v))
+    (some needs-elision? v)
+
+    :else
+    false))
+
+;; rf2-4spyl — module-level cache for `display-value`. The recursive
+;; rewrite allocates a fresh tree on every call, even when nothing
+;; needs eliding; that defeats the `(identical? before after)` short-
+;; circuit in `engine/project` (engine.cljc:515) and forces the diff
+;; engine into a full A* walk on every render. Combined with the audit's
+;; H1 finding (rf2-4p1vl) this is the load-bearing pair that drops mode-
+;; 3 renders from O(tree-size) to O(1) when inputs are stable.
+;;
+;; The fast path (`needs-elision?` → false) returns the input as-is and
+;; preserves identity natively — no cache lookup needed. The slow path
+;; (large strings present) caches the rewritten output keyed by the
+;; INPUT identity in a JS WeakMap; subsequent calls with the same input
+;; return the stable rewritten output, keeping identity downstream.
+;;
+;; WeakMap auto-evicts when the input is GC'd — no manual invalidation
+;; needed. Only collections (map / vector / set / seq) can be WeakMap
+;; keys in JS; scalars (string / number / nil / etc.) are not keyable
+;; but the recursion only hits them as leaves where the rewrite is
+;; either trivial (return `v`) or atomic (the elision marker), so a
+;; cache there would add overhead without payoff.
+(def ^:private display-value-cache
+  (js/WeakMap.))
+
+(defn- cache-key?
+  "Predicate for WeakMap-keyable values — collections only. Other
+  shapes (scalars, the elision marker output) skip the cache."
+  [v]
+  (or (map? v) (vector? v) (set? v) (and (sequential? v) (not (string? v)))))
+
+(defn- rewrite
+  "Recursive rewrite kernel — the original `display-value` logic. Only
+  invoked on the slow path (when `needs-elision?` returned true)."
   [v]
   (cond
     (and (string? v) (> (count v) display-large-string-threshold))
     {:rf.size/large-elided {:chars (count v)}}
 
     (map? v)
-    (into (empty v) (map (fn [[k value]] [k (display-value value)])) v)
+    (into (empty v) (map (fn [[k value]] [k (rewrite value)])) v)
 
     (vector? v)
-    (mapv display-value v)
+    (mapv rewrite v)
 
     (set? v)
-    (into (empty v) (map display-value) v)
+    (into (empty v) (map rewrite) v)
 
     (sequential? v)
-    (doall (map display-value v))
+    (doall (map rewrite v))
 
     :else
     v))
+
+(defn display-value
+  "Return `v` with large string leaves replaced by a stable marker.
+
+  rf2-4spyl — two-stage optimisation. First pre-scans `v` for any large
+  string; if none exists, returns `v` unchanged (preserves structural
+  identity so downstream `identical?` short-circuits hold — notably
+  `engine/project` and the edn-inspector's projection memo, rf2-4p1vl).
+  When elision IS needed, consults a module-level WeakMap cache keyed
+  by input identity; cache hit returns the prior rewritten output (also
+  identity-stable). Cache miss does the full rewrite and stores it.
+  WeakMap auto-evicts when the input is GC'd.
+
+  Semantically equivalent to the prior implementation; the rewrite
+  kernel is unchanged. Only the call-once-per-input guarantee is new."
+  [v]
+  (if-not (needs-elision? v)
+    v
+    (if (cache-key? v)
+      (or (.get display-value-cache v)
+          (let [rewritten (rewrite v)]
+            (.set display-value-cache v rewritten)
+            rewritten))
+      (rewrite v))))
 
 (defn format-display-edn
   "Best-effort EDN-like format for visible values."

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
@@ -2746,6 +2746,35 @@
         ;; arrive verbatim and should not churn the app-db slot.
         observer    (atom nil)
         last-width  (atom nil)
+        ;; rf2-4p1vl — per-mount projection cache. The Editscript-backed
+        ;; `engine/project` walks the full `(before, after)` pair every
+        ;; call; the inner render fn runs on EVERY render of the mount
+        ;; (expansion toggle, ResizeObserver widths update, parent re-
+        ;; render). Without this cache the mode-3 diff path re-walks the
+        ;; same byte-identical inputs N times per epoch — the audit's
+        ;; H1 finding (ai/findings/three-mode-diff-efficiency-audit-2026-
+        ;; 05-27.md §H1).
+        ;;
+        ;; Atom holds `{:before <ref> :after <ref> :projection <map>}` or
+        ;; nil. Cache hit when both refs match the previous call by
+        ;; `identical?`; otherwise recompute and store. The cache is
+        ;; closure-scoped so it lives exactly as long as the mount —
+        ;; unmount frees the closure, no leak.
+        ;;
+        ;; Identity stability of the inputs is gated by
+        ;; `f/display-value` preserving structural sharing (rf2-4spyl).
+        projection-cache (atom nil)
+        memoised-project
+        (fn [before after]
+          (let [cached @projection-cache]
+            (if (and cached
+                     (identical? before (:before cached))
+                     (identical? after  (:after  cached)))
+              (:projection cached)
+              (let [p (engine/project before after)]
+                (reset! projection-cache
+                        {:before before :after after :projection p})
+                p))))
         measure-and-dispatch
         (fn [^js el]
           (when el
@@ -2889,8 +2918,17 @@
             ;; projection is nil and the renderer's path-keyed lookups
             ;; return `:same` for everything. Pure data — same value
             ;; key composability as `expansion-map`.
+            ;;
+            ;; rf2-4p1vl — the projection is computed via the per-mount
+            ;; `memoised-project` closure (captured in the form-2 outer
+            ;; body). Byte-identical `(displayed-before, displayed-
+            ;; value)` pairs across renders short-circuit to the cached
+            ;; result; only changed inputs trigger a fresh Editscript
+            ;; walk. Restores parity with the sub-cached `:diff` lens
+            ;; path (rf2-yqjrd) which has the same caching property
+            ;; via `annotated-tree-cache`.
             projection    (when diff?
-                            (engine/project displayed-before displayed-value))
+                            (memoised-project displayed-before displayed-value))
             body-content  (render-node
                             {:value displayed-value
                              :before (if diff? displayed-before ::missing)

--- a/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_format_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_format_cljs_test.cljs
@@ -19,3 +19,62 @@
         v   (f/display-value {:k big})]
     (is (map? (:rf.size/large-elided (:k v)))
         "large strings collapse to the elision marker")))
+
+;; ---- rf2-4spyl — display-value identity preservation -----------------------
+;;
+;; The audit's H2 finding: `display-value` rebuilt the whole tree on every
+;; call, even when nothing needed eliding. That defeated downstream
+;; `(identical? before after)` short-circuits — notably `engine/project`
+;; which only short-circuits when the same JS reference is passed.
+;;
+;; The fix has two surfaces under test here:
+;;
+;; 1. Fast path — inputs with no large strings pass through unchanged
+;;    (same identity). Verified across map / vector / set / nested.
+;; 2. Slow path — inputs with large strings get a stable rewritten
+;;    output cached by input identity. Two calls with the same input
+;;    return the same JS reference.
+
+(deftest display-value-preserves-identity-when-no-elision-needed
+  ;; The audit's load-bearing property: when nothing in the tree needs
+  ;; eliding, `display-value` must return the input AS-IS so that
+  ;; identity-stable inputs stay identity-stable through the call.
+  (let [m {:a 1 :b "short string" :c [1 2 3] :d #{:x :y}}]
+    (is (identical? m (f/display-value m))
+        "map with no large strings returns the same reference"))
+  (let [v [1 [2 [3 [4 "still short"]]]]]
+    (is (identical? v (f/display-value v))
+        "deeply nested vector with no large strings returns same ref"))
+  (let [s #{:a :b :c}]
+    (is (identical? s (f/display-value s))
+        "set with no large strings returns the same reference"))
+  (let [seqv (doall (map inc [1 2 3]))]
+    (is (identical? seqv (f/display-value seqv))
+        "seq with no large strings returns the same reference")))
+
+(deftest display-value-caches-output-on-slow-path
+  ;; When elision IS needed, the rewritten output must be stable across
+  ;; repeated calls with the same input — otherwise the engine memo
+  ;; downstream sees a fresh tree every render and recomputes.
+  (let [big (apply str (repeat (inc f/display-large-string-threshold) "x"))
+        m   {:k big :other 42}
+        out1 (f/display-value m)
+        out2 (f/display-value m)]
+    (is (identical? out1 out2)
+        "repeated calls with the same input return the same rewritten output")
+    (is (map? (:rf.size/large-elided (:k out1)))
+        "large string still collapses to the elision marker")
+    (is (= 42 (:other out1))
+        "non-elided keys passed through")))
+
+(deftest display-value-still-elides-large-strings
+  ;; Regression guard — the optimisation must not break the semantic.
+  (let [big (apply str (repeat (inc f/display-large-string-threshold) "x"))]
+    (is (map? (:rf.size/large-elided (f/display-value big)))
+        "top-level large string elides")
+    (is (map? (:rf.size/large-elided (-> (f/display-value [big])
+                                          first)))
+        "large string inside a vector elides")
+    (is (map? (:rf.size/large-elided (-> (f/display-value #{big})
+                                          first)))
+        "large string inside a set elides")))

--- a/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs
@@ -29,6 +29,7 @@
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.views.edn-inspector :as ei]
+            [day8.re-frame2-xray.diff.engine :as engine]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens dark-palette light-palette]]))
 
@@ -2782,3 +2783,122 @@
         attrs (-> h second)]
     (is (nil? (:on-key-down attrs))
         "no zoom active → no keydown handler (keystrokes bubble up)")))
+
+;; ---- rf2-4p1vl — engine/project memoisation across re-renders -------------
+;;
+;; The audit's H1 finding: in diff mode (mode-3) the inner render fn invoked
+;; `engine/project` on every render — expansion toggle, ResizeObserver width
+;; update, parent re-render. Even when the `(before, after)` inputs were
+;; byte-identical, the full Editscript A* walk + ancestor classification
+;; ran again from scratch.
+;;
+;; The fix captures a per-mount projection cache in the form-2 outer body
+;; closure. Identity-stable inputs short-circuit to the cached projection.
+;; The cache key uses `identical?` on both `before` and `after`, matching
+;; the engine's own short-circuit at engine.cljc:515.
+;;
+;; Tests below spy on `engine/project` via `with-redefs` and count
+;; invocations across multiple inner-fn calls with identical inputs.
+
+(deftest projection-memo-skips-recompute-on-identical-inputs
+  ;; Mount the widget once (get the form-2 inner fn); call inner three
+  ;; times with the SAME `before` + `value` references. Without the
+  ;; memo `engine/project` fires three times; with the memo it fires
+  ;; once.
+  (let [before {:a 1 :b {:c 2}}
+        after  {:a 1 :b {:c 3}}
+        opts   {:panel-id :rf.xray/app-db
+                :before   before}
+        call-count (atom 0)
+        real-project engine/project]
+    (with-redefs [engine/project (fn [b a]
+                                   (swap! call-count inc)
+                                   (real-project b a))]
+      (let [inner (ei/edn-inspector after opts)]
+        ;; Three renders with identical (before, after) refs.
+        (inner after opts)
+        (inner after opts)
+        (inner after opts)
+        (is (= 1 @call-count)
+            "engine/project invoked exactly once across three identity-stable renders")))))
+
+(deftest projection-memo-recomputes-when-before-changes
+  ;; Cache invalidates when `before` is a different reference. New
+  ;; epoch / new diff input must trigger a fresh projection.
+  (let [before1 {:a 1}
+        before2 {:a 2}
+        after   {:a 3}
+        call-count (atom 0)
+        real-project engine/project]
+    (with-redefs [engine/project (fn [b a]
+                                   (swap! call-count inc)
+                                   (real-project b a))]
+      (let [inner (ei/edn-inspector after {:panel-id :rf.xray/app-db
+                                            :before   before1})]
+        (inner after {:panel-id :rf.xray/app-db :before before1})
+        (inner after {:panel-id :rf.xray/app-db :before before2})
+        (is (= 2 @call-count)
+            "engine/project re-runs when `before` reference changes")))))
+
+(deftest projection-memo-recomputes-when-after-changes
+  ;; Mirror of the above for the `after` side. Same-`before`, different-
+  ;; `after` reference must miss the cache.
+  (let [before {:a 1}
+        after1 {:a 2}
+        after2 {:a 3}
+        call-count (atom 0)
+        real-project engine/project]
+    (with-redefs [engine/project (fn [b a]
+                                   (swap! call-count inc)
+                                   (real-project b a))]
+      (let [inner (ei/edn-inspector after1 {:panel-id :rf.xray/app-db
+                                             :before   before})]
+        (inner after1 {:panel-id :rf.xray/app-db :before before})
+        (inner after2 {:panel-id :rf.xray/app-db :before before})
+        (is (= 2 @call-count)
+            "engine/project re-runs when `after` reference changes")))))
+
+(deftest projection-memo-is-per-mount-isolated
+  ;; The cache lives in the form-2 outer body closure → each mount gets
+  ;; its OWN cache. Two side-by-side mounts must not share entries,
+  ;; otherwise mount-A's projection could be served to mount-B with
+  ;; different inputs.
+  (let [before {:a 1}
+        after  {:a 2}
+        call-count (atom 0)
+        real-project engine/project]
+    (with-redefs [engine/project (fn [b a]
+                                   (swap! call-count inc)
+                                   (real-project b a))]
+      (let [inner1 (ei/edn-inspector after {:panel-id :rf.xray/app-db
+                                             :before   before})
+            inner2 (ei/edn-inspector after {:panel-id :rf.xray/app-db
+                                             :before   before})]
+        (inner1 after {:panel-id :rf.xray/app-db :before before})
+        (inner2 after {:panel-id :rf.xray/app-db :before before})
+        ;; Two distinct mounts → two cache misses, even with identity-
+        ;; stable inputs. The point of this test is the ABSENCE of
+        ;; cross-mount cache sharing; if both mounts shared, we'd see
+        ;; @call-count = 1 here.
+        (is (= 2 @call-count)
+            "each mount has its own projection cache (no cross-mount leak)")
+        ;; And within a single mount, second render is a cache hit.
+        (inner1 after {:panel-id :rf.xray/app-db :before before})
+        (is (= 2 @call-count)
+            "mount-1's second render hits its own cache")))))
+
+(deftest projection-not-invoked-outside-diff-mode
+  ;; Browse mode (no `:before` opt) must NOT touch `engine/project` at
+  ;; all — the projection is nil and the renderer's path-keyed lookups
+  ;; return `:same` for everything. This guards against accidentally
+  ;; warming the cache in non-diff renders.
+  (let [call-count (atom 0)
+        real-project engine/project]
+    (with-redefs [engine/project (fn [b a]
+                                   (swap! call-count inc)
+                                   (real-project b a))]
+      (let [inner (ei/edn-inspector {:a 1} {:panel-id :rf.xray/app-db})]
+        (inner {:a 1} {:panel-id :rf.xray/app-db})
+        (inner {:a 1} {:panel-id :rf.xray/app-db})
+        (is (= 0 @call-count)
+            "browse mode never calls engine/project")))))


### PR DESCRIPTION
Shape-2 cluster of two P1 (HIGH) memoisation wins from the rf2-gwm0y efficiency audit. Both load-bearing per the audit headline.

## Per-bead summary

### rf2-4p1vl — memoise `engine/project` across edn-inspector renders

The mode-3 diff path invoked `engine/project` on every render (expansion toggle / ResizeObserver / parent re-render), even when the `(before, after)` inputs were byte-identical. The full Editscript A* walk + per-leaf classification + container ancestors + R5/R6 walks ran from scratch each time. The flat-diff (`:diff` lens) path is already cached per-epoch at the sub level; mode-3 lost that property when the projection moved inside the widget.

**Fix:** per-mount projection cache captured in the form-2 outer body closure. Holds `{:before <ref> :after <ref> :projection <map>}` keyed by `identical?` on both refs.

### rf2-4spyl — short-circuit `f/display-value` on identity-stable inputs

`display-value` rebuilt the whole tree on every call, even when nothing needed eliding. Unstable output identity defeated downstream `identical?` short-circuits — including the projection memo above.

**Fix:** two-stage. (1) Pre-scan via `needs-elision?` — when no leaf needs eliding (the common case) return input AS-IS, preserving identity natively. (2) Slow path uses a module-level WeakMap cache keyed by input identity for inputs that DO need elision.

## Memoisation strategy

| Surface | Strategy | Lifetime |
|---|---|---|
| `engine/project` (rf2-4p1vl) | Per-mount atom in form-2 closure | Mount lifetime; freed by closure GC on unmount |
| `display-value` (rf2-4spyl) — fast path | Identity passthrough (no cache) | n/a — preserves input identity directly |
| `display-value` (rf2-4spyl) — slow path | Module-level JS WeakMap keyed by input identity | Auto-evicts when input is GC'd |

## Cache invalidation

- **rf2-4p1vl**: cache invalidates on the next render where either `before` or `after` is a different JS reference. Same-reference inputs hit; new epoch / new input misses and recomputes. No manual clear needed.
- **rf2-4spyl**: WeakMap auto-evicts when the keyed input is no longer reachable. No manual clear needed.

Both strategies are correct by construction — no stale-cache risk, no cross-frame leak, no cross-mount leak.

## Benchmark evidence

Tests instrument `engine/project` via `with-redefs` and count invocations across multiple inner-fn calls:

- `projection-memo-skips-recompute-on-identical-inputs` — 3 renders, identical inputs → **1 call**
- `projection-memo-recomputes-when-before-changes` — 2 renders, different `before` → **2 calls**
- `projection-memo-recomputes-when-after-changes` — 2 renders, different `after` → **2 calls**
- `projection-memo-is-per-mount-isolated` — 2 mounts × 1 render each → **2 calls** (no cross-mount sharing)
- `projection-not-invoked-outside-diff-mode` — browse mode → **0 calls**

For `display-value`:
- `display-value-preserves-identity-when-no-elision-needed` — 4 cases × `(identical? input output)` → all pass
- `display-value-caches-output-on-slow-path` — `(identical? out1 out2)` over repeated calls → pass
- `display-value-still-elides-large-strings` — semantic regression guard at every collection level → pass

## Quality gates

- `npm run test:cljs` — **PASS** (4811 tests / 15644 assertions / 0 failures)
- `npm run test:browser` — **PASS** (124 tests / 353 assertions / 0 failures)
- `npm run test:perf-bundle` — **PASS** (on=12 off=0; counter bundle 442749 chars)
- `npm run test:bundle-isolation` — **PASS** (all sentinels absent; allow-list budgets ok)
- `npm run test:xray-feature-gate:smoke` — **PASS** (3 scenarios / 10 matrix rows / 0 failures)
- `npm run test:examples` — env-level failure (EACCES port 8030 — local sandbox port-binding restriction, not a code regression)

## Files touched

- `tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs` — projection memo in form-2 closure
- `tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_format.cljs` — `display-value` pre-scan + WeakMap cache
- `tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs` — 5 new tests with `engine/project` spy
- `tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_format_cljs_test.cljs` — 3 new tests for identity-preserving display-value

Closes rf2-4p1vl + rf2-4spyl.