### PR TITLE
refactor(examples): fix framework-reserved-namespace violations in user-defined ids (rf2-fgkte + rf2-pwtfx + rf2-1m0jz)

### DIFF
--- a/examples/helix/README.md
+++ b/examples/helix/README.md
@@ -25,7 +25,7 @@ Per Decision 4 the `reg-view` macro stays Reagent-only; Helix users write `defnc
   Same `:counter/initialise` / `:counter/inc` / `:counter/dec` events as the Reagent counter; the view renders +/- buttons and a count between them. The count seeds to `5` (via `:counter/initialise`) and moves as the buttons dispatch.
 
 - **`helix/login_helix/`** ([build id `examples/login-helix`](../../implementation/shadow-cljs.edn))
-  Same login state machine (`:idle -> :submitting -> :authed`/`:error-shown`/`:locked-out`), same Malli schemas, same `:rf.http/managed.login-demo` stub fx as the Reagent and UIx login examples. The view layer is a Helix `defnc` form using `helix.hooks/use-state` for local input state. Entering credentials and submitting drives the machine to `:authed` and the welcome banner appears.
+  Same login state machine (`:idle -> :submitting -> :authed`/`:error-shown`/`:locked-out`), same Malli schemas, same `:auth.login.demo/managed-stub` stub fx as the Reagent and UIx login examples. The view layer is a Helix `defnc` form using `helix.hooks/use-state` for local input state. Entering credentials and submitting drives the machine to `:authed` and the welcome banner appears.
 
 - **`helix/process_monitor_helix/`** ([build id `examples/process-monitor-helix`](../../implementation/shadow-cljs.edn))
   Design-led example proving Helix can drive a substantive multi-pane layout. Shares the `_shared/css/style.css` "Editorial Warm" identity with the Reagent notebook and UIx dashboard counterparts. No state machines, no HTTP — design-led examples exist to prove polished visuals + interaction, not to replay platform features other examples already cover.

--- a/examples/helix/login_helix/core.cljs
+++ b/examples/helix/login_helix/core.cljs
@@ -61,7 +61,7 @@
     (when-let [ls (.-localStorage js/globalThis)]
       (.setItem ls "auth/token" token))))
 
-(rf/reg-fx :rf.http/managed.login-demo
+(rf/reg-fx :auth.login.demo/managed-stub
   {:doc       "Demo override for `:rf.http/managed`. Identical behaviour
                to the Reagent and UIx examples' stub.
 
@@ -258,5 +258,5 @@
   (rf/init! helix-adapter/adapter)
   (rf/reg-frame :rf/default
     {:doc          "Login (Helix) demo frame."
-     :fx-overrides {:rf.http/managed :rf.http/managed.login-demo}})
+     :fx-overrides {:rf.http/managed :auth.login.demo/managed-stub}})
   (.render react-root ($ root-view)))

--- a/examples/reagent/boot/core.cljs
+++ b/examples/reagent/boot/core.cljs
@@ -83,7 +83,7 @@
       (str/includes? u "/user.json")   demo-user
       :else                            {})))
 
-(rf/reg-fx :rf.http/managed.boot-demo
+(rf/reg-fx :boot.demo/http-stub
   {:doc       "Demo override for `:rf.http/managed`: routes by URL
                substring to canned boot responses so the example runs
                standalone without a backend. Delegates to the
@@ -134,7 +134,7 @@
   ;; non-mocked requests, so a blanket override is the right grain.
   (rf/reg-frame :rf/default
     {:doc          "Boot example demo frame."
-     :fx-overrides {:rf.http/managed :rf.http/managed.boot-demo}})
+     :fx-overrides {:rf.http/managed :boot.demo/http-stub}})
 
   ;; Kick the boot. The `:app/boot` machine's :initial state and
   ;; :data seed `[:rf/machines :app/boot]` on first dispatch (per

--- a/examples/reagent/boot/core.cljs
+++ b/examples/reagent/boot/core.cljs
@@ -60,9 +60,9 @@
    :title    "Pattern-Boot example app"})
 
 (def ^:private demo-routes
-  [{:id :route/home     :path "/"}
-   {:id :route/about    :path "/about"}
-   {:id :route/settings :path "/settings"}])
+  [{:id :boot.demo/home     :path "/"}
+   {:id :boot.demo/about    :path "/about"}
+   {:id :boot.demo/settings :path "/settings"}])
 
 (def ^:private demo-flags
   {:dark-mode?       false

--- a/examples/reagent/boot/test/boot/boot_test.cljs
+++ b/examples/reagent/boot/test/boot/boot_test.cljs
@@ -75,8 +75,8 @@
    :title    "Boot test app"})
 
 (def ^:private test-routes
-  [{:id :route/home  :path "/"}
-   {:id :route/about :path "/about"}])
+  [{:id :boot.demo/home  :path "/"}
+   {:id :boot.demo/about :path "/about"}])
 
 (def ^:private test-flags
   {:dark-mode?       true

--- a/examples/reagent/boot/test/boot/boot_test.cljs
+++ b/examples/reagent/boot/test/boot/boot_test.cljs
@@ -104,12 +104,12 @@
    is :ready, every staging slot is populated, and every top-level
    slice landed in app-db."
   []
-  (reg-canned-success-by-url! :rf.http/managed.boot-success payload-for)
+  (reg-canned-success-by-url! :boot.test/canned-boot-success payload-for)
 
   (with-frame [f (rf/make-frame
                    {:on-create    [:boot/initialise]
                     :fx-overrides {:rf.http/managed
-                                   :rf.http/managed.boot-success}})]
+                                   :boot.test/canned-boot-success}})]
     ;; The :on-create cofx fires :boot/initialise during make-frame,
     ;; which dispatches [:app/boot [:rf/start]]. The synchronous
     ;; drain runs all four canned-success stubs to completion.
@@ -136,12 +136,12 @@
    correctly so each child writes its payload to the matching
    staging key (no cross-talk between siblings)."
   []
-  (reg-canned-success-by-url! :rf.http/managed.boot-success payload-for)
+  (reg-canned-success-by-url! :boot.test/canned-boot-success payload-for)
 
   (with-frame [f (rf/make-frame
                    {:on-create    [:boot/initialise]
                     :fx-overrides {:rf.http/managed
-                                   :rf.http/managed.boot-success}})]
+                                   :boot.test/canned-boot-success}})]
     (let [db      (rf/get-frame-db f)
           staging (:boot/staging db)]
       ;; Each staging-key holds the payload that came back from the
@@ -165,7 +165,7 @@
   "A failure during the parallel phase routes the boot machine to
    :failed and records the error in :data."
   []
-  (reg-canned-failure! :rf.http/managed.boot-fail
+  (reg-canned-failure! :boot.test/canned-boot-fail
                        :rf.http/http-5xx
                        {:status 500
                         :body   "boot dependency unreachable"})
@@ -173,7 +173,7 @@
   (with-frame [f (rf/make-frame
                    {:on-create    [:boot/initialise]
                     :fx-overrides {:rf.http/managed
-                                   :rf.http/managed.boot-fail}})]
+                                   :boot.test/canned-boot-fail}})]
     (let [db    (rf/get-frame-db f)
           state (rf/compute-sub [:app.boot/state] db)]
       ;; Every child fails (the canned-failure stub is blanket); the

--- a/examples/reagent/login/core.cljs
+++ b/examples/reagent/login/core.cljs
@@ -97,7 +97,7 @@
 ;;
 ;; HTTP requests go via the framework-shipped `:rf.http/managed` (Spec 014).
 ;; The example demo would normally hit `/api/login`, which we don't ship —
-;; instead we register a per-app demo stub at `:rf.http/managed.login-demo`
+;; instead we register a per-app demo stub at `:auth.login.demo/managed-stub`
 ;; and override `:rf.http/managed` to it on the default frame in `run`. The
 ;; stub inspects the request body's `:password` and synthesises either a
 ;; success or failure reply via the framework-shipped canned-success /
@@ -115,7 +115,7 @@
     (when-let [ls (.-localStorage js/globalThis)]
       (.setItem ls "auth/token" token))))
 
-(rf/reg-fx :rf.http/managed.login-demo
+(rf/reg-fx :auth.login.demo/managed-stub
   {:doc       "Demo override for `:rf.http/managed`: routes by URL +
                request body to canned login responses so the example runs
                standalone without a backend.
@@ -364,5 +364,5 @@
   ;; backend required.
   (rf/reg-frame :rf/default
     {:doc          "Login demo frame."
-     :fx-overrides {:rf.http/managed :rf.http/managed.login-demo}})
+     :fx-overrides {:rf.http/managed :auth.login.demo/managed-stub}})
   (rdc/render react-root [root-view]))

--- a/examples/reagent/managed_http_counter/core.cljs
+++ b/examples/reagent/managed_http_counter/core.cljs
@@ -147,7 +147,7 @@
 ;; that contract end-to-end without requiring a real long-running
 ;; endpoint.
 
-(rf/reg-fx :rf.http/managed.long-stub
+(rf/reg-fx :managed-http-counter.demo/long-stub
   {:doc       "Per-app fx that synthesises a delayed :rf.http/managed
                reply for the :counter/start-long path. The deferred
                canned-failure reply lands ~750ms after dispatch, leaving
@@ -182,7 +182,7 @@
       ;; "long-running" demo uses the stub.
       :else
       {:db (assoc db :status :loading :error nil)
-       :fx [[:rf.http/managed.long-stub
+       :fx [[:managed-http-counter.demo/long-stub
              {:request    {:method :get :url "api/long"}
               :request-id :counter/long
               :decode     :json}]]})))

--- a/examples/reagent/realworld/README.md
+++ b/examples/reagent/realworld/README.md
@@ -79,7 +79,7 @@ The example's behaviour is verified by its CLJS test fixtures (see
 npm run test:cljs
 ```
 
