### PR TITLE
perf(xray/epoch): cascade + parent-lookup + cancellation pre-compute — 6 beads (rf2-w6yfq + rf2-wuwu3 + rf2-x25e0 + rf2-5t8y8 + rf2-z5zm4 + rf2-w8evg)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/cancellation_cascade.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/cancellation_cascade.cljs
@@ -137,10 +137,24 @@
 (def ^:private teardown-glyph-style {:color teardown-colour :font-weight 700})
 (def ^:private abort-glyph-style    {:color abort-colour    :font-weight 700})
 
-;; Cursor overlays for the row container — clickable rows get
-;; `pointer`, non-clickable rows get the browser default.
-(def ^:private cursor-pointer-overlay {:cursor "pointer"})
-(def ^:private cursor-default-overlay {:cursor "default"})
+;; rf2-wuwu3 — pre-computed row-style × cursor variants. The three
+;; row types × {clickable, static} fan out to exactly 6 final
+;; container maps; per-render `(merge … cursor-overlay)` allocations
+;; are gone. With ~50 abort rows that's ~50 fewer fresh objects per
+;; cascade re-render (on top of the rf2-qx414 hoists). Each pair
+;; folds `:cursor` into the row's chrome at ns load.
+(def ^:private decision-row-style-clickable
+  (assoc decision-row-style :cursor "pointer"))
+(def ^:private decision-row-style-static
+  (assoc decision-row-style :cursor "default"))
+(def ^:private teardown-row-style-clickable
+  (assoc teardown-row-style :cursor "pointer"))
+(def ^:private teardown-row-style-static
+  (assoc teardown-row-style :cursor "default"))
+(def ^:private abort-row-style-clickable
+  (assoc abort-row-style :cursor "pointer"))
+(def ^:private abort-row-style-static
+  (assoc abort-row-style :cursor "default"))
 
 ;; ---- header --------------------------------------------------------------
 
@@ -207,10 +221,9 @@
                                {:dispatch-id (:dispatch-id decision)
                                 :trace-id    (:trace-id decision)}]
                               {:frame :rf/xray})))
-           :style       (merge decision-row-style
-                                (if clickable?
-                                  cursor-pointer-overlay
-                                  cursor-default-overlay))}
+           :style       (if clickable?
+                          decision-row-style-clickable
+                          decision-row-style-static)}
      [:span {:style decision-glyph-style}
       (:parent-decision row-glyph)]
      [:span {:style time-chip-style}
@@ -237,10 +250,9 @@
                                {:dispatch-id dispatch-id
                                 :trace-id    trace-id}]
                               {:frame :rf/xray})))
-           :style       (merge teardown-row-style
-                                (if clickable?
-                                  cursor-pointer-overlay
-                                  cursor-default-overlay))}
+           :style       (if clickable?
+                          teardown-row-style-clickable
+                          teardown-row-style-static)}
      [:span {:style teardown-glyph-style}
       (:child-teardown row-glyph)]
      [:span {:style time-chip-style}
@@ -277,10 +289,9 @@
                                {:dispatch-id dispatch-id
                                 :trace-id    trace-id}]
                               {:frame :rf/xray})))
-           :style       (merge abort-row-style
-                                (if clickable?
-                                  cursor-pointer-overlay
-                                  cursor-default-overlay))}
+           :style       (if clickable?
+                          abort-row-style-clickable
+                          abort-row-style-static)}
      [:span {:style abort-glyph-style}
       (if last?
         (:effect-abort-last row-glyph)

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -1653,23 +1653,49 @@
                            candidates)]
       (:epoch-id (or exact (first candidates))))))
 
+(defn dispatch-id->epoch-id-index
+  "Build a `{dispatch-id → epoch-id}` map from an `epoch-history` vector.
+
+  rf2-x25e0 — collapses the per-row O(N) scan that `find-parent-epoch`
+  previously did to an O(1) lookup. Each record contributes both its
+  first-class `:dispatch-id` slot (rf2-rly4a; the common case) AND
+  the value derived via `dispatch-id-of-epoch` (the trace-walk
+  fallback for legacy / restored records lacking the slot). Same
+  matching surface as the prior `some`-based lookup; nil keys are
+  skipped so records with neither identifier don't collide.
+
+  Pure data → map. Build once per render at the call site (the view
+  layer) and feed `find-parent-epoch` for every DISPATCH-row lookup."
+  [epoch-history]
+  (persistent!
+    (reduce
+      (fn [acc record]
+        (let [id1 (:dispatch-id record)
+              id2 (common/dispatch-id-of-epoch record)
+              eid (:epoch-id record)]
+          (cond-> acc
+            (some? id1) (assoc! id1 eid)
+            (and (some? id2) (not= id2 id1)) (assoc! id2 eid))))
+      (transient {})
+      epoch-history)))
+
 (defn find-parent-epoch
-  "Resolve a parent epoch's `:epoch-id` against the epoch-history given
-  the child's parent-dispatch-id (rf2-5qp4g).
+  "Resolve a parent epoch's `:epoch-id` against a precomputed
+  `dispatch-id->epoch-id` index given the child's
+  `:parent-dispatch-id` (rf2-5qp4g).
 
   The reverse of `find-child-epoch`: child's `:parent-dispatch-id` →
-  parent's `:dispatch-id` → parent's `:epoch-id`. The lookup matches
-  on `dispatch-id-of-epoch` which falls back to a `:trace-events`
-  walk for records that lack the first-class `:dispatch-id` slot
-  (per the same helper's docstring). Returns nil when no parent
-  epoch is in the buffer (root cascade, or aged out)."
-  [epoch-history parent-dispatch-id]
-  (when (and (some? parent-dispatch-id) (seq epoch-history))
-    (some (fn [record]
-            (when (or (= parent-dispatch-id (common/dispatch-id-of-epoch record))
-                      (= parent-dispatch-id (:dispatch-id record)))
-              (:epoch-id record)))
-          epoch-history)))
+  parent's `:dispatch-id` → parent's `:epoch-id`. Returns nil when no
+  parent epoch is in the buffer (root cascade, or aged out).
+
+  rf2-x25e0 — O(1) lookup. The prior O(N) `some`-walk over
+  `epoch-history` is replaced by a map `get`. Callers build the
+  index once per panel render via `dispatch-id->epoch-id-index` and
+  thread it down to every DISPATCH-row lookup (clean-swap; the
+  arity-2 history-walking form is gone)."
+  [dispatch-id->epoch-id parent-dispatch-id]
+  (when (some? parent-dispatch-id)
+    (get dispatch-id->epoch-id parent-dispatch-id)))
 
 ;; ---- top-level projection ------------------------------------------------
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -719,24 +719,43 @@
   - Rows on a phase that maps to nil (e.g. `:always` with no transition
     in the cascade) — keep slots nil; source lookup degrades gracefully."
   [rows]
