### PR TITLE
refactor(framework): drop JSX dev-source-coord props — feature never worked (rf2-rohdn, rf2-fa4ly follow-on)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/reg_view_devtools_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/reg_view_devtools_cljs_test.cljs
@@ -1,25 +1,23 @@
 (ns re-frame.reg-view-devtools-cljs-test
   "Per Spec 006 §React DevTools support (rf2-fa4ly): the reg-view
-  wrapper sets a React `displayName` to the registered view-id, the
-  source-coord injection point emits JSX-shaped source-coord props
-  alongside the DOM attribute, and the React Context backing the
-  frame-provider carries a recognisable `displayName` for the Context
-  inspector.
+  wrapper sets a React `displayName` to the registered view-id and
+  the React Context backing the frame-provider carries a recognisable
+  `displayName` for the Context inspector.
 
   Coverage:
 
     - `displayName` on the wrapped fn matches `(str view-id)` for
       auto-derived and `:rf/id`-overridden registrations.
-    - JSX source-coord props (`:_jsxFileName`, `:_jsxLineNumber`,
-      `:_jsxColumnNumber`) land on the same root element as
-      `:data-rf2-source-coord`.
-    - JSX props are absent on programmatic `reg-view*` registrations
-      without macro-captured coords (graceful degrade).
     - The frame-context's React `displayName` is set to `\"rf2-frame\"`.
+    - Regression (rf2-rohdn): NO `:_jsxFileName` / `:_jsxLineNumber`
+      / `:_jsxColumnNumber` JSX-shaped source-coord props are injected
+      into rendered hiccup. The earlier rf2-fa4ly injection never
+      worked (Reagent passed them through as DOM attributes; DevTools
+      reads `__source` from React.createElement, not element props)
+      and rf2-rohdn dropped it.
 
   Production-elision is verified separately by the elision-probe
-  build (sentinels `_jsxFileName` + `rf2-frame` in
-  `scripts/check-elision.cjs`) and by
+  build (sentinel `rf2-frame` in `scripts/check-elision.cjs`) and by
   `reg_view_devtools_elision_prod_test.cljs`."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.adapter.context :as adapter-context]
@@ -65,73 +63,65 @@
              (.-displayName ^js wrapped))
           "the override id drives displayName"))))
 
-;; ---- JSX source-coord props -----------------------------------------------
+;; ---- JSX source-coord props (regression: must NOT be injected) -----------
+;;
+;; rf2-rohdn removed the JSX-prop injection (rf2-fa4ly): the props leaked
+;; to the DOM as attributes, triggering React's "unrecognised prop on a
+;; DOM element" console warnings, AND the feature didn't deliver its
+;; intended benefit (React DevTools' "View source" reads `__source`
+;; off `React.createElement`'s third arg — set by
+;; `@babel/plugin-transform-react-jsx-source` at JSX-compile time, NOT
+;; from element props). These regression tests pin the absence so a
+;; well-intentioned re-introduction doesn't bring the noise back.
 
