### PR TITLE
fix(framework/story): Inspect URI emits correct source-root segment — closes click-to-source bug class (rf2-wvsxg)

### DIFF
--- a/implementation/core/src/re_frame/source_coords.cljc
+++ b/implementation/core/src/re_frame/source_coords.cljc
@@ -202,6 +202,118 @@
       (not (no-source-path? file))      file
       :else                              nil)))
 
+;; ---- :file absolutisation (rf2-wvsxg) ------------------------------------
+;;
+;; Both shadow-cljs and the JVM compiler put the **classpath-relative**
+;; portion of a source file in the form's `:file` slot — for
+;; `tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs` (whose
+;; classpath root is `tools/xray/src/`), the form-meta `:file` is just
+;; `"day8/re_frame2_xray/views/edn_inspector.cljs"`. The source-root
+;; segment is invisible to anyone consuming the captured coord, which
+;; defeats Story / Xray's `open-in-editor` chip — `:project-root` plus
+;; the classpath-relative tail produces the wrong on-disk path
+;; whenever the project-root isn't the same as the classpath root that
+;; resolved the file.
+;;
+;; Live failure shape (rf2-wvsxg):
+;;   project-root  C:/Users/miket/code/re-frame2/tools/xray/testbeds
+;;   :file         day8/re_frame2_xray/views/edn_inspector.cljs
+;;   composed      C:/.../tools/xray/testbeds/day8/.../edn_inspector.cljs
+;;   actual        C:/.../tools/xray/src/day8/.../edn_inspector.cljs
+;;
+;; The fix: at macro-expansion time on the JVM, resolve the classpath-
+;; relative `:file` to its on-disk URL via the context class-loader and
+;; bake the **absolute on-disk path** into the emitted coord. The
+;; downstream URI builder's `compose-path` already detects absolute
+;; paths and passes them through unchanged, so a coord baked with an
+;; absolute `:file` ships the right URI regardless of which
+;; `:project-root` the host configured. Absolutisation runs once per
+;; macro expansion (JVM-side); the CLJS runtime sees a literal string
+;; (cheap), and production builds elide both the literal and the
+;; surrounding coord-form per the existing rf2-3un2g gate.
+;;
+;; Failure modes that fall through to the unchanged input:
+;;   - Already-absolute path (e.g. a JVM-compile `*file*` that
+;;     happened to be absolute, or a synthetic coord with an absolute
+;;     `:file`): detected by the same `absolute-path?` predicate
+;;     `editor-uri/compose-path` uses (leading `/`, leading drive
+;;     letter, leading `file:` scheme, leading backslash).
+;;   - File not resolvable on classpath (REPL-eval forms with synthetic
+;;     `:file`, a test fixture's fabricated path, a path under a
+;;     classpath root the JVM doesn't have when the macro expands):
+;;     pass through unchanged; the downstream URI builder still gets a
+;;     coord, just one whose `:project-root` join is the legacy
+;;     behaviour.
+;;   - CLJS-side calls (no class-loader access): no-op pass-through;
+;;     the macro path is JVM-side by construction so this branch only
+;;     fires when callers reach the fn from CLJS runtime code (rare).
+
+#?(:clj
+   (defn ^:private absolute-file-path?
+     "Mirrors `re-frame.source-coords.editor-uri/absolute-path?` (kept
+     local to avoid a JVM-side dep on a CLJS-only ns). True iff `path`
+     should NOT be absolutised — already-absolute paths, `file:` URLs,
+     or drive-letter prefixes pass through unchanged."
+     [^String path]
+     (or (.startsWith path "/")
+         (.startsWith path "\\")
+         (.startsWith (.toLowerCase path) "file:")
+         (and (>= (.length path) 2)
+              (= \: (.charAt path 1))
+              (let [c (.charAt path 0)]
+                (or (and (>= (int c) (int \a)) (<= (int c) (int \z)))
+                    (and (>= (int c) (int \A)) (<= (int c) (int \Z)))))))))
+
+#?(:clj
+   (defn ^:private context-class-loader ^ClassLoader []
+     (.getContextClassLoader (Thread/currentThread))))
+
+#?(:clj
+   (defn absolutise-file
+     "JVM-only. Resolve a classpath-relative source file path to its
+     absolute on-disk path via the context class-loader. Returns the
+     input unchanged when the path is already absolute, when classpath
+     resolution fails (no resource found, non-`file:` URL), or when
+     `path` is nil / blank.
+
+     Used by `coords-form` / `prod-coords-form` / `form-coords` at
+     macro-expansion time to bake an absolute `:file` value into each
+     emitted source-coord literal — defeating the source-root
+     ambiguity that bites multi-source-path builds (shadow-cljs lists
+     both `tools/xray/src` and `tools/xray/testbeds` for the panel-
+     gallery testbed; the form-meta's classpath-relative `:file` carries
+     no signal about which source root resolved it).
+
+     Per rf2-wvsxg."
+     [path]
+     (if (or (nil? path) (.isEmpty ^String path) (absolute-file-path? path))
+       path
+       (try
+         (if-let [url (.getResource (context-class-loader) path)]
+           (if (= "file" (.getProtocol url))
+             ;; URL paths come out URL-encoded (e.g. `%20` for spaces)
+             ;; and use `/` on every platform. URLDecoder handles the
+             ;; encoding; the result on Windows is `/C:/Users/...` so
+             ;; strip a leading slash before a drive-letter to get the
+             ;; canonical `C:/Users/...` shape `compose-path` already
+             ;; handles.
+             (let [decoded (java.net.URLDecoder/decode (.getPath url) "UTF-8")]
+               (if (and (> (.length ^String decoded) 2)
+                        (= \/ (.charAt ^String decoded 0))
+                        (= \: (.charAt ^String decoded 2)))
+                 (.substring ^String decoded 1)
+                 decoded))
+             ;; jar:/zip:/http: — leave the input unchanged; an
+             ;; in-jar source file isn't editable on disk anyway.
+             path)
+           ;; Not on classpath (REPL eval, synthetic coord, test
+           ;; fabrication): pass through.
+           path)
+         (catch Throwable _
+           ;; Defensive — classpath probing must never break macro
+           ;; expansion. Any failure → preserve original behaviour.
+           path)))))
+
 (defn coords-form
   "Construct the compile-time `(cond-> {:ns 'sym} ...)` form that every
   reg-* macro emits as the value of its `*pending-coords*` binding.
@@ -219,9 +331,18 @@
   shape (with `:column`) under `:advanced` + `goog.DEBUG=false`. The
   `with-coords-form` / `expand-reg-machine` helpers do this internally;
   per-element machine stamping and call-site stamping handle elision
-  through their own outer gates and call this fn directly."
+  through their own outer gates and call this fn directly.
+
+  Per rf2-wvsxg: when running on the JVM (the macro-expansion side),
+  the picked `:file` is fed through [[absolutise-file]] to resolve the
+  classpath-relative form-meta `:file` to its absolute on-disk path.
+  Downstream URI builders' `compose-path` detects absolute paths and
+  passes them through unchanged, so the emitted coord ships the right
+  on-disk path regardless of the host's `:project-root` configuration."
   [form-meta file ns-sym]
-  (let [chosen-file (resolve-file form-meta file)]
+  (let [chosen-file (resolve-file form-meta file)
+        chosen-file #?(:clj  (when chosen-file (absolutise-file chosen-file))
+                       :cljs chosen-file)]
     `(cond-> {:ns '~ns-sym}
        ~chosen-file         (assoc :file ~chosen-file)
        ~(:line form-meta)   (assoc :line ~(:line form-meta))
@@ -244,9 +365,15 @@
             ~(prod-coords-form form-meta file ns-sym))
 
      Both branches use `cond->` so absent keys (e.g. nil `:line` on a
-     programmatic synthesis) elide cleanly."
+     programmatic synthesis) elide cleanly.
+
+     Per rf2-wvsxg: the picked `:file` is absolutised via
+     [[absolutise-file]] at macro-expansion time so the downstream URI
+     builder receives an absolute on-disk path regardless of which
+     source-root resolved the file on shadow-cljs's classpath."
      [form-meta file ns-sym]
-     (let [chosen-file (resolve-file form-meta file)]
+     (let [chosen-file (resolve-file form-meta file)
+           chosen-file (when chosen-file (absolutise-file chosen-file))]
        `(cond-> {:ns '~ns-sym}
           ~chosen-file       (assoc :file ~chosen-file)
           ~(:line form-meta) (assoc :line ~(:line form-meta))))))
