### PR TITLE
chore(examples): comment-residue fixes — 5 beads (5idpd + 7xtc2 + uq6ix + 45pie + v5lpl)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -163,6 +163,15 @@ Stage the `index.html` once (copy `examples/reagent/counter/index.html` next to 
 
 **Do NOT add a `*.spec.cjs` under `examples/`.** If the new example proves a new framework contract that isn't already covered by `test:cljs` / `test:xray-feature-gate` / bundle-isolation / perf-bundle, file a follow-up bead to extend the appropriate gate (or, for a genuinely new cross-cutting surface, add a top-level `testbeds/<surface>/` with its own `spec.cjs`).
 
+### Banner-comment style — size-keyed
+
+Section dividers in `core.cljs` files use one of two styles, keyed by file size:
+
+- **Light banner** (`;; -- Events / subs --`) — for sketch-sized files (~60-100 lines). Used by `counter/`, `counter_uix/`, `counter_helix/` and similar small pedagogical examples.
+- **Heavy ASCII box** (a 76-char `;; ===…===` rule above and below a `;; SECTION NAME` line) — for design-led and machine-bearing files (~200-300+ lines). Used by `dashboard_uix/`, `process_monitor_helix/`, the three `login*` examples, `notebook/`, `realworld/`, etc.
+
+The heavy box earns its visual weight in files where the section markers must be scannable across multiple pages. The light style would disappear in a long file; the heavy style overwhelms a short one. Prefer the light style by default; promote to the heavy style when section markers become navigation aids rather than pretty hairlines.
+
 ## What examples are *not*
 
 - **Not a substitute for the [specification](../spec/).** Examples illustrate; the specification defines.

--- a/examples/helix/login_helix/core.cljs
+++ b/examples/helix/login_helix/core.cljs
@@ -281,4 +281,8 @@
   (rf/reg-frame :rf/default
     {:doc          "Login (Helix) demo frame."
      :fx-overrides {:rf.http/managed :auth.login.demo/managed-stub}})
+  ;; No `dispatch-sync` seed here (unlike counter / dashboard): the
+  ;; machine handler is self-initialising — its `:initial`/`:data` seed
+  ;; [:rf/machines :auth.login/flow] when the flow first runs (per
+  ;; Spec 005 §Restore semantics), so no separate :initialise is needed.
   (.render react-root ($ root-view)))

--- a/examples/reagent/long_running_work/worker.cljs
+++ b/examples/reagent/long_running_work/worker.cljs
@@ -194,11 +194,13 @@
      :entry :dispatch-done}
 
     :cancelled
-    ;; Never reached by ordinary child transitions — the cancellation
-    ;; cascade destroys the child via :rf.machine/destroy fx (per
-    ;; Spec 005 §Cancellation cascade) rather than transitioning it
-    ;; here. Kept in the spec for tag completeness and for code paths
-    ;; that may later route cancellation as an event into the child.
+    ;; Declared but never entered by the example's transitions: in this
+    ;; example the parent cancels the child by tearing it down via the
+    ;; :rf.machine/destroy fx (Spec 005 §Cancellation cascade), not by
+    ;; routing a cancel event in. The state stays in the spec so the
+    ;; machine's tag union exposes #{:work/cancelled} to tools (snapshot
+    ;; inspectors, conformance harnesses), and so an app that DOES route
+    ;; cancellation as an in-FSM event has somewhere to land.
     {:meta {:terminal? true}
      :tags #{:work/cancelled}}}})
 

--- a/examples/reagent/realworld/schema.cljs
+++ b/examples/reagent/realworld/schema.cljs
@@ -218,12 +218,6 @@
 ;; `{path -> schema}` map reads more cleanly than a tower of singular
 ;; `reg-app-schema` calls. Source-coords for the bulk call stamp every
 ;; registered entry.
-;;
-;; Note: the `:tags` slice from the slice-form era is gone — the popular-
-;; tags lifecycle is now the `:realworld/tags` machine (the :data-region
-;; machine variant of Pattern-RemoteData), and its snapshot lives at
-;; `[:rf/machines :realworld/tags]`. Similarly the `:settings` slice is
-;; replaced by the `:settings/form` machine at `[:rf/machines :settings/form]`.
 
 (rf/reg-app-schemas
   {[:auth]                          AuthSlice

--- a/examples/reagent/realworld/ssr.cljc
+++ b/examples/reagent/realworld/ssr.cljc
@@ -18,13 +18,11 @@
    :articles
    :article
    :comments
-   :tags
    :feed
    :profile
    :profile.articles
    :profile.favorites
    :editor
-   :settings
    :comment-form
    :rf/machines])
 

--- a/examples/reagent/realworld/tags.cljs
+++ b/examples/reagent/realworld/tags.cljs
@@ -23,9 +23,8 @@
      collapse into per-state `:tags` queried with `rf/machine-has-tag?`.
 
    Routing pieces (`:home/load`, `:home/show-global-feed`, etc.) sit
-   below — they predate the refactor and are unaffected by it,
-   though they dispatch `:tags/load` so the new machine fetches when
-   the home route activates."
+   below — they dispatch `:tags/load` so the popular-tags machine fetches
+   when the home route activates."
   (:require [re-frame.core :as rf]
             ;; The Spec 005 state-machine ns lives in the
             ;; day8/re-frame2-machines artefact. Loading the ns here
@@ -216,7 +215,7 @@
     (get-in snap [:data :error])))
 
 ;; ============================================================================
