### PR TITLE
refactor(ssr): inline naming-clarity renames (rf2-ngtxv)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr/response.cljc
+++ b/implementation/ssr/src/re_frame/ssr/response.cljc
@@ -237,7 +237,7 @@
    :cookies  []
    :redirect nil})
 
-(defn ensure-response
+(defn- ensure-response
   "Return resp with defaults applied. nil-tolerant — a frame whose slot
   has never been touched by an :rf.server/* fx still resolves to the
   default response shape."

--- a/implementation/ssr/src/re_frame/ssr/streaming.cljc
+++ b/implementation/ssr/src/re_frame/ssr/streaming.cljc
@@ -228,7 +228,7 @@
 ;; A specialised emitter that recognises `:rf/suspense-boundary` and emits
 ;; a placeholder + records a continuation instead of recursing into the
 ;; subtree. Everything else is delegated to the standard emitter via the
-;; recursive `walk` helper.
+;; recursive `walk-shell` helper.
 ;;
 ;; The walker is intentionally a sibling of `emit/emit-element` rather
 ;; than a drop-in replacement — non-streaming consumers should not pay
@@ -237,7 +237,7 @@
 ;; children of standard elements to find nested boundaries; the
 ;; non-streaming emitter is a pure right-fold over strings).
 
-(declare walk)
+(declare walk-shell)
 
 ;; Per rf2-muasb (perf-sweep H2, ai/findings/perf-sweep-2026-05-15.md):
 ;; the prior implementation called `(some-suspense-boundary? el)` —
@@ -260,7 +260,7 @@
 ;; cost the audit calls out.
 
 (defn- walk-children [children acc]
-  (clojure.string/join (mapv #(walk % acc) children)))
+  (clojure.string/join (mapv #(walk-shell % acc) children)))
 
 (defn- walk-dom-tag
   "Emit a DOM tag element while recursing into its children with the
@@ -329,10 +329,15 @@
       (record-continuation! acc id subtree fallback)
       (fallback-template id fallback-html))))
 
-(defn walk
+(defn- walk-shell
   "Walk a hiccup form, building shell HTML and recording continuation
   entries in `acc` (an atom of vector). Standard hiccup is delegated to
-  `emit-element`; the suspense-boundary head is intercepted."
+  `emit-element`; the suspense-boundary head is intercepted.
+
+  Private — the streaming module's recursive shell walker. The public
+  entry point is `render-shell` (below), which binds the per-render
+  parse-tag-name memo and the continuations accumulator before invoking
+  this fn on the root hiccup."
   [el acc]
   (cond
     (and (vector? el)
@@ -374,7 +379,7 @@
                 out   (if coord
                         (emit/inject-coord-on-root-hiccup coord raw)
                         raw)]
-            (walk out acc))
+            (walk-shell out acc))
           ;; DOM tag — always recurse via `walk-dom-tag` so nested
           ;; suspense-boundaries are reachable. Per rf2-muasb the
           ;; prior `some-suspense-boundary?` pre-scan was a perf
@@ -384,7 +389,7 @@
 
     (and (vector? el) (fn? (first el)))
     ;; fn-headed component — invoke + recurse on the body.
-    (walk (apply (first el) (rest el)) acc)
+    (walk-shell (apply (first el) (rest el)) acc)
 
     (sequential? el)
     (walk-children el acc)
@@ -419,7 +424,7 @@
   ;; duration of `render-shell`.
   (binding [emit/*tag-name-cache* (volatile! {})]
     (let [acc       (new-continuations-acc)
-          shell     (walk root-hiccup acc)
+          shell     (walk-shell root-hiccup acc)
           conts     (dedupe-continuations @acc)]
       {:shell-html shell
        :continuations conts})))


### PR DESCRIPTION
Naming-best-practice audit for `implementation/ssr` (rf2-ngtxv — one of the 33-bead audit wave). Pre-alpha posture: ELEGANCE + CLARITY + CORRECTNESS + GOOD PRACTICE. No back-compat shims.

## Verdict

The ssr slice is masterpiece-quality on the naming dimension — spec-aligned (Spec 011 vocabulary verbatim), family-consistent (`hydrate` / `render-hash` / `server-hash` / `head-snapshot` / `:rf/suspense-boundary` all wire-shape-pinned), predicates+side-effects marked correctly, no orphan / vague filenames.

Two clean inline renames applied; no public-surface follow-ons required. Mike-pending items rf2-f4sxg (`^:private` façade re-exports) and rf2-f4j8x (`:rf/hydration` root) untouched per the dispatch brief.

## Inline renames

### 1. `re-frame.ssr.streaming/walk` -> `walk-shell` + made `defn-`

Bare `walk` was forward-declared (capture-collision risk vs `clojure.walk`) and internal-only. Every neighbour walker in the file already follows the `walk-<kind>` family (`walk-children`, `walk-dom-tag`, `walk-suspense-boundary`). Renamed to align + demoted to `defn-` (no external `streaming/walk` references in the codebase).

### 2. `re-frame.ssr.response/ensure-response` made `defn-`

Visibility-only. Consumed exclusively by `swap-response!` and `response-of` in the same file. No external references in `implementation/`, `tools/`, `examples/`, `tests/`, or `skills/`.

## Findings doc

`ai/findings/naming-audit-implementation-ssr.md` (local-only, gitignored) catalogues the full audit:

- Every named entity reviewed (KEEP / RENAME-INLINE / RENAME-FOLLOWUP / NOTE).
- Spec-vocabulary alignment table (no drift observed).
- Cross-slice consistency check (`frame-id`, `head-*` family, `payload-*` family, the five-layer hash family all clean).
- Notes on the two pre-existing `clj-kondo` reader-conditional false positives (not actioned — clj-kondo limitation, source IS correct).

## Quality gates

- `cd implementation/ssr && clojure -M:test` — **238 tests / 818 assertions / 0 failures, 0 errors.**
- `cd implementation/ssr-ring && clojure -M:test` — **76 tests / 364 assertions / 0 failures, 0 errors.** (Downstream artefact unaffected.)
- `clj-kondo --lint implementation/ssr/src` — **0 errors / 8 warnings, identical to baseline.** Six known `^:private` façade-re-export warnings tracked by Mike-pending rf2-f4sxg; two reader-conditional false positives noted in the findings doc.

## Closes

rf2-ngtxv.