### PR TITLE
feat(re-frame2-pair-mcp): discover-app ergonomics — colon-tolerant build, unified ids, single-build auto-select, port→build (4 beads incl. rf2-8ohwv bug)

### DIFF
--- a/skills/re-frame2-pair/SKILL.md
+++ b/skills/re-frame2-pair/SKILL.md
@@ -126,8 +126,10 @@ This locates the shadow-cljs nREPL port, connects, switches the session to `:clj
 
 | Arg | Form | Examples |
 |---|---|---|
-| `build` | bare build id; a leading colon is also tolerated (rf2-8ohwv) | `"examples/step-deck"` or `":examples/step-deck"` — identical |
+| `build` | bare build id; a leading colon is also tolerated (rf2-8ohwv). **Omit it when one build is running** — discover-app auto-selects it (rf2-v70kv) | `"examples/step-deck"` or `":examples/step-deck"` — identical |
 | `frame` / `frames` | keyword **with** the colon | `":rf/default"`, `":step-deck"`, `[":rf/default" ":rf/xray"]` |
+
+**Single-build auto-selection (rf2-v70kv).** You usually don't need to pass `build` at all. When exactly one shadow-cljs build is running, a no-arg `discover-app` selects it and reports `:auto-selected-build` plus an explanatory `:note`. When several run, it errors with the running-builds list so you can pick — it never silently guesses.
 
 **Output representation.** discover-app reports every build/frame id (`:build-id`, `:frames`, `:running-builds`) as a **full keyword** (`:rf/default`, `:examples/step-deck`) in the canonical EDN result, and its `:note` / `:hint` prose uses the same colon form — one representation throughout. (Hosts that surface the `:structuredContent` JSON view will show the colon stripped — `"rf/default"` — that's the documented lossy JSON projection; read the EDN text for the id exactly as you'd type it back into a `:frame` arg.)
 

--- a/skills/re-frame2-pair/SKILL.md
+++ b/skills/re-frame2-pair/SKILL.md
@@ -122,6 +122,15 @@ discover-app
 
 This locates the shadow-cljs nREPL port, connects, switches the session to `:cljs` mode for the running build, verifies re-frame2 is loaded with `interop/debug-enabled?` true, and confirms the `re-frame2-pair.runtime` namespace was loaded by the consumer's `:devtools :preloads` (see §Setup above).
 
+**Arg forms (don't guess; rf2-cg37y).** Each arg has one expected shape:
+
+| Arg | Form | Examples |
+|---|---|---|
+| `build` | bare build id; a leading colon is also tolerated (rf2-8ohwv) | `"examples/step-deck"` or `":examples/step-deck"` — identical |
+| `frame` / `frames` | keyword **with** the colon | `":rf/default"`, `":step-deck"`, `[":rf/default" ":rf/xray"]` |
+
+**Output representation.** discover-app reports every build/frame id (`:build-id`, `:frames`, `:running-builds`) as a **full keyword** (`:rf/default`, `:examples/step-deck`) in the canonical EDN result, and its `:note` / `:hint` prose uses the same colon form — one representation throughout. (Hosts that surface the `:structuredContent` JSON view will show the colon stripped — `"rf/default"` — that's the documented lossy JSON projection; read the EDN text for the id exactly as you'd type it back into a `:frame` arg.)
+
 If any precondition fails, the script returns a structured edn error like `{:ok? false :reason :runtime-not-preloaded}`. Report the failing check to the user verbatim; do *not* guess at workarounds. See [references/errors.md](references/errors.md) for the common error reasons and the recovery each one calls for.
 
 **Port discovery (canonical MCP transport).** On the first tool call the MCP server discovers the live shadow-cljs nREPL via a five-step cascade — `--port-file <abs>` flag, then `$SHADOW_CLJS_NREPL_PORT` env var, then **MCP `roots/list`** asking the agent host for its open workspace roots and walking each for `shadow-cljs.edn` + `.shadow-cljs/nrepl.port` (rf2-3grub — the zero-config primary path), then shadow's HTTP probe at `:9630/api/project-info` (rf2-umoz2), then a CWD-relative scan. Multiple running shadow builds in the workspace trigger an `elicitation/create` prompt so the user picks the project to attach to. Shadow restarts are absorbed transparently — every subsequent tool call re-reads the cached port file and reconnects if it changed.

--- a/skills/re-frame2-pair/SKILL.md
+++ b/skills/re-frame2-pair/SKILL.md
@@ -127,9 +127,12 @@ This locates the shadow-cljs nREPL port, connects, switches the session to `:clj
 | Arg | Form | Examples |
 |---|---|---|
 | `build` | bare build id; a leading colon is also tolerated (rf2-8ohwv). **Omit it when one build is running** — discover-app auto-selects it (rf2-v70kv) | `"examples/step-deck"` or `":examples/step-deck"` — identical |
+| `port` | integer — the port from the browser URL (rf2-fyf0h) | `8031` — see *Connecting from a URL* below |
 | `frame` / `frames` | keyword **with** the colon | `":rf/default"`, `":step-deck"`, `[":rf/default" ":rf/xray"]` |
 
 **Single-build auto-selection (rf2-v70kv).** You usually don't need to pass `build` at all. When exactly one shadow-cljs build is running, a no-arg `discover-app` selects it and reports `:auto-selected-build` plus an explanatory `:note`. When several run, it errors with the running-builds list so you can pick — it never silently guesses.
+
+**Connecting from a URL (rf2-fyf0h).** When you only know the browser URL of the open tab (e.g. `http://localhost:8031/counter`) and several builds are running, pass the port instead of hunting for the build id: `discover-app {port: 8031}`. discover-app reads the shadow-cljs `:dev-http` map and resolves the build whose `:output-dir` is served on that port (8031 → `:examples/step-deck` in this repo) — no manual grep of `shadow-cljs.edn`. A `:port` that matches no build returns `{:ok? false :reason :port-unresolved}` rather than silently falling back. An explicit `:build` arg wins over `:port` if you pass both.
 
 **Output representation.** discover-app reports every build/frame id (`:build-id`, `:frames`, `:running-builds`) as a **full keyword** (`:rf/default`, `:examples/step-deck`) in the canonical EDN result, and its `:note` / `:hint` prose uses the same colon form — one representation throughout. (Hosts that surface the `:structuredContent` JSON view will show the colon stripped — `"rf/default"` — that's the documented lossy JSON projection; read the EDN text for the id exactly as you'd type it back into a `:frame` arg.)
 

--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -282,7 +282,9 @@ Verify the shadow-cljs nREPL is reachable, confirm the
 shadow-cljs `:devtools :preloads`, and return a health summary. Run
 first every session.
 
-**Args**: `build` (string, optional, default `"app"`).
+**Args**: `build` (string, optional, default `"app"`). Colon-tolerant
+(rf2-8ohwv) — `"examples/step-deck"` and `":examples/step-deck"` resolve
+to the same build id; a doubled colon never reaches the resolver.
 
 **Returns**: an `:ok? true` map with `:debug-enabled?`, `:frames`,
 `:coord-annotation-enabled?`, `:build-id`. On success the resolved

