### PR TITLE
feat(story): invariant sentinels + first-bad-epoch over the epoch tape (rf2-5x1wt.5 + rf2-5x1wt.6)

### DIFF
--- a/tools/story/deps.edn
+++ b/tools/story/deps.edn
@@ -47,6 +47,17 @@
  {:test {:extra-paths ["test"]
          :extra-deps  {;; rf2-try1x — silent-on-success reporter.
                        day8/re-frame2-test-quiet {:local/root "../../implementation/test-quiet"}
+                       ;; rf2-5x1wt.5 — the invariant-sentinel fixture
+                       ;; (`re-frame.story.invariants`) registers a live
+                       ;; epoch listener via `re-frame.core/register-epoch-
+                       ;; listener!`, which is a no-op unless the epoch
+                       ;; artefact is on the classpath. The top-level CLJS
+                       ;; build already carries `epoch/src` (shadow-cljs.edn);
+                       ;; this test-only dep gives the JVM `clojure -M:test`
+                       ;; gate the same live epoch surface so the sentinel's
+                       ;; fresh/destroyed-frame coverage actually exercises
+                       ;; the listener path.
+                       day8/re-frame2-epoch      {:local/root "../../implementation/epoch"}
                        io.github.cognitect-labs/test-runner
                        {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
          :main-opts   ["-m" "re-frame.test-quiet.runner"]}

--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -1204,6 +1204,84 @@ Equivalent inline plans and registered variants SHOULD be testable as a
 runner, they MUST produce the same final app-db and assertion records
 after `canonicalize`.
 
+## Invariant sentinels
+
+The epoch tape is also the substrate for **invariant sentinels** — the
+"this MUST hold after every committed epoch" assertion form (NewTestStory
+§A1 / §A2). Two surfaces share one notion of an invariant: a live
+fixture (`with-invariants`) and a pure post-hoc utility
+(`first-bad-epoch`). Both live in `re-frame.story.invariants`; the
+fixture USES the utility for its "which epoch failed?" reporting so the
+live and post-hoc verdicts agree by construction.
+
+### What an invariant is
+
+An invariant is a predicate that MUST hold after every committed epoch.
+It reads one `:rf/epoch-record` — its settled `:db-after`, its
+`:trigger-event`, its `:trace-events` — and answers "is the world still
+well-formed here?". Authors MAY express an invariant as:
+
+- a bare 1-arg fn `(fn [epoch] truthy?)` over the whole epoch record;
+- a `{:id … :check (fn [epoch] …)}` map (`:pred` is accepted as an alias
+  for `:check`);
+- a `[:db path pred]` / `[:db path = expected]` data shorthand for the
+  common "a value at an app-db path satisfies a predicate / equals a
+  literal" case — so the most frequent invariant stays data-shaped
+  (matching the §Story-variant data-shaped posture) and carries
+  `:path` / `:expected` / `:actual` onto the violation report.
+
+### `with-invariants` — the live sentinel
+
+```clojure
+(test/with-invariants [invariant-spec …] body…)
+```
+
+`with-invariants` registers ONE epoch listener (via
+`re-frame.core/register-epoch-listener!`) before `body` runs, checks
+every invariant after EACH committed epoch, and on exit unregisters the
+listener — even if `body` throws. It:
+
+- reports each violation through `clojure.test` / `cljs.test` (via
+  `do-report`, the same non-throwing channel
+  `re-frame.test-support/assert-path-equals` uses), so a violation
+  registers a counted failure;
+- reports each violation **exactly once per failing epoch** — a
+  re-fire of the same record (a back-filled render re-notify, §Run
+  result) is de-duplicated on the `[invariant-id epoch-id]` key;
+- reports a `:pass` for every invariant that held across the run, so a
+  green sentinel is visible rather than silent;
+- **NEVER throws from the epoch listener**: a violated OR a broken
+  (throwing) predicate is caught and reported, and the run continues.
+  Isolation is twofold — `register-epoch-listener!` already isolates
+  listener exceptions (Spec 009 §`register-epoch-listener!`), and the
+  per-epoch check itself catches predicate exceptions and reports them
+  as violations carrying the isolated `:error`.
+
+The sentinel observes every frame's epochs for the duration of `body`;
+scope an invariant to one frame by reading `(:frame epoch)` inside its
+`:check`. It works with fresh and destroyed frames: a frame destroyed
+mid-`body` simply commits no further epochs, and the listener is removed
+on the way out regardless.
+
+### `first-bad-epoch` — the pure post-hoc utility
+
+```clojure
+(test/first-bad-epoch epoch-tape invariant)
+```
+
+`first-bad-epoch` is **pure** — a retained epoch tape and an invariant
+(any of the authored shapes above) in, a result map or `nil` out. It
+walks the tape forward and returns the **first** epoch where the
+invariant fails, enriched with the spec's named slots — the failing
+`:epoch` record verbatim, the `:trigger-event`, a shallow top-level
+`:db-diff` (the set of changed app-db keys), and the epoch's
+`:trace-events` when retained — or `nil` when the invariant holds across
+the whole tape. An empty (or `nil`) tape returns `nil`; a failure in the
+first epoch returns that epoch. Because it never touches the runtime, it
+runs under `clojure -M:test` with no host, and the future Story UI
+first-bad-epoch view (§Story UI requirements) reads exactly this
+projection.
+
 ## Story UI requirements
 
 P1 Story UI MUST:

--- a/tools/story/src/re_frame/story/invariants.cljc
+++ b/tools/story/src/re_frame/story/invariants.cljc
@@ -1,0 +1,422 @@
+(ns re-frame.story.invariants
+  "Invariant sentinels + the first-bad-epoch utility (NewTestStory
+  rf2-5x1wt.5 + rf2-5x1wt.6, spec/017-Testing-Story.md §Invariant
+  sentinels).
+
+  ## What an invariant is
+
+  An invariant is a predicate that MUST hold after every committed
+  epoch. Spec/017 §Run result makes the `:rf/epoch-record` the single
+  evidence atom; an invariant reads that record (its settled
+  `:db-after`, its `:trigger-event`, its `:trace-events`) and answers
+  one question — \"is the world still well-formed here?\".
+
+  Two surfaces share this one notion of an invariant, so they share one
+  namespace:
+
+  - `with-invariants` — the live SENTINEL fixture (rf2-5x1wt.5). It
+    registers an epoch listener per invariant before `body` runs, checks
+    each invariant after every committed epoch, and reports failures
+    through `clojure.test` / `cljs.test`. It NEVER throws from the
+    listener (§Never throw): a broken predicate, or a violated one,
+    reports and the run continues.
+  - `first-bad-epoch` — the pure POST-HOC utility (rf2-5x1wt.6). Given a
+    retained epoch tape and an invariant, it returns the first epoch
+    where the invariant fails (enriched with the trigger event, the
+    db-diff, and the trace events), or `nil` when the invariant holds
+    across the whole tape. The fixture USES this utility to answer
+    \"which epoch failed?\" so the live and post-hoc surfaces agree by
+    construction.
+
+  ## Invariant shape
+
+  An invariant is normalized by `coerce-invariant` into a map:
+
+      {:id    keyword-or-string   ; report label; defaults to an ordinal
+       :check (fn [epoch] truthy?)} ; the predicate over an :rf/epoch-record
+
+  Authors MAY pass any of:
+
+  - a bare 1-arg fn `(fn [epoch] …)` — the whole epoch record is the
+    argument, so a predicate can read `:db-after`, `:trigger-event`, …;
+  - a map carrying an explicit `:check` fn (and an optional `:id`);
+  - a `[:db path pred]` / `[:db path = expected]` data shorthand for the
+    common \"a value at an app-db path satisfies a predicate\" case, so
+    the most frequent invariant needs no fn literal and stays
+    data-shaped (matching the Story authoring posture, spec/017
+    §Story variant).
+
+  ## Diagnostics
+
+  Each violation carries the spec/017 §A1 diagnostic spine where the
+  epoch record provides it — frame id, epoch id, the triggering event,
+  the path / expected / actual for a `:db`-path invariant, the predicate
+  source where the author supplied an `:id`, and the predicate exception
+  (isolated) when the check threw. The same `violation` map feeds both
+  the live `do-report` and the `first-bad-epoch` return value.
+
+  ## Pure / JVM-testable
+
+  Every fn here is `.cljc` and PURE: epoch records (data) in, violation
+  maps (data) out. `first-bad-epoch`, `coerce-invariant`, `check-epoch`,
+  and the report-projection run under `clojure -M:test` with no runtime.
+  Only `with-invariants` touches the live epoch-listener registry, and
+  that registration is the thin orchestration wrapper around the pure
+  core."
+  #?(:cljs (:require-macros [re-frame.story.invariants]))
+  (:require [re-frame.core :as rf]
+            #?(:clj  [clojure.test :as ctest]
+               :cljs [cljs.test :as ctest :include-macros true])))
+
+;; ===========================================================================
+;; INVARIANT NORMALIZATION
+;; ===========================================================================
+;;
+;; The author surface accepts a bare predicate, an explicit `:check` map,
+;; or a `[:db path …]` data shorthand. `coerce-invariant` lowers all three
+;; into the one `{:id … :check …}` shape the checker consumes, so the rest
+;; of the namespace reasons about a single form. `idx` is the 0-based
+;; position in the author's invariant vector, used for the default `:id`
+;; when the author supplied none — a stable, distinct label.
+
+(defn- db-path-check
+  "Build the `:check` fn for a `[:db path & rest]` shorthand. `rest` is
+  either `[pred]` (a 1-arg predicate over the value at `path`) or
+  `[= expected]` (equality against a literal). The returned fn carries
+  the resolved `:path` / `:expected` / `:actual` onto the epoch via the
+  invariant's diagnostic projection (`check-epoch` reads them back). Pure
+  data → fn; the fn itself is pure over an epoch record."
+  [path rst]
+  (let [[expected pred]
+        (cond
+          ;; [:db path = expected]  → equality shorthand
+          (and (= 2 (count rst)) (= = (first rst)))
+          [(second rst) #(= (second rst) %)]
+          ;; [:db path pred]        → predicate shorthand
+          (= 1 (count rst))
+          [::no-expected (first rst)]
+          :else
+          (throw (ex-info "re-frame2-story: :db invariant shorthand is [:db path pred] or [:db path = expected]"
+                          {:rf.error/id :rf.error/story-bad-invariant
+                           :shorthand   (into [:db path] rst)})))]
+    (fn db-path-invariant [epoch]
+      (let [actual (get-in (:db-after epoch) path)]
+        {:ok?      (boolean (pred actual))
+         :path     path
+         :actual   actual
+         :expected (when (not= ::no-expected expected) expected)}))))
+
+(defn coerce-invariant
+  "Normalize one authored invariant into `{:id … :check …}`. `idx` is the
+  invariant's 0-based position, used for the default `:id`. Pure.
+
+  `:check` is a fn `(fn [epoch] …)` that returns either a boolean (the
+  invariant holds / is violated) or a map `{:ok? boolean & diagnostics}`
+  carrying extra report slots (`:path` / `:expected` / `:actual`). The
+  map form is what the `[:db …]` shorthand emits; a bare-fn / `:check`-fn
+  author returns a boolean and the checker fills the spine from the epoch
+  record alone."
+  [idx invariant]
+  (cond
+    ;; A bare predicate over the epoch record.
+    (fn? invariant)
+    {:id (keyword (str "invariant-" idx)) :check invariant}
+
+    ;; The `[:db path …]` data shorthand.
+    (and (vector? invariant) (= :db (first invariant)))
+    {:id    (keyword (str "invariant-" idx))
+     :check (db-path-check (second invariant) (vec (drop 2 invariant)))}
+
+    ;; An explicit map; default the id from the ordinal.
+    (map? invariant)
+    (let [check (or (:check invariant) (:pred invariant))]
+      (when-not (fn? check)
+        (throw (ex-info "re-frame2-story: invariant map needs a `:check` (or `:pred`) fn"
+                        {:rf.error/id :rf.error/story-bad-invariant
+                         :invariant   invariant})))
+      (merge {:id (keyword (str "invariant-" idx))} invariant {:check check}))
+
+    :else
+    (throw (ex-info "re-frame2-story: invariant must be a fn, a `[:db path …]` vector, or a map"
+                    {:rf.error/id :rf.error/story-bad-invariant
+                     :invariant   invariant}))))
+
+(defn coerce-invariants
+  "Normalize a vector of authored invariants. Pure."
+  [invariants]
+  (into [] (map-indexed coerce-invariant) invariants))
+
+;; ===========================================================================
+;; THE EPOCH CHECK  (one invariant × one epoch → a result)
+;; ===========================================================================
+;;
+;; `check-epoch` is the single evaluation primitive both surfaces use. It
+;; runs the (already-normalized) invariant's `:check` against ONE epoch
+;; record and returns a result map. It NEVER throws (§Never throw): a
+;; predicate that explodes is caught and reported as a violation carrying
+;; `:error`, so a broken invariant fails the test rather than the run.
+
+(defn- diagnostic-spine
+  "The spec/017 §A1 diagnostic spine read from the epoch record alone —
+  frame id, epoch id, and the triggering event. The path / expected /
+  actual slots come from the check's return map (the `[:db …]` shorthand)
+  and are merged on top. Pure data → data."
+  [{:keys [frame epoch-id event-id trigger-event] :as _epoch}]
+  (cond-> {}
+    (some? frame)         (assoc :frame frame)
+    (some? epoch-id)      (assoc :epoch-id epoch-id)
+    (some? event-id)      (assoc :event event-id)
+    (some? trigger-event) (assoc :trigger-event trigger-event)))
+
+(defn check-epoch
+  "Evaluate one normalized `invariant` against one `epoch` record. Returns
+  `nil` when the invariant HOLDS, or a violation map when it is violated
+  (or the predicate threw). Pure / never-throws.
+
+  A violation map carries the invariant `:id`, the diagnostic spine from
+  the epoch (`:frame` / `:epoch-id` / `:event` / `:trigger-event`), any
+  `:path` / `:expected` / `:actual` the check returned, and — when the
+  predicate threw — the isolated `:error` message (the predicate
+  exception never escapes; a broken invariant is itself a violation)."
+  [{:keys [id check] :as _invariant} epoch]
+  (let [result (try
+                 (check epoch)
+                 (catch #?(:clj Throwable :cljs :default) e
+                   {:ok?   false
+                    :error #?(:clj  (.getMessage ^Throwable e)
+                              :cljs (str e))}))
+        ;; A bare-fn check returns a boolean; the `[:db …]` shorthand and
+        ;; the catch arm return a `{:ok? …}` map with extra diagnostics.
+        {:keys [ok?] :as detail} (if (map? result) result {:ok? (boolean result)})]
+    (when-not ok?
+      (-> (diagnostic-spine epoch)
+          (assoc :invariant id)
+          (merge (dissoc detail :ok?))))))
+
+(defn check-all
+  "Evaluate every normalized `invariant` against one `epoch`. Returns the
+  vector of violations (empty when every invariant holds). Pure /
+  never-throws — `check-epoch` isolates each predicate."
+  [invariants epoch]
+  (into [] (keep #(check-epoch % epoch)) invariants))
+
+;; ===========================================================================
+;; FIRST-BAD-EPOCH  (pure post-hoc utility, rf2-5x1wt.6)
+;; ===========================================================================
+;;
+;; spec/017 §First-bad-epoch / NewTestStory §A2: a pure utility over an
+;; epoch tape. It walks the tape forward and returns the FIRST epoch where
+;; the invariant fails, enriched with the trigger event, the db-diff, and
+;; the trace events (the spec's named enrichment slots), or `nil` when the
+;; invariant holds across the whole tape. `with-invariants` uses this for
+;; its "which epoch failed?" reporting, so the live and post-hoc surfaces
+;; agree.
+
+(defn- db-diff
+  "A shallow before→after diff for the report: the set of top-level
+  app-db keys whose value changed across the epoch. Cheap and pure —
+  enough to point a reader at the mutated region without serialising two
+  whole app-dbs. `nil` when neither snapshot is a map."
+  [{:keys [db-before db-after] :as _epoch}]
+  (when (or (map? db-before) (map? db-after))
+    (let [before (or db-before {})
+          after  (or db-after {})
+          ks     (into #{} (concat (keys before) (keys after)))]
+      (into #{}
+            (filter #(not= (get before %) (get after %)))
+            ks))))
+
+(defn first-bad-epoch
+  "Return the first epoch in `epoch-tape` where `invariant` fails, or
+  `nil` when the invariant holds across the whole tape. Pure /
+  never-throws (per spec/017 §First-bad-epoch / NewTestStory §A2).
+
+  `invariant` is any authored shape `coerce-invariant` accepts (a bare
+  predicate, a `[:db path …]` shorthand, or a `{:check …}` map). The
+  returned map is the `check-epoch` violation enriched with the spec's
+  named slots:
+
+      {:invariant     id
+       :epoch         the failing :rf/epoch-record (verbatim)
+       :epoch-id      …            ; the diagnostic spine
+       :frame         …
+       :event         …
+       :trigger-event the triggering event vector
+       :db-diff       #{changed-top-level-keys}
+       :trace-events  the epoch's raw trace stream (when retained)
+       :path/:expected/:actual …}  ; from a :db-path invariant
+
+  An empty tape returns `nil` (no epoch can fail). A failure in the FIRST
+  epoch returns that epoch."
+  [epoch-tape invariant]
+  (let [inv (coerce-invariant 0 invariant)]
+    (reduce
+      (fn [_ epoch]
+        (when-let [violation (check-epoch inv epoch)]
+          (reduced
+            (cond-> (assoc violation
+                           :epoch         epoch
+                           :db-diff       (db-diff epoch)
+                           :trigger-event (:trigger-event epoch))
+              (some? (:trace-events epoch)) (assoc :trace-events (:trace-events epoch))))))
+      nil
+      (or epoch-tape []))))
+
+;; ===========================================================================
+;; REPORTING  (violation → clojure.test / cljs.test, never throw)
+;; ===========================================================================
+;;
+;; The live fixture reports each violation through `ctest/do-report` — the
+;; same non-throwing channel `re-frame.test-support/assert-path-equals`
+;; uses — so a violation registers a `clojure.test` failure WITHOUT
+;; throwing out of the epoch listener (§Never throw). A run with no
+;; violations registers one `:pass` per invariant so a green sentinel is
+;; visible in the report rather than silent.
+
+(defn violation-message
+  "A one-line human-facing message for a violation. Pure / deterministic."
+  [{:keys [invariant epoch-id event error path] :as _violation}]
+  (str "invariant " (pr-str invariant)
+       " violated"
+       (when (some? epoch-id) (str " at epoch " (pr-str epoch-id)))
+       (when (some? event)    (str " (event " (pr-str event) ")"))
+       (when (some? path)     (str " at path " (pr-str path)))
+       (when error            (str " — predicate threw: " error))))
+
+(defn report-violation!
+  "Report one violation as a `clojure.test` / `cljs.test` `:fail` via
+  `do-report` — never throws. Returns the violation."
+  [{:keys [expected actual] :as violation}]
+  (ctest/do-report
+    {:type     :fail
+     :message  (violation-message violation)
+     :expected expected
+     :actual   actual})
+  violation)
+
+(defn report-pass!
+  "Report a passing invariant as a `:pass` via `do-report` so a green
+  sentinel is visible in the report. Never throws."
+  [invariant-id]
+  (ctest/do-report
+    {:type     :pass
+     :message  (str "invariant " (pr-str invariant-id) " held across all epochs")})
+  nil)
+
+;; ===========================================================================
+;; LISTENER ORCHESTRATION  (the live sentinel core, rf2-5x1wt.5)
+;; ===========================================================================
+;;
+;; `with-invariants` (below) brackets the body with one registered epoch
+;; listener that checks every invariant after each committed epoch. The
+;; pure core is here so the macro stays a thin wrapper and the
+;; report-once / exception-isolation logic is itself testable.
+;;
+;; report-once policy: a violation is reported at most ONCE per
+;; (invariant, epoch-id) pair (spec/017 §A1 "exactly once per failing
+;; epoch"). The listener threads a `seen` set of `[invariant-id epoch-id]`
+;; tuples through an atom so a re-fire of the same record (a back-filled
+;; render re-notify, rf2-qs6dl) does not double-count.
+
+(defn dedup-key
+  "The report-once key for a violation against an epoch: the
+  `[invariant-id epoch-id]` tuple. Pure."
+  [violation]
+  [(:invariant violation) (:epoch-id violation)])
+
+(defn on-epoch!
+  "The per-epoch listener step: check every `invariants` against `epoch`,
+  report each not-yet-seen violation exactly once, and record the seen
+  keys + every violation into `state-atom`. Never throws — `check-all`
+  isolates predicate exceptions and `report-violation!` uses `do-report`.
+
+  `state-atom` holds `{:seen #{[inv-id epoch-id] …} :violations [v …]}`.
+  Returns the violations reported on THIS call (for testing)."
+  [state-atom invariants epoch]
+  (let [violations (check-all invariants epoch)
+        fresh      (filterv #(not (contains? (:seen @state-atom) (dedup-key %)))
+                            violations)]
+    (doseq [v fresh]
+      (report-violation! v)
+      (swap! state-atom (fn [s]
+                          (-> s
+                              (update :seen conj (dedup-key v))
+                              (update :violations conj v)))))
+    fresh))
+
+(defn run-with-invariants*
+  "The runtime core of `with-invariants` — registers one epoch listener
+  that runs `on-epoch!` after every committed epoch, calls `body-fn`,
+  then on the way out (even if `body-fn` throws) unregisters the listener
+  and reports a `:pass` for every invariant that recorded no violation.
+  Returns `body-fn`'s value.
+
+  `invariants` is the authored vector; it is coerced here so the macro
+  passes author shapes through verbatim. The listener exception isolation
+  is twofold: `re-frame.core/register-epoch-listener!` already catches and
+  isolates listener exceptions (Spec 009 §register-epoch-listener!), AND
+  `on-epoch!` itself never throws — so a broken predicate can neither
+  break the runtime nor abort the body."
+  [invariants body-fn]
+  (let [coerced (coerce-invariants invariants)
+        state   (atom {:seen #{} :violations []})
+        key     (keyword "rf.story.invariants" (str (gensym "sentinel-")))]
+    (rf/register-epoch-listener! key (fn [epoch] (on-epoch! state coerced epoch)))
+    (try
+      (body-fn)
+      (finally
+        (rf/unregister-epoch-listener! key)
+        ;; Per spec/017 §A1 — a green sentinel is visible: report a
+        ;; `:pass` for every invariant that recorded no violation across
+        ;; the whole run.
+        (let [violated (into #{} (map :invariant) (:violations @state))]
+          (doseq [{:keys [id]} coerced
+                  :when (not (contains? violated id))]
+            (report-pass! id)))))))
+
+;; ===========================================================================
+;; with-invariants  (the public fixture macro, rf2-5x1wt.5)
+;; ===========================================================================
+
+#?(:clj
+   (defmacro with-invariants
+     "Run `body` with a live invariant sentinel: each invariant is checked
+     after every committed epoch and violations report through
+     `clojure.test` / `cljs.test` (spec/017 §Invariant sentinels).
+
+     Shape:
+
+         (with-invariants [invariant-spec …] body+)
+
+     Each `invariant-spec` is a bare predicate `(fn [epoch] …)` over an
+     `:rf/epoch-record`, a `[:db path pred]` / `[:db path = expected]`
+     data shorthand, or a `{:id … :check (fn [epoch] …)}` map. The
+     sentinel:
+
+     - checks every invariant after EACH committed epoch (via
+       `re-frame.core/register-epoch-listener!`);
+     - reports each violation through `clojure.test` / `cljs.test` exactly
+       ONCE per failing epoch;
+     - NEVER throws from the epoch listener — a violated OR a broken
+       (throwing) predicate reports and the run continues;
+     - unregisters the listener on the way out, even if `body` throws;
+     - reports a `:pass` for every invariant that held across the run, so
+       a green sentinel is visible.
+
+     Returns the value of `body`'s final form. The sentinel observes
+     EVERY frame's epochs for the duration of the body; scope invariants
+     to a frame by reading `(:frame epoch)` inside a `:check` fn.
+
+     Example — an app-db key must stay a vector across a dispatch run:
+
+         (with-invariants [[:db [:cart :items] vector?]
+                           (fn [epoch] (not (neg? (get-in (:db-after epoch)
+                                                          [:cart :total]))))]
+           (rf/dispatch-sync [:cart/add {:sku \"A\"}])
+           (rf/dispatch-sync [:cart/checkout]))"
+     {:arglists '([[invariant-spec*] body+])}
+     [invariants & body]
+     (when-not (vector? invariants)
+       (throw (ex-info "with-invariants expects a vector of invariant specs"
+                       {:invariants invariants})))
+     `(run-with-invariants* [~@invariants] (fn [] ~@body))))

--- a/tools/story/test/re_frame/story/invariants_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/invariants_cljs_test.cljs
@@ -1,0 +1,108 @@
+(ns re-frame.story.invariants-cljs-test
+  "CLJS coverage for `re-frame.story.invariants` (rf2-5x1wt.5 +
+  rf2-5x1wt.6, spec/017-Testing-Story.md §Invariant sentinels).
+
+  The pure surface (`first-bad-epoch`, `coerce-invariant`, `check-epoch`,
+  the report-once `on-epoch!` core) is exercised on the JVM by
+  `re-frame.story.invariants-test`; this CLJS sibling pins the
+  host-portable cases the `cljs-test$` node-test build discovers — the
+  `:require-macros` self-reference compiles, the `with-invariants` macro
+  expands to valid ClojureScript, and the live sentinel observes a real
+  CLJS frame's epochs (`dispatch-sync` drains synchronously on node, and
+  the epoch artefact is on the CLJS test classpath via shadow-cljs.edn)."
+  (:require [cljs.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.epoch :as epoch]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.machines]
+            [re-frame.story.invariants :as inv])
+  (:require-macros [re-frame.story.invariants :refer [with-invariants]]))
+
+(use-fixtures :each
+  (fn [test-fn]
+    (registrar/clear-all!)
+    (reset! frame/frames {})
+    (rf/init! plain-atom/adapter)
+    (epoch/clear-epoch-listeners!)
+    (epoch/clear-history!)
+    (frame/ensure-default-frame!)
+    (test-fn)))
+
+(defn- epoch-rec
+  [epoch-id m]
+  (merge {:epoch-id epoch-id :frame :test/frame :outcome :ok
+          :db-before {} :db-after {} :trace-events []}
+         m))
+
+;; ---- pure surface (host-portability) -------------------------------------
+
+(deftest first-bad-epoch-cljs
+  (testing "first-bad-epoch returns the first failing epoch on CLJS"
+    (let [tape [(epoch-rec 1 {:db-after {:n 1}})
+                (epoch-rec 2 {:db-after {:n -1}})]
+          bad  (inv/first-bad-epoch tape (fn [e] (pos? (:n (:db-after e)))))]
+      (is (= 2 (:epoch-id bad))))
+    (is (nil? (inv/first-bad-epoch [] (fn [_] false))))))
+
+(deftest check-epoch-isolates-throw-cljs
+  (testing "a throwing predicate is caught on CLJS"
+    (let [c (inv/coerce-invariant 0 (fn [_] (throw (ex-info "boom" {}))))
+          v (inv/check-epoch c (epoch-rec 1 {}))]
+      (is (some? v))
+      (is (string? (:error v))))))
+
+;; ---- on-epoch! report-once (CLJS report sink) ----------------------------
+
+(defn- with-captured-reports
+  [f]
+  (let [reports (atom [])]
+    (with-redefs [cljs.test/report (fn [m] (swap! reports conj m))]
+      (f))
+    @reports))
+
+(deftest on-epoch-reports-once-cljs
+  (testing "a violation reports once per (invariant, epoch) on CLJS"
+    (let [coerced (inv/coerce-invariants [(fn [e] (pos? (:n (:db-after e))))])
+          state   (atom {:seen #{} :violations []})
+          ep      (epoch-rec 5 {:db-after {:n -3}})
+          reports (with-captured-reports
+                    (fn [] (inv/on-epoch! state coerced ep)
+                           (inv/on-epoch! state coerced ep)))]
+      (is (= 1 (count (filter #(= :fail (:type %)) reports)))))))
+
+;; ---- live with-invariants over a real CLJS frame -------------------------
+
+(deftest with-invariants-live-cljs
+  (testing "the sentinel observes a real frame's epochs and reports once per failing epoch"
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event-db :dec  (fn [db _] (update db :n dec)))
+    (let [reports (with-captured-reports
+                    (fn []
+                      (with-invariants [(fn [e] (>= (:n (:db-after e)) 0))]
+                        (rf/dispatch-sync [:seed] {:frame :test/main})
+                        (rf/dispatch-sync [:dec]  {:frame :test/main})
+                        (rf/dispatch-sync [:dec]  {:frame :test/main}))))]
+      (is (= 2 (count (filter #(= :fail (:type %)) reports)))
+          "two failing epochs → two failures"))))
+
+(deftest with-invariants-pass-and-destroy-cljs
+  (testing "a holding invariant reports passes; destroying the frame mid-run is tolerated"
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (let [done    (atom false)
+          reports (with-captured-reports
+                    (fn []
+                      (with-invariants [(fn [e] (map? (:db-after e)))]
+                        (rf/dispatch-sync [:seed] {:frame :test/main})
+                        (rf/dispatch-sync [:inc]  {:frame :test/main})
+                        (rf/destroy-frame! :test/main)
+                        (reset! done true))))]
+      (is (true? @done) "the body completed across the destroy")
+      (is (zero? (count (filter #(= :fail (:type %)) reports)))
+          "a holding invariant reports no failures")
+      (is (pos? (count (filter #(= :pass (:type %)) reports)))
+          "a green sentinel reports a pass"))))

--- a/tools/story/test/re_frame/story/invariants_test.cljc
+++ b/tools/story/test/re_frame/story/invariants_test.cljc
@@ -1,0 +1,338 @@
+(ns re-frame.story.invariants-test
+  "Tests for `re-frame.story.invariants` — the invariant sentinel fixture
+  (rf2-5x1wt.5) and the pure first-bad-epoch utility (rf2-5x1wt.6),
+  spec/017-Testing-Story.md §Invariant sentinels.
+
+  Two axes:
+
+  - PURE — hand-built `:rf/epoch-record` tapes in, violations out:
+    `first-bad-epoch`, `coerce-invariant`, `check-epoch`, the
+    report-once `on-epoch!` core. These run under `clojure -M:test`
+    (JVM) and the node-runtime CLJS build with no runtime.
+  - LIVE — the `with-invariants` fixture over a real frame + dispatch +
+    epoch listeners, exercising the bead acceptance: passing invariant
+    across multiple dispatches; failing invariant reports once per
+    failing epoch; listener exceptions are isolated; works with fresh
+    AND destroyed frames.
+
+  The live axis captures `clojure.test` / `cljs.test` reports through a
+  rebound `report` multimethod / `do-report` so a deliberate violation
+  registers a counted failure WITHOUT failing this suite."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.story.invariants :as inv]
+            #?(:clj [re-frame.story.invariants :refer [with-invariants]])
+            #?(:clj [re-frame.frame :as frame])
+            #?(:clj [re-frame.registrar :as registrar])
+            #?(:clj [re-frame.epoch :as epoch])
+            #?(:clj [re-frame.substrate.plain-atom :as plain-atom])
+            ;; Side-effect require — machine restore hooks must be present
+            ;; on the classpath (mirrors re-frame.epoch-test / the story
+            ;; runtime fixture).
+            #?(:clj [re-frame.machines]))
+  #?(:cljs (:require-macros [re-frame.story.invariants :refer [with-invariants]])))
+
+;; The live `with-invariants` axis runs on the JVM (`clojure -M:test`),
+;; where a real frame can be allocated and dispatched synchronously. The
+;; fixture mirrors the canonical story runtime fixture
+;; (`re-frame.story-runtime-test/reset-all`): tear down the registrar +
+;; frames, re-seat the plain-atom adapter, re-require machines, and clear
+;; the epoch listener / history registries between tests.
+#?(:clj (use-fixtures :each
+          (fn [test-fn]
+            (registrar/clear-all!)
+            (reset! frame/frames {})
+            (try (rf/init! plain-atom/adapter)
+                 (catch clojure.lang.ExceptionInfo _ nil))
+            (require 're-frame.machines :reload)
+            (epoch/clear-epoch-listeners!)
+            (epoch/clear-history!)
+            (frame/ensure-default-frame!)
+            (test-fn))))
+
+;; ===========================================================================
+;; FIXTURE BUILDERS  (pure tapes)
+;; ===========================================================================
+
+(defn- epoch
+  "Build a minimal `:rf/epoch-record`. `m` overrides any slot."
+  [epoch-id m]
+  (merge {:epoch-id     epoch-id
+          :frame        :test/frame
+          :outcome      :ok
+          :db-before    {}
+          :db-after     {}
+          :trace-events []}
+         m))
+
+;; ===========================================================================
+;; coerce-invariant  (normalization)
+;; ===========================================================================
+
+(deftest coerce-bare-fn
+  (testing "a bare predicate normalizes to {:id … :check fn}"
+    (let [{:keys [id check]} (inv/coerce-invariant 0 (fn [e] (map? (:db-after e))))]
+      (is (= :invariant-0 id))
+      (is (fn? check)))))
+
+(deftest coerce-explicit-map
+  (testing "an explicit map keeps its :id and resolves :check (or :pred)"
+    (let [c (inv/coerce-invariant 3 {:id :my/inv :check (fn [_] true)})]
+      (is (= :my/inv (:id c)))
+      (is (fn? (:check c))))
+    (testing ":pred is accepted as an alias for :check"
+      (is (fn? (:check (inv/coerce-invariant 0 {:pred (fn [_] true)})))))
+    (testing "a map without a check fn throws a structured error"
+      (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+                   (inv/coerce-invariant 0 {:id :x}))))))
+
+(deftest coerce-db-shorthand
+  (testing "[:db path pred] checks the value at the path"
+    (let [{:keys [check]} (inv/coerce-invariant 0 [:db [:cart :items] vector?])]
+      (is (:ok? (check (epoch 1 {:db-after {:cart {:items []}}}))))
+      (let [bad (check (epoch 1 {:db-after {:cart {:items 7}}}))]
+        (is (false? (:ok? bad)))
+        (is (= [:cart :items] (:path bad)))
+        (is (= 7 (:actual bad))))))
+  (testing "[:db path = expected] checks equality and carries :expected"
+    (let [{:keys [check]} (inv/coerce-invariant 0 [:db [:n] = 5])]
+      (is (:ok? (check (epoch 1 {:db-after {:n 5}}))))
+      (let [bad (check (epoch 1 {:db-after {:n 4}}))]
+        (is (false? (:ok? bad)))
+        (is (= 5 (:expected bad)))
+        (is (= 4 (:actual bad)))))))
+
+(deftest coerce-bad-shape-throws
+  (testing "a non-fn / non-vector / non-map invariant throws"
+    (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+                 (inv/coerce-invariant 0 :not-an-invariant)))))
+
+;; ===========================================================================
+;; check-epoch  (one invariant × one epoch, never-throws)
+;; ===========================================================================
+
+(deftest check-epoch-holds-returns-nil
+  (testing "a holding invariant returns nil"
+    (let [c (inv/coerce-invariant 0 (fn [e] (map? (:db-after e))))]
+      (is (nil? (inv/check-epoch c (epoch 1 {:db-after {}})))))))
+
+(deftest check-epoch-violation-carries-spine
+  (testing "a violation carries the diagnostic spine from the epoch"
+    (let [c (inv/coerce-invariant 0 (fn [e] (pos? (get-in (:db-after e) [:n]))))
+          v (inv/check-epoch c (epoch 7 {:event-id      :do/thing
+                                         :trigger-event [:do/thing 42]
+                                         :db-after      {:n -1}}))]
+      (is (= :invariant-0 (:invariant v)))
+      (is (= 7 (:epoch-id v)))
+      (is (= :test/frame (:frame v)))
+      (is (= :do/thing (:event v)))
+      (is (= [:do/thing 42] (:trigger-event v))))))
+
+(deftest check-epoch-isolates-predicate-exception
+  (testing "a throwing predicate is caught and reported as a violation with :error"
+    (let [c (inv/coerce-invariant 0 (fn [_] (throw (ex-info "boom" {}))))
+          v (inv/check-epoch c (epoch 1 {}))]
+      (is (some? v))
+      (is (= :invariant-0 (:invariant v)))
+      (is (string? (:error v))))))
+
+;; ===========================================================================
+;; first-bad-epoch  (pure post-hoc utility, rf2-5x1wt.6)
+;; ===========================================================================
+
+(deftest first-bad-epoch-nil-when-holds
+  (testing "returns nil when the invariant holds across the whole tape"
+    (let [tape [(epoch 1 {:db-after {:n 1}})
+                (epoch 2 {:db-after {:n 2}})
+                (epoch 3 {:db-after {:n 3}})]]
+      (is (nil? (inv/first-bad-epoch tape (fn [e] (pos? (:n (:db-after e))))))))))
+
+(deftest first-bad-epoch-returns-first-failing
+  (testing "returns the FIRST failing epoch, enriched with trigger + db-diff + traces"
+    (let [tape [(epoch 1 {:db-after {:n 1}})
+                (epoch 2 {:trigger-event [:break]
+                          :db-before     {:n 1}
+                          :db-after      {:n -5 :extra true}
+                          :trace-events  [{:operation :rf.event/run-start}]})
+                (epoch 3 {:db-after {:n -9}})]
+          bad  (inv/first-bad-epoch tape (fn [e] (>= (:n (:db-after e)) 0)))]
+      (is (= 2 (:epoch-id bad)) "the FIRST failing epoch, not a later one")
+      (is (= [:break] (:trigger-event bad)))
+      (is (= #{:n :extra} (:db-diff bad)) "shallow top-level changed-key set")
+      (is (= [{:operation :rf.event/run-start}] (:trace-events bad)))
+      (is (= (get tape 1) (:epoch bad)) "the failing record is returned verbatim"))))
+
+(deftest first-bad-epoch-empty-tape
+  (testing "an empty (or nil) tape returns nil — no epoch can fail"
+    (is (nil? (inv/first-bad-epoch [] (fn [_] false))))
+    (is (nil? (inv/first-bad-epoch nil (fn [_] false))))))
+
+(deftest first-bad-epoch-failure-in-first-epoch
+  (testing "a failure in the FIRST epoch is returned"
+    (let [tape [(epoch 1 {:db-after {:n -1}})
+                (epoch 2 {:db-after {:n -2}})]
+          bad  (inv/first-bad-epoch tape (fn [e] (pos? (:n (:db-after e)))))]
+      (is (= 1 (:epoch-id bad))))))
+
+(deftest first-bad-epoch-accepts-db-shorthand
+  (testing "first-bad-epoch accepts the same authored shapes as with-invariants"
+    (let [tape [(epoch 1 {:db-after {:cart {:items []}}})
+                (epoch 2 {:db-after {:cart {:items :oops}}})]
+          bad  (inv/first-bad-epoch tape [:db [:cart :items] vector?])]
+      (is (= 2 (:epoch-id bad)))
+      (is (= [:cart :items] (:path bad)))
+      (is (= :oops (:actual bad))))))
+
+;; ===========================================================================
+;; on-epoch!  (report-once core — pure over a state atom)
+;; ===========================================================================
+;;
+;; on-epoch! reports through `do-report`; we rebind the report sink so the
+;; fixture's deliberate failures don't fail THIS suite, and count them.
+
+(defn- with-captured-reports
+  "Run `f`, capturing every `clojure.test` / `cljs.test` report into a
+  vector instead of letting it reach the live reporter. Returns the
+  captured reports."
+  [f]
+  (let [reports (atom [])]
+    #?(:clj
+       (binding [clojure.test/report (fn [m] (swap! reports conj m))]
+         (f))
+       :cljs
+       ;; cljs.test reports through the test-environment :report-counters
+       ;; / a dynamic var; rebind the report multimethod's sink via
+       ;; with-redefs on `cljs.test/report` is not portable, so we use the
+       ;; testing-context's report var binding.
+       (with-redefs [cljs.test/report (fn [m] (swap! reports conj m))]
+         (f)))
+    @reports))
+
+(deftest on-epoch-reports-violation-once-per-epoch
+  (testing "a violation is reported once per (invariant, epoch) — re-fire does not double-count"
+    (let [coerced (inv/coerce-invariants [(fn [e] (pos? (:n (:db-after e))))])
+          state   (atom {:seen #{} :violations []})
+          ep      (epoch 5 {:db-after {:n -3}})
+          reports (with-captured-reports
+                    (fn []
+                      (inv/on-epoch! state coerced ep)
+                      ;; A second fire of the SAME record (back-filled
+                      ;; render re-notify) must NOT re-report.
+                      (inv/on-epoch! state coerced ep)))]
+      (is (= 1 (count (filter #(= :fail (:type %)) reports)))
+          "exactly one :fail across two fires of the same epoch")
+      (is (= 1 (count (:violations @state)))))))
+
+(deftest on-epoch-reports-each-distinct-epoch
+  (testing "distinct failing epochs each report once"
+    (let [coerced (inv/coerce-invariants [(fn [e] (pos? (:n (:db-after e))))])
+          state   (atom {:seen #{} :violations []})
+          reports (with-captured-reports
+                    (fn []
+                      (inv/on-epoch! state coerced (epoch 1 {:db-after {:n -1}}))
+                      (inv/on-epoch! state coerced (epoch 2 {:db-after {:n -2}}))))]
+      (is (= 2 (count (filter #(= :fail (:type %)) reports))))
+      (is (= 2 (count (:violations @state)))))))
+
+(deftest on-epoch-isolates-and-reports-broken-predicate
+  (testing "a throwing predicate reports a :fail and never escapes on-epoch!"
+    (let [coerced (inv/coerce-invariants [(fn [_] (throw (ex-info "boom" {})))])
+          state   (atom {:seen #{} :violations []})
+          reports (with-captured-reports
+                    (fn [] (inv/on-epoch! state coerced (epoch 1 {}))))]
+      (is (= 1 (count (filter #(= :fail (:type %)) reports)))))))
+
+;; ===========================================================================
+;; with-invariants  (LIVE fixture over a real frame, JVM)
+;; ===========================================================================
+;;
+;; These spin up a real frame, dispatch real events, and let the
+;; registered epoch listener check invariants after each committed epoch.
+;; Reports are captured so deliberate violations are counted, not fatal.
+
+#?(:clj
+   (deftest with-invariants-passes-across-multiple-dispatches
+     (testing "a holding invariant across multiple dispatches reports only passes"
+       (rf/reg-frame :test/main {})
+       (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+       (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+       (let [reports (with-captured-reports
+                       (fn []
+                         (with-invariants [(fn [e] (>= (:n (:db-after e)) 0))
+                                           [:db [:n] number?]]
+                           (rf/dispatch-sync [:seed] {:frame :test/main})
+                           (rf/dispatch-sync [:inc]  {:frame :test/main})
+                           (rf/dispatch-sync [:inc]  {:frame :test/main}))))]
+         (is (zero? (count (filter #(= :fail (:type %)) reports)))
+             "no failures for a holding invariant")
+         (is (= 2 (count (filter #(= :pass (:type %)) reports)))
+             "one green :pass per invariant that held across the run")))))
+
+#?(:clj
+   (deftest with-invariants-reports-once-per-failing-epoch
+     (testing "a failing invariant reports exactly once per failing epoch"
+       (rf/reg-frame :test/main {})
+       (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+       (rf/reg-event-db :dec  (fn [db _] (update db :n dec)))
+       (let [reports (with-captured-reports
+                       (fn []
+                         (with-invariants [(fn [e] (>= (:n (:db-after e)) 0))]
+                           (rf/dispatch-sync [:seed] {:frame :test/main})  ; n=0  holds
+                           (rf/dispatch-sync [:dec]  {:frame :test/main})  ; n=-1 fails
+                           (rf/dispatch-sync [:dec]  {:frame :test/main})))) ; n=-2 fails
+             fails   (filter #(= :fail (:type %)) reports)]
+         (is (= 2 (count fails))
+             "two failing epochs → two failures, one per epoch")))))
+
+#?(:clj
+   (deftest with-invariants-isolates-listener-exception
+     (testing "a throwing invariant predicate does not break the run; it reports"
+       (rf/reg-frame :test/main {})
+       (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+       (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+       (let [body-completed (atom false)
+             reports        (with-captured-reports
+                              (fn []
+                                (with-invariants [(fn [_] (throw (ex-info "boom" {})))]
+                                  (rf/dispatch-sync [:seed] {:frame :test/main})
+                                  (rf/dispatch-sync [:inc]  {:frame :test/main})
+                                  (reset! body-completed true))))]
+         (is (true? @body-completed)
+             "the body ran to completion despite the throwing predicate")
+         (is (pos? (count (filter #(= :fail (:type %)) reports)))
+             "the broken predicate reported failures")))))
+
+#?(:clj
+   (deftest with-invariants-listener-unregistered-after-body
+     (testing "the sentinel listener is removed on exit — later epochs are not observed"
+       (rf/reg-frame :test/main {})
+       (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+       (rf/reg-event-db :dec  (fn [db _] (update db :n dec)))
+       (let [reports (with-captured-reports
+                       (fn []
+                         (with-invariants [(fn [e] (>= (:n (:db-after e)) 0))]
+                           (rf/dispatch-sync [:seed] {:frame :test/main}))
+                         ;; This dispatch happens AFTER with-invariants exits;
+                         ;; its (failing) epoch must NOT be observed.
+                         (rf/dispatch-sync [:dec] {:frame :test/main})))]
+         (is (zero? (count (filter #(= :fail (:type %)) reports)))
+             "the post-body dispatch's violation was not observed")))))
+
+#?(:clj
+   (deftest with-invariants-works-with-destroyed-frame
+     (testing "destroying the frame mid-run does not break the sentinel; the body completes"
+       (rf/reg-frame :test/main {})
+       (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+       (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+       (let [body-completed (atom false)]
+         (with-captured-reports
+           (fn []
+             (with-invariants [(fn [e] (map? (:db-after e)))]
+               (rf/dispatch-sync [:seed] {:frame :test/main})
+               (rf/dispatch-sync [:inc]  {:frame :test/main})
+               (rf/destroy-frame! :test/main)
+               (reset! body-completed true))))
+         (is (true? @body-completed)
+             "the body — including the destroy and the post-destroy form — completed")
+         (is (= [] (rf/epoch-history :test/main))
+             "the destroyed frame's ring is empty afterward")))))


### PR DESCRIPTION
@
## Summary

Adds `re-frame.story.invariants` — the invariant-sentinel surface from the NewTestStory P1 spec. Two tightly-cohesive beads ship together in one namespace because they share one notion of an invariant:

- **rf2-5x1wt.5 — `with-invariants` (live sentinel fixture).** Registers one epoch listener (`re-frame.core/register-epoch-listener!`), checks every invariant after each committed epoch, and reports through `clojure.test` / `cljs.test` via `do-report`. It **never throws from the epoch listener** (a violated *or* a broken/throwing predicate is caught and reported, the run continues), de-dupes to **exactly one report per failing epoch** on the `[invariant-id epoch-id]` key, unregisters the listener on exit even if the body throws, and reports a `:pass` for every invariant that held so a green sentinel is visible. Works with fresh and destroyed frames.
- **rf2-5x1wt.6 — `first-bad-epoch` (pure utility).** A pure walk over an epoch tape returning the first failing epoch — enriched with the failing record, trigger event, a shallow top-level `:db-diff`, and the trace events — or `nil`. Handles empty/nil tapes and a failure in the first epoch. The fixture uses this for its "which epoch failed?" reporting so the live and post-hoc verdicts agree.

Invariants are authored as a bare predicate `(fn [epoch] …)`, a `{:check fn}` map (`:pred` aliased), or a `[:db path pred]` / `[:db path = expected]` data shorthand.

Spec currency: `tools/story/spec/017-Testing-Story.md` gains a clearly-titled **§Invariant sentinels** section documenting both APIs and the never-throw / report-once contract.

`tools/story/deps.edn` gains a **test-only** `day8/re-frame2-epoch` dep so the JVM `clojure -M:test` gate exercises the live listener path (the CLJS build already carries `epoch/src` via `shadow-cljs.edn`).

## Files changed

- `tools/story/src/re_frame/story/invariants.cljc` (new) — the namespace.
- `tools/story/test/re_frame/story/invariants_test.cljc` (new) — JVM coverage (pure + live).
- `tools/story/test/re_frame/story/invariants_cljs_test.cljs` (new) — CLJS coverage (macro expansion + live frame).
- `tools/story/spec/017-Testing-Story.md` — new §Invariant sentinels section.
- `tools/story/deps.edn` — test-only `re-frame2-epoch` dep.

Did NOT touch `plan.cljc`, the run-artifact ns, or `story.cljc` (the test-support tools are consumed directly from the `invariants` ns, not the `story/run` runtime surface, so no re-export was required).

## Quality gates

- `cd tools/story && clojure -M:test` — **947 tests / 2842 assertions, 0 failures, 0 errors** (the new ns: 20 tests / 49 assertions).
- `npm --prefix implementation run test:cljs` — **4847 tests / 15879 assertions, 0 failures, 0 errors**.
- `bash scripts/test-fast-pr.sh` — **PASS** (CLJS spine green; README + docs anchor validators pass; mkdocs `--strict` soft-skipped locally, runs on CI).
@