### PR TITLE
fix(xray): subscriptions click-to-source + first-run container chrome + click-to-source consolidation (3 beads incl. 2 P2)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1628,7 +1628,7 @@ rendering — the full data tree with inline diff annotations against
 | Epoch HANDLER step `:db`               | FULL+DIFF via edn-inspector with `:before` threaded |
 | App-DB panel                           | Section list, each section FULL+DIFF |
 | Machine Inspector snapshot drill-in    | Single edn-inspector mount, FULL+DIFF |
-| Epoch SUBSCRIPTIONS step value cells   | Per-row leaf-scalar (rf2-fyd8u) or container FULL+DIFF |
+| Epoch SUBSCRIPTIONS step value cells   | Per-row leaf-scalar (rf2-fyd8u) or container FULL+DIFF; a first-run container routes through `:added?` (§10.0.13) for whole-tree `:added` chrome (rf2-kp7bw) |
 
 **R-rule applicability across surfaces**: all R1-R8 rules from
 §9.1.5.1 apply uniformly to every surface. Rules that have no work
@@ -2406,6 +2406,17 @@ reach for `[edn-inspector value opts]` directly.
   §10.0.12 for the contract + per-surface call-site obligation. The
   silent-default chosen here is intentional: it preserves the diff-
   only call sites that should NOT paint mode-3 chrome.
+- `:added?` (rf2-kp7bw) — boolean FIRST-RUN signal. When `true` AND
+  no explicit `:before` is supplied, the widget enters diff mode with
+  the prior side synthesised as `engine/missing-sentinel`, so the
+  projection classifies the WHOLE value tree as `:added` (root op
+  `:added` → green wash + `+` chrome over every descendant). Use for a
+  value that just came into existence — a sub's first cache entry, an
+  app-db key that just appeared — where a plain mount would read as
+  un-annotated. An explicit `:before` always takes precedence (a real
+  prior value is a genuine diff, not a first run), so `:added?` is a
+  no-op when `:before` is present. Empty containers still read
+  `:added`. See §10.0.13. Defaults `false`.
 
 The widget is a **Reagent form-2 component** — the outer fn captures
 a stable `mount-id` (auto-generated UUID, per D4=a — no public
@@ -3209,6 +3220,45 @@ Reagent component that takes `(value, opts)`. The boolean
 panel keep ownership while the widget keeps a pure data interface.
 Audit trail: rf2-ya3nj 24hr audit, finding M3 (spec drift) →
 rf2-6cm03 (this section).
+
+#### §10.0.13 `:added?` opt — first-run / whole-value-added chrome (rf2-kp7bw)
+
+A FIRST-RUN value is one with no prior state to diff against — a
+sub's first cache entry, an app-db key that just appeared. The
+scalar SUBSCRIPTIONS branch (rf2-fyd8u) already paints row-level
+`:added` chrome (green stripe + leading `+`) for such a value, but
+the container branch had no equivalent: a first-run map / vector /
+set fell through to a plain edn-inspector mount with `before` nil,
+so the widget never entered diff mode and the subtree read as
+un-annotated — visually indistinguishable from an unchanged value
+on the cascade that introduced it. Canonical repro: the `[:rf/route]`
+map sub on a `/counter` view-mount epoch (every sibling scalar sub
+painted `:added`; the route map painted plain).
+
+**Contract.**
+
+- **Signal.** `:added? true` (boolean opt). Without an explicit
+  `:before`, the widget synthesises the prior side as
+  `engine/missing-sentinel`. The projection (`diff.engine/project
+  missing-sentinel value`) reports the root op as `:added`, so the
+  whole tree paints the green wash + `+` added chrome.
+- **Precedence.** An explicit `:before` always wins — a real prior
+  value is a genuine diff, not a first run — so `:added?` is a no-op
+  when `:before` is supplied.
+- **Empty containers.** A first-run EMPTY map / vector / set still
+  reads `:added`: the engine reports root `:added` for
+  `(missing-sentinel, {})` / `(missing-sentinel, [])`.
+- **Sentinel discipline.** The synthesised prior is the **engine's**
+  `missing-sentinel` (`:day8.re-frame2-xray.diff.engine/missing`),
+  NOT the edn-inspector's `::missing` walker sentinel — only the
+  engine value drives the projection to a root `:added` classification
+  (the edn-inspector keyword would project as a `:modified` type-flip).
+
+**Consumer call-site** — `panels/epoch/view.cljs` `subs-value-cell`
+container branch passes `:added? true` when the row is `first-run?`
+and carries no `before`. Test surface:
+`first-run-container-sub-renders-added-chrome-test`
+(`view_cljs_test.cljs`).
 
 ### §10.1 Capabilities (LOCKED per B.9 super-prompt)
 

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1794,6 +1794,15 @@ into a single canonical home at
   overlay (rf2-xjgdk audit F4 hoist).
 - **Accessibility.** Native `<button>` (Enter / Space activate),
   `aria-label "open in editor"`, inline SVG `aria-hidden`.
+- **SUBSCRIPTIONS call-sites (rf2-aesni).** The active SUBSCRIPTIONS
+  table's sub-name cell mounts `coord-chip` (testid
+  `rf-xray-epoch-sub-row-coord-<i>`), exact parity with the
+  disposed-subs (`…-sub-disposed-row-coord-<i>`) + UNMOUNTED VIEWS
+  rows. The coord lookup keys off the row's `sub-id` keyword even
+  when a parameterized `sub-vec` (`[:counter/greater-than? 5]`)
+  drives the displayed label, so the chip resolves the sub's
+  REGISTRATION coord. Pre-fix this cell rendered a bare decorative
+  `external-link` glyph with no coord resolution + no click handler.
 
 **`coord-chip` vs `open_in_editor/open-chip`** — two surfaces co-
 exist by design. `coord-chip` (the dispatch-based button used inside

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1813,6 +1813,53 @@ URI pre-resolved against `editor-uri/editor-uri`; it is used by demo
 surfaces + the standalone static page where no trace bus is
 available. (rf2-evgf5 / rf2-g5q8d decision.)
 
+##### §9.1.6.2.1 Companion `coord-link` (rf2-vw5pi · `panels/shared/coord_link.cljs`)
+
+Where `coord-chip` is the **icon-only** affordance (a glyph appended
+after an id), `coord-link` is the **label-as-link** companion — the
+verb / label TEXT itself is the hyperlink, with the `external-link`
+glyph appended (`reg-event-fx ↗`). Before rf2-vw5pi this shape was
+hand-rolled ~11 times across `panels/epoch/view.cljs` (the HANDLER
+verb-link, the DISPATCH source label, the COEFFECT / FLOW verb ids,
+the machine cascade verb-link + state-path, the schema-violation
+action + inline prose link) plus the `↗` table-cell affordances in
+`panels/issues_ribbon.cljs` + `panels/trace.cljs`, each re-inlining
+the same `[:button {:on-click (rf/dispatch [:rf.xray/open-in-editor
+…])} …]` boilerplate + its own `clickable?` / plain-fallback branch.
+
+**Contract.**
+
+- **Public fns.** `coord-link coord label testid` (or `… testid
+  opts`). Renders a `<button>` carrying `label` + the glyph when
+  `coord` has a `:file`; degrades to a plain `<span>` (no dead button)
+  otherwise. `open-in-editor!` is the shared dispatch action — the ONE
+  `[:rf.xray/open-in-editor {:source-coord coord}]` dispatch every
+  panel-side affordance funnels through (incl. `coord-chip`, the
+  `↗` table cells, and the Reactive panel's SVG-node clicks which bind
+  it to `:on-click` directly because they are `<g>`/`<rect>` nodes, not
+  `<button>` chips).
+- **Opts.** `:style` (the button chrome), `:plain-style` (the no-coord
+  span chrome), `:glyph-leading?` (glyph BEFORE the label — the
+  schema-violation grammar), `:glyph?` (default true; `false` for a
+  pure inline text link inside prose, e.g. the `schema check` link).
+- **Per-site resolvers stay.** The coord RESOLVERS (`sub-coord`,
+  `view-coord`, `machine-state-path-coord`, the cofx / flow
+  `handler-meta` lookups, …) are legitimately per-site and remain at
+  their call sites — only the button + dispatch + fallback RENDERING
+  is shared.
+
+**Consolidation invariant + guard.** Exactly two shared panel-side
+click-to-source helpers exist (`coord-chip` icon-only · `coord-link`
+label), and no panel file re-inlines the open-in-editor dispatch. A
+JVM source-text guard
+(`tools/xray/test/.../panels/click_to_source_consolidation_test.clj`)
+asserts the `dispatch [:rf.xray/open-in-editor …]` CALL appears ONLY
+in `coord_chip.cljs` + `coord_link.cljs` — a future hand-rolled button
+trips it. (The guard keys on the dispatch-CALL shape, not the bare
+keyword, so docstrings / comments naming the event — and the
+`open_in_editor.cljs` reg-event-fx receiver + static-page `<a href>`
+anchor, excluded by design — do not false-positive.)
+
 #### §9.1.6.3 DISPATCH source-kind enrichment (rf2-5qp4g · consuming rf2-ejtpd)
 
 The DISPATCH step's source label adapts to the closed-set substrate-

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -2992,13 +2992,25 @@
           "← was "
           [:span {:data-rf-xray-subs-leaf-was "1"}
            [ei/mini before 40]]]])
