### PR TITLE
feat(implementation): npm run test:mcp-conformance entry-point (rf2-gt4pf)

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -154,6 +154,7 @@ agent pre-checkin "narrow to the changed surface" workflow.
 | `npm run test:story-static` | Static-build contract and deployable-output sanity for the Story export. |
 | `npm run story:build` | Build the Story static artefact. |
 | `npm run test:script-policy` / `npm run test:script-helpers` | Self-tests for the JS harness helpers (path policy, changed-surface classifier port, browser-test report, gate report, local browser harness). |
+| `npm run test:mcp-conformance` | Single operator-side entry-point (rf2-gt4pf) chaining the six PR-time MCP gates that CI runs as separate jobs: JVM story-mcp `clojure -M:test`, Node story-mcp stdio-roundtrip, Node re-frame2-pair-mcp `:server-test`, MCP-client conformance for both servers (via `tools/mcp-conformance/scripts/test-all.cjs`), and JVM wire-vocab `clojure -M:test`. Compiles the re-frame2-pair-mcp server bundle as a prerequisite. CI keeps the six gates split for differential surface attribution. |
 
 ### `tools/mcp-conformance/package.json` (run from `tools/mcp-conformance/`)
 

--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -232,7 +232,7 @@ gates. Pre-alpha posture: this menu is **prescriptive**, not advisory.
 | `tools/<tool>/src/*` | `cd tools/<tool> && clojure -M:test` AND every dependent tool (see TESTING.md S11+S12+S13) AND `npm run test:cljs` if the tool has CLJS tests |
 | `tools/{story,xray}/spec/*.md` | `mkdocs build --strict` **only** (per the rf2-f79t8 spec-md guard — do NOT run the JVM/CLJS tool probes for spec-prose edits) |
 | `tools/template/*` | `cd tools/template && clojure -M:test` + emitted-app smoke |
-| `tools/mcp-conformance/*`, `tools/re-frame2-pair-mcp/*`, `tools/mcp-base/*`, `tools/story-mcp/*` | MCP conformance suite from `tools/mcp-conformance/` |
+| `tools/mcp-conformance/*`, `tools/re-frame2-pair-mcp/*`, `tools/mcp-base/*`, `tools/story-mcp/*` | `cd implementation && npm run test:mcp-conformance` — single entry-point (rf2-gt4pf) chaining the six PR-time MCP gates: JVM story-mcp `clojure -M:test`, Node story-mcp stdio-roundtrip, Node re-frame2-pair-mcp `:server-test`, MCP conformance for both servers (via `tools/mcp-conformance/scripts/test-all.cjs`), and JVM wire-vocab `clojure -M:test`. Hermetic live-overflow stays out — operators who need it run `cd tools/mcp-conformance && npm run test:re-frame2-pair-live-overflow-hermetic` directly. |
 | Shared protocol surface (`Tool-Pair`, `Spec-Schemas`, `Conventions`, `API`) | **THE FULL MATRIX.** `scripts/test-jvm-implementation.sh` + `scripts/test-jvm-tools.sh` + `npm run test:cljs` + `mkdocs build --strict`. |
 | `spec/conformance/fixtures/*.edn` | impl JVM matrix (per-feature `_conformance_test.clj` consumes these) + `npm run test:cljs` |
 

--- a/implementation/package.json
+++ b/implementation/package.json
@@ -33,6 +33,7 @@
     "test:xray-feature-gate:smoke": "node scripts/serve-and-run-xray-feature-gate.cjs --smoke",
     "test:story-static": "node scripts/check-story-static.cjs",
     "test:script-policy": "node scripts/_path-policy.test.cjs && node scripts/_changed-surfaces.test.cjs && node scripts/_story-feature-load-port.test.cjs",
-    "test:script-helpers": "node scripts/_browser-test-report.test.cjs && node scripts/_gate-report.test.cjs && node scripts/_local-browser-harness.test.cjs"
+    "test:script-helpers": "node scripts/_browser-test-report.test.cjs && node scripts/_gate-report.test.cjs && node scripts/_local-browser-harness.test.cjs",
+    "test:mcp-conformance": "node scripts/test-mcp-conformance.cjs"
   }
 }

