### PR TITLE
refactor(adapters/reagent-slim): inline naming-clarity renames (rf2-0g6t1)

### DIFF
--- a/implementation/adapters/reagent-slim/src/reagent2/dom/server.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/dom/server.cljs
@@ -328,18 +328,18 @@
   React-element path uses) — both artefacts ship in the same bundle,
   so deduplicating avoids drift on the keyword/coll/string handling."
   [parsed user-attrs]
-  (let [id      (.-id parsed)
-        s-class (.-className parsed)
-        u-class-raw (or (:class user-attrs) (:className user-attrs))
-        merged  (template/class-names s-class u-class-raw)
-        base    (cond-> (or user-attrs {})
-                  ;; Drop :className duplicate; we collapse into :class.
-                  (contains? user-attrs :className) (dissoc :className))
-        with-id (if (and id (not (:id base)))
-                  (assoc base :id id)
-                  base)]
+  (let [id              (.-id parsed)
+        shorthand-class (.-className parsed)
+        user-class      (or (:class user-attrs) (:className user-attrs))
+        merged-class    (template/class-names shorthand-class user-class)
+        base            (cond-> (or user-attrs {})
+                          ;; Drop :className duplicate; we collapse into :class.
+                          (contains? user-attrs :className) (dissoc :className))
+        with-id         (if (and id (not (:id base)))
+                          (assoc base :id id)
+                          base)]
     (cond-> with-id
-      merged (assoc :class merged))))
+      merged-class (assoc :class merged-class))))
 
 ;; ---------------------------------------------------------------------------
 ;; Element emission

--- a/implementation/adapters/reagent-slim/src/reagent2/impl/component.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/component.cljs
@@ -457,17 +457,17 @@
       (copy-argv-from-props! this (.-props this))
       (binding [*current-component* this]
         (batching/mark-rendered this)
-        (let [^js rea (.-cljsRenderRea this)
-              hiccup (if (nil? rea)
-                       (let [^js r (ratom/make-reaction
-                                     #(wrap-render this render-fn)
-                                     :auto-run
-                                     (fn [_r]
-                                       (batching/queue-render! this)))]
-                         (set! (.-cljsRenderRea this) r)
-                         @r)
+        (let [^js cached-rea (.-cljsRenderRea this)
+              hiccup (if (nil? cached-rea)
+                       (let [^js new-rea (ratom/make-reaction
+                                           #(wrap-render this render-fn)
+                                           :auto-run
+                                           (fn [_changed-rea]
+                                             (batching/queue-render! this)))]
+                         (set! (.-cljsRenderRea this) new-rea)
+                         @new-rea)
                        ;; ._run re-captures deps AND produces fresh hiccup.
-                       (._run rea false))]
+                       (._run cached-rea false))]
           (->react-element hiccup))))))
 
 (defn create-class*

--- a/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
@@ -260,7 +260,7 @@
                     " call (name v) at the call site;"
                     " otherwise the keyword is preserved (rf2-6hyy §7.2 D2)."))))))
 
