### PR TITLE
refactor(machines-viz): MachineChart :overlays slot (rf2-7w4qr)

### DIFF
--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -66,15 +66,68 @@ registry).
 | `:show-minimap?` | no | `false` | When `true`, render xyflow's built-in MiniMap. |
 | `:show-controls?` | no | `true` | When `true`, render xyflow's built-in zoom/pan/fit Controls. |
 | `:show-background?` | no | `true` | When `true`, render xyflow's dot-pattern Background. |
-| `:after-ring-specs` | no | `nil` | rf2-uv1on. Optional vector of presentation-ready `:after`-timer ring-specs (each `{:node-id :fraction :color :cancelled? :tooltip :testid}`). When non-empty the chart mounts the `chart.overlays.after-rings` overlay as a sibling of the canvas; it walks the rendered node DOM to position each ring. The host owns the trace→spec projection + the scrubber-aware fraction. `nil` / empty → no overlay. |
-| `:after-ring-tick` | no | `nil` | Opaque value the host bumps to force the after-rings overlay to re-measure + repaint (Xray passes `now-ms`; Lock #8 — one rAF clock per chart, owned host-side). |
-| `:on-after-ring-hover` | no | `nil` | `(fn [node-id] ...)`. Hover-enter callback the overlay wires on each ring. |
-| `:on-after-ring-leave` | no | `nil` | `(fn [node-id] ...)`. Hover-leave callback the overlay wires on each ring. |
-| `:spawn-all-join` | no | `nil` | rf2-3ow55 (xyflow Phase 2). A presentation-ready `:spawn-all` join-spec — `{:node-id <string> :join <:all\|:any\|{:n N}\|{:fn _}> :children [{:key <kw> :done? :failed? :cancelled? :note}] :resolved? <bool?> :on-all-complete :on-any-failed}`. When present the chart mounts the `chart.overlays.spawn-all-join` inspector beside the spawn-all-bearing state, showing each spawned child + the join state. The host (Xray) projects the spec from its `:rf.machine.spawn-all/*` trace buffer; machines-viz owns only positioning + paint. `nil` → no inspector. |
-| `:on-spawn-child-click` | no | `nil` | `(fn [child-key] ...)`. Fires on a join-inspector child-row click; Xray pivots to the child instance. |
-| `:cancellation-cascade` | no | `nil` | rf2-3ow55 (xyflow Phase 2). A presentation-ready cascade-spec — `{:node-id <string> :parent-label <string?> :from-state <kw?> :steps [{:kind <:exit\|:destroy\|:abort\|:cleanup> :label <string> :note :delta-ms}]}`. When present (and `:steps` is non-empty) the chart mounts the `chart.overlays.cancellation-cascade` waterfall beneath the parent state, turning the scattered abort/destroy traces into one decision laid out vertically. The host projects the spec from the cancellation trace cluster. `nil` / no steps → dormant. |
-| `:overlay-tick` | no | `nil` | rf2-3ow55. Opaque value the host bumps to force the `:spawn-all` + cascade overlays to re-measure + repaint (mirrors `:after-ring-tick`). |
+| `:overlays` | no | `nil` | rf2-7w4qr. A **vector of host-fed overlay descriptor maps**, each keyed on `:id`. The single slot through which hosts compose the host-fed, spec+tick+callbacks overlay family (after-rings / spawn-all-join / cancellation-cascade) — collapses the former flat per-overlay props so a new overlay adds **one descriptor variant**, not 3–5 trunk props. The chart dispatches each descriptor to its already-modular rendering namespace by `:id` (`chart.cljs/render-overlay`); the renderers are unchanged. A per-descriptor `:tick` unifies the former `:after-ring-tick` + `:overlay-tick` (one rAF clock per chart stays host-owned — Lock #8 — just delivered per-overlay). A descriptor whose `:id` is outside the recognised set is **ignored** (a host data error, not a runtime fallback; dev builds emit a `js/console.warn`). Non-map entries are skipped. `nil` / `[]` → no overlays. See [§`:overlays` slot descriptor schema](#overlays-slot-descriptor-schema-rf2-7w4qr) for the multispec. |
 | `:testid` | no | `"rf-mv-chart"` | Root wrapper `data-testid` so tests + hosts can find the chart. |
+
+### `:overlays` slot descriptor schema (rf2-7w4qr)
+
+`MachineChart` exposes the host-fed, spec+tick+callbacks overlay family
+through a **single `:overlays` slot** — a vector of descriptor maps —
+rather than 3–5 flat trunk props per overlay. Mike ruled (rf2-7w4qr):
+adopt the slot. Hosts compose overlays through the slot; the trunk
+signature stays narrow as overlays are added.
+
+```clojure
+[viz/MachineChart
+ {:machine-id    :auth
+  :definition    defn
+  :current-state state
+  :overlays [{:id :after-rings :specs after-ring-specs :tick now-ms
+              :on-hover #(…) :on-leave #(…)}
+             {:id :spawn-all-join :spec spawn-all-spec :tick now-ms
+              :on-child-click #(…)}
+             {:id :cancellation-cascade :spec cascade-spec :tick now-ms}]}]
+```
+
+Each descriptor is a map keyed on `:id`. The chart dispatches it to its
+existing rendering namespace by `:id` (`chart.cljs/render-overlay`); the
+overlay renderers (`chart.overlays.after-rings` / `.spawn-all-join` /
+`.cancellation-cascade`) are unchanged — only the WIRING is lifted into
+the slot.
+
+**Multispec keyed on `:id`.** Common to every descriptor:
+
+| Key | Required | Meaning |
+|---|---|---|
+| `:id` | yes | The overlay kind. One of `#{:after-rings :spawn-all-join :cancellation-cascade}` (the closed set `chart.cljs/overlay-ids`). An `:id` outside this set is **ignored** — a host data error, not a runtime fallback; dev builds (`re-frame.interop/debug-enabled?`) emit a `js/console.warn`. |
+| `:tick` | no | Opaque value the host bumps to force the overlay to re-measure the DOM + repaint. One rAF clock per chart stays host-owned (Lock #8 — see [§One chart-level, visibility-gated animation clock](#one-chart-level-visibility-gated-animation-clock)); the clock just delivers its tick on the descriptor(s) it drives. Replaces the former flat `:after-ring-tick` + `:overlay-tick`. The always-on label-collisions overlay re-measures on the **first** non-nil descriptor `:tick`. |
+
+Per-`:id` variant keys:
+
+**`:id :after-rings`** (rf2-uv1on) — `:after`-timer countdown rings.
+
+| Key | Required | Meaning |
+|---|---|---|
+| `:specs` | yes | Vector of presentation-ready ring-specs, each `{:node-id :fraction :color :cancelled? :tooltip :testid}`. When non-empty the chart mounts the `chart.overlays.after-rings` overlay as a sibling of the canvas; it walks the rendered node DOM to position each ring. Empty / absent → the overlay is dormant. The host owns the trace→spec projection + the scrubber-aware fraction. |
+| `:on-hover` | no | `(fn [node-id] ...)`. Hover-enter callback the overlay wires on each ring. |
+| `:on-leave` | no | `(fn [node-id] ...)`. Hover-leave callback the overlay wires on each ring. |
+
+**`:id :spawn-all-join`** (rf2-3ow55) — `:spawn-all` join inspector.
+
+| Key | Required | Meaning |
+|---|---|---|
+| `:spec` | yes | Presentation-ready join-spec — `{:node-id <string> :join <:all\|:any\|{:n N}\|{:fn _}> :children [{:key <kw> :done? :failed? :cancelled? :note}] :resolved? <bool?> :on-all-complete :on-any-failed}`. When present (and `:node-id` is set) the chart mounts the `chart.overlays.spawn-all-join` inspector beside the spawn-all-bearing state. The host (Xray) projects the spec from its `:rf.machine.spawn-all/*` trace buffer; machines-viz owns only positioning + paint. No `:node-id` → dormant. |
+| `:on-child-click` | no | `(fn [child-key] ...)`. Fires on a join-inspector child-row click; Xray pivots to the child instance. |
+
+**`:id :cancellation-cascade`** (rf2-3ow55) — cancellation cascade waterfall.
+
+| Key | Required | Meaning |
+|---|---|---|
+| `:spec` | yes | Presentation-ready cascade-spec — `{:node-id <string> :parent-label <string?> :from-state <kw?> :steps [{:kind <:exit\|:destroy\|:abort\|:cleanup> :label <string> :note :delta-ms}]}`. When present (and `:node-id` is set and `:steps` is non-empty) the chart mounts the `chart.overlays.cancellation-cascade` waterfall beneath the parent state, turning the scattered abort/destroy traces into one decision laid out vertically. The host projects the spec from the cancellation trace cluster. No `:node-id` / no `:steps` → dormant. |
+
+A descriptor whose per-`:id` `:spec` / `:specs` is dormant (empty,
+missing `:node-id`, missing `:steps`) renders nothing — the same
+dormant behaviour the former flat props had when passed `nil`.
 
 ### Parallel-region rendering (rf2-lkwev, xyflow Phase 2)
 
@@ -543,8 +596,10 @@ The chart's click surface is `:on-state-click`, invoked with the
 clicked node's `path`; the host resolves source coords for that path
 against `(rf/machine-meta machine-id)` and opens the editor (per
 [Xray 003 §Source-coord integration](../../xray/spec/003-Machine-Inspector.md#source-coord-integration)).
-The overlay callbacks (`:on-spawn-child-click`, `:on-after-ring-hover`,
-`:on-after-ring-leave`) fire with the relevant child-key / node-id.
+The overlay callbacks — the `:on-child-click` on the `:spawn-all-join`
+descriptor and the `:on-hover` / `:on-leave` on the `:after-rings`
+descriptor (under the `:overlays` slot) — fire with the relevant
+child-key / node-id.
 
 ### What renders
 
@@ -600,25 +655,28 @@ For the supplied `:definition`, the chart shows:
   carries an `rf-mv-chart-state-entry` / `rf-mv-chart-state-exit`
   testid + the action name on a `data-entry` / `data-exit` attr.
 - **`:after` countdown rings (overlay, host-fed).** When the host
-  passes a non-empty `:after-ring-specs` vector the chart mounts the
+  passes an `{:id :after-rings :specs <vec> …}` descriptor in the
+  `:overlays` slot with a non-empty `:specs` vector the chart mounts the
   `chart.overlays.after-rings` overlay as a sibling of the canvas; it
   walks the rendered node DOM to position a filling arc on each source
-  state. The host owns the trace→spec projection and bumps
-  `:after-ring-tick` to repaint at up to 60Hz when the chart is visible
+  state. The host owns the trace→spec projection and bumps the
+  descriptor's `:tick` to repaint at up to 60Hz when the chart is visible
   (per [DESIGN-RATIONALE Lock #8](./DESIGN-RATIONALE.md)). The chart
   emits no `:spawn` / `:spawn-all` edge of its own.
 - **`:spawn-all` join inspector (overlay, host-fed).** When the host
-  passes a `:spawn-all-join` spec the chart mounts the
-  `chart.overlays.spawn-all-join` inspector beside the spawn-all-bearing
-  state, showing the spawned children + the join state. There is
-  deliberately no `spawn` topology edge — `:spawn` / `:spawn-all` are
-  state-entry actions, so spawned children surface through this overlay,
-  not as a row of nodes (per `chart.projection/choose-edge-type` and
+  passes an `{:id :spawn-all-join :spec <map> …}` descriptor in the
+  `:overlays` slot the chart mounts the `chart.overlays.spawn-all-join`
+  inspector beside the spawn-all-bearing state, showing the spawned
+  children + the join state. There is deliberately no `spawn` topology
+  edge — `:spawn` / `:spawn-all` are state-entry actions, so spawned
+  children surface through this overlay, not as a row of nodes (per
+  `chart.projection/choose-edge-type` and
   [Xray 003 §`:spawn-all` viz](../../xray/spec/003-Machine-Inspector.md#spawn-all-viz)).
-- **Cancellation cascade (overlay, host-fed).** When the host passes a
-  `:cancellation-cascade` spec with non-empty `:steps` the chart mounts
-  the `chart.overlays.cancellation-cascade` waterfall beneath the parent
-  state.
+- **Cancellation cascade (overlay, host-fed).** When the host passes an
+  `{:id :cancellation-cascade :spec <map> …}` descriptor in the
+  `:overlays` slot whose `:spec` carries non-empty `:steps` the chart
+  mounts the `chart.overlays.cancellation-cascade` waterfall beneath the
+  parent state.
 
 What does **not** render (the chart is presentation-only — the host
 supplies the data and decides on the callbacks):
@@ -646,9 +704,9 @@ surface to the prop the host derives from it.
 | `(rf/machine-meta machine-id)` | `:definition` — the registered topology (states, transitions, guards, actions). |
 | `[:rf/machines <id>]` slot in frame `app-db` | `:current-state` — the live `:state` driving the active highlight. |
 | `:rf.machine/transition` trace events | `:from-highlight` / `:to-highlight` — the focused-event lens. |
-| `:rf.machine.timer/scheduled` / `-fired` / `-stale-after` | `:after-ring-specs` (+ `:after-ring-tick`) — the countdown-ring overlay. |
-| `:rf.machine.spawn-all/started` / `-all-completed` / `-some-completed` / `-any-failed` | `:spawn-all-join` (+ `:overlay-tick`) — the join inspector overlay. |
-| cancellation trace cluster (`:rf.machine` abort / destroy events) | `:cancellation-cascade` (+ `:overlay-tick`) — the cascade overlay. |
+| `:rf.machine.timer/scheduled` / `-fired` / `-stale-after` | an `{:id :after-rings :specs … :tick …}` descriptor in `:overlays` — the countdown-ring overlay. |
+| `:rf.machine.spawn-all/started` / `-all-completed` / `-some-completed` / `-any-failed` | an `{:id :spawn-all-join :spec … :tick …}` descriptor in `:overlays` — the join inspector overlay. |
+| cancellation trace cluster (`:rf.machine` abort / destroy events) | an `{:id :cancellation-cascade :spec … :tick …}` descriptor in `:overlays` — the cascade overlay. |
 
 The host owns every trace→spec projection; the chart only positions and
 paints what it is handed. This keeps the chart testable in isolation and
@@ -825,10 +883,10 @@ prop groups:
   focused-event lens tint, the `:after` countdown-ring overlay, the
   `:spawn-all` join inspector, the cancellation cascade, and every
   other per-trace decoration. Derived solely from the decoration props
-  `:current-state`, `:from-highlight`, `:to-highlight`, `:sim?`,
-  `:after-ring-specs`, `:after-ring-tick`, `:spawn-all-join`,
-  `:cancellation-cascade`, and `:overlay-tick`. This plane is
-  **decorative**: changing it MUST NOT touch the topology plane.
+  `:current-state`, `:from-highlight`, `:to-highlight`, `:sim?`, and the
+  `:overlays` slot (each host-fed overlay descriptor + its per-descriptor
+  `:tick`). This plane is **decorative**: changing it MUST NOT touch the
+  topology plane.
 
 The decoration props MUST NOT participate in any computation whose
 output reaches the layout plane. The two planes share no caches.
@@ -836,9 +894,9 @@ output reaches the layout plane. The two planes share no caches.
 ### Highlight / overlay prop changes MUST change attrs/classes only
 
 A render driven by a change to any decoration prop (a new
-`:current-state`, `:from-highlight` / `:to-highlight`, an
-`:after-ring-tick` bump, a new `:spawn-all-join` / `:cancellation-cascade`
-spec, an `:overlay-tick` bump) MUST mutate **only**:
+`:current-state`, `:from-highlight` / `:to-highlight`, an `:overlays`
+descriptor `:tick` bump, a new / changed `:overlays` descriptor `:spec` /
+`:specs`) MUST mutate **only**:
 
 - DOM attributes (`class`, `style.opacity`, `style.transform` on
   decoration layers, SVG `stroke-dasharray` / `stroke-dashoffset`,
@@ -859,9 +917,9 @@ Such a render MUST NOT:
   inspector, the cascade) MAY mount and unmount; topology MUST NOT.
 - Mutate any value the topology plane recomputes from.
 
-A decoration-prop update arriving at 60Hz (e.g. an `:after-ring-tick`
-bump) MUST cost less than one paint frame end-to-end on the chart's
-hot path.
+A decoration-prop update arriving at 60Hz (e.g. an `:overlays`
+descriptor `:tick` bump) MUST cost less than one paint frame end-to-end
+on the chart's hot path.
 
 ### Layout-invalidation boundary is load-bearing
 
@@ -884,10 +942,9 @@ No other code path may invalidate layout. In particular:
 
 - A `:current-state` / `:from-highlight` / `:to-highlight` change
   MUST NOT reach the layout pipeline — it only re-tints existing nodes.
-- An `:after-ring-tick` / `:overlay-tick` bump or a new
-  `:after-ring-specs` / `:spawn-all-join` / `:cancellation-cascade`
-  spec MUST NOT reach the layout pipeline — these mount / repaint
-  decoration overlays only.
+- An `:overlays` descriptor `:tick` bump or a new / changed `:overlays`
+  descriptor `:spec` / `:specs` MUST NOT reach the layout pipeline —
+  these mount / repaint decoration overlays only.
 
 Implementations MUST place an explicit comment marking the
 layout-invalidation boundary as load-bearing in the code that owns
@@ -1003,9 +1060,8 @@ https://acme.example.com/path/to/viewer.html#machine=<base64-edn>
     (the share schema carries the state name only; there is no
     runtime `:data` to render).
   - `:read-only?` set to `true`, which no-op's `:on-state-click`.
-  - The decoration-overlay props (`:after-ring-specs`,
-    `:spawn-all-join`, `:cancellation-cascade`, the tick props) left
-    unset — a static share has no live trace bus to project them from.
+  - The `:overlays` slot left unset (`nil`) — a static share has no
+    live trace bus to project the host-fed overlay descriptors from.
 - A single banner at the top of the page reads: **"This is a
   static machine chart, not a Xray session — interactions are
   disabled."**

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
@@ -438,6 +438,90 @@
 (def ^:private node-types-memo (nodes/node-types))
 (def ^:private edge-types-memo (edges/edge-types))
 
+;; ---- :overlays slot (rf2-7w4qr) -----------------------------------------
+;;
+;; Mike ruled (rf2-7w4qr): the host-fed, spec+tick+callbacks overlay
+;; family is wired through ONE `:overlays` slot instead of a flat prop
+;; per overlay. Each descriptor is a map `{:id <keyword> …}` keyed on
+;; `:id`; the chart dispatches it to its already-modular rendering
+;; namespace (`chart.overlays.after-rings` / `.spawn-all-join` /
+;; `.cancellation-cascade`) by `:id`. This ns owns ONLY the wiring — the
+;; overlay renderers (their per-overlay shapes + DOM walk + paint) are
+;; untouched.
+;;
+;; The `:tick` story is unified: a per-descriptor `:tick` replaces both
+;; the old `:after-ring-tick` and `:overlay-tick`. One rAF clock per
+;; chart stays host-owned (Lock #8); the host just delivers the tick on
+;; whichever descriptor(s) the clock drives.
+;;
+;; What did NOT fold (stays on the trunk): `:fired-edge-ids` (a simple
+;; set, core to active-edge styling, not a spec+tick+callbacks overlay),
+;; `:current-state` / `:from-highlight` / `:to-highlight` (runtime
+;; highlight, not host-fed overlay specs), `:machine-data` (a corner
+;; panel rendered inline, not a positioned DOM-walking overlay), and all
+;; structural props (`:definition`, `:direction`, `:layout-options`,
+;; parallel handling).
+
+(def overlay-ids
+  "The closed set of recognised `:overlays` descriptor `:id`s. A
+  descriptor whose `:id` is outside this set is ignored (with a dev-only
+  console.warn — see `render-overlay`). Per spec/API.md §`:overlays`
+  slot."
+  #{:after-rings :spawn-all-join :cancellation-cascade})
+
+(defn- render-overlay
+  "Dispatch one `:overlays` descriptor to its rendering namespace by
+  `:id`, returning the overlay's hiccup (or nil when the descriptor is
+  dormant / its `:id` is unknown).
+
+  Per-overlay descriptor shapes (the renderers are unchanged — only the
+  wiring is lifted here, rf2-7w4qr):
+
+    {:id :after-rings          :specs <vec> :tick <opaque>
+                               :on-hover <fn> :on-leave <fn>}
+    {:id :spawn-all-join       :spec <map>  :tick <opaque>
+                               :on-child-click <fn>}
+    {:id :cancellation-cascade :spec <map>  :tick <opaque>}
+
+  An unknown `:id` is ignored (a host data error, not a runtime
+  fallback); in dev builds (gated on `interop/debug-enabled?`) it emits
+  a `js/console.warn` so the misconfigured host is visible without
+  failing the render."
+  [{:keys [id tick] :as descriptor}]
+  (case id
+    :after-rings
+    (let [{:keys [specs on-hover on-leave]} descriptor]
+      (when (seq specs)
+        [after-rings/AfterRingsOverlay
+         {:ring-specs specs
+          :tick       tick
+          :on-hover   on-hover
+          :on-leave   on-leave}]))
+
+    :spawn-all-join
+    (let [{:keys [spec on-child-click]} descriptor]
+      (when (and spec (:node-id spec))
+        [overlay-spawn-all/SpawnAllJoinOverlay
+         {:join-spec      spec
+          :tick           tick
+          :on-child-click on-child-click}]))
+
+    :cancellation-cascade
+    (let [{:keys [spec]} descriptor]
+      (when (and spec (:node-id spec) (seq (:steps spec)))
+        [overlay-cascade/CancellationCascadeOverlay
+         {:cascade-spec spec
+          :tick         tick}]))
+
+    ;; Unknown :id — ignore gracefully (dev-only warn).
+    (do
+      (when interop/debug-enabled?
+        (js/console.warn
+          "[machines-viz] MachineChart ignoring :overlays descriptor with"
+          "unknown :id" (pr-str id)
+          "— recognised ids:" (pr-str overlay-ids)))
+      nil)))
+
 ;; ---- MachineChart Reagent component -------------------------------------
 
 (defn MachineChart
@@ -513,48 +597,56 @@
                          built-in zoom/pan/fit Controls.
     :show-background?  — when true (default true) render xyflow's
                          dot-pattern Background.
-    :after-ring-specs  — rf2-uv1on. Optional vector of presentation-
-                         ready `:after`-timer ring-specs (each
-                         `{:node-id :fraction :color :cancelled?
-                         :tooltip :testid}`). When non-empty the chart
-                         mounts the `chart.overlays.after-rings`
-                         overlay as a sibling of the canvas; it walks
-                         the rendered node DOM to position each ring.
-                         The host owns the trace→spec projection +
-                         the scrubber-aware fraction (Xray supplies
-                         these from its trace buffer). nil / empty →
-                         no overlay layer.
-    :after-ring-tick   — opaque value the host bumps to force the
-                         overlay to re-measure the DOM + repaint the
-                         swept arcs (Xray passes `now-ms`; Lock #8 —
-                         one rAF clock per chart, owned host-side).
-    :on-after-ring-hover / :on-after-ring-leave — `(fn [node-id] ...)`
-                         hover callbacks the overlay wires on each ring.
-    :spawn-all-join    — rf2-3ow55. Optional presentation-ready
-                         `:spawn-all` join-spec (`{:node-id :join
-                         :children :resolved? :on-all-complete
-                         :on-any-failed}`). When present the chart
-                         mounts the `chart.overlays.spawn-all-join`
-                         inspector beside the spawn-all-bearing state;
-                         it shows the spawned children + join state.
-                         The host owns the trace→spec projection from
-                         its `:rf.machine.spawn-all/*` buffer. nil →
-                         no inspector.
-    :on-spawn-child-click — `(fn [child-key] ...)`; fires on a join-
-                         inspector child-row click (Xray pivots to
-                         the child instance).
-    :cancellation-cascade — rf2-3ow55. Optional presentation-ready
-                         cascade-spec (`{:node-id :parent-label
-                         :from-state :steps}`). When present (and the
-                         step list is non-empty) the chart mounts the
-                         `chart.overlays.cancellation-cascade`
-                         waterfall beneath the parent state. The host
-                         owns the trace→spec projection from the
-                         cancellation trace cluster. nil / no steps →
-                         dormant (no overlay).
-    :overlay-tick      — opaque value the host bumps to force the
-                         spawn-all + cascade overlays to re-measure +
-                         repaint (mirrors `:after-ring-tick`).
+    :overlays          — rf2-7w4qr. Optional vector of host-fed overlay
+                         DESCRIPTOR maps, each keyed on `:id`. Collapses
+                         the former flat overlay-wiring props (the
+                         `:after-ring-*` / `:spawn-all-*` /
+                         `:cancellation-cascade` / `:overlay-tick`
+                         family) into ONE slot; hosts compose overlays
+                         here instead of growing the trunk signature.
+                         The chart dispatches each descriptor to its
+                         already-modular rendering namespace by `:id`
+                         (`render-overlay`); the renderers are unchanged.
+                         A per-descriptor `:tick` unifies the old
+                         `:after-ring-tick` + `:overlay-tick` (one rAF
+                         clock per chart stays host-owned — Lock #8 —
+                         just delivered per-overlay). Unknown `:id` →
+                         ignored (dev-only console.warn). Recognised
+                         descriptors (see `render-overlay`):
+
+                           {:id :after-rings :specs <vec> :tick <opaque>
+                            :on-hover <fn> :on-leave <fn>}
+                             rf2-uv1on. Presentation-ready `:after`-timer
+                             ring-specs (each `{:node-id :fraction :color
+                             :cancelled? :tooltip :testid}`). When `:specs`
+                             is non-empty the chart mounts the
+                             `chart.overlays.after-rings` overlay as a
+                             sibling of the canvas; it walks the rendered
+                             node DOM to position each ring. The host owns
+                             the trace→spec projection + the scrubber-aware
+                             fraction; `:tick` (Xray's `now-ms`) drives the
+                             re-measure/repaint. Empty `:specs` → no overlay.
+
+                           {:id :spawn-all-join :spec <map> :tick <opaque>
+                            :on-child-click <fn>}
+                             rf2-3ow55. Presentation-ready `:spawn-all`
+                             join-spec (`{:node-id :join :children
+                             :resolved? :on-all-complete :on-any-failed}`).
+                             When `:spec` has a `:node-id` the chart mounts
+                             the `chart.overlays.spawn-all-join` inspector
+                             beside the spawn-all-bearing state. `:on-child-
+                             click` `(fn [child-key] ...)` fires on a child-
+                             row click (Xray pivots to the child instance).
+
+                           {:id :cancellation-cascade :spec <map>
+                            :tick <opaque>}
+                             rf2-3ow55. Presentation-ready cascade-spec
+                             (`{:node-id :parent-label :from-state :steps}`).
+                             When `:spec` has a `:node-id` and a non-empty
+                             `:steps` the chart mounts the
+                             `chart.overlays.cancellation-cascade` waterfall
+                             beneath the parent state. nil / no steps →
+                             dormant.
     :machine-data      — rf2-qo5xy. Optional CLJS map of the current
                          machine `:data` (`:rf.machine/data`). When
                          supplied the chart paints a small read-only
@@ -627,10 +719,7 @@
                  sim? on-state-click on-edge-click read-only?
                  direction layout-options density
                  height show-minimap? show-controls? show-background?
-                 after-ring-specs after-ring-tick
-                 on-after-ring-hover on-after-ring-leave
-                 spawn-all-join on-spawn-child-click
-                 cancellation-cascade overlay-tick
+                 overlays
                  machine-data
                  testid]
           :or   {direction         :tb
@@ -754,7 +843,16 @@
                                 (when (pos? n-regions)
                                   (str " across " n-regions " parallel "
                                        (if (= 1 n-regions) "region" "regions")))
-                                ".")]
+                                ".")
+                ;; rf2-7w4qr — the `:overlays` descriptor vector, with a
+                ;; unified tick. Per-descriptor `:tick` replaces the old
+                ;; flat `:after-ring-tick` + `:overlay-tick`; the always-
+                ;; on label-collisions overlay re-measures on the FIRST
+                ;; non-nil descriptor tick (one rAF clock per chart, Lock
+                ;; #8 — whichever overlay the host's clock drives shares
+                ;; its tick). nil when no host-fed overlay is ticking.
+                overlay-descriptors (filterv map? overlays)
+                overlays-tick       (some :tick overlay-descriptors)]
             [:div {:data-testid testid
                    :data-machine-id (str machine-id)
                    :data-node-count (str n-states)
@@ -892,45 +990,23 @@
                              :pannable true
                              :nodeColor (fn [_] (:bg-3 tokens/tokens))
                              :maskColor (tokens/with-alpha :bg-0 0.6)}])]
-             ;; rf2-uv1on — `:after`-timer countdown rings. The overlay
-             ;; is a sibling of the xyflow canvas inside this
-             ;; position:relative wrapper; it walks the rendered node DOM
-             ;; (`rf-mv-chart-node-<id>`) to position each ring. Hosts
-             ;; that want rings pass presentation-ready `:after-ring-specs`
-             ;; (see `chart.overlays.after-rings`); the host owns the
-             ;; trace→spec projection + the rAF clock that bumps
-             ;; `:after-ring-tick` (Lock #8 — one clock per chart). Xray
-             ;; mounts the same overlay via its `machine_canvas` wrapper;
-             ;; this prop path serves standalone hosts (viewer, Story).
-             (when (seq after-ring-specs)
-               [after-rings/AfterRingsOverlay
-                {:ring-specs after-ring-specs
-                 :tick       after-ring-tick
-                 :on-hover   on-after-ring-hover
-                 :on-leave   on-after-ring-leave}])
-             ;; rf2-3ow55 — `:spawn-all` join inspector. Same
-             ;; sibling-overlay shape as the after-rings overlay: it
-             ;; walks the node DOM to anchor a join-state card beside
-             ;; the spawn-all-bearing state. The host projects the
-             ;; presentation-ready join-spec from its
-             ;; `:rf.machine.spawn-all/*` trace buffer.
-             (when (and spawn-all-join (:node-id spawn-all-join))
-               [overlay-spawn-all/SpawnAllJoinOverlay
-                {:join-spec      spawn-all-join
-                 :tick           overlay-tick
-                 :on-child-click on-spawn-child-click}])
-             ;; rf2-3ow55 — cancellation-cascade visualiser. Dormant
-             ;; unless the host supplies a cascade-spec with steps;
-             ;; when a parent transition cancels children the host
-             ;; projects the cascade from the cancellation trace
-             ;; cluster and the overlay paints the waterfall beneath
-             ;; the parent state.
-             (when (and cancellation-cascade
-                        (:node-id cancellation-cascade)
-                        (seq (:steps cancellation-cascade)))
-               [overlay-cascade/CancellationCascadeOverlay
-                {:cascade-spec cancellation-cascade
-                 :tick         overlay-tick}])
+             ;; rf2-7w4qr — host-fed overlays, composed through the
+             ;; single `:overlays` slot. Each descriptor map (keyed on
+             ;; `:id`) is dispatched to its rendering namespace by
+             ;; `render-overlay` (after-rings / spawn-all-join /
+             ;; cancellation-cascade); the renderers are unchanged — only
+             ;; the wiring is lifted here. Every overlay is a sibling of
+             ;; the xyflow canvas inside this position:relative wrapper
+             ;; and walks the rendered node DOM (`rf-mv-chart-node-<id>`)
+             ;; to anchor itself; the host owns the trace→spec projection
+             ;; + the per-descriptor `:tick` (Lock #8 — one rAF clock per
+             ;; chart). Dormant descriptors + unknown `:id`s render nil.
+             (map-indexed
+               (fn [i descriptor]
+                 ^{:key (str "rf-mv-overlay-" i "-"
+                             (pr-str (:id descriptor)))}
+                 [render-overlay descriptor])
+               overlay-descriptors)
              ;; rf2-r7vsr — post-render label-collision avoidance.
              ;; Sibling overlay that walks the rendered DOM after
              ;; xyflow paints, finds every label that intersects a
@@ -948,7 +1024,7 @@
              ;; labels, and clean layouts measure zero collisions
              ;; (the overlay is a no-op).
              [label-collisions/LabelCollisionsOverlay
-              {:tick (or after-ring-tick overlay-tick)}]
+              {:tick overlays-tick}]
              ;; rf2-qo5xy — `:machine-data` corner panel. The Stately
              ;; graph view paints the machine's current `:data` /
              ;; context as a top-left panel so the operator reads it


### PR DESCRIPTION
**Mike ruled: adopt the `:overlays` slot (rf2-7w4qr).**

`MachineChart`'s trunk signature had grown a flat prop (or 3–5) per visualization overlay. This collapses the **host-fed, spec+tick+callbacks overlay family** into a single `:overlays` slot — a vector of descriptor maps keyed on `:id`.

```clojure
[viz/MachineChart
 {:machine-id :auth :definition def :current-state state
  :overlays [{:id :after-rings :specs after-ring-specs :tick now-ms
              :on-hover #(…) :on-leave #(…)}
             {:id :spawn-all-join :spec spawn-all-spec :tick now-ms
              :on-child-click #(…)}
             {:id :cancellation-cascade :spec cascade-spec :tick now-ms}]}]
```

### Prop-surface before/after

**Folded into `:overlays` (7 flat trunk props removed):**

| Old flat prop(s) | New descriptor |
|---|---|
| `:after-ring-specs`, `:after-ring-tick`, `:on-after-ring-hover`, `:on-after-ring-leave` | `{:id :after-rings :specs :tick :on-hover :on-leave}` |
| `:spawn-all-join`, `:on-spawn-child-click` (+ shared `:overlay-tick`) | `{:id :spawn-all-join :spec :tick :on-child-click}` |
| `:cancellation-cascade` (+ shared `:overlay-tick`) | `{:id :cancellation-cascade :spec :tick}` |

The per-descriptor `:tick` **unifies** the former `:after-ring-tick` + `:overlay-tick` — one rAF clock per chart stays host-owned (Lock #8), just delivered per-overlay. Net: **−7 flat props, +1 slot**, and a new overlay now adds one descriptor variant rather than 3–5 trunk props.

The chart dispatches each descriptor to its **existing** rendering namespace by `:id` via a new `render-overlay` fn; the overlay renderers (`chart.overlays.after-rings` / `.spawn-all-join` / `.cancellation-cascade`) are **unchanged** — only the wiring was lifted. Unknown `:id` → ignored gracefully with a dev-only `js/console.warn` (gated on `interop/debug-enabled?`). Non-map entries are skipped. Pre-alpha stance: the flat props are removed outright, no back-compat shim.

### Fold-boundary call

Following the bead's recommendation, only the **host-fed, spec+tick+callbacks overlay family** folded. Stayed on the trunk:

- `:fired-edge-ids` — a simple set, core to active-edge styling, not a spec+tick+callbacks overlay.
- `:current-state` / `:from-highlight` / `:to-highlight` / `:sim?` — runtime-highlight plane, not host-fed overlay specs.
- `:machine-data` — an inline top-left corner panel, not a positioned DOM-walking overlay.
- All structural props (`:definition`, `:direction`, `:layout-options`, parallel-region handling).

### Call-site migrations

**None required.** A repo sweep confirmed the flat overlay props had **no live consumer** outside `chart.cljs` itself + the spec:

- Xray's `panels/machine_canvas.cljs` `Chart` (the Machine Inspector host) never passed them — it mounts its own `panels/machine_after_rings` overlay as a sibling and forwards only `:definition` / `:machine-id` / highlight / `:fired-edge-ids` / `:sim?` / click / show-* / `:testid`. Its `cancellation_cascade_*` namespaces are a separate Xray popover panel, **not** the chart's `:cancellation-cascade` prop.
- The machines-viz viewer (`viewer.cljs`) passes a whole share-payload props map through; the share schema never carries overlay props.
- No Story renderer or testbed passed them.

**Xray spec unchanged — no Xray-owned contract changed (consumer-side surfaces don't reference these props).**

### Spec lockstep

`tools/machines-viz/spec/API.md` (same commit):
- Props table: collapsed the 7 folded rows into one `:overlays` row.
- New **§`:overlays` slot descriptor schema (rf2-7w4qr)** — a multispec keyed on `:id` documenting the common keys (`:id`, `:tick`) + per-`:id` variant keys.
- Updated the decoration-plane, layout-invalidation-boundary, data-sources, what-renders, callbacks, and read-only-viewer sections to reference the slot.

### Quality gates

- `npm run test:cljs` (node CLJS) — **4836 tests / 15853 assertions, 0 failures, 0 errors**. Build: 1069 compiled, 0 warnings.
- `npm run test:browser` (Playwright, mounts the real `MachineChart` + overlay siblings, incl. `chart_dom_cljs_test`) — **126 tests / 357 assertions, 0 failures, 0 errors**. (One pre-existing unrelated `:infer-warning` in `react_shared_suite.cljs`.)
- `clj-kondo --lint chart.cljs` — 0 errors, 0 warnings.
