### PR TITLE
refactor(machines): inline naming-clarity renames (rf2-8kjev)

### DIFF
--- a/implementation/machines/src/re_frame/machines.cljc
+++ b/implementation/machines/src/re_frame/machines.cljc
@@ -37,7 +37,7 @@
       `re-frame.machines.transition`'s `machine-transition-single`)
     - `machines`, `machine-meta`, `machine-by-system-id` — owned
       directly on this façade (Spec 005 §Querying machines)
-    - `spawn-fx`, `invoke-all-init-fx` —
+    - `spawn-fx`, `spawn-all-init-fx` —
       `re-frame.machines.lifecycle-fx.spawn`
     - `destroy-machine-fx` — `re-frame.machines.lifecycle-fx.destroy`
     - `after-schedule-fx`, `after-cancel-fx` — `re-frame.machines.timer`"
@@ -90,7 +90,7 @@
 ;; shape) directly against the leaf fn — no registrar/substrate fixture.
 (def validate-machine!      validation/validate-machine!)
 (def spawn-fx               spawn/spawn-fx)
-(def invoke-all-init-fx     spawn/invoke-all-init-fx)
+(def spawn-all-init-fx      spawn/spawn-all-init-fx)
 (def destroy-machine-fx     destroy/destroy-machine-fx)
 (def machine-transition     parallel/machine-transition)
 (def after-schedule-fx      timer/after-schedule-fx)
@@ -185,7 +185,7 @@
 
 (fx/reg-fx :rf.machine/spawn-all-init
   {:doc "Machine-internal: fire `:initial-entry` cascades for every machine spawned at app boot. Per Spec 005 §Initial entry. Not for direct application use."}
-  invoke-all-init-fx)
+  spawn-all-init-fx)
 
 (fx/reg-fx :rf.machine/after-schedule
   {:doc "Machine-internal: schedule an `:after` timer event for a machine state. Per Spec 005 §Timed transitions. Not for direct application use."}
@@ -280,7 +280,7 @@
 ;; `:where :machine-data` boundary (Spec 005 §Schema validation, Spec
 ;; 010 §Per-step recovery row 7).
 (late-bind/set-fn! :machines/validate-machine-data! validate-machine-data!)
-(late-bind/set-fn! :machines/spawn-all-init-fx      invoke-all-init-fx)
+(late-bind/set-fn! :machines/spawn-all-init-fx      spawn-all-init-fx)
 (late-bind/set-fn! :machines/after-schedule-fx      after-schedule-fx)
 (late-bind/set-fn! :machines/after-cancel-fx        after-cancel-fx)
 (late-bind/set-fn! :machines/update-snapshot-fx     update-snapshot/update-snapshot-fx)

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
@@ -89,7 +89,7 @@
         (registrar/unregister! :event actor-id)
         @sid))))
 
-(defn- destroy-invoke-all-children!
+(defn- destroy-spawn-all-children!
   "Per rf2-6vmw — the declarative-`:spawn-all` exit-cascade form.
   Resolves the children map from `[:rf/runtime :machines :spawned parent-id invoke-id]`,
   tears each child down via `destroy-single-actor!`, then clears the
@@ -243,12 +243,12 @@
   "fx handler for `:rf.machine/destroy`. Dispatches to the keyword-form
   / single-`:spawn` teardown (`destroy-single!`) or the
   `:spawn-all` children-iteration teardown
-  (`destroy-invoke-all-children!`) per the `args` shape. See the ns
+  (`destroy-spawn-all-children!`) per the `args` shape. See the ns
   docstring for the form semantics."
   [{frame-id :frame :or {frame-id :rf/default}} args]
-  (let [invoke-all? (and (map? args) (true? (:rf/spawn-all args)))]
-    (if invoke-all?
-      (destroy-invoke-all-children! frame-id
-                                    (:rf/parent-id args)
-                                    (:rf/spawn-id args))
+  (let [spawn-all? (and (map? args) (true? (:rf/spawn-all args)))]
+    (if spawn-all?
+      (destroy-spawn-all-children! frame-id
+                                   (:rf/parent-id args)
+                                   (:rf/spawn-id args))
       (destroy-single! frame-id args))))

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
@@ -84,7 +84,7 @@
              (transition/final-state-node? leaf-node)))
          state)))
 
