### PR TITLE
fix(xray/diff): inherit :added/:removed for empty-collection leaves in changed subtrees (rf2-bufw2)

### DIFF
--- a/tools/xray/spec/004-App-DB-Diff.md
+++ b/tools/xray/spec/004-App-DB-Diff.md
@@ -106,6 +106,39 @@ age-out.
 > retained ONLY for the trace panel's `db-changed-diff-triples`
 > surface (out of scope; tracked separately).
 
+### Empty-collection leaves are honest leaves (rf2-bufw2)
+
+An **empty collection** (`[]`, `{}`, `#{}`, `'()`) is a *terminal
+leaf*, not a container to recurse into — it has no descendant slots.
+The projection classifies an empty-collection slot exactly as it
+classifies a scalar:
+
+- Inside a wholly-**added** subtree (absent → present), an empty-
+  collection leaf classifies `:added` — the same green chrome as every
+  other leaf under the new subtree. The absent↔empty-collection
+  transition is a real change the operator must see.
+- Symmetrically, inside a wholly-**removed** subtree, an empty-
+  collection leaf classifies `:removed` (red).
+- An empty-collection leaf that is **identical on both sides** stays
+  `:same`. Its presence never falsely promotes an otherwise-mixed
+  container to a wholly-changed root.
+
+The rule is **kind-agnostic** — `(container? v)` + `(empty? v)` covers
+all four collection kinds, not just the vec + map first witnessed in
+the step-deck epoch-2 `:rf/runtime` allocation (`:messages []` +
+`:rf/spawn-counter {}`).
+
+> **Why this is a contract, not an edge case.** Editscript's A* treats
+> empty-collection-vs-absence as a no-diff (it emits no edit-script
+> entry), so the projection's leaf-expansion would drop the slot and
+> `op-at` would fall through to `:same` — the *only* path inside an
+> otherwise wholly-green added subtree that would lie to the operator.
+> Both the leaf-expansion walker and the wholly-changed uniformity
+> walker treat the empty container as a leaf so the two agree on the
+> classification (rf2-bufw2; this is the third operator-honesty fix in
+> the FULL+DIFF family alongside rf2-9d4j8 root-container and
+> rf2-fyd8u scalar-sub-cache cases).
+
 ## Colour coding
 
 | Op | Visual |

