### PR TITLE
fix(story): green the feature-load nightly gate — assertion_strip JSX-prop leak + Share-URL overrides serialisation (rf2-5fyo3)

### DIFF
--- a/examples/scripts/run-story-feature-load-tests.cjs
+++ b/examples/scripts/run-story-feature-load-tests.cjs
@@ -19,36 +19,17 @@ const TIMEOUT_MS = parseInt(process.env.STORY_FEATURE_LOAD_TIMEOUT_MS || '300000
 const VERBOSE = process.env.RF2_VERBOSE_TESTS === '1';
 
 /*
- * Known-noise console-error filter (rf2-mw1c0).
+ * The `_jsx*`-prop noise filter (rf2-mw1c0) was removed by rf2-5fyo3.
  *
- * The Reagent source-coord annotator (rf2-fa4ly,
- * implementation/core/src/re_frame/views/source_coord_annotation.cljs)
- * injects `:_jsxFileName` / `:_jsxLineNumber` / `:_jsxColumnNumber`
- * props into hiccup so React DevTools' "View source" button can resolve
- * a clicked node back to its reg-view call site. These props are gated
- * on `interop/debug-enabled?` so the production bundle elides them
- * entirely (verified by `test:elision`). In dev builds Reagent passes
- * the props through to React, which warns "React does not recognize
- * the `_jsx*` prop on a DOM element" because the props ride as DOM
- * attributes rather than React-element `__source` metadata. The
- * warning is benign — the feature is dev-only by design and the noise
- * doesn't represent a real defect — but its presence trips this gate's
- * console-error noise floor. Filter exactly this signature; everything
- * else still surfaces.
- *
- * Follow-on (rf2-rohdn filed 2026-05-28): redesign the JSX-dev-prop
- * channel so DevTools' "View source" actually sees them (likely via
- * `:>` interop with React.createElement's source arg) or remove the
- * injection entirely (the data-rf2-source-coord attribute already
- * gives pair tools what they need). Once the leak is gone this
- * filter can be removed.
+ * It masked the "React does not recognize the `_jsxFileName` prop on a
+ * DOM element" warnings the framework's JSX-dev-source-coord injection
+ * leaked. That injection never worked (DevTools reads `__source` off
+ * React.createElement's third arg, not element props) and was dropped
+ * at source by rf2-rohdn — the `data-rf2-source-coord` DOM attribute
+ * already gives pair tools what they need. With the leak gone the
+ * filter is dead code; keeping it would only mask a future regression,
+ * so every console error now trips the gate unfiltered.
  */
-const KNOWN_NOISE_CONSOLE_ERROR_RE =
-  /React does not recognize the .* prop on a DOM element[\s\S]*?_jsx(FileName|LineNumber|ColumnNumber)/;
-
-function isKnownNoiseConsoleError(text) {
-  return KNOWN_NOISE_CONSOLE_ERROR_RE.test(text);
-}
 
 const ALL_SPEC_FILES = [
   path.join(REPO_ROOT, 'tools', 'story', 'test', 'story_feature_load.cjs'),
@@ -115,7 +96,7 @@ function formatStoryContext(ctx) {
 
     page.on('console', (msg) => {
       const text = `[browser:${msg.type()}] ${msg.text()}`;
-      if (msg.type() === 'error' && !isKnownNoiseConsoleError(text)) {
+      if (msg.type() === 'error') {
         consoleErrors.push(text);
       }
       log(text);

--- a/tools/story/src/re_frame/story/ui/assertion_strip.cljs
+++ b/tools/story/src/re_frame/story/ui/assertion_strip.cljs
@@ -464,22 +464,31 @@
               multi-group? (> (count groups) 1)]
           [:div {:style     (:wrap styles)
                  :data-test "story-canvas-assertion-strip"}
-           (for [[gi {:keys [event records]}] (map-indexed vector groups)]
-             ^{:key (str "group-" gi)}
-             [:div {:style     (:group styles)
-                    :data-test "story-canvas-assertion-group"}
-              (when multi-group?
-                (group-head event))
-              (for [[ri rec] (map-indexed vector records)]
-                (let [row   (row-for rec)
-                      rkey  (:row-key row)
-                      open? (contains? @expanded rkey)]
-                  ;; The key MUST land on a vector literal (a Reagent
-                  ;; component element) — `^{:key ...}` on a function-CALL
-                  ;; form is dropped at read time (the meta does not
-                  ;; transfer to render-row's return value), so React's
-                  ;; row seq would have no key and warn 194×/run. Rendering
-                  ;; `[render-row ...]` as a component vector lands the key
-                  ;; on the element Reagent hands to React.
-                  ^{:key (str gi "/" ri "/" rkey)}
-                  [render-row row open? toggle]))])])))))
+           ;; `doall` realises both seqs eagerly inside the render
+           ;; reaction. The inner row seq derefs `@expanded`; a bare
+           ;; lazy `for` would defer that deref until React realises the
+           ;; seq OUTSIDE the tracking context, so the reaction wouldn't
+           ;; register `expanded` as a dependency (Reagent's "Reactive
+           ;; deref not supported in lazy seq" smell). Forcing the seqs
+           ;; here keeps the deref inside the reaction.
+           (doall
+             (for [[gi {:keys [event records]}] (map-indexed vector groups)]
+               ^{:key (str "group-" gi)}
+               [:div {:style     (:group styles)
+                      :data-test "story-canvas-assertion-group"}
+                (when multi-group?
+                  (group-head event))
+                (doall
+                  (for [[ri rec] (map-indexed vector records)]
+                    (let [row   (row-for rec)
+                          rkey  (:row-key row)
+                          open? (contains? @expanded rkey)]
+                      ;; The key MUST land on a vector literal (a Reagent
+                      ;; component element) — `^{:key ...}` on a function-CALL
+                      ;; form is dropped at read time (the meta does not
+                      ;; transfer to render-row's return value), so React's
+                      ;; row seq would have no key and warn 194×/run. Rendering
+                      ;; `[render-row ...]` as a component vector lands the key
+                      ;; on the element Reagent hands to React.
+                      ^{:key (str gi "/" ri "/" rkey)}
+                      [render-row row open? toggle])))]))])))))