-(deftest jsx-source-props-injected-with-data-rf2-source-coord
-  (testing "the reg-view wrapper merges JSX-shaped source-coord props
-            (`:_jsxFileName`, `:_jsxLineNumber`, `:_jsxColumnNumber`)
-            onto the same root element that carries
-            `:data-rf2-source-coord` — React DevTools' \"View source\"
-            gesture reads them to jump to the reg-view definition"
-    (rf/reg-view ^{:rf/id :rf.devtools-test/jsx-root}
-                 jsx-root-view []
+(deftest jsx-source-props-not-injected-by-macro-path
+  (testing "a macro-registered view's rendered hiccup carries NO
+            `_jsx*` props (rf2-rohdn regression — feature never
+            worked, dropped to remove dev-console noise)"
+    (rf/reg-view ^{:rf/id :rf.devtools-test/no-jsx-macro}
+                 no-jsx-macro-view []
       [:section "body"])
-    (let [render (rf/view :rf.devtools-test/jsx-root)
+    (let [render (rf/view :rf.devtools-test/no-jsx-macro)
           out    (render)
           attrs  (root-attrs out)]
-      (is (map? attrs) "the root has an attrs map (spliced in by the wrapper)")
+      (is (map? attrs) "attrs map still spliced in for data-* attributes")
       (is (string? (:data-rf2-source-coord attrs))
-          "data-rf2-source-coord present (parity)")
-      (is (string? (:_jsxFileName attrs))
-          "_jsxFileName present alongside data-rf2-source-coord")
-      (is (integer? (:_jsxLineNumber attrs))
-          "_jsxLineNumber is an integer")
-      ;; :column may be absent under the macro-emitted prod-coords-form,
-      ;; but in the dev build the macro emits it.
-      (is (or (nil? (:_jsxColumnNumber attrs))
-              (integer? (:_jsxColumnNumber attrs)))
-          "_jsxColumnNumber is integer or omitted"))))
+          "data-rf2-source-coord still present (rides the same wrapper)")
+      (is (string? (:data-rf-view attrs))
+          "data-rf-view still present (rides the same wrapper)")
+      (is (nil? (:_jsxFileName attrs))     "_jsxFileName not injected")
+      (is (nil? (:_jsxLineNumber attrs))   "_jsxLineNumber not injected")
+      (is (nil? (:_jsxColumnNumber attrs)) "_jsxColumnNumber not injected"))))
 
-(deftest jsx-source-props-merge-into-existing-attrs
-  (testing "an existing attrs map is preserved alongside the JSX props"
-    (rf/reg-view ^{:rf/id :rf.devtools-test/jsx-with-attrs}
-                 jsx-with-attrs-view []
-      [:div {:class "card"} "body"])
-    (let [render (rf/view :rf.devtools-test/jsx-with-attrs)
-          out    (render)
-          attrs  (root-attrs out)]
-      (is (= "card" (:class attrs)) "user :class preserved")
-      (is (string? (:_jsxFileName attrs))
-          "_jsxFileName merged in alongside the user's attrs"))))
-
-(deftest jsx-source-props-absent-on-programmatic-registration
-  (testing "a programmatic `reg-view*` without macro source-coords
-            carries NO JSX props (the contract degrades gracefully
-            — React DevTools' \"View source\" needs a real file+line)"
-    (rf/reg-view* :rf.devtools-test/jsx-programmatic
+(deftest jsx-source-props-not-injected-by-programmatic-path
+  (testing "a programmatic `reg-view*` registration also carries NO
+            `_jsx*` props (rf2-rohdn — covers both macro + non-macro
+            entry points)"
+    (rf/reg-view* :rf.devtools-test/no-jsx-prog
                   (fn [] [:em "p"]))
-    (let [render (rf/view :rf.devtools-test/jsx-programmatic)
+    (let [render (rf/view :rf.devtools-test/no-jsx-prog)
           out    (render)
           attrs  (root-attrs out)]
-      (is (map? attrs)
-          "attrs map still spliced in for data-rf2-source-coord / data-rf-view")
+      (is (map? attrs))
       (is (string? (:data-rf2-source-coord attrs))
           "data-rf2-source-coord still present (degrades to <ns>:<sym>:?:?)")
-      (is (nil? (:_jsxFileName attrs))
-          "_jsxFileName absent — no captured :file/:line to emit"))))
+      (is (nil? (:_jsxFileName attrs))     "_jsxFileName not injected")
+      (is (nil? (:_jsxLineNumber attrs))   "_jsxLineNumber not injected")
+      (is (nil? (:_jsxColumnNumber attrs)) "_jsxColumnNumber not injected"))))
 
-(deftest user-supplied-jsx-prop-wins
-  (testing "a render-fn that already set _jsxFileName is not overwritten —
-            composability with hand-stamped tools"
+(deftest jsx-source-props-preserve-user-supplied
+  (testing "if user code stamps `_jsx*` props themselves (e.g. a hand-
+            crafted React-DevTools shim), the framework does NOT
+            overwrite or strip them — passthrough is opaque (rf2-rohdn)"
     (rf/reg-view ^{:rf/id :rf.devtools-test/user-jsx} user-jsx-view []
       [:p {:_jsxFileName "by-user.cljs" :_jsxLineNumber 99} "ok"])
     (let [render (rf/view :rf.devtools-test/user-jsx)
           out    (render)
           attrs  (root-attrs out)]
       (is (= "by-user.cljs" (:_jsxFileName attrs))
-          "user-supplied :_jsxFileName wins")
+          "user-supplied :_jsxFileName preserved")
       (is (= 99 (:_jsxLineNumber attrs))
-          "user-supplied :_jsxLineNumber wins"))))
+          "user-supplied :_jsxLineNumber preserved"))))
 
 ;; ---- React Context displayName --------------------------------------------
 

