### PR TITLE
refactor(xray): inline naming-clarity renames (rf2-f9xao)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/frame_switcher.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/frame_switcher.cljs
@@ -82,7 +82,6 @@
             [re-frame.frame :as frame]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.theme.tokens
-             :as t
              :refer [tokens type-scale sans-stack]]))
 
 ;; ---- public contract: which frames Xray filters out by default ---------

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_canvas.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_canvas.cljs
@@ -65,7 +65,6 @@
             ;; `:panel-id`.
             [day8.re-frame2-xray.views.edn-inspector :as ei]
             [day8.re-frame2-xray.theme.tokens
-             :as t
              :refer [tokens sans-stack mono-stack]]))
 
 ;; ---- app-db slots -------------------------------------------------------

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
@@ -61,7 +61,6 @@
             [day8.re-frame2-xray.views.diff-mode-toggle :as diff-mode]
             [day8.re-frame2-xray.views.edn-inspector :as ei]
             [day8.re-frame2-xray.theme.tokens
-             :as t
              :refer [tokens mono-stack sans-stack display-stack spacing]]))
 
 ;; ---- shared layout constants (rf2-3d987) ------------------------------

--- a/tools/xray/src/day8/re_frame2_xray/panels/machines/topology_view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machines/topology_view.cljs
@@ -61,7 +61,7 @@
   (:require [day8.re-frame2-xray.panels.machine-canvas :as machine-canvas]
             [day8.re-frame2-xray.panels.machines.topology :as topology]
             [day8.re-frame2-xray.panels.machines.trace-state :as trace-state]
-            [day8.re-frame2-xray.theme.tokens :as t :refer [tokens]]))
+            [day8.re-frame2-xray.theme.tokens :refer [tokens]]))
 
 (defn- resolve-current-state-path
   "Per-spec precedence (high → low): explicit > focused-epoch traces >

--- a/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_view.cljs
@@ -70,8 +70,8 @@
   (:require [clojure.string :as string]
             [re-frame.core :as rf]
             [day8.re-frame2-xray.panels.reactive-flow-graph :as graph]
-            [day8.re-frame2-xray.theme.tokens :as tk
-             :refer [tokens mono-stack sans-stack]]
+            [day8.re-frame2-xray.theme.tokens
+             :refer [tokens mono-stack sans-stack with-alpha]]
             ;; rf2-e46qs phase 3 — per-sub value inspector renders
             ;; through the first-class edn-inspector widget (spec/021
             ;; §10) directly. Each sub-value mount gets its own stable
@@ -244,7 +244,7 @@
           click (assoc :on-click click
                        :style {:cursor "pointer"}))
      [:rect (cond-> {:x x :y y :width w :height h :rx 4}
-              changed?       (assoc :fill (tk/with-alpha :accent 12)
+              changed?       (assoc :fill (with-alpha :accent 12)
                                     :stroke (:accent tokens) :stroke-width 2)
               (not changed?) (assoc :fill "transparent"
                                     :stroke (:dim tokens) :stroke-width 1
@@ -284,7 +284,7 @@
          :on-click       (when coord (fn [e] (open-source! coord e)))
          :style {:cursor (if coord "pointer" "default")}}
      [:rect {:x x :y y :width w :height h :rx 4
-             :fill (tk/with-alpha :success 12)
+             :fill (with-alpha :success 12)
              :stroke (:success tokens) :stroke-width 2}]
      ;; view name
      [:text {:x (+ x (/ w 2)) :y (+ y 16)
@@ -317,7 +317,7 @@
              ;; was near-invisible against the card's `:bg-1` fill on the
              ;; dark theme; a `:dim`-tinted edge gives the SVG canvas a
              ;; clearly-bounded card the operator can read at a glance.
-             :style {:border (str "1px solid " (tk/with-alpha :dim 45))
+             :style {:border (str "1px solid " (with-alpha :dim 45))
                      :border-radius "8px"
                      :padding "16px"
                      :background (:bg-1 tokens)
@@ -396,7 +396,7 @@
   [:div {:data-testid testid
          :style list-row-style}
    [:span {:style (assoc list-row-swatch-style-base
-                         :background (tk/with-alpha swatch-token 20))}]
+                         :background (with-alpha swatch-token 20))}]
    [:span {:style list-row-primary-style} primary]
    [:span {:style list-row-tag-style}
     tag]])
@@ -630,7 +630,7 @@
     (swatch {:background (:accent tokens)} "changed (propagates downstream)")
     (swatch {:background "transparent" :border (str "1px dashed " (:dim tokens))}
             "no change (short-circuits)")
-    (swatch {:background (tk/with-alpha :error 20)} "unmounted / destroyed")]])
+    (swatch {:background (with-alpha :error 20)} "unmounted / destroyed")]])
 
 ;; ---- empty state ------------------------------------------------------
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/trace.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/trace.cljs
@@ -83,7 +83,8 @@
             [re-frame.core :as rf]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
             [day8.re-frame2-xray.panels.app-db-diff-format :as f]
-            [day8.re-frame2-xray.panels.cancellation-cascade-helpers :as cch]
+            [day8.re-frame2-xray.panels.cancellation-cascade-helpers
+             :as cancellation-cascade-helpers]
             [day8.re-frame2-xray.panels.event.event-status-colour :as event-status]
             [day8.re-frame2-xray.panels.shared.focus-resolver :as focus]
             [day8.re-frame2-xray.panels.trace-helpers :as h]
@@ -586,7 +587,7 @@
         severity?   (#{:error :warning} area)
         sev-colour  (when severity?
                       (get tokens (if (= area :error) :red :yellow)))
-        destroy?    (cch/destroy-event? {:operation operation})]
+        destroy?    (cancellation-cascade-helpers/destroy-event? {:operation operation})]
     {:key                   (h/row-key row)
      :data-testid           row-test-id
      :data-rf-xray-expanded (boolean expanded?)
@@ -633,7 +634,7 @@
         severity?   (#{:error :warning} area)
         sev-colour  (when severity?
                       (get tokens (if (= area :error) :red :yellow)))
-        destroy?    (cch/destroy-event? {:operation operation})]
+        destroy?    (cancellation-cascade-helpers/destroy-event? {:operation operation})]
     [;; ① Δt — ms offset from EPOCH OPEN; `!` lead for severity rows.
      [:span {:data-rf-xray-resizable-col "time"
              :data-testid (str row-test-id "-time")

--- a/tools/xray/src/day8/re_frame2_xray/resize_handle.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/resize_handle.cljs
@@ -113,7 +113,7 @@
   globally so the user reads the operation as continuous."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-xray.config :as config]
-            [day8.re-frame2-xray.theme.tokens :as t :refer [tokens]]))
+            [day8.re-frame2-xray.theme.tokens :refer [with-alpha]]))
 
 ;; ---- keyboard step constants -------------------------------------------
 
@@ -376,7 +376,7 @@
    ;; variable (rf2-on4cm) — light/dark both land on the live accent at
    ;; 33% alpha.
    :box-shadow       (str "inset 1px 0 0 0 "
-                          (t/with-alpha :accent 33))
+                          (with-alpha :accent 33))
    ;; Above the chrome's panels but below the modals; modals use
    ;; max-int z-index so we won't fight them.
    :z-index          1000