--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -292,6 +292,18 @@ build-id is cached on the conn-atom (`:resolved-build-id`, rf2-l9ixp);
 subsequent tool calls may omit the `:build` arg — see
 [`API.md` §Build-id resolution](./API.md#build-id-resolution).
 
+**Id representation (rf2-cg37y).** Every build/frame id discover-app
+surfaces — `:build-id`, `:frames`, and the diagnostic `:running-builds`
+— is a **full keyword** (`:rf/default`, `:examples/step-deck`) in the
+canonical EDN `:content` text slot, and the embedded `:note` / `:hint`
+strings re-state them in the same colon form. One representation
+throughout that slot, so a first-time caller never has to guess which
+field uses which form. The sibling `:structuredContent` JSON slot is the
+documented lossy projection (`clj->js` drops the leading colon —
+`["rf/default"]`); it is the SDK-friendly fallback, not the canonical
+form. Read the EDN text when you want the id exactly as you would type
+it back into a `:frame` arg.
+
 On a precondition failure the response is `:ok? false` with a
 `:reason` keyword. The runtime ships into the app via shadow-cljs
 `:preloads`; the server probes

--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -232,7 +232,7 @@ load-bearing: each carries different recovery semantics.
 
 | Dialect       | Meaning                                                            | Example reasons                                                                              |
 |---------------|--------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
-| **Bare**      | Per-call validation / runtime failure (the normal tool body ran)   | `:invalid-kind`, `:missing-path`, `:not-an-event-vector`, `:path-not-found`, `:unknown-tool`, `:runtime-not-preloaded`, `:nrepl-unreachable`, `:build-not-running`, `:no-runtime-connected`, `:runtime-loaded-but-preload-missing`, `:eval-error`, `:timed-out`, `:probe-errored`, `:<verb>-failed` (e.g. `:snapshot-failed`, `:dispatch-failed`) |
+| **Bare**      | Per-call validation / runtime failure (the normal tool body ran)   | `:invalid-kind`, `:missing-path`, `:not-an-event-vector`, `:path-not-found`, `:unknown-tool`, `:runtime-not-preloaded`, `:nrepl-unreachable`, `:build-not-running`, `:no-runtime-connected`, `:runtime-loaded-but-preload-missing`, `:port-unresolved`, `:eval-error`, `:timed-out`, `:probe-errored`, `:<verb>-failed` (e.g. `:snapshot-failed`, `:dispatch-failed`) |
 | `:rf.error/*` | Operator-gated denial OR shared cross-MCP error vocabulary — the server refused **without touching nREPL** because a boot-flag / resource cap rejected the call before the tool body ran, OR the call ran but failed in a way that warrants the shared cross-MCP error vocabulary (rf2-xn4f9: `:rf.error/eval-cljs-rejected` + `:rf.error/eval-cljs-timeout` are bare-shaped per-call failures but adopt the namespace so an agent host can pattern-match the eval-cljs error cluster as one family) | `:rf.error/eval-cljs-disabled`, `:rf.error/eval-cljs-rejected`, `:rf.error/eval-cljs-timeout`, `:rf.error/concurrent-stream-limit`, `:rf.error/stream-abuse-detected` |
 | `:rf.mcp/*`   | Wire-replacement-marker family (otherwise reserved for substitution markers like `:rf.mcp/overflow`, `:rf.mcp/dedup-table`, `:rf.mcp/cache-hit`, `:rf.mcp/summary`, `:rf.mcp/diff-from`). One carve-out as a `:reason` value: `:rf.mcp/cursor-stale` — cursor-staleness is detected at the wire boundary itself (the cursor envelope), not via tool body or boot gate, so it shares the `:rf.mcp/*` prefix with the rest of the wire-boundary vocabulary | `:rf.mcp/cursor-stale` (the only `:rf.mcp/*` `:reason` value) |
 
@@ -282,9 +282,21 @@ Verify the shadow-cljs nREPL is reachable, confirm the
 shadow-cljs `:devtools :preloads`, and return a health summary. Run
 first every session.
 
-**Args**: `build` (string, optional). Colon-tolerant (rf2-8ohwv) —
-`"examples/step-deck"` and `":examples/step-deck"` resolve to the same
-build id; a doubled colon never reaches the resolver.
+**Args**: `build` (string, optional) and `port` (integer, optional).
+`build` is colon-tolerant (rf2-8ohwv) — `"examples/step-deck"` and
+`":examples/step-deck"` resolve to the same build id; a doubled colon
+never reaches the resolver.
+
+**URL/port → build (rf2-fyf0h).** A pair session naturally starts from
+the browser URL of the open tab (e.g. `http://localhost:8031/counter`),
+but discover-app speaks build-ids. Pass the URL's port as `port` and
+discover-app resolves the serving build from the shadow-cljs `:dev-http`
+map — which binds a port to a list of file roots; the serving build is
+the one whose `:output-dir` is among those roots (`8031` →
+`:examples/step-deck` in this repo). No manual grep of `shadow-cljs.edn`.
+A `port` that maps to no build returns `:ok? false :reason
+:port-unresolved` (loud, not a silent fall-through to `:app` — the
+operator asked for that port). An explicit `build` arg wins over `port`.
 
 **Single-build auto-selection (rf2-v70kv).** When you omit `build` and
 **exactly one** shadow-cljs build is running, discover-app auto-selects

--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -282,9 +282,22 @@ Verify the shadow-cljs nREPL is reachable, confirm the
 shadow-cljs `:devtools :preloads`, and return a health summary. Run
 first every session.
 
-**Args**: `build` (string, optional, default `"app"`). Colon-tolerant
-(rf2-8ohwv) — `"examples/step-deck"` and `":examples/step-deck"` resolve
-to the same build id; a doubled colon never reaches the resolver.
+**Args**: `build` (string, optional). Colon-tolerant (rf2-8ohwv) —
+`"examples/step-deck"` and `":examples/step-deck"` resolve to the same
+build id; a doubled colon never reaches the resolver.
+
+**Single-build auto-selection (rf2-v70kv).** When you omit `build` and
+**exactly one** shadow-cljs build is running, discover-app auto-selects
+it (rather than defaulting to `:app`, which fails by construction on any
+checkout whose running watch isn't `:app`). The result echoes
+`:auto-selected-build <id>` and prepends an auto-selection sentence to
+`:note`, so the choice is visible — never silent. When **zero or many**
+builds run, discover-app keeps the `:app` default and the failure-path
+diagnostic ladder surfaces `:build-not-running` with the running-builds
+list (the multi-build path stays ambiguous-and-loud — discover-app does
+**not** guess a most-recently-active build). An explicit `build` arg (or
+a build cached by a prior discover-app) is honoured verbatim and skips
+auto-selection.
 
 **Returns**: an `:ok? true` map with `:debug-enabled?`, `:frames`,
 `:coord-annotation-enabled?`, `:build-id`. On success the resolved

--- a/tools/re-frame2-pair-mcp/spec/API.md
+++ b/tools/re-frame2-pair-mcp/spec/API.md
@@ -84,7 +84,13 @@ impl: [`src/re_frame2_pair_mcp/tools/wire.cljs`](../src/re_frame2_pair_mcp/tools
 `arg-build`, lines 125-146):
 
 1. **Explicit `:build` MCP arg on the call.** Operator override always
-   wins; no surprise from the cache.
+   wins; no surprise from the cache. The arg is **colon-tolerant**
+   (rf2-8ohwv): `"examples/step-deck"` and `":examples/step-deck"`
+   resolve to the same keyword — coerced via
+   `re-frame.mcp-base.args/fresh-keyword`, which strips a leading colon
+   before interning. A bare `keyword` on the colon form would mint the
+   malformed `::examples/step-deck` and probe a build that doesn't
+   exist; that footgun is closed.
 2. **Session-scoped `:resolved-build-id` cache on the conn-atom.**
    Populated by `discover-app` after a successful preload probe
    (`wire/mark-resolved-build-id!`, `src/.../tools/wire.cljs` line 108;

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/descriptors_data.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/descriptors_data.cljs
@@ -205,17 +205,20 @@
   {:name "discover-app"
    :description (str "Verify the shadow-cljs nREPL is reachable, confirm the re-frame2-pair runtime preload landed, and report a health summary. Run this first every session. Returns :reason :runtime-not-preloaded when the preload entry is missing. "
                      "Examples: "
-                     "1. Default build: {} -> {:ok? true :debug-enabled? true :frames [:rf/default] :coord-annotation-enabled? true :build-id :app}. "
-                     "2. Named build: {:build \"app\"} -> same shape against the named build. "
+                     "1. No arg, exactly one build running: {} -> auto-selects it: {:ok? true :debug-enabled? true :frames [:rf/default] :coord-annotation-enabled? true :build-id :examples/step-deck :auto-selected-build :examples/step-deck :note \"...auto-selected it.\"}. "
+                     "2. Named build: {:build \"app\"} -> {:ok? true ... :build-id :app}, no auto-selection (explicit build honoured verbatim). "
                      "3. Preload missing: {} -> {:ok? false :reason :runtime-not-preloaded :hint \"...\"}.")
    :typicalTokens 200
    :annotations idempotent-read-only-annotations
    :outputSchema envelope-or-marker
    :inputSchema {:type "object"
                  :properties {:build {:type "string"
-                                      :description (str "shadow-cljs build id (default: app). Colon-tolerant: "
+                                      :description (str "shadow-cljs build id. Colon-tolerant: "
                                                         "\"examples/step-deck\" and \":examples/step-deck\" "
-                                                        "resolve identically (rf2-8ohwv).")}}
+                                                        "resolve identically (rf2-8ohwv). "
+                                                        "Omit it when exactly one build is running — discover-app "
+                                                        "auto-selects it and notes the choice (rf2-v70kv). "
+                                                        "Falls back to app when none can be inferred.")}}
                  :additionalProperties false}})
 
 ;; ---------------------------------------------------------------------------

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/descriptors_data.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/descriptors_data.cljs
@@ -213,7 +213,9 @@
    :outputSchema envelope-or-marker
    :inputSchema {:type "object"
                  :properties {:build {:type "string"
-                                      :description "shadow-cljs build id (default: app)"}}
+                                      :description (str "shadow-cljs build id (default: app). Colon-tolerant: "
+                                                        "\"examples/step-deck\" and \":examples/step-deck\" "
+                                                        "resolve identically (rf2-8ohwv).")}}
                  :additionalProperties false}})
 
 ;; ---------------------------------------------------------------------------

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/descriptors_data.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/descriptors_data.cljs
@@ -207,7 +207,8 @@
                      "Examples: "
                      "1. No arg, exactly one build running: {} -> auto-selects it: {:ok? true :debug-enabled? true :frames [:rf/default] :coord-annotation-enabled? true :build-id :examples/step-deck :auto-selected-build :examples/step-deck :note \"...auto-selected it.\"}. "
                      "2. Named build: {:build \"app\"} -> {:ok? true ... :build-id :app}, no auto-selection (explicit build honoured verbatim). "
