### PR TITLE
fix(impl/tests): post-eguy4 :rf/route residue + fixture sweep across epoch/http/ssr (rf2-86wce + rf2-f8gmp + rf2-glvqq + rf2-8vino)

### DIFF
--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -1713,7 +1713,7 @@
     (is (= :route/article (rf/subscribe-once :test/main [:current-route])))
 
     (let [history (rf/epoch-history :test/main)
-          ;; The epoch whose db-after carries :route/home in :rf/route :id.
+          ;; The epoch whose db-after carries :route/home under [:rf/runtime :routing :current :id].
           target  (some (fn [r]
                           (when (= :route/home (get-in (:db-after r) [:rf/runtime :routing :current :id]))
                             r))
@@ -1721,9 +1721,9 @@
       (is (some? target))
       (is (true? (rf/restore-epoch :test/main (:epoch-id target))))
       (is (= :route/home (get-in (rf/get-frame-db :test/main) [:rf/runtime :routing :current :id]))
-          "the :rf/route slice is rewound by restore")
+          "the [:rf/runtime :routing] slice is rewound by restore")
       (is (= :route/home (rf/subscribe-once :test/main [:current-route]))
-          "a sub keyed on :rf/route returns the restored value"))))
+          "a sub reading the routing slice returns the restored value"))))
 
 ;; ---- reset-frame-db! (Tool-Pair §Pair-tool writes, rf2-zq55) -------------
 ;;

--- a/implementation/http/test/re_frame/routing_http_composed_corners_test.clj
+++ b/implementation/http/test/re_frame/routing_http_composed_corners_test.clj
@@ -231,7 +231,7 @@
 
       ;; The pending-nav slot is cleared.
       (is (nil? (get-in (rf/get-frame-db :rf/default) [:rf/runtime :routing :pending-navigation]))
-          ":rf/pending-navigation slot is cleared post-cancel")
+          "[:rf/runtime :routing :pending-navigation] slot is cleared post-cancel")
 
       ;; The in-flight HTTP request from the active route is UNTOUCHED —
       ;; cancel of the navigation does not abort requests issued by the
@@ -243,7 +243,7 @@
       ;; Slice still reflects the active route (no nav happened).
       (is (= :route/editor (get-in (rf/get-frame-db :rf/default)
                                    [:rf/runtime :routing :current :id]))
-          "post-cancel: :rf/route slice still on the active editor route"))))
+          "post-cancel: current route slice still on the active editor route"))))
 
 ;; ---------------------------------------------------------------------------
 ;; 3. Pending-navigation continue advances nav-token; in-flight registry
