### PR TITLE
test(xray/feature-gate): theme-token CSS-variable resolution probe (rf2-azfct, Mike-authorised)

### DIFF
--- a/implementation/scripts/serve-and-run-xray-feature-gate.cjs
+++ b/implementation/scripts/serve-and-run-xray-feature-gate.cjs
@@ -46,11 +46,21 @@ const VERBOSE_TESTS = isVerboseTests();
 const SMOKE =
   process.env.RF2_GATE_SMOKE === '1' || process.argv.includes('--smoke');
 
-// Map a scenario's served URL (e.g. "/counter/" or
-// "/testbeds/deliberate-throw/") back to the STAGED_SURFACES entry that
-// serves it, so smoke mode compiles only what the smoke scenarios need.
+// Map a scenario's served URL (e.g. "/counter/",
+// "/testbeds/deliberate-throw/", or
+// "/testbeds/panel-gallery/#/stories") back to the STAGED_SURFACES
+// entry that serves it, so smoke mode compiles only what the smoke
+// scenarios need. The matcher strips the hash fragment (rf2-azfct
+// added the first scenario whose URL carries a `#/...` hash route)
+// and any query string before comparing against `servedPath`, which
+// is hash-/query-free by construction.
 function surfaceForScenario(scenario) {
-  const urlPath = String(scenario.url || '').replace(/^\/+|\/+$/g, '');
+  const raw = String(scenario.url || '');
+  // Drop the hash + query first; some scenarios route via a
+  // hash-router (`#/stories`) where the path before the hash is the
+  // staged surface.
+  const pathOnly = raw.split('#')[0].split('?')[0];
+  const urlPath = pathOnly.replace(/^\/+|\/+$/g, '');
   return STAGED_SURFACES.find((surface) => surface.servedPath === urlPath) || null;
 }
 

--- a/tools/xray/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/xray/testbeds/feature_matrix/scenarios.cjs
@@ -122,6 +122,19 @@ const STAGED_SURFACES = [
     html: ['testbeds', 'ssr_multi_frame', 'index.html'],
     servedPath: 'testbeds/ssr-multi-frame',
   },
+  // rf2-azfct — panel-gallery testbed staged for the theme-token CSS-
+  // variable resolution probe. The gallery embeds bare Xray widgets
+  // without mounting the Xray shell, so its boot path must call
+  // `global-styles/install!` explicitly (rf2-pqulr). The probe asserts
+  // that contract from a real browser; without `install!` every
+  // `var(--rf-xray-*)` reference would resolve to its CSS fallback
+  // default and panels would paint unstyled.
+  {
+    build: 'testbeds/panel-gallery',
+    bundleDir: ['out', 'testbeds', 'panel-gallery'],
+    html: ['tools', 'xray', 'testbeds', 'panel_gallery', 'index.html'],
+    servedPath: 'testbeds/panel-gallery',
+  },
 ];
 
 function sleep(ms) {
@@ -2463,6 +2476,80 @@ async function runPaletteOpenExecute(page, state) {
   };
 }
 