-  (let [v   (vec rows)
-        n   (count v)
+  (let [v (vec rows)
+        n (count v)
         ;; For each row index, find the surrounding transition row:
-        ;; prefer the NEXT transition ahead (substrate emits actions
-        ;; before the transition), else fall back to the most recent
-        ;; preceding transition (post-commit timer-cancels).
+        ;; prefer the NEXT transition AT-OR-AHEAD (substrate emits
+        ;; actions before the transition), else fall back to the most
+        ;; recent preceding transition (post-commit timer-cancels).
+        ;;
+        ;; rf2-w6yfq — single-pass O(n) instead of O(n²). Walk
+        ;; RIGHT-TO-LEFT threading `next-ahead` (the most recent
+        ;; transition seen so far, looking back from the right); then
+        ;; walk LEFT-TO-RIGHT threading `prior` (the most recent
+        ;; transition emitted at-or-before i). Prefer `next-ahead`,
+        ;; fall back to `prior`. Two linear passes + one mapv → O(n).
+        ;; Prior shape did a forward `(some … (subvec v i))` per row,
+        ;; which is O(n²); real cascades are tiny (< 10 rows) so the
+        ;; win is asymptotic-only, but the shape is cleaner.
+        next-ahead (loop [i (dec n) seen nil acc (transient (vec (repeat n nil)))]
+                     (if (neg? i)
+                       (persistent! acc)
+                       (let [row (nth v i)
+                             tx? (= :transition (:kind row))
+                             ;; AT-OR-AHEAD: if this row IS a transition, it
+                             ;; IS the surrounding row for itself.
+                             surrounding (if tx? row seen)]
+                         (recur (dec i)
+                                (if tx? row seen)
+                                (assoc! acc i surrounding)))))
         next-tx (loop [i 0 prior nil acc (transient (vec (repeat n nil)))]
                   (if (>= i n)
                     (persistent! acc)
                     (let [row (nth v i)
-                          surrounding (cond
-                                        (= :transition (:kind row)) row
-                                        :else (or
-                                                (some #(when (= :transition (:kind %)) %)
-                                                      (subvec v i))
-                                                prior))]
+                          tx? (= :transition (:kind row))
+                          ;; Prefer next-ahead (which is the row itself
+                          ;; when tx?); fall back to `prior`.
+                          surrounding (or (nth next-ahead i) prior)]
                       (recur (inc i)
-                             (if (= :transition (:kind row)) row prior)
+                             (if tx? row prior)
                              (assoc! acc i surrounding)))))]
     (mapv
       (fn [row tx]

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -1090,16 +1090,12 @@
 (def ^:private rolled-back-mute-style
   {:opacity 0.55})
 
-(def ^:private rolled-back-banner-style
-  {:display     "flex"
-   :align-items "center"
-   :gap         "8px"
-   :margin-top  "5px"
-   :padding     "4px 8px"
-   :color       error-colour
-   :font-family sans-stack
-   :font-size   "11px"
-   :font-style  "italic"})
+;; `rolled-back-banner-style` + the `rolled-back-banner` render fn
+;; were retired (rf2-w8evg) — the rf2-7gf7v / rf2-8resu redesign moves
+;; the :app-db violation to the FX step's :db row (the implicit
+;; commit fx), so the standalone HANDLER-level "cascade rolled back"
+;; banner has no caller. Downstream-mute treatment lives on via
+;; `rolled-back-mute-style` (applied in `render-pipeline-steps`).
 
 ;; -- CHILD DISPATCHES -----------------------------------------------------
 
@@ -1269,14 +1265,14 @@
                             badge-pill-text-overlay))}
      label]))
 
-;; rf2-xgeag — violation sub-block + rolled-back banner are defined
-;; further down the file (in the §SCHEMA VIOLATION sub-block section)
-;; but each step renderer above attaches a `(violation-blocks ...)`
-;; sub-block to its body. Forward-declared here so the namespace
-;; compiles in source order without warnings.
+;; rf2-xgeag — violation sub-block defined further down the file (in
+;; the §SCHEMA VIOLATION sub-block section), but each step renderer
+;; above attaches a `(violation-blocks ...)` sub-block to its body.
+;; Forward-declared here so the namespace compiles in source order
+;; without warnings. (`rolled-back-banner` forward declare retired
+;; alongside its defn — rf2-w8evg.)
 (declare violation-blocks)
 (declare violation-block)
-(declare rolled-back-banner)
 
 (defn- numbered-circle
   "Render the numbered circle — 21px diameter, painted in the step's
@@ -3706,15 +3702,12 @@
      (map-indexed (fn [i v] (violation-block step-key i v))
                   violations)]))
 
-(defn- rolled-back-banner
-  "One-line banner shown immediately under the HANDLER step body
-  when the cascade is rolled-back, signposting the downstream-mute
-  treatment to the operator."
-  []
-  [:div {:data-testid "rf-xray-epoch-rolled-back-banner"
-         :style rolled-back-banner-style}
-   [:span {:aria-hidden true} "↓"]
-   "cascade rolled back — downstream effects skipped"])
+;; `rolled-back-banner` retired per rf2-w8evg — the rf2-8resu
+;; redesign moved the `:where :app-db` violation from HANDLER to the
+;; FX step's `:db` row, so the standalone HANDLER-level "cascade
+;; rolled back — downstream effects skipped" banner has no caller.
+;; The downstream-mute chrome (`rolled-back-mute-style`) still
+;; applies in `render-pipeline-steps`.
 
 ;; SCHEMA HOT-RELOAD step retired per rf2-7gf7v (Mike pair-debug
 ;; 2026-05-27). The standalone tail step was rendering opaque

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -2564,10 +2564,11 @@
      (case mode
        :diff
        (when-not empty?
-         ;; rf2-9ec65 — eager realisation via `mapv` so any future
-         ;; subscribe deref inside `db-diff-line` registers in this
-         ;; render's reactive scope (spec/006 §Lazy-seq deref tracking,
-         ;; rf2-atqkg). Was `(for [[i row] (map-indexed vector …)] …)`
+         ;; rf2-9ec65 — eager realisation via `(into [:<>] (map-indexed …))`
+         ;; so any future subscribe deref inside `db-diff-line` registers in
+         ;; this render's reactive scope (spec/006 §Lazy-seq deref tracking,
+         ;; rf2-atqkg). `into` is eager regardless of the transducer/seq it
+         ;; consumes. Was `(for [[i row] (map-indexed vector …)] …)`
          ;; which returns a LazySeq.
          (into [:<>]
                (map-indexed (fn [i row] (db-diff-line row i)) db-diff)))
@@ -2655,24 +2656,30 @@
      ;; folded into SNAPSHOT DIFF for machines
      (when-not machine?
        (handler-db-diff-block db-diff))
