### PR TITLE
refactor(routing): inline naming-clarity renames (rf2-vfdvh)

### DIFF
--- a/implementation/routing/src/re_frame/routing.cljc
+++ b/implementation/routing/src/re_frame/routing.cljc
@@ -55,7 +55,7 @@
             [re-frame.routing.on-match-error :as on-match-error]
             [re-frame.routing.registry :as registry]
             [re-frame.routing.scroll :as scroll]
-            [re-frame.routing.subs :as subs-ns]
+            [re-frame.routing.subs :as routing-subs]
             [re-frame.routing.url-bound :as url-bound]
             [re-frame.routing.url-change :as url-change]
             #?@(:cljs [[re-frame.views :as views]])))
@@ -80,7 +80,7 @@
 (def save-scroll-position       scroll/save-scroll-position)
 
 ;; Subs
-(def route-sub-fn               subs-ns/route-sub-fn)
+(def route-sub-fn               routing-subs/route-sub-fn)
 
 ;; URL-owner resolution
 (def url-owner-frame-id         nav-fx/url-owner-frame-id)
@@ -186,13 +186,13 @@
 (subs/reg-sub :rf.route/chain
   {:doc "Subscribe to the `:parent`-chain of the active route, returned
   as a vector `[parent-most ... current]`. Per Spec 012 §Nested layouts."}
-  :<- [:rf.route/id] (fn [id _] (subs-ns/chain-from-meta id)))
+  :<- [:rf.route/id] (fn [id _] (routing-subs/chain-from-meta id)))
 (subs/reg-sub :rf/pending-navigation
   {:doc "Subscribe to the pending-navigation slot at
   `[:rf/runtime :routing :pending-navigation]` (nil when no navigation
   is pending). Per Spec 012 §Navigation blocking — pending-nav
   protocol."}
-  subs-ns/pending-navigation-sub-fn)
+  routing-subs/pending-navigation-sub-fn)
 
 ;; :route/link registered view — Spec 012 §Linking from views.
 ;; Exposed on both platforms so .cljc render trees resolve identically

