### PR TITLE
refactor(examples): restore cross-substrate parity + extract websocket test scaffolding (rf2-cwlnl + rf2-1875u + rf2-88mf8)

### DIFF
--- a/examples/helix/counter_helix/core.cljs
+++ b/examples/helix/counter_helix/core.cljs
@@ -25,16 +25,8 @@
 
 ;; -- Events / subs (handler registry is app-global) --------------------------
 
-(defonce counter-log (atom []))
-
-(rf/reg-fx :counter/log
-  (fn [_ctx args]
-    (swap! counter-log conj args)))
-
-(rf/reg-event-fx :counter/initialise
-  (fn [_ctx _event]
-    {:db {:counter/value 5}
-     :fx [[:counter/log :initialised]]}))
+(rf/reg-event-db :counter/initialise
+  (fn [_db _event] {:counter/value 5}))
 
 (rf/reg-event-db :counter/inc
   (fn [db _event] (update db :counter/value inc)))

--- a/examples/reagent/counter_slim_and_fast/core.cljs
+++ b/examples/reagent/counter_slim_and_fast/core.cljs
@@ -40,25 +40,17 @@
 
 ;; -- Events / subs (handler registry is app-global) --------------------------
 
-(defonce counter-log (atom []))
-
-(rf/reg-fx :counter/log
-  (fn [_ctx args]
-    (swap! counter-log conj args)))
-
-(rf/reg-event-fx :counter/initialise
-  (fn [_ctx _event]
-    {:db {:count 5}
-     :fx [[:counter/log :initialised]]}))
+(rf/reg-event-db :counter/initialise
+  (fn [_db _event] {:counter/value 5}))
 
 (rf/reg-event-db :counter/inc
-  (fn [db _event] (update db :count inc)))
+  (fn [db _event] (update db :counter/value inc)))
 
 (rf/reg-event-db :counter/dec
-  (fn [db _event] (update db :count dec)))
+  (fn [db _event] (update db :counter/value dec)))
 
-(rf/reg-sub :count
-  (fn [db _query] (:count db)))
+(rf/reg-sub :counter/value
+  (fn [db _query] (:counter/value db)))
 
 ;; -- Views -------------------------------------------------------------------
 ;;