--- a/implementation/scripts/test-mcp-conformance.cjs
+++ b/implementation/scripts/test-mcp-conformance.cjs
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+/*
+ * Single MCP-conformance entry-point for operator pairs (rf2-gt4pf).
+ *
+ * Chains the six MCP-conformance gates that PR CI runs as separate jobs
+ * (`.github/workflows/test.yml`):
+ *
+ *   1. JVM tools/story-mcp         (`clojure -M:test`)
+ *   2. Node tools/story-mcp        stdio roundtrip (rf2-h8z5l)
+ *   3. Node tools/re-frame2-pair-mcp  shadow-cljs :server-test
+ *   4. MCP conformance tools/re-frame2-pair-mcp  (SDK Client driver, rf2-cum40)
+ *   5. MCP conformance tools/story-mcp           (SDK Client driver, rf2-cum40)
+ *   6. MCP conformance wire-vocab  (rf2-j2z7o + rf2-6m8tq + rf2-zvv65)
+ *
+ * Gates #4 + #5 ride on `tools/mcp-conformance/npm test` (which itself
+ * dispatches via `scripts/test-all.cjs` — exec-safety + re-frame2-pair +
+ * live-overflow SKIP + live-subscribe SKIP + story + flag-gates). The
+ * re-frame2-pair conformance harness drives the compiled
+ * `out/server.js` Node bundle, so this script also runs
+ * `shadow-cljs compile server` from `tools/re-frame2-pair-mcp/`
+ * before invoking the conformance suite — matching what
+ * `mcp-conformance-re-frame2-pair` does in CI.
+ *
+ * Fail-fast: the first non-zero exit code halts the run and the
+ * orchestrator forwards it verbatim, so the parent shell sees exactly
+ * which gate failed. The summary at the end attributes pass/fail per
+ * gate one-glance, matching the shape of
+ * `tools/mcp-conformance/scripts/test-all.cjs`.
+ *
+ * Out of scope per Mike's minimum-scope direction (rf2-gt4pf):
+ *   - Formal runner ns (this is a Node operator-side ergonomic, not a
+ *     CI gate — CI keeps the six split jobs for differential surface
+ *     attribution)
+ *   - Rich output formatting / unified report
+ *   - Incremental `--changed-only` mode
+ *
+ * Hermetic live-overflow (which boots shadow-cljs + Playwright Chromium
+ * against `skills/re-frame2-pair/tests/fixture/`) is intentionally NOT
+ * chained here — that gate lives in CI's `mcp-conformance-re-frame2-pair`
+ * job and burns ~2 min of wall-clock on a cold-cache run. Operators who
+ * want it run `cd tools/mcp-conformance && npm run test:re-frame2-pair-live-overflow-hermetic`
+ * directly.
+ */
+'use strict';
+
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const HERE = __dirname;
+const IMPL_ROOT = path.resolve(HERE, '..');
+const REPO_ROOT = path.resolve(IMPL_ROOT, '..');
+
+const TOOLS = path.join(REPO_ROOT, 'tools');
+const STORY_MCP = path.join(TOOLS, 'story-mcp');
+const PAIR_MCP = path.join(TOOLS, 're-frame2-pair-mcp');
+const CONFORMANCE = path.join(TOOLS, 'mcp-conformance');
+const WIRE_VOCAB = path.join(CONFORMANCE, 'wire-vocab');
+
+// `clojure` and `npm`/`npx` are resolved via PATH on Windows as `.cmd`
+// shims and on POSIX as plain binaries. `shell: true` lets the OS shell
+// do that resolution for us so the same `command` string works
+// cross-platform without per-platform branching.
+const STEPS = [
+  // ---- prep ----
+  {
+    name: 'install tools/re-frame2-pair-mcp deps',
+    command: 'npm install',
+    cwd: PAIR_MCP,
+    prep: true,
+  },
+  {
+    name: 'compile re-frame2-pair-mcp server bundle (shadow-cljs :server)',
+    command: 'npx shadow-cljs compile server',
+    cwd: PAIR_MCP,
+    prep: true,
+  },
+  {
+    name: 'install tools/mcp-conformance deps',
+    command: 'npm install',
+    cwd: CONFORMANCE,
+    prep: true,
+  },
+
+  // ---- the six gates ----
+  {
+    name: '[1/6] JVM tools/story-mcp (clojure -M:test)',
+    command: 'clojure -M:test',
+    cwd: STORY_MCP,
+  },
+  {
+    name: '[2/6] Node tools/story-mcp stdio roundtrip (rf2-h8z5l)',
+    command: 'node test/stdio-roundtrip.js',
+    cwd: STORY_MCP,
+  },
+  {
+    name: '[3/6] Node tools/re-frame2-pair-mcp (shadow-cljs :server-test)',
+    command: 'npm test',
+    cwd: PAIR_MCP,
+  },
+  {
+    name: '[4+5/6] MCP conformance tools/re-frame2-pair-mcp + tools/story-mcp (rf2-cum40)',
+    command: 'node scripts/test-all.cjs',
+    cwd: CONFORMANCE,
+    // tools/mcp-conformance/npm test == node scripts/test-all.cjs;
+    // it covers BOTH gates [4] (re-frame2-pair-mcp end-to-end + live-*
+    // SKIPs) and [5] (story-mcp end-to-end + flag-gates) in one
+    // orchestrator pass, alongside the exec-safety unit tests. The
+    // upstream orchestrator already prints its own per-test summary
+    // (see `tools/mcp-conformance/scripts/test-all.cjs`), so we don't
+    // artificially split its output.
+  },
+  {
+    name: '[6/6] MCP conformance wire-vocab (rf2-j2z7o + rf2-6m8tq + rf2-zvv65)',
+    command: 'clojure -M:test',
+    cwd: WIRE_VOCAB,
+  },
+];
+
+function banner(line) {
+  const sep = '─'.repeat(72);
+  process.stdout.write('\n' + sep + '\n' + line + '\n' + sep + '\n');
+}
+
+const results = [];
+let firstFailure = null;
+
+for (const step of STEPS) {
+  banner('▶ ' + step.name + '\n  cwd: ' + step.cwd + '\n  cmd: ' + step.command);
+  const child = spawnSync(step.command, {
+    cwd: step.cwd,
+    stdio: 'inherit',
+    shell: true,
+    env: process.env,
+  });
+  const status = child.status === null ? 'signal:' + child.signal : child.status;
+  // Don't include prep steps in the gate-summary (they're not gates, they're prerequisites).
+  if (!step.prep) {
+    results.push({ name: step.name, status });
+  }
+  if (child.status !== 0 && firstFailure === null) {
+    firstFailure = { step: step.name, status: child.status, signal: child.signal };
+    break;
+  }
+}
+
+banner('test:mcp-conformance summary');
+for (const r of results) {
+  const tick = r.status === 0 ? 'OK  ' : 'FAIL';
+  process.stdout.write(`  [${tick}] ${r.name} (exit=${r.status})\n`);
+}
+
+if (firstFailure) {
+  process.stdout.write(
+    `\nFAIL: ${firstFailure.step} exited ${firstFailure.status}` +
+      (firstFailure.signal ? ' (signal ' + firstFailure.signal + ')' : '') +
+      '\n',
+  );
+  process.exit(firstFailure.status === null ? 1 : firstFailure.status);
+}
+
+process.stdout.write('\nALL MCP-CONFORMANCE GATES GREEN\n');
+process.exit(0);


