### PR TITLE
feat(xray): pre-alpha posture polish — 4 beads (2thl2 + o1mna + lvqmw + 1nlzp)

### DIFF
--- a/tools/xray/spec/015-Configuration.md
+++ b/tools/xray/spec/015-Configuration.md
@@ -643,7 +643,7 @@ ownership rule below locks the contract for pre-alpha and forward.
 | Surface | Role | Mutability | Lifetime |
 |---|---|---|---|
 | `(xray-config/configure! {…})` | Static boot config — defaults, feature flags, host-environment wiring (editor target, project root, layout-host selector, auto-open, keybinding enabled, filter seed, …). | Host-code-mutable at boot; immutable from the user's perspective. | Process-global atoms; one set of values per host load. |
-| `(xray/init! opts)` | Lifecycle hook — called by host app code to bring Xray up (alternative to `:preloads`). The `opts` map carries per-instance panel-state wiring (Settings shape inputs such as `:theme`, `:density`, `:default-frame`, `:ai-provider`, `:buffer-depths`). Idempotent. | Host-code-driven; once-per-load. | Per-mount lifecycle. |
+| `(xray/init! opts)` | Lifecycle hook — called by host app code to bring Xray up (alternative to `:preloads`). The `opts` map carries per-instance panel-state wiring (Settings shape inputs such as `:theme`, `:density`, `:default-frame`, `:buffer-depths`). Per rf2-2thl2 each accepted key is wired end-to-end; aspirational Settings-shape keys without backing infrastructure (`:ai-provider`, `:sidebar-mode`, `:launcher-pill`, `:keybindings`) land via the persisted Settings shape only — `init!` does not accept them on the opts map until the wiring catches up. Idempotent. | Host-code-driven; once-per-load. | Per-mount lifecycle. |
 | Persisted Settings (`localStorage` slot `day8.re-frame2-xray/settings/v1`) | User-mutable overrides — the Settings popup is the canonical UI; persists `:theme`, `:density`, `:ai-provider`, `:buffer-depths`, `:default-frame`, `:sidebar-mode`, `:launcher-pill`, `:keybindings` per [`API.md`](./API.md) §Settings keys. | User-mutable via the Settings popup; round-trips through localStorage. | Survives reload until corrupted or cleared. |
 
 **Merge order (lowest precedence first):**
@@ -683,10 +683,11 @@ inventory, or refuse persistence at the harness layer; the merge
 order does not change.
 
 The same rule applies symmetrically to every overlapping key today
-(`:density`, `:default-frame`, `:ai-provider`, `:buffer-depths`).
-Future host-facing knobs added to `configure!` MUST declare whether
-they participate in the persisted Settings shape; knobs that do
-inherit this merge order automatically.
+(`:density`, `:default-frame`, `:buffer-depths`; `:ai-provider` once
+its backing infrastructure lands per rf2-2thl2). Future host-facing
+knobs added to `configure!` MUST declare whether they participate in
+the persisted Settings shape; knobs that do inherit this merge order
+automatically.
 
 ## Reserved keys
 

--- a/tools/xray/spec/API.md
+++ b/tools/xray/spec/API.md
@@ -153,14 +153,19 @@ implementation reality — ~40 symbols across 6 namespaces).
 ;; Mount Xray manually (alternative to :preloads). Idempotent.
 
 (xray/init! opts)
-;; opts: {:default-frame :app/main
-;;        :theme         :dark / :light / :high-contrast
-;;        :density       :compact / :cosy
-;;        :ai-provider   {:provider :claude / :openai / :gemini / :local / :custom
-;;                        :api-key  "sk-..."     ;; localStorage only; never sent to Day8
-;;                        :model    "claude-3-5-sonnet"
-;;                        :system-prompt "..."}
-;;        :buffer-depths {:trace 200 :epoch 50}}
+;; opts: {:default-frame :app/main         ;; scrubber's target frame
+;;        :theme         :dark / :light    ;; persisted Settings :theme
+;;        :density       :compact / :cosy  ;; persisted Settings :general/:density
+;;        :buffer-depths {:epoch 50}}      ;; per-frame ring depth (drives both
+;;                                         ;; :depth + :trace-events-keep per
+;;                                         ;; the rf2-3g9nw D1=a ruling)
+;; rf2-2thl2: each opt is wired end-to-end (no accept-but-ignore stubs).
+;; Unknown keys are silently ignored for forward-compatibility.
+;; `:ai-provider` is documented in the persisted Settings shape (see
+;; §Settings keys below) but the backing infrastructure lands in a
+;; follow-on bead; until then `init!` does not accept it on the opts
+;; map (host hand-edits of the Settings shape via `(configure!
+;; {:rf.xray/settings ...})` remain forward-compatible).
 
 (xray/open!)        ;; Show the panel programmatically.
 (xray/close!)       ;; Hide the panel programmatically.

