### PR TITLE
refactor(pair-mcp): inline naming-clarity renames (rf2-ck8d7)

### DIFF
--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/server.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/server.cljs
@@ -251,7 +251,7 @@
                                       (:ambiguous result))]
                         (throw (ex-info ":rf.error/pair-mcp-ambiguous-shadow"
                                         {:rf.error/id :rf.error/pair-mcp-ambiguous-shadow
-                                         :where    'pair-mcp/discover-and-cache!
+                                         :where    're-frame2-pair-mcp/discover-and-cache!
                                          :recovery :pick-via-port-file
                                          :reason   (:reason payload)
                                          :candidates (:candidates payload)
@@ -261,7 +261,7 @@
               :else
               (throw (ex-info ":rf.error/pair-mcp-nrepl-port-not-found"
                               {:rf.error/id :rf.error/pair-mcp-nrepl-port-not-found
-                               :where    'pair-mcp/discover-and-cache!
+                               :where    're-frame2-pair-mcp/discover-and-cache!
                                :recovery :no-recovery
                                :reason   port-not-found-hint
                                :hint     port-not-found-hint}))))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/eval_form.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/eval_form.cljs
@@ -128,7 +128,7 @@
   (when-not (symbol? n)
     (throw (ex-info ":rf.error/pair-mcp-rt-let-binding-bad-shape"
                     {:rf.error/id :rf.error/pair-mcp-rt-let-binding-bad-shape
-                     :where    'pair-mcp/rt-let
+                     :where    're-frame2-pair-mcp/rt-let
                      :recovery :no-recovery
                      :reason   "rt-let binding name must be a symbol"
                      :name     n

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/raw_state.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/raw_state.cljs
@@ -1,7 +1,7 @@
 (ns re-frame2-pair-mcp.tools.raw-state
   "Raw-state boot-gate (rf2-c2dtu).
 
-  Pair2-mcp's direct-read surfaces (`snapshot`, `get-path`, `subscribe`
+  re-frame2-pair-mcp's direct-read surfaces (`snapshot`, `get-path`, `subscribe`
   on `:epoch`) can return verbatim slices of a live app's state. The
   framework's per-call privacy table already defaults `:include-sensitive`
   to `false` and `:elision` to `true`, but a caller can still opt in

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/wire_pipeline.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/wire_pipeline.cljs
@@ -246,7 +246,7 @@
           :scalar-value (run-scalar-value payload opts)
           (throw (ex-info ":rf.error/pair-mcp-unknown-wire-pipeline-kind"
                           {:rf.error/id :rf.error/pair-mcp-unknown-wire-pipeline-kind
-                           :where    'pair-mcp/run-wire-pipeline
+                           :where    're-frame2-pair-mcp/run-wire-pipeline
                            :recovery :no-recovery
                            :reason   (str "run-wire-pipeline got an unknown :kind " (pr-str kind))
                            :kind     kind

--- a/tools/re-frame2-pair-mcp/test/README.md
+++ b/tools/re-frame2-pair-mcp/test/README.md
@@ -174,7 +174,7 @@ Is the regression visible in CLJS source?
 
 Sibling artefacts under `implementation/<feature>/` are pure CLJS /
 JVM; their test layers are all `clojure -M:test`, all in one host
-language. Pair2-mcp is the exception — it compiles to Node and runs
+language. re-frame2-pair-mcp is the exception — it compiles to Node and runs
 under `node out/server.js`. The compiled JS is the production
 artefact, but the source of truth is `.cljs`. So the test layer
 straddles both worlds: CLJS for everything verifiable from source,

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
@@ -29,7 +29,7 @@
 
   The framework's `spec/conformance/fixtures/` directory carries
   data-shaped fixtures for the spec-level core/machines/ssr/schemas/
-  flows surfaces. Pair2-mcp's contract is the MCP wire — a
+  flows surfaces. re-frame2-pair-mcp's contract is the MCP wire — a
   fundamentally different shape (tool name + JS args + canned eval
   responses → EDN result envelope). Cross-mounting onto the framework
   corpus would mix vocabularies; cross-host runners (a Python re-frame2-pair-mcp
@@ -75,7 +75,7 @@
 ;; ---------------------------------------------------------------------------
 ;; Test infrastructure — args coercion, result extraction, stub installation.
 ;;
-;; Pair2-mcp passes args as a #js {} object; the tools read each slot via
+;; re-frame2-pair-mcp passes args as a #js {} object; the tools read each slot via
 ;; `wire/arg` which does a `j/get`. The corpus carries args as CLJS maps
 ;; for readability; `args->js` converts on the fly.
 ;; ---------------------------------------------------------------------------

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/sensitive_filter_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/sensitive_filter_test.cljs
@@ -36,7 +36,7 @@
   ;; `:yes` is a contract violation that means an upstream
   ;; serialisation bug has coerced the boolean into the wrong shape.
   ;; The previous fail-OPEN posture silently leaked sensitive events
-  ;; on such drift. Pair2-mcp delegates to
+  ;; on such drift. re-frame2-pair-mcp delegates to
   ;; `re-frame.mcp-base.sensitive/sensitive-event?` (rf2-vw4sq) so the
   ;; contract is byte-identical across the MCP triplet.
   (with-redefs [js/console (clj->js {:warn (fn [& _])})] ; absorb the contract-drift warning


### PR DESCRIPTION
P3 naming-audit for `tools/re-frame2-pair-mcp` (rf2-ck8d7) — pair to the sibling rf2-cldaa (mcp-base, clean) and rf2-kzq0t (story-mcp, clean + 2 followons).

## Verdict

**Clean shape overall.** The pair-mcp slice is in good naming health: public ns names, file names, function names, predicates (`?`), side-effect markers (`!`), and test names all conform to the project conventions. The audit found **two cross-cutting consistency issues** — both fixed inline in this PR — and confirmed no public-surface rename is warranted.

## Inline renames

### 1. Stale `'pair-mcp/...` ex-info `:where` symbols → `'re-frame2-pair-mcp/...`

Four ex-info data maps used a `'pair-mcp/<fn>` symbol in the `:where` slot — a pre-rename legacy that drifted out of step with the actual namespace name (`re-frame2-pair-mcp.*`). Symbol form (not string), so the namespace-rewire grep missed it. Now `'re-frame2-pair-mcp/<fn>` everywhere.

- `src/re_frame2_pair_mcp/server.cljs:254` — `discover-and-cache!`
- `src/re_frame2_pair_mcp/server.cljs:264` — `discover-and-cache!`
- `src/re_frame2_pair_mcp/tools/eval_form.cljs:131` — `rt-let`
- `src/re_frame2_pair_mcp/tools/wire_pipeline.cljs:249` — `run-wire-pipeline`

### 2. `Pair2-mcp` docstring/comment typos → `re-frame2-pair-mcp`

Pre-rename product name survived in five prose locations.

- `src/re_frame2_pair_mcp/tools/raw_state.cljs:4` (ns docstring)
- `test/README.md:177`
- `test/re_frame2_pair_mcp/conformance_test.cljs:32` (ns docstring)
- `test/re_frame2_pair_mcp/conformance_test.cljs:78` (inline comment)
- `test/re_frame2_pair_mcp/sensitive_filter_test.cljs:39` (inline comment)

## Considered alternatives — declined

- **`tools.wire` split** (analogous to story-mcp's `tools.helpers` rf2-8yvyp). pair-mcp's `tools.wire` has a similar four-role shape (result builders / arg extraction / build-id resolution / marker detection), but at ~200 lines is much smaller than story-mcp's `helpers.cljc` and the four roles all sit at the "wire boundary". Recommend re-checking only if the ns grows past ~300 LOC.
- **`tools.cap` rename** (story-mcp's rf2-j4dgl) — does not apply. pair-mcp's `tools.cap` is **already correctly scoped**: just the token-budget cap. The wire-shrink composition lives in its own dedicated `tools.wire-pipeline` ns. pair-mcp is in fact the SOURCE of the rename story-mcp's bead points to.

## Not touched (deliberate)

- The `pair2-mcp` path fixtures in `test/probe-mcp-path-test.cjs` (heavy use). These are load-bearing — the test exercises the stale-path probe whose job is to detect legacy `~/.claude.json` entries pointing at the old product name. Renaming would defeat the test.
- The `tools/pair2-mcp/` reference in `test/README.md:126` describes what the probe detects (legitimate use).
- The `:cacheable?` registry key (rf2-uevjs is Mike-pending P4).

## Quality gates

```
cd tools/re-frame2-pair-mcp && clojure -M:test
  → 622 tests, 1689 assertions, 0 failures.

cd tools/re-frame2-pair-mcp && clj-kondo --lint src test
  → 16 pre-existing warnings, no new warnings introduced.

cd tools/mcp-conformance && node test/end-to-end-re-frame2-pair.cjs
  → GREEN. RE-FRAME2-PAIR-MCP MCP-CLIENT CONFORMANCE GREEN.
    17 tools advertised, every tool descriptor has inputSchema +
    outputSchema + annotations hint, every tool envelope carries
    :structuredContent, JSON-RPC error codes match expectations.
```

## Follow-on beads

**None.** The inline renames in this PR exhaust the rename surface.

## Findings doc

`ai/findings/naming-audit-tools-re-frame2-pair-mcp.md` — local-only per `the-mayor-method.md`; not committed.