-                     "3. Preload missing: {} -> {:ok? false :reason :runtime-not-preloaded :hint \"...\"}.")
+                     "3. From a browser URL's port: {:port 8031} -> resolves the build serving that port via the shadow-cljs :dev-http map: {:ok? true ... :build-id :examples/step-deck}. {:port <unmapped>} -> {:ok? false :reason :port-unresolved}. "
+                     "4. Preload missing: {} -> {:ok? false :reason :runtime-not-preloaded :hint \"...\"}.")
    :typicalTokens 200
    :annotations idempotent-read-only-annotations
    :outputSchema envelope-or-marker
@@ -218,7 +219,15 @@
                                                         "resolve identically (rf2-8ohwv). "
                                                         "Omit it when exactly one build is running — discover-app "
                                                         "auto-selects it and notes the choice (rf2-v70kv). "
-                                                        "Falls back to app when none can be inferred.")}}
+                                                        "Falls back to app when none can be inferred.")}
+                              :port {:type "integer"
+                                     :description (str "Resolve the serving build from a browser URL's port via "
+                                                       "the shadow-cljs :dev-http map (rf2-fyf0h). E.g. you opened "
+                                                       "http://localhost:8031/counter -> pass {:port 8031} and "
+                                                       "discover-app finds the build whose :output-dir is served "
+                                                       "on that port — no manual grep of shadow-cljs.edn. A port "
+                                                       "that maps to no build -> :reason :port-unresolved. Ignored "
+                                                       "when :build is given.")}}
                  :additionalProperties false}})
 
 ;; ---------------------------------------------------------------------------

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/discover_app.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/discover_app.cljs
@@ -3,30 +3,60 @@
   (:require [re-frame2-pair-mcp.tools.wire :as wire]
             [re-frame2-pair-mcp.tools.probe :as probe]))
 
+(defn- port-unresolved-result
+  "Error envelope for a `:port` arg that didn't resolve to a build via
+  the `:dev-http` map (rf2-fyf0h)."
+  [port]
+  (wire/ok-text
+    {:ok?    false
+     :reason :port-unresolved
+     :port   port
+     :hint   (str "No shadow-cljs build serves port " port " via the "
+                  ":dev-http map (the port may be missing from :dev-http, "
+                  "or no build's :output-dir matches its file roots). "
+                  "Check the port in your browser's address bar, or pass "
+                  ":build with the build-id directly.")}))
+
 (defn- resolve-build-id
-  "Resolve the build-id discover-app should probe. Returns a Promise of
-  `[build-id auto-selected?]`.
+  "Resolve the build discover-app should probe. Returns a Promise of a
+  result map. Precedence (highest first):
 
-  When the caller passed an explicit `:build` arg (or a prior
-  discover-app cached one on the conn), `wire/arg-build` already carries
-  a deliberate choice — honour it verbatim, never auto-select.
+    1. Explicit `:build` arg (or a build cached by a prior discover-app)
+       — `wire/arg-build` carries a deliberate choice; honour it
+       verbatim, never auto-select. Wins over `:port`.
+    2. `:port` arg (rf2-fyf0h) — resolve the serving build from the
+       shadow-cljs `:dev-http` map so an agent that only knows the
+       browser URL (e.g. http://localhost:8031/...) needn't grep the
+       repo for the build-id. A `:port` that resolves to no build is a
+       loud `:port-unresolved` error — NOT a silent fall-through to the
+       `:app` default (the operator asked for that port specifically).
+    3. Single running build (rf2-v70kv) — exactly one → auto-select +
+       flag it. Zero/many → keep the `:app` default so the diagnostic
+       ladder surfaces `:build-not-running` with the running list.
 
-  Otherwise (`arg-build` would fall through to the bare
-  `SHADOW_CLJS_BUILD_ID` / `:app` env default), try to auto-select the
-  single running build (rf2-v70kv): on a checkout where `:app` isn't the
-  running watch, defaulting to `:app` fails by construction on the very
-  first no-arg call. Exactly one running build → select it and flag the
-  auto-selection so the result can note it. Zero or many running → keep
-  the `:app` default and let `ensure-runtime!`'s diagnostic ladder
-  surface `:build-not-running` with the running-builds list (the
-  multi-build path stays ambiguous-and-loud, deliberately)."
+  Return shapes:
+    {:build-id <kw> :auto-selected? <bool>}   — proceed to probe.
+    {:error <js-envelope>}                     — short-circuit (port-unresolved)."
   [conn args]
-  (let [build-id (wire/arg-build conn args)]
-    (if (wire/arg-build-explicit? conn args)
-      (js/Promise.resolve [build-id false])
+  (let [explicit-build (wire/arg-build conn args)
+        port           (wire/arg args :port)]
+    (cond
+      (wire/arg-build-explicit? conn args)
+      (js/Promise.resolve {:build-id explicit-build :auto-selected? false})
+
+      (some? port)
+      (-> (probe/resolve-build-by-port conn port)
+          (.then (fn [resolved]
+                   (if resolved
+                     {:build-id resolved :auto-selected? false}
+                     {:error (port-unresolved-result port)}))))
+
+      :else
       (-> (probe/auto-select-single-build conn)
           (.then (fn [[selected auto?]]
-                   (if auto? [selected true] [build-id false])))))))
+                   (if auto?
+                     {:build-id selected :auto-selected? true}
+                     {:build-id explicit-build :auto-selected? false})))))))
 
 (defn- with-auto-selection
   "Annotate an `:ok? true` discover-app payload with the auto-selection
@@ -48,7 +78,9 @@
 (defn discover-app [conn args]
   (-> (resolve-build-id conn args)
    (.then
-    (fn [[build-id auto-selected?]]
+    (fn [{:keys [build-id auto-selected? error]}]
+    (if error
+     error
     (-> (probe/ensure-runtime! conn build-id)
         (.then (fn [_] (probe/runtime-health! conn build-id)))
         (.then
@@ -109,4 +141,4 @@
                   (with-auto-selection
                     (assoc health :ok? true :build-id build-id)
                     auto-selected? build-id))))))
-        (.catch (fn [err] (probe/err->result :discover-failed err))))))))
+        (.catch (fn [err] (probe/err->result :discover-failed err)))))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/discover_app.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/discover_app.cljs
@@ -3,8 +3,52 @@
   (:require [re-frame2-pair-mcp.tools.wire :as wire]
             [re-frame2-pair-mcp.tools.probe :as probe]))
 
