### PR TITLE
refactor(routing): merge-route-slice helper + prose drift cleanup (rf2-g8tzb + rf2-t7rjp [+rf2-dnb5q wont-fix])

### DIFF
--- a/implementation/routing/deps.edn
+++ b/implementation/routing/deps.edn
@@ -6,10 +6,11 @@
 ;; `:rf.route/handle-url-change`, `:rf.route/continue` /
 ;; `:rf.route/cancel`, the `:rf.nav/push-url` / `:rf.nav/replace-url` /
 ;; `:rf.nav/scroll` fxs, `match-url` / `route-url`, the `:rf/route` /
-;; `:rf.route/{id,params,query,transition,error}` framework subs, the
-;; per-frame routing-runtime sub-keys nested under `:rf/route`
+;; `:rf.route/{id,params,query,transition,error}` framework subs, and
+;; the per-frame routing-runtime sub-keys
 ;; (`:scroll-positions` / `:scroll-positions-order` /
-;; `:nav-token-counter` / `:pending-nav-counter` — rf2-3ib8h)) ships as a separate Maven
+;; `:nav-token-counter` / `:pending-nav-counter`) sitting as siblings
+;; under `[:rf/runtime :routing ...]` (rf2-3ib8h, rf2-eguy4)) ships as a separate Maven
 ;; artefact so apps that don't register any routes don't drag the
 ;; namespace, the route-rank / pattern-compile / nav-token machinery,
 ;; or any of the `:rf.route/*` and `:rf.nav/*` trace strings onto the

--- a/implementation/routing/src/re_frame/routing/events.cljc
+++ b/implementation/routing/src/re_frame/routing/events.cljc
@@ -10,6 +10,10 @@
       rf2-dn26r);
     - `identical-route-target?` — Spec 012 §Per-route data loading rule
       3 short-circuit predicate;
+    - `merge-route-slice` — the slice-publish merge over
+      `[:rf/runtime :routing :current]` (encodes the slice-shape
+      contract once for both the programmatic-nav and URL-driven paths,
+      rf2-g8tzb);
     - `:rf.route.internal/settle-transition` — the FIFO-drain
       `:loading → :idle` settle (nav-token-aware so a newer navigation
       mid-drain bumps `:nav-token` and the stale settle becomes a no-op).
@@ -83,6 +87,41 @@
          (= (:params prev)   params)
          (= (:query prev)    query)
          (= (:fragment prev) fragment))))
+
+;; Per Spec 012 §The route slice and Spec-Schemas §`:rf/runtime` the
+;; published slice carries exactly `{:id :params :query :fragment
+;; :transition :error :nav-token}` under `[:rf/runtime :routing
+;; :current]`. Both nav entry points (programmatic
+;; `:rf.route/navigate` and URL-driven `:rf.route/transitioned` /
+;; `:rf.route/handle-url-change`) write the same merge shape after
+;; allocating a nav-token. This helper encodes the slice-shape contract
+;; in ONE place so the two writers and the layer-1 read
+;; (`re-frame.routing.subs/route-sub-fn`) stay symmetric. `:error` is
+;; always nil on a successful commit; the error-trap path
+;; (`re-frame.routing.on-match-error`) sets it independently.
+;;
+;; The merge is targeted at `:current` (not at `:routing`), so the
+;; sibling routing-runtime keys under `[:rf/runtime :routing ...]`
+;; (`:scroll-positions` / `:scroll-positions-order` /
+;; `:nav-token-counter` / `:pending-nav-counter`) are untouched.
+(defn merge-route-slice
+  "Pure slice-publish: merges the new slice fields over the existing
+  `:current` map at `[:rf/runtime :routing :current]`. Returns the
+  updated db.
+
+  `slice` is a map of `{:id :params :query :fragment :transition
+  :nav-token}`. `:error` is forced to `nil` (the successful-commit
+  contract); callers needing an error-state slice go through the
+  `:rf.route/on-match-error` trap which writes `:error` explicitly."
+  [db {:keys [id params query fragment transition nav-token]}]
+  (update-in db [:rf/runtime :routing :current] merge
+             {:id         id
+              :params     params
+              :query      query
+              :fragment   fragment
+              :transition transition
+              :error      nil
+              :nav-token  nav-token}))
 
 ;; Per Spec 012 §Per-route data loading §2. FIFO drain queues
 ;; :rf.route.internal/settle-transition after the :on-match events so

