### PR TITLE
feat(xray): Epoch DISPATCH step renders rich source enrichment per :source kind (rf2-5qp4g)

### DIFF
--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -240,9 +240,17 @@
    ;; deferred dispatch stamps `:source :fx-dispatch-later` so the Epoch
    ;; panel's DISPATCH step renders the precise trigger rather than the
    ;; originating user event's `:source`.
+   ;;
+   ;; Per rf2-5qp4g: stamp `:source-detail {:ms <ms>}` alongside the
+   ;; `:source` so the Epoch panel's DISPATCH step can render the
+   ;; ORIGINAL scheduled delay (e.g. `from fx :dispatch-later · 500ms`)
+   ;; rather than just the kind label. The detail rides on the
+   ;; envelope, then onto the `:rf.event/dispatched` trace via
+   ;; `emit-dispatched-trace`'s opt-in stamp (router.cljc rf2-5qp4g).
    (fn [frame-id parent-envelope {:keys [ms event]}]
      (let [opts (assoc (child-dispatch-opts frame-id parent-envelope)
-                       :source :fx-dispatch-later)]
+                       :source        :fx-dispatch-later
+                       :source-detail {:ms ms})]
        (interop/set-timeout!
          (fn []
            ;; Sticky hook (rf2-f72pd) — same as above; the timer

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -186,6 +186,16 @@
              ;; their own kind. `:unknown` surfaces "we lost track"
              ;; rather than fabricating an origin.
              :source                 (:source opts :unknown)
+             ;; Per rf2-5qp4g: per-source-kind detail riding alongside
+             ;; the closed-set `:source` value. Optional; only stamped
+             ;; by substrate dispatch sites that carry kind-specific
+             ;; payload (e.g. `:dispatch-later` fx stamps `{:ms <ms>}`
+             ;; so the Epoch panel's DISPATCH step renders the
+             ;; originally scheduled delay alongside the kind label).
+             ;; Tools read this off the `:rf.event/source-detail` tag
+             ;; on `:rf.event/dispatched` (stamped in
+             ;; `emit-dispatched-trace`).
+             :source-detail          (:source-detail opts)
              :origin                 (:origin opts :app)
              ;; Per rf2-t1lxr: the closed-enum functional source per
              ;; Xray A.5 / Spec 009 §Dispatch-origin tagging. The 10-value
@@ -1718,7 +1728,16 @@
                        (:dispatch-id envelope)
                        (assoc :rf.trace/dispatch-id (:dispatch-id envelope))
                        (:parent-dispatch-id envelope)
-                       (assoc :rf.trace/parent-dispatch-id (:parent-dispatch-id envelope))))))))
+                       (assoc :rf.trace/parent-dispatch-id (:parent-dispatch-id envelope))
+                       ;; Per rf2-5qp4g: optional per-source-kind detail
+                       ;; map (e.g. `{:ms 500}` for `:dispatch-later`)
+                       ;; so the Epoch panel's DISPATCH source-kind
+                       ;; enrichment (spec/021 §9.1.6.3) can render
+                       ;; kind-specific chrome. Only stamped when the
+                       ;; envelope carried `:source-detail` (the
+                       ;; substrate dispatch site opt-in).
+                       (:source-detail envelope)
+                       (assoc :rf.event/source-detail (:source-detail envelope))))))))
 
 (defn- front-insert-machine-internal
   "Return `q` (a PersistentQueue of envelopes) with `envelope` spliced in

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1775,6 +1775,72 @@ URI pre-resolved against `editor-uri/editor-uri`; it is used by demo
 surfaces + the standalone static page where no trace bus is
 available. (rf2-evgf5 / rf2-g5q8d decision.)
 
+#### §9.1.6.3 DISPATCH source-kind enrichment (rf2-5qp4g · consuming rf2-ejtpd)
+
+The DISPATCH step's source label adapts to the closed-set substrate-
+internal `:source` values introduced in rf2-ejtpd (`:after-timer`,
+`:always`, `:machine-spawn`, `:fx-dispatch`, `:fx-dispatch-later`).
+Each kind paints richer chrome than the bare `from <source>` label
+the pre-rf2-5qp4g renderer produced for every value — the operator
+reads the specific timer/delay/state-path, the spawned actor's
+identity, or the parent-epoch link in the same numbered-cascade
+rhythm without leaving the panel.
+
+**Per-source label inventory.**
+
+| `:source`            | Rendered label                                                | Click affordance |
+|----------------------|---------------------------------------------------------------|------------------|
+| `:after-timer`       | `from :after timer · 250ms on [:active :authenticating]`      | the state-path is click-to-source on the machine spec's `:rf.machine/source-coords` index (rf2-8bp3); falls through to a plain monospace span when no coord captured |
+| `:machine-spawn`     | `from machine spawn · :child-actor-id`                        | none (the actor-id is gensym'd; resolving its spec is a follow-on enrichment) |
+| `:fx-dispatch`       | `from fx :dispatch · parent epoch #142`                       | the parent-epoch chip is click-to-navigate via `:rf.xray/focus-epoch <epoch-id>` (registered in `spine.cljs`'s `install!` per rf2-5qp4g) |
+| `:fx-dispatch-later` | `from fx :dispatch-later · 500ms · parent epoch #142`         | same parent-epoch navigation; the `500ms` chip surfaces when the trace carries the optional `:rf.event/source-detail :ms` tag |
+| `:always`            | `from :always`                                                | defensive — `:always` rides the microstep trace, not `:rf.event/dispatched`; the renderer covers it so the closed set is fully exhaustive |
+| `:ui` / `:frame-init` / `:test-harness` / `:unknown` | `from <source>` (unchanged from §9.1.6.1) | the source word itself is click-to-source on the dispatch call-site (rf2-80u5a) |
+
+**Projection.** `dispatch-row` (in `panels/epoch/projection.cljc`)
+attaches a `:source-enrichment` map to the row whose shape depends
+on `:source` — `{:machine-id :delay-ms :source-state-path}` for
+`:after-timer`, `{:spawned-actor-id}` for `:machine-spawn`,
+`{:parent-dispatch-id :delay-ms?}` for the fx-dispatch variants.
+Vanilla sources carry no enrichment; the renderer falls through to
+the pre-rf2-5qp4g call-site link.
+
+**Parent-epoch resolution.** The view layer resolves
+`:parent-dispatch-id → :parent-epoch-id` against the Xray
+`:epoch-history` slice threaded through `pipeline-view`'s `ctx`
+(`(proj/find-parent-epoch epoch-history parent-dispatch-id)`). When
+the parent epoch is in the buffer the chip renders as a clickable
+`<button>` carrying `parent epoch #N`; when not (root cascade, or
+the parent was evicted from the ring) the chip renders as a muted
+`<span>` reading `parent dispatch #N (not in buffer)` so the
+operator still sees the lineage.
+
+**Test surface.** Per-kind `data-testid` slots:
+
+  - `rf-xray-epoch-dispatch-source-label` (the source-label root,
+    present for every source kind)
+  - `rf-xray-epoch-dispatch-after-timer-delay` /
+    `rf-xray-epoch-dispatch-after-timer-state-path` (`:after-timer`)
+  - `rf-xray-epoch-dispatch-machine-spawn-actor` (`:machine-spawn`)
+  - `rf-xray-epoch-dispatch-fx-later-delay` (`:fx-dispatch-later`
+    delay chip)
+  - `rf-xray-epoch-dispatch-parent-epoch-link` /
+    `rf-xray-epoch-dispatch-parent-epoch-unresolved` (fx-dispatch
+    parent-epoch chrome — clickable variant + muted-unresolved
+    variant)
+
+**Trace stamp contract (substrate side).** The framework stamp
+sites that feed the enrichment live in `implementation/core/src/
+re_frame/fx.cljc` (`:dispatch` / `:dispatch-later` reserved-fx
+handlers stamp `:source :fx-dispatch` / `:source :fx-dispatch-later`
+on the child envelope, with the `:rf.event/source-detail {:ms ms}`
+tag riding on the dispatched trace for `:dispatch-later`),
+`implementation/machines/src/re_frame/machines/timer.cljc` (the
+`:after` timer's `dispatch!` stamps `:source :after-timer`), and
+`implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc`
+(the spawn fx stamps `:source :machine-spawn`). The substrate-side
+contract is the closed set documented in §9.1.10.1's table.
+
 ### §9.1.7 Composition with the edn-inspector widget
 
 Per the bead body's §Implementation Notes, expandable rows mount the
@@ -1810,6 +1876,7 @@ verbatim; no DOM concern bleeds into the data layer.
 | `:rf.xray.epoch/toggle-row-expand step-kw row-id` | flip the row's pair in `:epoch-panel-expanded-rows` |
 | `:rf.xray.epoch/clear-row-expand` | drop the expansion set |
 | `:rf.xray.epoch/set-subs-filter-mode mode` | set the SUBSCRIPTIONS filter mode (rf2-tzmmf — closed set `:all / :changed / :unchanged`; supersedes rf2-kfh1v's `toggle-subs-show-unchanged`. The button-bar replaces both the prior boolean toggle AND the badge-adjacent `N recomputed (M changed, K unchanged)` summary text — Mike pair-debug 2026-05-26: no coexistence, pre-alpha posture) |
+| `:rf.xray/focus-epoch epoch-id` | pivot the spine's `:rf.xray/focus` to the supplied epoch-id (rf2-5qp4g). Resolves the matching record's settling `:dispatch-id` via `spine/dispatch-id-for-epoch` and defers to `focus-cascade-reducer`. Drives the DISPATCH step's parent-epoch navigation chip on `:fx-dispatch` / `:fx-dispatch-later` dispatches (§9.1.6.3). When the epoch-id has no matching dispatch-id in the buffer (trace elided, record-only fixture), the event still pins `:focus :epoch-id` so panels pivoting on it (App-DB diff, Views, Machine Inspector) follow the navigation; the cascade's `:dispatch-id` resolves on the next live tick. |
 
 ### §9.1.10.1 Substrate tag dependencies (the trace-stamp contract)
 
@@ -1822,7 +1889,7 @@ and silently rendered empty rows. The binding inventory:
 
 | Step | Trace operation | Canonical tags |
 |------|-----------------|----------------|
-| `:dispatch` | `:rf.event/dispatched` | `:rf.event/v` (event vector — rf2-93a7s), `:source`, `:rf.trace/call-site` |
+| `:dispatch` | `:rf.event/dispatched` | `:rf.event/v` (event vector — rf2-93a7s), `:source` (closed set per rf2-hxj0d + rf2-ejtpd; substrate-internal values drive the §9.1.6.3 per-kind enrichment), `:rf.trace/call-site`, `:rf.trace/parent-dispatch-id` (rf2-5qp4g — fx-dispatch parent-epoch link), `:rf.event/source-detail` (rf2-5qp4g — optional per-source-kind detail map; `:dispatch-later` rides `{:ms <delay>}` so the renderer surfaces the original scheduled delay) |
 | `:coeffect` | `:rf.cofx/run` (preferred) or `:rf.event/run-end` `:rf.event/coeffects` (fallback) | `:rf.cofx/id`, `:rf.cofx/value`, `:rf.cofx/elapsed-ms` (rf2-w2r4p aligned the per-cofx duration read against the substrate's canonical name + threaded `:duration-ms` through the `cofx-steps` flattening) — SYSTEM defaults `:db / :event / :frame / :source / :trace-id` are filtered (rf2-cq0ch). **Projection splits each surviving cofx into its own numbered step** (rf2-s1jw4 · pair-debug 2026-05-26): `cofx-steps` is a `mapv` over `cofx-rows` producing `{:step :coeffect :badge :COEFFECT :id <kw> :value <v> :duration-ms <ms>}` per entry, spliced into the steps vec before HANDLER. |
 | `:handler` duration | `:rf.event/run-end` `:rf.event/elapsed-ms` (rf2-slnce aligned the per-handler duration read against the substrate's canonical name — see `re-frame.router/emit-run-end-trace`) |
 | `:handler` source | `(rf/handler-meta :event id)` → `:rf.handler/source` (rf2-66wis · NOT a trace read — registrar meta). The `{:file :line}` coord on the same meta drives the HANDLER verb-as-link affordance (§9.1.6.1 · rf2-ehd8v + pair-debug 2026-05-26). |

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -72,6 +72,107 @@
 
 ;; ---- DISPATCH row --------------------------------------------------------
 
+(defn- after-timer-enrichment
+  "Extract `:after-timer` enrichment from the dispatched event vector.
+
+  Per rf2-ejtpd, the machine `:after` timer dispatches synthetic
+  triggers shaped:
+
+      [<machine-id> [:rf.machine.timer/after-elapsed <delay-key>
+                     <epoch> <invoke-id>]]
+
+  where `<delay-key>` is the timer's delay (a number in ms or a
+  resolved sub-key per Spec 005 §Hierarchy interaction) and
+  `<invoke-id>` is the state-vector at which the `:after` timer was
+  scheduled. The renderer projects these into the rich label:
+
+      'from :after timer · 250ms on [:active :authenticating]'
+
+  Returns nil when the event vector doesn't match the timer shape —
+  defensive: a future stamp-site that emits `:source :after-timer` on
+  some non-canonical event shape still gets the kind label without
+  fields that don't apply."
+  [event]
+  (when (and (vector? event) (= 2 (count event)))
+    (let [[machine-id inner] event]
+      (when (and (vector? inner)
+                 (= :rf.machine.timer/after-elapsed (first inner))
+                 (>= (count inner) 4))
+        {:machine-id        machine-id
+         :delay-ms          (nth inner 1)
+         :source-state-path (vec (nth inner 3))}))))
+
+(defn- machine-spawn-enrichment
+  "Extract `:machine-spawn` enrichment from the dispatched event vector.
+
+  Per rf2-ejtpd, the spawn fx dispatches the spawned actor's first
+  event shaped:
+
+      [<spawned-actor-id> <start-event>]            ; user-supplied :start
+      [<spawned-actor-id> [:rf.machine/spawned]]    ; synthetic default
+
+  The spawned-actor-id is the first element. The renderer projects
+  this into the label:
+
+      'from machine spawn · :child-actor-id'
+
+  Returns nil when the event vector lacks an actor-id (defensive)."
+  [event]
+  (when (and (vector? event) (seq event))
+    (let [actor-id (first event)]
+      (when actor-id
+        {:spawned-actor-id actor-id}))))
+
+(defn- fx-dispatch-enrichment
+  "Extract `:fx-dispatch` / `:fx-dispatch-later` enrichment from the
+  dispatched trace event.
+
+  Per rf2-ejtpd, the `:dispatch` / `:dispatch-later` reserved fx
+  handlers stamp `:source :fx-dispatch` / `:source :fx-dispatch-later`
+  on the child envelope. The parent-dispatch-id rides on the
+  emit-dispatched trace under `:rf.trace/parent-dispatch-id` (already
+  wired by router.cljc per spec/018 §Dispatch correlation).
+
+  For `:fx-dispatch-later`, the parent's scheduled `:ms` delay is
+  read off the optional `:rf.event/source-detail :ms` tag — when
+  present the view renders an inline delay chip.
+
+  Returns nil when the trace event carries no parent-dispatch-id —
+  isolated dispatch (root cascade) leaves the parent-epoch-link off."
+  [ev]
+  (let [parent-id    (or (common/tag-of ev :rf.trace/parent-dispatch-id)
+                         (common/tag-of ev :parent-dispatch-id))
+        source-detail (common/tag-of ev :rf.event/source-detail)]
+    (cond-> nil
+      parent-id    (assoc :parent-dispatch-id parent-id)
+      (:ms source-detail) (assoc :delay-ms (:ms source-detail)))))
+
+(defn- source-enrichment
+  "Build the per-source-kind enrichment map for the DISPATCH row.
+
+  Closed-set source values (rf2-hxj0d + rf2-ejtpd):
+
+  - `:after-timer`       → `:delay-ms`, `:source-state-path`, `:machine-id`
+  - `:machine-spawn`     → `:spawned-actor-id`
+  - `:fx-dispatch`       → `:parent-dispatch-id`
+  - `:fx-dispatch-later` → `:parent-dispatch-id`, optional `:delay-ms`
+  - `:always`            → no enrichment fields (intra-macrostep; no
+                           dispatched envelope normally carries it but
+                           the renderer still labels the kind)
+  - other values         → no enrichment (existing labels: `:ui`,
+                           `:frame-init`, `:test-harness`, `:unknown`)
+
+  Per rf2-5qp4g — pure-data; the view layer reads these fields and
+  renders the rich chrome (state-path click-to-source, parent-epoch
+  navigation, delay-ms chip)."
+  [source event ev]
+  (case source
+    :after-timer       (after-timer-enrichment event)
+    :machine-spawn     (machine-spawn-enrichment event)
+    :fx-dispatch       (fx-dispatch-enrichment ev)
+    :fx-dispatch-later (fx-dispatch-enrichment ev)
+    nil))
+
 (defn dispatch-row
   "Build the step-1 DISPATCH row from the epoch's `:rf.event/dispatched`
   trace. Returns nil when the epoch carries no dispatched trace (test
@@ -83,21 +184,33 @@
   the canonical projection-side reader is `common/tag-of`. The legacy
   bare `:event` tag is retained as a fixture-compat fallback only —
   trace events never carry `:event` at top-level (the pre-rf2-509pq
-  `(:event ev)` arm was dead and removed)."
+  `(:event ev)` arm was dead and removed).
+
+  Per rf2-5qp4g (consuming rf2-ejtpd's substrate-internal `:source`
+  values), the row additionally carries source-kind-specific
+  enrichment under `:source-enrichment` — a map whose shape depends
+  on `:source`. The renderer reads these fields to render rich chrome
+  per source kind (after-timer delay + state-path,
+  machine-spawn actor-id, fx-dispatch parent-epoch navigation). See
+  `source-enrichment` for the per-kind field inventory."
   [events fallback-event]
   (let [ev (find-op events :rf.event/dispatched)]
     (cond
       ev
-      {:step        :dispatch
-       :badge       :DISPATCH
-       :event       (or (common/tag-of ev :rf.event/v)
+      (let [event   (or (common/tag-of ev :rf.event/v)
                         (common/tag-of ev :event)
                         fallback-event)
-       :source      (or (common/tag-of ev :source)
+            source  (or (common/tag-of ev :source)
                         (common/tag-of ev :rf.event/source))
-       :coord       (or (common/tag-of ev :rf.trace/call-site)
-                        (:rf.trace/call-site ev))
-       :duration-ms (common/tag-of ev :duration-ms)}
+            enrich  (source-enrichment source event ev)]
+        (cond-> {:step        :dispatch
+                 :badge       :DISPATCH
+                 :event       event
+                 :source      source
+                 :coord       (or (common/tag-of ev :rf.trace/call-site)
+                                  (:rf.trace/call-site ev))
+                 :duration-ms (common/tag-of ev :duration-ms)}
+          enrich (assoc :source-enrichment enrich)))
 
       (vector? fallback-event)
       {:step  :dispatch
@@ -1400,6 +1513,24 @@
           exact      (some #(when (= child-event (:trigger-event %)) %)
                            candidates)]
       (:epoch-id (or exact (first candidates))))))
+
+(defn find-parent-epoch
+  "Resolve a parent epoch's `:epoch-id` against the epoch-history given
+  the child's parent-dispatch-id (rf2-5qp4g).
+
+  The reverse of `find-child-epoch`: child's `:parent-dispatch-id` →
+  parent's `:dispatch-id` → parent's `:epoch-id`. The lookup matches
+  on `dispatch-id-of-epoch` which falls back to a `:trace-events`
+  walk for records that lack the first-class `:dispatch-id` slot
+  (per the same helper's docstring). Returns nil when no parent
+  epoch is in the buffer (root cascade, or aged out)."
+  [epoch-history parent-dispatch-id]
+  (when (and (some? parent-dispatch-id) (seq epoch-history))
+    (some (fn [record]
+            (when (or (= parent-dispatch-id (common/dispatch-id-of-epoch record))
+                      (= parent-dispatch-id (:dispatch-id record)))
+              (:epoch-id record)))
+          epoch-history)))
 
 ;; ---- top-level projection ------------------------------------------------
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -283,6 +283,49 @@
    :display     "inline-flex"
    :align-items "center"})
 
+;; -- DISPATCH source enrichment (rf2-5qp4g) -------------------------------
+;;
+;; Each closed-set substrate-internal `:source` value (rf2-ejtpd:
+;; `:after-timer`, `:machine-spawn`, `:fx-dispatch`, `:fx-dispatch-later`)
+;; renders a richer label than the prior `from <source>` chrome — the
+;; specific delay / state-path / spawned-actor / parent-epoch becomes
+;; visible chrome on the DISPATCH header.
+
+(def ^:private dispatch-source-detail-style
+  "Trailing detail chip following the kind label (e.g. ` · 250ms`)."
+  {:color       text-tertiary-colour
+   :font-family mono-stack
+   :font-size   "12px"
+   :white-space "nowrap"})
+
+(def ^:private dispatch-source-state-path-button-style
+  "State-path click-to-source button — accent-coloured, dotted-
+  underlined, mono. Mirrors `link-button-style` but rides the smaller
+  detail-chip font sizing."
+  (assoc link-button-style :font-size "12px"))
+
+(def ^:private dispatch-source-state-path-plain-style
+  "Plain (non-clickable) state-path rendering when no coord is
+  available — accent-coloured monospace span."
+  {:color       accent-colour
+   :font-family mono-stack
+   :font-size   "12px"
+   :white-space "nowrap"})
+
+(def ^:private dispatch-source-parent-epoch-button-style
+  "Parent-epoch navigation button — accent-coloured, dotted-underlined,
+  mono. Clicking dispatches `:rf.xray/focus-epoch` to navigate the
+  Epoch panel to the parent cascade."
+  (assoc link-button-style :font-size "12px"))
+
+(def ^:private dispatch-source-parent-epoch-plain-style
+  "Plain (non-clickable) parent-epoch rendering when no parent-epoch
+  could be resolved (root cascade or evicted from the buffer)."
+  {:color       text-tertiary-colour
+   :font-family mono-stack
+   :font-size   "12px"
+   :white-space "nowrap"})
+
 ;; -- COEFFECT --------------------------------------------------------------
 
 (def ^:private coeffect-row-style
@@ -1396,6 +1439,228 @@
               :style dispatch-source-plain-style}
        label])))
 
+;; ---- rf2-5qp4g — DISPATCH source enrichment per source kind --------------
+;;
+;; The closed-set substrate-internal `:source` values (rf2-ejtpd:
+;; `:after-timer`, `:machine-spawn`, `:fx-dispatch`,
+;; `:fx-dispatch-later`) carry richer per-kind detail than the prior
+;; bare `from <source>` chrome. Each kind renders a specific label +
+;; click-affordance:
+;;
+;;   :after-timer       → 'from :after timer · 250ms on [:active :auth]'
+;;                        (state-path → click-to-source on machine spec)
+;;   :machine-spawn     → 'from machine spawn · :child-actor-id'
+;;   :fx-dispatch       → 'from fx :dispatch · parent epoch #142'
+;;                        (parent-epoch link → focus-epoch dispatch)
+;;   :fx-dispatch-later → 'from fx :dispatch-later · 500ms ·
+;;                         parent epoch #142'
+;;
+;; Vanilla source kinds (`:ui`, `:frame-init`, `:test-harness`,
+;; `:unknown`) fall through to the pre-rf2-5qp4g `dispatch-source-label`
+;; chrome unchanged (call-site click-to-source on the source word).
+
+(defn- machine-state-path-coord
+  "Resolve a `{:file :line}` coord for a machine state-path via the
+  registered machine's `:rf.machine/source-coords` index (rf2-8bp3).
+
+  `machine-id` is the machine event-id; `state-path` is a vector like
+  `[:active :authenticating]`. We look up the index under
+  `[:states :active :states :authenticating]` first (the spec-path
+  shape produced by `state-spec-path-prefix`); the source-coords map
+  may or may not have a coord for this specific state, so the lookup
+  degrades gracefully.
+
+  Returns nil when no coord was captured (production builds, fn-form
+  machines, unregistered machine-id)."
+  [machine-id state-path]
+  (when (and (keyword? machine-id) (vector? state-path) (seq state-path))
+    (let [machine-meta (try (rf/handler-meta :machine machine-id)
+                            (catch :default _ nil))
+          idx          (or (get-in machine-meta [:rf/machine :rf.machine/source-coords])
+                           (:rf.machine/source-coords machine-meta))
+          spec-path    (proj/state-spec-path-prefix state-path)
+          c            (or (get idx spec-path)
+                           ;; Fallback: lookup by the raw state-path tuple
+                           ;; (some fixtures key by state-path directly).
+                           (get idx state-path))]
+      (when (and (map? c) (string? (:file c)) (seq (:file c)))
+        {:file (:file c) :line (:line c)}))))
+
+(defn- state-path-affordance
+  "Render a state-path with click-to-source affordance when a coord is
+  available; plain accent-coloured monospace span otherwise.
+
+  `path-str` is the rendered vector text (e.g. `[:active :auth]`);
+  `coord` is `{:file <string> :line <int>}` or nil; `testid` is the
+  data-testid suffix."
+  [path-str coord testid]
+  (if (and (map? coord) (seq (:file coord)))
+    [:button {:data-testid testid
+              :aria-label  (str "open " (:file coord)
+                                (when (:line coord) (str ":" (:line coord)))
+                                " in editor")
+              :title       (str "open " (:file coord)
+                                (when (:line coord) (str ":" (:line coord)))
+                                " in editor")
+              :on-click    (fn [e]
+                             (.stopPropagation e)
+                             (rf/dispatch
+                               [:rf.xray/open-in-editor
+                                {:source-coord coord}]
+                               {:frame :rf/xray}))
+              :style dispatch-source-state-path-button-style}
+     path-str
+     (icons/external-link)]
+    [:span {:data-testid testid
+            :style dispatch-source-state-path-plain-style}
+     path-str]))
+
+(defn- parent-epoch-affordance
+  "Render the `parent epoch #N` chrome for `:fx-dispatch` /
+  `:fx-dispatch-later`. When `parent-epoch-id` is resolved against
+  the supplied epoch-history, the chip renders as a clickable button
+  that dispatches `[:rf.xray/focus-epoch <epoch-id>]` to navigate the
+  Epoch panel to the parent cascade. When unresolved (root cascade
+  or aged out of the buffer) the chip renders as a muted plain span
+  with the parent-dispatch-id labelled to give the operator something
+  to orient on."
+  [parent-epoch-id parent-dispatch-id]
+  (cond
+    (some? parent-epoch-id)
+    [:button {:data-testid "rf-xray-epoch-dispatch-parent-epoch-link"
+              :aria-label  (str "focus parent epoch #" parent-epoch-id)
+              :title       (str "focus parent epoch #" parent-epoch-id)
+              :on-click    (fn [e]
+                             (.stopPropagation e)
+                             (rf/dispatch
+                               [:rf.xray/focus-epoch parent-epoch-id]
+                               {:frame :rf/xray}))
+              :style dispatch-source-parent-epoch-button-style}
+     (str "parent epoch #" parent-epoch-id)]
+
+    (some? parent-dispatch-id)
+    [:span {:data-testid "rf-xray-epoch-dispatch-parent-epoch-unresolved"
+            :style dispatch-source-parent-epoch-plain-style}
+     (str "parent dispatch #" parent-dispatch-id " (not in buffer)")]
+
+    :else nil))
+
+(defn- dispatch-after-timer-label
+  "Render the `:after-timer` rich label:
+
+      from :after timer · 250ms on [:active :authenticating]
+
+  The state-path is a click-to-source affordance via the machine's
+  `:rf.machine/source-coords` index (rf2-8bp3) when a coord was
+  captured; plain accent-coloured monospace span otherwise."
+  [{:keys [machine-id delay-ms source-state-path]}]
+  (let [path-str (pr-str source-state-path)
+        coord    (machine-state-path-coord machine-id source-state-path)]
+    [:span {:data-testid "rf-xray-epoch-dispatch-source-label"
+            :style dispatch-verb-style}
+     [:span {:style dispatch-source-plain-style}
+      "from :after timer"]
+     (when delay-ms
+       [:span {:data-testid "rf-xray-epoch-dispatch-after-timer-delay"
+               :style dispatch-source-detail-style}
+        (str " · " delay-ms "ms on ")])
+     (when (and (vector? source-state-path) (seq source-state-path))
+       (state-path-affordance
+         path-str coord "rf-xray-epoch-dispatch-after-timer-state-path"))]))
+
+(defn- dispatch-machine-spawn-label
+  "Render the `:machine-spawn` rich label:
+
+      from machine spawn · :child-actor-id
+
+  No click-to-source affordance — the actor-id is the gensym'd
+  identity of the spawned actor; resolving its spec source is a
+  follow-on enrichment (rf2-5qp4g scope is the actor-id label)."
+  [{:keys [spawned-actor-id]}]
+  [:span {:data-testid "rf-xray-epoch-dispatch-source-label"
+          :style dispatch-verb-style}
+   [:span {:style dispatch-source-plain-style}
+    "from machine spawn"]
+   (when spawned-actor-id
+     [:span {:data-testid "rf-xray-epoch-dispatch-machine-spawn-actor"
+             :style dispatch-source-detail-style}
+      (str " · " (pr-str spawned-actor-id))])])
+
+(defn- dispatch-fx-label
+  "Render the `:fx-dispatch` / `:fx-dispatch-later` rich label:
+
+      from fx :dispatch · parent epoch #142
+      from fx :dispatch-later · 500ms · parent epoch #142
+
+  The parent-epoch chip is click-to-navigate via
+  `:rf.xray/focus-epoch`. The delay-ms chip rides only for
+  `:dispatch-later` when the original scheduled delay was stamped
+  on the dispatched trace (`:rf.event/source-detail :ms`)."
+  [source {:keys [parent-dispatch-id delay-ms]} epoch-history]
+  (let [kind-label (case source
+                     :fx-dispatch       ":dispatch"
+                     :fx-dispatch-later ":dispatch-later"
+                     (name source))
+        parent-epoch-id (when (and parent-dispatch-id (seq epoch-history))
+                          (proj/find-parent-epoch epoch-history parent-dispatch-id))]
+    [:span {:data-testid "rf-xray-epoch-dispatch-source-label"
+            :style dispatch-verb-style}
+     [:span {:style dispatch-source-plain-style}
+      (str "from fx " kind-label)]
+     (when (and (= source :fx-dispatch-later) delay-ms)
+       [:span {:data-testid "rf-xray-epoch-dispatch-fx-later-delay"
+               :style dispatch-source-detail-style}
+        (str " · " delay-ms "ms")])
+     (when parent-dispatch-id
+       [:span {:style dispatch-source-detail-style} " · "])
+     (parent-epoch-affordance parent-epoch-id parent-dispatch-id)]))
+
+(defn- dispatch-always-label
+  "Render the `:always` defensive label.
+
+  Per rf2-ejtpd, `:source :always` is stamped on the
+  `:rf.machine.microstep/transition` trace — `:always` microsteps
+  do not produce their own dispatch envelope. So the DISPATCH step
+  renderer normally never sees `:source :always` on
+  `:rf.event/dispatched`. This branch exists for completeness across
+  the closed set; a future runtime emitting `:always` on a dispatch
+  trace would render the bare kind label without enrichment."
+  [_step]
+  [:span {:data-testid "rf-xray-epoch-dispatch-source-label"
+          :style dispatch-verb-style}
+   [:span {:style dispatch-source-plain-style}
+    "from :always"]])
+
+(defn- dispatch-source-enriched-label
+  "Dispatch the source-label rendering to the per-kind label fn based
+  on `:source` + `:source-enrichment`. Falls back to the vanilla
+  `dispatch-source-label` (call-site click-to-source) for all other
+  source kinds (`:ui`, `:frame-init`, `:test-harness`, `:unknown`,
+  plus any source value that lacks per-kind enrichment data).
+
+  Closed-set dispatch table (rf2-ejtpd + rf2-5qp4g):
+
+    :after-timer       → dispatch-after-timer-label
+    :machine-spawn     → dispatch-machine-spawn-label
+    :fx-dispatch       → dispatch-fx-label
+    :fx-dispatch-later → dispatch-fx-label
+    :always            → dispatch-always-label
+    other / nil        → dispatch-source-label (call-site link)"
+  [{:keys [source coord source-enrichment] :as step} epoch-history]
+  (case source
+    :after-timer       (if source-enrichment
+                         (dispatch-after-timer-label source-enrichment)
+                         (dispatch-source-label source coord))
+    :machine-spawn     (if source-enrichment
+                         (dispatch-machine-spawn-label source-enrichment)
+                         (dispatch-source-label source coord))
+    :fx-dispatch       (dispatch-fx-label source (or source-enrichment {})
+                                          epoch-history)
+    :fx-dispatch-later (dispatch-fx-label source (or source-enrichment {})
+                                          epoch-history)
+    :always            (dispatch-always-label step)
+    (dispatch-source-label source coord)))
+
 (defn render-dispatch-step
   "Render the DISPATCH step (always present). Header summarises `from
   <source>` with the call-site chip when a coord was captured;
@@ -1407,24 +1672,50 @@
   captured by the macro form (`rf/dispatch [...] [opts]`); plain
   text otherwise. The external-link icon rides INSIDE the button
   as a secondary cue so the affordance reads as a single labelled
-  link rather than a label-with-trailing-icon."
-  [{:keys [source coord duration-ms step-number violations] :as step}]
-  [:div {:data-testid "rf-xray-epoch-step-dispatch"
-         :data-step-kw "dispatch"}
-   (numbered-circle step-number :DISPATCH)
-   (step-header
-     {:step :dispatch
-      :badge :DISPATCH
-      :verb [:span {:style dispatch-verb-style}
-             "from "
-             (dispatch-source-label source coord)]
-      :expandable? false
-      :testid "rf-xray-epoch-dispatch"
-      :duration-ms duration-ms}
-     nil)
-   (dispatch-body step)
-   ;; rf2-xgeag — `:event` boundary violations attach to DISPATCH.
-   (violation-blocks :dispatch violations)])
+  link rather than a label-with-trailing-icon.
+
+  Per rf2-5qp4g, when `:source` is one of the substrate-internal
+  closed-set values (rf2-ejtpd: `:after-timer`, `:machine-spawn`,
+  `:fx-dispatch`, `:fx-dispatch-later`), the label gains rich chrome
+  for the kind (delay-ms + state-path / spawned-actor-id /
+  parent-epoch navigation). Vanilla sources fall through to the
+  pre-rf2-5qp4g call-site chrome unchanged.
+
+  `epoch-history` is the optional Xray epoch buffer slice the
+  `:fx-dispatch` / `:fx-dispatch-later` enrichments use to resolve
+  the parent-dispatch-id → parent-epoch-id link (rendered as a
+  click-to-navigate `:rf.xray/focus-epoch` button). When omitted
+  (direct test calls of the renderer) the parent-epoch chip falls
+  back to the unresolved variant."
+  ([step] (render-dispatch-step step nil))
+  ([{:keys [source coord duration-ms step-number violations] :as step}
+    epoch-history]
+   [:div {:data-testid "rf-xray-epoch-step-dispatch"
+          :data-step-kw "dispatch"
+          :data-source (when source (name source))}
+    (numbered-circle step-number :DISPATCH)
+    (step-header
+      {:step :dispatch
+       :badge :DISPATCH
+       :verb (let [enriched (dispatch-source-enriched-label step epoch-history)]
+               ;; Vanilla sources fall through to a wrapper that
+               ;; carries the prefix "from " — the per-kind labels
+               ;; carry their own "from <kind>" prefix already, so the
+               ;; wrapper differs by source.
+               (case source
+                 (:after-timer :machine-spawn :fx-dispatch
+                  :fx-dispatch-later :always)
+                 enriched
+                 [:span {:style dispatch-verb-style}
+                  "from "
+                  (dispatch-source-label source coord)]))
+       :expandable? false
+       :testid "rf-xray-epoch-dispatch"
+       :duration-ms duration-ms}
+      nil)
+    (dispatch-body step)
+    ;; rf2-xgeag — `:event` boundary violations attach to DISPATCH.
+    (violation-blocks :dispatch violations)]))
 
 ;; ---- COEFFECT step -------------------------------------------------------
 
@@ -3324,11 +3615,12 @@
 
   `ctx` carries the cascade-level pieces a row may need (e.g. the
   parent `:dispatch-id` + the `:epoch-history` slice for the
-  CHILD-DISPATCHES section's child-epoch resolution). Most steps
+  CHILD-DISPATCHES section's child-epoch resolution + rf2-5qp4g
+  DISPATCH `:fx-dispatch` parent-epoch link resolution). Most steps
   ignore it."
   [step ctx]
   (case (:step step)
-    :dispatch          (render-dispatch-step step)
+    :dispatch          (render-dispatch-step step (:epoch-history ctx))
     :coeffect          (render-coeffect-step step)
     :handler           (render-handler-step step)
     :flow              (render-flow-step step)

--- a/tools/xray/src/day8/re_frame2_xray/spine.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/spine.cljs
@@ -221,6 +221,25 @@
               (:epoch-id record)))
           epoch-history)))
 
+(defn dispatch-id-for-epoch
+  "Return the settling `:dispatch-id` of the epoch record in
+  `epoch-history` whose `:epoch-id` is `epoch-id`, or nil when no
+  match is found.
+
+  Reverse of `epoch-id-for-cascade`. Used by `:rf.xray/focus-epoch`
+  (rf2-5qp4g) to pivot focus by epoch-id (the primary key into the
+  epoch ring) when the caller — the Epoch panel's DISPATCH step's
+  parent-epoch navigation — only has the epoch-id and needs to drive
+  the spine's `:focus-cascade-reducer` which keys on dispatch-id.
+
+  Pure data; JVM-runnable."
+  [epoch-history epoch-id]
+  (when (and epoch-id (seq epoch-history))
+    (some (fn [record]
+            (when (= epoch-id (:epoch-id record))
+              (common/dispatch-id-of-epoch record)))
+          epoch-history)))
+
 (defn compose-focus
   "Derive the public `:rf.xray/focus` map from a stored `:focus` slot
   and the live cascade vector. Always re-derives `:head?` and the
@@ -709,6 +728,40 @@
     (fn [db _event]
       (focus-step-reducer db (db->cascades db) (db->epoch-history db) +1
                           (db->show-ungrouped? db))))
+
+  (rf/reg-event-db :rf.xray/focus-epoch
+    ;; Per rf2-5qp4g — focus the spine by epoch-id (the primary key
+    ;; into the epoch ring buffer). Resolves the matching record's
+    ;; settling dispatch-id via `dispatch-id-for-epoch` then defers
+    ;; to `focus-cascade-reducer` so the same focus-mutation path is
+    ;; reused. The Epoch panel's DISPATCH step renders a parent-epoch
+    ;; navigation chip for `:fx-dispatch` / `:fx-dispatch-later`
+    ;; dispatches (the parent epoch was settled in the buffer); the
+    ;; chip's click dispatches this event with the resolved
+    ;; parent-epoch-id.
+    (fn [db [_ epoch-id]]
+      (let [epoch-history   (db->epoch-history db)
+            dispatch-id     (dispatch-id-for-epoch epoch-history epoch-id)
+            cascades        (db->cascades db)
+            show-ungrouped? (db->show-ungrouped? db)
+            head-id         (focusable-head-id cascades show-ungrouped?)
+            record          (some #(when (= epoch-id (:epoch-id %)) %)
+                                  epoch-history)
+            frame-id        (:frame record)]
+        (if dispatch-id
+          (focus-cascade-reducer db dispatch-id frame-id epoch-id head-id)
+          ;; No matching dispatch-id (the epoch's trace was elided or
+          ;; the record lacks the slot) — still pin epoch-id so panels
+          ;; pivoting on `:rf.xray/focus :epoch-id` (App-db diff, Views,
+          ;; machine-inspector) follow the navigation. The cascade list
+          ;; will refresh and `compose-focus` will recover the dispatch-id
+          ;; on the next live tick.
+          (cond-> (update db :focus (fnil assoc {})
+                          :epoch-id   epoch-id
+                          :mode       :retro
+                          :previewing? false)
+            frame-id (assoc-in [:focus :frame] frame-id)
+            true     (assoc :selected-epoch-id epoch-id))))))
 
   (rf/reg-event-db :rf.xray/follow-head
     (fn [db _event]

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -255,6 +255,146 @@
           "event vector resolves through :rf.event/v")
       (is (= :ui (:source r))))))
 
+;; ---- rf2-5qp4g — per-source-kind enrichment -----------------------------
+;;
+;; Each closed-set source value from rf2-ejtpd produces a different
+;; enrichment payload under `:source-enrichment` so the view layer can
+;; render the rich label per kind. Vanilla sources (`:ui`,
+;; `:frame-init`, `:test-harness`, `:unknown`) carry no enrichment.
+
+(deftest dispatch-row-after-timer-enrichment-test
+  (testing "rf2-5qp4g — `:source :after-timer` enrichment extracts
+            delay-ms + source-state-path + machine-id from the
+            event-vector shape
+            `[<machine-id> [:rf.machine.timer/after-elapsed <delay>
+                            <epoch> <invoke-id>]]` (rf2-ejtpd
+            timer.cljc stamp site)"
+    (let [event [:ws/connection [:rf.machine.timer/after-elapsed
+                                 250 42 [:active :authenticating]]]
+          ev    {:op-type   :rf.event
+                 :operation :rf.event/dispatched
+                 :tags      {:rf.event/v event
+                             :source     :after-timer}}
+          r     (proj/dispatch-row [ev] nil)
+          enrich (:source-enrichment r)]
+      (is (= :after-timer (:source r)) "source kind is preserved")
+      (is (= :ws/connection (:machine-id enrich))
+          "machine-id from the event vector's head")
+      (is (= 250 (:delay-ms enrich))
+          "delay-ms from the inner vector's slot 1")
+      (is (= [:active :authenticating] (:source-state-path enrich))
+          "source-state-path from the inner vector's slot 3 (invoke-id)"))))
+
+(deftest dispatch-row-after-timer-defensive-degrade-test
+  (testing "rf2-5qp4g — when `:source :after-timer` is stamped but the
+            event vector doesn't match the canonical timer shape, the
+            row carries no enrichment (defensive fall-through; the
+            view renders the kind label only)"
+    (let [ev {:op-type   :rf.event
+              :operation :rf.event/dispatched
+              :tags      {:rf.event/v [:some/other-event]
+                          :source     :after-timer}}
+          r  (proj/dispatch-row [ev] nil)]
+      (is (= :after-timer (:source r)))
+      (is (nil? (:source-enrichment r))
+          "non-canonical timer-event shape → no enrichment"))))
+
+(deftest dispatch-row-machine-spawn-enrichment-test
+  (testing "rf2-5qp4g — `:source :machine-spawn` enrichment extracts
+            the spawned actor-id (event vector's head) so the renderer
+            can label the dispatch as `from machine spawn ·
+            :child-actor-id`"
+    (let [event [:checkout/worker [:rf.machine/spawned]]
+          ev    {:op-type   :rf.event
+                 :operation :rf.event/dispatched
+                 :tags      {:rf.event/v event
+                             :source     :machine-spawn}}
+          r     (proj/dispatch-row [ev] nil)
+          enrich (:source-enrichment r)]
+      (is (= :machine-spawn (:source r)))
+      (is (= :checkout/worker (:spawned-actor-id enrich))
+          "spawned-actor-id is the first element of the event vector"))))
+
+(deftest dispatch-row-fx-dispatch-enrichment-test
+  (testing "rf2-5qp4g — `:source :fx-dispatch` enrichment reads the
+            parent-dispatch-id off the dispatched trace's
+            `:rf.trace/parent-dispatch-id` tag (already stamped by
+            router.cljc `emit-dispatched-trace` per spec/018
+            §Dispatch correlation)"
+    (let [ev {:op-type   :rf.event
+              :operation :rf.event/dispatched
+              :tags      {:rf.event/v                 [:cart/add :apple]
+                          :source                     :fx-dispatch
+                          :rf.trace/parent-dispatch-id 9001}}
+          r  (proj/dispatch-row [ev] nil)
+          enrich (:source-enrichment r)]
+      (is (= :fx-dispatch (:source r)))
+      (is (= 9001 (:parent-dispatch-id enrich))
+          "parent-dispatch-id from the canonical trace tag")
+      (is (nil? (:delay-ms enrich))
+          "`:fx-dispatch` carries no delay-ms"))))
+
+(deftest dispatch-row-fx-dispatch-later-enrichment-test
+  (testing "rf2-5qp4g — `:source :fx-dispatch-later` enrichment reads
+            parent-dispatch-id + optional delay-ms (the original
+            scheduled delay) off `:rf.event/source-detail :ms`"
+    (let [ev {:op-type   :rf.event
+              :operation :rf.event/dispatched
+              :tags      {:rf.event/v                  [:checkout/retry-prompt]
+                          :source                      :fx-dispatch-later
+                          :rf.trace/parent-dispatch-id 9001
+                          :rf.event/source-detail      {:ms 500}}}
+          r  (proj/dispatch-row [ev] nil)
+          enrich (:source-enrichment r)]
+      (is (= :fx-dispatch-later (:source r)))
+      (is (= 9001 (:parent-dispatch-id enrich)))
+      (is (= 500 (:delay-ms enrich))
+          "delay-ms surfaces when `:rf.event/source-detail :ms` is present"))))
+
+(deftest dispatch-row-fx-dispatch-later-without-detail-test
+  (testing "rf2-5qp4g — when no `:rf.event/source-detail` tag rides on
+            the trace (older runtime, no per-fx detail stamping yet),
+            `:fx-dispatch-later` still surfaces parent-dispatch-id; the
+            delay-ms slot is just absent"
+    (let [ev {:op-type   :rf.event
+              :operation :rf.event/dispatched
+              :tags      {:rf.event/v                  [:checkout/retry-prompt]
+                          :source                      :fx-dispatch-later
+                          :rf.trace/parent-dispatch-id 9001}}
+          r  (proj/dispatch-row [ev] nil)
+          enrich (:source-enrichment r)]
+      (is (= 9001 (:parent-dispatch-id enrich)))
+      (is (nil? (:delay-ms enrich))))))
+
+(deftest dispatch-row-vanilla-source-has-no-enrichment-test
+  (testing "rf2-5qp4g — vanilla source kinds (`:ui`, `:frame-init`,
+            `:test-harness`, `:unknown`) carry no `:source-enrichment`
+            slot; their labels render through the existing pre-rf2-5qp4g
+            `from <source>` chrome unchanged"
+    (doseq [src [:ui :frame-init :test-harness :unknown]]
+      (let [ev {:op-type   :rf.event
+                :operation :rf.event/dispatched
+                :tags      {:rf.event/v [:counter/inc] :source src}}
+            r  (proj/dispatch-row [ev] nil)]
+        (is (= src (:source r)))
+        (is (nil? (:source-enrichment r))
+            (str src " — vanilla source kinds carry no enrichment"))))))
+
+(deftest dispatch-row-fx-dispatch-without-parent-test
+  (testing "rf2-5qp4g — when `:source :fx-dispatch` is stamped but the
+            trace carries no `:rf.trace/parent-dispatch-id` (root
+            cascade / test fixtures that omit dispatch-id correlation),
+            the row carries no enrichment (the parent-epoch link is
+            simply omitted; the kind label still reads `from fx`)"
+    (let [ev {:op-type   :rf.event
+              :operation :rf.event/dispatched
+              :tags      {:rf.event/v [:cart/add :apple]
+                          :source     :fx-dispatch}}
+          r  (proj/dispatch-row [ev] nil)]
+      (is (= :fx-dispatch (:source r)))
+      (is (nil? (:source-enrichment r))
+          "no parent-dispatch-id → no enrichment map (graceful degrade)"))))
+
 ;; ---- COEFFECT ------------------------------------------------------------
 
 (deftest coeffect-rows-granular-test
@@ -1547,6 +1687,32 @@
           "nil history → nil")
       (is (nil? (proj/find-child-epoch history nil [:e/x 7]))
           "nil parent-id → nil"))))
+
+(deftest find-parent-epoch-by-dispatch-id-test
+  (testing "rf2-5qp4g — find-parent-epoch resolves a parent epoch's
+            `:epoch-id` from its `:dispatch-id`. Reverse of
+            `find-child-epoch`: walks the epoch-history for a record
+            whose `:dispatch-id` matches the supplied
+            parent-dispatch-id, returning that record's `:epoch-id`.
+            The view layer uses this to wire the
+            `from fx · parent epoch #N` chrome on `:fx-dispatch` /
+            `:fx-dispatch-later` DISPATCH steps."
+    (let [history [{:epoch-id 41 :dispatch-id 9000 :trigger-event [:root]}
+                   {:epoch-id 42 :dispatch-id 9001 :trigger-event [:parent]}
+                   {:epoch-id 43 :dispatch-id 9002 :trigger-event [:child]
+                    :parent-dispatch-id 9001}]]
+      (is (= 41 (proj/find-parent-epoch history 9000))
+          "matches the first-class :dispatch-id slot")
+      (is (= 42 (proj/find-parent-epoch history 9001))
+          "matches a sibling parent's :dispatch-id")
+      (is (nil? (proj/find-parent-epoch history 99999))
+          "no match → nil")
+      (is (nil? (proj/find-parent-epoch nil 9001))
+          "nil history → nil")
+      (is (nil? (proj/find-parent-epoch history nil))
+          "nil parent-dispatch-id → nil")
+      (is (nil? (proj/find-parent-epoch [] 9001))
+          "empty history → nil"))))
 
 ;; `project-includes-child-dispatches-step-test` retired in rf2-xu5iv
 ;; (commit eccb6db1b dropped the CHILD-DISPATCHES step from the

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -133,6 +133,179 @@
       (is (nil? (:on-click (second label)))
           "no click handler on the degraded label"))))
 
