### PR TITLE
docs(tools/xray/spec/023): fix :rf.sub/disposed typo + expand dispose tags column (rf2-2v3p7)

### DIFF
--- a/tools/xray/spec/023-Trace-Panel.md
+++ b/tools/xray/spec/023-Trace-Panel.md
@@ -129,7 +129,7 @@ Colour and visual styling are intentionally **not specified here** — to be des
 
 ## §10 Data sources (grounding)
 
-Per-op fields already on the epoch record / trace bus: views (`:rf.view/elapsed-ms`, `:triggered-by`/`:cause-subs`, `:mount?`/`:unmounted`/`:rendered`/`:skip`); subs (`:rf.sub/create`/`:run`/`:computed`/`:skip`/`:disposed`, `:value-changed?`); plus the full Spec-009 op vocabulary (event/cofx/db/fx/flow/machine/route/epoch/error/warning). The panel reads the epoch record's `:trace-events` (the focused-epoch scope resolved via `:rf.xray/focus` — [`018`](./018-Event-Spine.md), [`021`](./021-Dynamic-Panel-Designs.md) §5.2).
+Per-op fields already on the epoch record / trace bus: views (`:rf.view/elapsed-ms`, `:triggered-by`/`:cause-subs`, `:mount?`/`:unmounted`/`:rendered`/`:skip`); subs (`:rf.sub/create`/`:run`/`:computed`/`:skip`/`:dispose`, `:value-changed?`); plus the full Spec-009 op vocabulary (event/cofx/db/fx/flow/machine/route/epoch/error/warning). The panel reads the epoch record's `:trace-events` (the focused-epoch scope resolved via `:rf.xray/focus` — [`018`](./018-Event-Spine.md), [`021`](./021-Dynamic-Panel-Designs.md) §5.2).
 
 **Per-step RESULTS (the data the arc must show, not just that a step ran):**
 - **Handler result** — its returned effects map: `:rf.event/fx` (incl. the handler's own `:db`) + `:rf.event/coeffects`. The EVENT "handler ran" row surfaces what the handler produced (its `:db` contribution *before* flows + the `:fx` it requested).
@@ -257,7 +257,7 @@ Every Spec-009 trace operation → its row. `dur?` = number once timing instrume
 | `:rf.sub/run`+`computed` (value-changed? ✓) | ④ | SUB | recalculated | sub-id  old → new | dur? |
 | `:rf.sub/run`+`computed` (value-changed? ✗) | ④ | SUB | ran-unchanged | sub-id | dur? |
 | `:rf.sub/skip` · `skipped` | ④ | SUB | cache-hit | sub-id | — |
-| `:rf.sub/disposed` | ④ | SUB | disposed | sub-id (no readers) | — |
+| `:rf.sub/dispose` | ④ | SUB | disposed | sub-id · query-v · `:reason` (closed set `:no-more-derefers / :hot-reload / :cache-clear`) · frame | — |
 | `:rf.view/render`+`rendered` (mount? ✗) | ④ | VIEW | re-rendered | view-id ← cause-sub | `elapsed-ms` |
 | `:rf.view/render` (mount? ✓) | ④ | VIEW | mounted | view-id | `elapsed-ms` |
 | `:rf.view/skip` | ④ | VIEW | skipped | view-id | — |


### PR DESCRIPTION
Source: rf2-gkh43 xray-spec coverage audit. Closes rf2-2v3p7.

## Problem

`tools/xray/spec/023-Trace-Panel.md` Appendix A — the normative op-handling matrix that's the panel's "completeness contract" — had a typo on the `:rf.sub/dispose` op-id (rendered as past-tense `:rf.sub/disposed`), AND under-specified the Tags column (claimed "sub-id (no readers)" where the substrate actually emits four tags including the discriminating `:rf.sub/reason` closed-set enum).

## Drift evidence

Impl + canonical spec all use `:rf.sub/dispose` (imperative):

- `implementation/core/src/re_frame/subs/cache.cljc:63-70` — `emit-dispose!` calls `(trace/emit! :rf.sub :rf.sub/dispose ...)`
- `spec/009-Instrumentation.md` — `:rf.sub/dispose`
- `tools/xray/spec/021-Dynamic-Panel-Designs.md:1796` — `:rf.sub/dispose` with full tag set

## Fix

Two-line edit to `tools/xray/spec/023-Trace-Panel.md`:

1. **Line 260** (Appendix A row):
   - op-id past-tense → imperative: `:rf.sub/disposed` → `:rf.sub/dispose`
   - Tags column: `sub-id (no readers)` → `sub-id · query-v · :reason (closed set :no-more-derefers / :hot-reload / :cache-clear) · frame`
2. **Line 132** (§10 prose op list):
   - `subs (... /:rf.sub/skip/:rf.sub/disposed ...)` → `... /:rf.sub/skip/:rf.sub/dispose ...`

## Canonical tags (cited)

Per `tools/xray/spec/021-Dynamic-Panel-Designs.md:1796` + `implementation/core/src/re_frame/subs/cache.cljc:63-70`, the four substrate-emitted tags on a `:rf.sub/dispose` event are:

1. `:rf.sub/id` — sub query id
2. `:rf.sub/query-v` — sub query vector (cache key)
3. `:rf.sub/reason` — closed-set enum: `:no-more-derefers` / `:hot-reload` / `:cache-clear`
4. `:frame` — frame id

## Quality gates

- `git grep ':rf.sub/disposed' tools/xray/spec/` → **0 hits**
- `python scripts/check_readme_links.py` → pass
- `python scripts/check_doc_slugs.py` → pass
- `mkdocs build --strict` → not run on this Windows worker (mkdocs not on PATH); rf2-lwweq markdown-gate scripts both passed
- `bash scripts/test-fast-pr.sh` → **PASS fast PR spine** (4738 tests, 15420 assertions, 0 failures)

## Out of scope

- `tools/xray/spec/021-Dynamic-Panel-Designs.md:1796` — already correct
- `spec/009-Instrumentation.md` — already correct
- `spec/018` line 767 prose "sub-dispose" — verb descriptor, not an op-id, left as-is per the bead