### PR TITLE
feat(xray/resizable-table): localStorage persistence + convert remaining 5 tables (rf2-xzg1y + rf2-jnxfj)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/mount.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/mount.cljs
@@ -58,7 +58,8 @@
             [day8.re-frame2-xray.static.persistence :as static-persistence]
             [day8.re-frame2-xray.self-noise :as self-noise]
             [day8.re-frame2-xray.theme.tokens :as tokens]
-            [day8.re-frame2-xray.trace-collector :as trace-collector]))
+            [day8.re-frame2-xray.trace-collector :as trace-collector]
+            [day8.re-frame2-xray.views.resizable-table :as resizable-table]))
 
 ;; ---- mount state ---------------------------------------------------------
 
@@ -488,6 +489,19 @@
     (filters-persistence/clear!)
     (spine-filters/clear-raw!)
     (frame-switcher/clear!)))
+
+(register-first-mount-hook!
+  ::hydrate-column-widths
+  ;; Hydrate the per-table column-widths slot from localStorage
+  ;; (rf2-xzg1y). Durable preference (NOT a transient filter) — the
+  ;; user's column reading-shape choices persist across reloads. The
+  ;; `resizable-table/hydrate!` fn guards on `(frame/frame :rf/xray)`
+  ;; being registered, so this hook is the canonical landing site
+  ;; (the orchestrator-time call from `registry/register-xray-
+  ;; handlers!` happens BEFORE the frame is mounted and short-
+  ;; circuits cleanly). Re-entrant — same source → same slot.
+  (fn []
+    (resizable-table/hydrate!)))
 
 (register-first-mount-hook!
   ::hydrate-static-mode

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -3046,36 +3046,52 @@
   "Render the DISPOSED sub-section (rf2-wpfjo) — one row per
   `:rf.sub/dispose` trace event. Visually distinct from the
   recompute rows: a red/error glyph conveys eviction; a muted
-  reason chip carries the dispose path."
+  reason chip carries the dispose path.
+
+  rf2-jnxfj — mounts through the shared `rt/resizable-table` so
+  column widths are user-draggable + persist across reloads via
+  the `:rf.xray.epoch/subscriptions-disposed` table-id slot."
   [rows]
-  [:div {:data-testid "rf-xray-epoch-subscriptions-disposed-table"
-         :style disposed-subs-table-style}
-   [:div {:style table-header-row-style}
-    [:div {:style table-glyph-cell-header-style} ""]
-    [:div {:style disposed-th-60-style} "disposed sub"]
-    [:div {:style disposed-th-40-style} "reason"]]
-   (for [[i {:keys [sub-id query reason]}] (map-indexed vector rows)]
-     [:div {:key (str "disposed-" i)
-            :data-testid (str "rf-xray-epoch-sub-disposed-row-" i)
-            :data-sub-reason (when reason (pr-str reason))
-            :style (if (< i (dec (count rows)))
-                     subs-row-style-with-border
-                     subs-row-style)}
-      [:div {:style disposed-glyph-cell-style}
-       ;; Eviction glyph — `✗` red/error tone conveys "removed from
-       ;; the reactive graph" (rf2-wpfjo).
-       "✗"]
-      [:div {:style disposed-id-cell-style}
-       [:span {:data-testid (str "rf-xray-epoch-sub-disposed-row-id-" i)
-               :style disposed-id-span-style}
-        (cond
-          (vector? query) [ei/mini query 40]
-          (some? sub-id)  [ei/mini sub-id 40]
-          :else           [:span {:style disposed-anonymous-style}
-                           "<anonymous sub>"])]]
-      [:div {:data-testid (str "rf-xray-epoch-sub-disposed-row-reason-" i)
-             :style disposed-reason-cell-style}
-       (dispose-reason-label reason)]])])
+  (let [columns [{:id :glyph    :label ""             :default-flex "24px"}
+                 {:id :disposed :label "disposed sub" :default-flex "1.5fr"}
+                 {:id :reason   :label "reason"       :default-flex "1fr"}]]
+    [rt/resizable-table
+     {:table-id        :rf.xray.epoch/subscriptions-disposed
+      :container-attrs {:data-testid "rf-xray-epoch-subscriptions-disposed-table"
+                        :style       disposed-subs-table-style}
+      :header-attrs    {:style table-header-row-style}
+      :columns         columns
+      :rows            rows
+      :row-key         (fn [_ i] (str "disposed-" i))
+      :row-attrs       (fn [{:keys [reason]} i]
+                         {:data-testid     (str "rf-xray-epoch-sub-disposed-row-" i)
+                          :data-sub-reason (when reason (pr-str reason))
+                          :style (if (< i (dec (count rows)))
+                                   subs-row-style-with-border
+                                   subs-row-style)})
+      :row-cells
+      (fn [{:keys [sub-id query reason]} i]
+        [;; glyph cell
+         [:div {:data-rf-xray-resizable-col "glyph"
+                :style disposed-glyph-cell-style}
+          ;; Eviction glyph — `✗` red/error tone conveys "removed from
+          ;; the reactive graph" (rf2-wpfjo).
+          "✗"]
+         ;; disposed-sub cell
+         [:div {:data-rf-xray-resizable-col "disposed"
+                :style disposed-id-cell-style}
+          [:span {:data-testid (str "rf-xray-epoch-sub-disposed-row-id-" i)
+                  :style disposed-id-span-style}
+           (cond
+             (vector? query) [ei/mini query 40]
+             (some? sub-id)  [ei/mini sub-id 40]
+             :else           [:span {:style disposed-anonymous-style}
+                              "<anonymous sub>"])]]
+         ;; reason cell
+         [:div {:data-rf-xray-resizable-col "reason"
+                :data-testid (str "rf-xray-epoch-sub-disposed-row-reason-" i)
+                :style disposed-reason-cell-style}
+          (dispose-reason-label reason)]])}]))
 
 (defn render-subscriptions-step
   "Render the SUBSCRIPTIONS step (present when subs recomputed OR
@@ -3185,57 +3201,66 @@
     - view-id (hyperlinked via the registrar's `:view` meta coord)
     - duration (when stamped, rendered as a muted chip below the id)
     - the subs the view dereffed during this render (one per line —
-      vectors via `pr-str`, scalars via `ns-keyword`)."
+      vectors via `pr-str`, scalars via `ns-keyword`).
+
+  rf2-jnxfj — mounts through the shared `rt/resizable-table` so
+  column widths are user-draggable + persist across reloads via
+  the `:rf.xray.epoch/views` table-id slot."
   [rows]
-  [:div {:data-testid "rf-xray-epoch-views-table"
-         :style views-table-style}
-   [:div {:style table-header-row-style}
-    [:div {:style views-th-50-style} "view"]
-    [:div {:style views-th-50-style} "subs"]]
-   (for [[i {:keys [view-id subs-read duration-ms]}] (map-indexed vector rows)]
-     [:div {:key (str "view-" i)
-            :data-testid (str "rf-xray-epoch-view-row-" i)
-            :data-view-id (when view-id (pr-str view-id))
-            ;; rf2-2f962 — pink-stripe view-name hover affordance. The
-            ;; row-level mouse-enter/leave stamps the
-            ;; `.rf-xray-view-highlight` class onto the live DOM node
-            ;; tagged by Spec 006's `data-rf-view`, mirroring the
-            ;; Reactive panel's view-node treatment (rf2-e33ad /
-            ;; rf2-8l03l). Pure DOM side-effect; no layout perturbation.
-            :on-mouse-enter (fn [_e] (apply-view-highlight! view-id))
-            :on-mouse-leave (fn [_e] (clear-view-highlight! view-id))
-            :style (if (< i (dec (count rows)))
-                     subs-row-style-with-border
-                     subs-row-style)}
-      [:div {:style views-cell-view-style}
-       [:span {:data-testid (str "rf-xray-epoch-view-row-id-" i)
-               :style (if view-id
-                        views-cell-id-clickable-style
-                        views-cell-id-span-style)}
-        (if (some? view-id)
-          (proj/ns-keyword view-id)
-          [:span {:style views-anonymous-style}
-           "<anonymous view>"])
-        (coord-chip/coord-chip (view-coord view-id)
-                               (str "rf-xray-epoch-view-row-coord-" i))]
-       (when (number? duration-ms)
-         [:span {:style views-row-duration-style}
-          (proj/format-duration-ms duration-ms)])]
-      [:div {:data-testid (str "rf-xray-epoch-view-row-subs-" i)
-             :style views-cell-subs-style}
-       ;; rf2-8w8er — each sub-id (keyword or sub-vector) renders
-       ;; through `mini` so the column reads as syntax-highlighted
-       ;; tokens (keywords magenta, vectors with their bracket
-       ;; chrome) rather than plain pr-str / `:foo` text.
-       (cond
-         (and (sequential? subs-read) (seq subs-read))
-         (into [:div {:style views-subs-list-style}]
-               (for [s subs-read]
-                 [:div [ei/mini s 60]]))
-         (some? subs-read)
-         [ei/mini subs-read 60]
-         :else
-         [:span {:style italic-style} "(none)"])]])])
+  (let [columns [{:id :view :label "view" :default-flex "1fr"}
+                 {:id :subs :label "subs" :default-flex "1fr"}]]
+    [rt/resizable-table
+     {:table-id        :rf.xray.epoch/views
+      :container-attrs {:data-testid "rf-xray-epoch-views-table"
+                        :style       views-table-style}
+      :header-attrs    {:style table-header-row-style}
+      :columns         columns
+      :rows            rows
+      :row-key         (fn [_ i] (str "view-" i))
+      :row-attrs       (fn [{:keys [view-id]} i]
+                         {:data-testid (str "rf-xray-epoch-view-row-" i)
+                          :data-view-id (when view-id (pr-str view-id))
+                          ;; rf2-2f962 — pink-stripe view-name hover
+                          ;; affordance. Pure DOM side-effect on the
+                          ;; row wrapper; no layout perturbation.
+                          :on-mouse-enter (fn [_e] (apply-view-highlight! view-id))
+                          :on-mouse-leave (fn [_e] (clear-view-highlight! view-id))
+                          :style (if (< i (dec (count rows)))
+                                   subs-row-style-with-border
+                                   subs-row-style)})
+      :row-cells
+      (fn [{:keys [view-id subs-read duration-ms]} i]
+        [;; view cell
+         [:div {:data-rf-xray-resizable-col "view"
+                :style views-cell-view-style}
+          [:span {:data-testid (str "rf-xray-epoch-view-row-id-" i)
+                  :style (if view-id
+                           views-cell-id-clickable-style
+                           views-cell-id-span-style)}
+           (if (some? view-id)
+             (proj/ns-keyword view-id)
+             [:span {:style views-anonymous-style}
+              "<anonymous view>"])
+           (coord-chip/coord-chip (view-coord view-id)
+                                  (str "rf-xray-epoch-view-row-coord-" i))]
+          (when (number? duration-ms)
+            [:span {:style views-row-duration-style}
+             (proj/format-duration-ms duration-ms)])]
+         ;; subs cell
+         [:div {:data-rf-xray-resizable-col "subs"
+                :data-testid (str "rf-xray-epoch-view-row-subs-" i)
+                :style views-cell-subs-style}
+          ;; rf2-8w8er — each sub-id renders through `mini` so the
+          ;; column reads as syntax-highlighted tokens.
+          (cond
+            (and (sequential? subs-read) (seq subs-read))
+            (into [:div {:style views-subs-list-style}]
+                  (for [s subs-read]
+                    [:div [ei/mini s 60]]))
+            (some? subs-read)
+            [ei/mini subs-read 60]
+            :else
+            [:span {:style italic-style} "(none)"])]])}]))
 
 (defn- unmounted-views-table
   "Render the UNMOUNTED VIEWS sub-section (rf2-gmw1i) — one row per
@@ -3243,33 +3268,47 @@
   re-render rows: a red/error glyph conveys the teardown semantic.
   Click-to-source uses the same `(rf/handler-meta :view view-id)`
   resolver the re-render rows use, so the operator can jump to the
-  view's definition even when the instance is gone."
+  view's definition even when the instance is gone.
+
+  rf2-jnxfj — mounts through the shared `rt/resizable-table` so
+  column widths are user-draggable + persist across reloads via
+  the `:rf.xray.epoch/views-unmounted` table-id slot."
   [rows]
-  [:div {:data-testid "rf-xray-epoch-views-unmounted-table"
-         :style unmounted-views-table-style}
-   [:div {:style table-header-row-style}
-    [:div {:style table-glyph-cell-header-style} ""]
-    [:div {:style unmounted-th-auto-style} "unmounted view"]]
-   (for [[i {:keys [view-id]}] (map-indexed vector rows)]
-     [:div {:key (str "unmounted-" i)
-            :data-testid (str "rf-xray-epoch-view-unmounted-row-" i)
-            :data-view-id (when view-id (pr-str view-id))
-            :style (if (< i (dec (count rows)))
-                     subs-row-style-with-border
-                     subs-row-style)}
-      [:div {:style unmounted-glyph-cell-style}
-       ;; Teardown glyph — `✗` red/error tone conveys the view came
-       ;; off the reactive graph (rf2-gmw1i).
-       "✗"]
-      [:div {:style unmounted-id-cell-style}
-       [:span {:data-testid (str "rf-xray-epoch-view-unmounted-row-id-" i)
-               :style unmounted-id-span-style}
-        (if (some? view-id)
-          (proj/ns-keyword view-id)
-          [:span {:style disposed-anonymous-style}
-           "<anonymous view>"])
-        (coord-chip/coord-chip (view-coord view-id)
-                               (str "rf-xray-epoch-view-unmounted-row-coord-" i))]]])])
+  (let [columns [{:id :glyph     :label ""               :default-flex "24px"}
+                 {:id :unmounted :label "unmounted view" :default-flex "1fr"}]]
+    [rt/resizable-table
+     {:table-id        :rf.xray.epoch/views-unmounted
+      :container-attrs {:data-testid "rf-xray-epoch-views-unmounted-table"
+                        :style       unmounted-views-table-style}
+      :header-attrs    {:style table-header-row-style}
+      :columns         columns
+      :rows            rows
+      :row-key         (fn [_ i] (str "unmounted-" i))
+      :row-attrs       (fn [{:keys [view-id]} i]
+                         {:data-testid  (str "rf-xray-epoch-view-unmounted-row-" i)
+                          :data-view-id (when view-id (pr-str view-id))
+                          :style (if (< i (dec (count rows)))
+                                   subs-row-style-with-border
+                                   subs-row-style)})
+      :row-cells
+      (fn [{:keys [view-id]} i]
+        [;; glyph cell
+         [:div {:data-rf-xray-resizable-col "glyph"
+                :style unmounted-glyph-cell-style}
+          ;; Teardown glyph — `✗` red/error tone conveys the view
+          ;; came off the reactive graph (rf2-gmw1i).
+          "✗"]
+         ;; unmounted-view cell
+         [:div {:data-rf-xray-resizable-col "unmounted"
+                :style unmounted-id-cell-style}
+          [:span {:data-testid (str "rf-xray-epoch-view-unmounted-row-id-" i)
+                  :style unmounted-id-span-style}
+           (if (some? view-id)
+             (proj/ns-keyword view-id)
+             [:span {:style disposed-anonymous-style}
+              "<anonymous view>"])
+           (coord-chip/coord-chip (view-coord view-id)
+                                  (str "rf-xray-epoch-view-unmounted-row-coord-" i))]]])}]))
 
 (defn render-views-step
   "Render the VIEWS step (present when views re-rendered OR when

--- a/tools/xray/src/day8/re_frame2_xray/panels/issues_ribbon.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/issues_ribbon.cljs
@@ -68,99 +68,92 @@
   empty-state classification — lives in `issues_ribbon_helpers.cljc`
   so the algebra runs under the JVM unit-test target."
   (:require [re-frame.core :as rf]
+            [day8.re-frame2-xray.panels.common-helpers :as common]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
             [day8.re-frame2-xray.panels.issues-ribbon-helpers :as h]
             [day8.re-frame2-xray.panels.overflow-indicator :as overflow]
             [day8.re-frame2-xray.theme.tokens
-             :refer [tokens mono-stack sans-stack]]))
+             :refer [tokens mono-stack sans-stack]]
+            [day8.re-frame2-xray.views.resizable-table :as rt]))
 
 ;; ---- per-row -------------------------------------------------------------
 
