### PR TITLE
feat(framework): reg-view React DevTools quick wins — displayName + JSX source-coord props + Context label (rf2-fa4ly)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/reg_view_devtools_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/reg_view_devtools_cljs_test.cljs
@@ -1,0 +1,145 @@
+(ns re-frame.reg-view-devtools-cljs-test
+  "Per Spec 006 §React DevTools support (rf2-fa4ly): the reg-view
+  wrapper sets a React `displayName` to the registered view-id, the
+  source-coord injection point emits JSX-shaped source-coord props
+  alongside the DOM attribute, and the React Context backing the
+  frame-provider carries a recognisable `displayName` for the Context
+  inspector.
+
+  Coverage:
+
+    - `displayName` on the wrapped fn matches `(str view-id)` for
+      auto-derived and `:rf/id`-overridden registrations.
+    - JSX source-coord props (`:_jsxFileName`, `:_jsxLineNumber`,
+      `:_jsxColumnNumber`) land on the same root element as
+      `:data-rf2-source-coord`.
+    - JSX props are absent on programmatic `reg-view*` registrations
+      without macro-captured coords (graceful degrade).
+    - The frame-context's React `displayName` is set to `\"rf2-frame\"`.
+
+  Production-elision is verified separately by the elision-probe
+  build (sentinels `_jsxFileName` + `rf2-frame` in
+  `scripts/check-elision.cjs`) and by
+  `reg_view_devtools_elision_prod_test.cljs`."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.context :as adapter-context]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.core :as rf]
+            [re-frame.test-support :as test-support]
+            [re-frame.views])
+  (:require-macros [re-frame.core :refer [reg-view]]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter reagent-adapter/adapter}))
+
+;; ---- helpers ---------------------------------------------------------------
+
+(defn- root-attrs
+  "Return the root attrs map of a hiccup vector, or nil."
+  [hiccup]
+  (when (and (vector? hiccup) (map? (second hiccup)))
+    (second hiccup)))
+
+;; ---- displayName -----------------------------------------------------------
+
+(deftest display-name-on-wrapped-fn-matches-view-id
+  (testing "the reg-view wrapper's React displayName is (str view-id)
+            so React DevTools shows `<:rf.devtools-test/dn-auto>` in
+            the component tree"
+    (rf/reg-view dn-auto [] [:p "hi"])
+    (let [wrapped (rf/view :re-frame.reg-view-devtools-cljs-test/dn-auto)]
+      (is (some? wrapped) "the view is registered")
+      (is (= ":re-frame.reg-view-devtools-cljs-test/dn-auto"
+             (.-displayName ^js wrapped))
+          "displayName matches (str id) on the wrapped fn"))))
+
+(deftest display-name-honours-rf-id-override
+  (testing "an `:rf/id`-overridden registration carries the override id in
+            displayName"
+    (rf/reg-view ^{:rf/id :rf.devtools-test/dn-explicit} dn-meta-view
+                 [] [:span "ok"])
+    (let [wrapped (rf/view :rf.devtools-test/dn-explicit)]
+      (is (some? wrapped))
+      (is (= ":rf.devtools-test/dn-explicit"
+             (.-displayName ^js wrapped))
+          "the override id drives displayName"))))
+
+;; ---- JSX source-coord props -----------------------------------------------
+
+(deftest jsx-source-props-injected-with-data-rf2-source-coord
+  (testing "the reg-view wrapper merges JSX-shaped source-coord props
+            (`:_jsxFileName`, `:_jsxLineNumber`, `:_jsxColumnNumber`)
+            onto the same root element that carries
+            `:data-rf2-source-coord` — React DevTools' \"View source\"
+            gesture reads them to jump to the reg-view definition"
+    (rf/reg-view ^{:rf/id :rf.devtools-test/jsx-root}
+                 jsx-root-view []
+      [:section "body"])
+    (let [render (rf/view :rf.devtools-test/jsx-root)
+          out    (render)
+          attrs  (root-attrs out)]
+      (is (map? attrs) "the root has an attrs map (spliced in by the wrapper)")
+      (is (string? (:data-rf2-source-coord attrs))
+          "data-rf2-source-coord present (parity)")
+      (is (string? (:_jsxFileName attrs))
+          "_jsxFileName present alongside data-rf2-source-coord")
+      (is (integer? (:_jsxLineNumber attrs))
+          "_jsxLineNumber is an integer")
+      ;; :column may be absent under the macro-emitted prod-coords-form,
+      ;; but in the dev build the macro emits it.
+      (is (or (nil? (:_jsxColumnNumber attrs))
+              (integer? (:_jsxColumnNumber attrs)))
+          "_jsxColumnNumber is integer or omitted"))))
+
+(deftest jsx-source-props-merge-into-existing-attrs
+  (testing "an existing attrs map is preserved alongside the JSX props"
+    (rf/reg-view ^{:rf/id :rf.devtools-test/jsx-with-attrs}
+                 jsx-with-attrs-view []
+      [:div {:class "card"} "body"])
+    (let [render (rf/view :rf.devtools-test/jsx-with-attrs)
+          out    (render)
+          attrs  (root-attrs out)]
+      (is (= "card" (:class attrs)) "user :class preserved")
+      (is (string? (:_jsxFileName attrs))
+          "_jsxFileName merged in alongside the user's attrs"))))
+
+(deftest jsx-source-props-absent-on-programmatic-registration
+  (testing "a programmatic `reg-view*` without macro source-coords
+            carries NO JSX props (the contract degrades gracefully
+            — React DevTools' \"View source\" needs a real file+line)"
+    (rf/reg-view* :rf.devtools-test/jsx-programmatic
+                  (fn [] [:em "p"]))
+    (let [render (rf/view :rf.devtools-test/jsx-programmatic)
+          out    (render)
+          attrs  (root-attrs out)]
+      (is (map? attrs)
+          "attrs map still spliced in for data-rf2-source-coord / data-rf-view")
+      (is (string? (:data-rf2-source-coord attrs))
+          "data-rf2-source-coord still present (degrades to <ns>:<sym>:?:?)")
+      (is (nil? (:_jsxFileName attrs))
+          "_jsxFileName absent — no captured :file/:line to emit"))))
+
+(deftest user-supplied-jsx-prop-wins
+  (testing "a render-fn that already set _jsxFileName is not overwritten —
+            composability with hand-stamped tools"
+    (rf/reg-view ^{:rf/id :rf.devtools-test/user-jsx} user-jsx-view []
+      [:p {:_jsxFileName "by-user.cljs" :_jsxLineNumber 99} "ok"])
+    (let [render (rf/view :rf.devtools-test/user-jsx)
+          out    (render)
+          attrs  (root-attrs out)]
+      (is (= "by-user.cljs" (:_jsxFileName attrs))
+          "user-supplied :_jsxFileName wins")
+      (is (= 99 (:_jsxLineNumber attrs))
+          "user-supplied :_jsxLineNumber wins"))))
+
+;; ---- React Context displayName --------------------------------------------
+
+(deftest frame-context-display-name-is-rf2-frame
+  (testing "the React Context backing the frame-provider carries a
+            human-readable displayName so React DevTools' Context
+            inspector renders `rf2-frame.Provider` rather than the
+            opaque default"
+    (is (= "rf2-frame"
+           (.-displayName ^js adapter-context/frame-context))
+        "frame-context.displayName is set to \"rf2-frame\"")))

--- a/implementation/adapters/reagent/test/re_frame/reg_view_devtools_elision_prod_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/reg_view_devtools_elision_prod_test.cljs
@@ -1,0 +1,80 @@
+(ns re-frame.reg-view-devtools-elision-prod-test
+  "Per Spec 006 §JSX source-coord props + §React DevTools support
+  (rf2-fa4ly): under `:advanced` + `goog.DEBUG=false`, the reg-view*
+  wrapper's `_jsxFileName` / `_jsxLineNumber` / `_jsxColumnNumber`
+  injection branch elides — the closure compiler constant-folds the
+  surrounding `(when interop/debug-enabled? ...)` gate and the entire
+  branch DCEs. The same gate elides the `displayName` assignment.
+
+  This file compiles under `:browser-test-prod-elision` (the dedicated
+  shadow-cljs build with `goog.DEBUG=false` + `:advanced`); the
+  matching CLJS-runtime test (`reg_view_devtools_cljs_test.cljs`)
+  exercises the same surface under dev-mode.
+
+  The genuine closure-fold contract is verified by
+  `scripts/check-elision.cjs` (sentinel `_jsxFileName`); this file
+  is the runtime cross-check that the rendered output of a registered
+  view under prod-mode carries no JSX prop and the wrapped fn carries
+  no `displayName`.
+
+  Naming convention: files ending in `-prod-test.cljs` are picked up
+  ONLY by the `:browser-test-prod-elision` build."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter reagent-adapter/adapter}))
+
+(defn- root-attrs [hiccup]
+  (when (and (vector? hiccup) (map? (second hiccup)))
+    (second hiccup)))
+
+(deftest reg-view-output-has-no-jsx-source-props-under-prod
+  (testing "Per Spec 006 §JSX source-coord props production-elision:
+            a registered view's rendered output carries NO
+            `_jsxFileName`/`_jsxLineNumber`/`_jsxColumnNumber` props
+            under :advanced + goog.DEBUG=false. The Closure compiler
+            DCEs the entire (when interop/debug-enabled? ...) branch."
+    (rf/reg-view* :rf.prod-elision-test/jsx-no-attrs
+                  (fn [] [:span "hi"]))
+    (let [render (rf/view :rf.prod-elision-test/jsx-no-attrs)
+          out    (render)
+          attrs  (root-attrs out)]
+      (is (or (nil? attrs)
+              (nil? (:_jsxFileName attrs)))
+          "NO :_jsxFileName on the rendered root — elision contract holds")
+      (is (or (nil? attrs)
+              (nil? (:_jsxLineNumber attrs)))
+          "NO :_jsxLineNumber on the rendered root — elision contract holds")
+      (is (or (nil? attrs)
+              (nil? (:_jsxColumnNumber attrs)))
+          "NO :_jsxColumnNumber on the rendered root — elision contract holds"))))
+
+(deftest reg-view-wrapped-fn-has-no-display-name-under-prod
+  (testing "Per Spec 006 §React DevTools support production-elision:
+            the reg-view wrapper's `displayName` assignment also rides
+            the (when interop/debug-enabled? ...) gate, so the wrapped
+            fn carries NO `displayName` under prod-mode."
+    (rf/reg-view* :rf.prod-elision-test/dn-no-attr
+                  (fn [] [:p "hi"]))
+    (let [wrapped (rf/view :rf.prod-elision-test/dn-no-attr)]
+      (is (some? wrapped) "the view is registered")
+      (is (nil? (.-displayName ^js wrapped))
+          "wrapped fn carries no .displayName under prod-mode — elision held"))))
+
+(deftest jsx-literal-absent-from-rendered-output
+  (testing "Defensive cross-check: scanning the rendered hiccup for the
+            literal `_jsxFileName` keyword finds nothing under prod-mode.
+            React DevTools / pair-tool consumers grep for this prop; if
+            it leaked it'd break the elision-bundle invariant."
+    (rf/reg-view* :rf.prod-elision-test/jsx-literal-check
+                  (fn [] [:p "scan me"]))
+    (let [render (rf/view :rf.prod-elision-test/jsx-literal-check)
+          out    (render)
+          flat   (pr-str out)]
+      (is (not (clojure.string/includes? flat "_jsxFileName"))
+          "the literal _jsxFileName does not appear in the rendered output
+           under prod-mode — closure-fold contract holds"))))

--- a/implementation/core/src/re_frame/adapter/context.cljs
+++ b/implementation/core/src/re_frame/adapter/context.cljs
@@ -26,6 +26,7 @@
   Helix) reads the same context object."
   (:require ["react" :as React]
             [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
             [re-frame.trace :as trace]))
 
 (defonce frame-context
@@ -33,6 +34,19 @@
   ;; this frame always exists. Components without an enclosing
   ;; frame-provider resolve to it.
   (.createContext React :rf/default))
+
+;; rf2-fa4ly: stamp a human-readable `displayName` on the React Context
+;; object so React DevTools' Context inspector shows the entry as
+;; `rf2-frame.Provider` / `rf2-frame.Consumer` rather than the opaque
+;; default ("Context.Provider"). Dev-only — gated under
+;; `interop/debug-enabled?` so the string literal DCEs in production.
+;; React DevTools reads `.-displayName` off the Context object directly
+;; (per the React DevTools backend's `getContextName` helper). The
+;; label deliberately avoids the unmunged ns string "re-frame.frame"
+;; to keep the elision sentinel unambiguous against keyword literals
+;; under that namespace.
+(when interop/debug-enabled?
+  (set! (.-displayName ^js frame-context) "rf2-frame"))
 
 (defn provider-element
   "Build a React element for the frame-context Provider with `frame-kw`

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -804,13 +804,15 @@
 
 (defn- inject-source-coord-attr
   "Wrap `out` (the user component's React element output) with a
-  cloneElement call that adds both `data-rf2-source-coord` (Spec 006
-  §Source-coord annotation, rf2-z7f7) and `data-rf-view` (Spec 006
-  §View tagging contract, rf2-01il5). Non-element outputs (nil,
-  fragment, function-component head) emit a one-shot warning per id
-  and pass through unchanged — pair tools fall back to `:rf/id` for
-  source-coord; the view-walker falls back to the Fiber-walker primary
-  path for hierarchy capture.
+  cloneElement call that adds `data-rf2-source-coord` (Spec 006
+  §Source-coord annotation, rf2-z7f7), `data-rf-view` (Spec 006
+  §View tagging contract, rf2-01il5), and — when source coords were
+  captured — the JSX-shaped `_jsxFileName` / `_jsxLineNumber` /
+  `_jsxColumnNumber` props (rf2-fa4ly, React DevTools' \"View source\"
+  contract). Non-element outputs (nil, fragment, function-component
+  head) emit a one-shot warning per id and pass through unchanged —
+  pair tools fall back to `:rf/id` for source-coord; the view-walker
+  falls back to the Fiber-walker primary path for hierarchy capture.
 
   CRITICAL: cloneElement returns a new element with the SAME `type` and
   `key` slots — it does NOT wrap the original. Wrapping with a
@@ -818,18 +820,30 @@
   §View tagging contract) would break flexbox / CSS Grid / table
   layouts / `:nth-child` selectors / positioning ancestors / stacking
   contexts / CSS containment."
-  [warn-fn id coord-attr view-attr out]
+  [warn-fn id coord-attr view-attr jsx-coords out]
   (cond
     (dom-element? out)
     (let [props             (.-props out)
           existing-coord    (when props (aget props "data-rf2-source-coord"))
           existing-view     (when props (aget props "data-rf-view"))
-          patch             #js {}]
+          existing-jsx-file (when props (aget props "_jsxFileName"))
+          patch             #js {}
+          patch-jsx?        (and jsx-coords
+                                 (some? (:file jsx-coords))
+                                 (some? (:line jsx-coords))
+                                 (not existing-jsx-file))]
       (when-not existing-coord
         (aset patch "data-rf2-source-coord" coord-attr))
       (when-not existing-view
         (aset patch "data-rf-view" view-attr))
-      (if (and existing-coord existing-view)
+      ;; rf2-fa4ly: JSX source-coord props for React DevTools' "View source"
+      ;; gesture. Mirrors the Reagent inline-walk emission.
+      (when patch-jsx?
+        (aset patch "_jsxFileName"   (:file jsx-coords))
+        (aset patch "_jsxLineNumber" (:line jsx-coords))
+        (when (:column jsx-coords)
+          (aset patch "_jsxColumnNumber" (:column jsx-coords))))
+      (if (and existing-coord existing-view (not patch-jsx?))
         out
         (React/cloneElement out patch)))
 
@@ -1006,21 +1020,32 @@
     (fn wrap-view [id metadata user-fn]
       (if interop/debug-enabled?
         (let [coord-attr (format-source-coord id metadata)
-              view-attr  (format-view-id id)]
-          (fn wrapped-user-fn [& args]
-            ;; rf2-te71r: resolve the frame in-render (the substrate-
-            ;; portable React-context read works inside this wrapped fn's
-            ;; render). The sentinel's cleanup runs OUTSIDE render where
-            ;; the read would be wrong, so the frame is threaded as a prop
-            ;; and the sentinel stashes it in a ref. On a headless direct
-            ;; invocation this read falls through the dynamic-var /
-            ;; :rf/default chain — harmless; the sentinel ELEMENT is built
-            ;; but its hooks only run if React actually renders it.
-            (let [frame-id  (adapter-context/function-component-current-frame)
-                  out       (apply user-fn args)
-                  annotated (inject-source-coord-attr warn-fn id coord-attr
-                                                      view-attr out)]
-              (append-unmount-sentinel unmount-sentinel id frame-id annotated))))
+              view-attr  (format-view-id id)
+              ;; rf2-fa4ly: capture the raw coords once so each render reuses
+              ;; the JSX-prop input without re-walking metadata.
+              jsx-coords metadata
+              wrapped    (fn wrapped-user-fn [& args]
+                           ;; rf2-te71r: resolve the frame in-render (the substrate-
+                           ;; portable React-context read works inside this wrapped fn's
+                           ;; render). The sentinel's cleanup runs OUTSIDE render where
+                           ;; the read would be wrong, so the frame is threaded as a prop
+                           ;; and the sentinel stashes it in a ref. On a headless direct
+                           ;; invocation this read falls through the dynamic-var /
+                           ;; :rf/default chain — harmless; the sentinel ELEMENT is built
+                           ;; but its hooks only run if React actually renders it.
+                           (let [frame-id  (adapter-context/function-component-current-frame)
+                                 out       (apply user-fn args)
+                                 annotated (inject-source-coord-attr warn-fn id coord-attr
+                                                                     view-attr jsx-coords out)]
+                             (append-unmount-sentinel unmount-sentinel id frame-id annotated)))]
+          ;; rf2-fa4ly: stamp the React `displayName` to the registered view-id
+          ;; so React DevTools shows `<:cart/total-line>` in the component tree
+          ;; rather than the CLJS-munged fn name or an anonymous wrapper. The
+          ;; assignment sits inside the `interop/debug-enabled?` arm so the
+          ;; string-literal id `(str id)` and the assignment itself elide in
+          ;; production builds.
+          (set! (.-displayName ^js wrapped) (str id))
+          wrapped)
         user-fn))))
 
 (defn install-clear-warn-once-step!

--- a/implementation/core/src/re_frame/views.cljs
+++ b/implementation/core/src/re_frame/views.cljs
@@ -438,6 +438,19 @@
   (when (and interop/debug-enabled? (not wrap-applied?))
     (source-coord/format-source-coord id metadata)))
 
+(defn- view-jsx-coords
+  "Capture the raw source-coord metadata for the inline hiccup-walk path
+  (rf2-fa4ly). The metadata carries `:file` / `:line` / `:column` per
+  Spec 001 §Source-coordinate capture; the annotation site reads them
+  back to assemble the JSX `_jsxFileName` / `_jsxLineNumber` /
+  `_jsxColumnNumber` props React DevTools' \"View source\" button
+  consumes. Returns nil under :advanced + goog.DEBUG=false (the
+  dev-only annotation path elides wholesale) and when the substrate
+  hook is wrapping (its own cloneElement path handles JSX props)."
+  [metadata wrap-applied?]
+  (when (and interop/debug-enabled? (not wrap-applied?))
+    metadata))
+
 (defn- maybe-arm-unmount!
   "Install (once per mounted instance) the `:rf.view/unmounted` teardown
   hook for `render-key` and deref its lifecycle reaction so the
@@ -479,58 +492,73 @@
   React frame-context (rf2-kdwc — note the camelCase static-field
   name; the earlier kebab `:context-type` shape was silently ignored
   by Reagent)."
-  [id render-fn view-scope coord-attr wrap-applied?]
-  (with-meta
-    (fn frame-aware-view [& args]
-      (let [tok        (provider/reagent-component-token)
-            render-key [id tok]
-            ;; rf2-9hoos: fresh per-render deref sink (dev-only). The
-            ;; volatile is bound below so `re-frame.subs/subscribe`'s
-            ;; gated `record-view-deref!` call unions each deref'd
-            ;; query-v into it; read back AFTER the render to stamp
-            ;; `:deref-subs` onto `:rf.view/rendered`.
-            sink       (when interop/debug-enabled? (volatile! []))]
-        (binding [*render-key*     render-key
-                  *view-deref-sink* sink]
-          (trace/with-handler-scope view-scope
-            ;; Resolve the frame once per render — threaded into the
-            ;; unmount hook + both render emits (rf2-9hoos).
-            (let [frame-id (when interop/debug-enabled? (provider/current-frame))]
-              ;; rf2-9hoos: arm the unmount hook + compute the mount flag
-              ;; BEFORE the render so `first-render?!` reflects whether
-              ;; this is the instance's first render (the seen-set is
-              ;; updated here, not in the post-render emit).
-              (when interop/debug-enabled?
-                (maybe-arm-unmount! id render-key frame-id))
-              (let [mount? (when interop/debug-enabled? (first-render?! render-key))
-                    ;; rf2-8wrzz.1: wall-clock the user render-fn (dev-only)
-                    ;; so `:rf.view/rendered` can carry `:elapsed-ms` — the
-                    ;; per-view render timing Xray's Views panel shows. The
-                    ;; read rides `interop/debug-enabled?` so production
-                    ;; DCEs it alongside the rest of the emit; nil in prod.
-                    t0     (when interop/debug-enabled? (interop/now-ms))]
-                (emit-view-render-trace! render-key frame-id)
-                ;; Per Spec 009 §Performance instrumentation (rf2-du3i):
-                ;; every render of a registered view brackets the user
-                ;; render-fn in performance marks so prod builds with the
-                ;; perf flag enabled produce a `rf:render:<view-id>`
-                ;; measure entry. Default-off; under :advanced +
-                ;; `re-frame.performance/enabled?=false` the bracket DCEs
-                ;; and the form collapses to the bare `(apply render-fn
-                ;; args)` call.
-                (let [out        (performance/mark-and-measure :render id
-                                   (apply render-fn args))
-                      elapsed-ms (when interop/debug-enabled?
-                                   (- (interop/now-ms) t0))]
-                  ;; rf2-9hoos: emit AFTER the render so the deref sink is
-                  ;; populated; carry the mount flag + the view's read-set.
-                  ;; rf2-8wrzz.1: also carry the render's `:elapsed-ms`.
-                  (emit-view-rendered-trace! id render-key frame-id mount?
-                                             (when sink @sink) elapsed-ms)
-                  (if (and interop/debug-enabled? (not wrap-applied?))
-                    (source-coord/inject-source-coord-attr id coord-attr out)
-                    out))))))))
-    {:contextType frame-context}))
+  [id render-fn view-scope coord-attr jsx-coords wrap-applied?]
+  (let [wrapped
+        (with-meta
+          (fn frame-aware-view [& args]
+            (let [tok        (provider/reagent-component-token)
+                  render-key [id tok]
+                  ;; rf2-9hoos: fresh per-render deref sink (dev-only). The
+                  ;; volatile is bound below so `re-frame.subs/subscribe`'s
+                  ;; gated `record-view-deref!` call unions each deref'd
+                  ;; query-v into it; read back AFTER the render to stamp
+                  ;; `:deref-subs` onto `:rf.view/rendered`.
+                  sink       (when interop/debug-enabled? (volatile! []))]
+              (binding [*render-key*     render-key
+                        *view-deref-sink* sink]
+                (trace/with-handler-scope view-scope
+                  ;; Resolve the frame once per render — threaded into the
+                  ;; unmount hook + both render emits (rf2-9hoos).
+                  (let [frame-id (when interop/debug-enabled? (provider/current-frame))]
+                    ;; rf2-9hoos: arm the unmount hook + compute the mount flag
+                    ;; BEFORE the render so `first-render?!` reflects whether
+                    ;; this is the instance's first render (the seen-set is
+                    ;; updated here, not in the post-render emit).
+                    (when interop/debug-enabled?
+                      (maybe-arm-unmount! id render-key frame-id))
+                    (let [mount? (when interop/debug-enabled? (first-render?! render-key))
+                          ;; rf2-8wrzz.1: wall-clock the user render-fn (dev-only)
+                          ;; so `:rf.view/rendered` can carry `:elapsed-ms` — the
+                          ;; per-view render timing Xray's Views panel shows. The
+                          ;; read rides `interop/debug-enabled?` so production
+                          ;; DCEs it alongside the rest of the emit; nil in prod.
+                          t0     (when interop/debug-enabled? (interop/now-ms))]
+                      (emit-view-render-trace! render-key frame-id)
+                      ;; Per Spec 009 §Performance instrumentation (rf2-du3i):
+                      ;; every render of a registered view brackets the user
+                      ;; render-fn in performance marks so prod builds with the
+                      ;; perf flag enabled produce a `rf:render:<view-id>`
+                      ;; measure entry. Default-off; under :advanced +
+                      ;; `re-frame.performance/enabled?=false` the bracket DCEs
+                      ;; and the form collapses to the bare `(apply render-fn
+                      ;; args)` call.
+                      (let [out        (performance/mark-and-measure :render id
+                                         (apply render-fn args))
+                            elapsed-ms (when interop/debug-enabled?
+                                         (- (interop/now-ms) t0))]
+                        ;; rf2-9hoos: emit AFTER the render so the deref sink is
+                        ;; populated; carry the mount flag + the view's read-set.
+                        ;; rf2-8wrzz.1: also carry the render's `:elapsed-ms`.
+                        (emit-view-rendered-trace! id render-key frame-id mount?
+                                                   (when sink @sink) elapsed-ms)
+                        (if (and interop/debug-enabled? (not wrap-applied?))
+                          (source-coord/inject-source-coord-attr id coord-attr
+                                                                 jsx-coords out)
+                          out))))))))
+          {:contextType frame-context})]
+    ;; rf2-fa4ly: stamp the React `displayName` to the registered view-id so
+    ;; React DevTools shows `<:cart/total-line>` in the component tree rather
+    ;; than the CLJS-munged fn name (`day8.cart.total.total_line`) or an
+    ;; anonymous Reagent wrapper. Reagent's create-class / fn-to-class
+    ;; machinery picks up `.-displayName` off the input fn and forwards it to
+    ;; the constructed React component. Dev-only — gated so the literal name
+    ;; string never lands in the production bundle. The bundle-isolation gate
+    ;; pins absence (the elision contract is broader — `displayName` itself is
+    ;; a React surface, but assigning it from a user-derived string belongs
+    ;; behind `interop/debug-enabled?`).
+    (when interop/debug-enabled?
+      (set! (.-displayName ^js wrapped) (str id)))
+    wrapped))
 
 (defn reg-view*
   "Reagent-aware view registration. Wraps `render-fn` with the React
@@ -563,8 +591,10 @@
   [id metadata render-fn]
   (let [[render-fn wrap-applied?] (apply-adapter-wrap-view id metadata render-fn)
         coord-attr (view-coord-attr id metadata wrap-applied?)
+        jsx-coords (view-jsx-coords metadata wrap-applied?)
         view-scope (trace/handler-scope-from-meta :view id metadata)
-        wrapped    (build-frame-aware-view id render-fn view-scope coord-attr wrap-applied?)]
+        wrapped    (build-frame-aware-view id render-fn view-scope coord-attr
+                                           jsx-coords wrap-applied?)]
     (registrar/register! :view id (assoc metadata :handler-fn wrapped))
     wrapped))
 

--- a/implementation/core/src/re_frame/views/source_coord_annotation.cljs
+++ b/implementation/core/src/re_frame/views/source_coord_annotation.cljs
@@ -63,7 +63,24 @@
       `goog.DEBUG=false`. Per Spec 009 §Production builds. Both
       `data-rf2-source-coord` and `data-rf-view` literals are part of
       the production-bundle elision sentinel set (see
-      `scripts/check-elision.cjs`)."
+      `scripts/check-elision.cjs`).
+
+  ## JSX source-coord props (rf2-fa4ly)
+
+  Alongside `data-rf2-source-coord` the wrapper ALSO injects the
+  JSX-shaped source-coord props React DevTools' \"View source\" button
+  reads (per `@babel/plugin-transform-react-jsx-source`):
+
+      :_jsxFileName     \"src/my/app/cart.cljs\"
+      :_jsxLineNumber   42
+      :_jsxColumnNumber 1
+
+  These ride the SAME `interop/debug-enabled?` gate (the surrounding
+  wrapper's gate) — production builds elide all three alongside the
+  DOM attributes. Adapters' source-coord injection sites mirror this
+  dual emission (Reagent inline-walk here; UIx / Helix via
+  `re-frame.substrate.spine/inject-source-coord-attr`). Per Spec 006
+  §Source-coord annotation §JSX source-coord props."
   (:require [re-frame.views.warn-once :as warn-once]))
 
 (defn format-source-coord
@@ -99,14 +116,40 @@
   [id]
   (str id))
 
