### PR TITLE
refactor(examples/uix): naming-clarity edits (rf2-kcclu)

### DIFF
--- a/examples/uix/counter_uix/index.html
+++ b/examples/uix/counter_uix/index.html
@@ -7,7 +7,7 @@
   <meta name="theme-color" content="#1A1814">
   <meta name="description" content="re-frame2 worked example — examples for the modern Clojure framework.">
   <meta property="og:type" content="website">
-  <meta property="og:title" content="re-frame2 · UIx example">
+  <meta property="og:title" content="re-frame2 example: counter (UIx)">
   <meta property="og:description" content="re-frame2 worked example — examples for the modern Clojure framework.">
   <meta property="og:image" content="_shared/img/og.svg">
   <meta name="twitter:card" content="summary_large_image">

--- a/examples/uix/dashboard_uix/core.cljs
+++ b/examples/uix/dashboard_uix/core.cljs
@@ -82,8 +82,8 @@
             (fn [s] (if (contains? s tag) (disj s tag) (conj s tag))))))
 
 (rf/reg-event-db :dashboard/set-range
-  (fn [db [_ r]]
-    (assoc db :dashboard/range r)))
+  (fn [db [_ range-id]]
+    (assoc db :dashboard/range range-id)))
 
 ;; ============================================================================
 ;; SUBSCRIPTIONS
