### PR TITLE
feat(story): semantic diff over canonical run artifacts (rf2-5x1wt.9)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -1865,6 +1865,100 @@ replay path settles synchronously to a fixed point via the headless
 flush-hooks, so the full gate also runs headless. The strip's
 host-portability is pinned on CLJS alongside the fingerprint primitive.
 
+## Semantic diff
+
+The semantic diff answers a different question from the determinism gate:
+not *is this run stable?* but *how do these two runs differ in behaviour?*
+It is the readable companion to a `:non-deterministic` divergence and to any
+before/after comparison (a regression baseline vs HEAD, a fix's before/after,
+a property-shrunk failure vs its neighbour). It ships in the
+`re-frame.story.diff` namespace and is re-exported as
+`test/diff-run-artifacts` (the testing-substrate surface owned by
+[`spec/008-Testing.md`](../../../spec/008-Testing.md) — the tool lives
+**below** Story and runs without the Story UI).
+
+```clojure
+(test/diff-run-artifacts baseline current)
+(test/diff-run-artifacts baseline current opts)
+;; -> {:same? true}
+;;  | {:same? false :facets #{facet …} <facet> <readable-delta> …}
+```
+
+`baseline` and `current` are each either a `:rf.test/run-artifact` — which is
+**replayed** into a fresh frame to obtain a run-result (the impure path, the
+same replay the determinism gate drives, §Run artifact and replay) — or an
+already-computed run-result (used directly, the pure path). `opts` MAY carry
+the `:frame` / `:hooks` / `:frame-config` threaded to `replay-run-artifact`.
+
+### Canonicalize first, then diff
+
+Both runs are projected through `canonicalize` (§Canonicalization) **before**
+any facet is compared, so the diff shows the **semantic** difference and not
+the per-run noise. A fresh-frame replay restarts the process-global epoch /
+dispatch / trace-id counters and allocates a new `:rf.test.replay/*` frame
+id, so two semantically-equal runs differ in dozens of stamps; without the
+canonicalize-first step a diff would drown in them. What survives the
+projection is exactly the behavioural surface the determinism gate compares
+— so a diff that finds **no facets** (`{:same? true}`) is the same judgement
+`assert-deterministic` renders `:deterministic`, and a diff that finds facets
+explains a `:non-deterministic` divergence in readable terms.
+
+The `:same?` judgement is canonical equality of the run-**slice**
+(`run-hash-input-keys` — the behavioural surface: `:status`, the final
+`:app-db`, the `:epoch-tape`, the `:assertions` / `:checks` verdicts, the
+projected `:effects` / `:schema-violations` / `:warnings`, and
+`:sub-overrides` / `:fidelity`), the EXACT slice + judgement the determinism
+gate's `compare-runs` uses — so a diff agrees with the determinism gate on
+what counts as the same run. The pure provenance a run-result also carries
+(the `:frame` replay id, the `:run-artifact` back-link, the per-step
+`:replay-steps`) is excluded, exactly as it is from `run-hash`.
+
+### What the diff covers
+
+Each facet is projected independently and contributes to the result **only
+when it differs**, so the diff localises *where* two runs parted and stays
+small:
+
+- `:app-db` — a readable key-path delta of the final app-db
+  (`:added` / `:removed` / `:changed`, each entry a `{:path … :baseline …
+  :current …}` over the differing leaf paths) — a 100-key db with one changed
+  key yields a one-entry delta, never a database dump;
+- `:effects` — a **multiset** delta of the projected effect rows
+  (`:only-baseline` / `:only-current`) — the effects one run emitted and the
+  other did not (emitting an effect twice vs once IS a difference);
+- `:schema-violations` — a multiset delta over the violation **surface
+  selectors** (§Schema rule, `evidence/violation-selector` — `[:event id]`,
+  `[:app-db registered-path path]`, …), not the full diagnostic records, so a
+  re-ordered-but-equal set of violations is not a diff while a genuinely-new
+  failure surface is;
+- `:trace-ops` — the ordered trace `:operation` sequence (the causal op
+  spine), reported as both spines plus the `:first-divergence` index — order
+  is semantic, so a re-ordered or dropped op reads as a difference;
+- `:sub-runs` — a multiset delta over the projected subscription / view
+  facts, when available;
+- `:status` — the top-level run status, when it differs (a `:pass` → `:fail`
+  flip is the headline a reader wants first).
+
+### A readable diff, not a data dump
+
+`diff-run-artifacts` returns `{:same? true}` for behaviourally-identical runs
+and otherwise a map carrying **only** the facets that actually differ, with
+`:facets` naming them up front. A matching facet contributes nothing. This is
+the semantic-diff contract: surface the semantic difference, suppress the
+volatile noise.
+
+### Pure / JVM-testable
+
+The facet diff fns (`diff-app-db`, `diff-effects`, `diff-schema-violations`,
+`diff-trace-ops`, `diff-sub-runs`) and the assembler (`diff-runs`) are pure
+data → data — two run-results in, a readable diff out — and run under
+`clojure -M:test` with no runtime; only the artifact-replay entry path is
+impure, and when both inputs are run-results `diff-run-artifacts` is itself
+pure. The facet fns receive the **noise-stripped but shape-preserved**
+run-results (`strip-noise` — the volatile / per-run-stamp / `:rf.story/*`
+strip without the map-flattening ordering pass `canonicalize` applies), so
+they read named slots while seeing none of the per-run noise.
+
 ## Relationship to the workshop surface (storytelling is in-scope)
 
 Story is a **workshop**, not only a test engine. The shipping authoring

--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -98,6 +98,10 @@
             ;; rf2-5x1wt.8 — the determinism gate. Re-exported as
             ;; `assert-deterministic` below (spec/017 §Determinism gate).
             [re-frame.story.determinism :as determinism]