-     ;; :fx — the canonical vector-of-vectors, FULL via edn-inspector
+     ;; :fx — the canonical vector-of-vectors, FULL via edn-inspector.
+     ;; rf2-5t8y8 — sub-header carries a trailing entry-count chip ("N
+     ;; entr{y,ies}") that the edn-inspector vector-header chrome alone
+     ;; doesn't surface at the same at-a-glance density.
      (when (seq fx-vec)
-       [:div {:data-testid "rf-xray-epoch-handler-fx"}
-        (sub-header ":fx")
-        [ei/edn-inspector fx-vec
-         {:site-id                [:rf.xray.epoch/handler-fx event-id]
-          :card?                  false
-          :zoomable?              true
-          :default-expanded-depth 16}]])
-     ;; other — return map minus :db and :fx, FULL via edn-inspector
+       (let [n (count fx-vec)]
+         [:div {:data-testid "rf-xray-epoch-handler-fx"}
+          (sub-header ":fx" (str n " entr" (if (= 1 n) "y" "ies")))
+          [ei/edn-inspector fx-vec
+           {:site-id                [:rf.xray.epoch/handler-fx event-id]
+            :card?                  false
+            :zoomable?              true
+            :default-expanded-depth 16}]]))
+     ;; other — return map minus :db and :fx, FULL via edn-inspector.
+     ;; rf2-5t8y8 — entry-count chip on the sub-header (parallel to :fx).
      (when (seq other-effects)
-       [:div {:data-testid "rf-xray-epoch-handler-other"}
-        (sub-header "other")
-        [ei/edn-inspector other-effects
-         {:site-id                [:rf.xray.epoch/handler-other event-id]
-          :card?                  false
-          :zoomable?              true
-          :default-expanded-depth 16}]])]))
+       (let [n (count other-effects)]
+         [:div {:data-testid "rf-xray-epoch-handler-other"}
+          (sub-header "other" (str n " entr" (if (= 1 n) "y" "ies")))
+          [ei/edn-inspector other-effects
+           {:site-id                [:rf.xray.epoch/handler-other event-id]
+            :card?                  false
+            :zoomable?              true
+            :default-expanded-depth 16}]]))]))
 
 (defn render-handler-step
   "Render the HANDLER step (always present). Per Mike pair-debug

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -1582,14 +1582,20 @@
   The parent-epoch chip is click-to-navigate via
   `:rf.xray/focus-epoch`. The delay-ms chip rides only for
   `:dispatch-later` when the original scheduled delay was stamped
-  on the dispatched trace (`:rf.event/source-detail :ms`)."
-  [source {:keys [parent-dispatch-id delay-ms]} epoch-history]
+  on the dispatched trace (`:rf.event/source-detail :ms`).
+
+  rf2-x25e0 — `dispatch-id->epoch-id` is the precomputed lookup map
+  built once per panel render in `Panel` and threaded through `ctx`.
+  Replaces the prior O(N) `(some … epoch-history)` scan with an O(1)
+  map `get`."
+  [source {:keys [parent-dispatch-id delay-ms]} dispatch-id->epoch-id]
   (let [kind-label (case source
                      :fx-dispatch       ":dispatch"
                      :fx-dispatch-later ":dispatch-later"
                      (name source))
-        parent-epoch-id (when (and parent-dispatch-id (seq epoch-history))
-                          (proj/find-parent-epoch epoch-history parent-dispatch-id))]
+        parent-epoch-id (when parent-dispatch-id
+                          (proj/find-parent-epoch dispatch-id->epoch-id
+                                                  parent-dispatch-id))]
     [:span {:data-testid "rf-xray-epoch-dispatch-source-label"
             :style dispatch-verb-style}
      [:span {:style dispatch-source-plain-style}
@@ -1633,7 +1639,7 @@
     :fx-dispatch-later → dispatch-fx-label
     :always            → dispatch-always-label
     other / nil        → dispatch-source-label (call-site link)"
-  [{:keys [source coord source-enrichment] :as step} epoch-history]
+  [{:keys [source coord source-enrichment] :as step} dispatch-id->epoch-id]
   (case source
     :after-timer       (if source-enrichment
                          (dispatch-after-timer-label source-enrichment)
@@ -1642,9 +1648,9 @@
                          (dispatch-machine-spawn-label source-enrichment)
                          (dispatch-source-label source coord))
     :fx-dispatch       (dispatch-fx-label source (or source-enrichment {})
-                                          epoch-history)
+                                          dispatch-id->epoch-id)
     :fx-dispatch-later (dispatch-fx-label source (or source-enrichment {})
-                                          epoch-history)
+                                          dispatch-id->epoch-id)
     :always            (dispatch-always-label step)
     (dispatch-source-label source coord)))
 
@@ -1668,15 +1674,17 @@
   parent-epoch navigation). Vanilla sources fall through to the
   pre-rf2-5qp4g call-site chrome unchanged.
 
-  `epoch-history` is the optional Xray epoch buffer slice the
-  `:fx-dispatch` / `:fx-dispatch-later` enrichments use to resolve
-  the parent-dispatch-id → parent-epoch-id link (rendered as a
+  `dispatch-id->epoch-id` is the optional precomputed
+  `{dispatch-id → epoch-id}` index (rf2-x25e0) the `:fx-dispatch` /
+  `:fx-dispatch-later` enrichments use to resolve the
+  parent-dispatch-id → parent-epoch-id link in O(1) (rendered as a
   click-to-navigate `:rf.xray/focus-epoch` button). When omitted
   (direct test calls of the renderer) the parent-epoch chip falls
-  back to the unresolved variant."
+  back to the unresolved variant. The index is built once per panel
+  render in `Panel` and threaded down via `ctx`."
   ([step] (render-dispatch-step step nil))
   ([{:keys [source coord duration-ms step-number violations] :as step}
-    epoch-history]
+    dispatch-id->epoch-id]
    [:div {:data-testid "rf-xray-epoch-step-dispatch"
           :data-step-kw "dispatch"
           :data-source (when source (name source))}
@@ -1684,7 +1692,7 @@
     (step-header
       {:step :dispatch
        :badge :DISPATCH
-       :verb (let [enriched (dispatch-source-enriched-label step epoch-history)]
+       :verb (let [enriched (dispatch-source-enriched-label step dispatch-id->epoch-id)]
                ;; Vanilla sources fall through to a wrapper that
                ;; carries the prefix "from " — the per-kind labels
                ;; carry their own "from <kind>" prefix already, so the
@@ -3835,7 +3843,7 @@
   ignore it."
   [step ctx]
   (case (:step step)
-    :dispatch          (render-dispatch-step step (:epoch-history ctx))
+    :dispatch          (render-dispatch-step step (:dispatch-id->epoch-id ctx))
     :coeffect          (render-coeffect-step step)
     :handler           (render-handler-step step)
     :flow              (render-flow-step step)
@@ -3944,9 +3952,16 @@
       (cond
         (= :focused status)
         (if (seq steps)
+          ;; rf2-x25e0 — build the `{dispatch-id → epoch-id}` index
+          ;; once per panel render. Threaded through `ctx` to the
+          ;; DISPATCH step's `:fx-dispatch` / `:fx-dispatch-later`
+          ;; parent-epoch resolver (O(1) lookup instead of an O(N)
+          ;; epoch-history scan per render).
           (pipeline-view steps
-                         {:dispatch-id   dispatch-id
-                          :epoch-history epoch-history})
+                         {:dispatch-id           dispatch-id
+                          :epoch-history         epoch-history
+                          :dispatch-id->epoch-id (proj/dispatch-id->epoch-id-index
+                                                   epoch-history)})
           (empty-state-view :no-events))
 
         :else

--- a/tools/xray/test/day8/re_frame2_xray/panels/cancellation_cascade_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/cancellation_cascade_cljs_test.cljs
@@ -167,7 +167,18 @@
         (let [aborts (find-all-by-testid-prefix
                        tree "rf-xray-cancellation-cascade-abort-row-")]
           (is (= 2 (count aborts))
-              "two abort rows rendered, one per fixture event"))))))
+              "two abort rows rendered, one per fixture event"))
+        ;; rf2-wuwu3 — each row's `:style` is one of the 6 precomputed
+        ;; row-style × cursor variants (no per-render `merge`). The
+        ;; `:cursor` slot is baked into the row style at ns load, so
+        ;; the rendered row's :style map carries `:cursor` directly.
+        (let [decision-row (find-by-testid tree "rf-xray-cancellation-cascade-decision-row")
+              aborts       (find-all-by-testid-prefix
+                             tree "rf-xray-cancellation-cascade-abort-row-")]
+          (is (contains? (:style (second decision-row)) :cursor)
+              "decision row picks one of the precomputed row-style × cursor variants")
+          (is (every? #(contains? (:style (second %)) :cursor) aborts)
+              "every abort row picks one of the precomputed row-style × cursor variants"))))))
 
 (deftest popover-renders-cascade-for-focused-event
   (testing "Popover opened with a dispatch-id focus pulls the cascade

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -1599,28 +1599,51 @@
 (deftest find-parent-epoch-by-dispatch-id-test
   (testing "rf2-5qp4g — find-parent-epoch resolves a parent epoch's
             `:epoch-id` from its `:dispatch-id`. Reverse of
-            `find-child-epoch`: walks the epoch-history for a record
-            whose `:dispatch-id` matches the supplied
-            parent-dispatch-id, returning that record's `:epoch-id`.
-            The view layer uses this to wire the
-            `from fx · parent epoch #N` chrome on `:fx-dispatch` /
-            `:fx-dispatch-later` DISPATCH steps."
+            `find-child-epoch`: looks up the supplied
+            parent-dispatch-id in a precomputed
+            `{dispatch-id → epoch-id}` index (rf2-x25e0; built once
+            per render via `dispatch-id->epoch-id-index`), returning
+            the matched record's `:epoch-id`. The view layer uses
+            this to wire the `from fx · parent epoch #N` chrome on
+            `:fx-dispatch` / `:fx-dispatch-later` DISPATCH steps."
     (let [history [{:epoch-id 41 :dispatch-id 9000 :trigger-event [:root]}
                    {:epoch-id 42 :dispatch-id 9001 :trigger-event [:parent]}
                    {:epoch-id 43 :dispatch-id 9002 :trigger-event [:child]
-                    :parent-dispatch-id 9001}]]
-      (is (= 41 (proj/find-parent-epoch history 9000))
+                    :parent-dispatch-id 9001}]
+          index   (proj/dispatch-id->epoch-id-index history)]
+      (is (= 41 (proj/find-parent-epoch index 9000))
           "matches the first-class :dispatch-id slot")
-      (is (= 42 (proj/find-parent-epoch history 9001))
+      (is (= 42 (proj/find-parent-epoch index 9001))
           "matches a sibling parent's :dispatch-id")
-      (is (nil? (proj/find-parent-epoch history 99999))
+      (is (nil? (proj/find-parent-epoch index 99999))
           "no match → nil")
       (is (nil? (proj/find-parent-epoch nil 9001))
-          "nil history → nil")
-      (is (nil? (proj/find-parent-epoch history nil))
+          "nil index → nil")
+      (is (nil? (proj/find-parent-epoch index nil))
           "nil parent-dispatch-id → nil")
-      (is (nil? (proj/find-parent-epoch [] 9001))
-          "empty history → nil"))))
+      (is (nil? (proj/find-parent-epoch {} 9001))
+          "empty index → nil"))))
+
+(deftest dispatch-id->epoch-id-index-test
+  (testing "rf2-x25e0 — `dispatch-id->epoch-id-index` builds the
+            O(1) lookup map the view threads through `ctx`. Each
+            record contributes via its first-class `:dispatch-id`
+            slot (rf2-rly4a) AND via `dispatch-id-of-epoch`'s trace-
+            walk fallback (for restored fixtures lacking the slot)."
+    (let [history [{:epoch-id 41 :dispatch-id 9000 :trigger-event [:root]}
+                   {:epoch-id 42 :dispatch-id 9001 :trigger-event [:parent]}
+                   {:epoch-id 43 :dispatch-id 9002 :trigger-event [:child]
+                    :parent-dispatch-id 9001}]
+          index   (proj/dispatch-id->epoch-id-index history)]
+      (is (= 41 (get index 9000)))
+      (is (= 42 (get index 9001)))
+      (is (= 43 (get index 9002)))
+      (is (nil? (get index 99999))
+          "absent key → nil")
+      (is (= {} (proj/dispatch-id->epoch-id-index []))
+          "empty history → empty index")
+      (is (= {} (proj/dispatch-id->epoch-id-index nil))
+          "nil history → empty index"))))
 
 ;; `project-includes-child-dispatches-step-test` retired in rf2-xu5iv
 ;; (commit eccb6db1b dropped the CHILD-DISPATCHES step from the

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -805,6 +805,38 @@
           "no surrounding transition → no source-state stamp")
       (is (nil? (:event-id (first rows)))))))
 
