### PR TITLE
fix(mcp-conformance): unhang pair-mcp gate — bound Playwright install + job with timeouts (rf2-e6enf)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1838,6 +1838,16 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.mcp_live == 'true'
     runs-on: ubuntu-latest
+    # rf2-e6enf — hard wall-clock cap on the WHOLE job. A healthy run is
+    # < 2 min (Playwright install ~20s, hermetic boot+conformance ~45s).
+    # Without this the job inherits GitHub's 360-min default, so when the
+    # `--with-deps` Playwright install wedges on the runner's apt/dpkg
+    # lock (the observed failure mode — see the step-level comment below)
+    # the gate sits "hung" for 15-75+ min until a human cancels, blocking
+    # the merge queue. 20 min gives a cold-Maven-cache run (no `~/.m2`
+    # restore hit) generous headroom while making any genuine hang a
+    # fast, re-runnable FAILURE rather than an open-ended block.
+    timeout-minutes: 20
     defaults:
       run:
         working-directory: tools/mcp-conformance
@@ -1942,11 +1952,43 @@ jobs:
         working-directory: implementation
         run: npm install --no-audit --no-fund
 
+      # rf2-f79t8 — cache the Playwright browser binary across runs (same
+      # shape as the cljs-browser jobs). On a hit, the install step below
+      # skips the ~120 MB Chromium download and only runs `--with-deps`
+      # (the apt system libs aren't cacheable). Keyed on the locked
+      # Playwright version so a bump busts it. rf2-e6enf added this job to
+      # the cache scheme — it previously re-downloaded Chromium every run.
+      - name: Cache Playwright browser binary
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('implementation/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
+      # rf2-e6enf — fast-fail the actual hang point. `--with-deps` runs
+      # `sudo apt-get install` for Chromium's system libraries; on a GHA
+      # runner that occasionally blocks indefinitely on the dpkg/apt lock
+      # held by the background `unattended-upgrades` job. The observed
+      # symptom (rf2-e6enf): this exact step never completed across four
+      # PRs simultaneously (#2304/#2311/#2316/#2324), each sitting 15-75+
+      # min — systemic/environmental, not per-diff. A healthy install is
+      # ~20s; 5 min covers a slow apt + cold (cache-miss) download while
+      # turning the lock-wait into a re-runnable FAILURE instead of an
+      # open-ended block.
       - name: Install Playwright chromium (for hermetic browser preload)
         working-directory: implementation
+        timeout-minutes: 5
         run: npx playwright install --with-deps chromium
 
+      # rf2-e6enf — backstop the orchestrator's own internal watchdog
+      # (HERMETIC_TIMEOUT_MS = 9 min in run-live-re-frame2-pair-overflow-hermetic.cjs,
+      # which `process.exit(2)`s on elapse). 12 min leaves margin for the
+      # process-tree teardown after that watchdog fires, so a wedged
+      # shadow-cljs JVM or orphaned Chromium can't hold the step open past
+      # the orchestrator's own cap.
       - name: Run re-frame2-pair-mcp live-overflow conformance (HERMETIC — spawns shadow-cljs)
+        timeout-minutes: 12
         run: npm run test:re-frame2-pair-live-overflow-hermetic
 
   mcp-conformance-story:

--- a/tools/mcp-conformance/scripts/run-live-re-frame2-pair-overflow-hermetic.cjs
+++ b/tools/mcp-conformance/scripts/run-live-re-frame2-pair-overflow-hermetic.cjs
@@ -98,6 +98,15 @@ const {
 const VERBOSE_TESTS = isVerboseTests();
 const DIAGNOSTICS = createDiagnosticBuffer();
 
+// Module-scope handle to the in-flight teardown closure (rf2-e6enf).
+// `main()` assigns this once it has spawned shadow-cljs / Chromium so
+// the hard watchdog below can tear those children down BEFORE
+// `process.exit` — without it, a watchdog-elapse would orphan the
+// shadow-cljs JVM (and a launched Chromium), and those orphans can keep
+// the CI step's inherited log pipes open past the node exit. Stays null
+// until the children exist; the watchdog null-guards it.
+let activeCleanup = null;
+
 // Shadow-cljs writes its nREPL port file under whichever cache-root
 // the build is configured for. Default in 3.x is `.shadow-cljs/`; older
 // configs used `target/shadow-cljs/`; nrepl itself drops `.nrepl-port`.
@@ -533,6 +542,10 @@ async function main() {
       }, 5000).unref();
     }
   };
