### PR TITLE
docs(the-mayor-method): Standard gate menu by surface + canonical Quality gates heading (rf2-gyqpj + rf2-9qp3j)

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -252,6 +252,24 @@ section listing the gates that were run with concrete pass/fail
 counts. The convention is de facto across the project (every real-source
 PR in the rf2-uspbd audit window had one); this codifies it.
 
+**Use the verbatim heading `## Quality gates`** — not `## Gates`, not
+`## Gates run`, not `## Tests run`. A canonical heading is a contract:
+it enables automated PR-body audits (e.g. rf2-uhd5d, which scanned 16
+PRs) and avoids the maintenance cost of tolerant greps. The rf2-uhd5d
+audit found 5 PRs in a single window using variant headings (#2333,
+#2343, #2345, #2346 used `## Gates`; #2337 used `## Gates run`) and 2
+PRs omitting the section entirely (#2334, #2335). The variant headings
+are semantic-equivalents but break any future automated scan that greps
+the canonical wording.
+
+**Spec-only / docs-only exception.** The section is still mandatory for
+spec-only or docs-only PRs (where no impl gates apply), but is permitted
+to be a one-line `no impl gates required (spec-only diff)` placeholder
+plus the docs gates (`mkdocs build --strict` + `check_doc_slugs` +
+`check_readme_links --ci`). Omitting the section entirely is NOT
+acceptable, even for spec-only diffs — see #2334 and #2335 from the
+rf2-uhd5d window for the failure mode.
+
 **Shape:** one short paragraph identifying which spine ran, then a
 bulleted list of named gates with test counts in the form
 `X tests, Y assertions, NF/ME`. Example:

--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -188,6 +188,63 @@ If you skipped `mkdocs build --strict` locally because mkdocs isn't on
 PATH (common on Windows), call it out in the PR body so the mayor knows
 to watch CI.
 
+## Standard gate menu by surface — mandatory
+
+**Why this block exists.** The canonical pre-checkin spine
+(`test-fast-pr.sh`) is necessary but **not sufficient** for cross-artefact
+diffs. The rf2-uhd5d audit (window: 2026-05-28 09:04Z–13:53Z, 16 PRs)
+identified two recurring worker-gate gaps:
+
+- **#2338 (eguy4 phase B+C, 251 files)** burned **3 sequential CI red
+  iterations** (~45 min runner time) because the worker gated only the
+  artefacts whose `src/` changed, not the downstream artefacts that
+  `:require` the modified public surface. Iter 1 red: `tools/story`
+  consumers. Iter 2 red: CLJS `:node-test` (adapter-reagent test). Iter 3
+  red: `tools/story-mcp` consumer. The PR blocked four follow-on PRs
+  mid-merge across the three iterations.
+- **#2341 (`merge-route-slice` helper extraction in
+  `routing/events.cljc`)** is the latent form of the same gap: the worker
+  ran `cd implementation/routing && clojure -M:test` only. CI's surface
+  classifier carried the consumers (`schemas`, `machines`, `flows`,
+  `http`, `ssr`, `ssr-ring`, `epoch`). No CI failure this time only
+  because the extraction happened to preserve behaviour — but the worker
+  hand-off message read "all green locally" which is the wrong signal for
+  a public-surface diff.
+
+**The rule.** Workers MUST gate every artefact reachable from the diff
+through `:require` edges, not just the artefact whose `src/` changed.
+Paste the relevant rows below verbatim into your PR-body `## Quality
+gates` section.
+
+### Standard gate menu — surface touched → MANDATORY worker-side gates
+
+Gate sets are additive: if your diff touches multiple rows, union the
+gates. Pre-alpha posture: this menu is **prescriptive**, not advisory.
+
+| Surface touched | Mandatory worker-side gates |
+|---|---|
+| Any `.md` under `spec/`, `docs/`, `migration/`, or `skills/` | `python -m mkdocs build --strict` (stage `docs/spec` + `docs/migration` first) + `python scripts/check_doc_slugs.py --verbose` + `python scripts/check_readme_links.py --ci` |
+| `implementation/<feat>/src/*` (any of: `schemas`, `machines`, `routing`, `flows`, `http`, `ssr`, `ssr-ring`, `epoch`) | `cd implementation/<feat> && clojure -M:test` + `npm run test:cljs` from `implementation/` |
+| `implementation/core/src/*` | `cd implementation/core && clojure -M:test` AND every per-feature `cd implementation/<feat> && clojure -M:test` AND `npm run test:cljs` AND every `cd tools/<tool> && clojure -M:test` for tool in `{xray, story, story-mcp, mcp-base}` |
+| Any public-surface namespace (e.g. `events.cljc`, `http_interceptors.cljc`, anything `:require`d from another artefact) | The artefact's own gate AND every `:require`r in the workspace. **MUST** discover them via: `git grep -lE "(:require \[.*re-frame\.<feat>\.)" implementation/ tools/` — gate each artefact in the resulting list. |
+| `implementation/adapters/*` (other than `reagent-slim`) | impl JVM matrix + `npm run test:cljs` + `npm run test:browser` (browser is the canonical adapter test surface — do NOT skip) |
+| `implementation/adapters/reagent-slim/*` | impl JVM matrix + reagent-slim bundle-isolation check |
+| `tools/<tool>/src/*` | `cd tools/<tool> && clojure -M:test` AND every dependent tool (see TESTING.md S11+S12+S13) AND `npm run test:cljs` if the tool has CLJS tests |
+| `tools/{story,xray}/spec/*.md` | `mkdocs build --strict` **only** (per the rf2-f79t8 spec-md guard — do NOT run the JVM/CLJS tool probes for spec-prose edits) |
+| `tools/template/*` | `cd tools/template && clojure -M:test` + emitted-app smoke |
+| `tools/mcp-conformance/*`, `tools/re-frame2-pair-mcp/*`, `tools/mcp-base/*`, `tools/story-mcp/*` | MCP conformance suite from `tools/mcp-conformance/` |
+| Shared protocol surface (`Tool-Pair`, `Spec-Schemas`, `Conventions`, `API`) | **THE FULL MATRIX.** `scripts/test-jvm-implementation.sh` + `scripts/test-jvm-tools.sh` + `npm run test:cljs` + `mkdocs build --strict`. |
+| `spec/conformance/fixtures/*.edn` | impl JVM matrix (per-feature `_conformance_test.clj` consumes these) + `npm run test:cljs` |
+
+Skipping any gate requires a one-line PR-body note explaining why (e.g.
+"Windows file-lock prevents `npm run test:cljs` locally; running CI as
+canonical"). A skip without a stated reason fails the audit.
+
+**Evidence.** This menu is the concrete fix for the rf2-uhd5d audit
+findings §3.1 + §3.2; the failure modes it closes are #2338's
+3-iteration CI red loop and #2341's latent helper-extraction
+consumer-gate gap.
+
 ## PR-body Quality gates section — mandatory
 
 Every editing dispatch's PR body MUST include a `## Quality gates`


### PR DESCRIPTION
Bundled Shape-2 follow-on for the rf2-uhd5d worker-gate audit. Two sequenced commits, both edits to `docs/the-mayor-method/dispatch-prompt-template.md`.

## Commit A — rf2-gyqpj (P2)

Adds a **Standard gate menu by surface — mandatory** block under the "Canonical pre-checkin quality gates" section (between the `test-fast-pr.sh` paragraph and the existing "## PR-body Quality gates section — mandatory" block).

The block is a verbatim table mapping surface-family touched -> mandatory worker-side gate list. Workers paste the relevant rows into their PR-body `## Quality gates` section. Pre-alpha posture: prescriptive ("MANDATORY"), not advisory.

Rows cover: `.md` under `spec/docs/migration/skills`, per-feature `implementation/<feat>/src/*`, `implementation/core/src/*`, public-surface namespaces (with the `git grep` discovery recipe for `:require`rs), `implementation/adapters/*` (full + reagent-slim variants), `tools/<tool>/src/*`, `tools/{story,xray}/spec/*.md` (mkdocs-only per the rf2-f79t8 spec-md guard), `tools/template/*`, the MCP-related tools, shared protocol surface (the full matrix), and `spec/conformance/fixtures/*.edn`.

Evidence cited: rf2-uhd5d audit + #2338's 3-iteration CI red loop (story / CLJS node-test / story-mcp gates each missed in turn, ~45 min runner time) + #2341's latent helper-extraction consumer-gate gap. The block explicitly addresses the Windows file-lock skip: "Skipping any gate requires a one-line PR-body note explaining why (e.g. Windows file-lock prevents `npm run test:cljs` locally; running CI as canonical)."

## Commit B — rf2-9qp3j (P3)

Tightens the existing **"## PR-body Quality gates section — mandatory"** block in the same file:

1. Adds the verbatim-heading instruction: "Use the verbatim heading `## Quality gates` — not `## Gates`, not `## Gates run`, not `## Tests run`."
2. Documents the spec-only / docs-only exception: the section is still mandatory but is permitted to be a one-line `no impl gates required (spec-only diff)` placeholder plus the docs gates.
3. Adds the rationale: "A canonical heading is a contract — it enables automated PR-body audits (e.g. rf2-uhd5d) and avoids the maintenance cost of tolerant greps."

Evidence cited verbatim: 5 PRs in the rf2-uhd5d audit window used variant headings (#2333, #2343, #2345, #2346 used `## Gates`; #2337 used `## Gates run`). 2 PRs (#2334, #2335) omitted the section entirely. Any future automated PR-body scan would false-negative on roughly half the window with the variant headings.

## Quality gates

`python -m mkdocs build --strict` + `python scripts/check_doc_slugs.py --verbose` + `python scripts/check_readme_links.py --ci` — all green. No impl gates required (docs-only diff to `docs/the-mayor-method/dispatch-prompt-template.md`).

- `python -m mkdocs build --strict` — passed (after staging `docs/spec` + `docs/migration` from the canonical `spec/` + `migration/` trees)
- `python scripts/check_doc_slugs.py --verbose` — 379 files, no broken links
- `python scripts/check_readme_links.py --ci` — exit 0

Files changed: 1 (`docs/the-mayor-method/dispatch-prompt-template.md`, +75 lines).

Bead refs: rf2-gyqpj (P2, gate menu by surface), rf2-9qp3j (P3, canonical `## Quality gates` heading). Audit source: rf2-uhd5d.
