### PR TITLE
refactor(xray/edn-inspector): hoist gutter-row + R3 chip styles + collapse engine/op-at calls (rf2-7cddi + rf2-rhmc5)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
@@ -607,6 +607,41 @@
     :modified (:diff-modified-stripe tokens)
     nil))
 
+;; ---- gutter-row hoisted style maps (rf2-7cddi) ---------------------------
+;;
+;; `gutter-row` fires once per change-bearing leaf in mode-3 — a 30-changed-
+;; leaf render allocates 90 fresh map literals at the call site without
+;; hoisting. The base shapes are static; only `:border-left` colour +
+;; `:background` wash overlay vary (5-value op enum) on the outer, and
+;; `:color` varies on the glyph span. Mirrors the hoisting culture
+;; established further down (body-grid-style, body-block-style,
+;; key-cell-style, value-cell-style, triangle-style, r3-chip-base-style).
+
+(def ^:private gutter-row-outer-base-style
+  "Outer `<span>` style for `gutter-row` — the static skeleton.
+  Dynamic overlays (per render):
+   - `:border-left` colour reflects the active op's stripe (or transparent)
+   - `:background` wash assoc'd when an op carries one."
+  {:display      "inline-flex"
+   :align-items  "baseline"
+   :gap          "4px"
+   :padding-left "6px"})
+
+(def ^:private gutter-glyph-base-style
+  "Glyph `<span>` style for `gutter-row` — static skeleton.
+  Dynamic overlay: `:color` resolves to the per-op gutter colour
+  (or `:text-tertiary` for suppressed / `:same` rows)."
+  {:flex        "0 0 12px"
+   :font-size   "11px"
+   :font-weight 700
+   :text-align  "center"
+   :user-select "none"})
+
+(def ^:private gutter-body-style
+  "Body `<span>` style for `gutter-row` — fully static (no dynamic
+  overlay)."
+  {:flex 1 :min-width 0})
+
 (defn- gutter-row
   "Wrap `body` with the diff row chrome: gutter glyph + low-opacity
   row-background wash + 2px left-edge stripe (rf2-awqts).
@@ -675,27 +710,23 @@
          glyph-colour  (if suppress-glyph?
                          (:text-tertiary tokens)
                          (op-gutter-colour op))]