+// rf2-azfct — Mike-authorised 2026-05-28 (explicit exception to the
+// "default Causa/Story tests to CLJS" rule because real-browser CSS-
+// variable resolution is the signal under test; the CLJS render-tree
+// tests pin the inline-style → `var(--rf-xray-*)` contract at the
+// hiccup layer but cannot prove the browser actually substitutes a
+// hex at paint time).
+//
+// rf2-pqulr (the P1 this gate catches): panel-gallery's boot path
+// missing `global-styles/install!` left every `var(--rf-xray-*)`
+// reference resolving to its CSS fallback default, painting every
+// variant unstyled. Without an automated gate the regression went
+// undetected for some time.
+//
+// The probe is minimal — one variant load + one token assertion per
+// the bead's acceptance. The Story shell is left at its default
+// landing (no variant click) because `:root` CSS custom properties
+// are global; the only thing under test is "did boot install them?".
+async function runPanelGalleryThemeTokens(page, state) {
+  // 1. Visit the gallery at /#/stories so the Story shell mounts.
+  //    The gallery's boot calls `global-styles/install!` from
+  //    `panel-gallery.core/run` BEFORE the hash-router routes to
+  //    `mount-stories!` — so the `<style id="rf-xray-themes">` node
+  //    is in `<head>` and the `:root` block is live regardless of
+  //    which mount branch runs.
+  await page.waitForFunction(
+    () => Boolean(document.querySelector('[data-rf-story-root]')),
+    { timeout: 10000 },
+  );
+
+  // 2. Read the published `:root` CSS variable. With
+  //    `global-styles/install!` called the light-palette
+  //    `--rf-xray-text-primary` resolves to the literal hex
+  //    `#24292f` (tokens.cljc `:light :text-primary`). Without
+  //    install! the variable is undefined and getPropertyValue
+  //    returns the empty string.
+  const probe = await page.evaluate(() => {
+    const root = document.documentElement;
+    const rootStyle = getComputedStyle(root);
+    const textPrimary = rootStyle.getPropertyValue('--rf-xray-text-primary').trim();
+    const accent = rootStyle.getPropertyValue('--rf-xray-accent').trim();
+    const themesStyleNode = document.getElementById('rf-xray-themes');
+    return {
+      textPrimary,
+      accent,
+      themesStylePresent: Boolean(themesStyleNode),
+    };
+  });
+
+  state.themeTokens = probe;
+
+  if (!probe.themesStylePresent) {
+    failWithDetails(
+      'panel-gallery boot did not install the rf-xray-themes <style> block — ' +
+        'global-styles/install! never ran. This is the rf2-pqulr regression class.',
+      probe,
+    );
+  }
+  if (!probe.textPrimary || !probe.textPrimary.startsWith('#')) {
+    failWithDetails(
+      '--rf-xray-text-primary did not resolve to a token value on :root. ' +
+        'Either global-styles/install! never ran or the light-palette block ' +
+        'no longer publishes :text-primary (theme/tokens.cljc).',
+      probe,
+    );
+  }
+  if (!probe.accent || !probe.accent.startsWith('#')) {
+    failWithDetails(
+      '--rf-xray-accent did not resolve to a token value on :root. ' +
+        'global-styles/install! likely did not run.',
+      probe,
+    );
+  }
+}
+
 const SCENARIOS = [
   {
     name: 'feature matrix shell and panel handoff',
@@ -2587,6 +2674,32 @@ const SCENARIOS = [
       'Shell, Keybinding, Config, Preload, Settings, and Production Elision',
     ],
     run: runPaletteOpenExecute,
+  },
+  {
+    // rf2-azfct — theme-token CSS-variable resolution probe.
+    // Mike-authorised 2026-05-28 (explicit exception to the
+    // "default Causa/Story tests to CLJS" rule — real-browser
+    // CSS-variable resolution is the signal under test, CLJS
+    // unit tests can't reach it). Gates against the rf2-pqulr
+    // regression class: a boot path that embeds bare Xray widgets
+    // without calling `global-styles/install!` leaves every
+    // `var(--rf-xray-*)` reference resolving to its CSS fallback
+    // default, painting every variant unstyled.
+    //
+    // PR-smoke tier — the panel-gallery surface is unique to this
+    // probe (no other smoke scenario uses it), but the regression
+    // class is severe (P1) and the probe is fast (~one page load
+    // + one DOM read). The compile + serve overhead is the cost
+    // of buying pre-merge coverage of a class of bugs that went
+    // undetected for some time when caught only by live observation.
+    name: 'panel-gallery theme-token CSS-variable resolution on :root (rf2-azfct)',
+    url: '/testbeds/panel-gallery/#/stories',
+    smoke: true,
+    panels: [],
+    coveredRows: [
+      'Shell, Keybinding, Config, Preload, Settings, and Production Elision',
+    ],
+    run: runPanelGalleryThemeTokens,
   },
   // ---- retired by rf2-xy4yb (4-layer chrome refactor) -------------------
   //


### PR DESCRIPTION
Adds a new smoke-tier scenario to the Xray feature-gate harness that
gates the panel-gallery testbed against the rf2-pqulr regression
class: a boot path that embeds bare Xray widgets without calling
`global-styles/install!` leaves every `var(--rf-xray-*)` reference
resolving to its CSS fallback default, painting every variant
unstyled. The original regression went undetected for some time and
was caught only by live observation.

Closes rf2-azfct.

## Why Playwright (Mike-authorised 2026-05-28)

The standing rule is "default new Causa/Story tests to CLJS". This
gate is an explicit exception cited by Mike on 2026-05-28: the
signal under test is the browser's actual resolution of \`:root\` CSS
custom properties at paint time, which only a real browser
exercises. The existing CLJS render-tree tests
(\`tools/xray/test/day8/re_frame2_xray/theme/var_resolution_cljs_test.cljs\`)
pin the inline-style → \`var(--rf-xray-*)\` contract at the hiccup
layer, but cannot prove the browser substitutes a hex when those
vars hit \`:root\` — only \`global-styles/install!\` running on the
boot path achieves that.

## What the probe asserts

After loading \`/testbeds/panel-gallery/#/stories\` and waiting for the
Story shell to mount:

1. The \`<style id=\"rf-xray-themes\">\` block is present in \`<head>\`
   (DOM proof that \`inject-themes-style!\` ran).
2. \`getComputedStyle(document.documentElement).getPropertyValue('--rf-xray-text-primary')\`
   resolves to a non-empty hex string.
3. \`--rf-xray-accent\` resolves to a non-empty hex string.

Any of these failing collapses the panel-gallery to unstyled paint,
which is the rf2-pqulr regression class.

## Regression-catch demonstration

Verified by temporarily commenting out the \`global-styles/install!\`
call in \`tools/xray/testbeds/panel_gallery/core.cljs\` and re-running
\`npm run test:xray-feature-gate:smoke\`:

\`\`\`
FAIL panel-gallery theme-token CSS-variable resolution on :root (rf2-azfct):
  panel-gallery boot did not install the rf-xray-themes <style> block —
  global-styles/install! never ran. This is the rf2-pqulr regression class.: {
    "textPrimary": "",
    "accent": "",
    "themesStylePresent": false
  }
\`\`\`

Restoring the call → all 4 smoke scenarios pass:

\`\`\`
Ran 4 Xray feature scenarios (PR-smoke tier). 0 failures. Covered 10 matrix rows.
\`\`\`

## Files touched

- \`tools/xray/testbeds/feature_matrix/scenarios.cjs\` — adds
  \`testbeds/panel-gallery\` to STAGED_SURFACES + a new smoke-tier
  scenario \`panel-gallery theme-token CSS-variable resolution on
  :root (rf2-azfct)\` with its \`runPanelGalleryThemeTokens\` driver.

- \`implementation/scripts/serve-and-run-xray-feature-gate.cjs\` —
  \`surfaceForScenario\` now strips the URL hash + query before
  matching against \`servedPath\` so smoke mode's compile selector
  resolves hash-routed surfaces (the new scenario uses \`#/stories\`,
  the first feature-gate scenario whose URL carries a hash route).

## Scope kept minimal

One variant load + one staged surface + three assertions on the
same boot path per the bead's acceptance. No matrix expansion (light
vs dark, multiple variants, per-token sweep) — kept as future work
if the gate proves valuable. The compile + serve cost for the new
surface is paid once per smoke run.

## Quality gates

- \`bash scripts/test-fast-pr.sh\` → PASS (4836 tests, 0 failures, 0 errors).
- \`npm run test:xray-feature-gate:smoke\` → PASS (4 scenarios incl. new probe, 0 failures).
- Regression-catch demo: probe FAILS with \`install!\` removed, PASSES with \`install!\` restored.