### PR TITLE
feat(xray): zoom via double-click + keyboard, remove glyphs (rf2-zl4rs)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -3081,7 +3081,7 @@ internal:
 Consumer adoption is per-panel and case-by-case; this section
 documents the contract, not a blanket migration.
 
-#### §10.0.11 `:zoomable?` opt — zoom-into-node + breadcrumb (rf2-h71e0)
+#### §10.0.11 `:zoomable?` opt — zoom-into-node + breadcrumb (rf2-h71e0; gesture reworked rf2-zl4rs)
 
 Dense app-db trees force the operator to scroll past chrome AND every
 intermediate level just to see one deep subtree. Sticky expansion
@@ -3090,27 +3090,49 @@ fully expanded the surrounding tree consumes screen real-estate and
 visual attention.
 
 Zoom-into-node turns the inspector into a focused window onto an
-arbitrary subtree. The operator clicks the `⊙` zoom affordance on any
-container; that node becomes the root of the displayed tree. A
-breadcrumb trail at the top shows the path from the original root;
-clicking any segment zooms back to that level. Anchors to known mental
-models — Chrome devtools' object inspector + nav, React devtools'
+arbitrary subtree. The operator **double-clicks** any container (or
+presses **Enter** while it is keyboard-focused); that node becomes the
+root of the displayed tree. A breadcrumb trail at the top shows the
+path from the original root; clicking any segment zooms back to that
+level. Anchors to known mental models — file-explorer double-click-to-
+descend, Chrome devtools' object inspector + nav, React devtools'
 selected-component focus, IDE nav-to-symbol + back, file browsers'
 breadcrumb drill-in.
 
-**Surface** — one new opt on the existing `[edn-inspector value opts]`:
+> **rf2-zl4rs gesture rework.** The earlier rf2-h71e0 design rendered a
+> separate `⊙` glyph button next to every container's expand triangle.
+> That glyph is **removed**: it crowded the header row, no-op'd in diff
+> mode, and added a second per-container interactive control. Zoom-in is
+> now a gesture on the container **itself** (double-click / Enter), with
+> the focusability + ARIA label the glyph button used to carry moved
+> onto the container. The same rework makes zoom apply in the single
+> full+diff renderer (see the `:before` composition note below).
 
-| `:zoomable?` value | Behaviour                                                                               |
-|--------------------|-----------------------------------------------------------------------------------------|
-| `false` (default)  | No affordance, no breadcrumb — widget renders as today (back-compat).                   |
-| `true`             | Every non-empty non-root container gets a `⊙` affordance; breadcrumb renders if zoomed. |
+**Surface** — one opt on the existing `[edn-inspector value opts]`:
 
-**Affordance glyph** — `⊙` (circled-dot, U+2299). Reads as "focus / aim
-cursor at this node" — visually distinct from the popup affordance (`↗`,
-"open in new pane"), the expand triangles (`▸`/`▾`), and the breadcrumb
-separator (`›`). Single codepoint, theme-token coloured (`:text-tertiary`
-at 0.55 resting opacity, hover bumps to `:text-secondary` via the
-`data-rf-affordance="zoom"` selector in the global stylesheet).
+| `:zoomable?` value | Behaviour                                                                                                  |
+|--------------------|------------------------------------------------------------------------------------------------------------|
+| `false` (default)  | No zoom target, no breadcrumb — widget renders as today (back-compat).                                     |
+| `true`             | Every non-empty non-root container is a double-click / Enter zoom target; breadcrumb renders if zoomed.    |
+
+**Gesture** — no glyph. Each non-empty non-root container's outer div
+carries:
+
+- `:on-double-click` — re-roots onto that node. `preventDefault`
+  suppresses the browser's native dblclick text-selection;
+  `stopPropagation` ensures a double-click deep in the tree zooms the
+  INNERMOST container rather than an ancestor.
+- `:on-key-down` — bare **Enter** (no Ctrl/Cmd/Alt/Shift) re-roots, same
+  as the double-click. Every other key passes through untouched, so the
+  Esc-zoom-out handler and the global spine bindings (Space/L/j/k/G) are
+  never swallowed.
+- `:tab-index 0` + `:aria-label "Zoom into <path>"` — keyboard-focusable
+  and screen-reader-announced, preserving the a11y the removed glyph
+  button provided. `role="button"` is deliberately NOT set: the
+  container already nests its own `role="button"` expand triangle, and a
+  button-inside-button role is an ARIA nesting violation — a focusable
+  labelled region is the correct shape for a composite node.
+- `:data-rf-zoom-target "1"` — DOM hook for tooling / tests.
 
 **Breadcrumb structure** — when a zoom is active, a row above the body
 renders `<home> › <seg1> › <seg2> › …`. Each segment is a clickable
