### PR TITLE
fix(routing): :rf/route layer-1 sub projects the slice (rf2-xak8u Option-A + rf2-l4upa)

### DIFF
--- a/implementation/routing/src/re_frame/routing.cljc
+++ b/implementation/routing/src/re_frame/routing.cljc
@@ -2167,7 +2167,7 @@ unknown strategies as :preserve (no-op)."}
   (select-keys (:rf/route db) route-slice-keys))
 
 (subs/reg-sub :rf/route
-  {:doc "Subscribe to the current route container — the route slice fields (`:id` / `:params` / `:query` / `:transition` / `:error` / `:fragment` / `:nav-token`) plus per-frame routing-runtime sub-keys nested under `:rf/route` per rf2-3ib8h (`:scroll-positions` / `:scroll-positions-order` / `:nav-token-counter` / `:pending-nav-counter`). Layer-1 read of the `:rf/route` slice. Per Spec 012."}
+  {:doc "Subscribe to the current route slice `{:id :params :query :transition :error :fragment :nav-token}`. Layer-1 read of the `:rf/route` slice — internal routing-runtime keys nested under `:rf/route` in app-db (`:scroll-positions`, `:nav-token-counter`, …) do not surface through this sub (rf2-xak8u). Per Spec 012."}
   route-sub-fn)
 (subs/reg-sub :rf.route/id
   {:doc "Subscribe to the current route's `:id` keyword. Per Spec 012."}

--- a/implementation/routing/src/re_frame/routing.cljc
+++ b/implementation/routing/src/re_frame/routing.cljc
@@ -2134,26 +2134,37 @@ unknown strategies as :preserve (no-op)."}
 ;; on their production-elision bundle (rf2-k682).
 
 ;; The `:rf/route` map at app-db root is the routing-runtime container.
-;; It carries the route-slice fields (:id :params :query :transition
-;; :error :fragment :nav-token) AND the per-frame routing-runtime
+;; It carries the route-slice fields AND the per-frame routing-runtime
 ;; sub-keys (:scroll-positions / :scroll-positions-order /
 ;; :nav-token-counter / :pending-nav-counter — rf2-3ib8h, nested under
 ;; :rf/route to preserve the :rf/* single-root scheme per spec/
-;; Conventions §Reserved app-db keys). Subscribers reading [:rf/route]
-;; see the full container; subscribers reading sub-keys (:rf.route/id
-;; / :rf.route/params / ...) get the projected slice fields.
+;; Conventions §Reserved app-db keys). The :rf/route layer-1 sub
+;; projects ONLY the published slice keys so views that deref
+;; [:rf/route] don't re-render on internal counter ticks (rf2-xak8u).
+;; The runtime keys remain in app-db under :rf/route and are read
+;; directly via (get-in db [:rf/route :scroll-positions]) where needed.
+
+(def ^:private route-slice-keys
+  "The published shape of the `:rf/route` sub — only these keys
+  propagate through the layer-1 sub (rf2-xak8u). Internal counters
+  (`:scroll-positions`, `:scroll-positions-order`, `:nav-token-counter`,
+  `:pending-nav-counter`) remain in `app-db` under `:rf/route` but do
+  not surface here, so consumers that deref `:rf/route` directly do
+  not re-render on internal counter ticks."
+  [:id :params :query :transition :error :fragment :nav-token])
 
 (defn route-sub-fn
-  "Layer-1 sub fn for :rf/route — reads the routing-runtime container
-  from app-db. The map carries the route-slice fields (:id :params
-  :query :transition :error :fragment :nav-token) and the per-frame
-  routing-runtime sub-keys nested under :rf/route per rf2-3ib8h
-  (:scroll-positions / :scroll-positions-order / :nav-token-counter /
-  :pending-nav-counter). Exposed publicly so external callers (smoke
-  tests, tooling) can recover the same projection without re-deriving
-  it."
+  "Layer-1 sub fn for `:rf/route` — projects the published route-slice
+  (`route-slice-keys`) from the routing-runtime container at
+  `(:rf/route db)`. The container additionally carries internal
+  routing-runtime sub-keys (`:scroll-positions` /
+  `:scroll-positions-order` / `:nav-token-counter` /
+  `:pending-nav-counter` — rf2-3ib8h); those stay in `app-db` but do
+  not leak through this sub (rf2-xak8u). Exposed publicly so external
+  callers (smoke tests, tooling) recover the same projection without
+  re-deriving it."
   [db _query]
-  (:rf/route db))
+  (select-keys (:rf/route db) route-slice-keys))
 
 (subs/reg-sub :rf/route
   {:doc "Subscribe to the current route container — the route slice fields (`:id` / `:params` / `:query` / `:transition` / `:error` / `:fragment` / `:nav-token`) plus per-frame routing-runtime sub-keys nested under `:rf/route` per rf2-3ib8h (`:scroll-positions` / `:scroll-positions-order` / `:nav-token-counter` / `:pending-nav-counter`). Layer-1 read of the `:rf/route` slice. Per Spec 012."}

--- a/spec/012-Routing.md
+++ b/spec/012-Routing.md
@@ -52,7 +52,7 @@ Audience column: **user** = an event apps dispatch or handle directly; **runtime
 
 | Sub | Returns |
 |---|---|
-| `:rf/route` | The full `:rf/route` map. |
+| `:rf/route` | The current route slice (`:id` `:params` `:query` `:fragment` `:transition` `:error` `:nav-token`). |
 | `:rf.route/id` | The active route id. |
 | `:rf.route/params` | Path params. |
 | `:rf.route/query` | Query params. |
@@ -395,10 +395,15 @@ Users who want plain anchors to be interceptable register their own delegating h
 
 ### Reading the route is a sub
 
+The `:rf/route` sub projects the published slice keys via `select-keys` over the routing-runtime container at `(:rf/route db)`. Internal routing-runtime keys (`:scroll-positions`, `:scroll-positions-order`, `:nav-token-counter`, `:pending-nav-counter`) live inside the container in `app-db` but do not surface through the sub — consumers that `deref` `[:rf/route]` see only the slice and do not re-render on internal counter ticks.
+
 ```clojure
+(def route-slice-keys
+  [:id :params :query :transition :error :fragment :nav-token])
+
 (rf/reg-sub :rf/route
-  {:doc "The current route map: {:id :params :query :transition :error}"}
-  (fn sub-route [db _] (:rf/route db)))
+  {:doc "The current route slice: {:id :params :query :fragment :transition :error :nav-token}."}
+  (fn sub-route [db _] (select-keys (:rf/route db) route-slice-keys)))
 
 (rf/reg-sub :rf.route/id
   :<- [:rf/route]

--- a/spec/conformance/fixtures/cross-spec-routing-in-ssr.edn
+++ b/spec/conformance/fixtures/cross-spec-routing-in-ssr.edn
@@ -40,9 +40,14 @@
   ;; built-in registration.
   }
 
+ ;; Per rf2-xak8u: no :sub override for :rf/route — the framework's
+ ;; route-sub-fn projects the slice (select-keys over the routing-
+ ;; runtime container at app-db :rf/route), which is what consumers
+ ;; see. A fixture-DSL `[[:get [:rf/route]]]` body would return the
+ ;; full container (including the internal counters), so we let the
+ ;; real sub stand.
  :fixture/handlers
- {:event {:rf/server-init [[:fx [[:dispatch [:rf.route/navigate :route/article-detail {:id "intro"}]]]]]}
-  :sub   {:rf/route [[:get [:rf/route]]]}}
+ {:event {:rf/server-init [[:fx [[:dispatch [:rf.route/navigate :route/article-detail {:id "intro"}]]]]]}}
 
  ;; :platform :server simulates an SSR request frame; the platform-gated
  ;; :rf.nav/push-url fx will be skipped per Spec 002 §:platforms gating.
@@ -60,18 +65,18 @@
   {:rf/route {:id     :route/article-detail
               :params {:id "intro"}}}
 
-  ;; Per rf2-3ib8h: routing-runtime per-frame state nests under
-  ;; :rf/route (:nav-token-counter etc.), satisfying the :rf/* single-
-  ;; root scheme (Conventions §Reserved app-db keys).
+  ;; Per rf2-xak8u (Option-A): the :rf/route layer-1 sub projects the
+  ;; slice keys only. Internal routing-runtime sub-keys
+  ;; (:nav-token-counter etc.) live under :rf/route in app-db but do
+  ;; not surface through the sub.
   :sub-values
-  {[:rf/route] {:id                :route/article-detail
-                :params            {:id "intro"}
-                :query             {}
-                :fragment          nil
-                :transition        :idle
-                :error             nil
-                :nav-token         "nav-1"
-                :nav-token-counter 1}}
+  {[:rf/route] {:id         :route/article-detail
+                :params     {:id "intro"}
+                :query      {}
+                :fragment   nil
+                :transition :idle
+                :error      nil
+                :nav-token  "nav-1"}}
 
   ;; The navigation fx was skipped on the server; nothing routed.
   :effects-routed []

--- a/spec/conformance/fixtures/routing-history-popstate.edn
+++ b/spec/conformance/fixtures/routing-history-popstate.edn
@@ -36,9 +36,14 @@
           :rf.nav/replace-url {:platforms #{:client}}
           :rf.nav/scroll      {:platforms #{:client}}}}
 
+ ;; Per rf2-xak8u: no :sub override for :rf/route — the framework's
+ ;; route-sub-fn projects the slice (select-keys over the routing-
+ ;; runtime container at app-db :rf/route), which is what consumers
+ ;; see. A fixture-DSL `[[:get [:rf/route]]]` body would return the
+ ;; full container (including the internal counters), so we let the
+ ;; real sub stand.
  :fixture/handlers
  {:event {:rf/init [[:set [:rf/route] {:id :route/home :params {}}]]}
-  :sub   {:rf/route [[:get [:rf/route]]]}
   :fx    {:rf.nav/push-url    [[:noop]]
           :rf.nav/replace-url [[:noop]]
           :rf.nav/scroll      [[:noop]]}}
@@ -57,18 +62,18 @@
   {:rf/route {:id     :route/article
               :params {:id "intro"}}}
 
-  ;; Per rf2-3ib8h: routing-runtime per-frame state nests under
-  ;; :rf/route (:nav-token-counter etc.), satisfying the :rf/* single-
-  ;; root scheme (Conventions §Reserved app-db keys).
+  ;; Per rf2-xak8u (Option-A): the :rf/route layer-1 sub projects the
+  ;; slice keys only. Internal routing-runtime sub-keys
+  ;; (:nav-token-counter etc.) live under :rf/route in app-db but do
+  ;; not surface through the sub.
   :sub-values
-  {[:rf/route] {:id                :route/article
-                :params            {:id "intro"}
-                :query             {}
-                :fragment          nil
-                :transition        :idle
-                :error             nil
-                :nav-token         "nav-1"
-                :nav-token-counter 1}}
+  {[:rf/route] {:id         :route/article
+                :params     {:id "intro"}
+                :query      {}
+                :fragment   nil
+                :transition :idle
+                :error      nil
+                :nav-token  "nav-1"}}
 
   ;; Critical contract: ONLY :rf.nav/scroll routes — the runtime MUST
   ;; NOT push or replace the URL when the URL change ORIGINATED at the

--- a/spec/conformance/fixtures/routing-navigate.edn
+++ b/spec/conformance/fixtures/routing-navigate.edn
@@ -20,9 +20,15 @@
  ;; runtime's built-in handler (per Spec 012) computes the URL via
  ;; route-url and emits :rf.nav/push-url, which is exactly what
  ;; :effects-routed asserts.
+ ;;
+ ;; Per rf2-xak8u: no :sub override for :rf/route either — the
+ ;; framework's route-sub-fn projects the slice (select-keys over the
+ ;; routing-runtime container at app-db :rf/route), which is what
+ ;; consumers see. A fixture-DSL `[[:get [:rf/route]]]` body would
+ ;; return the full container (including the internal counters), so
+ ;; we let the real sub stand.
  :fixture/handlers
  {:event {:rf/init [[:set [:rf/route] {:id :route/home :params {}}]]}
-  :sub   {:rf/route [[:get [:rf/route]]]}
   :fx    {:rf.nav/push-url [[:noop]]}}
 
  ;; :rf.nav/push-url declares :platforms #{:client}; the frame runs on the
@@ -39,24 +45,22 @@
  ;; (per Spec 012 §The :rf/route slice): :id, :params, :query, :fragment,
  ;; :transition, :error, :nav-token. The :final-app-db submap match
  ;; tolerates the additional keys; the :sub-values check is exact, so
- ;; the expected slice mirrors what the runtime writes. :nav-token is
- ;; matched via the wildcard `:rf.fixture/any` sentinel since the gensym
- ;; counter resets per fixture run.
+ ;; the expected slice mirrors what the :rf/route sub publishes.
  ;;
- ;; Per rf2-3ib8h: routing-runtime per-frame state nests under :rf/route
- ;; (:nav-token-counter etc.) to satisfy the :rf/* single-root scheme
- ;; (Conventions §Reserved app-db keys). After two navigates against a
- ;; reset counter the slot reads "nav-token-counter 2".
+ ;; Per rf2-xak8u (Option-A): the :rf/route layer-1 sub projects the
+ ;; slice keys only. Internal routing-runtime sub-keys
+ ;; (:nav-token-counter etc.) live under :rf/route in app-db but do
+ ;; not surface through the sub, so :sub-values asserts the slice-
+ ;; only shape.
  {:final-app-db {:rf/route {:id :route/article-detail :params {:id "intro"}}}
 
-  :sub-values   {[:rf/route] {:id                :route/article-detail
-                              :params            {:id "intro"}
-                              :query             {}
-                              :fragment          nil
-                              :transition        :idle
-                              :error             nil
-                              :nav-token         "nav-2"
-                              :nav-token-counter 2}}
+  :sub-values   {[:rf/route] {:id         :route/article-detail
+                              :params     {:id "intro"}
+                              :query      {}
+                              :fragment   nil
+                              :transition :idle
+                              :error      nil
+                              :nav-token  "nav-2"}}
 
   :effects-routed
   [{:fx-id :rf.nav/push-url :args "/articles"}


### PR DESCRIPTION
## Summary

Per [rf2-xak8u](https://github.com/day8/re-frame2/issues/xak8u) Option-A (Mike-approved 2026-05-28): the `:rf/route` layer-1 sub now projects the published route slice (`:id` `:params` `:query` `:transition` `:error` `:fragment` `:nav-token`) via `select-keys` over the routing-runtime container at `(:rf/route db)`. The four internal routing-runtime keys nested under `:rf/route` in app-db since rf2-3ib8h (`:scroll-positions`, `:scroll-positions-order`, `:nav-token-counter`, `:pending-nav-counter`) no longer leak through the sub — so consumers that `deref [:rf/route]` directly do **not** re-render on `save-scroll-position` / nav-token allocations.

Also closes [rf2-l4upa](https://github.com/day8/re-frame2/issues/l4upa) — the `:rf/route` reg-sub `:doc` string aligns with the Option-A contract (slice keys + leak-boundary note). rf2-l4upa's broader-shape doc edit was the correct fix for the pre-Option-A world; Option-A makes the slice-only form authoritative again.

## What changed

### Code

`implementation/routing/src/re_frame/routing.cljc`
- New `^:private route-slice-keys` def — the masterpiece touch; one place defines the published surface.
- `route-sub-fn` body switched from `(:rf/route db)` to `(select-keys (:rf/route db) route-slice-keys)`.
- `:doc` string updated to enumerate the full slice (`{:id :params :query :transition :error :fragment :nav-token}`) + name the internal keys that stay in app-db but don't surface through the sub.

### Conformance fixtures

Three fixtures dropped their `:fixture/handlers :sub :rf/route` body override and the `:nav-token-counter` line in `:sub-values`:

- `spec/conformance/fixtures/routing-navigate.edn`
- `spec/conformance/fixtures/routing-history-popstate.edn`
- `spec/conformance/fixtures/cross-spec-routing-in-ssr.edn`

The override (`[[:get [:rf/route]]]`) used to return just the slice pre-rf2-3ib8h (when the counters were at top-level under `:rf.route/*`). Post-3ib8h it returned the whole container; rf2-3ib8h added `:nav-token-counter` to the assertion to compensate. Option-A makes the framework sub project the slice — so the fixtures let the framework sub serve directly and assert the slice-only shape.

The fixtures keep the `:rf/route` entry in `:fixture/registry :sub` to document the dependency.

### Spec

`spec/012-Routing.md`
- §Surface inventory > Subscriptions table: `:rf/route` row reads 'the current route slice (`:id` `:params` …)' instead of 'the full `:rf/route` map'.
- §Reading the route is a sub: example sub uses `(select-keys (:rf/route db) route-slice-keys)` matching the real implementation; a new lead paragraph names the four internal routing-runtime keys that stay in app-db but don't surface through the sub.

`spec/Conventions.md` §Reserved app-db keys is unchanged — it describes app-db shape, which still has the broader container at `:rf/route` (only the sub projects).

## Internal callers — none

All internal routing reducer/effect code already reads counters via `get-in db [:rf/route :scroll-positions]` (etc.) directly — none go through the sub. Verified via `git grep`.

## Quality gates

- routing JVM: 121 tests / 550 assertions / 0F / 0E
- `re-frame.conformance-test`: 1 test / 1 assertion / 0F / 0E (3 routing fixtures pass after dropping their `:sub` body override)
- `npm run test:cljs`: 4817 tests / 15693 assertions / 0F / 0E
- `scripts/test-fast-pr.sh`: PASS (lockstep + skill/MCP drift + core JVM + JS harness helpers + CLJS node integration + markdown link/anchor + docs corpus; mkdocs soft-skipped locally — CI will run)

## Closes

- rf2-xak8u — Resolved by Option-A applied as designed.
- rf2-l4upa — Superseded by rf2-xak8u Option-A; the `:doc` string is now slice-only per the Mike-approved decision.