### PR TITLE
fix(xray/diff): empty->populated app-db root produces per-key :added entries (rf2-9d4j8)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/diff/engine.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/diff/engine.cljc
@@ -164,19 +164,66 @@
 ;; raw Editscript edit-script walker
 ;; =========================================================================
 
+(defn- expand-empty-map-replacement
+  "Expand a single Editscript edit that replaces an EMPTY MAP with a
+  populated map (or vice versa) into per-key `:+` / `:-` edits.
+
+  Editscript's A* emits a single `[[path] :r new-value]` edit for the
+  pathological `{} → {populated}` (and `{populated} → {}`) cases — the
+  whole map replacement is one step in the edit script. Downstream
+  classification then tags `path` as `:modified` and leaves every
+  PER-KEY path returning `:same` from `op-at`, which the renderer reads
+  as 'no per-key change' — wrong for an absent→present transition
+  (rf2-9d4j8; related precedent rf2-5j7ch which patched only the
+  `:flat-rows` lens).
+
+  This expansion runs over the raw edit script BEFORE classification so
+  every downstream artefact (`:path-ops`, `:container-ops`,
+  `:flat-rows`, `:wholly-changed-roots`) sees per-key granularity.
+
+  Rule: a `:r` edit at `path` substitutes into per-key edits ONLY when
+  the before-side value at `path` is `{}` AND the after-side value at
+  `path` is a non-empty map (or symmetrically populated→empty). Type
+  changes (nil↔map, scalar↔map, map↔vector) are LEFT ALONE so R7's
+  `:rf.xray.diff/type-change?` branch still fires on them.
+
+  Pure; non-matching edits pass through unchanged."
+  [edit before after]
+  (let [[path op value] edit]
+    (if (not= op :r)
+      [edit]
+      (let [before-at (value-at before path)
+            after-at  (value-at after path)]
+        (cond
+          ;; {} → populated map: per-key :+
+          (and (map? before-at) (empty? before-at)
+               (map? after-at)  (seq after-at))
+          (mapv (fn [[k v]] [(conj (vec path) k) :+ v]) after-at)
+
+          ;; populated map → {}: per-key :- (Editscript :- omits value)
+          (and (map? before-at) (seq before-at)
+               (map? after-at)  (empty? after-at))
+          (mapv (fn [[k _v]] [(conj (vec path) k) :-]) before-at)
+
+          :else
+          [edit])))))
+
 (defn- raw-edits
   "Return Editscript A* edits for `(before, after)` as a vector of
-  3-tuples `[path op value?]`. Pure."
+  3-tuples `[path op value?]`, with empty↔populated map replacements
+  pre-expanded into per-key `:+` / `:-` edits (rf2-9d4j8). Pure."
   [before after]
-  (try
-    (ee/get-edits (es/diff before after {:algo :a-star}))
-    (catch #?(:clj Exception :cljs js/Error) _e
-      ;; Editscript can throw on certain pathological inputs (e.g.
-      ;; comparing maps with unreadable keys); fall back to a
-      ;; conservative whole-value replacement so the renderer doesn't
-      ;; crash. The fallback edit reproduces the operator-visible
-      ;; signal ("everything changed") without false sub-tree precision.
-      [[[] :r after]])))
+  (let [raw (try
+              (ee/get-edits (es/diff before after {:algo :a-star}))
+              (catch #?(:clj Exception :cljs js/Error) _e
+                ;; Editscript can throw on certain pathological inputs
+                ;; (e.g. comparing maps with unreadable keys); fall
+                ;; back to a conservative whole-value replacement so
+                ;; the renderer doesn't crash. The fallback edit
+                ;; reproduces the operator-visible signal ("everything
+                ;; changed") without false sub-tree precision.
+                [[[] :r after]]))]
+    (into [] (mapcat (fn [edit] (expand-empty-map-replacement edit before after))) raw)))
 
 ;; =========================================================================
 ;; per-path op classification (leaves)
@@ -373,7 +420,15 @@
   check whether every descendant leaf-path under it carries a matching
   op in `path-ops`. If so, mark this container as the wholly-changed
   root, and ELIDE deeper roots — only the shallowest wholly-changed
