### PR TITLE
refactor(story): migrate public vocabulary to :setup/:script (rf2-5x1wt.11)

### DIFF
--- a/docs/story/01-first-story.md
+++ b/docs/story/01-first-story.md
@@ -25,11 +25,11 @@ Here is the smallest interesting `stories.cljs` you can write. (We're going to u
    :substrates #{:reagent}})
 
 (story/reg-variant :story.counter/empty
-  {:doc         "Fresh counter at zero."
-   :events      [[:counter/initialise 0]]
-   :play-script [[:dispatch-sync [:rf.assert/path-equals [:count] 0]]]
-   :tags        #{:dev :docs :test}
-   :substrates  #{:reagent}})
+  {:doc        "Fresh counter at zero."
+   :setup      [[:counter/initialise 0]]
+   :script     [[:dispatch-sync [:rf.assert/path-equals [:count] 0]]]
+   :tags       #{:dev :docs :test}
+   :substrates #{:reagent}})
 ```
 
 Save. Reload the dev build. Open `#/stories`. You're in.
@@ -56,13 +56,13 @@ This single design call — *keyword references, not function references* — is
 
 `reg-variant` registers **one variant** — one scenario, one frame, one canvas paint. Three slots carry the meat:
 
-- **`:events`** — a sequence of regular event vectors. They dispatch in source order through the same router the live app uses. By the time the canvas paints, the variant frame's `app-db` is exactly what those events left behind. This is your *setup phase*: how do you get the world into the state this variant exercises?
+- **`:setup`** — a sequence of regular event vectors. They dispatch in source order through the same router the live app uses. By the time the canvas paints, the variant frame's `app-db` is exactly what those events left behind. This is your *setup phase*: how do you get the world into the state this variant exercises?
 
 - **`:args`** — the variant's prop overrides. Deep-merged into the parent story's args (and into any active mode's args, and any global args, and any live cell-overrides from the controls panel). The resolved map is what the view renders against.
 
-- **`:play-script`** — the assertion sequence. Runs after `:events` settle and the canvas mounts. Each step in the script is a vector with a step-id (`:dispatch-sync`, `:wait`, `:click`, `:type`, `:assert-db`, `:assert-dom`) and its payload. The canonical assertion events from re-frame2 (`:rf.assert/path-equals`, `:rf.assert/sub-equals`, and the rest of the seven) ride the `:dispatch-sync` step.
+- **`:script`** — the behaviour-under-test sequence. Runs after `:setup` settles and the canvas mounts. Each step in the script is a vector with a step-id (`:dispatch-sync`, `:wait`, `:click`, `:type`, `:assert-db`, `:assert-dom`) and its payload. The canonical assertion events from re-frame2 (`:rf.assert/path-equals`, `:rf.assert/sub-equals`, and the rest of the seven) ride the `:dispatch-sync` step.
 
-> 💡 **Note for Storybook refugees.** Storybook's `play` function is JavaScript — you write async functions that call `userEvent.click(...)` and `expect(...).toBeVisible()`. Story's `:play-script` is *data* — a vector of step tuples that a runner interprets. Same role; different substance. The runner lives at `re-frame.story.play.runner`; the step grammar lives in [`API.md`](https://github.com/day8/re-frame2/blob/main/tools/story/spec/API.md) §`:play-script`. The advantage of the data shape is that the recorder (chapter 3) can *generate* a `:play-script` body from your interactions and you can paste it directly into source. Try generating a TypeScript function from a recording and you'll appreciate the difference.
+> 💡 **Note for Storybook refugees.** Storybook's `play` function is JavaScript — you write async functions that call `userEvent.click(...)` and `expect(...).toBeVisible()`. Story's `:script` is *data* — a vector of step tuples that a runner interprets. Same role; different substance. The runner lives at `re-frame.story.play.runner`; the step grammar lives in [`API.md`](https://github.com/day8/re-frame2/blob/main/tools/story/spec/API.md) §`:play-script`. The advantage of the data shape is that the recorder (chapter 3) can *generate* a `:script` body from your interactions and you can paste it directly into source. Try generating a TypeScript function from a recording and you'll appreciate the difference.
 
 A variant body is **plain EDN**. No fn slots; no closures; no JSX-shaped DSL. We mentioned this in the welcome; we will mention it again throughout this tutorial because every time you reach for "I'll just put a function here" the right answer is "register the thing the function does, reference it by id." It is the discipline that makes the rest of Story work.
 
@@ -137,22 +137,22 @@ Decorators are the only `reg-*` registration where Story authoring legally holds
 
   (story/reg-variant :story.counter/loaded
     {:decorators [[:app/centered-layout]]
-     :events     [[:counter/initialise 7]]
+     :setup      [[:counter/initialise 7]]
      :substrates #{:reagent}})
   ```
 
-- **`:frame-setup` decorators** — patch the variant's frame at allocation time. Used when several variants share a setup like "assume the user is logged in." The events dispatch before the variant's own `:events`; the patch merges into the variant frame's `app-db`. Pure data, no closures.
+- **`:frame-setup` decorators** — patch the variant's frame at allocation time. Used when several variants share a setup like "assume the user is logged in." The events dispatch before the variant's own `:setup`; the patch merges into the variant frame's `app-db`. Pure data, no closures.
 
 - **`:fx-override` decorators** — stub a network call (or *any* fx — analytics, websockets, geolocation, storage, navigation). The marquee shape is `force-fx-stub`, which Story ships built-in:
 
   ```clojure
   (story/reg-variant :story.counter/save-stubbed
-    {:events      [[:counter/initialise 5]]
-     :decorators  [[story/force-fx-stub-id :counter/sync-to-server {:ok? true}]]
-     :play-script [[:dispatch-sync [:counter/save]]
-                   [:dispatch-sync [:rf.assert/path-equals [:saving?] true]]
-                   [:dispatch-sync [:rf.assert/effect-emitted :counter/sync-to-server]]]
-     :substrates  #{:reagent}})
+    {:setup      [[:counter/initialise 5]]
+     :decorators [[story/force-fx-stub-id :counter/sync-to-server {:ok? true}]]
+     :script     [[:dispatch-sync [:counter/save]]
+                  [:dispatch-sync [:rf.assert/path-equals [:saving?] true]]
+                  [:dispatch-sync [:rf.assert/effect-emitted :counter/sync-to-server]]]
+     :substrates #{:reagent}})
   ```
 
 The `force-fx-stub-id` Var holds the well-known id for the built-in decorator; we expose it as a Var so you're not memorising keyword paths. Three lines stubs *any* effect handler — `reg-fx`'d HTTP, analytics, websocket, geolocation, storage, navigation. The Storybook ecosystem has a separate addon for each of these (`msw-storybook-addon` for HTTP, separate stuff for analytics, etc.); Story has the one primitive because re-frame2 already names the seam — every side effect runs through a registered `reg-fx` handler the runtime calls. Stubbing it is a one-liner because the seam already exists.
@@ -179,7 +179,7 @@ A few diagnostic notes from the trenches. Tutorials that pretend everything work
 
 - **The variant shows up but the canvas is blank.** Your view-id keyword doesn't resolve to a registered view. Story has no way to render a view that wasn't `reg-view`'d. Check the spelling of the keyword on `:component`; check that the view's namespace is loaded (transitively); check that the `reg-view` macro actually ran (a typo in `defn` vs `reg-view` is silent until render).
 
-- **You see *Canvas* / *Docs* / *Tests* tabs but the *Tests* tab says "no assertions recorded".** You probably wrote `:play` instead of `:play-script`, or you wrote the play-script body as `[:rf.assert/path-equals [:count] 0]` (a bare event vector) instead of `[:dispatch-sync [:rf.assert/path-equals [:count] 0]]` (a `:dispatch-sync` step containing the event vector). The play-script grammar is *step-tuples*; the canonical assertions ride the `:dispatch-sync` step. (This is a recent rename; some external blog posts still show the old shape.)
+- **You see *Canvas* / *Docs* / *Tests* tabs but the *Tests* tab says "no assertions recorded".** You probably wrote `:play` instead of `:script` (the public play slot; `:play-script` is the transitional spelling), or you wrote the script body as `[:rf.assert/path-equals [:count] 0]` (a bare event vector) instead of `[:dispatch-sync [:rf.assert/path-equals [:count] 0]]` (a `:dispatch-sync` step containing the event vector). The script grammar is *step-tuples*; the canonical assertions ride the `:dispatch-sync` step. (This is a recent rename; some external blog posts still show the old shape.)
 
 - **Variant renders but the right-side controls panel doesn't show your arg.** You probably haven't registered a schema on the view, and your parent story doesn't carry `:argtypes`. The controls panel needs *some* hint about how to render an editor; the schema is the preferred source, `:argtypes` is the override channel. We'll get into this more in chapter 4.
 

--- a/docs/story/index.md
+++ b/docs/story/index.md
@@ -29,7 +29,7 @@ The Story loop:
 1. Open `#/stories` in your dev build.
 2. Click each state in the left sidebar. The canvas swaps in 30ms.
 3. Open a workspace that mounts all five side-by-side; design review against the grid.
-4. Switch to *Tests* mode; every variant's `:play-script` assertions run automatically; the sidebar dots flip green.
+4. Switch to *Tests* mode; every variant's `:script` assertions run automatically; the sidebar dots flip green.
 5. Click *record* on the canvas toolbar, tap through the form once, click *stop*; out comes an EDN `:play-script` body that captures exactly what you just did. Paste it into the variant.
 6. Ship.
 
@@ -62,7 +62,7 @@ Before we dive in, three contracts that nothing else in Story makes sense withou
 
 1. **Each variant runs in its own frame.** Fresh `app-db`, fresh queue, fresh sub-cache. State doesn't leak between scenarios. What you see is what production would render against the same fixture. This sounds like a small thing; it isn't. It's the reason every other rule on this list is sustainable.
 
-2. **Variant bodies are data — never functions.** A variant body is a map with `:events`, `:args`, `:decorators`, `:play-script`, etc. Every slot is plain EDN, round-trippable across the network. Closures live in exactly one place: inside decorator registrations, where they're a registration-site concern, not a variant-body concern. This is the lock that lets MCP, visual-regression services, and agent input pipelines all consume the same shape.
+2. **Variant bodies are data — never functions.** A variant body is a map with `:setup`, `:args`, `:decorators`, `:script`, etc. Every slot is plain EDN, round-trippable across the network. Closures live in exactly one place: inside decorator registrations, where they're a registration-site concern, not a variant-body concern. This is the lock that lets MCP, visual-regression services, and agent input pipelines all consume the same shape.
 
 3. **Assertions record, don't throw.** A failing `:rf.assert/path-equals` doesn't blow up the variant — it appends an entry to the variant frame's assertion accumulator. The play sequence runs to completion either way; the test runner asks "did every entry pass?" at the end. You get the full picture from a broken variant, not a stack trace and a single failure.
 

--- a/tools/story/spec/001-Authoring.md
+++ b/tools/story/spec/001-Authoring.md
@@ -374,9 +374,9 @@ no fn-slots):
 ```clojure
 {:doc                   "..."
  :extends               <variant-id>             ; parent variant; merged at registration
- :events                [[:event-id args ...]]   ; setup events; phase 2
- :play-script           {:script [...steps]      ; post-render rich-DSL script; phase 4
-                         :auto-run? true         ; (rf2-0wrud — canonical AND ONLY phase-4 slot)
+ :setup                 [[:event-id args ...]]   ; precondition events; phase 2 (PUBLIC; :events is the transitional spelling)
+ :script                {:script [...steps]      ; post-render rich-DSL behaviour under test; phase 4 (PUBLIC; :play-script is the transitional spelling)
+                         :auto-run? true
                          :name "happy path"}
  :args                  {<arg-key> <value>}      ; override/extend story args
  :argtypes              {<arg-key> {...}}        ; override story argtypes
@@ -397,11 +397,22 @@ no fn-slots):
                          :focus   {...}}}
 ```
 
-### `:play-script` — the canonical phase-4 surface (rf2-0wrud)
+### `:script` — the public phase-4 surface (rf2-5x1wt.11)
 
-`:play-script` is the canonical AND ONLY phase-4 play surface
-(rf2-0wrud, 2026-05-20). Pre-alpha posture: the legacy `:play`
-event-vector slot has been removed — no transitional dual-acceptance.
+`:script` is the **public** authoring key for the post-render
+behaviour-under-test sequence; `:play-script` is the transitional
+spelling accepted during the pre-alpha rename and lowered to the
+shipping slot by the registrar (`schemas/lower-public-vocabulary`).
+Per [`017-Testing-Story.md`](017-Testing-Story.md) §Public vocabulary,
+`:setup` / `:script` are the target authoring vocabulary; `:events` /
+`:play-script` are transitional spellings that lower to the shipping
+slots until the runtime is routed through the variant-plan compiler
+(rf2-5x1wt.17 / .22). A variant declares ONE play surface from
+`:script` / `:play-script` / `:plays` (mutually exclusive at the
+schema layer).
+
+Pre-alpha posture: the legacy `:play` event-vector slot has been
+removed — no transitional dual-acceptance (rf2-0wrud, 2026-05-20).
 Authors compose post-render behaviour as a sequence of TAGGED steps:
 
 | Step                                  | Semantics                                                |

--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -96,6 +96,21 @@ in the normalized plan; they are not dropped in P1. The legacy `:play`
 event-vector slot was already removed (rf2-0wrud); P1 does not
 reintroduce it.
 
+The variant schema (`re-frame.story.schemas/Variant`) accepts both
+spellings and enforces that an author picks ONE setup surface
+(`:setup` xor `:events`) and ONE play surface
+(`:script` xor `:play-script` xor `:plays`). The registrar's
+`schemas/lower-public-vocabulary` step folds `:setup` → `:events` and
+`:script` → `:play-script` into the stored body so every shipping
+RUNTIME reader — phase-2 events, the play runner's `variant-body->plays`,
+snapshot identity, the workspace/canvas readers, and the recorder —
+consumes the shipping slot unchanged while the tree migrates. This
+lowering is the sanctioned temporary normalization, not a long-lived
+shim: it is removed once the runtime is routed through the variant-plan
+compiler (which already normalizes both spellings, §Compiler API and
+normalization contract). Until then, a variant authored with `:setup` /
+`:script` runs identically to one authored with the shipping slots.
+
 ### Four-bucket authoring model
 
 The normalized plan is organized around four buckets:

--- a/tools/story/src/re_frame/story/registrar.cljc
+++ b/tools/story/src/re_frame/story/registrar.cljc
@@ -330,14 +330,27 @@
   [id body]
   (maybe-auto-install!)
   (assert-id! :variant id)
-  (let [resolved (extends/resolve-extends
-                   body
+  ;; rf2-5x1wt.11 — validate the AUTHORED body first so the public-
+  ;; vocabulary mutual-exclusion (`:setup` xor `:events`, `:script` xor
+  ;; `:play-script` xor `:plays`) fires on what the author actually
+  ;; wrote, before `lower-public-vocabulary` folds the public spellings
+  ;; into the shipping slots.
+  (validate-shape! :variant id body)
+  (let [;; Lower `:setup`→`:events` and `:script`→`:play-script` so the
+        ;; stored body carries the shipping slots every downstream
+        ;; consumer reads (per spec/017 §Public vocabulary; removed when
+        ;; the runtime reads the normalized plan — rf2-5x1wt.17 / .22).
+        lowered  (schemas/lower-public-vocabulary body)
+        resolved (extends/resolve-extends
+                   lowered
                    (fn [pid] (handler-meta :variant pid))
                    ;; rf2-ee38b.3: :play-script and :plays are sibling
                    ;; encodings of the play surface. When the child
                    ;; overrides one, drop the inherited other so the
                    ;; merged body doesn't carry both (which the schema's
-                   ;; mutual-exclusion :fn would reject).
+                   ;; mutual-exclusion :fn would reject). Parents are
+                   ;; already stored lowered, so the public `:script` /
+                   ;; `:plays` distinction is collapsed before this point.
                    [#{:play-script :plays}])
         body     (-> resolved
                      merge-coords

--- a/tools/story/src/re_frame/story/schemas.cljc
+++ b/tools/story/src/re_frame/story/schemas.cljc
@@ -417,11 +417,18 @@
   [:vector PlayStep])
 
 (def PlaySpec
-  "The full body shape of `:play-script`. Two forms:
+  "The full body shape of the public `:script` slot (and the transitional
+  `:play-script` slot it supersedes). Two forms:
 
   - Bare vector — sugar for `{:script <vector> :auto-run? true}`.
   - Map         — `{:script :auto-run? :name}` with all keys optional
-                  bar `:script`."
+                  bar `:script`.
+
+  Per `tools/story/spec/017-Testing-Story.md` §Public vocabulary the
+  public authoring key for ordered behaviour-under-test is `:script`;
+  `:play-script` is the transitional spelling accepted during the
+  pre-alpha rename and lowered to the shipping slot by the registrar
+  (`lower-public-vocabulary`). Both spellings share this body shape."
   [:or
    PlayScript
    [:map
@@ -469,40 +476,80 @@
   their own keys without registration ceremony (per Spec-Schemas's
   open-by-default convention).
 
-  ## Multi-play (rf2-tl7zk)
+  ## Public vocabulary (rf2-5x1wt.11)
 
-  A variant may declare ONE of two play surfaces:
+  Per `tools/story/spec/017-Testing-Story.md` §Public vocabulary the P1
+  public authoring vocabulary is:
 
-  - `:play-script` — a single named play (the simple case).
+  - `:setup`  — preconditions (a vector of event vectors).
+  - `:script` — ordered behaviour under test (a `PlaySpec` body).
+
+  These supersede the shipping spellings as a **clean pre-alpha rename,
+  not a long-lived compatibility layer**:
+
+  | Public (target) | Transitional (shipping) |
+  |-----------------|-------------------------|
+  | `:setup`        | `:events`               |
+  | `:script`       | `:play-script`          |
+  | named `:plays`  | `:plays` (kept as named scripts) |
+
+  The schema accepts BOTH spellings so the tree can migrate incrementally
+  while existing tests stay green. The registrar's `lower-public-vocabulary`
+  step folds `:setup` → `:events` and `:script` → `:play-script` into the
+  stored body so every downstream consumer (runtime phase-2, the play
+  runner, snapshot identity, the workspace/canvas readers, the recorder)
+  reads the shipping slot unchanged until the runtime is routed through
+  the variant-plan compiler (rf2-5x1wt.17 / .22). `:plays` is preserved
+  as named scripts in the normalized plan; it is not dropped.
+
+  ## Setup surface — `:setup` xor `:events`
+
+  A variant declares its preconditions through ONE setup spelling. Mixing
+  `:setup` and `:events` is a schema-level error (the author picks one
+  during migration), validated by the `:fn` clause below.
+
+  ## Play surface — `:script` xor `:play-script` xor `:plays` (rf2-tl7zk)
+
+  A variant declares ONE play surface:
+
+  - `:script`      — the public single play (the simple case).
+  - `:play-script` — the transitional spelling of the single play.
   - `:plays`       — a vector of named plays (multiple scenarios).
 
-  These slots are mutually exclusive. If both are present the runner
-  prefers `:plays` and emits a one-time console warning.
+  These three slots are mutually exclusive (validated by the `:fn`
+  clause below). For `:plays` the toolbar surfaces a dropdown and the CI
+  runner enumerates each play as its own result row.
 
-  ## :play-script is the ONLY play surface (rf2-0wrud, 2026-05-20)
+  ## :play was REMOVED (rf2-0wrud, 2026-05-20)
 
-  Pre-alpha posture: `:play-script` is the canonical AND ONLY play
-  surface. The legacy `:play` slot (vector of event vectors) has been
-  removed entirely — there is no transitional dual-acceptance. Authors
-  migrate event-vector lists by wrapping each entry as `[:dispatch-sync
-  <event-vec>]` in a `:play-script` body."
+  Pre-alpha posture: the legacy `:play` slot (vector of event vectors)
+  has been removed entirely — there is no transitional dual-acceptance.
+  Authors migrate event-vector lists by wrapping each entry as
+  `[:dispatch-sync <event-vec>]` in a `:script` body."
   [:and
    [:map
     [:doc                   {:optional true} :string]
     [:extends               {:optional true} :keyword]
+    ;; rf2-5x1wt.11 — `:setup` is the PUBLIC precondition slot; `:events`
+    ;; is the transitional spelling lowered to `:setup`'s shipping slot
+    ;; by the registrar. Mutually exclusive (the `:fn` clause below).
+    [:setup                 {:optional true} [:vector EventVector]]
     [:events                {:optional true} [:vector EventVector]]
-    ;; rf2-8i2a9 — the rich Storybook-style play script. rf2-0wrud
-    ;; (2026-05-20): `:play-script` is the canonical AND ONLY phase-4
-    ;; surface; the legacy `:play` slot is REMOVED. Each step is a
-    ;; tagged vector (`[:dispatch ...]`, `[:dispatch-sync ...]`,
-    ;; `[:wait ms]`, `[:assert-db path value]`, `[:assert-dom selector
-    ;; ...]`, `[:click selector]`, `[:type selector text]`). See
-    ;; `PlaySpec`.
+    ;; rf2-5x1wt.11 — `:script` is the PUBLIC play slot (per spec/017
+    ;; §Public vocabulary). rf2-8i2a9 — the rich Storybook-style play
+    ;; script body shape. Each step is a tagged vector (`[:dispatch ...]`,
+    ;; `[:dispatch-sync ...]`, `[:wait ms]`, `[:assert-db path value]`,
+    ;; `[:assert-dom selector ...]`, `[:click selector]`, `[:type selector
+    ;; text]`). See `PlaySpec`.
+    [:script                {:optional true} PlaySpec]
+    ;; `:play-script` — the transitional spelling of `:script`, lowered
+    ;; to `:script`'s shipping slot by the registrar. rf2-0wrud
+    ;; (2026-05-20): the legacy `:play` slot is REMOVED.
     [:play-script           {:optional true} PlaySpec]
     ;; rf2-tl7zk — multi-play: a vector of named plays. Mutually
-    ;; exclusive with `:play-script` (validated by the `:fn` clause
-    ;; below). The toolbar surfaces a dropdown when `:plays` has more
-    ;; than one entry; the CI runner enumerates each play as its own
+    ;; exclusive with `:script` / `:play-script` (validated by the `:fn`
+    ;; clause below). The toolbar surfaces a dropdown when `:plays` has
+    ;; more than one entry; the CI runner enumerates each play as its own
     ;; result row. See `PlaysSpec`.
     [:plays                 {:optional true} PlaysSpec]
     [:args                  {:optional true} ArgMap]
@@ -536,14 +583,27 @@
     ;; with variant-first, then story-level, then chrome toolbar.
     [:viewport              {:optional true} ViewportSlot]
     [:background            {:optional true} BackgroundSlot]]
-   ;; rf2-tl7zk — mutual-exclusion check. Authors pick ONE play surface
-   ;; per variant; mixing them is a schema-level error so the rejection
-   ;; lands at `reg-variant*` rather than surprising the runner.
+   ;; rf2-5x1wt.11 — setup-surface mutual-exclusion. `:setup` is the
+   ;; public spelling, `:events` the transitional one; an author picks
+   ;; ONE during migration. Mixing both is a schema-level error so the
+   ;; rejection lands at `reg-variant*` rather than the registrar's
+   ;; `lower-public-vocabulary` step silently picking a winner.
    [:fn {:error/message
-         ":play-script and :plays are mutually exclusive — pick one per variant"}
+         ":setup and :events are mutually exclusive — :setup is the public spelling"}
     (fn [body]
-      (not (and (contains? body :play-script)
-                (contains? body :plays))))]])
+      (not (and (contains? body :setup)
+                (contains? body :events))))]
+   ;; rf2-tl7zk + rf2-5x1wt.11 — play-surface mutual-exclusion. Authors
+   ;; pick ONE play surface per variant from `:script` (public) /
+   ;; `:play-script` (transitional) / `:plays` (named scripts); mixing
+   ;; any two is a schema-level error so the rejection lands at
+   ;; `reg-variant*` rather than surprising the runner.
+   [:fn {:error/message
+         (str ":script / :play-script / :plays are mutually exclusive — "
+              "pick one play surface per variant (:script is the public spelling)")}
+    (fn [body]
+      (<= (count (filter #(contains? body %) [:script :play-script :plays]))
+          1))]])
 
 ;; ---- :rf/workspace --------------------------------------------------------
 
@@ -749,3 +809,41 @@
   (when-let [schema (get kind->schema kind)]
     (when-not (m/validate schema body)
       (m/explain schema body))))
+
+;; ---- public-vocabulary lowering (rf2-5x1wt.11) ---------------------------
+
+(defn lower-public-vocabulary
+  "Fold the public Story authoring vocabulary (`:setup` / `:script`) into
+  the shipping body slots (`:events` / `:play-script`). Pure data → data.
+
+  Per `tools/story/spec/017-Testing-Story.md` §Public vocabulary the
+  pre-alpha rename makes `:setup` / `:script` the public authoring keys.
+  The variant-plan compiler (`re-frame.story.plan`) already normalizes
+  both spellings, but the shipping RUNTIME — phase-2 events, the play
+  runner's `variant-body->plays`, snapshot identity, the workspace /
+  canvas readers, the recorder — still reads the `:events` / `:play-script`
+  / `:plays` slots. Until the runtime is routed through the plan compiler
+  (rf2-5x1wt.17 / .22) the registrar lowers the public spellings into the
+  shipping slots so a variant authored with `:setup` / `:script` runs
+  unchanged.
+
+  This is the sanctioned 'temporarily normalize current terms while the
+  tree is migrated' step (spec/017 §Public vocabulary), NOT a long-lived
+  compatibility layer — it is removed when the runtime reads the
+  normalized plan directly.
+
+  Lowering rules (only when the public key is present and the shipping
+  sibling is absent — the schema's mutual-exclusion `:fn` already
+  guarantees they never co-exist):
+
+  - `:setup`  → `:events`
+  - `:script` → `:play-script`
+
+  `:plays` (named scripts) is already a shipping slot and passes through
+  untouched. A body carrying only shipping spellings is returned as-is."
+  [body]
+  (cond-> body
+    (contains? body :setup)  (-> (assoc :events (:setup body))
+                                 (dissoc :setup))
+    (contains? body :script) (-> (assoc :play-script (:script body))
+                                 (dissoc :script))))

--- a/tools/story/test/re_frame/story_authoring_validation_test.clj
+++ b/tools/story/test/re_frame/story_authoring_validation_test.clj
@@ -186,6 +186,96 @@
         (is (= :rf.error/variant-shape (:rf.error/id (ex-data e))))))))
 
 ;; ===========================================================================
+;; rf2-5x1wt.11 — public vocabulary (:setup / :script) + lowering
+;; ===========================================================================
+;;
+;; Per tools/story/spec/017-Testing-Story.md §Public vocabulary, `:setup`
+;; and `:script` are the public authoring keys; `:events` / `:play-script`
+;; are the transitional spellings. The registrar lowers the public
+;; spellings into the shipping slots so the runtime reads them unchanged
+;; until rf2-5x1wt.17 / .22 route it through the variant plan.
+
+(deftest reg-variant-public-setup-script-validate-and-lower
+  (testing ":setup / :script are accepted and lowered to :events / :play-script"
+    (story/reg-variant :story.vocab/public
+      {:setup  [[:counter/initialise 3]]
+       :script [[:dispatch-sync [:rf.assert/path-equals [:count] 3]]]})
+    (let [body (story/handler-meta :variant :story.vocab/public)]
+      (is (= [[:counter/initialise 3]] (:events body))
+          ":setup lowered into the shipping :events slot")
+      (is (some? (:play-script body))
+          ":script lowered into the shipping :play-script slot")
+      (is (not (contains? body :setup))  "authored :setup key dropped after lowering")
+      (is (not (contains? body :script)) "authored :script key dropped after lowering"))))
+
+(deftest reg-variant-public-script-map-form-lowers
+  (testing "the :script map form (with :name / :auto-run?) lowers to :play-script"
+    (story/reg-variant :story.vocab/public-map
+      {:setup  []
+       :script {:name "named" :auto-run? true
+                :script [[:dispatch-sync [:counter/initialise 1]]]}})
+    (let [body (story/handler-meta :variant :story.vocab/public-map)]
+      (is (= "named" (get-in body [:play-script :name]))
+          "the named map-form :script lowered into :play-script intact"))))
+
+(deftest reg-variant-setup-and-events-mutually-exclusive
+  (testing "a variant may not declare BOTH :setup (public) and :events (transitional)"
+    (try
+      (story/reg-variant :story.vocab/both-setup
+        {:setup  [[:a]]
+         :events [[:b]]})
+      (is false "expected an exception")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :rf.error/variant-shape (:rf.error/id (ex-data e))))))))
+
+(deftest reg-variant-script-and-play-script-mutually-exclusive
+  (testing "a variant may not declare BOTH :script (public) and :play-script (transitional)"
+    (try
+      (story/reg-variant :story.vocab/both-script
+        {:setup       []
+         :script      [[:dispatch [:a]]]
+         :play-script [[:dispatch [:b]]]})
+      (is false "expected an exception")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :rf.error/variant-shape (:rf.error/id (ex-data e))))))))
+
+(deftest reg-variant-script-and-plays-mutually-exclusive
+  (testing "a variant may not declare BOTH :script and :plays"
+    (try
+      (story/reg-variant :story.vocab/script-and-plays
+        {:setup  []
+         :script [[:dispatch [:a]]]
+         :plays  [{:name "p" :script [[:dispatch [:b]]]}]})
+      (is false "expected an exception")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :rf.error/variant-shape (:rf.error/id (ex-data e))))))))
+
+(deftest reg-variant-public-named-plays-still-accepted
+  (testing "named :plays (named scripts) are preserved alongside the public :setup"
+    (story/reg-variant :story.vocab/named-plays
+      {:setup []
+       :plays [{:name "happy" :script [[:dispatch [:foo]]]}
+               {:name "error" :script [[:dispatch [:bar]]]}]})
+    (let [body (story/handler-meta :variant :story.vocab/named-plays)]
+      (is (= 2 (count (:plays body))) ":plays preserved as named scripts")
+      (is (not (contains? body :play-script))
+          ":plays is not lowered to :play-script"))))
+
+(deftest reg-variant-public-script-extends-overrides-transitional-parent
+  (testing "a child's public :script overrides a parent's transitional :play-script
+            (both lower to :play-script, so the existing sibling-drop applies)"
+    (story/reg-variant :story.vocab/parent
+      {:setup       []
+       :play-script {:script [[:dispatch [:p/legacy]]]}})
+    (story/reg-variant :story.vocab/child
+      {:extends :story.vocab/parent
+       :script  {:script [[:dispatch [:c/new]]]}})
+    (let [body (story/handler-meta :variant :story.vocab/child)]
+      (is (contains? body :play-script) "child's lowered :script survived")
+      (is (= [[:dispatch [:c/new]]] (get-in body [:play-script :script]))
+          "the child's play surface won wholesale — no double-encoding"))))
+
+;; ===========================================================================
 ;; UNKNOWN-TAG CONTRACT — tag-vocab cross-check error carries the offending set
 ;; ===========================================================================
 

