### PR TITLE
refactor(core): inline naming-clarity renames (rf2-i3kj2)

### DIFF
--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -379,8 +379,8 @@
   policy fn expects PLUS the tight `:error/:event/:event-id/:frame/
   :time/:exception/:elapsed-ms` record to corpus-wide listeners."
   [error event-id event frame ctx start-ms]
-  (let [e          (:exception error)
-        msg        #?(:clj (.getMessage ^Throwable e) :cljs (.-message e))
+  (let [exception  (:exception error)
+        msg        #?(:clj (.getMessage ^Throwable exception) :cljs (.-message exception))
         emit-event (privacy/redacted-event-from-ctx ctx)
         end-ms     (interop/now-ms)
         ;; Per rf2-bacs4 §Record shape: `:elapsed-ms` is an integer.
@@ -396,7 +396,7 @@
                     :failing-id        event-id
                     :handler-id        event-id
                     :phase             (:phase error)
-                    :exception         e
+                    :exception         exception
                     :exception-message msg
                     :reason            "Event handler threw."
                     :recovery          :no-recovery}]
@@ -414,7 +414,7 @@
       emit-event
       event-id
       frame
-      e
+      exception
       elapsed-ms
       end-ms
       {:operation :rf.error/handler-exception
@@ -463,8 +463,8 @@
             ;; nil-coerce: treat a nil return as success (don't roll
             ;; back) so a host that returns nil rather than true on a
             ;; clean validate keeps working.
-            (let [r (validate db-after event-id frame)]
-              (if (nil? r) true r))
+            (let [result (validate db-after event-id frame)]
+              (if (nil? result) true result))
             (catch #?(:clj Throwable :cljs :default) _ true))
           true)
         machines-ok?
@@ -475,8 +475,8 @@
         (if-let [validate-md (late-bind/get-fn-cached
                                :machines/validate-machine-data!)]
           (try
-            (let [r (validate-md db-after event-id frame)]
-              (if (nil? r) true r))
+            (let [result (validate-md db-after event-id frame)]
+              (if (nil? result) true result))
             (catch #?(:clj Throwable :cljs :default) _ true))
           true)]
     ;; Both must conform for the cascade to keep its commit; the per-
@@ -1869,7 +1869,7 @@
                             {:frame (:frame envelope) :event event
                              :recovery :no-recovery}))
 
-       (let [r @(:router frame-record)
+       (let [router-state @(:router frame-record)
              ;; Per rf2-ynk7: `:in-drain?` now holds the drainer's
              ;; thread (or nil). Only flag as "nested" when the current
              ;; thread is the drainer — a different thread mid-drain is
@@ -1879,9 +1879,9 @@
              ;; (truthy = same-thread by construction on a single-
              ;; threaded host).
              same-thread-drain?
-             #?(:clj  (identical? (:in-drain? r) (Thread/currentThread))
-                :cljs (true? (:in-drain? r)))]
-         (or (:in-sync-drain? r) same-thread-drain?))
+             #?(:clj  (identical? (:in-drain? router-state) (Thread/currentThread))
+                :cljs (true? (:in-drain? router-state)))]
+         (or (:in-sync-drain? router-state) same-thread-drain?))
        ;; Per Spec 002 §dispatch-sync: nesting dispatch-sync inside the
        ;; SAME frame's running drain (sync or async) is an error — the
        ;; event would interleave with the outer handler's run-to-completion.