-(defn- find-invoke-spec-at
+(defn- find-spawn-spec-at
   "Walk `parent-spec`'s state tree to the node at `invoke-id` (the
   absolute prefix-path stamped at spawn time) and return that node's
   `:spawn` map. For a parallel-region parent, the first element of
@@ -179,9 +179,9 @@
         parent-meta (when parent-id
                       (let [m (registrar/lookup :event parent-id)]
                         (when (:rf/machine? m) (:rf/machine m))))
-        invoke-spec (when (and parent-meta invoke-id)
-                      (find-invoke-spec-at parent-meta invoke-id))
-        on-done-fn  (:on-done invoke-spec)
+        spawn-spec  (when (and parent-meta invoke-id)
+                      (find-spawn-spec-at parent-meta invoke-id))
+        on-done-fn  (:on-done spawn-spec)
         parent-path [:rf/runtime :machines :snapshots parent-id]
         ;; (2) Emit `:rf.machine/done` trace BEFORE the destroy cascade
         ;; (D6 ordering).

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
@@ -25,7 +25,7 @@
         - dispatches the parent join event via `:fx [[:dispatch ...]]`.
    7. Writes the new join state back into app-db.
 
-  The interceptor's public entry point is `intercept-invoke-all-event`;
+  The interceptor's public entry point is `intercept-spawn-all-event`;
   the handler-factory in `re-frame.machines.lifecycle-fx.registration`
   routes every inbound event through it before the machine's normal `:on`
   lookup."
@@ -36,8 +36,8 @@
 
 #?(:clj (set! *warn-on-reflection* true))
 
-(defn- find-active-invoke-all-in-tree
-  "Helper for `find-active-invoke-all`. Given a machine-like map with
+(defn- find-active-spawn-all-in-tree
+  "Helper for `find-active-spawn-all`. Given a machine-like map with
   `:states` (for a non-parallel machine, the machine itself; for a
   region of a parallel machine, the region body) and a path inside
   that tree, walk leaf→root for a `:spawn-all`-bearing state whose
@@ -54,7 +54,7 @@
           (= inner-event-id (:on-child-error ia))
           {:spawn-id prefix :spec ia :kind :failed})))))
 
-(defn- find-active-invoke-all
+(defn- find-active-spawn-all
   "Walk the snapshot's `:state` path leaf→root looking for an
   `:spawn-all`-bearing state whose `:on-child-done` or `:on-child-error`
   matches the given inner-event-id. Returns
@@ -64,21 +64,21 @@
   Per Spec 005 §Parallel regions (rf2-l67o): for parallel-region
   machines, iterates each region's active state-tree (prefixing the
   region name onto the resolved `:spawn-id`, matching the per-region
-  scoping `prefix-region-invoke-id` applies on the entry-side)."
+  scoping `prefix-region-spawn-id` applies on the entry-side)."
   [machine snapshot inner-event-id]
   (cond
     (parallel/parallel? machine)
     (some (fn [[region-name region-state]]
             (let [region-body (parallel/region-machine machine region-name)
                   region-path (transition/state-path region-state)
-                  match       (find-active-invoke-all-in-tree
+                  match       (find-active-spawn-all-in-tree
                                 region-body region-path inner-event-id)]
               (when match
                 (update match :spawn-id #(vec (cons region-name %))))))
           (:state snapshot))
 
     :else
-    (find-active-invoke-all-in-tree machine (transition/state-path (:state snapshot)) inner-event-id)))
+    (find-active-spawn-all-in-tree machine (transition/state-path (:state snapshot)) inner-event-id)))
 
 (defn- join-condition-met?
   "Evaluate the join condition against the current join state.
@@ -225,7 +225,7 @@
             [[:dispatch [parent-id inner]]]))]
     (vec (concat (or cancel-fx []) (or dispatch-fx [])))))
 
