### PR TITLE
fix(adapters/reagent-slim/deps.edn): :clein/build :main → re-frame.adapter.reagent-slim (rf2-lxftu)

### DIFF
--- a/implementation/adapters/reagent-slim/deps.edn
+++ b/implementation/adapters/reagent-slim/deps.edn
@@ -35,7 +35,7 @@
 
   :clein/build
   {:lib      day8/reagent-slim
-   :main     re-frame.adapter.reagent
+   :main     re-frame.adapter.reagent-slim
    :url      "https://github.com/day8/re-frame2"
    :version  "../../../VERSION"
    :license  {:name "MIT"


### PR DESCRIPTION
## Summary

`implementation/adapters/reagent-slim/deps.edn` had its `:clein/build :main` pointing at `re-frame.adapter.reagent` (the **stock**-Reagent adapter namespace) instead of `re-frame.adapter.reagent-slim` (the slim variant's own namespace).

Single-line fix: `:main re-frame.adapter.reagent` → `:main re-frame.adapter.reagent-slim`.

## Why this matters

Slim is the standalone Reagent rewrite — per the artefact's own header comment, _"this artefact is the 'slim' rewrite of stock Reagent for React 19. It replaces (does not depend on) stock Reagent."_

The bundle-isolation contract (`npm run test:reagent-slim:bundle-isolation`) keeps the slim and stock-Reagent artefacts wholly disjoint. A clein-built `day8/reagent-slim` whose `:main` resolves through the stock-Reagent adapter namespace would, on consumption, pull stock-Reagent code into slim-consuming downstreams — exactly what bundle-isolation exists to prevent. Build metadata pointing at the wrong main is a latent correctness defect even though the gate (which exercises the example bundles, not the clein-published artefact) happens to still pass.

## Provenance

Filed by the Adapters audit (rf2-tfmse / PR #2291) as P3.

## Verification

- `npm run test:reagent-slim:bundle-isolation` — PASS (3 contracts, 19 sentinel checks; slim 439821 chars, stock 442736 chars; bundles remain disjoint).
- `bash scripts/test-fast-pr.sh` — PASS (lockstep, skill/MCP drift, core JVM 787 tests, JS harness helpers, CLJS node integration 4833 tests).

Closes rf2-lxftu.