### PR TITLE
refactor(ssr-ring): inline naming-clarity renames (rf2-nbgdw)

### DIFF
--- a/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
@@ -91,8 +91,8 @@
 
 (defn setup-request-frame!
   "Register a per-request frame and populate the request slot. Returns
-  `{:frame-id fid}` on success, or `{:short-circuit ring-response}` when
-  setup fails (the caller short-circuits to that response, skipping
+  `{:frame-id frame-id}` on success, or `{:short-circuit ring-response}`
+  when setup fails (the caller short-circuits to that response, skipping
   render).
 
   The slot is populated BEFORE `reg-frame` so the synchronous
@@ -122,10 +122,10 @@
   ;; AND spec-compliant. `clojure.core/keyword` does not validate, so
   ;; the read-side enforcement is the only signal — this naming is
   ;; load-bearing.
-  (let [fid (keyword "rf.frame" (str (gensym "f")))]
-    (ssr/set-request! fid request)
+  (let [frame-id (keyword "rf.frame" (str (gensym "f")))]
+    (ssr/set-request! frame-id request)
     (try
-      (rf/reg-frame fid
+      (rf/reg-frame frame-id
         (cond-> {:doc       "ssr-ring per-request frame"
                  :platform  :server
                  ;; Audit rf2-cegm7 A2 / rf2-j54ee: pass :on-create
@@ -135,10 +135,10 @@
                  :on-create (lifecycle/validate-on-create! on-create)}
           fx-overrides (assoc :fx-overrides fx-overrides)
           ssr          (assoc :ssr           ssr)))
-      {:frame-id fid}
+      {:frame-id frame-id}
       (catch Throwable t
-        (ssr/clear-request! fid)
-        (lifecycle/destroy-frame-quietly! fid)
+        (ssr/clear-request! frame-id)
+        (lifecycle/destroy-frame-quietly! frame-id)
         {:short-circuit (on-error request t)}))))
 
 (defn ^:private render-error-body


### PR DESCRIPTION
## Summary

Per the rf2-nbgdw naming audit of `implementation/ssr-ring/`. The slice is in carefully maintained shape — naming reads as intent-driven across both source and tests, and the public surface is anchored in Ring vocabulary (`handler` / `middleware` / `request` / `response`) that's exactly what a Clojure HTTP author would expect.

## Inline renames

One only:

- `pipeline.clj` `setup-request-frame!`: local `let`-binding `fid` → `frame-id`.

`frame-id` is the canonical name across the slice (52+ occurrences in 5 files); `pipeline.clj`'s `setup-request-frame!` body was the sole odd-one-out with `fid`, the same concept named two different ways. The rename is purely local — `fid` was only inside one fn body. Test-local `fid`s in `ring_streaming_test.clj` remain (separate name space; consistent with each other).

## Audit findings

Reviewed: 8 source files + 6 test files, every public def/defn, every private helper, every let-binding pattern, every test name. All other names verified KEEP. No public-surface or sub-namespace renames warranted.

- Ring-idiom match: clean. The slice avoids `wrap-*` / `handle-*` / `serve-*` precisely because none fit the adapter's contract (which is materialise the runtime's response accumulator into a Ring map).
- Verb/noun/predicate/`!` consistency: 8 side-effecting fns end `!`; shape transforms use `->`; no in-slice predicates (used inline as `(some? …)`).
- 76 `deftest` names narrate intent; `testing` strings crisp; acronyms preserved (FIFO, CRLF, CSP, RFC6265).
- Error keyword family (`:rf.error/ssr-ring-*`, `:rf.error/cookie-*`, etc.) consistent across the slice.

## Follow-ons

None filed. Sub-namespace names (`cookie`, `headers`, `lifecycle`, `payload`, `pipeline`, `shell`, `streaming`, `trust`) are referenced by spec (`011-SSR.md`, `Ownership.md`, `009-Instrumentation.md`) and tools (`tools/template/spec/004-SSR-Validation-Report.md`); all eight are single-concept, ns-name = filename 1:1, and the audit found no clarity wins from renaming any.

Findings doc at `ai/findings/naming-audit-implementation-ssr-ring.md` (local-only; not committed).

## Quality gates

- `cd implementation/ssr-ring && clojure -M:test`
  → 76 tests / 364 assertions / 0 failures / 0 errors (matches baseline)
- `clj-kondo --lint src test`
  → 0 errors / 14 pre-existing warnings (no new lints from the rename)