--- a/tools/xray/src/day8/re_frame2_xray/core.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/core.cljs
@@ -30,16 +30,13 @@
 
   ## Pre-alpha posture
 
-  One surface in `spec/API.md` ships as a TBD-impl stub that emits a
-  `:rf.warning/*` trace and otherwise no-ops:
-
-    - `load-theme` — programmatic theme swap. The theme module
-      exists (`day8.re-frame2-xray.theme/*`) but the runtime CSS-
-      swap surface is not yet wired.
-
-  When called, each stub emits a structured trace event tagged with
-  `:origin :xray` so the gap is visible in the trace stream
-  (consistent with `spec/API.md` §Trace-event tags Xray emits).
+  Every surface this facade exposes is wired end-to-end — no
+  TBD-impl stubs, no documented-warning-emit placeholders. `init!`,
+  `load-theme`, the mount/config re-exports, and the frame picker
+  all route through their respective backing surfaces (the persisted
+  Settings shape, the theme module's CSS-swap site, the mount
+  layer's singleton guards). Future opt-keys that don't yet have a
+  backing surface land here only after their machinery does.
 
   ## What this namespace deliberately does NOT expose
 

--- a/tools/xray/src/day8/re_frame2_xray/core.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/core.cljs
@@ -56,6 +56,7 @@
             [day8.re-frame2-xray.mount :as mount]
             [day8.re-frame2-xray.preload :as preload]
             [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.settings.effects :as settings-effects]
             [day8.re-frame2-xray.theme.global-styles :as global-styles]))
 
 ;; ---- mount entry points (re-exports from mount.cljs) --------------------
@@ -115,24 +116,41 @@
 
   Per `spec/API.md` §Public CLJS API, `opts` accepts:
 
-      {:default-frame :app/main          ;; target-frame for the scrubber
-       :theme         :dark              ;; / :light / :high-contrast
-       :density       :compact           ;; / :cosy
-       :ai-provider   {:provider :claude ;; ...}
-       :buffer-depths {:trace 200 :epoch 50}}
+      {:default-frame :app/main         ;; target-frame for the scrubber
+       :theme         :dark             ;; / :light  (settings persist)
+       :density       :compact          ;; / :cosy   (settings persist)
+       :buffer-depths {:epoch 50}}      ;; per-frame ring depth
 
-  The current pre-alpha posture wires the four foundation side-effects
-  (registry, trace-cb, epoch-cb, keybinding listener) and threads
-  `:default-frame` through to the `:rf.xray/set-target-frame` event.
-  The remaining keys (`:theme`, `:density`, `:ai-provider`,
-  `:buffer-depths`) are accepted today but ignored at runtime — the
-  per-area machinery lands under follow-on beads. Passing them now
-  keeps host code forward-compatible.
+  Wires the four foundation side-effects (registry, trace-cb, epoch-cb,
+  keybinding listener), then threads each supplied opt through to its
+  backing surface:
+
+  - `:default-frame` — dispatches `:rf.xray/set-target-frame` so the
+    scrubber + every dependent panel re-fire on the standard reactive
+    path.
+  - `:theme` — writes to the persisted Settings shape (slot `:theme`)
+    and applies the matching `rf-xray-theme-*` class so the next paint
+    honours the new palette without a reload.
+  - `:density` — writes `:general :density` into the persisted
+    Settings shape and applies the matching `--rf-xray-font-size` so
+    Views detail rows + App-db diff rows rescale immediately.
+  - `:buffer-depths` — accepts `{:epoch <n>}`; writes `:general
+    :epoch-history` and drives the substrate's per-frame ring
+    (`:depth` + `:trace-events-keep` to the same n) so trace is
+    retained for every retained epoch. The `:trace` axis from prior
+    spec drafts is folded into this single knob per the rf2-3g9nw D1=a
+    ruling + Mike pair-debug 2026-05-27 (one operator knob, atomic
+    relationship). Passing `:trace` is silently dropped pending a
+    second-axis separation if one re-emerges.
+
+  Unknown opt keys are silently ignored (forward-compat): a future
+  release adds keys here without breaking older callers, and a host
+  passing a newer key against an older Xray MUST NOT break either.
 
   Returns nothing."
   ([]
    (init! nil))
