### PR TITLE
refactor(story): pre-alpha posture polish — 3 beads (xwr1d + mobwk + 5hp3r)

### DIFF
--- a/tools/story/spec/006-MCP-Surface.md
+++ b/tools/story/spec/006-MCP-Surface.md
@@ -178,13 +178,13 @@ requests, calls Story's public CLJS / CLJC functions, serialises
 responses back over stdio. Zero agent-specific logic lives in
 `tools/story/`.
 
-## Stage markers — independent cadence
+## Independent cadence
 
-Story's own `re-frame.story/stage` advances as Story's surface
-extends (e.g. `:sota-features` after Stage 6). The MCP jar carries
-its own `re-frame.story-mcp.config/stage = :mcp` — the two artefacts
-have **independent stage progression** and ship at **independent
-cadence** per [`tools/README.md`](../../README.md).
+Story and the MCP jar ship at **independent cadence** per
+[`tools/README.md`](../../README.md). The MCP jar carries its own
+`re-frame.story-mcp.config/stage = :mcp` sentinel; Story's own
+loaded-surface marker was removed (rf2-mobwk) — a single-value
+sentinel carried no discriminator information.
 
 ## Cross-references
 

--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -21,6 +21,20 @@
   Every public symbol on the facade still resolves under its existing
   name; the bodies are thin re-exports / delegators.
 
+  ## Why this file is ~1100 LoC (rf2-5hp3r — facade-size investigation)
+
+  The implementation weight has already been moved off the facade. Of
+  the LoC that remain: ~18% is code-only (thin defmacro wrappers and
+  delegator defns), ~56% is docstring, ~10% is inline structure
+  comments, ~15% is blank-line separation. The size is documentation,
+  not waste — and the docstrings belong on the macros (where authors'
+  IDEs surface them on hover) rather than on the `*`-suffix runtime
+  helpers (which authors don't call directly). Comparable author-
+  facing facades — `re-frame.core` (1.5 KLoC), `day8.re-frame2-xray.
+  config` (1.5 KLoC) — sit in the same range for the same reason.
+  Investigation outcome: structure justifies size; no further split
+  warranted at this stage.
+
   ## Boot
 
   The canonical Story vocabulary auto-installs on the first `reg-*`

--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -984,13 +984,6 @@
   []
   config/static-mode?)
 
-(def stage
-  "Sentinel naming the loaded feature surface. Read by tools that
-  adapt to which Story surface is live; v1.0 is `:sota-features` —
-  every public surface (authoring + runtime + render-shell +
-  assertions+play + sota-features) is present."
-  :sota-features)
-
 ;; ---- UI shell mount / unmount surface -----------------------------------
 ;;
 ;; Per IMPL-SPEC §4 + §8.4 the shell entry points are CLJS-only —

--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -689,10 +689,35 @@
   where they render. Set to `true` while debugging redaction policy
   to see the raw cascade.
 
-  Unrecognised keys are accepted (for forward compat) but ignored."
+  Unrecognised keys raise `:rf.error/unknown-story-config-key` per
+  rf2-xwr1d. Pre-alpha posture: a typo (`:rf.story/edtior`) should
+  fail loudly at boot rather than silently no-op and leave the
+  author chasing 'why isn't my editor preference taking effect?'
+  across a session. The known-keys set is closed and small —
+  `:rf.story/global-args`, `:rf.story/global-decorators`,
+  `:rf.story/editor`, `:rf.story/project-root`, plus the cross-tool
+  `:rf.privacy/show-sensitive?` — if you need an additional key
+  the framework hasn't shipped, extend this set in the same patch
+  that ships the consumer."
   [{:rf.story/keys [global-args global-decorators editor project-root]
     show-sensitive? :rf.privacy/show-sensitive?
     :as opts}]
