### PR TITLE
refactor(examples): :dispatch-later + feature-prefix sub-ids in managed_http_counter + routing (rf2-z6ivh + rf2-kzzj0 + rf2-nmvh3)

### DIFF
--- a/examples/helix/login_helix/core.cljs
+++ b/examples/helix/login_helix/core.cljs
@@ -21,7 +21,6 @@
             [helix.dom          :as d]
             [helix.hooks        :as helix-hooks]
             [re-frame.core :as rf]
-            [re-frame.registrar :as registrar]
             [re-frame.schemas]
             [re-frame.machines]
             [re-frame.http-managed]
@@ -61,45 +60,57 @@
     (when-let [ls (.-localStorage js/globalThis)]
       (.setItem ls "auth/token" token))))
 
+(rf/reg-event-fx :auth.login.demo/schedule-reply
+  {:doc "Private — entered via dispatch from :auth.login.demo/managed-stub.
+         Uses `:dispatch-later` so framework time controls apply to the
+         demo latency. See examples/reagent/login for the full rationale."}
+  (fn handler-auth-login-demo-schedule-reply [_ [_ outcome args-map]]
+    {:fx [[:dispatch-later
+           {:ms    50
+            :event [:auth.login.demo/deliver-reply outcome args-map]}]]}))
+
+(rf/reg-event-fx :auth.login.demo/deliver-reply
+  {:doc "Private — fired by the :dispatch-later scheduled in
+         :auth.login.demo/schedule-reply. Delegates to the framework-
+         shipped canned-success / canned-failure fxs (Spec 014 §Testing)."}
+  (fn handler-auth-login-demo-deliver-reply [_ [_ outcome args-map]]
+    (case outcome
+      :success
+      {:fx [[:rf.http/managed-canned-success
+             (assoc args-map
+                    :value {:user  {:id    (random-uuid)
+                                    :email (-> args-map :request :body :email)}
+                            :token "demo-token-123"})]]}
+
+      :failure-401
+      {:fx [[:rf.http/managed-canned-failure
+             (assoc args-map
+                    :kind :rf.http/http-4xx
+                    :tags {:status  401
+                           :message "Invalid credentials."})]]}
+
+      :empty-success
+      {:fx [[:rf.http/managed-canned-success (assoc args-map :value {})]]})))
+
 (rf/reg-fx :auth.login.demo/managed-stub
   {:doc       "Demo override for `:rf.http/managed`. Identical behaviour
-               to the Reagent and UIx examples' stub.
-
-               NOTE on the raw js/setTimeout below. The deferred work
-               is an fx invocation (the canned-success / canned-failure
-               stub), not a dispatch, so the framework's
-               `:dispatch-later` path is not a 1:1 swap. The timer is
-               purely demo-stub latency so the `:submitting` UI state
-               is observable. Production app code should never use raw
-               `js/setTimeout` — use `:dispatch-later` so framework
-               time controls (Tool-Pair time-travel,
-               `:dispatch-later` nil-override) still apply."
+               to the Reagent and UIx examples' stub — dispatches into
+               the private :auth.login.demo/schedule-reply event so the
+               deferred reply rides framework `:dispatch-later` (50 ms)
+               rather than raw `js/setTimeout`. Framework time controls
+               (Tool-Pair time-travel, `:dispatch-later` nil-override)
+               apply automatically."
    :platforms #{:server :client}}
   (fn fx-managed-login-demo [frame-ctx args-map]
     (let [{:keys [url body]} (:request args-map)
-          login?    (= "/api/login" url)
-          success?  (and login? (= good-password (:password body)))
-          ok-stub   (registrar/handler :fx :rf.http/managed-canned-success)
-          fail-stub (registrar/handler :fx :rf.http/managed-canned-failure)]
-      ;; Demo-only artificial latency — see the fx doc above.
-      (js/setTimeout
-        (fn []
-          (cond
-            success?
-            (ok-stub frame-ctx (assoc args-map
-                                      :value {:user  {:id    (random-uuid)
-                                                      :email (:email body)}
-                                              :token "demo-token-123"}))
-
-            login?
-            (fail-stub frame-ctx (assoc args-map
-                                        :kind :rf.http/http-4xx
-                                        :tags {:status 401
-                                               :message "Invalid credentials."}))
-
-            :else
-            (ok-stub frame-ctx (assoc args-map :value {}))))
-        50))))
+          login?  (= "/api/login" url)
+          outcome (cond
+                    (and login? (= good-password (:password body))) :success
+                    login?                                          :failure-401
+                    :else                                           :empty-success)
+          frame   (:frame frame-ctx)]
+      (rf/dispatch [:auth.login.demo/schedule-reply outcome args-map]
+                   {:frame frame}))))
 
 ;; ============================================================================
 ;; STATE MACHINE

--- a/examples/reagent/boot/core.cljs
+++ b/examples/reagent/boot/core.cljs
@@ -21,9 +21,6 @@
             [re-frame.core :as rf]
             ;; Required for `rf/init!`.
             [re-frame.adapter.reagent-slim :as reagent-slim-adapter]