--- a/implementation/routing/src/re_frame/routing/navigate.cljc
+++ b/implementation/routing/src/re_frame/routing/navigate.cljc
@@ -158,21 +158,19 @@
             ;; that order for any cross-route transition.
             (routing-events/emit-activation-traces!
               (get-in db [:rf/runtime :routing :current :id]) route-id)
-            ;; Merge the new slice fields OVER the existing :current map at
-            ;; [:rf/runtime :routing :current]. The sibling routing-runtime
-            ;; keys ([:rf/runtime :routing :scroll-positions /
-            ;; :scroll-positions-order / :nav-token-counter /
-            ;; :pending-nav-counter]) are siblings (not nested under
-            ;; :current), so the targeted `update-in` here leaves them
+            ;; rf2-g8tzb: shared slice-publish helper — encodes the
+            ;; slice-shape contract once for both nav entry points.
+            ;; Targets `:current`, so sibling routing-runtime keys
+            ;; (`:scroll-positions` / `:scroll-positions-order` /
+            ;; `:nav-token-counter` / `:pending-nav-counter`) are
             ;; untouched.
-            {:db (update-in db' [:rf/runtime :routing :current] merge
-                            {:id         route-id
-                             :params     path-params
-                             :query      query-params
-                             :fragment   fragment
-                             :transition (if (seq on-match-vec) :loading :idle)
-                             :error      nil
-                             :nav-token  token})
+            {:db (routing-events/merge-route-slice
+                   db' {:id         route-id
+                        :params     path-params
+                        :query      query-params
+                        :fragment   fragment
+                        :transition (if (seq on-match-vec) :loading :idle)
+                        :nav-token  token})
              :fx (vec (concat (when capture-fx [capture-fx])
                               [push-fx]
                               (mapv (fn [ev] [:dispatch ev]) on-match-vec)

--- a/implementation/routing/src/re_frame/routing/url_change.cljc
+++ b/implementation/routing/src/re_frame/routing/url_change.cljc
@@ -186,21 +186,18 @@
         ;; activated?} in that order for any cross-route transition.
         (routing-events/emit-activation-traces!
           (get-in db [:rf/runtime :routing :current :id]) route-id)
-        ;; Merge slice fields over the existing :current map at
-        ;; [:rf/runtime :routing :current]. The sibling routing-runtime
-        ;; keys ([:rf/runtime :routing :scroll-positions /
-        ;; :scroll-positions-order / :nav-token-counter /
-        ;; :pending-nav-counter]) are siblings (not nested under
-        ;; :current), so the targeted `update-in` here leaves them
-        ;; untouched.
-        {:db (update-in db' [:rf/runtime :routing :current] merge
-                        {:id         route-id
-                         :params     params
-                         :query      query
-                         :fragment   fragment
-                         :transition transition
-                         :error      nil
-                         :nav-token  token})
+        ;; rf2-g8tzb: shared slice-publish helper — encodes the
+        ;; slice-shape contract once for both nav entry points.
+        ;; Targets `:current`, so sibling routing-runtime keys
+        ;; (`:scroll-positions` / `:scroll-positions-order` /
+        ;; `:nav-token-counter` / `:pending-nav-counter`) are untouched.
+        {:db (routing-events/merge-route-slice
+               db' {:id         route-id
+                    :params     params
+                    :query      query
+                    :fragment   fragment
+                    :transition transition
+                    :nav-token  token})
          :fx (vec (concat (when capture-fx [capture-fx])
                           (mapv (fn [ev] [:dispatch ev]) on-match-vec)
                           ;; Per Spec 012 §Per-route data loading §2:

--- a/implementation/routing/test/re_frame/routing_concurrency_stress_test.clj
+++ b/implementation/routing/test/re_frame/routing_concurrency_stress_test.clj
@@ -228,7 +228,7 @@
                 expected (str "/p" idx "/" (dec stress-iters))]
             (is (= (keyword "ksbur.stress" (str "route-" idx))
                    (:id slice))
-                (str "Frame " frame-id ": :rf/route :id should match "
+                (str "Frame " frame-id ": route-slice :id should match "
                      "this thread's per-thread route"))
             ;; Slug is captured as a path param; the LAST iter's slug
             ;; (= dec stress-iters) wins.

--- a/implementation/routing/test/re_frame/routing_test.clj
+++ b/implementation/routing/test/re_frame/routing_test.clj
@@ -284,7 +284,9 @@
     ;;                              :nav-token <captured-token>}]
     ;;
     ;; …and the runtime threads the carried token against the current
-    ;; `:rf/route :nav-token`. Match → the inner fx runs (canonically a
+    ;; route slice's `:nav-token` (read from
+    ;; `[:rf/runtime :routing :current :nav-token]`). Match → the inner
+    ;; fx runs (canonically a
     ;; `:dispatch` to the success continuation). Mismatch → the inner fx
     ;; is suppressed and `:rf.route.nav-token/stale-suppressed` emits.
     ;;
@@ -500,9 +502,10 @@
 ;; db value, `save-scroll-position` returns a db value with the saved
 ;; position assoc'd in. Per Spec 012 §Multi-frame routing the saved-
 ;; position map lives at `[:rf/runtime :routing :scroll-positions]` INSIDE each
-;; frame's app-db (rf2-3ib8h: nested under the reserved :rf/route root
-;; key) — so per-frame isolation is achieved by routing the helpers
-;; through the appropriate frame's db value.
+;; frame's app-db (rf2-3ib8h + rf2-eguy4: a sibling key under
+;; `[:rf/runtime :routing ...]`, not nested under the route slice) — so
+;; per-frame isolation is achieved by routing the helpers through the
+;; appropriate frame's db value.
 ;;
 ;; These tests pin the helper round-trip directly so a regression in
 ;; either fn surfaces without going through the navigate flow's scroll fx.


### PR DESCRIPTION
Mayor Method worker cluster — three follow-ons from the rf2-vigjc routing audit on the post-rf2-eguy4 `:rf/runtime` restructure.

## Commit A — rf2-t7rjp (P3, prose)
Four stale references to the pre-rf2-eguy4 `:rf/route` root key surfaced in the routing artefact's prose. Paths are correct; only the explanatory text lagged.
- `implementation/routing/deps.edn` — header said routing-runtime sub-keys are "nested under `:rf/route`"; corrected to siblings under `[:rf/runtime :routing ...]`.
- `implementation/routing/test/re_frame/routing_test.clj` (scroll-restoration preamble + with-nav-token preamble) — same staleness in two test-file comments.
- `implementation/routing/test/re_frame/routing_concurrency_stress_test.clj` — `is-message` reframed from `:rf/route :id` to `route-slice :id`.

## Commit B — rf2-g8tzb (P3, load-bearing) — `merge-route-slice` helper
The restructure left two call sites writing the identical slice-publish merge:
- `routing/navigate.cljc` — `:rf.route/navigate` programmatic path
- `routing/url_change.cljc` — `:rf.route/transitioned` / `:rf.route/handle-url-change` URL path

Both did `(update-in db [:rf/runtime :routing :current] merge {<7-field-shape>})` with `:error nil` constant. The 7-field shape IS the slice contract from Spec 012 §The route slice + Spec-Schemas §`:rf/runtime`; encoding it twice means a future shape change requires two synchronised edits.

Extracted `merge-route-slice` to `routing/events.cljc` (next to the other pure helpers: `alloc-nav-token`, `emit-activation-traces!`, `identical-route-target?`). Helper takes `(db, slice-map)` where slice-map is the user-meaningful fields; forces `:error` to nil (successful-commit contract; the error-trap path in `on-match-error.cljc` writes `:error` explicitly).

Pairs with `routing/subs.cljc/route-sub-fn` for read+write symmetry at the public surface.

## Commit C — rf2-dnb5q (P4) — CLOSED as WONT-FIX (no commit)
Evaluated after Commit B landed per the task spec's evaluation gate. Decision: WONT-FIX.

The write helper IS load-bearing because two writers had to keep a 7-field shape synchronised; the read helper would NOT be load-bearing — there is no synchronisation burden between read sites (the shape only matters at the write boundary). The canonical reader already exists as `routing/subs.cljc/route-sub-fn` (publicly exported layer-1 sub fn); read+write symmetry is achieved at that public surface, not at every internal call site. Of the 8 src-side reads, most are paired with destructuring where the path's literal presence makes data-flow legible — and Spec 012 names the path as the contract, so hiding it behind one indirection at every internal site weakens that visibility. The 31 test-file reads use `(rf/get-frame-db <id>)` not `db`, so a `(current-slice db)` helper does not cleanly cover them either.

Full rationale captured on the bead close.

## Quality gates
- `cd implementation/routing && clojure -M:test` → **122 tests, 552 assertions, 0 failures, 0 errors** (run after each commit)
- `clj-kondo` on changed source namespaces (`events.cljc`, `navigate.cljc`, `url_change.cljc`) — **clean**
- CLJS `:node-test` build covers routing history tests — not runnable locally (Windows file-lock); CI authoritative

## Beads
- Closes rf2-t7rjp
- Closes rf2-g8tzb
- Closes rf2-dnb5q (wont-fix; not implemented per evaluation gate)