### PR TITLE
refactor(ssr): polish sweep — 5 beads (z2n5l + 7bcn0 + c1tac + uzjhl + 5br2y)

### DIFF
--- a/implementation/ssr-ring/src/re_frame/ssr/ring.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring.clj
@@ -124,12 +124,32 @@
 ;; rf2-kzvwq topology-leak contract lives in one place).
 
 (def default-on-error lifecycle/default-on-error)
+(def make-default-on-error lifecycle/make-default-on-error)
 
 (def handler-defaults
   {:emit-hash?   true
    :html-shell   shell/default-html-shell
-   :content-type "text/html; charset=utf-8"
-   :on-error     default-on-error})
+   :content-type "text/html; charset=utf-8"})
+
+(defn- resolve-on-error
+  "Resolve the effective `:on-error` from `raw-opts`. Precedence:
+
+    1. caller-supplied `:on-error`     — full Ring-fn override; used verbatim.
+    2. caller-supplied `:on-error-fallback` — `{:body … :content-type …}`
+       template; built into a default-shaped fn via
+       `make-default-on-error`. The fn ignores the throwable (rf2-kzvwq
+       no-leak contract preserved).
+    3. neither                          — host-locked `default-on-error`
+       (`\"Internal error\"` plaintext).
+
+  Per rf2-c1tac — splits the templatable-default case from the full-
+  override case so callers can swap the body string without writing a
+  Ring fn AND without inheriting the `.getMessage` topology-leak risk."
+  [{:keys [on-error on-error-fallback]}]
+  (cond
+    on-error          on-error
+    on-error-fallback (make-default-on-error on-error-fallback)
+    :else             default-on-error))
 
 ;; ---- trusted-shell-hook contract (rf2-o6ndb) ------------------------------
 ;;
@@ -237,6 +257,20 @@
                       render `:error-view` / the default error template
                       (see below). `:on-error` is the last-resort
                       transport-failure net.