-In production point `realworld.http/api-base` at <https://api.realworld.io/api>; for local development, the upstream spec ships a Node/Postgres reference backend that listens on `http://localhost:3000/api`. The demo entry installs an in-process `:rf.http/managed` override (`:rf.http/managed.realworld-demo`) that synthesises canned responses for the common reads (global feed, tags, profile) — Spec 014 §Testing — so the fixtures run without a network.
+In production point `realworld.http/api-base` at <https://api.realworld.io/api>; for local development, the upstream spec ships a Node/Postgres reference backend that listens on `http://localhost:3000/api`. The demo entry installs an in-process `:rf.http/managed` override (`:conduit.demo/http-stub`) that synthesises canned responses for the common reads (global feed, tags, profile) — Spec 014 §Testing — so the fixtures run without a network.
 
 To view the app in a browser, build it under shadow-cljs id `examples/realworld` from `implementation/`:
 
@@ -117,7 +117,7 @@ at `implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs`
 (run with `npm run test:cljs` from the `implementation/` directory).
 
 Together the fixtures exercise the user-visible flow against the
-`:rf.http/managed.realworld-demo` override: the initial-load shell
+`:conduit.demo/http-stub` override: the initial-load shell
 (navbar, global feed, sidebar tags), article-detail navigation, the
 auth machine end-to-end (login → authed navbar), and an optimistic
 comment-submission round-trip through the comment form.

