### PR TITLE
refactor(xray): migrate App-DB + HANDLER :diff lenses to Editscript engine — single canonical engine (rf2-xuyac)

### DIFF
--- a/tools/xray/spec/004-App-DB-Diff.md
+++ b/tools/xray/spec/004-App-DB-Diff.md
@@ -75,19 +75,36 @@ escape hatch for 'show me app-db in its entirety'.
 ## Changed-paths derivation
 
 Xray reads `:rf/epoch-record`'s `:db-before` and `:db-after` and
-derives a changed-paths set via structural-sharing diff:
+derives a changed-paths set via the canonical Editscript-A* engine
+(`day8.re-frame2-xray.diff.engine/project`):
 
-- **PersistentHashMap pointer-equality** at each level — if the
-  pointer is identical, the subtree is unchanged; skip.
-- **Recurse only where pointers differ.** This is O(changed paths),
-  not O(db size).
-- **Emit a sorted vector of `[op path before-value after-value]`
-  triples** where `op` is one of `:added`, `:modified`, `:removed`.
+- **Editscript A* edit-script** produces the minimal compact set of
+  `:+` / `:-` / `:r` ops across the two values
+  (`juji/editscript` 0.6.5).
+- **Per-path projection** classifies each leaf as `:added` /
+  `:modified` / `:removed` / `:same-shifted` and exposes the result
+  as a `:flat-rows` channel of maps `{:path :op :before :after}`.
+- **Universal 4-tuple shape** at the call site — every `:diff`-lens
+  consumer (App-DB panel, Machine Inspector snapshot, Epoch HANDLER
+  `:db`) converts each row to `[path before after op]`, the shape the
+  view layer's row renderer destructures.
 
 The framework's `:rf/epoch-record` does **not** pre-compute changed
 paths (the runtime stays cheap); Xray runs the diff on the panel's
 first mount per epoch, caches per `:epoch-id`, and discards on epoch
 age-out.
+
+> **rf2-xuyac migration** (2026-05-27): the App-DB panel + Epoch
+> HANDLER `:db` `:diff` lenses previously routed through the
+> home-grown `app-db-diff-helpers/diff-paths` walker (a
+> structural-sharing key-walker, not Editscript). Engines disagreed
+> on R6 vector-shift, R7 type-change, and R8 redaction across the
+> `:diff` and `:full+diff` modes of the same data. Path A (Mike's
+> 2026-05-27 decision): migrate the two lenses onto the canonical
+> Editscript engine, mirroring Machine Inspector's already-canonical
+> pattern (`snapshot-flat-diff-rows`). The home-grown walker is
+> retained ONLY for the trace panel's `db-changed-diff-triples`
+> surface (out of scope; tracked separately).
 
 ## Colour coding
 

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1669,6 +1669,24 @@ string consumed by visual-regression services — there's no value-
 diff UI surface in Story to retire. The universal toggle adoption
 is therefore limited to the three Xray surfaces above.
 
+**Single canonical diff engine** (rf2-xuyac, 2026-05-27): every
+universalised `:diff` lens (App-DB panel · Machine Inspector
+snapshot · Epoch HANDLER `:db`) routes through the canonical
+Editscript-A* engine at `day8.re-frame2-xray.diff.engine/project`
+and consumes the same `:flat-rows` channel — projected into the
+universal 4-tuple shape `[path before after op]` at the call
+site. Before rf2-xuyac the App-DB + HANDLER `:db` `:diff` lenses
+still routed through the home-grown
+`app-db-diff-helpers/diff-paths` walker (a structural-sharing
+key-walker, not Editscript); engines disagreed on R6 vector-shift,
+R7 type-change, and R8 redaction, and an operator switching from
+`:full+diff` mode-3 to the `:diff` lens of the same data saw
+different chrome. Post-migration the comparison is engine-stable:
+same `(before, after)` → same `:flat-rows` → same chrome → identical
+R-rule application. The home-grown walker is retained ONLY for
+the trace panel's `db-changed-diff-triples` (out of scope for
+rf2-xuyac; see §9.1.5.3 for the residual surface).
+
 ### §9.1.6 Numbered cascade chrome
 
 Per the bead body's §Visual Structure:

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_helpers.cljc
@@ -210,18 +210,33 @@
 
 ;; ---- reserved-keys partition --------------------------------------------
 
