### PR TITLE
refactor(xray): consolidate static-panel search-box + filter-rows into shared helpers (rf2-1keg3)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/static/flows/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/flows/panel.cljs
@@ -48,6 +48,7 @@
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
+            [day8.re-frame2-xray.static.shared.search-box :as search-box]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens type-scale mono-stack sans-stack]]
             [day8.re-frame2-xray.views.edn-widget.widget :as edn]))
@@ -116,11 +117,7 @@
   "Substring filter against flow-id + frame + inputs + path + doc.
   Empty / blank query returns rows verbatim."
   [rows query]
-  (let [q (some-> query str/trim)]
-    (if (or (nil? q) (= "" q))
-      rows
-      (let [needle (str/lower-case q)]
-        (filterv #(str/includes? (row-haystack %) needle) rows)))))
+  (search-box/filter-rows row-haystack rows query))
 
 (defn project-data
   "View-facing composite. Folds the registered-flows map + UI controls
@@ -161,47 +158,18 @@
   [query total filtered?]
   ;; rf2-nesy9 — render-time frame capture so the deferred search input
   ;; dispatches into the surrounding instance frame (rendered inside the
-  ;; flows Panel reg-view), not a `:rf/xray` literal.
+  ;; flows Panel reg-view), not a `:rf/xray` literal. rf2-1keg3 — the
+  ;; flex-row markup lives in the shared `search-box` component.
   (let [frame (rf/current-frame)]
-   [:div {:data-testid "rf-xray-static-flows-search"
-         :style       {:display       "flex"
-                       :align-items   "center"
-                       :gap           "8px"
-                       :padding       "8px 16px"
-                       :border-bottom (str "1px solid " (:border-subtle tokens))
-                       :font-family   sans-stack}}
-   [:label {:style {:color          (:text-tertiary tokens)
-                    :font-size      "10px"
-                    :text-transform "uppercase"
-                    :letter-spacing "0.5px"
-                    :min-width      "60px"}}
-    "Search"]
-   [:input {:type        "text"
-            :data-testid "rf-xray-static-flows-search-input"
-            :placeholder "flow-id, path, or doc…"
-            :value       (or query "")
-            :on-change   (fn [e]
-                           (rf/dispatch [:rf.xray.static.flows/set-query
-                                         (-> e .-target .-value)]
-                                        {:frame frame}))
-            :style       {:flex          1
-                          :background    (:bg-3 tokens)
-                          :color         (:text-primary tokens)
-                          :border        (str "1px solid " (:border-default tokens))
-                          :border-radius "3px"
-                          :padding       "4px 8px"
-                          :font-family   mono-stack
-                          :font-size     "12px"}}]
-   [:span {:data-testid "rf-xray-static-flows-search-count"
-           :style       {:color       (:text-tertiary tokens)
-                         :font-family mono-stack
-                         :font-size   "11px"
-                         :min-width   "80px"
-                         :text-align  "right"}}
-    (cond
-      filtered?     "match"
-      (= 1 total)   "1 flow"
-      :else         (str total " flows"))]]))
+    [search-box/search-box
+     {:testid-prefix   "rf-xray-static-flows"
+      :dispatch        (fn [ev] (rf/dispatch ev {:frame frame}))
+      :set-query-event :rf.xray.static.flows/set-query
+      :placeholder     "flow-id, path, or doc…"
+      :value           query
+      :count-noun      "flow"
+      :total           total
+      :filtered?       filtered?}]))
 
 ;; ---- row -----------------------------------------------------------------
 

--- a/tools/xray/src/day8/re_frame2_xray/static/interceptors/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/interceptors/panel.cljs
@@ -39,6 +39,7 @@
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
+            [day8.re-frame2-xray.static.shared.search-box :as search-box]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens type-scale mono-stack sans-stack]]))
 
