### PR TITLE
fix(tools/xray/test): retire hot-reload-step tests — unbreak JVM xray test (rf2-o1l6c)

### DIFF
--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -1495,25 +1495,20 @@
         (is (= "not-an-int"         (:value r)))
         (is (= :logged-and-skipped  (:recovery r)))))))
 
-(deftest hot-reload-step-conditional-test
-  (testing "rf2-xgeag — no hot-reload events → standalone step OMITTED"
-    (is (nil? (proj/hot-reload-step []))))
-
-  (testing "rf2-xgeag — hot-reload-only event surfaces the standalone
-            SCHEMA-HOT-RELOAD step"
-    (let [rows (proj/schema-violation-rows
-                 [(schema-hot-reload-ev :rf/default [:count] "boom")])
-          s    (proj/hot-reload-step rows)]
-      (is (= :schema-hot-reload (:step s)))
-      (is (= :SCHEMA-HOT-RELOAD (:badge s)))
-      (is (= 1 (count (:rows s))))))
-
-  (testing "rf2-xgeag — runtime-boundary violations are NOT routed to
-            the hot-reload step (they attach to their owning step)"
-    (let [rows (proj/schema-violation-rows
-                 [(schema-violation-ev :app-db :counter/inc [:count]
-                                       "not-an-int" true)])]
-      (is (nil? (proj/hot-reload-step rows))))))
+;; `hot-reload-step-conditional-test` retired in rf2-7gf7v
+;; (commit 9b96f9f6a — `refactor(xray/epoch): retire SCHEMA HOT-RELOAD
+;; pipeline step + rollback chip wording`). Hot-reload drift is a
+;; dev-time event, not a cascade event; rendering it as a standalone
+;; pipeline tail step produced an opaque step content lacking the
+;; rich context the operator needs (pre/post schema, file:line of
+;; re-registration). The Issues panel — which already consumes
+;; `:rf.schema/violation` trace events — is its natural home. The
+;; `hot-reload-step` defn and its base-steps call site are gone;
+;; nothing to test at the projection layer. The runtime-boundary
+;; attachment path is covered by `attach-violations-*-test` above
+;; + `project-attaches-app-db-violation-to-handler-test` below; the
+;; negative assertion `not-any? :schema-hot-reload` in that test
+;; pins down that no tail step is appended.
 
 (deftest attach-violations-event-test
   (testing "rf2-xgeag — `:event` violation attaches to the DISPATCH step"
@@ -1745,10 +1740,16 @@
       (is (every? #(nil? (:violations %)) steps))
       (is (every? #(nil? (:rolled-back? %)) steps))))
 
-  (testing "rf2-xgeag — hot-reload drift rides on the standalone
-            SCHEMA-HOT-RELOAD tail step (Option A)"
+  (testing "rf2-7gf7v — hot-reload drift no longer surfaces as a
+            standalone cascade tail step; the Option A SCHEMA-HOT-RELOAD
+            step was retired (hot-reload is a dev-time event, not a
+            cascade event — Issues panel is its home). The trace
+            events still flow through `schema-violation-rows` for
+            consumers like the Issues panel; only the projection
+            pipeline declines to materialise them as a step."
     (let [rec   (record [(dispatched-ev [:counter/inc] :ui nil)
                          (schema-hot-reload-ev :rf/default
                                                [:counter :n] "boom")])
           steps (proj/project rec)]
-      (is (= :schema-hot-reload (-> steps last :step))))))
+      (is (not-any? #(= :schema-hot-reload (:step %)) steps)
+          "no SCHEMA-HOT-RELOAD tail step appended"))))


### PR DESCRIPTION
## Root cause

Commit [`9b96f9f6a`](https://github.com/day8/re-frame2/commit/9b96f9f6a)
(rf2-7gf7v — _"refactor(xray/epoch): retire SCHEMA HOT-RELOAD pipeline
step + rollback chip wording"_) retired the `proj/hot-reload-step`
defn intentionally — hot-reload drift is a dev-time event (re-registered
schema invalidates existing app-db state), not a cascade event. The
Issues panel — which already consumes `:rf.schema/violation` trace
events — is its natural home.

`projection.cljc` had `hot-reload-step` deleted and its base-steps
call site removed, but the corresponding test sites in
`projection_cljs_test.cljc` were not updated. JVM compilation broke
on main:

```
Syntax error compiling at (projection_cljs_test.cljc:1500:15).
No such var: proj/hot-reload-step
```

This blocked the merge queue — PRs #2268 (rf2-xzg1y+jnxfj, resizable-
table) and #2269 (rf2-cmfln, sync dispose) both failed CI.

## Path chosen

**Path C** — structural refactor that removed the feature, so the
test follows.

Two edits in `projection_cljs_test.cljc`:

1. `hot-reload-step-conditional-test` deftest deleted entirely. All
   three sub-testing blocks called `proj/hot-reload-step` which no
   longer exists. Replaced with a comment block recording the retire
   rationale + pointing at the covering tests (`attach-violations-*-test`
   for runtime-boundary attachment + `project-attaches-app-db-violation-
   to-handler-test` for the negative `not-any? :schema-hot-reload`
   assertion).

2. Third sub-testing block of `project-attaches-app-db-violation-to-
   handler-test` (lines 1748-1754) flipped: was asserting hot-reload
   drift PRODUCES a tail step (Option A pre-retire); now asserts
   it DOES NOT (projection pipeline declines to materialise hot-reload
   drift as a step).

The negative assertion at line 1737 (`not-any? :schema-hot-reload`)
was already correct and stays unchanged.

```diff
-(deftest hot-reload-step-conditional-test
-  (testing "rf2-xgeag — no hot-reload events → standalone step OMITTED"
-    (is (nil? (proj/hot-reload-step []))))
-  ...
+;; `hot-reload-step-conditional-test` retired in rf2-7gf7v
+;; (commit 9b96f9f6a). ...
```

## Verification

`cd tools/xray && clojure -M:test`:

```
Ran 944 tests containing 3656 assertions.
4 failures, 0 errors.
```

- **Syntax error gone** (was the merge-queue blocker).
- The 4 remaining failures (`attach-violations-app-db-to-handler-test`,
  `mark-rolled-back-downstream-test`, `project-attaches-app-db-
  violation-to-handler-test`) are caused by **rf2-8resu** (commit
  `35dccd058` — `:where :app-db` violations now attach to the FX
  step's `:db` row, not the HANDLER step). Pre-existing on main.
  Out of scope for this PR.

`npm run test:cljs`:

- 18 failures + 4 errors, all in `day8.re-frame2-xray.*` panels.
  Matches the bead body's expected "19F+6E pre-existing failures".
- Includes one `render-schema-hot-reload-step-test` ERROR in
  `view_cljs_test.cljs` from the same `9b96f9f6a` retire (`view.cljs`
  `render-schema-hot-reload-step` defn deleted too). That file lives
  outside this PR's restricted file surface (bead body limited it
  to `projection.cljc + projection_cljs_test.cljc`). **Follow-up
  filed as rf2-oc6ok.**

Closes rf2-o1l6c.