+(deftest machine-cascade-rows-post-transition-row-falls-back-to-prior-test
+  (testing "rf2-w6yfq — when rows trail BEHIND the last transition
+            (post-commit timer-cancels), `enrich-cascade-rows` falls
+            back to the most recent preceding transition's
+            :from-state / :to-state / :event. Pins the two-pass
+            (right-to-left then left-to-right) shape that replaced the
+            O(n²) forward-scan."
+    (let [evs [(machine-guard-ev :ready? :pass)
+               (machine-transition-ev :ws/conn
+                                       {:state :idle :data {}}
+                                       {:state :connected :data {}}
+                                       [:ws/start] 0)
+               ;; Post-commit timer-cancel — no transition ahead.
+               (machine-timer-cancel-ev :ws/conn [:idle] 250 :on-exit)]
+          rows (proj/machine-cascade-rows evs)]
+      ;; Pre-transition guard row → next-ahead supplies the transition
+      ;; states.
+      (is (= :idle      (-> rows (nth 0) :source-state)))
+      (is (= :connected (-> rows (nth 0) :target-state)))
+      ;; The transition row itself stamps from its own slots.
+      (is (= :idle      (-> rows (nth 1) :source-state)))
+      (is (= :connected (-> rows (nth 1) :target-state)))
+      ;; Post-transition timer-cancel — no next-ahead transition;
+      ;; falls back to `prior` (the preceding transition row). This
+      ;; is the exact path rf2-w6yfq tightened from O(n²) to O(n).
+      (is (= :idle      (-> rows (nth 2) :source-state))
+          "post-transition row inherits :source-state from the preceding transition (prior fallback)")
+      (is (= :connected (-> rows (nth 2) :target-state))
+          "post-transition row inherits :target-state from the preceding transition (prior fallback)")
+      (is (= :ws/start  (-> rows (nth 2) :event-id))
+          "post-transition row inherits :event-id from the preceding transition"))))
+
 (deftest state-spec-path-prefix-test
   (testing "rf2-wwc3j — `state-spec-path-prefix` coerces a state form
             into the spec-path prefix the macro's source-coord index uses"

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -194,15 +194,16 @@
 
 (deftest dispatch-source-fx-dispatch-renders-rich-label-test
   (testing "rf2-5qp4g — `:source :fx-dispatch` renders the kind label
-            and the parent-epoch navigation chip"
+            and the parent-epoch navigation chip. rf2-x25e0 — the
+            second arg is now the precomputed
+            `{dispatch-id → epoch-id}` index (was `epoch-history`)."
     (let [step {:step :dispatch :badge :DISPATCH :step-number 1
                 :event [:cart/add :apple]
                 :source :fx-dispatch
                 :coord nil
                 :source-enrichment {:parent-dispatch-id 9001}}
-          epoch-history [{:epoch-id 42 :dispatch-id 9001
-                          :trigger-event [:checkout/begin]}]
-          tree (view/render-dispatch-step step epoch-history)
+          index {9001 42}
+          tree (view/render-dispatch-step step index)
           header-text (text-of tree "rf-xray-epoch-dispatch-header")]
       (is (string/includes? (or header-text "") "from fx :dispatch")
           "the kind label reads 'from fx :dispatch'")
@@ -225,9 +226,8 @@
                 :coord nil
                 :source-enrichment {:parent-dispatch-id 9001
                                     :delay-ms 500}}
-          epoch-history [{:epoch-id 42 :dispatch-id 9001
-                          :trigger-event [:checkout/begin]}]
-          tree (view/render-dispatch-step step epoch-history)
+          index {9001 42}
+          tree (view/render-dispatch-step step index)
           header-text (text-of tree "rf-xray-epoch-dispatch-header")]
       (is (string/includes? (or header-text "") "from fx :dispatch-later")
           "the kind label reads 'from fx :dispatch-later'")
@@ -251,9 +251,8 @@
                 :source :fx-dispatch
                 :coord nil
                 :source-enrichment {:parent-dispatch-id 99999}}
-          epoch-history [{:epoch-id 42 :dispatch-id 9001
-                          :trigger-event [:checkout/begin]}]
-          tree (view/render-dispatch-step step epoch-history)]
+          index {9001 42}
+          tree (view/render-dispatch-step step index)]
       (is (nil? (th/find-by-testid tree "rf-xray-epoch-dispatch-parent-epoch-link"))
           "no clickable link when the parent epoch isn't in the buffer")
       (let [unresolved (th/find-by-testid
@@ -264,9 +263,9 @@
 
 (deftest dispatch-source-fx-dispatch-without-history-test
   (testing "rf2-5qp4g — when render-dispatch-step is called without
-            epoch-history (direct test callers, or pre-history-seed
-            cold mount), `:fx-dispatch` still renders the kind label
-            with the parent chip in unresolved form."
+            the dispatch-id->epoch-id index (direct test callers, or
+            pre-history-seed cold mount), `:fx-dispatch` still renders
+            the kind label with the parent chip in unresolved form."
     (let [step {:step :dispatch :badge :DISPATCH :step-number 1
                 :event [:cart/add :apple]
                 :source :fx-dispatch
@@ -274,7 +273,7 @@
                 :source-enrichment {:parent-dispatch-id 9001}}
           tree (view/render-dispatch-step step)]
       (is (nil? (th/find-by-testid tree "rf-xray-epoch-dispatch-parent-epoch-link"))
-          "no clickable link without epoch-history threaded")
+          "no clickable link without dispatch-id->epoch-id threaded")
       (is (some? (th/find-by-testid
                    tree "rf-xray-epoch-dispatch-parent-epoch-unresolved"))
           "the unresolved-parent chip carries the parent-dispatch-id"))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -1359,7 +1359,14 @@
       (is (some? oth-sec)
           "the other section mounts when other-effects is non-empty")
       (is (pos? (count (ei-mounts oth-sec)))
-          "the other section mounts an edn-inspector"))))
+          "the other section mounts an edn-inspector")
+      ;; rf2-5t8y8 — sub-header carries an at-a-glance entry-count chip
+      ;; on both `:fx` and `other` (was lost during the rf2-p2zy0
+      ;; edn-inspector migration).
+      (is (string/includes? (th/text-content fx-sec) "2 entries")
+          "the :fx sub-header carries the entry-count chip")
+      (is (string/includes? (th/text-content oth-sec) "1 entry")
+          "the other sub-header carries the singular entry chip"))))
 
 (deftest fx-step-args-route-through-mini-test
   (testing "rf2-8w8er — FX step row's args render through `ei/mini`."

--- a/tools/xray/testbeds/panel_gallery/fixtures_epoch.cljs
+++ b/tools/xray/testbeds/panel_gallery/fixtures_epoch.cljs
@@ -6,11 +6,13 @@
   `tools/xray/spec/021-Dynamic-Panel-Designs.md` §9.1 — the focused
   epoch's complete computational timeline as a numbered vertical
   cascade: DISPATCH → COEFFECT (one per cofx) → HANDLER → FLOW
-  (one per flow, rf2-xnb1x) → FX → SUBSCRIPTIONS → VIEWS →
-  SCHEMA HOT-RELOAD (rf2-xgeag — hot-reload drift only;
-  runtime-boundary violations attach as inline sub-blocks under
-  their owning step). Each step is CONDITIONAL — only the steps
-  whose driving trace events surfaced get rendered (per
+  (one per flow, rf2-xnb1x) → FX → SUBSCRIPTIONS → VIEWS. Runtime-
+  boundary schema violations attach as inline sub-blocks under
+  their owning step (rf2-xgeag + rf2-8resu); hot-reload drift
+  surfaces via the Issues panel exclusively (rf2-7gf7v retired the
+  standalone SCHEMA HOT-RELOAD tail step). Each step is
+  CONDITIONAL — only the steps whose driving trace events surfaced
+  get rendered (per
   `tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc`).
 
   The 10-entry badge inventory + 16ms long-step threshold ride on
@@ -49,116 +51,235 @@
   builder here mirrors the substrate emit-site shape — the same shape
   the projection unit tests at
   `tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc`
-  pin. Drift in either keeps both broken in lock-step.
+  pin. Drift in either keeps both broken in lock-step.")
 
-  ## Shared trace-event builders (rf2-tyivx)
+;; ---- trace-event primitives ---------------------------------------------
 
-  All trace-event primitives now live in
-  `day8.re-frame2-xray.test-helpers.trace-event-builders` and are
-  consumed via thin per-fixture wrappers below. ONE canonical name
-  set; one diff lands a substrate-side rename. The wrappers preserve
-  the gallery-specific timing / explanation defaults (cofx
-  elapsed-ms = 0.1, flow elapsed-ms = 0.4, sub elapsed-ms = 0.2, etc.)
-  so existing gallery variants keep their pre-rf2-tyivx visual shape."
-  (:require [day8.re-frame2-xray.test-helpers.trace-event-builders :as teb]))
+(defn- ev
+  "Minimal trace-event map. `op-type` is the broad classifier
+  (`:rf.event / :rf.fx / :rf.sub / :rf.view / :rf.machine / …`),
+  `operation` the precise emit op the projection reads."
+  [op-type operation tags]
+  {:op-type   op-type
+   :operation operation
+   :tags      tags})
 
-;; ---- trace-event primitives (gallery-specific wrappers) ----------------
-;;
-;; Each wrapper threads through to the shared `teb/*` builder with the
-;; gallery's default timing payloads — these timings drive the
-;; rendered "Nms" chips in the gallery snapshots; the projection
-;; reader unit tests don't need them. The shared builder set carries
-;; the same callable shape the substrate stamps; this seam preserves
-;; the gallery-specific defaults without duplicating the substrate
-;; tag schema.
-
-(def ^:private ev teb/ev)
-
-(def ^:private dispatched-ev teb/dispatched-ev)
+(defn- dispatched-ev
+  "`:rf.event/dispatched` trace — drives the DISPATCH row. Carries
+  the substrate-canonical `:rf.event/v` (event vector) +
+  `:source` + optional `:rf.trace/call-site`."
+  ([event] (dispatched-ev event nil nil))
+  ([event source] (dispatched-ev event source nil))
+  ([event source coord]
+   (cond-> (ev :rf.event :rf.event/dispatched
+              {:rf.event/v         event
+               :source             source
+               :rf.trace/call-site coord})
+     true (assoc :event event :source source))))
 
 (defn- cofx-run-ev
-  "Wrapper: cofx with the gallery's canonical 0.1ms elapsed default
-  so the rendered timing chip reads as expected. `teb/cofx-run-ev`
-  takes the elapsed explicitly."
+  "`:rf.cofx/run` trace — one per USER-injected coeffect. System
+  cofx (`:db / :event / :frame / :source / :trace-id`) are filtered
+  out by the projection (rf2-cq0ch), so fixtures only need to emit
+  the user-injected ids the COEFFECT step should surface.
+
+  rf2-w2r4p — substrate stamps the canonical `:rf.cofx/elapsed-ms`
+  duration tag (rf2-hhh92 · `re-frame.cofx`; spec 009 §243); fixture
+  mirrors that. The reader retains a legacy `:duration-ms` fallback
+  for older runtimes / external test fixtures."
   [id value]
-  (teb/cofx-run-ev id value 0.1))
+  (ev :rf.cofx :rf.cofx/run {:rf.cofx/id          id
+                             :rf.cofx/value       value
+                             :rf.cofx/elapsed-ms  0.1}))
 
-(def ^:private run-end-ev (fn [duration-ms] (teb/run-end-ev duration-ms)))
+(defn- run-end-ev
+  "`:rf.event/run-end` trace — the projection reads the handler's
+  finalised duration here.
 
-(def ^:private db-changed-ev teb/db-changed-ev)
-(def ^:private do-fx-ev teb/do-fx-ev)
-(def ^:private fx-handled-ev teb/fx-handled-ev)
+  rf2-slnce — substrate stamps the canonical `:rf.event/elapsed-ms`
+  (rf2-hhh92 · `re-frame.router/emit-run-end-trace`); fixture mirrors
+  that. The reader retains legacy `:duration-ms` fallbacks for older
+  runtimes / external test fixtures."
+  [duration-ms]
+  (ev :rf.event :rf.event/run-end {:rf.event/elapsed-ms duration-ms}))
+
+(defn- db-changed-ev
+  "`:rf.event/db-changed` trace — drives both HANDLER's `:db-diff`
+  slot AND the dedicated APP-DB DIFF step (rf2-rrykz, same payload,
+  two surfaces). `paths` is a vec of
+  `[path before after change-kind]` quads."
+  [paths]
+  (ev :rf.event :rf.event/db-changed
+      {:rf.event/db-changed-paths paths}))
+
+(defn- do-fx-ev
+  "`:rf.fx/do-fx` trace — carries the handler's returned `:rf.event/fx`
+  payload. Drives the FX step's per-row attribution AND the
+  CHILD-DISPATCHES step (rf2-yx1ae harvests dispatch-family fx from
+  this same payload)."
+  [fx]
+  (ev :rf.fx :rf.fx/do-fx {:rf.event/fx fx}))
+
+(defn- fx-handled-ev
+  "`:rf.fx/handled` trace — one per fx-handler invocation. The FX
+  step's per-row outcome reads `:rf.fx/id` + `:rf.fx/args` +
+  `:rf.fx/elapsed-ms` here.
+
+  rf2-ipaza — substrate stamps the canonical `:rf.fx/elapsed-ms`
+  (rf2-hhh92 · `re-frame.fx`; spec 009 §241); fixture mirrors that.
+  The reader retains a legacy `:duration-ms` fallback for older
+  runtimes / external test fixtures."
+  ([fx-id args duration-ms]
+   (ev :rf.fx :rf.fx/handled {:rf.fx/id          fx-id
+                              :rf.fx/args        args
+                              :rf.fx/elapsed-ms  duration-ms})))
 
 (defn- flow-recomputed-ev
-  "Wrapper: gallery default elapsed-ms = 0.4 for FLOW rows."
+  "`:rf.flow/computed` trace — drives the FLOW step.
+
+  rf2-yhgk8 — substrate stamps the `:rf.flow/computed` operation with
+  bare `:flow-id` / `:path` / `:before` / `:result` / `:elapsed-ms`
+  tags (Spec 009 §Flow trace events · `re-frame.flows`). The name
+  `flow-recomputed-ev` is retained for call-site stability; the
+  payload is canonical."
   [flow-id path before after]
-  (teb/flow-recomputed-ev flow-id path before after 0.4))
+  (ev :rf.flow :rf.flow/computed {:flow-id    flow-id
+                                  :path       path
+                                  :before     before
+                                  :result     after
+                                  :elapsed-ms 0.4}))
 
 (defn- sub-run-ev
-  "Wrapper: gallery default elapsed-ms = 0.2 for SUBSCRIPTIONS rows."
+  "`:rf.sub/run` trace — drives one SUBSCRIPTIONS row. Per rf2-kfh1v
+  the canonical tag names are `:rf.sub/id`, `:rf.sub/query-v`,
+  `:rf.sub/value-changed?`, `:rf.sub/prev-value`, `:rf.sub/value` —
+  the projection reads ONLY these post-rf2-kfh1v."
   [sub-vec changed? before after]
-  (teb/sub-run-ev sub-vec changed? before after 0.2))
+  (ev :rf.sub :rf.sub/run {:rf.sub/id             (when (vector? sub-vec) (first sub-vec))
+                           :rf.sub/query-v        sub-vec
+                           :rf.sub/value-changed? changed?
+                           :rf.sub/prev-value     before
+                           :rf.sub/value          after
+                           :rf.sub/elapsed-ms     0.2}))
 