+      ;; rf2-kp7bw — a CONTAINER-valued sub return. On a first run
+      ;; (`first-run?`, no prior cache entry) the inspector renders the
+      ;; whole subtree as `:added` via the `:added?` opt (edn-inspector
+      ;; §10.0.13) — parity with the scalar branch's row-level `:added`
+      ;; chrome above. Pre-fix the container branch consulted ONLY
+      ;; `:before`, which is nil on a first run, so the inspector
+      ;; mounted plain (no diff mode, no added signal) while every
+      ;; scalar sibling painted `:added`. Canonical case: the
+      ;; `[:rf/route]` map sub on a /counter view-mount epoch. An
+      ;; explicit prior value (`some? before`) is a genuine diff and
+      ;; takes precedence over the first-run signal.
       [:div {:style subs-value-cell-fill-style}
        [ei/edn-inspector after
         (cond-> {:panel-id :rf.xray.epoch/subs-value
                  :site-id  [:rf.xray.epoch/subs-value sub-id idx :full+diff]
                  :default-expanded-depth 3
                  :full-with-diff? true}
-          (some? before) (assoc :before before))]])))
+          (some? before)                 (assoc :before before)
+          (and first-run? (nil? before)) (assoc :added? true))]])))
 
 (defn- sub-coord
   "Pull the registered sub's source coord off

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -58,6 +58,7 @@
             [day8.re-frame2-xray.panels.epoch.icons :as icons]
             [day8.re-frame2-xray.panels.epoch.projection :as proj]
             [day8.re-frame2-xray.panels.shared.coord-chip :as coord-chip]
+            [day8.re-frame2-xray.panels.shared.coord-link :as coord-link]
             [day8.re-frame2-xray.views.edn-inspector :as ei]
             [day8.re-frame2-xray.views.edn-widget.widget :as edn]
             [day8.re-frame2-xray.views.resizable-table :as rt]
@@ -1483,27 +1484,13 @@
   `:rf.xray/open-in-editor` event (the same fx-id every other
   open-in-editor surface dispatches via)."
   [source coord]
-  (let [label (if source (name source) "unknown")
-        clickable? (and (map? coord) (seq (:file coord)))]
-    (if clickable?
-      [:button {:data-testid "rf-xray-epoch-dispatch-source-label"
-                :aria-label  (str "open dispatch call-site for " label)
-                :title       (str "open " (:file coord)
-                                  (when (:line coord)
-                                    (str ":" (:line coord)))
-                                  " in editor")
-                :on-click    (fn [e]
-                               (.stopPropagation e)
-                               (rf/dispatch
-                                 [:rf.xray/open-in-editor
-                                  {:source-coord coord}]
-                                 {:frame :rf/xray}))
-                :style link-button-style}
-       label
-       (icons/external-link)]
-      [:span {:data-testid "rf-xray-epoch-dispatch-source-label"
-              :style dispatch-source-plain-style}
-       label])))
+  (let [label (if source (name source) "unknown")]
+    ;; rf2-vw5pi — routes through the shared `coord-link` (label-as-link
+    ;; companion to `coord-chip`); the per-site link / plain styles stay
+    ;; here, the button + dispatch + nil-coord fallback are shared.
+    (coord-link/coord-link coord label "rf-xray-epoch-dispatch-source-label"
+                           {:style       link-button-style
+                            :plain-style dispatch-source-plain-style})))
 
 ;; ---- rf2-5qp4g — DISPATCH source enrichment per source kind --------------
 ;;
@@ -1560,26 +1547,10 @@
   `coord` is `{:file <string> :line <int>}` or nil; `testid` is the
   data-testid suffix."
   [path-str coord testid]
-  (if (and (map? coord) (seq (:file coord)))
-    [:button {:data-testid testid
-              :aria-label  (str "open " (:file coord)
-                                (when (:line coord) (str ":" (:line coord)))
-                                " in editor")
-              :title       (str "open " (:file coord)
-                                (when (:line coord) (str ":" (:line coord)))
-                                " in editor")
-              :on-click    (fn [e]
-                             (.stopPropagation e)
-                             (rf/dispatch
-                               [:rf.xray/open-in-editor
-                                {:source-coord coord}]
-                               {:frame :rf/xray}))
-              :style dispatch-source-state-path-button-style}
-     path-str
-     (icons/external-link)]
-    [:span {:data-testid testid
-            :style dispatch-source-state-path-plain-style}
-     path-str]))
+  ;; rf2-vw5pi — shared `coord-link`; per-site styles preserved.
+  (coord-link/coord-link coord path-str testid
+                         {:style       dispatch-source-state-path-button-style
+                          :plain-style dispatch-source-state-path-plain-style}))
 
 (defn- parent-epoch-affordance
   "Render the `parent epoch #N` chrome for `:fx-dispatch` /
@@ -1820,31 +1791,15 @@
                           (catch :default _ nil)))
         coord      (when (and cofx-meta (string? (:file cofx-meta)))
                      {:file (:file cofx-meta) :line (:line cofx-meta)})
