### PR TITLE
refactor(adapters/test-react): inline naming-clarity renames (rf2-7g5be)

### DIFF
--- a/implementation/adapters/test-react/src/re_frame/adapter/test_react.cljc
+++ b/implementation/adapters/test-react/src/re_frame/adapter/test_react.cljc
@@ -324,11 +324,11 @@
   ;; NOT route through the public unmount thunk (it would throw on the
   ;; currently-rendering? / render-depth guard) — forced teardown is the
   ;; escape hatch the guard deliberately cannot block.
-  (doseq [m @active-mounts]
-    (when @(:mounted? m)
-      (log-phase! m :forced-teardown)
-      (reset! (:mounted? m) false)
-      (reset! (:render-tree m) nil)))
+  (doseq [mount @active-mounts]
+    (when @(:mounted? mount)
+      (log-phase! mount :forced-teardown)
+      (reset! (:mounted? mount) false)
+      (reset! (:render-tree mount) nil)))
   (reset! active-mounts #{})
   ;; Reset the global render depth. `run-render!`'s `finally` already restores
   ;; it on the normal + guard-throw paths; this is belt-and-braces so a test


### PR DESCRIPTION
Naming-best-practice audit for `implementation/adapters/test-react/` — substrate-adapter that simulates the React class-3 lifecycle in pure CLJC (no React / no DOM / no jsdom). Part of the 33-bead audit wave.

## Findings summary

The slice is well named end-to-end. Verdict for nearly every entity reviewed: **KEEP**.

- **Namespaces:** `re-frame.adapter.test-react` matches the family pattern (`re-frame.adapter.{reagent,uix,helix}`); filename matches.
- **Public driver surface** (`mount!` / `trigger-update!` / `unmount!` / `lifecycle-log` / `current-render-tree` / `mounted-roots` / `children` / `rendering?` / `mount-child!` / `set-hiccup-emitter!` / `adapter`) is the natural vocabulary for a React-lifecycle-simulator test driver, matches the README + Spec 006 narrative, and has no out-of-slice callers yet (verified by grep — only the in-slice test file references these names).
- **Private helpers** (`make-derived-value` / `render` / `render-to-string` / `register-context-provider` / `dispose-adapter!`) mirror the Spec 006 nine-fn contract slot names verbatim. Renaming would diverge from the contract vocabulary.
- **Record fields** are predicate-shaped (`:currently-rendering?`, `:mounted?`) and `-fn`-suffixed (`:unmount-fn`) per Conventions.
- **Phase keywords** (`:constructor` / `:render` / `:did-mount` / `:did-update` / `:will-unmount`) mirror React class-3 vocabulary verbatim — the point of this adapter.
- **Error keywords** sit under the reserved `:rf.error/*` namespace.
- **Tests** are CLJC (`test_react_test.cljc`) — the `-cljs-test` / `-dom-cljs-test` filename suffix conventions used by Reagent/UIx/Helix don't apply. The `_test` suffix is correct for CLJC.
- **Vocabulary check:** the audit prompt mentioned `render-into-jsdom` / `mount` / `unmount` alignment. `render-into-jsdom` appears nowhere in the codebase (correctly — this adapter is deliberately headless). `mount` / `unmount` vocabulary is used consistently in this slice.

## Inline renames applied

One — minor:

- `dispose-adapter!` doseq loop variable `m` → `mount`, for symmetry with the rest of the file where every `MountedComponent` instance is bound to `mount`.

That is the only diff worth applying. Everything else is already idiomatic.

## Follow-on beads

**None.** No public surface rename warranted; no namespace rename warranted; no filename rename warranted.

Full per-entity verdict table lives in `ai/findings/naming-audit-implementation-adapters-test-react.md` (local-only / gitignored, per `the-mayor-method.md`).

## Quality gates

- `cd implementation/adapters/test-react && clojure -M:test` → **Ran 12 tests containing 37 assertions. 0 failures, 0 errors.**
- `clj-kondo --lint implementation/adapters/test-react/src implementation/adapters/test-react/test` → **0 errors, 0 warnings.**

Closes rf2-7g5be.