### PR TITLE
fix(xray/epoch): polish sweep — 8 beads (uo4e2 + zuh3p + zn6u5 + d2akf + byn7l + 309cy + zmkqi + f7wtq)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -814,6 +814,14 @@
    :flex-wrap   "wrap"
    :align-items "center"})
 
+(def ^:private subs-value-cell-fill-style
+  "Wrapper for the SUBSCRIPTIONS value cell's `:full` / `:full+diff`
+  edn-inspector mounts — fills the grid track + permits the
+  inspector's tree to wrap without overflow. Hoisted per rf2-zmkqi
+  (the 2 residual literals that escaped rf2-zlk6h's 189-style hoist)."
+  {:flex      1
+   :min-width 0})
+
 ;; -- SUBSCRIPTIONS filter button bar --------------------------------------
 
 (def ^:private subs-filter-bar-style
@@ -2943,14 +2951,14 @@
   (when changed?
     (case mode
       :full
-      [:div {:style {:flex 1 :min-width 0}}
+      [:div {:style subs-value-cell-fill-style}
        [ei/edn-inspector after
         {:panel-id :rf.xray.epoch/subs-value
          :site-id  [:rf.xray.epoch/subs-value sub-id idx :full]
          :default-expanded-depth 2}]]
 
       :full+diff
-      [:div {:style {:flex 1 :min-width 0}}
+      [:div {:style subs-value-cell-fill-style}
        [ei/edn-inspector after
         (cond-> {:panel-id :rf.xray.epoch/subs-value
                  :site-id  [:rf.xray.epoch/subs-value sub-id idx :full+diff]
@@ -2979,7 +2987,15 @@
   view; columns are user-draggable via the gutters between adjacent
   headers. Per-row layout becomes a CSS grid driven by the table's
   column-widths state slot (in-memory; reset on reload — localStorage
-  persistence is a follow-up bead)."
+  persistence is a follow-up bead).
+
+  rf2-zuh3p — when a row carries `:violations` (a `:sub-return`
+  boundary failure attributed to that sub-id by the projection), the
+  per-row violation sub-block renders INLINE via the resizable-table's
+  `:row-extras` slot — directly below the row, before the next row
+  begins. Parity with the sibling FX step's `fx-row-with-violations`.
+  Pre-fix all per-row violations rendered as a single foot-of-step
+  block (line 3178-3181), divorcing the violation from its row."
   [rows mode]
   (let [columns [{:id :sub    :label "sub"    :default-flex "1fr"}
                  {:id :inputs :label "inputs" :default-flex "1fr"}
@@ -3027,7 +3043,30 @@
          ;; value cell
          [:div {:data-rf-xray-resizable-col "value"
                 :style subs-cell-changed-style}
-          (subs-value-cell row mode i)]])}]))
+          (subs-value-cell row mode i)]])
+      ;; rf2-zuh3p — per-row violations attach inline as `:row-extras`
+      ;; so the schema-violation sub-block renders directly below its
+      ;; owning row (mirrors the FX step's `fx-row-with-violations`
+      ;; shape). The step-level violations (non-row attributed) still
+      ;; ride at the foot via the call-site below.
+      :row-extras
+      (fn [row _i]
+        (when (seq (:violations row))
+          (violation-blocks
+            (keyword (str "sub-row-" (some-> row :sub-id name)))
+            (:violations row))))}]))
+
+(defn- sub-coord
+  "Pull the registered sub's source coord off
+  `(rf/handler-meta :sub sub-id)`. Returns nil when no meta is
+  captured. Matches the sibling `view-coord` shape (rf2-d2akf —
+  bring click-to-source affordance to disposed-sub rows on parity
+  with the unmounted-views rows)."
+  [sub-id]
+  (when (some? sub-id)
+    (let [m (try (rf/handler-meta :sub sub-id) (catch :default _ nil))]
+      (when (and m (string? (:file m)))
+        {:file (:file m) :line (:line m) :ns (:ns m)}))))
 
 (defn- dispose-reason-label
   "Render a `:rf.sub/dispose` `:reason` keyword as a UI label
@@ -3085,7 +3124,14 @@
              (vector? query) [ei/mini query 40]
              (some? sub-id)  [ei/mini sub-id 40]
              :else           [:span {:style disposed-anonymous-style}
-                              "<anonymous sub>"])]]
+                              "<anonymous sub>"])
+           ;; rf2-d2akf — click-to-source affordance for the reg-sub,
+           ;; parity with the sibling unmounted-views row. Resolves
+           ;; `(rf/handler-meta :sub sub-id)` → coord; chip drops out
+           ;; cleanly when meta is absent (anonymous sub / production
+           ;; build without coords).
+           (coord-chip/coord-chip (sub-coord sub-id)
+                                  (str "rf-xray-epoch-sub-disposed-row-coord-" i))]]
          ;; reason cell
          [:div {:data-rf-xray-resizable-col "reason"
                 :data-testid (str "rf-xray-epoch-sub-disposed-row-reason-" i)
@@ -3127,8 +3173,7 @@
                         ;; renders an empty filter.
                         (filterv :changed? rows))
         n             (count rows)
-        l             (count disposed-rows)
-        per-row-vio   (filter (fn [r] (seq (:violations r))) rows)]
+        l             (count disposed-rows)]
     [:div {:data-testid "rf-xray-epoch-step-subscriptions"
            :data-step-kw "subscriptions"}
      (numbered-circle step-number :SUBSCRIPTIONS)
@@ -3170,14 +3215,12 @@
        (subscriptions-table visible-rows value-mode))
      (when (pos? l)
        (disposed-subs-table disposed-rows))
