### PR TITLE
chore(tools/mcp): polish sweep — 12 beads (7a63q + rk2c7 + 93cew + xvqwz + 8 P4s)

### DIFF
--- a/tools/mcp-base/spec/README.md
+++ b/tools/mcp-base/spec/README.md
@@ -130,6 +130,23 @@ Two rules:
    ns keeps a thin local alias over `re-frame.privacy/sensitive?`
    for code-review locality — the predicate itself lives here.)
 
+**What this rules OUT** — concrete rejection cases so a contributor
+sees the trap before falling in:
+
+- **story-mcp's recorder bridge** — NO. Only one consumer; the bridge
+  is recorder-specific machinery, not a cross-MCP primitive. Lifting
+  it would invert the rule and pull recorder-shaped concerns into the
+  base for every other server to ignore.
+- **A re-frame2-pair-only nREPL bencode helper** — NO. Single
+  consumer; nREPL transport is pair-mcp's domain. story-mcp does not
+  speak nREPL; lifting would add a runtime concern the base does not
+  need to know about.
+- **A token-cap algorithm shared with a hypothetical xray-mcp before
+  it ships** — NO. Speculative. The rule is "implemented somewhere
+  already"; a primitive lifted ahead of a real second consumer earns
+  the wrong shape for the consumer that eventually materialises (or
+  never materialises). Lift when the second consumer exists.
+
 A new shared primitive ships with:
 
 - A per-namespace spec doc in this folder (`<ns>.md`), at the

--- a/tools/mcp-base/spec/README.md
+++ b/tools/mcp-base/spec/README.md
@@ -50,8 +50,8 @@ per-namespace contract doc; the table below indexes them:
 | `section-grouping` | Patch-list → path-headed cluster sections (`group-patches-into-sections` / `sections->patches`, rf2-qeous); consumed by `diff-encode`. | [`section-grouping.md`](section-grouping.md) |
 | `overflow` | Overflow-marker payload SHAPE builder (`overflow-payload`) + `token-estimate` + fallback hint (rf2-rvyzy). | [`overflow.md`](overflow.md) |
 | `cap` | Wire-boundary two-stage token-budget cap pipeline + `max-tokens` resolver + `ResultIO` protocol (rf2-eyelu / rf2-ih7g4). | [`cap.md`](cap.md) |
-| `cursor` | Shared cursor-pagination machinery — base64 codec, opaque encode/decode with `::malformed` recovery, `:limit` clamp, `cursor-stale-result` envelope (rf2-ee38b.19). | _(see ns docstring)_ |
-| `envelope` | Indicator-field `with-indicators` splice (`:dropped-sensitive` / `:elided-large`, omit-when-zero MUST) + wire-bounded `:rf.mcp/*` marker detection (rf2-ee38b.19). | _(see ns docstring)_ |
+| `cursor` | Shared cursor-pagination machinery — base64 codec, opaque encode/decode with `::malformed` recovery, `:limit` clamp, `cursor-stale-result` envelope (rf2-ee38b.19). | [`cursor.md`](cursor.md) |
+| `envelope` | Indicator-field `with-indicators` splice (`:dropped-sensitive` / `:elided-large`, omit-when-zero MUST) + wire-bounded `:rf.mcp/*` marker detection (rf2-ee38b.19). | [`envelope.md`](envelope.md) |
 
 All `.cljc`, so consumers compile them under their own platform —
 re-frame2-pair-mcp's shadow-cljs node build, story-mcp's JVM

