### PR TITLE
refactor(adapters/reagent): inline naming-clarity renames (rf2-5r7eh)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/adapter_render_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/adapter_render_cljs_test.cljs
@@ -30,7 +30,7 @@
 
 ;; ---- helpers ---------------------------------------------------------------
 
-(defn- mk-fake-root
+(defn- make-fake-root
   "A fake Root identity — just an object with a `.unmount` method we
   never actually call (the spy replaces `rdc/unmount`). Using `(js-obj)`
   keeps the value JS-shaped without depending on React being present."
@@ -44,7 +44,7 @@
             first; (rdc/render root render-tree) follows; the unmount
             thunk closes over the Root (rf2-fn5rk)"
     (let [calls         (atom [])
-          fake-root     (mk-fake-root :non-hydrate)
+          fake-root     (make-fake-root :non-hydrate)
           fake-mount    #js {:rf-test-mount :non-hydrate}
           fake-tree     [:div "tree"]]
       ;; Stubs are multi-arity to mirror reagent.dom.client's API
@@ -114,7 +114,7 @@
             unmount thunk closes over the Root from hydrate-root
             (rf2-fn5rk)"
     (let [calls       (atom [])
-          fake-root   (mk-fake-root :hydrate)
+          fake-root   (make-fake-root :hydrate)
           fake-mount  #js {:rf-test-mount :hydrate}
           fake-tree   [:section "ssr-tree"]]
       (with-redefs [rdc/create-root  (fn
@@ -165,7 +165,7 @@
             18. This test asserts the mount-point never appears as
             the first arg to rdc/render."
     (let [render-calls (atom [])
-          fake-root    (mk-fake-root :regression)
+          fake-root    (make-fake-root :regression)
           fake-mount   #js {:rf-test-mount :regression}]
       (with-redefs [rdc/create-root  (fn
                                        ([_]   fake-root)

--- a/implementation/adapters/reagent/test/re_frame/dispose_adapter_sub_cache_walk_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/dispose_adapter_sub_cache_walk_cljs_test.cljs
@@ -37,7 +37,7 @@
 ;; test body call dispose-adapter! to drive the walk. Each test cleans
 ;; up after itself so a re-run is idempotent.
 
-(defn fresh-reagent [test-fn]
+(defn- cold-start-fixture [test-fn]
   ;; Wipe lifecycle state — adapter slot + disposed breadcrumb +
   ;; frame registry — so the test starts from a never-installed cold
   ;; state. The `reset-lifecycle-state-for-tests!` seam exists for
@@ -55,7 +55,7 @@
   (reset! frame/frames {})
   (adapter/reset-lifecycle-state-for-tests!))
 
-(use-fixtures :each fresh-reagent)
+(use-fixtures :each cold-start-fixture)
 
 ;; ---- helpers --------------------------------------------------------------
 

--- a/implementation/adapters/reagent/test/re_frame/events_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/events_cljs_test.cljs
@@ -23,13 +23,13 @@
   "Attach a listener that records `:rf.warning/interceptors-in-metadata-map`
   events and return the recording atom."
   [k]
-  (let [a (atom [])]
+  (let [recorded (atom [])]
     (trace-tooling/register-listener! k
       (fn [ev]
         (when (and (= :warning (:op-type ev))
                    (= :rf.warning/interceptors-in-metadata-map (:operation ev)))
-          (swap! a conj ev))))
-    a))
+          (swap! recorded conj ev))))
+    recorded))
 
 (def ^:private noop-icpt
   {:id :test/noop :before identity :after identity})
@@ -42,9 +42,9 @@
         (fn [db _] db))
       (trace-tooling/unregister-listener! ::db-warn)
       (is (= 1 (count @warns)))
-      (let [t (:tags (first @warns))]
-        (is (= "reg-event-db" (:reg-fn t)))
-        (is (= :test.bbea.cljs/db-bad (:id t)))))))
+      (let [tags (:tags (first @warns))]
+        (is (= "reg-event-db" (:reg-fn tags)))
+        (is (= :test.bbea.cljs/db-bad (:id tags)))))))
 
 (deftest reg-event-fx-warns-on-meta-interceptors
   (let [warns (collect-warnings ::fx-warn)]

--- a/implementation/adapters/reagent/test/re_frame/init_resolver_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/init_resolver_cljs_test.cljs
@@ -21,12 +21,12 @@
 ;; make-reset-runtime-fixture here — it pre-installs an adapter for us, and
 ;; the unit under test IS init!.
 
-(defn cold-start [test-fn]
+(defn- cold-start-fixture [test-fn]
   (adapter/dispose-adapter!)
   (test-fn)
   (adapter/dispose-adapter!))
 
-(use-fixtures :each cold-start)
+(use-fixtures :each cold-start-fixture)
 
 ;; ---- tests ----------------------------------------------------------------
 


### PR DESCRIPTION
Naming-best-practice audit (rf2-5r7eh) for the **stock** Reagent adapter slice (`implementation/adapters/reagent/`). Sibling `reagent-slim/` is a separate audit (rf2-0g6t1) and is NOT touched here.

The slice was in excellent shape — `src/` (96 lines), `testbed/`, `deps.edn`, and 35 of 38 test files audited as KEEP. This PR carries four small inline renames in three test files; all file-local, no public surface change.

## Renames

- `mk-fake-root` -> `make-fake-root` (`adapter_render_cljs_test.cljs`)
  Aligns with the wider `make-X` convention used across the slice (`make-source`, `make-mount-node!`, `make-frame`, `make-reaction`). 4 occurrences updated.

- `cold-start` -> `cold-start-fixture`, `defn` -> `defn-` (`init_resolver_cljs_test.cljs`)
  Only used via `(use-fixtures :each cold-start)` — should be private. The `-fixture` suffix matches the test-support convention (`make-reset-runtime-fixture`).

- `fresh-reagent` -> `cold-start-fixture`, `defn` -> `defn-` (`dispose_adapter_sub_cache_walk_cljs_test.cljs`)
  Same shape as above; the docstring already says "Cold-start". Picking the same name as #2 is fine — both are file-local.

- `a` -> `recorded`, `t` -> `tags` (`events_cljs_test.cljs` let-bindings)
  Bare `a` / `t` were stubs hiding the role. `recorded` matches the verb used by the other trace-collector helpers in the slice; `tags` reads as documentation in the subsequent `(:reg-fn tags)` / `(:id tags)` calls.

## Follow-on bead filed

**rf2-64iuw** — file-local divergence across nine test files for the same trace-recorder pattern (`collect-` vs `record-` verb, `!` suffix presence, return-shape divergence). The right fix is consolidation into a shared `re-frame.test-support/with-trace-recorder!` helper, not per-file rename — and the consolidation reaches into sibling adapter slices, beyond the rf2-5r7eh mandate. Linked to rf2-5r7eh via `bd dep relate`.

## Quality gates

- `cd implementation/adapters/reagent && clojure -M:test` — **0 tests / 0 errors** (slice has only CLJS tests; JVM gate is vacuous-pass by design)
- `clj-kondo --lint implementation/adapters/reagent/src implementation/adapters/reagent/test` — **0 errors**, 21 pre-existing warnings (none introduced by this PR; the renames do not touch any kondo-flagged surface)
- CLJS tests (`npm run test:cljs`) — **not run** in worker worktree (no `node_modules`). The renames are purely local-symbol scope (`defn-` for file-scope private helpers, `let`-bindings inside the same expression); no compilation risk. Will be exercised by the merge-queue CI's CLJS gate.

## Findings

The findings doc lives in the worker worktree at `ai/findings/naming-audit-implementation-adapters-reagent.md` (local-only, gitignored per the Mayor Method tree). Summary in the bead.