--- a/implementation/core/src/re_frame/router/diagnostics.cljc
+++ b/implementation/core/src/re_frame/router/diagnostics.cljc
@@ -141,8 +141,8 @@
   (some (fn [id]
           (when (not= id target-id)
             (when-let [fr (frame/frame id)]
-              (let [r @(:router fr)]
-                (when (or (:in-sync-drain? r) (:in-drain? r))
+              (let [router-state @(:router fr)]
+                (when (or (:in-sync-drain? router-state) (:in-drain? router-state))
                   id)))))
         (frame/frame-ids)))
 

--- a/implementation/core/src/re_frame/source_coords.cljc
+++ b/implementation/core/src/re_frame/source_coords.cljc
@@ -403,14 +403,14 @@
   [[absolutise-file]] (JVM macro-expansion path) so per-machine-element
   coords ship absolute on-disk paths matching the reg-* macro coords."
   [form ns-sym file]
-  (let [m            (meta form)
-        chosen-file  (resolve-file m file)
+  (let [form-meta    (meta form)
+        chosen-file  (resolve-file form-meta file)
         chosen-file  (when chosen-file (absolutise-file chosen-file))]
-    (when (and m (or (:line m) (:column m)))
+    (when (and form-meta (or (:line form-meta) (:column form-meta)))
       (cond-> {:ns ns-sym}
-        chosen-file (assoc :file chosen-file)
-        (:line m)   (assoc :line (:line m))
-        (:column m) (assoc :column (:column m))))))
+        chosen-file        (assoc :file chosen-file)
+        (:line form-meta)  (assoc :line (:line form-meta))
+        (:column form-meta) (assoc :column (:column form-meta))))))
 
 (defmacro ^:private stamp!
   "Compile-time helper for the machine-spec walker. Reads source coords off


### PR DESCRIPTION
Naming audit for `implementation/core` (rf2-i3kj2). The slice is in very good shape — naming conventions catalogued in `spec/Conventions.md` (bang-suffix bucketing, tear-down verb axis, optional-artefact wrapper convention, value-vs-fn, reserved namespaces) carry through cleanly across 59 src files (19.9K LOC) and 97 test files (26.8K LOC).

## Findings summary

Most apparent inconsistencies turned out to be **deliberate carve-outs documented in Conventions** with rationale:

- `unsubscribe` vs `clear-sub` — spec §Tear-down verb axis §Carve-out: `unsubscribe` (the two are semantically distinct: sub-cache ref-count vs registrar decrement)
- `dispatcher` / `subscriber` noun forms — rf2-knz3l, "considered and cut" the verb-form alternative
- `clear-event` / `clear-sub` / `clear-fx` no-bang — spec §Bang-suffix bucketing bucket 1 (single-id registrar decrement, symmetric with `reg-*`)
- `subs/unsubscribe` (no bang, facade) vs `subs.cache/unsubscribe!` (bang, impl) — facade/impl split per the same convention

One substantive public-surface issue surfaced — filed as a follow-on bead:

- **rf2-003ce** — `frame/get-frame-db` (returns container) and `core/get-frame-db` (returns value) share a name but differ in semantic return type. Internal callers can't tell which they hold from a grep. Multi-file rename (~6 src/test files); deferred so this PR stays scoped.

Full per-surface verdicts (including KEEPs with rationale) at `ai/findings/naming-audit-implementation-core.md` (local-only, gitignored).

## Inline renames in this PR

Private helpers + let-bindings only — no public surface. Aggressive on the let-binding axis per the worker brief.

- `router.cljc:466` `r` → `result` (validator return)
- `router.cljc:478` `r` → `result` (machine-data validator return)
- `router.cljc:1872` `r` → `router-state` (5 call sites in the nested-dispatch-sync guard)
- `router/diagnostics.cljc:144` `r` → `router-state` (matches sibling pattern)
- `source_coords.cljc:406` `m` → `form-meta` (4 call sites)
- `router.cljc:382` `e` → `exception` (3 call sites + 1 emit slot)

The `(when-let [f (late-bind/get-fn-cached ...)] (f args))` idiom (11+ call sites) was reviewed and **kept** — `f` is meaningful in context, tightly scoped, and the rename would expand 11 surfaces with no clarity gain.

## Quality gates

- `cd implementation/core && clojure -M:test` — **PASS** (792 tests, 3507 assertions, 0 failures, 0 errors)
- `cd implementation/schemas && clojure -M:test` — **PASS** (192 tests, 18251 assertions, 0 failures, 0 errors) — consumes the elision walker
- clj-kondo on changed files — **CLEAN** (5 pre-existing unused-binding/namespace warnings on lines this PR did not touch; no new warnings introduced)
- CLJS `npm run test:cljs` — **SKIPPED** (Windows host worktree file-lock environment per `reference_windows_worktree_file_locks`). The inline let-binding renames are pure-textual private-scope changes and cannot introduce CLJS-specific regression on top of the JVM + schemas gates above.

## Closes

- rf2-i3kj2 (audit; this PR delivers the inline renames + findings doc)

## Follow-on

- rf2-003ce (`frame/get-frame-db` rename — public-internal-boundary multi-file change)