### PR TITLE
fix(xray/epoch/view): remove dangling mode-toggle-bar-style aliases (rf2-x8aqd)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -847,15 +847,46 @@
    :user-select "none"})
 
 ;; -- SUBSCRIPTIONS filter button bar --------------------------------------
+;;
+;; rf2-x8aqd (2026-05-29) — these literals were previously hoisted as
+;; `mode-toggle-{bar,button-active,button-inactive}-style` and aliased
+;; via `(def subs-filter-… mode-toggle-…)`. rf2-vv3m6 retired the
+;; mode-toggle (FULL+DIFF is the single HANDLER rendering) which deleted
+;; the upstream defs and left the aliases dangling (3 unresolved-symbol
+;; kondo warnings). The SUBSCRIPTIONS [all][changed][unchanged] filter
+;; bar is a separate live feature, so we inline the original literals
+;; here as the sole owner.
 
 (def ^:private subs-filter-bar-style
-  mode-toggle-bar-style)
+  {:display       "inline-flex"
+   :align-items   "center"
+   :gap           0
+   :border        border-subtle-1px
+   :border-radius "3px"
+   :overflow      "hidden"
+   :margin-left   "8px"
+   :line-height   1})
+
+(def ^:private subs-filter-button-base-style
+  {:border         "none"
+   :padding        "2px 8px"
+   :font-family    sans-stack
+   :font-size      "10px"
+   :font-weight    700
+   :text-transform "uppercase"
+   :letter-spacing "0.5px"
+   :cursor         "pointer"
+   :line-height    1})
 
 (def ^:private subs-filter-button-active-style
-  mode-toggle-button-active-style)
+  (assoc subs-filter-button-base-style
+         :background accent-colour
+         :color      white-colour))
 
 (def ^:private subs-filter-button-inactive-style
-  mode-toggle-button-inactive-style)
+  (assoc subs-filter-button-base-style
+         :background "transparent"
+         :color      text-secondary-colour))
 
 (def ^:private subs-verb-style
   {:display     "inline-flex"


### PR DESCRIPTION
## Summary

PR #2385 (rf2-vv3m6 mode-toggle retirement) deleted the three
`mode-toggle-{bar,button-active,button-inactive}-style` defs but left
three aliases on lines 851-858 (`(def subs-filter-… mode-toggle-…)`)
that still resolved against the deleted symbols. clj-kondo flagged
three `Unresolved symbol: mode-toggle-*-style` warnings on the file.

## Fix

The SUBSCRIPTIONS `[all][changed][unchanged]` filter bar (rendered at
lines ~2820-2853) is a live feature, so the aliases cannot be deleted
outright — instead inline the original literal maps as the sole owner
under the `subs-filter-…` names, with a brief comment recording why
the inline lives here now. Pre-alpha; no back-compat shim.

Before / after on `tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs`:

| | unresolved-symbol warnings | unused-private-var warnings | total |
|---|---|---|---|
| origin/main | **3** | 15 | 18 |
| this PR    | **0** | 15 | 15 |

The 15 unused-private-var warnings are pre-existing residue unrelated
to this bead.

## Quality gates

- `cd tools/xray && clojure -M:test` — **957 tests, 3762 assertions, 0 failures, 0 errors**
- `cd implementation && npm run test:cljs` — **4811 tests, 15746 assertions, 0 failures, 0 errors**
- `clj-kondo --lint tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs` — **0 errors, 15 warnings** (all pre-existing unused-private-var; the 3 unresolved-symbol warnings are gone)

Closes rf2-x8aqd.