### PR TITLE
refactor(machines): centralize :rf/runtime :machines path literals behind snapshot/system-id/spawned-path helpers (rf2-at4cl)

### DIFF
--- a/implementation/machines/src/re_frame/machines.cljc
+++ b/implementation/machines/src/re_frame/machines.cljc
@@ -52,6 +52,7 @@
             [re-frame.machines.lifecycle-fx.update-snapshot :as update-snapshot]
             [re-frame.machines.lifecycle-fx.validation :as validation]
             [re-frame.machines.parallel :as parallel]
+            [re-frame.machines.paths :as paths]
             [re-frame.machines.spawn-order :as spawn-order]
             [re-frame.machines.timer :as timer]
             [re-frame.registrar :as registrar]
@@ -139,7 +140,7 @@
   ([system-id]
    (machine-by-system-id system-id (frame/current-frame)))
   ([system-id frame-id]
-   (get-in (frame/frame-app-db-value frame-id) [:rf/runtime :machines :system-ids system-id])))
+   (get-in (frame/frame-app-db-value frame-id) (paths/system-id-path system-id))))
 
 (defn reset-timers!
   "Cancel in-flight `:after` timers.
@@ -215,7 +216,7 @@
 (subs/reg-sub :rf/machine
   {:doc "Subscribe to a machine's current snapshot `{:state <kw> :data <map> :tags <set>}`. Returns nil for an unknown or not-yet-initialised machine. Per Spec 005 §Subscribing to machines via sub-machine."}
   (fn [db [_ machine-id]]
-    (get-in db [:rf/runtime :machines :snapshots machine-id])))
+    (get-in db (paths/snapshot-path machine-id))))
 
 ;; Per Spec 005 §State tags (rf2-ee0d / Nine States Stage 1): the
 ;; `:rf/machine-has-tag?` framework sub returns `true` iff the named
@@ -229,7 +230,7 @@
 (subs/reg-sub :rf/machine-has-tag?
   {:doc "Subscribe to a machine's `:fsm/tags` containment-bit for `tag`. Returns `true` iff the named machine's snapshot's `:tags` set contains `tag`, `false` otherwise (including unknown / not-yet-initialised machines). Per Spec 005 §State tags (rf2-ee0d / Nine States Stage 1)."}
   (fn [db [_ machine-id tag]]
-    (contains? (get-in db [:rf/runtime :machines :snapshots machine-id :tags]) tag)))
+    (contains? (get-in db (paths/snapshot-path machine-id :tags)) tag)))
 
 ;; ---- late-bind hook registration ------------------------------------------
 ;;

