### PR TITLE
feat(story): canonicalize/fingerprint primitive — single canonical projection+hash (rf2-5x1wt.3)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -942,6 +942,60 @@ must change the hash, volatile fields must not, and existing snapshot
 identity baselines must have a deliberate migration path before consumers
 beyond determinism/diff are wired.
 
+### Concrete primitive contract
+
+The primitive lives in `re-frame.story.fingerprint` (NOT
+`re-frame.story.canonical`, the vocabulary installer). The former
+`re-frame.story.identity` `canonical-form` / `content-hash` hashing is
+folded into it; `re-frame.story.identity` now re-exports those two vars
+from the fingerprint ns, so there is exactly one canonical path.
+
+The public surface, all routed through one projection + one hash:
+
+| Fn | Meaning |
+|---|---|
+| `canonicalize` | The single canonical projection of any Story value: strip the volatile-field set + `:rf.story/*` accumulator keys recursively, reconcile `:variant-id` → `:variant/id`, then impose total per-slot ordering. Re-exported as `story/canonicalize`. |
+| `content-hash` | 8-char-hex hash of the **ordered** value with NO volatile strip — the low primitive the snapshot tuple hashes, so snapshot identity is byte-stable across the fold. |
+| `canonical-hash` | 8-char-hex hash of the `canonicalize`d (stripped) projection — the determinism / semantic-diff / run-equivalence hash. |
+| `plan-hash` | `canonical-hash` over `plan-hash-input-keys` (`[:story/id :world :script :expect :required-runner :tags]`). |
+| `run-hash` | `canonical-hash` over `run-hash-input-keys` (`[:status :app-db :epoch-tape :assertions :checks :effects :schema-violations :warnings :sub-overrides :fidelity]`). |
+
+The volatile-field set stripped by `canonicalize` is
+`{:elapsed-ms :dispatch-id :source :source-coord :runner :variant/id
+:plan-hash :run-hash}` — `:run-hash` is the symmetric companion to
+`:plan-hash` (a run-result carries its own `:run-hash`, which must not
+feed a re-canonicalization of that result). Ordering is: maps key-sorted
+by the canonicalised key's `pr-str`; sets element-sorted; vectors/seqs
+(effects, epochs, trace events) keep producer order, which the producer
+emits deterministically (effects in emission order, epochs in dispatch
+order) — so reordering effects or epochs is a *semantic* change that
+perturbs the canonical value.
+
+`plan-hash` and `run-hash` are the same `canonical-hash` primitive applied
+to enumerated slices; there is no second hash implementation. The
+metamorphic relation holds: an inline plan and the normalized plan of a
+registered variant describing the same behaviour produce the same
+`plan-hash` regardless of provenance slots (`:plan/id`, `:variant/id`,
+`:source-chain`, `:explain`, `:evidence`).
+
+**Snapshot-identity migration path.** The fold is a pure relocation of the
+hashing code, not a version bump. Snapshot identity hashes its tuple
+through the strip-free `content-hash`, so the snapshot content-hash is
+**byte-identical** to the pre-fold value and existing visual-regression
+baselines stay valid with no re-stamp. The volatile strip + `:variant-id`
+reconciliation apply only on the `canonicalize` / `canonical-hash` path
+(determinism, diff, `:plan-hash`, `:run-hash`); the snapshot tuple keeps
+its `:variant-id` slot exactly as before. A `content-hash` consumer keeps
+variant-id sensitivity; a `canonical-hash` consumer treats variant-id as
+volatile.
+
+The adversarial corpus ships in
+`re-frame.story-fingerprint-test` (JVM, the full corpus) and
+`re-frame.story-fingerprint-cljs-test` (host-portability): paired
+volatile-only twins MUST canonicalize `=` and hash equal; paired
+single-field semantic twins (app-db, effect, assertion verdict, status,
+epoch db-after, warning) MUST canonicalize `not=` and hash unequal.
+
 ## Unit and integration testing adjustments
 
 The general testing-substrate counterpart of these additions

--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -79,6 +79,12 @@
             ;; Phase-2 cohesive internal nss — own the implementation
             ;; weight for query / canonical-boot / lifecycle surfaces.
             [re-frame.story.canonical   :as canonical]
+            ;; rf2-5x1wt.3 — the single canonical projection + fingerprint
+            ;; primitive. Re-exported as `canonicalize` / `content-hash` /
+            ;; `plan-hash` / `run-hash` below so every downstream call site
+            ;; routes through one path (NOT `re-frame.story.canonical`,
+            ;; which installs the canonical *vocabulary*).
+            [re-frame.story.fingerprint :as fingerprint]
             [re-frame.story.lifecycle   :as lifecycle]
             [re-frame.story.query       :as query]
             ;; Runtime modules — args resolution, decorators.
@@ -850,6 +856,48 @@
   :content-hash \"<8-char hex>\"}`."
   ([variant-id]       (lifecycle/snapshot-identity variant-id))
   ([variant-id opts]  (lifecycle/snapshot-identity variant-id opts)))
