### PR TITLE
refactor(xray): collapse edn-inspector to single value+optional-before renderer (rf2-e28r3)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1638,9 +1638,10 @@ containers; R2 (key glyph) no-ops on primitive cell values like a
 SUBSCRIPTIONS row's scalar return; R3 (collapsed-container `[N∆]`
 chip) no-ops on leaf scalars. The shared projection engine
 (`day8.re-frame2-xray.diff.engine`) holds the grammar; per-surface
-mounts contribute the `(before, after)` value pair PLUS the
-`:full-with-diff? true` opt (§10.0.12) that activates the R3 + R4
-structural-context chrome.
+mounts contribute the `(before, after)` value pair — passing
+`:before` IS the activation of the full R1-R8 grammar, including the
+R3 + R4 structural-context chrome (§10.0.12; rf2-e28r3 removed the
+former `:full-with-diff?` opt — there is no separate flag).
 
 **Canonical `data-*` shape** (Cluster F — rf2-xvu24): every
 surface's enclosing section still carries
@@ -2407,14 +2408,19 @@ reach for `[edn-inspector value opts]` directly.
   layout. Defaults `60`.
 - `:max-depth` — hard cap on recursion depth; deeper levels render
   `{…}` collapsed and click expands one level. Defaults `16`.
-- `:before` — when supplied, the widget renders in **DIFF mode**.
-  The `value` arg is treated as the AFTER side and the supplied
-  `:before` is the prior value. Gutter glyphs (`+` added · `-`
-  removed · `~` modified · `◴` children-changed) paint per node;
-  modified leaves get an inline `← was <prior>`
-  annotation; ancestor chain force-expands over any changed
-  descendant. Omit `:before` for plain BROWSE mode. See §10.0.8
-  for the full diff contract.
+- `:before` (rf2-q3dzw · rf2-e28r3) — the prior value to annotate
+  against. The widget has ONE rendering path keyed on **value
+  (always) + before (optional)** — there is no separate diff "mode".
+  With a `:before` present the `value` arg is the AFTER side and the
+  tree paints the full diff chrome: gutter glyphs (`+` added · `-`
+  removed · `~` modified · `◴` children-changed) per node, modified
+  leaves get an inline `← was <prior>` annotation, the R3 collapsed-
+  container `[N∆]` count chip + R4 2px vertical gutter rail render on
+  change-bearing subtrees (the §9.1.5.1 R1-R8 grammar), and the
+  ancestor chain force-expands over any changed descendant. With no
+  `:before` (and no `:added?`) the SAME renderer shows the value
+  plainly — no annotations, no chip, no rail. The presence of a pre-
+  image is the only diff signal. See §10.0.8 + §10.0.12.
 - `:popup-affordance?` — when `true`, renders a top-right ↗ icon
   button that pops the value into a modal overlay (§10.0.7.2).
   Defaults `false`.
@@ -2442,17 +2448,6 @@ reach for `[edn-inspector value opts]` directly.
   panel-leave-and-return round-trip (auto-mount-id changes on
   remount; a stable site-id does not). Omit to keep the per-call-
   site isolation default.
-- `:full-with-diff?` (rf2-n2jig · rf2-6cm03) — boolean. When `true`
-  (combined with `:before`) the widget paints the **mode-3** chrome
-  on top of the diff annotations: R3 collapsed-container `[N∆]`
-  count chip + R4 single-2px vertical gutter rail through each
-  change-bearing subtree. When `false` / omitted (the legacy diff
-  surface) the widget renders the **mode-2** chrome — per-leaf
-  gutter glyphs + `← was <prior>` annotations, no R3 chip,
-  no R4 rail. `:full-with-diff?` is a no-op without `:before`. See
-  §10.0.12 for the contract + per-surface call-site obligation. The
-  silent-default chosen here is intentional: it preserves the diff-
-  only call sites that should NOT paint mode-3 chrome.
 - `:added?` (rf2-kp7bw) — boolean FIRST-RUN signal. When `true` AND
   no explicit `:before` is supplied, the widget enters diff mode with
   the prior side synthesised as `engine/missing-sentinel`, so the
@@ -3216,57 +3211,66 @@ zoom root is a no-op. The renderer composes the absolute path as
 `(into zoom-path-prefix path)` so the dispatched `:zoom-to` carries the
 full path from the ORIGINAL root, not the currently-displayed root.
 
-#### §10.0.12 `:full-with-diff?` opt — FULL+DIFF chrome activation (rf2-n2jig · rf2-6cm03 · rf2-vv3m6)
+#### §10.0.12 Single renderer — value (always) + before (optional) (rf2-n2jig · rf2-6cm03 · rf2-vv3m6 · rf2-e28r3)
 
-The §9.1.5.1 R-rule grammar partitions diff chrome into two visual
-intensities — the per-leaf annotation layer (R1, R2, R7, R8) and the
-structural-context layer (R3 collapsed `[N∆]` chip + R4 vertical
-rail). The widget paints the annotation layer whenever `:before` is
-present; it paints the structural-context layer ONLY when the caller
-also passes `:full-with-diff? true`.
+The edn-inspector has ONE rendering path. Its inputs are **value
+(always supplied)** and **before (optional)**. There is no diff
+"mode" axis and no flag that selects a chrome intensity — the
+presence of a pre-image is the only signal:
 