### PR DESCRIPTION
Closes rf2-gt4pf — F-MC-1 from the Tools-MCP first-principles audit (rf2-9hflf): "tools/mcp-conformance: single 'run every conformance gate' entry-point would help AI pairs (decision)".

## Summary

Adds `npm run test:mcp-conformance` (from `implementation/`) — a single operator-side entry-point chaining the six PR-time MCP gates that CI runs as separate jobs. Mike-blessed Option A (minimum-scope npm script).

Before this landing, verifying MCP conformance locally meant reading `.github/workflows/test.yml` to identify the per-gate invocations across four directories with three different runtimes (JVM clojure, Node, shadow-cljs).

The six gates:
1. **JVM tools/story-mcp** — `clojure -M:test`
2. **Node tools/story-mcp** — stdio-roundtrip (rf2-h8z5l)
3. **Node tools/re-frame2-pair-mcp** — shadow-cljs `:server-test`
4. **MCP conformance tools/re-frame2-pair-mcp** (rf2-cum40)
5. **MCP conformance tools/story-mcp** (rf2-cum40)
6. **MCP conformance wire-vocab** (rf2-j2z7o + rf2-6m8tq + rf2-zvv65)

Gates 4 + 5 ride on the existing `tools/mcp-conformance/scripts/test-all.cjs` orchestrator (exec-safety + re-frame2-pair end-to-end + live-overflow SKIP + live-subscribe SKIP + story end-to-end + flag-gates). The re-frame2-pair conformance harness drives `tools/re-frame2-pair-mcp/out/server.js`, so the new orchestrator runs `shadow-cljs compile server` from `tools/re-frame2-pair-mcp/` as a prerequisite (same shape as CI's `mcp-conformance-re-frame2-pair` job).

## Design notes

- **Helper script, not raw `&&` chain**: three prep steps (`npm install` ×2, server bundle compile) cross three different cwds, and a per-step pass/fail summary makes failure attribution one-glance instead of one-grep. Modelled after `tools/mcp-conformance/scripts/test-all.cjs`.
- **CI unchanged**: the six CI jobs stay split for differential surface attribution. This is an operator-side ergonomic, not a CI consolidation.
- **Hermetic live-overflow stays out** of the chain (Playwright + shadow-cljs boot, ~2 min cold-cache). Operators who need it run `cd tools/mcp-conformance && npm run test:re-frame2-pair-live-overflow-hermetic` directly.

## Out of scope (per Mike's minimum-scope direction)

- Formal runner ns
- Rich output formatting / unified report
- Incremental `--changed-only` mode
- Replacing the six CI checks with one

## Surfaces touched

- `implementation/package.json` — new `test:mcp-conformance` script entry
- `implementation/scripts/test-mcp-conformance.cjs` — new orchestrator (modelled after `tools/mcp-conformance/scripts/test-all.cjs`)
- `docs/the-mayor-method/dispatch-prompt-template.md` — gate-menu row for `tools/{mcp-conformance,re-frame2-pair-mcp,mcp-base,story-mcp}/*` now points at the new single command (before: "MCP conformance suite from `tools/mcp-conformance/`" — operator still had to read the artefact's README to find the six commands; after: explicit single command + lists the six gates it chains + carve-out for hermetic)
- `TESTING.md` — new row in the `implementation/package.json` table

## Quality gates

| Gate | Result |
|---|---|
| `cd implementation && npm run test:mcp-conformance` (the new script's own run) | **PASS** — all 6 gates green (details below) |
| `python -m mkdocs build --strict` (staged `docs/spec` + `docs/migration`) | PASS — built in 10.19s, no new warnings |
| `python scripts/check_doc_slugs.py --verbose` | PASS — scanned 379 markdown files, no broken links |
| `python scripts/check_readme_links.py --ci` | PASS — exit 0 |

### `test:mcp-conformance` per-gate results

| # | Gate | Tests | Assertions | Outcome |
|---|---|---:|---:|---|
| 1/6 | JVM tools/story-mcp (`clojure -M:test`) | 172 | 859 | OK |
| 2/6 | Node tools/story-mcp stdio-roundtrip | 13 ops verified across 19 tools | — | OK |
| 3/6 | Node tools/re-frame2-pair-mcp (`:server-test`) | 622 | 1689 | OK |
| 4+5/6 | MCP conformance via `scripts/test-all.cjs` | exec-safety: 12 (8 pass / 4 platform-SKIP); re-frame2-pair end-to-end + 2 live-* SKIPs; story end-to-end; flag-gates 4 | — | OK |
| 6/6 | MCP conformance wire-vocab (`clojure -M:test`) | 48 | 560 | OK |

Final orchestrator summary:

```
test:mcp-conformance summary
────────────────────────────────────────────────────────────────────────
  [OK  ] [1/6] JVM tools/story-mcp (clojure -M:test) (exit=0)
  [OK  ] [2/6] Node tools/story-mcp stdio roundtrip (rf2-h8z5l) (exit=0)
  [OK  ] [3/6] Node tools/re-frame2-pair-mcp (shadow-cljs :server-test) (exit=0)
  [OK  ] [4+5/6] MCP conformance tools/re-frame2-pair-mcp + tools/story-mcp (rf2-cum40) (exit=0)
  [OK  ] [6/6] MCP conformance wire-vocab (rf2-j2z7o + rf2-6m8tq + rf2-zvv65) (exit=0)

ALL MCP-CONFORMANCE GATES GREEN
```