### PR TITLE
fix(routing): apply :source-collapse to routing siblings — :rf/dispatch-origin → :source :router (rf2-llx2k)

### DIFF
--- a/implementation/routing/src/re_frame/routing.cljc
+++ b/implementation/routing/src/re_frame/routing.cljc
@@ -1110,9 +1110,9 @@
           ;; Per rf2-t1lxr / rf2-1ve9h: routing-internal dispatches
           ;; self-tag with :source :router so Xray's L2 timeline +
           ;; tools filter pills can discriminate framework-origin
-          ;; events from user-origin events. The prior parallel
-          ;; `:rf/dispatch-origin` axis was collapsed into `:source`
-          ;; per rf2-1ve9h (Mike-approved 2026-05-28).
+          ;; events from user-origin events. `:source` is the single
+          ;; closed-enum functional-origin axis on the dispatch
+          ;; envelope per rf2-1ve9h (Mike-approved 2026-05-28).
           (router/dispatch! [:rf.route.internal/on-match-error
                              {:error     error-map
                               :nav-token nav-token}]

--- a/implementation/routing/src/re_frame/routing/link.cljc
+++ b/implementation/routing/src/re_frame/routing/link.cljc
@@ -73,14 +73,18 @@
                                 ;; Per rf2-t1lxr: route-link click → :router
                                 ;; origin so the L2 epoch timeline tags the
                                 ;; resulting :rf/url-requested cascade as a
-                                ;; routing-substrate dispatch (not :user).
+                                ;; routing-substrate dispatch (not :ui). Per
+                                ;; rf2-1ve9h the single closed-enum
+                                ;; functional-origin axis is `:source` —
+                                ;; routing-internal dispatches stamp
+                                ;; `:source :router`.
                                 (router/dispatch!
                                   [:rf/url-requested
                                    (cond-> {:url url :to to}
                                      (seq params)   (assoc :params params)
                                      (seq query)    (assoc :query  query)
                                      fragment       (assoc :fragment fragment))]
-                                  {:rf/dispatch-origin :router})))))]
+                                  {:source :router})))))]
        (into [:a attrs] children))))
 
 (defn route-link-render-ssr

--- a/implementation/routing/src/re_frame/routing/on_match_error.cljc
+++ b/implementation/routing/src/re_frame/routing/on_match_error.cljc
@@ -139,13 +139,14 @@
                                                :cljs (some-> exception .-message))
                          :reason            "An :on-match event threw."}]
           ;; Per rf2-t1lxr: routing-internal dispatches self-tag with
-          ;; :rf/dispatch-origin :router so Xray's L2 timeline + tools
-          ;; filter pills can discriminate framework-origin events from
-          ;; user-origin events.
+          ;; :source :router so Xray's L2 timeline + tools filter pills
+          ;; can discriminate framework-origin events from user-origin
+          ;; events. Per rf2-1ve9h `:source` is the single closed-enum
+          ;; functional-origin axis on the dispatch envelope.
           (router/dispatch! [:rf.route.internal/on-match-error
                              {:error     error-map
                               :nav-token nav-token}]
-                            {:frame frame :rf/dispatch-origin :router}))))))
+                            {:frame frame :source :router}))))))
 
 ;; The façade (`re-frame.routing`) wires the listener via
 ;; `error-emit/register-error-listener! :rf.route/on-match-error-trap`

--- a/implementation/routing/test/re_frame/route_link_cljs_test.cljs
+++ b/implementation/routing/test/re_frame/route_link_cljs_test.cljs
@@ -68,9 +68,18 @@
   Captures the dispatched event via a trace callback. router/dispatch!
   enqueues asynchronously, so we read the queued-event trace
   (`:event/dispatched`) rather than polling the queue drain. This keeps