-(defn- issue-row
-  "One row in the issues feed, reconciled to the Figma design
-  (`design-reference/xray_devtools_reference.cljs`, the `issues-panel`
-  component + spec/021 §8.2):
+(def ^:private issue-columns
+  "Resizable column defs for the Issues feed (rf2-jnxfj).
 
-      ▌ SEVERITY  category   short description       timestamp  ↗
+  Defaults mirror the pre-conversion fixed/fr template — severity (78px),
+  category (144px), description (1fr), time (auto-ish — fixed 100px since
+  resizable-table needs each track resolvable), source-icon (18px). Once
+  the user drags a column the override (px) wins."
+  [{:id :severity    :label "severity"    :default-flex "78px"}
+   {:id :category    :label "category"    :default-flex "144px"}
+   {:id :description :label "description" :default-flex "minmax(0, 1fr)"}
+   {:id :time        :label "time"        :default-flex "100px"}
+   {:id :source      :label ""            :default-flex "18px"}])
 
-  The leading `▌` is a 3px severity-coloured LEFT-BORDER; the SEVERITY
-  cell is an uppercase TEXT badge in its severity colour; the category
-  is muted; the description fills; the timestamp is mono + RIGHT-aligned;
-  and `↗` is the open-in-editor source affordance.
+(def ^:private issues-header-cell-style
+  {:padding       "6px 12px"
+   :color         (:text-tertiary tokens)
+   :font-family   sans-stack
+   :font-size     "10px"
+   :font-weight   600
+   :letter-spacing "0.4px"
+   :text-transform "uppercase"})
 
-  Click the row → pivot to the Event panel. Click `↗` → open in editor.
-  Within a focused-epoch lens the parent cascade is the focused epoch
-  itself, so the row pivot lands on the panel that already drives the
-  focus — the click is a convenience surface, not a cascade switch.
-  Source-coord click stops propagation so the source affordance stays
-  distinct from the row pivot."
-  [{:keys [id time severity category description source-coord]
-    :as _issue}]
+(defn- issue-row-cells
+  "Pure cell renderer — returns the 5 hiccup nodes for the resizable-
+  table grid (one per column). Mirrors the pre-conversion content
+  verbatim; the wrapper `:li`'s click handler + border-styles now
+  live on the resizable-table's `:row-attrs`."
+  [{:keys [id time severity category description source-coord] :as _issue}]
   (let [row-test-id (str "rf-xray-issues-row-" id)
         colour      (h/severity-colour severity)]
-    [:li {:key         id
-          :data-testid row-test-id
-          :on-click    (fn []
-                         ;; Flip the visible tab to Event so the row
-                         ;; pivot lands in the event lens.
-                         (rf/dispatch [:rf.xray/select-tab :event] {:frame :rf/xray}))
-          ;; rf2-tha26 — the category column is a FIXED width (≈ Figma
-          ;; `w-36`) so the description column is the SOLE flexible track
-          ;; (`1fr` = the reference's `flex-1`). The prior `0.6fr`
-          ;; category shared the flexible width with the description, so
-          ;; a long category starved the description into a `:r…`
-          ;; ellipsis even when the row had room — the description now
-          ;; fills all the space the fixed columns leave.
-          :style       {:display       "grid"
-                        :grid-template-columns "78px 144px minmax(0, 1fr) auto 18px"
-                        :gap           "16px"
-                        :align-items   "center"
-                        :padding       "8px 12px"
-                        :border        (str "1px solid " (:border-default tokens))
-                        :border-left   (str "3px solid " colour)
-                        :border-radius "4px"
-                        :margin-bottom "8px"
-                        :cursor        "pointer"
-                        :color         (:text-primary tokens)
-                        :font-family   sans-stack
-                        :font-size     "12px"
-                        :line-height   1.35}}
-     ;; Severity TEXT badge (uppercase, in its severity colour)
-     [:span {:data-testid (str row-test-id "-severity")
+    [;; Severity TEXT badge (uppercase, in its severity colour)
+     [:span {:data-rf-xray-resizable-col "severity"
+             :data-testid (str row-test-id "-severity")
              :title       (name severity)
              :style       {:color          colour
                            :font-weight    600
                            :font-size      "10px"
                            :letter-spacing "0.4px"
-                           :white-space    "nowrap"}}
+                           :white-space    "nowrap"
+                           :padding        "8px 0 8px 12px"}}
       (h/severity-badge-label severity)]
      ;; Category (muted)
-     [:span {:data-testid (str row-test-id "-category")
+     [:span {:data-rf-xray-resizable-col "category"
+             :data-testid (str row-test-id "-category")
              :style       {:color         (:text-tertiary tokens)
                            :overflow      "hidden"
                            :text-overflow "ellipsis"
-                           :white-space   "nowrap"}
+                           :white-space   "nowrap"
+                           :padding       "8px 0"}
              :title       (str category)}
       (or category "—")]
      ;; Description (primary)
-     [:span {:data-testid (str row-test-id "-description")
+     [:span {:data-rf-xray-resizable-col "description"
+             :data-testid (str row-test-id "-description")
              :style       {:color         (:text-primary tokens)
                            :overflow      "hidden"
                            :text-overflow "ellipsis"
-                           :white-space   "nowrap"}
+                           :white-space   "nowrap"
+                           :padding       "8px 0"
+                           :min-width     0}
              :title       description}
       description]
      ;; Timestamp (mono, muted, RIGHT-aligned)
-     [:span {:data-testid (str row-test-id "-time")
+     [:span {:data-rf-xray-resizable-col "time"
+             :data-testid (str row-test-id "-time")
              :style {:color       (:text-tertiary tokens)
                      :font-family mono-stack
                      :font-size   "11px"
                      :text-align  "right"
-                     :white-space "nowrap"}}
+                     :white-space "nowrap"
+                     :padding     "8px 0"}}
       (or (h/format-time time) "—")]
      ;; Source-coord affordance (`↗`, when present)
      (if source-coord
-       [:button {:data-testid (str row-test-id "-source")
+       [:button {:data-rf-xray-resizable-col "source"
+                 :data-testid (str row-test-id "-source")
                  :title       source-coord
                  :on-click    (fn [e]
                                 ;; Stop propagation so the row's pivot
@@ -173,14 +166,16 @@
                  :style       {:background  "transparent"
                                :color       (:accent tokens)
                                :border      "none"
-                               :padding     0
+                               :padding     "8px 12px 8px 0"
                                :cursor      "pointer"
                                :font-size   "13px"
                                :line-height 1}}
         "↗"]
-       [:span {:style {:color (:text-tertiary tokens)
+       [:span {:data-rf-xray-resizable-col "source"
+               :style {:color (:text-tertiary tokens)
                        :font-size "13px"
-                       :text-align "center"}}
+                       :text-align "center"
+                       :padding "8px 12px 8px 0"}}
         "·"])]))
 
 ;; ---- footer hint --------------------------------------------------------
@@ -276,7 +271,14 @@
   global firehose / aggregate view, and no `:ungrouped` escape-hatch
   lane (those navigation needs live on the L2 timeline's per-row
   badges per §1.2). No filter chrome (rf2-ad7zx.9) — pure rows per
-  the Figma design."
+  the Figma design.
+
+  rf2-jnxfj — the issue feed now mounts through the shared
+  `rt/resizable-table` view so each row's 5 columns share one drag-
+  resize affordance and the widths persist across reloads via the
+  `:rf.xray.issues/feed` table-id slot. The pre-conversion `:ul`/
+  `:li` shape is gone; the 200-row cap + overflow indicator are
+  applied to the rows fed to the resizable-table."
   []
   (let [{:keys [issues epoch-id empty-kind] :as _data}
         @(rf/subscribe [:rf.xray/issues-ribbon])]
@@ -293,16 +295,51 @@
         :no-focus      (empty-state-no-focus)
         :epoch-evicted (empty-state-epoch-evicted epoch-id)
         :no-issues     (empty-state-no-issues)
-        nil            [:<>
-                        (overflow/capped-list
-                          issues
-                          {:panel-id "issues"
-                           :ul-attrs {:data-testid "rf-xray-issues-feed"
-                                      :style       {:list-style "none"
-                                                    :margin     0
-                                                    :padding    0}}
-                           :row-fn   issue-row})
-                        (footer-hint)])]]))
+        nil            (let [[capped over-cap? hidden] (common/cap-rows issues)]
+                         [:<>
+                          [rt/resizable-table
+                           {:table-id        :rf.xray.issues/feed
+                            :container-attrs {:data-testid "rf-xray-issues-feed"
+                                              :style       {:margin 0
+                                                            :padding 0}}
+                            :header-attrs    {:style {:background    (:bg-3 tokens)
+                                                      :border        (str "1px solid "
+                                                                          (:border-default tokens))
+                                                      :border-radius "4px"
+                                                      :margin-bottom "8px"}}
+                            :header-cell-style issues-header-cell-style
+                            :columns         issue-columns
+                            :rows            capped
+                            :row-key         (fn [{:keys [id]} _i] (str "issues-row-" id))
+                            :row-attrs       (fn [{:keys [id severity]} _i]
+                                               {:data-testid (str "rf-xray-issues-row-" id)
+                                                :on-click    (fn []
+                                                               (rf/dispatch [:rf.xray/select-tab :event]
+                                                                            {:frame :rf/xray}))
+                                                :style       {:border        (str "1px solid "
+                                                                                   (:border-default tokens))
+                                                              :border-left   (str "3px solid "
+                                                                                   (h/severity-colour severity))
+                                                              :border-radius "4px"
+                                                              :margin-bottom "8px"
+                                                              :cursor        "pointer"
+                                                              :color         (:text-primary tokens)
+                                                              :font-family   sans-stack
+                                                              :font-size     "12px"
+                                                              :line-height   1.35}})
+                            :row-cells       issue-row-cells}]
+                          (when over-cap?
+                            ;; overflow-row returns an `:li` (designed
+                            ;; for the legacy `:ul`-wrapped path); wrap
+                            ;; in a minimal `:ul` so the document tree
+                            ;; stays well-formed.
+                            [:ul {:style {:list-style "none"
+                                          :margin     0
+                                          :padding    0}}
+                             (overflow/overflow-row {:panel-id     "issues"
+                                                     :over-cap?    over-cap?
+                                                     :hidden-count hidden})])
+                          (footer-hint)]))]]))
 
 ;; ---- registration entry --------------------------------------------------
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/trace.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/trace.cljs
@@ -90,7 +90,8 @@
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens mono-stack sans-stack]]
             [day8.re-frame2-xray.views.edn-inspector :as ei]
