### PR TITLE
refactor(framework-misc): polish sweep — 8 beads (4gvb4 + 740nl + obok3 + 91b57 + ti6w3 + 9a2ui + vo005 + byvp3)

### DIFF
--- a/implementation/adapters/README.md
+++ b/implementation/adapters/README.md
@@ -61,6 +61,17 @@ adapters/
 
 All five depend on `day8/re-frame2 {:local/root "../../core"}`. None depend on each other.
 
+## Where the substrate logic lives
+
+The four React-shaped adapters (Reagent, reagent-slim, UIx, Helix) are extremely thin (~100-130 lines each) because they all delegate into [`re-frame.substrate.spine`](../core/src/re_frame/substrate/spine.cljs) in the core artefact. Two factory families:
+
+- **Ratom family** — [`make-ratom-spine`](../core/src/re_frame/substrate/spine.cljs) + [`make-ratom-adapter`](../core/src/re_frame/substrate/spine.cljs) (Reagent + reagent-slim).
+- **React-hook family** — [`make-react-spine`](../core/src/re_frame/substrate/spine.cljs) + [`make-react-adapter`](../core/src/re_frame/substrate/spine.cljs) (UIx + Helix).
+
+Each adapter file builds a config map and hands it to the appropriate factory pair. The spine carries the epoch scheduler (glitch-freedom), the container quartet, `useSyncExternalStore` hooks, source-coord wrapping, the after-render sentinel, the unmount sentinel, and the nine-/five-hook routed late-bind tables. Reading the spine ns is the fastest path to understanding how the adapters work end-to-end.
+
+The test-react adapter is its own quadrant — pure CLJC, no React, shares only the atom-container quartet with plain-atom.
+
 ## Per-feature artefacts vs adapters
 
 Per-feature artefacts (`schemas/`, `machines/`, `routing/`, `flows/`, `http/`, `ssr/`, `epoch/`) sit at `implementation/<name>/` — they extend re-frame2's core capabilities. Adapters here implement the substrate contract for a specific reactive layer. The two tiers are independent: a consumer mixes one adapter with any subset of per-feature artefacts.

--- a/implementation/adapters/test-react/src/re_frame/adapter/test_react.cljc
+++ b/implementation/adapters/test-react/src/re_frame/adapter/test_react.cljc
@@ -256,6 +256,18 @@
 ;; substrate-adapter contract — they are test-driver utilities scoped to
 ;; this adapter. Other adapters expose nothing analogous (real React drives
 ;; the lifecycle from JS-side; here the test owns the clock).
+;;
+;; ---- two entry points: substrate :render vs public mount! ----
+;;
+;; The substrate contract's :render fn (above, registered in `adapter`)
+;; returns an unmount thunk and nothing else. Test code typically wants
+;; the lifecycle log + the mount record, so this adapter exposes `mount!`
+;; as the public driver. Both call the internal `mount-tree!` helper;
+;; the substrate :render discards the record and returns just the thunk,
+;; while `mount!` returns the whole `MountedComponent` record (whose
+;; `:unmount-fn` is the same thunk). Tests should reach for `mount!`,
+;; not `(substrate-adapter/render …)`, because they want the record's
+;; `:lifecycle-log` for assertions.
 
 (defn mount!
   "Mount `render-tree` (a hiccup vector or any data the test treats as the

--- a/implementation/core/src/re_frame/test_support.cljc
+++ b/implementation/core/src/re_frame/test_support.cljc
@@ -246,10 +246,11 @@
     1. Captures the current registrar (so user-test registrations can be
        rolled back without losing ns-load-time framework / example
        registrations).
-    2. Resets `frame/frames` to `{}`, plus `flows/flows` and
-       `schemas/schemas-by-frame` (when those artefacts are loaded —
-       reset is late-bound so JVM tests that don't pull them in are
-       unaffected).
+    2. Resets `frame/frames` to `{}`, plus the flows registry (via
+       `flows/reset-flows!` per rf2-4gvb4 — atoms are private behind
+       an accessor seam) and `schemas/schemas-by-frame` (when those
+       artefacts are loaded — reset is late-bound so JVM tests that
+       don't pull them in are unaffected).
     3. Disposes the currently-installed substrate adapter.
     4. Cancels the machines' in-flight `:after` wall-clock timers.
     5. Clears trace listeners and adapter warn-once caches
@@ -265,7 +266,9 @@
     8. Runs the test.
     9. Restores the registrar to the captured snapshot.
    10. Resets `frame/frames` back to `{}` for symmetry, and (when their
-       artefacts are loaded) `flows/flows` and `schemas/schemas-by-frame`.
+       artefacts are loaded) the flows registry (via the
+       `:flows/reset-flows!` late-bind hook) and
+       `schemas/schemas-by-frame`.
 
   Steps 9–10 run in a `finally` block so they fire even on test
   exceptions.

--- a/implementation/core/test/re_frame/boot_test.clj
+++ b/implementation/core/test/re_frame/boot_test.clj
@@ -36,7 +36,7 @@
 (defn cold-start [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   ;; Wipe both the install slot AND the disposed breadcrumb so each test
   ;; starts from a never-installed cold state (rf2-6wxys). A plain
@@ -52,7 +52,7 @@
   (adapter/reset-lifecycle-state-for-tests!)
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {}))
+  (flows/reset-flows!))
 
 (use-fixtures :each cold-start)
 