+;; ---- rf2-5qp4g — DISPATCH per-source-kind enrichment ------------------
+;;
+;; Each closed-set substrate-internal `:source` value (rf2-ejtpd:
+;; `:after-timer`, `:machine-spawn`, `:fx-dispatch`,
+;; `:fx-dispatch-later`) renders rich chrome — delay-ms, state-path
+;; click-to-source, spawned-actor-id, parent-epoch navigation.
+
+(deftest dispatch-source-after-timer-renders-rich-label-test
+  (testing "rf2-5qp4g — `:source :after-timer` renders the kind label,
+            the delay-ms chip, and the source-state-path with
+            click-to-source affordance"
+    (let [step {:step :dispatch :badge :DISPATCH :step-number 1
+                :event [:ws/connection [:rf.machine.timer/after-elapsed
+                                        250 42 [:active :authenticating]]]
+                :source :after-timer
+                :coord nil
+                :source-enrichment {:machine-id        :ws/connection
+                                    :delay-ms          250
+                                    :source-state-path [:active :authenticating]}}
+          tree (view/render-dispatch-step step)
+          header-text (text-of tree "rf-xray-epoch-dispatch-header")]
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-dispatch-source-label"))
+          "the dispatch source-label slot is present")
+      (is (string/includes? (or header-text "") "from :after timer")
+          "the kind label reads 'from :after timer'")
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-dispatch-after-timer-delay"))
+          "the delay chip slot renders when delay-ms is present")
+      (is (string/includes?
+            (or (text-of tree "rf-xray-epoch-dispatch-after-timer-delay") "")
+            "250ms")
+          "the delay chip shows the timer's delay in ms")
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-dispatch-after-timer-state-path"))
+          "the source-state-path slot renders")
+      (is (string/includes?
+            (or (text-of tree "rf-xray-epoch-dispatch-after-timer-state-path") "")
+            ":active")
+          "the state-path chip shows the path the timer fired from"))))
+
+(deftest dispatch-source-machine-spawn-renders-rich-label-test
+  (testing "rf2-5qp4g — `:source :machine-spawn` renders the kind label
+            and the spawned actor-id"
+    (let [step {:step :dispatch :badge :DISPATCH :step-number 1
+                :event [:checkout/worker [:rf.machine/spawned]]
+                :source :machine-spawn
+                :coord nil
+                :source-enrichment {:spawned-actor-id :checkout/worker}}
+          tree (view/render-dispatch-step step)
+          header-text (text-of tree "rf-xray-epoch-dispatch-header")]
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-dispatch-source-label"))
+          "the source-label slot is present")
+      (is (string/includes? (or header-text "") "from machine spawn")
+          "the kind label reads 'from machine spawn'")
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-dispatch-machine-spawn-actor"))
+          "the spawned-actor-id chip renders")
+      (is (string/includes?
+            (or (text-of tree "rf-xray-epoch-dispatch-machine-spawn-actor") "")
+            ":checkout/worker")
+          "the chip shows the spawned actor's id"))))
+
+(deftest dispatch-source-fx-dispatch-renders-rich-label-test
+  (testing "rf2-5qp4g — `:source :fx-dispatch` renders the kind label
+            and the parent-epoch navigation chip"
+    (let [step {:step :dispatch :badge :DISPATCH :step-number 1
+                :event [:cart/add :apple]
+                :source :fx-dispatch
+                :coord nil
+                :source-enrichment {:parent-dispatch-id 9001}}
+          epoch-history [{:epoch-id 42 :dispatch-id 9001
+                          :trigger-event [:checkout/begin]}]
+          tree (view/render-dispatch-step step epoch-history)
+          header-text (text-of tree "rf-xray-epoch-dispatch-header")]
+      (is (string/includes? (or header-text "") "from fx :dispatch")
+          "the kind label reads 'from fx :dispatch'")
+      (let [link (th/find-by-testid tree "rf-xray-epoch-dispatch-parent-epoch-link")]
+        (is (some? link) "the parent-epoch-link slot is present")
+        (is (= :button (first link))
+            "with a resolved parent-epoch-id, the chip renders as a clickable button")
+        (is (fn? (:on-click (second link)))
+            "click handler is attached for focus-epoch dispatch")
+        (is (string/includes? (or (text-of tree "rf-xray-epoch-dispatch-parent-epoch-link") "")
+                              "#42")
+            "the chip shows the resolved parent epoch number")))))
+
+(deftest dispatch-source-fx-dispatch-later-renders-delay-chip-test
+  (testing "rf2-5qp4g — `:source :fx-dispatch-later` renders kind label,
+            the delay-ms chip (when stamped) AND the parent-epoch link"
+    (let [step {:step :dispatch :badge :DISPATCH :step-number 1
+                :event [:checkout/retry-prompt]
+                :source :fx-dispatch-later
+                :coord nil
+                :source-enrichment {:parent-dispatch-id 9001
+                                    :delay-ms 500}}
+          epoch-history [{:epoch-id 42 :dispatch-id 9001
+                          :trigger-event [:checkout/begin]}]
+          tree (view/render-dispatch-step step epoch-history)
+          header-text (text-of tree "rf-xray-epoch-dispatch-header")]
+      (is (string/includes? (or header-text "") "from fx :dispatch-later")
+          "the kind label reads 'from fx :dispatch-later'")
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-dispatch-fx-later-delay"))
+          "the delay chip renders when delay-ms is present")
+      (is (string/includes?
+            (or (text-of tree "rf-xray-epoch-dispatch-fx-later-delay") "")
+            "500ms")
+          "the delay chip shows the original scheduled delay")
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-dispatch-parent-epoch-link"))
+          "the parent-epoch-link slot is also present"))))
+
+(deftest dispatch-source-fx-dispatch-unresolved-parent-test
+  (testing "rf2-5qp4g — when the parent-dispatch-id has no matching
+            epoch in the buffer (root cascade or aged out), the
+            parent-epoch chip degrades to a muted plain span carrying
+            the unresolved dispatch-id (gives the operator something to
+            orient on; no broken / dead click affordance)"
+    (let [step {:step :dispatch :badge :DISPATCH :step-number 1
+                :event [:cart/add :apple]
+                :source :fx-dispatch
+                :coord nil
+                :source-enrichment {:parent-dispatch-id 99999}}
+          epoch-history [{:epoch-id 42 :dispatch-id 9001
+                          :trigger-event [:checkout/begin]}]
+          tree (view/render-dispatch-step step epoch-history)]
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-dispatch-parent-epoch-link"))
+          "no clickable link when the parent epoch isn't in the buffer")
+      (let [unresolved (th/find-by-testid
+                         tree "rf-xray-epoch-dispatch-parent-epoch-unresolved")]
+        (is (some? unresolved) "the unresolved-parent chip is rendered")
+        (is (= :span (first unresolved))
+            "the unresolved chip is a plain span")))))
+
+(deftest dispatch-source-fx-dispatch-without-history-test
+  (testing "rf2-5qp4g — when render-dispatch-step is called without
+            epoch-history (direct test callers, or pre-history-seed
+            cold mount), `:fx-dispatch` still renders the kind label
+            with the parent chip in unresolved form."
+    (let [step {:step :dispatch :badge :DISPATCH :step-number 1
+                :event [:cart/add :apple]
+                :source :fx-dispatch
+                :coord nil
+                :source-enrichment {:parent-dispatch-id 9001}}
+          tree (view/render-dispatch-step step)]
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-dispatch-parent-epoch-link"))
+          "no clickable link without epoch-history threaded")
+      (is (some? (th/find-by-testid
+                   tree "rf-xray-epoch-dispatch-parent-epoch-unresolved"))
+          "the unresolved-parent chip carries the parent-dispatch-id"))))
+
+(deftest dispatch-source-after-timer-defensive-no-enrichment-test
+  (testing "rf2-5qp4g — when `:source :after-timer` is stamped but no
+            enrichment payload is present (defensive — non-canonical
+            event shape, older runtime), the renderer falls through to
+            the vanilla `dispatch-source-label` so the bare kind name
+            still renders + a coord-bearing call-site stays clickable"
+    (let [tree (view/render-dispatch-step
+                 {:step :dispatch :badge :DISPATCH :step-number 1
+                  :event [:some/other]
+                  :source :after-timer
+                  :coord nil})
+          label (th/find-by-testid tree "rf-xray-epoch-dispatch-source-label")]
+      (is (some? label) "the source-label slot still renders"))))
+
+(deftest dispatch-source-always-renders-kind-label-test
+  (testing "rf2-5qp4g — `:source :always` (defensive: stamped on
+            microstep traces, not DISPATCH) renders the bare kind label
+            so the closed set is fully covered even if a future runtime
+            emits it on a dispatch trace"
+    (let [tree (view/render-dispatch-step
+                 {:step :dispatch :badge :DISPATCH :step-number 1
+                  :event [:foo]
+                  :source :always
+                  :coord nil})
+          header-text (text-of tree "rf-xray-epoch-dispatch-header")]
+      (is (string/includes? (or header-text "") "from :always")))))
+
 ;; ---- rf2-cq0ch — COEFFECT body --------------------------------------
 
 (deftest coeffect-body-renders-labelled-value-test

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -502,6 +502,10 @@
    :rf.xray/focus-cascade
    :rf.xray/focus-cascade-next
    :rf.xray/focus-cascade-prev
+   ;; rf2-5qp4g — DISPATCH source-kind enrichment parent-epoch
+   ;; navigation: the Epoch panel's :fx-dispatch / :fx-dispatch-later
+   ;; parent-epoch chip dispatches this to pivot the spine by epoch-id.
+   :rf.xray/focus-epoch
    ;; rf2-uyp86 — managed-fx wire-boundary diff cross-link event
    ;; (HANDLER DISPATCHED row dispatches this to pivot the spine).
    :rf.xray/focus-event

--- a/tools/xray/test/day8/re_frame2_xray/spine_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/spine_cljs_test.cljs
@@ -736,6 +736,36 @@
     (is (nil? (spine/epoch-id-for-cascade nil :c1)))
     (is (nil? (spine/epoch-id-for-cascade [(epoch :e1 :c1)] nil)))))
 