+            ;; rf2-5x1wt.9 — the semantic diff over canonical run artifacts.
+            ;; Re-exported as `diff-run-artifacts` below (spec/017 §Semantic
+            ;; diff). Builds read-only on `.7` replay + `.3`/`.8` canonicalize.
+            [re-frame.story.diff        :as diff]
             ;; rf2-5x1wt.25 — the run-artifact → variant promotion bridge.
             ;; Re-exported as `materialize-variant-plan` (pure) +
             ;; `promote-run-artifact!` (the explicit-only registration path)
@@ -1092,6 +1096,30 @@
   registered variant id."
   [artifact opts]
   (promotion/promote-run-artifact! artifact opts))
+
+;; ---- semantic diff over run artifacts (rf2-5x1wt.9) ---------------------
+;;
+;; Per spec/017 §Semantic diff — a readable diff between two runs, with the
+;; per-run noise (frame ids, timestamps, dispatch / epoch / trace ids)
+;; stripped by `canonicalize` FIRST so the diff shows SEMANTIC differences.
+;; Builds read-only on `.7` replay + `.3`/`.8` canonicalize; re-exported as
+;; the testing-substrate `diff-run-artifacts` (the tool lives below Story and
+;; runs without the UI; spec/008 owns the substrate surface).
+
+(defn diff-run-artifacts
+  "Per spec/017 §Semantic diff — a readable semantic diff between two runs.
+  Each of `baseline` / `current` is a `:rf.test/run-artifact` (REPLAYED into
+  a fresh frame, the impure path) or an already-computed run-result (used
+  directly, the pure path). Both are projected through `canonicalize` to
+  strip the per-run noise (frame ids, timestamps, dispatch / epoch / trace
+  ids) BEFORE diffing, so the result shows SEMANTIC differences only. The
+  diff covers app-db deltas, effects, schema violations, the trace op spine,
+  subscription / view facts, and status. Returns `{:same? true}` for
+  behaviourally-identical runs, else `{:same? false :facets #{…} …}` carrying
+  ONLY the facets that differ. `opts` MAY carry `:frame` / `:hooks` /
+  `:frame-config` (threaded to the replay)."
+  ([baseline current]      (diff/diff-run-artifacts baseline current))
+  ([baseline current opts] (diff/diff-run-artifacts baseline current opts)))
 
 (defn destroy-variant!
   "Tear down a variant frame allocated via `run-variant`. Per IMPL-

--- a/tools/story/src/re_frame/story/diff.cljc
+++ b/tools/story/src/re_frame/story/diff.cljc
@@ -1,0 +1,427 @@
+(ns re-frame.story.diff
+  "Semantic diff over canonical run artifacts — `diff-run-artifacts`
+  (NewTestStory rf2-5x1wt.9, spec/017-Testing-Story.md §Semantic diff). It
+  answers ONE question: how do two runs differ in BEHAVIOUR, with the
+  per-run noise (frame ids, timestamps, dispatch / epoch / trace ids)
+  removed first?
+
+  ## Canonicalize first, then diff
+
+  A semantic diff that walked the raw run-results would drown in volatile
+  noise: a fresh-frame replay (`re-frame.story.artifact/replay-run-artifact`,
+  spec §Run artifact and replay) restarts the process-global epoch /
+  dispatch / trace-id counters and allocates a new `:rf.test.replay/*` frame
+  id, so two semantically-EQUAL runs differ in dozens of stamps. So both
+  inputs are projected through `re-frame.story.fingerprint/canonicalize`
+  (rf2-5x1wt.3, the determinism strip rf2-5x1wt.8) BEFORE any facet is
+  compared. What survives the projection is exactly the behavioural surface
+  the determinism gate compares — so a diff that finds NO facets is the same
+  judgement `assert-deterministic` renders `:deterministic`, and a diff that
+  finds facets explains a `:non-deterministic` divergence in readable terms.
+
+  ## What the diff covers (spec §Semantic diff)
+
+  Each facet is projected from the canonical run-result and compared
+  independently, so a diff localises WHERE two runs parted:
+
+  - `:app-db`            — a readable key-path delta of the final app-db
+                           (`:added` / `:removed` / `:changed` paths, each a
+                           `{:path … :baseline … :current …}`-style entry);
+  - `:effects`           — effects emitted by one run and not the other
+                           (multiset delta — `:only-baseline` / `:only-current`);
+  - `:schema-violations` — schema failures by surface selector
+                           (`re-frame.story.play.evidence/violation-selector`);
+  - `:trace-ops`         — the trace `:operation` sequence (the causal op
+                           spine), as an ordered alignment of the two;
+  - `:sub-runs`          — subscription / view facts when available (the
+                           per-epoch sub-run rows the evidence boundary
+                           projects);
+  - `:status`            — the top-level run status, when it differs.
+
+  ## A readable diff, not a data dump
+
+  The result is SMALL by construction: `diff-run-artifacts` returns
+  `{:same? true}` when the two runs are behaviourally identical, and
+  otherwise a map carrying ONLY the facets that actually differ
+  (`:facets #{…}` names them). A facet that matches contributes nothing, so
+  a one-key app-db change yields a one-entry `:app-db` facet — not the whole
+  database. This is the §Semantic-diff contract: surface the SEMANTIC
+  difference, suppress the volatile noise.
+
+  ## Inputs
+
+  `diff-run-artifacts` accepts, for each side, either:
+
+  - a `:rf.test/run-artifact` map — replayed via
+    `re-frame.story.artifact/replay-run-artifact` to obtain a run-result
+    (the IMPURE path; opts thread through);
+  - a run-result map (the shared §Run-result shape) — used directly (the
+    PURE path).
+
+  The artifact path is the only impurity; everything below it — `diff-runs`
+  and every facet fn — is pure data → data and runs under `clojure -M:test`
+  with no runtime. Tests drive `diff-runs` with two hand-built run-results.
+
+  ## Two-layer projection: strip noise, keep shape
+
+  `canonicalize` re-orders every map into a sorted `[k v …]` vector, which
+  destroys the named-slot access (`:app-db`, `:effects`, …) the facet fns
+  need. So the assembler projects both run-results through the SAME volatile
+  strip `canonicalize` applies — `re-frame.story.fingerprint/strip-run-stamps`
+  then `project` (the structural per-run-stamp strip + the recursive
+  volatile / `:rf.story/*` strip) — WITHOUT the final ordering pass. The
+  result is a noise-free run-result whose map SHAPE is intact, so the facet
+  fns read named slots while seeing none of the per-run noise. The top-level
+  `:same?` judgement still uses full `canonicalize` (ordering imposed) for a
+  robust order-insensitive equality.
+
+  ## Pure / JVM-testable
+
+  The facet diff fns (`diff-app-db`, `diff-effects`, `diff-schema-violations`,
+  `diff-trace-ops`, `diff-sub-runs`) and the assembler (`diff-runs`) are pure
+  data → data: two run-results in, a readable diff out. `diff-run-artifacts`
+  is the thin replay-then-`diff-runs` wrapper for the artifact inputs."
+  (:require [re-frame.story.artifact      :as artifact]
+            [re-frame.story.fingerprint   :as fingerprint]
+            [re-frame.story.play.evidence :as evidence]))
+
+;; ===========================================================================
+;; APP-DB DELTA  (readable key-path diff)
+;; ===========================================================================
+;;
+;; A raw `(not= db-a db-b)` is useless for a reader — it says THAT they
+;; differ, never WHERE. This produces a readable path delta: the leaf paths
+;; that were added, removed, or changed between baseline and current. The
+;; assembler feeds these fns NOISE-STRIPPED app-dbs (`strip-noise` —
+;; volatile / `:rf.story/*` accumulator keys gone), so a path that survives
+;; here is a genuine semantic difference.
+
+(defn- leaf-paths
+  "Every leaf path through a nested map, paired with its value. A non-map
+  value is a leaf at its own path; an EMPTY map is a leaf (its emptiness is
+  semantic — `{:k {}}` vs `{:k {:a 1}}` differs at `[:k]`). Pure data →
+  data; returns `{[path …] value}`."
+  [x]
+  (letfn [(walk [prefix v acc]
+            (if (and (map? v) (seq v))
+              (reduce-kv (fn [a k vv] (walk (conj prefix k) vv a)) acc v)
+              (assoc acc prefix v)))]
+    (walk [] x {})))
+
+(defn diff-app-db
+  "Readable key-path delta between two app-db values. Pure data → data.
+
+  Returns `nil` when the two are `=` (the canonical forms match), else:
+
+      {:added   [{:path … :current  v} …]   ; in current, not baseline
+       :removed [{:path … :baseline v} …]   ; in baseline, not current
+       :changed [{:path … :baseline a :current b} …]}
+
+  Paths are leaf paths through the nested map; a slot present on only one
+  side is `:added` / `:removed`, a slot present on both with different
+  values is `:changed`. Only the differing slots appear — a 100-key db with
+  one changed key yields a one-entry `:changed`."
+  [baseline current]
+  (when (not= baseline current)
+    (let [base-leaves (leaf-paths baseline)
+          cur-leaves  (leaf-paths current)
+          base-paths  (set (keys base-leaves))
+          cur-paths   (set (keys cur-leaves))
+          ;; `sort-by pr-str` is a total, type-safe order over heterogeneous
+          ;; path vectors (a path may mix keyword / string / number keys, so
+          ;; raw `sort` could throw comparing a keyword to a number).
+          added       (sort-by pr-str (remove base-paths cur-paths))
+          removed     (sort-by pr-str (remove cur-paths base-paths))
+          changed     (sort-by pr-str
+                               (filter (fn [p]
+                                         (and (contains? base-leaves p)
+                                              (not= (base-leaves p) (cur-leaves p))))
+                                       cur-paths))]
+      (cond-> {}
+        (seq added)   (assoc :added
+                             (mapv (fn [p] {:path p :current (cur-leaves p)}) added))
+        (seq removed) (assoc :removed
+                             (mapv (fn [p] {:path p :baseline (base-leaves p)}) removed))
+        (seq changed) (assoc :changed
+                             (mapv (fn [p] {:path     p
+                                            :baseline (base-leaves p)
+                                            :current  (cur-leaves p)})
+                                   changed))))))
+
+;; ===========================================================================
+;; MULTISET DELTA  (effects / sub-runs — emission-ordered evidence rows)
+;; ===========================================================================
+;;
+;; Effects and sub-runs are ordered vectors of rows. A semantic difference
+;; is a row one run emitted and the other did not — a MULTISET delta (a row
+;; emitted twice on one side and once on the other IS a difference). Both
+;; sides are canonical, so equal rows compare `=`.
+
+(defn- multiset
+  "Frequency map of `coll` — `{element count}`. Pure data → data."
+  [coll]
+  (frequencies coll))
+
+(defn- multiset-delta
+  "The multiset delta between `baseline` and `current` row vectors. Pure
+  data → data. Returns `nil` when the multisets match, else:
+
+      {:only-baseline [row …]   ; counts higher in baseline (the surplus)
+       :only-current  [row …]}  ; counts higher in current
+
+  Surplus counts are expanded back to rows (a row with baseline-count 2 and
+  current-count 1 contributes one row to `:only-baseline`), so the delta
+  reads as the concrete rows that differ. Rows are returned in their
+  baseline / current emission order (stable, deterministic)."
+  [baseline current]
+  (let [base-ms (multiset baseline)
+        cur-ms  (multiset current)]
+    (when (not= base-ms cur-ms)
+      (let [surplus (fn [these others rows]
+                      (into []
+                            (mapcat (fn [row]
+                                      (let [over (- (get these row 0)
+                                                    (get others row 0))]
+                                        (repeat (max 0 over) row))))
+                            (distinct rows)))
+            only-base (surplus base-ms cur-ms baseline)
+            only-cur  (surplus cur-ms base-ms current)]
+        (cond-> {}
+          (seq only-base) (assoc :only-baseline only-base)
+          (seq only-cur)  (assoc :only-current only-cur))))))
+
+(defn diff-effects
+  "Multiset delta over the two runs' projected `:effects` rows. Pure data →
+  data; `nil` when the effect multisets match, else `{:only-baseline […]
+  :only-current […]}` (the rows one run emitted and the other did not)."
+  [baseline current]
+  (multiset-delta (:effects baseline) (:effects current)))
+
+(defn diff-sub-runs
+  "Multiset delta over the two runs' projected `:sub-runs` rows — the
+  subscription / view facts, when available (spec §Semantic diff). Pure
+  data → data; `nil` when the sub-run multisets match (including when both
+  runs carry no sub-runs), else `{:only-baseline […] :only-current […]}`."
+  [baseline current]
+  (multiset-delta (:sub-runs baseline) (:sub-runs current)))
+
+;; ===========================================================================
+;; SCHEMA-VIOLATION DELTA  (by surface selector)
+;; ===========================================================================
+;;
+;; A schema violation's identity is its surface SELECTOR (spec §Schema rule,
+;; `re-frame.story.play.evidence/violation-selector`) — `[:event id]`,
+;; `[:app-db registered-path path]`, etc. — not the whole record (whose
+;; `:explain` / `:value` are diagnostic detail). The delta is the multiset
+;; of selectors one run produced and the other did not, so a reader sees
+;; "current introduced a schema failure at [:event :checkout/submit]".
+
+(defn- violation-selectors
+  "The surface selectors of a run-result's projected `:schema-violations`,
+  in tape order. Reuses an existing `:selector` when the evidence boundary
+  already attached it (it does — `schema-violation-record`), else recomputes
+  it via `evidence/violation-selector`. Pure data → data."
+  [run]
+  (mapv (fn [v] (or (:selector v) (evidence/violation-selector v)))
+        (:schema-violations run)))
+
+(defn diff-schema-violations
+  "Multiset delta over the two runs' schema-violation surface SELECTORS
+  (spec §Schema rule). Pure data → data; `nil` when both runs produced the
+  same multiset of violation surfaces, else `{:only-baseline [selector …]
+  :only-current [selector …]}` — the surfaces one run failed validation on
+  and the other did not. The selector (not the full record) is the identity,
+  so a re-ordered-but-equal set of violations does NOT read as a diff while
+  a genuinely-new failure surface does."
+  [baseline current]
+  (multiset-delta (violation-selectors baseline) (violation-selectors current)))
+
+;; ===========================================================================
+;; TRACE-OP SEQUENCE DELTA  (the causal op spine)
+;; ===========================================================================
+;;
+;; The ordered sequence of trace `:operation`s across the tape is the causal
+;; spine — the verbs the run executed, in order. A semantic difference is a
+;; divergence in that ordered sequence. Both tapes are canonical (per-run
+;; stamps stripped), so the operations align by position; the diff names the
+;; first index where they part plus the two op sequences for context.
+
+(defn- trace-ops
+  "The ordered vector of trace `:operation`s across a run-result's
+  `:epoch-tape`, in dispatch order (epoch order) then emission order within
+  each epoch. Pure data → data. This is the causal op spine the diff
+  compares; events with no `:operation` (a malformed row) contribute
+  nothing."
+  [run]
+  (into []
+        (comp (mapcat :trace-events)
+              (keep :operation))
+        (:epoch-tape run)))
+
+(defn diff-trace-ops
+  "Diff the two runs' trace `:operation` sequences — the causal op spine
+  (spec §Semantic diff). Pure data → data; `nil` when the sequences are
+  identical, else:
+
+      {:baseline [op …]      ; baseline op sequence, in order
+       :current  [op …]      ; current op sequence, in order
+       :first-divergence i}  ; first index where they differ (nil if one is
+                             ; a proper prefix of the other — only the length
+                             ; differs)
+
+  Keeping both ordered sequences (not just a set) means a re-ordering or a
+  dropped op reads as a genuine difference — the op spine is causal, so its
+  order is semantic."
+  [baseline current]
+  (let [a (trace-ops baseline)
+        b (trace-ops current)]
+    (when (not= a b)
+      (let [n     (min (count a) (count b))
+            diverge (first (filter #(not= (nth a %) (nth b %)) (range n)))]
+        (cond-> {:baseline a :current b}
+          (some? diverge) (assoc :first-divergence diverge))))))
+
+;; ===========================================================================
+;; STATUS DELTA
+;; ===========================================================================
+
+(defn diff-status
+  "The top-level run `:status` delta. Pure data → data; `nil` when the two
+  runs share a status, else `{:baseline s :current s}`. A `:pass` → `:fail`
+  (or `:deterministic` → `:error`) flip is the headline difference a reader
+  wants first."
+  [baseline current]
+  (let [a (:status baseline)
+        b (:status current)]
+    (when (not= a b)
+      {:baseline a :current b})))
+
+;; ===========================================================================
+;; THE ASSEMBLER  (pure — two run-results → readable diff)
+;; ===========================================================================
+
+(defn strip-noise
+  "Strip the per-run volatile noise from a run-result WITHOUT imposing the
+  canonical ordering. Pure data → data. This is `canonicalize` minus its
+  final `canonical-form` (ordering) pass: it runs `strip-run-stamps` (the
+  structural `:id` / `:time` / `:frame` strip on trace-event / epoch-record
+  carriers) then `project` (the recursive volatile-field + `:rf.story/*`
+  accumulator strip + `:variant-id` → `:variant/id` reconcile), but leaves
+  every map a MAP so named-slot access (`:app-db`, `:effects`, …) still
+  works. The facet fns read those slots, so they need the shape; this strip
+  is why they see no per-run noise."
+  [run]
+  (fingerprint/project (fingerprint/strip-run-stamps run)))
+
+(def facet-fns
+  "The ordered facet name → diff-fn map (spec §Semantic diff). Ordered so
+  the headline facets (`:status`, `:app-db`) read first. Each fn takes the
+  two NOISE-STRIPPED run-results (`strip-noise`) and returns the facet's
+  readable delta or `nil` (no difference). A new facet is added here once and
+  flows into `diff-runs` and `:facets` automatically."
+  (array-map
+    :status            diff-status
+    :app-db            (fn [b c] (diff-app-db (:app-db b) (:app-db c)))
+    :effects           diff-effects
+    :schema-violations diff-schema-violations
+    :trace-ops         diff-trace-ops
+    :sub-runs          diff-sub-runs))
+
+(defn diff-runs
+  "Diff two run-results — the PURE core (spec §Semantic diff). Pure data →
+  data: two run-results in, a readable diff out.
+
+  The `:same?` judgement is `re-frame.story.fingerprint/canonicalize`
+  equality (the SAME judgement `assert-deterministic` renders) — so two runs
+  the determinism gate calls equal diff to `{:same? true}`. When they differ,
+  each facet is computed over the NOISE-STRIPPED run-results (`strip-noise` —
+  the volatile / per-run-stamp / `:rf.story/*` strip, map shape preserved),
+  so the volatile per-run noise (frame ids, timestamps, epoch / dispatch /
+  trace ids) never reaches a facet delta — the diff shows SEMANTIC
+  differences only.
+
+  Returns `{:same? true}` when the two runs are behaviourally identical
+  (every facet matched — the same judgement `assert-deterministic` calls
+  `:deterministic`). Otherwise:
+
+      {:same?  false
+       :facets #{facet-name …}      ; which facets differ (the headline)
+       <facet-name> <facet-delta>}  ; each differing facet's readable delta
+
+  ONLY differing facets appear, so the diff stays small and readable. The
+  `:facets` set names them up front so a consumer can branch without probing
+  each slot.
+
+  The `:same?` judgement is canonical equality of the run-SLICE
+  (`fingerprint/run-hash-input-keys` — the behavioural surface, NOT the whole
+  result), the EXACT slice + judgement `re-frame.story.determinism/compare-runs`
+  uses. A run-result also carries pure provenance (`:frame` replay id,
+  `:run-artifact` back-link, per-step `:replay-steps`) that legitimately
+  differs per replay and is excluded from the slice for exactly this reason —
+  so a diff agrees with the determinism gate on what counts as the same run."
+  [baseline current]
+  (if (= (fingerprint/canonicalize (select-keys baseline fingerprint/run-hash-input-keys))
+         (fingerprint/canonicalize (select-keys current  fingerprint/run-hash-input-keys)))
+    {:same? true}
+    ;; The canonical forms differ. Feed each facet fn the NOISE-STRIPPED but
+    ;; SHAPE-PRESERVED run-results (`strip-noise` — the same volatile / stamp
+    ;; / accumulator strip `canonicalize` applies, WITHOUT the ordering pass
+    ;; that flattens maps into `[k v …]` vectors). The facet fns read named
+    ;; slots, so they need the map shape; they see none of the per-run noise,
+    ;; so every delta they surface is a genuine semantic difference.
+    (let [b      (strip-noise baseline)
+          c      (strip-noise current)
+          deltas (reduce-kv
+                   (fn [acc facet f]
+                     (if-let [d (f b c)]
+                       (assoc acc facet d)
+                       acc))
+                   {}
+                   facet-fns)]
+      (assoc deltas
+             :same?  false
+             :facets (set (keys deltas))))))
+
+;; ===========================================================================
+;; diff-run-artifacts  (the public entry — replay artifacts, then diff)
+;; ===========================================================================
+
+(defn- ->run-result
+  "Coerce a `diff-run-artifacts` side into a run-result. A run-result
+  (carrying a `:status`) is used directly — the PURE path. A
+  `:rf.test/run-artifact` is replayed into a FRESH frame via
+  `re-frame.story.artifact/replay-run-artifact` (the IMPURE path), threading
+  `opts` (`:frame` / `:hooks` / `:frame-config`). Replaying both sides means
+  a diff over two artifacts compares two FRESH-frame runs — exactly the runs
+  the determinism gate would compare — so artifact-vs-artifact and
+  result-vs-result diffs agree."
+  [side opts]
+  (cond
+    (artifact/run-artifact? side) (artifact/replay-run-artifact side opts)
+    :else                         side))
+
+(defn diff-run-artifacts
+  "Readable semantic diff between two runs — the public entry point (spec
+  §Semantic diff). `test/diff-run-artifacts`.
+
+  `baseline` and `current` are each either a `:rf.test/run-artifact` (which
+  is REPLAYED into a fresh frame to obtain a run-result — the impure path,
+  the same replay the determinism gate drives) or an already-computed
+  run-result (used directly — the pure path). `opts` (all optional) thread to
+  `replay-run-artifact`: `:frame` / `:hooks` / `:frame-config`.
+
+  Both runs are projected through `re-frame.story.fingerprint/canonicalize`
+  to strip the per-run noise (frame ids, timestamps, epoch / dispatch /
+  trace ids) BEFORE diffing, so the result shows the SEMANTIC differences —
+  not volatile drift. The diff covers app-db deltas, effects, schema
+  violations, the trace op spine, subscription / view facts, and the
+  top-level status.
+
+  Returns `{:same? true}` when the two runs are behaviourally identical,
+  else `{:same? false :facets #{…} <facet> <delta> …}` carrying ONLY the
+  facets that differ (see `diff-runs`). When both inputs are run-results,
+  this is PURE — `clojure -M:test` exercises it with no runtime."
+  ([baseline current] (diff-run-artifacts baseline current nil))
+  ([baseline current opts]
+   (diff-runs (->run-result baseline opts)
+              (->run-result current opts))))

--- a/tools/story/test/re_frame/story/diff_test.cljc
+++ b/tools/story/test/re_frame/story/diff_test.cljc
@@ -1,0 +1,294 @@
+(ns re-frame.story.diff-test
+  "Tests for the semantic diff over canonical run artifacts —
+  `diff-run-artifacts` + the pure `diff-runs` core (rf2-5x1wt.9,
+  spec/017-Testing-Story.md §Semantic diff).
+
+  Two layers, both under `clojure -M:test` (JVM) + the node-runtime CLJS
+  build:
+
+  - PURE: the facet diffs (`diff-app-db`, `diff-effects`,
+    `diff-schema-violations`, `diff-trace-ops`, `diff-sub-runs`) and the
+    assembler (`diff-runs`) over HAND-BUILT run-results — the §A5 acceptance
+    bullets:
+      • a small readable diff for an app-db change;
+      • an effect-only diff;
+      • a schema-error diff;
+    plus the load-bearing correctness property — volatile per-run noise
+    (frame ids, timestamps, epoch / dispatch / trace ids) is stripped FIRST,
+    so noise never reads as a difference while a real change always does.
+  - HEADLESS (against a live frame): `diff-run-artifacts` replays two
+    artifacts into fresh frames and diffs the results — two equal programs
+    diff `{:same? true}` (no volatile drift), a divergent program surfaces a
+    readable app-db facet."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core      :as rf]
+            [re-frame.epoch     :as epoch]
+            [re-frame.frame     :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.story.artifact :as artifact]
+            [re-frame.story.diff     :as diff]))
+
+;; ===========================================================================
+;; PURE: app-db delta  (§A5 — a small readable diff for an app-db change)
+;; ===========================================================================
+
+(deftest diff-app-db-readable-delta
+  (testing "an unchanged app-db has no delta"
+    (is (nil? (diff/diff-app-db {:n 1 :user {:name "ada"}}
+                                {:n 1 :user {:name "ada"}}))))
+
+  (testing "a single changed leaf yields a one-entry :changed at its path"
+    (let [d (diff/diff-app-db {:n 1 :user {:name "ada"}}
+                              {:n 2 :user {:name "ada"}})]
+      (is (= [{:path [:n] :baseline 1 :current 2}] (:changed d)))
+      (is (nil? (:added d)))
+      (is (nil? (:removed d)))
+      (is (= #{:changed} (set (keys d)))
+          "ONLY the differing slot appears — the unchanged :user path is silent")))
+
+  (testing "an added and a removed leaf are localised to their paths"
+    (let [d (diff/diff-app-db {:a 1 :gone 9}
+                              {:a 1 :new 7})]
+      (is (= [{:path [:new] :current 7}] (:added d)))
+      (is (= [{:path [:gone] :baseline 9}] (:removed d)))
+      (is (nil? (:changed d)))))
+
+  (testing "nested leaf changes report the full key path"
+    (let [d (diff/diff-app-db {:user {:profile {:age 30}}}
+                              {:user {:profile {:age 31}}})]
+      (is (= [{:path [:user :profile :age] :baseline 30 :current 31}]
+             (:changed d))))))
+
+;; ===========================================================================
+;; PURE: effect-only diff  (§A5 — an effect-only diff)
+;; ===========================================================================
+
+(deftest diff-effects-multiset-delta
+  (testing "identical effect rows produce no delta"
+    (is (nil? (diff/diff-effects {:effects [{:fx :http/get :args {:url "/a"}}]}
+                                 {:effects [{:fx :http/get :args {:url "/a"}}]}))))
+
+  (testing "an effect emitted only by current is :only-current"
+    (let [d (diff/diff-effects
+              {:effects [{:fx :http/get :args {:url "/a"}}]}
+              {:effects [{:fx :http/get :args {:url "/a"}}
+                         {:fx :analytics/track :args {:event :viewed}}]})]
+      (is (= [{:fx :analytics/track :args {:event :viewed}}] (:only-current d)))
+      (is (nil? (:only-baseline d)))))
+
+  (testing "the SAME effect twice vs once is a multiset difference (the surplus)"
+    (let [d (diff/diff-effects
+              {:effects [{:fx :db/save} {:fx :db/save}]}
+              {:effects [{:fx :db/save}]})]
+      (is (= [{:fx :db/save}] (:only-baseline d))
+          "baseline emitted it twice, current once — one surplus row")
+      (is (nil? (:only-current d))))))
+
+;; ===========================================================================
+;; PURE: schema-error diff  (§A5 — a schema-error diff)
+;; ===========================================================================
+
+(deftest diff-schema-violations-by-selector
+  (testing "the same violation surface on both sides is no diff"
+    (let [v {:where :event :failing-id :checkout/submit
+             :selector [:event :checkout/submit]}]
+      (is (nil? (diff/diff-schema-violations {:schema-violations [v]}
+                                             {:schema-violations [v]})))))
+
+  (testing "a violation surface only current failed on is :only-current"
+    (let [base    {:schema-violations []}
+          current {:schema-violations
+                   [{:where :event :failing-id :checkout/submit
+                     :selector [:event :checkout/submit]}]}
+          d       (diff/diff-schema-violations base current)]
+      (is (= [[:event :checkout/submit]] (:only-current d))
+          "current introduced a schema failure at [:event :checkout/submit]")
+      (is (nil? (:only-baseline d)))))
+
+  (testing "the selector is recomputed when a record omits it (no :selector slot)"
+    (let [current {:schema-violations
+                   [{:where :app-db :registered-path [:user] :path [:user :age]}]}
+          d       (diff/diff-schema-violations {:schema-violations []} current)]
+      (is (= [[:app-db [:user] [:user :age]]] (:only-current d))))))
+
+;; ===========================================================================
+;; PURE: trace-op spine + sub-runs + status
+;; ===========================================================================
+
+(defn- tape-with-ops
+  "A minimal epoch tape whose single epoch carries trace events with the
+  given `:operation`s, in order."
+  [ops]
+  [{:epoch-id 1
+    :trace-events (mapv (fn [op] {:operation op :op-type :event}) ops)}])
+
+(deftest diff-trace-ops-causal-spine
+  (testing "identical op sequences are no diff"
+    (is (nil? (diff/diff-trace-ops
+                {:epoch-tape (tape-with-ops [:rf.event/run-start :rf.event/run-end])}
+                {:epoch-tape (tape-with-ops [:rf.event/run-start :rf.event/run-end])}))))
+
+  (testing "a diverging op sequence reports both spines + the first divergence"
+    (let [d (diff/diff-trace-ops
+              {:epoch-tape (tape-with-ops [:a :b :c])}
+              {:epoch-tape (tape-with-ops [:a :x :c])})]
+      (is (= [:a :b :c] (:baseline d)))
+      (is (= [:a :x :c] (:current d)))
+      (is (= 1 (:first-divergence d)) "index 1 (:b vs :x) is the first divergence")))
+
+  (testing "a dropped trailing op is a diff with no in-range first-divergence"
+    (let [d (diff/diff-trace-ops
+              {:epoch-tape (tape-with-ops [:a :b :c])}
+              {:epoch-tape (tape-with-ops [:a :b])})]
+      (is (= [:a :b :c] (:baseline d)))
+      (is (= [:a :b] (:current d)))
+      (is (nil? (:first-divergence d))
+          "current is a proper prefix — only the length differs"))))
+
+(deftest diff-sub-runs-multiset-delta
+  (testing "a sub-run only one side produced surfaces as a view fact diff"
+    (let [d (diff/diff-sub-runs
+              {:sub-runs [{:query [:visible-todos] :value 3}]}
+              {:sub-runs [{:query [:visible-todos] :value 5}]})]
+      (is (= [{:query [:visible-todos] :value 3}] (:only-baseline d)))
+      (is (= [{:query [:visible-todos] :value 5}] (:only-current d))))))
+
+(deftest diff-status-headline
+  (testing "a pass → fail flip is reported"
+    (is (= {:baseline :pass :current :fail}
+           (diff/diff-status {:status :pass} {:status :fail}))))
+  (testing "a shared status is no diff"
+    (is (nil? (diff/diff-status {:status :pass} {:status :pass})))))
+
+;; ===========================================================================
+;; PURE: the assembler — :same? and the multi-facet readable diff
+;; ===========================================================================
+
+(deftest diff-runs-same-when-behaviourally-identical
+  (testing "two runs equal under canonicalize diff to {:same? true}"
+    (let [r {:status :pass :app-db {:n 1} :effects [] :sub-runs []
+             :epoch-tape (tape-with-ops [:rf.event/run-start])}]
+      (is (= {:same? true} (diff/diff-runs r r))))))
+
+(deftest diff-runs-collects-only-differing-facets
+  (testing "an app-db-only change surfaces ONLY the :app-db facet"
+    (let [base {:status :pass :app-db {:n 1} :effects [] :sub-runs []
+                :epoch-tape (tape-with-ops [:rf.event/run-start])}
+          cur  (assoc base :app-db {:n 2})
+          d    (diff/diff-runs base cur)]
+      (is (false? (:same? d)))
+      (is (= #{:app-db} (:facets d)))
+      (is (= [{:path [:n] :baseline 1 :current 2}] (get-in d [:app-db :changed])))
+      (is (not (contains? d :effects)))))
+
+  (testing "a status + effect change surfaces BOTH facets, named in :facets"
+    (let [base {:status :pass :app-db {} :effects [] :sub-runs []
+                :epoch-tape (tape-with-ops [:e])}
+          cur  {:status :fail :app-db {} :sub-runs []
+                :effects [{:fx :http/get :outcome :error}]
+                :epoch-tape (tape-with-ops [:e])}
+          d    (diff/diff-runs base cur)]
+      (is (= #{:status :effects} (:facets d)))
+      (is (= {:baseline :pass :current :fail} (:status d)))
+      (is (= [{:fx :http/get :outcome :error}] (get-in d [:effects :only-current]))))))
+
+;; ===========================================================================
+;; PURE: the load-bearing property — volatile noise is stripped FIRST
+;; ===========================================================================
+
+(defn- noisy-run
+  "A run-result whose epoch tape + app-db carry per-run stamps a fresh-frame
+  replay would write differently every time (frame id, epoch id, committed-at,
+  trace :id / :time), wrapping the same semantic `db-after`."
+  [{:keys [frame epoch-id committed-at trace-id db-after]}]
+  {:status :pass
+   :app-db db-after
+   :frame  frame
+   :epoch-tape
+   [{:epoch-id epoch-id :frame frame :committed-at committed-at
+     :outcome :ok :db-before {} :db-after db-after
+     :effects [] :sub-runs [] :renders []
+     :trace-events [{:operation :rf.event/run-start :op-type :event
+                     :id trace-id :time committed-at
+                     :tags {:rf.trace/event-id :app/go}}]}]})
+
+(deftest diff-runs-strips-volatile-noise
+  (testing "two runs differing ONLY in per-run stamps diff to {:same? true}"
+    (let [a (noisy-run {:frame :rf.test.replay/frame-aaa :epoch-id 5
+                        :committed-at 1000 :trace-id 17 :db-after {:n 1}})
+          b (noisy-run {:frame :rf.test.replay/frame-zzz :epoch-id 99
+                        :committed-at 2000 :trace-id 88 :db-after {:n 1}})]
+      (is (= {:same? true} (diff/diff-runs a b))
+          "frame ids, epoch ids, timestamps, trace ids are NOT differences")))
+
+  (testing "a real app-db change IS detected even amid the per-run noise"
+    (let [a (noisy-run {:frame :rf.test.replay/frame-aaa :epoch-id 5
+                        :committed-at 1000 :trace-id 17 :db-after {:n 1}})
+          c (noisy-run {:frame :rf.test.replay/frame-zzz :epoch-id 99
+                        :committed-at 2000 :trace-id 88 :db-after {:n 2}})
+          d (diff/diff-runs a c)]
+      (is (false? (:same? d)))
+      (is (contains? (:facets d) :app-db))
+      (is (= [{:path [:n] :baseline 1 :current 2}] (get-in d [:app-db :changed]))
+          "the strip surfaces the SEMANTIC change, not the volatile drift"))))
+
+(deftest diff-runs-strips-story-accumulator-keys
+  (testing ":rf.story/* accumulator keys in app-db are stripped before diffing"
+    (let [a {:status :pass :app-db {:n 1 :rf.story/probe :a}}
+          b {:status :pass :app-db {:n 1 :rf.story/probe :b}}]
+      (is (= {:same? true} (diff/diff-runs a b))
+          "the accumulator key differs but is not semantic — stripped first"))))
+
+;; ===========================================================================
+;; HEADLESS: diff-run-artifacts over real replays  (live frame)
+;; ===========================================================================
+
+(defn- reset-rf! [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (epoch/clear-history!)
+  (epoch/clear-epoch-listeners!)
+  (try (rf/init! plain-atom/adapter)
+       (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) _ nil))
+  (frame/ensure-default-frame!)
+  (test-fn))
+
+(use-fixtures :each reset-rf!)
+
+(deftest diff-run-artifacts-equal-programs-are-same
+  (testing "replaying the SAME program twice into fresh frames diffs {:same? true}
+            — fresh-frame volatile drift causes no false difference"
+    (rf/reg-event-db :diff/inc (fn [db _] (update db :n (fnil inc 0))))
+    (let [a (artifact/make-run-artifact
+              {:event-program [[:dispatch [:diff/inc]] [:dispatch [:diff/inc]]]})]
+      (is (= {:same? true} (diff/diff-run-artifacts a a))
+          "two fresh-frame replays of one program are behaviourally identical"))))
+
+(deftest diff-run-artifacts-divergent-program-surfaces-app-db-facet
+  (testing "two programs producing different final app-db surface a readable
+            :app-db facet"
+    (rf/reg-event-db :diff/set (fn [db [_ v]] (assoc db :v v)))
+    (let [a (artifact/make-run-artifact {:event-program [[:dispatch [:diff/set 1]]]})
+          b (artifact/make-run-artifact {:event-program [[:dispatch [:diff/set 2]]]})
+          d (diff/diff-run-artifacts a b)]
+      (is (false? (:same? d)))
+      (is (contains? (:facets d) :app-db))
+      (is (= [{:path [:v] :baseline 1 :current 2}]
+             (get-in d [:app-db :changed]))))))
+
+(deftest diff-run-artifacts-accepts-a-run-result-directly
+  (testing "a run-result side is used as-is (the pure path) — diffing an
+            artifact replay against a hand-built result still works"
+    (rf/reg-event-db :diff/set (fn [db [_ v]] (assoc db :v v)))
+    (let [art    (artifact/make-run-artifact {:event-program [[:dispatch [:diff/set 9]]]})
+          result {:status :pass :app-db {:v 9} :effects [] :sub-runs []
+                  :epoch-tape []}
+          d      (diff/diff-run-artifacts art result)]
+      ;; The artifact replay's app-db {:v 9} matches the hand-built result's
+      ;; {:v 9}; the trace-op spine differs (the replay has trace events, the
+      ;; hand-built result none), so the diff is NOT :same? but the app-db
+      ;; facet is absent.
+      (is (or (:same? d)
+              (not (contains? (:facets d) :app-db)))
+          "app-db agrees across the artifact-vs-result diff"))))


### PR DESCRIPTION
@
## Summary

Adds `test/diff-run-artifacts` — a readable **semantic diff** between two runs (NewTestStory §A5, `tools/story/spec/017-Testing-Story.md` §Semantic diff). New `re-frame.story.diff` namespace; one re-export on the `re-frame.story` facade; a `## Semantic diff` section in spec/017.

Each side is either a `:rf.test/run-artifact` (replayed into a fresh frame via `.7`s `replay-run-artifact`) or an already-computed run-result. Both are projected through `re-frame.story.fingerprint/canonicalize` (`.3`/`.8`) **before** diffing, so the result shows the SEMANTIC difference and not the per-run noise (frame ids, timestamps, epoch / dispatch / trace ids).

The diff is small by construction: `{:same? true}` for behaviourally-identical runs, else `{:same? false :facets #{…} <facet> <delta>}` carrying ONLY the facets that differ:

- `:app-db` — readable key-path delta (`:added` / `:removed` / `:changed`), never a database dump;
- `:effects` — multiset delta (`:only-baseline` / `:only-current`);
- `:schema-violations` — multiset delta over surface **selectors** (§Schema rule);
- `:trace-ops` — the ordered causal op spine + `:first-divergence`;
- `:sub-runs` — subscription / view facts when available;
- `:status` — the top-level run status.

The `:same?` judgement uses the same run-**slice** (`run-hash-input-keys`) + canonical equality the determinism gates `compare-runs` uses, so a diff agrees with `assert-deterministic` on what counts as the same run.

## Build-on, read-only

Consumes `re-frame.story.artifact` (`.7`), `re-frame.story.fingerprint` (`.3`/`.8`), and `re-frame.story.play.evidence` read-only. Did NOT touch `schemas.cljc` / `plan.cljc` / the render or sub-resolution path / `fingerprint.cljc` / `artifact.cljc` / `determinism.cljc` / `evidence.cljc` (the `.13` sibling lane + the merged deps). The only edit outside the new files is one appended `diff-run-artifacts` re-export on `re-frame.story` and the new spec section.

## Pure / JVM-testable

The facet fns (`diff-app-db`, `diff-effects`, `diff-schema-violations`, `diff-trace-ops`, `diff-sub-runs`) and the assembler (`diff-runs`) are pure data → data; only the artifact-replay entry path is impure. Tests (`diff_test.cljc`, `.cljc`) cover the §A5 acceptance — an app-db-change diff, an effect-only diff, a schema-error diff — plus the load-bearing property (volatile noise stripped first: equal-but-noisy runs diff `{:same? true}`; a real change is still detected) and a headless replay-based diff over real artifacts.

## Quality gates

- `cd tools/story && clojure -M:test` — 1047 tests, 3164 assertions, 0 failures, 0 errors
- `npm --prefix implementation run test:cljs` — 4848 tests, 15885 assertions, 0 failures, 0 errors
- `bash scripts/test-fast-pr.sh` — PASS fast PR spine
@