-;; HOME-PAGE QUERY HELPERS  (predate the machine refactor; unaffected by it)
+;; HOME-PAGE QUERY HELPERS
 ;; ============================================================================
 ;;
 ;; The route-query driven part of the home page:

--- a/examples/reagent/realworld/test/realworld/core_test.cljs
+++ b/examples/reagent/realworld/test/realworld/core_test.cljs
@@ -21,11 +21,8 @@
   (with-frame [f (rf/make-frame {:on-create    [:app/initialise]
                                  :fx-overrides {:rf.http/managed      :realworld.test/canned-success-empty
                                                 :auth.session/persist :rf/no-op}})]
-    ;; After init: auth + articles slices and the :realworld/tags
-    ;; and :settings/form machine snapshots are present. The tags
-    ;; machine replaces the slice-form `:tags` resource; the
-    ;; settings/form machine replaces the slice-form `:settings`
-    ;; resource.
+    ;; After init: the :auth + :articles slices and the
+    ;; :realworld/tags + :settings/form machine snapshots are present.
     (let [db (rf/get-frame-db f)]
       (assert (contains? db :auth))
       (assert (contains? db :articles))

--- a/examples/reagent/seven_guis/README.md
+++ b/examples/reagent/seven_guis/README.md
@@ -14,7 +14,7 @@
 
 Each example lives in its own self-contained sub-folder under `seven_guis/<name>/` with its CLJS source and a thin HTML host page (e.g. `cells/core.cljs` + `cells/index.html`). Per the test-free examples policy there is **no per-example `.spec.cjs`** — real-regression coverage lives in the substrate contract tests (`npm run test:cljs`) and the framework gates (`test:xray-feature-gate` / `test:bundle-isolation` / `test:perf-bundle`), not under `examples/`. The shadow-cljs build targets in `implementation/shadow-cljs.edn` wire each task up to its own bundle; to view one in a browser, watch its build (`shadow-cljs watch examples/cells`) and serve the staged `index.html`.
 
-CLJS namespace identifiers can't start with a digit, so the on-disk directory is `seven_guis/` and the cluster namespace prefix is `seven-guis.*`. Each task follows the catalogue's `<name>.core` shape: `seven-guis.cells.core`, `seven-guis.flight-booker.core`, etc. — one consistent scope across every example in the cluster (rf2-hg45c).
+CLJS namespace identifiers can't start with a digit, so the on-disk directory is `seven_guis/` and the cluster namespace prefix is `seven-guis.*`. Each task follows the catalogue's `<name>.core` shape: `seven-guis.cells.core`, `seven-guis.flight-booker.core`, etc. — one consistent scope across every example in the cluster.
 
 ## How these compare to the original 7GUIs reference
 

--- a/examples/reagent/seven_guis/cells/core.cljs
+++ b/examples/reagent/seven_guis/cells/core.cljs
@@ -14,7 +14,7 @@
 
    Demonstrates:
    - The subscription graph at full strength
-   - Cycles detected by walking declared deps                (per-formula static dep set)
+   - Cycles detected via a visited-set walk during evaluation
    - Open-map cell registry (sparse storage)
    - Pure parser + evaluator (no eval, no host I/O)
 
@@ -258,13 +258,11 @@
 ;; MOUNT
 ;; ============================================================================
 
-;; React root named `react-root` (not `root`) so it does NOT collide
-;; with reg-view-defined view vars in this ns.
-(defonce react-root
+(defonce root
   (rdc/create-root (js/document.getElementById "app")))
 
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-slim-adapter/adapter)
   (rf/dispatch-sync [:cells/initialise])
-  (rdc/render react-root [cells-grid]))
+  (rdc/render root [cells-grid]))