@@ -81,11 +82,7 @@
 
 (defn filter-rows
   [rows query]
-  (let [q (some-> query str/trim)]
-    (if (or (nil? q) (= "" q))
-      rows
-      (let [needle (str/lower-case q)]
-        (filterv #(str/includes? (row-haystack %) needle) rows)))))
+  (search-box/filter-rows row-haystack rows query))
 
 (defn project-data
   [registrations-map query]
@@ -111,47 +108,19 @@
 (defn- search-box
   [query total filtered?]
   ;; rf2-nesy9 — render-time frame capture (rendered inside the
-  ;; interceptors Panel reg-view), not a `:rf/xray` literal.
+  ;; interceptors Panel reg-view), not a `:rf/xray` literal. rf2-1keg3 —
+  ;; the flex-row markup lives in the shared `search-box` component.
   (let [frame (rf/current-frame)]
-   [:div {:data-testid "rf-xray-static-interceptors-search"
-         :style       {:display       "flex"
-                       :align-items   "center"
-                       :gap           "8px"
-                       :padding       "8px 16px"
-                       :border-bottom (str "1px solid " (:border-subtle tokens))
-                       :font-family   sans-stack}}
-   [:label {:style {:color          (:text-tertiary tokens)
-                    :font-size      "10px"
-                    :text-transform "uppercase"
-                    :letter-spacing "0.5px"
-                    :min-width      "60px"}}
-    "Search"]
-   [:input {:type        "text"
-            :data-testid "rf-xray-static-interceptors-search-input"
-            :placeholder "interceptor-id or doc…"
-            :value       (or query "")
-            :on-change   (fn [e]
-                           (rf/dispatch [:rf.xray.static.interceptors/set-query
-                                         (-> e .-target .-value)]
-                                        {:frame frame}))
-            :style       {:flex          1
-                          :background    (:bg-3 tokens)
-                          :color         (:text-primary tokens)
-                          :border        (str "1px solid " (:border-default tokens))
-                          :border-radius "3px"
-                          :padding       "4px 8px"
-                          :font-family   mono-stack
-                          :font-size     "12px"}}]
-   [:span {:data-testid "rf-xray-static-interceptors-search-count"
-           :style       {:color       (:text-tertiary tokens)
-                         :font-family mono-stack
-                         :font-size   "11px"
-                         :min-width   "90px"
-                         :text-align  "right"}}
-    (cond
-      filtered?     "match"
-      (= 1 total)   "1 interceptor"
-      :else         (str total " interceptors"))]]))
+    [search-box/search-box
+     {:testid-prefix   "rf-xray-static-interceptors"
+      :dispatch        (fn [ev] (rf/dispatch ev {:frame frame}))
+      :set-query-event :rf.xray.static.interceptors/set-query
+      :placeholder     "interceptor-id or doc…"
+      :value           query
+      :count-noun      "interceptor"
+      :total           total
+      :filtered?       filtered?
+      :count-min-width "90px"}]))
 
 ;; ---- row -----------------------------------------------------------------
 

--- a/tools/xray/src/day8/re_frame2_xray/static/machines/browse_list.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/browse_list.cljs
@@ -25,6 +25,7 @@
             [day8.re-frame2-xray.open-in-editor :as open-in-editor]
             [day8.re-frame2-xray.static.machines.helpers :as h]
             [day8.re-frame2-xray.static.machines.instances-jump :as jump]
+            [day8.re-frame2-xray.static.shared.search-box :as search-box]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens sans-stack mono-stack type-scale]]))
 
