### PR TITLE
refactor(schemas): inline naming-clarity renames (rf2-2aj30)

### DIFF
--- a/implementation/schemas/src/re_frame/schemas/digest.cljc
+++ b/implementation/schemas/src/re_frame/schemas/digest.cljc
@@ -114,8 +114,8 @@
   (let [lines       (mapv (fn [[path schema]] (digest-line path schema))
                           path->schema)
         sorted      (sort compare-utf8-bytes lines)
-        concatted   (apply str sorted)
-        full-hex    (sha256-hex concatted)]
+        joined      (apply str sorted)
+        full-hex    (sha256-hex joined)]
     (str "sha256:" (subs full-hex 0 16))))
 
 (defn app-schemas-digest

--- a/implementation/schemas/src/re_frame/schemas/validate.cljc
+++ b/implementation/schemas/src/re_frame/schemas/validate.cljc
@@ -344,10 +344,10 @@
        ;; gate). Pass-state stays `true` only when every entry passed.
        (loop [entries (seq (storage/frame-schema-entries frame-id))
               ok?     true]
-         (if-let [[reg-path m] (first entries)]
-           (let [val-at (get-in db reg-path)
-                 schema (:schema m)]
-             (if (vf schema val-at)
+         (if-let [[reg-path schema-meta] (first entries)]
+           (let [reg-slice (get-in db reg-path)
+                 schema    (:schema schema-meta)]
+             (if (vf schema reg-slice)
                (recur (next entries) ok?)
                (do
                  ;; Per rf2-oh4se — make the failure path precise and
@@ -390,14 +390,14 @@
                  ;; vocabulary rather than minting a new enum value).
                  ;; The router consumes the loop's final boolean to
                  ;; perform the actual container restoration.
-                 (let [explanation (validator/run-explainer schema val-at)
+                 (let [explanation (validator/run-explainer schema reg-slice)
                        in-path     (failing-in-path explanation)
                        leaf-path   (if in-path
                                      (vec (concat reg-path in-path))
                                      reg-path)
                        leaf-value  (if in-path
-                                     (get-in val-at in-path)
-                                     val-at)
+                                     (get-in reg-slice in-path)
+                                     reg-slice)
                        sensitive?  (if in-path
                                      (walker/schema-sensitive-at? schema in-path)
                                      (walker/schema-has-sensitive? schema))

--- a/implementation/schemas/test/re_frame/schemas_cljs_test.cljs
+++ b/implementation/schemas/test/re_frame/schemas_cljs_test.cljs
@@ -111,7 +111,7 @@
 ;; restore the hook on the way out so downstream tests see the canonical
 ;; opt-in's behaviour.
 
-(deftest rf2-t0hq-cljs-malli-adapter-enables-validation
+(deftest cljs-malli-adapter-enables-validation
   (testing "Per rf2-t0hq: with `re-frame.schemas.malli` required at
             app boot, the default validator consults Malli on CLJS and
             a malformed commit fires :rf.error/schema-validation-failure.
@@ -136,7 +136,7 @@
           (is (= [:user :age] (-> v :tags :path)))
           (is (= "twenty-three" (-> v :tags :value))))))))
 
-(deftest rf2-t0hq-cljs-no-adapter-soft-passes
+(deftest cljs-no-adapter-soft-passes
   (testing "Per Spec 010 §Recommended soft-pass: when an app does NOT
             require `re-frame.schemas.malli`, the late-bind hook
             `:schemas/malli-validate` is absent, the default validator


### PR DESCRIPTION
Closes rf2-2aj30 — naming-best-practice audit of `implementation/schemas`.

## Summary

The schemas slice's naming is in excellent shape. Public surface (everything re-exported through `re-frame.core`, every `:schemas/*` late-bind hook, the per-slot `:large?` / `:sensitive?` vocabulary) is load-bearing — 100+ consumer files, late-bind directory entries in `core/src/re_frame/late_bind/directory.cljc`, normative spec rows in 010-Schemas + Spec-Schemas §`:rf/app-schema-meta`. No public-surface renames warranted; no follow-on beads filed.

Four small inline clarity tweaks applied — none touch public surface or spec-locked vocabulary.

## Renames

- **`digest.cljc`** — `concatted` → `joined` in `compute-digest`. Idiomatic Clojure verb for `(apply str sorted)`, no coined past-tense form.
- **`validate.cljc`** — in `validate-app-schema!`'s entries loop, `[reg-path m]` → `[reg-path schema-meta]` and the value-at-registered-path `val-at` → `reg-slice`. Both flow through downstream `run-explainer` / `failing-in-path` / `get-in` / base-tags call sites; the new names make the slice-vs-leaf-value distinction self-documenting (sibling local `leaf-value` is the further-narrowed slot inside `reg-slice`).
- **`schemas_cljs_test.cljs`** — strip bead-id prefix from two `deftest` names (`rf2-t0hq-cljs-malli-adapter-enables-validation` → `cljs-malli-adapter-enables-validation`; `rf2-t0hq-cljs-no-adapter-soft-passes` → `cljs-no-adapter-soft-passes`). Each test's docstring already cites the bead; these were the only two `deftest rf2-*` names in 207 deftest across the slice.

Findings doc (local-only / gitignored): `ai/findings/naming-audit-implementation-schemas.md`.

## Considered but not renamed

- `opts-or-frame-id` — accurate name for the discriminated-union arg; documented + tested.
- `ba` / `bb` / `na` / `nb` / `ua` / `ub` (`compare-utf8-bytes`) — tight unsigned-byte comparison locals; comment + `a` / `b` parameter naming anchors them.
- `k` / `d` / `c` / `tail` / `maybe-prop` (`walk-flagged-schema`) — short loop locals inside a pure recursive walker; the docstring's "structural rules" enumeration anchors them.
- `vf` / `f` / `v` / `e` / `m` (single-letter locals immediately followed by a single use, deref → invoke / cache-find → val) — idiomatic.
- `schemas-by-frame` atom — public-by-design fixture composition primitive (rf2-1gm0o Finding #5).
- Warning-machinery names (`validator-unavailable-warned`, `walker-opaque-warned`, the matching `clear-*!` fns) — verbose but the one-shot-per-process semantics ride on the name.

## Quality gates

- `cd implementation/schemas && clojure -M:test` — `Ran 192 tests containing 18251 assertions. 0 failures, 0 errors.`
- `cd implementation/core && clojure -M:test` — `Ran 792 tests containing 3507 assertions. 0 failures, 0 errors.`
- `clj-kondo --lint implementation/schemas/{src,test}` — 9 pre-existing warnings (unused requires); none on edited lines.