@@ -72,7 +64,7 @@
 (reg-view counter-buttons []
   [:div
    [:button {:on-click #(dispatch [:counter/dec])} "-"]
-   [:span {:style {:margin "0 1em"} :data-testid "counter-value"} @(subscribe [:count])]
+   [:span {:style {:margin "0 1em"} :data-testid "counter-value"} @(subscribe [:counter/value])]
    [:button {:on-click #(dispatch [:counter/inc])} "+"]])
 
 (reg-view counter-app []
@@ -94,7 +86,11 @@
   ;; the bundle still must NOT contain `react-dom/server` symbols,
   ;; because reagent2.dom.server is pure-CLJS (no
   ;; `["react-dom/server" :as ...]` import — see IMPL-SPEC §8).
-  ;; The result is retained in `counter-log` so the closure compiler
-  ;; can't DCE the call (a no-op `js/console.log` would be elided).
-  (swap! counter-log conj [:pre-rendered (rds/render-to-static-markup [counter-app])])
+  ;;
+  ;; DCE protection: write the rendered string onto a host-global
+  ;; property. The closure compiler treats writes to extern-shaped
+  ;; properties on `globalThis` as side effects; the call survives
+  ;; `:advanced`. (A no-op like `js/console.log` would be elided.)
+  (set! (.-counterSlimPrerender js/globalThis)
+        (rds/render-to-static-markup [counter-app]))
   (rdc/render root [counter-app]))

--- a/examples/reagent/login/core.cljs
+++ b/examples/reagent/login/core.cljs
@@ -79,6 +79,14 @@
 ;; [:rf/machines :auth.login/flow] in app-db. It does not carry :closed
 ;; true — this isn't a system boundary.
 
+;; The submit-event payload — the credentials map the view collects from
+;; the form. Open by default; the regex/min-length checks describe the
+;; shape the inner handler relies on.
+(def Credentials
+  [:map
+   [:email    [:re #".+@.+"]]
+   [:password [:string {:min 8}]]])
+
 ;; The login flow's runtime state lives in the machine snapshot at
 ;; [:rf/machines :auth.login/flow] (per [005 §Where snapshots live]).
 ;; The snapshot shape is {:state <kw> :data <map>} per Spec 005.

--- a/examples/reagent/websocket/README.md
+++ b/examples/reagent/websocket/README.md
@@ -19,12 +19,13 @@
 
 | File | Notes |
 |---|---|
-| `core.cljs` | Entry point — mounts the React root, runs `:app/initialise`. |
+| `core.cljs` | Entry point — mounts the React root, runs `:ws.app/initialise`. |
 | `connection.cljs` | The `:ws/connection` machine — the heart of the example. Read alongside `spec/Pattern-WebSocket.md` §Worked example — the shapes are identical. |
 | `messages.cljs` | The `:websocket/socket` actor (the spawned child) + an in-process mock WebSocket server + `:ws/handle-message` + the app-level send/request/subscribe events. |
 | `views.cljs` | UI — status pill driven by tags, lifecycle buttons, send form, request/subscribe/server-push demo trio, inbox. |
 | `schema.cljs` | Malli schemas for the connection-machine snapshot, the `:data` slice, and the `[:messages]` slice. |
 | `index.html` | Minimal harness. |
+| `test/websocket/test_helpers.cljs` | Test-only re-registration scaffolding (recovers from upstream `clear-all!` callers). Not loaded by the production bundle; the wrapper test ns's `:each` fixture calls it. |
 | `test/websocket/connection_test.cljs` | Headless tests: initial state, happy-path lifecycle, offline-queue + drain, reconnect cascade, max-retries → `:failed`, connection-epoch staleness, `:ws/refresh-token`, clean `:ws/disconnect`. |
 | `test/websocket/messages_test.cljs` | Headless tests: request-reply correlation, server-push routing, subscription tracking, `[:messages :received]` newest-first invariant. |
 

--- a/examples/reagent/websocket/connection.cljs
+++ b/examples/reagent/websocket/connection.cljs
@@ -357,12 +357,12 @@
 ;;
 ;; All the `reg-*` calls are inside `register-all!` so the test fixture
 ;; can re-fire them after an upstream `clear-all!` wiped the registrar
-;; (see `websocket.core/register-all!` for context). At ns-load the
+;; (see `websocket.test-helpers/register-all!` for context). At ns-load the
 ;; function is called once via the trailing `(register-all!)` form.
 
 (defn register-all!
   "Idempotent re-registration of every event handler / sub this ns
-   owns. See `websocket.core/register-all!`."
+   owns. See `websocket.test-helpers/register-all!`."
   []
   ;; Use `rf/reg-machine` (not `reg-event-fx` + `make-machine-handler`)
   ;; so the registration metadata carries `:rf/machine? true` —

--- a/examples/reagent/websocket/core.cljs
+++ b/examples/reagent/websocket/core.cljs
@@ -37,86 +37,25 @@
   (:require [reagent2.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.adapter.reagent-slim :as reagent-slim-adapter]
-            [re-frame.fx :as fx]
-            [re-frame.late-bind :as late-bind]
             [websocket.schema]
             [websocket.connection]
             [websocket.messages]
             [websocket.views :as views]))
 
 ;; ============================================================================
-;; RE-REGISTRATION HOOK
+;; APP-BOOT EVENT
 ;; ============================================================================
-;;
-;; Some test fixtures upstream of this example (alphabetically before
-;; `re-frame.websocket-cljs-test` in the node-test run order) call
-;; `re-frame.registrar/clear-all!` without restoring afterwards —
-;; notably the Story `:rf.assert/*` test fixture. When that happens,
-;; the ns-load registrations the example relies on disappear before
-;; this example's own test ns gets a chance to run.
-;;
-;; To recover, every sub-namespace exposes an idempotent
-;; `register-all!` helper; this ns's `register-all!` calls them all,
-;; then re-installs the top-level `:ws.app/initialise` event. The
-;; test fixture calls this from its `:before` step. The function is
-;; idempotent (every `rf/reg-*` is last-write-wins) so it's also safe
-;; for hot-reload from the REPL.
-;;
-;; This pattern mirrors `counter-with-stories.stories/register-all!`,
-;; which solves the same problem for the Story side-table.
 
-(defn- re-register-machines-fx-and-subs!
-  "Re-fire the framework-shipped `:rf.machine/*` fx + the `:rf/machine`
-   / `:rf/machine-has-tag?` subs.
+(rf/reg-event-fx :ws.app/initialise
+  {:doc "App boot. Seeds the messages slice + materialises the
+         connection machine's initial `:disconnected` snapshot.
 
-   Idempotent (last-write-wins). Necessary because upstream test
-   namespaces (alphabetically before `re-frame.websocket-cljs-test`)
-   call `re-frame.registrar/clear-all!` without restoring, which
-   wipes the ns-load-time registrations in `re-frame.machines`.
-   Without these in place:
-   - declarative `:spawn` silently no-ops (the spawn fx isn't found);
-   - `rf/machine-has-tag?` returns false even when the tag is in the snapshot
-     (the framework sub isn't registered)."
-  []
-  (when-let [spawn-fx (late-bind/get-fn :machines/spawn-fx)]
-    (fx/reg-fx :rf.machine/spawn spawn-fx))
-  (when-let [destroy-fx (late-bind/get-fn :machines/destroy-machine-fx)]
-    (fx/reg-fx :rf.machine/destroy destroy-fx))
-  (when-let [spawn-all-init-fx (late-bind/get-fn :machines/spawn-all-init-fx)]
-    (fx/reg-fx :rf.machine/spawn-all-init spawn-all-init-fx))
-  (when-let [after-schedule-fx (late-bind/get-fn :machines/after-schedule-fx)]
-    (fx/reg-fx :rf.machine/after-schedule after-schedule-fx))
-  (when-let [after-cancel-fx (late-bind/get-fn :machines/after-cancel-fx)]
-    (fx/reg-fx :rf.machine/after-cancel after-cancel-fx))
-  ;; The framework subs that read machine state — both registered at
-  ;; machines.cljc ns-load time and equally vulnerable to `clear-all!`.
-  (rf/reg-sub :rf/machine
-    (fn [db [_ machine-id]]
-      (get-in db [:rf/machines machine-id])))
-  (rf/reg-sub :rf/machine-has-tag?
-    (fn [db [_ machine-id tag]]
-      (contains? (get-in db [:rf/machines machine-id :tags]) tag))))
-
-(defn register-all!
-  "Re-fire every `reg-*` this example depends on. Safe to call at any
-   point during the app's lifetime — every `reg-*` is last-write-wins."
-  []
-  (re-register-machines-fx-and-subs!)
-  (websocket.schema/register-all!)
-  (websocket.connection/register-all!)
-  (websocket.messages/register-all!)
-  (rf/reg-event-fx :ws.app/initialise
-    {:doc "App boot. Seeds the messages slice + materialises the
-           connection machine's initial `:disconnected` snapshot.
-
-           Namespaced under `:ws.app/*` (not `:app/initialise`) so the
-           example can coexist with the realworld + counter examples
-           without re-registering a common event key."}
-    (fn handler-app-initialise [_ _]
-      {:fx [[:dispatch [:ws.messages/initialise]]
-            [:dispatch [:ws.connection/initialise]]]})))
-
-(register-all!)
+         Namespaced under `:ws.app/*` (not `:app/initialise`) so the
+         example can coexist with the realworld + counter examples
+         without re-registering a common event key."}
+  (fn handler-app-initialise [_ _]
+    {:fx [[:dispatch [:ws.messages/initialise]]
+          [:dispatch [:ws.connection/initialise]]]}))
 
 ;; ============================================================================
 ;; MOUNT

--- a/examples/reagent/websocket/messages.cljs
+++ b/examples/reagent/websocket/messages.cljs
@@ -320,13 +320,13 @@
 ;;
 ;; All the `reg-*` calls live inside `register-all!` so the test fixture
 ;; can re-fire them after an upstream `clear-all!` wiped the registrar
-;; (see `websocket.core/register-all!` for context). The function is
+;; (see `websocket.test-helpers/register-all!` for context). The function is
 ;; idempotent (every `reg-*` is last-write-wins) and gets called at
 ;; ns-load via the trailing form below.
 
 (defn register-all!
   "Idempotent re-registration of every event handler / sub this ns
-   owns. See `websocket.core/register-all!`."
+   owns. See `websocket.test-helpers/register-all!`."
   []
   ;; The socket actor — Pattern-WebSocket §The connection state machine
   ;; names this as the child actor the parent invokes.

--- a/examples/reagent/websocket/schema.cljs
+++ b/examples/reagent/websocket/schema.cljs
@@ -122,7 +122,7 @@
 
 (defn register-all!
   "Idempotent re-registration of every schema attached in this ns.
-   See `websocket.core/register-all!` for why this exists."
+   See `websocket.test-helpers/register-all!` for why this exists."
   []
   (rf/reg-app-schema [:rf/machines :ws/connection] ConnectionSnapshot)
   (rf/reg-app-schema [:messages]                   MessagesSlice))

--- a/examples/reagent/websocket/test/websocket/test_helpers.cljs
+++ b/examples/reagent/websocket/test/websocket/test_helpers.cljs
@@ -1,0 +1,104 @@
+(ns websocket.test-helpers
+  "Test-only re-registration scaffolding for the websocket worked example.
+
+   The websocket example's sub-namespaces — `websocket.schema`,
+   `websocket.connection`, `websocket.messages` — each install their
+   reg-machine / reg-event-* / reg-sub / reg-app-schema entries at
+   ns-load time (the production-app idiom; loading the ns IS the
+   registration). The example's `core.cljs` then registers the top-level
+   `:ws.app/initialise` event in the same idiomatic ns-load shape and
+   mounts in `run`.
+
+   Some test fixtures upstream of this example (alphabetically before
+   `re-frame.websocket-cljs-test` in the node-test run order) call
+   `re-frame.registrar/clear-all!` without restoring afterwards —
+   notably the Story `:rf.assert/*` test fixture. When that happens,
+   the ns-load registrations the example relies on disappear before
+   this example's own test ns gets a chance to run.
+
+   This namespace exists purely to recover from that. It owns:
+
+   - `re-register-machines-fx-and-subs!` — re-fire the
+     framework-shipped `:rf.machine/*` fx + the `:rf/machine` /
+     `:rf/machine-has-tag?` subs that ns-load registered in
+     `re-frame.machines`. Without these, declarative `:spawn` silently
+     no-ops and `rf/machine-has-tag?` returns false even when the tag
+     is in the snapshot.
+
+   - `register-all!` — call the above and then re-fire every example
+     sub-ns's idempotent `register-all!`, plus re-install
+     `:ws.app/initialise`.
+
+   Idempotent (last-write-wins). The wrapper test ns invokes
+   `register-all!` from its `:each` fixture's `:init-fn`; the example's
+   `core.cljs` does NOT depend on this namespace, so the production
+   bundle does not carry the recovery dance.
+
+   The narrow `(rf/reg-sub :rf/... ...)` calls below are recovery only —
+   the user-code 'must not register under :rf/*' rule (Spec Conventions
+   §Reserved-ns) is about origination; this ns republishes
+   framework-owned registrations that an upstream fixture wiped. The
+   recovery lives here, not in the example source, so readers of the
+   teaching example don't see the dance."
+  (:require [re-frame.core :as rf]
+            [re-frame.fx :as fx]
+            [re-frame.late-bind :as late-bind]
+            [websocket.schema]
+            [websocket.connection]
+            [websocket.messages]))
+
+(defn- re-register-machines-fx-and-subs!
+  "Re-fire the framework-shipped `:rf.machine/*` fx + the `:rf/machine`
+   / `:rf/machine-has-tag?` subs.
+
+   Idempotent (last-write-wins). Necessary because upstream test
+   namespaces (alphabetically before `re-frame.websocket-cljs-test`)
+   call `re-frame.registrar/clear-all!` without restoring, which
+   wipes the ns-load-time registrations in `re-frame.machines`.
+   Without these in place:
+   - declarative `:spawn` silently no-ops (the spawn fx isn't found);
+   - `rf/machine-has-tag?` returns false even when the tag is in the
+     snapshot (the framework sub isn't registered)."
+  []
+  (when-let [spawn-fx (late-bind/get-fn :machines/spawn-fx)]
+    (fx/reg-fx :rf.machine/spawn spawn-fx))
+  (when-let [destroy-fx (late-bind/get-fn :machines/destroy-machine-fx)]
+    (fx/reg-fx :rf.machine/destroy destroy-fx))
+  (when-let [spawn-all-init-fx (late-bind/get-fn :machines/spawn-all-init-fx)]
+    (fx/reg-fx :rf.machine/spawn-all-init spawn-all-init-fx))
+  (when-let [after-schedule-fx (late-bind/get-fn :machines/after-schedule-fx)]
+    (fx/reg-fx :rf.machine/after-schedule after-schedule-fx))
+  (when-let [after-cancel-fx (late-bind/get-fn :machines/after-cancel-fx)]
+    (fx/reg-fx :rf.machine/after-cancel after-cancel-fx))
+  ;; The framework subs that read machine state — both registered at
+  ;; machines.cljc ns-load time and equally vulnerable to `clear-all!`.
+  (rf/reg-sub :rf/machine
+    (fn [db [_ machine-id]]
+      (get-in db [:rf/machines machine-id])))
+  (rf/reg-sub :rf/machine-has-tag?
+    (fn [db [_ machine-id tag]]
+      (contains? (get-in db [:rf/machines machine-id :tags]) tag))))
+
+(defn register-all!
+  "Re-fire every `reg-*` the websocket example depends on. Safe to call
+   at any point during the app's lifetime — every `reg-*` is
+   last-write-wins.
+
+   This is the recovery seam the test fixture's `:init-fn` calls between
+   tests. Production `(websocket.core/run)` does NOT call this; the
+   example's sub-namespaces install their registrations at ns-load."
+  []
+  (re-register-machines-fx-and-subs!)
+  (websocket.schema/register-all!)
+  (websocket.connection/register-all!)
+  (websocket.messages/register-all!)
+  (rf/reg-event-fx :ws.app/initialise
+    {:doc "App boot. Seeds the messages slice + materialises the
+           connection machine's initial `:disconnected` snapshot.
+
+           Namespaced under `:ws.app/*` (not `:app/initialise`) so the
+           example can coexist with the realworld + counter examples
+           without re-registering a common event key."}
+    (fn handler-app-initialise [_ _]
+      {:fx [[:dispatch [:ws.messages/initialise]]
+            [:dispatch [:ws.connection/initialise]]]})))

--- a/examples/uix/counter_uix/core.cljs
+++ b/examples/uix/counter_uix/core.cljs
@@ -23,16 +23,8 @@
 
 ;; -- Events / subs (handler registry is app-global) --------------------------
 
-(defonce counter-log (atom []))
-
-(rf/reg-fx :counter/log
-  (fn [_ctx args]
-    (swap! counter-log conj args)))
-
-(rf/reg-event-fx :counter/initialise
-  (fn [_ctx _event]
-    {:db {:counter/value 5}
-     :fx [[:counter/log :initialised]]}))
+(rf/reg-event-db :counter/initialise
+  (fn [_db _event] {:counter/value 5}))
 
 (rf/reg-event-db :counter/inc
   (fn [db _event] (update db :counter/value inc)))

--- a/implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs
@@ -20,6 +20,7 @@
             [re-frame.views]
             [websocket.core]
             [websocket.messages]
+            [websocket.test-helpers :as ws-test-helpers]
             [websocket.connection-test :as conn-t]
             [websocket.messages-test :as msg-t]))
 
@@ -27,7 +28,9 @@
 ;; ns-load registrations the tests depend on are present even when
 ;; an alphabetically-earlier test ns (e.g. the Story `:rf.assert/*`
 ;; fixture) has called `re-frame.registrar/clear-all!` without
-;; restoring afterwards. Idempotent — last-write-wins.
+;; restoring afterwards. Idempotent — last-write-wins. The recovery
+;; dance lives in the test-only `websocket.test-helpers` ns so the
+;; example's production source stays test-free (per rf2-88mf8).
 ;;
 ;; Also resets the mock WebSocket server's `:sockets` table — since
 ;; the spawn-counter resets to 1 each test, every test's actor lands
@@ -38,7 +41,7 @@
   (test-support/make-reset-runtime-fixture
     {:adapter reagent-adapter/adapter
      :init-fn (fn []
-                (websocket.core/register-all!)
+                (ws-test-helpers/register-all!)
                 (websocket.messages/reset-mock-server!))}))
 
 ;; ---- connection lifecycle ------------------------------------------------


### PR DESCRIPTION
Shape-2 cluster from the rf2-9g3we elegance audit. Three P2 examples
fixes, sequenced commits, single PR.

## rf2-1875u — Reagent login: add `Credentials` schema

The UIx and Helix login examples carry a `Credentials` schema
describing the submit-event payload (email + min-8-char password); the
Reagent canonical did not. Audit Finding M2 — same example across
substrates should tell the same story.

Ports the schema verbatim from the UIx/Helix variants. No behavioural
change.

## rf2-88mf8 — Websocket: move fixture re-registration to test-helper ns

The websocket example's `core.cljs` carried a ~70-line "RE-REGISTRATION
HOOK" block (`re-register-machines-fx-and-subs!` + `register-all!`)
that existed purely because upstream test fixtures (notably the Story
`:rf.assert/*` fixture) call `re-frame.registrar/clear-all!` without
restoring afterwards. Test-substrate scaffolding leaking into the
canonical Pattern-WebSocket teaching example — readers saw the
recovery dance before the actual websocket pattern, and a (narrow,
recovery-only) `(reg-sub :rf/...)` violation of the user-code
reserved-ns rule sat right in the example source.

Audit Findings M4 + L4.

- New `examples/reagent/websocket/test/websocket/test_helpers.cljs`
  owns the recovery dance. Namespace docstring carries the context
  that used to live in `core.cljs`.
- `core.cljs` shrunk from 143 → ~85 lines: docstring, the app-boot
  event registration (`:ws.app/initialise`), and `run`. No
  recovery scaffolding, no `reg-sub :rf/*`.
- The wrapper test ns's `:each` fixture's `:init-fn` calls
  `ws-test-helpers/register-all!` instead of
  `websocket.core/register-all!`. Same recovery semantics, in the
  right namespace.
- Docstring back-references updated.
- README's file table gains the `test_helpers.cljs` row.

## rf2-cwlnl — Counter trio: drop `:counter/log`, standardise on `:counter/value`

The four counter variants drifted from parity with the canonical
Reagent reference (`examples/reagent/counter`):

  - UIx, Helix, and slim accreted a `:counter/log` fx + `(defonce
    counter-log (atom []))` + `reg-event-fx` initialise that emits
    `:counter/log :initialised`. None of this is in the Reagent
    reference. The noise was originally added to defeat DCE for the
    slim variant's SSR-path exercise and then copy-pasted into UIx
    and Helix without that justification.
  - The slim variant additionally used `:count` (bare-keyword app-db
    key + sub-id) instead of `:counter/value`.

Audit Finding M1. Bead acceptance: all four variants render identical
dataflow modulo the substrate-specific view layer.

The slim variant must KEEP an SSR-path exercise at boot — the
bundle-isolation grep at
`implementation/scripts/check-reagent-slim-bundle-isolation.cjs`
Contract 3 (S3-005 pure-CLJS SSR) is non-vacuous specifically
because `reagent2.dom.server/render-to-static-markup` is compiled in
via `run`. The retention pattern changes from
`(swap! counter-log conj [:pre-rendered ...])` to
`(set! (.-counterSlimPrerender js/globalThis) ...)` — a host-global
property assignment, DCE-safe under `:advanced`, with no app-db /
event-machinery footprint.

### Counter-trio diff table

| Variant | Before | After |
|---|---|---|
| Reagent (`counter`) | `reg-event-db`, `:counter/value` | unchanged (the canonical reference) |
| UIx (`counter-uix`) | `reg-event-fx` + `:counter/log` + `counter-log` atom; `:counter/value` | `reg-event-db`, no log, `:counter/value` |
| Helix (`counter-helix`) | `reg-event-fx` + `:counter/log` + `counter-log` atom; `:counter/value` | `reg-event-db`, no log, `:counter/value` |
| Slim (`counter-slim-and-fast`) | `reg-event-fx` + `:counter/log` + `counter-log` atom; **`:count`**; SSR retained via `swap! counter-log conj` | `reg-event-db`, no log, **`:counter/value`**; SSR retained via `set!` on `globalThis` |

All four now share:
```clojure
(reg-event-db :counter/initialise (fn [_ _] {:counter/value 5}))
(reg-event-db :counter/inc        (fn [db _] (update db :counter/value inc)))
(reg-event-db :counter/dec        (fn [db _] (update db :counter/value dec)))
(reg-sub      :counter/value      (fn [db _] (:counter/value db)))
```

## Quality gates

- `scripts/test-fast-pr.sh`: **PASS** (lockstep + skill/MCP drift +
  core JVM 796 tests / 3708 assertions + JS harness helpers + script
  helpers + CLJS node integration **4738 tests / 15420 assertions, 0
  failures**)
- `npm run test:cljs`: **PASS** (4738 / 15420, 0 failures)
- `npm run test:reagent-slim:bundle-isolation`: **PASS** (3 contracts,
  19 sentinel checks — Contract 3 stays non-vacuous with the new
  globalThis DCE protection)
- Per-bundle compile (shadow-cljs compile): all 4 counter variants +
  3 login variants + websocket build with **0 warnings**.
- Markdown gate (README touched for websocket):
  `check_readme_links.py` PASS, `check_doc_slugs.py` PASS,
  `mkdocs build --strict` PASS.

`npm run test:examples` was not runnable locally — port 8030 is held
by an unrelated pre-existing JVM in this worker environment (the
Playwright smokes fail with EACCES on that port). The example builds
themselves compile cleanly; the substantive coverage for these
examples lives in the CLJS unit tests above and in the bundle-
isolation gate, both green.

## Closes

- rf2-1875u
- rf2-88mf8
- rf2-cwlnl