### PR TITLE
refactor(mcp-conformance): inline naming-clarity renames (rf2-xvgsn)

### DIFF
--- a/tools/mcp-conformance/scripts/run-live-re-frame2-pair-overflow-hermetic.cjs
+++ b/tools/mcp-conformance/scripts/run-live-re-frame2-pair-overflow-hermetic.cjs
@@ -735,7 +735,7 @@ async function main() {
         throw err;
       }
     }
-    log('RE-FRAME2-PAIR-MCPLIVE HERMETIC CONFORMANCE GREEN (' +
+    log('RE-FRAME2-PAIR-MCP LIVE HERMETIC CONFORMANCE GREEN (' +
       INNER_TESTS.length + ' inner tests)');
   } finally {
     cleanup();
@@ -768,7 +768,7 @@ main()
   .then(() => {
     clearTimeout(watchdog);
     console.log(
-      `RE-FRAME2-PAIR-MCPlive hermetic conformance passed (${INNER_TESTS.length} inner tests).`,
+      `RE-FRAME2-PAIR-MCP live hermetic conformance passed (${INNER_TESTS.length} inner tests).`,
     );
     process.exit(0);
   })

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/indicator_field_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/indicator_field_test.clj
@@ -73,9 +73,6 @@
 ;; the omit-when-zero rule turns 0 into "key absent").
 ;; ---------------------------------------------------------------------------
 
-(def ^:private dropped-sensitive-key :dropped-sensitive)
-(def ^:private elided-large-key      :elided-large)
-
 (def ^:private DroppedSensitive
   "Envelope shape with the `:dropped-sensitive` slot present and
   positive."

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
@@ -550,7 +550,7 @@
                " failed schema validation:\n"
                (me/humanize (m/explain schema fixture-value)))))))
 
-(deftest every-canonical-marker-has-at-least-two-fixtures
+(deftest every-canonical-marker-has-required-fixture-count
   ;; Every marker MUST carry >=1 fixture; multi-server markers MUST
   ;; carry >=2. Single-server today (all markers are re-frame2-pair-mcp-only
   ;; post rf2-bu21t), so the >=1 floor applies; the >=2 path stays


### PR DESCRIPTION
Naming-best-practice audit for `tools/mcp-conformance/`. The artefact's test corpus IS the wire / cross-server contract for the MCP pair (re-frame2-pair-mcp + story-mcp), so most surfaces are KEEP under the four-lens posture; the audit identified 3 inline cleanups that improve clarity without touching any contract surface.

## Renames applied

1. **Hermetic-orchestrator log strings** — `scripts/run-live-re-frame2-pair-overflow-hermetic.cjs` lines 738 + 771.
   - `RE-FRAME2-PAIR-MCPLIVE` → `RE-FRAME2-PAIR-MCP LIVE`
   - `RE-FRAME2-PAIR-MCPlive` → `RE-FRAME2-PAIR-MCP live`

   Sed-collision artefact from an earlier `pair-mcp` → `re-frame2-pair-mcp` rewrite that joined `-mcp` to `LIVE` / `live` without a space. Pure log-text fix; no programmatic matcher consumes these strings.

2. **deftest rename** in `wire_vocab_test.clj`.
   - `every-canonical-marker-has-at-least-two-fixtures` → `every-canonical-marker-has-required-fixture-count`

   The name claimed `at-least-two` but the body asserts `>=1` for single-server markers and `>=2` only for multi-server (per the inline comment "single-server today post rf2-bu21t"). No external callers — private deftest, runs by `clojure.test` discovery.

3. **Dead-var removal** in `indicator_field_test.clj`.
   Removed two unused private vars (`dropped-sensitive-key`, `elided-large-key`) — every reference uses the bare keyword literal directly. clj-kondo flagged both as unused; pre-existing dead code from an earlier refactor.

## KEEP — explicitly considered

Wire contract surfaces stay (tool names, wire markers, schema names, slot literals, reserved keywords, all canonical-markers/canonical-slots table content). Public JS exports are clear verb-noun (`runWithWatchdog`, `assertJsonRpcErrorCodes`, `assertDescriptorShape`, `decodeDedupEnvelope`, `resolveTrustedExe`, `safeUnlinkInside`). Namespace names match filenames. Public Clojure helpers in `fixtures.clj` (`fx/repo-root`, `fx/read-source`, `fx/known-servers`, `fx/story-mcp-source-files`, `fx/story-mcp-tool-source-files`, `fx/variant-regex`, `fx/strip-comments-and-strings`) are cross-namespace shared by design (rf2-113ti / rf2-rto1l / rf2-qnmne consolidations) and reads cleanly.

No follow-on beads filed — no surface-changing rename emerged from the audit.

## Quality gates

- `cd tools/mcp-conformance/wire-vocab && clojure -M:test` — **GREEN** (48 tests, 560 assertions, 0 failures, 0 errors; same baseline as pre-audit).
- `clj-kondo --lint tools/mcp-conformance/wire-vocab/test` — **GREEN** (0 warnings; down from 2 pre-audit, the two dead-var warnings resolved by R3).
- `cd tools/mcp-conformance && node --test test/exec-safety.test.cjs` — **GREEN** (8 pass, 0 fail, 4 platform-skip).
- Downstream sanity `cd tools/story-mcp && clojure -M:test` — **GREEN** (172 tests, 859 assertions, 0 failures, 0 errors).
- Downstream sanity `tools/re-frame2-pair-mcp` — shadow-cljs Node build artefact; orchestrator log-string change is pre-runtime and cannot affect this consumer.

## Audit findings doc

`ai/findings/naming-audit-tools-mcp-conformance.md` (local-only) lists every reviewed surface and its KEEP / RENAME-INLINE verdict.