### PR TITLE
feat(story): strict composition — fragments, checks, variant-owned-wins (rf2-5x1wt.15)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -788,6 +788,116 @@ is still mandatory: `explain` MUST list resolved strict conflicts,
 unresolved strict conflicts, winning sources, losing sources, and the
 priority rule that chose the winner.
 
+## Strict composition
+
+This section pins the implemented `reg-fragment` / `reg-check` / `:compose`
+contract (rf2-5x1wt.15) — the concrete surface the plan compiler enforces
+on top of the conceptual model in §`:compose` / §Merge rules / §Conflict
+resolution above. It is the authoritative reference for what an
+implementation MUST accept, reject, and order.
+
+### `reg-fragment` and `reg-check`
+
+```clojure
+(story/reg-fragment id body)   ;; reusable setup/script/world mixin
+(story/reg-check    id body)   ;; named, reusable assertion pack
+```
+
+Both register into the Story side-table under new kinds — `:fragment` and
+`:check` — queryable through the existing registry surface
+(`(story/registered? :fragment id)`, `(story/handler-meta :check id)`).
+Fragment and check ids are bare keywords; the example shapes
+(`:fragment.<path>/<name>`, `:check/<name>`) are a convention, not a
+locked grammar.
+
+A **fragment body** carries world/behaviour only — `:args`, `:argtypes`,
+`:setup` (or `:events`), `:script` (or `:play-script`), `:network`,
+`:fx-overrides`, `:interceptor-overrides`, `:loaders`,
+`:loaders-teardown`, `:decorators`. It MUST NOT carry judgement
+(`:checks` / `:assertions`) and MUST NOT carry `:compose` or `:extends`
+(flat-fragment rule, below). The body is stored verbatim — the compiler
+normalizes both the public (`:setup` / `:script`) and shipping (`:events`
+/ `:play-script`) spellings at compose time.
+
+A **check body** carries `:assertions` (required) and an optional `:doc`.
+It carries no world or behaviour. Check identity is preserved end-to-end
+(below).
+
+### `:compose` resolution
+
+A variant (or inline plan) names registered fragments and checks in a
+`:compose [id …]` vector, applied in **declared order**. The compiler
+resolves each id against the fragment registry first, then the check
+registry; an id matching neither FAILS plan construction with
+`:rf.error/story-compose-unknown`.
+
+`:compose` is a **child-only directive** — like `:extends`, it is not
+itself inherited down an `:extends` chain. It is applied at step 3 of the
+total resolution order, between the parent-chain merge (step 2) and the
+variant-owned values (step 4).
+
+### Flat fragments
+
+A composed fragment that itself carries `:compose` or `:extends` FAILS
+with `:rf.error/story-compose-nested-fragment`. The `Fragment` schema
+rejects both at registration; the compiler re-checks at compose time as
+the load-bearing guard (a programmatic registration or an inline plan may
+bypass the macro/schema path). This makes cycles impossible in P1 — there
+is no fragment DAG (a P1 non-goal).
+
+### Total merge order (as implemented)
+
+For a variant with parent chain `[root … parent child]` and a `:compose`
+list of fragments `F1 … Fn`:
+
+| Slot | Rule |
+|---|---|
+| `:setup` | APPEND: inherited (root→parent) ++ composed fragments (declared order) ++ child's own — variant-owned setup lands last. |
+| `:script` | APPEND through `:compose` only: composed fragments (declared order) ++ child's own. Parent scripts never append (a child does not silently run a parent's behaviour). |
+| `:args` / `:argtypes` | DEEP-MERGE root → fragments → child (last wins). |
+| `:checks` | inherited+own (root→child) ++ composed check-ids. |
+| `:assertions` | child-only (own terminal judgement). |
+| `:network` | per-route merge: composed fragments under the variant chain. |
+| `:fx-overrides` / `:interceptor-overrides` | strict-conflict, per-key (below). |
+
+### Variant-owned-wins for strict-conflict fields
+
+The strict-conflict fields are the override **maps** `:fx-overrides` and
+`:interceptor-overrides`, resolved **per key**:
+
+- the variant chain OWNS any key it set directly (the parent-chain-merged
+  value, where `:extends` context flowed down) — composed fragments only
+  fill keys the variant left unset;
+- exactly one composed fragment setting a key → that value fills it;
+- two+ composed fragments setting the same key to the **same** value → no
+  conflict;
+- two+ composed fragments setting the same key to **different** values
+  while the variant is silent → **HARD ERROR**
+  (`:rf.error/story-compose-conflict`), carrying every conflicting
+  `{:field :key :sources :values}`. The variant resolves it by stating the
+  wanted value directly in its body (which then wins per variant-owned).
+
+`explain` records the settled conflicts under `:strict-conflicts` — each
+`{:field :key :winner :winning-source :losing-sources :rule}` — and the
+resolved `:compose` entries under `:compose` (classified `:fragment` vs
+`:check`). Unresolved conflicts throw, so `:strict-conflicts` only ever
+lists conflicts the priority ladder settled.
+
+### No `:resolve-conflicts` in P1
+
+There is no `:resolve-conflicts` escape hatch. The `Variant` schema
+rejects a `:resolve-conflicts` key with `:rf.error/variant-shape` — the
+absence is enforced, not merely undocumented. The only resolution is the
+variant-owned-wins priority ladder above.
+
+### Check identity is preserved
+
+A composed (or inherited) check rides the plan as its **id** in
+`[:expect :checks]`, never inlined into the assertion list. The runner
+expands a check-id into grouped assertions keyed by the check id, so a
+failed check result shows both the check id and the underlying assertion
+records (§Checks).
+
 ## Checks and assertions
 
 ### Assertions — one atom, two positions

--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -4,8 +4,10 @@
   registrar side-table, schemas, extends resolution) live under
   `re-frame.story.<sub-ns>`.
 
-  This namespace re-exports the seven `reg-*` macros, the registry
-  query helpers (`registrations` / `handler-meta` / `ids` /
+  This namespace re-exports the `reg-*` macros (`reg-story` /
+  `reg-variant` / `reg-fragment` / `reg-check` / `reg-workspace` /
+  `reg-mode` / `reg-story-panel` / `reg-decorator` / `reg-tag`), the
+  registry query helpers (`registrations` / `handler-meta` / `ids` /
   `variants-of` / `variants-with-tags`), the runtime entry points
   (`run-variant` / `reset-variant` / `watch-variant` / `variant->edn` /
   `snapshot-identity`), and the shell mount/unmount surface
@@ -130,9 +132,9 @@
   ;; without an explicit :require-macros clause at the call site.
   ;; Mirror of the `re-frame.core` :require-macros pattern.
   #?(:cljs (:require-macros
-             [re-frame.story :refer [reg-story reg-variant reg-workspace
-                                     reg-mode reg-story-panel reg-decorator
-                                     reg-tag]])))
+             [re-frame.story :refer [reg-story reg-variant reg-fragment
+                                     reg-check reg-workspace reg-mode
+                                     reg-story-panel reg-decorator reg-tag]])))
 
 ;; ---- macros (the seven reg-* forms) --------------------------------------
 ;;
