### PR TITLE
feat(scripts): test-fast-pr.sh runs link/anchor validators when diff touches markdown (rf2-lwweq)

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -151,6 +151,43 @@ prose. The pre-PR lint `python scripts/check_doc_slugs.py` flags violations
 under defect category AI_FINDINGS_LINK.
 ```
 
+## Canonical pre-checkin quality gates
+
+Every editing dispatch MUST run the canonical pre-checkin spine before
+opening a PR:
+
+```bash
+bash scripts/test-fast-pr.sh
+```
+
+The spine bundles lockstep drift, skill/MCP drift, core JVM, JS harness
+helpers, CLJS node integration, AND — when the diff touches any `.md`
+file — the markdown link/anchor validators. **Markdown auto-detection
+runs `python scripts/check_readme_links.py` + `python
+scripts/check_doc_slugs.py` + `mkdocs build --strict` (mkdocs
+soft-skipped on Windows when not on PATH).**
+
+**If your diff touches any markdown file**, you MUST verify the
+markdown gates ran (they auto-trigger; pass `--with-docs` to force).
+Failure to do so is a recurring source of red CI — #2232 (`#trace-events-1`
+vs `#trace-events_1` slug-disambiguation underscore) and #2233
+(`#cljs-reference-helix-as-alternative-substrate` missing the
+`-rf2-2qit` suffix that the heading actually carries) both bit in one
+hour on 2026-05-27 because workers pushed without running the markdown
+gates locally. The `test-fast-pr.sh` spine now catches both.
+
+Manual invocation if you want to run only the markdown gates:
+
+```bash
+python scripts/check_readme_links.py
+python scripts/check_doc_slugs.py
+mkdocs build --strict        # Linux/CI; on Windows mkdocs may not be installed
+```
+
+If you skipped `mkdocs build --strict` locally because mkdocs isn't on
+PATH (common on Windows), call it out in the PR body so the mayor knows
+to watch CI.
+
 ## Worktree path convention
 
 Worker worktrees live under `<WORKTREE_ROOT>`. Not inside the mayor checkout

--- a/scripts/_test_fixtures/test_fast_pr_docs_gate/README.md
+++ b/scripts/_test_fixtures/test_fast_pr_docs_gate/README.md
@@ -1,0 +1,27 @@
+# test_fast_pr_docs_gate self-test (rf2-lwweq)
+
+Self-test for the markdown-change detection logic in
+`scripts/test-fast-pr.sh`.  Run with:
+
+```bash
+bash scripts/_test_fixtures/test_fast_pr_docs_gate/run-self-test.sh
+```
+
+The harness covers:
+
+* Detection-logic cases (A–D) — committed `.md` diff vs `origin/main`,
+  unstaged `.md` changes, `--no-docs` override, `--with-docs` override.
+* Gate-has-teeth cases (E–F) — `check_doc_slugs.py` + `check_readme_links.py`
+  exit non-zero on bundled broken fixtures.
+* Motivating-miss reproductions — minimal mkdocs-rooted repos that
+  reproduce the defect shapes from #2232
+  (`#trace-events-1` vs pymdownx's `#trace-events_1` underscore-N
+  disambiguation) and #2233 (anchor missing the `-rf2-XXX` suffix the
+  heading actually carries).  Both must trip `check_doc_slugs.py`.
+
+Why a hand-rolled harness instead of extending an existing test
+runner? The spine is plain bash invoked from POSIX environments
+(Mac/Linux CI + Windows Git Bash workers); pulling in pytest or the JS
+harness for a 200-line detection check would add more surface than the
+test exercises.  Keep dependencies to bash + python + git + the
+already-present link validators.