-The split survives the rf2-vv3m6 toggle retirement: every diff
-surface listed in §9.1.5.2 paints FULL+DIFF unconditionally and
-MUST set `:full-with-diff? true` on its edn-inspector mount.
+- **`before` present** → the full tree renders WITH inline diff
+  annotations. The widget paints the entire §9.1.5.1 R1-R8 grammar:
+  the per-leaf annotation layer (R1, R2, R7, R8 — gutter glyphs +
+  `← was <prior>` annotations) AND the structural-context layer (R3
+  collapsed-container `[N∆]` count chip + R4 single-2px vertical
+  gutter rail through each change-bearing subtree). The ancestor
+  chain force-expands over any changed descendant, and the depth/
+  width auto-expand heuristic is suppressed for unchanged subtrees so
+  the operator sees only changed slices plus the root.
+- **`before` absent** → the SAME renderer shows the value plainly —
+  no annotations, no R3 chip, no R4 rail. "Full" is not a mode; it is
+  this single renderer with no pre-image.
+
+> **Lineage (rf2-e28r3).** This collapses the former three-mode
+> machinery. rf2-vv3m6 retired the operator-facing `[diff][full]
+> [full+diff]` toggle; rf2-e28r3 then removed the `:full-with-diff?`
+> opt that internally distinguished the plain `:diff` lens (mode-2 —
+> per-leaf-focused, suppressed the rail/chip) from full+diff (mode-3).
+> With one path the rail/chip chrome is the only chrome and paints
+> whenever a change is present, so the flag — which only ever existed
+> to gate that distinction — is gone. The plain `:diff` lens is gone
+> with it. An efficiency audit's redundant-per-render-walk finding
+> (the projection cache, rf2-4p1vl) is preserved.
 
 **Contract**:
 
 ```clj
-;; FULL+DIFF — annotation + R3/R4 structural chrome
-[ei/edn-inspector after-value
- {:before before-value
-  :full-with-diff? true}]
+;; value + before → annotated diff render (R1-R8 grammar)
+[ei/edn-inspector after-value {:before before-value}]
+
+;; value only → plain render (no annotations, no rail, no chip)
+[ei/edn-inspector value]
 ```
 
-**Consequence of NOT passing it from a FULL+DIFF call site**: silent
-absence of R4 rails + R3 chips. The widget still paints R1/R2/R7/R8
-because those are driven off `:before` alone, so the surface looks
-"diff-y" at a glance but the operator loses the structural-context
-cues that the FULL+DIFF rendering promises. This was the root-cause
-class of bug rf2-kkhss (App-DB silently dropped R4 when its call
-site omitted the flag).
+**Per-surface usage** — the canonical consumer surfaces thread
+`:before` ONLY when a real pre-image is present; its absence is the
+signal to render plainly. None set any mode flag:
 
-**Per-surface call-site obligation** — the four canonical consumer
-surfaces from §9.1.5.2 each MUST set `:full-with-diff? true`:
+| Surface                              | Call site                                                                                  | Test surface                                                                |
+|--------------------------------------|--------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------|
+| Epoch HANDLER step `:db`             | `panels/epoch/view.cljs` — `handler-db-diff-block` (always threads `:before db-before`)    | `data-testid="rf-xray-epoch-handler-db-full-with-diff"`                     |
+| App-DB panel (per `:rf/*` section)   | `panels/app_db_diff_state.cljs` — `value-body` (one mount; `:before` via `cond->`)         | App-DB panel-gallery story fixtures + segment-inspector tests               |
+| Machine Inspector snapshot drill-in  | `panels/machine_inspector.cljs` — `snapshot-block` (`:before` via `cond->` when captured)  | `data-testid="rf-xray-machine-snapshot-block-<id>"` with `data-rf-xray-diff-mode="full+diff"` |
+| Epoch SUBSCRIPTIONS step value cells | `panels/epoch/view.cljs` — `subs-value-cell` container branch (`:before` / `:added?`)      | `data-testid="rf-xray-epoch-sub-row-*"` mount                               |
 
-| Surface                              | Call site                                                                                              | Test surface                                                                |
-|--------------------------------------|--------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------|
-| Epoch HANDLER step `:db`             | `panels/epoch/view.cljs` — `handler-db-diff-block` (rf2-n2jig)                                          | `data-testid="rf-xray-epoch-handler-db-full-with-diff"`                     |
-| App-DB panel (per `:rf/*` section)   | `panels/app_db_diff_state.cljs` — `value-body`'s `:before`-present branch (rf2-kkhss)                  | App-DB panel-gallery story fixtures + segment-inspector tests               |
-| Machine Inspector snapshot drill-in  | `panels/machine_inspector.cljs` — `snapshot-block` (`:before` + `:full-with-diff?`)                    | `data-testid="rf-xray-machine-snapshot-block-<id>"` with `data-rf-xray-diff-mode="full+diff"` |
-| Epoch SUBSCRIPTIONS step value cells | `panels/epoch/view.cljs` — `subs-value-cell` container branch                                          | `data-testid="rf-xray-epoch-sub-row-*"` FULL+DIFF mount                     |
-
-**Canonical visual reference** — the Story fixtures under
-`tools/xray/testbeds/panel_gallery/fixtures_diff_mode_3.cljs` pass
-`:full-with-diff? true` on every variant; that is the operator-
-facing pin for the FULL+DIFF chrome.
-
-**Why the opt isn't auto-inferred** — the widget is a pure-data
-Reagent component that takes `(value, opts)`. The boolean
-`:full-with-diff?` is the minimal handshake that lets the consumer
-panel keep ownership while the widget keeps a pure data interface.
-Audit trail: rf2-ya3nj 24hr audit, finding M3 (spec drift) →
-rf2-6cm03 (this section).
+**Why the input is the value, not a flag** — the widget is a pure-
+data Reagent component that takes `(value, opts)`. Keying the chrome
+on the natural input (is there a pre-image?) rather than a redundant
+boolean keeps the interface minimal and removes the
+rf2-kkhss class of bug entirely: there is no flag to forget, so the
+rail/chip can never silently fail to paint on a real diff. Audit
+trail: rf2-ya3nj 24hr audit, finding M3 (spec drift) → rf2-6cm03 →
+rf2-e28r3 (single-renderer collapse, this section).
 
 #### §10.0.13 `:added?` opt — first-run / whole-value-added chrome (rf2-kp7bw)
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs
@@ -27,14 +27,14 @@
   ## Current-state render — first-class edn-inspector widget (rf2-oqa60)
 
   Values render through the first-class `views/edn-inspector` widget.
