### PR TITLE
refactor(epoch): polish sweep — 7 beads (rf2-33lpr + dq2b7 + j0jxk + rtk2e + e0lva + h5r7l + bv5co)

### DIFF
--- a/implementation/core/src/re_frame/late_bind.cljc
+++ b/implementation/core/src/re_frame/late_bind.cljc
@@ -1,7 +1,8 @@
 (ns re-frame.late-bind
   "Hook registry for cross-namespace and cross-artefact forward
-  references. Producing ns calls `set-fn!` at load time; consumer calls
-  `get-fn` at call time. Identical behaviour on JVM and CLJS.
+  references. Producing ns calls `set-fn!` (single key) or `set-fns!`
+  (map of entries, rf2-rtk2e) at load time; consumer calls `get-fn` at
+  call time. Identical behaviour on JVM and CLJS.
 
   Carries two flavours of forward reference:
     1. Cyclic-load: leaf namespaces (frame, fx, cofx, subs, router)
@@ -15,7 +16,9 @@
   The authoritative inventory of every published key lives in
   `re-frame.late-bind.directory` — one CLJC entry per hook key. The
   drift test `implementation/core/test/re_frame/late_bind_drift_test.clj`
-  asserts the directory matches the in-tree `set-fn!` call sites.")
+  asserts the directory matches the in-tree publications, walking both
+  the per-key `set-fn!` form and the rf2-rtk2e map-form `set-fns!`
+  block.")
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -80,6 +83,22 @@
   [hook-key f]
   (swap! hooks assoc hook-key f)
   (invalidate-cache! hook-key)
+  nil)
+
+(defn set-fns!
+  "Register every `hook-key → fn` entry in `m` in one call (rf2-rtk2e).
+
+  Equivalent to calling `set-fn!` once per entry, but reads as a single
+  publication of an artefact's late-bind contract rather than a column
+  of identical imperative side-effects. Feature artefacts (epoch, flows,
+  schemas, machines, routing, http, ssr) publish ~15+ keys each at the
+  bottom of their facade ns; the map form makes the contract scannable.
+
+  Each entry invalidates its own slot in the resolution cache, identical
+  to repeated `set-fn!` calls. Returns nil."
+  [m]
+  (doseq [[hook-key f] m]
+    (set-fn! hook-key f))
   nil)
 
 (defn get-fn

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -39,16 +39,81 @@
 (def hooks
   "Vector of hook-directory entries — see the ns docstring for shape.
 
-  Ordering: grouped by namespace prefix (router → elision → flows →
-  schemas → machines → routing → http → subs → ssr → reagent → views →
-  adapter → epoch → trace) so additions land near their siblings."
-  [;; ---- re-frame.router (rf2-d4sf foundational dispatch seam) ----------------
+  Ordering: grouped into four primary purposes (rf2-j0jxk), and within
+  each purpose by namespace prefix so additions land near their siblings:
+
+    1. CYCLE-BREAKING  — leaf namespaces (router, subs) calling into
+       higher-level namespaces without `:require`ing them, breaking a
+       compile-time load cycle. Lookup-or-no-op is degenerate (the
+       producer always loads at boot); the indirection exists solely to
+       silence cljs.compiler's circular-dependency error.
+
+    2. CROSS-ARTEFACT  — re-frame.core (or a leaf consumer in core)
+       reaching into an OPTIONAL feature artefact (schemas, flows,
+       routing, machines, ssr, epoch, http, marks, elision) without a
+       static `:require`. When the artefact is absent from the
+       classpath the lookup returns nil and the consumer no-ops (or
+       throws a clear `:rf.error/<artefact>-artefact-missing` via
+       `require-fn!`). Also covers the always-on observability surface
+       (`:event-emit/*`, `:error-emit/*`) — production-survivor seams
+       that fire on every dispatch.
+
+    3. ADAPTER-INJECTION — substrate adapters (Reagent / reagent-slim /
+       UIx / Helix / test-react) publish CLJS-side primitives the core
+       runtime consumes (`:adapter/current-frame`, `:adapter/ratom`,
+       `:adapter/after-render`, …) and React-shaped view machinery
+       (`:reagent/set-hiccup-emitter!`, `:views/*`). Routed via
+       `substrate-adapter/route-hook!` so the installed-adapter
+       identity dispatches; chained across every loaded adapter so a
+       single SSR ns-load auto-wires every adapter's slot.
+
+    4. HOT-RELOAD / DEV-TOOLING — `:trace/*`, `:trace.tooling/*`,
+       `:trace.cascade/*`, `:privacy/*`. Dev-only surfaces gated on
+       `interop/debug-enabled?` whose producer namespaces DCE under
+       `:advanced` + `goog.DEBUG=false`; the late-bind indirection lets
+       production CLJS bundles short-circuit cleanly (lookup returns
+       nil, consumer no-ops) without surface-pruning the call sites.
+
+  Multi-category keys (e.g. `:views/*` are both adapter-injection AND
+  cycle-break depending on the consumer; `:event-emit/*` is both cross-
+  artefact AND production observability) are placed in the dominant
+  category — the one a reader first looks under when answering 'what
+  kind of forward-reference is this layer for?' The drift test is
+  unaffected by ordering; the grouping is documentation-only."
+  [;; ===========================================================================
+   ;; GROUP 1 — CYCLE-BREAKING
+   ;;
+   ;; Leaf namespaces calling into higher-level namespaces without
+   ;; `:require`ing them. The indirection exists to break compile-time
+   ;; load cycles; the producer always loads at boot, so lookup never
+   ;; misses in production.
+   ;; ===========================================================================
+
+   ;; ---- re-frame.router (rf2-d4sf foundational dispatch seam) ----------------
    {:key         :router/dispatch!
     :producer-ns 're-frame.router
     :description "Enqueue an event for processing by the drain loop."}
    {:key         :router/dispatch-sync!
     :producer-ns 're-frame.router
     :description "Process an event synchronously, bypassing the drain queue."}
+
+   ;; ---- re-frame.subs --------------------------------------------------------
+   {:key         :subs/subscribe-once
+    :producer-ns 're-frame.subs
+    :description "Subscribe and immediately deref (snapshot value, no reaction)."}
+
+   ;; ===========================================================================
+   ;; GROUP 2 — CROSS-ARTEFACT
+   ;;
+   ;; re-frame.core reaches into an OPTIONAL feature artefact (schemas,
+   ;; flows, routing, machines, ssr, epoch, http, marks, elision)
+   ;; without a static `:require`. When the artefact is absent from the
+   ;; classpath the lookup returns nil and the consumer no-ops or
+   ;; throws `:rf.error/<artefact>-artefact-missing` via `require-fn!`.
+   ;; Also covers always-on observability (`:event-emit/*`,
+   ;; `:error-emit/*`) — production-survivor seams that fire on every
+   ;; dispatch and ship in their own namespaces.
+   ;; ===========================================================================
 
    ;; ---- re-frame.elision (rf2-w3n5u schema-first registry) ------------------
    {:key         :elision/populate-from-schemas!
@@ -347,11 +412,6 @@
     :design-bead "rf2-ijm7"
     :description "Register the machine-shape wrapper for managed HTTP requests."}
 
-   ;; ---- re-frame.subs --------------------------------------------------------
-   {:key         :subs/subscribe-once
-    :producer-ns 're-frame.subs
-    :description "Subscribe and immediately deref (snapshot value, no reaction)."}
-
    ;; ---- re-frame.ssr (rf2-uo7v) ---------------------------------------------
    {:key         :ssr/render-tree-hash
     :producer-ns 're-frame.ssr
@@ -414,6 +474,94 @@
     :producer-ns 're-frame.ssr.streaming
     :design-bead "rf2-ojakd"
     :description "Build the final hydration payload after every streaming chunk has been emitted."}
+
+   ;; ---- re-frame.epoch (rf2-lt4e Tool-Pair surface) -------------------------
+   {:key         :epoch/settle!
+    :producer-ns 're-frame.epoch
+    :design-bead "rf2-nj6p7"
+    :description "Settle one DEQUEUED EVENT's epoch (commit to history). Per Spec 002 §Drain versus event the epoch boundary is the dequeued event, not the drain — the router calls this once per process-event! (incl. each :fx-dispatched child), harvesting that one event's cascade buffer. Skips an empty buffer (rejected/aborted dispatch)."}
+   {:key         :epoch/commit-halt-record!
+    :producer-ns 're-frame.epoch
+    :design-bead "rf2-nj6p7"
+    :description "Commit a :halted-* epoch record for a drain halt whose halting event never ran (the per-event depth-exceed boundary). Unlike :epoch/settle! it does NOT skip an empty buffer — under per-event epochs the already-settled events each harvested their own buffer, so the buffer is empty at halt; this synthesises the halting event's :halted-depth record from an explicit trigger. Already-settled siblings are durable (no whole-drain rollback)."}
+   {:key         :epoch/discard-buffer!
+    :producer-ns 're-frame.epoch
+    :description "Discard the in-flight epoch buffer without committing."}
+   {:key         :epoch/capture-event
+    :producer-ns 're-frame.epoch
+    :description "Capture an event into the in-flight epoch buffer."}
+   {:key         :epoch/cascade-cause
+    :producer-ns 're-frame.epoch
+    :design-bead "rf2-25zo2"
+    :description "Walk a frame's in-flight cascade buffer and return {:cause-event-id :cause-subs :rendered-so-far} for :rf.view/rendered attribution. Consumed by re-frame.views at view-render emit time so the Xray Reactive panel can graph cause→effect for re-renders. Returns nil when the epoch artefact is absent."}
+   {:key         :epoch/record-render!
+    :producer-ns 're-frame.epoch
+    :design-bead "rf2-qs6dl"
+    :description "Attribute a post-settle render emit (a :view/render / :rf.view/rendered op firing at React commit time, after the causing cascade settled) back to the cascade that caused it — the frame's most-recently-settled epoch. Called by re-frame.epoch.capture/capture-event! when a render op arrives with no in-flight cascade; back-fills the render into the causing epoch record and re-fans it to epoch listeners so snapshot consumers re-sync. Fixes the one-epoch :renders lag."}
+   {:key         :epoch/record-sub-run!
+    :producer-ns 're-frame.epoch
+    :design-bead "rf2-wi900"
+    :description "Subs sibling of :epoch/record-render!. Attribute a post-settle sub-run emit (a :sub/run / :rf.sub/skip op firing at React deref time, after the causing cascade settled, because reactions recompute lazily) back to the cascade that caused it — the frame's most-recently-settled epoch. Called by re-frame.epoch.capture/capture-event! when a sub-run op arrives with no in-flight cascade; back-fills the sub-run (and its :value-changed? / :prev-value / :value attribution) into the causing epoch record and re-fans it to epoch listeners. Fixes the one-epoch :sub-runs lag visible in Xray's per-cascade Views subs table."}
+   {:key         :epoch/epoch-history
+    :producer-ns 're-frame.epoch
+    :description "Return the committed-epoch ring buffer (introspection)."}
+   {:key         :epoch/restore-epoch
+    :producer-ns 're-frame.epoch
+    :description "Restore app-db / schemas to a previously-captured epoch."}
+   {:key         :epoch/reset-frame-db!
+    :producer-ns 're-frame.epoch
+    :description "Reset a frame's app-db to the epoch-recorded snapshot."}
+   {:key         :epoch/register-epoch-listener!
+    :producer-ns 're-frame.epoch
+    :description "Register an epoch-settled callback."}
+   {:key         :epoch/unregister-epoch-listener!
+    :producer-ns 're-frame.epoch
+    :description "Unregister a previously-registered epoch-settled callback."}
+   {:key         :epoch/configure!
+    :producer-ns 're-frame.epoch
+    :description "Configure epoch buffer size / capture policy."}
+   {:key         :epoch/clear-history!
+    :producer-ns 're-frame.epoch
+    :description "Clear the committed-epoch ring buffer (test isolation)."}
+   {:key         :epoch/clear-epoch-listeners!
+    :producer-ns 're-frame.epoch
+    :description "Clear every registered epoch-settled callback (test isolation)."}
+   {:key         :epoch/on-frame-destroyed
+    :producer-ns 're-frame.epoch
+    :description "Tear down a frame's epoch state when the frame is destroyed."}
+   {:key         :epoch/projected-record
+    :producer-ns 're-frame.epoch
+    :design-bead "rf2-mrsck"
+    :description "Project an :rf/epoch-record for off-box egress: route :db-before / :db-after / :trigger-event / :trace-events through elide-wire-value with off-box defaults; bookkeeping and structured projections pass through. Per Security.md §Epoch privacy posture."}
+   {:key         :epoch/projected-history
+    :producer-ns 're-frame.epoch
+    :design-bead "rf2-mrsck"
+    :description "Convenience wrapper returning (mapv projected-record (epoch-history frame-id))."}
+
+   ;; ---- re-frame.event-emit (rf2-rirbq — always-on event observability) -----
+   {:key         :event-emit/dispatch-on-event
+    :producer-ns 're-frame.event-emit
+    :design-bead "rf2-rirbq"
+    :description "Always-on per-event fan-out for production observability (Datadog / Honeycomb / Sentry). Survives `:advanced` + `goog.DEBUG=false`; parallel to (not a fallback for) the dev-only trace surface. Router invokes once per processed event after the cascade settles."}
+
+   ;; ---- re-frame.error-emit (rf2-bacs4 — always-on error observability) -----
+   {:key         :error-emit/dispatch-on-error
+    :producer-ns 're-frame.error-emit
+    :design-bead "rf2-bacs4"
+    :description "Always-on per-`:rf.error/*` fan-out: builds the tight error-record once (elided), then fans out to BOTH the corpus-wide listener registry (rf2-bacs4 — Sentry / Honeybadger / Rollbar shippers) AND the per-frame `:on-error` policy fn (rf2-hqbeh — in-app recovery). Both fan-out paths independent and try/catch wrapped. Survives `:advanced` + `goog.DEBUG=false`. Router invokes from the handler-exception path."}
+
+   ;; ===========================================================================
+   ;; GROUP 3 — ADAPTER-INJECTION
+   ;;
+   ;; Substrate adapters (Reagent / reagent-slim / UIx / Helix / test-
+   ;; react) publish CLJS-side primitives the core runtime consumes
+   ;; (`:adapter/current-frame`, `:adapter/ratom`, `:adapter/after-
+   ;; render`, …) and React-shaped view machinery
+   ;; (`:reagent/set-hiccup-emitter!`, `:views/*`). Routed via
+   ;; `substrate-adapter/route-hook!` so the installed-adapter identity
+   ;; dispatches; chained across every loaded adapter so a single SSR
+   ;; ns-load auto-wires every adapter's slot.
+   ;; ===========================================================================
 
    ;; ---- re-frame.adapter.reagent (rf2-0hxm) ---------------------------------
    {:key         :reagent/set-hiccup-emitter!
@@ -531,68 +679,15 @@
     :design-bead "rf2-00li"
     :description "Substrate-side source-coord injection on rendered React elements."}
 
-   ;; ---- re-frame.epoch (rf2-lt4e Tool-Pair surface) -------------------------
-   {:key         :epoch/settle!
-    :producer-ns 're-frame.epoch
-    :design-bead "rf2-nj6p7"
-    :description "Settle one DEQUEUED EVENT's epoch (commit to history). Per Spec 002 §Drain versus event the epoch boundary is the dequeued event, not the drain — the router calls this once per process-event! (incl. each :fx-dispatched child), harvesting that one event's cascade buffer. Skips an empty buffer (rejected/aborted dispatch)."}
-   {:key         :epoch/commit-halt-record!
-    :producer-ns 're-frame.epoch
-    :design-bead "rf2-nj6p7"
-    :description "Commit a :halted-* epoch record for a drain halt whose halting event never ran (the per-event depth-exceed boundary). Unlike :epoch/settle! it does NOT skip an empty buffer — under per-event epochs the already-settled events each harvested their own buffer, so the buffer is empty at halt; this synthesises the halting event's :halted-depth record from an explicit trigger. Already-settled siblings are durable (no whole-drain rollback)."}
-   {:key         :epoch/discard-buffer!
-    :producer-ns 're-frame.epoch
-    :description "Discard the in-flight epoch buffer without committing."}
-   {:key         :epoch/capture-event
-    :producer-ns 're-frame.epoch
-    :description "Capture an event into the in-flight epoch buffer."}
-   {:key         :epoch/cascade-cause
-    :producer-ns 're-frame.epoch
-    :design-bead "rf2-25zo2"
-    :description "Walk a frame's in-flight cascade buffer and return {:cause-event-id :cause-subs :rendered-so-far} for :rf.view/rendered attribution. Consumed by re-frame.views at view-render emit time so the Xray Reactive panel can graph cause→effect for re-renders. Returns nil when the epoch artefact is absent."}
-   {:key         :epoch/record-render!
-    :producer-ns 're-frame.epoch
-    :design-bead "rf2-qs6dl"
-    :description "Attribute a post-settle render emit (a :view/render / :rf.view/rendered op firing at React commit time, after the causing cascade settled) back to the cascade that caused it — the frame's most-recently-settled epoch. Called by re-frame.epoch.capture/capture-event! when a render op arrives with no in-flight cascade; back-fills the render into the causing epoch record and re-fans it to epoch listeners so snapshot consumers re-sync. Fixes the one-epoch :renders lag."}
-   {:key         :epoch/record-sub-run!
-    :producer-ns 're-frame.epoch
-    :design-bead "rf2-wi900"
-    :description "Subs sibling of :epoch/record-render!. Attribute a post-settle sub-run emit (a :sub/run / :rf.sub/skip op firing at React deref time, after the causing cascade settled, because reactions recompute lazily) back to the cascade that caused it — the frame's most-recently-settled epoch. Called by re-frame.epoch.capture/capture-event! when a sub-run op arrives with no in-flight cascade; back-fills the sub-run (and its :value-changed? / :prev-value / :value attribution) into the causing epoch record and re-fans it to epoch listeners. Fixes the one-epoch :sub-runs lag visible in Xray's per-cascade Views subs table."}
-   {:key         :epoch/epoch-history
-    :producer-ns 're-frame.epoch
-    :description "Return the committed-epoch ring buffer (introspection)."}
-   {:key         :epoch/restore-epoch
-    :producer-ns 're-frame.epoch
-    :description "Restore app-db / schemas to a previously-captured epoch."}
-   {:key         :epoch/reset-frame-db!
-    :producer-ns 're-frame.epoch
-    :description "Reset a frame's app-db to the epoch-recorded snapshot."}
-   {:key         :epoch/register-epoch-listener!
-    :producer-ns 're-frame.epoch
-    :description "Register an epoch-settled callback."}
-   {:key         :epoch/unregister-epoch-listener!
-    :producer-ns 're-frame.epoch
-    :description "Unregister a previously-registered epoch-settled callback."}
-   {:key         :epoch/configure!
-    :producer-ns 're-frame.epoch
-    :description "Configure epoch buffer size / capture policy."}
-   {:key         :epoch/clear-history!
-    :producer-ns 're-frame.epoch
-    :description "Clear the committed-epoch ring buffer (test isolation)."}
-   {:key         :epoch/clear-epoch-listeners!
-    :producer-ns 're-frame.epoch
-    :description "Clear every registered epoch-settled callback (test isolation)."}
-   {:key         :epoch/on-frame-destroyed
-    :producer-ns 're-frame.epoch
-    :description "Tear down a frame's epoch state when the frame is destroyed."}
-   {:key         :epoch/projected-record
-    :producer-ns 're-frame.epoch
-    :design-bead "rf2-mrsck"
-    :description "Project an :rf/epoch-record for off-box egress: route :db-before / :db-after / :trigger-event / :trace-events through elide-wire-value with off-box defaults; bookkeeping and structured projections pass through. Per Security.md §Epoch privacy posture."}
-   {:key         :epoch/projected-history
-    :producer-ns 're-frame.epoch
-    :design-bead "rf2-mrsck"
-    :description "Convenience wrapper returning (mapv projected-record (epoch-history frame-id))."}
+   ;; ===========================================================================
+   ;; GROUP 4 — HOT-RELOAD / DEV-TOOLING
+   ;;
+   ;; Dev-only surfaces gated on `interop/debug-enabled?` whose producer
+   ;; namespaces DCE under `:advanced` + `goog.DEBUG=false`. The late-
+   ;; bind indirection lets production CLJS bundles short-circuit
+   ;; cleanly (lookup returns nil, consumer no-ops) without surface-
+   ;; pruning the call sites.
+   ;; ===========================================================================
 
    ;; ---- re-frame.trace (re-frame.registrar replace-warning seam) ------------
    {:key         :trace/emit!
@@ -683,18 +778,6 @@
     :producer-ns 're-frame.trace.cascade
     :design-bead "rf2-931pm"
     :description "Restore the no-op default focus predicate (no epoch focused). Xray's Reactive panel calls this on unmount."}
-
-   ;; ---- re-frame.event-emit (rf2-rirbq — always-on event observability) -----
-   {:key         :event-emit/dispatch-on-event
-    :producer-ns 're-frame.event-emit
-    :design-bead "rf2-rirbq"
-    :description "Always-on per-event fan-out for production observability (Datadog / Honeycomb / Sentry). Survives `:advanced` + `goog.DEBUG=false`; parallel to (not a fallback for) the dev-only trace surface. Router invokes once per processed event after the cascade settles."}
-
-   ;; ---- re-frame.error-emit (rf2-bacs4 — always-on error observability) -----
-   {:key         :error-emit/dispatch-on-error
-    :producer-ns 're-frame.error-emit
-    :design-bead "rf2-bacs4"
-    :description "Always-on per-`:rf.error/*` fan-out: builds the tight error-record once (elided), then fans out to BOTH the corpus-wide listener registry (rf2-bacs4 — Sentry / Honeybadger / Rollbar shippers) AND the per-frame `:on-error` policy fn (rf2-hqbeh — in-app recovery). Both fan-out paths independent and try/catch wrapped. Survives `:advanced` + `goog.DEBUG=false`. Router invokes from the handler-exception path."}
 
    ;; ---- re-frame.privacy (rf2-w3n5u schema-first privacy) -------------------
    {:key         :privacy/clear-suppression-cache!

--- a/implementation/core/test/re_frame/elision_probe.cljs
+++ b/implementation/core/test/re_frame/elision_probe.cljs
@@ -47,6 +47,7 @@
             ;; closure DCE pass, not surface-pruned before DCE runs.
             [re-frame.trace.tooling :as trace-tooling]
             [re-frame.epoch        :as epoch]
+            [re-frame.epoch.listeners :as epoch.listeners]
             [re-frame.http-managed :as http-managed]
             [re-frame.views        :as views]
             [re-frame.machines]))
@@ -248,10 +249,12 @@
   ;; per (frame-id, cb-id) pair when a frame previously observed by a
   ;; register-epoch-listener! callback is destroyed. The whole body sits inside
   ;; `(when interop/debug-enabled? ...)`; the string fragment must elide
-  ;; under :advanced + goog.DEBUG=false. Touch the entry point through
-  ;; the public surface (frame destroy walks call into it via the
-  ;; :epoch/on-frame-destroyed late-bind hook).
-  (epoch/on-frame-destroyed! :rf/default))
+  ;; under :advanced + goog.DEBUG=false. Touch the implementation seam
+  ;; (`re-frame.epoch.listeners/on-frame-destroyed!`) directly — the
+  ;; `re-frame.epoch` facade publishes through the
+  ;; `:epoch/on-frame-destroyed` late-bind hook only (per rf2-e0lva the
+  ;; facade-side wrapper is private).
+  (epoch.listeners/on-frame-destroyed! :rf/default))
 
 ;; ---- Spec 004 §Render-tree primitives — reg-view* wrapper (rf2-piag) -----
 

--- a/implementation/core/test/re_frame/late_bind_cache_test.clj
+++ b/implementation/core/test/re_frame/late_bind_cache_test.clj
@@ -131,6 +131,58 @@
           "the very next get-fn-cached serves the newly-published fn — no stale slot"))))
 
 ;; =============================================================================