-     ;; rf2-xgeag — `:sub-return` boundary violations. Per-row
-     ;; attachments are rendered below their matching sub row;
-     ;; step-level violations (indirect recomputes that don't
-     ;; surface a row) ride at the foot.
-     (for [row per-row-vio]
-       (violation-blocks
-         (keyword (str "sub-row-" (some-> row :sub-id name)))
-         (:violations row)))
+     ;; rf2-xgeag · rf2-zuh3p — `:sub-return` boundary violations.
+     ;; Per-row attachments now render INLINE with their matching sub
+     ;; row via `subscriptions-table`'s `:row-extras` slot (no longer
+     ;; pooled at the foot of the step). Step-level violations
+     ;; (indirect recomputes that don't surface a row) continue to
+     ;; ride at the foot.
      (violation-blocks :subscriptions violations)]))
 
 ;; ---- VIEWS step ----------------------------------------------------------
@@ -3236,8 +3279,13 @@
                   :style (if view-id
                            views-cell-id-clickable-style
                            views-cell-id-span-style)}
+           ;; rf2-309cy — view-id keyword routes through `ei/mini` so
+           ;; it carries the same syntax-token chrome the sibling subs-
+           ;; read cell uses (rf2-8w8er intent). Pre-fix the cell rendered
+           ;; via `proj/ns-keyword` → plain coloured text, an inconsistency
+           ;; against the syntax-highlighted subs-read column to its right.
            (if (some? view-id)
-             (proj/ns-keyword view-id)
+             [ei/mini view-id 60]
              [:span {:style views-anonymous-style}
               "<anonymous view>"])
            (coord-chip/coord-chip (view-coord view-id)
@@ -3302,8 +3350,11 @@
                 :style unmounted-id-cell-style}
           [:span {:data-testid (str "rf-xray-epoch-view-unmounted-row-id-" i)
                   :style unmounted-id-span-style}
+           ;; rf2-309cy — view-id keyword routes through `ei/mini` so
+           ;; the UNMOUNTED row matches the re-render row's chrome (same
+           ;; data-shape, same syntax-highlighted token rendering).
            (if (some? view-id)
-             (proj/ns-keyword view-id)
+             [ei/mini view-id 60]
              [:span {:style disposed-anonymous-style}
               "<anonymous view>"])
            (coord-chip/coord-chip (view-coord view-id)
@@ -3496,6 +3547,35 @@
                     "See " link " for the new shape."]
        [:<> "Schema violation. " link " for details."])]))
 
+(defn decode-malli-explain
+  "Decompose a Malli `explain` map into the at-a-glance summary the
+  bead body's §SCHEMA VIOLATION section asks for (rf2-zn6u5).
+
+  Returns `{:expected <schema-form> :got <value> :more-errors <int>}`
+  when `explain` carries the canonical Malli shape — `{:errors [{...}
+  ...] :value <root>}`. Returns `nil` otherwise (non-Malli validators,
+  pre-rf2-2ek7t framework, malformed input) so the caller can drop
+  the decomposition row cleanly.
+
+  - `:expected` reads the FIRST error's `:schema` slot (the schema
+    form that failed at the deepest path Malli reached).
+  - `:got` reads the first error's `:value` when present; falls back
+    to the explain map's root `:value`.
+  - `:more-errors` is `(count errors) - 1` so the call-site can paint
+    a `(+N more)` chip when more than one error rode in.
+
+  Pure data; JVM-testable."
+  [explain]
+  (when (map? explain)
+    (let [errors (:errors explain)]
+      (when (and (sequential? errors) (seq errors))
+        (let [first-err (first errors)]
+          {:expected    (:schema first-err)
+           :got         (if (contains? first-err :value)
+                          (:value first-err)
+                          (:value explain))
+           :more-errors (max 0 (dec (count errors)))})))))
+
 (defn violation-block
   "Render one schema-violation sub-block (rf2-2ek7t redesign,
   supersedes rf2-xgeag).
@@ -3537,6 +3617,7 @@
                             (when failing-id
                               (violation-kind-coord :schema failing-id)))
         humanized-shown (or explain-humanized explain)