--- a/implementation/machines/src/re_frame/machines/data_validation.cljc
+++ b/implementation/machines/src/re_frame/machines/data_validation.cljc
@@ -37,6 +37,7 @@
   keyword, validator deref, and trace call."
   (:require [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
+            [re-frame.machines.paths :as paths]
             [re-frame.trace :as trace]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -123,7 +124,7 @@
   [db event-id frame-id]
   (if interop/debug-enabled?
     (if-let [machine-meta (late-bind/get-fn-cached :machines/machine-meta)]
-      (let [snapshots (get-in db [:rf/runtime :machines :snapshots])]
+      (let [snapshots (get-in db (paths/snapshot-path))]
         (loop [entries (seq snapshots)
                ok?     true]
           (if-let [[machine-id snapshot] (first entries)]

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
@@ -31,6 +31,7 @@
             [re-frame.machines.lifecycle-fx.finalize :as finalize]
             [re-frame.machines.lifecycle-fx.teardown :as teardown]
             [re-frame.machines.lifecycle-fx.traces :as traces]
+            [re-frame.machines.paths :as paths]
             [re-frame.machines.spawn-order :as spawn-order]
             [re-frame.machines.timer :as timer]
             [re-frame.registrar :as registrar]))
@@ -97,7 +98,7 @@
   nil actor-id)."
   [frame-id parent-id invoke-id]
   (let [join-state (get-in (frame/frame-app-db-value frame-id)
-                           [:rf/runtime :machines :spawned parent-id invoke-id])
+                           (paths/spawned-path parent-id invoke-id))
         children   (when (map? join-state) (:children join-state))]
     (doseq [[child-id spawned-id] children]
       ;; (rf2-iilco) `destroy-single-actor!` runs the child's `:exit`
@@ -182,7 +183,7 @@
         invoke-id (when tracked? (:rf/spawn-id args))
         old-db    (frame/frame-app-db-value frame-id)
         slot-id   (when (and tracked? old-db)
-                    (get-in old-db [:rf/runtime :machines :spawned parent-id invoke-id]))
+                    (get-in old-db (paths/spawned-path parent-id invoke-id)))
         actor-id  (if tracked? slot-id args)
         ;; rf2-lbjnz — silent-idempotent guard. `live?` is true iff ANY
         ;; liveness signal survives (handler registered / snapshot
@@ -191,7 +192,7 @@
         live?     (and actor-id
                        (or (some? (registrar/lookup :event actor-id))
                            (and (some? old-db)
-                                (contains? (get-in old-db [:rf/runtime :machines :snapshots]) actor-id))
+                                (contains? (get-in old-db (paths/snapshot-path)) actor-id))
                            (some #(= actor-id %)
                                  (spawn-order/frame-order frame-id))
                            (and tracked? (some? slot-id))))]

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/exit_cascade.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/exit_cascade.cljc
@@ -40,6 +40,7 @@
   (:require [re-frame.fx :as fx]
             [re-frame.frame :as frame]
             [re-frame.machines.parallel :as parallel]
+            [re-frame.machines.paths :as paths]
             [re-frame.machines.result :as result]
             [re-frame.registrar :as registrar]
             [re-frame.trace :as trace]))
@@ -77,7 +78,7 @@
   [frame-id actor-id]
   (when actor-id
     (let [db       (frame/frame-app-db-value frame-id)
-          snapshot (when db (get-in db [:rf/runtime :machines :snapshots actor-id]))
+          snapshot (when db (get-in db (paths/snapshot-path actor-id)))
           machine  (resolve-machine-spec actor-id)]
       (when (and snapshot machine)
         (let [r (parallel/run-active-exit-cascade machine snapshot)]
@@ -102,7 +103,7 @@
               ;; swap-frame-db! per destroy.
               (when (not= snapshot new-snap)
                 (frame/swap-frame-db! frame-id
-                                      (fn [d] (assoc-in d [:rf/runtime :machines :snapshots actor-id] new-snap))))
+                                      (fn [d] (assoc-in d (paths/snapshot-path actor-id) new-snap))))
               ;; (5) Fire the `:exit`-emitted fx via the standard fx
               ;; interpreter. Use the frame's `:platform` (defaults to
               ;; :client) so platform-gated fx behave consistently with

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
@@ -36,6 +36,7 @@
             [re-frame.machines.lifecycle-fx.teardown :as teardown]
             [re-frame.machines.lifecycle-fx.traces :as traces]
             [re-frame.machines.parallel :as parallel]
+            [re-frame.machines.paths :as paths]
             [re-frame.machines.result :as result]
             [re-frame.machines.timer :as timer]
             [re-frame.machines.transition :as transition]
@@ -141,7 +142,7 @@
                         ;; teardown projection (e.g. `:on-done` reading
                         ;; the child via `[:rf/runtime :machines :snapshots]`) sees the
                         ;; final state's writes.
-                        (assoc-in db [:rf/runtime :machines :snapshots machine-id] next-snapshot)
+                        (assoc-in db (paths/snapshot-path machine-id) next-snapshot)
                         db)
         _             (when (not exit-ok?)
                         (trace/emit-error! :rf.error/machine-action-exception
@@ -182,7 +183,7 @@
         spawn-spec  (when (and parent-meta invoke-id)
                       (find-spawn-spec-at parent-meta invoke-id))
         on-done-fn  (:on-done spawn-spec)
-        parent-path [:rf/runtime :machines :snapshots parent-id]
+        parent-path (paths/snapshot-path parent-id)
         ;; (2) Emit `:rf.machine/done` trace BEFORE the destroy cascade
         ;; (D6 ordering).
         _ (trace/emit! :rf.machine :rf.machine/done

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/frame_destroy.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/frame_destroy.cljc
@@ -42,6 +42,7 @@
             [re-frame.late-bind :as late-bind]
             [re-frame.machines.lifecycle-fx.destroy :as destroy]
             [re-frame.machines.lifecycle-fx.exit-cascade :as exit-cascade]
+            [re-frame.machines.paths :as paths]
             [re-frame.machines.spawn-order :as spawn-order]
             [re-frame.substrate.adapter :as adapter]
             [re-frame.trace :as trace]))
@@ -56,7 +57,7 @@
   [frame-id]
   (let [container (frame/app-db-container frame-id)
         db        (when container (adapter/read-container container))]
-    (or (get-in db [:rf/runtime :machines :snapshots]) {})))
+    (or (get-in db (paths/snapshot-path)) {})))
 
 (defn- emit-lifecycle-destroyed!
   "Emit the legacy `:rf.machine.lifecycle/destroyed` notification per

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
@@ -31,6 +31,7 @@
   lookup."
   (:require [re-frame.machines.parallel :as parallel]
             [re-frame.machines.path-walk :as path-walk]
+            [re-frame.machines.paths :as paths]
             [re-frame.machines.transition :as transition]
             [re-frame.trace :as trace]))
 
@@ -261,7 +262,7 @@
             child-extra (vec (drop 2 inner-event))
             ;; Read the live join state from app-db (the seed was written
             ;; by :rf.machine/spawn-all-init on entry).
-            join-state (get-in db [:rf/runtime :machines :spawned parent-id invoke-id])]
+            join-state (get-in db (paths/spawned-path parent-id invoke-id))]
         (cond
           ;; Pure-call snapshot: no app-db join state seeded yet — fall
           ;; through to no-op (the runtime tracks join state via the fx
@@ -313,5 +314,5 @@
                                      child-id child-extra resolution)
             (let [fx (build-resolution-fx frame-id parent-id invoke-id spec join-state''
                                           child-id child-extra resolution)]
-              {:db (assoc-in db [:rf/runtime :machines :spawned parent-id invoke-id] join-state'')
+              {:db (assoc-in db (paths/spawned-path parent-id invoke-id) join-state'')
                :fx fx})))))))

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
@@ -25,6 +25,7 @@
             [re-frame.machines.lifecycle-fx.join :as join]
             [re-frame.machines.lifecycle-fx.validation :as validation]
             [re-frame.machines.parallel :as parallel]