@@ -306,7 +306,7 @@
           ;; nav-token bumped.
           (is (= :route/sibling (get-in (rf/get-frame-db :rf/default)
                                         [:rf/runtime :routing :current :id]))
-              "post-continue: :rf/route slice is on the continued target")
+              "post-continue: current route slice is on the continued target")
           (let [token-after (get-in (rf/get-frame-db :rf/default)
                                     [:rf/runtime :routing :current :nav-token])]
             (is (not= token-before token-after)

--- a/implementation/ssr/test/re_frame/flows_integration_test.clj
+++ b/implementation/ssr/test/re_frame/flows_integration_test.clj
@@ -38,15 +38,16 @@
       the installed flow-augmented db).
     - An event whose `:fx` `:dispatch`es child events gives EACH child its
       OWN independent flow eval, not the parent's.
-    - A flow whose `:inputs` overlap the `:rf/route` slice reads the
-      POST-transition route (the slice rewrite is the handler's pending
-      `:db`; the flow at the outermost `:after` transforms that pending
-      value before install — there is no pre-transition window the flow
-      could observe). The dual atomicity assertion: a flow throw on a
-      `:rf.route/transitioned` dispatch aborts the WHOLE event — slice
-      stays on the previous route, `:on-match` `:dispatch` fxs are NOT
-      walked. Pin (rf2-qm8m3): regression coverage for the routing × flows
-      composition the rf2-hm4gi delta audit flagged."
+    - A flow whose `:inputs` overlap the `[:rf/runtime :routing :current]`
+      slice reads the POST-transition route (the slice rewrite is the
+      handler's pending `:db`; the flow at the outermost `:after`
+      transforms that pending value before install — there is no
+      pre-transition window the flow could observe). The dual atomicity
+      assertion: a flow throw on a `:rf.route/transitioned` dispatch
+      aborts the WHOLE event — slice stays on the previous route,
+      `:on-match` `:dispatch` fxs are NOT walked. Pin (rf2-qm8m3):
+      regression coverage for the routing × flows composition the
+      rf2-hm4gi delta audit flagged."
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
@@ -441,19 +442,20 @@
              child saw [2] — independent evals, not a shared one")))))
 
 ;; ===========================================================================
-;; 5. flow × routing (rf2-qm8m3) — a flow over the :rf/route slice reads the
-;;    POST-transition route, and a flow throw on a transition aborts the
-;;    WHOLE event (slice unchanged, :on-match :dispatch fxs skipped).
+;; 5. flow × routing (rf2-qm8m3) — a flow over the [:rf/runtime :routing
+;;    :current] slice reads the POST-transition route, and a flow throw on
+;;    a transition aborts the WHOLE event (slice unchanged, :on-match
+;;    :dispatch fxs skipped).
 ;;
 ;; `:rf.route/transitioned` is a normal event-fx: its handler returns
-;; `{:db (assoc db' :rf/route {...new-route...}) :fx [[:dispatch
-;; [:on-match]] ...]}`. The flow at the outermost `:after` transforms the
-;; pending :db (which already carries the rewritten :rf/route slice)
-;; BEFORE the single deferred install. So a flow whose :inputs overlap
-;; [:rf/route] sees the SETTLED post-transition slice, never an
-;; intermediate or pre-transition value. After install, `:fx` walks —
-;; any `[:dispatch [:on-match]]` entries fire against the flow-augmented
-;; db.
+;; `{:db (assoc-in db' [:rf/runtime :routing :current] {...new-route...})
+;; :fx [[:dispatch [:on-match]] ...]}`. The flow at the outermost
+;; `:after` transforms the pending :db (which already carries the
+;; rewritten route slice) BEFORE the single deferred install. So a flow
+;; whose :inputs overlap [:rf/runtime :routing :current] sees the SETTLED
+;; post-transition slice, never an intermediate or pre-transition value.
+;; After install, `:fx` walks — any `[:dispatch [:on-match]]` entries
+;; fire against the flow-augmented db.
 ;;
 ;; The atomicity contract (`bd remember event-pipeline-atomicity` rule a):
 ;; ANY pre-install throw, including a flow throw, aborts the event — no
@@ -464,11 +466,11 @@
 ;; ===========================================================================
 
 (deftest flow-over-route-slice-reads-settled-post-transition-route
-  (testing "a flow whose :inputs overlap [:rf/route] reads the
-            POST-transition route — the slice rewrite is the handler's
-            pending :db; the flow at the outermost :after transforms that
-            pending value, then a single deferred install commits the
-            slice + flow output together"
+  (testing "a flow whose :inputs overlap [:rf/runtime :routing :current]
+            reads the POST-transition route — the slice rewrite is the
+            handler's pending :db; the flow at the outermost :after
+            transforms that pending value, then a single deferred install
+            commits the slice + flow output together"
     (rf/reg-route :route/article {:path   "/articles/:id"
                                   :params [:map [:id :string]]})
     (rf/reg-route :route/home    {:path "/"})
@@ -573,7 +575,7 @@
              discarded wholesale by the flow throw")
         (is (= :route/home (get-in (rf/get-frame-db :rf/default)
                                    [:rf/runtime :routing :current :id]))
-            "the :rf/route slice stayed on :route/home — the transition's
+            "the route slice stayed on :route/home — the transition's
              slice rewrite did NOT install")
 
         ;; The :on-match :dispatch in the handler's :fx was NOT walked —

--- a/implementation/ssr/test/re_frame/ssr/payload_policy_cljs_test.cljc
+++ b/implementation/ssr/test/re_frame/ssr/payload_policy_cljs_test.cljc
@@ -26,7 +26,7 @@
    :public/user-id   "u-42"
    :server-only/auth "SECRET_TOKEN"
    :server-only/flag true
-   :rf/route         {:id :route/home}})
+   :rf/runtime       {:routing {:current {:id :route/home}}}})
 
 ;; ---- apply-policy: allowlist branch --------------------------------------
 

--- a/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
@@ -795,7 +795,7 @@
           ;; unified channel covers head + body; the head-vs-body
           ;; distinction lives entirely in :failing-id below.
           payload   {:rf/version     1
-                     :rf/app-db      {:rf/route {:id :route/article :params {:id "123"}}}
+                     :rf/app-db      {:rf/runtime {:routing {:current {:id :route/article :params {:id "123"}}}}}
                      :rf/render-hash "head-hash-server-A"}
           traces    (atom [])
           f         (rf/make-frame {:platform :client})]