@@ -285,10 +412,15 @@
 
   The same `:file` resolution as the call-site path applies: prefer
   the reader-attached `:file` on the form's metadata over the macro's
-  `*file*` arg, and reject the `\"NO_SOURCE_PATH\"` sentinel."
+  `*file*` arg, and reject the `\"NO_SOURCE_PATH\"` sentinel.
+
+  Per rf2-wvsxg: the picked `:file` is absolutised via
+  [[absolutise-file]] (JVM macro-expansion path) so per-machine-element
+  coords ship absolute on-disk paths matching the reg-* macro coords."
   [form ns-sym file]
   (let [m            (meta form)
-        chosen-file  (resolve-file m file)]
+        chosen-file  (resolve-file m file)
+        chosen-file  (when chosen-file (absolutise-file chosen-file))]
     (when (and m (or (:line m) (:column m)))
       (cond-> {:ns ns-sym}
         chosen-file (assoc :file chosen-file)

--- a/implementation/core/test/re_frame/source_coords_test.clj
+++ b/implementation/core/test/re_frame/source_coords_test.clj
@@ -29,6 +29,11 @@
             [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
+            ;; rf2-wvsxg — direct access to source-coords helpers + the
+            ;; URI builder's compose-path predicate for the absolutise-
+            ;; file regression coverage.
+            [re-frame.source-coords :as sc]
+            [re-frame.source-coords.editor-uri :as eu]
             [re-frame.substrate.plain-atom :as plain-atom]))
 
 (defn reset-runtime [test-fn]
@@ -198,3 +203,80 @@
       (is (nil? (:ns   meta)) ":ns absent on direct fn call")
       (is (nil? (:line meta)) ":line absent on direct fn call")
       (is (nil? (:file meta)) ":file absent on direct fn call"))))
