### PR TITLE
docs(tools/xray/spec/007+018): update Diff-tab copy — section-grouping engine retired (rf2-gbpct)

### DIFF
--- a/tools/xray/spec/007-UX-IA.md
+++ b/tools/xray/spec/007-UX-IA.md
@@ -655,7 +655,7 @@ mute manager modal). The Buffer tab inherited the
 | 1 | **General** | `g` | Text size · Panel width · Panel position · Auto-open-on-error · Density (Cosy / Compact — no Comfy) · Long-keyword threshold · **Editor override** (rf2-dudqz — per-machine click-to-source picker; nil / `:vscode` / `:cursor` / `:windsurf` / `:zed` / `:idea` / `{:custom <tpl>}`; default nil = use host default) · **Power user:** "Show tool frames in picker" toggle (off by default) · `:use-system-colors?` HCM-override toggle (relocated from Theme per rf2-ou3pn — slot is `:general :use-system-colors?`) |
 | 2 | **Keybindings** | `k` | Read-only chord table (every binding the global listener captures) · master "Handle keys?" toggle. v1 is READ-ONLY; rebind UI is the v1.1 follow-on. |
 | 3 | **Buffer** | `b` | `:general :epoch-history` (slider, relocated from General per rf2-pu9sb — slot stays under `:general` for the persisted-settings shape, only the popup home moved) · `:buffer/cascades-retained` · `:app-db/inspector-collapse-threshold` · "Clear buffer now" button with confirm modal |
-| 4 | **Diff** | `d` | Hiccup-diff opt-in `:highlight-fn-ref-changes?` toggle (sub-output diff layout fixed unified; section-grouping threshold fixed defaults — both dropped from the user surface) |
+| 4 | **Diff** | `d` | Hiccup-diff opt-in `:highlight-fn-ref-changes?` toggle (sub-output diff layout fixed unified; the app-db diff engine itself is Editscript A* per [`021-Dynamic-Panel-Designs.md`](./021-Dynamic-Panel-Designs.md) §9.1.5.1 with no user-tuneable knobs — the prior section-grouping engine was retired wholesale per rf2-7is22) |
 
 **Inner-tab mnemonics** (g / k / b / d) — bare-letter
 keystrokes captured at the dialog level while the modal is open.
@@ -678,7 +678,7 @@ typing into numeric knobs is not interrupted.
 | Per-tab default expansion (`:bookish` / `:dense`) | Each tab owns its expansion default; no global knob. |
 | Accent user-swap | The accent is a single fixed GitHub blue (per §Colour system); light/dark theme is the only user colour axis. |
 | Sub-output diff layout (`:unified` / `:split` toggle) | Fixed unified. |
