### PR TITLE
feat(xray/edn-inspector): mode-3 slot-vs-value anchoring — R2 + R6 paint whole row (rf2-zpeyv)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1527,10 +1527,17 @@ flips.
 per §7 with Mike's pair-debug answers):
 
 - **R1**: value-side `~` gutter glyph for modified scalars + `←
-  changed from <prior>` italic muted suffix.
-- **R2**: key-side `+` / `−` glyph at column 1 of the key row
-  when the KEY itself is `:added` / `:removed`. Strike-through
-  reaches the key text for `:removed`.
+  changed from <prior>` italic muted suffix. Value-anchored —
+  the slot identity didn't change, only the contents did, so
+  chrome paints the value cell only (no key-cell wash, no key
+  strike). See the **slot-vs-value anchoring rule** below.
+- **R2 (refined rf2-zpeyv)**: key-side `+` / `−` glyph at column 1
+  of the key row when the KEY itself is `:added` / `:removed`.
+  Per the slot-vs-value rule (below), the per-op WASH paints the
+  **whole row** (key cell + value cell) and the `:removed`
+  strike-through reaches the KEY text — not just the value. The
+  visual unit matches the semantic unit: the SLOT changed, so the
+  WHOLE ROW reads as changed.
 - **R3 (revised)**: container triangle stays default
   `:text-tertiary` always (no colour swap). When COLLAPSED (`▶`)
   AND the subtree carries change, a `[N∆]` count chip appears
@@ -1545,22 +1552,56 @@ per §7 with Mike's pair-debug answers):
   reclassify to `:added` / `:removed` at the parent. Descendant
   gutter GLYPHS + 2px STRIPES are suppressed; descendant row
   WASHES are RETAINED (low-opacity tint). Operator scrolled into
-  the middle of a 20-leaf added shard still reads green.
+  the middle of a 20-leaf added shard still reads green. The
+  PARENT key's row follows the R2-refined slot-anchoring rule:
+  whole-row wash on the parent key + value cells.
 - **R6**: vector shift-detection via Editscript's A* + Myers
   underpinnings. Shifted-but-equal rows carry a `(was N)` muted
   suffix in `:text-tertiary` and NO gutter glyph (new op
   classification `:same-shifted`). Removed elements live on a
   separate `:vector-removals` channel keyed by parent path
   (the after-tree has no stable path identity for the deleted
-  element).
+  element). Vector INSERT / REMOVE rows naturally satisfy the
+  slot-anchoring rule — the row IS the slot (no key column),
+  so the per-op wash on the row's content IS the whole-row
+  treatment.
 - **R7**: type-change containers reclassify to `:modified`. New
   value renders in the value column; `← was <prior>` suffix via
   the `mini` renderer (falling back to "<type> with N keys"
-  when `mini` overflows).
+  when `mini` overflows). Value-anchored per the slot-vs-value
+  rule — the slot still resolves, only the value's type flipped.
 - **R8**: one-sided `:rf/redacted` renders as `:modified` with
   curated `← was redacted` / `← now redacted` suffix (no
   sentinel text leak). Two-sided redacted classifies as `:same`
   for v1; propagating "underlying-differs" is a follow-on bead.
+  Value-anchored — the slot's visibility changed, not its
+  identity.
+
+**Slot-vs-value anchoring (rf2-zpeyv)** — the visual chrome
+mirrors the semantic unit of the change. R2 + R6 (slot-identity
+changes) paint the whole row; R1 / R7 / R8 (value mutations
+inside an existing slot) stay value-anchored.
+
+| Change kind | Anchor | Wash reach | Strike (for `:removed`) |
+|---|---|---|---|
+| **R2 — key added** (slot identity change) | Key cell | **Whole row** (key + value cells) | n/a |
+| **R2 — key removed** (slot identity change) | Key cell | **Whole row** (key + value cells) | Reaches the KEY text + value text |
+| **R5 — wholesale add/remove subtree** | Parent key | Whole subtree (R5-tinted descendants); parent key's row follows R2 | Parent key text struck when removed |
+| **R6 — vector insert / remove** | Whole row (the row IS the slot) | Whole row | Reaches the row's content |
+| **R1 — value mutated** (slot identity unchanged) | Value cell | Value cell only | n/a |
+| **R7 — type change** (slot identity unchanged) | Value cell | Value cell only | n/a |
+| **R8 — redaction transition** (slot identity unchanged) | Value cell | Value cell only | n/a |
+
+Implementation: the renderer paints the per-op wash directly on
+the key cell `<div>` and the value cell `<div>` of the grid row
+when the child slot's op is `:added` or `:removed`. The inner
+gutter-row's own wash is suppressed (via `:slot-anchored?` →
+`:suppress-wash?`) so the row reads as a single banded slot, not
+a double-painted darker band over the value half. Test surface:
+`slot-anchored-added-key-paints-whole-row`,
+`slot-anchored-removed-key-paints-whole-row-and-strikes-key`,
+and `value-anchored-modified-row-does-not-paint-key-cell-wash`
+in `tools/xray/test/.../views/edn_inspector_cljs_test.cljs`.
 
 **Default-expanded-depth**: 3 in mode-3 specifically (per Q4 — between
 browse's 1 and diff's 2; deep enough to surface most app-db top-level

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
@@ -694,17 +694,27 @@
     op is `:same` or `:same-shifted` (so descendants of a wholly-
     new subtree still read as green).
 
+  ## rf2-zpeyv — slot-vs-value anchoring
+
+  - `:suppress-wash?` — paint NO wash on this gutter-row. Used when
+    the slot-anchored chrome paints the wash on the WHOLE ROW (key +
+    value grid cells) at the parent's row level (R2 added/removed
+    map-key, R6 vector add/remove). Without suppression here, the
+    inner wash overlaps the outer cell wash and the row reads as a
+    double-painted band over the value half.
+
   When `chrome-opts` is omitted the chrome falls back to the per-op
   defaults (added=green, modified=amber, removed=red, same=invisible).
-  All three optional keys default to nil, so existing call sites
+  All four optional keys default to nil, so existing call sites
   (non-mode-3 diff renders) reach the same hiccup shape unchanged."
   ([op body] (gutter-row op body nil))
-  ([op body {:keys [suppress-glyph? suppress-stripe? wash-op]}]
+  ([op body {:keys [suppress-glyph? suppress-stripe? suppress-wash? wash-op]}]
    (let [active?       (and (not (#{:same :same-shifted} op))
                             (not suppress-stripe?))
          effective-wash-op (or wash-op
                                (when-not (#{:same :same-shifted} op) op))
-         wash          (op-wash-bg effective-wash-op)
+         wash          (when-not suppress-wash?
+                         (op-wash-bg effective-wash-op))
          stripe        (when-not suppress-stripe? (op-stripe-colour op))
          glyph         (if suppress-glyph? " " (op-glyph op))
          glyph-colour  (if suppress-glyph?
@@ -1989,6 +1999,18 @@
                                             :added   "+"
                                             :removed "−"
                                             nil)
+                           ;; rf2-zpeyv — slot-vs-value anchoring. When
+                           ;; the SLOT itself changes (key added /
+                           ;; removed) the chrome paints the WHOLE row
+                           ;; (key cell + value cell) in the per-op
+                           ;; wash, and `:removed` strike-through reaches
+                           ;; the key text. When only the VALUE inside
+                           ;; an existing slot changed (R1/R7/R8), the
+                           ;; chrome stays value-anchored (no key-cell
+                           ;; wash, no key strike).
+                           slot-anchored? (boolean (#{:added :removed} child-op))
+                           slot-wash (when slot-anchored?
+                                       (op-wash-bg child-op))
                            value-node (render-node
                                         {:value cv
                                          :before cb
@@ -2002,17 +2024,37 @@
                                          :dispatch-fn dispatch-fn
                                          :zoomable? zoomable?
                                          :zoom-path-prefix zoom-path-prefix
-                                         :opts opts})]
+                                         :opts opts
+                                         ;; Suppress the leaf's inner
+                                         ;; gutter-row wash — the slot
+                                         ;; row paints it on the value
+                                         ;; cell here. The gutter glyph
+                                         ;; + per-token text colour on
+                                         ;; the value still render.
+                                         :slot-anchored? slot-anchored?})]
                        [(with-meta
                           ;; Key cell — uses `div` so the grid baseline
                           ;; aligns predictably across rows. `white-
                           ;; space: nowrap` prevents long keys (e.g. a
                           ;; deeply-namespaced `:rf.x.with.many.parts/k`)
                           ;; from wrapping inside the key column.
+                          ;;
+                          ;; rf2-zpeyv — when slot-anchored, paint the
+                          ;; per-op wash across the KEY cell (whole-row
+                          ;; treatment) and strike the key text for
+                          ;; `:removed`. The wash on the sibling value
+                          ;; cell completes the row.
                           [:div (cond-> {:data-rf-cell "key"
-                                         :style key-cell-style}
+                                         :style (cond-> key-cell-style
+                                                  slot-wash
+                                                  (assoc :background slot-wash)
+                                                  (= child-op :removed)
+                                                  (assoc :text-decoration "line-through"))}
                                   key-side-glyph
-                                  (assoc :data-rf-key-glyph key-side-glyph))
+                                  (assoc :data-rf-key-glyph key-side-glyph)
+                                  slot-anchored?
+                                  (assoc :data-rf-row-anchor "slot"
+                                         :data-rf-row-wash "1"))
                            ;; R2 key-side glyph — paint `+` / `−` in
                            ;; column 1 of the key row when the KEY itself
                            ;; is new/removed. The key text picks up the
@@ -2031,8 +2073,19 @@
                                (conj [:span {:style {:text-decoration "line-through"}}])))]
                           {:key (str "k-" (pr-str k))})
                         (with-meta
-                          [:div {:data-rf-cell "value"
-                                 :style value-cell-style}
+                          ;; Value cell. rf2-zpeyv — when slot-anchored,
+                          ;; paint the per-op wash across the whole value
+                          ;; cell so it joins the key cell's wash into a
+                          ;; single banded row. The leaf's inner gutter-
+                          ;; row wash is suppressed via `:slot-anchored?`
+                          ;; on render-node (above) — no double-paint.
+                          [:div (cond-> {:data-rf-cell "value"
+                                         :style (cond-> value-cell-style
+                                                  slot-wash
+                                                  (assoc :background slot-wash))}
+                                  slot-anchored?
+                                  (assoc :data-rf-row-anchor "slot"
+                                         :data-rf-row-wash "1"))
                            value-node]
                           {:key (str "v-" (pr-str k))})]))
                    child-pairs))
@@ -2168,8 +2221,18 @@
 
   R5-tinted: when the leaf sits inside a wholly-changed ancestor, the
   glyph + stripe are suppressed (only the wash + parent's marking
-  carry the signal). Implemented via `gutter-row` chrome-opts."
-  [{:keys [value before diff? projection path]}]
+  carry the signal). Implemented via `gutter-row` chrome-opts.
+
+  ## rf2-zpeyv — slot-anchored rendering
+
+  When `:slot-anchored?` is true, the leaf's own wash is SUPPRESSED.
+  The caller (the map-row grid renderer) has painted the per-op wash
+  on the WHOLE row (key cell + value cell) so the slot-identity
+  change (R2 key add/remove) reads as a single banded row. Without
+  suppression, the inner wash overlaps the outer cell wash and the
+  value half reads darker than the key half. Only the gutter glyph
+  and per-token text colour remain on the leaf side."
+  [{:keys [value before diff? projection path slot-anchored?]}]
   (if-not diff?
     (render-scalar value)
     (let [;; Resolve op: prefer the projection at this path; else
@@ -2187,10 +2250,16 @@
           inside-wholly? (and wholly-anc (not= wholly-anc (vec (or path []))))
           ;; R5: suppress glyph + stripe on descendants of a wholly-
           ;; changed root, but RETAIN the wash for partial-visibility.
-          chrome-opts (when inside-wholly?
-                        {:suppress-glyph? true
-                         :suppress-stripe? true
-                         :wash-op (engine/op-at projection wholly-anc)})
+          ;; R2-revised (rf2-zpeyv): `:slot-anchored?` from the map-row
+          ;; caller adds wash suppression on top of the R5 rule — the
+          ;; outer key+value cells paint the whole-row wash.
+          chrome-opts (cond-> nil
+                        inside-wholly?
+                        (assoc :suppress-glyph?   true
+                               :suppress-stripe?  true
+                               :wash-op           (engine/op-at projection wholly-anc))
+                        slot-anchored?
+                        (assoc :suppress-wash? true))
           ;; R6: shifted-was-index for vector elements at a different
           ;; position than they were in the before-tree.
           was-index (when (= op :same-shifted)
@@ -2303,9 +2372,20 @@
   callers that drive render-node without a mount can omit it — the
   container-renderer falls back to the global `rf/dispatch`.
 
-  Public so unit tests can drive the renderer without mounting."
+  Public so unit tests can drive the renderer without mounting.
+
+  ## rf2-zpeyv — slot-anchored threading
+
+  `:slot-anchored?` is set by the map-row grid renderer when a CHILD
+  slot's op is `:added` / `:removed`. It threads to
+  `render-leaf-with-diff` so the leaf's inner gutter-row suppresses
+  its own wash (the map row paints whole-row wash on the key + value
+  cells). Container values inside an added/removed slot already
+  render via the recursive `render-container` path; that path paints
+  no leaf-wash itself, so the flag only matters when the value bottoms
+  out at a scalar leaf."
   [{:keys [value before diff? projection panel-id mount-id path depth expansion-map
-           dispatch-fn zoomable? zoom-path-prefix opts]
+           dispatch-fn zoomable? zoom-path-prefix opts slot-anchored?]
     :or   {depth 0 path [] zoom-path-prefix []}}]
   (or
     ;; Protocol seam (rf2-0qrcr) — light-touch satisfies? gate; nil
@@ -2328,7 +2408,8 @@
       ;; the structure, for deletions).
       (and diff? (= value ::missing))
       (render-leaf-with-diff {:value ::missing :before before :diff? true
-                              :projection projection :path path})
+                              :projection projection :path path
+                              :slot-anchored? slot-anchored?})
 
       ;; Diff mode: added slot at a container → render the new
       ;; container in green via the normal recursive path with `op
