### PR TITLE
refactor(framework): split with-frame (pin) + with-new-frame (eval/destroy) (rf2-twoc5, Mike-approved Option A)

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -106,12 +106,12 @@
   ;; by the dedicated hook in `.clj-kondo/hooks/re_frame/core.clj` —
   ;; lint-as wouldn't surface the injected bindings.
 
-  ;; `with-frame` has two shapes — `(with-frame :keyword body+)` and
-  ;; `(with-frame [sym expr] body+)`. The latter is `let`-shape; the
-  ;; former is `do`-shape with a leading keyword. Handled by the
-  ;; dedicated hook in `.clj-kondo/hooks/re_frame/core.clj` so both
-  ;; shapes parse cleanly and the binding-vector case surfaces the
-  ;; lexical `sym`.
+  ;; `with-frame` and `with-new-frame` are siblings (rf2-twoc5):
+  ;; `(with-frame :keyword body+)` is pin-form (`do`-shape with leading
+  ;; keyword), and `(with-new-frame [sym expr] body+)` is eval-bind-
+  ;; run-destroy (`let`-shape). Handled by the dedicated hooks in
+  ;; `.clj-kondo/hooks/re_frame/core.clj` so both parse cleanly and the
+  ;; binding-vector case surfaces the lexical `sym`.
 
   ;; Story authoring macros — `(reg-foo :id metadata)` is a registration
   ;; call, same shape as the core reg-* family. Same `do`-shape lint-as
