### PR TITLE
refactor(xray): adopt diff-mode-toggle helper + normalise 4-surface naming (rf2-0cyjm + rf2-44xya)

### DIFF
--- a/tools/xray/spec/007-UX-IA.md
+++ b/tools/xray/spec/007-UX-IA.md
@@ -1644,7 +1644,7 @@ history + spine focus:
 
 | Panel | Reads (subs) | Writes (dispatches) |
 |---|---|---|
-| **epoch-panel**    | `:rf.xray/focus` · `:rf.xray/epoch-history` (via `panels.shared.focus-resolver`) | `:rf.xray.epoch/toggle-row-expand` · `:rf.xray.epoch/set-subs-filter-mode` · `:rf.xray.epoch/set-db-view-mode` |
+| **epoch-panel**    | `:rf.xray/focus` · `:rf.xray/epoch-history` (via `panels.shared.focus-resolver`) | `:rf.xray.epoch/toggle-row-expand` · `:rf.xray.epoch/set-subs-filter-mode` · `:rf.xray.epoch/set-db-diff-mode` |
 | **app-db-diff**    | `:rf.xray/app-db-diff` (composite) | `:rf.xray/focus-slice-path` · `:rf.xray/open-segment-inspector` |
 | **views**          | `:rf.xray/views-focused-cascade-pair` · `:rf.xray/views-sub-diff` | view-row toggles · sub-diff selection |
 | **trace**          | `:rf.xray/trace-feed` (incremental projection) | `:rf.xray/select-dispatch-id` · `:rf.xray/open-in-editor` |

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1503,7 +1503,7 @@ The HANDLER step's `:db` sub-section carries a three-button toggle:
 
 **Default**: `:full+diff` (Mike pair-debug 2026-05-27 — the operator's
 most-useful default; shape + delta in one read). Mode persists via
-`:rf.xray.epoch/db-view-mode` so the operator's preference survives
+`:rf.xray.epoch/db-diff-mode` so the operator's preference survives
 focus shifts.
 
 > **Migration**: the prior two-button `[diff][all]` toggle was retired
@@ -1583,12 +1583,17 @@ regardless of panel.
 
 **Affected surfaces** (post-rf2-yqjrd):
 
-| Surface                           | Mode slot                              | Default |
-|-----------------------------------|----------------------------------------|---------|
-| Epoch HANDLER step `:db`          | `:rf.xray.epoch/db-view-mode`          | `:full+diff` |
-| App-DB panel (panel-wide)         | `:rf.xray.app-db/view-mode`            | `:full+diff` |
-| Machine Inspector snapshot drill-in | `:rf.xray.machine-inspector/view-mode` | `:full+diff` |
-| Epoch SUBSCRIPTIONS step value cells | `:rf.xray.epoch/subs-value-mode`     | `:full+diff` |
+| Surface                           | Sub                                       | Set event                                       | Default |
+|-----------------------------------|-------------------------------------------|-------------------------------------------------|---------|
+| Epoch HANDLER step `:db`          | `:rf.xray.epoch/db-diff-mode`             | `:rf.xray.epoch/set-db-diff-mode`               | `:full+diff` |
+| App-DB panel (panel-wide)         | `:rf.xray.app-db/diff-mode`               | `:rf.xray.app-db/set-diff-mode`                 | `:full+diff` |
+| Machine Inspector snapshot drill-in | `:rf.xray.machine-inspector/diff-mode`  | `:rf.xray.machine-inspector/set-diff-mode`      | `:full+diff` |
+| Epoch SUBSCRIPTIONS step value cells | `:rf.xray.epoch/subs-value-diff-mode`  | `:rf.xray.epoch/set-subs-value-diff-mode`       | `:full+diff` |
+
+All four surfaces install their sub + event pair via the shared
+`day8.re-frame2-xray.views.diff-mode-toggle/reg-mode-sub+event!`
+helper (rf2-0cyjm / rf2-44xya) — one call per surface, identical
+naming convention enforced at the source.
 
 Per-surface mode behaviour follows the same vocabulary as §9.1.5.1's
 HANDLER `:db`:

--- a/tools/xray/src/day8/re_frame2_xray/panels.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels.cljs
@@ -68,7 +68,7 @@
 
   | Panel | Reads | Writes (via dispatch) |
   |---|---|---|