-            ;; Loads the registrar so we can resolve the canned-success
-            ;; fx for the per-URL stub below.
-            [re-frame.registrar :as registrar]
             ;; Managed-HTTP ships in day8/re-frame2-http. The require
             ;; triggers its fx registrations (:rf.http/managed and
             ;; family) at app boot; without it, the child loaders'
@@ -83,35 +80,50 @@
       (str/includes? u "/user.json")   demo-user
       :else                            {})))
 
+(rf/reg-event-fx :boot.demo/schedule-reply
+  {:doc "Private — entered via dispatch from :boot.demo/http-stub. Uses
+         `:dispatch-later` so framework time controls (Tool-Pair
+         time-travel, the documented `:dispatch-later` nil-override
+         seam) apply to the demo latency. No user dispatches this
+         directly."}
+  (fn handler-boot-demo-schedule-reply [_ [_ args-map payload]]
+    {:fx [[:dispatch-later
+           {:ms    60
+            :event [:boot.demo/deliver-reply args-map payload]}]]}))
+
+(rf/reg-event-fx :boot.demo/deliver-reply
+  {:doc "Private — fired by the :dispatch-later scheduled in
+         :boot.demo/schedule-reply. Delegates to the framework-shipped
+         `:rf.http/managed-canned-success` with the per-URL canned
+         payload."}
+  (fn handler-boot-demo-deliver-reply [_ [_ args-map payload]]
+    {:fx [[:rf.http/managed-canned-success (assoc args-map :value payload)]]}))
+
 (rf/reg-fx :boot.demo/http-stub
   {:doc       "Demo override for `:rf.http/managed`: routes by URL
                substring to canned boot responses so the example runs
-               standalone without a backend. Delegates to the
-               framework-shipped `:rf.http/managed-canned-success`
-               per Spec 014 §Testing.
+               standalone without a backend.
 
-               A small artificial delay (60 ms) lets the boot-progress
-               view render the per-phase loading state before the
-               replies land — without it, the boot resolves in one
-               drain and the user only ever sees the `:ready` screen.
+               Dispatches into the private :boot.demo/schedule-reply
+               event so the deferred reply rides framework
+               `:dispatch-later` (60 ms) rather than raw
+               `js/setTimeout`. The delay lets the boot-progress view
+               render the per-phase loading state before the replies
+               land — without it, the boot resolves in one drain and
+               the user only ever sees the `:ready` screen. The reply
+               itself lands via the framework-shipped
+               `:rf.http/managed-canned-success` (Spec 014 §Testing).
 
-               NOTE on the raw js/setTimeout below. The deferred work
-               is an fx invocation, not a dispatch, so the framework's
-               `:dispatch-later` path is not a 1:1 swap. The timer is
-               purely demo-stub latency; production app code should
-               never use raw `js/setTimeout` (use `:dispatch-later` or
-               drive the fx via a private event whose dispatch is
-               `:dispatch-later`'d, so framework time controls apply)."
+               Framework time controls (Tool-Pair time-travel, the
+               documented `:dispatch-later` nil-override seam) apply
+               automatically."
    :platforms #{:server :client}}
   (fn fx-managed-boot-demo [frame-ctx args-map]
     (let [url     (-> args-map :request :url)
           payload (demo-payload-for-url url)
-          stub-fn (registrar/handler :fx :rf.http/managed-canned-success)]
-      (when stub-fn
-        ;; Demo-only artificial latency — see the fx doc above.
-        (js/setTimeout
-          (fn [] (stub-fn frame-ctx (assoc args-map :value payload)))
-          60)))))
+          frame   (:frame frame-ctx)]
+      (rf/dispatch [:boot.demo/schedule-reply args-map payload]
+                   {:frame frame}))))
 
 ;; ============================================================================
 ;; MOUNT

--- a/examples/reagent/login/core.cljs
+++ b/examples/reagent/login/core.cljs
@@ -42,7 +42,6 @@
   ;; slim.)
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
-            [re-frame.registrar :as registrar]
             ;; The Spec 010 schema-attachment ns lives in
             ;; the day8/re-frame2-schemas artefact. The require here
             ;; loads the ns so its late-bind hooks register before
@@ -123,61 +122,77 @@
     (when-let [ls (.-localStorage js/globalThis)]
       (.setItem ls "auth/token" token))))
 
