### PR TITLE
chore(comments): residue sweep — 10 beads (am8nh + 1284r + 8 P4s)

### DIFF
--- a/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
+++ b/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
@@ -43,10 +43,9 @@
 
 (def set-hiccup-emitter!
   "Install the hiccup → HTML fn used by render-to-string. Last call wins.
-  Reagent ships server-side rendering via reagent.dom.server — but in
-  CLJS browser builds we don't typically render-to-string; install the
-  emitter via this fn (or let the SSR seam resolve the late-bind hook)
-  if you need it in CLJS."
+  Per rf2-uo7v / IMPL-SPEC §2.1: published through the late-bind hook
+  `:reagent/set-hiccup-emitter!` so the SSR seam at re-frame.ssr
+  resolves it at load time without a static :require."
   (:set-hiccup-emitter! spine-fns))
 
 (def adapter

--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -431,7 +431,7 @@
   snapshot for `frame-id`. Returns `{}` for a frame that has never
   seen a `render-head` call (or whose snapshot has been cleared via
   per-request frame teardown). Useful for tests, introspection, and
-  tools (Xray, MCP). Per Spec 011 §Head/meta contract (rf2-4dra9).
+  tools (Xray, MCP). Per Spec 011 §Head/meta contract.
   Implementation ships in `day8/re-frame2-ssr`. Late-bound via
   `:ssr/head-snapshot`."}
   head-snapshot    rf-ssr/head-snapshot)