-  ancestor counts."
+  ancestor counts.
+
+  The root path `[]` is explicitly excluded from wholly-changed
+  promotion (rf2-9d4j8). Empty→populated cold-boot epochs would
+  otherwise see ALL per-key chrome (glyph + stripe) suppressed under a
+  single root-level reclassification, which contradicts the operator's
+  read on a cold-boot diff: each top-level key is a discrete addition
+  and wants its own gutter chrome. Nested containers can still qualify
+  as wholly-changed (e.g. `{} → {:user {:id 7}}` marks `[:user]`)."
   [before after path-ops]
   (let [collect-leaves
         (fn collect-leaves [data path]
@@ -400,10 +455,27 @@
         walk-containers
         (fn walk-containers [data path target-op acc]
           (cond
-            ;; Skip the root unless the root itself is wholly-changed
-            ;; (rare but valid — entire app-db replacement).
             (not (container? data))
             acc
+
+            ;; Root path `[]` never qualifies as a wholly-changed root —
+            ;; recurse into children instead so nested containers can
+            ;; still be marked (rf2-9d4j8).
+            (and (= [] path) (check-uniform data path target-op))
+            (cond
+              (map? data)
+              (reduce-kv (fn [acc k cv]
+                           (walk-containers cv (conj (vec path) k)
+                                            target-op acc))
+                         acc data)
+
+              (or (vector? data) (sequential? data))
+              (reduce (fn [acc [i cv]]
+                        (walk-containers cv (conj (vec path) i)
+                                         target-op acc))
+                      acc (map-indexed vector data))
+
+              :else acc)
 
             (check-uniform data path target-op)
             (conj acc path)
@@ -686,80 +758,14 @@
       0))
 
 ;; =========================================================================
-;; flat-rows post-processing — operator-friendly expansion (rf2-5j7ch)
-;; =========================================================================
-
-(defn expand-empty-root-replacement
-  "Post-process `flat-rows` so a wholesale root replacement against an
-  EMPTY before / after map expands into per-key rows (rf2-5j7ch).
-
-  Editscript's A* produces a single root-level `:r` edit for the
-  `{} → {populated}` (and `{populated} → {}`) cases — at engine
-  output that surfaces as ONE flat-row anchored at `[]`. The engine
-  is correct (one edit-script entry, mode-3 paints from the same
-  source), but the operator's UX read on `:diff` lens is less
-  informative: empty-to-populated is the canonical 'what landed?'
-  question for cold-boot epochs and wants per-key granularity.
-
-  This helper expands EXACTLY the empty-root-replacement case:
-
-    - before is `{}`        + after is a non-empty map  →
-      one `{:path [k] :op :added :before nil :after v}` row per
-      key (sorted by key for stable order).
-
-    - before is a non-empty map + after is `{}`        →
-      one `{:path [k] :op :removed :before v :after nil}` row
-      per key.
-
-  Non-empty-side replacements (two populated maps swapping wholesale)
-  are LEFT ALONE — that reads as a genuine wholesale event the
-  operator should see as one row.
-
-  Pure-data. Operates on the engine's `:flat-rows` shape (vector of
-  `{:path :op :before :after}` maps). The renderer-side
-  `flat-rows->triples` step folds the expanded rows into the same
-  4-tuple shape every `:diff` lens consumer reads.
-
-  Returns the (possibly-expanded) flat-rows vector."
-  [flat-rows]
-  (let [root-row (when (= 1 (count flat-rows))
-                   (first flat-rows))]
-    (cond
-      ;; Empty-to-populated: expand the `:modified` row at `[]` into
-      ;; per-key `:added` rows.
-      (and (some? root-row)
-           (= [] (:path root-row))
-           (= :modified (:op root-row))
-           (= {} (:before root-row))
-           (map? (:after root-row))
-           (seq (:after root-row)))
-      (->> (:after root-row)
-           (mapv (fn [[k v]]
-                   {:path   [k]
-                    :op     :added
-                    :before nil
-                    :after  v}))
-           (sort-by :path)
-           vec)
-
-      ;; Populated-to-empty: expand into per-key `:removed` rows.
-      (and (some? root-row)
-           (= [] (:path root-row))
-           (= :modified (:op root-row))
-           (map? (:before root-row))
-           (seq (:before root-row))
-           (= {} (:after root-row)))
-      (->> (:before root-row)
-           (mapv (fn [[k v]]
-                   {:path   [k]
-                    :op     :removed
-                    :before v
-                    :after  nil}))
-           (sort-by :path)
-           vec)
-
-      :else
-      flat-rows)))
+;; rf2-5j7ch / rf2-9d4j8 — empty↔populated map replacements are now
+;; expanded inside `project` (via `expand-empty-map-replacement` at the
+;; raw-edits stage). The previous post-processor `expand-empty-root-
+;; replacement` operated on `:flat-rows` only and left `:path-ops` /
+;; `:container-ops` carrying a single `[]`-anchored `:modified` op,
+;; which made `op-at` return `:same` for every per-key path in the
+;; FULL+DIFF lens (rf2-9d4j8). Pre-alpha clean swap: the post-processor
+;; is removed and the engine produces per-key rows at every lens.
 
 (defn wholly-changed-ancestor
   "Return the shallowest wholly-changed-root that is an ancestor of

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_subs.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_subs.cljs
@@ -156,18 +156,13 @@
               cached
               (let [proj (diff-engine/project (:db-before record)
                                               (:db-after  record))
-                    ;; rf2-5j7ch — operator-friendly expansion of the
-                    ;; wholesale root-replacement case (`{} →
-                    ;; {populated}` or inverse). The engine emits a
-                    ;; single `:r []` for that case (correct under
-                    ;; Editscript A*); the renderer-facing
-                    ;; `:diff` lens expands it into per-key rows so
-                    ;; the operator sees what landed in a cold-boot
-                    ;; epoch with per-key granularity. Non-empty-
-                    ;; side wholesales pass through unchanged.
-                    expanded (diff-engine/expand-empty-root-replacement
-                               (:flat-rows proj))
-                    diff (flat-rows->triples expanded)
+                    ;; rf2-5j7ch / rf2-9d4j8 — empty↔populated map
+                    ;; replacements are pre-expanded inside the engine
+                    ;; (per-key `:added` / `:removed` rows) so cold-boot
+                    ;; epochs read with per-key granularity at every
+                    ;; lens (`:diff`, `:full-with-diff`, container
+                    ;; ops). No post-processor needed here.
+                    diff (flat-rows->triples (:flat-rows proj))
                     live (into #{} (map :epoch-id) history)]
                 (swap! diff-cache
                        (fn [m]

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
@@ -539,16 +539,16 @@
   triples — the same shape the App-DB / Epoch HANDLER `:diff` lens
   consumes. Used by the Machine Inspector's `:diff` mode (rf2-yqjrd).
 
-  rf2-5j7ch — runs the engine's `expand-empty-root-replacement`
-  post-processor so a snapshot going `{} → {:state :idle …}` (cold-
-  boot first-transition) reads as per-key adds, not a wholesale
-  root replacement. Mirrors the App-DB `:diff` sub.
+  rf2-5j7ch / rf2-9d4j8 — the engine pre-expands empty↔populated map
+  replacements into per-key `:+` / `:-` edits so cold-boot first-
+  transition snapshots (`{} → {:state :idle …}`) read as per-key
+  adds at every lens. No post-processor needed here.
 
   Returns an empty vector when no Editscript edits surface (identical
   snapshots) so the renderer can paint a `— (no changes)` placeholder."
   [before after]
   (let [proj (diff-engine/project before after)
-        rows (diff-engine/expand-empty-root-replacement (:flat-rows proj))]
+        rows (:flat-rows proj)]
     (mapv (fn [{:keys [path op before after]}]
             (let [kind (case op
                          :added    :added

--- a/tools/xray/test/day8/re_frame2_xray/diff/engine_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/diff/engine_cljs_test.cljc
@@ -221,79 +221,110 @@
       (is (= :removed  (engine/op-at p [:legacy-flag])))
       (is (contains? (:wholly-changed-roots p) [:flash])))))
 
-;; ---- expand-empty-root-replacement (rf2-5j7ch) ----------------------------
+;; ---- empty↔populated map expansion (rf2-5j7ch / rf2-9d4j8) -------------
+;;
+;; The engine pre-expands `{} ↔ {populated}` Editscript :r edits into
+;; per-key :+ / :- edits BEFORE classification, so every downstream
+;; lens (`:path-ops`, `:container-ops`, `:flat-rows`,
+;; `:wholly-changed-roots`) sees per-key granularity. rf2-5j7ch first
+;; surfaced the issue on the `:diff` (pure-list) lens; rf2-9d4j8
+;; surfaced the same root cause on the FULL+DIFF lens, where `op-at`
+;; was returning `:same` for every per-key path because the engine's
+;; `path-ops` only held a single root-level `:modified` op. The fix
+;; moved the expansion inside `project` itself (pre-alpha clean swap;
+;; the old `expand-empty-root-replacement` flat-rows post-processor is
+;; gone).
 
-(deftest expand-empty-root-replacement-empty-to-populated
-  (testing "rf2-5j7ch — `{} → {:counter 1}` collapses to a single
-            `:r []` Editscript edit which the engine surfaces as a
-            wholesale root-replacement flat-row. The renderer-facing
-            expansion lifts this into per-key `:added` rows so the
-            operator's `:diff` lens reads cold-boot epochs with
-            per-key granularity."
-    (let [proj     (engine/project {} {:counter 1 :user {:id 7}})
-          rows     (:flat-rows proj)
-          expanded (engine/expand-empty-root-replacement rows)]
-      (is (= 1 (count rows))
-          "engine emits ONE wholesale root replacement under Editscript")
-      (is (= [] (:path (first rows)))
-          "the wholesale row anchors at the root path")
-      (is (= [{:path [:counter] :op :added :before nil :after 1}
-              {:path [:user]    :op :added :before nil :after {:id 7}}]
-             expanded)
-          "expansion produces one :added row per top-level key, sorted
-           by path"))))
+(deftest empty-to-populated-root-expands-to-per-key-added
+  (testing "rf2-9d4j8 — `{} → {:counter 1 :user {:id 7}}` produces
+            per-key `:added` ops at every lens, not a single root
+            `:modified` op."
+    (let [p (engine/project {} {:counter 1 :user {:id 7}})]
+      ;; path-ops carry per-key :added entries (the FULL+DIFF lens
+      ;; reads from here).
+      (is (= :added (engine/op-at p [:counter])))
+      (is (= :added (engine/op-at p [:user :id])))
+      (is (= 1 (:after (engine/entry-at p [:counter]))))
+      ;; The wholly-new container [:user] reclassifies as wholly-
+      ;; changed-added (R5).
+      (is (= :added (engine/op-at p [:user])))
+      (is (contains? (:wholly-changed-roots p) [:user]))
+      ;; The root `[]` does NOT enter wholly-changed-roots — cold-
+      ;; boot epochs want per-top-level-key chrome, not a single
+      ;; root-level reclassification.
+      (is (not (contains? (:wholly-changed-roots p) [])))
+      ;; Root `[]` carries `:children` (descendants changed) since
+      ;; the engine no longer emits a root `:modified` for this case.
+      (is (= :children (engine/op-at p [])))
+      ;; flat-rows carry per-key :added rows (the :diff lens reads
+      ;; from here; rf2-5j7ch's user-visible expectation).
+      (let [rows  (:flat-rows p)
+            paths (set (map :path rows))
+            ops   (set (map :op rows))]
+        (is (contains? paths [:counter]))
+        (is (contains? paths [:user :id]))
+        (is (= #{:added} ops))))))
 
-(deftest expand-empty-root-replacement-populated-to-empty
-  (testing "rf2-5j7ch — inverse case: a populated map going to `{}`
-            expands into per-key `:removed` rows."
-    (let [proj     (engine/project {:counter 1 :user {:id 7}} {})
-          rows     (:flat-rows proj)
-          expanded (engine/expand-empty-root-replacement rows)]
-      (is (= [{:path [:counter] :op :removed :before 1        :after nil}
-              {:path [:user]    :op :removed :before {:id 7}  :after nil}]
-             expanded)))))
+(deftest populated-to-empty-root-expands-to-per-key-removed
+  (testing "rf2-9d4j8 — symmetric removal: `{:counter 1 :user {:id 7}}
+            → {}` produces per-key `:removed` ops at every lens."
+    (let [p (engine/project {:counter 1 :user {:id 7}} {})]
+      (is (= :removed (engine/op-at p [:counter])))
+      (is (= :removed (engine/op-at p [:user :id])))
+      (is (= 1 (:before (engine/entry-at p [:counter]))))
+      (is (= :removed (engine/op-at p [:user])))
+      (is (contains? (:wholly-changed-roots p) [:user]))
+      (is (not (contains? (:wholly-changed-roots p) [])))
+      (let [rows  (:flat-rows p)
+            paths (set (map :path rows))
+            ops   (set (map :op rows))]
+        (is (contains? paths [:counter]))
+        (is (contains? paths [:user :id]))
+        (is (= #{:removed} ops))))))
 
-(deftest expand-empty-root-replacement-non-empty-passes-through
-  (testing "rf2-5j7ch — two populated maps swapping wholesale (the
-            engine-stable root replacement case) is LEFT ALONE. The
-            operator sees one row anchored at `[]` because that DOES
-            read as a wholesale event."
-    (let [proj     (engine/project {:a 1} {:b 2})
-          rows     (:flat-rows proj)
-          expanded (engine/expand-empty-root-replacement rows)]
-      ;; Two populated maps with disjoint keys may surface as a
-      ;; wholesale root-replacement OR per-key add/remove rows
-      ;; depending on the Editscript A* choice. Either way the
-      ;; expansion MUST be a no-op (only the empty-side case is
-      ;; rewritten).
-      (is (= rows expanded)
-          "non-empty-side flat-rows pass through unchanged"))))
+(deftest empty-to-populated-mid-tree-expands
+  (testing "rf2-9d4j8 — mid-tree empty-to-populated also expands:
+            `{:user {}} → {:user {:name 'Ada'}}` yields :added at
+            `[:user :name]`, not :modified at `[:user]`."
+    (let [p (engine/project {:user {}} {:user {:name "Ada"}})]
+      (is (= :added (engine/op-at p [:user :name])))
+      ;; [:user] is wholly-changed-added (every descendant is :added).
+      (is (= :added (engine/op-at p [:user])))
+      (is (contains? (:wholly-changed-roots p) [:user])))))
 
-(deftest expand-empty-root-replacement-non-root-modified-passes-through
-  (testing "rf2-5j7ch — a single :modified row at a NON-root path is
-            also passed through. The expansion only fires when a
-            single :modified row sits at the root path AND one side
-            is empty."
-    (let [rows [{:path [:counter] :op :modified :before 5 :after 6}]]
-      (is (= rows (engine/expand-empty-root-replacement rows))))))
+(deftest empty-to-populated-flat-scalar-keys
+  (testing "rf2-9d4j8 — flat scalar top-level keys (no nested
+            containers) still yield per-key :added rows."
+    (let [p (engine/project {} {:a 1 :b 2})]
+      (is (= :added (engine/op-at p [:a])))
+      (is (= :added (engine/op-at p [:b])))
+      (is (= 1 (:after (engine/entry-at p [:a]))))
+      (is (= 2 (:after (engine/entry-at p [:b]))))
+      ;; No nested container to mark wholly-changed; the per-key ops
+      ;; carry the chrome directly via path-ops.
+      (is (empty? (:wholly-changed-roots p)))
+      (is (= :children (engine/op-at p []))))))
 
-(deftest expand-empty-root-replacement-multiple-rows-passes-through
-  (testing "rf2-5j7ch — when the engine produces MORE than one flat-
-            row (e.g. several per-key adds + a removed) the
-            expansion bails: the operator already sees per-key rows."
-    (let [rows [{:path [:a] :op :added :before nil :after 1}
-                {:path [:b] :op :added :before nil :after 2}]]
-      (is (= rows (engine/expand-empty-root-replacement rows))))))
+(deftest non-empty-populated-disjoint-passes-through
+  (testing "rf2-9d4j8 — two populated maps swapping wholesale (e.g.
+            `{:a 1 :b 2} → {:c 3 :d 4}`) is NOT an empty-side
+            replacement and should NOT expand to spurious per-key
+            ops. Editscript emits a single root `:r` for this case
+            (A* chooses root replace over 4 per-key edits); the
+            engine leaves it classified as `:modified` at `[]`."
+    (let [p (engine/project {:a 1 :b 2} {:c 3 :d 4})]
+      ;; The wholesale root replacement classifies as :modified at []
+      ;; (one map swapped for another with disjoint keys). Per-key
+      ;; paths return :same — the operator sees one wholesale row.
+      (is (= :modified (engine/op-at p [])))
+      (is (= :same (engine/op-at p [:a])))
+      (is (= :same (engine/op-at p [:c]))))))
 
-(deftest expand-empty-root-replacement-end-to-end-via-engine
-  (testing "rf2-5j7ch — full pipeline check: engine/project →
-            :flat-rows → expand-empty-root-replacement produces the
-            per-key adds the operator's `:diff` lens consumes."
-    (let [proj     (engine/project {} {:state :idle :data {}})
-          expanded (engine/expand-empty-root-replacement (:flat-rows proj))
-          paths    (mapv :path expanded)
-          ops      (set (map :op expanded))]
-      (is (= [[:data] [:state]] paths)
-          "every top-level key surfaces as its own row, sorted by path")
-      (is (= #{:added} ops)
-          "empty-to-populated expansion produces only :added rows"))))
+(deftest type-change-still-modified
+  (testing "rf2-9d4j8 — `{} → {}` style detection must NOT catch
+            type changes (nil↔map, scalar↔map). R7's :modified +
+            :type-change? branch still fires."
+    ;; nil → map at a nested path (the most likely confusion):
+    (let [p (engine/project {:user nil} {:user {:a 1}})]
+      (is (= :modified (engine/op-at p [:user])))
+      (is (engine/type-change? p [:user])))))


### PR DESCRIPTION
## What

Fixes the Xray App-DB **FULL+DIFF** lens misclassifying new top-level keys as `:modified`/`:same` instead of `:added` when before-db was `{}` and after-db was a populated map.

## Reproducer

step-deck testbed, `/counter` route, hard refresh — first epoch is `:testdeck/initialise`. In the Epoch panel, focus epoch 1 → HANDLER step → `:db` section → click **FULL+DIFF**.

**Before this PR** (`engine/op-at` results):

```
{} -> {:counter 1 :user {:id 7}}
  op-at [] = :modified
  op-at [:counter] = :same      <-- BUG
  op-at [:user] = :same         <-- BUG
  op-at [:user :id] = :same     <-- BUG
```

**After this PR**:

```
{} -> {:counter 1 :user {:id 7}}
  op-at [] = :children
  op-at [:counter] = :added
  op-at [:user] = :added         (wholly-changed-root)
  op-at [:user :id] = :added
```

## Root cause

Editscript's A* emits a single root `[[] :r {populated}]` edit for the `{} → {populated}` case. The engine then classified this as one `:modified` op at `[]` in `:path-ops`, leaving every per-key path returning `:same` from `op-at`.

[rf2-5j7ch](https://github.com/day8/re-frame2/pull/2288) patched the `:diff` (pure-list) lens via a post-processor on `:flat-rows`. But the FULL+DIFF lens reads from `:path-ops` + `:container-ops` via `op-at` — surfaces the flat-rows post-processor never touched. Same root cause, different surface.

## Fix shape

Pre-alpha clean swap: move the empty↔populated expansion **inside the engine** at the raw-edits stage, so every downstream artefact (`:path-ops`, `:container-ops`, `:flat-rows`, `:wholly-changed-roots`) sees per-key granularity. The old `expand-empty-root-replacement` post-processor is removed; its two callers (`app_db_diff_subs.cljs`, `machine_inspector.cljs`) read `:flat-rows` directly now.

Located at `tools/xray/src/day8/re_frame2_xray/diff/engine.cljc`:
- New `expand-empty-map-replacement` substitutes `:r` edits into per-key `:+`/`:-` when one side is `{}` and the other is a populated map.
- `mark-wholly-changed` now explicitly skips root path `[]` — cold-boot epochs render per-top-level-key chrome instead of a single root reclassification (nested containers can still qualify, e.g. `{} → {:user {:id 7}}` marks `[:user]`).

Scope: maps only (vectors/sets retained for follow-up). The bead's acceptance criteria + the app-db symptom are map-bound. Type changes (nil↔map, scalar↔map, map↔vector) still classify as `:modified` via R7.

## Test added

`tools/xray/test/day8/re_frame2_xray/diff/engine_cljs_test.cljc` — six tests pinning the new behaviour:
- `empty-to-populated-root-expands-to-per-key-added` — primary case
- `populated-to-empty-root-expands-to-per-key-removed` — symmetric
- `empty-to-populated-mid-tree-expands` — `{:user {}} → {:user {:name "Ada"}}`
- `empty-to-populated-flat-scalar-keys` — `{} → {:a 1 :b 2}`
- `non-empty-populated-disjoint-passes-through` — regression guard against over-expansion
- `type-change-still-modified` — R7 preserved

## Quality gates

- `cd tools/xray && clojure -M:test`: 952 tests / 0F0E
- `npm run test:cljs` from `implementation/`: 4833 tests / 0F0E
- `scripts/test-fast-pr.sh`: PASS

## Related

Sibling to [rf2-5j7ch](https://github.com/day8/re-frame2/pull/2288) — same root cause, distinct lens surface. This PR also subsumes rf2-5j7ch's post-processor: the engine now produces per-key rows at every lens.