-  | **epoch-panel** | `:rf.xray/focus` · `:rf.xray/epoch-history` (via `panels.shared.focus-resolver`) | `:rf.xray.epoch/toggle-row-expand` · `:rf.xray.epoch/set-subs-filter-mode` · `:rf.xray.epoch/set-db-view-mode` |
+  | **epoch-panel** | `:rf.xray/focus` · `:rf.xray/epoch-history` (via `panels.shared.focus-resolver`) | `:rf.xray.epoch/toggle-row-expand` · `:rf.xray.epoch/set-subs-filter-mode` · `:rf.xray.epoch/set-db-diff-mode` |
   | **app-db (current-state inspector)** | `:rf.xray/app-db-state` (current-state section model over the observed frame's live app-db, sectioned by reserved `:rf/*` area — rf2-okvit) | `:rf.xray/open-segment-inspector` |
   | **reactive-panel** | `:rf.xray/reactive-data` (composite over focused cascade's `:trace-events`) | `:rf.xray/reactive-toggle-unchanged` |
   | **trace** | `:rf.xray/trace-feed` (epoch-scoped — projects the focused epoch's `:trace-events` into the whole-epoch arc: envelope + 4 phase bands, spec/023) | `:rf.xray/toggle-trace-row-expand` · `:rf.xray/toggle-trace-band-collapse` · `:rf.xray/open-in-editor` |

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff.cljs
@@ -67,10 +67,10 @@
                    focused epoch's `:db-before` threaded so inline
                    diff annotations paint (default; mode-3).
 
-  Mode persists in `:rf.xray.app-db/view-mode` on Xray's app-db so the
+  Mode persists in `:rf.xray.app-db/diff-mode` on Xray's app-db so the
   operator's preference survives focus shifts."
   []
-  (let [mode          @(rf/subscribe [:rf.xray.app-db/view-mode])
+  (let [mode          @(rf/subscribe [:rf.xray.app-db/diff-mode])
         section-model @(rf/subscribe [:rf.xray/app-db-state])
         diff-triples  @(rf/subscribe [:rf.xray/selected-epoch-diff])]
     [:section {:data-testid "rf-xray-app-db-diff"
@@ -103,7 +103,7 @@
         :testid "rf-xray-app-db-view-mode"
         :on-change (fn [m]
                      (rf/with-frame :rf/xray
-                       (rf/dispatch [:rf.xray.app-db/set-view-mode m])))}]]
+                       (rf/dispatch [:rf.xray.app-db/set-diff-mode m])))}]]
      ;; rf2-6xezz — the L4 tab strip is the panel-name source-of-truth;
      ;; content starts immediately under the tab bar.
      [:div {:style {:flex 1 :overflow "auto"}}

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_events.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_events.cljs
@@ -8,7 +8,8 @@
   pinned-watches strip was superseded by the path-segment inspector
   popup (Mike 2026-05-19 Q13). The matching `pin-path` / `unpin-path`
   / `reorder-paths` helpers were pulled in lockstep."
-  (:require [re-frame.core :as rf]))
+  (:require [day8.re-frame2-xray.views.diff-mode-toggle :as diff-mode]
+            [re-frame.core :as rf]))
 
 (defn install!
   "Install the App-DB Diff events and effects."
@@ -21,7 +22,7 @@
     (fn [db _event]
       (dissoc db :focused-slice-path)))
 
-  ;; ---- App-DB panel view-mode toggle (rf2-yqjrd) ----
+  ;; ---- App-DB panel diff-mode toggle (rf2-yqjrd / rf2-0cyjm) ----
   ;;
   ;; Three-mode toggle `[diff][full][full+diff]` that drives every section
   ;; (top + per-`:rf/*` area) in the App-DB panel. Per pair-debug
@@ -41,15 +42,11 @@
   ;;                  the operator's most-useful default; shape + delta
   ;;                  together.
   ;;
-  ;; Mode persists via `:rf.xray.app-db/view-mode` so the operator's
-  ;; preference survives focus shifts.
-  (rf/reg-sub :rf.xray.app-db/view-mode
-    (fn [db _query]
-      (get db :app-db-panel-view-mode :full+diff)))
-
-  (rf/reg-event-db :rf.xray.app-db/set-view-mode
-    (fn [db [_ mode]]
-      (assoc db :app-db-panel-view-mode mode)))
+  ;; Mode persists via `:rf.xray.app-db/diff-mode` so the operator's
+  ;; preference survives focus shifts. The sub + event pair + slot are
+  ;; installed by the shared helper from `views.diff-mode-toggle` so
+  ;; every Xray diff surface uses identical naming.
+  (diff-mode/reg-mode-sub+event! :rf.xray.app-db)
 
   (rf/reg-fx :rf.xray.fx/copy-to-clipboard
     (fn [_ctx {:keys [text]}]

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -611,7 +611,7 @@
    :color        text-tertiary-colour
    :padding-left "16px"})
 
-;; -- db-view-mode toggle / db-diff ----------------------------------------
+;; -- db-diff-mode toggle / db-diff ----------------------------------------
 
 (def ^:private mode-toggle-bar-style
   {:display       "inline-flex"
@@ -2221,7 +2221,7 @@
                :style handler-source-placeholder-style}
         "<source not yet captured>"])]))
 
