### PR TITLE
feat(story): run-artifact promotion bridge — materialize + promote (rf2-5x1wt.25)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -1487,6 +1487,63 @@ preconditions. The recorder/codegen output SHOULD share this contract, so
 a recorded interaction and a promoted failure are indistinguishable as
 authored variants.
 
+### Promotion bridge
+
+The promotion API ships in the `re-frame.story.promotion` namespace
+(re-exported on the `re-frame.story` facade). It is two functions with a
+deliberate purity split:
+
+```clojure
+(story/materialize-variant-plan artifact opts)
+;; -> a readable, normalized variant plan. PURE — registers NOTHING.
+
+(story/promote-run-artifact! artifact {:variant/id :story.checkout/regression-042})
+;; -> registers a NAMED variant. The ONLY function that registers.
+```
+
+`materialize-variant-plan` projects a run artifact into the four-bucket
+authoring shape and compiles it through the `variant-plan` compiler
+(§Variant plan) read-only, returning a normalized `:world` / `:script` /
+`:expect` plan. It is side-effect-free, so a tool or author MAY
+materialize a plan to READ what a promotion would produce before deciding
+to commit it.
+
+`promote-run-artifact!` is the single registering entry. It MUST be
+called with an explicit `:variant/id`; a missing id is an error
+(`:rf.error/story-promote-no-id`), never a silent default. There is no
+auto-register path — a generated failure becomes a curated variant ONLY
+through this named call. The function builds the same variant body
+`materialize-variant-plan` compiles and writes it into the Story
+side-table via the `reg-variant` write path (shape validation, `:extends`
+resolution, source-coord stamping). The registered variant is
+indistinguishable from a hand-authored one except for its `:run-artifact`
+provenance slot. Production builds (`config/enabled?` false)
+short-circuit before the write.
+
+**Setup/script projection.** The artifact's `:event-program` is one
+ordered program; the promotion policy in `opts` selects where the cut
+between PRECONDITION (`[:world :setup]`) and BEHAVIOUR-UNDER-TEST
+(`:script`) falls:
+
+- `:setup` + `:script` — an explicit partition, used verbatim.
+- `:setup-count n` — the first `n` steps are preconditions; the rest are
+  behaviour (clamped to the program bounds).
+- neither (default) — the whole program is behaviour (`:script`); nothing
+  is demoted to a silent precondition without a hint. This is the
+  conservative reading: a captured run IS the behaviour the artifact
+  recorded.
+
+**Source-artifact link.** Both the materialized plan and the promoted
+variant body preserve a back-link to the source artifact under the
+`:run-artifact` slot — the same slot a replay run-result carries (§Run
+result), so provenance reads the same everywhere. The link is a TRIMMED
+provenance view: the replayable + identifying core (`:artifact/kind`,
+`:seed`, `:event-program`, `:fx-decisions`, `:shrink-path`,
+`:created-at`, `:source`) WITHOUT the bulky captured evidence
+(`:epoch-tape`, `:trace`, `:result`). A curated variant can explain where
+it came from and re-derive the run; it does not drag a full epoch tape
+into the registrar side-table.
+
 ## Run artifact and replay
 
 The `:rf.test/run-artifact` shape (§Artifacts — Run artifact) is the

--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -96,6 +96,11 @@
             ;; rf2-5x1wt.8 — the determinism gate. Re-exported as
             ;; `assert-deterministic` below (spec/017 §Determinism gate).
             [re-frame.story.determinism :as determinism]
+            ;; rf2-5x1wt.25 — the run-artifact → variant promotion bridge.
+            ;; Re-exported as `materialize-variant-plan` (pure) +
+            ;; `promote-run-artifact!` (the explicit-only registration path)
+            ;; below (spec/017 §Promotion — Promotion bridge).
+            [re-frame.story.promotion   :as promotion]
             [re-frame.story.lifecycle   :as lifecycle]
             [re-frame.story.query       :as query]
             ;; Runtime modules — args resolution, decorators.
@@ -986,6 +991,40 @@
   `:runs` / `:hooks` / `:frame-config`."
   ([plan-or-artifact]      (determinism/assert-deterministic plan-or-artifact))
   ([plan-or-artifact opts] (determinism/assert-deterministic plan-or-artifact opts)))