+;; ---- rf2-5qp4g — dispatch-id-for-epoch reverse lookup -------------------
+;;
+;; Reverse of `epoch-id-for-cascade`. Drives the `:rf.xray/focus-epoch`
+;; event handler — the Epoch panel's DISPATCH step's parent-epoch
+;; navigation chip clicks land with an epoch-id and need to drive the
+;; spine's `focus-cascade-reducer`, which keys on dispatch-id.
+
+(deftest dispatch-id-for-epoch-resolves-via-trace-events
+  (testing "rf2-5qp4g — resolves :dispatch-id from an epoch's
+            :trace-events :dispatch-id tag (same walker as
+            common/dispatch-id-of-epoch)"
+    (let [history [(epoch :e1 :c1) (epoch :e2 :c2) (epoch :e3 :c3)]]
+      (is (= :c2 (spine/dispatch-id-for-epoch history :e2)))
+      (is (= :c3 (spine/dispatch-id-for-epoch history :e3))))))
+
+(deftest dispatch-id-for-epoch-falls-back-to-literal-dispatch-id
+  (testing "rf2-5qp4g — synthetic test epochs that lack :trace-events
+            still resolve via the literal :dispatch-id slot"
+    (let [history [{:epoch-id :e1 :dispatch-id 7}
+                   {:epoch-id :e2 :dispatch-id 8}]]
+      (is (= 8 (spine/dispatch-id-for-epoch history :e2))))))
+
+(deftest dispatch-id-for-epoch-missing-returns-nil
+  (testing "rf2-5qp4g — no matching epoch → nil (epoch evicted,
+            wrong-frame, or never landed in this buffer)"
+    (is (nil? (spine/dispatch-id-for-epoch [] :e1)))
+    (is (nil? (spine/dispatch-id-for-epoch [(epoch :e1 :c1)] :e-gone)))
+    (is (nil? (spine/dispatch-id-for-epoch nil :e1)))
+    (is (nil? (spine/dispatch-id-for-epoch [(epoch :e1 :c1)] nil)))))
+
 ;; ---- compose-focus :epoch-id auto-follow (rf2-70tkv) --------------------
 ;;
 ;; Mike repro 2026-05-19 watching parallel-frames @ localhost:8030:

