### PR TITLE
feat(story): determinism gate over canonical run artifacts (rf2-5x1wt.8)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -1212,11 +1212,18 @@ The public surface, all routed through one projection + one hash:
 | `plan-hash` | `canonical-hash` over `plan-hash-input-keys` (`[:story/id :world :script :expect :required-runner :tags]`). |
 | `run-hash` | `canonical-hash` over `run-hash-input-keys` (`[:status :app-db :epoch-tape :assertions :checks :effects :schema-violations :warnings :sub-overrides :fidelity]`). |
 
-The volatile-field set stripped by `canonicalize` is
+The volatile-field set stripped recursively by `canonicalize` is
 `{:elapsed-ms :dispatch-id :source :source-coord :runner :variant/id
-:plan-hash :run-hash}` — `:run-hash` is the symmetric companion to
-`:plan-hash` (a run-result carries its own `:run-hash`, which must not
-feed a re-canonicalization of that result). Ordering is: maps key-sorted
+:plan-hash :run-hash :epoch-id :trace-id :committed-at :schema-digest}` —
+`:run-hash` is the symmetric companion to `:plan-hash` (a run-result
+carries its own `:run-hash`, which must not feed a re-canonicalization of
+that result), and `:epoch-id` / `:trace-id` / `:committed-at` /
+`:schema-digest` are the reserved per-run epoch / trace stamps added for
+the determinism gate (§Determinism gate). The genuinely-common stamps a
+trace event / epoch record also carries (`:id`, `:time`, `:frame`, and the
+volatile `:tags` keys) are stripped **structurally** — only on their
+carrier map — so app-db data on those keys survives. Ordering is: maps
+key-sorted
 by the canonicalised key's `pr-str`; sets element-sorted; vectors/seqs
 (effects, epochs, trace events) keep producer order, which the producer
 emits deterministically (effects in emission order, epochs in dispatch
@@ -1506,6 +1513,114 @@ artifact schema + the result shape are exercised under `clojure -M:test`
 with no runtime; the headless replay path settles synchronously to a fixed
 point via the headless flush-hooks, so the live-frame replay also runs
 headless.
+
+## Determinism gate
+
+The determinism gate answers one question: does this plan / artifact
+produce the **same run every time**? It is the first consumer of
+`canonicalize` (§Canonicalization) beyond snapshot identity, and it builds
+directly on run-artifact replay (§Run artifact and replay). The base ships
+in the `re-frame.story.determinism` namespace and is re-exported as
+`test/assert-deterministic` (the testing-substrate surface owned by
+[`spec/008-Testing.md`](../../../spec/008-Testing.md) — the tool lives
+**below** Story and runs without the Story UI).
+
+```clojure
+(test/assert-deterministic plan-or-artifact)
+(test/assert-deterministic plan-or-artifact opts)
+;; -> {:status :deterministic     :run-hash <hash> :runs N :hashes [...]}
+;;  | {:status :non-deterministic :divergence {…}  :runs N :hashes [...] :results [...]}
+;;  | {:status :cannot-run        :reason :determinism-wall-clock-wait :wait-steps [...]}
+```
+
+`plan-or-artifact` is a `:rf.test/run-artifact`, a normalized variant plan
+(its `[:world :setup]` ⧺ `:script` fold into the replay event program and
+its `[:world :frame :fx-overrides]` become the replay fx decisions), or a
+`:setup` / `:script` / `:event-program` body. `opts` MAY carry `:runs`
+(replay count, default 2, minimum 2) and the `:hooks` / `:frame-config`
+threaded to `replay-run-artifact`.
+
+### What determinism means: canonical equality over N fresh-frame replays
+
+The gate replays the event program into **N FRESH frames** and compares
+the runs through `canonicalize`. A run is **deterministic** iff every
+replay's canonical **run-slice** (`run-hash-input-keys` — `:status`, the
+final `:app-db`, the `:epoch-tape`, the `:assertions` / `:checks` verdicts,
+and the projected `:effects` / `:schema-violations` / `:warnings` /
+`:sub-overrides` / `:fidelity`) is `=`. The slice — not the whole result —
+is the authority, because a run-result also carries pure provenance (the
+`:frame` replay id, the `:run-artifact` back-link, the per-step
+`:replay-steps`) that legitimately differs per replay and is excluded from
+`run-hash` for exactly this reason. The `run-hash` is the cheap
+discriminator; canonical equality of the slice is the authority, so a hash
+collision can never report a false `:deterministic`. A `:non-deterministic`
+result names the FIRST run whose canonical slice differs from run 0, with
+both run-hashes, and returns the per-run results for a downstream semantic
+diff (`test/diff-run-artifacts`).
+
+### Canonicalization MUST strip / normalize the per-run stamps
+
+A fresh frame restarts the **process-global** epoch / dispatch / trace-id
+counters and allocates a new generated `:rf.test.replay/*` frame id, so two
+semantically-equal runs stamp different values for every piece of per-run
+bookkeeping. `canonicalize` MUST strip / normalize these before comparison
+so the gate is not blinded by them:
+
+- **wall-clock timestamps** — `:committed-at` (epoch record), `:time`
+  (trace event), `:elapsed-ms` (run / assertion record);
+- **elapsed durations** — `:elapsed-ms`, the `:rf.event/elapsed-ms` trace
+  tag;
+- **generated dispatch ids** — `:dispatch-id`, the `:rf.trace/dispatch-id`
+  trace tag;
+- **generated frame ids** — `:frame` (the fresh `:rf.test.replay/*` id),
+  wherever it rides an epoch record or a trace event's `:tags`;
+- **runtime object identities** — `:epoch-id` / `:trace-id` (the
+  process-global counters), `:schema-digest`, the `:rf.trace/trace-id` tag,
+  and the trace event's `:id`;
+- **intentionally-unspecified source order** — maps are key-sorted and
+  sets element-sorted by `canonicalize`; effects and epochs keep producer
+  order (which IS semantic — reordering them is a real difference).
+
+The strip is split by SAFETY: reserved / framework-specific keys
+(`:epoch-id`, `:dispatch-id`, `:trace-id`, `:committed-at`,
+`:schema-digest`, plus `:elapsed-ms` / `:source` / `:runner` already in the
+volatile set) are stripped **recursively** by the projection; the
+genuinely-common keys a trace event / epoch record also carries (`:id`,
+`:time`, `:frame`, and the volatile `:tags` keys) are stripped
+**structurally** — only on their trace-event (`:operation` + `:op-type`) or
+epoch-record (`:epoch-id` + a record slot) carrier — so an app-db value
+that legitimately keys on `:id` / `:time` / `:frame` survives and a real
+semantic difference there is still detected. The semantic trace tags
+(`:rf.trace/event-id`, the event payload `:rf.event/v`, a changed
+`:rf.event/db`) are left intact.
+
+This strip applies on the `canonicalize` / `canonical-hash`
+(= determinism / diff / `:run-hash`) path ONLY. The strip-free
+`content-hash` that snapshot identity hashes is untouched, so
+snapshot-identity baselines stay byte-stable across this bead
+(§Snapshot-identity migration path).
+
+### The bare-`[:wait ms]` opt-out → `:cannot-run`
+
+Determinism guarantees apply only to plans free of wall-clock steps
+(§Unit and integration testing adjustments, §Script step grammar):
+`[:wait-until pred]` (queue/state-based) is deterministic and preferred;
+bare `[:wait ms]` is the explicit opt-out. `assert-deterministic` MUST
+**refuse** a plan / artifact whose event program contains a bare
+`[:wait ms]` with `:cannot-run` (the spec's third result state) rather than
+running it flakily. The refusal is a **pure pre-flight** — computed before
+any replay — and carries `:reason :determinism-wall-clock-wait` and the
+offending `:wait-steps`. (A virtual clock that would make `[:wait ms]`
+deterministic remains a non-goal, §P1 non-goals.)
+
+### Pure / JVM-testable
+
+The verdict logic (`wait-steps`, `has-wall-clock-wait?`,
+`cannot-run-wait-refusal`, `->artifact`, `compare-runs`) is pure data →
+data and runs under `clojure -M:test` with no runtime; the gate's headless
+replay path settles synchronously to a fixed point via the headless
+flush-hooks, so the full gate also runs headless. The strip's
+host-portability is pinned on CLJS alongside the fingerprint primitive.
 
 ## Relationship to the workshop surface (storytelling is in-scope)
 

--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -93,6 +93,9 @@
             ;; Re-exported as `make-run-artifact` / `run-artifact?` /
             ;; `replay-run-artifact` below (spec/017 §Run artifact and replay).
             [re-frame.story.artifact    :as artifact]
+            ;; rf2-5x1wt.8 — the determinism gate. Re-exported as
+            ;; `assert-deterministic` below (spec/017 §Determinism gate).
+            [re-frame.story.determinism :as determinism]
             [re-frame.story.lifecycle   :as lifecycle]
             [re-frame.story.query       :as query]
             ;; Runtime modules — args resolution, decorators.
@@ -963,6 +966,26 @@
   carry `:frame` / `:hooks` / `:frame-config`."
   ([art]      (artifact/replay-run-artifact art))
   ([art opts] (artifact/replay-run-artifact art opts)))
+
+;; ---- determinism gate (rf2-5x1wt.8) -------------------------------------
+;;
+;; Per spec/017 §Determinism gate — replay the plan/artifact into N FRESH
+;; frames and compare the canonical run-slices. Builds on `.7` replay and
+;; `.3` canonicalize. Re-exported as the testing-substrate `assert-
+;; deterministic` (spec/008 owns the substrate surface; the tool lives
+;; below Story and runs without the UI).
+
+(defn assert-deterministic
+  "Per spec/017 §Determinism gate — assert `plan-or-artifact` produces the
+  SAME run every time. Replays into N fresh frames (default 2) via
+  `replay-run-artifact` and compares the canonical run-slices through
+  `canonicalize`. Returns `:deterministic` (one shared `:run-hash`),
+  `:non-deterministic` (with the first `:divergence` + per-run results), or
+  `:cannot-run` when the program carries a bare `[:wait ms]` (the explicit
+  determinism opt-out — refused rather than run flakily). `opts` MAY carry
+  `:runs` / `:hooks` / `:frame-config`."
+  ([plan-or-artifact]      (determinism/assert-deterministic plan-or-artifact))
+  ([plan-or-artifact opts] (determinism/assert-deterministic plan-or-artifact opts)))
 
 (defn destroy-variant!
   "Tear down a variant frame allocated via `run-variant`. Per IMPL-

--- a/tools/story/src/re_frame/story/determinism.cljc
+++ b/tools/story/src/re_frame/story/determinism.cljc
@@ -1,0 +1,262 @@
+(ns re-frame.story.determinism
+  "The determinism gate — `assert-deterministic` (NewTestStory rf2-5x1wt.8,
+  spec/017-Testing-Story.md §Determinism gate). It answers ONE question:
+  does this plan / artifact produce the SAME run every time?
+
+  ## What determinism means here
+
+  A Story run is deterministic when replaying its event program into a
+  FRESH frame N times yields the SAME canonical run-result every time —
+  same final app-db, same effects, same assertion verdicts, same epoch
+  causal spine — after the per-RUN bookkeeping is normalized away. The
+  normalization is `re-frame.story.fingerprint/canonicalize` (rf2-5x1wt.3,
+  EXTENDED by this bead): a fresh frame restarts the process-global epoch /
+  dispatch / trace-id counters and allocates a new `:rf.test.replay/*`
+  frame id, so two semantically-equal runs stamp DIFFERENT epoch ids,
+  dispatch ids, trace ids, frame ids, and wall-clock times. The `.7`
+  replay worker deliberately left stripping those per-frame stamps in the
+  tape to THIS gate; `canonicalize` now strips them (reserved keys
+  recursively, the common `:id` / `:time` / `:frame` stamps structurally on
+  their trace-event / epoch-record carriers), so two semantically-equal
+  runs canonicalize `=` and `run-hash` equal.
+
+  ## The strip list (canonicalization, normalized before comparison)
+
+  Per spec §Determinism gate `canonicalize` strips / normalizes, before two
+  runs are compared:
+
+  - wall-clock timestamps — `:committed-at` (epoch record), `:time` (trace
+    event), `:elapsed-ms` (run / assertion record);
+  - elapsed durations — `:elapsed-ms`;
+  - generated dispatch ids — `:dispatch-id`;
+  - generated frame ids — `:frame` (a fresh replay's `:rf.test.replay/*`);
+  - runtime object identities — `:epoch-id` / `:trace-id` (process-global
+    counters), `:schema-digest` (per-frame digest);
+  - intentionally-unspecified source order — maps are key-sorted, sets
+    element-sorted (effects / epochs keep producer order, which IS
+    semantic).
+
+  ## The bare-`[:wait ms]` opt-out → `:cannot-run`
+
+  Determinism guarantees apply ONLY to plans free of wall-clock steps
+  (spec §Unit and integration testing adjustments / §Script step grammar):
+  `[:wait-until pred]` (queue/state-based) is deterministic; bare
+  `[:wait ms]` is the explicit opt-out. A plan / artifact whose event
+  program contains a bare `[:wait ms]` cannot be given a stable verdict, so
+  `assert-deterministic` REFUSES it with `:cannot-run` (the spec's third
+  result state) rather than running it flakily. This is the same refusal
+  vocabulary the settled-boundary uses (rf2-5x1wt.2).
+
+  ## Pure / JVM-testable
+
+  This ns splits the PURE verdict logic (`wait-steps`, `has-wall-clock-wait?`,
+  `cannot-run-wait-refusal`, `compare-runs`) from the impure REPLAY driver
+  (`assert-deterministic`, which calls `.7`'s `replay-run-artifact` N times
+  into fresh frames). The pure half runs under `clojure -M:test` with no
+  runtime; the replay half settles synchronously to a fixed point via the
+  headless flush-hooks, so the JVM gate exercises the full gate."
+  (:require [re-frame.story.artifact    :as artifact]
+            [re-frame.story.fingerprint :as fingerprint]
+            [re-frame.story.play.runner :as runner]))
+
+;; ===========================================================================
+;; PLAN / ARTIFACT → REPLAYABLE ARTIFACT  (pure)
+;; ===========================================================================
+
+(defn ->artifact
+  "Coerce a determinism-gate `target` into a replayable `:rf.test/run-artifact`.
+  Pure data → data.
+
+  `target` is one of:
+
+  - a `:rf.test/run-artifact` map — used verbatim (it already carries the
+    `:event-program` + `:fx-decisions`);
+  - a normalized variant plan (a map with `:world` / `:script`) — its
+    `[:world :setup]` ⧺ `:script` fold into the artifact `:event-program`
+    (the same setup-first fold `make-run-artifact` applies) and its
+    `[:world :frame :fx-overrides]` become the artifact `:fx-decisions`;
+  - any other map carrying `:setup` / `:script` / `:event-program` — folded
+    by `make-run-artifact` directly.
+
+  Reading the plan's `[:world :setup]` / `:script` is the only contact this
+  ns has with the plan compiler (`re-frame.story.plan`); it WRITES nothing
+  there. An already-built artifact short-circuits so a recorder's captured
+  program replays verbatim."
+  [target]
+  (cond
+    (artifact/run-artifact? target)
+    target
+
+    ;; A normalized variant plan: setup lives under [:world :setup], the
+    ;; primary script under :script, fx decisions under [:world :frame
+    ;; :fx-overrides]. Fold setup ⧺ script into the event program.
+    (and (map? target) (contains? target :world))
+    (artifact/make-run-artifact
+      {:setup        (get-in target [:world :setup] [])
+       :script       (get target :script [])
+       :fx-decisions (get-in target [:world :frame :fx-overrides] {})
+       :source       {:tool :determinism-gate :variant/id (:variant/id target)}})
+
+    :else
+    (artifact/make-run-artifact target)))
+
+;; ===========================================================================
+;; THE BARE-[:wait ms] OPT-OUT  (pure)
+;; ===========================================================================
+
+(defn wait-steps
+  "The bare wall-clock `[:wait ms]` steps in an artifact's `:event-program`
+  (spec §Script step grammar: `[:wait ms]` is the explicit determinism
+  opt-out). Pure data → data; returns them in program order.
+
+  `[:wait-until pred]` is NOT a wait step — it settles on a queue/state
+  condition and is deterministic — so it never appears here."
+  [artifact]
+  (filterv #(= :wait (runner/step-type %)) (:event-program artifact)))
+
+(defn has-wall-clock-wait?
+  "True iff the artifact's event program contains a bare `[:wait ms]` step —
+  the explicit determinism opt-out the gate must refuse. Pure data → data."
+  [artifact]
+  (boolean (seq (wait-steps artifact))))
+
+(defn cannot-run-wait-refusal
+  "Build the `:cannot-run` refusal for a plan/artifact carrying a bare
+  `[:wait ms]` step (spec §Determinism gate: refuse rather than produce a
+  flaky verdict). Pure data → data; shape mirrors the settled-boundary
+  refusal (a distinct third status, never a silent pass)."
+  [artifact]
+  {:status :cannot-run
+   :reason :determinism-wall-clock-wait
+   :wait-steps (wait-steps artifact)
+   :detail (str "re-frame2-story: assert-deterministic refuses a plan with a "
+                "bare [:wait ms] step — wall-clock waits are the explicit "
+                "determinism opt-out (use [:wait-until pred] for a "
+                "deterministic, queue/state-based settle).")})
+
+;; ===========================================================================
+;; COMPARE N RUNS  (pure)
+;; ===========================================================================
+
+(defn compare-runs
+  "Compare the canonical forms + `run-hash`es of `results` (the N replay
+  run-results). Pure data → data.
+
+  Returns:
+
+      {:deterministic? boolean
+       :run-count      N
+       :run-hash       <stable hash when deterministic, else nil>
+       :hashes         [hash …]              ; one per run, in order
+       :divergence     {…}}                  ; present only when NOT deterministic
+
+  A run is deterministic iff every run's canonical RUN-SLICE is `=`. The
+  slice is `re-frame.story.fingerprint/run-hash-input-keys` — the
+  behavioural surface (`:status`, final `:app-db`, `:epoch-tape`,
+  `:assertions` / `:checks`, projected `:effects` / `:schema-violations` /
+  `:warnings`, `:sub-overrides` / `:fidelity`) — NOT the whole result: the
+  result also carries pure provenance (`:frame` replay id, `:run-artifact`
+  back-link, `:replay-steps`) that legitimately differs per replay and is
+  excluded from `run-hash` for exactly this reason. The hash is the cheap
+  discriminator; equality of the canonical slice is the authority, so a
+  hash collision can never report a false GREEN. The `:divergence` slot
+  names the FIRST run whose canonical slice differs from run 0, with both
+  hashes, for a readable failure."
+  [results]
+  (let [n        (count results)
+        slice    (fn [r] (select-keys r fingerprint/run-hash-input-keys))
+        canons   (mapv (comp fingerprint/canonicalize slice) results)
+        hashes   (mapv fingerprint/run-hash results)
+        base     (first canons)
+        diverged (first (keep-indexed
+                          (fn [i c] (when (and (pos? i) (not= base c)) i))
+                          canons))]
+    (cond-> {:deterministic? (nil? diverged)
+             :run-count      n
+             :hashes         hashes
+             :run-hash       (when (nil? diverged) (first hashes))}
+      diverged
+      (assoc :divergence
+             {:run        diverged
+              :run-hash-0 (first hashes)
+              :run-hash-n (nth hashes diverged)
+              :detail     (str "run " diverged " diverged from run 0 — the "
+                               "canonical run-results are not =")}))))
+
+;; ===========================================================================
+;; THE GATE  (impure — N fresh-frame replays)
+;; ===========================================================================
+
+(def ^:const default-runs
+  "Default replay count for the determinism gate. Two runs are the minimum
+  that can witness non-determinism; callers pin a higher N for flaky-hunt
+  confidence via `:runs`."
+  2)
+
+(defn assert-deterministic
+  "Assert that `plan-or-artifact` produces the SAME run every time — the
+  determinism gate (spec §Determinism gate). Replays the event program into
+  N FRESH frames via `re-frame.story.artifact/replay-run-artifact` and
+  compares the runs through `re-frame.story.fingerprint/canonicalize`.
+
+  `plan-or-artifact` is a `:rf.test/run-artifact`, a normalized variant
+  plan, or a `:setup`/`:script`/`:event-program` body — coerced by
+  `->artifact`.
+
+  `opts` (all optional):
+
+  - `:runs`  — replay count (default 2). N >= 2.
+  - `:hooks` / `:frame-config` — threaded to `replay-run-artifact` (a `:dom`
+    adapter passes richer settled-boundary hooks; fx decisions still wrap
+    its `:dispatch!`).
+
+  Returns one of three statuses (never a flaky verdict):
+
+  - `{:status :cannot-run :reason :determinism-wall-clock-wait …}` — the
+    program contains a bare `[:wait ms]`; the gate REFUSES rather than run
+    it flakily. This is computed BEFORE any replay (pure pre-flight).
+  - `{:status :deterministic :run-hash <hash> :runs N :hashes [...]}` — every
+    replay canonicalized `=`.
+  - `{:status :non-deterministic :divergence {…} :runs N :hashes [...]
+      :results [run-result …]}` — at least one replay diverged; the
+    divergence names the first differing run + both run-hashes, and the
+    per-run results are returned for a semantic diff (rf2-5x1wt.9).
+
+  Each replay runs into its OWN fresh `:rf.test.replay/*` frame (torn down
+  before return), so the gate observes no cross-run app-db leak — the same
+  isolation `replay-run-artifact` already guarantees."
+  ([plan-or-artifact] (assert-deterministic plan-or-artifact nil))
+  ([plan-or-artifact {:keys [runs hooks frame-config] :as _opts}]
+   (let [art (->artifact plan-or-artifact)
+         n   (max 2 (or runs default-runs))]
+     (if (has-wall-clock-wait? art)
+       ;; Pure pre-flight refusal — never replay a wall-clock plan.
+       (cannot-run-wait-refusal art)
+       (let [replay-opts (cond-> {}
+                           hooks        (assoc :hooks hooks)
+                           frame-config (assoc :frame-config frame-config))
+             results     (mapv (fn [_] (artifact/replay-run-artifact art replay-opts))
+                               (range n))
+             ;; A replay that itself refused/errored is not a determinism
+             ;; question — surface it directly rather than comparing.
+             refused     (some (fn [r] (when (= :cannot-run (:status r)) r)) results)
+             errored     (some (fn [r] (when (= :error (:status r)) r)) results)
+             cmp         (compare-runs results)]
+         (cond
+           refused (assoc refused :runs n :results results)
+           errored (assoc errored :runs n :results results)
+
+           (:deterministic? cmp)
+           {:status   :deterministic
+            :runs     n
+            :run-hash (:run-hash cmp)
+            :hashes   (:hashes cmp)
+            :artifact art}
+
+           :else
+           {:status     :non-deterministic
+            :runs       n
+            :hashes     (:hashes cmp)
+            :divergence (:divergence cmp)
+            :results    results
+            :artifact   art}))))))

--- a/tools/story/src/re_frame/story/fingerprint.cljc
+++ b/tools/story/src/re_frame/story/fingerprint.cljc
@@ -94,9 +94,40 @@
   symmetric companion to `:plan-hash` — a run-result carries its own
   `:run-hash`, which must not feed a re-canonicalization of that result.
   The hashes still key the artifact at the call site; they simply do not
-  feed the canonical value recursively.)"
+  feed the canonical value recursively.)
+
+  ### Per-run stamp fields (rf2-5x1wt.8 — the determinism strip)
+
+  `:epoch-id`, `:dispatch-id`, `:trace-id`, `:committed-at`, and
+  `:schema-digest` are the per-RUN bookkeeping stamps the framework writes
+  into a freshly-captured epoch tape and its projected evidence rows. The
+  epoch counter, the dispatch-id counter, and the trace-event `:id`
+  counter are PROCESS-GLOBAL monotonic atoms (never reset per frame), and
+  `:committed-at` is wall-clock — so two semantically-equal runs replayed
+  into FRESH frames (`re-frame.story.artifact/replay-run-artifact`, spec
+  §Run artifact and replay) stamp DIFFERENT values for each. The `.7`
+  worker deliberately left this strip to the determinism gate
+  (rf2-5x1wt.8): a replay into a fresh frame stamps different epoch /
+  dispatch / trace ids, and THIS strip — together with the structural
+  `:id` / `:time` / `:frame` strip in `strip-run-stamps` below — is what
+  normalizes them so two semantically-equal runs canonicalize `=` and hash
+  equal.
+
+  Each of these keys is reserved or framework-specific (an app-db value is
+  vanishingly unlikely to key on `:epoch-id` / `:trace-id` /
+  `:committed-at` / `:schema-digest`), so the blunt recursive strip in
+  `project` is safe for them. The genuinely-common keys a trace event /
+  epoch record also carries (`:id`, `:time`, `:frame`) are NOT in this set
+  — stripping them globally would erase semantic app-db data; they are
+  stripped STRUCTURALLY (only on their carrier maps) by `strip-run-stamps`.
+
+  This strip applies on the `canonicalize` / `canonical-hash`
+  (= determinism / diff / `:run-hash`) path ONLY — the strip-free
+  `content-hash` (snapshot identity) is untouched, so snapshot-identity
+  baselines stay byte-stable (§Snapshot-identity migration path)."
   #{:elapsed-ms :dispatch-id :source :source-coord :runner
-    :variant/id :plan-hash :run-hash})
+    :variant/id :plan-hash :run-hash
+    :epoch-id :trace-id :committed-at :schema-digest})
 
 (def ^:private variant-id-spellings
   "The variant-id key spellings reconciled at this boundary. The shipping
@@ -163,6 +194,101 @@
     (set? x)        (into #{} (map project) x)
     (vector? x)     (mapv project x)
     (sequential? x) (mapv project x)
+    :else           x))
+
+;; ===========================================================================
+;; STRUCTURAL RUN-STAMP STRIP  (rf2-5x1wt.8 — the determinism layer)
+;; ===========================================================================
+;;
+;; `:id`, `:time`, and `:frame` are per-RUN stamps on a trace event / epoch
+;; record — but they are ALSO common semantic app-db keys (`{:user/id …
+;; :id 42}`, a `:frame` reference, a `:time` value). The blunt recursive
+;; `project` strip cannot touch them without erasing app data, so they are
+;; stripped STRUCTURALLY: only when they ride their carrier map.
+;;
+;; - a TRACE EVENT carries `:operation` + `:op-type` (Spec 009 §Trace event
+;;   shape); its per-run stamps are `:id` (process-global counter), `:time`
+;;   (wall-clock), and a handful of volatile slots that ride its `:tags`
+;;   sub-map — `:frame` (the fresh replay frame id), `:rf.trace/dispatch-id`
+;;   / `:rf.trace/trace-id` (per-run id counters), and `:rf.event/elapsed-ms`
+;;   (per-run timing). The SEMANTIC tags (`:rf.trace/event-id`, the event
+;;   payload `:rf.event/v`, a changed `:rf.event/db`) are LEFT intact, so a
+;;   real behavioural difference in the trace still perturbs the hash.
+;; - an EPOCH RECORD carries `:epoch-id` + (`:outcome` | `:db-after` |
+;;   `:trace-events`) (Spec-Schemas §`:rf/epoch-record`); its per-run frame
+;;   stamp is `:frame` (a fresh replay allocates a new `:rf.test.replay/*`
+;;   id). `:epoch-id` / `:committed-at` / `:schema-digest` are already
+;;   stripped by the recursive `project` (reserved keys), so only `:frame`
+;;   needs the structural treatment here.
+;;
+;; The strip is recursive so it reaches trace events nested inside an epoch
+;; record's `:trace-events` and epoch records nested inside a run-result's
+;; `:epoch-tape`. It runs BEFORE `project`, so a record's reserved stamps
+;; are dropped by `project` and its common-key stamps by this pass.
+
+(def ^:private volatile-trace-tag-keys
+  "The per-run stamp keys that ride a trace event's `:tags` sub-map
+  (Spec 009 §Trace event shape). A fresh-frame replay stamps a new
+  `:frame` id and per-run id / timing counters here; the SEMANTIC tags
+  (`:rf.trace/event-id`, `:rf.event/v` payload, `:rf.event/db` value) are
+  NOT in this set, so a real behavioural difference still perturbs the
+  canonical value."
+  #{:frame :rf.trace/dispatch-id :rf.trace/trace-id :rf.event/elapsed-ms})
+
+(defn- trace-event?
+  "True iff `m` is a trace event (Spec 009 §Trace event shape): a map
+  carrying both `:operation` and `:op-type`. Pure data → data."
+  [m]
+  (and (map? m) (contains? m :operation) (contains? m :op-type)))
+
+(defn- strip-trace-tags
+  "Drop the per-run stamp keys (`volatile-trace-tag-keys`) from a trace
+  event's `:tags` sub-map, leaving the semantic tags. No-op when `:tags`
+  is absent. Pure data → data."
+  [trace-event]
+  (if (map? (:tags trace-event))
+    (update trace-event :tags #(apply dissoc % volatile-trace-tag-keys))
+    trace-event))
+
+(defn- epoch-record?
+  "True iff `m` is an `:rf/epoch-record` (Spec-Schemas §`:rf/epoch-record`):
+  a map carrying `:epoch-id` plus at least one of the load-bearing record
+  slots (`:outcome` / `:db-after` / `:trace-events`). The extra slot guards
+  against a bare evidence row that merely back-references an `:epoch-id`
+  (those carry no `:frame`, so the guard only affects whether `:frame` is
+  read as a per-run stamp). Pure data → data."
+  [m]
+  (and (map? m)
+       (contains? m :epoch-id)
+       (or (contains? m :outcome)
+           (contains? m :db-after)
+           (contains? m :trace-events))))
+
+(defn strip-run-stamps
+  "Strip the per-run stamps that ride a trace event (`:id`, `:time`) or an
+  epoch record (`:frame`) — the common-key stamps `project` cannot strip
+  globally without erasing app-db data (rf2-5x1wt.8). Recursive across
+  maps, vectors, sets, and seqs, so it reaches trace events nested in an
+  epoch record's `:trace-events` and epoch records nested in a run-result's
+  `:epoch-tape`. Pure data → data; idempotent.
+
+  This is the structural companion to the reserved-key recursive strip in
+  `project`: between the two, two semantically-equal runs replayed into
+  fresh frames lose every per-run stamp and canonicalize `=`."
+  [x]
+  (cond
+    (map? x)
+    (let [m (cond-> x
+              (trace-event? x) (-> (dissoc :id :time) strip-trace-tags)
+              (epoch-record? x) (dissoc :frame))]
+      (persistent!
+        (reduce-kv (fn [acc k v] (assoc! acc k (strip-run-stamps v)))
+                   (transient {})
+                   m)))
+
+    (set? x)        (into #{} (map strip-run-stamps) x)
+    (vector? x)     (mapv strip-run-stamps x)
+    (sequential? x) (mapv strip-run-stamps x)
     :else           x))
 
 ;; ===========================================================================
@@ -272,9 +398,17 @@
   `:plan-hash`, `:run-hash`, golden slices, and the
   inline-plan-to-registered-variant metamorphic relation all consume it.
   Equivalent values canonicalize `=`; a semantic difference (app-db,
-  effect, assertion, …) perturbs the canonical value."
+  effect, assertion, …) perturbs the canonical value.
+
+  Projection composes two strips before ordering: the recursive reserved-key
+  strip (`project` — volatile + `:rf.story/*` accumulator keys) and the
+  structural per-run-stamp strip (`strip-run-stamps` — `:id` / `:time` /
+  `:frame` only on their trace-event / epoch-record carriers, rf2-5x1wt.8).
+  Together they erase every per-run stamp a fresh-frame replay writes, so
+  two semantically-equal runs canonicalize `=` (the determinism gate's
+  `test/assert-deterministic` is exactly this equality over N replays)."
   [x]
-  (canonical-form (project x)))
+  (canonical-form (project (strip-run-stamps x))))
 
 ;; ===========================================================================
 ;; CONTENT HASH

--- a/tools/story/test/re_frame/story/determinism_test.cljc
+++ b/tools/story/test/re_frame/story/determinism_test.cljc
@@ -1,0 +1,298 @@
+(ns re-frame.story.determinism-test
+  "Tests for the determinism gate `assert-deterministic` + the per-run
+  stamp strip the gate adds to `canonicalize` (rf2-5x1wt.8,
+  spec/017-Testing-Story.md §Determinism gate).
+
+  Two layers, both under `clojure -M:test` (JVM) + the node-runtime CLJS
+  build:
+
+  - PURE: the canonicalize strip normalizes per-run stamps (epoch / trace
+    / frame / wall-clock) but NOT semantic content; `wait-steps` /
+    `has-wall-clock-wait?` / `cannot-run-wait-refusal` detect + refuse a
+    bare `[:wait ms]`; `compare-runs` decides deterministic vs not over a
+    set of hand-built run-results.
+  - HEADLESS gate (against a live frame): `assert-deterministic` replays
+    into N FRESH frames and reports `:deterministic` / `:non-deterministic`
+    / `:cannot-run` — the §A4 acceptance bullets:
+      • same event program twice is equal after canonicalization;
+      • a real semantic difference IS detected;
+      • volatile fields do NOT cause false drift;
+      • a bare wall-clock `[:wait ms]` returns `:cannot-run`."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core      :as rf]
+            [re-frame.epoch     :as epoch]
+            [re-frame.frame     :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.story.artifact    :as artifact]
+            [re-frame.story.determinism :as det]
+            [re-frame.story.fingerprint :as fp]))
+
+;; ===========================================================================
+;; PURE: the per-run stamp strip in canonicalize  (rf2-5x1wt.8)
+;; ===========================================================================
+;;
+;; A fresh-frame replay restarts the process-global epoch / dispatch /
+;; trace-id counters and allocates a new :rf.test.replay/* frame id, so two
+;; semantically-equal runs stamp DIFFERENT values for each of these. The
+;; strip is what makes them canonicalize `=`.
+
+(defn- epoch-rec
+  "A minimal `:rf/epoch-record` carrying its per-run stamps."
+  [epoch-id frame m]
+  (merge {:epoch-id epoch-id :frame frame :committed-at 1234567
+          :schema-digest "abc" :outcome :ok
+          :db-before {} :db-after {}
+          :trace-events [] :effects [] :sub-runs [] :renders []}
+         m))
+
+(defn- trace-ev
+  "A minimal trace event carrying its per-run stamps (`:id` / `:time`)."
+  [id m]
+  (merge {:operation :rf.event/run-start :op-type :event
+          :id id :time 999 :tags {}}
+         m))
+
+(deftest canonicalize-strips-epoch-record-stamps
+  (testing "two epoch records that differ ONLY in per-run stamps canonicalize ="
+    (let [a (epoch-rec 5  :rf.test.replay/frame-aaa {:db-after {:n 1}})
+          b (epoch-rec 99 :rf.test.replay/frame-zzz {:db-after {:n 1}})]
+      (is (= (fp/canonicalize a) (fp/canonicalize b))
+          ":epoch-id / :frame / :committed-at / :schema-digest are per-run stamps")
+      (is (= (fp/canonical-hash a) (fp/canonical-hash b)))))
+
+  (testing "a SEMANTIC difference (db-after) still perturbs the canonical form"
+    (let [a (epoch-rec 5  :rf.test.replay/frame-aaa {:db-after {:n 1}})
+          c (epoch-rec 5  :rf.test.replay/frame-aaa {:db-after {:n 2}})]
+      (is (not= (fp/canonicalize a) (fp/canonicalize c))
+          "the strip must not hide a real app-db change")
+      (is (not= (fp/canonical-hash a) (fp/canonical-hash c))))))
+
+(deftest canonicalize-strips-trace-event-stamps
+  (testing "trace events differing only in :id / :time canonicalize ="
+    (let [a {:trace-events [(trace-ev 17 {:tags {:rf.trace/event-id :foo}})]}
+          b {:trace-events [(trace-ev 88 {:tags {:rf.trace/event-id :foo}})]}]
+      (is (= (fp/canonicalize a) (fp/canonicalize b))
+          ":id (process-global counter) + :time (wall-clock) are per-run stamps")))
+
+  (testing "a SEMANTIC trace difference (operation / tags) is NOT stripped"
+    (let [a {:trace-events [(trace-ev 17 {:tags {:rf.trace/event-id :foo}})]}
+          c {:trace-events [(trace-ev 17 {:tags {:rf.trace/event-id :bar}})]}]
+      (is (not= (fp/canonicalize a) (fp/canonicalize c))
+          "the event-id tag is behavioural, not a stamp"))))
+
+(deftest structural-strip-spares-app-db-keys
+  (testing ":id / :time / :frame as APP-DB values are NOT stripped — only the
+            trace-event / epoch-record carriers lose them"
+    ;; A plain app-db map that happens to key on :id / :time / :frame is not
+    ;; a trace event (no :operation+:op-type) nor an epoch record (no
+    ;; :epoch-id+record-slot), so the structural strip leaves it intact.
+    (let [db1 {:user {:id 1 :time 10 :frame :left}}
+          db2 {:user {:id 2 :time 20 :frame :right}}]
+      (is (not= (fp/canonicalize db1) (fp/canonicalize db2))
+          "semantic app-db data on common keys survives canonicalization")
+      ;; And run-results that embed them in :app-db preserve the distinction.
+      (is (not= (fp/run-hash {:status :pass :app-db db1})
+                (fp/run-hash {:status :pass :app-db db2}))))))
+
+(deftest fresh-frame-tape-twins-hash-equal
+  (testing "two run-results from fresh-frame replays — distinct epoch ids,
+            dispatch ids, trace ids, frame ids, wall-clock — hash equal after
+            the determinism strip"
+    (let [run (fn [epoch-base disp frame trace-base]
+                {:status :pass
+                 :app-db {:n 2}
+                 :epoch-tape
+                 [(epoch-rec epoch-base frame
+                    {:dispatch-id disp
+                     :db-after {:n 1}
+                     :trace-events [(trace-ev trace-base
+                                      {:tags {:rf.trace/event-id :rep/inc}})]})
+                  (epoch-rec (inc epoch-base) frame
+                    {:dispatch-id disp
+                     :db-before {:n 1} :db-after {:n 2}
+                     :trace-events [(trace-ev (inc trace-base)
+                                      {:tags {:rf.trace/event-id :rep/inc}})]})]})
+          r1 (run 5  "d-5"  :rf.test.replay/frame-aaa 17)
+          r2 (run 90 "d-90" :rf.test.replay/frame-zzz 200)]
+      (is (= (fp/canonicalize r1) (fp/canonicalize r2)))
+      (is (= (fp/run-hash r1) (fp/run-hash r2))
+          "semantically-equal fresh-frame runs share one run-hash"))))
+
+;; ===========================================================================
+;; PURE: wait-step detection + refusal
+;; ===========================================================================
+
+(deftest wait-step-detection
+  (testing "wait-steps picks out bare [:wait ms]; [:wait-until] is not a wait"
+    (let [a (artifact/make-run-artifact
+              {:event-program [[:dispatch [:a]]
+                               [:wait 100]
+                               [:dispatch [:b]]]})]
+      (is (= [[:wait 100]] (det/wait-steps a)))
+      (is (det/has-wall-clock-wait? a))))
+
+  (testing "a wall-clock-free program has no wait steps"
+    (let [a (artifact/make-run-artifact
+              {:event-program [[:dispatch [:a]] [:dispatch-sync [:b]]]})]
+      (is (= [] (det/wait-steps a)))
+      (is (not (det/has-wall-clock-wait? a)))))
+
+  (testing "the refusal is the :cannot-run third status with the wait steps"
+    (let [a (artifact/make-run-artifact {:event-program [[:wait 5] [:dispatch [:x]]]})
+          r (det/cannot-run-wait-refusal a)]
+      (is (= :cannot-run (:status r)))
+      (is (= :determinism-wall-clock-wait (:reason r)))
+      (is (= [[:wait 5]] (:wait-steps r))))))
+
+;; ===========================================================================
+;; PURE: ->artifact coercion
+;; ===========================================================================
+
+(deftest ->artifact-coercion
+  (testing "a run-artifact is used verbatim"
+    (let [a (artifact/make-run-artifact {:event-program [[:dispatch [:x]]]})]
+      (is (identical? a (det/->artifact a)))))
+
+  (testing "a normalized plan folds [:world :setup] ⧺ :script and lifts fx-overrides"
+    (let [plan {:variant/id :story/x
+                :world  {:setup [[:dispatch [:seed]]]
+                         :frame {:fx-overrides {:http/get :http/stub}}}
+                :script [[:dispatch [:act]] [:wait 9]]}
+          a    (det/->artifact plan)]
+      (is (artifact/run-artifact? a))
+      (is (= [[:dispatch [:seed]] [:dispatch [:act]] [:wait 9]]
+             (:event-program a))
+          "setup-first fold, then script")
+      (is (= {:http/get :http/stub} (:fx-decisions a))
+          "[:world :frame :fx-overrides] become :fx-decisions"))))
+
+;; ===========================================================================
+;; PURE: compare-runs
+;; ===========================================================================
+
+(deftest compare-runs-pure
+  (testing "identical canonical runs are deterministic with one shared run-hash"
+    (let [r {:status :pass :app-db {:n 1}}
+          c (det/compare-runs [r r r])]
+      (is (:deterministic? c))
+      (is (= 3 (:run-count c)))
+      (is (= (fp/run-hash r) (:run-hash c)))
+      (is (nil? (:divergence c)))))
+
+  (testing "a divergent run is detected and named (first differing run vs run 0)"
+    (let [r0 {:status :pass :app-db {:n 1}}
+          r1 {:status :pass :app-db {:n 1}}
+          r2 {:status :pass :app-db {:n 999}}
+          c  (det/compare-runs [r0 r1 r2])]
+      (is (not (:deterministic? c)))
+      (is (nil? (:run-hash c)))
+      (is (= 2 (get-in c [:divergence :run])) "run 2 is the first divergence")
+      (is (not= (get-in c [:divergence :run-hash-0])
+                (get-in c [:divergence :run-hash-n]))))))
+
+;; ===========================================================================
+;; HEADLESS gate: against a live frame  (the §A4 acceptance)
+;; ===========================================================================
+
+(defn- reset-rf! [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (epoch/clear-history!)
+  (epoch/clear-epoch-listeners!)
+  (try (rf/init! plain-atom/adapter)
+       (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) _ nil))
+  (frame/ensure-default-frame!)
+  (test-fn))
+
+(use-fixtures :each reset-rf!)
+
+(deftest gate-same-program-is-deterministic
+  (testing "the SAME event program replayed twice is equal after
+            canonicalization — :deterministic with one shared run-hash"
+    (rf/reg-event-db :det/inc (fn [db _] (update db :n (fnil inc 0))))
+    (let [a   (artifact/make-run-artifact
+                {:event-program [[:dispatch [:det/inc]] [:dispatch [:det/inc]]]})
+          res (det/assert-deterministic a)]
+      (is (= :deterministic (:status res)))
+      (is (= 2 (:runs res)))
+      (is (string? (:run-hash res)))
+      (is (= 8 (count (:run-hash res))))
+      (is (apply = (:hashes res)) "every replay shares the canonical run-hash"))))
+
+(deftest gate-accepts-a-normalized-plan
+  (testing "a normalized plan (setup ⧺ script) is replayed deterministically"
+    (rf/reg-event-db :det/seed (fn [db [_ v]] (assoc db :v v)))
+    (rf/reg-event-db :det/bump (fn [db _] (update db :v inc)))
+    (let [plan {:variant/id :story.det/plan
+                :world  {:setup [[:dispatch [:det/seed 10]]]}
+                :script [[:dispatch [:det/bump]]]}
+          res  (det/assert-deterministic plan {:runs 3})]
+      (is (= :deterministic (:status res)))
+      (is (= 3 (:runs res))))))
+
+(deftest gate-detects-real-semantic-nondeterminism
+  (testing "a handler whose result depends on a PROCESS-GLOBAL mutable counter
+            (not app-db) produces a different app-db each replay — the gate
+            DETECTS it as :non-deterministic"
+    (let [counter (atom 0)]
+      ;; Each dispatch reads + bumps a shared atom, so replay 1 writes 1 and
+      ;; replay 2 writes 2 into a FRESH frame's app-db — a genuine semantic
+      ;; divergence the canonical strip must NOT mask.
+      (rf/reg-event-db :det/nondet
+                       (fn [db _] (assoc db :token (swap! counter inc))))
+      (let [a   (artifact/make-run-artifact
+                  {:event-program [[:dispatch [:det/nondet]]]})
+            res (det/assert-deterministic a)]
+        (is (= :non-deterministic (:status res)))
+        (is (= 1 (get-in res [:divergence :run]))
+            "run 1 diverged from run 0")
+        (is (not= (get-in res [:divergence :run-hash-0])
+                  (get-in res [:divergence :run-hash-n])))
+        (is (= 2 (count (:results res)))
+            "per-run results returned for a downstream semantic diff")))))
+
+(deftest gate-volatile-fields-do-not-cause-false-drift
+  (testing "a purely-deterministic handler is :deterministic even though every
+            replay stamps fresh epoch / dispatch / trace ids, a new frame id,
+            and its own wall-clock — volatile fields cause NO false drift"
+    (rf/reg-event-db :det/pure (fn [db _] (assoc db :answer 42)))
+    (let [a   (artifact/make-run-artifact
+                {:event-program [[:dispatch [:det/pure]] [:dispatch [:det/pure]]]})
+          res (det/assert-deterministic a {:runs 4})]
+      (is (= :deterministic (:status res))
+          "four fresh-frame replays with distinct stamps still agree")
+      (is (= 4 (:runs res)))
+      (is (apply = (:hashes res))))))
+
+(deftest gate-refuses-bare-wall-clock-wait
+  (testing "a plan containing a bare [:wait ms] returns :cannot-run for the
+            determinism gate rather than a flaky verdict — and does NOT replay"
+    (rf/reg-event-db :det/inc (fn [db _] (update db :n (fnil inc 0))))
+    (let [a   (artifact/make-run-artifact
+                {:event-program [[:dispatch [:det/inc]]
+                                 [:wait 50]
+                                 [:dispatch [:det/inc]]]})
+          res (det/assert-deterministic a)]
+      (is (= :cannot-run (:status res)))
+      (is (= :determinism-wall-clock-wait (:reason res)))
+      (is (= [[:wait 50]] (:wait-steps res)))
+      (is (not (contains? res :hashes))
+          "the gate refused BEFORE replaying — no run hashes produced"))))
+
+(deftest gate-reapplies-fx-decisions-deterministically
+  (testing "fx decisions ride every replay — a stubbed effect fires the stub
+            on each fresh-frame run, and the gate is :deterministic"
+    (let [hits (atom [])]
+      (rf/reg-fx :det.fx/real {:platforms #{:client :server}}
+                 (fn [_ _] (swap! hits conj :real)))
+      (rf/reg-fx :det.fx/stub {:platforms #{:client :server}}
+                 (fn [_ _] (swap! hits conj :stub)))
+      (rf/reg-event-fx :det/fire (fn [_ _] {:fx [[:det.fx/real {}]]}))
+      (let [a   (artifact/make-run-artifact
+                  {:event-program [[:dispatch [:det/fire]]]
+                   :fx-decisions  {:det.fx/real :det.fx/stub}})
+            res (det/assert-deterministic a)]
+        (is (= :deterministic (:status res)))
+        (is (= [:stub :stub] @hits)
+            "the stub fired on BOTH fresh-frame replays")))))

--- a/tools/story/test/re_frame/story_fingerprint_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_fingerprint_cljs_test.cljs
@@ -7,7 +7,9 @@
   - the 8-char-hex hash renders identically (left-padded) on CLJS;
   - volatile-strip equivalence and semantic sensitivity hold under the
     CLJS `hash` + `pr-str`;
-  - the snapshot-identity content-hash fold is strip-free on CLJS too."
+  - the snapshot-identity content-hash fold is strip-free on CLJS too;
+  - the rf2-5x1wt.8 per-run stamp strip (epoch-record `:frame`, trace-event
+    `:id` / `:time` / volatile tags) is host-portable too."
   (:require [cljs.test :refer-macros [deftest is testing]]
             [re-frame.story.fingerprint :as fp]
             [re-frame.story.identity    :as ident]))
@@ -53,6 +55,40 @@
   (testing "a semantic app-db difference perturbs the run-hash on CLJS"
     (is (not= (fp/run-hash base)
               (fp/run-hash (assoc-in base [:app-db :n] 2))))))
+
+(deftest determinism-stamp-strip-on-cljs
+  (testing "epoch records differing only in per-run stamps canonicalize = on CLJS
+            (rf2-5x1wt.8): :epoch-id / :frame / :committed-at / :schema-digest"
+    (let [rec (fn [eid frame]
+                {:epoch-id eid :frame frame :committed-at 1 :schema-digest "d"
+                 :outcome :ok :db-after {:n 1} :trace-events [] :effects []})]
+      (is (= (fp/canonicalize (rec 5 :rf.test.replay/frame-a))
+             (fp/canonicalize (rec 90 :rf.test.replay/frame-z))))
+      (is (= (fp/canonical-hash (rec 5 :rf.test.replay/frame-a))
+             (fp/canonical-hash (rec 90 :rf.test.replay/frame-z))))
+      (is (not= (fp/canonicalize (rec 5 :rf.test.replay/frame-a))
+                (fp/canonicalize (assoc (rec 5 :rf.test.replay/frame-a)
+                                        :db-after {:n 2})))
+          "a real db-after difference still perturbs the canonical value")))
+
+  (testing "trace events differing only in :id / :time / volatile tags
+            canonicalize = on CLJS; the event-id tag is semantic"
+    (let [ev (fn [id frame]
+               {:operation :rf.event/run-start :op-type :event :id id :time id
+                :tags {:rf.trace/event-id :foo :frame frame
+                       :rf.trace/dispatch-id id}})]
+      (is (= (fp/canonicalize {:trace-events [(ev 1 :rf.test.replay/frame-a)]})
+             (fp/canonicalize {:trace-events [(ev 9 :rf.test.replay/frame-z)]})))
+      (is (not= (fp/canonicalize {:trace-events [(ev 1 :rf.test.replay/frame-a)]})
+                (fp/canonicalize
+                  {:trace-events [(assoc-in (ev 1 :rf.test.replay/frame-a)
+                                            [:tags :rf.trace/event-id] :bar)]}))
+          "the event-id tag is behavioural, not a stamp")))
+
+  (testing ":id / :time / :frame as plain app-db values are NOT stripped on CLJS"
+    (is (not= (fp/canonicalize {:status :pass :app-db {:id 1 :time 10 :frame :l}})
+              (fp/canonicalize {:status :pass :app-db {:id 2 :time 20 :frame :r}}))
+        "semantic app-db data on common keys survives canonicalization")))
 
 (deftest snapshot-fold-strip-free-on-cljs
   (testing "identity content-hash IS the fingerprint content-hash (folded)"


### PR DESCRIPTION
## What

Adds the **determinism gate** (NewTestStory §A4, spec/017-Testing-Story.md §Determinism gate) — `re-frame.story.determinism/assert-deterministic`, re-exported as `story/assert-deterministic`. The gate answers: does this plan / artifact produce the **same run every time**?

It replays a plan or `:rf.test/run-artifact` into **N fresh frames** (default 2) via `.7`'s `replay-run-artifact`, then compares the canonical **run-slices** through `.3`'s `canonicalize`. Returns one of three statuses (never a flaky verdict):

- `:deterministic` — every replay's canonical run-slice is `=` (one shared `:run-hash`).
- `:non-deterministic` — names the first divergent run + both run-hashes, returns the per-run results for a downstream semantic diff (`.9`).
- `:cannot-run` — the program carries a bare `[:wait ms]` (the explicit determinism opt-out); refused in a **pure pre-flight** rather than run flakily.

## The canonicalize strip the `.7` worker deferred here

A fresh-frame replay restarts the **process-global** epoch / dispatch / trace-id counters and allocates a new `:rf.test.replay/*` frame id, so two semantically-equal runs stamp different values for each. `canonicalize` now normalizes them:

- **Reserved per-run keys** (`:epoch-id` / `:trace-id` / `:committed-at` / `:schema-digest`) strip **recursively** via the existing projection (vanishingly unlikely as app-db keys).
- **Genuinely-common keys** (`:id` / `:time` / `:frame` + the volatile trace `:tags` keys `:rf.trace/dispatch-id` / `:rf.trace/trace-id` / `:rf.event/elapsed-ms`) strip **structurally** — only on their trace-event (`:operation`+`:op-type`) or epoch-record (`:epoch-id`+record-slot) carrier — so an app-db value keyed on `:id`/`:time`/`:frame` survives and a real semantic difference there is still detected.
- The semantic trace tags (`:rf.trace/event-id`, the `:rf.event/v` payload, a changed `:rf.event/db`) are left intact.
- The strip-free `content-hash` (snapshot identity) is **untouched** — snapshot-identity baselines stay byte-stable.

The determinism comparison authority is the `run-hash-input-keys` slice, not the whole result — provenance slots (`:frame` replay id, `:run-artifact`, `:replay-steps`) legitimately differ per replay and are excluded.

## Lane discipline

Write surface only: `fingerprint.cljc` (strip rules — my bead), new `re_frame/story/determinism.cljc` + tests, a new `spec/017 §Determinism gate` section + the `§Canonicalization` volatile-set enumeration, the `*-cljs-test` host-portability cases, and an appended `story/assert-deterministic` re-export. **Did NOT touch** `plan.cljc`, `schemas.cljc`, `artifact.cljc`, `save_variant.cljc`, the promotion ns, or `deps.edn`.

## Quality gates

| Gate | Result |
|---|---|
| `cd tools/story && clojure -M:test` | **PASS** — 980 tests, 2985 assertions, 0 failures / 0 errors |
| `npm --prefix implementation run test:cljs` | **PASS** — 4848 tests, 15885 assertions, 0 failures / 0 errors |
| `bash scripts/test-fast-pr.sh` | **PASS** — lockstep, skill/MCP drift, core JVM, JS harness, CLJS node integration, README/docs anchor validators (mkdocs soft-skipped locally; CI runs it) |
| `git diff --check` | clean |