+     ;; rf2-7cddi — hoisted style bases (see `gutter-row-*-style` defs above):
+     ;; the static skeletons are ns-top defs; only the dynamic per-op
+     ;; overlays (`:border-left` colour + optional `:background` wash on
+     ;; the outer; `:color` on the glyph) are computed per render.
      [:span {:data-rf-diff-op (name op)
              :data-rf-diff-wash (when wash "1")
              :data-rf-diff-stripe (when stripe "1")
              :data-rf-diff-suppressed (when suppress-glyph? "1")
-             :style (cond-> {:display      "inline-flex"
-                             :align-items  "baseline"
-                             :gap          "4px"
-                             :padding-left "6px"
-                             :border-left  (str "2px solid "
+             :style (cond-> (assoc gutter-row-outer-base-style
+                              :border-left (str "2px solid "
                                                 (if (and active? stripe)
                                                   stripe
-                                                  "transparent"))}
+                                                  "transparent")))
                       wash (assoc :background wash))}
-      [:span {:style {:flex          "0 0 12px"
-                      :color         glyph-colour
-                      :font-size     "11px"
-                      :font-weight   700
-                      :text-align    "center"
-                      :user-select   "none"}}
+      [:span {:style (assoc gutter-glyph-base-style :color glyph-colour)}
        glyph]
-      [:span {:style {:flex 1 :min-width 0}} body]])))
+      [:span {:style gutter-body-style} body]])))
 
 (def ^:private change-annotation-style
   "Style for the inline `← changed from <prior>` chip rendered to the
@@ -1398,6 +1429,15 @@
 ;; React skip the inline-style diff when the value hasn't changed).
 ;; `tokens` reads resolve to CSS-variable strings (theme-aware at paint
 ;; time), so the captured value stays valid across theme switches.
+;;
+;; Hoisting neighbours in this file (search anchors):
+;;   - `change-annotation-style`        — inline `← changed from <prior>` chip
+;;   - `gutter-row-outer-base-style`    — rf2-7cddi diff-row outer skeleton
+;;   - `gutter-glyph-base-style`        — rf2-7cddi diff-row glyph skeleton
+;;   - `gutter-body-style`              — rf2-7cddi diff-row body
+;;   - `triangle-style`                 — ▸/▾ click-target (rf2-tzvk9)
+;;   - `body-grid-style` / `body-block-style` / `key-cell-style` / `value-cell-style`
+;;   - `r3-chip-base-style`             — rf2-rhmc5 R3 [N∆] collapsed-change chip
 
 (def ^:private body-grid-style
   "Style for an expanded map / record / map-entry body — children laid

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
@@ -1471,6 +1471,27 @@
   pushing past the grid's allotment."
   {:min-width 0})
 
+(def ^:private r3-chip-base-style
+  "Static skeleton for the R3 `[N∆]` collapsed-change chip painted next
+  to a collapsed change-bearing container (rf2-rhmc5). Dynamic per-op
+  overlays applied at the call site:
+   - `:background`   ← `(op-wash-bg chip-op)`
+   - `:border`       ← `1px solid <stripe>` (or transparent)
+   - `:color`        ← `(op-stripe-colour chip-op)` (fallback `:text-secondary`)
+
+  Hoisted to elide three per-render `engine/op-at` lookups (the same
+  `[projection path]` was previously read three times inside one inline
+  map literal) and to give React reconciler a stable map identity for
+  the static skeleton; only the per-op colour slice gets a fresh map
+  per render."
+  {:margin-left   "6px"
+   :padding       "1px 6px"
+   :border-radius "8px"
+   :font-family   sans-stack
+   :font-size     "10px"
+   :font-weight   700
+   :line-height   1.2})
+
 (defn- on-toggle
   "Build the click handler for a node's `▸`/`▾` glyph.
   Dispatches the toggle event via `dispatch-fn` — the lexically-
@@ -1853,7 +1874,16 @@
               n-changes (when (and diff? projection)
                           (engine/change-count-at projection path))
               show-chip? (and (pos? (or n-changes 0))
-                              (not (#{:added :removed} op)))]
+                              (not (#{:added :removed} op)))
+              ;; rf2-rhmc5 — bind chip-op ONCE per render (pre-fix the
+              ;; chip's inline `:style` map read `engine/op-at` three
+              ;; times for the same `[projection path]`); fall back to
+              ;; `:modified` when the projection has no recorded op for
+              ;; this path (matches the original `(or … :modified)`
+              ;; behaviour at each call site).
+              chip-op    (when show-chip?
+                           (or (engine/op-at projection path) :modified))
+              chip-stripe (when show-chip? (op-stripe-colour chip-op))]
           (cond-> [:span {:style {:display "inline-flex" :align-items "center" :gap "6px"}}
                    [:span {:on-click   toggle-fn
                            :role       "button"
@@ -1867,26 +1897,19 @@
             zoom-button (conj zoom-button)
             true        (conj (collapsed-summary value kind))
             show-chip?
+            ;; rf2-rhmc5 — hoisted `r3-chip-base-style` carries the static
+            ;; skeleton (margin/padding/radius/font/line-height); per-op
+            ;; colour slice is overlayed via `assoc`. `chip-stripe` is
+            ;; computed once from `chip-op` (one `engine/op-at` call) and
+            ;; reused for both `:border` colour and `:color`.
             (conj [:span {:data-rf-diff-chip "1"
                           :data-rf-diff-chip-count (str n-changes)
-                          :style {:margin-left  "6px"
-                                  :padding      "1px 6px"
-                                  :background   (op-wash-bg (or (engine/op-at projection path)
-                                                                :modified))
-                                  :border       (str "1px solid "
-                                                     (or (op-stripe-colour
-                                                           (or (engine/op-at projection path)
-                                                               :modified))
-                                                         "transparent"))
-                                  :border-radius "8px"
-                                  :font-family  sans-stack
-                                  :font-size    "10px"
-                                  :font-weight  700
-                                  :color        (or (op-stripe-colour
-                                                      (or (engine/op-at projection path)
-                                                          :modified))
-                                                    (:text-secondary tokens))
-                                  :line-height  1.2}}
+                          :style (assoc r3-chip-base-style
+                                   :background (op-wash-bg chip-op)
+                                   :border     (str "1px solid "
+                                                    (or chip-stripe "transparent"))
+                                   :color      (or chip-stripe
+                                                   (:text-secondary tokens)))}
                    (str n-changes "∆")]))))]
 
      ;; ---- body — children rendered indented -----------------------------


### PR DESCRIPTION
Two style-hoist refactors in `tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs`, from the rf2-gwm0y three-mode diff efficiency audit. Single PR, sequenced commits.

## rf2-7cddi — hoist `gutter-row` styles

`gutter-row` (the per-leaf diff-row chrome) previously minted three fresh inline `:style` map literals on every invocation:

- outer `<span>` — 5-key map (display / align / gap / padding-left / border-left)
- glyph inner `<span>` — 6-key map (flex / color / font-size / font-weight / text-align / user-select)
- body inner `<span>` — 2-key map (flex / min-width)

In a 30-changed-leaf mode-3 render that was **90 fresh map allocations per render**, defeating the React reconciler's inline-style diff fast-path.

**Fix.** Hoisted three ns-top defs (`gutter-row-outer-base-style`, `gutter-glyph-base-style`, `gutter-body-style`) carrying the static skeleton. Only the dynamic per-op overlays (`:border-left` colour + optional `:background` wash on the outer; `:color` on the glyph) are computed per render via `cond->` / `assoc`. The body span is fully static.

Pattern matches the existing hoisting culture in this file (`change-annotation-style`, `triangle-style`, `body-grid-style` / `body-block-style` / `key-cell-style` / `value-cell-style`).

## rf2-rhmc5 — hoist R3 chip style + collapse redundant `engine/op-at` calls

The R3 collapsed `[N∆]` change-count chip previously called `engine/op-at` **three times** for the same `[projection path]` inside its inline `:style` map — once for `:background`, once for `:border` stripe colour, once for `:color`.

In a deeply-nested app-db with 30+ collapsed change-bearing nodes that was 90 redundant lookups + 30 fresh 9-key style maps per render.

**Fix.**

1. Bind `chip-op (or (engine/op-at projection path) :modified)` ONCE in the surrounding `let` (gated by `show-chip?` so it's elided when no chip will render).
2. Bind `chip-stripe (op-stripe-colour chip-op)` once and reuse for both `:border` colour and `:color` fallback.
3. Hoist `r3-chip-base-style` as ns-top def — static skeleton (margin / padding / radius / font-family / font-size / font-weight / line-height). Per-op colour slice overlayed via `assoc`.

Allocation + lookup delta per chip render:
- **pre:** 3 `engine/op-at` calls + 3 `op-stripe-colour` calls + 1 fresh 9-key map literal
- **post:** 1 `engine/op-at` call + 1 `op-stripe-colour` call + 1 `assoc` overlay (3 dynamic keys) onto a hoisted base

## Hoist-pattern citations

- Existing neighbour comment block at lines ~1392+ updated to include the new `gutter-row-*-style` + `r3-chip-base-style` anchors.
- Same convention as `body-grid-style` / `body-block-style` / `key-cell-style` / `value-cell-style` (defined right after the explanatory block).

## Allocation delta per render (before → after)

| Surface | Inline `:style` maps before | After | `engine/op-at` calls before | After |
|---|---|---|---|---|
| `gutter-row` (per call) | 3 | 0 (all hoisted; only sliver overlays) | n/a | n/a |
| R3 `[N∆]` chip (per render) | 1 (9-key) | 1 (3-key overlay on hoisted base) | 3 | 1 |

## Quality gates

- `bash scripts/test-fast-pr.sh` — PASS (0 warnings; 4738 tests / 15420 assertions / 0 failures; markdown gate skipped — no markdown touched in this PR)
- `npm run test:cljs` — PASS (0 warnings; same totals)
- `npm run test:browser` — PASS (124 tests / 353 assertions / 0 failures)
- `npm run test:bundle-isolation` — PASS (17 artefacts; 35 sentinels absent; 3 budgets ok)
- `npm run test:perf-bundle` — PASS (off-count=0, on-count=12)

## Stance

Pre-alpha masterpiece; GOOD-PRACTICE alignment with the existing hoisting culture. No behavioural change — `:data-rf-diff-*` attrs + glyph payload + visual chrome identical pre/post.

Closes rf2-7cddi · rf2-rhmc5