+            [re-frame.machines.paths :as paths]
             [re-frame.machines.result :as result
              #?@(:cljs [:include-macros true])]
             [re-frame.machines.transition :as transition]
@@ -262,7 +263,7 @@
                              :rf/frame     frame-id
                              :rf/platform  platform
                              :rf/parent-id machine-id)
-        path          [:rf/runtime :machines :snapshots machine-id]
+        path          (paths/snapshot-path machine-id)
         existing-snap (get-in db path)
         snapshot      (cond
                         (nil? existing-snap)

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
@@ -24,6 +24,7 @@
             [re-frame.machines.data-validation :as data-validation]
             [re-frame.machines.lifecycle-fx.registration :as registration]
             [re-frame.machines.parallel :as parallel]
+            [re-frame.machines.paths :as paths]
             [re-frame.machines.spawn-order :as spawn-order]
             [re-frame.registrar :as registrar]
             [re-frame.trace :as trace]))
@@ -126,7 +127,7 @@
   (let [initial-snap (when spec
                        (parallel/build-initial-snapshot
                          spec {:bootstrap-pending? true}))
-        existing     (when system-id (get-in db-after-alloc [:rf/runtime :machines :system-ids system-id]))]
+        existing     (when system-id (get-in db-after-alloc (paths/system-id-path system-id)))]
     (if (and spec (not (data-validation/validate-spawn-data!
                          spawned-id spec initial-snap)))
       :rejected
@@ -146,9 +147,9 @@
         (frame/swap-frame-db! frame-id
                               (fn [_db]
                                 (cond-> db-after-alloc
-                                  spec      (assoc-in [:rf/runtime :machines :snapshots spawned-id] initial-snap)
-                                  system-id (assoc-in [:rf/runtime :machines :system-ids system-id] spawned-id)
-                                  track?    (assoc-in [:rf/runtime :machines :spawned parent-id invoke-id] spawned-id))))
+                                  spec      (assoc-in (paths/snapshot-path spawned-id) initial-snap)
+                                  system-id (assoc-in (paths/system-id-path system-id) spawned-id)
+                                  track?    (assoc-in (paths/spawned-path parent-id invoke-id) spawned-id))))
         (when system-id
           (trace/emit! :rf.machine :rf.machine/system-id-bound
                        {:frame      frame-id
@@ -313,7 +314,7 @@
         join-state (:join-state args)
         children   (:children join-state)]
     (frame/swap-frame-db! frame-id assoc-in
-                          [:rf/runtime :machines :spawned parent-id invoke-id] join-state)
+                          (paths/spawned-path parent-id invoke-id) join-state)
     (trace/emit! :rf.machine :rf.machine.spawn-all/started
                  {:machine-id parent-id
                   :spawn-id  invoke-id

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/teardown.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/teardown.cljc
@@ -33,7 +33,8 @@
   ordering relative to db mutation is contract (Spec 005 §Cancellation
   cascade D6-D8: emit `:rf.machine/destroyed` BEFORE db mutation so
   in-flight trace consumers see the destroy signal while the handler
-  still resolves; unregister the handler LAST).")
+  still resolves; unregister the handler LAST)."
+  (:require [re-frame.machines.paths :as paths]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -46,7 +47,7 @@
   (when actor-id
     (some (fn [[sid mid]]
             (when (= mid actor-id) sid))
-          (get-in db [:rf/runtime :machines :system-ids]))))
+          (get-in db (paths/system-id-path)))))
 
 (defn teardown-actor
   "Apply the unified app-db teardown projection to `db`. Returns a tuple
@@ -79,23 +80,23 @@
         track?       (and parent-id invoke-id)
         ;; (1)+(2)+(3): the three primary slot mutations.
         new-db       (cond-> db
-                       actor-id     (update-in [:rf/runtime :machines :snapshots]
+                       actor-id     (update-in (paths/snapshot-path)
                                                dissoc actor-id)
-                       released-sid (update-in [:rf/runtime :machines :system-ids]
+                       released-sid (update-in (paths/system-id-path)
                                                dissoc released-sid)
-                       track?       (update-in [:rf/runtime :machines :spawned parent-id]
+                       track?       (update-in (paths/spawned-path parent-id)
                                                 dissoc invoke-id))
         ;; (4a): prune the per-parent `:spawned` map if empty.
         new-db       (cond-> new-db
                        (and track?
-                            (empty? (get-in new-db [:rf/runtime :machines :spawned parent-id])))
-                       (update-in [:rf/runtime :machines :spawned] dissoc parent-id))
+                            (empty? (get-in new-db (paths/spawned-path parent-id))))
+                       (update-in (paths/spawned-path) dissoc parent-id))
         ;; (4b): prune the `[:rf/runtime :machines :spawned]` slot if
         ;; empty (lazy-allocation mirror — :snapshots and :system-ids
         ;; stay present per fixture contract).
         new-db       (cond-> new-db
                        (and (contains? (get-in new-db [:rf/runtime :machines])
                                        :spawned)
-                            (empty? (get-in new-db [:rf/runtime :machines :spawned])))
+                            (empty? (get-in new-db (paths/spawned-path))))
                        (update-in [:rf/runtime :machines] dissoc :spawned))]
     [new-db released-sid]))

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/update_snapshot.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/update_snapshot.cljc
@@ -25,6 +25,7 @@
   the action-effect path enforces (Spec 005:463), surfaced as
   `:rf.error/machine-action-wrote-db`."
   (:require [re-frame.frame :as frame]
+            [re-frame.machines.paths :as paths]
             [re-frame.trace :as trace]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -60,7 +61,7 @@
             (fn [db]
               ;; No-op merge target when the snapshot is absent — never
               ;; conjure a snapshot for a destroyed / unknown actor.
-              (if (contains? (get-in db [:rf/runtime :machines :snapshots]) machine-id)
-                (update-in db [:rf/runtime :machines :snapshots machine-id] merge clean-patch)
+              (if (contains? (get-in db (paths/snapshot-path)) machine-id)
+                (update-in db (paths/snapshot-path machine-id) merge clean-patch)
                 db))))))
     nil))

