### PR TITLE
fix(xray): misc polish sweep — 10 beads (rc35g + xm1jy + 5j7ch + tyivx + 2678t + 4oy37 + eko4v + a7vkv + a1tv6 + vwfcp)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/config.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/config.cljc
@@ -406,6 +406,33 @@
   []
   @editor)
 
+(def ^:private valid-editor-override-keywords
+  "Enumerated keyword overrides accepted by `valid-editor-override?`.
+  Mirror of `set-editor!`'s accepted shape (rf2-dudqz). Adding a new
+  editor here requires a matching `defmethod` in
+  `re-frame.source-coords.editor-uri/editor-uri`."
+  #{:vscode :cursor :windsurf :zed :idea})
+
+(defn valid-editor-override?
+  "Predicate: is `v` a valid `[:general :editor-override]` value?
+
+  Returns true for:
+    - `nil`                — the cleared state.
+    - An enumerated keyword from `valid-editor-override-keywords`.
+    - A `{:custom <string>}` map (any non-empty string).
+
+  Returns false for every other shape — corrupted localStorage
+  payloads, hand-edits, legacy values from earlier experimental
+  shapes. The read-side `get-editor` filters through this predicate
+  (rf2-a1tv6) so a corrupted slot degrades to the host default rather
+  than passing a malformed value through to the URI builder."
+  [v]
+  (or (nil? v)
+      (contains? valid-editor-override-keywords v)
+      (and (map? v)
+           (string? (:custom v))
+           (not= "" (:custom v)))))
+
 (defn get-editor
   "Return the editor preference Xray's 'Open in editor' affordance
   should target.
@@ -418,6 +445,12 @@
        localStorage like every other operator preference. Wins when
        non-nil so a mixed-editor teammate can flip their machine to
        a different editor without touching the host app's boot config.
+       rf2-a1tv6 — the slot is filtered through
+       `valid-editor-override?` on read; malformed payloads (a
+       corrupted localStorage write, a hand-edit, a stale
+       experimental shape) degrade to the host default instead of
+       reaching the URI builder. A rejection emits a `tap>` so tests
+       + operators can observe the corruption.
     2. **Host default** — the `editor` atom set by
        `set-editor!` / `(xray-config/configure! {:rf.xray/editor …})`.
        The team's project-wide pick.
@@ -428,8 +461,13 @@
   atom. Clearing the override (selecting '(project default)' in the
   picker) restores the host default."
   []
-  (let [override (try (get-in @settings [:general :editor-override])
-                      (catch #?(:clj Throwable :cljs :default) _ nil))]
+  (let [raw (try (get-in @settings [:general :editor-override])
+                 (catch #?(:clj Throwable :cljs :default) _ nil))
+        override (if (valid-editor-override? raw)
+                   raw
+                   (do (tap> {:tag      ::reject-invalid-editor-override
+                              :value    raw})
+                       nil))]
     (or override @editor)))
 
 ;; ---- *project-root* (rf2-5m5n2 — 'Open in editor' path prefix) ----------

--- a/tools/xray/src/day8/re_frame2_xray/diff/engine.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/diff/engine.cljc
@@ -685,6 +685,82 @@
   (or (:change-count (get-in projection [:container-ops (vec path)]))
       0))
 
+;; =========================================================================
+;; flat-rows post-processing — operator-friendly expansion (rf2-5j7ch)
+;; =========================================================================
+
+(defn expand-empty-root-replacement
+  "Post-process `flat-rows` so a wholesale root replacement against an
+  EMPTY before / after map expands into per-key rows (rf2-5j7ch).
+
+  Editscript's A* produces a single root-level `:r` edit for the
+  `{} → {populated}` (and `{populated} → {}`) cases — at engine
+  output that surfaces as ONE flat-row anchored at `[]`. The engine
+  is correct (one edit-script entry, mode-3 paints from the same
+  source), but the operator's UX read on `:diff` lens is less
+  informative: empty-to-populated is the canonical 'what landed?'
+  question for cold-boot epochs and wants per-key granularity.
+
+  This helper expands EXACTLY the empty-root-replacement case:
+
+    - before is `{}`        + after is a non-empty map  →
+      one `{:path [k] :op :added :before nil :after v}` row per
+      key (sorted by key for stable order).
+
+    - before is a non-empty map + after is `{}`        →
+      one `{:path [k] :op :removed :before v :after nil}` row
+      per key.
+
+  Non-empty-side replacements (two populated maps swapping wholesale)
+  are LEFT ALONE — that reads as a genuine wholesale event the
+  operator should see as one row.
+
+  Pure-data. Operates on the engine's `:flat-rows` shape (vector of
+  `{:path :op :before :after}` maps). The renderer-side
+  `flat-rows->triples` step folds the expanded rows into the same
+  4-tuple shape every `:diff` lens consumer reads.
+
+  Returns the (possibly-expanded) flat-rows vector."
+  [flat-rows]
+  (let [root-row (when (= 1 (count flat-rows))
+                   (first flat-rows))]
+    (cond
+      ;; Empty-to-populated: expand the `:modified` row at `[]` into
+      ;; per-key `:added` rows.
+      (and (some? root-row)
+           (= [] (:path root-row))
+           (= :modified (:op root-row))
+           (= {} (:before root-row))
+           (map? (:after root-row))
+           (seq (:after root-row)))
+      (->> (:after root-row)
+           (mapv (fn [[k v]]
+                   {:path   [k]
+                    :op     :added
+                    :before nil
+                    :after  v}))
+           (sort-by :path)
+           vec)
+
+      ;; Populated-to-empty: expand into per-key `:removed` rows.
+      (and (some? root-row)
+           (= [] (:path root-row))
+           (= :modified (:op root-row))
+           (map? (:before root-row))
+           (seq (:before root-row))
+           (= {} (:after root-row)))
+      (->> (:before root-row)
+           (mapv (fn [[k v]]
+                   {:path   [k]
+                    :op     :removed
+                    :before v
+                    :after  nil}))
+           (sort-by :path)
+           vec)
+
+      :else
+      flat-rows)))
+
 (defn wholly-changed-ancestor
   "Return the shallowest wholly-changed-root that is an ancestor of
   `path` (or equal to `path`), or nil. Drives R5's

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_subs.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_subs.cljs
@@ -156,7 +156,18 @@
               cached
               (let [proj (diff-engine/project (:db-before record)
                                               (:db-after  record))
-                    diff (flat-rows->triples (:flat-rows proj))
+                    ;; rf2-5j7ch — operator-friendly expansion of the
+                    ;; wholesale root-replacement case (`{} →
+                    ;; {populated}` or inverse). The engine emits a
+                    ;; single `:r []` for that case (correct under
+                    ;; Editscript A*); the renderer-facing
+                    ;; `:diff` lens expands it into per-key rows so
+                    ;; the operator sees what landed in a cold-boot
+                    ;; epoch with per-key granularity. Non-empty-
+                    ;; side wholesales pass through unchanged.
+                    expanded (diff-engine/expand-empty-root-replacement
+                               (:flat-rows proj))
+                    diff (flat-rows->triples expanded)
                     live (into #{} (map :epoch-id) history)]
                 (swap! diff-cache
                        (fn [m]

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
@@ -539,11 +539,16 @@
   triples — the same shape the App-DB / Epoch HANDLER `:diff` lens
   consumes. Used by the Machine Inspector's `:diff` mode (rf2-yqjrd).
 
+  rf2-5j7ch — runs the engine's `expand-empty-root-replacement`
+  post-processor so a snapshot going `{} → {:state :idle …}` (cold-
+  boot first-transition) reads as per-key adds, not a wholesale
+  root replacement. Mirrors the App-DB `:diff` sub.
+
   Returns an empty vector when no Editscript edits surface (identical
   snapshots) so the renderer can paint a `— (no changes)` placeholder."
   [before after]
   (let [proj (diff-engine/project before after)
-        rows (:flat-rows proj)]
+        rows (diff-engine/expand-empty-root-replacement (:flat-rows proj))]
     (mapv (fn [{:keys [path op before after]}]
             (let [kind (case op
                          :added    :added

--- a/tools/xray/src/day8/re_frame2_xray/panels/machines/topology.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machines/topology.cljs
@@ -165,22 +165,21 @@
 
 (defn- event-segment-str
   "Render the leading event segment of an edge label per the Stately
-  graph view convention (rf2-a2b55, single source of truth in
-  `machines-viz/chart.layout/event-segment`):
+  graph view convention. rf2-2678t — delegate to the canonical
+  `machines-viz/chart.layout/event-segment` so xray + machines-viz
+  agree on every shape (no per-tool reimplementation drift):
 
-    - `:after <delay>` transition  → `\"⌚ <delay>ms\"` (clock glyph)
-    - `:always`        transition  → `\"∞\"`           (infinity glyph)
-    - regular event keyword         → `\"event-id\"` (ns preserved)
+    - `:* (any)` wildcard           — Spec 005 §Wildcard arm
+    - `:after <delay>` transition   — `⌚ <delay>ms` (clock glyph)
+    - `:always`        transition   — `∞`           (infinity glyph)
+    - regular event keyword          — `event-id` (ns preserved)
 
-  The xstate-textual `after(<delay>)` / `always` forms are NOT used
-  here — the Figma reconcile (spec/021 §6.2) + rf2-a2b55 fix the glyphs
-  as the canonical encoding so an `:always` / `:after` edge reads at a
-  glance against ordinary event arrows."
-  [{:keys [event after always?]}]
-  (cond
-    after            (str "⌚ " after "ms")
-    always?          "∞"
-    :else            (seg-name event)))
+  Pre-rf2-2678t (PR #2205) xray's local copy stripped the `:*` arm
+  and fell through to `seg-name`, which produced bare `\"*\"` — a
+  glyph drift away from machines-viz's `\"* (any)\"`. Importing the
+  canonical fn removes the entire drift class (rf2-2678t)."
+  [edge]
+  (chart-layout/event-segment edge))
 
 (defn- edge-label-str
   "Compose an xstate-stately edge label: `event [guard] / action`.

--- a/tools/xray/src/day8/re_frame2_xray/settings/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/settings/view.cljs
@@ -322,6 +322,17 @@
                 :general :editor-override value]
                {:frame :rf/xray}))
 
+(def ^:private custom-template-seed
+  "Seed template the Custom radio writes when the user first selects
+  it (rf2-rc35g). Echoes the framework-default `:vscode` URI shape so
+  click-to-source resolves to a working URI immediately — the user
+  edits from a known baseline rather than a blank that silently breaks
+  the chip until they finish typing.
+
+  Per `re-frame.source-coords.editor-uri/editor-uri`'s `:vscode`
+  branch."
+  "vscode://file/{path}:{line}:{column}")
+
 (defn- editor-override-section [override host-default]
   (let [active-id   (override->radio-id override)
         custom-tpl  (when (map? override) (:custom override))
@@ -352,17 +363,18 @@
                  :checked     (= id active-id)
                  :on-change   (fn [_]
                                 (cond
-                                  ;; Custom: don't write the override
-                                  ;; until the template input lands —
-                                  ;; selecting the radio just reveals
-                                  ;; the input. If there is no prior
-                                  ;; custom template, seed an empty
-                                  ;; `{:custom ""}` so the parent slot
-                                  ;; recognises Custom and the input
-                                  ;; renders.
+                                  ;; Custom: seed a working template
+                                  ;; (rf2-rc35g — was `{:custom ""}`,
+                                  ;; which breaks click-to-source
+                                  ;; until the user finishes typing).
+                                  ;; The vscode-style URI is the most
+                                  ;; common shape; users on other
+                                  ;; editors edit from a baseline that
+                                  ;; resolves cleanly today.
                                   (= id :custom)
                                   (when-not (map? override)
-                                    (dispatch-editor-override! {:custom ""}))
+                                    (dispatch-editor-override!
+                                      {:custom custom-template-seed}))
 
                                   :else
                                   (dispatch-editor-override! value)))}]

--- a/tools/xray/src/day8/re_frame2_xray/views/diff_mode_toggle.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/diff_mode_toggle.cljs
@@ -186,21 +186,31 @@
     :full+diff "full-with-diff"
     (name m)))
 
-(defn- make-on-click
-  "Factor the per-button `:on-click` so closure identity is stable per
-  `(on-change, m)` pair across renders (rf2-ihjnx). Inline lambdas in
-  the button hiccup mint three fresh closures per toggle render; React's
-  reconciler then re-writes the `onclick` DOM prop even when nothing
-  changed because function identity differs. With a named-fn factor
-  the closures are still per-render allocations, but the surface is now
-  the canonical place to memoise if a future audit lifts that.
+(def ^:private make-on-click
+  "Per-button `:on-click` handler factory with stable closure identity
+  per `(on-change, m)` pair across renders (rf2-ihjnx / rf2-a7vkv).
+
+  Each toggle render mounts three buttons; without memoisation each
+  render would mint three fresh closures and React's reconciler would
+  re-write the DOM `onclick` prop even when nothing changed (function
+  identity differs). `memoize` keyed on `[on-change m]` collapses
+  repeat renders to the cached handler.
+
+  Cache growth: bounded by the number of distinct `(on-change, m)`
+  pairs the program ever passes — typically one `on-change` per
+  consumer site (App-DB, Machine Inspector, two Epoch surfaces) times
+  three modes = 12 entries at steady state across the entire session.
+  Callers that mint a fresh `on-change` per render (anti-pattern) will
+  grow the cache linearly with renders — that is a caller bug; the
+  memoise here doesn't paper over it but doesn't amplify it either.
 
   Pure: takes `on-change` + `m`, returns an event handler that stops
   propagation then calls `(on-change m)`."
-  [on-change m]
-  (fn [e]
-    (.stopPropagation e)
-    (on-change m)))
+  (memoize
+    (fn [on-change m]
+      (fn [e]
+        (.stopPropagation e)
+        (on-change m)))))
 
 ;; =========================================================================
 ;; widget

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
@@ -3074,9 +3074,11 @@
             ;; body). Byte-identical `(displayed-before, displayed-
             ;; value)` pairs across renders short-circuit to the cached
             ;; result; only changed inputs trigger a fresh Editscript
-            ;; walk. Restores parity with the sub-cached `:diff` lens
-            ;; path (rf2-yqjrd) which has the same caching property
-            ;; via `annotated-tree-cache`.
+            ;; walk. Mirrors the sub-cache layer that fronts the
+            ;; `:diff` lens (rf2-yqjrd / engine/project in
+            ;; epoch/projection.cljc) — identical (before, after)
+            ;; inputs reuse the cached Editscript result rather than
+            ;; recomputing the A* edit-script on every render.
             projection    (when diff?
                             (memoised-project displayed-before displayed-value))
             body-content  (render-node

--- a/tools/xray/src/day8/re_frame2_xray/views/resizable_table.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/resizable_table.cljs
@@ -509,23 +509,34 @@
                        container-attrs)
            ;; Header hiccup is nil-tolerated by React/Reagent.
            header-hiccup]
-          ;; Body rows
-          (for [[i row] (map-indexed vector rows)
-                :let [attrs (or (when row-attrs (row-attrs row i)) {})
-                      cells (row-cells row i)
-                      extras (when row-extras (row-extras row i))
-                      woven (into [:<>] (weave-body cells columns))]]
-            ^{:key (row-key row i)}
-            (if (some? extras)
-              ;; Extras path — outer wrapper carries the consumer's
-              ;; attrs untouched (preserves border-bottom, click
-              ;; handlers, etc.); an inner div carries the grid layout
-              ;; for the cells; extras render below the inner grid.
-              [:div attrs
-               [:div {:style grid-style} woven]
-               extras]
-              ;; Default path — the outer wrapper IS the grid (the
-              ;; subscriptions-table shape).
-              [:div (-> attrs
-                        (assoc :style (merge (:style attrs) grid-style)))
-               woven])))))
+          ;; Body rows — eager `map-indexed` (per rf2-9ec65 / spec/006
+          ;; §Lazy-seq deref tracking, rf2-atqkg): a substrate widget
+          ;; must NOT hand React a `LazySeq` chunk because any future
+          ;; consumer that derefs a `(rf/subscribe ...)` inside its
+          ;; `:row-cells` fn would have the deref fall outside the
+          ;; parent render's reactive scope at the chunk boundary.
+          ;; The shared resizable-table is the canonical place to
+          ;; enforce eager realisation, not each call site.
+          (map-indexed
+            (fn [i row]
+              (let [attrs (or (when row-attrs (row-attrs row i)) {})
+                    cells (row-cells row i)
+                    extras (when row-extras (row-extras row i))
+                    woven (into [:<>] (weave-body cells columns))]
+                (with-meta
+                  (if (some? extras)
+                    ;; Extras path — outer wrapper carries the consumer's
+                    ;; attrs untouched (preserves border-bottom, click
+                    ;; handlers, etc.); an inner div carries the grid
+                    ;; layout for the cells; extras render below the
+                    ;; inner grid.
+                    [:div attrs
+                     [:div {:style grid-style} woven]
+                     extras]
+                    ;; Default path — the outer wrapper IS the grid
+                    ;; (the subscriptions-table shape).
+                    [:div (-> attrs
+                              (assoc :style (merge (:style attrs) grid-style)))
+                     woven])
+                  {:key (row-key row i)})))
+            rows))))

--- a/tools/xray/src/day8/re_frame2_xray/views/resizable_table.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/resizable_table.cljs
@@ -225,19 +225,39 @@
 
   ;; ---- events -----------------------------------------------------------
   ;;
-  ;; resize-pair + reset both upgraded to event-fx so the persist fx
-  ;; rides on every mutation. `:rf.trace/no-emit? true` matches the
-  ;; pattern used by `:rf.xray/set-event-list-col-width` (drag emits
-  ;; one event per pixel of motion; trace-buffering them would flood
-  ;; the bus with shape no panel consumes).
+  ;; The drag flow is split into two events so the localStorage write
+  ;; rides ONLY the commit, not every pointermove tick (rf2-xm1jy):
+  ;;
+  ;;   :resize-pair-tick   — pointermove cadence (~1 event/px).
+  ;;                         Writes the slot in app-db; NO persist fx.
+  ;;                         `:rf.trace/no-emit? true` keeps the trace
+  ;;                         bus quiet at drag cadence (no panel
+  ;;                         consumes the per-pixel shape).
+  ;;
+  ;;   :resize-pair-commit — pointerup. Persists the post-drag slot
+  ;;                         exactly once. Trace-quiet too because the
+  ;;                         tick event already covers the data side
+  ;;                         and the operator's interest is the
+  ;;                         settled widths, not the commit marker.
+  ;;
+  ;; Pre-rf2-xm1jy a single `:resize-pair` event-fx fired the persist
+  ;; fx on every tick — ~200 localStorage writes per typical drag,
+  ;; each serialising the full multi-table widths map. The split keeps
+  ;; the data-flow shape explicit (one event per semantic step) and
+  ;; trades a one-off pointerup commit for the bursty steady-state
+  ;; pattern. `reset` keeps its single-event shape; it has no drag
+  ;; cadence — one click → one mutation → one persist.
 
-  (rf/reg-event-fx :rf.xray.column-widths/resize-pair
+  (rf/reg-event-db :rf.xray.column-widths/resize-pair-tick
     {:rf.trace/no-emit? true}
-    (fn [{:keys [db]} [_ table-id left-id left-px right-id right-px]]
-      (let [next-db (write-pair db table-id left-id left-px right-id right-px)]
-        {:db next-db
-         :fx [[:rf.xray.column-widths/persist
-               (get next-db :rf.xray/column-widths)]]})))
+    (fn [db [_ table-id left-id left-px right-id right-px]]
+      (write-pair db table-id left-id left-px right-id right-px)))
+
+  (rf/reg-event-fx :rf.xray.column-widths/resize-pair-commit
+    {:rf.trace/no-emit? true}
+    (fn [{:keys [db]} _]
+      {:fx [[:rf.xray.column-widths/persist
+             (get db :rf.xray/column-widths)]]}))
 
   (rf/reg-event-fx :rf.xray.column-widths/reset
     {:rf.trace/no-emit? true}
@@ -321,16 +341,21 @@
         (let [left-px0  (.-offsetWidth left-el)
               right-px0 (.-offsetWidth right-el)
               start-x   (.-clientX ev)
+              ;; rf2-xm1jy — pointermove dispatches the no-persist
+              ;; tick; pointerup dispatches the commit (one
+              ;; localStorage write per drag, not one per pixel).
               on-move   (fn [m-ev]
                           (let [delta     (- (.-clientX m-ev) start-x)
                                 new-left  (max min-col-width-px (+ left-px0 delta))
                                 new-right (max min-col-width-px (- right-px0 delta))]
                             (rf/with-frame :rf/xray
-                              (rf/dispatch [:rf.xray.column-widths/resize-pair
+                              (rf/dispatch [:rf.xray.column-widths/resize-pair-tick
                                             table-id
                                             left-id new-left
                                             right-id new-right]))))
               on-up     (fn on-up [_]
+                          (rf/with-frame :rf/xray
+                            (rf/dispatch [:rf.xray.column-widths/resize-pair-commit]))
                           (.removeEventListener js/window "pointermove" on-move)
                           (.removeEventListener js/window "pointerup" on-up))]
           (.addEventListener js/window "pointermove" on-move)

--- a/tools/xray/test/day8/re_frame2_xray/diff/engine_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/diff/engine_cljs_test.cljc
@@ -220,3 +220,80 @@
       (is (= :modified (engine/op-at p [:user :name])))
       (is (= :removed  (engine/op-at p [:legacy-flag])))
       (is (contains? (:wholly-changed-roots p) [:flash])))))
+
+;; ---- expand-empty-root-replacement (rf2-5j7ch) ----------------------------
+
+(deftest expand-empty-root-replacement-empty-to-populated
+  (testing "rf2-5j7ch — `{} → {:counter 1}` collapses to a single
+            `:r []` Editscript edit which the engine surfaces as a
+            wholesale root-replacement flat-row. The renderer-facing
+            expansion lifts this into per-key `:added` rows so the
+            operator's `:diff` lens reads cold-boot epochs with
+            per-key granularity."
+    (let [proj     (engine/project {} {:counter 1 :user {:id 7}})
+          rows     (:flat-rows proj)
+          expanded (engine/expand-empty-root-replacement rows)]
+      (is (= 1 (count rows))
+          "engine emits ONE wholesale root replacement under Editscript")
+      (is (= [] (:path (first rows)))
+          "the wholesale row anchors at the root path")
+      (is (= [{:path [:counter] :op :added :before nil :after 1}
+              {:path [:user]    :op :added :before nil :after {:id 7}}]
+             expanded)
+          "expansion produces one :added row per top-level key, sorted
+           by path"))))
+
+(deftest expand-empty-root-replacement-populated-to-empty
+  (testing "rf2-5j7ch — inverse case: a populated map going to `{}`
+            expands into per-key `:removed` rows."
+    (let [proj     (engine/project {:counter 1 :user {:id 7}} {})
+          rows     (:flat-rows proj)
+          expanded (engine/expand-empty-root-replacement rows)]
+      (is (= [{:path [:counter] :op :removed :before 1        :after nil}
+              {:path [:user]    :op :removed :before {:id 7}  :after nil}]
+             expanded)))))
+
+(deftest expand-empty-root-replacement-non-empty-passes-through
+  (testing "rf2-5j7ch — two populated maps swapping wholesale (the
+            engine-stable root replacement case) is LEFT ALONE. The
+            operator sees one row anchored at `[]` because that DOES
+            read as a wholesale event."
+    (let [proj     (engine/project {:a 1} {:b 2})
+          rows     (:flat-rows proj)
+          expanded (engine/expand-empty-root-replacement rows)]
+      ;; Two populated maps with disjoint keys may surface as a
+      ;; wholesale root-replacement OR per-key add/remove rows
+      ;; depending on the Editscript A* choice. Either way the
+      ;; expansion MUST be a no-op (only the empty-side case is
+      ;; rewritten).
+      (is (= rows expanded)
+          "non-empty-side flat-rows pass through unchanged"))))
+
+(deftest expand-empty-root-replacement-non-root-modified-passes-through
+  (testing "rf2-5j7ch — a single :modified row at a NON-root path is
+            also passed through. The expansion only fires when a
+            single :modified row sits at the root path AND one side
+            is empty."
+    (let [rows [{:path [:counter] :op :modified :before 5 :after 6}]]
+      (is (= rows (engine/expand-empty-root-replacement rows))))))
+
+(deftest expand-empty-root-replacement-multiple-rows-passes-through
+  (testing "rf2-5j7ch — when the engine produces MORE than one flat-
+            row (e.g. several per-key adds + a removed) the
+            expansion bails: the operator already sees per-key rows."
+    (let [rows [{:path [:a] :op :added :before nil :after 1}
+                {:path [:b] :op :added :before nil :after 2}]]
+      (is (= rows (engine/expand-empty-root-replacement rows))))))
+
+(deftest expand-empty-root-replacement-end-to-end-via-engine
+  (testing "rf2-5j7ch — full pipeline check: engine/project →
+            :flat-rows → expand-empty-root-replacement produces the
+            per-key adds the operator's `:diff` lens consumes."
+    (let [proj     (engine/project {} {:state :idle :data {}})
+          expanded (engine/expand-empty-root-replacement (:flat-rows proj))
+          paths    (mapv :path expanded)
+          ops      (set (map :op expanded))]
+      (is (= [[:data] [:state]] paths)
+          "every top-level key surfaces as its own row, sorted by path")
+      (is (= #{:added} ops)
+          "empty-to-populated expansion produces only :added rows"))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -33,184 +33,40 @@
         grouping, timer reasons, guard outcomes)."
   (:require #?(:clj  [clojure.test :refer [deftest is testing]]
                :cljs [cljs.test    :refer-macros [deftest is testing]])
-            [day8.re-frame2-xray.panels.epoch.projection :as proj]))
+            [day8.re-frame2-xray.panels.epoch.projection :as proj]
+            ;; rf2-tyivx — canonical trace-event builders shared with
+            ;; the panel-gallery synth fixtures + any other projection
+            ;; test. Pre-rf2-tyivx every `*-ev` helper was duplicated
+            ;; per call site; the rf2-e0xjx cluster (rf2-yhgk8 /
+            ;; rf2-slnce / rf2-ipaza / rf2-w2r4p) is what happens when
+            ;; copies drift in lock-step. ONE canonical name set, one
+            ;; ns, one diff to land a substrate-side rename.
+            [day8.re-frame2-xray.test-helpers.trace-event-builders :as teb]))
 
-;; ---- fixture builders ----------------------------------------------------
+;; ---- local fixture aliases ----------------------------------------------
+;;
+;; Thin aliases over `teb/*` so existing call sites read identically to
+;; the pre-rf2-tyivx file. A single re-name lands in one place when the
+;; substrate emit shape rotates.
 
-(defn- ev
-  "Build a minimal trace event."
-  [op-type operation tags]
-  {:op-type   op-type
-   :operation operation
-   :tags      tags})
-
-(defn- dispatched-ev
-  ([event] (dispatched-ev event nil nil))
-  ([event source] (dispatched-ev event source nil))
-  ([event source coord]
-   (cond-> (ev :rf.event :rf.event/dispatched {:event event
-                                               :source source
-                                               :rf.trace/call-site coord})
-     true (assoc :event event :source source))))
-
-(defn- run-end-ev
-  ;; rf2-slnce — substrate stamps the handler's wall-clock duration
-  ;; as `:rf.event/elapsed-ms` on `:rf.event/run-end` (rf2-hhh92 ·
-  ;; `re-frame.router/emit-run-end-trace`). Fixture stamps the
-  ;; canonical name only; the reader's legacy fallbacks remain for
-  ;; older runtimes / external test fixtures.
-  ([] (run-end-ev nil nil))
-  ([duration-ms] (run-end-ev duration-ms nil))
-  ([duration-ms coeffects]
-   (ev :rf.event :rf.event/run-end (cond-> {:rf.event/elapsed-ms duration-ms}
-                                     coeffects (assoc :rf.event/coeffects
-                                                      coeffects)))))
-
-(defn- cofx-run-ev
-  ;; rf2-w2r4p — substrate stamps `:rf.cofx/elapsed-ms` on
-  ;; `:rf.cofx/run` (rf2-hhh92 · `re-frame.cofx`; spec 009 §243). The
-  ;; 3-arg form supplies a duration; the 2-arg legacy form omits it.
-  ([id value] (ev :rf.cofx :rf.cofx/run {:rf.cofx/id id :rf.cofx/value value}))
-  ([id value duration-ms]
-   (ev :rf.cofx :rf.cofx/run {:rf.cofx/id         id
-                              :rf.cofx/value      value
-                              :rf.cofx/elapsed-ms duration-ms})))
-
-(defn- db-changed-ev
-  [paths]
-  (ev :rf.event :rf.event/db-changed {:rf.event/db-changed-paths paths}))
-
-(defn- do-fx-ev
-  [fx]
-  (ev :rf.fx :rf.fx/do-fx {:rf.event/fx fx}))
-
-(defn- fx-handled-ev
-  ;; rf2-ipaza — substrate stamps the per-fx-handler invocation
-  ;; duration as `:rf.fx/elapsed-ms` on `:rf.fx/handled` (rf2-hhh92 ·
-  ;; `re-frame.fx`; spec 009 §241). Fixture stamps the canonical name
-  ;; only; the reader's legacy `:duration-ms` fallback remains for
-  ;; older runtimes / external test fixtures.
-  [fx-id args duration-ms]
-  (ev :rf.fx :rf.fx/handled {:rf.fx/id          fx-id
-                             :rf.fx/args        args
-                             :rf.fx/elapsed-ms  duration-ms}))
-
-(defn- flow-recomputed-ev
-  ;; rf2-yhgk8 — substrate stamps flow-recomputes under the
-  ;; `:rf.flow/computed` operation with bare `:flow-id`, `:path`,
-  ;; `:before`, `:result`, `:elapsed-ms` tags (Spec 009 §Flow trace
-  ;; events · `re-frame.flows`). Fixture mirrors substrate shape; the
-  ;; reader now reads against canonical names. Name retained as
-  ;; `flow-recomputed-ev` for call-site stability; the operation /
-  ;; tags are canonical.
-  [flow-id path before after]
-  (ev :rf.flow :rf.flow/computed {:flow-id flow-id
-                                  :path    path
-                                  :before  before
-                                  :result  after}))
-
-(defn- sub-run-ev
-  [sub-vec changed? before after]
-  ;; Per rf2-kfh1v the substrate stamps `:rf.sub/id`, `:rf.sub/query-v`,
-  ;; `:rf.sub/value-changed?`, `:rf.sub/prev-value`, `:rf.sub/value` —
-  ;; NOT the legacy `:rf.sub/query` / `:rf.sub/changed?` / `:rf.sub/before`
-  ;; the projection used to read. Fixture mirrors substrate shape.
-  (ev :rf.sub :rf.sub/run {:rf.sub/id             (when (vector? sub-vec) (first sub-vec))
-                           :rf.sub/query-v        sub-vec
-                           :rf.sub/value-changed? changed?
-                           :rf.sub/prev-value     before
-                           :rf.sub/value          after}))
-
-(defn- view-render-ev
-  ([view-id subs-read]
-   (view-render-ev view-id subs-read nil))
-  ([view-id subs-read elapsed-ms]
-   ;; Per rf2-6djth the substrate stamps the rich per-render marker as
-   ;; `:rf.view/rendered` (not `:rf.view/render`) with `:rf.view/id` +
-   ;; `:rf.view/deref-subs`. Fixture mirrors substrate shape.
-   (ev :rf.view :rf.view/rendered
-       (cond-> {:rf.view/id          view-id
-                :rf.view/deref-subs  subs-read}
-         (some? elapsed-ms)
-         (assoc :rf.view/elapsed-ms elapsed-ms)))))
-
-(defn- view-unmounted-ev
-  "`:rf.view/unmounted` trace event — drives the VIEWS step's
-  UNMOUNTED sub-section (rf2-gmw1i). Per
-  `re-frame.views/emit-view-unmounted!` the substrate stamps
-  `:rf.view/id` + `:rf.view/render-key` + `:frame`."
-  ([view-id]
-   (view-unmounted-ev view-id nil :rf/default))
-  ([view-id render-key frame]
-   (ev :rf.view :rf.view/unmounted
-       {:rf.view/id         view-id
-        :rf.view/render-key render-key
-        :frame              frame})))
-
-(defn- sub-dispose-ev
-  "`:rf.sub/dispose` trace event — drives the SUBSCRIPTIONS step's
-  DISPOSED sub-section (rf2-wpfjo). Per rf2-mrnur the substrate stamps
-  `:rf.sub/id` + `:rf.sub/query-v` + `:rf.sub/reason` + `:frame`
-  on every cache eviction site."
-  ([sub-vec reason]
-   (sub-dispose-ev sub-vec reason :rf/default))
-  ([sub-vec reason frame]
-   (ev :rf.sub :rf.sub/dispose
-       {:rf.sub/id      (when (vector? sub-vec) (first sub-vec))
-        :rf.sub/query-v sub-vec
-        :rf.sub/reason  reason
-        :frame          frame})))
-
-(defn- machine-transition-ev
-  ([machine-id before after]
-   (machine-transition-ev machine-id before after nil 0))
-  ([machine-id before after event microsteps]
-   (ev :rf.machine :rf.machine/transition
-       (cond-> {:machine-id machine-id
-                :before before
-                :after after}
-         event       (assoc :event event)
-         microsteps  (assoc :microsteps microsteps)))))
-
-(defn- machine-guard-ev
-  [guard-id outcome]
-  (ev :rf.machine :rf.machine/guard-evaluated {:guard-id guard-id
-                                               :outcome outcome}))
-
-(defn- machine-action-ev
-  ([action-id phase outcome]
-   (machine-action-ev action-id phase outcome nil))
-  ([action-id phase outcome data]
-   (ev :rf.machine :rf.machine/action-ran {:action-id action-id
-                                           :phase phase
-                                           :outcome outcome
-                                           :input {:data (or data {}) :event nil}})))
-
-(defn- machine-timer-cancel-ev
-  [machine-id state delay reason]
-  (ev :rf.machine :rf.machine.timer/cancelled {:machine-id machine-id
-                                               :state state
-                                               :delay delay
-                                               :reason reason}))
-
-(defn- schema-violation-ev
-  ([where failing-id path value]
-   (schema-violation-ev where failing-id path value nil))
-  ([where failing-id path value rollback?]
-   (ev :error :rf.error/schema-validation-failure
-       (cond-> {:where where
-                :failing-id failing-id
-                :path path
-                :value value}
-         (some? rollback?) (assoc :rollback? rollback?)))))
-
-(defn- schema-hot-reload-ev
-  [frame-id path mismatching-value]
-  (ev :warning :rf.schema/violation
-      {:frame frame-id
-       :path path
-       :mismatching-value mismatching-value
-       :recovery :logged-and-skipped}))
+(def ^:private ev                   teb/ev)
+(def ^:private dispatched-ev        teb/dispatched-ev)
+(def ^:private run-end-ev           teb/run-end-ev)
+(def ^:private cofx-run-ev          teb/cofx-run-ev)
+(def ^:private db-changed-ev        teb/db-changed-ev)
+(def ^:private do-fx-ev             teb/do-fx-ev)
+(def ^:private fx-handled-ev        teb/fx-handled-ev)
+(def ^:private flow-recomputed-ev   teb/flow-recomputed-ev)
+(def ^:private sub-run-ev           teb/sub-run-ev)
+(def ^:private view-render-ev       teb/view-rendered-ev)
+(def ^:private view-unmounted-ev    teb/view-unmounted-ev)
+(def ^:private sub-dispose-ev       teb/sub-dispose-ev)
+(def ^:private machine-transition-ev   teb/machine-transition-ev)
+(def ^:private machine-guard-ev        teb/machine-guard-ev)
+(def ^:private machine-action-ev       teb/machine-action-ev)
+(def ^:private machine-timer-cancel-ev teb/machine-timer-cancel-ev)
+(def ^:private schema-violation-ev     teb/schema-violation-ev)
+(def ^:private schema-hot-reload-ev    teb/schema-hot-reload-ev)
 
 (defn- record
   "Build a synthetic `:rf/epoch-record` for projection."

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/real_substrate_projection_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/real_substrate_projection_cljs_test.cljs
@@ -1,0 +1,137 @@
+(ns day8.re-frame2-xray.panels.epoch.real-substrate-projection-cljs-test
+  "End-to-end projection test driven by REAL substrate `trace/emit!`
+  events (rf2-tyivx).
+
+  ## Why
+
+  The synth-fixture projection tests at
+  `projection_cljs_test.cljc` exercise the reader against literal
+  trace-event maps the test author types. If the SUBSTRATE rotates
+  the emit names (rf2-yhgk8 / rf2-slnce / rf2-ipaza / rf2-w2r4p
+  rotated `:rf.flow/computed`, `:rf.event/elapsed-ms`,
+  `:rf.fx/elapsed-ms`, `:rf.cofx/elapsed-ms` all at once), the
+  fixtures + reader can drift together — both wrong, both consistent,
+  both green.
+
+  This test forecloses that drift class: it dispatches an event
+  through the LIVE substrate, captures the trace stream Xray's ring
+  buffer recorded, feeds it through `proj/project`, and asserts the
+  projection lit up the expected steps. If a substrate-side rename
+  ever drops a `:rf.cofx/run` emit on the floor (or stamps a new
+  operation name the reader doesn't match), the COEFFECT step
+  disappears from the projection here — the test goes red against
+  reality, not against a stale synth fixture.
+
+  ## What's exercised
+
+  - DISPATCH row — the substrate's `:rf.event/dispatched` emit.
+  - HANDLER     — the substrate's `:rf.event/run-end` emit (carries
+                  the canonical `:rf.event/elapsed-ms` tag); the
+                  HANDLER row's `:db-diff` slot is driven by the
+                  substrate's `:rf.event/db-changed` emit (canonical
+                  `:rf.event/db-changed-paths` tag).
+
+  COEFFECTs / FX / FLOW / SUBSCRIPTIONS / VIEWS are NOT exercised
+  here (each would require a non-trivial registration / mount /
+  substrate sub recompute). The cascade above is the minimum surface
+  that proves the reader is canonically aligned with substrate emit
+  reality; per-emit canonical-name pinning lives in the synth-fixture
+  projection tests."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-xray.panels.epoch.projection :as proj]
+            [day8.re-frame2-xray.preload :as preload]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.trace-collector :as trace-collector]))
+
+;; ---- fixture -----------------------------------------------------------
+
+(defn- xray-init! []
+  (preload/reset-for-test!)
+  (registry/reset-for-test!)
+  (trace-collector/reset-for-test!))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn xray-init!}))
+
+(defn- setup! []
+  (registry/register-xray-handlers!)
+  (frame/reg-frame :rf/xray {})
+  ;; Activate the trace-collector so `trace/emit!` calls land in
+  ;; Xray's ring buffer.
+  (preload/register-trace-collector!))
+
+;; ---- handler -----------------------------------------------------------
+
+(defn- register-counter-handler! []
+  (rf/reg-event-db
+    :rf.tyivx/counter-inc
+    (fn [db [_ amount]]
+      (update db :counter (fnil + 0) (or amount 1)))))
+
+;; ---- end-to-end ---------------------------------------------------------
+
+(deftest real-substrate-emits-project-to-dispatch+handler
+  (testing "rf2-tyivx — REAL substrate emits drive the projection.
+            One dispatch through a registered handler must produce
+            at least the DISPATCH + HANDLER steps; the HANDLER step's
+            `:db-diff` slot must carry the substrate's
+            `:rf.event/db-changed-paths`. If the substrate rotates an
+            emit name + the reader doesn't follow, the step / slot
+            disappears here."
+    (setup!)
+    (register-counter-handler!)
+    (rf/dispatch-sync [:rf.tyivx/counter-inc 1])
+    (let [buf         (vec (trace-collector/buffer-for-test))
+          dispatched? (some #(and (= :rf.event (:op-type %))
+                                  (= :rf.event/dispatched (:operation %)))
+                            buf)
+          run-end?    (some #(and (= :rf.event (:op-type %))
+                                  (= :rf.event/run-end (:operation %)))
+                            buf)
+          db-changed? (some #(and (= :rf.event (:op-type %))
+                                  (= :rf.event/db-changed (:operation %)))
+                            buf)]
+      (is dispatched?
+          "substrate emitted `:rf.event/dispatched` — the projection
+           reader keys on this operation name; a rename here would
+           drop the DISPATCH row")
+      (is run-end?
+          "substrate emitted `:rf.event/run-end` — drives the HANDLER
+           duration read; a rename here would drop the handler row")
+      (is db-changed?
+          "substrate emitted `:rf.event/db-changed` — drives the
+           HANDLER step's `:db-diff` slot; a rename here would drop
+           the diff annotation")
+      ;; Now feed the captured cascade through the projection. The
+      ;; record's :trace-events vector mirrors what the Xray epoch
+      ;; recorder would store for this dispatch.
+      (let [record    {:epoch-id      1
+                       :event-id      :rf.tyivx/counter-inc
+                       :trigger-event [:rf.tyivx/counter-inc 1]
+                       :dispatch-id   1
+                       :trace-events  buf}
+            projected (proj/project record)
+            steps     (set (map :step projected))]
+        (is (contains? steps :dispatch)
+            "DISPATCH step present — projection matched the
+             substrate's `:rf.event/dispatched` operation name")
+        (is (contains? steps :handler)
+            "HANDLER step present — projection matched the
+             substrate's `:rf.event/run-end` operation name")
+        ;; Find the HANDLER step and assert its `:db-diff` slot is
+        ;; populated. The projection reads `:rf.event/db-changed-paths`
+        ;; off the substrate's `:rf.event/db-changed` emit — both
+        ;; canonical names must align with substrate reality.
+        (let [handler-step (first (filter #(= :handler (:step %)) projected))]
+          (is (some? handler-step) "HANDLER step row exists")
+          (is (some? (:db-diff handler-step))
+              "HANDLER `:db-diff` slot carries data from the
+               substrate's `:rf.event/db-changed-paths` tag. If this
+               fails after a substrate-side rename, the synth fixtures
+               will still be green — pin the canonical names here."))))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/machines/topology_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machines/topology_cljs_test.cljs
@@ -565,6 +565,43 @@
       (is (not (contains? (:data to-ready) :after))
           "`:always` edge does not also carry `:after`"))))
 
+;; ---- rf2-2678t: :* wildcard label parity with machines-viz canonical ----
+;;
+;; Pre-rf2-2678t xray's local `event-segment-str` was a strict subset of
+;; the canonical `machines-viz/chart.layout/event-segment` — it lacked
+;; the `:*` → `\"* (any)\"` case. Post-fix the local helper delegates to
+;; the canonical fn, so wildcard edges label identically in xray and
+;; machines-viz (no glyph-convention drift).
+
+(deftest parse-definition-emits-edge-for-wildcard-event
+  (testing "rf2-2678t — `:on {:* :elsewhere}` (Spec 005 §Wildcard) emits
+            an edge labelled `\"* (any)\"`, matching the canonical
+            machines-viz layout helper. Pre-fix the label was bare
+            `\"*\"` — a strict subset of the canonical."
+    (let [def {:initial :a
+               :states  {:a {:on {:* :fallback}}
+                         :fallback {}}}
+          {:keys [edges]} (topology/parse-definition def)]
+      (is (= 1 (count edges)))
+      (let [e (first edges)]
+        (is (= :* (:event e))
+            "the wildcard event is recorded verbatim on the edge")
+        (is (= "* (any)" (:label e))
+            "label matches machines-viz convention (NOT bare `\"*\"`)")))))
+
+(deftest wildcard-label-matches-machines-viz-canonical
+  (testing "rf2-2678t — xray's edge label for `:*` must equal what
+            machines-viz produces for the same input. Single source of
+            truth lives in machines-viz/chart.layout/event-segment."
+    (let [def {:initial :a
+               :states  {:a {:on {:* :fallback}}
+                         :fallback {}}}
+          {:keys [edges]} (topology/parse-definition def)
+          xray-label    (-> edges first :label)
+          mviz-label    (chart-layout/event-segment {:event :*})]
+      (is (= xray-label mviz-label)
+          "xray + machines-viz agree on the wildcard edge label"))))
+
 (deftest project-includes-arrowhead-for-always-and-after
   (testing "rf2-ezqpm — every projected edge (including `:always` /
             `:after`) requests an arrowclosed markerEnd (rf2-5qsxo)"

--- a/tools/xray/test/day8/re_frame2_xray/panels/reactivity/app_db_diff_reactivity_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/reactivity/app_db_diff_reactivity_cljs_test.cljs
@@ -77,15 +77,15 @@
     (h/seed-epoch-history! epoch-history)
     (h/focus-cascade! :c1)
     (let [diff-1 (h/read-sub :rf.xray/selected-epoch-diff)]
-      ;; rf2-xuyac — universal 4-tuple `[path before after op]` shape
-      ;; (post-migration to `diff/engine.cljc`'s `:flat-rows`). The
-      ;; `{} → {:counter 1}` cascade collapses to a single root-level
-      ;; replacement (`:r []`) under Editscript A* — empty-to-populated
-      ;; map is one edit at the root, not per-key adds. Mode-3 paints
-      ;; the same row from `:path-ops`, so the two lenses agree.
-      (is (= [[[] {} {:counter 1} :modified]]
+      ;; rf2-5j7ch — the App-DB `:diff` sub post-processes the
+      ;; wholesale root-replacement that Editscript emits for
+      ;; `{} → {populated}` into per-key adds. Operator UX wants the
+      ;; per-key view for cold-boot epochs ("what landed?") rather
+      ;; than the engine-stable single-row root replacement. Non-
+      ;; empty-side replacements still surface wholesale.
+      (is (= [[[:counter] nil 1 :added]]
              diff-1)
-          ":e1's diff — root replacement {} → {:counter 1}")
+          ":e1's diff — empty-to-populated expands to per-key adds")
       (h/focus-cascade! :c2)
       (let [diff-2 (h/read-sub :rf.xray/selected-epoch-diff)]
         (is (= [[[:counter] 1 2 :modified]]

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -426,13 +426,16 @@
    ;; Issues panel's filter-chrome reconcile to the Figma design (pure
    ;; rows, no filtering — spec/021 §8.2).
    :rf.xray/add-filter
-   ;; rf2-uji72 — shared draggable column-resize events. `resize-pair`
-   ;; updates both adjacent column widths in one writeback so the
-   ;; sum is conserved; `reset` clears all overrides for a table.
+   ;; rf2-uji72 — shared draggable column-resize events. `resize-pair-
+   ;; tick` updates both adjacent column widths in one writeback so the
+   ;; sum is conserved; `resize-pair-commit` (rf2-xm1jy) persists the
+   ;; settled widths to localStorage exactly once on pointerup;
+   ;; `reset` clears all overrides for a table.
    ;; rf2-xzg1y — `hydrate` lifts the persisted column-widths map from
    ;; localStorage into app-db at first-mount time.
    :rf.xray.column-widths/hydrate
-   :rf.xray.column-widths/resize-pair
+   :rf.xray.column-widths/resize-pair-commit
+   :rf.xray.column-widths/resize-pair-tick
    :rf.xray.column-widths/reset
    ;; rf2-59e7k — Cancellation-cascade visualiser events. Per
    ;; `tools/xray/spec/019-Cross-Cutting-Insight.md` §M.3.

--- a/tools/xray/test/day8/re_frame2_xray/settings/editor_override_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/settings/editor_override_cljs_test.cljs
@@ -201,20 +201,46 @@
 ;; ---- robustness --------------------------------------------------------
 
 (deftest invalid-override-shape-degrades-to-host-default
-  (testing "A persisted override that is neither a keyword nor a
-            map (e.g. legacy payload corruption) does NOT crash
-            `get-editor`. Stored values that pass `update-setting!`
-            today come through the picker which only writes nil /
-            enumerated keywords / `{:custom ...}` maps — this test
-            covers the defensive read for unexpected payloads."
+  (testing "rf2-a1tv6 — a persisted override that fails
+            `valid-editor-override?` (corrupted localStorage payload,
+            hand-edit, stale experimental shape) falls back to the
+            host default on read. `get-editor` filters the slot
+            through the predicate so a malformed value can never
+            reach the URI builder."
     (config/set-editor! :idea)
-    ;; Force an invalid value in directly to bypass the picker.
+    ;; Force an invalid value in directly to bypass the picker (which
+    ;; is the single writer that today enforces the shape contract).
     (swap! config/settings assoc-in [:general :editor-override] "not-a-keyword")
-    ;; The `or` in `get-editor` returns truthy values straight back —
-    ;; the chip would render with `(name override)` and fall through
-    ;; to editor-uri's unknown-keyword path (which yields :vscode).
-    ;; Pin the contract: an unexpected truthy value DOES win, so the
-    ;; picker is the single writer to keep the shape sane.
-    (is (= "not-a-keyword" (config/get-editor))
-        "any truthy override wins; the picker is the single writer
-         that enforces the shape contract")))
+    (is (= :idea (config/get-editor))
+        "invalid override degrades to the host default")
+    ;; Empty-template :custom is also rejected (the picker's seed
+    ;; window — see rf2-rc35g — would otherwise leak through here).
+    (swap! config/settings assoc-in [:general :editor-override] {:custom ""})
+    (is (= :idea (config/get-editor))
+        "empty :custom template is rejected; host default wins")
+    ;; Maps without :custom string also fall back.
+    (swap! config/settings assoc-in [:general :editor-override] {:something 1})
+    (is (= :idea (config/get-editor))
+        "map without valid :custom string is rejected")))
+
+(deftest valid-editor-override?-predicate-coverage
+  (testing "rf2-a1tv6 — the predicate accepts exactly the shapes
+            `set-editor!` accepts (modulo nil for cleared)."
+    (is (config/valid-editor-override? nil))
+    (is (config/valid-editor-override? :vscode))
+    (is (config/valid-editor-override? :cursor))
+    (is (config/valid-editor-override? :idea))
+    (is (config/valid-editor-override? :zed))
+    (is (config/valid-editor-override? :windsurf))
+    (is (config/valid-editor-override?
+          {:custom "subl://open?url=file://{path}&line={line}"}))
+    (is (not (config/valid-editor-override? "string-keyword")))
+    (is (not (config/valid-editor-override? :unknown-editor)))
+    (is (not (config/valid-editor-override? {:custom ""}))
+        "empty :custom template is invalid (rf2-rc35g)")
+    (is (not (config/valid-editor-override? {:custom 42}))
+        ":custom must be a string")
+    (is (not (config/valid-editor-override? [:vscode]))
+        "vector wrappers reject")
+    (is (not (config/valid-editor-override? 42))
+        "scalars reject")))

--- a/tools/xray/test/day8/re_frame2_xray/settings/popup_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/settings/popup_cljs_test.cljs
@@ -25,6 +25,7 @@
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.settings.popup :as popup]
+            [day8.re-frame2-xray.settings.view :as view]
             [day8.re-frame2-xray.test-support :as xray-test-support]
             [day8.re-frame2-xray.trace-collector :as trace-collector]))
 
@@ -223,6 +224,26 @@
         (is (find-by-testid rendered "rf-xray-settings-editor-override-custom-input")
             "custom template input renders once the override is the
              :custom shape")))))
+
+(deftest editor-override-custom-radio-seeds-working-template
+  (testing "rf2-rc35g — the Custom radio's seed value (used when the
+            user first selects Custom with no prior template) is a
+            working vscode-style URI rather than `{:custom \"\"}`.
+            Pre-fix, click-to-source silently no-op'd until the user
+            finished typing the template; the seed makes the override
+            resolve to a valid URI immediately so the user edits from
+            a known baseline."
+    (let [seed @#'view/custom-template-seed]
+      (is (string? seed) "the seed is a string")
+      (is (not= "" seed)
+          "the seed is NOT the empty string (rf2-rc35g — empty
+           templates break click-to-source)")
+      (is (= "vscode://file/{path}:{line}:{column}" seed)
+          "the seed echoes the framework-default :vscode URI shape so
+           the chip resolves to a working URI immediately")
+      (is (config/valid-editor-override? {:custom seed})
+          "the seeded `{:custom <seed>}` shape passes the read-side
+           validator (rf2-a1tv6)"))))
 
 (deftest editor-override-default-radio-is-checked-on-fresh-install
   (testing "rf2-dudqz — with no override, the '(project default)'

--- a/tools/xray/test/day8/re_frame2_xray/test_helpers/trace_event_builders.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/test_helpers/trace_event_builders.cljc
@@ -1,0 +1,333 @@
+(ns day8.re-frame2-xray.test-helpers.trace-event-builders
+  "Canonical trace-event builders for Xray fixtures + projection tests
+  (rf2-tyivx).
+
+  ## Why one ns
+
+  Pre-rf2-tyivx the per-trace-event constructors (`cofx-run-ev`,
+  `fx-handled-ev`, `flow-recomputed-ev`, `view-rendered-ev`, etc.)
+  were duplicated between:
+
+    - `tools/xray/testbeds/panel_gallery/fixtures_epoch.cljs` (gallery
+      synth fixtures)
+    - `tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc`
+      (projection unit tests)
+    - the various substrate-side test fixtures that drive other
+      projection-adjacent tests.
+
+  Drift between copies caused the rf2-e0xjx cluster (rf2-yhgk8 /
+  rf2-slnce / rf2-ipaza / rf2-w2r4p): the substrate canonical emit
+  names rotated and the fixtures + projection reader changed in
+  lock-step — both wrong, both consistent, both silently broken in
+  any test that didn't also rotate. A single shared builder ns is the
+  forcing function that keeps fixtures + projection reader pinned to
+  ONE substrate-canonical name set.
+
+  ## Scope
+
+  Every builder mirrors the substrate emit-site shape one-for-one
+  (the same shape `re-frame.cofx` / `re-frame.fx` / `re-frame.flows`
+  / `re-frame.views` etc. stamp through `trace/emit!`). Adding a new
+  builder here is the right move whenever a new substrate emit shape
+  needs fixture coverage. Builders are pure-data and CLJC — call from
+  CLJS test files AND CLJ test files alike.
+
+  The companion ns
+  `day8.re-frame2-xray.test-helpers.real-substrate-projection-cljs-test`
+  (rf2-tyivx end-to-end coverage) drives a REAL `trace/emit!`
+  invocation against the substrate so a substrate-side rename can
+  never silently desync from the synth fixtures again.
+
+  ## Glossary
+
+  | Builder                        | Operation                              | Drives                              |
+  | ------------------------------ | -------------------------------------- | ----------------------------------- |
+  | `ev`                           | (low-level)                            | every other builder                 |
+  | `dispatched-ev`                | `:rf.event/dispatched`                 | DISPATCH row                        |
+  | `cofx-run-ev`                  | `:rf.cofx/run`                         | COEFFECT step                       |
+  | `run-end-ev`                   | `:rf.event/run-end`                    | HANDLER duration                    |
+  | `db-changed-ev`                | `:rf.event/db-changed`                 | APP-DB DIFF step                    |
+  | `do-fx-ev`                     | `:rf.fx/do-fx`                         | FX per-row attribution              |
+  | `fx-handled-ev`                | `:rf.fx/handled`                       | FX per-row outcome                  |
+  | `flow-recomputed-ev`           | `:rf.flow/computed`                    | FLOW step (one row per flow)        |
+  | `sub-run-ev`                   | `:rf.sub/run`                          | SUBSCRIPTIONS step                  |
+  | `sub-dispose-ev`               | `:rf.sub/dispose`                      | SUBSCRIPTIONS DISPOSED sub-section  |
+  | `view-rendered-ev`             | `:rf.view/rendered`                    | VIEWS step                          |
+  | `view-unmounted-ev`            | `:rf.view/unmounted`                   | VIEWS UNMOUNTED sub-section         |
+  | `machine-transition-ev`        | `:rf.machine/transition`               | HANDLER machine cascade             |
+  | `machine-guard-ev`             | `:rf.machine/guard-evaluated`          | HANDLER GUARDS                      |
+  | `machine-action-ev`            | `:rf.machine/action-ran`               | HANDLER LIFECYCLE                   |
+  | `machine-timer-cancel-ev`      | `:rf.machine.timer/cancelled`          | HANDLER AFTER-TIMERS                |
+  | `schema-violation-ev`          | `:rf.error/schema-validation-failure`  | SCHEMA VIOLATIONS                   |
+  | `schema-hot-reload-ev`         | `:rf.schema/violation`                 | SCHEMA HOT-RELOAD                   |"
+  (:refer-clojure :exclude [ev]))
+
+;; ---- low-level primitive -----------------------------------------------
+
+(defn ev
+  "Minimal trace-event map. `op-type` is the broad classifier
+  (`:rf.event / :rf.fx / :rf.sub / :rf.view / :rf.machine / …`),
+  `operation` the precise emit op the projection reader keys on."
+  [op-type operation tags]
+  {:op-type   op-type
+   :operation operation
+   :tags      tags})
+
+;; ---- dispatch + handler-frame ------------------------------------------
+
+(defn dispatched-ev
+  "`:rf.event/dispatched` trace — drives the DISPATCH row. Carries
+  the substrate-canonical `:rf.event/v` (event vector) + `:source` +
+  optional `:rf.trace/call-site`. The top-level `:event` + `:source`
+  slots are also stamped for legacy reader paths that match on the
+  outer shape (projection_cljs_test.cljc reads these)."
+  ([event] (dispatched-ev event nil nil))
+  ([event source] (dispatched-ev event source nil))
+  ([event source coord]
+   (cond-> (ev :rf.event :rf.event/dispatched
+               {:rf.event/v         event
+                :source             source
+                :rf.trace/call-site coord})
+     true (assoc :event event :source source))))
+
+(defn run-end-ev
+  "`:rf.event/run-end` trace — the projection reads the handler's
+  finalised duration here.
+
+  rf2-slnce — substrate stamps the canonical `:rf.event/elapsed-ms`
+  (rf2-hhh92 · `re-frame.router/emit-run-end-trace`); fixture mirrors
+  that shape. Reader retains a legacy `:duration-ms` fallback for
+  older runtimes / external test fixtures."
+  ([] (run-end-ev nil nil))
+  ([duration-ms] (run-end-ev duration-ms nil))
+  ([duration-ms coeffects]
+   (ev :rf.event :rf.event/run-end
+       (cond-> {:rf.event/elapsed-ms duration-ms}
+         coeffects (assoc :rf.event/coeffects coeffects)))))
+
+;; ---- coeffects ---------------------------------------------------------
+
+(defn cofx-run-ev
+  "`:rf.cofx/run` trace — one per USER-injected coeffect (system
+  cofx `:db / :event / :frame / :source / :trace-id` are filtered out
+  by the projection per rf2-cq0ch). The 3-arg form supplies a
+  duration; the 2-arg legacy form omits it.
+
+  rf2-w2r4p — substrate stamps the canonical `:rf.cofx/elapsed-ms`
+  duration tag (rf2-hhh92 · `re-frame.cofx`; spec 009 §243)."
+  ([id value]
+   (ev :rf.cofx :rf.cofx/run {:rf.cofx/id    id
+                              :rf.cofx/value value}))
+  ([id value duration-ms]
+   (ev :rf.cofx :rf.cofx/run {:rf.cofx/id         id
+                              :rf.cofx/value      value
+                              :rf.cofx/elapsed-ms duration-ms})))
+
+;; ---- db-changed --------------------------------------------------------
+
+(defn db-changed-ev
+  "`:rf.event/db-changed` trace — drives both HANDLER's `:db-diff`
+  slot AND the APP-DB DIFF step. `paths` is a vec of
+  `[path before after change-kind]` quads."
+  [paths]
+  (ev :rf.event :rf.event/db-changed
+      {:rf.event/db-changed-paths paths}))
+
+;; ---- fx ----------------------------------------------------------------
+
+(defn do-fx-ev
+  "`:rf.fx/do-fx` trace — carries the handler's returned `:rf.event/fx`
+  payload. Drives the FX step's per-row attribution AND the CHILD-
+  DISPATCHES step (rf2-yx1ae harvests dispatch-family fx from this
+  same payload)."
+  [fx]
+  (ev :rf.fx :rf.fx/do-fx {:rf.event/fx fx}))
+
+(defn fx-handled-ev
+  "`:rf.fx/handled` trace — one per fx-handler invocation. FX per-row
+  outcome chrome reads `:rf.fx/id` + `:rf.fx/args` +
+  `:rf.fx/elapsed-ms` here.
+
+  rf2-ipaza — substrate stamps the canonical `:rf.fx/elapsed-ms`
+  (rf2-hhh92 · `re-frame.fx`; spec 009 §241)."
+  [fx-id args duration-ms]
+  (ev :rf.fx :rf.fx/handled {:rf.fx/id         fx-id
+                             :rf.fx/args       args
+                             :rf.fx/elapsed-ms duration-ms}))
+
+;; ---- flows -------------------------------------------------------------
+
+(defn flow-recomputed-ev
+  "`:rf.flow/computed` trace — drives the FLOW step.
+
+  rf2-yhgk8 — substrate stamps the `:rf.flow/computed` operation with
+  bare `:flow-id` / `:path` / `:before` / `:result` / `:elapsed-ms`
+  tags (Spec 009 §Flow trace events · `re-frame.flows`). The name
+  `flow-recomputed-ev` is retained for call-site stability; the
+  payload is canonical.
+
+  4-arg legacy form omits the elapsed-ms tag; 5-arg form stamps it."
+  ([flow-id path before after]
+   (ev :rf.flow :rf.flow/computed {:flow-id flow-id
+                                   :path    path
+                                   :before  before
+                                   :result  after}))
+  ([flow-id path before after elapsed-ms]
+   (ev :rf.flow :rf.flow/computed {:flow-id    flow-id
+                                   :path       path
+                                   :before     before
+                                   :result     after
+                                   :elapsed-ms elapsed-ms})))
+
+;; ---- subscriptions -----------------------------------------------------
+
+(defn sub-run-ev
+  "`:rf.sub/run` trace — drives one SUBSCRIPTIONS row. Per rf2-kfh1v
+  the canonical tag names are `:rf.sub/id`, `:rf.sub/query-v`,
+  `:rf.sub/value-changed?`, `:rf.sub/prev-value`, `:rf.sub/value` —
+  the projection reads ONLY these post-rf2-kfh1v.
+
+  4-arg form omits an elapsed-ms tag; 5-arg form stamps it."
+  ([sub-vec changed? before after]
+   (ev :rf.sub :rf.sub/run
+       {:rf.sub/id             (when (vector? sub-vec) (first sub-vec))
+        :rf.sub/query-v        sub-vec
+        :rf.sub/value-changed? changed?
+        :rf.sub/prev-value     before
+        :rf.sub/value          after}))
+  ([sub-vec changed? before after elapsed-ms]
+   (ev :rf.sub :rf.sub/run
+       {:rf.sub/id             (when (vector? sub-vec) (first sub-vec))
+        :rf.sub/query-v        sub-vec
+        :rf.sub/value-changed? changed?
+        :rf.sub/prev-value     before
+        :rf.sub/value          after
+        :rf.sub/elapsed-ms     elapsed-ms})))
+
+(defn sub-dispose-ev
+  "`:rf.sub/dispose` trace — drives the SUBSCRIPTIONS DISPOSED sub-
+  section (rf2-wpfjo). Per rf2-mrnur substrate stamps `:rf.sub/id` +
+  `:rf.sub/query-v` + `:rf.sub/reason` + `:frame` on every cache-
+  eviction site (closed `:reason` set per rf2-mrnur:
+  `:no-more-derefers / :hot-reload / :cache-clear`)."
+  ([sub-vec reason]
+   (sub-dispose-ev sub-vec reason :rf/default))
+  ([sub-vec reason frame]
+   (ev :rf.sub :rf.sub/dispose
+       {:rf.sub/id      (when (vector? sub-vec) (first sub-vec))
+        :rf.sub/query-v sub-vec
+        :rf.sub/reason  reason
+        :frame          frame})))
+
+;; ---- views -------------------------------------------------------------
+
+(defn view-rendered-ev
+  "`:rf.view/rendered` trace (per rf2-6djth — NOT the simpler
+  `:rf.view/render` marker; only `:rf.view/rendered` carries
+  `:rf.view/id` + `:rf.view/deref-subs` + `:rf.view/elapsed-ms`).
+
+  Two-arg form omits elapsed-ms; three-arg stamps it."
+  ([view-id deref-subs]
+   (view-rendered-ev view-id deref-subs nil))
+  ([view-id deref-subs elapsed-ms]
+   (ev :rf.view :rf.view/rendered
+       (cond-> {:rf.view/id         view-id
+                :rf.view/deref-subs deref-subs}
+         (some? elapsed-ms)
+         (assoc :rf.view/elapsed-ms elapsed-ms)))))
+
+(defn view-unmounted-ev
+  "`:rf.view/unmounted` trace — drives the VIEWS UNMOUNTED sub-section
+  (rf2-gmw1i). Per `re-frame.views/emit-view-unmounted!` the substrate
+  stamps `:rf.view/id` + `:rf.view/render-key` + `:frame`."
+  ([view-id]
+   (view-unmounted-ev view-id nil :rf/default))
+  ([view-id render-key frame]
+   (ev :rf.view :rf.view/unmounted
+       {:rf.view/id         view-id
+        :rf.view/render-key render-key
+        :frame              frame})))
+
+;; ---- machine handler ---------------------------------------------------
+
+(defn machine-transition-ev
+  "`:rf.machine/transition` trace — drives the HANDLER step's
+  machine TRANSITION sub-section + the DATA-REDUCTION /
+  SNAPSHOT-DIFF projections (rf2-u69j7). `before` + `after` are full
+  machine snapshot maps (`:state` + `:data` + …)."
+  ([machine-id before after]
+   (machine-transition-ev machine-id before after nil 0))
+  ([machine-id before after event microsteps]
+   (ev :rf.machine :rf.machine/transition
+       (cond-> {:machine-id machine-id
+                :before     before
+                :after      after}
+         event      (assoc :event event)
+         microsteps (assoc :microsteps microsteps)))))
+
+(defn machine-guard-ev
+  "`:rf.machine/guard-evaluated` trace — drives the HANDLER step's
+  GUARDS sub-section (one row per guard, with outcome
+  `:pass / :fail / :threw`)."
+  [guard-id outcome]
+  (ev :rf.machine :rf.machine/guard-evaluated
+      {:guard-id guard-id
+       :outcome  outcome}))
+
+(defn machine-action-ev
+  "`:rf.machine/action-ran` trace — drives the HANDLER step's
+  LIFECYCLE sub-section (one row per action, grouped by `:phase` per
+  rf2-82a0u). Optional `:outcome :fx` rides the rf2-9c27r per-action
+  fx attribution."
+  ([action-id phase outcome]
+   (machine-action-ev action-id phase outcome nil))
+  ([action-id phase outcome data]
+   (ev :rf.machine :rf.machine/action-ran
+       {:action-id action-id
+        :phase     phase
+        :outcome   outcome
+        :input     {:data  (or data {})
+                    :event nil}})))
+
+(defn machine-timer-cancel-ev
+  "`:rf.machine.timer/cancelled` trace — drives the HANDLER step's
+  AFTER-TIMERS sub-section (one row per cancelled timer with
+  `:reason` in the unified rf2-82a0u set)."
+  [machine-id state delay reason]
+  (ev :rf.machine :rf.machine.timer/cancelled
+      {:machine-id machine-id
+       :state      state
+       :delay      delay
+       :reason     reason}))
+
+;; ---- schema ------------------------------------------------------------
+
+(defn schema-violation-ev
+  "`:rf.error/schema-validation-failure` trace (rf2-17vxj) — the
+  runtime per-event boundary check (`:where` in
+  `:app-db / :cofx / :sub-return / :fx-args`). Drives the SCHEMA
+  VIOLATIONS step.
+
+  4-arg form omits the rollback flag; 5-arg form stamps it."
+  ([where failing-id path value]
+   (schema-violation-ev where failing-id path value nil))
+  ([where failing-id path value rollback?]
+   (ev :error :rf.error/schema-validation-failure
+       (cond-> {:where      where
+                :failing-id failing-id
+                :path       path
+                :value      value}
+         (some? rollback?) (assoc :rollback? rollback?)))))
+
+(defn schema-hot-reload-ev
+  "`:rf.schema/violation` trace (rf2-17vxj) — the hot-reload drift
+  check fires when a re-registration changed the schema at a
+  `(frame-id, path)` AND the live `app-db` value at `path` fails the
+  new schema. Distinct from the runtime per-event failure; rides on
+  the standalone SCHEMA HOT-RELOAD tail step (rf2-xgeag · Option A)."
+  [frame-id path mismatching-value]
+  (ev :warning :rf.schema/violation
+      {:frame             frame-id
+       :path              path
+       :mismatching-value mismatching-value
+       :recovery          :logged-and-skipped}))

--- a/tools/xray/test/day8/re_frame2_xray/views/diff_mode_toggle_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/diff_mode_toggle_cljs_test.cljs
@@ -263,6 +263,52 @@
                    tree "rf-xray-test-diff-mode-full-with-diff"))
           "omitted modes do not paint"))))
 
+;; ---- (7b) on-click closure identity is stable across renders (rf2-a7vkv) ----
+
+(deftest diff-mode-toggle-on-click-identity-stable-across-renders
+  (testing "rf2-a7vkv — `make-on-click` is `memoize`-cached on
+            `[on-change m]`, so two renders of the toggle with the
+            same `on-change` reference yield BYTE-IDENTICAL :on-click
+            handlers per button. React's reconciler skips re-writing
+            the DOM onclick prop when function identity matches."
+    (let [on-change (fn [_])
+          render1 (widget/diff-mode-toggle
+                    {:mode :diff
+                     :on-change on-change
+                     :testid "rf-xray-test-diff-mode"})
+          render2 (widget/diff-mode-toggle
+                    {:mode :diff
+                     :on-change on-change
+                     :testid "rf-xray-test-diff-mode"})
+          h1 (:on-click (second
+                          (th/find-by-testid
+                            render1 "rf-xray-test-diff-mode-diff")))
+          h2 (:on-click (second
+                          (th/find-by-testid
+                            render2 "rf-xray-test-diff-mode-diff")))]
+      (is (identical? h1 h2)
+          "same on-change + same mode kw → cached on-click handler
+           reused across renders"))))
+
+(deftest diff-mode-toggle-on-click-identity-differs-per-mode
+  (testing "rf2-a7vkv — the memoise key is `[on-change m]` so each
+            mode kw gets its own cached handler. Two buttons in the
+            SAME render must have DIFFERENT on-click identities, else
+            clicking :full would dispatch :diff."
+    (let [on-change (fn [_])
+          tree (widget/diff-mode-toggle
+                 {:mode :diff
+                  :on-change on-change
+                  :testid "rf-xray-test-diff-mode"})
+          h-diff (:on-click (second
+                              (th/find-by-testid
+                                tree "rf-xray-test-diff-mode-diff")))
+          h-full (:on-click (second
+                              (th/find-by-testid
+                                tree "rf-xray-test-diff-mode-full")))]
+      (is (not (identical? h-diff h-full))
+          "different mode kws → different cached handlers"))))
+
 ;; ---- (8) on-click stops event propagation (rf2-eko4v) -------------------
 
 (deftest diff-mode-toggle-on-click-stops-propagation

--- a/tools/xray/test/day8/re_frame2_xray/views/diff_mode_toggle_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/diff_mode_toggle_cljs_test.cljs
@@ -262,3 +262,53 @@
       (is (nil?  (th/find-by-testid
                    tree "rf-xray-test-diff-mode-full-with-diff"))
           "omitted modes do not paint"))))
+
+;; ---- (8) on-click stops event propagation (rf2-eko4v) -------------------
+
+(deftest diff-mode-toggle-on-click-stops-propagation
+  (testing "rf2-eko4v / rf2-ihjnx — the per-button `:on-click` MUST
+            call `(.stopPropagation e)` before invoking `:on-change`.
+            The widget is typically nested under section headers that
+            themselves bind click handlers (e.g. the L4 tab strip's
+            mode picker); a bubbled mode-button click would re-trigger
+            the enclosing handler with confusing semantics. Pin the
+            invariant by simulating a click with a stub event whose
+            `stopPropagation` flips a flag, then assert `:on-change`
+            received the chosen mode AFTER propagation was stopped."
+    (let [tree (widget/diff-mode-toggle
+                 {:mode :full+diff
+                  :on-change identity
+                  :testid "rf-xray-test-diff-mode"})
+          btn-diff (th/find-by-testid tree "rf-xray-test-diff-mode-diff")
+          on-click (:on-click (second btn-diff))
+          stopped? (atom false)
+          received (atom nil)
+          ;; Rebuild the widget with a capturing on-change so we can
+          ;; assert order: stopPropagation MUST fire before on-change.
+          tree2    (widget/diff-mode-toggle
+                     {:mode :full+diff
+                      :on-change (fn [m]
+                                   (reset! received
+                                           {:mode m
+                                            :propagation-stopped? @stopped?}))
+                      :testid "rf-xray-test-diff-mode"})
+          on-click2 (:on-click
+                      (second
+                        (th/find-by-testid tree2 "rf-xray-test-diff-mode-diff")))
+          evt      (js-obj "stopPropagation" #(reset! stopped? true))]
+      ;; First handler: only assert stopPropagation is called.
+      (is (fn? on-click) "button carries a fn at :on-click")
+      (on-click evt)
+      (is @stopped?
+          ":on-click MUST call (.stopPropagation e) to block bubbling
+           into enclosing click handlers")
+      ;; Second handler: assert ordering — propagation stops THEN
+      ;; on-change fires with the chosen mode.
+      (reset! stopped? false)
+      (reset! received nil)
+      (on-click2 evt)
+      (is (= :diff (:mode @received))
+          ":on-change receives the mode for this button")
+      (is (true? (:propagation-stopped? @received))
+          "stopPropagation runs BEFORE :on-change so callers see the
+           event already cancelled by the time their handler fires"))))

--- a/tools/xray/test/day8/re_frame2_xray/views/resizable_table_persistence_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/resizable_table_persistence_cljs_test.cljs
@@ -10,8 +10,10 @@
        throws into init).
     3. save! → load round-trip via localStorage (when available).
     4. Empty / cleared slot loads as {}.
-    5. resize-pair event-fx writes the slot AND fires the persist fx
-       (post-dispatch, the localStorage slot reflects the new value).
+    5. resize-pair-tick event-db writes the slot (no persist);
+       resize-pair-commit event-fx writes the persist fx exactly once
+       on pointerup (rf2-xm1jy split — one localStorage write per
+       drag, not one per pixel).
     6. reset event-fx clears one table's overrides AND fires persist.
     7. hydrate! lifts the persisted slot back into :rf/xray's app-db
        so the for-table sub re-reads the restored value."
@@ -115,26 +117,54 @@
       (is (= {:t1 {:a 100}} (rt/load))
           "instance A's slot survived instance B's write"))))
 
-;; ---- (4) resize-pair persists via fx ------------------------------------
+;; ---- (4) resize-pair tick + commit (rf2-xm1jy split) --------------------
 
-(deftest resize-pair-writes-slot-and-persists
-  (when (and (exists? js/window) (.-localStorage js/window))
-    (xray-setup!)
-    (frame-dispatch [:rf.xray.column-widths/resize-pair
-                     :rf.xray.epoch/subscriptions
-                     :sub 250 :inputs 170])
-    (testing "app-db slot reflects the resize"
+(deftest resize-pair-tick-writes-slot-without-persisting
+  (testing "rf2-xm1jy — the pointermove-cadence event writes the slot
+            in app-db but does NOT touch localStorage (per-pixel
+            persistence flooded the main thread on lower-end devices)."
+    (when (and (exists? js/window) (.-localStorage js/window))
+      (xray-setup!)
+      (rt/clear!)
+      (frame-dispatch [:rf.xray.column-widths/resize-pair-tick
+                       :rf.xray.epoch/subscriptions
+                       :sub 250 :inputs 170])
       (is (= {:sub 250 :inputs 170}
              (frame-sub [:rf.xray.column-widths/for-table
-                         :rf.xray.epoch/subscriptions]))))
-    (testing "localStorage carries the same payload"
-      (is (= {:rf.xray.epoch/subscriptions {:sub 250 :inputs 170}}
-             (rt/load))))))
+                         :rf.xray.epoch/subscriptions]))
+          "app-db slot reflects the tick")
+      (is (= {} (rt/load))
+          "localStorage is NOT written by the tick event"))))
 
-(deftest resize-pair-clamps-sub-floor-width
+(deftest resize-pair-commit-persists-current-slot
+  (testing "rf2-xm1jy — pointerup dispatches the commit, which writes
+            whatever the app-db slot currently holds to localStorage
+            exactly once. Round-trip: N ticks then one commit ==
+            steady-state widths in localStorage."
+    (when (and (exists? js/window) (.-localStorage js/window))
+      (xray-setup!)
+      (rt/clear!)
+      (frame-dispatch [:rf.xray.column-widths/resize-pair-tick
+                       :rf.xray.epoch/subscriptions
+                       :sub 100 :inputs 100])
+      (frame-dispatch [:rf.xray.column-widths/resize-pair-tick
+                       :rf.xray.epoch/subscriptions
+                       :sub 200 :inputs 200])
+      (frame-dispatch [:rf.xray.column-widths/resize-pair-tick
+                       :rf.xray.epoch/subscriptions
+                       :sub 250 :inputs 170])
+      (is (= {} (rt/load))
+          "ticks accumulate in app-db only; localStorage untouched")
+      (frame-dispatch [:rf.xray.column-widths/resize-pair-commit])
+      (is (= {:rf.xray.epoch/subscriptions {:sub 250 :inputs 170}}
+             (rt/load))
+          "commit writes the final settled widths to localStorage
+           exactly once"))))
+
+(deftest resize-pair-tick-clamps-sub-floor-width
   (when (and (exists? js/window) (.-localStorage js/window))
     (xray-setup!)
-    (frame-dispatch [:rf.xray.column-widths/resize-pair
+    (frame-dispatch [:rf.xray.column-widths/resize-pair-tick
                      :rf.xray.epoch/subscriptions
                      :sub 5 :inputs 300])
     (is (= {:sub 24 :inputs 300}
@@ -147,10 +177,12 @@
 (deftest reset-clears-table-and-persists
   (when (and (exists? js/window) (.-localStorage js/window))
     (xray-setup!)
-    (frame-dispatch [:rf.xray.column-widths/resize-pair
+    (frame-dispatch [:rf.xray.column-widths/resize-pair-tick
                      :t1 :a 100 :b 200])
-    (frame-dispatch [:rf.xray.column-widths/resize-pair
+    (frame-dispatch [:rf.xray.column-widths/resize-pair-commit])
+    (frame-dispatch [:rf.xray.column-widths/resize-pair-tick
                      :t2 :a 50 :b 70])
+    (frame-dispatch [:rf.xray.column-widths/resize-pair-commit])
     (frame-dispatch [:rf.xray.column-widths/reset :t1])
     (is (nil? (frame-sub [:rf.xray.column-widths/for-table :t1]))
         "t1's overrides cleared")

--- a/tools/xray/testbeds/panel_gallery/fixtures_epoch.cljs
+++ b/tools/xray/testbeds/panel_gallery/fixtures_epoch.cljs
@@ -49,244 +49,116 @@
   builder here mirrors the substrate emit-site shape — the same shape
   the projection unit tests at
   `tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc`
-  pin. Drift in either keeps both broken in lock-step.")
+  pin. Drift in either keeps both broken in lock-step.
 
-;; ---- trace-event primitives ---------------------------------------------
+  ## Shared trace-event builders (rf2-tyivx)
 
-(defn- ev
-  "Minimal trace-event map. `op-type` is the broad classifier
-  (`:rf.event / :rf.fx / :rf.sub / :rf.view / :rf.machine / …`),
-  `operation` the precise emit op the projection reads."
-  [op-type operation tags]
-  {:op-type   op-type
-   :operation operation
-   :tags      tags})
+  All trace-event primitives now live in
+  `day8.re-frame2-xray.test-helpers.trace-event-builders` and are
+  consumed via thin per-fixture wrappers below. ONE canonical name
+  set; one diff lands a substrate-side rename. The wrappers preserve
+  the gallery-specific timing / explanation defaults (cofx
+  elapsed-ms = 0.1, flow elapsed-ms = 0.4, sub elapsed-ms = 0.2, etc.)
+  so existing gallery variants keep their pre-rf2-tyivx visual shape."
+  (:require [day8.re-frame2-xray.test-helpers.trace-event-builders :as teb]))
 
-(defn- dispatched-ev
-  "`:rf.event/dispatched` trace — drives the DISPATCH row. Carries
-  the substrate-canonical `:rf.event/v` (event vector) +
-  `:source` + optional `:rf.trace/call-site`."
-  ([event] (dispatched-ev event nil nil))
-  ([event source] (dispatched-ev event source nil))
-  ([event source coord]
-   (cond-> (ev :rf.event :rf.event/dispatched
-              {:rf.event/v         event
-               :source             source
-               :rf.trace/call-site coord})
-     true (assoc :event event :source source))))
+;; ---- trace-event primitives (gallery-specific wrappers) ----------------
+;;
+;; Each wrapper threads through to the shared `teb/*` builder with the
+;; gallery's default timing payloads — these timings drive the
+;; rendered "Nms" chips in the gallery snapshots; the projection
+;; reader unit tests don't need them. The shared builder set carries
+;; the same callable shape the substrate stamps; this seam preserves
+;; the gallery-specific defaults without duplicating the substrate
+;; tag schema.
+
+(def ^:private ev teb/ev)
+
+(def ^:private dispatched-ev teb/dispatched-ev)
 
 (defn- cofx-run-ev
-  "`:rf.cofx/run` trace — one per USER-injected coeffect. System
-  cofx (`:db / :event / :frame / :source / :trace-id`) are filtered
-  out by the projection (rf2-cq0ch), so fixtures only need to emit
-  the user-injected ids the COEFFECT step should surface.
-
-  rf2-w2r4p — substrate stamps the canonical `:rf.cofx/elapsed-ms`
-  duration tag (rf2-hhh92 · `re-frame.cofx`; spec 009 §243); fixture
-  mirrors that. The reader retains a legacy `:duration-ms` fallback
-  for older runtimes / external test fixtures."
+  "Wrapper: cofx with the gallery's canonical 0.1ms elapsed default
+  so the rendered timing chip reads as expected. `teb/cofx-run-ev`
+  takes the elapsed explicitly."
   [id value]
-  (ev :rf.cofx :rf.cofx/run {:rf.cofx/id          id
-                             :rf.cofx/value       value
-                             :rf.cofx/elapsed-ms  0.1}))
+  (teb/cofx-run-ev id value 0.1))
 
-(defn- run-end-ev
-  "`:rf.event/run-end` trace — the projection reads the handler's
-  finalised duration here.
+(def ^:private run-end-ev (fn [duration-ms] (teb/run-end-ev duration-ms)))
 
-  rf2-slnce — substrate stamps the canonical `:rf.event/elapsed-ms`
-  (rf2-hhh92 · `re-frame.router/emit-run-end-trace`); fixture mirrors
-  that. The reader retains legacy `:duration-ms` fallbacks for older
-  runtimes / external test fixtures."
-  [duration-ms]
-  (ev :rf.event :rf.event/run-end {:rf.event/elapsed-ms duration-ms}))
-
-(defn- db-changed-ev
-  "`:rf.event/db-changed` trace — drives both HANDLER's `:db-diff`
-  slot AND the dedicated APP-DB DIFF step (rf2-rrykz, same payload,
-  two surfaces). `paths` is a vec of
-  `[path before after change-kind]` quads."
-  [paths]
-  (ev :rf.event :rf.event/db-changed
-      {:rf.event/db-changed-paths paths}))
-
-(defn- do-fx-ev
-  "`:rf.fx/do-fx` trace — carries the handler's returned `:rf.event/fx`
-  payload. Drives the FX step's per-row attribution AND the
-  CHILD-DISPATCHES step (rf2-yx1ae harvests dispatch-family fx from
-  this same payload)."
-  [fx]
-  (ev :rf.fx :rf.fx/do-fx {:rf.event/fx fx}))
-
-(defn- fx-handled-ev
-  "`:rf.fx/handled` trace — one per fx-handler invocation. The FX
-  step's per-row outcome reads `:rf.fx/id` + `:rf.fx/args` +
-  `:rf.fx/elapsed-ms` here.
-
-  rf2-ipaza — substrate stamps the canonical `:rf.fx/elapsed-ms`
-  (rf2-hhh92 · `re-frame.fx`; spec 009 §241); fixture mirrors that.
-  The reader retains a legacy `:duration-ms` fallback for older
-  runtimes / external test fixtures."
-  ([fx-id args duration-ms]
-   (ev :rf.fx :rf.fx/handled {:rf.fx/id          fx-id
-                              :rf.fx/args        args
-                              :rf.fx/elapsed-ms  duration-ms})))
+(def ^:private db-changed-ev teb/db-changed-ev)
+(def ^:private do-fx-ev teb/do-fx-ev)
+(def ^:private fx-handled-ev teb/fx-handled-ev)
 
 (defn- flow-recomputed-ev
-  "`:rf.flow/computed` trace — drives the FLOW step.
-
-  rf2-yhgk8 — substrate stamps the `:rf.flow/computed` operation with
-  bare `:flow-id` / `:path` / `:before` / `:result` / `:elapsed-ms`
-  tags (Spec 009 §Flow trace events · `re-frame.flows`). The name
-  `flow-recomputed-ev` is retained for call-site stability; the
-  payload is canonical."
+  "Wrapper: gallery default elapsed-ms = 0.4 for FLOW rows."
   [flow-id path before after]
-  (ev :rf.flow :rf.flow/computed {:flow-id    flow-id
-                                  :path       path
-                                  :before     before
-                                  :result     after
-                                  :elapsed-ms 0.4}))
+  (teb/flow-recomputed-ev flow-id path before after 0.4))
 
 (defn- sub-run-ev
-  "`:rf.sub/run` trace — drives one SUBSCRIPTIONS row. Per rf2-kfh1v
-  the canonical tag names are `:rf.sub/id`, `:rf.sub/query-v`,
-  `:rf.sub/value-changed?`, `:rf.sub/prev-value`, `:rf.sub/value` —
-  the projection reads ONLY these post-rf2-kfh1v."
+  "Wrapper: gallery default elapsed-ms = 0.2 for SUBSCRIPTIONS rows."
   [sub-vec changed? before after]
-  (ev :rf.sub :rf.sub/run {:rf.sub/id             (when (vector? sub-vec) (first sub-vec))
-                           :rf.sub/query-v        sub-vec
-                           :rf.sub/value-changed? changed?
-                           :rf.sub/prev-value     before
-                           :rf.sub/value          after
-                           :rf.sub/elapsed-ms     0.2}))
+  (teb/sub-run-ev sub-vec changed? before after 0.2))
 
-(defn- view-rendered-ev
-  "`:rf.view/rendered` trace (per rf2-6djth — NOT the simpler
-  `:rf.view/render` marker; only `:rf.view/rendered` carries
-  `:rf.view/id` + `:rf.view/deref-subs` + `:rf.view/elapsed-ms`)."
-  [view-id deref-subs elapsed-ms]
-  (ev :rf.view :rf.view/rendered {:rf.view/id         view-id
-                                  :rf.view/deref-subs deref-subs
-                                  :rf.view/elapsed-ms elapsed-ms}))
+(def ^:private view-rendered-ev teb/view-rendered-ev)
 
 (defn- view-unmounted-ev
-  "`:rf.view/unmounted` trace (per rf2-9hoos / rf2-te71r) — drives
-  the VIEWS step's UNMOUNTED sub-section (rf2-gmw1i). Substrate
-  stamps `:rf.view/id` + `:rf.view/render-key` + `:frame` on every
-  view-instance teardown."
+  "Wrapper: gallery default frame = `:rf/default`."
   [view-id render-key]
-  (ev :rf.view :rf.view/unmounted {:rf.view/id         view-id
-                                   :rf.view/render-key render-key
-                                   :frame              :rf/default}))
+  (teb/view-unmounted-ev view-id render-key :rf/default))
 
-(defn- sub-dispose-ev
-  "`:rf.sub/dispose` trace (per rf2-mrnur) — drives the SUBSCRIPTIONS
-  step's DISPOSED sub-section (rf2-wpfjo). Substrate stamps
-  `:rf.sub/id` + `:rf.sub/query-v` + `:rf.sub/reason` + `:frame` on
-  every cache-eviction site (closed `:reason` set per rf2-mrnur:
-  `:no-more-derefers / :hot-reload / :cache-clear`)."
-  [sub-vec reason]
-  (ev :rf.sub :rf.sub/dispose {:rf.sub/id      (when (vector? sub-vec) (first sub-vec))
-                               :rf.sub/query-v sub-vec
-                               :rf.sub/reason  reason
-                               :frame          :rf/default}))
+(def ^:private sub-dispose-ev teb/sub-dispose-ev)
 
 ;; ---- machine-handler trace primitives -----------------------------------
 
 (defn- machine-transition-ev
-  "`:rf.machine/transition` trace — drives the HANDLER step's
-  machine TRANSITION sub-section + the DATA-REDUCTION /
-  SNAPSHOT-DIFF projections (the panel's machine-handler full
-  design, PR #2193). `before` + `after` are full machine snapshot
-  maps (`:state` + `:data` + …)."
+  "Wrapper: gallery's full-arity form requires `:event` + `:microsteps`,
+  whereas the shared `teb/machine-transition-ev` makes them optional
+  via cond->. Stamp them unconditionally here."
   [machine-id event before after microsteps]
-  (ev :rf.machine :rf.machine/transition
-      {:machine-id machine-id
-       :event      event
-       :before     before
-       :after      after
-       :microsteps microsteps}))
+  (teb/machine-transition-ev machine-id before after event microsteps))
 
-(defn- machine-guard-ev
-  "`:rf.machine/guard-evaluated` trace — drives the HANDLER step's
-  GUARDS sub-section (one row per guard, with outcome
-  `:pass / :fail / :threw`)."
-  [guard-id outcome]
-  (ev :rf.machine :rf.machine/guard-evaluated {:guard-id guard-id
-                                               :outcome  outcome}))
+(def ^:private machine-guard-ev teb/machine-guard-ev)
 
 (defn- machine-action-ev
-  "`:rf.machine/action-ran` trace — drives the HANDLER step's
-  LIFECYCLE sub-section (one row per action, grouped by `:phase`
-  `:exit / :transition / :entry / :always / :after-action / …` per
-  rf2-82a0u). Optional `:outcome :fx` rides the rf2-9c27r
-  per-action fx attribution."
+  "Wrapper: gallery's richer 5-arg form folds `:fx` + `:data` into
+  the outcome map. The shared builder's 4-arg form takes a plain
+  outcome (kw or map); we compose the outcome locally."
   ([action-id phase outcome]
    (machine-action-ev action-id phase outcome nil nil))
   ([action-id phase outcome data action-fx]
    (let [outcome-map (cond-> (if (map? outcome) outcome {})
                        action-fx (assoc :fx action-fx)
                        data      (assoc :data data))]
-     (ev :rf.machine :rf.machine/action-ran
-         {:action-id action-id
-          :phase     phase
-          :outcome   outcome-map
-          :input     {:data (or data {}) :event nil}}))))
+     (teb/machine-action-ev action-id phase outcome-map data))))
 
-(defn- machine-timer-cancel-ev
-  "`:rf.machine.timer/cancelled` trace — drives the HANDLER step's
-  AFTER-TIMERS sub-section (one row per cancelled timer with
-  `:reason` in the unified rf2-82a0u set)."
-  [machine-id state delay reason]
-  (ev :rf.machine :rf.machine.timer/cancelled
-      {:machine-id machine-id
-       :state      state
-       :delay      delay
-       :reason     reason}))
+(def ^:private machine-timer-cancel-ev teb/machine-timer-cancel-ev)
 
 ;; ---- schema-violation trace primitives ----------------------------------
 
 (defn- schema-violation-ev
-  "`:rf.error/schema-validation-failure` trace (rf2-17vxj) — the
-  runtime per-event boundary check (`:where` in
-  `:app-db / :cofx / :sub-return / :fx-args`). Drives the SCHEMA
-  VIOLATIONS step.
-
-  Per rf2-2ek7t the trace event also carries `:explain-humanized` —
-  the Malli-humanized form of the raw `:explain` map. The substrate
-  populates this slot via the late-bind `:schemas/humanize-explain!`
-  hook (Malli adapter publishes `malli.error/humanize` under it).
-  For fixture-replay tests (which bypass the substrate's
-  `emit-validation-failure!` helper) we seed a representative
-  humanized shape directly so the violation block demonstrates the
-  new chrome — `{<path-leaf> [<message>]}` is the canonical
-  humanize output for a single-error explain."
+  "Wrapper: gallery seeds a representative `:explain` + `:explain-
+  humanized` shape (per rf2-2ek7t) on top of the shared builder's
+  bare runtime-failure payload — the gallery panels render the
+  humanized chrome, so a literal example is the right gallery seed.
+  Real substrate emits populate `:explain-humanized` via the
+  `:schemas/humanize-explain!` late-bind hook."
   [where failing-id path value rollback?]
-  (let [path-leaf (if (sequential? path) (last path) path)]
-    (ev :error :rf.error/schema-validation-failure
-        {:where             where
-         :failing-id        failing-id
-         :path              path
-         :value             value
-         :rollback?         (boolean rollback?)
-         :explain           {:errors [{:path path :message "expected int"}]}
-         :explain-humanized {path-leaf [(str "should be an integer, got "
-                                              (pr-str value))]}})))
+  (let [base      (teb/schema-violation-ev where failing-id path value rollback?)
+        path-leaf (if (sequential? path) (last path) path)]
+    (update base :tags merge
+            {:explain           {:errors [{:path path :message "expected int"}]}
+             :explain-humanized {path-leaf [(str "should be an integer, got "
+                                                  (pr-str value))]}})))
 
 (defn- schema-hot-reload-ev
-  "`:rf.schema/violation` trace (rf2-17vxj) — the hot-reload drift
-  check fires when a re-registration changed the schema at a
-  `(frame-id, path)` AND the live `app-db` value at `path` fails the
-  new schema. Distinct from the runtime per-event failure; rides on
-  the standalone SCHEMA HOT-RELOAD tail step (rf2-xgeag · Option A)."
+  "Wrapper: gallery seeds richer hot-reload metadata (`:pre-reload-
+  schema` / `:post-reload-schema`) on top of the shared builder's
+  minimal `:frame / :path / :mismatching-value / :recovery` set."
   [frame-id path mismatching-value]
-  (ev :warning :rf.schema/violation
-      {:frame              frame-id
-       :path               path
-       :mismatching-value  mismatching-value
-       :pre-reload-schema  :int?
-       :post-reload-schema :pos-int?
-       :recovery           :logged-and-skipped}))
+  (let [base (teb/schema-hot-reload-ev frame-id path mismatching-value)]
+    (update base :tags merge
+            {:pre-reload-schema  :int?
+             :post-reload-schema :pos-int?})))
 
 ;; ---- epoch-record builder ------------------------------------------------
 


### PR DESCRIPTION
## Summary

Misc Xray polish sweep — 10 beads, one commit per bead, ordered smallest cleanup → biggest fix.

## Beads + fixes

| # | bead | type | files touched | fix | test |
| - | --- | --- | --- | --- | --- |
| 1 | rf2-4oy37 | P4 docstring | `views/edn_inspector.cljs` | Replace stale narrative reference to retired `annotated-tree-cache` with the surviving sub-cache layer | n/a (doc) |
| 2 | rf2-eko4v | P4 test | `views/diff_mode_toggle_cljs_test.cljs` | Add direct assertion on `make-on-click` stop-propagation behaviour; pin ordering (stopPropagation BEFORE on-change) | added |
| 3 | rf2-vwfcp | P3 refactor | `views/resizable_table.cljs` | Body-row construction now uses eager `map-indexed`/`with-meta` per rf2-9ec65 — no lazy seq chunk; future deref-in-row-cells won't reactivity-leak silently | existing tests pass |
| 4 | rf2-xm1jy | P3 bug | `views/resizable_table.cljs`, `resizable_table_persistence_cljs_test.cljs`, `registry_cljs_test.cljs` | Split `:resize-pair` into `:resize-pair-tick` (no persist; pointermove cadence) + `:resize-pair-commit` (persists; pointerup). ~200 localStorage writes per drag → 1 | updated + new tick/commit round-trip |
| 5 | rf2-a7vkv | P4 polish | `views/diff_mode_toggle.cljs`, `diff_mode_toggle_cljs_test.cljs` | `make-on-click` now `memoize`-cached on `[on-change m]` so :on-click identity is stable across renders; React reconciler skips re-writing the DOM onclick prop | added identity-stability + per-mode-distinct tests |
| 6 | rf2-a1tv6 | P4 polish | `config.cljc`, `settings/editor_override_cljs_test.cljs` | New `valid-editor-override?` predicate; `get-editor` filters malformed slots through it, degrading to host default + `tap>` rejection rather than passing junk to URI builder | updated existing test + new predicate-coverage test |
| 7 | rf2-rc35g | P3 bug | `settings/view.cljs`, `settings/popup_cljs_test.cljs` | Custom radio seed flipped from `{:custom \"\"}` to `{:custom \"vscode://file/{path}:{line}:{column}\"}` — click-to-source works immediately; user edits from a working baseline | added seed-value pin |
| 8 | rf2-tyivx | P3 refactor | new `test_helpers/trace_event_builders.cljc` + `panels/epoch/projection_cljs_test.cljc` + `testbeds/panel_gallery/fixtures_epoch.cljs` + new `panels/epoch/real_substrate_projection_cljs_test.cljs` | Shared canonical trace-event-builders ns reachable from BOTH test/ and testbeds/ (on shadow-cljs source-paths cascade). Projection test ns + gallery fixtures now consume the shared builders via thin wrappers — one diff lands a substrate-side rename. Plus end-to-end test that drives a REAL `trace/emit!` through the substrate (`dispatch-sync` of `:rf.tyivx/counter-inc`) and asserts DISPATCH + HANDLER + db-diff project correctly | shared builder ns + e2e real-substrate test |
| 9 | rf2-5j7ch | P3 bug | `diff/engine.cljc`, `panels/app_db_diff_subs.cljs`, `panels/machine_inspector.cljs`, `diff/engine_cljs_test.cljc`, `panels/reactivity/app_db_diff_reactivity_cljs_test.cljs` | New `engine/expand-empty-root-replacement` pure helper — when before is `{}` and after is a non-empty map (or inverse), the engine's single wholesale root-replacement row expands into per-key `:added`/`:removed` rows. Cold-boot epoch's `:diff` lens now reads at per-key granularity. Non-empty-side wholesales pass through unchanged. Applied at App-DB sub + Machine Inspector | 5 dedicated engine tests + updated existing reactivity test |
| 10 | rf2-2678t | P3 convention drift | `panels/machines/topology.cljs`, `panels/machines/topology_cljs_test.cljs` | Local `event-segment-str` was a strict subset of canonical `machines-viz/chart.layout/event-segment` (missing `:* (any)` arm). Delegated to the canonical fn — xray + machines-viz now agree on every shape; the docstring's \"single source of truth\" claim becomes accurate | added `:*` wildcard label + parity-with-machines-viz tests |

## Constraints honoured

- No `tools/xray/src/.../panels/epoch/*` writes (owned by in-flight `fix-xray-epoch-polish` worker).
- Surgical fixes per bead — no drive-by refactors.
- Pre-alpha posture: removed `:resize-pair` rather than keeping a back-compat alias.

## Quality gates

- `npm run test:cljs` (from `implementation/`) — **4832 tests, 15739 assertions, 0 failures, 0 errors**.
- `clojure -M:test` (from `tools/xray/`) — **950 tests, 3672 assertions, 0 failures, 0 errors**.