-(def ^:private view-rendered-ev teb/view-rendered-ev)
+(defn- view-rendered-ev
+  "`:rf.view/rendered` trace (per rf2-6djth — NOT the simpler
+  `:rf.view/render` marker; only `:rf.view/rendered` carries
+  `:rf.view/id` + `:rf.view/deref-subs` + `:rf.view/elapsed-ms`)."
+  [view-id deref-subs elapsed-ms]
+  (ev :rf.view :rf.view/rendered {:rf.view/id         view-id
+                                  :rf.view/deref-subs deref-subs
+                                  :rf.view/elapsed-ms elapsed-ms}))
 
 (defn- view-unmounted-ev
-  "Wrapper: gallery default frame = `:rf/default`."
+  "`:rf.view/unmounted` trace (per rf2-9hoos / rf2-te71r) — drives
+  the VIEWS step's UNMOUNTED sub-section (rf2-gmw1i). Substrate
+  stamps `:rf.view/id` + `:rf.view/render-key` + `:frame` on every
+  view-instance teardown."
   [view-id render-key]
-  (teb/view-unmounted-ev view-id render-key :rf/default))
+  (ev :rf.view :rf.view/unmounted {:rf.view/id         view-id
+                                   :rf.view/render-key render-key
+                                   :frame              :rf/default}))
 