+  // Expose the teardown to the module-scope hard watchdog (rf2-e6enf)
+  // so a watchdog-elapse kills shadow-cljs + Chromium rather than
+  // orphaning them.
+  activeCleanup = cleanup;
   for (const sig of ['SIGINT', 'SIGTERM', 'SIGHUP']) {
     process.on(sig, () => {
       logErr(`caught ${sig} — tearing down`);
@@ -732,10 +745,22 @@ async function main() {
 // Hard watchdog: if the orchestrator hangs past this, kill the process
 // so CI gets a deterministic failure instead of waiting on the job
 // timeout. Length set to cover cold Maven cache + cold chromium boot.
+//
+// Per rf2-e6enf: tear down shadow-cljs + Chromium BEFORE exiting. The
+// pre-fix watchdog called `process.exit(2)` directly, orphaning the
+// spawned JVM (and any launched Chromium); orphans that inherited the
+// step's stdio can keep the CI step's log pipes open past the node
+// exit, which is part of why the gate appeared to hang well past the
+// orchestrator's own cap. `activeCleanup` sends SIGTERM (then SIGKILL
+// via its own unref'd 5s timer); we hold the exit ~1s so the SIGTERM
+// lands before the process tears down, then exit regardless.
 const watchdog = setTimeout(() => {
   logErr(`watchdog timeout (${HERMETIC_TIMEOUT_MS}ms) — bailing`);
+  if (activeCleanup) {
+    try { activeCleanup(); } catch {}
+  }
   flushDiagnostics();
-  process.exit(2);
+  setTimeout(() => process.exit(2), 1000).unref();
 }, HERMETIC_TIMEOUT_MS);
 watchdog.unref();
 


### PR DESCRIPTION
## Problem

The `MCP conformance tools/re-frame2-pair-mcp (rf2-cum40)` CI check hung **15-75+ min** across four PRs simultaneously (#2304, #2311, #2316, #2324) before being cancelled. A healthy run is **< 2 min**.

## Root cause

Step-status across all four hung runs is identical:

```
✓ Run re-frame2-pair-mcp end-to-end MCP-client conformance
✓ Run re-frame2-pair-mcp live-overflow conformance (SKIPPED without nREPL)
✓ Install implementation deps (for playwright)
* Install Playwright chromium (for hermetic browser preload)   <-- stuck here
* Run re-frame2-pair-mcp live-overflow conformance (HERMETIC ...)
```

Every run stalls on **`npx playwright install --with-deps chromium`**, with the prior end-to-end / skip steps all green. `--with-deps` runs `sudo apt-get install` for Chromium's system libraries; on a GHA runner that occasionally blocks indefinitely on the dpkg/apt lock held by the background `unattended-upgrades` job. The job had **no `timeout-minutes`**, so it inherited GitHub's 360-min default and sat "hung" until a human cancelled.

This is **systemic / environmental, not per-diff** — it hit non-MCP PRs too, which confirms #2304's diff did not break the MCP server; the hang predates it.

In a healthy run (e.g. job 78215522148, 1m50s) that same install step completes in ~20s and the hermetic conformance in ~45s.

## Fix (shape b — fast-fail timeouts + flake-surface reduction)

- **Job-level `timeout-minutes: 20`** — healthy run < 2 min; 20 min covers a cold Maven-cache resolve while turning any genuine hang into a fast, re-runnable FAILURE instead of an open-ended merge-queue block.
- **`timeout-minutes: 5`** on the Playwright install step (the actual hang point; healthy ~20s).
- **`timeout-minutes: 12`** on the hermetic step, backstopping the orchestrator's own 9-min internal watchdog (`HERMETIC_TIMEOUT_MS`) plus teardown margin.
- **Add the `~/.cache/ms-playwright` binary cache** (rf2-f79t8, same shape as the `cljs-browser` jobs) — this job re-downloaded Chromium (~120 MB) every run.

Also hardened the hermetic orchestrator's hard watchdog: it now tears down shadow-cljs + Chromium **before** exiting (via a hoisted `activeCleanup`) instead of orphaning them — orphans that inherit the step's stdio can hold the CI step's log pipes open past the node exit.

## Verification (local)

- end-to-end conformance green (1s)
- live-overflow skip path green
- exec-safety unit tests green (8 pass / 4 Linux-only skips)
- hermetic conformance green (33s, 2 inner tests)
- a failed shadow boot fast-fails **with cleanup** (bounded, exit 2)
- fast PR spine green (4836 tests, 0 failures)

## Unblocks

This unblocks #2304 (its diff IS the MCP surface, so it needs the real gate to pass — now bounded).