### PR TITLE
refactor(examples/state_machine_walkthrough): chain via :rf/machine canonical sub — flake-free retry (rf2-vt9tn)

### DIFF
--- a/examples/reagent/state_machine_walkthrough/core.cljc
+++ b/examples/reagent/state_machine_walkthrough/core.cljc
@@ -194,17 +194,21 @@
 
 ;; The machine snapshot lives at
 ;; [:rf/runtime :machines :snapshots :auth.login/flow] (per Spec 005).
-;; These named subs project out the convenient pieces. The "in
-;; :submitting?" / "in :authed?" / "in :locked-out?" predicates moved
-;; to the `rf/machine-has-tag?` queries in views.cljs (ch.11 §State
-;; tags) — discriminating on the machine's runtime-projected `:tags`
-;; set decouples view code from individual state-keyword identity.
+;; The framework ships `:rf/machine` as the canonical layer-3 entry
+;; point onto that path (see re-frame.machines §framework-shipped subs);
+;; the named subs below chain off it to project out the convenient
+;; pieces. The "in :submitting?" / "in :authed?" / "in :locked-out?"
+;; predicates moved to the `rf/machine-has-tag?` queries in views.cljs
+;; (ch.11 §State tags) — discriminating on the machine's runtime-projected
+;; `:tags` set decouples view code from individual state-keyword identity.
 
 (rf/reg-sub :auth.login/state
-  (fn [db _] (get-in db [:rf/runtime :machines :snapshots :auth.login/flow :state])))
+  :<- [:rf/machine :auth.login/flow]
+  (fn [machine _] (:state machine)))
 
 (rf/reg-sub :auth.login/error
-  (fn [db _] (get-in db [:rf/runtime :machines :snapshots :auth.login/flow :data :error])))
+  :<- [:rf/machine :auth.login/flow]
+  (fn [machine _] (get-in machine [:data :error])))
 
 ;; The chapter's headless tests (pure machine-transition + full-drain
 ;; scenarios) live in the sibling test ns

--- a/implementation/core/test/re_frame/examples_test.clj
+++ b/implementation/core/test/re_frame/examples_test.clj
@@ -40,6 +40,19 @@
   ;; require from each example ns wouldn't re-evaluate the body (Clojure
   ;; require is idempotent without :reload-all), so reload here.
   (require 're-frame.http-test-support :reload)
+  ;; clear-all! also drops the framework-shipped `:rf/machine` /
+  ;; `:rf/machine-has-tag?` subs, which register at re-frame.machines load
+  ;; time (see re-frame.machines §framework-shipped subs). The state-machine-
+  ;; walkthrough example's `:auth.login/state` / `:auth.login/error` named
+  ;; subs CHAIN off `:rf/machine` (`:<- [:rf/machine :auth.login/flow]`), so
+  ;; their input sub must be present in the registrar. The transitive require
+  ;; from the example ns wouldn't re-fire re-frame.machines' toplevel reg-sub
+  ;; forms once the ns is already loaded (Clojure require is idempotent), so
+  ;; reload here — exactly as the machines ns header anticipates. Without
+  ;; this, whether the smw drain test is green depends on whether some
+  ;; earlier-loaded ns happened to (re-)register `:rf/machine` since the last
+  ;; clear-all! — an ordering-dependent flake.
+  (require 're-frame.machines :reload)
   ;; Drop any cached require of example namespaces (and their sibling test
   ;; namespaces) so each test re-evaluates their namespace-level handlers
   ;; against a fresh registrar.


### PR DESCRIPTION
@-