### PR TITLE
fix(xray/views): convert edn_inspector_popup_stack defn → reg-view to capture surrounding frame (rf2-1yif8)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/views/edn_inspector_popup.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_inspector_popup.cljs
@@ -489,7 +489,7 @@
 ;; stack view — renders every open popup over the active panel
 ;; =========================================================================
 
-(defn edn-inspector-popup-stack
+(rf/reg-view edn-inspector-popup-stack
   "Stack view that renders every open popup in z-index order. Mount
   this once at the shell's overlay container (follow-on bead wires
   it into `mount.cljs`); each entry's payload is the value + opts
@@ -504,7 +504,16 @@
   and this view picks the entry up and renders it. The plain
   `[edn-inspector-popup v opts]` component is the entry point for
   **inline** opens (a panel that wants to control the popup
-  imperatively from its own view tree)."
+  imperatively from its own view tree).
+
+  Per rf2-1yif8 `reg-view`-registered (was a plain Reagent `defn`
+  prior, which silently routed `subscribe` / `dispatch` to
+  `:rf/default` when mounted under a non-default frame — the exact
+  class of bug `:rf.warning/plain-fn-under-non-default-frame-once`
+  was added to catch). The view-id is auto-derived from the symbol
+  per the canonical reg-view convention; the surrounding shell mounts
+  this stack under `:rf/xray`, so all its `subscribe` calls now
+  resolve through the React-context tier to the surrounding frame."
   []
   (let [stack   @(rf/subscribe [stack-slot])
         entries @(rf/subscribe [entries-slot])

--- a/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_popup_wireup_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_popup_wireup_cljs_test.cljs
@@ -272,3 +272,87 @@
       (let [stack @(rf/subscribe [ddp/stack-slot])]
         (is (= ["smoke"] stack)
             "open event resolved through the registry-installed handler")))))
