### PR TITLE
feat(testbeds): add re-frame2-pair.runtime preload to testbed builds for pair-MCP probing (rf2-54jz4)

### DIFF
--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -630,11 +630,19 @@
   ;;
   ;; Served at http://localhost:8765 via the top-level `:dev-http` map
   ;; (rf2-aqcix) — see the docstring on that key for the cascade rationale.
+  ;;
+  ;; rf2-54jz4 — the re-frame2-pair.runtime preload is wired so the
+  ;; pair-MCP can probe this testbed's live runtime (discover-app /
+  ;; eval-cljs / snapshot / subscribe / etc.). Dev-only: `:devtools`
+  ;; preloads are honoured by `shadow-cljs watch` / `compile` but NOT
+  ;; by `release`, so the preload never reaches a production bundle
+  ;; (testbed isn't released anyway — it's served via dev-http only).
   :testbeds/panel-gallery
   {:target     :browser
    :output-dir "out/testbeds/panel-gallery"
    :asset-path "."
-   :modules    {:main {:init-fn panel-gallery.core/run}}}
+   :modules    {:main {:init-fn panel-gallery.core/run}}
+   :devtools   {:preloads [re-frame2-pair.runtime]}}
 
   :examples/temperature
   {:target     :browser
@@ -954,85 +962,109 @@
 
   ;; rf2-kzcim — deliberate-throw testbed (the throw-from-each-layer
   ;; surface; four buttons, four :rf.error/* categories).
+  ;; rf2-54jz4 — re-frame2-pair.runtime preload added so pair-MCP can
+  ;; probe this dev testbed's live runtime alongside Xray.
   :testbeds/deliberate-throw
   {:target     :browser
    :output-dir "out/testbeds/deliberate-throw"
    :asset-path "."
    :modules    {:main {:init-fn deliberate-throw.core/run}}
-   :devtools   {:preloads [day8.re-frame2-xray.preload]}}
+   :devtools   {:preloads [re-frame2-pair.runtime
+                           day8.re-frame2-xray.preload]}}
 
   ;; rf2-kzcim — schema-violation testbed (the four :where surfaces of
   ;; :rf.error/schema-validation-failure; one button per :where).
+  ;; rf2-54jz4 — re-frame2-pair.runtime preload added so pair-MCP can
+  ;; probe this dev testbed's live runtime alongside Xray.
   :testbeds/schema-violation
   {:target     :browser
    :output-dir "out/testbeds/schema-violation"
    :asset-path "."
    :modules    {:main {:init-fn schema-violation.core/run}}
-   :devtools   {:preloads [day8.re-frame2-xray.preload]}}
+   :devtools   {:preloads [re-frame2-pair.runtime
+                           day8.re-frame2-xray.preload]}}
 
   ;; rf2-kzcim — http-toggle testbed (single button + outcome dropdown
   ;; enumerating the eight :rf.http/* categories per Spec 014).
+  ;; rf2-54jz4 — re-frame2-pair.runtime preload added so pair-MCP can
+  ;; probe this dev testbed's live runtime alongside Xray.
   :testbeds/http-toggle
   {:target     :browser
    :output-dir "out/testbeds/http-toggle"
    :asset-path "."
    :modules    {:main {:init-fn http-toggle.core/run}}
-   :devtools   {:preloads [day8.re-frame2-xray.preload]}}
+   :devtools   {:preloads [re-frame2-pair.runtime
+                           day8.re-frame2-xray.preload]}}
 
   ;; rf2-kzcim Tier 2 — multi-frame testbed (three frames coexisting:
   ;; :counter/a, :counter/b, :log; the Cross-bump button fans out a
   ;; handler running on :counter/a to dispatches against :counter/b
   ;; and :log via cross-frame `:dispatch` fx per Spec 002).
+  ;; rf2-54jz4 — re-frame2-pair.runtime preload added so pair-MCP can
+  ;; probe this dev testbed's live runtime alongside Xray.
   :testbeds/multi-frame
   {:target     :browser
    :output-dir "out/testbeds/multi-frame"
    :asset-path "."
    :modules    {:main {:init-fn multi-frame.core/run}}
-   :devtools   {:preloads [day8.re-frame2-xray.preload]}}
+   :devtools   {:preloads [re-frame2-pair.runtime
+                           day8.re-frame2-xray.preload]}}
 
   ;; rf2-kzcim Tier 2 — deep-machine testbed (one machine exercising
   ;; every Spec 005 grammar surface: parallel regions, hierarchical
   ;; compound 5+ levels deep, :always, :after, :spawn, :spawn-all).
+  ;; rf2-54jz4 — re-frame2-pair.runtime preload added so pair-MCP can
+  ;; probe this dev testbed's live runtime alongside Xray.
   :testbeds/deep-machine
   {:target     :browser
    :output-dir "out/testbeds/deep-machine"
    :asset-path "."
    :modules    {:main {:init-fn deep-machine.core/run}}
-   :devtools   {:preloads [day8.re-frame2-xray.preload]}}
+   :devtools   {:preloads [re-frame2-pair.runtime
+                           day8.re-frame2-xray.preload]}}
 
   ;; rf2-kzcim Tier 2 — long-flow-w-failure testbed (a multi-second
   ;; cascade of app-db writes driving three flows in topo order; the
   ;; middle flow throws on a configurable input threshold to
   ;; exercise the atomicity contract per Spec 013 §Failure semantics
   ;; rf2-hrqvg).
+  ;; rf2-54jz4 — re-frame2-pair.runtime preload added so pair-MCP can
+  ;; probe this dev testbed's live runtime alongside Xray.
   :testbeds/long-flow-w-failure
   {:target     :browser
    :output-dir "out/testbeds/long-flow-w-failure"
    :asset-path "."
    :modules    {:main {:init-fn long-flow-w-failure.core/run}}
-   :devtools   {:preloads [day8.re-frame2-xray.preload]}}
+   :devtools   {:preloads [re-frame2-pair.runtime
+                           day8.re-frame2-xray.preload]}}
 
   ;; rf2-kzcim Tier 3 — drain-depth-trigger testbed (one handler that
   ;; recursively dispatches itself; the runtime's run-to-completion
   ;; drain halts at the frame's :drain-depth ceiling and rolls back
   ;; per Spec 002 rule 3 + Spec 009 :rf.error/drain-depth-exceeded).
+  ;; rf2-54jz4 — re-frame2-pair.runtime preload added so pair-MCP can
+  ;; probe this dev testbed's live runtime alongside Xray.
   :testbeds/drain-depth-trigger
   {:target     :browser
    :output-dir "out/testbeds/drain-depth-trigger"
    :asset-path "."
    :modules    {:main {:init-fn drain-depth-trigger.core/run}}
-   :devtools   {:preloads [day8.re-frame2-xray.preload]}}
+   :devtools   {:preloads [re-frame2-pair.runtime
+                           day8.re-frame2-xray.preload]}}
 
   ;; rf2-kzcim Tier 3 — non-trivial-app-db testbed (a 55-leaf app-db
   ;; nested up to 5 levels deep; six buttons each trigger a
   ;; structurally distinct diff shape at a known path — exercises the
   ;; consumer's diff visualisation under realistic depth).
+  ;; rf2-54jz4 — re-frame2-pair.runtime preload added so pair-MCP can
+  ;; probe this dev testbed's live runtime alongside Xray.
   :testbeds/non-trivial-app-db
   {:target     :browser
    :output-dir "out/testbeds/non-trivial-app-db"
    :asset-path "."
    :modules    {:main {:init-fn non-trivial-app-db.core/run}}
-   :devtools   {:preloads [day8.re-frame2-xray.preload]}}
+   :devtools   {:preloads [re-frame2-pair.runtime
+                           day8.re-frame2-xray.preload]}}
 
   ;; (removed) rf2-kzcim sensitive-dispatcher testbed — the handler-meta
   ;; :sensitive? annotation has been removed; path-marked classification
@@ -1042,12 +1074,15 @@
   ;; commit a value to a path whose wire elision is governed by a
   ;; different nomination path — schema-driven :large? on a Malli slot
   ;; — per Spec 009 §Size elision in traces).
+  ;; rf2-54jz4 — re-frame2-pair.runtime preload added so pair-MCP can
+  ;; probe this dev testbed's live runtime alongside Xray.
   :testbeds/large-dispatcher
   {:target     :browser
    :output-dir "out/testbeds/large-dispatcher"
    :asset-path "."
    :modules    {:main {:init-fn large-dispatcher.core/run}}
-   :devtools   {:preloads [day8.re-frame2-xray.preload]}}
+   :devtools   {:preloads [re-frame2-pair.runtime
+                           day8.re-frame2-xray.preload]}}
 
   ;; (removed rf2-9jfo1.1) known-bad-a11y testbed — the a11y-panel
   ;; scope contract (rf2-qgms1 / PR #1080) is now exercised inside
@@ -1076,7 +1111,10 @@
    :output-dir "out/examples/testbed-ssr-basic"
    :asset-path "."
    :modules    {:main {:init-fn ssr-basic.core/run}}
-   :devtools   {:preloads [day8.re-frame2-xray.preload]}}
+   ;; rf2-54jz4 — re-frame2-pair.runtime preload added so pair-MCP can
+   ;; probe this dev testbed's live runtime alongside Xray.
+   :devtools   {:preloads [re-frame2-pair.runtime
+                           day8.re-frame2-xray.preload]}}
 
   ;; rf2-ik4io — ssr-hydration-mismatch testbed (the deliberate-mismatch
   ;; surface). The payload bakes a known-wrong :rf/render-hash so
@@ -1089,7 +1127,10 @@
    :output-dir "out/examples/testbed-ssr-hydration-mismatch"
    :asset-path "."
    :modules    {:main {:init-fn ssr-hydration-mismatch.core/run}}
-   :devtools   {:preloads [day8.re-frame2-xray.preload]}}
+   ;; rf2-54jz4 — re-frame2-pair.runtime preload added so pair-MCP can
+   ;; probe this dev testbed's live runtime alongside Xray.
+   :devtools   {:preloads [re-frame2-pair.runtime
+                           day8.re-frame2-xray.preload]}}
 
   ;; rf2-ik4io — ssr-multi-frame testbed (per-frame hydration isolation).
   ;; Three frames each receive their own :rf/hydrate dispatch with a
@@ -1102,7 +1143,10 @@
    :output-dir "out/examples/testbed-ssr-multi-frame"
    :asset-path "."
    :modules    {:main {:init-fn ssr-multi-frame.core/run}}
-   :devtools   {:preloads [day8.re-frame2-xray.preload]}}
+   ;; rf2-54jz4 — re-frame2-pair.runtime preload added so pair-MCP can
+   ;; probe this dev testbed's live runtime alongside Xray.
+   :devtools   {:preloads [re-frame2-pair.runtime
+                           day8.re-frame2-xray.preload]}}
 
   ;; ============================================================================
   ;; Per-adapter testbeds (rf2-eceuv).
@@ -1119,23 +1163,31 @@
   ;; (discovered by the runner via SPEC_ROOTS).
   ;; ============================================================================
 
+  ;; rf2-54jz4 — re-frame2-pair.runtime preload added so pair-MCP can
+  ;; probe each adapter testbed's live runtime. These are dev-only
+  ;; smoke fixtures (the browser smoke runs them under
+  ;; `shadow-cljs compile`); `:devtools` preloads DCE from `release`
+  ;; builds so this never reaches a production bundle.
   :adapters/reagent-testbed
   {:target     :browser
    :output-dir "out/examples/adapter-testbeds/reagent"
    :asset-path "."
-   :modules    {:main {:init-fn adapter-testbed-reagent.core/init}}}
+   :modules    {:main {:init-fn adapter-testbed-reagent.core/init}}
+   :devtools   {:preloads [re-frame2-pair.runtime]}}
 
   :adapters/uix-testbed
   {:target     :browser
    :output-dir "out/examples/adapter-testbeds/uix"
    :asset-path "."
-   :modules    {:main {:init-fn adapter-testbed-uix.core/init}}}
+   :modules    {:main {:init-fn adapter-testbed-uix.core/init}}
+   :devtools   {:preloads [re-frame2-pair.runtime]}}
 
   :adapters/helix-testbed
   {:target     :browser
    :output-dir "out/examples/adapter-testbeds/helix"
    :asset-path "."
-   :modules    {:main {:init-fn adapter-testbed-helix.core/init}}}
+   :modules    {:main {:init-fn adapter-testbed-helix.core/init}}
+   :devtools   {:preloads [re-frame2-pair.runtime]}}
 
   ;; ============================================================================
   ;; Machines-Viz read-only viewer (rf2-8wrzz.2 — wires PR #2013's viewer


### PR DESCRIPTION
## Why

Pair-debug 2026-05-27: every attempt to probe the `:testbeds/panel-gallery` testbed''s live runtime via the re-frame2-pair MCP returned:

```edn
{:ok? false
 :reason :runtime-loaded-but-preload-missing
 :build "panel-gallery"
 :hint "re-frame2-pair.runtime is not loaded into this build. ..."}
```

The build at `implementation/shadow-cljs.edn:633-637` (prior shape) carried no `:devtools` block, so the pair-MCP''s helper namespace never loaded into the runtime. The runtime was alive (re-frame2 worked, variants rendered, dispatches fired), but every `eval-cljs` / `snapshot` / `subscribe` / etc. had nowhere to route.

## Per-build table

| Build | Preload added? | Rationale |
| --- | --- | --- |
| `:testbeds/panel-gallery` | YES (NEW - primary fix) | No prior `:devtools` block - the original bead trigger |
| `:testbeds/deliberate-throw` | YES (NEW - added alongside Xray) | Dev-only testbed served via shadow-cljs |
| `:testbeds/schema-violation` | YES (NEW - added alongside Xray) | Dev-only testbed served via shadow-cljs |
| `:testbeds/http-toggle` | YES (NEW - added alongside Xray) | Dev-only testbed served via shadow-cljs |
| `:testbeds/multi-frame` | YES (NEW - added alongside Xray) | Dev-only testbed served via shadow-cljs |
| `:testbeds/deep-machine` | YES (NEW - added alongside Xray) | Dev-only testbed served via shadow-cljs |
| `:testbeds/long-flow-w-failure` | YES (NEW - added alongside Xray) | Dev-only testbed served via shadow-cljs |
| `:testbeds/drain-depth-trigger` | YES (NEW - added alongside Xray) | Dev-only testbed served via shadow-cljs |
| `:testbeds/non-trivial-app-db` | YES (NEW - added alongside Xray) | Dev-only testbed served via shadow-cljs |
| `:testbeds/large-dispatcher` | YES (NEW - added alongside Xray) | Dev-only testbed served via shadow-cljs |
| `:testbeds/ssr-basic` | YES (NEW - added alongside Xray) | Dev-only testbed served via shadow-cljs |
| `:testbeds/ssr-hydration-mismatch` | YES (NEW - added alongside Xray) | Dev-only testbed served via shadow-cljs |
| `:testbeds/ssr-multi-frame` | YES (NEW - added alongside Xray) | Dev-only testbed served via shadow-cljs |
| `:adapters/reagent-testbed` | YES (NEW - no prior preload) | Dev-only adapter smoke fixture (browser smoke runs `compile`, not `release`) |
| `:adapters/uix-testbed` | YES (NEW - no prior preload) | Same |
| `:adapters/helix-testbed` | YES (NEW - no prior preload) | Same |
| `:examples/two-frame-isolation` | (unchanged - already had it) | - |
| `:examples/step-deck` | (unchanged - already had it) | - |
| `:examples/counter` and other `:examples/*` real-app builds | NO | Released as production artefacts (the bundle-isolation gate runs `shadow-cljs release` against them); preload must not leak |

## Source-paths confirmation

`../skills/re-frame2-pair/preload` is **already** on the top-level `:source-paths` (`implementation/shadow-cljs.edn:173`). No source-path adjustment was needed.

## Bundle-isolation evidence - production builds remain clean

The bundle-isolation gate runs `shadow-cljs release` on `:examples/counter`, `:examples/counter-uix`, and `:examples/counter-helix`. `:devtools` preloads are honoured by `shadow-cljs watch` / `compile` but NOT by `release`, so even though the released counter builds DO carry the Xray preload entry in their config, neither Xray nor the re-frame2-pair runtime body reaches the production bundle.

```
$ npm run test:bundle-isolation
[:examples/counter]       Build completed. (129 files, 74 compiled, 0 warnings, 17.32s)
[:examples/counter-uix]   Build completed. (127 files, 72 compiled, 0 warnings,  8.74s)
[:examples/counter-helix] Build completed. (135 files, 79 compiled, 0 warnings,  6.48s)
PASS bundle-isolation: 17 artefact entries; 35 internal sentinels absent;
     3 allow-list budgets ok; bundle=out/examples/counter (442957 chars)
PASS uix-helix-reagent-free: 3 bundles checked; 6 sentinel checks
```

Direct grep on the released counter bundle confirms zero `re_frame2_pair` symbols:

```
$ grep -l "re_frame2_pair" out/examples/counter/*.js
(no matches)
```

The dev-mode panel-gallery bundle, by contrast, DOES contain the runtime helper (as designed):

```
$ grep -l "re_frame2_pair.runtime" out/testbeds/panel-gallery/cljs-runtime/*.js
out/testbeds/panel-gallery/cljs-runtime/re_frame2_pair.runtime.js
```

## Quality gates

- `bash scripts/test-fast-pr.sh` - **PASS** (lockstep version drift, skill/MCP allowed-tools drift, core JVM 796 tests / 3708 assertions, JS harness helpers, CLJS node integration 4781 tests / 15625 assertions, README link/anchor, docs corpus anchor - all PASS)
- `npm run test:bundle-isolation` - **PASS** (17 artefact entries, 35 internal sentinels absent)
- `npm run test:reagent-slim:bundle-isolation` - **PASS** (3 contracts, 19 sentinel checks)
- `shadow-cljs compile testbeds/panel-gallery` - PASS (555 files, 0 warnings; preload compiled to `out/testbeds/panel-gallery/cljs-runtime/re_frame2_pair.runtime.js` as expected)
- `shadow-cljs compile testbeds/deliberate-throw` - PASS (both preloads load in order, 0 warnings)
- `shadow-cljs compile adapters/reagent-testbed` - PASS (preload loads cleanly, 0 warnings)

## Verification limitation

Worker env did not have re-frame2-pair-mcp loaded for a direct `mcp__re-frame2-pair__discover-app` round-trip against a running panel-gallery. The bundle-isolation gate is the authoritative pass/fail for the production-leak invariant; the compile-side checks above confirm the preload is wired correctly into dev bundles.

## Closes

rf2-54jz4.