@@ -136,8 +136,9 @@
 
  :hooks
  {:analyze-call
-  {re-frame.core/reg-view   hooks.re-frame.core/reg-view
-   re-frame.core/with-frame hooks.re-frame.core/with-frame}}
+  {re-frame.core/reg-view       hooks.re-frame.core/reg-view
+   re-frame.core/with-frame     hooks.re-frame.core/with-frame
+   re-frame.core/with-new-frame hooks.re-frame.core/with-new-frame}}
 
  ;; `tools/template/resources/` ships deps-new template `.cljs` files
  ;; whose `{{placeholder}}` substitutions are not valid Clojure (see

--- a/.clj-kondo/hooks/re_frame/core.clj
+++ b/.clj-kondo/hooks/re_frame/core.clj
@@ -20,32 +20,34 @@
   (:require [clj-kondo.hooks-api :as api]))
 
 (defn with-frame
-  "clj-kondo macro hook for `re-frame.core/with-frame`.
-
-  Two shapes — per Spec 002 §with-frame:
+  "clj-kondo macro hook for `re-frame.core/with-frame` — pin form only
+  (per rf2-twoc5):
 
       (with-frame :keyword body+)        ;; pin to existing frame
-      (with-frame [sym expr] body+)      ;; lexical bind, run, dispose
 
-  Rewrites:
-    - keyword shape → `(do body)`
-    - binding shape → `(let [sym expr] body)`"
+  Rewrites to `(do <frame-id> body)` so kondo sees the body in
+  sequential context."
   [{:keys [node]}]
-  (let [[_with-frame discriminator & body] (:children node)]
-    (cond
-      ;; `(with-frame [sym expr] body+)` — binding-vector shape.
-      (api/vector-node? discriminator)
-      {:node (api/list-node
-               (list* (api/token-node 'let)
-                      discriminator
-                      body))}
-      ;; `(with-frame :keyword body+)` — keyword shape; the keyword is
-      ;; eval'd as an expression (a no-op) and the body runs sequentially.
-      :else
-      {:node (api/list-node
-               (list* (api/token-node 'do)
-                      discriminator
-                      body))})))
+  (let [[_with-frame frame-id & body] (:children node)]
+    {:node (api/list-node
+             (list* (api/token-node 'do)
+                    frame-id
+                    body))}))
+
+(defn with-new-frame
+  "clj-kondo macro hook for `re-frame.core/with-new-frame` — eval-bind-
+  run-destroy form (per rf2-twoc5):
+
+      (with-new-frame [sym expr] body+) ;; eval, bind, run, destroy
+
+  Rewrites to `(let [sym expr] body)` so kondo sees `sym` as a lexical
+  binding for the body."
+  [{:keys [node]}]
+  (let [[_with-new-frame bindings & body] (:children node)]
+    {:node (api/list-node
+             (list* (api/token-node 'let)
+                    bindings
+                    body))}))
 
 (defn reg-view
   "Hook entry — see ns doc."

--- a/docs/api/01-core.md
+++ b/docs/api/01-core.md
@@ -133,7 +133,7 @@ This is the surface every re-frame2 app touches. You're answering "what events c
 - **Description**: Anonymous-frame shortcut. The id is gensym'd; useful for tests, transient sandboxes, and the SSR per-request frame pattern.
 - **Example**:
   ```clojure
-  (rf/with-frame [f (rf/make-frame {:on-create [:temp/initialise]})]
+  (rf/with-new-frame [f (rf/make-frame {:on-create [:temp/initialise]})]
     (rf/dispatch [:temp/set-celsius 21]))
   ```
 - **In the wild**: [7GUIs](https://github.com/day8/re-frame2/tree/main/examples/reagent/seven_guis)

--- a/docs/api/02-views.md
+++ b/docs/api/02-views.md
@@ -109,15 +109,15 @@ These five surfaces work the same across Reagent, UIx, and Helix. They're how vi
   ```
 - **Description**: "Children inside this provider see `:todo` as their current frame." Lexical scope for the implicit frame; nestable; pairs with `with-frame` for non-component code.
 
-### `with-frame`
+### `with-frame` / `with-new-frame`
 
-- **Kind**: macro
-- **Signature**:
+- **Kind**: macros (sibling pair)
+- **Signatures**:
   ```clojure
-  (with-frame :keyword body)
-  (with-frame [sym expr] body)
+  (with-frame :keyword body)        ;; pin to an existing frame-id
+  (with-new-frame [sym expr] body)  ;; eval, bind, run, destroy on exit
   ```
-- **Description**: "Run this code as if the current frame were `:keyword`." Two shapes — bare keyword vs let-binding — documented in [002 §with-frame](../../spec/002-Frames.md#with-frame).
+- **Description**: `with-frame` pins `*current-frame*` to an existing frame-id; the frame is not created or destroyed. `with-new-frame` evals `expr`, binds the resulting id to `sym`, runs body in that frame's dynamic context, and destroys the frame on exit. Each rejects the other's argument shape at compile time. Documented in [002 §with-frame and with-new-frame](../../spec/002-Frames.md#with-frame-and-with-new-frame).
 
 ### `bound-fn`
 
@@ -172,20 +172,24 @@ The pattern composes inside `with-frame`:
 
 `bound-fn` is the broader hammer — it captures *every* dynamic-var binding into the closure, not just the frame. Use `dispatcher` / `subscriber` for the common frame-capture case; reach for `bound-fn` when the closure needs to honour other bindings (interceptor overrides, the dev-time trace context, etc.).
 
-### `with-frame`'s two shapes
+### `with-frame` and `with-new-frame` — the sibling pair
 
 ```clojure
-;; Bare keyword — most common
+;; Pin form — most common: bind *current-frame* to an existing id
 (rf/with-frame :todo
   (rf/dispatch [::add-item ...]))
 
-;; Let-binding — when you want the keyword in a local
-(let [f (compute-frame-id ...)]
-  (rf/with-frame [chosen f]
+;; Pin to a computed id — pass the keyword directly, no extra binding
+(let [chosen (compute-frame-id ...)]
+  (rf/with-frame chosen
     (rf/dispatch [::action chosen])))
+
+;; Eval-bind-run-destroy form — create a throwaway frame for the body
+(rf/with-new-frame [f (rf/make-frame {:on-create [:test/initialise]})]
+  (rf/dispatch [::action f]))   ;; frame destroyed on exit
 ```
 
-Full semantics in [002 §with-frame](../../spec/002-Frames.md#with-frame).
+Full semantics in [002 §with-frame and with-new-frame](../../spec/002-Frames.md#with-frame-and-with-new-frame).
 
 ## Reagent: the default substrate
 

--- a/docs/api/09-ssr.md
+++ b/docs/api/09-ssr.md
@@ -20,7 +20,7 @@ The normative source is [011-SSR.md](../../spec/011-SSR.md). The SSR surfaces li
 - **Description**: The canonical server-side render. Walks the hiccup tree once, emits a string. JVM-runnable. Test-friendly because it's pure.
 - **Example**:
   ```clojure
-  (rf/with-frame [f (rf/make-frame {:on-create [:app/server-init]})]
+  (rf/with-new-frame [f (rf/make-frame {:on-create [:app/server-init]})]
     (ssr/render-to-string [app-root] {:frame f}))
   ```
 - **In the wild**: [ssr](https://github.com/day8/re-frame2/tree/main/examples/reagent/ssr)

--- a/docs/guide/13-server-side.md
+++ b/docs/guide/13-server-side.md
@@ -264,7 +264,7 @@ A server handling concurrent requests can't have one global frame — each reque
 
 ```clojure
 (defn handle-request [request]
-  (rf/with-frame [f (rf/make-frame {:on-create [:rf/server-init request]})]
+  (rf/with-new-frame [f (rf/make-frame {:on-create [:rf/server-init request]})]
     ;; make-frame returns the gensym'd frame id (a keyword under :rf.frame/);
     ;; with-frame binds *current-frame* to it for the body. The frame's
     ;; :on-create dispatches synchronously when the frame is created, so by

--- a/docs/guide/15-testing.md
+++ b/docs/guide/15-testing.md
@@ -35,7 +35,7 @@ Three patterns, ranked roughly by frequency:
 
 ```clojure
 (deftest auth-flow
-  (rf/with-frame [f (rf/make-frame {:on-create [:auth/init-idle]})]
+  (rf/with-new-frame [f (rf/make-frame {:on-create [:auth/init-idle]})]
     (rf/dispatch-sync [:auth/login-pressed])
     (is (= :validating (get-in (rf/get-frame-db f) [:auth :state])))))
 ```
@@ -124,7 +124,7 @@ For tests that exercise multiple events in sequence and want to assert at the en
 
 ```clojure
 (deftest auth-happy-path
-  (rf/with-frame [f (rf/make-frame {:on-create [:auth/init-idle]})]
+  (rf/with-new-frame [f (rf/make-frame {:on-create [:auth/init-idle]})]
     (rf/dispatch-sync [:auth/email-changed "alice@example.com"])
     (rf/dispatch-sync [:auth/password-changed "hunter2"])
     (rf/dispatch-sync [:auth/login-pressed]
@@ -161,7 +161,7 @@ Dispatch, call the view-fn, walk the result. Catches the "state correct, view br
 
 ```clojure
 (deftest counter-view-shows-current-count
-  (rf/with-frame [f (rf/make-frame {:on-create [:counter/init]})]
+  (rf/with-new-frame [f (rf/make-frame {:on-create [:counter/init]})]
     (rf/dispatch-sync [:counter/inc])
     (rf/dispatch-sync [:counter/inc])
     ;; state assertion — the handler updated the db
@@ -180,7 +180,7 @@ Pull `:on-click` off the hiccup node and invoke it. Catches the "wrong-frame dis
 
 ```clojure
 (deftest counter-button-fires-inc
-  (rf/with-frame [f (rf/make-frame {:on-create [:counter/init]})]
+  (rf/with-new-frame [f (rf/make-frame {:on-create [:counter/init]})]
     (let [tree (counter-view {:n 0})
           btn  (h/find-by-testid tree "counter-inc")]
       (h/invoke-handler btn :on-click nil)            ;; fires :on-click
@@ -238,7 +238,7 @@ Two ways to test a sub:
 
 ;; 2. compute-sub against a frame's app-db, after dispatching events
 (deftest pending-todos-sub-via-events
-  (rf/with-frame [f (rf/make-frame {})]
+  (rf/with-new-frame [f (rf/make-frame {})]
     (rf/dispatch-sync [:todos/add {:id 1 :status :pending}])
     (rf/dispatch-sync [:todos/add {:id 2 :status :done}])
     (rf/dispatch-sync [:todos/add {:id 3 :status :pending}])
@@ -282,7 +282,7 @@ Three levels of machine testing, in order of unit-cost:
 **Level 3 — registered in test frame.** Register the machine in a frame, dispatch events, assert against the frame's `app-db`:
 
 ```clojure
-(rf/with-frame [f (rf/make-frame {})]
+(rf/with-new-frame [f (rf/make-frame {})]
   (rf/reg-machine :auth.login/flow login-flow)
   (rf/dispatch-sync [:auth.login/flow [:auth.login/submit {...}]])
   (is (= :submitting (get-in (rf/get-frame-db f)
@@ -494,7 +494,7 @@ A handler that depends on the outside world via `inject-cofx` becomes determinis
   (ts/with-fresh-registrar
     (rf/reg-cofx :now
       (fn [ctx] (assoc-in ctx [:coeffects :now] #inst "2026-01-01T12:00:00.000Z")))
-    (rf/with-frame [f (rf/make-frame {})]
+    (rf/with-new-frame [f (rf/make-frame {})]
       (rf/dispatch-sync [:todo/add "buy milk"])
       (is (= #inst "2026-01-01T12:00:00.000Z"
              (-> (rf/get-frame-db f) :todos first val :created-at))))))

--- a/examples/reagent/boot/test/boot/boot_test.cljs
+++ b/examples/reagent/boot/test/boot/boot_test.cljs
@@ -29,7 +29,7 @@
             ;; if a future refactor unhooks the transitive load.
             [re-frame.http-test-support]
             [boot.boot])
-  (:require-macros [re-frame.core :refer [with-frame]]))
+  (:require-macros [re-frame.core :refer [with-new-frame]]))
 
 ;; ============================================================================
 ;; PER-URL CANNED STUBS
@@ -106,7 +106,7 @@
   []
   (reg-canned-success-by-url! :boot.test/canned-boot-success payload-for)
 
-  (with-frame [f (rf/make-frame
+  (with-new-frame [f (rf/make-frame
                    {:on-create    [:boot/initialise]
                     :fx-overrides {:rf.http/managed
                                    :boot.test/canned-boot-success}})]
@@ -138,7 +138,7 @@
   []
   (reg-canned-success-by-url! :boot.test/canned-boot-success payload-for)
 
-  (with-frame [f (rf/make-frame
+  (with-new-frame [f (rf/make-frame
                    {:on-create    [:boot/initialise]
                     :fx-overrides {:rf.http/managed
                                    :boot.test/canned-boot-success}})]
@@ -170,7 +170,7 @@
                        {:status 500
                         :body   "boot dependency unreachable"})
 
-  (with-frame [f (rf/make-frame
+  (with-new-frame [f (rf/make-frame
                    {:on-create    [:boot/initialise]
                     :fx-overrides {:rf.http/managed
                                    :boot.test/canned-boot-fail}})]

--- a/examples/reagent/long_running_work/test/long_running_work/worker_test.cljs
+++ b/examples/reagent/long_running_work/test/long_running_work/worker_test.cljs
@@ -31,7 +31,7 @@
   (:require [cljs.test :refer-macros [is]]
             [re-frame.core :as rf]
             [long-running-work.worker])
-  (:require-macros [re-frame.core :refer [with-frame]]))
+  (:require-macros [re-frame.core :refer [with-new-frame]]))
 
 ;; ============================================================================
 ;; HELPERS
@@ -64,7 +64,7 @@
 ;; ============================================================================
 
 (defn test-spawn-cascade []
-  (with-frame [f (new-frame)]
+  (with-new-frame [f (new-frame)]
     ;; After :app/initialise, the parent is :idle with progress all-zero.
     (let [snap (snapshot f)]
       (is (= :idle (:state snap)))
@@ -94,7 +94,7 @@
 ;; ============================================================================
 
 (defn test-happy-path-join []
-  (with-frame [f (new-frame)]
+  (with-new-frame [f (new-frame)]
     (rf/dispatch-sync [:work/flow [:start]] {:frame f})
 
     ;; The child machines would normally drive themselves to :done
@@ -139,7 +139,7 @@
 ;; ============================================================================
 
 (defn test-cancel-cascade []
-  (with-frame [f (new-frame)]
+  (with-new-frame [f (new-frame)]
     (rf/dispatch-sync [:work/flow [:start]] {:frame f})
 
     ;; Simulate partial progress from each shard. The action's
@@ -188,7 +188,7 @@
 ;; Reagent idiom, not a re-frame2 contract).
 
 (defn test-parent-unmount-cascade []
-  (with-frame [f (new-frame)]
+  (with-new-frame [f (new-frame)]
     (rf/dispatch-sync [:work/flow [:start]] {:frame f})
     (is (= :working (:state (snapshot f))))
 
@@ -207,7 +207,7 @@
 ;; ============================================================================
 
 (defn test-reset-after-cancel []
-  (with-frame [f (new-frame)]
+  (with-new-frame [f (new-frame)]
     (rf/dispatch-sync [:work/flow [:start]]               {:frame f})
     (rf/dispatch-sync [:work/flow [:progress :s1 42 100]] {:frame f})
     (rf/dispatch-sync [:work/flow [:cancel]]              {:frame f})

--- a/examples/reagent/nine_states/test/nine_states/core_test.cljs
+++ b/examples/reagent/nine_states/test/nine_states/core_test.cljs
@@ -13,7 +13,7 @@
   (:require [cljs.test :refer-macros [is]]
             [re-frame.core :as rf]
             [nine-states.core])
-  (:require-macros [re-frame.core :refer [with-frame]]))
+  (:require-macros [re-frame.core :refer [with-new-frame]]))
 
 (defn- machine-has-tag?
   "Read the machine's tag union against a frame's app-db."
@@ -36,7 +36,7 @@
      :fx-overrides demo-overrides}))
 
 (defn test-state-1-nothing []
-  (with-frame [f (new-frame)]
+  (with-new-frame [f (new-frame)]
     (is       (machine-has-tag?    f :data/nothing))
     (is (not  (machine-has-tag?    f :data/loading)))
     (is (=    :nothing     (render-model f)))))
@@ -44,46 +44,46 @@
 (defn test-state-2-loading []
   ;; The demo stub resolves synchronously, so we observe :loading by
   ;; dispatching :fetch-started directly (without a follow-up reply).
-  (with-frame [f (new-frame)]
+  (with-new-frame [f (new-frame)]
     (rf/dispatch-sync [:ui/nine-states [:fetch-started]] {:frame f})
     (is       (machine-has-tag?    f :data/loading))
     (is       (machine-has-tag?    f :data/transient))
     (is (=    :loading     (render-model f)))))
 
 (defn test-state-3-empty []
-  (with-frame [f (new-frame)]
+  (with-new-frame [f (new-frame)]
     (rf/dispatch-sync [:nine-states.demo/load {:n 0}] {:frame f})
     (is       (machine-has-tag?    f :data/empty))
     (is (not  (machine-has-tag?    f :data/one)))
     (is (=    :empty       (render-model f)))))
 
 (defn test-state-4-one []
-  (with-frame [f (new-frame)]
+  (with-new-frame [f (new-frame)]
     (rf/dispatch-sync [:nine-states.demo/load {:n 1}] {:frame f})
     (is       (machine-has-tag?    f :data/one))
     (is (=    :one         (render-model f)))))
 
 (defn test-state-5-some []
-  (with-frame [f (new-frame)]
+  (with-new-frame [f (new-frame)]
     (rf/dispatch-sync [:nine-states.demo/load {:n 4}] {:frame f})
     (is       (machine-has-tag?    f :data/some))
     (is (=    :some        (render-model f)))))
 
 (defn test-state-6-too-many []
-  (with-frame [f (new-frame)]
+  (with-new-frame [f (new-frame)]
     (rf/dispatch-sync [:nine-states.demo/load {:n 25}] {:frame f})
     (is       (machine-has-tag?    f :data/too-many))
     (is (=    :too-many    (render-model f)))))
 
 (defn test-state-7-incorrect []
-  (with-frame [f (new-frame)]
+  (with-new-frame [f (new-frame)]
     (rf/dispatch-sync [:new-todo/edit-field :title "ab"] {:frame f})
     (rf/dispatch-sync [:new-todo/submit] {:frame f})
     (is       (machine-has-tag?    f :form/invalid))
     (is (=    :incorrect   (render-model f)))))
 
 (defn test-state-8-correct []
-  (with-frame [f (new-frame)]
+  (with-new-frame [f (new-frame)]
     (rf/dispatch-sync [:nine-states.demo/load {:n 0}] {:frame f})
     (rf/dispatch-sync [:new-todo/edit-field :title "Buy milk"] {:frame f})
     (rf/dispatch-sync [:new-todo/submit] {:frame f})
@@ -95,7 +95,7 @@
     (is (=    :correct     (render-model f)))))
 
 (defn test-state-9-done []
-  (with-frame [f (new-frame)]
+  (with-new-frame [f (new-frame)]
     (rf/dispatch-sync [:nine-states.demo/load {:n 4}] {:frame f})
     (rf/dispatch-sync [:ui/nine-states [:archive {:now 1}]] {:frame f})
     (let [snap (get-in (rf/get-frame-db f) [:rf/machines :ui/nine-states])]

--- a/examples/reagent/realworld/test/realworld/article_editor_test.cljs
+++ b/examples/reagent/realworld/test/realworld/article_editor_test.cljs
@@ -6,7 +6,7 @@
   (:require [re-frame.core :as rf]
             [realworld.article-editor]
             [realworld.test-helpers :as th])
-  (:require-macros [re-frame.core :refer [with-frame]]))
+  (:require-macros [re-frame.core :refer [with-new-frame]]))
 
 (defn editor-create-test []
   (th/reg-canned-success! :realworld.test/canned-editor-save
@@ -21,7 +21,7 @@
                                      :favoritesCount 0
                                      :author {:username "alice" :bio nil :image nil :following false}}})
 
-  (with-frame [f (rf/make-frame {:on-create [:app/initialise]
+  (with-new-frame [f (rf/make-frame {:on-create [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-editor-save}})]
     (rf/dispatch-sync [:editor/initialise] {:frame f})
     ;; The :mode region starts at :create; the :lifecycle region starts
@@ -44,7 +44,7 @@
     (assert (false? (rf/compute-sub [:editor/dirty?] (rf/get-frame-db f))))))
 
 (defn editor-can-leave-test []
-  (with-frame [f (rf/make-frame {:on-create [:app/initialise]})]
+  (with-new-frame [f (rf/make-frame {:on-create [:app/initialise]})]
     (rf/dispatch-sync [:editor/initialise] {:frame f})
     (assert (true? (rf/compute-sub [:editor/can-leave?] (rf/get-frame-db f))))
     (rf/dispatch-sync [:editor/edit-field :title "Changed"] {:frame f})

--- a/examples/reagent/realworld/test/realworld/articles_test.cljs
+++ b/examples/reagent/realworld/test/realworld/articles_test.cljs
@@ -5,7 +5,7 @@
   (:require [re-frame.core :as rf]
             [realworld.articles]
             [realworld.test-helpers :as th])
-  (:require-macros [re-frame.core :refer [with-frame]]))
+  (:require-macros [re-frame.core :refer [with-new-frame]]))
 
 (defn articles-load-test []
   (th/reg-canned-success! :realworld.test/canned-articles
@@ -22,7 +22,7 @@
                                                 :following false}}]
                            :articlesCount 1})
 
-  (with-frame [f (rf/make-frame {:on-create [:app/initialise]
+  (with-new-frame [f (rf/make-frame {:on-create [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-articles}})]
     (assert (= :idle (:status (rf/compute-sub [:articles] (rf/get-frame-db f)))))
     (rf/dispatch-sync [:articles/load] {:frame f})
@@ -41,7 +41,7 @@
                           {:status 500
                            :body   "server error"})
 
-  (with-frame [f (rf/make-frame {:on-create [:app/initialise]
+  (with-new-frame [f (rf/make-frame {:on-create [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-articles-failure}})]
     (rf/dispatch-sync [:articles/load] {:frame f})
     (assert (= :error (:status (rf/compute-sub [:articles] (rf/get-frame-db f)))))

--- a/examples/reagent/realworld/test/realworld/auth_test.cljs
+++ b/examples/reagent/realworld/test/realworld/auth_test.cljs
@@ -12,7 +12,7 @@
             [re-frame.registrar :as registrar]
             [realworld.auth]
             [realworld.test-helpers :as th])
-  (:require-macros [re-frame.core :refer [with-frame]]))
+  (:require-macros [re-frame.core :refer [with-new-frame]]))
 
 (defn login-happy-path-test []
   (th/reg-canned-success! :realworld.test/login-success
@@ -22,7 +22,7 @@
                                   :bio      nil
                                   :image    nil}})
 
-  (with-frame [f (rf/make-frame {:on-create    [:auth/initialise]
+  (with-new-frame [f (rf/make-frame {:on-create    [:auth/initialise]
                                  :fx-overrides {:rf.http/managed      :realworld.test/login-success
                                                 :auth.session/persist :rf/no-op}})]
     (assert (= :idle (rf/compute-sub [:auth/state] (rf/get-frame-db f))))
@@ -62,7 +62,7 @@
                           {:status 422
                            :body   {:errors {:body ["email or password is invalid"]}}})
 
-  (with-frame [f (rf/make-frame {:on-create    [:auth/initialise]
+  (with-new-frame [f (rf/make-frame {:on-create    [:auth/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/login-failure}})]
     (rf/dispatch-sync [:auth/flow [:auth/login {:email "x@y.z" :password "wrong"}]]
                       {:frame f})

--- a/examples/reagent/realworld/test/realworld/comments_test.cljs
+++ b/examples/reagent/realworld/test/realworld/comments_test.cljs
@@ -12,7 +12,7 @@
             [re-frame.core :as rf]
             [realworld.comments]
             [realworld.test-helpers :as th])
-  (:require-macros [re-frame.core :refer [with-frame]]))
+  (:require-macros [re-frame.core :refer [with-new-frame]]))
 
 (defn comments-load-test []
   ;; URL-routed stub: the article-detail page issues two requests
@@ -40,7 +40,7 @@
                                                 :favoritesCount 0
                                                 :author {:username "alice" :bio nil :image nil :following false}}})))
 
-  (with-frame [f (rf/make-frame {:on-create [:app/initialise]
+  (with-new-frame [f (rf/make-frame {:on-create [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-article-and-comments}})]
     (rf/dispatch-sync [:article/initialise] {:frame f})
     (rf/dispatch-sync [:comments/initialise] {:frame f})
@@ -79,7 +79,7 @@
                                                 :favoritesCount 0
                                                 :author {:username "alice" :bio nil :image nil :following false}}})))
 
-  (with-frame [f (rf/make-frame {:on-create [:app/initialise]
+  (with-new-frame [f (rf/make-frame {:on-create [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-comment-post}})]
     (rf/dispatch-sync [:article/initialise] {:frame f})
     (rf/dispatch-sync [:comments/initialise] {:frame f})

--- a/examples/reagent/realworld/test/realworld/core_test.cljs
+++ b/examples/reagent/realworld/test/realworld/core_test.cljs
@@ -10,7 +10,7 @@
   (:require [re-frame.core :as rf]
             [realworld.core]
             [realworld.test-helpers :as th])
-  (:require-macros [re-frame.core :refer [with-frame]]))
+  (:require-macros [re-frame.core :refer [with-new-frame]]))
 
 ;; A generic success stub: every :rf.http/managed call resolves :success
 ;; with an empty map. Tests register a richer canned response when they
@@ -18,7 +18,7 @@
 (th/reg-canned-success! :realworld.test/canned-success-empty {})
 
 (defn app-smoke-test []
-  (with-frame [f (rf/make-frame {:on-create    [:app/initialise]
+  (with-new-frame [f (rf/make-frame {:on-create    [:app/initialise]
                                  :fx-overrides {:rf.http/managed      :realworld.test/canned-success-empty
                                                 :auth.session/persist :rf/no-op}})]
     ;; After init: auth + articles slices and the :realworld/tags

--- a/examples/reagent/realworld/test/realworld/favorites_test.cljs
+++ b/examples/reagent/realworld/test/realworld/favorites_test.cljs
@@ -5,7 +5,7 @@
   (:require [re-frame.core :as rf]
             [realworld.favorites]
             [realworld.test-helpers :as th])
-  (:require-macros [re-frame.core :refer [with-frame]]))
+  (:require-macros [re-frame.core :refer [with-new-frame]]))
 
 (defn favorite-toggle-test []
   (th/reg-canned-failure! :realworld.test/favorite-rollback
@@ -13,7 +13,7 @@
                           {:status 400
                            :body   {:errors {:body ["rollback"]}}})
 
-  (with-frame [f (rf/make-frame {:on-create [:app/initialise]
+  (with-new-frame [f (rf/make-frame {:on-create [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/favorite-rollback}})]
     (rf/dispatch-sync [:articles/initialise] {:frame f})
     (rf/dispatch-sync [:articles/loaded

--- a/examples/reagent/realworld/test/realworld/profile_test.cljs
+++ b/examples/reagent/realworld/test/realworld/profile_test.cljs
@@ -6,7 +6,7 @@
             [re-frame.core :as rf]
             [realworld.profile]
             [realworld.test-helpers :as th])
-  (:require-macros [re-frame.core :refer [with-frame]]))
+  (:require-macros [re-frame.core :refer [with-new-frame]]))
 
 (defn profile-load-test []
   (th/reg-canned-success-by-url! :realworld.test/canned-profile
@@ -24,7 +24,7 @@
                                                   :favoritesCount 0
                                                   :author {:username "eve" :bio nil :image nil :following false}}]})))
 
-  (with-frame [f (rf/make-frame {:on-create [:app/initialise]
+  (with-new-frame [f (rf/make-frame {:on-create [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-profile}})]
     (rf/dispatch-sync [:profile/initialise] {:frame f})
     (rf/dispatch-sync [:rf.route/handle-url-change "/profile/eve"] {:frame f})

--- a/examples/reagent/realworld/test/realworld/routing_test.cljs
+++ b/examples/reagent/realworld/test/realworld/routing_test.cljs
@@ -4,10 +4,10 @@
    (Spec 012 §Redirects and guards)."
   (:require [re-frame.core :as rf]
             [realworld.routing :as routing])
-  (:require-macros [re-frame.core :refer [with-frame]]))
+  (:require-macros [re-frame.core :refer [with-new-frame]]))
 
 (defn routing-tests []
-  (with-frame [f (rf/make-frame {:on-create [:app/initialise]})]
+  (with-new-frame [f (rf/make-frame {:on-create [:app/initialise]})]
     (rf/dispatch-sync [:rf.route/navigate :realworld.article/show {:slug "hello"}] {:frame f})
     (assert (= :realworld.article/show (rf/compute-sub [:rf.route/id] (rf/get-frame-db f))))
     (assert (= "hello" (:slug (rf/compute-sub [:rf.route/params] (rf/get-frame-db f)))))
@@ -29,7 +29,7 @@
   ;; guards) wired into the demo frame via `reg-frame :interceptors`
   ;; (core.cljs). Configure the test frame with the same interceptor so
   ;; the guard is exercised end-to-end.
-  (with-frame [f (rf/make-frame {:on-create    [:app/initialise]
+  (with-new-frame [f (rf/make-frame {:on-create    [:app/initialise]
                                  :interceptors [routing/auth-guard]})]
     ;; Unauthenticated: navigating to a :requires-auth route
     ;; (:realworld.user/settings) is redirected to :realworld.auth/login.

--- a/examples/reagent/realworld/test/realworld/settings_test.cljs
+++ b/examples/reagent/realworld/test/realworld/settings_test.cljs
@@ -14,7 +14,7 @@
   (:require [re-frame.core :as rf]
             [realworld.settings]
             [realworld.test-helpers :as th])
-  (:require-macros [re-frame.core :refer [with-frame]]))
+  (:require-macros [re-frame.core :refer [with-new-frame]]))
 
 (defn- snapshot [db]
   (get-in db [:rf/machines :settings/form]))
@@ -44,7 +44,7 @@
                                   :bio "New bio"
                                   :image nil}})
 
-  (with-frame [f (rf/make-frame {:on-create    [:app/initialise]
+  (with-new-frame [f (rf/make-frame {:on-create    [:app/initialise]
                                  :fx-overrides {:rf.http/managed    :realworld.test/canned-settings-save
                                                 :auth.session/persist :rf/no-op}})]
     ;; After :app/initialise → :settings/initialise → [:reset], the
@@ -107,7 +107,7 @@
   (th/reg-canned-failure! :realworld.test/canned-settings-failure
                           :rf.http/http-5xx
                           {:status 500 :body "server error"})
-  (with-frame [f (rf/make-frame {:on-create    [:app/initialise]
+  (with-new-frame [f (rf/make-frame {:on-create    [:app/initialise]
                                  :fx-overrides {:rf.http/managed    :realworld.test/canned-settings-failure
                                                 :auth.session/persist :rf/no-op}})]
     (rf/dispatch-sync [:auth/store-session {:email "alice@example.com"
@@ -138,7 +138,7 @@
   ;; validate inside :settings/submit would dispatch :submit-invalid
   ;; when the draft failed validation, matching Pattern-Forms'
   ;; §Standard events table.
-  (with-frame [f (rf/make-frame {:on-create [:app/initialise]
+  (with-new-frame [f (rf/make-frame {:on-create [:app/initialise]
                                  :fx-overrides {:auth.session/persist :rf/no-op}})]
     (rf/dispatch-sync [:auth/store-session {:email "alice@example.com"
                                             :token "jwt-1"

--- a/examples/reagent/realworld/test/realworld/tags_test.cljs
+++ b/examples/reagent/realworld/test/realworld/tags_test.cljs
@@ -11,10 +11,10 @@
   (:require [re-frame.core :as rf]
             [realworld.tags]
             [realworld.test-helpers :as th])
-  (:require-macros [re-frame.core :refer [with-frame]]))
+  (:require-macros [re-frame.core :refer [with-new-frame]]))
 
 (defn tag-query-test []
-  (with-frame [f (rf/make-frame {:on-create [:app/initialise]})]
+  (with-new-frame [f (rf/make-frame {:on-create [:app/initialise]})]
     (rf/dispatch-sync [:tags/apply-filter "clojure"] {:frame f})
     (assert (= "clojure" (:tag (rf/compute-sub [:rf.route/query] (rf/get-frame-db f)))))
     (rf/dispatch-sync [:home/show-your-feed] {:frame f})
@@ -43,7 +43,7 @@
   ;;     :loading? (a derived boolean sub)       (machine-has-tag? :tags/loading)
   (th/reg-canned-success! :realworld.test/canned-tags
                           {:tags ["intro" "demo" "clojure"]})
-  (with-frame [f (rf/make-frame {:on-create    [:app/initialise]
+  (with-new-frame [f (rf/make-frame {:on-create    [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-tags}})]
     ;; After :app/initialise → :tags/initialise → [:reset], the machine
     ;; sits at :idle with empty :data.
@@ -95,7 +95,7 @@
   (th/reg-canned-failure! :realworld.test/canned-tags-failure
                           :rf.http/http-5xx
                           {:status 500 :body "server error"})
-  (with-frame [f (rf/make-frame {:on-create    [:app/initialise]
+  (with-new-frame [f (rf/make-frame {:on-create    [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-tags-failure}})]
     (rf/dispatch-sync [:tags/load] {:frame f})
     (let [db   (rf/get-frame-db f)

--- a/examples/reagent/websocket/test/websocket/connection_test.cljs
+++ b/examples/reagent/websocket/test/websocket/connection_test.cljs
@@ -33,7 +33,7 @@
             [websocket.core]
             [websocket.messages :as messages]
             [websocket.connection])
-  (:require-macros [re-frame.core :refer [with-frame]]))
+  (:require-macros [re-frame.core :refer [with-new-frame]]))
 
 ;; ============================================================================
 ;; HELPERS
@@ -79,7 +79,7 @@
 ;; ============================================================================
 
 (defn initial-state-test []
-  (with-frame [f (new-frame)]
+  (with-new-frame [f (new-frame)]
     (rf/dispatch-sync [:ws/connection [:ws/noop]] {:frame f})
     (let [s (snapshot (rf/get-frame-db f))]
       (assert (= :disconnected (:state s))
@@ -93,7 +93,7 @@
 (defn connect-happy-path-test []
   (with-sync-mock!
     (fn []
-      (with-frame [f (new-frame)]
+      (with-new-frame [f (new-frame)]
         (rf/dispatch-sync [:ws/connection
                            [:ws/connect {:url "ws://mock"
                                          :auth-token "demo"}]]
@@ -116,7 +116,7 @@
 (defn offline-queue-test []
   (with-sync-mock!
     (fn []
-      (with-frame [f (new-frame)]
+      (with-new-frame [f (new-frame)]
         ;; Enqueue two messages while :disconnected.
         (rf/dispatch-sync [:ws/connection
                            [:ws/send {:type :note :body "A"}]]
@@ -145,7 +145,7 @@
 (defn reconnect-cascade-test []
   (with-sync-mock!
     (fn []
-      (with-frame [f (new-frame)]
+      (with-new-frame [f (new-frame)]
         ;; Connect, then drop.
         (rf/dispatch-sync [:ws/connection
                            [:ws/connect {:url "ws://mock"
@@ -226,7 +226,7 @@
   ;; reconnect cascade.
   (with-sync-mock!
     (fn []
-      (with-frame [f (new-frame)]
+      (with-new-frame [f (new-frame)]
         ;; Connect to spawn the actor.
         (rf/dispatch-sync [:ws/connection
                            [:ws/connect {:url "ws://mock"
@@ -257,7 +257,7 @@
 (defn connection-epoch-staleness-test []
   (with-sync-mock!
     (fn []
-      (with-frame [f (new-frame)]
+      (with-new-frame [f (new-frame)]
         (rf/dispatch-sync [:ws/connection
                            [:ws/connect {:url "ws://mock"
                                          :auth-token "demo"}]]
@@ -294,7 +294,7 @@
   ;; :spawn :data fn reads the refreshed token.
   (with-sync-mock!
     (fn []
-      (with-frame [f (new-frame)]
+      (with-new-frame [f (new-frame)]
         (rf/dispatch-sync [:ws/connection
                            [:ws/connect {:url "ws://mock"
                                          :auth-token "old-token"}]]
@@ -311,7 +311,7 @@
 (defn disconnect-cleanly-test []
   (with-sync-mock!
     (fn []
-      (with-frame [f (new-frame)]
+      (with-new-frame [f (new-frame)]
         (rf/dispatch-sync [:ws/connection
                            [:ws/connect {:url "ws://mock"
                                          :auth-token "demo"}]]

--- a/examples/reagent/websocket/test/websocket/messages_test.cljs
+++ b/examples/reagent/websocket/test/websocket/messages_test.cljs
@@ -17,7 +17,7 @@
             [websocket.core]
             [websocket.messages :as messages]
             [websocket.connection])
-  (:require-macros [re-frame.core :refer [with-frame]]))
+  (:require-macros [re-frame.core :refer [with-new-frame]]))
 
 (defn- snapshot [db]
   (get-in db [:rf/machines :ws/connection]))
@@ -36,7 +36,7 @@
 (defn request-reply-correlation-test []
   (with-sync-mock!
     (fn []
-      (with-frame [f (new-frame)]
+      (with-new-frame [f (new-frame)]
         (rf/dispatch-sync [:ws/connection
                            [:ws/connect {:url "ws://mock"
                                          :auth-token "demo"}]]
@@ -60,7 +60,7 @@
 (defn server-push-test []
   (with-sync-mock!
     (fn []
-      (with-frame [f (new-frame)]
+      (with-new-frame [f (new-frame)]
         (rf/dispatch-sync [:ws/connection
                            [:ws/connect {:url "ws://mock"
                                          :auth-token "demo"}]]
@@ -78,7 +78,7 @@
 (defn subscription-tracking-test []
   (with-sync-mock!
     (fn []
-      (with-frame [f (new-frame)]
+      (with-new-frame [f (new-frame)]
         (rf/dispatch-sync [:ws/connection
                            [:ws/connect {:url "ws://mock"
                                          :auth-token "demo"}]]
@@ -100,7 +100,7 @@
 (defn handle-message-newest-first-test []
   ;; :ws/handle-message is the dispatch :ws/received uses for pushed
   ;; bodies. The slice keeps them newest-first.
-  (with-frame [f (new-frame)]
+  (with-new-frame [f (new-frame)]
     (rf/dispatch-sync [:ws/handle-message {:type :push :n 1}] {:frame f})
     (rf/dispatch-sync [:ws/handle-message {:type :push :n 2}] {:frame f})
     (rf/dispatch-sync [:ws/handle-message {:type :push :n 3}] {:frame f})

--- a/implementation/adapters/reagent/test/re_frame/runtime_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/runtime_cljs_test.cljs
@@ -31,7 +31,8 @@
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.test-support :as test-support]
             [re-frame.views])
-  (:require-macros [re-frame.core :refer [with-frame bound-fn reg-view]]))
+  (:require-macros [re-frame.core :refer [with-frame with-new-frame
+                                          bound-fn reg-view]]))
 
 ;; Snapshot/restore the registrar around each test (rf2-am9d). Wiping the
 ;; registrar with clear-all! is hostile to CLJS test isolation: framework
@@ -69,8 +70,8 @@
   (testing "with-frame :foo binds *current-frame* in the body"
     (with-frame :left
       (is (= :left (rf/current-frame))))
-    (testing "and the [sym expr] form binds the symbol AND the dynamic var"
-      (with-frame [f :right]
+    (testing "with-new-frame [sym expr] binds the symbol AND the dynamic var"
+      (with-new-frame [f :right]
         (is (= :right f))
         (is (= :right (rf/current-frame))))))
   (testing "outside any binding the dynamic var falls back to :rf/default"

--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -86,7 +86,8 @@
                                     reg-http-interceptor
                                     reg-view reg-machine
                                     dispatch dispatch-sync subscribe inject-cofx
-                                    with-frame bound-fn with-fx-overrides
+                                    with-frame with-new-frame bound-fn
+                                    with-fx-overrides
                                     with-managed-request-stubs]])))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -769,15 +770,43 @@
 
 #?(:clj
    (defmacro with-frame
-     "Run `body` with `*current-frame*` bound to the given frame-id.
-     Two shapes — first arg is the discriminator:
-       (with-frame :keyword body+)        pin to an existing frame-id;
-       (with-frame [sym expr] body+)      eval expr, bind, run, destroy.
-     For async closures after body returns, capture via `bound-fn` /
-     `dispatcher` / `subscriber`. Per Spec 002 §with-frame."
-     {:arglists '([frame-id body+] [[sym expr] body+])}
+     "Pin `*current-frame*` to an existing frame-id for `body`'s
+     lexical scope. The pin form:
+
+       (with-frame :existing-frame-id body+)
+
+     The frame is **not** created or destroyed by this macro — use
+     `with-new-frame` when you want eval-bind-run-destroy. Throws at
+     compile time on a vector argument.
+
+     For async closures that fire after body returns, capture via
+     `bound-fn` / `frame-bound-fn` / `dispatcher` / `subscriber`. Per
+     Spec 002 §with-frame."
+     {:arglists '([frame-id body+])}
+     [frame-id & body]
+     (rvm/expand-with-frame frame-id body)))
+
+#?(:clj
+   (defmacro with-new-frame
+     "Eval `expr`, bind the resulting frame-id to `sym`, run `body`
+     with `*current-frame*` bound to that id, and destroy the frame on
+     exit (success or exception). The eval-bind-run-destroy form:
+
+       (with-new-frame [sym (rf/make-frame opts)] body+)
+
+     `expr` may be `(rf/make-frame opts)`, `(rf/reg-frame :id opts)`
+     (returns the keyword), or any expression yielding a frame-id;
+     whatever is bound is destroyed on body exit. Throws at compile
+     time on a keyword argument — use `with-frame` to pin to an
+     existing frame-id.
+
+     For async closures that fire after body returns, capture via
+     `bound-fn` / `frame-bound-fn` — the body's dynamic binding has
+     unwound and `destroy-frame!` has already run by then. Per Spec 002
+     §with-frame."
+     {:arglists '([[sym expr] body+])}
      [bindings & body]
-     (rvm/expand-with-frame bindings body)))
+     (rvm/expand-with-new-frame bindings body)))
 
 #?(:clj
    (defmacro bound-fn

--- a/implementation/core/src/re_frame/core_reg_view_macro.cljc
+++ b/implementation/core/src/re_frame/core_reg_view_macro.cljc
@@ -145,12 +145,46 @@
 
 ;; ---- frame-scope lexical-binding macro expansions ------------------------
 ;;
-;; `with-frame` discriminates on first-arg shape: a 2-element vector
-;; `[sym expr]` triggers Shape 2 (eval, bind, run, destroy); anything
-;; else is Shape 1 (bind an existing frame-id). Per Spec 002 §with-frame.
+;; `with-frame` and `with-new-frame` are two separate macros with
+;; non-overlapping shapes:
+;;
+;;   `with-frame`     — pin to an existing frame-id:
+;;                      `(with-frame :keyword body+)`.
+;;                      Rejects vector argument at compile time.
+;;
+;;   `with-new-frame` — eval an expression, bind a local symbol, run
+;;                      the body in the new frame, destroy on exit:
+;;                      `(with-new-frame [sym expr] body+)`.
+;;                      Rejects keyword argument at compile time.
+;;
+;; Per Spec 002 §with-frame.
 
 #?(:clj
    (defn expand-with-frame
+     "Expansion for `with-frame` — pin form only. Rejects a vector
+     argument with `:rf.error/with-frame-vector-form` (the caller meant
+     `with-new-frame`)."
+     [frame-id body]
+     (cond
+       (vector? frame-id)
+       (throw (ex-info
+                ":rf.error/with-frame-vector-form"
+                {:rf.error/id :rf.error/with-frame-vector-form
+                 :where       'rf/with-frame
+                 :recovery    :use-with-new-frame
+                 :reason      (str "with-frame pins to an existing frame-id (keyword). "
+                                   "Got a vector — did you mean `with-new-frame`, "
+                                   "which evals, binds, runs, and destroys?")
+                 :got         frame-id}))
+
+       :else
+       `(binding [re-frame.frame/*current-frame* ~frame-id]
+          ~@body))))
+
+#?(:clj
+   (defn expand-with-new-frame
+     "Expansion for `with-new-frame` — eval/destroy form only. Rejects
+     anything other than a 2-element vector binding."
      [bindings body]
      (cond
        (and (vector? bindings) (= 2 (count bindings)))
@@ -162,27 +196,42 @@
               (finally
                 (re-frame.frame/destroy-frame! ~sym)))))
 
-       ;; Shape 2 disambiguator: a vector that is NOT 2-element is
-       ;; almost certainly a typo of the binding form (e.g. `[]` or
-       ;; `[f x y]`). Reject at compile time per Spec 002 §with-frame —
-       ;; falling through to Shape 1 would silently bind
-       ;; `*current-frame*` to a vector value, producing a confusing
-       ;; runtime error far from the call site.
+       ;; Common mistake: passed a keyword instead of `[sym expr]`. The
+       ;; caller meant `with-frame` (pin form). Reject loudly.
+       (keyword? bindings)
+       (throw (ex-info
+                ":rf.error/with-new-frame-keyword-form"
+                {:rf.error/id :rf.error/with-new-frame-keyword-form
+                 :where       'rf/with-new-frame
+                 :recovery    :use-with-frame
+                 :reason      (str "with-new-frame evals, binds, runs, and destroys. "
+                                   "Got a keyword — did you mean `with-frame`, "
+                                   "which pins to an existing frame-id?")
+                 :got         bindings}))
+
+       ;; Vector but wrong arity — almost certainly a typo of the
+       ;; binding form (e.g. `[]` or `[f x y]`). Reject at compile time —
+       ;; per Spec 002 §with-frame.
        (vector? bindings)
        (throw (ex-info
-                ":rf.error/with-frame-bad-binding"
-                {:rf.error/id :rf.error/with-frame-bad-binding
-                 :where       'rf/with-frame
+                ":rf.error/with-new-frame-bad-binding"
+                {:rf.error/id :rf.error/with-new-frame-bad-binding
+                 :where       'rf/with-new-frame
                  :recovery    :fix-registration
-                 :reason      (str "with-frame's vector binding must be [sym expr] (Shape 2). "
+                 :reason      (str "with-new-frame's binding must be [sym expr]. "
                                    "Got " (count bindings) " element"
                                    (when-not (= 1 (count bindings)) "s") ".")
                  :got         bindings
                  :count       (count bindings)}))
 
        :else
-       `(binding [re-frame.frame/*current-frame* ~bindings]
-          ~@body))))
+       (throw (ex-info
+                ":rf.error/with-new-frame-bad-binding"
+                {:rf.error/id :rf.error/with-new-frame-bad-binding
+                 :where       'rf/with-new-frame
+                 :recovery    :fix-registration
+                 :reason      "with-new-frame's binding must be a 2-element vector [sym expr]."
+                 :got         bindings})))))
 
 #?(:clj
    (defn expand-bound-fn

--- a/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
+++ b/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
@@ -102,7 +102,7 @@
             [re-frame.adapter.context :as adapter-context]
             [re-frame.substrate.adapter :as substrate-adapter]
             [re-frame.trace.tooling :as trace-tooling])
-  (:require-macros [re-frame.core :refer [with-frame bound-fn]]))
+  (:require-macros [re-frame.core :refer [with-frame with-new-frame bound-fn]]))
 
 ;; ===========================================================================
 ;; helpers
@@ -962,8 +962,8 @@
   (testing (str name " — with-frame binds *current-frame*")
     (with-frame :left
       (is (= :left (rf/current-frame))))
-    (testing "and the [sym expr] form binds the symbol AND the dynamic var"
-      (with-frame [f :right]
+    (testing "with-new-frame [sym expr] binds the symbol AND the dynamic var"
+      (with-new-frame [f :right]
         (is (= :right f))
         (is (= :right (rf/current-frame)))))
     (testing "outside any binding the dynamic var falls back to :rf/default"

--- a/implementation/core/test/re_frame/core_api_additions_test.clj
+++ b/implementation/core/test/re_frame/core_api_additions_test.clj
@@ -2,9 +2,9 @@
   "JVM tests for three core-API additions landed together
    (rf2-7whh / rf2-ewku / rf2-t38q):
 
-   - `rf/with-frame` macro form (replacing the fn form). Two shapes:
-     bare-keyword (Shape 1) and let-binding (Shape 2). Per Spec 002
-     §with-frame and `spec/API.md` row 74.
+   - `rf/with-frame` (pin form) and `rf/with-new-frame` (eval-bind-
+     run-destroy form). Per Spec 002 §with-frame and `spec/API.md`
+     row 74. Split per rf2-twoc5 (Mike-approved 2026-05-28).
 
    - `(rf/registrations kind pred-fn)` 2-arity filter. Per `spec/API.md`
      row 304 and Spec 001 §Public registrar query API.
@@ -37,10 +37,10 @@
 (use-fixtures :each reset-runtime)
 
 ;; ===========================================================================
-;; rf2-7whh — with-frame macro form
+;; rf2-7whh / rf2-twoc5 — with-frame (pin) + with-new-frame (eval/destroy)
 ;; ===========================================================================
 
-(deftest with-frame-shape-1-bare-keyword
+(deftest with-frame-bare-keyword
   (testing "(with-frame :keyword body) binds *current-frame* across body"
     (rf/reg-frame :wf/alpha {:doc "alpha"})
     (is (= :rf/default (rf/current-frame))
@@ -51,7 +51,7 @@
     (is (= :rf/default (rf/current-frame))
         "after the macro returns: dynamic binding unwinds")))
 
-(deftest with-frame-shape-1-multi-form-body
+(deftest with-frame-multi-form-body
   (testing "(with-frame :keyword expr1 expr2 ...) evaluates all body forms,
             returns the last"
     (rf/reg-frame :wf/beta {:doc "beta"})
@@ -65,7 +65,7 @@
       (is (= :wf/beta result)
           "the last form's value is returned"))))
 
-(deftest with-frame-shape-1-subscriber-captures-frame
+(deftest with-frame-subscriber-captures-frame
   (testing "subscriber called inside (with-frame :k ...) captures :k"
     (rf/reg-frame :wf/left  {:doc "left"})
     (rf/reg-frame :wf/right {:doc "right"})
@@ -78,11 +78,11 @@
       (is (= 7  @(sl [:wf/n])) ":wf/left subscriber sees :wf/left's :n")
       (is (= 99 @(sr [:wf/n])) ":wf/right subscriber sees :wf/right's :n"))))
 
-(deftest with-frame-shape-2-let-binding-create-use-destroy
-  (testing "(with-frame [f (make-frame opts)] body) creates, binds, destroys"
+(deftest with-new-frame-let-binding-create-use-destroy
+  (testing "(with-new-frame [f (make-frame opts)] body) creates, binds, destroys"
     (let [captured-id (atom nil)
           observed-current (atom nil)]
-      (rf/with-frame [f (rf/make-frame {:doc "ephemeral"})]
+      (rf/with-new-frame [f (rf/make-frame {:doc "ephemeral"})]
         (reset! captured-id f)
         (reset! observed-current (rf/current-frame))
         (is (= f (rf/current-frame))
@@ -98,11 +98,11 @@
       (is (= :rf/default (rf/current-frame))
           "*current-frame* reverted after the body"))))
 
-(deftest with-frame-shape-2-destroys-on-exception
-  (testing "(with-frame [f ...] body) destroys the frame even when body throws"
+(deftest with-new-frame-destroys-on-exception
+  (testing "(with-new-frame [f ...] body) destroys the frame even when body throws"
     (let [captured-id (atom nil)]
       (try
-        (rf/with-frame [f (rf/make-frame {:doc "ephemeral-throw"})]
+        (rf/with-new-frame [f (rf/make-frame {:doc "ephemeral-throw"})]
           (reset! captured-id f)
           (throw (ex-info "boom" {:kind ::boom})))
         (catch Exception e
@@ -112,39 +112,74 @@
       (is (nil? (rf/frame-meta @captured-id))
           "the frame is destroyed even on exception"))))
 
-(deftest with-frame-shape-2-on-create-fires-and-state-is-readable
-  (testing "(with-frame [f (make-frame {:on-create [...]})] body) — on-create
-            fires before body, body sees the seeded state, destroy runs after"
+(deftest with-new-frame-on-create-fires-and-state-is-readable
+  (testing "(with-new-frame [f (make-frame {:on-create [...]})] body) —
+            on-create fires before body, body sees the seeded state,
+            destroy runs after"
     (rf/reg-event-db :wf/initialise (fn [_ _] {:counter 42}))
     (let [captured-db (atom nil)]
-      (rf/with-frame [f (rf/make-frame {:on-create [:wf/initialise]})]
+      (rf/with-new-frame [f (rf/make-frame {:on-create [:wf/initialise]})]
         (reset! captured-db (rf/get-frame-db f)))
       (is (= {:counter 42} @captured-db)
           "the body observed the on-create-seeded app-db"))))
 
-(deftest with-frame-rejects-vector-bindings-with-wrong-arity
-  (testing "(with-frame [...] body) with vector-but-not-2-count raises at compile time (rf2-4ymm0 CQ4)"
+(deftest with-frame-rejects-vector-argument
+  (testing "(with-frame [...] body) raises at compile time — caller meant with-new-frame (rf2-twoc5)"
     ;; `macroexpand` wraps macro-side ex-infos in a Compiler$CompilerException;
     ;; call the expansion helper directly so we observe the structured throw
-    ;; that fires at compile time when the user types `with-frame []`.
+    ;; that fires at compile time.
     (require 're-frame.core-reg-view-macro)
     (let [expand (resolve 're-frame.core-reg-view-macro/expand-with-frame)]
-      ;; Empty vector — easy typo of Shape 2 to omit both sides.
+      (let [e (try (expand '[f (make-frame {})] '((do nil))) nil
+                   (catch clojure.lang.ExceptionInfo e e))]
+        (is (some? e) "vector argument must throw")
+        (is (= :rf.error/with-frame-vector-form (:rf.error/id (ex-data e)))
+            ":rf.error/id is the canonical discriminator")
+        (is (= :use-with-new-frame (:recovery (ex-data e)))
+            ":recovery points the caller at with-new-frame")
+        (is (re-find #"did you mean `with-new-frame`"
+                     (:reason (ex-data e)))
+            ":reason names the sibling macro"))
+      (let [e (try (expand [] '((do nil))) nil
+                   (catch clojure.lang.ExceptionInfo e e))]
+        (is (some? e) "empty vector must throw")
+        (is (= :rf.error/with-frame-vector-form (:rf.error/id (ex-data e))))))))
+
+(deftest with-new-frame-rejects-keyword-argument
+  (testing "(with-new-frame :keyword body) raises at compile time — caller meant with-frame (rf2-twoc5)"
+    (require 're-frame.core-reg-view-macro)
+    (let [expand (resolve 're-frame.core-reg-view-macro/expand-with-new-frame)]
+      (let [e (try (expand :existing/id '((do nil))) nil
+                   (catch clojure.lang.ExceptionInfo e e))]
+        (is (some? e) "keyword argument must throw")
+        (is (= :rf.error/with-new-frame-keyword-form (:rf.error/id (ex-data e)))
+            ":rf.error/id is the canonical discriminator")
+        (is (= :use-with-frame (:recovery (ex-data e)))
+            ":recovery points the caller at with-frame")
+        (is (re-find #"did you mean `with-frame`"
+                     (:reason (ex-data e)))
+            ":reason names the sibling macro")))))
+
+(deftest with-new-frame-rejects-vector-bindings-with-wrong-arity
+  (testing "(with-new-frame [...] body) with wrong vector arity raises at compile time (rf2-4ymm0 CQ4)"
+    (require 're-frame.core-reg-view-macro)
+    (let [expand (resolve 're-frame.core-reg-view-macro/expand-with-new-frame)]
+      ;; Empty vector — easy typo to omit both sides.
       (let [e (try (expand [] '((do nil))) nil
                    (catch clojure.lang.ExceptionInfo e e))]
         (is (some? e) "[] must throw")
-        (is (= :rf.error/with-frame-bad-binding (:rf.error/id (ex-data e)))
+        (is (= :rf.error/with-new-frame-bad-binding (:rf.error/id (ex-data e)))
             ":rf.error/id is the canonical discriminator")
-        (is (re-find #"with-frame's vector binding must be \[sym expr\]"
+        (is (re-find #"binding must be \[sym expr\]"
                      (:reason (ex-data e)))
             ":reason carries the structured explanation"))
       ;; 3-element vector — typo of `[sym expr]` with extra tail.
       (let [e (try (expand '[f g h] '((do nil))) nil
                    (catch clojure.lang.ExceptionInfo e e))]
         (is (some? e) "[f g h] must throw")
-        (is (= :rf.error/with-frame-bad-binding (:rf.error/id (ex-data e)))
+        (is (= :rf.error/with-new-frame-bad-binding (:rf.error/id (ex-data e)))
             ":rf.error/id is the canonical discriminator")
-        (is (re-find #"with-frame's vector binding must be \[sym expr\]"
+        (is (re-find #"binding must be \[sym expr\]"
                      (:reason (ex-data e)))
             ":reason carries the structured explanation")))))
 

--- a/skills/re-frame-migration/references/guided-handlers-state.md
+++ b/skills/re-frame-migration/references/guided-handlers-state.md
@@ -149,7 +149,7 @@ If the author declines, document the warning in the report.
 **Decision shape**:
 
 1. **Author the `:on-create` event**. `(rf/reg-frame :rf/default {:on-create [:app/seed initial-state]})` plus the `[:app/seed initial]` event handler that writes the seed into `app-db`. (`:on-create` accepts a **single** event vector, not a vector of event vectors — per [`spec/002-Frames.md` §reg-frame metadata grammar](../../../spec/002-Frames.md). To fire multiple seed events, the single `:on-create` handler dispatches them via its `:fx` slot.)
-2. **Move the seed to test fixtures only** if the seed is test-specific. Seed the test frame the same way — via `:on-create` — never a top-level `app-db` poke: `(rf/with-frame [f (rf/make-frame {:on-create [:test/seed initial]})] ...)`.
+2. **Move the seed to test fixtures only** if the seed is test-specific. Seed the test frame the same way — via `:on-create` — never a top-level `app-db` poke: `(rf/with-new-frame [f (rf/make-frame {:on-create [:test/seed initial]})] ...)`.
 
 Present the seed value and the proposed rewrite; confirm with the author; apply both the M-1 require-removal and the M-15 `:on-create` rewrite together.
 

--- a/skills/re-frame2/references/cross-cutting/testing.md
+++ b/skills/re-frame2/references/cross-cutting/testing.md
@@ -74,7 +74,7 @@ Target a non-default frame with `{:frame :feature/frame-id}` in the trailing opt
   (rf/dispatch-sync [:counter/inc])
   (ts/assert-path-equals [:n] 1))
 
-(rf/with-frame [f :stories]      ;; bind a symbol AND the dynamic var
+(rf/with-new-frame [f :stories]      ;; bind a symbol AND the dynamic var
   (is (= :stories f))
   (is (= :stories (rf/current-frame))))
 ```
@@ -179,7 +179,7 @@ When a fixture didn't stash the tree, or you need the `:on-click`-fires-the-righ
 
 ```clojure
 (deftest counter-view-shows-and-fires
-  (rf/with-frame [f (rf/make-frame {:on-create [:counter/init]})]
+  (rf/with-new-frame [f (rf/make-frame {:on-create [:counter/init]})]
     (let [tree (counter-view {:n 0})
           btn  (h/find-by-testid tree "counter-inc")]
       (h/invoke-handler btn :on-click nil)              ;; fire the handler as the DOM would

--- a/skills/re-frame2/references/fundamentals/frames.md
+++ b/skills/re-frame2/references/fundamentals/frames.md
@@ -61,7 +61,7 @@ The verb-form names imply capture-at-call-time semantics; earlier `bound-dispatc
 Per-test isolated frame, from `examples/reagent/login/core.cljs`:
 
 ```clojure
-(with-frame [f (rf/make-frame
+(with-new-frame [f (rf/make-frame
                  {:fx-overrides {:rf.http/managed :auth.login/test-canned-success}})]
   (rf/dispatch-sync [:auth.login/flow [:auth.login/submit
                                        {:email "user@example.com"

--- a/spec/002-Frames.md
+++ b/spec/002-Frames.md
@@ -778,11 +778,11 @@ Always available, frame-keyword-targeted via the opts arg:
 
 These are also the right APIs from non-Reagent contexts (server-side, headless tests, agents). No `dispatch-to` / `subscribe-to` sugar functions exist — the two-arg form is the one mechanism. On the JVM, `subscribe` cannot return a deref-able reactive (no Reagent) — the headless equivalent for "compute a sub against an `app-db` value" is `compute-sub`, defined in [008-Testing §`compute-sub` algorithm](008-Testing.md#compute-sub-algorithm). JVM tests typically read `(rf/get-frame-db <id>)` and pass that into `(rf/compute-sub query-v db)`; `subscribe` on the JVM is supported only when the substrate adapter provides a value-shape implementation.
 
-### `with-frame`
+### `with-frame` and `with-new-frame`
 
-A helper macro for tests/REPL that establishes an implicit current frame for a block. It has **two shapes**:
+Two sibling macros for tests/REPL that establish an implicit current frame for a block. They are split per concern — the macro name telegraphs the intent (per rf2-twoc5, Mike-approved 2026-05-28).
 
-#### Shape 1 — bare keyword (operate on an existing frame)
+#### `with-frame` — pin to an existing frame
 
 ```clojure
 (rf/with-frame :scratch
@@ -792,32 +792,29 @@ A helper macro for tests/REPL that establishes an implicit current frame for a b
 
 Used when the frame already exists (registered via `reg-frame` or created earlier via `make-frame`). The macro binds the dynamic-frame var for the body's duration; plain `dispatch`/`subscribe` route to `:scratch` via the dynamic-binding tier of the resolution chain. The frame is **not** created or destroyed by the macro.
 
+`with-frame` rejects a vector argument at compile time (`:rf.error/with-frame-vector-form`) — pass a keyword (or a symbol that resolves to one). If you want eval-bind-run-destroy, reach for `with-new-frame`.
+
 Use case: REPL sessions, tests that share a fixture across multiple `deftest` blocks.
 
-#### Shape 2 — let-binding (create, use, destroy)
+#### `with-new-frame` — create, bind, use, destroy
 
 ```clojure
-(rf/with-frame [f (rf/make-frame {:on-create [:auth/init]})]
+(rf/with-new-frame [f (rf/make-frame {:on-create [:auth/init]})]
   (rf/dispatch-sync [:auth/login])
   (is (= :authenticated (get-in (rf/get-frame-db f) [:auth :state]))))
 ```
 
-Used when the frame's lifetime is exactly the body. The macro creates the frame from the given expression, binds the resulting frame keyword to the local symbol, runs the body in that frame's dynamic context, and **destroys** the frame on exit (success or exception).
+Used when the frame's lifetime is exactly the body. The macro evaluates `expr`, binds the resulting frame keyword to `sym`, runs the body in that frame's dynamic context, and **destroys** the frame on exit (success or exception).
 
 The expression may be `(make-frame opts)`, `(reg-frame :id opts)` (returns the keyword), or any expression returning a frame keyword. The macro destroys whatever was bound on exit.
 
+`with-new-frame` rejects a keyword argument at compile time (`:rf.error/with-new-frame-keyword-form`) — pass a `[sym expr]` vector. If you only want to pin to an existing frame-id, reach for `with-frame`.
+
 Use case: per-test fixtures, devcard widgets, REPL sessions where you want a guaranteed clean frame and guaranteed teardown.
 
-#### Discriminator
+#### Async work outliving `with-frame` / `with-new-frame`
 
-The macro inspects its first argument:
-
-- Keyword → Shape 1 (bare keyword form).
-- Vector `[sym expr]` → Shape 2 (let-binding form, with create-and-destroy).
-
-#### Async work outliving `with-frame`
-
-For async closures that fire after the body returns, capture the frame keyword explicitly via `bound-fn` (above) — the `with-frame` body's dynamic binding has unwound by then. Shape 2's `destroy-frame!` runs immediately on body exit; an outstanding async callback that fires after that will hit a destroyed frame.
+For async closures that fire after the body returns, capture the frame keyword explicitly via `bound-fn` (above) — the body's dynamic binding has unwound by then. `with-new-frame`'s `destroy-frame!` runs immediately on body exit; an outstanding async callback that fires after that will hit a destroyed frame.
 
 ### `dispatch-sync`
 

--- a/spec/005-StateMachines.md
+++ b/spec/005-StateMachines.md
@@ -2931,7 +2931,7 @@ The handler resolves its id from the inbound event vector's first element (`:dra
 ### Level 3 — registered in a test frame
 
 ```clojure
-(rf/with-frame [f (rf/make-frame {:on-create [:my/init]})]
+(rf/with-new-frame [f (rf/make-frame {:on-create [:my/init]})]
   (rf/reg-event-fx :my/editor {} (rf/make-machine-handler {...}))
   (rf/dispatch-sync [:my/editor [:event]] {:frame f})
   (assert ...))

--- a/spec/008-Testing.md
+++ b/spec/008-Testing.md
@@ -50,7 +50,7 @@ The plain-atom adapter (JVM, SSR, headless) does NOT ship `flush-views!` — the
 | Need | API |
 |---|---|
 | Per-test frame fixture | `(rf/make-frame opts)` / `(rf/destroy-frame! f)` |
-| Scoped REPL/test block | `(rf/with-frame :frame-id body...)` *or* `(rf/with-frame [sym expr] body...)` — see [§`with-frame` call shapes](#with-frame-call-shapes) |
+| Scoped REPL/test block | `(rf/with-frame :frame-id body...)` (pin) *or* `(rf/with-new-frame [sym expr] body...)` (eval-bind-run-destroy) — see [§`with-frame` and `with-new-frame`](#with-frame-and-with-new-frame) |
 | Synchronous test trigger | `(rf/dispatch-sync event)` or `(rf/dispatch-sync event opts)` |
 | Stub fx (per-call) | `(rf/dispatch-sync ev {:fx-overrides {:my-app/http stub-fn}})` |
 | Stub fx (per-frame) | `(rf/reg-frame :test-frame {:fx-overrides {…}})` |
@@ -65,11 +65,11 @@ The plain-atom adapter (JVM, SSR, headless) does NOT ship `flush-views!` — the
 | Test-flavoured helpers | `(ts/dispatch-sequence events)` — chained `dispatch-sync`; `(ts/assert-path-equals path expected)` — clojure.test-aware assertion mirroring the `:rf.assert/path-equals` event used inside Story `:play` blocks (see [007 §Play functions](007-Stories.md#play-functions)); `(ts/assert-db-equals expected-db)` — companion full-db form (no event analog). All three ship with `re-frame.test-support`. |
 | Single-frame e2e fixture | `(th/with-app-fixture {:install f :root-view v} :frame-id body...)` — create + bind frame, run `:install`, stash `:root-view`, destroy on exit. Pair with `(th/expect-text testid expected)` and `(th/wait-until pred-or-testid expected)` for the two-line single-frame test pattern. |
 
-### `with-frame` call shapes
+### `with-frame` and `with-new-frame`
 
-`with-frame` has **two canonical shapes**, both normative and both required of every host. The canonical definition lives in [002 §`with-frame`](002-Frames.md#with-frame); this section gathers the test-surface usage notes.
+Two sibling macros — split per concern, the macro name telegraphs the intent (rf2-twoc5, Mike-approved 2026-05-28). Both are normative and both required of every host. The canonical definition lives in [002 §`with-frame` and `with-new-frame`](002-Frames.md#with-frame-and-with-new-frame); this section gathers the test-surface usage notes.
 
-#### Shape 1 — bare keyword (operate on an existing frame)
+#### `with-frame` — pin to an existing frame
 
 ```clojure
 (rf/with-frame :scratch
@@ -77,30 +77,23 @@ The plain-atom adapter (JVM, SSR, headless) does NOT ship `flush-views!` — the
   @(rf/subscribe [:status]))
 ```
 
-Pins `*current-frame*` to the supplied frame id for the body's dynamic extent. The frame is **not** created or destroyed by the macro — the keyword is used as-is. Used when the frame already exists (registered via `reg-frame` or created earlier via `make-frame`), e.g. shared fixtures across multiple `deftest` blocks, REPL sessions.
+Pins `*current-frame*` to the supplied frame id for the body's dynamic extent. The frame is **not** created or destroyed by the macro — the keyword is used as-is. Used when the frame already exists (registered via `reg-frame` or created earlier via `make-frame`), e.g. shared fixtures across multiple `deftest` blocks, REPL sessions. Rejects a vector argument at compile time (`:rf.error/with-frame-vector-form`); use `with-new-frame` for eval-bind-run-destroy.
 
-#### Shape 2 — binding-vector (create, use, destroy)
+#### `with-new-frame` — create, use, destroy
 
 ```clojure
-(rf/with-frame [binding-sym expr] body...)
+(rf/with-new-frame [binding-sym expr] body...)
 ```
 
-Evaluates `expr` (typically `(rf/make-frame opts)`), binds the result to `binding-sym` (so the body can refer to it for `get-frame-db`, `dispatch-sync` opts, etc.), sets that frame as the implicit `*current-frame*` for the body's dynamic extent (so `dispatch-sync` and `subscribe` inside the body resolve to it without needing `{:frame ...}`), and on body exit (success or exception) calls `destroy-frame!` on whatever was bound. Modelled on `with-open`. Used when the frame's lifetime is exactly the body — per-test fixtures, devcard widgets, REPL sessions wanting guaranteed teardown.
+Evaluates `expr` (typically `(rf/make-frame opts)`), binds the result to `binding-sym` (so the body can refer to it for `get-frame-db`, `dispatch-sync` opts, etc.), sets that frame as the implicit `*current-frame*` for the body's dynamic extent (so `dispatch-sync` and `subscribe` inside the body resolve to it without needing `{:frame ...}`), and on body exit (success or exception) calls `destroy-frame!` on whatever was bound. Modelled on `with-open`. Used when the frame's lifetime is exactly the body — per-test fixtures, devcard widgets, REPL sessions wanting guaranteed teardown. Rejects a keyword argument at compile time (`:rf.error/with-new-frame-keyword-form`); use `with-frame` to pin.
 
-#### Discriminator
-
-The macro inspects its first argument:
-
-- Keyword → Shape 1.
-- Vector `[sym expr]` → Shape 2.
-
-Both shapes are part of the normative test surface; tests, fixtures, and helper macros MAY freely use either, and hosts MUST support both.
+Both macros are part of the normative test surface; tests, fixtures, and helper macros MAY freely use either, and hosts MUST support both.
 
 ### JVM-runnable boundary (authoritative)
 
 Every entry in the table above is JVM-runnable, with the exceptions listed below — this is the single authoritative statement of the test-surface's JVM/CLJS split, per [C2](000-Vision.md#c2-cross-platform-jvm-interop-preserved):
 
-- ✓ `make-frame` / `destroy-frame!` / `reset-frame!` / `with-frame`
+- ✓ `make-frame` / `destroy-frame!` / `reset-frame!` / `with-frame` / `with-new-frame`
 - ✓ `dispatch-sync` and the entire dispatch pipeline (router, drain, interceptors)
 - ✓ All `reg-event-*` handler invocation
 - ✓ Override application (`:fx-overrides`, `:interceptor-overrides`, `:interceptors`)
@@ -134,18 +127,18 @@ The most common shape. Each test creates a frame, runs assertions, tears down.
         (rf/destroy-frame! f)))))
 ```
 
-### Pattern 2 — `with-frame` for tighter blocks
+### Pattern 2 — `with-new-frame` for tighter blocks
 
-For tests that don't need explicit teardown logic, `with-frame` handles the lifecycle:
+For tests that don't need explicit teardown logic, `with-new-frame` handles the lifecycle:
 
 ```clojure
 (deftest auth-flow
-  (rf/with-frame [f (rf/make-frame {:on-create [:auth/init-idle]})]
-    (rf/dispatch-sync [:auth/login-pressed])         ;; uses :frame f via with-frame's binding
+  (rf/with-new-frame [f (rf/make-frame {:on-create [:auth/init-idle]})]
+    (rf/dispatch-sync [:auth/login-pressed])         ;; uses :frame f via the binding
     (is (= :validating (get-in (rf/get-frame-db f) [:auth :state])))))
 ```
 
-`with-frame` binds the frame for the body's duration, dispatch-syncs/subscribes inside the body resolve to that frame via the dynamic-var tier of the resolution chain, and the frame is destroyed on exit (success or exception).
+`with-new-frame` evaluates the bound expression, binds the frame for the body's duration, dispatch-syncs/subscribes inside the body resolve to that frame via the dynamic-var tier of the resolution chain, and the frame is destroyed on exit (success or exception).
 
 ### Pattern 3 — named fixture across many tests
 
@@ -215,7 +208,7 @@ The companion helpers:
 When NOT to use Pattern 5:
 
 - **Multi-frame setups** (Xray, Story, cross-frame tests) — Pattern 1 / 2 with explicit `rf/with-frame` calls each frame is clearer; the fixture stash is single-slot by design.
-- **Tests that don't render** — the install + frame lifecycle of Pattern 5 is overkill for pure-event tests. Reach for `(rf/with-frame [f (rf/make-frame opts)] ...)` and skip the view-stash entirely.
+- **Tests that don't render** — the install + frame lifecycle of Pattern 5 is overkill for pure-event tests. Reach for `(rf/with-new-frame [f (rf/make-frame opts)] ...)` and skip the view-stash entirely.
 
 ### HTTP test surfaces — single namespace
 
@@ -308,7 +301,7 @@ The recommended pattern is to drive `db` state via dispatches against a fixture 
                  (fn [db _] (filter #(= :pending (:status %)) (:items db))))
 
 (deftest pending-todos-sub
-  (rf/with-frame [f (rf/make-frame {})]
+  (rf/with-new-frame [f (rf/make-frame {})]
     (rf/dispatch-sync [:todos/add {:id 1 :status :pending}])
     (rf/dispatch-sync [:todos/add {:id 2 :status :done}])
     (rf/dispatch-sync [:todos/add {:id 3 :status :pending}])
@@ -428,7 +421,7 @@ Drive a click and assert state changed downstream:
 
 ```clojure
 (deftest counter-inc
-  (rf/with-frame [_ (rf/make-frame {:on-create [:counter/init]})]
+  (rf/with-new-frame [_ (rf/make-frame {:on-create [:counter/init]})]
     (let [tree (counter-view {})
           btn  (th/find-by-testid tree "counter-inc")]
       (th/invoke-handler btn :on-click)
@@ -439,7 +432,7 @@ Assert rendered text after dispatching:
 
 ```clojure
 (deftest counter-label
-  (rf/with-frame [f (rf/make-frame {:on-create [:counter/init]})]
+  (rf/with-new-frame [f (rf/make-frame {:on-create [:counter/init]})]
     (rf/dispatch-sync [:counter/set 5])
     (let [tree  (counter-view {})
           label (th/find-by-testid tree "counter-label")]
@@ -552,7 +545,7 @@ When you want to verify what *would* dispatch without actually running the casca
 For tests that exercise event sequences and want to assert at intermediate points, dispatch one event at a time and assert between dispatches:
 
 ```clojure
-(rf/with-frame [f (rf/make-frame {:on-create [:auth/init-idle]})]
+(rf/with-new-frame [f (rf/make-frame {:on-create [:auth/init-idle]})]
   (rf/dispatch-sync [:auth/email-changed "alice@example.com"])
   (is (= "alice@example.com" (get-in (rf/get-frame-db f) [:auth :form :email])))
   (rf/dispatch-sync [:auth/password-changed "hunter2"])

--- a/spec/API.md
+++ b/spec/API.md
@@ -123,14 +123,15 @@ The two sub-families compose: `dispatch-to-system` ultimately calls `dispatch`, 
 | API | M/Fn | Signature | Status | Spec |
 |---|---|---|---|---|
 | `frame-provider` | Component (Reagent) | `[rf/frame-provider {:frame :todo} & children]` | v1 | 002 |
-| `with-frame` | M | `(with-frame :keyword body)` *or* `(with-frame [sym expr] body)` | v1 | 002 |
+| `with-frame` | M | `(with-frame :keyword body)` — pin to an existing frame-id. Vector arg is a compile-time error (use `with-new-frame`) | v1 | 002 |
+| `with-new-frame` | M | `(with-new-frame [sym expr] body)` — eval `expr`, bind `sym`, run body, destroy frame on exit. Keyword arg is a compile-time error (use `with-frame`) | v1 | 002 |
 | `bound-fn` | M | `(bound-fn [args] body)` | v1 | 002 |
 | `frame-bound-fn` | Fn | `(frame-bound-fn f)` *or* `(frame-bound-fn frame-id f)` → frame-rebinding closure. Higher-order sibling of `bound-fn` — wrap an existing callback so its body always runs with `*current-frame*` re-bound. Canonical React click-handler shape | v1 | 002 |
 | `dispatcher` | Fn | `(dispatcher)` → `(fn [event] ...)` — captures the current frame at call time and returns a frame-bound dispatch fn. Safe to call during render AND from async callbacks where the dynamic-var binding has unwound | v1 | 002, 004 |
 | `subscriber` | Fn | `(subscriber)` → `(fn [query-v] ...)` — companion to `dispatcher` for subscribe. Captures the current frame at call time | v1 | 002, 004 |
 | `view` | Fn | `(view view-id)` → **render-fn** (runtime-lookup handle; returns the registered render-fn, *not* hiccup). Use in hiccup as `[(rf/view :id) args...]` — the lookup form for late-binding a registered view by id. | v1 | 001, 004 |
 
-`with-frame`'s two shapes (bare keyword vs let-binding) are documented in [002 §with-frame](002-Frames.md#with-frame).
+`with-frame` (pin) and `with-new-frame` (eval-bind-run-destroy) are documented in [002 §with-frame and with-new-frame](002-Frames.md#with-frame-and-with-new-frame). The macros are non-overlapping: each rejects the other's argument shape at compile time, with `:recovery` pointing the caller at the right sibling. Per rf2-twoc5.
 
 `bound-fn` is a CLJS-only macro; CLJS users either reach it via `rf/bound-fn` (after `(:require [re-frame.core :as rf])`) or `:require-macros [re-frame.core :refer [bound-fn]]`. `frame-bound-fn` is a plain fn, available on both CLJS and JVM (no macro indirection).
 
@@ -582,7 +583,7 @@ Schemas are **open** by default (consumers tolerate unknown keys; producers grow
 
 ## Testing
 
-The testing surface lives across three namespaces. `re-frame.core` carries the production primitives that double as testing entry points (`make-frame`, `with-frame`, `dispatch-sync`, `with-fx-overrides`, `get-frame-db`, `snapshot-of`, `compute-sub`, `machine-transition`, `sub-topology`). `re-frame.test-support` ships the test-only fixture machinery and test-flavoured helpers. `re-frame.test-helpers` ships the view-assertion helpers (hiccup-walk + `testid` authoring). `re-frame.test-support` does **not** re-export from `re-frame.core` — a test file requires both `[re-frame.core :as rf]` and `[re-frame.test-support :as ts]`, and additionally `[re-frame.test-helpers :as th]` for view-assertion tests. See [008-Testing.md](008-Testing.md) for fixtures, framework adapters, and `re-frame-test` compatibility.
+The testing surface lives across three namespaces. `re-frame.core` carries the production primitives that double as testing entry points (`make-frame`, `with-frame`, `with-new-frame`, `dispatch-sync`, `with-fx-overrides`, `get-frame-db`, `snapshot-of`, `compute-sub`, `machine-transition`, `sub-topology`). `re-frame.test-support` ships the test-only fixture machinery and test-flavoured helpers. `re-frame.test-helpers` ships the view-assertion helpers (hiccup-walk + `testid` authoring). `re-frame.test-support` does **not** re-export from `re-frame.core` — a test file requires both `[re-frame.core :as rf]` and `[re-frame.test-support :as ts]`, and additionally `[re-frame.test-helpers :as th]` for view-assertion tests. See [008-Testing.md](008-Testing.md) for fixtures, framework adapters, and `re-frame-test` compatibility.
 
 | API | M/Fn | Signature | Status | Spec | Notes |
 |---|---|---|---|---|---|

--- a/spec/Construction-Prompts.md
+++ b/spec/Construction-Prompts.md
@@ -74,7 +74,7 @@ Each entry below is one CP:
 
 ```clojure
 (deftest feature-verb-noun-test
-  (rf/with-frame [f (rf/make-frame {:on-create [:feature/initialise]})]
+  (rf/with-new-frame [f (rf/make-frame {:on-create [:feature/initialise]})]
     (rf/dispatch-sync [:feature/verb-noun "value"] {:frame f})
     (is (= "value" (get-in (rf/get-frame-db f) [:feature :path])))))
 ```
@@ -233,7 +233,7 @@ Each entry below is one CP:
       (rf/dispatch (conj on-success {:status 200 :body "test"})))))
 
 ;; in a test
-(rf/with-frame [f (rf/make-frame {:fx-overrides {:http :http.canned-200}
+(rf/with-new-frame [f (rf/make-frame {:fx-overrides {:http :http.canned-200}
                                   :on-create [:feature/load]})]
   ...)
 ```
@@ -315,7 +315,7 @@ The override seam is **id-valued at the pattern level**. The CLJS reference also
 
 ```clojure
 (deftest feature-component-name-renders
-  (rf/with-frame [f (rf/make-frame {:on-create [:feature/initialise]})]
+  (rf/with-new-frame [f (rf/make-frame {:on-create [:feature/initialise]})]
     (let [hiccup [component-name "test-label" 42]
           html   (rf/render-to-string hiccup {:frame f})]
       (is (str/includes? html "test-label"))
@@ -542,7 +542,7 @@ After this action, `(:pending-request data)` is the new actor's id; subsequent t
 
 ;; Level 3 — registered in a test frame (full integration; required for spawn lifecycle).
 (deftest auth-login-happy-path-l3
-  (rf/with-frame [f (rf/make-frame {:on-create [:auth/init]})]
+  (rf/with-new-frame [f (rf/make-frame {:on-create [:auth/init]})]
     (rf/dispatch-sync [:auth.login/flow [:submit {:email "..."}]] {:frame f})
     ;; Read via the framework-registered :rf/machine sub:
     (is (= :submitting (:state @(rf/subscribe [:rf/machine :auth.login/flow] {:frame f}))))))
@@ -704,7 +704,7 @@ test/my_app/
 
 ```clojure
 (deftest cart-feature-happy-path
-  (rf/with-frame [f (rf/make-frame {:on-create [:cart/initialise]})]
+  (rf/with-new-frame [f (rf/make-frame {:on-create [:cart/initialise]})]
     (let [item {:id (random-uuid) :sku "ABC-1" :qty 2 :price 9.99}]
       (rf/dispatch-sync [:cart.item/add item] {:frame f})
       (is (= [item] (rf/compute-sub [:cart/items] (rf/get-frame-db f))))
@@ -944,7 +944,7 @@ The handler reads `(:rf/route db)` for any path/query params it needs — the `:
 ```clojure
 (defn handle-request [request]
   (let [frame-id (gensym :ssr-frame)]
-    (rf/with-frame [f (rf/make-frame
+    (rf/with-new-frame [f (rf/make-frame
                        {:id           frame-id
                         :on-create    [:rf/server-init request]})]
       ;; rebound to f

--- a/tools/template/resources/day8/re_frame2_template/root/dev/scratch.cljs
+++ b/tools/template/resources/day8/re_frame2_template/root/dev/scratch.cljs
@@ -20,11 +20,11 @@
   ;; Run a scratch experiment against a throw-away frame — leaves
   ;; the live :rf/default frame untouched.
   ;;
-  ;; `with-frame` Shape 1 takes a keyword frame-id and binds
-  ;; `*current-frame*` to it for the duration of the body. (Shape 2
-  ;; is `[sym expr]` for an eval-bind-run-destroy pattern; map or
-  ;; non-keyword first-args are NOT supported and silently misbind
-  ;; the current frame — see Spec 002 §with-frame.)
+  ;; `with-frame` takes a keyword frame-id and binds `*current-frame*`
+  ;; to it for the duration of the body. (For an eval-bind-run-destroy
+  ;; throwaway frame, reach for the sibling macro `with-new-frame`,
+  ;; which takes `[sym expr]` and destroys the bound frame on exit —
+  ;; see Spec 002 §with-frame.)
   (rf/with-frame :scratch
     (rf/dispatch-sync [:counter/initialise])
     (rf/dispatch-sync [:counter/increment])

--- a/tools/template/test/day8/re_frame2_template/template_emission_test.clj
+++ b/tools/template/test/day8/re_frame2_template/template_emission_test.clj
@@ -314,17 +314,22 @@
               (str (.getName file) " (" substrate ") requires " target-ns
                    " but no source file found under implementation/core/src/")))))))
 
-;; --- scratch.cljs with-frame shape audit (rf2-ah0gi) -----------------------
+;; --- scratch.cljs with-frame shape audit (rf2-ah0gi / rf2-twoc5) -----------
 ;;
-;; The emitted dev/scratch.cljs is the user's REPL on-ramp. Any
-;; `(rf/with-frame …)` call in the (comment …) block MUST use Shape 1
-;; (a keyword) or Shape 2 (a 2-elem `[sym expr]` vector) per Spec 002
-;; §with-frame and the macro definition at
-;; `implementation/core/src/re_frame/core_reg_view_macro.cljc`. A map
-;; first-arg (or any other literal) falls through to Shape 1 and binds
-;; `*current-frame*` to a non-frame value — runtime breaks far from
-;; the call site. The audit walks every `with-frame` form in scratch
-;; and asserts the first-arg shape.
+;; The emitted dev/scratch.cljs is the user's REPL on-ramp. The two
+;; frame-scope macros are non-overlapping (per rf2-twoc5, Mike-approved
+;; 2026-05-28):
+;;
+;;   `with-frame`     — pin form: first arg MUST be a keyword (or
+;;                      keyword-resolving symbol). Vector arg is a
+;;                      compile-time error.
+;;   `with-new-frame` — eval/destroy form: first arg MUST be a
+;;                      2-element `[sym expr]` vector. Keyword arg is
+;;                      a compile-time error.
+;;
+;; This audit walks every `with-frame` / `with-new-frame` form in
+;; scratch and asserts the first-arg shape is right for the chosen
+;; macro.
 
 (defn- with-frame-call?
   "True when `form` is `(rf-or-alias/with-frame …)` — covers both
@@ -334,24 +339,36 @@
        (symbol? (first form))
        (= "with-frame" (name (first form)))))
 
-(defn- valid-with-frame-first-arg?
-  "Shape 1 = keyword; Shape 2 = 2-elem [sym expr] vector. Anything
-  else is the bug rf2-ah0gi found."
-  [arg]
-  (or (keyword? arg)
-      (and (vector? arg)
-           (= 2 (count arg))
-           (symbol? (first arg)))))
+(defn- with-new-frame-call?
+  "True when `form` is `(rf-or-alias/with-new-frame …)`."
+  [form]
+  (and (seq? form)
+       (symbol? (first form))
+       (= "with-new-frame" (name (first form)))))
 
-(defn- collect-with-frame-calls
-  "Walk `forms` and return every `(with-frame …)` call form, including
+(defn- valid-with-frame-first-arg?
+  "Pin form: keyword or symbol (resolves to keyword). Vector is the
+  compile-time error rf2-twoc5 added."
+  [arg]
+  (or (keyword? arg) (symbol? arg)))
+
+(defn- valid-with-new-frame-first-arg?
+  "Eval/destroy form: 2-elem [sym expr] vector. Anything else is a
+  compile-time error."
+  [arg]
+  (and (vector? arg)
+       (= 2 (count arg))
+       (symbol? (first arg))))
+
+(defn- collect-calls
+  "Walk `forms` and return every form matching `pred`, including
   those nested inside `(comment …)` blocks (which is where the emitted
   scratch ns puts its examples)."
-  [forms]
+  [pred forms]
   (let [acc (volatile! [])]
     (walk/postwalk
       (fn [x]
-        (when (with-frame-call? x)
+        (when (pred x)
           (vswap! acc conj x))
         x)
       forms)
@@ -362,21 +379,30 @@
   (let [scratch (io/file root "dev/scratch.cljs")]
     (is (.isFile scratch)
         (str "dev/scratch.cljs emitted for " substrate))
-    (let [forms (read-cljs-forms scratch)
-          calls (collect-with-frame-calls forms)]
-      (is (seq calls)
+    (let [forms          (read-cljs-forms scratch)
+          pin-calls      (collect-calls with-frame-call? forms)
+          new-frame-calls (collect-calls with-new-frame-call? forms)]
+      (is (or (seq pin-calls) (seq new-frame-calls))
           (str "scratch.cljs (" substrate
-               ") contains at least one (with-frame …) example — "
-               "the REPL on-ramp should demonstrate the shape"))
-      (doseq [call calls]
+               ") contains at least one (with-frame …) or "
+               "(with-new-frame …) example — the REPL on-ramp should "
+               "demonstrate at least one frame-scope shape"))
+      (doseq [call pin-calls]
         (let [first-arg (second call)]
           (is (valid-with-frame-first-arg? first-arg)
               (str "scratch.cljs (" substrate ") (with-frame "
                    (pr-str first-arg) " …) — first arg must be a "
-                   "keyword (Shape 1) or a 2-elem [sym expr] vector "
-                   "(Shape 2). Per Spec 002 §with-frame, anything "
-                   "else binds *current-frame* to a non-frame "
-                   "value and breaks downstream dispatch/subscribe.")))))))
+                   "keyword or symbol (pin form). Per rf2-twoc5, a "
+                   "vector argument is a compile-time error; use "
+                   "`with-new-frame` for eval-bind-run-destroy."))))
+      (doseq [call new-frame-calls]
+        (let [first-arg (second call)]
+          (is (valid-with-new-frame-first-arg? first-arg)
+              (str "scratch.cljs (" substrate ") (with-new-frame "
+                   (pr-str first-arg) " …) — first arg must be a "
+                   "2-element [sym expr] vector. Per rf2-twoc5, a "
+                   "keyword argument is a compile-time error; use "
+                   "`with-frame` to pin to an existing frame-id.")))))))
 
 (defn- run-for-substrate!
   [substrate]


### PR DESCRIPTION
Today `with-frame` is shape-overloaded — the keyword form pins to an existing frame-id while the `[sym expr]` vector form evaluates an expression, binds it, and destroys the frame on exit. The shared name obscures intent at every call site (a reader must inspect the first argument to know whether the macro is read-only or destructive).

This split makes the intent telegraph at the macro name:

- **`with-frame`** — pin form only: `(with-frame :keyword body+)`. Rejects vector argument at compile time (`:rf.error/with-frame-vector-form`) with `:recovery :use-with-new-frame`.
- **`with-new-frame`** — eval/destroy form only: `(with-new-frame [sym expr] body+)`. Rejects keyword argument at compile time (`:rf.error/with-new-frame-keyword-form`) with `:recovery :use-with-frame`.

Pre-alpha clean swap: no back-compat shim, no arity-overloaded single name; every existing call site is updated to the correct macro.

### Surfaces touched

- **implementation/core**: macro definitions split in `core.cljc`, expansion helpers split in `core_reg_view_macro.cljc`, JVM tests covering both macros + both compile-time rejection paths.
- **implementation/adapters + react-shared-suite**: vector-shape test cases moved to `with-new-frame`; pin-shape tests keep `with-frame`.
- **examples/reagent**: `boot`, `long_running_work`, `nine_states`, `realworld` (all 10 test files), `websocket` (2 files) — all vector-shape sites moved to `with-new-frame`.
- **spec**: `002-Frames`, `008-Testing`, `API`, `005-StateMachines`, `Construction-Prompts` updated to document the split and use the right macro in each example.
- **docs + skills**: `api/01-core`, `api/02-views`, `api/09-ssr`, `guide/13-server-side`, `guide/15-testing`, `re-frame-migration` and `re-frame2` skill references all updated.
- **.clj-kondo**: hook + `config.edn` carry the new `with-new-frame` entry alongside the simplified `with-frame` pin-form hook.
- **tools/template**: `scratch.cljs` commentary refreshed; `template-emission` audit teaches the audit walker to accept either macro with the right shape per rf2-twoc5.

### Quality gates (local)

- `cd implementation/core && clojure -M:test` — 785 tests / 3482 assertions, 0F/0E.
- `cd implementation && npm run test:cljs` — 4836 tests / 15778 assertions, 0F/0E.
- `cd tools/xray && clojure -M:test` — 952 tests / 3685 assertions, 0F/0E.
- `bash scripts/test-fast-pr.sh` — PASS.
- `bash scripts/test-jvm-implementation.sh` — PASS (all 9 artefacts).
- `bash scripts/test-jvm-tools.sh` — PASS (all artefacts).
- `npm run test:elision` — PASS.

Mike-approved 2026-05-28 (Option A, names telegraph intent).