--- a/examples/reagent/seven_guis/circle_drawer/core.cljs
+++ b/examples/reagent/seven_guis/circle_drawer/core.cljs
@@ -224,13 +224,11 @@
 ;; MOUNT
 ;; ============================================================================
 
-;; React root named `react-root` (not `root`) so it does NOT collide
-;; with the `drawer-view` reg-view above.
-(defonce react-root
+(defonce root
   (rdc/create-root (js/document.getElementById "app")))
 
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-slim-adapter/adapter)
   (rf/dispatch-sync [:drawer/initialise])
-  (rdc/render react-root [drawer-view]))
+  (rdc/render root [drawer-view]))

--- a/examples/reagent/seven_guis/crud/core.cljs
+++ b/examples/reagent/seven_guis/crud/core.cljs
@@ -190,14 +190,11 @@
 ;; MOUNT
 ;; ============================================================================
 
-;; The React root is named `react-root` (not `root`) so it does NOT
-;; collide with the `crud-view` reg-view above; reg-view defs vars in
-;; this ns and any name-collision would shadow the rdc root handle.
-(defonce react-root
+(defonce root
   (rdc/create-root (js/document.getElementById "app")))
 
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-slim-adapter/adapter)
   (rf/dispatch-sync [:crud/initialise])
-  (rdc/render react-root [crud-view]))
+  (rdc/render root [crud-view]))

--- a/examples/reagent/ssr_streaming/README.md
+++ b/examples/reagent/ssr_streaming/README.md
@@ -2,8 +2,11 @@
 
 A dashboard with three slow cards: the page's shell + header render
 immediately on the server, then each card streams its content as its
-data fetch resolves. The browser shows a usable shell within ~50ms
-while the cards trickle in over ~300ms each. The worked companion to
+data fetch resolves. In a real deployment with three slow microservices
+the browser would show a usable shell within ~50ms while the cards
+trickle in over ~300ms each; this canned demo seeds all three cards
+synchronously from `:rf/server-init` so the demo runs offline. The
+worked companion to
 [Spec 011 §Streaming
 SSR](../../../spec/011-SSR.md#streaming-ssr).
 

--- a/examples/reagent/ssr_streaming/core.cljc
+++ b/examples/reagent/ssr_streaming/core.cljc
@@ -175,14 +175,16 @@
 ;;     `<body>` begins downloading.
 ;;  2. Resolved-card chunks stream in via Transfer-Encoding: chunked.
 ;;     Each one is `<template data-rf2-suspense-resolved=…>…</template>`
-;;     plus `<script data-rf2-suspense-hydrate=…>…</script>`. Our shim
-;;     (forthcoming, see below) swaps the fallback for the resolved
-;;     content and merges the per-subtree delta into the client app-db.
-;;  3. The final `<script id="__rf_payload">` arrives last. The shim
-;;     dispatches `:rf/hydrate` with the canonical full payload, which
-;;     runs :replace-app-db semantics — the per-card deltas were
-;;     progressive-render speed props; the final payload is the
-;;     correctness lock.
+;;     plus `<script data-rf2-suspense-hydrate=…>…</script>`. In a real
+;;     deployment, a thin client shim would swap the fallback for the
+;;     resolved content and merge the per-subtree delta into the client
+;;     app-db; this canned demo skips that step — the index.html host
+;;     shell already contains the pre-baked resolved chunks, so the DOM
+;;     is in its final shape by the time `run` executes.
+;;  3. The final `<script id="__rf_payload">` is the canonical full
+;;     payload; `run` dispatches `:rf/hydrate` against it, which runs
+;;     :replace-app-db semantics — the per-card deltas were progressive-
+;;     render speed props; the final payload is the correctness lock.
 
 #?(:cljs
    (defn read-server-payload []

--- a/examples/reagent/state_machine_walkthrough/README.md
+++ b/examples/reagent/state_machine_walkthrough/README.md
@@ -68,9 +68,12 @@ test suite. To run them ad-hoc from a CLJS or JVM REPL:
 ```clojure
 (require '[state-machine-walkthrough.core])      ;; load the machine
 (require '[state-machine-walkthrough.core-test :as t])
-(t/test-idle-to-submitting)
-(t/test-submitting-to-error)
-;; ...one per chapter scenario.
+(t/smoke-tests)                                  ;; runs all four scenarios
+;; or one at a time:
+(t/pure-happy-path-test)
+(t/pure-lockout-test)
+(t/drain-happy-path-test)
+(t/drain-retry-then-lockout-test)
 ```
 
 ## Cross-references

--- a/examples/reagent/state_machine_walkthrough/core.cljc
+++ b/examples/reagent/state_machine_walkthrough/core.cljc
@@ -1,7 +1,7 @@
 (ns state-machine-walkthrough.core
   "Runnable companion to docs/guide/11-machines.md.
 
-  This is the login-flow chapter as code. Every prose snippet in ch.09
+  This is the login-flow chapter as code. Every prose snippet in ch.11
   appears here in the order the chapter introduces it; each section
   ends with a smoke-test fn that drives the machine through the
   scenario the chapter describes.
@@ -29,7 +29,13 @@
             ;; :fx-overrides into :rf.http/managed-canned-* relies on
             ;; those fx ids being registered. Registration lives in
             ;; re-frame.http-test-support.
-            [re-frame.http-test-support]))
+            [re-frame.http-test-support]
+            ;; The canned-failure / canned-success stubs below delegate
+            ;; to the framework-shipped `:rf.http/managed-canned-*` fxs
+            ;; via the registrar so the example demo (views.cljs) and
+            ;; the headless tests (test/state_machine_walkthrough/core_test.cljc)
+            ;; can share one registration point.
+            [re-frame.registrar :as registrar]))
 
 ;; ============================================================================
 ;; THE TRANSITION TABLE — chapter §The same flow as a machine
