### PR TITLE
fix(tools/xray/test): align violation-routing tests with rf2-8resu FX :db row, retire hot-reload view test (rf2-rll0x + rf2-oc6ok)

### DIFF
--- a/tools/xray/test/day8/re_frame2_xray/p3_polish_aria_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/p3_polish_aria_cljs_test.cljs
@@ -247,23 +247,28 @@
              (:aria-labelledby attrs))
           "body aria-labelledby resolves back to the active tab"))))
 
-(deftest settings-text-size-label-associates-with-input
-  (testing "rf2-h4mnh — text-size <input :id> matches a <label
-            :html-for> so clicking the label focuses the input."
+(deftest settings-epoch-history-label-associates-with-input
+  (testing "rf2-h4mnh — the epoch-history slider's <input :id> matches a
+            <label :html-for> so clicking the label focuses the input.
+
+            (Originally exercised on the text-size slider; the
+            text-size slider was retired in the 2026-05-27 UX cleanup
+            — epoch-history is the surviving slider in General that
+            carries the documented `:html-for` ↔ `:id` pair.)"
     (xray-setup!)
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/settings-open]))
     (let [tree  (rf/with-frame :rf/xray (settings-view/popup-view))
-          input (find-by-testid tree "rf-xray-settings-text-size-input")
+          input (find-by-testid tree "rf-xray-settings-epoch-history-input")
           ;; The label sits in the same <div> field; find by html-for.
           label (some (fn [node]
                         (when (and (vector? node)
                                    (map? (second node))
-                                   (= "rf-xray-settings-text-size-input"
+                                   (= "rf-xray-settings-epoch-history-input"
                                       (:html-for (second node))))
                           node))
                       (hiccup-seq tree))]
-      (is (= "rf-xray-settings-text-size-input" (:id (props input)))
+      (is (= "rf-xray-settings-epoch-history-input" (:id (props input)))
           "input carries the documented id")
       (is (some? label)
           "a <label html-for=...> matches the input's id"))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -1532,14 +1532,29 @@
       (is (= 1 (count (:violations (nth out 1))))
           "matching cofx step attached"))))
 