-(def ^:private sub-dispose-ev teb/sub-dispose-ev)
+(defn- sub-dispose-ev
+  "`:rf.sub/dispose` trace (per rf2-mrnur) — drives the SUBSCRIPTIONS
+  step's DISPOSED sub-section (rf2-wpfjo). Substrate stamps
+  `:rf.sub/id` + `:rf.sub/query-v` + `:rf.sub/reason` + `:frame` on
+  every cache-eviction site (closed `:reason` set per rf2-mrnur:
+  `:no-more-derefers / :hot-reload / :cache-clear`)."
+  [sub-vec reason]
+  (ev :rf.sub :rf.sub/dispose {:rf.sub/id      (when (vector? sub-vec) (first sub-vec))
+                               :rf.sub/query-v sub-vec
+                               :rf.sub/reason  reason
+                               :frame          :rf/default}))
 
 ;; ---- machine-handler trace primitives -----------------------------------
 
 (defn- machine-transition-ev
-  "Wrapper: gallery's full-arity form requires `:event` + `:microsteps`,
-  whereas the shared `teb/machine-transition-ev` makes them optional
-  via cond->. Stamp them unconditionally here."
+  "`:rf.machine/transition` trace — drives the HANDLER step's
+  machine TRANSITION sub-section + the DATA-REDUCTION /
+  SNAPSHOT-DIFF projections (the panel's machine-handler full
+  design, PR #2193). `before` + `after` are full machine snapshot
+  maps (`:state` + `:data` + …)."
   [machine-id event before after microsteps]
-  (teb/machine-transition-ev machine-id before after event microsteps))
+  (ev :rf.machine :rf.machine/transition
+      {:machine-id machine-id
+       :event      event
+       :before     before
+       :after      after
+       :microsteps microsteps}))
 