@@ -3153,30 +3175,47 @@ Pure helpers `resolve-zoom-path` + `resolve-zoom-into` project the
 map for a given mount into either the stored path vector or the
 resolved sub-value (used by the widget's render-time `get-in` walk).
 
-**Keyboard navigation** — Esc (when the widget has focus AND a zoom is
-active) dispatches `:zoom-up`. The handler is installed on the outer
-container only while `zoom-active?` is true, so unzoomed mounts let
-Esc bubble unchanged. Coordinates with the popup widget's Esc-closes-
-top (rf2-7sdja): the popup's own keydown handler lives on its
-backdrop + dialog and `stopPropagation`s, so an open popup intercepts
-Esc first; subsequent Esc presses (no popup) reach the inspector's
-handler and zoom up.
+**Keyboard navigation** — two node-local + widget-level bindings:
+
+- **Enter** (zoom IN) — pressing Enter while a non-root container is
+  keyboard-focused re-roots onto that node (the gesture's keyboard half;
+  the a11y replacement for clicking the removed glyph). The handler
+  lives on each zoomable container; it matches bare Enter only and
+  `stopPropagation`s on a match so the keypress doesn't double-fire.
+- **Esc** (zoom OUT) — when the widget has focus AND a zoom is active,
+  Esc dispatches `:zoom-up`. The handler is installed on the outer
+  widget container only while `zoom-active?` is true, so unzoomed mounts
+  let Esc bubble unchanged. Coordinates with the popup widget's
+  Esc-closes-top (rf2-7sdja): the popup's own keydown handler lives on
+  its backdrop + dialog and `stopPropagation`s, so an open popup
+  intercepts Esc first; subsequent Esc presses (no popup) reach the
+  inspector's handler and zoom up.
+
+Esc-zoom-out is now active in diff mode too (zoom applies in the single
+full+diff renderer — see the `:before` note below).
 
 **Composition with other opts** —
 
-- **`:popup-affordance?`** — independent. Both affordances render
-  side-by-side when both opts are present — they serve different
-  intents (zoom = focus here without opening a new pane; popup = open
-  the value in a roomier modal). Inside a popup the inner inspector
-  recurses with `:popup-affordance? false` (§10.0.7.2) but
+- **`:popup-affordance?`** — independent. The popup affordance + the
+  zoom gesture coexist (popup = open the value in a roomier modal; zoom
+  = focus here without opening a new pane). Inside a popup the inner
+  inspector recurses with `:popup-affordance? false` (§10.0.7.2) but
   `:zoomable?` survives the recursion so the popup body is itself
   zoom-navigable.
-- **`:before` (diff mode)** — zoom is SUPPRESSED in diff mode. The
-  widget self-detects (`zoom-active? = zoomable? AND NOT diff? AND
-  zoom-path non-empty`) and renders the full value with the gutter
-  glyphs as today. Rationale: diff's force-expand-over-changed-
-  descendants logic and zoom's hide-everything-outside-the-subtree are
-  conflicting intents; operators view diffs over the full value.
+- **`:before` (diff mode)** — zoom applies in the single full+diff
+  renderer (rf2-zl4rs supersedes the earlier rf2-h71e0 "diff suppresses
+  zoom"). When a zoom is active the widget re-roots `value` along the
+  stored path ALWAYS, and re-roots `before` the same way when a
+  pre-image is present; the projection is recomputed over the re-rooted
+  `(before, value)` pair, so the diff rail / `[N∆]` chip / inline
+  `← was X` annotations paint relative to the zoomed subtree exactly as
+  they do at the root. Edge cases: a zoom into a wholly-`:added` subtree
+  re-roots both halves so the whole subtree reads `:added` (the
+  re-rooted before stays the missing-sentinel and the projection
+  classifies the subtree green); a stale path (mutated out from under
+  the zoom) falls back to the full value via `resolve-zoom-into`. So
+  `zoom-active? = zoomable? AND zoom-path non-empty` — the `NOT diff?`
+  clause is gone.
 - **`:header`** — the hiccup feeds the breadcrumb home segment when
   zoomed (`home-label`).
 - **`:default-expanded-depth`** / **`:max-depth`** — applied to the
@@ -3205,9 +3244,10 @@ handler and zoom up.
 - **Inspector-card titles / chip mounts** — single-level renders never
   need zoom.
 
-**Skipped affordance** — the root of the displayed subtree (relative
-path `[]`) never renders the affordance; zooming into the current
-zoom root is a no-op. The renderer composes the absolute path as
+**Skipped target** — the root of the displayed subtree (relative
+path `[]`) and any empty container are never zoom targets; zooming into
+the current zoom root (or into a container with no subtree to focus) is
+a no-op. The renderer composes the absolute path as
 `(into zoom-path-prefix path)` so the dispatched `:zoom-to` carries the
 full path from the ORIGINAL root, not the currently-displayed root.
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs
@@ -226,9 +226,11 @@
     ;; to render plainly. `:card?` + `:zoomable?` are constant across
     ;; both cases (rf2-63ie5 gives each top-level mount discrete card
     ;; chrome; rf2-h71e0 makes App-DB the canonical zoom-into-node
-    ;; consumer — the widget self-suppresses zoom resolution whenever a
-    ;; before is present because diff's force-expand-over-changes logic
-    ;; and zoom's hide-everything-outside-the-subtree conflict).
+    ;; consumer — double-click / Enter on a container re-roots the
+    ;; inspector onto it, rf2-zl4rs). Zoom now applies in the single
+    ;; full+diff renderer: when a before is present the widget re-roots
+    ;; BOTH value and before along the zoom path, so the diff annotations
+    ;; paint relative to the focused subtree.
     [ei/edn-inspector
      (f/display-value value)
      (cond-> {:panel-id :rf.xray/app-db

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
@@ -150,31 +150,37 @@
                     its own surface chrome, so `:card?` is usually
                     redundant when `:header` is present).
 
-  - `:zoomable?`     (optional, default false) — rf2-h71e0; when true
-                    every container in the tree renders a `⊙` zoom-
-                    affordance button next to the expand triangle.
-                    Click dispatches
+  - `:zoomable?`     (optional, default false) — rf2-h71e0; gesture
+                    reworked rf2-zl4rs. When true every non-root
+                    container becomes a zoom-in TARGET: double-click
+                    (or Enter while the node is keyboard-focused)
+                    re-roots the inspector onto that node. There is no
+                    longer a `⊙` glyph button — the gesture lives on
+                    the container itself, which carries `tab-index 0` +
+                    an `aria-label` so the keyboard + screen-reader
+                    affordance the glyph button used to provide is
+                    preserved. The gesture dispatches
                     `[:rf.xray.edn-inspector/zoom-to panel-id mount-id
                     absolute-path]`, which stores the absolute path
                     under `:rf.xray.edn-inspector/zoom` keyed by
                     `[panel-id site-or-mount-id]`. The widget then
-                    renders ONLY the subtree at that path, with a
-                    breadcrumb row above the body showing the path
-                    from the original root (each segment clickable for
-                    one-tap zoom-up).
+                    re-roots onto that subtree, with a breadcrumb row
+                    above the body showing the path from the original
+                    root (each segment clickable for one-tap zoom-up).
                     Esc (when the widget has focus AND a zoom is
                     active) pops one level off the zoom stack.
-                    Composes with `:popup-affordance?` (both
-                    affordances render side-by-side — they serve
-                    different intents: zoom = focus here; popup = open
-                    in new pane). Diff mode (`:before` present)
-                    suppresses zoom resolution — the diff path's
-                    force-expand-over-changed-descendants logic and
-                    zoom's hide-everything-outside-the-subtree are
-                    conflicting intents; operators view diffs over the
-                    full value. Per-mount keying matches the
-                    expansion-slot pattern; pass a stable `:site-id`
-                    to survive a panel-leave-and-return round-trip.
+                    Zoom applies in the SINGLE full+diff renderer
+                    (rf2-e28r3 / rf2-zl4rs): the re-root walks `value`
+                    always and `before` too when a pre-image is present,
+                    so the diff rail / chip / inline annotations paint
+                    relative to the zoomed subtree. A zoom into a wholly
+                    `:added` subtree re-roots both halves so the whole
+                    subtree reads `:added`; a stale path falls back to
+                    the full value. Composes with `:popup-affordance?`
+                    (popup = open in new pane; zoom = focus here).
+                    Per-mount keying matches the expansion-slot pattern;
+                    pass a stable `:site-id` to survive a panel-leave-
+                    and-return round-trip.
 
   Drop the `:render-id` arg from the old facade — mount-id is now
   auto-generated internally per D4=a (rf2-sndui).
@@ -353,14 +359,16 @@
       db)))
 
 ;; =========================================================================
-;; zoom-into-node + breadcrumb navigation (rf2-h71e0)
+;; zoom-into-node + breadcrumb navigation (rf2-h71e0; gesture reworked rf2-zl4rs)
 ;; =========================================================================
 ;;
 ;; Zoom turns the inspector into a focused window onto an arbitrary subtree.
-;; Operator clicks the `⊙` zoom affordance on any container; that node
-;; becomes the root of the displayed tree. A breadcrumb trail at the top
-;; shows the path from the original root; clicking any segment zooms back
-;; to that level.
+;; Operator double-clicks any container (or presses Enter while it is
+;; keyboard-focused, rf2-zl4rs); that node becomes the root of the displayed
+;; tree. There is no separate `⊙` glyph button — the gesture lives on the
+;; container itself. A breadcrumb trail at the top shows the path from the
+;; original root; clicking any segment zooms back to that level. Esc zooms
+;; out one level.
 ;;
 ;; State shape mirrors `expansion-slot` — keyed by `[panel-id site-or-
 ;; mount-id]` so two side-by-side mounts zoom independently and a stable
@@ -1593,11 +1601,14 @@
 
 (declare render-inline-recursive)
 
-;; rf2-h71e0 — forward declaration for the zoom affordance button
-;; rendered inside `render-container`'s header row. The definition
-;; lives further down alongside the breadcrumb component + popup
-;; affordance (all three are top-level chrome surfaces).
-(declare zoom-affordance-button)
+;; rf2-zl4rs — forward declaration for the per-node zoom-trigger
+;; attribute factory. Zoom-in is now a node-local gesture (double-click
+;; / Enter) on the container itself rather than a separate `⊙` glyph
+;; button; the factory composes the `:on-double-click` + `:on-key-down`
+;; + a11y attrs that render-container merges onto each zoomable
+;; container's outer div. Defined below alongside the breadcrumb
+;; component.
+(declare zoom-trigger-attrs)
 
 (defn- render-inline-pair
   "Render a single map / record entry `[k v]` as a key+value sequence
@@ -1671,13 +1682,18 @@
    - diff? / before — when diff? true the renderer paints gutter rows,
                       annotates changed leaves, and force-expands the
                       ancestor chain over any changed descendant.
-   - zoomable? / zoom-path-prefix — when zoomable? true (rf2-h71e0), the
-                                    container renders a `⊙` zoom-in
-                                    affordance next to the expand
-                                    triangle. zoom-path-prefix is the
-                                    absolute path of the CURRENT zoom
+   - zoomable? / zoom-path-prefix — when zoomable? true (rf2-h71e0,
+                                    gesture reworked rf2-zl4rs), every
+                                    non-root container becomes a zoom-in
+                                    target: double-click (or Enter while
+                                    focused) re-roots the inspector onto
+                                    that node. There is no separate
+                                    glyph button — the container's own
+                                    outer div carries the gesture
+                                    handlers + a11y. zoom-path-prefix is
+                                    the absolute path of the CURRENT zoom
                                     root within the original value; the
-                                    affordance dispatches with `(into
+                                    gesture dispatches with `(into
                                     zoom-path-prefix path)` so the
                                     zoom-slot stores the full path."
   [{:keys [value kind panel-id mount-id path depth expansion-map opts
@@ -1793,28 +1809,29 @@
                         (if diff?
                           (children-of-pair before value kind)
                           (children-of value)))
-        ;; rf2-h71e0 — zoom affordance is rendered next to the expand
-        ;; triangle on every non-empty container at a NON-ROOT relative
-        ;; path. The root (`[]`) skips the affordance because zooming
-        ;; into the current zoom root is a no-op. The button dispatches
-        ;; with the ABSOLUTE path = `(into zoom-path-prefix path)` so
-        ;; the zoom-slot stores the full path from the original root.
-        zoom-button   (when (and zoomable?
+        ;; rf2-zl4rs — zoom-in is a node-local gesture (double-click /
+        ;; Enter) on every non-empty container at a NON-ROOT relative
+        ;; path. The root (`[]`) skips the gesture because zooming into
+        ;; the current zoom root is a no-op; empty containers have no
+        ;; meaningful subtree to focus. The handlers dispatch with the
+        ;; ABSOLUTE path = `(into zoom-path-prefix path)` so the zoom-slot
+        ;; stores the full path from the original root. The attrs merge
+        ;; onto the container's outer div below (nil when not zoomable).
+        zoom-attrs    (when (and zoomable?
                                  (not empty?)
                                  (seq path))
-                        (zoom-affordance-button
+                        (zoom-trigger-attrs
                           {:dispatch-fn   dispatch-fn
                            :panel-id      panel-id
                            :mount-id      mount-id
-                           :absolute-path (into (vec zoom-path-prefix) path)
-                           :testid        (str (testid-for panel-id mount-id path)
-                                               "-zoom-affordance")}))]
-    [:div {:data-testid (testid-for panel-id mount-id path)
-           :data-rf-kind (name kind)
-           :data-rf-expanded (if expanded? "1" "0")
-           :data-rf-diff-op (when diff? (name op))
-           :style {:font-family mono-stack
-                   :line-height 1.4}}
+                           :absolute-path (into (vec zoom-path-prefix) path)}))]
+    [:div (merge {:data-testid (testid-for panel-id mount-id path)
+                  :data-rf-kind (name kind)
+                  :data-rf-expanded (if expanded? "1" "0")
+                  :data-rf-diff-op (when diff? (name op))
+                  :style {:font-family mono-stack
+                          :line-height 1.4}}
+                 zoom-attrs)
      ;; ---- header row ---------------------------------------------------
      [:div {:style {:display "flex"
                     :align-items "baseline"
@@ -1840,7 +1857,6 @@
                          ;; -height).
                          :style triangle-style}
                   "▸"]]
-          zoom-button (conj zoom-button)
           true        (conj (bracket kind :open value))
           true        (conj [:span {:style (token-style :text-tertiary)} "…"])
           true        (conj (bracket kind :close value)))
@@ -1882,17 +1898,10 @@
                                          true (conj (render-scalar cv)))))
                                    pairs))
                           [(bracket kind :close value)]))))]
-          (if zoom-button
-            ;; rf2-h71e0 — wrap the inline render in a flex span so the
-            ;; zoom button sits next to (and aligned with) the inline
-            ;; content. The inline-fit path has no toggle triangle, so
-            ;; the affordance leads.
-            [:span {:style {:display "inline-flex"
-                            :align-items "baseline"
-                            :gap "4px"}}
-             zoom-button
-             inline-render]
-            inline-render))
+          ;; rf2-zl4rs — the inline-fit row has no separate zoom glyph;
+          ;; the zoom gesture lives on the container's outer div (handlers
+          ;; merged above), so the inline render passes through unwrapped.
+          inline-render)
 
         ;; Default — toggle glyph + open bracket (when expanded) OR summary.
         expanded?
@@ -1906,7 +1915,6 @@
                          ;; `triangle-style`.
                          :style triangle-style}
                   "▾"]]
-          zoom-button (conj zoom-button)
           true        (conj (bracket kind :open value)))
 
         :else
@@ -1940,7 +1948,6 @@
                           :data-rf-diff-chip-count (str n-changes)
                           :style r3-chip-style}
                    (str n-changes "∆")])
-            zoom-button (conj zoom-button)
             true        (conj (collapsed-summary value kind)))))]
 
      ;; ---- body — children rendered indented -----------------------------
@@ -2544,17 +2551,21 @@
    :opacity       0.6})
 
 ;; =========================================================================
-;; zoom affordance + breadcrumb (rf2-h71e0)
+;; zoom trigger + breadcrumb (rf2-h71e0; gesture reworked rf2-zl4rs)
 ;; =========================================================================
 ;;
 ;; Two surfaces:
 ;;
-;; 1. `zoom-affordance-button` — inline `⊙` button rendered next to the
-;;    expand triangle on every container when `:zoomable? true`. Click
-;;    dispatches `:zoom-to` with the node's ABSOLUTE path from the
-;;    original root (the renderer's per-node `:path` is RELATIVE to the
-;;    current zoom root, so the dispatch composes `zoom-path-prefix` +
-;;    `path` before storing).
+;; 1. `zoom-trigger-attrs` — the gesture attrs render-container merges
+;;    onto every non-root container's outer div when `:zoomable? true`.
+;;    Double-click (or Enter while the node is keyboard-focused) re-roots
+;;    the inspector onto that node. The dispatch carries the node's
+;;    ABSOLUTE path from the original root (the renderer's per-node
+;;    `:path` is RELATIVE to the current zoom root, so the caller composes
+;;    `zoom-path-prefix` + `path` before passing it in). There is no
+;;    separate `⊙` glyph button (rf2-zl4rs): the container itself is the
+;;    target, with `tab-index 0` + an `aria-label` carrying the keyboard +
+;;    screen-reader affordance the button used to provide.
 ;;
 ;; 2. `zoom-breadcrumbs` — segmented nav at the top of the inspector
 ;;    when the zoom path is non-empty. First segment is the `:header`
@@ -2563,89 +2574,82 @@
 ;;    `:zoom-to` with a TRUNCATED path so clicking segment N pops the
 ;;    zoom back to N levels deep.
 
-(def ^:private zoom-affordance-glyph
-  ;; `⊙` (circled-dot) reads as "focus / aim cursor at this node" — the
-  ;; mental model the bead body identified (Chrome devtools' object
-  ;; inspector + nav, IDE nav-to-symbol). Visually distinct from the
-  ;; popup affordance (`↗` — "open in new pane"), the expand triangles
-  ;; (`▸`/`▾` — toggle), and the breadcrumb separator (`›`). Single
-  ;; codepoint, theme-token coloured.
-  "⊙")
-
 (def ^:private breadcrumb-separator
   ;; `›` (single right-pointing angle) reads as nav direction — same
   ;; convention as file-browser breadcrumbs + IDE path bars. Distinct
   ;; from `→` (transition / arrow) and `>` (greater-than / blockquote).
   "›")
 
-(def ^:private zoom-affordance-button-style
-  {:background    "transparent"
-   :border        "none"
-   :color         (:text-tertiary tokens)
-   :font-size     "13px"
-   :line-height   1
-   :cursor        "pointer"
-   :padding       "0 4px"
-   :margin        "0"
-   :border-radius "3px"
-   ;; Subtle by default — matches the popup affordance's resting opacity
-   ;; so the operator's eye reads "secondary affordance" at both glyphs.
-   ;; Theme-aware via the token resolution.
-   :opacity       0.55
-   :display       "inline-flex"
-   :align-items   "center"
-   :user-select   "none"})
+(defn zoom-trigger-attrs
+  "Gesture attrs for a single zoomable container — merged onto the
+  container's outer div by `render-container`. Returns a map carrying:
 
-(defn zoom-affordance-button
-  "Inline `⊙` zoom-in button. Renders next to the expand triangle on
-  containers when `:zoomable? true`. Click dispatches `:zoom-to` with
-  the absolute path from the original root (composed by the caller as
-  `(into zoom-path-prefix path)`).
+   - `:on-double-click` — double-click re-roots the inspector onto this
+     node. `preventDefault` (suppresses the browser's native dblclick
+     text-selection) + `stopPropagation` (so a dblclick deep in the tree
+     zooms to the INNERMOST container, not an ancestor).
+   - `:on-key-down` — Enter (no modifiers) on the focused node re-roots,
+     same as the double-click; other keys pass through untouched so the
+     surrounding spine bindings (j/k/L/G) and Esc-zoom-out keep working.
+   - `:tab-index 0` + `:aria-label` — the node is keyboard-focusable and
+     announces itself as a zoom target, preserving the a11y the removed
+     `⊙` button provided. We deliberately do NOT set `role \"button\"`:
+     the container already nests its own `role=\"button\"` expand
+     triangle, and a button-inside-button role is an ARIA nesting
+     violation. A focusable labelled region is the correct shape for a
+     composite node whose double-click / Enter zooms in.
+   - `:data-rf-zoom-target \"1\"` — DOM hook for tooling / tests.
 
   ## Capture-the-frame (rf2-r0o63 — supersedes the rf2-kcaiz pin)
 
-  The zoom-to event dispatches through the lexically-captured
-  `dispatch-fn` — the frame-aware dispatcher the surrounding `reg-view`
-  body bound via `(rf/dispatcher)` at render time. The closure captured
-  `(current-frame)` synchronously during render, so it dispatches into
-  the SURROUNDING instance frame even though the click fires later
-  (after React's synthetic-event timing has popped the dynamic frame
-  context). This is the same shape as `on-toggle` — the zoom slot is
-  per-frame, so the write must land on the instance frame, not a
-  `:rf/xray` literal.
-
-  This supersedes the rf2-kcaiz fix, which pinned the frame to a bare
-  `:rf/xray` literal at call time. That worked for the single-instance
-  shell but entrenched the singleton: two shells on one page would both
-  write the global `:rf/xray` zoom-slot and clobber each other.
-  Capturing the dispatcher keeps N instances isolated.
+  Both gestures dispatch through the lexically-captured `dispatch-fn` —
+  the frame-aware dispatcher the surrounding `reg-view` body bound via
+  `(rf/dispatcher)` at render time. The closure captured the instance
+  frame synchronously during render, so the dispatch lands on the
+  SURROUNDING instance frame even though the gesture fires later (after
+  React's synthetic-event timing has popped the dynamic frame context).
+  This is the same shape as `on-toggle` — the zoom slot is per-frame, so
+  the write must land on the instance frame, NOT a `:rf/xray` literal
+  (which would entrench the singleton: two shells on one page would both
+  write the global zoom-slot and clobber each other).
 
   `dispatch-fn` falls back to `rf/dispatch*` when absent (pure-render
-  tests that drive the button without a `reg-view` ancestor).
+  tests that drive the gesture without a `reg-view` ancestor).
 
-  Public so unit tests can drive the button without mounting."
-  [{:keys [panel-id mount-id absolute-path testid dispatch-fn]}]
-  (let [dispatch-fn (or dispatch-fn rf/dispatch*)]
-    [:button
-     {:data-testid        testid
-      :data-rf-affordance "zoom"
-      :aria-label         "Zoom into this node"
-      :title              "Zoom into this node"
-      :on-click           (fn [^js e]
+  Public so unit tests can drive the gesture without mounting."
+  [{:keys [panel-id mount-id absolute-path dispatch-fn]}]
+  (let [dispatch-fn (or dispatch-fn rf/dispatch*)
+        path        (vec absolute-path)
+        zoom!       (fn []
+                      ;; rf2-r0o63 — dispatch through the captured
+                      ;; frame-aware dispatcher so the zoom-slot write
+                      ;; lands on the SURROUNDING instance frame. N shells
+                      ;; stay isolated; no `:rf/xray` literal.
+                      (dispatch-fn
+                        [:rf.xray.edn-inspector/zoom-to
+                         panel-id mount-id path]))]
+    {:data-rf-zoom-target "1"
+     :tab-index           0
+     :aria-label          (str "Zoom into " (pr-str path))
+     :title               "Double-click or press Enter to zoom into this node"
+     :on-double-click     (fn [^js e]
                             (when e
+                              ;; Suppress the native double-click text
+                              ;; selection + stop the event reaching an
+                              ;; ancestor container (innermost wins).
                               (.preventDefault e)
                               (.stopPropagation e))
-                            ;; rf2-r0o63 — dispatch through the
-                            ;; captured frame-aware dispatcher so the
-                            ;; zoom-slot write lands on the SURROUNDING
-                            ;; instance frame (captured at render time).
-                            ;; N shells stay isolated; no `:rf/xray`
-                            ;; literal entrenching the singleton.
-                            (dispatch-fn
-                              [:rf.xray.edn-inspector/zoom-to
-                               panel-id mount-id (vec absolute-path)]))
-      :style              zoom-affordance-button-style}
-     zoom-affordance-glyph]))
+                            (zoom!))
+     :on-key-down         (fn [^js e]
+                            (when (and e
+                                       (= "Enter" (.-key e))
+                                       (not (.-ctrlKey e))
+                                       (not (.-metaKey e))
+                                       (not (.-altKey e))
+                                       (not (.-shiftKey e)))
+                              (.preventDefault e)
+                              (.stopPropagation e)
+                              (zoom!)))}))
 
 (defn- breadcrumb-segment-label
   "Render a single path-segment label using the syntax-palette colour
@@ -3040,16 +3044,24 @@
             ;; active zoom. The slot is per-frame (same `:rf/xray`
             ;; pattern as `expansion-slot`); the per-mount key is
             ;; `[panel-id effective-id]` (effective-id is `site-id` if
-            ;; supplied, else the auto-mount-id). Diff mode ALSO ignores
-            ;; zoom (`zoom-active?` short-circuits when `diff?` is true)
-            ;; because the diff path's force-expand-over-changed-
-            ;; descendants logic + zoom's hide-everything-outside the
-            ;; subtree are conflicting intents. Operators view diffs
-            ;; over the FULL value; non-diff browse can zoom.
+            ;; supplied, else the auto-mount-id).
+            ;;
+            ;; rf2-zl4rs — zoom now applies in the SINGLE full+diff
+            ;; renderer (rf2-e28r3). When a zoom is active the inspector
+            ;; re-roots `value` along the path ALWAYS, and re-roots
+            ;; `before` the same way ONLY when a pre-image is present
+            ;; (diff mode). The projection is recomputed over the
+            ;; re-rooted pair below, so the diff rail / chip / inline
+            ;; annotations paint relative to the zoomed subtree exactly
+            ;; as they do at the root. A stale path (mutated out from
+            ;; under the zoom) falls back to the full value via
+            ;; `resolve-zoom-into`. (The earlier rf2-h71e0 design
+            ;; suppressed zoom whenever a `before` was present; that
+            ;; conflict is resolved by re-rooting both halves together.)
             zoom-map      (when zoomable? @(subscribe [zoom-slot]))
             zoom-path     (resolve-zoom-path zoom-map panel-id
                                              (or site-id mount-id))
