### PR TITLE
refactor(xray): for to mapv + factor on-click + hoist diff-body styles (rf2-9ec65 + rf2-ihjnx + rf2-mndut)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff.cljs
@@ -50,6 +50,37 @@
              :refer [tokens sans-stack]]
             [day8.re-frame2-xray.views.diff-mode-toggle :as diff-mode]))
 
+;; ---- style hoists (rf2-mndut) -------------------------------------------
+;;
+;; Every literal `:style {...}` map in the Panel view below is hoisted to
+;; ns-top defs so React's reconciler sees stable object identities across
+;; re-renders (follow-on to rf2-qx414 / rf2-zlk6h / rf2-xjgdk / rf2-gjiog
+;; / rf2-alsnz). `tokens` values resolve to `var(--rf-xray-*)` CSS strings
+;; at ns load so the light/dark theme toggle continues to flip palette in
+;; lockstep without re-evaluation (spec/007 §UX-IA).
+
+(def ^:private panel-root-style
+  "Outer `[:section]` chrome for the app-db Panel view."
+  {:height         "100%"
+   :display        "flex"
+   :flex-direction "column"
+   :background     (:bg-2 tokens)
+   :color          (:text-primary tokens)
+   :font-family    sans-stack
+   :font-size      "14px"})
+
+(def ^:private panel-top-bar-style
+  "Top-bar wrapper around the universal three-mode toggle (rf2-yqjrd)."
+  {:padding     "12px 12px 0"
+   :display     "flex"
+   :align-items "center"
+   :gap         "8px"})
+
+(def ^:private panel-body-host-style
+  "Scrolling host for the section list / flat-diff body."
+  {:flex     1
+   :overflow "auto"})
+
 (rf/reg-view Panel
   "The app-db tab's root view — a current-state inspector sectioned by
   reserved `:rf/*` area.
@@ -78,13 +109,7 @@
                ;; every diff-mode-toggle consumer's enclosing section
                ;; (was the per-surface drifted `data-view-mode`).
                :data-rf-xray-diff-mode (name mode)
-               :style       {:height         "100%"
-                             :display        "flex"
-                             :flex-direction "column"
-                             :background     (:bg-2 tokens)
-                             :color          (:text-primary tokens)
-                             :font-family    sans-stack
-                             :font-size      "14px"}}
+               :style       panel-root-style}
      ;; rf2-yqjrd — universal three-mode toggle. Sits at the top of the
      ;; panel above the section list; one mode applies to every
      ;; section's body. Frame-anchored to `:rf/xray` per the same
@@ -93,10 +118,7 @@
      ;;
      ;; rf2-fytu4 — discoverability label `View` is owned by the shared
      ;; widget via the `:label` opt (was a hand-rolled span here).
-     [:div {:style {:padding "12px 12px 0"
-                    :display "flex"
-                    :align-items "center"
-                    :gap "8px"}}
+     [:div {:style panel-top-bar-style}
       [diff-mode/diff-mode-toggle
        {:mode mode
         ;; rf2-7vv8f — testid prefix normalised across all four
@@ -108,7 +130,7 @@
                        (rf/dispatch [:rf.xray.app-db/set-diff-mode m])))}]]
      ;; rf2-6xezz — the L4 tab strip is the panel-name source-of-truth;
      ;; content starts immediately under the tab bar.
-     [:div {:style {:flex 1 :overflow "auto"}}
+     [:div {:style panel-body-host-style}
       (state/state-body section-model {:mode mode :diff-triples diff-triples})]]))
 
 (defn install!

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs
@@ -80,6 +80,150 @@
             ;; (rf2-q3dzw phase 5, D5=a per rf2-sndui).
             [day8.re-frame2-xray.views.edn-inspector :as ei]))
 