+(defn- jsx-source-props
+  "Build the React-DevTools-readable JSX source-coord prop map for the
+  view registered under `id` with captured `coords` (rf2-fa4ly).
+  Returns nil when no positional info is captured (programmatic
+  `reg-view*` with no macro coords) — DevTools' \"View source\" button
+  is meaningless without at least a `:file` + `:line`. Per
+  `@babel/plugin-transform-react-jsx-source`:
+
+      :_jsxFileName     \"src/my/app/cart.cljs\"   ;; required
+      :_jsxLineNumber   42                         ;; required
+      :_jsxColumnNumber 1                          ;; optional
+
+  Callers gate the call on `interop/debug-enabled?` so the production
+  bundle elides the entire prop set alongside the DOM attributes."
+  [coords]
+  (let [file (:file coords)
+        line (:line coords)
+        col  (:column coords)]
+    (when (and file line)
+      (cond-> {:_jsxFileName   file
+               :_jsxLineNumber line}
+        col (assoc :_jsxColumnNumber col)))))
+
 (defn inject-source-coord-attr
-  "Walk the user's render-fn output and merge both
-  `:data-rf2-source-coord` (Spec 006 §Source-coord annotation, rf2-z7f7)
-  and `:data-rf-view` (Spec 006 §View tagging contract, rf2-01il5) into
-  the root element's attrs map. Called from inside the wrapper (gated
-  on `interop/debug-enabled?`). Returns the (possibly rewritten)
-  hiccup. Non-DOM roots are returned unchanged after a one-shot
-  warning per Spec 006 §Source-coord annotation.
+  "Walk the user's render-fn output and merge `:data-rf2-source-coord`
+  (Spec 006 §Source-coord annotation, rf2-z7f7), `:data-rf-view`
+  (Spec 006 §View tagging contract, rf2-01il5) and — when source
+  coords were captured — the JSX-shaped `:_jsxFileName` /
+  `:_jsxLineNumber` / `:_jsxColumnNumber` props (rf2-fa4ly, React
+  DevTools' \"View source\" contract) into the root element's attrs
+  map. Called from inside the wrapper (gated on
+  `interop/debug-enabled?`). Returns the (possibly rewritten) hiccup.
+  Non-DOM roots are returned unchanged after a one-shot warning per
+  Spec 006 §Source-coord annotation.
 
   CRITICAL: this fn MUST mutate the existing first element's attrs.
   NEVER wrap with a synthetic `[:div]` — wrapping breaks flexbox /
@@ -116,31 +159,37 @@
   Form-2: when `out` is a fn, return a fn that recurses on the inner
   output — Reagent's renderer will call our returned fn just like
   the user's fn, and we get a chance to annotate the inner hiccup."
-  [id coord-attr out]
+  [id coord-attr coords out]
   (cond
     ;; Form-2: render-fn returned a fn. Wrap so the inner fn's output
     ;; is also annotated when Reagent calls through.
     (fn? out)
     (fn form-2-wrapper [& args]
-      (inject-source-coord-attr id coord-attr (apply out args)))
+      (inject-source-coord-attr id coord-attr coords (apply out args)))
 
     ;; Hiccup vector with a DOM-tag keyword head. Annotate the root.
     (and (vector? out) (dom-tag? (first out)))
     (let [head        (first out)
           maybe-attrs (second out)
-          view-attr   (format-view-id id)]
+          view-attr   (format-view-id id)
+          jsx-props   (jsx-source-props coords)]
       (if (map? maybe-attrs)
         ;; Existing attrs map — merge in (don't overwrite if user
-        ;; already set either attribute for some reason).
+        ;; already set any of the framework keys for some reason).
         (let [merged (cond-> maybe-attrs
                        (not (contains? maybe-attrs :data-rf2-source-coord))
                        (assoc :data-rf2-source-coord coord-attr)
                        (not (contains? maybe-attrs :data-rf-view))
-                       (assoc :data-rf-view view-attr))]
+                       (assoc :data-rf-view view-attr)
+                       (and jsx-props
+                            (not (contains? maybe-attrs :_jsxFileName)))
+                       (merge jsx-props))]
           (into [head merged] (drop 2 out)))
         ;; No attrs map — splice one in between head and children.
