### PR TITLE
docs(skills/xray): naming-clarity edits (rf2-4pwt6)

### DIFF
--- a/skills/re-frame2-xray/README.md
+++ b/skills/re-frame2-xray/README.md
@@ -7,7 +7,7 @@
 1. **How do I launch Xray?** — the inline panel, the pop-out, the programmatic `init!`, the wired hotkeys, and the Dynamic ↔ Static mode toggle.
 2. **Which tab shows X?** — a one-line purpose for each tab across both modes: the 7 Dynamic event-spine tabs and the 5 Static registry-browse tabs.
 
-Workflow procedures (find-wrong-sub, scrub-bad-epoch, click-to-source, redaction-indicator semantics) are out of scope for this iteration — see `SKILL.md` §Out of scope for what to do when one of those comes up.
+Workflow procedures (find-wrong-sub, scrub-bad-epoch, click-to-source, redaction-marker semantics) are out of scope for this iteration — see `SKILL.md` §Out of scope for what to do when one of those comes up.
 
 ## What Xray is
 


### PR DESCRIPTION
## Summary

Naming-best-practice audit of the `skills/re-frame2-xray/` bundle (bead **rf2-4pwt6**, one slice of the 33-bead audit wave).

Surface audited: `SKILL.md` + `README.md` + `references/launch-modes.md` + `references/panels.md` + `references/shared-components.md` + frontmatter + anchor slugs + section headings + `package.json` / `plugin.json` / `evals/evals.json` + cross-skill labels.

**One inline edit.** `skills/re-frame2-xray/README.md` line 10 — `redaction-indicator` → `redaction-marker`, aligning the README with the SKILL.md body (which already uses "redaction-marker" three times) and the dominant spec surface `tools/xray/spec/018-Event-Spine.md`.

The rest of the bundle is in good shape:

- Frontmatter `name`, `description`, `allowed-tools` are crisp and minimal.
- Bundle dir / file layout is kebab-case, no abbreviations, one reference file per top-level concern (launch / panels / shared-components).
- Headings are operator-facing questions or first-screen surfaces.
- The all-plural-domain-noun tab convention (Mike-direction 2026-05-21) — Event / app-db / Views / Trace / Machines / Routes / Issues — is honoured across SKILL.md, panels.md, shared-components.md, with explicit internal-id-vs-display-label call-outs where they exist (Views/`:views`, app-db/`:app-db`, Routes/`:routing`).
- Anchor slug (one) matches its in-skill caller.
- Eval fixture `name` slugs are crisp surface-coded (`launch-default`, `panel-route-state`, `static-browse-registry`, `chrome-rewind`, ...).
- Tour-skill shape (`## Out of scope` + `## Style guidance`) is consistent with sibling `re-frame2-pair/SKILL.md`.

Findings doc: `ai/findings/naming-audit-skills-re-frame2-xray.md` (local-only, gitignored).

## Follow-on bead candidate

`skills/README.md` lines 72-73 still describe Dynamic tabs as `"(Event / App DB / View / Trace / Machines / Routing / Issues)"` — pre-rebrand label drift. The correct list is `(Event / app-db / Views / Trace / Machines / Routes / Issues)`. Out of this bundle's scope (it lives in the shared skill-routing single-source); worth filing as a small coordinated follow-on.

## Quality gates

| Gate | Result |
|---|---|
| `python -m mkdocs build --strict` (from worktree root) | passes (build completes; only informational `INFO` lines about pages-not-in-nav and a single pre-existing relative-link note, unchanged by this PR) |
| `python scripts/check_doc_slugs.py --verbose` | passes (`no broken links`, exit 0) |
| `python scripts/check_readme_links.py --ci` | passes (exit 0) |

Skill bundle is prose-only — no CLJS / JVM gates apply.

## Closes

- rf2-4pwt6