-            zoom-active?  (and zoomable? (not diff?) (seq zoom-path))
+            zoom-active?  (and zoomable? (seq zoom-path))
             displayed-value
             (if zoom-active?
               (resolve-zoom-into value zoom-map panel-id

--- a/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs
@@ -2530,6 +2530,7 @@
 
 ;; =========================================================================
 ;; rf2-h71e0 — zoom-into-node + breadcrumb navigation
+;; (gesture reworked rf2-zl4rs — double-click / Enter, no glyph)
 ;; =========================================================================
 ;;
 ;; The zoom feature turns the inspector into a focused window onto an
@@ -2539,16 +2540,22 @@
 ;; path from the original root; each segment is clickable for one-tap
 ;; zoom-to-that-depth.
 ;;
+;; rf2-zl4rs — zoom-in is a node-local gesture (double-click / Enter)
+;; on the container itself; there is NO `⊙` glyph button. Zoom applies
+;; in the SINGLE full+diff renderer (re-root value always, before too
+;; when present). Esc + breadcrumb still zoom out.
+;;
 ;; Tests under this section cover:
 ;;
 ;; - Pure helpers: `zoom-key`, `resolve-zoom-path`, `resolve-zoom-into`.
 ;; - Event reducers: `:zoom-to`, `:zoom-up`, `:zoom-reset`.
 ;; - Public widget plumbing: `:zoomable?` opts emit data-attrs +
-;;   breadcrumb + the `⊙` affordance on containers; default (no opt)
-;;   leaves the renderer unchanged.
+;;   breadcrumb + the double-click / Enter zoom-trigger attrs on
+;;   containers; default (no opt) leaves the renderer unchanged.
 ;; - Per-mount keying: two side-by-side mounts zoom independently;
 ;;   stable `:site-id` survives unmount/remount.
-;; - Diff suppression: diff mode (`:before`) ignores an active zoom.
+;; - Single full+diff renderer: a zoom re-roots BOTH value and before;
+;;   no glyph renders.
 
 ;; ---- pure helpers --------------------------------------------------------
 
@@ -2671,14 +2678,59 @@
       (is (nil? (:data-rf-zoomed attrs))
           "no zoom active yet — :data-rf-zoomed is still absent"))))
 