-            [day8.re-frame2-xray.views.edn-widget.widget :as edn]))
+            [day8.re-frame2-xray.views.edn-widget.widget :as edn]
+            [day8.re-frame2-xray.views.resizable-table :as rt]))
 
 ;; ---- row grid template (spec/023 §3 · §14) -----------------------------
 ;;
@@ -102,6 +103,49 @@
 (def ^:private row-grid-columns
   "The 5-column grid template for an op row (spec/023 §3)."
   "56px 64px 92px minmax(0, 1fr) auto")
+
+;; ---- resizable-table columns (rf2-jnxfj) --------------------------------
+;;
+;; The op-row's 5-column grid is now driven by the shared
+;; `rt/resizable-table` view. One `:table-id :rf.xray.trace/ops` is
+;; shared between the single header bar at the top of the panel and
+;; every phase band's rows, so a drag in the header live-resizes every
+;; row in the arc. Column widths persist via the rf2-xzg1y
+;; localStorage round-trip.
+;;
+;; Defaults mirror the pre-conversion `row-grid-columns` template so
+;; the first paint reads identically. The `minmax(0, 1fr)` on the
+;; target column survives the resolver because `build-template` passes
+;; the `:default-flex` string through verbatim when no px override is
+;; in the slot.
+
+(def ^:private trace-op-columns
+  [{:id :time     :label "Δt"       :default-flex "56px"}
+   {:id :badge    :label "area"     :default-flex "64px"}
+   {:id :verb     :label "what"     :default-flex "92px"}
+   {:id :target   :label "target"   :default-flex "minmax(0, 1fr)"}
+   {:id :duration :label "duration" :default-flex "70px"}])
+
+(def trace-ops-table-id
+  "Shared table-id every band reads against so a drag updates one slot
+  that the header + every row reads."
+  :rf.xray.trace/ops)
+
+(def ^:private trace-header-cell-style
+  {:padding        "4px 8px"
+   :color          (:text-tertiary tokens)
+   :font-family    sans-stack
+   :font-size      "10px"
+   :font-weight    600
+   :text-transform "uppercase"
+   :letter-spacing "0.4px"
+   :min-width      0})
+
+(def ^:private trace-header-attrs
+  {:data-testid "rf-xray-trace-ops-header"
+   :style       {:background    (:bg-2 tokens)
+                 :border-bottom (str "1px solid " (:border-subtle tokens))
+                 :margin-bottom "4px"}})
 
 ;; ---- style primitives (rf2-5venq) ---------------------------------------
 ;;
@@ -515,137 +559,160 @@
                        {:key (pr-str path)})))))
 
 ;; ---- one op row (spec/023 §3) -------------------------------------------
+;;
+;; rf2-jnxfj — the op row's 5-column grid is now driven by the shared
+;; `rt/resizable-table` view (one `:table-id :rf.xray.trace/ops` per
+;; arc, shared by header + every band so a drag re-aligns every row).
+;; The pre-conversion `op-row` returned a single `:li` containing the
+;; grid + db-diff + payload; resizable-table now owns the `:div` row
+;; wrapper, and the per-row attrs / cells / extras are produced by the
+;; three helpers below. testids land verbatim on the new structure so
+;; the existing trace_view_cljs_test corpus still resolves them.
 