+
+;; =========================================================================
+;; rf2-1yif8 — frame-context regression
+;; =========================================================================
+;;
+;; Before rf2-1yif8 `edn-inspector-popup-stack` was a plain Reagent `defn`.
+;; Plain fns are substrate-level Reagent components: they do not carry the
+;; `:rf/frame` React-context that `reg-view` automatically wires up, so the
+;; body's `rf/subscribe` calls fell through to `:rf/default` even when the
+;; component was mounted under a non-default frame (the shell mounts the
+;; stack under `:rf/xray`). The runtime fires
+;; `:rf.warning/plain-fn-under-non-default-frame-once` to catch exactly
+;; this class of bug.
+;;
+;; Post-fix the symbol is registered via `rf/reg-view`, so the auto-derived
+;; id `:day8.re-frame2-xray.views.edn-inspector-popup/edn-inspector-popup-
+;; stack` is resolvable through `(rf/view id)`, and subscribes inside the
+;; render body route through the surrounding `:rf/xray` frame instead of
+;; silently landing on `:rf/default`.
+
+(def ^:private popup-stack-view-id
+  :day8.re-frame2-xray.views.edn-inspector-popup/edn-inspector-popup-stack)
+
+(deftest popup-stack-view-is-reg-view-registered
+  (testing "rf2-1yif8 — `edn-inspector-popup-stack` is `reg-view`-
+            registered under its auto-derived ns/sym id, so the body's
+            subscribes inherit the surrounding frame from React context
+            (the symptom under a plain `defn` was the
+            `:rf.warning/plain-fn-under-non-default-frame-once` warning
+            firing on every panel-gallery `:rf/xray` render)."
+    (setup-xray-frame!)
+    (is (some? (rf/view popup-stack-view-id))
+        "view is registered under the auto-derived ns/sym id")))
+
+(deftest popup-stack-view-subscribes-route-to-surrounding-frame
+  (testing "rf2-1yif8 — when the stack view is rendered under `:rf/xray`,
+            its subscribes read `:rf/xray`'s app-db, NOT `:rf/default`.
+            We open a popup in `:rf/xray` and confirm the rendered chrome
+            reflects `:rf/xray`'s stack; a popup written into
+            `:rf/default` MUST NOT leak in.
+            Plain-fn regression would render `:rf/default`'s entry (or
+            nil when `:rf/xray`'s slot is empty) — that is exactly the
+            bug this test pins."
+    (setup-xray-frame!)
+    ;; `:rf.xray/modal-positioning` is already registered by
+    ;; `register-xray-handlers!` inside `setup-xray-frame!`.
+    ;; Seed contradicting data in :rf/default + :rf/xray. If the
+    ;; subscribes silently route to :rf/default, the test would see
+    ;; the "default-only" mount-id; the correct routing sees "xray-only".
+    (rf/dispatch-sync
+      [:rf.xray.edn-inspector-popup/open
+       "default-only" {:value :default-payload :opts {}}])
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync
+        [:rf.xray.edn-inspector-popup/open
+         "xray-only" {:value :xray-payload :opts {}}]))
+    ;; Render the stack view under :rf/xray. After rf2-1yif8 this is a
+    ;; reg-view, so calling it under `with-frame :rf/xray` resolves
+    ;; subscribes through the dynamic-var tier (headless mode — no React
+    ;; context here, but the registered wrapper still routes through the
+    ;; surrounding frame). The pre-fix plain-fn would have ignored the
+    ;; `with-frame` binding entirely because the body's `rf/subscribe`
+    ;; calls would have fallen all the way through to `:rf/default`.
+    (rf/with-frame :rf/xray
+      (let [tree (ddp/edn-inspector-popup-stack)]
+        (is (some? tree)
+            "stack view rendered some chrome under :rf/xray (proves :rf/xray's
+             stack slot is non-empty from the view's perspective)")
+        (is (some? (find-by-testid tree
+                                   "rf-xray-edn-inspector-popup-backdrop-xray-only"))
+            "the :rf/xray-frame's mount-id `xray-only` was picked up by the
+             view's subscribe — proves the subscribe routed to :rf/xray,
+             not :rf/default")
+        (is (nil? (find-by-testid tree
+                                  "rf-xray-edn-inspector-popup-backdrop-default-only"))
+            "the :rf/default-frame's mount-id `default-only` was NOT
+             visible to the view — proves the subscribe did not leak across
+             frames"))
+      ;; And the stack's count attribute reflects :rf/xray's stack
+      ;; depth exclusively (one entry), not the combined two.
+      (let [tree (ddp/edn-inspector-popup-stack)]
+        (is (= 1 (-> tree second :data-rf-popup-count))
+            "popup-count reflects :rf/xray's stack only (one entry), not
+             the two-entry total across frames")))))


### PR DESCRIPTION
## Root cause

`edn_inspector_popup_stack` in `tools/xray/src/day8/re_frame2_xray/views/edn_inspector_popup.cljs` (line 509 pre-fix) was defined as a plain Reagent `defn`. Plain Reagent fns are substrate-level components — they do not carry the `:rf/frame` React-context that `reg-view` auto-wires up. The popup stack is mounted under `:rf/xray` in the shell, but the body's `rf/subscribe` calls fell through to `:rf/default`. The framework's runtime warning fires on every panel-gallery render under non-default frames:

```
[re-frame] day8.re_frame2_xray.views.edn_inspector_popup
.edn_inspector_popup_stack rendered under :rf/xray;
subscribe/dispatch routed to :rf/default.
Plain Reagent fns do not pick up the surrounding frame;
their dispatch/subscribe targets :rf/default. To capture
the surrounding frame, register the view via reg-view.
```

This is the exact class of bug `:rf.warning/plain-fn-under-non-default-frame-once` (Spec 006 §706) was added to catch.

## Diff (defn → reg-view)

```clojure
;; before (line 492 pre-fix)
(defn edn-inspector-popup-stack
  "..."
  []
  (let [stack   @(rf/subscribe [stack-slot]) ...]
    ...))

;; after
(rf/reg-view edn-inspector-popup-stack
  "... Per rf2-1yif8 reg-view-registered (was a plain Reagent `defn`
   prior, which silently routed `subscribe` / `dispatch` to
   `:rf/default` when mounted under a non-default frame ..."
  []
  (let [stack   @(rf/subscribe [stack-slot]) ...]
    ...))
```

The macro auto-derives the view id
`:day8.re-frame2-xray.views.edn-inspector-popup/edn-inspector-popup-stack`
(matching the convention used by every other `reg-view` in `tools/xray/`) and attaches `{:contextType frame-context}` to the wrapper so React-context resolves `:rf/xray` at render time. The body is otherwise unchanged.

## Frame-context test (new)

Added two regression-pinning tests to `edn_inspector_popup_wireup_cljs_test.cljs`:

1. `popup-stack-view-is-reg-view-registered` — confirms `(rf/view :day8.re-frame2-xray.views.edn-inspector-popup/edn-inspector-popup-stack)` resolves to a non-nil handler (the registration is real).
2. `popup-stack-view-subscribes-route-to-surrounding-frame` — seeds contradicting popup-stack data into `:rf/default` and `:rf/xray`, then renders the view under `with-frame :rf/xray`. Asserts:
    - the `:rf/xray` mount-id IS in the rendered chrome,
    - the `:rf/default` mount-id is NOT in the rendered chrome,
    - `data-rf-popup-count` reflects `:rf/xray`'s stack only (1, not the combined 2).
   Under the plain-fn shape this would have failed: the subscribe would have read `:rf/default`'s stack, surfacing `default-only` and missing `xray-only`.

## Verification

| Gate | Result |
|------|--------|
| `bash scripts/test-fast-pr.sh` | PASS |
| `npm run test:cljs` | PASS (4783 tests, 15630 assertions, 0 failures) |
| `npm run test:browser` | PASS (124 tests, 353 assertions) |
| `npm run test:bundle-isolation` | PASS |
| `npm run test:xray-feature-gate:smoke` | PASS (3 scenarios, 10 matrix rows) |
| New frame-context tests | PASS |

The new `popup-stack-view-subscribes-route-to-surrounding-frame` test is the canonical regression pin for this bug class.

## Out of scope

The inline `edn-inspector-popup` Form-2 component (same file, line 445) is also a plain Reagent fn with `rf/subscribe` calls in its render body. Per the bead it is out of scope — the bead is narrowly scoped to `edn_inspector_popup_stack`. A follow-up bead will track the inline component if the warning fires for it under any mount path.

Closes rf2-1yif8.