### PR TITLE
feat(story): validate view args + derive controls from schema (rf2-5x1wt.12)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -214,6 +214,8 @@ merge.
 | `:checks` | `[:expect :checks]` |
 | `:assertions` | `[:expect :assertions]` |
 | `:args` / `:argtypes` | `[:world :args]` / `[:world :argtypes]` |
+| (derived) view props schema | `[:world :view-args-schema]` — copied from the `:component` view's metadata (§View arg schemas) |
+| (derived) resolved args | `[:world :effective-args]` — the args feeding the view; validated against the view-args schema before render |
 | `:sub-overrides` | `[:world :render :sub-overrides]` |
 | `:network` / `:fx-overrides` | `[:world :network]` / `[:world :frame :fx-overrides]` |
 | platforms / tags / workshop slots (`:decorators`, `:modes`, `:viewport`, …) | preserved under `:world` (and top-level `:tags`) |
@@ -439,6 +441,62 @@ validation schema. The plan compiler MUST copy the props schema into
 This schema applies only to explicit view inputs. It does not validate
 values returned from subscriptions (those remain subscription output
 schemas) and it does not seed app-db.
+
+**Metadata key (M0-confirmed).** `reg-view` stamps a view's symbol
+metadata (minus `:rf/id`) onto its `:view` registrar slot, so the props
+schema rides on that slot. The compiler resolves it **first match wins**:
+`:rf/props` (the spec-named props key, for a port that adopts it) →
+`:spec` (the live Spec 010 boundary-schema slot the framework already
+exposes) → `:schema` (the Story-only alias the controls / schema-
+validation panels already read). Story consumes the key the framework
+exposes rather than inventing a parallel one; the controls-panel
+derivation (`re-frame.story.ui.controls`) reads the same slot, so a view
+that declares a props schema gets controls AND validation from one
+source.
+
+**Plan slots.** When the variant's resolved `:component` view carries a
+schema, the compiler writes:
+
+| Plan slot | Meaning |
+|---|---|
+| `[:world :view-args-schema]` | the view's explicit-input schema, copied verbatim |
+| `[:world :effective-args]` | the args that feed the view — at plan time the resolved arg-map; the render path layers control-panel overrides on top |
+| `[:explain :view-args-schema]` / `[:explain :effective-args]` | the same, surfaced in `explain` (and downstream docs) |
+| `[:explain :view-args-validation]` | `{:status :ok :missing [] :malformed []}` for a passing plan (an invalid one throws — see below) |
+
+`[:world :effective-args]` is recorded even when no view schema is on
+file (it is the resolved arg-map); the `:view-args-schema` /
+`:view-args-validation` slots are present only when a schema exists.
+
+**Validation, two tiers (both pure / JVM-testable).**
+
+- **Required-key presence (host-free floor).** For a top-level
+  `[:map …]` schema, every entry NOT marked `{:optional true}` whose key
+  is absent from `:effective-args` is a missing-required violation. This
+  needs no Malli runtime, so it runs under `clojure -M:test`.
+- **Malformed-value (validator-driven).** When the caller threads a
+  `{:validate :explain}` validator pair (e.g. the Malli late-bind hook
+  the renderer already uses), each present entry's value is validated
+  against its entry schema; a failure carries the validator's
+  explanation. With no validator, malformed-value checking soft-passes
+  (matching `re-frame.story.ui.schema-validation/args-violations`).
+
+A missing-required or malformed view input **FAILS plan construction**
+with `:rf.error/story-view-args-invalid`, whose ex-data carries the
+failing arg key(s), the Malli schema `:path` (`[k]` for a top-level map
+entry), the `:effective-args`, and the source `:variant/id`.
+`variant-plan` opts `:view-lookup` (a `(view-id) → view-meta` fn or map,
+defaulting to the framework `:view` registrar) and `:validator-fns`
+thread the view-metadata source and the malformed-value validator, so
+the compiler stays a pure data → data fn for host-free tests.
+
+**Sharp boundary.** View-arg schemas validate the **explicit view
+inputs** only (the `:args` that feed the rendered view). They are a
+different contract from subscription-output schemas, which validate
+values supplied by subscriptions and `:sub-overrides` (§View-state
+subscription overrides). The two MUST NOT be conflated: `:sub-overrides`
+lower to `[:world :render :sub-overrides]` and are never checked against
+the `:view-args-schema`.
 
 ### View-state subscription overrides
 