-  ([{:keys [default-frame] :as _opts}]
+  ([{:keys [default-frame theme density buffer-depths] :as _opts}]
    (registry/register-xray-handlers!)
    (preload/register-trace-collector!)
    (preload/register-epoch-collector!)
@@ -140,6 +158,16 @@
    (when default-frame
      (rf/with-frame :rf/xray
        (rf/dispatch [:rf.xray/set-target-frame default-frame])))
+   (when theme
+     (config/update-setting! :theme nil theme)
+     (settings-effects/apply-theme! theme))
+   (when density
+     (config/update-setting! :general :density density)
+     (settings-effects/apply-density-font-size! density))
+   (when-let [epoch-depth (and (map? buffer-depths) (:epoch buffer-depths))]
+     (when (and (number? epoch-depth) (pos? epoch-depth))
+       (config/update-setting! :general :epoch-history (long epoch-depth))
+       (settings-effects/apply-epoch-history! (long epoch-depth))))
    nil))
 
 ;; ---- frame picker -------------------------------------------------------

--- a/tools/xray/src/day8/re_frame2_xray/drop_in.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/drop_in.cljc
@@ -48,7 +48,9 @@
      and the host calls `(drop-in/emit! event)` for each event.
      This is the simplest mode and the right default when the host
      produces events synchronously inside an existing callback (an
-     XState `subscribe` cb, a Redux middleware, etc.).
+     XState `subscribe` cb, a Redux middleware, etc.). `emit!` is
+     strict: it throws when called before `attach!` so a missing
+     attach surfaces loudly rather than silently dropping events.
 
   2. **Atom mode** — `(attach! {:trace-source <atom-ref>})`. The
      drop-in `add-watch`es the atom; every conj / assoc that grows
@@ -377,17 +379,26 @@
   modes (`:atom`, `:sub`) call `collect-from-host!` indirectly through
   the watch / subscribe fan-out; push-mode hosts call this directly.
 
-  Pre-alpha posture: this fn is callable regardless of whether
-  `attach!` ran — the buffer accepts events. We do NOT gate on
-  `(attached?)` because `attach!` for push mode is purely
-  bookkeeping (there is no subscription to register); requiring the
-  call would add ceremony without behaviour gain. Hosts that prefer
-  the explicit lifecycle still call `(attach! {:mode :push})` for
-  symmetry with the other modes.
+  Pre-alpha posture: strict, symmetric with `attach!`. The host MUST
+  call `(attach! {:mode :push})` before the first `emit!`; calling
+  `emit!` while detached throws `:rf.error/xray-emit-before-attach`
+  so a misconfigured push-mode wiring fails loudly at the call site
+  rather than silently dropping events. This matches `attach!`'s
+  strict posture on unknown modes — one lifecycle contract across
+  the surface, no implicit fallbacks.
 
-  Returns nothing. No-op in production."
+  Returns nothing. No-op in production (the `interop/debug-enabled?`
+  gate short-circuits both `collect-from-host!` and this fn's
+  attachment check, so production builds never observe the throw)."
   [event]
-  (collect-from-host! event)
+  (when interop/debug-enabled?
+    (when-not (attached?)
+      (throw (ex-info ":rf.error/xray-emit-before-attach"
+                      {:rf.error/id :rf.error/xray-emit-before-attach
+                       :where    'xray/emit!
+                       :recovery :no-recovery
+                       :reason   "drop-in/emit! called before drop-in/attach! — call (attach! {:mode :push}) at host boot"})))
+    (collect-from-host! event))
   nil)
 
 (defn reset-for-test!

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch_panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch_panel.cljs
@@ -17,22 +17,14 @@
   ## Tab placement
 
   Registered against `:dynamic` mode at order 5 (between Machines (4)
-  and Routing (6)). Co-exists with the existing Event lens (the
-  `:event` tab) initially — both surface the focused epoch, but
-  through different lenses:
-
-  - **Event** (`:event` tab) — the Figma-locked operational-order
-    handling pipeline (rf2-ynnre B+); reads more like a
-    spec-shaped attribution document.
-  - **Epoch** (`:epoch` tab — this panel) — the full timeline as a
-    delightful numbered cascade including the reactive trailing
-    edge (SUBSCRIPTIONS + VIEWS) that the Event lens routes to its
-    own Reactive tab.
-
-  Per the bead body's pre-alpha posture, this co-existence is the
-  initial landing; the older Event/Reactive split deprecates as a
-  follow-on bead once the new Epoch panel is exercised in
-  production.
+  and Routing (6)). This panel is the **canonical** \"what happened
+  in this epoch?\" surface — it presents the full timeline as a
+  delightful numbered cascade including the reactive trailing edge
+  (SUBSCRIPTIONS + VIEWS). The Reactive tab covers a complementary
+  axis (per-sub recomputation detail across cascades) and remains
+  side-by-side with this panel; the older Event/Handler panel
+  (`:event` tab) was retired under rf2-5gl5r when this Epoch panel
+  landed as its supersedant.
 
   ## Frame integration
 