-(defn intercept-invoke-all-event
+(defn intercept-spawn-all-event
   "Per Spec 005 §Child completion protocol (rf2-6vmw). When the parent's
   handler receives an event whose inner event-id matches the active
   `:spawn-all`-bearing state's `:on-child-done` / `:on-child-error`,
@@ -238,7 +238,7 @@
   destroys + the join-event dispatch)."
   [machine db _path snapshot parent-id inner-event]
   (let [inner-id (first inner-event)
-        match    (find-active-invoke-all machine snapshot inner-id)
+        match    (find-active-spawn-all machine snapshot inner-id)
         ;; Per rf2-ko8jb: resolve the live frame from the runtime-stamped
         ;; machine (registration.cljc/prepare-machine-ctx assoc'd
         ;; `:rf/frame` before handing the machine to the interceptor).

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
@@ -14,7 +14,7 @@
       cascade, `:data` / `:meta` / `:rf/spawn-counter` seeding, tag union
       stamping (lazily, on first event). Single source of truth shared
       with the spawn path.
-    - the returned handler fn — frame stamping, `intercept-invoke-all-
+    - the returned handler fn — frame stamping, `intercept-spawn-all-
       event` branch (in `lifecycle-fx.join`), bootstrap-pending
       detection + initial-entry cascade, machine-transition dispatch,
       action-failure projection, finalize delegation (in
@@ -105,7 +105,7 @@
 ;;   4. `commit-or-finalize`   — emit transition / snapshot-updated traces,
 ;;      build new-db, route to `finalize-machine` if `finished?`.
 ;;
-;; The intercept-invoke-all-event short-circuit is the visible top-level
+;; The intercept-spawn-all-event short-circuit is the visible top-level
 ;; branch in `make-machine-handler` itself — it must short-circuit before
 ;; boot / step / commit run.
 
@@ -372,14 +372,14 @@
     - `parallel/build-initial-snapshot` — initial-state cascade, `:data` /
       `:meta` seeding, `:rf/spawn-counter` seeding, tag union stamping
       (rf2-fgqs4 unified this with the spawn path).
-    - the returned handler fn — frame stamping, intercept-invoke-all-
+    - the returned handler fn — frame stamping, intercept-spawn-all-
       event branch (in `lifecycle-fx.join`), bootstrap-pending detection
       + initial-entry cascade, machine-transition dispatch, action-failure
       projection, finalize delegation (in `lifecycle-fx.finalize`).
 
   Per rf2-2zzyg the returned handler fn is further decomposed into a
   four-step pipeline — `prepare-machine-ctx` → `maybe-boot` →
-  `run-step` → `commit-or-finalize` — with the intercept-invoke-all-
+  `run-step` → `commit-or-finalize` — with the intercept-spawn-all-
   event short-circuit branching off after step 1."
   [machine]
   (validation/validate-machine! machine)
@@ -407,7 +407,7 @@
                     :event      event
                     :frame      (or frame :rf/default)})
       (let [ctx         (prepare-machine-ctx db frame event machine base-initial)
-            intercepted (join/intercept-invoke-all-event
+            intercepted (join/intercept-spawn-all-event
                           (:machine ctx) db (:path ctx) (:snapshot ctx)
                           (:machine-id ctx) (:inner-event ctx))]
         (if intercepted

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
@@ -15,7 +15,7 @@
   `events/reg-event-fx`. Frame isolation is preserved by the snapshot
   living at `[:rf/runtime :machines :snapshots <id>]` inside the spawning frame's app-db.
 
-  Per rf2-6vmw `invoke-all-init-fx` also lives here — the runtime
+  Per rf2-6vmw `spawn-all-init-fx` also lives here — the runtime
   emits `[:rf.machine/spawn-all-init args]` alongside per-child
   `:rf.machine/spawn` fxs on entry to a `:spawn-all`-bearing state to
   seed the join state at `[:rf/runtime :machines :spawned <parent> <invoke-id>]`."
@@ -286,7 +286,7 @@
 
 ;; ---- :rf.machine/spawn-all-init -------------------------------------------
 
-(defn invoke-all-init-fx
+(defn spawn-all-init-fx
   "fx handler for `:rf.machine/spawn-all-init` (rf2-6vmw). Per Spec 005
   §Spawn-and-join via `:spawn-all`, on entry to a `:spawn-all`-bearing
   state the runtime emits this fx (alongside per-child `:rf.machine/spawn`
@@ -301,7 +301,7 @@
 
   Subsequent `:on-child-done` / `:on-child-error` events arrive at the
   parent's `make-machine-handler` boundary and are intercepted by
-  `intercept-invoke-all-event` (in `lifecycle-fx.join`)."
+  `intercept-spawn-all-event` (in `lifecycle-fx.join`)."
   [{frame-id :frame :or {frame-id :rf/default}} args]
   (let [parent-id  (:rf/parent-id args)
         invoke-id  (:rf/spawn-id args)

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/traces.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/traces.cljc
@@ -28,7 +28,7 @@
   :child-id :reason}`. Callers pass only the slots their site populates
   — `nil` values are stamped through, matching pre-consolidation
   behaviour (e.g. `destroy-single!` always stamps `:system-id`, even
-  when nil; `destroy-invoke-all-children!` per-child fires omit
+  when nil; `destroy-spawn-all-children!` per-child fires omit
   `:system-id` by NOT passing the key).
 
   `reason` is the discriminator — `:explicit` for direct-destroy

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/validation.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/validation.cljc
@@ -9,8 +9,8 @@
   in this namespace are:
 
     - `validate-parallel!` — `:type :parallel` shape (rf2-l67o).
-    - `validate-invoke-all!` — `:spawn-all` shape (rf2-6vmw).
-    - `validate-no-invoke-timeout-ms!` — rejects the dropped
+    - `validate-spawn-all!` — `:spawn-all` shape (rf2-6vmw).
+    - `validate-no-spawn-timeout-ms!` — rejects the dropped
       `:timeout-ms` / `:on-timeout` slots on `:spawn` / `:spawn-all`
       (rf2-3y3y).
     - `validate-final-state!` — `:final?` shape (rf2-gn80).
@@ -55,7 +55,7 @@
                     :reason      reason}
                    extras))))
 