--- a/implementation/adapters/reagent/test/re_frame/reg_view_devtools_elision_prod_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/reg_view_devtools_elision_prod_test.cljs
@@ -1,21 +1,19 @@
 (ns re-frame.reg-view-devtools-elision-prod-test
-  "Per Spec 006 §JSX source-coord props + §React DevTools support
-  (rf2-fa4ly): under `:advanced` + `goog.DEBUG=false`, the reg-view*
-  wrapper's `_jsxFileName` / `_jsxLineNumber` / `_jsxColumnNumber`
-  injection branch elides — the closure compiler constant-folds the
+  "Per Spec 006 §React DevTools support: under `:advanced` +
+  `goog.DEBUG=false`, the reg-view* wrapper's `displayName`
+  assignment elides — the closure compiler constant-folds the
   surrounding `(when interop/debug-enabled? ...)` gate and the entire
-  branch DCEs. The same gate elides the `displayName` assignment.
+  branch DCEs.
+
+  This file also asserts the rendered output of a registered view
+  carries NO `_jsx*` props (rf2-rohdn — these never worked and were
+  dropped; the absence under prod-mode is doubly-pinned by the
+  fact that the entire reg-view* annotation site elides in prod).
 
   This file compiles under `:browser-test-prod-elision` (the dedicated
   shadow-cljs build with `goog.DEBUG=false` + `:advanced`); the
   matching CLJS-runtime test (`reg_view_devtools_cljs_test.cljs`)
   exercises the same surface under dev-mode.
-
-  The genuine closure-fold contract is verified by
-  `scripts/check-elision.cjs` (sentinel `_jsxFileName`); this file
-  is the runtime cross-check that the rendered output of a registered
-  view under prod-mode carries no JSX prop and the wrapped fn carries
-  no `displayName`.
 
   Naming convention: files ending in `-prod-test.cljs` are picked up
   ONLY by the `:browser-test-prod-elision` build."
@@ -33,11 +31,11 @@
     (second hiccup)))
 
 (deftest reg-view-output-has-no-jsx-source-props-under-prod
-  (testing "Per Spec 006 §JSX source-coord props production-elision:
-            a registered view's rendered output carries NO
-            `_jsxFileName`/`_jsxLineNumber`/`_jsxColumnNumber` props
-            under :advanced + goog.DEBUG=false. The Closure compiler
-            DCEs the entire (when interop/debug-enabled? ...) branch."
+  (testing "Per rf2-rohdn: a registered view's rendered output carries
+            NO `_jsxFileName`/`_jsxLineNumber`/`_jsxColumnNumber` props.
+            Under :advanced + goog.DEBUG=false the entire reg-view*
+            annotation branch DCEs anyway; rf2-rohdn also removed the
+            JSX-prop emission so the same absence holds under dev-mode."
     (rf/reg-view* :rf.prod-elision-test/jsx-no-attrs
                   (fn [] [:span "hi"]))
     (let [render (rf/view :rf.prod-elision-test/jsx-no-attrs)
@@ -45,13 +43,13 @@
           attrs  (root-attrs out)]
       (is (or (nil? attrs)
               (nil? (:_jsxFileName attrs)))
-          "NO :_jsxFileName on the rendered root — elision contract holds")
+          "NO :_jsxFileName on the rendered root")
       (is (or (nil? attrs)
               (nil? (:_jsxLineNumber attrs)))
-          "NO :_jsxLineNumber on the rendered root — elision contract holds")
+          "NO :_jsxLineNumber on the rendered root")
       (is (or (nil? attrs)
               (nil? (:_jsxColumnNumber attrs)))
-          "NO :_jsxColumnNumber on the rendered root — elision contract holds"))))
+          "NO :_jsxColumnNumber on the rendered root"))))
 
 (deftest reg-view-wrapped-fn-has-no-display-name-under-prod
   (testing "Per Spec 006 §React DevTools support production-elision:
@@ -68,13 +66,13 @@
 (deftest jsx-literal-absent-from-rendered-output
   (testing "Defensive cross-check: scanning the rendered hiccup for the
             literal `_jsxFileName` keyword finds nothing under prod-mode.
-            React DevTools / pair-tool consumers grep for this prop; if
-            it leaked it'd break the elision-bundle invariant."
+            Doubly-pinned by rf2-rohdn (the framework no longer emits
+            this prop at all) and by the elision gate (the whole branch
+            DCEs in prod)."
     (rf/reg-view* :rf.prod-elision-test/jsx-literal-check
                   (fn [] [:p "scan me"]))
     (let [render (rf/view :rf.prod-elision-test/jsx-literal-check)
           out    (render)
           flat   (pr-str out)]
       (is (not (clojure.string/includes? flat "_jsxFileName"))
-          "the literal _jsxFileName does not appear in the rendered output
-           under prod-mode — closure-fold contract holds"))))
+          "the literal _jsxFileName does not appear in the rendered output"))))

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -790,45 +790,39 @@
 (defn- inject-source-coord-attr
   "Wrap `out` (the user component's React element output) with a
   cloneElement call that adds `data-rf2-source-coord` (Spec 006
-  §Source-coord annotation, rf2-z7f7), `data-rf-view` (Spec 006
-  §View tagging contract, rf2-01il5), and — when source coords were
-  captured — the JSX-shaped `_jsxFileName` / `_jsxLineNumber` /
-  `_jsxColumnNumber` props (rf2-fa4ly, React DevTools' \"View source\"
-  contract). Non-element outputs (nil, fragment, function-component
-  head) emit a one-shot warning per id and pass through unchanged —
-  pair tools fall back to `:rf/id` for source-coord; the view-walker
-  falls back to the Fiber-walker primary path for hierarchy capture.
+  §Source-coord annotation, rf2-z7f7) and `data-rf-view` (Spec 006
+  §View tagging contract, rf2-01il5). Non-element outputs (nil,
+  fragment, function-component head) emit a one-shot warning per id
+  and pass through unchanged — pair tools fall back to `:rf/id` for
+  source-coord; the view-walker falls back to the Fiber-walker primary
+  path for hierarchy capture.
 
   CRITICAL: cloneElement returns a new element with the SAME `type` and
   `key` slots — it does NOT wrap the original. Wrapping with a
   synthetic host element (the `[:div]` shape rejected by Spec 006
   §View tagging contract) would break flexbox / CSS Grid / table
   layouts / `:nth-child` selectors / positioning ancestors / stacking
-  contexts / CSS containment."
-  [warn-fn id coord-attr view-attr jsx-coords out]
+  contexts / CSS containment.
+
+  History: an earlier version also patched the JSX-shaped source-coord
+  props (`_jsxFileName` / `_jsxLineNumber` / `_jsxColumnNumber`)
+  intended for React DevTools' \"View source\" gesture (rf2-fa4ly).
+  The feature never worked — DevTools reads `__source` from
+  `React.createElement`'s third arg, not from element props — and the
+  props leaked to the DOM as attributes, triggering React's
+  \"unrecognised prop\" warnings. rf2-rohdn dropped the injection."
+  [warn-fn id coord-attr view-attr out]
   (cond
     (dom-element? out)
     (let [props             (.-props out)
           existing-coord    (when props (aget props "data-rf2-source-coord"))
           existing-view     (when props (aget props "data-rf-view"))
-          existing-jsx-file (when props (aget props "_jsxFileName"))
-          patch             #js {}
-          patch-jsx?        (and jsx-coords
-                                 (some? (:file jsx-coords))
-                                 (some? (:line jsx-coords))
-                                 (not existing-jsx-file))]
+          patch             #js {}]
       (when-not existing-coord
         (aset patch "data-rf2-source-coord" coord-attr))
       (when-not existing-view
         (aset patch "data-rf-view" view-attr))
-      ;; rf2-fa4ly: JSX source-coord props for React DevTools' "View source"
-      ;; gesture. Mirrors the Reagent inline-walk emission.
-      (when patch-jsx?
-        (aset patch "_jsxFileName"   (:file jsx-coords))
-        (aset patch "_jsxLineNumber" (:line jsx-coords))
-        (when (:column jsx-coords)
-          (aset patch "_jsxColumnNumber" (:column jsx-coords))))
-      (if (and existing-coord existing-view (not patch-jsx?))
+      (if (and existing-coord existing-view)
         out
         (React/cloneElement out patch)))
 
@@ -1006,9 +1000,6 @@
       (if interop/debug-enabled?
         (let [coord-attr (format-source-coord id metadata)
               view-attr  (format-view-id id)
-              ;; rf2-fa4ly: capture the raw coords once so each render reuses
-              ;; the JSX-prop input without re-walking metadata.
-              jsx-coords metadata
               wrapped    (fn wrapped-user-fn [& args]
                            ;; rf2-te71r: resolve the frame in-render (the substrate-
                            ;; portable React-context read works inside this wrapped fn's
@@ -1021,7 +1012,7 @@
                            (let [frame-id  (adapter-context/function-component-current-frame)
                                  out       (apply user-fn args)
                                  annotated (inject-source-coord-attr warn-fn id coord-attr
-                                                                     view-attr jsx-coords out)]
+                                                                     view-attr out)]
                              (append-unmount-sentinel unmount-sentinel id frame-id annotated)))]
           ;; rf2-fa4ly: stamp the React `displayName` to the registered view-id
           ;; so React DevTools shows `<:cart/total-line>` in the component tree

--- a/implementation/core/src/re_frame/views.cljs
+++ b/implementation/core/src/re_frame/views.cljs
@@ -443,19 +443,6 @@
   (when (and interop/debug-enabled? (not wrap-applied?))
     (source-coord/format-source-coord id metadata)))
 
-(defn- view-jsx-coords
-  "Capture the raw source-coord metadata for the inline hiccup-walk path
-  (rf2-fa4ly). The metadata carries `:file` / `:line` / `:column` per
-  Spec 001 §Source-coordinate capture; the annotation site reads them
-  back to assemble the JSX `_jsxFileName` / `_jsxLineNumber` /
-  `_jsxColumnNumber` props React DevTools' \"View source\" button
-  consumes. Returns nil under :advanced + goog.DEBUG=false (the
-  dev-only annotation path elides wholesale) and when the substrate
-  hook is wrapping (its own cloneElement path handles JSX props)."
-  [metadata wrap-applied?]
-  (when (and interop/debug-enabled? (not wrap-applied?))
-    metadata))
-
 (defn- maybe-arm-unmount!
   "Install (once per mounted instance) the `:rf.view/unmounted` teardown
   hook for `render-key` and deref its lifecycle reaction so the
@@ -497,7 +484,7 @@
   React frame-context (rf2-kdwc — note the camelCase static-field
   name; the earlier kebab `:context-type` shape was silently ignored
   by Reagent)."
-  [id render-fn view-scope coord-attr jsx-coords wrap-applied?]
+  [id render-fn view-scope coord-attr wrap-applied?]
   (let [wrapped
         (with-meta
           (fn frame-aware-view [& args]
@@ -548,7 +535,7 @@
                                                    (when sink @sink) elapsed-ms)
                         (if (and interop/debug-enabled? (not wrap-applied?))
                           (source-coord/inject-source-coord-attr id coord-attr
-                                                                 jsx-coords out)
+                                                                 out)
                           out))))))))
           {:contextType frame-context})]
     ;; rf2-fa4ly: stamp the React `displayName` to the registered view-id so