-(defn- op-row
-  "One op row in the arc — the five columns of spec/023 §3
-  (Δt · area badge · what-happened · target/detail · duration) with the
-  op-family colour as a 3px left-border band and the outcome tier tinting
-  the what-happened column (spec/023 §8).
+(defn- op-row-attrs
+  "Per-row attrs for the resizable-table — preserves the click /
+  context-menu handlers + the op-family colour band + severity /
+  expansion backgrounds.
 
-  The React `:key` is the row's stable trace `:id` (via `h/row-key`) so
-  a trace push doesn't remount the viewport. The row testid keeps the
-  `rf-xray-trace-row-` prefix so the shell's scoped rounded-pill hover
-  rule (theme/global-styles) lights it.
-
-  Row click → toggle inline raw-EDN payload expansion (spec/023 §3); no
-  nav (the panel is already scoped to the focused epoch). Error /
-  warning rows are visually emphasised inline (spec/023 §7) — the Δt
-  leads with `!`, the badge + verb ride the semantic colour, and the row
-  carries a tinted left rail."
-  [{:keys [id operation rel-time time area area-badge verb target
-           duration-ms source-coord dispatch-id db-diff]
-    :as row}
-   {:keys [expanded?]}]
+  Stamps `:key` into the attrs map alongside the meta-key
+  resizable-table emits, so the rf2-l2f2g React-key contract surface
+  (rf-xray-trace-row-N row vectors stably keyed by `(h/row-key row)`)
+  is observable in the rendered hiccup — the test corpus reads
+  `:key` from the row attrs map because the framework hiccup walker
+  rebuilds inner vectors via `mapv` and drops their metadata."
+  [{:keys [id operation area dispatch-id] :as row} expanded?]
   (let [row-test-id (str "rf-xray-trace-row-" id)
         band-colour (h/op-family-colour row)
+        severity?   (#{:error :warning} area)
+        sev-colour  (when severity?
+                      (get tokens (if (= area :error) :red :yellow)))
+        destroy?    (cch/destroy-event? {:operation operation})]
+    {:key                   (h/row-key row)
+     :data-testid           row-test-id
+     :data-rf-xray-expanded (boolean expanded?)
+     :data-rf-xray-area     (some-> area name)
+     :data-rf-xray-op-family (some-> (h/op-family row) name)
+     :data-rf-xray-severity (when severity? (name area))
+     :on-click              (fn []
+                              (rf/dispatch [:rf.xray/toggle-trace-row-expand id]
+                                           {:frame :rf/xray}))
+     :on-context-menu       (when destroy?
+                              (fn [e]
+                                (.preventDefault e)
+                                (.stopPropagation e)
+                                (rf/dispatch
+                                  [:rf.xray/cancellation-cascade-open
+                                   {:kind :dispatch-id :id dispatch-id}]
+                                  {:frame :rf/xray})))
+     ;; op-family colour band — 3px LEFT-BORDER (error / warning
+     ;; override the band so a failure stands out · spec/023 §7).
+     ;; Severity rows carry a faint tinted fill (spec/023 §7);
+     ;; expanded rows show a bg-1 backdrop.
+     :style                 (cond-> (assoc op-row-container-base-style
+                                           :border-left
+                                           (str "3px solid "
+                                                (or sev-colour band-colour)))
+                              expanded?
+                              (assoc :background (:bg-1 tokens))
+                              (and (not expanded?) (= area :error))
+                              (assoc :background op-row-bg-error)
+                              (and (not expanded?) (= area :warning))
+                              (assoc :background op-row-bg-warning))}))
+
+(defn- op-row-cells
+  "Per-row cells — the 5 hiccup nodes resizable-table interleaves into
+  the grid template. Each carries `data-rf-xray-resizable-col` so the
+  pointer-down handler can locate the adjacent cell off the live DOM,
+  AND keeps the original `data-testid` so the trace_view tests resolve
+  unchanged."
+  [{:keys [id operation rel-time time area area-badge verb target
+           duration-ms source-coord dispatch-id]
+    :as row}]
+  (let [row-test-id (str "rf-xray-trace-row-" id)
         verb-colour (h/outcome-colour row)
         severity?   (#{:error :warning} area)
         sev-colour  (when severity?
                       (get tokens (if (= area :error) :red :yellow)))
         destroy?    (cch/destroy-event? {:operation operation})]
-    [:li {:key         (h/row-key row)
-          :data-testid row-test-id
-          :data-rf-xray-expanded (boolean expanded?)
-          :data-rf-xray-area     (some-> area name)
-          :data-rf-xray-op-family (some-> (h/op-family row) name)
-          :data-rf-xray-severity (when severity? (name area))
-          :on-click    (fn []
-                         (rf/dispatch [:rf.xray/toggle-trace-row-expand id]
-                                      {:frame :rf/xray}))
-          :on-context-menu (when destroy?
-                             (fn [e]
-                               (.preventDefault e)
-                               (.stopPropagation e)
-                               (rf/dispatch
-                                 [:rf.xray/cancellation-cascade-open
-                                  {:kind :dispatch-id :id dispatch-id}]
-                                 {:frame :rf/xray})))
-          ;; op-family colour band — 3px LEFT-BORDER (error / warning
-          ;; override the band so a failure stands out · spec/023 §7).
-          ;; Severity rows carry a faint tinted fill (spec/023 §7);
-          ;; expanded rows show a bg-1 backdrop.
-          :style       (cond-> (assoc op-row-container-base-style
-                                      :border-left
-                                      (str "3px solid "
-                                           (or sev-colour band-colour)))
-                         expanded?
-                         (assoc :background (:bg-1 tokens))
-                         (and (not expanded?) (= area :error))
-                         (assoc :background op-row-bg-error)
-                         (and (not expanded?) (= area :warning))
-                         (assoc :background op-row-bg-warning))}
-     [:div {:data-testid (str row-test-id "-summary")
-            :style       op-row-summary-grid-style}
-      ;; ① Δt — ms offset from EPOCH OPEN; `!` lead for severity rows.
-      [:span {:data-testid (str row-test-id "-time")
-              :title       (or (h/format-time time) "")
-              :style       (if severity?
-                             (assoc op-row-time-base-style
-                                    :color sev-colour
-                                    :font-weight 700)
-                             op-row-time-default-style)}
-       (cond
-         (and severity? rel-time) (str "!" (subs rel-time 1))
-         rel-time                 rel-time
-         :else                    "—")]
-      ;; ② area badge — neutral uppercase text badge (spec/023 §3); the
-      ;; severity tiers ride their semantic colour so a failure's family
-      ;; is unmistakeable (spec/023 §7 / §8).
-      [:span {:data-testid (str row-test-id "-badge")
-              :style       (if sev-colour
-                             (assoc op-row-badge-base-style :color sev-colour)
-                             op-row-badge-default-style)}
-       area-badge]
-      ;; ③ what-happened — the per-area verb, tinted by outcome tier.
-      [:span {:data-testid (str row-test-id "-verb")
-              :style       (assoc op-row-verb-base-style
-                                  :color (if severity? sev-colour verb-colour))
-              :title       verb}
-       verb]
-      ;; ④ target / detail — the op's subject; the flexible column that
-      ;; truncates first (spec/023 §14). Source-coord ↗ rides at its end.
-      [:span {:data-testid (str row-test-id "-target")
-              :style       op-row-target-container-style}
-       [:span {:style op-row-target-text-style
-               :title (or target "")}
-        (or target "—")]
-       (when source-coord
-         [:button {:data-testid (str row-test-id "-source-coord")
-                   ;; The bare `file:line` coord rides the button's title
-                   ;; (the ↗ icon is the affordance); the open-in-editor
-                   ;; bridge reads this title verbatim.
-                   :title       source-coord
-                   :on-click    (fn [e]
-                                  (.stopPropagation e)
-                                  (rf/dispatch [:rf.xray/open-in-editor
-                                                {:source-coord source-coord}]
-                                               {:frame :rf/xray}))
-                   :style       op-row-source-coord-button-style}
-          "↗"])
-       (when destroy?
-         [:button {:data-testid (str row-test-id "-cancellation-cascade")
-                   :title       "Show cancellation cascade"
-                   :on-click    (fn [e]
-                                  (.stopPropagation e)
-                                  (rf/dispatch
-                                    [:rf.xray/cancellation-cascade-open
-                                     {:kind :dispatch-id :id dispatch-id}]
-                                    {:frame :rf/xray}))
-                   :style       op-row-cancellation-button-style}
-          "⟲"])]
-      ;; ⑤ duration — `N.N ms` when timed, em-dash otherwise (spec/023 §6).
-      [:span {:data-testid (str row-test-id "-duration")
-              :style       op-row-duration-style}
-       (or (h/format-duration duration-ms) "—")]]
-     ;; Per-path db-changed diff rows (rf2-b3zw2 / rf2-8q8i4 = (b)) —
-     ;; only present on `:rf.event/db-changed` rows; derived panel-side
-     ;; from the focused epoch record's `:db-before` / `:db-after` by
-     ;; `trace_helpers/db-changed-diff-triples`. Empty diffs render no
-     ;; sub-list per spec/023 §APP-DB CHANGES (the empty-diff case).
-     (when (= operation :rf.event/db-changed)
-       (db-diff-rows id db-diff))
-     ;; Row click → raw trace-event EDN inline (spec/023 §3).
-     (when expanded? (render-payload row))]))
+    [;; ① Δt — ms offset from EPOCH OPEN; `!` lead for severity rows.
+     [:span {:data-rf-xray-resizable-col "time"
+             :data-testid (str row-test-id "-time")
+             :title       (or (h/format-time time) "")
+             :style       (if severity?
+                            (assoc op-row-time-base-style
+                                   :color sev-colour
+                                   :font-weight 700)
+                            op-row-time-default-style)}
+      (cond
+        (and severity? rel-time) (str "!" (subs rel-time 1))
+        rel-time                 rel-time
+        :else                    "—")]
+     ;; ② area badge — neutral uppercase text badge (spec/023 §3); the
+     ;; severity tiers ride their semantic colour so a failure's family
+     ;; is unmistakeable (spec/023 §7 / §8).
+     [:span {:data-rf-xray-resizable-col "badge"
+             :data-testid (str row-test-id "-badge")
+             :style       (if sev-colour
+                            (assoc op-row-badge-base-style :color sev-colour)
+                            op-row-badge-default-style)}
+      area-badge]
+     ;; ③ what-happened — the per-area verb, tinted by outcome tier.
+     [:span {:data-rf-xray-resizable-col "verb"
+             :data-testid (str row-test-id "-verb")
+             :style       (assoc op-row-verb-base-style
+                                 :color (if severity? sev-colour verb-colour))
+             :title       verb}
+      verb]
+     ;; ④ target / detail — the op's subject; the flexible column that
+     ;; truncates first (spec/023 §14). Source-coord ↗ rides at its end.
+     [:span {:data-rf-xray-resizable-col "target"
+             :data-testid (str row-test-id "-target")
+             :style       op-row-target-container-style}
+      [:span {:style op-row-target-text-style
+              :title (or target "")}
+       (or target "—")]
+      (when source-coord
+        [:button {:data-testid (str row-test-id "-source-coord")
+                  :title       source-coord
+                  :on-click    (fn [e]
+                                 (.stopPropagation e)
+                                 (rf/dispatch [:rf.xray/open-in-editor
+                                               {:source-coord source-coord}]
+                                              {:frame :rf/xray}))
+                  :style       op-row-source-coord-button-style}
+         "↗"])
+      (when destroy?
+        [:button {:data-testid (str row-test-id "-cancellation-cascade")
+                  :title       "Show cancellation cascade"
+                  :on-click    (fn [e]
+                                 (.stopPropagation e)
+                                 (rf/dispatch
+                                   [:rf.xray/cancellation-cascade-open
+                                    {:kind :dispatch-id :id dispatch-id}]
+                                   {:frame :rf/xray}))
+                  :style       op-row-cancellation-button-style}
+         "⟲"])]
+     ;; ⑤ duration — `N.N ms` when timed, em-dash otherwise (spec/023 §6).
+     [:span {:data-rf-xray-resizable-col "duration"
+             :data-testid (str row-test-id "-duration")
+             :style       op-row-duration-style}
+      (or (h/format-duration duration-ms) "—")]]))
+
+(defn- op-row-extras
+  "Per-row extras rendered BELOW the grid (the resizable-table's
+  `:row-extras` slot — see ns docstring of `views.resizable-table`).
+  Returns the per-path db-diff sub-list (rf2-b3zw2) when the row is a
+  `:rf.event/db-changed` op AND/OR the raw-EDN payload (spec/023 §3)
+  when the row is expanded."
+  [{:keys [id operation db-diff] :as row} expanded?]
+  (let [diff?    (= operation :rf.event/db-changed)
+        diff-h   (when diff? (db-diff-rows id db-diff))
+        payload  (when expanded? (render-payload row))]
+    (cond
+      (and diff-h payload) [:<> diff-h payload]
+      diff-h               diff-h
+      payload              payload
+      :else                nil)))
 
 ;; ---- phase band (spec/023 §2 · §13 · §14) -------------------------------
 
