### PR TITLE
docs(skills/pair): naming-clarity edits (rf2-lrtf7)

### DIFF
--- a/skills/re-frame2-pair/SKILL.md
+++ b/skills/re-frame2-pair/SKILL.md
@@ -198,9 +198,9 @@ Load at most two references for a single task. If you find yourself wanting thre
 
 ## When to also open Xray
 
-A re-frame2-pair session and a running Xray panel are **complementary** surfaces over the same trace bus + epoch history. Pair2 owns the *driving* (dispatch, hot-swap, restore-epoch); Xray owns the *seeing* (the visual reading of what just happened across its Dynamic event-spine tabs and Static registry-browse tabs — `skills/re-frame2-xray/` is the canonical source for Xray facts). Reach for Xray alongside re-frame2-pair when:
+A re-frame2-pair session and a running Xray panel are **complementary** surfaces over the same trace bus + epoch history. re-frame2-pair owns the *driving* (dispatch, hot-swap, restore-epoch); Xray owns the *seeing* (the visual reading of what just happened across its Dynamic event-spine tabs and Static registry-browse tabs — `skills/re-frame2-xray/` is the canonical source for Xray facts). Reach for Xray alongside re-frame2-pair when:
 
-| Pair2 just did | Open Xray to … |
+| re-frame2-pair just did | Open Xray to … |
 |---|---|
 | Rewound to an earlier epoch via `restore-epoch` | Scrub the bottom-rail time-travel scrubber to inspect adjacent epochs visually; pin slices in the App-DB Diff panel. |
 | Dispatched into a cascade you don't fully understand | The Event Detail panel lands on the latest cascade and shows the dispatch-id tree. |

--- a/skills/re-frame2-pair/references/recipes.md
+++ b/skills/re-frame2-pair/references/recipes.md
@@ -247,7 +247,7 @@ When a streaming probe seems to have gone quiet, call `mcp__re-frame2-pair__list
 
 ## "Refine a variant interactively"
 
-**Why this works:** the same loop that powers Story-MCP's self-healing pattern (`skills/re-frame2/references/tooling/story-mcp-loop.md`) is observable from re-frame2-pair — modify the variant body via story-mcp, then watch the trace events as it re-runs. Pair2 sees every dispatch the play-runner makes, and you can intervene mid-loop without leaving the runtime.
+**Why this works:** the same loop that powers Story-MCP's self-healing pattern (`skills/re-frame2/references/tooling/story-mcp-loop.md`) is observable from re-frame2-pair — modify the variant body via story-mcp, then watch the trace events as it re-runs. re-frame2-pair sees every dispatch the play-runner makes, and you can intervene mid-loop without leaving the runtime.
 
 **Setup.** Story-MCP write surface is enabled (`--allow-writes` / `RF_STORY_MCP_ALLOW_WRITES=true`). The variant exists; you want to iterate on its `:play-script` body to make an assertion pass.
 
@@ -281,7 +281,7 @@ When a streaming probe seems to have gone quiet, call `mcp__re-frame2-pair__list
    ```
    mcp__re-frame2-story-mcp__read-failures {variant-id: ":story.counter/loaded"}
    ```
-6. If `:passing? false`, repeat from step 3 with a refined body. Pair2's subscription stays open across iterations — close it with `unsubscribe` when the loop terminates.
+6. If `:passing? false`, repeat from step 3 with a refined body. re-frame2-pair's subscription stays open across iterations — close it with `unsubscribe` when the loop terminates.
 
 **Expected output shape.** Stream of epoch records on the re-frame2-pair channel (one per play event), plus a `:passing?` boolean + `:assertions` list from `read-failures`. Successful loop ends with `:passing? true`.
 

--- a/skills/re-frame2-pair/references/variant-as-frame.md
+++ b/skills/re-frame2-pair/references/variant-as-frame.md
@@ -23,7 +23,7 @@ The `variant-id` keyword (e.g. `:story.counter/loaded`) is BOTH the variant id S
 
 This identity is the single most important thing about the variant-as-frame pattern. Once you've internalised it, the rest is just normal re-frame2-pair ops with a different default-frame.
 
-## Pair2 ops scoped to a variant
+## re-frame2-pair ops scoped to a variant
 
 Every re-frame2-pair op that takes an operating frame works against a variant out of the box. The two recommended idioms:
 