-        clickable? (and (map? coord) (seq (:file coord)))
         label      (proj/ns-keyword id)]
     [:div {:key (str "cofx-" idx)
            :data-testid (str "rf-xray-epoch-coeffect-row-" idx)
            :style coeffect-row-style}
-     ;; id — clickable button when coord captured; plain span otherwise
-     (if clickable?
-       [:button {:data-testid (str "rf-xray-epoch-coeffect-row-id-" idx)
-                 :aria-label  (str "open " (:file coord)
-                                   (when (:line coord) (str ":" (:line coord)))
-                                   " in editor")
-                 :title       (str "open " (:file coord)
-                                   (when (:line coord) (str ":" (:line coord)))
-                                   " in editor")
-                 :on-click    (fn [e]
-                                (.stopPropagation e)
-                                (rf/dispatch [:rf.xray/open-in-editor
-                                              {:source-coord coord}]
-                                             {:frame :rf/xray}))
-                 :style link-button-inherit-style}
-        label
-        (icons/external-link)]
-       [:span {:data-testid (str "rf-xray-epoch-coeffect-row-id-" idx)
-               :style coeffect-row-id-plain-style}
-        label])
+     ;; rf2-vw5pi — id via shared `coord-link` (clickable when coord
+     ;; captured, plain span otherwise); per-site styles preserved.
+     (coord-link/coord-link coord label (str "rf-xray-epoch-coeffect-row-id-" idx)
+                            {:style       link-button-inherit-style
+                             :plain-style coeffect-row-id-plain-style})
      ;; injected value (labelled — no cryptic `+[]nil` line)
      [:span {:data-testid (str "rf-xray-epoch-coeffect-row-value-" idx)
              :style coeffect-row-value-style}
@@ -1867,7 +1822,6 @@
                           (catch :default _ nil)))
         coord      (when (and cofx-meta (string? (:file cofx-meta)))
                      {:file (:file cofx-meta) :line (:line cofx-meta)})
-        clickable? (and (map? coord) (seq (:file coord)))
         label      (proj/ns-keyword id)]
     [:div {:data-testid (str "rf-xray-epoch-step-coeffect-" (name id))
            :data-step-kw "coeffect"
@@ -1878,29 +1832,12 @@
         :badge :COEFFECT
         ;; Verb = cofx-id (clickable when coord captured), nothing
         ;; else. The injected value renders in the BODY below the
-        ;; badge per pair-debug 2026-05-26.
-        :verb (if clickable?
-                [:button {:data-testid (str "rf-xray-epoch-coeffect-id-" (name id))
-                          :aria-label  (str "open " (:file coord)
-                                            (when (:line coord)
-                                              (str ":" (:line coord)))
-                                            " in editor")
-                          :title       (str "open " (:file coord)
-                                            (when (:line coord)
-                                              (str ":" (:line coord)))
-                                            " in editor")
-                          :on-click    (fn [e]
-                                         (.stopPropagation e)
-                                         (rf/dispatch
-                                           [:rf.xray/open-in-editor
-                                            {:source-coord coord}]
-                                           {:frame :rf/xray}))
-                          :style coeffect-verb-link-button-style}
-                 label
-                 (icons/external-link)]
-                [:span {:data-testid (str "rf-xray-epoch-coeffect-id-" (name id))
-                        :style coeffect-verb-plain-style}
-                 label])
+        ;; badge per pair-debug 2026-05-26. rf2-vw5pi — via shared
+        ;; `coord-link`; per-site verb styles preserved.
+        :verb (coord-link/coord-link coord label
+                                     (str "rf-xray-epoch-coeffect-id-" (name id))
+                                     {:style       coeffect-verb-link-button-style
+                                      :plain-style coeffect-verb-plain-style})
         :expandable? false
         :testid (str "rf-xray-epoch-coeffect-" (name id))}
        nil)
@@ -2075,30 +2012,14 @@
   shape as the HANDLER step's verb so the operator's eye trains on
   ONE source-link grammar across the panel."
   [row coord verb-string]
-  (let [clickable? (and (map? coord) (seq (:file coord)))]
-    (if clickable?
-      [:button {:data-testid (str "rf-xray-epoch-machine-cascade-verb-link-"
-                                  (:step row))
-                :aria-label  (str "open " (:file coord)
-                                  (when (:line coord)
-                                    (str ":" (:line coord)))
-                                  " in editor")
-                :title       (str "open " (:file coord)
-                                  (when (:line coord)
-                                    (str ":" (:line coord)))
-                                  " in editor")
-                :on-click    (fn [e]
-                               (.stopPropagation e)
-                               (rf/dispatch [:rf.xray/open-in-editor
-                                             {:source-coord coord}]
-                                            {:frame :rf/xray}))
-                :style cascade-verb-link-button-style}
-       verb-string
-       (icons/external-link)]
-      [:span {:data-testid (str "rf-xray-epoch-machine-cascade-verb-"
-                                (:step row))
-              :style cascade-verb-plain-style}
-       verb-string])))
+  ;; rf2-vw5pi — shared `coord-link`; per-site styles preserved. The
+  ;; testid is now a single stem (`…-verb-link-<step>`) across both the
+  ;; clickable + plain branches — the prior `…-verb-<step>` plain-only
+  ;; variant was a hand-rolled artefact, not pinned by any selector.
+  (coord-link/coord-link coord verb-string
+                         (str "rf-xray-epoch-machine-cascade-verb-link-" (:step row))
+                         {:style       cascade-verb-link-button-style
+                          :plain-style cascade-verb-plain-style}))
 
 (defn- source-form->string
   "Coerce a cascade-row source-form value into a printable Clojure
@@ -2465,30 +2386,14 @@
                           (if machine? :machine :event) event-id)
                         (catch :default _ nil)))
         coord    (coord-from-handler-meta meta)
-        label    (proj/handler-flavour-label flavour)
-        clickable? (and (map? coord) (seq (:file coord)))]
-    (if clickable?
-      [:button {:data-testid "rf-xray-epoch-handler-verb-link"
-                :aria-label  (str "open " (:file coord)
-                                  (when (:line coord)
-                                    (str ":" (:line coord)))
-                                  " in editor")
-                :title       (str "open " (:file coord)
-                                  (when (:line coord)
-                                    (str ":" (:line coord)))
-                                  " in editor")
-                :on-click    (fn [e]
-                               (.stopPropagation e)
-                               (rf/dispatch
-                                 [:rf.xray/open-in-editor
-                                  {:source-coord coord}]
-                                 {:frame :rf/xray}))
-                :style handler-verb-link-button-style}
-       label
-       (icons/external-link)]
-      [:span {:data-testid "rf-xray-epoch-handler-verb-plain"
-              :style handler-verb-plain-style}
-       label])))
+        label    (proj/handler-flavour-label flavour)]
+    ;; rf2-vw5pi — the HANDLER verb-as-link routes through the shared
+    ;; `coord-link`. Single testid across both branches (the prior
+    ;; `…-verb-plain` variant was a hand-rolled artefact, not pinned);
+    ;; per-site link / plain styles preserved.
+    (coord-link/coord-link coord label "rf-xray-epoch-handler-verb-link"
+                           {:style       handler-verb-link-button-style
+                            :plain-style handler-verb-plain-style})))
 
 (defn- handler-source-block
   "Render the source-code block under the HANDLER header. Three
@@ -2692,7 +2597,6 @@
                           (catch :default _ nil)))
         coord      (when (and flow-meta (string? (:file flow-meta)))
                      {:file (:file flow-meta) :line (:line flow-meta)})