-(deftest zoomable-renders-affordance-on-containers
-  ;; When zoomable? is on, the recursive renderer emits a `⊙` button
-  ;; next to every non-root container. We probe render-node directly
-  ;; with a `zoom-path-prefix` of [] to confirm the affordance appears
-  ;; at child paths (not at the root).
+;; ---- zoom GESTURE — double-click / Enter, no glyph (rf2-zl4rs) -----------
+;;
+;; rf2-zl4rs removed the `⊙` glyph button entirely; zoom-in is now a
+;; node-local gesture on the container's own outer div. These tests
+;; assert: (a) NO `⊙` / zoom-affordance glyph renders anywhere; (b) the
+;; non-root container carries the `data-rf-zoom-target` + handlers; (c)
+;; the root + opt-off cases carry no zoom target; (d) double-click +
+;; Enter both dispatch the canonical zoom-to through the captured
+;; dispatcher with the absolute path.
+
+(defn- zoom-target-nodes
+  "Every hiccup node carrying `data-rf-zoom-target=1`."
+  [tree]
+  (filter (fn [n]
+            (and (vector? n)
+                 (map? (second n))
+                 (= "1" (:data-rf-zoom-target (second n)))))
+          (walk-hiccup tree)))
+
+(defn- glyph-nodes
+  "Every hiccup node whose string content is the legacy `⊙` zoom glyph,
+  plus any `data-rf-affordance=zoom` button — the surfaces rf2-zl4rs
+  removed. Used to assert their TOTAL ABSENCE."
+  [tree]
+  (filter (fn [n]
+            (and (vector? n)
+                 (or (= "⊙" (last n))
+                     (and (map? (second n))
+                          (= "zoom" (:data-rf-affordance (second n)))))))
+          (walk-hiccup tree)))
+
+(deftest zoomable-emits-no-glyph-button
+  ;; The `⊙` glyph + the `data-rf-affordance=zoom` button are GONE
+  ;; (rf2-zl4rs). The recursive walker emits neither, at any depth.
   (let [v {:a {:nested 1} :b 2}
-        ;; Drive render-node with a `:default-expanded-depth 8` so the
-        ;; container expands and the `:a` child gets a header row.
+        h (ei/render-node {:value v
+                           :panel-id :p
+                           :mount-id "m"
+                           :path []
+                           :depth 0
+                           :expansion-map {}
+                           :zoomable? true
+                           :zoom-path-prefix []
+                           :opts {:default-expanded-depth 8}})]
+    (is (empty? (glyph-nodes h))
+        "rf2-zl4rs — no `⊙` glyph / zoom-affordance button renders")))
+
+(deftest zoomable-marks-non-root-containers-as-zoom-targets
+  ;; With zoomable? on, every non-root container's outer div carries the
+  ;; zoom-trigger attrs (data-rf-zoom-target + tab-index + aria-label +
+  ;; handlers). We probe render-node directly with a `zoom-path-prefix`
+  ;; of [] to confirm the child container `:a` is a target.
+  (let [v {:a {:nested 1} :b 2}
         h (ei/render-node {:value v
                            :panel-id :p
                            :mount-id "m"
@@ -2688,15 +2740,23 @@
                            :zoomable? true
                            :zoom-path-prefix []
                            :opts {:default-expanded-depth 8}})
-        affordance (find-attr h :data-rf-affordance "zoom")]
-    (is (some? affordance)
-        "the recursive walker emits a zoom affordance on a non-root container")
-    (is (= "⊙" (last affordance))
-        "the affordance glyph is `⊙` (focus / aim-cursor semantic)")))
+        targets (zoom-target-nodes h)]
+    (is (seq targets)
+        "a non-root container is marked as a zoom target")
+    (let [attrs (-> targets first second)]
+      (is (= 0 (:tab-index attrs))
+          "the target is keyboard-focusable (tab-index 0)")
+      (is (string? (:aria-label attrs))
+          "the target carries an aria-label — preserves the removed
+           button's screen-reader affordance")
+      (is (fn? (:on-double-click attrs))
+          "double-click handler present")
+      (is (fn? (:on-key-down attrs))
+          "key-down handler present (Enter zooms in)"))))
 