+        decoded         (decode-malli-explain explain)
         testid-base     (str "rf-xray-epoch-violation-"
                              (name (or step-key :unknown)) "-" idx)]
     [:div {:key (str "violation-" step-key "-" idx)
@@ -3559,7 +3640,35 @@
          recovery-label])]
      ;; 2. Prose sentence with inline schema link
      (violation-prose where schema-coord testid-base)
-     ;; 3. Humanized explain map (or raw fallback) — render via
+     ;; 3. Expected / Got decomposition (rf2-zn6u5) — when the row's
+     ;; `:explain` carries the canonical Malli shape, surface the
+     ;; first error's `:schema` (expected) + `:value` (got) as
+     ;; programmer-friendly summary lines ABOVE the full humanized
+     ;; explain map. Multi-error explain maps gain a `(+N more)` chip
+     ;; so the operator sees the first-error-prominent summary the
+     ;; rf2-xgeag bead body designed. Drops out cleanly when
+     ;; `decode-malli-explain` returns nil (non-Malli validator).
+     (when decoded
+       [:div {:data-testid (str testid-base "-decoded")
+              :style schema-violation-explain-body-style}
+        [:div {:style schema-violation-line-style}
+         [:span {:style schema-violation-line-label-style}
+          "expected:"]
+         [:span {:data-testid (str testid-base "-expected")
+                 :style schema-violation-line-value-style}
+          [ei/mini (:expected decoded) 80]]]
+        [:div {:style schema-violation-line-style}
+         [:span {:style schema-violation-line-label-style}
+          "got:"]
+         [:span {:data-testid (str testid-base "-got")
+                 :style schema-violation-line-value-style}
+          [ei/mini (:got decoded) 80]]]
+        (when (pos? (:more-errors decoded))
+          [:div {:data-testid (str testid-base "-more-errors")
+                 :style schema-violation-sensitive-style}
+           (str "(+" (:more-errors decoded) " more error"
+                (when (> (:more-errors decoded) 1) "s") ")")])])
+     ;; 4. Humanized explain map (or raw fallback) — render via
      ;; edn-inspector fully expanded ("FULL" per Mike pair-debug
      ;; 2026-05-27). `:default-expanded-depth 16` matches the
      ;; widget's `:max-depth` ceiling so every nested level of the

--- a/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_subs.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_subs.cljs
@@ -268,17 +268,18 @@
   "Project the epoch's DESTROYED SUBSCRIPTIONS section rows (spec/021
   §3.2) — subs cleaned up when their last reader unmounted.
 