--- a/tools/story/src/re_frame/story/plan.cljc
+++ b/tools/story/src/re_frame/story/plan.cljc
@@ -30,14 +30,32 @@
     requirements work).
   - Attach `:source-chain` and an `:explain` map.
 
+  ## View arg schemas (rf2-5x1wt.12)
+
+  When a variant's `:component` resolves to a registered view that
+  carries a props schema on its view metadata, the compiler copies that
+  schema into `[:world :view-args-schema]`, records the resolved
+  `[:world :effective-args]` (the post-substitution args that feed the
+  view — at plan time, before control-panel overrides), and validates
+  the effective args against the schema. A required view input that is
+  missing, or a malformed value, FAILS plan construction with
+  `:rf.error/story-view-args-invalid` carrying the failing arg key, the
+  Malli schema path, and the source variant. The schema, effective args,
+  and any validation outcome surface in `:explain` (and downstream docs).
+
+  This is the **explicit view-input** contract only. It is distinct from
+  subscription-output schemas, which validate values supplied by
+  subscriptions / `:sub-overrides` (§View-state subscription overrides);
+  the two MUST NOT be conflated.
+
   ## What this layer DEFERS
 
   Strict `:compose` fragment/check composition + conflict resolution
   (§Merge rules / §Conflict resolution), the runner itself, evidence
-  projection, view-arg-schema validation, `:network` lowering, and the
-  capability-token registry are **later beads**. This compiler emits the
-  scaffolding (e.g. an empty `[:world :network]` passthrough, a coarse
-  `:required-runner`) so those beads slot in without reshaping the plan.
+  projection, `:network` lowering, and the capability-token registry are
+  **later beads**. This compiler emits the scaffolding (e.g. an empty
+  `[:world :network]` passthrough, a coarse `:required-runner`) so those
+  beads slot in without reshaping the plan.
 
   ## Purity / elision
 
@@ -47,9 +65,11 @@
   contract is empty in a production bundle; callers thread an explicit
   `:lookup` (a `{variant-id → raw-body}` map or a 1-arg fn) for pure
   tests."
-  (:require [re-frame.story.args      :as args]
-            [re-frame.story.registrar :as registrar]
-            [re-frame.story.play.runner :as runner]))
+  (:require [re-frame.story.args         :as args]
+            [re-frame.story.registrar    :as registrar]
+            [re-frame.story.malli-schema :as msu]
+            [re-frame.story.play.runner  :as runner]
+            [re-frame.registrar          :as framework-registrar]))
 
 ;; ============================================================================
 ;; Errors
@@ -329,6 +349,138 @@
                   (map assertion-tokens assertions))))
 
 ;; ============================================================================
