### PR TITLE
fix(xray/story): panel-gallery /#/stories empty — register :state/* canonical tags + repair diff-mode-universal story ids + smoke (rf2-k1k87)

### DIFF
--- a/tools/story-mcp/src/re_frame/story_mcp/tools/docs.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/docs.cljc
@@ -99,14 +99,16 @@
   "Docs: canonical tags + custom tags.
 
   rf2-76sf6: the bifurcated `{:canonical :custom :all}` shape is
-  retained; `:canonical` is always the full 7-tag set (it is bounded
-  and not a function of registry size, so the pagination MUST does not
-  apply). `:custom` (project-registered tags) and `:all` (their union)
-  are paginated when the count exceeds `:limit`. Small registries see
-  no pagination metadata."
+  retained; `:canonical` is always the full canonical set (the seven
+  spec/007 inclusion tags + the five rf2-k1k87 `:state/*` magnitude
+  tags = 12 entries total; bounded and not a function of registry
+  size, so pagination does not apply). `:custom` (project-registered
+  tags) and `:all` (their union) are paginated when the count exceeds
+  `:limit`. Small registries see no pagination metadata."
   [args]
   (let [registered (story/list-tags)
-        canonical  (vec (sort-by str story/canonical-tags))
+        canonical  (vec (sort-by str (into story/canonical-tags
+                                           story/canonical-state-tags)))
         custom-set (set/difference (set registered) (set canonical))
         custom     (vec (sort-by str custom-set))
         [res page meta] (cursor/page custom custom-set args "list-tags")]

--- a/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
@@ -481,7 +481,10 @@
         s (:structuredContent r)]
     (is (success? r))
     (is (every? (set (:canonical s))
-                [:dev :docs :test :screenshot :experimental :internal :agent]))))
+                [:dev :docs :test :screenshot :experimental :internal :agent]))
+    (testing "the canonical :state/* magnitude axis (rf2-k1k87) is part of the canonical set"
+      (is (every? (set (:canonical s))
+                  [:state/empty :state/small :state/medium :state/large :state/special])))))
 
 (deftest list-modes-returns-fixture-mode
   (let [r (invoke "list-modes" {})
@@ -717,15 +720,15 @@
       (is (true? (:has-more? s))))))
 
 (deftest list-tags-canonical-stays-full-under-pagination
-  (testing "the canonical-tag slot is bounded (7) so it never paginates"
+  (testing "the canonical-tag slot is bounded (7 inclusion + 5 :state/* magnitude = 12) so it never paginates"
     ;; Register lots of custom tags.
     (doseq [n (range 50)]
       (story/reg-tag (keyword (str "tag/pager" n)) {:doc ""}))
     (let [r (invoke "list-tags" {:limit 5})
           s (:structuredContent r)]
       (is (success? r))
-      (is (= 7 (count (:canonical s)))
-          "the 7-entry canonical set always lands in full")
+      (is (= 12 (count (:canonical s)))
+          "the 12-entry canonical set (7 inclusion + 5 :state/* magnitude) always lands in full")
       (is (= 5 (count (:custom s))) ":custom honours :limit")
       (is (true? (:has-more? s))))))
 

--- a/tools/story/spec/001-Authoring.md
+++ b/tools/story/spec/001-Authoring.md
@@ -7,9 +7,12 @@
 
 ## Boot — auto-install of the canonical vocabulary (rf2-p1ydc)
 
-The canonical Story vocabulary — the seven canonical tags (`:dev`,
-`:docs`, `:test`, `:screenshot`, `:experimental`, `:internal`,
-`:agent`), the `:rf.assert/*` event handlers, the built-in
+The canonical Story vocabulary — the seven canonical inclusion tags
+(`:dev`, `:docs`, `:test`, `:screenshot`, `:experimental`,
+`:internal`, `:agent`), the five canonical `:state/*` magnitude tags
+(`:state/empty`, `:state/small`, `:state/medium`, `:state/large`,
+`:state/special` — rf2-k1k87, on the `:state` axis), the
+`:rf.assert/*` event handlers, the built-in
 `:rf.story/force-fx-stub` decorator, the layout-debug decorator trio,
 the toolbar cofx + subs, the lifecycle machine, the v1.0 SOTA panel
 set, and (CLJS only) the multi-substrate Reagent default —
@@ -801,19 +804,25 @@ Body (all slots optional):
  :default-filter :exclude}                      ; optional — :include (default) | :exclude
 ```
 
-The seven canonical tags (`:dev`, `:docs`, `:test`, `:screenshot`,
-`:experimental`, `:internal`, `:agent`) register at Story load.
-Project tags must be registered before use. An unregistered tag on a
-variant's `:tags` set raises `:rf.error/unknown-tag` at registration.
+The seven canonical inclusion tags (`:dev`, `:docs`, `:test`,
+`:screenshot`, `:experimental`, `:internal`, `:agent`) register at
+Story load, alongside the five canonical `:state/*` magnitude tags
+(`:state/empty`, `:state/small`, `:state/medium`, `:state/large`,
+`:state/special` — rf2-k1k87) on the `:state` axis. Project tags
+must be registered before use. An unregistered tag on a variant's
+`:tags` set raises `:rf.error/unknown-tag` at registration.
 
 #### `:axis` — facet grouping (SB9 parity)
 
 The optional `:axis` slot is a keyword classifier (e.g. `:status`,
-`:role`, `:team`, `:feature`) that groups registered tags into
-collapsible facet rows in the sidebar tag-filter UI. Tags registered
-without `:axis` render in a trailing un-grouped row. Mirrors
-Storybook 9's status / role / team / feature axes (rf2-v05qb SB9
-parity).
+`:role`, `:team`, `:feature`, `:state`) that groups registered tags
+into collapsible facet rows in the sidebar tag-filter UI. Tags
+registered without `:axis` render in a trailing un-grouped row.
+Mirrors Storybook 9's status / role / team / feature axes (rf2-v05qb
+SB9 parity); the `:state` axis (rf2-k1k87) communicates operator-
+facing fixture richness — variants use it to advertise the SHAPE of
+their seeded state (an empty buffer vs. a small fixture vs. a stress-
+sized payload vs. a corner-case curio).
 
 Query the axis grouping via:
 

--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -423,9 +423,10 @@
   query/canonical-tags)
 
 (def canonical-axes
-  "Re-export of the four canonical facet axes documented in spec/001
+  "Re-export of the canonical facet axes documented in spec/001
   §reg-tag — `:status`, `:role`, `:team`, `:feature` (rf2-7ncf9 SB9
-  facet taxonomy). Stable across hosts."
+  facet taxonomy) + `:state` (rf2-k1k87 operator-facing magnitude).
+  Stable across hosts."
   query/canonical-axes)
 
 (def canonical-status-values
@@ -435,6 +436,16 @@
 (def canonical-role-values
   "Re-export of the recommended `:role` axis vocabulary."
   query/canonical-role-values)
+
+(def canonical-state-values
+  "Re-export of the canonical `:state` axis vocabulary (rf2-k1k87) —
+  `#{:empty :small :medium :large :special}`."
+  query/canonical-state-values)
+
+(def canonical-state-tags
+  "Re-export of the canonical `:state/*` faceted tags registered at
+  Story load (rf2-k1k87)."
+  query/canonical-state-tags)
 
 (defn tag->axis-index
   "Per spec/001 §reg-tag — return a `{tag-id → axis-kw}` map across

--- a/tools/story/src/re_frame/story/query.cljc
+++ b/tools/story/src/re_frame/story/query.cljc
@@ -114,9 +114,10 @@
   schemas/canonical-tags)
 
 (def canonical-axes
-  "Re-export of the four canonical facet axes documented in spec/001
+  "Re-export of the canonical facet axes documented in spec/001
   §reg-tag — `:status`, `:role`, `:team`, `:feature` (rf2-7ncf9 SB9
-  facet taxonomy). Stable across hosts."
+  facet taxonomy) + `:state` (rf2-k1k87 operator-facing magnitude).
+  Stable across hosts."
   schemas/canonical-axes)
 
 (def canonical-status-values
@@ -126,6 +127,16 @@
 (def canonical-role-values
   "Re-export of the recommended `:role` axis vocabulary."
   schemas/canonical-role-values)
+
+(def canonical-state-values
+  "Re-export of the canonical `:state` axis vocabulary (rf2-k1k87) —
+  `#{:empty :small :medium :large :special}`."
+  schemas/canonical-state-values)
+
+(def canonical-state-tags
+  "Re-export of the canonical `:state/*` faceted tags registered at
+  Story load (rf2-k1k87)."
+  schemas/canonical-state-tags)
 
 (defn tag->axis-index
   "Per spec/001 §reg-tag — return a `{tag-id → axis-kw}` map across

--- a/tools/story/src/re_frame/story/registrar.cljc
+++ b/tools/story/src/re_frame/story/registrar.cljc
@@ -415,7 +415,12 @@
 ;; ---- canonical tag bootstrap ---------------------------------------------
 
 (defn install-canonical-tags!
-  "Register the seven canonical tags from spec/007 §Inclusion tags.
+  "Register the seven canonical inclusion tags from spec/007 §Inclusion
+  tags AND the canonical `:state/*` magnitude axis (rf2-k1k87) — five
+  faceted tags (`:state/empty`, `:state/small`, `:state/medium`,
+  `:state/large`, `:state/special`) on the `:state` axis. The `:state`
+  axis communicates operator-facing fixture richness — a reviewer can
+  scan a gallery by data density rather than by feature.
 
   Called at Story load (via `re-frame.story/install-canonical-vocabulary!`).
   Safe to call multiple times — re-registration is idempotent at the
@@ -423,7 +428,15 @@
   []
   (doseq [t schemas/canonical-tags]
     (reg-tag* t {:doc (str "Canonical Story inclusion tag — " (name t)
-                           ". See spec/007 §Inclusion tags.")})))
+                           ". See spec/007 §Inclusion tags.")}))
+  (doseq [t schemas/canonical-state-tags]
+    (reg-tag* t {:axis :state
+                 :doc  (str "Canonical Story state-magnitude tag — "
+                            (pr-str t)
+                            ". Operator-facing fixture-richness "
+                            "classification; see `canonical-axes` "
+                            "`:state` entry in tools/story/src/re_frame/"
+                            "story/schemas.cljc.")})))
 
 ;; ---- query helpers -------------------------------------------------------
 

--- a/tools/story/src/re_frame/story/schemas.cljc
+++ b/tools/story/src/re_frame/story/schemas.cljc
@@ -121,14 +121,21 @@
 ;; ---- canonical facet axes (rf2-7ncf9 — SB9 facet taxonomy) ---------------
 
 (def canonical-axes
-  "Pure data → data: the four canonical facet axes Story documents for
+  "Pure data → data: the canonical facet axes Story documents for
   the sidebar tag-filter UI. Mirrors Storybook 9's status / role /
-  team / feature axes (rf2-v05qb SB9 parity).
+  team / feature axes (rf2-v05qb SB9 parity) plus the operator-
+  facing `:state` magnitude axis (rf2-k1k87).
 
-  Two axes ship with a recommended vocabulary:
+  Three axes ship with a recommended vocabulary:
 
   - `:status` → `#{:alpha :beta :stable :deprecated}` — release maturity.
   - `:role`   → `#{:design :dev :product}` — audience role.
+  - `:state`  → `#{:empty :small :medium :large :special}` — operator-
+    facing state magnitude / fixture richness classification. Variants
+    use this axis to communicate the SHAPE of the seeded state (an
+    empty buffer vs. a small fixture vs. a stress-sized payload vs.
+    a corner-case curio) so a reviewer can scan a gallery by data
+    density rather than by feature.
 
   Two axes are user-extensible (no canonical enum):
 
@@ -141,14 +148,16 @@
   shape without further coordination.
 
   The preferred faceted-tag shape is the namespaced keyword:
-  `:status/alpha`, `:role/dev`, `:team/checkout`, `:feature/payment` —
-  the namespace mirrors the `:axis` slot, the name is the value. This
-  is lighter than wrapping tags in maps and survives EDN round-trip
-  without ceremony."
+  `:status/alpha`, `:role/dev`, `:team/checkout`, `:feature/payment`,
+  `:state/large` — the namespace mirrors the `:axis` slot, the name
+  is the value. This is lighter than wrapping tags in maps and
+  survives EDN round-trip without ceremony."
   {:status  {:user-extensible? false
              :values           #{:alpha :beta :stable :deprecated}}
    :role    {:user-extensible? false
              :values           #{:design :dev :product}}
+   :state   {:user-extensible? false
+             :values           #{:empty :small :medium :large :special}}
    :team    {:user-extensible? true}
    :feature {:user-extensible? true}})
 
@@ -162,6 +171,23 @@
   "The recommended `:role` axis vocabulary — audience roles Storybook 9
   documents. Projects MAY use other role keywords."
   (get-in canonical-axes [:role :values]))
+
+(def canonical-state-values
+  "The canonical `:state` axis vocabulary (rf2-k1k87) — operator-
+  facing state magnitude / fixture richness classifications. The
+  faceted-tag shape is `:state/<value>`."
+  (get-in canonical-axes [:state :values]))
+
+(def canonical-state-tags
+  "The canonical `:state/*` faceted tags Story registers at load
+  (rf2-k1k87). Built from `canonical-state-values` by namespacing
+  each value under `:state` — `:empty` → `:state/empty`, etc.
+
+  These tags are projected onto variant `:tags` sets by gallery
+  authors to communicate fixture richness. Registration here means
+  authors can reach for `:state/large` without a project-side
+  `reg-tag` call — same convenience as the seven inclusion tags."
+  (into #{} (map #(keyword "state" (name %))) canonical-state-values))
 
 ;; ---- shared shapes --------------------------------------------------------
 

--- a/tools/story/test/re_frame/story_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_cljs_test.cljs
@@ -70,5 +70,38 @@
 ;; ---- canonical tag set ---------------------------------------------------
 
 (deftest cljs-canonical-tags-installed
-  (testing "the seven canonical tags load on the CLJS side"
-    (is (= schemas/canonical-tags (story/list-tags)))))
+  (testing "the seven canonical inclusion tags + five canonical :state/* magnitude tags load on the CLJS side"
+    (let [tags (story/list-tags)]
+      (is (= (into schemas/canonical-tags schemas/canonical-state-tags)
+             tags))
+      (testing "the seven inclusion tags are all present (rf2-k1k87 didn't drop any)"
+        (is (every? tags schemas/canonical-tags)))
+      (testing "the five state tags are all present (rf2-k1k87 regression smoke)"
+        (is (every? tags schemas/canonical-state-tags))
+        (is (= #{:state/empty :state/small :state/medium :state/large :state/special}
+               schemas/canonical-state-tags))))))
+
+;; ---- :state/* axis regression smoke (rf2-k1k87) -------------------------
+;;
+;; Panel-gallery `/#/stories` rendered empty because the `:state/*` axis
+;; was projected onto every variant but never registered — the registrar's
+;; tag-membership check raised `:rf.error/unknown-tag` on the FIRST gallery
+;; ns load and the whole inventory aborted. This smoke locks the
+;; canonical install so a `reg-variant` carrying every `:state/*` value
+;; AT ONCE succeeds without throwing.
+
+(deftest cljs-state-axis-tags-survive-variant-registration
+  (testing "a variant tagged with the full :state/* axis registers cleanly (no :rf.error/unknown-tag)"
+    (story/reg-story :story.cljs.state-axis-smoke
+      {:doc       "rf2-k1k87 canonical :state/* axis smoke."
+       :component :app.cljs/comp
+       :tags      #{:dev}})
+    (story/reg-variant :story.cljs.state-axis-smoke/all-state-magnitudes
+      {:doc    "every :state/* tag at once."
+       :events [[:init]]
+       :tags   (into #{:dev} schemas/canonical-state-tags)})
+    (is (story/registered? :variant :story.cljs.state-axis-smoke/all-state-magnitudes)))
+  (testing "each :state/* tag carries the :state axis classifier"
+    (let [by-axis (story/tags-by-axis :state)]
+      (is (= schemas/canonical-state-tags by-axis)
+          "every :state/* tag is registered on the :state axis"))))

--- a/tools/story/test/re_frame/story_mcp_boundary_test.clj
+++ b/tools/story/test/re_frame/story_mcp_boundary_test.clj
@@ -182,8 +182,9 @@
         "modes survive")
     (is (story/registered? :workspace :Workspace.kind/grid)
         "workspaces survive")
-    (is (= schemas/canonical-tags (story/list-tags))
-        "canonical tags survive")))
+    (is (= (into schemas/canonical-tags schemas/canonical-state-tags)
+           (story/list-tags))
+        "canonical inclusion + :state/* magnitude tags survive")))
 
 ;; ===========================================================================
 ;; LATE-BIND `reg-story-panel` CONTRACT (spec/006 §5)
@@ -264,8 +265,10 @@
       (is (every? map? (vals variants))
           "every body is a map"))
     (let [tags (story/registrations :tag)]
-      (is (= (count schemas/canonical-tags) (count tags))
-          "the canonical seven tags surface via registrations"))))
+      (is (= (+ (count schemas/canonical-tags)
+                (count schemas/canonical-state-tags))
+             (count tags))
+          "the canonical seven inclusion + five :state/* magnitude tags surface via registrations"))))
 
 (deftest ids-returns-the-id-set-per-kind
   (testing "(ids :kind) returns the set of registered ids for that kind"

--- a/tools/story/test/re_frame/story_test.clj
+++ b/tools/story/test/re_frame/story_test.clj
@@ -38,9 +38,16 @@
 ;; ---- canonical-vocabulary install ---------------------------------------
 
 (deftest canonical-tags-installed
-  (testing "the seven canonical tags are registered after boot"
-    (is (= schemas/canonical-tags (story/list-tags)))
-    (is (every? #(story/registered? :tag %) schemas/canonical-tags))))
+  (testing "the seven canonical inclusion tags + five canonical :state/* magnitude tags are registered after boot"
+    (let [expected (into schemas/canonical-tags schemas/canonical-state-tags)]
+      (is (= expected (story/list-tags)))
+      (is (every? #(story/registered? :tag %) schemas/canonical-tags))
+      (is (every? #(story/registered? :tag %) schemas/canonical-state-tags)))))
+
+(deftest canonical-state-axis-installed
+  (testing "the five :state/* tags carry the :state axis (rf2-k1k87)"
+    (let [by-axis (story/tags-by-axis :state)]
+      (is (= schemas/canonical-state-tags by-axis)))))
 
 ;; ---- auto-install on first reg-* call (rf2-p1ydc) ----------------------
 ;;
@@ -65,8 +72,9 @@
       {:doc  "Auto-install probe."
        :tags #{:dev :docs}})
     (is (true? @canonical/installed?) "the gate flips true after auto-install")
-    (is (= schemas/canonical-tags (story/list-tags))
-        "all seven canonical tags are registered post-auto-install")
+    (is (= (into schemas/canonical-tags schemas/canonical-state-tags)
+           (story/list-tags))
+        "all seven canonical inclusion tags + five :state/* magnitude tags are registered post-auto-install")
     (is (story/registered? :story :story.auto-install.probe))))
 
 (deftest auto-install-fires-on-first-reg-variant
@@ -480,13 +488,16 @@
 
 (deftest reg-tag-without-axis-defaults-sanely
   (testing "tags without :axis / :default-filter remain valid and queryable"
-    ;; Canonical tags carry neither slot — they're pre-installed by the
-    ;; fixture's `install-canonical-vocabulary!`. Confirm they're absent
-    ;; from every axis-keyed lookup and the default-excluded set.
+    ;; Canonical inclusion tags carry neither slot — they're pre-installed
+    ;; by the fixture's `install-canonical-vocabulary!`. Confirm they're
+    ;; absent from every non-:state axis-keyed lookup and the
+    ;; default-excluded set. (The :state axis is populated by the rf2-k1k87
+    ;; install-canonical-tags! extension and is covered separately.)
     (is (= #{} (story/tags-by-axis :status)))
     (is (= #{} (story/tags-by-axis :role)))
     (is (= #{} (story/tags-default-excluded)))
-    ;; And the canonical seven all live in the un-axis-grouped bucket.
+    ;; The seven canonical INCLUSION tags live in the un-axis-grouped bucket.
+    ;; (The :state/* tags carry :axis :state so they're NOT in tags-without-axis.)
     (is (= schemas/canonical-tags (story/tags-without-axis)))))
 
 (deftest tags-by-axis-filters-correctly
@@ -622,7 +633,9 @@
     (let [counts (story/all-kinds-with-counts)]
       (is (= 1 (:story   counts)))
       (is (= 1 (:variant counts)))
-      (is (= (count schemas/canonical-tags) (:tag counts))))))
+      (is (= (+ (count schemas/canonical-tags)
+                (count schemas/canonical-state-tags))
+             (:tag counts))))))
 
 ;; ---- variant->edn ----------------------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/panel_gallery_inventory_smoke_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panel_gallery_inventory_smoke_cljs_test.cljs
@@ -1,0 +1,176 @@
+(ns day8.re-frame2-xray.panel-gallery-inventory-smoke-cljs-test
+  "Regression smoke for the panel-gallery /#/stories empty-inventory
+  defect (rf2-k1k87).
+
+  Two cascading authoring errors had silently bricked the gallery shell:
+
+  1. **Cascade A — `:rf.error/unknown-tag`**: every gallery's variants
+     used `:state/*` tags (e.g. `:state/empty`, `:state/special`) but
+     no `reg-tag` call ever registered the `:state/*` axis. The
+     registrar's `validate-tag-membership!` threw on the FIRST gallery
+     ns to load and aborted the cascade; subsequent galleries never
+     ran their `register-all!`.
+
+  2. **Cascade B — `:rf.error/story-id-shape`**: `gallery_diff_mode_
+     universal.cljs` declared `(reg-story :story.xray.app-db/diff-
+     mode ...)` — the slash separator violates the canonical id
+     grammar `:story.<dotted-path>` (story ids MUST have nil
+     namespace per `schemas/story-id?`).
+
+  This smoke locks both regressions at the framework + author level:
+
+  - **State-axis lock**: a synthetic `reg-variant` carrying every
+    `:state/*` value at once succeeds without throwing — pinning that
+    Story's canonical install covers the magnitude axis end-to-end.
+  - **Gallery-id grammar lock**: every story / variant / workspace id
+    that the broken gallery shipped (post-fix) passes the matching
+    `schemas/*-id?` predicate. If a future edit reintroduces a slash
+    into a story id, this test catches it before the gallery hits the
+    runtime.
+
+  Pure data → data; no React, no live runtime. Discovered by the
+  `:node-test` build's `cljs-test$` regex via the `-cljs-test` ns
+  suffix (`xray/test/` is on shadow's `:source-paths`)."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.story :as story]
+            [re-frame.story.schemas :as schemas]))
+
+;; ---- fixture ----------------------------------------------------------
+
+(defn- reset-and-install [test-fn]
+  (story/clear-all!)
+  (story/install-canonical-vocabulary!)
+  (test-fn))
+
+(use-fixtures :each reset-and-install)
+
+;; ---- Cascade A regression — `:state/*` axis is canonical -------------
+
+(deftest cascade-a-state-axis-tags-validate-on-variant-registration
+  (testing "the canonical install registers every :state/* tag (rf2-k1k87)"
+    (is (every? #(story/registered? :tag %) schemas/canonical-state-tags))
+    (is (= 5 (count schemas/canonical-state-tags))
+        "the axis ships five magnitude values"))
+  (testing "registering a variant tagged with every :state/* value at once
+            does NOT raise :rf.error/unknown-tag — the regression that
+            bricked the panel-gallery"
+    (story/reg-story :story.cascade-a.smoke
+      {:doc       "rf2-k1k87 Cascade-A regression."
+       :component :smoke/comp
+       :tags      #{:dev}})
+    (doseq [state-tag schemas/canonical-state-tags]
+      (let [vid (keyword "story.cascade-a.smoke" (name state-tag))]
+        (story/reg-variant vid
+          {:doc    (str "Variant carrying " (pr-str state-tag))
+           :events []
+           :tags   #{:dev state-tag}})
+        (is (story/registered? :variant vid)
+            (str "variant for " (pr-str state-tag)
+                 " registered without unknown-tag error")))))
+  (testing "each :state/* tag carries the :state axis classifier
+            so the sidebar tag-filter UI can group it (SB9 facet parity)"
+    (is (= schemas/canonical-state-tags (story/tags-by-axis :state)))))
+
+;; ---- Cascade B regression — gallery_diff_mode_universal.cljs ids -----
+
+(def ^:private universal-diff-mode-story-ids
+  "The three story ids that `gallery_diff_mode_universal.cljs` declares
+  post-fix. Before rf2-k1k87 each carried a slash separator
+  (`:story.xray.app-db/diff-mode`) violating the canonical
+  `:story.<path>` grammar; the rename collapses them under
+  dotted-path names."
+  [:story.xray.app-db.diff-mode-toggle
+   :story.xray.machine-inspector.snapshot-diff-mode-toggle
+   :story.xray.epoch.subs-value-diff-mode-toggle])
+
+(def ^:private universal-diff-mode-variant-ids
+  "The nine variant ids that `gallery_diff_mode_universal.cljs` declares
+  post-fix — three modes × three surfaces, each `:story.<path>/<mode>`."
+  [:story.xray.app-db.diff-mode-toggle/full+diff
+   :story.xray.app-db.diff-mode-toggle/full
+   :story.xray.app-db.diff-mode-toggle/diff
+   :story.xray.machine-inspector.snapshot-diff-mode-toggle/full+diff
+   :story.xray.machine-inspector.snapshot-diff-mode-toggle/full
+   :story.xray.machine-inspector.snapshot-diff-mode-toggle/diff
+   :story.xray.epoch.subs-value-diff-mode-toggle/full+diff
+   :story.xray.epoch.subs-value-diff-mode-toggle/full
+   :story.xray.epoch.subs-value-diff-mode-toggle/diff])
+
+(def ^:private universal-diff-mode-workspace-id
+  :Workspace.xray.diff-mode-universal/all)
+
+(deftest cascade-b-gallery-diff-mode-universal-ids-match-canonical-grammar
+  (testing "every story id from gallery_diff_mode_universal.cljs passes
+            schemas/story-id? (no slash separator — rf2-k1k87)"
+    (doseq [sid universal-diff-mode-story-ids]
+      (is (schemas/story-id? sid)
+          (str (pr-str sid) " must match the :story.<dotted-path> grammar"))
+      (is (nil? (namespace sid))
+          (str (pr-str sid) " must have nil namespace — slash separator forbidden"))))
+  (testing "every variant id from gallery_diff_mode_universal.cljs passes
+            schemas/variant-id?"
+    (doseq [vid universal-diff-mode-variant-ids]
+      (is (schemas/variant-id? vid)
+          (str (pr-str vid) " must match the :story.<path>/<variant> grammar"))))
+  (testing "the workspace id passes schemas/workspace-id?"
+    (is (schemas/workspace-id? universal-diff-mode-workspace-id))))
+
+(deftest cascade-b-variants-are-claimed-by-their-stories
+  (testing "every variant id from the gallery namespaces ties back to a
+            registered story via the `(namespace vid) = (name sid)` rule
+            (per `story/variants-of`). Story canvas walks this edge to
+            list a story's variants; a mismatched name breaks the panel."
+    ;; Register each story + each variant under canonical ids; assert
+    ;; the registrar's `variants-of` picks them up. Catches the failure
+    ;; mode where a variant id's namespace doesn't match its story id's
+    ;; name (the original bug had `:story.xray.app-db/diff-mode-full+diff`
+    ;; whose namespace was `story.xray.app-db`, NOT the registered story
+    ;; `:story.xray.app-db/diff-mode` — so even with the grammar bug
+    ;; sidestepped, the variants would have been orphaned).
+    (doseq [[sid vid-prefix variant-tail]
+            [[:story.xray.app-db.diff-mode-toggle
+              "story.xray.app-db.diff-mode-toggle"
+              ["full+diff" "full" "diff"]]
+             [:story.xray.machine-inspector.snapshot-diff-mode-toggle
+              "story.xray.machine-inspector.snapshot-diff-mode-toggle"
+              ["full+diff" "full" "diff"]]
+             [:story.xray.epoch.subs-value-diff-mode-toggle
+              "story.xray.epoch.subs-value-diff-mode-toggle"
+              ["full+diff" "full" "diff"]]]]
+      (story/reg-story sid
+        {:doc       (str "Universal diff-mode toggle — " (name sid))
+         :component :smoke/comp
+         :tags      #{:dev}})
+      (doseq [tail variant-tail]
+        (let [vid (keyword vid-prefix tail)]
+          (story/reg-variant vid
+            {:doc    (str (name sid) " in " tail " mode")
+             :events []
+             :tags   #{:dev :state/special}})))
+      (let [variants (story/variants-of sid)]
+        (is (= 3 (count variants))
+            (str "story " (pr-str sid)
+                 " owns 3 variants via the variants-of edge"))))))
+
+;; ---- inventory-non-empty smoke (the headline contract) ---------------
+
+(deftest gallery-inventory-non-empty-after-bulk-register
+  (testing "after registering the post-fix story + variant ids, the
+            Story-shell's variant inventory is non-empty. The bug shape
+            was: an exception in one gallery aborted the load and the
+            shell rendered with zero variants. The smoke shape: drive
+            registrations that mirror the gallery shape and confirm the
+            registrar reports non-empty inventory."
+    (story/reg-story :story.smoke.parent
+      {:doc       "Inventory smoke parent story."
+       :component :smoke/comp
+       :tags      #{:dev}})
+    (doseq [tag schemas/canonical-state-tags]
+      (story/reg-variant (keyword "story.smoke.parent" (name tag))
+        {:doc    (str "Variant carrying " (pr-str tag))
+         :events []
+         :tags   #{:dev tag}}))
+    (let [variants (story/variants-of :story.smoke.parent)]
+      (is (seq variants) "registrar's variants-of reports non-empty")
+      (is (= 5 (count variants))
+          "every :state/* tag drove a variant — no :rf.error/unknown-tag aborts"))))

--- a/tools/xray/testbeds/panel_gallery/gallery_diff_mode_universal.cljs
+++ b/tools/xray/testbeds/panel_gallery/gallery_diff_mode_universal.cljs
@@ -62,14 +62,14 @@
 
   ;; -- App-DB panel --------------------------------------------------------
 
-  (story/reg-story :story.xray.app-db/diff-mode
+  (story/reg-story :story.xray.app-db.diff-mode-toggle
     {:doc        "App-DB panel — universal three-mode toggle drives
                   every section (TOP + per-:rf/* areas) uniformly."
      :component  :panel-gallery.app-db/Panel
      :tags       #{:dev :feature/xray-diff-mode-universal}
      :substrates #{:reagent}})
 
-  (story/reg-variant :story.xray.app-db/diff-mode-full+diff
+  (story/reg-variant :story.xray.app-db.diff-mode-toggle/full+diff
     {:doc        "App-DB panel in `:full+diff` mode (default). Every
                   section paints LIVE current-state with inline diff
                   annotations against the focused epoch's `:db-before`.
@@ -80,7 +80,7 @@
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
 
-  (story/reg-variant :story.xray.app-db/diff-mode-full
+  (story/reg-variant :story.xray.app-db.diff-mode-toggle/full
     {:doc        "App-DB panel in `:full` mode. Every section paints
                   LIVE current-state with NO `:before` threaded —
                   plain browse, no diff chrome. Useful when the
@@ -89,7 +89,7 @@
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
 
-  (story/reg-variant :story.xray.app-db/diff-mode-diff
+  (story/reg-variant :story.xray.app-db.diff-mode-toggle/diff
     {:doc        "App-DB panel in `:diff` mode. Section list
                   suppressed; one flat path-prefixed change list at
                   the top. Same source as the Epoch HANDLER `:diff`
@@ -101,7 +101,7 @@
 
   ;; -- Machine Inspector snapshot drill-in --------------------------------
 
-  (story/reg-story :story.xray.machine-inspector/snapshot-diff-mode
+  (story/reg-story :story.xray.machine-inspector.snapshot-diff-mode-toggle
     {:doc        "Machine Inspector snapshot drill-in — single mount
                   + three-mode toggle. Replaces the rf2-3d987 side-
                   by-side Before/After grid."
@@ -109,7 +109,7 @@
      :tags       #{:dev :feature/xray-diff-mode-universal}
      :substrates #{:reagent}})
 
-  (story/reg-variant :story.xray.machine-inspector/snapshot-full+diff
+  (story/reg-variant :story.xray.machine-inspector.snapshot-diff-mode-toggle/full+diff
     {:doc        "Machine Inspector snapshot in `:full+diff` mode
                   (default). Single mount; AFTER snapshot painted
                   with BEFORE threaded as the diff pre-image so
@@ -118,7 +118,7 @@
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
 
-  (story/reg-variant :story.xray.machine-inspector/snapshot-full
+  (story/reg-variant :story.xray.machine-inspector.snapshot-diff-mode-toggle/full
     {:doc        "Machine Inspector snapshot in `:full` mode. AFTER
                   snapshot alone, no BEFORE comparison — plain
                   browse of the post-transition state."
@@ -126,7 +126,7 @@
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
 
-  (story/reg-variant :story.xray.machine-inspector/snapshot-diff
+  (story/reg-variant :story.xray.machine-inspector.snapshot-diff-mode-toggle/diff
     {:doc        "Machine Inspector snapshot in `:diff` mode. Flat
                   path-prefixed change list — same shape as App-DB
                   and Epoch HANDLER `:diff` lenses."
@@ -136,7 +136,7 @@
 
   ;; -- SUBSCRIPTIONS step value-cell ---------------------------------------
 
-  (story/reg-story :story.xray.epoch/subs-value-diff-mode
+  (story/reg-story :story.xray.epoch.subs-value-diff-mode-toggle
     {:doc        "Epoch SUBSCRIPTIONS step — per-row value cell
                   routed through the universal three-mode toggle.
                   Orthogonal to the existing `[all][changed]
@@ -145,7 +145,7 @@
      :tags       #{:dev :feature/xray-diff-mode-universal}
      :substrates #{:reagent}})
 
-  (story/reg-variant :story.xray.epoch/subs-value-full+diff
+  (story/reg-variant :story.xray.epoch.subs-value-diff-mode-toggle/full+diff
     {:doc        "SUBSCRIPTIONS value cells in `:full+diff` mode
                   (default). Each `:changed?` row's value cell
                   paints the AFTER value via the edn-inspector with
@@ -154,7 +154,7 @@
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
 
-  (story/reg-variant :story.xray.epoch/subs-value-full
+  (story/reg-variant :story.xray.epoch.subs-value-diff-mode-toggle/full
     {:doc        "SUBSCRIPTIONS value cells in `:full` mode. Each
                   `:changed?` row's value cell renders the AFTER
                   value alone via the edn-inspector — no BEFORE
@@ -163,7 +163,7 @@
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
 
-  (story/reg-variant :story.xray.epoch/subs-value-diff
+  (story/reg-variant :story.xray.epoch.subs-value-diff-mode-toggle/diff
     {:doc        "SUBSCRIPTIONS value cells in `:diff` mode — the
                   pre-rf2-yqjrd shape: `✓ before → after` via the
                   `mini` widget. Preserved as one mode of the new


### PR DESCRIPTION
P1 bug fix for the panel-gallery testbed at `http://localhost:8765/#/stories` rendering no variants. Mike diagnosed two cascading errors live at 2026-05-27 11:40 AUSEST.

## Cascade A — `:rf.error/unknown-tag`

Every gallery's variants used `:state/*` tags (`:state/empty`, `:state/small`, `:state/medium`, `:state/large`, `:state/special`) but no `reg-tag` call ever registered the `:state/*` axis. The registrar's `validate-tag-membership!` threw on the first gallery namespace to load (`gallery_app_db.cljs:55`) and aborted the cascade; subsequent galleries never ran their `register-all!`. `git grep 'reg-tag :state/' tools/story/src/` returned zero matches.

**Fix**: add `:state` as a fifth canonical facet axis alongside `:status` / `:role` / `:team` / `:feature` in `schemas/canonical-axes`, and expand `install-canonical-tags!` to register the five `:state/*` tags with `:axis :state` at Story load. Files:
- `tools/story/src/re_frame/story/schemas.cljc` — adds `:state` to `canonical-axes` with `#{:empty :small :medium :large :special}`; introduces `canonical-state-values` + `canonical-state-tags` exports.
- `tools/story/src/re_frame/story/registrar.cljc` — `install-canonical-tags!` now also registers each `:state/*` tag with the `:state` axis classifier.
- `tools/story/src/re_frame/story/query.cljc` + `tools/story/src/re_frame/story.cljc` — re-export the new values for downstream consumers.
- `tools/story/spec/001-Authoring.md` — spec updated to mention the `:state` axis alongside the seven inclusion tags (rf2-xray-specs-kept-current discipline).

## Cascade B — `:rf.error/story-id-shape`

`gallery_diff_mode_universal.cljs` declared three story ids with a slash separator — violating the canonical `:story.<dotted-path>` grammar (story ids MUST have nil namespace per `schemas/story-id?`). The accompanying nine variants similarly carried namespaces that wouldn't tie back to their parent story via `variants-of`.

**Fix**: rename all 3 story ids + 9 variant ids in `tools/xray/testbeds/panel_gallery/gallery_diff_mode_universal.cljs`:

| before | after |
| --- | --- |
| `:story.xray.app-db/diff-mode` | `:story.xray.app-db.diff-mode-toggle` |
| `:story.xray.app-db/diff-mode-full+diff` | `:story.xray.app-db.diff-mode-toggle/full+diff` |
| `:story.xray.app-db/diff-mode-full` | `:story.xray.app-db.diff-mode-toggle/full` |
| `:story.xray.app-db/diff-mode-diff` | `:story.xray.app-db.diff-mode-toggle/diff` |
| `:story.xray.machine-inspector/snapshot-diff-mode` | `:story.xray.machine-inspector.snapshot-diff-mode-toggle` |
| `:story.xray.machine-inspector/snapshot-full+diff` | `:story.xray.machine-inspector.snapshot-diff-mode-toggle/full+diff` |
| `:story.xray.machine-inspector/snapshot-full` | `:story.xray.machine-inspector.snapshot-diff-mode-toggle/full` |
| `:story.xray.machine-inspector/snapshot-diff` | `:story.xray.machine-inspector.snapshot-diff-mode-toggle/diff` |
| `:story.xray.epoch/subs-value-diff-mode` | `:story.xray.epoch.subs-value-diff-mode-toggle` |
| `:story.xray.epoch/subs-value-full+diff` | `:story.xray.epoch.subs-value-diff-mode-toggle/full+diff` |
| `:story.xray.epoch/subs-value-full` | `:story.xray.epoch.subs-value-diff-mode-toggle/full` |
| `:story.xray.epoch/subs-value-diff` | `:story.xray.epoch.subs-value-diff-mode-toggle/diff` |

No external consumers reference the old ids (confirmed via full-repo grep — only this file and the bead carried them).

## Cascade C — CI smoke

New CLJS unit test `tools/xray/test/day8/re_frame2_xray/panel_gallery_inventory_smoke_cljs_test.cljs` locks both regressions at the framework + author level:

- **Cascade-A lock**: a synthetic `reg-variant` carrying every `:state/*` tag at once succeeds without `:rf.error/unknown-tag` (was the abort path).
- **Cascade-B lock**: every story / variant / workspace id from the broken gallery passes the matching `schemas/*-id?` predicate post-fix.
- **Inventory lock**: bulk-registering the gallery shape and querying `variants-of` returns a non-empty set (the headline contract).
- **`:state` axis classifier**: every `:state/*` tag returns from `(story/tags-by-axis :state)` so the sidebar tag-filter UI can group it (SB9 facet parity).

Pure data → data; no React, no live runtime. Discovered by `:node-test`'s `cljs-test\$` regex via the `-cljs-test` ns suffix.

## Knock-on test updates

The canonical install now ships 12 tags (7 inclusion + 5 `:state/*`), not 7 — adjusted exact-count assertions in:
- `tools/story/test/re_frame/story_test.clj`
- `tools/story/test/re_frame/story_cljs_test.cljs`
- `tools/story/test/re_frame/story_mcp_boundary_test.clj`
- `tools/story-mcp/test/re_frame/story_mcp/tools_test.clj`

The story-mcp `list-tags` handler (`tools/story-mcp/src/re_frame/story_mcp/tools/docs.cljc`) now classifies `:state/*` as canonical (they're framework-installed), preserving the bifurcated `{:canonical :custom :all}` shape contract.

## Live verification

`shadow-cljs compile :testbeds/panel-gallery` succeeds with 0 warnings + the new smoke test asserts inventory shape. Browser-spin-up verification was not performed by the worker (worktree env can compile but doesn't spawn a browser session) — the smoke covers the abort path that produced the empty page.

## Quality gates

- `bash scripts/test-fast-pr.sh`: PASS (link/anchor validators auto-ran)
- `npm run test:cljs`: 4777 tests / 15566 assertions, 0 failures
- `npm run test:bundle-isolation`: PASS
- `npm run test:xray-feature-gate:smoke`: PASS (3 scenarios, 0 failures)
- `bash scripts/test-jvm-tools.sh`: PASS (story + story-mcp + mcp-base + mcp-conformance, all 0 failures)
- New CI smoke (panel-gallery-inventory-smoke): included in `npm run test:cljs`, passing

Closes rf2-k1k87.