### PR TITLE
docs(guide): rewrite outline + voice-test intro chapter (rf2-7fhok phase a+b)

### DIFF
--- a/docs/guide/01-introduction.md
+++ b/docs/guide/01-introduction.md
@@ -1,0 +1,145 @@
+# 01 — Introduction
+
+This chapter is your foot in the door. By the end of it you'll understand maybe 80% of the basics, you'll have run a real re-frame2 program in your browser without installing a single thing, and — if I've done my job — you'll have a working theory of *why* the framework is shaped the way it is, which is the part that actually sticks. The other 20% is the rest of the guide. The 80% is right here, and it's mostly one idea wearing several hats.
+
+## Let me tell you about the gravity well
+
+I want to start with a complaint, because that's how every good engineering essay starts, and because the complaint is load-bearing.
+
+For about ten years now — call it since hooks landed, though the rot set in earlier — the React world has organised itself around a single gravitational centre: the component. State? Lives in the component, in a `useState`. Data fetching? In the component, in a `useEffect`, or in some hook a library plumbed in. Routing? Hooks. Subscriptions to your store? A `useSelector`, which is a hook, which lives in — say it with me — the component. The component is the sun, and everything else is in orbit around it, and the orbit has been decaying *toward the sun* for a decade.
+
+And here's the thing: everyone knows this is a problem. That's the funny part. The entire history of React state management is a series of increasingly elaborate attempts to get state *out* of the component tree without anyone having to admit out loud that the component tree was the wrong place to put it. Redux showed up and said "fine, we'll have one store, off to the side, with reducers" — and it was *right*, it was genuinely a good idea, and then over the next five years the ecosystem slowly, lovingly, migrated all the Redux bits back into hooks because the gravity was just too strong. `useReducer`. `useContext`. "Co-location." MobX tried. Zustand showed up wearing a tiny disguise and pretending it wasn't going to attach state to components and then, well. Recoil, Jotai, signals, server components, the whole parade — every single one of them is, when you squint, another attempt to bolt state onto the component tree while maintaining deniability about it.
+
+I'm not even mad. It's a *reasonable* mistake. The component tree is the thing the framework can see, so the component tree is where everything ends up living. Water flows downhill. Effects colocate with views because views are what's legible to the runtime. It's not stupidity; it's gravity. But it means that in a mature React app, the answer to "where does this piece of state live?" is "somewhere in a tree of three hundred components, possibly in four of them, possibly out of sync between two of them, good luck," and the answer to "what changed it?" is a shrug and a debugger.
+
+re-frame — the original, the one this is the sequel to — looked at that gravity well in 2015 and said: no. We're not doing that. We're going to turn the whole thing inside out.
+
+## Inside out
+
+Here's the inversion, and it's the one idea the rest of the chapter is consequences of, so read it twice.
+
+**State is not in your views. State is in one place. Views are the last thing that happens, not the first.**
+
+In re-frame2 there is exactly one blob of application state, called `app-db`. It's an immutable map. (If you've used Redux: yes, it's the store. If you haven't: it's a big map holding everything your app knows.) Things happen — a click, a server reply, a timer fires, a websocket burps — and each of those becomes an **event**, which is just a little vector of data describing what happened. An **event handler** — a pure function, no funny business — takes the current `app-db` and the event and computes the *next* `app-db`. Then **subscriptions**, which are derivations, recompute the slices of state that views care about. Then, and only then, at the very end of the line, your **views** re-render to match.
+
+Notice what's *not* in that loop. There's no `useState`. There's no `useEffect`. There's no "lifting state up," because the state was never down in the components to begin with — there's nothing to lift. A view in re-frame2 is a render function over some reactive inputs that fires when its inputs change, and that is the *entire* job it has. It's not causal. It doesn't fetch. It doesn't own anything. It's derivative, in the precise sense that it is *derived from* state rather than being the home of state.
+
+This is the part that bites every React-shaped brain on first contact, so let me just say it plainly: **your views are going to be boring.** Gloriously, structurally, can't-get-this-into-a-weird-state boring. That's not a limitation we apologise for. That's the entire point. We took the most bug-infested real estate in your application — the place where state and effects and rendering all got tangled together — and we evicted everybody. Views render. Full stop.
+
+> *Your language of choice should be Turing complete; your architecture shouldn't be.*
+
+That's the snarky version of the thesis, and I'll stand behind it. ClojureScript, the language this is written in, is plenty Turing complete — go wild. But the *architecture* — the shape your app's behaviour flows through — is deliberately not a free-for-all. It's a small, fixed pipeline that every event walks through, the same way, every time. Which brings me to the dominoes.
+
+## A virtual machine made of dominoes
+
+Here's the framing that made it click for me, and I think it's the truest one: **a re-frame2 app is, quite literally, a little virtual machine.**
+
+The handlers you register are the instruction set. The events you dispatch are the instructions. The stream of events your app sees over its whole lifetime — every click, every reply, every tick — is, collectively, the program. And `app-db` is the machine's memory. That's not a cute analogy I'm stretching for a paragraph; it's structurally what's going on, and once you see it you can't unsee it.
+
+Every event runs through the same six-step pipeline. People draw it as a line of dominoes falling, because that's what it is — knock the first one over and the cascade runs to the end, deterministically, every time:
+
+```mermaid
+flowchart LR
+    E["1 · Event<br/>(something happened)"] --> H["2 · Effects<br/>handler runs (pure)"]
+    H --> FX["3 · Effects<br/>actioned by runtime"]
+    FX --> DB["4 · app-db<br/>new value swapped in"]
+    DB --> S["5 · Subscriptions<br/>recompute (derived)"]
+    S --> V["6 · Views<br/>re-render (hiccup)"]
+```
+
+One pass through that pipeline is one **epoch**. (The dominoes and the epoch are the same picture with two names; you'll hear both.) Pure data flows in at the left, pure data flows out, and at exactly *one* point — domino 3 — the runtime takes the data-described effects your handler asked for and actions them against the messy real world: fires the HTTP request, writes to localStorage, pushes the route. Everything else is just values turning into other values.
+
+I want to flag why that one-impure-spot discipline matters so much, because it's not aesthetics. When effects only happen at one known place, and they're *described as data* before they're actioned, then a single bus can watch the whole thing go by. Every event, every effect, every state transition, on one wire. That trace bus is what makes time-travel debugging possible. It's what lets you scrub your app backwards. It's what lets an AI pair-programmer attach to your *running* application and replay the exact cascade that broke. Six different tools — the devtools panel, the component playground, the MCP pair server, the linter, the migration agent, the log shipper — all read that one stream and tell consistent stories about it, *because there is one stream*. You don't get that surveillance state for free in an architecture where anything can change anything from anywhere. You get it precisely *because* you gave up that freedom. Less flexibility, more inspectability. That trade is the whole game.
+
+Okay. That's the theory. I promised you'd run something. Let's run something.
+
+## The smallest interesting program
+
+The smallest program worth writing is a counter: a number, a plus button, a minus button. Click plus, number goes up. It is *aggressively* unimpressive, and that's deliberate, because the shape we use to build this trivial thing is the *exact same shape* we'd use for a trading desk. If the small case feels clean, the large case will too. (And if the small case feels like ceremony — well, hold that thought, we'll come back to it.)
+
+Here's the whole thing, live. This is a real re-frame2 program running in your browser right now — there's no toolchain, no install, nothing hidden off-screen. Click into the cell, then hit **`Ctrl-Enter`** (or **`Cmd-Enter`** on a Mac) to evaluate it. The first run takes a second while the engine wakes up; after that it's instant. Then click the buttons.
+
+```cljs-rf2
+(require '[reagent2.core :as r]
+         '[re-frame.core :as rf])
+
+;; ---- Events: pure functions of (db, event) -> next db ----
+(rf/reg-event-db :counter/initialise
+  (fn [_db _event] {:counter/value 5}))
+
+(rf/reg-event-db :counter/inc
+  (fn [db _event] (update db :counter/value inc)))
+
+(rf/reg-event-db :counter/dec
+  (fn [db _event] (update db :counter/value dec)))
+
+;; ---- Subscription: a derivation from app-db ----
+(rf/reg-sub :counter/value
+  (fn [db _query] (:counter/value db)))
+
+;; ---- View: hiccup that subscribes and dispatches ----
+(defn counter []
+  [:div
+   [:button {:on-click #(rf/dispatch [:counter/dec])} "-"]
+   [:span {:style {:margin "0 1em" :font-size "1.4em"}}
+    @(rf/subscribe [:counter/value])]
+   [:button {:on-click #(rf/dispatch [:counter/inc])} "+"]])
+
+;; ---- Seed app-db, then hand the view back to be rendered ----
+(rf/dispatch-sync [:counter/initialise])
+[counter]
+```
+
+That's the entire program. Every line is load-bearing and every line is on the page. Roughly thirty lines, and four of those are comments. Let me walk it, because each piece is one of the things you came here to understand, and they're all *right there*.
+
+**The three events** are `reg-event-db` registrations. Each one maps an event id — `:counter/inc`, say — to a pure function. The function takes the current `db` and the event vector, and returns the *new* `db`. That's it. `:counter/inc` is `(fn [db _event] (update db :counter/value inc))` — read a state, return a state, no side effects, no DOM, no network, no `console.log`. The `_` prefixes mean "I'm ignoring this argument." `update` is the Clojure idiom for "transform the value at this key with this function," and crucially it returns a *new* map and leaves the old one alone. Immutability everywhere; nobody mutates `db` in place because *you can't*, it's a value.
+
+A thing to notice while it's in front of you: the ids are **namespaced**. `:counter/inc`, not `:inc`. Every event id starts with the feature it belongs to. In a thirty-line counter this looks like fussiness. In a thirty-thousand-line app it's the difference between "I can grep for everything the counter feature does" and "good luck." The habit costs nothing and starts now.
+
+**The subscription** is a derivation: a function from `app-db` to some value a view wants. Ours is the simplest one that exists — `(fn [db _query] (:counter/value db))`, just read the key. Why bother naming a derivation this trivial? Because once `:counter/value` is a registered, queryable *thing*, your view can ask for it without knowing where it lives in `app-db`. Move the value into some richer slice later and only the subscription changes; the view never notices. (Subscriptions also *chain* — you can build a `:counter/doubled` on top of `:counter/value` and the framework wires up the dependency graph so it only recomputes when something's actually looking. That's chapter 5's whole job. Park it.)
+
+**The view** is the only piece with real shape, and even it is boring on purpose. It's a function returning **hiccup** — a Clojure data structure that describes a DOM tree. `[:div ...]` is a `<div>`; `[:button {:on-click ...} "-"]` is a `<button>` with a click handler and the label `-`. Two interesting bits:
+
+- `@(rf/subscribe [:counter/value])` reads the current value of the subscription. The `@` is "unwrap this reactive thing to its current contents" — it's the hook that makes the view re-render when the value changes. The view doesn't poll, doesn't get told to update; it just declared a dependency and the runtime handles the rest.
+- `#(rf/dispatch [:counter/dec])` is the click handler. It puts the `:counter/dec` event on the queue and returns. That's *all* a click does in re-frame2 — it announces that something happened. It does not reach into state. It does not touch the DOM. It dispatches an event and walks away, and the cascade takes it from there.
+
+Notice the view never imperatively pokes a DOM node. There's no `element.textContent = ...`. It *declares what the screen should look like given the current state*, and the runtime makes the DOM match. That's the derivative-not-causal thing, made concrete: the view is a pure-ish function of subscription values, and it just so happens to paint pixels.
+
+**The last two lines** are the mount. `(rf/dispatch-sync [:counter/initialise])` runs the initialiser *synchronously and right now* — by the time the next line executes, `app-db` is `{:counter/value 5}`, so the first render shows `5` instead of flickering through empty. (`dispatch-sync` is the seed-before-render hammer; you'll reach for it at app boot and in tests, and almost nowhere else. Everywhere else, plain `dispatch` — fire and forget, let the runtime order things.) Then the bare `[counter]` hands the view back to be mounted.
+
+> **Try it.** In the cell above, change the `inc` in `:counter/inc` to `(partial + 10)`, re-evaluate (`Ctrl-Enter`), then click `+`. The counter now jumps by ten. You just changed your program's behaviour by editing one pure function — no rebuild, no reload, no ceremony. Now try adding a reset button: drop `[:button {:on-click #(rf/dispatch [:counter/initialise])} "reset"]` in among the others, re-evaluate, click `+` a few times, then `reset`. It snaps back to `5`. You added a feature by *dispatching an event that already existed.* No new handler. That's the shape paying off, in miniature.
+
+## What just happened, in slow motion
+
+When you clicked `+`, here is the cascade, all six dominoes, in order:
+
+1. The button's `:on-click` fired `(rf/dispatch [:counter/inc])`. The event — the vector `[:counter/inc]` — joined the queue. The click handler's job is now over.
+2. The runtime popped the event and ran the `:counter/inc` handler: it read `{:counter/value 5}`, returned `{:counter/value 6}`.
+3. There were no external effects to action this time — the only effect was "the new db" — so the runtime swapped `app-db`'s reference to the new value, atomically. One instant it's the old state, the next it's the new state, nothing in between for anyone to catch mid-update.
+4. The `:counter/value` subscription noticed its input changed and recomputed to `6`.
+5. The `counter` view, which had declared a dependency on that subscription via `@subscribe`, re-rendered. The new hiccup is `[:div [:button "-"] [:span 6] [:button "+"]]`.
+6. The runtime patched the DOM to match. The `<span>` now reads `6`.
+
+Five named steps you can point at, no surprises, no magic. The same cascade runs whether the app is this counter or something with ten thousand events an hour. *That's* the claim. The machine doesn't get more complicated as your app does; you just register more instructions.
+
+## "This is a lot of ceremony for a counter"
+
+Yeah. It is. I'm not going to pretend otherwise — a counter in plain React is `useState(5)` and two `onClick`s, and it's six lines, and here we are with thirty. If your whole app is a counter, use `useState`. Godspeed. Close the tab.
+
+But your whole app is not a counter, and the ceremony you're paying for here is *amortised over the entire lifetime of a real application*, which is where it stops being ceremony and starts being the only thing keeping you sane. Here's the actual claim, the one this whole guide is in service of:
+
+**The cost of adding a feature is bounded by the size of the feature, not the size of the app.**
+
+Sit with that, because it's the opposite of how most codebases age. In a normally-shaped app, adding a feature means first *reading a substantial fraction of the existing code* to figure out where on earth to wire it in, which components own the relevant state, which effects might fire, what'll break. The marginal cost of a feature grows with the app. That's the death spiral every large frontend eventually circles. In a re-frame2 app, you read the events, the subs, and the one view that touches the area you're changing — and that's *enough*, because there's nowhere else for the relevant logic to hide. State is in one place. Changes happen in one place. Effects are described as data in one place. The "extension" you tried above — adding reset by reusing an existing event — is the small version of that property. It scales up.
+
+So the counter is ceremony, and the ceremony is the point, and the point only becomes visible at scale. You'll have to take that partly on faith for now. The rest of the guide is me earning it back.
+
+## What you now know, and what's coming
+
+You came in cold and you've already got the spine of it: events are data describing what happened; handlers are pure functions computing the next state; `app-db` is the one place state lives; subscriptions derive what views need; views are boring derivative render functions; and the whole thing is a little virtual machine running every event through the same six-domino cascade. You ran it. You changed it. You added a feature to it. That's the 80%.
+
+The 20% is depth and breadth: what happens when a handler genuinely *needs* a side effect (you describe it as data — chapter 7); how subscriptions form a graph that's cheap when nobody's looking and fast when they are (chapter 5); how you test all of this with no browser and no mocks because the handlers are *just functions* (chapter 13); state machines for the flows where "what state are we even in?" is the real question (chapter 12); HTTP that survives contact with a flaky network (chapter 10); and the tooling that turns your running app into something you can scrub backwards through (chapter 17).
+
+Next door, [chapter 02](02-app-db.md) zooms all the way in on the one noun everything else orbits — `app-db` — because ten minutes understanding *where the data actually lives* saves you an afternoon of confusion later. After that, [chapter 03](03-first-app.md) builds this same counter for real, in a project, on your own toolchain, so you can stop borrowing my browser.
+
+A housekeeping note before you go: every line of code in this guide is ClojureScript. If you can already read a Lisp you're fine; if you can't, the [ClojureScript reading guide](../cljs/index.md) is a thirty-minute investment that gets you to "reads it but doesn't write it yet" comfort, which is all the guide assumes. You don't need to be able to *write* Clojure to follow along. You need to be able to look at `(update db :counter/value inc)` and read it left to right as "take db, transform the `:counter/value` key with `inc`." That's the bar. You just cleared it twice.

--- a/docs/guide/OUTLINE.md
+++ b/docs/guide/OUTLINE.md
@@ -1,0 +1,198 @@
+# Guide rewrite — chapter outline and sequence
+
+> **Status: phase (a)+(b) of the docs/guide rewrite — awaiting Mike's voice approval.**
+> This document is the proposed chapter list, sequence, and rationale for the from-scratch
+> rewrite of `docs/guide/`. The companion deliverable is one fully-written voice-test chapter
+> ([`01-introduction.md`](01-introduction.md)) — the tone-setter Mike reads to approve or reject
+> the voice before the full corpus (phase c) is written.
+>
+> This is an authoring artefact, not a reader page. It is excluded from the published nav.
+
+## What this rewrite is
+
+The current guide (chapters `02-app-db` through `26-config`) is competent, accurate, and
+LLM-shaped. It reads like a careful reference that someone gently narrativised after the fact:
+measured, even, allergic to a strong sentence, and bookended on every page by a "What's Next"
+section that does the table of contents' job for it. It is *correct*. It is not *alive*.
+
+The rewrite is a tutorial for **humans** — a person reading a story, not an agent parsing a
+contract. The voice is Steve Yegge's blog register: long-form-rant-as-engineering-essay,
+conversational, funny, opinionated-but-analytical, technically deep without being dry, digressive
+by design, and willing to start from a local complaint and expand it into a theory of software.
+The reference track (`/docs/api`, `/spec`) stays contract-shaped; the guide is the complement.
+
+## Structure rules (hard constraints — these govern every chapter)
+
+1. **Chapter files are `NN-name.md`.** Straight integer ordering, no `NNa-`/`NNb-` suffixes,
+   no gaps. The current guide starts at `02` with no `01`; the rewrite renumbers from `01`.
+2. **Every chapter opens with a 2-3 sentence problem/interest hook.** Not "Welcome to the chapter
+   on subscriptions." Instead: *"You like to sleep at night and you want to add unit tests? This
+   chapter teaches you the seam between event handlers and pure code."* The hook is the bait; it
+   names the reader's actual problem and the payoff for reading on.
+3. **No "What's Next" / "Next" / "Where this goes" section at the end of a chapter.** The chapter
+   ends when its point is made. The TOC carries onward-navigation; the prose does not need to.
+   Mid-chapter cross-links to other chapters are fine and encouraged — it's the *trailing
+   signpost section* that's banned.
+4. **Concepts before notation; notation reinforced by concrete example.** Name the idea, then show
+   the form, then run it.
+5. **Worked examples beat toy snippets beat prose.** Where an idea rewards being *changed and
+   re-run*, it gets a runnable live cell, not a static block.
+
+## The runnable-cell policy
+
+The guide has a live-cell capability: ` ```cljs-rf2 ` fences become editable CodeMirror editors
+that mount a real re-frame2 component in the reader's browser (see
+[Writing interactive tutorials](interactive-tutorials.md)). Not every chapter gets cells, and
+the ones that do don't get *walls* of them. A cell earns its place when editing-and-rerunning
+teaches more than reading would. The "Live cells" column below records the intent per chapter;
+where a chapter is marked **no**, a static block is the right call and a live cell would be a slow
+screenshot.
+
+Two cell rules the rewrite inherits from the existing interactive track and must honour:
+- Cells are functions-only: write `defn` views with explicit `rf/dispatch` / `rf/subscribe`,
+  not the `reg-view` macro. Note the equivalence in prose the first time it comes up.
+- Every cell is self-contained: its own `require`, registrations, app-db seed, and a final
+  renderable hiccup form. No cell depends on state left by an earlier cell.
+
+## The chapter list
+
+The guide is in four arcs. The arc boundaries are pedagogical, not structural — there's no
+"Part II" page; the reader just notices the terrain change.
+
+### Arc 1 — Foundations (the reader can build a real app after this arc)
+
+| # | File | The hook this chapter sells | Live cells |
+|---|---|---|---|
+| 01 | `01-introduction.md` | *Your foot in the door. By the end you understand 80% of the basics and have run a real re-frame2 program in your browser without installing a thing.* | **yes** — the whole counter, live |
+| 02 | `02-app-db.md` | *Where does the data actually live? In one place. This chapter is the one-sentence answer and all of its consequences.* | no |
+| 03 | `03-first-app.md` | *Build the counter for real — in a project, on your toolchain — and meet the five primitives that every re-frame2 app is made of.* | **yes** — counter, taken apart |
+| 04 | `04-events-and-the-cascade.md` | *A click happened. Now what? This chapter walks one event through all six dominoes and shows you the machine that runs under every re-frame2 app.* | **yes** — dispatch + trace |
+| 05 | `05-subscriptions.md` | *Your view needs to read state without knowing where it lives, and recompute only when it must. That's a subscription, and the graph behind it is where the performance comes from.* | **yes** — sub graph |
+| 06 | `06-views.md` | *Views are the least interesting part of the app, and that's the whole point. This chapter is why your render functions are boring, derivative, and impossible to get into a weird state.* | **yes** — hiccup + reaction |
+
+### Arc 2 — Doing real work (the reader can build a feature that talks to the world)
+
+| # | File | The hook this chapter sells | Live cells |
+|---|---|---|---|
+| 07 | `07-effects-and-coeffects.md` | *Your handler needs the current time, a random id, and to fire an HTTP request — but you swore it would stay pure. Effects and coeffects are how it stays pure and still gets things done.* | **yes** — fx as data |
+| 08 | `08-schemas.md` | *You want the app to scream the instant app-db goes wrong, in dev, and to cost exactly nothing in production. This chapter is the schema boundary and the off-switch.* | **yes** — validate at the seam |
+| 09 | `09-interceptors.md` | *Every event handler in your app should do the same three boring things before and after the interesting part. This chapter is how you write that once instead of three hundred times.* | no |
+| 10 | `10-http.md` | *Network calls are where naive apps go to die: retries, aborts, double-submits, the eight states of a request. This chapter is the one managed-effect shape that handles all of it as data.* | no |
+| 11 | `11-forms.md` | *A form is a tiny state machine wearing a trenchcoat: draft, dirty, submitting, failed, done. This chapter is the seven-event lifecycle that stops you reinventing it badly on every screen.* | **yes** — form lifecycle |
+| 12 | `12-machines.md` | *Some flows are not "set a flag" — they're "what state are we even in?" Wizards, auth, retries, the Nine States of every GUI. This chapter is when you reach for an actual state machine and why it's the same six dominoes underneath.* | **yes** — a small FSM |
+
+### Arc 3 — Confidence (the reader can trust, test, observe, and ship the app)
+
+| # | File | The hook this chapter sells | Live cells |
+|---|---|---|---|
+| 13 | `13-testing.md` | *You like to sleep at night and you want to add unit tests? This chapter teaches you the seam between event handlers and pure code — and why testing a re-frame2 app needs no browser, no mocks, and no patience.* | no |
+| 14 | `14-errors.md` | *Things break: a handler throws, the network 500s, the schema rejects, the server-rendered HTML disagrees with the client. This chapter is the difference between an error you can see in the trace and a white screen and a shrug.* | no |
+| 15 | `15-performance.md` | *Your app got slow and you have no idea why. This chapter is why re-frame2 is fast by default, the handful of ways you can sabotage that, and how the tooling tells you which one you did.* | no |
+| 16 | `16-observability.md` | *Every event your app has ever seen is on one bus, and six different tools read it. This chapter is the trace stream, the epoch buffer, and why your running app is the ultimate surveillance state.* | no |
+| 17 | `17-tooling.md` | *You could debug with println. Or you could scrub time backwards in a panel mounted inside your own app, click any trace event to the line that fired it, and let an AI replay the cascade that broke. This chapter is Xray, Story, and the pair tool.* | no |
+
+### Arc 4 — The wider world (the reader can build the whole thing, not just the SPA)
+
+| # | File | The hook this chapter sells | Live cells |
+|---|---|---|---|
+| 18 | `18-frames.md` | *You want two independent copies of your app on one screen — a Story canvas, a split-pane editor, a server render — that don't leak state into each other. This chapter is frames, the isolated context that makes that not a nightmare.* | no |
+| 19 | `19-routing.md` | *The URL is application state, your back button is a dispatch, and a route change is just an event. This chapter is routing without a router that fights your state model.* | no |
+| 20 | `20-server-side.md` | *You want server-rendered HTML that hydrates cleanly, runs your real handlers on the JVM, and doesn't make you learn a second mental model. This chapter is SSR as the same six dominoes, server-side.* | no |
+| 21 | `21-dynamic-model.md` | *Most app state isn't a flag — it's a thing with a lifecycle that the runtime should manage for you: machines, flows, route state, in-flight requests. This chapter is the dynamic model, the runtime-managed slices of app-db you read but don't write.* | no |
+| 22 | `22-adapters.md` | *Reagent, UIx, Helix, slim — same app, four substrates, one `init!` call that differs by a single Var. This chapter is what the adapter does and why your app code never names a substrate.* | no |
+| 23 | `23-privacy-and-large-things.md` | *Your auth token must not end up in a Datadog log, and a 40MB PDF must not end up in the trace buffer. This chapter is the `:sensitive?` and `:large?` elision story, opt-in and composable.* | no |
+| 24 | `24-config-and-safety.md` | *Every knob the framework exposes — what to validate, what to trace, what to elide, what to elide in production — in one place, with the safe defaults called out and the footguns flagged.* | no |
+| 25 | `25-from-re-frame-v1.md` | *You have a re-frame v1 app and a migration to plan. This chapter is what maps across cleanly, what changed and why, and where the v2 architecture tells a genuinely different story.* | no |
+| 26 | `26-where-to-go-next.md` | *You've read the guide. Here's the spec, the tooling docs, the skills, and the examples — the curated portal to everything the tutorial deliberately didn't cover.* | no |
+
+## Sequence rationale
+
+The didactic spine follows re-frame v1's proven sequence — *counter → cascade → subscriptions →
+views* — because it works: it front-loads the smallest complete program, then takes it apart in
+the order the reader will need the pieces. The rewrite deviates from v1 in three places where the
+v2 architecture changes the story, and the deviations are deliberate:
+
+**Why `01` is a live, hands-on introduction (not a prose overview).** The single best thing the
+guide can do in chapter one is get a real re-frame2 program *running in the reader's browser
+before they've installed anything*. The capability exists; v1 didn't have it. So chapter 01 folds
+together what the current guide splits across `README.md` (the philosophy), `02-app-db`, `03-first-app`,
+and `interactive-counter.md` (the live version) into one foot-in-the-door chapter that ends with
+the reader having clicked a counter they edited. The "80% of the basics" promise is the hook, and
+it's honest: after chapter 1 they've seen events, subscriptions, a view, dispatch, and the cascade,
+running. The deeper *why* of each is what arcs 1-2 are for.
+
+**Why effects/coeffects (07) come before HTTP (10) and after the core loop.** The current guide
+puts coeffects at `06`, before views. That's backwards for a human: the reader has no *motivating
+problem* for coeffects until they've felt the pain of wanting a side effect inside a pure handler.
+So the rewrite teaches the pure six-domino loop first (arcs 1), *then* introduces effects/coeffects
+(07) as the answer to "but my handler needs to do something impure" — and only then HTTP (10) as
+the worked, managed instance of an effect. Problem before machinery, every time.
+
+**Why frames, routing, and SSR move to arc 4.** The current guide front-loads frames (`08`) right
+after views. Frames are conceptually gorgeous and pedagogically premature — a reader who can't yet
+build a single app doesn't need to know how to run two isolated copies of one. The rewrite holds
+frames until the reader has a whole app under their belt and a *reason* to want isolation (Story
+canvases, split panes, server renders). Same logic moves routing and SSR late: they're "the wider
+world," not "the basics."
+
+**What the reader can build after each arc** — the milestone test for the sequence:
+
+- **After arc 1 (ch. 1-6):** a complete, correct, single-feature SPA — the counter and anything
+  shaped like it. Events, subscriptions, a view, the cascade. They understand the machine.
+- **After arc 2 (ch. 7-12):** a real feature that talks to the world — a form that validates,
+  submits over HTTP, retries, and is driven by a state machine where the flow warrants one. This is
+  the arc where re-frame2 stops being a toy and starts being a framework.
+- **After arc 3 (ch. 13-17):** an app they can *trust* — tested without a browser, observable on the
+  trace bus, debuggable in Xray, fast by default. The arc that turns "it works on my machine" into
+  "I can ship this."
+- **After arc 4 (ch. 18-26):** the whole system — multi-pane, routed, server-rendered, ported from
+  v1 if need be, running on whichever React substrate they like. Plus the portal to the spec for
+  when they want the contract.
+
+## Mapping from the current guide
+
+The rewrite is not a renaming pass; several current chapters merge, split, or move arcs. For the
+phase-c dispatch, here's the provenance so no content is silently dropped:
+
+| Rewrite chapter | Sourced / merged from current |
+|---|---|
+| 01 introduction | `README.md` (philosophy) + `interactive-counter.md` + opening of `03-first-app` |
+| 02 app-db | `02-app-db` |
+| 03 first app | `03-first-app` |
+| 04 events + cascade | `04-events` |
+| 05 subscriptions | subscription material currently split across `07-views` |
+| 06 views | `07-views` (view material) |
+| 07 effects + coeffects | `06-coeffects` + effects material from `04-events` |
+| 08 schemas | `05-schemas` |
+| 09 interceptors | `09-interceptors` |
+| 10 http | `12-http` |
+| 11 forms | `10-forms` |
+| 12 machines | `11-machines` |
+| 13 testing | `15-testing` |
+| 14 errors | `16-errors` |
+| 15 performance | `17-performance` |
+| 16 observability | `23-observability` |
+| 17 tooling | new — consolidates the Xray/Story/pair narrative the current guide scatters |
+| 18 frames | `08-frames` |
+| 19 routing | `18-routing` + `19-routing-ref` (ref folds in or moves to /api) |
+| 20 server side | `13-server-side` |
+| 21 dynamic model | `14-dynamic-model` |
+| 22 adapters | `21-adapters` |
+| 23 privacy + large things | `24-privacy` + `25-large-blobs` |
+| 24 config + safety | `26-config` |
+| 25 from re-frame v1 | `20-migration` |
+| 26 where to go next | `22-where-next` |
+
+Two current pages don't survive as chapters: `interactive-counter.md` folds into `01`, and the
+`interactive-tutorials.md` / `AUTHORING.md` contributor notes stay as contributor notes (not reader
+chapters, not in nav). `19-routing-ref` is reference-shaped and is a candidate to move to `/api`
+rather than live in the narrative track — flagged for Mike's call in phase c.
+
+## Phase plan
+
+- **(a) outline + sequence** — this document. ✅ delivered.
+- **(b) voice-test chapter** — [`01-introduction.md`](01-introduction.md), written fully in the
+  target voice as the tone-setter. ✅ delivered.
+- **(c) full-corpus rewrite** — one bead per chapter, filed only *after* Mike approves the voice and
+  the outline. Each phase-c bead inherits the four structure rules above and the per-chapter hook
+  seeded in the table.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ site_dir: site
 # that does install playground deps before building docs.
 exclude_docs: |
   tools/playground/
+  guide/OUTLINE.md
 
 # Build-time hooks. mkdocs_hooks.py rewrites guide/* cross-references
 # from ../../spec/ (correct for GitHub source-tree browsing, where spec/
@@ -154,6 +155,12 @@ nav:
     # navigation.indexes: the section label IS the Guide overview page (no
     # redundant "Overview" child) — see theme.features (rf2-qgpkm).
     - guide/README.md
+    # Rewrite phase a+b (rf2-7fhok): the voice-test introduction chapter slots
+    # in as the new chapter 01. The full integer renumber of the rest of the
+    # guide (02..26 below → the OUTLINE.md sequence) is phase c, gated on Mike's
+    # voice approval. For now 01 sits ahead of the current 02..26 to demonstrate
+    # where the rewritten chapters land in the nav.
+    - "01 — Introduction": guide/01-introduction.md
     - "02 — app-db": guide/02-app-db.md
     - "03 — First app": guide/03-first-app.md
     - "Interactive: the counter": guide/interactive-counter.md


### PR DESCRIPTION
## What this is

**Phase a+b** of the from-scratch `docs/guide` rewrite (rf2-7fhok). The mandate: the current guide is accurate but LLM-shaped — measured, flat, allergic to a strong sentence, and bookended by a "What''s Next" section on every page. The rewrite is a tutorial for **humans**, in Steve Yegge''s blog register.

This PR is **not** the rewrite. It is the two things Mike asked for before the bulk work starts:

1. **The outline** — `docs/guide/OUTLINE.md`
2. **One voice-test chapter** — `docs/guide/01-introduction.md`

Mike reads the voice + outline and approves/rejects **before** the full-corpus phase (c) is written.

## The outline (`docs/guide/OUTLINE.md`)

26 chapters in four pedagogical arcs, each with a one-line problem-hook seed and a live-cell intent flag:

- **Arc 1 — Foundations** (ch. 1-6): app-db, the counter, the six-domino cascade, subscriptions, views. After this arc the reader can build a complete single-feature SPA.
- **Arc 2 — Doing real work** (ch. 7-12): effects/coeffects, schemas, interceptors, HTTP, forms, machines. After this arc: a real feature that talks to the world.
- **Arc 3 — Confidence** (ch. 13-17): testing, errors, performance, observability, tooling. After this arc: an app they can trust and ship.
- **Arc 4 — The wider world** (ch. 18-26): frames, routing, SSR, dynamic model, adapters, privacy/large-things, config, v1 migration, where-to-go-next. After this arc: the whole system.

### Outline decisions worth your eye

- **Renumbered from `01`.** The current guide starts at `02` with no `01` and uses no a/b suffixes already — good — but the rewrite is a straight integer sequence from 01.
- **Chapter 01 is live and hands-on, not a prose overview.** It folds the current `README.md` philosophy + `interactive-counter.md` + the opening of `03-first-app` into one foot-in-the-door chapter that ends with the reader having clicked a counter they edited. v1 didn''t have live cells; we do, so chapter one uses them.
- **Coeffects/effects (07) move *after* the core loop, before HTTP.** The current guide teaches coeffects at `06`, before the reader has a motivating problem for them. Rewrite: pure loop first, then "but my handler needs a side effect" → effects/coeffects, then HTTP as the worked managed instance. Problem before machinery.
- **Frames, routing, SSR move to arc 4.** Currently frames sit at `08`, right after views — conceptually lovely, pedagogically premature. Held until the reader has a whole app and a *reason* to want isolation.
- **Provenance map included** so the phase-c dispatch drops no content — every current chapter is accounted for (merged, split, or moved). `interactive-counter.md` folds into 01; `19-routing-ref` flagged as a candidate to move to `/api` (reference-shaped).

The outline is excluded from the published nav (it''s an authoring artefact, added to `exclude_docs`).

## The voice-test chapter (`docs/guide/01-introduction.md`)

This is the deliverable to judge. It is the tone-setter, written fully in the Yegge register:

- Opens with the **gravity-well rant** (a decade of React state management trying to get state out of the component tree without admitting that''s the problem) and turns the local complaint into the inside-out thesis.
- The **six-domino virtual machine** framing, with a mermaid cascade diagram.
- One **runnable `cljs-rf2` counter cell** with a "try it" edit (change `inc` to `(partial + 10)`, add a reset button by reusing an existing event).
- The **cost-of-a-feature thesis** and an honest "this is a lot of ceremony for a counter" beat that earns the trade rather than dodging it.
- Honours every structure rule: `NN-name.md`, a 2-3 sentence problem-framing open ("Your foot in the door... 80% of the basics"), and **no trailing What''s-Next section**.

## Gates

- `mkdocs build --strict` — clean, zero warnings on the new files (run via `python -m mkdocs`; the `mkdocs` binary isn''t on PATH on Windows but the module is).
- `check_doc_slugs.py` + `check_readme_links.py` — pass.

## Status

**Phase a+b only.** One sample chapter, not the corpus. **rf2-7fhok stays OPEN** for phase c (the full rewrite), gated on Mike approving the voice and outline here.