+;; View arg schemas (rf2-5x1wt.12)
+;; ============================================================================
+;;
+;; Per spec §View arg schemas: a registered view MAY expose a schema for
+;; its explicit args/props on its view metadata. Story copies that schema
+;; into `[:world :view-args-schema]`, validates `[:world :effective-args]`
+;; against it before render, and derives controls from it where explicit
+;; argtypes are absent (the controls-panel derivation in
+;; `re-frame.story.ui.controls` reads the same schema).
+;;
+;; **Metadata key.** The spec names `:rf/props` for the props schema and
+;; `:rf/args` for macro-captured argument *symbols* (introspection, NOT a
+;; validation schema — so it is never consumed here). The live framework
+;; view-metadata contract (Spec 010) carries the boundary schema on
+;; `:spec`, with `:schema` as the Story-only alias the controls /
+;; schema-validation panels already read. We therefore resolve, first
+;; match wins: `:rf/props` (the spec-named props key, when a port adopts
+;; it) → `:spec` (the live Spec 010 slot) → `:schema` (the alias). This
+;; consumes the key the framework already exposes rather than inventing a
+;; parallel one (§View arg schemas — "M0 MUST confirm the exact key").
+;;
+;; **Boundary.** This validates EXPLICIT view inputs only. Values
+;; returned from subscriptions are validated by subscription-output
+;; schemas (§View-state subscription overrides); the two are different
+;; contracts and are not conflated here.
+
+(def ^:private view-args-schema-keys
+  "View-metadata keys carrying the explicit-input (props) schema, in
+  resolution order (first present wins). See the section comment."
+  [:rf/props :spec :schema])
+
+(defn view-args-schema
+  "Return the explicit view-args/props schema from a `view-meta` map (the
+  `:view` registrar slot), or nil when none is present. Picks the first
+  of `view-args-schema-keys` that is set."
+  [view-meta]
+  (when (map? view-meta)
+    (some (fn [k] (let [s (get view-meta k)] (when (some? s) s)))
+          view-args-schema-keys)))
+
+(defn- map-entry-optional?
+  "True iff a Malli `[:map …]` entry `[k props? child]` is marked
+  `{:optional true}` in its per-entry properties map. A non-optional
+  entry is a REQUIRED view input."
+  [entry]
+  (let [props (second entry)]
+    (boolean (and (msu/properties? props) (:optional props)))))
+
+(defn validate-effective-args
+  "Validate `effective-args` against a view-args `schema` (the value
+  returned by `view-args-schema`). Returns a result map:
+
+      {:status :ok | :invalid
+       :schema schema
+       :missing  [{:key k :schema entry-schema :path [...]} ...]
+       :malformed [{:key k :value v :schema entry-schema
+                    :path [...] :explain explanation} ...]}
+
+  Two tiers of checking, both pure:
+
+  - **Required-key presence (host-free floor).** For a top-level
+    `[:map …]` schema, every entry NOT marked `{:optional true}` whose
+    key is absent from `effective-args` is a `:missing` violation. This
+    needs no Malli runtime, so it runs under `clojure -M:test`.
+
+  - **Malformed-value (validator-driven).** When `validator-fns`
+    (`{:validate (fn [schema value] truthy?) :explain (fn [schema value]
+    explanation)}`) is supplied, each present entry's value is validated
+    against its entry schema; a failure is a `:malformed` violation
+    carrying the validator's explanation. With no validator (the
+    JVM-test default) malformed-value checking soft-passes, matching the
+    `re-frame.story.ui.schema-validation/args-violations` convention.
+
+  Each violation carries the Malli `:path` (`[k]` for a top-level map
+  entry) so callers can report 'where' in the schema the failure sits.
+  A non-`:map` top-level schema validates the whole args map as one
+  value (validator-driven only)."
+  ([schema effective-args] (validate-effective-args schema effective-args nil))
+  ([schema effective-args validator-fns]
+   (let [validate (:validate validator-fns)
+         explain  (:explain  validator-fns)
+         args     (or effective-args {})]
+     (cond
+       (nil? schema)
+       {:status :ok :schema nil :missing [] :malformed []}
+
+       (and (vector? schema) (= :map (msu/schema-op schema)))
+       (let [entries   (msu/schema-children schema)
+             missing   (into []
+                              (keep (fn [entry]
+                                      (let [k (msu/map-entry-key entry)]
+                                        (when (and (not (map-entry-optional? entry))
+                                                   (not (contains? args k)))
+                                          {:key    k
+                                           :schema (msu/map-entry-schema entry)
+                                           :path   [k]}))))
+                              entries)
+             malformed (when validate
+                         (into []
+                               (keep (fn [entry]
+                                       (let [k  (msu/map-entry-key entry)
+                                             cs (msu/map-entry-schema entry)
+                                             v  (get args k)]
+                                         (when (and (contains? args k)
+                                                    (not (validate cs v)))
+                                           {:key     k
+                                            :value   v
+                                            :schema  cs
+                                            :path    [k]
+                                            :explain (when explain (explain cs v))}))))
+                               entries))
+             malformed (vec malformed)]
+         {:status    (if (and (empty? missing) (empty? malformed)) :ok :invalid)
+          :schema    schema
+          :missing   missing
+          :malformed malformed})
+
+       ;; Top-level non-:map schema — validate the whole args map.
+       (and validate (not (validate schema args)))
+       {:status    :invalid
+        :schema    schema
+        :missing   []
+        :malformed [{:key     ::root
+                     :value   args
+                     :schema  schema
+                     :path    []
+                     :explain (when explain (explain schema args))}]}
+
+       :else
+       {:status :ok :schema schema :missing [] :malformed []}))))
+
+;; ============================================================================
 ;; Compiler
 ;; ============================================================================
 
@@ -350,14 +502,45 @@
                          "re-frame2-story: :lookup must be a fn or a map"
                          {:lookup lookup})))
 