-(deftest zoomable-skips-affordance-at-root
-  ;; The root displayed node (relative path `[]`) does NOT carry a
-  ;; zoom affordance — zooming into the current root is a no-op.
+(deftest zoomable-skips-zoom-target-at-root
+  ;; The root displayed node (relative path `[]`) is NOT a zoom target —
+  ;; zooming into the current root is a no-op.
   (let [v {:a 1 :b 2}
         h (ei/render-node {:value v
                            :panel-id :p
@@ -2706,20 +2766,14 @@
                            :expansion-map {}
                            :zoomable? true
                            :zoom-path-prefix []
-                           :opts {:default-expanded-depth 0}})
-        all-zoom-buttons (filter (fn [n]
-                                   (and (vector? n)
-                                        (map? (second n))
-                                        (= "zoom" (:data-rf-affordance (second n)))))
-                                 (walk-hiccup h))]
+                           :opts {:default-expanded-depth 0}})]
     ;; With depth-0 expansion the root is collapsed → only one node
-    ;; renders. If the root had emitted an affordance we'd see one
-    ;; button; we expect zero.
-    (is (zero? (count all-zoom-buttons))
-        "root container at relative-path [] does NOT render a zoom button")))
+    ;; renders. The root must NOT be a zoom target.
+    (is (zero? (count (zoom-target-nodes h)))
+        "root container at relative-path [] is NOT a zoom target")))
 