-(def ^:private machine-guard-ev teb/machine-guard-ev)
+(defn- machine-guard-ev
+  "`:rf.machine/guard-evaluated` trace — drives the HANDLER step's
+  GUARDS sub-section (one row per guard, with outcome
+  `:pass / :fail / :threw`)."
+  [guard-id outcome]
+  (ev :rf.machine :rf.machine/guard-evaluated {:guard-id guard-id
+                                               :outcome  outcome}))
 
 (defn- machine-action-ev
-  "Wrapper: gallery's richer 5-arg form folds `:fx` + `:data` into
-  the outcome map. The shared builder's 4-arg form takes a plain
-  outcome (kw or map); we compose the outcome locally."
+  "`:rf.machine/action-ran` trace — drives the HANDLER step's
+  LIFECYCLE sub-section (one row per action, grouped by `:phase`
+  `:exit / :transition / :entry / :always / :after-action / …` per
+  rf2-82a0u). Optional `:outcome :fx` rides the rf2-9c27r
+  per-action fx attribution."
   ([action-id phase outcome]
    (machine-action-ev action-id phase outcome nil nil))
   ([action-id phase outcome data action-fx]
    (let [outcome-map (cond-> (if (map? outcome) outcome {})
                        action-fx (assoc :fx action-fx)
                        data      (assoc :data data))]
-     (teb/machine-action-ev action-id phase outcome-map data))))
+     (ev :rf.machine :rf.machine/action-ran
+         {:action-id action-id
+          :phase     phase
+          :outcome   outcome-map
+          :input     {:data (or data {}) :event nil}}))))
 