@@ -211,6 +213,66 @@
      (macros/gen-reg-call (meta &form) *file*
                           (symbol (str (ns-name *ns*)))
                           `re-frame.story.registrar/reg-variant*
+                          id metadata)))
+
+#?(:clj
+   (defmacro reg-fragment
+     "Register a fragment — a reusable setup / script / world mixin a
+     variant pulls in through `:compose`. Per spec/017 §Fragments +
+     §Strict composition (rf2-5x1wt.15).
+
+     Fragment body shape — every key is data, no fn-valued slots:
+
+     ```
+     {:doc                   \"...\"
+      :args                  {<arg-key> <value>}
+      :setup                 [[:dispatch [:event-id ...]] ...]
+      :script                {:script [[:dispatch [:event-id ...]] ...]}
+      :network               {[method url] {:reply {:ok|:failure ...}}}
+      :fx-overrides          {<fx-id> <override>}
+      :interceptor-overrides {<interceptor-id> <override>}
+      :loaders               [[:loader-event-id ...]]
+      :decorators            [[:dec-id args...]]}
+     ```
+
+     **P1 fragments MUST be flat.** A fragment MUST NOT carry `:compose`
+     or `:extends` (the schema rejects both, so cycles are impossible).
+     Fragments carry world/behaviour, never judgement — no `:checks` /
+     `:assertions`. Compose a check by naming its id in the variant's
+     `:compose`; put own assertions on the variant.
+
+     When a variant composes two fragments that disagree on a strict-
+     conflict field (`:fx-overrides` / `:interceptor-overrides`) while the
+     variant is silent, plan construction fails — the variant owns its
+     end-state and resolves the conflict by stating the wanted value (no
+     `:resolve-conflicts` escape hatch in P1)."
+     [id metadata]
+     (macros/gen-reg-call (meta &form) *file*
+                          (symbol (str (ns-name *ns*)))
+                          `re-frame.story.registrar/reg-fragment*
+                          id metadata)))
+
+#?(:clj
+   (defmacro reg-check
+     "Register a check — a named, reusable assertion pack. Per spec/017
+     §Checks + §Strict composition (rf2-5x1wt.15).
+
+     Check body shape:
+
+     ```
+     {:doc        \"...\"
+      :assertions [[:rf.assert/no-warnings] ...]}    ;; required
+     ```
+
+     Checks are the inheritable expectation form: they inherit through
+     `:extends` and compose through `:compose` (distinct from a variant's
+     own-only `:assertions`, which do NOT inherit). Check identity (the
+     id) is preserved in the plan and in run results, so a failed check
+     shows both the check id and the underlying assertion records."
+     [id metadata]
+     (macros/gen-reg-call (meta &form) *file*
+                          (symbol (str (ns-name *ns*)))
+                          `re-frame.story.registrar/reg-check*
                           id metadata)))
 
 #?(:clj
@@ -494,6 +556,11 @@
 
 (def reg-story*       registrar/reg-story*)
 (def reg-variant*     registrar/reg-variant*)
+;; rf2-5x1wt.15 — fragment + check runtime helpers, grouped with the
+;; other registrar re-exports (strict composition: `:compose` pulls these
+;; into a variant plan).
+(def reg-fragment*    registrar/reg-fragment*)
+(def reg-check*       registrar/reg-check*)
 (def reg-workspace*   registrar/reg-workspace*)
 (def reg-mode*        registrar/reg-mode*)
 (def reg-story-panel* registrar/reg-story-panel*)

--- a/tools/story/src/re_frame/story/plan.cljc
+++ b/tools/story/src/re_frame/story/plan.cljc
@@ -581,6 +581,153 @@
             :fx-overrides author-fx-overrides})))
 
 ;; ============================================================================
+;; Strict composition — `:compose` fragments + checks (rf2-5x1wt.15)
+;; ============================================================================
+;;
+;; Per spec/017 §`:compose` / §Total resolution order / §Merge rules /
+;; §Conflict resolution: a variant (or inline plan) MAY pull in registered
+;; fragments and checks through `:compose [id ...]`, applied in declared
+;; order between the parent-chain merge (step 2) and the variant-owned
+;; values (step 4).
+;;
+;; - A FRAGMENT contributes world/behaviour: setup + script APPEND in
+;;   declared order; args/argtypes deep-merge; `:network`,
+;;   `:fx-overrides`, `:interceptor-overrides`, loaders, decorators fold
+;;   in. (Per §Merge rules script DOES append through `:compose` — unlike
+;;   `:extends`, where script never appends.)
+;; - A CHECK contributes its id to the inheritable `:expect :checks` list
+;;   (check identity preserved); its body is NOT inlined here — the runner
+;;   expands a check-id into grouped assertions, keyed by the check id, so
+;;   a failed check shows both the id and the underlying records.
+;;
+;; FLAT FRAGMENTS (§Fragments). A composed fragment that itself carries
+;; `:compose` (or `:extends`) is a hard error — `:rf.error/story-compose-
+;; nested-fragment` — so cycles are impossible in P1. The schema already
+;; rejects this at registration; the compiler re-checks because a
+;; programmatic registration may bypass the macro/schema path, and an
+;; inline plan may name a fragment whose body was hand-built.
+;;
+;; STRICT-CONFLICT FIELDS (§Merge rules / §Conflict resolution). The
+;; strict-conflict fields are the override MAPS `:fx-overrides` and
+;; `:interceptor-overrides`, resolved per-KEY:
+;;
+;;   - the variant OWNS any key it sets directly → variant-owned-wins;
+;;     composed fragments only fill keys the variant left unset;
+;;   - two composed fragments setting the SAME key to DIFFERENT values
+;;     while the variant is silent → HARD ERROR (`:rf.error/story-compose-
+;;     conflict`), resolved by the variant stating the wanted value;
+;;   - two composed fragments setting the same key to the SAME value → no
+;;     conflict (declared order, identical → fine);
+;;   - exactly one fragment setting a key → that value fills it.
+;;
+;; There is NO `:resolve-conflicts` escape hatch in P1 (the schema rejects
+;; it); the only resolution is the priority ladder above.
+
+(def ^:private strict-conflict-keys
+  "The context-map keys whose per-key composition is strict (§Merge rules
+  — Strict conflict). Each value is a `{id → override}` map; the conflict
+  is resolved per id, with the variant owning any id it sets directly."
+  [:fx-overrides :interceptor-overrides])
+
+(defn- fragment-append-keys
+  "Context keys a fragment APPENDS (vectors concatenated in declared
+  order) into the composing body. Setup + script are handled separately
+  (they coordinate with the parent-chain setup and the child script);
+  these are the remaining append-shaped world slots."
+  []
+  [:loaders :loaders-teardown :decorators])
+
+(defn- check-flat-fragment!
+  "FAIL with `:rf.error/story-compose-nested-fragment` when a composed
+  `fragment` body carries `:compose` or `:extends` — P1 fragments MUST be
+  flat (§Fragments). The schema rejects this at registration; this is the
+  compile-time guard for programmatic/inline paths."
+  [variant-id fragment-id fragment]
+  (when (or (contains? fragment :compose)
+            (contains? fragment :extends))
+    (fail! :rf.error/story-compose-nested-fragment
+           (str "re-frame2-story: fragment " fragment-id " composed by "
+                variant-id " carries "
+                (if (contains? fragment :compose) ":compose" ":extends")
+                " — P1 fragments MUST be flat (no fragment composing "
+                "another fragment); cycles are impossible in P1.")
+           {:variant/id  variant-id
+            :fragment/id fragment-id
+            :offending-key (if (contains? fragment :compose) :compose :extends)})))
+
+(defn- resolve-strict-conflict
+  "Resolve ONE strict-conflict override-map field across the composed
+  fragments + the variant-owned value. Pure data → data.
+
+  - `field` — `:fx-overrides` or `:interceptor-overrides`.
+  - `frag-contribs` — vector of `{:source fragment-id :map override-map}`
+    in declared order.
+  - `variant-owned` — the override map set DIRECTLY in the variant body
+    (nil/absent when the variant is silent).
+  - `variant-id` — for error/explain attribution.
+
+  Returns `{:merged {id → override} :resolved [...] :unresolved [...]}`:
+
+  - `:merged` is the final override map fed into `[:world :frame field]`.
+  - `:resolved` is the explain trail of strict conflicts the priority
+    ladder settled — each `{:field :key :winner :winning-source
+    :losing-sources :rule}`.
+  - `:unresolved` records any id where two fragments disagree AND the
+    variant is silent — a HARD conflict. The caller FAILS when this is
+    non-empty (the variant resolves it by stating the value).
+
+  Variant-owned-wins: a key the variant sets directly is owned by the
+  variant; composed fragments for that key become losing sources (the
+  variant value is the winner; no failure, even when fragments disagree)."
+  [field frag-contribs variant-owned variant-id]
+  (let [;; gather, per override id, the fragment sources that set it
+        ;; (in declared order) — {id [{:source :value} ...]}
+        by-id    (reduce
+                   (fn [acc {:keys [source map]}]
+                     (reduce-kv (fn [m k v]
+                                  (update m k (fnil conj [])
+                                          {:source source :value v}))
+                                acc map))
+                   {}
+                   frag-contribs)
+        owned?   (fn [k] (and (map? variant-owned) (contains? variant-owned k)))]
+    (reduce-kv
+      (fn [{:keys [merged resolved unresolved]} k contribs]
+        (let [distinct-vals (distinct (map :value contribs))]
+          (cond
+            ;; variant owns this key → variant-owned-wins (no conflict,
+            ;; even if fragments disagree); the fragment(s) lose.
+            (owned? k)
+            {:merged     merged   ; variant value is merged on top later
+             :resolved   (conj resolved
+                               {:field          field
+                                :key            k
+                                :winner         (get variant-owned k)
+                                :winning-source :variant
+                                :losing-sources (mapv :source contribs)
+                                :rule           :variant-owned-wins})
+             :unresolved unresolved}
+
+            ;; one distinct value across all contributing fragments →
+            ;; no conflict (identical, or a single fragment).
+            (= 1 (count distinct-vals))
+            {:merged     (assoc merged k (-> contribs first :value))
+             :resolved   resolved
+             :unresolved unresolved}
+
+            ;; two+ fragments disagree AND the variant is silent → HARD.
+            :else
+            {:merged     merged
+             :resolved   resolved
+             :unresolved (conj unresolved
+                               {:field   field
+                                :key     k
+                                :sources (mapv :source contribs)
+                                :values  (vec distinct-vals)})})))
+      {:merged {} :resolved [] :unresolved []}
+      by-id)))
+
+;; ============================================================================
 ;; Compiler
 ;; ============================================================================
 
@@ -621,6 +768,33 @@
                               "re-frame2-story: :view-lookup must be a fn or a map"
                               {:view-lookup view-lookup})))
 
+;; ---- fragment + check lookup (rf2-5x1wt.15) ------------------------------
+
+(defn- default-fragment-lookup
+  "Default fragment-body lookup — reads the Story side-table `:fragment`
+  kind. Production bundles elide the side-table; pure tests thread an
+  explicit `:fragment-lookup`."
+  [fragment-id]
+  (registrar/handler-meta :fragment fragment-id))
+
+(defn- default-check-lookup
+  "Default check-body lookup — reads the Story side-table `:check` kind."
+  [check-id]
+  (registrar/handler-meta :check check-id))
+
+(defn- coerce-kind-lookup
+  "Accept a 1-arg fn or a `{id → body}` map as a fragment/check lookup,
+  falling back to `default-fn` when nil. `opt-key` names the option for
+  the error message."
+  [opt-key lookup default-fn]
+  (cond
+    (nil? lookup) default-fn
+    (map? lookup) #(get lookup %)
+    (fn? lookup)  lookup
+    :else         (fail! :rf.error/story-bad-lookup
+                         (str "re-frame2-story: " opt-key " must be a fn or a map")
+                         {opt-key lookup})))
+
 (defn compile-body
   "Compile a raw variant `body` (the child) registered under `id` into a
   normalized plan. `lookup` is a 1-arg fn returning raw parent bodies.
@@ -636,13 +810,45 @@
   - `:validator-fns` — `{:validate (fn [schema value]) :explain (fn …)}`
     used for malformed-value checking of `:effective-args` (§View arg
     schemas). With no validator only required-key presence is checked
-    (the host-free floor)."
+    (the host-free floor).
+  - `:fragment-lookup` / `:check-lookup` — a 1-arg fn `(id) → body` OR a
+    `{id → body}` map resolving the bodies named in `:compose`
+    (rf2-5x1wt.15). Default to the Story side-table `:fragment` / `:check`
+    kinds."
   ([id body lookup] (compile-body id body lookup nil))
-  ([id body lookup {:keys [view-lookup validator-fns] :as _opts}]
+  ([id body lookup {:keys [view-lookup validator-fns
+                           fragment-lookup check-lookup] :as _opts}]
   (let [view-lookup  (coerce-view-lookup view-lookup)
+        frag-lookup  (coerce-kind-lookup :fragment-lookup fragment-lookup
+                                         default-fragment-lookup)
+        chk-lookup   (coerce-kind-lookup :check-lookup check-lookup
+                                         default-check-lookup)
         chain        (resolve-source-chain id body lookup)
         bodies       (map :body chain)         ; root-first
+        inherited    (vec (butlast bodies))    ; root → immediate parent
         child        (:body (last chain))
+        ;; ---- :compose resolution (rf2-5x1wt.15, §Total resolution order
+        ;; step 3 — applied BETWEEN the parent merge and the variant-owned
+        ;; values). `:compose` is a child-only directive (like `:extends`);
+        ;; it is not inherited. Each entry resolves to a fragment OR a
+        ;; check; an unregistered id FAILS. Composed fragments are checked
+        ;; FLAT (no nested :compose/:extends).
+        compose-ids  (vec (:compose child))
+        composed     (mapv
+                       (fn [cid]
+                         (if-let [frag (frag-lookup cid)]
+                           (do (check-flat-fragment! id cid frag)
+                               {:kind :fragment :id cid :body frag})
+                           (if-let [chk (chk-lookup cid)]
+                             {:kind :check :id cid :body chk}
+                             (fail! :rf.error/story-compose-unknown
+                                    (str "re-frame2-story: :compose on " id
+                                         " references unregistered fragment/check "
+                                         cid)
+                                    {:variant/id id :compose/id cid}))))
+                       compose-ids)
+        frag-layers  (->> composed (filter #(= :fragment (:kind %))) (mapv :body))
+        composed-checks (->> composed (filter #(= :check (:kind %))) (mapv :id))
         ;; ---- context merge (root→child) ----
         ctx          (reduce
                        (fn [acc layer]
@@ -653,40 +859,96 @@
                                  acc context-keys))
                        {}
                        bodies)
-        ;; checks inherit; build the inherited+own check list root→child
-        checks       (reduce (fn [acc layer]
-                               (into acc (:checks layer)))
-                             []
-                             bodies)
-        ;; setup APPENDS root→child (§Merge rules)
-        setup-raw    (vec (mapcat (fn [layer] (or (pick-setup layer) [])) bodies))
-        ;; script + terminal assertions are CHILD-ONLY (verdict is local)
-        {:keys [script scripts]} (normalize-scripts child)
+        ;; checks inherit root→child (incl. the child's own :checks); the
+        ;; composed check-ids append after (declared order; identity kept).
+        checks       (-> (reduce (fn [acc layer] (into acc (:checks layer)))
+                                 [] bodies)
+                         (into composed-checks))
+        ;; setup APPENDS: inherited (root→parent), THEN composed fragments
+        ;; (declared order), THEN the variant's own setup — variant-owned
+        ;; values land last (§Merge rules + §Total resolution order).
+        setup-raw    (vec (concat
+                            (mapcat (fn [l] (or (pick-setup l) [])) inherited)
+                            (mapcat (fn [l] (or (pick-setup l) [])) frag-layers)
+                            (or (pick-setup child) [])))
+        ;; script APPENDS through `:compose` only (never through
+        ;; `:extends`): composed-fragment scripts in declared order, THEN
+        ;; the child's own script (§Merge rules). Each fragment's script is
+        ;; coerced the same way the child's is.
+        compose-script (vec (mapcat (fn [l] (:script (normalize-scripts l)))
+                                    frag-layers))
+        {child-script :script scripts :scripts} (normalize-scripts child)
+        script       (vec (concat compose-script child-script))
+        ;; terminal assertions are CHILD-ONLY (verdict is local)
         assertions   (vec (:assertions child))
-        ;; ---- args ----
-        arg-map      (reduce (fn [m layer] (args/deep-merge m (:args layer)))
-                             {} bodies)
-        argtypes     (reduce (fn [m layer] (args/deep-merge m (:argtypes layer)))
-                             {} bodies)
+        ;; ---- args: inherited deep-merge, THEN composed fragments, THEN
+        ;; the child's own — variant args win over composed/inherited (the
+        ;; layers go root → fragments → child, last-wins per deep-merge).
+        merge-key    (fn [k]
+                       (reduce (fn [m l] (args/deep-merge m (get l k)))
+                               {}
+                               (concat inherited frag-layers [child])))
+        arg-map      (merge-key :args)
+        argtypes     (merge-key :argtypes)
         ;; ---- arg substitution ----
         subs!        (atom [])
         setup        (substitute-args setup-raw arg-map subs!)
         script*      (substitute-args script arg-map subs!)
         sub-overrides (substitute-args (:sub-overrides ctx) arg-map subs!)
+        ;; ---- strict-conflict composition (rf2-5x1wt.15) ----
+        ;; The strict-conflict override MAPS (`:fx-overrides` /
+        ;; `:interceptor-overrides`) compose per-KEY: the variant chain
+        ;; OWNS any key it set (variant-owned-wins), composed fragments
+        ;; fill the rest, and two fragments disagreeing on a key while the
+        ;; variant is silent is a HARD conflict (§Conflict resolution). The
+        ;; variant-owned value is the parent-chain-merged `ctx` slot (the
+        ;; variant + its ancestors, where `:extends` context flowed down).
+        strict-res   (into {}
+                           (map (fn [field]
+                                  (let [contribs (mapv (fn [{:keys [id body]}]
+                                                         {:source id
+                                                          :map    (get body field)})
+                                                       (filter #(= :fragment (:kind %)) composed))
+                                        contribs (filterv #(map? (:map %)) contribs)]
+                                    [field (resolve-strict-conflict
+                                             field contribs (get ctx field) id)])))
+                           strict-conflict-keys)
+        unresolved   (mapcat :unresolved (vals strict-res))
+        _            (when (seq unresolved)
+                       (fail! :rf.error/story-compose-conflict
+                              (str "re-frame2-story: variant " id
+                                   " — composed fragments conflict on strict field(s) "
+                                   "while the variant is silent: "
+                                   (pr-str (mapv (fn [u] [(:field u) (:key u)]) unresolved))
+                                   ". The variant owns its end-state — state the "
+                                   "wanted value directly in the variant body "
+                                   "(§Conflict resolution; no :resolve-conflicts in P1).")
+                              {:variant/id id :conflicts (vec unresolved)}))
+        ;; Final strict-override maps: composed contributions (the keys no
+        ;; variant value owns) UNDER the variant-owned map (variant wins).
+        composed-fx  (get-in strict-res [:fx-overrides :merged])
+        composed-ic  (get-in strict-res [:interceptor-overrides :merged])
+        ctx-fx       (merge composed-fx (:fx-overrides ctx))
+        ctx-ic       (merge composed-ic (:interceptor-overrides ctx))
         ;; ---- network world slot (rf2-5x1wt.14) ----
         ;; Per-route replies may carry `[:arg key]` placeholders (e.g. a
         ;; stubbed id driven by a control), so substitute before lowering.
-        network      (substitute-args (:network ctx) arg-map subs!)
+        ;; `:network` composes through the parent chain (ctx) + composed
+        ;; fragments' route maps (later wins per declared order, then the
+        ;; variant chain).
+        frag-network (reduce (fn [m l] (merge m (:network l))) {} frag-layers)
+        network      (substitute-args (merge frag-network (:network ctx)) arg-map subs!)
         ;; `:network` and an explicit `:fx-overrides` on :rf.http/managed
         ;; both own the same fx — that is a hard conflict (§Network stubs).
-        _            (check-network-fx-conflict! id (:fx-overrides ctx) network)
+        _            (check-network-fx-conflict! id ctx-fx network)
         ;; Lower the route map to the managed-stub fx override; nil when
         ;; there are no routes. The derived `:fx-overrides` merges UNDER any
         ;; non-managed author overrides (the conflict above already ruled
         ;; out a managed-targeting author override).
         network-low  (lower-network network)
         fx-overrides (merge (when network-low (:fx-overrides network-low))
-                            (:fx-overrides ctx))
+                            ctx-fx)
+        interceptor-overrides ctx-ic
         ;; ---- view arg schema + effective-args validation (rf2-5x1wt.12) ----
         ;; `:effective-args` at plan time IS the resolved arg-map; the
         ;; render path layers control-panel overrides on top later. We
@@ -733,7 +995,7 @@
                        ;; override into the frame's `:fx-overrides` below.
                        (seq network)          (assoc :network network)
                        (seq fx-overrides)     (assoc-in [:frame :fx-overrides] fx-overrides)
-                       (contains? ctx :interceptor-overrides) (assoc-in [:frame :interceptor-overrides] (:interceptor-overrides ctx))
+                       (seq interceptor-overrides) (assoc-in [:frame :interceptor-overrides] interceptor-overrides)
                        (contains? ctx :loaders)     (assoc :loaders (:loaders ctx))
                        (contains? ctx :loaders-teardown) (assoc :loaders-teardown (:loaders-teardown ctx))
                        (contains? ctx :decorators)  (assoc :decorators (:decorators ctx))
@@ -743,14 +1005,28 @@
                        (contains? ctx :background)  (assoc :background (:background ctx))
                        (contains? ctx :xray)        (assoc :xray (:xray ctx))
                        (contains? ctx :component)   (assoc :component (:component ctx)))
+        resolved-conflicts (vec (mapcat :resolved (vals strict-res)))
         explain      {:source-chain (mapv :variant/id chain)
                       :parent-chain (mapv :variant/id (butlast chain))
-                      :compose      []          ; foundation: no fragments/checks compose yet
-                      :merge        {:setup      :append-root-to-child
-                                     :args       :deep-merge-root-to-child
-                                     :checks     :inherit-root-to-child
+                      ;; rf2-5x1wt.15 — the resolved `:compose` entries, in
+                      ;; declared order, classified fragment vs check (§Explain
+                      ;; API — composed fragments/checks).
+                      :compose      (mapv (fn [{:keys [kind id]}] {:kind kind :id id})
+                                          composed)
+                      ;; resolved strict conflicts: winning + losing sources +
+                      ;; the rule that chose the winner (§Conflict resolution —
+                      ;; explain MUST list these). Unresolved conflicts throw
+                      ;; upstream, so this slot only ever lists settled ones.
+                      :strict-conflicts resolved-conflicts
+                      :merge        {:setup      :append-inherited-compose-own
+                                     :args       :deep-merge-inherited-compose-own
+                                     :checks     :inherit-then-compose
                                      :assertions :child-only
-                                     :script     :child-only}
+                                     ;; script appends through :compose only,
+                                     ;; never through :extends (§Merge rules).
+                                     :script     :compose-then-child
+                                     :fx-overrides :strict-variant-owned-wins
+                                     :interceptor-overrides :strict-variant-owned-wins}
                       :args         arg-map
                       :substitutions @subs!
                       :effective-args eff-args
@@ -810,6 +1086,9 @@
   - `:validator-fns` — `{:validate (fn …) :explain (fn …)}` for
     malformed-value checking of `:effective-args`; with none supplied
     only required-key presence is checked.
+  - `:fragment-lookup` / `:check-lookup` — a 1-arg fn `(id) → body` OR a
+    `{id → body}` map resolving the bodies named in `:compose`
+    (rf2-5x1wt.15). Default to the side-table `:fragment` / `:check` kinds.
 
   Returns the normalized plan map: `:variant/id`, `:source-chain`,
   `:world` (incl. `:effective-args` and `:view-args-schema` when a view
@@ -818,12 +1097,14 @@
 
   FAILS with a structured `:rf.error/story-*` ex-info on: an unregistered
   keyword target, an unregistered `:extends` parent, an `:extends` cycle,
-  a missing `[:arg key]`, or `:effective-args` that violate the view-args
-  schema (`:rf.error/story-view-args-invalid`)."
+  a missing `[:arg key]`, an unregistered/nested `:compose` fragment, a
+  silent strict-conflict between composed fragments, or `:effective-args`
+  that violate the view-args schema (`:rf.error/story-view-args-invalid`)."
   ([target] (variant-plan target nil))
   ([target {:keys [lookup] :as opts}]
    (let [lookup-fn    (coerce-lookup lookup)
-         compile-opts (select-keys opts [:view-lookup :validator-fns])]
+         compile-opts (select-keys opts [:view-lookup :validator-fns
+                                         :fragment-lookup :check-lookup])]
      (cond
        (keyword? target)
        (if-let [body (lookup-fn target)]

--- a/tools/story/src/re_frame/story/registrar.cljc
+++ b/tools/story/src/re_frame/story/registrar.cljc
@@ -22,6 +22,8 @@
 
   - `:story` — parent of variants
   - `:variant` — concrete scenario; one per frame at runtime (Stage 3)
+  - `:fragment` — reusable setup/script/world mixin composed via `:compose`
+  - `:check` — reusable assertion pack composed via `:compose` / inherited
   - `:workspace` — layout artefact
   - `:mode` — saved-tuple of args
   - `:story-panel` — extension hook into the story-tool's chrome
@@ -101,6 +103,8 @@
 (defn- fresh-table []
   {:story       {}
    :variant     {}
+   :fragment    {}
+   :check       {}
    :workspace   {}
    :mode        {}
    :story-panel {}
@@ -254,6 +258,8 @@
   (let [ok? (case kind
               :story       schemas/story-id?
               :variant     schemas/variant-id?
+              :fragment    schemas/fragment-id?
+              :check       schemas/check-id?
               :workspace   schemas/workspace-id?
               :mode        schemas/mode-id?
               ;; story-panel, decorator, tag — any keyword.
@@ -357,6 +363,43 @@
                      (->> (validate-shape! :variant id)))
         _        (validate-tag-membership! id (:tags body))]
     (swap! kind->id->body assoc-in [:variant id] body)
+    (bump-tick!)
+    id))
+
+(defn reg-fragment*
+  "Runtime helper for `reg-fragment` macro (rf2-5x1wt.15). A fragment is a
+  reusable setup/script/world mixin a variant pulls in through `:compose`.
+
+  Validates the body against the `Fragment` schema — which enforces the
+  flat-fragment rule (a fragment MUST NOT carry `:compose` / `:extends`)
+  and the world/behaviour-only shape (no `:checks` / `:assertions`). The
+  body is stored verbatim (un-lowered): the plan compiler normalizes both
+  `:setup`/`:events` and `:script`/`:play-script` spellings at compose
+  time, so the fragment keeps the author's spelling."
+  [id body]
+  (maybe-auto-install!)
+  (assert-id! :fragment id)
+  (let [body (-> body
+                 merge-coords
+                 (->> (validate-shape! :fragment id)))]
+    (swap! kind->id->body assoc-in [:fragment id] body)
+    (bump-tick!)
+    id))
+
+(defn reg-check*
+  "Runtime helper for `reg-check` macro (rf2-5x1wt.15). A check is a named,
+  reusable assertion pack — the inheritable expectation form. Validates the
+  body against the `Check` schema (`:assertions` required, no
+  world/behaviour). Check identity (the id) is preserved by the plan
+  compiler and by run results so a failed check shows its id alongside the
+  underlying assertion records."
+  [id body]
+  (maybe-auto-install!)
+  (assert-id! :check id)
+  (let [body (-> body
+                 merge-coords
+                 (->> (validate-shape! :check id)))]
+    (swap! kind->id->body assoc-in [:check id] body)
     (bump-tick!)
     id))
 

--- a/tools/story/src/re_frame/story/schemas.cljc
+++ b/tools/story/src/re_frame/story/schemas.cljc
@@ -109,6 +109,26 @@
                   (and (>= (count ns) 5)
                        (= (subs ns 0 5) "Mode.")))))))
 
+(defn fragment-id?
+  "True iff `id` is a keyword id for a `reg-fragment` (rf2-5x1wt.15). The
+  spec/017 §Strict composition example shape is
+  `:fragment.<path>/<name>` (e.g. `:fragment.checkout/cart-with-sku`),
+  but fragments are anonymous reusable mixins with no story lineage, so
+  the grammar is intentionally NOT locked to that namespace — any keyword
+  is accepted. The `:fragment.*` example is a convention, not a contract."
+  [id]
+  (keyword? id))
+
+(defn check-id?
+  "True iff `id` is a keyword id for a `reg-check` (rf2-5x1wt.15). The
+  spec/017 §Strict composition example shape is `:check/<name>` (e.g.
+  `:check/no-runtime-errors`); like fragment ids the grammar is left open
+  — any keyword is accepted. Checks preserve identity in run results, so
+  the id is the stable label a failed check shows alongside its
+  underlying assertion records."
+  [id]
+  (keyword? id))
+
 ;; ---- canonical tag vocabulary ---------------------------------------------
 
 (def canonical-tags
@@ -465,6 +485,32 @@
     (fn [v] (or (empty? v)
                 (= (count v) (count (distinct (map :name v))))))]])
 
+;; ---- :compose — strict fragment/check composition (rf2-5x1wt.15) ---------
+
+(def AssertionVector
+  "A terminal/checkpoint assertion atom — the data vector
+  `[:rf.assert/id & args]` (spec/017 §Assertions — one atom, two
+  positions). Shape is left loose (vector starting with a keyword) so the
+  assertion-id registry surfaces a clear runner error rather than a schema
+  rejection on an unknown id."
+  [:and
+   [:vector :any]
+   [:fn {:error/message "assertion must be a vector starting with a keyword id"}
+    (fn [v]
+      (and (vector? v)
+           (pos? (count v))
+           (keyword? (first v))))]])
+
+(def ComposeRefs
+  "Schema for the `:compose` slot on a variant / inline plan (rf2-5x1wt.15
+  + spec/017 §`:compose`). A vector of registered fragment-ids and
+  check-ids, applied in declared order. Each entry is a bare keyword — the
+  reference is by id; the fragment/check body lives at its registration
+  site. The plan compiler resolves a fragment-id against the fragment
+  registry and a check-id against the check registry; an unregistered id
+  FAILS plan construction."
+  [:vector :keyword])
+
 ;; ---- :network — managed HTTP request stubs (rf2-5x1wt.14) ----------------
 
 (def NetworkRoute
@@ -587,6 +633,11 @@
    [:map
     [:doc                   {:optional true} :string]
     [:extends               {:optional true} :keyword]
+    ;; rf2-5x1wt.15 — `:compose` includes registered fragments + checks
+    ;; explicitly, applied in declared order (spec/017 §`:compose`).
+    ;; Fragments contribute world context + setup/script; checks
+    ;; contribute inheritable assertion packs. See `ComposeRefs`.
+    [:compose               {:optional true} ComposeRefs]
     ;; rf2-5x1wt.11 — `:setup` is the PUBLIC precondition slot; `:events`
     ;; is the transitional spelling lowered to `:setup`'s shipping slot
     ;; by the registrar. Mutually exclusive (the `:fn` clause below).
@@ -619,6 +670,22 @@
     ;; serves non-HTTP effects. See `NetworkSpec` + spec/017 §Network
     ;; world.
     [:network               {:optional true} NetworkSpec]
+    ;; rf2-5x1wt.15 — strict-conflict effect/interceptor override slots.
+    ;; `:fx-overrides` is the first-class fx-override surface (spec/017
+    ;; §The effect-override surface); `:interceptor-overrides` the
+    ;; interceptor analog. Both are strict-conflict fields: a variant that
+    ;; sets one directly OWNS it (variant-owned-wins), and two composed
+    ;; fragments that disagree on the same fx/interceptor key while the
+    ;; variant is silent is a hard conflict (spec/017 §Conflict
+    ;; resolution).
+    [:fx-overrides          {:optional true} [:map-of :keyword :any]]
+    [:interceptor-overrides {:optional true} [:map-of :keyword :any]]
+    ;; rf2-5x1wt.15 — `:checks` is the inheritable expectation form (a
+    ;; vector of registered check-ids, expanded by the plan compiler);
+    ;; `:assertions` is own-only terminal judgement (spec/017 §Checks and
+    ;; assertions). Both ride the variant body alongside `:compose`.
+    [:checks                {:optional true} [:vector :keyword]]
+    [:assertions            {:optional true} [:vector AssertionVector]]
     [:tags                  {:optional true} TagSet]
     [:decorators            {:optional true} DecoratorRefs]
     [:loaders               {:optional true} [:vector EventVector]]
@@ -668,7 +735,100 @@
               "pick one play surface per variant (:script is the public spelling)")}
     (fn [body]
       (<= (count (filter #(contains? body %) [:script :play-script :plays]))
-          1))]])
+          1))]
+   ;; rf2-5x1wt.15 — P1 ships NO `:resolve-conflicts` escape hatch. The
+   ;; variant owns its end-state: a strict-conflict field set directly in
+   ;; the variant body wins, and the only hard error is two composed
+   ;; fragments conflicting while the variant is silent — resolved by the
+   ;; variant stating the wanted value, NOT by a stale-prone resolution
+   ;; map (spec/017 §Conflict resolution). Reject `:resolve-conflicts` at
+   ;; the schema so the absence is enforced, not merely undocumented.
+   [:fn {:error/message
+         (str ":resolve-conflicts is not a P1 slot — the variant owns its "
+              "end-state. State the wanted strict-conflict value directly "
+              "in the variant body (spec/017 §Conflict resolution).")}
+    (fn [body]
+      (not (contains? body :resolve-conflicts)))]])
+
+;; ---- :rf/fragment + :rf/check (rf2-5x1wt.15) ------------------------------
+
+(def Fragment
+  "Schema for the body of `reg-fragment` (spec/017 §Fragments + §Strict
+  composition).
+
+  Fragments are reusable setup / script / frame / args pieces a variant
+  pulls in through `:compose`. Every key is data — no fn-valued slots —
+  exactly like a variant body, and a fragment's slots merge into the
+  composing variant per the §Merge rules (setup/script APPEND in declared
+  order; args/argtypes deep-merge; `:fx-overrides` /
+  `:interceptor-overrides` are strict-conflict fields).
+
+  ## P1 fragments MUST be flat
+
+  A fragment MUST NOT carry `:compose` (and MUST NOT `:extends`). A
+  fragment composing another fragment is a hard error so cycles are
+  impossible in P1 (spec/017 §Fragments — 'P1 fragments MUST be flat').
+  The `:fn` clause below rejects both at the schema; the plan compiler
+  re-checks at compose time as the load-bearing guard (a programmatic
+  registration may bypass the macro path).
+
+  ## What a fragment does NOT carry
+
+  Fragments are world/behaviour mixins, not judgement: they carry no
+  `:checks` / `:assertions` (those compose as checks — `reg-check` — or
+  ride the variant's own `:assertions`). Composing a check is done by
+  naming the check-id in the variant's `:compose`, not by nesting it in a
+  fragment."
+  [:and
+   [:map
+    [:doc                   {:optional true} :string]
+    [:args                  {:optional true} ArgMap]
+    [:argtypes              {:optional true} ArgtypesMap]
+    [:setup                 {:optional true} [:vector EventVector]]
+    [:events                {:optional true} [:vector EventVector]]
+    [:script                {:optional true} PlaySpec]
+    [:play-script           {:optional true} PlaySpec]
+    [:network               {:optional true} NetworkSpec]
+    [:fx-overrides          {:optional true} [:map-of :keyword :any]]
+    [:interceptor-overrides {:optional true} [:map-of :keyword :any]]
+    [:loaders               {:optional true} [:vector EventVector]]
+    [:loaders-teardown      {:optional true} [:vector EventVector]]
+    [:decorators            {:optional true} DecoratorRefs]]
+   ;; Flat-fragment enforcement (spec/017 §Fragments). A fragment that
+   ;; composes another fragment, or extends a variant, would re-open the
+   ;; cycle surface P1 closes — reject both at registration.
+   [:fn {:error/message
+         (str "P1 fragments MUST be flat — a fragment MUST NOT carry "
+              ":compose or :extends (spec/017 §Fragments)")}
+    (fn [body]
+      (not (or (contains? body :compose)
+               (contains? body :extends))))]
+   ;; A fragment carries world/behaviour, never judgement (§Fragments).
+   [:fn {:error/message
+         (str "fragments carry no :checks / :assertions — compose a check "
+              "(reg-check) by id, or put own assertions on the variant")}
+    (fn [body]
+      (not (or (contains? body :checks)
+               (contains? body :assertions))))]])
+
+(def Check
+  "Schema for the body of `reg-check` (spec/017 §Checks + §Strict
+  composition).
+
+  A check is a named, reusable assertion pack. It carries `:assertions`
+  (a vector of assertion atoms) and an optional `:doc`. The check-id is
+  the stable label a run result shows alongside the underlying assertion
+  records — check identity is preserved in the plan and in results
+  (spec/017 §Checks — 'A failed check result MUST show both the check id
+  and the underlying assertion records').
+
+  Checks are the inheritable expectation form (distinct from own-only
+  `:assertions` on a variant): they inherit through `:extends` and compose
+  through `:compose`. A check carries no world/behaviour — no setup,
+  script, args, or overrides — so the body is intentionally tight."
+  [:map
+   [:doc        {:optional true} :string]
+   [:assertions [:vector AssertionVector]]])
 
 ;; ---- :rf/workspace --------------------------------------------------------
 
@@ -856,6 +1016,8 @@
   schema here and call `m/validate` against it."
   {:story        Story
    :variant      Variant
+   :fragment     Fragment
+   :check        Check
    :workspace    Workspace
    :mode         Mode
    :story-panel  StoryPanel

--- a/tools/story/test/re_frame/story/compose_test.cljc
+++ b/tools/story/test/re_frame/story/compose_test.cljc
@@ -1,0 +1,346 @@
+(ns re-frame.story.compose-test
+  "Tests for strict `:compose` composition — fragments, checks, total merge
+  order, variant-owned-wins, and the silent-conflict failure (rf2-5x1wt.15).
+
+  Per `tools/story/spec/017-Testing-Story.md` §`:compose` / §Merge rules /
+  §Conflict resolution + `ai/findings/NewTestStory` §B3. The compiler is a
+  pure data → data fn, so every test runs on both the JVM and CLJS without
+  a host: fragment / check / variant bodies are supplied through explicit
+  `:lookup` / `:fragment-lookup` / `:check-lookup` maps of RAW bodies."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.story.plan :as plan]
+            [re-frame.story.schemas :as schemas]))
+
+;; ---- helpers ------------------------------------------------------------
+
+(defn- compose-plan
+  "Compile a keyword `target` with explicit fragment + check lookup maps.
+  `opts` defaults: `:lookup variants`, `:fragment-lookup fragments`,
+  `:check-lookup checks`."
+  [target {:keys [variants fragments checks]
+           :or   {variants {} fragments {} checks {}}}]
+  (plan/variant-plan target {:lookup          variants
+                             :fragment-lookup fragments
+                             :check-lookup    checks}))
+
+;; ===========================================================================
+;; Fragment composition — setup + script append in declared order
+;; ===========================================================================
+
+(deftest fragment-setup-composes
+  (testing "a composed fragment's :setup appends before the variant's own setup"
+    (let [fragments {:fragment.cart/with-sku
+                     {:args  {:sku "A"}
+                      :setup [[:dispatch [:cart/add {:sku [:arg :sku]}]]]}}
+          variants  {:story.checkout/submits
+                     {:compose [:fragment.cart/with-sku]
+                      :setup   [[:dispatch [:checkout/open]]]}}
+          p (compose-plan :story.checkout/submits
+                          {:variants variants :fragments fragments})]
+      (testing "fragment setup lands first, variant setup after (declared order)"
+        (is (= [[:dispatch [:cart/add {:sku "A"}]]
+                [:dispatch [:checkout/open]]]
+               (get-in p [:world :setup]))))
+      (testing "fragment args deep-merge into the effective args"
+        (is (= {:sku "A"} (get-in p [:world :args])))))))
+
+(deftest fragment-script-composes
+  (testing "a composed fragment's :script appends before the variant's own script"
+    (let [fragments {:fragment.checkout/ready-to-submit
+                     {:setup  [[:dispatch [:cart/add {:sku "A"}]]]
+                      :script [[:dispatch [:checkout/open]]
+                               [:dispatch [:checkout/type-address {:postcode "2000"}]]]}}
+          variants  {:story.checkout/submits
+                     {:compose [:fragment.checkout/ready-to-submit]
+                      :script  [[:dispatch [:checkout/submit]]]}}
+          p (compose-plan :story.checkout/submits
+                          {:variants variants :fragments fragments})]
+      (testing "fragment script lands first, variant script after"
+        (is (= [[:dispatch [:checkout/open]]
+                [:dispatch [:checkout/type-address {:postcode "2000"}]]
+                [:dispatch [:checkout/submit]]]
+               (:script p))))
+      (testing "fragment setup also folds in"
+        (is (= [[:dispatch [:cart/add {:sku "A"}]]]
+               (get-in p [:world :setup])))))))
+
+(deftest two-fragments-compose-in-declared-order
+  (testing "two composed fragments' setup + script append in declared order"
+    (let [fragments {:fragment/a {:setup  [[:dispatch [:a-setup]]]
+                                  :script [[:dispatch [:a-script]]]}
+                     :fragment/b {:setup  [[:dispatch [:b-setup]]]
+                                  :script [[:dispatch [:b-script]]]}}
+          variants  {:story.x/v {:compose [:fragment/a :fragment/b]
+                                 :script  [[:dispatch [:own]]]}}
+          p (compose-plan :story.x/v
+                          {:variants variants :fragments fragments})]
+      (is (= [[:dispatch [:a-setup]] [:dispatch [:b-setup]]]
+             (get-in p [:world :setup])))
+      (is (= [[:dispatch [:a-script]] [:dispatch [:b-script]] [:dispatch [:own]]]
+             (:script p))))))
+
+;; ===========================================================================
+;; Check composition + identity preservation
+;; ===========================================================================
+
+(deftest check-composes
+  (testing "a composed check adds its id to [:expect :checks] (identity preserved)"
+    (let [checks   {:check/no-runtime-errors
+                    {:assertions [[:rf.assert/no-warnings]]}}
+          variants {:story.x/v {:compose [:check/no-runtime-errors]
+                                :script  [[:dispatch [:go]]]}}
+          p (compose-plan :story.x/v
+                          {:variants variants :checks checks})]
+      (testing "the check-id (not its inlined assertions) rides :expect :checks"
+        (is (= [:check/no-runtime-errors] (get-in p [:expect :checks]))))
+      (testing "explain classifies the composed entry as a check"
+        (is (= [{:kind :check :id :check/no-runtime-errors}]
+               (get-in p [:explain :compose])))))))
+
+(deftest compose-mixes-fragments-and-checks-in-declared-order
+  (testing "a :compose list interleaving fragments + checks resolves each kind"
+    (let [fragments {:fragment/seed {:setup [[:dispatch [:seed]]]}}
+          checks    {:check/clean {:assertions [[:rf.assert/no-warnings]]}}
+          variants  {:story.x/v {:compose [:fragment/seed :check/clean]
+                                 :checks  [:check/own]}}
+          p (compose-plan :story.x/v
+                          {:variants variants :fragments fragments :checks checks})]
+      (is (= [[:dispatch [:seed]]] (get-in p [:world :setup])))
+      (testing "own checks come first (inherited+own), composed checks append"
+        (is (= [:check/own :check/clean] (get-in p [:expect :checks]))))
+      (is (= [{:kind :fragment :id :fragment/seed}
+              {:kind :check :id :check/clean}]
+             (get-in p [:explain :compose]))))))
+
+;; ===========================================================================
+;; :extends inheritance — checks inherit; assertions + script do not
+;; ===========================================================================
+
+(deftest parent-check-inherits
+  (testing "a parent variant's :checks inherit to the child (inheritable form)"
+    (let [variants {:story.k/parent {:checks [:check/no-runtime-errors]}
+                    :story.k/child  {:extends :story.k/parent
+                                     :checks  [:check/extra]}}
+          p (compose-plan :story.k/child {:variants variants})]
+      (is (= [:check/no-runtime-errors :check/extra]
+             (get-in p [:expect :checks]))))))
+
+(deftest parent-assertion-does-not-inherit
+  (testing "a parent variant's ordinary :assertions do NOT inherit (verdict is local)"
+    (let [variants {:story.a/parent
+                    {:assertions [[:rf.assert/path-equals [:s] :parent]]}
+                    :story.a/child
+                    {:extends    :story.a/parent
+                     :assertions [[:rf.assert/path-equals [:s] :child]]}}
+          p (compose-plan :story.a/child {:variants variants})]
+      (is (= [[:rf.assert/path-equals [:s] :child]]
+             (get-in p [:expect :assertions]))
+          "only the child's own terminal assertions survive"))))
+
+(deftest parent-assertion-absent-when-child-silent
+  (testing "a child with no :assertions does not pick up the parent's"
+    (let [variants {:story.a/parent
+                    {:assertions [[:rf.assert/path-equals [:s] :parent]]}
+                    :story.a/child {:extends :story.a/parent}}
+          p (compose-plan :story.a/child {:variants variants})]
+      (is (= [] (get-in p [:expect :assertions]))))))
+
+(deftest parent-script-does-not-inherit
+  (testing "a parent variant's :script does NOT inherit through :extends"
+    (let [variants {:story.s/parent {:script [[:dispatch [:parent-step]]]}
+                    :story.s/child  {:extends :story.s/parent
+                                     :script  [[:dispatch [:child-step]]]}}
+          p (compose-plan :story.s/child {:variants variants})]
+      (is (= [[:dispatch [:child-step]]] (:script p))
+          "script is behaviour under test — a child does not silently run the parent's"))))
+
+(deftest extends-context-flows-down-compose-adds-behaviour
+  (testing ":extends inherits context; :compose adds behaviour on top"
+    (let [fragments {:fragment/prefix {:script [[:dispatch [:prefix]]]}}
+          variants  {:story.m/parent {:args  {:env :prod}
+                                      :setup [[:dispatch [:parent-setup]]]}
+                     :story.m/child  {:extends :story.m/parent
+                                      :compose [:fragment/prefix]
+                                      :script  [[:dispatch [:child-step]]]}}
+          p (compose-plan :story.m/child
+                          {:variants variants :fragments fragments})]
+      (testing "parent context (args + setup) flows down"
+        (is (= {:env :prod} (get-in p [:world :args])))
+        (is (= [[:dispatch [:parent-setup]]] (get-in p [:world :setup]))))
+      (testing "compose script prefixes the child's own script"
+        (is (= [[:dispatch [:prefix]] [:dispatch [:child-step]]] (:script p)))))))
+
+;; ===========================================================================
+;; Flat fragments — a fragment composing a fragment FAILS
+;; ===========================================================================
+
+(deftest fragment-composing-fragment-fails
+  (testing "a composed fragment that itself carries :compose FAILS (P1 flat fragments)"
+    (let [fragments {:fragment/leaf   {:setup [[:dispatch [:leaf]]]}
+                     :fragment/nested {:compose [:fragment/leaf]
+                                       :setup   [[:dispatch [:nested]]]}}
+          variants  {:story.x/v {:compose [:fragment/nested]}}
+          opts      {:variants variants :fragments fragments}]
+      (is (thrown-with-msg?
+            #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
+            #"story-compose-nested-fragment"
+            (compose-plan :story.x/v opts)))
+      (let [data (try (compose-plan :story.x/v opts)
+                      (catch #?(:clj Exception :cljs :default) e (ex-data e)))]
+        (is (= :rf.error/story-compose-nested-fragment (:rf.error/id data)))
+        (is (= :fragment/nested (:fragment/id data)))
+        (is (= :compose (:offending-key data)))))))
+
+(deftest fragment-extending-variant-fails
+  (testing "a composed fragment carrying :extends also FAILS (flat fragments)"
+    (let [fragments {:fragment/bad {:extends :story.x/parent
+                                    :setup   [[:dispatch [:bad]]]}}
+          variants  {:story.x/v {:compose [:fragment/bad]}}
+          opts      {:variants variants :fragments fragments}]
+      (is (= :rf.error/story-compose-nested-fragment
+             (try (compose-plan :story.x/v opts)
+                  (catch #?(:clj Exception :cljs :default) e
+                    (:rf.error/id (ex-data e)))))))))
+
+(deftest unknown-compose-id-fails
+  (testing "a :compose id naming no registered fragment/check FAILS"
+    (let [variants {:story.x/v {:compose [:fragment/ghost]}}
+          opts     {:variants variants}]
+      (is (thrown-with-msg?
+            #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
+            #"story-compose-unknown"
+            (compose-plan :story.x/v opts)))
+      (is (= :fragment/ghost
+             (:compose/id (try (compose-plan :story.x/v opts)
+                               (catch #?(:clj Exception :cljs :default) e
+                                 (ex-data e)))))))))
+
+;; ===========================================================================
+;; Strict-conflict resolution — variant-owned-wins + silent-conflict failure
+;; ===========================================================================
+
+(deftest two-fragments-conflict-when-variant-silent
+  (testing "two composed fx-overrides on the SAME fx-id, differing, with a silent variant → HARD"
+    (let [fragments {:fragment/http-a {:fx-overrides {:rf.http/fetch :stub-a}}
+                     :fragment/http-b {:fx-overrides {:rf.http/fetch :stub-b}}}
+          variants  {:story.x/v {:compose [:fragment/http-a :fragment/http-b]}}
+          opts      {:variants variants :fragments fragments}]
+      (is (thrown-with-msg?
+            #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
+            #"story-compose-conflict"
+            (compose-plan :story.x/v opts)))
+      (let [data (try (compose-plan :story.x/v opts)
+                      (catch #?(:clj Exception :cljs :default) e (ex-data e)))
+            c    (first (:conflicts data))]
+        (is (= :rf.error/story-compose-conflict (:rf.error/id data)))
+        (is (= :fx-overrides (:field c)))
+        (is (= :rf.http/fetch (:key c)))
+        (is (= #{:fragment/http-a :fragment/http-b} (set (:sources c))))
+        (is (= #{:stub-a :stub-b} (set (:values c))))))))
+
+(deftest identical-fragment-overrides-do-not-conflict
+  (testing "two composed fragments setting the SAME fx-id to the SAME value → no conflict"
+    (let [fragments {:fragment/http-a {:fx-overrides {:rf.http/fetch :stub}}
+                     :fragment/http-b {:fx-overrides {:rf.http/fetch :stub}}}
+          variants  {:story.x/v {:compose [:fragment/http-a :fragment/http-b]}}
+          p (compose-plan :story.x/v
+                          {:variants variants :fragments fragments})]
+      (is (= {:rf.http/fetch :stub}
+             (get-in p [:world :frame :fx-overrides]))))))
+
+(deftest fragments-on-different-keys-do-not-conflict
+  (testing "fragments overriding DIFFERENT fx-ids both fill in (no conflict)"
+    (let [fragments {:fragment/http {:fx-overrides {:rf.http/fetch :http-stub}}
+                     :fragment/ws   {:fx-overrides {:ws/send :ws-stub}}}
+          variants  {:story.x/v {:compose [:fragment/http :fragment/ws]}}
+          p (compose-plan :story.x/v
+                          {:variants variants :fragments fragments})]
+      (is (= {:rf.http/fetch :http-stub :ws/send :ws-stub}
+             (get-in p [:world :frame :fx-overrides]))))))
+
+(deftest variant-owned-fx-override-wins
+  (testing "a variant-owned fx-override wins over composed-fragment overrides"
+    (let [fragments {:fragment/http-a {:fx-overrides {:rf.http/fetch :stub-a}}
+                     :fragment/http-b {:fx-overrides {:rf.http/fetch :stub-b}}}
+          variants  {:story.x/v {:compose      [:fragment/http-a :fragment/http-b]
+                                 :fx-overrides {:rf.http/fetch :variant-stub}}}
+          p (compose-plan :story.x/v
+                          {:variants variants :fragments fragments})]
+      (testing "the variant value wins; fragments do NOT conflict (variant owns the key)"
+        (is (= :variant-stub
+               (get-in p [:world :frame :fx-overrides :rf.http/fetch]))))
+      (testing "explain records the resolved conflict: winner, losing sources, rule"
+        (let [c (first (get-in p [:explain :strict-conflicts]))]
+          (is (= :fx-overrides (:field c)))
+          (is (= :rf.http/fetch (:key c)))
+          (is (= :variant-stub (:winner c)))
+          (is (= :variant (:winning-source c)))
+          (is (= #{:fragment/http-a :fragment/http-b} (set (:losing-sources c))))
+          (is (= :variant-owned-wins (:rule c))))))))
+
+(deftest variant-owned-fills-only-its-key
+  (testing "variant-owned-wins is per-KEY: the variant fills its key, the fragment fills the rest"
+    (let [fragments {:fragment/http {:fx-overrides {:rf.http/fetch :frag-fetch
+                                                    :rf.http/post  :frag-post}}}
+          variants  {:story.x/v {:compose      [:fragment/http]
+                                 :fx-overrides {:rf.http/fetch :variant-fetch}}}
+          p (compose-plan :story.x/v
+                          {:variants variants :fragments fragments})]
+      (is (= {:rf.http/fetch :variant-fetch     ; variant owns this key
+              :rf.http/post  :frag-post}         ; fragment fills the rest
+             (get-in p [:world :frame :fx-overrides]))))))
+
+(deftest interceptor-overrides-are-strict-too
+  (testing ":interceptor-overrides follow the same strict-conflict rule"
+    (let [fragments {:fragment/i-a {:interceptor-overrides {:guard :a}}
+                     :fragment/i-b {:interceptor-overrides {:guard :b}}}
+          variants  {:story.x/v {:compose [:fragment/i-a :fragment/i-b]}}
+          opts      {:variants variants :fragments fragments}]
+      (is (= :rf.error/story-compose-conflict
+             (try (compose-plan :story.x/v opts)
+                  (catch #?(:clj Exception :cljs :default) e
+                    (:rf.error/id (ex-data e))))))
+      (testing "variant-owned interceptor override wins"
+        (let [vw {:variants {:story.x/w {:compose [:fragment/i-a :fragment/i-b]
+                                         :interceptor-overrides {:guard :v}}}
+                  :fragments fragments}
+              p  (compose-plan :story.x/w vw)]
+          (is (= {:guard :v}
+                 (get-in p [:world :frame :interceptor-overrides]))))))))
+
+;; ===========================================================================
+;; No `:resolve-conflicts` escape hatch in P1
+;; ===========================================================================
+
+(deftest resolve-conflicts-rejected-by-schema
+  (testing ":resolve-conflicts is rejected by the P1 variant schema (no escape hatch)"
+    (let [explain (schemas/validate
+                    :variant {:resolve-conflicts {[:fx-overrides :rf.http/fetch] :stub-a}})]
+      (is (some? explain) ":resolve-conflicts must fail variant-body validation"))))
+
+(deftest resolve-conflicts-absent-from-plan
+  (testing "a composed plan carries no :resolve-conflicts surface"
+    (let [fragments {:fragment/http {:fx-overrides {:rf.http/fetch :stub}}}
+          variants  {:story.x/v {:compose [:fragment/http]}}
+          p (compose-plan :story.x/v
+                          {:variants variants :fragments fragments})]
+      (is (not (contains? p :resolve-conflicts)))
+      (is (not (contains? (:world p) :resolve-conflicts)))
+      (is (not (contains? (:explain p) :resolve-conflicts))))))
+
+;; ===========================================================================
+;; Inline plan composing registered fragments/checks
+;; ===========================================================================
+
+(deftest inline-plan-composes-registered-fragments
+  (testing "an inline map plan MAY compose registered fragments + checks (§Inline plan)"
+    (let [fragments {:fragment/seed {:setup [[:dispatch [:seed]]]}}
+          checks    {:check/clean {:assertions [[:rf.assert/no-warnings]]}}
+          p (plan/variant-plan
+              {:variant/id :inline/v
+               :compose    [:fragment/seed :check/clean]
+               :script     [[:dispatch [:go]]]}
+              {:fragment-lookup fragments :check-lookup checks})]
+      (is (= [[:dispatch [:seed]]] (get-in p [:world :setup])))
+      (is (= [[:dispatch [:go]]] (:script p)))
+      (is (= [:check/clean] (get-in p [:expect :checks]))))))

--- a/tools/story/test/re_frame/story/plan_test.cljc
+++ b/tools/story/test/re_frame/story/plan_test.cljc
@@ -240,8 +240,15 @@
       (is (= [{:key :n :value 1}] (:substitutions ex)))
       (is (= [[:dispatch [:seed 1]]] (:setup-order ex)))
       (is (= [[:dispatch [:go]]] (:script-order ex)))
-      (is (= :append-root-to-child (get-in ex [:merge :setup])))
-      (is (= :child-only (get-in ex [:merge :script]))))))
+      ;; rf2-5x1wt.15 — the merge vocabulary names the inherited / compose /
+      ;; own layering now that `:compose` lands between the parent merge and
+      ;; the variant-owned values. Setup appends inherited→compose→own;
+      ;; script appends through `:compose` only, never `:extends`.
+      (is (= :append-inherited-compose-own (get-in ex [:merge :setup])))
+      (is (= :compose-then-child (get-in ex [:merge :script])))
+      (testing "no :compose on a plain :extends variant"
+        (is (= [] (:compose ex)))
+        (is (= [] (:strict-conflicts ex)))))))
 
 ;; ===========================================================================
 ;; View arg schemas (rf2-5x1wt.12 — spec §View arg schemas)

--- a/tools/story/test/re_frame/story_authoring_validation_test.clj
+++ b/tools/story/test/re_frame/story_authoring_validation_test.clj
@@ -128,6 +128,61 @@
       (catch clojure.lang.ExceptionInfo e
         (is (= :rf.error/story-panel-shape (:rf.error/id (ex-data e))))))))
 
+;; ---- fragments + checks (rf2-5x1wt.15) ------------------------------------
+
+(deftest reg-fragment-registers-and-is-queryable
+  (testing "reg-fragment lands a body in the :fragment side-table"
+    (story/reg-fragment :fragment.cart/with-sku
+      {:args  {:sku "A"}
+       :setup [[:dispatch [:cart/add {:sku [:arg :sku]}]]]})
+    (is (story/registered? :fragment :fragment.cart/with-sku))
+    (is (= {:sku "A"}
+           (:args (story/handler-meta :fragment :fragment.cart/with-sku))))))
+
+(deftest reg-check-registers-and-is-queryable
+  (testing "reg-check lands a body in the :check side-table"
+    (story/reg-check :check/no-runtime-errors
+      {:assertions [[:rf.assert/no-warnings]]})
+    (is (story/registered? :check :check/no-runtime-errors))
+    (is (= [[:rf.assert/no-warnings]]
+           (:assertions (story/handler-meta :check :check/no-runtime-errors))))))
+
+(deftest reg-fragment-rejects-nested-compose
+  (testing "a fragment carrying :compose is rejected at registration (flat fragments)"
+    (try
+      (story/reg-fragment :fragment.bad/nested
+        {:compose [:fragment.cart/with-sku]
+         :setup   [[:dispatch [:x]]]})
+      (is false "expected an exception")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :rf.error/fragment-shape (:rf.error/id (ex-data e))))))))
+
+(deftest reg-fragment-rejects-judgement-slots
+  (testing "a fragment carrying :assertions is rejected (fragments carry no judgement)"
+    (try
+      (story/reg-fragment :fragment.bad/judges
+        {:assertions [[:rf.assert/no-warnings]]})
+      (is false "expected an exception")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :rf.error/fragment-shape (:rf.error/id (ex-data e))))))))
+
+(deftest reg-check-requires-assertions
+  (testing "a check body missing :assertions is rejected"
+    (try
+      (story/reg-check :check/empty {:doc "no assertions"})
+      (is false "expected an exception")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :rf.error/check-shape (:rf.error/id (ex-data e))))))))
+
+(deftest reg-variant-rejects-resolve-conflicts
+  (testing ":resolve-conflicts on a variant body is rejected (no P1 escape hatch)"
+    (try
+      (story/reg-variant :story.bad/resolve
+        {:resolve-conflicts {[:fx-overrides :rf.http/fetch] :stub}})
+      (is false "expected an exception")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :rf.error/variant-shape (:rf.error/id (ex-data e))))))))
+
 ;; ===========================================================================
 ;; rf2-tl7zk — :plays multi-play schema contract
 ;; ===========================================================================


### PR DESCRIPTION
## What

Implements **strict composition** for Story variants (rf2-5x1wt.15, NewTestStory §B3): the public `reg-fragment` / `reg-check` registration surface and `:compose` in the variant-plan compiler.

```clojure
(story/reg-fragment :fragment.checkout/ready-to-submit
  {:setup  [[:dispatch [:cart/add {:sku "A"}]]]
   :script [[:dispatch [:checkout/open]]]})

(story/reg-check :check/no-runtime-errors
  {:assertions [[:rf.assert/no-warnings]]})

(story/reg-variant :story.checkout/submits
  {:compose    [:fragment.checkout/ready-to-submit :check/no-runtime-errors]
   :script     [[:dispatch [:checkout/submit]]]
   :assertions [[:rf.assert/path-equals [:checkout :state] :submitted]]})
```

## How

- **registrar.cljc** — new `:fragment` + `:check` side-table kinds; `reg-fragment*` / `reg-check*` runtime helpers; id-shape + auto-install wiring.
- **schemas.cljc** — `Fragment` schema (flat: rejects `:compose`/`:extends`; world/behaviour-only: rejects `:checks`/`:assertions`) and `Check` schema (`:assertions` required). Added `:compose` / `:fx-overrides` / `:interceptor-overrides` / `:checks` / `:assertions` slots to `Variant`, and a `:fn` clause **rejecting `:resolve-conflicts`** (no P1 escape hatch).
- **plan.cljc** — `:compose` resolved between the parent merge (step 2) and variant-owned values (step 4). Flat-fragment guard re-checked at compose time. Total merge order: setup appends `inherited→compose→own`; script appends through `:compose` only (never `:extends`); args/argtypes deep-merge; checks `inherit-then-compose`. Per-key strict-conflict resolution with **variant-owned-wins**; two composed fragments disagreeing on a strict key while the variant is silent **fails** (`:rf.error/story-compose-conflict`). Check identity preserved as the id in `[:expect :checks]`. `explain` records `:compose` (classified) + `:strict-conflicts` (winner/losing-sources/rule).
- **story.cljc** — `reg-fragment` / `reg-check` macros + `reg-fragment*` / `reg-check*` re-exports **grouped with the existing `reg-*` runtime helpers** (not EOF-appended).
- **spec/017-Testing-Story.md** — new `## Strict composition` section pinning the implemented contract (registration surface, `:compose` resolution, flat fragments, total merge order, variant-owned-wins, silent-conflict failure, no `:resolve-conflicts`, check-identity preservation).

## Quality gates

| Gate | Result |
|---|---|
| `cd tools/story && clojure -M:test` | PASS — 1015 tests, 3029 assertions, 0 failures, 0 errors (28 new) |
| `npm --prefix implementation run test:cljs` | PASS — 4847 tests, 15879 assertions, 0 failures, 0 errors |
| `bash scripts/test-fast-pr.sh` | PASS fast PR spine (markdown link/anchor gates ran; mkdocs soft-skipped on Windows) |
| `python -m mkdocs build --strict` | PASS (built clean) |

Tests cover every §B3 case: fragment setup/script compose; check composes; parent check inherits; parent assertion + parent script do NOT inherit; fragment-composing-fragment fails; two composed fx-overrides conflict when the variant is silent; variant-owned fx-override wins and appears in explain; `:resolve-conflicts` rejected by schema + absent from the plan; inline plan composes registered fragments/checks.