-(defn- validate-no-invoke-timeout-ms!
+(defn- validate-no-spawn-timeout-ms!
   "Per rf2-3y3y / Spec 005 §Wall-clock timeouts on :spawn — use parent
   state's `:after`, the pre-release `:timeout-ms` / `:on-timeout` slots
   on `:spawn` and `:spawn-all` are DROPPED."
@@ -80,13 +80,13 @@
                     :on-timeout ot
                     :migration  "migration/from-re-frame-v1/README.md §M-44"})))))))
 
-(defn- validate-invoke-all!
+(defn- validate-spawn-all!
   "Per Spec 005 §Spawn-and-join via `:spawn-all` (rf2-6vmw): walk the
   state tree at registration time and reject malformed `:spawn-all`
   declarations.
 
   Three error categories:
-    - `:rf.error/machine-spawn-all-bad-shape` — a child invoke-spec is
+    - `:rf.error/machine-spawn-all-bad-shape` — a child spawn-spec is
       missing `:id`; or `:spawn-all` is not a vector; or the join-event
       slots are missing per the required-iff rules; or no `:machine-id`
       / `:definition`.
@@ -105,7 +105,7 @@
       (when-not (map? inv-all)
         (throw (validation-error
                  :rf.error/machine-spawn-all-bad-shape
-                 "invoke-all slot must be a map"
+                 ":spawn-all slot must be a map"
                  {:state state-key})))
       (let [children (:children inv-all)]
         (when-not (and (vector? children) (seq children))
@@ -117,13 +117,13 @@
           (when-not (and (map? c) (keyword? (:id c)))
             (throw (validation-error
                      :rf.error/machine-spawn-all-bad-shape
-                     "each child invoke-spec must declare an :id keyword"
+                     "each child spawn-spec must declare an :id keyword"
                      {:state state-key
                       :child c})))
           (when-not (or (:machine-id c) (:definition c))
             (throw (validation-error
                      :rf.error/machine-spawn-all-bad-shape
-                     "each child invoke-spec must declare :machine-id or :definition"
+                     "each child spawn-spec must declare :machine-id or :definition"
                      {:state state-key
                       :child c}))))
         (let [ids (map :id children)]
@@ -478,8 +478,8 @@
   (validate-no-history! machine)
   (validate-parallel! machine)
   (doseq [[s n] (walk-state-nodes machine)]
-    (validate-invoke-all! s n)
-    (validate-no-invoke-timeout-ms! s n)
+    (validate-spawn-all! s n)
+    (validate-no-spawn-timeout-ms! s n)
     (validate-final-state! s n)
     (validate-compound-initial! s n))
   ;; The self-loop check needs each declaring node's absolute path to

--- a/implementation/machines/src/re_frame/machines/parallel.cljc
+++ b/implementation/machines/src/re_frame/machines/parallel.cljc
@@ -174,13 +174,13 @@
     (cond-> tagged
       bootstrap-pending? (assoc :rf/bootstrap-pending? true))))
 
-(defn- prefix-region-invoke-id
+(defn- prefix-region-spawn-id
   "Per Spec 005 §Per-region `:spawn` / `:after` / `:always` scoping:
   spawn / destroy / after-schedule / after-cancel fxs emitted by a region
   carry an `:rf/spawn-id` that's the in-region prefix-path. To keep the
   runtime-owned `[:rf/runtime :machines :spawned <parent-id> <invoke-id>]` slot unique
   per-region (and per-region `:after` epoch tracking distinct from sibling
-  regions), prepend the region name onto the invoke-id."
+  regions), prepend the region name onto the `:rf/spawn-id`."
   [region-name fx]
   (let [[fx-id args] fx]
     (cond
@@ -241,7 +241,7 @@
 ;;   - run each region as a synthetic single-machine spec via
 ;;     `region-machine`,
 ;;   - prefix per-region fx with the region name via
-;;     `prefix-region-invoke-id` so per-region `[:rf/runtime :machines :spawned ...]` /
+;;     `prefix-region-spawn-id` so per-region `[:rf/runtime :machines :spawned ...]` /
 ;;     `:after`-epoch tracking slots stay distinct from siblings,
 ;;   - short-circuit to a `result/fail` if any region's step fails,
 ;;   - commit `:tags` via `commit-tags-parallel` AFTER every region has
@@ -316,7 +316,7 @@
                        (:rf/spawn-counter reg-snap)
                        (assoc new-states rn (:state reg-snap))
                        (into acc-fx
-                             (map (partial prefix-region-invoke-id rn))
+                             (map (partial prefix-region-spawn-id rn))
                              reg-fx)
                        (or any-handled? region-handled?)
                        (long (+ micro-total region-micro)))))))))))