-(defn- db-view-mode-toggle
+(defn- db-diff-mode-toggle
   "Thin wrapper around the shared `views.diff-mode-toggle/diff-mode-toggle`
   widget (rf2-yqjrd extraction of the rf2-n2jig toggle). The button-bar
   chrome + per-mode labels + R1-R8 grammar default mode (`:full+diff`)
@@ -2240,7 +2240,7 @@
     :testid    "rf-xray-epoch-handler-db-view-mode"
     :on-change (fn [m]
                  (rf/with-frame :rf/xray
-                   (rf/dispatch [:rf.xray.epoch/set-db-view-mode m])))}])
+                   (rf/dispatch [:rf.xray.epoch/set-db-diff-mode m])))}])
 
 (defn- handler-db-diff-block
   "Render the HANDLER step's `:db` sub-section (rf2-93436 / design
@@ -2264,7 +2264,7 @@
     rules per the findings doc `diff-mode-3-key-and-triangle-
     grammar-2026-05-27.md` §5.1 (revised per §7).
 
-  Mode persists via `:rf.xray.epoch/db-view-mode` so the operator's
+  Mode persists via `:rf.xray.epoch/db-diff-mode` so the operator's
   preference survives focus shifts.
 
   Distinct from the (retired) top-level APP-DB DIFF step (rf2-rrykz)
@@ -2276,7 +2276,7 @@
   slot folds into SNAPSHOT DIFF rather than carrying a redundant
   standalone slot."
   [db-diff]
-  (let [mode      @(rf/subscribe [:rf.xray.epoch/db-view-mode])
+  (let [mode      @(rf/subscribe [:rf.xray.epoch/db-diff-mode])
         empty?    (not (seq db-diff))
         n         (count db-diff)
         diff-summary (cond
@@ -2285,11 +2285,11 @@
                        :else  (str n " path" (when (not= 1 n) "s")))]
     [:div {:data-testid "rf-xray-epoch-handler-db-diff"
            :data-empty (str empty?)
-           :data-db-view-mode (name mode)}
+           :data-db-diff-mode (name mode)}
      (sub-header ":db"
                  [:span {:style inline-flex-center-style}
                   (when diff-summary diff-summary)
-                  (db-view-mode-toggle mode)])
+                  (db-diff-mode-toggle mode)])
      (case mode
        :diff
        (when-not empty?
@@ -2622,7 +2622,7 @@
   "Render the `changed` cell for one sub recomputation row using the
   universal three-mode toggle (rf2-yqjrd).
 
-  `mode` is the panel-wide `:rf.xray.epoch/subs-value-mode` keyword:
+  `mode` is the panel-wide `:rf.xray.epoch/subs-value-diff-mode` keyword:
 
   - `:diff`      — `✓ before → after` row (the prior shape; surfaces
                    only the value pair via `mini`).
@@ -2676,10 +2676,10 @@
 
   rf2-yqjrd — the `changed` cell now routes through `subs-value-cell`
   so the universal three-mode toggle drives value rendering. `mode`
-  carries the resolved `:rf.xray.epoch/subs-value-mode` keyword."
+  carries the resolved `:rf.xray.epoch/subs-value-diff-mode` keyword."
   [rows mode]
   [:div {:data-testid "rf-xray-epoch-subscriptions-table"
-         :data-subs-value-mode (when (keyword? mode) (name mode))
+         :data-subs-value-diff-mode (when (keyword? mode) (name mode))
          :style subscriptions-table-style}
    ;; header
    [:div {:style table-header-row-style}
@@ -2790,7 +2790,7 @@
   (let [mode          @(rf/subscribe :rf/xray
                                      [:rf.xray.epoch/subs-filter-mode])
         value-mode    @(rf/subscribe :rf/xray
-                                     [:rf.xray.epoch/subs-value-mode])
+                                     [:rf.xray.epoch/subs-value-diff-mode])
         visible-rows  (case mode
                         :all       rows
                         :unchanged (filterv (complement :changed?) rows)
@@ -2827,7 +2827,7 @@
                    :on-change (fn [m]
                                 (rf/with-frame :rf/xray
                                   (rf/dispatch
-                                    [:rf.xray.epoch/set-subs-value-mode m])))}])
+                                    [:rf.xray.epoch/set-subs-value-diff-mode m])))}])
                (when (pos? l)
                  [:span {:style subs-disposed-count-style}
                   (str l " disposed")])]

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch_panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch_panel.cljs
@@ -46,7 +46,8 @@
             [day8.re-frame2-xray.panel-registry :as panel-registry]
             [day8.re-frame2-xray.panels.epoch.projection :as proj]
             [day8.re-frame2-xray.panels.epoch.view :as view]
-            [day8.re-frame2-xray.panels.shared.focus-resolver :as focus]))
+            [day8.re-frame2-xray.panels.shared.focus-resolver :as focus]
+            [day8.re-frame2-xray.views.diff-mode-toggle :as diff-mode]))
 
 ;; ---- public Panel surface ------------------------------------------------
 
@@ -164,7 +165,7 @@
     (fn [db [_ mode]]
       (assoc db :epoch-panel-subs-filter-mode mode)))
 