+;; rf2-rtk2e — set-fns! map-form publication
+;; =============================================================================
+
+(deftest set-fns!-publishes-every-entry-equivalently-to-set-fn!
+  (testing "set-fns! is equivalent to per-entry set-fn! calls"
+    (let [k1 :test/rtk2e-a
+          k2 :test/rtk2e-b
+          k3 :test/rtk2e-c
+          f1 (fn [] :a)
+          f2 (fn [] :b)
+          f3 (fn [] :c)]
+      (late-bind/set-fns! {k1 f1, k2 f2, k3 f3})
+      (is (identical? f1 (late-bind/get-fn k1))
+          "first entry published")
+      (is (identical? f2 (late-bind/get-fn k2))
+          "second entry published")
+      (is (identical? f3 (late-bind/get-fn k3))
+          "third entry published"))))
+
+(deftest set-fns!-invalidates-each-cache-slot
+  (testing "every entry's slot is invalidated — hot-reload via set-fns! works per key"
+    (let [k1     :test/rtk2e-inv-a
+          k2     :test/rtk2e-inv-b
+          old-a  (fn [] :old-a)
+          old-b  (fn [] :old-b)
+          new-a  (fn [] :new-a)
+          new-b  (fn [] :new-b)]
+      ;; Seed both keys via set-fn!, warm both cache slots.
+      (late-bind/set-fn! k1 old-a)
+      (late-bind/set-fn! k2 old-b)
+      (is (identical? old-a (late-bind/get-fn-cached k1)))
+      (is (identical? old-b (late-bind/get-fn-cached k2)))
+      (is (cached? k1))
+      (is (cached? k2))
+      ;; Re-publish both via set-fns! — every slot must invalidate.
+      (late-bind/set-fns! {k1 new-a, k2 new-b})
+      (is (not (cached? k1)) "k1's slot invalidated by set-fns!")
+      (is (not (cached? k2)) "k2's slot invalidated by set-fns!")
+      (is (identical? new-a (late-bind/get-fn-cached k1))
+          "next lookup serves the newly-published fn for k1")
+      (is (identical? new-b (late-bind/get-fn-cached k2))
+          "next lookup serves the newly-published fn for k2"))))
+
+(deftest set-fns!-returns-nil
+  (testing "set-fns! returns nil (side-effecting publication)"
+    (is (nil? (late-bind/set-fns! {:test/rtk2e-ret (fn [] :x)})))))
+
+(deftest set-fns!-empty-map-is-a-noop
+  (testing "set-fns! tolerates an empty map (no entries published, no throw)"
+    (is (nil? (late-bind/set-fns! {})))))
+
+;; =============================================================================
 ;; G2 — chain-fn! runtime composition ordering
 ;; =============================================================================
 