-(def ^:private machine-timer-cancel-ev teb/machine-timer-cancel-ev)
+(defn- machine-timer-cancel-ev
+  "`:rf.machine.timer/cancelled` trace — drives the HANDLER step's
+  AFTER-TIMERS sub-section (one row per cancelled timer with
+  `:reason` in the unified rf2-82a0u set)."
+  [machine-id state delay reason]
+  (ev :rf.machine :rf.machine.timer/cancelled
+      {:machine-id machine-id
+       :state      state
+       :delay      delay
+       :reason     reason}))
 
 ;; ---- schema-violation trace primitives ----------------------------------
 
 (defn- schema-violation-ev
-  "Wrapper: gallery seeds a representative `:explain` + `:explain-
-  humanized` shape (per rf2-2ek7t) on top of the shared builder's
-  bare runtime-failure payload — the gallery panels render the
-  humanized chrome, so a literal example is the right gallery seed.
-  Real substrate emits populate `:explain-humanized` via the
-  `:schemas/humanize-explain!` late-bind hook."
-  [where failing-id path value rollback?]
-  (let [base      (teb/schema-violation-ev where failing-id path value rollback?)
-        path-leaf (if (sequential? path) (last path) path)]
-    (update base :tags merge
-            {:explain           {:errors [{:path path :message "expected int"}]}
-             :explain-humanized {path-leaf [(str "should be an integer, got "
-                                                  (pr-str value))]}})))
+  "`:rf.error/schema-validation-failure` trace (rf2-17vxj) — the
+  runtime per-event boundary check (`:where` in
+  `:app-db / :cofx / :sub-return / :fx-args`). Drives the SCHEMA
+  VIOLATIONS step.
 
-(defn- schema-hot-reload-ev
-  "Wrapper: gallery seeds richer hot-reload metadata (`:pre-reload-
-  schema` / `:post-reload-schema`) on top of the shared builder's
-  minimal `:frame / :path / :mismatching-value / :recovery` set."
-  [frame-id path mismatching-value]
-  (let [base (teb/schema-hot-reload-ev frame-id path mismatching-value)]
-    (update base :tags merge
-            {:pre-reload-schema  :int?
-             :post-reload-schema :pos-int?})))
+  Per rf2-2ek7t the trace event also carries `:explain-humanized` —
+  the Malli-humanized form of the raw `:explain` map. The substrate
+  populates this slot via the late-bind `:schemas/humanize-explain!`
+  hook (Malli adapter publishes `malli.error/humanize` under it).
+  For fixture-replay tests (which bypass the substrate's
+  `emit-validation-failure!` helper) we seed a representative
+  humanized shape directly so the violation block demonstrates the
+  new chrome — `{<path-leaf> [<message>]}` is the canonical
+  humanize output for a single-error explain."
+  [where failing-id path value rollback?]
+  (let [path-leaf (if (sequential? path) (last path) path)]
+    (ev :error :rf.error/schema-validation-failure
+        {:where             where
+         :failing-id        failing-id
+         :path              path
+         :value             value
+         :rollback?         (boolean rollback?)
+         :explain           {:errors [{:path path :message "expected int"}]}
+         :explain-humanized {path-leaf [(str "should be an integer, got "
+                                              (pr-str value))]}})))
+
+;; `schema-hot-reload-ev` retired per rf2-w8evg — the standalone
+;; SCHEMA HOT-RELOAD tail step was retired in rf2-7gf7v; hot-reload
+;; drift now surfaces via the Issues panel exclusively, so a fixture
+;; helper that synthesises a tail-step trace is dead weight. If the
+;; Issues-panel gallery needs an equivalent it lives there.
 
 ;; ---- epoch-record builder ------------------------------------------------
 
@@ -352,23 +473,26 @@
 ;;
 ;; Section coverage: rf2-xgeag inline violation sub-blocks. Each
 ;; runtime per-boundary failure attaches to its OWNING pipeline step
-;; (HANDLER for :app-db, FX row for :fx-args, SUBSCRIPTIONS row for
-;; :sub-return). Hot-reload drift rides on the standalone
-;; SCHEMA HOT-RELOAD tail step (Option A) since drift has no owning
-;; cascade step.
+;; (post-rf2-8resu + rf2-7gf7v attachment mapping):
 ;;
-;; The fixture covers the most operator-visible cases:
-;;   - `:app-db` rolled back → HANDLER sub-block + downstream mute
-;;   - `:fx-args` skipped    → FX row sub-block (per-row attachment)
-;;   - `:sub-return` nil     → SUBSCRIPTIONS row sub-block
-;;   - hot-reload drift      → tail SCHEMA HOT-RELOAD step
+;;   :where slot   | owning step
+;;   --------------|------------------------------------------------
+;;   :app-db       | FX step's `:db` row (the implicit commit fx;
+;;                 |   rf2-8resu — moved from HANDLER)
+;;   :fx-args      | FX row matching `:failing-id` (per-row)
+;;   :sub-return   | SUBSCRIPTIONS row matching `:failing-id`
+;;   :hot-reload   | Issues panel only — no cascade step (rf2-7gf7v)
+;;
+;; The fixture exercises the FX-row attachment surface (`:app-db`'s
+;; :db row + a `:fx-args` failure on a sibling fx row). Hot-reload
+;; drift is no longer a cascade-step concern, so the fixture no
+;; longer synthesises it.
 
 (defn schema-violations-history
-  "Cascade exercising the rf2-xgeag inline violation attachment. The
-  `:app-db` violation rolls back the cascade, muting the FX /
-  SUBSCRIPTIONS / VIEWS chrome downstream; the FX-args + sub-return
-  violations land on their matching rows; the hot-reload drift rides
-  on the tail SCHEMA HOT-RELOAD step."
+  "Cascade exercising the rf2-xgeag inline violation attachment.
+  The `:app-db` violation attaches to the FX step's `:db` row
+  (rf2-8resu — the implicit commit fx), rolls the cascade back, and
+  mutes the SUBSCRIPTIONS / VIEWS chrome downstream."
   []
   (single-epoch-history
     {:epoch-id 4
@@ -377,15 +501,10 @@
      [(dispatched-ev [:counter/set "not-a-number"] :ui)
       ;; Validation failure: the handler tried to set :counter to
       ;; a string; the app-db boundary schema rejected the write
-      ;; and rolled the cascade back. Attaches to HANDLER + flips
-      ;; downstream steps muted.
+      ;; and rolled the cascade back. Attaches to the FX step's
+      ;; `:db` row (rf2-8resu) + flips downstream steps muted.
       (schema-violation-ev :app-db :counter/set [:counter]
                            "not-a-number" true)
-      ;; Hot-reload drift: a separate schema (the :user/profile
-      ;; map) was re-registered tighter, and the live app-db value
-      ;; now fails the new shape. Rides on the tail SCHEMA HOT-RELOAD
-      ;; step (Option A — drift has no owning cascade step).
-      (schema-hot-reload-ev :rf/default [:user/profile :age] -3)
       (run-end-ev 0.3)]}))
 
 ;; ---- VARIANT 5: child-dispatching cascade -------------------------------

--- a/tools/xray/testbeds/panel_gallery/gallery_epoch.cljs
+++ b/tools/xray/testbeds/panel_gallery/gallery_epoch.cljs
@@ -17,7 +17,7 @@
   | `vanilla-db`             | DISPATCH · COEFFECT · HANDLER (db) · APP-DB DIFF · SUBSCRIPTIONS · VIEWS |
   | `reg-event-fx`           | DISPATCH · HANDLER (fx) · APP-DB DIFF · FX (✓ + ✗ + header counters) |
   | `machine-driven`         | DISPATCH · HANDLER (machine: TRANSITION · GUARDS · LIFECYCLE · AFTER-TIMERS · DATA-REDUCTION · SNAPSHOT-DIFF) · APP-DB DIFF · FX |
-  | `schema-violations`      | DISPATCH · HANDLER (db, with rolled-back app-db violation sub-block + downstream mute) · SCHEMA HOT-RELOAD tail (rf2-xgeag) |
+  | `schema-violations`      | DISPATCH · HANDLER (db) · FX (`:db` row carries the rolled-back app-db violation sub-block — rf2-8resu — and mutes SUBSCRIPTIONS / VIEWS downstream) |
   | `child-dispatches`       | DISPATCH · HANDLER (fx) · APP-DB DIFF · FX · CHILD DISPATCHES (resolved + not-in-buffer) |
   | `long-step`              | DISPATCH · HANDLER (fx, 42ms · long-step chrome) · APP-DB DIFF · FX (28ms long-step) · SUBSCRIPTIONS · VIEWS |
   | `flow-firing`            | DISPATCH · HANDLER (db) · APP-DB DIFF · FLOW · FX · SUBSCRIPTIONS · VIEWS |
@@ -115,12 +115,13 @@
   ;; ----- 4. schema-violation cascade ---------------------------------
   (story/reg-variant :story.xray.epoch/schema-violations
     {:doc        "Cascade where the app-db boundary check fired
-                 (validation failure with rollback) AND a hot-reload
-                 drift surfaced. Exercises the rf2-xgeag inline
-                 violation sub-block: the :app-db violation attaches
-                 to HANDLER with a pink sub-block + rolled-back banner,
-                 and downstream steps mute. The hot-reload drift rides
-                 on the standalone SCHEMA HOT-RELOAD tail step."
+                 (validation failure with rollback). Exercises the
+                 rf2-xgeag inline violation sub-block: per rf2-8resu
+                 the :app-db violation attaches to the FX step's :db
+                 row (the implicit commit fx) with a pink sub-block,
+                 and downstream steps mute. Hot-reload drift is now
+                 an Issues-panel concern (rf2-7gf7v) — no cascade
+                 step surfaces it."
      :events     [[:rf.xray/sync-epoch-history (fixtures/schema-violations-history)]]
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})


### PR DESCRIPTION
Surgical perf + polish sweep across the Xray Epoch + cancellation-cascade panels. Six beads concentrated on `tools/xray/src/day8/re_frame2_xray/panels/epoch/*` + the cancellation-cascade panel. Each commit is per-bead so reviewers can land/revert at the bead granularity.

## Per-bead summary

### rf2-z5zm4 (P4 · comment polish) · `7d2fc7617`
db-diff eager-realisation comment claimed `mapv` but the code uses `(into [:<>] (map-indexed …))`. Aligned the comment to the actual idiom (`into` is eager regardless of the transducer/seq it consumes).

### rf2-5t8y8 (P4 · UX polish) · `7d2fc7617` (folded with above)
HANDLER step's `:fx` and `other` sub-headers lost their trailing entry-count chip during the rf2-p2zy0 edn-inspector migration. Re-threaded `(count …)` through the existing sub-header trailing-arg arity — parallel to the `cascade` sub-header. Test pinned: `"2 entries"` (plural) and `"1 entry"` (singular).

### rf2-w8evg (P3 · dead-code) · `5a6e03cde`
Items 4-6 of the bead (items 1-3 landed in #2284):
- Dropped dead `rolled-back-banner` defn + style + forward declare. The rf2-8resu redesign moved the `:where :app-db` violation from HANDLER to the FX step's `:db` row, so the standalone HANDLER-level "cascade rolled back — downstream effects skipped" banner has no caller. Downstream-mute chrome (`rolled-back-mute-style`) is still live in `render-pipeline-steps`.
- Refactored `panel-gallery.fixtures-epoch/schema-violations-history` — dropped the now-dead `schema-hot-reload-ev` helper + call site (rf2-7gf7v retired the standalone SCHEMA HOT-RELOAD tail step; drift surfaces via the Issues panel exclusively).
- Updated `gallery_epoch.cljs` section-coverage table + variant doc for `schema-violations` to reflect the new attachment shape.

### rf2-w6yfq (P4 · perf) · `ca58bee8d`
`enrich-cascade-rows` previously did a forward `(some … (subvec v i))` per row — O(n²) in the cascade length. Replaced with two linear passes:
1. RIGHT-TO-LEFT: build `next-ahead[i]` = the first transition at-or-ahead of `i`.
2. LEFT-TO-RIGHT: thread `prior` (most recent transition strictly before `i`). Surrounding tx is `(or next-ahead[i] prior)`.

Two linear passes + one `mapv` → O(n). Real cascades are tiny (< 10 rows) so the wall-time win is asymptotic-only; the shape itself is the win. New test `machine-cascade-rows-post-transition-row-falls-back-to-prior-test` pins the prior-fallback path.

### rf2-wuwu3 (P4 · perf) · `bf244da2b`
Each `parent-decision-row` / `teardown-row` / `abort-row` previously did `(merge X-row-style cursor-Y-overlay)` per render — ~50 fresh maps per cascade re-render with the default abort threshold. Pre-computed all 6 row-style × cursor variants (3 row types × {clickable, static}) at ns load via `assoc`; each row picks one of the 6 by a single `if`. The `cursor-pointer-overlay` + `cursor-default-overlay` defs are gone. Test pins that every rendered row carries `:cursor` directly in its `:style` map.

### rf2-x25e0 (P4 · perf) · `0c1dbc050`
`find-parent-epoch` was O(N) per render — linear scan of the epoch ring per `:fx-dispatch` / `:fx-dispatch-later` DISPATCH row. Clean swap (no back-compat fallback):
- NEW `proj/dispatch-id->epoch-id-index` builds a `{dispatch-id → epoch-id}` map (one walk of history).
- CHANGED `proj/find-parent-epoch` — now `[index parent-dispatch-id]`, a thin `get` (the arity-2 history-walking form is gone).
- CHANGED `view/Panel` — builds the index ONCE per panel render and threads it through `ctx` under `:dispatch-id->epoch-id`. `render-step` → `render-dispatch-step` → `dispatch-source-enriched-label` → `dispatch-fx-label` all take the index now.

New test `dispatch-id->epoch-id-index-test` pins the index shape + nil-safety. Existing tests re-pinned against the index shape.

## Quality gates

- `npm run test:cljs` (from `implementation/`): **4819 tests, 15710 assertions, 0F/0E** ✓
- `clojure -M:test` (from `tools/xray/`): **946 tests, 3676 assertions, 0F/0E** ✓

## Stance

Pre-alpha · no back-compat shims · surgical per-bead commits.