@@ -82,7 +82,7 @@ mcp__re-frame2-pair__eval-cljs {form: "(filter #(= \"story\" (namespace %)) (rf/
 
 For richer metadata (parent story, tags, modes, substrates), use Story's side-table via the MCP transport if available (`mcp__re-frame2-story-mcp__list-stories` / `get-variant`), or fall back to `(re-frame.story/variant->edn <id>)` over `repl/eval`. The variant-id grammar (`:story.<dotted.path>/<variant-name>`) is documented in `skills/re-frame2/references/tooling/stories.md`.
 
-To discover the *active* variant in the user's canvas (the one currently visible), inspect frame metadata for the `:story/active?` flag set by Story's shell — or ask the user. Pair2 has no DOM bridge that locates the canvas iframe specifically; use `dom/source-at` on something inside it.
+To discover the *active* variant in the user's canvas (the one currently visible), inspect frame metadata for the `:story/active?` flag set by Story's shell — or ask the user. re-frame2-pair has no DOM bridge that locates the canvas iframe specifically; use `dom/source-at` on something inside it.
 
 ## Common gotchas — variant-as-frame specific
 

--- a/skills/re-frame2-pair/tests/e2e/README.md
+++ b/skills/re-frame2-pair/tests/e2e/README.md
@@ -1,4 +1,4 @@
-# Pair2 end-to-end tests
+# re-frame2-pair end-to-end tests
 
 Browser-level checks that drive the **live** fixture app
 (`tests/fixture/`) through real shadow-cljs + nREPL + Playwright.
@@ -59,7 +59,7 @@ Exit code 0 = pass; non-zero with structured stderr = fail.
 
 ## Skill output, not visual UI
 
-Pair2's E2E suite asserts on **structured shim output**, not pixel
+re-frame2-pair's E2E suite asserts on **structured shim output**, not pixel
 positions. The browser is along for the ride so the runtime is real;
 the assertions are still edn shape on stdout. This matches the rest of
 re-frame2-pair's test surfaces.

--- a/skills/re-frame2-pair/tests/fixture/README.md
+++ b/skills/re-frame2-pair/tests/fixture/README.md
@@ -2,14 +2,14 @@
 ;;
 ;; A deliberately tiny re-frame2 counter (mirrors examples/reagent/counter)
 ;; with `re-frame2-pair.runtime` wired in as a shadow-cljs `:devtools :preloads`
-;; entry. Pair2's tests/shim, tests/e2e, and tests/prompts surfaces target
+;; entry. re-frame2-pair's tests/shim, tests/e2e, and tests/prompts surfaces target
 ;; this fixture.
 ;;
 ;; The fixture is intentionally trivial — one event, one sub, one view,
 ;; one frame. Validation here proves re-frame2-pair's runtime ↔ Tool-Pair contract
 ;; without taking on examples/ scope.
 
-# Pair2 fixture app
+# re-frame2-pair fixture app
 
 Minimal re-frame2 counter app used by `tests/shim`, `tests/e2e`, and
 `tests/prompts`. Mirrors `examples/reagent/counter/core.cljs`, with

--- a/skills/re-frame2-pair/tests/fixture/deps.edn
+++ b/skills/re-frame2-pair/tests/fixture/deps.edn
@@ -1,4 +1,4 @@
-;; Pair2 fixture classpath.
+;; re-frame2-pair fixture classpath.
 ;;
 ;; Pulls in the local re-frame2 artefacts as :local/root entries so the
 ;; fixture builds against the exact tree-of-truth in this repo (rather

--- a/skills/re-frame2-pair/tests/fixture/public/index.html
+++ b/skills/re-frame2-pair/tests/fixture/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <title>Pair2 fixture — counter</title>
+  <title>re-frame2-pair fixture — counter</title>
   <style>
     body { font-family: system-ui, sans-serif; margin: 2em; }
     #app { display: flex; align-items: center; gap: 1em; }
@@ -10,7 +10,7 @@
   </style>
 </head>
 <body>
-  <h1>Pair2 fixture</h1>
+  <h1>re-frame2-pair fixture</h1>
   <p>
     Minimal re-frame2 counter. <code>re-frame2-pair.runtime</code> is
     preloaded — confirm with

--- a/skills/re-frame2-pair/tests/fixture/shadow-cljs.edn
+++ b/skills/re-frame2-pair/tests/fixture/shadow-cljs.edn
@@ -1,4 +1,4 @@
-;; Pair2 fixture build.
+;; re-frame2-pair fixture build.
 ;;
 ;; A minimal shadow-cljs build that mounts the counter view and preloads
 ;; `re-frame2-pair.runtime`. Used by re-frame2-pair's tests/shim, tests/e2e, and
@@ -9,7 +9,7 @@
 ;;
 ;; 1. The `../../preload` source path — directory carrying the
 ;; `re_frame2_pair/runtime.cljs` namespace that ships in the
-;; `@day8/re-frame2-pair` npm package's `preload/`. Pair2's SKILL.md
+;; `@day8/re-frame2-pair` npm package's `preload/`. re-frame2-pair's SKILL.md
 ;; §Setup tells consumers to put `node_modules/@day8/re-frame2-pair/preload`
 ;; on the build's source paths; here we point straight at the
 ;; in-repo source. With `:deps true` the source-paths live in

--- a/skills/re-frame2-pair/tests/fixture/src/counter/core.cljs
+++ b/skills/re-frame2-pair/tests/fixture/src/counter/core.cljs
@@ -1,5 +1,5 @@
 (ns counter.core
- "Pair2 fixture counter.
+ "re-frame2-pair fixture counter.
 
  Deliberately tiny: one event-db (`:counter/inc`, `:counter/dec`,
  `:counter/initialise`), one sub (`:count`), one reg-view

--- a/skills/re-frame2-pair/tests/shim/stub_nrepl.clj
+++ b/skills/re-frame2-pair/tests/shim/stub_nrepl.clj
@@ -1,6 +1,6 @@
 ;;;; tests/shim/stub_nrepl.clj — bencode nREPL stub for shim integration tests.
 ;;;;
-;;;; Pair2's shell scripts shell out to `bb ops.clj <subcmd>`, which in turn
+;;;; re-frame2-pair's shell scripts shell out to `bb ops.clj <subcmd>`, which in turn
 ;;;; opens a TCP socket to shadow-cljs's nREPL and speaks bencode. We don't
 ;;;; want a live shadow-cljs process in `tests/shim/` — that's `tests/e2e/`'s
 ;;;; job — so this stub is a self-contained babashka program that:


### PR DESCRIPTION
## Summary

Naming-best-practice audit of the `skills/re-frame2-pair/` bundle (bead **rf2-lrtf7**, slice 8 of the 33-bead audit wave).

Surface audited: frontmatter (`name` / `description` / `allowed-tools`) + `SKILL.md` + `README.md` + `STATUS.md` + 10 `references/*.md` leaves + `preload/re_frame2_pair/runtime.cljs` (the CLJS code shipped to the operator's REPL) + `docs/*` + `tests/*` + `.claude-plugin/plugin.json` + `package.json` + `evals/evals.json`.

**Theme: canonical-naming consistency.** Sibling re-frame2-xray naming-clarity PR (#2350, rf2-4pwt6) established that the canonical bundle name should ride everywhere with no shorthand drift. Same posture applied here: 13 occurrences of the informal `Pair2` shorthand normalised to `re-frame2-pair` across 10 files.

### Files touched

| File | Occurrences |
|---|---|
| `skills/re-frame2-pair/SKILL.md` § "When to also open Xray" | 2 |
| `skills/re-frame2-pair/references/variant-as-frame.md` | 2 |
| `skills/re-frame2-pair/references/recipes.md` | 2 |
| `skills/re-frame2-pair/tests/shim/stub_nrepl.clj` | 1 |
| `skills/re-frame2-pair/tests/e2e/README.md` | 2 |
| `skills/re-frame2-pair/tests/fixture/README.md` | 2 |
| `skills/re-frame2-pair/tests/fixture/deps.edn` | 1 |
| `skills/re-frame2-pair/tests/fixture/shadow-cljs.edn` | 2 |
| `skills/re-frame2-pair/tests/fixture/src/counter/core.cljs` | 1 |
| `skills/re-frame2-pair/tests/fixture/public/index.html` | 2 |

No CLJS public-surface name changed (preload fns / MCP tool ids / sub-ids byte-identical). One section heading was renamed (`## Pair2 ops scoped to a variant` -> `## re-frame2-pair ops scoped to a variant` in `variant-as-frame.md`); grepped the corpus for inbound references to the old slug `pair2-ops-scoped-to-a-variant` -- none exist.

### What the audit found in good shape (verdict: KEEP)

- **Frontmatter** is crisp: `name: re-frame2-pair` matches dir + npm + plugin manifest; `description` is operator-facing prose naming the four primary capabilities + the **Do not use** negative case; `allowed-tools` lists 15 `mcp__re-frame2-pair__*` ops + 5 `mcp__re-frame2-story-mcp__*` live-session ops + minimal Read/Edit/Write/Grep/Glob.
- **MCP tool grammar** (`discover-app`, `eval-cljs`, `dispatch`, `dispatch-dry-run`, `trace-window`, `watch-epochs`, `tail-build`, `snapshot`, `get-path`, `subscribe`, `unsubscribe`, `list-subscriptions`, `list-handlers`, `handler-meta`, `get-re-frame2-pair-instructions`) follows the cross-MCP NAMING.md `list-<things>` verb-noun convention.
- **MCP <-> runtime fn naming asymmetry** is deliberately documented in `runtime.cljs` lines 31-52 (`list-subscriptions` (MCP) <-> `subscription-info` (runtime); `list-handlers` (MCP) <-> `registry-list` (runtime)). The split exists because the runtime audience is smaller than the MCP surface and a runtime rename ripples into every eval-form caller.
- **Reference filenames** (`ops.md`, `recipes.md`, `errors.md`, `on-error.md`, `mcp-transport.md`, `streaming-subscriptions.md`, `variant-as-frame.md`, `stories.md`, `vocabulary.md`, `wire-size-budget.md`) -- each kebab-case noun named for one concern, mirroring the xray sibling's leaf shape.
- **Recipe headings** in `recipes.md` are operator-question shaped (`"Why didn't my view update?"`, `"Post-mortem - how did we get here?"`, `"Where in the code does this come from?"`, etc.).
- **Tour-skill shape** -- `## Style guidance` is present (the rf2-4pwt6 convention).
- **CLJS preload** -- ns + fn names follow CLJS conventions (predicates end `?`, side-effects end `!`); let-bindings + parameters use descriptive names throughout; no `x` / `tmp` / `m` / `e` stub-names. Test ns names + `deftest` strings narrate assertions.

## Follow-on observations (cross-bundle / out-of-scope here)

1. **`skills/README.md` pre-rebrand label drift** -- lines 72-73 still describe Dynamic tabs as `"(Event / App DB / View / Trace / Machines / Routing / Issues)"`. The all-plural-domain-noun convention (rf2-4pwt6 PR #2350) is `(Event / app-db / Views / Trace / Machines / Routes / Issues)`. Sits in the shared skill-routing single-source doc; the naming-audit slice belongs to sibling worker `naming-skills-rf2-0ed1y`. Cross-ref recorded in findings; no action here.
2. **`:rf2-pair/*` vs `:re-frame2-pair/*` reserved-namespace abbreviation mismatch** -- the `dispatch-dry-run` recorder fx is registered under `:rf2-pair/dry-run-recorder`, which abbreviates differently from the dominant `:re-frame2-pair/*` (skill listener id) family. Touches `spec/Conventions.md` reserved-ns allocation; deferring until an operator-friction signal appears.

Findings doc: `ai/findings/naming-audit-skills-re-frame2-pair.md` (local-only, gitignored).

## Quality gates

| Gate | Result |
|---|---|
| `python -m mkdocs build --strict` (from worktree root) | passes (`Documentation built in 7.93 seconds`; only the pre-existing informational `INFO` line on `the-mayor-method.md` relative link, unchanged by this PR) |
| `python scripts/check_doc_slugs.py --verbose` | passes (no broken links, exit 0) |
| `python scripts/check_readme_links.py --ci` | passes (exit 0) |
| `bb tests/runtime/preload_sentinel_test.clj` | `Ran 3 tests containing 3 assertions. 0 failures, 0 errors.` |
| `bb tests/prompts/prompt_regression_test.clj` | `Ran 8 tests containing 28 assertions. 0 failures, 0 errors.` |
| `bb tests/runtime/parse_rf2_coord_test.clj` | `Ran 12 tests containing 21 assertions. 0 failures, 0 errors.` |
| `bb tests/runtime/snapshot_test.clj` | `Ran 9 tests containing 17 assertions. 0 failures, 0 errors.` |

## Closes

- rf2-lrtf7