-  the test independent of the queue's drain timing."
+  the test independent of the queue's drain timing.
+
+  `:source` is the closed-enum functional-origin tag on the
+  `:rf.event/dispatched` trace (stamped from the envelope in
+  `emit-dispatched-trace!`); we surface it so callers can pin that the
+  route-link click stamps `:source :router` (rf2-t1lxr / rf2-1ve9h).
+  `:source` is hoisted to a top-level slot on every trace event
+  (re-frame.trace/build-event — Spec 009 §Core fields hoist contract),
+  not stamped under `:tags` on the success path."
   [props event]
   (let [dispatched (atom nil)
+        source     (atom nil)
         cb-key     (keyword (gensym "click-capture-"))]
     (trace-tooling/register-listener!
       cb-key
@@ -78,12 +87,14 @@
         (when (and (= :rf.event/dispatched (:operation ev))
                    (vector? (-> ev :tags :rf.event/v))
                    (= :rf/url-requested (-> ev :tags :rf.event/v first)))
-          (reset! dispatched (-> ev :tags :rf.event/v)))))
+          (reset! dispatched (-> ev :tags :rf.event/v))
+          (reset! source     (:source ev)))))
     (try
       (let [[_ attrs] (routing/route-link-render props)
             on-click (:on-click attrs)]
         (on-click event)
         {:dispatched @dispatched
+         :source     @source
          :prevented? (.-defaultPrevented event)
          :href       (:href attrs)})
       (finally
@@ -108,12 +119,18 @@
 (deftest plain-left-click-intercepts
   (testing "button 0 + no modifiers → preventDefault + :rf/url-requested"
     (rf/reg-route :route/cart {:path "/cart"})
-    (let [{:keys [dispatched prevented? href]}
+    (let [{:keys [dispatched source prevented? href]}
           (click! {:to :route/cart} (mk-event {}))]
       (is (= "/cart" href))
       (is prevented? "preventDefault was called on plain left-click")
       (is (= :rf/url-requested (first dispatched))
           "the dispatched event is :rf/url-requested")
+      ;; Per rf2-t1lxr / rf2-1ve9h: the route-link click stamps the
+      ;; closed-enum functional-origin axis `:source :router` so Xray's
+      ;; L2 timeline + filter pills tag the cascade as a
+      ;; routing-substrate dispatch, not :ui.
+      (is (= :router source)
+          "the route-link dispatch stamps :source :router (not :unknown / :ui)")
       (let [payload (second dispatched)]
         (is (= "/cart" (:url payload)))
         (is (= :route/cart (:to payload)))))))

--- a/implementation/routing/test/re_frame/routing_test.clj
+++ b/implementation/routing/test/re_frame/routing_test.clj
@@ -2589,6 +2589,48 @@
           ":rf.route/on-match-frame names the dispatching frame"))))
 
 ;; ============================================================================