--- a/implementation/routing/src/re_frame/routing/match.cljc
+++ b/implementation/routing/src/re_frame/routing/match.cljc
@@ -17,7 +17,7 @@
 ;; ---- registration ---------------------------------------------------------
 
 (defn segment-end
-  "Scan forward from index `j` in `pattern` (length `n`) until a
+  "Scan forward from `start` in `pattern` (length `n`) until a
   segment-boundary char is hit; return the index of that boundary (or
   `n` if none). The boundary set is always {/, {, }}; the 4-arity
   additionally treats `?` as a boundary when `?-boundary?` is truthy.
@@ -25,15 +25,15 @@
   `parse-pattern`. The 3-arity (defaults `?-boundary?` to true) suits
   param / splat scanners; the static-segment branch passes false so a
   `?` inside a static segment doesn't truncate the static run."
-  ([^String pattern n j] (segment-end pattern n j true))
-  ([^String pattern n j ?-boundary?]
-   (loop [m j]
+  ([^String pattern n start] (segment-end pattern n start true))
+  ([^String pattern n start ?-boundary?]
+   (loop [idx start]
      (cond
-       (>= m n) m
-       (let [c (.charAt pattern m)]
+       (>= idx n) idx
+       (let [c (.charAt pattern idx)]
          (or (= c \/) (= c \{) (= c \})
-             (and ?-boundary? (= c \?)))) m
-       :else (recur (inc m))))))
+             (and ?-boundary? (= c \?)))) idx
+       :else (recur (inc idx))))))
 
 (defn- regex-escape
   "Quote a string for use as a regex literal. Portable across JVM

--- a/implementation/routing/src/re_frame/routing/nav_token.cljc
+++ b/implementation/routing/src/re_frame/routing/nav_token.cljc
@@ -42,14 +42,16 @@
 (defn- inner-fx-event-id
   "Best-effort extraction of an `event-id` from an `:do` fx entry. For
   the canonical `[:dispatch [<event-id> args...]]` shape the event-id is
-  the head of the inner vector; for any other fx entry we fall back to
-  the outer fx-id (e.g. `:rf.http/managed`) so the `:event-id` tag still
-  identifies what was suppressed."
+  the head of the inner event vector; for any other fx entry we fall
+  back to the outer fx-id (e.g. `:rf.http/managed`) so the `:event-id`
+  tag still identifies what was suppressed."
   [do-entry]
   (when (vector? do-entry)
-    (let [[fx-id args] do-entry]
-      (if (and (= :dispatch fx-id) (vector? args) (seq args))
-        (first args)
+    (let [[fx-id inner-event-vec] do-entry]
+      (if (and (= :dispatch fx-id)
+               (vector? inner-event-vec)
+               (seq inner-event-vec))
+        (first inner-event-vec)
         fx-id))))
 
 (def with-nav-token-meta

--- a/implementation/routing/src/re_frame/routing/navigate.cljc
+++ b/implementation/routing/src/re_frame/routing/navigate.cljc
@@ -44,11 +44,11 @@
              :query-params (:query opts {})}
 
             (and (map? target) (:url target))
-            (let [m (registry/match-url (:url target))]
-              {:route-id         (or (:route-id m) :rf.route/not-found)
-               :path-params      (:params m {:url (:url target)})
-               :query-params     (:query m {})
-               :matched-fragment (:fragment m)}))
+            (let [match (registry/match-url (:url target))]
+              {:route-id         (or (:route-id match) :rf.route/not-found)
+               :path-params      (:params match {:url (:url target)})
+               :query-params     (:query match {})
+               :matched-fragment (:fragment match)}))
           fragment    (or (:fragment opts)
                           (and (map? target) (:fragment target))
                           matched-fragment)

--- a/implementation/routing/src/re_frame/routing/registry.cljc
+++ b/implementation/routing/src/re_frame/routing/registry.cljc
@@ -73,8 +73,8 @@
   []
   (let [source (registrar/registrations :route)
         pairs  (->> source
-                    (sort-by (fn [[_id meta]]
-                               (or (:rf.route/rank meta) [0 0 0 0 0 0]))
+                    (sort-by (fn [[_id route-meta]]
+                               (or (:rf.route/rank route-meta) [0 0 0 0 0 0]))
                              #(compare %2 %1))
                     vec)]
     (reset! route-table-cache {:source-id source :pairs pairs})
@@ -232,13 +232,13 @@
   (when (and schema (vector? schema))
     (persistent!
       (reduce
-        (fn [m e]
-          (if (and (vector? e) (keyword? (first e)))
-            (let [k         (first e)
+        (fn [acc slot-entry]
+          (if (and (vector? slot-entry) (keyword? (first slot-entry)))
+            (let [k         (first slot-entry)
                   raw       (cond
-                              (= 2 (count e)) (second e)
-                              (= 3 (count e)) (last e)
-                              :else           nil)
+                              (= 2 (count slot-entry)) (second slot-entry)
+                              (= 3 (count slot-entry)) (last slot-entry)
+                              :else                    nil)
                   ;; rf2-3k3o7: detect `[:enum kw kw ...]` as a bounded
                   ;; keyword allowlist. Skip the optional opts-map at
                   ;; position 1 when present (Malli convention:
@@ -255,8 +255,8 @@
                               enum-set        [:rf.route/enum-keyword enum-set]
                               (= :keyword raw) :rf.route/keyword-unbounded
                               :else           raw)]
-              (assoc! m k type-form))
-            m))
+              (assoc! acc k type-form))
+            acc))
         (transient {})
         (rest schema)))))
 
@@ -503,7 +503,7 @@
               (when query-str
                 (let [pairs (clojure.string/split query-str #"&")]
                   (reduce
-                    (fn [m pair]
+                    (fn [acc pair]
                       (let [[k v] (clojure.string/split pair #"=" 2)
                             ;; Per Spec 012 §Routing failure semantics
                             ;; (rf2-wbvme + rf2-4ic0f): malformed %-encoding
@@ -518,16 +518,16 @@
                             vstr  (if v (url/safe-url-decode v) "")]
                         (if (or (nil? kstr) (nil? vstr))
                           (reduced ::malformed-query)
-                          (let [m' (assoc m kstr vstr)]
-                            (when (> (count m') default-max-decoded-keys)
+                          (let [acc' (assoc acc kstr vstr)]
+                            (when (> (count acc') default-max-decoded-keys)
                               (throw (route-error
                                        :rf.error/route-too-many-keys
                                        'rf/match-url
                                        (str "the query string exceeded the per-call unique-key cap (" default-max-decoded-keys ") — a keyword-interning DoS guard; the URL is treated as a route-miss")
                                        {:url   url
                                         :limit default-max-decoded-keys
-                                        :count (count m')})))
-                            m'))))
+                                        :count (count acc')})))
+                            acc'))))
                     (array-map)
                     pairs))))]
         ;; Iterate the pre-sorted table; the first pattern that matches is
@@ -535,13 +535,13 @@
         ;; `reduce` with `reduced` short-circuits on the first hit. nil ⇒
         ;; no route matched OR malformed query fails closed (rf2-4ic0f).
         (reduce
-          (fn [_ [id meta]]
-            (when-let [compiled (or (:rf.route/compiled meta)
-                                    (some-> (:path meta) match/parse-pattern))]
+          (fn [_ [id route-meta]]
+            (when-let [compiled (or (:rf.route/compiled route-meta)
+                                    (some-> (:path route-meta) match/parse-pattern))]
               (when-let [params (match/match-against compiled path)]
-                (let [query-coerce  (:rf.route/query-coerce meta)
-                      defaults      (:query-defaults meta)
-                      retain        (:query-retain meta)
+                (let [query-coerce  (:rf.route/query-coerce route-meta)
+                      defaults      (:query-defaults route-meta)
+                      retain        (:query-retain route-meta)
                       ;; Force the query parse on the first successful path
                       ;; match — unmatched URLs and pre-match iterations skip
                       ;; the work entirely (rf2-r1in4).
@@ -580,8 +580,8 @@
                           ;; flag; the explanation surfaces under :validation-error
                           ;; so callers ((`:rf.route/handle-url-change`)) can route
                           ;; to `:rf.route/not-found` with `:reason :validation`.
-                          [params-failed? params-error] (validate-route-shape meta :params params)
-                          [query-failed?  query-error]  (validate-route-shape meta :query  with-defaults)
+                          [params-failed? params-error] (validate-route-shape route-meta :params params)
+                          [query-failed?  query-error]  (validate-route-shape route-meta :query  with-defaults)
                           validation-failed? (or params-failed? query-failed?)
                           validation-error   (cond
                                                (and params-failed? query-failed?)
@@ -631,8 +631,8 @@
   ([route-id path-params query-params] (route-url route-id path-params query-params nil))
   ([route-id path-params query-params fragment]
    (let [query-params (or query-params {})
-         meta    (registrar/lookup :route route-id)
-         pattern (:path meta)]
+         route-meta   (registrar/lookup :route route-id)
+         pattern      (:path route-meta)]
      (when (nil? pattern)
        (throw (route-error
                 :rf.error/no-such-route
@@ -645,7 +645,7 @@
      ;; the structured id so callers (`:rf.route/navigate`) and tests
      ;; can react. When no schema is declared OR no validator is
      ;; registered, this is a no-op.
-     (let [[p-failed? p-error] (validate-route-shape meta :params path-params)]
+     (let [[p-failed? p-error] (validate-route-shape route-meta :params path-params)]
        (when p-failed?
          (throw (route-error
                   :rf.error/route-url-validation
@@ -655,7 +655,7 @@
                    :slot     :params
                    :value    path-params
                    :error    p-error}))))
-     (let [[q-failed? q-error] (validate-route-shape meta :query query-params)]
+     (let [[q-failed? q-error] (validate-route-shape route-meta :query query-params)]
        (when q-failed?
          (throw (route-error
                   :rf.error/route-url-validation
@@ -672,7 +672,7 @@
            ;; each opening '{' index to `{:inner-names [...] :close-end
            ;; <pos-after-}?>}` — `route-url` consults it instead of
            ;; re-walking the pattern body.
-           groups (or (:groups (:rf.route/compiled meta))
+           groups (or (:groups (:rf.route/compiled route-meta))
                       (:groups (match/parse-pattern pattern)))
            ;; Inner loop emits the body of an optional group whose params
            ;; are all present. State threads as (loop [i parts]); returns

--- a/implementation/routing/src/re_frame/routing/url_change.cljc
+++ b/implementation/routing/src/re_frame/routing/url_change.cljc
@@ -68,16 +68,16 @@
      %-decode. The `:reason` discriminator lets per-route error UIs
      and SSR projections branch on the cause."
   [db url default-scroll frame]
-  (let [m                 (registry/match-url url)
+  (let [match             (registry/match-url url)
         ;; rf2-4ic0f: when match-url returns nil, discriminate the
         ;; bare-miss case from the malformed-URL case via the public
         ;; `malformed-url?` predicate. The predicate scans the URL
         ;; once; we run it only when match-url already missed (the
         ;; happy path pays nothing).
-        malformed?        (and (nil? m) (registry/malformed-url? url))
+        malformed?        (and (nil? match) (registry/malformed-url? url))
         ;; Malformed URLs surface no fragment in the slice — the
         ;; fragment was the (or potentially the) decode-fail site.
-        fragment          (when-not malformed? (:fragment m))
+        fragment          (when-not malformed? (:fragment match))
         ;; Spec 012 §Fragments rules 3-4: when the new URL differs from
         ;; the current slice ONLY in its `#fragment` (same route-id,
         ;; params, query) the runtime updates `:fragment`, emits the
@@ -89,21 +89,21 @@
         ;; Back/Forward to a same-page anchor must not re-fetch route
         ;; data (rf2-8oxj6).
         prev              (get-in db [:rf/runtime :routing :current])
-        fragment-only?    (and prev m
-                               (= (:id prev)     (:route-id m))
-                               (= (:params prev) (:params m))
-                               (= (:query prev)  (:query m))
+        fragment-only?    (and prev match
+                               (= (:id prev)     (:route-id match))
+                               (= (:params prev) (:params match))
+                               (= (:query prev)  (:query match))
                                (not= (:fragment prev) fragment))
-        matched?          (some? m)
-        validation-fail?  (:validation-failed? m)
+        matched?          (some? match)
+        validation-fail?  (:validation-failed? match)
         fallback?         (or (not matched?) validation-fail?)
-        route-id          (if fallback? :rf.route/not-found (:route-id m))
+        route-id          (if fallback? :rf.route/not-found (:route-id match))
         params            (cond
                             malformed?       {:url url :reason :malformed-url}
                             validation-fail? {:url url :reason :validation}
                             (not matched?)   {:url url}
-                            :else            (:params m))
-        query             (if fallback? {} (:query m))
+                            :else            (:params match))
+        query             (if fallback? {} (:query match))
         ;; Spec 012 §Per-route data loading rule 3: a re-navigation whose
         ;; resolved id/params/query/fragment match the current slice
         ;; exactly is a complete no-op — no new nav-token, no `:on-match`


### PR DESCRIPTION
Naming-best-practice audit for `implementation/routing/` per **rf2-vfdvh** (Shape-1 solo, one of the 33-bead audit wave).

Findings doc: `ai/findings/naming-audit-implementation-routing.md` (local-only, gitignored). All inline renames are file-local — no public-surface change, no cross-artefact ripple.

## What changed

| File | Rename |
|------|--------|
| `routing.cljc` | ns alias `subs-ns` → `routing-subs` (matches sibling `routing-events`) |
| `routing/match.cljc` | `segment-end` params `j`/loop `m` → `start`/`idx` (ns-internal helper) |
| `routing/navigate.cljc` | match-url result binding `m` → `match` |
| `routing/url_change.cljc` | match-url result binding `m` → `match` in `url-change-fx` |
| `routing/registry.cljc` | `meta` → `route-meta` in `route-url` + `match-url` reduce + `rebuild-route-table-cache!` sort-by (was shadowing `clojure.core/meta`; aligns with established name used in 6 other files in this slice) |
| `routing/registry.cljc` | reduce idioms `(fn [m e])` / `(fn [m pair])` → `(fn [acc slot-entry])` / `(fn [acc pair])` in `compile-query-coercions` + `match-url` query-parse |
| `routing/nav_token.cljc` | `inner-fx-event-id` `args` → `inner-event-vec` (the binding holds the inner event vector, not raw args) |

## What was considered and kept

- **`frame` (cofx-destructured key)** — kept; `:frame` is the established cofx key across the entire re-frame2 corpus.
- **`id` (positional `reg-route` arg)** — kept; matches `reg-event-db` / `reg-sub` / `reg-fx` registration-verb signature convention.
- **`pn-id` (pending-nav local binding)** — kept; mirrors the runtime-emitted `\"pn-N\"` token prefix.
- **`route-link-render` vs `route-link-render-ssr`** — kept; intentional split for CLJS event-interception vs JVM/SSR render.
- **`transitioned-handler` vs `handle-url-change-handler`** — kept; mirrors the event-id pair (`:rf.route/transitioned` past-tense vs `:rf.route/handle-url-change` imperative).

## Vocabulary alignment with spec

The slice's naming aligns 1:1 with `spec/012-Routing.md`:
- `nav-token` / `pending-nav` / `pending-navigation` / route slice at `[:rf/runtime :routing :current]`
- `:rf.route/*` user-facing vs `:rf.route.internal/*` runtime-internal sub-namespacing
- `:rf.nav/*` (push-url / replace-url / scroll / capture-scroll)
- `url-owner-frame-id` / `:url-bound?` exclusivity per Spec 012 §Multi-frame routing
- `:rf.route.nav-token/*` audience-split trace stream

No drift detected.

## Follow-on beads

**None.** Every rename is a lexical-scope binding (`let` / `loop` / fn-param / ns-alias) within a single file. No public surface affected. Tools, examples, downstream `:require`rs, and the conformance suite see no name change.

## Quality gates

- **JVM tests** (`cd implementation/routing && clojure -M:test`): **122 tests, 552 assertions, 0 failures, 0 errors** (pre- and post-rebase baselines matched).
- **clj-kondo** (`clj-kondo --lint implementation/routing/src`): **0 errors**, 14 pre-existing warnings (CLJS reader-conditional false positives on `clojure.string`, transient unused-require flags). No warnings introduced or removed by this PR.
- **CLJS gate**: skipped (no `node_modules` in the worktree; renames are pure binding/alias changes inside CLJC source — no platform-divergent code reached).

Refs **rf2-vfdvh**.