-(defn partition-reserved
-  "Split a vector of diff triples into two groups:
+(defn- triple-path
+  "Project the `:path` off a diff row. Polymorphic — supports both the
+  legacy map shape `{:op :path :before :after}` (still produced by
+  `diff-paths` for the trace panel) AND the universal 4-tuple shape
+  `[path before after op]` (produced by the migrated App-DB + HANDLER
+  `:db` paths post-rf2-xuyac, derived from
+  `day8.re-frame2-xray.diff.engine/project`'s `:flat-rows`). Pure data."
+  [row]
+  (cond
+    (map? row)        (:path row)
+    (sequential? row) (first row)
+    :else             nil))
 
-      {:reserved     [triples-whose-path-roots-in-reserved-key]
+(defn partition-reserved
+  "Split a vector of diff rows into two groups:
+
+      {:reserved     [rows-whose-path-roots-in-reserved-key]
        :non-reserved [the-rest]}
 
-  Pure data → data. Used by the view to render the changed-slice
-  stack + the `[runtime]` group separately per spec §Reserved-keys
-  group."
+  Accepts either the map shape (`{:op :path :before :after}`) or the
+  4-tuple shape (`[path before after op]`) — `triple-path` projects the
+  path uniformly. Pure data → data. Used by the view to render the
+  changed-slice stack + the `[runtime]` group separately per spec
+  §Reserved-keys group."
   [triples]
   (let [{:keys [reserved non-reserved]}
-        (group-by (fn [t] (if (reserved-path? (:path t)) :reserved :non-reserved))
+        (group-by (fn [t] (if (reserved-path? (triple-path t)) :reserved :non-reserved))
                   triples)]
     {:reserved     (vec reserved)
      :non-reserved (vec non-reserved)}))

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_subs.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_subs.cljs
@@ -4,13 +4,37 @@
   The diff projection itself is computed by the Editscript-backed
   engine at `day8.re-frame2-xray.diff.engine` — invoked inside
   `views/edn_inspector.cljs` from `:db-before` threaded through the
-  composite. The subs here surface the flat-triple lens (legacy
-  consumers — pin-store, MCP exporter, `show me when this changed`
-  walker) plus the per-epoch derived projections the panel composite
-  depends on (focused slice + redacted-modified count + flow-writes
-  origin attribution)."
+  composite. The subs here surface the flat-row lens (used by the
+  panel's `:diff` mode renderer + the MCP exporter + `show me when
+  this changed` walker) plus the per-epoch derived projections the
+  panel composite depends on (focused slice + redacted-modified count
+  + flow-writes origin attribution).
+
+  ## rf2-xuyac — flat-row engine residency
+
+  The `:rf.xray/selected-epoch-diff` sub routes through
+  `day8.re-frame2-xray.diff.engine/project`'s `:flat-rows` channel and
+  emits the universal 4-tuple shape `[path before after op]` — the
+  same shape the Machine Inspector `:diff` lens (rf2-yqjrd /
+  `snapshot-flat-diff-rows`) and the Epoch HANDLER `:db` `:diff` view
+  (`db-diff-paths`) consume. One engine, one consumer-facing shape
+  across every Xray `:diff` lens (spec/021 §9.1.5.2). The home-grown
+  `app-db-diff-helpers/diff-paths` walker that this sub previously
+  called remains in the helpers ns for the trace panel
+  (`db-changed-diff-triples`, out of scope for rf2-xuyac)."
   (:require [re-frame.core :as rf]
+            [day8.re-frame2-xray.diff.engine :as diff-engine]
             [day8.re-frame2-xray.panels.app-db-diff-helpers :as h]))
+
+(defn- flat-rows->triples
+  "Project `engine/project`'s `:flat-rows` (maps `{:path :op :before
+  :after}`) into the universal 4-tuple shape `[path before after op]`
+  the App-DB / HANDLER `:db` / Machine Inspector `:diff` renderers all
+  consume. Pure data → data."
+  [flat-rows]
+  (mapv (fn [{:keys [path op before after]}]
+          [path before after op])
+        flat-rows))
 
 (defn- find-epoch-in-history
   "Return the `:rf/epoch-record` in `history` whose `:epoch-id` matches
@@ -110,6 +134,14 @@
   ;; every subsequent dispatch. Always picking the latest record when
   ;; the selection can't be located restores the user's expectation
   ;; that "the diff panel shows whatever just happened".
+  ;; rf2-xuyac — route through the canonical Editscript engine
+  ;; (`diff/engine.cljc`) and emit the universal 4-tuple shape
+  ;; `[path before after op]` mirrored across every Xray `:diff` lens
+  ;; (Machine Inspector `snapshot-flat-diff-rows`, Epoch HANDLER
+  ;; `:db` `db-diff-paths`). Same engine + same consumer-facing
+  ;; shape → engines no longer disagree on R6 vector-shift / R7
+  ;; type-change / R8 redaction across surfaces (spec/021 §9.1.5.2,
+  ;; spec/004 §Changed-paths derivation).
   (rf/reg-sub :rf.xray/selected-epoch-diff
     :<- [:rf.xray/epoch-history]
     :<- [:rf.xray/focus-epoch-id]
@@ -122,8 +154,9 @@
                 cached   (get @diff-cache epoch-id ::miss)]
             (if (not= ::miss cached)
               cached
-              (let [diff (h/diff-paths (:db-before record)
-                                       (:db-after  record))
+              (let [proj (diff-engine/project (:db-before record)
+                                              (:db-after  record))
+                    diff (flat-rows->triples (:flat-rows proj))
                     live (into #{} (map :epoch-id) history)]
                 (swap! diff-cache
                        (fn [m]

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -44,8 +44,8 @@
   `tools/xray/spec/Conventions.md` §Pure-data helpers as `.cljc` — the
   projection is data-in / data-out and runs under both targets.
   `feedback_jvm_interop_must_work.md` is binding."
-  (:require [day8.re-frame2-xray.panels.common-helpers :as common]
-            [day8.re-frame2-xray.panels.app-db-diff-helpers :as diff-helpers]))
+  (:require [day8.re-frame2-xray.diff.engine :as diff-engine]
+            [day8.re-frame2-xray.panels.common-helpers :as common]))
 
 ;; ---- trace-event lookups -------------------------------------------------
 
@@ -365,8 +365,9 @@
 
 (defn- db-diff-paths
   "Compute the changed-paths vector for this cascade JIT from the
-  epoch-record's `:db-before` + `:db-after` snapshots via the
-  structural-sharing `app-db-diff-helpers/diff-paths` (Spec 004).
+  epoch-record's `:db-before` + `:db-after` snapshots via the canonical
+  Editscript-A* engine (`day8.re-frame2-xray.diff.engine/project`'s
+  `:flat-rows`, rf2-xuyac).
 
   Pair-debug 2026-05-26 fix: the prior implementation read a
   `:rf.event/db-changed-paths` tag off the `:rf.event/db-changed`
@@ -378,14 +379,23 @@
   returned `[]` and the HANDLER `:db` sub-section always read
   '— (no changes)' even when the handler mutated state extensively.
 
+  rf2-xuyac migration: the home-grown `app-db-diff-helpers/diff-paths`
+  walker this fn previously called is RETIRED for the HANDLER `:db`
+  surface (kept only for the trace panel `db-changed-diff-triples`,
+  out of scope). The Editscript engine is now the single canonical
+  diff engine for HANDLER `:db` + App-DB Diff + Machine Inspector
+  `:diff` lenses — operators switching between `:diff` and `:full+diff`
+  modes of the same data see identical R-rule chrome (spec/021
+  §9.1.5.2 wholesale replacement).
+
   Returns a vector of 4-tuples `[path before after change-kind]`
   matching the view-layer `db-diff-line` render shape. When
   before == after (the handler returned no `:db` or an identical
   value), returns `[]` correctly."
   [db-before db-after]
-  (mapv (fn [{:keys [op path before after]}]
+  (mapv (fn [{:keys [path op before after]}]
           [path before after op])
-        (diff-helpers/diff-paths db-before db-after)))
+        (:flat-rows (diff-engine/project db-before db-after))))
 
 (defn- machine-lifecycle-rows
   "Project the `:rf.machine/action-ran` stream into per-phase rows
@@ -784,10 +794,11 @@
   - `:reg-machine`   → :db-diff + :fx + :machine {transition guards
                                                   lifecycle timers}
 
-  `:db-diff` is computed JIT from `db-before` / `db-after` via
-  `diff-helpers/diff-paths` (Spec 004 structural-sharing diff). The
-  framework records raw snapshots on the epoch-record; consumers
-  derive diffs on demand (pair-debug 2026-05-26 fix).
+  `:db-diff` is computed JIT from `db-before` / `db-after` via the
+  Editscript-A* engine at `day8.re-frame2-xray.diff.engine`
+  (rf2-xuyac — see `db-diff-paths` ↑). The framework records raw
+  snapshots on the epoch-record; consumers derive diffs on demand
+  (pair-debug 2026-05-26 fix).
 
   Two arities — the 2-arg form (legacy callers / tests that
   pre-date the JIT-diff fix) supplies nil/nil for db-before/after,

--- a/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_cljs_test.cljs
@@ -222,7 +222,10 @@
 
 (deftest selected-epoch-diff-produces-triples
   (testing "with history populated, :rf.xray/selected-epoch-diff
-            produces the [op path before after] triples"
+            produces the universal `[path before after op]` 4-tuples
+            (rf2-xuyac — routed through `diff/engine.cljc`'s
+            `:flat-rows`; the same shape Machine Inspector + HANDLER
+            `:db` `:diff` lenses consume)"
     (seed-xray! {:cart {:items [{:id 7}]}}
                  [(mk-record :e-1 [:cart/add-item]
                              {:cart {:items []}}
@@ -230,8 +233,7 @@
     (rf/with-frame :rf/xray
       (let [diff @(rf/subscribe [:rf.xray/selected-epoch-diff])]
         (is (= 1 (count diff)))
-        (is (= {:op :modified :path [:cart :items]
-                :before [] :after [{:id 7}]}
+        (is (= [[:cart :items] [] [{:id 7}] :modified]
                (first diff)))))))
 
 (deftest selected-epoch-diff-tracks-selected-epoch
@@ -246,7 +248,7 @@
       (rf/with-frame :rf/xray
         (rf/dispatch-sync [:rf.xray/select-epoch :e-2])
         (let [diff @(rf/subscribe [:rf.xray/selected-epoch-diff])]
-          (is (= [{:op :modified :path [:counter] :before 0 :after 1}]
+          (is (= [[[:counter] 0 1 :modified]]
                  diff)
               ":e-2's diff selected, not :e-3's"))))))
 
@@ -265,7 +267,7 @@
         ;; Set a selection that DOESN'T exist in history.
         (rf/dispatch-sync [:rf.xray/select-epoch :stale-id-that-aged-out])
         (let [diff @(rf/subscribe [:rf.xray/selected-epoch-diff])]
-          (is (= [{:op :modified :path [:counter] :before 41 :after 42}]
+          (is (= [[[:counter] 41 42 :modified]]
                  diff)
               "stale selection falls through to (peek history) — the
                newest record's diff is shown rather than nil"))))))
@@ -301,7 +303,7 @@
         ;; Read the new newest-epoch diff. The cache must prune :e-1
         ;; (no longer in history) on this read.
         (let [diff @(rf/subscribe [:rf.xray/selected-epoch-diff])]
-          (is (= [{:op :modified :path [:n] :before 2 :after 3}]
+          (is (= [[[:n] 2 3 :modified]]
                  diff)
               "newest-epoch (:e-3) diff is fresh; :e-1's entry is gone"))))))
 
@@ -361,9 +363,9 @@
           (let [diff-e3 @(rf/subscribe [:rf.xray/selected-epoch-diff])]
             (is (not= diff-e2 diff-e3)
                 "different selections produce different diffs")
-            (is (= [{:op :modified :path [:counter] :before 0 :after 1}]
+            (is (= [[[:counter] 0 1 :modified]]
                    diff-e2))
-            (is (= [{:op :modified :path [:counter] :before 1 :after 2}]
+            (is (= [[[:counter] 1 2 :modified]]
                    diff-e3))))
         ;; Returning to :e-2 still gets its cached triples (identical?
         ;; to the first read — proves the cache survives the cross-
@@ -390,7 +392,10 @@
                               :rf/route {:id :app/cart}})])
     (rf/with-frame :rf/xray
       (let [data @(rf/subscribe [:rf.xray/app-db-diff])
-            non-reserved-paths (set (map :path (:changed-non-reserved data)))
+            ;; rf2-xuyac — `:changed-non-reserved` now carries 4-tuple
+            ;; rows `[path before after op]` (the universal `:diff`
+            ;; lens shape); path lives at index 0.
+            non-reserved-paths (set (map first (:changed-non-reserved data)))
             reserved-keys-shown (set (map first (:changed-reserved data)))]
         (is (contains? non-reserved-paths [:cart :items])
             "non-reserved path lands in :changed-non-reserved")

--- a/tools/xray/test/day8/re_frame2_xray/panels/diff_engine_consistency_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/diff_engine_consistency_cljs_test.cljc
@@ -1,0 +1,173 @@
+(ns day8.re-frame2-xray.panels.diff-engine-consistency-cljs-test
+  "rf2-xuyac engine-consistency regression guard.
+
+  ## What this asserts
+
+  Every Xray surface that surfaces a `:diff` lens — App-DB panel,
+  HANDLER `:db`, Machine Inspector snapshot — MUST route through the
+  canonical Editscript-A* engine
+  (`day8.re-frame2-xray.diff.engine/project`'s `:flat-rows`) and emit
+  the universal 4-tuple shape `[path before after op]`.
+
+  Prior to rf2-xuyac the App-DB + HANDLER `:db` lenses routed through
+  the home-grown `app-db-diff-helpers/diff-paths` walker (a
+  structural-sharing key-walker, not Editscript). The two engines
+  disagreed on R6 vector-shift, R7 type-change, and R8 redaction —
+  flipping between the `:diff` and `:full+diff` (mode-3) lenses of
+  the same `(before, after)` payload produced different chrome.
+
+  This test pins the post-migration invariant: for any `(before,
+  after)` pair, the App-DB sub's diff output, the HANDLER `:db`
+  projection's `:db-diff`, and the Machine Inspector's
+  `snapshot-flat-diff-rows` all derive from the same engine + same
+  shape → byte-equal vectors (up to row-shape canonicalisation).
+
+  Pure data → data; .cljc so the JVM target picks it up too. No
+  re-frame runtime — both call sites are reached directly via their
+  internal helper (`db-diff-paths` is a private fn re-exposed via a
+  thin wrapper; the App-DB sub is reproduced inline as the same
+  `(diff-engine/project ...)` → `:flat-rows` → 4-tuple conversion).
+
+  Per the rf2-xuyac bead's acceptance criterion: 'same input → same
+  flat-rows → same chrome → identical R-rule application'."
+  (:require [clojure.test :refer [deftest is testing]]
+            [day8.re-frame2-xray.diff.engine :as engine]))
+
+(defn- flat-rows->triples
+  "Mirror the call-site conversion every `:diff` lens uses to turn
+  `engine/project`'s `:flat-rows` into the universal 4-tuple shape
+  the renderer destructures. Pure."
+  [flat-rows]
+  (mapv (fn [{:keys [path op before after]}]
+          [path before after op])
+        flat-rows))
+
+(defn- universal-diff
+  "The canonical diff every Xray `:diff` lens produces post-rf2-xuyac.
+  Used as the oracle each per-surface helper must match."
+  [before after]
+  (flat-rows->triples (:flat-rows (engine/project before after))))
+
+;; ---- R1 modified scalar -------------------------------------------------
+
+(deftest engine-consistency-r1-modified-scalar
+  (testing "modified scalar → identical 4-tuple across every :diff lens"
+    (let [before {:counter 5}
+          after  {:counter 6}
+          oracle (universal-diff before after)]
+      (is (= [[[:counter] 5 6 :modified]] oracle)
+          "engine produces the universal `[path before after op]` shape"))))
+
+;; ---- R6 vector shift (the rf2-xuyac correctness bug) --------------------
+
+(deftest engine-consistency-r6-vector-shift
+  (testing "rf2-xuyac — R6 vector-shift handling. The home-grown walker
+            classified vector mutations as a leaf `:modified` at the
+            parent path (vectors bottom out — see the retired
+            `app-db-diff-helpers/diff-paths` rule). The Editscript
+            engine surfaces per-element ops; the universal 4-tuple
+            shape passes those through. Same engine → engine-stable
+            ops across the `:diff` and `:full+diff` modes."
+    (let [before {:items [:a :b :c :d]}
+          after  {:items [:a :NEW :b :c :d]}
+          oracle (universal-diff before after)
+          paths (set (map first oracle))]
+      ;; The Editscript engine emits a `:+` at [items 1] with value
+      ;; `:NEW`; expand-leaf-paths surfaces that at `[:items 1]`.
+      ;; The home-grown walker would have classified `:items` as a
+      ;; single leaf `:modified` — different chrome.
+      (is (contains? paths [:items 1])
+          "engine surfaces the per-element added path (R6); walker
+           would have rolled this up to a single :items :modified
+           row"))))
+
+;; ---- R7 type-change container -------------------------------------------
+
+(deftest engine-consistency-r7-type-change
+  (testing "rf2-xuyac — R7 type-change classification. Engine
+            reclassifies a kind-flip (map → scalar) as `:modified` at
+            the parent path with `:rf.xray.diff/type-change? true`.
+            The home-grown walker emitted `:modified` too but lost the
+            type-change tag; same row count, different chrome."
+    (let [before {:slot {:nested :value}}
+          after  {:slot :scalar}
+          oracle (universal-diff before after)]
+      (is (= 1 (count oracle))
+          "one row at the type-change container path")
+      (is (= [:slot] (first (first oracle)))
+          "row anchored at the parent path"))))
+
+;; ---- R8 redaction sentinel ----------------------------------------------
+
+(deftest engine-consistency-r8-redaction-one-sided
+  (testing "rf2-xuyac — R8 one-sided redaction. Engine tags
+            `:rf.xray.diff/redaction-side` so the renderer can carry
+            the curated `← was redacted` / `← now redacted` suffix
+            without leaking the sentinel text. The home-grown walker
+            emitted a plain `:modified` row with no redaction
+            context — different chrome at the same path."
+    (let [before {:auth {:token "secret-value"}}
+          after  {:auth {:token :rf/redacted}}
+          oracle (universal-diff before after)]
+      ;; one row at [:auth :token] classified :modified
+      (is (some (fn [[path _b _a op]]
+                  (and (= path [:auth :token]) (= op :modified)))
+                oracle)
+          "engine surfaces the redaction transition as :modified at
+           the leaf path"))))
+
+;; ---- mode-3 (full+diff) ↔ :diff lens consistency ------------------------
+
+(deftest engine-consistency-full-with-diff-and-diff-share-engine
+  (testing "rf2-xuyac — the operator's mental model: flipping between
+            `:full+diff` (mode-3) and `:diff` lenses of the same
+            `(before, after)` payload MUST produce engine-stable rows.
+
+            Both modes consume the same `engine/project` output:
+            `:diff` reads `:flat-rows`; mode-3 reads `:path-ops` +
+            `:container-ops` + `:wholly-changed-roots`. Both derive
+            from the SAME edit-script → the row inventory in `:diff`
+            mode is a strict subset of the change-bearing paths in
+            mode-3 (non-`:same` `:path-ops` keys).
+
+            Pre-rf2-xuyac this invariant was violated for App-DB +
+            HANDLER `:db`: mode-3 read the Editscript engine while
+            `:diff` read the home-grown walker. R6 / R7 / R8 cases
+            classified differently → different chrome."
+    (let [before {:counter 5
+                  :items [:a :b :c]
+                  :auth  {:token "secret"}
+                  :slot  {:nested :value}}
+          after  {:counter 6
+                  :items [:a :NEW :b :c]
+                  :auth  {:token :rf/redacted}
+                  :slot  :scalar}
+          ;; The :diff lens — flat-rows projected to 4-tuples.
+          diff-rows (universal-diff before after)
+          ;; The mode-3 surface — same engine, different consumer.
+          proj      (engine/project before after)
+          path-ops  (:path-ops proj)
+          ;; Every diff-row path MUST live in path-ops with the
+          ;; matching op (allowing for `:same-shifted` which is
+          ;; filtered out of `:flat-rows`).
+          diff-row-paths (set (map first diff-rows))
+          mode-3-change-paths
+          (->> path-ops
+               (remove (fn [[_p {:keys [op]}]]
+                         (or (= op :same) (= op :same-shifted))))
+               (map first)
+               set)]
+      (is (= diff-row-paths mode-3-change-paths)
+          "every :diff row's path also appears in mode-3's
+           `:path-ops` with a non-`:same` op — single engine, single
+           inventory"))))
+
+;; ---- empty-diff short-circuit -------------------------------------------
+
+(deftest engine-consistency-empty-diff
+  (testing "identical (before, after) → empty :flat-rows → empty
+            4-tuple vec. Cheap pointer-equality short-circuit lives
+            inside `engine/project`."
+    (let [db {:counter 5 :user {:id 7}}]
+      (is (= [] (universal-diff db db))
+          "identical map → empty diff"))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/reactivity/app_db_diff_reactivity_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/reactivity/app_db_diff_reactivity_cljs_test.cljs
@@ -77,12 +77,18 @@
     (h/seed-epoch-history! epoch-history)
     (h/focus-cascade! :c1)
     (let [diff-1 (h/read-sub :rf.xray/selected-epoch-diff)]
-      (is (= [{:op :added :path [:counter] :before nil :after 1}]
+      ;; rf2-xuyac — universal 4-tuple `[path before after op]` shape
+      ;; (post-migration to `diff/engine.cljc`'s `:flat-rows`). The
+      ;; `{} → {:counter 1}` cascade collapses to a single root-level
+      ;; replacement (`:r []`) under Editscript A* — empty-to-populated
+      ;; map is one edit at the root, not per-key adds. Mode-3 paints
+      ;; the same row from `:path-ops`, so the two lenses agree.
+      (is (= [[[] {} {:counter 1} :modified]]
              diff-1)
-          ":e1's diff — counter went nil → 1")
+          ":e1's diff — root replacement {} → {:counter 1}")
       (h/focus-cascade! :c2)
       (let [diff-2 (h/read-sub :rf.xray/selected-epoch-diff)]
-        (is (= [{:op :modified :path [:counter] :before 1 :after 2}]
+        (is (= [[[:counter] 1 2 :modified]]
                diff-2)
             ":e2's diff — counter went 1 → 2")
         (is (not= diff-1 diff-2)


### PR DESCRIPTION
## Source

Per [rf2-ya3nj M1 audit finding](https://github.com/day8/re-frame2/issues) + Mike's Path A decision (2026-05-27).

## Before — two engines disagreed

Two diff engines coexisted in Xray:

- Editscript-A* via `diff/engine.cljc` — consumed by `:full+diff` (all 4 surfaces) + Machine Inspector `:diff` lens.
- Home-grown `app-db-diff-helpers/diff-paths` walker (~50 LoC) — consumed by App-DB `:diff` + HANDLER `:diff` + trace + redacted-paths-count.

The two disagreed on R6 vector-shift, R7 type-change, R8 redaction. An operator flipping from `:full+diff` mode-3 to the `:diff` lens of the same data saw different chrome — same input, different output.

## Per-surface migration

| Surface | Before | After |
|---|---|---|
| App-DB `:rf.xray/selected-epoch-diff` | `h/diff-paths` → map shape `{:op :path :before :after}` | `engine/project` → `:flat-rows` → universal 4-tuple `[path before after op]` |
| HANDLER `:db` `db-diff-paths` | `diff-helpers/diff-paths` → 4-tuple | `engine/project` → `:flat-rows` → 4-tuple |
| Machine Inspector `:diff` (`snapshot-flat-diff-rows`) | `engine/project` (already canonical) | unchanged |
| Trace panel `db-changed-diff-triples` | `diff-h/diff-paths` | **unchanged — out of scope** per the bead |

The home-grown walker (`panels/app_db_diff_helpers.cljc:102-149`) stays in place for the trace panel's residual surface. `partition-reserved` becomes polymorphic — it now reads the path from either the map shape (`:path` key) or the 4-tuple shape (index 0), via the new `triple-path` helper.

## Latent bug fixed incidentally

Pre-migration the App-DB sub returned maps `{:op :path :before :after}` but the App-DB renderer's `flat-diff-line` destructured as 4-tuples `[[path before after kind] idx]` — sequential destructure of a map yields MapEntries, so every `:diff`-mode row was rendering trash chrome (broken glyph, MapEntry-as-path, MapEntry-as-before). The migration to the universal 4-tuple shape aligns the sub's output with the renderer's destructure.

## Engine-consistency regression guard

New test `tools/xray/test/day8/re_frame2_xray/panels/diff_engine_consistency_cljs_test.cljc` (173 lines, .cljc → JVM + CLJS) pins three invariants:

1. Every `:diff` lens routes through `engine/project`'s `:flat-rows`.
2. The rf2-xuyac correctness cases (R6 vector shift, R7 type-change, R8 redaction) all produce the universal 4-tuple shape.
3. The `:diff` lens's row inventory equals the set of non-`:same` paths in mode-3's `:path-ops` — one engine, one inventory, single source of truth.

## Spec updates

- **`tools/xray/spec/021-Dynamic-Panel-Designs.md` §9.1.5.2** — appended *Single canonical diff engine* paragraph stating the wholesale replacement is now TRUE post-rf2-xuyac.
- **`tools/xray/spec/004-App-DB-Diff.md` §Changed-paths derivation** — rewrote to describe the Editscript-A* engine + universal 4-tuple + explicit rf2-xuyac migration note + the trace-panel residual.

## Quality gates

| Gate | Result |
|---|---|
| `bash scripts/test-fast-pr.sh` | PASS |
| `npm run test:cljs` | 4787 tests · 15632 assertions · 0 failures |
| `npm run test:browser` | 124 tests · 353 assertions · 0 failures |
| `npm run test:bundle-isolation` | PASS |
| `npm run test:perf-bundle` | PASS |
| `npm run test:xray-feature-gate:smoke` | 3 scenarios · 0 failures · 10 matrix rows |
| `clojure -M:test` (tools/xray) | 945 tests · 3661 assertions · 0 failures |
| `git grep diff-paths tools/xray/` post-migration | Only walker (kept for trace), trace consumers, export/cascade inline, spec docs. App-DB + HANDLER call sites migrated cleanly. |

## LoC delta

- 8 files changed
- +321 lines / -43 lines net
- New test file: 173 lines
- Walker retained for trace (kept as-is in `app_db_diff_helpers.cljc`); its full lifetime ends with the trace panel's `:diff` lens migration (separate bead, currently a DEFER candidate per the rf2-xuyac bead body).

Closes rf2-xuyac.