### PR TITLE
refactor(examples/reagent): naming-clarity edits (rf2-7ygrz)

### DIFF
--- a/examples/reagent/seven_guis/cells/core.cljs
+++ b/examples/reagent/seven_guis/cells/core.cljs
@@ -33,13 +33,21 @@
             [clojure.string :as str])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
-(def COLS 26)
-(def ROWS 100)
-(def CELL-RE #"^[A-Z]\d{1,2}$")
+(def cols
+  "Number of spreadsheet columns (A..Z)."
+  26)
+
+(def rows
+  "Number of spreadsheet rows (1..100)."
+  100)
+
+(def cell-re
+  "Cell-id regex — one capital letter + 1-2 digits (e.g. A1, Z99)."
+  #"^[A-Z]\d{1,2}$")
 
 (defn cell-id [col row] (str (char (+ 65 col)) row))
 (defn parse-cell-id [s]
-  (when (re-matches CELL-RE s)
+  (when (re-matches cell-re s)
     [(- (int (.charAt s 0)) 65) (js/parseInt (subs s 1))]))
 
 ;; ============================================================================
@@ -94,7 +102,7 @@
         (let [num (js/parseFloat t)]
           (cond
             (not (js/isNaN num))           [num                             more]
-            (re-matches CELL-RE t)         [{:cell t}                       more]
+            (re-matches cell-re t)         [{:cell t}                       more]
             (#{"+" "-" "*" "/"} t)         [(symbol t)                      more]
             :else                          (throw (ex-info "Bad atom" {:token t}))))))))
 
@@ -245,12 +253,12 @@
 
 (reg-view cells-grid []
   [:table.cells-grid
-   [:thead [:tr [:th] (for [c (range COLS)] ^{:key c} [:th (char (+ 65 c))])]]
+   [:thead [:tr [:th] (for [c (range cols)] ^{:key c} [:th (char (+ 65 c))])]]
    [:tbody
-    (for [r (range 1 (inc ROWS))]
+    (for [r (range 1 (inc rows))]
       ^{:key r}
       [:tr [:th r]
-       (for [c (range COLS)]
+       (for [c (range cols)]
          ^{:key c}
          [cell-view (cell-id c r)])])]])
 

--- a/examples/reagent/seven_guis/timer/core.cljs
+++ b/examples/reagent/seven_guis/timer/core.cljs
@@ -30,7 +30,11 @@
             [re-frame.adapter.reagent-slim :as reagent-slim-adapter])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
-(def TICK-MS 100)
+(def tick-ms
+  "Wall-clock delay between successive timer ticks. Kebab-case per the
+   sibling `examples/reagent/long_running_work` convention; the
+   SCREAMING-CASE here was a v1 holdover."
+  100)
 
 ;; ============================================================================
 ;; SCHEMA
@@ -71,7 +75,7 @@
                            :duration-ms  10000
                            :tick-active? true
                            :tick-gen     0})
-     :fx [[:dispatch-later {:ms TICK-MS :event [:timer/tick 0]}]]}))
+     :fx [[:dispatch-later {:ms tick-ms :event [:timer/tick 0]}]]}))
 
 (rf/reg-event-fx :timer/tick
   {:doc "Advance elapsed by one tick. Schedules the next tick if still ticking.
@@ -81,12 +85,12 @@
       (if (not= gen tick-gen)
         ;; Stale tick from a retired generation (Reset bumped :tick-gen). Drop it.
         {}
-        (let [next-elapsed (min (+ elapsed-ms TICK-MS) duration-ms)
+        (let [next-elapsed (min (+ elapsed-ms tick-ms) duration-ms)
               done?        (>= next-elapsed duration-ms)]
           (cond-> {:db (assoc-in db [:timer :elapsed-ms] next-elapsed)}
             ;; Continue ticking while not done and tick still active.
             (and tick-active? (not done?))
-            (assoc :fx [[:dispatch-later {:ms TICK-MS :event [:timer/tick gen]}]])))))))
+            (assoc :fx [[:dispatch-later {:ms tick-ms :event [:timer/tick gen]}]])))))))
 
 (rf/reg-event-db :timer/set-duration
   {:doc "User dragged the slider."
@@ -103,7 +107,7 @@
                (assoc-in [:timer :elapsed-ms]   0)
                (assoc-in [:timer :tick-active?] true)
                (assoc-in [:timer :tick-gen]     next-gen))
-       :fx [[:dispatch-later {:ms TICK-MS :event [:timer/tick next-gen]}]]})))
+       :fx [[:dispatch-later {:ms tick-ms :event [:timer/tick next-gen]}]]})))
 
 ;; ============================================================================
 ;; SUBSCRIPTIONS


