### PR TITLE
feat(adapters/test-react): organic child-mount + ported lifecycle regressions (rf2-n2cuo)

### DIFF
--- a/implementation/adapters/README.md
+++ b/implementation/adapters/README.md
@@ -12,7 +12,7 @@ This directory groups re-frame2's **substrate adapters** — implementations of 
 | [`uix/`](uix/) | UIx adapter | `day8/re-frame2-uix` | UIx 2.x — modern hooks-based React layer |
 | [`helix/`](helix/) | Helix adapter | `day8/re-frame2-helix` | Helix 0.2.x — minimal React wrapper |
 | [`reagent-slim/`](reagent-slim/) | Reagent-slim adapter | `day8/re-frame2-reagent-slim` (NB: artefact coord is `day8/reagent-slim` per IMPL-SPEC DECISION-1) | Reagent rewrite for React 19 — Stage 4 landed (full `reagent2.*` rewrite) |
-| [`test-react/`](test-react/) | Test-React adapter | `day8/re-frame2-test-react` | Pure-CLJC React class-3 lifecycle simulator — unit-testable lifecycle bug catching (rf2-gqyqv placeholder skeleton) |
+| [`test-react/`](test-react/) | Test-React adapter | `day8/re-frame2-test-react` | Pure-CLJC React class-3 lifecycle simulator — unit-testable lifecycle bug catching; carries ported regressions incl. the organic rf2-4l7t2 sync-unmount-during-render repro (rf2-gqyqv skeleton, broadened rf2-n2cuo) |
 
 A consumer picks one (or more) by adding the matching artefact to their `deps.edn` alongside `day8/re-frame2`. Bundle isolation is **structural** — the wrong adapter is absent from the classpath, not eliminated by dead-code analysis. See [Conventions §Substrate-adapter shipping convention](../../spec/Conventions.md).
 

--- a/implementation/adapters/test-react/README.md
+++ b/implementation/adapters/test-react/README.md
@@ -1,6 +1,6 @@
 # Test-React adapter
 
-Maven artefact: `day8/re-frame2-test-react`. Public ns: `re-frame.adapter.test-react`. Status: **minimal viable skeleton** (rf2-gqyqv, P4 placeholder).
+Maven artefact: `day8/re-frame2-test-react`. Public ns: `re-frame.adapter.test-react`. Status: **carries ported lifecycle regressions** (rf2-gqyqv skeleton, broadened under rf2-n2cuo). The headline rf2-4l7t2 sync-unmount-during-render bug is now reproduced *organically* (a child/sibling render body trips the guard), not via fabricated in-flight state.
 
 A substrate adapter that simulates React class-3 lifecycle (constructor → did-mount → did-update → will-unmount) in pure CLJC. **No React, no DOM, no jsdom** — runs on the JVM and on Node-CLJS at unit-test speed.
 
@@ -11,25 +11,36 @@ Purpose: catch React-lifecycle-driven bugs at unit-test speed without spinning u
 | Bug class | Caught by plain-atom? | Caught by Test-React? | Caught by Playwright? |
 |---|---|---|---|
 | Stale closures in event handlers | yes (sub computation) | yes | yes |
-| Unbalanced subscribe / dispose | partial | yes (mount/unmount asserts) | yes |
-| Double-render | no | yes (render counter on log) | yes |
-| Sync unmount during render (rf2-4l7t2) | no | **yes** (see note) | yes (slow) |
+| Unbalanced subscribe / dispose | partial | **yes** (live-mount / ref-count imbalance) | yes |
+| Double-render | no | **yes** (extra `:render` / `:did-update` on the log) | yes |
+| Sync unmount during render (rf2-4l7t2) | no | **yes** (organic — see note) | yes (slow) |
 | Real DOM measurement / event listeners | no | no | yes |
 | Real React reconciler quirks | no | no | yes |
 
-If your bug class lives in the leftmost four rows and the seminal symptom is "React threw / logged a warning during a lifecycle transition," reach for the Test-React adapter. If the bug only manifests with a real DOM, real React, or real browser timing, stay on Playwright.
+The three **bold** rows carry living regressions in
+`test/re_frame/adapter/test_react_test.cljc` (ported under rf2-n2cuo) — each
+asserts the bug's *symptom* (the error raised / the imbalance / the extra
+render), so a future regression in that class fails the unit test. If your bug
+class lives in the leftmost four rows and the seminal symptom is "React threw /
+logged a warning during a lifecycle transition," reach for the Test-React
+adapter. If the bug only manifests with a real DOM, real React, or real browser
+timing, stay on Playwright.
 
