### PR TITLE
refactor(adapters/uix): inline naming-clarity renames (rf2-ze5n1)

### DIFF
--- a/implementation/adapters/uix/test/re_frame/adapter/uix_frame_provider_branches_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_frame_provider_branches_cljs_test.cljs
@@ -102,9 +102,11 @@
   (testing "rf2-9i2du: a sequential :children vector flows through the
             spine's coercion branch unchanged — multiple children are
             handed to the Provider as separate args."
-    (let [a :child-a
-          b :child-b
-          el (uix-adapter/frame-provider {:frame :session :children [a b]})]
+    ;; The :child-a / :child-b keywords act as visible sentinels for the
+    ;; two children slots — inlined (no `a` / `b` aliases) so the call
+    ;; site reads as documentation.
+    (let [el (uix-adapter/frame-provider {:frame    :session
+                                          :children [:child-a :child-b]})]
       (is (some? el))
       (is (= :session (provider-element-frame-kw el)))
       (let [kids (provider-element-children el)]


### PR DESCRIPTION
## Summary

P3 Shape-1 naming-audit pass on `implementation/adapters/uix` (rf2-ze5n1) — one of 33 distinct surfaces in the naming-audit wave.

Inline rename: in `uix_frame_provider_branches_cljs_test.cljs/frame-provider-sequential-children-preserved`, dropped the `a :child-a` / `b :child-b` let aliases and inlined the keyword sentinels at the call site. The keywords now act as visible role markers; removing the aliases removes a layer of indirection so the test body reads as documentation.

## Audit verdicts roll-up

- KEEP: 41 entities (public ns + 8 public defs + deps.edn lib coord + every test ns + every deftest + every helper + the testbed component / atoms / locators)
- RENAME-INLINE: 1 (this PR)
- RENAME-NEEDS-FOLLOWUP: 0

Public surface (`re-frame.adapter.uix/` — `set-hiccup-emitter!`, `use-current-frame`, `frame-provider`, `use-subscribe`, `flush-views!`, `wrap-view`, `clear-warned-non-dom-roots!`, `adapter`) is fully spec-anchored and sibling-parallel against Helix. Test surface is byte-parallel against the Helix sibling modulo `-uix` / `-helix` substrate suffixes where needed for cross-substrate disambiguation.

Findings doc (local-only, gitignored): `ai/findings/naming-audit-implementation-adapters-uix.md`.

## Follow-on bead suggestion (filed below, not in this PR)

The Helix sibling test file is named `helix_frame_provider_children_cljs_test.cljs` while UIx's is `uix_frame_provider_branches_cljs_test.cljs`. Both files actually test the same two branch categories (nil-/missing-`:frame` AND single-vs-sequential `:children`). "branches" is the more accurate name; UIx already carries it. Suggested follow-on: rename the Helix file/ns/deftests after the Helix sibling audit (rf2-uqlce) lands. Low priority.

## Quality gates

- `cd implementation/adapters/uix && clojure -M:test` — classpath-probe alias only; `Ran 0 tests`; classpath OK
- `clj-kondo --lint implementation/adapters/uix/{src,test,testbed}` — 0 errors, 0 warnings
- `cd implementation && npm run test:cljs` — `Ran 4845 tests containing 15891 assertions. 0 failures, 0 errors.`

Closes rf2-ze5n1.