@@ -638,7 +638,7 @@
    ;; either theme. 33% alpha of the single `:accent` (GitHub blue) —
    ;; same intensity as the panel-width handle's hairline so the two
    ;; affordances read as one family.
-   :box-shadow      (str "inset 0 4px 0 -3px " (t/with-alpha :accent 33))
+   :box-shadow      (str "inset 0 4px 0 -3px " (with-alpha :accent 33))
    ;; Disable native gestures during drag (text-select on mouse,
    ;; page-pan on touch).
    :touch-action    "none"

--- a/tools/xray/src/day8/re_frame2_xray/shell.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/shell.cljs
@@ -138,8 +138,8 @@
             [day8.re-frame2-xray.static.shell :as static-shell]
             [day8.re-frame2-xray.theme.global-styles :as global-styles]
             [day8.re-frame2-xray.theme.tokens
-             :as t
-             :refer [tokens type-scale layout sans-stack mono-stack]]))
+             :refer [tokens type-scale layout sans-stack mono-stack
+                     duration-css motion]]))
 
 ;; ---- tab inventory ------------------------------------------------------
 ;;
@@ -2116,7 +2116,7 @@
                     ;; `forwards` pins the end state (opacity 1) so
                     ;; the panel stays visible after the fade settles.
                     :animation  (str "rf-xray-fade-in "
-                                     (t/duration-css (:fade-duration-ms t/motion))
+                                     (duration-css (:fade-duration-ms motion))
                                      " ease-out forwards")}}
       ;; rf2-2moh1 — registry-driven panel mount. Each tab's per-panel
       ;; `install!` declares `:panel <view-fn>` via

--- a/tools/xray/src/day8/re_frame2_xray/static/flows/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/flows/panel.cljs
@@ -49,7 +49,6 @@
             [re-frame.core :as rf]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
             [day8.re-frame2-xray.theme.tokens
-             :as t
              :refer [tokens type-scale mono-stack sans-stack]]
             [day8.re-frame2-xray.views.edn-widget.widget :as edn]))
 

--- a/tools/xray/src/day8/re_frame2_xray/static/interceptors/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/interceptors/panel.cljs
@@ -40,7 +40,6 @@
             [re-frame.core :as rf]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
             [day8.re-frame2-xray.theme.tokens
-             :as t
              :refer [tokens type-scale mono-stack sans-stack]]))
 
 ;; ---- pure helpers --------------------------------------------------------

--- a/tools/xray/src/day8/re_frame2_xray/static/machines/browse_list.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/browse_list.cljs
@@ -26,7 +26,6 @@
             [day8.re-frame2-xray.static.machines.helpers :as h]
             [day8.re-frame2-xray.static.machines.instances-jump :as jump]
             [day8.re-frame2-xray.theme.tokens
-             :as t
              :refer [tokens sans-stack mono-stack type-scale]]))
 
 ;; ---- search box ---------------------------------------------------------

--- a/tools/xray/src/day8/re_frame2_xray/static/machines/cascade_dimmed.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/cascade_dimmed.cljs
@@ -8,7 +8,6 @@
   Dynamic sub-strip (same DOM, same letter mnemonic), but it's GREYED
   and the click is a no-op. A tooltip surfaces the why."
   (:require [day8.re-frame2-xray.theme.tokens
-             :as t
              :refer [tokens sans-stack type-scale]]))
 
 (def tooltip-text

--- a/tools/xray/src/day8/re_frame2_xray/static/machines/definition_detail.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/definition_detail.cljs
@@ -44,8 +44,8 @@
             [day8.re-frame2-xray.static.machines.sim :as sim]
             [day8.re-frame2-xray.static.machines.topology :as topology]
             [day8.re-frame2-xray.theme.tokens
-             :as t
-             :refer [tokens sans-stack mono-stack display-stack type-scale]]))
+             :refer [tokens sans-stack mono-stack display-stack type-scale
+                     accent-stripe-style]]))
 
 ;; ---- header -------------------------------------------------------------
 
@@ -74,7 +74,7 @@
                          :font-weight 600
                          :letter-spacing "-0.01em"
                          :color (:text-primary tokens)}
-                        (try (t/accent-stripe-style :machines) (catch :default _ {})))}
+                        (try (accent-stripe-style :machines) (catch :default _ {})))}
     [:span {:style {:font-family mono-stack
                     :color (:accent tokens)}}
      (str machine-id)]]