-  Reads the `:rf.sub/disposed` teardown op (the sub-dispose op spec/021
-  §3.5 pairs with view-unmount). Data-availability honesty: the live
-  build does not yet emit a sub-dispose trace op (the sub-cache disposes
-  reactions silently on last-reader teardown — see subs/cache.cljc), so
-  this projection is empty until that op lands. When it does, each
-  `:rf.sub/disposed` op anchors a row `{:sub-id <kw/id>}`. First-seen
-  order, de-duplicated. nil-safe; ops without a `:sub-id` are skipped."
+  Reads the `:rf.sub/dispose` teardown op (the sub-dispose op spec/021
+  §3.5 pairs with view-unmount). Per rf2-uo4e2 the framework-emitted
+  op-name is `:rf.sub/dispose` (singular form per spec/023's rf2-2v3p7
+  typo fix); pre-fix this panel read the past-tense form which never
+  matched any framework-emitted trace and rendered as silent dead code.
+  Each `:rf.sub/dispose` op anchors a row `{:sub-id <kw/id>}`. First-
+  seen order, de-duplicated. nil-safe; ops without a `:sub-id` are
+  skipped."
   [trace-events]
   (->> (or trace-events [])
        (keep (fn [ev]
-               (when (= :rf.sub/disposed (op-kw ev))
+               (when (= :rf.sub/dispose (op-kw ev))
                  (let [tags (:tags ev)]
                    (or (:rf.sub/id tags) (:sub-id tags)
                        (:rf.sub/id ev) (:sub-id ev))))))

--- a/tools/xray/src/day8/re_frame2_xray/panels/trace_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/trace_helpers.cljc
@@ -203,15 +203,20 @@
 
 (defn outcome-tier
   "Classify a row's outcome into a visual tier per spec/023 §8. Reads
-  the operation's terminal segment (`disposed`, `skip`, `cache-hit`, …).
-  Pure data → keyword; JVM-testable."
+  the operation's terminal segment (`dispose`, `skip`, `cache-hit`, …).
+  Pure data → keyword; JVM-testable.
+
+  Per rf2-uo4e2 the dispose terminal is the singular `dispose` form
+  (matches the framework-emitted `:rf.sub/dispose` op spec/009 + spec/023
+  ratified via rf2-2v3p7). The regex uses the shorter root so it
+  still matches both `dispose` and any legacy `disposed` substring."
   [{:keys [op-type operation] :as _row-or-ev}]
   (let [op-name (when (keyword? operation) (name operation))]
     (cond
       (= op-type :error)   :error
       (= op-type :warning) :warning
       (nil? op-name)       :active
-      (re-find #"(?i)(disposed|unmounted|cleared|cancelled|stale|released|destroyed)" op-name)
+      (re-find #"(?i)(dispose|unmounted|cleared|cancelled|stale|released|destroyed)" op-name)
       :gone
       (re-find #"(?i)(skip|skipped|cache-hit|unchanged|ran-unchanged)" op-name)
       :inert

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -1509,3 +1509,270 @@
                  (instance? cljs.core/LazySeq step-seq)
                  (str "LazySeq, realized?=" (realized? step-seq))
                  :else (str "type=" (type step-seq))))))))
+
+;; ---- rf2-zmkqi — SUBSCRIPTIONS :full / :full+diff value cell smoke ------
+
+(deftest subscriptions-full-mode-renders-without-inline-style-test
+  (testing "rf2-zmkqi — the `:full` / `:full+diff` value-cell modes
+            render without crashing. Smoke check that the post-hoist
+            ns-level style def (`subs-value-cell-fill-style`) lands a
+            valid `:style` map under the wrapping div — pre-fix two
+            literal `{:flex 1 :min-width 0}` maps were still inline."
+    (epoch-orchestrator/install!)
+    (frame/reg-frame :rf/xray {})
+    (rf/with-frame :rf/xray
+      ;; Flip mode to :full so the hoisted style wrapper renders.
+      (rf/dispatch-sync [:rf.xray.epoch/set-subs-value-diff-mode :full])
+      (let [step {:step :subscriptions :badge :SUBSCRIPTIONS :step-number 5
+                  :rows [{:sub-id :counter/total :sub-vec [:counter/total]
+                          :inputs nil :changed? true :before 5 :after 6}]
+                  :changed 1 :unchanged 0}
+            tree (view/render-subscriptions-step step)
+            row  (th/find-by-testid tree "rf-xray-epoch-sub-row-0")]
+        (is (some? row)
+            "row renders cleanly under :full mode (hoisted style applied)"))
+      (rf/dispatch-sync [:rf.xray.epoch/set-subs-value-diff-mode :full+diff])
+      (let [step {:step :subscriptions :badge :SUBSCRIPTIONS :step-number 5
+                  :rows [{:sub-id :counter/total :sub-vec [:counter/total]
+                          :inputs nil :changed? true :before 5 :after 6}]
+                  :changed 1 :unchanged 0}
+            tree (view/render-subscriptions-step step)
+            row  (th/find-by-testid tree "rf-xray-epoch-sub-row-0")]
+        (is (some? row)
+            "row renders cleanly under :full+diff mode (hoisted style applied)")))))
+
+;; ---- rf2-309cy — VIEWS row view-id keyword routes through ei/mini ------
+
+(deftest views-row-view-id-routes-through-mini-test
+  (testing "rf2-309cy — VIEWS row's view-id keyword routes through
+            `ei/mini` so the cell carries the syntax-highlighted
+            keyword chrome (same data-shape as the sibling subs-read
+            cell, rf2-8w8er intent). The id cell must mount at least
+            one mini widget alongside the view-id text."
+    (let [step {:step :views :badge :VIEWS :step-number 6
+                :rows [{:view-id :app.counter/Counter
+                        :subs-read [] :duration-ms nil}]}
+          tree (view/render-views-step step)
+          id-cell (th/find-by-testid tree "rf-xray-epoch-view-row-id-0")]
+      (is (some? id-cell)
+          "the view-id span renders")
+      (is (pos? (count (mini-mounts id-cell)))
+          "the view-id cell mounts at least one ei/mini widget (no longer plain text)")
+      (is (string/includes? (th/text-content id-cell) ":app.counter/Counter")
+          "the keyword text is still present (mini renders the colon + ns + name)"))))
+
+(deftest unmounted-views-row-view-id-routes-through-mini-test
+  (testing "rf2-309cy — UNMOUNTED VIEWS row's view-id keyword routes
+            through `ei/mini` (parity with the re-render row's chrome)."
+    (let [step {:step :views :badge :VIEWS :step-number 6
+                :rows []
+                :unmounted-rows [{:view-id :app.sidebar/Item
+                                  :instance [:Item 0]
+                                  :frame :rf/default}]}
+          tree (view/render-views-step step)
+          id-cell (th/find-by-testid tree "rf-xray-epoch-view-unmounted-row-id-0")]
+      (is (some? id-cell)
+          "the unmounted view-id span renders")
+      (is (pos? (count (mini-mounts id-cell)))
+          "the unmounted view-id cell mounts at least one ei/mini widget"))))
+
+;; ---- rf2-d2akf — DISPOSED sub row carries click-to-source ---------------
+
+(deftest disposed-sub-row-mounts-coord-chip-when-meta-resolves-test
+  (testing "rf2-d2akf — the DISPOSED sub row routes through
+            `coord-chip/coord-chip` to surface a click-to-source
+            affordance for the reg-sub (parity with the sibling
+            unmounted-views row). Pre-fix the disposed cell had NO
+            coord-chip affordance at all — the call-site itself was
+            missing.
+
+            The chip's <button> mounts when `(rf/handler-meta :sub
+            sub-id)` resolves a `:file` coord. CLJS macro-form
+            `reg-sub` captures `:file`/`:line` at the test call-site
+            so the integration round-trip is testable here."
+    (epoch-orchestrator/install!)
+    (frame/reg-frame :rf/xray {})
+    (rf/with-frame :rf/xray
+      (rf/reg-sub :rf.uo4e2-fixture/items
+        (fn [db _] (get db :items [])))
+      (let [meta-resolved? (boolean (some-> (rf/handler-meta :sub :rf.uo4e2-fixture/items)
+                                            :file string?))
+            step {:step :subscriptions :badge :SUBSCRIPTIONS :step-number 5
+                  :rows []
+                  :changed 0 :unchanged 0
+                  :disposed-rows [{:sub-id :rf.uo4e2-fixture/items
+                                   :query  [:rf.uo4e2-fixture/items]
+                                   :reason :no-more-derefers
+                                   :frame  :rf/default}]}
+            tree (view/render-subscriptions-step step)]
+        (is (some? (th/find-by-testid tree "rf-xray-epoch-sub-disposed-row-0"))
+            "the disposed row itself renders")
+        ;; If the test harness captured a source coord, the chip
+        ;; mounts. Otherwise the call-site still fired but produced
+        ;; nil (graceful degrade per coord-chip's contract). Either
+        ;; way the bug-fix is in place — pre-fix there was no chip
+        ;; call-site at all. Pin both branches.
+        (let [chip (th/find-by-testid tree
+                     "rf-xray-epoch-sub-disposed-row-coord-0")]
+          (if meta-resolved?
+            (do
+              (is (some? chip)
+                  "coord chip mounts when reg-sub captured a source coord")
+              (is (= :button (first chip))
+                  "chip mounts as a <button>")
+              (is (fn? (:on-click (second chip)))
+                  "chip carries an on-click handler"))
+            (is (nil? chip)
+                "coord chip drops out cleanly when no coord is resolvable")))))))
+
+;; ---- rf2-zuh3p — SUBSCRIPTIONS per-row violations attach inline ----------
+
+(deftest subscriptions-row-violations-attach-inline-test
+  (testing "rf2-zuh3p — when a SUBSCRIPTIONS row carries a per-row
+            :violations slot (the :sub-return boundary failure attached
+            by the projection), the schema-violation sub-block renders
+            INLINE — directly underneath its owning row, via the
+            resizable-table's :row-extras slot — not pooled at the foot
+            of the step. Mirrors the FX step's `fx-row-with-violations`."
+    (epoch-orchestrator/install!)
+    (frame/reg-frame :rf/xray {})
+    (rf/with-frame :rf/xray
+      (let [violation {:where :sub-return
+                       :failing-id :cart/preview
+                       :explain-humanized {:errors ["must be int"]}
+                       :rollback? false}
+            step {:step :subscriptions :badge :SUBSCRIPTIONS :step-number 5
+                  :rows [{:sub-id :cart/preview :sub-vec [:cart/preview]
+                          :inputs nil :changed? true :before 1 :after "bad"
+                          :violations [violation]}]
+                  :changed 1 :unchanged 0}
+            tree (view/render-subscriptions-step step)
+            ;; The inline-attached block uses the step-key
+            ;; `:sub-row-<sub-name>` (rf2-xgeag namer).
+            inline-block (th/find-by-testid
+                           tree "rf-xray-epoch-violations-sub-row-preview")]
+        (is (some? inline-block)
+            "the per-row violation sub-block renders (anchored on the
+            sub-row-<name> step-key suffix)")))))
+
+(deftest subscriptions-step-level-violations-still-at-foot-test
+  (testing "rf2-zuh3p — step-level (non-row-attributed) violations
+            still ride at the foot of the SUBSCRIPTIONS step via the
+            `violation-blocks :subscriptions` call (parity preserved —
+            only per-row violations moved to inline)."
+    (epoch-orchestrator/install!)
+    (frame/reg-frame :rf/xray {})
+    (rf/with-frame :rf/xray
+      (let [step {:step :subscriptions :badge :SUBSCRIPTIONS :step-number 5
+                  :rows []
+                  :changed 0 :unchanged 0
+                  :violations [{:where :sub-return :failing-id :indirect/sub
+                                :explain-humanized {:errors ["nope"]}}]}
+            tree (view/render-subscriptions-step step)
+            foot (th/find-by-testid tree "rf-xray-epoch-violations-subscriptions")]
+        (is (some? foot)
+            "step-level violations still render at the foot of the
+            SUBSCRIPTIONS step (no behaviour change for non-row
+            attribution)")))))
+
+;; ---- rf2-zn6u5 — schema-violation Malli expected/got decomposition -------
+
+(deftest decode-malli-explain-returns-expected-got-test
+  (testing "rf2-zn6u5 — `decode-malli-explain` lifts the first error's
+            :schema + :value into a programmer-friendly summary map.
+            Pure data fn; JVM-testable."
+    (is (= {:expected :int :got "bad" :more-errors 0}
+           (view/decode-malli-explain
+             {:schema :int
+              :value "bad"
+              :errors [{:path [] :in [] :schema :int :value "bad"}]})))))
+
+(deftest decode-malli-explain-falls-back-to-root-value-test
+  (testing "rf2-zn6u5 — when the first error does NOT carry :value
+            (the value rides on the explain map's root), :got reads
+            from `explain`'s `:value` slot."
+    (is (= {:expected :int :got 42 :more-errors 0}
+           (view/decode-malli-explain
+             {:schema :int :value 42
+              :errors [{:path [] :schema :int}]})))))
+
+(deftest decode-malli-explain-counts-additional-errors-test
+  (testing "rf2-zn6u5 — multi-error explain maps surface
+            `:more-errors (- N 1)` so the call-site can paint a
+            `(+N more)` chip beneath the first-error summary."
+    (let [exp {:schema [:map [:a :int] [:b :int]]
+               :value {:a "x" :b "y"}
+               :errors [{:path [:a] :schema :int :value "x"}
+                        {:path [:b] :schema :int :value "y"}
+                        {:path [:c] :schema :int :value :extra}]}]
+      (is (= 2 (:more-errors (view/decode-malli-explain exp)))
+          "explain with 3 errors → :more-errors 2"))))
+
+(deftest decode-malli-explain-non-malli-returns-nil-test
+  (testing "rf2-zn6u5 — non-Malli validators / pre-rf2-2ek7t framework
+            produce explain maps without the canonical {:errors [...]}
+            shape; the decoder degrades to nil so the view drops the
+            decomposition row cleanly."
+    (is (nil? (view/decode-malli-explain nil)))
+    (is (nil? (view/decode-malli-explain {})))
+    (is (nil? (view/decode-malli-explain {:errors []})))
+    (is (nil? (view/decode-malli-explain {:errors :not-a-vec})))
+    (is (nil? (view/decode-malli-explain "not a map")))))
+
+(deftest violation-block-renders-expected-got-summary-test
+  (testing "rf2-zn6u5 — when a violation's :explain carries Malli's
+            canonical shape, the sub-block paints `expected:` + `got:`
+            summary lines via `ei/mini` ABOVE the full humanized
+            explain map render."
+    (let [row {:kind :rf.error/schema-validation-failure
+               :where :app-db
+               :failing-id :counter/inc
+               :path [:count]
+               :value "not-an-int"
+               :explain {:schema :int
+                         :value "not-an-int"
+                         :errors [{:path [:count] :schema :int
+                                   :value "not-an-int"}]}
+               :explain-humanized {:errors ["must be int"]}
+               :rollback? true
+               :sensitive? false}
+          tree (view/violation-block :handler 0 row)
+          base "rf-xray-epoch-violation-handler-0"]
+      (is (some? (th/find-by-testid tree (str base "-decoded")))
+          "the decomposed sub-block renders when explain carries the Malli shape")
+      (let [expected (text-of tree (str base "-expected"))
+            got      (text-of tree (str base "-got"))]
+        (is (string/includes? expected ":int")
+            "expected line renders the schema form via ei/mini")
+        (is (string/includes? got "not-an-int")
+            "got line renders the failing value via ei/mini")))))
+
+(deftest violation-block-multi-error-paints-more-chip-test
+  (testing "rf2-zn6u5 — multi-error explain maps surface a
+            `(+N more)` chip below the first-error summary."
+    (let [row {:where :app-db
+               :failing-id :user/profile
+               :path [:user]
+               :explain {:schema [:map [:a :int] [:b :int]]
+                         :value {:a "x" :b "y"}
+                         :errors [{:path [:a] :schema :int :value "x"}
+                                  {:path [:b] :schema :int :value "y"}]}}
+          tree (view/violation-block :handler 0 row)
+          chip-text (text-of tree "rf-xray-epoch-violation-handler-0-more-errors")]
+      (is (some? chip-text))
+      (is (string/includes? chip-text "+1 more")
+          "the multi-error chip reads `(+N more)` where N = errors-count - 1"))))
+
+(deftest violation-block-non-malli-skips-decoded-block-test
+  (testing "rf2-zn6u5 — when :explain is absent or non-Malli, the
+            decomposed sub-block drops out cleanly (no row appears)
+            and the humanized explain map still renders."
+    (let [row {:where :app-db
+               :failing-id :no-explain/case
+               :explain-humanized {:errors ["something"]}}
+          tree (view/violation-block :handler 0 row)
+          base "rf-xray-epoch-violation-handler-0"]
+      (is (nil? (th/find-by-testid tree (str base "-decoded")))
+          "decoded sub-block is omitted when no Malli explain is present")
+      (is (some? (th/find-by-testid tree (str base "-explain")))
+          "the humanized explain still renders (unchanged behaviour)"))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/reactive_panel_subs_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/reactive_panel_subs_cljs_test.cljs
@@ -269,16 +269,18 @@
   (is (= [] (subs/unmounted-views [(rendered-ev :v/a true nil)]))))
 
 (deftest destroyed-subscriptions-reads-dispose-op-when-present
-  (testing "rf2-ad7zx.6 — DESTROYED SUBSCRIPTIONS reads :rf.sub/disposed
-            ops; absent in the live build so empty by default (data-
-            availability honesty), populated when the op lands."
+  (testing "rf2-ad7zx.6 / rf2-uo4e2 — DESTROYED SUBSCRIPTIONS reads
+            :rf.sub/dispose ops (singular form per spec/023's
+            rf2-2v3p7 typo fix; pre-rf2-uo4e2 the fixture used the
+            past-tense form which never matched any framework-emitted
+            trace)."
     (is (= [] (subs/destroyed-subscriptions [(rendered-ev :v/a true nil)]))
         "no dispose op → empty (live-build reality)")
-    (let [events [{:operation :rf.sub/disposed :tags {:rf.sub/id :s/modal}}
-                  {:operation :rf.sub/disposed :tags {:sub-id :s/tip}}]]
+    (let [events [{:operation :rf.sub/dispose :tags {:rf.sub/id :s/modal}}
+                  {:operation :rf.sub/dispose :tags {:sub-id :s/tip}}]]
       (is (= [{:sub-id :s/modal} {:sub-id :s/tip}]
              (subs/destroyed-subscriptions events))
-          "forward-compatible: reads the dispose op when present"))))
+          "reads the framework-emitted :rf.sub/dispose op"))))
 
 ;; ---- Level 1 / Level 2+ partition -------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/trace_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/trace_helpers_cljs_test.cljc
@@ -230,7 +230,7 @@
     (is (= :inert (h/outcome-tier {:operation :rf.sub/skip})))
     (is (= :inert (h/outcome-tier {:operation :rf.view/skip}))))
   (testing "gone — disposed / unmounted / cleared / cancelled"
-    (is (= :gone (h/outcome-tier {:operation :rf.sub/disposed})))
+    (is (= :gone (h/outcome-tier {:operation :rf.sub/dispose})))
     (is (= :gone (h/outcome-tier {:operation :rf.view/unmounted})))
     (is (= :gone (h/outcome-tier {:operation :rf.flow/cleared}))))
   (testing "error / warning keep their semantic tier"
@@ -238,10 +238,10 @@
     (is (= :warning (h/outcome-tier {:op-type :warning :operation :rf.warning/x})))))
 
 (deftest project-row-carries-outcome-tier-and-verb-and-target
-  (let [row (h/project-row (ev {:id 1 :op-type :rf.sub :operation :rf.sub/disposed
+  (let [row (h/project-row (ev {:id 1 :op-type :rf.sub :operation :rf.sub/dispose
                                 :tags {:rf.sub/id :cart/preview}}))]
     (is (= :gone (:outcome-tier row)))
-    (is (= "disposed" (:verb row)))
+    (is (= "dispose" (:verb row)))
     (is (= ":cart/preview" (:target row)))))
 
 ;; ---- (7) op-family band colour — retained left-border -----------------
@@ -287,7 +287,7 @@
   (is (= (:text-tertiary tokens/tokens)
          (h/outcome-colour {:operation :rf.sub/skip})))
   (is (= (:dim tokens/tokens)
-         (h/outcome-colour {:operation :rf.sub/disposed})))
+         (h/outcome-colour {:operation :rf.sub/dispose})))
   (is (= (:red tokens/tokens)
          (h/outcome-colour {:op-type :error :operation :rf.error/x}))))
 

--- a/tools/xray/test/day8/re_frame2_xray/theme/var_resolution_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/theme/var_resolution_cljs_test.cljs
@@ -164,7 +164,7 @@
   (testing "rf2-l2f2g — `trace-helpers/outcome-colour` tints the
             what-happened column by outcome tier and resolves to a CSS
             variable (spec/023 §8)."
-    (doseq [op [:rf.sub/run :rf.sub/skip :rf.sub/disposed :rf.error/x]]
+    (doseq [op [:rf.sub/run :rf.sub/skip :rf.sub/dispose :rf.error/x]]
       (let [v (trace-h/outcome-colour {:op-type (if (= op :rf.error/x) :error :rf.sub)
                                        :operation op})]
         (is (string? v))


### PR DESCRIPTION
Eight-bead polish sweep on the Epoch panel + reactive-panel typo fix. Surgical fixes, no drive-by refactors.

## Beads

### rf2-uo4e2 (P2 silent bug) — :rf.sub/disposed -> :rf.sub/dispose rename
spec/023 fix (rf2-2v3p7) corrected the typo on the spec sheet; the xray code/tests never picked it up. `reactive_panel_subs.cljs` matched `:rf.sub/disposed` (past-tense form) which the framework never emits — the Destroyed-Subscriptions panel was silent dead code in production. 4 test files used the wrong key in fixtures so greens were misleading. `trace_helpers.cljc` regex updated to match the shorter `dispose` root.

- Touched: `reactive_panel_subs.cljs` + `trace_helpers.cljc` + 3 test files
- `git grep ':rf\.sub/disposed'` → 0 hits across tracked source

### rf2-zmkqi (P4 style hoist)
Two residual `{:flex 1 :min-width 0}` literals at SUBSCRIPTIONS value-cell `:full` / `:full+diff` branches escaped rf2-zlk6h's 189-style hoist. Hoisted to ns-level `subs-value-cell-fill-style`.

### rf2-309cy (P3 chrome consistency)
VIEWS row + UNMOUNTED VIEWS row view-id keywords now render through `ei/mini` (per rf2-8w8er intent). Pre-fix both rendered via `proj/ns-keyword` as plain coloured text, an inconsistency against the sibling subs-read column.

### rf2-d2akf (P3 missing affordance)
DISPOSED sub row gains click-to-source via shared `coord-chip/coord-chip`, parity with the unmounted-views row. New `sub-coord` helper resolves `(rf/handler-meta :sub sub-id)`.

### rf2-zuh3p (P3 layout)
SUBSCRIPTIONS per-row schema violations now attach INLINE with their owning row via `resizable-table`'s `:row-extras` slot, mirroring the FX step's `fx-row-with-violations` shape. Step-level violations still ride at the foot.

### rf2-zn6u5 (P3 actionable summary)
Schema violation sub-block gains programmer-friendly `expected:` / `got:` decomposition lines above the humanized explain map. Multi-error explain maps paint a `(+N more)` chip. New pure helper `decode-malli-explain` returning `{:expected :got :more-errors}`.

### rf2-byn7l (P3 — no-op, already fixed)
DISPATCH body already routes through `edn-inspector` (PR #2198 / rf2-8w8er). Bead was filed against stale state. Closed with reference to the existing implementation at `view.cljs:1365 dispatch-body`.

### rf2-f7wtq (P4 — no-op, audit complete)
Visual audit of step renderers (COEFFECT/FLOW/FX/SUBSCRIPTIONS/VIEWS/SCHEMA) for text-duplication per rf2-9jvx1's acceptance #1. No further duplication found beyond what rf2-9jvx1 fixed for DISPATCH/HANDLER. Cofx-id ringing in both header verb-link AND body diff-path labels is intentional descriptor (header summary + body diff-path), not duplication.

## Tests added (11 new tests, in `panels/epoch/view_cljs_test.cljs`)

- `views-row-view-id-routes-through-mini-test` (rf2-309cy)
- `unmounted-views-row-view-id-routes-through-mini-test` (rf2-309cy)
- `disposed-sub-row-mounts-coord-chip-when-meta-resolves-test` (rf2-d2akf)
- `subscriptions-row-violations-attach-inline-test` (rf2-zuh3p)
- `subscriptions-step-level-violations-still-at-foot-test` (rf2-zuh3p)
- `decode-malli-explain-returns-expected-got-test` (rf2-zn6u5)
- `decode-malli-explain-falls-back-to-root-value-test` (rf2-zn6u5)
- `decode-malli-explain-counts-additional-errors-test` (rf2-zn6u5)
- `decode-malli-explain-non-malli-returns-nil-test` (rf2-zn6u5)
- `violation-block-renders-expected-got-summary-test` (rf2-zn6u5)
- `violation-block-multi-error-paints-more-chip-test` (rf2-zn6u5)
- `violation-block-non-malli-skips-decoded-block-test` (rf2-zn6u5)
- `subscriptions-full-mode-renders-without-inline-style-test` (rf2-zmkqi smoke)

Plus 5 test fixtures updated (rf2-uo4e2) — `:rf.sub/disposed` -> `:rf.sub/dispose`.

## Quality gates

- `npm run test:cljs` (from `implementation/`): Ran 4817 tests, 15693 assertions, **0 failures, 0 errors**
- `clojure -M:test` (from `tools/xray/`): Ran 944 tests, 3663 assertions, **0 failures, 0 errors**

## Files touched

```
tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs              (5 beads)
tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_subs.cljs      (rf2-uo4e2)
tools/xray/src/day8/re_frame2_xray/panels/trace_helpers.cljc            (rf2-uo4e2)
tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs   (5 beads, +11 tests)
tools/xray/test/day8/re_frame2_xray/panels/reactive_panel_subs_cljs_test.cljs (rf2-uo4e2)
tools/xray/test/day8/re_frame2_xray/panels/trace_helpers_cljs_test.cljc       (rf2-uo4e2)
tools/xray/test/day8/re_frame2_xray/theme/var_resolution_cljs_test.cljs       (rf2-uo4e2)
```