--- a/tools/mcp-base/spec/cursor.md
+++ b/tools/mcp-base/spec/cursor.md
@@ -1,0 +1,101 @@
+# `cursor` — shared cursor-pagination machinery (rf2-ee38b.19)
+
+> **Type:** Reference (`tools/mcp-base/spec/`)
+> Owns the cross-MCP cursor codec, the EDN-with-no-tagged-literals reader, the size cap, the `::malformed` recovery contract, the `:limit` clamp, and the `cursor-stale-result` envelope. The cursor PAYLOAD shape is consumer-side (story carries `{:offset :total :sig}`; pair carries `{:after-id :ms :until-ms :frame}`).
+
+This doc is one of ten per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`envelope.md`](envelope.md).
+
+## Scope
+
+Per `spec/Principles.md` §Pagination and `spec/Tool-Pair.md` §Cursor pagination, every read tool whose return size is a function of registry / ring size MUST accept a `:limit` arg and return an opaque `:cursor` for continuation. Cursors are OPAQUE on the wire — the agent passes them back verbatim and has no business decoding the format.
+
+`cursor` owns:
+
+- `max-cursor-bytes` const (**1024**) — hard ceiling on a cursor token's character length.
+- `b64-encode` / `b64-decode` — the base64 codec, resolving to `java.util.Base64` (JVM) / `js/Buffer` (CLJS) via reader-conditional.
+- `parse-limit-arg` — the `:limit` clamp (`default` and `max` per-consumer).
+- `encode-cursor` / `decode-cursor` — opaque codec around the consumer's payload map.
+- `malformed?` — predicate for the `::malformed` sentinel.
+- `cursor-stale-result` — the cross-MCP cursor-stale envelope builder, delegating to the consumer's `error-result`.
+
+`cursor` does NOT own:
+
+- The cursor PAYLOAD shape — that's consumer-side. `decode-cursor` takes a `valid?` predicate so each server validates its own payload map.
+- The wire envelope shape — `cursor-stale-result` takes the consumer's `error-result` fn so each server shapes the envelope its own way.
+- The cursor *resource controls* (concurrent-stream cap, token-bucket rate-limit, abuse window) — those live consumer-side in pair-mcp's `resource_controls.cljs`.
+
+## Surface
+
+### `max-cursor-bytes` — const, 1024
+
+Hard ceiling on the cursor token's character length. Cursors are short opaque tokens (a base64'd EDN map of a handful of scalar slots); anything longer is rejected before parsing as a cheap DoS / malformed guard. 1 KB is far past any legitimate cursor.
+
+### `b64-encode s` — string → base64 string
+
+Base64-encode a UTF-8 string. `java.util.Base64` on the JVM, `js/Buffer` on CLJS.
+
+### `b64-decode s` — base64 string → string
+
+Inverse of `b64-encode`.
+
+### `parse-limit-arg raw default max` — int
+
+Normalise the `:limit` MCP arg into an integer in `[1, max]`, defaulting to `default`. Caller-supplied values above `max` clamp DOWN (a legitimate large request still works, just capped). Delegates to `args/parse-positive-int` for the shared string/number coercion, then applies the ceiling.
+
+Each server bakes its own `default` (story 25, pair 50) and `max` (story's 200; pair's wire-cap is the implicit ceiling) — the convention is the CLAMP behaviour, not the numbers.
+
+### `encode-cursor payload` — payload map → base64 string
+
+Unconditional encoder — always produces a token for a payload map. The caller decides WHEN to emit a cursor (when there are more entries / records); the absence-of-cursor IS the end-of-pagination signal, so the caller passes `nil` rather than calling this when pagination is over. Returns `nil` for a nil / non-map payload as a safety net.
+
+### `decode-cursor s valid?` — base64 string × predicate → payload map | nil | `::malformed`
+
+Decode an opaque base64 cursor back to its EDN payload map.
+
+Returns:
+
+- `nil` — the cursor arg is absent (nil / undefined) or blank. The caller treats this as "start from the beginning" (offset 0 / head).
+- `::malformed` — the cursor exists but is not a well-formed, `valid?`-passing payload map: it failed to base64/EDN-decode, carried a tagged literal, exceeded `max-cursor-bytes`, or its payload map failed the consumer's `valid?` predicate. Callers treat `::malformed` exactly like a STALE cursor — drop it and restart.
+
+`valid?` is the consumer's payload-shape predicate (e.g. `#(and (map? %) (integer? (:offset %)) (string? (:sig %)))` for story; `#(and (map? %) (string? (:after-id %)))` for pair).
+
+Hardened: non-string input → `::malformed`; oversize input → `::malformed` BEFORE parsing; the input is decoded exactly once.
+
+### `malformed? decoded` — predicate
+
+True when `decoded` is the `::malformed` sentinel returned by `decode-cursor`. Convenience for consumers that prefer a predicate over the qualified-keyword literal at the call site.
+
+### `cursor-stale-result error-result tool opts` — envelope map
+
+Build a structured cursor-stale error result via the consumer's `error-result` fn.
+
+The `:reason` slot is the cross-MCP `vocab/cursor-stale-reason` (`:rf.mcp/cursor-stale`) so an agent that learned the recovery path on one server reuses it on the other — whether staleness means ring-rotation (pair) or registry-change-between-pages (story).
+
+`error-result` is the consumer's error-envelope builder. It is called as `(error-result message data-map)` where `message` is a human-readable string and `data-map` carries the structured slots (`:ok? false`, `:reason`, `:tool`, `:hint`, plus any caller `extra`). Each server's `error-result` shapes the wire envelope its own way (story-mcp's `h/error-result`, pair-mcp's `wire/err-text`); this builder owns only the cross-MCP slot vocabulary.
+
+`opts`:
+
+- `:message` — override the default human-readable message.
+- `:hint` — override the default recovery hint.
+- `:extra` — a map of additional structured slots to merge in (e.g. pair's `:requested-id` / `:head-id`).
+
+## Tagged-literal rejection
+
+The EDN reader inside `decode-cursor` runs with a `:default` data-reader that throws `:rf.error/mcp-cursor-bad-edn-tag` on ANY tagged literal. A hostile / corrupt cursor cannot smuggle a `#js`, `#inst`, or custom tagged literal past the reader. The throw is caught by the surrounding try and surfaces as `::malformed`.
+
+## Why this ns
+
+Both servers previously hand-rolled the SAME machinery:
+
+- `tools/story-mcp/.../cursor.cljc` — offset/total/sig over append-mostly registries.
+- `tools/re-frame2-pair-mcp/.../cursor.cljs` — after-id/ms over the bounded epoch ring.
+
+The cursor PAYLOAD differs by domain, but the base64 codec, the EDN reader with tagged-literal rejection + size guard, the `::malformed` recovery contract, the `:limit` clamp, and the `cursor-stale-result` envelope are identical. Earlier the README argued the codec was consumer-side because `js/Buffer` vs `java.util.Base64` differ — story-mcp's `cursor.cljc` refuted that — the codec lifts cleanly as a `.cljc` reader-conditional.
+
+## See also
+
+- [`README.md`](README.md) — the per-namespace index this doc is part of.
+- [`vocab.md` §JSON-RPC error codes + cross-MCP error reasons](vocab.md) — the `cursor-stale-reason` key.
+- [`args.md`](args.md) — `parse-positive-int`, used by `parse-limit-arg`.
+- `spec/Tool-Pair.md` §Cursor pagination — the framework-level rule the codec implements.
+- rf2-ee38b.19 — the bead that landed this ns.

--- a/tools/mcp-base/spec/envelope.md
+++ b/tools/mcp-base/spec/envelope.md
@@ -1,0 +1,80 @@
+# `envelope` — cross-MCP response-envelope helpers (rf2-ee38b.19)
+
+> **Type:** Reference (`tools/mcp-base/spec/`)
+> Owns the SHAPE of the indicator-field splice (`with-indicators`) enforcing the MUST-level "omit when zero" rule, plus the wire-bounded `:rf.mcp/*` marker detection used by the cache + cap boundary steps. The indicator KEYS themselves live in [`vocab.md`](vocab.md); this ns owns the splice + detection logic.
+
+This doc is one of ten per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md).
+
+## Scope
+
+`envelope` owns:
+
+- `with-indicators` — splice the `:dropped-sensitive` / `:elided-large` slots onto an envelope, enforcing the "omit when zero" MUST.
+- `marker-prefixes` — the rendered-text prefixes of the wire-bounded `:rf.mcp/cache-hit` / `:rf.mcp/overflow` envelopes (both flat and namespaced-map print forms).
+- `marker-text?` — wire-bounded marker detection on a rendered text string.
+
+`envelope` does NOT own:
+
+- The indicator KEYS — those live in [`vocab.md`](vocab.md) (`dropped-sensitive-key`, `elided-large-key`).
+- The COUNTS — the producers live in [`sensitive.md`](sensitive.md) (`strip-sensitive`) and [`elision.md`](elision.md) (`count-elided-markers`).
+- The transport. `with-indicators` operates on a Clojure envelope map. `marker-text?` operates on the RENDERED text string — the consumer reads its own platform's content slot (`:text` from a Clojure map / `j/get :text` from a JS object) and passes the string here, so the shape-specific accessor stays consumer-side while the prefix-detection logic is shared.
+
+## Surface
+
+### `with-indicators envelope counts` — envelope map
+
+Splice the cross-MCP indicator-field slots onto a tool's envelope map, enforcing the MUST-level "omit when zero" rule from Conventions §Cross-MCP indicator-field vocabulary and Spec 009 §Indicator field on tool responses.
+
+Every tool that walks a tree-typed payload (`snapshot`, `get-path`, `trace-window`, `watch-epochs`, `subscribe`, …) routes its envelope-tail through here so the rule lives in one place — drift across emit sites can no longer silently violate the MUST.
+
+`counts`:
+
+- `:dropped` — count of `:sensitive? true` leaves dropped at the wire boundary (from `sensitive/strip-sensitive`). Emitted under `vocab/dropped-sensitive-key` when positive.
+- `:elided` — count of leaves replaced with the `:rf.size/large-elided` marker (from `elision/count-elided-markers`). Emitted under `vocab/elided-large-key` when positive.
+
+A zero / nil / absent count omits its slot entirely (the "omit when zero" MUST). Returns `envelope` unchanged when both counts are zero — identity-preserving on the common path.
+
+### `marker-prefixes` — vector of prefix strings
+
+Rendered-text prefixes of the wire-bounded `:rf.mcp/*` replacement envelopes (`:rf.mcp/cache-hit`, `:rf.mcp/overflow`). Includes BOTH the flat and the namespaced-map print forms (see §Print-form parity below) so the detector works regardless of host or `*print-namespace-maps*`.
+
+### `marker-text? text` — predicate
+
+Is `text` (the rendered EDN text of a response's first content slot) a wire-bounded `:rf.mcp/*` marker envelope?
+
+Returns true for `:rf.mcp/cache-hit` / `:rf.mcp/overflow` markers — the two envelopes the cache + cap steps emit themselves. The consumer reads its own platform's content text (`:text` from a Clojure map, `j/get :text` from a JS object) and passes the string here; this fn owns only the prefix-match logic, shared across hosts.
+
+Nil-safe: a nil / non-string `text` is not a marker.
+
+## Why wire-bounded markers matter (rf2-gktyn, rf2-3z0zi)
+
+The `:rf.mcp/cache-hit` and `:rf.mcp/overflow` envelopes are replacement results the cache + cap boundary steps emit themselves. By construction they are sub-cap size — re-walking either is wasted work, and a cache check on a hit-marker would hash the marker, not the original payload. `marker-text?` is the cheap detector every boundary step uses to short-circuit when it sees an earlier step's marker.
+
+## Print-form parity
+
+Substring-match on the rendered text is the cheap detector — the marker map's namespaced key is the first key of the outer map, so a `starts-with?` on the trimmed text is fast and tight. The detector matches BOTH print forms the single-key namespaced marker map can take:
+
+- the flat form `{:rf.mcp/overflow …` (the form CLJS `pr-str` emits and the form JVM emits with `*print-namespace-maps*` false), and
+- the namespaced-map shorthand `#:rf.mcp{:overflow …` (the form JVM `pr-str` emits by default for a single-namespace map).
+
+Matching both keeps the detector host- and print-setting-agnostic. A false positive would require an agent-supplied payload that ALSO renders with `:rf.mcp/cache-hit` / `:rf.mcp/overflow` as its leading top-level key — not a realistic shape for any tool's result.
+
+## Indicator-field parity
+
+The cross-MCP conformance gate at `tools/mcp-conformance/wire-vocab/` pins the canonical Malli schema for the indicator-field slots and asserts the "omit when zero" MUST across both servers' fixtures. The slot keys themselves come from [`vocab.md`](vocab.md):
+
+- `vocab/dropped-sensitive-key` — `:dropped-sensitive`
+- `vocab/elided-large-key` — `:elided-large`
+
+Every server that emits an envelope with one of these slots routes through `with-indicators` so the MUST is enforced in one place.
+
+## See also
+
+- [`README.md`](README.md) — the per-namespace index this doc is part of.
+- [`vocab.md`](vocab.md) — the indicator + marker key catalogue.
+- [`sensitive.md`](sensitive.md) — the producer of `:dropped` counts.
+- [`elision.md`](elision.md) — the producer of `:elided` counts.
+- `spec/Conventions.md` §Cross-MCP indicator-field vocabulary — the MUST-level parity rule.
+- `spec/009-Instrumentation.md` §Indicator field on tool responses — the framework-level surface.
+- rf2-ee38b.19 — the bead that landed this ns.
+- rf2-gktyn / rf2-3z0zi — the beads that landed the wire-bounded marker detection.

--- a/tools/mcp-base/src/re_frame/mcp_base/sensitive.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/sensitive.cljc
@@ -5,7 +5,8 @@
   ## What spec/009 mandates
 
   Framework-published forwarders — Sentry / Honeybadger, re-frame2-pair server,
-  Story-MCP, Xray-MCP — MUST default-drop trace events whose
+  Story-MCP (xray-mcp was dropped in rf2-bu21t; xray now ships as a
+  Clojars-only library, not an MCP server) — MUST default-drop trace events whose
   registration declared `:sensitive? true`. The runtime stamps the
   flag at the top level of every emitted trace event inside such a
   registration's handler scope; the forwarder's job is to gate egress

--- a/tools/mcp-conformance/test/live-re-frame2-pair-overflow.cjs
+++ b/tools/mcp-conformance/test/live-re-frame2-pair-overflow.cjs
@@ -72,6 +72,16 @@
 // (same as the sibling harness). Exits 0 on success or SKIP. Exits 1
 // on any conformance violation.
 
+// ## DRY-on-3 trigger (rf2-1bwph)
+//
+// This file and its sibling `live-re-frame2-pair-subscribe.cjs` share
+// LIVE-specific fixture setup (nREPL gating via $SHADOW_CLJS_NREPL_PORT,
+// SDK Client construction against the spawned server, watchdog ceremony).
+// The shared `_runner.cjs` already covers the common SDK-spawn ceremony.
+// We deliberately do NOT factor the LIVE-specific setup at 2 files —
+// factoring at 2 is premature; the right shape only emerges at 3. When a
+// 3rd `live-*` script lands, lift the shared bits per rf2-1bwph.
+
 const path = require('node:path');
 const os = require('node:os');
 const { parseEDNString } = require('edn-data');

--- a/tools/mcp-conformance/test/live-re-frame2-pair-subscribe.cjs
+++ b/tools/mcp-conformance/test/live-re-frame2-pair-subscribe.cjs
@@ -58,6 +58,16 @@
 // (`scripts/run-live-re-frame2-pair-overflow-hermetic.cjs`) wires the env when
 // run as part of the hermetic suite.
 
+// ## DRY-on-3 trigger (rf2-1bwph)
+//
+// This file and its sibling `live-re-frame2-pair-overflow.cjs` share
+// LIVE-specific fixture setup (nREPL gating via $SHADOW_CLJS_NREPL_PORT,
+// SDK Client construction against the spawned server, watchdog ceremony).
+// The shared `_runner.cjs` already covers the common SDK-spawn ceremony.
+// We deliberately do NOT factor the LIVE-specific setup at 2 files —
+// factoring at 2 is premature; the right shape only emerges at 3. When a
+// 3rd `live-*` script lands, lift the shared bits per rf2-1bwph.
+
 const path = require('node:path');
 const os = require('node:os');
 const { runWithWatchdog } = require('./_runner.cjs');

--- a/tools/mcp-conformance/wire-vocab/deps.edn
+++ b/tools/mcp-conformance/wire-vocab/deps.edn
@@ -30,11 +30,15 @@
 ;; runtime classpath.
 {:paths []
 
- :deps  {org.clojure/clojure {:mvn/version "1.12.0"}
+ :deps  {org.clojure/clojure  {:mvn/version "1.12.0"}
          ;; Malli for schema validation. Already on the implementation's
          ;; classpath (used by tools/story-mcp); pinning the same version
          ;; here so the schema syntax matches.
-         metosin/malli       {:mvn/version "0.16.4"}}
+         metosin/malli        {:mvn/version "0.16.4"}
+         ;; data.json for the verb-vocab linter (rf2-vkx7m) — reads each
+         ;; server's canonical `tool-names.json` fixture to lint against
+         ;; the NAMING.md verb catalogue.
+         org.clojure/data.json {:mvn/version "2.5.0"}}
 
  :aliases
  ;; All fixtures are inlined in `wire_vocab_test.clj` (as the `:fixtures`

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/fixtures.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/fixtures.clj
@@ -16,10 +16,9 @@
   ## What this ns owns
 
   - **`repo-root`** — absolute path to the repo root, derived from the
-    classpath URL of this file. Walks five `.getParentFile` levels
-    (one fewer than the test files used because this file lives in
-    the same directory as them, but the macro that computes it from
-    `*file*` resolves at the same classpath leaf).
+    classpath URL of this file. Walks seven `.getParentFile` levels
+    (mcp_conformance → re_frame → test → wire-vocab → mcp-conformance
+    → tools → repo-root).
   - **`read-source`** — slurp a file at a repo-relative path. Fails
     loudly via `slurp`'s IOException if the path doesn't resolve;
     that's the right signal — a moved/removed file under conformance
@@ -41,15 +40,12 @@
   (:require [clojure.java.io :as io]))
 
 ;; ---------------------------------------------------------------------------
-;; Repo-root resolution. Each conformance test ns lives at
-;; `tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/<name>.clj`
+;; Repo-root resolution. This file lives at
+;; `tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/fixtures.clj`
 ;; relative to the repo root. We resolve THIS file's classpath URL and
-;; walk five parents up to reach the repo root. The walk is one shorter
-;; than the original per-test calculation because the original code
-;; computed it from `*file*` (a relative path) and the parent chain had
-;; an extra synthetic step; `io/resource` returns the absolute classpath
-;; URL whose first parent is the `mcp_conformance/` leaf directly. Both
-;; computations resolve to the same repo root.
+;; walk seven parents up to reach the repo root (one `.getParentFile`
+;; per path segment). `io/resource` returns the absolute classpath URL
+;; whose first parent is the `mcp_conformance/` leaf directly.
 ;; ---------------------------------------------------------------------------
 
 (def repo-root

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/indicator_field_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/indicator_field_test.clj
@@ -66,10 +66,11 @@
 ;; ---------------------------------------------------------------------------
 ;; Contract — the canonical envelope-slot vocabulary.
 ;;
-;; Both slots are unqualified keywords (per Conventions:157 — they ride
-;; alongside tool-shaped payloads where the tool's slot vocabulary is
-;; unqualified by convention). Values are non-negative integers (`0`
-;; never appears — the omit-when-zero rule turns 0 into "key absent").
+;; Both slots are unqualified keywords (per Conventions §Cross-MCP
+;; indicator-field vocabulary — they ride alongside tool-shaped
+;; payloads where the tool's slot vocabulary is unqualified by
+;; convention). Values are non-negative integers (`0` never appears —
+;; the omit-when-zero rule turns 0 into "key absent").
 ;; ---------------------------------------------------------------------------
 
 (def ^:private dropped-sensitive-key :dropped-sensitive)

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/verb_vocab_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/verb_vocab_test.clj
@@ -1,0 +1,185 @@
+(ns re-frame.mcp-conformance.verb-vocab-test
+  "Cross-MCP verb-vocabulary conformance (rf2-vkx7m).
+
+  Pins the cross-server **tool-name verb vocabulary** catalogued in
+  `tools/mcp-conformance/NAMING.md` §The verb table. Every tool the
+  pair (re-frame2-pair-mcp, story-mcp) advertises MUST start with one
+  of the catalogued verb prefixes — or appear on the bare-verb /
+  bare-noun exception list — so an agent that learned the verb table
+  once recognises the surface across servers.
+
+  Sibling to:
+
+  - [`wire_vocab_test.clj`](wire_vocab_test.clj)     — wire MARKER
+    vocabulary (`:rf.mcp/*` / `:rf.size/*` namespaced payload shapes).
+  - [`indicator_field_test.clj`](indicator_field_test.clj) —
+    envelope SLOT vocabulary for suppression counters.
+  - [`slot_name_test.clj`](slot_name_test.clj)       — `tools/call`
+    INPUT-arg slot vocabulary.
+  - **This file**                                    — tool-NAME verb
+    vocabulary.
+
+  ## What this test guards
+
+  Each server ships a canonical `tool-names.json` fixture used by the
+  per-server unit tests (story-mcp's `tools_test.clj`,
+  re-frame2-pair-mcp's stdio roundtrip). This linter reads each
+  fixture and asserts every tool name starts with a catalogued verb,
+  is a catalogued bare-verb, or appears on the bare-noun-exception
+  allowlist (Clojure-idiomatic projections like `variant->edn`, single-
+  primitive reads like `snapshot-identity`).
+
+  A new tool with an off-convention verb (`fetch-foo`, `update-bar`,
+  …) lands today without anything tripping — the convention is doc-
+  only. This gate makes the convention executable.
+
+  ## Adding a new verb
+
+  Extending the catalogue requires a Lock entry in the relevant
+  server's `spec/DESIGN-RATIONALE.md` AND a row in NAMING.md §The
+  verb table. THEN extend `verb-prefixes` / `bare-verbs` /
+  `bare-noun-exceptions` below. The friction is intentional — every
+  added verb is a new surface an agent must learn."
+  (:require [clojure.data.json :as json]
+            [clojure.string    :as str]
+            [clojure.test      :refer [deftest is testing]]
+            [re-frame.mcp-conformance.fixtures :as fx]))
+
+;; ---------------------------------------------------------------------------
+;; Catalogued verb prefixes — every entry mirrors a row in NAMING.md
+;; §The verb table. Order is non-significant; matching is "first prefix
+;; that matches", so register-/unregister- precede register precedes
+;; nothing — we test by prefix-with-trailing-dash so no ordering hazard.
+;; ---------------------------------------------------------------------------
+
+(def ^:private verb-prefixes
+  "Catalogued prefix verbs from NAMING.md §The verb table. Each entry
+  matches as `<prefix>-<rest>` against a tool name."
+  #{"get"
+    "list"
+    "read"
+    "discover"
+    "restore"
+    "reset"
+    "register"
+    "unregister"
+    "run"
+    "preview"
+    "record-as"
+    "tail"})
+
+(def ^:private bare-verbs
+  "Catalogued bare-verb tool names from NAMING.md §The verb table
+  (`dispatch`, `eval-cljs`, `subscribe` / `unsubscribe`) plus the
+  mega-op bare verbs (`snapshot`, `trace-window`, `watch-epochs`)."
+  #{"dispatch"
+    "dispatch-dry-run"  ; sibling of `dispatch` (rf2-ee38b.18 dry-run gate)
+    "eval-cljs"
+    "subscribe"
+    "unsubscribe"
+    "snapshot"
+    "trace-window"
+    "watch-epochs"})
+
+(def ^:private bare-noun-exceptions
+  "Bare-noun reads catalogued in NAMING.md §Server alignment today as
+  'Deviation — accepted exception'. Each entry needs a row in the
+  alignment table explaining the exception:
+
+  - `handler-meta` — bare-noun read of a single-record metadata map
+    (re-frame2-pair-mcp; accepted under the bare-noun-exception clause
+    for structured metadata blobs the agent reads as one record).
+  - `variant->edn` — Clojure-idiomatic projection name (story-mcp;
+    `<thing>->edn` is preferable to `get-<thing>-edn` when the
+    operation is a canonical-form serialiser).
+  - `snapshot-identity` — bare-noun read of a content-hash (story-mcp;
+    accepted under the bare-noun-exception clause when the return
+    value is a single primitive)."
+  #{"handler-meta"
+    "variant->edn"
+    "snapshot-identity"})
+
+;; ---------------------------------------------------------------------------
+;; Tool-name fixtures. The canonical per-server `tool-names.json`
+;; (already used by per-server tests for `tools/list` agreement) — we
+;; read the same fixture so this linter and the per-server tests can't
+;; drift apart.
+;; ---------------------------------------------------------------------------
+
+(def ^:private tool-name-fixtures
+  "Per-server `tool-names.json` fixture paths. Adding a new server
+  means adding a row here AND extending `fx/known-servers`."
+  {:re-frame2-pair-mcp "tools/re-frame2-pair-mcp/test/fixtures/tool-names.json"
+   :story-mcp          "tools/story-mcp/test/fixtures/tool-names.json"})
+
+(defn- read-tool-names
+  "Slurp + JSON-parse the canonical tool-names fixture for `server`.
+  Returns a vector of strings."
+  [server]
+  (-> (fx/read-source (get tool-name-fixtures server))
+      (json/read-str)
+      (get "names")
+      vec))
+
+;; ---------------------------------------------------------------------------
+;; Verb classification.
+;; ---------------------------------------------------------------------------
+
+(defn- starts-with-catalogued-prefix?
+  "True when `tool-name` begins with one of the catalogued verb
+  prefixes followed by a `-`. The trailing-dash check avoids matching
+  e.g. `runtime` against the `run` prefix — only `run-<rest>` is the
+  catalogued shape."
+  [tool-name]
+  (some (fn [prefix]
+          (str/starts-with? tool-name (str prefix "-")))
+        verb-prefixes))
+
+(defn- classify-tool
+  "Classify `tool-name` against the catalogued vocabulary. Returns one
+  of `:prefix` / `:bare-verb` / `:exception` / `:unknown`. `:unknown`
+  is the only failing classification."
+  [tool-name]
+  (cond
+    (starts-with-catalogued-prefix? tool-name) :prefix
+    (contains? bare-verbs tool-name)           :bare-verb
+    (contains? bare-noun-exceptions tool-name) :exception
+    :else                                      :unknown))
+
+;; ---------------------------------------------------------------------------
+;; Tests.
+;; ---------------------------------------------------------------------------
+
+(deftest every-tool-name-uses-a-catalogued-verb
+  (testing "every tool in every server's tool-names.json starts with a
+            catalogued NAMING.md verb prefix, is a catalogued bare verb,
+            or appears on the bare-noun-exception allowlist"
+    (doseq [server (sort (keys tool-name-fixtures))
+            tool   (read-tool-names server)]
+      (let [verdict (classify-tool tool)]
+        (is (not= :unknown verdict)
+            (str server " ships tool '" tool "' which does not match a "
+                 "catalogued verb shape. See NAMING.md §The verb table. "
+                 "If the tool is genuinely a new verb shape, follow "
+                 "NAMING.md §How to extend this table (Lock entry + row "
+                 "+ catalogue update); if it's a near-synonym for a "
+                 "catalogued verb, rename to the catalogued form."))))))
+
+(deftest catalogued-fixture-paths-resolve
+  (testing "every entry in tool-name-fixtures resolves to a file that
+            yields at least one tool name (catches a moved/removed
+            fixture)"
+    (doseq [server (sort (keys tool-name-fixtures))]
+      (let [names (read-tool-names server)]
+        (is (pos? (count names))
+            (str server "'s tool-names.json fixture at "
+                 (get tool-name-fixtures server)
+                 " yielded zero tool names — fixture moved or empty?"))))))
+
+(deftest catalogue-covers-every-known-server
+  (testing "the verb-vocab linter knows about every server in fx/known-servers"
+    (doseq [server fx/known-servers]
+      (is (contains? tool-name-fixtures server)
+          (str "fx/known-servers carries " server " but the verb-vocab "
+               "linter has no tool-names.json fixture path for it. Add "
+               "a row to tool-name-fixtures.")))))

--- a/tools/re-frame2-pair-mcp/spec/000-Vision.md
+++ b/tools/re-frame2-pair-mcp/spec/000-Vision.md
@@ -29,6 +29,85 @@ persistent nREPL socket is held for the lifetime of the session;
 the canonical re-frame2-pair ops are exposed as MCP tools — see
 [`003-Tool-Catalogue.md`](003-Tool-Catalogue.md) for the live count.
 
+## Architecture at a glance
+
+The artefact is 9,700 LOC across 44 source files — intrinsically large
+(live nREPL bridge + streaming + 17 tools + roots-discovery + resource
+controls). The layering is straightforward but only surfaces from
+reading multiple ns docstrings; this diagram sits at the entrance so a
+new reader (human or AI pair) is oriented in 60 seconds.
+
+```
+                          MCP client (Claude Code / Cursor / Copilot)
+                              │
+                              ▼  tools/call request (stdio, JSON-RPC)
+                       ┌─────────────────────────────────────────────┐
+                       │  server.cljs                                │
+                       │    lifecycle, port-discovery cascade,       │
+                       │    SDK transport wiring                     │
+                       └─────────────────────────────────────────────┘
+                              │
+                              ▼  invoke
+                       ┌─────────────────────────────────────────────┐
+                       │  tools.cljs — wire-boundary pipeline        │
+                       │    precheck → dispatch → apply-cache        │
+                       │             → apply-cap                     │
+                       └─────────────────────────────────────────────┘
+                              │
+                              ▼  per-tool body
+                       ┌─────────────────────────────────────────────┐
+                       │  tools/<tool>.cljs                          │
+                       │    snapshot.cljs, dispatch.cljs,            │
+                       │    eval_cljs.cljs, subscribe.cljs, …        │
+                       │    (one file per tool — 17 total)           │
+                       └─────────────────────────────────────────────┘
+                              │
+                              ▼  bencode round-trip
+                       ┌─────────────────────────────────────────────┐
+                       │  nrepl.cljs                                 │
+                       │    persistent socket, message correlation   │
+                       └─────────────────────────────────────────────┘
+                              │
+                              ▼  cljs-eval
+                       ┌─────────────────────────────────────────────┐
+                       │  shadow-cljs JVM (the user's app)           │
+                       └─────────────────────────────────────────────┘
+                              │
+                              ▼  preload runtime (re-frame2-pair.runtime)
+                       ┌─────────────────────────────────────────────┐
+                       │  app-db · sub-cache · machines · epochs ·   │
+                       │  traces                                     │
+                       └─────────────────────────────────────────────┘
+```
+
+### Concern namespaces
+
+Twelve concern namespaces sit alongside the per-tool bodies. Each owns
+one cross-cutting concern; new tools `:require` from these rather than
+reinventing the lens:
+
+| Lens                          | Owned by                          |
+|---|---|
+| Wire-bounded markers          | `tools/wire.cljs`, `tools/wire_pipeline.cljs` |
+| Boundary step protocol        | `tools/boundary_step.cljs`        |
+| Precheck (early-exit gates)   | `tools/precheck.cljs`             |
+| Cache (per-session response)  | `cache.cljs`                      |
+| Cap (token-budget pipeline)   | `tools/cap.cljs`                  |
+| Dedup (structural)            | `tools/dedup.cljs`                |
+| Elision (size-bounded leaves) | `tools/elision.cljs`              |
+| Sensitive (privacy filter)    | `tools/sensitive.cljs`            |
+| Cursor (pagination)           | `tools/cursor.cljs`               |
+| Args (coercion + parsing)     | `tools/args.cljs`                 |
+| Summary (lazy tree-summary)   | `tools/summary.cljs`              |
+| Snapshot pipeline             | `tools/snapshot_pipeline.cljs`    |
+
+The cross-MCP-shared half of these primitives lives in
+[`tools/mcp-base/`](../../mcp-base/spec/README.md) (`vocab`,
+`sensitive`, `elision`, `args`, `cursor`, `envelope`, `cap`,
+`overflow`, `diff-encode`, `section-grouping`); the
+re-frame2-pair-mcp-side wrappers above adapt the shared primitives to
+this server's wire-shape and per-tool registrations.
+
 ## What it isn't
 
 - **Not** a new re-frame2-pair contract. The op vocabulary is identical to the

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/server.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/server.cljs
@@ -414,7 +414,14 @@
 
   Used by both `--port-file` (rf2-3dbwh) and `--http-port` (rf2-umoz2);
   one parser, one shape — so a future string-valued flag lands here
-  without growing a per-flag micro-parser."
+  without growing a per-flag micro-parser.
+
+  ## DRY-on-5 trigger (rf2-xnbvz)
+
+  Today two string-valued flags ride through this helper. If a fifth
+  lands, switch to a declared schema (vector of `{:flag :type :env}`
+  maps reduced over) — more elegant than five hand-rolled `parse-X-flag`
+  helpers. Not needed at 2; the 3rd and 4th can ride through unchanged."
   [flag-name argv]
   (let [equals-prefix (str flag-name "=")]
     (loop [items argv

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/descriptors_data.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/descriptors_data.cljs
@@ -186,6 +186,21 @@
                 "reason"          {:type "string"
                                     :description "termination reason keyword (as a string)"}}})
 
+;; ===========================================================================
+;; Tool descriptors
+;;
+;; One def per tool, in catalogue order (per
+;; spec/003-Tool-Catalogue.md). Each section is bounded by a comment
+;; rule so a reader scrolling through the file can land on a tool
+;; without grepping. The file's leaf-size exemption (rf2-zkca8 —
+;; catalogue-shaped leaves) earns the length; the section navigation
+;; (rf2-rk2c7) earns the scannability.
+;; ===========================================================================
+
+;; ---------------------------------------------------------------------------
+;; discover-app
+;; ---------------------------------------------------------------------------
+
 (def discover-app
   {:name "discover-app"
    :description (str "Verify the shadow-cljs nREPL is reachable, confirm the re-frame2-pair runtime preload landed, and report a health summary. Run this first every session. Returns :reason :runtime-not-preloaded when the preload entry is missing. "
@@ -200,6 +215,10 @@
                  :properties {:build {:type "string"
                                       :description "shadow-cljs build id (default: app)"}}
                  :additionalProperties false}})