--- a/implementation/ssr/test/re_frame/ssr_head_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_head_test.clj
@@ -69,7 +69,7 @@
 
 (deftest render-head-invokes-handler-against-db-and-route
   (testing "render-head reads the frame's app-db, the active route from the
-            :rf/route slice, and applies the registered fn"
+            [:rf/runtime :routing :current] slice, and applies the registered fn"
     (rf/reg-head :head/article
                  (fn [db {:keys [params]}]
                    (let [{:keys [title summary]} (get-in db [:articles (:id params)])]
@@ -151,9 +151,9 @@
       (rf/dispatch-sync
         [::seed-route] {:frame f})
       ;; The test sub-handler isn't registered; instead seed app-db directly
-      ;; via with-frame and assoc — but the framework's :rf/route slice
-      ;; populates via dispatch-driven routing. We bypass with a one-shot
-      ;; event below.
+      ;; via with-frame and assoc — but the framework's [:rf/runtime
+      ;; :routing :current] slice populates via dispatch-driven routing.
+      ;; We bypass with a one-shot event below.
       (rf/reg-event-db ::seed-route
                        (fn [db _]
                          (assoc-in db [:rf/runtime :routing :current]
@@ -181,7 +181,7 @@
             "default carries the viewport meta")))))
 
 (deftest active-head-uses-default-when-no-route-at-all
-  (testing "no :rf/route slice (e.g. a frame that hasn't routed yet) → default"
+  (testing "no route slice (e.g. a frame that hasn't routed yet) → default"
     (let [f (rf/make-frame {:doc "Bare" :platform :server})
           model (rf/active-head f)]
       (is (= "Bare" (:title model)))


### PR DESCRIPTION
Shape-2 sequenced commits, single PR — pure test-prose / fixture cleanup left over from the :rf/runtime restructure (rf2-eguy4 #2338). Across the four commits: zero spec changes, zero load-bearing code changes, zero shim — outright path rewrites only.

## Commits

### A — rf2-8vino (P3, XS)
**File:** `implementation/epoch/test/re_frame/epoch_test.clj`

Three descriptive sites in `restore-rewinds-route-slice-and-route-sub` still named the slice by the pre-eguy4 `:rf/route` shape. Comment + 2 assertion docstrings updated to `[:rf/runtime :routing ...]` language.

**Gate:** `clojure -M:test` — 214 tests / 804 assertions, 0 failures.

### B — rf2-glvqq (P3, XS)
**File:** `implementation/http/test/re_frame/routing_http_composed_corners_test.clj`

Three stale assertion-message strings (L234, L246, L309) referenced the old `:rf/route` / `:rf/pending-navigation` top-level slots. Rewritten to current shape so a CI failure message would not mislead a debugging operator.

**Gate:** `clojure -M:test` — 273 tests / 1427 assertions, 0 failures.

### C — rf2-86wce (P3, S)
**Files:** `implementation/ssr/test/re_frame/flows_integration_test.clj`, `implementation/ssr/test/re_frame/ssr_head_test.clj`

Seven prose/docstring/comment sites across the two files still used the pre-eguy4 `:rf/route` slice name. Preserved unchanged per the bead: `:rf.route/transitioned` event-id mentions and `:route/article` / `:route/home` route-id mentions (those are IDs, not paths).

**Gate:** `clojure -M:test` — 238 tests / 818 assertions, 0 failures.

### D — rf2-f8gmp (P3, S)
**Files:** `implementation/ssr/test/re_frame/ssr/payload_policy_cljs_test.cljc`, `implementation/ssr/test/re_frame/ssr_end_to_end_test.clj`

Two test fixtures still seeded a flat top-level `:rf/route` key in their sample-app-db values. The tests pass either way (neither probes the routing slice) but the fixtures drifted from production-realistic shape — rewritten to `{:rf/runtime {:routing {:current ...}}}`. The WIRE payload key `:rf/route` (Spec-Schemas) is intentionally preserved and is NOT this key — this is the app-db value INSIDE `:rf/app-db`.

**Gate:** `clojure -M:test` — 238 tests / 818 assertions, 0 failures.

## Sweep verification

Residue grep on `implementation/{epoch,http,ssr}/test/` before + after.

**Before:**
```
implementation/epoch/test/re_frame/epoch_test.clj: 3 sites
implementation/http/test/re_frame/routing_http_composed_corners_test.clj: 3 sites (including 1 :rf/pending-navigation)
implementation/ssr/test/re_frame/flows_integration_test.clj: 6 sites
implementation/ssr/test/re_frame/ssr_head_test.clj: 3 sites
implementation/ssr/test/re_frame/ssr/payload_policy_cljs_test.cljc: 1 site (fixture)
implementation/ssr/test/re_frame/ssr_end_to_end_test.clj: 1 site (fixture)
```

**After:** `git grep -nE ':rf/route\b' -- 'implementation/epoch/test/' 'implementation/http/test/' 'implementation/ssr/test/'` returns ZERO hits. Reserved `:rf.route/...` event-id forms (e.g. `:rf.route/transitioned`, `:rf.route/cancel`, `:rf.route/continue`, `:rf.route/with-nav-token`) preserved.

## Lint

`clj-kondo --lint` on changed files: 3 warnings, all pre-existing (unrelated to touched lines), no new warnings introduced.

## Bead refs

Closes rf2-8vino, rf2-glvqq, rf2-86wce, rf2-f8gmp. Discovered from audits rf2-5cllw / rf2-3q04j / rf2-32j96 (all closed).