### PR DESCRIPTION
Shape-1 solo Mayor-Method worker output for **rf2-7ygrz** — naming
best-practice audit for `examples/reagent/`.

## Audit scope

Every CLJS / CLJC source file under `examples/reagent/` (18 examples
total counting each 7GUIs task: boot, counter, counter_slim_and_fast,
flows, login, long_running_work, managed_http_counter, nine_states,
notebook, realworld, routing, seven_guis/{cells,circle_drawer,crud,
flight_booker,temperature,timer}, ssr, ssr_streaming,
state_machine_walkthrough, todomvc, websocket).

Per Mike's rf2-vt9tn note, snapshot-read idioms
(`[:rf/runtime :machines :snapshots :<id> ...]` vs `:<- [:rf/machine
id]`) were deliberately untouched — that polish is a separate
decision.

## Inline renames applied

The seven_guis/timer and seven_guis/cells examples were the only
places under examples/reagent/ using SCREAMING-CASE for top-level
constants — a v1 holdover. Every sibling (long_running_work,
nine_states, websocket, etc.) uses kebab-case for the equivalent
shape, and Clojure's idiomatic constant style is kebab-case.

| Old           | New           | File                                   |
|---------------|---------------|----------------------------------------|
| `TICK-MS`     | `tick-ms`     | `seven_guis/timer/core.cljs`           |
| `COLS`        | `cols`        | `seven_guis/cells/core.cljs`           |
| `ROWS`        | `rows`        | `seven_guis/cells/core.cljs`           |
| `CELL-RE`     | `cell-re`     | `seven_guis/cells/core.cljs`           |

All four constants are private to their owning ns; no external
references (verified via repo-wide `git grep`). Each rename also
picks up a docstring so the intent reads off the source instead of
relying on capitalisation to signal "constant".

## Verdicts — full table in findings doc

Every other example reviewed got **KEEP**. The findings doc at
`ai/findings/naming-audit-examples-reagent.md` (local-only)
catalogues:

- the per-example verdicts with reasoning,
- the cross-slice consistency check (the hypothetical
  `:cart/items` vs `:cart/lines` clash from the bead description
  does not exist),
- the realworld per-feature vocabulary catalogue (11 files,
  consistent prefix discipline across `:auth/*`, `:article/*` vs
  `:articles/*`, `:comments/*` vs `:comment-form/*` vs `:comment/*`,
  etc.),
- the rationale for keeping `todomvc`'s `:todo/showing` sub-name
  (v1-fidelity benchmark — the comparison value beats the
  cosmetic gain),
- the `:cart/items` slice vs `cart-line` view shape (two
  distinct domain concepts, not vocabulary drift).

## Follow-on beads needed

**None.** The two inline renames are private to their owning ns
and the audit found no public-surface renames worth filing.

## Quality gates

- `clj-kondo` on the two changed files: **0 errors, 0 warnings**.
- Examples are test-free per rf2-8cevm lock (no per-example
  spec.cjs touched, no per-example clojure -M:test).
- No external references to the renamed symbols (verified via
  repo-wide `git grep` across `implementation/`, `examples/`,
  `tools/`, `docs/`, `spec/`).
- Reagent adapter-level smoke at
  `implementation/adapters/reagent/testbed/spec.cjs` exercises
  only `counter` (the Reagent adapter smoke surface); neither
  `seven_guis/timer` nor `seven_guis/cells` is on the smoke path,
  so no smoke run was needed.

Closes rf2-7ygrz.