### PR TITLE
docs(spec): privacy at a glance paragraph (rf2-vjv7i)

### DIFF
--- a/spec/014-HTTPRequests.md
+++ b/spec/014-HTTPRequests.md
@@ -1060,6 +1060,19 @@ Per (motivated by the [ §Completeness matrix G3](#) — the sensitive-elision a
 
 Spec 014 specifies HTTP-side honouring on top of the Spec 009 contract: every `:rf.http/*` trace event MUST stamp `:sensitive?` when the originating handler is sensitive, MUST redact known-sensitive request headers regardless of handler sensitivity, and MUST redact request / response bodies when the request is sensitive. The contract layers as three cooperating pieces.
 
+### Privacy at a glance — user-facing entry points and owning namespaces
+
+App code requires only the `re-frame.http` façade, which re-exports the four entry points below. The structural split (three implementation namespaces) is visible to the operator who's reading the spec or stepping into framework source — headers, URL query-string params, and the orchestrating composers are distinct decoration surfaces.
+
+| Entry point | Purpose | Owning namespace |
+|---|---|---|
+| `declare-sensitive-header!` | Extend the always-on header denylist with an app-specific header name. | `re-frame.http-privacy-headers` |
+| `clear-sensitive-headers!` | Clear the app-extended header denylist (test ergonomics). The fixed default denylist is not affected. | `re-frame.http-privacy-headers` |
+| `declare-sensitive-query-param!` | Extend the always-on query-string param denylist with an app-specific param name. | `re-frame.http-url` |
+| `clear-sensitive-query-params!` | Clear the app-extended query-param denylist (test ergonomics). The fixed default denylist is not affected. | `re-frame.http-url` |
+
+The composers that orchestrate per-emit redaction + stamping — `request-sensitive?`, `prepare-emit-tags`, `prepare-emit-failure` — live in `re-frame.http-privacy` as the privacy orchestrator. They consult the two denylist atoms and the per-request / per-call `:sensitive?` flag and produce the redacted slot values + stamped tags map that `trace/emit!` / `trace/emit-error!` sees.
+
 ### 1. Header denylist (always-on)
 
 A canonical set of HTTP header names is **always sensitive** — the names themselves declare the value secret regardless of the surrounding handler's `:sensitive?` flag. Implementations MUST redact (substitute the framework-reserved `:rf/redacted` sentinel per [Spec 009 §Privacy](009-Instrumentation.md#privacy--sensitive-data-in-traces)) the values of these headers in every `:rf.http/*` trace event that carries a `:headers` slot. Header-name matching is **case-insensitive**.


### PR DESCRIPTION
## Summary

Adds a "Privacy at a glance" subsection to `spec/014-HTTPRequests.md` §Privacy that maps the four user-facing privacy entry points to their owning implementation namespaces, plus a one-sentence callout for the composers in `re-frame.http-privacy`.

A newcomer reading §Privacy can now see the full structural model in one short scan, without grepping three source files to discover where each entry point lives.

## The mapping

| Entry point | Owning namespace |
|---|---|
| `declare-sensitive-header!` | `re-frame.http-privacy-headers` |
| `clear-sensitive-headers!` | `re-frame.http-privacy-headers` |
| `declare-sensitive-query-param!` | `re-frame.http-url` |
| `clear-sensitive-query-params!` | `re-frame.http-url` |

Composers (`request-sensitive?` / `prepare-emit-tags` / `prepare-emit-failure`) live in `re-frame.http-privacy` as the privacy orchestrator — a one-sentence mention follows the table.

## Context

Per rf2-6kd3u ruling (Mike 2026-05-29 option A): the HTTP privacy surface stays split across three implementation namespaces because the structural seam is real — headers, URL query params, and the orchestrating composers are distinct decoration surfaces. User-facing flatness is preserved by the `re-frame.http` façade, which re-exports the four entry points so apps require only one ns. The §Privacy paragraph is for the operator who's reading the spec to understand the structural model.

Pre-alpha doc-only edit. No code touch.

## Files

- `spec/014-HTTPRequests.md` (+13 lines, new "Privacy at a glance" subsection between the opening prose and "### 1. Header denylist (always-on)")

## Quality gates

- `python -m mkdocs build --strict` — exit 0 (clean build)
- `python scripts/check_doc_slugs.py --verbose` — "no broken links" / exit 0
- `python scripts/check_readme_links.py --ci` — exit 0

Closes rf2-vjv7i.