### PR TITLE
docs(spec): polish sweep — 4 beads (7bfs7 + 1hd9g + 7vjju + kabt8)

### DIFF
--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -1294,40 +1294,31 @@
       (process-event* envelope))))
 
 (def ^:private drain-depth-default
-  ;; Deep enough for typical cascade depths; cheap atomic rollback per
-  ;; Spec 002 §Run-to-completion rule 3 when exceeded.
+  ;; Deep enough for typical cascade depths. When exceeded, the runtime
+  ;; halts the next (unstarted) event per Spec 002 §Run-to-completion rule
+  ;; 3 — already-settled events stay durable; the halting event gets a
+  ;; trailing `:halted-depth` epoch record (no whole-drain rollback under
+  ;; the per-event epoch model).
   100)
 
 (defn- handle-depth-exceeded!
   "Tail-path for the depth-limit branch of `drain!`. Per Spec 002
-  §Drain versus event — the epoch unit (rf2-u6jsj/rf2-nj6p7): the epoch
-  boundary is the dequeued EVENT, so the events that already ran in this
-  drain each settled their own DURABLE `:ok` epoch (and their own db
-  write) as they completed — there is NO whole-drain rollback under
-  per-event epochs. The depth limit stops processing the NEXT event (the
-  halting event, still at the head of the queue); the work that already
-  ran is a sequence of complete, individually-atomic events.
+  §Drain versus event — the epoch unit: the epoch boundary is the
+  dequeued EVENT, so the events that already ran in this drain each
+  settled their own DURABLE `:ok` epoch (and their own db write) as they
+  completed — there is no whole-drain rollback under per-event epochs.
+  The depth limit stops processing the NEXT event (the halting event,
+  still at the head of the queue); the work that already ran is a
+  sequence of complete, individually-atomic events.
 
-  Per rf2-v0jwt §Outcomes: commit a `:halted-depth` epoch record so
-  devtools (Xray, re-frame2-pair) get a clear 'drain halted here'
-  marker following the runaway `:ok` epochs. The halting event never ran,
-  so its record's `:db-before` / `:db-after` both equal the current
-  (last-settled) db value and its buffer is empty — `commit-halt-record!`
-  synthesises the record from the halting event's trigger. Listeners
-  receive it like any other; `restore-epoch` refuses non-`:ok` targets.
-
-  ## Reconcile with Spec 002 rule 3 (NOTED for spec-tightening, rf2-nj6p7)
-
-  Rule 3 (and the `drain-depth-limit.edn` conformance fixture) describe
-  WHOLE-DRAIN atomic rollback to a pre-drain snapshot, written for the
-  pre-rf2-u6jsj per-drain epoch model. The merged spec PR #1948 redefined
-  the epoch as per-event but did NOT update rule 3 / the fixture
-  (\"impl follow-up rf2-nj6p7\"). Under per-event epochs, whole-drain
-  rollback is incoherent — each settled event is independently atomic and
-  durable. This impl follows the per-event model the merged spec defines:
-  already-settled siblings are durable; only the halting event (which
-  never ran) gets a `:halted-depth` marker. Rule 3's pre-drain-rollback
-  text and the fixture need tightening to the per-event boundary."
+  Per Spec-Schemas §`:rf/epoch-record` §Outcomes: commit a `:halted-depth`
+  epoch record so devtools (Xray, re-frame2-pair) get a clear 'drain
+  halted here' marker following the runaway `:ok` epochs. The halting
+  event never ran, so its record's `:db-before` / `:db-after` both equal
+  the current (last-settled) db value and its buffer is empty —
+  `commit-halt-record!` synthesises the record from the halting event's
+  trigger. Listeners receive it like any other; `restore-epoch` refuses
+  non-`:ok` targets."
   [frame-id router depth last-event]
   (let [{:keys [queue]} @router
         queue-size      (count queue)

--- a/spec/009-Instrumentation.md
+++ b/spec/009-Instrumentation.md
@@ -344,6 +344,32 @@ t1 fires when the handler returned `:db`, regardless of whether the flows artefa
 
 `:rf.event/db-changed` does NOT fire because the pending `:db` effect was discarded (no install, app-db unchanged, no partial commit); `:rf.fx/handled` does NOT fire because `:fx` is the post-install stage and the event aborted before it. This is the **same** truncated signature every other pre-install throw produces — a handler throw or an interceptor-`:after` throw emits `:rf.error/handler-exception` and then the `:rf.event/run-end` cascade-tail trailer, with no `:rf.event/db-changed` and no `:rf.fx/handled`. (As on the clean path, `:rf.event/run-end` is the **last** trace — the error event precedes the trailer.)
 
+#### Emit-gate summary — which emits ride which substrate
+
+Tooling authors (Xray, Story, re-frame-10x, off-box monitors) need to know **for every emit in the canonical sequence**: under what condition does the emit fire, and which substrate carries it — the **always-on** event-emit / error stream available in production builds, or the **dev-only** trace stream gated by `re-frame.interop/debug-enabled?` (alias of `goog.DEBUG`; DCE'd in `:advanced` builds). The table below pins both contracts for the per-event emits between `:run-start` and `:run-end`:
+
+| `:operation` | Substrate | Gate — fires when |
+|---|---|---|
+| `:rf.event/dispatched` | always-on | every dispatch envelope (precedes the drain; one per dispatch) |
+| `:rf.event/run-start` | always-on | every event the handler chain begins on |
+| `:rf.cofx/run` | dev-only | per inject-cofx interceptor that ran to success, in `:before-chain` order |
+| `:rf.event/db-pending` (t1) | dev-only | the handler returned a `:db` slot (suppressed otherwise) |
+| `:rf.flow/computed` | dev-only | per flow whose dirty-check observed an input value-difference |
+| `:rf.flow/skip` | dev-only | per flow whose dirty-check found inputs `=`-equal to the previous run |
+| `:rf.flow/failed` | dev-only | per flow whose `:output` threw |
+| `:rf.event/db-pending-post-flow` (t2) | dev-only | flows transformed the pending value (`(not (identical? new-db pending-db))`); suppressed when t1 == t2 |
+| `:rf.event/db-changed` | dev-only | the flow-augmented `:db` installed into `app-db` (single deferred commit) |
+| `:rf.sub/run` / `:rf.sub/skip` | dev-only | per sub on the cache that depends on a changed input |
+| `:rf.fx/handled` | dev-only | per `:fx` entry, after the deferred install |
+| `:rf.fx/do-fx` | dev-only | terminating `:fx`-walk marker, after all per-entry `:rf.fx/handled` emits |
+| `:rf.view/render` / `:rf.view/rendered` | dev-only | per reactive view re-rendered on the new db |
+| `:rf.error/*` (cascade-level) | always-on | every cascade error — `:rf.error/handler-exception` / `:rf.error/flow-eval-exception` / interceptor errors / fx errors |
+| `:rf.event/run-end` | always-on | cascade-tail; fires LAST after `commit-and-flow!`, on both clean and aborted paths |
+
+**Always-on emits** ride the production-available event-emit / error-emit channels per [§Production debugging](#production-debugging-what-remains): they survive `:advanced` DCE and feed the production listener surfaces (event-emit, error-emit, error-projection). Wire-egress to off-box monitors (Sentry / Rollbar / etc.) only sees these.
+
+**Dev-only emits** are wrapped in the `interop/debug-enabled?` gate per [§Production builds: zero overhead, zero code](#production-builds-zero-overhead-zero-code); they vanish entirely from `:advanced` bundles. Xray / Story / re-frame-10x consume them in dev builds where the gate is true. A production `:advanced` build emits exactly the always-on rows above and nothing else.
+
 ### Flow trace events
 
 Five trace events constitute the flow lifecycle stream (per [013 §Flow tracing](013-Flows.md#flow-tracing)). All five carry `:op-type :flow`; consumers filter by `:op-type` to subscribe to the whole stream and branch on `:operation` to discriminate. Every event's `:tags` carries `:flow-id` and `:frame` so tools can attribute and route per-frame.

--- a/spec/014-HTTPRequests.md
+++ b/spec/014-HTTPRequests.md
@@ -79,17 +79,23 @@ When the request resolves, the runtime dispatches `[:article/load (assoc msg :rf
 
 ## The args map
 
-| Key | Required? | Type | Purpose |
+The `:rf.http/managed` fx accepts a single args map. The reference card below lists every public slot, its default, and — for slots that can cause a request to fail — the failure category the runtime classifies into. Each row anchors to its Spec 014 detail section.
+
+| Slot | Default | Meaning | Recovery on failure |
 |---|---|---|---|
-| `:request` | yes | map | The request envelope (see [§Request envelope](#request-envelope)). |
-| `:decode` | no | spec / fn / `:json` / `:text` / `:blob` / `:array-buffer` / `:form-data` / `:auto` | How to parse the response body (see [§Decoding](#decoding)). Default: `:auto` (content-type sniffing). |
-| `:accept` | no | fn `(decoded → {:ok v} | {:failure m})` | Post-decode normalisation; lets a handler treat a structurally-valid 200 as a domain failure. Default: `(fn [v] {:ok v})` for 2xx, structural failure otherwise. |
-| `:retry` | no | map | Retry policy (see [§Retry and backoff](#retry-and-backoff)). Default: no retry. |
-| `:timeout-ms` | no | int / `nil` / `0` | Wall-clock timeout per attempt. **Default: 30000** when the key is absent. Per [§`:timeout-ms` security defaults](#timeout-ms-security-defaults) — `:timeout-ms nil` and `:timeout-ms 0` are explicit opt-outs (no per-attempt timeout). Apps facing untrusted upstreams SHOULD leave the default in place. |
-| `:on-success` | no | event vector | Where to dispatch on success. Default: back to originating event id with `:rf/reply` merged. |
-| `:on-failure` | no | event vector or `nil` | Where to dispatch on failure. Default: back to originating event id with `:rf/reply` merged. `nil` means swallow silently. |
-| `:request-id` | no | any `=`-comparable value | Stable id for abort + correlation (see [§Aborts](#aborts)). Keywords (`:search`), strings (`"req-42"`), vectors (`[:articles :load 7]`), uuids — anything the runtime can `=`-compare. The fx stores in-flight requests in a `{request-id → request-handle}` map; identity is structural. |
-| `:abort-signal` | no | external `AbortController.signal` | External abort handle. Mutually exclusive with `:request-id`-driven internal abort. |
+| `:request` | required | The wire envelope — `:method` / `:url` / `:headers` / `:params` / `:body` / `:request-content-type` / `:credentials` / `:mode` / `:redirect` / `:cache` / `:referrer` / `:integrity` / `:sensitive?`. See [§Request envelope](#request-envelope). | A bad envelope surfaces as `:rf.http/transport`, `:rf.http/cors`, `:rf.http/http-4xx`, or `:rf.http/http-5xx` depending on how the host rejects it. |
+| `:decode` | `:auto` | Response-body decoder: a Malli schema, a fn `(response-text headers → decoded)`, or one of `:json` / `:text` / `:blob` / `:array-buffer` / `:form-data` / `:auto`. Runs only on 2xx. See [§Decoding](#decoding). | `:rf.http/decode-failure` (schema reject, JSON parse, custom-fn throw). |
+| `:accept` | 2xx → `{:ok body}`, else structural failure | Post-decode normaliser `(decoded → {:ok v} | {:failure m})` — lets a structurally-valid 200 surface as a domain failure. See [§`:accept` — domain-failure normalisation](#accept--domain-failure-normalisation). | `:rf.http/accept-failure` (the user map rides at `:detail`). |
+| `:retry` | no retry | Retry policy `{:on #{categories} :max-attempts N :backoff {:base-ms :factor :max-ms :jitter}}`. `:on` is a closed subset of `#{:rf.http/transport :rf.http/cors :rf.http/timeout :rf.http/http-4xx :rf.http/http-5xx}`. See [§Retry and backoff](#retry-and-backoff). | Invalid `:retry :on` member → `:rf.error/http-bad-retry-on` at registration / dispatch time. Retries exhaust → the final failure category. |
+| `:timeout-ms` | `30000` | Per-attempt wall-clock timeout in ms. `nil` or `0` opts out (no timeout). See [§`:timeout-ms` security defaults](#timeout-ms-security-defaults). | `:rf.http/timeout` when the budget elapses. |
+| `:on-success` | originating event id with `:rf/reply` merged | Where to dispatch the success reply. See [§Reply addressing](#reply-addressing). | — (`:on-success` does not itself fail.) |
+| `:on-failure` | originating event id with `:rf/reply` merged | Where to dispatch the failure reply. `nil` swallows silently. See [§Reply addressing](#reply-addressing). | — (`:on-failure` does not itself fail; it routes the reply.) |
+| `:request-id` | none | Stable `=`-comparable id for abort + correlation. Keywords / strings / vectors / uuids all work. See [§`:request-id` (internal)](#request-id-internal). | Superseded by a later request with the same id → in-flight request aborts with `:rf.http/aborted :reason :request-id-superseded` on the trace stream. |
+| `:abort-signal` | none | External `AbortController.signal` handle. Mutually exclusive with `:request-id`-driven internal abort. CLJS-only; JVM ignores. See [§`:abort-signal` (external)](#abort-signal-external). | `:rf.http/aborted :reason :user` when the host fires the signal. |
+| `:sensitive?` | `false` | Marks the request body / headers / params / decoded value as sensitive for the trace stream. Honours [Spec 009 §Privacy](009-Instrumentation.md#privacy--sensitive-data-in-traces). May also be set under `:request`; the top-level slot is sugar. See [§Privacy](#privacy). | — (privacy flag; does not affect classification.) |
+| `:rf.http/max-decoded-keys` | `10000` | Per-request cap on the number of unique JSON object keys the decoder will intern. Second line of defence after `:decode :text` for untrusted-origin payloads. See [§Keyword-interning cap](#keyword-interning-cap). | `:rf.http/decode-failure :reason :too-many-keys` on overflow. |
+
+Stub-mode slots (`:rf.http/canned-success` / `:rf.http/canned-failure` and the `with-managed-request-stubs` family) live in the sibling `re-frame.http-test-support` namespace and are documented in [§Testing](#testing); they are not part of the production args-map surface.
 
 ## Request envelope
 

--- a/spec/Principles.md
+++ b/spec/Principles.md
@@ -33,6 +33,14 @@ Anonymous closures hidden inside setup code are harder for tools to inspect, pat
 
 Positional shapes are *placeful*: meaning is carried by where a value sits, which is implicit knowledge readers and writers must keep in their heads. They are brittle under evolution — inserting a new field in the middle is a multi-site rewrite where every call site must reshuffle in lock-step; reordering has the same hazard. They are also harder for tools, AIs, and migration agents to reason about, because the names that give the values meaning live somewhere else (the destructuring site, the docstring) rather than at the data itself. Map-shaped data inverts the trade-off: meaning is at the data, evolution is additive (new key in some sites; old sites still parse), and the schema attaches as a `:map` rather than a fragile `:tuple`. The pattern applies anywhere data carries multiple values: event payloads (`[<id> {...}]` over `[<id> arg1 arg2 ...]` per [MIGRATION §M-19](../migration/from-re-frame-v1/README.md#m-19-multi-positional-dispatch--subscribe-vectors--map-payload-form-opt-in)), effect maps, registration metadata, frame configs, machine snapshots, trace event tags, hiccup attributes. Single-value cases (a sub of one scalar id, a `[:counter/inc]` event with no payload) stay positional — the place-vs-name trade-off only bites once arity grows.
 
+### Uniform context-map callbacks
+
+**Principle:** every callback slot in a family takes a *single context-map argument*; new slot additions extend the keys, not the arity.
+
+The discipline applies wherever the runtime invokes user code from multiple slot types in the same family — state-machine `:guard` / `:action` / `:entry` / `:exit` / `:on-done` / `:on-spawn` / `:after` / `:spawn :data`, fx interceptors, sub query functions, error projectors. Each callback receives one map whose keys depend on the slot (`:data` / `:event` / `:state` / `:meta` for guards and actions; `:data` / `:result` for `:on-done`; `:snapshot` for `:after`; etc.), and user code destructures the keys it cares about. This is a specialisation of *name over place* for callback arities: instead of an N-positional signature that varies by slot — `(fn [data event] ...)` vs `(fn [data event state meta] ...)` vs `(fn [data result] ...)` — every slot reads one uniform map.
+
+The benefit is symmetry across the family: future slot additions add keys without expanding an arity-permutation matrix, destructuring at the call site makes the meaningful keys explicit, and a single context shape is what tooling, conformance fixtures, and AI scaffolding can describe once and apply everywhere. Spec 005 §Guards / §Actions / §Spawn defines the realisation for machine callbacks; [005-StateMachines §Guards](005-StateMachines.md#guards) and the surrounding sections pin the slot-by-slot key contract.
+
 ### Data before magic
 
 **Principle:** behaviour is expressible as data plus interpreter.

--- a/spec/conformance/fixtures/drain-depth-limit.edn
+++ b/spec/conformance/fixtures/drain-depth-limit.edn
@@ -2,28 +2,22 @@
 ;; Exercises the drain-depth-exceeded error. A handler that recursively
 ;; dispatches itself triggers the configured drain depth limit.
 ;;
-;; Per rf2-u6jsj/rf2-nj6p7 (Spec 002 §Drain versus event — the epoch
-;; unit): the epoch boundary is the dequeued EVENT, not the drain, so the
+;; Per Spec 002 §Drain versus event — the epoch unit and §Run-to-completion
+;; rule 3: the epoch boundary is the dequeued EVENT, not the drain. The
 ;; runaway events that already ran each settled their OWN durable :ok
-;; epoch (and their own db write) before the limit tripped. There is NO
-;; whole-drain rollback under per-event epochs — each settled event is
-;; independently atomic. The depth limit stops the NEXT (halting) event;
-;; the runtime commits a trailing :halted-depth :rf/epoch-record for it
-;; (rf2-v0jwt §Outcomes) so devtools (Xray, re-frame2-pair) get a clear
-;; "drain halted here" marker following the durable :ok epochs. The
+;; epoch (and their own db write) before the limit tripped — each settled
+;; event is independently atomic, and there is no whole-drain rollback.
+;; The depth limit stops the NEXT (halting) event; the runtime commits a
+;; trailing :halted-depth :rf/epoch-record for it (Spec-Schemas
+;; §:rf/epoch-record §Outcomes) so devtools (Xray, re-frame2-pair) get a
+;; clear "drain halted here" marker following the durable :ok epochs. The
 ;; halting event never ran, so its record's :db-before / :db-after both
 ;; equal the durable last-settled db.
-;;
-;; SUPERSEDES the pre-rf2-u6jsj per-drain rollback semantics (Spec 002
-;; rule 3's "restore app-db to its pre-drain snapshot" / "epoch history
-;; records nothing for the failed drain"), which was written for the
-;; per-drain epoch model. Rule 3 needs tightening to the per-event
-;; boundary — see rf2-nj6p7.
 
 {:fixture/id           :drain/depth-limit
  :fixture/spec-version "1.0"
  :fixture/capabilities #{:core/event-handler :core/error :core/trace}
- :fixture/doc          "A handler that always dispatches itself recursively. Drain hits the configured depth limit and emits :rf.error/drain-depth-exceeded. Per rf2-u6jsj/rf2-nj6p7 (per-event epochs) the events that already ran are DURABLE :ok epochs (no whole-drain rollback); the runtime commits a trailing :halted-depth :rf/epoch-record for the halting event (which never ran) so devtools receive a halt marker."
+ :fixture/doc          "A handler that always dispatches itself recursively. Drain hits the configured depth limit and emits :rf.error/drain-depth-exceeded. Per Spec 002 §Drain versus event (per-event epochs) the events that already ran are durable :ok epochs (no whole-drain rollback); the runtime commits a trailing :halted-depth :rf/epoch-record for the halting event (which never ran) so devtools receive a halt marker."
 
  :fixture/registry
  {:event {:recursive {:doc "Always dispatches itself."}}
@@ -42,9 +36,9 @@
 
  :fixture/expect
  {;; The handler ran 5 times (the depth limit) before the runtime stopped
-  ;; the 6th. Per rf2-nj6p7 each :recursive event settled its own durable
-  ;; epoch + db write — there is NO whole-drain rollback — so the final
-  ;; app-db reflects the five completed writes.
+  ;; the 6th. Each :recursive event settled its own durable epoch + db
+  ;; write — there is no whole-drain rollback — so the final app-db
+  ;; reflects the five completed writes.
   :final-app-db {:depth 5}
 
   :trace-emissions
@@ -53,9 +47,9 @@
    {:operation :rf.event/run-start :tags {:rf.trace/event-id :recursive}}
    {:operation :rf.event/run-start :tags {:rf.trace/event-id :recursive}}
    {:operation :rf.event/run-start :tags {:rf.trace/event-id :recursive}}
-   ;; Drain depth exceeded — the 6th (halting) event is not run. Per
-   ;; rf2-nj6p7 there is no whole-drain rollback, so :rollback? is false;
-   ;; the already-settled events are durable.
+   ;; Drain depth exceeded — the 6th (halting) event is not run. There
+   ;; is no whole-drain rollback, so :rollback? is false; the
+   ;; already-settled events are durable.
    {:operation :rf.error/drain-depth-exceeded
     :op-type   :error
     :tags      {:category   :rf.error/drain-depth-exceeded
@@ -72,15 +66,15 @@
    {:operation :rf.epoch/snapshotted
     :tags      {:frame   :rf/default
                 :outcome :halted-depth}}
-   ;; rf2-18g1w / rf2-jppad — paired with :rf.epoch/snapshotted the runtime
-   ;; emits :rf.epoch/outcome carrying the consumer-facing {:ok :blocked
-   ;; :error} summary. :halted-depth projects to :blocked per the canonical
-   ;; mapping (`re-frame.epoch.assembly/outcome->consumer-facing`).
+   ;; Paired with :rf.epoch/snapshotted the runtime emits :rf.epoch/outcome
+   ;; carrying the consumer-facing {:ok :blocked :error} summary.
+   ;; :halted-depth projects to :blocked per the canonical mapping
+   ;; (`re-frame.epoch.assembly/outcome->consumer-facing`).
    {:operation :rf.epoch/outcome
     :tags      {:frame   :rf/default
                 :outcome :blocked}}]
 
-  ;; Per rf2-nj6p7 §Drain versus event: five durable :ok epochs (one per
+  ;; Per Spec 002 §Drain versus event: five durable :ok epochs (one per
   ;; dequeued :recursive event, db chaining {:depth 1}…{:depth 5}) followed
   ;; by the trailing :halted-depth marker. The marker's :db-before /
   ;; :db-after both equal the durable last-settled db ({:depth 5}); the


### PR DESCRIPTION
Cluster Y spec/doc polish — 4 beads, doc/spec edits only.

## Beads

### rf2-7bfs7 — :rf.http/managed args-map at-a-glance reference card

Replace Spec 014's existing 'The args map' table with a one-row-per-slot reference card: **Slot / Default / Meaning / Recovery on failure**, with each row anchoring to its detail section.

Adds previously-undocumented top-level slots (`:sensitive?`, `:rf.http/max-decoded-keys`) to the headline table so authors can scan the full args-map surface in one place.

### rf2-1hd9g — uniform context-map callbacks principle

Promote the unified context-map contract for machine callbacks — already locked at the impl level (`machines/transition.cljc`) and at Spec 005 §Guards / §Actions — to a first-class discipline principle in spec/Principles.md.

The principle generalises: every callback in a multi-slot family takes ONE context-map; future slot additions extend keys, not arity. A specialisation of *name over place* for callback arities (vs xstate-style positional args).

### rf2-7vjju — Spec/009 cascade trace emit-gate summary (HOT-ZONE)

Add a normative emit-gate summary table to Spec 009 §Canonical per-event trace sequence pinning, for every emit between `:run-start` and `:run-end`:

- The condition under which the emit fires
- Whether it rides the **always-on** substrate (event-emit / error-emit, production-available) or the **dev-only** `interop/debug-enabled?` gate (DCE'd from `:advanced` bundles)

Pulls gate info — previously scattered across the section's prose — into one table tooling authors (Xray / Story / re-frame-10x / off-box monitors) can read in one glance.

### rf2-kabt8 — drain-depth per-event epoch model alignment (HOT-ZONE)

Spec 002 rule 3 and the `drain-depth-limit.edn` fixture **already** reflect the per-event epoch boundary (rolled in by PR #1948). The in-code 'NOTED for spec-tightening' reconciliation block in `router.cljc` and the fixture's superseded-state historical note are now stale residue.

This bead removes the residue and tightens supporting docstrings:

- Removed the `§Reconcile with Spec 002 rule 3` block from `handle-depth-exceeded!` — spec, fixture, and impl are aligned.
- Tightened `drain-depth-default`'s docstring to the per-event halt contract (no whole-drain rollback, trailing `:halted-depth` marker on the halting event).
- Dropped the SUPERSEDES historical block + per-bead breadcrumbs from `drain-depth-limit.edn`; cross-references now point to the normative Spec 002 / Spec-Schemas sections.

## Quality gates

- `python scripts/check_readme_links.py --ci` — pass
- `python scripts/check_doc_slugs.py` — pass
- All new cross-reference anchors verified against existing section headers.
- `mkdocs build --strict` will run in CI (not installed locally).