+    :on-error-fallback — (map) `{:body \"…\" :content-type \"…\"}` —
+                      templating shortcut (rf2-c1tac) for callers who
+                      want to swap the locked default body string
+                      (\"Internal error\") for a branded plaintext-or-
+                      HTML page WITHOUT writing a full `:on-error` fn.
+                      The resulting fn ignores the throwable, so the
+                      rf2-kzvwq `.getMessage` topology-leak surface
+                      stays closed. Ignored when `:on-error` is also
+                      supplied (the explicit fn wins). The caller-
+                      supplied `:body` is the caller's trust boundary
+                      — emitted RAW like the four trusted shell-hook
+                      opts. Use the `:error-view` opt below for caller-
+                      registered hiccup-rendered error pages on the
+                      projected (drain-time) path.
     :error-view     — (optional) the projected-error page body (Spec 011
                       §Server error projection step 5). Either a
                       registered-view keyword (resolved as
@@ -310,7 +344,14 @@
   ;; Merge defaults once at construction time so the pipeline helpers
   ;; (`setup-request-frame!`, `build-full-response`) can destructure
   ;; without re-stating the `:or` map. Caller-supplied values win.
-  (let [opts        (merge handler-defaults raw-opts)
+  ;;
+  ;; rf2-c1tac — `:on-error` resolution moved through `resolve-on-error`:
+  ;; the templatable `:on-error-fallback {:body … :content-type …}` opt
+  ;; produces a default-shaped fn without forcing the caller to write a
+  ;; Ring fn. Resolution happens AFTER merge so handler-defaults can stay
+  ;; orthogonal to on-error (no `:on-error` slot in the defaults map).
+  (let [opts        (-> (merge handler-defaults raw-opts)
+                        (assoc :on-error (resolve-on-error raw-opts)))
         {:keys [on-error]} opts]
     (fn ring-handler [request]
       (let [{:keys [frame-id short-circuit]}

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/lifecycle.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/lifecycle.clj
@@ -25,7 +25,58 @@
 
 (set! *warn-on-reflection* true)
 
-(defn default-on-error
+(def ^:const default-on-error-body
+  "The literal body emitted by `default-on-error` when no template is
+  supplied. Pinned to the rf2-kzvwq topology-leak-safe shape: generic
+  plaintext, no throwable detail, no internal class names. The
+  templating surface (`make-default-on-error`) accepts a caller-
+  supplied body that overrides this; the locked default itself stays
+  constant."
+  "Internal error")
+
+(def ^:const default-on-error-content-type
+  "The Content-Type emitted by `default-on-error` when no template
+  is supplied — plaintext UTF-8, matching the locked default body
+  shape (rf2-kzvwq §P2.1)."
+  "text/plain; charset=utf-8")
+
+(defn make-default-on-error
+  "Construct a `(fn [request throwable] ring-response)` fallback shaped
+  like `default-on-error` but with a caller-templated body. Returns the
+  fixed 500 status and the configured Content-Type + body unchanged on
+  every call. Per rf2-c1tac — callers that want a branded plaintext-
+  or-HTML error page can supply `:body` (and optionally
+  `:content-type`) at handler-construction time without writing a full
+  `:on-error` fn AND without inheriting the `.getMessage` topology-
+  leak risk: the constructor never touches the throwable.
+
+  Opts:
+
+    :body          — (string) the literal response body. Defaults to
+                     `default-on-error-body` (\"Internal error\").
+                     Caller-supplied strings are emitted VERBATIM; the
+                     caller is responsible for trusting the source (a
+                     CMS-driven body is the caller's XSS exposure to
+                     accept, same trust boundary as the four trusted
+                     shell-hook opts).
+    :content-type  — (string) the Content-Type header. Defaults to
+                     `default-on-error-content-type` (\"text/plain;
+                     charset=utf-8\"). Pass \"text/html; charset=utf-8\"
+                     when the supplied `:body` is HTML.
+
+  rf2-kzvwq §P2.1 contract preserved: the returned fn ignores the
+  throwable. The `.getMessage` topology-leak surface stays closed
+  regardless of the supplied template."
+  ([] (make-default-on-error nil))
+  ([{:keys [body content-type]}]
+   (let [body*         (or body default-on-error-body)
+         content-type* (or content-type default-on-error-content-type)
+         response      {:status  500
+                        :headers {"Content-Type" content-type*}
+                        :body    body*}]
+     (fn default-on-error-fn [_request _t] response))))
+
+(def default-on-error
   "Minimal 500 response used when a handler caller doesn't supply
   `:on-error`. Shared by `ssr-handler` AND `stream-handler` so the
   topology-leak contract below lives in exactly one place.
@@ -40,11 +91,11 @@
   name), file paths under deploy roots, partial SQL fragments, server-
   internal class names. We emit a fixed generic body matching the
   projector's `fallback-public-error` shape. Apps that want dev-mode
-  detail override via `:on-error`."
-  [_request _t]
-  {:status  500
-   :headers {"Content-Type" "text/plain; charset=utf-8"}
-   :body    "Internal error"})
+  detail override via `:on-error`; apps that want a branded HTML body
+  without the .getMessage exposure pass `:on-error-fallback {:body
+  \"…\" :content-type \"text/html; …\"}` (rf2-c1tac — the templating
+  surface that builds this exact shape via `make-default-on-error`)."
+  (make-default-on-error))
 
 (defn destroy-frame-quietly!
   "Best-effort frame teardown. Exceptions during destroy must not mask

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
@@ -37,7 +37,6 @@
   now."
   (:require [re-frame.core :as rf]
             [re-frame.ssr :as ssr]
-            [re-frame.ssr.html-helpers :as html-helpers]
             [re-frame.ssr.ring.headers :as headers]
             [re-frame.ssr.ring.lifecycle :as lifecycle]
             [re-frame.ssr.ring.payload :as payload]
@@ -149,10 +148,15 @@
   the \"or the host's default error template\" branch). Used when no
   caller `:error-view` is registered and `render-to-string` has
   thrown, so the host can no longer rely on the user's root-view to
-  produce wire bytes. The body is fully escaped through `escape-html`
-  / `escape-attr` — the public-error's `:message`/`:code` are caller-
-  controlled (custom projectors may produce arbitrary strings) so we
-  treat them as untrusted-for-HTML.
+  produce wire bytes.
+
+  Per rf2-uzjhl: built as hiccup then rendered via
+  `ssr/render-to-string` (with `:doctype? true`, `:emit-hash? false`)
+  so the public-error map flows through position-appropriate escaping
+  the emitter already owns — same render path as the caller-supplied
+  `:error-view` (`resolve-error-body` below). Removes the `(str ...)`
+  concatenation + manual `escape-html` / `escape-attr` calls that
+  duplicated the emitter's escaping behaviour.
 
   Carries no internal trace detail — the wire surface is locked to the
   public-error keys; the internal Throwable already rode the trace bus
@@ -160,18 +164,17 @@
   [{:keys [status code message]}]
   (let [status* (or status 500)
         code*   (when code (name code))
-        msg*    (or message "Something went wrong")]
-    (str "<!DOCTYPE html><html><head><meta charset=\"utf-8\">"
-         "<title>" (html-helpers/escape-html msg*) "</title>"
-         "</head><body>"
-         "<h1>" (html-helpers/escape-html msg*) "</h1>"
-         (when code*
-           (str "<p data-rf-error-code=\""
-                (html-helpers/escape-attr code*) "\">"
-                "Error code: " (html-helpers/escape-html code*)
-                " (status " status* ")"
-                "</p>"))
-         "</body></html>")))
+        msg*    (or message "Something went wrong")
+        hiccup  [:html
+                 [:head
+                  [:meta {:charset "utf-8"}]
+                  [:title msg*]]
+                 [:body
+                  [:h1 msg*]
+                  (when code*
+                    [:p {:data-rf-error-code code*}
+                     (str "Error code: " code* " (status " status* ")")])]]]
+    (ssr/render-to-string hiccup {:doctype? true :emit-hash? false})))
 
 (defn ^:private resolve-error-body
   "Resolve the projected-error HTML body (Spec 011 §Server error

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
@@ -229,27 +229,66 @@
   "The non-error path of `build-full-response`. Split into its own fn
   so the outer try/catch (rf2-zwgsv render-time projector unification)
   reads as a simple wrap of the rendering / payload / shell pipeline,
-  not as a 30-line body in the catch's scope."
+  not as a 30-line body in the catch's scope.
+
+  Per rf2-5br2y: the frame-aware stages (`resolve-root-view`,
+  `render-to-string`, `resolve-head`) run inside a SINGLE outer
+  `with-frame` so the `current-frame` push/pop happens once per request,
+  not three times. `get-frame-db` reads the named frame explicitly and
+  doesn't need the binding; it sits outside the block to keep that
+  explicitness visible."
   [frame-id resp
    {:keys [root-view emit-hash? version schema-digest payload-keys
            payload-policy html-shell content-type]
     :as   opts}]
-  (let [hiccup      (rf/with-frame frame-id (lifecycle/resolve-root-view root-view))
-        ;; rf2-i15nh / rf2-atmvj: compute the structural hash ONCE per
-        ;; request. The same hex feeds the root-element
-        ;; `data-rf-render-hash` (via render-to-string's `:render-hash`
-        ;; opt) AND the payload's `:rf/render-hash`. Pre-rf2-i15nh
-        ;; render-to-string computed the hash internally on the
-        ;; `:emit-hash?` branch and the pipeline called render-tree-hash
-        ;; again here — two full canonical-EDN walks per request. The
-        ;; opt-threaded form drops it to one. When `:emit-hash?` is
-        ;; false the hash is still needed for the payload slot.
-        hash-str    (ssr/render-tree-hash hiccup)
-        body-html   (rf/with-frame frame-id
-                      (ssr/render-to-string hiccup
-                                            {:doctype?    false
-                                             :emit-hash?  emit-hash?
-                                             :render-hash (when emit-hash? hash-str)}))
+  (let [;; Single `with-frame` block covers the three frame-aware
+        ;; stages: root-view resolution (a 0-arity fn may close over
+        ;; subscribe-time reads), the render walk (subs on registered
+        ;; views), and head resolution (`rf/active-head` reads the
+        ;; frame's route registry). One push/pop per request.
+        explicit-head (:head opts)
+        {:keys [hash-str body-html head-html html-attrs body-attrs]}
+        (rf/with-frame frame-id
+          (let [hiccup    (lifecycle/resolve-root-view root-view)
+                ;; rf2-i15nh / rf2-atmvj: compute the structural hash
+                ;; ONCE per request. The same hex feeds the root-element
+                ;; `data-rf-render-hash` (via render-to-string's
+                ;; `:render-hash` opt) AND the payload's
+                ;; `:rf/render-hash`. Pre-rf2-i15nh render-to-string
+                ;; computed the hash internally on the `:emit-hash?`
+                ;; branch and the pipeline called render-tree-hash again
+                ;; here — two full canonical-EDN walks per request. The
+                ;; opt-threaded form drops it to one. When `:emit-hash?`
+                ;; is false the hash is still needed for the payload
+                ;; slot.
+                hash-str  (ssr/render-tree-hash hiccup)
+                body-html (ssr/render-to-string
+                            hiccup
+                            {:doctype?    false
+                             :emit-hash?  emit-hash?
+                             :render-hash (when emit-hash? hash-str)})
+                ;; rf2-4dra9 / rf2-h2ujj: resolve the active route's
+                ;; :head (or default-head fallback). The head fragment
+                ;; goes through the shell as the :head opt; the
+                ;; :html-attrs / :body-attrs bags ride alongside so the
+                ;; shell can stamp them on <html> / <body> per Spec 011
+                ;; §Default flow step 4. Callers that supplied an
+                ;; explicit :head string take precedence — they chose to
+                ;; bypass route-driven head resolution, and an explicit
+                ;; string carries no attr-bag sidechannel.
+                head-bag  (if explicit-head
+                            {:head-html explicit-head
+                             :html-attrs nil
+                             :body-attrs nil}
+                            (lifecycle/resolve-head frame-id))]
+            (assoc head-bag
+                   :hash-str  hash-str
+                   :body-html body-html)))
+        ;; get-frame-db reads the named frame explicitly; no with-frame
+        ;; needed. Kept outside the block so the explicit frame-id read
+        ;; is visible — pulling the snapshot AFTER the render walk is
+        ;; load-bearing (a continuation drain inside the walker may
+        ;; mutate app-db; the payload must reflect the post-walk value).
         app-db      (rf/get-frame-db frame-id)
         payload     (payload/build-payload frame-id app-db hash-str
                                            {:version        version
@@ -257,21 +296,6 @@
                                             :payload-keys   payload-keys
                                             :payload-policy payload-policy})
         payload-edn (pr-str payload)
-        ;; rf2-4dra9 / rf2-h2ujj: resolve the active route's :head
-        ;; (or default-head fallback). The head fragment goes through
-        ;; the shell as the :head opt; the :html-attrs / :body-attrs
-        ;; bags ride alongside so the shell can stamp them on <html>
-        ;; / <body> per Spec 011 §Default flow step 4.
-        ;;
-        ;; Callers that supplied an explicit :head string take
-        ;; precedence — they chose to bypass route-driven head
-        ;; resolution, and an explicit string carries no attr-bag
-        ;; sidechannel (an explicit head opt is the escape hatch for
-        ;; bespoke fragments).
-        {:keys [head-html html-attrs body-attrs]}
-        (if (:head opts)
-          {:head-html (:head opts) :html-attrs nil :body-attrs nil}
-          (lifecycle/resolve-head frame-id))
         shell-opts  (assoc opts
                            :head        head-html
                            :html-attrs  html-attrs

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
@@ -237,13 +237,21 @@
   (payload-policy/validate-policy-opts! raw-opts)
   (trust/validate-trusted-shell-opts! raw-opts)
   ;; Mirror ssr-handler's defaults so streaming and non-streaming
-  ;; handlers feel symmetric to callers. `:on-error` reuses the shared
-  ;; `lifecycle/default-on-error` so the rf2-kzvwq topology-leak
-  ;; contract is not silently re-implemented.
-  (let [opts        (merge {:emit-hash?   true
-                            :content-type "text/html; charset=utf-8"
-                            :on-error     lifecycle/default-on-error}
-                           raw-opts)
+  ;; handlers feel symmetric to callers. `:on-error` resolves the same
+  ;; way (rf2-c1tac): caller's `:on-error` wins, then
+  ;; `:on-error-fallback {:body … :content-type …}` is templated through
+  ;; `lifecycle/make-default-on-error`, then the locked
+  ;; `lifecycle/default-on-error` (rf2-kzvwq topology-leak contract).
+  (let [resolved-on-error
+        (cond
+          (:on-error raw-opts)          (:on-error raw-opts)
+          (:on-error-fallback raw-opts) (lifecycle/make-default-on-error
+                                          (:on-error-fallback raw-opts))
+          :else                         lifecycle/default-on-error)
+        opts        (-> (merge {:emit-hash?   true
+                                :content-type "text/html; charset=utf-8"}
+                               raw-opts)
+                        (assoc :on-error resolved-on-error))
         {:keys [on-error content-type]} opts]
     (fn ring-handler [request]
       (let [{:keys [frame-id short-circuit]}

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
@@ -1935,3 +1935,118 @@
       (is (not (str/includes? (str (:headers response)) secret-msg))
           "rf2-kzvwq §P2.1: headers do NOT carry the throwable's
            .getMessage text either"))))
+
+;; ===========================================================================
+;; rf2-c1tac — make-default-on-error templates the body without leaking
+;; ===========================================================================
+;;
+;; Per rf2-c1tac the locked `default-on-error` body ("Internal error",
+;; plaintext) is the safe default. Apps that want a branded plaintext-
+;; or-HTML default error page without writing a full `:on-error` fn pass
+;; a `:on-error-fallback {:body … :content-type …}` opt — the resulting
+;; fn is built by `make-default-on-error`, ignores the throwable, and
+;; preserves the rf2-kzvwq no-leak contract.
+
+(deftest make-default-on-error-templates-body-and-content-type
+  (testing "rf2-c1tac — make-default-on-error returns a fn that responds
+            with the configured body + content-type + locked 500 status.
+            The fn ignores the throwable, so .getMessage cannot leak
+            (rf2-kzvwq §P2.1 contract preserved)."
+    (let [secret-msg "boom-jdbc-secret:postgres://internal-db.svc:5432/auth"
+          t          (ex-info secret-msg {})
+          req        {:uri "/anything" :request-method :get}
+          custom-body "<!DOCTYPE html><html><body><h1>Service unavailable</h1></body></html>"
+          on-err     (ssr-ring/make-default-on-error
+                       {:body custom-body
+                        :content-type "text/html; charset=utf-8"})
+          response   (on-err req t)]
+      (is (= 500 (:status response))
+          "status pinned to 500 — the templating surface does NOT let
+           callers change the locked status")
+      (is (= {"Content-Type" "text/html; charset=utf-8"}
+             (:headers response))
+          "configured :content-type rides through verbatim")
+      (is (= custom-body (:body response))
+          "configured :body rides through verbatim — caller-supplied
+           HTML can replace the plaintext default")
+      (is (not (str/includes? (:body response) secret-msg))
+          "rf2-kzvwq §P2.1: configured body does NOT carry the
+           throwable's .getMessage — make-default-on-error never
+           touches the throwable, only the caller's static template"))))
+
+(deftest make-default-on-error-zero-args-matches-default-on-error
+  (testing "rf2-c1tac — `(make-default-on-error)` with no opts produces
+            the SAME shape as the host-locked `default-on-error`. The
+            locked default stays constant; the templating surface
+            extends it without breaking the no-args baseline."
+    (let [req       {:uri "/x" :request-method :get}
+          t         (ex-info "boom" {})
+          via-ctor  ((ssr-ring/make-default-on-error) req t)
+          via-host  (ssr-ring/default-on-error req t)]
+      (is (= via-ctor via-host)
+          "`(make-default-on-error)` returns a fn equivalent to the host
+           `default-on-error` — same status, same headers, same body"))))
+
+(deftest ssr-handler-on-error-fallback-opt-templates-default-body
+  (testing "rf2-c1tac — ssr-handler resolves `:on-error-fallback` into
+            a templated default-on-error fn when the caller didn't
+            supply `:on-error`. The handler's transport-failure path
+            then emits the templated body (not the locked
+            \"Internal error\" string).
+
+            Drive the transport-failure path with a non-vector
+            `:on-create` — `validate-on-create!` throws inside
+            `setup-request-frame!`'s try/catch, which surfaces the
+            short-circuit on-error response. This path is the
+            framework's last-resort net for setup-frame failures
+            the projector can't see."
+    (let [custom-body "<!DOCTYPE html><html><body>Service offline</body></html>"
+          handler     (ssr-ring/ssr-handler
+                        ;; Non-vector :on-create passes the truthy
+                        ;; presence check at handler construction
+                        ;; (`validate-required-opts!`) but fails the
+                        ;; vector? check inside `validate-on-create!`,
+                        ;; which runs inside the per-request setup
+                        ;; try/catch — exactly the on-error path.
+                        {:on-create '(:rf/server-init)
+                         :root-view [:div]
+                         :payload-keys [:x]
+                         :on-error-fallback {:body custom-body
+                                             :content-type "text/html; charset=utf-8"}})
+          response    (handler {:uri "/x" :request-method :get})]
+      (is (= 500 (:status response))
+          "status still pinned to 500 — the templating surface does not
+           let callers change the locked status")
+      (is (= custom-body (:body response))
+          ":on-error-fallback :body templated into the transport-failure
+           response, replacing the locked \"Internal error\" default")
+      (is (= "text/html; charset=utf-8"
+             (get (:headers response) "Content-Type"))
+          ":on-error-fallback :content-type templated into the response
+           headers"))))
+
+(deftest ssr-handler-explicit-on-error-overrides-on-error-fallback
+  (testing "rf2-c1tac — when BOTH `:on-error` and `:on-error-fallback`
+            are supplied, the explicit `:on-error` fn wins. The
+            templating shortcut is for callers who do NOT want to write
+            a Ring fn; an explicit-fn caller has already opted into the
+            full surface. Same non-vector-:on-create trigger as the
+            previous test."
+    (let [explicit-body "EXPLICIT"
+          template-body "TEMPLATED"
+          handler       (ssr-ring/ssr-handler
+                          {:on-create '(:rf/server-init)
+                           :root-view [:div]
+                           :payload-keys [:x]
+                           :on-error (fn [_req _t]
+                                       {:status 503
+                                        :headers {"Content-Type" "text/plain"}
+                                        :body    explicit-body})
+                           :on-error-fallback {:body template-body
+                                               :content-type "text/html"}})
+          response      (handler {:uri "/x" :request-method :get})]
+      (is (= 503 (:status response))
+          "explicit :on-error fn drove status (503), not the
+           templated default's locked 500 — :on-error wins")
+      (is (= explicit-body (:body response))
+          "explicit :on-error fn body wins over :on-error-fallback :body"))))

--- a/implementation/ssr/src/re_frame/ssr/hydrate.cljc
+++ b/implementation/ssr/src/re_frame/ssr/hydrate.cljc
@@ -19,15 +19,33 @@
 
   Per the rf2-gxgo7 split of re-frame.ssr."
   (:require [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.ssr.hash :as hash]
             [re-frame.trace :as trace]))
 
+(defn- client-platform?
+  "Resolve the active platform for `frame-id` and answer whether
+  client-only fxs would actually execute. Mirrors the resolution in
+  `router/run-fx-effects!` — per-frame `:config :platform` override
+  wins over the host-wide `interop/active-platform` marker. Used by
+  the hydrate handler to avoid dispatching `:rf.ssr/check-*` fxs on a
+  server-side `:rf/hydrate` (test harness, isomorphic loopback), where
+  the fx's own `:platforms #{:client}` gate would otherwise emit a
+  `:rf.fx/skipped-on-platform` warning per check (rf2-7bcn0)."
+  [frame-id]
+  (let [resolved (or (some-> frame-id frame/frame :config :platform)
+                     (interop/active-platform))]
+    (= :client resolved)))
+
 (defn hydrate-event-handler
   "Handler fn for the `:rf/hydrate` event. Replaces app-db with
   `(:rf/app-db payload)`, stashes server-hash + version under
-  `:rf/hydration`, and dispatches the two `:rf.ssr/check-*` fxs."
-  [{:keys [db]} [_ payload]]
+  `:rf/hydration`, and dispatches the two `:rf.ssr/check-*` fxs when
+  the resolved platform is `:client` (per rf2-7bcn0 — server-side
+  `:rf/hydrate` skips them to avoid `:rf.fx/skipped-on-platform`
+  noise)."
+  [{:keys [db frame]} [_ payload]]
   (let [new-db        (or (:rf/app-db payload) (:app-db payload) db)
         version       (:rf/version payload)
         schema-digest (:rf/schema-digest payload)
@@ -38,7 +56,15 @@
         metadata      (into {}
                             (filter (comp some? val))
                             {:server-hash (:rf/render-hash payload)
-                             :version     version})]
+                             :version     version})
+        ;; Per rf2-7bcn0: gate the compatibility-check dispatches at the
+        ;; HANDLER level (not at the fx-platform-gate level) so server-
+        ;; side `:rf/hydrate` runs (test harness, isomorphic loopback)
+        ;; don't fire `:rf.fx/skipped-on-platform` per check. The fxs
+        ;; themselves remain `:platforms #{:client}` so any direct
+        ;; caller still gets the gate; the handler simply doesn't
+        ;; request them on a known non-client run.
+        client?       (client-platform? frame)]
     ;; Per Spec 011 §The :rf/hydrate event: dispatch the compatibility-
     ;; check fxs as part of `:fx` so a mismatch surfaces a structured
     ;; trace event without crashing the hydration path. Both fxs gate on
@@ -48,8 +74,11 @@
     {:db (cond-> new-db
            (seq metadata) (assoc :rf/hydration metadata))
      :fx (cond-> []
-           version       (conj [:rf.ssr/check-version       version])
-           schema-digest (conj [:rf.ssr/check-schema-digest schema-digest]))}))
+           (and client? version)
+           (conj [:rf.ssr/check-version       version])
+
+           (and client? schema-digest)
+           (conj [:rf.ssr/check-schema-digest schema-digest]))}))
 
 ;; ---- :rf.ssr/check-version + :rf.ssr/check-schema-digest fxs --------------
 ;;

--- a/implementation/ssr/src/re_frame/ssr/streaming.cljc
+++ b/implementation/ssr/src/re_frame/ssr/streaming.cljc
@@ -3,6 +3,19 @@
   registry, per-subtree hydration deltas. Per Spec 011 §Streaming SSR
   (rf2-ojakd / rf2-olb64 (a)).
 
+  ## Chunk-ordering invariant (FIFO over registration)
+
+  Continuations stream in **registration FIFO order** — the order the
+  shell walk encountered each `:rf/suspense-boundary` (document order
+  for siblings, parent-before-children for nesting). `render-shell`'s
+  `:continuations` vector preserves that order; the host adapter MUST
+  drain it sequentially without reordering. Two boundaries registering
+  the same `:id` is a programmer error: `dedupe-continuations` keeps
+  the LAST registration and emits `:rf.error/suspense-boundary-
+  duplicate-id`. Conformance: `ssr_streaming_test` (`'FIFO registration
+  in document order'`) + `ssr_streaming_conformance_test` (fixture-
+  pinned FIFO).
+
   The hiccup author marks deferred subtrees with the
   `:rf/suspense-boundary` reserved hiccup head:
 
@@ -17,7 +30,9 @@
     `:rf/suspense-boundary` node it (a) renders the fallback wrapped in
     a `<template data-rf2-suspense-id … data-rf2-suspense-fallback>`
     placeholder, (b) registers a continuation `{:id :subtree}` for the
-    body. Returns `{:shell-html … :continuations [{:id … :subtree …} …]}`.
+    body. Returns `{:shell-html … :continuations [{:id … :subtree …} …]}`
+    where `:continuations` is in registration FIFO order (see invariant
+    above).
 
   - `render-continuation` — drains one continuation. Captures the
     before-db, calls `render-to-string` on the subtree, captures the

--- a/implementation/ssr/test/re_frame/ssr_hydration_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_hydration_test.clj
@@ -238,6 +238,78 @@
 ;; spec.cjs §(7) → NO mismatch trace on the baseline
 ;; ===========================================================================
 
+;; ===========================================================================
+;; rf2-7bcn0 — server-side :rf/hydrate skips the client-only check fxs
+;; ===========================================================================
+
+(deftest hydration-on-server-platform-skips-client-only-check-fxs
+  (testing "Per rf2-7bcn0: when :rf/hydrate runs on a frame whose resolved
+            platform is :server (test harness, isomorphic loopback), the
+            handler MUST NOT enqueue the :rf.ssr/check-version /
+            :rf.ssr/check-schema-digest fxs. The fxs themselves carry
+            :platforms #{:client}, so if the handler enqueued them
+            unconditionally the fx-platform-gate would fire a
+            :rf.fx/skipped-on-platform warning per check on every server-
+            side hydrate. The handler-level gate prevents that noise."
+    (register-baseline-handlers!)
+    (let [server-frame (rf/make-frame {:doc "ssr-basic server frame"
+                                       :platform :server})
+          ;; Add a :rf/schema-digest so BOTH checks would fire if the
+          ;; handler enqueued them; otherwise only :rf.ssr/check-version
+          ;; would and the test couldn't distinguish "gated by handler"
+          ;; from "absent because no schema-digest".
+          payload      (-> baseline-payload
+                           (assoc :rf/schema-digest "test-digest-abc")
+                           materialise-response)
+          traces       (capture-traces!
+                         (fn []
+                           (rf/dispatch-sync [:rf/hydrate payload]
+                                             {:frame server-frame})))
+          skipped-checks
+          (filter (fn [ev]
+                    (and (= :rf.fx/skipped-on-platform (:operation ev))
+                         (#{:rf.ssr/check-version :rf.ssr/check-schema-digest}
+                          (-> ev :tags :rf.fx/id))))
+                  traces)]
+      (is (empty? skipped-checks)
+          (str "expected zero :rf.fx/skipped-on-platform traces for the two "
+               ":rf.ssr/check-* fxs on a :server-platform :rf/hydrate; saw: "
+               (pr-str (mapv (juxt :operation #(-> % :tags :rf.fx/id))
+                             skipped-checks))))
+      ;; Sanity: the handler still landed the app-db swap + metadata —
+      ;; the gate skipped only the check-fx dispatches, not the rest.
+      (is (= 7 (rf/subscribe-once server-frame [:count]))
+          ":rf/app-db still applied on the server-side run"))))
+
+(deftest hydration-on-client-platform-still-dispatches-check-fxs
+  (testing "Per rf2-7bcn0 (counter-test to the server-side skip): on a
+            :client-platform frame the handler MUST still enqueue the
+            check fxs so legitimate client-side mismatches surface via
+            :rf.ssr/compatibility-check-skipped (when the late-bind
+            hook is absent) or :rf.ssr/version-mismatch (when present
+            and differing). Without this counter-assertion the
+            server-side gate could silently strip both code paths."
+    (register-baseline-handlers!)
+    (let [client-frame (rf/make-frame {:doc "ssr-basic client frame"
+                                       :platform :client})
+          payload      (materialise-response baseline-payload)
+          traces       (capture-traces!
+                         (fn []
+                           (rf/dispatch-sync [:rf/hydrate payload]
+                                             {:frame client-frame})))
+          skipped (filter #(= :rf.ssr/compatibility-check-skipped
+                              (:operation %))
+                          traces)]
+      ;; Same trace as hydration-baseline-emits-compatibility-check-skipped-trace —
+      ;; the fx STILL fires on the client frame because no
+      ;; :rf2/runtime-version hook is registered. Asserts the
+      ;; rf2-7bcn0 gate did NOT over-skip on :client.
+      (is (seq skipped)
+          (str "on :client the :rf.ssr/check-version fx still fires and "
+               "emits :rf.ssr/compatibility-check-skipped (no runtime-"
+               "version hook registered); saw operations: "
+               (pr-str (mapv :operation traces)))))))
+
 (deftest hydration-baseline-no-mismatch-trace-when-server-hash-nil
   (testing "Migrated from testbeds/ssr_basic/spec.cjs assertion #13.
             Per Spec 011 §Hydration-mismatch detection:


### PR DESCRIPTION
Polish sweep over `implementation/ssr/` + `implementation/ssr-ring/` — five P4 beads on disjoint surfaces, each commit narrowly scoped.

## Beads

| # | bead | summary |
|---|---|---|
| 1 | **rf2-z2n5l** | docs(ssr): hoist streaming-continuations FIFO invariant into the `streaming` ns docstring (was buried in a wire-shape comment + inline `render-shell` docstring slot) |
| 2 | **rf2-7bcn0** | perf(ssr): gate `:rf.ssr/check-*` fx dispatch on resolved `:client` platform — server-side `:rf/hydrate` (test harness, isomorphic loopback) no longer fires `:rf.fx/skipped-on-platform` warnings per check |
| 3 | **rf2-c1tac** | chore(ssr-ring): templatable `default-on-error` body via `:on-error-fallback {:body … :content-type …}` opt + `make-default-on-error` constructor; rf2-kzvwq `.getMessage` no-leak contract preserved (the templated fn ignores the throwable) |
| 4 | **rf2-uzjhl** | refactor(ssr-ring): `render-error-body` built as hiccup + rendered through `ssr/render-to-string` — same render path as `:error-view` (`resolve-error-body`), drops the manual `escape-html`/`escape-attr` calls + the `(str ...)` concatenation |
| 5 | **rf2-5br2y** | refactor(ssr-ring): merge `build-full-response*`'s three direct `(with-frame frame-id …)` blocks into one outer block; `get-frame-db` stays outside the block (takes frame-id explicitly; that visibility flags the post-walk snapshot timing as load-bearing) |

## Tests

Behaviour-changing beads (2, 3) carry tests:

- **rf2-7bcn0** — `hydration-on-server-platform-skips-client-only-check-fxs` (no `:rf.fx/skipped-on-platform` for the two check fxs on `:server` frame) + `hydration-on-client-platform-still-dispatches-check-fxs` (counter-assertion that `:client` still fires).
- **rf2-c1tac** — direct constructor unit tests (`make-default-on-error-templates-body-and-content-type`, `make-default-on-error-zero-args-matches-default-on-error`) + integration through `ssr-handler` (templated default body wins; explicit `:on-error` fn beats `:on-error-fallback` map).

Pure-refactor beads (4, 5) leave existing tests covering the wire shape.

## Gates

- `cd implementation/ssr && clojure -M:test` → 238 tests, 818 assertions, 0F/0E
- `cd implementation/ssr-ring && clojure -M:test` → 76 tests, 364 assertions, 0F/0E
- `npm run test:cljs` → 4836 tests, 15778 assertions, 0F/0E
- `bash scripts/test-fast-pr.sh` → PASS