@@ -103,7 +109,7 @@
     :submitting
     ;; :auth/busy tag — views query (rf/machine-has-tag? :auth.login/flow
     ;; :auth/busy) to disable inputs and re-label the submit button
-    ;; while the request is in flight (ch.09 §State tags).
+    ;; while the request is in flight (ch.11 §State tags).
     {:tags  #{:auth/busy}
      :entry :issue-request
      :on    {:auth.login/success {:target :authed
@@ -145,6 +151,32 @@
   {:doc "Stub: a real implementation would write localStorage."}
   (fn [_m _args] nil))
 
+;; Per Spec 014 §Testing, the framework ships `:rf.http/managed-canned-success`
+;; and `:rf.http/managed-canned-failure` fxs that synthesise the canonical reply
+;; shape. The wrappers below pin the example's specific payloads — both the
+;; browser demo (views.cljs installs the canned-failure override on the
+;; default frame) and the headless tests (core-test.cljc reads them via
+;; `:fx-overrides`) consume them.
+
+(rf/reg-fx :auth.login/canned-success
+  {:doc "Example stub: every `:rf.http/managed` call resolves :success with a
+         canned user/token payload. Delegates to the framework-shipped
+         `:rf.http/managed-canned-success` per Spec 014 §Testing."}
+  (fn [frame-ctx args-map]
+    (let [stub (registrar/handler :fx :rf.http/managed-canned-success)]
+      (stub frame-ctx (assoc args-map :value {:user  {:id "test-user"}
+                                              :token "test-token"})))))
+
+(rf/reg-fx :auth.login/canned-failure
+  {:doc "Example stub: every `:rf.http/managed` call resolves :failure.
+         Delegates to the framework-shipped `:rf.http/managed-canned-failure`
+         per Spec 014 §Testing."}
+  (fn [frame-ctx args-map]
+    (let [stub (registrar/handler :fx :rf.http/managed-canned-failure)]
+      (stub frame-ctx (assoc args-map
+                             :kind :rf.http/http-4xx
+                             :tags {:message "bad creds" :status 401})))))
+
 ;; ============================================================================
 ;; REGISTRATION — chapter §Wiring a machine into the rest of re-frame
 ;; ============================================================================
@@ -163,7 +195,7 @@
 ;; The machine snapshot lives at [:rf/machines :auth.login/flow] (per
 ;; Spec 005). These named subs project out the convenient pieces. The
 ;; "in :submitting?" / "in :authed?" / "in :locked-out?" predicates
-;; moved to the `rf/machine-has-tag?` queries in views.cljs (ch.09 §State
+;; moved to the `rf/machine-has-tag?` queries in views.cljs (ch.11 §State
 ;; tags) — discriminating on the machine's runtime-projected `:tags`
 ;; set decouples view code from individual state-keyword identity.
 

--- a/examples/reagent/state_machine_walkthrough/test/state_machine_walkthrough/core_test.cljc
+++ b/examples/reagent/state_machine_walkthrough/test/state_machine_walkthrough/core_test.cljc
@@ -19,37 +19,12 @@
   re-frame.state-machine-walkthrough-cljs-test."
   (:require [re-frame.core :as rf]
             [re-frame.machines.result :as result]
-            [re-frame.registrar :as registrar]
             [state-machine-walkthrough.core :as core]))
 
-;; ============================================================================
-;; TEST STUBS — per-test wrappers that delegate to the framework-shipped
-;; canned-success / canned-failure stubs.
-;; ============================================================================
-;;
-;; Per Spec 014 §Testing, the framework ships `:rf.http/managed-canned-success`
-;; and `:rf.http/managed-canned-failure` fxs that synthesise the canonical
-;; reply shape. Per-test wrappers delegate to those stubs while supplying
-;; the test-specific `:value` (success) / failure category.
-
-(rf/reg-fx :auth.login/canned-success
-  {:doc "Test stub: every `:rf.http/managed` call resolves :success with a
-         canned user/token payload. Delegates to the framework-shipped
-         `:rf.http/managed-canned-success` per Spec 014 §Testing."}
-  (fn [frame-ctx args-map]
-    (let [stub (registrar/handler :fx :rf.http/managed-canned-success)]
-      (stub frame-ctx (assoc args-map :value {:user  {:id "test-user"}
-                                              :token "test-token"})))))
-
-(rf/reg-fx :auth.login/canned-failure
-  {:doc "Test stub: every `:rf.http/managed` call resolves :failure.
-         Delegates to the framework-shipped `:rf.http/managed-canned-failure`
-         per Spec 014 §Testing."}
-  (fn [frame-ctx args-map]
-    (let [stub (registrar/handler :fx :rf.http/managed-canned-failure)]
-      (stub frame-ctx (assoc args-map
-                             :kind :rf.http/http-4xx
-                             :tags {:message "bad creds" :status 401})))))
+;; The `:auth.login/canned-success` and `:auth.login/canned-failure` stubs
+;; used by the drain tests below are registered in
+;; `state-machine-walkthrough.core` (loaded via the `:as core` require above)
+;; so both the browser demo and the tests share one registration point.
 
 ;; ============================================================================
 ;; HEADLESS TESTS — chapter §Headless testing

--- a/examples/reagent/state_machine_walkthrough/views.cljs
+++ b/examples/reagent/state_machine_walkthrough/views.cljs
@@ -27,7 +27,7 @@
                   :auth.login/flow → :auth.login/submit on submit.
 
                   View-side discriminators read the machine's runtime-projected
-                  `:tags` set (ch.09 §State tags) via `rf/machine-has-tag?`, not boolean
+                  `:tags` set (ch.11 §State tags) via `rf/machine-has-tag?`, not boolean
                   state-predicate subs."}
           login-form []
   (let [state (atom {:email "" :password ""})]

--- a/examples/reagent/todomvc/views.cljs
+++ b/examples/reagent/todomvc/views.cljs
@@ -116,13 +116,12 @@
         "Clear completed"])]))
 
 ;; Sub-views (task-entry, task-list, todo-item, footer-controls) above
-;; are plain Reagent fns. Per Spec 004 §reg-view auto-inject, the
-;; capture-and-pass threading PR #51 introduced is no longer needed —
-;; sub-views can read `dispatch` / `subscribe` directly from the
-;; surrounding reg-view scope. We keep them as plain fns here (rather
-;; than reg-view'ing each sub-piece) because they're internal helpers
-;; with no need for their own registry slot or auto-defed Var; that
-;; gives the cleanest read in this example.
+;; are plain Reagent helper fns, not reg-views. They take `dispatch` /
+;; `subscribe` as explicit args because that's the right shape for plain
+;; fns; if they were reg-views they would read both from the surrounding
+;; reg-view scope automatically (Spec 004 §reg-view auto-inject). Plain
+;; fns are the cleanest read for these internal helpers — no need for
+;; per-sub-piece registry slots or auto-defed Vars.
 (reg-view root-view []
   (let [todos @(subscribe [:todo/todos])]
     [:<>

--- a/examples/reagent/websocket/schema.cljs
+++ b/examples/reagent/websocket/schema.cljs
@@ -114,8 +114,9 @@
    [:draft    :string]
    ;; Received-message log: newest-first so the view renders top-down.
    [:received [:vector Message]]
-   ;; Last correlated reply landed via :ws/reply — handy for the
-   ;; request-reply round-trip view + the Playwright smoke assertion.
+   ;; Last correlated reply landed via :ws.app/request-reply (or via
+   ;; :ws/handle-message for server pushes) — handy for the request-reply
+   ;; round-trip view + the Playwright smoke assertion.
    [:last-reply [:maybe :any]]
    ;; Monotonic counter feeding each message's stable :rx-seq.
    [:rx-count :int]])

--- a/examples/scripts/run-examples-tests.cjs
+++ b/examples/scripts/run-examples-tests.cjs
@@ -34,10 +34,14 @@
  *     name:  string,                         // human-readable
  *     url:   string,                         // path under the static server root
  *     run:   async (page) => void,           // Playwright assertions
- *     skip:  string | false                  // optional — when truthy, the
- *                                            //   spec is reported as SKIP
- *                                            //   with this string as the
- *                                            //   reason.
+ *     skip:  string | falsy                  // optional — when truthy
+ *                                            //   (any non-empty string),
+ *                                            //   the spec is reported as
+ *                                            //   SKIP with this string as
+ *                                            //   the reason. Any falsy
+ *                                            //   value (false / null /
+ *                                            //   undefined / "") = run
+ *                                            //   normally.
  *   }
  *
  * Exit code: 0 if every spec's `run` resolves (skipped specs count as

--- a/examples/scripts/story-feature-load-port.cjs
+++ b/examples/scripts/story-feature-load-port.cjs
@@ -1,3 +1,11 @@
+/*
+ * Worktree-aware port resolver for the Story feature-load gate. The
+ * deterministic hash of the worktree path derives a stable port offset
+ * so parallel worktrees (rf2-* worker checkouts) never collide on 8031.
+ * Honours STORY_FEATURE_LOAD_PORT if set; otherwise scans forward from
+ * the derived preference until an unused port is found.
+ */
+
 'use strict';
 
 const net = require('net');


### PR DESCRIPTION
Five comment-residue beads from the EXAMPLES-R1/R2/R3 audits. All
mechanical edits except for one **real runtime bug** surfaced by the
state_machine_walkthrough audit; see rf2-5idpd item 6 below.

## Beads

| bead    | summary |
|---------|---------|
| rf2-5idpd | examples/reagent: 16 comment + content fixes from EXAMPLES-R2 audit (state_machine_walkthrough + todomvc + websocket + ssr_streaming + seven_guis + realworld). **Includes a real runtime-bug fix** — see below. |
| rf2-7xtc2 | examples/helix/login_helix: port the `no dispatch-sync seed` rationale comment from the UIx/Reagent twins. |
| rf2-uq6ix | examples: document the size-keyed banner-comment style policy in examples/README.md (light banner for sketch-sized files, heavy ASCII box for ~250-line design-led / machine-bearing files). |
| rf2-45pie | examples/scripts: add the file-header preamble to story-feature-load-port.cjs + tighten the `skip` type in run-examples-tests.cjs (`string \| falsy`). |
| rf2-v5lpl | examples/long_running_work: clarify the `:cancelled` shape-completeness rationale comment. (boot left as-is — its `:failed` IS reached on demo-stub failure.) |

## Runtime-bug fix (rf2-5idpd item 6)

`examples/reagent/state_machine_walkthrough/views.cljs` installs an
`:fx-overrides` redirect from `:rf.http/managed` to
`:auth.login/canned-failure`, but that fx was only registered in
`test/state_machine_walkthrough/core_test.cljc`. The standalone browser
demo would resolve the override to nothing.

Fix: move both `:auth.login/canned-success` and `:auth.login/canned-failure`
into `core.cljc` so views.cljs (which already `:require`s
state-machine-walkthrough.core) and the headless test ns share one
registration point. The test ns's stub definitions are dropped (it now
relies on the core.cljc registrations via its `(:require [...core :as core])`).

## Quality gates

- `npm run test:examples` — 3/3 adapter smokes pass (port 18030 used
  locally because 8030 was blocked).
- `bash scripts/test-fast-pr.sh` — lockstep + skill/MCP drift + core JVM (787 tests) + script policy + cljs node integration (4836 tests) + markdown link/anchor gates all PASS. `mkdocs --strict` soft-skipped on Windows (CI runs it).