### PR TITLE
refactor(core): extract elision-slot helpers + cosmetic indents (rf2-x8p3v + rf2-9o4t8 + rf2-35he3)

### DIFF
--- a/implementation/core/src/re_frame/elision.cljc
+++ b/implementation/core/src/re_frame/elision.cljc
@@ -98,7 +98,20 @@
     :else
     db))
 
-(defn- swap-registry!
+(defn ^:no-doc swap-elision-slot!
+  "Read-transform-write helper for the per-frame elision registry.
+
+  Reads the registry at `[:rf/runtime :elision]` from `frame-id`'s
+  app-db, applies `(f reg) -> new-reg`, and writes the result back
+  through `write-elision-slot` (which prunes a stranded `:rf/runtime`
+  when the slot clears). No-op when the frame's container does not
+  exist. Returns nil.
+
+  Internal helper; exposed (with `^:no-doc`) so the sibling
+  `re-frame.marks` ns — which mutates the SAME slot from its
+  `add-marks` / `set-marks` / `clear-app-db-marks!` / `write-marks!`
+  paths — can share a single source of truth for the read-transform-
+  write skeleton. Not part of the public API."
   [frame-id f]
   (when-let [container (frame/get-frame-db frame-id)]
     (let [old-db  (adapter/read-container container)
@@ -134,7 +147,7 @@
 
 (defn- install-schema-declarations!
   [frame-id registry-key schema-decls]
-  (swap-registry! frame-id
+  (swap-elision-slot! frame-id
     (fn [reg]
       (let [without-schema (reduce-kv
                              (fn [acc path decl]

--- a/implementation/core/src/re_frame/elision.cljc
+++ b/implementation/core/src/re_frame/elision.cljc
@@ -68,28 +68,43 @@
   (when-let [container (frame/get-frame-db frame-id)]
     (get-in (adapter/read-container container) [:rf/runtime :elision])))
 
+(defn ^:no-doc write-elision-slot
+  "Set or clear the per-frame elision registry inside `db`. When `new-reg`
+  is non-empty it lands at `[:rf/runtime :elision]`. When empty, the
+  slot is removed — and if the resulting `:rf/runtime` becomes empty,
+  the `:rf/runtime` key itself is dissoc'd so apps that never used
+  framework state don't manifest a stray nil container.
+
+  Internal helper; exposed (with `^:no-doc`) so the sibling
+  `re-frame.marks` ns — which writes through the SAME slot via
+  `add-marks` / `set-marks` / `clear-app-db-marks!` — can share a
+  single source of truth for the runtime-prune logic. Not part of the
+  public API."
+  [db new-reg]
+  (cond
+    (seq new-reg)
+    (assoc-in db [:rf/runtime :elision] new-reg)
+
+    ;; Clearing — only mutate when there's actually an :elision slot to
+    ;; clear, so apps that never used elision don't get a stray
+    ;; `:rf/runtime nil` entry.
+    (and (contains? db :rf/runtime)
+         (contains? (get db :rf/runtime) :elision))
+    (let [next-runtime (dissoc (get db :rf/runtime) :elision)]
+      (if (seq next-runtime)
+        (assoc db :rf/runtime next-runtime)
+        (dissoc db :rf/runtime)))
+
+    :else
+    db))
+
 (defn- swap-registry!
   [frame-id f]
   (when-let [container (frame/get-frame-db frame-id)]
     (let [old-db  (adapter/read-container container)
           old-reg (get-in old-db [:rf/runtime :elision])
           new-reg (f old-reg)
-          new-db  (cond
-                    (seq new-reg)
-                    (assoc-in old-db [:rf/runtime :elision] new-reg)
-
-                    ;; Clearing — only mutate when there's actually an
-                    ;; :elision slot to clear, so apps that never used
-                    ;; elision don't get a stray `:rf/runtime nil` entry.
-                    (and (contains? old-db :rf/runtime)
-                         (contains? (get old-db :rf/runtime) :elision))
-                    (let [next-runtime (dissoc (get old-db :rf/runtime) :elision)]
-                      (if (seq next-runtime)
-                        (assoc old-db :rf/runtime next-runtime)
-                        (dissoc old-db :rf/runtime)))
-
-                    :else
-                    old-db)]
+          new-db  (write-elision-slot old-db new-reg)]
       (adapter/replace-container! container new-db)))
   nil)
 

--- a/implementation/core/src/re_frame/marks.cljc
+++ b/implementation/core/src/re_frame/marks.cljc
@@ -153,17 +153,6 @@
 ;; this namespace and live alongside per Spec 015 §Relationship with
 ;; schema-attached marks.
 
-(defn- swap-app-db!
-  "Mutate the frame's app-db through the substrate adapter. The mark-
-  registry lives at `[:rf/runtime :elision ...]` per Spec 015
-  §Mark-lookup table shape and matches the schema-first elision
-  walker's storage location."
-  [frame-id f]
-  (when-let [container (frame/get-frame-db frame-id)]
-    (let [old-db (adapter/read-container container)
-          new-db (f old-db)]
-      (adapter/replace-container! container new-db))))
-
 (defn- without-marks-sourced
   "Drop entries whose `:source` is `:marks` from a declaration map.
   Used by `set-marks` to clear the prior `add-marks` / `set-marks`
@@ -206,15 +195,13 @@
   If the resulting `[:rf/runtime :elision]` map is empty, the slot is
   dissoc'd from `:rf/runtime`."
   [frame-id sensitive-decls large-decls]
-  (swap-app-db! frame-id
-    (fn [db]
-      (let [reg     (get-in db [:rf/runtime :elision])
-            new-reg (cond-> (or reg {})
-                      (seq sensitive-decls)   (assoc :sensitive-declarations sensitive-decls)
-                      (empty? sensitive-decls) (dissoc :sensitive-declarations)
-                      (seq large-decls)       (assoc :declarations large-decls)
-                      (empty? large-decls)    (dissoc :declarations))]
-        (elision/write-elision-slot db new-reg)))))
+  (elision/swap-elision-slot! frame-id
+    (fn [reg]
+      (cond-> (or reg {})
+        (seq sensitive-decls)    (assoc :sensitive-declarations sensitive-decls)
+        (empty? sensitive-decls) (dissoc :sensitive-declarations)
+        (seq large-decls)        (assoc :declarations large-decls)
+        (empty? large-decls)     (dissoc :declarations)))))
 
 (defn add-marks
   "Additively merge path-marks into the `app-db` mark-set of `frame-id`.
@@ -244,17 +231,15 @@
   that path's mark."
   [frame-id path->mark]
   (let [[sens-paths large-paths] (split-by-mark path->mark)]
-    (swap-app-db! frame-id
-      (fn [db]
-        (let [reg     (get-in db [:rf/runtime :elision])
-              new-s   (assoc-paths (get reg :sensitive-declarations) sens-paths)
-              new-l   (assoc-paths (get reg :declarations) large-paths)
-              new-reg (cond-> (or reg {})
-                        (seq new-s) (assoc :sensitive-declarations new-s)
-                        (empty? new-s) (dissoc :sensitive-declarations)
-                        (seq new-l) (assoc :declarations new-l)
-                        (empty? new-l) (dissoc :declarations))]
-          (elision/write-elision-slot db new-reg)))))
+    (elision/swap-elision-slot! frame-id
+      (fn [reg]
+        (let [new-s (assoc-paths (get reg :sensitive-declarations) sens-paths)
+              new-l (assoc-paths (get reg :declarations) large-paths)]
+          (cond-> (or reg {})
+            (seq new-s)    (assoc :sensitive-declarations new-s)
+            (empty? new-s) (dissoc :sensitive-declarations)
+            (seq new-l)    (assoc :declarations new-l)
+            (empty? new-l) (dissoc :declarations))))))
   frame-id)
 
 (defn set-marks
@@ -284,21 +269,19 @@
   Use `add-marks` for additive-merge semantics."
   [frame-id path->mark]
   (let [[sens-paths large-paths] (split-by-mark path->mark)]
-    (swap-app-db! frame-id
-      (fn [db]
-        (let [reg     (get-in db [:rf/runtime :elision])
-              ;; Drop prior :marks-sourced entries first (schema-sourced survive),
-              ;; then assoc the new paths.
-              carry-s (without-marks-sourced (get reg :sensitive-declarations))
+    (elision/swap-elision-slot! frame-id
+      (fn [reg]
+        ;; Drop prior :marks-sourced entries first (schema-sourced survive),
+        ;; then assoc the new paths.
+        (let [carry-s (without-marks-sourced (get reg :sensitive-declarations))
               carry-l (without-marks-sourced (get reg :declarations))
               new-s   (assoc-paths carry-s sens-paths)
-              new-l   (assoc-paths carry-l large-paths)
-              new-reg (cond-> (or reg {})
-                        (seq new-s) (assoc :sensitive-declarations new-s)
-                        (empty? new-s) (dissoc :sensitive-declarations)
-                        (seq new-l) (assoc :declarations new-l)
-                        (empty? new-l) (dissoc :declarations))]
-          (elision/write-elision-slot db new-reg)))))
+              new-l   (assoc-paths carry-l large-paths)]
+          (cond-> (or reg {})
+            (seq new-s)    (assoc :sensitive-declarations new-s)
+            (empty? new-s) (dissoc :sensitive-declarations)
+            (seq new-l)    (assoc :declarations new-l)
+            (empty? new-l) (dissoc :declarations))))))
   frame-id)
 
 (defn clear-app-db-marks!
@@ -306,15 +289,13 @@
   `frame-id`. Schema-sourced declarations are preserved. Returns nil.
   Test-isolation only; production code rarely needs this."
   [frame-id]
-  (swap-app-db! frame-id
-    (fn [db]
-      (let [reg     (get-in db [:rf/runtime :elision])
-            new-s   (without-marks-sourced (:sensitive-declarations reg))
-            new-l   (without-marks-sourced (:declarations reg))
-            new-reg (cond-> {}
-                      (seq new-s) (assoc :sensitive-declarations new-s)
-                      (seq new-l) (assoc :declarations new-l))]
-        (elision/write-elision-slot db new-reg))))
+  (elision/swap-elision-slot! frame-id
+    (fn [reg]
+      (let [new-s (without-marks-sourced (:sensitive-declarations reg))
+            new-l (without-marks-sourced (:declarations reg))]
+        (cond-> {}
+          (seq new-s) (assoc :sensitive-declarations new-s)
+          (seq new-l) (assoc :declarations new-l)))))
   nil)
 
 ;; ---- emit-time projection ------------------------------------------------

--- a/implementation/core/src/re_frame/marks.cljc
+++ b/implementation/core/src/re_frame/marks.cljc
@@ -32,7 +32,8 @@
   `[:rf/runtime :elision :declarations]`), keyed by absolute path. The
   two declaration sources union at lookup time — a path declared
   sensitive by EITHER source is sensitive."
-  (:require [re-frame.frame :as frame]
+  (:require [re-frame.elision :as elision]
+            [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.privacy :as privacy]
@@ -163,27 +164,6 @@
           new-db (f old-db)]
       (adapter/replace-container! container new-db))))
 
-(defn- write-elision-slot
-  "Set or clear the per-frame elision registry inside `db`. When `new-reg`
-  is non-empty it lands at `[:rf/runtime :elision]`. When empty, the
-  slot is removed — and if the resulting `:rf/runtime` becomes empty,
-  the `:rf/runtime` key itself is dissoc'd so apps that never used
-  framework state don't manifest a stray nil container."
-  [db new-reg]
-  (cond
-    (seq new-reg)
-    (assoc-in db [:rf/runtime :elision] new-reg)
-
-    (and (contains? db :rf/runtime)
-         (contains? (get db :rf/runtime) :elision))
-    (let [next-runtime (dissoc (get db :rf/runtime) :elision)]
-      (if (seq next-runtime)
-        (assoc db :rf/runtime next-runtime)
-        (dissoc db :rf/runtime)))
-
-    :else
-    db))
-
 (defn- without-marks-sourced
   "Drop entries whose `:source` is `:marks` from a declaration map.
   Used by `set-marks` to clear the prior `add-marks` / `set-marks`
@@ -234,7 +214,7 @@
                       (empty? sensitive-decls) (dissoc :sensitive-declarations)
                       (seq large-decls)       (assoc :declarations large-decls)
                       (empty? large-decls)    (dissoc :declarations))]
-        (write-elision-slot db new-reg)))))
+        (elision/write-elision-slot db new-reg)))))
 
 (defn add-marks
   "Additively merge path-marks into the `app-db` mark-set of `frame-id`.
@@ -274,7 +254,7 @@
                         (empty? new-s) (dissoc :sensitive-declarations)
                         (seq new-l) (assoc :declarations new-l)
                         (empty? new-l) (dissoc :declarations))]