-(defn- ^boolean named?* [x]
+(defn- ^boolean named? [x]
   (or (keyword? x) (symbol? x)))
 
 (defn- ^boolean js-val? [x]
@@ -321,7 +321,7 @@
    ;; CSS prop name, not an HTML attr.
    (cond
      (js-val? v)  v
-     (named?* v)  (name v)         ; nested map values: stringify (CSS values)
+     (named? v)  (name v)         ; nested map values: stringify (CSS values)
      (map? v)     (reduce-kv kv-conv #js {} v)
      (coll? v)    (clj->js v)
      (fn? v)      v                ; pass through — preserves identity
@@ -330,7 +330,7 @@
   ([k v]
    (cond
      (js-val? v)  v
-     (named?* v)  (if (html-attr-name? k)
+     (named? v)  (if (html-attr-name? k)
                     (name v)
                     (do
                       (when ^boolean js/goog.DEBUG
@@ -367,11 +367,11 @@
    (if (coll? class)
      (let [classes (keep (fn [c]
                            (when c
-                             (if (named?* c) (name c) c)))
+                             (if (named? c) (name c) c)))
                          class)]
        (when (seq classes)
          (str/join " " classes)))
-     (if (named?* class)
+     (if (named? class)
        (name class)
        class)))
   ([a b]
@@ -721,7 +721,7 @@
     (js-val? x)     x
     (vector? x)     (vec-to-elem x)
     (seq? x)        (expand-seq x)
-    (named?* x)     (name x)
+    (named? x)     (name x)
     (satisfies? IPrintWithWriter x) (pr-str x)
     :else           x))
 

--- a/implementation/adapters/reagent-slim/src/reagent2/ratom.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/ratom.cljs
@@ -135,8 +135,8 @@
           (f k this old new))
         (recur (+ 2 i))))))
 
-(defn- pr-atom [a writer opts s v]
-  (-write writer (str "#object[reagent2.ratom." s " "))
+(defn- pr-atom [a writer opts type-tag body]
+  (-write writer (str "#object[reagent2.ratom." type-tag " "))
   ;; `pr-writer` is marked private in cljs.core but is the documented
   ;; entrypoint for nested `IPrintWithWriter` dispatch (every reagent2
   ;; ratom's `-pr-writer` delegates to it for the value's recursive
@@ -144,7 +144,7 @@
   ;; API contract — silence kondo's private-call check at the one
   ;; call site rather than blanket-excluding the linter.
   #_:clj-kondo/ignore
-  (pr-writer (binding [*ratom-context* nil] v) writer opts)
+  (pr-writer (binding [*ratom-context* nil] body) writer opts)
   (-write writer "]"))
 
 ;; ---------------------------------------------------------------------------


### PR DESCRIPTION
Shape-1 solo P3 naming audit for `implementation/adapters/reagent-slim/` (rf2-0g6t1).

The slice is the day8/reagent-slim React-19-ready slim Reagent rewrite — own `reagent2.*` ns tree plus the substrate adapter `re-frame.adapter.reagent-slim`. Public surface is heavily pinned by IMPL-SPEC §2.1-§2.4 + DECISION-4; renames here are confined to private symbols + local bindings.

## Renames

1. `reagent2.impl.template/named?*` → `named?` — removed gratuitous trailing star (no `named?` to disambiguate against). 6 call sites in the same ns.
2. `reagent2.ratom/pr-atom` params: `s` → `type-tag`, `v` → `body` — two single-character names spelled out for clarity.
3. `reagent2.impl.component/make-render-method` inner Reaction bindings: `rea`/`r`/`_r` → `cached-rea`/`new-rea`/`_changed-rea` — lifecycle made self-documenting at the binding site.
4. `reagent2.dom.server/merge-shorthand` bindings: `s-class` → `shorthand-class`, `u-class-raw` → `user-class`, `merged` → `merged-class` — full words; aligns with `class-names` helper they delegate to.

No public surface touched. No follow-on beads needed — the audit found the slice's public naming already strong (DECISION-4 `reagent2.*` ns, audit-binding 14 surfaces, `do-*` / `cap-keys` / `IReactiveAtom` / `IDisposable` all pinned by spec and consistently applied across src + tests). Findings doc at `ai/findings/naming-audit-implementation-adapters-reagent-slim.md` (local-only).

Pre-alpha posture honoured: outright renames, no shims.

## Quality gates

- `cd implementation/adapters/reagent-slim && clojure -M:test` → 11 tests, 12 assertions, 0 failures, 0 errors.
- `clj-kondo --lint implementation/adapters/reagent-slim/{src,test}` → 0 errors, 11 warnings (all pre-existing; none introduced).
- `npm run test:cljs` → 4845 tests, 15891 assertions, 0 failures, 0 errors.
- `npm run test:reagent-slim:bundle-isolation` → PASS (3 contracts, 19 sentinel checks). Bundle isolation discipline preserved — the slim adapter still names no stock `reagent.*` symbols.