--- a/tools/story/src/re_frame/story/ui/url_state.cljc
+++ b/tools/story/src/re_frame/story/ui/url_state.cljc
@@ -38,10 +38,13 @@
   toggle) → `pushState` so the browser back-button restores the prior
   view.
 
-  Cell-override edits are NOT pushed/replaced here — they're handled
-  by the existing share-URL surface (the share popover) on demand.
-  Threading every keystroke into the URL is too chatty for an
-  interactive controls panel.
+  Cell-override edits on the focused variant ARE pushed (rf2-5fyo3):
+  the share popover that once owned override serialisation was retired
+  (rf2-ymnfx), so the live address bar is the only surface that shares
+  overrides. `url-relevant-slots-changed?` compares the focused
+  variant's overrides slice, and `params-from-state` serialises it into
+  the `overrides=` param — a teammate pasting the URL lands on the same
+  override set. Overrides on non-focused variants stay off the URL.
 
   ## Idempotence
 
@@ -115,6 +118,16 @@
 
 ;; ---- diff predicate -----------------------------------------------------
 
+(defn- focused-overrides
+  "The cell-overrides slice for the currently-focused variant — the
+  same projection `params-from-state` serialises into the `overrides=`
+  param. Returns nil when no variant is focused so an overrides change
+  on a non-focused variant never triggers a push (only the focused
+  variant's overrides ride the URL)."
+  [shell]
+  (when-let [vid (:selected-variant shell)]
+    (get-in shell [:cell-overrides vid])))
+
 (defn url-relevant-slots-changed?
   "True iff any URL-encoded slot differs between two shell-state maps.
   Pure data → data; the state-watcher uses this to skip pushState when
@@ -122,8 +135,13 @@
 
   Compared slots: `:selected-variant`, `:selected-workspace`,
   `:active-mode-tab`, `:active-modes`, `:viewport`, `:background`,
-  `:tag-filter`, `:substrate`. Cell-overrides are NOT included — they
-  ride the share popover, not the live URL."
+  `:tag-filter`, `:substrate`, plus the focused variant's
+  cell-overrides slice. The overrides slice is variant-scoped (the URL
+  carries the focused variant's overrides, per `params-from-state`); a
+  controls edit on the focused variant must push so the live address
+  bar round-trips the override (rf2-5fyo3 — the share popover that used
+  to own override serialisation was retired by rf2-ymnfx, so the live
+  URL is now the only override-sharing surface)."
   [old new]
   (or (not= (:selected-variant   old) (:selected-variant   new))
       (not= (:selected-workspace old) (:selected-workspace new))
@@ -132,7 +150,8 @@
       (not= (:viewport           old) (:viewport           new))
       (not= (:background         old) (:background         new))
       (not= (:tag-filter         old) (:tag-filter         new))
-      (not= (:substrate          old) (:substrate          new))))
+      (not= (:substrate          old) (:substrate          new))
+      (not= (focused-overrides   old) (focused-overrides   new))))
 
 ;; ---- hydrator: URL params → shell-state apply ---------------------------
 

