### PR TITLE
fix(xray): issues-ribbon footer hint → Epoch panel (rf2-rtyd9)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/issues_ribbon.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/issues_ribbon.cljs
@@ -196,7 +196,7 @@
                        :color       (:text-tertiary tokens)
                        :font-family sans-stack
                        :font-size   "11px"}}
-   "click a row → Event panel (the cascade) · click ↗ → source file:line"])
+   "click a row → Epoch panel (the cascade) · click ↗ → source file:line"])
 
 ;; ---- empty states -------------------------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/issues_ribbon_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/issues_ribbon_view_cljs_test.cljs
@@ -385,7 +385,7 @@
 
 (deftest footer-hint-renders-below-the-feed
   (testing "rf2-tha26 — the Figma footer hint renders below the feed
-            naming the row affordances (click a row → Event panel · click
+            naming the row affordances (click a row → Epoch panel · click
             ↗ → source file:line)"
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
@@ -396,7 +396,7 @@
       (let [tree (issues-ribbon/Panel)
             hint (find-by-testid tree "rf-xray-issues-footer-hint")]
         (is (some? hint) "footer hint renders in the feed branch")
-        (is (= "click a row → Event panel (the cascade) · click ↗ → source file:line"
+        (is (= "click a row → Epoch panel (the cascade) · click ↗ → source file:line"
                (last hint))
             "footer hint carries the reference copy")))))
 


### PR DESCRIPTION
## Summary

The xray issues-ribbon footer hint rendered:

> click a row → Event panel (the cascade) · click ↗ → source file:line

The Event panel was retired under rf2-5gl5r — the Epoch panel supersedes it. Update the UI text and the matching test assertion in `issues_ribbon_view_cljs_test.cljs` to reference the Epoch panel.

## Scope

- `tools/xray/src/.../panels/issues_ribbon.cljs` — `footer-hint` rendered text only.
- `tools/xray/test/.../issues_ribbon_view_cljs_test.cljs` — `footer-hint-renders-below-the-feed` exact-text assertion + `testing` docstring.

## Out of scope (deliberate)

- The row's `:on-click` still dispatches `[:rf.xray/select-tab :event]`. That tab-id cleanup is part of the broader Event-tab-id retirement work, not this bead.
- The `row-click-pivots-to-event-tab` test's docstring still references the Event panel — it describes the still-existing `:event` dispatch and is out of scope for this UI-text bead.

## Gates

- `cd tools/xray && clojure -M:test` — 952 tests / 3709 assertions, 0F/0E
- `npm run test:cljs` — 4836 tests / 15807 assertions, 0F/0E
- `bash scripts/test-fast-pr.sh` — PASS fast PR spine

Closes rf2-rtyd9.
