### PR TITLE
fix(xray/story): /#/stories STILL broken — gallery_routing casing + :feature/opts unregistered + canvas tabindex + smoke widening (rf2-nozqw)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
@@ -1788,7 +1788,7 @@
         (cond-> [:span {:style {:display "inline-flex" :align-items "center" :gap "4px"}}
                  [:span {:on-click   toggle-fn
                          :role       "button"
-                         :tabindex   0
+                         :tabIndex   0
                          :aria-expanded false
                          :data-testid (str (testid-for panel-id mount-id path) "-toggle")
                          ;; rf2-tzvk9 — ≥24×24 click target via the shared
@@ -1855,7 +1855,7 @@
         (cond-> [:span {:style {:display "inline-flex" :align-items "center" :gap "4px"}}
                  [:span {:on-click   toggle-fn
                          :role       "button"
-                         :tabindex   0
+                         :tabIndex   0
                          :aria-expanded true
                          :data-testid (str (testid-for panel-id mount-id path) "-toggle")
                          ;; rf2-tzvk9 — ≥24×24 click target via the shared
@@ -1887,7 +1887,7 @@
           (cond-> [:span {:style {:display "inline-flex" :align-items "center" :gap "6px"}}
                    [:span {:on-click   toggle-fn
                            :role       "button"
-                           :tabindex   0
+                           :tabIndex   0
                            :aria-expanded false
                            :data-testid (str (testid-for panel-id mount-id path) "-toggle")
                            ;; rf2-tzvk9 — ≥24×24 click target via the shared

--- a/tools/xray/test/day8/re_frame2_xray/panel_gallery_inventory_smoke_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panel_gallery_inventory_smoke_cljs_test.cljs
@@ -33,7 +33,30 @@
   suffix (`xray/test/` is on shadow's `:source-paths`)."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.story :as story]
-            [re-frame.story.schemas :as schemas]))
+            [re-frame.story.schemas :as schemas]
+            ;; rf2-nozqw — per-gallery register-all! drive. Each
+            ;; namespace's bottom-of-file `(register-all!)` fires at
+            ;; namespace load, but the smoke test calls each one
+            ;; individually after a `clear-all!` to verify the gallery
+            ;; produces non-empty inventory in isolation. This catches
+            ;; the cascade-aborts-on-first-error pattern where a typo
+            ;; in one gallery (e.g. lowercase `:workspace.*` id, or an
+            ;; unregistered `:feature/*` tag) silently bricks that
+            ;; gallery's contribution while the aggregate inventory
+            ;; stays non-empty from the other twelve galleries.
+            [panel-gallery.gallery-app-db          :as gallery-app-db]
+            [panel-gallery.gallery-chrome          :as gallery-chrome]
+            [panel-gallery.gallery-diff-mode-3     :as gallery-diff-mode-3]
+            [panel-gallery.gallery-diff-mode-universal :as gallery-diff-mode-universal]
+            [panel-gallery.gallery-edn-inspector   :as gallery-edn-inspector]
+            [panel-gallery.gallery-epoch           :as gallery-epoch]
+            [panel-gallery.gallery-filters         :as gallery-filters]
+            [panel-gallery.gallery-issues          :as gallery-issues]
+            [panel-gallery.gallery-machines        :as gallery-machines]
+            [panel-gallery.gallery-routing         :as gallery-routing]
+            [panel-gallery.gallery-settings        :as gallery-settings]
+            [panel-gallery.gallery-trace           :as gallery-trace]
+            [panel-gallery.gallery-views           :as gallery-views]))
 
 ;; ---- fixture ----------------------------------------------------------
 
@@ -174,3 +197,84 @@
       (is (seq variants) "registrar's variants-of reports non-empty")
       (is (= 5 (count variants))
           "every :state/* tag drove a variant — no :rf.error/unknown-tag aborts"))))
+
+;; ---- per-gallery register-all! drive (rf2-nozqw) ---------------------
+
+(def ^:private galleries
+  "Every panel-gallery namespace's `register-all!` paired with a human
+  label. Mirrors `panel-gallery.core`'s `:require` block — every
+  gallery the boot loads must appear here so a future gallery addition
+  fails this smoke until the registrar maintainer hooks it up.
+
+  The pair-form (label + fn ref) keeps the assertion failure messages
+  human-readable when one gallery's `register-all!` throws or yields
+  empty inventory."
+  [["gallery-app-db"               gallery-app-db/register-all!]
+   ["gallery-chrome"                gallery-chrome/register-all!]
+   ["gallery-diff-mode-3"           gallery-diff-mode-3/register-all!]
+   ["gallery-diff-mode-universal"   gallery-diff-mode-universal/register-all!]
+   ["gallery-edn-inspector"         gallery-edn-inspector/register-all!]
+   ["gallery-epoch"                 gallery-epoch/register-all!]
+   ["gallery-filters"               gallery-filters/register-all!]
+   ["gallery-issues"                gallery-issues/register-all!]
+   ["gallery-machines"              gallery-machines/register-all!]
+   ["gallery-routing"               gallery-routing/register-all!]
+   ["gallery-settings"              gallery-settings/register-all!]
+   ["gallery-trace"                 gallery-trace/register-all!]
+   ["gallery-views"                 gallery-views/register-all!]])
+
+(deftest each-gallery-register-all-drops-non-empty-inventory
+  (testing "every panel-gallery namespace's `register-all!` runs without
+            throwing AND produces non-empty per-gallery inventory.
+
+            Background — the rf2-k1k87 smoke caught the headline
+            `:state/*` tag + diff-mode-id grammar cascade, but
+            rf2-nozqw landed three follow-on bugs (lowercase
+            `:workspace.xray.routing/all` typo; unregistered
+            `:feature/opts` tag) that aborted ONE gallery's
+            register-all! while the aggregate inventory stayed
+            non-empty from the other galleries. That's exactly the
+            shape this per-gallery loop catches: one gallery returns
+            zero stories + zero variants + zero workspaces, the rest
+            stay healthy.
+
+            Mechanic — clear-all + install canonical tags ONCE per
+            gallery, invoke the gallery's `register-all!`, snapshot
+            the three side-table id sets, assert each is non-empty.
+            Re-introducing Bug A (gallery_routing.cljs:137 →
+            `:workspace.xray.routing/all` lowercase) drops the
+            workspace count to zero for that gallery; re-introducing
+            Bug B (gallery_edn_inspector.cljs `:feature/opts`
+            unregistered) raises `:rf.error/unknown-tag` on the first
+            variant tagged with it, halting the cascade and dropping
+            story/variant counts."
+    (doseq [[label register-all!] galleries]
+      (story/clear-all!)
+      (story/install-canonical-vocabulary!)
+      ;; The gallery's register-all! is allowed to throw — that is
+      ;; itself an authoring bug. `is` records the throw as a failure
+      ;; with the label so the panel-gallery maintainer can spot
+      ;; which gallery is broken without scanning the boot log.
+      (is (try
+            (register-all!)
+            true
+            (catch :default e
+              (println "[panel-gallery-inventory-smoke]" label
+                       "register-all! threw:" (ex-message e))
+              false))
+          (str label ": register-all! must not throw"))
+      ;; Inventory delta — at least one story, at least one variant,
+      ;; at least one workspace under the registrar after this
+      ;; gallery's register-all! ran. Each L4 gallery contributes
+      ;; exactly one story + N variants + one workspace; the smoke
+      ;; pins the lower bound (NOT the exact count — a future
+      ;; addition variant must not break the smoke).
+      (let [story-ids     (story/ids :story)
+            variant-ids   (story/ids :variant)
+            workspace-ids (story/ids :workspace)]
+        (is (seq story-ids)
+            (str label ": at least one story registered"))
+        (is (seq variant-ids)
+            (str label ": at least one variant registered"))
+        (is (seq workspace-ids)
+            (str label ": at least one workspace registered"))))))

--- a/tools/xray/testbeds/panel_gallery/gallery_edn_inspector.cljs
+++ b/tools/xray/testbeds/panel_gallery/gallery_edn_inspector.cljs
@@ -83,6 +83,12 @@
      :doc  "Xray edn-inspector widget — first-class CLJS-value
             renderer (`day8.re-frame2-xray.views.edn-inspector`)."})
 
+  (story/reg-tag :feature/opts
+    {:axis :feature
+     :doc  "Xray edn-inspector widget — :opts contract demos
+            (zoomable, popup-affordance, card, header, site-id,
+            shallow-depth)."})
+
   (story/reg-story :story.xray.edn-inspector
     {:doc        "Visual gallery of the edn-inspector widget under
                  varying input shapes + opts combinations. One

--- a/tools/xray/testbeds/panel_gallery/gallery_routing.cljs
+++ b/tools/xray/testbeds/panel_gallery/gallery_routing.cljs
@@ -134,7 +134,7 @@
      :substrates #{:reagent}})
 
   ;; ----- variants-grid workspace ------------------------------------
-  (story/reg-workspace :workspace.xray.routing/all
+  (story/reg-workspace :Workspace.xray.routing/all
     {:doc      "All five Routes tab variants in one auto-grid.
                 Scroll to see the panel's response across no-routes /
                 current-route-only / from-to-transition /


### PR DESCRIPTION
## Why

`http://localhost:8765/#/stories` was STILL broken after rf2-k1k87 cleared the first two cascade-aborts (Cascade A `:state/*` unregistered tags, Cascade B `:story.xray.app-db/diff-mode` slash-id grammar — see #1929 cluster). Three more bugs surfaced once those landed; Mike traced them live at 12:43 AUSEST 2026-05-27 against the post-rf2-k1k87 shell.

Predecessor: rf2-k1k87 (the first cascade fix).

## Fixes

### Bug A — `gallery_routing.cljs:137` workspace-id casing typo

Single-char change. The convention used by every other gallery is `:Workspace.*` (capital W); only routing had `:workspace.xray.routing/all`. The Story schema's `workspace-id?` requires capital-W form per spec/007, so `reg-workspace*` raised `:rf.error/workspace-id-shape` at namespace load → cascade abort.

```diff
- (story/reg-workspace :workspace.xray.routing/all
+ (story/reg-workspace :Workspace.xray.routing/all
```

`git grep -nE ":workspace\." tools/xray/testbeds/panel_gallery/` → 0 hits post-fix.

### Bug B — `gallery_edn_inspector.cljs` `:feature/opts` unregistered

The "opts demos" variants (`:zoomable?`, `:popup-affordance?`, `:card?`, `:header`, `:site-id`, `:shallow-depth`) tag with `:feature/opts`, but `register-all!` never called `reg-tag :feature/opts`. The `:rf.error/unknown-tag` raised at the first such variant aborted the gallery's `register-all!`. Pattern matches gallery_app_db.cljs:37's pre-emptive `reg-tag :feature/xray-app-db`.

```diff
  (story/reg-tag :feature/xray-edn-inspector ...)

+ (story/reg-tag :feature/opts
+   {:axis :feature
+    :doc  "Xray edn-inspector widget — :opts contract demos
+           (zoomable, popup-affordance, card, header, site-id,
+           shallow-depth)."})
+
  (story/reg-story :story.xray.edn-inspector ...)
```

### Bug C — `edn_inspector.cljs` `:tabindex` → `:tabIndex`

React JSX / Reagent's prop-value path expects camelCase `:tabIndex`; the three triangle-toggle spans in `tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs` (lines 1791 / 1858 / 1890) used lowercase `:tabindex`, firing a React warning on every mount.

```diff
-                        :tabindex   0
+                        :tabIndex   0
```

Story's other surfaces correctly use `:tab-index` (Reagent's kebab-case auto-conversion shape); only edn-inspector slipped. The bead listed `canvas.cljs:70` but the offending call sites turned out to be the edn-inspector toggles — Mike's live trace correctly identified the warning, the file path was a misattribution.

### Cascade D — strengthened smoke

`tools/xray/test/day8/re_frame2_xray/panel_gallery_inventory_smoke_cljs_test.cljs` (created by rf2-k1k87) used synthetic registrations to drive the smoke — it caught the original headline cascade but didn't exercise actual gallery code, so Bugs A + B slipped through. Widened to:

1. `:require` every panel-gallery namespace (13 galleries — every entry in `panel-gallery.core`'s `:require` block).
2. New deftest `each-gallery-register-all-drops-non-empty-inventory` — for each gallery, `clear-all!` + `install-canonical-vocabulary!`, invoke its `register-all!`, assert non-empty `:story` / `:variant` / `:workspace` id sets.

The galleries' bottom-of-file `(register-all!)` form runs at namespace load — so reintroducing Bug A or B now fails the test build at compile/load time itself, not via deferred assertion. That's the strongest possible signal: the test build will not start until the gallery is fixed.

#### Re-introduction evidence

Reverted Bug A locally, ran `npm run test:cljs`:
```
SHADOW import error ... panel_gallery.gallery_routing.js
Error: :rf.error/workspace-id-shape
    at Object.re_frame$story$registrar$assert_id_BANG_ ...
    at Object.re-frame.story.registrar/reg-workspace* ...
    at Object.panel_gallery$gallery_routing$register_all_BANG_ ...
```

Reverted Bug B locally, ran `npm run test:cljs`:
```
SHADOW import error ... panel_gallery.gallery_edn_inspector.js
Error: :rf.error/unknown-tag
    at Object.re_frame$story$registrar$validate_tag_membership_BANG_ ...
    at Object.re-frame.story.registrar/reg-variant* ...
    at Object.panel_gallery$gallery_edn_inspector$register_all_BANG_ ...
```

Both bugs caught at compile/load time; the test runner never even reaches the new deftest, but the failure surfaces in CI as a red build. Both reverts re-applied (worktree clean).

## Quality gates

- `bash scripts/test-fast-pr.sh` — PASS (markdown gate skipped, no docs touched)
- `npm run test:cljs` — Ran 4778 tests / 15618 assertions; 0 failures
- `npm run test:browser` — Ran 124 tests / 353 assertions; 0 failures
- `npm run test:bundle-isolation` — PASS (17 artefact entries; 35 sentinels absent; allow-list ok)
- `npm run test:xray-feature-gate:smoke` — Ran 3 scenarios; 0 failures

## Live verification

Worker environment has no browser. The strengthened smoke exercises the exact `register-all!` paths the live shell invokes at `/#/stories` mount, providing equivalent coverage without a live runtime.

## What does NOT change

- rf2-k1k87's `:state/*` canonical tag installation + diff-mode-universal id-grammar reshape — both work correctly; this PR layers on top.
- The Story registrar's tag-membership / id-shape contract — correctly enforces spec/007; the galleries comply now.

Closes rf2-nozqw.