--- a/tools/xray/testbeds/panel_gallery/fixtures_epoch.cljs
+++ b/tools/xray/testbeds/panel_gallery/fixtures_epoch.cljs
@@ -695,3 +695,159 @@
       (view-unmounted-ev :app.checkout/Modal      [:Modal 0])
       (view-unmounted-ev :app.sidebar/CheckoutItem [:CheckoutItem 0])
       (run-end-ev 0.6)]}))
+
+;; ---- rf2-5qp4g — DISPATCH source-kind enrichment fixtures ----------------
+;;
+;; Each closed-set substrate-internal `:source` value (rf2-ejtpd:
+;; `:after-timer`, `:machine-spawn`, `:fx-dispatch`,
+;; `:fx-dispatch-later`) produces a different rich label on the
+;; DISPATCH step. One fixture per kind exercises the projection +
+;; renderer path for that kind.
+
+(defn- dispatched-ev-rich
+  "Tag-rich dispatched trace primitive — preserves the canonical
+  `:rf.event/v` + `:source` of `dispatched-ev` AND admits extra tags
+  the substrate stamps for source-kind enrichment (parent-dispatch-id,
+  source-detail). Mirrors the shape `re-frame.router/emit-dispatched-
+  trace` produces under rf2-ejtpd."
+  [event source extra-tags]
+  (ev :rf.event :rf.event/dispatched
+      (merge {:rf.event/v event :source source} extra-tags)))
+
+(defn after-timer-source-history
+  "Cascade triggered by a machine `:after` timer firing (rf2-ejtpd ·
+  rf2-5qp4g). The dispatched event is the synthetic
+  `[:rf.machine.timer/after-elapsed 250 <epoch> [:active :authenticating]]`
+  payload the substrate dispatches when the timer's delay elapses;
+  `:source :after-timer` rides the envelope.
+
+  Exercises the DISPATCH step's `from :after timer · 250ms on
+  [:active :authenticating]` rich chrome."
+  []
+  (single-epoch-history
+    {:epoch-id 12
+     :event    [:ws/connection
+                [:rf.machine.timer/after-elapsed 250 41
+                 [:active :authenticating]]]
+     :trace-events
+     [(dispatched-ev-rich
+        [:ws/connection
+         [:rf.machine.timer/after-elapsed 250 41
+          [:active :authenticating]]]
+        :after-timer
+        {:rf.trace/call-site {:file "src/app/ws.cljs" :line 22}})
+      (run-end-ev 0.3)]}))
+
+(defn machine-spawn-source-history
+  "Cascade triggered by a spawn fx — substrate dispatches the spawned
+  actor's first event with `:source :machine-spawn` (rf2-ejtpd ·
+  rf2-5qp4g). The synthetic-default path emits the spawned-id +
+  `[:rf.machine/spawned]` payload (rf2-ijm7).
+
+  Exercises the DISPATCH step's `from machine spawn ·
+  :checkout/worker` rich chrome."
+  []
+  (single-epoch-history
+    {:epoch-id 13
+     :event    [:checkout/worker [:rf.machine/spawned]]
+     :trace-events
+     [(dispatched-ev-rich
+        [:checkout/worker [:rf.machine/spawned]]
+        :machine-spawn
+        {:rf.trace/call-site {:file "src/app/checkout.cljs" :line 88}})
+      (db-changed-ev [[[:checkout :workers :worker-1] nil
+                       {:id :worker-1 :state :idle} :added]])
+      (run-end-ev 0.4)]}))
+
+(defn fx-dispatch-source-history
+  "Multi-record history: a parent cascade whose handler returned a
+  `:dispatch` fx, plus the resulting child cascade (rf2-ejtpd ·
+  rf2-5qp4g). The child's `:source :fx-dispatch` rides with
+  `:rf.trace/parent-dispatch-id` pointing back to the parent
+  cascade's `:dispatch-id` so the DISPATCH step's parent-epoch chip
+  resolves and renders as a click-to-navigate button."
+  []
+  [;; PARENT cascade — emits the :dispatch fx
+   (-> (epoch-record
+         {:epoch-id    20
+          :event       [:checkout/begin]
+          :dispatch-id 9001
+          :trace-events
+          [(dispatched-ev [:checkout/begin] :ui)
+           (db-changed-ev [[[:checkout :phase] :idle :began :modified]])
+           (do-fx-ev {:dispatch [:cart/add :apple]})
+           (fx-handled-ev :dispatch [:cart/add :apple] 0.1)
+           (run-end-ev 0.5)]}))
+   ;; CHILD cascade — emitted by the :dispatch fx; the panel
+   ;; head-fallback (`peek epoch-history`) lands on this record so
+   ;; the DISPATCH renderer reads `:source :fx-dispatch` with
+   ;; parent-dispatch-id 9001 → parent-epoch-id 20.
+   (-> (epoch-record
+         {:epoch-id    21
+          :event       [:cart/add :apple]
+          :dispatch-id 9002
+          :trace-events
+          [(dispatched-ev-rich
+             [:cart/add :apple]
+             :fx-dispatch
+             {:rf.trace/parent-dispatch-id 9001})
+           (db-changed-ev [[[:cart :items] [] [{:id :apple}] :modified]])
+           (run-end-ev 0.3)]})
+       (assoc :parent-dispatch-id 9001))])
+
+(defn fx-dispatch-later-source-history
+  "Multi-record history: a parent cascade whose handler returned a
+  `:dispatch-later` fx, plus the resulting child cascade fired by
+  the timer (rf2-ejtpd · rf2-5qp4g).
+
+  The child's dispatched trace carries `:source :fx-dispatch-later`
+  + `:rf.trace/parent-dispatch-id` 9001 + the rich
+  `:rf.event/source-detail {:ms 500}` tag so the DISPATCH step
+  renders the original scheduled delay alongside the kind label and
+  the parent-epoch link."
+  []
+  [;; PARENT cascade — emits the :dispatch-later fx
+   (-> (epoch-record
+         {:epoch-id    22
+          :event       [:checkout/begin]
+          :dispatch-id 9001
+          :trace-events
+          [(dispatched-ev [:checkout/begin] :ui)
+           (do-fx-ev {:dispatch-later
+                      {:ms 500 :dispatch [:checkout/retry-prompt]}})
+           (fx-handled-ev :dispatch-later
+                          {:ms 500 :dispatch [:checkout/retry-prompt]}
+                          0.1)
+           (run-end-ev 0.4)]}))
+   ;; CHILD cascade — fired 500ms later by the timer
+   (-> (epoch-record
+         {:epoch-id    23
+          :event       [:checkout/retry-prompt]
+          :dispatch-id 9003
+          :trace-events
+          [(dispatched-ev-rich
+             [:checkout/retry-prompt]
+             :fx-dispatch-later
+             {:rf.trace/parent-dispatch-id 9001
+              :rf.event/source-detail      {:ms 500}})
+           (db-changed-ev [[[:checkout :phase] :began :prompting :modified]])
+           (run-end-ev 0.5)]})
+       (assoc :parent-dispatch-id 9001))])
+
+(defn fx-dispatch-orphaned-source-history
+  "Child cascade with `:source :fx-dispatch` whose parent has aged
+  out of the buffer (rf2-5qp4g). Exercises the unresolved
+  parent-epoch chrome — a muted plain span carrying the
+  parent-dispatch-id so the operator sees the lineage even when the
+  parent isn't in the ring."
+  []
+  (single-epoch-history
+    {:epoch-id 24
+     :event    [:cart/sync]
+     :trace-events
+     [(dispatched-ev-rich
+        [:cart/sync]
+        :fx-dispatch
+        ;; No matching parent epoch in this single-record history
+        {:rf.trace/parent-dispatch-id 99999})
+      (run-end-ev 0.2)]}))

--- a/tools/xray/testbeds/panel_gallery/gallery_epoch.cljs
+++ b/tools/xray/testbeds/panel_gallery/gallery_epoch.cljs
@@ -12,19 +12,24 @@
 
   ## Section-coverage table
 
-  | Variant                | Sections exercised                                 |
-  |------------------------|----------------------------------------------------|
-  | `vanilla-db`           | DISPATCH · COEFFECT · HANDLER (db) · APP-DB DIFF · SUBSCRIPTIONS · VIEWS |
-  | `reg-event-fx`         | DISPATCH · HANDLER (fx) · APP-DB DIFF · FX (✓ + ✗ + header counters) |
-  | `machine-driven`       | DISPATCH · HANDLER (machine: TRANSITION · GUARDS · LIFECYCLE · AFTER-TIMERS · DATA-REDUCTION · SNAPSHOT-DIFF) · APP-DB DIFF · FX |
-  | `schema-violations`    | DISPATCH · HANDLER (db, with rolled-back app-db violation sub-block + downstream mute) · SCHEMA HOT-RELOAD tail (rf2-xgeag) |
-  | `child-dispatches`     | DISPATCH · HANDLER (fx) · APP-DB DIFF · FX · CHILD DISPATCHES (resolved + not-in-buffer) |
-  | `long-step`            | DISPATCH · HANDLER (fx, 42ms · long-step chrome) · APP-DB DIFF · FX (28ms long-step) · SUBSCRIPTIONS · VIEWS |
-  | `flow-firing`          | DISPATCH · HANDLER (db) · APP-DB DIFF · FLOW · FX · SUBSCRIPTIONS · VIEWS |
-  | `empty`                | empty-state — no epochs (`:no-focus`)              |
-  | `no-events`            | cold pipeline — one epoch with empty `:trace-events` |
-  | `unmounted-views`      | DISPATCH · HANDLER (db) · SUBSCRIPTIONS · VIEWS (re-renders + UNMOUNTED sub-section — rf2-gmw1i) |
-  | `disposed-subs`        | DISPATCH · HANDLER (db) · SUBSCRIPTIONS (recompute + DISPOSED sub-section — rf2-wpfjo) |
+  | Variant                  | Sections exercised                                 |
+  |--------------------------|----------------------------------------------------|
+  | `vanilla-db`             | DISPATCH · COEFFECT · HANDLER (db) · APP-DB DIFF · SUBSCRIPTIONS · VIEWS |
+  | `reg-event-fx`           | DISPATCH · HANDLER (fx) · APP-DB DIFF · FX (✓ + ✗ + header counters) |
+  | `machine-driven`         | DISPATCH · HANDLER (machine: TRANSITION · GUARDS · LIFECYCLE · AFTER-TIMERS · DATA-REDUCTION · SNAPSHOT-DIFF) · APP-DB DIFF · FX |
+  | `schema-violations`      | DISPATCH · HANDLER (db, with rolled-back app-db violation sub-block + downstream mute) · SCHEMA HOT-RELOAD tail (rf2-xgeag) |
+  | `child-dispatches`       | DISPATCH · HANDLER (fx) · APP-DB DIFF · FX · CHILD DISPATCHES (resolved + not-in-buffer) |
+  | `long-step`              | DISPATCH · HANDLER (fx, 42ms · long-step chrome) · APP-DB DIFF · FX (28ms long-step) · SUBSCRIPTIONS · VIEWS |
+  | `flow-firing`            | DISPATCH · HANDLER (db) · APP-DB DIFF · FLOW · FX · SUBSCRIPTIONS · VIEWS |
+  | `empty`                  | empty-state — no epochs (`:no-focus`)              |
+  | `no-events`              | cold pipeline — one epoch with empty `:trace-events` |
+  | `unmounted-views`        | DISPATCH · HANDLER (db) · SUBSCRIPTIONS · VIEWS (re-renders + UNMOUNTED sub-section — rf2-gmw1i) |
+  | `disposed-subs`          | DISPATCH · HANDLER (db) · SUBSCRIPTIONS (recompute + DISPOSED sub-section — rf2-wpfjo) |
+  | `after-timer-source`     | DISPATCH source-kind enrichment (rf2-5qp4g) — `from :after timer · 250ms on [:active :authenticating]` |
+  | `machine-spawn-source`   | DISPATCH source-kind enrichment (rf2-5qp4g) — `from machine spawn · :checkout/worker` |
+  | `fx-dispatch-source`     | DISPATCH source-kind enrichment (rf2-5qp4g) — `from fx :dispatch · parent epoch #20` (parent in buffer) |
+  | `fx-dispatch-later-source` | DISPATCH source-kind enrichment (rf2-5qp4g) — `from fx :dispatch-later · 500ms · parent epoch #22` |
+  | `fx-dispatch-orphan`     | DISPATCH source-kind enrichment (rf2-5qp4g) — orphan path: parent dispatch-id 99999 not in buffer (muted unresolved chip) |
 
   ## Why seed via `:rf.xray/sync-epoch-history`
 
