### PR TITLE
chore(adapters/reagent): post-eguy4 prose + indent cleanup (rf2-vmv5g + rf2-z9h7v)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/cross_spec_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/cross_spec_dom_cljs_test.cljs
@@ -108,7 +108,7 @@
   (rf/reg-event-db :seed
     (fn [db _]
       (assoc-in db [:rf/runtime :machines :snapshots] {:flow/login    {:state :authed   :data {}}
-                              :flow/checkout {:state :pending  :data {}}})))
+                                                       :flow/checkout {:state :pending  :data {}}})))
   (rf/dispatch-sync [:seed] {:frame :tenant-x})
   (let [traces (collect-traces ::xspec-1)]
     (rf/destroy-frame! :tenant-x)

--- a/implementation/adapters/reagent/test/re_frame/routing_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/routing_cljs_test.cljs
@@ -6,9 +6,10 @@
                                            drive the slice under the Reagent
                                            adapter; subscriptions resolve.
   - routing-frame-provider-routing-cljs  — multi-frame routing: each frame's
-                                           :rf/route slice is independent, the
-                                           registry is shared, subscriptions
-                                           resolve per-frame.
+                                           [:rf/runtime :routing :current] slice
+                                           is independent, the registry is
+                                           shared, subscriptions resolve
+                                           per-frame.
 
   Note on test isolation: routing.cljc registers framework events
   (:rf.route/transitioned, :rf.route/navigate, etc.) at namespace-load time.
@@ -43,12 +44,12 @@
   (testing ":rf.route/transitioned drives the slice on CLJS"
     ;; Per Spec 012 §URL changes are events: the runtime's URL-driven
     ;; entry point is :rf.route/transitioned (or :rf.route/handle-url-change for
-    ;; SSR-equivalent code paths). Both write the :rf/route slice from the
-    ;; URL and dispatch :on-match events. Subscriptions over the slice
-    ;; resolve under the Reagent adapter.
+    ;; SSR-equivalent code paths). Both write the [:rf/runtime :routing :current]
+    ;; slice from the URL and dispatch :on-match events. Subscriptions over
+    ;; the slice resolve under the Reagent adapter.
     ;;
-    ;; Test isolation: a fresh frame so prior tests' :rf/route slices don't
-    ;; leak in.
+    ;; Test isolation: a fresh frame so prior tests' [:rf/runtime :routing :current]
+    ;; slices don't leak in.
     (let [f (rf/make-frame {:doc "isolated frame for this test"})]
       (rf/reg-route :route.cljs/home
                     {:path "/cljs/home"})
@@ -85,10 +86,10 @@
 ;; ---- Spec 012 §Multi-frame routing ---------------------------------------
 
 (deftest routing-frame-provider-routing-cljs
-  (testing "two frames carry independent :rf/route slices over a shared registry"
-    ;; Per Spec 012 §Multi-frame routing: each frame's :rf/route slice is
-    ;; independent — same registered routes, different active route per
-    ;; frame. Subscriptions resolve per-frame. This is the contract React
+  (testing "two frames carry independent [:rf/runtime :routing :current] slices over a shared registry"
+    ;; Per Spec 012 §Multi-frame routing: each frame's [:rf/runtime :routing :current]
+    ;; slice is independent — same registered routes, different active route
+    ;; per frame. Subscriptions resolve per-frame. This is the contract React
     ;; context-aware routing components rely on (story-variant frames,
     ;; devcards, per-test fixtures).
     (rf/reg-route :route.cljs2/home          {:path "/cljs2/"})
@@ -109,9 +110,9 @@
       (let [left-route  (rf/subscribe-once left  [:rf.cljs2/route])
             right-route (rf/subscribe-once right [:rf.cljs2/route])]
         (is (= :route.cljs2/articles (:id left-route))
-            "left frame's :rf/route is :route.cljs2/articles")
+            "left frame's current route is :route.cljs2/articles")
         (is (= :route.cljs2/article  (:id right-route))
-            "right frame's :rf/route is :route.cljs2/article")
+            "right frame's current route is :route.cljs2/article")
         (is (= {} (:params left-route))
             "left frame has no :params (collection route)")
         (is (= {:id "intro"} (:params right-route))


### PR DESCRIPTION
Post-eguy4 ( restructure) residue cleanup on the reagent
adapter test surface. Discovered by audit bead rf2-pl1qt.

## Commits

1. **rf2-z9h7v** — style: realign map literal at
   `implementation/adapters/reagent/test/re_frame/cross_spec_dom_cljs_test.cljs`
   L110-111. `assoc → assoc-in` rewrite during eguy4 left `:flow/checkout`
   off-aligned with `:flow/login`. 1 file, +1/-1.

2. **rf2-vmv5g** — docs: update stale `:rf/route slice` prose to
   `[:rf/runtime :routing :current]` shape in
   `implementation/adapters/reagent/test/re_frame/routing_cljs_test.cljs`
   docstrings/comments/messages (L9, L46, L50, L88, L89, L112, L114).
   1 file, +15/-14.

## Files changed: 2

## Gates

- `npm run test:cljs` — PASS (4840 tests, 15856 assertions, 0 failures, 0 errors)
- `clj-kondo --lint` on changed files — no new warnings (one pre-existing
  unused-require warning at `cross_spec_dom_cljs_test.cljs:48:14`,
  unrelated to this PR)

Pre-alpha masterpiece: prose-only + cosmetic; no behavioural change.