-  ;; ---- HANDLER :db view-mode toggle (pair-debug 2026-05-26 + rf2-n2jig 2026-05-27) ----
+  ;; ---- HANDLER :db diff-mode toggle (pair-debug 2026-05-26 + rf2-n2jig 2026-05-27) ----
   ;;
   ;; The HANDLER step's `:db` sub-section carries a three-button toggle
   ;; `[diff][full][full+diff]` (per rf2-n2jig — was a two-button
@@ -188,32 +189,21 @@
   ;;                  2026-05-27: this is the operator's most-useful
   ;;                  default — shape + delta in one read.
   ;;
-  ;; Mode persists via `:rf.xray.epoch/db-view-mode` so the operator's
-  ;; preference survives focus shifts.
+  ;; Mode persists via `:rf.xray.epoch/db-diff-mode` so the operator's
+  ;; preference survives focus shifts. The sub + event pair + slot are
+  ;; installed by the shared helper from `views.diff-mode-toggle` so
+  ;; every Xray diff surface uses identical naming (rf2-0cyjm /
+  ;; rf2-44xya).
 
-  (rf/reg-sub :rf.xray.epoch/db-view-mode
-    (fn [db _query]
-      ;; rf2-n2jig — default flipped from `:diff` to `:full+diff` per
-      ;; pair-debug 2026-05-27. Mode-3 carries the most operator-
-      ;; useful signal (shape + delta together).
-      (let [mode (get db :epoch-panel-db-view-mode :full+diff)]
-        ;; Migrate the legacy `:all` enum value to `:full` for any
-        ;; persisted-app-db reads from a pre-rf2-n2jig session.
-        (case mode
-          :all      :full
-          mode))))
+  (diff-mode/reg-mode-sub+event! :rf.xray.epoch/db)
 
-  (rf/reg-event-db :rf.xray.epoch/set-db-view-mode
-    (fn [db [_ mode]]
-      (assoc db :epoch-panel-db-view-mode mode)))
-
-  ;; ---- SUBSCRIPTIONS value view-mode toggle (rf2-yqjrd) ------------
+  ;; ---- SUBSCRIPTIONS value diff-mode toggle (rf2-yqjrd / rf2-0cyjm) ----
   ;;
   ;; Universal three-mode toggle for the per-row sub-value rendering in
   ;; the SUBSCRIPTIONS step. Orthogonal to the existing
   ;; `:rf.xray.epoch/subs-filter-mode` row-filter (`:all` / `:changed` /
-  ;; `:unchanged`) — the filter governs WHICH rows render; this view-
-  ;; mode governs HOW each `:changed?` row's value cell renders.
+  ;; `:unchanged`) — the filter governs WHICH rows render; this
+  ;; diff-mode governs HOW each `:changed?` row's value cell renders.
   ;;
   ;; - `:diff`      — pure-diff lens: `before → after` glyph row (the
   ;;                  prior shape; surfaces only the value pair).
@@ -225,15 +215,10 @@
   ;;                  annotations paint. Default per pair-debug
   ;;                  2026-05-27.
   ;;