@@ -36,35 +37,20 @@
 
   `dispatch` (rf2-nesy9) is the frame-aware dispatcher threaded from the
   `browse-list` reg-view (a plain fn invoked as a Reagent component
-  renders in its own cycle, so it cannot recover the frame itself)."
+  renders in its own cycle, so it cannot recover the frame itself).
+  rf2-1keg3 — the markup lives in the shared `search-box` component's
+  `:pane` variant."
   [dispatch]
   (let [query @(rf/subscribe [:rf.xray.static.machines/search])]
-    [:div {:data-testid "rf-xray-static-machines-search"
-           :style {:padding "8px 10px"
-                   :border-bottom (str "1px solid " (:border-subtle tokens))
-                   :background    (:bg-1 tokens)}}
-     [:input {:data-testid "rf-xray-static-machines-search-input"
-              :type        "search"
-              :value       (or query "")
-              :placeholder "Search machines…"
-              :aria-label  "Search registered machines"
-              :on-change   (fn [^js e]
-                             (dispatch
-                               [:rf.xray.static.machines/set-search
-                                (.. e -target -value)]))
-              :on-key-down (fn [^js e]
-                             (when (= "Escape" (.-key e))
-                               (dispatch
-                                 [:rf.xray.static.machines/clear-search])))
-              :style {:width        "100%"
-                      :background   (:bg-2 tokens)
-                      :border       (str "1px solid " (:border-default tokens))
-                      :border-radius "4px"
-                      :color        (:text-primary tokens)
-                      :font-family  sans-stack
-                      :font-size    (:body-tight type-scale)
-                      :padding      "4px 8px"
-                      :box-sizing   "border-box"}}]]))
+    [search-box/search-box
+     {:variant          :pane
+      :testid-prefix    "rf-xray-static-machines"
+      :dispatch         dispatch
+      :set-query-event  :rf.xray.static.machines/set-search
+      :on-clear-event   :rf.xray.static.machines/clear-search
+      :placeholder      "Search machines…"
+      :input-aria-label "Search registered machines"
+      :value            query}]))
 
 ;; ---- sort cycle button --------------------------------------------------
 

--- a/tools/xray/src/day8/re_frame2_xray/static/routes/browse_list.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/routes/browse_list.cljs
@@ -24,6 +24,7 @@
   enclosing frame-provider in `static/shell.cljs`."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-xray.static.routes.row-expand :as row-expand]
+            [day8.re-frame2-xray.static.shared.search-box :as search-box]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens mono-stack sans-stack]]))
 
@@ -60,49 +61,23 @@
 (defn- search-box
   "Substring filter. Matches against route-id + path + doc via
   `routing-helpers/filter-rows`. State on
-  `:rf.xray.static.routes/query`."
+  `:rf.xray.static.routes/query`.
+
+  rf2-nesy9 — `dispatch` threaded from the routes `Panel` reg-view (via
+  `render`), not a render-time capture (this whole subtree is invoked as
+  a Reagent component and cannot recover the frame). rf2-1keg3 — the
+  flex-row markup lives in the shared `search-box` component."
   [dispatch query total-routes filtered?]
-  ;; rf2-nesy9 — `dispatch` threaded from the routes `Panel` reg-view
-  ;; (via `render`), not a render-time capture (this whole subtree is
-  ;; invoked as a Reagent component and cannot recover the frame).
-  [:div {:data-testid "rf-xray-static-routes-search"
-         :style       {:display       "flex"
-                       :align-items   "center"
-                       :gap           "8px"
-                       :padding       "8px 16px"
-                       :border-bottom (str "1px solid " (:border-subtle tokens))
-                       :font-family   sans-stack}}
-   [:label {:style {:color          (:text-tertiary tokens)
-                    :font-size      "10px"
-                    :text-transform "uppercase"
-                    :letter-spacing "0.5px"
-                    :min-width      "60px"}}
-    "Search"]
-   [:input {:type        "text"
-            :data-testid "rf-xray-static-routes-search-input"
-            :placeholder "route-id, path, or doc…"
-            :value       (or query "")
-            :on-change   (fn [e]
-                           (dispatch [:rf.xray.static.routes/set-query
-                                      (-> e .-target .-value)]))
-            :style       {:flex          1
-                          :background    (:bg-3 tokens)
-                          :color         (:text-primary tokens)
-                          :border        (str "1px solid " (:border-default tokens))
-                          :border-radius "3px"
-                          :padding       "4px 8px"
-                          :font-family   mono-stack
-                          :font-size     "12px"}}]
-   [:span {:data-testid "rf-xray-static-routes-search-count"
-           :style       {:color       (:text-tertiary tokens)
-                         :font-family mono-stack
-                         :font-size   "11px"
-                         :min-width   "60px"
-                         :text-align  "right"}}
-    (cond
-      filtered?              "match"
-      (= 1 total-routes)     "1 route"
-      :else                  (str total-routes " routes"))]])
+  [search-box/search-box
+   {:testid-prefix   "rf-xray-static-routes"
+    :dispatch        dispatch
+    :set-query-event :rf.xray.static.routes/set-query
+    :placeholder     "route-id, path, or doc…"
+    :value           query
+    :count-noun      "route"
+    :total           total-routes
+    :filtered?       filtered?
+    :count-min-width "60px"}])
 
 (defn- route-row
   "One row in the flat catalogue. No marker chip, no `:here` glyph —

--- a/tools/xray/src/day8/re_frame2_xray/static/schemas/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/schemas/panel.cljs
@@ -57,6 +57,7 @@
             [re-frame.schemas :as schemas]
             [day8.re-frame2-xray.open-in-editor :as open-in-editor]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
+            [day8.re-frame2-xray.static.shared.search-box :as search-box]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens type-scale mono-stack sans-stack]]
             [day8.re-frame2-xray.views.edn-widget.widget :as edn]))