--- a/tools/xray/src/day8/re_frame2_xray/diff/engine.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/diff/engine.cljc
@@ -384,9 +384,27 @@
   "When an edit at `path` operates on a container value (e.g. `[[:flash] :+
   {:level :ok :text \"hi\"}]`), expand it into per-leaf paths so the
   renderer's path-keyed lookup finds an op at every descendant slot. The
-  expansion is recursive over maps / vectors / sets. Pure."
+  expansion is recursive over maps / vectors / sets. Pure.
+
+  rf2-bufw2 — an EMPTY container (`[]`, `{}`, `#{}`, `'()`) is itself a
+  terminal leaf the operator navigates to and sees in the tree: it has
+  no descendant slots to recurse into, so the recursive branches below
+  would emit NOTHING and the slot would fall through `op-at` to `:same`
+  — the only path inside a wholly-`:+`/`:-` subtree that would lie to
+  the operator (a green-`:added` cascade with two muted `:same` empty
+  slots). The renderer treats empty containers as leaf rows (see
+  `render-node`'s `empty?` branch); the engine must classify them as
+  leaves too. Emit the empty container as a single leaf op so the
+  absent↔empty-collection transition surfaces honestly. The check is
+  `container?` + `empty?` (NOT type-specific) because the equivalence
+  covers all four collection kinds, and ordering it before the
+  recursive branches keeps the per-kind walks for the non-empty case
+  untouched."
   [path op value]
   (cond
+    (and (container? value) (empty? value))
+    [{:path path :op op :value value}]
+
     (map? value)
     (mapcat (fn [[k cv]] (expand-leaf-paths (conj (vec path) k) op cv)) value)
 
@@ -433,6 +451,21 @@
   (let [collect-leaves
         (fn collect-leaves [data path]
           (cond
+            ;; rf2-bufw2 — an empty container is a terminal leaf (it has
+            ;; no descendant slots), exactly as `expand-leaf-paths`
+            ;; treats it. The two walkers MUST agree on what a leaf is:
+            ;; if `collect-leaves` skipped an empty-collection slot, a
+            ;; container whose only changed descendants are real `:added`
+            ;; leaves alongside an UNCHANGED (`:same`) empty-collection
+            ;; sibling would be falsely promoted to wholly-changed
+            ;; `:added` (the empty slot being invisible to the
+            ;; uniformity check). Emitting it as a leaf lets
+            ;; `check-uniform` see its `path-ops` op (`:same` when
+            ;; unchanged, `:added`/`:removed` when inside a genuinely
+            ;; wholly-changed subtree) and decide correctly.
+            (and (container? data) (empty? data))
+            [path]
+
             (map? data)
             (mapcat (fn [[k cv]] (collect-leaves cv (conj (vec path) k))) data)
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/diff_engine_consistency_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/diff_engine_consistency_cljs_test.cljc
@@ -171,3 +171,107 @@
     (let [db {:counter 5 :user {:id 7}}]
       (is (= [] (universal-diff db db))
           "identical map → empty diff"))))
+
+;; ---- rf2-bufw2 empty-collection leaves in changed subtrees --------------
+;;
+;; Inside a wholly-`:added` (or wholly-`:removed`) subtree, an empty-
+;; collection leaf (`[]`, `{}`, `#{}`, `'()`) used to fall through
+;; `op-at` to `:same` — `expand-leaf-paths` recursed into a container
+;; with zero descendant slots and emitted NOTHING, so no `:path-ops`
+;; entry existed. The leaf was the only path in the subtree that lied
+;; to the operator (a green-`:added` cascade with muted `:same` empty
+;; slots). The fix classifies an empty container as a terminal leaf in
+;; BOTH walkers — `expand-leaf-paths` (so the slot carries an explicit
+;; op) and `mark-wholly-changed`'s `collect-leaves` (so the uniformity
+;; check sees the slot and a `:same` empty sibling doesn't get falsely
+;; swept into a wholly-changed promotion). The equivalence is NOT
+;; type-specific: `(container? v)` + `(empty? v)` covers all four kinds.
+
+(def ^:private empty-collections
+  "The four empty-collection kinds the equivalence covers."
+  {:vec  []
+   :map  {}
+   :set  #{}
+   :list '()})
+
+(defn- build-projection
+  "Thin alias for `engine/project` matching the bead's vocabulary."
+  [before after]
+  (engine/project before after))
+
+(deftest empty-collection-leaf-added-direct
+  (testing "rf2-bufw2 — a wholly-added empty-collection leaf at depth 2
+            classifies `:added`, not `:same`, for every collection kind."
+    (doseq [[kind empty-coll] empty-collections]
+      (let [proj (build-projection {} {:a {:b empty-coll}})]
+        (is (= :added (engine/op-at proj [:a :b]))
+            (str "empty " (name kind) " leaf inside an added subtree is :added"))
+        ;; the container that holds the lone empty leaf is wholly-added
+        (is (= :added (engine/op-at proj [:a]))
+            (str "container of a lone added empty " (name kind) " is wholly-:added"))))))
+
+(deftest empty-collection-leaf-added-deeply-nested
+  (testing "rf2-bufw2 — the inheritance holds ≥3 levels deep inside the
+            added subtree (the live epoch-2 witness sat 6 levels deep)."
+    (doseq [[kind empty-coll] empty-collections]
+      (let [proj (build-projection {} {:root {:x {:y {:z empty-coll}}}})]
+        (is (= :added (engine/op-at proj [:root :x :y :z]))
+            (str "deeply-nested empty " (name kind) " leaf is :added"))))))
+
+(deftest empty-collection-leaf-removed-direct
+  (testing "rf2-bufw2 — symmetric: a wholly-removed empty-collection
+            leaf (before-side empty, after-side absent) classifies
+            `:removed`, not `:same`, for every collection kind."
+    (doseq [[kind empty-coll] empty-collections]
+      (let [proj (build-projection {:a {:b empty-coll}} {})]
+        (is (= :removed (engine/op-at proj [:a :b]))
+            (str "empty " (name kind) " leaf inside a removed subtree is :removed"))))))
+
+(deftest empty-collection-leaf-removed-deeply-nested
+  (testing "rf2-bufw2 — symmetric removed inheritance ≥3 levels deep."
+    (doseq [[kind empty-coll] empty-collections]
+      (let [proj (build-projection {:root {:x {:y {:z empty-coll}}}} {})]
+        (is (= :removed (engine/op-at proj [:root :x :y :z]))
+            (str "deeply-nested empty " (name kind) " leaf is :removed"))))))
+
+(deftest empty-collection-leaf-epoch2-witness
+  (testing "rf2-bufw2 — the live step-deck epoch-2 :rf/runtime allocation:
+            `:messages []` and `:rf/spawn-counter {}` paint :added (green)
+            alongside every other leaf under the wholly-added subtree —
+            no :same paint anywhere in the cascade."
+    (let [after {:rf/runtime
+                 {:machines
+                  {:snapshots
+                   {:ws/connection
+                    {:state :disconnected
+                     :data  {:connections 0
+                             :messages    []}
+                     :rf/spawn-counter {}}}}}}
+          proj (build-projection {} after)
+          messages-path [:rf/runtime :machines :snapshots :ws/connection :data :messages]
+          spawn-path    [:rf/runtime :machines :snapshots :ws/connection :rf/spawn-counter]]
+      (is (= :added (engine/op-at proj messages-path))
+          "`:messages []` paints :added, not :same")
+      (is (= :added (engine/op-at proj spawn-path))
+          "`:rf/spawn-counter {}` paints :added, not :same")
+      (is (= :added (engine/op-at proj [:rf/runtime]))
+          "the whole :rf/runtime subtree is wholly-:added"))))
+
+(deftest empty-collection-leaf-same-container-does-not-inherit
+  (testing "rf2-bufw2 — the mid-tree boundary: an UNCHANGED empty-
+            collection leaf does NOT inherit a changed classification.
+            Only genuine absent↔empty transitions classify; an empty
+            collection that is identical on both sides stays `:same`,
+            and its presence must not falsely promote an otherwise
+            mixed container to wholly-changed."
+    (doseq [[kind empty-coll] empty-collections]
+      ;; `:b` is unchanged (empty both sides); a sibling key `:c` is added.
+      (let [proj (build-projection {:a {:b empty-coll}}
+                                   {:a {:b empty-coll :c 1}})]
+        (is (= :same (engine/op-at proj [:a :b]))
+            (str "unchanged empty " (name kind) " leaf stays :same"))
+        (is (= :added (engine/op-at proj [:a :c]))
+            "the genuinely-added sibling is :added")
+        (is (= :children (engine/op-at proj [:a]))
+            (str "container with a :same empty " (name kind)
+                 " + one :added sibling is :children, NOT wholly-:added"))))))


### PR DESCRIPTION
rf2-bufw2 — empty-collection leaves (`[]`, `{}`, `#{}`, `'()`) inside a wholly-`:added`/`:removed` subtree now classify `:added`/`:removed` (green/red) instead of falling through `op-at` to `:same`, so the FULL+DIFF inspector stops lying about the only slots in an otherwise-honest changed cascade.

## Quality gates

- **`cd tools/xray && clojure -M:test`** (JVM; the `.cljc` consistency + engine tests run here): **964 tests, 3802 assertions, 0 failures, 0 errors** (baseline was 958 / 3767 → +6 tests, +35 assertions from this PR's new fixtures).
- **`implementation/ npm run test:xray-feature-gate`**: 13/14 scenarios PASS. The single failure — **multi-frame isolation substrate** (`waitForValue: expected epoch panel projection after focusing B cascade within 5000ms`) — is **pre-existing on the clean baseline** (verified by running the gate on a fresh worktree at `7f1f93234` with no changes: identical failure, identical scenario). It is an epoch-panel / frame-focus timing issue unrelated to diff classification; all 13 diff-relevant scenarios pass.
- **`bash scripts/test-fast-pr.sh`**: PASS — gate-report / browser-report / harness unit tests, CLJS node integration **4820 tests, 15792 assertions, 0 failures, 0 errors**, lockstep + skill/MCP drift + core, plus markdown gates (README link/anchor + docs corpus anchor validators PASS). `mkdocs --strict build` soft-skipped locally (mkdocs not on PATH on Windows) — **CI must run it**; watch the docs gate.

## Design notes

**Root cause.** Editscript treats empty-collection-vs-absence as a no-diff (emits no edit-script entry). `expand-leaf-paths` then recursed into the empty container, found zero descendant slots, and emitted nothing — so no `:path-ops` entry existed and `op-at` fell through to `:same`.

**Fix (engine-only, two symmetric one-branch changes).** An empty container is a *terminal leaf*, not a container to recurse into — exactly how `render-node` already renders it (the `empty?` branch). I taught both engine walkers this:

1. `expand-leaf-paths` — emit `(and (container? v) (empty? v))` as a single leaf op (carrying the `:+`/`:-` op), so the slot gets an explicit `:added`/`:removed` entry.
2. `mark-wholly-changed`'s `collect-leaves` — treat the empty container as a leaf too, so the uniformity check *sees* the slot. Without this the two walkers disagree: a container with one real `:added` leaf beside a `:same` empty-collection sibling would be falsely promoted to a wholly-changed `:added` root (the empty slot being invisible). With it, the slot's `path-ops` op (`:same` when unchanged) is honoured.

The check is `container?` + `empty?` — kind-agnostic, covering all four collection kinds (the equivalence is not type-specific; the epoch-2 witness happened to be vec + map). Ordered before the recursive branches so the non-empty walks are untouched.

**Why not the `op-at` walk-up the bead sketched.** The bead's worked example assumed a classified ancestor to inherit from, but the bead's own acceptance fixtures (`(op-at (project {} {:a {:b []}}) [:a :b]) ⇒ :added`) have NO classified ancestor — the whole projection is empty when the empty collection is the only added value, so walk-up is unsatisfiable there. Fixing the data at the expansion stage (same philosophy as the existing `expand-empty-map-replacement` / rf2-9d4j8 precedent) satisfies BOTH the isolated fixtures and the epoch-2 nested witness, and is strictly more correct — every downstream consumer (`:path-ops`, `:container-ops`, `:flat-rows`, wholly-changed promotion, the renderer) sees consistent leaf granularity. No `op-at` change, no walk-up heuristic, no read-time patch.

**No `edn_inspector` change.** The renderer reads the op via `engine/op-at projection path` for both containers (`render-node`'s `empty?` branch) and leaves; the corrected `path-ops` / `container-ops` flow straight through. The `missing-sentinel` fallback only fires for projection-less test-direct calls and is untouched.

**Tests.** New `diff_engine_consistency_cljs_test.cljc` fixtures pin all four kinds × {added, removed} × {direct, ≥3-levels-deep}, the live epoch-2 witness (`:messages []` + `:rf/spawn-counter {}` ⇒ `:added`), and the negative boundary (an unchanged empty-collection leaf stays `:same` and does NOT promote its mixed parent to wholly-changed).

**Spec.** `tools/xray/spec/004-App-DB-Diff.md` gains an "Empty-collection leaves are honest leaves (rf2-bufw2)" subsection documenting the kind-agnostic absent↔empty classification rule and why it is a contract (third operator-honesty fix in the FULL+DIFF family alongside rf2-9d4j8 / rf2-fyd8u).

**Risk.** Low. Confined to the two engine walkers; behaviour change is limited to empty-collection slots that previously emitted nothing. The pre-existing multi-frame gate failure is environment timing, not regression — flagged above for the mayor to watch CI.
