### PR TITLE
fix(xray/diff-mode-toggle): align Machine Inspector toggle testid to canonical shape (rf2-shuxd)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1619,13 +1619,16 @@ event pair so the modes are independent (operator's App-DB choice
 doesn't override the Machine Inspector choice).
 
 **Canonical `data-testid` + `data-*` shapes** (Cluster F — rf2-7vv8f
-+ rf2-xvu24): post-normalisation every surface follows ONE shape so
-browser-test selectors + DOM probes target a uniform axis:
++ rf2-xvu24, with rf2-shuxd alignment): post-normalisation every
+surface follows ONE shape so browser-test selectors + DOM probes
+target a uniform axis. The rule is **testid prefix matches the
+sub-id namespace**, giving a single naming root across DevTools
+(testid) + Trace (sub-id):
 
 | Surface | Toggle `:testid` prefix | Section-level data-attr |
 |---|---|---|
 | App-DB panel                          | `rf-xray-app-db-diff-mode`             | `data-rf-xray-diff-mode` |
-| Machine Inspector snapshot drill-in   | `rf-xray-machine-snapshot-diff-mode`   | `data-rf-xray-diff-mode` |
+| Machine Inspector snapshot drill-in   | `rf-xray-machine-inspector-diff-mode`  | `data-rf-xray-diff-mode` |
 | Epoch HANDLER step `:db`              | `rf-xray-epoch-handler-db-diff-mode`   | `data-rf-xray-diff-mode` |
 | Epoch SUBSCRIPTIONS step value cells  | `rf-xray-epoch-subs-value-diff-mode`   | `data-rf-xray-diff-mode` |
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
@@ -678,7 +678,11 @@
   [diff-mode/diff-mode-toggle
    {:mode      mode
     ;; rf2-7vv8f — testid prefix normalised to `rf-xray-<surface>-diff-mode`.
-    :testid    "rf-xray-machine-snapshot-diff-mode"
+    ;; rf2-shuxd — `<surface>` matches the sub-id namespace
+    ;; (`:rf.xray.machine-inspector`) for one naming root across DevTools
+    ;; (testid) + Trace (sub-id). Prior `machine-snapshot` testid split the
+    ;; root from the dispatching sub; aligned to `machine-inspector` here.
+    :testid    "rf-xray-machine-inspector-diff-mode"
     ;; rf2-fytu4 — uniform "View" discoverability label.
     :label     "View"
     :on-change (fn [m]

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_view_cljs_test.cljs
@@ -1029,14 +1029,17 @@
             drill  (find-by-testid tree "rf-xray-machine-snapshot-drill-in")
             ;; rf2-7vv8f — testid prefix normalised across all four
             ;; diff-mode-toggle consumers to `rf-xray-<surface>-diff-mode`.
+            ;; rf2-shuxd — `<surface>` matches the sub-id namespace
+            ;; (`:rf.xray.machine-inspector`), prior `machine-snapshot`
+            ;; root retired (testid + sub-id share one root).
             toggle (find-by-testid
-                     tree "rf-xray-machine-snapshot-diff-mode")
+                     tree "rf-xray-machine-inspector-diff-mode")
             ;; rf2-xlmhh — the toggle bar no longer carries `:data-mode`
             ;; (retired axis name per spec/Conventions.md §264). Read the
             ;; active mode off the active button's `aria-pressed="true"`
             ;; + canonical testid suffix instead.
             active-btn (find-by-testid
-                         tree "rf-xray-machine-snapshot-diff-mode-full-with-diff")]
+                         tree "rf-xray-machine-inspector-diff-mode-full-with-diff")]
         (is (some? drill)
             "drill-in section mounts")
         (is (some? toggle)


### PR DESCRIPTION
## Drift citation

Source: `rf2-ya3nj` audit (2026-05-27), finding M2.

The Machine Inspector's diff-mode toggle had a `:testid` prefix
(`rf-xray-machine-snapshot-diff-mode`) that did not match its
dispatching sub-id namespace (`:rf.xray.machine-inspector`).

This split broke the Cluster F (PR #2241) normalisation invariant:
an operator probing via DevTools saw `machine-snapshot`, while reading
the same surface via Trace saw `machine-inspector`. The drift was
documented in the spec table without comment, not flagged as deliberate.

| Surface | Sub-id namespace | Testid prefix (pre) | Testid prefix (post) |
|---|---|---|---|
| App-DB | `app-db` | `app-db` ✓ | unchanged ✓ |
| **Machine Inspector** | `machine-inspector` | `machine-snapshot` ✗ | **`machine-inspector`** ✓ |
| Epoch HANDLER | `epoch/db` | `epoch-handler-db` ✓ | unchanged ✓ |
| Epoch SUBSCRIPTIONS | `epoch/subs-value` | `epoch-subs-value` ✓ | unchanged ✓ |

## Canonical source

`tools/xray/spec/021-Dynamic-Panel-Designs.md` §9.1.5.2 — Cluster F
4-surface testid normalisation. This PR makes the rule **testid
prefix matches the sub-id namespace** explicit alongside the surface
table (it was implicit before; the implicitness allowed M.I. to drift).

## Before / after grep counts

```
rf-xray-machine-snapshot-diff-mode     : 4 → 0
rf-xray-machine-inspector-diff-mode    : 0 → 4
```

Distribution post-change: 1 src (`panels/machine_inspector.cljs:681`)
+ 1 spec (`021-Dynamic-Panel-Designs.md:1631`) + 2 tests
(`machine_inspector_view_cljs_test.cljs:1036,1042`).

The other `rf-xray-machine-snapshot-*` testids (`-drill-in`, `-block-`,
`-diff-`, `-diff-row-`, `-drill-in-header`) are separate DOM-structure
testids on different elements (drill-in section, per-machine snapshot
block, diff rows). They are not the diff-mode toggle and are out of
scope for this bead.

The Story-id `:story.xray.machine-inspector.snapshot-diff-mode-toggle`
is also orthogonal (story registry name, not a DOM testid) and is
left unchanged per the bead description.

## Quality gates

- `bash scripts/test-fast-pr.sh` — PASS (core JVM 796 tests / 3708
  assertions, CLJS node 4777 tests / 15566 assertions, lockstep +
  skill/MCP drift + harness helpers all green)
- `npm run test:bundle-isolation` — PASS (3 example bundles, 35
  sentinels absent, 6 cross-substrate isolation checks)
- `npm run test:browser` — PASS (124 tests, 353 assertions)

Closes rf2-shuxd.