@@ -682,19 +749,35 @@
   `(none)` and no rows (spec/023 §13); collapsed bands render the header
   alone. A thin left rail (mirroring the Handler panel's pipeline rail)
   runs down the band's rows so the phase reads as a distinct segment of
-  the arc (spec/023 §8)."
+  the arc (spec/023 §8).
+
+  rf2-jnxfj — rows mount through `rt/resizable-table` with `:header?
+  false` (the header lives once at the top of the panel) so every band
+  shares the same `:rf.xray.trace/ops` column-widths slot — a drag on
+  the panel header re-aligns every band's rows live."
   [{:keys [id rows empty?] :as band} {:keys [expanded? expanded-row-ids]}]
   [:section {:data-testid (str "rf-xray-trace-band-" (name id))
              :data-rf-xray-band id
              :style phase-band-container-style}
    (band-header band expanded?)
    (when (and expanded? (not empty?))
-     [:ul {:data-testid (str "rf-xray-trace-band-rows-" (name id))
-           :style phase-band-rows-style}
-      (for [row rows]
-        ^{:key (h/row-key row)}
-        (op-row row {:expanded? (contains? (or expanded-row-ids #{})
-                                           (:id row))}))])])
+     [rt/resizable-table
+      {:table-id        trace-ops-table-id
+       :header?         false
+       :columns         trace-op-columns
+       :container-attrs {:data-testid (str "rf-xray-trace-band-rows-" (name id))
+                         :style       phase-band-rows-style}
+       :rows            rows
+       :row-key         (fn [row _i] (h/row-key row))
+       :row-attrs       (fn [row _i]
+                          (op-row-attrs row
+                                        (contains? (or expanded-row-ids #{})
+                                                   (:id row))))
+       :row-cells       (fn [row _i] (op-row-cells row))
+       :row-extras      (fn [row _i]
+                          (op-row-extras row
+                                         (contains? (or expanded-row-ids #{})
+                                                    (:id row))))}])])
 
 ;; ---- epoch envelope (spec/023 §2) ---------------------------------------
 
@@ -728,12 +811,27 @@
                :style (assoc envelope-outcome-base-style :color outcome-hex)}
         (str "outcome " outcome-kw)])
      (when (seq rows)
-       [:ul {:data-testid (str "rf-xray-trace-envelope-rows-" (name kind))
-             :style envelope-rows-list-style}
-        (for [row rows]
-          ^{:key (h/row-key row)}
-          (op-row row {:expanded? (contains? (or expanded-row-ids #{})
-                                             (:id row))}))])]))
+       ;; rf2-jnxfj — envelope rows mount through the shared resizable-
+       ;; table view (same `:rf.xray.trace/ops` table-id every band reads)
+       ;; so a single drag on the panel header re-aligns the OPEN/CLOSE
+       ;; envelope rows alongside every phase band.
+       [rt/resizable-table
+        {:table-id        trace-ops-table-id
+         :header?         false
+         :columns         trace-op-columns
+         :container-attrs {:data-testid (str "rf-xray-trace-envelope-rows-" (name kind))
+                           :style       envelope-rows-list-style}
+         :rows            rows
+         :row-key         (fn [row _i] (h/row-key row))
+         :row-attrs       (fn [row _i]
+                            (op-row-attrs row
+                                          (contains? (or expanded-row-ids #{})
+                                                     (:id row))))
+         :row-cells       (fn [row _i] (op-row-cells row))
+         :row-extras      (fn [row _i]
+                            (op-row-extras row
+                                           (contains? (or expanded-row-ids #{})
+                                                      (:id row))))}])]))
 
 ;; ---- empty states (spec/023 §14) ----------------------------------------
 
@@ -814,12 +912,27 @@
         nil
         ;; The arc container keeps the `rf-xray-trace-feed` testid as the
         ;; external "the arc rendered rows" contract surface. Every arc
-        ;; child carries an explicit React key (envelope-open · the four
-        ;; bands · envelope-close) so the reconciler keys the whole
-        ;; sibling list uniformly.
+        ;; child carries an explicit React key (the column-widths
+        ;; header · envelope-open · the four bands · envelope-close) so
+        ;; the reconciler keys the whole sibling list uniformly.
         (into
           [:div {:data-testid "rf-xray-trace-feed"
                  :style panel-feed-container-style}
+           ;; rf2-jnxfj — column-widths drag-handle bar. One header
+           ;; bar at the top of the arc carries the gutter handles for
+           ;; the shared `:rf.xray.trace/ops` table-id; every band's
+           ;; rows render their own resizable-tables with `:header?
+           ;; false` reading the SAME slot, so a drag here re-aligns
+           ;; every row in the arc.
+           ^{:key "ops-header"}
+           [rt/resizable-table
+            {:table-id        trace-ops-table-id
+             :columns         trace-op-columns
+             :rows            []
+             :row-key         (fn [_ _] "")
+             :row-cells       (fn [_ _] [])
+             :header-attrs    trace-header-attrs
+             :header-cell-style trace-header-cell-style}]
            ;; ○ EPOCH OPEN — the arc's opening bracket (spec/023 §2).
            ^{:key "envelope-open"}
            (envelope-row {:kind            :open

--- a/tools/xray/src/day8/re_frame2_xray/registry.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/registry.cljs
@@ -751,8 +751,17 @@
     (edn-inspector-popup/install!)
     ;; rf2-uji72 — shared draggable column-resize state for Xray
     ;; tables. Registers :rf.xray.column-widths/{for-table,resize-pair,
-    ;; reset}. Day-1 widths are in-memory; persistence is a follow-up.
+    ;; reset,hydrate} + the :rf.xray.column-widths/persist fx.
+    ;;
+    ;; rf2-xzg1y — column-widths now persist to localStorage under
+    ;; `re-frame2.xray.column-widths.v1`. `install!` wires the fx +
+    ;; events; `hydrate!` runs here (preload-time, before the frame is
+    ;; registered, so it's a guarded no-op) AND from `mount.cljs`'s
+    ;; `::hydrate-column-widths` first-mount hook (after the frame is
+    ;; registered, where the dispatch actually lands). Mirrors the
+    ;; static-mode hydrate pattern.
     (resizable-table/install!)
+    (resizable-table/hydrate!)
     ;; Filters install AFTER `:rf.xray/active-filters` + the
     ;; add-filter / remove-filter events above are registered (the
     ;; filters facade adds `:rf.xray/filtered-cascades` + the edit-

--- a/tools/xray/src/day8/re_frame2_xray/theme/global_styles.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/theme/global_styles.cljs
@@ -796,16 +796,17 @@
     ;; `hover:bg-[var(--devtools-hover)]` fill (no flat hairline
     ;; dividers). Inline styles can't carry a `:hover` pseudo-class
     ;; (mirrors the L3 tab-bar + EDN-copy hover handling above), so the
-    ;; hover fill is a scoped CSS rule keyed off the row `<li>`'s testid.
-    ;; The `li` qualifier scopes the rule to the ROW pills only — the
-    ;; per-row inner cells share the `rf-xray-trace-row-` testid prefix
-    ;; (e.g. `…-summary`, `…-time`) so an unqualified prefix selector
-    ;; would tint them too. The reactive-aftermath collapse GROUP
-    ;; (`rf-xray-trace-group-`) is a trace row too, so it lights the
-    ;; same way. The op-family 3px left-border + the rounded corners are
-    ;; the per-row inline styles; this rule only adds the hover fill.
-    "li[data-testid^=\"rf-xray-trace-row-\"]:hover,\n"
-    "li[data-testid^=\"rf-xray-trace-group-\"]:hover {\n"
+    ;; hover fill is a scoped CSS rule keyed off the row's testid +
+    ;; the `data-rf-xray-area` attribute the row stamps (rf2-jnxfj —
+    ;; rows are now `div`s wrapped by `rt/resizable-table` so the
+    ;; pre-conversion `li` qualifier no longer scopes; the `area`
+    ;; attribute is present only on row containers, not on inner
+    ;; cells / wrappers, so it scopes the rule equivalently to the
+    ;; pre-conversion `li` qualifier). The op-family 3px left-border +
+    ;; the rounded corners are the per-row inline styles; this rule
+    ;; only adds the hover fill.
+    "[data-testid^=\"rf-xray-trace-row-\"][data-rf-xray-area]:hover,\n"
+    "[data-testid^=\"rf-xray-trace-group-\"]:hover {\n"
     "  background-color: " (:hover tokens/tokens) ";\n"
     "}\n"
     ;; rf2-cplj8 / rf2-xawwb — borderless chrome icon-buttons hover. The

--- a/tools/xray/src/day8/re_frame2_xray/views/resizable_table.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/resizable_table.cljs
@@ -9,12 +9,12 @@
   before any override exists), pointer-move computes a delta,
   pointer-up releases the listeners.
 
-  Day-1 widths are in-memory only — localStorage persistence is a
-  follow-up bead. The view is mode-agnostic: consumers pass column
-  defs, a row-key fn, a row-attrs fn, and a row-cells fn that
-  returns one hiccup node per column. The wrapper interleaves
-  empty spacer divs into the body-row gutter tracks so columns
-  align with the header.
+  Widths persist to localStorage across sessions (rf2-xzg1y; see the
+  §localStorage persistence section below). The view is mode-
+  agnostic: consumers pass column defs, a row-key fn, a row-attrs fn,
+  and a row-cells fn that returns one hiccup node per column. The
+  wrapper interleaves empty spacer divs into the body-row gutter
+  tracks so columns align with the header.
 
   ## Consumer API
 
@@ -34,13 +34,137 @@
         }]
 
   See `subscriptions-table` in `panels/epoch/view.cljs` for the
-  canonical consumer."
+  canonical consumer.
+
+  ## localStorage persistence (rf2-xzg1y)
+
+  Column-widths are durable per browser profile. The slot
+  `{table-id {col-id px}}` round-trips to localStorage under the key
+  `re-frame2.xray.column-widths.v1` via the
+  `:rf.xray.column-widths/persist` fx (attached to every resize-pair
+  + reset event) and hydrates via `hydrate!` at install-time / from
+  `mount.cljs`'s first-mount hook. Mirrors the durable-pref pattern
+  the Static-mode + Static-Machines selection slots use; differs from
+  the transient filter / mute / frame slots that reset on every page
+  load (rf2-swclw). Column widths are NOT exploration filters — they
+  encode the operator's preferred reading shape for each table, so
+  carrying them across sessions is the desired behaviour."
   (:require [clojure.string :as string]
+            [cljs.reader :as reader]
             [reagent.core :as r]
-            [re-frame.core :as rf]))
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]))
 
 (def ^:private gutter-width-px 4)
 (def ^:private min-col-width-px 24)