@@ -493,21 +493,21 @@
 (def ^{:doc "Register the validator fn every dev-time schema-validation
   site routes through — `(fn [schema value] truthy?)` (or nil to
   disable). Map-arity atomically swaps `{:validate :explain}` together.
-  Per Spec 010 §Non-Malli validators (rf2-froe). Default ships Malli;
+  Per Spec 010 §Non-Malli validators. Default ships Malli;
   callers swap to drop the ~24 KB gzipped Malli surface. Implementation
   ships in `day8/re-frame2-schemas`."}
   set-schema-validator!  rf-schemas/set-schema-validator!)
 
 (def ^{:doc "Register the explainer fn — `(fn [schema value] explanation)`
   — used to enrich schema-validation-failure traces' `:explain` key.
-  Per Spec 010 §Non-Malli validators (rf2-froe). Implementation ships
+  Per Spec 010 §Non-Malli validators. Implementation ships
   in `day8/re-frame2-schemas`."}
   set-schema-explainer!  rf-schemas/set-schema-explainer!)
 
 (def ^{:doc "Register the schema-print companion — `(fn [schema-value]
   canonical-string)` — that the digest pipeline hashes. MUST be pure
-  and cross-runtime deterministic. Per Spec 010 §Digest algorithm
-  (rf2-wla45). Implementation ships in `day8/re-frame2-schemas`."}
+  and cross-runtime deterministic. Per Spec 010 §Digest algorithm.
+  Implementation ships in `day8/re-frame2-schemas`."}
   set-schema-printer!    rf-schemas/set-schema-printer!)
 
 ;; ---- data classification (Spec 015) -------------------------------------
@@ -899,7 +899,7 @@
 
 (def ^{:doc "Remove a registered route. Emits `:rf.route/cleared` so
   tools subscribing to route lifecycle observe the removal; symmetric
-  with `:rf.flow/cleared`. Per Spec 012 §Trace events (rf2-dn26r).
+  with `:rf.flow/cleared`. Per Spec 012 §Trace events.
   Implementation ships in `day8/re-frame2-routing`."}
   unregister-route!  rf-routing/unregister-route!)
 
@@ -998,7 +998,7 @@
 (def ^{:doc "Subscribe to a machine's `:fsm/tags` containment-bit for
   `tag`. Sugar over `(subscribe [:rf/machine-has-tag? machine-id tag])`
   — returns a reaction whose value is `true` iff the current snapshot's
-  `:tags` set contains `tag`. Per Spec 005 §State tags (rf2-ee0d)."}
+  `:tags` set contains `tag`. Per Spec 005 §State tags."}
   machine-has-tag?               rf-machines/machine-has-tag?)
 
 ;; ---- introspection (Spec 002 §The public registrar query API) -----------
@@ -1114,7 +1114,7 @@
   the `:event` coeffect with the payload map itself. Usage:
   `(reg-event-fx :foo [unwrap-interceptor] (fn [_ {:keys [a b]}] ...))`.
   Per Conventions §Canonical event-vector shape (M-19) and §Value-vs-fn
-  naming (rf2-k367k)."}
+  naming."}
   unwrap-interceptor std-interceptors/unwrap-interceptor)
 
 (def ^{:doc "Build a positional interceptor that overwrites the named
@@ -1138,13 +1138,12 @@
 (def ^{:doc "Production-side schema validation interceptor. Add to a
   `reg-event-*` handler's positional interceptor vector to force `:schema`
   validation against the dispatched event vector even in production
-  builds where dev-time validation is elided. The verb `validate-` (per
-  rf2-todvi) telegraphs the time/build-mode axis the interceptor lives
-  on (no-op in dev, validates in prod); the `-interceptor` suffix (per
-  rf2-k367k, Conventions §Value-vs-fn naming) telegraphs that this is a
-  Var holding a value, not a fn. Per Spec 010 §Production builds.
-  The interceptor reuses the handler's existing `:schema` metadata —
-  no parallel schema."}
+  builds where dev-time validation is elided. The verb `validate-`
+  telegraphs the time/build-mode axis the interceptor lives on (no-op in
+  dev, validates in prod); the `-interceptor` suffix (per Conventions
+  §Value-vs-fn naming) telegraphs that this is a Var holding a value,
+  not a fn. Per Spec 010 §Production builds. The interceptor reuses the
+  handler's existing `:schema` metadata — no parallel schema."}
   validate-at-boundary-interceptor spec/validate-at-boundary-interceptor)
 
 (def ^{:doc "Emit a trace event. Production builds elide the body
@@ -1211,12 +1210,11 @@
   builds where the trace surface is elided. `f` receives a tight
   event-record per processed event (NOT subs / fxs); see
   `re-frame.event-emit` ns docstring for the record shape. Re-registering
-  the same id replaces. Returns `id`. Per Spec 009 §Event-emit listener
-  (rf2-rirbq + rf2-ic1sv pick c)."}
+  the same id replaces. Returns `id`. Per Spec 009 §Event-emit listener."}
   register-event-listener!   event-emit/register-event-listener!)
 
 (def ^{:doc "Drop the always-on event-emit listener registered under `id`.
-  Returns nil. Per Spec 009 §Event-emit listener (rf2-rirbq + rf2-ic1sv)."}
+  Returns nil. Per Spec 009 §Event-emit listener."}
   unregister-event-listener! event-emit/unregister-event-listener!)
 
 (def ^{:doc "Register an always-on error-emit listener `f` under `id`.
@@ -1224,11 +1222,11 @@
   error-record per `:rf.error/*` event (see `re-frame.error-emit` ns
   docstring for the record shape). For off-box observability shippers
   (Sentry, Honeybadger, Rollbar). Re-registering the same id replaces.
-  Returns `id`. Per Spec 009 §Error-handler policy (rf2-bacs4 + rf2-ic1sv)."}
+  Returns `id`. Per Spec 009 §Error-handler policy."}
   register-error-listener!   error-emit/register-error-listener!)
 
 (def ^{:doc "Drop the always-on error-emit listener registered under `id`.
-  Returns nil. Per Spec 009 §Error-handler policy (rf2-bacs4 + rf2-ic1sv)."}
+  Returns nil. Per Spec 009 §Error-handler policy."}
   unregister-error-listener! error-emit/unregister-error-listener!)
 
 (def ^{:doc "Walk `v` and substitute schema-declared sensitive or large

--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -64,7 +64,9 @@
             [re-frame.core-ssr      :as rf-ssr]
             [re-frame.core-epoch    :as rf-epoch]
             [re-frame.core-http     :as rf-http]
-            ;; Macro-helper carve-out (rf2-4rnui).
+            ;; Macro helpers — the macro siblings live in their own
+            ;; nss; required here with `:include-macros` so CLJS callers
+            ;; see them under `rf/<name>`.
             [re-frame.core-reg-macros        :as rm
              #?@(:cljs [:include-macros true])]
             [re-frame.core-call-site-macros  :as csm]
@@ -303,28 +305,24 @@
                             machine-id
                             machine)))
 
-;; ---- public helpers re-exported for test access (rf2-4rnui) -------------
+;; ---- public helpers re-exported for test access -------------------------
 ;;
-;; Re-exposed because pre-split tests reach `re-frame.core/expand-reg-
-;; view` and `re-frame.core/parse-reg-view-args` directly. Preserved as
-;; CLJ-only aliases — the helpers themselves are JVM-only (used at
-;; macro-expansion time).
+;; Tests reach `re-frame.core/expand-reg-view` and
+;; `re-frame.core/parse-reg-view-args` directly; the helpers themselves
+;; live in `re-frame.core-reg-view-macro` (JVM-only — used at macro-
+;; expansion time).
 
 #?(:clj
    (do
      (def ^{:no-doc true
             :doc "JVM-only macro-helper re-exposed for tests that reach
-  `re-frame.core/expand-reg-view` directly (pre-split test access, per
-  rf2-4rnui). Not part of the public surface — see
-  `re-frame.core-reg-view-macro/expand-reg-view`. Internal per rf2-kp835
-  Phase-2 (2026-05-17)."}
+  `re-frame.core/expand-reg-view` directly. Not part of the public
+  surface — see `re-frame.core-reg-view-macro/expand-reg-view`."}
        expand-reg-view             rvm/expand-reg-view)
      (def ^{:no-doc true
             :doc "JVM-only macro-helper re-exposed for tests that reach
-  `re-frame.core/parse-reg-view-args` directly (pre-split test access,
-  per rf2-4rnui). Not part of the public surface — see
-  `re-frame.core-reg-view-macro/parse-reg-view-args`. Internal per
-  rf2-kp835 Phase-2 (2026-05-17)."}
+  `re-frame.core/parse-reg-view-args` directly. Not part of the public
+  surface — see `re-frame.core-reg-view-macro/parse-reg-view-args`."}
        parse-reg-view-args         rvm/parse-reg-view-args)))
 
 ;; ---- view registration ---------------------------------------------------

--- a/implementation/core/src/re_frame/core_artefact.cljc
+++ b/implementation/core/src/re_frame/core_artefact.cljc
@@ -10,12 +10,12 @@
   a structured `:rf.error/<artefact>-artefact-missing` ex-info,
   depending on the surface's contract.
 
-  Pre-rf2-h824v the seven `core_<artefact>.cljc` files carried ~740 LoC
-  of structurally-identical late-bind boilerplate — 26 `ex-info`
-  literals each spelling the same skeleton. This namespace replaces
-  the boilerplate with a single `defwrapper` macro driven by a
-  declarative per-row spec, paired with the `late-bind/require-fn!`
-  helper (rf2-uchhp) that centralises the throw shape.
+  The seven `core_<artefact>.cljc` files share their late-bind shape —
+  per-row declarative spec, structured throw, optional safe-default —
+  through a single `defwrapper` macro defined here, paired with the
+  `late-bind/require-fn!` helper (rf2-uchhp) that centralises the throw
+  skeleton. One macro + one helper replaces what would otherwise be ~26
+  `ex-info` literals copied across the artefact wrappers.
 
   ## `defwrapper` shape
 

--- a/implementation/core/src/re_frame/events.cljc
+++ b/implementation/core/src/re_frame/events.cljc
@@ -66,14 +66,11 @@
 ;; ---- validate-at-boundary-interceptor registration-time validation (rf2-iftj4) -----------------
 ;;
 ;; The `:rf.schema/at-boundary` interceptor (per Spec 010 §Production builds)
-;; is structurally meaningless without a `:schema` to validate against. If a
-;; developer attaches it to a handler that carries no `:schema` metadata,
-;; pre-rf2-iftj4 the runtime emitted `:rf.warning/boundary-without-spec` on
-;; the FIRST dispatch in a production build only — dev builds were silent,
-;; and the misconfiguration only surfaced in prod. Per rf2-ycqtv finding #8
-;; (Mike-pick option (b)), the registrar now hard-rejects the registration
-;; with `:rf.error/at-boundary-missing-schema` so the developer learns
-;; immediately, regardless of dev/prod gate.
+;; is structurally meaningless without a `:schema` to validate against. Per
+;; rf2-ycqtv finding #8 (Mike-pick option (b)), the registrar hard-rejects
+;; any handler that attaches the interceptor without `:schema` metadata,
+;; throwing `:rf.error/at-boundary-missing-schema` at reg time so the
+;; developer learns immediately, regardless of dev/prod gate.
 ;;
 ;; Detection is by interceptor `:id` (`:rf.schema/at-boundary`), not by var
 ;; equality — keeps `events` decoupled from `re-frame.spec` (which depends

--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -502,7 +502,7 @@
   [id]
   (if-let [teardown! (late-bind/get-fn :machines/teardown-on-frame-destroy!)]
     (teardown! id)
-    ;; Fallback path — preserve the pre-rf2-vsigt minimal contract.
+    ;; Fallback path — minimal contract when the machines artefact is absent.
     (let [container  (get-frame-db id)
           db         (when container (adapter/read-container container))
           machines   (get db :rf/machines)

--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -163,9 +163,8 @@
 ;; Per rf2-ejtpd, `:source` is ALSO not inherited — each fx-emitted
 ;; child dispatch's `:source` reflects its immediate trigger
 ;; (`:fx-dispatch` / `:fx-dispatch-later`), stamped by the fx handler
-;; below. Pre-rf2-ejtpd `:source` was inherited, causing every fx-emitted
-;; descendant to mis-report the originating user event's trigger (a
-;; `:dispatch` fx three levels deep kept reporting `:source :ui`).
+;; below. Inheriting `:source` would mis-report a `:dispatch` fx three
+;; levels deep as `:source :ui`.
 (def ^:private inheritable-envelope-keys
   [:frame :fx-overrides :interceptor-overrides :trace-id :origin])
 
@@ -282,12 +281,10 @@
    ;; the dispatching frame.
    ;;
    ;; Both fx-ids route through the SAME hooks the public API uses
-   ;; (`:flows/reg-flow` / `:flows/clear-flow`). Pre-rf2-7ppmo the
-   ;; flows artefact published four hooks — two API-shape, two fx-
-   ;; shape — but the API-shape hooks already accept `(arg opts)` with
-   ;; opts carrying `:frame`, and `call-frame-scoped-hook!` passes
-   ;; `{:frame frame-id}` as the second arg. The fx-shape hooks were
-   ;; one-line pass-throughs; consolidated to two hooks.
+   ;; (`:flows/reg-flow` / `:flows/clear-flow`) — the API-shape hooks
+   ;; accept `(arg opts)` with opts carrying `:frame`, and
+   ;; `call-frame-scoped-hook!` passes `{:frame frame-id}` as the second
+   ;; arg, so one hook pair serves both surfaces.
    :rf.fx/reg-flow
    (fn [frame-id _parent-envelope args]
      (call-frame-scoped-hook! :flows/reg-flow frame-id args))

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -671,7 +671,7 @@
                    re-frame.adapter.helix]
     :chained?    true
     :design-bead "rf2-s36l"
-    :description "Substrate-specific after-render hook (re-frame.interop/after-render). Per rf2-334d9 the UIx + Helix adapters publish a `React.useLayoutEffect`-backed impl via the spine's after-render machinery (closing the pre-rf2-334d9 silent no-op named in rf2-neiqf). Reagent + reagent-slim route through their substrate's native render scheduler."}
+    :description "Substrate-specific after-render hook (re-frame.interop/after-render). Per rf2-334d9 the UIx + Helix adapters publish a `React.useLayoutEffect`-backed impl via the spine's after-render machinery (Mike decision rf2-neiqf). Reagent + reagent-slim route through their substrate's native render scheduler."}
    {:key         :adapter/wrap-view
     :producer-ns '[re-frame.adapter.uix
                    re-frame.adapter.helix]

--- a/implementation/core/src/re_frame/performance.cljc
+++ b/implementation/core/src/re_frame/performance.cljc
@@ -86,8 +86,8 @@
        enabled?=false` the entire branch DCEs and this fn vanishes
        from the production bundle.
 
-  The body is pure data-shaping with no platform-specific calls — the
-  pre-rf2-4ymm0 JVM/CLJS twins held identical bodies."
+  The body is pure data-shaping with no platform-specific calls — one
+  `.cljc` definition serves both JVM and CLJS callers."
   [bucket id]
   (str "rf:" (name bucket) ":"
        (cond

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -231,10 +231,10 @@
   (registrar/lookup :event event-id))
 
 ;; Fallthrough-to-default + cross-frame dispatch-sync warnings + the
-;; no-handler error path live in `re-frame.router.diagnostics` —
-;; extracted per rf2-0ytl4 Phase-2 seam R-B. Every one of those fns
-;; runs on a cold/error path or sits behind `interop/debug-enabled?`,
-;; so the cross-ns indirection adds no measurable cost.
+;; no-handler error path live in `re-frame.router.diagnostics`. Every
+;; one of those fns runs on a cold/error path or sits behind
+;; `interop/debug-enabled?`, so the cross-ns indirection adds no
+;; measurable cost.
 
 (def ^:private empty-fx-overrides
   "Shared sentinel returned by `apply-overrides` on the no-override hot

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -462,9 +462,9 @@
         ;; Sticky hook (rf2-f72pd) — fires per-dispatch.
         (if-let [validate (late-bind/get-fn-cached :schemas/validate-app-schema!)]
           (try
-            ;; nil-coerce: pre-rf2-6m0se the fn returned nil on success.
-            ;; Treat nil as true (don't roll back) so a hosted port that
-            ;; still ships the older contract keeps working.
+            ;; nil-coerce: treat a nil return as success (don't roll
+            ;; back) so a host that returns nil rather than true on a
+            ;; clean validate keeps working.
             (let [r (validate db-after event-id frame)]
               (if (nil? r) true r))
             (catch #?(:clj Throwable :cljs :default) _ true))

--- a/implementation/core/src/re_frame/subs/cache.cljc
+++ b/implementation/core/src/re_frame/subs/cache.cljc
@@ -19,11 +19,9 @@
   a recompute landing AFTER the last derefer has dropped is a wasted
   cycle, and the elegant fix is to never schedule it.
 
-  The pre-rf2-cmfln implementation deferred disposal by `grace-period-ms`
-  (default 50ms) to absorb React-render-churn — components briefly
-  unmount/remount with the same subscription. With sync dispose the
-  shared-component-thrash scenario re-builds the slot on the new mount;
-  this is acceptable per the bead's design phase (rf2-cmfln) — the
+  The shared-component-thrash scenario (a component unmounts and the
+  same subscription remounts in the same tick) re-builds the slot on the
+  new mount; this is acceptable per the rf2-cmfln design — the
   recomputed value is `=` to the disposed one, so the post-mount render
   observes no value change, and the cache-miss path's cost is dominated
   by `compute-and-cache!`'s reaction construction (one allocation, no

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -212,18 +212,16 @@
 ;; `validate-and-trace`, and for a layer-2+ sub eagerly derefs the whole
 ;; `:<-` input chain. Reagent (`ratom/make-reaction`, lazy until first
 ;; deref) and the plain-atom adapter (recompute-on-deref) both defer the
-;; first body invocation to first read. The spine MUST match: seeding
-;; `prev-state` with `(recompute)` at construction (the pre-rf2-ee38b.1
-;; shape) ran the body once per `subscribe` even when the reaction is
-;; never deref'd, emitting a subscribe-time `:rf.sub/run` rather than a
-;; deref-time one — an observable cross-adapter divergence (extra body
-;; invocation count, different trace timing, side-effecting bodies firing
-;; before any render reads them) contradicting Spec 006 §No-op via value
-;; equality's "body runs on demand" intent. The fix seeds `prev-state`
-;; with the `unset` sentinel; the first flush (or deref) is the first
-;; real recompute, and the sentinel `not=` any real value so the first
-;; post-construction change always notifies — the same first-change-
-;; notifies semantics Reagent gives.
+;; first body invocation to first read; the spine matches by seeding
+;; `prev-state` with the `unset` sentinel rather than with `(recompute)`.
+;; The first flush (or deref) is then the first real recompute — a
+;; subscribe-time `(recompute)` would emit `:rf.sub/run` and side-effect
+;; before any render reads the reaction, an observable cross-adapter
+;; divergence (extra body invocations, different trace timing) that
+;; contradicts Spec 006 §No-op via value equality's "body runs on demand"
+;; intent. The sentinel `not=` any real value, so the first post-
+;; construction change always notifies — the same first-change-notifies
+;; semantics Reagent gives.
 
 (def ^:private unset
   "Sentinel for a derived value whose baseline has not yet been computed.
@@ -246,15 +244,11 @@
   + `re-frame.subs`, `source-containers` is a vector) so the recompute
   closure pays no per-tick `count`.
 
-  Single source of truth (rf2-eoy63 lockstep): the Reagent,
-  reagent-slim, UIx, and Helix adapters all build their recompute
-  closure through this fn — pre-rf2-eoy63 the arity-spec lived only in
-  the Reagent adapter and the spine + reagent-slim had naive
-  `(apply compute-fn (map deref ...))` shapes that paid the apply +
-  lazy-seq cost on every sub recompute × every dispatch. Lifting the
-  arity-spec into the spine matches the rf2-jcjul `make-dispose-adapter!`
-  shape: one implementation, four adapters, zero drift. Sourced from
-  the rf2-fzrav perf-sweep findings."
+  Single source of truth: the Reagent, reagent-slim, UIx, and Helix
+  adapters all build their recompute closure through this fn — one
+  implementation, four adapters, zero drift. The arity-spec lifted
+  into the spine matches the `make-dispose-adapter!` shape
+  (rf2-jcjul); sourced from the rf2-fzrav perf-sweep findings."
   [source-containers compute-fn]
   (let [n (count source-containers)]
     (case n
@@ -366,12 +360,12 @@
         ;; Re-frame-owned IDisposable — `interop/add-on-dispose!` /
         ;; `interop/dispose!` route into this protocol via the
         ;; adapter's `:adapter/add-on-dispose!` / `:adapter/dispose!`
-        ;; hooks (per Spec 006 §subscription-cache). Pre-rf2-jicu2 the
-        ;; spine reified `reagent.ratom/IDisposable` here, which forced
-        ;; every UIx/Helix bundle to pay ~9KB optimised / 2-3KB gzipped
-        ;; of `reagent.ratom` + `reagent.impl.batching` for one
-        ;; protocol — the new `re-frame.disposable/IDisposable` is
-        ;; re-frame-owned and carries no Reagent dependency.
+        ;; hooks (per Spec 006 §subscription-cache). The spine
+        ;; deliberately uses `re-frame.disposable/IDisposable` (re-
+        ;; frame-owned, no Reagent dependency) rather than
+        ;; `reagent.ratom/IDisposable` so UIx/Helix bundles don't pay
+        ;; ~9KB optimised / 2-3KB gzipped of `reagent.ratom` +
+        ;; `reagent.impl.batching` for one protocol.
         rf-disposable/IDisposable
         (-dispose [_]
           (doseq [[s k] @own-keys] (remove-watch s k))
@@ -439,10 +433,8 @@
 ;;
 ;; `:adapter/after-render` for React-only substrates (UIx, Helix) per
 ;; rf2-334d9 (Mike decision rf2-neiqf 2026-05-19: publish via
-;; useLayoutEffect). Pre-rf2-334d9 the UIx and Helix adapters did NOT
-;; publish `:adapter/after-render`, so `(rf/after-render f)` under those
-;; adapters was a silent no-op — a correctness bug under the pre-alpha
-;; masterpiece posture.
+;; useLayoutEffect) — without this `(rf/after-render f)` under those
+;; adapters would be a silent no-op.
 ;;
 ;; Architecture. Per-adapter queue cell + a sentinel function component
 ;; injected at the root of every mounted tree (via `make-render`'s
@@ -1243,12 +1235,11 @@
             ;; Pair the memoised `subs/subscribe` (above) with an
             ;; explicit `subs/unsubscribe` on unmount / key-change so
             ;; the sub-cache's ref-count is decremented when the
-            ;; component drops the reaction. Pre-rf2-7g959 the cleanup
-            ;; was implicit only via the useSyncExternalStore
-            ;; subscribe-fn's `remove-watch` — which freed the React
-            ;; listener but left the sub-cache entry pinned at
-            ;; ref-count 1 for the rest of the process. Per
-            ;; Spec 006 §Reference counting and disposal.
+            ;; component drops the reaction. Without this pairing the
+            ;; useSyncExternalStore subscribe-fn's `remove-watch` would
+            ;; free the React listener but leave the sub-cache entry
+            ;; pinned at ref-count 1. Per Spec 006 §Reference counting
+            ;; and disposal.
             ;;
             ;; Memo can rebuild on key change; pairing the subscribe
             ;; with a useEffect keyed on the same deps means React
@@ -1333,8 +1324,9 @@
 ;;     via the spine's after-render machinery. `after-render` is a React-
 ;;     lifecycle question (when does the next commit complete?), not a
 ;;     reactive-atom one — so the "no reactive primitive" rationale that
-;;     excludes the four hooks above does NOT apply. Pre-rf2-334d9
-;;     `(rf/after-render f)` under these adapters was a silent no-op.
+;;     excludes the four hooks above does NOT apply. Without this hook
+;;     `(rf/after-render f)` under these adapters would be a silent
+;;     no-op.
 ;;   :adapter/wrap-view — rf2-00li. Substrate-side source-coord injection
 ;;     via React.cloneElement (the views.cljs inline hiccup-walk would
 ;;     mis-classify React-element output as a non-DOM root). Production-
@@ -1396,11 +1388,10 @@
 ;;
 ;; The Reagent and reagent-slim adapters are the SAME shape under a
 ;; different reactive-atom impl (stock `reagent.*` vs the `reagent2.*`
-;; rewrite). Pre-rf2-rzex9 each carried a byte-identical (modulo the
-;; ratom ns) copy of the container quartet, the React-root renderer, and
-;; the dispose body. `make-ratom-spine` factors that shared shape exactly
-;; as `make-react-spine` factors the UIx/Helix hook family — one
-;; implementation, two adapters, zero drift.
+;; rewrite). `make-ratom-spine` factors the shared container quartet,
+;; React-root renderer, and dispose body exactly as `make-react-spine`
+;; factors the UIx/Helix hook family — one implementation, two adapters,
+;; zero drift.
 ;;
 ;; CRITICAL — slim bundle isolation (IMPL-SPEC §1.8 / the
 ;; `test:reagent-slim:bundle-isolation` gate). This helper lives in
@@ -1458,12 +1449,11 @@
   spine's hook-shaped `frame-provider` is not. Keeping it as adapter-side
   wiring also keeps this core ns free of a spine→views dependency edge.
 
-  Behaviour is byte-for-byte equivalent to the pre-rf2-rzex9 hand-written
-  adapter bodies: container quartet incl. the substrate-scoped gensym;
-  the create-root/hydrate-root render with active-roots tracking + an
-  unmount thunk that drops itself from the set; and the four-MUST dispose
-  body (`dispose-frame-sub-caches!` + active-roots drain w/ per-root
-  throw-swallow + emitter clear)."
+  Produces: container quartet incl. the substrate-scoped gensym; the
+  create-root/hydrate-root render with active-roots tracking + an unmount
+  thunk that drops itself from the set; and the four-MUST dispose body
+  (`dispose-frame-sub-caches!` + active-roots drain w/ per-root throw-
+  swallow + emitter clear)."
   [{:keys [gensym-prefix-sub ratom-ops]}]
   (let [{r-atom        :r/atom
          make-reaction :ratom/make-reaction

--- a/implementation/core/src/re_frame/views.cljs
+++ b/implementation/core/src/re_frame/views.cljs
@@ -42,7 +42,12 @@
   Putting the canonical Var here makes the read and the binding hit
   identical Vars — a `(def ^:dynamic *render-key* provider/*render-key*)`
   re-export would create a SECOND Var whose binding the test wouldn't
-  observe."
+  observe.
+
+  The view-deref-sink + first-render? machinery (`*view-deref-sink*`,
+  `record-view-deref!`, `first-render?!`, `clear-seen-render-keys!`)
+  introduced in rf2-9hoos — see the per-block sections below for
+  contract detail."
   (:require [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.performance :as performance :include-macros true]
@@ -93,7 +98,7 @@
   []
   *render-key*)
 
-;; ---- per-render deref sink (view→sub edges, rf2-9hoos) -------------------
+;; ---- per-render deref sink (view→sub edges) -----------------------------
 ;;
 ;; Captures the set of subscription query-vectors a view derefs DURING
 ;; its render, so the `:rf.view/rendered` trace can carry the view's OWN
@@ -114,13 +119,13 @@
 
 (def ^:dynamic *view-deref-sink*
   "Per-render volatile holding the set of subscription query-vectors the
-  in-flight view render has deref'd so far (rf2-9hoos). Bound by the
+  in-flight view render has deref'd so far. Bound by the
   `build-frame-aware-view` wrapper for the duration of each render under
   `interop/debug-enabled?`; nil otherwise."
   nil)
 
 (defn record-view-deref!
-  "Union `query-v` into the in-flight render's deref sink (rf2-9hoos).
+  "Union `query-v` into the in-flight render's deref sink.
   No-op when no render is on the stack (`*view-deref-sink*` nil — a
   handler-side subscribe, an SSR walk, a direct read). Published through
   late-bind under `:views/record-view-deref!` so `re-frame.subs/subscribe`
@@ -131,7 +136,7 @@
     (vswap! sink conj query-v))
   nil)
 
-;; ---- mount-vs-rerender discrimination (rf2-9hoos) ------------------------
+;; ---- mount-vs-rerender discrimination ------------------------------------
 ;;
 ;; `:rf.view/rendered` fires on every render; the `:mount?` flag
 ;; discriminates a component instance's FIRST render from its subsequent
@@ -147,7 +152,7 @@
 
 (defn first-render?!
   "Return `true` the FIRST time `render-key` is seen this process run,
-  `false` thereafter — the mount-vs-rerender discriminator (rf2-9hoos).
+  `false` thereafter — the mount-vs-rerender discriminator.
   Side-effecting: records the key on first sighting. Caller gates on
   `interop/debug-enabled?`."
   [render-key]
@@ -155,7 +160,7 @@
     (not (contains? old render-key))))
 
 (defn clear-seen-render-keys!
-  "Wipe the seen-render-keys set (rf2-9hoos). Test fixtures call this so
+  "Wipe the seen-render-keys set. Test fixtures call this so
   a sibling test's `:mount?` flag does not leak across cases (the
   per-process set would otherwise report a re-used render-key as a
   rerender in the next test). Wired into the chained

--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -54,9 +54,8 @@
 
 ;; ---- configuration --------------------------------------------------------
 ;;
-;; Atoms, defaults, and config-merge validation live in `re-frame.epoch.state`
-;; (Phase-2 seam A, rf2-0wi86). The facade keeps the public docstrings and
-;; the late-bind hook publication.
+;; Atoms, defaults, and config-merge validation live in `re-frame.epoch.state`.
+;; The facade keeps the public docstrings and the late-bind hook publication.
 ;;
 ;; Design provenance (kept out of the public `configure!` docstring per the
 ;; rf2-ee38b clarity review):
@@ -114,15 +113,14 @@
 
 ;; The record-assembly helpers — `maybe-redact`, `current-schema-digest`,
 ;; the sensitive-rollup family, and `build-record` itself — live in
-;; `re-frame.epoch.assembly` (Phase-2 seam D, rf2-0wi86).
+;; `re-frame.epoch.assembly`.
 
 ;; ---- the per-frame ring buffer --------------------------------------------
 ;;
 ;; Per Tool-Pair §Time-travel "Bounded history": last N epochs per frame.
 ;; Stored as a map of frame-id → vector (oldest-first). New records append
 ;; to the back; the front evicts when the buffer exceeds the configured
-;; depth. The atom + ring-buffer mutators live in
-;; `re-frame.epoch.state` (Phase-2 seam A, rf2-0wi86).
+;; depth. The atom + ring-buffer mutators live in `re-frame.epoch.state`.
 
 (defn epoch-history
   "Return the vector of `:rf/epoch-record` values for the frame, oldest-
@@ -149,8 +147,8 @@
 ;; ---- listener registry ----------------------------------------------------
 ;;
 ;; The listener / observed-frames atoms and their low-level CRUD live in
-;; `re-frame.epoch.state` (Phase-2 seam A, rf2-0wi86); the facade keeps
-;; the public docstrings and the fan-out / failure-isolation policy.
+;; `re-frame.epoch.state`; the facade keeps the public docstrings and the
+;; fan-out / failure-isolation policy.
 
 (defn register-epoch-listener!
   "Register a callback fired once per drain-settle with the assembled

--- a/implementation/http/src/re_frame/http_transport.cljc
+++ b/implementation/http/src/re_frame/http_transport.cljc
@@ -1,17 +1,15 @@
 (ns re-frame.http-transport
   "Shared transport + attempt-and-retry loop for `:rf.http/managed`.
 
-  Extracted from `re-frame.http-managed` per rf2-3i9b; collapsed onto a
-  single .cljc per rf2-921qy. The CLJS path uses the Fetch API and the
-  JVM path uses `java.net.http.HttpClient`; everything else
-  (`dispatch-reply!`, `finalise-success!`, `finalise-failure!`,
-  `maybe-retry!`, the 4xx/5xx/2xx/else response cascade, the
-  in-flight registry interaction, the retry-trace emission, the
-  rf2-bma05 privacy redaction, the rf2-lxd3 supersede suppression)
-  is platform-agnostic and shared. Platform-specific fragments
-  (`cljs-fetch` + `classify-cljs-error` on CLJS; `jvm-fetch` +
-  `classify-jvm-error` + `check-cljs-only-keys!` on JVM) are gated
-  with reader conditionals.
+  The CLJS path uses the Fetch API and the JVM path uses
+  `java.net.http.HttpClient`; everything else (`dispatch-reply!`,
+  `finalise-success!`, `finalise-failure!`, `maybe-retry!`, the
+  4xx/5xx/2xx/else response cascade, the in-flight registry interaction,
+  the retry-trace emission, the rf2-bma05 privacy redaction, the
+  rf2-lxd3 supersede suppression) is platform-agnostic and shared.
+  Platform-specific fragments (`cljs-fetch` + `classify-cljs-error` on
+  CLJS; `jvm-fetch` + `classify-jvm-error` + `check-cljs-only-keys!` on
+  JVM) are gated with reader conditionals.
 
   Per-row CLJS-only request keys (`:abort-signal`, `:mode`, `:cache`,
   `:referrer`, `:integrity`) are no-ops on JVM with a one-line trace

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
@@ -23,9 +23,9 @@
   `:children` sub-map has every spawned child id. The handler iterates
   `:children` and tears each one down, then clears the slot.
 
-  Per rf2-lha2t the actor-teardown app-db dance lives in
-  `re-frame.machines.lifecycle-fx.teardown` — one helper, three (now
-  unified) call-sites."
+  The actor-teardown app-db dance lives in
+  `re-frame.machines.lifecycle-fx.teardown` — one helper, three
+  call-sites."
   (:require [re-frame.frame :as frame]
             [re-frame.machines.lifecycle-fx.exit-cascade :as exit-cascade]
             [re-frame.machines.lifecycle-fx.finalize :as finalize]

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/exit_cascade.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/exit_cascade.cljc
@@ -1,5 +1,5 @@
 (ns re-frame.machines.lifecycle-fx.exit-cascade
-  "Destroy-time `:exit` cascade runner (rf2-nahfm).
+  "Destroy-time `:exit` cascade runner.
 
   Per Spec 005 §Declarative `:spawn` §Composition with explicit
   `:entry` / `:exit`: when a `:spawn`-spawned actor is destroyed, the
@@ -8,12 +8,12 @@
   `:entry` / `:exit`: a final state's `:exit` runs from the auto-
   destroy teardown, same ordering convention.
 
-  Pre-rf2-nahfm the four destroy entry-points — explicit
+  Centralises the four destroy entry-points — explicit
   `:rf.machine/destroy`, declarative-`:spawn` exit-cascade destroy,
   `:spawn-all` per-child teardown, and final-state auto-destroy —
-  each tore the actor's snapshot down WITHOUT firing the active
-  configuration's `:exit` actions. This namespace centralises the fix
-  so every destroy path runs through `run-child-exit!`.
+  so every destroy path runs through `run-child-exit!` and the
+  active configuration's `:exit` actions fire before the snapshot
+  is torn down.
 
   The pure exit cascade (path resolution + action collection) lives in
   `re-frame.machines.parallel/run-active-exit-cascade` (which dispatches

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
@@ -1,7 +1,7 @@
 (ns re-frame.machines.lifecycle-fx.finalize
-  "Final-state orchestration (rf2-gn80).
+  "Final-state orchestration.
 
-  Per Spec 005 §Final states (rf2-gn80): when a machine enters a `:final?`
+  Per Spec 005 §Final states: when a machine enters a `:final?`
   state, the runtime fires the parent's `:on-done` (if any) and auto-
   destroys the actor SYNCHRONOUSLY (D4). The orchestration:
 
@@ -29,9 +29,9 @@
   hook into the http-managed artefact (rf2-wvkn) — because both the
   finalize cascade and the spawn-destroy teardowns invoke it.
 
-  Per rf2-lha2t the actor-teardown app-db dance lives in
-  `re-frame.machines.lifecycle-fx.teardown` — one helper, three (now
-  unified) call-sites."
+  The actor-teardown app-db dance lives in
+  `re-frame.machines.lifecycle-fx.teardown` — one helper, three
+  call-sites."
   (:require [re-frame.late-bind :as late-bind]
             [re-frame.machines.lifecycle-fx.teardown :as teardown]
             [re-frame.machines.lifecycle-fx.traces :as traces]

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/frame_destroy.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/frame_destroy.cljc
@@ -1,5 +1,5 @@
 (ns re-frame.machines.lifecycle-fx.frame-destroy
-  "Frame-destroy machine-cascade orchestrator (rf2-vsigt).
+  "Frame-destroy machine-cascade orchestrator.
 
   Per Spec 005 §Cross-Spec Interactions §1 — Frame disposal with active
   machine instances — `destroy-frame!` must:

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
@@ -1,5 +1,5 @@
 (ns re-frame.machines.lifecycle-fx.join
-  "`:spawn-all` join-event interception (rf2-6vmw).
+  "`:spawn-all` join-event interception.
 
   Per Spec 005 §Spawn-and-join via `:spawn-all` §Child completion protocol,
   the parent's handler boundary intercepts events whose inner-event-id

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
@@ -1,10 +1,10 @@
 (ns re-frame.machines.lifecycle-fx.registration
-  "Registration boundary: handler factory + `reg-machine*` (rf2-f9tu).
+  "Registration boundary: handler factory + `reg-machine*`.
 
   `make-machine-handler` is the event-fx handler factory beneath the
   `reg-machine` macro; `reg-machine*` is the plain-fn surface used by
-  the late-bind table and by REPL workflows. Per rf2-f9tu the factory
-  is decomposed into:
+  the late-bind table and by REPL workflows. The factory decomposes
+  into:
 
     - `validate-machine!` — every registration-time check (extracted to
       `re-frame.machines.lifecycle-fx.validation`: parallel shape,

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
@@ -88,14 +88,11 @@
                       invoke-id (assoc :rf/spawn-id invoke-id))]
       (assoc spec :data data'))))
 
-;; Per rf2-fgqs4: the spawned actor's initial snapshot is built by
+;; The spawned actor's initial snapshot is built by
 ;; `parallel/build-initial-snapshot` — the single source of truth shared
 ;; with the singleton-registration path
-;; (`lifecycle-fx.registration/make-machine-handler`). Pre-rf2-fgqs4
-;; the spawn-path's local helper silently omitted `:rf/spawn-counter`
-;; (so an `:entry`-declared `:spawn` fell to `allocate-spawned-id`'s
-;; defensive `(fnil inc 0)` backstop) and `:meta` (so spawned actors
-;; that declared `:meta` couldn't introspect it from the snapshot).
+;; (`lifecycle-fx.registration/make-machine-handler`); the shared builder
+;; seeds `:rf/spawn-counter` and `:meta` consistently across both paths.
 ;; The spawn path passes `:bootstrap-pending? true` because the actor's
 ;; first dispatch must fire the initial-entry cascade (rf2-0z73).
 

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/teardown.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/teardown.cljc
@@ -20,11 +20,10 @@
   fixture the runtime keeps those slots present-but-empty so callers
   observing the app-db root see a stable shape.
 
-  Per audit rf2-ra1he §P0 #3 / §L2 / §L7 / §L8 / §L12 (rf2-lha2t): this
-  dance was previously inlined at three call-sites with subtle
-  order-of-operations divergence around the lazy-allocation prunes. The
-  unification lives here so contract changes (e.g. a `:rf/spawned` key
-  rename, an extra root to prune) touch one spot.
+  The unification lives here so contract changes (e.g. a `:rf/spawned`
+  key rename, an extra root to prune) touch one spot — the three
+  destroy paths (explicit, exit-cascade declarative, final-state auto-
+  destroy) all route through this projection.
 
   This namespace is PURE — it does not unregister handlers, abort
   in-flight HTTP, or emit traces. Those are caller side effects whose

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/validation.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/validation.cljc
@@ -1,5 +1,5 @@
 (ns re-frame.machines.lifecycle-fx.validation
-  "Registration-time validators for the machine grammar (rf2-f9tu).
+  "Registration-time validators for the machine grammar.
 
   Pure leaf functions called from
   `re-frame.machines.lifecycle-fx.registration/make-machine-handler` at

--- a/implementation/routing/src/re_frame/routing/events.cljc
+++ b/implementation/routing/src/re_frame/routing/events.cljc
@@ -42,7 +42,7 @@
      (str "pn-" n)]))
 
 (defn emit-activation-traces!
-  "Per Spec 012 §Trace events and rf2-dn26r: emit `:rf.route/deactivated`
+  "Per Spec 012 §Trace events: emit `:rf.route/deactivated`
   for the previously-active route id (when leaving one) and
   `:rf.route/activated` for the newly-active route id (when entering a
   different one). Both fire as part of every successful navigation

--- a/implementation/routing/src/re_frame/routing/registry.cljc
+++ b/implementation/routing/src/re_frame/routing/registry.cljc
@@ -168,13 +168,13 @@
       ;; gets a new identity on every register!, and `route-table` checks
       ;; identity equality before reusing the cached pairs vector.
       ;;
-      ;; Per Spec 012 §Trace events and rf2-dn26r: `:rf.route/registered`
-      ;; fires on FIRST-TIME registration so tools subscribing to "all
-      ;; route lifecycle events" see one event per fresh route.
+      ;; Per Spec 012 §Trace events: `:rf.route/registered` fires on
+      ;; FIRST-TIME registration so tools subscribing to "all route
+      ;; lifecycle events" see one event per fresh route.
       ;; Re-registration rides the cross-kind `:rf.registry/handler-
       ;; replaced` trace (emitted by `registrar/register!` per Spec 001
       ;; §Hot-reload trace surface); not re-emitted here. Mirrors the
-      ;; `:rf.flow/registered` symmetry (rf2-ehxez).
+      ;; `:rf.flow/registered` symmetry.
       (when (nil? previous)
         (trace/emit! :rf.event :rf.route/registered
                      {:route-id id
@@ -184,7 +184,7 @@
 (defn unregister-route!
   "Remove a registered route. Emits `:rf.route/cleared` so tools
   subscribing to route lifecycle observe the removal; symmetric with
-  `:rf.flow/cleared`. Per Spec 012 §Trace events (rf2-dn26r). No-op
+  `:rf.flow/cleared`. Per Spec 012 §Trace events. No-op
   when the route id was not registered."
   [id]
   (let [previous (registrar/lookup :route id)]

--- a/implementation/routing/test/re_frame/routing_test.clj
+++ b/implementation/routing/test/re_frame/routing_test.clj
@@ -504,9 +504,8 @@
 ;; key) — so per-frame isolation is achieved by routing the helpers
 ;; through the appropriate frame's db value.
 ;;
-;; Pre-rf2-1aqz the helpers were reachable only through the navigate
-;; flow's scroll fx; a regression in either fn would only surface via
-;; integration. These tests pin the round-trip directly.
+;; These tests pin the helper round-trip directly so a regression in
+;; either fn surfaces without going through the navigate flow's scroll fx.
 
 (deftest scroll-position-lookup-after-save
   (testing "save-scroll-position then lookup-scroll-position round-trips
@@ -769,17 +768,12 @@
 ;; malformed link must produce a route-miss (404 path), never a request-
 ;; handler crash.
 ;;
-;; rf2-4ic0f tightened the contract uniformly across path / query /
-;; fragment: ALL three fail closed at the URL level — `match-url`
-;; returns nil regardless of which portion is malformed. Pre-rf2-4ic0f
-;; the query branch was lenient (silently dropped the bad pair); that
-;; let hostile URLs into the routing slice when the host route had no
-;; required keys. The new contract refuses any URL whose %-encoding
-;; cannot be uniformly decoded.
+;; Contract (rf2-4ic0f): uniform fail-closed across path / query /
+;; fragment — `match-url` returns nil regardless of which portion is
+;; malformed. The runtime refuses any URL whose %-encoding cannot be
+;; uniformly decoded.
 ;;
-;; The reproducer from the security audit: `(routing/match-url "/search?x=%")`
-;; previously threw `IllegalArgumentException` on JVM; pre-rf2-4ic0f
-;; resolved to `{:route-id :route/search :query {}}`; post-rf2-4ic0f
+;; Reproducer from the security audit: `(routing/match-url "/search?x=%")`
 ;; resolves to nil (route-miss → `:rf.route/not-found` with
 ;; `:reason :malformed-url` at `:rf.route/transitioned`).
 
@@ -1952,17 +1946,14 @@
 ;; ---- rf2-5ifai: no :query vocabulary -> all string keys ------------------
 ;;
 ;; Per Spec 012 §Query strings and fragments and the rf2-tfgdv security
-;; review. Pre-rf2-5ifai a route declaring NO query vocabulary at all
-;; (no `:query` / `:query-defaults` / `:query-retain`) received the
-;; legacy "keyword-all" shortcut — every URL key was promoted to a
-;; permanent JVM keyword. That symmetrical-to-rf2-3k3o7 leak was the
-;; same DoS surface seen on the value side: hostile URLs composed of
-;; N-unique keys burn N permanent JVM keyword slots, and a bare
-;; `(reg-route :route/x {:path "/x"})` is precisely the high-cardinality
-;; public-surface case where this hits hardest. Post-rf2-5ifai routes
-;; that declare no vocabulary keep every URL key as a string. Authors
-;; who want keyword keys declare them via `:query` / `:query-defaults`
-;; / `:query-retain` — author-named intent is the trust boundary.
+;; review: a route declaring NO query vocabulary at all (no `:query` /
+;; `:query-defaults` / `:query-retain`) keeps every URL key as a string.
+;; Authors who want keyword keys declare them via `:query` /
+;; `:query-defaults` / `:query-retain` — author-named intent is the
+;; trust boundary. Symmetrical to the rf2-3k3o7 value-side fix: hostile
+;; URLs composed of N-unique keys would otherwise burn N permanent JVM
+;; keyword slots, and a bare `(reg-route :route/x {:path "/x"})` is the
+;; high-cardinality public-surface case where the DoS hits hardest.
 
 (deftest rf2-5ifai-no-vocabulary-route-keeps-all-keys-as-strings
   (testing "rf2-5ifai: a route declaring NO :query vocabulary keeps
@@ -2604,11 +2595,9 @@
 (deftest can-leave-non-boolean-blocks-navigation
   (testing "a :can-leave sub that returns a non-boolean truthy value
             BLOCKS navigation and emits :rf.error/can-leave-non-boolean
-            (rf2-5pyyl). Closed contract: pre-rf2-5pyyl the runtime
-            tolerated non-booleans with a warning and let the nav
-            through; now it BLOCKS so the polarity bug (returning the
-            dirty-flag value rather than (not dirty?)) cannot silently
-            strand form state."
+            (rf2-5pyyl). Closed contract — blocking ensures the polarity
+            bug (returning the dirty-flag value rather than (not dirty?))
+            cannot silently strand form state."
     (rf/reg-route :editor/article
                   {:path      "/editor/articles/:id"
                    :params    [:map [:id :string]]
@@ -2617,8 +2606,7 @@
     (rf/reg-event-db :editor/set-dirty
                      (fn [db [_ v]] (assoc-in db [:editor :dirty?] v)))
     ;; Polarity bug: return the dirty-flag directly (truthy when dirty).
-    ;; Pre-rf2-5pyyl this would pass the nav through (it's truthy);
-    ;; now it must BLOCK.
+    ;; A truthy non-boolean must BLOCK nav (rf2-5pyyl).
     (rf/reg-sub :editor/leave?
                 (fn [db _] (get-in db [:editor :dirty?])))
     (rf/reg-fx :rf.nav/push-url

--- a/implementation/schemas/src/re_frame/schemas/validate.cljc
+++ b/implementation/schemas/src/re_frame/schemas/validate.cljc
@@ -42,13 +42,13 @@
   the primitive itself, along with every literal reason string passed
   through it.
 
-  Per Spec 010 §Non-Malli validators (rf2-froe) the validator/explainer
+  Per Spec 010 §Non-Malli validators the validator/explainer
   are pluggable via the registered atoms in `re-frame.schemas.validator`;
   when none is registered every fn here returns true (pass) without
   inspecting the schema.
 
   Per Spec 010 §`:sensitive?` — privacy in schema-validation error
-  traces (rf2-kj51z). The emit-sites redact the failing value before
+  traces. The emit-sites redact the failing value before
   stamping a trace event when either:
     1. The schema slot at the failing path (or a containing slot)
        carries `:sensitive? true` in its Malli props.

--- a/implementation/schemas/src/re_frame/schemas/validator.cljc
+++ b/implementation/schemas/src/re_frame/schemas/validator.cljc
@@ -164,7 +164,7 @@
 
 (defn set-schema-validator!
   "Register the validator fn that every dev-time validation site routes
-  through. Per Spec 010 §Non-Malli validators (rf2-froe) the seam is
+  through. Per Spec 010 §Non-Malli validators the seam is
   the substitute-Malli extension point — apps that want to drop Malli
   (the ~24 KB gzipped surface measured in the rf2-qnxf bundle audit)
   swap in their own validator at boot, before the first `reg-app-schema`

--- a/implementation/ssr-ring/src/re_frame/ssr/ring.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring.clj
@@ -117,11 +117,10 @@
 
 ;; ---- handler defaults + caller-opt validation -----------------------------
 ;;
-;; Pre-rf2-zkca8.1 these lived in `re-frame.ssr.ring.handler-defaults`
-;; (45 L, one consumer — this ns). Recombined here so the handler
-;; constructor reads top-down as one concept. `default-on-error` is
-;; re-exported from `lifecycle` (shared with `stream-handler` so the
-;; rf2-kzvwq topology-leak contract lives in one place).
+;; Co-located with the handler constructor so the file reads top-down as
+;; one concept. `default-on-error` is re-exported from `lifecycle`
+;; (shared with `stream-handler` so the rf2-kzvwq topology-leak contract
+;; lives in one place).
 
 (def default-on-error lifecycle/default-on-error)
 (def make-default-on-error lifecycle/make-default-on-error)

--- a/implementation/ssr-ring/src/re_frame/ssr/ring.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring.clj
@@ -162,9 +162,8 @@
 
 (defn- validate-handler-opts!
   "Throw a structured `:rf.error/ssr-ring-missing-*` ex-info when a
-  caller omits a required `ssr-handler` opt. Extracted from the
-  handler body per audit rf2-asmj1 R3 / cluster rf2-sljs1 so the body
-  of `ssr-handler` reads as the lifecycle wiring rather than a
+  caller omits a required `ssr-handler` opt. Separated from the handler
+  body so `ssr-handler` reads as the lifecycle wiring rather than a
   validation-then-wire two-step.
 
   Per rf2-gtgf9 the hydration-payload policy is also validated here so

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/cookie.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/cookie.clj
@@ -142,12 +142,12 @@
                      :recovery :no-recovery})))
   ;; rf2-rpedl §P2.4 — RFC 6265 §4.1.1 cookie-name token grammar.
   (validate-cookie-name! name)
-  ;; Per audit rf2-asmj1 R7 / cluster rf2-sljs1: `Instant/ofEpochMilli`
-  ;; takes a primitive long; passing anything else (a string-shaped
-  ;; epoch from a misconfigured projector, a `java.util.Date`, …) would
-  ;; NPE deep inside the format path. Catch the type-mismatch up front
-  ;; with a clear `:rf.error/cookie-invalid-expires` so the misuse
-  ;; surfaces with the cookie's actual shape attached.
+  ;; `Instant/ofEpochMilli` takes a primitive long; passing anything
+  ;; else (a string-shaped epoch from a misconfigured projector, a
+  ;; `java.util.Date`, …) would NPE deep inside the format path. Catch
+  ;; the type-mismatch up front with a clear
+  ;; `:rf.error/cookie-invalid-expires` so the misuse surfaces with the
+  ;; cookie's actual shape attached.
   (when (and (some? expires) (not (integer? expires)))
     (throw (ex-info ":rf.error/cookie-invalid-expires"
                     {:rf.error/id :rf.error/cookie-invalid-expires

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/headers.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/headers.clj
@@ -16,8 +16,7 @@
   "Fold a `[name value]` header pair into the accumulating Ring headers
   map. The accumulator only ever carries `nil`, `string`, or `vector`
   values per the contract upstream — no other shapes flow in — so the
-  three arms here are exhaustive (audit rf2-asmj1 R8 / cluster
-  rf2-sljs1: the prior `:else` arm was dead)."
+  three arms here are exhaustive."
   [m [k v]]
   (let [existing (get m k)]
     (cond
@@ -51,12 +50,11 @@
   (header names are tokens; tokens are case-insensitive) — a mixed-case
   caller header must NOT get a duplicate default appended.
 
-  Ordering note (audit rf2-asmj1 R9 / cluster rf2-sljs1) — the PER-NAME
-  ordering of multi-valued headers (multiple `Set-Cookie` entries) is
-  preserved by `merge-pair-into-header-map`'s `conj`. The ACROSS-NAME
-  ordering is the JDK's HAMT iteration order — stable but not first-seen
-  order; Ring servers don't promise cross-name header order on the wire
-  either."
+  Ordering: the PER-NAME ordering of multi-valued headers (multiple
+  `Set-Cookie` entries) is preserved by `merge-pair-into-header-map`'s
+  `conj`. The ACROSS-NAME ordering is the JDK's HAMT iteration order —
+  stable but not first-seen order; Ring servers don't promise cross-name
+  header order on the wire either."
   [pairs content-type]
   (let [step (fn [[m saw-ct?] [k v :as pair]]
                [(merge-pair-into-header-map m pair)

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/lifecycle.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/lifecycle.clj
@@ -102,10 +102,8 @@
   a real handler error; swallow + emit a `:warning` trace is preferred
   over propagation.
 
-  Per audit rf2-asmj1 R6 / cluster rf2-sljs1: prior to this change the
-  catch silently returned nil, so a destroy-time throw vanished entirely
-  whenever the trace listener fired before the destroy. Surfacing the
-  throwable on the trace bus keeps the error visible to dev tooling
+  Surfaces any destroy-time throw on the trace bus rather than
+  silently swallowing it — keeps the error visible to dev tooling
   without escalating to a user-visible 500 (the handler-side error has
   already been materialised by the time this fn runs)."
   [frame-id]

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
@@ -30,11 +30,10 @@
   stamp the projector's `:status` onto the response accumulator,
   then emits a minimal HTML error body driven by the projector's
   public-error map (Spec 011 §Server error projection §View-time
-  exceptions). Pre-rf2-zwgsv a render-side throw escaped to the
-  outer ssr-handler try/catch and produced the fixed
-  `\"Internal error\"` text (rf2-kzvwq) — different body contract
-  on the wire depending on where the failure originated. Unified
-  now."
+  exceptions). Render-time and drain-time exceptions thus share one
+  body contract on the wire — the projector's public-error map — and
+  no fixed `\"Internal error\"` fallback string ever reaches a client
+  (rf2-kzvwq)."
   (:require [re-frame.core :as rf]
             [re-frame.ssr :as ssr]
             [re-frame.ssr.ring.headers :as headers]
@@ -254,13 +253,9 @@
                 ;; ONCE per request. The same hex feeds the root-element
                 ;; `data-rf-render-hash` (via render-to-string's
                 ;; `:render-hash` opt) AND the payload's
-                ;; `:rf/render-hash`. Pre-rf2-i15nh render-to-string
-                ;; computed the hash internally on the `:emit-hash?`
-                ;; branch and the pipeline called render-tree-hash again
-                ;; here — two full canonical-EDN walks per request. The
-                ;; opt-threaded form drops it to one. When `:emit-hash?`
-                ;; is false the hash is still needed for the payload
-                ;; slot.
+                ;; `:rf/render-hash`, so the canonical-EDN walk runs
+                ;; once per request. When `:emit-hash?` is false the
+                ;; hash is still needed for the payload slot.
                 hash-str  (ssr/render-tree-hash hiccup)
                 body-html (ssr/render-to-string
                             hiccup
@@ -343,19 +338,16 @@
        uses — so headers / cookies the drain DID accumulate before
        the render-time throw still ride the wire.
 
-  Pre-rf2-zwgsv this code didn't try/catch — render-time throws
-  bubbled to the outer `ssr-handler` try/catch and got the fixed
-  `\"Internal error\"` body (rf2-kzvwq). That left two body
-  contracts on the wire depending on where the failure originated:
-  drain-time → projector body; render-time → fixed string. The
-  unification ensures both go through the projector.
+  The try/catch is the unification point: render-time AND drain-time
+  exceptions both go through the projector, so the wire body contract
+  is uniform regardless of where the failure originated (rf2-zwgsv).
 
   Note: the outer `ssr-handler`'s `:on-error` hook still wraps this
   call. The remaining exceptions it catches are Ring-layer / transport
   failures the projector can't see (e.g. an exception in the host's
   Content-Type negotiator, or a re-throw from the projector pipeline
-  itself when no server frame is registered). Those still hit the
-  fixed-string default per rf2-kzvwq's topology-leak rule."
+  itself when no server frame is registered). Those hit the fixed-
+  string default per rf2-kzvwq's topology-leak rule."
   [frame-id resp opts]
   (try
     (build-full-response* frame-id resp opts)

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
@@ -389,16 +389,14 @@
       ;; rf2-kzvwq / security audit §P2.1 — the default body MUST NOT
       ;; carry the exception's message. .getMessage is documented as
       ;; carrying internal topology (JDBC URLs, file paths, SQL
-      ;; fragments); leaking it publicly is the bug. Same boundary as
-      ;; pre-rf2-zwgsv (the projector is the security boundary now).
+      ;; fragments); leaking it publicly is the bug. The projector is
+      ;; the security boundary.
       (is (not (str/includes? (:body response) "boom-internal-jdbc-url-secret"))
           "rf2-kzvwq: the throwable's message text MUST NOT appear in
            the projector body (topology disclosure surface)")
-      ;; rf2-zwgsv: the new projector-driven body MUST carry the
-      ;; default projector's `:message` ("Something went wrong") so the
-      ;; client / crawler / monitoring stack sees the public surface,
-      ;; not the fixed `"Internal error"` string the pre-rf2-zwgsv
-      ;; on-error fallback produced.
+      ;; rf2-zwgsv: the projector-driven body carries the default
+      ;; projector's `:message` ("Something went wrong") so the
+      ;; client / crawler / monitoring stack sees the public surface.
       (is (str/includes? (:body response) "Something went wrong")
           "rf2-zwgsv: wire body carries the projector's `:message`
            (default = 'Something went wrong' per
@@ -408,9 +406,9 @@
            (default = `:internal-error`) as a stable category that
            response-page templates can branch on.")
       (is (not (= "Internal error" (:body response)))
-          "rf2-zwgsv: the pre-rf2-zwgsv fixed 'Internal error' string
-           is gone — render-time throws now go through the projector,
-           not the Ring :on-error fallback."))))
+          "rf2-zwgsv: render-time throws go through the projector,
+           not the Ring :on-error fallback — the fixed
+           'Internal error' string is never the wire body."))))
 
 (deftest handler-render-error-custom-projector-shapes-body
   (testing "rf2-zwgsv — caller customises the render-time error wire
@@ -547,12 +545,12 @@
 ;;
 ;; The fn-form branch of `:root-view` is not guaranteed to be idempotent —
 ;; unsorted-map iteration order, gensym'd react keys, and time-of-day
-;; props all vary between calls. Pre-rf2-6t36h the adapter invoked the
-;; root-view fn twice per request (once for the wire HTML / its embedded
-;; data-rf-render-hash, once for the payload's :rf/render-hash). Two
-;; non-identical trees → two non-equal hashes → spurious
-;; :rf.ssr/hydration-mismatch on the client for an otherwise successful
-;; hydration.
+;; props all vary between calls. The adapter therefore invokes the
+;; root-view fn ONCE per request and reuses the same tree for the wire
+;; HTML / its embedded data-rf-render-hash AND for the payload's
+;; :rf/render-hash. Two invocations would produce two non-identical trees
+;; → two non-equal hashes → spurious :rf.ssr/hydration-mismatch on the
+;; client for an otherwise successful hydration.
 ;;
 ;; These tests pin the contract: ONE invocation per request, and the wire
 ;; hash equals the payload hash even when the fn is technically
@@ -579,7 +577,8 @@
         (is (= 200 (:status response)))
         (is (= 1 @call-count)
             "fn-form :root-view must be invoked exactly once per request
-             (rf2-6t36h: was 2 — once for wire HTML, once for hash)")))))
+             (rf2-6t36h: ONE call covers both the wire HTML and the
+             payload :rf/render-hash)")))))
 
 (deftest fn-form-root-view-non-idempotent-still-hashes-consistently
   (testing "rf2-6t36h: a non-idempotent fn-form :root-view produces a wire
@@ -591,10 +590,10 @@
         (fn [_ _] {}))
 
       ;; A view fn that produces a DIFFERENT tree on every call — its
-      ;; key includes a monotonic counter. Pre-rf2-6t36h the wire HTML
-      ;; would carry hash(tree_1) and the payload would carry
-      ;; hash(tree_2); they would differ and the client's hydration
-      ;; verifier would fire a spurious mismatch.
+      ;; key includes a monotonic counter. With two invocations the wire
+      ;; HTML would carry hash(tree_1) and the payload would carry
+      ;; hash(tree_2); rf2-6t36h's single-invocation contract closes that
+      ;; spurious-mismatch gap.
       (rf/reg-view* :pages/noni
         (fn [n] [:div {:data-call n} "noni"]))
 
@@ -790,11 +789,10 @@
 ;;   2. **The fail-closed proof** — when a handler is constructed
 ;;      with an allowlist that does NOT include a server-only key,
 ;;      that key MUST NOT appear in the hydration payload on the
-;;      wire. This is the regression-bite: pre-rf2-gtgf9 the absence
-;;      of `:payload-keys` defaulted to whole-app-db, so a server-
-;;      only key on app-db rode the wire silently. The new contract
-;;      requires the allowlist; an un-permitted slot is provably
-;;      excluded by inspection of the wire payload.
+;;      wire. The contract requires the allowlist; an un-permitted
+;;      slot is provably excluded by inspection of the wire payload
+;;      (rf2-gtgf9: no default-whole-app-db fallback exists, so
+;;      server-only keys cannot ride the wire silently).
 ;;
 ;;   3. The opt-in branch — `:payload-policy
 ;;      :rf.ssr.payload/whole-app-db` ships the whole app-db verbatim
@@ -887,10 +885,10 @@
 (deftest fail-closed-proof-unpermitted-slot-not-on-wire
   (testing "rf2-gtgf9 FAIL-CLOSED PROOF: a server-only app-db key NOT in
             the :payload-keys allowlist MUST NOT appear in the
-            hydration-payload script tag's EDN body. This is the
-            regression-bite — pre-rf2-gtgf9, absence of :payload-keys
-            shipped the whole app-db, so an unaudited new app-db key
-            silently rode the wire on every request."
+            hydration-payload script tag's EDN body. Without the
+            allowlist gate an unaudited new app-db key would silently
+            ride the wire on every request — the allowlist is load-
+            bearing."
     (rf/reg-event-fx :init/with-secret
       {:platforms #{:server}}
       (fn [_ _]
@@ -934,16 +932,12 @@
            dropping everything by accident)")
 
       ;; THE FAIL-CLOSED PROOF: the un-permitted slot's value MUST
-      ;; NOT appear in the wire payload. If pre-rf2-gtgf9 behaviour
-      ;; were still in force, the leak-probe string would be present
-      ;; (whole-app-db default). Under rf2-gtgf9 the allowlist is
-      ;; load-bearing — this assertion is what the security audit
+      ;; NOT appear in the wire payload. Under rf2-gtgf9 the allowlist
+      ;; is load-bearing — this assertion is what the security audit
       ;; asked for.
       (is (not (str/includes? payload-edn "RF2_GTGF9_FAIL_CLOSED_PROBE_xyz789"))
           "rf2-gtgf9 fail-closed proof: an un-permitted server-only
-           key's value does NOT appear in the wire hydration payload.
-           Pre-rf2-gtgf9 the absence of :payload-keys defaulted to
-           whole-app-db — this string would have leaked.")
+           key's value does NOT appear in the wire hydration payload.")
       (is (not (str/includes? payload-edn "feature-flag"))
           "rf2-gtgf9: the un-permitted key NAME also does not leak —
            neither key nor value reaches the wire")
@@ -1256,8 +1250,7 @@
 (deftest default-shell-html-and-body-bare-when-attrs-absent
   (testing "head model with no :html-attrs / :body-attrs → <html> falls
             back to the :lang opt (default \"en\"); <body> is bare. This
-            is the pre-rf2-h2ujj shape and the default for routes that
-            don't opt in."
+            is the default for routes that don't opt into attr bags."
     (register-attrs-app! {:title "T"}) ; no attr bags
 
     (let [handler  (ssr-ring/ssr-handler
@@ -1443,9 +1436,10 @@
            lives in a framework-private side-channel atom, not in app-db")
 
       ;; (c) The server-only secret values MUST NOT appear in the payload.
-      ;; This is the regression-bite assertion: pre-rf2-jbcmt these strings
-      ;; rode the wire as part of `[:rf/response :cookies ...]` /
-      ;; `[:rf/response :headers ...]` inside the app-db slice.
+      ;; rf2-jbcmt strips `[:rf/response :cookies ...]` /
+      ;; `[:rf/response :headers ...]` from the app-db slice before it
+      ;; reaches the wire — Set-Cookie / X-Secret-Header values live in
+      ;; the response headers ONLY, not also in the hydration payload.
       (is (not (str/includes? payload-edn "SUPER_SECRET_AUTH_TOKEN_xyz"))
           "rf2-jbcmt: the Set-Cookie auth token does NOT leak into the
            hydration payload")

--- a/implementation/ssr/src/re_frame/ssr/error_listener.cljc
+++ b/implementation/ssr/src/re_frame/ssr/error_listener.cljc
@@ -257,8 +257,7 @@
 
   Use this from debug paths or midpoint inspections where draining the
   projector buffer (the side-effect baked into `get-response`) would
-  consume a trace the host had not yet observed (audit rf2-asmj1 P5 /
-  cluster rf2-sljs1)."
+  consume a trace the host had not yet observed."
   [frame-id]
   (-> (response/response-of frame-id)
       (dissoc response/status-writes-key response/redirect-writes-key)))
@@ -269,9 +268,10 @@
   buffer; the first call after an error trace wins (last-write-wins,
   mirroring `:rf.server/set-status`).
 
-  This is the read host adapters call once at drain settle-point.
-  `get-response` is preserved as the back-compat alias (audit
-  rf2-asmj1 P5 / cluster rf2-sljs1)."
+  This is the explicit-side-effect spelling. `get-response` is the
+  canonical host-adapter alias for the same drain-then-read sequence;
+  `peek-response` is the pure-read counterpart for callers that want
+  to opt out of the drain side effect."
   [frame-id]
   (apply-error-projection! frame-id)
   (peek-response frame-id))
@@ -287,11 +287,10 @@
   Spec 011 §Server error projection — \"runtime sets `:rf.server/set-
   status` to the public-error's :status\".
 
-  Note (audit rf2-asmj1 P5 / cluster rf2-sljs1): `get-response` is the
-  drain-then-read entry point — equivalent to `flush-response!`. The
-  pure read (no drain) is `peek-response`. Both new names exist so a
-  caller can opt into the side-effect explicitly; `get-response` is
-  preserved as the canonical host-adapter call."
+  `get-response` is the canonical host-adapter alias for the drain-
+  then-read sequence. `flush-response!` is the explicit-side-effect
+  spelling; `peek-response` is the pure read. All three exist so
+  callers can opt into the side-effect explicitly."
   [frame-id]
   (flush-response! frame-id))
 

--- a/implementation/ssr/src/re_frame/ssr/hash.cljc
+++ b/implementation/ssr/src/re_frame/ssr/hash.cljc
@@ -20,22 +20,17 @@
 
 ;; ---- canonical-EDN walker (rf2-8otin / rf2-atmvj) -------------------------
 ;;
-;; Pre-rf2-8otin the walker materialised the whole canonical form as a
-;; nested `(str ...)` of `clojure.string/join` results, then handed the
-;; finished string to `fnv-1a-32` which walked the UTF-8 bytes a second
-;; time. Two passes plus a tree-shaped tower of intermediate strings.
-;;
-;; The new shape is single-pass: a mutually-recursive walker
-;; (`canonical-edn-into`) appends each canonical fragment into a
-;; per-call `StringBuilder` on JVM / mutable JS string accumulator on
-;; CLJS. The accumulated string is then byte-hashed once. The output
-;; (the parity-pinned canonical literal at every fixture in
-;; `re-frame.ssr.hash-parity-fixtures`) is byte-identical to the old
-;; walker — only the allocation profile changes.
+;; Single-pass mutually-recursive walker (`canonical-edn-into`): each
+;; canonical fragment appends into a per-call `StringBuilder` on JVM /
+;; mutable JS string accumulator on CLJS; the accumulated string is then
+;; byte-hashed once. The output (the parity-pinned canonical literal at
+;; every fixture in `re-frame.ssr.hash-parity-fixtures`) is byte-
+;; identical to the prior nested-`(str ...)` shape that materialised the
+;; whole form before hashing — only the allocation profile changes.
 ;;
 ;; `canonical-edn` (string-returning) is retained as the public surface
 ;; for tests + the JVM↔CLJS parity fixtures that pin the canonical-EDN
-;; literal directly; it now delegates to the same builder-driven walker.
+;; literal directly; it delegates to the same builder-driven walker.
 
 (declare canonical-edn-into)
 
@@ -187,9 +182,9 @@
   spurious `:rf.ssr/hydration-mismatch` traces. Returns nil for nil
   input so the parent collection's `keep` / `remove` step prunes it.
 
-  Post rf2-8otin this delegates to `canonical-edn-into` with a fresh
-  accumulator — the public surface is unchanged but the production
-  hash path skips this allocation entirely (see `render-tree-hash`)."
+  Delegates to `canonical-edn-into` with a fresh accumulator (rf2-8otin) —
+  the public surface is unchanged but the production hash path skips this
+  allocation entirely (see `render-tree-hash`)."
   [x]
   (when-not (nil? x)
     #?(:clj
@@ -262,13 +257,10 @@
   identical canonical-EDN representation.
 
   Single-pass (rf2-8otin) — feeds the canonical-EDN walker into one
-  accumulator and byte-hashes the result once. Pre-rf2-8otin
-  `canonical-edn` materialised a tree-shaped tower of intermediate
-  strings (one per nesting level from the inner `(str ...)` /
-  `clojure.string/join` calls) before `fnv-1a-32` walked the bytes;
-  the streaming walker eliminates those intermediates while preserving
-  byte-identical output (the parity-pinned literals at
-  `re-frame.ssr.hash-parity-fixtures` are the cross-runtime contract)."
+  accumulator and byte-hashes the result once. The streaming walker
+  emits byte-identical output to the prior tree-shaped-intermediates
+  shape; the parity-pinned literals at `re-frame.ssr.hash-parity-fixtures`
+  are the cross-runtime contract."
   [render-tree]
   #?(:clj
      (let [sb (StringBuilder.)]

--- a/implementation/ssr/src/re_frame/ssr/head.cljc
+++ b/implementation/ssr/src/re_frame/ssr/head.cljc
@@ -10,11 +10,8 @@
 
   ---- file split (rf2-x7g10) ----
 
-  Pre-split this ns was 415 LoC carrying three concerns: the HTML
-  escape helpers (duplicated with `re-frame.ssr.emit`), the canonical-
-  order head-model emitter, and the registry + render + active +
-  per-frame snapshot + late-bind wiring. Per the rf2-x7g10 split
-  (audit rf2-asmj1 §H1/Q2):
+  The head module decomposes into three concern-per-file siblings + a
+  shared HTML-helpers ns:
 
     - `re-frame.ssr.html-helpers`   — shared HTML escape helpers
                                       (`escape-html` / `escape-attr` /

--- a/implementation/ssr/src/re_frame/ssr/head/emit.cljc
+++ b/implementation/ssr/src/re_frame/ssr/head/emit.cljc
@@ -40,10 +40,8 @@
   (str "<link" (html/attr-string m) ">"))
 
 (defn- emit-script-tag [m]
-  ;; `attr-string` already iterates the whole map in declaration order —
-  ;; the historical pull-known-keys-then-merge-remainder dance was a
-  ;; no-op that obscured the contract. Per audit rf2-asmj1 H2 / cluster
-  ;; rf2-sljs1: pass `m` straight through.
+  ;; `attr-string` already iterates the whole map in declaration order;
+  ;; pass `m` straight through.
   (str "<script" (html/attr-string m) "></script>"))
 
 (defn- ld-json-string
@@ -158,16 +156,14 @@
 ;; Canonical emission order per Spec 011 §Default flow step 4:
 ;; <title> → <meta> → <link> → <script> → JSON-LD. Encoded as a vector
 ;; of `[model-key emit-fn]` pairs so the canonical ordering reads as
-;; data, not as a six-arm `cond->` (audit rf2-asmj1 H4 / cluster
-;; rf2-sljs1).
+;; data, not as a six-arm `cond->`.
 ;;
 ;; `:title` is intentionally absent — it's a singleton (one slot, one
 ;; string value) whose emit fn takes a string rather than an item from a
 ;; collection. `head-model->html` extracts it via a separate `when-let`
 ;; binding outside this loop. Future singleton additions (e.g. `<base>`)
 ;; need the same separate-binding treatment; collection keys (multiple
-;; tags emitted in declaration order) extend this vector. Audit
-;; rf2-cegm7 A5.
+;; tags emitted in declaration order) extend this vector.
 (def ^:private emission-order
   [[:meta    emit-meta-tag]
    [:link    emit-link-tag]

--- a/implementation/ssr/src/re_frame/ssr/head/registry.cljc
+++ b/implementation/ssr/src/re_frame/ssr/head/registry.cljc
@@ -104,8 +104,7 @@
   Always carries `:title` — defaulting to `\"\"` when the frame has no
   `:doc`. Empty-title and missing-title both emit no `<title>` tag (the
   emitter elides empty strings), but a programmatic consumer reading
-  the model sees a stable key shape (audit rf2-asmj1 H5 / cluster
-  rf2-sljs1)."
+  the model sees a stable key shape."
   [frame-id]
   (let [doc (when frame-id (:doc (frame/frame-meta frame-id)))]
     {:title (or doc "")
@@ -123,10 +122,9 @@
       (when db (:rf/route db)))))
 
 (defn- render-head*
-  "Resolve a normalised opts map and run the registered head fn. Split
-  from `render-head` per audit rf2-asmj1 H7 / cluster rf2-sljs1 so the
-  caller-facing fn carries the documented two-shape contract on its
-  signature and a private helper carries the work."
+  "Resolve a normalised opts map and run the registered head fn. The
+  caller-facing `render-head` carries the documented two-shape contract
+  on its signature and delegates the work here."
   [head-id {:keys [frame] :as opts}]
   (let [route (if (contains? opts :route)
                 (:route opts)

--- a/implementation/ssr/src/re_frame/ssr/html_helpers.cljc
+++ b/implementation/ssr/src/re_frame/ssr/html_helpers.cljc
@@ -1,14 +1,8 @@
 (ns re-frame.ssr.html-helpers
   "HTML escape + attribute-serialisation helpers shared by the SSR emitter
   (`re-frame.ssr.emit`) and the head/meta emitter
-  (`re-frame.ssr.head.emit`). Per rf2-x7g10 (audit rf2-asmj1 §H1/Q2).
-
-  Pre-split, `re-frame.ssr.emit` and `re-frame.ssr.head` each carried a
-  line-for-line copy of `escape-html`, `escape-attr`, and `attr-string`.
-  The duplication was a hangover from when `head` shipped under a
-  different artefact; under one artefact they're local-deps. Both
-  callsites now `:require` this ns so the entity-escape rules change in
-  exactly one place.
+  (`re-frame.ssr.head.emit`). Both callsites `:require` this ns so the
+  entity-escape rules change in exactly one place.
 
   Escape semantics:
 

--- a/implementation/ssr/src/re_frame/ssr/hydrate.cljc
+++ b/implementation/ssr/src/re_frame/ssr/hydrate.cljc
@@ -51,8 +51,7 @@
         schema-digest (:rf/schema-digest payload)
         ;; Declarative `:rf/hydration` metadata construction — additive,
         ;; nil-pruned. New keys land here as kv pairs without re-ordering
-        ;; the previous `cond->` clauses (audit rf2-asmj1 Q9 / cluster
-        ;; rf2-sljs1).
+        ;; the previous `cond->` clauses.
         metadata      (into {}
                             (filter (comp some? val))
                             {:server-hash (:rf/render-hash payload)

--- a/implementation/ssr/src/re_frame/ssr/payload_policy.cljc
+++ b/implementation/ssr/src/re_frame/ssr/payload_policy.cljc
@@ -9,13 +9,11 @@
   feature flags, server-only working scratch) to every visitor of every
   page.
 
-  Pre-rf2-gtgf9 the payload builder defaulted to `app-db` in toto when
-  `:payload-keys` was nil/empty — a fail-OPEN default that made the
-  privacy decision implicit. Audits surfaced this as the
-  `:rf/response`-accumulator-on-app-db trap (rf2-jbcmt landed the
-  side-channel storage substrate to defend against ONE path of the
-  same family); rf2-briq0's review surfaced that the underlying
-  default was still wrong.
+  A fail-OPEN default (ship whole `app-db` when `:payload-keys` is
+  nil/empty) would make the privacy decision implicit; the
+  `:rf/response`-accumulator-on-app-db trap is one branch of the same
+  family (rf2-jbcmt landed the side-channel storage substrate, rf2-gtgf9
+  closed the default).
 
   This namespace makes the policy:
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff.cljs
@@ -5,7 +5,7 @@
   it renders the observed frame's LIVE `app-db` value, sectioned by
   reserved `:rf/*` area. It is NOT a diff — the diff / value-changed /
   'show me when this changed' affordances were dropped here (rf2-okvit).
-  Diff rendering still lives in the Event tab's `:db` + `:fx` section.
+  Diff rendering lives in the Epoch panel's `:db` + `:fx` section.
 
   ## Layout (rf2-okvit)
 
@@ -39,7 +39,7 @@
     panel's body).
   - `app-db-diff-subs` / `app-db-diff-events` — subs + events. The
     composite diff sub (`:rf.xray/selected-epoch-diff` and friends)
-    survives there for the Event tab's diff surface + the MCP exporter;
+    survives there for the Epoch panel's diff surface + the MCP exporter;
     this panel reads only `:rf.xray/app-db-state`."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-xray.panel-registry :as panel-registry]

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_helpers.cljc
@@ -773,10 +773,10 @@
 ;;      app-db at its registered `:path`.
 ;;
 ;; Without per-path attribution the developer sees "path X changed" and
-;; has to look elsewhere (the FLOWS section in the Event lens) to
-;; figure out which subset of changes came from flow recomputes. The
-;; origin chip on each diff section closes that gap: the section header
-;; carries `[fx :db]` or `[flow :flow-id]` next to the breadcrumb.
+;; has to look elsewhere (the Epoch panel's FLOWS section) to figure out
+;; which subset of changes came from flow recomputes. The origin chip
+;; on each diff section closes that gap: the section header carries
+;; `[fx :db]` or `[flow :flow-id]` next to the breadcrumb.
 ;;
 ;; ## Source of truth
 ;;

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs
@@ -38,7 +38,7 @@
   The widget has NO ⎘ copy affordance (deferred to follow-on beads —
   the popup phase, D6=a). The old EDN widget's copy gesture is
   unaffected on surfaces still wired to it (Trace, segment-inspector,
-  Event lens, Static panels) until phases 2-4 migrate them.
+  Static panels) until subsequent phases migrate them.
 
   ## Inspector-card layout (rf2-63ie5 + rf2-okq7p, post-rf2-jcdvo)
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/icons.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/icons.cljc
@@ -3,9 +3,10 @@
   are required per the bead body's §Icon Requirements:
 
   - **ExternalLink** — 13×13 lucide glyph trailing click-to-source
-    affordances. Already shipped under `panels/event/icons` for the
-    Event lens — the Epoch panel re-uses that hiccup form via a
-    re-export so both panels read the same Figma authority.
+    affordances. The hiccup form lives in `panels/event/icons` (a
+    leftover ns from the retired Event panel that is now re-exported
+    from here); the re-export keeps a single Figma-authority glyph
+    while preserving the existing import path.
   - **CornerDownRight** — 13×13 lucide-style arrow used in the
     handler step's `:db` diff / `:fx` sub-headers (per the bead body's
     §3 HANDLER row design — DB CHANGES + FX sub-blocks).
@@ -19,8 +20,8 @@
 (defn external-link
   "Re-export of `panels.event.icons/external-link` — the lucide-style
   open-in-editor glyph (13×13). Same hiccup, same currentColor stroke.
-  Both panels render the same Figma authority glyph so a Xray operator
-  reads the affordance vocabulary as one verb."
+  One Figma-authority glyph keeps the affordance vocabulary uniform
+  across surfaces."
   []
   (event-icons/external-link))
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch_panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch_panel.cljs
@@ -22,9 +22,7 @@
   delightful numbered cascade including the reactive trailing edge
   (SUBSCRIPTIONS + VIEWS). The Reactive tab covers a complementary
   axis (per-sub recomputation detail across cascades) and remains
-  side-by-side with this panel; the older Event/Handler panel
-  (`:event` tab) was retired under rf2-5gl5r when this Epoch panel
-  landed as its supersedant.
+  side-by-side with this panel.
 
   ## Frame integration
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/event/icons.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/event/icons.cljc
@@ -1,14 +1,16 @@
 (ns day8.re-frame2-xray.panels.event.icons
-  "Inline SVG glyphs used by the Event lens — small lucide-style icons
-  per the Figma authority (`tools/xray/design-reference/xray_devtools_reference.cljs`).
+  "Inline SVG glyphs — small lucide-style icons per the Figma authority
+  (`tools/xray/design-reference/xray_devtools_reference.cljs`). Surviving
+  utility re-exported from `panels.epoch.icons` (the Epoch panel
+  superseded the original Event panel under rf2-5gl5r; the glyph set
+  travelled with the rename).
 
-  These exist as a shared, single-source-of-truth helper so every
-  click-to-source affordance in the Event lens renders the SAME glyph at
-  the SAME size with the SAME stroke + fill convention. Pre-rf2-xw7mj
-  the Event lens rendered the unicode `↗` arrow as the trailing
-  affordance; per the Figma authority the canonical glyph is the
-  lucide-style `external-link` SVG (open window with an outbound arrow)
-  — visually richer and more recognisably an 'open in editor' verb.
+  Shared, single-source-of-truth helper so every click-to-source
+  affordance renders the SAME glyph at the SAME size with the SAME
+  stroke + fill convention. The canonical glyph is the lucide-style
+  `external-link` SVG (open window with an outbound arrow) — visually
+  richer and more recognisably an 'open in editor' verb than the
+  unicode `↗` arrow.
 
   Pure data → hiccup (a static svg vector); no substrate dependency.
   `.cljc` so the rendered tree is JVM-portable (the event-detail panel
@@ -37,10 +39,10 @@
 
 (defn external-link
   "Render the lucide `external-link` glyph — the canonical 'open in
-  editor / open in new tab' verb on click-to-source affordances in the
-  Event lens. Inherits its colour from the enclosing link via
-  `currentColor` so the glyph reads as part of the link, not as
-  separate chrome. Always returns the same static hiccup vector — the
-  fn-form is preserved so call sites read as a component."
+  editor / open in new tab' verb on click-to-source affordances.
+  Inherits its colour from the enclosing link via `currentColor` so
+  the glyph reads as part of the link, not as separate chrome. Always
+  returns the same static hiccup vector — the fn-form is preserved so
+  call sites read as a component."
   []
   external-link-svg)

--- a/tools/xray/src/day8/re_frame2_xray/panels/issues_ribbon.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/issues_ribbon.cljs
@@ -27,8 +27,8 @@
   and the timestamp is mono + RIGHT-aligned. The trailing `↗` opens
   the responsible handler at `file:line`.
 
-  Click a row → flips the visible tab to Event so the user pivots to
-  the Event panel for the cascade that produced the issue. Click the
+  Click a row → flips the visible tab to Epoch so the user pivots to
+  the Epoch panel for the cascade that produced the issue. Click the
   `↗` source affordance → the editor opens at that line (via the
   `:rf.xray/open-in-editor` event — the actual editor jump rides on
   the open-in-editor module).
@@ -184,7 +184,7 @@
   "Reference footer hint (rf2-tha26 ·
   `design-reference/xray_devtools_reference.cljs`, the `issues-panel`
   component). Spells out the row's
-  two affordances — click the row pivots to the Event panel (the
+  two affordances — click the row pivots to the Epoch panel (the
   cascade that produced the issue); click `↗` opens the responsible
   handler at `file:line`. Rendered below the feed (feed branch only) so
   it shares the focused-epoch lens with the rows it describes."

--- a/tools/xray/src/day8/re_frame2_xray/shell.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/shell.cljs
@@ -202,7 +202,7 @@
   rf2-cmtkw — one-line minimal rows. The full event vector (args +
   payload) and all dropped fields (datetime, sequence number, duration
   tier, source coordinates) move to the row's hover tooltip + the
-  Event tab detail (which has plenty of room).
+  Epoch panel detail (which has plenty of room).
 
   - `event-id` is the first element of the event vector.
   - Renders in the mode `accent` colour so it pops out of the row.
@@ -224,7 +224,7 @@
   minimal one-line row surfaces only `event-id + ⚠/🌐/🤖`; the
   dropped fields (full event vector, sequence number, frame, source
   coordinates, handler duration) appear in this tooltip + in the
-  Event tab detail panel on row click.
+  Epoch panel detail on row click.
 
   Pure data — JVM-runnable. nil-safe per cascade slot. Returns a
   newline-joined string suitable for an HTML `:title` attribute.
@@ -627,7 +627,7 @@
   `:time`), returns an absolute-time tooltip string for the chip's
   `:title` attribute. Used as the power-user reveal that complements
   the `HH:MM:SS.mmm` clock column — clicking the row still opens the
-  Event lens, but a hover shows the full ISO walltime + epoch-ms.
+  Epoch panel, but a hover shows the full ISO walltime + epoch-ms.
 
   Returns the empty string when `then-ms` is nil so the caller can
   decide whether to attach the tooltip."
@@ -1315,7 +1315,7 @@
       :event-id   source   timestamp   duration
 
   - **`:event-id`** — the bare event-id keyword (not the full event
-    vector). Args / payload move to the tooltip + Event tab detail.
+    vector). Args / payload move to the tooltip + Epoch panel detail.
   - **`source`** — the dispatch-origin tag (`ui` / `fx` / `timer` / …).
   - **`timestamp`** — the absolute wall-clock `HH:MM:SS.mmm`.
   - **`duration`** — the handler wall-time (`1.2 ms`).
@@ -1330,7 +1330,7 @@
   The row's `:title` attribute carries the dropped fields (full event
   vector with args, sequence number, frame, source coord, handler
   duration) so a hover surfaces them without leaving L2. Clicking the
-  row opens the Event tab in L4 with the full untruncated content.
+  row opens the Epoch panel in L4 with the full untruncated content.
 
   Right-click (`on-context-menu`) lowers per spec/018 §7 'Right-click
   event-row → context menu' into `:rf.xray/open-row-context-menu`
@@ -1452,7 +1452,7 @@
                   ;; rf2-cmtkw — dropped fields (full event vector with
                   ;; args, sequence number, frame, source coord, handler
                   ;; duration) surface in this hover tooltip + the L4
-                  ;; Event tab on click.
+                  ;; Epoch panel on click.
                   :title (row-tooltip-text cascade)
                   :style {:display       "flex"
                           :align-items   "center"
@@ -1490,7 +1490,7 @@
      ;; focus feature. The bare event-id keyword leads the row as the
      ;; primary read; the source tag follows as secondary context. The
      ;; full event vector with args moves to the row's hover tooltip + the
-     ;; L4 Event tab detail. The event-id column is LEFT-aligned (Figma
+     ;; L4 Epoch panel detail. The event-id column is LEFT-aligned (Figma
      ;; `text-left`) so the keyword sits flush under the header's
      ;; `event id` label.
      [:span {:data-testid "rf-xray-row-event-id"

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_widget/widget.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_widget/widget.cljs
@@ -76,16 +76,11 @@
 
 ;; ---- universal copy-to-clipboard affordance (rf2-f026h) ------------------
 ;;
-;; re-frame-10x makes every value copyable. Pre-f026h the only copy
-;; gesture in Xray lived on the App-DB diff panel's section headers
-;; (the now-deleted structural-diff renderer →
-;; `:rf.xray/copy-{path,value}-to-clipboard`);
-;; the Event lens, Trace, segment-inspector, and the Static panels —
-;; 7 of 8 EDN surfaces — had none. Rather than thread a copy button
-;; into each panel, the affordance rides on the WIDGET ROOT so it
-;; lands on every `browse` (and therefore `inspect`) call — Trace's
-;; `edn/browse`, the segment-inspector + Event lens + Static panels'
-;; `edn/inspect`, all at once.
+;; re-frame-10x makes every value copyable. Rather than thread a copy
+;; button into each panel, the affordance rides on the WIDGET ROOT so
+;; it lands on every `browse` (and therefore `inspect`) call — Trace's
+;; `edn/browse`, the segment-inspector + Static panels' `edn/inspect`,
+;; all at once.
 ;;
 ;; The `:rf.xray/copy-value-to-clipboard` event + the
 ;; `:rf.xray.fx/copy-to-clipboard` fx are registered process-globally


### PR DESCRIPTION
## Cluster T2 — comment-residue sweep across `implementation/` + `tools/xray/`

Smallest-cleanup → biggest-fix, comment-only edits. No source-behaviour changes.

| # | bead | P | what shipped |
|---|---|---|---|
| 1 | rf2-15hy1 | P4 | adapters/reagent set-hiccup-emitter! docstring converged with the slim sibling (names the late-bind hook + IMPL-SPEC §2.1) |
| 2 | rf2-3g07l | P4 | machines/lifecycle_fx ns docstrings trimmed of extraction-pedigree tags (`(rf2-X)` first-line annotations, Pre-rf2-X extraction narratives, the rf2-lha2t teardown-pedigree references in destroy + finalize) |
| 3 | rf2-47i0w | P4 | Pre-rf2-X historical-state notes flipped to prescriptive (or dropped) across `core/substrate/spine.cljs`, `core/router.cljc`, `core/core_artefact.cljc`, `core/events.cljc`, `core/frame.cljc`, `core/fx.cljc`, `core/late_bind/directory.cljc`, `core/performance.cljc`, `core/subs/cache.cljc`, plus the listed routing-test + ssr-ring-test instances |
| 4 | rf2-8qovj | P4 | refactor-bead residue dropped from section headers in `epoch.cljc` (3 section markers), `core.cljc` (macro-carveout block), `core/router.cljc` (Phase-2 seam R-B), `http/http_transport.cljc` (extraction + collapse pedigree) |
| 5 | rf2-a3aii | P4 | Pre-rf2-XXXXX historical framing flipped to prescriptive across `ssr/hash.cljc` (3 sites), `ssr/payload_policy.cljc` (1 site), `ssr-ring/ring.clj` (1 site), `ssr-ring/ring/pipeline.clj` (3 sites) |
| 6 | rf2-lttyq | P4 | `core/views.cljs` consolidated: one ns-level statement names rf2-9hoos as the source bead for the view-deref-sink + first-render? machinery; per-block rf2-9hoos repeats dropped from the four section headers + four docstrings (the rf2-vh1k3 distinction kept) |
| 7 | rf2-qfjc9 | P4 | `Per Spec N §X (rf2-Y)` duplicate citations collapsed in `core/core.cljc` (8 sites), `routing/registry.cljc` + `routing/events.cljc` (3 sites), `schemas/validate.cljc` + `schemas/validator.cljc` (3 sites) |
| 8 | rf2-0z8m0 | P4 | audit rf2-asmj1 attributions trimmed across ssr (`hydrate.cljc`, `error_listener.cljc`, `head.cljc`, `head/registry.cljc`, `head/emit.cljc`, `html_helpers.cljc`) + ssr-ring (`ring.clj`, `ring/lifecycle.clj`, `ring/cookie.clj`, `ring/headers.clj`); also dropped the rf2-ra1he §P0 #3 pedigree from `machines/lifecycle_fx/teardown.cljc` |
| 9 | rf2-am8nh | P3 | tools/xray: Event-panel retirement references rewritten or dropped across `panels/epoch_panel.cljs`, `panels/app_db_diff.cljs`, `panels/app_db_diff_state.cljs`, `panels/app_db_diff_helpers.cljc`, `shell.cljs` (5 sites), `views/edn_widget/widget.cljs`, `panels/event/icons.cljc`, `panels/epoch/icons.cljc`, `panels/issues_ribbon.cljs` (2 comment sites). One UI-text site (`issues_ribbon.cljs:199` footer-hint string) was out of scope for the comment-only sweep — filed as **rf2-rtyd9** |
| 10 | rf2-1284r | P3 | `ssr/error_listener.cljc` `get-response`/`flush-response!`/`peek-response` docstrings rewritten to remove the stale 'back-compat alias' claim and clarify each fn's role (pure read / explicit-side-effect / canonical host-adapter alias) |

## Gates

- `npm run test:cljs` — **4836 tests / 15807 assertions / 0F / 0E**
- `cd tools/xray && clojure -M:test` — **952 tests / 3709 assertions / 0F / 0E**
- `bash scripts/test-fast-pr.sh` — **PASS fast PR spine**
- `git grep 'Pre-rf2-' implementation/*/src tools/*/src` reduced from ~30+ to **29** remaining (the kept ones are in non-targeted artefacts: epoch/capture, epoch/state, flows/registry, machines-viz, story, pair-mcp, xray panels — outside this bead cluster's surface)

## Follow-ups filed

- **rf2-rtyd9** — issues-ribbon footer-hint UI text references retired Event panel (UI text, not a comment; out of scope for this sweep)