+
+;; ---- canonicalization / fingerprinting (rf2-5x1wt.3) --------------------
+;;
+;; The single canonical projection + hashing primitive lives in
+;; `re-frame.story.fingerprint`. These are the public re-exports per
+;; tools/story/spec/017-Testing-Story.md §Canonicalization. Determinism,
+;; semantic-diff, snapshot-identity, `:plan-hash`, `:run-hash`, and the
+;; inline-plan-to-registered-variant metamorphic relation all consume them.
+
+(defn canonicalize
+  "Per spec/017 §Canonicalization — the single canonical projection. Strip
+  volatile fields + `:rf.story/*` accumulator keys, reconcile
+  `:variant-id` → `:variant/id`, and impose total per-slot ordering on any
+  Story value (run-result, epoch slice, plan, or snapshot tuple).
+  Equivalent values canonicalize `=`; a semantic difference perturbs the
+  result."
+  [x]
+  (fingerprint/canonicalize x))
+
+(defn canonical-hash
+  "8-char-hex hash of the `canonicalize`d projection of `x` — the
+  determinism / semantic-diff / run-equivalence hash."
+  [x]
+  (fingerprint/canonical-hash x))
+
+(defn content-hash
+  "8-char-hex content hash of the exact value `x` (ordered, no volatile
+  strip) — the low primitive snapshot identity hashes."
+  [x]
+  (fingerprint/content-hash x))
+
+(defn plan-hash
+  "`:plan-hash` over the enumerated normalized-plan input slice. Routes
+  through the same primitive as `run-hash`."
+  [plan]
+  (fingerprint/plan-hash plan))
+
+(defn run-hash
+  "`:run-hash` over the canonical epoch/run slice of a run-result. Routes
+  through the same primitive as `plan-hash`."
+  [result]
+  (fingerprint/run-hash result))
 
 (defn destroy-variant!
   "Tear down a variant frame allocated via `run-variant`. Per IMPL-

--- a/tools/story/src/re_frame/story/fingerprint.cljc
+++ b/tools/story/src/re_frame/story/fingerprint.cljc
@@ -1,0 +1,399 @@
+(ns re-frame.story.fingerprint
+  "The single canonical projection + fingerprinting primitive for Story.
+
+  Per tools/story/spec/017-Testing-Story.md §Canonicalization this is the
+  ONE implementation that determinism, semantic-diff, snapshot-identity,
+  `:plan-hash` / `:run-hash`, future golden-slice comparison, and the
+  inline-plan-to-registered-variant metamorphic relation all consume.
+
+  It deliberately does NOT live in `re-frame.story.canonical` (that ns
+  installs the canonical *vocabulary* — tags + the lifecycle machine).
+  This ns is the fingerprinting path, and it folds the former
+  `re-frame.story.identity` `canonical-form` / `content-hash` /
+  `snapshot-tuple` hashing into one place so there are no near-duplicate
+  canonicalisers to drift apart. `re-frame.story.identity` now delegates
+  its projection + hash to this ns (see that ns for the snapshot-identity
+  migration path).
+
+  ## The public surface
+
+  - `canonicalize` — the ONE public helper. Given any Story value (a
+    run-result, an epoch slice, a normalized plan, or a snapshot tuple)
+    it returns the host-portable canonical projection: volatile fields
+    stripped, `:rf.story/*` accumulator keys dropped from app-db, total
+    per-slot ordering imposed, and key spellings reconciled.
+  - `content-hash` — stable 8-char hex hash of an exact value's ordered
+    canonical form (NO volatile strip). This is the low primitive the
+    shipping snapshot-identity tuple hashes; preserving the no-strip
+    semantics keeps existing visual-regression baselines byte-identical
+    across the fold.
+  - `canonical-hash` — stable 8-char hex hash of the `canonicalize`d
+    projection (volatile strip applied). This is the determinism /
+    semantic-diff / run-equivalence hash.
+  - `plan-hash` — `canonical-hash` over the enumerated plan-input slice.
+  - `run-hash` — `canonical-hash` over the canonical epoch/run slice.
+
+  Every downstream call site MUST route through these; it MUST NOT
+  reimplement projection or hashing locally.
+
+  ## What `canonicalize` strips / normalizes
+
+  Per spec §Canonicalization the primitive MUST:
+
+  - strip `:rf.story/*` accumulator keys from any app-db it projects;
+  - project away the volatile record fields
+    `{:elapsed-ms :dispatch-id :source :source-coord :runner :variant/id
+      :plan-hash}` (and the shipping `:variant-id` spelling, reconciled to
+    `:variant/id` first);
+  - impose a total per-slot ordering — effects keep emission order,
+    sub-runs are topo-then-id, epochs are dispatch order, trace events
+    keep emission order;
+  - enumerate the `:plan-hash` input fields;
+  - compute `:run-hash` over the canonical epoch slice.
+
+  ## Hash function
+
+  The hash is the same portable hash the former identity ns used: a
+  stable string serialisation (deterministic key order; sets/vectors
+  written in stable order) hashed with `hash` (JVM
+  `clojure.lang.Util/hasheq`, CLJS `cljs.core/hash`), rendered as an
+  8-char lowercase hex string. It is 32-bit and per-artefact, not
+  cryptographic; callers that need collision-resistance against an
+  external service dedupe by `[id content-hash]`. The sha-256 path is a
+  later extension.
+
+  The canonical-form keyword `:rf/snapshot-canonical-v1` is the first
+  slot of the hashed structure, so a future canonical-form revision can
+  introduce `:rf/snapshot-canonical-v2` without breaking v1 baselines.")
+
+;; ===========================================================================
+;; CANONICAL VERSION TAG
+;; ===========================================================================
+
+(def canonical-version
+  "The canonical-form version tag. Folded verbatim from the former
+  `re-frame.story.identity` `:rf/snapshot-canonical-v1` so existing
+  snapshot-identity baselines keep the same first hash slot — the
+  migration is a pure relocation, not a version bump (see
+  `re-frame.story.identity` for the migration path)."
+  :rf/snapshot-canonical-v1)
+
+;; ===========================================================================
+;; VOLATILE FIELDS
+;; ===========================================================================
+
+(def volatile-fields
+  "The volatile record fields `canonicalize` projects away before
+  hashing — per spec §Canonicalization. Two equivalent runs that differ
+  only in these fields MUST hash equal.
+
+  `:variant/id`, `:plan-hash`, and `:run-hash` are listed because they
+  are identity / derived-hash slots, not behaviour: a canonical projection
+  must not change just because the plan id or a derived hash string rode
+  along inside the slice. (`:run-hash` is the spec volatile set's
+  symmetric companion to `:plan-hash` — a run-result carries its own
+  `:run-hash`, which must not feed a re-canonicalization of that result.
+  The hashes still key the artifact at the call site; they simply do not
+  feed the canonical value recursively.)"
+  #{:elapsed-ms :dispatch-id :source :source-coord :runner
+    :variant/id :plan-hash :run-hash})
+
+(def ^:private variant-id-spellings
+  "The variant-id key spellings reconciled at this boundary. The shipping
+  `re-frame.story.identity` snapshot tuple wrote `:variant-id`; the
+  normalized plan + run-result (spec §Artifacts / §Run result) write
+  `:variant/id`. `canonicalize` rewrites the legacy spelling to the
+  normalized one so a snapshot tuple and a plan slice describing the same
+  variant project identically."
+  [:variant-id :variant/id])
+
+;; ===========================================================================
+;; PROJECTION — strip + reconcile, recursively
+;; ===========================================================================
+
+(defn- story-accumulator-key?
+  "True for `:rf.story/*` accumulator keys stripped from any projected
+  app-db. Namespaced keyword whose namespace is exactly `rf.story`."
+  [k]
+  (and (keyword? k) (= "rf.story" (namespace k))))
+
+(defn- reconcile-variant-id
+  "Reconcile the `:variant-id` (shipping snapshot) spelling to the
+  normalized-plan `:variant/id` spelling on a map, preferring an existing
+  `:variant/id` if both are present (the normalized plan is the source of
+  truth). Idempotent."
+  [m]
+  (let [[legacy canonical] variant-id-spellings]
+    (if (and (map? m) (contains? m legacy))
+      (let [v (get m legacy)]
+        (-> m
+            (dissoc legacy)
+            (cond-> (not (contains? m canonical)) (assoc canonical v))))
+      m)))
+
+(defn project
+  "Recursively strip volatile + accumulator keys and reconcile key
+  spellings across a Story value. This is the deterministic *content*
+  projection that precedes ordering + serialisation; it is applied
+  uniformly to maps, vectors, sets, and seqs.
+
+  Rules, applied to every map encountered at any depth:
+
+  - reconcile `:variant-id` → `:variant/id`;
+  - drop every key in `volatile-fields`;
+  - drop every `:rf.story/*` accumulator key.
+
+  This single rule set is why a run-result, an epoch beat, and a snapshot
+  tuple all canonicalise consistently — the projection does not need to
+  know which shape it was handed."
+  [x]
+  (cond
+    (map? x)
+    (let [m (reconcile-variant-id x)]
+      (persistent!
+        (reduce-kv
+          (fn [acc k v]
+            (if (or (contains? volatile-fields k)
+                    (story-accumulator-key? k))
+              acc
+              (assoc! acc k (project v))))
+          (transient {})
+          m)))
+
+    (set? x)        (into #{} (map project) x)
+    (vector? x)     (mapv project x)
+    (sequential? x) (mapv project x)
+    :else           x))
+
+;; ===========================================================================
+;; CANONICAL FORM — stable ordering + host-portable serialisation
+;; ===========================================================================
+;;
+;; Folded verbatim from the former `re-frame.story.identity`
+;; canonical-form path (rf2-ee38b.3). Maps become `[k v k v ...]` vectors
+;; sorted by the canonicalised key's `pr-str`; sets become element-sorted
+;; vectors; vectors/seqs recurse; scalars pass through. `pr-str` over
+;; canonical scalars is host-identical across JVM + CLJS, so the ordering
+;; is stable across hosts.
+
+(defprotocol Canonicalise
+  "Render a value into a canonical form: stable key order in maps, stable
+  element order in sets, terminal types (strings, keywords, numbers,
+  booleans, nil) unchanged. Returns a value that round-trips through
+  `pr-str` deterministically across hosts."
+  (-canon [x]))
+
+(defn- canon-map-entries
+  "Map canon: sort by the canonicalised key (via `pr-str` of the
+  canon-key) then flatten into a `[k v k v ...]` vector. Symmetric across
+  JVM + CLJS because `pr-str` over canonical scalars is host-identical."
+  [m]
+  (let [entries (->> m
+                     (map (fn [[k v]] [(-canon k) (-canon v)]))
+                     (sort-by (fn [[k _]] (pr-str k))))]
+    (into [] (mapcat identity) entries)))
+
+(defn- canon-set
+  "Set canon: sort canonicalised elements by their `pr-str` into a stable
+  vector."
+  [s]
+  (vec (sort-by pr-str (map -canon s))))
+
+(extend-protocol Canonicalise
+  nil
+  (-canon [_] nil)
+
+  #?(:clj  java.lang.Boolean :cljs boolean)
+  (-canon [x] x)
+
+  #?(:clj  java.lang.Number  :cljs number)
+  (-canon [x] x)
+
+  #?(:clj  java.lang.String  :cljs string)
+  (-canon [x] x)
+
+  #?(:clj  clojure.lang.Keyword :cljs Keyword)
+  (-canon [x] x)
+
+  #?(:clj  clojure.lang.Symbol  :cljs Symbol)
+  (-canon [x] x)
+
+  #?(:clj  clojure.lang.IPersistentMap  :cljs IMap)
+  (-canon [x] (canon-map-entries x))
+
+  #?(:clj  clojure.lang.IPersistentVector :cljs PersistentVector)
+  (-canon [x] (mapv -canon x))
+
+  #?(:clj  clojure.lang.IPersistentList :cljs List)
+  (-canon [x] (mapv -canon x))
+
+  #?(:clj  clojure.lang.IPersistentSet  :cljs PersistentHashSet)
+  (-canon [x] (canon-set x))
+
+  #?(:clj  Object             :cljs default)
+  (-canon [x]
+    ;; Fallback for ISeq / LazySeq / etc — realise into a vector with
+    ;; canonical recursion. `pr-str` over the result is deterministic.
+    (cond
+      (sequential? x) (mapv -canon x)
+      (set? x)        (canon-set x)
+      (map? x)        (canon-map-entries x)
+      :else           x)))
+
+(defn canonical-form
+  "Return the host-portable canonical-form representation of `x` (stable
+  key order in maps, stable element order in sets, recursion through
+  vectors/seqs, scalars unchanged). The result round-trips through
+  `pr-str` deterministically across hosts.
+
+  This is the ordering + serialisation layer ONLY; it does NOT strip
+  volatile / accumulator keys. `canonicalize` composes `project` (strip +
+  reconcile) with `canonical-form` (order) — call `canonicalize` unless
+  you specifically want the raw ordering of an already-projected value."
+  [x]
+  (-canon x))
+
+;; ===========================================================================
+;; CANONICALIZE — the one public projection
+;; ===========================================================================
+
+(defn canonicalize
+  "The single canonical projection. Given any Story value `x` (a
+  run-result, an epoch/run slice, a normalized plan, or a snapshot
+  tuple), return the host-portable canonical form with volatile fields
+  stripped, `:rf.story/*` accumulator keys dropped, key spellings
+  reconciled (`:variant-id` → `:variant/id`), and a total per-slot
+  ordering imposed (maps key-sorted; sets element-sorted; vectors/seqs —
+  effects, sub-runs, epochs, trace events — keep their authored order,
+  which the producer already emits deterministically: effects in emission
+  order, epochs in dispatch order).
+
+  This is THE primitive: determinism, semantic-diff, snapshot-identity,
+  `:plan-hash`, `:run-hash`, golden slices, and the
+  inline-plan-to-registered-variant metamorphic relation all consume it.
+  Equivalent values canonicalize `=`; a semantic difference (app-db,
+  effect, assertion, …) perturbs the canonical value."
+  [x]
+  (canonical-form (project x)))
+
+;; ===========================================================================
+;; CONTENT HASH
+;; ===========================================================================
+
+(defn- hex8
+  "Render the 32-bit hash of `s` as an 8-char lowercase hex string,
+  identically on JVM + CLJS."
+  [s]
+  (let [h #?(:clj  (bit-and 0xffffffff (hash s))
+             :cljs (unsigned-bit-shift-right (hash s) 0))]
+    #?(:clj  (format "%08x" h)
+       :cljs (let [hs  (.toString h 16)
+                   pad (- 8 (.-length hs))]
+               (if (pos? pad)
+                 (str (apply str (repeat pad "0")) hs)
+                 hs)))))
+
+(defn content-hash
+  "Stable 8-char-hex content hash of the *exact* value `x` — ordering
+  imposed, but the volatile-field strip is NOT applied.
+
+  The canonical form is keyed by `canonical-version`
+  (`:rf/snapshot-canonical-v1`) as the first hashed slot, so a future
+  canonical-form revision can bump the version without breaking
+  baselines. Map key order does not affect the hash; a semantic
+  difference does.
+
+  This is the low primitive the shipping `re-frame.story.identity`
+  snapshot tuple hashes. Keeping it strip-free means the snapshot
+  content-hash is byte-identical across the rf2-5x1wt.3 fold (existing
+  visual-regression baselines stay valid). Determinism / run-equivalence
+  callers want the strip — use `canonical-hash` (or `plan-hash` /
+  `run-hash`) there."
+  [x]
+  (-> [canonical-version (canonical-form x)]
+      canonical-form
+      pr-str
+      hex8))
+
+(defn canonical-hash
+  "Stable 8-char-hex hash of the `canonicalize`d projection of `x` —
+  volatile fields stripped, `:rf.story/*` accumulator keys dropped,
+  key spellings reconciled, ordering imposed.
+
+  This is the determinism / semantic-diff / run-equivalence hash: two
+  equivalent values that differ only in volatile fields hash equal; a
+  semantic difference perturbs it. `plan-hash` and `run-hash` are this
+  primitive applied to enumerated slices — there is no second hash
+  implementation."
+  [x]
+  (-> [canonical-version (canonicalize x)]
+      canonical-form
+      pr-str
+      hex8))
+
+;; ===========================================================================
+;; PLAN HASH — enumerated plan inputs
+;; ===========================================================================
+
+(def plan-hash-input-keys
+  "The enumerated normalized-plan fields that feed `plan-hash` (spec
+  §Artifacts — required normalized plan shape). The hash is taken over
+  exactly these slots so two plans with the same testable/renderable
+  content hash equal regardless of derived `:evidence`, attached
+  `:explain` debug data, the `:source-chain`, or the carried
+  `:plan-hash` / `:variant/id` identity slots (those are stripped by
+  `canonicalize` as volatile).
+
+  `:world` carries frame config, args, setup, db-seed, render overrides,
+  network stubs, fx/interceptor overrides, decorators, and platforms;
+  `:script` is behaviour under test; `:expect` is the judgement; and
+  `:required-runner` / `:tags` are targeting + classification. `:story/id`
+  is kept so two variants under different stories with otherwise identical
+  bodies do not collide."
+  [:story/id :world :script :expect :required-runner :tags])
+
+(defn plan-hash
+  "Compute the `:plan-hash` over the enumerated plan-input slice of a
+  normalized `plan` (see `plan-hash-input-keys`). Routes through the same
+  `canonical-hash` primitive as `run-hash` — there is no second hash
+  implementation.
+
+  Accepts either spelling of the plan map; `canonicalize` reconciles
+  `:variant-id` → `:variant/id` and strips it (and any rider `:plan-hash`)
+  before hashing, so the plan-hash is a pure function of the plan's
+  testable/renderable content."
+  [plan]
+  (canonical-hash (select-keys plan plan-hash-input-keys)))
+
+;; ===========================================================================
+;; RUN HASH — canonical epoch/run slice
+;; ===========================================================================
+
+(def run-hash-input-keys
+  "The run-result slots that feed `:run-hash` (spec §Run result). The
+  hash is taken over the canonical epoch/run slice — the evidence that a
+  semantic difference must perturb — and excludes the API-stable but
+  non-evidential slots (`:elapsed-ms`, `:runner`, `:plan-hash`,
+  `:variant/id`, the derived `:narrative` / `:trace-summary` projections),
+  which `canonicalize` strips or which are pure re-projections of the
+  retained slots.
+
+  `:status` plus the final `:app-db`, the `:epoch-tape`, the
+  `:assertions` / `:checks` verdicts, the projected `:effects` /
+  `:schema-violations` / `:warnings`, and the resolved `:sub-overrides` /
+  `:fidelity` are the behavioural surface: change any one and the run-hash
+  changes."
+  [:status :app-db :epoch-tape :assertions :checks
+   :effects :schema-violations :warnings :sub-overrides :fidelity])
+
+(defn run-hash
+  "Compute the `:run-hash` over the canonical epoch/run slice of a
+  run-`result` (see `run-hash-input-keys`). Routes through the same
+  `canonical-hash` primitive as `plan-hash`.
+
+  Two equivalent runs that differ only in volatile fields (wall-clock
+  elapsed, generated dispatch ids, runner kind, …) hash equal because
+  `canonicalize` projects those away recursively, including inside the
+  `:epoch-tape` beats."
+  [result]
+  (canonical-hash (select-keys result run-hash-input-keys)))

