### PR TITLE
feat(template): tighten coerce-substrate to keyword-only (rf2-h0imw)

### DIFF
--- a/tools/template/spec/001-Substrate-Variants.md
+++ b/tools/template/spec/001-Substrate-Variants.md
@@ -45,22 +45,25 @@ substrate.
 
 ## Substrate coercion
 
-The template accepts the substrate arg as a keyword, a string (with
-or without leading `:`), or a symbol — across shells and tooling
-ecosystems the args round-trip through `-Tnew` slightly differently,
-and tolerating all three keeps the command line forgiving:
+The template requires the substrate arg as a keyword. deps-new's
+top-level k/v contract guarantees the value reaches `data-fn` as a
+keyword, so the template does not accept stringified or symbol forms
+— passing one is a registration error and throws with a clear
+message naming the valid set:
 
 ```clojure
 (coerce-substrate :uix)        ;; => :uix
-(coerce-substrate "uix")       ;; => :uix
-(coerce-substrate ":uix")      ;; => :uix
-(coerce-substrate 'uix)        ;; => :uix
 (coerce-substrate :unknown)    ;; => throws — clear message
 (coerce-substrate nil)         ;; => :reagent (default)
+(coerce-substrate "uix")       ;; => throws — must be a keyword
+(coerce-substrate 'uix)        ;; => throws — must be a keyword
 ```
 
-Anything not in `#{:reagent :uix :helix}` throws an `ex-info` with
-the offending value and the set of valid substrates in `ex-data`.
+Anything not in `#{:reagent :uix :helix}` (or anything not a keyword)
+throws an `ex-info` with the offending value and the set of valid
+substrates in `ex-data`. This tightening (rf2-h0imw) replaces the
+earlier kw/string/symbol forgiving-input posture; see
+[DESIGN-RATIONALE.md §8](DESIGN-RATIONALE.md) for the rationale.
 
 ## What each variant emits
 

--- a/tools/template/spec/API.md
+++ b/tools/template/spec/API.md
@@ -70,9 +70,11 @@ clojure -Tnew create \
 | `:substrate` | no | One of `:reagent` `:uix` `:helix`. | `:reagent` |
 | `:include-story?` | no | When `true`, scaffolds the Story playground alongside the live app — adds the `day8/re-frame2-story` coord, emits `src/.../stories.cljs`, and swaps the entry `core.cljs` for the hash-routing `core_with_stories.cljs` variant. **Reagent only in v1** — non-Reagent substrates throw a clear error (UIx + Helix follow once those variants' app-shells catch up to Reagent's). | `false` |
 
-`:substrate` accepts a keyword, a string (with or without leading
-`:`), or a symbol. The template coerces to a keyword internally.
-Anything not in the valid set throws.
+`:substrate` accepts only a keyword (or omission, which defaults
+to `:reagent`). Anything else — string, symbol, number, … — throws
+with a clear message naming the valid set. See
+[DESIGN-RATIONALE.md §8](DESIGN-RATIONALE.md) for why the earlier
+forgiving-input posture was tightened (rf2-h0imw).
 
 `:include-story?` accepts `true` / `false` / `nil`; anything else
 throws. The branching exception is justified in
@@ -142,7 +144,7 @@ mirror the chosen `:substrate` + `:include-story?` flags.
 
 | Condition | Error keyword | Behaviour |
 |---|---|---|
-| `:substrate` not one of `#{:reagent :uix :helix}` | `:rf.error/template-substrate-must-be-one-of` (keyword arg outside the valid set) / `:rf.error/template-unrecognised-substrate` (non-keyword/string/symbol shape) | `ex-info` thrown; message names the valid set; `ex-data` carries `{:substrate <bad-value> :valid #{...}}`. |
+| `:substrate` not one of `#{:reagent :uix :helix}` | `:rf.error/template-substrate-must-be-one-of` (keyword arg outside the valid set) / `:rf.error/template-substrate-must-be-keyword` (non-keyword shape — string, symbol, number, …) | `ex-info` thrown; message names the valid set; `ex-data` carries `{:substrate <bad-value> :valid #{...}}`. |
 | `:include-story?` not `true` / `false` / `nil` | `:rf.error/template-bad-include-story-flag` | `ex-info` thrown; message gives the offending value. |
 | `:include-story? true` with non-Reagent substrate | `:rf.error/template-include-story-reagent-only` | `ex-info` thrown; message says "Reagent-only in v1" and names the chosen substrate. |
 | `:name` missing | n/a (deps-new) | deps-new's harness rejects before template is invoked. |