-(defn discover-app [conn args]
+(defn- resolve-build-id
+  "Resolve the build-id discover-app should probe. Returns a Promise of
+  `[build-id auto-selected?]`.
+
+  When the caller passed an explicit `:build` arg (or a prior
+  discover-app cached one on the conn), `wire/arg-build` already carries
+  a deliberate choice — honour it verbatim, never auto-select.
+
+  Otherwise (`arg-build` would fall through to the bare
+  `SHADOW_CLJS_BUILD_ID` / `:app` env default), try to auto-select the
+  single running build (rf2-v70kv): on a checkout where `:app` isn't the
+  running watch, defaulting to `:app` fails by construction on the very
+  first no-arg call. Exactly one running build → select it and flag the
+  auto-selection so the result can note it. Zero or many running → keep
+  the `:app` default and let `ensure-runtime!`'s diagnostic ladder
+  surface `:build-not-running` with the running-builds list (the
+  multi-build path stays ambiguous-and-loud, deliberately)."
+  [conn args]
   (let [build-id (wire/arg-build conn args)]
+    (if (wire/arg-build-explicit? conn args)
+      (js/Promise.resolve [build-id false])
+      (-> (probe/auto-select-single-build conn)
+          (.then (fn [[selected auto?]]
+                   (if auto? [selected true] [build-id false])))))))
+
+(defn- with-auto-selection
+  "Annotate an `:ok? true` discover-app payload with the auto-selection
+  fact (rf2-v70kv). No-op when the build was NOT auto-selected (an
+  explicit / cached / default build). When auto-selected, records
+  `:auto-selected-build` and either seeds or prepends an auto-selection
+  sentence to `:note` so the operator sees which build the no-arg call
+  landed on."
+  [m auto-selected? build-id]
+  (if-not auto-selected?
+    m
+    (let [sentence (str "No :build arg given and exactly one shadow-cljs "
+                        "build is running (" build-id ") — auto-selected it.")]
+      (-> m
+          (assoc :auto-selected-build build-id)
+          (update :note (fn [existing]
+                          (if existing (str sentence " " existing) sentence)))))))
+
+(defn discover-app [conn args]
+  (-> (resolve-build-id conn args)
+   (.then
+    (fn [[build-id auto-selected?]]
     (-> (probe/ensure-runtime! conn build-id)
         (.then (fn [_] (probe/runtime-health! conn build-id)))
         (.then
@@ -30,23 +74,29 @@
                 ;; calls (with the frame disambiguator) don't need to
                 ;; re-specify `:build`.
                 (wire/mark-resolved-build-id! conn build-id)
-                (wire/ok-text (assoc health :ok? true
-                                            :warning :ambiguous-frame
-                                            :note (str "Multiple frames registered: "
-                                                       (vec (:frames health))
-                                                       ". Mutating ops require --frame :foo "
-                                                       "or run `frames/select` first."))))
+                (wire/ok-text
+                  (with-auto-selection
+                    (assoc health :ok? true
+                                  :warning :ambiguous-frame
+                                  :note (str "Multiple frames registered: "
+                                             (vec (:frames health))
+                                             ". Mutating ops require --frame :foo "
+                                             "or run `frames/select` first."))
+                    auto-selected? build-id)))
 
               (not (:coord-annotation-enabled? health))
               (do
                 (wire/mark-resolved-build-id! conn build-id)
-                (wire/ok-text (assoc health :ok? true
-                                            :warning :no-source-coord-annotation
-                                            :note (str "Neither data-rf2-source-coord nor "
-                                                       "data-rc-src is on any element. "
-                                                       "DOM->source ops will degrade. Enable "
-                                                       "(rf/configure :source-coords {:annotate-dom? true}) "
-                                                       "or use re-com with :src (at)."))))
+                (wire/ok-text
+                  (with-auto-selection
+                    (assoc health :ok? true
+                                  :warning :no-source-coord-annotation
+                                  :note (str "Neither data-rf2-source-coord nor "
+                                             "data-rc-src is on any element. "
+                                             "DOM->source ops will degrade. Enable "
+                                             "(rf/configure :source-coords {:annotate-dom? true}) "
+                                             "or use re-com with :src (at)."))
+                    auto-selected? build-id)))
 
               :else
               (do
@@ -55,5 +105,8 @@
                 ;; default to it instead of the `SHADOW_CLJS_BUILD_ID` /
                 ;; `:app` env-var fallback. Invalidates on nREPL reconnect.
                 (wire/mark-resolved-build-id! conn build-id)
-                (wire/ok-text (assoc health :ok? true :build-id build-id))))))
-        (.catch (fn [err] (probe/err->result :discover-failed err))))))
+                (wire/ok-text
+                  (with-auto-selection
+                    (assoc health :ok? true :build-id build-id)
+                    auto-selected? build-id))))))
+        (.catch (fn [err] (probe/err->result :discover-failed err))))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/probe.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/probe.cljs
@@ -333,6 +333,67 @@
                  (if (vector? v) v []))))
       (.catch (fn [_] []))))
 
+;; ---------------------------------------------------------------------------
+;; URL/port → build resolution via the shadow-cljs :dev-http map (rf2-fyf0h).
+;;
+;; A pair session naturally starts from the URL of the open browser tab
+;; (e.g. http://localhost:8031/counter), but discover-app speaks build-
+;; ids. shadow's `:dev-http` map binds a port to a LIST OF FILE ROOTS
+;; (not a build-id directly); the serving build is the one whose
+;; `:output-dir` is among those roots — exactly how shadow's dev server
+;; finds the compiled assets to serve. We resolve port → build entirely
+;; JVM-side (where the config lives), matching `:output-dir` against the
+;; port's roots, and return the build-id keyword.
+;; ---------------------------------------------------------------------------
+
+(defn- port->build-jvm-form
+  "JVM-side form that reads the shadow-cljs config, looks up `port` in the
+  `:dev-http` map, and returns the keyword build-id whose `:output-dir`
+  is one of that port's file roots — or nil. Defensive: any failure
+  (old shadow, unparseable config, no match) collapses to nil so the
+  caller degrades to a clear `:port-unresolved` reason rather than a
+  crash. `:output-dir` strings are normalised (leading `./` and trailing
+  `/` stripped) on both sides before comparison so trivial path-spelling
+  differences don't miss a real match."
+  [port]
+  (str
+    "(try"
+    "  (let [cfg (shadow.cljs.devtools.config/load-cljs-edn)"
+    "        norm (fn [s] (when s (-> (str s)"
+    "                                 (clojure.string/replace #\"^\\./\" \"\")"
+    "                                 (clojure.string/replace #\"/$\" \"\"))))"
+    "        roots (set (map norm (get (:dev-http cfg) " port ")))]"
+    "    (when (seq roots)"
+    "      (some (fn [[bid b]]"
+    "              (when (and (map? b) (contains? roots (norm (:output-dir b)))) bid))"
+    "            (:builds cfg))))"
+    "  (catch Throwable _ nil))"))
+
+(defn resolve-build-by-port
+  "Resolve the shadow-cljs build-id serving `port` via the `:dev-http`
+  map (rf2-fyf0h). Returns a Promise resolving to the build-id keyword,
+  or nil when the port isn't in `:dev-http`, no build's `:output-dir`
+  matches its roots, or the JVM probe fails. `port` is an integer (a
+  string is coerced).
+
+  This removes the manual `grep shadow-cljs.edn for 8031` step: an agent
+  that only knows the browser URL passes the port and gets the build."
+  [conn port]
+  (let [p (cond
+            (number? port) (long port)
+            (string? port) (let [n (js/parseInt port 10)]
+                             (when-not (js/isNaN n) n))
+            :else nil)]
+    (if (nil? p)
+      (js/Promise.resolve nil)
+      (-> (try
+            (nrepl/jvm-eval conn (port->build-jvm-form p))
+            (catch :default _ (js/Promise.resolve nil)))
+          (.then (fn [resp]
+                   (let [v (some-> (:value resp) cljs.reader/read-string)]
+                     (when (keyword? v) v))))
+          (.catch (fn [_] nil))))))
+
 (defn auto-select-single-build
   "Resolve a build-id when EXACTLY ONE shadow-cljs build is running, else
   nil (rf2-v70kv). Returns a Promise resolving to `[build-id true]` when

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/probe.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/probe.cljs
@@ -333,6 +333,28 @@
                  (if (vector? v) v []))))
       (.catch (fn [_] []))))
 