-  The new widget owns the WHOLE contract — browse + diff + mini —
-  CLJS-aware type detection, distinct bracket styling per collection
-  kind, click-to-toggle expansion stored in re-frame app-db, first-
-  class sentinel chrome (`:rf/redacted`, `:rf.size/large-elided`).
-  After phase 5
-  (rf2-q3dzw, D5=a per rf2-sndui) diff also routes through this same
-  widget via the `:before` opt — the legacy `edn-inspector.render`
-  engine is gone.
+  The widget has ONE rendering path keyed on value (always) + before
+  (optional) — CLJS-aware type detection, distinct bracket styling per
+  collection kind, click-to-toggle expansion stored in re-frame app-db,
+  first-class sentinel chrome (`:rf/redacted`, `:rf.size/large-elided`),
+  and inline diff annotations when a `:before` pre-image is supplied
+  (rf2-q3dzw phase 5, D5=a per rf2-sndui; rf2-e28r3 collapsed the
+  former browse/diff modes into the single path). The legacy
+  `edn-inspector.render` engine is gone.
 
   The widget has NO ⎘ copy affordance (deferred to follow-on beads —
   the popup phase, D6=a). The old EDN widget's copy gesture is
@@ -62,14 +62,14 @@
 
   Each section carries a `:before` slice (from the cascade's `db-before`,
   threaded by `app-db-diff-helpers/current-state-sections`'s 2-arity).
-  When a pre-image is present and differs, the value body routes
-  through the edn-inspector widget's DIFF mode (rf2-q3dzw phase 5,
-  D5=a) — passing `:before` paints inline `← was X`
-  annotations in place on changed nodes and force-expands the
+  When a pre-image is present and differs, the value body passes
+  `:before` to the edn-inspector widget — painting inline `← was X`
+  annotations in place on changed nodes and force-expanding the
   ancestor chain so the operator never expands to find a change. When
   no pre-image is threaded (`no-diff` sentinel — LIVE at boot,
-  1-arity model) the body falls back to plain BROWSE mode on the same
-  widget. The keyword-accent is already orange (owned by rf2-ad7zx.3).
+  1-arity model) `:before` is omitted and the same widget renders the
+  value plainly. The keyword-accent is already orange (owned by
+  rf2-ad7zx.3).
 
   Pure hiccup; reuses Xray's theme tokens so light/dark resolve."
   (:require [day8.re-frame2-xray.panels.app-db-diff-format :as f]
@@ -191,19 +191,19 @@
   payload from flooding the inspector (and from leaking the raw bytes
   into the rendered text).
 
-  ## Diff vs current-state routing
+  ## Single render path — value + optional before
 
-  When `before` is the `h/no-diff` sentinel (no pre-image threaded —
-  LIVE at boot / 1-arity model) the value renders in BROWSE mode via
-  the first-class edn-inspector widget — a plain current-state tree.
-
-  When a real pre-image is present the value renders in DIFF mode via
-  the SAME widget (rf2-q3dzw phase 5), passing `:before` so the
-  widget paints inline `← was X` annotations and force-
-  expands the ancestor chain over changed descendants (spec/021 §4.3 +
-  §10.4). App-db's depth heuristic is depth-3-collapsed by default
-  (§10.4). The keyword-accent is already orange (owned by
-  rf2-ad7zx.3)."
+  The edn-inspector has ONE rendering path (rf2-e28r3): value (always)
+  + before (optional). When `before` is the `h/no-diff` sentinel (no
+  pre-image threaded — LIVE at boot / 1-arity model) the `:before` opt
+  is omitted and the value renders plainly — a current-state tree with
+  no diff annotations, no rail, no chip. When a real pre-image is
+  present `:before` is passed and the SAME renderer paints inline
+  `← was X` annotations, the R4 rail + R3 chip on change-bearing
+  containers, and force-expands the ancestor chain over changed
+  descendants (spec/021 §4.3 + §10.4). App-db's depth heuristic is
+  depth-3-collapsed by default (§10.4). The keyword-accent is already
+  orange (owned by rf2-ad7zx.3)."
   [value before render-id title]
   (let [_node-key (str "app-db-state/" render-id)
         ;; rf2-pvsxs — stable `:site-id` so expansion overrides survive
@@ -212,57 +212,33 @@
         ;; area name for the per-:rf/* sections), so passing it AS the
         ;; site-id reuses the existing per-surface key without
         ;; introducing a new namespace.
-        site-id [:rf.xray/app-db render-id]]
+        site-id [:rf.xray/app-db render-id]
+        has-before? (not= h/no-diff before)]
     ;; rf2-7sdja — App-DB does NOT use `:popup-affordance?` (Mike's
     ;; live-testing call 2026-05-26). The side panel has plenty of
     ;; horizontal room; the whole-tree inspector renders comfortably
     ;; in-place. Other panels (Handler / Trace / Machines / Reactive)
     ;; keep the affordance where the inline widget is genuinely
     ;; cramped.
-    (if (= h/no-diff before)
-      [ei/edn-inspector
-       (f/display-value value)
-       {:panel-id :rf.xray/app-db
-        :site-id  site-id
-        :default-expanded-depth 3
-        ;; rf2-63ie5 — App-DB renders the user-domain TOP + every
-        ;; reserved `:rf/*` area as top-level mounts in the same panel.
-        ;; Without card chrome the mounts blend into one continuous
-        ;; block; the opt-in chrome gives each mount a distinct card
-        ;; affordance so the operator sees them as discrete inspector
-        ;; cards.
-        :card? true
-        ;; rf2-h71e0 — App-DB is the canonical zoom-into-node consumer.
-        ;; Dense top-level trees benefit hugely from focusing on a
-        ;; single subtree; the breadcrumb row keeps the operator's
-        ;; bearings. Diff mode (`before` present) suppresses zoom
-        ;; resolution because diff's force-expand-over-changes logic
-        ;; and zoom's hide-everything-outside-the-subtree conflict.
-        :zoomable? true
-        :header title}]
-      [ei/edn-inspector
-       (f/display-value value)
-       {:panel-id :rf.xray/app-db
-        :site-id  site-id
-        :default-expanded-depth 3
-        :before (f/display-value before)
-        ;; rf2-kkhss — opts mode-3 grammar (spec/021 §9.1.5.2 axis 2)
-        ;; into the App-DB diff render. `render-container` gates the
-        ;; R4 2px vertical rail behind `(and full-with-diff? has-
-        ;; change?)`; without this flag the rail silently never paints
-        ;; on App-DB even though Stories — which all pass the opt —
-        ;; render it correctly. Sister surfaces (HANDLER `:db` /
-        ;; Machine / SUBS) also set it. The BROWSE branch above MUST
-        ;; NOT carry this opt: no `:before` is present, and mode-3
-        ;; chrome would mis-render against a non-diff tree.
-        :full-with-diff? true
-        :card? true
-        ;; rf2-h71e0 — zoomable opt is preserved here for symmetry;
-        ;; the widget self-suppresses zoom resolution in diff mode so
-        ;; the affordance + breadcrumb stay off until the operator
-        ;; returns to current-state (non-diff) browse.
-        :zoomable? true
-        :header title}])))
+    ;;
+    ;; rf2-e28r3 — ONE `ei/edn-inspector` call. `:before` is threaded
+    ;; ONLY when a real pre-image is present; its absence is the signal
+    ;; to render plainly. `:card?` + `:zoomable?` are constant across
+    ;; both cases (rf2-63ie5 gives each top-level mount discrete card
+    ;; chrome; rf2-h71e0 makes App-DB the canonical zoom-into-node
+    ;; consumer — the widget self-suppresses zoom resolution whenever a
+    ;; before is present because diff's force-expand-over-changes logic
+    ;; and zoom's hide-everything-outside-the-subtree conflict).
+    [ei/edn-inspector
+     (f/display-value value)
+     (cond-> {:panel-id :rf.xray/app-db
+              :site-id  site-id
+              :default-expanded-depth 3
+              :card? true
+              :zoomable? true
+              :header title}
+       has-before?
+       (assoc :before (f/display-value before)))]))
 
 ;; ---- top (user-domain) section ------------------------------------------
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -2472,7 +2472,6 @@
         [ei/edn-inspector db-after
          {:site-id [:rf.xray.epoch/handler-db-full-with-diff (:epoch-id record)]
           :before db-before
-          :full-with-diff? true
           :default-expanded-depth 3}]]
        [:span {:data-testid "rf-xray-epoch-handler-db-full-with-diff-missing"
                :style handler-db-all-missing-style}
@@ -2894,8 +2893,7 @@
        [ei/edn-inspector after
         (cond-> {:panel-id :rf.xray.epoch/subs-value
                  :site-id  [:rf.xray.epoch/subs-value sub-id idx :full+diff]
-                 :default-expanded-depth 3
-                 :full-with-diff? true}
+                 :default-expanded-depth 3}
           (some? before)                 (assoc :before before)
           (and first-run? (nil? before)) (assoc :added? true))]])))
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
@@ -516,10 +516,12 @@
                ;; full-modal inspection surface alongside the per-
                ;; machine drill-in.
                :popup-affordance? true}
-        ;; FULL+DIFF — thread BEFORE so changed leaves carry inline
-        ;; `← was X` annotations. Skipped when no BEFORE is captured.
+        ;; rf2-e28r3 — thread BEFORE so changed leaves carry inline
+        ;; `← was X` annotations + the R4 rail / R3 chip. Skipped when
+        ;; no BEFORE is captured, in which case the same renderer shows
+        ;; the snapshot plainly.
         (some? before-snapshot)
-        (assoc :before before-snapshot :full-with-diff? true))]]))
+        (assoc :before before-snapshot))]]))
 
 (defn- snapshot-drill-in
   "Snapshot drill-in section beneath the focused-event chart. Renders

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
@@ -68,15 +68,28 @@
                     to `available-width-px` (the measured column).
   - `:max-depth` (optional, default 16) — hard cap on recursion
                     depth; deeper levels render `{…}` collapsed.
-  - `:before` (optional) — when supplied, the widget renders in DIFF
-                    mode. The `value` arg is treated as the `after`
-                    side; the supplied `:before` is the prior value.
-                    Gutter glyphs + colours paint per node
-                    (`+` added · `-` removed · `~` modified ·
-                    `◴` children-changed); modified leaves get an
-                    inline `← was <prior>` annotation;
-                    ancestors of any changed descendant force open
-                    regardless of the default-expand heuristic.
+  - `:before` (optional) — the prior value to annotate against. The
+                    widget has ONE rendering path keyed on value (always)
+                    + before (optional): with a `:before` present the
+                    `value` arg is the `after` side and the tree paints
+                    inline diff annotations — gutter glyphs + colours per
+                    node (`+` added · `-` removed · `~` modified ·
+                    `◴` children-changed), modified leaves get an inline
+                    `← was <prior>` annotation, the R4 op-coloured rail +
+                    R3 `[N∆]` collapsed-change chip render on change-
+                    bearing containers, and ancestors of any changed
+                    descendant force open regardless of the default-
+                    expand heuristic. With no `:before` (and no
+                    `:added?`) the same renderer shows `value` plainly —
+                    no annotations, no rail, no chip.
+  - `:added?` (optional, default false) — rf2-kp7bw FIRST-RUN signal: a
+                    value that just came into existence (a sub's first
+                    cache entry, an app-db key that just appeared) with
+                    no prior value to diff against. Synthesises the
+                    before side as `engine/missing-sentinel`, so the
+                    whole tree classifies as `:added` (green wash + `+`
+                    chrome over every descendant). An explicit `:before`
+                    always wins; empty containers still read `:added`.
   - `:popup-affordance?` (optional, default false) — rf2-l4625; when
                     true the widget renders a top-right ↗ icon button
                     (rf2-7sdja — was ⊕; ↗ reads as 'open in new pane')
@@ -609,8 +622,8 @@
 
 ;; ---- gutter-row hoisted style maps (rf2-7cddi) ---------------------------
 ;;
-;; `gutter-row` fires once per change-bearing leaf in mode-3 — a 30-changed-
-;; leaf render allocates 90 fresh map literals at the call site without
+;; `gutter-row` fires once per change-bearing leaf in a diff render — a
+;; 30-changed-leaf render allocates 90 fresh map literals at the call site without
 ;; hoisting. The base shapes are static; only `:border-left` colour +
 ;; `:background` wash overlay vary (5-value op enum) on the outer, and
 ;; `:color` varies on the glyph span. Mirrors the hoisting culture
@@ -705,8 +718,8 @@
 
   When `chrome-opts` is omitted the chrome falls back to the per-op
   defaults (added=green, modified=amber, removed=red, same=invisible).
-  All four optional keys default to nil, so existing call sites
-  (non-mode-3 diff renders) reach the same hiccup shape unchanged."
+  All four optional keys default to nil, so call sites that pass no
+  chrome-opts reach the same hiccup shape unchanged."
   ([op body] (gutter-row op body nil))
   ([op body {:keys [suppress-glyph? suppress-stripe? suppress-wash? wash-op]}]
    (let [active?       (and (not (#{:same :same-shifted} op))
@@ -1312,7 +1325,7 @@
   available-width is yet measured the legacy depth-driven path runs as
   the fallback so unit tests + first-paint behaviour stay deterministic.
 
-  rf2-fqcdd — FULL+DIFF posture: when `:full-with-diff?` is true the
+  rf2-fqcdd — DIFF posture: when a pre-image is present (`:diff?`) the
   depth/width heuristics are SUPPRESSED for unchanged subtrees.
   Only two reasons to auto-expand a container:
 
@@ -1323,17 +1336,17 @@
   plus the root, no surrounding context noise. Sticky override via
   `resolve-expanded?` still wins for ad-hoc inspection."
   [{:keys [depth child-count default-expanded-depth available-width-px value
-           has-changed-descendant? full-with-diff?]
+           has-changed-descendant? diff?]
     :or   {default-expanded-depth default-ceiling-depth}}]
   (cond
     has-changed-descendant?
     true
 
-    ;; rf2-fqcdd — FULL+DIFF: collapse unchanged subtrees regardless of
+    ;; rf2-fqcdd — DIFF: collapse unchanged subtrees regardless of
     ;; depth/width. Root (depth 0) still expands so the operator sees
     ;; the top-level keys; everything below collapses unless an
     ;; ancestor of a change.
-    full-with-diff?
+    diff?
     (zero? depth)
 
     ;; Width-aware path — once a measurement exists, width drives the
@@ -1666,7 +1679,7 @@
   [{:keys [value kind panel-id mount-id path depth expansion-map opts
            dispatch-fn diff? before zoomable? zoom-path-prefix projection]}]
   (let [{:keys [default-expanded-depth max-depth max-inline-width
-                available-width-px full-with-diff?]
+                available-width-px]
          :or {default-expanded-depth default-ceiling-depth
               max-depth 16
               max-inline-width 60}} opts
@@ -1721,7 +1734,7 @@
                               :child-count             cnt
                               :default-expanded-depth  default-expanded-depth
                               :has-changed-descendant? has-change?
-                              :full-with-diff?         full-with-diff?
+                              :diff?                   diff?
                               :available-width-px      available-width-px
                               :value                   value}))
         expanded?     (and (not empty?)
@@ -1980,11 +1993,11 @@
            ;; brace column all converge on one vertical column, so the
            ;; tree reads as `▾ { │ keys │ }` recursively at every depth.
            ;; R4 rail (rf2-n2jig): when this container is change-
-           ;; bearing AND we're in mode-3 (full+diff), promote the
-           ;; body's left border to a 2px coloured rail in the dominant-
-           ;; op hue. Outside mode-3 (or no change) the subtle guide
-           ;; line stays.
-           (into [:div (let [rail-stripe (when (and full-with-diff? has-change?)
+           ;; bearing, promote the body's left border to a 2px coloured
+           ;; rail in the dominant-op hue. `has-change?` already implies
+           ;; a pre-image is present (it's `(and diff? …)`); when there's
+           ;; no diff, or no change, the subtle guide line stays.
+           (into [:div (let [rail-stripe (when has-change?
                                            (op-stripe-colour op))]
                          {:data-testid (str (testid-for panel-id mount-id path) "-body")
                           :data-rf-body-layout "grid"
@@ -2107,7 +2120,7 @@
            ;; the vertical guide line sits at the triangle's visual
            ;; centre. Closing bracket below shares the same `16px`
            ;; padding-left.
-           (into [:div (let [rail-stripe (when (and full-with-diff? has-change?)
+           (into [:div (let [rail-stripe (when has-change?
                                            (op-stripe-colour op))]
                          {:data-testid (str (testid-for panel-id mount-id path) "-body")
                           :data-rf-body-layout "block"
@@ -2222,7 +2235,7 @@
 
   ## rf2-n2jig — projection-aware
 
-  When `:projection` is supplied (mode-3 / full+diff path), the
+  When `:projection` is supplied (the diff render path), the
   `op` for this leaf is read off `engine/op-at projection path`.
   Otherwise the call falls back to the legacy (before, after) pair-
   based op classification via `engine/op-at` over a 1-shot projection
@@ -2900,10 +2913,9 @@
         ;; `engine/project` walks the full `(before, after)` pair every
         ;; call; the inner render fn runs on EVERY render of the mount
         ;; (expansion toggle, ResizeObserver widths update, parent re-
-        ;; render). Without this cache the mode-3 diff path re-walks the
-        ;; same byte-identical inputs N times per epoch — the audit's
-        ;; H1 finding (ai/findings/three-mode-diff-efficiency-audit-2026-
-        ;; 05-27.md §H1).
+        ;; render). Without this cache the diff render path re-walks the
+        ;; same byte-identical inputs N times per epoch (the redundant
+        ;; per-render Editscript walk an efficiency audit flagged).
         ;;
         ;; Atom holds `{:before <ref> :after <ref> :projection <map>}` or
         ;; nil. Cache hit when both refs match the previous call by
@@ -2964,7 +2976,7 @@
       (let [opts          (first rest-args)
             {:keys [panel-id site-id default-expanded-depth max-inline-width
                     max-depth popup-affordance? card? header zoomable?
-                    full-with-diff? added?]
+                    added?]
              :or   {panel-id :rf.xray.edn-inspector/anon
                     ;; rf2-kbdk8 — default raised from 2 → 8. Under the
                     ;; width-aware heuristic this opt is a CEILING (never
@@ -3116,20 +3128,7 @@
                              :opts {:default-expanded-depth default-expanded-depth
                                     :max-inline-width max-inline-width
                                     :max-depth max-depth
-                                    :available-width-px available-width-px
-                                    ;; rf2-n2jig — `:full-with-diff?` is
-                                    ;; threaded through opts so the
-                                    ;; recursive render-container path
-                                    ;; can promote the R4 rail + R3
-                                    ;; chip chrome. Mode-2 (plain
-                                    ;; `:diff` lens) does NOT set this
-                                    ;; flag — it walks the same
-                                    ;; renderer but suppresses the
-                                    ;; rail + chip (per pair-debug
-                                    ;; 2026-05-27 the diff lens stays
-                                    ;; per-leaf focused; mode-3 adds
-                                    ;; the structural-context chrome).
-                                    :full-with-diff? (boolean full-with-diff?)}})
+                                    :available-width-px available-width-px}})
             ;; rf2-h71e0 — breadcrumb row above the body, only when a
             ;; zoom is active. Home label uses the consumer's `:header`
             ;; if supplied (mirrors §10.0.10's "header is the natural

--- a/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_state_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_state_cljs_test.cljs
@@ -436,57 +436,42 @@
       (is (every? #(true? (:card? (:opts %))) diff-mts)
           "diff-mode mounts also opt in to the card chrome"))))
 
-;; ---- mode-3 grammar opt (rf2-kkhss) -------------------------------------
+;; ---- single render path: `:before` presence is the only diff signal
+;;      (rf2-e28r3) -----------------------------------------------------------
 ;;
-;; The edn-inspector widget gates its mode-3 R4 2px vertical rail behind
-;; `(and full-with-diff? has-change?)` in `render-container`. The App-DB
-;; call site MUST set `:full-with-diff? true` on the DIFF branch so the
-;; rail paints on change-bearing subtrees — Stories at
-;; `gallery_diff_mode_3.cljs` all set it, and sister surfaces (HANDLER
-;; `:db`, Machine, SUBS) also set it; the App-DB BROWSE branch (no
-;; `:before` present) MUST NOT set it (mode-3 chrome against a non-diff
-;; tree mis-renders).
-;;
-;; Per rf2-ya3nj audit finding H1. Without the opt the R4 rail silently
-;; never paints on App-DB — a load-bearing visual signal absent on the
-;; real surface while Stories render it correctly.
+;; The edn-inspector has ONE rendering path keyed on value (always) +
+;; before (optional). The former `:full-with-diff?` flag — which gated
+;; the R4 2px vertical rail + R3 chip on a distinction between the plain
+;; `:diff` lens (mode-2) and full+diff (mode-3) — is GONE; with a single
+;; path the chrome paints whenever a `:before` pre-image is present. The
+;; App-DB call site threads `:before` ONLY when a real pre-image differs
+;; and omits it otherwise (one `ei/edn-inspector` call, no browse/diff
+;; branch). These tests pin that the diff signal rides EXCLUSIVELY on
+;; `:before` presence and that no mount re-introduces the removed flag.
 
-(deftest diff-mode-mounts-carry-full-with-diff-opt
-  (testing "rf2-kkhss — DIFF-mode mounts (when a pre-image is supplied)
-            carry `:full-with-diff? true` so the edn-inspector widget
-            paints the mode-3 R4 vertical rail on change-bearing
-            subtrees (Stories at `gallery_diff_mode_3.cljs` all set
-            this opt; live App-DB used to silently drop it)"
-    (let [model    (h/current-state-sections {:counter 2} {:counter 1})
-          tree     (state/state-body model)
-          mounts   (find-edn-inspector-mounts tree)
-          diff-mts (filter #(contains? (:opts %) :before) mounts)]
-      (is (seq diff-mts) "diff-mode mounts present")
-      (is (every? #(true? (:full-with-diff? (:opts %))) diff-mts)
-          "every diff-mode mount opts in to mode-3 chrome so the R4
-           rail paints on change-bearing containers"))))
-
-(deftest browse-mode-mounts-omit-full-with-diff-opt
-  (testing "rf2-kkhss — BROWSE-mode mounts (1-arity / no pre-image,
-            `:before` absent) MUST NOT carry `:full-with-diff? true`
-            — mode-3 chrome against a non-diff tree mis-renders. The
-            opt belongs exclusively on the DIFF branch."
-    (let [model  (h/current-state-sections
-                   (runtime-db {:counter 2}
-                               {:rf/route {:id :home}
-                                :rf/machines {:auth {:state :idle}}}))
-          tree   (state/state-body model)
-          mounts (find-edn-inspector-mounts tree)]
+(deftest no-mount-carries-the-removed-full-with-diff-flag
+  (testing "rf2-e28r3 — the `:full-with-diff?` opt was removed; no
+            App-DB mount (diff or plain) may carry it. The R4 rail + R3
+            chip now paint whenever `:before` is present, with no
+            separate flag."
+    (let [diff-tree  (state/state-body
+                       (h/current-state-sections {:counter 2} {:counter 1}))
+          plain-tree (state/state-body
+                       (h/current-state-sections
+                         (runtime-db {:counter 2}
+                                     {:rf/route {:id :home}
+                                      :rf/machines {:auth {:state :idle}}})))
+          mounts     (concat (find-edn-inspector-mounts diff-tree)
+                             (find-edn-inspector-mounts plain-tree))]
       (is (seq mounts) "the panel mounts edn-inspector widget instances")
-      (is (every? #(not (contains? (:opts %) :before)) mounts)
-          "no `:before` opt — every mount is in BROWSE mode")
-      (is (not-any? #(true? (:full-with-diff? (:opts %))) mounts)
-          "no browse-mode mount carries the mode-3 opt"))))
+      (is (not-any? #(contains? (:opts %) :full-with-diff?) mounts)
+          "no mount carries the removed `:full-with-diff?` opt"))))
 
-(deftest changed-machine-snapshot-diff-mount-carries-mode-3-opt
-  (testing "rf2-kkhss — DIFF-mode mounts in the per-machine fan-out
-            (instance sections) also carry `:full-with-diff? true` so
-            the R4 rail paints uniformly across every reserved area"
+(deftest changed-machine-snapshot-diff-mount-threads-before
+  (testing "rf2-e28r3 — DIFF mounts in the per-machine fan-out thread
+            `:before` (the only diff signal) so the widget paints the
+            R4 rail / R3 chip + inline annotation uniformly across every
+            reserved area"
     (let [before   (runtime-db {:rf/machines {:title/flow {:state :idle}}})
           after    (runtime-db {:rf/machines {:title/flow {:state :loaded}}})
           model    (h/current-state-sections after before)
@@ -495,6 +480,5 @@
                      tree "rf-xray-app-db-state-instance-:rf/machines-:title/flow")
           mounts   (find-edn-inspector-mounts flow)
           diff-mts (filter #(contains? (:opts %) :before) mounts)]
-      (is (seq diff-mts) "the instance section renders in DIFF mode")
-      (is (every? #(true? (:full-with-diff? (:opts %))) diff-mts)
-          "the changed-machine instance mount opts in to mode-3 chrome"))))
+      (is (seq diff-mts)
+          "the changed-machine instance mount threads `:before`"))))

--- a/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs
@@ -1487,6 +1487,82 @@
         "modified leaf still carries the change annotation")))
 
 ;; =========================================================================
+;; rf2-e28r3 — single render path: value (always) + before (optional)
+;; =========================================================================
+;;
+;; The widget has ONE renderer. With a `:before` pre-image present the
+;; tree paints inline diff annotations + the R4 op-coloured rail + R3
+;; chip on change-bearing containers; with no pre-image the SAME renderer
+;; shows the value plainly (no rail, no chip, no annotation). The former
+;; `:full-with-diff?` flag — which gated the rail/chip on a defunct
+;; mode-2-vs-mode-3 distinction — is GONE; the rail now keys directly on
+;; `has-change?` (which itself implies `:diff?`).
+
+(deftest with-before-paints-rail-on-change-bearing-container
+  (testing "rf2-e28r3 — a `:before` pre-image renders the change-bearing
+            container with the R4 rail (`data-rf-rail`); modified leaves
+            carry the `← was <prior>` annotation. The rail paints on a
+            container whose OWN op is added/removed/modified (a newly-
+            added nested map here), the only chrome now that the
+            `:full-with-diff?` flag is gone."
+    (let [before {:a 1}
+          after  {:a 1 :nested {:x 1 :y 2}}
+          proj   (engine/project before after)
+          h      (ei/render-node {:value after
+                                  :before before
+                                  :diff? true
+                                  :projection proj
+                                  :panel-id :p :mount-id "m"
+                                  :path [] :depth 0
+                                  :expansion-map {}
+                                  :opts {:default-expanded-depth 4}})]
+      (is (some? (find-attr h :data-rf-rail "1"))
+          "the added nested container's body carries the R4 rail attr")
+      ;; A modified leaf also annotates (separate scenario keeps the
+      ;; rail assertion clean above).
+      (let [hm (ei/render-node {:value {:counter 2}
+                                :before {:counter 1}
+                                :diff? true
+                                :projection (engine/project {:counter 1} {:counter 2})
+                                :panel-id :p :mount-id "m"
+                                :path [] :depth 0
+                                :expansion-map {}
+                                :opts {:default-expanded-depth 2}})
+            sm (try (pr-str hm) (catch :default _ ""))]
+        (is (re-find #"← was 1" sm)
+            "the modified leaf carries the inline change annotation")))))
+
+(defn- diff-op-values
+  "Collect every non-nil `:data-rf-diff-op` attribute value in `tree`."
+  [tree]
+  (->> (walk-hiccup tree)
+       (keep (fn [n]
+               (when (map? (second n))
+                 (get (second n) :data-rf-diff-op))))
+       (remove nil?)))
+
+(deftest value-only-render-has-no-rail-or-annotation
+  (testing "rf2-e28r3 — with NO pre-image (`:diff?` absent) the same
+            renderer shows the value plainly: no R4 rail, no `← was`
+            annotation, no painted diff-op markers"
+    (let [v {:counter 2 :stable :x :nested {:deep 1}}
+          h (ei/render-node {:value v
+                             :panel-id :p :mount-id "m"
+                             :path [] :depth 0
+                             :expansion-map {}
+                             :opts {:default-expanded-depth 4}})
+          s (try (pr-str h) (catch :default _ ""))]
+      (is (nil? (find-attr h :data-rf-rail "1"))
+          "plain value render paints no R4 rail")
+      (is (not (re-find #"← was" s))
+          "plain value render carries no change annotation")
+      (is (empty? (diff-op-values h))
+          "plain value render emits no painted diff-op markers (the
+           `:data-rf-diff-op` value is nil outside diff mode)")
+      (is (re-find #":counter" s)
+          "the value's keys still render"))))
+
+;; =========================================================================
 ;; rf2-zpeyv — slot-vs-value anchoring (R2 + R6 whole-row treatment)
 ;; =========================================================================
 ;;
@@ -2312,30 +2388,32 @@
                   {:depth 5 :child-count 2 :value {:a 1 :b 2}
                    :default-expanded-depth 2})))))
 
-(deftest default-expanded-full-with-diff-collapses-unchanged
-  (testing "rf2-fqcdd — FULL+DIFF mode: unchanged subtrees collapse
-            regardless of depth/width. Only the root + ancestors of
-            a change auto-expand."
+(deftest default-expanded-diff-collapses-unchanged
+  (testing "rf2-fqcdd / rf2-e28r3 — with a pre-image present (`:diff?`):
+            unchanged subtrees collapse regardless of depth/width. Only
+            the root + ancestors of a change auto-expand. (The former
+            `:full-with-diff?` flag was removed; the collapse heuristic
+            now keys directly on `:diff?`.)"
     ;; Root (depth 0) always expands so the operator sees the keys.
     (is (true? (ei/default-expanded?
                  {:depth 0 :child-count 5 :value {:a 1 :b 2}
                   :default-expanded-depth 3
-                  :full-with-diff? true})))
-    ;; Depth 1 with NO changed descendant + FULL+DIFF on → collapse,
+                  :diff? true})))
+    ;; Depth 1 with NO changed descendant + diff on → collapse,
     ;; even though depth ≤ default-expanded-depth (would normally expand).
     (is (false? (ei/default-expanded?
                   {:depth 1 :child-count 5 :value {:a 1 :b 2}
                    :default-expanded-depth 3
-                   :full-with-diff? true})))
-    ;; Depth 1 WITH changed descendant + FULL+DIFF on → expand (the
+                   :diff? true})))
+    ;; Depth 1 WITH changed descendant + diff on → expand (the
     ;; force-expand rule for diff readability wins).
     (is (true? (ei/default-expanded?
                  {:depth 1 :child-count 5 :value {:a 1 :b 2}
                   :default-expanded-depth 3
-                  :full-with-diff? true
+                  :diff? true
                   :has-changed-descendant? true})))
-    ;; FULL+DIFF off — width/depth heuristic applies (the regression
-    ;; pin: the new branch is gated on `:full-with-diff?`).
+    ;; No pre-image (`:diff?` absent) — width/depth heuristic applies
+    ;; (the regression pin: the collapse branch is gated on `:diff?`).
     (is (true? (ei/default-expanded?
                  {:depth 1 :child-count 5 :value {:a 1 :b 2}
                   :default-expanded-depth 3})))))


### PR DESCRIPTION
@
**rf2-e28r3** — Collapses the edn-inspector to ONE rendering path keyed on **value (always) + before (optional)**: a pre-image present renders the full annotated diff (R1-R8 grammar + R4 rail + R3 chip), absent renders the value plainly. Removes the three-mode machinery left by rf2-vv3m6.

## Quality gates

| Gate | Result |
|------|--------|
| `cd tools/xray && clojure -M:test` | 965 tests / 3804 assertions · 0 failures |
| `cd implementation && npm run test:cljs` (CLJS node, incl. xray view/projection S11+) | 4824 tests / 15802 assertions · 0 failures |
| `npm run test:xray-feature-gate` | 14 scenarios · 0 failures · 13 matrix rows |
| `scripts/test-fast-pr.sh` (markdown gates auto-ran) | PASS (core JVM 795/3516; README + docs anchor validators OK; mkdocs --strict soft-skip local, CI runs) |

## What was removed

1. **`full-with-diff?` flag** — all 14 uses across the 4 files (was 14 → now 0 in `tools/xray/src/`). It only existed to distinguish the plain `:diff` lens (mode-2) from full+diff (mode-3); with one path it is always-on, so deleted. In `views/edn_inspector.cljs` the rail gate `(and full-with-diff? has-change?)` collapsed to `has-change?` (which already implies `diff?`), the `default-expanded?` collapse key became `:diff?`, and the opt was dropped from `render-edn-inspector` + the `body-content` opts thread.
2. **Plain `:diff` lens (mode-2)** — there was no flag-independent mode-2 renderer; removing the flag removes the lens. The R3 chip was already gated on `diff?` alone.
3. **Browse-vs-diff branch in `app_db_diff_state.cljs`** — the `(if (= h/no-diff before) … …)` split into two `ei/edn-inspector` calls collapsed to ONE call that threads `:before` via `cond->` only when a real pre-image is present.

The three other consumers (`epoch/view.cljs` HANDLER `:db` + SUBSCRIPTIONS, `machine_inspector.cljs` snapshot) just dropped the `:full-with-diff? true` opt.

**Preserved (#2401):** the `:added?` first-run opt + first-run-container behaviour in `subs-value-cell` are untouched — `:added?` synthesises a missing-sentinel before, which makes `diff?` true so the chrome paints; removing the unconditional `:full-with-diff? true` from that base map does not affect it.

**Spec:** rewrote `tools/xray/spec/021` §10.0.12 from the `:full-with-diff?` opt contract to the single value+optional-before renderer contract; folded the framing into the §9.1.5 `:before` opt entry and fixed the §9.1.5.1 activation prose.

Closes rf2-e28r3.
@