### PR TITLE
refactor(examples/state_machine_walkthrough): chain via :rf/machine canonical sub (rf2-vt9tn stage 1)

### DIFF
--- a/examples/reagent/state_machine_walkthrough/core.cljc
+++ b/examples/reagent/state_machine_walkthrough/core.cljc
@@ -194,17 +194,22 @@
 
 ;; The machine snapshot lives at
 ;; [:rf/runtime :machines :snapshots :auth.login/flow] (per Spec 005).
-;; These named subs project out the convenient pieces. The "in
-;; :submitting?" / "in :authed?" / "in :locked-out?" predicates moved
-;; to the `rf/machine-has-tag?` queries in views.cljs (ch.11 §State
-;; tags) — discriminating on the machine's runtime-projected `:tags`
-;; set decouples view code from individual state-keyword identity.
+;; The framework ships `:rf/machine` as the canonical layer-3 entry
+;; point onto that path (see re-frame.machines/213); the named subs
+;; below chain off it to project out the convenient pieces. The
+;; "in :submitting?" / "in :authed?" / "in :locked-out?" predicates
+;; moved to the `rf/machine-has-tag?` queries in views.cljs (ch.11
+;; §State tags) — discriminating on the machine's runtime-projected
+;; `:tags` set decouples view code from individual state-keyword
+;; identity.
 
 (rf/reg-sub :auth.login/state
-  (fn [db _] (get-in db [:rf/runtime :machines :snapshots :auth.login/flow :state])))
+  :<- [:rf/machine :auth.login/flow]
+  (fn [machine _] (:state machine)))
 
 (rf/reg-sub :auth.login/error
-  (fn [db _] (get-in db [:rf/runtime :machines :snapshots :auth.login/flow :data :error])))
+  :<- [:rf/machine :auth.login/flow]
+  (fn [machine _] (get-in machine [:data :error])))
 
 ;; The chapter's headless tests (pure machine-transition + full-drain
 ;; scenarios) live in the sibling test ns


### PR DESCRIPTION
Closes rf2-vt9tn (stage 1 only — see scope note below).

## What

Migrate the 2 `reg-sub` sites in `examples/reagent/state_machine_walkthrough/core.cljc` from raw `(get-in db [:rf/runtime :machines :snapshots :auth.login/flow ...])` reads to chained subscriptions via the framework-shipped `:rf/machine` canonical sub.

### Before
```clojure
(rf/reg-sub :auth.login/state
  (fn [db _] (get-in db [:rf/runtime :machines :snapshots :auth.login/flow :state])))

(rf/reg-sub :auth.login/error
  (fn [db _] (get-in db [:rf/runtime :machines :snapshots :auth.login/flow :data :error])))
```

### After
```clojure
(rf/reg-sub :auth.login/state
  :<- [:rf/machine :auth.login/flow]
  (fn [machine _] (:state machine)))

(rf/reg-sub :auth.login/error
  :<- [:rf/machine :auth.login/flow]
  (fn [machine _] (get-in machine [:data :error])))
```

## Why

`:rf/machine` is the framework's canonical layer-3 entry onto the snapshot path (registered in `implementation/machines/src/re_frame/machines.cljc:213`). The state-machine walkthrough is the most teaching-y example surface, so it models the recommended idiom: chain off `:rf/machine`, destructure in the projection fn. The output shape of both subs is unchanged — consumers in `views.cljs` and the sibling test ns are not affected.

## Stage 2 deferred

Stage 2 (6 other example sites: `login/`, `realworld/auth.cljs`, `realworld/settings.cljs`, `realworld/article_editor.cljs`, `nine_states/`, `boot/`, `websocket/`) **deliberately kept on raw `get-in`** per Mike-decision 2026-05-29: the raw idiom is appropriate where surrounding code already destructures app-db at varied paths. Test files appropriately use `(get-in (get-frame-db f) ...)` outside the sub system, per the bead body. No follow-on bead filed.

## Quality gates

- `clj-kondo --lint examples/reagent/state_machine_walkthrough/core.cljc` — 0 errors, 0 warnings
- `cd implementation && npm run test:cljs` — 4845 tests, 15891 assertions, **0 failures, 0 errors**
- Examples are test-free per rf2-8cevm lock; the Reagent adapter-level smoke at `implementation/adapters/reagent/testbed/spec.cjs` covers cross-example regression for the substrate.