--- a/tools/template/spec/DESIGN-RATIONALE.md
+++ b/tools/template/spec/DESIGN-RATIONALE.md
@@ -314,28 +314,43 @@ are nice-to-have signals; the harder contract is the file-tree
 shape + the static-parse framework-surface audit + the
 version-lockstep guards.
 
-## §8 — Forgiving substrate coercion
+## §8 — Strict substrate coercion (keyword-only)
 
-**Decision.** `coerce-substrate` accepts keyword, string (with or
-without leading `:`), symbol; throws on anything else.
+**Decision.** `coerce-substrate` accepts only a keyword (or nil,
+which defaults to `:reagent`). String, symbol, and any other shape
+throws with a clear message naming the valid set.
 
-**Why.**
+**History.** This tightened from a forgiving-input posture
+(kw/string/symbol all accepted) to keyword-only in rf2-h0imw, on the
+back of the rf2-c8tmc first-principles audit (Finding #3 / §D5). The
+earlier forgiving posture was defensive against shell quoting
+variance that — in deps-new's actual k/v contract — does not happen:
+deps-new passes top-level args through as Clojure values, so a
+keyword on the CLI reaches `data-fn` as a keyword. The
+multi-form branch was guarding against a problem the contract
+already rules out.
 
-- **The Clojure CLI ecosystem hands keywords through
-  inconsistently across shells.** On some shells / OSes,
-  `:substrate :uix` reaches the template as the keyword `:uix`;
-  on others, as the string `":uix"`; in some setups, with the
-  leading colon stripped; occasionally as a symbol.
-- **Coercion is cheap.** A six-line `cond` covers all four cases.
-  No reason to make the user fight quoting.
-- **Strict on the value set.** Any input that maps to a keyword
-  outside `#{:reagent :uix :helix}` throws with a clear message
-  naming the valid set. The user sees the typo and fixes it.
+**Why keyword-only.**
 
-The inverse — strict on input shape, forgiving on value set
-(silent fallback to default) — would be worse: a typo silently
-delivers the Reagent variant instead of the requested UIx, and
-the user finds out at `shadow-cljs watch app` time.
+- **deps-new's contract is sharp.** `clojure -Tnew create
+  :substrate :uix` arrives at `data-fn`'s `data` map as `{:substrate
+  :uix}` — a keyword. The forgiving branches existed for a clj-new-era
+  invocation shape that no longer applies. (No string/symbol input
+  has ever been observed in the deps-new tests; the branches were
+  dead defensiveness.)
+- **Pre-alpha SOTA-masterpiece posture.** Narrow contracts catch
+  registration errors earlier and read more honestly. The contract
+  is now: pass a keyword, get a result; pass anything else, get a
+  clear error.
+- **Strict on the value set is unchanged.** Any keyword outside
+  `#{:reagent :uix :helix}` throws with a clear message naming the
+  valid set. The user sees the typo and fixes it.
+
+**Why not keep the forgiving posture.** The inverse — strict on
+value set, forgiving on input shape — sounded ergonomic in
+principle, but in practice deps-new never delivers a non-keyword,
+so the forgiving paths were untested code that papered over no real
+input. Removing them aligns the code with the actual contract.
 
 ## §9 — Xray on by default (rf2-y9zqc)
 

--- a/tools/template/spec/Principles.md
+++ b/tools/template/spec/Principles.md
@@ -119,17 +119,23 @@ implementation's own CI is exercising. A developer who runs the
 template and then files an issue should be running the same combo
 the maintainers smoke-test. Drift here is a bug.
 
-## P6 — Forgiving on input shape, strict on substrate set
+## P6 — Strict on input shape, strict on substrate set
 
-The template accepts the substrate arg as a keyword, a string
-(with or without leading `:`), or a symbol — clj-new harnesses
-across the wider tooling ecosystem hand keywords through
-inconsistently, and the template tolerates the variants.
+The template requires the substrate arg as a keyword — deps-new's
+top-level k/v contract guarantees it arrives as a keyword, so
+accepting string/symbol shapes would paper over registration errors
+that should surface immediately. Pass a non-keyword, get an
+`ex-info` naming the valid set.
 
-But the substrate **value** is strict: anything not in
+The substrate **value** is also strict: anything not in
 `#{:reagent :uix :helix}` throws with a clear message naming the
 valid set. No silent fallback to default, no "did you mean...?"
 fuzz. The user sees the typo and fixes it.
+
+(History: this principle tightened from "forgiving on input shape,
+strict on substrate set" to "strict on both" in rf2-h0imw, on the
+back of the rf2-c8tmc first-principles audit. See
+[DESIGN-RATIONALE.md §8](DESIGN-RATIONALE.md) for the rationale.)
 
 ## P7 — Tested end-to-end, per substrate
 

--- a/tools/template/src/day8/re_frame2_template/hooks.clj
+++ b/tools/template/src/day8/re_frame2_template/hooks.clj
@@ -43,22 +43,31 @@
 (def ^:private valid-substrates #{:reagent :uix :helix})
 
 (defn- coerce-substrate
-  "Accept the substrate arg as either a keyword (`:reagent`), a string
-  (`reagent` / `:reagent`), or a symbol; return one of
-  `valid-substrates` or throw with a clear message."
+  "Validate the `:substrate` arg. Accepts only a keyword (one of
+  `valid-substrates`) or nil (defaults to `:reagent`). deps-new's
+  top-level k/v contract guarantees the value reaches us as a keyword
+  — anything else is a registration error and we throw with a clear
+  message naming the valid set.
+
+  Tightened from the earlier kw/string/symbol forgiving-input posture
+  to the SOTA pre-alpha contract (rf2-h0imw / rf2-c8tmc Finding #3)."
   [raw]
   (let [substrate-kw (cond
                        (nil? raw)     :reagent
                        (keyword? raw) raw
-                       (symbol? raw)  (keyword (name raw))
-                       (string? raw)  (keyword (string/replace raw #"^:" ""))
                        :else
-                       (throw (ex-info ":rf.error/template-unrecognised-substrate"
-                                       {:rf.error/id :rf.error/template-unrecognised-substrate
+                       (throw (ex-info ":rf.error/template-substrate-must-be-keyword"
+                                       {:rf.error/id :rf.error/template-substrate-must-be-keyword
                                         :where     'template/coerce-substrate
                                         :recovery  :fix-registration
-                                        :reason    (str "unrecognised :substrate value: " (pr-str raw))
-                                        :substrate raw})))]
+                                        :reason    (str ":substrate must be a keyword (one of "
+                                                        (pr-str valid-substrates)
+                                                        "). Got "
+                                                        (.getName (class raw))
+                                                        ": "
+                                                        (pr-str raw))
+                                        :substrate raw
+                                        :valid     valid-substrates})))]
     (when-not (valid-substrates substrate-kw)
       (throw (ex-info ":rf.error/template-substrate-must-be-one-of"
                       {:rf.error/id :rf.error/template-substrate-must-be-one-of

--- a/tools/template/test/day8/re_frame2_template/template_test.clj
+++ b/tools/template/test/day8/re_frame2_template/template_test.clj
@@ -317,6 +317,31 @@
         (finally
           (delete-recursively tmp))))))
 
+(deftest non-keyword-substrate-rejected-test
+  (testing "non-keyword :substrate value (string, symbol, number, …)
+            is rejected with a clear message (rf2-h0imw: keyword-only
+            coercion replaces the earlier forgiving-input posture)."
+    (let [tmp (tmp-dir "rf2-template-non-kw-")]
+      (try
+        ;; String form — previously coerced silently to :reagent;
+        ;; now rejected so registration errors surface immediately.
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #":rf\.error/template-substrate-must-be-keyword"
+                              (run-template! tmp "acme/my-app" "reagent"))
+            "string substrate is rejected")
+        ;; Symbol form — same.
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #":rf\.error/template-substrate-must-be-keyword"
+                              (run-template! tmp "acme/my-app" 'reagent))
+            "symbol substrate is rejected")
+        ;; Arbitrary other type — same.
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #":rf\.error/template-substrate-must-be-keyword"
+                              (run-template! tmp "acme/my-app" 42))
+            "number substrate is rejected")
+        (finally
+          (delete-recursively tmp))))))
+
 ;; --- :include-story? flag (rf2-t009p / rf2-dolpf §2.4) -------------------
 
 (deftest default-path-emits-no-story-files-test


### PR DESCRIPTION
## Summary

Tighten `tools/template`'s `coerce-substrate` from the earlier kw/string/symbol forgiving-input posture (P6) to **keyword-only** acceptance. Implements the Mike-ruled **Option B** decision on rf2-h0imw (2026-05-29), on the back of the rf2-c8tmc first-principles audit (Finding #3 / §D5).

## Why

deps-new's top-level k/v contract guarantees `:substrate <kw>` reaches `data-fn` as a keyword. The string/symbol branches were defensiveness against a registration shape that never occurs through the deps-new path — paper over registration errors that should surface immediately. SOTA pre-alpha posture is narrow-contract.

## Old vs new behaviour

| Input | Old behaviour | New behaviour |
|---|---|---|
| `:reagent` / `:uix` / `:helix` (keyword) | Accepted | Accepted (unchanged) |
| `nil` | Defaults to `:reagent` | Defaults to `:reagent` (unchanged) |
| `:svelte` (keyword outside valid set) | Throws `:rf.error/template-substrate-must-be-one-of` | Throws `:rf.error/template-substrate-must-be-one-of` (unchanged) |
| `"reagent"` / `":reagent"` (string) | Coerced silently to `:reagent` | **Throws `:rf.error/template-substrate-must-be-keyword`** |
| `'reagent` (symbol) | Coerced silently to `:reagent` | **Throws `:rf.error/template-substrate-must-be-keyword`** |
| Other types (number, map, …) | Threw `:rf.error/template-unrecognised-substrate` | Throws `:rf.error/template-substrate-must-be-keyword` (renamed error id; same recovery path) |

## Migration impact

- **Source.** `hooks.clj/coerce-substrate` — string?/symbol? branches removed; nil/keyword paths + `valid-substrates` membership check preserved; docstring rewritten.
- **Tests.** No existing test passed string or symbol substrate input (all tests already used keywords), so no test rewrite was required. New `non-keyword-substrate-rejected-test` pins the strict behaviour for string/symbol/number inputs.
- **Specs.** Four spec docs updated to match the new contract:
  - `spec/Principles.md` P6 retitled 'Strict on input shape, strict on substrate set' (with history note linking DESIGN-RATIONALE §8).
  - `spec/DESIGN-RATIONALE.md` §8 rewritten as the strict-coercion rationale.
  - `spec/001-Substrate-Variants.md` examples flipped to show string/symbol throwing.
  - `spec/API.md` errors table row + adjacent prose updated; error-id name changed to `:rf.error/template-substrate-must-be-keyword`.
- **No call-site changes elsewhere.** `coerce-substrate` is private to `hooks.clj` and called only from `data-fn`.
- **No deprecation shim.** Pre-alpha — direct rename of the error id; downstream tooling should match on `:rf.error/template-substrate-must-be-*` if it needs both.

## Quality gates

- `cd tools/template && clojure -M:test` → **22 tests, 300 assertions, 0 failures, 0 errors**
- `clj-kondo --lint tools/template/src tools/template/test` → **errors: 0, warnings: 0**

## Refs

- Closes rf2-h0imw (decision: tighten to keyword-only).
- Discovered from rf2-c8tmc (tools/template first-principles audit).
- Decision note on bead: "option (B) — tighten coerce-substrate to keyword-only. Aligns with pre-alpha SOTA-masterpiece posture (no defensive shims against guaranteed input). deps-new's top-level k/v contract guarantees a keyword."