-(deftest zoomable-skips-affordance-when-opt-off
-  ;; `:zoomable? false` (the default) suppresses the affordance even on
+(deftest zoomable-skips-zoom-target-when-opt-off
+  ;; `:zoomable? false` (the default) suppresses the gesture even on
   ;; deep nested containers.
   (let [v {:a {:b {:c 1}}}
         h (ei/render-node {:value v
@@ -2728,96 +2782,131 @@
                            :path []
                            :depth 0
                            :expansion-map {}
-                           :opts {:default-expanded-depth 8}})
-        all-zoom-buttons (filter (fn [n]
-                                   (and (vector? n)
-                                        (map? (second n))
-                                        (= "zoom" (:data-rf-affordance (second n)))))
-                                 (walk-hiccup h))]
-    (is (zero? (count all-zoom-buttons))
-        "with :zoomable? off no node emits a zoom affordance")))
+                           :opts {:default-expanded-depth 8}})]
+    (is (zero? (count (zoom-target-nodes h)))
+        "with :zoomable? off no node is a zoom target")
+    (is (empty? (glyph-nodes h))
+        "and certainly no glyph")))
 
 (defn- with-captured-dispatch-spy
-  "Build the affordance with a captured-dispatcher STUB as its
-  `:dispatch-fn`, click it, and capture the dispatched event vector
-  WITHOUT spinning up the router. `make-btn` is `(fn [spy] hiccup)`.
-  Returns the captured single-arg event vector.
+  "Build the zoom-trigger attrs with a captured-dispatcher STUB as its
+  `:dispatch-fn`, FIRE the named gesture, and capture the dispatched
+  event vector WITHOUT spinning up the router. `make-attrs` is
+  `(fn [spy] attrs-map)`; `gesture` is `:on-double-click` or
+  `:on-key-down`; `evt` is the synthetic DOM event (nil → a stub that
+  satisfies the Enter predicate). Returns `{:event ... :attrs ...}`.
 
-  Per rf2-r0o63 — the post-fix `zoom-affordance-button` dispatches
-  through the SUPPLIED frame-aware dispatcher (the one the surrounding
-  `reg-view` body captured via `(rf/dispatcher)`), NOT a bare
-  `rf/dispatch` with a `{:frame :rf/xray}` literal. The dispatcher
-  closure already bound the instance frame at render time; this stub
-  stands in for it."
-  [make-btn]
-  (let [captured (atom nil)
-        spy      (fn [ev] (reset! captured ev))
-        h        (make-btn spy)
-        on-click (-> h second :on-click)]
-    (on-click nil)
-    {:event @captured :on-click on-click}))
+  Per rf2-r0o63 — the gesture dispatches through the SUPPLIED frame-aware
+  dispatcher (the one the surrounding `reg-view` body captured via
+  `(rf/dispatcher)`), NOT a bare `rf/dispatch` with a `{:frame :rf/xray}`
+  literal. The dispatcher closure already bound the instance frame at
+  render time; this stub stands in for it."
+  ([make-attrs] (with-captured-dispatch-spy make-attrs :on-double-click nil))
+  ([make-attrs gesture evt]
+   (let [captured (atom nil)
+         spy      (fn [ev] (reset! captured ev))
+         attrs    (make-attrs spy)
+         handler  (get attrs gesture)
+         ;; Enter handler needs a key-bearing event; dblclick ignores it.
+         event    (or evt
+                      (when (= gesture :on-key-down)
+                        (js-obj "key" "Enter"
+                                "ctrlKey" false "metaKey" false
+                                "altKey" false "shiftKey" false
+                                "preventDefault" (fn [])
+                                "stopPropagation" (fn []))))]
+     (handler event)
+     {:event @captured :attrs attrs})))
 
-(deftest zoom-affordance-button-dispatches-zoom-to-with-absolute-path
-  (let [{:keys [event on-click]}
+(deftest zoom-trigger-double-click-dispatches-zoom-to-with-absolute-path
+  (let [{:keys [event attrs]}
         (with-captured-dispatch-spy
           (fn [spy]
-            (ei/zoom-affordance-button
+            (ei/zoom-trigger-attrs
               {:dispatch-fn   spy
                :panel-id      :p
                :mount-id      "m"
-               :absolute-path [:a :b :c]
-               :testid        "rf-xray-edn-inspector-zoom-aff"})))]
-    (is (some? on-click) "button carries an on-click handler")
+               :absolute-path [:a :b :c]})))]
+    (is (fn? (:on-double-click attrs)) "carries a double-click handler")
     (is (= [:rf.xray.edn-inspector/zoom-to :p "m" [:a :b :c]] event)
-        "click dispatches the canonical zoom-to event with the absolute path")))
+        "double-click dispatches the canonical zoom-to with the absolute path")))
 