+  (let [known-keys #{:rf.story/global-args
+                     :rf.story/global-decorators
+                     :rf.story/editor
+                     :rf.story/project-root
+                     :rf.privacy/show-sensitive?}
+        unknown    (remove known-keys (keys opts))]
+    (when (seq unknown)
+      (throw (ex-info ":rf.error/unknown-story-config-key"
+                      {:rf.error/id :rf.error/unknown-story-config-key
+                       :where       'rf.story/configure!
+                       :recovery    :fix-call-site
+                       :reason      (str "configure! got unknown key(s): "
+                                         (pr-str (vec unknown))
+                                         " — known keys are " (pr-str known-keys))
+                       :unknown     (vec unknown)
+                       :known       known-keys}))))
   (when (some? global-args)
     (config/set-global-args! global-args))
   (when (contains? opts :rf.story/global-decorators)

--- a/tools/story/test/re_frame/story_authoring_validation_test.clj
+++ b/tools/story/test/re_frame/story_authoring_validation_test.clj
@@ -365,3 +365,44 @@
            (macros/variant-id-for :story.auth.login-form :empty)))
     (is (= :story.foo/bar
            (macros/variant-id-for :story.foo :bar)))))
+
+;; ===========================================================================
+;; configure! key validation (rf2-xwr1d)
+;;
+;; Pre-alpha posture: configure! validates its keys and throws on any key
+;; outside the closed known-set. A misspelled or unknown key must fail
+;; loudly at boot rather than silently no-op — see story.cljc :configure!
+;; docstring.
+
+(deftest configure-bang-rejects-unknown-keys
+  (testing "an unknown top-level key raises :rf.error/unknown-story-config-key"
+    (let [e (try (story/configure! {:rf.story/edtior :cursor}) ; typo
+                 nil
+                 (catch clojure.lang.ExceptionInfo e e))]
+      (is (some? e) "expected ex-info to be thrown")
+      (is (= ":rf.error/unknown-story-config-key" (.getMessage ^Exception e)))
+      (let [data (ex-data e)]
+        (is (= :rf.error/unknown-story-config-key (:rf.error/id data)))
+        (is (= 'rf.story/configure! (:where data)))
+        (is (= :fix-call-site (:recovery data)))
+        (is (= [:rf.story/edtior] (:unknown data)))
+        (is (contains? (:known data) :rf.story/editor))))))
+
+(deftest configure-bang-accepts-every-known-key
+  (testing "the closed known-set passes through without error"
+    (is (nil? (story/configure! {})) "empty map is a no-op")
+    (is (nil? (story/configure! {:rf.story/global-args        {:theme :light}
+                                 :rf.story/global-decorators  []
+                                 :rf.story/editor             :vscode
+                                 :rf.story/project-root       nil
+                                 :rf.privacy/show-sensitive?  false})))))
+
+(deftest configure-bang-error-lists-every-unknown
+  (testing "multiple unknown keys all surface in :unknown so the author
+            fixes the whole call site in one pass"
+    (let [e (try (story/configure! {:rf.story/edtior :cursor
+                                    :foo             1})
+                 nil
+                 (catch clojure.lang.ExceptionInfo e e))]
+      (is (some? e))
+      (is (= #{:rf.story/edtior :foo} (set (:unknown (ex-data e))))))))

--- a/tools/story/test/re_frame/story_multi_substrate_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_multi_substrate_cljs_test.cljs
@@ -64,8 +64,3 @@
     (is (= #{:reagent}
            (multi/resolve-substrate-set {} {} :reagent)))))
 
-;; ---- stage marker --------------------------------------------------------
-
-(deftest stage-sentinel
-  (testing "Stage 6 advertises :sota-features"
-    (is (= :sota-features story/stage))))

--- a/tools/story/test/re_frame/story_runtime_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_runtime_cljs_test.cljs
@@ -58,12 +58,6 @@
 ;; body. Wrap the reset fn as a map.
 (use-fixtures :each {:before reset-all!})
 
-;; ---- stage marker -------------------------------------------------------
-
-(deftest cljs-stage-marker
-  (testing "Stage 6 supersedes Stage 5 — the loaded CLJS surface advertises :sota-features"
-    (is (= :sota-features story/stage))))
-
 ;; ---- run-variant returns a Promise --------------------------------------
 
 (deftest cljs-run-variant-returns-promise

--- a/tools/story/test/re_frame/story_runtime_test.clj
+++ b/tools/story/test/re_frame/story_runtime_test.clj
@@ -66,12 +66,6 @@
 
 (use-fixtures :each reset-all)
 
-;; ---- stage marker --------------------------------------------------------
-
-(deftest stage-marker-runtime
-  (testing "Stage 6 supersedes Stage 5 — the loaded surface advertises :sota-features"
-    (is (= :sota-features story/stage))))
-
 ;; ===========================================================================
 ;; ARGS PRECEDENCE
 ;; ===========================================================================

--- a/tools/story/test/re_frame/story_test.clj
+++ b/tools/story/test/re_frame/story_test.clj
@@ -731,8 +731,3 @@ without :axis (rf2-jlsvj — lock the public-API contract)"
         (is (= :re-frame.story.registrar/no-axis
                (get idx :dev)))))))
 
-;; ---- Stage 6 contract check -----------------------------------------
-
-(deftest stage-marker
-  (testing "the loaded surface advertises Stage 6 (sota-features)"
-    (is (= :sota-features re-frame.story/stage))))

--- a/tools/story/test/re_frame/story_ui_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_ui_cljs_test.cljs
@@ -49,12 +49,6 @@
 
 (use-fixtures :each {:before reset-all!})
 
-;; ---- stage marker --------------------------------------------------------
-
-(deftest stage-6-marker
-  (testing "Stage 6 advertises :sota-features"
-    (is (= :sota-features story/stage))))
-
 ;; ---- public API additions ------------------------------------------------
 
 (deftest mount-shell-fn-present


### PR DESCRIPTION
Three pre-alpha posture beads on the Story facade.

## rf2-mobwk — drop `:sota-features` single-value stage sentinel

The public `re-frame.story/stage` Var was a sentinel naming the loaded
feature surface — but every reader got `:sota-features`. A single-value
discriminator carries no discriminator information. Pre-alpha posture:
remove it until/unless a second value actually lands.

Drops the Var, four stage-marker tests (one per substrate, each
asserting the same constant), and the stage-progression paragraph in
`story/spec/006-MCP-Surface.md`. The MCP jar's `:mcp` stage marker is
retained — it discriminates between the story jar and the mcp jar, so
it remains a real two-value sentinel.

## rf2-xwr1d — `configure!` validates keys + throws on unknown

`configure!`'s docstring used to end "Unrecognised keys are accepted
(for forward compat) but ignored." Pre-alpha posture per `CLAUDE.md`
('no back-compat shims') argues the opposite: a misspelled key
(`:rf.story/edtior` instead of `:rf.story/editor`) should fail loudly
at boot, not silently no-op and leave the author chasing 'why isn't my
editor preference taking effect?' across a session.

Now: unknown keys raise `:rf.error/unknown-story-config-key` with the
standard error-record shape (`:rf.error/id`, `:where`, `:recovery`,
`:reason`, `:unknown`, `:known`) matching the canonical
`:rf.error/unknown-registry-kind` pattern from `core/registrar.cljc`.

The known-keys set is closed and small — four `:rf.story/*` keys plus
the cross-tool `:rf.privacy/show-sensitive?`. Adding a key in a future
patch extends the set in the same diff as the consumer.

Three new tests in `story_authoring_validation_test.clj`: rejects
unknown, accepts every known key, error lists every unknown so the
author fixes the whole call site in one pass.

## rf2-5hp3r — facade-size investigation (best-effort)

Line classification of `story.cljc` (1137 LoC after the other two beads):

- 207 lines (18%) code-only — thin defmacro wrappers + delegator defns
- 640 lines (56%) docstring  — author-facing IDE-visible help
- 114 lines (10%) inline structure comments
- 176 lines (15%) blank-line separation

The implementation weight has already been split off (rf2-l8eso Phase-2
thinning to query/canonical/lifecycle leaves). What remains is
documentation — and the docstrings belong on the macros (where authors'
IDEs surface them on hover), NOT on the `*`-suffix runtime helpers
(which authors don't call directly).

Comparable peer facades:
- `re-frame.core`              1501 LoC (321 code-only / 892 docstring)
- `day8.re-frame2-xray.config` 1476 LoC

Story's facade at 1137 sits below both. Investigation outcome: the
structure justifies the size; no further split warranted at this stage.
Rationale recorded inline in the namespace docstring so the next
reviewer arrives at the same conclusion without re-running the analysis.

## Quality gates

- `cd tools/story && clojure -M:test` — **860 tests / 2554 assertions, 0F/0E**
- `cd implementation && npm run test:cljs` — **4833 tests / 15775 assertions, 0F/0E**
- `bash scripts/test-fast-pr.sh` — **PASS fast PR spine**
