### PR TITLE
refactor(epoch): inline naming-clarity renames (rf2-v89dx)

### DIFF
--- a/implementation/epoch/src/re_frame/epoch/capture.cljc
+++ b/implementation/epoch/src/re_frame/epoch/capture.cljc
@@ -173,9 +173,9 @@
       ;; uses the read-set to tell a view's genuine re-render from a
       ;; mount-burst tail. Fires regardless of the routing branch below.
       (when frame-id
-        (when-let [reader-rk (:rf.sub/reader-render-key tags)]
+        (when-let [reader-render-key (:rf.sub/reader-render-key tags)]
           (when (= :rf.sub/run op)
-            (state/record-render-deps! frame-id reader-rk (:rf.sub/id tags)))))
+            (state/record-render-deps! frame-id reader-render-key (:rf.sub/id tags)))))
       (when (and frame-id (not (contains? skip-ops op)))
         (cond
           ;; Post-settle render — attribute to the causing cascade.
@@ -365,15 +365,15 @@
   `:rf/redacted` sentinel — they ride elide-wire-value at the emit site."
   [event]
   (when (= :rf.sub/run (:operation event))
-    (let [t (:tags event)]
-      {:sub-id         (:rf.sub/id t)
-       :query-v        (:rf.sub/query-v t)
+    (let [tags (:tags event)]
+      {:sub-id         (:rf.sub/id tags)
+       :query-v        (:rf.sub/query-v tags)
        :recomputed?    true
-       :value-changed? (:rf.sub/value-changed? t)
-       :prev-value     (:rf.sub/prev-value t)
-       :value          (:rf.sub/value t)
-       :cascade?       (:rf.sub/cascade? t)
-       :cause-sub      (:rf.sub/cause-sub t)})))
+       :value-changed? (:rf.sub/value-changed? tags)
+       :prev-value     (:rf.sub/prev-value tags)
+       :value          (:rf.sub/value tags)
+       :cascade?       (:rf.sub/cascade? tags)
+       :cause-sub      (:rf.sub/cause-sub tags)})))
 
 (defn render-row
   "Project a `:rf.view/rendered` trace event into its structured
@@ -408,15 +408,15 @@
   re-renders, matching the open-map schema."
   [event]
   (when (= :rf.view/rendered (:operation event))
-    (let [t (:tags event)]
-      (cond-> {:render-key (or (:rf.view/render-key t)
+    (let [tags (:tags event)]
+      (cond-> {:render-key (or (:rf.view/render-key tags)
                                [:rf.view/anonymous nil])}
-        (contains? t :rf.view/mount?)
-        (assoc :mount? (:rf.view/mount? t))
-        (some? (:rf.view/triggered-by t))
-        (assoc :triggered-by (:rf.view/triggered-by t))
-        (some? (:rf.view/elapsed-ms t))
-        (assoc :elapsed-ms (:rf.view/elapsed-ms t))))))
+        (contains? tags :rf.view/mount?)
+        (assoc :mount? (:rf.view/mount? tags))
+        (some? (:rf.view/triggered-by tags))
+        (assoc :triggered-by (:rf.view/triggered-by tags))
+        (some? (:rf.view/elapsed-ms tags))
+        (assoc :elapsed-ms (:rf.view/elapsed-ms tags))))))
 
 (defn project-all
   "Walk the captured trace events ONCE and emit the three `:sub-runs`,
@@ -467,8 +467,8 @@
   ;; `:renders` / `:effects` shape is materialised once at the end.
   (let [acc (reduce
               (fn [acc ev]
-                (let [op (:operation ev)
-                      t  (:tags ev)]
+                (let [op   (:operation ev)
+                      tags (:tags ev)]
                   (cond
                     ;; Per rf2-l1jz8 — the reactive recompute path enriches
                     ;; the `:sub/run` tag with value-change + cascade
@@ -487,30 +487,30 @@
                     (= :rf.fx/handled op)
                     (assoc! acc :e
                             (conj! (get acc :e)
-                                   {:fx-id   (:rf.fx/id t)
-                                    :args    (:rf.fx/args t)
+                                   {:fx-id   (:rf.fx/id tags)
+                                    :args    (:rf.fx/args tags)
                                     :outcome :ok}))
 
                     (= :rf.fx/skipped-on-platform op)
                     (assoc! acc :e
                             (conj! (get acc :e)
-                                   {:fx-id   (:rf.fx/id t)
-                                    :args    (:rf.fx/args t)
+                                   {:fx-id   (:rf.fx/id tags)
+                                    :args    (:rf.fx/args tags)
                                     :outcome :skipped-on-platform}))
 
                     (= :rf.error/fx-handler-exception op)
                     (assoc! acc :e
                             (conj! (get acc :e)
-                                   {:fx-id       (:rf.fx/id t)
-                                    :args        (:rf.fx/args t)
+                                   {:fx-id       (:rf.fx/id tags)
+                                    :args        (:rf.fx/args tags)
                                     :outcome     :error
                                     :error-trace (:id ev)}))
 
                     (= :rf.error/no-such-fx op)
                     (assoc! acc :e
                             (conj! (get acc :e)
-                                   {:fx-id       (:rf.fx/id t)
-                                    :args        (:rf.fx/args t)
+                                   {:fx-id       (:rf.fx/id tags)
+                                    :args        (:rf.fx/args tags)
                                     :outcome     :error
                                     :error-trace (:id ev)}))
 

--- a/implementation/epoch/src/re_frame/epoch/state.cljc
+++ b/implementation/epoch/src/re_frame/epoch/state.cljc
@@ -405,7 +405,7 @@
   nil)
 
 (defn- epoch-value-changed-for-view?
-  "True when epoch record `r` carries a value-changed `:sub/run` belonging
+  "True when epoch `record` carries a value-changed `:sub/run` belonging
   to the view named by `render-key` — i.e. a `:sub/run` with
   `:value-changed? true` whose `:reader-render-key` is `render-key`
   (the synchronous in-render deref, when stamped) OR whose `:sub-id` is
@@ -413,14 +413,14 @@
   recompute, which carries no render-key). `deps` may be nil when the
   view's read-set was never learned — then only the render-key match
   applies."
-  [r render-key deps]
+  [record render-key deps]
   (some (fn [ev]
           (and (= :rf.sub/run (:operation ev))
                (true? (-> ev :tags :rf.sub/value-changed?))
-               (let [t (:tags ev)]
-                 (or (= render-key (:rf.sub/reader-render-key t))
-                     (and deps (contains? deps (:rf.sub/id t)))))))
-        (:trace-events r)))
+               (let [tags (:tags ev)]
+                 (or (= render-key (:rf.sub/reader-render-key tags))
+                     (and deps (contains? deps (:rf.sub/id tags)))))))
+        (:trace-events record)))
 
 (defn- value-changed-epoch-for
   "Scan `frame-id`'s ring (most-recent first) for the newest epoch in
@@ -445,9 +445,9 @@
         deps    (render-deps-for frame-id render-key)]
     (loop [i (dec (count history))]
       (when (>= i 0)
-        (let [r (nth history i)]
-          (if (epoch-value-changed-for-view? r render-key deps)
-            (:epoch-id r)
+        (let [record (nth history i)]
+          (if (epoch-value-changed-for-view? record render-key deps)
+            (:epoch-id record)
             (recur (dec i))))))))
 
 (defn resolve-render-epoch
@@ -538,14 +538,14 @@
                    idx     (epoch-index history epoch-id)]
                (if (nil? idx)
                  history
-                 (let [r  (nth history idx)
-                       r' (cond-> r
-                            (contains? r :trace-events)
-                            (update :trace-events (fnil conj []) event)
-                            (some? row)
-                            (update slot (fnil conj []) row))]
-                   (reset! updated r')
-                   (assoc history idx r'))))))
+                 (let [record   (nth history idx)
+                       record+  (cond-> record
+                                  (contains? record :trace-events)
+                                  (update :trace-events (fnil conj []) event)
+                                  (some? row)
+                                  (update slot (fnil conj []) row))]
+                   (reset! updated record+)
+                   (assoc history idx record+))))))
     @updated))
 
 (defn back-fill-render!
@@ -598,9 +598,9 @@
 (defn harvest-buffer!
   "Atomically read-and-clear the frame's in-flight buffer."
   [frame-id]
-  (let [b (get @capture-buffers frame-id [])]
+  (let [buffer (get @capture-buffers frame-id [])]
     (swap! capture-buffers dissoc frame-id)
-    b))
+    buffer))
 
 (defn- settling-dispatch-id
   "The `:dispatch-id` of the event being settled, read off the FIRST
@@ -638,39 +638,37 @@
   settling id to scope by, and `settle!`'s empty-buffer / no-trigger
   policy handles the degenerate record."
   [frame-id]
-  (let [b (get @capture-buffers frame-id [])]
-    (if-let [sid (settling-dispatch-id b)]
+  (let [buffer (get @capture-buffers frame-id [])]
+    (if-let [settling-id (settling-dispatch-id buffer)]
       ;; Three-way partition by the event's :rf.trace/dispatch-id:
-      ;;   * MINE   (= did sid)        — the settling event's own traces;
-      ;;                                  returned to ride this epoch.
-      ;;   * THEIRS (non-nil, ≠ sid)   — a child's `:event/dispatched`
-      ;;                                  marker fired during THIS event's
-      ;;                                  do-fx carrying the CHILD's id;
-      ;;                                  LEFT in the buffer for the child's
-      ;;                                  own settle (Spec 009 §Dispatch
-      ;;                                  correlation: one dispatch-id = one
-      ;;                                  epoch).
-      ;;   * ORPHAN (nil did)          — an out-of-cascade emit (e.g.
-      ;;                                  `:frame/created`) with no cascade
-      ;;                                  to ride. DISCARDED here.
+      ;;   * MINE   (= event-dispatch-id settling-id)
+      ;;       — the settling event's own traces; returned to ride this epoch.
+      ;;   * THEIRS (non-nil, ≠ settling-id)
+      ;;       — a child's `:event/dispatched` marker fired during THIS event's
+      ;;         do-fx carrying the CHILD's id; LEFT in the buffer for the
+      ;;         child's own settle (Spec 009 §Dispatch correlation: one
+      ;;         dispatch-id = one epoch).
+      ;;   * ORPHAN (nil event-dispatch-id)
+      ;;       — an out-of-cascade emit (e.g. `:frame/created`) with no
+      ;;         cascade to ride. DISCARDED here.
       ;;
       ;; Per rf2-avvwm orphans are dropped at the capture seam
       ;; (capture/capture-event! out-of-cascade branch) so in normal
       ;; operation none arrive. This seam is the defensive backstop: a
-      ;; nil-did orphan that slips past the upstream guard has no settle
-      ;; event to ever reclaim it, so retaining it (the pre-rf2-ee38b
+      ;; nil-dispatch-id orphan that slips past the upstream guard has no
+      ;; settle event to ever reclaim it, so retaining it (the pre-rf2-ee38b
       ;; behaviour) left it in the buffer indefinitely — re-grouped into
       ;; `theirs` and re-retained on every subsequent harvest. Discarding
       ;; it makes the harvest self-cleaning and removes reliance on the
       ;; upstream guard being perfect (rf2-ee38b §correctness). The
-      ;; `did = sid` predicate already guarantees an orphan never folds
-      ;; into an epoch's `:trace-events`; this only changes whether it
-      ;; lingers in the buffer (no) vs. is dropped (yes).
-      (let [mine   (filterv (fn [ev] (= (-> ev :tags :rf.trace/dispatch-id) sid)) b)
+      ;; `event-dispatch-id = settling-id` predicate already guarantees an
+      ;; orphan never folds into an epoch's `:trace-events`; this only changes
+      ;; whether it lingers in the buffer (no) vs. is dropped (yes).
+      (let [mine   (filterv (fn [ev] (= (-> ev :tags :rf.trace/dispatch-id) settling-id)) buffer)
             theirs (filterv (fn [ev]
-                              (let [did (-> ev :tags :rf.trace/dispatch-id)]
-                                (and (some? did) (not= did sid))))
-                            b)]
+                              (let [event-dispatch-id (-> ev :tags :rf.trace/dispatch-id)]
+                                (and (some? event-dispatch-id) (not= event-dispatch-id settling-id))))
+                            buffer)]
         ;; Leave the other-event traces (non-nil, non-matching id) in the
         ;; buffer for their own event's settle; drop orphans + ours.
         (if (seq theirs)
@@ -679,7 +677,7 @@
         mine)
       ;; No run-start — rejected/aborted dispatch. Clear and return all.
       (do (swap! capture-buffers dissoc frame-id)
-          b))))
+          buffer))))
 
 (defn drop-frame-buffer!
   "Drop the frame's in-flight capture buffer."


### PR DESCRIPTION
Per the rf2-v89dx naming-best-practice audit of `implementation/epoch`.

Cosmetic, scope-local let-binding clarity. **No public-surface change.**

## Audit verdict

The epoch artefact is mature and tightly aligned with the spec vocabulary (`spec/Spec-Schemas.md §:rf/epoch-record`, `spec/Tool-Pair.md §Time-travel`). Most named entities — namespaces, public fns, trace ops, test names — pass the audit unchanged. The full findings doc is in the worktree at `ai/findings/naming-audit-implementation-epoch.md` (local-only, gitignored per the-mayor-method).

## Inline renames in this PR

### `capture.cljc`

- `capture-event!` — `reader-rk` → `reader-render-key` (matches the tag literal it reads from + the rest of the file's `render-key` vocab)
- `sub-run-row` — `t` → `tags`
- `render-row` — `t` → `tags`
- `project-all` — `t` → `tags` (inner reducer)

### `state.cljc`

- `epoch-value-changed-for-view?` (private) — `r` → `record`, `t` → `tags`
- `value-changed-epoch-for` (private) — `r` → `record`
- `back-fill-event!` (private) — `r` → `record`, `r'` → `record+`
- `harvest-buffer!` — `b` → `buffer`
- `harvest-buffer-for-event!` — `b` → `buffer`, `sid` → `settling-id`, `did` → `event-dispatch-id`. The accompanying inline comment block ("MINE / THEIRS / ORPHAN" three-way partition narrative) is re-spelled to match the new bindings; the docstring narrative is preserved verbatim.

## Public surface

The public surface (`re-frame.epoch/*` + late-bind hooks under `:epoch/*` + the `:rf.epoch/*` and `:rf.epoch.cb/*` trace-op families) is consumed cross-artefact by `tools/xray`, `tools/story`, `tools/mcp-base`, `skills/re-frame2-pair`, `implementation/core` (late-bind directory + trace.cascade + tests), `implementation/machines` (docstring references), and `implementation/ssr` (tests). The audit finds the surface well-named and spec-aligned. **No public-surface renames are recommended; no follow-on beads filed.**

## Quality gates

- `cd implementation/epoch && clojure -M:test` — **PASS** 214 tests, 804 assertions, 0 failures, 0 errors
- `clj-kondo --lint implementation/epoch/{src,test}` — **PASS** 0 errors, 2 pre-existing warnings (`epoch_concurrency_stress_test.clj`'s unused `TimeUnit` import + `epoch_redact_fn_projection_test.clj`'s unused `re-frame.elision` require — both predate this bead)
- `cd implementation && npm run test:cljs` — **PASS** 4845 tests, 15891 assertions, 0 failures, 0 errors

Closes rf2-v89dx.