+;; ---- style hoists (rf2-mndut) -------------------------------------------
+;;
+;; Every literal `:style {...}` map in the section / flat-diff renderers
+;; below is hoisted to ns-top defs so React's reconciler sees stable
+;; object identities across re-renders (follow-on to rf2-qx414 /
+;; rf2-zlk6h / rf2-xjgdk / rf2-gjiog / rf2-alsnz). The flat-diff body
+;; in particular renders N rows × 4-5 inline `:style {...}` maps per
+;; row inside a render loop; a 20-row diff was minting 80-100 fresh
+;; map allocations per render before this hoist. `tokens` values
+;; resolve to `var(--rf-xray-*)` CSS strings at ns load so the light/
+;; dark theme toggle continues to flip palette in lockstep without
+;; re-evaluation (spec/007 §UX-IA).
+;;
+;; Per-call variation rides:
+;;   - small `assoc` / `cond->` overlays on a shared base map
+;;     (glyph-colour swaps), and
+;;   - hoisted named variants where the variation is whole-map (added /
+;;     removed / modified glyph rows).
+
+;; -- section chrome --------------------------------------------------------
+
+(def ^:private section-shell-style
+  "Outer `[:section]` wrapper inside section-shell."
+  {:padding "12px 12px 4px"})
+
+(def ^:private section-shell-h3-style
+  "H3 ribbon when section-shell renders its own header (rare;
+  hide-header? is the common case post-rf2-okq7p)."
+  {:display         "flex"
+   :align-items     "center"
+   :gap             "8px"
+   :margin          "0 0 8px"
+   :font-family     sans-stack
+   :font-size       "11px"
+   :font-weight     600
+   :text-transform  "uppercase"
+   :letter-spacing  "0.5px"
+   :color           (:text-secondary tokens)})
+
+(def ^:private section-shell-h3-title-style
+  "Title span inside section-shell-h3 — ellipsises on overflow."
+  {:overflow      "hidden"
+   :text-overflow "ellipsis"
+   :white-space   "nowrap"
+   :flex          1})
+
+(def ^:private empty-body-style
+  "Empty-state placeholder body style (italic muted prose)."
+  {:font-family sans-stack
+   :font-size   "12px"
+   :font-style  "italic"
+   :color       (:text-tertiary tokens)})
+
+(def ^:private area-label-style
+  "Reserved-area `:rf/*` keyword title in mode `accent` colour."
+  {:font-family mono-stack
+   :color       (:accent tokens)})
+
+(def ^:private instance-section-separator-style
+  "The `›` separator between area-label and instance-id in
+  instance-section's title."
+  {:margin "0 6px"
+   :color  (:text-tertiary tokens)})
+
+(def ^:private instance-section-id-style
+  "Instance-id text inside instance-section's title."
+  {:font-family mono-stack
+   :color       (:text-primary tokens)})
+
+;; -- flat-diff (`:diff` mode) chrome --------------------------------------
+
+(def ^:private flat-diff-row-style
+  "One change-list row inside flat-diff-body."
+  {:display     "flex"
+   :gap         "8px"
+   :align-items "baseline"
+   :font-family mono-stack
+   :font-size   "12px"
+   :padding     "2px 12px"
+   :flex-wrap   "wrap"})
+
+(def ^:private flat-diff-glyph-base-style
+  "Per-row glyph span — only `:color` varies, applied via assoc."
+  {:font-weight 700
+   :min-width   "1ch"})
+
+(def ^:private flat-diff-path-style
+  "Path-prefix span — the `[:foo :bar]` text inside one diff row."
+  {:color      (:text-secondary tokens)
+   :word-break "break-word"})
+
+(def ^:private flat-diff-modified-before-style
+  "The `~`-modified row's BEFORE-value mini inspector — strikethrough
+  tertiary text."
+  {:color           (:text-tertiary tokens)
+   :text-decoration "line-through"})
+
+(def ^:private flat-diff-modified-arrow-style
+  "The `→` separator between BEFORE and AFTER on `~`-modified rows."
+  {:color (:text-tertiary tokens)})
+
+(def ^:private flat-diff-modified-after-style
+  "The `~`-modified row's AFTER-value mini inspector."
+  {:color (:success tokens)})
+
+(def ^:private flat-diff-added-style
+  "The `+`-added row's value mini inspector — success-coloured, flex 1."
+  {:color     (:success tokens)
+   :flex      1
+   :min-width 0})
+
+(def ^:private flat-diff-removed-style
+  "The `−`-removed row's value mini inspector — strikethrough error."
+  {:color           (:error tokens)
+   :text-decoration "line-through"
+   :flex            1
+   :min-width       0})
+
+(def ^:private flat-diff-section-style
+  "Outer `[:section]` chrome for the flat-diff body."
+  {:padding "12px 0 4px"})
+
+(def ^:private flat-diff-header-style
+  "H3 ribbon at the top of the flat-diff body."
+  {:display         "flex"
+   :align-items     "center"
+   :gap             "8px"
+   :margin          "0 12px 8px"
+   :font-family     sans-stack
+   :font-size       "11px"
+   :font-weight     600
+   :text-transform  "uppercase"
+   :letter-spacing  "0.5px"
+   :color           (:text-secondary tokens)})
+
+(def ^:private flat-diff-summary-style
+  "Right-side `N paths` / `— (no changes)` summary inside flat-diff
+  header. Lighter weight + normal-case + normal letter-spacing so it
+  reads as supporting metadata next to the uppercase `diff` title."
+  {:color           (:text-tertiary tokens)
+   :font-weight     400
+   :text-transform  "none"
+   :letter-spacing  "normal"})
+
 ;; ---- shared section chrome ----------------------------------------------
 
 (defn- section-shell
@@ -96,22 +240,10 @@
   card borders for the eye's attention."
   [{:keys [testid title body hide-header?]}]
   [:section {:data-testid testid
-             :style       {:padding "12px 12px 4px"}}
+             :style       section-shell-style}
    (when-not hide-header?
-     [:h3 {:style {:display         "flex"
-                   :align-items     "center"
-                   :gap             "8px"
-                   :margin          "0 0 8px"
-                   :font-family     sans-stack
-                   :font-size       "11px"
-                   :font-weight     600
-                   :text-transform  "uppercase"
-                   :letter-spacing  "0.5px"
-                   :color           (:text-secondary tokens)}}
-      [:span {:style {:overflow      "hidden"
-                      :text-overflow "ellipsis"
-                      :white-space   "nowrap"
-                      :flex          1}}
+     [:h3 {:style section-shell-h3-style}
+      [:span {:style section-shell-h3-title-style}
        title]])
    [:div body]])
 
@@ -119,10 +251,7 @@
   "Empty-state placeholder body for an absent / empty section. `label`
   is a short prose hint (e.g. \"no machines\")."
   [label]
-  [:div {:style {:font-family sans-stack
-                 :font-size   "12px"
-                 :font-style  "italic"
-                 :color       (:text-tertiary tokens)}}
+  [:div {:style empty-body-style}
    label])
 
 (defn- value-body
@@ -231,8 +360,7 @@
   "Render a reserved-area section title — the bare `:rf/*` key in the
   mode `accent` keyword colour."
   [area]
-  [:span {:style {:font-family mono-stack
-                  :color       (:accent tokens)}}
+  [:span {:style area-label-style}
    (pr-str area)])
 
 (defn instance-section
@@ -245,10 +373,9 @@
   [area {:keys [id value] :as inst}]
   (let [title [:span
                (area-label area)
-               [:span {:style {:margin "0 6px" :color (:text-tertiary tokens)}}
+               [:span {:style instance-section-separator-style}
                 "›"]
-               [:span {:style {:font-family mono-stack
-                               :color       (:text-primary tokens)}}
+               [:span {:style instance-section-id-style}
                 (pr-str id)]]]
     (section-shell
       {:testid       (str "rf-xray-app-db-state-instance-"
@@ -344,33 +471,23 @@
         glyph-colour (flat-diff-glyph-colour glyph)]
     [:div {:key (str "app-db-diff-row-" idx)
            :data-testid (str "rf-xray-app-db-diff-row-" idx)
-           :style {:display "flex"
-                   :gap "8px"
-                   :align-items "baseline"
-                   :font-family mono-stack
-                   :font-size "12px"
-                   :padding "2px 12px"
-                   :flex-wrap "wrap"}}
-     [:span {:style {:color glyph-colour :font-weight 700 :min-width "1ch"}}
+           :style flat-diff-row-style}
+     [:span {:style (assoc flat-diff-glyph-base-style :color glyph-colour)}
       glyph]
-     [:span {:style {:color (:text-secondary tokens)
-                     :word-break "break-word"}}
+     [:span {:style flat-diff-path-style}
       (pr-str path)]
      (when (= "~" glyph)
        [:<>
-        [:span {:style {:color (:text-tertiary tokens)
-                        :text-decoration "line-through"}}
+        [:span {:style flat-diff-modified-before-style}
          [ei/mini before 40]]
-        [:span {:style {:color (:text-tertiary tokens)}} "→"]
-        [:span {:style {:color (:success tokens)}}
+        [:span {:style flat-diff-modified-arrow-style} "→"]
+        [:span {:style flat-diff-modified-after-style}
          [ei/mini after 40]]])
      (when (= "+" glyph)
-       [:span {:style {:color (:success tokens) :flex 1 :min-width 0}}
+       [:span {:style flat-diff-added-style}
         [ei/mini after 80]])
      (when (= "−" glyph)
-       [:span {:style {:color (:error tokens)
-                       :text-decoration "line-through"
-                       :flex 1 :min-width 0}}
+       [:span {:style flat-diff-removed-style}
         [ei/mini before 80]])]))
 
 (defn- flat-diff-body
@@ -381,30 +498,18 @@
   (let [empty? (empty? diff-triples)]
     [:section {:data-testid "rf-xray-app-db-diff-flat"
                :data-empty (str empty?)
-               :style {:padding "12px 0 4px"}}
-     [:h3 {:style {:display "flex"
-                   :align-items "center"
-                   :gap "8px"
-                   :margin "0 12px 8px"
-                   :font-family sans-stack
-                   :font-size "11px"
-                   :font-weight 600
-                   :text-transform "uppercase"
-                   :letter-spacing "0.5px"
-                   :color (:text-secondary tokens)}}
+               :style flat-diff-section-style}
+     [:h3 {:style flat-diff-header-style}
       [:span "diff"]
-      [:span {:style {:color (:text-tertiary tokens)
-                      :font-weight 400
-                      :text-transform "none"
-                      :letter-spacing "normal"}}
+      [:span {:style flat-diff-summary-style}
        (if empty?
          "— (no changes)"
          (str (count diff-triples) " path"
               (when (not= 1 (count diff-triples)) "s")))]]
      (when-not empty?
        (into [:div]
-             (for [[i row] (map-indexed vector diff-triples)]
-               (flat-diff-line row i))))]))
+             (map-indexed (fn [i row] (flat-diff-line row i))
+                          diff-triples)))]))
 
 ;; ---- panel body ----------------------------------------------------------
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -2298,8 +2298,13 @@
      (case mode
        :diff
        (when-not empty?
-         (for [[i row] (map-indexed vector db-diff)]
-           (db-diff-line row i)))
+         ;; rf2-9ec65 — eager realisation via `mapv` so any future
+         ;; subscribe deref inside `db-diff-line` registers in this
+         ;; render's reactive scope (spec/006 §Lazy-seq deref tracking,
+         ;; rf2-atqkg). Was `(for [[i row] (map-indexed vector …)] …)`
+         ;; which returns a LazySeq.
+         (into [:<>]
+               (map-indexed (fn [i row] (db-diff-line row i)) db-diff)))
 
        :full
        (let [record  @(rf/subscribe [:rf.xray/selected-epoch-record])

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
@@ -497,47 +497,54 @@
                       :font-style "italic"
                       :color (:text-tertiary tokens)}}
         "— (no changes)"]
+       ;; rf2-9ec65 — eager realisation via `map-indexed` so any future
+       ;; subscribe deref inside the row body registers in this render's
+       ;; reactive scope (spec/006 §Lazy-seq deref tracking, rf2-atqkg).
+       ;; `into` already realises the seq, but the named-fn shape aligns
+       ;; with the canonical eager idiom used in `diff/hiccup_render.cljs`.
        (into [:div {:style {:font-family mono-stack
                             :font-size "12px"}}]
-             (for [[i [path before-v after-v kind]] (map-indexed vector rows)]
-               (let [glyph        (case kind
-                                    :added    "+"
-                                    :removed  "−"
-                                    :modified "~"
-                                    "~")
-                     glyph-colour (case glyph
-                                    "+" (:success tokens)
-                                    "−" (:error tokens)
-                                    (:warning tokens))]
-                 [:div {:key (str "row-" i)
-                        :data-testid (str "rf-xray-machine-snapshot-diff-row-"
-                                          (machine-id-suffix machine-id) "-" i)
-                        :style {:display "flex"
-                                :gap "8px"
-                                :align-items "baseline"
-                                :padding "2px 0"
-                                :flex-wrap "wrap"}}
-                  [:span {:style {:color glyph-colour :font-weight 700 :min-width "1ch"}}
-                   glyph]
-                  [:span {:style {:color (:text-secondary tokens)
-                                  :word-break "break-word"}}
-                   (pr-str path)]
-                  (when (= "~" glyph)
-                    [:<>
-                     [:span {:style {:color (:text-tertiary tokens)
-                                     :text-decoration "line-through"}}
-                      [ei/mini before-v 40]]
-                     [:span {:style {:color (:text-tertiary tokens)}} "→"]
-                     [:span {:style {:color (:success tokens)}}
-                      [ei/mini after-v 40]]])
-                  (when (= "+" glyph)
-                    [:span {:style {:color (:success tokens) :flex 1 :min-width 0}}
-                     [ei/mini after-v 80]])
-                  (when (= "−" glyph)
-                    [:span {:style {:color (:error tokens)
-                                    :text-decoration "line-through"
-                                    :flex 1 :min-width 0}}
-                     [ei/mini before-v 80]])]))))]))
+             (map-indexed
+               (fn [i [path before-v after-v kind]]
+                 (let [glyph        (case kind
+                                      :added    "+"
+                                      :removed  "−"
+                                      :modified "~"
+                                      "~")
+                       glyph-colour (case glyph
+                                      "+" (:success tokens)
+                                      "−" (:error tokens)
+                                      (:warning tokens))]
+                   [:div {:key (str "row-" i)
+                          :data-testid (str "rf-xray-machine-snapshot-diff-row-"
+                                            (machine-id-suffix machine-id) "-" i)
+                          :style {:display "flex"
+                                  :gap "8px"
+                                  :align-items "baseline"
+                                  :padding "2px 0"
+                                  :flex-wrap "wrap"}}
+                    [:span {:style {:color glyph-colour :font-weight 700 :min-width "1ch"}}
+                     glyph]
+                    [:span {:style {:color (:text-secondary tokens)
+                                    :word-break "break-word"}}
+                     (pr-str path)]
+                    (when (= "~" glyph)
+                      [:<>
+                       [:span {:style {:color (:text-tertiary tokens)
+                                       :text-decoration "line-through"}}
+                        [ei/mini before-v 40]]
+                       [:span {:style {:color (:text-tertiary tokens)}} "→"]
+                       [:span {:style {:color (:success tokens)}}
+                        [ei/mini after-v 40]]])
+                    (when (= "+" glyph)
+                      [:span {:style {:color (:success tokens) :flex 1 :min-width 0}}
+                       [ei/mini after-v 80]])
+                    (when (= "−" glyph)
+                      [:span {:style {:color (:error tokens)
+                                      :text-decoration "line-through"
+                                      :flex 1 :min-width 0}}
+                       [ei/mini before-v 80]])]))
+               rows)))]))
 
 (defn- snapshot-block
   "Render a machine snapshot map (`{:state X :data Y}`) via the

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
@@ -186,6 +186,83 @@
    :border-top-left-radius  "4px"
    :border-top-right-radius "4px"})
 