+
+;; ---- run-artifact → variant promotion bridge (rf2-5x1wt.25) -------------
+;;
+;; Per spec/017 §Promotion — Promotion bridge: a curated run artifact
+;; becomes a NAMED Story variant. Two surfaces: `materialize-variant-plan`
+;; is PURE (projects the artifact into a readable normalized plan, registers
+;; NOTHING); `promote-run-artifact!` is the ONLY registering path (no
+;; `:variant/id`, no registration — a generated failure is never
+;; auto-registered). Both preserve the source-artifact link on
+;; `:run-artifact`.
+
+(defn materialize-variant-plan
+  "Per spec/017 §Promotion — project a run artifact into a readable,
+  data-shaped normalized variant plan. PURE / side-effect-free — registers
+  NOTHING; use it to READ what a promotion would produce. The program's
+  preconditions land on `[:world :setup]` and its behaviour-under-test on
+  `:script` (the projection rule); the plan carries a `:run-artifact`
+  source link. `opts` MAY carry `:variant/id` / `:setup` / `:script` /
+  `:setup-count` / `:doc` / `:extends` / `:tags` / `:args` / `:lookup` /
+  `:view-lookup` / `:validator-fns`."
+  ([artifact]      (promotion/materialize-variant-plan artifact))
+  ([artifact opts] (promotion/materialize-variant-plan artifact opts)))
+
+(defn promote-run-artifact!
+  "Per spec/017 §Promotion — promote a curated run artifact into a NAMED
+  Story variant. The ONLY registering path in the bridge: `opts` MUST
+  carry `:variant/id`; a generated failure is NEVER auto-registered. Builds
+  the same body `materialize-variant-plan` compiles (preconditions on
+  `:setup`, behaviour on `:script`, the source-artifact link on
+  `:run-artifact`) and writes it into the Story side-table via the
+  `reg-variant` write path. Production builds short-circuit. Returns the
+  registered variant id."
+  [artifact opts]
+  (promotion/promote-run-artifact! artifact opts))
 
 (defn destroy-variant!
   "Tear down a variant frame allocated via `run-variant`. Per IMPL-

--- a/tools/story/src/re_frame/story/promotion.cljc
+++ b/tools/story/src/re_frame/story/promotion.cljc
@@ -1,0 +1,291 @@
+(ns re-frame.story.promotion
+  "The run-artifact → variant promotion bridge (NewTestStory rf2-5x1wt.25,
+  spec/017-Testing-Story.md §Promotion — Promotion bridge).
+
+  ## What promotion is
+
+  A run artifact (`re-frame.story.artifact` — the `:rf.test/run-artifact`
+  shape) is the low-level, data-shaped evidence emitted by a generated
+  test, a failed run, a replay, a determinism check, or tool/agent
+  exploration (spec/017 §Artifacts). A run artifact is NOT a Story
+  variant — it carries no curation, no navigation slot, no `:extends`
+  lineage. Most generated failures are throwaway; only a CURATED few
+  earn a permanent home in the gallery.
+
+  Promotion is the deliberate act of turning ONE curated run artifact
+  into a NAMED Story variant. It splits in two:
+
+  - `materialize-variant-plan` — PURE. Reads a run artifact, projects its
+    dispatch program into the four-bucket authoring shape (preconditions →
+    `[:world :setup]`, behaviour-under-test → `:script`), compiles it
+    through the `.10` variant-plan compiler (read-only), and returns a
+    readable, data-shaped normalized plan. Side-effect-free: it registers
+    NOTHING. A tool or an author can materialize a plan to READ what a
+    promotion WOULD produce, then decide.
+
+  - `promote-run-artifact!` — IMPURE. The ONLY function that registers.
+    Builds the same variant body `materialize-variant-plan` compiles and
+    writes it into the Story side-table under the explicit `:variant/id`
+    via `re-frame.story.registrar/reg-variant*`. No `:variant/id`, no
+    registration — there is no auto-register path. A generated failure
+    becomes a curated variant only when an author (or an agent acting on
+    an author's behalf) makes this call by name.
+
+  ## The projection rule (spec/017 §Promotion)
+
+  Replayable event programs become `:script` when they represent
+  behaviour UNDER TEST, and `[:world :setup]` when they are only
+  PRECONDITIONS. The artifact's `:event-program` is one ordered program;
+  the promotion policy says where the cut between precondition and
+  behaviour falls. The default policy treats the whole program as
+  behaviour-under-test (`:script`) — the conservative reading, since a
+  captured run IS the behaviour the artifact recorded. The caller refines
+  the cut via `opts` (`:setup-count` / an explicit `:setup` + `:script`
+  partition); see `artifact->variant-body`.
+
+  ## Source-artifact link (spec/017 §Promotion)
+
+  Both the materialized plan and the promoted variant body preserve a
+  back-link to the source artifact under the `:run-artifact` slot — the
+  same slot `replay-result` stamps on a replay run-result (§Run result),
+  so provenance reads the same everywhere. The link is a TRIMMED
+  provenance view (`provenance-link`): the replayable + identifying core
+  (`:artifact/kind`, `:seed`, `:event-program`, `:fx-decisions`,
+  `:shrink-path`, `:created-at`, `:source`) WITHOUT the bulky captured
+  evidence (`:epoch-tape`, `:trace`, `:result`). A curated variant can
+  explain where it came from and re-derive the run; it does not drag a
+  full epoch tape into the registrar side-table.
+
+  ## Purity / elision
+
+  `materialize-variant-plan` + the body/link builders are pure data →
+  data and run under `clojure -M:test` with no host. `promote-run-artifact!`
+  is the single impure entry; it gates on `re-frame.story.config/enabled?`
+  so a production CLJS build short-circuits before touching the side-table
+  (mirroring `save-variant`)."
+  (:require [re-frame.story.artifact   :as artifact]
+            [re-frame.story.config     :as config]
+            [re-frame.story.plan       :as plan]
+            [re-frame.story.play.runner :as runner]
+            [re-frame.story.registrar  :as registrar]))
+
+;; ===========================================================================
+;; Source-artifact provenance link
+;; ===========================================================================
+
+(def provenance-link-keys
+  "The artifact slots a promotion preserves as the source-artifact link
+  (spec/017 §Promotion — source-artifact link). The replayable +
+  identifying core: enough to explain where a curated variant came from
+  AND to re-derive the run. Deliberately EXCLUDES the bulky captured
+  evidence (`:epoch-tape`, `:trace`, `:result`) — a registered variant
+  body is a curation surface, not an evidence dump; the full evidence
+  lives on the original artifact the tool keeps."
+  #{:artifact/kind :seed :event-program :fx-decisions
+    :shrink-path :created-at :source})
+
+(defn provenance-link
+  "Project a run `artifact` to its source-artifact link — the trimmed
+  provenance view a promotion stores under `:run-artifact`. Pure data →
+  data.
+
+  Keeps `provenance-link-keys` (the replayable + identifying core) and
+  drops the captured-evidence slots so the link stays a compact pointer
+  back to the source run rather than a full evidence copy."
+  [artifact]
+  (select-keys artifact provenance-link-keys))
+
+;; ===========================================================================
+;; Program → setup / script partition (the projection rule)
+;; ===========================================================================
+
+(defn partition-program
+  "Partition an artifact's `:event-program` into `{:setup … :script …}`
+  per the promotion projection rule (spec/017 §Promotion). Pure data →
+  data — tagged step vectors in, two ordered step vectors out.
+
+  `opts` selects the cut between PRECONDITION (`[:world :setup]`) and
+  BEHAVIOUR-UNDER-TEST (`:script`):
+
+  - `:setup` + `:script` — an EXPLICIT partition. Each is a step program
+    (or bare-event list); they are coerced through the runner and used
+    verbatim, ignoring the artifact's own `:event-program`. The escape
+    hatch for a caller that already knows the cut (e.g. a recorder that
+    tracked which dispatches were arrange-vs-act).
+  - `:setup-count n` — the FIRST `n` steps of the program are
+    preconditions (`:setup`); the rest are behaviour (`:script`). A
+    negative / oversized `n` clamps to the program bounds.
+  - neither — the DEFAULT policy: the whole program is behaviour
+    (`:script`), `:setup` is empty. Conservative — a captured run IS the
+    behaviour the artifact recorded, so absent a hint nothing is demoted
+    to a silent precondition.
+
+  The returned programs are coerced through `runner/coerce-script`, so a
+  bare event list lifts to a legal `[:dispatch …]` program and an
+  already-tagged program passes through."
+  [artifact {:keys [setup script setup-count] :as _opts}]
+  (cond
+    (or (some? setup) (some? script))
+    {:setup  (runner/coerce-script (or setup []))
+     :script (runner/coerce-script (or script []))}
+
+    (some? setup-count)
+    (let [program (vec (:event-program artifact))
+          n       (-> setup-count (max 0) (min (count program)))]
+      {:setup  (subvec program 0 n)
+       :script (subvec program n)})
+
+    :else
+    {:setup  []
+     :script (vec (:event-program artifact))}))
+
+;; ===========================================================================
+;; Artifact → variant body
+;; ===========================================================================
+
+(defn artifact->variant-body
+  "Build a Story variant body from a run `artifact`. Pure data → data —
+  the shared core of `materialize-variant-plan` (which compiles it) and
+  `promote-run-artifact!` (which registers it).
+
+  The body carries the four-bucket authoring vocabulary (spec/017 §Public
+  vocabulary): the program's preconditions land on `:setup`, its
+  behaviour-under-test on `:script` (per the projection rule — see
+  `partition-program`). Both are the PUBLIC bare step-vector spelling the
+  variant-plan compiler reads (`:setup` → `[:world :setup]`, `:script` →
+  the primary play); an empty partition omits the slot. The source-artifact
+  link rides on `:run-artifact` (see `provenance-link`).
+
+  `opts`:
+  - `:setup` / `:script` / `:setup-count` — the program partition policy
+    (see `partition-program`).
+  - `:doc`     — a docstring for the curated variant. Defaults to a
+                 generated note that records the promotion provenance.
+  - `:extends` — a parent variant id, threaded onto `:extends` so a
+                 promoted variant can inherit a story's `:component` /
+                 decorators / fixture args.
+  - `:tags`    — a tag set for the curated variant.
+  - `:args`    — an args map for the curated variant.
+
+  Slots the artifact carries that are not part of the variant surface are
+  not copied — the body is a clean authoring surface, the artifact link
+  the only provenance."
+  ([artifact] (artifact->variant-body artifact nil))
+  ([artifact {:keys [doc extends tags args] :as opts}]
+   (let [{:keys [setup script]} (partition-program artifact opts)]
+     (cond-> {:run-artifact (provenance-link artifact)
+              :doc          (or doc
+                                (str "Promoted from a "
+                                     (:artifact/kind artifact :rf.test/run-artifact)
+                                     " run artifact (spec/017 §Promotion)."))}
+       (seq setup)    (assoc :setup setup)
+       (seq script)   (assoc :script script)
+       (some? extends) (assoc :extends extends)
+       (some? tags)   (assoc :tags tags)
+       (some? args)   (assoc :args args)))))
+
+;; ===========================================================================
+;; materialize-variant-plan — PURE, registers NOTHING
+;; ===========================================================================
+
+(defn materialize-variant-plan
+  "Project a run `artifact` into a readable normalized variant plan
+  (spec/017 §Promotion — Promotion bridge). Pure / side-effect-free — it
+  registers NOTHING. Use it to READ what a promotion would produce.
+
+  Pipeline:
+  1. Build a variant body from the artifact (`artifact->variant-body`) —
+     the program's preconditions on `:setup`, behaviour on `:script`, the
+     source-artifact link on `:run-artifact`.
+  2. Compile the body through the `.10` variant-plan compiler
+     (`re-frame.story.plan/variant-plan`) — called READ-ONLY as an inline
+     map target, resolving `:extends`, lowering the four-bucket
+     vocabulary, substituting `[:arg …]`, and emitting the normalized
+     `:world` / `:script` / `:expect` plan.
+  3. Re-attach the `:run-artifact` source-artifact link to the plan (the
+     compiler reads only known variant slots, so the link must be carried
+     across explicitly — promotion's invariant is that the plan can
+     always explain its provenance).
+
+  `opts` (all optional):
+  - `:setup` / `:script` / `:setup-count` — program partition policy
+    (`partition-program`).
+  - `:variant/id` — the plan's `:variant/id`. Materialization does NOT
+    require one (the plan is readable without a name); when supplied it
+    rides onto the inline plan target so the compiled plan is named.
+  - `:doc` / `:extends` / `:tags` / `:args` — variant-body slots
+    (`artifact->variant-body`).
+  - `:lookup` / `:view-lookup` / `:validator-fns` — threaded to
+    `variant-plan` for `:extends` parent resolution + view-args schema
+    validation (defaults: the Story side-table + framework `:view`
+    registrar).
+
+  Returns the normalized plan map with a `:run-artifact` source link.
+  FAILS with the compiler's structured `:rf.error/story-*` ex-info on an
+  unknown `:extends` parent, an `:extends` cycle, a missing `[:arg …]`,
+  or view-args that violate the view schema."
+  ([artifact] (materialize-variant-plan artifact nil))
+  ([artifact {:keys [lookup view-lookup validator-fns] :as opts}]
+   (let [variant-id   (:variant/id opts)
+         body         (artifact->variant-body artifact opts)
+         target       (cond-> body
+                        (some? variant-id) (assoc :variant/id variant-id))
+         compile-opts (cond-> {}
+                        (some? lookup)        (assoc :lookup lookup)
+                        (some? view-lookup)   (assoc :view-lookup view-lookup)
+                        (some? validator-fns) (assoc :validator-fns validator-fns))
+         plan         (plan/variant-plan target compile-opts)]
+     ;; The compiler reads only known variant slots, so the source link
+     ;; does not survive into the plan on its own — re-attach it so the
+     ;; materialized plan ALWAYS carries its provenance (spec/017
+     ;; §Promotion — source-artifact link).
+     (assoc plan :run-artifact (provenance-link artifact)))))
+
+;; ===========================================================================
+;; promote-run-artifact! — IMPURE, the ONLY registering path
+;; ===========================================================================
+
+(defn promote-run-artifact!
+  "Promote a curated run `artifact` into a NAMED Story variant (spec/017
+  §Promotion — Promotion bridge). This is the ONLY function in the bridge
+  that REGISTERS — `materialize-variant-plan` is pure and registers
+  nothing. There is no auto-register path: a generated failure becomes a
+  curated variant ONLY through this explicit, named call.
+
+  `opts` MUST carry `:variant/id` — the keyword id of the variant to
+  register (e.g. `:story.checkout/regression-042`). A missing id throws
+  `:rf.error/story-promote-no-id`: registration without a name is exactly
+  the auto-register the projection rule forbids.
+
+  `opts` MAY also carry the `artifact->variant-body` slots (`:setup` /
+  `:script` / `:setup-count` / `:doc` / `:extends` / `:tags` / `:args`).
+
+  Builds the same variant body `materialize-variant-plan` compiles —
+  preconditions on `:setup`, behaviour on `:script`, the source-artifact
+  link on `:run-artifact` — and writes it into the Story side-table via
+  `re-frame.story.registrar/reg-variant*` (the same write path the
+  `reg-variant` macro expands to: shape validation, `:extends`
+  resolution, source-coord stamping). The registered variant is
+  indistinguishable from a hand-authored one except for its
+  `:run-artifact` provenance slot.
+
+  Production CLJS builds (`config/enabled?` false) short-circuit before
+  the write and return nil, mirroring `save-variant`.
+
+  Returns the registered variant id on success (the value
+  `reg-variant*` returns)."
+  [artifact {:keys [variant-id] :as opts}]
+  (let [variant-id (or variant-id (:variant/id opts))]
+    (when (nil? variant-id)
+      (throw (ex-info ":rf.error/story-promote-no-id"
+                      {:rf.error/id :rf.error/story-promote-no-id
+                       :where       'rf.story/promote-run-artifact!
+                       :recovery    :supply-variant-id
+                       :reason      (str "re-frame2-story: promote-run-artifact! "
+                                         "requires an explicit :variant/id — a run "
+                                         "artifact is never auto-registered (spec/017 "
+                                         "§Promotion).")
+                       :artifact    (provenance-link artifact)})))
+    (when config/enabled?
+      (let [body (artifact->variant-body artifact opts)]
+        (registrar/reg-variant* variant-id body)))))

