### PR TITLE
feat(story): run-artifact schema + replay-run-artifact (rf2-5x1wt.7)

### DIFF
--- a/tools/story/deps.edn
+++ b/tools/story/deps.edn
@@ -47,16 +47,22 @@
  {:test {:extra-paths ["test"]
          :extra-deps  {;; rf2-try1x — silent-on-success reporter.
                        day8/re-frame2-test-quiet {:local/root "../../implementation/test-quiet"}
-                       ;; rf2-5x1wt.5 — the invariant-sentinel fixture
-                       ;; (`re-frame.story.invariants`) registers a live
-                       ;; epoch listener via `re-frame.core/register-epoch-
-                       ;; listener!`, which is a no-op unless the epoch
-                       ;; artefact is on the classpath. The top-level CLJS
-                       ;; build already carries `epoch/src` (shadow-cljs.edn);
-                       ;; this test-only dep gives the JVM `clojure -M:test`
-                       ;; gate the same live epoch surface so the sentinel's
-                       ;; fresh/destroyed-frame coverage actually exercises
-                       ;; the listener path.
+                       ;; rf2-5x1wt.5/.6 + rf2-5x1wt.7 — two test-only consumers
+                       ;; need the live epoch surface on the JVM classpath:
+                       ;;   • the invariant-sentinel fixture
+                       ;;     (`re-frame.story.invariants`) registers a live epoch
+                       ;;     listener via `re-frame.core/register-epoch-listener!`;
+                       ;;   • the run-artifact replay path (`re-frame.story.artifact`)
+                       ;;     captures a live epoch tape via `rf/epoch-history`.
+                       ;; Both degrade to a no-op / empty tape unless the epoch
+                       ;; artefact is on the classpath. The top-level CLJS build
+                       ;; already carries `epoch/src` (shadow-cljs.edn); this gives
+                       ;; the JVM `clojure -M:test` gate the same live surface so
+                       ;; both the sentinel's fresh/destroyed-frame coverage and the
+                       ;; replay tests exercise the real listener/capture path.
+                       ;; Test-only — the published Story jar carries no epoch dep
+                       ;; (both sources read the late-bound facade), mirroring how
+                       ;; implementation/core/deps.edn pulls epoch on :test only.
                        day8/re-frame2-epoch      {:local/root "../../implementation/epoch"}
                        io.github.cognitect-labs/test-runner
                        {:git/tag "v0.5.1" :git/sha "dfb30dd"}}

--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -1404,6 +1404,109 @@ preconditions. The recorder/codegen output SHOULD share this contract, so
 a recorded interaction and a promoted failure are indistinguishable as
 authored variants.
 
+## Run artifact and replay
+
+The `:rf.test/run-artifact` shape (§Artifacts — Run artifact) is the
+serializable, data-shaped record of ONE run: enough to replay it
+deterministically and to project the same evidence a fresh run would
+produce. Replay lives **below** Story — it runs without the Story UI — and
+is the foundation the determinism gate and semantic diff build on. The
+base schema + the replay function ship in the
+`re-frame.story.artifact` namespace.
+
+### The base schema
+
+A run artifact is a map carrying:
+
+```clojure
+{:artifact/kind :rf.test/run-artifact  ; the discriminating tag
+ :seed          optional
+ :event-program [step …]               ; the dispatch program (setup ⧺ script)
+ :fx-decisions  {fx-id override}       ; the fx overrides reapplied on replay
+ :epoch-tape    [epoch-record …]       ; the captured tape, when retained
+ :trace         [trace-event …]        ; optional flat trace
+ :result        run-result             ; the projected run-result (§Run result)
+ :shrink-path   optional
+ :created-at    instant-or-string
+ :source        optional}
+```
+
+- `:artifact/kind` is `:rf.test/run-artifact`, distinguishing a run
+  artifact from a normalized plan or a curated variant body.
+- `:event-program` is a vector of **tagged** script steps — the same
+  grammar the play runner executes (§Script step grammar). A bare event
+  vector lifts to `[:dispatch …]` through the runner's `coerce-script`, so
+  a recorder MAY hand a flat event list and get a legal program. Setup and
+  script fold into ONE ordered program (setup first); replay re-runs the
+  whole program, then projects the captured tape.
+- `:fx-decisions` is the `{fx-id override}` map of fx decisions applied at
+  capture time — the same shape the dispatch `:fx-overrides` opt and the
+  per-frame frame-config `:fx-overrides` slot carry (Spec 002
+  §`:fx-overrides`). Replay REAPPLIES them, so a run that stubbed an HTTP
+  effect replays against the same stub rather than firing the live effect.
+
+`re-frame.story.artifact/make-run-artifact` is the **pure** constructor
+(data → data, JVM-runnable): it coerces the `:event-program`, folds
+optional `:setup` / `:script` sugar into it, stamps `:artifact/kind`, and
+defaults `:fx-decisions` to `{}`. `run-artifact?` is the recogniser (the
+`:artifact/kind` tag plus a vector `:event-program`). `program-events`
+projects the artifact to its ordered dispatched event vectors (for
+promotion + diagnostics).
+
+### `replay-run-artifact`
+
+```clojure
+(story/replay-run-artifact artifact)
+(story/replay-run-artifact artifact opts)
+;; -> run-result (§Run result)
+```
+
+Replay MUST:
+
+- **Replay the dispatch program into a FRESH frame** — a unique
+  `:rf.test.replay/*` frame allocated for the replay (or the caller's
+  `:frame`), so the replay never observes a sibling run's app-db. A frame
+  the replay allocated is torn down before return; a caller-supplied
+  `:frame` is left intact (the caller owns its lifecycle).
+- **Reapply the fx decisions / overrides** — the artifact's
+  `:fx-decisions` ride the per-call `:fx-overrides` on every replayed
+  dispatch, routed through the **same** `settled-boundary`
+  (§Script and `settled-boundary`) a live run uses. Replay never reaches
+  for `dispatch-sync` directly; the boundary's `:cannot-run` / `:error`
+  refusals fire unchanged, so a step that needs a richer boundary than the
+  replay runner provides refuses rather than under-flushing.
+- **Capture a NEW epoch tape** — read from `re-frame.core/epoch-history`
+  after the program settles, NOT the artifact's captured tape. The replay
+  proves what the program does NOW.
+- **Return the shared run-result shape** (§Run result) — the tape is
+  projected through the single evidence boundary
+  (`re-frame.story.play.evidence/project-evidence`,
+  §Run-result evidence projection), so `:status`, `:epoch-tape`,
+  `:schema-violations`, `:warnings`, `:effects`, `:sub-runs`, `:renders`,
+  and the two-level `:narrative` all derive from ONE tape. The result
+  carries a back-link `:run-artifact` to the replayed source.
+
+The replay `:status` follows the agreement floor
+(§Run-result evidence projection): `:cannot-run` if any step refused,
+`:error` if any step or the tape errored, `:fail` if the tape carries
+unconsumed failure evidence, `:pass` otherwise — computed from the
+PROJECTED evidence and the per-step settle outcomes, never a sibling
+accumulator, so a replay cannot read green while the tape is red.
+
+`opts` MAY carry `:frame` (replay into a caller-owned frame),
+`:hooks` (richer settled-boundary flush-hooks — a `:dom` adapter declares
+`:provides :dom`; the fx decisions still wrap its `:dispatch!`), and
+`:frame-config` (extra `reg-frame` config for the allocated frame).
+
+The replay result is **stable + canonicalizable** (§Canonicalization): it
+feeds cleanly through `canonicalize` / `run-hash`, so the determinism gate
+(`test/assert-deterministic`) and semantic diff (`test/diff-run-artifacts`)
+build directly on it. Construction and result projection are pure, so the
+artifact schema + the result shape are exercised under `clojure -M:test`
+with no runtime; the headless replay path settles synchronously to a fixed
+point via the headless flush-hooks, so the live-frame replay also runs
+headless.
+
 ## Relationship to the workshop surface (storytelling is in-scope)
 
 Story is a **workshop**, not only a test engine. The shipping authoring

--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -89,6 +89,10 @@
             ;; Re-exported as `project-evidence` below so every downstream
             ;; run-result slot derives from ONE tape (NewTestStory §A0c).
             [re-frame.story.play.evidence :as evidence]
+            ;; rf2-5x1wt.7 — the `:rf.test/run-artifact` schema + replay.
+            ;; Re-exported as `make-run-artifact` / `run-artifact?` /
+            ;; `replay-run-artifact` below (spec/017 §Run artifact and replay).
+            [re-frame.story.artifact    :as artifact]
             [re-frame.story.lifecycle   :as lifecycle]
             [re-frame.story.query       :as query]
             ;; Runtime modules — args resolution, decorators.
@@ -929,6 +933,36 @@
   expected schema failures. Pure data → data."
   ([epoch-tape]                     (evidence/tape-shows-failure? epoch-tape))
   ([epoch-tape consumed-selectors]  (evidence/tape-shows-failure? epoch-tape consumed-selectors)))
+
+;; ---- run artifact + replay (rf2-5x1wt.7) --------------------------------
+;;
+;; Per spec/017 §Run artifact and replay — the serializable
+;; `:rf.test/run-artifact` record + the function that replays it into a
+;; fresh frame, reapplies the fx decisions, captures a NEW epoch tape, and
+;; returns the shared run-result shape. Lives below Story (runs without the
+;; UI); the determinism gate + semantic diff build on it.
+
+(defn make-run-artifact
+  "Per spec/017 §Run artifact and replay — pure constructor for a
+  `:rf.test/run-artifact`. Coerces the `:event-program`, folds optional
+  `:setup` / `:script` sugar into it, stamps `:artifact/kind`, and defaults
+  `:fx-decisions`. Pure data → data."
+  [parts]
+  (artifact/make-run-artifact parts))
+
+(defn run-artifact?
+  "Per spec/017 §Run artifact and replay — true iff `x` is a
+  `:rf.test/run-artifact` map (the kind tag plus a vector `:event-program`)."
+  [x]
+  (artifact/run-artifact? x))
+
+(defn replay-run-artifact
+  "Per spec/017 §Run artifact and replay — replay a `:rf.test/run-artifact`
+  into a FRESH frame, reapplying the fx decisions, capturing a NEW epoch
+  tape, and returning the shared run-result shape (§Run result). `opts` MAY
+  carry `:frame` / `:hooks` / `:frame-config`."
+  ([art]      (artifact/replay-run-artifact art))
+  ([art opts] (artifact/replay-run-artifact art opts)))
 
 (defn destroy-variant!
   "Tear down a variant frame allocated via `run-variant`. Per IMPL-

--- a/tools/story/src/re_frame/story/artifact.cljc
+++ b/tools/story/src/re_frame/story/artifact.cljc
@@ -1,0 +1,295 @@
+(ns re-frame.story.artifact
+  "The `:rf.test/run-artifact` schema + `replay-run-artifact` — a
+  serializable record of a Story run, and the function that replays it
+  into a fresh frame (NewTestStory rf2-5x1wt.7, spec/017-Testing-Story.md
+  §Run artifact and replay + §Artifacts — Run artifact).
+
+  ## What a run artifact is
+
+  A run artifact is the low-level, data-shaped evidence emitted by
+  generated tests, failed runs, replay, determinism checks, or tool/agent
+  exploration (spec/017 §Artifacts). It is NOT a Story variant: it carries
+  no curation, no navigation slot, no `:extends` lineage. It is a captured
+  RUN — enough to replay it deterministically and to project the same
+  evidence a fresh run would produce.
+
+  Required P1 shape (spec/017 §Artifacts — Run artifact):
+
+      {:artifact/kind :rf.test/run-artifact
+       :seed          optional
+       :event-program [step …]        ; the dispatch program (setup ⧺ script)
+       :fx-decisions  {fx-id override} ; reapplied fx overrides / decisions
+       :epoch-tape    [epoch-record …] ; the captured tape (when retained)
+       :trace         [trace-event …]  ; optional flat trace
+       :result        run-result       ; the projected run-result
+       :shrink-path   optional
+       :created-at    instant-or-string
+       :source        optional}
+
+  The `:event-program` is a vector of TAGGED script steps (the same
+  grammar the play runner executes — `[:dispatch …]` / `[:dispatch-sync …]`
+  / `[:wait …]` / `[:assert-* …]`). A bare event vector is lifted to
+  `[:dispatch …]` by `re-frame.story.play.runner/coerce-script` so a
+  recorder can hand a flat event list and get a legal program. Setup and
+  script are folded into ONE ordered program — replay re-runs the whole
+  program, then projects the captured tape.
+
+  `:fx-decisions` is the serializable record of fx overrides applied at
+  capture time: a `{fx-id override}` map, the same shape the dispatch
+  `:fx-overrides` opt and the per-frame frame-config `:fx-overrides` slot
+  carry (Spec 002 §`:fx-overrides`). Replay REAPPLIES them, so a run that
+  stubbed `:http/get` replays against the same stub rather than hitting a
+  live effect.
+
+  ## Replay
+
+  `(replay-run-artifact artifact opts)` replays the artifact's dispatch
+  program into a FRESH frame, reapplying the fx decisions, captures a NEW
+  epoch tape, and projects it through the merged `.4` evidence boundary
+  (`re-frame.story.play.evidence/project-evidence`). The returned
+  run-result is the SHARED run-result shape (spec/017 §Run result) — the
+  same shape the runner returns and the same one `canonicalize` /
+  `run-hash` consume — so a later determinism gate (rf2-5x1wt.8) and
+  semantic diff (rf2-5x1wt.9) build directly on it.
+
+  ## Pure / JVM-testable
+
+  This ns splits PURE construction (`make-run-artifact`, `run-artifact?`,
+  `program-events`, `replay-result`) from the impure HEADLESS replay path
+  (`replay-into-frame!`). Construction + result projection are pure
+  data → data and run under `clojure -M:test` with no runtime. The
+  headless replay path uses the `.2` settled-boundary so each
+  `[:dispatch …]` settles deterministically to a fixed point with no async
+  yield — `clojure -M:test` exercises a live frame synchronously. Richer
+  runners (DOM/browser) supply their own flush-hooks; this ns defaults to
+  the headless hooks and never reaches for `dispatch-sync` directly."
+  (:require [re-frame.core                        :as rf]
+            [re-frame.story.play.evidence         :as evidence]
+            [re-frame.story.play.runner           :as runner]
+            [re-frame.story.play.settled-boundary :as boundary]))
+
+;; ===========================================================================
+;; THE :rf.test/run-artifact SCHEMA
+;; ===========================================================================
+
+(def artifact-kind
+  "The `:artifact/kind` tag every run artifact carries (spec/017
+  §Artifacts — Run artifact). A distinct value so a consumer can tell a
+  run artifact apart from a normalized plan or a curated variant body."
+  :rf.test/run-artifact)
+
+(def artifact-keys
+  "The full set of slots a `:rf.test/run-artifact` MAY carry (spec/017
+  §Artifacts — Run artifact). `:artifact/kind` + `:event-program` are the
+  load-bearing slots; the rest are optional evidence / provenance.
+
+  Enumerated so `select-keys` can normalize a hand-built / over-stuffed
+  map down to the artifact surface without dropping a future-added slot
+  silently elsewhere."
+  #{:artifact/kind :seed :event-program :fx-decisions :epoch-tape
+    :trace :result :shrink-path :created-at :source})
+
+(defn run-artifact?
+  "True iff `x` is a `:rf.test/run-artifact` map. The minimal contract is
+  the `:artifact/kind` tag plus a vector `:event-program` — the dispatch
+  program is what makes the artifact replayable; everything else is
+  optional evidence. Pure data → data."
+  [x]
+  (boolean
+    (and (map? x)
+         (= artifact-kind (:artifact/kind x))
+         (vector? (:event-program x)))))
+
+(defn make-run-artifact
+  "Construct a `:rf.test/run-artifact` from its parts. Pure data → data —
+  no runtime, JVM-runnable.
+
+  `parts` is a map carrying any of `artifact-keys`. The `:event-program`
+  is coerced through the play runner's `coerce-script` so a bare event
+  list (`[[:my/event …] …]`) lifts to a legal tagged dispatch program
+  (`[[:dispatch [:my/event …]] …]`) and an already-tagged program passes
+  through verbatim. Optional `:setup` / `:script` slots, when present, are
+  folded into the program in order (setup first) so a recorder can hand
+  the two phases separately; an explicit `:event-program` takes
+  precedence over `:setup` / `:script`.
+
+  The result stamps `:artifact/kind` and defaults `:fx-decisions` to an
+  empty map, so a replay never has to nil-check the override slot. Slots
+  outside `artifact-keys` (plus the `:setup`/`:script` authoring sugar)
+  are dropped so the artifact stays a clean, serializable surface."
+  [parts]
+  (let [program (cond
+                  (contains? parts :event-program) (:event-program parts)
+                  (or (contains? parts :setup)
+                      (contains? parts :script))
+                  (into (vec (:setup parts)) (:script parts))
+                  :else [])]
+    (-> (select-keys parts artifact-keys)
+        (assoc :artifact/kind artifact-kind
+               :event-program (runner/coerce-script program))
+        (update :fx-decisions #(or % {})))))
+
+(defn program-events
+  "Project a run artifact's `:event-program` to the ordered vector of
+  event vectors its `:dispatch` / `:dispatch-sync` steps dispatch. Pure
+  data → data — non-dispatch steps (`:wait`, `:assert-*`) contribute no
+  event. Useful for promotion (spec/017 §Promotion) + diagnostics."
+  [artifact]
+  (into []
+        (keep runner/step-event)
+        (:event-program artifact)))
+
+;; ===========================================================================
+;; REPLAY — fresh frame, reapply fx decisions, capture a new tape
+;; ===========================================================================
+
+(defn- gen-replay-frame-id
+  "Allocate a unique frame id for a replay. Namespaced under
+  `:rf.test.replay/*` so a replay frame is never confused with a variant
+  frame or the default frame."
+  []
+  (keyword "rf.test.replay"
+           (str "frame-"
+                #?(:clj  (str (java.util.UUID/randomUUID))
+                   :cljs (.toString (js/Math.random) 36)))))
+
+(defn- replay-flush-hooks
+  "Build the settled-boundary flush-hooks for a replay (spec/017 §Script
+  and `settled-boundary`). It starts from `base-hooks` (the headless hooks
+  by default — `:provides :headless`, `dispatch-sync*` drain) and wraps
+  `:dispatch!` so every replayed dispatch carries the artifact's
+  `fx-decisions` as the per-call `:fx-overrides`. Reapplying the fx
+  decisions through the dispatch opt — not a parallel install — keeps
+  replay on the SAME settlement path as a live run and lets the boundary's
+  `:cannot-run` / `:error` refusals fire unchanged. A richer adapter caller
+  can pass its own `base-hooks` (declaring `:provides :dom`, etc.) and the
+  fx reapplication still wraps its `:dispatch!`."
+  [base-hooks fx-decisions]
+  (let [inner (or (:dispatch! base-hooks) boundary/drain-sync!)]
+    (assoc base-hooks
+           :dispatch!
+           (fn replay-dispatch! [frame-id event-vector]
+             (if (seq fx-decisions)
+               (rf/dispatch-sync* event-vector {:frame        frame-id
+                                                :fx-overrides fx-decisions})
+               (inner frame-id event-vector))))))
+
+(defn replay-into-frame!
+  "Replay an artifact's `:event-program` into the LIVE `frame-id`,
+  reapplying `fx-decisions` and settling each `[:dispatch …]` step through
+  `settled-boundary`. Returns a vector of per-step settle outcomes (one
+  per dispatch step), in program order — `{:status :settled :boundary …}`
+  on success, a `cannot-run-refusal` / `{:status :error …}` otherwise.
+
+  This is the IMPURE seam — it dispatches into a live frame. The caller
+  owns frame allocation + teardown + the epoch-tape read; `replay-run-
+  artifact` wires those around it. Non-dispatch steps (`:wait` / `:assert-*`)
+  are skipped here: replay reproduces the CAUSAL program (the dispatches),
+  and the captured tape + projected evidence carry the assertion / timing
+  story. `hooks` defaults to the headless flush-hooks; the fx decisions are
+  wrapped onto its `:dispatch!`."
+  ([frame-id artifact]
+   (replay-into-frame! frame-id artifact boundary/headless-flush-hooks))
+  ([frame-id artifact hooks]
+   (let [fx-decisions (:fx-decisions artifact {})
+         replay-hooks (replay-flush-hooks hooks fx-decisions)]
+     (into []
+           (keep (fn [step]
+                   (when-let [evec (runner/step-event step)]
+                     (let [required (boundary/step-required-boundary step)]
+                       (boundary/dispatch-and-settle!
+                         frame-id evec replay-hooks required step)))))
+           (:event-program artifact)))))
+
+(defn replay-result
+  "Build the replay run-result from the captured `epoch-tape`, the
+  artifact, the per-step settle `outcomes`, and the replay `frame-id`.
+  Pure data → data — epoch records + outcomes in, run-result out, so the
+  result-shape construction is JVM-testable without a live frame.
+
+  The result is the SHARED run-result shape (spec/017 §Run result): a
+  top-level `:status`, the projected `:epoch-tape` / `:schema-violations` /
+  `:warnings` / `:effects` / `:sub-runs` / `:renders` / `:narrative`
+  evidence (via the `.4` `project-evidence` boundary), the final
+  `:app-db`, and a back-link `:run-artifact` to the replayed source. The
+  `:script` for the two-level narrative is the artifact's
+  `:event-program`.
+
+  `:status` follows the agreement floor (spec/017 §Run-result evidence
+  projection): `:cannot-run` if any step refused; `:error` if any step or
+  the tape errored; `:fail` if the tape shows unconsumed failure evidence;
+  `:pass` otherwise. The status is computed from the PROJECTED evidence and
+  the settle outcomes — never a sibling accumulator — so a replay cannot
+  read green while the tape is red."
+  [{:keys [epoch-tape artifact outcomes frame-id app-db]}]
+  (let [evidence-slots (evidence/project-evidence
+                         epoch-tape {:script (:event-program artifact)})
+        refusal        (some (fn [o] (when (= :cannot-run (:status o)) o)) outcomes)
+        errored        (some (fn [o] (when (= :error (:status o)) o)) outcomes)
+        tape-red?      (evidence/tape-shows-failure? epoch-tape)
+        status         (cond
+                         refusal   :cannot-run
+                         errored   :error
+                         tape-red? :fail
+                         :else     :pass)]
+    (cond-> (merge {:status        status
+                    :runner        :headless
+                    :frame         frame-id
+                    :app-db        app-db
+                    :run-artifact  artifact
+                    :replay-steps  outcomes}
+                   evidence-slots)
+      refusal (assoc :cannot-run refusal)
+      errored (assoc :error (:error errored)))))
+
+(defn replay-run-artifact
+  "Replay a `:rf.test/run-artifact` into a FRESH frame and return a
+  run-result (spec/017 §Run artifact and replay). The contract:
+
+  - Replay the dispatch program into a FRESH frame — a unique
+    `:rf.test.replay/*` frame allocated for this replay (or the caller's
+    `:frame`), so the replay never observes a sibling run's app-db.
+  - Reapply the fx decisions / overrides — the artifact's `:fx-decisions`
+    ride the per-call `:fx-overrides` on every replayed dispatch.
+  - Capture a NEW epoch tape — read from `re-frame.core/epoch-history`
+    after the program settles, NOT the artifact's captured tape.
+  - Project that tape through the merged `.4` evidence boundary and return
+    the shared run-result shape — stable + canonicalizable, so the
+    determinism gate (rf2-5x1wt.8) + semantic diff (rf2-5x1wt.9) build on
+    it directly.
+
+  `opts` (all optional):
+
+  - `:frame`       — replay into this frame id instead of allocating a
+                     fresh one. The caller then owns teardown; the
+                     internally-allocated frame is destroyed automatically.
+  - `:hooks`       — settled-boundary flush-hooks (default the headless
+                     hooks). A `:dom` adapter passes richer hooks; the fx
+                     decisions wrap its `:dispatch!`.
+  - `:frame-config`— extra `reg-frame` config for the allocated frame.
+
+  The replayed frame is allocated through `re-frame.core/reg-frame` and —
+  when this fn allocated it — torn down through `destroy-frame!` before
+  return, so a JVM test leaves no frame behind. A caller-supplied `:frame`
+  is left intact (the caller owns its lifecycle)."
+  ([artifact] (replay-run-artifact artifact nil))
+  ([artifact {:keys [frame hooks frame-config] :as _opts}]
+   (let [own-frame? (nil? frame)
+         frame-id   (or frame (gen-replay-frame-id))
+         hooks      (or hooks boundary/headless-flush-hooks)]
+     (when own-frame?
+       (rf/reg-frame frame-id (merge {:doc "rf2-5x1wt.7 run-artifact replay frame"}
+                                     frame-config)))
+     (try
+       (let [outcomes (replay-into-frame! frame-id artifact hooks)
+             tape     (vec (rf/epoch-history frame-id))
+             app-db   (rf/get-frame-db frame-id)]
+         (replay-result {:epoch-tape tape
+                         :artifact   artifact
+                         :outcomes   outcomes
+                         :frame-id   frame-id
+                         :app-db     app-db}))
+       (finally
+         (when own-frame?
+           (try (rf/destroy-frame! frame-id)
+                (catch #?(:clj Throwable :cljs :default) _ nil))))))))

--- a/tools/story/test/re_frame/story/artifact_test.cljc
+++ b/tools/story/test/re_frame/story/artifact_test.cljc
@@ -1,0 +1,259 @@
+(ns re-frame.story.artifact-test
+  "Tests for the `:rf.test/run-artifact` schema + `replay-run-artifact`
+  (rf2-5x1wt.7, spec/017-Testing-Story.md §Run artifact and replay).
+
+  Two layers, both under `clojure -M:test` (JVM) + the node-runtime CLJS
+  build:
+
+  - PURE construction: `make-run-artifact` coerces the event program,
+    folds setup ⧺ script, defaults `:fx-decisions`, and `run-artifact?`
+    recognises the shape. `replay-result` builds the shared run-result
+    from a hand-built tape with no live frame.
+  - HEADLESS replay (against a live frame): `replay-run-artifact` replays
+    the dispatch program into a FRESH frame, reapplies fx
+    decisions/overrides, captures a NEW epoch tape, and returns the
+    shared run-result shape (the §A3 acceptance bullets)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core   :as rf]
+            [re-frame.epoch  :as epoch]
+            [re-frame.frame  :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.story.artifact :as artifact]
+            [re-frame.story.fingerprint :as fingerprint]))
+
+;; ===========================================================================
+;; PURE: schema + construction
+;; ===========================================================================
+
+(deftest make-run-artifact-coerces-program
+  (testing "a bare event list lifts to a tagged [:dispatch …] program"
+    (let [a (artifact/make-run-artifact
+              {:event-program [[:counter/inc] [:dispatch [:counter/dec]]]})]
+      (is (= :rf.test/run-artifact (:artifact/kind a)))
+      (is (= [[:dispatch [:counter/inc]] [:dispatch [:counter/dec]]]
+             (:event-program a))
+          "bare event vector lifts; an already-tagged step passes through")
+      (is (artifact/run-artifact? a))))
+
+  (testing "an empty / fx-less artifact defaults :fx-decisions to {}"
+    (let [a (artifact/make-run-artifact {})]
+      (is (= {} (:fx-decisions a)))
+      (is (= [] (:event-program a)))
+      (is (artifact/run-artifact? a))))
+
+  (testing ":setup ⧺ :script fold into one ordered program (setup first)"
+    (let [a (artifact/make-run-artifact
+              {:setup  [[:dispatch [:seed/a]]]
+               :script [[:dispatch [:act/b]] [:wait 5]]})]
+      (is (= [[:dispatch [:seed/a]] [:dispatch [:act/b]] [:wait 5]]
+             (:event-program a)))))
+
+  (testing "an explicit :event-program wins over :setup/:script"
+    (let [a (artifact/make-run-artifact
+              {:event-program [[:dispatch [:only/this]]]
+               :setup         [[:dispatch [:ignored]]]})]
+      (is (= [[:dispatch [:only/this]]] (:event-program a)))))
+
+  (testing "slots outside the artifact surface are dropped; known slots kept"
+    (let [a (artifact/make-run-artifact
+              {:event-program [[:dispatch [:e]]]
+               :seed          42
+               :fx-decisions  {:http/get :http/stub}
+               :source        {:tool :recorder}
+               :bogus/extra   :dropped})]
+      (is (= 42 (:seed a)))
+      (is (= {:http/get :http/stub} (:fx-decisions a)))
+      (is (= {:tool :recorder} (:source a)))
+      (is (not (contains? a :bogus/extra))))))
+
+(deftest run-artifact-predicate
+  (testing "run-artifact? requires the kind tag AND a vector :event-program"
+    (is (artifact/run-artifact?
+          {:artifact/kind :rf.test/run-artifact :event-program []}))
+    (is (not (artifact/run-artifact? {:event-program []}))
+        "missing :artifact/kind")
+    (is (not (artifact/run-artifact?
+               {:artifact/kind :rf.test/run-artifact}))
+        "missing :event-program")
+    (is (not (artifact/run-artifact? nil)))
+    (is (not (artifact/run-artifact? [:not :a :map])))))
+
+(deftest program-events-projection
+  (testing "program-events projects only the dispatched event vectors"
+    (let [a (artifact/make-run-artifact
+              {:event-program [[:dispatch [:a 1]]
+                               [:wait 10]
+                               [:dispatch-sync [:b 2]]
+                               [:assert-db [:k] :v]]})]
+      (is (= [[:a 1] [:b 2]] (artifact/program-events a))
+          ":wait / :assert-* contribute no event"))))
+
+;; ===========================================================================
+;; PURE: replay-result construction from a hand-built tape
+;; ===========================================================================
+
+(defn- epoch
+  "A minimal `:rf/epoch-record`."
+  [epoch-id m]
+  (merge {:epoch-id epoch-id :outcome :ok
+          :db-before {} :db-after {}
+          :trace-events [] :effects [] :sub-runs [] :renders []}
+         m))
+
+(deftest replay-result-shared-shape
+  (testing "replay-result builds the shared run-result shape from a clean tape"
+    (let [a    (artifact/make-run-artifact {:event-program [[:dispatch [:e]]]})
+          tape [(epoch :e1 {:db-after {:n 1}})]
+          res  (artifact/replay-result
+                 {:epoch-tape tape :artifact a
+                  :outcomes [{:status :settled :boundary :headless}]
+                  :frame-id :rf.test.replay/f :app-db {:n 1}})]
+      (is (= :pass (:status res)))
+      (is (= :headless (:runner res)))
+      (is (= {:n 1} (:app-db res)))
+      (is (= tape (:epoch-tape res)) "the captured tape is the evidence source")
+      (is (= a (:run-artifact res)) "back-link to the replayed source")
+      (is (vector? (:narrative res)) "two-level narrative present")
+      (is (vector? (:schema-violations res)))
+      (is (empty? (:schema-violations res))))))
+
+(deftest replay-result-status-follows-tape
+  (testing ":fail when the tape carries unconsumed failure evidence"
+    (let [a    (artifact/make-run-artifact {:event-program [[:dispatch [:e]]]})
+          tape [(epoch :e1 {:outcome :halt})]
+          res  (artifact/replay-result
+                 {:epoch-tape tape :artifact a
+                  :outcomes [{:status :settled :boundary :headless}]
+                  :frame-id :f :app-db {}})]
+      (is (= :fail (:status res))
+          "a non-:ok epoch outcome trips the agreement floor")))
+
+  (testing ":cannot-run when a step refused"
+    (let [a   (artifact/make-run-artifact {:event-program [[:dispatch [:e]]]})
+          res (artifact/replay-result
+                {:epoch-tape [] :artifact a
+                 :outcomes [{:status :cannot-run :required-boundary :dom
+                             :provided-boundary :headless}]
+                 :frame-id :f :app-db {}})]
+      (is (= :cannot-run (:status res)))
+      (is (= :dom (get-in res [:cannot-run :required-boundary])))))
+
+  (testing ":error when a step errored"
+    (let [a   (artifact/make-run-artifact {:event-program [[:dispatch [:e]]]})
+          res (artifact/replay-result
+                {:epoch-tape [] :artifact a
+                 :outcomes [{:status :error :error "boom"}]
+                 :frame-id :f :app-db {}})]
+      (is (= :error (:status res)))
+      (is (= "boom" (:error res))))))
+
+;; ===========================================================================
+;; HEADLESS replay: against a live frame
+;; ===========================================================================
+
+(defn- reset-rf! [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  ;; Requiring `re-frame.epoch` (above) installs the epoch artefact's
+  ;; late-bind hooks, so `epoch-history` records a real tape; clear its
+  ;; per-frame ring + listeners between tests so a replay reads only its
+  ;; own freshly-captured epochs.
+  (epoch/clear-history!)
+  (epoch/clear-epoch-listeners!)
+  (try (rf/init! plain-atom/adapter)
+       (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) _ nil))
+  (frame/ensure-default-frame!)
+  (test-fn))
+
+(use-fixtures :each reset-rf!)
+
+(deftest replay-into-fresh-frame
+  (testing "replay-run-artifact replays the dispatch program into a FRESH
+            frame, captures a NEW tape, and returns the shared run-result —
+            the fresh frame is torn down before return"
+    (rf/reg-event-db :rep/inc (fn [db _] (update db :n (fnil inc 0))))
+    (let [a   (artifact/make-run-artifact
+                {:event-program [[:dispatch [:rep/inc]] [:dispatch [:rep/inc]]]})
+          res (artifact/replay-run-artifact a)]
+      (is (= :pass (:status res)))
+      (is (= 2 (:n (:app-db res))) "the program ran into a fresh, empty frame")
+      (is (seq (:epoch-tape res)) "a NEW epoch tape was captured")
+      (is (vector? (:narrative res)))
+      (is (= a (:run-artifact res)))
+      ;; the internally-allocated frame is gone (teardown ran)
+      (let [fid (:frame res)]
+        (is (not (contains? @frame/frames fid))
+            "the replay-allocated frame is destroyed before return")))))
+
+(deftest replay-reapplies-fx-decisions
+  (testing "replay reapplies fx decisions/overrides — the recorded override
+            fires instead of the real effect"
+    (let [hits (atom [])]
+      ;; The 'real' effect would record :real; the stub records :stub.
+      ;; `:platforms #{:client :server}` so the fx fire on the JVM
+      ;; (`:server`) test platform as well as in the browser.
+      (rf/reg-fx :rep.fx/real {:platforms #{:client :server}}
+                 (fn [_ _] (swap! hits conj :real)))
+      (rf/reg-fx :rep.fx/stub {:platforms #{:client :server}}
+                 (fn [_ _] (swap! hits conj :stub)))
+      (rf/reg-event-fx :rep/fire (fn [_ _] {:fx [[:rep.fx/real {}]]}))
+      (let [a   (artifact/make-run-artifact
+                  {:event-program [[:dispatch [:rep/fire]]]
+                   :fx-decisions  {:rep.fx/real :rep.fx/stub}})
+            res (artifact/replay-run-artifact a)]
+        (is (= :pass (:status res)))
+        (is (= [:stub] @hits)
+            "the fx decision remapped :rep.fx/real → :rep.fx/stub on replay")))))
+
+(deftest replay-isolation-fresh-frame-each-time
+  (testing "two replays of the same artifact each run into their own fresh
+            frame — no shared app-db leaks between replays"
+    (rf/reg-event-db :rep/set (fn [db [_ v]] (assoc db :v v)))
+    (let [a    (artifact/make-run-artifact
+                 {:event-program [[:dispatch [:rep/set 7]]]})
+          r1   (artifact/replay-run-artifact a)
+          r2   (artifact/replay-run-artifact a)]
+      (is (= 7 (:v (:app-db r1))))
+      (is (= 7 (:v (:app-db r2))))
+      (is (not= (:frame r1) (:frame r2)) "distinct fresh frames"))))
+
+(deftest replay-result-is-canonicalizable
+  (testing "the replay result feeds cleanly through the .3 canonicalize /
+            run-hash path — the result is stable + canonicalizable so the
+            determinism gate (.8) + semantic diff (.9) build on it. (Cross-
+            run run-hash EQUALITY is .8's concern: it owns stripping the
+            per-frame epoch ids from the tape; this bead pins only that the
+            result canonicalizes deterministically and run-hash is stable.)"
+    (rf/reg-event-db :rep/seed (fn [db _] (assoc db :seeded true)))
+    (let [a   (artifact/replay-run-artifact
+                (artifact/make-run-artifact {:event-program [[:dispatch [:rep/seed]]]}))
+          h   (fingerprint/run-hash a)]
+      (is (string? h))
+      (is (= 8 (count h)) "run-hash is the stable 8-char-hex primitive")
+      (is (= h (fingerprint/run-hash a)) "run-hash is idempotent on one result")
+      (is (= (fingerprint/canonicalize a) (fingerprint/canonicalize a))
+          "canonicalize is deterministic on the result"))
+    (testing "canonicalize strips the volatile top-level slots .3 enumerates"
+      (let [res {:status :pass :app-db {:n 1}
+                 :elapsed-ms 42 :runner :headless :variant/id :x :plan-hash "ab"}
+            c   (fingerprint/canonicalize res)
+            ;; canonical-form renders maps as flattened [k v k v …] vectors
+            ks  (set (take-nth 2 c))]
+        (is (not (contains? ks :elapsed-ms)) ":elapsed-ms stripped")
+        (is (not (contains? ks :runner))     ":runner stripped")
+        (is (not (contains? ks :variant/id)) ":variant/id stripped")
+        (is (not (contains? ks :plan-hash))  ":plan-hash stripped")
+        (is (contains? ks :status)           ":status retained (behavioural)")))))
+
+(deftest replay-into-caller-supplied-frame
+  (testing "a caller-supplied :frame is replayed into and LEFT intact (the
+            caller owns its lifecycle)"
+    (rf/reg-event-db :rep/inc (fn [db _] (update db :n (fnil inc 0))))
+    (rf/reg-frame :rep/caller-frame {:doc "caller-owned replay frame"})
+    (let [a   (artifact/make-run-artifact {:event-program [[:dispatch [:rep/inc]]]})
+          res (artifact/replay-run-artifact a {:frame :rep/caller-frame})]
+      (is (= :pass (:status res)))
+      (is (= :rep/caller-frame (:frame res)))
+      (is (contains? @frame/frames :rep/caller-frame)
+          "the caller-supplied frame is NOT destroyed"))))


### PR DESCRIPTION
## What

Lands NewTestStory **§A3 — Run Artifact Schema And Replay** (rf2-5x1wt.7): the base `:rf.test/run-artifact` schema and the `replay-run-artifact` function, in a new `re-frame.story.artifact` namespace. Builds read-only on the merged deps `.2` (settled-boundary), `.3` (fingerprint/canonicalize), and `.4` (evidence projection).

### Schema (`re-frame.story.artifact`)

- `make-run-artifact` — **pure** constructor (data → data, JVM-runnable). Coerces the `:event-program` through the play runner's `coerce-script` (a bare event list lifts to a tagged `[:dispatch …]` program), folds optional `:setup` ⧺ `:script` into one ordered program, stamps `:artifact/kind`, defaults `:fx-decisions`.
- `run-artifact?` — recogniser (`:artifact/kind` tag + vector `:event-program`).
- `program-events` — projects the artifact to its ordered dispatched event vectors.

### Replay

`replay-run-artifact` MUST and does:
- **Replay into a FRESH frame** — a unique `:rf.test.replay/*` frame (or a caller-supplied `:frame`); a self-allocated frame is torn down before return.
- **Reapply fx decisions/overrides** — `:fx-decisions` ride the per-call `:fx-overrides` on every replayed dispatch, routed through the `.2` settled-boundary (never `dispatch-sync` directly; `:cannot-run` / `:error` refusals fire unchanged).
- **Capture a NEW epoch tape** — read from `re-frame.core/epoch-history` after the program settles.
- **Return the shared run-result shape** — projected via the merged `.4` `project-evidence`, with the agreement-floor `:status` (`:cannot-run` / `:error` / `:fail` / `:pass`) computed from the projected evidence, plus a `:run-artifact` back-link. Stable + canonicalizable through `.3` so the determinism gate (`.8`) and semantic diff (`.9`) build on it directly.

Re-exported as `story/make-run-artifact` / `run-artifact?` / `replay-run-artifact`.

### Spec

New `spec/017-Testing-Story.md` §**Run artifact and replay** documents the `:rf.test/run-artifact` schema + the `replay-run-artifact` contract (fresh-frame, fx reapplication, new tape, shared result shape, status floor).

### Scope note

Lands **only A3**. A4 determinism gate (`.8`) and A5 semantic diff (`.9`) build on this schema + replay — left for those beads. Cross-run `run-hash` equality is `.8`'s concern (it owns stripping per-frame epoch ids from the tape); this bead pins only that the result canonicalizes deterministically and `run-hash` is stable.

## Quality gates

| Gate | Result |
|---|---|
| `tools/story` JVM (`clojure -M:test`) | **937 tests, 2847 assertions, 0 failures / 0 errors** |
| `npm run test:cljs` (node CLJS) | **4842 tests, 15870 assertions, 0 failures / 0 errors** |
| `scripts/test-fast-pr.sh` (core JVM 795 + JS harness + CLJS + markdown gates) | **PASS** (mkdocs soft-skip on Windows; CI runs it) |

Tests cover §A3's acceptance: pure construction/coercion, and a headless replay path under `clojure -M:test` that replays a dispatch program into a fresh frame, reapplies fx decisions/overrides, captures a new epoch tape, and returns the shared result shape (plus fresh-frame isolation + caller-frame + status-floor cases). `day8/re-frame2-epoch` added to the `tools/story` `:test` alias (test-only — the published jar reads the late-bound `epoch-history` facade, which degrades to an empty tape when the artefact is absent).

## Collision avoidance

Did NOT touch `plan.cljc` (.12), `schemas.cljc` (sibling), `play/evidence.cljc` (.4, consumed read-only), or the invariants ns (.5/.6). The new `spec/017` section is a separate `## Run artifact and replay` block placed between `## Promotion` and `## Relationship to the workshop surface`.