+(rf/reg-event-fx :auth.login.demo/schedule-reply
+  {:doc "Private — entered via dispatch from :auth.login.demo/managed-stub.
+         Uses `:dispatch-later` so framework time controls (Tool-Pair
+         time-travel, the documented `:dispatch-later` nil-override
+         seam) apply to the demo latency. No user dispatches this
+         directly."}
+  (fn handler-auth-login-demo-schedule-reply [_ [_ outcome args-map]]
+    {:fx [[:dispatch-later
+           {:ms    50
+            :event [:auth.login.demo/deliver-reply outcome args-map]}]]}))
+
+(rf/reg-event-fx :auth.login.demo/deliver-reply
+  {:doc "Private — fired by the :dispatch-later scheduled in
+         :auth.login.demo/schedule-reply. Delegates to the framework-
+         shipped `:rf.http/managed-canned-success` /
+         `:rf.http/managed-canned-failure` (Spec 014 §Testing)."}
+  (fn handler-auth-login-demo-deliver-reply [_ [_ outcome args-map]]
+    (case outcome
+      :success
+      {:fx [[:rf.http/managed-canned-success
+             (assoc args-map
+                    :value {:user  {:id    (random-uuid)
+                                    :email (-> args-map :request :body :email)}
+                            :token "demo-token-123"})]]}
+
+      :failure-401
+      {:fx [[:rf.http/managed-canned-failure
+             (assoc args-map
+                    :kind :rf.http/http-4xx
+                    :tags {:status  401
+                           :message "Invalid credentials."})]]}
+
+      :empty-success
+      {:fx [[:rf.http/managed-canned-success (assoc args-map :value {})]]})))
+
 (rf/reg-fx :auth.login.demo/managed-stub
   {:doc       "Demo override for `:rf.http/managed`: routes by URL +
-               request body to canned login responses so the example runs
-               standalone without a backend.
+               request body to canned login responses so the example
+               runs standalone without a backend.
 
                POST /api/login with `:password good-password` → success
                  with `{:user {...} :token \"demo-token-123\"}`.
                POST /api/login otherwise → 401 failure.
                Anything else (e.g. /api/auth/lock) → empty success.
 
-               Delegates to the framework-shipped
-               `:rf.http/managed-canned-success` /
-               `:rf.http/managed-canned-failure` per Spec 014 §Testing,
-               so the reply shape (`{:kind :success :value ...}` /
-               `{:kind :failure :failure ...}`) lands at the inner
-               `:auth.login/success` / `:auth.login/failure` sub-events
-               via the explicit `:on-success` / `:on-failure` form.
+               Dispatches into the private
+               :auth.login.demo/schedule-reply event so the deferred
+               reply rides framework `:dispatch-later` (50 ms) rather
+               than raw `js/setTimeout`. The delay lets the
+               `:submitting` UI state be observable; the reply itself
+               lands via the framework-shipped canned-success /
+               canned-failure fxs so the reply shape
+               (`{:kind :success :value ...}` / `{:kind :failure
+               :failure ...}`) reaches the inner `:auth.login/success`
+               / `:auth.login/failure` sub-events via the explicit
+               `:on-success` / `:on-failure` form.
 
-               NOTE on the raw js/setTimeout below. The deferred work
-               is an fx invocation (the canned-success / canned-failure
-               stub), not a dispatch, so the framework's
-               `:dispatch-later` path is not a 1:1 swap. The timer is
-               purely demo-stub latency so the `:submitting` UI state
-               is observable. Production app code should never use raw
-               `js/setTimeout` — use `:dispatch-later` (or, for a
-               deferred fx, dispatch-later to a private event whose
-               handler issues the fx) so framework time controls
-               (Tool-Pair time-travel, `:dispatch-later` nil-override)
-               still apply."
+               Framework time controls (Tool-Pair time-travel, the
+               documented `:dispatch-later` nil-override seam) apply
+               automatically."
    :platforms #{:server :client}}
   (fn fx-managed-login-demo [frame-ctx args-map]
     (let [{:keys [url body]} (:request args-map)
-          login?    (= "/api/login" url)
-          success?  (and login? (= good-password (:password body)))
-          ok-stub   (registrar/handler :fx :rf.http/managed-canned-success)
-          fail-stub (registrar/handler :fx :rf.http/managed-canned-failure)]
-      ;; Demo-only artificial latency — see the fx doc above.
-      (js/setTimeout
-        (fn []
-          (cond
-            success?
-            (ok-stub frame-ctx (assoc args-map
-                                      :value {:user  {:id    (random-uuid)
-                                                      :email (:email body)}
-                                              :token "demo-token-123"}))
-
-            login?
-            (fail-stub frame-ctx (assoc args-map
-                                        :kind :rf.http/http-4xx
-                                        :tags {:status 401
-                                               :message "Invalid credentials."}))
-
-            :else
-            (ok-stub frame-ctx (assoc args-map :value {}))))
-        50))))
+          login?  (= "/api/login" url)
+          outcome (cond
+                    (and login? (= good-password (:password body))) :success
+                    login?                                          :failure-401
+                    :else                                           :empty-success)
+          frame   (:frame frame-ctx)]
+      (rf/dispatch [:auth.login.demo/schedule-reply outcome args-map]
+                   {:frame frame}))))
 
 ;; ============================================================================
 ;; STATE MACHINE  (CP-5)

--- a/examples/reagent/managed_http_counter/core.cljs
+++ b/examples/reagent/managed_http_counter/core.cljs
@@ -47,13 +47,18 @@
 
 ;; -- App-db shape ------------------------------------------------------------
 ;;