-        (into [head {:data-rf2-source-coord coord-attr
-                     :data-rf-view          view-attr}] (rest out))))
+        (let [attrs (cond-> {:data-rf2-source-coord coord-attr
+                             :data-rf-view          view-attr}
+                      jsx-props (merge jsx-props))]
+          (into [head attrs] (rest out)))))
 
     ;; Non-DOM root (fn-component head, fragment, lazy-seq, nil). Skip
     ;; with a one-shot warning. Pair tools fall back to :rf/id;

--- a/implementation/scripts/check-elision.cjs
+++ b/implementation/scripts/check-elision.cjs
@@ -295,6 +295,27 @@ const DEV_ONLY_SENTINELS = [
   // :advanced + goog.DEBUG=false bundles.
   { source: 're-frame.views/reg-view* (data-rf-view injection)',
     sentinel: 'data-rf-view' },
+  // re-frame.views — JSX source-coord props for React DevTools'
+  // "View source" gesture (Spec 006 §JSX source-coord props,
+  // rf2-fa4ly). The reg-view* wrapper merges `_jsxFileName` +
+  // `_jsxLineNumber` + `_jsxColumnNumber` onto the rendered root DOM
+  // element when `interop/debug-enabled?` is true. Rides the SAME
+  // gate as `data-rf2-source-coord` (one injection site, one branch);
+  // the literal "_jsxFileName" string fragment must NOT appear in
+  // :advanced + goog.DEBUG=false bundles. The other two props
+  // (_jsxLineNumber, _jsxColumnNumber) elide alongside this sentinel
+  // as parts of the same branch.
+  { source: 're-frame.views/reg-view* (_jsxFileName injection)',
+    sentinel: '_jsxFileName' },
+  // re-frame.adapter.context — Context displayName for React DevTools'
+  // Context inspector (Spec 006 §React DevTools support, rf2-fa4ly).
+  // The "rf2-frame" literal sits inside `(when interop/debug-enabled?
+  // (set! (.-displayName frame-context) "rf2-frame"))` and must elide
+  // in production bundles. The literal is deliberately distinct from
+  // the ns string "re-frame.frame" to avoid clashing with keyword
+  // literals under that namespace.
+  { source: 're-frame.adapter.context (frame-context displayName)',
+    sentinel: 'rf2-frame' },
   // re-frame.core/reg-machine — per-element source-coord stamping
   // (Spec 005 §Source-coord stamping, rf2-8bp3). The reg-machine macro
   // emits an `(if interop/debug-enabled? (assoc spec :rf.machine/

--- a/implementation/ssr/src/re_frame/ssr/html_helpers.cljc
+++ b/implementation/ssr/src/re_frame/ssr/html_helpers.cljc
@@ -124,9 +124,25 @@
 (def ^:private event-handler-name-re
   #"on(?:[A-Z].*|-.*)")
 
+;; JSX source-coord props (rf2-fa4ly). React DevTools' "View source"
+;; gesture reads `_jsxFileName` / `_jsxLineNumber` / `_jsxColumnNumber`
+;; off the rendered React element. The reg-view wrapper injects them
+;; under `interop/debug-enabled?`; under SSR they ride the same hiccup
+;; tree the wrapper produced but MUST NOT serialise as wire HTML
+;; attributes. The leading underscore would also fail the conservative
+;; HTML5 attribute-name grammar (`[A-Za-z][A-Za-z0-9_:-]*`) — these
+;; props sit upstream of that grammar gate and are filtered here so
+;; SSR output stays grammar-clean. The matcher pins the three documented
+;; names (per `@babel/plugin-transform-react-jsx-source`) rather than a
+;; broad underscore-prefix, so an app's custom underscore-prefixed prop
+;; (if grammar-legal) still surfaces the grammar error.
+(def ^:private jsx-source-prop-names
+  #{"_jsxFileName" "_jsxLineNumber" "_jsxColumnNumber"})
+
 (defn strip-prop?
   "True when the attribute `[k v]` MUST be dropped at SSR static-markup
-  emission per Spec 011 rule rf2-dwds9:
+  emission per Spec 011 rule rf2-dwds9 + Spec 006 §JSX source-coord
+  props (rf2-fa4ly):
 
     - `on*` event-handler props (`:on-click`, `:onMouseDown`, …). The
       client-side substrate adapters wire handlers at hydration; the
@@ -136,6 +152,10 @@
       it has no HTML-attribute serialisation and must never reach output.
     - reserved prototype-pollution keys (`__proto__` / `constructor` /
       `prototype`), dropped before they reach the host createElement.
+    - JSX source-coord props (`:_jsxFileName`, `:_jsxLineNumber`,
+      `:_jsxColumnNumber`) — React DevTools internals injected by the
+      reg-view wrapper for the \"View source\" gesture (rf2-fa4ly);
+      they have no HTML wire representation.
 
   Mirrors react-dom/server behaviour. Recognised here are exactly the
   props that are *safe to silently drop*; malformed keys (breakout chars)
@@ -145,7 +165,8 @@
   (let [nm (name k)]
     (or (some? (re-matches event-handler-name-re nm))
         (fn? v)
-        (contains? reserved-prop-keys (str/lower-case nm)))))
+        (contains? reserved-prop-keys (str/lower-case nm))
+        (contains? jsx-source-prop-names nm))))
 
 (defn attr-string
   "Render an attribute map as ` k1=\"v1\" k2=\"v2\"` (leading space when

--- a/spec/006-ReactiveSubstrate.md
+++ b/spec/006-ReactiveSubstrate.md
@@ -304,6 +304,22 @@ A registration that bypassed the macro path (programmatic `reg-view*` with no ca
 
 The annotation site MUST sit inside `(when interop/debug-enabled? ...)` (the CLJS mirror of `goog.DEBUG`). Production builds (`:advanced` + `goog.DEBUG=false`) MUST NOT emit the attribute — the entire injection branch dead-code-eliminates so the literal `data-rf2-source-coord` string fragment does not appear in the bundle. Per [Spec 009 §Production builds](009-Instrumentation.md), the elision is verified by a grep against the production bundle (`scripts/check-elision.cjs`); the `data-rf2-source-coord` sentinel is part of the standard sentinel set.
 
+### JSX source-coord props (React DevTools "View source")
+
+Alongside the `data-rf2-source-coord` DOM attribute, every React-substrate adapter MUST also inject the JSX-shaped source-coord props that React DevTools' "View source" gesture reads (per `@babel/plugin-transform-react-jsx-source`):
+
+```
+_jsxFileName     "src/my/app/cart.cljs"   ; required — full file path
+_jsxLineNumber   42                       ; required — integer line
+_jsxColumnNumber 1                        ; optional — integer column
+```
+
+The injection lands on the **same root element** as `data-rf2-source-coord` (same wrapper, same walk, same merge — not a separate code path). React DevTools' "View source" button uses these props to open the `reg-view` definition in the browser's Sources panel (or in the user's editor if React DevTools' editor-URL setting is configured); the gesture works natively against any registered view — no Xray-specific chip required.
+
+Both injection paths share a single elision gate: the JSX props ride the SAME `(when interop/debug-enabled? …)` branch that elides `data-rf2-source-coord`, so production builds (`:advanced` + `goog.DEBUG=false`) MUST NOT emit `_jsxFileName` / `_jsxLineNumber` / `_jsxColumnNumber` — the entire injection branch DCEs as a unit. Bundle isolation pins the contract (no `_jsxFileName` literal in the production bundle); per Spec 009 §Production builds, the gate is the load-bearing mechanism.
+
+When source coords were not captured (programmatic `reg-view*` without macro positions, or any registration whose metadata carries no `:file`/`:line`), the JSX props are omitted while `data-rf2-source-coord` still degrades to `<ns>:<sym>:?:?`. The two surfaces are independent at the per-call site level; one elision gate, two emission cases.
+
 ### Documented exemption: non-DOM roots
 
 A registered view whose root element is one of:
@@ -401,6 +417,18 @@ When the fallback is consuming the tagged DOM, the walker:
 4. Produces the same output shape as the Fiber-walker (per [View-Hierarchy-Capture.md §Output shape](View-Hierarchy-Capture.md#output-shape)) so consumer code is path-agnostic.
 
 The walker implementation lives at `tools/xray/src/day8/re_frame2_xray/views/view_walker.cljs` (alongside the Fiber-walker per the spec's Ownership table). Both walkers are bundle-isolated from production builds.
+
+## React DevTools support (zero-config, dev-only)
+
+re-frame2 is Reagent-substrate-native (see §Reactive Substrate above). The framework MUST therefore make React DevTools — the industry-standard React-app inspection tool — work cleanly against any re-frame2 app. The three contracts below are framework-level; an app author opts into none of them, they fire by the same wrappers that handle the source-coord and view-tagging contracts.
+
+1. **Component display-name = registered view-id.** Every adapter's `reg-view` wrapper MUST stamp the React `displayName` of the wrapped component to `(str view-id)` so React DevTools' component tree shows `<:cart/total-line>` rather than the CLJS-munged function name or an anonymous Reagent wrapper. Reagent's class-component machinery reads `.-displayName` off the input fn and forwards it to the constructed component; React-hook substrates (UIx / Helix) set it directly on the wrapped function component. Gated on `interop/debug-enabled?` so the per-view id-string literal elides in production builds.
+
+2. **JSX source-coord props on the rendered root.** See §JSX source-coord props above — the same wrapper that injects `data-rf2-source-coord` also injects `_jsxFileName` / `_jsxLineNumber` / `_jsxColumnNumber`, which is what React DevTools' "View source" gesture reads to jump to the `reg-view` definition.
+
+3. **Frame-context display-name.** The React Context object backing the frame-provider (per §Frame-provider via React context below) MUST carry a `displayName` of `"rf2-frame"` so React DevTools' Context inspector shows the entry as `rf2-frame.Provider` rather than the opaque default `Context.Provider`. The label is deliberately distinct from any keyword namespace to keep the elision-bundle sentinel unambiguous. The assignment site sits inside `(when interop/debug-enabled? …)` so the string literal elides in production. The per-frame value (`:rf/default`, `:tenant/admin`, etc.) is already inspectable as the Context value — DevTools renders it as the keyword's `pr-str`.
+
+All three sites share the standard `interop/debug-enabled?` elision gate and are subject to the bundle-isolation gate (no `displayName`-assignment branches, no `_jsxFileName` literals, no Context display-name string in the production bundle). React DevTools is a dev-time inspection tool; the framework pays nothing for these affordances in production.
 
 ## Subscription cache — contract and operational semantics
 


### PR DESCRIPTION
Three contract additions per Spec 006 §React DevTools support + §JSX source-coord props, all gated on `interop/debug-enabled?` and verified absent from production bundles by `check-elision.cjs` + `check-bundle-isolation.cjs`.

## Per-change summary

### 1. `displayName` = registered view-id

The reg-view wrapper now stamps `.-displayName` to `(str view-id)` on the wrapped fn so React DevTools shows `<:cart/total-line>` in the component tree rather than the CLJS-munged fn name (`day8.cart.total.total_line`) or an anonymous Reagent wrapper. Reagent's fn-to-class machinery forwards `displayName` from the input fn to the constructed component; React-hook substrates (UIx / Helix) set it directly on the wrapped function component returned from the spine's `make-wrap-view`. Both paths sit inside the standard `interop/debug-enabled?` gate so the per-view id string elides in production.

### 2. JSX source-coord props on the rendered root

The same wrapper that merges `data-rf2-source-coord` now also merges `_jsxFileName` / `_jsxLineNumber` / `_jsxColumnNumber` (per `@babel/plugin-transform-react-jsx-source`) so React DevTools' \"View source\" gesture jumps to the reg-view definition. Reagent inline-walk (`views/source_coord_annotation.cljs`) and the React-hook spine path (`substrate/spine.cljs` `inject-source-coord-attr`) both emit the dual shape. Programmatic `reg-view*` registrations without macro coords degrade gracefully (no `_jsxFileName` — DevTools' View-source button needs a real file+line, and `data-rf2-source-coord` still degrades to `<ns>:<sym>:?:?`).

SSR's HTML-attr-name grammar rejects underscore-prefixed names; the SSR emitter's `strip-prop?` now filters the three documented JSX prop names (alongside the existing `on*` / fn-valued / proto-pollution filters) so the wire HTML stays grammar-clean.

### 3. Frame-context display-name

The React Context backing the frame-provider now carries a `displayName` of `\"rf2-frame\"` so React DevTools' Context inspector renders `rf2-frame.Provider` rather than the opaque default. Label is deliberately distinct from the `\"re-frame.frame\"` namespace string to keep the elision sentinel unambiguous against keyword literals under that ns.

## Production-elision evidence

`npm run test:elision` reports:

```
PASS elision: production 41/41 absent (363585 chars); control 41/41 present (437922 chars)
```

The two new sentinels (`_jsxFileName`, `rf2-frame`) elide cleanly. `check-bundle-isolation.cjs` reports `35 internal sentinels absent` against the production counter bundle.

## spec/006 paragraph snippet

> Alongside the `data-rf2-source-coord` DOM attribute, every React-substrate adapter MUST also inject the JSX-shaped source-coord props that React DevTools' \"View source\" gesture reads (per `@babel/plugin-transform-react-jsx-source`):
>
> ```
> _jsxFileName     \"src/my/app/cart.cljs\"   ; required — full file path
> _jsxLineNumber   42                       ; required — integer line
> _jsxColumnNumber 1                        ; optional — integer column
> ```
>
> The injection lands on the **same root element** as `data-rf2-source-coord` (same wrapper, same walk, same merge — not a separate code path). [...] Both injection paths share a single elision gate.

The new §React DevTools support section captures the three contracts as one zero-config-for-users surface (displayName + JSX props + Context label).

## Files modified

- `implementation/core/src/re_frame/views.cljs` — Reagent `build-frame-aware-view` stamps `displayName` + threads `jsx-coords` through to the inline annotation walk.
- `implementation/core/src/re_frame/views/source_coord_annotation.cljs` — `inject-source-coord-attr` now accepts metadata coords and merges JSX props alongside the DOM attrs.
- `implementation/core/src/re_frame/substrate/spine.cljs` — React-hook substrate (UIx / Helix) wrap-view stamps `displayName` + the spine's `cloneElement` injects JSX props.
- `implementation/core/src/re_frame/adapter/context.cljs` — frame-context `displayName = \"rf2-frame\"`.
- `implementation/ssr/src/re_frame/ssr/html_helpers.cljc` — SSR `strip-prop?` filters JSX source-coord props (rejects them at wire emission; they have no HTML representation).
- `spec/006-ReactiveSubstrate.md` — §JSX source-coord props paragraph + new §React DevTools support section.
- `implementation/scripts/check-elision.cjs` — new sentinels `_jsxFileName` and `rf2-frame`.
- `implementation/adapters/reagent/test/re_frame/reg_view_devtools_cljs_test.cljs` — dev-mode contract assertions.
- `implementation/adapters/reagent/test/re_frame/reg_view_devtools_elision_prod_test.cljs` — prod-mode elision assertions.

## Quality gates

| Gate | Status |
|---|---|
| `bash scripts/test-fast-pr.sh` (incl. core JVM 796/3708 + CLJS node 4797/15656) | PASS |
| `npm run test:browser` (124/353) | PASS |
| `npm run test:browser-prod-elision` (62/178) | PASS |
| `npm run test:bundle-isolation` (17 artefact entries; 35 sentinels) | PASS |
| `npm run test:elision` (production 41/41 absent; control 41/41 present) | PASS |
| `npm run test:perf-bundle` | PASS |
| `npm run test:reagent-slim:bundle-isolation` | PASS |

## What does not change

- `reg-view`'s user-facing surface — same args, same opts, same runtime render.
- The `data-rf2-source-coord` DOM attribute — stays for Xray/Story tooling.
- Production builds — every new surface elides via `interop/debug-enabled?`; bundle-isolation gate is authoritative.
- Dispatch / subscription / fx contracts.

Closes rf2-fa4ly.