### PR TITLE
fix(xray/testbeds/panel-gallery): install Xray theme CSS vars on :root via global-styles/install! (rf2-pqulr)

### DIFF
--- a/tools/xray/testbeds/panel_gallery/core.cljs
+++ b/tools/xray/testbeds/panel_gallery/core.cljs
@@ -66,6 +66,15 @@
             ;; the OS scheme handler, which rejects it.
             [day8.re-frame2-xray.config :as xray-config]
             [day8.re-frame2-xray.registry :as xray-registry]
+            ;; rf2-pqulr — Xray's `:root` CSS-variable installer. Required
+            ;; here because the panel-gallery embeds bare Xray widgets
+            ;; without mounting the Xray shell; the shell normally calls
+            ;; `global-styles/install!` from its `shell-view` reg-view body.
+            ;; Without this call the tokens in
+            ;; `day8.re-frame2-xray.theme.tokens` resolve their
+            ;; `var(--rf-xray-*)` references to CSS fallback defaults and
+            ;; every variant paints unstyled.
+            [day8.re-frame2-xray.theme.global-styles :as global-styles]
             [panel-gallery.panel-views :as panel-views]
             ;; Side-effecting story registrations — namespaces fire
             ;; their `register-all!` at namespace load.
@@ -309,6 +318,14 @@
   ;; Register `:rf/xray` so the chrome's hardcoded frame-provider
   ;; resolves to a real frame (not nil → throw on subscribe).
   (ensure-xray-frame!)
+  ;; rf2-pqulr — install Xray theme CSS variables on :root so
+  ;; embedded widgets paint with the themed palette rather than
+  ;; browser defaults. Shell normally calls this from shell-view;
+  ;; the gallery bypasses the shell so we call directly.
+  ;; `global-styles/install!` is idempotent (defonce-guarded +
+  ;; DOM-probed via fixed id attributes per its docstring) so this
+  ;; call is safe to make regardless of boot order or hot-reload.
+  (global-styles/install!)
   (register-testbed-seed-events!)
   ;; Story's canonical vocabulary (seven reg-* macros / tags / modes
   ;; / canvas decorators) installed once at boot. Each


### PR DESCRIPTION
## Root cause

Variants rendered in the panel-gallery testbed at `/#/stories` paint with browser-default styling (unstyled text, no theme chrome, default fonts) — Xray theme tokens resolve to their CSS-fallback values instead of the themed palette.

`tools/xray/testbeds/panel_gallery/core.cljs`'s `run` fn registered Xray handlers (`xray-registry/register-xray-handlers!`), seeded the `:rf/xray` frame, and installed Story's vocabulary — but never called `day8.re-frame2-xray.theme.global-styles/install!`. That installer is the canonical writer of the `:root` CSS custom properties (`--rf-xray-text-primary`, `--rf-xray-bg-canvas`, the font stacks, the keyframes, the per-theme palette) that the Xray token system (`day8.re-frame2-xray.theme.tokens`) references via `var(--rf-xray-*)`.

The Xray shell normally calls `install!` from its `shell-view` reg-view body. The panel-gallery embeds bare widgets WITHOUT mounting the shell — so the CSS variables stayed undefined and every variant painted with browser-default fallback colours, fonts, and chrome.

## Fix

One-line addition (plus require) to `tools/xray/testbeds/panel_gallery/core.cljs`:

```clojure
(:require ...
          [day8.re-frame2-xray.theme.global-styles :as global-styles]
          ...)

(defn ^:export run []
  (xray-config/configure! ...)
  (rf/init! reagent-adapter/adapter)
  (xray-registry/register-xray-handlers!)
  (ensure-xray-frame!)
  ;; rf2-pqulr — install Xray theme CSS variables on :root so
  ;; embedded widgets paint with the themed palette rather than
  ;; browser defaults. Shell normally calls this from shell-view;
  ;; the gallery bypasses the shell so we call directly.
  (global-styles/install!)            ; NEW
  (register-testbed-seed-events!)
  ...)
```

## Idempotency

`global-styles/install!` is idempotent:

- `@installed?` atom guard at `global_styles.cljs:1684` short-circuits repeat calls.
- DOM-probed via fixed `id` attributes per its docstring — even a `defonce` reset converges to a single set of `<style>` nodes in `<head>`.
- Per docstring: "shadow-cljs `:after-load` reloads, repeated shell mounts, and `defonce` resets all converge to a single set of nodes".

So this additional call from the gallery boot path is safe regardless of boot order, hot-reload, or future inclusion of the production shell in a variant.

## Quality gates

| Gate | Status |
|------|--------|
| `scripts/test-fast-pr.sh` | PASS (796 JVM tests / 3708 assertions; 4777 CLJS tests / 15566 assertions) |
| `npm run test:browser` | PASS (124 tests / 353 assertions) |
| `npm run test:bundle-isolation` | PASS (17 artefact entries; 35 sentinels absent; 3 budgets ok; uix/helix reagent-free) |
| `npm run test:xray-feature-gate:smoke` | PASS (3 scenarios / 10 matrix rows) |

## Live verification

Browser-based live verification of the actual unstyled-vs-themed paint is best done by Mike at `/#/stories` after this lands; the change is mechanically minimal and the install path is covered by Xray's existing tests.

## Files modified

- `tools/xray/testbeds/panel_gallery/core.cljs` (+17 lines: require + install! call + rationale comments)

Closes rf2-pqulr.