-| Section-grouping threshold | Fixed defaults; not user-tuneable. |
+| Section-grouping threshold | Engine retired wholesale per rf2-7is22 (#2235); app-db diff now runs Editscript A* directly with no separate section-grouping stage. |
 | Popout as its own tab | Folds into General's Panel-position sub-section. |
 
 Full wireframe + per-field configure! mapping in

--- a/tools/xray/spec/018-Event-Spine.md
+++ b/tools/xray/spec/018-Event-Spine.md
@@ -1306,7 +1306,7 @@ renders. Tabs are equal-weight; **General** is the default-on-open.
 | **General** (default) | Text-size slider · Panel-width slider · Panel-position radio (`:right-rail` / `:popout` / `:fullscreen`) · Density radio (`:cosy` / `:compact`; the `:comfy` tier was dropped per 015 §Density) · Auto-open-on-error checkbox · Long-keyword treatment threshold · **`── Power user ──` divider · "Show tool frames in picker" toggle** (OFF by default; reveals `:rf/xray` etc. in ribbon picker; only useful when debugging Xray itself) · `:use-system-colors?` HCM-override toggle (relocated from Theme per rf2-ou3pn — slot stays `:general :use-system-colors?`) |
 | **Keybindings** | Read-only chord table (every binding the global keydown listener captures) · `Handle keys?` master toggle. v1 ships READ-ONLY; the per-row chord editor + reset-to-defaults UI is the v1.1 follow-on. |
 | **Buffer** | `:general :epoch-history <int>` (slider, default 50, range 10–500; slot stays under `:general` per rf2-pu9sb — only the popup home moved into Buffer) · `:buffer/cascades-retained <int>` (default 50) · `:app-db/inspector-collapse-threshold <int>` (default 20) · "Clear buffer now" button (confirm modal) |
-| **Diff** | Hiccup-diff opt-in `:highlight-fn-ref-changes?` toggle (sub-output diff layout fixed unified; section-grouping threshold fixed defaults — both dropped from the user surface) |
+| **Diff** | Hiccup-diff opt-in `:highlight-fn-ref-changes?` toggle (sub-output diff layout fixed unified; the app-db diff engine itself is Editscript A* per [`021-Dynamic-Panel-Designs.md`](./021-Dynamic-Panel-Designs.md) §9.1.5.1 with no user-tuneable knobs — the prior section-grouping engine was retired wholesale per rf2-7is22) |
 
 ### v1 ships
 


### PR DESCRIPTION
Closes rf2-gbpct.

## Problem

PR #2235 (rf2-7is22) excised the `section_grouping` engine entirely (deleted `tools/xray/src/day8/re_frame2_xray/diff/section_grouping.cljc` — 349 LoC + tests). Two spec docs still described the Diff-tab Settings popup as if the engine ran with fixed defaults — pure spec/impl drift.

## Files modified

- `tools/xray/spec/007-UX-IA.md` — Settings-popup inner-tab Diff row (line 658) + Dropped-from-earlier-drafts table 'Section-grouping threshold' row (line 681).
- `tools/xray/spec/018-Event-Spine.md` — identical lockstep Diff row (line 1309).

## Before / after

Both files' **Diff** inner-tab row (lockstep):

```diff
- | **Diff** | Hiccup-diff opt-in `:highlight-fn-ref-changes?` toggle (sub-output diff layout fixed unified; section-grouping threshold fixed defaults — both dropped from the user surface) |
+ | **Diff** | Hiccup-diff opt-in `:highlight-fn-ref-changes?` toggle (sub-output diff layout fixed unified; the app-db diff engine itself is Editscript A* per [`021-Dynamic-Panel-Designs.md`](./021-Dynamic-Panel-Designs.md) §9.1.5.1 with no user-tuneable knobs — the prior section-grouping engine was retired wholesale per rf2-7is22) |
```

007's *Dropped from earlier drafts* table row (only in 007):

```diff
- | Section-grouping threshold | Fixed defaults; not user-tuneable. |
+ | Section-grouping threshold | Engine retired wholesale per rf2-7is22 (#2235); app-db diff now runs Editscript A* directly with no separate section-grouping stage. |
```

Replacement copy was checked against [`021-Dynamic-Panel-Designs.md`](../tools/xray/spec/021-Dynamic-Panel-Designs.md) §9.1.5.1 (the canonical current-state description of the Editscript A* engine, per rf2-n2jig).

## Quality gates

- `python scripts/check_readme_links.py --ci` — **PASS**
- `python scripts/check_doc_slugs.py` — **PASS**
- `git grep -E '(section.grouping|section-grouping|section_grouping)' tools/xray/spec/` — three remaining hits, all of which explicitly document the engine retirement (the two updated Diff-tab rows + the updated Dropped row); no stale drift.

CLJS spine gates not re-run (docs-only change, no code surface touched).

## References

- rf2-7is22 / PR #2235 — section-grouping engine excised (349 LoC + tests deleted)
- rf2-n2jig — Editscript A* engine adoption + three-mode toggle (`021-Dynamic-Panel-Designs.md` §9.1.5.1)
- rf2-gbpct (this PR) — spec/impl drift cleanup, follow-on to rf2-7is22