+(defn auto-select-single-build
+  "Resolve a build-id when EXACTLY ONE shadow-cljs build is running, else
+  nil (rf2-v70kv). Returns a Promise resolving to `[build-id true]` when
+  one build was auto-selected, or `[nil false]` when zero or many run.
+
+  Unlike `resolve-build!` (the eval-path resolver, which REJECTS on
+  zero/many), this is the soft probe `discover-app` uses to fill an
+  omitted `:build` arg without losing the existing multi-build error
+  path: on zero/many the caller keeps its default build-id and lets the
+  diagnostic ladder surface `:build-not-running` with the running list.
+
+  Deliberately does NOT pick a most-recently-active build when several
+  run — that's a silent wrong-build footgun Mike explicitly rejected.
+  Two running builds stays ambiguous."
+  [conn]
+  (-> (running-builds conn)
+      (.then (fn [running]
+               (if (= 1 (count running))
+                 [(first running) true]
+                 [nil false])))
+      (.catch (fn [_] [nil false]))))
+
 (defn- auto-detect-hint [running]
   (cond
     (empty? running)

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/wire.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/wire.cljs
@@ -9,6 +9,7 @@
   Build-id resolution lives here too — `default-build-id` reads
   `SHADOW_CLJS_BUILD_ID` from `process.env`, falling back to `:app`."
   (:require [applied-science.js-interop :as j]
+            [re-frame.mcp-base.args :as base-args]
             [re-frame.mcp-base.envelope :as base-envelope]))
 
 ;; ---------------------------------------------------------------------------
@@ -134,6 +135,17 @@
        (same lifecycle as `:probed-builds`).
     3. `SHADOW_CLJS_BUILD_ID` env var, defaulting to `:app`.
 
+  The explicit `:build` arg is coerced via
+  `re-frame.mcp-base.args/fresh-keyword` (rf2-8ohwv), which strips a
+  leading colon: `\"examples/step-deck\"` and `\":examples/step-deck\"`
+  resolve identically. A bare `keyword` on the colon form would mint the
+  malformed `::examples/step-deck` (`cljs-eval` then renders it
+  `\"::examples/step-deck\"` and probes a build that doesn't exist) — the
+  failed-round-trip footgun the human-facing hint's colon form invited.
+  `fresh-keyword` is the right primitive here: the build-id is a
+  runtime-bounded read path resolving against shadow's finite running-
+  build registry, so the per-id intern cost is capped.
+
   1-arity (`(arg-build args)`) is the legacy entry — used by call sites
   that have no `conn` in scope (notably `args.cljs`'s frame/build
   parsing). It SKIPS the conn cache and falls straight through to the
@@ -141,7 +153,7 @@
   2-arity."
   ([args] (arg-build nil args))
   ([conn args]
-   (or (arg-keyword args :build)
+   (or (base-args/fresh-keyword (arg args :build))
        (conn-resolved-build-id conn)
        (default-build-id))))
 
@@ -165,7 +177,7 @@
   with no `conn` in scope; it sees only the per-call arg."
   ([args] (arg-build-explicit? nil args))
   ([conn args]
-   (or (some? (arg-keyword args :build))
+   (or (some? (arg args :build))
        (some? (conn-resolved-build-id conn)))))
 
 ;; ---------------------------------------------------------------------------

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/build_id_cache_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/build_id_cache_test.cljs
@@ -54,6 +54,43 @@
    :ambiguous-frame?           false})
 
 ;; ---------------------------------------------------------------------------
+;; `wire/arg-build` — colon tolerance (rf2-8ohwv).
+;; ---------------------------------------------------------------------------
+
+(deftest arg-build-tolerates-a-leading-colon
+  ;; rf2-8ohwv: the human-facing hint shows the colon form
+  ;; (`--build=:examples/step-deck`) but the MCP arg used to want the bare
+  ;; form — a leading colon double-prepended into the malformed
+  ;; `::examples/step-deck` and failed the round-trip. Both forms must now
+  ;; resolve to the SAME keyword, and a doubled colon must never reach the
+  ;; resolver.
+  (let [conn (fresh-conn)]
+    (is (= :examples/step-deck
+           (wire/arg-build conn (tu/args->js {:build "examples/step-deck"})))
+        "bare form")
+    (is (= :examples/step-deck
+           (wire/arg-build conn (tu/args->js {:build ":examples/step-deck"})))
+        "colon form resolves identically")
+    (is (= (wire/arg-build conn (tu/args->js {:build "examples/step-deck"}))
+           (wire/arg-build conn (tu/args->js {:build ":examples/step-deck"})))
+        "the two forms are indistinguishable post-coercion")))
+
+(deftest arg-build-colon-tolerance-on-bare-build
+  ;; The non-namespaced case the original `keyword` mishandled too:
+  ;; `:app` → `::app` (a `user`-ns keyword) → probes a build that doesn't
+  ;; exist. Both forms must land on `:app`.
+  (let [conn (fresh-conn)]
+    (is (= :app (wire/arg-build conn (tu/args->js {:build "app"}))))
+    (is (= :app (wire/arg-build conn (tu/args->js {:build ":app"}))))))
+
+(deftest arg-build-explicit-predicate-sees-either-colon-form
+  ;; Explicitness keys on arg PRESENCE, not coercion shape — both the
+  ;; bare and colon forms count as a deliberate `:build`.
+  (let [conn (fresh-conn)]
+    (is (true? (wire/arg-build-explicit? conn (tu/args->js {:build "app"}))))
+    (is (true? (wire/arg-build-explicit? conn (tu/args->js {:build ":app"}))))))
+
+;; ---------------------------------------------------------------------------
 ;; `wire/arg-build` — cache lookup precedence.
 ;; ---------------------------------------------------------------------------
 

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/build_id_cache_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/build_id_cache_test.cljs
@@ -27,6 +27,7 @@
   (:require [cljs.test :refer-macros [deftest is async]]
             [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.tools.discover-app :as discover-app]
+            [re-frame2-pair-mcp.tools.probe :as probe]
             [re-frame2-pair-mcp.tools.wire :as wire]
             [re-frame2-pair-mcp.test-utils :as tu]))
 