-  ;; Mode persists via `:rf.xray.epoch/subs-value-mode` so the
-  ;; operator's preference survives focus shifts.
-  (rf/reg-sub :rf.xray.epoch/subs-value-mode
-    (fn [db _query]
-      (get db :epoch-panel-subs-value-mode :full+diff)))
-
-  (rf/reg-event-db :rf.xray.epoch/set-subs-value-mode
-    (fn [db [_ mode]]
-      (assoc db :epoch-panel-subs-value-mode mode)))
+  ;; Mode persists via `:rf.xray.epoch/subs-value-diff-mode`; sub +
+  ;; event installed via the shared helper for uniform naming
+  ;; (rf2-0cyjm / rf2-44xya).
+  (diff-mode/reg-mode-sub+event! :rf.xray.epoch/subs-value)
 
   ;; ---- L4 tab registration ----------------------------------------------
   ;;

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
@@ -607,7 +607,7 @@
     :testid    "rf-xray-machine-snapshot-view-mode"
     :on-change (fn [m]
                  (rf/with-frame :rf/xray
-                   (rf/dispatch [:rf.xray.machine-inspector/set-view-mode m])))}])
+                   (rf/dispatch [:rf.xray.machine-inspector/set-diff-mode m])))}])
 
 (defn- snapshot-drill-in
   "Snapshot drill-in section beneath the focused-event chart. Renders
@@ -636,7 +636,7 @@
   [{:keys [machine-id before after]}]
   (when (or (some? before) (some? after))
     (let [mode @(rf/subscribe :rf/xray
-                              [:rf.xray.machine-inspector/view-mode])]
+                              [:rf.xray.machine-inspector/diff-mode])]
       [:section
        {:data-testid     "rf-xray-machine-snapshot-drill-in"
         :data-machine-id (str machine-id)
@@ -1194,19 +1194,16 @@
   `static.machines.sim` — installed via
   `static.machines.panel/install!` further down the registry."
   []
-  ;; ---- Machine Inspector snapshot view-mode toggle (rf2-yqjrd) -----
+  ;; ---- Machine Inspector snapshot diff-mode toggle (rf2-yqjrd / rf2-0cyjm) -----
   ;;
   ;; Universal three-mode toggle for the snapshot drill-in section.
   ;; Replaces the prior Before/After side-by-side grid — one mount,
   ;; one toggle, same R1-R8 grammar every other Xray diff surface
-  ;; uses (rf2-n2jig).
-  (rf/reg-sub :rf.xray.machine-inspector/view-mode
-    (fn [db _query]
-      (get db :machine-inspector-view-mode :full+diff)))
-
-  (rf/reg-event-db :rf.xray.machine-inspector/set-view-mode
-    (fn [db [_ mode]]
-      (assoc db :machine-inspector-view-mode mode)))
+  ;; uses (rf2-n2jig). Sub `:rf.xray.machine-inspector/diff-mode` +
+  ;; event `:rf.xray.machine-inspector/set-diff-mode` + slot are
+  ;; installed by the shared helper from `views.diff-mode-toggle` so
+  ;; every Xray diff surface uses identical naming.
+  (diff-mode/reg-mode-sub+event! :rf.xray.machine-inspector)
 
   ;; Registered-machine vector (reads `(rf/machines)`).
   (rf/reg-sub :rf.xray/registered-machines

--- a/tools/xray/src/day8/re_frame2_xray/views/diff_mode_toggle.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/diff_mode_toggle.cljs
@@ -51,15 +51,20 @@
 
   ## Per-surface storage convention
 
-  Each surface registers its own sub + event for the mode keyword:
+  Each surface registers its own sub + event for the mode keyword
+  via the `reg-mode-sub+event!` helper (one call per surface):
 
+      ;; top-level surfaces — surface-id is an unqualified keyword
       :rf.xray.<surface>/diff-mode        ;; sub returning the keyword
       :rf.xray.<surface>/set-diff-mode    ;; event-db setting the keyword
 
-  Existing per-surface persistence (e.g. the Epoch panel's
-  `:epoch-panel-db-view-mode` slot) is preserved verbatim — this
-  widget is the chrome, not the storage. See `reg-mode-sub+event!`
-  below for a one-call helper that installs the standard pair.
+      ;; sub-surfaces — surface-id is a namespaced keyword
+      :rf.xray.<surface-ns>/<sub>-diff-mode      ;; sub
+      :rf.xray.<surface-ns>/set-<sub>-diff-mode  ;; event-db
+
+  Mode is stored at the sub-id key in Xray's app-db (one slot per
+  surface, no cross-surface collisions). See `reg-mode-sub+event!`
+  below for the one-call helper that installs the standard pair.
 
   ## Frame-anchor pattern (rf2-p56sk / rf2-7sdja)
 
@@ -188,7 +193,7 @@
                     omit a mode (rare; mode-3 is the canonical full
                     bar) pass a subset.
 
-  rf2-yqjrd — extracted from `panels.epoch.view/db-view-mode-toggle`
+  rf2-yqjrd — extracted from `panels.epoch.view/db-diff-mode-toggle`
   (rf2-n2jig) so every Xray surface consumes the same chrome verbatim."
   [{:keys [mode on-change testid modes]
     :or   {modes default-modes}}]
@@ -216,27 +221,41 @@
   "Register the canonical sub + event pair for a per-surface diff
   mode. Idempotent across hot-reload (re-registering replaces).
 
-  `surface-id` is a namespaced keyword like `:rf.xray.app-db` or
-  `:rf.xray.machine-inspector`. The fn registers:
+  `surface-id` is a keyword. Two shapes are supported:
 
-      <surface-id>/diff-mode       ;; sub returning the keyword (default
-                                   ;; mode `:full+diff`)
-      <surface-id>/set-diff-mode   ;; event-db setting the keyword
+  - Top-level surface — a plain (unqualified) keyword whose `name`
+    is itself a dotted namespace, e.g. `:rf.xray.app-db` or
+    `:rf.xray.machine-inspector`. Registers:
 
-  The mode is stored under a derived slot keyword
-  `<surface-namespace>/<surface-name>-diff-mode` so two surfaces'
-  modes don't collide.
+        :rf.xray.<surface>/diff-mode       ;; sub
+        :rf.xray.<surface>/set-diff-mode   ;; event-db
+
+  - Sub-surface — a namespaced keyword, e.g. `:rf.xray.epoch/db` or
+    `:rf.xray.epoch/subs-value`. Registers:
+
+        :rf.xray.<surface-ns>/<sub>-diff-mode     ;; sub
+        :rf.xray.<surface-ns>/set-<sub>-diff-mode ;; event-db
+
+  The mode is stored under the sub-id keyword in Xray's app-db (one
+  slot per surface; no cross-surface collisions). Returns
+  `{:sub-id … :event-id … :slot …}` so callers can introspect the
+  canonical names.
 
   Mode persists in Xray's app-db so the operator's preference survives
-  focus shifts (rf2-n2jig). Use `:reset` opt-out for transient surfaces."
+  focus shifts (rf2-n2jig). The `:default-mode` opt overrides the
+  widget's `:full+diff` default for surfaces where a different starting
+  lens makes more sense."
   [surface-id & [{:keys [default-mode]
                   :or   {default-mode default-default-mode}}]]
-  (let [sub-id   (keyword (namespace surface-id)
-                          (str (name surface-id) "/diff-mode"))
-        event-id (keyword (namespace surface-id)
-                          (str "set-" (name surface-id) "-diff-mode"))
-        slot     (keyword (namespace surface-id)
-                          (str (name surface-id) "-diff-mode"))]
+  (let [ns-part  (namespace surface-id)
+        nm-part  (name surface-id)
+        sub-id   (if ns-part
+                   (keyword ns-part (str nm-part "-diff-mode"))
+                   (keyword nm-part "diff-mode"))
+        event-id (if ns-part
+                   (keyword ns-part (str "set-" nm-part "-diff-mode"))
+                   (keyword nm-part "set-diff-mode"))
+        slot     sub-id]
     (rf/reg-sub sub-id
       (fn [db _]
         (get db slot default-mode)))

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -380,7 +380,7 @@
     (epoch-orchestrator/install!)
     (frame/reg-frame :rf/xray {})
     (rf/with-frame :rf/xray
-      (rf/dispatch-sync [:rf.xray.epoch/set-db-view-mode :diff]))
+      (rf/dispatch-sync [:rf.xray.epoch/set-db-diff-mode :diff]))
     (testing "reg-event-db with empty diff"
       (let [tree (rf/with-frame :rf/xray
                    (view/render-handler-step
@@ -1129,7 +1129,7 @@
     (epoch-orchestrator/install!)
     (frame/reg-frame :rf/xray {})
     (rf/with-frame :rf/xray
-      (rf/dispatch-sync [:rf.xray.epoch/set-db-view-mode :diff]))
+      (rf/dispatch-sync [:rf.xray.epoch/set-db-diff-mode :diff]))
     (let [tree (rf/with-frame :rf/xray
                  (view/render-handler-step
                    {:step :handler :badge :HANDLER :step-number 3
@@ -1179,7 +1179,7 @@
       ;; rf2-yqjrd — flip the value-mode to `:diff` so the per-row
       ;; cell renders via `mini` instead of the new edn-inspector
       ;; mount that `:full+diff` (default) uses.
-      (rf/dispatch-sync [:rf.xray.epoch/set-subs-value-mode :diff])
+      (rf/dispatch-sync [:rf.xray.epoch/set-subs-value-diff-mode :diff])
       (let [step {:step :subscriptions :badge :SUBSCRIPTIONS :step-number 5
                   :rows [{:sub-id :counter/total :sub-vec [:counter/total]
                           :inputs nil :changed? true :before 5 :after 6}]
@@ -1230,7 +1230,7 @@
 ;; pipeline's `(for [[i step] …] …)` MUST be realised inside
 ;; `pipeline-view`'s return value so that any `@(rf/subscribe …)` deref
 ;; reached transitively by `render-step` (e.g. `handler-db-diff-block`'s
-;; `:rf.xray.epoch/db-view-mode` read, or `render-subscriptions-step`'s
+;; `:rf.xray.epoch/db-diff-mode` read, or `render-subscriptions-step`'s
 ;; `:rf.xray.epoch/subs-filter-mode` read — rf2-tzmmf) fires while the
 ;; parent reg-view's reactive scope is still live. A lazy seq realised
 ;; AFTER the reg-view returns
@@ -1274,7 +1274,7 @@
 (deftest pipeline-view-realises-step-seq-rf2-atqkg-test
   (testing "rf2-atqkg — `pipeline-view` returns its step-seq REALISED
             so descendant sub derefs (e.g. handler-db-diff-block's
-            `:rf.xray.epoch/db-view-mode` read) fire during the parent
+            `:rf.xray.epoch/db-diff-mode` read) fire during the parent
             reg-view's reactive scope. An unrealised lazy seq at this
             position is the rf2-atqkg bug shape (Reagent emits the
             `Reactive deref not supported in lazy seq, it should be

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -166,18 +166,22 @@
    ;; (`[all][changed][unchanged]` button-bar; supersedes
    ;; rf2-kfh1v's boolean `subs-show-unchanged?`).
    :rf.xray.epoch/subs-filter-mode
-   ;; pair-debug 2026-05-26 (ee9def224) — HANDLER `:db` `[diff][all]`
-   ;; toggle slot. Persists the operator's preferred view-mode for
-   ;; the HANDLER step's `:db` sub-section. Defaults to `:diff`.
-   :rf.xray.epoch/db-view-mode
-   ;; rf2-yqjrd — SUBSCRIPTIONS value-mode toggle. Orthogonal to the
-   ;; row-filter `:subs-filter-mode`; governs how each `:changed?`
-   ;; row's value cell renders (`:diff` / `:full` / `:full+diff`).
-   :rf.xray.epoch/subs-value-mode
-   ;; rf2-yqjrd — App-DB panel universal view-mode toggle slot.
-   :rf.xray.app-db/view-mode
-   ;; rf2-yqjrd — Machine Inspector snapshot view-mode toggle slot.
-   :rf.xray.machine-inspector/view-mode
+   ;; pair-debug 2026-05-26 (ee9def224) + rf2-0cyjm 2026-05-27 — HANDLER
+   ;; `:db` three-mode toggle sub. Persists the operator's preferred
+   ;; diff-mode for the HANDLER step's `:db` sub-section. Installed via
+   ;; the shared `views.diff-mode-toggle/reg-mode-sub+event!` helper.
+   :rf.xray.epoch/db-diff-mode
+   ;; rf2-yqjrd / rf2-0cyjm — SUBSCRIPTIONS value-cell diff-mode toggle.
+   ;; Orthogonal to the row-filter `:subs-filter-mode`; governs how each
+   ;; `:changed?` row's value cell renders (`:diff` / `:full` /
+   ;; `:full+diff`). Installed via the shared helper.
+   :rf.xray.epoch/subs-value-diff-mode
+   ;; rf2-yqjrd / rf2-0cyjm — App-DB panel universal diff-mode toggle
+   ;; sub. Installed via the shared helper.
+   :rf.xray.app-db/diff-mode
+   ;; rf2-yqjrd / rf2-0cyjm — Machine Inspector snapshot diff-mode
+   ;; toggle sub. Installed via the shared helper.
+   :rf.xray.machine-inspector/diff-mode
    :rf.xray/event-detail
    :rf.xray/filtered-cascades
    ;; rf2-jvghz — model behind the L2 'N hidden by filters' indicator
@@ -478,16 +482,18 @@
    ;; (`[all][changed][unchanged]` button-bar; supersedes
    ;; rf2-kfh1v's `toggle-subs-show-unchanged`).
    :rf.xray.epoch/set-subs-filter-mode
-   ;; pair-debug 2026-05-26 (ee9def224) — HANDLER `:db` `[diff][all]`
-   ;; toggle write event. Sets the persisted view-mode slot the
-   ;; `:rf.xray.epoch/db-view-mode` sub reads.
-   :rf.xray.epoch/set-db-view-mode
-   ;; rf2-yqjrd — universal three-mode toggle write events. Each
-   ;; surface registers its own pair so per-surface mode persistence
-   ;; stays isolated.
-   :rf.xray.epoch/set-subs-value-mode
-   :rf.xray.app-db/set-view-mode
-   :rf.xray.machine-inspector/set-view-mode
+   ;; pair-debug 2026-05-26 (ee9def224) + rf2-0cyjm 2026-05-27 — HANDLER
+   ;; `:db` three-mode toggle write event. Sets the persisted diff-mode
+   ;; slot the `:rf.xray.epoch/db-diff-mode` sub reads. Installed via
+   ;; the shared `views.diff-mode-toggle/reg-mode-sub+event!` helper.
+   :rf.xray.epoch/set-db-diff-mode
+   ;; rf2-yqjrd / rf2-0cyjm — universal three-mode toggle write events.
+   ;; Each surface registers its own pair so per-surface mode
+   ;; persistence stays isolated; all four installed via the shared
+   ;; helper for uniform naming.
+   :rf.xray.epoch/set-subs-value-diff-mode
+   :rf.xray.app-db/set-diff-mode
+   :rf.xray.machine-inspector/set-diff-mode
    :rf.xray/epoch-recorded
    ;; rf2-piye4 — typed-predicate filter events. Each appends a
    ;; typed `{:kind <kw> :params {…}}` IN pill from a right-click

--- a/tools/xray/testbeds/panel_gallery/gallery_diff_mode_universal.cljs
+++ b/tools/xray/testbeds/panel_gallery/gallery_diff_mode_universal.cljs
@@ -85,7 +85,7 @@
                   LIVE current-state with NO `:before` threaded —
                   plain browse, no diff chrome. Useful when the
                   operator wants to inspect shape alone."
-     :events     [[:rf.xray.app-db/set-view-mode :full]]
+     :events     [[:rf.xray.app-db/set-diff-mode :full]]
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
 
@@ -95,7 +95,7 @@
                   the top. Same source as the Epoch HANDLER `:diff`
                   view + the MCP exporter (`:rf.xray/selected-epoch-
                   diff` triples)."
-     :events     [[:rf.xray.app-db/set-view-mode :diff]]
+     :events     [[:rf.xray.app-db/set-diff-mode :diff]]
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
 
@@ -122,7 +122,7 @@
     {:doc        "Machine Inspector snapshot in `:full` mode. AFTER
                   snapshot alone, no BEFORE comparison — plain
                   browse of the post-transition state."
-     :events     [[:rf.xray.machine-inspector/set-view-mode :full]]
+     :events     [[:rf.xray.machine-inspector/set-diff-mode :full]]
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
 
@@ -130,13 +130,13 @@
     {:doc        "Machine Inspector snapshot in `:diff` mode. Flat
                   path-prefixed change list — same shape as App-DB
                   and Epoch HANDLER `:diff` lenses."
-     :events     [[:rf.xray.machine-inspector/set-view-mode :diff]]
+     :events     [[:rf.xray.machine-inspector/set-diff-mode :diff]]
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
 
   ;; -- SUBSCRIPTIONS step value-cell ---------------------------------------
 
-  (story/reg-story :story.xray.epoch/subs-value-mode
+  (story/reg-story :story.xray.epoch/subs-value-diff-mode
     {:doc        "Epoch SUBSCRIPTIONS step — per-row value cell
                   routed through the universal three-mode toggle.
                   Orthogonal to the existing `[all][changed]
@@ -159,7 +159,7 @@
                   `:changed?` row's value cell renders the AFTER
                   value alone via the edn-inspector — no BEFORE
                   comparison."
-     :events     [[:rf.xray.epoch/set-subs-value-mode :full]]
+     :events     [[:rf.xray.epoch/set-subs-value-diff-mode :full]]
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
 
@@ -169,7 +169,7 @@
                   `mini` widget. Preserved as one mode of the new
                   toggle so the prior compact rendering remains
                   available."
-     :events     [[:rf.xray.epoch/set-subs-value-mode :diff]]
+     :events     [[:rf.xray.epoch/set-subs-value-diff-mode :diff]]
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
 


### PR DESCRIPTION
Combined fix for the two interlocking elegance/structural findings from
the rf2-gpuv3 audit (H1 + H2). The helper adoption IS the convention-
enforcing structural fix — adopting `reg-mode-sub+event!` at all four
install sites collapses each hand-rolled `reg-sub` + `reg-event-db`
pair to one line AND eliminates the 4-different-names drift in a
single move.

## rf2-0cyjm (H2) — helper adopted at four install sites

`views/diff_mode_toggle/reg-mode-sub+event!` previously had **zero
callers** (verified via grep — only docstring mention + the defn
itself). The helper''s prior `(keyword (namespace surface-id) (str
(name surface-id) "/diff-mode"))` form would have produced invalid
keywords (slash inside name), so both correcting + adopting were
required in lockstep — Option A per the bead''s preferred pre-alpha
posture.

The reworked helper accepts surface-id in two shapes:

- Top-level surface (plain keyword like `:rf.xray.app-db`):
    - sub      `:rf.xray.app-db/diff-mode`
    - event    `:rf.xray.app-db/set-diff-mode`
- Sub-surface (namespaced keyword like `:rf.xray.epoch/db`):
    - sub      `:rf.xray.epoch/db-diff-mode`
    - event    `:rf.xray.epoch/set-db-diff-mode`

Mode is stored at the sub-id keyword in Xray app-db (one slot per
surface; no cross-surface collisions). Each call returns
`{:sub-id … :event-id … :slot …}` for introspection.

The four install sites — `app_db_diff_events.cljs`,
`machine_inspector.cljs`, and the two in `epoch_panel.cljs` — now
delegate via one-line calls:

```clojure
(diff-mode/reg-mode-sub+event! :rf.xray.app-db)
(diff-mode/reg-mode-sub+event! :rf.xray.machine-inspector)
(diff-mode/reg-mode-sub+event! :rf.xray.epoch/db)
(diff-mode/reg-mode-sub+event! :rf.xray.epoch/subs-value)
```

## rf2-44xya (H1) — keyword naming normalised

Before/after surface inventory:

| Surface | Before sub | After sub | Before event | After event |
|---|---|---|---|---|
| App-DB                 | `:rf.xray.app-db/view-mode`            | `:rf.xray.app-db/diff-mode`            | `:rf.xray.app-db/set-view-mode`            | `:rf.xray.app-db/set-diff-mode`            |
| Machine Inspector      | `:rf.xray.machine-inspector/view-mode` | `:rf.xray.machine-inspector/diff-mode` | `:rf.xray.machine-inspector/set-view-mode` | `:rf.xray.machine-inspector/set-diff-mode` |
| Epoch HANDLER `:db`    | `:rf.xray.epoch/db-view-mode`          | `:rf.xray.epoch/db-diff-mode`          | `:rf.xray.epoch/set-db-view-mode`          | `:rf.xray.epoch/set-db-diff-mode`          |
| Epoch SUBSCRIPTIONS    | `:rf.xray.epoch/subs-value-mode`       | `:rf.xray.epoch/subs-value-diff-mode`  | `:rf.xray.epoch/set-subs-value-mode`       | `:rf.xray.epoch/set-subs-value-diff-mode`  |

Per-surface slots migrate from unqualified (`:app-db-panel-view-mode`,
`:machine-inspector-view-mode`, `:epoch-panel-db-view-mode`,
`:epoch-panel-subs-value-mode`) to namespaced keys equal to each
surface''s sub-id, derived by the shared helper.

The pre-rf2-n2jig `:all → :full` migration in the Epoch HANDLER `:db`
sub is dropped (pre-alpha posture; the old slot key is no longer
read, so any persisted `:all` value is moot).

Spec/021 §9.1.5.2 table updated to reflect the normalised names and
explicitly note the shared-helper adoption. Spec/007 §UX-IA +
`panels.cljs` docstring updated. Gallery story IDs + test slot/event
allow-lists + internal `:data-*` attributes renamed in lockstep so the
rename reads coherently across source, tests, docs, and canvas data
attributes.

**Out of scope**: `data-testid` strings (`rf-xray-*-view-mode`) — handled
by sibling bead rf2-7vv8f / H4.

## Quality gates

| Gate | Result |
|---|---|
| `npm run test:cljs` | PASS — 4803 tests / 15628 assertions / 0 failures |
| `npm run test:browser` | PASS — 124 tests / 353 assertions / 0 failures |
| `npm run test:bundle-isolation` | PASS — 17 artefact entries; 35 internal sentinels absent |
| `npm run test:examples` | PASS — 3/3 adapter smokes (port 8030 sandbox-busy locally; rerun with `EXAMPLES_PORT=64830`) |
| `npm run test:xray-feature-gate:smoke` | PASS — 3 scenarios / 0 failures / 10 matrix rows covered |

Closes rf2-0cyjm.
Closes rf2-44xya.