--- a/implementation/machines/src/re_frame/machines/paths.cljc
+++ b/implementation/machines/src/re_frame/machines/paths.cljc
@@ -1,0 +1,59 @@
+(ns re-frame.machines.paths
+  "App-db path constructors for the runtime-owned machines slots.
+
+  The machines runtime keeps three sibling maps under
+  `[:rf/runtime :machines …]` in each frame's app-db:
+
+    - `:snapshots`  — actor-id → snapshot `{:state :data :tags …}`
+    - `:system-ids` — system-id → actor-id reverse index
+    - `:spawned`    — parent-id → invoke-id → join-state / spawned-id
+
+  These constructors are the single source of truth for the literal
+  path vectors that `src/` reads and writes (`get-in` / `update-in` /
+  `assoc-in`). They keep the spelling in one place so a future restructure
+  (eguy4-style) touches one namespace, and they let a call-site read as
+  `(snapshot-path actor-id)` rather than a runtime-path-shaped vector —
+  surfacing intent (\"this is the machines snapshot slot\") at the call.
+
+  This namespace is a leaf: it requires nothing from the rest of the
+  machines artefact, so any `re-frame.machines.*` namespace may require it
+  without a cycle.
+
+  Scope is `src/` only. Test assertions deliberately keep raw
+  `(get-in db [:rf/runtime :machines …])` paths — those live outside the
+  machines runtime and read more honestly as literal app-db probes.")
+
+#?(:clj (set! *warn-on-reflection* true))
+
+(defn snapshot-path
+  "Path to the `:snapshots` slot, optionally drilling into a specific
+  actor's snapshot and a key (or key pair) within it.
+
+    (snapshot-path)                  => [:rf/runtime :machines :snapshots]
+    (snapshot-path machine-id)       => [:rf/runtime :machines :snapshots machine-id]
+    (snapshot-path machine-id k)     => [:rf/runtime :machines :snapshots machine-id k]
+    (snapshot-path machine-id k k2)  => [:rf/runtime :machines :snapshots machine-id k k2]"
+  ([]                [:rf/runtime :machines :snapshots])
+  ([machine-id]      [:rf/runtime :machines :snapshots machine-id])
+  ([machine-id k]    [:rf/runtime :machines :snapshots machine-id k])
+  ([machine-id k k2] [:rf/runtime :machines :snapshots machine-id k k2]))
+
+(defn system-id-path
+  "Path to the `:system-ids` reverse-index slot, optionally drilling into
+  a specific system-id's binding.
+
+    (system-id-path)     => [:rf/runtime :machines :system-ids]
+    (system-id-path sid) => [:rf/runtime :machines :system-ids sid]"
+  ([]    [:rf/runtime :machines :system-ids])
+  ([sid] [:rf/runtime :machines :system-ids sid]))
+
+(defn spawned-path
+  "Path to the `:spawned` slot, optionally drilling into a parent's
+  per-invoke map and a specific invoke-id's join-state slot.
+
+    (spawned-path)                   => [:rf/runtime :machines :spawned]
+    (spawned-path parent-id)         => [:rf/runtime :machines :spawned parent-id]
+    (spawned-path parent-id inv-id)  => [:rf/runtime :machines :spawned parent-id inv-id]"
+  ([]                    [:rf/runtime :machines :spawned])
+  ([parent-id]           [:rf/runtime :machines :spawned parent-id])
+  ([parent-id invoke-id] [:rf/runtime :machines :spawned parent-id invoke-id]))

--- a/implementation/machines/src/re_frame/machines/timer.cljc
+++ b/implementation/machines/src/re_frame/machines/timer.cljc
@@ -35,6 +35,7 @@
   (:require [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
+            [re-frame.machines.paths :as paths]
             [re-frame.machines.transition :as transition]
             [re-frame.subs :as subs]
             [re-frame.trace :as trace]))
@@ -239,7 +240,7 @@
     (let [k (after-timer-key parent-id invoke-id delay-key)]
       (cancel-after-timer-entry! frame-id k :on-resolution)
       (when-let [db (frame/frame-app-db-value frame-id)]
-        (let [snap (get-in db [:rf/runtime :machines :snapshots parent-id])
+        (let [snap (get-in db (paths/snapshot-path parent-id))
               ;; Per Spec 005 §Per-region :after scoping (rf2-l67o): for
               ;; parallel-region machines the snapshot's :state is a map
               ;; of region-name → that region's state, and the invoke-id
@@ -418,7 +419,7 @@
         epoch      (:epoch args)
         server?    (boolean (:server? args))
         snapshot   (get-in (frame/frame-app-db-value frame-id)
-                           [:rf/runtime :machines :snapshots parent-id])]
+                           (paths/snapshot-path parent-id))]
     ;; Initial state-entry scheduling — the :scheduled trace was already
     ;; emitted synchronously by apply-transition-once (the pure side). For
     ;; sub-vec delays, the fx layer's resolution may yield a different


### PR DESCRIPTION
rf2-at4cl — centralizes the runtime-owned `[:rf/runtime :machines …]` app-db path literals in machines `src/` behind three constructors so intent reads at the call-site and a future restructure touches one namespace.

## What

Adds `re-frame.machines.paths` (new leaf ns — depends on nothing in the machines artefact, so any `re-frame.machines.*` ns may require it without a cycle; placing the helpers inline in `re-frame.machines` would invert the existing dependency direction, since `re-frame.machines` already requires every lifecycle-fx ns):

- `snapshot-path`  — `([] / [machine-id] / [machine-id k] / [machine-id k k2])` → `[:rf/runtime :machines :snapshots …]`
- `system-id-path` — `([] / [sid])` → `[:rf/runtime :machines :system-ids …]`
- `spawned-path`   — `([] / [parent-id] / [parent-id invoke-id])` → `[:rf/runtime :machines :spawned …]`

(The bead spec'd `snapshot-path` from 1 arg; I added the 0-arity for the bare `:snapshots` map root so all three helpers expose a symmetric 0-arity — there are 4 bare-root uses.)

Routes the **23 executable** `get-in`/`assoc-in`/`update-in`/`contains?` call-sites through the helpers across 12 files (densest: `teardown.cljc`, 8 sites in one fn). Local-binding precedents `registration.cljc` and `finalize.cljc` now bind `(paths/…)`. Docstrings/comments that cite the path shape are kept verbatim (they accurately describe the canonical path the helpers produce).

Out of scope (left as literals, by design): test assertions (raw paths are correct for app-db probes outside the runtime); the 2-element `[:rf/runtime :machines]` parent-container literals in teardown's lazy-prune (no container helper requested).

Pure readability refactor: structural paths and on-disk app-db shape are **identical**. No public API change. No shim / deprecated alias (pre-alpha).

Spec unchanged because internal refactor, paths identical — the machines artefact ships no spec doc, and the normative path is documented in `spec/Conventions.md` (untouched: the layout is unchanged).

## Quality gates

- `cd implementation/machines && clojure -M:test` → **298 tests, 980 assertions, 0 failures, 0 errors**
- `cd implementation && npm run test:cljs` → **4820 tests, 15792 assertions, 0 failures, 0 errors**
- `bash scripts/test-fast-pr.sh` → **PASS fast PR spine** (changed-surfaces 38, CLJS node integration 4820/15792 0/0, script-helper gates green)
- Coupling check `git grep -lE "re-frame\.machines\.paths" implementation/ tools/` → only the 12 machines `src/` files (no leak into other artefacts).