-(deftest zoom-affordance-button-onclick-dispatches-through-captured-dispatcher
-  ;; rf2-r0o63 — supersedes the rf2-kcaiz pin. The zoom-affordance click
-  ;; handler dispatches through the SUPPLIED frame-aware dispatcher (the
-  ;; one the surrounding reg-view body captured via `(rf/dispatcher)` at
-  ;; render time), so the zoom-slot write lands on the instance frame.
-  ;; The captured closure bound the frame synchronously during render,
-  ;; so React's synthetic-event timing popping the dynamic context after
-  ;; render does NOT leak the dispatch — and no `:rf/xray` literal
-  ;; entrenches the singleton (N shells stay isolated).
-  (testing "rf2-r0o63 — clicking the zoom-affordance dispatches
-            `[:rf.xray.edn-inspector/zoom-to ...]` through the captured
-            dispatcher (single-arg event vector; frame baked into the
-            closure, not a `{:frame :rf/xray}` literal)"
+(deftest zoom-trigger-enter-key-dispatches-zoom-to
+  ;; rf2-zl4rs — Enter on the focused node is the keyboard a11y path the
+  ;; removed glyph button used to provide.
+  (let [{:keys [event]}
+        (with-captured-dispatch-spy
+          (fn [spy]
+            (ei/zoom-trigger-attrs
+              {:dispatch-fn   spy
+               :panel-id      :p
+               :mount-id      "m"
+               :absolute-path [:a :b]}))
+          :on-key-down nil)]
+    (is (= [:rf.xray.edn-inspector/zoom-to :p "m" [:a :b]] event)
+        "Enter dispatches the canonical zoom-to with the absolute path")))
+
+(deftest zoom-trigger-enter-ignores-modifiers-and-other-keys
+  ;; A bare Enter zooms; Ctrl/Cmd/Alt/Shift+Enter and non-Enter keys do
+  ;; NOT — so Esc-zoom-out + the spine bindings (j/k/L/G) pass through.
+  (let [mk (fn [opts]
+             (js-obj "key" (:key opts)
+                     "ctrlKey" (boolean (:ctrl? opts))
+                     "metaKey" (boolean (:meta? opts))
+                     "altKey"  (boolean (:alt? opts))
+                     "shiftKey" (boolean (:shift? opts))
+                     "preventDefault" (fn [])
+                     "stopPropagation" (fn [])))]
+    (doseq [evt [(mk {:key "Enter" :ctrl? true})
+                 (mk {:key "Enter" :meta? true})
+                 (mk {:key "Enter" :alt? true})
+                 (mk {:key "Enter" :shift? true})
+                 (mk {:key "Escape"})
+                 (mk {:key "j"})
+                 (mk {:key "k"})]]
+      (let [{:keys [event]}
+            (with-captured-dispatch-spy
+              (fn [spy]
+                (ei/zoom-trigger-attrs
+                  {:dispatch-fn spy :panel-id :p :mount-id "m"
+                   :absolute-path [:a]}))
+              :on-key-down evt)]
+        (is (nil? event)
+            (str "key " (.-key evt) " (modifiers held: "
+                 (.-ctrlKey evt) (.-metaKey evt) (.-altKey evt) (.-shiftKey evt)
+                 ") must NOT trigger zoom"))))))
+
+(deftest zoom-trigger-dispatches-through-captured-dispatcher
+  ;; rf2-r0o63 — supersedes the rf2-kcaiz pin. The gesture dispatches
+  ;; through the SUPPLIED frame-aware dispatcher so the zoom-slot write
+  ;; lands on the instance frame — single-arg event vector, frame baked
+  ;; into the closure, NOT a `{:frame :rf/xray}` literal.
+  (testing "rf2-r0o63 — the zoom gesture dispatches a single-arg
+            `[:rf.xray.edn-inspector/zoom-to ...]` (no `{:frame :rf/xray}`)"
     (let [{:keys [event]}
           (with-captured-dispatch-spy
             (fn [spy]
-              (ei/zoom-affordance-button
+              (ei/zoom-trigger-attrs
                 {:dispatch-fn   spy
                  :panel-id      :rf.xray/app-db
                  :mount-id      "m-1"
-                 :absolute-path [:cart :items 0]
-                 :testid        "x"})))
+                 :absolute-path [:cart :items 0]})))
           [event-id panel-id mount-id path] event]
-      (is (= :rf.xray.edn-inspector/zoom-to event-id)
-          "canonical event id")
-      (is (= :rf.xray/app-db panel-id)
-          "panel-id flows through as second positional arg")
-      (is (= "m-1" mount-id)
-          "mount-id flows through as third positional arg")
-      (is (= [:cart :items 0] path)
-          "absolute path flows through as fourth positional arg")
+      (is (= :rf.xray.edn-inspector/zoom-to event-id) "canonical event id")
+      (is (= :rf.xray/app-db panel-id) "panel-id flows through")
+      (is (= "m-1" mount-id) "mount-id flows through")
+      (is (= [:cart :items 0] path) "absolute path flows through")
       (is (= 4 (count event))
-          "rf2-r0o63 — dispatch is a single-arg event vector; the frame
-           is captured in the dispatcher closure, not a `{:frame :rf/xray}`
-           literal at the call site"))))
+          "rf2-r0o63 — single-arg event vector; the frame is captured in
+           the dispatcher closure, not a `{:frame :rf/xray}` literal"))))
 
-(deftest zoom-affordance-composes-prefix-and-relative-path
-  ;; The renderer threads the absolute path = (into zoom-path-prefix path)
-  ;; into the affordance — so when the operator is already zoomed at
-  ;; `[:rf/runtime :machines :snapshots]` and clicks the affordance on the
-  ;; nested `:ws/connection` container (relative path `[:ws/connection]`),
-  ;; the dispatch carries the FULL absolute path
-  ;; `[:rf/runtime :machines :snapshots :ws/connection]`.
+(deftest zoom-trigger-composes-prefix-and-relative-path
+  ;; render-container threads the absolute path = (into zoom-path-prefix
+  ;; path) into the gesture — so when the operator is already zoomed at
+  ;; `[:rf/runtime :machines :snapshots]` and double-clicks the nested
+  ;; `:ws/connection` container (relative path `[:ws/connection]`), the
+  ;; dispatch carries the FULL absolute path.
   (let [v {:ws/connection {:state :open}}
-        ;; Drive the renderer with a non-trivial zoom-path-prefix to
-        ;; simulate "we're already zoomed into machine snapshots and
-        ;; looking at its child :ws/connection".
         h (ei/render-node {:value v
                            :panel-id :p
                            :mount-id "m"
@@ -2827,25 +2916,21 @@
                            :zoomable? true
                            :zoom-path-prefix [:rf/runtime :machines :snapshots]
                            :opts {:default-expanded-depth 8}})
-        affordance (find-attr h :data-rf-affordance "zoom")]
-    (is (some? affordance)
-        "the recursive walker emits a zoom affordance on the displayed root's
-         children even when `:zoom-path-prefix` is non-empty")
-    (is (= "zoom" (-> affordance second :data-rf-affordance))
-        "data-rf-affordance attribute is 'zoom'")
-    ;; Confirm via integration: re-build the affordance the same way
-    ;; render-container does, mirroring the zoom-path-prefix + path
-    ;; composition.
+        targets (zoom-target-nodes h)]
+    (is (seq targets)
+        "the child container is a zoom target even when zoom-path-prefix
+         is non-empty")
+    ;; Confirm via the factory directly, mirroring render-container's
+    ;; (into zoom-path-prefix path) composition.
     (let [composed (vec (concat [:rf/runtime :machines :snapshots] [:ws/connection]))
           {:keys [event]}
           (with-captured-dispatch-spy
             (fn [spy]
-              (ei/zoom-affordance-button
+              (ei/zoom-trigger-attrs
                 {:dispatch-fn   spy
                  :panel-id      :p
                  :mount-id      "m"
-                 :absolute-path composed
-                 :testid        "x"})))]
+                 :absolute-path composed})))]
       (is (= [:rf.xray.edn-inspector/zoom-to :p "m"
               [:rf/runtime :machines :snapshots :ws/connection]]
              event)
@@ -2991,12 +3076,13 @@
            whole point of zoom"))
     (rf/dispatch-sync [:rf.xray.edn-inspector/zoom-reset])))
 
-(deftest widget-diff-mode-suppresses-zoom
-  ;; Diff mode (`:before` present) renders the FULL value regardless of
-  ;; an active zoom path — the diff path's force-expand-over-changes
-  ;; logic and zoom's hide-everything-outside the subtree are
-  ;; conflicting intents. Operator viewing a diff sees the whole value;
-  ;; non-diff browse can zoom.
+(deftest widget-diff-mode-zooms-and-reroots-both-halves
+  ;; rf2-zl4rs — zoom now applies in the SINGLE full+diff renderer.
+  ;; A zoom in diff mode re-roots `value` AND `before` onto the same
+  ;; subtree, so the operator focuses the changed subtree with its diff
+  ;; annotations intact — siblings outside the subtree are hidden, and
+  ;; the re-rooted before still feeds the projection so the change paints.
+  ;; (Supersedes the rf2-h71e0 "diff suppresses zoom" behaviour.)
   (rf/dispatch-sync [:rf.xray.edn-inspector/zoom-reset])
   (let [site-id [:rf.xray/app-db "top"]
         _ (rf/dispatch-sync [:rf.xray.edn-inspector/zoom-to
@@ -3011,11 +3097,18 @@
                                       :header   [:span "app-db"]})
         attrs  (-> h second)
         text   (collect-text h)]
-    (is (nil? (:data-rf-zoomed attrs))
-        ":data-rf-zoomed absent in diff mode even when zoom-slot is populated")
-    (is (re-find #":sibling" text)
-        "diff mode renders the FULL value (siblings outside the would-be
-         zoom subtree are visible)")
+    (is (= "1" (:data-rf-zoomed attrs))
+        ":data-rf-zoomed=1 in diff mode — zoom applies in the unified renderer")
+    (is (= (pr-str [:nested]) (:data-rf-zoom-path attrs))
+        ":data-rf-zoom-path carries the stored path even with a :before")
+    (is (re-find #":deep" text)
+        "the zoomed subtree's leaf renders in the body")
+    (is (not (re-find #":sibling" text))
+        "siblings OUTSIDE the zoom subtree are hidden — even in diff mode")
+    (is (re-find #"42" text) "the after-side leaf value renders")
+    (is (re-find #"41" text)
+        "the re-rooted before's prior leaf renders too — diff annotation
+         survives the zoom (before re-rooted along the same path)")
     (rf/dispatch-sync [:rf.xray.edn-inspector/zoom-reset])))
 
 (deftest zoom-persists-across-mount-unmount-via-site-id

--- a/tools/xray/testbeds/panel_gallery/gallery_edn_inspector.cljs
+++ b/tools/xray/testbeds/panel_gallery/gallery_edn_inspector.cljs
@@ -230,8 +230,9 @@
 
   ;; ----- opts demos ---------------------------------------------------
   (story/reg-variant :story.xray.edn-inspector/opts-zoomable
-    {:doc        "`:zoomable? true` (rf2-h71e0) — each container
-                 gains a `⊙` zoom button beside the expand triangle."
+    {:doc        "`:zoomable? true` (rf2-h71e0; gesture rf2-zl4rs) —
+                 double-click a container (or press Enter while it is
+                 focused) to re-root the inspector onto it. No glyph."
      :events     [[:panel-gallery.edn-inspector/seed! (fixtures/opts-zoomable)]]
      :tags       #{:dev :feature/opts}
      :substrates #{:reagent}})


### PR DESCRIPTION
## Summary

Reworks the edn-inspector's zoom-into-node UX (`tools/xray/`, App-DB the canonical consumer).

- **Removes the per-container `⊙` zoom glyph button** entirely (`zoom-affordance-button` / `-glyph` / `-style` gone).
- **Zoom-in is now a node-local gesture** on the container itself: **double-click** (`preventDefault` + `stopPropagation` so the innermost node wins) or **Enter** while the node is keyboard-focused. Each non-empty non-root container's outer div carries `:on-double-click` + `:on-key-down` + `tab-index 0` + an `aria-label` + `data-rf-zoom-target`. `role="button"` is deliberately omitted to avoid a button-in-button ARIA nesting violation (the container already nests its `role="button"` expand triangle) — a focusable labelled region is the correct shape for a composite node.
- **Zoom now applies in the single full+diff renderer** (rf2-e28r3): `zoom-active?` drops its `NOT diff?` clause; `value` re-roots along the stored path always, `before` re-roots the same way when a pre-image is present. The projection recomputes over the re-rooted pair so the diff rail / chip / inline `← was X` annotations paint relative to the zoomed subtree. A wholly-`:added` subtree reads `:added`; a stale path falls back to the full value.
- **Breadcrumb + Esc still zoom out** (now in diff mode too).
- Dispatch flows through the captured frame-aware `dispatch-fn` (rf2-r0o63), **not** a `:rf/xray` literal — the frame-singleton guard stays green and N shells stay isolated.

The bead's line refs (3028/3034-3038) were stale (#2402/#2403 rewrote the file); zoom code re-located fresh.

## Files

- `views/edn_inspector.cljs` — `zoom-trigger-attrs` factory replaces the glyph button; merged onto each zoomable container's div; `zoom-active?` clause change + `:before` re-root.
- `panels/app_db_diff_state.cljs` — comment updated (no behaviour change; `:zoomable? true` constant as before).
- `testbeds/panel_gallery/gallery_edn_inspector.cljs` — variant doc updated.
- `tools/xray/spec/021-Dynamic-Panel-Designs.md` §10.0.11 — gesture + single-renderer contract.
- tests — assert no glyph renders, non-root container is a `data-rf-zoom-target` with handlers, double-click + Enter both dispatch `zoom-to` (Enter rejects modifiers + non-Enter keys), diff-mode zoom re-roots both halves.

## Quality gates

- `cd tools/xray && clojure -M:test` — **969 tests, 0 failures** (frame-singleton-guard + two_instance_isolation green).
- `cd implementation && npm run test:cljs` — **4832 tests, 0 failures** (reworked + new zoom view tests).
- `cd implementation && npm run test:xray-feature-gate` — **14 scenarios, 0 failures, 13 matrix rows** (after clearing a stale http-server holding port 8037).
- `bash scripts/test-fast-pr.sh` — **PASS fast PR spine**.