### PR TITLE
feat(story): variant-plan compiler + explain base (rf2-5x1wt.10)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -169,6 +169,84 @@ to author `:setup`, `:args`, `:argtypes`, `:sub-overrides`, `:checks`,
 and `:assertions` at the top level; the plan compiler lowers them into
 this shape and `explain` shows both source and normalized locations.
 
+### Compiler API and normalization contract
+
+The compiler is a **pure data → data** function (so it is JVM-runnable
+and host-free) exposed through three entry points:
+
+```clojure
+(story/variant-plan target)        ; -> normalized plan
+(story/variant-plan target opts)
+(story/explain       target)       ; -> the plan's :explain map
+(story/explain       target opts)
+```
+
+`target` is a keyword (a registered variant id, resolved through the
+Story side-table) or a map (an inline plan body, with an optional
+`:variant/id`). `opts` MAY carry `:lookup` — a `(variant-id) →
+raw-body` fn or a `{variant-id → raw-body}` map — used to resolve
+`:extends` parents and the keyword target; it defaults to the
+side-table. Because `:lookup` accepts raw bodies, the compiler owns
+parent-chain resolution rather than depending on registration-time
+merge.
+
+**Normalization (author spelling → normalized slot):**
+
+| Author key | Normalized slot |
+|---|---|
+| `:setup` / `:events` | `[:world :setup]` (both spellings; `:setup` is the target) |
+| `:script` / `:play-script` / `:plays` | `:script` (the primary play); the full named-play set is preserved under `[:world :scripts]` so `:plays` is not dropped |
+| `:checks` | `[:expect :checks]` |
+| `:assertions` | `[:expect :assertions]` |
+| `:args` / `:argtypes` | `[:world :args]` / `[:world :argtypes]` |
+| `:sub-overrides` | `[:world :render :sub-overrides]` |
+| `:network` / `:fx-overrides` | `[:world :network]` / `[:world :frame :fx-overrides]` |
+| platforms / tags / workshop slots (`:decorators`, `:modes`, `:viewport`, …) | preserved under `:world` (and top-level `:tags`) |
+
+Script steps lower through the shipping coercion (bare event-vector
+shorthand lifts to `[:dispatch …]`; the `:dispatch` / `:dispatch-sync`
+/ `:wait` / `:assert-*` tag grammar is preserved verbatim), so the
+normalized `:script` matches what the runner executes.
+
+**Parent chain (`:extends`).** The compiler resolves the chain root to
+child and applies the §`:extends` principle — context flows down,
+verdict is local:
+
+- `:setup` **appends** root → child (a common silent-regression site);
+- world context (`:args` / `:argtypes` deep-merge; frame/render/network/
+  workshop slots) and `:checks` **inherit** root → child;
+- ordinary terminal `:assertions` and `:script` are **child-only**;
+- `:tags` union.
+
+**Args and `[:arg key]`.** `:args` resolve through the deep-merge
+precedence chain (later/closer-to-child wins). Every `[:arg key]`
+placeholder in setup, script, and sub-overrides is substituted before
+the plan is returned; a placeholder referencing an undeclared arg
+**fails** plan construction with `:rf.error/story-missing-arg`. `explain`
+records each substitution as `{:key … :value …}`.
+
+**Cycle/unknown detection.** A missing keyword target fails with
+`:rf.error/story-unknown-variant`; an unregistered `:extends` parent
+with `:rf.error/story-extends-unknown`; a repeated id (or a chain past
+the depth cap) with `:rf.error/story-extends-cycle` /
+`:rf.error/story-extends-chain-too-long`.
+
+**Required runner (initial).** The compiler computes an initial
+`:required-runner` capability **set** by unioning the tokens each setup
+step, script step, and terminal assertion declares (app-db work needs no
+token and resolves to `:headless`; DOM steps/assertions add `:dom`,
+visual adds `:pixels`, etc.). This is a coarse first cut; the
+per-assertion capability registry (a later bead) supersedes the static
+map without reshaping the plan.
+
+**Explain data.** `(story/explain target)` returns the plan's `:explain`
+map: source chain, parent chain, field-level merge decisions, resolved
+args + substitutions, final setup order and script order, checks and
+terminal assertions, required runner, platforms, tags, and source
+coords. Strict-conflict resolution and composed-fragment/check
+explanation (§Conflict resolution) are filled in by the composition
+bead; the foundation emits an empty `:compose` slot.
+
 ### Inline plan
 
 An inline plan is an executable plan map that is not registered as a

