### PR TITLE
docs(skills/pair-retro): naming-clarity edits (rf2-il18u)

### DIFF
--- a/skills/re-frame2-pair-retro/.claude-plugin/plugin.json
+++ b/skills/re-frame2-pair-retro/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "re-frame2-pair-retro",
   "version": "0.1.0-alpha.1",
-  "description": "Review a re-frame2-pair session, identify workflow friction, and propose improvements or bead drafts.",
+  "description": "Review a re-frame2-pair session, identify workflow friction, and propose improvements or GitHub-issue drafts.",
   "skills": [
     "./SKILL.md"
   ],

--- a/skills/re-frame2-pair-retro/agents/openai.yaml
+++ b/skills/re-frame2-pair-retro/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "re-frame2-pair retro"
   short_description: "Retrospect on a re-frame2-pair session and surface friction."
-  default_prompt: "Use $re-frame2-pair-retro to review this session, identify where re-frame2-pair made the workflow harder than it should have been, and propose concrete improvements before drafting any bead."
+  default_prompt: "Use $re-frame2-pair-retro to review this session, identify where re-frame2-pair made the workflow harder than it should have been, and propose concrete improvements before drafting any GitHub issue."

--- a/skills/re-frame2-pair-retro/evals/evals.json
+++ b/skills/re-frame2-pair-retro/evals/evals.json
@@ -6,11 +6,11 @@
  "evals": [
  {"id": 1, "name": "explicit-retro", "should_trigger": true, "prompt": "Retro on this re-frame2-pair session: I spent 20 minutes debugging why discover-app refused to attach. Multiple retries, same :reason :runtime-not-preloaded each time."},
  {"id": 2, "name": "review-pair-session", "should_trigger": true, "prompt": "Review my re-frame2-pair session from the last hour. What took longer than it should have?"},
- {"id": 3, "name": "draft-bead", "should_trigger": true, "prompt": "Draft a bead for the friction I just hit with re-frame2-pair — restore-epoch returned :ok but the UI didn't actually update."},
+ {"id": 3, "name": "draft-issue", "should_trigger": true, "prompt": "Draft a GitHub issue for the friction I just hit with re-frame2-pair — restore-epoch returned :ok but the UI didn't actually update."},
  {"id": 4, "name": "post-error-postmortem", "should_trigger": true, "prompt": "We just got a hard error from re-frame2-pair's eval-cljs and the session crashed. Walk me through what went wrong."},
  {"id": 5, "name": "session-recap", "should_trigger": true, "prompt": "Here's a recap of a re-frame2-pair session: <recap>. What friction patterns do you see and what improvements would you propose?"},
  {"id": 6, "name": "should-pair-absorb", "should_trigger": true, "prompt": "Which parts of this re-frame2-pair workflow should the pair tool itself absorb?"},
- {"id": 7, "name": "upstream-framework", "should_trigger": true, "prompt": "I think the friction in this re-frame2-pair session is actually a re-frame2 framework gap, not a pair-tool gap. Where would I file an upstream bead?"},
+ {"id": 7, "name": "upstream-framework", "should_trigger": true, "prompt": "I think the friction in this re-frame2-pair session is actually a re-frame2 framework gap, not a pair-tool gap. Where would I file an upstream GitHub issue?"},
  {"id": 8, "name": "retro-five-rounds", "should_trigger": true, "prompt": "I just finished pairing with Claude on a re-frame2 bug for five rounds. Retro on the session — what wasted effort can we shave?"},
  {"id": 17, "name": "post-error-onerror-postmortem", "should_trigger": true, "prompt": "That re-frame2-pair session just ended after the frame's :on-error policy fired and the cascade halted. Now that the dust has settled, post-mortem the firefight — what could re-frame2-pair have done to make that error easier to handle?"},
  {"id": 18, "name": "post-error-restore-failed", "should_trigger": true, "prompt": "We're done debugging — restore-epoch kept failing with :rf.epoch/restore-version-mismatch for ten minutes during that re-frame2-pair session. Retro the post-error scramble and tell me where the friction was."},


### PR DESCRIPTION
Naming-best-practice audit for skills/re-frame2-pair-retro (bead rf2-il18u). Operator-facing skill bundle — Causa/Pair-adjacent.

## Findings

The skill's design (spec/design.md §L3) is explicit:

> *"bd (beads) is the re-frame2 monorepo's internal tracker and is never invoked from a published skill."*

And SKILL.md §Guard-rails restates it:

> *"**Tracker boundary — file GitHub issues, never bd beads.** bd is the re-frame2 monorepo's internal tracker; skills consumed downstream file against the target repo's GitHub issues via gh issue create."*

But four downstream-operator-facing strings still leaked the internal `bead` vocabulary:

1. `.claude-plugin/plugin.json` description: `"…propose improvements or bead drafts."`
2. `agents/openai.yaml` default_prompt: `"…drafting any bead."`
3. `evals/evals.json` id 3: eval name `"draft-bead"` + prompt `"Draft a bead for the friction…"`
4. `evals/evals.json` id 7: prompt `"…file an upstream bead?"`

These are exactly the surfaces a downstream operator (outside the monorepo) reads — they don't run bd and don't know the term. The eval prompts also train the skill-creator's description-optimisation loop, so wrong-vocabulary prompts pollute the trigger surface.

Sibling re-frame2-pair (PR #2358, rf2-lrtf7) carries **zero** bead mentions in its three equivalent operator-facing surfaces — verified. After this PR re-frame2-pair-retro is in lockstep with the sibling and the shared skills/shared/issue-filing.md recipe.

## Renames (4 occurrences across 3 files)

| File | Before | After |
|------|--------|-------|
| `.claude-plugin/plugin.json` | `bead drafts` | `GitHub-issue drafts` |
| `agents/openai.yaml` | `drafting any bead` | `drafting any GitHub issue` |
| `evals/evals.json` id 3 | name `draft-bead` + `Draft a bead` | name `draft-issue` + `Draft a GitHub issue` |
| `evals/evals.json` id 7 | `file an upstream bead?` | `file an upstream GitHub issue?` |

No CLJS public-surface name changed. No anchor slug change. No reference-leaf rename. No frontmatter `name` change. No README change.

## What stayed

- Pair2 shorthand: **zero hits**. Already canonical (consistent with sibling rf2-lrtf7 outcome).
- Internal bd mentions in pedagogical contrast clauses (SKILL.md §Guard-rails, design.md §L3, issue-template.md §Filing-rules, shared/issue-filing.md): KEEP — they're teaching the boundary, not invoking the tracker.
- rf2-XXXX ids in user-facing skill content: verified zero (the only matches are the data-rf2-source-coord HTML attribute, a re-frame2 contract surface).
- Frontmatter name / description / allowed-tools: KEEP — all canonical.
- All references/*.md filenames + headings: KEEP — domain-correct.
- All spec/*.md filenames: KEEP — standard sibling convention.
- Bundle dir name, SKILL.md heading structure: KEEP.

Findings doc at `ai/findings/naming-audit-skills-re-frame2-pair-retro.md` (local-only / gitignored).

## Quality gates

- `python -m mkdocs build --strict` — pass (only INFO messages from unrelated docs).
- `python scripts/check_doc_slugs.py` — pass (exit 0).
- `python scripts/check_readme_links.py` — pass (exit 0).
- JSON validation on `.claude-plugin/plugin.json` + `evals/evals.json` — pass.
- YAML validation on `agents/openai.yaml` — pass.

## Posture

Pre-alpha; pure clarity wins. No back-compat shims. ELEGANCE (vocabulary lockstep with sibling) + CLARITY (downstream operators see correct vocab) + CORRECTNESS (L3 lock honoured at every operator-facing surface) + GOOD PRACTICE (single vocabulary across the skill family).