--- a/tools/xray/src/day8/re_frame2_xray/static/machines/instances_jump.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/instances_jump.cljs
@@ -25,7 +25,6 @@
   cljs/select-machine-id`)."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-xray.theme.tokens
-             :as t
              :refer [tokens sans-stack type-scale]]))
 
 (defn dispatch-jump!

--- a/tools/xray/src/day8/re_frame2_xray/static/machines/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/panel.cljs
@@ -65,7 +65,6 @@
             [day8.re-frame2-xray.static.machines.persistence :as persistence]
             [day8.re-frame2-xray.static.machines.sim :as sim]
             [day8.re-frame2-xray.theme.tokens
-             :as t
              :refer [tokens sans-stack type-scale]]))
 
 ;; ---- panel layout -------------------------------------------------------

--- a/tools/xray/src/day8/re_frame2_xray/static/machines/sim.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/sim.cljs
@@ -76,7 +76,6 @@
             [day8.re-frame2-xray.panels.machine-canvas :as machine-canvas]
             [day8.re-frame2-xray.static.machines.sim-helpers :as sim-h]
             [day8.re-frame2-xray.theme.tokens
-             :as t
              :refer [tokens mono-stack sans-stack type-scale]]))
 
 ;; ---- runtime hook -------------------------------------------------------

--- a/tools/xray/src/day8/re_frame2_xray/static/machines/topology.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/topology.cljs
@@ -57,7 +57,6 @@
             [day8.re-frame2-xray.panels.machine-canvas :as machine-canvas]
             [day8.re-frame2-xray.static.machines.helpers :as h]
             [day8.re-frame2-xray.theme.tokens
-             :as t
              :refer [tokens sans-stack mono-stack type-scale]]))
 
 ;; ---- empty surfaces -----------------------------------------------------

--- a/tools/xray/src/day8/re_frame2_xray/static/mode_pill.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/mode_pill.cljs
@@ -49,7 +49,6 @@
   site threads the active mode as a prop."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-xray.theme.tokens
-             :as t
              :refer [tokens type-scale sans-stack]]))
 
 ;; ---- options ------------------------------------------------------------

--- a/tools/xray/src/day8/re_frame2_xray/static/routes/browse_list.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/routes/browse_list.cljs
@@ -25,7 +25,6 @@
   (:require [re-frame.core :as rf]
             [day8.re-frame2-xray.static.routes.row-expand :as row-expand]
             [day8.re-frame2-xray.theme.tokens
-             :as t
              :refer [tokens mono-stack sans-stack]]))
 
 (defn- meta-badge

--- a/tools/xray/src/day8/re_frame2_xray/static/routes/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/routes/panel.cljs
@@ -63,7 +63,6 @@
             [day8.re-frame2-xray.static.routes.browse-list :as browse-list]
             [day8.re-frame2-xray.static.routes.simulate-url :as simulate-url]
             [day8.re-frame2-xray.theme.tokens
-             :as t
              :refer [tokens type-scale sans-stack]]))
 
 ;; ---- header --------------------------------------------------------------

--- a/tools/xray/src/day8/re_frame2_xray/static/routes/row_expand.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/routes/row_expand.cljs
@@ -32,7 +32,6 @@
   (:require [re-frame.core :as rf]
             [day8.re-frame2-xray.static.routes.simulate-nav :as sim-nav]
             [day8.re-frame2-xray.theme.tokens
-             :as t
              :refer [tokens mono-stack sans-stack]]
             [day8.re-frame2-xray.views.edn-widget.widget :as edn]))
 

--- a/tools/xray/src/day8/re_frame2_xray/static/routes/simulate_nav.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/routes/simulate_nav.cljs
@@ -26,7 +26,6 @@
   layer only."
   (:require [day8.re-frame2-xray.panels.routing-helpers :as h]
             [day8.re-frame2-xray.theme.tokens
-             :as t
              :refer [tokens mono-stack sans-stack]]))
 
 (defn- field-row

--- a/tools/xray/src/day8/re_frame2_xray/static/routes/simulate_url.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/routes/simulate_url.cljs
@@ -29,7 +29,6 @@
   `[rf/frame-provider {:frame :rf/xray}]` in `static/shell.cljs`."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-xray.theme.tokens
-             :as t
              :refer [tokens mono-stack sans-stack]]))
 
 (defn- rank-cell

--- a/tools/xray/src/day8/re_frame2_xray/static/schemas/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/schemas/panel.cljs
@@ -58,7 +58,6 @@
             [day8.re-frame2-xray.open-in-editor :as open-in-editor]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
             [day8.re-frame2-xray.theme.tokens
-             :as t
              :refer [tokens type-scale mono-stack sans-stack]]
             [day8.re-frame2-xray.views.edn-widget.widget :as edn]))
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/event/event_status_colour_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/event/event_status_colour_cljs_test.cljc
@@ -24,7 +24,7 @@
       input map consumed by the classifier."
   (:require #?(:clj  [clojure.test :refer [deftest is testing]]
                :cljs [cljs.test    :refer-macros [deftest is testing]])
-            [day8.re-frame2-xray.panels.event.event-status-colour :as esc]
+            [day8.re-frame2-xray.panels.event.event-status-colour :as event-status]
             [day8.re-frame2-xray.theme.tokens :as tokens]))
 
 ;; ---- vocabulary ---------------------------------------------------------
@@ -35,13 +35,13 @@
             deterministically."
     (is (= [:in-flight :settled-success :settled-error
             :paused-by-tool :stale]
-           esc/statuses))))
+           event-status/statuses))))
 
 (deftest status-token-map-covers-every-status
   (testing "rf2-b76v4 — every status has a token keyword. No
             unmapped status leaks a nil into the palette."
-    (is (= (set esc/statuses)
-           (set (keys esc/status->token))))))
+    (is (= (set event-status/statuses)
+           (set (keys event-status/status->token))))))
 
 (deftest status-token-map-mirrors-tanstack-anchors
   (testing "rf2-b76v4 / rf2-ad7zx.13 — the per-status token assignments
@@ -49,11 +49,11 @@
             head (`:in-flight`) IS the current-epoch accent → the single
             `:accent` (GitHub blue); `:paused-by-tool` takes the fixed
             cool blue `:info` as a distinct peer."
-    (is (= :accent         (esc/status->token :in-flight)))
-    (is (= :green          (esc/status->token :settled-success)))
-    (is (= :red            (esc/status->token :settled-error)))
-    (is (= :info           (esc/status->token :paused-by-tool)))
-    (is (= :yellow         (esc/status->token :stale)))))
+    (is (= :accent         (event-status/status->token :in-flight)))
+    (is (= :green          (event-status/status->token :settled-success)))
+    (is (= :red            (event-status/status->token :settled-error)))
+    (is (= :info           (event-status/status->token :paused-by-tool)))
+    (is (= :yellow         (event-status/status->token :stale)))))
 
 (deftest every-status-resolves-to-a-non-nil-hex
   (testing "the indirection chain (status → token-kw → hex) lands on
@@ -61,8 +61,8 @@
             missing key in `theme/tokens`. Drives off `dark-palette`
             directly (the hex source of truth) — `tokens` exposes
             CSS-variable strings post rf2-on4cm."
-    (doseq [status esc/statuses]
-      (let [token-kw (esc/status->token status)
+    (doseq [status event-status/statuses]
+      (let [token-kw (event-status/status->token status)
             hex      (get tokens/dark-palette token-kw)]
         (is (string? hex) (str status " → " token-kw " resolves to a hex"))
         (is (re-find #"^#[0-9A-Fa-f]+$" hex)
@@ -73,68 +73,68 @@
 (deftest classify-status-settled-success
   (testing ":ok outcome with no other signals → :settled-success."
     (is (= :settled-success
-           (esc/classify-status {:outcome :ok})))))
+           (event-status/classify-status {:outcome :ok})))))
 
 (deftest classify-status-settled-error
   (testing ":error outcome → :settled-error regardless of any other
             slot. Errors override RETRO mode, in-flight, paused — the
             user MUST notice the red."
-    (is (= :settled-error (esc/classify-status {:outcome :error})))
-    (is (= :settled-error (esc/classify-status {:outcome :error :mode :retro})))
-    (is (= :settled-error (esc/classify-status {:outcome :error :paused? true})))
-    (is (= :settled-error (esc/classify-status {:outcome :error :stale? true})))
-    (is (= :settled-error (esc/classify-status {:outcome :error :in-flight? true})))))
+    (is (= :settled-error (event-status/classify-status {:outcome :error})))
+    (is (= :settled-error (event-status/classify-status {:outcome :error :mode :retro})))
+    (is (= :settled-error (event-status/classify-status {:outcome :error :paused? true})))
+    (is (= :settled-error (event-status/classify-status {:outcome :error :stale? true})))
+    (is (= :settled-error (event-status/classify-status {:outcome :error :in-flight? true})))))
 
 (deftest classify-status-settled-warning-resolves-to-success
   (testing ":warning outcome → :settled-success. The yellow glyph
             ALREADY signals warning at the Event header; the row
             status colour reads 'settled' rather than re-amplifying
             the warning."
-    (is (= :settled-success (esc/classify-status {:outcome :warning})))))
+    (is (= :settled-success (event-status/classify-status {:outcome :warning})))))
 
 (deftest classify-status-in-flight
   (testing ":in-flight? true with no terminal outcome → :in-flight.
             The LIVE-head cascade still building."
-    (is (= :in-flight (esc/classify-status {:in-flight? true})))
-    (is (= :in-flight (esc/classify-status {:in-flight? true :mode :live})))))
+    (is (= :in-flight (event-status/classify-status {:in-flight? true})))
+    (is (= :in-flight (event-status/classify-status {:in-flight? true :mode :live})))))
 
 (deftest classify-status-in-flight-clears-on-outcome
   (testing "in-flight? + a settled outcome → the outcome wins. A
             cascade in mid-build that has just landed its :event/
             do-fx is logically settled."
     (is (= :settled-success
-           (esc/classify-status {:in-flight? true :outcome :ok})))
+           (event-status/classify-status {:in-flight? true :outcome :ok})))
     (is (= :settled-error
-           (esc/classify-status {:in-flight? true :outcome :error})))))
+           (event-status/classify-status {:in-flight? true :outcome :error})))))
 
 (deftest classify-status-paused-by-tool
   (testing ":paused? true with no error → :paused-by-tool. A tool
             (story, MCP, the user via the spine pause button) has
             claimed the buffer; LIVE mode is paused."
-    (is (= :paused-by-tool (esc/classify-status {:paused? true})))
-    (is (= :paused-by-tool (esc/classify-status {:paused? true :mode :live})))))
+    (is (= :paused-by-tool (event-status/classify-status {:paused? true})))
+    (is (= :paused-by-tool (event-status/classify-status {:paused? true :mode :live})))))
 
 (deftest classify-status-stale-from-explicit-flag
   (testing ":stale? true → :stale regardless of mode. Used for
             cascades replayed via time-travel / dispatch-replay."
-    (is (= :stale (esc/classify-status {:stale? true})))
-    (is (= :stale (esc/classify-status {:stale? true :outcome :ok})))))
+    (is (= :stale (event-status/classify-status {:stale? true})))
+    (is (= :stale (event-status/classify-status {:stale? true :outcome :ok})))))
 
 (deftest classify-status-stale-from-retro-mode
   (testing ":retro mode → :stale even without the explicit flag. A
             user pinning a non-head cascade IS inspecting a stale
             row; the colour reflects that."
-    (is (= :stale (esc/classify-status {:mode :retro})))
-    (is (= :stale (esc/classify-status {:mode :retro :outcome :ok})))))
+    (is (= :stale (event-status/classify-status {:mode :retro})))
+    (is (= :stale (event-status/classify-status {:mode :retro :outcome :ok})))))
 
 (deftest classify-status-error-wins-over-stale
   (testing "error trumps stale — a RETRO-replayed errored cascade
             still reads red so the user spots it among the yellow
             history."
     (is (= :settled-error
-           (esc/classify-status {:mode :retro :outcome :error})))
+           (event-status/classify-status {:mode :retro :outcome :error})))
     (is (= :settled-error
-           (esc/classify-status {:stale? true :outcome :error})))))
+           (event-status/classify-status {:stale? true :outcome :error})))))
 
 (deftest classify-status-stale-wins-over-paused
   (testing "stale wins over paused — if the user has scrubbed to a
@@ -142,17 +142,17 @@
             regardless of the paused? slot value the spine stamped
             on the way past."
     (is (= :stale
-           (esc/classify-status {:mode :retro :paused? true})))
+           (event-status/classify-status {:mode :retro :paused? true})))
     (is (= :stale
-           (esc/classify-status {:stale? true :paused? true})))))
+           (event-status/classify-status {:stale? true :paused? true})))))
 
 (deftest classify-status-empty-input-defaults-to-in-flight
   (testing "no signals at all → :in-flight. A cold-start row with
             no outcome / mode / focus reads as still-in-progress —
             the safest default (violet, the project's neutral
             causal-chain colour) rather than a misleading green."
-    (is (= :in-flight (esc/classify-status {})))
-    (is (= :in-flight (esc/classify-status nil)))))
+    (is (= :in-flight (event-status/classify-status {})))
+    (is (= :in-flight (event-status/classify-status nil)))))
 
 ;; ---- hex resolver --------------------------------------------------------
 
@@ -172,19 +172,19 @@
              [{:paused? true}             :paused-by-tool]
              [{}                          :in-flight]]]
       (let [expected-colour (get tokens/tokens
-                                 (get esc/status->token expected-status))]
-        (is (= expected-colour (esc/event-status-colour state))
+                                 (get event-status/status->token expected-status))]
+        (is (= expected-colour (event-status/event-status-colour state))
             (str "state " state " resolves to " expected-status " colour"))))))
 
 (deftest event-status-token-resolves-to-keyword
   (testing "`event-status-token` is the keyword-side of the resolver
             — useful for callers that compose styles through
             `theme/tokens` rather than inlining the hex."
-    (is (= :red (esc/event-status-token {:outcome :error})))
-    (is (= :green (esc/event-status-token {:outcome :ok})))
-    (is (= :yellow (esc/event-status-token {:mode :retro})))
-    (is (= :info (esc/event-status-token {:paused? true})))
-    (is (= :accent (esc/event-status-token {})))))
+    (is (= :red (event-status/event-status-token {:outcome :error})))
+    (is (= :green (event-status/event-status-token {:outcome :ok})))
+    (is (= :yellow (event-status/event-status-token {:mode :retro})))
+    (is (= :info (event-status/event-status-token {:paused? true})))
+    (is (= :accent (event-status/event-status-token {})))))
 
 (deftest event-status-colour-fallback
   (testing "unknown status (shouldn't happen via the classifier, but
@@ -195,7 +195,7 @@
     ;; We test by reaching into the public API with a deliberately-
     ;; malformed state shape — every key unrecognised — and ensure
     ;; the accent fallback rides.
-    (is (string? (esc/event-status-colour {:outcome :unknown :mode :unknown})))))
+    (is (string? (event-status/event-status-colour {:outcome :unknown :mode :unknown})))))
 
 ;; ---- cascade → state projection ----------------------------------------
 
@@ -208,22 +208,22 @@
             classifier then resolves to :settled-error."
     (let [cascade {:dispatch-id 42}
           focus   {:dispatch-id 42 :mode :live :paused? false}
-          state   (esc/cascade->state cascade focus (mock-outcome :error))]
+          state   (event-status/cascade->state cascade focus (mock-outcome :error))]
       (is (= :error (:outcome state)))
       (is (true? (:focused? state)))
       (is (false? (:stale? state)))
       (is (= :live (:mode state)))
-      (is (= :settled-error (esc/classify-status state))))))
+      (is (= :settled-error (event-status/classify-status state))))))
 
 (deftest cascade->state-projects-retro-stale
   (testing "a focused cascade in RETRO mode → :stale? true (derived
             from :mode :retro)."
     (let [cascade {:dispatch-id 7}
           focus   {:dispatch-id 7 :mode :retro :paused? false}
-          state   (esc/cascade->state cascade focus (mock-outcome :ok))]
+          state   (event-status/cascade->state cascade focus (mock-outcome :ok))]
       (is (true? (:stale? state)))
       (is (= :retro (:mode state)))
-      (is (= :stale (esc/classify-status state))))))
+      (is (= :stale (event-status/classify-status state))))))
 
 (deftest cascade->state-projects-non-focused-cascade
   (testing "a cascade that's NOT the spine focus → :focused? false +
@@ -232,20 +232,20 @@
             their settled state, not the spine's RETRO scope."
     (let [cascade {:dispatch-id 1}
           focus   {:dispatch-id 99 :mode :retro :paused? true}
-          state   (esc/cascade->state cascade focus (mock-outcome :ok))]
+          state   (event-status/cascade->state cascade focus (mock-outcome :ok))]
       (is (false? (:focused? state)))
       (is (nil? (:mode state)))
       (is (false? (:stale? state)))
       (is (false? (:paused? state)))
-      (is (= :settled-success (esc/classify-status state))))))
+      (is (= :settled-success (event-status/classify-status state))))))
 
 (deftest cascade->state-with-nil-focus
   (testing "no focus map (e.g. test rig pre-mount) → :focused? false.
             The fn still resolves cleanly so JVM-side fixture
             builders can call it without a live spine."
-    (let [state (esc/cascade->state {:dispatch-id 1} nil (mock-outcome :ok))]
+    (let [state (event-status/cascade->state {:dispatch-id 1} nil (mock-outcome :ok))]
       (is (false? (:focused? state)))
-      (is (= :settled-success (esc/classify-status state))))))
+      (is (= :settled-success (event-status/classify-status state))))))
 
 ;; ---- visual smoke — per-state hex landing on the right palette anchor --
 
@@ -260,18 +260,18 @@
             same var-map (`tokens/tokens`)."
     (let [palette tokens/tokens]
       (is (= (:accent palette)
-             (esc/event-status-colour {:in-flight? true}))
+             (event-status/event-status-colour {:in-flight? true}))
           "in-flight rides the mode accent — the current-epoch accent")
       (is (= (:green palette)
-             (esc/event-status-colour {:outcome :ok}))
+             (event-status/event-status-colour {:outcome :ok}))
           "settled-success rides green")
       (is (= (:red palette)
-             (esc/event-status-colour {:outcome :error}))
+             (event-status/event-status-colour {:outcome :error}))
           "settled-error rides red")
       (is (= (:info palette)
-             (esc/event-status-colour {:paused? true}))
+             (event-status/event-status-colour {:paused? true}))
           "paused-by-tool rides the fixed cool blue :info (distinct
            from the in-flight accent)")
       (is (= (:yellow palette)
-             (esc/event-status-colour {:mode :retro}))
+             (event-status/event-status-colour {:mode :retro}))
           "stale rides yellow"))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/machines/xyflow_style_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machines/xyflow_style_cljs_test.cljs
@@ -5,7 +5,7 @@
   (:require [clojure.string :as str]
             [cljs.test :refer-macros [deftest is testing]]
             [day8.re-frame2-xray.panels.machines.xyflow-style :as xstyle]
-            [day8.re-frame2-xray.theme.tokens :as t :refer [tokens]]))
+            [day8.re-frame2-xray.theme.tokens :refer [tokens]]))
 
 ;; ---- node-style ---------------------------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_popup_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_popup_cljs_test.cljs
@@ -30,7 +30,7 @@
             [re-frame.core :as rf]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
-            [day8.re-frame2-xray.views.edn-inspector-popup :as ddp]))
+            [day8.re-frame2-xray.views.edn-inspector-popup :as edn-inspector-popup]))
 
 ;; Fresh re-frame runtime per test so dispatch-sync against the
 ;; registered popup handlers lands on a clean slot every time.
@@ -67,51 +67,51 @@
 ;; =========================================================================
 
 (deftest push-entry-appends-new-id
-  (is (= ["a"] (ddp/push-entry [] "a")))
-  (is (= ["a" "b"] (ddp/push-entry ["a"] "b")))
-  (is (= ["a" "b" "c"] (ddp/push-entry ["a" "b"] "c"))))
+  (is (= ["a"] (edn-inspector-popup/push-entry [] "a")))
+  (is (= ["a" "b"] (edn-inspector-popup/push-entry ["a"] "b")))
+  (is (= ["a" "b" "c"] (edn-inspector-popup/push-entry ["a" "b"] "c"))))
 
 (deftest push-entry-raises-existing-id
   (testing "re-pushing an existing id moves it to the TOP of the stack"
-    (is (= ["b" "c" "a"] (ddp/push-entry ["a" "b" "c"] "a")))
-    (is (= ["a" "c" "b"] (ddp/push-entry ["a" "b" "c"] "b")))))
+    (is (= ["b" "c" "a"] (edn-inspector-popup/push-entry ["a" "b" "c"] "a")))
+    (is (= ["a" "c" "b"] (edn-inspector-popup/push-entry ["a" "b" "c"] "b")))))
 
 (deftest push-entry-handles-nil-stack
-  (is (= ["a"] (ddp/push-entry nil "a"))))
+  (is (= ["a"] (edn-inspector-popup/push-entry nil "a"))))
 
 (deftest pop-entry-removes-id
-  (is (= ["a" "c"] (ddp/pop-entry ["a" "b" "c"] "b")))
-  (is (= [] (ddp/pop-entry ["a"] "a"))))
+  (is (= ["a" "c"] (edn-inspector-popup/pop-entry ["a" "b" "c"] "b")))
+  (is (= [] (edn-inspector-popup/pop-entry ["a"] "a"))))
 
 (deftest pop-entry-noop-when-missing
-  (is (= ["a" "b"] (ddp/pop-entry ["a" "b"] "missing"))))
+  (is (= ["a" "b"] (edn-inspector-popup/pop-entry ["a" "b"] "missing"))))
 
 (deftest pop-entry-handles-nil-stack
-  (is (= [] (ddp/pop-entry nil "a"))))
+  (is (= [] (edn-inspector-popup/pop-entry nil "a"))))
 
 (deftest top-entry-returns-last
-  (is (nil? (ddp/top-entry [])))
-  (is (nil? (ddp/top-entry nil)))
-  (is (= "a" (ddp/top-entry ["a"])))
-  (is (= "c" (ddp/top-entry ["a" "b" "c"]))))
+  (is (nil? (edn-inspector-popup/top-entry [])))
+  (is (nil? (edn-inspector-popup/top-entry nil)))
+  (is (= "a" (edn-inspector-popup/top-entry ["a"])))
+  (is (= "c" (edn-inspector-popup/top-entry ["a" "b" "c"]))))
 
 (deftest z-index-for-stacks-above-base
   (testing "z-index increases with stack position so deeper popups
             paint above earlier ones"
-    (is (= 2147483640 (ddp/z-index-for 0)))
-    (is (= 2147483641 (ddp/z-index-for 1)))
-    (is (= 2147483645 (ddp/z-index-for 5)))
+    (is (= 2147483640 (edn-inspector-popup/z-index-for 0)))
+    (is (= 2147483641 (edn-inspector-popup/z-index-for 1)))
+    (is (= 2147483645 (edn-inspector-popup/z-index-for 5)))
     ;; Tolerates nil — defensive for the indexOf-returns-(-1) case.
-    (is (= 2147483640 (ddp/z-index-for nil)))))
+    (is (= 2147483640 (edn-inspector-popup/z-index-for nil)))))
 
 ;; =========================================================================
 ;; state slot constants — pinned so a downstream renamer breaks a test
 ;; =========================================================================
 
 (deftest state-slot-keywords-stable
-  (is (= :rf.xray.edn-inspector-popup/stack   ddp/stack-slot))
-  (is (= :rf.xray.edn-inspector-popup/entries ddp/entries-slot))
-  (is (= :rf.xray.edn-inspector-popup/anon    ddp/default-panel-id)))
+  (is (= :rf.xray.edn-inspector-popup/stack   edn-inspector-popup/stack-slot))
+  (is (= :rf.xray.edn-inspector-popup/entries edn-inspector-popup/entries-slot))
+  (is (= :rf.xray.edn-inspector-popup/anon    edn-inspector-popup/default-panel-id)))
 
 ;; =========================================================================
 ;; install! + reducers + subs
@@ -119,74 +119,74 @@
 
 (deftest install-is-idempotent
   ;; Two installs in a row must not double-register or throw.
-  (is (nil? (ddp/install!)))
-  (is (nil? (ddp/install!))))
+  (is (nil? (edn-inspector-popup/install!)))
+  (is (nil? (edn-inspector-popup/install!))))
 
 (deftest open-event-pushes-stack-and-stores-payload
-  (ddp/install!)
+  (edn-inspector-popup/install!)
   (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
                      "m1" {:value {:a 1} :opts {:title "First"}}])
-  (let [stack   @(rf/subscribe [ddp/stack-slot])
-        entries @(rf/subscribe [ddp/entries-slot])]
+  (let [stack   @(rf/subscribe [edn-inspector-popup/stack-slot])
+        entries @(rf/subscribe [edn-inspector-popup/entries-slot])]
     (is (= ["m1"] stack))
     (is (= {:value {:a 1} :opts {:title "First"}} (get entries "m1")))))
 
 (deftest open-event-stacks-multiple
-  (ddp/install!)
+  (edn-inspector-popup/install!)
   (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
                      "m1" {:value 1 :opts {}}])
   (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
                      "m2" {:value 2 :opts {}}])
   (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
                      "m3" {:value 3 :opts {}}])
-  (let [stack @(rf/subscribe [ddp/stack-slot])]
+  (let [stack @(rf/subscribe [edn-inspector-popup/stack-slot])]
     (is (= ["m1" "m2" "m3"] stack)
         "multiple opens stack in dispatch order")))
 
 (deftest close-event-removes-specific-id
-  (ddp/install!)
+  (edn-inspector-popup/install!)
   (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
                      "m1" {:value 1 :opts {}}])
   (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
                      "m2" {:value 2 :opts {}}])
   (rf/dispatch-sync [:rf.xray.edn-inspector-popup/close "m1"])
-  (let [stack   @(rf/subscribe [ddp/stack-slot])
-        entries @(rf/subscribe [ddp/entries-slot])]
+  (let [stack   @(rf/subscribe [edn-inspector-popup/stack-slot])
+        entries @(rf/subscribe [edn-inspector-popup/entries-slot])]
     (is (= ["m2"] stack) "m1 removed from stack")
     (is (nil? (get entries "m1")) "m1 entry dropped")
     (is (some? (get entries "m2")) "m2 entry preserved")))
 
 (deftest close-top-removes-topmost-only
-  (ddp/install!)
+  (edn-inspector-popup/install!)
   (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
                      "m1" {:value 1 :opts {}}])
   (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
                      "m2" {:value 2 :opts {}}])
   (rf/dispatch-sync [:rf.xray.edn-inspector-popup/close-top])
-  (let [stack @(rf/subscribe [ddp/stack-slot])]
+  (let [stack @(rf/subscribe [edn-inspector-popup/stack-slot])]
     (is (= ["m1"] stack)
         "close-top removed the topmost (m2); m1 still standing")))
 
 (deftest close-top-noop-on-empty-stack
-  (ddp/install!)
+  (edn-inspector-popup/install!)
   ;; No popups open — close-top must not throw.
   (rf/dispatch-sync [:rf.xray.edn-inspector-popup/close-top])
-  (is (empty? (or @(rf/subscribe [ddp/stack-slot]) []))))
+  (is (empty? (or @(rf/subscribe [edn-inspector-popup/stack-slot]) []))))
 
 (deftest close-all-clears-state
-  (ddp/install!)
+  (edn-inspector-popup/install!)
   (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
                      "m1" {:value 1 :opts {}}])
   (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
                      "m2" {:value 2 :opts {}}])
   (rf/dispatch-sync [:rf.xray.edn-inspector-popup/close-all])
-  (let [stack   @(rf/subscribe [ddp/stack-slot])
-        entries @(rf/subscribe [ddp/entries-slot])]
+  (let [stack   @(rf/subscribe [edn-inspector-popup/stack-slot])
+        entries @(rf/subscribe [edn-inspector-popup/entries-slot])]
     (is (= [] stack))
     (is (= {} entries))))
 
 (deftest open-sub-projects-correctly
-  (ddp/install!)
+  (edn-inspector-popup/install!)
   (is (false? @(rf/subscribe [:rf.xray.edn-inspector-popup/open?]))
       "no popups → :open? false")
   (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
@@ -195,7 +195,7 @@
       "one popup → :open? true"))
 
 (deftest top-sub-tracks-topmost-mount-id
-  (ddp/install!)
+  (edn-inspector-popup/install!)
   (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
                      "m1" {:value 1 :opts {}}])
   (is (= "m1" @(rf/subscribe [:rf.xray.edn-inspector-popup/top])))
@@ -205,7 +205,7 @@
       "second open promotes m2 to topmost"))
 
 (deftest entry-sub-returns-specific-payload
-  (ddp/install!)
+  (edn-inspector-popup/install!)
   (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
                      "m1" {:value {:cart 1} :opts {:title "A"}}])
   (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
@@ -217,15 +217,15 @@
 
 (deftest reopen-with-same-id-preserves-position-and-replaces-payload
   (testing "re-opening m1 raises it to top AND replaces its payload"
-    (ddp/install!)
+    (edn-inspector-popup/install!)
     (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
                        "m1" {:value 1 :opts {}}])
     (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
                        "m2" {:value 2 :opts {}}])
     (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
                        "m1" {:value 99 :opts {:title "raised"}}])
-    (let [stack   @(rf/subscribe [ddp/stack-slot])
-          entries @(rf/subscribe [ddp/entries-slot])]
+    (let [stack   @(rf/subscribe [edn-inspector-popup/stack-slot])
+          entries @(rf/subscribe [edn-inspector-popup/entries-slot])]
       (is (= ["m2" "m1"] stack)
           "m1 raised back to top of stack")
       (is (= 99 (-> entries (get "m1") :value))
@@ -236,7 +236,7 @@
 ;; =========================================================================
 
 (deftest popup-chrome-emits-backdrop-and-dialog
-  (let [h (ddp/popup-chrome
+  (let [h (edn-inspector-popup/popup-chrome
             {:mount-id    "m1"
              :value       {:a 1 :b 2}
              :opts        {:title "Inspect cart"}
@@ -256,7 +256,7 @@
         "close button carries mount-id-suffixed testid")))
 
 (deftest popup-chrome-emits-title-node-with-caller-title
-  (let [h (ddp/popup-chrome
+  (let [h (edn-inspector-popup/popup-chrome
             {:mount-id    "m1"
              :value       42
              :opts        {:title "Custom title"}
@@ -270,7 +270,7 @@
         "title text echoes caller-supplied :title")))
 
 (deftest popup-chrome-default-title
-  (let [h (ddp/popup-chrome
+  (let [h (edn-inspector-popup/popup-chrome
             {:mount-id    "m1"
              :value       42
              :opts        {}
@@ -282,7 +282,7 @@
         "no :title → default 'Inspect' label")))
 
 (deftest popup-chrome-embeds-edn-inspector-widget
-  (let [h    (ddp/popup-chrome
+  (let [h    (edn-inspector-popup/popup-chrome
                {:mount-id    "m1"
                 :value       {:foo :bar}
                 :opts        {}
@@ -305,7 +305,7 @@
           "body embeds a fn-as-component call (the edn-inspector widget)"))))
 
 (deftest popup-chrome-uses-aria-dialog-attrs
-  (let [h      (ddp/popup-chrome
+  (let [h      (edn-inspector-popup/popup-chrome
                  {:mount-id    "m1"
                   :value       42
                   :opts        {}
@@ -322,7 +322,7 @@
         "dialog labelled by the title node id")))
 
 (deftest popup-chrome-respects-modal-positioning-absolute
-  (let [h (ddp/popup-chrome
+  (let [h (edn-inspector-popup/popup-chrome
             {:mount-id    "m1"
              :value       42
              :opts        {}
@@ -338,7 +338,7 @@
         "positioning marker exposed for instrumentation")))
 
 (deftest popup-chrome-respects-modal-positioning-fixed
-  (let [h (ddp/popup-chrome
+  (let [h (edn-inspector-popup/popup-chrome
             {:mount-id    "m1"
              :value       42
              :opts        {}
@@ -358,14 +358,14 @@
   (let [captured (atom nil)]
     (with-redefs [rf/dispatch* (fn [event-v & _]
                                  (reset! captured event-v))]
-      (let [f (ddp/close-fn "m1" {})]
+      (let [f (edn-inspector-popup/close-fn "m1" {})]
         (f)
         (is (= [:rf.xray.edn-inspector-popup/close "m1"] @captured)
             "default close-fn dispatches the :close event for this id")))))
 
 (deftest close-fn-uses-caller-on-close-when-supplied
   (let [called (atom 0)
-        f (ddp/close-fn "m1" {:on-close #(swap! called inc)})]
+        f (edn-inspector-popup/close-fn "m1" {:on-close #(swap! called inc)})]
     (f)
     (is (= 1 @called)
         "caller-supplied :on-close fires instead of the default dispatch")
@@ -376,7 +376,7 @@
 (deftest close-button-on-click-resolves
   ;; The chrome's ✕ button must carry an :on-click. We don't fire it
   ;; (no DOM event obj to pass), only assert the wiring is present.
-  (let [h     (ddp/popup-chrome
+  (let [h     (edn-inspector-popup/popup-chrome
                 {:mount-id    "m1"
                  :value       42
                  :opts        {}
@@ -390,7 +390,7 @@
 (deftest backdrop-on-click-closes-via-handler
   ;; Backdrop click closes the popup; we capture the dispatch.
   (let [captured (atom nil)
-        h        (ddp/popup-chrome
+        h        (edn-inspector-popup/popup-chrome
                    {:mount-id    "m1"
                     :value       42
                     :opts        {}
@@ -412,7 +412,7 @@
   (let [captured (atom nil)]
     (with-redefs [rf/dispatch* (fn [event-v & _]
                                  (reset! captured event-v))]
-      (ddp/handle-keydown
+      (edn-inspector-popup/handle-keydown
         #js {:key "Escape"
              :preventDefault  (fn [])
              :stopPropagation (fn [])})
@@ -425,7 +425,7 @@
   (let [captured (atom nil)]
     (with-redefs [rf/dispatch* (fn [event-v & _]
                                  (reset! captured event-v))]
-      (ddp/handle-keydown
+      (edn-inspector-popup/handle-keydown
         #js {:key "Enter"
              :preventDefault  (fn [])
              :stopPropagation (fn [])})
@@ -440,8 +440,8 @@
   ;; Two outer calls to the form-2 component (each modelling a
   ;; separate mount) should produce DISTINCT inner fns with distinct
   ;; mount-ids in closure.
-  (let [outer-1 (ddp/edn-inspector-popup {:a 1})
-        outer-2 (ddp/edn-inspector-popup {:a 1})]
+  (let [outer-1 (edn-inspector-popup/edn-inspector-popup {:a 1})
+        outer-2 (edn-inspector-popup/edn-inspector-popup {:a 1})]
     (is (fn? outer-1) "form-2 outer returns an inner fn")
     (is (fn? outer-2))
     ;; Distinct closures imply distinct mount-ids; we can't peek into
@@ -453,11 +453,11 @@
 (deftest edn-inspector-popup-two-arity-overload
   (testing "[edn-inspector-popup value opts] arity is accepted (D2=a
             two-arg overload convention)"
-    (is (fn? (ddp/edn-inspector-popup {:a 1} {:title "Cart"})))))
+    (is (fn? (edn-inspector-popup/edn-inspector-popup {:a 1} {:title "Cart"})))))
 
 (deftest edn-inspector-popup-default-arity
   (testing "[edn-inspector-popup value] single-arg arity works"
-    (is (fn? (ddp/edn-inspector-popup {:a 1})))))
+    (is (fn? (edn-inspector-popup/edn-inspector-popup {:a 1})))))
 
 ;; =========================================================================
 ;; per-mount isolation — embedded widget panel-id is mount-scoped
@@ -467,7 +467,7 @@
   ;; The embedded edn-inspector widget should receive a :panel-id that
   ;; incorporates the popup's mount-id so two popups inspecting the
   ;; same value never collide on expansion state.
-  (let [h    (ddp/popup-chrome
+  (let [h    (edn-inspector-popup/popup-chrome
                {:mount-id    "m-abc"
                 :value       {:a 1 :b {:c 2}}
                 :opts        {:panel-id :sub-detail}
@@ -498,7 +498,7 @@
 (deftest popup-chrome-default-panel-id-when-opts-omitted
   ;; If the caller omits :panel-id, the embedded widget still gets a
   ;; mount-id-scoped panel-id derived from default-panel-id.
-  (let [h    (ddp/popup-chrome
+  (let [h    (edn-inspector-popup/popup-chrome
                {:mount-id    "m-xyz"
                 :value       42
                 :opts        {}
@@ -525,20 +525,20 @@
 ;; =========================================================================
 
 (deftest stack-view-renders-nothing-when-empty
-  (ddp/install!)
+  (edn-inspector-popup/install!)
   ;; Register the modal-positioning sub the stack view subscribes to.
   (rf/reg-sub :rf.xray/modal-positioning (fn [_ _] :fixed))
-  (is (nil? (ddp/edn-inspector-popup-stack))
+  (is (nil? (edn-inspector-popup/edn-inspector-popup-stack))
       "closed stack short-circuits to nil"))
 
 (deftest stack-view-renders-one-entry-per-open-popup
-  (ddp/install!)
+  (edn-inspector-popup/install!)
   (rf/reg-sub :rf.xray/modal-positioning (fn [_ _] :fixed))
   (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
                      "m1" {:value 1 :opts {:title "A"}}])
   (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
                      "m2" {:value 2 :opts {:title "B"}}])
-  (let [tree (ddp/edn-inspector-popup-stack)]
+  (let [tree (edn-inspector-popup/edn-inspector-popup-stack)]
     (is (some? tree) "stack view renders when at least one popup is open")
     (is (some? (find-attr tree :data-testid
                           "rf-xray-edn-inspector-popup-stack"))
@@ -551,7 +551,7 @@
         "m2 chrome present")))
 
 (deftest stack-view-marks-popup-count
-  (ddp/install!)
+  (edn-inspector-popup/install!)
   (rf/reg-sub :rf.xray/modal-positioning (fn [_ _] :fixed))
   (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
                      "m1" {:value 1 :opts {}}])
@@ -559,6 +559,6 @@
                      "m2" {:value 2 :opts {}}])
   (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
                      "m3" {:value 3 :opts {}}])
-  (let [tree (ddp/edn-inspector-popup-stack)]
+  (let [tree (edn-inspector-popup/edn-inspector-popup-stack)]
     (is (= 3 (-> tree second :data-rf-popup-count))
         "popup-count attribute reflects stack depth")))

--- a/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_popup_wireup_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_popup_wireup_cljs_test.cljs
@@ -35,7 +35,7 @@
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]
             [day8.re-frame2-xray.views.edn-inspector :as ei]
-            [day8.re-frame2-xray.views.edn-inspector-popup :as ddp]))
+            [day8.re-frame2-xray.views.edn-inspector-popup :as edn-inspector-popup]))
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture
@@ -220,7 +220,7 @@
 (deftest popup-stack-view-empty-when-stack-empty
   (setup-xray-frame!)
   (rf/with-frame :rf/xray
-    (let [tree (ddp/edn-inspector-popup-stack)]
+    (let [tree (edn-inspector-popup/edn-inspector-popup-stack)]
       (is (nil? tree)
           "stack view returns nil when no popups are open (closed-state
            cost is one subscribe + a when-gate)"))))
@@ -234,7 +234,7 @@
         [:rf.xray.edn-inspector-popup/open
          "m1" {:value {:foo :bar}
                :opts  {:title "Inspect cart"}}])
-      (let [tree (ddp/edn-inspector-popup-stack)]
+      (let [tree (edn-inspector-popup/edn-inspector-popup-stack)]
         (is (some? tree) "stack view returns hiccup when stack non-empty")
         (is (some? (find-by-testid tree "rf-xray-edn-inspector-popup-stack"))
             "outer stack container present")
@@ -250,7 +250,7 @@
                          "m1" {:value 1 :opts {}}])
       (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
                          "m2" {:value 2 :opts {}}])
-      (let [tree (ddp/edn-inspector-popup-stack)]
+      (let [tree (edn-inspector-popup/edn-inspector-popup-stack)]
         (is (some? (find-by-testid tree
                                    "rf-xray-edn-inspector-popup-backdrop-m1")))
         (is (some? (find-by-testid tree
@@ -269,7 +269,7 @@
       (rf/dispatch-sync
         [:rf.xray.edn-inspector-popup/open
          "smoke" {:value :hi :opts {:title "Smoke"}}])
-      (let [stack @(rf/subscribe [ddp/stack-slot])]
+      (let [stack @(rf/subscribe [edn-inspector-popup/stack-slot])]
         (is (= ["smoke"] stack)
             "open event resolved through the registry-installed handler")))))
 
@@ -336,7 +336,7 @@
     ;; `with-frame` binding entirely because the body's `rf/subscribe`
     ;; calls would have fallen all the way through to `:rf/default`.
     (rf/with-frame :rf/xray
-      (let [tree (ddp/edn-inspector-popup-stack)]
+      (let [tree (edn-inspector-popup/edn-inspector-popup-stack)]
         (is (some? tree)
             "stack view rendered some chrome under :rf/xray (proves :rf/xray's
              stack slot is non-empty from the view's perspective)")
@@ -352,7 +352,7 @@
              frames"))
       ;; And the stack's count attribute reflects :rf/xray's stack
       ;; depth exclusively (one entry), not the combined two.
-      (let [tree (ddp/edn-inspector-popup-stack)]
+      (let [tree (edn-inspector-popup/edn-inspector-popup-stack)]
         (is (= 1 (-> tree second :data-rf-popup-count))
             "popup-count reflects :rf/xray's stack only (one entry), not
              the two-entry total across frames")))))


### PR DESCRIPTION
Naming-audit pass on `tools/xray/` per bead rf2-f9xao (P3 of the 33-bead naming-audit wave, Mike-filed 2026-05-29).

## Summary

Audit covered ~325 CLJS source + test files. **No bad names found at the public surface.** The xray slice is exceptionally well-named — every public ns, every public reg-view (`Panel` per spec/Conventions.md §Panel naming rf2-qiek0), every panel facade + leaf split, every setter verb (`set-` / `update-` / `reset-` / `clear-` per §Setter-naming axis) reads cleanly. Docstrings are exemplary. `core.cljs`'s 13-symbol public surface matches `spec/API.md` exactly.

The audit found only one class of inline issue — alias-discipline drift — fixed across 28 files in two logical commits.

**Zero follow-on beads filed.** No public-surface renames are warranted; the only borderline case (`panels.trace-helpers/area`) is domain vocabulary explicitly documented in `spec/023-Trace-Panel.md` §3.

## What changed

**Commit 1: `theme.tokens` alias unification (24 files).**

The `day8.re-frame2-xray.theme.tokens` ns is required by ~50 files. The dominant convention is `:refer [tokens ...]` (or `:as tokens` with no `:refer`). 22 outliers used `:as t` or `:as tk` — 18 of them never USED the alias (vestigial after `:refer` migration). This commit drops the vestigial aliases and rewrites the 4 files that actually used them to expand `:refer` with the symbols actually called.

The lone deliberate exception (`test/.../theme/tokens_cljs_test.cljc`) keeps `:as t` paired with `:as mv` for 111 contrast comparisons against machines-viz tokens — documented as the one intended divergence.

**Commit 2: cryptic per-file aliases (4 files).**

Four files diverged from the dominant convention with opaque acronyms. `:as ddp` for `edn-inspector-popup` in 2 test files (production code uses `:as edn-inspector-popup`; the same acronym `ddp` ALSO aliases a DIFFERENT ns `edn-inspector-protocol` in production — a naming collision). `:as cch` for `cancellation-cascade-helpers` in `panels/trace.cljs`. `:as esc` for `event-status-colour` in one test file (production uses `:as event-status`).

## Quality gates

- **`cd tools/xray && clojure -M:test`** — **957 tests, 3762 assertions, 0 failures, 0 errors.** Baseline before edits = identical numbers.
- **clj-kondo on all 28 changed files** — **0 errors, 0 new warnings.** The 9 pre-existing warnings (unused requires / unused refers / unused bindings unrelated to this PR) are confirmed baseline noise — verified by re-linting the un-edited file set.
- **`cd implementation && npm run test:cljs`** — **skipped on this Windows worker**. The xray tests cover every changed namespace via JVM, the changed files are tools/xray-internal (no implementation/ build-path file touched per `git diff --name-only`), and the bundle-isolation gate forbids implementation/ from requiring tools/. CI will run the cljs node-test gate on the PR canonically.

## Renames inventory

- **Inline renames (this PR)**: 28 files.
- **Follow-on beads**: 0.

Detailed list of files + rationale per file lives in `ai/findings/naming-audit-tools-xray.md` (local-only / gitignored).

## Worktree

`C:/Users/miket/code/re-frame2-worktrees/naming-xray-rf2-f9xao` — worker-worktree guard passed at session start; findings doc path-leak test passed (worker-side True, mayor-side False).