@@ -596,10 +583,9 @@
   [id metadata render-fn]
   (let [[render-fn wrap-applied?] (apply-adapter-wrap-view id metadata render-fn)
         coord-attr (view-coord-attr id metadata wrap-applied?)
-        jsx-coords (view-jsx-coords metadata wrap-applied?)
         view-scope (trace/handler-scope-from-meta :view id metadata)
         wrapped    (build-frame-aware-view id render-fn view-scope coord-attr
-                                           jsx-coords wrap-applied?)]
+                                           wrap-applied?)]
     (registrar/register! :view id (assoc metadata :handler-fn wrapped))
     wrapped))
 

--- a/implementation/core/src/re_frame/views/source_coord_annotation.cljs
+++ b/implementation/core/src/re_frame/views/source_coord_annotation.cljs
@@ -65,22 +65,22 @@
       the production-bundle elision sentinel set (see
       `scripts/check-elision.cjs`).
 
-  ## JSX source-coord props (rf2-fa4ly)
+  ## History: JSX source-coord props (rf2-fa4ly, removed by rf2-rohdn)
 
-  Alongside `data-rf2-source-coord` the wrapper ALSO injects the
-  JSX-shaped source-coord props React DevTools' \"View source\" button
-  reads (per `@babel/plugin-transform-react-jsx-source`):
-
-      :_jsxFileName     \"src/my/app/cart.cljs\"
-      :_jsxLineNumber   42
-      :_jsxColumnNumber 1
-
-  These ride the SAME `interop/debug-enabled?` gate (the surrounding
-  wrapper's gate) — production builds elide all three alongside the
-  DOM attributes. Adapters' source-coord injection sites mirror this
-  dual emission (Reagent inline-walk here; UIx / Helix via
-  `re-frame.substrate.spine/inject-source-coord-attr`). Per Spec 006
-  §Source-coord annotation §JSX source-coord props."
+  An earlier version of this wrapper also injected the JSX-shaped
+  source-coord props (`:_jsxFileName` / `:_jsxLineNumber` /
+  `:_jsxColumnNumber`) intended for React DevTools' \"View source\"
+  gesture. The feature never worked: Reagent passed the props through
+  as DOM attributes (triggering React's \"unrecognised prop on a DOM
+  element\" warnings), and DevTools does not read \"View source\" from
+  element props anyway — it reads `__source` off the third arg of
+  `React.createElement`, which is set by `@babel/plugin-transform-
+  react-jsx-source` at JSX-compile time and is not accessible via
+  hiccup. Net effect: dev-console noise with no DevTools benefit.
+  Option A from rf2-rohdn dropped the injection cleanly. The
+  `data-rf2-source-coord` + `data-rf-view` DOM attributes (which DO
+  work and are read by re-frame-pair, the view-walker, IDE jump-to-
+  source tooling) ride the same wrapper unchanged."
   (:require [re-frame.views.warn-once :as warn-once]))
 
 (defn format-source-coord
@@ -116,37 +116,11 @@
   [id]
   (str id))
 
-(defn- jsx-source-props
-  "Build the React-DevTools-readable JSX source-coord prop map for the
-  view registered under `id` with captured `coords` (rf2-fa4ly).
-  Returns nil when no positional info is captured (programmatic
-  `reg-view*` with no macro coords) — DevTools' \"View source\" button
-  is meaningless without at least a `:file` + `:line`. Per
-  `@babel/plugin-transform-react-jsx-source`:
-
-      :_jsxFileName     \"src/my/app/cart.cljs\"   ;; required
-      :_jsxLineNumber   42                         ;; required
-      :_jsxColumnNumber 1                          ;; optional
-
-  Callers gate the call on `interop/debug-enabled?` so the production
-  bundle elides the entire prop set alongside the DOM attributes."
-  [coords]
-  (let [file (:file coords)
-        line (:line coords)
-        col  (:column coords)]
-    (when (and file line)
-      (cond-> {:_jsxFileName   file
-               :_jsxLineNumber line}
-        col (assoc :_jsxColumnNumber col)))))
-
 (defn inject-source-coord-attr
   "Walk the user's render-fn output and merge `:data-rf2-source-coord`
-  (Spec 006 §Source-coord annotation, rf2-z7f7), `:data-rf-view`
-  (Spec 006 §View tagging contract, rf2-01il5) and — when source
-  coords were captured — the JSX-shaped `:_jsxFileName` /
-  `:_jsxLineNumber` / `:_jsxColumnNumber` props (rf2-fa4ly, React
-  DevTools' \"View source\" contract) into the root element's attrs
-  map. Called from inside the wrapper (gated on
+  (Spec 006 §Source-coord annotation, rf2-z7f7) and `:data-rf-view`
+  (Spec 006 §View tagging contract, rf2-01il5) into the root element's
+  attrs map. Called from inside the wrapper (gated on
   `interop/debug-enabled?`). Returns the (possibly rewritten) hiccup.
   Non-DOM roots are returned unchanged after a one-shot warning per
   Spec 006 §Source-coord annotation.
@@ -159,20 +133,19 @@
   Form-2: when `out` is a fn, return a fn that recurses on the inner
   output — Reagent's renderer will call our returned fn just like
   the user's fn, and we get a chance to annotate the inner hiccup."
-  [id coord-attr coords out]
+  [id coord-attr out]
   (cond
     ;; Form-2: render-fn returned a fn. Wrap so the inner fn's output
     ;; is also annotated when Reagent calls through.
     (fn? out)
     (fn form-2-wrapper [& args]
-      (inject-source-coord-attr id coord-attr coords (apply out args)))
+      (inject-source-coord-attr id coord-attr (apply out args)))
 
     ;; Hiccup vector with a DOM-tag keyword head. Annotate the root.
     (and (vector? out) (dom-tag? (first out)))
     (let [head        (first out)
           maybe-attrs (second out)
-          view-attr   (format-view-id id)
-          jsx-props   (jsx-source-props coords)]
+          view-attr   (format-view-id id)]
       (if (map? maybe-attrs)
         ;; Existing attrs map — merge in (don't overwrite if user
         ;; already set any of the framework keys for some reason).
@@ -180,15 +153,11 @@
                        (not (contains? maybe-attrs :data-rf2-source-coord))
                        (assoc :data-rf2-source-coord coord-attr)
                        (not (contains? maybe-attrs :data-rf-view))
-                       (assoc :data-rf-view view-attr)
-                       (and jsx-props
-                            (not (contains? maybe-attrs :_jsxFileName)))
-                       (merge jsx-props))]
+                       (assoc :data-rf-view view-attr))]
           (into [head merged] (drop 2 out)))
         ;; No attrs map — splice one in between head and children.
