### PR TITLE
refactor(flows): inline naming-clarity renames (rf2-r4mmm)

### DIFF
--- a/implementation/flows/src/re_frame/flows/registry.cljc
+++ b/implementation/flows/src/re_frame/flows/registry.cljc
@@ -354,9 +354,9 @@
 
   - **Unmaterialised parent.** When a flow with `:path [:step-2 :result]`
     is cleared BEFORE its first drain, the parent slot `:step-2` may not
-    exist. The naïve `(update-in cur [:step-2] dissoc :result)` returns
+    exist. The naïve `(update-in db [:step-2] dissoc :result)` returns
     `(dissoc nil :result)` ⇒ `nil`, producing `{:step-2 nil}` — a
-    spurious nil parent. Detect this case and leave `cur` unchanged.
+    spurious nil parent. Detect this case and leave `db` unchanged.
   - **Non-map intermediate.** When an intermediate path step holds a
     non-map value (a scalar already wrote past the flow's planned path),
     the naïve `update-in` calls `(dissoc 1 :result)` and throws
@@ -365,22 +365,22 @@
 
   Single-element paths and non-vector paths are handled by the caller's
   earlier branches; this helper is only called for `(>= (count path) 2)`."
-  [cur path]
+  [db path]
   (let [parent-path (vec (butlast path))
         leaf        (last path)
-        parent      (get-in cur parent-path ::missing)]
+        parent      (get-in db parent-path ::missing)]
     (cond
-      ;; Parent was never materialised — leave cur as-is. Per audit
+      ;; Parent was never materialised — leave db as-is. Per audit
       ;; rf2-q25os Repro 1: registering a nested-path flow then clearing
       ;; before any drain would write `{<parent> nil}` otherwise.
-      (or (= ::missing parent) (nil? parent)) cur
+      (or (= ::missing parent) (nil? parent)) db
       ;; Parent is non-map (scalar / vector / set) — there's no
       ;; meaningful "dissoc this leaf" on a non-map intermediate. Per
       ;; audit rf2-q25os Repro 2: throwing ClassCastException for a
       ;; cleanup operation is poor manners; leave the value untouched
       ;; (it's not OUR flow's output anyway).
-      (not (map? parent)) cur
-      :else (update-in cur parent-path dissoc leaf))))
+      (not (map? parent)) db
+      :else (update-in db parent-path dissoc leaf))))
 
 (defn clear-flow
   "Deregister a flow from a frame; dissoc its output path from that
@@ -406,7 +406,7 @@
      (when-let [flow (get-in @flows [frame-id id])]
        (let [path (:path flow)]
          (when-let [container (frame/get-frame-db frame-id)]
-           (let [cur    (adapter/read-container container)
+           (let [db     (adapter/read-container container)
                  ;; `validate-flow` guarantees `:path` is a non-empty
                  ;; vector at registration (rejects non-vector and empty
                  ;; via :rf.error/flow-bad-path), so a flow read back out
@@ -414,7 +414,7 @@
                  ;; empty-path arms are reachable here.
                  ;;
                  ;; rf2-aqt7: when :path is a single-element vector [:k],
-                 ;; (butlast [:k]) is () and (update-in cur [] dissoc :k)
+                 ;; (butlast [:k]) is () and (update-in db [] dissoc :k)
                  ;; does NOT dissoc — Clojure's update-in on the empty
                  ;; path falls into (assoc {} nil (apply f val args)),
                  ;; producing {... nil nil}. Special-case length 1 so
@@ -425,18 +425,18 @@
                  ;; intermediate cases without writing nil parents or
                  ;; throwing (per audit rf2-q25os).
                  new-db (if (= 1 (count path))
-                          (dissoc cur (first path))
-                          (dissoc-in-safe cur path))]
+                          (dissoc db (first path))
+                          (dissoc-in-safe db path))]
              ;; Per rf2-2vpac: skip `replace-container!` when the dissoc
              ;; branch was a no-op (empty-path, missing key, or
-             ;; `dissoc-in-safe` returning `cur` literally on
+             ;; `dissoc-in-safe` returning `db` literally on
              ;; unmaterialised-parent / non-map-intermediate). Otherwise
              ;; we trigger reactive sub-cache invalidation for a no-op
              ;; write — cheap-but-needless walk of the sub graph
              ;; (`identical?` is O(1); the prior unconditional write
              ;; forced an O(n) sub-graph walk for every clear of an
              ;; absent slot, common during teardown).
-             (when-not (identical? new-db cur)
+             (when-not (identical? new-db db)
                (adapter/replace-container! container new-db))))
          (swap! flows update frame-id dissoc id)
          ;; `last-inputs` is shaped {flow-id {frame-id inputs}} — clear

--- a/implementation/flows/src/re_frame/flows/topo.cljc
+++ b/implementation/flows/src/re_frame/flows/topo.cljc
@@ -33,9 +33,9 @@
   topo-sort invocation (n = flow count, k = inputs per flow); zero-
   alloc matters here even at v1's tiny per-frame node counts."
   [a b]
-  (let [n (count a)]
-    (and (<= n (count b))
-         (= a (subvec b 0 n)))))
+  (let [a-count (count a)]
+    (and (<= a-count (count b))
+         (= a (subvec b 0 a-count)))))
 
 (defn depends-on?
   "Per Spec 013 §Topological sort: B depends on A iff A's :path and any
@@ -146,18 +146,21 @@
         (loop [ready     (filterv #(empty? (graph %)) ids)
                remaining graph
                order     []]
-          (if-let [n (peek ready)]
-            (let [rem0 (dissoc remaining n)
+          (if-let [node-id (peek ready)]
+            ;; Peel `node-id` from the remaining graph: drop its row, then
+            ;; walk every other node, dropping the edge into `node-id` from
+            ;; its dep-set. A dep-set that empties out is newly-ready.
+            (let [remaining-without-node (dissoc remaining node-id)
                   [remaining' ready']
-                  (reduce-kv (fn [[rem rdy] m m-deps]
-                               (if-not (contains? m-deps n)
-                                 [rem rdy]
-                                 (let [m-deps' (disj m-deps n)]
-                                   [(assoc rem m m-deps')
-                                    (cond-> rdy (empty? m-deps') (conj m))])))
-                             [rem0 (pop ready)]
-                             rem0)]
-              (recur ready' remaining' (conj order n)))
+                  (reduce-kv (fn [[acc-remaining acc-ready] dep-id dep-set]
+                               (if-not (contains? dep-set node-id)
+                                 [acc-remaining acc-ready]
+                                 (let [dep-set' (disj dep-set node-id)]
+                                   [(assoc acc-remaining dep-id dep-set')
+                                    (cond-> acc-ready (empty? dep-set') (conj dep-id))])))
+                             [remaining-without-node (pop ready)]
+                             remaining-without-node)]
+              (recur ready' remaining' (conj order node-id)))
             (if (seq remaining)
               ;; Cycle ex-info carries the canonical thrown-error shape
               ;; (per Spec 009 §The thrown-error shape) every other flow


### PR DESCRIPTION
Naming-best-practice audit of the standalone `implementation/flows/` artefact (the publishable `day8/re-frame2-flows` jar). The artefact is in **excellent naming shape** — Spec 013's wire vocabulary (`flow-id`, `:inputs`, `:output`, `:path`, `:schema`, `reg-flow`, `clear-flow`, `last-inputs`, the `:rf.flow/*` op-type namespace, the `:flows/*` late-bind hook prefix) flows through the implementation 1:1.

Three inline let-binding rename clusters applied where short single-letter locals were impeding readability on algorithmic code without serving a documented purpose.

**No public-surface renames.** The surface is consumed by ssr + xray + story and already spec-aligned, so any change would be cost without value. No follow-on beads filed.

## Changes

### `topo.cljc` — Kahn's-loop bindings

`topo-sort`'s inner `reduce-kv` used `n` / `rem0` / `rem` / `rdy` / `m` / `m-deps` / `m-deps'` — terse enough to obscure the algorithm at first read. Renamed to spell out the role each name carries:

- `n` → `node-id` (the node being peeled this iteration)
- `rem0` → `remaining-without-node` (the graph after dropping `node-id`'s row)
- `rem` / `rdy` → `acc-remaining` / `acc-ready` (the reduce-kv accumulator pair)
- `m` / `m-deps` / `m-deps'` → `dep-id` / `dep-set` / `dep-set'` (the iterated node-id and its dep-set, prime for the post-peel value)

Added a 3-line algorithmic comment naming the peel-and-walk step so the next reader sees the shape without having to derive it from the locals.

`prefix?`'s `(let [n (count a)])` → `(let [a-count (count a)])` — `n` was both confusable with the algorithm's 'n flows' variable in the docstring AND non-descriptive.

### `registry.cljc` — `dissoc-in-safe` + `clear-flow` `cur` binding

`dissoc-in-safe`'s parameter `cur` → `db`. The fn operates on a db value (the `read-container` snapshot); the surrounding codebase uses `db` / `new-db` consistently for this role, and the call-site already binds `new-db` on the result. Rename makes the input/output relationship read as `db → new-db` without the abbreviation hop.

`clear-flow`'s `(let [cur (adapter/read-container container)])` → `(let [db (adapter/read-container container)])`. Consistent with the helper rename and with the surrounding `new-db` binding.

## Vocabulary cross-check

All Spec 013 wire vocabulary verified aligned 1:1 (flow-id, `:inputs`, `:output`, `:path`, `:schema`, `reg-flow`, `clear-flow`, `run-flows-on-db`, `last-inputs`, `:rf.flow/*` op-types, `:rf.error/flow-*` error-ids, `:flows/*` late-bind hooks, frame-scoped `{frame-id {flow-id flow-map}}` registry shape). The `last-inputs` shape `{flow-id {frame-id inputs}}` flips the key order vs the spec's pseudocode `last-inputs[[frame-id flow-id]]` — this is a deliberate O(1)-hot-reload-invalidation optimisation, documented in both the source comment and the ns docstring; the vocabulary is unchanged.

## Findings doc

`ai/findings/naming-audit-implementation-flows.md` (gitignored / local-only per the Mayor Method) records every named entity reviewed (3 namespaces, 9 public surface vars, 18 private helpers, 10 test files, the full domain vocabulary table) with KEEP / RENAME-INLINE / DEFERRED verdicts and reasoning. Includes the considered-and-rejected set so a future audit doesn't revisit `flows` / `last-inputs` / `prefix?` / `flow-error` / `validate-flow`.

## Quality gates

- `cd implementation/flows && clojure -M:test` → **117 tests, 489 assertions, 0 failures, 0 errors**
- `clj-kondo --lint src` → **0 errors, 0 warnings**
- `npm run test:cljs` (full CLJS sweep, the canonical fast PR gate) → **4845 tests, 15891 assertions, 0 failures, 0 errors**

Closes rf2-r4mmm.