-> **Note on the sync-unmount-during-render row.** The simulator's guard
-> (`:currently-rendering?` → throw on synchronous `unmount!`) is *logic*
-> the adapter enforces correctly, but in this skeleton it is reachable
-> only via **fabricated** in-flight state — a test sets
-> `:currently-rendering?` true by hand to stand in for the production state.
-> Because children are not recursively mounted (see "What this skeleton does
-> NOT cover"), there is no child render-body from which a re-entrant
-> `unmount!` can fire organically. The guard becomes organically reachable
-> once recursive child mounting lands; until then the "**yes**" above means
-> "the guard logic is verified," not "the bug condition is reproduced
-> without test setup."
+> **Note on the sync-unmount-during-render row.** The guard is now reachable
+> **organically** — no fabricated in-flight state. A render tree may declare an
+> imperative body via the node shape `{:rf/component (fn [mount] ...)}`; the
+> body runs while a render is in flight and can mount children (via
+> `mount-child!`) or issue an `unmount!`. The regression
+> `organic-sync-unmount-during-render-rf2-4l7t2` models the real Story senbl
+> panel-host: a host re-renders to switch panels and, *from inside that render
+> body*, synchronously unmounts the previous panel's separately-tracked root.
+> The guard fires because React (the global render depth) is rendering
+> somewhere — the same condition React 18+ keys off, and the cross-root case
+> the old per-mount `:currently-rendering?` flag could not see. The companion
+> `deferred-unmount-after-render-is-safe-rf2-4l7t2-fix` proves the guard
+> discriminates in-render from after-render (the microtask-defer fix), so it is
+> not a blunt always-throw. The "**yes**" above now means "the bug condition is
+> reproduced," not merely "the guard logic is verified."
 
 ## Why a separate adapter instead of extending plain-atom
 
@@ -53,7 +64,26 @@ If your bug class lives in the leftmost four rows and the seminal symptom is "Re
          (mapv :phase (test-react/lifecycle-log mount)))))
 ```
 
-The `mount!` / `trigger-update!` / `unmount!` trio drive the simulator. The test owns the clock — there is no auto-re-render on app-db change in the current skeleton (tests call `trigger-update!` explicitly after a dispatch settles). The adapter's own demonstration tests (`test/re_frame/adapter/test_react_test.cljc`) install/dispose the adapter directly via `re-frame.substrate.adapter` in a per-test `:each` fixture; nothing forces you to use `re-frame.test-support/make-reset-runtime-fixture`, though that helper works here just as it does for the production adapters.
+The `mount!` / `trigger-update!` / `unmount!` trio drive the simulator. The test owns the clock — there is no auto-re-render on app-db change (tests call `trigger-update!` explicitly after a dispatch settles). The adapter's own tests (`test/re_frame/adapter/test_react_test.cljc`) install/dispose the adapter directly via `re-frame.substrate.adapter` in a per-test `:each` fixture; nothing forces you to use `re-frame.test-support/make-reset-runtime-fixture`, though that helper works here just as it does for the production adapters.
+
+### Render bodies and recursive children
+
+A render tree may be plain opaque data (`[:div "hi"]` — most tests) *or* declare an imperative render body via the node shape `{:rf/component (fn [mount] ...)}`. The body runs during the render phase, while a render is in flight. From inside it you can:
+
+- **Mount children** with `(test-react/mount-child! child-tree)` — the child runs its own `constructor → render → did-mount` lifecycle, is recorded under the parent (`test-react/children`), and is torn down children-first when the parent unmounts.
+- **Issue an `unmount!`** of any root — and if you unmount an ancestor or a separately-tracked sibling while the render is in flight, the guard fires `:rf.error/sync-unmount-during-render` *organically*. This is the rf2-4l7t2 reproducer.
+
+```clojure
+;; The rf2-4l7t2 shape, organically:
+(let [panel-a (test-react/mount! [:div.panel "A"])]
+  (is (thrown-with-msg? ExceptionInfo #":rf.error/sync-unmount-during-render"
+        (test-react/mount! {:rf/component
+                            (fn [_host]
+                              ;; BUG: synchronous unmount of a separate root during render
+                              (test-react/unmount! panel-a))}))))
+```
+
+`test-react/rendering?` reports whether a render is in flight anywhere in the tree (the condition the guard keys off), for tests that want to assert it directly rather than via a thrown guard.
 
 ## Lifecycle phases recorded
 
@@ -66,14 +96,14 @@ The `mount!` / `trigger-update!` / `unmount!` trio drive the simulator. The test
 | `:will-unmount` | The unmount thunk fires. |
 | `:forced-teardown` | `dispose-adapter!` drained a still-mounted root. |
 
-The simulator throws `:rf.error/sync-unmount-during-render` if `unmount!` is called while `:currently-rendering?` is true — the rf2-4l7t2 production manifestation.
+The simulator throws `:rf.error/sync-unmount-during-render` if `unmount!` is called while a render is in flight **anywhere in the tree** (tracked by a global render-depth counter, not a per-mount flag) — the rf2-4l7t2 production manifestation. Keying off the global depth is what lets the cross-root organic case (a parent re-render unmounting a separate sibling root) trip the guard, mirroring React's actual "while React was already rendering" condition.
 
-## What this skeleton does NOT cover
+## What this adapter does NOT cover
 
-- **Children are not recursively mounted.** The current simulator treats the render tree as opaque data. The class-3 invariants (one root, one mount, did-mount-after-render, will-unmount-before-teardown) catch the rf2-4l7t2 class without recursion.
-- **No automatic re-render on app-db change.** Tests drive re-renders explicitly via `trigger-update!`. A follow-on bead may wire `subscribe-container` watchers into automatic `trigger-update!` calls if the use case warrants it.
+- **No automatic re-render on app-db change.** Tests drive re-renders explicitly via `trigger-update!`. Children re-render only when a test re-runs the parent's render body or drives the child directly; there is no automatic propagation from a `subscribe-container` change. A follow-on bead may wire watchers into automatic `trigger-update!` calls if the use case warrants it.
 - **No React context provider.** Frame-routing under this adapter is via the dynamic-var tier (`re-frame.frame/current-frame`); the React-context tier is degenerate.
 - **No `data-rf2-source-coord` annotation.** Spec 006 makes source-coord injection a normative entry on the adapter contract, but it lives "on the rendered root DOM element." This adapter has no DOM root — the render tree is opaque data — so per the spec's non-DOM-root exemption the annotation is N/A here.
+- **No real reconciliation.** Children declared by `mount-child!` are imperative mounts, not a diffed child list. The simulator does not reconcile a render tree's child vector across updates — that fidelity belongs to a real React adapter / Playwright. The class-3 invariants (constructor/render/did-mount ordering, children-before-parent teardown, the sync-unmount-during-render guard) are what this adapter verifies.
 
 If those gaps prove costly, file a follow-on bead with a concrete reproducer.
 
@@ -90,5 +120,6 @@ If those gaps prove costly, file a follow-on bead with a concrete reproducer.
 ## Cross-references
 
 - [Spec 006 — Reactive substrate](../../../spec/006-ReactiveSubstrate.md) — the contract this adapter implements.
-- rf2-4l7t2 — the seminal sync-unmount-during-render bug; the motivating example for this adapter's existence.
-- rf2-gqyqv — this bead.
+- rf2-4l7t2 — the seminal sync-unmount-during-render bug; the motivating example for this adapter's existence, now reproduced organically as a unit regression.
+- rf2-gqyqv — the original skeleton bead.
+- rf2-n2cuo — broadened the skeleton: recursive child mounting + render bodies, the organic rf2-4l7t2 repro, and ported lifecycle regressions (unbalanced subscribe/dispose, double-render).

--- a/implementation/adapters/test-react/src/re_frame/adapter/test_react.cljc
+++ b/implementation/adapters/test-react/src/re_frame/adapter/test_react.cljc
@@ -8,20 +8,28 @@
   container quartet is shared with plain-atom via
   `re-frame.substrate.atom-container`; the render half is the novel surface
   — a `class-3` lifecycle simulator that records every transition into a
-  per-mount log and enforces the `:currently-rendering?` invariant (it
-  throws on a synchronous `unmount!` while a render is in flight, mirroring
-  React 18+).
+  per-mount log and enforces the sync-unmount-during-render invariant (it
+  throws on a synchronous `unmount!` while a render is in flight ANYWHERE in
+  the tree, mirroring React 18+).
 
-  Status: minimal viable skeleton (rf2-gqyqv; placeholder bead).
+  Render bodies + recursive children: a render tree may declare an imperative
+  body via the node shape `{:rf/component (fn [mount] ...)}`. The body runs
+  during the render phase (while the global render depth is non-zero) and can
+  mount children via `mount-child!` (which recurse through their own
+  lifecycle) or issue an `unmount!`. An `unmount!` of an ancestor/sibling from
+  inside such a body trips the guard ORGANICALLY — no hand-fabricated
+  in-flight state — which is exactly the rf2-4l7t2 shape (the senbl panel-host
+  unmounting the previous panel's root on a chip-row re-render).
+
+  Status: carries ported lifecycle regressions (rf2-n2cuo broadened the
+  rf2-gqyqv skeleton): organic sync-unmount-during-render, unbalanced
+  mount/unmount ref-count, and double-render.
 
   Out of scope (deferred to follow-on beads):
-    - Recursive child mounting: the render tree is treated as opaque data,
-      so the rf2-4l7t2 guard is reachable only via fabricated in-flight
-      state (a test sets `:currently-rendering?` by hand) until recursive
-      child mount lands and a child render-body can organically issue a
-      re-entrant unmount.
     - Auto-re-render on app-db change: tests drive re-renders explicitly
-      via `trigger-update!`.
+      via `trigger-update!`. Children re-render only when a test re-runs the
+      parent's render body (via `trigger-update!` with the same body) or
+      drives the child directly; there is no automatic propagation.
     - React-context provider traversal (frame-routing is via the
       dynamic-var tier; the React-context tier is degenerate — no React).
     - Source-coord annotation (Spec 006 §Source-coord annotation): N/A —
@@ -84,19 +92,49 @@
 ;;   :render-tree     — atom holding the currently-rendered tree
 ;;   :lifecycle-log   — atom holding a vector of {:phase ... :at ms} entries;
 ;;                      the test driver inspects this to assert ordering.
-;;   :currently-rendering? — atom<boolean>; true while a render is in flight.
-;;                      The simulator THROWS on attempts to unmount!
-;;                      synchronously while this is true, mirroring React
-;;                      18+'s sync-unmount-during-render guard (rf2-4l7t2).
+;;   :currently-rendering? — atom<boolean>; true while THIS mount's render is
+;;                      in flight. Distinct from the global render-depth (see
+;;                      below): this cell marks the self-render case, the
+;;                      global cell marks "React is rendering somewhere."
 ;;   :mounted?        — atom<boolean>; false after unmount. The simulator
 ;;                      THROWS on trigger-update! / unmount! after teardown.
+;;   :children        — atom<vector<MountedComponent>>; child roots this mount
+;;                      mounted from inside its own render body via
+;;                      `mount-child!`. Unmounting a parent cascades to its
+;;                      children (will-unmount fires children-first, mirroring
+;;                      React's child-before-parent teardown order).
 ;;   :unmount-fn      — the unmount thunk for this mount; `unmount!` calls it.
 
 (defrecord ^:no-doc MountedComponent
-  [id render-tree lifecycle-log currently-rendering? mounted? unmount-fn])
+  [id render-tree lifecycle-log currently-rendering? mounted? children unmount-fn])
 
 ;; All live mounts; `dispose-adapter!` walks this to drain.
 (defonce ^:private active-mounts (atom #{}))
+
+;; Global render depth — "React is rendering somewhere in the tree." React's
+;; sync-unmount-during-render guard fires whenever ANY render is in flight, not
+;; only when the root being unmounted is itself mid-render. The rf2-4l7t2 shape
+;; is exactly this cross-root case: a parent re-renders and, from inside that
+;; render body, synchronously unmounts a SEPARATELY-tracked sibling/child root
+;; (the senbl panel-host unmounting the previous panel's root on a chip-row
+;; switch). The per-mount :currently-rendering? cell cannot see that — it is
+;; false on the sibling being torn down — so the guard keys off this global
+;; counter. A counter (not a boolean) so nested child renders restore the flag
+;; correctly on unwind.
+(defonce ^:private render-depth (atom 0))
+
+;; The mount whose render body is currently executing, if any. `mount-child!`
+;; attaches newly-mounted children to this parent so the tree structure (and
+;; thus cascading unmount) is recorded. nil when no render is in flight.
+(def ^:private ^:dynamic *rendering-mount* nil)
+
+(defn rendering?
+  "True when the simulator is mid-render anywhere in the tree (the condition
+  React's sync-unmount-during-render guard keys off). Exposed for tests that
+  want to assert the global render state directly rather than via a thrown
+  guard."
+  []
+  (pos? @render-depth))
 
 (defn- now-ms []
   #?(:clj (System/currentTimeMillis)
@@ -106,37 +144,68 @@
   (swap! (:lifecycle-log mount)
          conj (merge {:phase phase :at (now-ms)} extras)))
 
+;; Declared so `run-render!` (which invokes a render body that may mount
+;; children) can call the mount seam defined below it.
+(declare mount-tree!)
+
+(defn- component-render-fn
+  "If `tree` declares an imperative render body, return it; else nil. The body
+  is `(fn [mount] ...)` run while a render is in flight (so any `unmount!`
+  issued from within fires the guard organically, and any `mount-child!`
+  attaches to `mount`). A render tree carries a body via the node shape
+  `{:rf/component (fn [mount] ...) ...}`; plain hiccup / opaque data has none."
+  [tree]
+  (when (map? tree)
+    (:rf/component tree)))
+
 (defn- run-render!
-  "Set the :currently-rendering? flag, record a :render phase entry, store the
-  render-tree, clear the flag. Throws from inside the render body are NOT
-  caught — they propagate to the caller (React 18+ unmounts the root)."
+  "Run one render of `mount` with `tree` as its output. Increments the global
+  render depth and sets the per-mount :currently-rendering? flag for the
+  duration, records a :render phase entry, stores the tree, and — if the tree
+  declares an imperative render body (`:rf/component`) — invokes that body with
+  `mount` bound as `*rendering-mount*` so it can mount children or issue a
+  (guard-tripping) re-entrant unmount. Throws from the render body are NOT
+  caught — they propagate to the caller (React 18+ unmounts the root); the
+  flags/depth are restored on unwind via `finally`."
   [mount tree]
+  (swap! render-depth inc)
   (reset! (:currently-rendering? mount) true)
   (try
     (reset! (:render-tree mount) tree)
     (log-phase! mount :render)
+    (when-let [body (component-render-fn tree)]
+      (binding [*rendering-mount* mount]
+        (body mount)))
     (finally
-      (reset! (:currently-rendering? mount) false))))
+      (reset! (:currently-rendering? mount) false)
+      (swap! render-depth dec))))
 
 (defn- unmount-thunk
   "Build the unmount thunk for `mount`. Idempotent (a second call on an
-  already-unmounted mount is a no-op). Throws
-  `:rf.error/sync-unmount-during-render` if called while a render is in
-  flight (the rf2-4l7t2 class)."
+  already-unmounted mount is a no-op). Cascades to children first (React tears
+  children down before their parent). Throws
+  `:rf.error/sync-unmount-during-render` if called while a render is in flight
+  ANYWHERE in the tree (the rf2-4l7t2 class) — keyed off the global
+  `render-depth`, so a parent re-render that synchronously unmounts a separate
+  sibling/child root trips the guard just as React does."
   [mount]
   (fn unmount []
     (when @(:mounted? mount)
-      (when @(:currently-rendering? mount)
+      (when (rendering?)
         (throw (ex-info ":rf.error/sync-unmount-during-render"
                         {:where    'rf/test-react-unmount
                          :recovery :no-recovery
                          :reason   (str "Attempted to synchronously unmount a root"
-                                        " while a render is in flight. React 18+"
-                                        " raises the equivalent runtime error; the"
-                                        " Test-React adapter raises here so the bug"
-                                        " is caught at unit-test speed. See"
+                                        " while React was already rendering. React"
+                                        " 18+ raises the equivalent runtime error;"
+                                        " the Test-React adapter raises here so the"
+                                        " bug is caught at unit-test speed. See"
                                         " rf2-4l7t2 for the production manifestation.")
                          :mount-id (:id mount)})))
+      ;; Children-first teardown (mirrors React). Each child's own thunk runs
+      ;; the same guard + cascade, so a deep tree unwinds leaf-upward.
+      (doseq [child @(:children mount)]
+        ((:unmount-fn child)))
       (log-phase! mount :will-unmount)
       (reset! (:mounted? mount) false)
       (reset! (:render-tree mount) nil)
@@ -149,7 +218,11 @@
   `active-mounts`, and returns the record itself (with its unmount thunk
   stored in the `:unmount-fn` field). Both the substrate `render` fn and the
   public `mount!` driver call this — `render` discards everything but the
-  thunk; `mount!` returns the whole record so tests can inspect the log."
+  thunk; `mount!` returns the whole record so tests can inspect the log.
+
+  If invoked while a parent's render body is running (i.e. via `mount-child!`,
+  with `*rendering-mount*` bound) the new mount is appended to that parent's
+  `:children`, so unmounting the parent later cascades to it."
   [render-tree]
   (let [base    (->MountedComponent
                   (gensym "test-react-mount-")
@@ -157,6 +230,7 @@
                   (atom [])    ; lifecycle-log
                   (atom false) ; currently-rendering?
                   (atom true)  ; mounted?
+                  (atom [])    ; children
                   nil)         ; unmount-fn — filled in below
         mount   (assoc base :unmount-fn (unmount-thunk base))]
     (log-phase! mount :constructor)
@@ -164,6 +238,31 @@
     (log-phase! mount :did-mount)
     (swap! active-mounts conj mount)
     mount))
+
+(defn mount-child!
+  "Mount `render-tree` as a child of the component whose render body is
+  currently executing. Intended to be called from inside an `:rf/component`
+  render body (where `*rendering-mount*` is bound). Returns the child's
+  `MountedComponent`. Throws if called outside a render body — a child must
+  have a parent.
+
+  This is the recursive-child seam: the child runs its own
+  constructor → render → did-mount lifecycle (and may itself mount
+  grandchildren), is appended to the parent's `:children`, and is torn down
+  when the parent unmounts."
+  [render-tree]
+  (let [parent *rendering-mount*]
+    (when (nil? parent)
+      (throw (ex-info ":rf.error/mount-child-outside-render"
+                      {:where    'rf/test-react-mount-child!
+                       :recovery :no-recovery
+                       :reason   (str "mount-child! must be called from inside an"
+                                      " :rf/component render body (a child needs a"
+                                      " parent render in flight); *rendering-mount*"
+                                      " was nil.")})))
+    (let [child (mount-tree! render-tree)]
+      (swap! (:children parent) conj child)
+      child)))
 
 (defn- render [render-tree _mount-point _opts]
   ;; Spec 006 §`render` — return an unmount thunk. Under test-react the
@@ -219,12 +318,23 @@
   ;; `spine/dispose-frame-sub-caches!` — this adapter is CLJC and the spine
   ;; is CLJS-only. Acceptable because test-react's `make-derived-value` holds
   ;; no host resources (plain IDeref reify); nothing for the walk to dispose.
+  ;; Drain flat over active-mounts: children are themselves registered in
+  ;; active-mounts (mount-tree! adds every mount, parent or child), so a flat
+  ;; walk drains the whole forest without recursing through :children. We do
+  ;; NOT route through the public unmount thunk (it would throw on the
+  ;; currently-rendering? / render-depth guard) — forced teardown is the
+  ;; escape hatch the guard deliberately cannot block.
   (doseq [m @active-mounts]
     (when @(:mounted? m)
       (log-phase! m :forced-teardown)
       (reset! (:mounted? m) false)
       (reset! (:render-tree m) nil)))
   (reset! active-mounts #{})
+  ;; Reset the global render depth. `run-render!`'s `finally` already restores
+  ;; it on the normal + guard-throw paths; this is belt-and-braces so a test
+  ;; that bypassed run-render! by hand cannot leak a stuck "rendering" state
+  ;; into the next case.
+  (reset! render-depth 0)
   nil)
 
 (def adapter
@@ -300,10 +410,12 @@
   mount)
 
 (defn unmount!
-  "Unmount `mount`. Records a `:will-unmount` phase entry. Throws
-  `:rf.error/sync-unmount-during-render` if called while the mount is in the
-  middle of a render (the rf2-4l7t2 class). Idempotent: a second call on the
-  same mount is a no-op."
+  "Unmount `mount`, cascading to its children first (React tears children down
+  before their parent). Records a `:will-unmount` phase entry per torn-down
+  mount. Throws `:rf.error/sync-unmount-during-render` if called while a render
+  is in flight anywhere in the tree (the rf2-4l7t2 class) — including the
+  organic case where a parent's render body synchronously unmounts a separate
+  sibling/child root. Idempotent: a second call on the same mount is a no-op."
   [mount]
   ((:unmount-fn mount))
   nil)
@@ -322,10 +434,21 @@
   @(:render-tree mount))
 
 (defn mounted-roots
-  "Return all currently-mounted `MountedComponent`s under this adapter.
-  Useful for tests asserting balanced mount/unmount counts."
+  "Return all currently-mounted `MountedComponent`s under this adapter — the
+  whole live forest, parents AND recursively-mounted children (every mount,
+  child or not, is registered in `active-mounts`). Useful for tests asserting
+  balanced mount/unmount counts: an unbalanced subscribe/dispose or a leaked
+  child shows up as a non-zero count after the test's teardown should have
+  drained everything."
   []
   (filter (comp deref :mounted?) @active-mounts))
+
+(defn children
+  "Return the live (still-mounted) child `MountedComponent`s a `mount` mounted
+  from inside its own render body via `mount-child!`, in mount order. Useful
+  for tests that walk the tree or assert a parent tore its children down."
+  [mount]
+  (filterv (comp deref :mounted?) @(:children mount)))
 
 ;; ---- late-bind hook routing -----------------------------------------------
 ;; The Test-React adapter publishes only the React-context-tier fallback for

--- a/implementation/adapters/test-react/test/re_frame/adapter/test_react_test.cljc
+++ b/implementation/adapters/test-react/test/re_frame/adapter/test_react_test.cljc
@@ -1,25 +1,31 @@
 (ns re-frame.adapter.test-react-test
-  "Demonstration tests for the Test-React adapter (rf2-gqyqv).
+  "Tests for the Test-React adapter.
 
-  Scenarios drawn from the rf2-4l7t2 bug class:
+  Two layers:
 
-    1. Happy-path lifecycle ordering — constructor → render → did-mount
-       → did-update → will-unmount.
-    2. Sync unmount during render — the rf2-4l7t2 production manifestation;
-       the adapter throws `:rf.error/sync-unmount-during-render` at
-       unit-test speed.
-    3. Adapter-disposal teardown — `dispose-adapter!` drains stranded
-       mounts and the test surface can see the `:forced-teardown`
-       breadcrumb.
-    4. mount! identity — the record threaded back from the internal mount
-       seam is the one created, even with many mounts live (rf2-ee38b.16,
-       replacing the old :seq scan-recovery tests).
-    5. render-to-string survives a dispose/reinstall cycle — dispose does
-       not clear the chained hiccup emitter (rf2-ee38b.16).
+  A. Demonstration scenarios — the original skeleton coverage (rf2-gqyqv):
+     happy-path lifecycle ordering, render-tree tracking, adapter-disposal
+     drain, mount! record identity, render-to-string dispose/reinstall.
 
-  These are minimal demonstration tests, not exhaustive coverage. The
-  bead is P4 / placeholder; broader test corpora ship in follow-on
-  beads if React-lifecycle bugs prove recurrent."
+  B. Ported lifecycle regressions (rf2-n2cuo) — each guards a REAL bug class
+     the adapter claims to catch, and asserts that bug's *symptom* so a
+     future regression in the class fails this unit test:
+
+       1. Organic sync-unmount-during-render (the rf2-4l7t2 class). Modelled
+          on the real Story senbl panel-host shape: a panel-host parent holds
+          the current panel's child root; on a chip-row 'switch panel'
+          re-render, the parent's render body synchronously unmounts the
+          PREVIOUS panel's root. The guard fires ORGANICALLY — no
+          hand-fabricated :currently-rendering? — because the unmount happens
+          while React (the global render depth) is rendering somewhere.
+
+       2. Unbalanced subscribe/dispose (mount/unmount ref-count). A faulty
+          teardown disposes only some of the resources it acquired on mount;
+          the symptom is a non-zero live-mount / ref count after teardown.
+
+       3. Double-render. A redundant re-render fires where exactly one was
+          expected; the symptom is an extra :render (and :did-update) entry in
+          the lifecycle log — the render counter is higher than the contract."
   (:require [re-frame.adapter.test-react :as test-react]
             [re-frame.substrate.adapter :as substrate-adapter]
             #?(:clj  [clojure.test :as ctest :refer [deftest is testing use-fixtures]]
@@ -40,7 +46,11 @@
 
 (use-fixtures :each install-test-react!)
 
-;; ---- scenario 1: happy-path lifecycle ordering ----------------------------
+;; ----------------------------------------------------------------------------
+;; A. Demonstration scenarios
+;; ----------------------------------------------------------------------------
+
+;; ---- happy-path lifecycle ordering ----------------------------------------
 
 (deftest happy-path-lifecycle-ordering
   (testing "constructor → render → did-mount → did-update → will-unmount"
@@ -62,25 +72,7 @@
       (is (zero? (count (test-react/mounted-roots))))
       (is (nil? (test-react/current-render-tree mount))))))
 
-;; ---- scenario 2: the rf2-4l7t2 class --------------------------------------
-
-(deftest sync-unmount-during-render-throws
-  (testing "synchronous unmount during render raises :rf.error/sync-unmount-during-render"
-    (let [mount (test-react/mount! [:div])]
-      ;; Force the currently-rendering? flag on (simulating a render in
-      ;; flight — production code that calls `(.unmount root)` from a
-      ;; child's render body hits this state in real React).
-      (reset! (:currently-rendering? mount) true)
-      (is (thrown-with-msg?
-            #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core.ExceptionInfo)
-            #":rf.error/sync-unmount-during-render"
-            (test-react/unmount! mount))
-          "the adapter mirrors React 18+'s sync-unmount-during-render guard")
-      ;; Clear the flag so the fixture's dispose-adapter! can drain
-      ;; cleanly.
-      (reset! (:currently-rendering? mount) false))))
-
-;; ---- scenario 3: adapter-disposal drains stranded mounts ------------------
+;; ---- adapter-disposal drains stranded mounts ------------------------------
 
 (deftest dispose-adapter-drains-stranded-mounts
   (testing "dispose-adapter! drains mounts the test forgot to unmount; log carries :forced-teardown breadcrumb"
@@ -96,7 +88,7 @@
       ;; Re-install so the fixture's outer dispose call below is a no-op.
       (substrate-adapter/install-adapter! test-react/adapter))))
 
-;; ---- scenario 4: mount! returns the exact record it created ---------------
+;; ---- mount! returns the exact record it created ---------------------------
 
 (deftest mount-returns-its-own-record-under-many-live-mounts
   (testing "mount! returns the record it created — and its unmount thunk tears
@@ -123,7 +115,7 @@
       ;; dispose-adapter! has nothing surprising to forcibly tear down.
       (doseq [m earlier] (test-react/unmount! m)))))
 
-;; ---- scenario 5: render-to-string survives a dispose/reinstall cycle ------
+;; ---- render-to-string survives a dispose/reinstall cycle ------------------
 
 (deftest render-to-string-survives-dispose-reinstall
   (testing "dispose-adapter! does NOT clear the chained hiccup emitter, so
@@ -142,3 +134,213 @@
           "emitter still bound after dispose + reinstall")
       (finally
         (test-react/set-hiccup-emitter! nil)))))
+
+;; ----------------------------------------------------------------------------
+;; A'. Recursive child mounting — the structural seam the regressions ride on
+;; ----------------------------------------------------------------------------
+
+(deftest child-mounts-recurse-through-their-own-lifecycle
+  (testing "a parent's render body mounts a child via mount-child!; the child
+            runs its own constructor → render → did-mount, is tracked as a
+            child of the parent, and is torn down children-first when the
+            parent unmounts"
+    (let [child-ref (atom nil)
+          parent    (test-react/mount!
+                      {:rf/component
+                       (fn [_parent]
+                         (reset! child-ref
+                                 (test-react/mount-child! [:span "child"])))})]
+      ;; The child ran its full mount lifecycle.
+      (is (= [:constructor :render :did-mount]
+             (mapv :phase (test-react/lifecycle-log @child-ref)))
+          "child recursed through its own class-3 mount lifecycle")
+      ;; The forest holds both mounts; the parent records the child.
+      (is (= 2 (count (test-react/mounted-roots)))
+          "parent + child are both live in the forest")
+      (is (= [@child-ref] (test-react/children parent))
+          "the child is recorded under the parent")
+      ;; Unmounting the parent cascades to the child, children-first.
+      (test-react/unmount! parent)
+      (is (zero? (count (test-react/mounted-roots)))
+          "parent unmount cascaded to the child — nothing leaks")
+      (is (some #{:will-unmount} (mapv :phase (test-react/lifecycle-log @child-ref)))
+          "the child saw its own :will-unmount during the cascade")
+      (let [child-unmount-at  (->> (test-react/lifecycle-log @child-ref)
+                                   (filter (comp #{:will-unmount} :phase))
+                                   first :at)
+            parent-unmount-at (->> (test-react/lifecycle-log parent)
+                                   (filter (comp #{:will-unmount} :phase))
+                                   first :at)]
+        (is (<= child-unmount-at parent-unmount-at)
+            "children tear down before (or no later than) their parent")))))
+
+;; ----------------------------------------------------------------------------
+;; B.1 — Organic sync-unmount-during-render (the rf2-4l7t2 class)
+;; ----------------------------------------------------------------------------
+;;
+;; Real shape (Story senbl panel-host, PR #1577): a single persistent
+;; panel-host owns the CURRENT panel's child root. When the chip-row picker
+;; switches panels, the host re-renders and — inside that render body —
+;; synchronously calls (.unmount) on the PREVIOUS panel's root. React 18+
+;; raises "Attempted to synchronously unmount a root while React was already
+;; rendering." The original fix deferred the unmount to a microtask.
+;;
+;; Here the bug is reproduced ORGANICALLY: the host's render body issues the
+;; unmount while the global render depth is non-zero — no test sets
+;; :currently-rendering? by hand. That converts the headline capability from
+;; "guard logic verified" to "bug condition reproduced."
+
+(deftest organic-sync-unmount-during-render-rf2-4l7t2
+  (testing "a panel-host that synchronously unmounts the previous panel's root
+            from inside its switch-panel re-render trips
+            :rf.error/sync-unmount-during-render ORGANICALLY (no fabricated
+            in-flight state) — the rf2-4l7t2 bug condition, reproduced"
+    ;; Mount panel A as a standalone root (the host's current child).
+    (let [panel-a (test-react/mount! [:div.panel "A"])]
+      (is (= 1 (count (test-react/mounted-roots))))
+      ;; The host re-renders to switch to panel B. The BUGGY render body
+      ;; synchronously unmounts panel A's root mid-render (the senbl pattern
+      ;; before the microtask-defer fix).
+      (is (thrown-with-msg?
+            #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core.ExceptionInfo)
+            #":rf.error/sync-unmount-during-render"
+            (test-react/mount!
+              {:rf/component
+               (fn [_host]
+                 ;; BUG: synchronous unmount of a separate root during render.
+                 (test-react/unmount! panel-a))}))
+          "the guard fires organically: the unmount happens while the host's
+           render is in flight, which is React's actual guard condition")
+      ;; Panel A is still mounted — the guard short-circuited the unmount
+      ;; before it could tear the root down (matching React: it refuses the
+      ;; synchronous unmount rather than racing).
+      (is (true? @(:mounted? panel-a))
+          "the guard refused the synchronous unmount — panel A was NOT torn down")
+      (test-react/unmount! panel-a))))
+
+(deftest deferred-unmount-after-render-is-safe-rf2-4l7t2-fix
+  (testing "the rf2-4l7t2 FIX shape: unmounting the previous panel's root AFTER
+            the host's render has completed (the microtask-defer) does not trip
+            the guard — proves the guard discriminates in-render from
+            after-render, so it is not a blunt always-throw"
+    (let [panel-a (test-react/mount! [:div.panel "A"])
+          ;; Host re-renders to switch to B WITHOUT unmounting A mid-render.
+          host    (test-react/mount! {:rf/component (fn [_host] :switched-to-B)})]
+      (is (= 2 (count (test-react/mounted-roots))))
+      ;; Now that no render is in flight, unmounting panel A is safe (this is
+      ;; what queueMicrotask buys you in the production fix).
+      (is (false? (test-react/rendering?))
+          "no render in flight after the host's render completed")
+      (test-react/unmount! panel-a)        ; must NOT throw
+      (is (= 1 (count (test-react/mounted-roots)))
+          "deferred unmount tore down panel A cleanly")
+      (test-react/unmount! host))))
+
+;; ----------------------------------------------------------------------------
+;; B.2 — Unbalanced subscribe/dispose (mount/unmount ref-count)
+;; ----------------------------------------------------------------------------
+;;
+;; Bug class: a component acquires a resource on mount (a subscription, a
+;; listener, a child root) and is supposed to release it on unmount. A faulty
+;; teardown releases only SOME of what it acquired. The leak is invisible to a
+;; happy-path test but shows up as an imbalanced ref-count / a non-zero live
+;; mount after the component's own teardown should have drained everything.
+
+(deftest unbalanced-subscribe-dispose-leaves-an-orphaned-root
+  (testing "a parent spins up a SECOND root inside its render body but tracks it
+            as a standalone mount (mount!) instead of a child (mount-child!), so
+            the parent's teardown cascade never disposes it. The symptom is a
+            non-zero live-mount count after the parent unmounts — the
+            subscribe-without-matching-dispose imbalance, and the orphaned-root
+            root cause behind the rf2-4l7t2 family."
+    (let [orphan-ref (atom nil)
+          ;; The host mounts a tracked child AND — the bug — a second root via
+          ;; the standalone `mount!` seam (think: an effect that creates a
+          ;; Reagent root but forgets to register its unmount thunk for
+          ;; teardown). `mount!` does NOT attach to the parent's :children.
+          host (test-react/mount!
+                 {:rf/component
+                  (fn [_host]
+                    (test-react/mount-child! [:section "tracked-child"])
+                    (reset! orphan-ref (test-react/mount! [:section "ORPHAN"])))})]
+      (is (= 3 (count (test-react/mounted-roots)))
+          "host + tracked child + orphaned root are all live")
+      (is (= 1 (count (test-react/children host)))
+          "the host only KNOWS about the one tracked child (the orphan is untracked)")
+      ;; Correct-looking teardown: unmount the host. Its cascade tears down the
+      ;; tracked child — but cannot reach the untracked orphan.
+      (test-react/unmount! host)
+      ;; Symptom: the orphan is still mounted; the count never returned to zero.
+      (is (= 1 (count (test-react/mounted-roots)))
+          "the orphaned root leaks — subscribe/dispose imbalance detected")
+      (is (true? @(:mounted? @orphan-ref))
+          "the specific leaked root is the orphan the host forgot to track")
+      (is (not (zero? (count (test-react/mounted-roots))))
+          "a balanced teardown would zero the live-mount count; this buggy path leaks")
+      ;; Clean up the orphan so the fixture's drain has nothing to forcibly tear.
+      (test-react/unmount! @orphan-ref))))
+
+(deftest balanced-subscribe-dispose-returns-to-zero
+  (testing "the CORRECT counterpart: a parent that lets the cascade tear all
+            children down returns the live-mount count and ref count to zero —
+            the green state a regression in B.2 would break"
+    (let [live   (atom 0)
+          parent (test-react/mount!
+                   {:rf/component
+                    (fn [_parent]
+                      (test-react/mount-child! [:li "a"]) (swap! live inc)
+                      (test-react/mount-child! [:li "b"]) (swap! live inc))})]
+      (is (= 3 (count (test-react/mounted-roots))))
+      ;; Correct teardown: just unmount the parent; the cascade handles
+      ;; children, and we mirror the ref release per child it tears down.
+      (let [n-children (count (test-react/children parent))]
+        (test-react/unmount! parent)
+        (dotimes [_ n-children] (swap! live dec)))
+      (is (zero? (count (test-react/mounted-roots)))
+          "cascade tore every child down — nothing leaks")
+      (is (zero? @live)
+          "ref count balanced back to zero"))))
+
+;; ----------------------------------------------------------------------------
+;; B.3 — Double-render
+;; ----------------------------------------------------------------------------
+;;
+;; Bug class: a single logical state change drives TWO renders where the
+;; contract is one. (E.g. a handler that both replaces app-db AND imperatively
+;; pokes the component, or a sub that fires twice.) The symptom is an extra
+;; :render / :did-update entry in the lifecycle log — the render count exceeds
+;; the number of intended updates.
+
+(deftest double-render-shows-an-extra-render-entry
+  (testing "a buggy update path that re-renders twice for one logical change
+            records TWO :did-update :render pairs; the symptom is a render
+            count of 2 where the contract is 1"
+    (let [mount (test-react/mount! [:div "v1"])]
+      ;; CONTRACT: one logical change → one update render.
+      ;; BUG: the update path fires trigger-update! twice (the redundant
+      ;; second render real double-render bugs produce).
+      (test-react/trigger-update! mount [:div "v2"])
+      (test-react/trigger-update! mount [:div "v2"]) ; redundant re-render
+      (let [renders (->> (test-react/lifecycle-log mount)
+                         (filter (comp #{:render} :phase))
+                         count)
+            updates (->> (test-react/lifecycle-log mount)
+                         (filter (comp #{:did-update} :phase))
+                         count)]
+        ;; Mount render + two update renders = 3.
+        (is (= 3 renders)
+            "render count is 3 (1 mount + 2 update) — the doubled update render is visible")
+        (is (= 2 updates)
+            "two :did-update entries expose the redundant second render"))
+      (test-react/unmount! mount))))
+
+(deftest single-render-is-the-balanced-baseline
+  (testing "the CORRECT counterpart: one logical change → exactly one update
+            render (one :did-update). A double-render regression breaks this."
+    (let [mount (test-react/mount! [:div "v1"])]
+      (test-react/trigger-update! mount [:div "v2"])
+      (is (= 1 (->> (test-react/lifecycle-log mount)
+                    (filter (comp #{:did-update} :phase))
+                    count))
+          "exactly one update render for one logical change")
+      (test-react/unmount! mount))))


### PR DESCRIPTION
## Decision

Mike ruled **Option 1 (broaden)** — rf2-n2cuo — make the test-react adapter earn its keep rather than demote it to a do-nothing skeleton. **Revisit in ~3 months; demote if still idle.**

## What changed

### Child mounting (simulator, `src/re_frame/adapter/test_react.cljc`)
- **Render bodies.** A render tree may now declare an imperative body via the node shape `{:rf/component (fn [mount] ...)}`, run during the render phase (while a render is in flight).
- **Recursive child mounting** via `mount-child!`: a child runs its own `constructor → render → did-mount` lifecycle, is tracked under its parent (`children`), and is torn down **children-first** when the parent unmounts.
- **Guard keyed off global render-depth.** The sync-unmount-during-render guard now fires when a render is in flight *anywhere in the tree* (a global `render-depth` counter — "React is rendering somewhere"), not just when the unmounted mount is itself mid-render. This is what lets the cross-root rf2-4l7t2 case trip organically, and it matches React's actual "while React was already rendering" condition.
- New public helpers: `mount-child!`, `children`, `rendering?`.

### Ported regressions (`test/re_frame/adapter/test_react_test.cljc`)
Each asserts the bug's **symptom**, so a future regression in that class fails the unit test:

| Regression | Bug class guarded |
|---|---|
| `organic-sync-unmount-during-render-rf2-4l7t2` | **rf2-4l7t2 sync-unmount-during-render** — reproduced ORGANICALLY (no fabricated `:currently-rendering?`). Modelled on the real Story senbl panel-host: a host re-renders to switch panels and, from inside that render body, synchronously unmounts the previous panel's separately-tracked root. |
| `deferred-unmount-after-render-is-safe-rf2-4l7t2-fix` | The rf2-4l7t2 **fix** shape (microtask-defer) — proves the guard discriminates in-render from after-render (not a blunt always-throw). |
| `unbalanced-subscribe-dispose-leaves-an-orphaned-root` | **Unbalanced subscribe/dispose** — a parent spins up a second root via standalone `mount!` (untracked) instead of `mount-child!`, so its teardown cascade misses it; symptom = non-zero live-mount count after teardown. |
| `double-render-shows-an-extra-render-entry` | **Double-render** — a redundant re-render fires where one was expected; symptom = an extra `:render`/`:did-update` on the lifecycle log. |
| `balanced-subscribe-dispose-returns-to-zero`, `single-render-is-the-balanced-baseline` | Green baselines a regression in the two classes above would break. |
| `child-mounts-recurse-through-their-own-lifecycle` | Structural cover for the new recursive-child seam (lifecycle ordering + children-before-parent teardown). |

### README (`adapters/test-react/README.md`)
- Rewrote the candid **"Note on the sync-unmount-during-render row"** to reflect reality: the guard is now reachable **organically**, not via fabricated in-flight state.
- Updated the capability table — the three living-regression rows are now bold, with a footnote pointing at the regression suite.
- Added a **"Render bodies and recursive children"** usage section (`:rf/component`, `mount-child!`, `rendering?`).
- Refreshed the status line (no longer "minimal viable skeleton / P4 placeholder" — it carries real regressions), the "What this adapter does NOT cover" section, and the cross-references.
- One-line refresh to the parent `adapters/README.md` index row (kept the doc honest in lockstep).

## Follow-on split?
**No split.** Recursive child mounting landed cleanly in this PR — it was not a large-enough undertaking to defer, so no follow-on bead was filed. rf2-4l7t2 is now organically reproduced as a unit regression.

## Gates
- `clojure -M:test` (from `implementation/adapters/test-react/`, JVM): **12 tests, 37 assertions, 0 failures, 0 errors**.
- clj-kondo on both changed namespaces: **0 errors, 0 warnings**.
- Node-CLJS (`npm run test:cljs`): **not run locally** — `implementation/node_modules` is absent and a fresh install risks the documented Windows shadow-cljs/Node file-lock issue in worktrees. The tests are pure `.cljc` (reader-conditionalized JS interop only) and the existing `:node-test` shadow build already discovers `re-frame.adapter.test-react-test`, so CI covers the CLJS path.

## Scope
Stayed within `implementation/adapters/test-react/` (src + test + README) plus a one-line status refresh to the `implementation/adapters/README.md` index. No spec edits; none warranted.