### PR TITLE
fix(xray): App-DB mode-3 R4 rail paints + drop dead inside-wholly? binding (rf2-kkhss + rf2-6q2tz)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs
@@ -320,6 +320,16 @@
         :site-id  site-id
         :default-expanded-depth 3
         :before (f/display-value before)
+        ;; rf2-kkhss — opts mode-3 grammar (spec/021 §9.1.5.2 axis 2)
+        ;; into the App-DB diff render. `render-container` gates the
+        ;; R4 2px vertical rail behind `(and full-with-diff? has-
+        ;; change?)`; without this flag the rail silently never paints
+        ;; on App-DB even though Stories — which all pass the opt —
+        ;; render it correctly. Sister surfaces (HANDLER `:db` /
+        ;; Machine / SUBS) also set it. The BROWSE branch above MUST
+        ;; NOT carry this opt: no `:before` is present, and mode-3
+        ;; chrome would mis-render against a non-diff tree.
+        :full-with-diff? true
         :card? true
         ;; rf2-h71e0 — zoomable opt is preserved here for symmetry;
         ;; the widget self-suppresses zoom resolution in diff mode so

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
@@ -1679,16 +1679,11 @@
 
                         :else :same)
         has-change?   (and diff? (not (#{:same :same-shifted} op)))
-        ;; R5-tinted: when this container is INSIDE a wholly-changed
-        ;; ancestor, the renderer suppresses per-leaf gutter glyphs +
-        ;; stripes on its descendants (the parent's marking covers them).
-        ;; The descendant row WASH is retained so a partial-visibility
-        ;; scroll into the middle of a 20-leaf added shard still reads
-        ;; as green. The ancestor itself is the wholly-changed-root and
-        ;; gets the full chrome — only deeper descendants suppress.
-        wholly-anc    (when (and diff? projection)
-                        (engine/wholly-changed-ancestor projection path))
-        inside-wholly? (and wholly-anc (not= wholly-anc (vec path)))
+        ;; rf2-6q2tz — the R5 wholly-changed-ancestor lookup +
+        ;; `inside-wholly?` derivation live in `render-leaf-with-diff`
+        ;; (where R5 chrome-opts are actually gated on them). The
+        ;; duplicate container-level bindings were dead code and have
+        ;; been removed; the container has no R5-specific behaviour.
         default?      (and (not depth-capped?)
                            (default-expanded?
                              {:depth                   depth

--- a/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_state_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_state_cljs_test.cljs
@@ -417,3 +417,65 @@
       (is (seq diff-mts) "diff-mode mounts present")
       (is (every? #(true? (:card? (:opts %))) diff-mts)
           "diff-mode mounts also opt in to the card chrome"))))
+
+;; ---- mode-3 grammar opt (rf2-kkhss) -------------------------------------
+;;
+;; The edn-inspector widget gates its mode-3 R4 2px vertical rail behind
+;; `(and full-with-diff? has-change?)` in `render-container`. The App-DB
+;; call site MUST set `:full-with-diff? true` on the DIFF branch so the
+;; rail paints on change-bearing subtrees — Stories at
+;; `gallery_diff_mode_3.cljs` all set it, and sister surfaces (HANDLER
+;; `:db`, Machine, SUBS) also set it; the App-DB BROWSE branch (no
+;; `:before` present) MUST NOT set it (mode-3 chrome against a non-diff
+;; tree mis-renders).
+;;
+;; Per rf2-ya3nj audit finding H1. Without the opt the R4 rail silently
+;; never paints on App-DB — a load-bearing visual signal absent on the
+;; real surface while Stories render it correctly.
+
+(deftest diff-mode-mounts-carry-full-with-diff-opt
+  (testing "rf2-kkhss — DIFF-mode mounts (when a pre-image is supplied)
+            carry `:full-with-diff? true` so the edn-inspector widget
+            paints the mode-3 R4 vertical rail on change-bearing
+            subtrees (Stories at `gallery_diff_mode_3.cljs` all set
+            this opt; live App-DB used to silently drop it)"
+    (let [model    (h/current-state-sections {:counter 2} {:counter 1})
+          tree     (state/state-body model)
+          mounts   (find-edn-inspector-mounts tree)
+          diff-mts (filter #(contains? (:opts %) :before) mounts)]
+      (is (seq diff-mts) "diff-mode mounts present")
+      (is (every? #(true? (:full-with-diff? (:opts %))) diff-mts)
+          "every diff-mode mount opts in to mode-3 chrome so the R4
+           rail paints on change-bearing containers"))))
+
+(deftest browse-mode-mounts-omit-full-with-diff-opt
+  (testing "rf2-kkhss — BROWSE-mode mounts (1-arity / no pre-image,
+            `:before` absent) MUST NOT carry `:full-with-diff? true`
+            — mode-3 chrome against a non-diff tree mis-renders. The
+            opt belongs exclusively on the DIFF branch."
+    (let [model  (h/current-state-sections
+                   {:counter 2 :rf/route {:id :home}
+                    :rf/machines {:auth {:state :idle}}})
+          tree   (state/state-body model)
+          mounts (find-edn-inspector-mounts tree)]
+      (is (seq mounts) "the panel mounts edn-inspector widget instances")
+      (is (every? #(not (contains? (:opts %) :before)) mounts)
+          "no `:before` opt — every mount is in BROWSE mode")
+      (is (not-any? #(true? (:full-with-diff? (:opts %))) mounts)
+          "no browse-mode mount carries the mode-3 opt"))))
+
+(deftest changed-machine-snapshot-diff-mount-carries-mode-3-opt
+  (testing "rf2-kkhss — DIFF-mode mounts in the per-machine fan-out
+            (instance sections) also carry `:full-with-diff? true` so
+            the R4 rail paints uniformly across every reserved area"
+    (let [before   {:rf/machines {:title/flow {:state :idle}}}
+          after    {:rf/machines {:title/flow {:state :loaded}}}
+          model    (h/current-state-sections after before)
+          tree     (state/state-body model)
+          flow     (find-by-testid
+                     tree "rf-xray-app-db-state-instance-:rf/machines-:title/flow")
+          mounts   (find-edn-inspector-mounts flow)
+          diff-mts (filter #(contains? (:opts %) :before) mounts)]
+      (is (seq diff-mts) "the instance section renders in DIFF mode")
+      (is (every? #(true? (:full-with-diff? (:opts %))) diff-mts)
+          "the changed-machine instance mount opts in to mode-3 chrome"))))


### PR DESCRIPTION
## Shape-2 cluster from rf2-ya3nj 24hr audit

Two sequenced commits — P1 HIGH + P3 LOW from the edn-inspector audit.

### Commit 1 — rf2-6q2tz (P3 LOW) — dead let binding

`render-container` in `views/edn_inspector.cljs` bound `wholly-anc` + `inside-wholly?` (at line 1689-1691) but **referenced neither anywhere in its body**. The actual R5 chrome-opts logic lives in `render-leaf-with-diff` (lines 2190-2198), where the matching derivation drives `{:suppress-glyph? :suppress-stripe? :wash-op}`. Container-level bindings were dead code — removed.

No behaviour change. Per audit finding L1.

### Commit 2 — rf2-kkhss (P1 HIGH) — App-DB mode-3 silently drops R4 vertical rail

**Root cause.** The App-DB diff render at `panels/app_db_diff_state.cljs` line 317-329 was calling `edn-inspector` with `:before` threaded through but **without `:full-with-diff? true`**. The edn-inspector's `render-container` gates its mode-3 R4 2px vertical rail behind `(and full-with-diff? has-change?)`, so the rail silently never painted on App-DB.

**The mismatch.** Stories at `gallery_diff_mode_3.cljs` all pass `:full-with-diff? true`, so the visual mental model formed in Stories didn't match what shipped to operators. The three sister surfaces (HANDLER `:db` line 2632, Machine line 671, SUBS line 2960) all set the opt. App-DB was the lone exception.

**Operator impact.** In `:full+diff` mode App-DB rendered R1/R2/R3/R5/R6/R7/R8 chrome correctly but dropped R4. R3 chips fire only on COLLAPSED containers; for EXPANDED change-bearing containers (the common case at App-DB's `:default-expanded-depth 3`), the rail is the canonical structural-context signal. Operator couldn't see which subtree carried the change at a glance.

**Fix.** Add `:full-with-diff? true` to the DIFF branch of `value-body`. The BROWSE branch (no `:before` present) deliberately does NOT carry the opt — mode-3 chrome against a non-diff tree mis-renders.

Per audit finding H1 + spec/021 §9.1.5.2 axis 2 (mode-3 grammar applies uniformly to every `:full+diff` surface).

## Test evidence

`app_db_diff_state_cljs_test.cljs` gains 3 assertions:

1. `diff-mode-mounts-carry-full-with-diff-opt` — every DIFF mount carries `:full-with-diff? true` (TOP user-domain section).
2. `browse-mode-mounts-omit-full-with-diff-opt` — no BROWSE mount carries the opt (mode-3 chrome against non-diff tree would mis-render).
3. `changed-machine-snapshot-diff-mount-carries-mode-3-opt` — fan-out per-machine instance diff mounts also opt in (uniform R4 across reserved areas).

## Quality gates

| Gate | Status |
|---|---|
| `bash scripts/test-fast-pr.sh` | PASS (4780 cljs tests, 0 failures) |
| `npm run test:cljs` | PASS (within fast-pr) |
| `npm run test:browser` | PASS (124 tests, 353 assertions, 0 failures) |
| `npm run test:bundle-isolation` | PASS |
| `npm run test:xray-feature-gate:smoke` | PASS (3 scenarios, 10 matrix rows) |

## Files modified

- `tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs` — drop dead `wholly-anc` + `inside-wholly?` from `render-container`
- `tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs` — add `:full-with-diff? true` to DIFF branch of `value-body`
- `tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_state_cljs_test.cljs` — 3 new mode-3-opt assertions

Closes rf2-6q2tz + rf2-kkhss.