### PR TITLE
fix(xray): triangle dbl-click owns its gesture, no double-toggle/zoom-bubble (rf2-6nw3g)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -3134,6 +3134,15 @@ carries:
   labelled region is the correct shape for a composite node.
 - `:data-rf-zoom-target "1"` — DOM hook for tooling / tests.
 
+**Triangle owns its own double-click (rf2-6nw3g).** The nested
+`role="button"` expand triangle toggles on `:on-click` (which already
+`stopPropagation`s each click). It additionally carries an
+`:on-double-click` that `preventDefault`s + `stopPropagation`s and
+dispatches **nothing** — so a double-click _on the triangle_ never
+bubbles to the container's `:on-double-click` zoom. Zoom-in only fires
+on a double-click in the container body **outside** the triangle; the
+triangle is purely an expand/collapse control.
+
 **Breadcrumb structure** — when a zoom is active, a row above the body
 renders `<home> › <seg1> › <seg2> › …`. Each segment is a clickable
 button; click dispatches `:zoom-to` with a TRUNCATED prefix of the zoom

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
@@ -1569,6 +1569,19 @@
     (dispatch-fn [:rf.xray.edn-inspector/toggle-node
                   panel-id mount-id path rendered-expanded?])))
 
+(defn- swallow-dblclick
+  "`:on-double-click` for the `▸`/`▾` toggle glyph (rf2-6nw3g). The
+  triangle's `:on-click` already toggles + `stopPropagation`s each
+  click, but a double-click on the glyph still emits a `dblclick` that
+  would bubble to the enclosing zoomable container's `:on-double-click`
+  zoom (`zoom-trigger-attrs`). Swallowing it here lets the triangle own
+  its own gesture — zoom only fires on a double-click OUTSIDE the
+  triangle — and `preventDefault` suppresses the native text-selection."
+  [^js e]
+  (when e
+    (.preventDefault e)
+    (.stopPropagation e)))
+
 (defn- collapsed-summary
   "Right-of-triangle summary for a collapsed collection. Shows an
   inline preview if any first elements fit; falls back to the
@@ -1848,6 +1861,7 @@
         depth-capped?
         (cond-> [:span {:style {:display "inline-flex" :align-items "center" :gap "4px"}}
                  [:span {:on-click   toggle-fn
+                         :on-double-click swallow-dblclick
                          :role       "button"
                          :tabIndex   0
                          :aria-expanded false
@@ -1907,6 +1921,7 @@
         expanded?
         (cond-> [:span {:style {:display "inline-flex" :align-items "center" :gap "4px"}}
                  [:span {:on-click   toggle-fn
+                         :on-double-click swallow-dblclick
                          :role       "button"
                          :tabIndex   0
                          :aria-expanded true
@@ -1932,6 +1947,7 @@
                               (not (#{:added :removed} op)))]
           (cond-> [:span {:style {:display "inline-flex" :align-items "center" :gap "6px"}}
                    [:span {:on-click   toggle-fn
+                           :on-double-click swallow-dblclick
                            :role       "button"
                            :tabIndex   0
                            :aria-expanded false

--- a/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs
@@ -2939,6 +2939,62 @@
           "rf2-r0o63 — composed-path dispatch is ALSO a single-arg event
            vector through the captured dispatcher (no `:rf/xray` literal)"))))
 
+;; ---- rf2-6nw3g — the toggle triangle owns its double-click gesture -------
+;;
+;; A zoomable container's outer div carries `:on-double-click -> zoom-to`
+;; (zoom-trigger-attrs). The `▸`/`▾` toggle glyph nested inside dispatches
+;; toggle on `:on-click`. Before the fix the glyph had no `:on-double-click`
+;; guard, so a double-click on the TRIANGLE fired toggle twice (net visual
+;; no-op, two dispatches) AND its `dblclick` bubbled to the container's zoom.
+;; The fix adds `swallow-dblclick` (preventDefault + stopPropagation, no
+;; dispatch) so the triangle owns its gesture: zoom only fires on a
+;; double-click OUTSIDE the triangle, and a single click still toggles.
+
+(defn- stub-evt
+  "A synthetic-event stub that records `preventDefault` / `stopPropagation`
+  invocations into the supplied atom map `{:prevented? false :stopped? false}`."
+  [spy]
+  (js-obj "preventDefault"  (fn [] (swap! spy assoc :prevented? true))
+          "stopPropagation" (fn [] (swap! spy assoc :stopped? true))))
+
+(deftest toggle-glyph-double-click-is-swallowed-no-zoom
+  ;; Render a NON-ROOT, collapsed, zoomable container so BOTH the toggle
+  ;; glyph and the container's zoom-trigger attrs are present.
+  (let [dispatched (atom [])
+        dispatch-fn (fn [ev] (swap! dispatched conj ev))
+        v   {:a 1 :b 2 :c 3 :d 4 :e 5}
+        h   (ei/render-node {:value v
+                             :panel-id :p
+                             :mount-id "m"
+                             :path [:parent]
+                             :depth 5
+                             :expansion-map {}
+                             :zoomable? true
+                             :dispatch-fn dispatch-fn
+                             :opts {:default-expanded-depth 1}})
+        tog (find-attr h :data-testid "rf-xray-edn-inspector-p-m-:parent-toggle")
+        on-click (-> tog second :on-click)
+        on-dblclick (-> tog second :on-double-click)]
+    (is (some? tog) "the collapsed container renders a toggle glyph")
+    (is (seq (zoom-target-nodes h))
+        "the non-root container is also a zoom target (gesture lives on the
+         outer div, which the dblclick must NOT reach)")
+    (testing "the toggle glyph carries a double-click swallow guard"
+      (is (fn? on-dblclick) "toggle glyph must carry an :on-double-click")
+      (let [spy (atom {:prevented? false :stopped? false})]
+        (on-dblclick (stub-evt spy))
+        (is (:prevented? @spy)
+            "preventDefault — suppresses the native text-selection")
+        (is (:stopped? @spy)
+            "stopPropagation — the dblclick never bubbles to the container's zoom")
+        (is (empty? @dispatched)
+            "the swallow dispatches NOTHING (no zoom-to, no toggle)")))
+    (testing "a single click still toggles (existing behaviour preserved)"
+      (on-click nil)
+      (is (= [[:rf.xray.edn-inspector/toggle-node :p "m" [:parent] false]]
+             @dispatched)
+          "one click dispatches exactly one canonical toggle event"))))
+
 ;; ---- breadcrumb ----------------------------------------------------------
 
 (deftest breadcrumb-nil-when-no-zoom


### PR DESCRIPTION
## What

`views/edn_inspector.cljs` — the `▸`/`▾` expand triangle's `:on-click` already toggles and `stopPropagation`s each click, but it carried **no `:on-double-click` guard**. A double-click on the triangle therefore:

1. Fired `toggle-fn` **twice** (net visual no-op, two wasted dispatches), and
2. Emitted a `dblclick` that **bubbled to the enclosing zoomable container's `:on-double-click → zoom-to`**, zooming when the operator only meant to expand/collapse.

## Fix

Add a small `swallow-dblclick` handler (`preventDefault` + `stopPropagation`, dispatches nothing) and attach it as `:on-double-click` to all three triangle call sites (depth-capped, expanded, collapsed-default). The triangle now owns its own gesture: zoom only fires on a double-click **outside** the triangle; the triangle stays a pure expand/collapse control. `preventDefault` also suppresses the native text-selection. Dispatch stays via the lexically-captured frame-aware dispatcher (no `:rf/xray` literal — the frame-singleton guard stays green).

- Fix + helper: `tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs` — `swallow-dblclick` defn at ~L1572; wired at the three triangle spans (~L1864 / L1924 / L1950).
- Test: `tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs` — `toggle-glyph-double-click-is-swallowed-no-zoom`. Renders a non-root, collapsed, zoomable container (so both the triangle AND the container's zoom-trigger attrs are present), asserts the toggle's `:on-double-click` prevents default + stops propagation + dispatches nothing (no zoom), and that a single click still dispatches exactly one canonical `:toggle-node`.
- Spec: `tools/xray/spec/021-Dynamic-Panel-Designs.md` — added a "Triangle owns its own double-click (rf2-6nw3g)" note to the EDN-inspector zoom Gesture section (the contract was documented there).

## Quality gates

- `cd tools/xray && clojure -M:test` — **969 tests, 3808 assertions, 0 failures, 0 errors** (frame-singleton guard + two-instance isolation green)
- `cd implementation && npm run test:cljs` — **4833 tests, 15844 assertions, 0 failures, 0 errors** (includes the new view test)
- `cd implementation && npm run test:xray-feature-gate` — **14 scenarios, 0 failures, 13 matrix rows**
- `bash scripts/test-fast-pr.sh --with-docs` — **PASS** (CLJS spine + README/docs anchor validators; mkdocs soft-skipped locally, CI will run it)