--- a/tools/story/test/re_frame/story/ui/url_state_test.cljc
+++ b/tools/story/test/re_frame/story/ui/url_state_test.cljc
@@ -145,14 +145,11 @@
         {:active-modes [:m/dark]})))
 
 (deftest url-relevant-slots-changed-ignores-non-url-slots
-  (testing "changes to non-URL slots (hot-reload-tick, cell-overrides,
-            fingerprints, panel-visibility) do NOT trigger a push"
+  (testing "changes to non-URL slots (hot-reload-tick, fingerprints,
+            panel-visibility) do NOT trigger a push"
     (is (not (us/url-relevant-slots-changed?
                {:selected-variant :foo/a :hot-reload-tick 0}
                {:selected-variant :foo/a :hot-reload-tick 99})))
-    (is (not (us/url-relevant-slots-changed?
-               {:selected-variant :foo/a :cell-overrides {}}
-               {:selected-variant :foo/a :cell-overrides {:foo/a {:x 1}}})))
     (is (not (us/url-relevant-slots-changed?
                {:selected-variant :foo/a :fingerprints {}}
                {:selected-variant :foo/a :fingerprints {:foo/a {:dec :h}}})))
@@ -161,6 +158,29 @@
                 :panel-visibility {:trace true}}
                {:selected-variant :foo/a
                 :panel-visibility {:trace false}})))))
