### PR TITLE
refactor(template): inline naming-clarity renames (rf2-klsda)

### DIFF
--- a/tools/template/src/day8/re_frame2_template/hooks.clj
+++ b/tools/template/src/day8/re_frame2_template/hooks.clj
@@ -47,29 +47,29 @@
   (`reagent` / `:reagent`), or a symbol; return one of
   `valid-substrates` or throw with a clear message."
   [raw]
-  (let [s (cond
-            (nil? raw)     :reagent
-            (keyword? raw) raw
-            (symbol? raw)  (keyword (name raw))
-            (string? raw)  (keyword (string/replace raw #"^:" ""))
-            :else
-            (throw (ex-info ":rf.error/template-unrecognised-substrate"
-                            {:rf.error/id :rf.error/template-unrecognised-substrate
-                             :where     'template/coerce-substrate
-                             :recovery  :fix-registration
-                             :reason    (str "unrecognised :substrate value: " (pr-str raw))
-                             :substrate raw})))]
-    (when-not (valid-substrates s)
+  (let [substrate-kw (cond
+                       (nil? raw)     :reagent
+                       (keyword? raw) raw
+                       (symbol? raw)  (keyword (name raw))
+                       (string? raw)  (keyword (string/replace raw #"^:" ""))
+                       :else
+                       (throw (ex-info ":rf.error/template-unrecognised-substrate"
+                                       {:rf.error/id :rf.error/template-unrecognised-substrate
+                                        :where     'template/coerce-substrate
+                                        :recovery  :fix-registration
+                                        :reason    (str "unrecognised :substrate value: " (pr-str raw))
+                                        :substrate raw})))]
+    (when-not (valid-substrates substrate-kw)
       (throw (ex-info ":rf.error/template-substrate-must-be-one-of"
                       {:rf.error/id :rf.error/template-substrate-must-be-one-of
                        :where     'template/coerce-substrate
                        :recovery  :fix-registration
                        :reason    (str ":substrate must be one of "
                                        (pr-str valid-substrates)
-                                       " (got " (pr-str s) ")")
-                       :substrate s
+                                       " (got " (pr-str substrate-kw) ")")
+                       :substrate substrate-kw
                        :valid     valid-substrates})))
-    s))
+    substrate-kw))
 
 ;; -- :include-story? coercion ----------------------------------------------
 
@@ -169,14 +169,14 @@
                                 "Reagent's.")
                 :substrate substrate
                 :include-story? include-story?})))
-    (let [substrate-nm    (name substrate)
+    (let [substrate-name  (name substrate)
           top             (:top data)
           main            (:main data)
           top-file        (->file-path top)
           main-file       (->file-path main)
           top-ns          (->ns-form top)
           main-ns         (->ns-form main)]
-      {:substrate           substrate-nm
+      {:substrate           substrate-name
        :substrate-kw        substrate
        :include-story?      include-story?
        :namespace           (str top-ns "." main-ns)


### PR DESCRIPTION
Shape-1 solo P3 naming audit — `tools/template/` (rf2-klsda, part of the
33-bead audit wave).

## Summary

Two tight-scope let-binding renames in
`tools/template/src/day8/re_frame2_template/hooks.clj`. Both private;
no public-surface change.

- `s` → `substrate-kw` in `coerce-substrate`'s `let`. The single-letter
  binding lives through ~25 lines (cond body + two throw bodies); the
  longer name reads self-documenting at the validation site.
- `substrate-nm` → `substrate-name` in `data-fn`'s `let`. The sibling
  bindings in the same let are fully spelled out (`top-file`,
  `main-file`, `top-ns`, `main-ns`); the abbreviated `-nm` broke the
  local convention.

## Audit verdict

The slice was already in excellent shape — every public-surface name
(deps-new contract `data-fn` / `template-fn` / `post-process-fn`,
emitted-app vocabulary, coord names, alias names, ns names, file names)
was correct. The two inline renames close the only small daylight
between the audit criteria (CLARITY) and the implementation.

Full findings doc: `ai/findings/naming-audit-tools-template.md`
(local-only, gitignored).

No follow-on beads required.

Note: rf2-h0imw (Mike-pending decision on `coerce-substrate`
forgiving-input posture) is a behaviour decision and was deliberately
untouched.

## Quality gates

- `cd tools/template && clojure -M:test` — **21 tests, 297 assertions,
  0 failures, 0 errors**.
- `clj-kondo --lint src/day8/re_frame2_template/hooks.clj` — **0
  errors, 0 warnings**.

Closes rf2-klsda.