### PR TITLE
feat(story): name settled-boundary contract (dispatch drain + runner flush) (rf2-5x1wt.2)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -441,6 +441,52 @@ the headless *implementation*. `[:dispatch-sync event-vector]` MAY remain
 as a low-level escape step but SHOULD NOT be the normal authoring form;
 an explicit `[:dispatch-sync …]` keeps its current meaning.
 
+#### Concrete contract surface
+
+The contract is named and exposed by the `re-frame.story.play.settled-boundary`
+namespace. It does **not** introduce a second quiescence engine; it names
+the existing framework drain and a flush-hook seam over it.
+
+- `boundary-levels` — the ladder vector `[:headless :cljs-reactive :dom
+  :browser]`, cheapest → richest; `boundary>=` compares two boundaries on
+  it (unknown boundaries fail closed). `step-required-boundary` maps a
+  script step to the minimum boundary it needs (`[:dispatch …]` →
+  `:headless`; `[:click …]` / `[:type …]` / `[:assert-dom …]` → `:dom`).
+- `drain-sync!` — the headless `settled-boundary`: `dispatch-sync*`
+  (= `router/dispatch-sync!`) projected under the boundary name. This is
+  the existing run-to-fixed-point drain (Spec 002 §dispatch-sync), not a
+  reimplementation.
+- **flush-hooks** — the adapter-aware caller supplies a hooks map:
+
+  ```clojure
+  {:provides  :headless | :cljs-reactive | :dom | :browser
+   :dispatch! (fn [frame-id event-vector] …)         ; enqueue / fire
+   :flush!    {:headless      (fn [frame-id] …)       ; drain to fixed point
+               :cljs-reactive (fn [frame-id] …)       ; + reaction flush
+               :dom           (fn [frame-id] …)}      ; + act()/microtask
+   :timeout-ms optional-number}
+  ```
+
+  `headless-flush-hooks` is the default the JVM / node-runtime headless
+  runner uses (`:provides :headless`, `:dispatch!` routed through
+  `drain-sync!`). Adapter callers register richer hooks declaring a higher
+  `:provides`; the runner resolves them through the
+  `:settled-boundary-hooks` late-bind slot and never reaches for
+  `dispatch-sync` directly.
+- `dispatch-and-settle!` — the entry point `[:dispatch event-vector]`
+  lowers to: dispatch through the supplied `:dispatch!`, then run each
+  registered flush whose level is `<= required` in ladder order. It
+  returns `{:status :settled :boundary <required>}` on success, a
+  `:cannot-run` refusal when the runner's `:provides` does not reach the
+  required boundary (the event is **not** dispatched — fail-closed), or
+  `{:status :error …}` when a flush/dispatch throws. A flush timeout
+  reports `:cannot-run` or `:error` per policy (`flush-timeout-result`) —
+  **never a silent pass**.
+
+The play runner's `[:dispatch …]` step (`re-frame.story.play.runner-events/
+exec-dispatch!`) routes through `dispatch-and-settle!`, so in headless it
+settles synchronously to fixed point and is no longer an async-yield step.
+
 ### Script step grammar
 
 P1 uses **one tagged step grammar** across `:setup` and `:script`, but

--- a/tools/story/src/re_frame/story/play/runner.cljc
+++ b/tools/story/src/re_frame/story/play/runner.cljc
@@ -76,16 +76,23 @@
 
 (def async-yield-step-types
   "Steps that put work on an async queue the runner cannot directly
-  flush — `:dispatch` (re-frame router), `:click` / `:type` (synthetic
-  DOM events whose handlers re-enter the dispatch chain), and `:wait`
-  (the runner sleeps explicitly). The driver yields one tick AFTER these
-  steps so the queued effects drain before the next step runs.
+  flush — `:click` / `:type` (synthetic DOM events whose handlers
+  re-enter the dispatch chain) and `:wait` (the runner sleeps
+  explicitly). The driver yields one tick AFTER these steps so the
+  queued effects drain before the next step runs.
 
-  Steps NOT in this set (`:dispatch-sync`, `:assert-db`, `:assert-dom`)
-  are pure-synchronous on CLJS — yielding between them is what allowed
-  concurrent `auto-run!` calls to interleave and overshoot counter
-  increments in the Playwright matrix (rf2-ftow6)."
-  #{:dispatch :click :type :wait})
+  `:dispatch` is NOT in this set as of rf2-5x1wt.2: a `[:dispatch …]`
+  step now settles through `settled-boundary` (spec/017) — in headless
+  the `dispatch-sync*` run-to-fixed-point drain — so it is synchronous
+  at the step boundary, exactly like `:dispatch-sync`. Yielding between
+  synchronous steps is what let concurrent `auto-run!` calls interleave
+  and overshoot counter increments in the Playwright matrix (rf2-ftow6);
+  settling `:dispatch` synchronously removes that hazard for the queued
+  authoring form too.
+
+  Steps NOT in this set (`:dispatch`, `:dispatch-sync`, `:assert-db`,
+  `:assert-dom`) recur synchronously on CLJS."
+  #{:click :type :wait})
 
 (declare step-type)
 

--- a/tools/story/src/re_frame/story/play/runner_events.cljc
+++ b/tools/story/src/re_frame/story/play/runner_events.cljc
@@ -43,6 +43,7 @@
             [re-frame.story.play        :as play]
             [re-frame.story.play.dom    :as dom]
             [re-frame.story.play.runner :as runner]
+            [re-frame.story.play.settled-boundary :as boundary]
             [re-frame.story.registrar   :as registrar]))
 
 ;; ---- per-variant run-state -----------------------------------------------
@@ -247,6 +248,28 @@
         (merge {:frame variant-id} payload)))
     (catch #?(:clj Throwable :cljs :default) _ nil)))
 
+;; ---- settled-boundary flush hooks (rf2-5x1wt.2) --------------------------
+;;
+;; `[:dispatch event-vector]` settles through `settled-boundary` (spec/017
+;; §Script and `settled-boundary`). The runner takes its flush-hooks from
+;; the adapter-aware caller via the `:settled-boundary-hooks` late-bind
+;; slot; the default is the headless hooks (`dispatch-sync*` drain). Story
+;; core never reaches for `dispatch-sync` directly — the boundary ns owns
+;; the drain, the hooks own the richer reactive / DOM flushes.
+
+(defn current-flush-hooks
+  "Resolve the active flush-hooks map. An adapter-aware caller (the
+  Reagent/UIx/Helix shell, a future `:dom` browser runner) registers a
+  richer hooks map via `late-bind/set-fn! :settled-boundary-hooks <fn>`,
+  where the fn takes the frame-id and returns the hooks for that frame.
+  When no adapter has registered, the headless hooks are used so a
+  `[:dispatch …]` step settles to fixed point synchronously."
+  [frame-id]
+  (if-let [f (late-bind/get-fn :settled-boundary-hooks)]
+    (or (try (f frame-id) (catch #?(:clj Throwable :cljs :default) _ nil))
+        boundary/headless-flush-hooks)
+    boundary/headless-flush-hooks))
+
 ;; ---- step executors ------------------------------------------------------
 
 (declare read-frame-db)
@@ -289,8 +312,45 @@
                            :message  msg}))
       (runner/step-skip idx step))))
 
+(defn- boundary-result->step
+  "Project a `settled-boundary/dispatch-and-settle!` non-`:settled`
+  outcome into a runner step-result. `:cannot-run` becomes a step-fail
+  carrying the refusal (so the play surfaces a distinct refusal, never a
+  silent pass — spec/017 §`:cannot-run`); `:error` becomes a step-fail
+  with the boundary error message. Returns nil for `:settled` (the
+  dispatch's pass/fail comes from the assertion bridge instead)."
+  [idx step settle]
+  (case (:status settle)
+    :cannot-run
+    (runner/step-fail idx step
+                      {:cannot-run? true
+                       :required-boundary (:required-boundary settle)
+                       :provided-boundary (:provided-boundary settle)
+                       :reason   (:reason settle)
+                       :message  (str "cannot run " (pr-str step)
+                                      " — requires settled-boundary "
+                                      (pr-str (:required-boundary settle))
+                                      " but runner provides "
+                                      (pr-str (:provided-boundary settle))
+                                      " (" (name (or (:reason settle) :runner-below-required-boundary)) ")")})
+    :error
+    (runner/step-exception idx step (:error settle))
+    ;; :settled → no step-level result from the boundary itself.
+    nil))
+
 (defn- exec-dispatch!
-  "Execute a `:dispatch` step. Returns a step-result.
+  "Execute a `:dispatch` step — dispatch the event and settle through
+  `settled-boundary` (spec/017 §Script and `settled-boundary`,
+  rf2-5x1wt.2). In headless this is the existing `dispatch-sync*`
+  run-to-fixed-point drain, named via `settled-boundary`; richer runners
+  supply reactive / DOM flushes through their flush-hooks. The runner
+  NEVER hard-codes `dispatch-sync` — it routes through the boundary's
+  caller-supplied hooks (`current-flush-hooks`).
+
+  When the active runner cannot satisfy the step's required boundary the
+  boundary refuses with `:cannot-run` and the step is NOT dispatched
+  (fail-closed); the refusal becomes a runner step-fail rather than a
+  silent pass.
 
   Drains any handler-exception trace events captured by the play
   listener into `:rf.story/assertions` so the test-mode pane + Xray
@@ -304,17 +364,19 @@
   `:passed? false` becomes a runner-visible step-fail so the play's
   terminal status flips to `:fail`."
   [frame-id idx step]
-  (let [evec   (runner/step-event step)
-        prev   (assertion-count frame-id)
-        result (try
-                 (rf/dispatch* evec {:frame frame-id})
-                 nil
-                 (catch #?(:clj Throwable :cljs :default) e
-                   (runner/step-exception idx step
-                                          #?(:clj  (.getMessage ^Throwable e)
-                                             :cljs (str e)))))]
+  (let [evec     (runner/step-event step)
+        prev     (assertion-count frame-id)
+        required (boundary/step-required-boundary step)
+        hooks    (current-flush-hooks frame-id)
+        settle   (try
+                   (boundary/dispatch-and-settle! frame-id evec hooks required step)
+                   (catch #?(:clj Throwable :cljs :default) e
+                     {:status :error
+                      :error  #?(:clj (.getMessage ^Throwable e) :cljs (str e))
+                      :step   step}))]
     (play/drain-pending-exceptions! frame-id :phase-4-play)
-    (or result (dispatch-step-result frame-id prev idx step))))
+    (or (boundary-result->step idx step settle)
+        (dispatch-step-result frame-id prev idx step))))
 
 (defn- exec-dispatch-sync!
   [frame-id idx step]

--- a/tools/story/src/re_frame/story/play/settled_boundary.cljc
+++ b/tools/story/src/re_frame/story/play/settled_boundary.cljc
@@ -1,0 +1,280 @@
+(ns re-frame.story.play.settled-boundary
+  "The `settled-boundary` contract — the single name for what
+  `[:dispatch event-vector]` waits for before the runner advances to the
+  next script step (NewTestStory rf2-5x1wt.2, spec/017-Testing-Story.md
+  §Script and `settled-boundary` + §Shared primitive lock).
+
+  ## What a settled boundary is
+
+  `settled-boundary` is NOT a new headless scheduler and NOT a second
+  quiescence engine. It is a *name* for the settlement contract layered
+  over the framework primitives that already exist:
+
+  - `:headless` — the variant frame's event queue is drained AND all
+    synchronous re-dispatches have settled. This is the existing
+    `re-frame.core/dispatch-sync*` (= `router/dispatch-sync!`)
+    run-to-fixed-point drain, projected under a name — not reimplemented.
+  - `:cljs-reactive` — the headless boundary AND reaction recomputation
+    has flushed.
+  - `:dom` — the above AND the adapter's `act()` / microtask flush has
+    completed, within a declared maximum.
+  - `:browser` — the above AND real browser layout / paint has settled.
+
+  These are an **ordered ladder**: a richer boundary subsumes every
+  cheaper one. `boundary-levels` is the canonical order; `boundary>=`
+  compares two boundaries on it.
+
+  ## The flush-hook seam
+
+  The runner MUST NOT hard-code `dispatch-sync`. It takes a *flush-hooks*
+  map from the adapter-aware caller:
+
+      {:dispatch! (fn [frame-id event-vector] ...)  ; enqueue / fire the event
+       :provides  :headless | :cljs-reactive | :dom | :browser
+       :flush!    {:headless      (fn [frame-id] ...)   ; drain to fixed point
+                   :cljs-reactive (fn [frame-id] ...)   ; + reaction flush
+                   :dom           (fn [frame-id] ...)}  ; + act()/microtask
+       :timeout-ms optional-number}                     ; richer-boundary bound
+
+  `headless-flush-hooks` is the default the JVM / node-runtime headless
+  runner uses: `:provides :headless`, `:dispatch!` and the `:headless`
+  flush both routed through `re-frame.core/dispatch-sync*` so a queued
+  `[:dispatch …]` step settles to fixed point synchronously — the
+  behaviour the legacy `:dispatch` step approximated with a `setTimeout`
+  yield, now named and deterministic.
+
+  Adapter-aware callers (the Reagent/UIx/Helix shell, a future `:dom`
+  browser runner) register richer hooks declaring a higher `:provides`
+  and supplying the reactive / DOM flush fns. Story core never reaches
+  for React or the DOM directly; the flush fns are the only seam.
+
+  ## `:cannot-run`
+
+  A step declares the boundary it needs (`step-required-boundary`). When
+  the active runner's `:provides` does not reach that boundary — e.g. a
+  `:dom`-requiring `[:click …]` under a `:headless` runner — the boundary
+  REFUSES with a `:cannot-run` refusal map (`cannot-run-refusal`) rather
+  than under-flushing and passing falsely. A flush that times out reports
+  `:cannot-run` or `:error` per the caller's policy; it MUST NEVER report
+  a silent pass.
+
+  This namespace is `.cljc` and stays free of `re-frame` view / DOM
+  requires beyond the framework `dispatch-sync*` alias, so the contract +
+  the headless boundary are JVM-runnable and unit-testable. The richer
+  flush fns are injected by adapter callers; this ns only *names* the
+  ladder, *routes* a dispatch through the supplied hooks, and *refuses*
+  when the supplied boundary is too weak."
+  (:require [re-frame.core :as rf]))
+
+;; ---- the boundary ladder -------------------------------------------------
+
+(def boundary-levels
+  "The settlement ladder, cheapest → richest. Each level subsumes every
+  level before it. `[:dispatch …]` declares the MINIMUM boundary it needs
+  (`:headless`); richer steps (`:click`, `:type`, DOM assertions) declare
+  a richer minimum. A runner is valid for a step iff the boundary it
+  PROVIDES is `>=` the step's required boundary on this ladder."
+  [:headless :cljs-reactive :dom :browser])
+
+(def ^:private boundary-rank
+  "boundary keyword → its 0-based index on `boundary-levels`."
+  (into {} (map-indexed (fn [i b] [b i]) boundary-levels)))
+
+(defn boundary?
+  "True iff `b` is a recognised boundary keyword."
+  [b]
+  (contains? boundary-rank b))
+
+(defn boundary>=
+  "True iff boundary `a` is at least as rich as boundary `b` on the
+  ladder. Unknown boundaries compare false (fail-closed)."
+  [a b]
+  (boolean
+    (and (boundary? a) (boundary? b)
+         (>= (boundary-rank a) (boundary-rank b)))))
+
+(defn max-boundary
+  "Return the richer of two boundaries (the one further along the
+  ladder). Unknown boundaries are treated as the weakest. With no
+  recognised boundary, returns `:headless`."
+  ([] :headless)
+  ([b] (if (boundary? b) b :headless))
+  ([a b]
+   (cond
+     (and (boundary? a) (boundary? b)) (if (boundary>= a b) a b)
+     (boundary? a) a
+     (boundary? b) b
+     :else :headless)))
+
+;; ---- step → required boundary --------------------------------------------
+
+(def default-step-boundaries
+  "The minimum settled-boundary each script step type requires, per
+  spec/017 §Script step grammar. `[:dispatch …]` needs only `:headless`
+  (drain to fixed point); DOM-touching steps need `:dom`. `:wait-until` /
+  `:wait` are runner-dependent (the predicate / the wall-clock dictates),
+  so they declare the cheapest boundary and the caller's predicate decides
+  the rest. `:dispatch-sync` is the explicit low-level escape — it IS the
+  headless boundary."
+  {:dispatch       :headless
+   :dispatch-sync  :headless
+   :wait           :headless
+   :wait-until     :headless
+   :assert-db      :headless
+   :assert-dom     :dom
+   :click          :dom
+   :type           :dom
+   :focus          :dom})
+
+(defn step-required-boundary
+  "The minimum settled-boundary `step` needs, from `default-step-boundaries`
+  keyed by the step's tag. Unknown / untagged steps default to `:headless`
+  (a bare dispatch). Pure data → data."
+  [step]
+  (let [tag (when (and (vector? step) (pos? (count step)))
+              (let [h (first step)] (when (keyword? h) h)))]
+    (get default-step-boundaries tag :headless)))
+
+;; ---- :cannot-run refusal -------------------------------------------------
+
+(defn cannot-run-refusal
+  "Build the `:cannot-run` refusal map for a step whose required boundary
+  the active runner cannot satisfy. Shape mirrors spec/017 §`:cannot-run`
+  (a distinct third status, never a silent pass):
+
+      {:status           :cannot-run
+       :required-boundary <boundary>
+       :provided-boundary <boundary>
+       :reason            <keyword>
+       :step              <step or nil>}
+
+  `:reason` defaults to `:runner-below-required-boundary`; a flush timeout
+  caller passes `:flush-timeout`."
+  ([required provided step]
+   (cannot-run-refusal required provided step :runner-below-required-boundary))
+  ([required provided step reason]
+   (cond-> {:status            :cannot-run
+            :required-boundary  required
+            :provided-boundary  provided
+            :reason             reason}
+     (some? step) (assoc :step step))))
+
+(defn satisfies-boundary?
+  "True iff a runner that PROVIDES `provided` can settle a step that
+  REQUIRES `required`. Pure ladder comparison; fail-closed on unknowns."
+  [provided required]
+  (boundary>= provided required))
+
+;; ---- the headless flush hooks (default) ----------------------------------
+
+(defn drain-sync!
+  "The headless `settled-boundary`: dispatch `event-vector` into
+  `frame-id` and drain the router to fixed point — synchronous
+  re-dispatches included. This is `re-frame.core/dispatch-sync*` projected
+  under the boundary name; it is the SAME run-to-fixed-point drain the
+  framework already owns (Spec 002 §dispatch-sync), not a new scheduler.
+
+  Returns nil. Raises nothing the framework would not already raise (a
+  `dispatch-sync` issued from inside a running drain surfaces
+  `:rf.error/dispatch-sync-in-handler` through the trace bus, as usual)."
+  [frame-id event-vector]
+  (rf/dispatch-sync* event-vector {:frame frame-id})
+  nil)
+
+(def headless-flush-hooks
+  "Default flush-hooks map for the headless runner (JVM + node-runtime).
+  `:provides :headless`; both `:dispatch!` and the `:headless` flush route
+  through the framework `dispatch-sync*` drain (`drain-sync!`), so a
+  `[:dispatch …]` step settles to fixed point synchronously and
+  deterministically.
+
+  Adapter callers that can flush reactions / DOM register their own hooks
+  declaring a higher `:provides` and supplying `:flush!` fns for the
+  richer levels. The runner consumes ONLY this map — it never reaches for
+  `dispatch-sync` directly (spec/017 §Script and `settled-boundary`: the
+  runner takes a flush-fn from the adapter-aware caller)."
+  {:provides  :headless
+   :dispatch! drain-sync!
+   :flush!    {:headless (fn headless-flush [_frame-id] nil)}})
+
+(defn hooks-provided-boundary
+  "The boundary a flush-hooks map PROVIDES. Reads `:provides`; defaults to
+  `:headless` when absent (a hooks map with no declared ceiling is assumed
+  headless-only — fail-closed for richer steps)."
+  [hooks]
+  (let [p (:provides hooks)]
+    (if (boundary? p) p :headless)))
+
+;; ---- the dispatch-and-settle entry point ---------------------------------
+
+(defn dispatch-and-settle!
+  "Dispatch `event-vector` into `frame-id` and settle to the boundary the
+  step requires, using the caller-supplied `hooks`. This is what
+  `[:dispatch event-vector]` MEANS (spec/017 §Script and
+  `settled-boundary`): dispatch, then wait for `settled-boundary`.
+
+  `hooks` is a flush-hooks map (see `headless-flush-hooks`). `required`
+  is the boundary the step needs (default `:headless`); when omitted, a
+  bare dispatch settles to the headless drain.
+
+  Returns one of:
+
+  - `{:status :settled :boundary <required>}` — the dispatch fired and
+    the runner flushed up to (and including) the required boundary.
+  - a `cannot-run-refusal` map — the runner's `:provides` does not reach
+    `required`; the event is NOT dispatched (fail-closed, no partial /
+    under-flushed pass).
+  - `{:status :error :error <message> :step …}` — a flush fn threw or the
+    `:dispatch!` hook threw. NEVER a silent pass.
+
+  Settlement runs every flush registered in `(:flush! hooks)` whose level
+  is `<= required`, in ladder order — so a `:dom` step under a runner that
+  provides `:dom` runs the `:headless`, `:cljs-reactive`, and `:dom`
+  flushes in turn. A missing flush fn for a level the runner claims to
+  provide is treated as a no-op for that level (the cheaper level still
+  drained the queue)."
+  ([frame-id event-vector hooks]
+   (dispatch-and-settle! frame-id event-vector hooks :headless nil))
+  ([frame-id event-vector hooks required]
+   (dispatch-and-settle! frame-id event-vector hooks required nil))
+  ([frame-id event-vector hooks required step]
+   (let [required (if (boundary? required) required :headless)
+         provided (hooks-provided-boundary hooks)]
+     (if-not (satisfies-boundary? provided required)
+       ;; Fail-closed: do not dispatch, do not under-flush. A step that
+       ;; needs a richer boundary than the runner provides is refused.
+       (cannot-run-refusal required provided step)
+       (try
+         (let [dispatch! (or (:dispatch! hooks) drain-sync!)
+               flushes   (:flush! hooks)]
+           (dispatch! frame-id event-vector)
+           ;; Run each registered flush up to and including `required`,
+           ;; in ladder order. The headless flush is folded into
+           ;; `:dispatch!` (`drain-sync!`), so its hook is a no-op; the
+           ;; richer flushes carry the adapter's reactive / DOM work.
+           (doseq [level boundary-levels
+                   :while (boundary>= required level)]
+             (when-let [f (get flushes level)]
+               (f frame-id)))
+           {:status :settled :boundary required})
+         (catch #?(:clj Throwable :cljs :default) e
+           {:status :error
+            :error  #?(:clj (.getMessage ^Throwable e) :cljs (str e))
+            :step   step}))))))
+
+;; ---- timeout helper ------------------------------------------------------
+
+(defn flush-timeout-result
+  "Build the result for a richer-boundary flush that exceeded its declared
+  maximum. Per spec/017 a flush timeout reports `:cannot-run` or `:error`
+  per the caller's policy — NEVER a silent pass. `policy` is
+  `:cannot-run` (default) or `:error`."
+  ([required provided step] (flush-timeout-result required provided step :cannot-run))
+  ([required provided step policy]
+   (case policy
+     :error {:status :error
+             :error  (str "settled-boundary flush for " required
+                          " exceeded its declared maximum")
+             :step   step}
+     ;; default :cannot-run
+     (cannot-run-refusal required provided step :flush-timeout))))

--- a/tools/story/test/re_frame/story/play/runner_test.cljc
+++ b/tools/story/test/re_frame/story/play/runner_test.cljc
@@ -24,19 +24,21 @@
 
 (deftest async-yield-classification
   (testing "async-yield? returns true for steps whose effects queue
-            outside the runner — :dispatch (router), :click / :type
-            (synthetic-event handlers re-entering dispatch), :wait
-            (explicit sleep). Used by run-loop! to decide whether to
-            recur synchronously or yield. rf2-ftow6."
-    (is (true? (runner/async-yield? [:dispatch [:foo]])))
+            outside the runner — :click / :type (synthetic-event handlers
+            re-entering dispatch) and :wait (explicit sleep). Used by
+            run-loop! to decide whether to recur synchronously or yield.
+            rf2-ftow6."
     (is (true? (runner/async-yield? [:click "[data-test=x]"])))
     (is (true? (runner/async-yield? [:type "[data-test=x]" "text"])))
     (is (true? (runner/async-yield? [:wait 0])))
     (is (true? (runner/async-yield? [:wait 100]))))
   (testing "sync-class steps must NOT yield — that's the bug the race
-            fix corrects. :dispatch-sync, :assert-db, :assert-dom are
-            purely synchronous on CLJS; yielding between them allowed
-            concurrent runs to interleave and overshoot counter incs."
+            fix corrects. :dispatch (now settled through settled-boundary
+            — the dispatch-sync* drain, rf2-5x1wt.2), :dispatch-sync,
+            :assert-db, :assert-dom are synchronous at the step boundary
+            on CLJS; yielding between them allowed concurrent runs to
+            interleave and overshoot counter incs."
+    (is (false? (runner/async-yield? [:dispatch [:foo]])))
     (is (false? (runner/async-yield? [:dispatch-sync [:foo]])))
     (is (false? (runner/async-yield? [:assert-db [:k] 1])))
     (is (false? (runner/async-yield? [:assert-db [:k] :pred even?])))

--- a/tools/story/test/re_frame/story/play/settled_boundary_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/play/settled_boundary_cljs_test.cljs
@@ -1,0 +1,90 @@
+(ns re-frame.story.play.settled-boundary-cljs-test
+  "Node-runtime (CLJS) tests for the `settled-boundary` headless drain
+  (rf2-5x1wt.2, spec/017-Testing-Story.md §Script and `settled-boundary`).
+
+  Dispatch / settle behaviour is host-sensitive — the JVM `.cljc` suite
+  covers the pure ladder + refusal shape; this ns confirms the headless
+  boundary actually drains the frame queue and synchronous re-dispatches
+  to fixed point on the CLJS host (where the legacy `:dispatch` step used
+  a `setTimeout` yield rather than a synchronous drain). The pure ladder
+  helpers themselves also run here so a host-specific regression in the
+  ladder math would surface."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core  :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.story.play.settled-boundary :as boundary]))
+
+(def ^:private bf :story.boundary.cljs/frame)
+
+(defn- reset-frame! [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (try (rf/init! plain-atom/adapter)
+       (catch :default _ nil))
+  (frame/ensure-default-frame!)
+  (frame/reg-frame bf {:doc "settled-boundary cljs drain test frame"})
+  (test-fn))
+
+(use-fixtures :each reset-frame!)
+
+;; ---- pure ladder math on the CLJS host -----------------------------------
+
+(deftest ladder-and-refusal-on-cljs
+  (testing "the boundary ladder + refusal helpers behave identically on CLJS"
+    (is (= [:headless :cljs-reactive :dom :browser] boundary/boundary-levels))
+    (is (boundary/boundary>= :dom :headless))
+    (is (not (boundary/boundary>= :headless :dom)))
+    (is (= :headless (boundary/step-required-boundary [:dispatch [:e]])))
+    (is (= :dom      (boundary/step-required-boundary [:click "b"])))
+    (is (= :headless (boundary/hooks-provided-boundary boundary/headless-flush-hooks)))))
+
+;; ---- headless drain on the node host -------------------------------------
+
+(deftest cljs-headless-dispatch-drains-to-fixed-point
+  (testing "dispatch-and-settle! drains the frame queue AND synchronous
+            re-dispatches to fixed point on CLJS — the whole cascade is
+            settled synchronously when the call returns, NO setTimeout
+            tick (the legacy :dispatch step relied on a yield here)"
+    (rf/reg-event-fx :cljs.chain/a
+      (fn [{:keys [db]} _]
+        {:db (update db :hops (fnil conj []) :a)
+         :fx [[:dispatch [:cljs.chain/b]]]}))
+    (rf/reg-event-fx :cljs.chain/b
+      (fn [{:keys [db]} _]
+        {:db (update db :hops (fnil conj []) :b)
+         :fx [[:dispatch [:cljs.chain/c]]]}))
+    (rf/reg-event-db :cljs.chain/c
+      (fn [db _] (update db :hops (fnil conj []) :c)))
+    (let [res (boundary/dispatch-and-settle!
+                bf [:cljs.chain/a] boundary/headless-flush-hooks
+                :headless [:dispatch [:cljs.chain/a]])]
+      (is (= :settled (:status res)))
+      (is (= :headless (:boundary res)))
+      (is (= [:a :b :c] (:hops (rf/get-frame-db bf)))
+          "the queued re-dispatch cascade drained to fixed point before return"))))
+
+(deftest cljs-headless-refuses-dom-step
+  (testing "a :dom-requiring step under the headless runner refuses with
+            :cannot-run and does NOT dispatch the event on CLJS"
+    (let [fired (atom false)]
+      (rf/reg-event-db :cljs.dom/should-not-fire
+        (fn [db _] (reset! fired true) db))
+      (let [res (boundary/dispatch-and-settle!
+                  bf [:cljs.dom/should-not-fire] boundary/headless-flush-hooks
+                  :dom [:click "button"])]
+        (is (= :cannot-run (:status res)))
+        (is (= :dom      (:required-boundary res)))
+        (is (= :headless (:provided-boundary res)))
+        (is (false? @fired) "fail-closed: the event is not dispatched")))))
+
+(deftest cljs-flush-error-not-swallowed
+  (testing "a throwing flush fn surfaces :error on CLJS, never a silent pass"
+    (let [hooks {:provides  :dom
+                 :dispatch! (fn [frame-id evec] (boundary/drain-sync! frame-id evec))
+                 :flush!    {:dom (fn [_] (throw (ex-info "cljs flush boom" {})))}}]
+      (rf/reg-event-db :cljs.dom/x (fn [db _] db))
+      (let [res (boundary/dispatch-and-settle! bf [:cljs.dom/x] hooks :dom [:click "b"])]
+        (is (= :error (:status res)))
+        (is (re-find #"cljs flush boom" (:error res)))))))

--- a/tools/story/test/re_frame/story/play/settled_boundary_test.cljc
+++ b/tools/story/test/re_frame/story/play/settled_boundary_test.cljc
@@ -1,0 +1,204 @@
+(ns re-frame.story.play.settled-boundary-test
+  "Contract tests for the `settled-boundary` primitive (rf2-5x1wt.2,
+  spec/017-Testing-Story.md §Script and `settled-boundary`).
+
+  Two layers:
+
+  - PURE (JVM + CLJS): the boundary ladder, step→boundary mapping,
+    `:cannot-run` refusal shape, and the headless flush-hooks default.
+  - HEADLESS DRAIN (JVM + CLJS, against a live frame): `dispatch-and-settle!`
+    drains the frame queue + synchronous redispatches to fixed point; a
+    step requiring a richer boundary than the runner provides refuses with
+    `:cannot-run` (never a silent pass); a flush error is reported as
+    `:error`, never swallowed."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core   :as rf]
+            [re-frame.frame  :as frame]
+            [re-frame.story.play.settled-boundary :as boundary]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.registrar :as registrar]))
+
+;; ---- pure: the boundary ladder -------------------------------------------
+
+(deftest boundary-ladder-ordering
+  (testing "the ladder is cheapest→richest and `boundary>=` respects it"
+    (is (= [:headless :cljs-reactive :dom :browser] boundary/boundary-levels))
+    (is (boundary/boundary>= :dom :headless))
+    (is (boundary/boundary>= :headless :headless))
+    (is (boundary/boundary>= :browser :dom))
+    (is (not (boundary/boundary>= :headless :dom)))
+    (is (not (boundary/boundary>= :cljs-reactive :browser)))))
+
+(deftest unknown-boundary-fails-closed
+  (testing "unknown boundaries compare false (fail-closed)"
+    (is (not (boundary/boundary>= :nonsense :headless)))
+    (is (not (boundary/boundary>= :headless :nonsense)))
+    (is (false? (boundary/boundary? :nonsense)))
+    (is (true?  (boundary/boundary? :dom)))))
+
+(deftest max-boundary-picks-richer
+  (testing "max-boundary returns the richer of two, treating unknowns as weakest"
+    (is (= :dom      (boundary/max-boundary :headless :dom)))
+    (is (= :dom      (boundary/max-boundary :dom :headless)))
+    (is (= :browser  (boundary/max-boundary :browser :cljs-reactive)))
+    (is (= :headless (boundary/max-boundary :nonsense :nonsense)))
+    (is (= :dom      (boundary/max-boundary :nonsense :dom)))))
+
+;; ---- pure: step → required boundary --------------------------------------
+
+(deftest step-required-boundary-mapping
+  (testing "[:dispatch …] needs only :headless; DOM steps need :dom"
+    (is (= :headless (boundary/step-required-boundary [:dispatch [:e]])))
+    (is (= :headless (boundary/step-required-boundary [:dispatch-sync [:e]])))
+    (is (= :headless (boundary/step-required-boundary [:assert-db [:k] 1])))
+    (is (= :dom      (boundary/step-required-boundary [:click "button"])))
+    (is (= :dom      (boundary/step-required-boundary [:type "input" "x"])))
+    (is (= :dom      (boundary/step-required-boundary [:assert-dom "div" :visible]))))
+  (testing "unknown / untagged steps default to :headless"
+    (is (= :headless (boundary/step-required-boundary [:no/such-step])))
+    (is (= :headless (boundary/step-required-boundary "not-a-step")))))
+
+;; ---- pure: :cannot-run refusal shape -------------------------------------
+
+(deftest cannot-run-refusal-shape
+  (testing "refusal carries required + provided + reason + step"
+    (let [r (boundary/cannot-run-refusal :dom :headless [:click "b"])]
+      (is (= :cannot-run (:status r)))
+      (is (= :dom        (:required-boundary r)))
+      (is (= :headless   (:provided-boundary r)))
+      (is (= :runner-below-required-boundary (:reason r)))
+      (is (= [:click "b"] (:step r)))))
+  (testing "an explicit reason (e.g. flush timeout) is preserved"
+    (let [r (boundary/cannot-run-refusal :dom :headless nil :flush-timeout)]
+      (is (= :flush-timeout (:reason r)))
+      (is (not (contains? r :step)) "nil step is omitted"))))
+
+(deftest satisfies-boundary-predicate
+  (testing "a runner satisfies a step iff its provided boundary >= required"
+    (is (boundary/satisfies-boundary? :dom :headless))
+    (is (boundary/satisfies-boundary? :headless :headless))
+    (is (not (boundary/satisfies-boundary? :headless :dom)))))
+
+;; ---- pure: the default headless flush-hooks ------------------------------
+
+(deftest headless-hooks-shape
+  (testing "the default headless hooks provide :headless and route dispatch through the drain"
+    (is (= :headless (boundary/hooks-provided-boundary boundary/headless-flush-hooks)))
+    (is (fn? (:dispatch! boundary/headless-flush-hooks)))
+    (is (fn? (get-in boundary/headless-flush-hooks [:flush! :headless])))))
+
+(deftest hooks-provided-defaults-headless
+  (testing "a hooks map with no :provides is assumed headless-only (fail-closed)"
+    (is (= :headless (boundary/hooks-provided-boundary {})))
+    (is (= :headless (boundary/hooks-provided-boundary {:provides :bogus})))
+    (is (= :dom      (boundary/hooks-provided-boundary {:provides :dom})))))
+
+;; ---- pure: flush-timeout result policy -----------------------------------
+
+(deftest flush-timeout-policy
+  (testing "a flush timeout reports :cannot-run or :error per policy, never a pass"
+    (let [cr (boundary/flush-timeout-result :dom :headless [:click "b"])]
+      (is (= :cannot-run (:status cr)))
+      (is (= :flush-timeout (:reason cr))))
+    (let [err (boundary/flush-timeout-result :dom :headless [:click "b"] :error)]
+      (is (= :error (:status err)))
+      (is (string? (:error err))))))
+
+;; ---- headless drain: against a live frame --------------------------------
+
+(def ^:private bf :story.boundary/frame)
+
+(defn- reset-frame! [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (try (rf/init! plain-atom/adapter)
+       (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) _ nil))
+  (frame/ensure-default-frame!)
+  (frame/reg-frame bf {:doc "settled-boundary drain test frame"})
+  (test-fn))
+
+(use-fixtures :each reset-frame!)
+
+(deftest headless-dispatch-drains-to-fixed-point
+  (testing "dispatch-and-settle! drains the queue AND synchronous
+            re-dispatches to fixed point under the headless hooks — the
+            cascade is fully settled when the call returns (no yield)"
+    ;; :chain/a re-dispatches :chain/b (queued); :chain/b re-dispatches
+    ;; :chain/c. A run-to-fixed-point drain settles all three before
+    ;; dispatch-and-settle! returns.
+    (rf/reg-event-fx :chain/a
+      (fn [{:keys [db]} _]
+        {:db (update db :hops (fnil conj []) :a)
+         :fx [[:dispatch [:chain/b]]]}))
+    (rf/reg-event-fx :chain/b
+      (fn [{:keys [db]} _]
+        {:db (update db :hops (fnil conj []) :b)
+         :fx [[:dispatch [:chain/c]]]}))
+    (rf/reg-event-db :chain/c
+      (fn [db _] (update db :hops (fnil conj []) :c)))
+    (let [res (boundary/dispatch-and-settle!
+                bf [:chain/a] boundary/headless-flush-hooks :headless [:dispatch [:chain/a]])]
+      (is (= :settled (:status res)))
+      (is (= :headless (:boundary res)))
+      ;; The entire synchronous cascade has settled — all three hops are
+      ;; present immediately, no async tick required.
+      (is (= [:a :b :c] (:hops (rf/get-frame-db bf)))
+          "queued re-dispatches drained to fixed point before return"))))
+
+(deftest headless-refuses-dom-required-step
+  (testing "a :dom-requiring step under the headless runner refuses with
+            :cannot-run and does NOT dispatch the event (fail-closed,
+            never a silent pass)"
+    (let [fired (atom false)]
+      (rf/reg-event-db :dom/should-not-fire
+        (fn [db _] (reset! fired true) db))
+      (let [res (boundary/dispatch-and-settle!
+                  bf [:dom/should-not-fire] boundary/headless-flush-hooks
+                  :dom [:click "button"])]
+        (is (= :cannot-run (:status res)))
+        (is (= :dom      (:required-boundary res)))
+        (is (= :headless (:provided-boundary res)))
+        (is (false? @fired)
+            "the event is NOT dispatched when the boundary cannot be satisfied")))))
+
+(deftest richer-runner-satisfies-dom-and-runs-flush
+  (testing "a runner that PROVIDES :dom satisfies a :dom step and runs the
+            registered reactive + dom flush fns in ladder order"
+    (let [flushed (atom [])
+          hooks   {:provides  :dom
+                   :dispatch! (fn [frame-id evec]
+                                (boundary/drain-sync! frame-id evec))
+                   :flush!    {:headless      (fn [_] (swap! flushed conj :headless))
+                               :cljs-reactive (fn [_] (swap! flushed conj :reactive))
+                               :dom           (fn [_] (swap! flushed conj :dom))}}]
+      (rf/reg-event-db :dom/click (fn [db _] (assoc db :clicked true)))
+      (let [res (boundary/dispatch-and-settle! bf [:dom/click] hooks :dom [:click "b"])]
+        (is (= :settled (:status res)))
+        (is (= :dom     (:boundary res)))
+        (is (true? (:clicked (rf/get-frame-db bf))) "event dispatched")
+        (is (= [:headless :reactive :dom] @flushed)
+            "flushes run in ladder order up to and including the required boundary")))))
+
+(deftest flush-error-is-reported-not-swallowed
+  (testing "a throwing flush fn surfaces :error, never a silent pass
+            (spec/017: a flush timeout/error NEVER reports a pass)"
+    (let [hooks {:provides  :dom
+                 :dispatch! (fn [frame-id evec] (boundary/drain-sync! frame-id evec))
+                 :flush!    {:dom (fn [_] (throw (ex-info "flush boom" {})))}}]
+      (rf/reg-event-db :dom/x (fn [db _] db))
+      (let [res (boundary/dispatch-and-settle! bf [:dom/x] hooks :dom [:click "b"])]
+        (is (= :error (:status res)))
+        (is (re-find #"flush boom" (:error res)))
+        (is (not= :settled (:status res)) "a flush failure is never a settled pass")))))
+
+(deftest drain-sync-settles-synchronous-redispatch
+  (testing "drain-sync! (the named headless boundary) is the framework
+            dispatch-sync* drain — re-dispatched events settle before return"
+    (rf/reg-event-fx :seed/start
+      (fn [{:keys [db]} _]
+        {:db (assoc db :n 0)
+         :fx [[:dispatch [:seed/bump]]]}))
+    (rf/reg-event-db :seed/bump (fn [db _] (update db :n inc)))
+    (boundary/drain-sync! bf [:seed/start])
+    (is (= 1 (:n (rf/get-frame-db bf)))
+        "the queued :seed/bump drained synchronously within drain-sync!")))


### PR DESCRIPTION
Names the dispatch-settlement contract for NewTestStory (rf2-5x1wt.2) as the **existing** `dispatch-sync` run-to-fixed-point drain plus an adapter-supplied flush-hook seam — no competing quiescence engine, no shims. Implements plan §A0 / spec/017 §Script and `settled-boundary`.

## What changed

- **New `re-frame.story.play.settled-boundary` ns** names + exposes the contract:
  - `boundary-levels` ladder (`:headless` < `:cljs-reactive` < `:dom` < `:browser`); `boundary>=`, `max-boundary`, `step-required-boundary`.
  - `drain-sync!` — the headless `settled-boundary`: `re-frame.core/dispatch-sync*` (= the framework `router/dispatch-sync!` run-to-fixed-point drain) projected under the boundary name, **not** reimplemented.
  - flush-hooks shape (`:provides` / `:dispatch!` / `:flush!` per level / `:timeout-ms`) + the default `headless-flush-hooks`.
  - `dispatch-and-settle!` — the meaning of `[:dispatch event-vector]`: dispatch, then run each registered flush `<= required` in ladder order. Returns `{:status :settled …}`, a `:cannot-run` refusal (fail-closed: the event is **not** dispatched), or `{:status :error …}`. `flush-timeout-result` reports `:cannot-run`/`:error` per policy — never a silent pass.
- **`[:dispatch …]` now settles through the boundary** in the play runner (`runner-events/exec-dispatch!`): headless drains the frame queue + synchronous re-dispatches to fixed point. The runner resolves flush-hooks via the `:settled-boundary-hooks` late-bind slot and never hard-codes `dispatch-sync`; adapter-aware callers register richer hooks for reactive/DOM flushes.
- **`:cannot-run` at the boundary**: a DOM-required step under a headless runner refuses rather than under-flushing and passing falsely.
- `:dispatch` removed from the async-yield set — it is now synchronous at the step boundary like `:dispatch-sync` (consistent with the rf2-ftow6 race fix).
- spec/017 §Script and `settled-boundary` updated with the concrete contract surface.

## Quality gates

- `tools/story` JVM (`clojure -M:test`): **876 tests / 2615 assertions, 0 failures**.
- CLJS node integration (`npm run test:cljs`): **4837 tests / 15859 assertions, 0 failures** (host-sensitive dispatch/settle covered — includes the new `settled-boundary-cljs-test`).
- Story play-scripts (`npm run test:story-play-scripts`): **29 rows / 0 unexpected outcomes** (DOM, multi-play, failing scenarios all green).
- `scripts/test-fast-pr.sh`: **PASS** (core JVM 795/3516; CLJS node 4837/15859; JS harness; README/docs anchor gates; mkdocs soft-skipped — CI runs it).

## Tests added

- `settled-boundary-test.cljc` (JVM): pure ladder/refusal/hooks + headless drain against a live frame (fixed-point cascade; `:cannot-run` doesn't dispatch; flush error reported, not swallowed).
- `settled-boundary-cljs-test.cljs` (node): the host-sensitive headless drain on CLJS (legacy `:dispatch` relied on a `setTimeout` yield here).

## Risks / notes

- No shared-file overlap with in-flight rf2-5x1wt.3 (`identity.cljc` / fingerprint ns) or rf2-5x1wt.10 (`plan.cljc`) — confirmed by file list.
- Behaviour change: `[:dispatch …]` is now synchronous in headless. Intended per spec (pre-alpha, no back-compat). The one existing test asserting `:dispatch` async-yield (`runner-test/async-yield-classification`) was updated to the new contract; `[:dispatch-sync …]` remains the low-level escape step.
- The full capability-token registry + variant-level `:cannot-run` aggregation are rf2-5x1wt.16 (blocked by this); this PR delivers the boundary-level refusal that .16 builds on.