+;; ---- snapshot-flat-diff styles (rf2-mndut) ------------------------------
+;;
+;; The snapshot drill-in's `:diff` body (rf2-yqjrd) renders N rows × 4-5
+;; inline `:style {...}` maps per row inside a render loop. A 20-row diff
+;; minted 80-100 fresh map allocations per render before this hoist;
+;; combined with the per-render `engine/project` call upstream the whole
+;; sub-section thrashed. Hoist to ns-top defs so React's reconciler sees
+;; stable object identities across re-renders, with per-row glyph-colour
+;; variation riding a single `assoc` overlay on a base map (same pattern
+;; as `app-db-diff-state` flat-diff + `diff/hiccup_render`).
+;;
+;; `tokens` values resolve to `var(--rf-xray-*)` CSS strings at ns load
+;; so the light/dark theme toggle continues to flip palette in lockstep
+;; without re-evaluation (spec/007 §UX-IA).
+
+(def ^:private snapshot-flat-diff-root-style
+  "Outer `[:div]` wrapper for the snapshot-flat-diff body."
+  {:padding    "8px 12px"
+   :background (:bg-2 tokens)
+   :min-width  0})
+
+(def ^:private snapshot-flat-diff-empty-style
+  "Italic muted `(no changes)` placeholder body."
+  {:font-family sans-stack
+   :font-size   "11px"
+   :font-style  "italic"
+   :color       (:text-tertiary tokens)})
+
+(def ^:private snapshot-flat-diff-list-style
+  "Inner `[:div]` host for the flat-diff row list — mono base."
+  {:font-family mono-stack
+   :font-size   "12px"})
+
+(def ^:private snapshot-flat-diff-row-style
+  "One change-list row inside snapshot-flat-diff-body."
+  {:display     "flex"
+   :gap         "8px"
+   :align-items "baseline"
+   :padding     "2px 0"
+   :flex-wrap   "wrap"})
+
+(def ^:private snapshot-flat-diff-glyph-base-style
+  "Per-row glyph span — only `:color` varies, applied via assoc."
+  {:font-weight 700
+   :min-width   "1ch"})
+
+(def ^:private snapshot-flat-diff-path-style
+  "Path-prefix span — the `[:foo :bar]` text inside one diff row."
+  {:color      (:text-secondary tokens)
+   :word-break "break-word"})
+
+(def ^:private snapshot-flat-diff-modified-before-style
+  "The `~`-modified row's BEFORE-value mini inspector — strikethrough."
+  {:color           (:text-tertiary tokens)
+   :text-decoration "line-through"})
+
+(def ^:private snapshot-flat-diff-modified-arrow-style
+  "The `→` separator between BEFORE and AFTER on `~`-modified rows."
+  {:color (:text-tertiary tokens)})
+
+(def ^:private snapshot-flat-diff-modified-after-style
+  "The `~`-modified row's AFTER-value mini inspector."
+  {:color (:success tokens)})
+
+(def ^:private snapshot-flat-diff-added-style
+  "The `+`-added row's value mini inspector — success-coloured, flex 1."
+  {:color     (:success tokens)
+   :flex      1
+   :min-width 0})
+
+(def ^:private snapshot-flat-diff-removed-style
+  "The `−`-removed row's value mini inspector — strikethrough error."
+  {:color           (:error tokens)
+   :text-decoration "line-through"
+   :flex            1
+   :min-width       0})
+
 ;; ---- safe-name helper ---------------------------------------------------
 
 (defn- safe-name
@@ -488,22 +565,16 @@
                              (machine-id-suffix machine-id))
            :data-machine-id (str machine-id)
            :data-empty (str empty?)