-;; {:count    <int>           ;; current counter value
-;;  :status   <:idle|:loading|:error>
-;;  :error    <failure-map-or-nil>}
+;; {:counter/count    <int>           ;; current counter value
+;;  :counter/status   <:idle|:loading|:error>
+;;  :counter/error    <failure-map-or-nil>}
+;;
+;; Per spec/Conventions §Feature-modularity prefix convention every
+;; app-db slot and sub-id carries the feature prefix; events already do.
 
 (rf/reg-event-db :counter/initialise
   (fn [_db _ev]
-    {:count 0 :status :idle :error nil}))
+    {:counter/count  0
+     :counter/status :idle
+     :counter/error  nil}))
 
 ;; -- +1 (real round-trip via Fetch) ------------------------------------------
 ;;
@@ -69,21 +74,21 @@
       ;; Reply branch — increment by the delta the server returned.
       (some-> msg :rf/reply :kind (= :success))
       {:db (-> db
-               (update :count + (or (:delta (:value (:rf/reply msg))) 1))
-               (assoc :status :idle :error nil))}
+               (update :counter/count + (or (:delta (:value (:rf/reply msg))) 1))
+               (assoc :counter/status :idle :counter/error nil))}
 
       ;; Failure branch — record the error.
       (some-> msg :rf/reply :kind (= :failure))
       {:db (-> db
-               (assoc :status :error
-                      :error  (:failure (:rf/reply msg))))}
+               (assoc :counter/status :error
+                      :counter/error  (:failure (:rf/reply msg))))}
 
       ;; Initial branch — issue the request. The `rf.http/get`
       ;; helper synthesises the same `[:rf.http/managed args-map]`
       ;; envelope a hand-written `:method :get` entry would; the
       ;; call-site reads as one line of intent.
       :else
-      {:db (assoc db :status :loading :error nil)
+      {:db (assoc db :counter/status :loading :counter/error nil)
        :fx [(rf.http/get "api/inc.json" {:decode :json})]})))
 
 ;; -- Fail (real 404 from http-server) ----------------------------------------
@@ -92,11 +97,11 @@
   (fn [{:keys [db]} [_ msg]]
     (cond
       (some-> msg :rf/reply :kind (= :failure))
-      {:db (assoc db :status :error :error (:failure (:rf/reply msg)))}
+      {:db (assoc db :counter/status :error :counter/error (:failure (:rf/reply msg)))}
 
       (some-> msg :rf/reply :kind (= :success))
       ;; Should not happen — the URL is intentionally 404.
-      {:db (assoc db :status :idle :error nil)}
+      {:db (assoc db :counter/status :idle :counter/error nil)}
 
       ;; Same `rf.http/get` helper as above. Per Spec 014
       ;; §Classification order, status-check fires before decode — so
@@ -106,7 +111,7 @@
       ;; default `:auto` here exercises the common case: a JSON
       ;; endpoint that 404s with a load-balancer HTML page.
       :else
-      {:db (assoc db :status :loading :error nil)
+      {:db (assoc db :counter/status :loading :counter/error nil)
        :fx [(rf.http/get "api/does-not-exist")]})))
 
 ;; -- Retry-recover (canned-stub at app level) --------------------------------
@@ -123,11 +128,11 @@
     (cond
       (some-> msg :rf/reply :kind (= :success))
       {:db (-> db
-               (update :count + (or (:delta (:value (:rf/reply msg))) 0))
-               (assoc :status :idle :error nil))}
+               (update :counter/count + (or (:delta (:value (:rf/reply msg))) 0))
+               (assoc :counter/status :idle :counter/error nil))}
 
       :else