--- a/tools/story/src/re_frame/story/plan.cljc
+++ b/tools/story/src/re_frame/story/plan.cljc
@@ -1,0 +1,495 @@
+(ns re-frame.story.plan
+  "Variant-plan compiler and `explain` base (Lane B foundation).
+
+  Per `tools/story/spec/017-Testing-Story.md` §Four-bucket authoring
+  model + §Variant plan + §Total resolution order, every registered
+  variant and inline plan MUST be normalized before execution. This
+  namespace is the **author-surface foundation**: it turns a raw variant
+  body (or inline map) into the normalized `:world` / `:script` /
+  `:expect` shape, resolving the `:extends` parent chain, lowering author
+  ergonomics, resolving `:args` + `[:arg key]` placeholders, computing the
+  initial required-runner capability set, and producing `explain` data
+  during compilation.
+
+  ## What this layer DOES (rf2-5x1wt.10)
+
+  - Read a registered variant body (or accept an inline map).
+  - Resolve the `:extends` parent chain root-to-child, bounded with cycle
+    detection (§Total resolution order step 1; §`:extends`).
+  - Lower author ergonomics into the four-bucket shape: `:events`/`:setup`
+    → `[:world :setup]`; `:play-script`/`:plays`/`:script` → `:script`;
+    `:checks`/`:assertions` → `:expect`.
+  - Resolve `:args` through the same precedence chain as
+    `re-frame.story.args` (deep-merge, later wins) and substitute
+    `[:arg key]` placeholders in setup/script/sub-overrides; a missing
+    arg FAILS plan construction.
+  - Preserve platforms / tags / workshop context under `:world`.
+  - Compute the **initial** `:required-runner` capability set from the
+    script steps and the declared assertions (a coarse first cut; the
+    full per-assertion capability registry lands with rf2 runner-
+    requirements work).
+  - Attach `:source-chain` and an `:explain` map.
+
+  ## What this layer DEFERS
+
+  Strict `:compose` fragment/check composition + conflict resolution
+  (§Merge rules / §Conflict resolution), the runner itself, evidence
+  projection, view-arg-schema validation, `:network` lowering, and the
+  capability-token registry are **later beads**. This compiler emits the
+  scaffolding (e.g. an empty `[:world :network]` passthrough, a coarse
+  `:required-runner`) so those beads slot in without reshaping the plan.
+
+  ## Purity / elision
+
+  Every fn here is pure data → data, so the compiler is JVM-runnable and
+  the test suite needs no host. The default body `lookup` reads the Story
+  side-table (`re-frame.story.registrar`), which under the §6 elision
+  contract is empty in a production bundle; callers thread an explicit
+  `:lookup` (a `{variant-id → raw-body}` map or a 1-arg fn) for pure
+  tests."
+  (:require [re-frame.story.args      :as args]
+            [re-frame.story.registrar :as registrar]
+            [re-frame.story.play.runner :as runner]))
+
+;; ============================================================================
+;; Errors
+;; ============================================================================
+
+(defn- fail!
+  "Throw a structured plan-construction error. Mirrors the
+  `:rf.error/story-*` family the registrar / extends layers use so tools
+  surface plan failures the same way registration failures surface."
+  [id reason data]
+  (throw (ex-info (str id)
+                  (merge {:rf.error/id id
+                          :where       'rf.story/variant-plan
+                          :recovery    :fix-registration
+                          :reason      reason}
+                         data))))
+
+;; ============================================================================
+;; Parent-chain resolution
+;; ============================================================================
+
+(def ^:dynamic *max-extends-depth*
+  "Hard cap on the `:extends` chain length, mirroring
+  `re-frame.story.extends/*max-extends-depth*`. A body that hits this
+  limit is treated as a cycle."
+  32)
+
+(defn resolve-source-chain
+  "Walk the `:extends` chain from `body` and return the vector of
+  `{:variant/id :body}` layers in **root-first** order — the deepest
+  ancestor first, the supplied `body` last.
+
+  `lookup` is a fn `(variant-id) → raw-body-or-nil` that returns the
+  *raw* (un-merged) body for a parent variant. A body that does not carry
+  `:extends` yields a single-entry chain `[{:variant/id id :body body}]`.
+
+  FAILS with `:rf.error/story-extends-unknown` when a named parent is not
+  found, and `:rf.error/story-extends-cycle` when a variant id reappears
+  on the chain (or the depth cap is exceeded).
+
+  Self-resolving: the supplied `id`/`body` is the child; only `:extends`
+  references are looked up. Per §Total resolution order step 1."
+  [id body lookup]
+  (loop [acc     (list {:variant/id id :body body})
+         current body
+         visited  (if id #{id} #{})
+         depth    0]
+    (let [parent-id (:extends current)]
+      (cond
+        (nil? parent-id)
+        (vec acc)                          ; acc is built child-first via conj-to-front
+
+        (contains? visited parent-id)
+        (fail! :rf.error/story-extends-cycle
+               (str "re-frame2-story: :extends cycle through " parent-id)
+               {:chain (conj (vec visited) parent-id) :id parent-id})
+
+        (>= depth *max-extends-depth*)
+        (fail! :rf.error/story-extends-chain-too-long
+               (str "re-frame2-story: :extends chain exceeds "
+                    *max-extends-depth* " levels at " parent-id)
+               {:chain (conj (vec visited) parent-id) :id parent-id})
+
+        :else
+        (if-let [parent (lookup parent-id)]
+          (recur (conj acc {:variant/id parent-id :body parent})
+                 parent
+                 (conj visited parent-id)
+                 (inc depth))
+          (fail! :rf.error/story-extends-unknown
+                 (str "re-frame2-story: :extends references unregistered "
+                      "variant " parent-id)
+                 {:parent parent-id :id id}))))))
+
+;; ============================================================================
+;; Field merge (foundation: context-flows-down / verdict-is-local)
+;; ============================================================================
+;;
+;; rf2-5x1wt.10 implements the *parent-chain* slice of §Merge rules — the
+;; foundation that .11/.12 build the strict `:compose` conflict machinery
+;; on. The principle from §`:extends`: context flows down, verdict is
+;; local.
+;;
+;;   - inherited through :extends — world context (setup, args, frame,
+;;     platforms, tags, workshop slots) AND checks (the inheritable
+;;     expectation form);
+;;   - NOT inherited — ordinary terminal `:assertions` and `:script`.
+;;
+;; Setup APPENDS root→child (preserving order); script and assertions are
+;; taken from the child only.
+
+(def ^:private setup-keys
+  "Source keys that lower into `[:world :setup]`, in priority order
+  (`:setup` is the target spelling; `:events` is the shipping spelling)."
+  [:setup :events])
+
+(def ^:private context-keys
+  "World/context keys inherited through `:extends` (deep-merge for maps,
+  child-wins for scalars; see `merge-context`)."
+  [:args :argtypes :sub-overrides :network :fx-overrides :interceptor-overrides
+   :decorators :loaders :loaders-teardown :loaders-complete-when
+   :modes :substrates :platforms :viewport :background :xray
+   :dispatch-console? :component :doc :args->events])
+
+(defn- pick-setup
+  "Return the raw setup vector for a body — the first of `setup-keys`
+  present. Both spellings lower to the same `[:world :setup]` slot."
+  [body]
+  (some (fn [k] (when (contains? body k) (get body k))) setup-keys))
+
+(defn- merge-context
+  "Deep-merge one context value root→child. Maps recurse (per
+  `args/deep-merge`); everything else is child-wins replacement."
+  [parent child]
+  (if (and (map? parent) (map? child))
+    (args/deep-merge parent child)
+    (if (some? child) child parent)))
+
+(defn- merge-tags
+  "Tags are additive through `:extends` (§Merge rules — append/union)."
+  [parent child]
+  (into (set parent) (set child)))
+
+;; ============================================================================
+;; Script normalization
+;; ============================================================================
+;;
+;; `:play-script` (single) / `:plays` (named) / `:script` (target) all
+;; lower to `:script`. We reuse the shipping `runner/variant-body->plays`
+;; so bare event-vector shorthand and the `:dispatch`/`:dispatch-sync`/
+;; `:wait`/`:assert-*` tag grammar coerce exactly as the runtime sees
+;; them. Per spec §Public vocabulary + §Setup and script.
+;;
+;; The normalized `:script` is the FIRST (auto-run / primary) play's
+;; coerced step vector; the full named-play set is preserved under
+;; `[:world :scripts]` so `:plays` is not dropped (§Public vocabulary —
+;; "named scripts in the normalized plan").
+
+(defn- normalize-scripts
+  "Return `{:script [step ...] :scripts [{:name :script :auto-run?} ...]}`
+  for a merged body. Accepts the target `:script` spelling AND the
+  shipping `:play-script` / `:plays` spellings, lowering them through the
+  runner's canonical coercion. The primary `:script` is the first play."
+  [body]
+  (let [plays (cond
+                (contains? body :script)
+                ;; Target spelling: a bare step vector, coerced the same
+                ;; way the runner coerces a `:play-script` body's `:script`.
+                [{:script (runner/coerce-script (:script body)) :auto-run? true}]
+
+                :else
+                (runner/variant-body->plays body))
+        plays (vec plays)]
+    {:script  (-> plays first :script (or []))
+     :scripts plays}))
+
+;; ============================================================================
+;; Arg placeholder substitution
+;; ============================================================================
+
+(defn arg-placeholder?
+  "True iff `x` is an `[:arg key]` placeholder (per §Args — data
+  placeholders)."
+  [x]
+  (and (vector? x)
+       (= 2 (count x))
+       (= :arg (first x))))
+
+(defn substitute-args
+  "Recursively replace every `[:arg key]` placeholder in `form` with the
+  resolved value from `arg-map`. FAILS with `:rf.error/story-missing-arg`
+  when a placeholder references an absent key (§Args — 'plan construction
+  MUST fail'). Records each substitution into the `subs!` atom as
+  `{:key key :value v}` so `explain` can show them.
+
+  Walks vectors, maps, sets, and lists; scalars pass through. A resolved
+  value is itself walked so a placeholder may resolve to a structure
+  containing further data (placeholders inside resolved values are NOT
+  re-expanded — resolution is one level)."
+  [form arg-map subs!]
+  (cond
+    (arg-placeholder? form)
+    (let [k (second form)]
+      (if (contains? arg-map k)
+        (let [v (get arg-map k)]
+          (swap! subs! conj {:key k :value v})
+          v)
+        (fail! :rf.error/story-missing-arg
+               (str "re-frame2-story: [:arg " k "] references an arg that "
+                    "is not declared on the variant or its parents")
+               {:arg k :available (set (keys arg-map))})))
+
+    (map? form)
+    (reduce-kv (fn [m k v]
+                 (assoc m
+                        (substitute-args k arg-map subs!)
+                        (substitute-args v arg-map subs!)))
+               (empty form) form)
+
+    (vector? form)
+    (mapv #(substitute-args % arg-map subs!) form)
+
+    (set? form)
+    (into (empty form) (map #(substitute-args % arg-map subs!)) form)
+
+    (seq? form)
+    (apply list (map #(substitute-args % arg-map subs!) form))
+
+    :else form))
+
+;; ============================================================================
+;; Expect normalization
+;; ============================================================================
+
+(defn- normalize-expect
+  "Lower `:checks` + `:assertions` into the `:expect` bucket. Checks are
+  the inheritable expectation form (already merged into `merged` by the
+  context pass); ordinary assertions are own-only (taken from the child
+  body only — handled by the caller passing the child's assertions)."
+  [checks assertions]
+  {:checks     (vec (or checks []))
+   :assertions (vec (or assertions []))})
+
+;; ============================================================================
+;; Required-runner inference (coarse foundation)
+;; ============================================================================
+;;
+;; The full capability-token registry is a later bead. This foundation
+;; emits the *initial* required-runner set from a small static map of the
+;; step/assertion ids the shipping grammar already carries. Per §Runner
+;; model — capability is a SET of tokens, not a tier scalar.
+
+(def ^:private step-capabilities
+  "Capability tokens a script step requires, keyed by step tag."
+  {:dispatch       #{:app-db}
+   :dispatch-sync  #{:app-db}
+   :wait           #{}
+   :wait-until     #{}
+   :assert-db      #{:app-db}
+   :assert         #{:app-db}
+   :assert-dom     #{:dom}
+   :click          #{:dom}
+   :type           #{:dom}
+   :focus          #{:dom}})
+
+(def ^:private assertion-capabilities
+  "Capability tokens a terminal assertion id requires. Coarse first cut;
+  the per-assertion registry (rf2 runner-requirements) supersedes this."
+  {:rf.assert/path-equals    #{:app-db}
+   :rf.assert/path-matches   #{:app-db}
+   :rf.assert/sub-equals     #{:app-db}
+   :rf.assert/dispatched?    #{:app-db}
+   :rf.assert/state-is       #{:app-db}
+   :rf.assert/no-warnings    #{:app-db}
+   :rf.assert/effect-emitted #{:app-db}
+   :rf.assert/schema-error   #{:app-db}
+   :rf.assert/dom-visible    #{:dom}
+   :rf.assert/dom-hidden     #{:dom}
+   :rf.assert/dom-text       #{:dom}
+   :rf.assert/visual-snapshot #{:pixels}
+   :rf.assert/a11y           #{:a11y-engine}})
+
+(defn- step-tokens [step]
+  (get step-capabilities (when (vector? step) (first step)) #{}))
+
+(defn- assertion-tokens [assertion]
+  (get assertion-capabilities (when (vector? assertion) (first assertion)) #{}))
+
+(defn- compute-required-runner
+  "Union the capability tokens demanded by every setup step, script step,
+  and terminal assertion. `:headless` work needs no token (the empty set
+  resolves to the default `:headless` runner)."
+  [setup script assertions]
+  (reduce into #{}
+          (concat (map step-tokens setup)
+                  (map step-tokens script)
+                  (map assertion-tokens assertions))))
+
+;; ============================================================================
+;; Compiler
+;; ============================================================================
+
+(defn- default-lookup
+  "Default raw-body lookup — reads the Story side-table. Production
+  bundles elide the side-table, so the lookup returns nil there; pure
+  tests thread an explicit `:lookup`."
+  [variant-id]
+  (registrar/handler-meta :variant variant-id))
+
+(defn- coerce-lookup
+  "Accept either a 1-arg fn or a `{variant-id → body}` map as `:lookup`."
+  [lookup]
+  (cond
+    (nil? lookup) default-lookup
+    (map? lookup) #(get lookup %)
+    (fn? lookup)  lookup
+    :else         (fail! :rf.error/story-bad-lookup
+                         "re-frame2-story: :lookup must be a fn or a map"
+                         {:lookup lookup})))
+
+(defn compile-body
+  "Compile a raw variant `body` (the child) registered under `id` into a
+  normalized plan. `lookup` is a 1-arg fn returning raw parent bodies.
+
+  This is the pure core; `variant-plan` is the public front door that
+  resolves a registered/keyword/map target onto this fn."
+  [id body lookup]
+  (let [chain        (resolve-source-chain id body lookup)
+        bodies       (map :body chain)         ; root-first
+        child        (:body (last chain))
+        ;; ---- context merge (root→child) ----
+        ctx          (reduce
+                       (fn [acc layer]
+                         (reduce (fn [m k]
+                                   (if (contains? layer k)
+                                     (update m k merge-context (get layer k))
+                                     m))
+                                 acc context-keys))
+                       {}
+                       bodies)
+        ;; checks inherit; build the inherited+own check list root→child
+        checks       (reduce (fn [acc layer]
+                               (into acc (:checks layer)))
+                             []
+                             bodies)
+        ;; setup APPENDS root→child (§Merge rules)
+        setup-raw    (vec (mapcat (fn [layer] (or (pick-setup layer) [])) bodies))
+        ;; script + terminal assertions are CHILD-ONLY (verdict is local)
+        {:keys [script scripts]} (normalize-scripts child)
+        assertions   (vec (:assertions child))
+        ;; ---- args ----
+        arg-map      (reduce (fn [m layer] (args/deep-merge m (:args layer)))
+                             {} bodies)
+        argtypes     (reduce (fn [m layer] (args/deep-merge m (:argtypes layer)))
+                             {} bodies)
+        ;; ---- arg substitution ----
+        subs!        (atom [])
+        setup        (substitute-args setup-raw arg-map subs!)
+        script*      (substitute-args script arg-map subs!)
+        sub-overrides (substitute-args (:sub-overrides ctx) arg-map subs!)
+        ;; ---- runner requirement ----
+        required     (compute-required-runner setup script* assertions)
+        ;; ---- source coords ----
+        source       (:source child)
+        platforms    (or (:platforms ctx) #{:client})
+        world        (cond-> {:setup     setup
+                              :args      arg-map
+                              :argtypes  argtypes
+                              :scripts   scripts
+                              :platforms platforms}
+                       (some? sub-overrides) (assoc-in [:render :sub-overrides] sub-overrides)
+                       (contains? ctx :network)     (assoc :network (:network ctx))
+                       (contains? ctx :fx-overrides) (assoc-in [:frame :fx-overrides] (:fx-overrides ctx))
+                       (contains? ctx :interceptor-overrides) (assoc-in [:frame :interceptor-overrides] (:interceptor-overrides ctx))
+                       (contains? ctx :loaders)     (assoc :loaders (:loaders ctx))
+                       (contains? ctx :loaders-teardown) (assoc :loaders-teardown (:loaders-teardown ctx))
+                       (contains? ctx :decorators)  (assoc :decorators (:decorators ctx))
+                       (contains? ctx :modes)       (assoc :modes (:modes ctx))
+                       (contains? ctx :substrates)  (assoc :substrates (:substrates ctx))
+                       (contains? ctx :viewport)    (assoc :viewport (:viewport ctx))
+                       (contains? ctx :background)  (assoc :background (:background ctx))
+                       (contains? ctx :xray)        (assoc :xray (:xray ctx))
+                       (contains? ctx :component)   (assoc :component (:component ctx)))
+        explain      {:source-chain (mapv :variant/id chain)
+                      :parent-chain (mapv :variant/id (butlast chain))
+                      :compose      []          ; foundation: no fragments/checks compose yet
+                      :merge        {:setup      :append-root-to-child
+                                     :args       :deep-merge-root-to-child
+                                     :checks     :inherit-root-to-child
+                                     :assertions :child-only
+                                     :script     :child-only}
+                      :args         arg-map
+                      :substitutions @subs!
+                      :setup-order  setup
+                      :script-order script*
+                      :checks       checks
+                      :assertions   assertions
+                      :required-runner required
+                      :platforms    platforms
+                      :tags         (reduce (fn [acc layer] (merge-tags acc (:tags layer)))
+                                            #{} bodies)
+                      :source       source}]
+    (cond-> {:variant/id      id
+             :source-chain    (mapv :variant/id chain)
+             :world           world
+             :script          script*
+             :expect          (normalize-expect checks assertions)
+             :required-runner required
+             :tags            (reduce (fn [acc layer] (merge-tags acc (:tags layer)))
+                                      #{} bodies)
+             :explain         explain}
+      source (assoc :source source))))
+
+(defn variant-plan
+  "Compile `target` into a normalized variant plan (§Variant plan).
+
+  `target` is either:
+
+  - a **keyword** — a registered variant id resolved through the body
+    `lookup` (default: the Story side-table);
+  - a **map** — an inline plan body (compiled the same way, with an
+    optional `:variant/id`).
+
+  `opts`:
+
+  - `:lookup` — a 1-arg fn `(variant-id) → raw-body` OR a
+    `{variant-id → raw-body}` map, used to resolve `:extends` parents
+    (and the keyword target itself). Defaults to the side-table.
+
+  Returns the normalized plan map: `:variant/id`, `:source-chain`,
+  `:world`, `:script`, `:expect`, `:required-runner`, `:tags`, `:explain`
+  (and `:source` when coords are present).
+
+  FAILS with a structured `:rf.error/story-*` ex-info on: an unregistered
+  keyword target, an unregistered `:extends` parent, an `:extends` cycle,
+  or a missing `[:arg key]`."
+  ([target] (variant-plan target nil))
+  ([target {:keys [lookup] :as _opts}]
+   (let [lookup-fn (coerce-lookup lookup)]
+     (cond
+       (keyword? target)
+       (if-let [body (lookup-fn target)]
+         (compile-body target body lookup-fn)
+         (fail! :rf.error/story-unknown-variant
+                (str "re-frame2-story: no registered variant " target)
+                {:variant/id target}))
+
+       (map? target)
+       (compile-body (:variant/id target) (dissoc target :variant/id) lookup-fn)
+
+       :else
+       (fail! :rf.error/story-bad-target
+              "re-frame2-story: variant-plan target must be a keyword id or a map"
+              {:target target})))))
+
+(defn explain
+  "Return the `:explain` map for `target` (§Explain API). Convenience over
+  `(:explain (variant-plan target opts))`. Shows the source chain, parent
+  chain, field-level merge decisions, args + substitutions, final
+  setup/script order, checks/assertions, required runner, platforms, and
+  tags."
+  ([target] (explain target nil))
+  ([target opts] (:explain (variant-plan target opts))))

--- a/tools/story/test/re_frame/story/plan_test.cljc
+++ b/tools/story/test/re_frame/story/plan_test.cljc
@@ -1,0 +1,243 @@
+(ns re-frame.story.plan-test
+  "Tests for the variant-plan compiler + explain base (rf2-5x1wt.10).
+
+  Per `tools/story/spec/017-Testing-Story.md` §Four-bucket authoring
+  model + `ai/findings/NewTestStory` §B1. The compiler is a pure
+  data → data fn, so every test runs on both the JVM and CLJS without a
+  host: variant bodies are supplied through an explicit `:lookup` map of
+  RAW bodies (the parent-chain resolution is the compiler's job, so the
+  test bodies still carry `:extends` rather than relying on the
+  registrar's eager merge)."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.story.plan :as plan]))
+
+;; ---- helpers ------------------------------------------------------------
+
+(defn- plan-of
+  "Compile a keyword `target` against a raw-body lookup `m`."
+  [target m]
+  (plan/variant-plan target {:lookup m}))
+
+;; ---- simple variant compiles --------------------------------------------
+
+(deftest simple-variant-compiles
+  (testing "a simple variant compiles to a plan with the four-bucket shape"
+    (let [m {:story.counter/at-five
+             {:setup      [[:dispatch [:counter/init 5]]]
+              :script     [[:dispatch [:counter/inc]]]
+              :assertions [[:rf.assert/path-equals [:count] 6]]}}
+          p (plan-of :story.counter/at-five m)]
+      (is (= :story.counter/at-five (:variant/id p)))
+      (is (contains? p :world))
+      (is (contains? p :script))
+      (is (contains? p :expect))
+      (is (= [[:dispatch [:counter/init 5]]] (get-in p [:world :setup])))
+      (is (= [[:dispatch [:counter/inc]]] (:script p)))
+      (is (= [[:rf.assert/path-equals [:count] 6]]
+             (get-in p [:expect :assertions]))))))
+
+(deftest normalized-plan-has-world-script-expect
+  (testing "normalized plan always carries :world / :script / :expect"
+    (let [m {:story.x/y {:setup [[:dispatch [:a]]]}}
+          p (plan-of :story.x/y m)]
+      (is (vector? (get-in p [:world :setup])))
+      (is (vector? (:script p)))
+      (is (map? (:expect p)))
+      (is (= #{:client} (get-in p [:world :platforms])))
+      ;; setup-only variant: no script
+      (is (= [] (:script p))))))
+
+;; ---- inline map target ---------------------------------------------------
+
+(deftest inline-map-target-compiles
+  (testing "a map target compiles the same way as a registered keyword"
+    (let [p (plan/variant-plan {:variant/id :story.inline/v
+                                :setup  [[:dispatch [:a]]]
+                                :script [[:dispatch [:b]]]})]
+      (is (= :story.inline/v (:variant/id p)))
+      (is (= [[:dispatch [:a]]] (get-in p [:world :setup])))
+      (is (= [[:dispatch [:b]]] (:script p))))))
+
+;; ---- args + [:arg key] substitution -------------------------------------
+
+(deftest variant-with-args-compiles
+  (testing "args resolve and [:arg key] placeholders substitute"
+    (let [m {:story.cart/add
+             {:args   {:sku "A" :qty 2}
+              :setup  [[:dispatch [:cart/add {:sku [:arg :sku] :qty [:arg :qty]}]]]
+              :script [[:dispatch [:cart/touch {:sku [:arg :sku]}]]]}}
+          p (plan-of :story.cart/add m)]
+      (is (= {:sku "A" :qty 2} (get-in p [:world :args])))
+      (is (= [[:dispatch [:cart/add {:sku "A" :qty 2}]]]
+             (get-in p [:world :setup])))
+      (is (= [[:dispatch [:cart/touch {:sku "A"}]]] (:script p)))
+      (testing "explain records the substitutions"
+        (let [subs (get-in p [:explain :substitutions])]
+          (is (= #{{:key :sku :value "A"} {:key :qty :value 2}}
+                 (set subs))))))))
+
+(deftest missing-arg-fails
+  (testing "a [:arg key] referencing an undeclared arg fails plan construction"
+    (let [m {:story.bad/arg
+             {:args  {:sku "A"}
+              :setup [[:dispatch [:cart/add {:sku [:arg :sku] :qty [:arg :qty]}]]]}}]
+      (is (thrown-with-msg?
+            #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
+            #"story-missing-arg"
+            (plan-of :story.bad/arg m)))
+      (let [data (try (plan-of :story.bad/arg m)
+                      (catch #?(:clj Exception :cljs :default) e
+                        (ex-data e)))]
+        (is (= :rf.error/story-missing-arg (:rf.error/id data)))
+        (is (= :qty (:arg data)))
+        (is (re-find #"qty" (:reason data)))))))
+
+;; ---- parent chain (:extends) --------------------------------------------
+
+(deftest variant-with-parent-compiles
+  (testing "context inherits root→child; setup appends; script/assertions are child-only"
+    (let [m {:story.login/filled
+             {:args       {:user "ann"}
+              :setup      [[:dispatch [:auth/fill {:user [:arg :user]}]]]
+              :assertions [[:rf.assert/path-equals [:auth :state] :filled]]
+              :tags       #{:test}}
+             :story.login/error-after-submit
+             {:extends    :story.login/filled
+              :script     [[:dispatch [:auth/login-pressed]]]
+              :assertions [[:rf.assert/path-equals [:auth :state] :error]]}}
+          p (plan-of :story.login/error-after-submit m)]
+      (testing "source chain is root-first"
+        (is (= [:story.login/filled :story.login/error-after-submit]
+               (:source-chain p))))
+      (testing "context (args) inherits"
+        (is (= {:user "ann"} (get-in p [:world :args]))))
+      (testing "setup inherited from parent (substituted with inherited arg)"
+        (is (= [[:dispatch [:auth/fill {:user "ann"}]]]
+               (get-in p [:world :setup]))))
+      (testing "script is child-only"
+        (is (= [[:dispatch [:auth/login-pressed]]] (:script p))))
+      (testing "terminal assertions are child-only (verdict is local)"
+        (is (= [[:rf.assert/path-equals [:auth :state] :error]]
+               (get-in p [:expect :assertions]))))
+      (testing "tags are additive"
+        (is (= #{:test} (:tags p)))))))
+
+(deftest parent-setup-appends-before-child-setup
+  (testing "parent + child :setup APPEND in root→child order (silent-regression site)"
+    (let [m {:story.s/parent {:setup [[:dispatch [:p1]] [:dispatch [:p2]]]}
+             :story.s/child  {:extends :story.s/parent
+                              :setup   [[:dispatch [:c1]]]}}
+          p (plan-of :story.s/child m)]
+      (is (= [[:dispatch [:p1]] [:dispatch [:p2]] [:dispatch [:c1]]]
+             (get-in p [:world :setup]))))))
+
+(deftest missing-parent-fails
+  (testing "an :extends referencing an unregistered variant fails"
+    (let [m {:story.x/child {:extends :story.x/ghost}}]
+      (is (= :rf.error/story-extends-unknown
+             (try (plan-of :story.x/child m)
+                  (catch #?(:clj Exception :cljs :default) e
+                    (:rf.error/id (ex-data e)))))))))
+
+(deftest extends-cycle-fails
+  (testing "an :extends cycle fails plan construction"
+    (let [m {:story.c/a {:extends :story.c/b}
+             :story.c/b {:extends :story.c/a}}]
+      (is (= :rf.error/story-extends-cycle
+             (try (plan-of :story.c/a m)
+                  (catch #?(:clj Exception :cljs :default) e
+                    (:rf.error/id (ex-data e)))))))))
+
+(deftest unknown-keyword-target-fails
+  (testing "a keyword target with no registered body fails"
+    (is (= :rf.error/story-unknown-variant
+           (try (plan-of :story.none/here {})
+                (catch #?(:clj Exception :cljs :default) e
+                  (:rf.error/id (ex-data e))))))))
+
+;; ---- shipping-vocabulary normalization ----------------------------------
+
+(deftest events-normalizes-to-world-setup
+  (testing "shipping :events lowers to [:world :setup]"
+    (let [m {:story.legacy/e {:events [[:counter/init 3]]}}
+          p (plan-of :story.legacy/e m)]
+      (is (= [[:counter/init 3]] (get-in p [:world :setup]))))))
+
+(deftest play-script-normalizes-to-script
+  (testing "shipping :play-script lowers to :script (bare vectors lift to :dispatch)"
+    (let [m {:story.legacy/p
+             {:play-script [[:dispatch-sync [:counter/init 3]]
+                            [:counter/inc]
+                            [:wait 50]]}}
+          p (plan-of :story.legacy/p m)]
+      (is (= [[:dispatch-sync [:counter/init 3]]
+              [:dispatch [:counter/inc]]
+              [:wait 50]]
+             (:script p))))))
+
+(deftest play-script-map-form-normalizes
+  (testing ":play-script map form lowers its :script"
+    (let [m {:story.legacy/pm
+             {:play-script {:script [[:dispatch [:a]]] :auto-run? false}}}
+          p (plan-of :story.legacy/pm m)]
+      (is (= [[:dispatch [:a]]] (:script p))))))
+
+(deftest plays-preserved-as-named-scripts
+  (testing ":plays normalizes to the primary :script and preserves all named scripts"
+    (let [m {:story.legacy/multi
+             {:plays [{:name "happy" :script [[:dispatch [:h]]]}
+                      {:name "sad"   :script [[:dispatch [:s]]]}]}}
+          p (plan-of :story.legacy/multi m)]
+      (testing "primary script is the first play"
+        (is (= [[:dispatch [:h]]] (:script p))))
+      (testing "all named scripts preserved under [:world :scripts]"
+        (is (= ["happy" "sad"] (mapv :name (get-in p [:world :scripts]))))
+        (is (= [[[:dispatch [:h]]] [[:dispatch [:s]]]]
+               (mapv :script (get-in p [:world :scripts]))))))))
+
+;; ---- checks (inheritable) ------------------------------------------------
+
+(deftest checks-inherit-through-extends
+  (testing "checks are the inheritable expectation form (root→child)"
+    (let [m {:story.k/parent {:checks [:check/no-runtime-errors]}
+             :story.k/child  {:extends :story.k/parent
+                              :checks  [:check/extra]}}
+          p (plan-of :story.k/child m)]
+      (is (= [:check/no-runtime-errors :check/extra]
+             (get-in p [:expect :checks]))))))
+
+;; ---- required-runner -----------------------------------------------------
+
+(deftest headless-variant-needs-no-tokens
+  (testing "an app-db-only variant requires only :app-db (resolves to :headless)"
+    (let [m {:story.r/h
+             {:setup      [[:dispatch [:a]]]
+              :assertions [[:rf.assert/path-equals [:x] 1]]}}
+          p (plan-of :story.r/h m)]
+      (is (= #{:app-db} (:required-runner p))))))
+
+(deftest dom-step-requires-dom-token
+  (testing "a DOM script step lifts the required-runner to include :dom"
+    (let [m {:story.r/d
+             {:script [[:dispatch [:a]] [:click "[data-test=go]"]]}}
+          p (plan-of :story.r/d m)]
+      (is (contains? (:required-runner p) :dom))
+      (is (contains? (:required-runner p) :app-db)))))
+
+;; ---- explain -------------------------------------------------------------
+
+(deftest explain-includes-source-chain-and-substitutions
+  (testing "explain shows the source chain, parent chain, merge decisions, and substitutions"
+    (let [m {:story.e/parent {:args  {:n 1}
+                              :setup [[:dispatch [:seed [:arg :n]]]]}
+             :story.e/child  {:extends :story.e/parent
+                              :script  [[:dispatch [:go]]]}}
+          ex (plan/explain :story.e/child {:lookup m})]
+      (is (= [:story.e/parent :story.e/child] (:source-chain ex)))
+      (is (= [:story.e/parent] (:parent-chain ex)))
+      (is (= {:n 1} (:args ex)))
+      (is (= [{:key :n :value 1}] (:substitutions ex)))
+      (is (= [[:dispatch [:seed 1]]] (:setup-order ex)))
+      (is (= [[:dispatch [:go]]] (:script-order ex)))
+      (is (= :append-root-to-child (get-in ex [:merge :setup])))
+      (is (= :child-only (get-in ex [:merge :script]))))))


### PR DESCRIPTION
Lane B author-surface foundation for the NewTestStory plan model (blocks rf2-5x1wt.11 / .12). Adds a NEW file `tools/story/src/re_frame/story/plan.cljc` — the pure data->data variant-plan compiler — per `tools/story/spec/017-Testing-Story.md` §Four-bucket authoring model + §Variant plan, and documents the compiler API/normalization contract in that spec.

## What this adds

- **`(story/variant-plan target opts)` / `(story/explain target opts)`** — keyword target = registered variant (side-table lookup); map target = inline plan. `opts :lookup` threads raw bodies (fn or `{id -> body}` map) so the compiler owns `:extends` resolution rather than depending on registration-time merge.
- **Normalization** into the four-bucket shape: `:setup`/`:events` -> `[:world :setup]`; `:script`/`:play-script`/`:plays` -> `:script` (named plays preserved under `[:world :scripts]`); `:checks`/`:assertions` -> `:expect`; `:args`/workshop slots/platforms/tags preserved under `:world`. Script steps lower through the shipping `runner/coerce-script` coercion so the normalized `:script` matches what the runner executes.
- **Parent chain** resolved root->child with the §`:extends` rule: setup **appends**, world context + checks **inherit**, terminal assertions + script are **child-only**, tags union.
- **Args + `[:arg key]`**: deep-merge precedence chain; placeholders substituted in setup/script/sub-overrides; a missing arg **fails** with `:rf.error/story-missing-arg`.
- **Failure modes**: unknown keyword target, unknown `:extends` parent, `:extends` cycle / depth-cap — all structured `:rf.error/story-*` ex-info.
- **Initial `:required-runner`** capability **set** (coarse static map; superseded by the per-assertion registry bead).
- **`:explain`** map: source/parent chain, field-level merge decisions, args + substitutions, final setup/script order, checks, terminal assertions, required runner, platforms, tags, source coords.

Deferred to .11/.12 (scaffolding emitted, not reshaped later): strict `:compose` fragment/check composition + conflict resolution, the runner, evidence projection, view-arg-schema validation, `:network` lowering, the capability-token registry.

## Tests

`tools/story/test/re_frame/story/plan_test.cljc` (`.cljc`, runs JVM + compiles CLJS): simple / inline / args / parent compiles; missing-parent / extends-cycle / missing-arg / unknown-target failures; `:events` + `:play-script` (vector + map form) + `:plays` normalization; checks inheritance; required-runner (headless vs DOM); explain (source chain + substitutions + merge decisions). Compiler is pure, so JVM is the authoritative gate.

## Quality gates

- `cd tools/story && clojure -M:test` — 880 tests, 2608 assertions, 0 failures, 0 errors.
- `cd implementation && npm run test:cljs` — 4833 tests, 15844 assertions, 0 failures, 0 errors (compiles `plan.cljc` clean under CLJS).
- `bash scripts/test-fast-pr.sh` — PASS (CLJS node integration green; README + docs anchor validators pass; mkdocs --strict soft-skipped on Windows, CI runs it).
- `git diff --check` — clean.

Spec updated: yes — `tools/story/spec/017-Testing-Story.md` §Compiler API and normalization contract.