### PR TITLE
docs(tools/xray/spec): retitle §9.1.5.1 + polish triple + :machine-data row (rf2-pvy2n + rf2-3tjkc + rf2-ot28z)

### DIFF
--- a/tools/xray/spec/016-Auxiliary-Panels.md
+++ b/tools/xray/spec/016-Auxiliary-Panels.md
@@ -38,7 +38,7 @@ mount paths and L3-tab backing (when applicable) are:
 | 8  | 2 | App-DB segment-inspector popup    | `app-db-segment-inspector/Popup`        | — (overlay) |
 | 9  | 2 | Cancellation-cascade side-panel    | `cancellation-cascade/SidePanel`        | — (overlay) |
 | 10 | 2 | Cancellation-cascade popover       | `cancellation-cascade/Popover`          | — (overlay) |
-| 11 | 3 | Managed-fx records list            | `panels/ManagedFxList`                  | standalone mount (rf2-5gl5r — the Event/Handler tab that originally embedded it was retired) |
+| 11 | 3 | Managed-fx records list            | `panels/ManagedFxList`                  | standalone mount — no current panel embeds it (rf2-5gl5r retired the Event/Handler tab that originally hosted it). Consumers mount directly per the embedding contract ([`008-Embedding-Contract.md`](008-Embedding-Contract.md)). |
 | 12 | 4 | After-rings overlay                | `machine-after-rings/AfterRingsOverlay` | sub of Machines tab |
 | 13 | 4 | Sim side-rail                      | `static.machines.sim/SimRail`           | sub of Machines tab |
 

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1603,6 +1603,17 @@ HANDLER `:db`:
 - `:full+diff` — mode-3 combined lens (full tree + R1-R8 grammar
   annotations against `:before`).
 
+**R-rule applicability across surfaces**: all R1-R8 rules from
+§9.1.5.1 apply uniformly to every surface in `:full+diff` mode.
+Rules that have no work to do on a given value shape trivially
+no-op rather than special-cased per surface — e.g. R6 (vector
+shift-detection) no-ops on map containers; R2 (key glyph) no-ops
+on primitive cell values like a SUBSCRIPTIONS row's scalar return;
+R3 (collapsed-container `[N∆]` chip) no-ops on leaf scalars. The
+shared widget + shared projection engine (`day8.re-frame2-xray.diff.engine`)
+hold the grammar; per-surface mounts contribute only the
+`(before, after)` value pair.
+
 **Per-surface storage**: every surface registers its own sub +
 event pair so the modes are independent (operator's App-DB choice
 doesn't override the Machine Inspector choice).

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1887,14 +1887,15 @@ unchanged); only the aggregation moved.
 
 #### Attachment mapping (the new contract)
 