-      {:db (assoc db :status :loading)
+      {:db (assoc db :counter/status :loading)
        ;; The canned-success stub synthesises the reply per Spec 014
        ;; §Testing. The retry policy is declared so user code reads
        ;; the same as a live retry-recover; the stub short-circuits.
@@ -166,14 +171,14 @@
       ;; cancellation, which lands here via default reply addressing.
       ;; Either kind (success / failure) returns the UI to :idle.
       (some-> msg :rf/reply :kind some?)
-      {:db (assoc db :status :idle)}
+      {:db (assoc db :counter/status :idle)}
 
       ;; Defer the canned-failure via :dispatch-later so the :loading UI
       ;; state is observable before it lands. The +1 / Fail / Retry-recover
       ;; paths above still hit the framework's :rf.http/managed; only this
       ;; "long-running" demo defers a synthetic reply.
       :else
-      {:db (assoc db :status :loading :error nil)
+      {:db (assoc db :counter/status :loading :counter/error nil)
        :fx [[:dispatch-later
              {:ms    750
               :event [:managed-http-counter.demo/deliver-long-reply
@@ -183,25 +188,25 @@
 
 (rf/reg-event-fx :counter/cancel
   (fn [{:keys [db]} _]
-    {:db (assoc db :status :idle)
+    {:db (assoc db :counter/status :idle)
      ;; Abort by request-id. The live fx fires the abort handle and
      ;; the in-flight request emits :on-failure :rf.http/aborted via
      ;; default reply addressing back to :counter/start-long, which
-     ;; handles the reply by clearing :status (see above).
+     ;; handles the reply by clearing :counter/status (see above).
      :fx [[:rf.http/managed-abort :counter/long]]}))
 
 ;; -- Subs --------------------------------------------------------------------
 
-(rf/reg-sub :count  (fn [db _] (:count db)))
-(rf/reg-sub :status (fn [db _] (:status db)))
-(rf/reg-sub :error  (fn [db _] (:error db)))
+(rf/reg-sub :counter/count  (fn [db _] (:counter/count  db)))
+(rf/reg-sub :counter/status (fn [db _] (:counter/status db)))
+(rf/reg-sub :counter/error  (fn [db _] (:counter/error  db)))
 
 ;; -- Views -------------------------------------------------------------------
 
 (reg-view counter-view []
-  (let [count  @(subscribe [:count])
-        status @(subscribe [:status])
-        error  @(subscribe [:error])]
+  (let [count  @(subscribe [:counter/count])
+        status @(subscribe [:counter/status])
+        error  @(subscribe [:counter/error])]
     [:div {:style {:font-family "sans-serif" :padding "1em"}}
      [:h1 "Managed HTTP counter"]
      [:p "Count: " [:span {:data-testid "count"} count]]

--- a/examples/reagent/managed_http_counter/core.cljs
+++ b/examples/reagent/managed_http_counter/core.cljs
@@ -25,7 +25,6 @@
   and Fetch."
   (:require [reagent2.dom.client :as rdc]
             [re-frame.core :as rf]
-            [re-frame.registrar :as registrar]
             [re-frame.views]
             ;; Managed-HTTP ships in day8/re-frame2-http.
             ;; Requiring re-frame.http-managed at app boot is what
@@ -139,33 +138,26 @@
 
 ;; -- Cancel an in-flight request ---------------------------------------------
 ;;
-;; A "long" request is routed through a per-app stub that defers its
-;; reply via js/setTimeout, so the :loading state is observable in a
-;; browser long enough for the cancel UI to interact with it.
-;; The Spec 014 contract is that the in-flight request dispatches
-;; :rf.http/aborted on cancellation; the deferred-stub approach mimics
-;; that contract end-to-end without requiring a real long-running
-;; endpoint.
+;; A "long" request defers its synthetic failure-reply via
+;; `:dispatch-later` so the :loading state is observable in a browser
+;; long enough for the cancel UI to interact with it. The Spec 014
+;; contract is that an in-flight request dispatches `:rf.http/aborted`
+;; on cancellation; routing the deferred reply through the framework's
+;; `:dispatch-later` + `:rf.http/managed-canned-failure` mimics that
+;; contract end-to-end without requiring a real long-running endpoint
+;; — and framework time controls (Tool-Pair time-travel, the
+;; documented `:dispatch-later` nil-override) apply automatically.
 
-(rf/reg-fx :managed-http-counter.demo/long-stub
-  {:doc       "Per-app fx that synthesises a delayed :rf.http/managed
-               reply for the :counter/start-long path. The deferred
-               canned-failure reply lands ~750ms after dispatch, leaving
-               the :loading UI state observable long enough for a
-               browser smoke test to assert on it before the Cancel
-               click fires. Used directly by :counter/start-long (no
-               frame-level override), so the +1 / Fail / Retry-recover
-               paths still hit the framework-shipped `:rf.http/managed`."
-   :platforms #{:client :server}}
-  (fn fx-managed-long-stub [frame-ctx args-map]
-    (let [stub (registrar/handler :fx :rf.http/managed-canned-failure)]
-      ;; Demo-only artificial latency — see the fx doc above.
-      (js/setTimeout
-        (fn []
-          (stub frame-ctx (assoc args-map
-                                 :kind :rf.http/transport
-                                 :tags {:message "Demo: long request did not resolve."})))
-        750))))
+(rf/reg-event-fx :managed-http-counter.demo/deliver-long-reply
+  {:doc "Private — invoked via :dispatch-later from :counter/start-long.
+         Synthesises a deferred :rf.http/managed-canned-failure reply
+         so the :loading UI state is observable before the failure
+         lands. No user dispatches this directly."}
+  (fn handler-deliver-long-reply [_ [_ args-map]]
+    {:fx [[:rf.http/managed-canned-failure
+           (assoc args-map
+                  :kind :rf.http/transport
+                  :tags {:message "Demo: long request did not resolve."})]]}))
 
 (rf/reg-event-fx :counter/start-long
   (fn [{:keys [db]} [_ msg]]
@@ -176,16 +168,18 @@
       (some-> msg :rf/reply :kind some?)
       {:db (assoc db :status :idle)}
 
-      ;; Route through the per-app delayed stub so the :loading UI
-      ;; state is observable. The +1 / Fail / Retry-recover paths
-      ;; above still hit the framework's :rf.http/managed; only this
-      ;; "long-running" demo uses the stub.
+      ;; Defer the canned-failure via :dispatch-later so the :loading UI
+      ;; state is observable before it lands. The +1 / Fail / Retry-recover
+      ;; paths above still hit the framework's :rf.http/managed; only this
+      ;; "long-running" demo defers a synthetic reply.
       :else
       {:db (assoc db :status :loading :error nil)
-       :fx [[:managed-http-counter.demo/long-stub
-             {:request    {:method :get :url "api/long"}
-              :request-id :counter/long
-              :decode     :json}]]})))
+       :fx [[:dispatch-later
+             {:ms    750
+              :event [:managed-http-counter.demo/deliver-long-reply
+                      {:request    {:method :get :url "api/long"}
+                       :request-id :counter/long
+                       :decode     :json}]}]]})))
 
 (rf/reg-event-fx :counter/cancel
   (fn [{:keys [db]} _]

--- a/examples/reagent/realworld/core.cljs
+++ b/examples/reagent/realworld/core.cljs
@@ -54,7 +54,6 @@
             ;; `:rf/hydrate`. Without the require those calls raise
             ;; :rf.error/ssr-artefact-missing.
             [re-frame.ssr]
-            [re-frame.registrar :as registrar]
             [re-frame.adapter.reagent-slim :as reagent-slim-adapter]
             [realworld.schema]
             [realworld.http]
@@ -309,36 +308,47 @@
 
       :else {})))
 
-(rf/reg-fx :conduit.demo/http-stub
-  {:doc       "Demo override for :rf.http/managed: routes by URL to canned
-               Conduit-shaped responses so the example runs standalone
-               without a backend. Delegates to :rf.http/managed-canned-success
-               with a synthesised :value per Spec 014 §Testing.
+(rf/reg-event-fx :conduit.demo/schedule-reply
+  {:doc "Private — entered via dispatch from :conduit.demo/http-stub.
+         Uses `:dispatch-later` so framework time controls (Tool-Pair
+         time-travel, the documented `:dispatch-later` nil-override
+         seam) apply to the demo latency. No user dispatches this
+         directly."}
+  (fn handler-conduit-demo-schedule-reply [_ [_ args-map payload]]
+    {:fx [[:dispatch-later
+           {:ms    20
+            :event [:conduit.demo/deliver-reply args-map payload]}]]}))
 
-               NOTE on the raw js/setTimeout below. The deferred work
-               is an fx invocation (`:rf.http/managed-canned-success`),
-               not a dispatch, so the framework's `:dispatch-later`
-               path is not a 1:1 swap. The timer is here ONLY to delay
-               the canned reply long enough for the `:loading` UI state
-               to be observable in the demo; production app code should
-               never use raw `js/setTimeout` — use `:dispatch-later` or
-               (for an fx invocation) drive it through a tiny
-               framework dispatch (e.g. dispatch-later to a private
-               event whose handler issues the fx) so framework time
-               controls (Tool-Pair time-travel, the documented
-               `:dispatch-later` nil-override seam) still apply."
+(rf/reg-event-fx :conduit.demo/deliver-reply
+  {:doc "Private — fired by the :dispatch-later scheduled in
+         :conduit.demo/schedule-reply. Delegates to the
+         framework-shipped `:rf.http/managed-canned-success` with the
+         per-URL canned Conduit payload."}
+  (fn handler-conduit-demo-deliver-reply [_ [_ args-map payload]]
+    {:fx [[:rf.http/managed-canned-success (assoc args-map :value payload)]]}))
+
+(rf/reg-fx :conduit.demo/http-stub
+  {:doc       "Demo override for :rf.http/managed: routes by URL to
+               canned Conduit-shaped responses so the example runs
+               standalone without a backend.
+
+               Dispatches into the private :conduit.demo/schedule-reply
+               event so the deferred reply rides framework
+               `:dispatch-later` (20 ms) rather than raw
+               `js/setTimeout`. The delay lets the `:loading` UI state
+               be observable in the demo; the reply itself lands via
+               the framework-shipped `:rf.http/managed-canned-success`
+               (Spec 014 §Testing).
+
+               Framework time controls (Tool-Pair time-travel, the
+               documented `:dispatch-later` nil-override seam) apply
+               automatically."
    :platforms #{:server :client}}
   (fn fx-managed-demo-stub [frame-ctx args-map]
     (let [payload (demo-payload-for-args args-map)
-          stub-fn (registrar/handler :fx :rf.http/managed-canned-success)]
-      ;; Drive the framework-shipped canned-success stub to get the
-      ;; correct reply shape (default reply addressing or explicit
-      ;; :on-success — Spec 014 §Reply addressing).
-      (when stub-fn
-        ;; Demo-only artificial latency — see the fx doc above.
-        (js/setTimeout
-          (fn [] (stub-fn frame-ctx (assoc args-map :value payload)))
-          20)))))
+          frame   (:frame frame-ctx)]
+      (rf/dispatch [:conduit.demo/schedule-reply args-map payload]
+                   {:frame frame}))))
 
 ;; React root named `react-root` (not `root`) so it does NOT collide with
 ;; the `root-view` reg-view above. Held in an atom and populated lazily

--- a/examples/reagent/routing/core.cljs
+++ b/examples/reagent/routing/core.cljs
@@ -50,14 +50,15 @@
 
 (rf/reg-event-db :routing.app/initialise
   (fn [_ _]
-    {:articles [{:id "intro" :title "Intro to re-frame2" :body "..."}
-                {:id "ssr"   :title "Server rendering"  :body "..."}]}))
+    {:routing.app/articles
+     [{:id "intro" :title "Intro to re-frame2" :body "..."}
+      {:id "ssr"   :title "Server rendering"  :body "..."}]}))
 
-(rf/reg-sub :articles
-  (fn [db _] (:articles db)))
+(rf/reg-sub :routing.app/articles
+  (fn [db _] (:routing.app/articles db)))
 
-(rf/reg-sub :article-by-id
-  :<- [:articles]
+(rf/reg-sub :routing.app/article-by-id
+  :<- [:routing.app/articles]
   (fn [articles [_ id]]
     (first (filter #(= id (:id %)) articles))))
 
@@ -85,7 +86,7 @@
   [:div
    [:h1 "Articles"]
    [:ul
-    (for [{:keys [id title]} @(subscribe [:articles])]
+    (for [{:keys [id title]} @(subscribe [:routing.app/articles])]
       ^{:key id}
       [:li [rf/route-link {:to :routing.app/article-detail
                            :params {:id id}
@@ -94,7 +95,7 @@
 
 (reg-view article-detail-page []
   (let [id      (:id @(subscribe [:rf.route/params]))
-        article @(subscribe [:article-by-id id])]
+        article @(subscribe [:routing.app/article-by-id id])]
     (if article
       [:div
        [:h1 (:title article)]

--- a/examples/uix/login_uix/core.cljs
+++ b/examples/uix/login_uix/core.cljs
@@ -18,7 +18,6 @@
   (:require [uix.core :as uix :refer [$ defui]]
             [uix.dom  :as uix-dom]
             [re-frame.core :as rf]
-            [re-frame.registrar :as registrar]
             [re-frame.schemas]
             [re-frame.machines]
             [re-frame.http-managed]
@@ -58,38 +57,57 @@
     (when-let [ls (.-localStorage js/globalThis)]
       (.setItem ls "auth/token" token))))
 
+(rf/reg-event-fx :auth.login.demo/schedule-reply
+  {:doc "Private — entered via dispatch from :auth.login.demo/managed-stub.
+         Uses `:dispatch-later` so framework time controls apply to the
+         demo latency. See examples/reagent/login for the full rationale."}
+  (fn handler-auth-login-demo-schedule-reply [_ [_ outcome args-map]]
+    {:fx [[:dispatch-later
+           {:ms    50
+            :event [:auth.login.demo/deliver-reply outcome args-map]}]]}))
+
+(rf/reg-event-fx :auth.login.demo/deliver-reply
+  {:doc "Private — fired by the :dispatch-later scheduled in
+         :auth.login.demo/schedule-reply. Delegates to the framework-
+         shipped canned-success / canned-failure fxs (Spec 014 §Testing)."}
+  (fn handler-auth-login-demo-deliver-reply [_ [_ outcome args-map]]
+    (case outcome
+      :success
+      {:fx [[:rf.http/managed-canned-success
+             (assoc args-map
+                    :value {:user  {:id    (random-uuid)
+                                    :email (-> args-map :request :body :email)}
+                            :token "demo-token-123"})]]}
+
+      :failure-401
+      {:fx [[:rf.http/managed-canned-failure
+             (assoc args-map
+                    :kind :rf.http/http-4xx
+                    :tags {:status  401
+                           :message "Invalid credentials."})]]}
+
+      :empty-success
+      {:fx [[:rf.http/managed-canned-success (assoc args-map :value {})]]})))
+
 (rf/reg-fx :auth.login.demo/managed-stub
   {:doc       "Demo override for `:rf.http/managed`. Identical behaviour
-               to the Reagent example's stub. The raw `js/setTimeout`
-               below is demo-only latency so the `:submitting` UI state
-               is observable — see examples/reagent/login for the full
-               rationale on why production code uses `:dispatch-later`."
+               to the Reagent example's stub — dispatches into the
+               private :auth.login.demo/schedule-reply event so the
+               deferred reply rides framework `:dispatch-later` (50 ms)
+               rather than raw `js/setTimeout`. Framework time controls
+               (Tool-Pair time-travel, `:dispatch-later` nil-override)
+               apply automatically."
    :platforms #{:server :client}}
   (fn fx-managed-login-demo [frame-ctx args-map]
     (let [{:keys [url body]} (:request args-map)
-          login?    (= "/api/login" url)
-          success?  (and login? (= good-password (:password body)))
-          ok-stub   (registrar/handler :fx :rf.http/managed-canned-success)
-          fail-stub (registrar/handler :fx :rf.http/managed-canned-failure)]
-      ;; Demo-only artificial latency — see the fx doc above.
-      (js/setTimeout
-        (fn []
-          (cond
-            success?
-            (ok-stub frame-ctx (assoc args-map
-                                      :value {:user  {:id    (random-uuid)
-                                                      :email (:email body)}
-                                              :token "demo-token-123"}))
-
-            login?
-            (fail-stub frame-ctx (assoc args-map
-                                        :kind :rf.http/http-4xx
-                                        :tags {:status 401
-                                               :message "Invalid credentials."}))
-
-            :else
-            (ok-stub frame-ctx (assoc args-map :value {}))))
-        50))))
+          login?  (= "/api/login" url)
+          outcome (cond
+                    (and login? (= good-password (:password body))) :success
+                    login?                                          :failure-401
+                    :else                                           :empty-success)
+          frame   (:frame frame-ctx)]
+      (rf/dispatch [:auth.login.demo/schedule-reply outcome args-map]
+                   {:frame frame}))))
 
 ;; ============================================================================
 ;; STATE MACHINE


### PR DESCRIPTION
Shape-2 cluster of three rf2-9g3we elegance-audit follow-ups, sequenced smallest -> biggest as separate commits.

## Per-bead summary

### rf2-z6ivh (P2) - replace `js/setTimeout` with `:dispatch-later`

Six demo HTTP stubs were using raw `js/setTimeout` for artificial latency, with docstrings disclaiming "production code should never use raw `js/setTimeout`". That is a "do as I say, not as I do" teaching antipattern in the canonical examples.

Reshape: the fx (kept as `:fx-overrides` target) dispatches into a private `:<feature>.demo/schedule-reply` event that returns `{:fx [[:dispatch-later {:ms N :event [:deliver-reply ...]}]]}`. The deliver event then fires the framework-shipped `:rf.http/managed-canned-success` / `-canned-failure` with the canned reply value. Framework time controls (Tool-Pair time-travel, the documented `:dispatch-later` nil-override seam) now apply automatically.

For the managed_http_counter long-stub case the stub fx was invoked directly (not via `:fx-overrides`), so the fx is eliminated entirely in favour of a single `:dispatch-later` inside `:counter/start-long`.

Stubs affected:

- `examples/reagent/managed_http_counter/core.cljs` - long-stub (~750ms)
- `examples/reagent/login/core.cljs` - `:auth.login.demo/managed-stub` (50ms)
- `examples/uix/login_uix/core.cljs` - same (50ms)
- `examples/helix/login_helix/core.cljs` - same (50ms)
- `examples/reagent/boot/core.cljs` - `:boot.demo/http-stub` (60ms)
- `examples/reagent/realworld/core.cljs` - `:conduit.demo/http-stub` (20ms)

The websocket mock-server's `js/setTimeout f 0` in `examples/reagent/websocket/messages.cljs` is the only remaining `js/setTimeout` under `examples/` - it is the load-bearing next-tick helper, NOT demo-stub latency. Per the bead acceptance criteria, that one stays.

### rf2-kzzj0 (P3) - feature-prefix routing example sub-ids

| before                   | after                          |
|--------------------------|--------------------------------|
| app-db `:articles`       | `:routing.app/articles`        |
| reg-sub `:articles`      | `:routing.app/articles`        |
| reg-sub `:article-by-id` | `:routing.app/article-by-id`   |

Updates the seed in `:routing.app/initialise` and the two view call-sites (`articles-page`, `article-detail-page`).

### rf2-nmvh3 (P3) - feature-prefix managed_http_counter sub-ids + app-db keys

| before            | after             |
|-------------------|-------------------|
| app-db `:count`   | `:counter/count`  |
| app-db `:status`  | `:counter/status` |
| app-db `:error`   | `:counter/error`  |
| reg-sub `:count`  | `:counter/count`  |
| reg-sub `:status` | `:counter/status` |
| reg-sub `:error`  | `:counter/error`  |

Used `:counter/*` to match the events' existing prefix. The counter trio (`counter` / `counter-uix` / `counter-helix` / `counter_slim_and_fast`) standardised on `:counter/value` in rf2-cwlnl; this example uses `:counter/count` so the names don't accidentally suggest cross-example sharing.

## Build-on confirmation

- E1 (#2239 - rf2-fgkte + rf2-1m0jz + rf2-pwtfx) - `:rf.http/managed.*` -> demo-prefixed fx ids; `:route/*` -> `:conduit.*/*` + `:routing.app/*` + `:boot.demo/*`. Confirmed on main.
- E2 (#2238 - rf2-cwlnl + rf2-1875u + rf2-88mf8) - counter trio standardised on `:counter/value`. Confirmed on main.

## Quality gates

- `bash scripts/test-fast-pr.sh` -> PASS (4752 tests, 15466 assertions, 0 failures)
- `npm run test:cljs` -> PASS (same totals)
- `npm run test:examples` -> environmental fail only: `listen EACCES: permission denied 0.0.0.0:8030` (Windows local port-permission issue, not caused by these changes). All three adapter-testbed shadow-cljs builds compiled cleanly (0 warnings). CI will run this gate in a Linux environment.
- `git grep ':articles' examples/reagent/routing/` -> 0 hits
- `git grep ':counter/count' examples/reagent/managed_http_counter/` -> 6 hits (all the renamed slots/subs/call-sites)
- `git grep 'js/setTimeout' examples/` -> 6 hits: 5 docstring mentions + 1 load-bearing websocket helper (intentional).

## Commits

1. `refactor(examples): replace js/setTimeout demo-stub latency with :dispatch-later (rf2-z6ivh)`
2. `refactor(examples/routing): feature-prefix sub-ids - :articles -> :routing.app/articles (rf2-kzzj0)`
3. `refactor(examples/managed_http_counter): feature-prefix sub-ids + app-db keys (rf2-nmvh3)`