-        clickable? (and (map? coord) (seq (:file coord)))
         label      (proj/ns-keyword flow-id)]
     [:div {:data-testid (str "rf-xray-epoch-step-flow-" (name flow-id))
            :data-step-kw "flow"
@@ -2703,28 +2607,11 @@
         :badge :FLOW
         ;; Verb = flow-id (clickable when coord captured). Same
         ;; affordance shape as the COEFFECT step's cofx-id hyperlink.
-        :verb (if clickable?
-                [:button {:data-testid (str "rf-xray-epoch-flow-id-" (name flow-id))
-                          :aria-label  (str "open " (:file coord)
-                                            (when (:line coord)
-                                              (str ":" (:line coord)))
-                                            " in editor")
-                          :title       (str "open " (:file coord)
-                                            (when (:line coord)
-                                              (str ":" (:line coord)))
-                                            " in editor")
-                          :on-click    (fn [e]
-                                         (.stopPropagation e)
-                                         (rf/dispatch
-                                           [:rf.xray/open-in-editor
-                                            {:source-coord coord}]
-                                           {:frame :rf/xray}))
-                          :style coeffect-verb-link-button-style}
-                 label
-                 (icons/external-link)]
-                [:span {:data-testid (str "rf-xray-epoch-flow-id-" (name flow-id))
-                        :style coeffect-verb-plain-style}
-                 label])
+        ;; rf2-vw5pi — via shared `coord-link`; per-site styles kept.
+        :verb (coord-link/coord-link coord label
+                                     (str "rf-xray-epoch-flow-id-" (name flow-id))
+                                     {:style       coeffect-verb-link-button-style
+                                      :plain-style coeffect-verb-plain-style})
         :expandable? false
         :testid (str "rf-xray-epoch-flow-" (name flow-id))
         :duration-ms duration-ms}
@@ -3477,31 +3364,19 @@
 (defn- violation-open-source-action
   "Click-to-source button. `coord` is `{:file :line}` or nil; when
   nil renders a muted plain-text fallback (graceful degrade — the
-  framework may not yet stamp coords for some surfaces)."
+  framework may not yet stamp coords for some surfaces).
+
+  rf2-vw5pi — routes through the shared `coord-link` with
+  `:glyph-leading?` (the schema-violation grammar leads with the
+  glyph: `↗ <failing-id>`). The muted plain fallback overlays the
+  link style with `:text-tertiary` + `default` cursor."
   [{:keys [label coord testid]}]
-  (if (and (map? coord) (string? (:file coord)) (seq (:file coord)))
-    [:button {:data-testid testid
-              :aria-label  (str "open " (:file coord)
-                                (when (:line coord)
-                                  (str ":" (:line coord)))
-                                " in editor")
-              :title       (str "open " (:file coord)
-                                (when (:line coord)
-                                  (str ":" (:line coord)))
-                                " in editor")
-              :on-click    (fn [e]
-                             (.stopPropagation e)
-                             (rf/dispatch [:rf.xray/open-in-editor
-                                           {:source-coord coord}]
-                                          {:frame :rf/xray}))
-              :style schema-violation-action-link-style}
-     (icons/external-link)
-     label]
-    [:span {:data-testid testid
-            :style (assoc schema-violation-action-link-style
-                          :color text-tertiary-colour
-                          :cursor "default")}
-     label]))
+  (coord-link/coord-link coord label testid
+                         {:style          schema-violation-action-link-style
+                          :plain-style    (assoc schema-violation-action-link-style
+                                                 :color  text-tertiary-colour
+                                                 :cursor "default")
+                          :glyph-leading? true}))
 
 (defn- violation-kind-coord
   "Resolve a `(rf/handler-meta <kind> <id>)` coord, returning
@@ -3551,19 +3426,15 @@
   "Render the inline `[schema check]` link inside a violation prose
   sentence (rf2-2ek7t). When `coord` resolves, the text is a clickable
   button that dispatches `:rf.xray/open-in-editor`; absent a coord,
-  it degrades to plain inline text so the sentence stays readable."
+  it degrades to plain inline text so the sentence stays readable.
+
+  rf2-vw5pi — routes through the shared `coord-link` with `:glyph?
+  false` (this is a pure inline TEXT link inside a sentence — no
+  trailing `external-link` glyph)."
   [{:keys [label coord testid]}]
-  (if (and (map? coord) (string? (:file coord)) (seq (:file coord)))
-    [:button {:data-testid testid
-              :type        "button"
-              :on-click    (fn [^js e]
-                             (.stopPropagation e)
-                             (rf/dispatch [:rf.xray/open-in-editor
-                                           {:source-coord coord}]
-                                          {:frame :rf/xray}))
-              :style       violation-inline-link-style}
-     label]
-    [:span {:data-testid testid} label]))
+  (coord-link/coord-link coord label testid
+                         {:style  violation-inline-link-style
+                          :glyph? false}))
 
 (defn- violation-prose
   "Per-`:where` natural-language sentence with an inline `schema check`

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -3000,6 +3000,18 @@
                  :full-with-diff? true}
           (some? before) (assoc :before before))]])))
 
+(defn- sub-coord
+  "Pull the registered sub's source coord off
+  `(rf/handler-meta :sub sub-id)`. Returns nil when no meta is
+  captured. Matches the sibling `view-coord` shape (rf2-d2akf —
+  bring click-to-source affordance to disposed-sub rows on parity
+  with the unmounted-views rows)."
+  [sub-id]
+  (when (some? sub-id)
+    (let [m (try (rf/handler-meta :sub sub-id) (catch :default _ nil))]
+      (when (and m (string? (:file m)))
+        {:file (:file m) :line (:line m) :ns (:ns m)}))))
+
 (defn- subscriptions-table
   "Render the SUBSCRIPTIONS table — 3 columns (sub / inputs / changed).
   Per the bead body's §SUBSCRIPTIONS (Step 7) shape (rf2-kfh1v).
@@ -3047,7 +3059,19 @@
            (if (vector? sub-vec)
              [ei/mini sub-vec 40]
              [ei/mini sub-id 40])
-           (icons/external-link)]
+           ;; rf2-aesni — functional click-to-source via the shared
+           ;; `coord-chip`, exact parity with the disposed-subs (~3167)
+           ;; + views (~3311 / ~3380) rows. Pre-fix this was a bare
+           ;; decorative `(icons/external-link)` glyph with no coord
+           ;; resolution + no click handler — it never dispatched
+           ;; `:rf.xray/open-in-editor`. The coord lookup keys off
+           ;; `sub-id` (the keyword) even when `sub-vec` drives the
+           ;; label, so a parameterized sub (`[:counter/greater-than? 5]`)
+           ;; resolves its REGISTRATION coord. Chip drops out cleanly
+           ;; when no coord was captured (anonymous sub / production
+           ;; build without coords).
+           (coord-chip/coord-chip (sub-coord sub-id)
+                                  (str "rf-xray-epoch-sub-row-coord-" i))]
           ;; rf2-1cc03 — `caused by <event-id>` chrome surfaces the
           ;; dispatching cascade's event-id (the cascade whose handler-
           ;; body invalidated this sub's reactive input). OMITTED when