+
+;; ---------------------------------------------------------------------------
+;; eval-cljs
+;; ---------------------------------------------------------------------------
 
 (def eval-cljs
   {:name "eval-cljs"
@@ -255,6 +274,10 @@
                  :required ["form"]
                  :additionalProperties false}})
 
+;; ---------------------------------------------------------------------------
+;; dispatch
+;; ---------------------------------------------------------------------------
+
 (def dispatch
   {:name "dispatch"
    :description (str "Fire a re-frame2 event tagged with :origin :pair. Default mode is queued dispatch. "
@@ -289,6 +312,10 @@
                               :build {:type "string"}}
                  :required ["event"]
                  :additionalProperties false}})
+
+;; ---------------------------------------------------------------------------
+;; dispatch-dry-run
+;; ---------------------------------------------------------------------------
 
 (def dispatch-dry-run
   {:name "dispatch-dry-run"
@@ -326,6 +353,10 @@
                  :required ["event"]
                  :additionalProperties false}})
 
+;; ---------------------------------------------------------------------------
+;; restore-epoch
+;; ---------------------------------------------------------------------------
+
 (def restore-epoch
   {:name "restore-epoch"
    :description (str "Time-travel undo (rf2-ee38b.18): rewind a frame's app-db to a recorded prior epoch. "
@@ -360,6 +391,10 @@
                  :required ["epoch-id"]
                  :additionalProperties false}})
 
