### PR TITLE
feat(xray/stories): 3 missing grammar-edge variants — set-add + long-string-truncation + symbol-value-diff (rf2-r7xf7)

### DIFF
--- a/tools/xray/testbeds/panel_gallery/fixtures_edn_inspector.cljs
+++ b/tools/xray/testbeds/panel_gallery/fixtures_edn_inspector.cljs
@@ -426,3 +426,57 @@
             :status  :ok}
    :value  {:session {:user {:id 7 :password "hunter2"}}
             :status  :ok}})
+
+;; =========================================================================
+;; additional grammar-edge diff fixtures (rf2-r7xf7)
+;; =========================================================================
+;;
+;; Three further before/after pairs that pin grammar edges the
+;; rf2-yaajg six don't reach: pure-add set diff (no remove signal
+;; clouding the `+` glyph), long-string truncation under diff
+;; annotation, and symbol-value mutation (distinct from keyword
+;; mutation, which the canonical maps already cover). Each fixture
+;; pins ONE engine behaviour so visual regressions surface in
+;; isolation.
+
+(defn diff-set-add
+  "Pure-add set diff — `#{:a :b}` → `#{:a :b :c}`. Distinct from
+  `diff-set-mixed`'s add+remove pair: here only `:c` is new and
+  nothing is removed, so the engine paints a single `+` glyph
+  against unchanged `:a` and `:b`. Verifies the key-side glyph
+  treatment under pure-add (no remove signal cluttering the
+  per-member walk)."
+  []
+  {:before #{:a :b}
+   :value  #{:a :b :c}})
+
+(defn diff-long-string-truncation
+  "Long-string mutation — `{:bio \"short\"}` → `{:bio
+  \"<>200-char essay>\"}`. Verifies the widget's truncation
+  chrome (ellipsis / hover-expand / overflow handling) renders
+  cleanly when a long string also carries a `:modified` diff
+  annotation: the `~` glyph, the truncated rendering, and the
+  `← changed from \"short\"` suffix must coexist without one
+  clobbering the other."
+  []
+  (let [long-text (str "Lorem ipsum dolor sit amet, consectetur "
+                       "adipiscing elit, sed do eiusmod tempor "
+                       "incididunt ut labore et dolore magna aliqua. "
+                       "Ut enim ad minim veniam, quis nostrud "
+                       "exercitation ullamco laboris nisi ut aliquip "
+                       "ex ea commodo consequat.")]
+    {:before {:bio "short"}
+     :value  {:bio long-text}}))
+
+(defn diff-symbol-value
+  "Symbol-value mutation — `{:fn-name 'old-handler}` →
+  `{:fn-name 'new-handler}`. Verifies the inspector handles
+  symbols correctly under diff annotation (distinct from
+  keywords, which the canonical map diffs already exercise).
+  Symbols carry the `:syntax-symbol` token; under modification
+  the `~` glyph + `← changed from old-handler` suffix must
+  render against the symbol palette without falling back to
+  the keyword or string token."
+  []
+  {:before {:fn-name 'old-handler}
+   :value  {:fn-name 'new-handler}})

--- a/tools/xray/testbeds/panel_gallery/gallery_edn_inspector.cljs
+++ b/tools/xray/testbeds/panel_gallery/gallery_edn_inspector.cljs
@@ -358,6 +358,53 @@
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
 
+  ;; ----- additional grammar-edge diffs (rf2-r7xf7) --------------------
+  ;;
+  ;; Three further diff variants the rf2-yaajg six don't reach:
+  ;; pure-add set diff (distinct from set-mixed's add+remove pair),
+  ;; long-string truncation under diff annotation, and symbol-value
+  ;; mutation (distinct from keyword mutation already covered by
+  ;; the canonical map diffs). Each variant pins ONE engine
+  ;; behaviour for visual-regression isolation.
+
+  (story/reg-variant :story.xray.edn-inspector/diff-set-add
+    {:doc        "Pure-add set diff: `#{:a :b}` → `#{:a :b :c}`.
+                 Distinct from `diff-set-mixed`'s add+remove pair —
+                 only `:c` is new and nothing is removed, so the
+                 engine paints a single `+` glyph cleanly without
+                 the remove signal cluttering the per-member walk."
+     :events     [[:panel-gallery.edn-inspector/seed! (fixtures/diff-set-add)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.edn-inspector/diff-long-string-truncation
+    {:doc        "Long-string mutation — `{:bio \"short\"}` →
+                 `{:bio \"<>200-char essay>\"}`. Verifies the
+                 widget's truncation chrome (ellipsis / hover-
+                 expand / overflow handling) renders cleanly when
+                 a long string also carries a `:modified` diff
+                 annotation: the `~` glyph, the truncated
+                 rendering, and the `← changed from \"short\"`
+                 suffix must coexist without one clobbering the
+                 other."
+     :events     [[:panel-gallery.edn-inspector/seed! (fixtures/diff-long-string-truncation)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.xray.edn-inspector/diff-symbol-value
+    {:doc        "Symbol-value mutation — `{:fn-name 'old-handler}`
+                 → `{:fn-name 'new-handler}`. Verifies the
+                 inspector handles symbols correctly under diff
+                 annotation (distinct from keyword mutation).
+                 Symbols carry the `:syntax-symbol` token; under
+                 modification the `~` glyph + `← changed from
+                 old-handler` suffix must render against the
+                 symbol palette without falling back to the
+                 keyword or string token."
+     :events     [[:panel-gallery.edn-inspector/seed! (fixtures/diff-symbol-value)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
   ;; ----- workspace ----------------------------------------------------
   (story/reg-workspace :Workspace.xray.edn-inspector/all
     {:doc      "All edn-inspector widget variants in one auto-grid.
@@ -366,7 +413,8 @@
                 / vector / list / lazy-seq / set / record / uuid /
                 inst / diff (mixed-ops / vector / deep / set-mixed
                 / boolean-toggle / vector-of-maps / nil-vs-missing
-                / numeric-near-equal / redacted-context) / opts
+                / numeric-near-equal / redacted-context / set-add
+                / long-string-truncation / symbol-value) / opts
                 (zoomable / popup / card / header / header-hiccup
                 / site-id / shallow-depth / combined)."
      :layout   :variants-grid


### PR DESCRIPTION
Follow-on to rf2-yaajg #2251 (6 variants) — from the rf2-ya3nj edn-inspector 24hr audit (finding L2). The audit flagged 3 grammar edges the rf2-yaajg six did not reach. This PR lands them, matching the established fixture + reg-variant pattern in `tools/xray/testbeds/panel_gallery/`.

## Predecessors

- **rf2-yaajg / #2251** — landed 6 grammar-edge diff variants (set-mixed, boolean-toggle, vector-of-maps, nil-vs-missing, numeric-near-equal, redacted-context). Set the pattern this PR extends.
- **rf2-ya3nj** — edn-inspector 24-hour audit (2026-05-27) finding L2 flagged 3 still-missing edges.

## Variants added (gallery 30 → 33)

- **`diff-set-add`** — pure-add set diff `#{:a :b}` → `#{:a :b :c}`. Distinct from `diff-set-mixed`'s add+remove pair; isolates the `+` glyph on the key-side member walk without a remove signal cluttering.
- **`diff-long-string-truncation`** — `{:bio "short"}` → `{:bio "<200-char essay>"}`. Verifies the inspector's truncation chrome (ellipsis / hover-expand) renders cleanly when a long string also carries a `:modified` annotation.
- **`diff-symbol-value`** — `{:fn-name '"'"'old-handler}` → `{:fn-name '"'"'new-handler}`. Verifies symbols render under diff annotation against the `:syntax-symbol` palette (distinct from the keyword palette which the canonical map diffs already cover).

## Files

- `tools/xray/testbeds/panel_gallery/fixtures_edn_inspector.cljs` — three new fixture builders under a new "additional grammar-edge diff fixtures (rf2-r7xf7)" banner.
- `tools/xray/testbeds/panel_gallery/gallery_edn_inspector.cljs` — three new `reg-variant` calls under an "additional grammar-edge diffs (rf2-r7xf7)" banner; workspace doc updated to mention the new variants.

## Quality gates

- `shadow-cljs compile :testbeds/panel-gallery` — 553 compiled, **0 warnings**.
- `npm run test:cljs` — 4778 tests / 15618 assertions, **0 failures**. The strengthened smoke from #2254 (`each-gallery-register-all-drops-non-empty-inventory`) passes — the 3 new variants register cleanly with no unknown-tag or grammar errors.
- `bash scripts/test-fast-pr.sh` — **PASS fast PR spine** (markdown gates auto-ran; no md changes).
- `npm run test:browser` — 124 tests / 353 assertions, **0 failures**.

Closes rf2-r7xf7.