+(defn- default-view-lookup
+  "Default view-metadata lookup — reads the **framework** `:view`
+  registrar slot (where `reg-view` stamps a view's symbol metadata, incl.
+  any props/`:spec`/`:schema` slot). Production bundles that elide views
+  return nil; pure tests thread an explicit `:view-lookup`."
+  [view-id]
+  (framework-registrar/handler-meta :view view-id))
+
+(defn- coerce-view-lookup
+  "Accept a 1-arg fn or a `{view-id → view-meta}` map as `:view-lookup`."
+  [view-lookup]
+  (cond
+    (nil? view-lookup) default-view-lookup
+    (map? view-lookup) #(get view-lookup %)
+    (fn? view-lookup)  view-lookup
+    :else              (fail! :rf.error/story-bad-lookup
+                              "re-frame2-story: :view-lookup must be a fn or a map"
+                              {:view-lookup view-lookup})))
+
 (defn compile-body
   "Compile a raw variant `body` (the child) registered under `id` into a
   normalized plan. `lookup` is a 1-arg fn returning raw parent bodies.
 
   This is the pure core; `variant-plan` is the public front door that
-  resolves a registered/keyword/map target onto this fn."
-  [id body lookup]
-  (let [chain        (resolve-source-chain id body lookup)
+  resolves a registered/keyword/map target onto this fn.
+
+  `opts` (4-arity) may carry:
+
+  - `:view-lookup` — a 1-arg fn `(view-id) → view-meta` resolving the
+    `:component` view's registration metadata (for the view-args schema).
+    Defaults to the framework `:view` registrar.
+  - `:validator-fns` — `{:validate (fn [schema value]) :explain (fn …)}`
+    used for malformed-value checking of `:effective-args` (§View arg
+    schemas). With no validator only required-key presence is checked
+    (the host-free floor)."
+  ([id body lookup] (compile-body id body lookup nil))
+  ([id body lookup {:keys [view-lookup validator-fns] :as _opts}]
+  (let [view-lookup  (coerce-view-lookup view-lookup)
+        chain        (resolve-source-chain id body lookup)
         bodies       (map :body chain)         ; root-first
         child        (:body (last chain))
         ;; ---- context merge (root→child) ----
@@ -390,16 +573,45 @@
         setup        (substitute-args setup-raw arg-map subs!)
         script*      (substitute-args script arg-map subs!)
         sub-overrides (substitute-args (:sub-overrides ctx) arg-map subs!)
+        ;; ---- view arg schema + effective-args validation (rf2-5x1wt.12) ----
+        ;; `:effective-args` at plan time IS the resolved arg-map; the
+        ;; render path layers control-panel overrides on top later. We
+        ;; copy the view's explicit-input schema into the plan, validate
+        ;; the effective args against it, and FAIL plan construction on a
+        ;; missing-required or malformed view input (§View arg schemas).
+        component-id (:component ctx)
+        view-meta    (when component-id (view-lookup component-id))
+        schema       (view-args-schema view-meta)
+        eff-args     arg-map
+        validation   (when schema
+                       (validate-effective-args schema eff-args validator-fns))
+        _            (when (and validation (= :invalid (:status validation)))
+                       (fail! :rf.error/story-view-args-invalid
+                              (str "re-frame2-story: variant " id
+                                   " — :effective-args do not satisfy the view-args "
+                                   "schema of :component " component-id
+                                   (when-let [m (seq (:missing validation))]
+                                     (str "; missing required " (mapv :key m)))
+                                   (when-let [b (seq (:malformed validation))]
+                                     (str "; malformed " (mapv :key b))))
+                              {:variant/id      id
+                               :component       component-id
+                               :view-args-schema schema
+                               :missing         (:missing validation)
+                               :malformed       (:malformed validation)
+                               :effective-args  eff-args}))
         ;; ---- runner requirement ----
         required     (compute-required-runner setup script* assertions)
         ;; ---- source coords ----
         source       (:source child)
         platforms    (or (:platforms ctx) #{:client})
-        world        (cond-> {:setup     setup
-                              :args      arg-map
-                              :argtypes  argtypes
-                              :scripts   scripts
-                              :platforms platforms}
+        world        (cond-> {:setup          setup
+                              :args           arg-map
+                              :argtypes       argtypes
+                              :effective-args eff-args
+                              :scripts        scripts
+                              :platforms      platforms}
+                       (some? schema)        (assoc :view-args-schema schema)
                        (some? sub-overrides) (assoc-in [:render :sub-overrides] sub-overrides)
                        (contains? ctx :network)     (assoc :network (:network ctx))
                        (contains? ctx :fx-overrides) (assoc-in [:frame :fx-overrides] (:fx-overrides ctx))
@@ -423,6 +635,15 @@
                                      :script     :child-only}
                       :args         arg-map
                       :substitutions @subs!
+                      :effective-args eff-args
+                      :view-args-schema schema
+                      :view-args-validation (when validation
+                                              ;; :status :ok here (an :invalid
+                                              ;; validation throws upstream); the
+                                              ;; slot documents the passing contract.
+                                              {:status    (:status validation)
+                                               :missing   (:missing validation)
+                                               :malformed (:malformed validation)})
                       :setup-order  setup
                       :script-order script*
                       :checks       checks
@@ -441,7 +662,7 @@
              :tags            (reduce (fn [acc layer] (merge-tags acc (:tags layer)))
                                       #{} bodies)
              :explain         explain}
-      source (assoc :source source))))
+      source (assoc :source source)))))
 
 (defn variant-plan
   "Compile `target` into a normalized variant plan (§Variant plan).
@@ -458,27 +679,38 @@
   - `:lookup` — a 1-arg fn `(variant-id) → raw-body` OR a
     `{variant-id → raw-body}` map, used to resolve `:extends` parents
     (and the keyword target itself). Defaults to the side-table.
+  - `:view-lookup` — a 1-arg fn `(view-id) → view-meta` OR a
+    `{view-id → view-meta}` map, used to resolve the `:component` view's
+    props/`:spec`/`:schema` slot for view-args validation. Defaults to
+    the framework `:view` registrar (§View arg schemas).
+  - `:validator-fns` — `{:validate (fn …) :explain (fn …)}` for
+    malformed-value checking of `:effective-args`; with none supplied
+    only required-key presence is checked.
 
   Returns the normalized plan map: `:variant/id`, `:source-chain`,
-  `:world`, `:script`, `:expect`, `:required-runner`, `:tags`, `:explain`
-  (and `:source` when coords are present).
+  `:world` (incl. `:effective-args` and `:view-args-schema` when a view
+  schema is on file), `:script`, `:expect`, `:required-runner`, `:tags`,
+  `:explain` (and `:source` when coords are present).
 
   FAILS with a structured `:rf.error/story-*` ex-info on: an unregistered
   keyword target, an unregistered `:extends` parent, an `:extends` cycle,
-  or a missing `[:arg key]`."
+  a missing `[:arg key]`, or `:effective-args` that violate the view-args
+  schema (`:rf.error/story-view-args-invalid`)."
   ([target] (variant-plan target nil))
-  ([target {:keys [lookup] :as _opts}]
-   (let [lookup-fn (coerce-lookup lookup)]
+  ([target {:keys [lookup] :as opts}]
+   (let [lookup-fn    (coerce-lookup lookup)
+         compile-opts (select-keys opts [:view-lookup :validator-fns])]
      (cond
        (keyword? target)
        (if-let [body (lookup-fn target)]
-         (compile-body target body lookup-fn)
+         (compile-body target body lookup-fn compile-opts)
          (fail! :rf.error/story-unknown-variant
                 (str "re-frame2-story: no registered variant " target)
                 {:variant/id target}))
 
        (map? target)
-       (compile-body (:variant/id target) (dissoc target :variant/id) lookup-fn)
+       (compile-body (:variant/id target) (dissoc target :variant/id)
+                     lookup-fn compile-opts)
 
        :else
        (fail! :rf.error/story-bad-target

--- a/tools/story/test/re_frame/story/plan_test.cljc
+++ b/tools/story/test/re_frame/story/plan_test.cljc
@@ -9,6 +9,7 @@
   test bodies still carry `:extends` rather than relying on the
   registrar's eager merge)."
   (:require [clojure.test :refer [deftest is testing]]
+            [malli.core :as m]
             [re-frame.story.plan :as plan]))
 
 ;; ---- helpers ------------------------------------------------------------
@@ -241,3 +242,179 @@
       (is (= [[:dispatch [:go]]] (:script-order ex)))
       (is (= :append-root-to-child (get-in ex [:merge :setup])))
       (is (= :child-only (get-in ex [:merge :script]))))))
+
+;; ===========================================================================
+;; View arg schemas (rf2-5x1wt.12 — spec §View arg schemas)
+;; ===========================================================================
+;;
+;; A registered view MAY expose an explicit-input (props) schema on its
+;; `:view` metadata. The compiler copies it into [:world :view-args-schema],
+;; records [:world :effective-args], validates the effective args against
+;; the schema before render, and FAILS plan construction on a missing-
+;; required or malformed view input. These tests thread an explicit
+;; `:view-lookup` (a {view-id → view-meta} map) so they run host-free on
+;; both the JVM and CLJS. The `:component` arg-lookup precedence verifies
+;; the live-framework key resolution (`:rf/props` → `:spec` → `:schema`).
+
+(def ^:private malli-validator
+  "A `{:validate :explain}` pair backed by Malli (on Story's classpath),
+  matching the injectable shape the renderer threads from the late-bind
+  hook. Used for the malformed-value tests; the required-key floor needs
+  no validator."
+  {:validate (fn [schema value] (m/validate schema value))
+   :explain  (fn [schema value] (m/explain schema value))})
+
+(deftest view-args-schema-copied-into-plan
+  (testing "the :component view's props schema is copied to [:world :view-args-schema]"
+    (let [view-schema [:map [:label :string] [:count :int]]
+          m {:story.widget/ok
+             {:component :views/widget
+              :args      {:label "Hi" :count 3}}}
+          p (plan/variant-plan :story.widget/ok
+                               {:lookup      m
+                                :view-lookup {:views/widget {:rf/props view-schema}}})]
+      (is (= view-schema (get-in p [:world :view-args-schema])))
+      (testing "effective-args are recorded (the resolved args at plan time)"
+        (is (= {:label "Hi" :count 3} (get-in p [:world :effective-args])))))))
+
+(deftest valid-effective-args-render
+  (testing "valid effective-args compile cleanly (no plan failure)"
+    (let [m {:story.widget/valid
+             {:component :views/widget
+              :args      {:label "Hi" :count 3}}}
+          p (plan/variant-plan :story.widget/valid
+                               {:lookup      m
+                                :view-lookup {:views/widget
+                                              {:rf/props [:map [:label :string] [:count :int]]}}
+                                :validator-fns malli-validator})]
+      (is (= :story.widget/valid (:variant/id p)))
+      (is (= :ok (get-in p [:explain :view-args-validation :status]))))))
+
+(deftest missing-required-arg-fails-before-render
+  (testing "a missing required view input FAILS plan construction"
+    (let [m {:story.widget/missing
+             {:component :views/widget
+              :args      {:label "Hi"}}}   ; :count required, absent
+          opts {:lookup      m
+                :view-lookup {:views/widget {:rf/props [:map [:label :string] [:count :int]]}}}]
+      (is (thrown-with-msg?
+            #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
+            #"story-view-args-invalid"
+            (plan/variant-plan :story.widget/missing opts)))
+      (let [data (try (plan/variant-plan :story.widget/missing opts)
+                      (catch #?(:clj Exception :cljs :default) e (ex-data e)))]
+        (is (= :rf.error/story-view-args-invalid (:rf.error/id data)))
+        (testing "the failure reports the missing key, schema path, and source variant"
+          (is (= :story.widget/missing (:variant/id data)))
+          (is (= [{:key :count :schema :int :path [:count]}] (:missing data))))))))
+
+(deftest optional-arg-may-be-absent
+  (testing "an entry marked {:optional true} is NOT a required input"
+    (let [m {:story.widget/opt
+             {:component :views/widget
+              :args      {:label "Hi"}}}
+          p (plan/variant-plan :story.widget/opt
+                               {:lookup      m
+                                :view-lookup {:views/widget
+                                              {:rf/props [:map
+                                                          [:label :string]
+                                                          [:count {:optional true} :int]]}}})]
+      (is (= {:label "Hi"} (get-in p [:world :effective-args])))
+      (is (= :ok (get-in p [:explain :view-args-validation :status]))))))
+
+(deftest malformed-arg-reports-schema-path-and-source-variant
+  (testing "a malformed value FAILS with the schema path + source variant"
+    (let [m {:story.widget/bad
+             {:component :views/widget
+              :args      {:label "Hi" :count "three"}}}  ; :count must be :int
+          opts {:lookup        m
+                :view-lookup   {:views/widget {:rf/props [:map [:label :string] [:count :int]]}}
+                :validator-fns malli-validator}]
+      (is (thrown-with-msg?
+            #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
+            #"story-view-args-invalid"
+            (plan/variant-plan :story.widget/bad opts)))
+      (let [data (try (plan/variant-plan :story.widget/bad opts)
+                      (catch #?(:clj Exception :cljs :default) e (ex-data e)))
+            bad  (first (:malformed data))]
+        (is (= :rf.error/story-view-args-invalid (:rf.error/id data)))
+        (is (= :story.widget/bad (:variant/id data))
+            "the failure carries the source variant")
+        (is (= :count (:key bad)))
+        (is (= [:count] (:path bad)) "reports the Malli schema path")
+        (is (= "three" (:value bad)))
+        (is (some? (:explain bad)) "carries the validator explanation")))))
+
+(deftest no-view-schema-no-validation
+  (testing "a view with no props schema leaves the plan unvalidated (slots absent)"
+    (let [m {:story.widget/none
+             {:component :views/widget
+              :args      {:anything 1}}}
+          p (plan/variant-plan :story.widget/none
+                               {:lookup      m
+                                :view-lookup {:views/widget {}}})]  ; no schema slot
+      (is (nil? (get-in p [:world :view-args-schema])))
+      (is (nil? (get-in p [:explain :view-args-validation])))
+      (testing "effective-args still recorded"
+        (is (= {:anything 1} (get-in p [:world :effective-args])))))))
+
+(deftest no-component-no-validation
+  (testing "a variant with no :component is never view-validated"
+    (let [m {:story.plain/v {:args {:x 1} :setup [[:dispatch [:a]]]}}
+          p (plan/variant-plan :story.plain/v {:lookup m})]
+      (is (nil? (get-in p [:world :view-args-schema])))
+      (is (= {:x 1} (get-in p [:world :effective-args]))))))
+
+(deftest schema-key-precedence
+  (testing ":rf/props wins over :spec which wins over :schema"
+    (let [props  [:map [:a :string]]
+          spec   [:map [:b :string]]
+          schema [:map [:c :string]]]
+      (testing ":rf/props chosen when present"
+        (is (= props (plan/view-args-schema {:rf/props props :spec spec :schema schema}))))
+      (testing ":spec chosen when no :rf/props (the live Spec 010 slot)"
+        (is (= spec (plan/view-args-schema {:spec spec :schema schema}))))
+      (testing ":schema chosen as the last-resort alias"
+        (is (= schema (plan/view-args-schema {:schema schema}))))
+      (testing "nil when no schema slot present"
+        (is (nil? (plan/view-args-schema {:title "x"})))))))
+
+(deftest derived-effective-args-validation-unit
+  (testing "validate-effective-args required-key floor needs no validator"
+    (let [schema [:map [:label :string] [:count :int]]]
+      (testing "all present → :ok"
+        (is (= :ok (:status (plan/validate-effective-args
+                              schema {:label "x" :count 1})))))
+      (testing "missing required → :invalid with the missing entry"
+        (let [r (plan/validate-effective-args schema {:label "x"})]
+          (is (= :invalid (:status r)))
+          (is (= [{:key :count :schema :int :path [:count]}] (:missing r)))
+          (is (= [] (:malformed r)) "no malformed without a validator")))
+      (testing "malformed value soft-passes without a validator (floor only)"
+        ;; :count present but wrong type — with no validator the floor
+        ;; can only check presence, so this is :ok at floor level.
+        (is (= :ok (:status (plan/validate-effective-args
+                              schema {:label "x" :count "nope"})))))
+      (testing "malformed value is caught WITH a validator"
+        (let [r (plan/validate-effective-args
+                  schema {:label "x" :count "nope"} malli-validator)]
+          (is (= :invalid (:status r)))
+          (is (= :count (:key (first (:malformed r))))))))))
+
+(deftest view-args-boundary-is-distinct-from-sub-overrides
+  (testing "view-args schema validates explicit args; :sub-overrides ride a separate slot"
+    (let [m {:story.boundary/v
+             {:component     :views/widget
+              :args          {:label "Hi"}
+              :sub-overrides {[:widget/state] :error}}}
+          p (plan/variant-plan :story.boundary/v
+                               {:lookup      m
+                                :view-lookup {:views/widget {:rf/props [:map [:label :string]]}}})]
+      (testing "the view-args schema covers explicit args only"
+        (is (= [:map [:label :string]] (get-in p [:world :view-args-schema]))))
+      (testing ":sub-overrides lower to their own [:world :render :sub-overrides] slot"
+        (is (= {[:widget/state] :error}
+               (get-in p [:world :render :sub-overrides]))))
+      (testing "the two contracts are not conflated — sub-overrides are NOT in view-args-schema"
+        (is (not (contains? (set (get-in p [:world :view-args-schema]))
+                            [:widget/state])))))))


### PR DESCRIPTION
## Summary

Implements Plan §B2a "View Arg Schemas" — the variant-plan compiler now
consumes a registered view's explicit-input (props) schema, validates the
plan's `:effective-args` against it before render, and surfaces the
schema + effective args + validation outcome in `explain`.

Primary edit surface is `tools/story/src/re_frame/story/plan.cljc` (built
by .10). No changes to `story.cljc` or `evidence.cljc` (owned by the open
sibling PR #2414).

### What changed

- **Schema resolution** — from the `:component` view's `:view` registrar
  slot, first match wins: `:rf/props` (the spec-named props key) →
  `:spec` (the live Spec 010 boundary-schema slot the framework actually
  exposes) → `:schema` (the Story-only alias the controls / schema-
  validation panels already read). Confirmed against `core-reg-view-macro`
  + `reg_view_test` + the existing `schema_validation.cljc` lookup — the
  framework exposes the props/args contract on `:spec`/`:schema`, so Story
  consumes that rather than inventing a parallel key. The `:rf/props`
  spelling is honoured first for any port that adopts it.
- **Plan slots** — `[:world :view-args-schema]` (copied schema),
  `[:world :effective-args]` (resolved arg-map at plan time; render layers
  control overrides on top later), and `[:explain :view-args-schema]` /
  `[:explain :effective-args]` / `[:explain :view-args-validation]`.
- **Two-tier validation (both pure / JVM-testable)** — a host-free
  required-key presence floor (every non-`{:optional true}` `[:map …]`
  entry must be present) plus an optional validator-driven malformed-value
  check (the `{:validate :explain}` pair the renderer already threads via
  the Malli late-bind hook). A missing-required or malformed input **fails
  plan construction** with `:rf.error/story-view-args-invalid` carrying the
  failing key, the Malli schema `:path`, the effective args, and the source
  `:variant/id`.
- **Sharp boundary** — view-arg schemas validate explicit view inputs;
  subscription-output schemas validate sub / `:sub-overrides` values. The
  two are kept distinct (a test pins that `:sub-overrides` ride their own
  `[:world :render :sub-overrides]` slot and are never checked against the
  view-args schema).
- **Purity** — `:view-lookup` (a `(view-id) → view-meta` fn or map,
  defaulting to the framework `:view` registrar) and `:validator-fns` are
  threaded through `variant-plan`, so the compiler stays a pure data → data
  fn runnable under `clojure -M:test`.

### Tests (`plan_test.cljc`, 12 new)

Schema copied into the plan; valid effective-args render; missing required
arg fails before render (reports key + path + source variant); optional
arg may be absent; malformed arg fails with schema path + source variant +
validator explanation; no-schema / no-component leave the plan unvalidated;
schema-key precedence (`:rf/props` → `:spec` → `:schema`); the
`validate-effective-args` unit floor; and the view-args-vs-sub-overrides
boundary.

### Spec currency

`tools/story/spec/017-Testing-Story.md` updated in the same PR: the
existing §View arg schemas section gains the M0-confirmed metadata-key
resolution, the plan slots, the two-tier validation contract, and the
sharp boundary vs subscription-output schemas; the compiler normalization
table gains the `:view-args-schema` / `:effective-args` rows. Placed in
the authoring/plan sections, away from the evidence/vocabulary sections to
avoid collision with #2414.

## Quality gates

| Gate | Result |
|---|---|
| `cd tools/story && clojure -M:test` | PASS — 923 tests / 2768 assertions, 0 failures, 0 errors (plan-test isolated: 28 tests / 87 assertions) |
| `npm --prefix implementation run test:cljs` | PASS — 4842 tests / 15870 assertions, 0 failures, 0 errors |
| `bash scripts/test-fast-pr.sh` | PASS — full spine + markdown link/anchor gates (mkdocs soft-skipped locally; CI runs it) |