+;; ---------------------------------------------------------------------------
+;; reset-frame-db
+;; ---------------------------------------------------------------------------
+
 (def reset-frame-db
   {:name "reset-frame-db"
    :description (str "State injection (rf2-ee38b.18): replace a frame's app-db with an arbitrary EDN value the "
@@ -391,6 +426,10 @@
                               :build {:type "string"}}
                  :required ["db"]
                  :additionalProperties false}})
+
+;; ---------------------------------------------------------------------------
+;; trace-window
+;; ---------------------------------------------------------------------------
 
 (def trace-window
   {:name "trace-window"
@@ -428,6 +467,10 @@
                                                    :description "Opt back in to forwarding `:sensitive? true` items. Default false."}
                               :build {:type "string"}}
                  :additionalProperties false}})
+
+;; ---------------------------------------------------------------------------
+;; watch-epochs
+;; ---------------------------------------------------------------------------
 
 (def watch-epochs
   {:name "watch-epochs"
@@ -472,6 +515,10 @@
                               :build    {:type "string"}}
                  :additionalProperties false}})
 
+;; ---------------------------------------------------------------------------
+;; tail-build
+;; ---------------------------------------------------------------------------
+
 (def tail-build
   {:name "tail-build"
    :description (str "Wait for a hot-reload to land by polling a probe form until its value changes. Returns once changed, or times out. "
@@ -487,6 +534,10 @@
                               :wait-ms {:type "integer" :description "Max wait in ms (default 5000)"}
                               :build   {:type "string"}}
                  :additionalProperties false}})
