### PR TITLE
fix(xray): re-target frame before focusing cross-frame cascade in multi-frame gate (rf2-25n9r)

### DIFF
--- a/tools/xray/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/xray/testbeds/feature_matrix/scenarios.cjs
@@ -1291,6 +1291,21 @@ async function runMultiFrame(page, state) {
   // then asserting the event-detail projection. We look up the
   // dispatch-id by walking the bus buffer for the (frame, event-id)
   // pair, which is independent of the cascade-scoped Trace DOM.
+  //
+  // The L2 event list is frame-scoped: in a multi-frame app the
+  // operator first picks the frame they want to inspect (the L1
+  // frame-picker → `:rf.xray/set-target-frame`, which re-seeds the
+  // Xray `:epoch-history` slot from THAT frame's per-frame ring), and
+  // only then does that frame's cascade appear in L2 to click. So we
+  // re-target Xray onto :counter/b BEFORE focusing the B cascade —
+  // mirroring the real picker gesture and the CLJS e2e analogue
+  // `multi_frame_isolation_e2e_cljs_test/xray-focused-frame-tracks-
+  // host-dispatch-frame`. Without the re-seed the focus event resolves
+  // dispatch-id 19's `:epoch-id` against the previously-targeted
+  // frame's history (no match → nil), so the Epoch panel's
+  // head-fallback renders that frame's head cascade (the :log
+  // :log-append fan-out) instead of the chosen :counter/b :inc.
+  await setXrayTargetFrame(page, ':counter/b');
   const selected = await focusCascadeByFrameEvent(page, {
     frame: ':counter/b',
     eventId: ':multi-frame.core/inc',


### PR DESCRIPTION
## Summary

The `multi-frame isolation substrate` scenario in `test:xray-feature-gate` was failing **deterministically** (reproduced 3/3 local runs, identical failure each time — not a flake). `runMultiFrame` focused a `:counter/b` cascade by dispatch-id via `:rf.xray/focus-cascade` **without first re-targeting Xray onto `:counter/b`**.

### Root cause

The Xray app-db carries a single `:epoch-history` slot keyed to `:target-frame`. `:rf.xray/focus-cascade` does **not** re-seed that slot — only `:rf.xray/set-target-frame` / `:rf.xray/set-frame` do (`epoch.cljs`, `spine/set-frame-reducer`). So the focus handler resolved the cascade's `:epoch-id` via `epoch-id-for-cascade` against the **previously-targeted** frame's history → no match → `nil`. The Epoch panel sub (`epoch_panel.cljs`) pivots on `:epoch-id`; a `nil` epoch-id with non-empty history triggers `find-epoch-record`'s **head-fallback** (`focus_resolver.cljc`), which rendered the targeted frame's HEAD cascade (the `:log` / `:multi-frame.core/log-append` fan-out) instead of the chosen `:counter/b` / `:multi-frame.core/inc`.

Production is correct: the canonical frame-switch (`:rf.xray/select-frame` → `:rf.xray/set-frame`) re-seeds `:epoch-history`, and the L2 event list is frame-scoped — a real operator picks the frame first, so this gesture sequence never arises in the UI. The scenario skipped that step.

### Fix

`runMultiFrame` now calls `setXrayTargetFrame(page, ':counter/b')` before `focusCascadeByFrameEvent` — mirroring the real picker gesture **and** the already-passing CLJS e2e analogue `multi_frame_isolation_e2e_cljs_test/xray-focused-frame-tracks-host-dispatch-frame` (which does `set-target-frame` first). Test-surface only; no production code change.

**Spec unchanged** — no contract change, only the test gesture order was corrected.

### Note (separate issue)

The expensive-tests **nightly** redness is NOT this case: the `Browser/bundle/examples/Story-Xray gates` job runs all gates in one `set -euo pipefail` block and aborts at `test:story-feature-load` (8th) before `test:xray-feature-gate` (10th) ever runs. That Story-surface regression is filed separately as **rf2-5fyo3**.

## Quality gates

- `npm run test:xray-feature-gate`: **14/14, 0 failures** (was 1 failure pre-fix; confirmed 3/3 deterministic before, 0/3 after)
- `cd tools/xray && clojure -M:test`: **964 tests, 0 failures, 0 errors**
- `scripts/test-fast-pr.sh`: **PASS** (core JVM 795 tests 0 failures; JS harness helpers; CLJS node integration — all green)

Closes rf2-25n9r.