--- a/implementation/core/test/re_frame/cascade_dispatch_id_test.clj
+++ b/implementation/core/test/re_frame/cascade_dispatch_id_test.clj
@@ -37,7 +37,7 @@
 (defn reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (trace/clear-listeners!)
   (rf/init! plain-atom/adapter)

--- a/implementation/core/test/re_frame/cascade_envelope_propagation_test.clj
+++ b/implementation/core/test/re_frame/cascade_envelope_propagation_test.clj
@@ -30,7 +30,7 @@
 (defn reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (trace/clear-listeners!)
   (rf/init! plain-atom/adapter)

--- a/implementation/core/test/re_frame/cofx_test.clj
+++ b/implementation/core/test/re_frame/cofx_test.clj
@@ -23,7 +23,7 @@
 (defn- reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
   ;; Framework registrations live at namespace-load time; clear-all!

--- a/implementation/core/test/re_frame/concurrency_stress_test.clj
+++ b/implementation/core/test/re_frame/concurrency_stress_test.clj
@@ -51,7 +51,7 @@
 (defn- reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (trace/clear-listeners!)
   (rf/init! plain-atom/adapter)

--- a/implementation/core/test/re_frame/configure_test.clj
+++ b/implementation/core/test/re_frame/configure_test.clj
@@ -38,7 +38,7 @@
 (defn reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (trace/clear-listeners!)
   (trace-tooling/clear-trace-rings!)

--- a/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
+++ b/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
@@ -257,7 +257,7 @@
   (registrar/clear-kind! :route)
   ;; 2. Clear per-process state held outside the registrar.
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   ;; 3. Reset id-allocators so the routing / machine fixtures see
   ;;    deterministic counters.

--- a/implementation/core/test/re_frame/conformance_test.clj
+++ b/implementation/core/test/re_frame/conformance_test.clj
@@ -219,7 +219,7 @@
 (defn- reset-runtime! []
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   ;; rf2-wxe9t — drop every corpus-wide error-emit listener so a
   ;; listener installed by `collect-error-emit-records!` for one

--- a/implementation/core/test/re_frame/core_api_additions_test.clj
+++ b/implementation/core/test/re_frame/core_api_additions_test.clj
@@ -24,10 +24,9 @@
 (defn reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
-  (when-let [li-var (resolve 're-frame.flows/last-inputs)]
-    (reset! (deref li-var) {}))
+  (flows/reset-last-inputs!)
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr :reload)

--- a/implementation/core/test/re_frame/drain_test.clj
+++ b/implementation/core/test/re_frame/drain_test.clj
@@ -18,7 +18,7 @@
 (defn- reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)

--- a/implementation/core/test/re_frame/elision_test.clj
+++ b/implementation/core/test/re_frame/elision_test.clj
@@ -13,7 +13,7 @@
 (defn- reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (trace/clear-listeners!)
   (elision/clear-warning-cache!)

--- a/implementation/core/test/re_frame/event_emit_test.cljc
+++ b/implementation/core/test/re_frame/event_emit_test.cljc
@@ -33,7 +33,7 @@
   (registrar/clear-all!)
   (reset! frame/frames {})
   (reset! schemas/schemas-by-frame {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (trace/clear-listeners!)
   (event-emit/clear-event-listeners!)
   (rf/init! plain-atom/adapter)

--- a/implementation/core/test/re_frame/examples_test.clj
+++ b/implementation/core/test/re_frame/examples_test.clj
@@ -23,7 +23,7 @@
 (defn- reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
   ;; clear-all! also drops the framework-shipped fxs that register at

--- a/implementation/core/test/re_frame/frame_destroy_composed_test.clj
+++ b/implementation/core/test/re_frame/frame_destroy_composed_test.clj
@@ -26,6 +26,7 @@
             [re-frame.epoch :as epoch]
             [re-frame.epoch.state :as epoch-state]
             [re-frame.flows :as flows]
+            [re-frame.flows.registry :as flows-registry]
             [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
@@ -45,8 +46,8 @@
 (defn reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
-  (reset! flows/last-inputs {})
+  (flows/reset-flows!)
+  (flows/reset-last-inputs!)
   (reset! schemas/schemas-by-frame {})
   (trace/clear-listeners!)
   (epoch/clear-history!)
@@ -358,10 +359,10 @@
     ;; swap pins the post-condition contract this test cares about
     ;; (the destroy-frame! teardown clears the row) without depending
     ;; on the flow walker firing during this specific dispatch.
-    (swap! flows/last-inputs assoc-in [:composed/area :composed/leak-audit] [3 4])
-    (is (contains? @flows/flows :composed/leak-audit)
+    (flows-registry/swap-last-inputs! assoc-in [:composed/area :composed/leak-audit] [3 4])
+    (is (contains? (flows/flows-snapshot) :composed/leak-audit)
         "precondition: flow registry has a row for the frame")
-    (is (= [3 4] (get-in @flows/last-inputs [:composed/area :composed/leak-audit]))
+    (is (= [3 4] (get-in (flows/last-inputs-snapshot) [:composed/area :composed/leak-audit]))
         "precondition: flow last-inputs has a row for the frame")
 
     (let [observed @(deref #'epoch-state/observed-frames-by-cb)]
@@ -393,9 +394,9 @@
         "post: frame is unregistered from the registrar")
     (is (not (contains? @schemas/schemas-by-frame :composed/leak-audit))
         "post: schema row dropped (per rf2-wkxng / rf2-6m0se)")
-    (is (not (contains? @flows/flows :composed/leak-audit))
+    (is (not (contains? (flows/flows-snapshot) :composed/leak-audit))
         "post: flow registry slot dropped (per rf2-wbtjn)")
-    (is (not (contains? (get @flows/last-inputs :composed/area)
+    (is (not (contains? (get (flows/last-inputs-snapshot) :composed/area)
                         :composed/leak-audit))
         "post: flow last-inputs row dropped for the destroyed frame")
     (is (= [] (rf/epoch-history :composed/leak-audit))

--- a/implementation/core/test/re_frame/frame_lifecycle_test.clj
+++ b/implementation/core/test/re_frame/frame_lifecycle_test.clj
@@ -19,7 +19,7 @@
 (defn reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (trace/clear-listeners!)
   (rf/init! plain-atom/adapter)

--- a/implementation/core/test/re_frame/fx_test.clj
+++ b/implementation/core/test/re_frame/fx_test.clj
@@ -28,7 +28,7 @@
 (defn- reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
   ;; Framework registrations live at namespace-load time; clear-all!

--- a/implementation/core/test/re_frame/hot_reload_test.clj
+++ b/implementation/core/test/re_frame/hot_reload_test.clj
@@ -30,7 +30,7 @@
 (defn reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
   ;; Framework events / fx are registered at namespace-load time in

--- a/implementation/core/test/re_frame/init_platform_test.clj
+++ b/implementation/core/test/re_frame/init_platform_test.clj
@@ -28,7 +28,7 @@
 (defn- reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
   ;; Per-test JVM default — explicitly :server so a sibling test that

--- a/implementation/core/test/re_frame/interceptor_overrides_test.clj
+++ b/implementation/core/test/re_frame/interceptor_overrides_test.clj
@@ -31,7 +31,7 @@
 (defn reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (trace/clear-listeners!)
   (rf/init! plain-atom/adapter)

--- a/implementation/core/test/re_frame/interceptor_test.clj
+++ b/implementation/core/test/re_frame/interceptor_test.clj
@@ -26,7 +26,7 @@
 (defn reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
   ;; Framework-shipped registrations live in routing.cljc / ssr.cljc /

--- a/implementation/core/test/re_frame/marks_test.clj
+++ b/implementation/core/test/re_frame/marks_test.clj
@@ -23,7 +23,7 @@
 (defn- reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (trace-tooling/clear-listeners!)
   (marks/clear-marks!)

--- a/implementation/core/test/re_frame/pattern_smoke_test.clj
+++ b/implementation/core/test/re_frame/pattern_smoke_test.clj
@@ -21,7 +21,7 @@
 (defn- reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
   (test-fn))

--- a/implementation/core/test/re_frame/reg_view_test.clj
+++ b/implementation/core/test/re_frame/reg_view_test.clj
@@ -20,10 +20,9 @@
 (defn reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
-  (when-let [li-var (resolve 're-frame.flows/last-inputs)]
-    (reset! (deref li-var) {}))
+  (flows/reset-last-inputs!)
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr :reload)

--- a/implementation/core/test/re_frame/router_drain_race_test.clj
+++ b/implementation/core/test/re_frame/router_drain_race_test.clj
@@ -23,7 +23,7 @@
 (defn- reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)

--- a/implementation/core/test/re_frame/smoke_test.clj
+++ b/implementation/core/test/re_frame/smoke_test.clj
@@ -19,7 +19,7 @@
 (defn reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   ;; flows.cljc keeps a private last-inputs atom for dirty-checking
   ;; (per Spec 013 §Dirty-check semantics). Without resetting it, an
@@ -27,8 +27,7 @@
   ;; flow registration and cause its first evaluation to no-op (the
   ;; new-inputs would =-equal the stale last-inputs). Clear it here so
   ;; cross-test order can't introduce hidden flakiness. See rf2-xsfj.
-  (when-let [li-var (resolve 're-frame.flows/last-inputs)]
-    (reset! (deref li-var) {}))
+  (flows/reset-last-inputs!)
   (rf/init! plain-atom/adapter)
   ;; Framework events / fx / subs are registered at namespace-load time
   ;; in routing.cljc, ssr.cljc, and machines.cljc; clear-all! wiped them.

--- a/implementation/core/test/re_frame/source_coord_test.cljc
+++ b/implementation/core/test/re_frame/source_coord_test.cljc
@@ -35,7 +35,7 @@
 (defn reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (trace/clear-listeners!)
   (rf/init! plain-atom/adapter)

--- a/implementation/core/test/re_frame/source_coords_test.clj
+++ b/implementation/core/test/re_frame/source_coords_test.clj
@@ -39,10 +39,9 @@
 (defn reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
-  (when-let [li-var (resolve 're-frame.flows/last-inputs)]
-    (reset! (deref li-var) {}))
+  (flows/reset-last-inputs!)
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr :reload)

--- a/implementation/core/test/re_frame/sub_cache_concurrency_test.clj
+++ b/implementation/core/test/re_frame/sub_cache_concurrency_test.clj
@@ -49,7 +49,7 @@
 (defn- reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)

--- a/implementation/core/test/re_frame/sub_cache_test.clj
+++ b/implementation/core/test/re_frame/sub_cache_test.clj
@@ -23,7 +23,7 @@
 (defn reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)

--- a/implementation/core/test/re_frame/sub_dispose_trace_test.clj
+++ b/implementation/core/test/re_frame/sub_dispose_trace_test.clj
@@ -38,7 +38,7 @@
 (defn- reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)

--- a/implementation/core/test/re_frame/sub_memo_layer_1_test.clj
+++ b/implementation/core/test/re_frame/sub_memo_layer_1_test.clj
@@ -28,7 +28,7 @@
 (defn reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)

--- a/implementation/core/test/re_frame/sub_memo_layer_n_1_test.clj
+++ b/implementation/core/test/re_frame/sub_memo_layer_n_1_test.clj
@@ -30,7 +30,7 @@
 (defn reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)

--- a/implementation/core/test/re_frame/sub_topology_test.clj
+++ b/implementation/core/test/re_frame/sub_topology_test.clj
@@ -26,7 +26,7 @@
 (defn reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)

--- a/implementation/core/test/re_frame/substrate_source_test.clj
+++ b/implementation/core/test/re_frame/substrate_source_test.clj
@@ -34,7 +34,7 @@
 (defn reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (trace/clear-listeners!)
   (rf/init! plain-atom/adapter)

--- a/implementation/core/test/re_frame/success_path_call_site_test.clj
+++ b/implementation/core/test/re_frame/success_path_call_site_test.clj
@@ -38,7 +38,7 @@
 (defn reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (trace/clear-listeners!)
   (rf/init! plain-atom/adapter)

--- a/implementation/core/test/re_frame/success_path_trigger_handler_test.clj
+++ b/implementation/core/test/re_frame/success_path_trigger_handler_test.clj
@@ -40,7 +40,7 @@
 (defn reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (trace/clear-listeners!)
   (rf/init! plain-atom/adapter)

--- a/implementation/core/test/re_frame/test_support_test.clj
+++ b/implementation/core/test/re_frame/test_support_test.clj
@@ -32,7 +32,7 @@
 (defn- reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (trace/clear-listeners!)
   (rf/init! plain-atom/adapter)
@@ -203,10 +203,10 @@
   `:flows/reset-flows!` is the documented exception: it fires twice —
   once mid-body (via `:pre-dispose`) and once in the `finally` block,
   per the fixture docstring step 10 (\"Resets `frame/frames` back to
-  `{}` for symmetry, and (when their artefacts are loaded)
-  `flows/flows` and `schemas/schemas-by-frame`\"). The two-fire shape
-  is load-bearing — symmetric pre-test and post-test reset so a
-  failing test leaves no residue for the next. Pin the count here so a
+  `{}` for symmetry, and (when their artefacts are loaded) the flows
+  registry and `schemas/schemas-by-frame`\"). The two-fire shape is
+  load-bearing — symmetric pre-test and post-test reset so a failing
+  test leaves no residue for the next. Pin the count here so a
   refactor that drops EITHER call site (or unifies them into one) is
   surfaced as a regression."
   {:flows/reset-flows!              2  ;; pre + finally (symmetry)

--- a/implementation/core/test/re_frame/trace_buffer_test.clj
+++ b/implementation/core/test/re_frame/trace_buffer_test.clj
@@ -26,7 +26,7 @@
 (defn reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (trace/clear-listeners!)
   (trace-tooling/clear-trace-rings!)

--- a/implementation/core/test/re_frame/trace_cascade_captured_test.clj
+++ b/implementation/core/test/re_frame/trace_cascade_captured_test.clj
@@ -29,7 +29,7 @@
 (defn reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)

--- a/implementation/core/test/re_frame/trace_listener_test.clj
+++ b/implementation/core/test/re_frame/trace_listener_test.clj
@@ -45,7 +45,7 @@
 (defn reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (trace/clear-listeners!)
   (re-frame.trace.tooling/clear-trace-rings!)

--- a/implementation/core/test/re_frame/trace_test.clj
+++ b/implementation/core/test/re_frame/trace_test.clj
@@ -46,7 +46,7 @@
 (defn reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (trace/clear-listeners!)
   (rf/init! plain-atom/adapter)

--- a/implementation/core/test/re_frame/trigger_handler_coord_test.clj
+++ b/implementation/core/test/re_frame/trigger_handler_coord_test.clj
@@ -41,7 +41,7 @@
 (defn reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (trace/clear-listeners!)
   (rf/init! plain-atom/adapter)

--- a/implementation/epoch/test/re_frame/epoch_attribution_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_attribution_test.clj
@@ -98,10 +98,9 @@
 (defn- reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
-  (when-let [li-var (resolve 're-frame.flows/last-inputs)]
-    (reset! (deref li-var) {}))
+  (flows/reset-last-inputs!)
   (trace/clear-listeners!)
   (epoch/clear-history!)
   (epoch/clear-epoch-listeners!)

--- a/implementation/epoch/test/re_frame/epoch_concurrency_stress_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_concurrency_stress_test.clj
@@ -136,10 +136,9 @@
 (defn- reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
-  (when-let [li-var (resolve 're-frame.flows/last-inputs)]
-    (reset! (deref li-var) {}))
+  (flows/reset-last-inputs!)
   (trace/clear-listeners!)
   (epoch/clear-history!)
   (epoch/clear-epoch-listeners!)

--- a/implementation/epoch/test/re_frame/epoch_jvm_prod_gate_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_jvm_prod_gate_test.clj
@@ -30,10 +30,9 @@
 (defn- reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
-  (when-let [li-var (resolve 're-frame.flows/last-inputs)]
-    (reset! (deref li-var) {}))
+  (flows/reset-last-inputs!)
   (trace/clear-listeners!)
   (epoch/clear-history!)
   (epoch/clear-epoch-listeners!)

--- a/implementation/epoch/test/re_frame/epoch_mcp_egress_conformance_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_mcp_egress_conformance_test.clj
@@ -73,10 +73,9 @@
 (defn- reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
-  (when-let [li-var (resolve 're-frame.flows/last-inputs)]
-    (reset! (deref li-var) {}))
+  (flows/reset-last-inputs!)
   (trace/clear-listeners!)
   (epoch/clear-history!)
   (epoch/clear-epoch-listeners!)

--- a/implementation/epoch/test/re_frame/epoch_privacy_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_privacy_test.clj
@@ -44,10 +44,9 @@
 (defn- reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
-  (when-let [li-var (resolve 're-frame.flows/last-inputs)]
-    (reset! (deref li-var) {}))
+  (flows/reset-last-inputs!)
   (trace/clear-listeners!)
   (epoch/clear-history!)
   (epoch/clear-epoch-listeners!)

--- a/implementation/epoch/test/re_frame/epoch_redact_fn_projection_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_redact_fn_projection_test.clj
@@ -75,10 +75,9 @@
 (defn- reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
-  (when-let [li-var (resolve 're-frame.flows/last-inputs)]
-    (reset! (deref li-var) {}))
+  (flows/reset-last-inputs!)
   (trace/clear-listeners!)
   (epoch/clear-history!)
   (epoch/clear-epoch-listeners!)

--- a/implementation/epoch/test/re_frame/epoch_redact_fn_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_redact_fn_test.clj
@@ -49,10 +49,9 @@
 (defn- reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
-  (when-let [li-var (resolve 're-frame.flows/last-inputs)]
-    (reset! (deref li-var) {}))
+  (flows/reset-last-inputs!)
   (trace/clear-listeners!)
   (epoch/clear-history!)
   (epoch/clear-epoch-listeners!)

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -54,14 +54,13 @@
 (defn- reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   ;; Per smoke_test.clj fixture (rf2-xsfj): flows.cljc keeps a private
   ;; last-inputs atom for dirty-checking. Clear it so a prior test's
   ;; flow registration can't leak its last-inputs into a same-keyed
   ;; flow in a subsequent test.
-  (when-let [li-var (resolve 're-frame.flows/last-inputs)]
-    (reset! (deref li-var) {}))
+  (flows/reset-last-inputs!)
   (trace/clear-listeners!)
   (epoch/clear-history!)
   (epoch/clear-epoch-listeners!)

--- a/implementation/flows/src/re_frame/flows.cljc
+++ b/implementation/flows/src/re_frame/flows.cljc
@@ -33,17 +33,15 @@
 
 ;; ---- public-surface re-exports -------------------------------------------
 ;;
-;; Atoms re-exported as Vars so test fixtures across artefacts
-;; (`flows_test.clj`, `flows_trace_test.clj`, `smoke_test.clj`,
-;; `epoch_test.clj`, `core_api_additions_test.clj`, `reg_view_test.clj`,
-;; `source_coords_test.clj`, `ssr/test_fixture.clj`) keep working
-;; against the SAME atom value at `re-frame.flows/flows` and
-;; `re-frame.flows/last-inputs`. Several tests reach `last-inputs`
-;; via `(resolve 're-frame.flows/last-inputs)`; that resolve must
-;; continue to land on a var deref-equal to the registry's atom.
+;; Per rf2-4gvb4 — the registry atoms are private. External consumers
+;; (test fixtures, conformance harnesses, cross-artefact integration tests)
+;; reach the registry shape through the read accessors
+;; (`flows-snapshot` / `last-inputs-snapshot`) and the existing reset fns
+;; (`reset-flows!` / `reset-last-inputs!`). The facade re-exports both
+;; pairs.
 
-(def flows       registry/flows)
-(def last-inputs registry/last-inputs)
+(def flows-snapshot       registry/flows-snapshot)
+(def last-inputs-snapshot registry/last-inputs-snapshot)
 
 (def reg-flow           registry/reg-flow)
 (def clear-flow         registry/clear-flow)
@@ -154,7 +152,7 @@
         ;; hot-reload invalidation hook can drop a flow's whole row
         ;; with one O(1) dissoc (rf2-2xq8w / PERF Q10). Per-frame
         ;; dirty-check windows stay independent.
-        old-inputs (get-in @last-inputs [flow-id frame-id])]
+        old-inputs (get-in (registry/last-inputs-snapshot) [flow-id frame-id])]
     (if (= new-inputs old-inputs)
       (do
         ;; Per Spec 009 §:op-type vocabulary: `:rf.flow/skip` records a
@@ -201,7 +199,7 @@
               old-output (when interop/debug-enabled?
                            (get-in db (:path flow)))
               new-db     (assoc-in db (:path flow) new-output)]
-          (swap! last-inputs assoc-in [flow-id frame-id] new-inputs)
+          (registry/swap-last-inputs! assoc-in [flow-id frame-id] new-inputs)
           ;; Per Spec 009 §:op-type vocabulary: `:rf.flow/computed`
           ;; records a successful recompute. The dirty-check is
           ;; `=`-equality so this only fires when inputs actually
@@ -352,7 +350,7 @@
   preserved on the re-thrown ex-info so the router can attribute the
   cascade-level error to the failing flow."
   [frame-id db]
-  (let [flow-map (get @flows frame-id)]
+  (let [flow-map (get (registry/flows-snapshot) frame-id)]
     (if-not (seq flow-map)
       db
       (let [ordered (topo/topo-sort flow-map)
@@ -360,7 +358,7 @@
             ;; roll it back wholesale — the event aborts, so prior flows'
             ;; `last-inputs` advances must NOT survive (their outputs were
             ;; never installed). Restored in the catch below.
-            last-inputs-before @last-inputs]
+            last-inputs-before (registry/last-inputs-snapshot)]
         (try
           (loop [remaining  ordered
                  db         db
@@ -377,7 +375,7 @@
             ;; every flow re-attempts next drain. The throw (carrying
             ;; `:rf.flow/failed-id` from `evaluate-flow!`) propagates
             ;; unchanged for router attribution.
-            (reset! last-inputs last-inputs-before)
+            (registry/reset-last-inputs-to! last-inputs-before)
             (throw e)))))))
 
 ;; ---- late-bind hook registration ----------------------------------------

--- a/implementation/flows/src/re_frame/flows/registry.cljc
+++ b/implementation/flows/src/re_frame/flows/registry.cljc
@@ -152,51 +152,59 @@
                     :flow        flow}
                    extras))))
 
+;; The validation rules, in evaluation order. Each rule has a predicate
+;; over the flow map (returns truthy to accept), a stable `:error-kw`
+;; discriminator, a `:reason` diagnostic, and optional `:extras` that
+;; build per-clause ex-data slots (`:bad-entries` / `:bad-elements`).
+;; `validate-flow` walks this vector and throws on the first failing
+;; predicate — matching the original `cond` evaluation order so existing
+;; tests pinning rejection ids see no shift.
+;;
+;; Data-driven so the rules are introspectable (a test or the spec can
+;; read the table) and adding a clause is a single conj.
+(def ^:private validation-rules
+  [{:pred     (fn [flow] (some? (:id flow)))
+    :error-kw :rf.error/flow-missing-id
+    :reason   ":id is required (flow registration must name an id)"}
+
+   {:pred     (fn [flow] (vector? (:inputs flow)))
+    :error-kw :rf.error/flow-bad-inputs
+    :reason   ":inputs must be a vector of paths"}
+
+   ;; One clause for both "entry isn't a vector" and "entry isn't a valid
+   ;; path" — `valid-path?` already requires `vector?`, so the older
+   ;; two-arm split (the prior code carried a separate `(every? vector?
+   ;; ...)` check) was strictly subsumed by this one. The single rejection
+   ;; message names what the entry must be; the `:bad-entries` slot points
+   ;; at the offending values so callers can fix them without a stack-trace
+   ;; dig.
+   {:pred     (fn [flow] (every? valid-path? (:inputs flow)))
+    :error-kw :rf.error/flow-bad-inputs
+    :reason   ":inputs entries must each be a non-empty vector of scalar keys (keyword / string / integer / symbol / boolean)"
+    :extras   (fn [flow] {:bad-entries (vec (remove valid-path? (:inputs flow)))})}
+
+   {:pred     (fn [flow] (fn? (:output flow)))
+    :error-kw :rf.error/flow-bad-output
+    :reason   ":output must be a fn"}
+
+   {:pred     (fn [flow] (vector? (:path flow)))
+    :error-kw :rf.error/flow-bad-path
+    :reason   ":path must be a vector"}
+
+   {:pred     (fn [flow] (seq (:path flow)))
+    :error-kw :rf.error/flow-bad-path
+    :reason   ":path must be non-empty (an empty :path would make this flow a depends-on prerequisite of every other flow per Spec 013 §Dependency rule)"}
+
+   {:pred     (fn [flow] (every? valid-path-element? (:path flow)))
+    :error-kw :rf.error/flow-bad-path
+    :reason   ":path elements must each be a scalar key (keyword / string / integer / symbol / boolean)"
+    :extras   (fn [flow] {:bad-elements (vec (remove valid-path-element? (:path flow)))})}])
+
 (defn- validate-flow [flow]
-  (cond
-    (nil? (:id flow))
-    (throw (flow-error :rf.error/flow-missing-id
-                       ":id is required (flow registration must name an id)"
-                       flow))
-
-    (not (vector? (:inputs flow)))
-    (throw (flow-error :rf.error/flow-bad-inputs
-                       ":inputs must be a vector of paths"
-                       flow))
-
-    ;; One clause for both "entry isn't a vector" and "entry isn't a
-    ;; valid path" — `valid-path?` already requires `vector?`, so the
-    ;; older two-arm split (the prior code carried a separate
-    ;; `(every? vector? ...)` check) was strictly subsumed by this one.
-    ;; The single rejection message names what the entry must be; the
-    ;; `:bad-entries` slot points at the offending values so callers
-    ;; can fix them without a stack-trace dig.
-    (not (every? valid-path? (:inputs flow)))
-    (throw (flow-error :rf.error/flow-bad-inputs
-                       ":inputs entries must each be a non-empty vector of scalar keys (keyword / string / integer / symbol / boolean)"
-                       flow
-                       {:bad-entries (vec (remove valid-path? (:inputs flow)))}))
-
-    (not (fn? (:output flow)))
-    (throw (flow-error :rf.error/flow-bad-output
-                       ":output must be a fn"
-                       flow))
-
-    (not (vector? (:path flow)))
-    (throw (flow-error :rf.error/flow-bad-path
-                       ":path must be a vector"
-                       flow))
-
-    (empty? (:path flow))
-    (throw (flow-error :rf.error/flow-bad-path
-                       ":path must be non-empty (an empty :path would make this flow a depends-on prerequisite of every other flow per Spec 013 §Dependency rule)"
-                       flow))
-
-    (not (every? valid-path-element? (:path flow)))
-    (throw (flow-error :rf.error/flow-bad-path
-                       ":path elements must each be a scalar key (keyword / string / integer / symbol / boolean)"
-                       flow
-                       {:bad-elements (vec (remove valid-path-element? (:path flow)))}))))
+  (some (fn [{:keys [pred error-kw reason extras]}]
+          (when-not (pred flow)
+            (throw (flow-error error-kw reason flow (when extras (extras flow))))))
+        validation-rules))
 
 ;; ---- registration --------------------------------------------------------
 

--- a/implementation/flows/src/re_frame/flows/registry.cljc
+++ b/implementation/flows/src/re_frame/flows/registry.cljc
@@ -10,12 +10,13 @@
   registry shape is `{frame-id {flow-id flow-map}}`.
 
   Per rf2-mnu8z this is the second leg of the flows split. The façade
-  (`re-frame.flows`) re-exports `flows`, `last-inputs`, `reg-flow`,
-  `clear-flow`, `reset-flows!`, `reset-last-inputs!` so external
-  consumers — production code, the late-bind directory, and the test
-  fixtures that `(reset! flows/flows {})` or
-  `(resolve 're-frame.flows/last-inputs)` — continue to reach them at
-  their documented namespace-qualified names."
+  (`re-frame.flows`) re-exports the public surface — `reg-flow`,
+  `clear-flow`, `reset-flows!`, `reset-last-inputs!`, plus the
+  rf2-4gvb4 read accessors `flows-snapshot` / `last-inputs-snapshot`.
+  The underlying atoms themselves are PRIVATE to this artefact: external
+  consumers (production code, the late-bind directory, test fixtures
+  across artefacts) reach the registry state through the accessor seam
+  rather than dereferencing the atom Vars directly."
   (:require [re-frame.flows.topo :as topo]
             [re-frame.frame :as frame]
             [re-frame.interop :as interop]
@@ -26,28 +27,80 @@
             [re-frame.trace :as trace]))
 
 ;; ---- state ---------------------------------------------------------------
+;;
+;; Per rf2-4gvb4 — the two atoms below are PRIVATE to this artefact. External
+;; consumers reach the registry state through the public read accessors
+;; (`flows-snapshot` / `last-inputs-snapshot`) and the reset fns
+;; (`reset-flows!` / `reset-last-inputs!`) — the facade re-exports them at
+;; `re-frame.flows`. The atoms themselves are NOT a public surface; treating
+;; them as one couples consumers to the internal shape (a future move to a
+;; concurrent map, a sharded structure, or a different bookkeeping layout
+;; would force every test fixture to follow). The accessor seam keeps the
+;; flexibility on the framework side while giving tests the read-and-reset
+;; affordances they actually need.
 
 (defonce
-  ^{:doc "frame-id → flow-id → flow-map. Per-frame so undo / time-travel
-          / clear semantics are unambiguous."}
+  ^{:doc     "frame-id → flow-id → flow-map. Per-frame so undo / time-travel
+              / clear semantics are unambiguous."
+    :private true}
   flows
   (atom {}))
 
 (defonce
-  ^{:doc "Per-flow, per-frame last-inputs index: `flow-id → frame-id →
-          last-seen input vec`. Drives the dirty-check skip path in
-          `re-frame.flows/evaluate-flow!` (rf2-719e).
+  ^{:doc     "Per-flow, per-frame last-inputs index: `flow-id → frame-id →
+              last-seen input vec`. Drives the dirty-check skip path in
+              `re-frame.flows/evaluate-flow!` (rf2-719e).
 
-          Shape note: the outer key is `flow-id` (not `[frame-id flow-id]`
-          flat) so the hot-reload invalidation hook (which fires on
-          `:flow` registrar replacement) can drop every per-frame entry
-          for the replaced flow with one `dissoc` — O(1) instead of the
-          prior O(N) walk over all entries. Per-frame slots stay
-          independent (each flow id can register against multiple
-          frames with its own dirty-check window per Spec 013
-          §Frame-scoping)."}
+              Shape note: the outer key is `flow-id` (not `[frame-id flow-id]`
+              flat) so the hot-reload invalidation hook (which fires on
+              `:flow` registrar replacement) can drop every per-frame entry
+              for the replaced flow with one `dissoc` — O(1) instead of the
+              prior O(N) walk over all entries. Per-frame slots stay
+              independent (each flow id can register against multiple
+              frames with its own dirty-check window per Spec 013
+              §Frame-scoping)."
+    :private true}
   last-inputs
   (atom {}))
+
+;; ---- public read accessors (rf2-4gvb4) -----------------------------------
+;;
+;; `flows-snapshot` and `last-inputs-snapshot` are the public seam external
+;; consumers (test fixtures, conformance harnesses, the cross-artefact
+;; integration tests in http / epoch / routing / ssr / core) use to observe
+;; the registry shape without dereferencing the private atoms above. Reads
+;; only — mutation goes through `reg-flow` / `clear-flow` /
+;; `teardown-on-frame-destroy!` / `reset-flows!` / `reset-last-inputs!`.
+
+(defn flows-snapshot
+  "Return the per-frame flow registry value: `{frame-id {flow-id flow-map}}`.
+  Snapshot — observers MUST NOT mutate (the underlying atom is private)."
+  []
+  @flows)
+
+(defn last-inputs-snapshot
+  "Return the dirty-check `last-inputs` value: `{flow-id {frame-id inputs}}`.
+  Snapshot — observers MUST NOT mutate (the underlying atom is private)."
+  []
+  @last-inputs)
+
+;; ---- intra-artefact-only mutation helpers (rf2-4gvb4) --------------------
+;;
+;; `re-frame.flows` (the facade evaluation path) updates `last-inputs` on
+;; every successful flow recompute and snapshots / restores it across the
+;; drain. These helpers keep the mutation contained in this namespace —
+;; the atom never escapes. NOT a public surface; ns-doc names the consumer.
+
+(defn ^:no-doc swap-last-inputs!
+  [f & args]
+  (apply swap! last-inputs f args))
+
+(defn ^:no-doc reset-last-inputs-to!
+  "Restore `last-inputs` to `prior` (the drain-start snapshot). Called by
+  `re-frame.flows/run-flows-on-db`'s catch arm to roll back dirty-check
+  bookkeeping when a flow throws mid-cascade."
+  [prior]
+  (reset! last-inputs prior))
 
 ;; ---- two-level-map maintenance helpers -----------------------------------
 ;;

--- a/implementation/flows/test/re_frame/flows_concurrency_stress_test.clj
+++ b/implementation/flows/test/re_frame/flows_concurrency_stress_test.clj
@@ -71,13 +71,14 @@
        probe).
 
     4. **Clean registry — no leak.** After all threads finish and
-       every per-thread cycle is cleared, the per-frame registry
-       (`re-frame.flows/flows`) holds zero entries for every test
-       frame, the dirty-check `last-inputs` map holds zero entries
-       for every per-thread flow id, and the global `:flow`
-       registrar slot is unregistered for every per-thread flow id
-       (the LAST frame holding it released the id, so per Spec 013
-       §Frame-scoping the registrar slot must be vacated).
+       every per-thread cycle is cleared, the per-frame flow registry
+       (read via `flows/flows-snapshot`) holds zero entries for every
+       test frame, the dirty-check `last-inputs` map (read via
+       `flows/last-inputs-snapshot`) holds zero entries for every
+       per-thread flow id, and the global `:flow` registrar slot is
+       unregistered for every per-thread flow id (the LAST frame
+       holding it released the id, so per Spec 013 §Frame-scoping
+       the registrar slot must be vacated).
 
   Threads start in lockstep via `CountDownLatch.countDown` — the same
   shape rf2-35rgj / rf2-1gpx8 use to maximise contention. Per-thread
@@ -330,8 +331,8 @@
         ;;     the global `:flow` registrar slot must be gone for
         ;;     every per-thread flow id (the LAST frame holding it
         ;;     released the id per Spec 013 §Frame-scoping).
-        (let [flows-snapshot       @flows/flows
-              last-inputs-snapshot @flows/last-inputs]
+        (let [flows-snapshot       (flows/flows-snapshot)
+              last-inputs-snapshot (flows/last-inputs-snapshot)]
           (doseq [{:keys [frame-id flow-id cyc-a cyc-b]} per-thread]
             (let [per-frame-slot (get flows-snapshot frame-id)]
               (is (or (nil? per-frame-slot) (empty? per-frame-slot))

--- a/implementation/flows/test/re_frame/flows_conformance_test.clj
+++ b/implementation/flows/test/re_frame/flows_conformance_test.clj
@@ -123,10 +123,9 @@
 (defn- reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
-  (when-let [li-var (resolve 're-frame.flows/last-inputs)]
-    (reset! (deref li-var) {}))
+  (flows/reset-last-inputs!)
   ;; Per rf2-bacs4: the error-emit listener registry is a `defonce` atom
   ;; that survives test re-runs. Clear before each test so a listener
   ;; registered by one fixture (per rf2-gmrks `:error-emit-records`
@@ -442,7 +441,7 @@
   flows. Fixtures that register on a non-default frame would extend
   this; today's flow-*.edn fixtures all target `:rf/default`."
   []
-  (let [registry (get @flows/flows :rf/default {})]
+  (let [registry (get (flows/flows-snapshot) :rf/default {})]
     (into {}
           (for [[id flow] registry]
             [id (into #{}
@@ -461,7 +460,7 @@
   fixtures (per Spec 013 §Frame-scoping)."
   ([] (flow-registry-ids :rf/default))
   ([frame-id]
-   (into #{} (keys (get @flows/flows frame-id {})))))
+   (into #{} (keys (get (flows/flows-snapshot) frame-id {})))))
 
 (defn- last-inputs-frame-set
   "Per-flow set of frame-ids currently present in `last-inputs[flow-id]`.
@@ -469,7 +468,7 @@
   destroyed frame's row in every `last-inputs[flow-id]` MUST be dropped;
   the whole flow-id key drops when no other frame still holds an entry."
   [flow-id]
-  (into #{} (keys (get @flows/last-inputs flow-id {}))))
+  (into #{} (keys (get (flows/last-inputs-snapshot) flow-id {}))))
 
 (defn- registrar-has-flow?
   "True iff the cross-kind `:flow` registrar slot for `flow-id` is

--- a/implementation/flows/test/re_frame/flows_destroy_frame_teardown_test.clj
+++ b/implementation/flows/test/re_frame/flows_destroy_frame_teardown_test.clj
@@ -33,8 +33,8 @@
 (defn- reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
-  (reset! flows/last-inputs {})
+  (flows/reset-flows!)
+  (flows/reset-last-inputs!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
@@ -60,10 +60,10 @@
                   :output (fn [w h] (* (or w 0) (or h 0)))
                   :path   [:rect :area]}
                  {:frame :fc/scratch})
-    (is (contains? @flows/flows :fc/scratch)
+    (is (contains? (flows/flows-snapshot) :fc/scratch)
         "precondition: the flow registered under the scratch frame's slot")
     (frame/destroy-frame! :fc/scratch)
-    (is (not (contains? @flows/flows :fc/scratch))
+    (is (not (contains? (flows/flows-snapshot) :fc/scratch))
         "post-destroy: the destroyed frame's slot is gone")))
 
 ;; ---- last-inputs rows cleared on destroy --------------------------------
@@ -81,12 +81,12 @@
     ;; `last-inputs[:area][:fc/scratch]`.
     (rf/dispatch-sync [:fc/seed] {:frame :fc/scratch})
     (is (= [3 4]
-           (get-in @flows/last-inputs [:area :fc/scratch]))
+           (get-in (flows/last-inputs-snapshot) [:area :fc/scratch]))
         "precondition: last-inputs recorded the scratch frame's inputs")
     (frame/destroy-frame! :fc/scratch)
-    (is (not (contains? (get @flows/last-inputs :area) :fc/scratch))
+    (is (not (contains? (get (flows/last-inputs-snapshot) :area) :fc/scratch))
         "post-destroy: the destroyed frame's last-inputs entry is gone")
-    (is (not (contains? @flows/last-inputs :area))
+    (is (not (contains? (flows/last-inputs-snapshot) :area))
         "and the whole flow-id row is dropped (no other frame still held an entry)")))
 
 ;; ---- last-inputs rows from sibling frames are preserved -----------------
@@ -109,12 +109,12 @@
                  {:frame :fc/b})
     (rf/dispatch-sync [:fc/seed-a] {:frame :fc/a})
     (rf/dispatch-sync [:fc/seed-b] {:frame :fc/b})
-    (is (= [2 5] (get-in @flows/last-inputs [:area :fc/a])))
-    (is (= [7 9] (get-in @flows/last-inputs [:area :fc/b])))
+    (is (= [2 5] (get-in (flows/last-inputs-snapshot) [:area :fc/a])))
+    (is (= [7 9] (get-in (flows/last-inputs-snapshot) [:area :fc/b])))
     (frame/destroy-frame! :fc/a)
-    (is (not (contains? (get @flows/last-inputs :area) :fc/a))
+    (is (not (contains? (get (flows/last-inputs-snapshot) :area) :fc/a))
         "destroyed-frame A's last-inputs row is gone")
-    (is (= [7 9] (get-in @flows/last-inputs [:area :fc/b]))
+    (is (= [7 9] (get-in (flows/last-inputs-snapshot) [:area :fc/b]))
         "sibling frame B's last-inputs row is preserved")))
 
 ;; ---- registrar :flow slot pruned when destroyed frame was last owner ----
@@ -169,9 +169,9 @@
           (rf/reg-event-db :fc/seed-churn (fn [_ [_ v]] {:n v}))
           (rf/dispatch-sync [:fc/seed-churn i] {:frame frame-id})
           (frame/destroy-frame! frame-id)))
-      (is (empty? @flows/flows)
+      (is (empty? (flows/flows-snapshot))
           "per-frame flow registry is empty after N destroy cycles")
-      (is (empty? @flows/last-inputs)
+      (is (empty? (flows/last-inputs-snapshot))
           "last-inputs is empty after N destroy cycles")
       (is (nil? (registrar/lookup :flow :churn))
           "registrar :flow slot is gone after the last owning frame was destroyed"))))
@@ -190,9 +190,9 @@
     (rf/dispatch-sync [:fc/seed] {:frame :fc/scratch})
     (frame/destroy-frame! :fc/scratch)
     (rf/reg-frame :fc/scratch {:doc "second incarnation"})
-    (is (not (contains? @flows/flows :fc/scratch))
+    (is (not (contains? (flows/flows-snapshot) :fc/scratch))
         "the new frame has no inherited flow-registry slot")
-    (is (not (contains? (get @flows/last-inputs :area) :fc/scratch))
+    (is (not (contains? (get (flows/last-inputs-snapshot) :area) :fc/scratch))
         "the new frame has no inherited last-inputs row")
     (is (nil? (registrar/lookup :flow :area))
         "the new frame has no inherited :flow registrar slot")))

--- a/implementation/flows/test/re_frame/flows_schema_validation_test.clj
+++ b/implementation/flows/test/re_frame/flows_schema_validation_test.clj
@@ -43,11 +43,10 @@
 (defn- reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (schemas/reset-schema-validator!)
-  (when-let [li-var (resolve 're-frame.flows/last-inputs)]
-    (reset! (deref li-var) {}))
+  (flows/reset-last-inputs!)
   (error-emit/clear-error-listeners!)
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)

--- a/implementation/flows/test/re_frame/flows_t2_trace_test.clj
+++ b/implementation/flows/test/re_frame/flows_t2_trace_test.clj
@@ -34,10 +34,9 @@
 (defn- reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
-  (when-let [li-var (resolve 're-frame.flows/last-inputs)]
-    (reset! (deref li-var) {}))
+  (flows/reset-last-inputs!)
   (error-emit/clear-error-listeners!)
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)

--- a/implementation/flows/test/re_frame/flows_test.clj
+++ b/implementation/flows/test/re_frame/flows_test.clj
@@ -36,7 +36,7 @@
 (defn- reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   ;; flows.cljc keeps a private last-inputs atom for dirty-checking
   ;; (per Spec 013 §Dirty-check semantics). The smoke-test fixture
@@ -45,8 +45,7 @@
   ;; cause its first-evaluation to no-op (new-inputs would =-equal the
   ;; stale last-inputs). Clear it here so cross-namespace test order
   ;; can't introduce hidden flakiness.
-  (when-let [li-var (resolve 're-frame.flows/last-inputs)]
-    (reset! (deref li-var) {}))
+  (flows/reset-last-inputs!)
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr :reload)
@@ -64,7 +63,7 @@
                   :inputs [[:w] [:h]]
                   :output (fn [w h] (* (or w 0) (or h 0)))
                   :path   [:rect :area]})
-    (is (contains? (get @flows/flows :rf/default) :area)
+    (is (contains? (get (flows/flows-snapshot) :rf/default) :area)
         "the flow lives under :rf/default's slot of the per-frame registry")
     (is (some? (registrar/lookup :flow :area))
         "the flow is also discoverable via the :flow registrar kind")))
@@ -83,7 +82,7 @@
     (is (= 12 (get-in (rf/get-frame-db :rf/default) [:rect :area]))
         "flow ran on the drain after :seed and materialised :rect/:area")
     (rf/clear-flow :area)
-    (is (not (contains? (get @flows/flows :rf/default) :area))
+    (is (not (contains? (get (flows/flows-snapshot) :rf/default) :area))
         "the per-frame registry no longer carries :area")
     (is (not (contains? (get (rf/get-frame-db :rf/default) :rect) :area))
         "clear-flow dissoc'd the leaf at the flow's :path"))
@@ -261,8 +260,8 @@
       (is (= :fix-registration (:recovery data)) ":recovery names the disposition")
       (is (string? (:reason data)) ":reason is a human-readable sentence")))
   (testing "flow cycle throw stamps :rf.error/id"
-    (reset! flows/flows {})
-    (reset! (deref (resolve 're-frame.flows/last-inputs)) {})
+    (flows/reset-flows!)
+    (flows/reset-last-inputs!)
     (rf/reg-flow {:id :a :inputs [[:b]] :output identity :path [:a]})
     (let [ex (try
                (rf/reg-flow {:id :b :inputs [[:a]] :output identity :path [:b]})
@@ -394,7 +393,7 @@
                  (rf/reg-flow {:id :b :inputs [[:a]]
                                :output identity :path [:b]}))
         "the cyclic registration unwinds and throws :rf.error/flow-cycle")
-    (is (not (contains? (get @flows/flows :rf/default) :b))
+    (is (not (contains? (get (flows/flows-snapshot) :rf/default) :b))
         "cycle-detection rolls back the partial registration of :b")))
 
 (deftest reg-flow-cycle-error-carries-ordered-cycle-path
@@ -432,8 +431,8 @@
     ;; Reset and build a longer chain. The reg-flow ordering matters
     ;; because the cycle is detected on the registration that closes
     ;; it — register :a, :b first (no cycle yet), then :c closes.
-    (reset! flows/flows {})
-    (reset! (deref (resolve 're-frame.flows/last-inputs)) {})
+    (flows/reset-flows!)
+    (flows/reset-last-inputs!)
     (rf/reg-flow {:id :a :inputs [[:b]] :output identity :path [:a]})
     (rf/reg-flow {:id :b :inputs [[:c]] :output identity :path [:b]})
     (let [ex (try
@@ -471,7 +470,7 @@
                   :inputs [[:b]]
                   :output (fn [b] (str "A-from-B-" b))
                   :path   [:a]})
-    (is (contains? (get @flows/flows :rf/default) :a)
+    (is (contains? (get (flows/flows-snapshot) :rf/default) :a)
         "initial :a registers cleanly")
 
     ;; 2. :b reads an unrelated path [:source], writes [:b]. Graph is
@@ -485,7 +484,7 @@
                     :inputs [[:source]]
                     :output original-b-output
                     :path   [:b]})
-      (is (contains? (get @flows/flows :rf/default) :b)
+      (is (contains? (get (flows/flows-snapshot) :rf/default) :b)
           "initial :b registers cleanly (reads [:source]; no cycle)")
 
       ;; 3. RE-register :b with :inputs [[:a]]. :a already reads [:b],
@@ -502,9 +501,9 @@
       ;;    not silently deleted. The bug today (flows.cljc:149) dissocs
       ;;    by id on rollback, vacating the prior registration along
       ;;    with the just-written one.
-      (is (contains? (get @flows/flows :rf/default) :b)
+      (is (contains? (get (flows/flows-snapshot) :rf/default) :b)
           "after a failed cyclic replacement, the prior :b registration is preserved")
-      (let [b-after (get-in @flows/flows [:rf/default :b])]
+      (let [b-after (get-in (flows/flows-snapshot) [:rf/default :b])]
         (is (= [[:source]] (:inputs b-after))
             "prior :b's :inputs are intact ([[:source]], not the rejected [[:a]])")
         (is (identical? original-b-output (:output b-after))
@@ -699,7 +698,7 @@
     ;; Register the flow during :enter. Per Spec 013 §Sequencing the flow
     ;; first runs on the NEXT event drain.
     (rf/dispatch-sync [:enter])
-    (is (contains? (get @flows/flows :rf/default) :step-2/computed)
+    (is (contains? (get (flows/flows-snapshot) :rf/default) :step-2/computed)
         "registry now carries :step-2/computed")
     ;; Drive a drain with a benign event; the flow first-fires here.
     (rf/dispatch-sync [:foo! 5])
@@ -707,7 +706,7 @@
         "flow ran on this drain with 5 + 4 = 9")
     ;; Now clear via fx.
     (rf/dispatch-sync [:leave])
-    (is (not (contains? (get @flows/flows :rf/default) :step-2/computed))
+    (is (not (contains? (get (flows/flows-snapshot) :rf/default) :step-2/computed))
         "registry slot removed")
     (is (not (contains? (get (rf/get-frame-db :rf/default) :wizard) :result))
         ":rf.fx/clear-flow dissoc-in'd the output path")))
@@ -741,14 +740,13 @@
     (rf/dispatch-sync [:init])
     (is (= 10 (:doubled (rf/get-frame-db :rf/default)))
         "flow evaluated; last-inputs row populated for [:double :rf/default]")
-    (let [li-var (resolve 're-frame.flows/last-inputs)]
-      (is (some? (get-in @(deref li-var) [:double :rf/default]))
-          "last-inputs has the dirty-check entry before reset")
-      (flows/reset-flows!)
-      (is (empty? @flows/flows)
-          "flow registry is empty after reset-flows!")
-      (is (empty? @(deref li-var))
-          "last-inputs is ALSO empty after reset-flows! (rf2-mb65w)"))))
+    (is (some? (get-in (flows/last-inputs-snapshot) [:double :rf/default]))
+        "last-inputs has the dirty-check entry before reset")
+    (flows/reset-flows!)
+    (is (empty? (flows/flows-snapshot))
+        "flow registry is empty after reset-flows!")
+    (is (empty? (flows/last-inputs-snapshot))
+        "last-inputs is ALSO empty after reset-flows! (rf2-mb65w)")))
 
 (deftest reset-flows-allows-re-registration-without-stale-skip
   ;; The footgun: re-register the same flow id with the same inputs
@@ -777,16 +775,16 @@
       (is (= 2 @calls)
           "after reset-flows! the freshly-registered flow evaluates again — last-inputs was cleared so no stale skip"))))
 
-(deftest reset-flows-atom-clears-per-frame-state
-  (testing "resetting flows/flows clears the per-frame registry; reg-flow repopulates fresh"
+(deftest reset-flows-clears-per-frame-state
+  (testing "(flows/reset-flows!) clears the per-frame registry; reg-flow repopulates fresh"
     (rf/reg-flow {:id :one :inputs [[:a]] :output identity :path [:slots :one]})
-    (is (contains? (get @flows/flows :rf/default) :one))
-    (reset! flows/flows {})
+    (is (contains? (get (flows/flows-snapshot) :rf/default) :one))
+    (flows/reset-flows!)
     (reset! schemas/schemas-by-frame {})
-    (is (empty? (get @flows/flows :rf/default))
+    (is (empty? (get (flows/flows-snapshot) :rf/default))
         "per-frame map is empty after reset")
     (rf/reg-flow {:id :one :inputs [[:a]] :output identity :path [:slots :one]})
-    (is (contains? (get @flows/flows :rf/default) :one)
+    (is (contains? (get (flows/flows-snapshot) :rf/default) :one)
         "re-registration after reset works without raising")))
 
 ;; ---------------------------------------------------------------------------
@@ -837,17 +835,17 @@
         "left frame's :compute used the 2x formula (5 * 2)")
     (is (= 500 (:result (rf/get-frame-db :right)))
         "right frame's :compute used the 100x formula (5 * 100)")
-    (is (contains? (get @flows/flows :left)  :compute)
+    (is (contains? (get (flows/flows-snapshot) :left)  :compute)
         ":left's per-frame registry slot carries :compute")
-    (is (contains? (get @flows/flows :right) :compute)
+    (is (contains? (get (flows/flows-snapshot) :right) :compute)
         ":right's per-frame registry slot carries :compute"))
 
   (testing "clear-flow on one frame leaves the sibling frame's registry slot intact"
     ;; Branch 1: per-frame registry routing.
     (rf/clear-flow :compute {:frame :left})
-    (is (not (contains? (get @flows/flows :left)  :compute))
+    (is (not (contains? (get (flows/flows-snapshot) :left)  :compute))
         ":left's slot was removed")
-    (is (contains? (get @flows/flows :right) :compute)
+    (is (contains? (get (flows/flows-snapshot) :right) :compute)
         ":right's slot is untouched — flow STILL registered against :right"))
 
   (testing ":left's app-db output path is dissoc'd; :right's app-db is unchanged"
@@ -881,7 +879,7 @@
 
   (testing "clearing from the second (last) frame finally unregisters the registrar slot"
     (rf/clear-flow :compute {:frame :right})
-    (is (not (contains? (get @flows/flows :right) :compute))
+    (is (not (contains? (get (flows/flows-snapshot) :right) :compute))
         ":right's slot is now gone")
     (is (nil? (registrar/lookup :flow :compute))
         "registrar slot was unregistered once the LAST frame released the id")))
@@ -951,11 +949,10 @@
     ;; Drive a drain on each frame so both have last-inputs rows.
     (rf/dispatch-sync [:seed 5] {:frame :left})
     (rf/dispatch-sync [:seed 5] {:frame :right})
-    (let [li-var (resolve 're-frame.flows/last-inputs)
-          li     (deref li-var)]
-      (is (some? (get-in @li [:shared :left]))
+    (let [li (flows/last-inputs-snapshot)]
+      (is (some? (get-in li [:shared :left]))
           "before re-registration: :left's last-inputs row is populated")
-      (is (some? (get-in @li [:shared :right]))
+      (is (some? (get-in li [:shared :right]))
           "before re-registration: :right's last-inputs row is populated"))
     ;; Re-register :shared on :left with a NEW body — should invalidate
     ;; :left's row ONLY.
@@ -964,11 +961,10 @@
                   :output (fn [n] (* 7 (or n 0)))
                   :path   [:result]}
                  {:frame :left})
-    (let [li-var (resolve 're-frame.flows/last-inputs)
-          li     (deref li-var)]
-      (is (nil? (get-in @li [:shared :left]))
+    (let [li (flows/last-inputs-snapshot)]
+      (is (nil? (get-in li [:shared :left]))
           "after re-registration on :left: :left's last-inputs row was dropped (re-evaluate on next drain)")
-      (is (some? (get-in @li [:shared :right]))
+      (is (some? (get-in li [:shared :right]))
           ":right's last-inputs row is PRESERVED — re-registration on :left did not invalidate :right (rf2-jfpf3)"))))
 
 ;; ---------------------------------------------------------------------------
@@ -1007,9 +1003,9 @@
     (is (= :right (:frame (registrar/lookup :flow :shared)))
         ":right's metadata wins after second registration — last-registration-wins per Spec 013 line 105")
     ;; Sanity: both frames still hold the flow in their per-frame registry.
-    (is (contains? (get @flows/flows :left)  :shared)
+    (is (contains? (get (flows/flows-snapshot) :left)  :shared)
         ":left still carries :shared in its per-frame registry")
-    (is (contains? (get @flows/flows :right) :shared)
+    (is (contains? (get (flows/flows-snapshot) :right) :shared)
         ":right carries :shared in its per-frame registry too")))
 
 ;; ---------------------------------------------------------------------------

--- a/implementation/flows/test/re_frame/flows_trace_emit_elision_prod_test.cljs
+++ b/implementation/flows/test/re_frame/flows_trace_emit_elision_prod_test.cljs
@@ -92,10 +92,11 @@
       (is (empty? seen)
           "no trace events delivered under :advanced + goog.DEBUG=false"))
     ;; Cross-check: the flow IS registered — the registrar mutation
-    ;; happened, only the trace surface elided. `flows/flows` is keyed
+    ;; happened, only the trace surface elided. The per-frame flow
+    ;; registry (read via `flows/flows-snapshot`) is keyed
     ;; `{frame-id {flow-id flow}}`; the flow registers under
     ;; `:rf/default` by default.
-    (is (some? (get-in @flows/flows [:rf/default :prod-elision/area]))
+    (is (some? (get-in (flows/flows-snapshot) [:rf/default :prod-elision/area]))
         "flow registered in the per-frame index — only trace surface elided")))
 
 ;; ---- :rf.flow/computed elides under prod ----------------------------------
@@ -193,7 +194,7 @@
                    (rf/clear-flow :prod-elision/clearable)))]
       (is (empty? seen)
           "no :rf.flow/cleared trace under prod"))
-    (is (nil? (get-in @flows/flows [:rf/default :prod-elision/clearable]))
+    (is (nil? (get-in (flows/flows-snapshot) [:rf/default :prod-elision/clearable]))
         "flow removed from per-frame index — only trace surface elided")))
 
 ;; ---- :schema output validation elides under prod --------------------------

--- a/implementation/flows/test/re_frame/flows_trace_test.clj
+++ b/implementation/flows/test/re_frame/flows_trace_test.clj
@@ -29,10 +29,9 @@
 (defn- reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
-  (when-let [li-var (resolve 're-frame.flows/last-inputs)]
-    (reset! (deref li-var) {}))
+  (flows/reset-last-inputs!)
   ;; Per rf2-bacs4: the error-emit listener registry is a `defonce`
   ;; atom that survives test re-runs. Clear before each test so a
   ;; listener registered by one test doesn't leak into the next.

--- a/implementation/http/src/re_frame/http_middleware.cljc
+++ b/implementation/http/src/re_frame/http_middleware.cljc
@@ -24,9 +24,10 @@
   extension.
 
   Storage is per-frame in a `defonce` atom keyed `frame-id → [interceptor ...]`,
-  mirroring the `re-frame.flows/flows` pattern. Frame-scoped: an
-  interceptor registered against frame A does not fire for a request
-  dispatched from frame B."
+  mirroring the per-frame flow registry pattern (see
+  `re-frame.flows.registry`'s private `flows` atom + the
+  `flows-snapshot` accessor). Frame-scoped: an interceptor registered
+  against frame A does not fire for a request dispatched from frame B."
   (:require [re-frame.http-privacy :as privacy]
             [re-frame.interop      :as interop]
             [re-frame.source-coords :as source-coords]

--- a/implementation/http/test/re_frame/flows_http_integration_test.clj
+++ b/implementation/http/test/re_frame/flows_http_integration_test.clj
@@ -76,10 +76,9 @@
 (defn- reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
-  (when-let [li-var (resolve 're-frame.flows/last-inputs)]
-    (reset! @li-var {}))
+  (flows/reset-last-inputs!)
   (rf/init! plain-atom/adapter)
   ;; clear-all! wiped the ns-load-time registrations of these artefacts;
   ;; :reload re-evaluates each ns body so its registrations resurrect.

--- a/implementation/http/test/re_frame/http_abort_precedence_test.clj
+++ b/implementation/http/test/re_frame/http_abort_precedence_test.clj
@@ -42,7 +42,7 @@
 (defn- reset-runtime [t]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)

--- a/implementation/http/test/re_frame/http_actor_destroy_cancellation_test.clj
+++ b/implementation/http/test/re_frame/http_actor_destroy_cancellation_test.clj
@@ -42,7 +42,7 @@
 (defn- reset-runtime [t]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)

--- a/implementation/http/test/re_frame/http_helpers_integration_test.clj
+++ b/implementation/http/test/re_frame/http_helpers_integration_test.clj
@@ -27,7 +27,7 @@
 (defn- reset-runtime [t]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)

--- a/implementation/http/test/re_frame/http_interceptors_test.clj
+++ b/implementation/http/test/re_frame/http_interceptors_test.clj
@@ -39,7 +39,7 @@
 (defn- reset-runtime [t]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)

--- a/implementation/http/test/re_frame/http_managed_machine_test.clj
+++ b/implementation/http/test/re_frame/http_managed_machine_test.clj
@@ -47,7 +47,7 @@
 (defn- reset-runtime [t]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)

--- a/implementation/http/test/re_frame/http_managed_test.clj
+++ b/implementation/http/test/re_frame/http_managed_test.clj
@@ -40,7 +40,7 @@
 (defn- reset-runtime [t]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)

--- a/implementation/http/test/re_frame/http_privacy_integration_test.clj
+++ b/implementation/http/test/re_frame/http_privacy_integration_test.clj
@@ -27,7 +27,7 @@
 (defn- reset-runtime [t]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)

--- a/implementation/http/test/re_frame/http_retry_on_validation_test.clj
+++ b/implementation/http/test/re_frame/http_retry_on_validation_test.clj
@@ -30,7 +30,7 @@
 (defn- reset-runtime [t]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)

--- a/implementation/http/test/re_frame/http_source_coords_test.clj
+++ b/implementation/http/test/re_frame/http_source_coords_test.clj
@@ -31,7 +31,7 @@
 (defn- reset-runtime [t]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)

--- a/implementation/http/test/re_frame/routing_http_composed_corners_test.clj
+++ b/implementation/http/test/re_frame/routing_http_composed_corners_test.clj
@@ -41,7 +41,7 @@
 (defn- reset-runtime [t]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (trace/clear-listeners!)
   (rf/init! plain-atom/adapter)

--- a/implementation/routing/test/re_frame/route_link_test.clj
+++ b/implementation/routing/test/re_frame/route_link_test.clj
@@ -34,7 +34,7 @@
 (defn reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)

--- a/implementation/routing/test/re_frame/routing_concurrency_stress_test.clj
+++ b/implementation/routing/test/re_frame/routing_concurrency_stress_test.clj
@@ -73,7 +73,7 @@
 (defn- reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (trace/clear-listeners!)
   (rf/init! plain-atom/adapter)

--- a/implementation/routing/test/re_frame/routing_test.clj
+++ b/implementation/routing/test/re_frame/routing_test.clj
@@ -50,7 +50,7 @@
 (defn reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
   ;; Framework events / fx (routing.cljc, ssr.cljc) are registered at

--- a/implementation/schemas/src/re_frame/schemas.cljc
+++ b/implementation/schemas/src/re_frame/schemas.cljc
@@ -41,18 +41,20 @@
 ;; **intentional fixture-composition primitive**, not a backdoor. Test
 ;; fixtures across the implementation tree (~70+ test namespaces under
 ;; `implementation/{core,epoch,flows,http,routing,schemas,ssr}/test/`)
-;; compose `(reset! schemas/schemas-by-frame {})` directly alongside
-;; `(reset! re-frame.flows/flows {})` and the other per-feature atom
-;; resets to express "wipe per-feature state to a known shape, atomically,
-;; before this test." The dedicated `snapshot-schemas-by-frame` /
-;; `restore-schemas-by-frame!` / `clear-schemas-by-frame!` /
-;; `reset-schema-validator!` fns serve the **registered-test-fixture
-;; pathway** (consumed by `re-frame.test-support`'s `reset-runtime-
-;; fixture` via the late-bind hook table); the raw atom Vars serve the
-;; **ad-hoc-test-fixture pathway** where the test author composes the
-;; setup without going through the registered fixture. Both surfaces are
-;; documented as supported. The atoms are NOT marked `^:private` because
-;; the dual pathway is by design — see rf2-ycqtv audit Finding #5.
+;; compose `(reset! schemas/schemas-by-frame {})` directly alongside the
+;; flows facade's reset fns (`(flows/reset-flows!)` /
+;; `(flows/reset-last-inputs!)` per rf2-4gvb4 — the flows atoms moved
+;; behind an accessor seam) to express "wipe per-feature state to a known
+;; shape, atomically, before this test." The dedicated
+;; `snapshot-schemas-by-frame` / `restore-schemas-by-frame!` /
+;; `clear-schemas-by-frame!` / `reset-schema-validator!` fns serve the
+;; **registered-test-fixture pathway** (consumed by
+;; `re-frame.test-support`'s `reset-runtime-fixture` via the late-bind
+;; hook table); the raw atom Vars serve the **ad-hoc-test-fixture
+;; pathway** where the test author composes the setup without going
+;; through the registered fixture. Both surfaces are documented as
+;; supported. The atoms are NOT marked `^:private` because the dual
+;; pathway is by design — see rf2-ycqtv audit Finding #5.
 
 (def schemas-by-frame storage/schemas-by-frame)
 (def validator-fn     validator/validator-fn)

--- a/implementation/schemas/src/re_frame/schemas/validate.cljc
+++ b/implementation/schemas/src/re_frame/schemas/validate.cljc
@@ -62,8 +62,8 @@
   (until rf2-isdwf's top-level hoisting lands in core).
 
   The value-bearing slots are redacted (`:value`, `:received`,
-  `:explain`, plus `:fx-args` on `:where :fx-args` emissions and
-  `:query-v` on `:where :sub-return` emissions — see `redact-tags`);
+  `:explain`, plus `:rf.fx/args` on `:where :fx-args` emissions and
+  `:rf.sub/query-v` on `:where :sub-return` emissions — see `redact-tags`);
   the structural / categorical slots (`:path`, `:failing-id`,
   `:schema-id`, `:reason`) are kept — consumers need them to locate
   the broken slot without leaking user data.
@@ -105,17 +105,17 @@
   correctly. Idempotent — safe to call on an already-redacted map.
 
   The five redacted slots (`:value`, `:received`, `:explain`,
-  `:fx-args`, `:query-v`) are the canonical set per the Spec 010
-  §`:sensitive?` redaction-shape list. Two of them are per-surface
-  doubled-id names carried only on a single emit-site (`:fx-args` on
-  `:where :fx-args`; `:query-v` on `:where :sub-return`); the
-  `contains?` guards make those clauses no-ops on the other surfaces
-  whose tag maps don't carry the slot. Per rf2-nijom this replaces the
-  previous fx-only `extra-redact` lambda — the redaction is now
-  symmetric across every value-bearing slot, and the schema lists
-  them canonically.
+  `:rf.fx/args`, `:rf.sub/query-v`) are the canonical set per the
+  Spec 010 §`:sensitive?` redaction-shape list. Two of them are
+  per-surface doubled-id names carried only on a single emit-site
+  (`:rf.fx/args` on `:where :fx-args`; `:rf.sub/query-v` on
+  `:where :sub-return`); the `contains?` guards make those clauses
+  no-ops on the other surfaces whose tag maps don't carry the slot.
+  Per rf2-nijom this replaces the previous fx-only `extra-redact`
+  lambda — the redaction is now symmetric across every value-bearing
+  slot, and the schema lists them canonically.
 
-  Per rf2-adtp2 / rf2-p2adl Q2 — `:query-v` (the caller-supplied
+  Per rf2-adtp2 / rf2-p2adl Q2 — `:rf.sub/query-v` (the caller-supplied
   subscription query vector on `:where :sub-return` emissions) is
   the lookup key, not just an id, and on `:sensitive?`-marked subs
   typically carries the same secret material the registered schema
@@ -262,8 +262,8 @@
 
   Per rf2-nijom this primitive no longer carries an `extra-redact`
   escape hatch — the four canonical redacted slots
-  (`:value`, `:received`, `:explain`, `:fx-args`) all live on the
-  central `redact-tags` cond->. The fx-args clause is a no-op on
+  (`:value`, `:received`, `:explain`, `:rf.fx/args`) all live on the
+  central `redact-tags` cond->. The `:rf.fx/args` clause is a no-op on
   the other three surfaces (their base-tags don't contain the
   slot), so a single redactor covers every meta-bearing emit site."
   [meta value meta-sensitive? walk-schema? build-base-tags]
@@ -516,11 +516,11 @@
   continue to run, and downstream queued events still drain. Returns
   true/false per the `run-validation` contract.
 
-  Per rf2-nijom the per-surface `:fx-args` slot is redacted by the
+  Per rf2-nijom the per-surface `:rf.fx/args` slot is redacted by the
   central `redact-tags` cond->; the lambda escape hatch that used to
   do this here is gone, and Spec 010 §`:sensitive?` now lists
-  `:fx-args` alongside `:value` / `:received` / `:explain` as the
-  canonical redacted slots (and `:query-v` on the sub-return
+  `:rf.fx/args` alongside `:value` / `:received` / `:explain` as the
+  canonical redacted slots (and `:rf.sub/query-v` on the sub-return
   surface, per rf2-adtp2)."
   [fx-id event-id args fx-meta]
   (if interop/debug-enabled?

--- a/implementation/schemas/test/re_frame/schemas/test_fixture.clj
+++ b/implementation/schemas/test/re_frame/schemas/test_fixture.clj
@@ -20,7 +20,7 @@
 
   - `(registrar/clear-all!)`
   - `(reset! frame/frames {})`
-  - `(reset! flows/flows {})`
+  - `(flows/reset-flows!)`
   - `(reset! schemas/schemas-by-frame {})`
   - `(schemas/reset-schema-validator!)` — restores Malli defaults
     per rf2-froe so a test that mutates the pluggable validator
@@ -50,7 +50,7 @@
   [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (schemas/reset-schema-validator!)
   (schemas/clear-validator-unavailable-warned!)

--- a/implementation/ssr/test/re_frame/flows_integration_test.clj
+++ b/implementation/ssr/test/re_frame/flows_integration_test.clj
@@ -81,15 +81,14 @@
 (defn- reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (schemas/reset-schema-validator!)
   (reset! request/request-slots {})
   (reset! response/response-slots {})
   (reset! error-listener/pending-error-traces {})
   (reset! head/head-snapshots {})
-  (when-let [li-var (resolve 're-frame.flows/last-inputs)]
-    (reset! @li-var {}))
+  (flows/reset-last-inputs!)
   ;; The error-emit listener registry is a `defonce` atom that survives
   ;; test re-runs (per rf2-bacs4) — clear so a listener registered by one
   ;; test does not leak into the next.

--- a/implementation/ssr/test/re_frame/ssr/test_fixture.clj
+++ b/implementation/ssr/test/re_frame/ssr/test_fixture.clj
@@ -22,7 +22,7 @@
   ## What gets reset
 
   Registrar + frame state — `(registrar/clear-all!)`,
-  `(reset! frame/frames {})`, `(reset! flows/flows {})`,
+  `(reset! frame/frames {})`, `(flows/reset-flows!)`,
   `(reset! schemas/schemas-by-frame {})`.
 
   SSR side-channel atoms (Spec 011 §Per-request frame teardown). All
@@ -72,7 +72,7 @@
   [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
-  (reset! flows/flows {})
+  (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   ;; SSR side-channel atoms — direct refs into the producing sub-ns
   ;; rather than the (private) façade aliases. Same atoms either way;
@@ -82,13 +82,11 @@
   (reset! response/response-slots {})
   (reset! error-listener/pending-error-traces {})
   (reset! head/head-snapshots {})
-  ;; The flows artefact's per-frame "last-inputs" memo table is
-  ;; framework-private (no public reset surface); resolve reflectively
-  ;; and skip silently when the var is absent so this fixture stays
-  ;; resilient to flows-internal renames. Spec 013 §Flow re-evaluation
-  ;; trigger.
-  (when-let [li-var (resolve 're-frame.flows/last-inputs)]
-    (reset! @li-var {}))
+  ;; Per rf2-4gvb4 — the flows artefact's per-frame `last-inputs` memo
+  ;; table is reset through the public `flows/reset-last-inputs!` seam
+  ;; (the atom itself is now private to the flows artefact). Spec 013
+  ;; §Flow re-evaluation trigger.
+  (flows/reset-last-inputs!)
   (rf/init! ssr/adapter)
   ;; Namespace-load-time registrations get wiped by clear-all!; reload
   ;; so :rf/hydrate, :rf.route/navigate, :rf.server/* fxs, the

--- a/tools/template/spec/API.md
+++ b/tools/template/spec/API.md
@@ -140,14 +140,14 @@ mirror the chosen `:substrate` + `:include-story?` flags.
 
 ## Errors
 
-| Condition | Behaviour |
-|---|---|
-| `:substrate` not one of `#{:reagent :uix :helix}` | `ex-info` thrown; message names the valid set; `ex-data` carries `{:substrate <bad-value> :valid #{...}}`. |
-| `:include-story?` not `true` / `false` / `nil` | `ex-info` thrown; message gives the offending value. |
-| `:include-story? true` with non-Reagent substrate | `ex-info` thrown; message says "Reagent-only in v1" and names the chosen substrate. |
-| `:name` missing | deps-new's harness rejects before template is invoked. |
-| `:name` not group-qualified | deps-new's harness rejects (`acme/my-app`, not `my-app`). |
-| Target directory already exists | deps-new's harness aborts to avoid clobbering (unless `:overwrite` is passed). |
+| Condition | Error keyword | Behaviour |
+|---|---|---|
+| `:substrate` not one of `#{:reagent :uix :helix}` | `:rf.error/template-substrate-must-be-one-of` (keyword arg outside the valid set) / `:rf.error/template-unrecognised-substrate` (non-keyword/string/symbol shape) | `ex-info` thrown; message names the valid set; `ex-data` carries `{:substrate <bad-value> :valid #{...}}`. |
+| `:include-story?` not `true` / `false` / `nil` | `:rf.error/template-bad-include-story-flag` | `ex-info` thrown; message gives the offending value. |
+| `:include-story? true` with non-Reagent substrate | `:rf.error/template-include-story-reagent-only` | `ex-info` thrown; message says "Reagent-only in v1" and names the chosen substrate. |
+| `:name` missing | n/a (deps-new) | deps-new's harness rejects before template is invoked. |
+| `:name` not group-qualified | n/a (deps-new) | deps-new's harness rejects (`acme/my-app`, not `my-app`). |
+| Target directory already exists | n/a (deps-new) | deps-new's harness aborts to avoid clobbering (unless `:overwrite` is passed). |
 
 ## Cross-references
 

--- a/tools/template/src/day8/re_frame2_template/hooks.clj
+++ b/tools/template/src/day8/re_frame2_template/hooks.clj
@@ -185,6 +185,13 @@
                               :reagent "https://img.shields.io/badge/substrate-Reagent-1abc9c.svg"
                               :uix     "https://img.shields.io/badge/substrate-UIx-3498db.svg"
                               :helix   "https://img.shields.io/badge/substrate-Helix-9b59b6.svg")
+       ;; -- DO NOT EDIT — managed by version_lockstep_test --
+       ;; The three version pins below are checked against the repo-root
+       ;; sources of truth (the VERSION file, implementation/package.json's
+       ;; shadow-cljs / react pins) by
+       ;; `test/day8/re_frame2_template/version_lockstep_test.clj`. Bumping
+       ;; them here in isolation will fail that test. The §3 release pipeline
+       ;; (rf2-dolpf) updates all four in lockstep.
        :rf2-version         "0.0.1.alpha"
        :shadow-version      "3.4.10"
        :react-version       "19.2.0"})))


### PR DESCRIPTION
Mixed surgical polish across adapters, schemas, flows, template, and a deferred follow-on for the demo-stub HTTP shorthand.

## Beads in this PR

| # | bead | P | what |
|---|---|---|---|
| 1 | rf2-740nl | P4 | adapters/test-react: top-of-section block clarifying `mount!` vs substrate `:render` |
| 2 | rf2-obok3 | P4 | adapters/README.md: cross-link the spine factories (`make-ratom-spine` + `make-react-spine`) |
| 3 | rf2-91b57 | P4 | template/API.md Errors table: name the four `:rf.error/template-*` keywords in a new column |
| 4 | rf2-ti6w3 | P4 | template/hooks.clj data-fn: 'DO NOT EDIT — managed by version_lockstep_test' marker above the pin trio |
| 5 | rf2-9a2ui | P4 | schemas/validate.cljc docstrings: refresh stale `:fx-args`/`:query-v` → canonical `:rf.fx/args`/`:rf.sub/query-v` (6 slots) |
| 6 | rf2-vo005 | P4 | flows/validate-flow: data-driven rewrite over a `validation-rules` vector |
| 7 | rf2-4gvb4 | P3 | flows: re-private the `flows` + `last-inputs` atom Vars; migrate ~80 consumer files to a public read accessor + reset seam |
| 8 | rf2-byvp3 | P4 | Demo-stub HTTP `-later` shorthand: design questions surfaced — **deferred to follow-on bead rf2-j1mo4** per the parent bead's `'file a follow-on instead of guessing the shape'` constraint |

## Highlights

**rf2-4gvb4 — the largest change.** The flows facade previously re-exported `flows` + `last-inputs` atom Vars so test fixtures could `(reset! flows/flows {})`, `(resolve 're-frame.flows/last-inputs)`, or read `@flows/flows` directly. That coupled every consumer to the internal atom shape. Pre-alpha clean cut:

- `registry/flows` + `registry/last-inputs` now `^:private`.
- New public accessors `flows-snapshot` / `last-inputs-snapshot` re-exported from `re-frame.flows` alongside the existing `reset-flows!` / `reset-last-inputs!`.
- New `^:no-doc` intra-artefact mutator pair (`swap-last-inputs!` / `reset-last-inputs-to!`) used by the flows evaluation loop.
- Drops the `(def flows registry/flows)` / `(def last-inputs registry/last-inputs)` Var re-exports.
- ~80 consumer files across `core/`, `epoch/`, `flows/`, `http/`, `routing/`, `schemas/`, `ssr/` migrated to the public seam.
- One test (`frame_destroy_composed_test.clj`) seeds `last-inputs` directly to set up a teardown precondition; it now reaches via the `:no-doc` `swap-last-inputs!` helper with an explicit `re-frame.flows.registry` require (signalling 'backdoor').

**rf2-vo005 — data-driven validate-flow.** 7-clause `cond` replaced with a `(some pred validation-rules)` walk. Same evaluation order, same error keywords, same ex-data slots. All 117 flows tests / 489 assertions pass unchanged. Rules are now introspectable + adding a clause is a single `conj`.

**rf2-byvp3 — deferred.** Implementing surfaced multiple non-trivial API questions (time-travel posture, args shape, Spec 014 §Testing diff, `:fx-overrides` interaction, naming). Filed rf2-j1mo4 for the design + implementation; no code change here.

## Quality gates

- `scripts/test-jvm-implementation.sh` — all artefacts 0F/0E.
- `implementation`: `npm run test:cljs` — **4833 tests / 15 775 assertions — 0F/0E**.
- `implementation/flows`: `clojure -M:test` — **117 / 489 — 0F/0E**.
- `implementation/schemas`: `clojure -M:test` — **192 / 18 251 — 0F/0E**.
- `tools/template`: `clojure -M:test` — **21 / 297 — 0F/0E**.
- `scripts/test-fast-pr.sh` — PASS.

## Notes

- rf2-byvp3 deferred to rf2-j1mo4 per the parent bead's 'file a follow-on instead of guessing the shape' constraint.