### PR TITLE
feat(xray/stories): add edn-inspector grammar-edge variants — set-diff + boolean-toggle + vector-of-maps + nil-vs-missing + numeric-near-equal + redacted-context (rf2-yaajg)

### DIFF
--- a/tools/xray/testbeds/panel_gallery/fixtures_edn_inspector.cljs
+++ b/tools/xray/testbeds/panel_gallery/fixtures_edn_inspector.cljs
@@ -339,3 +339,90 @@
    :opts  {:header            "All affordances at once"
            :popup-affordance? true
            :zoomable?         true}})
+
+;; =========================================================================
+;; grammar-edge diff fixtures (rf2-yaajg)
+;; =========================================================================
+;;
+;; Six additional before/after pairs that pin grammar edges the
+;; canonical added/removed/modified/full/nested coverage doesn't
+;; reach: set-diff ops, boolean primitive toggle, vector-of-maps
+;; per-element changes, nil-vs-missing key distinction, near-equal
+;; float non-collapse, and a deeply nested redacted-sentinel
+;; appearance. Each fixture pins ONE engine behaviour so visual
+;; regressions surface in isolation.
+
+(defn diff-set-mixed
+  "Set diff with both add and remove ops in the same set:
+  `#{:a :b :c}` → `#{:a :b :d}`. `:c` is removed, `:d` is added,
+  `:a` and `:b` are unchanged. Sets have no positional identity
+  so the engine routes through key-side glyph treatment — `:c`
+  paints `−`, `:d` paints `+`."
+  []
+  {:before #{:a :b :c}
+   :value  #{:a :b :d}})
+
+(defn diff-boolean-toggle
+  "Simplest possible scalar diff — `{:enabled? true}` →
+  `{:enabled? false}`. Verifies the `~` value-side glyph + `←
+  changed from true` suffix render cleanly for the boolean leaf
+  case."
+  []
+  {:before {:enabled? true}
+   :value  {:enabled? false}})
+
+(defn diff-vector-of-maps
+  "The canonical `[{:id 1 :n 5} {:id 2 :n 8}]` → `[{:id 1 :n 6}
+  {:id 2 :n 8}]` shape — a vector of record-shaped maps where
+  one element's inner field changed and the other is unchanged.
+  Every re-frame app-db carries this shape (lists of rows);
+  verifies per-element diff against per-vector-index walk."
+  []
+  {:before [{:id 1 :name "Ada"   :count 5}
+            {:id 2 :name "Grace" :count 8}]
+   :value  [{:id 1 :name "Ada"   :count 6}
+            {:id 2 :name "Grace" :count 8}]})
+
+(defn diff-nil-vs-missing
+  "Two distinct cases in one fixture demonstrating that
+  `nil`-valued keys are NOT the same as absent keys. Before:
+  `{:explicit-nil nil :present 1 :will-disappear 42}`. After:
+  `{:explicit-nil nil :present 1 :newly-nil nil}` — `:will-
+  disappear` is removed (`−` glyph), `:newly-nil` is added with
+  a nil value (`+` glyph), `:explicit-nil` stays nil-valued
+  unchanged (no glyph), and `:present` is unchanged. Confirms
+  the engine distinguishes `(contains? m k)` from `(some? (get
+  m k))`."
+  []
+  {:before {:explicit-nil   nil
+            :present        1
+            :will-disappear 42}
+   :value  {:explicit-nil nil
+            :present      1
+            :newly-nil    nil}})
+
+(defn diff-numeric-near-equal
+  "Near-equal-floats edge — `{:x 1.0 :y 2.0}` → `{:x 1.0000001
+  :y 2.0}`. Verifies the diff engine does NOT collapse nearly-
+  equal floats into `:same` (no epsilon comparison); the `:x`
+  row must paint `~` + render the full `← changed from 1.0`
+  suffix. `:y` stays untouched as a control."
+  []
+  {:before {:x 1.0 :y 2.0}
+   :value  {:x 1.0000001 :y 2.0}})
+
+(defn diff-redacted-context
+  "Redacted sentinel sitting three levels deep inside an
+  otherwise-clean tree — `{:session {:user {:password :rf/
+  redacted}}}` → `{:session {:user {:password \"hunter2\"}}}`.
+  Verifies R8's redaction-curated suffix (`← was redacted`)
+  composes with deep nesting; ancestors paint the `◴` children-
+  changed glyph + the rail; the leaf carries the curated suffix
+  rather than printing the sentinel keyword. Mirrors the shape
+  the real elision contract produces when an operator drills
+  into a path that was previously redacted."
+  []
+  {:before {:session {:user {:id 7 :password :rf/redacted}}
+            :status  :ok}
+   :value  {:session {:user {:id 7 :password "hunter2"}}
+            :status  :ok}})

--- a/tools/xray/testbeds/panel_gallery/gallery_edn_inspector.cljs
+++ b/tools/xray/testbeds/panel_gallery/gallery_edn_inspector.cljs
@@ -282,13 +282,85 @@
      :tags       #{:dev :feature/opts}
      :substrates #{:reagent}})
 
+  ;; ----- grammar-edge diffs (rf2-yaajg) -------------------------------
+  ;;
+  ;; Six additional diff variants that pin grammar edges the canonical
+  ;; added/removed/modified coverage doesn't reach: set ops, boolean
+  ;; toggle, vector-of-records, nil-vs-missing, near-equal floats,
+  ;; deep redaction. Each variant pins ONE engine behaviour for
+  ;; visual-regression isolation.
+
+  (story/reg-variant :story.xray.edn-inspector/diff-set-mixed
+    {:doc        "Set diff with both add and remove ops: `#{:a :b
+                 :c}` → `#{:a :b :d}`. Sets have no positional
+                 identity — `:c` paints `−`, `:d` paints `+`, both
+                 from the key-side glyph treatment."
+     :events     [[:panel-gallery.edn-inspector/seed! (fixtures/diff-set-mixed)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.edn-inspector/diff-boolean-toggle
+    {:doc        "Simplest scalar diff — `{:enabled? true}` →
+                 `{:enabled? false}`. Pins the `~` glyph + `←
+                 changed from true` suffix for the boolean leaf
+                 case."
+     :events     [[:panel-gallery.edn-inspector/seed! (fixtures/diff-boolean-toggle)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.edn-inspector/diff-vector-of-maps
+    {:doc        "Vector-of-records — `[{:id 1 :count 5} {:id 2
+                 :count 8}]` → `[{:id 1 :count 6} {:id 2 :count
+                 8}]`. The canonical app-db rows-of-records shape;
+                 verifies per-element walk against per-vector-
+                 index diff."
+     :events     [[:panel-gallery.edn-inspector/seed! (fixtures/diff-vector-of-maps)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.edn-inspector/diff-nil-vs-missing
+    {:doc        "`{:k nil}` vs `{}` distinction. Before carries
+                 `:will-disappear 42` and `:explicit-nil nil`;
+                 after replaces `:will-disappear` with `:newly-nil
+                 nil`. Verifies `(contains? m k)` is the
+                 discriminator — not `(some? (get m k))` — so the
+                 engine paints `−` for the removed key and `+` for
+                 the newly-present-but-nil key."
+     :events     [[:panel-gallery.edn-inspector/seed! (fixtures/diff-nil-vs-missing)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.edn-inspector/diff-numeric-near-equal
+    {:doc        "Near-equal floats — `1.0` vs `1.0000001`.
+                 Verifies the engine does NOT fold nearly-equal
+                 floats into `:same`; the `:x` row paints `~` +
+                 the full `← changed from 1.0` suffix. `:y` stays
+                 untouched as a control."
+     :events     [[:panel-gallery.edn-inspector/seed! (fixtures/diff-numeric-near-equal)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.edn-inspector/diff-redacted-context
+    {:doc        "`:rf/redacted` sentinel three levels deep —
+                 `{:session {:user {:password :rf/redacted}}}` →
+                 `{:session {:user {:password \"hunter2\"}}}`.
+                 Verifies R8's redaction-curated suffix composes
+                 with deep nesting; ancestors paint `◴` children-
+                 changed; the leaf carries `← was redacted`
+                 without printing the sentinel."
+     :events     [[:panel-gallery.edn-inspector/seed! (fixtures/diff-redacted-context)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
   ;; ----- workspace ----------------------------------------------------
   (story/reg-workspace :Workspace.xray.edn-inspector/all
     {:doc      "All edn-inspector widget variants in one auto-grid.
                 Scroll to see the renderer's response across scalar
                 / map (small / medium / large / nested / sentinel)
                 / vector / list / lazy-seq / set / record / uuid /
-                inst / diff (mixed-ops / vector / deep) / opts
+                inst / diff (mixed-ops / vector / deep / set-mixed
+                / boolean-toggle / vector-of-maps / nil-vs-missing
+                / numeric-near-equal / redacted-context) / opts
                 (zoomable / popup / card / header / header-hiccup
                 / site-id / shallow-depth / combined)."
      :layout   :variants-grid


### PR DESCRIPTION
## What

Six new diff variants on the edn-inspector gallery that pin grammar edges the existing canonical added/removed/modified coverage doesn't reach. Each variant pins ONE engine behaviour for visual-regression isolation, follows the rf2-n2jig single-fixture + single-description pattern, and tags `#{:dev :state/special}` per existing gallery convention.

## Variants (6)

1. **diff-set-mixed** — `#{:a :b :c}` → `#{:a :b :d}` ; set add+remove in one fixture. Sets have no positional identity, so the engine routes through key-side glyph treatment — `:c` paints `−`, `:d` paints `+`.
2. **diff-boolean-toggle** — `{:enabled? true}` → `{:enabled? false}` ; simplest possible scalar diff. Pins the `~` value-side glyph + `← changed from true` suffix for the boolean leaf case.
3. **diff-vector-of-maps** — `[{:id 1 :name "Ada" :count 5} {:id 2 :name "Grace" :count 8}]` → first row's `:count` bumped; second row unchanged. The canonical app-db rows-of-records shape every re-frame app carries.
4. **diff-nil-vs-missing** — `{:k nil}` vs `{}` distinction. Before: `{:explicit-nil nil :present 1 :will-disappear 42}`. After: `{:explicit-nil nil :present 1 :newly-nil nil}`. `:will-disappear` removed (`−`), `:newly-nil` added with nil value (`+`), `:explicit-nil` stays nil-valued unchanged. Verifies the engine uses `contains?` not `(some? (get m k))`.
5. **diff-numeric-near-equal** — `{:x 1.0}` → `{:x 1.0000001}` ; verifies floats are NOT folded into `:same` via epsilon comparison. `:x` row paints `~` + the full `← changed from 1.0` suffix.
6. **diff-redacted-context** — `:rf/redacted` sentinel three levels deep inside `{:session {:user {:password ...}}}`. Verifies R8's redaction-curated suffix (`← was redacted`) composes with deep nesting; ancestors paint `◴` children-changed glyph + rail; leaf carries the curated suffix without printing the sentinel keyword.

Gallery variant count grows from 24 to 30. The workspace doc string is updated to enumerate the new diff variants. Existing 24 variants unchanged.

## Coordination — rf2-k1k87

Sibling bead **rf2-k1k87** (P1 BUG — panel-gallery `/#/stories` renders empty; `:state/*` axis tags never registered + diff-mode-universal story-id grammar violation) is in flight in parallel. Its fix registers the `:state/*` canonical-tag axis that this gallery (and the broader 11-file gallery suite) depends on.

This PR uses `:state/special` tags matching the existing convention used by every other gallery variant in the suite — `gallery_app_db.cljs` (12 uses), `gallery_chrome.cljs` (~7 uses), `gallery_diff_mode_3.cljs` (~22 uses), the existing 24 `gallery_edn_inspector.cljs` variants, etc. The tag's registration is rf2-k1k87's responsibility, not this bead's. Once rf2-k1k87 merges the new variants here become canonical-tagged alongside the rest.

No file conflict: rf2-k1k87 touches `tools/story/src/re_frame/story/canonical.cljc` + `gallery_diff_mode_universal.cljs` + a new smoke test; this PR touches `gallery_edn_inspector.cljs` + `fixtures_edn_inspector.cljs`. Independent file surfaces.

## Quality gates (all PASS on this branch)

- `shadow-cljs compile :testbeds/panel-gallery`: **PASS** — 554 files, 0 warnings.
- `scripts/test-fast-pr.sh`: **PASS** — 4772 CLJS unit tests, 15532 assertions, 0 failures.
- `npm run test:browser`: **PASS** — 124 browser tests, 353 assertions, 0 failures.
- `npm run test:bundle-isolation`: **PASS** — 17 artefact entries, 35 internal sentinels absent.
- `npm run test:xray-feature-gate:smoke`: **PASS** — 3 scenarios, 10 matrix rows, 0 failures.

## Closes

Closes rf2-yaajg.