+;; rf2-t1lxr / rf2-1ve9h — routing-internal dispatches stamp :source :router
+;; ============================================================================
+
+(deftest on-match-error-internal-dispatch-stamps-source-router
+  (testing "the routing-internal `:rf.route.internal/on-match-error`
+            dispatch stamps the closed-enum functional-origin axis
+            `:source :router` on its envelope (visible on the
+            `:rf.event/dispatched` trace) so Xray's L2 timeline + filter
+            pills discriminate framework-origin events from user-origin
+            events. Per rf2-t1lxr; per rf2-1ve9h `:source` is the single
+            closed-enum functional-origin axis on the dispatch envelope,
+            and `:source :router` is the routing discriminator."
+    (rf/reg-event-db :load/throw-source
+                     (fn [_db _]
+                       (throw (ex-info "source-boom" {:why :test}))))
+    (rf/reg-route :route/source-attributed
+                  {:path     "/source-attributed"
+                   :on-match [[:load/throw-source]]})
+    (rf/reg-fx :rf.nav/push-url
+               {:platforms #{:server :client}}
+               (fn [_ _] nil))
+    (let [traces (atom [])]
+      (rf/register-listener! ::on-match-source
+                             (fn [ev] (swap! traces conj ev)))
+      (rf/dispatch-sync [:rf.route/transitioned "/source-attributed"])
+      (rf/unregister-listener! ::on-match-source)
+      (let [internal-dispatch
+            (some (fn [ev]
+                    (and (= :rf.event/dispatched (:operation ev))
+                         (= :rf.route.internal/on-match-error
+                            (-> ev :tags :rf.event/v first))
+                         ev))
+                  @traces)]
+        (is (some? internal-dispatch)
+            "the on-match-error listener dispatched :rf.route.internal/on-match-error")
+        ;; `:source` is hoisted to a top-level slot on every trace event
+        ;; (re-frame.trace/build-event — Spec 009 §Core fields hoist
+        ;; contract), not stamped under `:tags`.
+        (is (= :router (:source internal-dispatch))
+            ":source :router rides on the routing-internal dispatch envelope")))))
+
+;; ============================================================================
 ;; rf2-5pyyl — :can-leave non-boolean → BLOCK + :rf.error/can-leave-non-boolean
 ;; ============================================================================
 


### PR DESCRIPTION
## Summary

Applies the rf2-1ve9h `:source`-collapse to the post-rf2-2yabr routing sibling files.

PR #2311 (**rf2-1ve9h**, Mike-approved Option A) collapsed the parallel `:rf/dispatch-origin` axis into the single closed-enum `:source` axis, adding `:router` (plus `:tool`, `:websocket`) to the enum. That PR landed against **pre-split** `routing.cljc`; during its rebase against #2309's routing-split (**rf2-2yabr**) the `routing.cljc` conflict was resolved by taking main's facade — leaving the post-split routing sibling files still carrying the stale `:rf/dispatch-origin :router` stamp the collapse should have removed.

## Changes

- **`routing/link.cljc`** — route-link click now stamps `{:source :router}` (was `{:rf/dispatch-origin :router}` — a key `build-envelope` ignores, so it silently fell through to `:source :unknown`).
- **`routing/on_match_error.cljc`** — on-match-error internal dispatch now stamps `{:frame frame :source :router}` (was `:rf/dispatch-origin`).
- **`routing.cljc` facade** — already stamped `:source :router` correctly; only its migration comment reworded.
- **Tests** — `route_link_cljs_test` pins the route-link click stamps `:source :router`; `routing_test` pins the on-match-error internal dispatch stamps `:source :router`. Both read the **hoisted top-level** `:source` slot on the `:rf.event/dispatched` trace (per `re-frame.trace/build-event` — the success path strips `:source` from `:tags` and hoists it top-level).

`:rf/dispatch-origin` is now grep-clean across the routing tree. The axis is retired with no compat alias (pre-alpha clean swap).

## Quality gates

- `cd implementation/routing && clojure -M:test` — 122 tests / 552 assertions, 0F/0E
- `npm run test:cljs` — 4836 tests / 15853 assertions, 0F/0E
- `cd tools/xray && clojure -M:test` — 953 tests / 3753 assertions, 0F/0E
- `scripts/test-fast-pr.sh` — PASS

## Out-of-scope finding (filed rf2-5uenf, P2)

The facade `routing.cljc` is a ~2354-line **monolith** with all logic inline and requires only the `match`/`url` siblings; the other 14 #2309 siblings are **orphaned dead code** (only cross-reference each other, not wired into the loaded artefact or any test). The #2311 rebase that "took main's facade" clobbered the post-#2309 thin facade with the pre-split fat monolith, effectively reverting the rf2-2yabr decomposition. This drift is exactly how the two copies diverged on `:source`/`:rf/dispatch-origin`. Filed **rf2-5uenf** for Mike to decide: re-apply the split (thin facade delegating to siblings) vs delete the orphans.

## Note on corpus-wide grep

`git grep ':rf/dispatch-origin'` is **routing-clean** but non-zero corpus-wide (18 files in core/machines/http/spec/tools/xray). Every remaining hit is a **deliberate retirement-witness** left by #2311 — past-tense migration comments, `(nil? … :rf/dispatch-origin)` absence-assertions, and spec prose documenting the collapse. None are live production stamps/reads. The axis is fully retired as a live envelope key; #2311 did not miss any live site outside routing.