--- a/examples/reagent/realworld/article_editor.cljs
+++ b/examples/reagent/realworld/article_editor.cljs
@@ -326,7 +326,7 @@
       {:db (assoc db :editor (editor-slice (:slug article) draft))
        :fx [[:dispatch [:ui/article-editor [:use-edit]]]
             [:dispatch [:ui/article-editor [:submit-succeeded]]]
-            [:dispatch [:rf.route/navigate :route/article {:slug (:slug article)}]]]})))
+            [:dispatch [:rf.route/navigate :conduit.article/show {:slug (:slug article)}]]]})))
 
 (rf/reg-event-fx :editor/submit-error
   (fn [{:keys [db]} [_ {:keys [failure]}]]
@@ -353,7 +353,7 @@
   (fn [{:keys [db]} _]
     {:db (assoc db :editor (editor-slice))
      :fx [[:dispatch [:ui/article-editor [:reset]]]
-          [:dispatch [:rf.route/navigate :route/home]]]}))
+          [:dispatch [:rf.route/navigate :conduit/home]]]}))
 
 (rf/reg-event-fx :editor/delete-error
   (fn [{:keys [db]} [_ {:keys [failure]}]]

--- a/examples/reagent/realworld/articles.cljs
+++ b/examples/reagent/realworld/articles.cljs
@@ -340,11 +340,11 @@
   (let [{:keys [slug title description createdAt favoritesCount author tagList]} article]
     [:div.article-preview
      [:div.article-meta
-      [rf/route-link {:to     :route/profile
+      [rf/route-link {:to     :conduit.profile/show
                            :params {:username (:username author)}}
        [:img {:src (:image author)}]]
       [:div.info
-       [rf/route-link {:to     :route/profile
+       [rf/route-link {:to     :conduit.profile/show
                             :params {:username (:username author)}
                             :class  "author"}
         (:username author)]
@@ -353,7 +353,7 @@
        {:type "button"
         :on-click #(dispatch [:article/toggle-favorite slug])}
        [:i.ion-heart] " " favoritesCount]]
-     [rf/route-link {:to          :route/article
+     [rf/route-link {:to          :conduit.article/show
                           :params      {:slug slug}
                           :class       "preview-link"
                           :data-testid (str "article-preview-link-" slug)}

--- a/examples/reagent/realworld/auth.cljs
+++ b/examples/reagent/realworld/auth.cljs
@@ -131,7 +131,7 @@
           {:data {:error nil}
            :fx [[:dispatch [:auth/store-session user]]
                 [:auth.session/persist {:token (:token user)}]
-                [:dispatch [:rf.route/navigate :route/home]]]}))
+                [:dispatch [:rf.route/navigate :conduit/home]]]}))
 
       :record-error
       (fn [{[_ {:keys [failure]}] :event}]
@@ -142,7 +142,7 @@
         {:data {:error nil}
          :fx [[:dispatch [:auth/clear-session]]
               [:auth.session/persist {:token nil}]
-              [:dispatch [:rf.route/navigate :route/home]]]})}
+              [:dispatch [:rf.route/navigate :conduit/home]]]})}
      :states
      {:idle
       {:on {:auth/login    {:target :submitting :action :begin-login}
@@ -314,7 +314,7 @@
         err         @(subscribe [:auth/error])]
     [:div.auth-page {:data-testid "login-page"}
      [:h1 "Sign in"]
-     [rf/route-link {:to :route/register} "Need an account?"]
+     [rf/route-link {:to :conduit.auth/register} "Need an account?"]
      (when err [:ul.error-messages [:li err]])
      [:form
       {:data-testid "login-form"
@@ -348,7 +348,7 @@
         err         @(subscribe [:auth/error])]
     [:div.auth-page
      [:h1 "Sign up"]
-     [rf/route-link {:to :route/login} "Have an account?"]
+     [rf/route-link {:to :conduit.auth/login} "Have an account?"]
      (when err [:ul.error-messages [:li err]])
      [:form
       {:on-submit (fn [e]

--- a/examples/reagent/realworld/comments.cljs
+++ b/examples/reagent/realworld/comments.cljs
@@ -295,7 +295,7 @@
     [:div.card {:data-testid (str "comment-card-" (:id comment))}
      [:div.card-block [:p.card-text {:data-testid "comment-body"} (:body comment)]]
      [:div.card-footer
-      [rf/route-link {:to     :route/profile
+      [rf/route-link {:to     :conduit.profile/show
                            :params {:username (get-in comment [:author :username])}
                            :class  "comment-author"}
        [:img.comment-author-img {:src (get-in comment [:author :image])}]
@@ -353,7 +353,7 @@
               [:li.tag-default.tag-pill.tag-outline tag])]]]
          [:hr]
          [:div.article-actions
-          [rf/route-link {:to :route/home} "Back to feed"]]
+          [rf/route-link {:to :conduit/home} "Back to feed"]]
          [:div.row
           [:div.col-xs-12.col-md-8.offset-md-2
            (if current-user
@@ -382,9 +382,9 @@
               (when submit-error
                 [:div.error-messages submit-error])]
              [:p
-              [rf/route-link {:to :route/login} "Sign in"]
+              [rf/route-link {:to :conduit.auth/login} "Sign in"]
               " or "
-              [rf/route-link {:to :route/register} "sign up"]
+              [rf/route-link {:to :conduit.auth/register} "sign up"]
               " to add comments."])
            (when comments-error
              [:div.article-preview.error

--- a/examples/reagent/realworld/core.cljs
+++ b/examples/reagent/realworld/core.cljs
@@ -148,7 +148,7 @@
 (reg-view ^{:doc "Renders a confirm dialog when navigation is blocked by a
                   :can-leave guard. Reads the :rf/pending-navigation slot."}
           pending-nav-dialog []
-  (when-let [pending @(subscribe [:rf/pending-navigation])]
+  (when-let [pending @(subscribe [:conduit.routing/pending-navigation])]
     [:div.pending-nav-overlay
      [:div.pending-nav-dialog
       [:p (or (:reason pending) "You have unsaved changes. Leave anyway?")]

--- a/examples/reagent/realworld/core.cljs
+++ b/examples/reagent/realworld/core.cljs
@@ -102,20 +102,20 @@
         user    @(subscribe [:auth/user])]
     [:nav.navbar.navbar-light
      [:div.container
-      [rf/route-link {:to :route/home :class "navbar-brand"} "conduit"]
+      [rf/route-link {:to :conduit/home :class "navbar-brand"} "conduit"]
       [:ul.nav.navbar-nav.pull-xs-right
        [:li.nav-item
-        [rf/route-link {:to :route/home :class "nav-link"} "Home"]]
+        [rf/route-link {:to :conduit/home :class "nav-link"} "Home"]]
        (if authed?
          [:<>
           [:li.nav-item
-           [rf/route-link {:to :route/editor :class "nav-link"}
+           [rf/route-link {:to :conduit.editor/new :class "nav-link"}
             [:i.ion-compose] " New Article"]]
           [:li.nav-item
-           [rf/route-link {:to :route/settings :class "nav-link"}
+           [rf/route-link {:to :conduit.user/settings :class "nav-link"}
             [:i.ion-gear-a] " Settings"]]
           [:li.nav-item
-           [rf/route-link {:to :route/profile
+           [rf/route-link {:to :conduit.profile/show
                                 :params {:username (:username user)}
                                 :class "nav-link"
                                 :data-testid "nav-username"}
@@ -128,12 +128,12 @@
             "Logout"]]]
          [:<>
           [:li.nav-item
-           [rf/route-link {:to :route/login
+           [rf/route-link {:to :conduit.auth/login
                                 :class "nav-link"
                                 :data-testid "nav-signin"}
             "Sign in"]]
           [:li.nav-item
-           [rf/route-link {:to :route/register
+           [rf/route-link {:to :conduit.auth/register
                                 :class "nav-link"
                                 :data-testid "nav-signup"}
             "Sign up"]]])]]]))
@@ -141,7 +141,7 @@
 (reg-view footer []
   [:footer
    [:div.container
-    [rf/route-link {:to :route/home :class "logo-font"} "conduit"]
+    [rf/route-link {:to :conduit/home :class "logo-font"} "conduit"]
     [:span.attribution "An interactive learning project from Thinkster."
      " Code & design licensed under MIT."]]])
 
@@ -162,7 +162,7 @@
     [:div.not-found-page
      [:h1 "Page not found"]
      (when url [:p (str "No route matches: " url)])
-     [rf/route-link {:to :route/home} "Home"]]))
+     [rf/route-link {:to :conduit/home} "Home"]]))
 
 (reg-view ^{:doc "App-level root. Switches on :rf.route/id to render the active page."}
           root-view []
@@ -170,15 +170,15 @@
    [header]
    [pending-nav-dialog]
    (case @(subscribe [:rf.route/id])
-     :route/home              [articles/home-page]
-     :route/login             [auth/login-page]
-     :route/register          [auth/register-page]
-     :route/article           [comments/article-page]
-     :route/editor            [editor/editor-page]
-     :route/editor.edit       [editor/editor-page]
-     :route/profile           [profile/profile-page]
-     :route/profile.favorites [profile/profile-page]
-     :route/settings          [settings/settings-page]
+     :conduit/home              [articles/home-page]
+     :conduit.auth/login             [auth/login-page]
+     :conduit.auth/register          [auth/register-page]
+     :conduit.article/show           [comments/article-page]
+     :conduit.editor/new            [editor/editor-page]
+     :conduit.editor/edit       [editor/editor-page]
+     :conduit.profile/show           [profile/profile-page]
+     :conduit.profile/favorites [profile/profile-page]
+     :conduit.user/settings          [settings/settings-page]
      [not-found-page])
    [footer]])
 
@@ -388,7 +388,7 @@
   ;; for all non-navigation events and redirects unauthenticated
   ;; `:rf.route/navigate` to `:requires-auth`-tagged routes to login (Spec
   ;; 012 §Redirects and guards). This is what makes the `:requires-auth`
-  ;; tags on :route/settings / :route/editor / :route/editor.edit actually
+  ;; tags on :conduit.user/settings / :conduit.editor/new / :conduit.editor/edit actually
   ;; protect those routes.
   (rf/reg-frame :rf/default {:doc          "Realworld demo frame."
                              :interceptors [routing/auth-guard]
@@ -398,7 +398,7 @@
   ;; authenticated requests as soon as the JWT is hydrated.
   (rf/reg-http-interceptor :realworld/bearer-auth bearer-auth-interceptor)
   ;; The orchestrator serves this example at /realworld/; strip that
-  ;; prefix before the route matcher sees the URL so :route/home (path "/")
+  ;; prefix before the route matcher sees the URL so :conduit/home (path "/")
   ;; matches.
   (routing/set-base-path! "/realworld")
   (rf/dispatch-sync [:app/initialise])

--- a/examples/reagent/realworld/core.cljs
+++ b/examples/reagent/realworld/core.cljs
@@ -309,7 +309,7 @@
 
       :else {})))
 
-(rf/reg-fx :rf.http/managed.realworld-demo
+(rf/reg-fx :conduit.demo/http-stub
   {:doc       "Demo override for :rf.http/managed: routes by URL to canned
                Conduit-shaped responses so the example runs standalone
                without a backend. Delegates to :rf.http/managed-canned-success
@@ -392,7 +392,7 @@
   ;; protect those routes.
   (rf/reg-frame :rf/default {:doc          "Realworld demo frame."
                              :interceptors [routing/auth-guard]
-                             :fx-overrides {:rf.http/managed :rf.http/managed.realworld-demo}})
+                             :fx-overrides {:rf.http/managed :conduit.demo/http-stub}})
   ;; Register the Bearer-auth interceptor at app boot. Order matters:
   ;; before :app/initialise dispatches, since session-restore will fire
   ;; authenticated requests as soon as the JWT is hydrated.

--- a/examples/reagent/realworld/profile.cljs
+++ b/examples/reagent/realworld/profile.cljs
@@ -51,7 +51,7 @@
 ;;   :tab    — which list of articles is rendered (authored vs favorited).
 ;;             Driven by `:show-articles` / `:show-favorites` broadcasts
 ;;             from the route's `:on-match` (see `routing.cljs`'s
-;;             `:route/profile` and `:route/profile.favorites`). The
+;;             `:conduit.profile/show` and `:conduit.profile/favorites`). The
 ;;             state-keyword tells the view which app-db slice's items
 ;;             to render.
 ;;
@@ -405,7 +405,7 @@
          [:h4 (:username profile)]
          [:p (:bio profile)]
          (if own?
-           [rf/route-link {:to :route/settings
+           [rf/route-link {:to :conduit.user/settings
                                 :class "btn btn-sm btn-outline-secondary action-btn"}
             [:i.ion-gear-a] " Edit Profile Settings"]
            [:button.btn.btn-sm.btn-outline-secondary.action-btn
@@ -421,12 +421,12 @@
         [:div.articles-toggle
          [:ul.nav.nav-pills.outline-active
           [:li.nav-item
-           [rf/route-link {:to     :route/profile
+           [rf/route-link {:to     :conduit.profile/show
                                 :params {:username (:username profile)}
                                 :class  (str "nav-link" (when-not on-favs? " active"))}
             "My Articles"]]
           [:li.nav-item
-           [rf/route-link {:to     :route/profile.favorites
+           [rf/route-link {:to     :conduit.profile/favorites
                                 :params {:username (:username profile)}
                                 :class  (str "nav-link" (when on-favs? " active"))}
             "Favorited Articles"]]]]

--- a/examples/reagent/realworld/routing.cljs
+++ b/examples/reagent/realworld/routing.cljs
@@ -135,7 +135,7 @@
 ;; SUBSCRIPTIONS
 ;; ============================================================================
 
-(rf/reg-sub :rf/pending-navigation
+(rf/reg-sub :conduit.routing/pending-navigation
   (fn [db _] (:rf/pending-navigation db)))
 
 ;; ============================================================================

--- a/examples/reagent/realworld/routing.cljs
+++ b/examples/reagent/realworld/routing.cljs
@@ -26,7 +26,7 @@
 ;; ROUTES
 ;; ============================================================================
 
-(rf/reg-route :route/home
+(rf/reg-route :conduit/home
   {:doc      "The landing page: global feed, your feed, and optional tag filter."
    :path     "/"
    :query    [:map
@@ -35,28 +35,28 @@
    :on-match [[:home/load]]
    :scroll   :top})
 
-(rf/reg-route :route/login
+(rf/reg-route :conduit.auth/login
   {:doc  "Login page."
    :path "/login"})
 
-(rf/reg-route :route/register
+(rf/reg-route :conduit.auth/register
   {:doc  "Register page."
    :path "/register"})
 
-(rf/reg-route :route/settings
+(rf/reg-route :conduit.user/settings
   {:doc  "User settings page (requires auth)."
    :path "/settings"
    :on-match [[:settings/load]]
    :tags #{:requires-auth}})
 
-(rf/reg-route :route/editor
+(rf/reg-route :conduit.editor/new
   {:doc       "Create a new article (requires auth)."
    :path      "/editor"
    :tags      #{:requires-auth}
    :on-match  [[:editor/initialise]]
    :can-leave [:editor/can-leave?]})
 
-(rf/reg-route :route/editor.edit
+(rf/reg-route :conduit.editor/edit
   {:doc       "Edit an existing article (requires auth)."
    :path      "/editor/:slug"
    :params    [:map [:slug :string]]
@@ -64,7 +64,7 @@
    :can-leave [:editor/can-leave?]
    :on-match  [[:editor/load-article]]})
 
-(rf/reg-route :route/article
+(rf/reg-route :conduit.article/show
   {:doc      "Article detail page. The #comments fragment scrolls to comments."
    :path     "/article/:slug"
    :params   [:map [:slug :string]]
@@ -72,14 +72,14 @@
               [:comments/load]]
    :scroll   :top})
 
-(rf/reg-route :route/profile
+(rf/reg-route :conduit.profile/show
   {:doc      "A user's profile — articles they authored."
    :path     "/profile/:username"
    :params   [:map [:username :string]]
    :on-match [[:profile/load]
               [:profile.articles/load]]})
 
-(rf/reg-route :route/profile.favorites
+(rf/reg-route :conduit.profile/favorites
   {:doc      "A user's profile — articles they have favorited."
    :path     "/profile/:username/favorites"
    :params   [:map [:username :string]]
@@ -98,7 +98,7 @@
 ;; not a special routing mechanism. Guards are plain interceptors; they
 ;; compose, and multiple guards can layer. This one redirects
 ;; unauthenticated users away from any route tagged `:requires-auth`
-;; (`:route/settings`, `:route/editor`, `:route/editor.edit`) to the login
+;; (`:conduit.user/settings`, `:conduit.editor/new`, `:conduit.editor/edit`) to the login
 ;; page, stashing the original target under `:return-to` so a post-login
 ;; handler could bounce the user back.
 ;;
@@ -114,7 +114,7 @@
 ;; tests exercise.)
 
 (def auth-guard
-  {:id     :route/auth-guard
+  {:id     :conduit.routing/auth-guard
    :before (fn auth-guard-before [ctx]
              (let [event (get-in ctx [:coeffects :event])]
                (if (= :rf.route/navigate (first event))
@@ -127,7 +127,7 @@
                      ;; `:rf.route/navigate` is [_ target params opts]; the
                      ;; original target rides through under :return-to.
                      (assoc-in ctx [:coeffects :event]
-                               [:rf.route/navigate :route/login {} {:return-to target}])
+                               [:rf.route/navigate :conduit.auth/login {} {:return-to target}])
                      ctx))
                  ctx)))})
 

--- a/examples/reagent/realworld/settings.cljs
+++ b/examples/reagent/realworld/settings.cljs
@@ -221,7 +221,7 @@
 
 (rf/reg-event-fx :settings/load
   {:doc "Seed the form draft from the currently-authenticated user.
-         Dispatched by the :route/settings :on-match (see routing.cljs)
+         Dispatched by the :conduit.user/settings :on-match (see routing.cljs)
          and by tests after :auth/store-session."}
   [(rf/inject-cofx :realworld/now)]
   (fn handler-settings-load [{:keys [db realworld/now]} _]
@@ -271,7 +271,7 @@
       {:fx [[:dispatch [:settings/form
                         [:submit-succeeded {:user user}]]]
             [:dispatch [:auth/store-session user]]
-            [:dispatch [:rf.route/navigate :route/profile {:username (:username user)}]]]})))
+            [:dispatch [:rf.route/navigate :conduit.profile/show {:username (:username user)}]]]})))
 
 (rf/reg-event-fx :settings/submit-error
   {:doc "Server rejected. Folds a human-readable error message into the

--- a/examples/reagent/realworld/tags.cljs
+++ b/examples/reagent/realworld/tags.cljs
@@ -224,7 +224,7 @@
 ;; - `?feed=your` switches the home page to the authenticated feed
 ;; - navigation is always expressed as `:rf.route/navigate` events
 ;;
-;; `:home/load` is dispatched by the `:route/home` `:on-match`; it
+;; `:home/load` is dispatched by the `:conduit/home` `:on-match`; it
 ;; broadcasts the per-axis transitions into the home machine
 ;; (`:realworld/articles-home`) before kicking the per-feed fetch.
 
@@ -232,7 +232,7 @@
   (get-in db [:rf/route :query] {}))
 
 (rf/reg-event-fx :home/load
-  {:doc "Route :on-match handler for `:route/home`. Reads the route's
+  {:doc "Route :on-match handler for `:conduit/home`. Reads the route's
          query params and:
            - broadcasts the `:feed` region into `:user-feed` / `:tag-feed`
              / `:global` per `?feed=` and `?tag=`,
@@ -259,20 +259,20 @@
 
 (rf/reg-event-fx :home/show-global-feed
   (fn [_ _]
-    {:fx [[:dispatch [:rf.route/navigate :route/home {} {:query {}}]]]}))
+    {:fx [[:dispatch [:rf.route/navigate :conduit/home {} {:query {}}]]]}))
 
 (rf/reg-event-fx :home/show-your-feed
   (fn [_ _]
-    {:fx [[:dispatch [:rf.route/navigate :route/home {} {:query {:feed "your"}}]]]}))
+    {:fx [[:dispatch [:rf.route/navigate :conduit/home {} {:query {:feed "your"}}]]]}))
 
 (rf/reg-event-fx :tags/apply-filter
   (fn [_ [_ tag]]
-    {:fx [[:dispatch [:rf.route/navigate :route/home {} {:query {:tag tag}}]]]}))
+    {:fx [[:dispatch [:rf.route/navigate :conduit/home {} {:query {:tag tag}}]]]}))
 
 (rf/reg-event-fx :tags/clear-filter
   (fn [{:keys [db]} _]
     (let [query (dissoc (home-query db) :tag)]
-      {:fx [[:dispatch [:rf.route/navigate :route/home {} {:query query}]]]})))
+      {:fx [[:dispatch [:rf.route/navigate :conduit/home {} {:query query}]]]})))
 
 (rf/reg-sub :home/query
   (fn [db _] (home-query db)))

--- a/examples/reagent/realworld/test/realworld/article_editor_test.cljs
+++ b/examples/reagent/realworld/test/realworld/article_editor_test.cljs
@@ -9,7 +9,7 @@
   (:require-macros [re-frame.core :refer [with-frame]]))
 
 (defn editor-create-test []
-  (th/reg-canned-success! :rf.http/managed.canned-editor-save
+  (th/reg-canned-success! :conduit.test/canned-editor-save
                           {:article {:slug "hello-world"
                                      :title "Hello"
                                      :description "Short"
@@ -22,7 +22,7 @@
                                      :author {:username "alice" :bio nil :image nil :following false}}})
 
   (with-frame [f (rf/make-frame {:on-create [:app/initialise]
-                                 :fx-overrides {:rf.http/managed :rf.http/managed.canned-editor-save}})]
+                                 :fx-overrides {:rf.http/managed :conduit.test/canned-editor-save}})]
     (rf/dispatch-sync [:editor/initialise] {:frame f})
     ;; The :mode region starts at :create; the :lifecycle region starts
     ;; at :idle.

--- a/examples/reagent/realworld/test/realworld/articles_test.cljs
+++ b/examples/reagent/realworld/test/realworld/articles_test.cljs
@@ -8,7 +8,7 @@
   (:require-macros [re-frame.core :refer [with-frame]]))
 
 (defn articles-load-test []
-  (th/reg-canned-success! :rf.http/managed.canned-articles
+  (th/reg-canned-success! :conduit.test/canned-articles
                           {:articles [{:slug "hello-world"
                                        :title "Hello, world"
                                        :description "An intro"
@@ -23,7 +23,7 @@
                            :articlesCount 1})
 
   (with-frame [f (rf/make-frame {:on-create [:app/initialise]
-                                 :fx-overrides {:rf.http/managed :rf.http/managed.canned-articles}})]
+                                 :fx-overrides {:rf.http/managed :conduit.test/canned-articles}})]
     (assert (= :idle (:status (rf/compute-sub [:articles] (rf/get-frame-db f)))))
     (rf/dispatch-sync [:articles/load] {:frame f})
     (let [slice (rf/compute-sub [:articles] (rf/get-frame-db f))]
@@ -36,13 +36,13 @@
       (assert (= 2 (:attempt slice))))))
 
 (defn articles-load-failure-test []
-  (th/reg-canned-failure! :rf.http/managed.canned-articles-failure
+  (th/reg-canned-failure! :conduit.test/canned-articles-failure
                           :rf.http/http-5xx
                           {:status 500
                            :body   "server error"})
 
   (with-frame [f (rf/make-frame {:on-create [:app/initialise]
-                                 :fx-overrides {:rf.http/managed :rf.http/managed.canned-articles-failure}})]
+                                 :fx-overrides {:rf.http/managed :conduit.test/canned-articles-failure}})]
     (rf/dispatch-sync [:articles/load] {:frame f})
     (assert (= :error (:status (rf/compute-sub [:articles] (rf/get-frame-db f)))))
     (assert (some? (rf/compute-sub [:articles/error] (rf/get-frame-db f))))))

--- a/examples/reagent/realworld/test/realworld/auth_test.cljs
+++ b/examples/reagent/realworld/test/realworld/auth_test.cljs
@@ -15,7 +15,7 @@
   (:require-macros [re-frame.core :refer [with-frame]]))
 
 (defn login-happy-path-test []
-  (th/reg-canned-success! :rf.http/managed.login-success
+  (th/reg-canned-success! :conduit.test/login-success
                           {:user {:email    "alice@example.com"
                                   :username "alice"
                                   :token    "jwt-abc"
@@ -23,7 +23,7 @@
                                   :image    nil}})
 
   (with-frame [f (rf/make-frame {:on-create    [:auth/initialise]
-                                 :fx-overrides {:rf.http/managed      :rf.http/managed.login-success
+                                 :fx-overrides {:rf.http/managed      :conduit.test/login-success
                                                 :auth.session/persist :rf/no-op}})]
     (assert (= :idle (rf/compute-sub [:auth/state] (rf/get-frame-db f))))
 
@@ -57,13 +57,13 @@
             "the misshapen-cofx witness — the value must NOT land at top of ctx")))
 
 (defn login-failure-test []
-  (th/reg-canned-failure! :rf.http/managed.login-failure
+  (th/reg-canned-failure! :conduit.test/login-failure
                           :rf.http/http-4xx
                           {:status 422
                            :body   {:errors {:body ["email or password is invalid"]}}})
 
   (with-frame [f (rf/make-frame {:on-create    [:auth/initialise]
-                                 :fx-overrides {:rf.http/managed :rf.http/managed.login-failure}})]
+                                 :fx-overrides {:rf.http/managed :conduit.test/login-failure}})]
     (rf/dispatch-sync [:auth/flow [:auth/login {:email "x@y.z" :password "wrong"}]]
                       {:frame f})
     (assert (= :error (rf/compute-sub [:auth/state] (rf/get-frame-db f))))

--- a/examples/reagent/realworld/test/realworld/comments_test.cljs
+++ b/examples/reagent/realworld/test/realworld/comments_test.cljs
@@ -18,7 +18,7 @@
   ;; URL-routed stub: the article-detail page issues two requests
   ;; (`/articles/:slug` and `/articles/:slug/comments`); pick the canned
   ;; payload from the URL.
-  (th/reg-canned-success-by-url! :rf.http/managed.canned-article-and-comments
+  (th/reg-canned-success-by-url! :conduit.test/canned-article-and-comments
                                  (fn [url]
                                    (cond
                                      (str/ends-with? url "/comments")
@@ -41,7 +41,7 @@
                                                 :author {:username "alice" :bio nil :image nil :following false}}})))
 
   (with-frame [f (rf/make-frame {:on-create [:app/initialise]
-                                 :fx-overrides {:rf.http/managed :rf.http/managed.canned-article-and-comments}})]
+                                 :fx-overrides {:rf.http/managed :conduit.test/canned-article-and-comments}})]
     (rf/dispatch-sync [:article/initialise] {:frame f})
     (rf/dispatch-sync [:comments/initialise] {:frame f})
     (rf/dispatch-sync [:comment-form/initialise] {:frame f})
@@ -50,7 +50,7 @@
     (assert (= 1 (count (rf/compute-sub [:comments/data] (rf/get-frame-db f)))))))
 
 (defn comment-submit-test []
-  (th/reg-canned-success-by-url! :rf.http/managed.canned-comment-post
+  (th/reg-canned-success-by-url! :conduit.test/canned-comment-post
                                  (fn [method url]
                                    (cond
                                      ;; POST /articles/:slug/comments → returns the saved comment.
@@ -80,7 +80,7 @@
                                                 :author {:username "alice" :bio nil :image nil :following false}}})))
 
   (with-frame [f (rf/make-frame {:on-create [:app/initialise]
-                                 :fx-overrides {:rf.http/managed :rf.http/managed.canned-comment-post}})]
+                                 :fx-overrides {:rf.http/managed :conduit.test/canned-comment-post}})]
     (rf/dispatch-sync [:article/initialise] {:frame f})
     (rf/dispatch-sync [:comments/initialise] {:frame f})
     (rf/dispatch-sync [:comment-form/initialise] {:frame f})

--- a/examples/reagent/realworld/test/realworld/core_test.cljs
+++ b/examples/reagent/realworld/test/realworld/core_test.cljs
@@ -15,11 +15,11 @@
 ;; A generic success stub: every :rf.http/managed call resolves :success
 ;; with an empty map. Tests register a richer canned response when they
 ;; need specific payloads.
-(th/reg-canned-success! :rf.http/managed.canned-success-empty {})
+(th/reg-canned-success! :conduit.test/canned-success-empty {})
 
 (defn app-smoke-test []
   (with-frame [f (rf/make-frame {:on-create    [:app/initialise]
-                                 :fx-overrides {:rf.http/managed      :rf.http/managed.canned-success-empty
+                                 :fx-overrides {:rf.http/managed      :conduit.test/canned-success-empty
                                                 :auth.session/persist :rf/no-op}})]
     ;; After init: auth + articles slices and the :realworld/tags
     ;; and :settings/form machine snapshots are present. The tags

--- a/examples/reagent/realworld/test/realworld/favorites_test.cljs
+++ b/examples/reagent/realworld/test/realworld/favorites_test.cljs
@@ -8,13 +8,13 @@
   (:require-macros [re-frame.core :refer [with-frame]]))
 
 (defn favorite-toggle-test []
-  (th/reg-canned-failure! :rf.http/managed.favorite-rollback
+  (th/reg-canned-failure! :conduit.test/favorite-rollback
                           :rf.http/http-4xx
                           {:status 400
                            :body   {:errors {:body ["rollback"]}}})
 
   (with-frame [f (rf/make-frame {:on-create [:app/initialise]
-                                 :fx-overrides {:rf.http/managed :rf.http/managed.favorite-rollback}})]
+                                 :fx-overrides {:rf.http/managed :conduit.test/favorite-rollback}})]
     (rf/dispatch-sync [:articles/initialise] {:frame f})
     (rf/dispatch-sync [:articles/loaded
                        {:kind :success

--- a/examples/reagent/realworld/test/realworld/profile_test.cljs
+++ b/examples/reagent/realworld/test/realworld/profile_test.cljs
@@ -9,7 +9,7 @@
   (:require-macros [re-frame.core :refer [with-frame]]))
 
 (defn profile-load-test []
-  (th/reg-canned-success-by-url! :rf.http/managed.canned-profile
+  (th/reg-canned-success-by-url! :conduit.test/canned-profile
                                  (fn [url]
                                    (if (str/includes? url "/profiles/")
                                      {:profile {:username "eve" :bio "Writes things" :image nil :following false}}
@@ -25,7 +25,7 @@
                                                   :author {:username "eve" :bio nil :image nil :following false}}]})))
 
   (with-frame [f (rf/make-frame {:on-create [:app/initialise]
-                                 :fx-overrides {:rf.http/managed :rf.http/managed.canned-profile}})]
+                                 :fx-overrides {:rf.http/managed :conduit.test/canned-profile}})]
     (rf/dispatch-sync [:profile/initialise] {:frame f})
     (rf/dispatch-sync [:rf.route/handle-url-change "/profile/eve"] {:frame f})
     (assert (= "eve" (:username (rf/compute-sub [:profile/data] (rf/get-frame-db f)))))

--- a/examples/reagent/realworld/test/realworld/routing_test.cljs
+++ b/examples/reagent/realworld/test/realworld/routing_test.cljs
@@ -8,15 +8,15 @@
 
 (defn routing-tests []
   (with-frame [f (rf/make-frame {:on-create [:app/initialise]})]
-    (rf/dispatch-sync [:rf.route/navigate :route/article {:slug "hello"}] {:frame f})
-    (assert (= :route/article (rf/compute-sub [:rf.route/id] (rf/get-frame-db f))))
+    (rf/dispatch-sync [:rf.route/navigate :conduit.article/show {:slug "hello"}] {:frame f})
+    (assert (= :conduit.article/show (rf/compute-sub [:rf.route/id] (rf/get-frame-db f))))
     (assert (= "hello" (:slug (rf/compute-sub [:rf.route/params] (rf/get-frame-db f)))))
 
     (rf/dispatch-sync [:rf.route/handle-url-change "/profile/eve"] {:frame f})
-    (assert (= :route/profile (rf/compute-sub [:rf.route/id] (rf/get-frame-db f))))
+    (assert (= :conduit.profile/show (rf/compute-sub [:rf.route/id] (rf/get-frame-db f))))
 
     (rf/dispatch-sync [:rf.route/handle-url-change "/settings"] {:frame f})
-    (assert (= :route/settings (rf/compute-sub [:rf.route/id] (rf/get-frame-db f))))
+    (assert (= :conduit.user/settings (rf/compute-sub [:rf.route/id] (rf/get-frame-db f))))
 
     (rf/dispatch-sync [:rf.route/handle-url-change "/?tag=clojure"] {:frame f})
     (assert (= "clojure" (:tag (rf/compute-sub [:rf.route/query] (rf/get-frame-db f)))))
@@ -32,18 +32,18 @@
   (with-frame [f (rf/make-frame {:on-create    [:app/initialise]
                                  :interceptors [routing/auth-guard]})]
     ;; Unauthenticated: navigating to a :requires-auth route
-    ;; (:route/settings) is redirected to :route/login.
-    (rf/dispatch-sync [:rf.route/navigate :route/settings {}] {:frame f})
-    (assert (= :route/login (rf/compute-sub [:rf.route/id] (rf/get-frame-db f)))
+    ;; (:conduit.user/settings) is redirected to :conduit.auth/login.
+    (rf/dispatch-sync [:rf.route/navigate :conduit.user/settings {}] {:frame f})
+    (assert (= :conduit.auth/login (rf/compute-sub [:rf.route/id] (rf/get-frame-db f)))
             "unauthenticated nav to a :requires-auth route redirects to login")
 
     ;; A non-guarded route is unaffected by the guard.
-    (rf/dispatch-sync [:rf.route/navigate :route/home {}] {:frame f})
-    (assert (= :route/home (rf/compute-sub [:rf.route/id] (rf/get-frame-db f)))
+    (rf/dispatch-sync [:rf.route/navigate :conduit/home {}] {:frame f})
+    (assert (= :conduit/home (rf/compute-sub [:rf.route/id] (rf/get-frame-db f)))
             "unguarded route navigates normally with the guard installed")
 
     ;; Authenticated: the same guarded nav now proceeds.
     (rf/dispatch-sync [:auth/store-session {:username "eve" :token "t"}] {:frame f})
-    (rf/dispatch-sync [:rf.route/navigate :route/settings {}] {:frame f})
-    (assert (= :route/settings (rf/compute-sub [:rf.route/id] (rf/get-frame-db f)))
+    (rf/dispatch-sync [:rf.route/navigate :conduit.user/settings {}] {:frame f})
+    (assert (= :conduit.user/settings (rf/compute-sub [:rf.route/id] (rf/get-frame-db f)))
             "authenticated nav to a :requires-auth route proceeds")))

--- a/examples/reagent/realworld/test/realworld/settings_test.cljs
+++ b/examples/reagent/realworld/test/realworld/settings_test.cljs
@@ -37,7 +37,7 @@
   ;;     (:status slice) = :submitted            (:state snap)  = :correct
   ;;     (:draft slice)                          (-> snap :data :draft)
   ;;     :submitting? (a derived boolean sub)    (machine-has-tag? :settings/in-flight)
-  (th/reg-canned-success! :rf.http/managed.canned-settings-save
+  (th/reg-canned-success! :conduit.test/canned-settings-save
                           {:user {:email "alice@example.com"
                                   :token "jwt-2"
                                   :username "alice"
@@ -45,7 +45,7 @@
                                   :image nil}})
 
   (with-frame [f (rf/make-frame {:on-create    [:app/initialise]
-                                 :fx-overrides {:rf.http/managed    :rf.http/managed.canned-settings-save
+                                 :fx-overrides {:rf.http/managed    :conduit.test/canned-settings-save
                                                 :auth.session/persist :rf/no-op}})]
     ;; After :app/initialise → :settings/initialise → [:reset], the
     ;; machine sits at :neutral with empty :data.
@@ -104,11 +104,11 @@
   ;; and the form-level error surface is the same one validation
   ;; would use (per Pattern-Forms — both paths render via :errors /
   ;; :submit-error).
-  (th/reg-canned-failure! :rf.http/managed.canned-settings-failure
+  (th/reg-canned-failure! :conduit.test/canned-settings-failure
                           :rf.http/http-5xx
                           {:status 500 :body "server error"})
   (with-frame [f (rf/make-frame {:on-create    [:app/initialise]
-                                 :fx-overrides {:rf.http/managed    :rf.http/managed.canned-settings-failure
+                                 :fx-overrides {:rf.http/managed    :conduit.test/canned-settings-failure
                                                 :auth.session/persist :rf/no-op}})]
     (rf/dispatch-sync [:auth/store-session {:email "alice@example.com"
                                             :token "jwt-1"

--- a/examples/reagent/realworld/test/realworld/ssr_test.cljc
+++ b/examples/reagent/realworld/test/realworld/ssr_test.cljc
@@ -7,7 +7,7 @@
   (:require [realworld.ssr :as ssr]))
 
 (defn hydration-payload-test []
-  (let [db {:rf/route {:id :route/home}
+  (let [db {:rf/route {:id :conduit/home}
             :auth {:user {:username "alice"} :token "jwt"}
             :articles {:status :loaded :data [] :error nil :loaded-at 1 :attempt 1}
             :transient {:popup true}}

--- a/examples/reagent/realworld/test/realworld/tags_test.cljs
+++ b/examples/reagent/realworld/test/realworld/tags_test.cljs
@@ -41,10 +41,10 @@
   ;;     (:status slice) = :loaded               (:state snap)  = :loaded
   ;;     (:data slice)                           (-> snap :data :tags)
   ;;     :loading? (a derived boolean sub)       (machine-has-tag? :tags/loading)
-  (th/reg-canned-success! :rf.http/managed.canned-tags
+  (th/reg-canned-success! :conduit.test/canned-tags
                           {:tags ["intro" "demo" "clojure"]})
   (with-frame [f (rf/make-frame {:on-create    [:app/initialise]
-                                 :fx-overrides {:rf.http/managed :rf.http/managed.canned-tags}})]
+                                 :fx-overrides {:rf.http/managed :conduit.test/canned-tags}})]
     ;; After :app/initialise → :tags/initialise → [:reset], the machine
     ;; sits at :idle with empty :data.
     (let [snap (snapshot (rf/get-frame-db f))]
@@ -92,11 +92,11 @@
   ;; Failure path — the :tags region lands in :error with the projected
   ;; failure message in :data, and the `:tags/error` derived sub picks
   ;; it up. Prior :data (if any) is preserved across the transition.
-  (th/reg-canned-failure! :rf.http/managed.canned-tags-failure
+  (th/reg-canned-failure! :conduit.test/canned-tags-failure
                           :rf.http/http-5xx
                           {:status 500 :body "server error"})
   (with-frame [f (rf/make-frame {:on-create    [:app/initialise]
-                                 :fx-overrides {:rf.http/managed :rf.http/managed.canned-tags-failure}})]
+                                 :fx-overrides {:rf.http/managed :conduit.test/canned-tags-failure}})]
     (rf/dispatch-sync [:tags/load] {:frame f})
     (let [db   (rf/get-frame-db f)
           snap (snapshot db)]

--- a/examples/reagent/routing/core.cljs
+++ b/examples/reagent/routing/core.cljs
@@ -26,15 +26,15 @@
 ;; ROUTES
 ;; ============================================================================
 
-(rf/reg-route :route/home
+(rf/reg-route :routing.app/home
   {:doc  "Landing page."
    :path "/"})
 
-(rf/reg-route :route/articles
+(rf/reg-route :routing.app/articles
   {:doc  "Articles list."
    :path "/articles"})
 
-(rf/reg-route :route/article-detail
+(rf/reg-route :routing.app/article-detail
   {:doc    "Detail page for one article."
    :path   "/articles/:id"
    :params [:map [:id :string]]})
@@ -77,7 +77,7 @@
 (reg-view home-page []
   [:div
    [:h1 "Welcome"]
-   [:p [rf/route-link {:to :route/articles
+   [:p [rf/route-link {:to :routing.app/articles
                        :data-testid "route-link-articles"}
         "See the articles →"]]])
 
@@ -87,7 +87,7 @@
    [:ul
     (for [{:keys [id title]} @(subscribe [:articles])]
       ^{:key id}
-      [:li [rf/route-link {:to :route/article-detail
+      [:li [rf/route-link {:to :routing.app/article-detail
                            :params {:id id}
                            :data-testid (str "route-link-article-" id)}
             title]])]])
@@ -99,12 +99,12 @@
       [:div
        [:h1 (:title article)]
        [:p (:body article)]
-       [:p [rf/route-link {:to :route/articles
+       [:p [rf/route-link {:to :routing.app/articles
                            :data-testid "route-link-back-to-articles"}
             "← Back"]]]
       [:div
        [:p "Article not found."]
-       [:p [rf/route-link {:to :route/articles
+       [:p [rf/route-link {:to :routing.app/articles
                            :data-testid "route-link-back-to-articles"}
             "← Back"]]])))
 
@@ -113,15 +113,15 @@
     [:div
      [:h1 "Not found"]
      [:p (str "No route matches: " url)]
-     [:p [rf/route-link {:to :route/home
+     [:p [rf/route-link {:to :routing.app/home
                          :data-testid "route-link-home"}
           "Home"]]]))
 
 (reg-view root-view []
   (case @(subscribe [:rf.route/id])
-    :route/home           [home-page]
-    :route/articles       [articles-page]
-    :route/article-detail [article-detail-page]
+    :routing.app/home           [home-page]
+    :routing.app/articles       [articles-page]
+    :routing.app/article-detail [article-detail-page]
     :rf.route/not-found   [not-found-page]
     [not-found-page]))
 

--- a/examples/reagent/ssr/core.cljc
+++ b/examples/reagent/ssr/core.cljc
@@ -105,7 +105,7 @@
     ;; `request` is the host-supplied HTTP request map (Ring shape under
     ;; the bundled adapter); read URL/headers/cookies from here rather
     ;; than from a positional event arg.
-    {:db (assoc db :rf/route {:id :route/articles :params {}})
+    {:db (assoc db :rf/route {:id :ssr.app/articles :params {}})
      :fx [[:rf.http/managed
            {:request    {:method :get :url "/api/articles"}
             :decode     :json

--- a/examples/reagent/ssr/index.html
+++ b/examples/reagent/ssr/index.html
@@ -45,7 +45,7 @@
 {:rf/version 1
  :rf/app-db {:articles [{:id "a" :title "Article A" :body "Body A"}
                         {:id "b" :title "Article B" :body "Body B"}]
-             :route {:id :route/articles :params {}}}
+             :route {:id :ssr.app/articles :params {}}}
  :rf/render-hash "deadbeef"}
   </script>
   <script src="main.js"></script>

--- a/examples/uix/README.md
+++ b/examples/uix/README.md
@@ -23,7 +23,7 @@ The dataflow — events, subs, schemas, machine, managed-HTTP stub — is **iden
   Same `:counter/initialise` / `:counter/inc` / `:counter/dec` events as the Reagent counter; the view renders +/- buttons and a count between them. The count seeds to `5` (via `:counter/initialise`) and moves as the buttons dispatch.
 
 - **`uix/login_uix/`** ([build id `examples/login-uix`](../../implementation/shadow-cljs.edn))
-  Same login state machine (`:idle -> :submitting -> :authed`/`:error-shown`), same Malli schemas, same `:rf.http/managed.login-demo` stub fx as the Reagent login example. The view layer is a UIx `defui` form. Entering credentials and submitting drives the machine to `:authed` and the welcome banner appears on success.
+  Same login state machine (`:idle -> :submitting -> :authed`/`:error-shown`), same Malli schemas, same `:auth.login.demo/managed-stub` stub fx as the Reagent login example. The view layer is a UIx `defui` form. Entering credentials and submitting drives the machine to `:authed` and the welcome banner appears on success.
 
 - **`uix/dashboard_uix/`** ([build id `examples/dashboard-uix`](../../implementation/shadow-cljs.edn))
   Design-led example proving UIx can drive a substantive multi-pane layout. Shares the `_shared/css/style.css` "Editorial Warm" visual identity with the Reagent notebook and Helix process-monitor counterparts. No state machines, no HTTP — design-led examples exist to prove polished visuals + interaction, not to replay platform features other examples already cover.

--- a/examples/uix/login_uix/core.cljs
+++ b/examples/uix/login_uix/core.cljs
@@ -58,7 +58,7 @@
     (when-let [ls (.-localStorage js/globalThis)]
       (.setItem ls "auth/token" token))))
 
-(rf/reg-fx :rf.http/managed.login-demo
+(rf/reg-fx :auth.login.demo/managed-stub
   {:doc       "Demo override for `:rf.http/managed`. Identical behaviour
                to the Reagent example's stub. The raw `js/setTimeout`
                below is demo-only latency so the `:submitting` UI state
@@ -244,7 +244,7 @@
   (rf/init! uix-adapter/adapter)
   (rf/reg-frame :rf/default
     {:doc          "Login (UIx) demo frame."
-     :fx-overrides {:rf.http/managed :rf.http/managed.login-demo}})
+     :fx-overrides {:rf.http/managed :auth.login.demo/managed-stub}})
   ;; No `dispatch-sync` seed here (unlike counter / dashboard): the
   ;; machine handler is self-initialising — its `:initial`/`:data` seed
   ;; [:rf/machines :auth.login/flow] when the flow first runs (per


### PR DESCRIPTION
Shape-2 cluster of three P1 framework-reserved-namespace fixes across /examples, from the rf2-9g3we elegance audit. Each commit closes one bead.

## Beads

### rf2-fgkte — Rename user reg-sub `:rf/pending-navigation` (realworld)

Per `spec/Conventions.md` §Reserved namespaces: user code MUST NOT register handlers, fx, subs, or frames under `:rf/*`. The `:rf/pending-navigation` app-db key is framework-owned (the routing runtime writes it under the `:can-leave` guard mechanism per Spec 012), but the user sub that reads the slot must carry a user-namespaced id.

| Before | After | Where |
|---|---|---|
| `(rf/reg-sub :rf/pending-navigation ...)` | `(rf/reg-sub :conduit.routing/pending-navigation ...)` | `examples/reagent/realworld/routing.cljs` |
| `@(subscribe [:rf/pending-navigation])` | `@(subscribe [:conduit.routing/pending-navigation])` | `examples/reagent/realworld/core.cljs` |

The `reg-sub` source-fn still reads `(:rf/pending-navigation db)` — that's the framework-reserved app-db key the routing runtime writes to (not a violation; framework owns reads/writes of that slot).

### rf2-pwtfx — Rename demo-stub fx-ids out of `:rf.http/*`

Per `spec/Conventions.md` §Library-owned prefixes (line 84): *Third-party libraries MUST NOT reserve under `:rf.*`.* User code (examples are user code) was registering demo-stub fxs under `:rf.http/managed.*` — the framework-reserved namespace.

Source-side demo overrides:

| Before | After | Where |
|---|---|---|
| `:rf.http/managed.login-demo` | `:auth.login.demo/managed-stub` | `examples/{reagent,uix,helix}/login*/core.cljs` |
| `:rf.http/managed.boot-demo` | `:boot.demo/http-stub` | `examples/reagent/boot/core.cljs` |
| `:rf.http/managed.long-stub` | `:managed-http-counter.demo/long-stub` | `examples/reagent/managed_http_counter/core.cljs` |
| `:rf.http/managed.realworld-demo` | `:conduit.demo/http-stub` | `examples/reagent/realworld/core.cljs` |

Test-fixture overrides (per-test canned stubs in realworld/boot tests):

| Before pattern | After pattern | Where |
|---|---|---|
| `:rf.http/managed.canned-*` / `.login-*` / `.favorite-*` | `:conduit.test/*` | `examples/reagent/realworld/test/realworld/*` |
| `:rf.http/managed.boot-success` / `.boot-fail` | `:boot.test/canned-*` | `examples/reagent/boot/test/boot/boot_test.cljs` |

The `:fx-overrides` map references the new id; the override mechanism still works because override targets are user-supplied ids. READMEs updated alongside source.

Framework-shipped ids untouched: `:rf.http/managed`, `:rf.http/managed-canned-success`, `:rf.http/managed-canned-failure`, `:rf.http/managed-abort`.

Acceptance: `git grep ':rf.http/managed\.' examples/` returns 0 hits.

### rf2-1m0jz — Fix `:route/*` user-defined route-id convention

Per `spec/Conventions.md` §User-defined route ids (line 71): *User-defined route ids are NOT namespaced under any framework prefix.* The v2 answer is unambiguously that user route ids have no `:route/*` prefix at all.

| Example | Before | After |
|---|---|---|
| `examples/reagent/routing/core.cljs` | `:route/home`, `:route/articles`, `:route/article-detail` | `:routing.app/home`, `:routing.app/articles`, `:routing.app/article-detail` |
| `examples/reagent/realworld/routing.cljs` | `:route/home` | `:conduit/home` |
| | `:route/login`, `:route/register` | `:conduit.auth/login`, `:conduit.auth/register` |
| | `:route/settings` | `:conduit.user/settings` |
| | `:route/editor`, `:route/editor.edit` | `:conduit.editor/new`, `:conduit.editor/edit` |
| | `:route/article` | `:conduit.article/show` |
| | `:route/profile`, `:route/profile.favorites` | `:conduit.profile/show`, `:conduit.profile/favorites` |
| | `:route/auth-guard` (interceptor id) | `:conduit.routing/auth-guard` |
| `examples/reagent/boot/core.cljs` | `:route/home`, `:route/about`, `:route/settings` | `:boot.demo/home`, `:boot.demo/about`, `:boot.demo/settings` |
| `examples/reagent/ssr/core.cljc` + `index.html` | `:route/articles` | `:ssr.app/articles` |

Updated every consumer: `:on-match` dispatches, `rf/route-link :to` targets, `(case @(subscribe [:rf.route/id]) ...)` arms, realworld test fixtures, READMEs.

Framework-shipped ids untouched: `:rf.route/not-found` (framework route id) and `:route/link` (framework-shipped registered view id) remain as-is — both are framework surface, not user code.

Acceptance: `git grep ':route/' examples/` returns only `:route/link` references in comments/docstrings (framework-shipped registered view).

## Convention citations

- `spec/Conventions.md` §Reserved namespaces (line 8): *User code MUST NOT register handlers, fx, subs, or frames under `:rf/*`.*
- `spec/Conventions.md` §User-defined route ids (line 71): *User-defined route ids are not namespaced under any framework prefix...*
- `spec/Conventions.md` §Library-owned prefixes (line 84): *Third-party libraries MUST NOT reserve under `:rf.*`.*

## Quality gates

- `bash scripts/test-fast-pr.sh` — PASS (lockstep, skill/MCP drift, core JVM, JS harness, CLJS node integration)
- `npm run test:cljs` (from `implementation/`) — PASS (4738 tests, 15420 assertions, 0 failures)
- `python scripts/check_readme_links.py` — PASS (READMEs touched: realworld/, helix/, uix/)
- `python scripts/check_doc_slugs.py` — PASS
- `mkdocs build --strict` — SKIPPED (Windows worker, `mkdocs` not on PATH; CI will catch any link/anchor regression)
- `npm run test:examples` — FAIL on adapter-smoke environment (EACCES port 8030 on Windows worker); unrelated to renames — the cljs builds for all three adapter testbeds completed cleanly.

## Source

Audit `rf2-9g3we` — Findings H1, H2, H3.