### PR TITLE
refactor(machines-viz): inline naming-clarity renames (rf2-yei4m)

### DIFF
--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/visual_constants.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/visual_constants.cljc
@@ -309,7 +309,7 @@
     :else
     (throw (ex-info ":rf.error/machines-viz-unknown-chart-density"
                     {:rf.error/id :rf.error/machines-viz-unknown-chart-density
-                     :where     'machines-viz/resolve-chart-density
+                     :where     'machines-viz/chart-for-density
                      :recovery  :no-recovery
                      :reason    (str "unknown chart density: " (pr-str density)
                                      ". Expected one of " (pr-str densities) ".")


### PR DESCRIPTION
Naming-best-practice audit for `tools/machines-viz/` (rf2-yei4m).

Top-line verdict: **the slice is shipped quality**. Domain vocabulary
tracks `spec/005-StateMachines.md` + the Stately graph-view convention
the codebase explicitly anchors to. Namespaces, public-fn names,
predicates (`?`), side-effect markers (`!`), file-to-ns matching,
let-binding discipline, and test-name narrative all KEEP. The audit
benefited from prior hygiene passes (`overlay-anchor` being the canonical
node-id-to-testid seam, `chart.projection/state-node-min-*` being the
single source the renderer reads through, etc.).

## What changed

One inline rename, one line of code:

- `tools/machines-viz/src/day8/re_frame2_machines_viz/visual_constants.cljc`
  - `chart-for-density`'s `ex-info` `:where` slot:
    - **Before:** `'machines-viz/resolve-chart-density`
    - **After:** `'machines-viz/chart-for-density`

The `:where` slot referenced `resolve-chart-density` — a fn that does
not exist anywhere in the codebase. Every other `:where` in the slice
uses the actual public-fn name (`'machines-viz/spec->scxml`,
`'machines-viz/scxml->spec`, `'machines-viz/generate-machine`);
aligning this one keeps the trace-bus consumer surface consistent.
A consumer landing on this error and reaching for the named fn would
otherwise find nothing.

Risk: zero. Pure data-string change in an `ex-info` payload; no
behavioural surface. No test pinned the old symbol (`rg
"resolve-chart-density"` returns zero matches across the slice).
The `:rf.error/id` keyword is unchanged, so error-pattern matching
downstream is unaffected.

## Follow-on beads

**Zero filed.** Candidates considered + rejected (see findings doc
§Follow-on beads):

- `:on-state-click` vs `:on-edge-click` callback-shape asymmetry — both
  shapes are documented + justified by the payloads they carry.
- `:where 'machines-viz/<fn>` short-tag pseudo-namespace — internal
  marker, not an actual ns reference; the convention is consistent.
- `region-boundary-color-key`, `parse-edn`, `viewer-view` — read cleanly
  in their local context.

## Findings doc

`ai/findings/naming-audit-tools-machines-viz.md` (local-only,
gitignored). Categorised verdicts across the 7 audit criteria
(namespaces / function names / file names / let-bindings + parameters /
test names / cross-slice consistency / domain vocabulary), with the
inline rename's reasoning + every rejected follow-on candidate listed.

## Quality gates

- `cd tools/machines-viz && clojure -M:test` → **0 failures, 0 errors**
  (292 tests, 740 assertions). Covers the changed `.cljc` file end to
  end via the JVM test corpus.
- `clj-kondo --lint tools/machines-viz/src/day8/re_frame2_machines_viz/visual_constants.cljc`
  → **0 errors, 0 warnings**.
- CLJS gate (`npm run test:cljs`) skipped — shadow-cljs is not
  installed in this worktree (Windows file-lock-style skip per the
  rf2-gyqpj surface-gate-menu allowance). The JVM gate covers the
  pure-data `.cljc` change conclusively; the change is a string
  literal in an `ex-info` payload with no semantic effect on any
  computation.

Closes rf2-yei4m.