--- a/tools/xray/test/day8/re_frame2_xray/core_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/core_cljs_test.cljs
@@ -41,7 +41,11 @@
 
 (defn- xray-init! []
   (xray-test-support/reset-all!)
-  (trace-collector/reset-for-test!))
+  (trace-collector/reset-for-test!)
+  ;; rf2-2thl2 — init! writes through to the persisted Settings atom;
+  ;; reset between tests so per-test mutations don't leak into the
+  ;; next test's read.
+  (config/reset-settings!))
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture
@@ -166,16 +170,40 @@
       (is (some #(= [:rf.xray/set-target-frame :app/main] %) @seen)
           "init! dispatched :rf.xray/set-target-frame with :default-frame"))))
 
-(deftest init!-accepts-future-opts-without-throwing
-  (testing "init! tolerates spec/API.md keys not yet wired (forward-compat)"
-    ;; Per the docstring: :theme / :density / :ai-provider /
-    ;; :buffer-depths are accepted today and ignored at runtime. The
-    ;; contract is that passing them does not throw — host code wired
-    ;; against the spec stays runnable as the impl fills in.
+(deftest init!-wires-theme-density-and-buffer-depths
+  (testing "rf2-2thl2 — init! threads :theme / :density / :buffer-depths
+            through to the persisted Settings shape so a host's boot-time
+            opts land in the same slots the Settings popup writes."
     (setup-xray-frame!)
     (core/init! {:default-frame :app/main
                  :theme         :dark
                  :density       :compact
-                 :ai-provider   {:provider :claude}
-                 :buffer-depths {:trace 200 :epoch 50}})
-    (is true "init! did not throw on the full spec/API.md opts map")))
+                 :buffer-depths {:epoch 75}})
+    (is (= :dark    (config/get-setting :theme nil))
+        ":theme landed in the persisted Settings shape")
+    (is (= :compact (config/get-setting :general :density))
+        ":density landed under :general")
+    (is (= 75       (config/get-setting :general :epoch-history))
+        ":buffer-depths :epoch landed under :general :epoch-history")))
+
+(deftest init!-tolerates-unknown-opts-keys
+  (testing "rf2-2thl2 — init! silently ignores keys it doesn't recognise
+            (forward-compat: a host passing a key a future Xray release
+            adds MUST NOT break the current Xray boot)."
+    (setup-xray-frame!)
+    (core/init! {:default-frame   :app/main
+                 :unknown/future  :something
+                 :rf.xray/another 42})
+    (is true "init! did not throw on unknown keys")))
+
+(deftest init!-buffer-depths-with-nil-epoch-is-noop
+  (testing "rf2-2thl2 — init! ignores :buffer-depths shapes without a
+            usable :epoch (nil, non-numeric, non-positive)."
+    (setup-xray-frame!)
+    (let [start (config/get-setting :general :epoch-history)]
+      (core/init! {:buffer-depths {:trace 200}})
+      (is (= start (config/get-setting :general :epoch-history))
+          ":trace-only map left :epoch-history at the prior value")
+      (core/init! {:buffer-depths {:epoch -5}})
+      (is (= start (config/get-setting :general :epoch-history))
+          "negative epoch depth was rejected by the apply-epoch-history! gate"))))

--- a/tools/xray/test/day8/re_frame2_xray/drop_in_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/drop_in_cljs_test.cljc
@@ -76,11 +76,26 @@
          (is (number?       (:time      (first buf))) ":time filled by drop-in")))))
 
 #?(:cljs
