### PR TITLE
refactor(story): inline naming-clarity renames (rf2-152jq)

### DIFF
--- a/tools/story/src/re_frame/story/canonical.cljc
+++ b/tools/story/src/re_frame/story/canonical.cljc
@@ -53,8 +53,8 @@
   [registrar/install-canonical-tags!
    loaders/install!
    loaders/install-mirror-writer!
-   frames/install-helpers!
-   runtime/install-helpers!
+   frames/install-canonical-frame-events!
+   runtime/install-canonical-runtime-events!
    assertions/install-canonical-assertions!
    fx-stubs/install-canonical-fx-stubs!
    save-variant/install-canonical-event-handlers!

--- a/tools/story/src/re_frame/story/frames.cljc
+++ b/tools/story/src/re_frame/story/frames.cljc
@@ -385,11 +385,17 @@
                               {:frame variant-id})
             (catch #?(:clj Throwable :cljs :default) _ nil)))))))
 
-(defn install-helpers!
+(defn install-canonical-frame-events!
   "Register Story-internal helper events: `::apply-app-db-patch` for
   `:frame-setup` decorators' `:app-db-patch` slot, and
   `::append-teardown-assertion` for the `:teardown` exception
-  projection path. Idempotent."
+  projection path. Idempotent.
+
+  Mirrors the `install-canonical-<X>!` shape used by every sibling
+  installer in `canonical/canonical-installers` (`install-canonical-tags!`,
+  `install-canonical-assertions!`, `install-canonical-fx-stubs!`, …). Was
+  the vague `install-helpers!` (rf2-152jq inline rename) — the new name
+  states what's installed."
   []
   (when config/enabled?
     (rf/reg-event-db
@@ -453,7 +459,7 @@
   reset-variant`) destroys first."
   [variant-id decorator-stack]
   (when config/enabled?
-    (install-helpers!)
+    (install-canonical-frame-events!)
     (let [fx-stack       (decorators/fx-overrides-map (:fx-override decorator-stack))
           fx-overrides   (register-fx-overrides! fx-stack)
           config-map     (variant-frame-config variant-id fx-overrides)

--- a/tools/story/src/re_frame/story/malli_schema.cljc
+++ b/tools/story/src/re_frame/story/malli_schema.cljc
@@ -1,4 +1,4 @@
-(ns re-frame.story.malli-schema-utils
+(ns re-frame.story.malli-schema
   "Pure Malli-schema introspection helpers. Shared between the
   controls panel's widget-derivation (`re-frame.story.ui.controls`,
   CLJS-only) and the schema-validation panel's args-violation walk

--- a/tools/story/src/re_frame/story/play.cljc
+++ b/tools/story/src/re_frame/story/play.cljc
@@ -56,8 +56,8 @@
   - `execute-play!`  — runs a play sequence against a variant frame
                        and returns a resolved promise of the
                        accumulated assertions vector.
-  - `install-helpers!` — registers the play-runner's internal
-                         trace-listener helpers; idempotent.
+  - `install-trace-listener!` / `remove-trace-listener!` — per-frame
+                         trace-listener install + teardown; idempotent.
   - `play-stepper-active?` / `step-once!` — UI hooks (Stage 4's
                                             play-stepper slot)."
   (:require [re-frame.core             :as rf]

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -283,8 +283,14 @@
 
 ;; ---- helper event registrations ------------------------------------------
 
-(defn install-helpers!
-  "Register the runtime's internal helper events. Idempotent."
+(defn install-canonical-runtime-events!
+  "Register the runtime's internal helper events: `::append-assertion`
+  for projecting exception captures + assertion records onto the
+  variant frame's `:rf.story/assertions` accumulator. Idempotent.
+
+  Mirrors the `install-canonical-<X>!` shape used by every sibling
+  installer in `canonical/canonical-installers`. Was the vague
+  `install-helpers!` (rf2-152jq inline rename)."
   []
   (when config/enabled?
     (rf/reg-event-db

--- a/tools/story/src/re_frame/story/ui/controls.cljs
+++ b/tools/story/src/re_frame/story/ui/controls.cljs
@@ -37,7 +37,7 @@
             [re-frame.story.registrar          :as registrar]
             [re-frame.story.args               :as args]
             [re-frame.story.decorators         :as decorators]
-            [re-frame.story.malli-schema-utils :as msu]
+            [re-frame.story.malli-schema       :as msu]
             [re-frame.story.ui.controls-styles :refer [styles]]
             [re-frame.story.ui.save-variant    :as save-variant-ui]
             [re-frame.story.ui.state           :as state]))
@@ -48,7 +48,7 @@
 
 ;; ---- pure: Malli-schema introspection -----------------------------------
 ;;
-;; Canonical helpers live in `re-frame.story.malli-schema-utils` (a pure
+;; Canonical helpers live in `re-frame.story.malli-schema` (a pure
 ;; leaf ns shared with `schema-validation`). Aliased privately here so
 ;; in-file call sites stay textually identical.
 

--- a/tools/story/src/re_frame/story/ui/schema_validation.cljc
+++ b/tools/story/src/re_frame/story/ui/schema_validation.cljc
@@ -74,7 +74,7 @@
   `:rf.story.panel/schema-validation-view`, registered against the
   framework view registry."
   (:require [clojure.string :as str]
-            [re-frame.story.malli-schema-utils :as msu]
+            [re-frame.story.malli-schema :as msu]
             #?@(:cljs [[reagent.core              :as r]
                        [re-frame.core             :as rf]
                        [re-frame.late-bind        :as late-bind]
@@ -162,7 +162,7 @@
 
 ;; ---- pure: Malli walk over `:map` schemas ------------------------------
 ;;
-;; Canonical helpers live in `re-frame.story.malli-schema-utils` (a pure
+;; Canonical helpers live in `re-frame.story.malli-schema` (a pure
 ;; leaf ns shared with `controls`). Aliased privately here so in-file
 ;; call sites stay textually identical.
 


### PR DESCRIPTION
@
Inline naming-clarity renames from the rf2-152jq naming-best-practice audit of `tools/story`. Pre-alpha posture — rename outright, no shim.

## What changes

1. **`re-frame.story.malli-schema-utils` → `re-frame.story.malli-schema`**
   The only `*-utils` ns in the slice. Per the bead criterion (avoid `util` / `helpers` / `core` overload), the trailing `-utils` adds no signal — the namespace IS the canonical leaf for Malli-schema introspection. Two in-slice consumers (`ui.controls`, `ui.schema-validation`) updated; `:as msu` alias preserved at call sites for textual continuity.

2. **`frames/install-helpers!` + `runtime/install-helpers!` → `install-canonical-frame-events!` + `install-canonical-runtime-events!`**
   Aligns the two outlier installer names with the `install-canonical-<X>!` shape used by **ten** sibling installers in `canonical/canonical-installers`:
   - `install-canonical-tags!`
   - `install-canonical-assertions!`
   - `install-canonical-fx-stubs!`
   - `install-canonical-event-handlers!` (save-variant)
   - `install-canonical-layout-debug!`
   - `install-canonical-cofx!`
   - `install-canonical-panels!`
   - `install-canonical-a11y!`
   - `install-canonical-chrome-a11y!`
   - `install-late-bind-shims!`

   `install-helpers!` was generic; the new names state what each registers (the `::apply-app-db-patch` + `::append-teardown-assertion` helper events in frames; the `::append-assertion` helper event in runtime).

**Drive-by:** Fixed a stale docstring in `play.cljc` that listed a non-existent `install-helpers!` in its Public API section. The actual installer pair is `install-trace-listener!` / `remove-trace-listener!`.

## Audit verdict

The slice is in **very good** shape — the public surface mirrors `spec/Conventions.md` + `spec/API.md` doctrine; the seven `reg-*` macro + `*`-fn split is uniform; predicates end `?`; side-effects end `!`; the `:rf.story.*` framework carve-out is honoured everywhere; test names are narrative (`preset-table-includes-every-bead-mandated-id`, `event-step-assertion-rides-dispatch-sync`).

Five **follow-on beads** filed for the larger systemic re-alignment that Conventions.md §Chrome-installer pair shape already calls out as "migrate by future bead":
- `keybindings/remove!` → `uninstall!`
- `dom-capture/remove!` → `uninstall!`
- `recorder/install-trace-listener!` / `remove-trace-listener!` pair shape
- `play` / `ui.recorder` / `trace-buffer` per-listener naming
- Conventions doc reciprocal sweep (name the specific divergences)

Findings doc at `ai/findings/naming-audit-tools-story.md` (local-only) catalogues every named entity reviewed with KEEP / RENAME-INLINE / RENAME-NEEDS-FOLLOWUP verdicts and reasoning.

## Quality gates

- `cd tools/story && clojure -M:test` — **860 tests, 2554 assertions, 0 failures, 0 errors**
- `cd tools/story && clj-kondo --lint src test` — **0 errors** (pre-existing warnings unrelated to the rename)
- `cd implementation && npm run test:cljs` — **4845 tests, 15891 assertions, 0 failures, 0 errors**

Closes rf2-152jq.
@