+
+;; ---------------------------------------------------------------------------
+;; snapshot
+;; ---------------------------------------------------------------------------
 
 (def snapshot
   {:name "snapshot"
@@ -584,6 +635,10 @@
                               :build   {:type "string" :description "shadow-cljs build id (default: app)"}}
                  :additionalProperties false}})
 
+;; ---------------------------------------------------------------------------
+;; get-path
+;; ---------------------------------------------------------------------------
+
 (def get-path
   {:name "get-path"
    :description (str "Read a single value at `path` from a frame's app-db. Minimal primitive for "
@@ -628,6 +683,10 @@
                               :build   {:type "string"}}
                  :required ["path"]
                  :additionalProperties false}})
+
+;; ---------------------------------------------------------------------------
+;; subscribe
+;; ---------------------------------------------------------------------------
 
 (def subscribe
   {:name "subscribe"
@@ -690,6 +749,10 @@
                  :required ["topic"]
                  :additionalProperties false}})
 
+;; ---------------------------------------------------------------------------
+;; unsubscribe
+;; ---------------------------------------------------------------------------
+
 (def unsubscribe
   {:name "unsubscribe"
    :description (str "Close the subscription with the given sub-id. Idempotent — closing an unknown sub-id returns :existed? false. "
@@ -706,6 +769,10 @@
                               :build  {:type "string"}}
                  :required ["sub-id"]
                  :additionalProperties false}})