+
+(deftest url-relevant-slots-changed-detects-focused-overrides-change
+  (testing "rf2-5fyo3 — a controls edit on the FOCUSED variant changes
+            its cell-overrides slice and MUST trigger a push so the
+            live address bar round-trips the override (the share popover
+            that used to own override serialisation was retired)"
+    (is (us/url-relevant-slots-changed?
+          {:selected-variant :foo/a :cell-overrides {}}
+          {:selected-variant :foo/a :cell-overrides {:foo/a {:x 1}}}))
+    (is (us/url-relevant-slots-changed?
+          {:selected-variant :foo/a :cell-overrides {:foo/a {:x 1}}}
+          {:selected-variant :foo/a :cell-overrides {:foo/a {:x 2}}}))))
+
+(deftest url-relevant-slots-changed-ignores-unfocused-overrides-change
+  (testing "rf2-5fyo3 — overrides on a NON-focused variant stay off the
+            URL (the URL carries only the focused variant's overrides)"
+    (is (not (us/url-relevant-slots-changed?
+               {:selected-variant :foo/a :cell-overrides {:foo/b {:x 1}}}
+               {:selected-variant :foo/a :cell-overrides {:foo/b {:x 2}}})))
+    (testing "no focused variant — overrides edits never push"
+      (is (not (us/url-relevant-slots-changed?
+                 {:selected-variant nil :cell-overrides {}}
+                 {:selected-variant nil :cell-overrides {:foo/a {:x 1}}}))))))
 
 ;; ---- apply-parsed-to-state ----------------------------------------------
 

--- a/tools/story/test/story_feature_load.cjs
+++ b/tools/story/test/story_feature_load.cjs
@@ -1551,8 +1551,13 @@ async function runTwentyEventBurst(page) {
   await toolbar.locator('[data-toolbar-mode=":Mode.app/light"]').click(); // 11
   await toolbar.locator('[data-test="story-toolbar-reset"]').click(); // 12
 
-  await page.getByRole('button', { name: /^share$/i }).first().click(); // 13
-  await page.getByRole('button', { name: /^close$/i }).first().click(); // 14
+  // rf2-5fyo3: the per-variant Share popover (open/close) that events
+  // 13-14 used to drive was retired by rf2-ymnfx — the live address-bar
+  // URL is the share surface now (and the Share-URL probe asserts it).
+  // Substitute the backgrounds-menu open/close popover so the burst
+  // still exercises a real open-then-dismiss chrome interaction.
+  await toolbar.locator('[data-test="story-toolbar-backgrounds"]').click(); // 13
+  await page.locator('[data-test="story-backgrounds-backdrop"]').click(); // 14
 
   await toolbar.locator('[data-test="story-toolbar-rec"]').click(); // 15
   await expectVisible(page.locator('[data-test="story-recorder-overlay"]'), 5000);


### PR DESCRIPTION
**rf2-5fyo3** — greens the NIGHTLY expensive-tests gate (red ~6 days) by fixing the two failing Story `test:story-feature-load` specs at source: the assertion-strip lazy-seq reactive-deref smell (plus removing the now-dead `_jsx*` console-error noise filter) and the Share-URL overrides serialisation regression.

## Quality gates

- `npm run test:story-feature-load` — **GREEN**. Before: 1 failure (`Story feature exercise + 20-event load gate`; Share-URL probe timed out at `[phase=matrix-before-load]` — last URL had `variant=...&modes=...` but no `overrides=`). After: **2 specs, 0 failures, 0 console errors, 0 "Reactive deref" warnings** (deref-warning count 16→0).
- `cd tools/story && clojure -M:test` — 862 tests / 2557 assertions, 0 failures, 0 errors (+2 new `url-relevant-slots-changed?` tests).
- `cd tools/story-mcp && clojure -M:test` — 172 tests / 859 assertions, 0 failures, 0 errors.
- `scripts/test-fast-pr.sh` — 4820 tests / 15792 assertions, 0 failures, 0 errors; markdown gates skipped (no `.md` changes).

## Root cause — sub-bug 1 (`_jsx*` console-error leak + lazy-seq deref)

The `_jsxFileName`/`_jsxLineNumber`/`_jsxColumnNumber` DOM-prop leak was **already fixed at source** before this branch: the framework's JSX-dev-source-coord injection (the only thing that ever emitted those props) was dropped by **rf2-rohdn (#2324, ancestor of HEAD)** — DevTools reads `__source` off `React.createElement`'s third arg, never element props, so the injection never worked and only produced dev-console noise. The CI redness on 05-21..05-27 predated that merge; the leak reproduces 0× locally. The leftover artefact was the runner's `KNOWN_NOISE_CONSOLE_ERROR_RE` filter that had masked it. Per the masterpiece lens (fix at source, don't filter) I removed the dead filter — its own comment said "Once the leak is gone this filter can be removed" — so every console error now trips the gate unfiltered.

The real co-occurring smell was genuine: `assertion-strip`'s inner row `(for ...)` derefs `@expanded` inside a **lazy** seq, so the deref was deferred until React realised the seq outside the render reaction's tracking context — Reagent's "Reactive deref not supported in lazy seq". Wrapped both the group and row seqs in `doall` so the deref runs inside the reaction.

## Root cause — sub-bug 2 (Share-URL overrides not serialised)

`url-state`'s state-watcher pushes a new address-bar URL only when `url-relevant-slots-changed?` returns true, and that predicate **deliberately excluded `:cell-overrides`** — a design from rf2-o4u18 when overrides rode the Share popover. **rf2-ymnfx retired the popover**, orphaning the overrides-into-URL path: `params-from-state`/`build-params`/`parse-params` still round-trip overrides end-to-end, but a controls edit (an overrides-only state change) never triggered a push, so overrides never reached the address bar. Fix: include the **focused variant's** cell-overrides slice (the same variant-scoped projection serialised into `overrides=`) in the change predicate; non-focused-variant overrides stay off the URL.

Fixing that let the run progress past the matrix into the `load-burst` phase, which exposed a second stale reference: events 13–14 of the 20-event burst clicked the `Share`/`Close` popover buttons rf2-ymnfx removed (previously never reached). Substituted the backgrounds-menu open/close popover — an equivalent real open-then-dismiss chrome interaction.

## Spec / story-mcp

- **Story spec unchanged** — `tools/story/spec/Tutorial-Embed.md` already specifies the live address bar "always reflects the focused variant + active modes + cell-overrides + chrome state"; this PR aligns the implementation back to that contract rather than changing it.
- **story-mcp touched? No.** story-mcp consumes the headless Story runtime/registrar/share surfaces, not the CLJS UI chrome (`ui.url-state`, `ui.assertion-strip`); the public `url-relevant-slots-changed?` signature is unchanged. Ran its JVM suite anyway (green) since `url_state.cljc` is `.cljc`.