-| `:where` slot | Owning pipeline step                                | Granularity              |
-|---------------|-----------------------------------------------------|--------------------------|
-| `:event`      | DISPATCH                                            | step-level               |
-| `:cofx`       | COEFFECT step whose `:id` = `:failing-id`           | step-level (per cofx)    |
-| `:app-db`     | HANDLER                                             | step-level               |
-| `:fx-args`    | FX step, row whose `:fx-id` = `:failing-id`         | row-level (fallback step)|
-| `:sub-return` | SUBSCRIPTIONS step, row whose `:sub-id` = `:failing-id` | row-level (fallback step) |
-| `:hot-reload` | standalone SCHEMA HOT-RELOAD tail step              | step-level               |
+| `:where` slot   | Owning pipeline step                                | Granularity              |
+|-----------------|-----------------------------------------------------|--------------------------|
+| `:event`        | DISPATCH                                            | step-level               |
+| `:cofx`         | COEFFECT step whose `:id` = `:failing-id`           | step-level (per cofx)    |
+| `:app-db`       | HANDLER                                             | step-level               |
+| `:fx-args`      | FX step, row whose `:fx-id` = `:failing-id`         | row-level (fallback step)|
+| `:sub-return`   | SUBSCRIPTIONS step, row whose `:sub-id` = `:failing-id` | row-level (fallback step) |
+| `:machine-data` | HANDLER, machine-cascade row whose machine id = `:failing-id` (the failing machine). When the violation triggered full-cascade rollback (`:rollback? true`), attach instead to the rolled-back-tail step so the reader lands on the boundary where the cascade halted. Per rf2-jbbp7 (see [spec/005 §Schema validation](../../../spec/005-StateMachines.md#schema-validation), [spec/010 §Per-step recovery row 7](../../../spec/010-Schemas.md#per-step-recovery)). | row-level (fallback step) |
+| `:hot-reload`   | standalone SCHEMA HOT-RELOAD tail step              | step-level               |
 
 The projection pass `attach-violations` walks the
 `schema-violation-rows` once and binds each row onto its owning

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1491,7 +1491,7 @@ no replay. The substrate enhancements in #2155 (rf2-82a0u) are the
 prerequisite that lets every cascade row read directly off the
 trace.
 
-#### §9.1.5.1 HANDLER `:db` view-mode toggle — three-mode `[diff][full][full+diff]` (rf2-n2jig)
+#### §9.1.5.1 HANDLER `:db` diff-mode toggle — three-mode `[diff][full][full+diff]` (rf2-n2jig)
 
 The HANDLER step's `:db` sub-section carries a three-button toggle:
 

--- a/tools/xray/spec/README.md
+++ b/tools/xray/spec/README.md
@@ -128,7 +128,7 @@ main read**.
    third** for the matrix of features across the four cross-cutting areas
    (SSR · Machines · Routes · Managed-Fx).
 4. **Then per-tab specs (003 Machines, 004 App-db, 006 Hydration, 012
-   Views, 013 Trace, 016 Event/Issues)** for the specific surfaces. Each
+   Views, 013 Trace, 016 Auxiliary panels)** for the specific surfaces. Each
    is independent of the others bar explicit cross-references.
 
 The 19-doc set is complete enough to one-shot the tool. Where v1's


### PR DESCRIPTION
Shape-2 cluster of three xray-spec polish fixes from the rf2-gkh43 coverage audit (P2 + 2×P3). Single PR, three sequenced commits.

## Per-bead summary

### rf2-pvy2n (P3) — retitle §9.1.5.1
spec/021 §9.1.5.1 heading was "HANDLER `:db` view-mode toggle"; the body and storage key (`:rf.xray.epoch/db-diff-mode`) use the canonical "diff-mode" vocabulary. The "view-mode" wording collided with the Machines tab Canvas/List view-mode toggle (spec/007-UX-IA.md:601, machine_canvas.cljs:258-282). Retitled to `diff-mode toggle`. Body unchanged.

### rf2-3tjkc (P3) — polish triple
- **L1 — spec/021 §9.1.5.2**: noted that all R1-R8 rules apply uniformly to every surface in `:full+diff` mode; rules without applicable work no-op rather than special-cased per surface. Implementer no longer guesses which R-rules a non-HANDLER surface needs.
- **L2 — spec/016 line 41**: clarified the Managed-fx records list mount status — no current panel embeds it; consumers mount directly per `008-Embedding-Contract.md`.
- **L3 — spec/README line 131**: replaced "016 Event/Issues" with "016 Auxiliary panels" (Event/Handler tab retired; spec/016 now covers Event tab, Issues ribbon, Routes, Flows).

### rf2-ot28z (P2) — `:machine-data` row in §9.1.10.3 violation table
PR #2227 (rf2-jbbp7) extended `:rf.error/schema-validation-failure` with `:where :machine-data`. Xray's §9.1.10.3 attachment-mapping table never got the new row, so an implementer reading an unhandled `:machine-data` violation would fall through to default chrome.

Row added:
| `:machine-data` | HANDLER, machine-cascade row whose machine id = `:failing-id` (the failing machine). On full-cascade rollback (`:rollback? true`), attach to the rolled-back-tail step instead. Per rf2-jbbp7 (cross-links spec/005 §Schema validation + spec/010 §Per-step recovery row 7). | row-level (fallback step) |

Cross-links use the existing `../../../spec/` relative-path shape from `003-Machine-Inspector.md`.

## Anchor cross-ref updates from the retitle
No anchor refs use the §9.1.5.1 heading slug — all in-doc cross-refs are by section number (§9.1.5.1 itself is the read-target). `python scripts/check_doc_slugs.py` passes after the retitle (exit 0).

## Files modified
- `tools/xray/spec/021-Dynamic-Panel-Designs.md` (all three commits — retitle, R-rule note, :machine-data row)
- `tools/xray/spec/016-Auxiliary-Panels.md` (Managed-fx mount clarification)
- `tools/xray/spec/README.md` (Event/Issues → Auxiliary panels)

## Quality gates
- `bash scripts/test-fast-pr.sh` → PASS (4752 tests / 15466 assertions / 0 failures / 0 errors; markdown link/anchor gates passed; mkdocs soft-skipped locally per existing convention)
- `python scripts/check_doc_slugs.py` → exit 0

## Closes
- rf2-pvy2n
- rf2-3tjkc
- rf2-ot28z