+
+;; ---------------------------------------------------------------------------
+;; list-subscriptions
+;; ---------------------------------------------------------------------------
 
 (def list-subscriptions
   {:name "list-subscriptions"
@@ -735,6 +802,10 @@
                                        :description "Optional filter — only return the sub with this uuid."}
                               :build  {:type "string"}}
                  :additionalProperties false}})
+
+;; ---------------------------------------------------------------------------
+;; handler-meta
+;; ---------------------------------------------------------------------------
 
 (def handler-meta
   {:name "handler-meta"
@@ -779,6 +850,10 @@
                  :required ["kind" "id"]
                  :additionalProperties false}})
 
+;; ---------------------------------------------------------------------------
+;; list-handlers
+;; ---------------------------------------------------------------------------
+
 (def list-handlers
   {:name "list-handlers"
    :description (str "Return every registered id under a kind. The discovery "
@@ -809,6 +884,10 @@
                               :build {:type "string"}}
                  :required ["kind"]
                  :additionalProperties false}})
+
+;; ---------------------------------------------------------------------------
+;; get-re-frame2-pair-instructions
+;; ---------------------------------------------------------------------------
 
 (def get-re-frame2-pair-instructions
   {:name "get-re-frame2-pair-instructions"

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/get_re_frame2_pair_instructions.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/get_re_frame2_pair_instructions.cljs
@@ -7,17 +7,21 @@
   `:origin :pair` tagged mutations, streaming subscribe semantics,
   the wire-boundary cap + dedup + elision pipeline).
 
-  No nREPL round-trip; the text is a `def` baked into the bundle so
-  the call costs one MCP frame and zero socket bytes. Hostable agents
-  load this at session start to orient before the first real op."
+  `instructions-text` ships inline as a single string so the artefact
+  is self-contained — no resource read at boot, one MCP frame, zero
+  socket bytes. The structural peer in story-mcp
+  (`story-instructions-text` in `re-frame.story-mcp.tools.dev`) uses
+  the same inline-`(str ...)` shape, kept aligned per rf2-93cew so AI
+  pairs reading both servers see one answer to the onboarding-text
+  question."
   (:require [re-frame2-pair-mcp.tools.wire :as wire]))
 
 (def instructions-text
-  "Inline onboarding prose. Kept here (rather than read from a
-  resource) so the compiled `.js` bundle is self-contained and the
-  call is a single frame. Edit this string when the catalogue
-  changes; the docstring on `re-frame2-pair-mcp.tools/tool-descriptors`
-  is the structural peer."
+  "Inline onboarding prose. Inline `(str ...)` of `\\n`-glued lines —
+  see the ns docstring for the rationale (mirrors story-mcp per
+  rf2-93cew). Edit this string when the catalogue changes; the
+  docstring on `re-frame2-pair-mcp.tools/tool-descriptors` is the
+  structural peer."
   (str
     "re-frame2-pair-mcp agent quick reference.\n"
     "Full spec: tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md.\n"

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
@@ -37,7 +37,7 @@
 
   So this runner keeps its fixtures inline as CLJS data — one map per
   case — and treats THIS namespace as the canonical re-frame2-pair-mcp wire
-  corpus. A follow-on bead (`rf2-???`) may later promote the corpus to
+  corpus. The corpus may later promote to
   `tools/re-frame2-pair-mcp/spec/conformance/fixtures/*.edn` if cross-host
   reuse materialises; the in-memory shape will be the same.
 

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/dev.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/dev.cljc
@@ -3,17 +3,22 @@
   `preview-variant`, `list-substrates`. Per IMPL-SPEC §7.2 these are
   the read-only agent-onboarding + canvas-state surfaces.
 
-  `story-instructions-text` ships inline as a single string to keep
-  this jar self-contained — no external resource read needed at boot."
+  `story-instructions-text` ships inline as a single string so the
+  artefact is self-contained — no resource read at boot, one MCP
+  frame, zero classpath / IO dependencies. The structural peer in
+  pair-mcp (`get-re-frame2-pair-instructions`) uses the same inline-
+  `(str ...)` shape, kept aligned per rf2-93cew so AI pairs reading
+  both servers see one answer to the onboarding-text question."
   (:require [re-frame.story :as story]
             [re-frame.story.async :as async]
             [re-frame.story-mcp.tools.helpers :as h]
             [re-frame.story-mcp.tools.schemas :as s]))
 
 (def story-instructions-text
-  "The agent-onboarding text returned by `get-story-instructions`. Kept
-  inline as a single string to keep this jar self-contained — no
-  external resource read needed at boot."
+  "The agent-onboarding text returned by `get-story-instructions`.
+  Inline `(str ...)` of `\\n`-glued lines — see the ns docstring for
+  the rationale (mirrors pair-mcp per rf2-93cew). Edit this string
+  when the catalogue changes."
   (str
     "re-frame2-story authoring conventions (agent quick reference).\n"
     "Full spec: spec/007-Stories.md + tools/story/spec/.\n"

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/registry.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/registry.cljc
@@ -131,11 +131,16 @@
               (some? annotations)  (assoc :annotations annotations)))
           tool-registry)))
 