@@ -3089,18 +3113,6 @@
           (violation-blocks
             (keyword (str "sub-row-" (some-> row :sub-id name)))
             (:violations row))))}]))
-
-(defn- sub-coord
-  "Pull the registered sub's source coord off
-  `(rf/handler-meta :sub sub-id)`. Returns nil when no meta is
-  captured. Matches the sibling `view-coord` shape (rf2-d2akf —
-  bring click-to-source affordance to disposed-sub rows on parity
-  with the unmounted-views rows)."
-  [sub-id]
-  (when (some? sub-id)
-    (let [m (try (rf/handler-meta :sub sub-id) (catch :default _ nil))]
-      (when (and m (string? (:file m)))
-        {:file (:file m) :line (:line m) :ns (:ns m)}))))
 
 (defn- dispose-reason-label
   "Render a `:rf.sub/dispose` `:reason` keyword as a UI label

--- a/tools/xray/src/day8/re_frame2_xray/panels/issues_ribbon.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/issues_ribbon.cljs
@@ -72,6 +72,7 @@
             [day8.re-frame2-xray.panel-registry :as panel-registry]
             [day8.re-frame2-xray.panels.issues-ribbon-helpers :as h]
             [day8.re-frame2-xray.panels.overflow-indicator :as overflow]
+            [day8.re-frame2-xray.panels.shared.coord-link :as coord-link]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens mono-stack sans-stack]]
             [day8.re-frame2-xray.views.resizable-table :as rt]))
@@ -155,14 +156,16 @@
        [:button {:data-rf-xray-resizable-col "source"
                  :data-testid (str row-test-id "-source")
                  :title       source-coord
+                 ;; rf2-vw5pi — the open-in-editor dispatch routes
+                 ;; through the shared `coord-link/open-in-editor!`
+                 ;; (stops propagation so the row's pivot handler
+                 ;; doesn't also fire — the source-coord click is a
+                 ;; distinct affordance per spec/021 §8.4). The `↗`
+                 ;; text-glyph table-cell chrome + `·` no-source
+                 ;; placeholder stay local — they are column layout,
+                 ;; not the bespoke dispatch the guard targets.
                  :on-click    (fn [e]
-                                ;; Stop propagation so the row's pivot
-                                ;; handler doesn't also fire — the
-                                ;; source-coord click is a distinct
-                                ;; affordance per spec/021 §8.4.
-                                (.stopPropagation e)
-                                (rf/dispatch [:rf.xray/open-in-editor
-                                              {:source-coord source-coord}] {:frame :rf/xray}))
+                                (coord-link/open-in-editor! source-coord e))
                  :style       {:background  "transparent"
                                :color       (:accent tokens)
                                :border      "none"

--- a/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_view.cljs
@@ -64,6 +64,7 @@
   (:require [clojure.string :as string]
             [re-frame.core :as rf]
             [day8.re-frame2-xray.panels.reactive-flow-graph :as graph]
+            [day8.re-frame2-xray.panels.shared.coord-link :as coord-link]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens mono-stack sans-stack with-alpha]]))
 
@@ -171,11 +172,14 @@
 ;; ---- [code] open-chip --------------------------------------------------
 
 (defn- open-source!
-  "Dispatch the jump-to-source effect for a topology coord."
+  "Dispatch the jump-to-source effect for a topology coord. rf2-vw5pi
+  — delegates to the shared `coord-link/open-in-editor!` so the
+  `:rf.xray/open-in-editor` dispatch lives in ONE place; the reactive
+  graph's source affordances are SVG `<g>`/`<rect>` node clicks (not
+  `<button>` chips), so they bind this helper to `:on-click` directly
+  rather than mounting a `coord-chip` / `coord-link`."
   [coord e]