+
+;; ---- rf2-wvsxg: :file is absolutised via classpath resolution -------------
+
+(deftest absolutise-file-resolves-classpath-relative-paths
+  (testing "rf2-wvsxg: absolutise-file returns absolute on-disk path for a
+  classpath-relative source file"
+    ;; This very test file lives on the classpath under its
+    ;; classpath-relative path; absolutising it must yield a path that
+    ;; matches the absolute-path predicate the URI builder uses.
+    (let [rel  "re_frame/source_coords_test.clj"
+          abs  (#'sc/absolutise-file rel)]
+      (is (string? abs))
+      (is (not= rel abs)
+          "classpath-relative path should resolve to a different (absolute) path")
+      ;; The result must look absolute to compose-path so the URI build
+      ;; passes it through unchanged. compose-path is private — go
+      ;; through the public editor-uri's 3-arg form (which calls
+      ;; compose-path internally) by checking the URI carries the
+      ;; absolute path without the project-root prepended.
+      (let [uri (eu/editor-uri :vscode {:file abs :line 1 :column 1}
+                               {:project-root "/fake/project/root"})]
+        (is (.contains ^String uri abs)
+            "URI must carry the absolute :file value")
+        (is (not (.contains ^String uri "/fake/project/root"))
+            "URI must NOT contain the project-root (absolute path passes through)")))))
+
+(deftest absolutise-file-passes-through-already-absolute
+  (testing "rf2-wvsxg: already-absolute paths pass through unchanged"
+    ;; Windows-style drive letter
+    (is (= "C:/foo/bar.cljs"
+           (#'sc/absolutise-file "C:/foo/bar.cljs")))
+    ;; POSIX absolute
+    (is (= "/foo/bar.cljs"
+           (#'sc/absolutise-file "/foo/bar.cljs")))
+    ;; file: URL
+    (is (= "file:/foo/bar.cljs"
+           (#'sc/absolutise-file "file:/foo/bar.cljs")))))
+
+(deftest absolutise-file-passes-through-unresolvable
+  (testing "rf2-wvsxg: classpath-relative paths not on classpath fall
+  through unchanged (synthetic coords, REPL eval, fabricated test
+  paths shouldn't break)"
+    (is (= "no/such/file/exists.cljs"
+           (#'sc/absolutise-file "no/such/file/exists.cljs")))))
+
+(deftest absolutise-file-handles-nil-and-blank
+  (testing "rf2-wvsxg: nil / empty input passes through (the macro
+  call-sites already gate on non-nil, but defense-in-depth)"
+    (is (nil? (#'sc/absolutise-file nil)))
+    (is (= "" (#'sc/absolutise-file "")))))
+
+(deftest reg-event-db-emits-absolute-file
+  (testing "rf2-wvsxg: a reg-* macro fired against a real classpath-
+  resident file (this test ns) emits an ABSOLUTE :file, not a
+  classpath-relative tail. This is the core regression: source-coord
+  consumers (Story / Xray open-in-editor chips) can take the :file
+  through compose-path unchanged and ship a URI that resolves on disk
+  regardless of which project-root the host configured."
+    (rf/reg-event-db :rf2-wvsxg/absolute-file-sample
+                     (fn [db _] db))
+    (let [meta (rf/handler-meta :event :rf2-wvsxg/absolute-file-sample)
+          f    (:file meta)]
+      (is (string? f) ":file should be present")
+      ;; The host's `re_frame/source_coords_test.clj` lives at
+      ;; `<repo>/implementation/core/test/...`. The exact prefix is
+      ;; environment-dependent — but the path must look absolute to
+      ;; the URI builder so it won't double-prefix it.
+      (let [uri (eu/editor-uri :vscode meta {:project-root "/wrong/project/root"})]
+        (is (.contains ^String uri f)
+            ":file should appear absolute in URI")
+        (is (not (.contains ^String uri "/wrong/project/root"))
+            ":file must be absolute (URI builder doesn't prepend project-root)"))
+      ;; And the path must end in the test file's classpath-relative
+      ;; tail — sanity that classpath resolution found the right
+      ;; resource.
+      (is (.endsWith ^String f "re_frame/source_coords_test.clj")
+          ":file should end with the classpath-relative tail"))))


### PR DESCRIPTION
Closes rf2-wvsxg (P1 BUG).

## Symptom (from the bead)

Clicking Inspect on a panel-gallery variant rendering `edn_inspector` launched
```
vscode://file/C:/Users/miket/code/re-frame2/tools/xray/testbeds/day8/re_frame2_xray/views/edn_inspector.cljs:2732:14
```
but the file actually lives at `tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs` — vscode rejected the URI.

## Candidate identified: A (annotator side)

The bead listed two candidates:
- **A** — annotator emits the wrong relative path (the `:file` slot bakes in a string with the wrong source-root prefix).
- **B** — Story / Xray resolve-uri concatenates the wrong base.

Reverse-engineering the composed URI confirmed Candidate A:
- composed URI = `C:/Users/miket/code/re-frame2/tools/xray/testbeds` + `/day8/re_frame2_xray/views/edn_inspector.cljs`
- the first segment is exactly the testbed-configured `:project-root` (`xray-config/configure!` in `panel-gallery/core.cljs`)
- the second segment is exactly the classpath-relative tail

So the URI builder (`editor-uri/compose-path`) did its job — but the `:file` slot was classpath-relative WITHOUT the source-root segment (`tools/xray/src/`). shadow-cljs lists both `../tools/xray/src` and `../tools/xray/testbeds` as `:source-paths`; the form-meta `:file` that the CLJS analyzer puts on each form is the classpath-relative tail, stripping whichever source-root resolved it. A single host-configured `:project-root` cannot disambiguate which classpath root holds the file.

## Fix

At macro-expansion time on the JVM, resolve the classpath-relative form-meta `:file` to its absolute on-disk path via `Thread.currentThread().getContextClassLoader().getResource(...)`. Bake the absolute path into the emitted coord literal.

Downstream `editor-uri/compose-path` already detects absolute paths (drive-letter, leading `/`, leading `\`, `file:` URL) and passes them through unchanged — so the URI ships the right path regardless of which `:project-root` the host configured.

Adds `absolutise-file` (private, JVM-only):
- URL-decodes the classpath resource URL.
- Strips the Windows leading-slash so `/C:/...` becomes `C:/...` (matching the predicate `compose-path` uses).
- Falls through unchanged on already-absolute paths, unresolvable paths (REPL-eval / synthetic coords / fabricated test paths), and non-`file:` URLs (jar:/zip:/http:).

Hooked into the three macro-emission entry points:
- `coords-form` — `reg-*` call-site stamping.
- `prod-coords-form` — production-elision slim variant.
- `form-coords` — per-machine-element stamping.

All flow through `resolve-file` → `absolutise-file` on JVM; the CLJS branch is a no-op pass-through (reader-conditional inside the let-binding).

## Regression test

`implementation/core/test/re_frame/source_coords_test.clj` adds 5 new test cases:

- `absolutise-file-resolves-classpath-relative-paths` — feeds the host test file's classpath-relative path through `absolutise-file`, verifies the result is detected as absolute (the URI builder doesn't prepend `:project-root`).
- `absolutise-file-passes-through-already-absolute` — Windows drive letter, POSIX absolute, `file:` URL.
- `absolutise-file-passes-through-unresolvable` — `no/such/file/exists.cljs` stays unchanged.
- `absolutise-file-handles-nil-and-blank` — defensive.
- `reg-event-db-emits-absolute-file` — end-to-end: registers an event handler in the test ns, asserts the emitted `:file` is absolute by construction (`editor-uri` returns a URI that contains the file value without the `:project-root` prepended) and ends with the classpath-relative tail (sanity: classpath resolution found the right resource).

## xray-side audit

`tools/xray/src/day8/re_frame2_xray/open_in_editor.cljs` uses the same `resolve-uri` / `compose-path` pipeline as Story (both consume the shared `re-frame.source-coords.editor-uri` ns — single seam by design). The macro-emission fix benefits both surfaces transparently; no separate xray-side patch needed.

Same reasoning extends to every testbed with a `:project-root` knob (`tools/xray/testbeds/{perf_counter,two_frame_isolation,step_deck}`, `tools/story/testbeds/{login_form,counter_with_stories}`) — they all benefit transparently. The `:project-root` config remains useful as a fallback for synthetic coords (REPL-eval, fabricated test fixtures) where classpath resolution returns the input unchanged.

## Predecessor work

- **rf2-ymnfx Issue A** — seeded `:rf.story/project-root` in panel-gallery so the Story chip received SOME root. Closed the "absent root" branch but kept the "wrong root" branch open. This PR closes the remaining branch.
- **rf2-fa4ly** — added JSX source-coord props for React DevTools' "View source" button (rides the same `:file` slot fixed here — benefits transparently).

## Quality gates

- `bash scripts/test-fast-pr.sh` — **PASS** (CLJS node integration: 4806 tests, 15684 assertions, 0/0; core JVM included via the spine)
- `npm run test:bundle-isolation` — **PASS** (17 artefact entries; 35 sentinels absent)
- `npm run test:elision` — **PASS** (production 41/41 absent — `absolutise-file` is `#?(:clj ...)`-gated, doesn't enter CLJS bundles)
- `npm run test:browser` — **PASS** (124 tests, 353 assertions)

## Spec alignment

`spec/Spec-Schemas.md` §`:rf/source-coord-meta` already documents `:file` as "absolute or classpath-relative source file; nil when not captured." This PR makes the CLJS reference emit the absolute shape — within the existing spec contract.