-           :style {:padding "8px 12px"
-                   :background (:bg-2 tokens)
-                   :min-width 0}}
+           :style snapshot-flat-diff-root-style}
      (if empty?
-       [:div {:style {:font-family sans-stack
-                      :font-size "11px"
-                      :font-style "italic"
-                      :color (:text-tertiary tokens)}}
+       [:div {:style snapshot-flat-diff-empty-style}
         "— (no changes)"]
        ;; rf2-9ec65 — eager realisation via `map-indexed` so any future
        ;; subscribe deref inside the row body registers in this render's
        ;; reactive scope (spec/006 §Lazy-seq deref tracking, rf2-atqkg).
        ;; `into` already realises the seq, but the named-fn shape aligns
        ;; with the canonical eager idiom used in `diff/hiccup_render.cljs`.
-       (into [:div {:style {:font-family mono-stack
-                            :font-size "12px"}}]
+       (into [:div {:style snapshot-flat-diff-list-style}]
              (map-indexed
                (fn [i [path before-v after-v kind]]
                  (let [glyph        (case kind
@@ -518,33 +589,26 @@
                    [:div {:key (str "row-" i)
                           :data-testid (str "rf-xray-machine-snapshot-diff-row-"
                                             (machine-id-suffix machine-id) "-" i)
-                          :style {:display "flex"
-                                  :gap "8px"
-                                  :align-items "baseline"
-                                  :padding "2px 0"
-                                  :flex-wrap "wrap"}}
-                    [:span {:style {:color glyph-colour :font-weight 700 :min-width "1ch"}}
+                          :style snapshot-flat-diff-row-style}
+                    [:span {:style (assoc snapshot-flat-diff-glyph-base-style
+                                          :color glyph-colour)}
                      glyph]
-                    [:span {:style {:color (:text-secondary tokens)
-                                    :word-break "break-word"}}
+                    [:span {:style snapshot-flat-diff-path-style}
                      (pr-str path)]
                     (when (= "~" glyph)
                       [:<>
-                       [:span {:style {:color (:text-tertiary tokens)
-                                       :text-decoration "line-through"}}
+                       [:span {:style snapshot-flat-diff-modified-before-style}
                         [ei/mini before-v 40]]
-                       [:span {:style {:color (:text-tertiary tokens)}} "→"]
-                       [:span {:style {:color (:success tokens)}}
+                       [:span {:style snapshot-flat-diff-modified-arrow-style} "→"]
+                       [:span {:style snapshot-flat-diff-modified-after-style}
                         [ei/mini after-v 40]]])
                     (when (= "+" glyph)
-                      [:span {:style {:color (:success tokens) :flex 1 :min-width 0}}
+                      [:span {:style snapshot-flat-diff-added-style}
                        [ei/mini after-v 80]])
                     (when (= "−" glyph)
-                      [:span {:style {:color (:error tokens)
-                                      :text-decoration "line-through"
-                                      :flex 1 :min-width 0}}
-                       [ei/mini before-v 80]])]))
-               rows)))]))
+                      [:span {:style snapshot-flat-diff-removed-style}
+                       [ei/mini before-v 80]])])))
+               rows))]))
 
 (defn- snapshot-block
   "Render a machine snapshot map (`{:state X :data Y}`) via the

--- a/tools/xray/src/day8/re_frame2_xray/views/diff_mode_toggle.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/diff_mode_toggle.cljs
@@ -186,6 +186,22 @@
     :full+diff "full-with-diff"
     (name m)))
 