@@ -357,7 +357,7 @@
   For the synthetic `[:rf.machine.timer/after-elapsed ...]` event,
   delivery is region-scoped — the broadcast routes to the bearing region
   only, identified by the region-name prefix on the in-flight timer's
-  invoke-id."
+  `:rf/spawn-id`."
   [machine snapshot event]
   (let [result (reduce-regions machine snapshot
                                (fn [region-spec region-snap]

--- a/implementation/machines/src/re_frame/machines/path_walk.cljc
+++ b/implementation/machines/src/re_frame/machines/path_walk.cljc
@@ -57,7 +57,7 @@
   ## Why not also root→leaf?
 
   The inverse direction (root→leaf descent to a known absolute path,
-  as in `find-invoke-spec-at`) is a different operation — it walks to
+  as in `find-spawn-spec-at`) is a different operation — it walks to
   a known target rather than seeking a deepest match. Treating it as
   the same primitive with a direction flag obscured the unifying rule
   (deepest-wins isn't 'a walk'; it's 'a walk in a specific direction

--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -460,7 +460,7 @@
   (let [[_ delay-key carried-epoch raw-carried-decl-path] event
         region        (:rf/region machine)
         ;; Per Spec 005 §Per-region :after scoping: the runtime carries a
-        ;; region-name-prefixed decl-path (`prefix-region-invoke-id`) for
+        ;; region-name-prefixed decl-path (`prefix-region-spawn-id`) for
         ;; timers scheduled inside a parallel region. Within a region's
         ;; `pick-after-transition` the active path is in-region, so strip
         ;; the region-name head. A carried path naming a DIFFERENT region
@@ -968,7 +968,7 @@
 
 ;; ---- :spawn / :spawn-all spawn reducers ----------------------------------
 
-(defn- handle-invoke-spawn
+(defn- handle-spawn-decl
   "Handle the `:spawn` branch of the spawn reducer in
   `apply-transition-once`. Allocates one spawned-id, delegates the
   `:data` materialisation and spawn-args assembly to `spawn-one`, then
@@ -996,7 +996,7 @@
             s'       (apply-on-spawn machine s-alloc inv id)]
         [s' (into acc-fx spawn-fx)]))))
 
-(defn- handle-invoke-all-spawn
+(defn- handle-spawn-all-decl
   "Handle the `:spawn-all` branch of the spawn reducer in
   `apply-transition-once`. Per Spec 005 §Spawn-and-join via `:spawn-all`
   (rf2-6vmw), `:spawn-all` is spawn-and-join sugar over N parallel
@@ -1125,8 +1125,8 @@
 
   Returns a `re-frame.machines.result/Result` — a `result/ok` carrying
   the post-cascade snapshot + accumulated fx, or a `result/fail` if any
-  `:exit` action threw. Callers (destroy / finalize / invoke-all child
-  teardown) emit a `[:rf.machine/bootstrap-exit]` synthetic event so
+  `:exit` action threw. Callers (destroy / finalize / `:spawn-all` per-
+  child teardown) emit a `[:rf.machine/bootstrap-exit]` synthetic event so
   3-arity `:exit` fns that introspect the event see a discriminator
   distinguishing destroy-time exit from transition-driven exit.
 
@@ -1169,9 +1169,9 @@
 ;;                            any exited/entered node carries `:after`.
 ;;
 ;;   run-spawn-phase        — reduce over `entered-pairs` dispatching to
-;;                            `handle-invoke-spawn` / `handle-invoke-all-
-;;                            spawn`. Threads snapshot + acc-fx; short-
-;;                            circuits to `result/fail` on `:data`-fn throws.
+;;                            `handle-spawn-decl` / `handle-spawn-all-decl`.
+;;                            Threads snapshot + acc-fx; short-circuits to
+;;                            `result/fail` on `:data`-fn throws.
 
 (defn- compute-cascade-paths
   "Phase 1 — derive the transition's geometry. Returns a map with:
@@ -1330,10 +1330,10 @@
                    (fn [[s acc-fx] [prefix n]]
                      (cond
                        (:spawn n)
-                       (handle-invoke-spawn machine parent-id s acc-fx prefix n event)
+                       (handle-spawn-decl machine parent-id s acc-fx prefix n event)
 
                        (:spawn-all n)
-                       (handle-invoke-all-spawn machine parent-id s acc-fx prefix n event)
+                       (handle-spawn-all-decl machine parent-id s acc-fx prefix n event)
 
                        :else
                        [s acc-fx]))

--- a/implementation/machines/test/re_frame/destroy_exit_cascade_test.clj
+++ b/implementation/machines/test/re_frame/destroy_exit_cascade_test.clj
@@ -13,7 +13,7 @@
        fired by `apply-transition-once` when the exit cascade crosses
        a `:spawn`-bearing state).
     3. `:spawn-all` per-child teardown (parent cascade tears children
-       down through `destroy-invoke-all-children!`).
+       down through `destroy-spawn-all-children!`).
     4. Final-state auto-destroy (child enters `:final?`; `finalize-
        machine` runs the cascade).
 

--- a/implementation/machines/test/re_frame/destroyed_exit_order_test.clj
+++ b/implementation/machines/test/re_frame/destroyed_exit_order_test.clj
@@ -4,7 +4,7 @@
 
   Before rf2-iilco the explicit / declarative-`:spawn` destroy
   (`destroy-single!`) and the `:spawn-all` per-child teardown
-  (`destroy-invoke-all-children!`) emitted `:rf.machine/destroyed`
+  (`destroy-spawn-all-children!`) emitted `:rf.machine/destroyed`
   BEFORE running `run-child-exit!`, while the final-state auto-destroy
   (`finalize-machine`) emitted it AFTER the cascade. A consumer keying
   on `:rf.machine/destroyed` therefore saw the destroy signal at a
@@ -96,7 +96,7 @@
             "declarative :spawn exit cascade emits :exit then :destroyed")
         (finally (unreg))))))
 
-;; ---- Path 2: :spawn-all per-child teardown (destroy-invoke-all-children!) --
+;; ---- Path 2: :spawn-all per-child teardown (destroy-spawn-all-children!) --
 
 (deftest destroyed-after-exit-on-invoke-all-teardown
   (testing ":spawn-all per-child teardown fires each :exit BEFORE its :destroyed"

--- a/implementation/machines/test/re_frame/destroyed_trace_shape_test.clj
+++ b/implementation/machines/test/re_frame/destroyed_trace_shape_test.clj
@@ -4,7 +4,7 @@
   `:rf.machine/destroyed` is emitted at three distinct sites — each
   for a different destroy class:
 
-    1. `destroy-invoke-all-children!` (lifecycle_fx/destroy.cljc):
+    1. `destroy-spawn-all-children!` (lifecycle_fx/destroy.cljc):
        per-child fire when a `:spawn-all` parent tears down its
        children. The trace carries an extra `:child-id` slot keying
        the join-state map but does NOT include `:system-id`.
@@ -90,10 +90,10 @@
       (is (#{:explicit :rf.machine/finished} (:reason tags))
           (str label ": :reason is one of :explicit / :rf.machine/finished")))))
 
-;; ---- Site 1: destroy-invoke-all-children! ---------------------------------
+;; ---- Site 1: destroy-spawn-all-children! ---------------------------------
 
 (deftest invoke-all-children-destroy-trace-shape
-  (testing "destroy-invoke-all-children! per-child traces carry :child-id and omit :system-id"
+  (testing "destroy-spawn-all-children! per-child traces carry :child-id and omit :system-id"
     (let [[cap unreg] (record!)
           child {:initial :running
                  :data    {}
@@ -121,7 +121,7 @@
         ;; Force a :spawn-all teardown via re-entering :idle through
         ;; an explicit destroy of the parent. Easier: drive the parent
         ;; via :ia/cancel into :idle (the invoke-all exit cascade tears
-        ;; the children down through destroy-invoke-all-children!).
+        ;; the children down through destroy-spawn-all-children!).
         (rf/dispatch-sync [:ia/parent [:ia/cancel]])
         (let [traces (destroyed-traces cap)
               child-traces (filter #(contains? (:tags %) :child-id) traces)]

--- a/implementation/machines/test/re_frame/reduce_regions_test.clj
+++ b/implementation/machines/test/re_frame/reduce_regions_test.clj
@@ -8,7 +8,7 @@
    2. A later region's step sees earlier regions' `:data` writes.
    3. The shared `:rf/spawn-counter` (rf2-gr8q) threads in/out across
       regions — bumps in one region are visible to the next.
-   4. Per-region fx is prefixed via `prefix-region-invoke-id` so the
+   4. Per-region fx is prefixed via `prefix-region-spawn-id` so the
       `[:rf/runtime :machines :spawned ...]` slot key stays unique per region.
 
   And the contract:
@@ -120,7 +120,7 @@
       (is (result/ok? r))
       ;; Each region's step emits a :spawn-id starting with its own
       ;; region name; reduce-regions prepends the region name AGAIN
-      ;; (the standard prefix-region-invoke-id rule) so the final fx
+      ;; (the standard prefix-region-spawn-id rule) so the final fx
       ;; carries `[rn rn :child]`.
       (is (= [[:rf.machine/spawn {:rf/spawn-id [:a :a :child]}]
               [:rf.machine/spawn {:rf/spawn-id [:b :b :child]}]]

--- a/implementation/machines/test/re_frame/spawn_all_test.clj
+++ b/implementation/machines/test/re_frame/spawn_all_test.clj
@@ -373,7 +373,7 @@
 
 ;; ---- late-completion safety net (rf2-1tt9q) -----------------------------
 ;;
-;; intercept-invoke-all-event has a post-resolution branch (join.cljc:134-141)
+;; intercept-spawn-all-event has a post-resolution branch (join.cljc:134-141)
 ;; that fires when a child-done event arrives AFTER the join already
 ;; resolved. The contract surface is the :rf.machine.spawn-all/late-completion
 ;; trace — the return-value is a no-op {:db db :fx []}.
@@ -437,7 +437,7 @@
 
 ;; ---- forged child-id rejection (rf2-ns8ut) ------------------------------
 ;;
-;; intercept-invoke-all-event must verify the inbound `child-id` is one
+;; intercept-spawn-all-event must verify the inbound `child-id` is one
 ;; of the parent's spawned children before mutating the join state.
 ;; Otherwise a hand-crafted dispatch (typo, copy-paste from a sibling
 ;; :spawn-all, cascaded event from another parent) silently folds an


### PR DESCRIPTION
Naming-clarity sweep for `implementation/machines/` (Shape-1 solo P3 audit bead).

The dominant finding: residual xstate-vocabulary leak in the private scaffolding. Per Spec 005 §Lessons from xstate the public surface deliberately diverged from xstate's `:invoke` to `:spawn`, but multiple internal helpers, let-bindings, and ns-internal docstrings still spelled `invoke` / `invoke-all` / `invoke-id`. The public grammar keys (`:spawn`, `:spawn-all`, `:on-spawn`, `:rf/spawn-id`, `:rf/spawned-id`), the trace ids, and the late-bind hook keys are already clean — only the engine's private scaffolding had drifted.

## What changed

Inline renames (private helpers, let-bindings, and one artefact-private public def with zero external readers — corpus-grep confirmed):

| Old | New | File |
|---|---|---|
| `handle-invoke-spawn` | `handle-spawn-decl` | `transition.cljc` |
| `handle-invoke-all-spawn` | `handle-spawn-all-decl` | `transition.cljc` |
| `prefix-region-invoke-id` | `prefix-region-spawn-id` | `parallel.cljc` |
| `find-active-invoke-all` | `find-active-spawn-all` | `lifecycle-fx/join.cljc` |
| `find-active-invoke-all-in-tree` | `find-active-spawn-all-in-tree` | `lifecycle-fx/join.cljc` |
| `intercept-invoke-all-event` | `intercept-spawn-all-event` | `lifecycle-fx/join.cljc` |
| `destroy-invoke-all-children!` | `destroy-spawn-all-children!` | `lifecycle-fx/destroy.cljc` |
| `invoke-all?` let-binding | `spawn-all?` | `lifecycle-fx/destroy.cljc` |
| `find-invoke-spec-at` | `find-spawn-spec-at` | `lifecycle-fx/finalize.cljc` |
| `invoke-spec` let-binding | `spawn-spec` | `lifecycle-fx/finalize.cljc` |
| `invoke-all-init-fx` | `spawn-all-init-fx` | `lifecycle-fx/spawn.cljc` + façade re-export |
| `validate-invoke-all!` | `validate-spawn-all!` | `lifecycle-fx/validation.cljc` |
| `validate-no-invoke-timeout-ms!` | `validate-no-spawn-timeout-ms!` | `lifecycle-fx/validation.cljc` |

Drive-by: comment + docstring sweep across the touched files plus test-file comments referencing the renamed fns. Validator error messages ("invoke-all slot must be a map", "each child invoke-spec must declare …") updated to spec-aligned wording.

## What did NOT change

- `invoke-id` let-binding family is **kept** — Spec 005 itself uses `<invoke-id>` as the placeholder name inside the bracket address `[:rf/runtime :machines :spawned <parent-id> <invoke-id>]` to disambiguate the slot-key path from the spawned-actor `:rf/spawned-id` that shares the same `let` block. Filed as follow-on for spec/code vocabulary unification (findings Section C1).
- Public surface (`reg-machine*`, `machine-transition`, `spawn-fx`, `destroy-machine-fx`, `validate-machine!`, etc.): zero touched.
- Sub-namespace names: not renamed (would be public-surface). Filed as Section C2 follow-on.
- `mermaid.cljc`: interior names are clean already; the file's location is the subject of rf2-sqhqu (separate decision bead).

## Quality gates

- `cd implementation/machines && clojure -M:test`: **298 tests / 980 assertions, 0 failures, 0 errors**.
- `clj-kondo --lint src test` (from `implementation/machines`): **0 errors, 35 warnings** — all pre-existing (`with-ok` macro destructuring patterns clj-kondo doesn't understand, plus stale `:require`s in test files; baseline `git stash` run produced the same 35-count).
- `npm run test:cljs` (from `implementation/`): **4845 tests / 15891 assertions, 0 failures, 0 errors**.

## Findings + follow-ons

Findings doc lives at `ai/findings/naming-audit-implementation-machines.md` (local-only, gitignored). Section C lists follow-on items needing Mike-approval or cross-artefact rewire:

- C1: `invoke-id` vs `:rf/spawn-id` vs `:rf/spawned-id` vocabulary unification (decision bead).
- C2: `re-frame.machines.parallel` carries non-parallel engine fns — split candidate.
- C3: `mermaid.cljc` location decision tracked at rf2-sqhqu.
- C4: paired with C1 — if C1 lands, let-bindings family is a mechanical rename.
- C5: `::after-watch` reserved namespace id is undocumented in Spec 005 §Reserved synthetic events — file as note.

closes rf2-8kjev