@@ -195,13 +200,74 @@
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
 
+  ;; ----- 12. :after-timer source enrichment (rf2-5qp4g) ----------------
+  (story/reg-variant :story.xray.epoch/after-timer-source
+    {:doc        "Cascade dispatched by a machine `:after` timer firing
+                 (rf2-ejtpd + rf2-5qp4g). The DISPATCH step renders
+                 `from :after timer · 250ms on [:active :authenticating]` —
+                 the kind label, the delay-ms chip, and the
+                 source-state-path as a click-to-source affordance."
+     :events     [[:rf.xray/sync-epoch-history (fixtures/after-timer-source-history)]]
+     :tags       #{:dev :state/small}
+     :substrates #{:reagent}})
+
+  ;; ----- 13. :machine-spawn source enrichment (rf2-5qp4g) --------------
+  (story/reg-variant :story.xray.epoch/machine-spawn-source
+    {:doc        "Cascade dispatched by a spawn fx (rf2-ejtpd +
+                 rf2-5qp4g). The DISPATCH step renders
+                 `from machine spawn · :checkout/worker` — the kind label
+                 + the spawned actor-id."
+     :events     [[:rf.xray/sync-epoch-history (fixtures/machine-spawn-source-history)]]
+     :tags       #{:dev :state/small}
+     :substrates #{:reagent}})
+
+  ;; ----- 14. :fx-dispatch source enrichment (rf2-5qp4g) ----------------
+  (story/reg-variant :story.xray.epoch/fx-dispatch-source
+    {:doc        "Multi-record history: a parent cascade emits a
+                 `:dispatch` fx; the child cascade is the head record
+                 (rf2-ejtpd + rf2-5qp4g). The DISPATCH step renders
+                 `from fx :dispatch · parent epoch #20` — the kind
+                 label + a click-to-navigate parent-epoch chip resolved
+                 against the in-buffer parent."
+     :events     [[:rf.xray/sync-epoch-history (fixtures/fx-dispatch-source-history)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 15. :fx-dispatch-later source enrichment (rf2-5qp4g) ----------
+  (story/reg-variant :story.xray.epoch/fx-dispatch-later-source
+    {:doc        "Multi-record history: a parent cascade emits a
+                 `:dispatch-later` fx (500ms); the timer-fired child
+                 cascade is the head record (rf2-ejtpd + rf2-5qp4g).
+                 The DISPATCH step renders
+                 `from fx :dispatch-later · 500ms · parent epoch #22` —
+                 the kind label, the original scheduled delay, and the
+                 parent-epoch navigation link."
+     :events     [[:rf.xray/sync-epoch-history (fixtures/fx-dispatch-later-source-history)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 16. :fx-dispatch orphan (parent aged out) (rf2-5qp4g) ---------
+  (story/reg-variant :story.xray.epoch/fx-dispatch-orphan
+    {:doc        "Defensive `:fx-dispatch` variant: the child cascade's
+                 parent-dispatch-id has no matching epoch in the buffer
+                 (the parent aged out of the ring). The DISPATCH step
+                 renders the kind label + the unresolved parent chip
+                 (`parent dispatch #99999 (not in buffer)`) — muted
+                 plain span, no dead click affordance."
+     :events     [[:rf.xray/sync-epoch-history (fixtures/fx-dispatch-orphaned-source-history)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
   ;; ----- workspace ---------------------------------------------------
   (story/reg-workspace :Workspace.xray.epoch/all
-    {:doc      "All eleven Epoch panel variants in one auto-grid.
+    {:doc      "All sixteen Epoch panel variants in one auto-grid.
                 Scroll to see the cascade across vanilla-db /
                 reg-event-fx / machine-driven / schema-violations /
                 child-dispatches / long-step / flow-firing / empty /
-                no-events / unmounted-views / disposed-subs."
+                no-events / unmounted-views / disposed-subs and the
+                rf2-5qp4g per-source-kind enrichment variants
+                (after-timer / machine-spawn / fx-dispatch /
+                fx-dispatch-later / fx-dispatch-orphan)."
      :layout   :variants-grid
      :story    :story.xray.epoch
      :columns  2


### PR DESCRIPTION
Per **rf2-5qp4g** (consuming **rf2-ejtpd**'s substrate-internal `:source` values), the DISPATCH step's source label adapts to the closed set — the bare `from <source>` chrome gains per-kind rich chrome so the operator reads which timer fired, which actor spawned, which parent cascade chained into this one — without leaving the panel.

## Per-source-kind label inventory

| `:source`            | Rendered label                                              | Click affordance |
|----------------------|-------------------------------------------------------------|------------------|
| `:after-timer`       | `from :after timer · 250ms on [:active :authenticating]`    | state-path click-to-source on machine spec via `:rf.machine/source-coords` (rf2-8bp3) |
| `:machine-spawn`     | `from machine spawn · :child-actor-id`                      | none (actor-id is gensym'd; follow-on) |
| `:fx-dispatch`       | `from fx :dispatch · parent epoch #142`                     | parent-epoch chip click-to-navigate via `:rf.xray/focus-epoch` (new event, rf2-5qp4g) |
| `:fx-dispatch-later` | `from fx :dispatch-later · 500ms · parent epoch #142`       | parent-epoch + delay-ms surfaces from `:rf.event/source-detail :ms` |
| `:always`            | `from :always` (defensive — rides microstep trace, not DISPATCH) | — |
| `:ui` / `:frame-init` / `:test-harness` / `:unknown` | `from <source>` (unchanged) | call-site click-to-source per §9.1.6.1 |

When the parent-dispatch-id has no matching epoch in the buffer (root cascade or aged out), the chip degrades to a muted `parent dispatch #N (not in buffer)` span — operator still sees the lineage, no broken click affordance.

## Substrate-side additions (consumed by the renderer)

- `implementation/core/src/re_frame/router.cljc`: `build-envelope` threads `:source-detail` off opts; `emit-dispatched-trace` stamps it as `:rf.event/source-detail` on the trace when present.
- `implementation/core/src/re_frame/fx.cljc`: `:dispatch-later` stamps `:source-detail {:ms ms}` alongside `:source :fx-dispatch-later` so the renderer surfaces the originally scheduled delay.

## Tool-side additions

- `tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc` — `source-enrichment` dispatch attaches a per-kind `:source-enrichment` map to the DISPATCH row; `find-parent-epoch` helper (reverse of `find-child-epoch`).
- `tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs` — `dispatch-source-enriched-label` dispatcher + per-kind label fns; `render-dispatch-step` accepts `epoch-history` via ctx; shared `state-path-affordance` / `parent-epoch-affordance` helpers.
- `tools/xray/src/day8/re_frame2_xray/spine.cljs` — `:rf.xray/focus-epoch` `reg-event-db` (takes epoch-id, defers to `focus-cascade-reducer` once `dispatch-id-for-epoch` resolves).

## Spec/021 updates

- New **§9.1.6.3 DISPATCH source-kind enrichment** documents the per-kind label inventory, projection enrichment shape, parent-epoch resolution, test-id surface, and the substrate stamp contract.
- §9.1.10 Events table adds `:rf.xray/focus-epoch`.
- §9.1.10.1 Substrate tag dependencies extends the `:dispatch` row's canonical-tags list with `:rf.trace/parent-dispatch-id` + `:rf.event/source-detail`.

## Tests

- **Projection** (`projection_cljs_test.cljc`): 8 new deftests covering each `:source` kind's enrichment (after-timer rich shape + defensive degrade, machine-spawn, fx-dispatch with/without parent, fx-dispatch-later with/without `:ms`, vanilla sources untouched) + `find-parent-epoch`.
- **View** (`view_cljs_test.cljs`): 8 new deftests covering the per-kind rendered hiccup — after-timer label + delay-chip + state-path affordance, machine-spawn label + actor chip, fx-dispatch resolved-parent button, fx-dispatch-later delay-chip + parent button, unresolved parent (muted span variant), no-history fallback, defensive no-enrichment degrade, `:always` label.
- **Spine** (`spine_cljs_test.cljs`): 3 new deftests for `dispatch-id-for-epoch` (trace-walk path, literal `:dispatch-id` fallback, missing → nil).
- **Registry snapshot** updated to include `:rf.xray/focus-epoch`.

## Story variants (5 new)

`:story.xray.epoch/after-timer-source`, `machine-spawn-source`, `fx-dispatch-source`, `fx-dispatch-later-source`, `fx-dispatch-orphan` (the muted-unresolved variant). Section-coverage table updated.

## Quality gates

- `tools/xray` JVM tests (`clojure -M:test`): **939 tests, 3654 assertions** (was 930 → +9 new tests). PASS.
- `implementation/core` JVM tests: **796 tests, 3708 assertions**. PASS.
- `implementation/machines` JVM tests: **296 tests, 976 assertions**. PASS.
- `bash scripts/test-fast-pr.sh`: PASS (CLJS node-test 4772 tests / 15532 assertions; markdown link gate; per-spec gates).
- `npm run test:bundle-isolation`: PASS.
- `npm run test:perf-bundle`: PASS.
- `npm run test:elision`: PASS (39/39 absent in production).
- `npm run test:xray-feature-gate:smoke`: PASS (3 scenarios).

Closes rf2-5qp4g.