### PR TITLE
docs(skills/implementor): naming-clarity edits (rf2-df6ko)

### DIFF
--- a/skills/re-frame2-implementor/SKILL.md
+++ b/skills/re-frame2-implementor/SKILL.md
@@ -32,6 +32,8 @@ The job is to walk the engineer through two phases:
 1. **Phase 1** — lock the load-bearing decisions (target language, substrate, scope, identity primitive, persistent data, concurrency, schema mechanism, hot-reload).
 2. **Phase 2** — implement EPs in dependency order (001 → 002 → 006 → 004 → 009, then optional EPs per Phase 1 scope), validated by the conformance corpus.
 
+> **Term: EP.** Throughout this skill, "EP" abbreviates **Extension Point** — a numbered per-area Spec in the corpus at [`spec/`](../../spec/). EP 001 corresponds to [`spec/001-Registration.md`](../../spec/001-Registration.md), EP 002 to [`spec/002-Frames.md`](../../spec/002-Frames.md), and so on. The spec itself calls these "numbered Specs"; this skill uses "EP" as a compact shorthand because the walking order, dependency graph, and conformance-fixture families are all keyed off the numbers.
+
 ## When NOT to use this skill
 
 Full skill-disambiguation matrix lives at [`skills/README.md` §Skill routing — single source](../README.md#skill-routing--single-source). In brief: not for authoring on the CLJS reference, greenfield bootstrap, v1→v2 migration, live-app inspection, or pattern-rationale reading.

--- a/skills/re-frame2-implementor/references/phase-2-impl-order.md
+++ b/skills/re-frame2-implementor/references/phase-2-impl-order.md
@@ -7,7 +7,7 @@ The walking order is dependency-driven. Earlier EPs are foundations for later on
 **Three cross-cutting anchors to keep open for every EP below:**
 
 - [`spec/Ownership.md`](https://day8.github.io/re-frame2/spec/Ownership/) — the canonical "where does X live" contract-surface map. When an EP touches a surface and you're unsure which spec owns it, this is the index. Read it once before EP 001 and consult it per-EP.
-- [`spec/Conventions.md`](https://day8.github.io/re-frame2/spec/Conventions/) — the reserved `:rf/*` single-root namespace scheme, reserved fx-ids, reserved app-db keys, the `reg-*` macro inventory. Every framework id your port emits lands under `:rf/*`; honour the scheme from EP 001 onward (cardinal rule 11). Conformance fixtures assert `:rf.*` operation ids.
+- [`spec/Conventions.md`](https://day8.github.io/re-frame2/spec/Conventions/) — the reserved `:rf/*` single-root namespace scheme, reserved fx-ids, reserved app-db keys, the `reg-*` macro inventory. Every framework id your port emits lands under `:rf/*`; honour the scheme from EP 001 onward (cardinal rule 10). Conformance fixtures assert `:rf.*` operation ids.
 - [`spec/API.md`](https://day8.github.io/re-frame2/spec/API/) — the consolidated public signature list. Read the relevant entries first whenever an EP's "The contract" names a public surface (`reg-*`, `dispatch`, `subscribe`, the fx/cofx surface, …).
 
 ## Walking order


### PR DESCRIPTION
Two small clarity edits to `skills/re-frame2-implementor/` from the rf2-df6ko naming audit. Operator-facing audit per Mike's bead — pre-alpha masterpiece posture, no back-compat shims.

## Summary

**1. `SKILL.md` — define EP on first use.**
The skill uses `EP NNN` (Extension Point) shorthand 91 times across its operator-facing leaves, but the term is **never** expanded anywhere in the skill, and the re-frame2 spec corpus itself does not use the term at all — the spec says "numbered Spec" or refers to Specs by number only. A first-time operator hitting `EP 001` cold has no way to derive what `EP` means or that `EP NNN` maps to `spec/NNN-*.md`.

Added a one-line definition block in `SKILL.md` immediately after the two-phase summary. The shorthand stays (Mike's in-flight bead rf2-r3zc4 phrases its concerns as "EP 005 / EP 012" so the shorthand is the working vocabulary), but the term is now defined once at the surface a fresh session loads first.

**2. `references/phase-2-impl-order.md` — fix cardinal-rule numbering bug.**
`phase-2-impl-order.md` line 10 referenced "cardinal rule 11" but `cardinal-rules.md` carries exactly 10 rules; rule 10 is the `:rf/*` namespace scheme. Changed `11` -> `10`.

## What this PR deliberately does NOT touch

- **Bulk-renaming `EP` to `Spec`.** Would (a) preempt Mike's vocabulary choice as evidenced by rf2-r3zc4, and (b) increase confusability with "the spec corpus" framing the skill leans on heavily. The defined shorthand is the minimal-surprise fix.
- **The EP 012 description.** Mike-pending per rf2-r3zc4 — out of scope for this audit.
- **Filenames** (`cardinal-rules.md`, `conformance.md`, `decision-record.md`, `kickoff-prompt.md`, `output-format.md`, `phase-1-decisions.md`, `phase-2-impl-order.md`, `reference-impl-tour.md`) — all clear, operator-facing, single-purpose. KEEP.
- **Vocabulary tokens** (`substrate`, `port`, `adapter`, `frame`, `kind`, `drain`, `fixture`, `capability tag`, `implementor` spelling) — all spec-aligned. KEEP.
- **Anchor slugs** — none exist (no `<a id=>` tags); heading slugs match their headings.

Full findings (verdict + reasoning per surface) in the worker's local findings doc (`ai/findings/naming-audit-skills-re-frame2-implementor.md`; gitignored).

## Quality gates

- `mkdocs build --strict` — green (`Documentation built in 7.60 seconds`, no warnings)
- `python scripts/check_doc_slugs.py` — green (silent pass)
- `python scripts/check_readme_links.py` — green (silent pass)

## Closes

rf2-df6ko