-  (when e (.stopPropagation e))
-  (rf/dispatch [:rf.xray/open-in-editor {:source-coord coord}]
-               {:frame :rf/xray}))
+  (coord-link/open-in-editor! coord e))
 
 ;; ---- SVG paint helpers -------------------------------------------------
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/shared/coord_link.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/shared/coord_link.cljs
@@ -1,0 +1,120 @@
+(ns day8.re-frame2-xray.panels.shared.coord-link
+  "Shared `coord-link` — the canonical 'open in editor' LABEL-as-link
+  affordance, companion to `coord-chip` (the icon-only chip).
+
+  ## Why this exists (rf2-vw5pi)
+
+  Two shapes of panel-side click-to-source affordance live in the Xray
+  panels:
+
+  - **icon-only** — a glyph appended after an id (`:counter/value ↗`).
+    The canonical home is `panels/shared/coord_chip.cljs` (rf2-xjgdk).
+  - **label-as-link** — the verb / label TEXT itself is the hyperlink,
+    with the `external-link` glyph appended (`reg-event-fx ↗`). Before
+    rf2-vw5pi this shape was hand-rolled ~7 times across
+    `panels/epoch/view.cljs` (the HANDLER verb-link, the DISPATCH
+    source label, the COEFFECT / FLOW verb ids, the machine cascade
+    verb-link, the machine state-path affordance) plus the schema-
+    violation action button — each re-inlining the same
+    `[:button {:on-click (rf/dispatch [:rf.xray/open-in-editor …])} …]`
+    boilerplate + its own `clickable?` / plain-fallback branch.
+
+  `coord-link` folds the button + dispatch + nil-when-no-`:file`
+  fallback into one place, mirroring `coord-chip`. The per-site coord
+  RESOLVERS (`sub-coord`, `view-coord`, `machine-state-path-coord`, …)
+  stay where they are — they are legitimately per-site; only the
+  button + dispatch + fallback RENDERING is shared.
+
+  ## What this is NOT
+
+  `open_in_editor/open-chip` is a SEPARATE surface (an `<a href>`
+  anchor for the static page, rf2-evgf5 / rf2-g5q8d) and is excluded
+  by design. `coord-link` (like `coord-chip`) dispatches via the trace
+  bus so the click is observable as a first-class operation on the
+  `:rf/xray` frame; the `:rf.xray/open-in-editor` reg-event-fx →
+  `:rf.editor/open` reg-fx pipeline resolves the URI.
+
+  See `panels/shared/coord_chip.cljs` for the icon-only sibling and
+  spec/021 §9.1.6.2 for the contract."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-xray.panels.epoch.icons :as icons]))
+
+;; ---- editor-open dispatch (shared with coord-chip's contract) -----------
+
+(defn open-in-editor!
+  "Dispatch `[:rf.xray/open-in-editor {:source-coord coord}]` on the
+  `:rf/xray` frame, stopping event propagation so a click on the
+  affordance does not also fire an enclosing row / node handler. This
+  is the ONE dispatch every panel-side click-to-source affordance
+  routes through (coord-chip, coord-link, and the SVG-node clicks in
+  the Reactive panel)."
+  [coord e]
+  (when e (.stopPropagation e))
+  (rf/dispatch [:rf.xray/open-in-editor {:source-coord coord}]
+               {:frame :rf/xray}))
+
+(defn- coord->title
+  "`open <file>:<line> in editor` title string for the affordance's
+  tooltip + aria-label. Mirrors the verbatim shape every hand-rolled
+  site produced before consolidation."
+  [coord]
+  (str "open " (:file coord)
+       (when (:line coord) (str ":" (:line coord)))
+       " in editor"))
+
+;; ---- public link --------------------------------------------------------
+
+(defn coord-link
+  "Render the canonical 'open in editor' LABEL-as-link affordance — a
+  `<button>` carrying `label` text + the `external-link` glyph. Returns
+  a plain `<span>` (no click affordance) when `coord` lacks a `:file`,
+  so a missing coord degrades cleanly to non-clickable label text
+  rather than a dead button.
+
+  Clicking dispatches `[:rf.xray/open-in-editor {:source-coord coord}]`
+  on the `:rf/xray` frame (via `open-in-editor!`).
+
+  Arguments:
+
+  - `coord` — the source-coord map `{:file :line …}`. Nil or any value
+    without a `:file` renders the plain-span fallback.
+  - `label` — the link text (a string or hiccup — e.g. an `ei/mini`
+    span for a syntax-token-coloured id).
+  - `testid` — the `data-testid` for the rendered node (button OR
+    fallback span — both carry it so a test can pin the slot
+    regardless of branch).
+  - `opts` (optional):
+    - `:style`          — the `<button>` style map (per-site link
+                          chrome: accent colour, dotted underline,
+                          font sizing). REQUIRED in practice — each
+                          call-site owns its link style — but defaults
+                          to nil (the browser button default) so a
+                          bare call still renders.
+    - `:plain-style`    — the fallback `<span>` style map when no
+                          coord is captured. Defaults to nil.
+    - `:glyph-leading?` — when true the glyph renders BEFORE the label
+                          (`↗ label`) instead of after (`label ↗`).
+                          Defaults false. Used by the schema-violation
+                          action button, whose grammar leads with the
+                          glyph.
+    - `:glyph?`         — when false, NO `external-link` glyph renders;
+                          the label text alone is the link (an inline
+                          underlined `schema check` style link inside
+                          a prose sentence). Defaults true."
+  ([coord label testid]
+   (coord-link coord label testid nil))
+  ([coord label testid {:keys [style plain-style glyph-leading? glyph?]
+                        :or   {glyph? true}}]
+   (if (and (map? coord) (seq (:file coord)))
+     (into [:button {:data-testid testid
+                     :aria-label  (coord->title coord)
+                     :title       (coord->title coord)
+                     :on-click    (fn [e] (open-in-editor! coord e))
+                     :style       style}]
+           (cond
+             (not glyph?)   [label]
+             glyph-leading? [(icons/external-link) label]
+             :else          [label (icons/external-link)]))
+     [:span {:data-testid testid
+             :style       plain-style}
+      label])))

--- a/tools/xray/src/day8/re_frame2_xray/panels/trace.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/trace.cljs
@@ -86,6 +86,7 @@
             [day8.re-frame2-xray.panels.cancellation-cascade-helpers
              :as cancellation-cascade-helpers]
             [day8.re-frame2-xray.panels.event.event-status-colour :as event-status]
+            [day8.re-frame2-xray.panels.shared.coord-link :as coord-link]
             [day8.re-frame2-xray.panels.shared.focus-resolver :as focus]
             [day8.re-frame2-xray.panels.trace-helpers :as h]
             [day8.re-frame2-xray.theme.tokens
@@ -673,13 +674,13 @@
               :title (or target "")}
        (or target "—")]
       (when source-coord
+        ;; rf2-vw5pi — open-in-editor dispatch via the shared
+        ;; `coord-link/open-in-editor!`. The `↗` text-glyph cell chrome
+        ;; stays local (column layout, not the bespoke dispatch).
         [:button {:data-testid (str row-test-id "-source-coord")
                   :title       source-coord
                   :on-click    (fn [e]
-                                 (.stopPropagation e)
-                                 (rf/dispatch [:rf.xray/open-in-editor
-                                               {:source-coord source-coord}]
-                                              {:frame :rf/xray}))
+                                 (coord-link/open-in-editor! source-coord e))
                   :style       op-row-source-coord-button-style}
          "↗"])
       (when destroy?

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
@@ -2963,8 +2963,8 @@
       [value & rest-args]
       (let [opts          (first rest-args)
             {:keys [panel-id site-id default-expanded-depth max-inline-width
-                    max-depth before popup-affordance? card? header zoomable?
-                    full-with-diff?]
+                    max-depth popup-affordance? card? header zoomable?
+                    full-with-diff? added?]
              :or   {panel-id :rf.xray.edn-inspector/anon
                     ;; rf2-kbdk8 — default raised from 2 → 8. Under the
                     ;; width-aware heuristic this opt is a CEILING (never
@@ -2982,7 +2982,26 @@
                     ;; no zoom affordance, no breadcrumb, full tree
                     ;; rendered from the original root.
                     zoomable? false}} opts
-            diff?         (contains? opts :before)
+            ;; rf2-kp7bw — `:added?` is the FIRST-RUN signal: a value
+            ;; that just came into existence (a sub's first cache entry,
+            ;; an app-db key that just appeared). Without an explicit
+            ;; `:before`, `:added? true` synthesises the diff's prior
+            ;; side as `engine/missing-sentinel`, so the projection
+            ;; classifies the WHOLE tree as `:added` (root op `:added`
+            ;; → green wash + `+` chrome over every descendant). This is
+            ;; the container-shaped parity for the scalar first-run
+            ;; `:added` chrome the SUBSCRIPTIONS leaf branch paints at
+            ;; the row level (rf2-fyd8u handled scalars only; containers
+            ;; mounted plain on a first run because `before` was nil and
+            ;; the inspector never entered diff mode). An explicit
+            ;; `:before` always wins (an actual prior value is a real
+            ;; diff, not a first run); empty containers still read
+            ;; `:added` (the engine reports root `:added` for
+            ;; `(missing-sentinel, {})`). See §10.0.13.
+            before        (if (contains? opts :before)
+                            (:before opts)
+                            (when added? engine/missing-sentinel))
+            diff?         (or (contains? opts :before) (boolean added?))
             ;; rf2-okq7p — `:header` opts the widget into the 3-shade
             ;; card chrome (outer SECTION + grey-on-grey HEADER ribbon
             ;; + body), modelled on the Machine panel's `focused-event-

--- a/tools/xray/test/day8/re_frame2_xray/panels/click_to_source_consolidation_test.clj
+++ b/tools/xray/test/day8/re_frame2_xray/panels/click_to_source_consolidation_test.clj
@@ -1,0 +1,80 @@
+(ns day8.re-frame2-xray.panels.click-to-source-consolidation-test
+  "Guard test for rf2-vw5pi — the click-to-source consolidation.
+
+  Every panel-side 'open in editor' affordance routes through ONE of
+  two shared helpers: `panels/shared/coord_chip.cljs` (icon-only chip)
+  or `panels/shared/coord_link.cljs` (label-as-link + the shared
+  `open-in-editor!` dispatch action). No panel file may re-inline the
+  `[:rf.xray/open-in-editor …]` dispatch — that boilerplate-and-its-
+  fallback-branch pattern was hand-rolled ~11 times before rf2-vw5pi.
+
+  This is a SOURCE-TEXT guard (JVM, runs in the fast `clojure -M:test`
+  gate): it greps the panel source tree for the dispatch literal and
+  asserts it appears ONLY in the sanctioned homes. A future
+  contributor who hand-rolls a new bespoke open-in-editor button trips
+  this immediately — the fix is to route through `coord-chip` /
+  `coord-link` (or, for an SVG-node click that can't mount a button,
+  bind `coord-link/open-in-editor!` to `:on-click`)."
+  (:require [clojure.test :refer [deftest is]]
+            [clojure.java.io :as io]
+            [clojure.string :as str]))
+
+(def ^:private dispatch-pattern
+  "Matches a `(... dispatch [:rf.xray/open-in-editor …])` CALL — the
+  bespoke open-in-editor dispatch the consolidation eliminates. Keyed
+  on the `dispatch [:` shape (not the bare keyword) so DOCSTRINGS and
+  COMMENTS that merely NAME the event — e.g. the static-page surfaces
+  that reference it in prose, or a panel docstring noting 'clicks
+  dispatch :rf.xray/open-in-editor' — do not false-positive. Only an
+  actual `dispatch`-call form trips the guard."
+  #"dispatch\s*\[:rf\.xray/open-in-editor")
+
+(def ^:private sanctioned
+  "Files allowed to carry the open-in-editor dispatch CALL:
+
+  - `panels/shared/coord_chip.cljs` — the icon-only chip (rf2-xjgdk).
+  - `panels/shared/coord_link.cljs` — the label-as-link companion +
+    the shared `open-in-editor!` dispatch action (rf2-vw5pi). Every
+    panel-side affordance funnels its dispatch through here (or
+    through `coord-chip`).
+
+  `open_in_editor.cljs` (the reg-event-fx receiver + the static-page
+  `<a href>` anchor, excluded by design per rf2-evgf5 / rf2-g5q8d) is
+  NOT listed because it never emits a `dispatch`-CALL form — it
+  DEFINES the event (`reg-event-fx :rf.xray/open-in-editor`), so the
+  `dispatch [:` pattern never matches it."
+  #{"coord_chip.cljs"
+    "coord_link.cljs"})
+
+(defn- src-root []
+  ;; The `:test` alias runs from `tools/xray`; `src` is on the classpath
+  ;; root. Resolve the source tree relative to the working directory so
+  ;; the guard reads the on-disk text (not a classpath resource).
+  (io/file "src" "day8" "re_frame2_xray"))
+
+(defn- cljs-source-files [^java.io.File dir]
+  (->> (file-seq dir)
+       (filter #(.isFile ^java.io.File %))
+       (filter #(let [n (.getName ^java.io.File %)]
+                  (or (str/ends-with? n ".cljs")
+                      (str/ends-with? n ".cljc"))))))
+
+(deftest no-bespoke-open-in-editor-dispatch-outside-shared-helpers
+  (let [root (src-root)]
+    (is (.exists root)
+        (str "source root must resolve from the test's working "
+             "directory (tools/xray); got " (.getPath root)))
+    (let [offenders
+          (->> (cljs-source-files root)
+               (keep (fn [^java.io.File f]
+                       (let [name (.getName f)]
+                         (when (and (not (sanctioned name))
+                                    (re-find dispatch-pattern (slurp f)))
+                           (.getPath f))))))]
+      (is (empty? offenders)
+          (str "These files inline a `dispatch [:rf.xray/open-in-editor …]` "
+               "call but are not a sanctioned shared helper. Route the "
+               "affordance through `panels/shared/coord_chip.cljs` "
+               "(icon-only), `panels/shared/coord_link.cljs` (label), or "
+               "bind `coord-link/open-in-editor!` for an SVG-node click:\n  "
+               (str/join "\n  " offenders))))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -1828,6 +1828,49 @@
             (is (nil? chip)
                 "coord chip drops out cleanly when no coord is resolvable")))))))
 