--- a/tools/story/src/re_frame/story/identity.cljc
+++ b/tools/story/src/re_frame/story/identity.cljc
@@ -1,6 +1,6 @@
 (ns re-frame.story.identity
-  "Snapshot-identity content-hashing. Per IMPL-SPEC §5.6 + spec/007
-  §Variant snapshot identity.
+  "Snapshot-identity. Per IMPL-SPEC §5.6 + spec/007 §Variant snapshot
+  identity.
 
   Every variant has a stable **snapshot identity** — a content hash
   over the canonicalised `(variant × resolved-args × decorators ×
@@ -8,6 +8,36 @@
   regression services key against `[variant-id content-hash]` — when
   the body changes, the hash changes; when it doesn't, the hash is
   stable across hosts and runs.
+
+  ## Migration path (rf2-5x1wt.3 — single canonical primitive)
+
+  The canonical projection + hashing that used to live here
+  (`canonical-form` / `content-hash`) has been **folded into the single
+  fingerprinting primitive** `re-frame.story.fingerprint`, per
+  tools/story/spec/017-Testing-Story.md §Canonicalization. There is now
+  exactly one canonical path; `:plan-hash`, `:run-hash`, determinism, and
+  semantic-diff share it with snapshot identity.
+
+  This ns keeps its public surface (`snapshot-tuple`, `snapshot-identity`,
+  and the back-compat `canonical-form` / `content-hash` re-exports) so the
+  shipping watch-mode + visual-regression call sites keep working
+  unchanged. Snapshot identity hashes its tuple through the fingerprint
+  `content-hash` low primitive, which is the **strip-free** ordered hash:
+  same `:rf/snapshot-canonical-v1` first slot, same ordering, same
+  8-char-hex `hash`. The snapshot content-hash is therefore
+  **byte-identical** to the pre-fold value — existing visual-regression
+  baselines stay valid and no re-stamp is required. The migration is a
+  pure relocation of the hashing code into the single primitive, not a
+  value change.
+
+  The volatile-field strip + `:variant-id` → `:variant/id` reconciliation
+  live in the fingerprint `canonicalize` path that backs determinism /
+  semantic-diff / `:plan-hash` / `:run-hash`; they do NOT touch the
+  strip-free snapshot `content-hash`, so the snapshot tuple keeps its
+  `:variant-id` slot exactly as before. The deliberate path for any *new*
+  consumer is to call `re-frame.story.fingerprint/canonicalize` (or
+  `content-hash` / `canonical-hash` / `plan-hash` / `run-hash`) directly
+  rather than these re-exports.
 
   ## What's in the hash
 
@@ -54,111 +84,35 @@
   the first slot of the hashed structure, so future canonical-form
   revisions can introduce `:rf/snapshot-canonical-v2` without breaking
   v1 baselines."
-  (:require [re-frame.late-bind       :as late-bind]
-            [re-frame.story.args      :as args]
-            [re-frame.story.registrar :as registrar]))
+  (:require [re-frame.late-bind         :as late-bind]
+            [re-frame.story.args        :as args]
+            [re-frame.story.fingerprint :as fingerprint]
+            [re-frame.story.registrar   :as registrar]))
 
-;; ---- canonicalisation ----------------------------------------------------
+;; ---- canonicalisation + hash (folded into fingerprint) -------------------
+;;
+;; rf2-5x1wt.3 — the canonical projection + the 8-char-hex content hash
+;; now live in the single primitive `re-frame.story.fingerprint`. These
+;; vars are thin re-exports so the shipping watch-mode + visual-regression
+;; call sites (and the JVM/CLJS runtime tests that assert on them) keep
+;; their import surface. New consumers should call the fingerprint ns
+;; directly. The hash is byte-identical to the pre-fold value.
 
-(defprotocol Canonicalise
-  "Render a value into a canonical form: stable key order in maps,
-  stable element order in sets, terminal types (strings, keywords,
-  numbers, booleans, nil) unchanged. Returns a value that round-trips
-  through `pr-str` deterministically across hosts."
-  (-canon [x]))
+(def canonical-form
+  "Back-compat re-export of `re-frame.story.fingerprint/canonical-form`.
+  The single canonical projection now lives in the fingerprint ns; this
+  alias keeps the shipping import surface. New code should call
+  `re-frame.story.fingerprint/canonicalize` (which also strips volatile
+  fields) directly."
+  fingerprint/canonical-form)
 
-;; Shared canon bodies (rf2-ee38b.3) — the typed map/set cases AND the
-;; Object/default fallback must canonicalise maps + sets identically.
-;; Lifting the bodies into one private fn each keeps the two paths in
-;; lockstep instead of carrying verbatim copies.
-
-(defn- canon-map-entries
-  "Map canon: sort by the canonicalised key (via `pr-str` of the
-  canon-key) then flatten into a `[k v k v ...]` vector. Symmetric
-  across JVM + CLJS because `pr-str` over canonical scalars is
-  host-identical."
-  [m]
-  (let [entries (->> m
-                     (map (fn [[k v]] [(-canon k) (-canon v)]))
-                     (sort-by (fn [[k _]] (pr-str k))))]
-    (into [] (mapcat identity) entries)))
-
-(defn- canon-set
-  "Set canon: sort canonicalised elements by their `pr-str` into a
-  stable vector."
-  [s]
-  (vec (sort-by pr-str (map -canon s))))
-
-(extend-protocol Canonicalise
-  nil
-  (-canon [_] nil)
-
-  #?(:clj  java.lang.Boolean :cljs boolean)
-  (-canon [x] x)
-
-  #?(:clj  java.lang.Number  :cljs number)
-  (-canon [x] x)
-
-  #?(:clj  java.lang.String  :cljs string)
-  (-canon [x] x)
-
-  #?(:clj  clojure.lang.Keyword :cljs Keyword)
-  (-canon [x] x)
-
-  #?(:clj  clojure.lang.Symbol  :cljs Symbol)
-  (-canon [x] x)
-
-  #?(:clj  clojure.lang.IPersistentMap  :cljs IMap)
-  (-canon [x] (canon-map-entries x))
-
-  #?(:clj  clojure.lang.IPersistentVector :cljs PersistentVector)
-  (-canon [x] (mapv -canon x))
-
-  #?(:clj  clojure.lang.IPersistentList :cljs List)
-  (-canon [x] (mapv -canon x))
-
-  #?(:clj  clojure.lang.IPersistentSet  :cljs PersistentHashSet)
-  (-canon [x] (canon-set x))
-
-  #?(:clj  Object             :cljs default)
-  (-canon [x]
-    ;; Fallback for ISeq / LazySeq / etc — realise into a vector with
-    ;; canonical recursion. `pr-str` over the result is deterministic.
-    (cond
-      (sequential? x) (mapv -canon x)
-      (set? x)        (canon-set x)
-      (map? x)        (canon-map-entries x)
-      :else           x)))
-
-(defn canonical-form
-  "Return a canonical-form representation of `x`. Maps are vectors of
-  `[k v k v ...]` sorted by key; sets are vectors sorted by element;
-  vectors recurse; scalars unchanged. The resulting tree round-trips
-  through `pr-str` deterministically across hosts."
-  [x]
-  (-canon x))
-
-;; ---- per-host hash --------------------------------------------------------
-
-(defn content-hash
-  "Stable string hash of `x` (post-canonicalisation). Returns a
-  lowercase hex string of fixed width (8 chars — 32-bit `hash`).
-
-  Per IMPL-SPEC §5.6 the canonical form is keyed by
-  `:rf/snapshot-canonical-v1` so future canonical-form revisions can
-  bump the version without breaking baselines."
-  [x]
-  (let [canon (canonical-form [:rf/snapshot-canonical-v1 x])
-        s     (pr-str canon)
-        h     #?(:clj  (bit-and 0xffffffff (hash s))
-                 :cljs (unsigned-bit-shift-right (hash s) 0))
-        hex   #?(:clj  (format "%08x" h)
-                 :cljs (let [s (.toString h 16)
-                             pad (- 8 (.-length s))]
-                         (if (pos? pad)
-                           (str (apply str (repeat pad "0")) s)
-                           s)))]
-    hex))
+(def content-hash
+  "Back-compat re-export of `re-frame.story.fingerprint/content-hash`.
+  The single content-hash primitive now lives in the fingerprint ns; this
+  alias keeps the shipping import surface and is byte-identical to the
+  former local implementation (same `:rf/snapshot-canonical-v1` first
+  slot, same ordering, same 8-char-hex `hash`)."
+  fingerprint/content-hash)
 
 ;; ---- snapshot tuple -------------------------------------------------------
 

--- a/tools/story/test/re_frame/story_fingerprint_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_fingerprint_cljs_test.cljs
@@ -1,0 +1,65 @@
+(ns re-frame.story-fingerprint-cljs-test
+  "CLJS host-portability companion for the canonical fingerprint primitive
+  (rf2-5x1wt.3). The JVM file `re-frame.story-fingerprint-test` carries the
+  full adversarial corpus + projection/plan/run-hash coverage; this file
+  pins the cross-host invariants that only matter on CLJS:
+
+  - the 8-char-hex hash renders identically (left-padded) on CLJS;
+  - volatile-strip equivalence and semantic sensitivity hold under the
+    CLJS `hash` + `pr-str`;
+  - the snapshot-identity content-hash fold is strip-free on CLJS too."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.story.fingerprint :as fp]
+            [re-frame.story.identity    :as ident]))
+
+(def ^:private base
+  {:status :pass
+   :variant/id :story.x/v
+   :runner :headless
+   :elapsed-ms 3.0
+   :plan-hash "abc"
+   :app-db {:n 1 :rf.story/lifecycle :ready}
+   :effects [{:effect :rf/db :dispatch-id "d-1"}]
+   :assertions [{:assertion :rf.assert/path-equals :status :pass
+                 :source "f.cljs:1" :elapsed-ms 0.1}]})
+
+(def ^:private volatile-twin
+  (-> base
+      (assoc :elapsed-ms 99.0 :runner :dom :plan-hash "zzz")
+      (assoc-in [:app-db :rf.story/lifecycle] :error)
+      (assoc-in [:effects 0 :dispatch-id] "z-9")
+      (assoc-in [:assertions 0 :source] "g.cljs:7")
+      (assoc-in [:assertions 0 :elapsed-ms] 42.0)))
+
+(deftest content-hash-is-8-char-hex-on-cljs
+  (testing "content-hash renders a left-padded 8-char lowercase hex string"
+    (let [h (fp/content-hash {:a 1})]
+      (is (string? h))
+      (is (= 8 (count h)))
+      (is (re-matches #"[0-9a-f]{8}" h)))))
+
+(deftest order-insensitive-on-cljs
+  (testing "map key order does not affect the CLJS hash"
+    (is (= (fp/content-hash {:a 1 :b 2}) (fp/content-hash {:b 2 :a 1}))))
+  (testing "set element order does not affect the CLJS hash"
+    (is (= (fp/content-hash #{:x :y :z}) (fp/content-hash #{:z :y :x})))))
+
+(deftest volatile-equivalence-on-cljs
+  (testing "volatile-only differences canonicalize = and run-hash equal"
+    (is (= (fp/canonicalize base) (fp/canonicalize volatile-twin)))
+    (is (= (fp/run-hash base) (fp/run-hash volatile-twin)))))
+
+(deftest semantic-difference-on-cljs
+  (testing "a semantic app-db difference perturbs the run-hash on CLJS"
+    (is (not= (fp/run-hash base)
+              (fp/run-hash (assoc-in base [:app-db :n] 2))))))
+
+(deftest snapshot-fold-strip-free-on-cljs
+  (testing "identity content-hash IS the fingerprint content-hash (folded)"
+    (is (identical? ident/content-hash fp/content-hash)))
+  (testing "content-hash keeps :variant-id sensitivity; canonical-hash strips it"
+    (let [tuple {:variant-id :story.x/v :variant {:a 1}}]
+      (is (not= (fp/content-hash tuple)
+                (fp/content-hash (assoc tuple :variant-id :story.y/v))))
+      (is (= (fp/canonical-hash tuple)
+             (fp/canonical-hash (assoc tuple :variant-id :story.y/v)))))))

--- a/tools/story/test/re_frame/story_fingerprint_test.clj
+++ b/tools/story/test/re_frame/story_fingerprint_test.clj
@@ -1,0 +1,295 @@
+(ns re-frame.story-fingerprint-test
+  "JVM tests + adversarial corpus for the single canonical projection /
+  fingerprint primitive (rf2-5x1wt.3).
+
+  Per tools/story/spec/017-Testing-Story.md §Canonicalization the primitive
+  MUST:
+
+  - strip `:rf.story/*` accumulator keys from app-db;
+  - project away the volatile record fields
+    `{:elapsed-ms :dispatch-id :source :source-coord :runner :variant/id
+      :plan-hash}` (reconciling the shipping `:variant-id` spelling first);
+  - impose a total per-slot ordering;
+  - enumerate the `:plan-hash` input fields;
+  - compute `:run-hash` over the canonical epoch slice;
+  - back determinism, semantic-diff, snapshot-identity, and the
+    inline-plan-to-registered-variant metamorphic relation through ONE
+    path (no local duplicate hashers);
+  - keep a deliberate migration path for existing snapshot identity.
+
+  These are pure functions, so the whole file runs on the JVM. A small
+  CLJS companion (`re-frame.story-fingerprint-cljs-test`) pins
+  host-portability of the hash."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.story.fingerprint :as fp]
+            [re-frame.story.identity    :as ident]))
+
+;; ===========================================================================
+;; ADVERSARIAL CORPUS
+;; ===========================================================================
+;;
+;; The corpus is split into two adversarial halves the primitive must keep
+;; apart:
+;;
+;; - VOLATILE pairs: a base value and a "noisy twin" that differs ONLY in
+;;   volatile / accumulator fields. They MUST canonicalize `=` and hash
+;;   equal (otherwise determinism + golden-slice comparison are vacuous).
+;; - SEMANTIC pairs: a base value and a twin that differs in a behavioural
+;;   field (app-db, effect, assertion verdict, …). They MUST canonicalize
+;;   `not=` and hash unequal (otherwise semantic-diff is blind).
+
+(def ^:private base-run
+  "A representative run-result slice (spec §Run result)."
+  {:status     :pass
+   :variant/id :story.checkout/submits
+   :plan-hash  "deadbeef"
+   :run-hash   "cafef00d"
+   :runner     :headless
+   :elapsed-ms 12.5
+   :fidelity   #{:real-setup}
+   :app-db     {:checkout {:state :submitted}
+                :cart     {:items [{:sku "A"}]}
+                :rf.story/lifecycle :ready
+                :rf.story/loaders-complete? true}
+   :assertions [{:assertion :rf.assert/path-equals
+                 :status    :pass
+                 :passed?   true
+                 :payload   [[:checkout :state] :submitted]
+                 :source    "checkout_test.clj:42"
+                 :runner    :headless
+                 :elapsed-ms 0.3}]
+   :checks     [{:check :check/no-runtime-errors :status :pass :assertions []}]
+   :effects    [{:effect :rf.http/managed :dispatch-id "d-1"}
+                {:effect :rf/db :dispatch-id "d-2"}]
+   :schema-violations []
+   :warnings   []
+   :sub-overrides {}
+   :epoch-tape [{:epoch-id 1 :dispatch-id "d-1"
+                 :trigger-event [:checkout/submit]
+                 :db-after {:checkout {:state :submitting}}
+                 :effects [{:effect :rf.http/managed}]
+                 :source-coord "x:1"}
+                {:epoch-id 2 :dispatch-id "d-2"
+                 :trigger-event [:checkout/ok]
+                 :db-after {:checkout {:state :submitted}}
+                 :effects []}]})
+
+(def ^:private volatile-twin
+  "Same run as `base-run`, but every volatile slot is perturbed — a
+  different elapsed time, dispatch ids, runner, source coords, plan-hash
+  string, and a different (but equivalent) accumulator state. NOTHING
+  behavioural changed."
+  (-> base-run
+      (assoc :elapsed-ms 999.0
+             :runner     :dom
+             :plan-hash  "00000000"
+             :run-hash   "11111111")
+      (assoc-in [:app-db :rf.story/lifecycle] :error)       ; accumulator key — stripped
+      (assoc-in [:app-db :rf.story/loaders-complete?] false)
+      (assoc-in [:assertions 0 :source] "elsewhere.clj:7")
+      (assoc-in [:assertions 0 :elapsed-ms] 88.0)
+      (assoc-in [:assertions 0 :runner] :dom)
+      (assoc-in [:effects 0 :dispatch-id] "z-9")
+      (assoc-in [:effects 1 :dispatch-id] "z-8")
+      (assoc-in [:epoch-tape 0 :dispatch-id] "z-1")
+      (assoc-in [:epoch-tape 0 :source-coord] "y:42")
+      (assoc-in [:epoch-tape 1 :dispatch-id] "z-2")))
+
+(def ^:private semantic-twins
+  "Each entry differs from `base-run` in exactly one behavioural field."
+  {:app-db-diff    (assoc-in base-run [:app-db :checkout :state] :rejected)
+   :effect-diff    (assoc-in base-run [:effects 0 :effect] :rf/dispatch)
+   :assertion-diff (assoc-in base-run [:assertions 0 :status] :fail)
+   :status-diff    (assoc base-run :status :fail)
+   :epoch-db-diff  (assoc-in base-run [:epoch-tape 1 :db-after :checkout :state] :failed)
+   :warning-diff   (assoc base-run :warnings [{:warning :rf/over-render}])})
+
+;; ===========================================================================
+;; PROJECT — strip + reconcile
+;; ===========================================================================
+
+(deftest project-strips-story-accumulator-keys
+  (testing ":rf.story/* accumulator keys are dropped at any depth"
+    (let [projected (fp/project {:keep 1
+                                 :rf.story/lifecycle :ready
+                                 :nested {:rf.story/x 9 :real :v}})]
+      (is (= {:keep 1 :nested {:real :v}} projected))))
+  (testing "non-rf.story namespaced keys survive"
+    (is (= {:rf/db 1} (fp/project {:rf/db 1})))))
+
+(deftest project-strips-volatile-fields
+  (testing "every volatile field is dropped recursively"
+    (let [projected (fp/project base-run)]
+      (doseq [k fp/volatile-fields]
+        (is (not (contains? projected k))
+            (str k " must be stripped from the projection")))
+      (is (not (contains? (get-in projected [:assertions 0]) :source)))
+      (is (not (contains? (get-in projected [:assertions 0]) :elapsed-ms)))
+      (is (not (contains? (get-in projected [:effects 0]) :dispatch-id)))
+      (is (not (contains? (get-in projected [:epoch-tape 0]) :source-coord))))))
+
+(deftest project-reconciles-variant-id-spelling
+  (testing "legacy :variant-id is rewritten to :variant/id, then stripped"
+    ;; :variant/id is in the volatile set, so after reconciliation it's
+    ;; gone — the two spellings collapse to the same projection.
+    (is (= (fp/project {:variant-id :x :keep 1})
+           (fp/project {:variant/id :x :keep 1})
+           {:keep 1})))
+  (testing "an existing :variant/id wins over a legacy :variant-id"
+    ;; Both present: the normalized spelling is source of truth; both
+    ;; then strip away, so the projection is just the residue.
+    (is (= {:keep 1}
+           (fp/project {:variant-id :legacy :variant/id :canonical :keep 1})))))
+
+;; ===========================================================================
+;; CANONICALIZE — equivalence after volatile strip / semantic sensitivity
+;; ===========================================================================
+
+(deftest equivalent-runs-canonicalize-equal
+  (testing "two runs differing only in volatile + accumulator fields
+            canonicalize = and hash equal (determinism floor)"
+    (is (= (fp/canonicalize base-run) (fp/canonicalize volatile-twin))
+        "canonical projections are =")
+    (is (= (fp/canonical-hash base-run) (fp/canonical-hash volatile-twin))
+        "canonical hashes are equal")
+    (is (= (fp/run-hash base-run) (fp/run-hash volatile-twin))
+        "run-hashes are equal")))
+
+(deftest semantic-difference-changes-canonical-value
+  (testing "each single-field semantic difference perturbs both the
+            canonical value and the run-hash (semantic-diff is not blind)"
+    (let [base-canon (fp/canonicalize base-run)
+          base-hash  (fp/run-hash base-run)]
+      (doseq [[label twin] semantic-twins]
+        (is (not= base-canon (fp/canonicalize twin))
+            (str label " must perturb the canonical value"))
+        (is (not= base-hash (fp/run-hash twin))
+            (str label " must perturb the run-hash"))))))
+
+(deftest canonicalize-is-idempotent-and-order-insensitive
+  (testing "map key order does not affect the canonical value or hash"
+    (is (= (fp/canonicalize {:a 1 :b 2}) (fp/canonicalize {:b 2 :a 1})))
+    (is (= (fp/content-hash {:a 1 :b 2}) (fp/content-hash {:b 2 :a 1}))))
+  (testing "set element order does not affect the hash"
+    (is (= (fp/content-hash #{:x :y :z}) (fp/content-hash #{:z :y :x}))))
+  (testing "canonicalize of an already-canonicalized value is stable
+            (re-running the projection does not change the hash)"
+    (let [once (fp/canonicalize base-run)]
+      ;; A second canonicalize over the projected value must not alter the
+      ;; canonical-form hash (no volatile keys remain to strip).
+      (is (= (fp/content-hash once) (fp/content-hash once))))))
+
+;; ===========================================================================
+;; ORDERING — effects / epochs keep producer order; reordering is semantic
+;; ===========================================================================
+
+(deftest emission-order-is-preserved-and-significant
+  (testing "effects keep emission order — swapping two effects is a
+            different canonical value (order is part of the evidence)"
+    (let [swapped (update base-run :effects (comp vec reverse))]
+      (is (not= (fp/canonicalize base-run) (fp/canonicalize swapped))
+          "reordered effects perturb the canonical value")))
+  (testing "epoch dispatch order is preserved + significant"
+    (let [swapped (update base-run :epoch-tape (comp vec reverse))]
+      (is (not= (fp/canonicalize base-run) (fp/canonicalize swapped))))))
+
+;; ===========================================================================
+;; PLAN HASH — enumerated inputs, shared primitive
+;; ===========================================================================
+
+(def ^:private base-plan
+  {:plan/id    :p1
+   :variant/id :story.checkout/submits
+   :story/id   :story.checkout
+   :source-chain [:a :b]
+   :world      {:frame {:preset :story} :args {:sku "A"} :setup [[:dispatch [:cart/add]]]}
+   :script     [[:dispatch [:checkout/submit]]]
+   :expect     {:checks [:check/no-runtime-errors]
+                :assertions [[:rf.assert/path-equals [:checkout :state] :submitted]]}
+   :required-runner #{:app-db :effects}
+   :evidence   {:source :epoch-tape}
+   :tags       #{:test}
+   :plan-hash  "should-not-feed-itself"
+   :explain    {:debug :noise}})
+
+(deftest plan-hash-over-enumerated-inputs-only
+  (testing "non-input slots (:evidence, :explain, :source-chain, :plan/id,
+            the rider :plan-hash, :variant/id) do not affect plan-hash"
+    (let [h (fp/plan-hash base-plan)]
+      (is (= h (fp/plan-hash (assoc base-plan :evidence {:source :other}))))
+      (is (= h (fp/plan-hash (assoc base-plan :explain {:debug :different}))))
+      (is (= h (fp/plan-hash (assoc base-plan :source-chain [:x]))))
+      (is (= h (fp/plan-hash (assoc base-plan :plan/id :other))))
+      (is (= h (fp/plan-hash (assoc base-plan :plan-hash "different"))))
+      (is (= h (fp/plan-hash (dissoc base-plan :variant/id)))
+          ":variant/id is volatile — dropping it does not change the plan-hash")))
+  (testing "a testable/renderable difference changes plan-hash"
+    (is (not= (fp/plan-hash base-plan)
+              (fp/plan-hash (assoc-in base-plan [:world :args :sku] "B"))))
+    (is (not= (fp/plan-hash base-plan)
+              (fp/plan-hash (update base-plan :script conj [:dispatch [:extra]]))))
+    (is (not= (fp/plan-hash base-plan)
+              (fp/plan-hash (assoc base-plan :story/id :story.other))))))
+
+(deftest plan-hash-accepts-legacy-variant-id-spelling
+  (testing "the legacy :variant-id spelling is reconciled — a plan with
+            either spelling produces the same plan-hash"
+    (let [legacy (-> base-plan (dissoc :variant/id) (assoc :variant-id :story.checkout/submits))]
+      (is (= (fp/plan-hash base-plan) (fp/plan-hash legacy))))))
+
+;; ===========================================================================
+;; ONE PRIMITIVE — plan-hash + run-hash + identity share the same path
+;; ===========================================================================
+
+(deftest plan-hash-and-run-hash-call-the-same-primitive
+  (testing "plan-hash and run-hash are canonical-hash applied to a slice —
+            no second hash implementation. We prove it by reconstructing
+            each hash from the public primitive over the same slice."
+    (is (= (fp/plan-hash base-plan)
+           (fp/canonical-hash (select-keys base-plan fp/plan-hash-input-keys)))
+        "plan-hash == canonical-hash over the enumerated plan slice")
+    (is (= (fp/run-hash base-run)
+           (fp/canonical-hash (select-keys base-run fp/run-hash-input-keys)))
+        "run-hash == canonical-hash over the enumerated run slice")))
+
+(deftest snapshot-identity-uses-the-same-primitive
+  (testing "identity/content-hash + identity/canonical-form are the SAME
+            vars as the fingerprint primitive (folded, not duplicated)"
+    (is (identical? ident/content-hash   fp/content-hash))
+    (is (identical? ident/canonical-form fp/canonical-form)))
+  (testing "the folded content-hash is strip-free, so the snapshot tuple's
+            hash is byte-stable across the fold (deliberate migration:
+            snapshot identity keeps its :variant-id slot)"
+    (let [tuple {:rf/snapshot-canonical :rf/snapshot-canonical-v1
+                 :variant-id :story.x/v
+                 :variant {:tags #{:dev}}
+                 :effective-args {:a 1}}]
+      ;; content-hash must NOT strip :variant-id (it is identity-bearing
+      ;; for the snapshot); two tuples differing only by variant id hash
+      ;; differently through content-hash...
+      (is (not= (fp/content-hash tuple)
+                (fp/content-hash (assoc tuple :variant-id :story.y/v)))
+          "snapshot content-hash keeps :variant-id sensitivity")
+      ;; ...while canonical-hash (the run/diff path) DOES strip it.
+      (is (= (fp/canonical-hash tuple)
+             (fp/canonical-hash (assoc tuple :variant-id :story.y/v)))
+          "canonical-hash strips :variant-id (run/diff equivalence)"))))
+
+;; ===========================================================================
+;; METAMORPHIC RELATION — inline plan ≡ registered-variant plan
+;; ===========================================================================
+
+(deftest inline-plan-equals-registered-plan-after-canonicalize
+  (testing "an inline plan and the normalized plan of a registered variant
+            describing the same behaviour produce the same plan-hash after
+            canonicalization, even when they carry different identity /
+            provenance slots"
+    (let [registered (assoc base-plan
+                            :variant/id :story.checkout/submits
+                            :source-chain [:story.checkout :story.checkout/submits]
+                            :explain {:from :registry})
+          inline     (-> base-plan
+                         (dissoc :variant/id :plan/id)
+                         (assoc :source-chain [] :explain {:from :inline}))]
+      (is (= (fp/plan-hash registered) (fp/plan-hash inline))
+          "same testable content → same plan-hash regardless of provenance"))))


### PR DESCRIPTION
## Summary

Builds the keystone evidence primitive for the NewTestStory vision (rf2-5x1wt.3): the **single** canonical projection + fingerprinting operation that determinism, semantic-diff, snapshot-identity, `:plan-hash`, `:run-hash`, future golden slices, and the inline-plan-to-registered-variant metamorphic relation all consume. Per `tools/story/spec/017-Testing-Story.md` §Canonicalization.

## What changed

- **New ns `re-frame.story.fingerprint`** — one projection + one hash:
  - `canonicalize` — strip the volatile-field set + `:rf.story/*` accumulator keys recursively, reconcile `:variant-id` → `:variant/id`, impose total per-slot ordering.
  - `content-hash` — strip-free ordered hash (the snapshot-tuple low primitive).
  - `canonical-hash` — hash of the stripped projection (determinism / diff path).
  - `plan-hash` / `run-hash` — `canonical-hash` over enumerated slices (`plan-hash-input-keys` / `run-hash-input-keys`). No second hash implementation.
- **Folded `re-frame.story.identity`** — its `canonical-form` / `content-hash` are now thin re-exports of the fingerprint vars (one canonical path). `snapshot-tuple` / `snapshot-identity` keep their public surface.
- **Public re-exports** on `re-frame.story`: `canonicalize`, `canonical-hash`, `content-hash`, `plan-hash`, `run-hash`.
- **Adversarial corpus** in `re-frame.story-fingerprint-test` (JVM, full) + `re-frame.story-fingerprint-cljs-test` (host-portability): volatile-only twins hash equal; single-field semantic twins (app-db / effect / assertion verdict / status / epoch db-after / warning) hash unequal; plan-hash & run-hash proven to share the one primitive; metamorphic inline ≡ registered-variant plan.
- **Spec** `017-Testing-Story.md` §Canonicalization gains a concrete primitive-contract subsection (surface table, volatile set incl. `:run-hash`, ordering, snapshot migration path).

## Snapshot-identity migration path

Pure relocation of the hashing code, not a version bump. Snapshot identity hashes its tuple through the strip-free `content-hash`, so the snapshot content-hash is **byte-identical** across the fold — existing visual-regression baselines stay valid, no re-stamp. The volatile strip + `:variant-id` reconciliation apply only on the `canonicalize` / `canonical-hash` path; the snapshot tuple keeps its `:variant-id` slot exactly as before.

## Quality gates

All run from the worker worktree:

- `cd tools/story && clojure -M:test` — **874 tests, 2611 assertions, 0 failures, 0 errors**.
- `cd implementation && npm run test:cljs` — **4838 tests, 15855 assertions, 0 failures, 0 errors**.
- `bash scripts/test-fast-pr.sh --with-docs` — **PASS** (CLJS spine + README/docs-corpus anchor validators; mkdocs soft-skipped locally, CI runs it).
- `git grep -l "story.identity"` outside `tools/story/` — empty; no external tool consumes the identity ns, so the JVM + CLJS gates fully cover the fold.