-        (let [attrs (cond-> {:data-rf2-source-coord coord-attr
-                             :data-rf-view          view-attr}
-                      jsx-props (merge jsx-props))]
+        (let [attrs {:data-rf2-source-coord coord-attr
+                     :data-rf-view          view-attr}]
           (into [head attrs] (rest out)))))
 
     ;; Non-DOM root (fn-component head, fragment, lazy-seq, nil). Skip

--- a/implementation/scripts/check-elision.cjs
+++ b/implementation/scripts/check-elision.cjs
@@ -295,18 +295,15 @@ const DEV_ONLY_SENTINELS = [
   // :advanced + goog.DEBUG=false bundles.
   { source: 're-frame.views/reg-view* (data-rf-view injection)',
     sentinel: 'data-rf-view' },
-  // re-frame.views — JSX source-coord props for React DevTools'
-  // "View source" gesture (Spec 006 §JSX source-coord props,
-  // rf2-fa4ly). The reg-view* wrapper merges `_jsxFileName` +
-  // `_jsxLineNumber` + `_jsxColumnNumber` onto the rendered root DOM
-  // element when `interop/debug-enabled?` is true. Rides the SAME
-  // gate as `data-rf2-source-coord` (one injection site, one branch);
-  // the literal "_jsxFileName" string fragment must NOT appear in
-  // :advanced + goog.DEBUG=false bundles. The other two props
-  // (_jsxLineNumber, _jsxColumnNumber) elide alongside this sentinel
-  // as parts of the same branch.
-  { source: 're-frame.views/reg-view* (_jsxFileName injection)',
-    sentinel: '_jsxFileName' },
+  // Note (rf2-rohdn): the `_jsxFileName` sentinel was removed when
+  // Option A dropped the JSX dev-source-coord prop injection (the
+  // feature never worked — Reagent passed the props through as DOM
+  // attributes triggering React warnings, and DevTools' "View source"
+  // reads `__source` off React.createElement's third arg, not element
+  // props). The injection branch is gone; `data-rf2-source-coord` +
+  // `data-rf-view` (the real DOM API used by re-frame-pair and the
+  // view-walker) ride the same wrapper unchanged and remain covered
+  // by their own sentinels above.
   // re-frame.adapter.context — Context displayName for React DevTools'
   // Context inspector (Spec 006 §React DevTools support, rf2-fa4ly).
   // The "rf2-frame" literal sits inside `(when interop/debug-enabled?

--- a/implementation/ssr/src/re_frame/ssr/html_helpers.cljc
+++ b/implementation/ssr/src/re_frame/ssr/html_helpers.cljc
@@ -118,25 +118,29 @@
 (def ^:private event-handler-name-re
   #"on(?:[A-Z].*|-.*)")
 
-;; JSX source-coord props (rf2-fa4ly). React DevTools' "View source"
-;; gesture reads `_jsxFileName` / `_jsxLineNumber` / `_jsxColumnNumber`
-;; off the rendered React element. The reg-view wrapper injects them
-;; under `interop/debug-enabled?`; under SSR they ride the same hiccup
-;; tree the wrapper produced but MUST NOT serialise as wire HTML
-;; attributes. The leading underscore would also fail the conservative
-;; HTML5 attribute-name grammar (`[A-Za-z][A-Za-z0-9_:-]*`) — these
-;; props sit upstream of that grammar gate and are filtered here so
-;; SSR output stays grammar-clean. The matcher pins the three documented
-;; names (per `@babel/plugin-transform-react-jsx-source`) rather than a
-;; broad underscore-prefix, so an app's custom underscore-prefixed prop
+;; JSX source-coord props. React DevTools' "View source" gesture reads
+;; `_jsxFileName` / `_jsxLineNumber` / `_jsxColumnNumber` off the
+;; rendered React element. The framework no longer emits these — see
+;; Spec 006 §Historical: JSX source-coord props (rf2-rohdn dropped the
+;; rf2-fa4ly injection) — but user code, JSX-compiled third-party
+;; libraries, or hand-stamped DevTools shims may still produce hiccup
+;; carrying them. SSR MUST NOT serialise them as wire HTML attributes:
+;; the leading underscore fails the conservative HTML5 attribute-name
+;; grammar (`[A-Za-z][A-Za-z0-9_:-]*`), and they have no HTML wire
+;; representation in any case. This stripper is defensive — it sits
+;; upstream of the grammar gate so user-carried JSX source-coord props
+;; pass through cleanly without surfacing as a grammar error.
+;;
+;; The matcher pins the three documented names (per
+;; `@babel/plugin-transform-react-jsx-source`) rather than a broad
+;; underscore-prefix, so an app's custom underscore-prefixed prop
 ;; (if grammar-legal) still surfaces the grammar error.
 (def ^:private jsx-source-prop-names
   #{"_jsxFileName" "_jsxLineNumber" "_jsxColumnNumber"})
 
 (defn strip-prop?
   "True when the attribute `[k v]` MUST be dropped at SSR static-markup
-  emission per Spec 011 rule rf2-dwds9 + Spec 006 §JSX source-coord
-  props (rf2-fa4ly):
+  emission per Spec 011 rule rf2-dwds9:
 
     - `on*` event-handler props (`:on-click`, `:onMouseDown`, …). The
       client-side substrate adapters wire handlers at hydration; the
@@ -147,9 +151,11 @@
     - reserved prototype-pollution keys (`__proto__` / `constructor` /
       `prototype`), dropped before they reach the host createElement.
     - JSX source-coord props (`:_jsxFileName`, `:_jsxLineNumber`,
-      `:_jsxColumnNumber`) — React DevTools internals injected by the
-      reg-view wrapper for the \"View source\" gesture (rf2-fa4ly);
-      they have no HTML wire representation.
+      `:_jsxColumnNumber`) — React DevTools internals that may appear
+      in hiccup from user code, JSX-compiled libraries, or hand-stamped
+      shims (the framework itself does not emit them; see Spec 006
+      §Historical: JSX source-coord props). They have no HTML wire
+      representation and would fail the HTML5 attribute-name grammar.
 
   Mirrors react-dom/server behaviour. Recognised here are exactly the
   props that are *safe to silently drop*; malformed keys (breakout chars)

--- a/spec/006-ReactiveSubstrate.md
+++ b/spec/006-ReactiveSubstrate.md
@@ -304,21 +304,18 @@ A registration that bypassed the macro path (programmatic `reg-view*` with no ca
 
 The annotation site MUST sit inside `(when interop/debug-enabled? ...)` (the CLJS mirror of `goog.DEBUG`). Production builds (`:advanced` + `goog.DEBUG=false`) MUST NOT emit the attribute — the entire injection branch dead-code-eliminates so the literal `data-rf2-source-coord` string fragment does not appear in the bundle. Per [Spec 009 §Production builds](009-Instrumentation.md), the elision is verified by a grep against the production bundle (`scripts/check-elision.cjs`); the `data-rf2-source-coord` sentinel is part of the standard sentinel set.
 
-### JSX source-coord props (React DevTools "View source")
+### Historical: JSX source-coord props (removed — never worked)
 
-Alongside the `data-rf2-source-coord` DOM attribute, every React-substrate adapter MUST also inject the JSX-shaped source-coord props that React DevTools' "View source" gesture reads (per `@babel/plugin-transform-react-jsx-source`):
-
-```
-_jsxFileName     "src/my/app/cart.cljs"   ; required — full file path
-_jsxLineNumber   42                       ; required — integer line
-_jsxColumnNumber 1                        ; optional — integer column
-```
-
-The injection lands on the **same root element** as `data-rf2-source-coord` (same wrapper, same walk, same merge — not a separate code path). React DevTools' "View source" button uses these props to open the `reg-view` definition in the browser's Sources panel (or in the user's editor if React DevTools' editor-URL setting is configured); the gesture works natively against any registered view — no Xray-specific chip required.
-
-Both injection paths share a single elision gate: the JSX props ride the SAME `(when interop/debug-enabled? …)` branch that elides `data-rf2-source-coord`, so production builds (`:advanced` + `goog.DEBUG=false`) MUST NOT emit `_jsxFileName` / `_jsxLineNumber` / `_jsxColumnNumber` — the entire injection branch DCEs as a unit. Bundle isolation pins the contract (no `_jsxFileName` literal in the production bundle); per Spec 009 §Production builds, the gate is the load-bearing mechanism.
-
-When source coords were not captured (programmatic `reg-view*` without macro positions, or any registration whose metadata carries no `:file`/`:line`), the JSX props are omitted while `data-rf2-source-coord` still degrades to `<ns>:<sym>:?:?`. The two surfaces are independent at the per-call site level; one elision gate, two emission cases.
+> **Status: removed in rf2-rohdn (Option A).** An earlier version of this contract (rf2-fa4ly) called for the wrapper to ALSO inject the JSX-shaped source-coord props (`_jsxFileName` / `_jsxLineNumber` / `_jsxColumnNumber`) per `@babel/plugin-transform-react-jsx-source`, with the intent of making React DevTools' "View source" gesture jump to the `reg-view` definition.
+>
+> The feature never delivered. Two problems compounded:
+>
+> 1. Reagent passes these props through as DOM attributes (it does not route them to React.createElement's `__source` slot), so React's runtime emitted "does not recognize the `_jsx*` prop on a DOM element" console warnings for every annotated view's root.
+> 2. React DevTools does not read "View source" from element props anyway — it reads `__source` off `React.createElement`'s third argument, which is set by the Babel plugin at JSX-compile time and is not reachable from hiccup. So the DevTools gesture never lit up for re-frame2-registered views.
+>
+> Net effect: dev-console noise with no DevTools benefit. rf2-rohdn dropped the injection cleanly. The `data-rf2-source-coord` and `data-rf-view` DOM attributes (which DO work and are consumed by re-frame-pair, the view-walker, and IDE jump-to-source tooling) ride the same wrapper unchanged.
+>
+> If a future pass restores React DevTools "View source" integration, the correct path is to thread `__source` into the React element at element-creation time (cloneElement's third arg, or a substrate hook that participates in element construction) — not via element props.
 
 ### Documented exemption: non-DOM roots
 
@@ -420,15 +417,15 @@ The walker implementation lives at `tools/xray/src/day8/re_frame2_xray/views/vie
 
 ## React DevTools support (zero-config, dev-only)
 
-re-frame2 is Reagent-substrate-native (see §Reactive Substrate above). The framework MUST therefore make React DevTools — the industry-standard React-app inspection tool — work cleanly against any re-frame2 app. The three contracts below are framework-level; an app author opts into none of them, they fire by the same wrappers that handle the source-coord and view-tagging contracts.
+re-frame2 is Reagent-substrate-native (see §Reactive Substrate above). The framework MUST therefore make React DevTools — the industry-standard React-app inspection tool — work cleanly against any re-frame2 app. The two contracts below are framework-level; an app author opts into none of them, they fire by the same wrappers that handle the source-coord and view-tagging contracts.
 
 1. **Component display-name = registered view-id.** Every adapter's `reg-view` wrapper MUST stamp the React `displayName` of the wrapped component to `(str view-id)` so React DevTools' component tree shows `<:cart/total-line>` rather than the CLJS-munged function name or an anonymous Reagent wrapper. Reagent's class-component machinery reads `.-displayName` off the input fn and forwards it to the constructed component; React-hook substrates (UIx / Helix) set it directly on the wrapped function component. Gated on `interop/debug-enabled?` so the per-view id-string literal elides in production builds.
 
-2. **JSX source-coord props on the rendered root.** See §JSX source-coord props above — the same wrapper that injects `data-rf2-source-coord` also injects `_jsxFileName` / `_jsxLineNumber` / `_jsxColumnNumber`, which is what React DevTools' "View source" gesture reads to jump to the `reg-view` definition.
+2. **Frame-context display-name.** The React Context object backing the frame-provider (per §Frame-provider via React context below) MUST carry a `displayName` of `"rf2-frame"` so React DevTools' Context inspector shows the entry as `rf2-frame.Provider` rather than the opaque default `Context.Provider`. The label is deliberately distinct from any keyword namespace to keep the elision-bundle sentinel unambiguous. The assignment site sits inside `(when interop/debug-enabled? …)` so the string literal elides in production. The per-frame value (`:rf/default`, `:tenant/admin`, etc.) is already inspectable as the Context value — DevTools renders it as the keyword's `pr-str`.
 
-3. **Frame-context display-name.** The React Context object backing the frame-provider (per §Frame-provider via React context below) MUST carry a `displayName` of `"rf2-frame"` so React DevTools' Context inspector shows the entry as `rf2-frame.Provider` rather than the opaque default `Context.Provider`. The label is deliberately distinct from any keyword namespace to keep the elision-bundle sentinel unambiguous. The assignment site sits inside `(when interop/debug-enabled? …)` so the string literal elides in production. The per-frame value (`:rf/default`, `:tenant/admin`, etc.) is already inspectable as the Context value — DevTools renders it as the keyword's `pr-str`.
+Both sites share the standard `interop/debug-enabled?` elision gate and are subject to the bundle-isolation gate (no `displayName`-assignment branches, no Context display-name string in the production bundle). React DevTools is a dev-time inspection tool; the framework pays nothing for these affordances in production.
 
-All three sites share the standard `interop/debug-enabled?` elision gate and are subject to the bundle-isolation gate (no `displayName`-assignment branches, no `_jsxFileName` literals, no Context display-name string in the production bundle). React DevTools is a dev-time inspection tool; the framework pays nothing for these affordances in production.
+A third contract — JSX source-coord props for the "View source" gesture — was attempted in rf2-fa4ly and removed in rf2-rohdn (see §Historical: JSX source-coord props (removed — never worked) above). The framework no longer emits `_jsxFileName` / `_jsxLineNumber` / `_jsxColumnNumber`.
 
 ## Subscription cache — contract and operational semantics
 


### PR DESCRIPTION
Per **rf2-rohdn (Option A)**: drop the JSX-shaped source-coord prop injection (`:_jsxFileName` / `:_jsxLineNumber` / `:_jsxColumnNumber`) the `reg-view` wrapper used to add alongside `data-rf2-source-coord`. The feature, introduced in **rf2-fa4ly** with the intent of making React DevTools "View source" jump to the `reg-view` definition, never delivered:

1. Reagent passes these props through as DOM attributes — it does not route them to `React.createElement`'s `__source` slot. Result: React's runtime emits "does not recognize the `_jsx*` prop on a DOM element" console warnings for every annotated view's root in dev builds.

2. React DevTools' "View source" button does **not** read these from props anyway — it reads `__source` off `React.createElement`'s third arg, set by `@babel/plugin-transform-react-jsx-source` at JSX-compile time. The gesture never lit up for re-frame2 views.

**Net effect:** dev-console noise with no DevTools benefit. Discovered during **rf2-mw1c0** nightly-fix work (2026-05-28) when the noise broke the JSX-dev-prop console-error gate. Option A drops the injection cleanly — pre-alpha, no compat shim.

The `data-rf2-source-coord` and `data-rf-view` DOM attributes (which **do** work and are consumed by re-frame-pair, the view-walker, IDE jump-to-source tooling) ride the same wrapper unchanged.

## Changes

- `source_coord_annotation.cljs`: drop `jsx-source-props` defn + the `jsx-coords` param + merge logic in `inject-source-coord-attr`.
- `spine.cljs` (UIx/Helix path): drop `jsx-coords` from `inject-source-coord-attr` + `make-wrap-view`.
- `views.cljs`: drop `view-jsx-coords` helper + the `jsx-coords` thread-through `reg-view*` and `build-frame-aware-view`.
- `check-elision.cjs`: drop the `_jsxFileName` sentinel (40 sentinels instead of 41).
- `reg_view_devtools_cljs_test.cljs`: replace the four "JSX props injected" deftests with three regression deftests pinning their absence under macro + programmatic + user-supplied entry points.
- `reg_view_devtools_elision_prod_test.cljs`: re-purpose the prod deftests to assert `_jsx*` absence under prod-mode (now doubly-pinned: not emitted at all, **and** elided by the gate).
- `spec/006-ReactiveSubstrate.md`: replace the §JSX source-coord props normative section with a §Historical note explaining why; update §React DevTools support from three contracts to two.
- `ssr/html_helpers.cljc`: keep `strip-prop?` defensive entry for `_jsx*` props (third-party JSX-compiled libraries or hand-stamped DevTools shims may still produce hiccup carrying them); clarify the comment to say the framework no longer emits them.

If a future pass restores React DevTools "View source" integration, the correct path threads `__source` into the React element at element-creation time (`cloneElement`'s third arg, or a substrate hook participating in element construction) — not via element props.

## Quality gates

- `npm run test:cljs`: **0F/0E** (4835 tests, 15808 assertions).
- `npm run test:elision`: **PASS** (production 40/40 absent, control 40/40 present).
- `scripts/test-fast-pr.sh`: **PASS** (all spine gates green).