-(def ^:private tool-by-name-index
-  "Pre-computed `name → descriptor` map so `tool-by-name` is O(1)
-  instead of the linear scan over `tool-registry`. The registry shape
-  is frozen at load time (`tool-registry` is a `def`), so the index
-  is similarly stable."
+(defonce ^:private tool-by-name-index
+  ;; `defonce` (rf2-xa1oc) so a REPL `(require ... :reload)` of this ns
+  ;; does NOT re-bind the index out from under callers that captured
+  ;; the old map. The registry shape is frozen at load time
+  ;; (`tool-registry` is a `def`), so re-binding adds nothing —
+  ;; `defonce` is the right primitive when the value is computed once
+  ;; and lives for the lifetime of the process.
+  ;;
+  ;; Pre-computed `name → descriptor` map so `tool-by-name` is O(1)
+  ;; instead of the linear scan over `tool-registry`.
   (into {} (map (juxt :name identity)) tool-registry))
 
 (defn tool-by-name

--- a/tools/story/src/re_frame/story/recorder/play_export.cljc
+++ b/tools/story/src/re_frame/story/recorder/play_export.cljc
@@ -272,8 +272,8 @@
 ;;
 ;; The diff is a shallow path enumeration — every keyword key of the
 ;; final db that differs from the seed produces a `[:assert-db [k]
-;; v]` step. Deep diffing is deferred (rf2-recorder-deep-diff TODO);
-;; the v1 cap is the safety valve, not the diff sophistication.
+;; v]` step. Deep diffing is deferred to a later iteration; the v1
+;; cap is the safety valve, not the diff sophistication.
 ;; ---------------------------------------------------------------------------
 
 (defn- map-like?

--- a/tools/story/test/re_frame/story_assertions_test.clj
+++ b/tools/story/test/re_frame/story_assertions_test.clj
@@ -3,7 +3,7 @@
   vocabulary.
 
   Covers each of the seven canonical assertion semantics from
-  spec/007 line 304:
+  spec/007 §Assertion vocabulary:
 
     1. :rf.assert/path-equals    — value at path matches
     2. :rf.assert/path-matches   — value at path validates against malli

--- a/tools/story/test/re_frame/story_runtime_test.clj
+++ b/tools/story/test/re_frame/story_runtime_test.clj
@@ -485,7 +485,7 @@
             "editing a play's script must produce a fresh hash")))))
 
 (deftest snapshot-identity-changes-with-view-schema-digest
-  (testing "Per spec/007 §Variant snapshot identity (line 429) — the
+  (testing "Per spec/007 §Variant snapshot identity — the
             *registered* schema digest of the view (per spec/011
             §:rf/schema-digest) participates in the hash. A schema change
             on the view MUST invalidate the snapshot identity (and the

--- a/tools/xray/src/day8/re_frame2_xray/diff/engine.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/diff/engine.cljc
@@ -3,8 +3,8 @@
 
   ## Purpose
 
-  Replace the home-grown classifier that used to live at
-  `tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs:533-664`
+  Replace the home-grown classifier (since deleted from
+  `tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs`)
   (`diff-op`, `diff-op-container`, `children-changed?`, etc.). Per
   pair-debug 2026-05-27 the project locks Editscript in as the canonical
   diff engine for Xray — pre-alpha posture, no transitional double-engine


### PR DESCRIPTION
## Summary

Twelve polish beads across the Tools-MCP cluster (mcp-base, mcp-conformance, story-mcp, re-frame2-pair-mcp). Mostly docs hygiene plus one new automated gate.

## Beads (12)

### P3 (4)

- **rf2-7a63q** — pair-mcp `spec/000-Vision.md` ASCII architecture diagram (44 src files needs orientation)
- **rf2-rk2c7** — pair-mcp `descriptors_data.cljs` (829 LOC) internal section navigation
- **rf2-93cew** — story-mcp + pair-mcp agent-onboarding text shape alignment
- **rf2-xvqwz** — mcp-conformance stale parent-walk count + line-num cite

### P4 (8)

- **rf2-3s4tl** — replace line-number cites + placeholder bead-refs with section anchors (5 sites)
- **rf2-nox5i** — mcp-base README index: per-ns spec docs for `cursor.md` + `envelope.md`
- **rf2-ukkil** — retire stale Xray-MCP reference in `sensitive.cljc`
- **rf2-ul3qd** — mcp-base README 'Adding to the base': 3-bullet 'What this rules OUT'
- **rf2-1bwph** — mcp-conformance DRY-on-3 trigger comment for live-* fixture setup
- **rf2-vkx7m** — **NEW TEST**: NAMING.md verb-vocabulary automated linter (verb_vocab_test.clj, 3 deftests / 40 assertions)
- **rf2-xa1oc** — story-mcp `tool-by-name-index` → `defonce` for hot-reload friendliness
- **rf2-xnbvz** — pair-mcp `parse-string-value-flag` DRY-on-5 trigger comment

## Quality gates (all 0F/0E)

- mcp-base: 157 tests
- mcp-conformance/wire-vocab: 48 tests (was 45 — 3 new in verb-vocab linter)
- story-mcp: 172 tests
- re-frame2-pair-mcp: 622 tests
- fast-pr spine: 4836 tests

## Notes

The new `verb-vocab-test.clj` makes the NAMING.md verb catalogue executable — a new tool with an off-convention verb (fetch-foo / update-bar / …) trips the gate. Future verb extension still requires the existing Lock entry + NAMING.md row + catalogue update; this just adds enforcement so the discipline can't drift silently.

Two beads (rf2-1bwph DRY-on-3, rf2-xnbvz DRY-on-5) close as "trigger marker in place; reopens when condition lands" — inline comments at the duplication site so future authors find the bead naturally.