@@ -2351,7 +2432,8 @@
                              :before ::missing
                              :projection projection})
           (render-leaf-with-diff {:value value :before ::missing :diff? true
-                                  :projection projection :path path})))
+                                  :projection projection :path path
+                                  :slot-anchored? slot-anchored?})))
 
       :else
       (let [kind (collection-kind value)]
@@ -2374,7 +2456,8 @@
                                   :before before
                                   :diff? (boolean diff?)
                                   :projection projection
-                                  :path path}))))))
+                                  :path path
+                                  :slot-anchored? slot-anchored?}))))))
 
 ;; =========================================================================
 ;; mount-id generator + public entry — edn-inspector (form-2 component)

--- a/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs
@@ -1487,6 +1487,234 @@
         "modified leaf still carries the change annotation")))
 
 ;; =========================================================================
+;; rf2-zpeyv — slot-vs-value anchoring (R2 + R6 whole-row treatment)
+;; =========================================================================
+;;
+;; When the SLOT itself changes (key added / removed), the per-op wash
+;; paints the WHOLE row (key cell + value cell) and the `:removed`
+;; strike-through reaches the key text. When only the VALUE changed
+;; inside an existing slot (R1/R7/R8), the chrome stays value-anchored —
+;; no key-cell wash, no key strike.
+
+(defn- ^:private projection-for
+  "Compute a projection for `(before, after)` so tests can drive
+  `render-node` with the same engine the production renderer uses."
+  [before after]
+  (engine/project before after))
+
+(deftest slot-anchored-added-key-paints-whole-row
+  ;; R2 added map-key — both the key cell AND the value cell carry the
+  ;; per-op wash; `data-rf-row-anchor="slot"` markers appear on both.
+  (let [before {:a 1}
+        after  {:a 1 :b 2}
+        proj   (projection-for before after)
+        h      (ei/render-node {:value after
+                                :before before
+                                :diff? true
+                                :projection proj
+                                :panel-id :p :mount-id "m"
+                                :path [] :depth 0
+                                :expansion-map {}
+                                :opts {:default-expanded-depth 2}})
+        nodes  (walk-hiccup h)
+        slot-cells (->> nodes
+                        (filter (fn [n]
+                                  (and (vector? n)
+                                       (map? (second n))
+                                       (= "slot"
+                                          (get (second n) :data-rf-row-anchor))))))
+        cell-roles (->> slot-cells
+                        (map (fn [n] (get (second n) :data-rf-cell)))
+                        set)]
+    (is (>= (count slot-cells) 2)
+        "added-key row tags both grid cells with data-rf-row-anchor=slot")
+    (is (contains? cell-roles "key")
+        "the key cell carries the slot-anchor marker")
+    (is (contains? cell-roles "value")
+        "the value cell carries the slot-anchor marker")
+    ;; Both cells must paint a non-empty :background (the per-op wash).
+    (doseq [cell slot-cells]
+      (let [bg (-> cell second :style :background)]
+        (is (some? bg)
+            (str "slot cell " (get (second cell) :data-rf-cell)
+                 " paints :background wash"))))))
+
+(deftest slot-anchored-removed-key-paints-whole-row-and-strikes-key
+  ;; R2 removed map-key — both cells get the wash AND the key cell
+  ;; gets `text-decoration: line-through` so the strike reaches the
+  ;; key text, not just the value text.
+  (let [before {:a 1 :legacy-flag true}
+        after  {:a 1}
+        proj   (projection-for before after)
+        h      (ei/render-node {:value after
+                                :before before
+                                :diff? true
+                                :projection proj
+                                :panel-id :p :mount-id "m"
+                                :path [] :depth 0
+                                :expansion-map {}
+                                :opts {:default-expanded-depth 2}})
+        nodes  (walk-hiccup h)
+        slot-cells (->> nodes
+                        (filter (fn [n]
+                                  (and (vector? n)
+                                       (map? (second n))
+                                       (= "slot"
+                                          (get (second n) :data-rf-row-anchor))))))
+        key-cells (filter (fn [n] (= "key" (get (second n) :data-rf-cell)))
+                          slot-cells)
+        value-cells (filter (fn [n] (= "value" (get (second n) :data-rf-cell)))
+                            slot-cells)]
+    (is (= 1 (count key-cells))
+        "removed-key row contributes exactly one slot-anchored key cell")
+    (is (= 1 (count value-cells))
+        "removed-key row contributes exactly one slot-anchored value cell")
+    (let [key-style (-> key-cells first second :style)]
+      (is (some? (:background key-style))
+          "key cell paints the per-op wash background")
+      (is (= "line-through" (:text-decoration key-style))
+          "key cell paints strike-through so the strike reaches the key text"))
+    (let [val-style (-> value-cells first second :style)]
+      (is (some? (:background val-style))
+          "value cell paints the per-op wash background"))))
+
+(deftest slot-anchored-leaf-wash-suppressed-no-double-paint
+  ;; The inner gutter-row inside a slot-anchored value cell MUST
+  ;; suppress its own wash; otherwise the wash double-paints over the
+  ;; cell-level wash. We assert via the `data-rf-diff-wash` attribute
+  ;; (set by gutter-row when it paints a wash) being absent inside an
+  ;; `:added` / `:removed` slot row.
+  (let [before {:a 1}
+        after  {:a 1 :b 2}
+        proj   (projection-for before after)
+        h      (ei/render-node {:value after
+                                :before before
+                                :diff? true
+                                :projection proj
+                                :panel-id :p :mount-id "m"
+                                :path [] :depth 0
+                                :expansion-map {}
+                                :opts {:default-expanded-depth 2}})
+        nodes  (walk-hiccup h)
+        ;; Find the value cell for the added :b key — it carries
+        ;; `data-rf-cell value` and `data-rf-row-anchor slot`.
+        value-cell (->> nodes
+                        (filter (fn [n]
+                                  (and (vector? n)
+                                       (map? (second n))
+                                       (= "value" (get (second n) :data-rf-cell))
+                                       (= "slot" (get (second n) :data-rf-row-anchor)))))
+                        first)
+        ;; Walk inside the slot-anchored value cell looking for any
+        ;; descendant with `data-rf-diff-wash` set — that would mean a
+        ;; gutter-row inside the cell painted its own wash.
+        inner-washes (->> (walk-hiccup value-cell)
+                          (filter (fn [n]
+                                    (and (vector? n)
+                                         (map? (second n))
+                                         (= "1" (get (second n) :data-rf-diff-wash))))))]
+    (is (some? value-cell)
+        "added-key slot-anchored value cell is present")
+    (is (zero? (count inner-washes))
+        "slot-anchored value cell suppresses inner gutter-row wash")))
+
+(deftest value-anchored-modified-row-does-not-paint-key-cell-wash
+  ;; R1 (value mutated, slot identity unchanged) MUST stay value-
+  ;; anchored. No `data-rf-row-anchor=slot` markers on the key/value
+  ;; cells; key cell carries no wash and no strike.
+  (let [before {:counter 5}
+        after  {:counter 6}
+        proj   (projection-for before after)
+        h      (ei/render-node {:value after
+                                :before before
+                                :diff? true
+                                :projection proj
+                                :panel-id :p :mount-id "m"
+                                :path [] :depth 0
+                                :expansion-map {}
+                                :opts {:default-expanded-depth 2}})
+        nodes  (walk-hiccup h)
+        slot-cells (->> nodes
+                        (filter (fn [n]
+                                  (and (vector? n)
+                                       (map? (second n))
+                                       (= "slot"
+                                          (get (second n) :data-rf-row-anchor))))))
+        key-cells (->> nodes
+                       (filter (fn [n]
+                                 (and (vector? n)
+                                      (map? (second n))
+                                      (= "key" (get (second n) :data-rf-cell))))))
+        s   (try (pr-str h) (catch :default _ ""))]
+    (is (zero? (count slot-cells))
+        "modified-leaf row carries no slot-anchor markers (value-anchored)")
+    (is (pos? (count key-cells))
+        "the key cell still renders (no regression)")
+    (doseq [kc key-cells]
+      (let [style (-> kc second :style)]
+        (is (not (:background style))
+            "modified-key cell paints NO row wash")
+        (is (not= "line-through" (:text-decoration style))
+            "modified-key cell paints NO key-text strike")))
+    (is (re-find #"← changed from 5" s)
+        "value-side R1 annotation still present")))
+
+(deftest value-anchored-redaction-row-stays-value-anchored
+  ;; R8 (redaction transition) keeps value-anchored chrome — the slot
+  ;; identity didn't change, only the visibility of the value did.
+  (let [before {:secret :rf/redacted}
+        after  {:secret "now-visible"}
+        proj   (projection-for before after)
+        h      (ei/render-node {:value after
+                                :before before
+                                :diff? true
+                                :projection proj
+                                :panel-id :p :mount-id "m"
+                                :path [] :depth 0
+                                :expansion-map {}
+                                :opts {:default-expanded-depth 2}})
+        nodes  (walk-hiccup h)
+        slot-cells (->> nodes
+                        (filter (fn [n]
+                                  (and (vector? n)
+                                       (map? (second n))
+                                       (= "slot"
+                                          (get (second n) :data-rf-row-anchor))))))]
+    (is (zero? (count slot-cells))
+        "R8 row stays value-anchored — no slot-anchor markers")))
+
+(deftest slot-anchored-removed-key-marker-on-data-attrs
+  ;; The removed-row regression test already covers `line-through`
+  ;; appearing in pr-str — but we want a positive assertion that the
+  ;; KEY CELL specifically carries the strike. Walk through the hiccup
+  ;; and confirm the key-cell `<div>` is what holds it (not just the
+  ;; inner key-segment span).
+  (let [before {:a 1 :b 2}
+        after  {:a 1}
+        proj   (projection-for before after)
+        h      (ei/render-node {:value after
+                                :before before
+                                :diff? true
+                                :projection proj
+                                :panel-id :p :mount-id "m"
+                                :path [] :depth 0
+                                :expansion-map {}
+                                :opts {:default-expanded-depth 2}})
+        nodes  (walk-hiccup h)
+        key-cell-with-strike
+        (->> nodes
+             (filter (fn [n]
+                       (and (vector? n)
+                            (map? (second n))
+                            (= "key" (get (second n) :data-rf-cell))
+                            (= "slot" (get (second n) :data-rf-row-anchor))
+                            (= "line-through"
+                               (get-in (second n) [:style :text-decoration])))))
+             first)]
+    (is (some? key-cell-with-strike)
+        "removed-key cell DIV (not just inner span) carries line-through")))
+
+;; =========================================================================
 ;; rf2-y59tb — frame-leak + first-click regression guards
 ;; =========================================================================
 ;;

--- a/tools/xray/testbeds/panel_gallery/gallery_diff_mode_3.cljs
+++ b/tools/xray/testbeds/panel_gallery/gallery_diff_mode_3.cljs
@@ -76,19 +76,24 @@
      :substrates #{:reagent}})
 
   (story/reg-variant :story.xray.diff-mode-3/r2-new-map-key
-    {:doc        "R2 — new map key. `{:a 1} → {:a 1 :b 2}`. The `:b`
-                  key row paints `+` glyph at column 1 + green wash
-                  on the value side."
+    {:doc        "R2 (refined rf2-zpeyv) — new map key.
+                  `{:a 1} → {:a 1 :b 2}`. Slot-anchored chrome: the
+                  green wash spans the WHOLE row (`:b` key cell +
+                  value cell). `+` glyph sits at column 1 of the key
+                  cell. The slot identity changed (a key appeared),
+                  so the visual unit is the whole row."
      :events     [[:panel-gallery.edn-inspector/seed!
                    (fixtures/r2-new-map-key)]]
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
 
   (story/reg-variant :story.xray.diff-mode-3/r2-removed-map-key
-    {:doc        "R2 — removed map key. `{:a 1 :b 2} → {:a 1}`. The
-                  `:b` key row paints `−` glyph + strike-through reaches
-                  the key text. The value column renders the prior
-                  value (also struck-through)."
+    {:doc        "R2 (refined rf2-zpeyv) — removed map key.
+                  `{:a 1 :b 2} → {:a 1}`. Slot-anchored chrome: the
+                  red wash spans the WHOLE row, and the strike-through
+                  reaches the KEY text (`:b`) — not just the value.
+                  `−` glyph sits at column 1 of the key cell. The
+                  whole slot died, so the whole row reads as dead."
      :events     [[:panel-gallery.edn-inspector/seed!
                    (fixtures/r2-removed-map-key)]]
      :tags       #{:dev :state/special}


### PR DESCRIPTION
## Slot-vs-value anchoring principle

The visual chrome should mirror the semantic unit of the change.

- **Slot identity change** (R2 — key added/removed, R6 — vector insert/remove): the SLOT is what changed → paint the WHOLE row (key cell + value cell) with the per-op wash, and `:removed` strike-through reaches the KEY text.
- **Value mutation inside an existing slot** (R1 — value mutated, R7 — type change, R8 — redaction transition): the slot identity didn't change, only the contents did → chrome stays value-anchored (no key-cell wash, no key strike).

| Change kind | Anchor | Wash reach | Strike |
|---|---|---|---|
| R2 — key added | Key cell | **Whole row** | n/a |
| R2 — key removed | Key cell | **Whole row** | Reaches key text |
| R5 — wholesale subtree add/remove | Parent key | Whole subtree (R5-tinted); parent row follows R2 | Parent key text |
| R6 — vector insert/remove | Whole row (no key column) | Whole row | Row content |
| R1 — value mutated | Value cell | Value cell only | n/a |
| R7 — type change | Value cell | Value cell only | n/a |
| R8 — redaction transition | Value cell | Value cell only | n/a |

## Before / after

```
Before R2 refinement (variant E shipped):

  :legacy-flag    -  ~~true~~       ← key text NOT struck; wash only on value
  (key cell has no wash; value cell has red wash via gutter-row)

After R2 refinement (this PR):

  ~~:legacy-flag~~  -  ~~true~~     ← key text + value text both struck
  (red wash spans key cell AND value cell — one banded row)


Before R2 refinement:

  ▼  +:flash       +  {             ← green wash only on value
  (key cell has no wash; value cell has green wash on the leaf)

After R2 refinement (this PR):

  ▼ + :flash         {              ← green wash spans key cell AND value cell
```

## spec/021 §9.1.5.1 update

Updated the R-rule descriptions to reference the slot-vs-value rule and added a normative table summarising anchor / wash reach / strike per rule. R1 / R7 / R8 explicitly noted as value-anchored.

## Story variants updated

`r2-new-map-key` + `r2-removed-map-key` docstrings updated to describe the refined whole-row chrome ("slot-anchored chrome: the green wash spans the WHOLE row...").

## Implementation

- `gutter-row` gains `:suppress-wash?` chrome-opt — used by slot-anchor rows so the inner wash doesn't double-paint over the value half.
- `render-leaf-with-diff` accepts `:slot-anchored?` which threads into `gutter-row` as `:suppress-wash?`. Gutter glyph + per-token text colour still render.
- The map-row grid renderer (`render-container` body-grid path) computes `slot-anchored?` when child-op is `:added` / `:removed` and paints the per-op wash on the key cell `<div>` AND the value cell `<div>`. `:removed` rows add `text-decoration: line-through` to the key cell so the strike reaches the key text.
- `render-node` threads `:slot-anchored?` so it flows from the map-row caller down to the leaf.

R5 + R6 verification:

- **R5**: when the parent slot is wholly-changed (`:added` / `:removed` at the engine projection), the parent's key sits in a row whose child-op resolves to that op — so the R2-refined whole-row rule applies automatically. No additional wiring needed.
- **R6 (vector insert / remove)**: each vector row sits in the block body with no key column — the row IS the slot. The leaf's gutter-row wash on the row's content IS the whole-row treatment. Pre-existing behaviour matches the rule.

## Quality gates

- `scripts/test-fast-pr.sh` — PASS
- `npm run test:cljs` — 4799 tests / 15667 assertions, 0 failures
- `npm run test:browser` — 124 tests / 353 assertions, 0 failures
- `npm run test:bundle-isolation` — PASS
- `npm run test:xray-feature-gate:smoke` — 3 scenarios, 0 failures, 10 matrix rows

Closes rf2-zpeyv.