@@ -246,3 +247,118 @@
   (let [conn (nrepl/make-conn 0 "127.0.0.1")]
     (is (contains? @conn :resolved-build-id))
     (is (nil? (:resolved-build-id @conn)))))
+
+;; ---------------------------------------------------------------------------
+;; Single-build auto-selection (rf2-v70kv).
+;;
+;; discover-app used to default an omitted :build to :app; on a checkout
+;; where :app isn't the running watch, the first no-arg call failed by
+;; construction. When EXACTLY ONE build runs, discover-app now selects it
+;; and notes the choice. Zero/many running keeps the existing diagnostic
+;; (which lists the running builds) — never a silent most-recently-active
+;; pick.
+;; ---------------------------------------------------------------------------
+
+(defn- with-running-builds!
+  "Stub `probe/running-builds` to resolve to `running-vec` and
+  `nrepl/cljs-eval-value` to resolve to `health` (the runtime probe +
+  health call). Restores both in `.finally`."
+  [running-vec health body-fn]
+  (let [orig-running probe/running-builds
+        orig-eval    nrepl/cljs-eval-value]
+    (set! probe/running-builds (fn [_conn] (js/Promise.resolve running-vec)))
+    (set! nrepl/cljs-eval-value
+          (fn
+            ([_c _b _f] (js/Promise.resolve health))
+            ([_c _b _f _o] (js/Promise.resolve health))))
+    (-> (js/Promise.resolve nil)
+        (.then (fn [_] (body-fn)))
+        (.finally (fn []
+                    (set! probe/running-builds orig-running)
+                    (set! nrepl/cljs-eval-value orig-eval))))))
+
+(deftest discover-app-auto-selects-the-single-running-build
+  ;; No :build arg, exactly one running build → discover-app selects it,
+  ;; notes the auto-selection, caches it, and echoes :auto-selected-build.
+  (async done
+    (let [conn (fresh-conn)
+          _    (prime-probe-cache! conn :examples/step-deck)]
+      (-> (with-running-builds! [:examples/step-deck] healthy-health
+            (fn [] (discover-app/discover-app conn (tu/args->js {}))))
+          (.then
+            (fn [result]
+              (let [edn (tu/extract-edn result)]
+                (is (true? (:ok? edn)))
+                (is (= :examples/step-deck (:build-id edn))
+                    "auto-selected the single running build")
+                (is (= :examples/step-deck (:auto-selected-build edn))
+                    "result flags the auto-selection")
+                (is (re-find #"auto-selected" (:note edn))
+                    "note explains the auto-selection")
+                (is (= :examples/step-deck (:resolved-build-id @conn))
+                    "auto-selected build is cached for follow-up calls"))
+              (done)))))))
+
+(deftest discover-app-no-arg-does-not-auto-select-when-many-run
+  ;; Two running builds, no :build arg → NO auto-select. The build falls
+  ;; back to the :app default and the diagnostic surfaces the running
+  ;; list (here: the build is running per the stub, so we assert the
+  ;; payload is NOT auto-selected against :app rather than step-deck).
+  (async done
+    (let [conn (fresh-conn)
+          _    (prime-probe-cache! conn :app)]
+      (-> (with-running-builds! [:testbeds/panel-gallery :examples/step-deck]
+                                healthy-health
+            (fn [] (discover-app/discover-app conn (tu/args->js {}))))
+          (.then
+            (fn [result]
+              (let [edn (tu/extract-edn result)]
+                ;; The default :app is probed (the stub answers health for
+                ;; any build) — the point is no SILENT pick of one of the
+                ;; two ambiguous builds.
+                (is (not (contains? edn :auto-selected-build))
+                    "must NOT auto-select when multiple builds run")
+                (is (= :app (:build-id edn))
+                    "falls back to the :app default, not a guessed build"))
+              (done)))))))
+
+(deftest discover-app-explicit-build-skips-auto-select
+  ;; An explicit :build arg is honoured verbatim — auto-select never
+  ;; fires, even though only one OTHER build is running.
+  (async done
+    (let [conn (fresh-conn)
+          _    (prime-probe-cache! conn :my-app)]
+      (-> (with-running-builds! [:examples/step-deck] healthy-health
+            (fn [] (discover-app/discover-app conn (tu/args->js {:build "my-app"}))))
+          (.then
+            (fn [result]
+              (let [edn (tu/extract-edn result)]
+                (is (= :my-app (:build-id edn))
+                    "explicit build used verbatim")
+                (is (not (contains? edn :auto-selected-build))
+                    "explicit build is not an auto-selection"))
+              (done)))))))
+
+(deftest auto-select-single-build-returns-pair
+  ;; Unit-pin the probe helper directly: exactly-one → [build true];
+  ;; zero/many → [nil false].
+  (async done
+    (let [conn (fresh-conn)
+          orig probe/running-builds]
+      (set! probe/running-builds (fn [_] (js/Promise.resolve [:only])))
+      (-> (probe/auto-select-single-build conn)
+          (.then (fn [[b auto?]]
+                   (is (= :only b))
+                   (is (true? auto?))
+                   (set! probe/running-builds (fn [_] (js/Promise.resolve [:a :b])))
+                   (probe/auto-select-single-build conn)))
+          (.then (fn [[b auto?]]
+                   (is (nil? b))
+                   (is (false? auto?))
+                   (set! probe/running-builds (fn [_] (js/Promise.resolve [])))
+                   (probe/auto-select-single-build conn)))
+          (.then (fn [[b auto?]]
+                   (is (nil? b))
+                   (is (false? auto?))))
+          (.finally (fn [] (set! probe/running-builds orig)))
+          (.then (fn [_] (done)))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/discover_app_representation_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/discover_app_representation_test.cljs
@@ -1,0 +1,95 @@
+(ns re-frame2-pair-mcp.discover-app-representation-test
+  "Pin the id-representation contract of discover-app's output (rf2-cg37y).
+
+  First live pair session (2026-05-29) surfaced that discover-app
+  responses mixed id forms WITHIN one payload — running-builds /
+  frames as short names (`step-deck`) in one place, full keywords
+  (`:examples/step-deck`) in the adjacent hint string. A first-time
+  caller had to guess which field used which form.
+
+  ## The contract these tests pin
+
+  The canonical, agent-read representation is the EDN `:content` text
+  slot — `wire/ok-text` renders it with `pr-str`. In that slot every
+  build/frame id is a FULL KEYWORD (`:rf/default`, `:examples/step-deck`)
+  and the embedded `:note` / `:hint` strings use the SAME colon form, so
+  the payload reads with one representation throughout.
+
+  The sibling `:structuredContent` slot is the documented lossy JSON
+  projection (`clj->js`) where keywords lose their leading colon — that
+  is a fixed cross-MCP convention (`wire/ok-text` docstring; story-mcp
+  shares it). Callers that want the canonical id form read the EDN text;
+  the JSON view is the SDK-friendly fallback. These tests therefore
+  assert against the EDN text — the slot that carries the single
+  representation."
+  (:require [cljs.test :refer-macros [deftest is async]]
+            [clojure.string :as str]
+            [re-frame2-pair-mcp.nrepl :as nrepl]
+            [re-frame2-pair-mcp.tools.discover-app :as discover-app]
+            [re-frame2-pair-mcp.test-utils :as tu]))
+
+(defn- fresh-conn []
+  (let [conn (nrepl/make-conn 0 "127.0.0.1")]
+    (swap! conn assoc :probed-builds #{} :resolved-build-id nil)
+    conn))
+
+(defn- prime! [conn build-id]
+  (swap! conn update :probed-builds (fnil conj #{}) build-id))
+
+(def ^:private multi-frame-health
+  "An ambiguous-frame health payload — exercises the `:note` string
+  branch that embeds the frame ids, the place the representation mix
+  was first seen."
+  {:ok?                        true
+   :debug-enabled?             true
+   :coord-annotation-enabled?  true
+   :frames                     [:rf/default :step-deck :rf/xray]
+   :ambiguous-frame?           true})
+
+(deftest discover-app-frames-are-full-keywords-in-canonical-text
+  ;; The :frames value and the :note string that re-states them must
+  ;; BOTH render as full keywords in the EDN text — no short-name leak.
+  (async done
+    (let [conn (fresh-conn)
+          _    (prime! conn :examples/step-deck)
+          args (tu/args->js {:build "examples/step-deck"})]
+      (-> (tu/with-stubbed-eval! multi-frame-health
+            (fn [] (discover-app/discover-app conn args)))
+          (.then
+            (fn [result]
+              (let [text (tu/extract-text result)
+                    edn  (tu/extract-edn result)]
+                (is (= [:rf/default :step-deck :rf/xray] (:frames edn))
+                    ":frames value is a vector of full keywords")
+                ;; The note re-states the frames; the colon form must
+                ;; appear there too so value + prose agree.
+                (is (str/includes? (:note edn) ":rf/default")
+                    ":note embeds the colon form, matching the value")
+                (is (str/includes? (:note edn) ":step-deck"))
+                ;; And no short-name leak anywhere in the canonical text.
+                (is (not (str/includes? text "[default step-deck"))
+                    "no colon-stripped short-name list in the canonical EDN text"))
+              (done)))))))
+
+(deftest discover-app-build-id-is-a-full-keyword-in-canonical-text
+  ;; The resolved :build-id echoed on success is a keyword, rendered
+  ;; with its colon in the EDN text.
+  (async done
+    (let [conn (fresh-conn)
+          _    (prime! conn :examples/step-deck)
+          args (tu/args->js {:build "examples/step-deck"})
+          healthy {:ok?                        true
+                   :debug-enabled?             true
+                   :coord-annotation-enabled?  true
+                   :frames                     [:rf/default]
+                   :ambiguous-frame?           false}]
+      (-> (tu/with-stubbed-eval! healthy
+            (fn [] (discover-app/discover-app conn args)))
+          (.then
+            (fn [result]
+              (let [edn (tu/extract-edn result)]
+                (is (= :examples/step-deck (:build-id edn))
+                    ":build-id is the full keyword")
+                (is (str/includes? (tu/extract-text result) ":build-id :examples/step-deck")
+                    "rendered with its colon in the canonical text"))
+              (done)))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/port_to_build_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/port_to_build_test.cljs
@@ -1,0 +1,179 @@
+(ns re-frame2-pair-mcp.port-to-build-test
+  "URL/port -> build resolution via the shadow-cljs :dev-http map (rf2-fyf0h).
+
+  A pair session starts from the browser URL of the open tab (e.g.
+  http://localhost:8031/counter), but discover-app speaks build-ids. The
+  first live session (2026-05-29) had the agent grep the repo for 8031 to
+  learn that port maps to the step_deck testbed before connecting. These
+  tests pin the new `:port` arg path:
+
+    - `probe/resolve-build-by-port` reads the :dev-http map JVM-side and
+      returns the build whose :output-dir is served on that port.
+    - discover-app accepts `:port` and probes the resolved build; an
+      explicit `:build` arg wins; an unmappable port fails loud with
+      `:port-unresolved` rather than silently defaulting to :app."
+  (:require [cljs.test :refer-macros [deftest is async]]
+            [re-frame2-pair-mcp.nrepl :as nrepl]
+            [re-frame2-pair-mcp.tools.discover-app :as discover-app]
+            [re-frame2-pair-mcp.tools.probe :as probe]
+            [re-frame2-pair-mcp.test-utils :as tu]))
+
+(defn- fresh-conn []
+  (let [conn (nrepl/make-conn 0 "127.0.0.1")]
+    (swap! conn assoc :probed-builds #{} :resolved-build-id nil)
+    conn))
+
+(def ^:private healthy-health
+  {:ok?                        true
+   :debug-enabled?             true
+   :coord-annotation-enabled?  true
+   :frames                     [:rf/default]
+   :ambiguous-frame?           false})
+
+;; ---------------------------------------------------------------------------
+;; The probe helper — drives the JVM form through a stubbed `jvm-eval`.
+;; ---------------------------------------------------------------------------
+
+(deftest resolve-build-by-port-reads-the-jvm-result
+  ;; The JVM form does the :dev-http lookup + :output-dir match server-
+  ;; side and returns a keyword; the helper reads it back as EDN.
+  (async done
+    (let [conn (fresh-conn)
+          orig nrepl/jvm-eval]
+      (set! nrepl/jvm-eval
+            (fn
+              ([_c form] (js/Promise.resolve
+                           ;; sanity: the form references the port + the
+                           ;; :dev-http / :output-dir matcher.
+                           (if (and (re-find #"8031" form)
+                                    (re-find #":dev-http" form)
+                                    (re-find #":output-dir" form))
+                             {:value ":examples/step-deck"}
+                             {:value "nil"})))
+              ([_c form _o] (js/Promise.resolve
+                              (if (re-find #"8031" form)
+                                {:value ":examples/step-deck"}
+                                {:value "nil"})))))
+      (-> (probe/resolve-build-by-port conn 8031)
+          (.then (fn [bid]
+                   (is (= :examples/step-deck bid)
+                       "resolves the build serving port 8031")))
+          (.finally (fn [] (set! nrepl/jvm-eval orig)))
+          (.then (fn [_] (done)))))))
+
+(deftest resolve-build-by-port-nil-on-no-match
+  ;; Unmapped port → JVM form returns nil → helper returns nil (the
+  ;; caller turns that into :port-unresolved).
+  (async done
+    (let [conn (fresh-conn)
+          orig nrepl/jvm-eval]
+      (set! nrepl/jvm-eval (fn [& _] (js/Promise.resolve {:value "nil"})))
+      (-> (probe/resolve-build-by-port conn 9999)
+          (.then (fn [bid] (is (nil? bid))))
+          (.finally (fn [] (set! nrepl/jvm-eval orig)))
+          (.then (fn [_] (done)))))))
+
+(deftest resolve-build-by-port-coerces-string-port
+  ;; The MCP wire may deliver the port as a string; it's coerced to int.
+  (async done
+    (let [conn (fresh-conn)
+          orig nrepl/jvm-eval
+          seen (atom nil)]
+      (set! nrepl/jvm-eval
+            (fn
+              ([_c form] (reset! seen form) (js/Promise.resolve {:value ":examples/step-deck"}))
+              ([_c form _o] (reset! seen form) (js/Promise.resolve {:value ":examples/step-deck"}))))
+      (-> (probe/resolve-build-by-port conn "8031")
+          (.then (fn [bid]
+                   (is (= :examples/step-deck bid))
+                   (is (re-find #"\b8031\b" @seen)
+                       "string port coerced to the integer 8031 in the JVM form")))
+          (.finally (fn [] (set! nrepl/jvm-eval orig)))
+          (.then (fn [_] (done)))))))
+
+(deftest resolve-build-by-port-nil-on-non-numeric
+  ;; A non-numeric port short-circuits to nil without a round-trip.
+  (async done
+    (-> (probe/resolve-build-by-port (fresh-conn) "not-a-port")
+        (.then (fn [bid] (is (nil? bid))))
+        (.then (fn [_] (done))))))
+
+;; ---------------------------------------------------------------------------
+;; discover-app integration — stub the resolver to keep these hermetic.
+;; ---------------------------------------------------------------------------
+
+(defn- with-port-resolution! [resolved health body-fn]
+  (let [orig-port probe/resolve-build-by-port
+        orig-eval nrepl/cljs-eval-value]
+    (set! probe/resolve-build-by-port (fn [_c _p] (js/Promise.resolve resolved)))
+    (set! nrepl/cljs-eval-value
+          (fn
+            ([_c _b _f] (js/Promise.resolve health))
+            ([_c _b _f _o] (js/Promise.resolve health))))
+    (-> (js/Promise.resolve nil)
+        (.then (fn [_] (body-fn)))
+        (.finally (fn []
+                    (set! probe/resolve-build-by-port orig-port)
+                    (set! nrepl/cljs-eval-value orig-eval))))))
+
+(deftest discover-app-port-resolves-to-the-serving-build
+  ;; {:port 8031} -> probes :examples/step-deck, succeeds, caches it.
+  (async done
+    (let [conn (fresh-conn)]
+      ;; prime so runtime-preloaded? short-circuits and the only cljs-eval
+      ;; the stub serves is the health call.
+      (swap! conn update :probed-builds conj :examples/step-deck)
+      (-> (with-port-resolution! :examples/step-deck healthy-health
+            (fn [] (discover-app/discover-app conn (tu/args->js {:port 8031}))))
+          (.then
+            (fn [result]
+              (let [edn (tu/extract-edn result)]
+                (is (true? (:ok? edn)))
+                (is (= :examples/step-deck (:build-id edn))
+                    "resolved the build serving the port")
+                ;; port-resolved is a deliberate choice, not an auto-select.
+                (is (not (contains? edn :auto-selected-build)))
+                (is (= :examples/step-deck (:resolved-build-id @conn))
+                    "resolved build cached for follow-up calls"))
+              (done)))))))
+
+(deftest discover-app-port-unresolved-fails-loud
+  ;; A port that maps to no build → :port-unresolved, NOT a silent :app.
+  (async done
+    (let [conn (fresh-conn)]
+      (-> (with-port-resolution! nil healthy-health
+            (fn [] (discover-app/discover-app conn (tu/args->js {:port 9999}))))
+          (.then
+            (fn [result]
+              ;; The payload carries :ok? false but rides the ok-text
+              ;; envelope (matching the other discover-app precondition
+              ;; failures), so :isError is not set.
+              (is (not (tu/error? result)))
+              (let [edn (tu/extract-edn result)]
+                (is (false? (:ok? edn)))
+                (is (= :port-unresolved (:reason edn)))
+                (is (= 9999 (:port edn)))
+                (is (string? (:hint edn)))
+                (is (nil? (:resolved-build-id @conn))
+                    "an unresolved port must not cache anything"))
+              (done)))))))
+
+(deftest discover-app-explicit-build-wins-over-port
+  ;; Both :build and :port given → :build wins; the resolver isn't even
+  ;; consulted (a throwing stub proves it).
+  (async done
+    (let [conn (fresh-conn)
+          orig probe/resolve-build-by-port]
+      (swap! conn update :probed-builds conj :my-app)
+      (set! probe/resolve-build-by-port
+            (fn [& _] (throw (js/Error. "resolver must not be called when :build is explicit"))))
+      (-> (tu/with-stubbed-eval! healthy-health
+            (fn [] (discover-app/discover-app conn (tu/args->js {:build "my-app" :port 8031}))))
+          (.then
+            (fn [result]
+              (let [edn (tu/extract-edn result)]
+                (is (true? (:ok? edn)))
+                (is (= :my-app (:build-id edn)) "explicit build wins over port"))
+              (done)))
+          (.finally (fn [] (set! probe/resolve-build-by-port orig)))
+          (.then (fn [_] (done)))))))


### PR DESCRIPTION
Cluster of 4 ergonomics fixes for discover-app, all surfaced in Mike's first live pair session (2026-05-29, examples/step-deck testbed). One worktree, one PR, sequenced commits.

Beads (all closed against their commits):
- **rf2-8ohwv** (P3 bug) — build arg tolerates a leading colon
- **rf2-cg37y** (P3) — unified id representation in discover-app output
- **rf2-v70kv** (P4) — auto-select the single running build
- **rf2-fyf0h** (P3 feature) — resolve a URL/port to a build via the `:dev-http` map

## Quality gates

- `cd implementation && npm run test:mcp-conformance` — **ALL 6 GATES GREEN** (run after rf2-8ohwv, rf2-v70kv, and rf2-fyf0h commits). Gate breakdown: [1/6] JVM story-mcp, [2/6] Node story-mcp stdio, [3/6] Node re-frame2-pair-mcp server-test, [4+5/6] SDK-client conformance (pair + story), [6/6] wire-vocab (48 tests / 599 assertions).
- `bash scripts/test-fast-pr.sh` — **PASS** (full spine). CLJS node integration: 4820 tests / 15792 assertions, 0 failures. Also green: version lockstep, skill/MCP allowed-tools drift, core JVM, JS harness helpers, README link validator, docs corpus anchor validator.
- pair-mcp server-test (gate #3, run after every commit): **638 tests / 1734 assertions, 0 failures, 0 warnings** (baseline was 622/1689 → +16 tests across the cluster).
- **mkdocs `--strict` was NOT run** — mkdocs is not on PATH on this Windows worktree (the spine soft-skips it). Please watch CI for the mkdocs link/anchor gate. No new cross-tree links were added; all new doc text is inline or links to existing in-repo files.

## Per-bead summary

**rf2-8ohwv — colon-tolerant build arg.** `wire/arg-build` coerced `:build` with a bare `keyword`, so `":examples/step-deck"` minted the malformed `::examples/step-deck` and failed the first round-trip. Routed coercion through `re-frame.mcp-base.args/fresh-keyword` (strips a leading colon; bounded-intern, correct for the runtime-bounded build-id read path). Bare and colon forms now resolve identically. The bash-shim (`ops.clj` `build-id-from-args`) already stripped the colon — both transports now agree.

**rf2-cg37y — unified id representation.** The canonical EDN `:content` text already renders every id (`:build-id`, `:frames`, `:running-builds`) and the embedded `:note`/`:hint` prose as full keywords. The short-name form the operator saw was the documented lossy `clj->js` projection in `:structuredContent` (a fixed cross-MCP convention; the keyword-vector contract for `:running-builds`/`:build-id` is pinned by the eval-path tests — string-coercion was considered and rejected). Pinned the EDN consistency with a regression test and documented the representation + the exact per-arg forms in Tool-Catalogue + SKILL.

**rf2-v70kv — single-build auto-select.** discover-app defaulted an omitted `:build` to `:app`; on a checkout where `:app` isn't the running watch the first no-arg call failed by construction. `discover-app` now resolves the build first: explicit/cached build honoured verbatim; otherwise `probe/auto-select-single-build` picks the build when exactly one runs (echoes `:auto-selected-build`, explains in `:note`). Zero/many keeps the `:app` default so the diagnostic ladder still surfaces `:build-not-running` with the running list — no most-recently-active guess (explicitly rejected by Mike).

**rf2-fyf0h — port→build via `:dev-http`.** discover-app accepts an optional `:port`. `probe/resolve-build-by-port` reads shadow's config JVM-side (`shadow.cljs.devtools.config/load-cljs-edn`), looks up the port in `:dev-http` (which binds port→file-roots, not port→build), and returns the build whose `:output-dir` is among those roots. Validated the matcher against the live config: 8765→`:testbeds/panel-gallery`, 8030→`:examples/two-frame-isolation`, 8031→`:examples/step-deck`, 9999→nil. Explicit `:build` wins over `:port`; an unmappable port fails loud with `:reason :port-unresolved` (not a silent `:app` fall-through).

## Scope notes
- Touched `re-frame.mcp-base.args` only by *requiring* it (no edits to mcp-base) — `fresh-keyword` already existed; the mcp-conformance gate covers the shared surface.
- Did **not** touch top-level `spec/Tool-Pair.md` — all contract changes landed in the tool-local `tools/re-frame2-pair-mcp/spec/*` per the beads' scope.
- New args (`port`) + behaviours documented in `tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md`, `spec/API.md` (build-id resolution), the `discover-app` descriptor, and `skills/re-frame2-pair/SKILL.md` (Connect-first arg-form table + URL→build + auto-select).