### PR TITLE
fix(xray): broken reserved-keys-buffer fixture + 4 cleanups (rf2-3v3k9 + rf2-xogq5 + rf2-lidwy + rf2-enqtx + rf2-eg6kl)

### DIFF
--- a/tools/xray/spec/007-UX-IA.md
+++ b/tools/xray/spec/007-UX-IA.md
@@ -1721,8 +1721,8 @@ genuinely per-frame surface each Static panel projects:
 
 | Tab | Frame-scoped (picker changes it) | Process-global (cross-frame) |
 |---|---|---|
-| **Machines** | live machine snapshots (`:rf/machines` in the target-frame db) | the machine-definition catalogue |
-| **Routes** | the current-route slice (`:rf/route`) | the route-definition catalogue |
+| **Machines** | live machine snapshots (the `:rf/machines` runtime area — `[:rf/runtime :machines :snapshots]` in the target-frame db) | the machine-definition catalogue |
+| **Routes** | the current-route slice (the `:rf/route` runtime area — `[:rf/runtime :routing :current]`) | the route-definition catalogue |
 | **Schemas** | the app-db-schema side-table (`schemas-by-frame`) | event-spec + sub-spec rows |
 | **Flows** | the flows registry (`{frame-id {flow-id …}}`, [Spec 013](../../../spec/013-Flows.md)) | — (fully per-frame) |
 | **Interceptors** | — | interceptor chains (live on globally registered events) |

--- a/tools/xray/spec/016-Auxiliary-Panels.md
+++ b/tools/xray/spec/016-Auxiliary-Panels.md
@@ -290,8 +290,9 @@ list browse-all surface with hermetic Simulate-URL preview.
 - **Per-row hermetic Simulate-navigation preview** — clicking the
   expanded row's `Simulate navigation` button renders an inline
   preview of `:on-match`'s app-db slot + the matched params, **without
-  calling the host's navigation fx**. The host's `:rf/route` slot is
-  unchanged; this is a lens, not a verb. Pure-data projection via
+  calling the host's navigation fx**. The host's current-route slice
+  (at `[:rf/runtime :routing :current]`) is unchanged; this is a lens,
+  not a verb. Pure-data projection via
   `routing_helpers/simulate-navigation-preview` (JVM-portable).
 - **Per-row `→ Dynamic` jump chip** — flips Xray to Dynamic mode
   (`:rf.xray/set-mode :dynamic`) and selects the Dynamic Routing
@@ -315,13 +316,14 @@ list browse-all surface with hermetic Simulate-URL preview.
 
 The Simulate-navigation preview MUST NOT call the host's navigation
 fx (`:rf/url-requested`, `:rf.route/navigate`, `history.pushState`,
-etc.). It MUST NOT write the host's `:rf/route` slot. The preview is
-a pure-data projection: given a route-id + a URL, return what
-`:on-match`'s app-db slot would look like if that URL navigated. The
-host stays where it is; Xray is a lens, not a verb. (This is the
-load-bearing distinction from the host's `:rf.route/navigate` fx —
-the Dynamic lens picks that up if the user runs it; the Static
-preview never does.)
+etc.). It MUST NOT write the host's current-route slice (at
+`[:rf/runtime :routing :current]`). The preview is a pure-data
+projection: given a route-id + a URL, return what `:on-match`'s
+app-db slot would look like if that URL navigated. The host stays
+where it is; Xray is a lens, not a verb. (This is the load-bearing
+distinction from the host's `:rf.route/navigate` fx — the Dynamic
+lens picks that up if the user runs it; the Static preview never
+does.)
 
 ### Empty state
 
@@ -350,8 +352,9 @@ signal.
 
 - `:rf.xray/registered-routes` — shared with Static Routes.
 - `:rf.xray/current-route-slice` — composite over
-  `:rf.xray/target-frame-db` reading the `:rf/route` slice.
-  Switching the L1 frame picker re-binds the lens.
+  `:rf.xray/target-frame-db` reading the current-route slice at
+  `[:rf/runtime :routing :current]`. Switching the L1 frame picker
+  re-binds the lens.
 - `:rf.xray/cascades` — the shared cascade projection. The composite
   scans the focused cascade's trace events for the routing-emit.
 - `:rf.xray/focus` — the spine's focused dispatch-id + epoch.
@@ -381,7 +384,8 @@ The composite scans the focused cascade's trace events for a
 inside both `:rf.route/navigate` and `:rf.route/transitioned`). Detection:
 
 - The emit's `:tags :route-id` is the **TO** (the new route).
-- The current `:rf/route` slice's `:id` (when different from TO) is
+- The current-route slice's `:id` (read at
+  `[:rf/runtime :routing :current]`) — when different from TO — is
   the **FROM**.
 - Same-route re-navigations (different params/query, same route-id)
   collapse FROM to nil — surfacing a FROM equal to TO is noise.