+(defn- make-on-click
+  "Factor the per-button `:on-click` so closure identity is stable per
+  `(on-change, m)` pair across renders (rf2-ihjnx). Inline lambdas in
+  the button hiccup mint three fresh closures per toggle render; React's
+  reconciler then re-writes the `onclick` DOM prop even when nothing
+  changed because function identity differs. With a named-fn factor
+  the closures are still per-render allocations, but the surface is now
+  the canonical place to memoise if a future audit lifts that.
+
+  Pure: takes `on-change` + `m`, returns an event handler that stops
+  propagation then calls `(on-change m)`."
+  [on-change m]
+  (fn [e]
+    (.stopPropagation e)
+    (on-change m)))
+
 ;; =========================================================================
 ;; widget
 ;; =========================================================================
@@ -241,9 +257,10 @@
                ^{:key (name m)}
                [:button {:data-testid (str testid "-" (mode-testid-suffix m))
                          :aria-pressed (str active?)
-                         :on-click (fn [e]
-                                     (.stopPropagation e)
-                                     (on-change m))
+                         ;; rf2-ihjnx — closure construction factored
+                         ;; out of the inline hiccup so the on-click
+                         ;; site is the canonical place to memoise.
+                         :on-click (make-on-click on-change m)
                          :style (if active?
                                   mode-toggle-button-active-style
                                   mode-toggle-button-inactive-style)}


### PR DESCRIPTION
Three-bead Shape-2 cluster from the rf2-gwm0y efficiency audit — style-discipline / idiom cleanups in the three-mode diff toggle surfaces (rf2-yqjrd). Single PR, three sequenced commits (smallest → biggest).

## Per-bead summary

### rf2-9ec65 (P3 / L1) — `for` → `mapv` in two `:diff` render loops

Two diff-mode `:diff` render loops returned a `LazySeq` for hiccup children. Per spec/006 §Lazy-seq deref tracking (rf2-atqkg), any `@(rf/subscribe ...)` inside an unrealised `for` would execute outside the parent reaction's tracking context. Row bodies don't deref ratoms today, but the L1 audit flagged these as load-bearing the moment a future edit threads a subscribe through.

- `panels/epoch/view.cljs` `:diff` branch — `(into [:<>] (map-indexed …))` so the `case`'s branch returns a fragment React unrolls as children.
- `panels/machine_inspector.cljs` `snapshot-flat-diff-body` — refactored the inner `(for [[i [...]] (map-indexed vector rows)] …)` to `(map-indexed (fn [i [...]] …) rows)` inside the existing `(into [:div] …)`. `into` already realises; the named-fn shape aligns with the canonical eager idiom in `diff/hiccup_render.cljs`.

### rf2-ihjnx (P3 / L2) — Factor per-button on-click handlers

`views/diff_mode_toggle.cljs` minted 3 fresh `:on-click` closures per render of the toggle bar × 4 caller surfaces. React's reconciler observes the identity change every re-render and re-writes the DOM `onclick` prop even when nothing changed.

Factored to a private `make-on-click` helper taking `(on-change, m)` and returning the event handler. Closures are still per-render allocations today, but the call site is now the canonical place a future audit can memoise per `(on-change, m)` pair.

### rf2-mndut (P2 / M3) — Hoist inline styles in app-db + machine-inspector `:diff` body

Three surfaces added under rf2-yqjrd universalisation retained inline `:style` shape. Hoisted every literal `:style {...}` map to ns-top defs so React's reconciler sees stable object identities across re-renders. `tokens` resolve to `var(--rf-xray-*)` at ns load — light/dark theme switching keeps riding the CSS-variable seam (spec/007 §UX-IA).

- `panels/app_db_diff.cljs` — Panel root + top-bar + body-host (3 inline maps → 3 hoisted defs).
- `panels/app_db_diff_state.cljs` — section-shell H3 chrome, empty-body placeholder, area-label, instance-section title separator + id, and the whole flat-diff (`:diff` mode) body chrome (section, header, summary, row, glyph base, path, modified-before, modified-arrow, modified-after, added, removed). Plus a `(for …)` → `(map-indexed …)` inside `(into [:div] …)` to align with the eager idiom.
- `panels/machine_inspector.cljs` `snapshot-flat-diff-body` — 12 inline `:style` maps inside the per-row render loop. Hoisted to ns-top, with per-row glyph-colour variation riding a single `(assoc snapshot-flat-diff-glyph-base-style :color glyph-colour)` overlay (matches the existing `diff/hiccup_render.cljs` and `app_db_diff_state.cljs` flat-diff pattern).

## Allocation delta evidence

- A 20-row machine-snapshot diff that previously minted ~80–100 fresh `:style` maps per render now mints 20 (one `assoc` overlay per row); app-db flat-diff + section chrome behave similarly.
- Reagent-style `perf-bundle` gate: `off-count=0` / `on-count=12` unchanged (the perf-API itself is independent of these hoists), bundle size delta within noise (`off=442749 chars` / `on=444397 chars`).

## Quality gates

- `bash scripts/test-fast-pr.sh` — PASS (4752 tests, 15466 assertions; 0 failures, 0 errors).
- `npm run test:cljs` — PASS (4752 tests, 15466 assertions).
- `npm run test:browser` — PASS (124 tests, 353 assertions; 0 failures, 0 errors).
- `npm run test:bundle-isolation` — PASS (17 artefact entries; 35 internal sentinels absent; 3 allow-list budgets ok).
- `npm run test:perf-bundle` — PASS (off-count=0; on-count=12).
- `clj-kondo --lint` on touched files — only pre-existing warnings (no errors).

## File surface

- `tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs`
- `tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs`
- `tools/xray/src/day8/re_frame2_xray/panels/app_db_diff.cljs`
- `tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs`
- `tools/xray/src/day8/re_frame2_xray/views/diff_mode_toggle.cljs`