+(deftest active-sub-row-mounts-coord-chip-when-meta-resolves-test
+  (testing "rf2-aesni — the ACTIVE SUBSCRIPTIONS row's sub-name cell
+            routes through `coord-chip/coord-chip` to surface a
+            functional click-to-source affordance for the reg-sub
+            (parity with the disposed-subs + views rows). Pre-fix the
+            active cell rendered a bare decorative `(icons/external-
+            link)` glyph with no coord resolution + no click handler —
+            it never dispatched `:rf.xray/open-in-editor`.
+
+            The chip's <button> mounts when `(rf/handler-meta :sub
+            sub-id)` resolves a `:file` coord. CLJS macro-form `reg-sub`
+            captures `:file`/`:line` at the test call-site so the
+            integration round-trip is testable here."
+    (epoch-orchestrator/install!)
+    (frame/reg-frame :rf/xray {})
+    (rf/with-frame :rf/xray
+      (rf/reg-sub :rf.aesni-fixture/items
+        (fn [db _] (get db :items [])))
+      (let [meta-resolved? (boolean (some-> (rf/handler-meta :sub :rf.aesni-fixture/items)
+                                            :file string?))
+            ;; A parameterized sub-vec drives the LABEL but the coord
+            ;; lookup must still key off `sub-id` (the registration
+            ;; keyword) — that is the rf2-aesni invariant.
+            step {:step :subscriptions :badge :SUBSCRIPTIONS :step-number 5
+                  :rows [{:sub-id :rf.aesni-fixture/items
+                          :sub-vec [:rf.aesni-fixture/items 5]
+                          :inputs nil :changed? true :before 1 :after 2}]
+                  :changed 1 :unchanged 0}
+            tree (view/render-subscriptions-step step)]
+        (is (some? (th/find-by-testid tree "rf-xray-epoch-sub-row-0"))
+            "the active sub row itself renders")
+        (let [chip (th/find-by-testid tree "rf-xray-epoch-sub-row-coord-0")]
+          (if meta-resolved?
+            (do
+              (is (some? chip)
+                  "coord chip mounts when reg-sub captured a source coord")
+              (is (= :button (first chip))
+                  "chip mounts as a clickable <button> (not a dead glyph)")
+              (is (fn? (:on-click (second chip)))
+                  "chip carries an on-click handler that dispatches open-in-editor"))
+            (is (nil? chip)
+                "coord chip drops out cleanly when no coord is resolvable")))))))
+
 ;; ---- rf2-zuh3p — SUBSCRIPTIONS per-row violations attach inline ----------
 
 (deftest subscriptions-row-violations-attach-inline-test

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -1871,6 +1871,65 @@
             (is (nil? chip)
                 "coord chip drops out cleanly when no coord is resolvable")))))))
 
+(deftest first-run-container-sub-renders-added-chrome-test
+  (testing "rf2-kp7bw — a first-run subscription whose value is a
+            CONTAINER (map / vector / set) renders the whole subtree
+            with `:added` chrome, parity with scalar first-runs. Pre-fix
+            the container branch consulted only `:before` (nil on a
+            first run), so the inspector mounted plain — no diff mode,
+            no added signal — while every scalar sibling painted
+            `:added`. The fix passes `:added? true` to the edn-inspector
+            (edn-inspector §10.0.13), which synthesises the prior side
+            as the engine's missing-sentinel so the projection
+            classifies the root op as `:added`.
+
+            Canonical case: the `[:rf/route]` map sub on a /counter
+            view-mount epoch — a first run returning a map."
+    (epoch-orchestrator/install!)
+    (frame/reg-frame :rf/xray {})
+    (rf/with-frame :rf/xray
+      (let [route-map {:id :counter :params {} :query {} :transition :idle}
+            step {:step :subscriptions :badge :SUBSCRIPTIONS :step-number 5
+                  :rows [{:sub-id :rf/route :sub-vec [:rf/route]
+                          :inputs nil :changed? true :first-run? true
+                          :before nil :after route-map}]
+                  :changed 1 :unchanged 0}
+            tree (view/render-subscriptions-step step)
+            ;; The container branch mounts the canonical edn-inspector;
+            ;; the realized widget root + descendants stamp
+            ;; `data-rf-diff-op` with the classified op. `find-all-by-
+            ;; attr` walks through (realizes) the form-2 component, so
+            ;; the inspector's projection is actually computed.
+            added-nodes    (th/find-all-by-attr tree :data-rf-diff-op "added")
+            modified-nodes (th/find-all-by-attr tree :data-rf-diff-op "modified")]
+        (is (some? (th/find-by-testid tree "rf-xray-epoch-sub-row-0"))
+            "the first-run container sub row renders")
+        (is (pos? (count added-nodes))
+            "the first-run container subtree paints `:added` chrome
+             (the inspector entered diff mode via `:added?`, not a
+             plain mount)")
+        (is (zero? (count modified-nodes))
+            "the first-run is `:added`, never a `:modified` type-flip
+             (engine missing-sentinel discipline — NOT the edn-inspector
+             `::missing` keyword, which would project `:modified`)")))))
+
+(deftest first-run-empty-container-sub-still-added-test
+  (testing "rf2-kp7bw — the inverse case: a first-run sub returning an
+            EMPTY container (`{}` / `[]`) still reads `:added`. The
+            engine reports root `:added` for `(missing-sentinel, {})`."
+    (epoch-orchestrator/install!)
+    (frame/reg-frame :rf/xray {})
+    (rf/with-frame :rf/xray
+      (let [step {:step :subscriptions :badge :SUBSCRIPTIONS :step-number 5
+                  :rows [{:sub-id :app/empty-map :sub-vec [:app/empty-map]
+                          :inputs nil :changed? true :first-run? true
+                          :before nil :after {}}]
+                  :changed 1 :unchanged 0}
+            tree (view/render-subscriptions-step step)
+            added-nodes (th/find-all-by-attr tree :data-rf-diff-op "added")]
+        (is (pos? (count added-nodes))
+            "a first-run EMPTY container still reads `:added`")))))
+
 ;; ---- rf2-zuh3p — SUBSCRIPTIONS per-row violations attach inline ----------
 
 (deftest subscriptions-row-violations-attach-inline-test


### PR DESCRIPTION
Three-bead Xray cluster (one worktree, sequenced commits) on the SUBSCRIPTIONS click-to-source + first-run-diff surfaces. All three touch `panels/epoch/view.cljs`, so they ship together.

- **rf2-aesni (P2 bug)** — the active SUBSCRIPTIONS sub-name cell rendered a bare decorative `(icons/external-link)` glyph with no coord resolution + no click handler. Replaced with the functional shared `coord-chip`, parity with the disposed-subs + views rows.
- **rf2-kp7bw (P2 bug)** — a first-run sub whose value is a CONTAINER got no `:added` chrome (scalars did). Added an `:added?` opt to the edn-inspector that synthesises the prior side as the engine's missing-sentinel, so the projection classifies the whole tree as `:added`.
- **rf2-vw5pi (P3)** — consolidated the ~11 hand-rolled `[:button … :rf.xray/open-in-editor …]` sites onto two shared helpers (`coord-chip` icon-only + new `coord-link` label) plus a shared `open-in-editor!` dispatch action; added a JVM guard.

## Quality gates

| Gate | Result |
|------|--------|
| `cd tools/xray && clojure -M:test` (JVM) | **965 tests / 3804 assertions · 0 failures** (was 964 pre-cluster; +1 = the vw5pi guard) |
| CLJS view/projection suite (`npm run test:cljs`, `node-test`) | **4823 tests / 15800 assertions · 0 failures** (was 4821; +2 = the kp7bw first-run-container tests; the aesni active-sub-row test rides existing assertions) |
| `npm run test:xray-feature-gate` | **14 scenarios · 0 failures · 13 matrix rows** |
| `bash scripts/test-fast-pr.sh` | **PASS** — CLJS integration + README/docs anchor validators green |

`mkdocs --strict` was soft-skipped locally (mkdocs not on PATH on Windows); CI will run it. No `ai/findings/*` links were added to committed files.

## Per-bead detail

- **rf2-aesni** — `panels/epoch/view.cljs:~3059` (sub-name cell now `coord-chip/coord-chip (sub-coord sub-id) …`); `sub-coord` resolver moved above `subscriptions-table` to avoid a forward reference. Coord keys off `sub-id` even when a parameterized `sub-vec` drives the label. Test: `active-sub-row-mounts-coord-chip-when-meta-resolves-test`. Spec: 021 §9.1.6.2.
- **rf2-kp7bw** — `views/edn_inspector.cljs` gains the `:added?` opt; `panels/epoch/view.cljs` `subs-value-cell` container branch passes `:added? true` on `first-run?`. Empty containers still read `:added`; an explicit `:before` wins. The edn-inspector's R1 `:added` IS exposed via `:added?` (engine missing-sentinel route — NOT the row-wrap fallback; verified the engine projects root `:added` for `(missing-sentinel, <container>)` incl. empties, while `nil`/the edn-inspector `::missing` keyword would project `:modified`). Tests: `first-run-container-sub-renders-added-chrome-test`, `first-run-empty-container-sub-still-added-test`. Spec: 021 §10.0.1 + new §10.0.13 + §9.1.5.2 row.
- **rf2-vw5pi** — new `panels/shared/coord_link.cljs` (`coord-link` + `open-in-editor!`); routed `epoch/view.cljs` sites (dispatch-source-label, state-path-affordance, coeffect row/verb, machine cascade verb-link, handler-verb-link, flow verb, schema-violation action + inline prose link), `issues_ribbon.cljs:~164`, `trace.cljs:~680`, `reactive_panel_view.cljs:~177` (SVG-node clicks). Dispatch CALL now lives only in `coord_chip` + `coord_link`. `open_in_editor.cljs` anchor untouched. Guard: `panels/click_to_source_consolidation_test.clj`. Spec: 021 §9.1.6.2.1.

## Risks

- vw5pi normalised two hand-rolled split testids to a single stem (`…-handler-verb-link`, `…-machine-cascade-verb-link-<step>`) — no test or `.cjs` browser scenario pinned the dropped `…-verb-plain` / `…-verb-<step>` variants (verified).
- `coord-link`'s button drops the prior `:type "button"` attr on the inline prose link (no functional effect outside a `<form>`; xray panels aren't forms).