--- a/tools/story/testbeds/counter_with_stories/stories.cljs
+++ b/tools/story/testbeds/counter_with_stories/stories.cljs
@@ -276,8 +276,8 @@
   ;; `:count` slot equals zero.
   (story/reg-variant :story.counter/empty
     {:doc    "Fresh counter at zero. The simplest possible variant."
-     :events [[:counter/initialise 0]]
-     :play-script [[:dispatch-sync [:rf.assert/path-equals [:count] 0]]]
+     :setup [[:counter/initialise 0]]
+     :script [[:dispatch-sync [:rf.assert/path-equals [:count] 0]]]
      :tags   #{:dev :docs :test}
      :substrates #{:reagent}})
 
@@ -288,8 +288,8 @@
   (story/reg-variant :story.counter/loaded
     {:doc    "A counter seeded with a non-zero value."
      :args   {:label "Total"}
-     :events [[:counter/initialise 7]]
-     :play-script [[:dispatch-sync [:rf.assert/path-equals [:count]              7]]
+     :setup [[:counter/initialise 7]]
+     :script [[:dispatch-sync [:rf.assert/path-equals [:count]              7]]
               [:dispatch-sync [:rf.assert/sub-equals  [:count-doubled]      14]]
               [:dispatch-sync [:rf.assert/sub-equals  [:count-parity]       :odd]]]
      ;; rf2-7ncf9 — faceted tags alongside the existing canonical seven.
@@ -305,7 +305,7 @@
   (story/reg-variant :story.counter/clicked-three-times
     {:doc    "Counter after three increments from zero, driven from
              the play slot so :rf.assert/dispatched? observes them."
-     :events [[:counter/initialise 0]]
+     :setup [[:counter/initialise 0]]
      ;; rf2-yn825: the play-runner's :rf.assert/* bridge now surfaces
      ;; assertion failures that the buggy runner used to swallow. The
      ;; path-equals [:count] 3 check passes under plain-atom (CLJS unit
@@ -314,7 +314,7 @@
      ;; contract is pinned by the CLJS unit test; the dispatched? assertion
      ;; remains here because it observes the trace bus, not the rendered
      ;; count, so substrate quirks do not affect it.
-     :play-script [[:dispatch-sync [:counter/inc]]
+     :script [[:dispatch-sync [:counter/inc]]
               [:dispatch-sync [:counter/inc]]
               [:dispatch-sync [:counter/inc]]
               [:dispatch-sync [:rf.assert/dispatched? [:counter/inc]]]]
@@ -345,7 +345,7 @@
              decorators — the lifecycle takes the fast-path direct to
              `:ready`. Folded in from the retired xray_rhs_smoke
              testbed per rf2-9jfo1.2."
-     :events [[:counter/initialise 5]]
+     :setup [[:counter/initialise 5]]
      :tags   #{:dev :test :internal}
      :substrates #{:reagent}})
 
@@ -360,9 +360,9 @@
     {:doc    "The save flow with the network fx stubbed. Demonstrates
              the MSW-shaped force-fx-stub decorator alongside the
              `:rf.assert/effect-emitted` assertion."
-     :events [[:counter/initialise 5]]
+     :setup [[:counter/initialise 5]]
      :decorators [[story/force-fx-stub-id :counter/sync-to-server {:ok? true}]]
-     :play-script [[:dispatch-sync [:counter/save]]
+     :script [[:dispatch-sync [:counter/save]]
               [:dispatch-sync [:rf.assert/path-equals     [:saving?] true]]
               [:dispatch-sync [:rf.assert/effect-emitted  :counter/sync-to-server]]]
      :tags   #{:dev :test}
@@ -375,8 +375,8 @@
   (story/reg-variant :story.counter-diagnostics/failing-play
     {:doc    "Deterministic failing play assertion. The counter is
              initialised to 1 but the play assertion expects 999."
-     :events [[:counter/initialise 1]]
-     :play-script [[:dispatch-sync [:rf.assert/path-equals [:count] 999]]]
+     :setup [[:counter/initialise 1]]
+     :script [[:dispatch-sync [:rf.assert/path-equals [:count] 999]]]
      :tags   #{:dev :test :internal}
      :substrates #{:reagent}})
 
@@ -385,8 +385,8 @@
   ;; the test pane can explain the failure without blanking the shell.
   (story/reg-variant :story.counter-diagnostics/failing-event-throws
     {:doc    "Deterministic event-handler exception during :play."
-     :events [[:counter/initialise 0]]
-     :play-script [[:dispatch-sync [:counter/throw-deterministic]]]
+     :setup [[:counter/initialise 0]]
+     :script [[:dispatch-sync [:counter/throw-deterministic]]]
      :tags   #{:dev :test :internal}
      :substrates #{:reagent}})
 
@@ -395,8 +395,8 @@
   (story/reg-variant :story.counter-diagnostics/loader-throws
     {:doc     "Deterministic loader exception before events/render."
      :loaders [[:counter/throw-deterministic]]
-     :events  [[:counter/initialise 0]]
-     :play-script [[:dispatch-sync [:rf.assert/path-equals [:count] 0]]]
+     :setup  [[:counter/initialise 0]]
+     :script [[:dispatch-sync [:rf.assert/path-equals [:count] 0]]]
      :tags    #{:dev :test :internal}
      :substrates #{:reagent}})
 
@@ -406,8 +406,8 @@
                 id, and stack detail while keeping the Story shell
                 interactive."
      :component :counter-with-stories.views/throwing-card
-     :events    [[:counter/initialise 0]]
-     :play-script [[:dispatch-sync [:rf.assert/path-equals [:count] 0]]]
+     :setup    [[:counter/initialise 0]]
+     :script [[:dispatch-sync [:rf.assert/path-equals [:count] 0]]]
      :tags      #{:dev :test :internal}
      :substrates #{:reagent}})
 
@@ -417,7 +417,7 @@
              variant passed."
      :args   {:label "No play"
               :settings {:title "No play" :enabled? true}}
-     :events [[:counter/initialise 2]]
+     :setup [[:counter/initialise 2]]
      :tags   #{:dev :internal}
      :substrates #{:reagent}})
 
@@ -428,7 +428,7 @@
      :args    {:label "Loaded by loader"
                :settings {:title "Loader" :enabled? true}}
      :loaders [[:counter/set 12]]
-     :play-script [[:dispatch-sync [:rf.assert/path-equals [:count] 12]]]
+     :script [[:dispatch-sync [:rf.assert/path-equals [:count] 12]]]
      :tags    #{:dev :test :internal}
      :substrates #{:reagent}})
 
@@ -441,7 +441,7 @@
                :settings {:title "Never" :enabled? true}}
      :loaders [[:counter/set 13]]
      :loaders-complete-when :counter/loader-never-ready?
-     :play-script [[:dispatch-sync [:rf.assert/path-equals [:count] 13]]]
+     :script [[:dispatch-sync [:rf.assert/path-equals [:count] 13]]]
      :tags    #{:dev :test :internal}
      :substrates #{:reagent}})
 
@@ -452,8 +452,8 @@
      :args    {:label "Loader rejects"
                :settings {:title "Rejects" :enabled? true}}
      :loaders [[:counter/throw-loader-rejection]]
-     :events  [[:counter/initialise 0]]
-     :play-script [[:dispatch-sync [:rf.assert/path-equals [:count] 0]]]
+     :setup  [[:counter/initialise 0]]
+     :script [[:dispatch-sync [:rf.assert/path-equals [:count] 0]]]
      :tags    #{:dev :test :internal}
      :substrates #{:reagent}})
 
@@ -463,8 +463,8 @@
              failing key while the shell stays interactive."
      :args   {:label 42
               :settings {:title "Bad label" :enabled? true}}
-     :events [[:counter/initialise 4]]
-     :play-script [[:dispatch-sync [:rf.assert/path-equals [:count] 4]]]
+     :setup [[:counter/initialise 4]]
+     :script [[:dispatch-sync [:rf.assert/path-equals [:count] 4]]]
      :tags   #{:dev :test :internal}
      :substrates #{:reagent}})
 
@@ -474,8 +474,8 @@
              still expose path-aware nested widgets."
      :args   {:label "Nested"
               :settings {:title "Nested title" :enabled? true}}
-     :events [[:counter/initialise 6]]
-     :play-script [[:dispatch-sync [:rf.assert/path-equals [:count] 6]]]
+     :setup [[:counter/initialise 6]]
+     :script [[:dispatch-sync [:rf.assert/path-equals [:count] 6]]]
      :tags   #{:dev :test :internal}
      :substrates #{:reagent}})
 
@@ -483,9 +483,9 @@
     {:doc        "Decorator failure projection fixture."
      :args       {:label "Decorator failure"
                   :settings {:title "Decorator" :enabled? true}}
-     :events     [[:counter/initialise 8]]
+     :setup     [[:counter/initialise 8]]
      :decorators [[:counter-with-stories/throwing-decorator]]
-     :play-script [[:dispatch-sync [:rf.assert/path-equals [:count] 8]]]
+     :script [[:dispatch-sync [:rf.assert/path-equals [:count] 8]]]
      :tags       #{:dev :test :internal}
      :substrates #{:reagent}})
 
@@ -495,8 +495,8 @@
                  state rather than leak frames or crash."
      :args       {:label "Substrates"
                   :settings {:title "Substrates" :enabled? true}}
-     :events     [[:counter/initialise 10]]
-     :play-script [[:dispatch-sync [:rf.assert/path-equals [:count] 10]]]
+     :setup     [[:counter/initialise 10]]
+     :script [[:dispatch-sync [:rf.assert/path-equals [:count] 10]]]
      :tags       #{:dev :test :internal}
      :substrates #{:reagent :uix}})
 
@@ -505,8 +505,8 @@
              different seed."
      :args   {:label "Isolation A"
               :settings {:title "A" :enabled? true}}
-     :events [[:counter/initialise 1]]
-     :play-script [[:dispatch-sync [:rf.assert/path-equals [:count] 1]]]
+     :setup [[:counter/initialise 1]]
+     :script [[:dispatch-sync [:rf.assert/path-equals [:count] 1]]]
      :tags   #{:dev :test :internal}
      :substrates #{:reagent}})
 
@@ -515,8 +515,8 @@
              different seed."
      :args   {:label "Isolation B"
               :settings {:title "B" :enabled? true}}
-     :events [[:counter/initialise 100]]
-     :play-script [[:dispatch-sync [:rf.assert/path-equals [:count] 100]]]
+     :setup [[:counter/initialise 100]]
+     :script [[:dispatch-sync [:rf.assert/path-equals [:count] 100]]]
      :tags   #{:dev :test :internal}
      :substrates #{:reagent}})
 
@@ -528,8 +528,8 @@
      :component :counter-with-stories.views/recorder-redaction-card
      :args      {:label "Recorder redaction"
                  :settings {:title "Recorder" :enabled? true}}
-     :events    [[:counter/initialise 11]]
-     :play-script [[:dispatch-sync [:rf.assert/path-equals [:count] 11]]]
+     :setup    [[:counter/initialise 11]]
+     :script [[:dispatch-sync [:rf.assert/path-equals [:count] 11]]]
      :tags      #{:dev :test :internal}
      :substrates #{:reagent}})
 
@@ -540,8 +540,8 @@
      :component :counter-with-stories.views/a11y-known-good-card
      :args      {:label "A11y known good"
                  :settings {:title "A11y good" :enabled? true}}
-     :events    [[:counter/initialise 21]]
-     :play-script [[:dispatch-sync [:rf.assert/path-equals [:count] 21]]]
+     :setup    [[:counter/initialise 21]]
+     :script [[:dispatch-sync [:rf.assert/path-equals [:count] 21]]]
      :tags      #{:dev :test :internal}
      :substrates #{:reagent}})
 
@@ -552,8 +552,8 @@
      :component :counter-with-stories.views/a11y-known-bad-card
      :args      {:label "A11y known bad"
                  :settings {:title "A11y bad" :enabled? true}}
-     :events    [[:counter/initialise 22]]
-     :play-script [[:dispatch-sync [:rf.assert/path-equals [:count] 22]]]
+     :setup    [[:counter/initialise 22]]
+     :script [[:dispatch-sync [:rf.assert/path-equals [:count] 22]]]
      :tags      #{:dev :test :internal}
      :substrates #{:reagent}})
 
@@ -578,8 +578,8 @@
                 diagnostics/failing-play."
      :args      {:label "failing-fx-stub-miss"
                  :settings {:title "failing-fx-stub-miss" :enabled? true}}
-     :events    [[:counter/initialise 0]]
-     :play-script [[:dispatch-sync [:rf.assert/effect-emitted :never-stubbed]]]
+     :setup    [[:counter/initialise 0]]
+     :script [[:dispatch-sync [:rf.assert/effect-emitted :never-stubbed]]]
      :tags      #{:dev :test :internal}
      :substrates #{:reagent}})
 
@@ -613,8 +613,8 @@
                  and assert :count equals 3. Idempotent under any
                  number of auto-run repeats."
      :args       {:label "Play-script pass"}
-     :events     []
-     :play-script
+     :setup     []
+     :script
      {:name      "initialise-three-and-assert-pass"
       :auto-run? true
       :script    [[:dispatch-sync [:counter/initialise 3]]
@@ -630,8 +630,8 @@
                  process-level result stays clean even though the
                  variant deliberately fails."
      :args       {:label "Play-script fail"}
-     :events     []
-     :play-script
+     :setup     []
+     :script
      {:name      "initialise-one-but-expect-nine"
       :auto-run? true
       :script    [[:dispatch-sync [:counter/initialise 1]]
@@ -649,8 +649,8 @@
                  references handed in directly. Survives advanced CLJS
                  because no symbol resolution is performed at run time."
      :args       {:label "Play-script :pred fn-direct"}
-     :events     []
-     :play-script
+     :setup     []
+     :script
      {:name      "pred-fn-direct-passes"
       :auto-run? true
       :script    [[:dispatch-sync [:counter/initialise 3]]
@@ -682,8 +682,8 @@
                  coverage too."
      :component  :counter-with-stories.views/counter-with-input
      :args       {:label "Play-script DOM"}
-     :events     []
-     :play-script
+     :setup     []
+     :script
      {:name      "type-click-and-assert-dom"
       :auto-run? true
       ;; A leading `:wait 300` gives React's first commit a chance to
@@ -713,8 +713,8 @@
                  variant id and asserts the play reaches `:fail`."
      :component  :counter-with-stories.views/counter-with-input
      :args       {:label "Play-script DOM (expected-fail)"}
-     :events     []
-     :play-script
+     :setup     []
+     :script
      {:name      "type-click-and-assert-dom-wrong"
       :auto-run? true
       :script    [[:dispatch-sync [:counter/initialise 0]]
@@ -738,7 +738,7 @@
                  expected status using `failing` / `expected-fail` name
                  markers."
      :args       {:label "Multi-play"}
-     :events     []
+     :setup     []
      :plays      [{:name      "happy-path"
                    :script    [[:dispatch-sync [:counter/initialise 5]]
                                [:assert-db [:count] 5]]}

--- a/tools/story/testbeds/counter_with_stories/stories_cljs_test.cljs
+++ b/tools/story/testbeds/counter_with_stories/stories_cljs_test.cljs
@@ -185,14 +185,23 @@
 ;; ---- variants resolve cleanly ------------------------------------------
 
 (deftest variant-edn-roundtrip
-  (testing "variant->edn returns the registered body for each variant"
+  (testing "variant->edn returns the registered body for each variant.
+            rf2-5x1wt.11: the variants now AUTHOR the public `:setup`
+            vocabulary, but the registrar's `lower-public-vocabulary`
+            step folds `:setup` → `:events` into the stored body so the
+            shipping runtime/snapshot/recorder readers see the shipping
+            slot. The round-trip therefore surfaces `:events` (the
+            lowered form), not `:setup` — this assertion pins that
+            lowering until the runtime is routed through the variant
+            plan (rf2-5x1wt.17 / .22)."
     (doseq [vid [:story.counter/empty
                  :story.counter/loaded
                  :story.counter/clicked-three-times
                  :story.counter/save-stubbed]]
       (let [body (story/variant->edn vid)]
         (is (map? body) (str vid " variant->edn returned a map"))
-        (is (some? (:events body)) (str vid " has :events"))))))
+        (is (some? (:events body))
+            (str vid " has :events (the lowered shipping form of authored :setup)"))))))
 
 ;; ---- play sequences pass ------------------------------------------------
 

--- a/tools/story/testbeds/login_form/stories.cljs
+++ b/tools/story/testbeds/login_form/stories.cljs
@@ -12,7 +12,7 @@
     :story.login/submitting-retry  → user fixed the typo, re-submitted
     :story.login/authenticated     → welcome banner
 
-  Every variant body is plain EDN — `:events`, `:decorators`, `:play`,
+  Every variant body is plain EDN — `:setup`, `:decorators`, `:script`,
   `:tags`, `:substrates`. No function-slots; no closures except in the
   decorator registration (the `:counter-with-stories/log-decorator`
   pattern). This is the canonical agent-consumable shape (round-trips
@@ -102,8 +102,8 @@
              cascade seeds the snapshot — without it, the
              `[:rf/runtime :machines :snapshots :login/flow]` slot is nil and the
              state-pill in the view renders empty."
-     :events [[:login/flow [:login/dismiss]]]
-     :play-script [[:dispatch-sync [:rf.assert/path-equals  [:rf/runtime :machines :snapshots :login/flow :state] :idle]]
+     :setup [[:login/flow [:login/dismiss]]]
+     :script [[:dispatch-sync [:rf.assert/path-equals  [:rf/runtime :machines :snapshots :login/flow :state] :idle]]
               [:dispatch-sync [:rf.assert/state-is :login/flow :idle]]]
      :tags   #{:dev :docs :test}
      :substrates #{:reagent}})
@@ -123,10 +123,10 @@
              button reads 'Signing in…'. The fx-stub records the
              request and resolves nothing so the canvas locks in
              :submitting."
-     :events [[:login/flow [:login/submit {:email    "ada@example.com"
+     :setup [[:login/flow [:login/submit {:email    "ada@example.com"
                                             :password "correct-horse"}]]]
      :decorators [[story/force-fx-stub-id :rf.http/managed {}]]
-     :play-script [[:dispatch-sync [:rf.assert/state-is      :login/flow :submitting]]
+     :script [[:dispatch-sync [:rf.assert/state-is      :login/flow :submitting]]
               [:dispatch-sync [:rf.assert/effect-emitted :rf.http/managed]]]
      :tags   #{:dev :docs :test}
      :substrates #{:reagent}})
@@ -145,7 +145,7 @@
     {:doc    "Server rejected credentials. Form re-enabled; the error
              message is surfaced under the submit button; the
              'Cancel' button lets the user back out without retrying."
-     :events [[:login/flow [:login/submit {:email    "ada@example.com"
+     :setup [[:login/flow [:login/submit {:email    "ada@example.com"
                                             :password "wrong"}]]
               ;; Manually fire the failure sub-event the stubbed-out
               ;; request would otherwise have triggered. This is the
@@ -156,7 +156,7 @@
                             {:failure {:status  401
                                        :message "Invalid credentials."}}]]]
      :decorators [[story/force-fx-stub-id :rf.http/managed {}]]
-     :play-script [[:dispatch-sync [:rf.assert/state-is :login/flow :error]]
+     :script [[:dispatch-sync [:rf.assert/state-is :login/flow :error]]
               [:dispatch-sync [:rf.assert/path-equals
                [:rf/runtime :machines :snapshots :login/flow :data :error]
                "Invalid credentials."]]]
@@ -177,14 +177,14 @@
              from :submitting because attempts > 0; the variant body
              sequences the failure then the retry, leaving the
              retry request pending in the stub."
-     :events [[:login/flow [:login/submit
+     :setup [[:login/flow [:login/submit
                             {:email "ada@example.com" :password "wrong"}]]
               [:login/flow [:login/failure
                             {:failure {:status 401 :message "Invalid credentials."}}]]
               [:login/flow [:login/retry
                             {:email "ada@example.com" :password "correct-horse"}]]]
      :decorators [[story/force-fx-stub-id :rf.http/managed {}]]
-     :play-script [[:dispatch-sync [:rf.assert/state-is :login/flow :submitting-retry]]
+     :script [[:dispatch-sync [:rf.assert/state-is :login/flow :submitting-retry]]
               [:dispatch-sync [:rf.assert/path-equals
                [:rf/runtime :machines :snapshots :login/flow :data :attempts]
                1]]]
@@ -206,13 +206,13 @@
              a welcome banner addressing the user by email; the
              :sign-out button routes back to :idle. This is the
              canonical screenshot the tutorial pins to."
-     :events [[:login/flow [:login/submit {:email    "ada@example.com"
+     :setup [[:login/flow [:login/submit {:email    "ada@example.com"
                                             :password "correct-horse"}]]
               [:login/flow [:login/success
                             {:value {:user  {:email "ada@example.com"}
                                      :token "story-token"}}]]]
      :decorators [[story/force-fx-stub-id :rf.http/managed {}]]
-     :play-script [[:dispatch-sync [:rf.assert/state-is :login/flow :authenticated]]
+     :script [[:dispatch-sync [:rf.assert/state-is :login/flow :authenticated]]
               [:dispatch-sync [:rf.assert/sub-equals [:login/email] "ada@example.com"]]]
      :tags   #{:dev :docs :test :login-form/tutorial}
      :substrates #{:reagent}})


### PR DESCRIPTION
Makes `:setup` / `:script` the **public** Story authoring vocabulary per `tools/story/spec/017-Testing-Story.md` §Public vocabulary, keeping `:events` / `:play-script` accepted as transitional spellings during the pre-alpha rename (a clean rename, not a long-lived shim). The variant-plan compiler (rf2-5x1wt.10, merged) already normalizes both spellings; this PR is the public-facing migration: schema, testbeds, docs.

## What changed

- **`schemas.cljc`** — add `:setup` and `:script` slots to the `Variant` schema; enforce `:setup` xor `:events` and `:script` xor `:play-script` xor `:plays` mutual-exclusion; add `lower-public-vocabulary` (pure data→data) folding `:setup` → `:events` and `:script` → `:play-script`. Named `:plays` is preserved (passes through untouched).
- **`registrar.cljc`** — validate the **authored** body first (so the public mutual-exclusion fires on what the author wrote), then lower to the shipping slots before `:extends` resolution + storage. Every downstream RUNTIME reader (phase-2 events, the play runner's `variant-body->plays`, snapshot identity, workspace/canvas readers, recorder) consumes the shipping slot unchanged — zero behaviour change, zero collision with the locked runner files.
- **Testbeds** — `counter_with_stories` + `login_form` authored with `:setup` / `:script` (named `:plays` kept). `stories_cljs_test` pins the `:setup` → `:events` lowering via `variant->edn`.
- **Docs** — `docs/story/01-first-story.md` + `docs/story/index.md` migrated to `:setup` / `:script`; `tools/story/spec/001-Authoring.md` variant-body reference + phase-4 section updated with the public-vs-transitional split and a spec/017 cross-reference.
- **spec/017** — edited only the §Public vocabulary section (recorded the registrar lowering seam). **Not** §Canonicalization (owned by the open rf2-5x1wt.3 PR).
- **JVM tests** — added public-vocabulary acceptance + lowering + mutual-exclusion + extends-override tests to `story_authoring_validation_test.clj`.

## Deferrals (runner-gated)

- **Live runner reading top-level `:script`** — `runner.cljc`'s `variant-body->plays` (the runner dispatch path) is locked by the open **rf2-5x1wt.2** PR (#2412). The registrar lowering bridges this so `:script`-authored variants run today; native `:script` reading belongs to **rf2-5x1wt.17** (tagged step runner) / **.22** (route runtime through plans), which own those files and remove the lowering.
- **Recorder output emitting `:script`** — spec §B2.4 says "after runner support exists"; the recorder still emits `:play-script`. Belongs to **rf2-5x1wt.19**. The recorder-output doc references (`index.md` recorder steps, `03-recorder-codegen.md`) were left accurate to current behaviour.
- **CI script rename** — `test:story-play-scripts` keeps its name (per spec §CI policy + dispatch note); its own migration bead handles the rename.
- **Exhaustive doc sweep** — the API reference pages + remaining `001-Authoring` examples (~30 occurrences) were left for a follow-on docs bead to avoid a large mechanical sweep colliding with the runner/runtime beads revising the same phase-4 prose.

## Quality gates

- Story JVM (`clojure -M:test`): **887 tests / 2620 assertions, 0 failures, 0 errors**
- CLJS node (`npm run test:cljs`): **4833 tests / 15844 assertions, 0 failures, 0 errors**
- Story play-scripts gate (`npm run test:story-play-scripts`): **27 variants / 29 rows, 0 unexpected outcomes** — proves the live browser runtime runs the `:setup`/`:script`-authored testbeds end-to-end (lowering works at runtime)
- `bash scripts/test-fast-pr.sh`: **PASS** (markdown link/anchor gates ran; mkdocs strict soft-skipped locally, CI runs it)

## Notes / risks

- The `:setup` → `:events` lowering means `variant->edn` / MCP / recorder surface the lowered `:events`/`:play-script` form; intentional and pinned by `variant-edn-roundtrip`. Removed when the runtime reads the normalized plan.
- No collision with the in-flight rf2-5x1wt.2 (#2412, runner) or rf2-5x1wt.3 (#2411, `story.cljc`/`identity.cljc`/`fingerprint`) PRs: this PR touches `schemas.cljc` / `registrar.cljc` / `extends`-callsite / testbeds / docs / spec/017 §vocabulary only.