-(deftest attach-violations-app-db-to-handler-test
-  (testing "rf2-xgeag — `:app-db` violation attaches to the HANDLER step"
+(deftest attach-violations-app-db-to-fx-db-row-test
+  (testing "rf2-8resu — `:app-db` violation attaches to the FX step's
+            `:db` row (the implicit commit fx). The commit IS an fx —
+            the framework treats `:db` as the first, implicit fx —
+            so the schema violation belongs on the row representing
+            the failed commit, not on HANDLER (which describes what
+            the handler RETURNED). HANDLER + DISPATCH stay clean."
     (let [steps  [{:step :dispatch :badge :DISPATCH}
-                  {:step :handler  :badge :HANDLER}]
+                  {:step :handler  :badge :HANDLER}
+                  {:step :fx       :badge :FX
+                   :rows [{:fx-id :db :status :rollback}]}]
           rows   [{:where :app-db :failing-id :counter/inc :rollback? true}]
-          out    (proj/attach-violations steps rows)]
-      (is (nil? (:violations (first out))))
-      (is (= 1 (count (:violations (second out))))))))
+          out    (proj/attach-violations steps rows)
+          fx     (nth out 2)]
+      (is (nil? (:violations (nth out 0)))
+          "DISPATCH step untouched")
+      (is (nil? (:violations (nth out 1)))
+          "HANDLER step untouched — the violation no longer attaches here")
+      (is (nil? (:violations fx))
+          "FX step-level :violations untouched — the violation routes
+           into the :db row, not the step")
+      (is (= 1 (count (:violations (first (:rows fx)))))
+          "FX :db row carries the attached violation"))))
 
 (deftest attach-violations-fx-row-test
   (testing "rf2-xgeag — `:fx-args` violation attaches to the FX row whose
@@ -1580,17 +1595,27 @@
                   [{:where :app-db :rollback? true}])))))
 
 (deftest mark-rolled-back-downstream-test
-  (testing "rf2-xgeag — rollback flags every step AFTER the HANDLER"
+  (testing "rf2-8resu — rollback flags every step AFTER the FX step
+            (not after HANDLER). The FX step itself is NOT muted —
+            its `:db` row IS the visible rollback indicator (red ✗ +
+            violation sub-block); muting the entire FX step would hide
+            the signal. DISPATCH + HANDLER are upstream of the failed
+            commit so they stay unmuted too — they ran for real."
     (let [steps [{:step :dispatch} {:step :handler}
-                 {:step :fx}       {:step :subscriptions}]
+                 {:step :fx}       {:step :subscriptions}
+                 {:step :views}]
           rows  [{:where :app-db :rollback? true}]
           out   (proj/mark-rolled-back-downstream steps rows)]
-      (is (nil? (:rolled-back? (nth out 0))))
+      (is (nil? (:rolled-back? (nth out 0)))
+          "DISPATCH untouched (upstream of the commit)")
       (is (nil? (:rolled-back? (nth out 1)))
-          "the HANDLER step itself is NOT muted (the violation
-           sub-block already shows the rollback in-place)")
-      (is (true? (:rolled-back? (nth out 2))))
-      (is (true? (:rolled-back? (nth out 3))))))
+          "HANDLER untouched (described what it RETURNED; that ran)")
+      (is (nil? (:rolled-back? (nth out 2)))
+          "FX step itself NOT muted — its :db row is the visible signal")
+      (is (true? (:rolled-back? (nth out 3)))
+          "SUBSCRIPTIONS downstream of FX gets muted")
+      (is (true? (:rolled-back? (nth out 4)))
+          "VIEWS downstream of FX gets muted")))
 
   (testing "rf2-xgeag — no rollback → no `:rolled-back?` flags"
     (let [steps [{:step :dispatch} {:step :handler} {:step :fx}]
@@ -1714,19 +1739,39 @@
 ;; top-level cascade). See comment header above the child-dispatch
 ;; helpers section.
 
-(deftest project-attaches-app-db-violation-to-handler-test
-  (testing "rf2-xgeag — top-level `project` attaches `:app-db`
-            boundary violations to the HANDLER step inline and
-            mutes the downstream cascade with `:rolled-back? true`"
-    (let [rec   (record [(dispatched-ev [:counter/inc] :ui nil)
-                         (db-changed-ev [[[:count] 0 "boom" :modified]])
-                         (schema-violation-ev :app-db :counter/inc
-                                              [:count] "boom" true)])
-          steps (proj/project rec)
-          handler (some #(when (= :handler (:step %)) %) steps)]
+(deftest project-attaches-app-db-violation-to-fx-db-row-test
+  (testing "rf2-8resu — top-level `project` attaches `:app-db`
+            boundary violations to the FX step's `:db` row (the
+            implicit-commit fx). The FX step is synthesised even when
+            no user-fx fired — the `:where :app-db` violation alone
+            is sufficient signal that a `:db` commit was attempted
+            (the framework suppresses user-fx on rollback per Spec
+            010, so the `:rf.fx/handled` trace doesn't emit; the
+            violation IS the signal). The FX step contains exactly
+            one row — the synthesised `:db` row, `:status :rollback`,
+            carrying the violation. HANDLER stays clean — it
+            describes what the handler RETURNED; the commit outcome
+            is the FX step's `:db` row's concern."
+    (let [rec     (record [(dispatched-ev [:counter/inc] :ui nil)
+                           (db-changed-ev [[[:count] 0 "boom" :modified]])
+                           (schema-violation-ev :app-db :counter/inc
+                                                [:count] "boom" true)])
+          steps   (proj/project rec)
+          handler (some #(when (= :handler (:step %)) %) steps)
+          fx      (some #(when (= :fx (:step %)) %) steps)
+          db-row  (some #(when (= :db (:fx-id %)) %) (:rows fx))]
       (is (some? handler))
-      (is (= 1 (count (:violations handler))))
-      (is (true? (-> handler :violations first :rollback?)))
+      (is (nil? (:violations handler))
+          "HANDLER step carries no violations — routing moved to FX :db row")
+      (is (some? fx)
+          "FX step is synthesised when a :where :app-db rollback fires
+           even with no user-emitted fx")
+      (is (some? db-row)
+          "the FX step's first row is the synthesised :db row")
+      (is (= :rollback (:status db-row))
+          "the :db row's status reflects the rollback")
+      (is (= 1 (count (:violations db-row))))
+      (is (true? (-> db-row :violations first :rollback?)))
       (is (not-any? #(= :schema-violations (:step %)) steps)
           "the retired aggregate SCHEMA-VIOLATIONS step never appears")
       (is (not-any? #(= :schema-hot-reload (:step %)) steps)

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -779,24 +779,17 @@
                             "rf-xray-epoch-violation-subscriptions-0-recovery")]
       (is (string/includes? recovery "returned nil")))))
 
-(deftest render-schema-hot-reload-step-test
-  (testing "rf2-xgeag — standalone SCHEMA HOT-RELOAD step renders one
-            sub-block per drift row + the badge label is the renamed
-            'SCHEMA HOT-RELOAD' (not the retired 'SCHEMA VIOLATIONS')"
-    (let [step {:step :schema-hot-reload :badge :SCHEMA-HOT-RELOAD
-                :step-number 8
-                :rows [{:kind :rf.schema/violation
-                        :where :hot-reload
-                        :failing-id :rf/default
-                        :path [:count]
-                        :value "boom"
-                        :recovery :logged-and-skipped}]}
-          tree (view/render-schema-hot-reload-step step)]
-      (is (some? (th/find-by-testid tree "rf-xray-epoch-step-schema-hot-reload")))
-      (is (some? (th/find-by-testid tree "rf-xray-epoch-violation-hot-reload-0"))
-          "the drift row renders as a violation sub-block")
-      (let [header (text-of tree "rf-xray-epoch-schema-hot-reload-header")]
-        (is (string/includes? header "1 hot-reload drift"))))))
+;; `render-schema-hot-reload-step-test` retired here (rf2-oc6ok) — pairs
+;; with the rf2-o1l6c projection-side retire. Commit 9b96f9f6a
+;; (rf2-7gf7v) deleted both the projection's `hot-reload-step` fn AND
+;; the view's `render-schema-hot-reload-step` fn — hot-reload drift is
+;; a dev-time event (re-registered schema invalidates existing app-db
+;; state), not a cascade event. It surfaces exclusively via the Issues
+;; panel which consumes `:rf.schema/violation` trace events. No tail
+;; cascade step → no render fn → no view test. The projection-side
+;; negative assertion (`not-any? :schema-hot-reload`) in
+;; `project-attaches-app-db-violation-to-fx-db-row-test` pins down
+;; that no tail step is appended.
 
 ;; ---- rf2-uffov — FX section header + per-action attribution ----------
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -736,48 +736,75 @@
       (is (string/includes? header "1 unmounted")
           "header reads the unmount-only shape"))))
 
-;; ---- rf2-xgeag — inline violation sub-block + hot-reload tail step ----
+;; ---- rf2-2ek7t (supersedes rf2-xgeag) — violation sub-block redesign ----
+;;
+;; Pre-rf2-2ek7t the block carried discrete `:headline`, `:path`, and
+;; `:value` rows alongside the title bar. rf2-2ek7t retired those —
+;; the per-`:where` prose sentence + humanized `ei/edn-inspector`
+;; explain map subsume them. Tests now anchor on:
+;;
+;;   - title           → "Schema Violation Error" (mixed case)
+;;   - recovery chip   → "Aborted" / "Skipped" / "Returned nil" /
+;;                       "Rejected" (per-`:where` short labels)
+;;   - prose paragraph → `<base>-prose`, contains the per-`:where`
+;;                       canned sentence with an inline "schema check"
+;;                       link
+;;   - explain block   → `<base>-explain` when humanized/raw explain
+;;                       data is present
+;;
+;; See `view.cljs` §SCHEMA VIOLATION sub-block (rf2-xgeag) for the
+;; live renderer.
 
-(deftest violation-block-renders-headline-+-fields-test
-  (testing "rf2-xgeag — `violation-block` renders the pink sub-block
-            with title, recovery chip, headline, path, and value rows"
+(deftest violation-block-renders-title-+-prose-test
+  (testing "rf2-2ek7t — `violation-block` renders the pink sub-block
+            with the mixed-case title, per-:where recovery chip, prose
+            paragraph carrying an inline schema-link, and the
+            humanized explain map"
     (let [row  {:kind :rf.error/schema-validation-failure
                 :where :app-db
                 :failing-id :counter/inc
                 :path [:count]
                 :value "not-an-int"
+                :explain-humanized {:errors ["must be int"]}
                 :rollback? true
                 :sensitive? false}
           tree (view/violation-block :handler 0 row)
           base "rf-xray-epoch-violation-handler-0"]
       (is (some? (th/find-by-testid tree base))
           "the sub-block wrapper renders")
-      (let [title    (text-of tree (str base "-title"))
-            recovery (text-of tree (str base "-recovery"))
-            headline (text-of tree (str base "-headline"))
-            path     (text-of tree (str base "-path"))]
-        (is (string/includes? title "SCHEMA VIOLATION"))
-        (is (string/includes? recovery "rolled back"))
-        (is (string/includes? headline "app-db commit"))
-        (is (string/includes? headline ":counter/inc"))
-        (is (string/includes? path "[:count]"))))))
+      (let [title       (text-of tree (str base "-title"))
+            recovery    (text-of tree (str base "-recovery"))
+            prose       (text-of tree (str base "-prose"))
+            schema-link (text-of tree (str base "-schema-link"))]
+        (is (string/includes? title "Schema Violation Error")
+            "title bar reads the mixed-case 'Schema Violation Error'")
+        (is (string/includes? recovery "Aborted")
+            "rollback? true → recovery chip reads 'Aborted'")
+        (is (string/includes? prose "committed to app-db")
+            "prose sentence explains the :app-db :where outcome")
+        (is (string/includes? schema-link "schema check")
+            "inline 'schema check' link sits inside the prose")
+        (is (some? (th/find-by-testid tree (str base "-explain")))
+            "humanized explain map renders via `edn-inspector`")))))
 
 (deftest violation-block-recovery-chip-test
-  (testing "rf2-xgeag — recovery chip surfaces a per-where label when
+  (testing "rf2-2ek7t — recovery chip surfaces a per-:where label when
             no rollback fired"
     (let [tree (view/violation-block :fx 0
                  {:where :fx-args :failing-id :http/post
                   :rollback? false})
           recovery (text-of tree "rf-xray-epoch-violation-fx-0-recovery")]
-      (is (string/includes? recovery "fx skipped"))))
+      (is (string/includes? recovery "Skipped")
+          ":fx-args + no rollback → 'Skipped'")))
 
-  (testing "rf2-xgeag — sub-return → 'returned nil'"
+  (testing "rf2-2ek7t — sub-return → 'Returned nil'"
     (let [tree (view/violation-block :subscriptions 0
                  {:where :sub-return :failing-id :user/profile
                   :rollback? false})
           recovery (text-of tree
                             "rf-xray-epoch-violation-subscriptions-0-recovery")]
-      (is (string/includes? recovery "returned nil")))))
+      (is (string/includes? recovery "Returned nil")
+          ":sub-return + no rollback → 'Returned nil'"))))
 
 ;; `render-schema-hot-reload-step-test` retired here (rf2-oc6ok) — pairs
 ;; with the rf2-o1l6c projection-side retire. Commit 9b96f9f6a

--- a/tools/xray/test/day8/re_frame2_xray/panels_e2e/focus_epoch_id_correlation_e2e_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels_e2e/focus_epoch_id_correlation_e2e_cljs_test.cljs
@@ -17,11 +17,17 @@
   depth 1000) against `:rf.xray/epoch-history` via
   `epoch-id-for-cascade` → `dispatch-id-of-epoch`. Pre-fix that helper
   walked the record's `:trace-events` for a `:dispatch-id` tag — but
-  `:trace-events-keep` (default 5) ELIDES `:trace-events` from all but
-  the 5 most-recent records, and the post-settle reactive back-fill
-  (rf2-qs6dl / rf2-wi900) pads `:trace-events` with nil-`:dispatch-id`
-  sub-run / render events. So any focused cascade whose epoch was
-  outside the keep-window correlated to nil → empty panels.
+  `:trace-events-keep` ELIDES `:trace-events` from all but the most-
+  recent N records, and the post-settle reactive back-fill (rf2-qs6dl
+  / rf2-wi900) pads `:trace-events` with nil-`:dispatch-id` sub-run /
+  render events. So any focused cascade whose epoch was outside the
+  keep-window correlated to nil → empty panels.
+
+  (Per Mike pair-debug 2026-05-27 the framework default for
+  `:trace-events-keep` was lifted from 5 to 50 — matching `:depth`
+  so trace evicts atomically with its epoch. To bite the elision
+  path under test the elision-sensitive deftests below explicitly
+  shrink `:trace-events-keep` via `rf/configure`.)
 
   ## Fix
 
@@ -124,17 +130,22 @@
 
 (deftest retro-focus-on-trace-elided-epoch-resolves-epoch-id
   (testing "RETRO focus on an OLD cascade whose epoch had `:trace-events`
-  elided by the `:trace-events-keep` window (default 5). Pre-rf2-rly4a
-  the `dispatch-id-of-epoch` `:trace-events` walk returned nil for these
+  elided by the `:trace-events-keep` window. Pre-rf2-rly4a the
+  `dispatch-id-of-epoch` `:trace-events` walk returned nil for these
   records, so `focus.epoch-id` was nil and Views + Trace went empty. The
   first-class `:dispatch-id` slot survives elision — the correlation
-  must resolve."
+  must resolve.
+
+  Framework default for `:trace-events-keep` is now 50 (matches
+  `:depth`); shrink to 3 here so the 10 cascades below produce
+  trace-elided records that exercise the rly4a fix."
     (install-xray!)
     (frame/reg-frame frame-below {})
     (install-counter!)
     (mount-xray-with-target! frame-below)
+    (rf/configure :epoch-history {:trace-events-keep 3})
     ;; Drive 10 cascades so the earliest ones fall well outside the
-    ;; keep-5 window (their `:trace-events` get dissoc'd).
+    ;; keep-3 window (their `:trace-events` get dissoc'd).
     (dotimes [_ 10] (dispatch-host-frame [:counter/inc] frame-below))
     (let [history    (sub-xray [:rf.xray/epoch-history])
           ;; Pick the OLDEST host cascade — its epoch is trace-elided.
@@ -166,11 +177,16 @@
 (deftest dispatch-id-slot-pinned-on-every-retained-epoch
   (testing "Every retained epoch record carries the first-class
   `:dispatch-id` slot independent of `:trace-events` retention — the
-  structural property the correlation now leans on (rf2-rly4a)."
+  structural property the correlation now leans on (rf2-rly4a).
+
+  Framework default for `:trace-events-keep` is now 50 (matches
+  `:depth`); shrink to 3 here so 8 cascades produce a mix of
+  trace-retained and trace-elided records."
     (install-xray!)
     (frame/reg-frame frame-below {})
     (install-counter!)
     (mount-xray-with-target! frame-below)
+    (rf/configure :epoch-history {:trace-events-keep 3})
     (dotimes [_ 8] (dispatch-host-frame [:counter/inc] frame-below))
     (let [history (sub-xray [:rf.xray/epoch-history])
           elided  (filterv #(not (contains? % :trace-events)) history)]

--- a/tools/xray/test/day8/re_frame2_xray/settings/popup_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/settings/popup_cljs_test.cljs
@@ -103,30 +103,34 @@
   (rf/with-frame :rf/xray
     (let [rendered (popup/Modal)]
       (is (find-by-testid rendered "rf-xray-settings-section-general"))
-      (is (find-by-testid rendered "rf-xray-settings-text-size-input"))
       (is (find-by-testid rendered "rf-xray-settings-panel-position-right-rail"))
       (is (find-by-testid rendered "rf-xray-settings-auto-open-on-error"))
-      ;; rf2-pu9sb — Epoch history slider relocated from General to
-      ;; Buffer (the spec-canonical category for buffer-capacity
-      ;; knobs). The slot stays `:general :epoch-history`; only the
-      ;; visual home moved. See `epoch-history-slider-renders-in-buffer`
-      ;; below for the new home.
-      (is (nil? (find-by-testid rendered "rf-xray-settings-epoch-history-input"))
-          "Epoch history slider no longer renders in General (rf2-pu9sb)")
-      (is (nil? (find-by-testid rendered "rf-xray-settings-epoch-history-value"))
-          "Epoch history numeric readout no longer renders in General (rf2-pu9sb)"))))
+      ;; UX cleanup 2026-05-27: the text-size slider was removed —
+      ;; defaults suffice. The `:general :text-size` slot + the
+      ;; `apply-text-size!` effect remain so any host-set default still
+      ;; lands; only the UI surface went away.
+      (is (nil? (find-by-testid rendered "rf-xray-settings-text-size-input"))
+          "Text-size slider removed from the popup (defaults suffice)")
+      ;; rf2-pu9sb originally moved the Epoch history slider from
+      ;; General to Buffer. That move was reverted 2026-05-27 per Mike
+      ;; — the slider is back in General, sitting next to the auto-
+      ;; open-on-error checkbox. The slot stays `:general
+      ;; :epoch-history`; the Buffer section no longer carries the
+      ;; slider.
+      (is (find-by-testid rendered "rf-xray-settings-epoch-history-input")
+          "Epoch history slider renders in General (relocated back from Buffer)")
+      (is (find-by-testid rendered "rf-xray-settings-epoch-history-value")
+          "Epoch history numeric readout renders alongside the slider"))))
 
-;; rf2-pu9sb — Epoch history slider dedupe. Pre-pu9sb the popup
-;; carried two fields for the same conceptual knob: a wired
-;; `:general :epoch-history` slider on General and a dead
-;; `:buffer :retained-epochs` numeric input on Buffer (no substrate
-;; consumer). pu9sb collapsed to one slider in Buffer (the spec-
-;; canonical category per spec/007 §Settings popup row 5) using the
-;; wired `:general :epoch-history` slot.
+;; rf2-pu9sb moved the Epoch history slider from General to Buffer;
+;; that move was reverted 2026-05-27 per Mike. The slot stays
+;; `:general :epoch-history`; only the visual home moved. The
+;; coverage now lives in `general-section-renders` above; the Buffer
+;; section no longer carries the slider.
 
-(deftest epoch-history-slider-renders-in-buffer
-  (testing "rf2-pu9sb — Epoch history slider renders in the Buffer
-            section (not General); slot stays `:general :epoch-history`."
+(deftest epoch-history-slider-absent-from-buffer-section
+  (testing "Epoch history slider does NOT render in the Buffer section
+            after the 2026-05-27 revert; it lives in General."
     (setup!)
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/settings-open])
@@ -134,12 +138,12 @@
     (rf/with-frame :rf/xray
       (let [rendered (popup/Modal)]
         (is (find-by-testid rendered "rf-xray-settings-section-buffer"))
-        (is (find-by-testid rendered "rf-xray-settings-epoch-history-input")
-            "Epoch history slider renders in Buffer")
-        (is (find-by-testid rendered "rf-xray-settings-epoch-history-value")
-            "Epoch history numeric readout renders alongside the slider")
+        (is (nil? (find-by-testid rendered "rf-xray-settings-epoch-history-input"))
+            "Epoch history slider is no longer in Buffer (relocated back to General)")
+        (is (nil? (find-by-testid rendered "rf-xray-settings-epoch-history-value"))
+            "Epoch history numeric readout is no longer in Buffer")
         ;; The dead `:buffer :retained-epochs` numeric input had no
-        ;; substrate consumer and was removed in the same cleanup.
+        ;; substrate consumer and was removed in the rf2-pu9sb cleanup.
         (is (nil? (find-by-testid rendered "rf-xray-settings-buffer-retained-epochs"))
             "Dead `:buffer :retained-epochs` numeric input is gone")))))
 
@@ -254,21 +258,30 @@
             "the :idea radio is the checked option after the override
              writes")))))
 
-(deftest use-system-colors-renders-in-general
-  (testing "rf2-ou3pn — `:use-system-colors?` HCM-override checkbox
-            relocated from the retired Theme tab to General → Power
-            user. The settings slot has always been `:general
-            :use-system-colors?` — only the cosmetic home moved."
+;; rf2-ou3pn moved the `:use-system-colors?` HCM-override checkbox
+;; from the retired Theme tab into General → Power user; the UI
+;; surface was then removed entirely 2026-05-27 (UX cleanup pass).
+;; The settings slot + the `apply-use-system-colors!` effect remain
+;; so a future UI can re-expose if needed; the OS-level
+;; `@media (forced-colors: active)` detection still works
+;; automatically. No deftest covers the checkbox now — the slot's
+;; behaviour is exercised by the substrate-level theme effects
+;; tests; the cosmetic surface is the only thing that went away.
+
+(deftest use-system-colors-checkbox-absent-from-general
+  (testing "2026-05-27 UX cleanup — the `:use-system-colors?` checkbox
+            is no longer surfaced in the popup. The slot + the
+            `apply-use-system-colors!` effect remain; only the UI went."
     (setup!)
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/settings-open])
       (rf/dispatch-sync [:rf.xray/settings-select-tab :general]))
     (rf/with-frame :rf/xray
       (let [rendered (popup/Modal)]
-        (is (find-by-testid rendered "rf-xray-settings-use-system-colors")
-            "Use system colors toggle renders in the General section")
+        (is (nil? (find-by-testid rendered "rf-xray-settings-use-system-colors"))
+            "Use system colors toggle no longer renders")
         (is (nil? (find-by-testid rendered "rf-xray-settings-section-theme"))
-            "Theme section is gone")))))
+            "Theme section is also gone (retired by rf2-ou3pn earlier)")))))
 
 ;; ---- Tab switching ------------------------------------------------------
 


### PR DESCRIPTION
Closes rf2-rll0x. Closes rf2-oc6ok. Closes rf2-9m8mb.

## Context

Three test-drift beads, same surface (xray test corpus), same drift pattern (tests still asserted the old contract after the source-of-truth moved). Bundled because the fixes are interlocking and let main go green in one step.

**rf2-rll0x (P1):** Commits `35dccd058` + `d8f3e9950` (rf2-8resu) moved `:where :app-db` schema-violation routing from the HANDLER pipeline step to the FX step's synthesised `:db` row (the implicit-commit fx). The `:db` commit IS conceptually an fx — the framework treats it as the first, implicit fx; that's the row representing the failed unit. HANDLER describes what the handler RETURNED (its effects map); the commit outcome moves to the FX `:db` row. Four JVM test failures in `projection_cljs_test.cljc` still asserted the old HANDLER-attached behaviour.

**rf2-oc6ok (P2):** Commit `9b96f9f6a` (rf2-7gf7v) retired the SCHEMA HOT-RELOAD cascade tail step + its render fn — hot-reload drift is a dev-time event (re-registered schema invalidates existing app-db state), not a cascade event, and now surfaces via the Issues panel exclusively. The view-side test `render-schema-hot-reload-step-test` still referenced the deleted `view/render-schema-hot-reload-step` fn (`rf2-o1l6c` handled the projection-side analogue; this PR closes out the view-side analogue).

**rf2-9m8mb (P1) — added to this PR:** The remaining CLJS test drifts on main from recent direct-action source changes (rf2-2ek7t violation-block redesign, default lift of `:trace-events-keep` 5 → 50, 2026-05-27 settings popup UX cleanup). Same drift pattern; rolled into this PR so main goes green in one merge.

## Tests in this PR

### projection_cljs_test.cljc (rf2-rll0x)

1. **`attach-violations-app-db-to-handler-test` → restructured + renamed `attach-violations-app-db-to-fx-db-row-test`.** Fixture now includes a FX step with a synthesised `:db` row; assertions check the violation routes onto that row + HANDLER + DISPATCH + FX step-level `:violations` stay clean.

2. **`mark-rolled-back-downstream-test`** restructured. Per rf2-8resu the FX step itself is NOT muted — its `:db` row IS the visible rollback indicator (✗ + violation sub-block); muting the step hides the signal. Fixture uses `[dispatch handler fx subscriptions views]`; only steps AFTER FX get `:rolled-back? true`. DISPATCH + HANDLER + FX stay unmuted.

3. **`project-attaches-app-db-violation-to-handler-test` → restructured + renamed `project-attaches-app-db-violation-to-fx-db-row-test`.** Per the fixup commit `d8f3e9950`: a `:where :app-db` violation alone is sufficient signal that a `:db` commit was attempted, so the FX step synthesises (with the `:db` row at `:status :rollback`) even when no user-fx fired. The test asserts FX synthesised + `:db` row present + `:status :rollback` + violation attached to the `:db` row + HANDLER `:violations` stays nil.

### view_cljs_test.cljs (rf2-oc6ok)

4. **`render-schema-hot-reload-step-test`** deleted entirely (path C — feature gone, test follows). The `view/render-schema-hot-reload-step` fn was retired with the cascade step in `9b96f9f6a`. Replaced with a comment recording the retire rationale + pointing at the negative assertion that pins down no tail step is appended.

### view_cljs_test.cljs — violation-block redesign (rf2-9m8mb / rf2-2ek7t)

5. **`violation-block-renders-headline-+-fields-test` → renamed + restructured `violation-block-renders-title-+-prose-test`.** rf2-2ek7t retired the discrete `:headline` / `:path` / `:value` rows — the per-`:where` prose sentence + humanized `edn-inspector` explain map subsume them. Assertions now: title reads `"Schema Violation Error"` (mixed case, not `SCHEMA VIOLATION`), recovery chip reads `"Aborted"` on rollback, prose paragraph carries the `:app-db` canned sentence with the inline `"schema check"` link, the `<base>-explain` block renders when humanized data is present.

6. **`violation-block-recovery-chip-test`** updated. Chip labels follow the new per-`:where` vocabulary: `:fx-args` → `"Skipped"` (not `"fx skipped"`); `:sub-return` → `"Returned nil"` (not `"returned nil"`).

### focus_epoch_id_correlation_e2e_cljs_test.cljs (rf2-9m8mb)

7. **`retro-focus-on-trace-elided-epoch-resolves-epoch-id`** + **`dispatch-id-slot-pinned-on-every-retained-epoch`** now configure `:trace-events-keep` explicitly. Per `epoch/state.cljc` the framework default was lifted from 5 to 50 (Mike pair-debug 2026-05-27 — trace evicts atomically with its epoch). Both tests rely on elision to bite the rf2-rly4a fix path; they now shrink `:trace-events-keep` to 3 via `rf/configure` so the elision still fires under their cascade volumes. The ns docstring is updated to record the default lift.

### settings/popup_cljs_test.cljs (rf2-9m8mb)

8. **`general-section-renders`** updated. The 2026-05-27 UX cleanup removed the text-size slider (assert ABSENCE) and relocated the epoch-history slider from Buffer back to General (flip `nil?` → `find-by-testid`).

9. **`epoch-history-slider-renders-in-buffer` → renamed `epoch-history-slider-absent-from-buffer-section`.** Buffer no longer carries the slider; assert ABSENCE.

10. **`use-system-colors-renders-in-general` → renamed `use-system-colors-checkbox-absent-from-general`.** The checkbox was removed; the `:use-system-colors?` slot + `apply-use-system-colors!` effect remain (so a future UI can re-expose), so the test now asserts ABSENCE.

### p3_polish_aria_cljs_test.cljs (rf2-9m8mb)

11. **`settings-text-size-label-associates-with-input` → renamed `settings-epoch-history-label-associates-with-input`.** The rf2-h4mnh `<label html-for>` ↔ `<input id>` contract is now exercised against the surviving epoch-history slider since the text-size slider was retired.

## Verification

- `cd tools/xray && clojure -M:test` — 944 tests, 0 failures, 0 errors.

- `cd implementation && npm run test:cljs` — 4790 tests, 15656 assertions, 0 failures, 0 errors.