--- a/tools/story/test/re_frame/story/promotion_test.cljc
+++ b/tools/story/test/re_frame/story/promotion_test.cljc
@@ -1,0 +1,207 @@
+(ns re-frame.story.promotion-test
+  "Tests for the run-artifact → variant promotion bridge (rf2-5x1wt.25,
+  spec/017-Testing-Story.md §Promotion — Promotion bridge; NewTestStory
+  §C1).
+
+  Two layers, both under `clojure -M:test` (JVM) + the node-runtime CLJS
+  build:
+
+  - PURE `materialize-variant-plan` (§C1 bullets 1, 2, 4): a run artifact
+    becomes a readable normalized plan; the plan preserves the source
+    artifact link; the program projects into setup/script per the policy.
+    Side-effect-free — these tests assert it registers NOTHING.
+  - The explicit `promote-run-artifact!` registration path (§C1 bullet 3):
+    promotion does NOT auto-register without the explicit named call; the
+    explicit call registers a variant carrying the source link.
+
+  The variant-plan compiler is pure data → data and the registrar is a
+  pure side-table, so every test runs on both targets with no host — a
+  fresh side-table per test via the fixture, and an explicit `:lookup`
+  for `:extends` resolution where needed."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.story :as story]
+            [re-frame.story.artifact :as artifact]
+            [re-frame.story.promotion :as promotion]
+            [re-frame.story.registrar :as registrar]))
+
+;; ---- fixtures -----------------------------------------------------------
+;;
+;; Standard `clojure.test` fixture FUNCTION (not the `{:before …}` map
+;; form): a one-arg fn that resets the Story side-table to empty, runs
+;; the test, and the promotion path repopulates only what it registers.
+;; Matches the `artifact_test` fixture shape — the function form runs on
+;; both the JVM `clojure -M:test` runner and the node CLJS build.
+
+(defn reset-side-table! [t]
+  (registrar/clear-all!)
+  (t))
+
+(use-fixtures :each reset-side-table!)
+
+;; ---- helpers ------------------------------------------------------------
+
+(defn- sample-artifact
+  "A run artifact with a two-step dispatch program + a stubbed fx
+  decision + provenance slots + bulky captured evidence (so the
+  provenance-trim assertions have something to drop)."
+  []
+  (artifact/make-run-artifact
+    {:event-program [[:dispatch [:counter/init 5]]
+                     [:dispatch [:counter/inc]]]
+     :seed          42
+     :fx-decisions  {:http/get :http/stub}
+     :created-at    "2026-05-30T00:00:00Z"
+     :source        {:tool :recorder}
+     ;; bulky captured evidence the promotion link MUST drop:
+     :epoch-tape    [{:big :tape}]
+     :trace         [{:big :trace}]
+     :result        {:status :fail}}))
+
+;; ===========================================================================
+;; §C1 bullet 1 — a run artifact becomes a readable normalized plan
+;; ===========================================================================
+
+(deftest materialize-produces-readable-plan
+  (testing "a run artifact materializes to the normalized four-bucket plan"
+    (let [art  (sample-artifact)
+          plan (promotion/materialize-variant-plan art)]
+      (is (contains? plan :world))
+      (is (contains? plan :script))
+      (is (contains? plan :expect))
+      (is (map? (:expect plan)))
+      (is (= #{:client} (get-in plan [:world :platforms]))
+          "the plan carries the compiler's normalized defaults")))
+
+  (testing "the default policy projects the whole program into :script"
+    (let [art  (sample-artifact)
+          plan (promotion/materialize-variant-plan art)]
+      (is (= [[:dispatch [:counter/init 5]]
+              [:dispatch [:counter/inc]]]
+             (:script plan)))
+      (is (= [] (get-in plan [:world :setup]))
+          "nothing is demoted to a silent precondition without a hint")))
+
+  (testing "a :variant/id rides onto the materialized plan"
+    (let [art  (sample-artifact)
+          plan (promotion/materialize-variant-plan
+                 art {:variant/id :story.counter/regression-042})]
+      (is (= :story.counter/regression-042 (:variant/id plan))))))
+
+;; ===========================================================================
+;; §C1 bullet 4 — generated event program becomes script/setup per policy
+;; ===========================================================================
+
+(deftest program-projects-to-setup-and-script-per-policy
+  (testing ":setup-count cuts preconditions off the front into [:world :setup]"
+    (let [art  (sample-artifact)
+          plan (promotion/materialize-variant-plan art {:setup-count 1})]
+      (is (= [[:dispatch [:counter/init 5]]] (get-in plan [:world :setup]))
+          "the first step is a precondition")
+      (is (= [[:dispatch [:counter/inc]]] (:script plan))
+          "the rest is behaviour-under-test")))
+
+  (testing "an explicit :setup + :script partition is used verbatim"
+    (let [art  (sample-artifact)
+          plan (promotion/materialize-variant-plan
+                 art {:setup  [[:dispatch [:seed/a]]]
+                      :script [[:dispatch [:act/b]]]})]
+      (is (= [[:dispatch [:seed/a]]] (get-in plan [:world :setup])))
+      (is (= [[:dispatch [:act/b]]] (:script plan)))))
+
+  (testing "partition-program clamps an oversized :setup-count"
+    (let [art (sample-artifact)
+          {:keys [setup script]} (promotion/partition-program art {:setup-count 99})]
+      (is (= 2 (count setup)) "every step becomes a precondition")
+      (is (= [] script))))
+
+  (testing "a bare event list in :script lifts to a tagged [:dispatch …] program"
+    (let [art  (sample-artifact)
+          plan (promotion/materialize-variant-plan
+                 art {:script [[:counter/reset]]})]
+      (is (= [[:dispatch [:counter/reset]]] (:script plan))))))
+
+;; ===========================================================================
+;; §C1 bullet 2 — promotion preserves the source-artifact link
+;; ===========================================================================
+
+(deftest materialize-preserves-source-artifact-link
+  (testing "the plan carries a :run-artifact back-link to the source"
+    (let [art  (sample-artifact)
+          plan (promotion/materialize-variant-plan art)
+          link (:run-artifact plan)]
+      (is (= :rf.test/run-artifact (:artifact/kind link)))
+      (is (= 42 (:seed link)))
+      (is (= {:http/get :http/stub} (:fx-decisions link)))
+      (is (= {:tool :recorder} (:source link)))
+      (is (= [[:dispatch [:counter/init 5]]
+              [:dispatch [:counter/inc]]]
+             (:event-program link))
+          "the replayable program survives on the link")))
+
+  (testing "the link is TRIMMED — bulky captured evidence is dropped"
+    (let [link (:run-artifact (promotion/materialize-variant-plan (sample-artifact)))]
+      (is (not (contains? link :epoch-tape)))
+      (is (not (contains? link :trace)))
+      (is (not (contains? link :result))
+          "a registered variant is a curation surface, not an evidence dump")))
+
+  (testing "the promoted variant body also carries the source link"
+    (let [body (promotion/artifact->variant-body (sample-artifact))]
+      (is (= :rf.test/run-artifact (get-in body [:run-artifact :artifact/kind]))))))
+
+;; ===========================================================================
+;; §C1 bullet 3 — promotion does NOT auto-register without the explicit call
+;; ===========================================================================
+
+(deftest materialize-registers-nothing
+  (testing "materialize-variant-plan is pure — it registers NO variant"
+    (let [art (sample-artifact)]
+      (promotion/materialize-variant-plan art {:variant/id :story.counter/never})
+      (is (not (registrar/registered? :variant :story.counter/never))
+          "materialize must not touch the side-table")
+      (is (empty? (registrar/registrations :variant))
+          "the side-table stays empty after materialization"))))
+
+(deftest promote-requires-explicit-variant-id
+  (testing "promote-run-artifact! throws without an explicit :variant/id"
+    (let [art (sample-artifact)]
+      (is (thrown-with-msg?
+            #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
+            #"story-promote-no-id"
+            (promotion/promote-run-artifact! art {})))
+      (is (empty? (registrar/registrations :variant))
+            "a no-id promotion registers nothing"))))
+
+(deftest promote-registers-the-named-variant
+  (testing "the explicit named call DOES register a curated variant"
+    (let [art (sample-artifact)
+          ret (promotion/promote-run-artifact!
+                art {:variant/id :story.counter/regression-042})]
+      (is (= :story.counter/regression-042 ret)
+          "promote returns the registered variant id")
+      (is (registrar/registered? :variant :story.counter/regression-042)
+          "the variant is now in the side-table")))
+
+  (testing "the registered body carries the source-artifact link + the program"
+    (registrar/clear-all!)
+    (let [art (sample-artifact)]
+      (promotion/promote-run-artifact!
+        art {:variant/id :story.counter/regression-042})
+      (let [body (registrar/handler-meta :variant :story.counter/regression-042)]
+        (is (= :rf.test/run-artifact (get-in body [:run-artifact :artifact/kind]))
+            "provenance survives into the registered variant")
+        ;; The registrar lowers the public `:script` bare step-vector to
+        ;; the shipping `:play-script` slot (still a bare step vector).
+        (is (= [[:dispatch [:counter/init 5]]
+                [:dispatch [:counter/inc]]]
+               (:play-script body))
+            "the behaviour program is the registered play script"))))
+
+  (testing "the facade re-exports route to the same bridge"
+    (registrar/clear-all!)
+    (let [art (sample-artifact)]
+      (is (contains? (story/materialize-variant-plan art) :run-artifact))
+      (is (= :story.counter/from-facade
+             (story/promote-run-artifact!
+               art {:variant/id :story.counter/from-facade})))
+      (is (registrar/registered? :variant :story.counter/from-facade)))))


### PR DESCRIPTION
## What

Adds the run-artifact → plan/variant **promotion bridge** (NewTestStory Plan §C1) in a new `re-frame.story.promotion` namespace, re-exported on the `re-frame.story` facade.

```clojure
(story/materialize-variant-plan artifact opts)        ;; run artifact -> a readable normalized plan
(story/promote-run-artifact! artifact {:variant/id variant-id})  ;; promote a curated failure into a NAMED Story variant
```

### Design

- **`materialize-variant-plan` (PURE):** projects a `:rf.test/run-artifact` into the four-bucket authoring shape and compiles it through the `.10` `variant-plan` compiler **read-only**, returning a readable normalized `:world` / `:script` / `:expect` plan. Side-effect-free — registers NOTHING. Use it to READ what a promotion would produce.
- **`promote-run-artifact!` (IMPURE):** the **only** registering path. MUST be called with an explicit `:variant/id` (a missing id throws `:rf.error/story-promote-no-id`) — there is no auto-register path. Writes the curated variant via the existing `reg-variant` write path (`registrar/reg-variant*`); production builds short-circuit on `config/enabled?`.
- **Source-artifact link:** both the plan and the promoted variant body preserve a back-link on `:run-artifact` (the same slot a replay run-result carries), as a TRIMMED provenance view — keeps the replayable + identifying core, drops the bulky `:epoch-tape` / `:trace` / `:result`.
- **Setup/script projection rule:** the artifact's `:event-program` projects to `[:world :setup]` (preconditions) vs `:script` (behaviour) per policy — `:setup-count n`, an explicit `:setup` + `:script` partition, or the default (whole program → `:script`).

### Scope discipline

- New `promotion` ns + tests; 2 appended re-exports on `story.cljc` (+ one require line); a new `### Promotion bridge` subsection within the existing `## Promotion` heading in `spec/017`.
- Did **not** touch `plan.cljc` / `schemas.cljc` (.14's lane), `artifact.cljc` (.7), `fingerprint.cljc` / the determinism ns (.8), or `deps.edn`. The `.10` compiler + `.7` artifact ns are consumed read-only.

## Tests (§C1 acceptance bullets)

- run artifact becomes a readable plan
- promotion preserves the source-artifact link (incl. the bulky-evidence trim)
- promotion does NOT auto-register without the explicit `promote-run-artifact!` call
- generated event program becomes script/setup per policy

Pure JVM-testable `materialize-variant-plan` + a focused test of the explicit `promote-run-artifact!` registration path. `.cljc` so it runs on both the JVM and node CLJS targets.

## Quality gates

- `cd tools/story && clojure -M:test` → **973 tests, 2967 assertions, 0 failures, 0 errors** (+6 deftests / +35 assertions from this PR)
- `npm --prefix implementation run test:cljs` → **4847 tests, 15879 assertions, 0 failures, 0 errors**
- `bash scripts/test-fast-pr.sh` → **PASS** (CLJS spine green + README/docs anchor validators PASS; mkdocs `--strict` soft-skipped locally, CI runs it)

## Note for follow-up

While wiring the test I found a pre-existing latent bug: `.cljc` test namespaces that use the non-standard `(use-fixtures :each {:before f})` **map** fixture form (e.g. `xray_preset_test.cljc`) are **silently skipped** by the JVM `clojure -M:test` runner — the map is treated as a fixture fn that never calls the wrapped test. This PR's test uses the standard one-arg fixture-fn form (matching `artifact_test.cljc`) and runs correctly. Worth a separate bead to sweep the map-form fixtures.