@@ -662,11 +666,12 @@ severity (different from `:error` / `:warning`, not pushed to top):
 Xray is a debugger, not a linter — advisories are quiet by default;
 configurable to "loud" via Settings → Trace → "Security advisories".
 
-### App-db tab — `:rf/route` slice always-visible
+### App-db tab — current-route slice always-visible
 
-The `:rf/route` slice is structured and small; it pins at the top of
-the App-db tab under a `[reserved]` group banner, always-expanded,
-with each sub-key on its own line. See
+The current-route slice (the `:rf/route` runtime area, at
+`[:rf/runtime :routing :current]`) is structured and small; it pins
+at the top of the App-db tab under a `[reserved]` group banner,
+always-expanded, with each sub-key on its own line. See
 [`019-Cross-Cutting-Insight.md`](019-Cross-Cutting-Insight.md) §2.2 R.11.
 
 Note that the Routing tab (§Routing tab above, rf2-nrbs9) is the
@@ -747,6 +752,7 @@ See [`007-UX-IA.md` §Settings popup](./007-UX-IA.md#settings-popup-modal-overla
   tab surfaces (under "Re-rendered" group).
 - [`spec/012-Routing.md`](../../../spec/012-Routing.md) — the
   framework substrate the Routing tab projects: the registrar
-  (`reg-route` + `(rf/registrations :route)`), the `:rf/route` slice,
-  and the `:rf.route.nav-token/allocated` emit the panel scans for
-  the FROM/TO marker derivation.
+  (`reg-route` + `(rf/registrations :route)`), the current-route
+  slice (at `[:rf/runtime :routing :current]`), and the
+  `:rf.route.nav-token/allocated` emit the panel scans for the
+  FROM/TO marker derivation.

--- a/tools/xray/spec/019-Cross-Cutting-Insight.md
+++ b/tools/xray/spec/019-Cross-Cutting-Insight.md
@@ -400,7 +400,9 @@ Match rank for :route/cart.item-detail vs URL /cart/items/abc:
   ...
 ```
 
-**Affordance:** App-db tab → `:rf/route` slice → rank-explainer (R-C5).
+**Affordance:** App-db tab → current-route slice (the `:rf/route`
+runtime area, at `[:rf/runtime :routing :current]`) → rank-explainer
+(R-C5).
 
 #### R.4 — Other route bug classes (catalogued)
 
@@ -412,7 +414,8 @@ Match rank for :route/cart.item-detail vs URL /cart/items/abc:
 - **R.8** Route-chain visualiser (`:parent` → child chain) (R-C9).
 - **R.9** Open-redirect security advisory (R-C10).
 - **R.10** Routing badge `🧭` on Event-list rows (R-C1).
-- **R.11** `:rf/route` slice always-visible in App-db tab (R-C2).
+- **R.11** current-route slice (the `:rf/route` runtime area, at
+  `[:rf/runtime :routing :current]`) always-visible in App-db tab (R-C2).
 
 ### §2.3 SSR / Hydration
 
@@ -702,7 +705,7 @@ NO new tabs. The placement is uniform across areas:
 | Tab | Cross-cutting growth |
 |---|---|
 | **Event** (`e`) | Per-fx **wire-boundary diff** (F-C2). `:on-match` event chain (R-C4). Retry timeline (F-C3). Head model inspector (S-C6). Server error projection (S-C5). Per-fx source-coord chip (F-C6). |
-| **App-db** (`a`) | `:rf/route` slice always-visible at top (R-C2). Hydration diff in App-db tab (S-C3). Route-chain visualiser (R-C9). Trusted-shell opt visualiser (S-C9). |
+| **App-db** (`a`) | current-route slice (`:rf/route` runtime area, `[:rf/runtime :routing :current]`) always-visible at top (R-C2). Hydration diff in App-db tab (S-C3). Route-chain visualiser (R-C9). Trusted-shell opt visualiser (S-C9). |
 | **Views** (`v`) | (Largely unchanged; flows surface in the "Re-rendered" group when a flow's downstream sub recomputed.) |
 | **Trace** (`t`) | **Wall-clock axis** for timer rings, retry waterfalls, deferred-dispatch arrivals. Nav-token timeline as sticky header (or via `r` popover). Streaming SSR boundary waterfall (F-C10 / S-C10). Skipped-on-platform tally chip (F-C9). |
 | **Machines** (`m`) | All of §2.1's M-C* features. The cancellation cascade visualiser (M-C3) is the tab's hero growth. |
@@ -754,8 +757,10 @@ sequenced so authors see compounding improvement week over week.
 
 1. **Badge expansion + routing badge** (F-C1, R-C1, S-C1) — add `🔌 📄 🌊
    🧭` to L2 event-list row badges; add SSR indicator to ribbon.
-2. **`:rf/route` slice always-visible + per-event route-chain + match-rank
-   tooltip** (R-C2, R-C5, R-C9) — App-db tab and Epoch panel inline content.
+2. **Current-route slice always-visible + per-event route-chain + match-rank
+   tooltip** (R-C2, R-C5, R-C9) — the `:rf/route` runtime area
+   (`[:rf/runtime :routing :current]`) pinned in the App-db tab; route-chain
+   + match-rank tooltip in the Epoch panel inline content.
 3. **Machine quick wins** (M-C1 guard-verdict overlay + M-C4 `:spawn-all`
    join card + M-C5 per-instance trace + M-C8 path-walked + M-C9 spawn-ancestry).
 4. **Effect surface quick wins** (F-C3 retry timeline + F-C5 stale badge

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff.cljs
@@ -13,16 +13,18 @@
   produces drives the body:
 
     - a TOP section — the app-db MINUS every reserved `:rf/*` key (the
-      user-domain app-db).
-    - one section per reserved `:rf/*` area (per spec/Conventions.md
-      §Reserved app-db keys: `:rf/machines`, `:rf/spawned`, `:rf/route`,
-      `:rf/system-ids`, `:rf/pending-navigation`, `:rf/elision`).
+      user-domain app-db). Per spec/Conventions.md §Reserved app-db
+      keys the runtime owns ONE top-level slot, `:rf/runtime`, and any
+      `:rf.<subns>/*` keys the framework stashes at the root.
+    - one section per operator-facing runtime area (per the
+      `runtime-areas` table — machines, routing, spawned, system-ids,
+      pending-navigation, elision — all nested under `:rf/runtime`).
       Map-of-instances areas (`:rf/machines`, `:rf/spawned`) FAN OUT to
       one named sub-section per instance (section title = the instance
-      id, e.g. `:title/flow`). Singleton slices (`:rf/route` SINGULAR —
-      the current-route slice per spec/012 §The `:rf/route` slice — and
-      the rest) render as one section each. Absent / empty areas still
-      render, as an empty-state placeholder.
+      id, e.g. `:title/flow`). Singleton slices (the current-route
+      slice at `[:rf/runtime :routing :current]` per spec/012 §The
+      `:rf/route` slice, and the rest) render as one section each.
+      Absent / empty areas still render, as an empty-state placeholder.
 
   Values render through the canonical EDN widget's cljs-devtools
   current-state path (`views.edn-widget.widget/inspect`), the same

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_helpers.cljc
@@ -31,11 +31,12 @@
 
   ## Reserved-keys partition — `partition-reserved`
 
-  Per spec §Reserved-keys group the runtime owns five top-level keys
-  (`:rf/machines`, `:rf/route`, `:rf/system-ids`,
-  `:rf/pending-navigation`, `:rf/spawned`). The diff triples for
-  those keys render in a separate `[runtime]` group; the rest render
-  as slice mini-panels.
+  Per spec §Reserved-keys group the runtime owns ONE top-level key
+  (`:rf/runtime`) which nests the per-area sub-paths catalogued in the
+  `runtime-areas` table (machines, routing, system-ids, pending-
+  navigation, spawned, …). Diff triples whose path roots in
+  `:rf/runtime` render in a separate `[runtime]` group; the rest
+  render as slice mini-panels.
 
   ## rf2-e9tb0 — pin-store helpers dropped
 
@@ -338,12 +339,11 @@
 (defn reserved-namespace-key?
   "True when `k` is a qualified keyword in the reserved `:rf/*` or
   `:rf.<subns>/*` namespace family per spec/Conventions.md §Reserved
-  namespaces. Catches BOTH the six explicit reserved-app-db-keys
-  (`:rf/machines` etc.) AND any other framework-internal key the
-  runtime stashes at the app-db root (e.g. `:rf.route/nav-token-
-  counter`, `:rf.machine/*` slots). The user-domain TOP section
-  must hide all of these — they're framework plumbing, not user-
-  domain state. Pure data → bool."
+  namespaces. Catches BOTH the single explicit reserved-app-db-key
+  (`:rf/runtime`) AND any other framework-internal key the runtime
+  stashes at the app-db root (e.g. `:rf.machine/*` slots). The
+  user-domain TOP section must hide all of these — they're framework
+  plumbing, not user-domain state. Pure data → bool."
   [k]
   (boolean
     (when (qualified-keyword? k)
@@ -354,12 +354,11 @@
 (defn user-domain-db
   "Return `db` with every reserved `:rf*`-namespaced key removed —
   the user-domain app-db that heads the inspector's TOP section. The
-  filter catches both the six explicit reserved-app-db-keys
-  (`:rf/machines` etc., per spec/Conventions.md §Reserved app-db keys)
-  AND any framework-internal slot the runtime stashes under the
-  broader reserved-namespace family (e.g. `:rf.route/nav-token-
-  counter`, `:rf.machine/*`). Pure data → map. nil-safe (nil db →
-  empty map)."
+  filter catches both the single explicit reserved-app-db-key
+  (`:rf/runtime`, per spec/Conventions.md §Reserved app-db keys) AND
+  any framework-internal slot the runtime stashes under the broader
+  reserved-namespace family (e.g. `:rf.machine/*`). Pure data → map.
+  nil-safe (nil db → empty map)."
   [db]
   (into {} (remove (fn [[k _v]] (reserved-namespace-key? k))) (or db {})))
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs
@@ -7,13 +7,14 @@
 
     - a TOP section — the app-db MINUS every reserved `:rf/*` key (the
       user-domain app-db). ALWAYS renders, even when empty.
-    - one section per POPULATED reserved `:rf/*` area (per
-      spec/Conventions.md §Reserved app-db keys). Map-of-instances
-      areas (`:rf/machines`, `:rf/spawned`) FAN OUT to one named
-      sub-section per instance — section title = the instance id (e.g.
-      `:title/flow`). Singleton slices (`:rf/route`, `:rf/system-ids`,
-      `:rf/pending-navigation`, `:rf/elision`) render as one section
-      each.
+    - one section per POPULATED operator-facing runtime area (per the
+      `runtime-areas` table — all nested under the single reserved
+      `:rf/runtime` slot per spec/Conventions.md §Reserved app-db
+      keys). Map-of-instances areas (`:rf/machines`, `:rf/spawned`)
+      FAN OUT to one named sub-section per instance — section title =
+      the instance id (e.g. `:title/flow`). Singleton slices
+      (`:rf/route`, `:rf/system-ids`, `:rf/pending-navigation`,
+      `:rf/elision`) render as one section each.
 
   rf2-jcdvo — empty / absent reserved areas are FILTERED at projection
   time (`current-state-sections` omits any `:empty?` entry). The

--- a/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_helpers_cljs_test.cljc
@@ -30,8 +30,7 @@
        counter wired through a wrapper.
 
     3. **Reserved-keys segregation.** `partition-reserved` splits
-       triples whose path roots in `:rf/machines` / `:rf/route` /
-       etc. into a separate group.
+       triples whose path roots in `:rf/runtime` into a separate group.
 
     4. **`epochs-touching-path` walks the history.** Returns only
        epochs that touched the focused path, classified by op.

--- a/tools/xray/test/day8/re_frame2_xray/panels/reactivity/routing_reactivity_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/reactivity/routing_reactivity_cljs_test.cljs
@@ -20,10 +20,12 @@
   (testing "rf2-dhoc9 — `:rf.xray/routing-tab-data` re-fires on focus
             flip; the composite map's identity changes between two
             focused cascades. The composite's `:current` slot reads
-            from the host frame's `:rf/route` so the slice stays
-            consistent; the `:from-id` / `:to-id` axes are derived
-            from the focused cascade's trace events. Either axis
-            change yields a different composite map."
+            from the host frame's
+            `[:rf/runtime :routing :current]` slice (via the
+            `:rf.route/id` sub) so the slice stays consistent; the
+            `:from-id` / `:to-id` axes are derived from the focused
+            cascade's trace events. Either axis change yields a
+            different composite map."
     (h/setup-xray-frame!)
     (h/seed-cascades! cascades)
     (h/focus-cascade! :c1)
@@ -44,7 +46,8 @@
 
 (deftest routing-tab-data-current-slice-tracks-host-frame
   (testing "rf2-dhoc9 — `:rf.xray/current-route-slice` reads off the
-            host frame's `:rf/route` slot. The reactive chain
+            host frame's `[:rf/runtime :routing :current]` slice
+            (via the `:rf.route/id` sub). The reactive chain
             `target-frame-db → current-route-slice → routing-tab-
             data` runs end-to-end."
     (h/setup-xray-frame!)

--- a/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs
@@ -2728,13 +2728,14 @@
 (deftest zoom-affordance-composes-prefix-and-relative-path
   ;; The renderer threads the absolute path = (into zoom-path-prefix path)
   ;; into the affordance — so when the operator is already zoomed at
-  ;; `[:rf/machines]` and clicks the affordance on the nested `:ws/connection`
-  ;; container (relative path `[:ws/connection]`), the dispatch carries
-  ;; the FULL absolute path `[:rf/machines :ws/connection]`.
+  ;; `[:rf/runtime :machines :snapshots]` and clicks the affordance on the
+  ;; nested `:ws/connection` container (relative path `[:ws/connection]`),
+  ;; the dispatch carries the FULL absolute path
+  ;; `[:rf/runtime :machines :snapshots :ws/connection]`.
   (let [v {:ws/connection {:state :open}}
         ;; Drive the renderer with a non-trivial zoom-path-prefix to
-        ;; simulate "we're already zoomed into :rf/machines and looking
-        ;; at its child :ws/connection".
+        ;; simulate "we're already zoomed into machine snapshots and
+        ;; looking at its child :ws/connection".
         h (ei/render-node {:value v
                            :panel-id :p
                            :mount-id "m"
@@ -2742,7 +2743,7 @@
                            :depth 0
                            :expansion-map {}
                            :zoomable? true
-                           :zoom-path-prefix [:rf/machines]
+                           :zoom-path-prefix [:rf/runtime :machines :snapshots]
                            :opts {:default-expanded-depth 8}})
         affordance (find-attr h :data-rf-affordance "zoom")]
     (is (some? affordance)
@@ -2753,7 +2754,7 @@
     ;; Confirm via integration: re-build the affordance the same way
     ;; render-container does, mirroring the zoom-path-prefix + path
     ;; composition.
-    (let [composed (vec (concat [:rf/machines] [:ws/connection]))
+    (let [composed (vec (concat [:rf/runtime :machines :snapshots] [:ws/connection]))
           h2       (ei/zoom-affordance-button
                      {:dispatch-fn   nil
                       :panel-id      :p
@@ -2761,7 +2762,8 @@
                       :absolute-path composed
                       :testid        "x"})
           {:keys [event opts]} (with-rf-dispatch-spy (-> h2 second :on-click))]
-      (is (= [:rf.xray.edn-inspector/zoom-to :p "m" [:rf/machines :ws/connection]]
+      (is (= [:rf.xray.edn-inspector/zoom-to :p "m"
+              [:rf/runtime :machines :snapshots :ws/connection]]
              event)
           "the dispatched path is the absolute path = prefix + relative")
       (is (= :rf/xray (:frame opts))

--- a/tools/xray/testbeds/panel_gallery/fixtures_app_db.cljs
+++ b/tools/xray/testbeds/panel_gallery/fixtures_app_db.cljs
@@ -216,19 +216,23 @@
 
 (defn reserved-keys-buffer
   "Epoch mutating reserved app-db keys (per Spec Conventions §Reserved
-  app-db keys: `:rf/machines`, `:rf/route`, `:rf/spawned`, `:rf/elision`).
-  Panel routes these into the `[runtime]` group via
+  app-db keys the runtime owns ONE top-level slot, `:rf/runtime`,
+  which nests the per-area sub-paths catalogued by the panel's
+  `runtime-areas` table — `:routing :current`, `:machines :snapshots`,
+  `:machines :spawned`, `:elision`). Panel routes diff triples rooted
+  in `:rf/runtime` into the `[runtime]` group via
   `app-db-diff-helpers/partition-reserved` — the axis pins that branch."
   []
   [(epoch-record
      {:epoch-id 10
       :event    [:rf/route-change]
-      :db-before {:rf/route    {:path "/home"}
-                  :rf/machines {}
+      :db-before {:rf/runtime {:routing  {:current {:path "/home"}}
+                               :machines {:snapshots {}}}
                   :counter 5}
-      :db-after  {:rf/route    {:path "/cart" :query {:tab :items}}
-                  :rf/machines {:checkout {:state :idle}}
-                  :rf/spawned  {:worker/sync :alive}
+      :db-after  {:rf/runtime {:routing  {:current {:path "/cart"
+                                                    :query {:tab :items}}}
+                               :machines {:snapshots {:checkout {:state :idle}}
+                                          :spawned   {:worker/sync :alive}}}
                   :counter 6}})])
 
 ;; ---- tab-specific buffer builders --------------------------------------

--- a/tools/xray/testbeds/panel_gallery/fixtures_epoch.cljs
+++ b/tools/xray/testbeds/panel_gallery/fixtures_epoch.cljs
@@ -459,7 +459,7 @@
                            {:armed true}
                            nil
                            nil)
-        (db-changed-ev [[[:rf/machines :ws/connection :state]
+        (db-changed-ev [[[:rf/runtime :machines :snapshots :ws/connection :state]
                          :connecting :open :modified]])
         (do-fx-ev {:db ::placeholder
                    :dispatch [:ws/notify :open]

--- a/tools/xray/testbeds/panel_gallery/fixtures_machines.cljs
+++ b/tools/xray/testbeds/panel_gallery/fixtures_machines.cljs
@@ -18,8 +18,8 @@
 
   These exist precisely for gallery / test fixtures — the production
   path reads through `(rf/machines)` + `(rf/machine-meta id)` +
-  app-db's `:rf/machines` slot. Variant `:events` dispatch the
-  override events to seed each slot.
+  the app-db's `[:rf/runtime :machines :snapshots]` subtree. Variant
+  `:events` dispatch the override events to seed each slot.
 
   ## Machine-definition shape (per Spec 005)
 

--- a/tools/xray/testbeds/panel_gallery/fixtures_routing.cljs
+++ b/tools/xray/testbeds/panel_gallery/fixtures_routing.cljs
@@ -8,8 +8,8 @@
       :route)`; test override slot exists at
       `:rf.xray/set-registered-routes-override-for-test`.
     - `:rf.xray/current-route-slice` — defaults to the target-frame
-      app-db's `:rf/route` slot; test override slot at
-      `:rf.xray/set-current-route-slice-override-for-test`.
+      app-db's `[:rf/runtime :routing :current]` slice; test override
+      slot at `:rf.xray/set-current-route-slice-override-for-test`.
     - `:rf.xray/cascades` — drives the FROM/TO detection. Seed via
       `:rf.xray/sync-trace-buffer` + `:rf.xray/focus-cascade` so
       the spine's focused cascade carries the

--- a/tools/xray/testbeds/panel_gallery/gallery_app_db.cljs
+++ b/tools/xray/testbeds/panel_gallery/gallery_app_db.cljs
@@ -157,10 +157,12 @@
 
   ;; ----- 12. reserved keys (panel-specific axis) ---------------------
   (story/reg-variant :story.xray.app-db/reserved-keys
-    {:doc        "Epoch mutating reserved app-db keys (`:rf/route`,
-                 `:rf/machines`, `:rf/spawned`). The `[runtime]` group
-                 surfaces these separately from user-key slices per
-                 Spec Conventions §Reserved app-db keys."
+    {:doc        "Epoch mutating reserved app-db keys — paths under the
+                 single `:rf/runtime` slot covering the routing
+                 current-route slice, machine snapshots, and the
+                 spawned-actor table. The `[runtime]` group surfaces
+                 these separately from user-key slices per Spec
+                 Conventions §Reserved app-db keys."
      :events     [[:rf.xray/sync-epoch-history (fixtures/reserved-keys-buffer)]]
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})

--- a/tools/xray/testbeds/panel_gallery/gallery_machines.cljs
+++ b/tools/xray/testbeds/panel_gallery/gallery_machines.cljs
@@ -9,8 +9,9 @@
     - `:rf.xray/registered-machines`  — defaults to `(rf/machines)`;
                                          test override slot exists.
     - `:rf.xray/machine-snapshots`    — defaults to target-frame's
-                                         `:rf/machines`; test override
-                                         slot exists.
+                                         `[:rf/runtime :machines
+                                          :snapshots]` subtree; test
+                                         override slot exists.
     - `:rf.xray/machine-definitions`  — defaults to
                                          `(rf/machine-meta ...)`; test
                                          override slot exists.

--- a/tools/xray/testbeds/panel_gallery/gallery_routing.cljs
+++ b/tools/xray/testbeds/panel_gallery/gallery_routing.cljs
@@ -8,8 +8,9 @@
                                           :route)`; test override slot
                                           exists.
     - `:rf.xray/current-route-slice`   — default target-frame's
-                                          `:rf/route`; test override
-                                          slot exists.
+                                          `[:rf/runtime :routing
+                                           :current]` slice; test
+                                          override slot exists.
     - `:rf.xray/cascades`              — drives FROM/TO detection.
     - `:rf.xray/focus`                 — the spine's focused
                                           dispatch-id.

--- a/tools/xray/testbeds/testdeck/machine.cljs
+++ b/tools/xray/testbeds/testdeck/machine.cljs
@@ -7,8 +7,9 @@
 
   Shared by both testdeck surfaces (two-frame isolation testbed +
   step-deck rf2-6qgbs.2). The machine is registered once globally; its
-  snapshot lives in each frame's `[:rf/machines :ws/connection]` slot,
-  so the ABOVE frame can be `:connected` while the BELOW frame sits at
+  snapshot lives in each frame's
+  `[:rf/runtime :machines :snapshots :ws/connection]` slot, so the
+  ABOVE frame can be `:connected` while the BELOW frame sits at
   `:disconnected` — an isolated machine per frame (Spec 006 §The cache
   is held inside the frame container).
 
@@ -194,8 +195,9 @@
 (def initial-db
   "Initial `:machine-ui` slice — the message-input draft. Held in
   app-db (frame-scoped, Xray-observable) rather than a component-local
-  atom. The machine's own state lives in `[:rf/machines :ws/connection]`
-  and is seeded lazily on first dispatch."
+  atom. The machine's own state lives in
+  `[:rf/runtime :machines :snapshots :ws/connection]` and is seeded
+  lazily on first dispatch."
   {:machine-ui {:draft ""}})
 
 (defn register-all!

--- a/tools/xray/testbeds/testdeck/panel.cljs
+++ b/tools/xray/testbeds/testdeck/panel.cljs
@@ -59,7 +59,8 @@
           ;; the runtime synthesises the :disconnected snapshot on first
           ;; dispatch).
           [:dispatch [:ws/connection [:ws/noop]]]
-          ;; Land on the default tab — writes this frame's :rf/route slot.
+          ;; Land on the default tab — writes this frame's
+          ;; [:rf/runtime :routing :current] slice.
           [:dispatch [:rf.route/navigate routes/default-tab]]]}))
 
 ;; ============================================================================
@@ -243,8 +244,8 @@
   (let [active @(subscribe [:testdeck/active-tab])]
     [:div {:data-testid (str frame-label "-routing-tab")}
      [:p {:style {:color "#444" :margin "0.5em 0"}}
-      "Tabs are routes. The active tab below is this frame's "
-      [:code ":rf/route"] " slot — switching tabs is "
+      "Tabs are routes. The active tab below is this frame's current "
+      "route slice — switching tabs is "
       [:code ":rf.route/navigate"] ", scoped to this frame."]
      [:div {:data-testid (str frame-label "-route-current")
             :style (merge mono {:margin "0.25em 0"})}

--- a/tools/xray/testbeds/testdeck/routes.cljs
+++ b/tools/xray/testbeds/testdeck/routes.cljs
@@ -19,13 +19,14 @@
 
   Each frame is an isolated reactive context (Spec 006 §The cache is
   held inside the frame container). The two-frame testbed mounts two
-  frame-providers; the route slot (`:rf.route/id`) lives in each
-  frame's own `app-db`, so the ABOVE frame can sit on the Counter tab
-  while the BELOW frame sits on the Machine tab — there is no shared
-  route state and no cross-frame navigation. The `route-tab` view
-  below dispatches `:rf.route/navigate` through the surrounding
-  frame-provider's injected `dispatch`, so a tab click navigates ONLY
-  the frame it was clicked in."
+  frame-providers; the current route slice lives at
+  `[:rf/runtime :routing :current]` in each frame's own `app-db` and
+  is read through the `:rf.route/id` sub, so the ABOVE frame can sit
+  on the Counter tab while the BELOW frame sits on the Machine tab —
+  there is no shared route state and no cross-frame navigation. The
+  `route-tab` view below dispatches `:rf.route/navigate` through the
+  surrounding frame-provider's injected `dispatch`, so a tab click
+  navigates ONLY the frame it was clicked in."
   (:require [re-frame.core :as rf]
             ;; Routing ships in day8/re-frame2-routing. Requiring
             ;; re-frame.routing triggers its load-time hook + the

--- a/tools/xray/testbeds/two_frame_isolation/README.md
+++ b/tools/xray/testbeds/two_frame_isolation/README.md
@@ -77,19 +77,21 @@ See the saved Mike-feedback memories:
 Each tab is a registered route (`testdeck.routes`). Switching tabs is
 `:rf.route/navigate`, dispatched through the clicked frame's injected
 `dispatch` — so the ABOVE frame can sit on Counter while BELOW sits on
-Machine. The active route id lives in each frame's own `:rf/route`
-slot.
+Machine. The active route id lives in each frame's own
+`[:rf/runtime :routing :current]` slice (read through the
+`:rf.route/id` sub).
 
 ### URL ownership across two frames
 
 A browser has one address bar but this page has two routed frames. Per
 `spec/012-Routing.md` §Multi-frame routing only one frame may own the
 URL. Both frames are registered **non-url-bound**
-(`:url-bound? false`), so each frame's `:rf/route` slot updates on tab
-nav while the browser-history push no-ops (no two-frame URL race). The
-route SLOT — the isolation point — stays per-frame; only the shared
-browser-URL sync is suppressed. (The single-frame step-deck, rf2-6qgbs.2,
-uses the default URL-bound frame, so its tab nav syncs the address bar.)
+(`:url-bound? false`), so each frame's `[:rf/runtime :routing :current]`
+slice updates on tab nav while the browser-history push no-ops (no
+two-frame URL race). The route slice — the isolation point — stays
+per-frame; only the shared browser-URL sync is suppressed. (The
+single-frame step-deck, rf2-6qgbs.2, uses the default URL-bound frame,
+so its tab nav syncs the address bar.)
 
 ## Issues source — the slow fetch is intentional
 
@@ -113,8 +115,9 @@ Machines, Routing, Issues, Trace) panel between observing `:above` and
    `:counter` movement.
 
 2. **Per-frame routing.** Navigate `:above` to the Machine tab and
-   `:below` to the Routing tab. Each frame's `:rf/route` slot differs;
-   the Xray routing lens shows each frame's active route independently.
+   `:below` to the Routing tab. Each frame's
+   `[:rf/runtime :routing :current]` slice differs; the Xray routing
+   lens shows each frame's active route independently.
 
 3. **Per-frame machine state.** Click Connect on `:below`'s Machine
    tab. Open the Machines lens — `:ws/connection` walks `:connecting →

--- a/tools/xray/testbeds/two_frame_isolation/core.cljs
+++ b/tools/xray/testbeds/two_frame_isolation/core.cljs
@@ -51,10 +51,10 @@
   A browser has ONE address bar but this page has TWO routed frames.
   Per Spec 012 §Multi-frame routing only one frame may own the URL.
   Both `:above` and `:below` are registered NON-url-bound, so each
-  frame's `:rf/route` slot updates on tab nav while the browser-history
-  push no-ops (no two-frame URL race). The route SLOT — the isolation
-  point — stays per-frame; only the shared browser-URL sync is
-  suppressed.
+  frame's `[:rf/runtime :routing :current]` slice updates on tab nav
+  while the browser-history push no-ops (no two-frame URL race). The
+  route slice — the isolation point — stays per-frame; only the shared
+  browser-URL sync is suppressed.
 
   ## Test surface, not tutorial
 


### PR DESCRIPTION
Five follow-on beads from the rf2-1bldb xray-surface audit, sequenced smallest→biggest within one PR. Four are pre-alpha prose/synthetic-path cleanups; one (rf2-3v3k9) is a real defect — a gallery fixture degraded after the eguy4 `:rf/runtime` restructure.

## Commits

- **`c1c4653a5` chore(xray): synthetic-path fixtures use `:rf/runtime` shape (rf2-eg6kl)** — fixture realism. `fixtures_epoch.cljs` db-changed-ev and the `zoom-affordance-composes-prefix-and-relative-path` test now use realistic post-eguy4 paths (`[:rf/runtime :machines :snapshots ...]`). No behavioural impact — logic is path-agnostic.
- **`a48d6961c` chore(xray): testbed docstrings reference `:rf/runtime` container (rf2-lidwy)** — sweep prose drift in `panel_gallery/` fixtures + `testdeck/` namespace docstrings + `two_frame_isolation/` README + routing-reactivity test docstrings. Prose-only.
- **`cf68c10af` chore(xray): docstring sweep — `:rf/runtime` container in app-db-diff helpers + panels (rf2-xogq5)** — six docstring sites in `app_db_diff_helpers.cljc`, `app_db_diff.cljs`, `app_db_diff_state.cljs`, and the helpers cljs test that contradicted `reserved-app-db-keys #{:rf/runtime}`. Prose-only.
- **`8f1e3144e` docs(xray/spec): `:rf/route` slot/slice prose untangled (rf2-enqtx)** — `tools/xray/spec/007-UX-IA.md`, `016-Auxiliary-Panels.md`, `019-Cross-Cutting-Insight.md` had ambiguous `:rf/route slot` / `:rf/route slice` phrasing. Clarified as "current-route slice (the `:rf/route` runtime area, at `[:rf/runtime :routing :current]`)" or similar throughout. Per `[[xray-specs-kept-current]]`, spec edits ride in the same PR as the code edits.
- **`3474e9ed0` fix(xray): reserved-keys-buffer fixture seeds `:rf/runtime` container (rf2-3v3k9)** — real defect. `testbeds/panel_gallery/fixtures_app_db.cljs` `reserved-keys-buffer` seeded `:db-before` / `:db-after` with the OLD direct-root shape (`{:rf/route ... :rf/machines ... :rf/spawned ...}`). Post-eguy4 `partition-reserved` keys on `:rf/runtime`, so those triples routed to `:changed-non-reserved` instead of the `[runtime]` group — the `:story.xray.app-db/reserved-keys` gallery story silently degraded. Migrated the seed to nest under `:rf/runtime` (`:routing :current`, `:machines :snapshots`, `:machines :spawned`) so the partition routes back into the `[runtime]` group and the story exercises its named axis again.

## Gates

- `tools/xray && clojure -M:test` → **956 tests / 3754 assertions / 0 failures / 0 errors** (run on final tip).
- `clj-kondo --lint` over the 17 changed namespaces → 0 errors, 1 warning (`unused binding top` in `app_db_diff_state.cljs:587` — pre-existing on `origin/main`, untouched by this PR).

## Closes

- rf2-3v3k9 (P2 real defect)
- rf2-xogq5 (P3 docstring drift)
- rf2-lidwy (P3 testbed docstring drift)
- rf2-enqtx (P3 spec prose drift)
- rf2-eg6kl (P4 synthetic-path fixture realism)