+
+;; ---- localStorage round-trip (rf2-xzg1y) --------------------------------
+
+(def default-storage-key
+  "Default localStorage key the column-widths slot persists under.
+  One root key carries the full `{table-id {col-id px}}` map per the
+  bead's scope — no per-frame / per-host partitioning. Hand-edited
+  values that fail to parse are ignored (the load falls back to the
+  registry's empty default)."
+  "re-frame2.xray.column-widths.v1")
+
+(defonce ^:private storage-key (atom default-storage-key))
+
+(defn set-storage-key!
+  "Replace the localStorage key Xray uses for column-widths
+  persistence. `nil` resets to the default. Hosts that mount multiple
+  Xray instances (Story testbeds) can set distinct keys so each
+  instance's widths stay isolated."
+  [k]
+  (reset! storage-key (or k default-storage-key))
+  nil)
+
+(defn get-storage-key
+  "Return the current localStorage key for column-widths persistence."
+  []
+  @storage-key)
+
+(defn- storage-available?
+  "True when `js/window.localStorage` is reachable. JVM / node tests
+  without jsdom land in the no-op branch."
+  []
+  (and (exists? js/window)
+       (some? (.-localStorage js/window))))
+
+(defn- read-raw
+  []
+  (when (storage-available?)
+    (try
+      (.getItem (.-localStorage js/window) (get-storage-key))
+      (catch :default _ nil))))
+
+(defn- write-raw!
+  [s]
+  (when (storage-available?)
+    (try
+      (.setItem (.-localStorage js/window) (get-storage-key) s)
+      (catch :default _ nil)))
+  nil)
+
+(defn clear!
+  "Remove the persisted column-widths slot. Used by tests to reset
+  between scenarios. No-op when localStorage is unavailable."
+  []
+  (when (storage-available?)
+    (try
+      (.removeItem (.-localStorage js/window) (get-storage-key))
+      (catch :default _ nil)))
+  nil)
+
+(defn ->edn
+  "Serialise `widths` (`{table-id {col-id px}}`) into a stable EDN
+  string. The empty map round-trips as `\"{}\"` so the load path can
+  distinguish 'empty slot' from 'no entry'."
+  [widths]
+  (pr-str (or widths {})))
+
+(defn <-edn
+  "Parse a stored EDN string. Returns the parsed `{table-id {col-id
+  px}}` map on success, or `{}` on parse failure / unrecognised shape
+  — the load path never throws into init.
+
+  Every numeric value is coerced through `long` + clamped to
+  `min-col-width-px` so a corrupted entry can't sneak a degenerate
+  width past the resolver."
+  [s]
+  (let [parsed (try (reader/read-string s)
+                    (catch :default _ nil))]
+    (if (map? parsed)
+      (into {}
+            (keep (fn [[table-id col-map]]
+                    (when (and (some? table-id) (map? col-map))
+                      [table-id
+                       (into {}
+                             (keep (fn [[col-id px]]
+                                     (when (and (some? col-id) (number? px))
+                                       [col-id
+                                        (long (max min-col-width-px
+                                                   (long px)))])))
+                             col-map)])))
+            parsed)
+      {})))
+
+(defn load
+  "Read + parse the persisted column-widths map. Returns `{}` when
+  localStorage is unavailable / the slot is empty / the stored EDN
+  is malformed."
+  []
+  (if-let [raw (read-raw)]
+    (<-edn raw)
+    {}))
+
+(defn save!
+  "Write `widths` into localStorage. No-op when localStorage is
+  unavailable. Swallows quota / serialisation errors so a write
+  failure cannot poison the dispatch chain."
+  [widths]
+  (write-raw! (->edn widths))
+  nil)
 
 ;; ---- Grid-template builder ----------------------------------------------
 
@@ -64,26 +188,103 @@
 
 ;; ---- State + events ------------------------------------------------------
 
+(defn- write-pair
+  "Pure reducer — write both adjacent columns' widths into the slot,
+  clamped at the floor. Used by the `resize-pair` event-fx so the
+  reducer and the persist fx land in one place."
+  [db table-id left-id left-px right-id right-px]
+  (-> db
+      (assoc-in [:rf.xray/column-widths table-id left-id]
+                (long (max min-col-width-px left-px)))
+      (assoc-in [:rf.xray/column-widths table-id right-id]
+                (long (max min-col-width-px right-px)))))
+
 (defn install!
-  "Register the `:rf.xray.column-widths/*` events + sub. Called
-  from `registry/register-xray-handlers!`. Re-entrant: re-frame's
-  registrar tolerates same-id re-registration."
+  "Register the `:rf.xray.column-widths/*` events + sub + persistence
+  fx. Called from `registry/register-xray-handlers!`. Re-entrant:
+  re-frame's registrar tolerates same-id re-registration.
+
+  ## Persistence shape (rf2-xzg1y)
+
+  Every mutation (resize-pair + reset) attaches the
+  `:rf.xray.column-widths/persist` fx so the post-mutation slot lands
+  in localStorage in one place — no fx-per-handler duplication. The
+  `hydrate!` fn is called separately (from the orchestrator + from
+  `mount.cljs`'s first-mount hook) so the persisted slot lifts into
+  app-db once `:rf/xray` is registered."
   []
+  ;; ---- fx ---------------------------------------------------------------
+  (rf/reg-fx :rf.xray.column-widths/persist
+    (fn [_ctx widths]
+      (save! widths)))
+
+  ;; ---- subs -------------------------------------------------------------
   (rf/reg-sub :rf.xray.column-widths/for-table
     (fn [db [_ table-id]]
       (get-in db [:rf.xray/column-widths table-id])))
 
-  (rf/reg-event-db :rf.xray.column-widths/resize-pair
-    (fn [db [_ table-id left-id left-px right-id right-px]]
-      (-> db
-          (assoc-in [:rf.xray/column-widths table-id left-id]
-                    (long (max min-col-width-px left-px)))
-          (assoc-in [:rf.xray/column-widths table-id right-id]
-                    (long (max min-col-width-px right-px))))))
+  ;; ---- events -----------------------------------------------------------
+  ;;
+  ;; resize-pair + reset both upgraded to event-fx so the persist fx
+  ;; rides on every mutation. `:rf.trace/no-emit? true` matches the
+  ;; pattern used by `:rf.xray/set-event-list-col-width` (drag emits
+  ;; one event per pixel of motion; trace-buffering them would flood
+  ;; the bus with shape no panel consumes).
 
-  (rf/reg-event-db :rf.xray.column-widths/reset
-    (fn [db [_ table-id]]
-      (update db :rf.xray/column-widths dissoc table-id))))
+  (rf/reg-event-fx :rf.xray.column-widths/resize-pair
+    {:rf.trace/no-emit? true}
+    (fn [{:keys [db]} [_ table-id left-id left-px right-id right-px]]
+      (let [next-db (write-pair db table-id left-id left-px right-id right-px)]
+        {:db next-db
+         :fx [[:rf.xray.column-widths/persist
+               (get next-db :rf.xray/column-widths)]]})))
+
+  (rf/reg-event-fx :rf.xray.column-widths/reset
+    {:rf.trace/no-emit? true}
+    (fn [{:keys [db]} [_ table-id]]
+      (let [next-db (update db :rf.xray/column-widths dissoc table-id)]
+        {:db next-db
+         :fx [[:rf.xray.column-widths/persist
+               (get next-db :rf.xray/column-widths)]]})))
+
+  ;; ---- events: hydrate from localStorage --------------------------------
+  ;;
+  ;; The hydrate event is wholesale-assoc so re-running with the same
+  ;; source produces the same slot. `:rf.trace/no-emit?` mirrors the
+  ;; other hydrate handlers (the hydrate dispatch is a load-time
+  ;; orchestration step, not a user-facing event).
+  (rf/reg-event-db :rf.xray.column-widths/hydrate
+    {:rf.trace/no-emit? true}
+    (fn [db [_ widths]]
+      (assoc db :rf.xray/column-widths (or widths {})))))
+
+;; ---- hydration ----------------------------------------------------------
+
+(defn hydrate!
+  "Lift the persisted column-widths slot into `:rf/xray`'s app-db.
+
+  Mirrors `frame-switcher/hydrate!` / `static-machines/hydrate!`:
+  re-entrant; safe to call from `install!` (preload-time, before the
+  frame is registered) AND from `mount.cljs/ensure-xray-frame!`
+  (first open, frame registered). Both invocations converge on the
+  same slot because:
+
+    - the load read is pure;
+    - the hydrate dispatch is a wholesale `(assoc db
+      :rf.xray/column-widths …)` so re-running with the same source
+      produces the same slot;
+    - the frame guard short-circuits the pre-mount call without
+      losing state — the localStorage value is still readable at
+      the second call.
+
+  Returns nil. No-op when localStorage has no stored map."
+  []
+  (let [loaded (load)]
+    (when (and (seq loaded)
+               (some? (frame/frame :rf/xray)))
+      (rf/with-frame :rf/xray
+        (rf/dispatch-sync [:rf.xray.column-widths/hydrate loaded]))
+      nil)))
 
 ;; ---- Pointer plumbing ----------------------------------------------------
 
@@ -239,42 +440,92 @@
    label])
 
 (defn resizable-table
-  "See the ns docstring for the consumer API."
-  [{:keys [table-id columns rows row-key row-attrs row-cells
-           header-attrs container-attrs header-cell-style]}]
+  "See the ns docstring for the consumer API.
+
+  ## Optional `:row-extras` (rf2-jnxfj)
+
+  Some consumers (the Trace panel's op rows) need to render content
+  BELOW a row's grid cells — sub-lists (the per-path db-diff triple
+  block) and inline expansion payloads. Passing `:row-extras` as a
+  `(fn [row idx] hiccup-or-nil)` switches the row layout to:
+
+      [:div row-attrs                       ;; outer wrapper, NOT grid
+        [:div {:style grid-style} ...cells/gutters...]
+        ...extras...]
+
+  Without `:row-extras` the row keeps the original layout where the
+  consumer's row-attrs `:div` IS the grid (the subscriptions-table
+  shape — no behavioural change for existing callers).
+
+  ## Optional `:header?` (rf2-jnxfj)
+
+  Defaults to `true`. The Trace panel renders a single header
+  resizable-table at the top of the panel (carrying the drag-gutters)
+  and then ONE resizable-table per phase band sharing the same
+  `:table-id` with `:header? false` so all the bands' rows align under
+  the one shared header. The `:header? false` resizable-table simply
+  omits the header row; column widths are still read from the
+  per-table-id slot and applied to body rows."
+  [{:keys [table-id columns rows row-key row-attrs row-cells row-extras
+           header-attrs container-attrs header-cell-style header?]
+    :or   {header? true}}]
   ;; The surrounding `frame-provider` resolves to the OBSERVED frame
   ;; (whichever frame the Xray panel was mounted to inspect) — not
   ;; `:rf/xray`. The column-widths slot lives on `:rf/xray`, so we
   ;; subscribe via `rf/with-frame :rf/xray` to escape the panel's
   ;; React-context frame. Same pattern every other Xray panel uses
   ;; when reading its OWN state vs observed-app state.
-  (let [overrides (rf/with-frame :rf/xray
-                    @(rf/subscribe [:rf.xray.column-widths/for-table table-id]))
-        template  (build-template columns overrides)
+  ;;
+  ;; Defensive: `(rf/subscribe ...)` returns nil when the sub isn't
+  ;; registered (e.g. in pure-render tests that exercise a view
+  ;; directly without running `registry/register-xray-handlers!`). A
+  ;; nil reaction would throw on deref; treat it as "no overrides" so
+  ;; the test render path sees default widths and a downstream
+  ;; install-before-mount in production stays the canonical path.
+  (let [reaction   (rf/with-frame :rf/xray
+                     (rf/subscribe [:rf.xray.column-widths/for-table table-id]))
+        overrides  (some-> reaction deref)
+        template   (build-template columns overrides)
         grid-style {:display "grid"
                     :grid-template-columns template
-                    :align-items "stretch"}]
+                    :align-items "stretch"}
+        header-hiccup
+        (when header?
+          ;; Header — merge the consumer's :style UNDER our grid-style
+          ;; so the grid layout always wins (consumer styles like
+          ;; `table-header-row-style` carry `display: flex` which would
+          ;; silently break the column tracks if it won).
+          (into [:div (-> (or header-attrs {})
+                          (assoc :style (merge (:style header-attrs)
+                                               grid-style)))]
+                (weave-header
+                  (for [col columns]
+                    (header-cell (merge col
+                                        (when header-cell-style
+                                          {:header-cell-style header-cell-style}))))
+                  columns
+                  table-id)))]
     (into [:div (merge {:data-rf-xray-resizable-table (name table-id)}
                        container-attrs)
-           ;; Header — merge the consumer's :style UNDER our grid-style
-           ;; so the grid layout always wins (consumer styles like
-           ;; `table-header-row-style` carry `display: flex` which would
-           ;; silently break the column tracks if it won).
-           (into [:div (-> (or header-attrs {})
-                           (assoc :style (merge (:style header-attrs)
-                                                grid-style)))]
-                 (weave-header
-                   (for [col columns]
-                     (header-cell (merge col
-                                         (when header-cell-style
-                                           {:header-cell-style header-cell-style}))))
-                   columns
-                   table-id))]
+           ;; Header hiccup is nil-tolerated by React/Reagent.
+           header-hiccup]
           ;; Body rows
           (for [[i row] (map-indexed vector rows)
                 :let [attrs (or (when row-attrs (row-attrs row i)) {})
-                      cells (row-cells row i)]]
+                      cells (row-cells row i)
+                      extras (when row-extras (row-extras row i))
+                      woven (into [:<>] (weave-body cells columns))]]
             ^{:key (row-key row i)}
-            [:div (-> attrs
-                      (assoc :style (merge (:style attrs) grid-style)))
-             (into [:<>] (weave-body cells columns))]))))
+            (if (some? extras)
+              ;; Extras path — outer wrapper carries the consumer's
+              ;; attrs untouched (preserves border-bottom, click
+              ;; handlers, etc.); an inner div carries the grid layout
+              ;; for the cells; extras render below the inner grid.
+              [:div attrs
+               [:div {:style grid-style} woven]
+               extras]
+              ;; Default path — the outer wrapper IS the grid (the
+              ;; subscriptions-table shape).
+              [:div (-> attrs
+                        (assoc :style (merge (:style attrs) grid-style)))
+               woven])))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/trace_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/trace_view_cljs_test.cljs
@@ -876,22 +876,27 @@
 
 ;; ---- (8) React-key stability across the feed ---------------------------
 
-(defn- row-li-by-id
-  "Walk the rendered tree and return the `<li>` whose data-testid is
+(defn- row-node-by-id
+  "Walk the rendered tree and return the row container (`:div` since
+  rf2-jnxfj — formerly `:li`) whose data-testid is
   `rf-xray-trace-row-<id>`."
   [tree id]
   (let [testid (str "rf-xray-trace-row-" id)]
     (some (fn [node]
             (when (and (vector? node)
-                       (= :li (first node))
                        (map? (second node))
                        (= testid (:data-testid (second node))))
               node))
           (hiccup-seq tree))))
 
 (deftest trace-row-react-keys-are-stable-trace-ids
-  (testing "the rendered <li> :key is the stable trace id (`t:<id>`),
-            distinct per row and free of any positional component"
+  (testing "rf2-jnxfj — rows now ride `rt/resizable-table` so the row
+            container is a `:div` (formerly `:li`). `op-row-attrs`
+            stamps the `(h/row-key row)` value into the attrs map's
+            `:key` slot so the contract surface stays observable in
+            the rendered hiccup; resizable-table also threads the
+            same value via the meta-key it emits for React's
+            reconciler."
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
       (seed-history!
@@ -904,9 +909,9 @@
                                :time 300 :dispatch-id 1})])])
       (focus! 1)
       (let [tree (trace/Panel)
-            k11  (:key (second (row-li-by-id tree 11)))
-            k22  (:key (second (row-li-by-id tree 22)))
-            k33  (:key (second (row-li-by-id tree 33)))]
+            k11  (:key (second (row-node-by-id tree 11)))
+            k22  (:key (second (row-node-by-id tree 22)))
+            k33  (:key (second (row-node-by-id tree 33)))]
         (is (= "t:11" k11))
         (is (= "t:22" k22))
         (is (= "t:33" k33))

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -429,6 +429,9 @@
    ;; rf2-uji72 — shared draggable column-resize events. `resize-pair`
    ;; updates both adjacent column widths in one writeback so the
    ;; sum is conserved; `reset` clears all overrides for a table.
+   ;; rf2-xzg1y — `hydrate` lifts the persisted column-widths map from
+   ;; localStorage into app-db at first-mount time.
+   :rf.xray.column-widths/hydrate
    :rf.xray.column-widths/resize-pair
    :rf.xray.column-widths/reset
    ;; rf2-59e7k — Cancellation-cascade visualiser events. Per
@@ -724,6 +727,12 @@
    ;; by `:rf.xray/close-shell`. Registered via `mount/install-fx!` from
    ;; the orchestrator; calls `mount/close!`.
    :rf.xray.fx/hide-shell
+   ;; rf2-xzg1y — shared draggable column-widths persistence fx.
+   ;; Attached to every `resize-pair` + `reset` event so the
+   ;; post-mutation `{table-id {col-id px}}` map round-trips to
+   ;; localStorage in one place (mirrors the filter-persistence shape
+   ;; below).
+   :rf.xray.column-widths/persist
    ;; rf2-ak4ms — auto-filter persistence side-effect. Lives under the
    ;; filter-specific prefix because the localStorage write is bound
    ;; to the filter-mutating events (add-filter / remove-filter /

--- a/tools/xray/test/day8/re_frame2_xray/views/resizable_table_persistence_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/resizable_table_persistence_cljs_test.cljs
@@ -1,0 +1,191 @@
+(ns day8.re-frame2-xray.views.resizable-table-persistence-cljs-test
+  "localStorage round-trip tests for the shared resizable-table
+  column-widths persistence layer (rf2-xzg1y).
+
+  Mirrors the shape of `filters/persistence_cljs_test.cljs`:
+
+    1. ->edn / <-edn round-trip preserves the {table-id {col-id px}}
+       shape.
+    2. <-edn on malformed input falls back to {} (load path never
+       throws into init).
+    3. save! → load round-trip via localStorage (when available).
+    4. Empty / cleared slot loads as {}.
+    5. resize-pair event-fx writes the slot AND fires the persist fx
+       (post-dispatch, the localStorage slot reflects the new value).
+    6. reset event-fx clears one table's overrides AND fires persist.
+    7. hydrate! lifts the persisted slot back into :rf/xray's app-db
+       so the for-table sub re-reads the restored value."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.test-support :as xray-test-support]
+            [day8.re-frame2-xray.views.resizable-table :as rt]))
+
+;; ---- fixture ------------------------------------------------------------
+
+(defn- xray-init! []
+  (xray-test-support/reset-all!)
+  (rt/clear!)
+  (rt/set-storage-key! nil))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn xray-init!}))
+
+(defn- xray-setup!
+  "Register Xray handlers + the :rf/xray frame, then re-run the
+  column-widths hydration so any localStorage value lifts into the
+  slot. Mirrors `filters/persistence_cljs_test`'s `xray-setup!`."
+  []
+  (registry/register-xray-handlers!)
+  (frame/reg-frame :rf/xray {})
+  (rt/hydrate!))
+
+(defn- frame-sub [q]
+  (rf/with-frame :rf/xray
+    @(rf/subscribe q)))
+
+(defn- frame-dispatch [ev]
+  (rf/with-frame :rf/xray
+    (rf/dispatch-sync ev)))
+
+;; ---- (1) ->edn / <-edn round-trip ---------------------------------------
+
+(deftest edn-round-trip-preserves-shape
+  (let [widths {:rf.xray.epoch/subscriptions       {:sub 220 :inputs 180 :value 240}
+                :rf.xray.epoch/subscriptions-disposed {:disposed 200}}]
+    (is (= widths (rt/<-edn (rt/->edn widths))))))
+
+(deftest edn-round-trip-handles-empty
+  (is (= {} (rt/<-edn (rt/->edn {}))))
+  (is (= {} (rt/<-edn (rt/->edn nil)))
+      "nil widths round-trips as the empty map"))
+
+(deftest from-edn-malformed-falls-back-to-empty
+  (is (= {} (rt/<-edn "this is not edn")))
+  (is (= {} (rt/<-edn "[1 2 3]"))
+      "non-map parsed value collapses to default")
+  (is (= {} (rt/<-edn ""))
+      "empty string collapses to default"))
+
+(deftest from-edn-clamps-degenerate-widths
+  (testing "rf2-xzg1y — a corrupted entry below the min-col floor
+            (24px) is clamped on read so a stale persisted value
+            can't sneak past the resolver"
+    (let [parsed (rt/<-edn (pr-str {:t1 {:a 5}}))]
+      (is (= {:t1 {:a 24}} parsed)
+          "5px clamps to the 24px floor"))))
+
+(deftest from-edn-drops-non-numeric-widths
+  (testing "rf2-xzg1y — defence-in-depth: a non-number value in the
+            stored map drops out rather than poisoning the slot"
+    (is (= {:t1 {:a 100}}
+           (rt/<-edn (pr-str {:t1 {:a 100 :b "oops"}})))
+        ":b dropped, :a preserved")))
+
+;; ---- (2) save! / load round-trip (depends on localStorage) --------------
+
+(deftest save-and-load-round-trip
+  (when (and (exists? js/window) (.-localStorage js/window))
+    (let [widths {:rf.xray.epoch/subscriptions {:sub 300 :inputs 150 :value 200}}]
+      (rt/save! widths)
+      (is (= widths (rt/load))))))
+
+(deftest load-when-slot-is-empty-returns-empty-map
+  (rt/clear!)
+  (is (= {} (rt/load))))
+
+;; ---- (3) Storage-key override (per-instance isolation) ------------------
+
+(deftest custom-storage-key-isolates-per-instance
+  (when (and (exists? js/window) (.-localStorage js/window))
+    (testing "story testbeds set distinct keys so two Xray instances
+              do not stomp on each other's column-widths state"
+      (rt/set-storage-key! "story.testbed.a.column-widths")
+      (rt/save! {:t1 {:a 100}})
+      (rt/set-storage-key! "story.testbed.b.column-widths")
+      (is (= {} (rt/load))
+          "instance B's slot is independent of instance A")
+      (rt/save! {:t2 {:b 200}})
+      (rt/set-storage-key! "story.testbed.a.column-widths")
+      (is (= {:t1 {:a 100}} (rt/load))
+          "instance A's slot survived instance B's write"))))
+
+;; ---- (4) resize-pair persists via fx ------------------------------------
+
+(deftest resize-pair-writes-slot-and-persists
+  (when (and (exists? js/window) (.-localStorage js/window))
+    (xray-setup!)
+    (frame-dispatch [:rf.xray.column-widths/resize-pair
+                     :rf.xray.epoch/subscriptions
+                     :sub 250 :inputs 170])
+    (testing "app-db slot reflects the resize"
+      (is (= {:sub 250 :inputs 170}
+             (frame-sub [:rf.xray.column-widths/for-table
+                         :rf.xray.epoch/subscriptions]))))
+    (testing "localStorage carries the same payload"
+      (is (= {:rf.xray.epoch/subscriptions {:sub 250 :inputs 170}}
+             (rt/load))))))
+
+(deftest resize-pair-clamps-sub-floor-width
+  (when (and (exists? js/window) (.-localStorage js/window))
+    (xray-setup!)
+    (frame-dispatch [:rf.xray.column-widths/resize-pair
+                     :rf.xray.epoch/subscriptions
+                     :sub 5 :inputs 300])
+    (is (= {:sub 24 :inputs 300}
+           (frame-sub [:rf.xray.column-widths/for-table
+                       :rf.xray.epoch/subscriptions]))
+        "sub clamped to the 24px floor; inputs verbatim")))
+
+;; ---- (5) reset clears one table AND persists ----------------------------
+
+(deftest reset-clears-table-and-persists
+  (when (and (exists? js/window) (.-localStorage js/window))
+    (xray-setup!)
+    (frame-dispatch [:rf.xray.column-widths/resize-pair
+                     :t1 :a 100 :b 200])
+    (frame-dispatch [:rf.xray.column-widths/resize-pair
+                     :t2 :a 50 :b 70])
+    (frame-dispatch [:rf.xray.column-widths/reset :t1])
+    (is (nil? (frame-sub [:rf.xray.column-widths/for-table :t1]))
+        "t1's overrides cleared")
+    (is (= {:a 50 :b 70}
+           (frame-sub [:rf.xray.column-widths/for-table :t2]))
+        "t2's overrides untouched")
+    (is (= {:t2 {:a 50 :b 70}} (rt/load))
+        "localStorage reflects the reset")))
+
+;; ---- (6) hydrate! lifts persisted slot into app-db ----------------------
+
+(deftest hydrate-lifts-persisted-widths
+  (when (and (exists? js/window) (.-localStorage js/window))
+    ;; Seed localStorage BEFORE setup so hydrate sees it.
+    (rt/save! {:rf.xray.epoch/views {:view 180 :subs 220}})
+    (xray-setup!)
+    (is (= {:view 180 :subs 220}
+           (frame-sub [:rf.xray.column-widths/for-table
+                       :rf.xray.epoch/views]))
+        "hydrate! ran in xray-setup! and lifted the slot into app-db")))
+
+(deftest hydrate-is-no-op-when-storage-empty
+  (rt/clear!)
+  (xray-setup!)
+  ;; The for-table sub returns nil for an unwritten table (the
+  ;; default "no override" shape).
+  (is (nil? (frame-sub [:rf.xray.column-widths/for-table
+                        :rf.xray.epoch/subscriptions]))
+      "no localStorage value → no slot in app-db"))
+
+(deftest hydrate-is-no-op-pre-frame-registration
+  (testing "rf2-xzg1y — hydrate! short-circuits when :rf/xray is not
+            yet registered (the preload-time call from registry's
+            install! fan-out lands here and must not throw)"
+    (rt/save! {:t1 {:a 100}})
+    ;; Don't call xray-setup! → :rf/xray is NOT registered.
+    (is (nil? (rt/hydrate!))
+        "hydrate! returns nil rather than dispatching")))

--- a/tools/xray/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/xray/testbeds/feature_matrix/scenarios.cjs
@@ -984,8 +984,13 @@ async function runShellFeatureSweep(page) {
   // dispatches above, LIVE auto-snap focuses the head epoch whose
   // `:trace-events` populate the ribbon. Assert non-empty via the
   // rendered rows (the 'X / Y in view' counts header is gone, rf2-o6yqq).
+  //
+  // rf2-jnxfj — rows are now `:div`s wrapped by the shared
+  // `rt/resizable-table` view (formerly `:li`s in a `:ul`). The
+  // data-testid contract `rf-xray-trace-row-<id>` is unchanged; only
+  // the container tag-name moved.
   await waitForValue(
-    () => page.locator('li[data-testid^="rf-xray-trace-row-"]').count(),
+    () => page.locator('[data-testid^="rf-xray-trace-row-"]').count(),
     (count) => count > 0,
     { timeoutMs: 5000, description: 'epoch-scoped trace feed renders rows' },
   );


### PR DESCRIPTION
Two sequenced commits on a P3 pair extending Xray's shared draggable column-resize affordance (rf2-uji72) so widths now persist across reloads AND every remaining Xray table reads through it.

## Commits

1. `feat(xray/views/resizable-table): localStorage persistence (rf2-xzg1y)`
2. `refactor(xray/panels): convert remaining 5 tables to [resizable-table] (rf2-jnxfj)`

## rf2-xzg1y — localStorage persistence

Column widths are now durable per browser profile. The full `{table-id {col-id px}}` map round-trips to localStorage under `re-frame2.xray.column-widths.v1` via the `:rf.xray.column-widths/persist` fx (attached to every resize-pair + reset event) and hydrates via `hydrate!` from `mount.cljs`'s `::hydrate-column-widths` first-mount hook. Mirrors the durable-pref pattern `static/persistence.cljs` uses for Dynamic/Static mode + Static-Machines selection slots — differs from the TRANSIENT filter / mute / frame slots that reset on every page load per rf2-swclw.

Defensive `<-edn` clamps degenerate widths to the 24px floor and drops non-numeric entries so a corrupted persisted blob cannot smuggle past the resolver.

The same commit also lands two small foundation extensions to `rt/resizable-table` that the rf2-jnxfj conversion needs:

- `:row-extras` — optional fn returning hiccup rendered BELOW the row's grid cells (needed for Trace's per-path db-diff + payload sub-content).
- `:header? false` — omits the header bar, so per-band tables can share one header at the top of the Trace arc.

Plus a defensive nil-tolerant subscribe so pure-render tests that exercise a converted view directly (without running `registry/register-xray-handlers!`) see default widths rather than throwing on `@nil`.

## rf2-jnxfj — 5 tables converted

| Table | Source | table-id | Cols |
|---|---|---|---|
| DISPOSED SUBS | panels/epoch/view.cljs | `:rf.xray.epoch/subscriptions-disposed` | 3 |
| VIEWS | panels/epoch/view.cljs | `:rf.xray.epoch/views` | 2 |
| UNMOUNTED VIEWS | panels/epoch/view.cljs | `:rf.xray.epoch/views-unmounted` | 2 |
| TRACE op rows | panels/trace.cljs | `:rf.xray.trace/ops` (shared across header + every band + envelope) | 5 |
| ISSUES feed | panels/issues_ribbon.cljs | `:rf.xray.issues/feed` | 5 |

The Trace panel renders one header bar at the top of the arc; every phase band + the OPEN/CLOSE envelope render their rows through `rt/resizable-table` with `:header? false` sharing the same `:rf.xray.trace/ops` slot — one drag re-aligns every row in the arc.

The Issues feed previously rendered as `overflow/capped-list` → `[:ul]` of `[:li]` rows. Conversion keeps the 200-row cap + overflow indicator; the row container is now a `:div` and the click handler + 3px severity left-border flow through `:row-attrs`.

Every existing `data-testid` is preserved on the new structure (e.g. `rf-xray-trace-row-<id>`, `-N-time` / `-N-badge` / `-N-verb` / `-N-target` / `-N-duration`, `rf-xray-epoch-sub-disposed-row-N`, `rf-xray-issues-row-N`). Tests resolve them unchanged.

## localStorage persistence test evidence

New `tools/xray/test/day8/re_frame2_xray/views/resizable_table_persistence_cljs_test.cljs` (mirrors `filters/persistence_cljs_test`):

- ->edn / <-edn round-trip preserves shape; malformed input falls back to {} (load path never throws into init).
- Degenerate widths clamp on read; non-numeric values drop.
- save! → load round-trip via localStorage.
- Storage-key override isolates per-instance (Story testbeds).
- resize-pair event-fx writes the slot AND fires the persist fx.
- reset clears one table AND persists (other tables untouched).
- hydrate! lifts the persisted slot into `:rf/xray`'s app-db; no-op when storage is empty / frame not yet registered.

Registry snapshot updated to carry the new `:rf.xray.column-widths/persist` fx + `:rf.xray.column-widths/hydrate` event ids.

## Quality gates

- `bash scripts/test-fast-pr.sh` — PASS (CLJS node integration runs all xray cljs tests; the 19 pre-existing failures on origin/main — settings/popup, epoch/projection violation-block, p3_polish_aria, focus_epoch_id_correlation_e2e — are unchanged by this PR).
- `npm run test:cljs` — same.
- `npm run test:bundle-isolation` — PASS (17 artefact entries; 35 internal sentinels absent; 3 allow-list budgets ok; uix-helix-reagent-free all green).
- `npm run test:xray-feature-gate:smoke` — PASS (3/3 scenarios; the trace feed selector + the row-hover CSS rule were updated to match the new `div` row container).
- `git grep '[:table' tools/xray/src/` — zero raw-`[:table` callers remain.

Per bd: closes rf2-xzg1y + rf2-jnxfj.