### PR TITLE
docs(skills/improver): naming-clarity edits (rf2-yh7i0)

### DIFF
--- a/skills/re-frame2-improver/references/imperative-effects.md
+++ b/skills/re-frame2-improver/references/imperative-effects.md
@@ -21,7 +21,7 @@ The whole point of re-frame's data-driven loop is that handlers describe *what* 
 - **Testability** — the handler can no longer run under `dispatch-sync` against a JVM frame without a browser; tests need DOM mocks.
 - **Time-travel & replay** — Xray and re-frame2-pair restore through re-frame2's epoch surfaces; imperative side-effects inside handlers cannot be represented as data, so replay/restoration can double-write `localStorage` or refocus the wrong element.
 - **Server-side rendering** — Spec 011 SSR runs handlers on the server; `js/document` blows up.
-- **Instrumentation** — Spec 009's `:rf.fx/*` trace channel sees only what flows through `reg-fx`; imperative calls are invisible to the inspector, story, and pair-tool surfaces.
+- **Instrumentation** — Spec 009's `:rf.fx/*` trace channel sees only what flows through `reg-fx`; imperative calls are invisible to Xray, Story, and re-frame2-pair surfaces.
 - **`:platforms` gating** — [Spec 011 (SSR)](../../../spec/011-SSR.md) lets an fx declare `:platforms #{:client}`; an imperative side-effect inside a handler cannot be skipped on the server.
 
 A re-frame2 effect is data: a `[fx-id args]` pair. The runtime walks the `:fx` vector and dispatches to the registered handler.

--- a/skills/re-frame2-improver/references/view-side-hook-state.md
+++ b/skills/re-frame2-improver/references/view-side-hook-state.md
@@ -19,8 +19,8 @@ The re-frame2 mental model has one source of truth per frame: `app-db`. Subs pro
 
 - **Invisible to subs** — sibling components must `require` the view's namespace just to deref the atom, coupling otherwise-independent views.
 - **Invisible to events** — handlers cannot consult the value as part of their decision (they'd have to reach into the view module, breaking the data-flow direction).
-- **Invisible to tools** — Xray's panels and re-frame2-pair's `app-db` inspector/time-travel surfaces see only `app-db` plus the runtime trace/epoch surfaces. A view-side atom is dark to every diagnostic.
-- **Invisible to SSR / story / replay** — the story artefact serialises `app-db`; the view-atom is reconstructed only when the view mounts, and its value at render time is not what produced the snapshot.
+- **Invisible to tools** — Xray's tabs and re-frame2-pair's `app-db` reads + time-travel surfaces see only `app-db` plus the runtime trace/epoch surfaces. A view-side atom is dark to every diagnostic.
+- **Invisible to SSR / Story / replay** — the story artefact serialises `app-db`; the view-atom is reconstructed only when the view mounts, and its value at render time is not what produced the snapshot.
 - **Not testable** — `compute-sub` (and `dispatch-sync` + `get-frame-db` for events) operate on `app-db` values; a test for "what does the view show when state is X" requires mounting the view to set the atom.
 
 A `reagent/atom` is legitimate when its state is **render-local** — a hovered-over flag, an in-flight input draft that never leaves the component, an animation tick. The smell is using it as a stand-in for `app-db`.


### PR DESCRIPTION
Naming-best-practice audit for `skills/re-frame2-improver/` (bead rf2-yh7i0, P3). Three small operator-facing-clarity edits to two anti-pattern leaves, aligning cross-skill labels with the canonical Story/Xray/re-frame2-pair vocabulary per the rf2-4pwt6 tab-label convention.

## Surface audited

Skill bundle at `skills/re-frame2-improver/` — operator-facing critique-mode skill. Audited: `SKILL.md`, `README.md`, `references/README.md`, six anti-pattern leaves (`boolean-discriminator-subs`, `imperative-effects`, `manual-loading-flags`, `manual-retry-loops`, `schemaless-events`, `view-side-hook-state`), the `spec/{design,inputs,authoring-prompt}.md` meta-triad, `evals/evals.json`, `.claude-plugin/plugin.json`, `package.json`, `LICENSE`. No CLJS in this slice — prose-only audit.

## Findings summary

| Verdict | Count | Notes |
|---|---|---|
| KEEP | ~40 named entities | Filenames, headings, anti-pattern labels, API citations, cross-links, eval fixtures — all in good shape. |
| RENAME-INLINE | 3 | Cross-skill label drift in two leaves. This PR. |
| RENAME-NEEDS-FOLLOWUP | 0 | None. The improver''s public surface stays put. |

The bundle is narrow, evidence-grown, and the locked five-section per-leaf format is consistent across all six leaves. Every API citation (`:rf.http/managed`, `reg-machine`, `:tags`, `machine-has-tag?`, `reg-app-schema`, `validate-at-boundary-interceptor`, `reg-fx`, `:platforms`, `compute-sub`, `dispatch-sync` + `get-frame-db`) verified against the current `spec/`. The only operator-facing-clarity drift was three minor cross-skill label inconsistencies, all RENAME-INLINE.

## Inline edits applied

1. **`references/view-side-hook-state.md:22`** — `Xray''s panels` -> `Xray''s tabs`; `re-frame2-pair''s app-db inspector/time-travel surfaces` -> `re-frame2-pair''s app-db reads + time-travel surfaces`. Xray''s display surfaces are tabs (canonical, per `skills/re-frame2-xray/SKILL.md` L195: "Xray''s tabs"). re-frame2-pair drives app-db reads programmatically; the named visual surface for app-db is Xray''s **app-db** Dynamic tab.
2. **`references/view-side-hook-state.md:23`** — `SSR / story / replay` -> `SSR / Story / replay`. Capitalises the named tool when listed alongside SSR + replay capabilities. The trailing "the story artefact" stays lowercase (matches spec/007-Stories.md L461 noun-phrase usage).
3. **`references/imperative-effects.md:24`** — `invisible to the inspector, story, and pair-tool surfaces` -> `invisible to Xray, Story, and re-frame2-pair surfaces`. Names the three canonical diagnostic tools instead of vague (`inspector`) / lowercase-when-tool-name (`story`) / non-canonical (`pair-tool`) aliases.

No public-surface renames — filenames, frontmatter, anchor slugs, cross-link targets all unchanged.

## Cross-slice observations (out of scope, noted)

- `skills/re-frame2-pair/SKILL.md` L205–209 still carries pre-rebrand Xray panel labels ("App-DB Diff panel", "Event Detail panel", "Subscriptions panel", "Machine Inspector", "Schema Violation Timeline"). Canonical Dynamic tabs are **Event / app-db / Views / Trace / Machines / Routes / Issues**. Sibling audit (when filed) should align these.
- `skills/README.md` L72-73 pre-rebrand Dynamic-tab labels — already noted by rf2-4pwt6.

## Quality gates

- `python scripts/check_doc_slugs.py` — exit 0
- `python scripts/check_readme_links.py` — exit 0
- `python -m mkdocs build --strict` — exit 0 (only INFO; no errors)

No CLJS in this slice -> no `clojure -M:test` / clj-kondo / `npm run test:cljs` runs needed.

Bead: rf2-yh7i0