-   (deftest emit!-without-attach-still-pushes
-     (testing "push-mode emit! does NOT require a prior attach! (per ns docstring)"
-       (drop-in/emit! {:operation :host/foo :op-type :rf.event})
-       (is (= 1 (count (trace-collector/buffer-for-test)))
-           "emit! is callable independently of attach! — push mode has no subscription to gate on"))))
+   (deftest emit!-without-attach-throws
+     (testing "rf2-lvqmw — push-mode emit! is strict: throws when called before attach!"
+       (is (thrown? js/Error
+                    (drop-in/emit! {:operation :host/foo :op-type :rf.event}))
+           "emit! before attach! raises :rf.error/xray-emit-before-attach")
+       (is (= 0 (count (trace-collector/buffer-for-test)))
+           "no event reached the buffer — the throw fired before collect"))))
+
+#?(:cljs
+   (deftest emit!-after-detach-throws
+     (testing "rf2-lvqmw — emit! after detach! re-asserts the strict posture"
+       (drop-in/attach! {:mode :push})
+       (drop-in/emit! {:operation :host/before :op-type :rf.event})
+       (drop-in/detach!)
+       (is (thrown? js/Error
+                    (drop-in/emit! {:operation :host/after :op-type :rf.event}))
+           "post-detach emit! throws the same as a pre-attach emit!")
+       (let [ops (mapv :operation (trace-collector/buffer-for-test))]
+         (is (= [:host/before] ops)
+             "only the attached emit landed; the detached one did not")))))
 
 #?(:cljs
    (deftest emit!-drops-non-map-events


### PR DESCRIPTION
Pre-alpha posture polish on the Xray facade + drop-in surface. Per first-principles audit rf2-26puv: wire-or-drop, no accept-but-ignore opts, no TBD-impl stubs, no drift docstrings.

## Beads

| # | bead | P | summary |
|---|---|---|---|
| 1 | rf2-1nlzp | P4 | epoch_panel ns docstring described co-existence with the removed Event tab (retired under rf2-5gl5r) — update to reflect Epoch as the canonical 'what happened in this epoch?' surface. |
| 2 | rf2-lvqmw | P4 | drop-in/emit! was lenient (callable before attach!, silently pushed) while attach! was strict (threw on unknown mode) — asymmetric. Tightened emit! to throw `:rf.error/xray-emit-before-attach` so the lifecycle contract is symmetric across the surface. |
| 3 | rf2-2thl2 | P3 | init! advertised five opts but only :default-frame was wired. Wired :theme, :density, :buffer-depths through to the persisted Settings shape + their backing apply-* effects. Dropped :ai-provider from the init! signature pending its backing infrastructure (the persisted-settings path remains forward-compatible). |
| 4 | rf2-o1mna | P3 | core.cljs ns docstring still described load-theme as a 'TBD-impl stub that emits a :rf.warning/* trace' — false since rf2-ee38b.2 wired it through global-styles/set-host-theme-css!. Updated the Pre-alpha posture section to reflect the actual every-surface-wired contract. |

## Behaviour changes

- `drop-in/emit!` now throws `:rf.error/xray-emit-before-attach` when called before `drop-in/attach!`. The prior lenient posture silently pushed events into the buffer; the new symmetric-throw posture surfaces a misconfigured push-mode wiring loudly at the call site. Production builds (interop/debug-enabled? false) are unchanged — the throw check + the collect path both elide.
- `core/init!` opts `:theme`, `:density`, `:buffer-depths` now write through to the persisted Settings atom + drive the matching apply-* side-effect. `:ai-provider` is no longer accepted (host hand-edits via `(configure! {:rf.xray/settings ...})` remain forward-compatible).

## Test coverage

- `drop_in_cljs_test.cljc` — replaced the prior `emit!-without-attach-still-pushes` lenient-posture assertion with `emit!-without-attach-throws` + `emit!-after-detach-throws`.
- `core_cljs_test.cljs` — replaced the prior `init!-accepts-future-opts-without-throwing` lenient-posture assertion with `init!-wires-theme-density-and-buffer-depths`, `init!-tolerates-unknown-opts-keys`, and `init!-buffer-depths-with-nil-epoch-is-noop`. Fixture now resets the settings atom between tests.

## Spec touched

- `tools/xray/spec/API.md` — `init! opts` block now lists only wired keys; explanatory note on `:ai-provider`.
- `tools/xray/spec/015-Configuration.md` — `(xray/init! opts)` table row + Settings-shape overlap list updated to remove `:ai-provider` from the init! signature (still listed in the persisted Settings shape).

## Quality gates

- `npm run test:cljs` — 4839 tests / 15786 assertions / 0F0E.
- `clojure -M:test` in tools/xray — 952 tests / 3685 assertions / 0F0E.
- `scripts/test-fast-pr.sh` — PASS.