-          (write-elision-slot db new-reg)))))
+          (elision/write-elision-slot db new-reg)))))
   frame-id)
 
 (defn set-marks
@@ -318,7 +298,7 @@
                         (empty? new-s) (dissoc :sensitive-declarations)
                         (seq new-l) (assoc :declarations new-l)
                         (empty? new-l) (dissoc :declarations))]
-          (write-elision-slot db new-reg)))))
+          (elision/write-elision-slot db new-reg)))))
   frame-id)
 
 (defn clear-app-db-marks!
@@ -334,7 +314,7 @@
             new-reg (cond-> {}
                       (seq new-s) (assoc :sensitive-declarations new-s)
                       (seq new-l) (assoc :declarations new-l))]
-        (write-elision-slot db new-reg))))
+        (elision/write-elision-slot db new-reg))))
   nil)
 
 ;; ---- emit-time projection ------------------------------------------------

--- a/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
+++ b/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
@@ -1424,7 +1424,7 @@
     (rf/reg-event-db :seed
       (fn [db _]
         (assoc-in db [:rf/runtime :machines :snapshots] {:flow/login    {:state :authed  :data {}}
-                                :flow/checkout {:state :pending :data {}}})))
+                                                         :flow/checkout {:state :pending :data {}}})))
     (rf/dispatch-sync [:seed] {:frame :tenant-x})
     (let [traces (collect-traces ::xspec-1)]
       (rf/destroy-frame! :tenant-x)

--- a/implementation/core/test/re_frame/elision_test.clj
+++ b/implementation/core/test/re_frame/elision_test.clj
@@ -347,11 +347,11 @@
         sub-cache {[:auth/token]   {:value {:token "shh-secret"} :ref-count 1}
                    [:cart/total]   {:value 42 :ref-count 2}}]
     ;; Install the sensitive declaration directly into the live registry