@@ -100,8 +100,8 @@
 
 (rf/reg-sub :dashboard/selected-range
   :<- [:dashboard/range]
-  (fn [r _]
-    (some #(when (= r (:id %)) %) ranges)))
+  (fn [range-id _]
+    (some #(when (= range-id (:id %)) %) ranges)))
 
 (rf/reg-sub :dashboard/visible-metrics
   ;; Two re-deriving inputs feed the visible card set: the active tag chips
@@ -110,10 +110,10 @@
   :<- [:dashboard/metrics]
   :<- [:dashboard/active-tags]
   :<- [:dashboard/selected-range]
-  (fn [[ms tags {:keys [points]}] _]
-    (->> ms
-         (filter #(contains? tags (:tag %)))
-         (map (fn [m] (update m :series #(vec (take-last points %))))))))
+  (fn [[metrics active-tags {:keys [points]}] _]
+    (->> metrics
+         (filter #(contains? active-tags (:tag %)))
+         (map (fn [metric] (update metric :series #(vec (take-last points %))))))))
 
 ;; ============================================================================
 ;; SPARKLINE PATH
@@ -121,7 +121,7 @@
 
 (defn- sparkline-path
   "Return an SVG <path> `d` string for the series, normalised into a
-   100×30 viewBox. Pure — used by `Sparkline` below.
+   100×30 viewBox. Pure — used by `sparkline` below.
 
    Why polyline-via-path: a single <path d=\"M…L…L…\"> renders crisper
    than <polyline> when the viewBox is small and the stroke is hair-thin
@@ -177,8 +177,8 @@
     (.toLocaleString value "en-US")
     (.toFixed value 2)))
 
-(defui metric-card [{:keys [m]}]
-  (let [{:keys [id label value unit delta tag series]} m
+(defui metric-card [{:keys [metric]}]
+  (let [{:keys [id label value unit delta tag series]} metric
         ;; `$` renders before the value (a prefix unit); `ms` / `%` render
         ;; after. The flag names the placement, decoupled from the tag.
         prefix-unit? (= "$" unit)
@@ -223,23 +223,23 @@
             label)))))
 
 (defui dashboard []
-  (let [visible    (uix-adapter/use-subscribe [:dashboard/visible-metrics])
-        sel-range  (uix-adapter/use-subscribe [:dashboard/selected-range])]
+  (let [visible-metrics (uix-adapter/use-subscribe [:dashboard/visible-metrics])
+        selected-range  (uix-adapter/use-subscribe [:dashboard/selected-range])]
     ($ :div.dash-shell
        ($ :header.dash-shell-head
           ($ :div
              ($ :h1 "Atlas")
              ($ :p.dash-tagline
                 {:data-testid "dashboard-range-label"}
-                (str "Last " (:label sel-range) " · ")
+                (str "Last " (:label selected-range) " · ")
                 ($ :span.dash-substrate-tag "UIx substrate")))
           ($ :div.dash-controls
              ($ range-picker)
              ($ filter-chips)))
        ($ :section.dash-grid
           {:data-testid "dashboard-grid"}
-          (for [m visible]
-            ($ metric-card {:key (:id m) :m m})))
+          (for [metric visible-metrics]
+            ($ metric-card {:key (:id metric) :metric metric})))
        ($ :footer.dash-shell-foot
           ($ :span "re-frame2 · examples/uix/dashboard_uix")))))
 

--- a/examples/uix/dashboard_uix/index.html
+++ b/examples/uix/dashboard_uix/index.html
@@ -7,7 +7,7 @@
   <meta name="theme-color" content="#1A1814">
   <meta name="description" content="re-frame2 worked example — examples for the modern Clojure framework.">
   <meta property="og:type" content="website">
-  <meta property="og:title" content="re-frame2 · UIx example">
+  <meta property="og:title" content="re-frame2 example: dashboard (UIx · design-led)">
   <meta property="og:description" content="re-frame2 worked example — examples for the modern Clojure framework.">
   <meta property="og:image" content="_shared/img/og.svg">
   <meta name="twitter:card" content="summary_large_image">

--- a/examples/uix/login_uix/index.html
+++ b/examples/uix/login_uix/index.html
@@ -7,7 +7,7 @@
   <meta name="theme-color" content="#1A1814">
   <meta name="description" content="re-frame2 worked example — examples for the modern Clojure framework.">
   <meta property="og:type" content="website">
-  <meta property="og:title" content="re-frame2 · UIx example">
+  <meta property="og:title" content="re-frame2 example: login (UIx)">
   <meta property="og:description" content="re-frame2 worked example — examples for the modern Clojure framework.">
   <meta property="og:image" content="_shared/img/og.svg">
   <meta name="twitter:card" content="summary_large_image">


### PR DESCRIPTION
Naming-best-practice audit for **examples/uix/** (bead rf2-kcclu) — one of the 33-surface audit wave.

## Scope

Three UIx-substrate worked examples:
- `counter_uix/` — UIx variant of the canonical counter
- `login_uix/` — UIx variant of the canonical login
- `dashboard_uix/` — UIx design-led "Atlas" analytics dashboard

Surface character: **didactic**. Cross-substrate parity with `examples/helix/*` and `examples/reagent/{counter,login}/` is a primary lens.

## What changed (inline, private surface only)

### `examples/uix/dashboard_uix/core.cljs`
- `:dashboard/set-range` handler: `[_ r]` → `[_ range-id]`
- `:dashboard/selected-range` sub fn: `(fn [r _] ...)` → `(fn [range-id _] ...)`
- `:dashboard/visible-metrics` sub fn:
  - `ms` → `metrics` (`ms` is a unit-collision hazard in a dashboard context — readers parse `ms` as milliseconds)
  - `tags` → `active-tags` (mirrors the upstream sub `:dashboard/active-tags`)
  - inner `m` → `metric`
- `metric-card` defui param `m` → `metric` (and the call site in `dashboard`)
- `dashboard` defui let-bindings: `visible` → `visible-metrics`, `sel-range` → `selected-range`
- `sparkline-path` docstring: ``used by `Sparkline` below`` → ``used by `sparkline` below`` (case match with the lowercase defui)

### `examples/uix/{counter_uix,login_uix,dashboard_uix}/index.html`
- `<meta property="og:title">` was a generic `re-frame2 · UIx example` for all three; now example-specific (`re-frame2 example: counter (UIx)`, etc.), mirroring the helix sibling pattern. Drift fix; `<title>` was already example-specific.

## What did NOT change (KEEP)

- **Folder + namespace names** (`counter_uix`, `login_uix`, `dashboard_uix` / `*-uix.core`): substrate suffix is intentional and documented in `examples/uix/README.md` — both substrate trees share the shadow-cljs classpath, so namespaces must be unique. Helix sibling follows the parallel `*_helix` / `*-helix.core` pattern.
- **Every event-id, sub-id, schema name, fx-id, machine-state, machine-tag**: zero public-surface renames. Cross-substrate parity with helix + reagent siblings is exact for the shared dataflow.
- **`count` shadowing `clojure.core/count`** in counter_uix: cross-sibling parity (helix sibling does the same); tight let, no `clojure.core/count` call in body.
- **Math-style abbreviations in `sparkline-path`** (`n`, `lo`, `hi`, `span`, `->x`, `->y`, `head`, `tail`): conventional in a tight geometry function; docstring documents the role.
- **`(fn [s] ...)` toggle-set lambdas**: cross-sibling idiom (helix `process_monitor_helix` uses the identical pattern).

## Findings doc

`ai/findings/naming-audit-examples-uix.md` (local-only / gitignored). Full per-entity verdict matrix with KEEP / RENAME-INLINE rationale + cross-slice consistency table.

## Follow-on beads

**None.** Every concern was either fixable inline as a private-surface edit or judged KEEP after cross-sibling analysis.

## Quality gates

- **clj-kondo** on changed files (`examples/uix/`): clean, 0 errors, 0 warnings.
- **Test surface**: examples are test-free per rf2-8cevm lock (`examples/README.md`). UIx adapter-level smoke at `implementation/adapters/uix/testbed/spec.cjs` covers regression for this substrate.
- **Public-surface integrity**: zero public-surface renames. No shadow-cljs build id, no event id, no sub id, no schema name, no namespace, no folder name changed. All cross-artefact references (`implementation/shadow-cljs.edn`, `spec/006`, `skills/`, `docs/`) remain valid.