@@ -138,11 +139,7 @@
 
 (defn filter-rows
   [rows query]
-  (let [q (some-> query str/trim)]
-    (if (or (nil? q) (= "" q))
-      rows
-      (let [needle (str/lower-case q)]
-        (filterv #(str/includes? (row-haystack %) needle) rows)))))
+  (search-box/filter-rows row-haystack rows query))
 
 (defn project-data
   "View-facing composite. `frame-id` scopes the per-frame app-db
@@ -173,47 +170,18 @@
 (defn- search-box
   [query total filtered?]
   ;; rf2-nesy9 — render-time frame capture (rendered inside the schemas
-  ;; Panel reg-view), not a `:rf/xray` literal.
+  ;; Panel reg-view), not a `:rf/xray` literal. rf2-1keg3 — the flex-row
+  ;; markup lives in the shared `search-box` component.
   (let [frame (rf/current-frame)]
-   [:div {:data-testid "rf-xray-static-schemas-search"
-         :style       {:display       "flex"
-                       :align-items   "center"
-                       :gap           "8px"
-                       :padding       "8px 16px"
-                       :border-bottom (str "1px solid " (:border-subtle tokens))
-                       :font-family   sans-stack}}
-   [:label {:style {:color          (:text-tertiary tokens)
-                    :font-size      "10px"
-                    :text-transform "uppercase"
-                    :letter-spacing "0.5px"
-                    :min-width      "60px"}}
-    "Search"]
-   [:input {:type        "text"
-            :data-testid "rf-xray-static-schemas-search-input"
-            :placeholder "kind, id, frame, or doc…"
-            :value       (or query "")
-            :on-change   (fn [e]
-                           (rf/dispatch [:rf.xray.static.schemas/set-query
-                                         (-> e .-target .-value)]
-                                        {:frame frame}))
-            :style       {:flex          1
-                          :background    (:bg-3 tokens)
-                          :color         (:text-primary tokens)
-                          :border        (str "1px solid " (:border-default tokens))
-                          :border-radius "3px"
-                          :padding       "4px 8px"
-                          :font-family   mono-stack
-                          :font-size     "12px"}}]
-   [:span {:data-testid "rf-xray-static-schemas-search-count"
-           :style       {:color       (:text-tertiary tokens)
-                         :font-family mono-stack
-                         :font-size   "11px"
-                         :min-width   "80px"
-                         :text-align  "right"}}
-    (cond
-      filtered?     "match"
-      (= 1 total)   "1 schema"
-      :else         (str total " schemas"))]]))
+    [search-box/search-box
+     {:testid-prefix   "rf-xray-static-schemas"
+      :dispatch        (fn [ev] (rf/dispatch ev {:frame frame}))
+      :set-query-event :rf.xray.static.schemas/set-query
+      :placeholder     "kind, id, frame, or doc…"
+      :value           query
+      :count-noun      "schema"
+      :total           total
+      :filtered?       filtered?}]))
 
 ;; ---- row -----------------------------------------------------------------
 

--- a/tools/xray/src/day8/re_frame2_xray/static/shared/search_box.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/shared/search_box.cljs
@@ -1,0 +1,209 @@
+(ns day8.re-frame2-xray.static.shared.search-box
+  "Shared search-box + substring `filter-rows` algebra for the Static
+  surface's flat-catalogue sub-tabs (rf2-1keg3).
+
+  ## Why this exists (rf2-nesy9 dedup follow-on, Cluster 1 + 2)
+
+  Five Static sub-tabs each grow a flat searchable catalogue — Flows,
+  Interceptors, Schemas, Routes (the browse list), and Machines (the
+  browse list). Before this ns they each carried a private
+  `defn- search-box` that re-implemented the same skeleton: an
+  `<input>` dispatching a `set-query` event on every keystroke, wrapped
+  in a header row. Two layout variants existed:
+
+    - the `:catalogue` variant (Flows / Interceptors / Schemas /
+      Routes) — a flex row with a `Search` label and a right-aligned
+      count chip, varying only on the `data-testid` prefix, the
+      set-query event keyword, the placeholder, the count noun, and the
+      count chip's `min-width`;
+    - the `:pane` variant (Machines browse-list) — a block header with
+      a full-width `type=search` input, an Esc-to-clear handler, and an
+      `aria-label`, with no count chip (Machines surfaces its count in a
+      separate toolbar).
+
+  Folding the five into one component drops each call-site from ~40 LoC
+  to ~6 and makes a UX change to the search affordance a one-file edit.
+  The two variants keep each call-site's exact rendered markup — this is
+  a pure refactor, zero visual change.
+
+  ## Frame-correctness (rf2-1w07r EPIC / rf2-nesy9)
+
+  The input's keystroke dispatch is an OUT-OF-RENDER affordance: it
+  fires after render unwinds, when the ambient frame is gone, so a bare
+  global `rf/dispatch` would leak to `:rf/default` and two Xray shells
+  on one page would collide. This component therefore takes a
+  caller-supplied frame-aware `:dispatch` fn and NEVER reaches a bare
+  `{:frame :rf/xray}` literal or a global `rf/dispatch`. Each call-site
+  supplies the dispatcher its own way:
+
+    - Flows / Interceptors / Schemas — these `search-box` call-sites
+      render INSIDE a `reg-view` body, so they render-capture
+      `(rf/current-frame)` and hand down a closure
+      `(fn [ev] (rf/dispatch ev {:frame frame}))`.
+    - Routes / Machines — the browse list is invoked as a plain-fn
+      Reagent component (its own render cycle can't recover the frame),
+      so the routes/machines `reg-view` threads its injected frame-aware
+      `dispatch` straight through.
+
+  Either way the dispatcher is already frame-bound by the time it
+  reaches here; this ns stays a pure presentational helper. The JVM
+  `frame_singleton_guard_test` locks that invariant — no `:rf/xray`
+  literal, no `:on-* #(rf/dispatch …)`.
+
+  ## Pure hiccup
+
+  Same contract as every Xray view — pure hiccup, no Reagent / UIx /
+  Helix references."
+  (:require [clojure.string :as str]
+            [day8.re-frame2-xray.theme.tokens
+             :refer [tokens type-scale mono-stack sans-stack]]))
+
+;; ---- filter-rows algebra (Cluster 2) ------------------------------------
+
+(defn filter-rows
+  "Higher-order substring filter shared by the Flows / Interceptors /
+  Schemas catalogues. `row->haystack` projects a row to the lower-cased
+  string the needle is matched against (each tab supplies its own —
+  flow-id + frame + paths + doc for Flows, kind + id + schema for
+  Schemas, …). A nil / blank query returns `rows` verbatim. Pure data —
+  JVM-runnable, so each tab's projection tests cover it without a CLJS
+  runtime."
+  [row->haystack rows query]
+  (let [q (some-> query str/trim)]
+    (if (or (nil? q) (= "" q))
+      rows
+      (let [needle (str/lower-case q)]
+        (filterv #(str/includes? (row->haystack %) needle) rows)))))
+
+;; ---- count chip ---------------------------------------------------------
+
+(defn count-text
+  "The catalogue count-chip text: `\"match\"` while a query is filtering,
+  else a `noun`-pluralised total (`\"1 flow\"` / `\"7 flows\"`). `noun`
+  is the singular form; the plural appends `\"s\"` (every Static noun —
+  flow / interceptor / schema / route — pluralises that way). Pure —
+  JVM-runnable for the projection tests."
+  [noun total filtered?]
+  (cond
+    filtered?   "match"
+    (= 1 total) (str "1 " noun)
+    :else       (str total " " noun "s")))
+
+;; ---- per-variant style maps ---------------------------------------------
+
+(def ^:private catalogue-container-style
+  "Flex-row header for the Flows / Interceptors / Schemas / Routes
+  catalogue search box."
+  {:display       "flex"
+   :align-items   "center"
+   :gap           "8px"
+   :padding       "8px 16px"
+   :border-bottom (str "1px solid " (:border-subtle tokens))
+   :font-family   sans-stack})
+
+(def ^:private catalogue-input-style
+  {:flex          1
+   :background    (:bg-3 tokens)
+   :color         (:text-primary tokens)
+   :border        (str "1px solid " (:border-default tokens))
+   :border-radius "3px"
+   :padding       "4px 8px"
+   :font-family   mono-stack
+   :font-size     "12px"})
+
+(def ^:private pane-container-style
+  "Block header for the Machines browse-list search box — the left-pane
+  list lives below it, the count lives in a separate toolbar."
+  {:padding       "8px 10px"
+   :border-bottom (str "1px solid " (:border-subtle tokens))
+   :background    (:bg-1 tokens)})
+
+(def ^:private pane-input-style
+  {:width         "100%"
+   :background    (:bg-2 tokens)
+   :border        (str "1px solid " (:border-default tokens))
+   :border-radius "4px"
+   :color         (:text-primary tokens)
+   :font-family   sans-stack
+   :font-size     (:body-tight type-scale)
+   :padding       "4px 8px"
+   :box-sizing    "border-box"})
+
+;; ---- search box ---------------------------------------------------------
+
+(defn search-box
+  "Render a Static-surface search box. All knobs arrive in one opts map
+  so the four catalogue tabs and the Machines browse-list share one
+  component. Two layout variants (see the ns docstring) preserve each
+  call-site's exact rendered markup.
+
+  Always-present knobs:
+
+  - `:testid-prefix`   — `data-testid` stem, e.g.
+                         `\"rf-xray-static-flows\"`. The container,
+                         input, and count chip suffix `-search`,
+                         `-search-input`, and `-search-count`.
+  - `:dispatch`        — REQUIRED frame-aware dispatcher (see the ns
+                         docstring on frame-correctness). Called with a
+                         single event vector.
+  - `:set-query-event` — event keyword the keystroke dispatches; the
+                         input's current value is conj'd as the payload.
+  - `:placeholder`     — input placeholder text.
+  - `:value`           — current query string (nil-safe; rendered as
+                         `(or value \"\")`).
+  - `:variant`         — `:catalogue` (default — flex row + label +
+                         count chip) or `:pane` (block header,
+                         full-width `type=search` input, no count chip).
+
+  `:catalogue`-variant knobs:
+
+  - `:count-noun`      — singular noun for the count chip (`\"flow\"`,
+                         `\"route\"`, …); the chip renders
+                         `(count-text noun total filtered?)`.
+  - `:total`           — pre-filter row count.
+  - `:filtered?`       — whether a query is narrowing the list.
+  - `:count-min-width` — `min-width` for the count chip. Defaults to
+                         `\"80px\"`; Interceptors widens it to `\"90px\"`,
+                         Routes narrows it to `\"60px\"`.
+
+  `:pane`-variant knobs:
+
+  - `:on-clear-event`  — event keyword fired when Esc is pressed in the
+                         input.
+  - `:input-aria-label`— `aria-label` on the input."
+  [{:keys [testid-prefix dispatch set-query-event placeholder value variant
+           count-noun total filtered? count-min-width
+           on-clear-event input-aria-label]
+    :or   {variant         :catalogue
+           count-min-width "80px"}}]
+  (let [pane? (= variant :pane)]
+    [:div {:data-testid (str testid-prefix "-search")
+           :style       (if pane? pane-container-style catalogue-container-style)}
+     (when-not pane?
+       [:label {:style {:color          (:text-tertiary tokens)
+                        :font-size      "10px"
+                        :text-transform "uppercase"
+                        :letter-spacing "0.5px"
+                        :min-width      "60px"}}
+        "Search"])
+     [:input (cond-> {:type        (if pane? "search" "text")
+                      :data-testid (str testid-prefix "-search-input")
+                      :placeholder placeholder
+                      :value       (or value "")
+                      :on-change   (fn [^js e]
+                                     (dispatch [set-query-event
+                                                (.. e -target -value)]))
+                      :style       (if pane? pane-input-style catalogue-input-style)}
+               input-aria-label (assoc :aria-label input-aria-label)
+               on-clear-event   (assoc :on-key-down
+                                       (fn [^js e]
+                                         (when (= "Escape" (.-key e))
+                                           (dispatch [on-clear-event])))))]
+     (when (and (not pane?) count-noun)
+       [:span {:data-testid (str testid-prefix "-search-count")
+               :style       {:color       (:text-tertiary tokens)
+                             :font-family mono-stack
+                             :font-size   "11px"
+                             :min-width   count-min-width
+                             :text-align  "right"}}
+        (count-text count-noun total filtered?)])]))


### PR DESCRIPTION
## Summary

rf2-nesy9 dedup follow-on (Cluster 1 + 2). Five Static sub-tabs each carried a private `defn- search-box` whose hiccup was ~95% identical, and three of them repeated a `row-haystack` / `filter-rows` substring trio. This extracts a new shared ns `day8.re-frame2-xray.static.shared.search-box`:

- **`search-box`** — one component, two layout variants: `:catalogue` (Flows / Interceptors / Schemas / Routes — flex row + label + count chip) and `:pane` (Machines browse-list — block header, full-width `type=search` input, Esc-to-clear, no count chip). Each call-site supplies only its knobs (testid prefix, set-query event, placeholder, count noun, count min-width).
- **`filter-rows`** — higher-order substring filter taking a `row->haystack` fn. The flows / interceptors / schemas panels keep a thin 2-arity `filter-rows [rows query]` (preserving the projection-test contract) that delegates with their own haystack projection.
- **`count-text`** — the shared `"match"` / `"1 noun"` / `"N nouns"` chip text.

Each caller drops ~40 LoC → ~6.

## Frame-correctness (rf2-1w07r EPIC)

The keystroke dispatch is an out-of-render affordance, so the shared component takes a caller-supplied **frame-aware `:dispatch`** and holds **no** `{:frame :rf/xray}` literal and **no** global `rf/dispatch`:
- Flows / Interceptors / Schemas render-capture `(rf/current-frame)` and hand down `(fn [ev] (rf/dispatch ev {:frame frame}))`.
- Routes / Machines thread their reg-view-injected `dispatch` straight through.

The JVM `frame_singleton_guard_test` (no `:rf/xray` literal, no `:on-* #(rf/dispatch …)`) stays green and locks the new file clean.

## Pure refactor

Zero behaviour change. Every `data-testid`, style map, and rendered markup is preserved — the two variants encode the exact prior appearance of each call-site.

## LoC before → after (per caller, search-box + filter trio)

| caller | removed | added |
|---|---|---|
| flows/panel.cljs | 45 | 13 |
| interceptors/panel.cljs | 45 | 14 |
| schemas/panel.cljs | 45 | 13 |
| routes/browse_list.cljs | 42 | 17 |
| machines/browse_list.cljs | 27 | 13 |

New shared ns: `tools/xray/src/day8/re_frame2_xray/static/shared/search_box.cljs` (+209, mostly docstring).

## Spec

`tools/xray/spec/*` unchanged — the per-panel `search-box` is a private `defn-` view implementation detail; no spec doc documents a search-box contract (grep for `search-box`/`search_box` across `tools/xray/spec/` returns nothing).

## Quality gates

- `cd tools/xray && clojure -M:test` → **969 tests / 3808 assertions, 0 failures** (incl. frame_singleton_guard_test + projection tests)
- `npm run test:cljs` (xray CLJS view tests + two_instance_isolation) → **4832 tests / 15837 assertions, 0 failures**
- `npm run test:xray-feature-gate` → **14 scenarios, 0 failures, 13 matrix rows**
- `bash scripts/test-fast-pr.sh` → **PASS**