--- a/scripts/_test_fixtures/test_fast_pr_docs_gate/run-self-test.sh
+++ b/scripts/_test_fixtures/test_fast_pr_docs_gate/run-self-test.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+# Self-test for the markdown-change detection in scripts/test-fast-pr.sh
+# (rf2-lwweq).
+#
+# This isolates the detection-and-conditional-run logic — it does NOT
+# invoke the full spine (which would re-run lockstep + CLJS tests for
+# many minutes).  Instead we extract the detection block + the
+# conditional invocations into a tiny harness and assert four cases:
+#
+#   case A — no markdown diff, --auto      → markdown gates skipped
+#   case B — markdown diff present, --auto → markdown gates run
+#   case C — --no-docs flag → markdown gates skipped regardless of diff
+#   case D — --with-docs flag → markdown gates run regardless of diff
+#
+# We also assert the gates actually catch a known-broken anchor (case E)
+# and a broken README target (case F), proving the gate has teeth.
+#
+# Run from any cwd:
+#   bash scripts/_test_fixtures/test_fast_pr_docs_gate/run-self-test.sh
+#
+# Exit code:
+#   0  all assertions hold
+#   1  at least one assertion failed
+#   2  setup error
+
+set -u
+
+fixture_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$fixture_dir/../../.." && pwd)"
+spine="$repo_root/scripts/test-fast-pr.sh"
+
+if [ ! -f "$spine" ]; then
+  printf 'setup error: spine script not found at %s\n' "$spine" >&2
+  exit 2
+fi
+
+fail_count=0
+pass_count=0
+
+assert() {
+  local label="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    printf '  PASS %s\n' "$label"
+    pass_count=$((pass_count + 1))
+  else
+    printf '  FAIL %s: expected %q, got %q\n' "$label" "$expected" "$actual"
+    fail_count=$((fail_count + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Detection-logic harness.
+#
+# We replicate the detection block from test-fast-pr.sh against a clean
+# disposable git repo so the spine's behaviour on a real diff is testable
+# without actually running the expensive gates.
+# ---------------------------------------------------------------------------
+
+tmp_root="$(mktemp -d 2>/dev/null || mktemp -d -t 'test-fast-pr-detect')"
+trap 'rm -rf "$tmp_root"' EXIT
+
+detect_md_change() {
+  # Args: $1 = repo path; $2 = with_docs mode (auto|force|skip)
+  local repo="$1"
+  local with_docs="$2"
+  if [ "$with_docs" = "force" ]; then
+    printf 'true\n'
+    return
+  fi
+  if [ "$with_docs" = "skip" ]; then
+    printf 'false\n'
+    return
+  fi
+  local markdown_changed=false
+  if git -C "$repo" rev-parse --verify origin/main >/dev/null 2>&1; then
+    if git -C "$repo" diff --name-only origin/main HEAD 2>/dev/null | grep -qE '\.md$'; then
+      markdown_changed=true
+    fi
+  fi
+  if git -C "$repo" status --porcelain 2>/dev/null | grep -qE '\.md$'; then
+    markdown_changed=true
+  fi
+  printf '%s\n' "$markdown_changed"
+}
+
+# Build a fake repo with origin/main fixed at HEAD and one non-md committed
+# change on top — represents a "no markdown diff vs origin/main, no
+# unstaged md" state.
+init_repo_no_md() {
+  local r="$1"
+  mkdir -p "$r"
+  git -C "$r" init -q -b main 2>/dev/null
+  git -C "$r" config user.email "self-test@local"
+  git -C "$r" config user.name "self-test"
+  # Silence CRLF auto-conversion warnings on Windows Git Bash.
+  git -C "$r" config core.autocrlf false
+  git -C "$r" config core.safecrlf false
+  printf 'first\n' > "$r/initial.txt"
+  git -C "$r" add initial.txt
+  git -C "$r" commit -q -m 'initial'
+  # Fake origin/main pointing at this commit.
+  git -C "$r" update-ref refs/remotes/origin/main HEAD
+  # One non-md change on top.
+  printf 'second\n' >> "$r/initial.txt"
+  git -C "$r" add initial.txt
+  git -C "$r" commit -q -m 'non-md change'
+}
+
+# Build a fake repo with a committed .md change on top of origin/main.
+init_repo_committed_md() {
+  local r="$1"
+  init_repo_no_md "$r"
+  printf '# changed\n' > "$r/notes.md"
+  git -C "$r" add notes.md
+  git -C "$r" commit -q -m 'add markdown'
+}
+
+# Build a fake repo with an UNSTAGED .md change (worktree dirty, no
+# commit beyond origin/main).
+init_repo_unstaged_md() {
+  local r="$1"
+  init_repo_no_md "$r"
+  printf '# unstaged\n' > "$r/dirty.md"
+  # Deliberately do NOT git add; we want porcelain to show '??'.
+}
+
+# ---- Case A: no md, --auto ----
+case_a="$tmp_root/case-a"
+init_repo_no_md "$case_a"
+assert "case A (no md, --auto)" "false" "$(detect_md_change "$case_a" auto)"
+
+# ---- Case B1: committed md vs origin/main, --auto ----
+case_b1="$tmp_root/case-b1"
+init_repo_committed_md "$case_b1"
+assert "case B1 (committed md vs origin/main, --auto)" "true" "$(detect_md_change "$case_b1" auto)"
+
+# ---- Case B2: unstaged md, --auto ----
+case_b2="$tmp_root/case-b2"
+init_repo_unstaged_md "$case_b2"
+assert "case B2 (unstaged md, --auto)" "true" "$(detect_md_change "$case_b2" auto)"
+
+# ---- Case C: md present, --no-docs ----
+case_c="$tmp_root/case-c"
+init_repo_committed_md "$case_c"
+assert "case C (md present, --no-docs)" "false" "$(detect_md_change "$case_c" skip)"
+
+# ---- Case D: no md, --with-docs ----
+case_d="$tmp_root/case-d"
+init_repo_no_md "$case_d"
+assert "case D (no md, --with-docs)" "true" "$(detect_md_change "$case_d" force)"
+
+# ---------------------------------------------------------------------------
+# Gate-has-teeth tests.
+#
+# We exercise the actual link/anchor validators against the bundled
+# broken fixtures and assert they exit non-zero — proving that when the
+# detection block decides "run the gates", the gates would actually
+# catch the motivating regressions.
+# ---------------------------------------------------------------------------
+
+slugs_script="$repo_root/scripts/check_doc_slugs.py"
+readme_script="$repo_root/scripts/check_readme_links.py"
+
+# ---- Case E: check_doc_slugs catches a broken anchor ----
+broken_anchor_fixture="$repo_root/scripts/_test_fixtures/check_doc_slugs/broken_anchor"
+if [ -d "$broken_anchor_fixture" ]; then
+  python "$slugs_script" --repo-root "$broken_anchor_fixture" >/dev/null 2>&1
+  rc=$?
+  assert "case E (check_doc_slugs catches broken anchor)" "1" "$rc"
+else
+  printf '  SKIP case E: fixture %s not found\n' "$broken_anchor_fixture"
+fi
+
+# ---- Case F: check_readme_links catches a broken target ----
+broken_readme_fixture="$repo_root/scripts/_test_fixtures/check_readme_links/broken_internal_link"
+if [ -d "$broken_readme_fixture" ]; then
+  python "$readme_script" --repo-root "$broken_readme_fixture" --ci >/dev/null 2>&1
+  rc=$?
+  assert "case F (check_readme_links catches broken target)" "1" "$rc"
+else
+  printf '  SKIP case F: fixture %s not found\n' "$broken_readme_fixture"
+fi
+
+# ---------------------------------------------------------------------------
+# Motivating-miss verification.
+#
+# Build a tiny mkdocs-rooted repo that reproduces #2232's defect shape
+# (anchor #trace-events-1 vs heading-derived slug trace-events_1) and
+# #2233's defect shape (anchor without the (rf2-XXX) suffix the heading
+# carries), then assert the validators flag both.
+# ---------------------------------------------------------------------------
+
+# #2232 reproduction — duplicate "Trace events" heading where the
+# second occurrence gets pymdownx's `_1` suffix; an author referencing
+# it with GitHub-style `-1` would slip through GitHub preview but fail
+# on the MkDocs build.
+case_2232="$tmp_root/case-2232"
+mkdir -p "$case_2232/docs"
+cat > "$case_2232/mkdocs.yml" <<'EOF'
+site_name: test
+EOF
+cat > "$case_2232/docs/index.md" <<'EOF'
+# Index
+
+See [trace events](target.md#trace-events-1) for the second occurrence.
+EOF
+cat > "$case_2232/docs/target.md" <<'EOF'
+# Target
+
+## Trace events
+
+First occurrence — slug is `trace-events`.
+
+## Trace events
+
+Second occurrence — pymdownx slug is `trace-events_1` (underscore N).
+EOF
+python "$slugs_script" --repo-root "$case_2232" >/dev/null 2>&1
+rc_2232=$?
+assert "#2232 motivating miss (trace-events-1 vs trace-events_1)" "1" "$rc_2232"
+
+# #2233 reproduction — heading with bead suffix `## Foo (rf2-2qit)`,
+# pymdownx slug is `foo-rf2-2qit`; an author who writes `#foo` (without
+# the suffix) gets a broken anchor.
+case_2233="$tmp_root/case-2233"
+mkdir -p "$case_2233/docs"
+cat > "$case_2233/mkdocs.yml" <<'EOF'
+site_name: test
+EOF
+cat > "$case_2233/docs/index.md" <<'EOF'
+# Index
+
+See [section](target.md#cljs-reference-helix-as-alternative-substrate) for details.
+EOF
+cat > "$case_2233/docs/target.md" <<'EOF'
+# Target
+
+## CLJS reference: Helix as alternative substrate (rf2-2qit)
+
+Body — heading slug is `cljs-reference-helix-as-alternative-substrate-rf2-2qit`,
+NOT `cljs-reference-helix-as-alternative-substrate`.
+EOF
+python "$slugs_script" --repo-root "$case_2233" >/dev/null 2>&1
+rc_2233=$?
+assert "#2233 motivating miss (anchor missing -rf2-XXX suffix)" "1" "$rc_2233"
+
+# ---- Summary ----
+total=$((pass_count + fail_count))
+printf '\n%s/%s self-test cases passed.\n' "$pass_count" "$total"
+if [ "$fail_count" -gt 0 ]; then
+  printf '%s FAILED.\n' "$fail_count" >&2
+  exit 1
+fi
+exit 0

--- a/scripts/test-fast-pr.sh
+++ b/scripts/test-fast-pr.sh
@@ -1,7 +1,53 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Fast pre-checkin spine for the canonical agent quality gate.
+#
+# Mirrors CI's PR-gate matrix so workers see local failures BEFORE pushing.
+# When the working tree's diff vs origin/main (or unstaged changes) touches
+# any .md file, the spine additionally runs the markdown link/anchor
+# validators that CI runs.  Workers were repeatedly pushing green-locally
+# branches that failed on CI link/anchor breaks (#2232 + #2233 in one
+# hour on 2026-05-27) — this gate closes that gap (rf2-lwweq).
+#
+# Usage:
+#   scripts/test-fast-pr.sh              auto-detect markdown diff
+#   scripts/test-fast-pr.sh --with-docs  force-run the markdown gates
+#   scripts/test-fast-pr.sh --no-docs    skip markdown gates even if .md changed
+#
+# Markdown-gate components:
+#   1. python scripts/check_readme_links.py — README anchor + target validator
+#   2. python scripts/check_doc_slugs.py    — docs corpus anchor validator
+#   3. mkdocs build --strict (when mkdocs on PATH; soft-skip on Windows when not)
+
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+with_docs="auto"
+for arg in "$@"; do
+  case "$arg" in
+    --with-docs) with_docs="force" ;;
+    --no-docs)   with_docs="skip" ;;
+    -h|--help)
+      cat <<EOF
+fast PR pre-checkin spine
+
+Usage:
+  $(basename "$0") [--with-docs|--no-docs]
+
+Flags:
+  --with-docs   always run the markdown link/anchor + mkdocs --strict gates
+  --no-docs     skip markdown gates even when the diff touches .md
+  (default)     auto-detect: run markdown gates iff diff vs origin/main
+                OR unstaged changes touch any .md file
+EOF
+      exit 0
+      ;;
+    *)
+      printf 'unknown flag: %s\n' "$arg" >&2
+      exit 2
+      ;;
+  esac
+done
 
 run() {
   local surface="$1"
@@ -14,6 +60,48 @@ run() {
   fi
 }
 
+# Soft-run: log + continue when the binary is unavailable.  Used for mkdocs
+# on Windows machines where mkdocs is not always installed in PATH but the
+# CI Linux runners always have it (mkdocs.yml + requirements.txt pinned).
+run_soft() {
+  local surface="$1"
+  local repro="$2"
+  local probe="$3"
+  shift 3
+  printf '==> %s\n' "$surface"
+  if ! command -v "$probe" >/dev/null 2>&1; then
+    printf '    SKIP %s: %s not on PATH (CI will run this; local soft-skip OK)\n' \
+      "$surface" "$probe"
+    return 0
+  fi
+  if ! "$@"; then
+    printf '\nFAIL %s\nrepro: %s\n' "$surface" "$repro" >&2
+    return 1
+  fi
+}
+
+# ---- markdown-change detection ----
+# Two signals:
+#   1. committed diff vs origin/main touches *.md
+#   2. unstaged or staged working-tree changes touch *.md
+# Either signal → markdown gates run (unless --no-docs).
+markdown_changed=false
+if [ "$with_docs" = "force" ]; then
+  markdown_changed=true
+elif [ "$with_docs" = "skip" ]; then
+  markdown_changed=false
+else
+  if git -C "$repo_root" rev-parse --verify origin/main >/dev/null 2>&1; then
+    if git -C "$repo_root" diff --name-only origin/main HEAD 2>/dev/null | grep -qE '\.md$'; then
+      markdown_changed=true
+    fi
+  fi
+  if git -C "$repo_root" status --porcelain 2>/dev/null | grep -qE '\.md$'; then
+    markdown_changed=true
+  fi
+fi
+
+# ---- existing gates ----
 run "lockstep version drift" "./.github/scripts/verify-version-lockstep.sh" \
   bash -lc "tmp='$repo_root/.github/scripts/.verify-version-lockstep.tmp.'\$\$; trap 'rm -f \"\$tmp\"' EXIT; tr -d '\r' < '$repo_root/.github/scripts/verify-version-lockstep.sh' > \"\$tmp\"; bash \"\$tmp\""
 
@@ -28,5 +116,21 @@ run "implementation JS harness helpers" "cd implementation && npm run test:scrip
 
 run "CLJS node integration" "cd implementation && npm run test:cljs" \
   bash -lc "cd '$repo_root/implementation' && npm run test:cljs"
+
+# ---- conditional markdown gates ----
+if [ "$markdown_changed" = "true" ]; then
+  printf '\n--- markdown changes detected → running link/anchor gates ---\n'
+
+  run "README link/anchor validator" "python scripts/check_readme_links.py --ci" \
+    python "$repo_root/scripts/check_readme_links.py" --ci
+
+  run "docs corpus anchor validator" "python scripts/check_doc_slugs.py" \
+    python "$repo_root/scripts/check_doc_slugs.py"
+
+  run_soft "mkdocs --strict build" "mkdocs build --strict" mkdocs \
+    bash -lc "cd '$repo_root' && mkdocs build --strict"
+else
+  printf '\n--- no markdown changes → skipping link/anchor gates (override with --with-docs) ---\n'
+fi
 
 printf 'PASS fast PR spine\n'


### PR DESCRIPTION
## Problem

Workers running the current pre-checkin spine (`scripts/test-fast-pr.sh`) see green locally, push, and then CI fails on link/anchor breaks. Two motivating misses bitten in one hour on 2026-05-27:

- **#2232** — `#trace-events-1` (GitHub-style `-N`) instead of pymdownx's `#trace-events_1` (underscore-N disambiguation). Caught by `check_doc_slugs.py`.
- **#2233** — `#cljs-reference-helix-as-alternative-substrate` but the heading is `## CLJS reference: Helix as alternative substrate (rf2-2qit)` — the pymdownx slug includes the bead suffix. Caught by `check_readme_links.py`.

The pre-checkin spine must mirror CI's PR gates.

## Changes

### `scripts/test-fast-pr.sh`

Auto-detects whether the working tree's diff vs `origin/main` (or unstaged changes) touches any `.md` file. When true, additionally runs:

1. `python scripts/check_readme_links.py --ci` — README anchor + target validator
2. `python scripts/check_doc_slugs.py` — docs corpus anchor validator
3. `mkdocs build --strict` — soft-skipped on Windows when `mkdocs` isn't on PATH (logged + continues; CI Linux runners always have it)

Flags:
- `--with-docs` — force-run markdown gates regardless of diff
- `--no-docs` — skip markdown gates even when diff touches `.md`
- `--help`

### `docs/the-mayor-method/dispatch-prompt-template.md`

New "Canonical pre-checkin quality gates" section near Common preamble. Explicit clause: any diff touching `.md` MUST run the markdown gates (auto-triggered by `test-fast-pr.sh`; `--with-docs` forces). Names #2232 + #2233 as motivating misses. Windows mkdocs escape-hatch documented.

### `scripts/_test_fixtures/test_fast_pr_docs_gate/`

Self-test harness — bash + python + git, no extra deps:

- **Detection cases A-D** — committed md vs origin/main, unstaged md, `--no-docs` override, `--with-docs` override.
- **Gate-has-teeth cases E-F** — `check_doc_slugs.py` + `check_readme_links.py` exit 1 on bundled broken fixtures.
- **Motivating-miss reproductions** — minimal mkdocs-rooted repos reproducing the #2232 underscore-N defect and the #2233 missing-suffix defect; both trip `check_doc_slugs.py` as expected.

```
9/9 self-test cases passed.
```

## Verification

- Self-test (`bash scripts/_test_fixtures/test_fast_pr_docs_gate/run-self-test.sh`): 9/9 pass.
- Dogfood: `bash scripts/test-fast-pr.sh` on its own diff runs all existing gates (lockstep + skill drift + core JVM + JS harness helpers + CLJS node integration — 4811 tests, 0 failures) **plus** the new markdown gates (README validator + doc-slug validator + soft-skip mkdocs on this Windows host). Final line: `PASS fast PR spine`.
- `--no-docs` flow verified: markdown gates correctly skipped.
- Baseline `check_readme_links.py` + `check_doc_slugs.py` against the live repo: both green (no regressions from the new fixture tree — `_test_fixtures/` excluded by design).

Closes rf2-lwweq.