### PR TITLE
fix(docs/skills): docs mirror sweep — /references/ + spawn.md typos (rf2-kmbkz)

### DIFF
--- a/docs/skills/re-frame2.md
+++ b/docs/skills/re-frame2.md
@@ -40,7 +40,7 @@ For greenfield-then-author, walk the [re-frame2-setup](re-frame2-setup.md) skill
 
 - Source: [`skills/re-frame2/`](https://github.com/day8/re-frame2/tree/main/skills/re-frame2)
 - `SKILL.md`: [`skills/re-frame2/SKILL.md`](https://github.com/day8/re-frame2/blob/main/skills/re-frame2/SKILL.md)
-- Reference leaves: [`skills/re-frame2/references/`](https://github.com/day8/re-frame2/tree/main/skills/re-frame2/reference) — fundamentals (events, fx, cofx, subs, schemas, frames, project-structure), state-machines (reg-machine, regions, tags, invoke, cancellation), tooling (stories, routing), cross-cutting (testing, API cheatsheet).
+- Reference leaves: [`skills/re-frame2/references/`](https://github.com/day8/re-frame2/tree/main/skills/re-frame2/references) — fundamentals (events, fx, cofx, subs, schemas, frames, project-structure), state-machines (reg-machine, regions, tags, spawn, cancellation), tooling (stories, routing), cross-cutting (testing, API cheatsheet).
 - Pattern leaves: [`skills/re-frame2/patterns/`](https://github.com/day8/re-frame2/tree/main/skills/re-frame2/patterns) — one leaf per canonical pattern, each with a mini-declaration and a link to the worked example.
 - Decision trees: [`skills/re-frame2/decision-trees/`](https://github.com/day8/re-frame2/tree/main/skills/re-frame2/decision-trees) — *slice or machine?*, *pick a pattern*.
 - Worked example map: [`skills/re-frame2/examples-map.md`](https://github.com/day8/re-frame2/blob/main/skills/re-frame2/examples-map.md).


### PR DESCRIPTION
Doc-only fix for `docs/skills/re-frame2.md:43`. The mirror line for the re-frame2 skill had two stale references surfaced by the rf2-0ed1y naming audit:

1. URL target was `https://github.com/day8/re-frame2/tree/main/skills/re-frame2/reference` (singular). The actual directory is `references/` (plural). Anchor text was already plural; only the link target was wrong.
2. Prose listed `state-machines (reg-machine, regions, tags, invoke, cancellation)`. `invoke` is xstate's name; the leaf in re-frame2 is `spawn.md` (the deliberate rename catalogued in `references/state-machines/reg-machine.md` §Mental model). The mirror predated the spawn rename swept by #1771 / #1864.

## Fix sites + reasoning

| Site | Change | Reason |
|---|---|---|
| `docs/skills/re-frame2.md:43` URL fragment | `/reference` → `/references` | Target dir is `references/` (plural) — the singular path 404s on GitHub |
| `docs/skills/re-frame2.md:43` prose list | `invoke` → `spawn` | Leaf was renamed `invoke.md` → `spawn.md` (rf2-uzj8d, rf2-u20dj). Mental model: "spawn semantics differ from xstate's invoke" |

## Sweep-wide verification

Per Mike's "sweep-wide is the posture" stance, I grepped the whole tracked corpus before applying the fix:

- `git grep -nE 'skills/re-frame2/reference($|[^s/])'` across `docs/ skills/ migration/` → **1 hit** (the seed defect). No other sites.
- `git grep -nE 'invoke\.md'` across `docs/ skills/ migration/` → **0 hits**. Prior sweeps (rf2-uzj8d in PR #1864, rf2-u20dj in PR #1771) cleared all `invoke.md` cross-refs.
- `git grep -nE '\binvoke\b' -- 'docs/skills/'` → 2 hits. `docs/skills/index.md:11` ("invoke it explicitly") is the verb usage — **DELIBERATELY KEPT**. The other was the seed defect.

The seed defect is **isolated**, not systemic. Mike's "halt + report if mostly KEEP / >10 files" guard didn't trigger — the sweep confirmed surgical scope was correct.

## Quality gates

- `python -m mkdocs build --strict` (with `docs/spec` + `docs/migration` staged) → exit 0
- `python scripts/check_doc_slugs.py --verbose` → `scanning 379 markdown files... no broken links.` exit 0
- `python scripts/check_readme_links.py --ci` → exit 0

Closes rf2-kmbkz.