### PR TITLE
feat(xray): diff-mode-toggle elegance + 4-surface attribute normalisation + widget tests (cluster F)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1607,6 +1607,32 @@ HANDLER `:db`:
 event pair so the modes are independent (operator's App-DB choice
 doesn't override the Machine Inspector choice).
 
+**Canonical `data-testid` + `data-*` shapes** (Cluster F — rf2-7vv8f
++ rf2-xvu24): post-normalisation every surface follows ONE shape so
+browser-test selectors + DOM probes target a uniform axis:
+
+| Surface | Toggle `:testid` prefix | Section-level data-attr |
+|---|---|---|
+| App-DB panel                          | `rf-xray-app-db-diff-mode`             | `data-rf-xray-diff-mode` |
+| Machine Inspector snapshot drill-in   | `rf-xray-machine-snapshot-diff-mode`   | `data-rf-xray-diff-mode` |
+| Epoch HANDLER step `:db`              | `rf-xray-epoch-handler-db-diff-mode`   | `data-rf-xray-diff-mode` |
+| Epoch SUBSCRIPTIONS step value cells  | `rf-xray-epoch-subs-value-diff-mode`   | `data-rf-xray-diff-mode` |
+
+Per-button testids combine the prefix with the canonical mode suffix
+(`-diff`, `-full`, `-full-with-diff`) so `[data-testid$="-diff-mode-
+full-with-diff"]` matches the active-button of any surface in mode-3.
+The active button itself reports `aria-pressed="true"` — that is the
+single source of truth for "which mode is selected" (rf2-xlmhh — the
+toggle bar's redundant `data-mode` retired per `tools/xray/spec/
+Conventions.md` §264; section-level `data-rf-xray-diff-mode` survives
+as an enclosing-section decoration only).
+
+**Discoverability label** (rf2-fytu4): every consumer passes
+`:label "View"` to the shared widget. The widget renders the label
+inline with the bar (`View [diff][full][full+diff]`) so a first-time
+operator has a contextual anchor on every surface — no per-surface
+hand-rolled labels.
+
 **Retired by rf2-yqjrd**:
 
 - The Machine Inspector's prior Before/After CSS-Grid side-by-side

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff.cljs
@@ -74,7 +74,10 @@
         section-model @(rf/subscribe [:rf.xray/app-db-state])
         diff-triples  @(rf/subscribe [:rf.xray/selected-epoch-diff])]
     [:section {:data-testid "rf-xray-app-db-diff"
-               :data-view-mode (name mode)
+               ;; rf2-xvu24 — canonical `data-rf-xray-diff-mode` axis on
+               ;; every diff-mode-toggle consumer's enclosing section
+               ;; (was the per-surface drifted `data-view-mode`).
+               :data-rf-xray-diff-mode (name mode)
                :style       {:height         "100%"
                              :display        "flex"
                              :flex-direction "column"
@@ -87,20 +90,19 @@
      ;; section's body. Frame-anchored to `:rf/xray` per the same
      ;; rf2-p56sk / rf2-7sdja / rf2-kcaiz pattern the HANDLER `:db`
      ;; toggle uses.
+     ;;
+     ;; rf2-fytu4 — discoverability label `View` is owned by the shared
+     ;; widget via the `:label` opt (was a hand-rolled span here).
      [:div {:style {:padding "12px 12px 0"
                     :display "flex"
                     :align-items "center"
                     :gap "8px"}}
-      [:span {:style {:font-family sans-stack
-                      :font-size "11px"
-                      :font-weight 600
-                      :text-transform "uppercase"
-                      :letter-spacing "0.5px"
-                      :color (:text-secondary tokens)}}
-       "View"]
       [diff-mode/diff-mode-toggle
        {:mode mode
-        :testid "rf-xray-app-db-view-mode"
+        ;; rf2-7vv8f — testid prefix normalised across all four
+        ;; toggle consumers to `rf-xray-<surface>-diff-mode`.
+        :testid "rf-xray-app-db-diff-mode"
+        :label "View"
         :on-change (fn [m]
                      (rf/with-frame :rf/xray
                        (rf/dispatch [:rf.xray.app-db/set-diff-mode m])))}]]

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -2237,7 +2237,10 @@
   [mode]
   [diff-mode/diff-mode-toggle
    {:mode      mode
-    :testid    "rf-xray-epoch-handler-db-view-mode"
+    ;; rf2-7vv8f — testid prefix normalised to `rf-xray-<surface>-diff-mode`.
+    :testid    "rf-xray-epoch-handler-db-diff-mode"
+    ;; rf2-fytu4 — uniform "View" discoverability label.
+    :label     "View"
     :on-change (fn [m]
                  (rf/with-frame :rf/xray
                    (rf/dispatch [:rf.xray.epoch/set-db-diff-mode m])))}])
@@ -2285,7 +2288,9 @@
                        :else  (str n " path" (when (not= 1 n) "s")))]
     [:div {:data-testid "rf-xray-epoch-handler-db-diff"
            :data-empty (str empty?)
-           :data-db-diff-mode (name mode)}
+           ;; rf2-xvu24 — canonical `data-rf-xray-diff-mode` axis (was
+           ;; the drifted `data-db-diff-mode`).
+           :data-rf-xray-diff-mode (name mode)}
      (sub-header ":db"
                  [:span {:style inline-flex-center-style}
                   (when diff-summary diff-summary)
@@ -2679,7 +2684,9 @@
   carries the resolved `:rf.xray.epoch/subs-value-diff-mode` keyword."
   [rows mode]
   [:div {:data-testid "rf-xray-epoch-subscriptions-table"
-         :data-subs-value-diff-mode (when (keyword? mode) (name mode))
+         ;; rf2-xvu24 — canonical `data-rf-xray-diff-mode` axis (was
+         ;; the drifted `data-subs-value-diff-mode`).
+         :data-rf-xray-diff-mode (when (keyword? mode) (name mode))
          :style subscriptions-table-style}
    ;; header
    [:div {:style table-header-row-style}
@@ -2823,7 +2830,11 @@
                (when (pos? n)
                  [diff-mode/diff-mode-toggle
                   {:mode      value-mode
-                   :testid    "rf-xray-epoch-subscriptions-value-mode"
+                   ;; rf2-7vv8f — testid prefix normalised to
+                   ;; `rf-xray-<surface>-diff-mode`.
+                   :testid    "rf-xray-epoch-subs-value-diff-mode"
+                   ;; rf2-fytu4 — uniform "View" discoverability label.
+                   :label     "View"
                    :on-change (fn [m]
                                 (rf/with-frame :rf/xray
                                   (rf/dispatch

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
@@ -569,7 +569,9 @@
     [:div {:data-testid    (str "rf-xray-machine-snapshot-block-"
                                 (machine-id-suffix machine-id))
            :data-machine-id (str machine-id)
-           :data-view-mode  (when (keyword? mode) (name mode))
+           ;; rf2-xvu24 — canonical `data-rf-xray-diff-mode` axis (was
+           ;; the drifted `data-view-mode`).
+           :data-rf-xray-diff-mode (when (keyword? mode) (name mode))
            ;; Issue #2 (option b): match the outer section's `bg-2`
            ;; rather than the brighter `bg-1` so the snapshot reads as
            ;; continuation of the body, not as a second card layer.
@@ -604,7 +606,10 @@
   [mode]
   [diff-mode/diff-mode-toggle
    {:mode      mode
-    :testid    "rf-xray-machine-snapshot-view-mode"
+    ;; rf2-7vv8f — testid prefix normalised to `rf-xray-<surface>-diff-mode`.
+    :testid    "rf-xray-machine-snapshot-diff-mode"
+    ;; rf2-fytu4 — uniform "View" discoverability label.
+    :label     "View"
     :on-change (fn [m]
                  (rf/with-frame :rf/xray
                    (rf/dispatch [:rf.xray.machine-inspector/set-diff-mode m])))}])
@@ -642,7 +647,9 @@
         :data-machine-id (str machine-id)
         :data-has-before (str (some? before))
         :data-has-after  (str (some? after))
-        :data-view-mode  (when (keyword? mode) (name mode))
+        ;; rf2-xvu24 — canonical `data-rf-xray-diff-mode` axis (was
+        ;; the drifted `data-view-mode`).
+        :data-rf-xray-diff-mode (when (keyword? mode) (name mode))
         :style {:background (:bg-2 tokens)}}
        ;; Header carries the section label + the universal three-mode
        ;; toggle. Same shape as the Epoch HANDLER `:db` and App-DB

--- a/tools/xray/src/day8/re_frame2_xray/views/diff_mode_toggle.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/diff_mode_toggle.cljs
@@ -40,14 +40,18 @@
                                 ;; bridge to rf/dispatch as needed)
         :testid     <str>       ;; data-testid prefix for the bar + buttons
         ;; optional —
+        :label      <str>       ;; prefix label e.g. \"View\" (rf2-fytu4);
+                                ;; omit for bare bar; supply for the
+                                ;; canonical uniform discoverability
+                                ;; affordance every Xray consumer passes.
         :modes      <vec>       ;; defaults to [:diff :full :full+diff]
        }]
 
-  Returns a hiccup `<span>` with three buttons. Active button paints
-  in `:accent` token colour; inactive buttons are transparent with
-  muted text. The widget is stateless chrome — the caller owns the
-  mode value (typically via a sub) and the dispatch (typically via
-  `with-frame :rf/xray`).
+  Returns a hiccup `<span>` with three buttons (and an optional prefix
+  label). Active button paints in `:accent` token colour; inactive
+  buttons are transparent with muted text. The widget is stateless
+  chrome — the caller owns the mode value (typically via a sub) and
+  the dispatch (typically via `with-frame :rf/xray`).
 
   ## Per-surface storage convention
 
@@ -122,18 +126,38 @@
          :background "transparent"
          :color      (:text-secondary tokens)))
 
+(def ^:private mode-toggle-prefix-label-style
+  ;; rf2-fytu4 — discoverability label rendered at the head of the
+  ;; toggle. Same typography envelope as section sub-headers across
+  ;; Xray (11px uppercase semibold muted) so the widget reads as part
+  ;; of the surrounding header chrome.
+  {:font-family    sans-stack
+   :font-size      "11px"
+   :font-weight    600
+   :text-transform "uppercase"
+   :letter-spacing "0.5px"
+   :color          (:text-secondary tokens)
+   :margin-right   "8px"
+   :line-height    1})
+
+(def ^:private mode-toggle-wrapper-style
+  ;; rf2-fytu4 — wrapper span used when a `:label` is supplied so the
+  ;; prefix label + button-bar align baseline-to-baseline.
+  {:display      "inline-flex"
+   :align-items  "center"})
+
 ;; =========================================================================
 ;; mode keywords
 ;; =========================================================================
 
-(def default-modes
+(def ^:private default-modes
   "Canonical mode order for the three-button bar — `[diff][full][full+diff]`.
   Per Mike's pair-debug 2026-05-27 the operator's eye reads left → right:
   least-rich (just-what-changed) → richest (full tree + annotations).
   Surfaces may override but should not depart from this ordering."
   [:diff :full :full+diff])
 
-(def default-default-mode
+(def ^:private default-default-mode
   "The widget's recommended default mode keyword across every surface
   per pair-debug 2026-05-27: mode-3 is the operator's most-useful
   lens because it carries shape + delta in one read. Surfaces with
@@ -142,7 +166,7 @@
   policy not a default-mode override."
   :full+diff)
 
-(defn mode-label
+(defn- mode-label
   "Render the human-readable button label for a mode keyword. The
   literal `+` in `:full+diff` is intentional per the findings-doc
   grammar lock — the symbol IS the cue (combining two lenses)."
@@ -153,7 +177,7 @@
     :full+diff "full+diff"
     (name m)))
 
-(defn mode-testid-suffix
+(defn- mode-testid-suffix
   "Sanitised testid suffix — the `+` in `:full+diff` is not a valid
   CSS selector tail downstream, so substitute a hyphenated alias.
   All other mode keywords use their `name`."
@@ -188,30 +212,50 @@
                     testids. The bar gets `<testid>` verbatim; buttons
                     get `<testid>-<mode-suffix>` (e.g. `…-diff`,
                     `…-full`, `…-full-with-diff`).
+  - `:label`      — optional prefix label (rf2-fytu4). When supplied the
+                    widget renders `[:span <label> [bar...]]` so the
+                    operator has a contextual anchor (`View: [diff]
+                    [full] [full+diff]`). Omit for a bare bar. Every
+                    current Xray consumer passes `\"View\"`.
   - `:modes`      — optional ordered vector of mode keywords. Defaults to
                     `[:diff :full :full+diff]`. Surfaces that want to
                     omit a mode (rare; mode-3 is the canonical full
                     bar) pass a subset.
 
+  rf2-xlmhh — the bar no longer carries a `:data-mode` attribute.
+  Per `tools/xray/spec/Conventions.md` §264 `data-mode` was retired
+  as a duplicate axis; the active mode is observable via the active
+  button's `aria-pressed=\"true\"` instead. Surfaces that need the
+  mode as a section-level decoration use the canonical
+  `data-rf-xray-diff-mode` attribute on their own enclosing section
+  (rf2-xvu24).
+
   rf2-yqjrd — extracted from `panels.epoch.view/db-diff-mode-toggle`
   (rf2-n2jig) so every Xray surface consumes the same chrome verbatim."
-  [{:keys [mode on-change testid modes]
+  [{:keys [mode on-change testid label modes]
     :or   {modes default-modes}}]
-  [:span {:data-testid testid
-          :data-mode (when (keyword? mode) (name mode))
-          :style mode-toggle-bar-style}
-   (for [m modes
-         :let [active? (= mode m)]]
-     ^{:key (name m)}
-     [:button {:data-testid (str testid "-" (mode-testid-suffix m))
-               :aria-pressed (str active?)
-               :on-click (fn [e]
-                           (.stopPropagation e)
-                           (on-change m))
-               :style (if active?
-                        mode-toggle-button-active-style
-                        mode-toggle-button-inactive-style)}
-      (mode-label m)])])
+  (let [bar [:span {:data-testid testid
+                    :style mode-toggle-bar-style}
+             (for [m modes
+                   :let [active? (= mode m)]]
+               ^{:key (name m)}
+               [:button {:data-testid (str testid "-" (mode-testid-suffix m))
+                         :aria-pressed (str active?)
+                         :on-click (fn [e]
+                                     (.stopPropagation e)
+                                     (on-change m))
+                         :style (if active?
+                                  mode-toggle-button-active-style
+                                  mode-toggle-button-inactive-style)}
+                (mode-label m)])]]
+    (if (some? label)
+      [:span {:data-testid (str testid "-wrapper")
+              :style mode-toggle-wrapper-style}
+       [:span {:data-testid (str testid "-label")
+               :style mode-toggle-prefix-label-style}
+        label]
+       bar]
+      bar)))
 
 ;; =========================================================================
 ;; helpers — per-surface sub + event registration

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_view_cljs_test.cljs
@@ -1027,14 +1027,23 @@
       (focus-epoch! 1)
       (let [tree   (machine-inspector/Panel)
             drill  (find-by-testid tree "rf-xray-machine-snapshot-drill-in")
+            ;; rf2-7vv8f — testid prefix normalised across all four
+            ;; diff-mode-toggle consumers to `rf-xray-<surface>-diff-mode`.
             toggle (find-by-testid
-                     tree "rf-xray-machine-snapshot-view-mode")]
+                     tree "rf-xray-machine-snapshot-diff-mode")
+            ;; rf2-xlmhh — the toggle bar no longer carries `:data-mode`
+            ;; (retired axis name per spec/Conventions.md §264). Read the
+            ;; active mode off the active button's `aria-pressed="true"`
+            ;; + canonical testid suffix instead.
+            active-btn (find-by-testid
+                         tree "rf-xray-machine-snapshot-diff-mode-full-with-diff")]
         (is (some? drill)
             "drill-in section mounts")
         (is (some? toggle)
             "three-mode toggle paints in the drill-in header")
-        (is (= "full+diff" (:data-mode (second toggle)))
-            "default mode is :full+diff per pair-debug 2026-05-27")
+        (is (= "true" (:aria-pressed (second active-btn)))
+            "default mode is :full+diff per pair-debug 2026-05-27 — the
+            `full-with-diff` button reports `aria-pressed=\"true\"`")
         ;; The grid container retired with the side-by-side layout.
         (is (nil? (find-by-testid
                     tree "rf-xray-machine-snapshot-drill-in-grid"))

--- a/tools/xray/test/day8/re_frame2_xray/views/diff_mode_toggle_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/diff_mode_toggle_cljs_test.cljs
@@ -1,0 +1,264 @@
+(ns day8.re-frame2-xray.views.diff-mode-toggle-cljs-test
+  "Unit tests for the shared three-mode diff toggle widget
+  (`views.diff-mode-toggle` — rf2-yqjrd / rf2-n2jig).
+
+  Cluster F (rf2-hf6gb) — the widget is consumed by every Xray diff
+  surface (App-DB, Machine Inspector snapshot, Epoch HANDLER `:db`,
+  Epoch SUBSCRIPTIONS) and exercised in 10+22 stories, but the widget
+  itself shipped without direct unit tests. This file pins the
+  regression-fragile contracts:
+
+    - per-mode label rendering (`:diff` / `:full` / `:full+diff` +
+      `name` fallback for unknown keywords).
+    - per-mode testid suffix (`:full+diff` → `full-with-diff`; other
+      modes use their `name`).
+    - the public `reg-mode-sub+event!` helper installs a sub + an
+      event-db with the canonical naming scheme for both top-level
+      (`:rf.xray.app-db`) and sub-surface (`:rf.xray.epoch/db`)
+      surface-id shapes.
+    - the rendered hiccup shape — three buttons keyed by mode, active
+      button reports `aria-pressed=\"true\"`, per-button testids follow
+      the `<prefix>-<suffix>` convention.
+    - the rf2-fytu4 `:label` opt — optional prefix label wraps the bar
+      with a deterministic label-span testid.
+    - rf2-xlmhh — the bar no longer carries `:data-mode` (retired axis
+      per `tools/xray/spec/Conventions.md` §264).
+
+  Pure-data unit tests; no DOM mount. Default for new Causa/Story
+  tests per `feedback-causa-story-cljs-unit-tests-not-playwright`."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-helpers :as th]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-xray.views.diff-mode-toggle :as widget]))
+
+;; Fresh re-frame runtime per test so `reg-sub` + `reg-event-db`
+;; installs from one test don't bleed into the next.
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+;; ---- private-fn handles -------------------------------------------------
+;;
+;; The two internal helpers are marked `^:private` (rf2-2zq54) — reach
+;; through the var to exercise them under test without weakening the
+;; widget's public surface.
+
+(def ^:private mode-label        @#'widget/mode-label)
+(def ^:private mode-testid-suffix @#'widget/mode-testid-suffix)
+
+;; ---- (1) mode-label coverage -------------------------------------------
+
+(deftest mode-label-canonical-modes
+  (testing "`mode-label` returns the documented human label for each
+            canonical mode keyword. The literal `+` in `full+diff` is
+            intentional per the findings-doc grammar lock (the symbol
+            IS the cue)."
+    (is (= "diff"      (mode-label :diff)))
+    (is (= "full"      (mode-label :full)))
+    (is (= "full+diff" (mode-label :full+diff)))))
+
+(deftest mode-label-fallback-uses-name
+  (testing "`mode-label` falls through to `(name m)` for any unknown
+            keyword so future modes paint a label without an explicit
+            case branch."
+    (is (= "custom"        (mode-label :custom)))
+    (is (= "experimental"  (mode-label :experimental)))))
+
+;; ---- (2) mode-testid-suffix coverage -----------------------------------
+
+(deftest mode-testid-suffix-canonical-modes
+  (testing "`mode-testid-suffix` sanitises `:full+diff` to a hyphenated
+            alias because `+` is not a valid CSS-selector tail. All
+            other modes use their `name` verbatim."
+    (is (= "diff"            (mode-testid-suffix :diff)))
+    (is (= "full"            (mode-testid-suffix :full)))
+    (is (= "full-with-diff"  (mode-testid-suffix :full+diff)))))
+
+(deftest mode-testid-suffix-fallback-uses-name
+  (testing "Unknown keywords fall through to `(name m)` — the `+`
+            sanitisation is the ONLY special case."
+    (is (= "custom" (mode-testid-suffix :custom)))))
+
+;; ---- (3) reg-mode-sub+event! — top-level surface -----------------------
+
+(deftest reg-mode-sub+event!-top-level-surface
+  (testing "rf2-0cyjm / rf2-44xya helper — for a top-level surface
+            (unqualified keyword) it installs a sub at
+            `:rf.xray.<surface>/diff-mode` + an event-db at
+            `:rf.xray.<surface>/set-diff-mode`. The sub reads from
+            the same slot the event writes; default mode is
+            `:full+diff` per pair-debug 2026-05-27."
+    (let [{:keys [sub-id event-id slot]}
+          (widget/reg-mode-sub+event! :rf.xray.app-db)]
+      (is (= :rf.xray.app-db/diff-mode sub-id)
+          "sub-id is `<surface>/diff-mode`")
+      (is (= :rf.xray.app-db/set-diff-mode event-id)
+          "event-id is `<surface>/set-diff-mode`")
+      (is (= sub-id slot)
+          "slot key in app-db === sub-id (one-slot-per-surface)")
+      (is (some? (registrar/handler :sub sub-id))
+          "sub is registered")
+      (is (some? (registrar/handler :event event-id))
+          "event-db is registered")
+      ;; Default-mode fallback when the slot is absent.
+      (is (= :full+diff @(rf/subscribe [sub-id]))
+          "sub returns `:full+diff` as the default when the slot is unset")
+      ;; Dispatch the set-event, sub re-reads through the new value.
+      (rf/dispatch-sync [event-id :diff])
+      (is (= :diff @(rf/subscribe [sub-id]))
+          "sub returns the mode just written by the event"))))
+
+(deftest reg-mode-sub+event!-top-level-surface-custom-default
+  (testing "The helper accepts `:default-mode` to override the
+            widget's `:full+diff` default — surfaces with no `before`
+            available may prefer `:full` as the starting lens."
+    (let [{:keys [sub-id]}
+          (widget/reg-mode-sub+event! :rf.xray.app-db
+                                      {:default-mode :full})]
+      (is (= :full @(rf/subscribe [sub-id]))
+          "sub returns the supplied custom default when the slot is unset"))))
+
+;; ---- (4) reg-mode-sub+event! — sub-surface ------------------------------
+
+(deftest reg-mode-sub+event!-sub-surface
+  (testing "For a sub-surface (namespaced keyword) the helper folds
+            the keyword's `name` into the sub + event names — e.g.
+            `:rf.xray.epoch/db` registers `:rf.xray.epoch/db-diff-mode`
+            + `:rf.xray.epoch/set-db-diff-mode`. Matches the four
+            cluster-F production sites' naming."
+    (let [{:keys [sub-id event-id]}
+          (widget/reg-mode-sub+event! :rf.xray.epoch/db)]
+      (is (= :rf.xray.epoch/db-diff-mode sub-id))
+      (is (= :rf.xray.epoch/set-db-diff-mode event-id))
+      (is (some? (registrar/handler :sub sub-id)))
+      (is (some? (registrar/handler :event event-id)))
+      (is (= :full+diff @(rf/subscribe [sub-id])))
+      (rf/dispatch-sync [event-id :full])
+      (is (= :full @(rf/subscribe [sub-id]))))))
+
+(deftest reg-mode-sub+event!-subs-value-surface
+  (testing "The SUBSCRIPTIONS value-mode surface is the most-tortured
+            naming case — `:rf.xray.epoch/subs-value` folds to
+            `:rf.xray.epoch/subs-value-diff-mode` + matching set
+            event. Pin the exact shape post-cluster-F."
+    (let [{:keys [sub-id event-id]}
+          (widget/reg-mode-sub+event! :rf.xray.epoch/subs-value)]
+      (is (= :rf.xray.epoch/subs-value-diff-mode sub-id))
+      (is (= :rf.xray.epoch/set-subs-value-diff-mode event-id)))))
+
+;; ---- (5) widget render shape — bare bar (no label) ----------------------
+
+(deftest diff-mode-toggle-renders-three-buttons
+  (testing "Without `:label` the widget returns a single bar `<span>`
+            whose `:data-testid` is the supplied prefix; three child
+            `<button>` elements, one per default mode."
+    (let [tree (widget/diff-mode-toggle
+                 {:mode :full+diff
+                  :on-change (fn [_])
+                  :testid "rf-xray-test-diff-mode"})
+          bar (th/find-by-testid tree "rf-xray-test-diff-mode")
+          btn-diff (th/find-by-testid tree "rf-xray-test-diff-mode-diff")
+          btn-full (th/find-by-testid tree "rf-xray-test-diff-mode-full")
+          btn-fwd  (th/find-by-testid
+                     tree "rf-xray-test-diff-mode-full-with-diff")]
+      (is (some? bar) "the bar carries the supplied testid")
+      (is (some? btn-diff)       "diff button is present")
+      (is (some? btn-full)       "full button is present")
+      (is (some? btn-fwd)        "full+diff button is present")
+      (is (= "diff"      (last btn-diff)) ":diff button label")
+      (is (= "full"      (last btn-full)) ":full button label")
+      (is (= "full+diff" (last btn-fwd))  ":full+diff button label"))))
+
+(deftest diff-mode-toggle-active-button-aria-pressed
+  (testing "rf2-xlmhh — `aria-pressed=\"true\"` on the active button
+            is the single source of truth for which mode is selected
+            (the bar's retired `:data-mode` is gone). Inactive
+            buttons report `aria-pressed=\"false\"`."
+    (let [tree (widget/diff-mode-toggle
+                 {:mode :diff
+                  :on-change (fn [_])
+                  :testid "rf-xray-test-diff-mode"})
+          btn-diff (th/find-by-testid tree "rf-xray-test-diff-mode-diff")
+          btn-full (th/find-by-testid tree "rf-xray-test-diff-mode-full")
+          btn-fwd  (th/find-by-testid
+                     tree "rf-xray-test-diff-mode-full-with-diff")]
+      (is (= "true"  (:aria-pressed (second btn-diff)))
+          ":diff button is active when :mode = :diff")
+      (is (= "false" (:aria-pressed (second btn-full)))
+          ":full button is inactive when :mode = :diff")
+      (is (= "false" (:aria-pressed (second btn-fwd)))
+          ":full+diff button is inactive when :mode = :diff"))))
+
+(deftest diff-mode-toggle-bar-has-no-data-mode-attribute
+  (testing "rf2-xlmhh — the bar `<span>` must NOT carry a `:data-mode`
+            attribute. Per `tools/xray/spec/Conventions.md` §264 the
+            attribute was retired as a duplicate axis."
+    (let [tree (widget/diff-mode-toggle
+                 {:mode :full+diff
+                  :on-change (fn [_])
+                  :testid "rf-xray-test-diff-mode"})
+          bar (th/find-by-testid tree "rf-xray-test-diff-mode")]
+      (is (some? bar))
+      (is (not (contains? (second bar) :data-mode))
+          "the bar carries no :data-mode attribute"))))
+
+;; ---- (6) widget render shape — with :label (rf2-fytu4) -----------------
+
+(deftest diff-mode-toggle-with-label-wraps-bar
+  (testing "rf2-fytu4 — when `:label` is supplied the widget wraps
+            the bar in a `<span>` carrying `<testid>-wrapper` + a
+            prefix-label `<span>` carrying `<testid>-label` whose
+            last child is the label text. The bar still renders
+            inside the wrapper with the original testid."
+    (let [tree (widget/diff-mode-toggle
+                 {:mode :full+diff
+                  :on-change (fn [_])
+                  :testid "rf-xray-test-diff-mode"
+                  :label "View"})
+          wrapper (th/find-by-testid
+                    tree "rf-xray-test-diff-mode-wrapper")
+          label   (th/find-by-testid
+                    tree "rf-xray-test-diff-mode-label")
+          bar     (th/find-by-testid tree "rf-xray-test-diff-mode")]
+      (is (some? wrapper) "wrapper span exists when :label supplied")
+      (is (some? label)   "prefix label span exists when :label supplied")
+      (is (= "View" (last label))
+          "the prefix label renders the supplied text verbatim")
+      (is (some? bar)
+          "the bar still mounts inside the wrapper with its original testid"))))
+
+(deftest diff-mode-toggle-without-label-no-wrapper
+  (testing "rf2-fytu4 — when `:label` is OMITTED the widget renders
+            the bare bar — no wrapper, no label-span. Backwards-
+            compatible with any future caller that wants the bar
+            unadorned."
+    (let [tree (widget/diff-mode-toggle
+                 {:mode :full+diff
+                  :on-change (fn [_])
+                  :testid "rf-xray-test-diff-mode"})]
+      (is (nil? (th/find-by-testid
+                  tree "rf-xray-test-diff-mode-wrapper"))
+          "no wrapper span when :label omitted")
+      (is (nil? (th/find-by-testid
+                  tree "rf-xray-test-diff-mode-label"))
+          "no prefix-label span when :label omitted"))))
+
+;; ---- (7) :modes opt overrides ordering ----------------------------------
+
+(deftest diff-mode-toggle-respects-custom-modes-opt
+  (testing "When `:modes` is supplied the widget renders ONLY those
+            modes in the supplied order. Surfaces that want to omit
+            a mode (rare; mode-3 is the canonical full bar) pass a
+            subset."
+    (let [tree (widget/diff-mode-toggle
+                 {:mode :diff
+                  :on-change (fn [_])
+                  :testid "rf-xray-test-diff-mode"
+                  :modes [:diff :full]})]
+      (is (some? (th/find-by-testid tree "rf-xray-test-diff-mode-diff")))
+      (is (some? (th/find-by-testid tree "rf-xray-test-diff-mode-full")))
+      (is (nil?  (th/find-by-testid
+                   tree "rf-xray-test-diff-mode-full-with-diff"))
+          "omitted modes do not paint"))))

--- a/tools/xray/testbeds/panel_gallery/gallery_diff_mode_universal.cljs
+++ b/tools/xray/testbeds/panel_gallery/gallery_diff_mode_universal.cljs
@@ -11,7 +11,7 @@
 
   ## Surfaces
 
-  - **App-DB panel** — universal panel-wide view-mode at the top.
+  - **App-DB panel** — universal panel-wide diff-mode toggle at the top.
     Variants seed an epoch into the spine so the App-DB panel's
     sections paint with diff annotations, then exercise each mode
     keyword via the toggle.


### PR DESCRIPTION
## Cluster F — diff-mode-toggle elegance + 4-surface normalisation

Per the rf2-gpuv3 elegance audit, six follow-ups on the now-canonical `views/diff_mode_toggle.cljs` widget + its four consumers (App-DB, Machine Inspector snapshot, Epoch HANDLER `:db`, Epoch SUBSCRIPTIONS value cells). Builds on rf2-0cyjm + rf2-44xya (#2236 — the helper `reg-mode-sub+event!` adopted at all 4 surfaces).

### Per-bead summary

| Bead | Pri | What |
|---|---|---|
| **rf2-2zq54** | P2 | Mark internal helpers `^:private` — `default-modes`, `default-default-mode`, `mode-label`, `mode-testid-suffix`. Restores the same-file discipline already applied to style-defs. |
| **rf2-xlmhh** | P2 | Drop the bar `<span>`'s redundant `:data-mode` attribute (retired axis per `tools/xray/spec/Conventions.md` §264). The active button's `aria-pressed="true"` is the single source of truth. One dependent test (`machine_inspector_view_cljs_test.cljs`) migrates to reading `aria-pressed`. |
| **rf2-fytu4** | P2 | Add `:label` opt to the shared widget. Every consumer now passes `:label "View"` — uniform discoverability affordance, no per-surface hand-rolled prefix. The App-DB panel's hand-rolled `<span>` is removed. |
| **rf2-xvu24** | P2 | Normalise the four section-level `data-*-mode` attribute names to a single canonical axis: **`data-rf-xray-diff-mode`**. Retires the prior `data-view-mode` x2, `data-db-diff-mode`, `data-subs-value-diff-mode` fork. |
| **rf2-7vv8f** | P1 | Normalise the four `:testid` prefixes to **`rf-xray-<surface>-diff-mode`**. Browser-test selectors can now match any toggle button across any surface with one CSS suffix selector. |
| **rf2-hf6gb** | P2 | Add CLJS unit tests for the widget — `mode-label`, `mode-testid-suffix`, `reg-mode-sub+event!` (both top-level + sub-surface shapes), default-mode fallback, custom `:default-mode`, render shape, `aria-pressed`, `:data-mode` absence pin, `:label` wrapper, `:modes` subset. 264 lines, 14 deftests. |

### Canonical shapes (post-cluster-F)

| Surface | `:testid` prefix | Section-level `data-*` |
|---|---|---|
| App-DB panel                          | `rf-xray-app-db-diff-mode`             | `data-rf-xray-diff-mode` |
| Machine Inspector snapshot drill-in   | `rf-xray-machine-snapshot-diff-mode`   | `data-rf-xray-diff-mode` |
| Epoch HANDLER step `:db`              | `rf-xray-epoch-handler-db-diff-mode`   | `data-rf-xray-diff-mode` |
| Epoch SUBSCRIPTIONS value cells       | `rf-xray-epoch-subs-value-diff-mode`   | `data-rf-xray-diff-mode` |

Per-button testids combine the prefix with the widget's existing mode suffixes (`-diff` / `-full` / `-full-with-diff`) — `[data-testid$="-diff-mode-full-with-diff"]` matches the active mode-3 button on any surface.

### Spec

`tools/xray/spec/021-Dynamic-Panel-Designs.md` §9.1.5.2 gains a canonical shapes table + a discoverability-label paragraph documenting the new cluster-F invariants.

`tools/xray/spec/Conventions.md` §264 cited for rf2-xlmhh — `data-mode` was the retired axis.

### Quality gates

- `bash scripts/test-fast-pr.sh` — PASS (fast PR spine, includes local-browser-harness + cljs-node integration: 4752 tests / 15466 assertions / 0 failures / 0 errors)
- `npm run test:cljs` — PASS (includes 14 new widget tests)
- `npm run test:bundle-isolation` — PASS (17 entries, 35 sentinels absent, 3 budgets ok)
- `npm run test:xray-feature-gate:smoke` — PASS (3 scenarios, 10 matrix rows)
- Markdown gate (rf2-lwweq): `check_readme_links.py` + `check_doc_slugs.py` + `mkdocs build --strict` — all PASS

### Test coverage delta

New file `tools/xray/test/day8/re_frame2_xray/views/diff_mode_toggle_cljs_test.cljs` — 264 lines, 14 deftests across 7 sections. The widget previously had ZERO direct unit tests despite being consumed at four production surfaces + exercised in 10+22 Stories.

### Sequenced commits

1. `refactor(xray): diff-mode-toggle widget — privatise helpers + drop redundant data-mode + add :label opt (rf2-2zq54, rf2-xlmhh, rf2-fytu4)`
2. `refactor(xray): normalise data-*-mode + data-testid + add "View" label across four diff-mode-toggle surfaces (rf2-xvu24, rf2-7vv8f, rf2-fytu4)`
3. `test(xray): unit tests for views/diff-mode-toggle widget (rf2-hf6gb)`