-    ;; via the private `swap-registry!` helper — the same code path
+    ;; via the internal `swap-elision-slot!` helper — the same code path
     ;; `populate-sensitive-from-schemas!` uses, just without the
     ;; schema-extraction step (sub-cache content has no natural app-
     ;; schema path).
-    (#'re-frame.elision/swap-registry!
+    (re-frame.elision/swap-elision-slot!
        frame-id
        (fn [reg]
          (assoc reg :sensitive-declarations
@@ -381,7 +381,7 @@
   (let [path     [[:user/uploaded] :value :pdf]
         frame-id :rf/default
         sub-cache {[:user/uploaded] {:value {:pdf "<<5MB-blob>>"} :ref-count 1}}]
-    (#'re-frame.elision/swap-registry!
+    (re-frame.elision/swap-elision-slot!
        frame-id
        (fn [reg]
          (assoc reg :declarations

--- a/implementation/core/test/re_frame/smoke_test.clj
+++ b/implementation/core/test/re_frame/smoke_test.clj
@@ -528,7 +528,7 @@
     (rf/reg-event-db :seed-machines
       (fn [db _]
         (assoc-in db [:rf/runtime :machines :snapshots] {:flow/login    {:state :authed   :data {}}
-                                :flow/checkout {:state :pending  :data {}}})))
+                                                         :flow/checkout {:state :pending  :data {}}})))
     (rf/dispatch-sync [:seed-machines] {:frame :tenant-a})
     (let [traces (atom [])]
       (rf/register-listener! ::df (fn [ev] (swap! traces conj ev)))


### PR DESCRIPTION
Three follow-ons from rf2-fgefd audit of the `:rf/runtime` restructure (#2338), all landing on `implementation/core/{src,test}/re_frame/{marks,elision}.cljc`. Sequenced smallest -> biggest; each commit stands alone.

## Commits

### `c75b182` — style(core/test): realign assoc-in map literals (rf2-35he3, P4 cosmetic)

rf2-9x5u3 mechanically rewrote `(assoc db :rf/machines {...})` into `(assoc-in db [:rf/runtime :machines :snapshots] {...})` in three test files but left two of the map continuation lines aligned to the old column. Re-indent so map continuation lines align under the new `assoc-in` call. Zero behaviour change.

Files: `implementation/core/test/re_frame/smoke_test.clj:530-531`, `implementation/core/test/re_frame/adapter/react_shared_suite.cljs:1426-1427`.

### `4457062` — refactor(core): extract shared write-elision-slot helper (rf2-x8p3v, P3)

The 12-line `cond` block that prunes a stranded `:rf/runtime` when the last `:elision` sub-key clears was duplicated:

- `marks.cljc` had its own `write-elision-slot` private helper (from rf2-9x5u3)
- `elision.cljc/swap-registry!` inlined the identical block

Promote `write-elision-slot` into `re-frame.elision` (the ns that owns the slot) as a `^:no-doc` internal helper. `re-frame.marks` requires `re-frame.elision` and calls `elision/write-elision-slot` from its 4 mutation sites. No cycle (marks -> elision -> trace; trace doesn't require marks, uses late-bind).

Before/after grep on the `:rf/runtime`-prune cond block: `marks.cljc=1, elision.cljc=1` -> `marks.cljc=0, elision.cljc=1`.

### `11fbb3e` — refactor(core): collapse read-transform-write into swap-elision-slot! (rf2-9o4t8, P3)

Builds on the previous commit. After `write-elision-slot` was shared, the same read-transform-write skeleton was still repeated 5x:

```
(swap-app-db! frame-id
  (fn [db]
    (let [reg (get-in db [:rf/runtime :elision])
          ... compute new-reg ...]
      (write-elision-slot db new-reg))))
```

Promote the skeleton into `re-frame.elision/swap-elision-slot!` (`^:no-doc`), taking a single `(fn [reg] new-reg)` transform. Rename the existing `swap-registry!` in place. The 5 sites collapse to one-liners:

```
(elision/swap-elision-slot! frame-id (fn [reg] ... compute ...))
```

Marks' local `swap-app-db!` helper becomes unused and is removed. Two test sites in `elision_test.clj` switch from the var-quoted private `swap-registry!` to the new `swap-elision-slot!` name.

Before/after grep on the `(get-in db [:rf/runtime :elision])` let-binding: `marks.cljc=4, elision.cljc=1` -> `marks.cljc=0, elision.cljc=0` (read now lives once inside the helper).

## Quality gates

- `implementation/core` `clojure -M:test` -> **789 tests, 3495 assertions, 0 failures**
- `implementation/schemas` `clojure -M:test` -> **192 tests, 18251 assertions, 0 failures**
- `clj-kondo` on changed files -> 5 warnings (all pre-existing on this surface; no new warnings introduced)

Closes rf2-x8p3v, rf2-9o4t8, rf2-35he3.