--- a/implementation/core/test/re_frame/late_bind_drift_test.clj
+++ b/implementation/core/test/re_frame/late_bind_drift_test.clj
@@ -18,9 +18,13 @@
     2. Every published key has a directory entry.
 
   Mechanism: walk every `.clj{c,s}` file under `implementation/` and
-  match `(late-bind/set-fn! <keyword> ...)`. Filter to source files
-  (skip `test/` paths — test files temporarily flip hooks for
-  isolation but don't publish new keys).
+  match three publication shapes — `(late-bind/set-fn! <keyword> ...)`,
+  `(substrate-adapter/route-hook! adapter <keyword> ...)`,
+  `(late-bind/chain-fn! <keyword> ...)`, and the rf2-rtk2e map-form
+  `(late-bind/set-fns! {<keyword> <fn> ...})` (every key inside the
+  map body counts). Filter to source files (skip `test/` paths — test
+  files temporarily flip hooks for isolation but don't publish new
+  keys).
 
   Failure messages name the missing entries / orphaned publications
   explicitly so the fix is obvious.")
@@ -87,10 +91,50 @@
   equivalent to direct `set-fn!` publication."
   #"\(late-bind/chain-fn!\s+(:[a-zA-Z][a-zA-Z0-9.!?*+\-]*/[a-zA-Z][a-zA-Z0-9!?*+\-]*)")
 
+(def ^:private set-fns-block-re
+  "Match a `(late-bind/set-fns! { ... })` map-form block; the named
+  capture group returns the map body (everything between `{` and the
+  matching `})`).
+
+  Per rf2-rtk2e: feature artefacts publish their late-bind contract as
+  a single map of `hook-key → fn` entries rather than a column of 15+
+  individual `set-fn!` calls. The drift scan must treat each key in the
+  map body as a publication. Multiline-friendly (the map typically spans
+  many lines)."
+  #"(?s)\(late-bind/set-fns!\s*\{([^}]*)\}")
+
+(def ^:private map-entry-key-re
+  "Match a fully-qualified keyword at column-0-ish of a line in a
+  `set-fns!` map body. Used to extract the `:namespace/key` entries
+  from a match captured by `set-fns-block-re`."
+  #"(:[a-zA-Z][a-zA-Z0-9.!?*+\-]*/[a-zA-Z][a-zA-Z0-9!?*+\-]*)")
+
 (defn- match-keys
   [re content]
   (->> (re-seq re content)
        (map (comp keyword #(subs % 1) second))
+       set))
+
+(defn- strip-line-comments
+  "Strip `;;`-to-end-of-line comments from `s`. Used to filter `set-fns!`
+  map bodies before extracting their keyword keys so a keyword mentioned
+  in a comment block doesn't masquerade as a published hook."
+  [s]
+  (str/replace s #";;[^\n]*" ""))
+
+(defn- match-set-fns-block-keys
+  "Extract every fully-qualified hook key from every
+  `(late-bind/set-fns! { ... })` block in `content`. Per rf2-rtk2e the
+  map-form publication is an equivalent shape to per-entry `set-fn!`
+  calls; the drift scan reaches each key by walking the block body.
+  Comments inside the map body are stripped first so a `;;` mention of
+  another keyword (e.g. a per-entry rationale referencing `:rf.view/
+  rendered`) doesn't masquerade as a published hook."
+  [content]
+  (->> (re-seq set-fns-block-re content)
+       (mapcat (fn [[_whole body]]
+                 (->> (re-seq map-entry-key-re (strip-line-comments body))
+                      (map (comp keyword #(subs % 1) first)))))
        set))
 
 (defn- published-keys-in-file
@@ -98,7 +142,8 @@
   (let [content (slurp f)]
     (-> (match-keys set-fn-call-re content)
         (into (match-keys route-hook-call-re content))
-        (into (match-keys chain-fn-call-re content)))))
+        (into (match-keys chain-fn-call-re content))
+        (into (match-set-fns-block-keys content)))))
 
 (defn- published-keys
   "Set of every late-bind key published from in-tree source files."

--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -35,9 +35,12 @@
   fully-assembled record after it lands in the ring buffer.
 
   Restore (`restore-epoch`) rewinds a frame's app-db to the named
-  epoch's `:db-after`. Six documented failure modes (Tool-Pair table)
-  each emit a structured trace under `:rf.epoch/*` and leave the
-  frame's app-db unchanged."
+  epoch's `:db-after`. Seven documented failure modes (Tool-Pair
+  §Time-travel restore-failure-modes table) each emit a structured
+  trace and leave the frame's app-db unchanged — six under the
+  reserved `:rf.epoch/*` namespace, plus the registry-lookup
+  `:rf.error/no-such-handler` (kind `:frame`) for an unknown
+  frame-id."
   (:require [re-frame.epoch.assembly :as assembly]
             [re-frame.epoch.capture :as capture]
             [re-frame.epoch.listeners :as listeners]

--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -184,7 +184,7 @@
 ;; straddles state, capture, and assembly) live in
 ;; `re-frame.epoch.listeners` (Phase-2 seam C, rf2-0wi86).
 
-(defn on-frame-destroyed!
+(defn- on-frame-destroyed!
   "Per Tool-Pair §Surface behaviour against destroyed frames (rf2-d656)
   and rf2-v0jwt §Outcomes (`:halted-destroy`):
 
@@ -388,7 +388,7 @@
          (commit-record! frame-id db-before db-after events outcome
                          halt-reason nil))))))
 
-(defn commit-halt-record!
+(defn- commit-halt-record!
   "Commit a `:halted-*` epoch record for a drain halt whose halting event
   never ran to completion — the per-event depth-exceed boundary
   (rf2-nj6p7). Unlike `settle!`, this does NOT skip on an empty capture

--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -356,7 +356,14 @@
   Emits `:rf.epoch/snapshotted` with a `:outcome` tag so trace listeners
   can discriminate clean from halted boundaries without inspecting the
   epoch-history vector. Listeners (`register-epoch-listener!`) receive every
-  record regardless of outcome."
+  record regardless of outcome.
+
+  See also `commit-halt-record!` — the sibling commit path for the
+  depth-exceed halt whose halting event never ran, so the buffer is empty
+  at halt and `settle!`'s empty-buffer skip would suppress the record.
+  Both fns share the private `commit-record!` helper; `commit-halt-record!`
+  synthesises the halting event's trigger explicitly while `settle!` lets
+  `build-record` derive it from the harvested buffer."
   ([frame-id db-before db-after]
    (settle! frame-id db-before db-after :ok nil))
   ([frame-id db-before db-after outcome halt-reason]
@@ -401,7 +408,13 @@
 
   Harvests-and-clears any residual buffer first so a stray pre-halt emit
   (there should be none under per-event settling) can't leak into the
-  next cascade for this frame."
+  next cascade for this frame.
+
+  See also `settle!` — the clean-path sibling that handles every per-
+  event `:ok` settle. Both fns share the private `commit-record!`
+  helper; `settle!` lets `build-record` derive the trigger from the
+  harvested buffer (an `:event/run-start` is always present on the
+  clean path) and skips on an empty buffer."
   [frame-id db-before db-after outcome halt-reason trigger-event]
   (when interop/debug-enabled?
     (let [events (state/harvest-buffer! frame-id)]

--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -624,46 +624,55 @@
 ;; epoch surface is dev-tier so an absent artefact degrades quietly
 ;; rather than throwing.
 
-(late-bind/set-fn! :epoch/settle!             settle!)
-;; rf2-nj6p7: per-event halt commit — the depth-exceed boundary whose
-;; halting event never ran (so the buffer is empty and `settle!` would
-;; skip). Synthesises the halting event's `:halted-depth` record.
-(late-bind/set-fn! :epoch/commit-halt-record! commit-halt-record!)
-(late-bind/set-fn! :epoch/discard-buffer!     discard-buffer!)
-(late-bind/set-fn! :epoch/capture-event       capture/capture-event!)
-;; rf2-25zo2: in-flight cascade-cause lookup for :rf.view/rendered. Views
-;; consume this via `:epoch/cascade-cause` at render-emit time to stamp
-;; :cause-event-id + :cause-subs onto the per-render trace.
-(late-bind/set-fn! :epoch/cascade-cause       capture/cascade-cause)
-;; rf2-qs6dl: post-settle render back-fill. `capture-event!` routes a
-;; view-render op that fires with no in-flight cascade (a React-commit-
-;; time async re-render) here so it is attributed to the cascade that
-;; CAUSED it (the frame's most-recently-settled epoch) rather than the
-;; next in-flight cascade. The orchestrator lives in
-;; `re-frame.epoch.listeners` (state back-fill + listener re-notify);
-;; publishing it through late-bind keeps `capture` free of a require on
-;; `listeners` (which would close the assembly→capture cycle).
-(late-bind/set-fn! :epoch/record-render!      listeners/record-render!)
-;; rf2-wi900: post-settle sub-run back-fill — the subs sibling of
-;; `:epoch/record-render!`. `capture-event!` routes a `:sub/run` /
-;; `:rf.sub/skip` op that fires with no in-flight cascade (a React-deref-
-;; time async reactive recompute) here so it is attributed to the cascade
-;; that CAUSED it (the frame's most-recently-settled epoch) rather than the
-;; next in-flight cascade — fixing the one-epoch `:sub-runs` /
-;; `:value-changed?` lag visible in Xray's per-cascade Views subs table.
-(late-bind/set-fn! :epoch/record-sub-run!     listeners/record-sub-run!)
-(late-bind/set-fn! :epoch/epoch-history       epoch-history)
-(late-bind/set-fn! :epoch/restore-epoch       restore-epoch)
-(late-bind/set-fn! :epoch/reset-frame-db!     reset-frame-db!)
-(late-bind/set-fn! :epoch/register-epoch-listener!  register-epoch-listener!)
-(late-bind/set-fn! :epoch/unregister-epoch-listener!    unregister-epoch-listener!)
-(late-bind/set-fn! :epoch/configure!          configure!)
-(late-bind/set-fn! :epoch/clear-history!      clear-history!)
-(late-bind/set-fn! :epoch/clear-epoch-listeners!    clear-epoch-listeners!)
-(late-bind/set-fn! :epoch/on-frame-destroyed  listeners/on-frame-destroyed!)
-;; Per rf2-mrsck and Security.md §Epoch privacy posture: off-box
-;; egress projection helpers, parallel to elide-wire-value for direct
-;; reads. Tools that forward records over a process boundary use
-;; these (Xray-MCP `watch-epochs`, story / pair recorders).
-(late-bind/set-fn! :epoch/projected-record    projected-record)
-(late-bind/set-fn! :epoch/projected-history   projected-history)
+;; Per rf2-rtk2e: a single map-form publication reads as 'the late-bind
+;; contract for this artefact' rather than a column of identical
+;; imperative side-effects. Each entry is identical to a standalone
+;; `(late-bind/set-fn! key fn)` call; the drift gate
+;; (`re-frame.late-bind-drift-test`) walks both call shapes.
+(late-bind/set-fns!
+  {;; ---- per-cascade lifecycle (router + trace capture seam) -------
+   :epoch/settle!             settle!
+   ;; rf2-nj6p7: per-event halt commit — the depth-exceed boundary whose
+   ;; halting event never ran (so the buffer is empty and `settle!` would
+   ;; skip). Synthesises the halting event's `:halted-depth` record.
+   :epoch/commit-halt-record! commit-halt-record!
+   :epoch/discard-buffer!     discard-buffer!
+   :epoch/capture-event       capture/capture-event!
+   ;; rf2-25zo2: in-flight cascade-cause lookup for :rf.view/rendered.
+   ;; Views consume this via `:epoch/cascade-cause` at render-emit time
+   ;; to stamp :cause-event-id + :cause-subs onto the per-render trace.
+   :epoch/cascade-cause       capture/cascade-cause
+   ;; rf2-qs6dl: post-settle render back-fill. `capture-event!` routes a
+   ;; view-render op that fires with no in-flight cascade (a React-
+   ;; commit-time async re-render) here so it is attributed to the
+   ;; cascade that CAUSED it (the frame's most-recently-settled epoch)
+   ;; rather than the next in-flight cascade. The orchestrator lives in
+   ;; `re-frame.epoch.listeners` (state back-fill + listener re-notify);
+   ;; publishing it through late-bind keeps `capture` free of a require
+   ;; on `listeners` (which would close the assembly→capture cycle).
+   :epoch/record-render!      listeners/record-render!
+   ;; rf2-wi900: post-settle sub-run back-fill — the subs sibling of
+   ;; `:epoch/record-render!`. Same React-deref-time async recompute
+   ;; problem; same attribution fix.
+   :epoch/record-sub-run!     listeners/record-sub-run!
+   :epoch/on-frame-destroyed  listeners/on-frame-destroyed!
+
+   ;; ---- introspection + Tool-Pair write surface --------------------
+   :epoch/epoch-history       epoch-history
+   :epoch/restore-epoch       restore-epoch
+   :epoch/reset-frame-db!     reset-frame-db!
+
+   ;; ---- listener + config surface ----------------------------------
+   :epoch/register-epoch-listener!   register-epoch-listener!
+   :epoch/unregister-epoch-listener! unregister-epoch-listener!
+   :epoch/configure!                 configure!
+   :epoch/clear-history!             clear-history!
+   :epoch/clear-epoch-listeners!     clear-epoch-listeners!
+
+   ;; ---- off-box egress projection (rf2-mrsck) ----------------------
+   ;; Per Security.md §Epoch privacy posture: off-box egress projection
+   ;; helpers, parallel to elide-wire-value for direct reads. Tools that
+   ;; forward records over a process boundary use these (Xray-MCP
+   ;; `watch-epochs`, story / pair recorders).
+   :epoch/projected-record    projected-record
+   :epoch/projected-history   projected-history})

--- a/implementation/epoch/src/re_frame/epoch/listeners.cljc
+++ b/implementation/epoch/src/re_frame/epoch/listeners.cljc
@@ -271,9 +271,9 @@
     ;; into a record belonging to the destroyed frame's history — which
     ;; was just dropped above anyway.
     (state/drop-last-settled-epoch! frame-id)
-    ;; Per rf2-vh1k3: forget every render-key's mount-epoch anchor AND
-    ;; read-set for the destroyed frame so a re-registration of a
-    ;; same-keyed frame (`reset-frame! :app/main`) re-mints both from
-    ;; scratch.
-    (state/drop-frame-mount-epochs! frame-id)
-    (state/drop-frame-render-deps! frame-id)))
+    ;; Per rf2-vh1k3 + rf2-dq2b7: forget every render-key's mount-epoch
+    ;; anchor AND read-set for the destroyed frame so a re-registration
+    ;; of a same-keyed frame (`reset-frame! :app/main`) re-mints both
+    ;; from scratch. Both signals share the single `mount-attribution`
+    ;; atom; one wipe replaces the former two.
+    (state/drop-frame-mount-attribution! frame-id)))

--- a/implementation/epoch/src/re_frame/epoch/state.cljc
+++ b/implementation/epoch/src/re_frame/epoch/state.cljc
@@ -28,7 +28,37 @@
   Per Phase-1 finding (rf2-0wi86): no two atoms are ever held in a
   single critical section, so a tiny state ns owns all of them with
   zero locking/ordering subtleties — the cross-cutting coupling is
-  cosmetic, not structural.")
+  cosmetic, not structural.
+
+  Per rf2-33lpr decision review: the eight-atom shape (post the
+  rf2-dq2b7 mount-attribution merge) is the right resting point.
+  Two further consolidations were considered and rejected:
+
+    * Per-frame cluster (`histories` + `last-settled-epoch` +
+      `mount-attribution` + `capture-buffers` → one `frame-state`
+      atom keyed by frame-id). REJECTED: `capture-buffers` is the
+      hottest atom (one swap per trace emit, potentially many per
+      event); co-locating it with the rarely-touched back-fill atoms
+      forces every hot-path swap! to operate on a larger map and
+      adds cross-drain contention through a shared swap site (every
+      frame's drain now races every other frame's drain on the
+      single per-frame-state atom). The per-atom decomposition lets
+      the JIT specialise each swap's hot loop, keeps each map small
+      (one key class per atom), and isolates contention by signal
+      class.
+
+    * Listener cluster (`listeners` + `observed-frames-by-cb` → one
+      atom keyed by cb-id). REJECTED: `listeners-snapshot` reads on
+      every settle (fan-out target); `observed-frames-by-cb` updates
+      lazily on first-sighting only. Co-locating means every settle's
+      snapshot deref pulls the larger map, and per-cb writes flow
+      through the same swap! site as the registry. The Phase-1
+      invariant (rf2-0wi86, no shared critical section) lets the two
+      atoms stay separate at zero cost.
+
+  The singletons `config` and `epoch-counter` are irreducible (the
+  former is configuration state, the latter a counter source — both
+  read/written by ALL frames, so frame-id keying would be artificial).")
 
 ;; ---- configuration --------------------------------------------------------
 

--- a/implementation/epoch/src/re_frame/epoch/state.cljc
+++ b/implementation/epoch/src/re_frame/epoch/state.cljc
@@ -1,5 +1,5 @@
 (ns re-frame.epoch.state
-  "Shared state for the epoch surface — the six defonce atoms plus the
+  "Shared state for the epoch surface — the eight defonce atoms plus the
   low-level CRUD against them, and the config knob accessors. Per
   rf2-0wi86 (cohesion split): every other seam (`capture`, `assembly`,
   `write`, `listeners`) and the `re-frame.epoch` facade reach the
@@ -10,11 +10,20 @@
   The atoms in question:
 
     config                  per-frame ring-buffer config + redact-fn
+    epoch-counter           monotonically-increasing :epoch-id source
     histories               frame-id → vector<:rf/epoch-record>
+    last-settled-epoch      frame-id → epoch-id of the most-recently-
+                            settled `:ok` epoch (rf2-qs6dl back-fill
+                            anchor)
+    mount-attribution       frame-id → {render-key → {:epoch-id E
+                                                       :deps #{sub-id…}}}
+                            (rf2-vh1k3 + rf2-dq2b7 — the mount-anchor
+                            and the view's learned read-set share one
+                            entry; per Phase-1 finding they never
+                            diverge in usage)
     capture-buffers         frame-id → vector<trace-event> (in-flight)
     listeners               cb-id    → fn
     observed-frames-by-cb   cb-id    → #{frame-id ...}
-    epoch-counter           monotonically-increasing :epoch-id source
 
   Per Phase-1 finding (rf2-0wi86): no two atoms are ever held in a
   single critical section, so a tiny state ns owns all of them with
@@ -283,24 +292,34 @@
 ;; attributed to K's MOUNT epoch (its first-ever attribution) rather than
 ;; whatever cascade happens to be settling.
 
-(defonce ^:private mount-epoch-by-render-key
-  ;; frame-id → {render-key → epoch-id} : the epoch a render-key was
-  ;; FIRST attributed to (its mount epoch). Bounds: one entry per live
-  ;; render-key per frame; pruned with the frame on teardown.
-  (atom {}))
+;; Per rf2-dq2b7: the two former atoms (`mount-epoch-by-render-key` ::
+;; `{frame-id {render-key epoch-id}}` and `render-deps-by-render-key` ::
+;; `{frame-id {render-key #{sub-id…}}}`) were merged into a single
+;; `mount-attribution` atom keyed identically (frame-id × render-key)
+;; carrying both signals under one entry. The two atoms NEVER diverged
+;; in usage: both pruned in lockstep by `drop-frame-mount-attribution!`,
+;; both wiped together by `reset-mount-attribution!`. Collapsing them
+;; halves the defonce count (Phase-1 finding rf2-0wi86 §two atoms) and
+;; halves the swap! count on frame teardown without changing any
+;; observable semantic.
+;;
+;; The four accessor names (`mount-epoch-for` / `record-mount-epoch!`
+;; and `render-deps-for` / `record-render-deps!`) survive as the public
+;; surface — each is semantically distinct (one reads/writes the
+;; mount-anchor, the other the read-set) — but they project from one
+;; underlying map.
+;;
+;; Per-entry shape:
+;;
+;;   {frame-id {render-key {:epoch-id <epoch-id-or-nil>
+;;                          :deps     #{<sub-id> ...}}}}
+;;
+;; Either slot may be absent on a given (frame, render-key) entry — the
+;; mount-anchor lands on first render attribution, the read-set lands as
+;; the synchronous in-render derefs fire. Reads default to nil / empty;
+;; writes use `update-in` so a missing entry materialises on demand.
 
-;; frame-id → {render-key → #{sub-id ...}} : which subscriptions each
-;; view reads. Learned from the `:reader-render-key` stamp on `:sub/run`
-;; traces — which the runtime only sets when the reaction recomputes
-;; SYNCHRONOUSLY inside the view's render (the mount / first-paint
-;; deref). A post-settle reactive recompute fires during Reagent's
-;; reaction-flush phase with no `*render-key*` bound, so the stamp is
-;; absent there; the mount-time learning is sufficient because a view's
-;; sub set is stable across its life. The index lets the render
-;; back-fill (`value-changed-epoch-for`) decide whether a cascade
-;; actually re-rendered a view by checking value-change on the view's
-;; OWN subs, even when the post-settle sub-run carries no render-key.
-(defonce ^:private render-deps-by-render-key (atom {}))
+(defonce ^:private mount-attribution (atom {}))
 
 (defn record-render-deps!
   "Union `sub-id` into `render-key`'s read-set for `frame-id`. Called for
@@ -309,33 +328,21 @@
   view. Idempotent; the set only grows."
   [frame-id render-key sub-id]
   (when (and frame-id render-key sub-id)
-    (swap! render-deps-by-render-key
-           update-in [frame-id render-key] (fnil conj #{}) sub-id))
+    (swap! mount-attribution
+           update-in [frame-id render-key :deps] (fnil conj #{}) sub-id))
   nil)
 
 (defn render-deps-for
   "Return the set of sub-ids `render-key` is known to read in `frame-id`,
   or nil when none learned yet."
   [frame-id render-key]
-  (get-in @render-deps-by-render-key [frame-id render-key]))
-
-(defn drop-frame-render-deps!
-  "Forget every render-key's read-set for `frame-id` (frame teardown)."
-  [frame-id]
-  (swap! render-deps-by-render-key dissoc frame-id)
-  nil)
-
-(defn reset-render-deps!
-  "Wipe the render-deps map across all frames (fixture reset)."
-  []
-  (reset! render-deps-by-render-key {})
-  nil)
+  (get-in @mount-attribution [frame-id render-key :deps]))
 
 (defn mount-epoch-for
   "Return the epoch-id `render-key` was first attributed to in `frame-id`,
   or nil when never seen."
   [frame-id render-key]
-  (get-in @mount-epoch-by-render-key [frame-id render-key]))
+  (get-in @mount-attribution [frame-id render-key :epoch-id]))
 
 (defn record-mount-epoch!
   "Record `epoch-id` as `render-key`'s mount epoch for `frame-id`, but
@@ -344,23 +351,27 @@
   mount anchor)."
   [frame-id render-key epoch-id]
   (when (and frame-id render-key epoch-id)
-    (swap! mount-epoch-by-render-key
+    (swap! mount-attribution
            (fn [m]
-             (if (get-in m [frame-id render-key])
+             (if (get-in m [frame-id render-key :epoch-id])
                m
-               (assoc-in m [frame-id render-key] epoch-id)))))
+               (assoc-in m [frame-id render-key :epoch-id] epoch-id)))))
   nil)
 
-(defn drop-frame-mount-epochs!
-  "Forget every render-key's mount epoch for `frame-id` (frame teardown)."
+(defn drop-frame-mount-attribution!
+  "Forget every render-key's mount-anchor + read-set for `frame-id`
+  (frame teardown). Replaces the four-wiper pair
+  `drop-frame-mount-epochs!` + `drop-frame-render-deps!` (rf2-dq2b7)."
   [frame-id]
-  (swap! mount-epoch-by-render-key dissoc frame-id)
+  (swap! mount-attribution dissoc frame-id)
   nil)
 
-(defn reset-mount-epochs!
-  "Wipe the mount-epoch map across all frames (fixture reset)."
+(defn reset-mount-attribution!
+  "Wipe the mount-attribution map across all frames (fixture reset).
+  Replaces the two-reset pair `reset-mount-epochs!` +
+  `reset-render-deps!` (rf2-dq2b7)."
   []
-  (reset! mount-epoch-by-render-key {})
+  (reset! mount-attribution {})
   nil)
 
 (defn- epoch-value-changed-for-view?
@@ -659,14 +670,14 @@
 
 (defn reset-histories!
   "Wipe every frame's recorded epochs. Also clears the last-settled-epoch
-  map (rf2-qs6dl) and the mount-epoch map (rf2-vh1k3) so a fixture's
-  first cascade can't back-fill a render into a previous fixture's
-  record nor inherit a stale render-key→mount-epoch anchor."
+  map (rf2-qs6dl) and the mount-attribution map (rf2-vh1k3, rf2-dq2b7)
+  so a fixture's first cascade can't back-fill a render into a previous
+  fixture's record nor inherit a stale render-key → {mount-epoch +
+  read-set} anchor."
   []
   (reset! histories {})
   (reset-last-settled-epochs!)
-  (reset-mount-epochs!)
-  (reset-render-deps!)
+  (reset-mount-attribution!)
   nil)
 
 ;; ---- listener registry ----------------------------------------------------

--- a/implementation/epoch/test/re_frame/epoch_attribution_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_attribution_test.clj
@@ -90,8 +90,10 @@
 ;;
 ;; Mirrors `re-frame.epoch-test/reset-runtime` — the attribution surface
 ;; reaches the same shared atoms (`state/last-settled-epoch`,
-;; `mount-epoch-by-render-key`, `render-deps-by-render-key`, the per-frame
-;; ring), all wiped by `epoch/clear-history!`.
+;; `mount-attribution`, the per-frame ring), all wiped by
+;; `epoch/clear-history!`. Per rf2-dq2b7 the former two render-attribution
+;; atoms (`mount-epoch-by-render-key` + `render-deps-by-render-key`)
+;; collapsed into a single `mount-attribution` atom.
 
 (defn- reset-runtime [test-fn]
   (registrar/clear-all!)
@@ -849,3 +851,68 @@
       (is (not (contains? row :triggered-by))
           ":triggered-by absent on a structural re-render row")
       (is (= 0.3 (:elapsed-ms row)) ":elapsed-ms still preserved"))))
+
+;; ===========================================================================
+;; rf2-dq2b7 — mount-attribution atom merge: epoch-id + deps share one entry
+;; ===========================================================================
+
+(deftest mount-attribution-coexists-on-single-entry
+  (testing "rf2-dq2b7 — `record-mount-epoch!` and `record-render-deps!`
+            update DIFFERENT slots on the SAME `(frame, render-key)` entry
+            in the merged `mount-attribution` atom. Cross-population must
+            not clobber the sibling slot, and the public accessors read
+            each slot independently."
+    (let [frame      :test/dq2b7
+          render-key [:my-view 0]]
+      ;; Seed the read-set FIRST — the in-render deref typically fires
+      ;; before the post-settle render commit.
+      (state/record-render-deps! frame render-key :sub/a)
+      (state/record-render-deps! frame render-key :sub/b)
+      (is (= #{:sub/a :sub/b} (state/render-deps-for frame render-key))
+          "both deps recorded on the entry's :deps slot")
+      (is (nil? (state/mount-epoch-for frame render-key))
+          "mount-epoch slot is still empty — record-render-deps! did not touch it")
+
+      ;; Now record the mount-epoch — populates the sibling :epoch-id slot
+      ;; on the same entry without clobbering the deps set.
+      (state/record-mount-epoch! frame render-key :epoch/one)
+      (is (= :epoch/one (state/mount-epoch-for frame render-key))
+          "mount-epoch landed on the entry's :epoch-id slot")
+      (is (= #{:sub/a :sub/b} (state/render-deps-for frame render-key))
+          "deps slot survived the mount-epoch write — single entry, two slots")
+
+      ;; First-sighting invariant survives the merge: a second
+      ;; record-mount-epoch! must NOT overwrite the anchor.
+      (state/record-mount-epoch! frame render-key :epoch/ninety-nine)
+      (is (= :epoch/one (state/mount-epoch-for frame render-key))
+          "re-recording a mount epoch does not move the anchor (first-sighting)")
+
+      ;; Single-wipe contract: one `drop-frame-mount-attribution!` clears
+      ;; BOTH slots; the bead's "four wipers → two" lift.
+      (state/drop-frame-mount-attribution! frame)
+      (is (nil? (state/mount-epoch-for frame render-key))
+          "mount-epoch cleared by drop-frame-mount-attribution!")
+      (is (nil? (state/render-deps-for frame render-key))
+          "deps cleared by the same wipe — one swap clears both slots"))))
+
+(deftest mount-attribution-frame-scoping
+  (testing "rf2-dq2b7 — `mount-attribution` is keyed by (frame × render-key);
+            dropping one frame's entry does not affect a sibling frame's
+            anchor or read-set."
+    (let [render-key [:shared-view 0]]
+      (state/record-mount-epoch!  :test/dq2b7-a render-key :epoch/a-1)
+      (state/record-render-deps!  :test/dq2b7-a render-key :sub/a)
+      (state/record-mount-epoch!  :test/dq2b7-b render-key :epoch/b-1)
+      (state/record-render-deps!  :test/dq2b7-b render-key :sub/b)
+
+      ;; Drop only frame A.
+      (state/drop-frame-mount-attribution! :test/dq2b7-a)
+      (is (nil? (state/mount-epoch-for :test/dq2b7-a render-key)))
+      (is (nil? (state/render-deps-for :test/dq2b7-a render-key)))
+      ;; Frame B survives intact.
+      (is (= :epoch/b-1 (state/mount-epoch-for :test/dq2b7-b render-key)))
+      (is (= #{:sub/b}  (state/render-deps-for :test/dq2b7-b render-key)))
+
+      ;; reset-mount-attribution! wipes everything left.
+      (state/reset-mount-attribution!)
+      (is (nil? (state/mount-epoch-for :test/dq2b7-b render-key))))))

--- a/implementation/epoch/test/re_frame/epoch_elision_prod_test.cljs
+++ b/implementation/epoch/test/re_frame/epoch_elision_prod_test.cljs
@@ -46,7 +46,8 @@
             [re-frame.core :as rf]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.test-support :as test-support]
-            [re-frame.epoch :as epoch]))
+            [re-frame.epoch :as epoch]
+            [re-frame.epoch.listeners :as epoch.listeners]))
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture
@@ -160,5 +161,5 @@
             observed-frames-by-cb bookkeeping side-effect is dead too.
             Frame-destroy paths that route through this hook do not
             crash."
-    (is (nil? (epoch/on-frame-destroyed! :rf/default))
+    (is (nil? (epoch.listeners/on-frame-destroyed! :rf/default))
         "on-frame-destroyed! returns nil under prod even for unknown frames")))

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -14,8 +14,10 @@
        assembled record; same-key replaces; remove unhooks; exception
        isolation.
     6. Restore happy path — `restore-epoch` rewinds app-db.
-    7. The six documented failure modes — each fires the documented
-       trace under `:rf.epoch/*` and leaves app-db unchanged.
+    7. The seven documented failure modes (Tool-Pair §Time-travel
+       restore-failure-modes table) — six fire under `:rf.epoch/*`,
+       plus `:rf.error/no-such-handler` (kind `:frame`) for an
+       unknown frame-id; each leaves app-db unchanged.
     8. Sub-runs / renders / effects projection from the trace stream.
 
   Per-cascade / per-mount POST-SETTLE attribution (rf2-qs6dl render lag,
@@ -37,6 +39,7 @@
             [re-frame.epoch :as epoch]
             [re-frame.epoch.assembly :as assembly]
             [re-frame.epoch.capture :as capture]
+            [re-frame.epoch.listeners :as epoch.listeners]
             [re-frame.epoch.state :as state]
             ;; rf2-v6z0: machines is a separate artefact whose late-bind
             ;; hook publishes `rf/reg-machine` only when the namespace is
@@ -2307,7 +2310,7 @@
 ;; seam.
 
 (deftest on-frame-destroyed-clears-frame-buffer-directly
-  (testing "calling epoch/on-frame-destroyed! on a frame drops its
+  (testing "calling epoch.listeners/on-frame-destroyed! on a frame drops its
             ring buffer regardless of whether the frame itself was
             destroyed via the usual frame/destroy-frame! path"
     (rf/reg-frame :test/other {})
@@ -2324,7 +2327,7 @@
     ;; Call on-frame-destroyed! DIRECTLY — without going through
     ;; frame/destroy-frame!. The frame record still exists in
     ;; frames-atom; only the epoch ring is dropped.
-    (epoch/on-frame-destroyed! :test/other)
+    (epoch.listeners/on-frame-destroyed! :test/other)
 
     ;; The frame's ring is gone.
     (is (= [] (rf/epoch-history :test/other))
@@ -2344,11 +2347,11 @@
     (is (= 1 (count (rf/epoch-history :test/repeat))))
 
     ;; First call — clears the buffer.
-    (epoch/on-frame-destroyed! :test/repeat)
+    (epoch.listeners/on-frame-destroyed! :test/repeat)
     (is (= [] (rf/epoch-history :test/repeat)))
 
     ;; Second call — no-op.
-    (epoch/on-frame-destroyed! :test/repeat)
+    (epoch.listeners/on-frame-destroyed! :test/repeat)
     (is (= [] (rf/epoch-history :test/repeat))
         "ring stays empty across repeated calls")))
 
@@ -2360,7 +2363,7 @@
     ;; The observable contract is "no throw, no side effects on
     ;; unrelated state".
     (let [traces (record-trace!)]
-      (epoch/on-frame-destroyed! :test/no-such-frame)
+      (epoch.listeners/on-frame-destroyed! :test/no-such-frame)
       (is (empty? @traces)
           "no traces emitted — nothing observed to silence"))))
 
@@ -2459,7 +2462,7 @@
       (is (some? (get @buffers-atom :test/main))
           "sanity: the synthetic capture-buffer entry is present pre-destroy")
 
-      (epoch/on-frame-destroyed! :test/main)
+      (epoch.listeners/on-frame-destroyed! :test/main)
 
       (is (nil? (get @buffers-atom :test/main))
           "the capture-buffer entry was dropped on destroy — no


### PR DESCRIPTION
Epoch artefact polish cluster — seven beads landed sequentially from smallest cleanup to biggest structural fix. All changes scoped to `implementation/epoch/`, `implementation/core/src/re_frame/late_bind*`, and the elision/test sites that consume those surfaces. No spec churn, no back-compat shims (pre-alpha).

## Beads

| # | bead | files | rationale | tests |
|---|------|-------|-----------|-------|
| 1 | rf2-bv5co | `epoch.cljc` | ns docstring drift — "Six failure modes" → "Seven" (rf2-eu9pb added `:rf.epoch/restore-non-ok-record`); clarifies "six under `:rf.epoch/*` + one `:rf.error/no-such-handler` (kind `:frame`)" matching the Tool-Pair §Time-travel table | docs only — no behaviour change |
| 2 | rf2-h5r7l | `epoch.cljc` | cross-link `settle!` ↔ `commit-halt-record!` docstrings — they share `commit-record!` and differ only in buffer-scope vs synthesised-trigger semantics | docs only |
| 3 | rf2-e0lva | `epoch.cljc` + `elision_probe.cljs` + `epoch_test.clj` + `epoch_elision_prod_test.cljs` | tighten `on-frame-destroyed!` / `commit-halt-record!` from `defn` → `defn-`; tests + elision probe migrate from `epoch/on-frame-destroyed!` to `epoch.listeners/on-frame-destroyed!` (the impl seam) | existing tests pass at new surface; no new tests (visibility-only) |
| 4 | rf2-rtk2e | `late_bind.cljc` + `late_bind_drift_test.clj` + `late_bind_cache_test.clj` + `epoch.cljc` | add `late-bind/set-fns!` map-form publisher; migrate epoch's 18 trailing `set-fn!` calls into one map; extend drift gate to recognise the map form (with line-comment stripping); add 4 tests pinning the contract | +4 tests in late-bind-cache-test |
| 5 | rf2-j0jxk | `directory.cljc` | regroup 70+ keys into 4 named purpose-groups (cycle-breaking / cross-artefact / adapter-injection / hot-reload-dev-tooling) with banner blocks; ns-docstring rewrite | drift test unaffected — ordering is documentation-only |
| 6 | rf2-dq2b7 | `state.cljc` + `listeners.cljc` + `epoch_attribution_test.clj` | merge `mount-epoch-by-render-key` + `render-deps-by-render-key` into single `mount-attribution` atom; collapses 2 atoms → 1, 4 wipers → 2; four public accessors survive as projection helpers | +2 structural tests pinning the merged-atom shape |
| 7 | rf2-33lpr | `state.cljc` | review the now-8 atoms; record decision in ns docstring — per-frame cluster (capture-buffers + histories + last-settled + mount-attribution) and listener cluster (listeners + observed-frames-by-cb) both considered and REJECTED on hot-path / contention grounds | docs only — the rf2-dq2b7 merge IS this thread's structural lift |

## Quality gates

- `implementation/epoch` — 214 tests / 804 assertions, 0F/0E (was 212 / 792 pre-rf2-dq2b7).
- `implementation/core` — 787 tests / 3485 assertions, 0F/0E.
- `implementation/` CLJS node-test — 4834 tests / 15761 assertions, 0F/0E.
- `tools/xray` — 950 tests / 3672 assertions, 0F/0E.
- `npm run test:elision` — 41/41 sentinels absent in production / present in control. The `:rf.epoch.cb/silenced-on-frame-destroy` sentinel still elides correctly via `listeners/on-frame-destroyed!`.
- `bash scripts/test-fast-pr.sh` — lockstep / version / core-JVM / JS harness all pass. The `skill/MCP allowed-tools drift` step couldn't find `python` on PATH (Windows host); ran manually via `python3` and it passed too.

## Notable

- rf2-rtk2e introduces `late-bind/set-fns!` as a NEW publication shape; the existing per-key `set-fn!` continues to work everywhere. The drift gate now matches both shapes. The other six feature artefacts (flows, schemas, machines, routing, http, ssr) can migrate to `set-fns!` incrementally as separate refactors.
- rf2-33lpr is a decision-needed bead — the recorded decision is "eight atoms is the right shape after the rf2-dq2b7 merge". The reasoning lives in the `state.cljc` ns docstring so future readers don't re-litigate.
- rf2-e0lva slipped a tiny test-side ns-docstring fix that belongs to rf2-bv5co (the same "six → seven" drift in the test file's coverage checklist). Folded into the e0lva commit and called out in the commit body.