### PR TITLE
feat(story): :sub-overrides for view-state variants + fidelity marking (rf2-5x1wt.13)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -531,6 +531,63 @@ legitimate, but it must be labelled. In the normalized plan, top-level
 is computed from the resolved world inputs, so authors SHOULD NOT have to
 type it.
 
+**Compiler contract (as implemented).** The plan compiler
+(`re-frame.story.plan`):
+
+1. **Resolves `[:arg key]` placeholders inside the override VALUES** (and
+   keys), through the same one-level `substitute-args` pass setup / script
+   / network use. A placeholder referencing an undeclared arg FAILS plan
+   construction with `:rf.error/story-missing-arg` — the override value is
+   not exempt from the args contract.
+2. **Composes through fragments + the parent chain.** A composed fragment
+   MAY contribute `:sub-overrides`; fragment maps merge in declared order,
+   then the variant chain (where `:extends` context flowed down) wins per
+   query key. The result is one flat `{query-vector value}` map.
+3. **Validates each resolved value against the subscription's OUTPUT
+   schema** when one is on file (via the `:sub-lookup` opt — a `(sub-id) →
+   sub-meta` fn / map, defaulting to the framework `:sub` registrar; the
+   schema rides on the sub-metadata `:schema` slot). This is the
+   subscription-output contract, **distinct** from the view-arg/props
+   schema (§View arg schemas — sharp boundary). A value that violates a
+   present output schema FAILS plan construction **before render** with
+   `:rf.error/story-sub-override-invalid`, whose ex-data carries the
+   offending `:violations` (each `{:query-v :sub-id :value :schema
+   :explain}`). A sub with no output schema soft-passes; with no validator
+   threaded the value-against-schema check soft-passes (the host-free
+   floor — the same convention the view-arg malformed-value check uses).
+4. **Lowers the resolved map to `[:world :render :sub-overrides]`** and
+   **marks `[:world :fidelity]`** with `:sub-overrides`. `:fidelity` is a
+   SET drawn from `#{:real-setup :db-seed :sub-overrides}`, computed from
+   the world inputs: `:real-setup` when setup events / a script drive real
+   state, `:db-seed` when a schema-checked app-db seed is present
+   (reserved world slot), `:sub-overrides` when any override resolves. A
+   pure design variant yields `#{:sub-overrides}`; a hybrid carries both.
+   Because `:fidelity` lives in `:world`, it participates in `:plan-hash`.
+
+| Plan slot | Meaning |
+|---|---|
+| `[:world :render :sub-overrides]` | the resolved `{query-vector value}` map, `[:arg]` placeholders substituted |
+| `[:world :fidelity]` | the resolved fidelity-ladder set (present when non-empty) |
+| `[:explain :sub-overrides]` | `{:overrides … :validation {:status :ok :violations []}}` — overrides are visible in explain |
+| `[:explain :fidelity]` | the same fidelity set, surfaced for docs / review |
+
+**Render-path read + the honesty rule.** Overrides feed the RENDER PATH
+only. The render-path resolver (`re-frame.story.sub-overrides`) binds the
+variant's resolved override map for the view-render extent; a Story-
+rendered view's subscribed reads that route through `sub-overrides/read`
+surface the override on an **exact** query-vector match (`=` on the whole
+vector — no prefix / sub-id fuzzing, so an override never leaks into a
+sibling query the author did not name; a `nil`-valued override is a
+genuine hit). The resolver never writes app-db and never calls
+`compute-sub`. That boundary is what keeps `:rf.assert/sub-equals` honest:
+the assertion evaluates a sub through `compute-sub` against the frame's
+app-db snapshot (`re-frame.story.assertions/evaluate-sub-equals`), which
+the resolver does not touch — so a `:sub-overrides` value does NOT satisfy
+a subscription assertion. Subscription correctness is proven by real setup
+events, a schema-checked app-db seed, or `compute-sub`, never by an
+override (unless a future assertion explicitly opts into override-source
+semantics).
+
 ### Network stubs
 
 Top-level `:network` lowers to `[:world :network]` and then to the

--- a/tools/story/src/re_frame/story/plan.cljc
+++ b/tools/story/src/re_frame/story/plan.cljc
@@ -48,6 +48,27 @@
   subscriptions / `:sub-overrides` (§View-state subscription overrides);
   the two MUST NOT be conflated.
 
+  ## View-state subscription overrides (rf2-5x1wt.13)
+
+  A variant whose goal is rendering / design exploration MAY author
+  `:sub-overrides` — a map of exact subscription query vectors to data
+  values the renderer surfaces for them (§View-state subscription
+  overrides). The compiler resolves `[:arg key]` placeholders inside the
+  override VALUES (same one-level mechanism as setup/script), validates
+  each resolved value against the subscription's OUTPUT schema when one is
+  on file (distinct from the view-arg schema above — a missing schema soft-
+  passes), lowers the map to `[:world :render :sub-overrides]`, and marks
+  the plan `:fidelity` with `:sub-overrides`. A resolved value that
+  violates a sub's output schema FAILS plan construction (before render)
+  with `:rf.error/story-sub-override-invalid`.
+
+  Overrides feed the RENDER PATH only (`re-frame.story.sub-overrides`) —
+  never app-db, never `compute-sub` — so a `:sub-overrides` value does NOT
+  satisfy `:rf.assert/sub-equals` (which evaluates through `compute-sub`
+  against the frame snapshot). `:sub-overrides` is the third, deliberately
+  lower-fidelity rung of the fidelity ladder; the `:fidelity` set labels
+  it so a reviewer can tell at a glance which evidence a variant rests on.
+
   ## Network world slot (rf2-5x1wt.14)
 
   When a variant authors `:network` (a `{[method url] {:reply …}}` route
@@ -497,6 +518,139 @@
        {:status :ok :schema schema :missing [] :malformed []}))))
 
 ;; ============================================================================
+;; View-state subscription overrides (rf2-5x1wt.13)
+;; ============================================================================
+;;
+;; Per spec §View-state subscription overrides. `:sub-overrides` is a map
+;; of EXACT subscription query vectors → data values the renderer surfaces
+;; for view-state / design exploration. The compiler:
+;;
+;;   1. resolves `[:arg key]` placeholders inside the override VALUES
+;;      (handled in `compile-body` by the shared `substitute-args` pass);
+;;   2. validates each resolved value against the subscription's OUTPUT
+;;      schema when one is on file (this section) — DISTINCT from the
+;;      view-arg schema, which validates explicit view inputs. A sub with
+;;      no output schema soft-passes (the floor matches the view-arg
+;;      malformed-value convention: no validator → no malformed check);
+;;   3. lowers the resolved map to `[:world :render :sub-overrides]`;
+;;   4. marks the plan `:fidelity` with `:sub-overrides`.
+;;
+;; A resolved value that VIOLATES a sub's output schema FAILS plan
+;; construction (before render) with `:rf.error/story-sub-override-
+;; invalid`. The override never touches app-db or `compute-sub`, so it
+;; does NOT satisfy `:rf.assert/sub-equals` (the §View-state subscription
+;; overrides honesty rule) — that boundary lives at the render-path
+;; resolver (`re-frame.story.sub-overrides`) + the assertion module.
+;;
+;; **Subscription-output-schema source.** A sub's output schema rides on
+;; its framework `:sub` registrar metadata `:schema` slot (`reg-sub`'s
+;; optional metadata map: `(reg-sub :id {:schema …} …)`). The sub-id is
+;; the FIRST element of the query vector. The compiler resolves it through
+;; a `:sub-lookup` opt — a `(sub-id) → sub-meta` fn or `{sub-id → sub-meta}`
+;; map, defaulting to the framework `:sub` registrar — so the compiler
+;; stays a pure data → data fn for host-free tests (the test threads an
+;; explicit map; production reads the registrar).
+
+(def ^:private sub-output-schema-keys
+  "Sub-metadata keys carrying the subscription OUTPUT schema, in
+  resolution order (first present wins). `:schema` is the `reg-sub`
+  metadata slot (Spec 010 §reg-sub); `:rf/output` is reserved for a
+  future explicit output-schema key a port may adopt."
+  [:schema :rf/output])
+
+(defn sub-output-schema
+  "Return the OUTPUT schema for a subscription from its `sub-meta` map
+  (the framework `:sub` registrar slot), or nil when none is present.
+  Picks the first of `sub-output-schema-keys` that is set. This is the
+  subscription-output contract — DISTINCT from the view-args/props schema
+  `view-args-schema` reads (§View-state subscription overrides — sharp
+  boundary)."
+  [sub-meta]
+  (when (map? sub-meta)
+    (some (fn [k] (let [s (get sub-meta k)] (when (some? s) s)))
+          sub-output-schema-keys)))
+
+(defn validate-sub-overrides
+  "Validate every resolved `:sub-overrides` value against its
+  subscription's OUTPUT schema. Pure data → data.
+
+  - `sub-overrides` — the resolved `{query-vector value}` map (post `[:arg
+    key]` substitution).
+  - `sub-lookup` — a 1-arg fn `(sub-id) → sub-meta` resolving a
+    subscription's registration metadata (for its output schema). The
+    sub-id is `(first query-vector)`.
+  - `validator-fns` — `{:validate (fn [schema value] truthy?) :explain (fn
+    [schema value] explanation)}`, the SAME malformed-value validator the
+    view-arg path threads. With no validator, value-against-schema
+    checking SOFT-PASSES (the host-free floor — a `:sub-overrides`-only
+    JVM test that wants schema enforcement threads a Malli validator).
+
+  Returns `{:status :ok | :invalid :violations [...]}` where each
+  violation is `{:query-v qv :sub-id id :value v :schema s :explain
+  explanation}`. A query whose sub carries no output schema is skipped
+  (soft-pass); only a present schema that the value fails is a violation."
+  [sub-overrides sub-lookup validator-fns]
+  (let [validate (:validate validator-fns)
+        explain  (:explain  validator-fns)
+        entries  (seq sub-overrides)]
+    (if (or (nil? entries) (nil? validate))
+      ;; No overrides, or no validator → nothing structural to check.
+      {:status :ok :violations []}
+      (let [violations
+            (into []
+                  (keep (fn [[query-v value]]
+                          (let [sub-id (when (vector? query-v) (first query-v))
+                                schema (sub-output-schema (sub-lookup sub-id))]
+                            (when (and (some? schema) (not (validate schema value)))
+                              {:query-v query-v
+                               :sub-id  sub-id
+                               :value   value
+                               :schema  schema
+                               :explain (when explain (explain schema value))}))))
+                  entries)]
+        {:status     (if (empty? violations) :ok :invalid)
+         :violations violations}))))
+
+;; ============================================================================
+;; Fidelity ladder (rf2-5x1wt.13)
+;; ============================================================================
+;;
+;; Per spec §View-state subscription overrides — the fidelity ladder is:
+;; real setup events (highest) → schema-checked app-db seed → subscription
+;; overrides (lowest, but legitimate when labelled). `:fidelity` is a SET
+;; of the rungs a resolved plan actually rests on, computed from the world
+;; inputs so authors never type it. A reviewer reads the set to know which
+;; evidence a variant's render leans on.
+;;
+;;   :real-setup    — the variant has setup events (or a script) that
+;;                    drive real state into the frame;
+;;   :db-seed       — a schema-checked direct app-db seed (the world
+;;                    `:db-seed` slot; reserved — folded in when that slot
+;;                    lands so this fn does not need revisiting);
+;;   :sub-overrides — one or more view-state subscription overrides.
+
+(defn compute-fidelity
+  "Compute the `:fidelity` set for a resolved plan from its world inputs.
+  Pure data → data. Returns a (possibly empty) set drawn from
+  `#{:real-setup :db-seed :sub-overrides}`:
+
+  - `:real-setup`    when `setup` (or `script`) is non-empty — real
+                     events drive the frame's state;
+  - `:db-seed`       when `db-seed` is present (a schema-checked direct
+                     app-db seed; reserved world slot);
+  - `:sub-overrides` when `sub-overrides` resolves any entry.
+
+  A plain events-driven variant yields `#{:real-setup}`; a pure design
+  variant that only pins sub values yields `#{:sub-overrides}`; a hybrid
+  carries both. The empty set (no setup, no seed, no overrides) is a
+  legitimate render-the-view-as-mounted variant."
+  [{:keys [setup script db-seed sub-overrides]}]
+  (cond-> #{}
+    (or (seq setup) (seq script)) (conj :real-setup)
+    (some? db-seed)               (conj :db-seed)
+    (seq sub-overrides)           (conj :sub-overrides)))
+
+;; ============================================================================
 ;; Network world slot (rf2-5x1wt.14)
 ;; ============================================================================
 ;;
@@ -768,6 +922,26 @@
                               "re-frame2-story: :view-lookup must be a fn or a map"
                               {:view-lookup view-lookup})))
 
+(defn- default-sub-lookup
+  "Default subscription-metadata lookup — reads the **framework** `:sub`
+  registrar slot (where `reg-sub` stamps a sub's metadata, incl. any
+  `:schema` output-schema slot). Resolves the OUTPUT-schema source for
+  `:sub-overrides` value validation (rf2-5x1wt.13). Production bundles
+  that elide subs return nil; pure tests thread an explicit `:sub-lookup`."
+  [sub-id]
+  (framework-registrar/handler-meta :sub sub-id))
+
+(defn- coerce-sub-lookup
+  "Accept a 1-arg fn or a `{sub-id → sub-meta}` map as `:sub-lookup`."
+  [sub-lookup]
+  (cond
+    (nil? sub-lookup) default-sub-lookup
+    (map? sub-lookup) #(get sub-lookup %)
+    (fn? sub-lookup)  sub-lookup
+    :else             (fail! :rf.error/story-bad-lookup
+                             "re-frame2-story: :sub-lookup must be a fn or a map"
+                             {:sub-lookup sub-lookup})))
+
 ;; ---- fragment + check lookup (rf2-5x1wt.15) ------------------------------
 
 (defn- default-fragment-lookup
@@ -814,11 +988,16 @@
   - `:fragment-lookup` / `:check-lookup` — a 1-arg fn `(id) → body` OR a
     `{id → body}` map resolving the bodies named in `:compose`
     (rf2-5x1wt.15). Default to the Story side-table `:fragment` / `:check`
-    kinds."
+    kinds.
+  - `:sub-lookup` — a 1-arg fn `(sub-id) → sub-meta` OR a `{sub-id →
+    sub-meta}` map resolving a subscription's registration metadata (for
+    its OUTPUT schema, against which `:sub-overrides` values are validated
+    — rf2-5x1wt.13). Defaults to the framework `:sub` registrar."
   ([id body lookup] (compile-body id body lookup nil))
-  ([id body lookup {:keys [view-lookup validator-fns
+  ([id body lookup {:keys [view-lookup validator-fns sub-lookup
                            fragment-lookup check-lookup] :as _opts}]
   (let [view-lookup  (coerce-view-lookup view-lookup)
+        sub-lookup   (coerce-sub-lookup sub-lookup)
         frag-lookup  (coerce-kind-lookup :fragment-lookup fragment-lookup
                                          default-fragment-lookup)
         chk-lookup   (coerce-kind-lookup :check-lookup check-lookup
@@ -894,7 +1073,18 @@
         subs!        (atom [])
         setup        (substitute-args setup-raw arg-map subs!)
         script*      (substitute-args script arg-map subs!)
-        sub-overrides (substitute-args (:sub-overrides ctx) arg-map subs!)
+        ;; ---- view-state subscription overrides (rf2-5x1wt.13) ----
+        ;; `:sub-overrides` composes like `:network`: composed-fragment
+        ;; override maps merge in declared order (a later fragment wins a
+        ;; query key), THEN the variant chain (`ctx`, where `:extends`
+        ;; context flowed down) wins on top. Override VALUES may carry
+        ;; `[:arg key]` placeholders (e.g. an error message driven by a
+        ;; control), so substitute AFTER merging. KEYS are exact query
+        ;; vectors — `[:arg]` substitution walks them too, so a query arg
+        ;; can also be control-driven.
+        frag-sub-ovr (reduce (fn [m l] (merge m (:sub-overrides l))) {} frag-layers)
+        sub-overrides (substitute-args (merge frag-sub-ovr (:sub-overrides ctx))
+                                       arg-map subs!)
         ;; ---- strict-conflict composition (rf2-5x1wt.15) ----
         ;; The strict-conflict override MAPS (`:fx-overrides` /
         ;; `:interceptor-overrides`) compose per-KEY: the variant chain
@@ -976,6 +1166,34 @@
                                :missing         (:missing validation)
                                :malformed       (:malformed validation)
                                :effective-args  eff-args}))
+        ;; ---- :sub-overrides output-schema validation (rf2-5x1wt.13) ----
+        ;; Each resolved override value is validated against its
+        ;; subscription's OUTPUT schema (distinct from the view-args
+        ;; schema above). A sub with no output schema soft-passes; a value
+        ;; that violates a present schema FAILS plan construction BEFORE
+        ;; render with `:rf.error/story-sub-override-invalid`. Threads the
+        ;; SAME malformed-value validator the view-args path uses, so a
+        ;; JVM test with no validator checks shape only at the renderer.
+        sub-ovr-val  (when (seq sub-overrides)
+                       (validate-sub-overrides sub-overrides sub-lookup validator-fns))
+        _            (when (and sub-ovr-val (= :invalid (:status sub-ovr-val)))
+                       (fail! :rf.error/story-sub-override-invalid
+                              (str "re-frame2-story: variant " id
+                                   " — :sub-overrides value(s) do not satisfy the "
+                                   "subscription output schema(s): "
+                                   (pr-str (mapv :query-v (:violations sub-ovr-val))))
+                              {:variant/id id
+                               :violations (:violations sub-ovr-val)}))
+        ;; ---- fidelity ladder (rf2-5x1wt.13) ----
+        ;; Computed from the resolved world inputs so authors never type
+        ;; it. `:real-setup` (events/script) > `:db-seed` (reserved world
+        ;; slot) > `:sub-overrides` — the rung(s) a reviewer reads to know
+        ;; which evidence the variant rests on (§View-state subscription
+        ;; overrides — fidelity ladder).
+        fidelity     (compute-fidelity {:setup         setup
+                                        :script        script*
+                                        :db-seed       (:db-seed ctx)
+                                        :sub-overrides sub-overrides})
         ;; ---- runner requirement ----
         required     (compute-required-runner setup script* assertions)
         ;; ---- source coords ----
@@ -989,6 +1207,13 @@
                               :platforms      platforms}
                        (some? schema)        (assoc :view-args-schema schema)
                        (some? sub-overrides) (assoc-in [:render :sub-overrides] sub-overrides)
+                       ;; rf2-5x1wt.13 — the fidelity ladder, computed from
+                       ;; the resolved world inputs. In `:world` so it
+                       ;; participates in `:plan-hash` (fingerprint's
+                       ;; `plan-hash-input-keys` hashes `:world`). Present
+                       ;; when non-empty; a bare render-as-mounted variant
+                       ;; (no setup/seed/overrides) carries no slot.
+                       (seq fidelity)        (assoc :fidelity fidelity)
                        ;; `:network` keeps the per-route reply data (source
                        ;; of truth, feeds :plan-hash via :world); the
                        ;; lowering (rf2-5x1wt.14) folds its managed-stub fx
@@ -1044,6 +1269,23 @@
                       :network      (when (seq network)
                                       {:routes       network
                                        :lowered-to   (:fx-overrides network-low)})
+                      ;; rf2-5x1wt.13 — view-state subscription overrides +
+                      ;; the resolved fidelity ladder. `explain` surfaces
+                      ;; the resolved override map (post `[:arg]`
+                      ;; substitution) and the validation outcome so a
+                      ;; reviewer / doc page can see exactly which subs were
+                      ;; pinned, and `:fidelity` labels the evidence rung(s)
+                      ;; (§View-state subscription overrides — overrides are
+                      ;; visible in explain).
+                      :sub-overrides (when (seq sub-overrides)
+                                       {:overrides  sub-overrides
+                                        ;; :status :ok here (an :invalid run
+                                        ;; throws upstream); documents the
+                                        ;; passing output-schema contract.
+                                        :validation (when sub-ovr-val
+                                                      {:status     (:status sub-ovr-val)
+                                                       :violations (:violations sub-ovr-val)})})
+                      :fidelity     fidelity
                       :setup-order  setup
                       :script-order script*
                       :checks       checks
@@ -1089,21 +1331,28 @@
   - `:fragment-lookup` / `:check-lookup` — a 1-arg fn `(id) → body` OR a
     `{id → body}` map resolving the bodies named in `:compose`
     (rf2-5x1wt.15). Default to the side-table `:fragment` / `:check` kinds.
+  - `:sub-lookup` — a 1-arg fn `(sub-id) → sub-meta` OR a `{sub-id →
+    sub-meta}` map resolving a subscription's registration metadata for
+    its OUTPUT schema, against which `:sub-overrides` values are validated
+    (rf2-5x1wt.13). Defaults to the framework `:sub` registrar.
 
   Returns the normalized plan map: `:variant/id`, `:source-chain`,
   `:world` (incl. `:effective-args` and `:view-args-schema` when a view
-  schema is on file), `:script`, `:expect`, `:required-runner`, `:tags`,
-  `:explain` (and `:source` when coords are present).
+  schema is on file, `[:render :sub-overrides]` + `:fidelity` when the
+  variant pins view-state), `:script`, `:expect`, `:required-runner`,
+  `:tags`, `:explain` (and `:source` when coords are present).
 
   FAILS with a structured `:rf.error/story-*` ex-info on: an unregistered
   keyword target, an unregistered `:extends` parent, an `:extends` cycle,
   a missing `[:arg key]`, an unregistered/nested `:compose` fragment, a
-  silent strict-conflict between composed fragments, or `:effective-args`
-  that violate the view-args schema (`:rf.error/story-view-args-invalid`)."
+  silent strict-conflict between composed fragments, `:effective-args`
+  that violate the view-args schema (`:rf.error/story-view-args-invalid`),
+  or a `:sub-overrides` value that violates its subscription's output
+  schema (`:rf.error/story-sub-override-invalid`)."
   ([target] (variant-plan target nil))
   ([target {:keys [lookup] :as opts}]
    (let [lookup-fn    (coerce-lookup lookup)
-         compile-opts (select-keys opts [:view-lookup :validator-fns
+         compile-opts (select-keys opts [:view-lookup :validator-fns :sub-lookup
                                          :fragment-lookup :check-lookup])]
      (cond
        (keyword? target)

--- a/tools/story/src/re_frame/story/schemas.cljc
+++ b/tools/story/src/re_frame/story/schemas.cljc
@@ -550,6 +550,45 @@
    [:fn {:error/message ":network route value must carry a :reply"}
     (fn [m] (contains? m :reply))]])
 
+;; ---- :sub-overrides — view-state subscription overrides (rf2-5x1wt.13) ---
+
+(def SubQueryVector
+  "A `:sub-overrides` key — an exact subscription query vector
+  `[sub-id & args]` (spec/017 §View-state subscription overrides). The
+  first element is the subscription id keyword; the rest are the query
+  args. Shape is left loose past the leading-keyword check so the
+  subscription-output-schema validation (a plan-compiler concern) carries
+  the precise diagnostic rather than a structural schema rejection on an
+  arg shape."
+  [:and
+   [:vector :any]
+   [:fn {:error/message
+         ":sub-overrides key must be a query vector starting with a sub-id keyword"}
+    (fn [v]
+      (and (vector? v)
+           (pos? (count v))
+           (keyword? (first v))))]])
+
+(def SubOverridesMap
+  "Schema for the `:sub-overrides` slot on a variant / fragment body —
+  the deliberate lower-fidelity view-state affordance (rf2-5x1wt.13 +
+  spec/017 §View-state subscription overrides). A map of exact
+  subscription query vectors to the data values the renderer should
+  surface for them.
+
+  Values are plain data (`:any`) — they MAY carry `[:arg key]`
+  placeholders, which the plan compiler resolves before render; the
+  resolved value MUST validate against the subscription's output schema
+  when one exists (a plan-compiler check, not a structural one here).
+
+  `:sub-overrides` is a RENDERING / design-exploration affordance: it
+  feeds the render path only, never app-db or `compute-sub`, so a
+  `:sub-overrides` value does NOT satisfy `:rf.assert/sub-equals` as
+  proof of real subscription logic. A plan that resolves any override
+  carries `:fidelity` including `:sub-overrides` (the third, labelled
+  rung of the fidelity ladder)."
+  [:map-of SubQueryVector :any])
+
 (def NetworkSpec
   "Schema for the `:network` slot on a story / variant / fragment body —
   first-class managed-HTTP request stubs (rf2-5x1wt.14). A map of
@@ -670,6 +709,17 @@
     ;; serves non-HTTP effects. See `NetworkSpec` + spec/017 §Network
     ;; world.
     [:network               {:optional true} NetworkSpec]
+    ;; rf2-5x1wt.13 — view-state subscription overrides. A map of exact
+    ;; subscription query vectors → data values the renderer surfaces
+    ;; for design/view-state exploration. The plan compiler resolves
+    ;; `[:arg key]` placeholders in the values, validates each resolved
+    ;; value against the subscription's output schema when one exists,
+    ;; lowers the map to `[:world :render :sub-overrides]`, and marks the
+    ;; plan `:fidelity` with `:sub-overrides`. Overrides feed render only
+    ;; — never app-db / `compute-sub` — so they do NOT satisfy
+    ;; `:rf.assert/sub-equals`. See `SubOverridesMap` + spec/017
+    ;; §View-state subscription overrides.
+    [:sub-overrides         {:optional true} SubOverridesMap]
     ;; rf2-5x1wt.15 — strict-conflict effect/interceptor override slots.
     ;; `:fx-overrides` is the first-class fx-override surface (spec/017
     ;; §The effect-override surface); `:interceptor-overrides` the
@@ -789,6 +839,11 @@
     [:script                {:optional true} PlaySpec]
     [:play-script           {:optional true} PlaySpec]
     [:network               {:optional true} NetworkSpec]
+    ;; rf2-5x1wt.13 — a fragment MAY contribute `:sub-overrides`; they
+    ;; deep-merge into the composing variant's override map (a later
+    ;; fragment / the variant wins per key) and mark the resolved plan
+    ;; `:fidelity` with `:sub-overrides`. See `SubOverridesMap`.
+    [:sub-overrides         {:optional true} SubOverridesMap]
     [:fx-overrides          {:optional true} [:map-of :keyword :any]]
     [:interceptor-overrides {:optional true} [:map-of :keyword :any]]
     [:loaders               {:optional true} [:vector EventVector]]

--- a/tools/story/src/re_frame/story/sub_overrides.cljc
+++ b/tools/story/src/re_frame/story/sub_overrides.cljc
@@ -1,0 +1,139 @@
+(ns re-frame.story.sub-overrides
+  "View-state subscription overrides — the render-path resolver
+  (rf2-5x1wt.13).
+
+  Per `tools/story/spec/017-Testing-Story.md` §View-state subscription
+  overrides, a variant whose goal is rendering / design exploration MAY
+  author `:sub-overrides` — a map of exact subscription query vectors to
+  the data values the renderer should surface for them. This namespace is
+  the RENDER-PATH read side: given the plan's resolved override map and a
+  query vector a view is subscribing to, return either the override value
+  or a miss sentinel.
+
+  ## What this layer is — and is NOT
+
+  `:sub-overrides` is the THIRD, deliberately lower-fidelity rung of the
+  fidelity ladder (real setup events → schema-checked app-db seed →
+  subscription overrides). It exists so a designer can pin a view into an
+  `:error` / `:loading` / `:empty` state without authoring the full
+  event sequence that would naturally produce it.
+
+  The override feeds the RENDER PATH ONLY. It never writes into the
+  variant frame's app-db and never reaches `re-frame.subs/compute-sub`.
+  This is the load-bearing boundary that keeps `:rf.assert/sub-equals`
+  honest: that assertion evaluates a sub through `compute-sub` against the
+  frame's app-db snapshot (see `re-frame.story.assertions/
+  evaluate-sub-equals`), which this namespace deliberately does not touch.
+  A `:sub-overrides` value therefore does NOT satisfy a subscription
+  assertion — subscription correctness is proven by real setup events, a
+  schema-checked app-db seed, or `compute-sub`, not by an override.
+
+  ## Resolution — exact query-vector match
+
+  Override keys are EXACT subscription query vectors `[sub-id & args]`
+  AFTER `[:arg key]` substitution (the plan compiler resolves the
+  placeholders; this layer matches resolved vectors). A view subscribing
+  to `[:login/state]` is overridden by an override keyed `[:login/state]`;
+  a view subscribing to `[:item 7]` is overridden only by `[:item 7]`,
+  NOT by `[:item]` or `[:item 8]`. Match is plain `=` on the whole vector
+  — no prefix / sub-id-only fuzzing, so an override can never leak into a
+  sibling query the author did not name.
+
+  ## Purity / elision
+
+  Every fn here is pure data → data, so the resolver is JVM-runnable and
+  the test suite needs no host. The render path (`re-frame.story.ui.
+  canvas`, CLJS) reads the plan's `[:world :render :sub-overrides]` map
+  and threads it through `with-overrides` so a Story-rendered view's
+  subscribed reads consult `resolve` first; production bundles elide the
+  whole runtime, so the binding is never set there."
+  (:refer-clojure :exclude [resolve read]))
+
+;; ============================================================================
+;; Render-path override binding
+;; ============================================================================
+;;
+;; The renderer binds the active variant's resolved override map for the
+;; dynamic extent of its render so a `read`-through subscribed value can
+;; consult it. Unbound (the default, and always in production) every
+;; lookup misses and the view reads its real subscription.
+
+(def ^:dynamic *overrides*
+  "The active variant's resolved `:sub-overrides` map for the dynamic
+  extent of a Story render — `{query-vector value}`, exact query vectors
+  after `[:arg key]` substitution. Unbound (`nil`) outside a Story render
+  and in production; every lookup then misses."
+  nil)
+
+(def ^:private miss
+  "Sentinel returned by `resolve` when a query vector has no override. A
+  distinct sentinel (not `nil`) so an override whose VALUE is `nil` is
+  still honoured as a hit."
+  ::miss)
+
+(defn miss?
+  "True iff `x` is the no-override sentinel `resolve` returns on a miss."
+  [x]
+  (= miss x))
+
+(defn resolve
+  "Return the override value for `query-v` from `overrides`, or the
+  `miss` sentinel when no exact-match override is registered.
+
+  Match is `=` on the whole query vector — `:sub-overrides` keys are
+  exact `[sub-id & args]` vectors after `[:arg key]` substitution, so an
+  override for `[:item 7]` matches ONLY a subscription to `[:item 7]`.
+
+  `nil` / empty `overrides` always misses. An override whose value is
+  `nil` is a HIT (the sentinel is distinct from `nil`), so a view can be
+  pinned to a nil subscription value."
+  ([query-v] (resolve *overrides* query-v))
+  ([overrides query-v]
+   (if (and (map? overrides) (contains? overrides query-v))
+     (get overrides query-v)
+     miss)))
+
+(defn overridden?
+  "True iff `query-v` has an exact-match override in `overrides` (or the
+  bound `*overrides*` in the 1-arity form). Distinct from a `nil`-valued
+  override, which is a genuine hit."
+  ([query-v] (overridden? *overrides* query-v))
+  ([overrides query-v]
+   (and (map? overrides) (contains? overrides query-v))))
+
+(defn read
+  "Render-path read for a subscribed `query-v`: return the override value
+  when one is registered for the active extent, otherwise call `real-read`
+  (a 0-arg thunk that performs the genuine subscription) and return its
+  value. This is the seam a Story-rendered view's subscribed reads route
+  through so an override surfaces at render WITHOUT ever touching app-db
+  or `compute-sub`.
+
+  `real-read` is invoked ONLY on a miss, so subscribing to a non-
+  overridden query is exactly as it would be without overrides — no extra
+  work, no behavioural change."
+  [query-v real-read]
+  (let [v (resolve *overrides* query-v)]
+    (if (miss? v) (real-read) v)))
+
+(defn with-overrides*
+  "Run `thunk` with `*overrides*` bound to `overrides` (a
+  `{query-vector value}` map, typically the plan's
+  `[:world :render :sub-overrides]`). Returns `thunk`'s value. The
+  function form behind the `with-overrides` macro — callers that already
+  have a thunk (or are on a host where the macro is awkward) use this
+  directly."
+  [overrides thunk]
+  (binding [*overrides* overrides]
+    (thunk)))
+
+#?(:clj
+   (defmacro with-overrides
+     "Evaluate `body` with `*overrides*` bound to `overrides` for its
+     dynamic extent. Sugar over `with-overrides*`. The Story render path
+     wraps the variant's view render in this so a `read`-through
+     subscribed value surfaces an override; outside the binding (and in
+     production) every `read` falls through to the real subscription."
+     [overrides & body]
+     `(binding [*overrides* ~overrides]
+        ~@body)))

--- a/tools/story/src/re_frame/story/ui/canvas.cljs
+++ b/tools/story/src/re_frame/story/ui/canvas.cljs
@@ -25,7 +25,9 @@
             [re-frame.story.registrar :as registrar]
             [re-frame.story.args :as args]
             [re-frame.story.decorators :as decorators]
+            [re-frame.story.plan :as plan]
             [re-frame.story.runtime :as runtime]
+            [re-frame.story.sub-overrides :as sub-overrides]
             [re-frame.story.ui.assertion-strip :as assertion-strip]
             [re-frame.story.ui.multi-substrate :as multi-substrate]
             [re-frame.story.ui.open-in-editor :as open-in-editor]
@@ -287,6 +289,47 @@
     (or (:component variant-body)
         (:component story-body))))
 
+;; ---- view-state subscription overrides (rf2-5x1wt.13) -------------------
+;;
+;; A variant whose goal is rendering / design exploration MAY author
+;; `:sub-overrides` — a map of exact subscription query vectors → data
+;; values the renderer surfaces for them (spec/017 §View-state
+;; subscription overrides). At render the canvas resolves the variant's
+;; override map (arg-substituting `[:arg key]` placeholders against the
+;; effective args, the SAME one-level substitution the plan compiler uses)
+;; and binds it through `sub-overrides/with-overrides*` for the view-
+;; render extent. A Story-rendered view's subscribed reads that route
+;; through `sub-overrides/read` then surface the override; the binding
+;; never touches app-db or `compute-sub`, so it cannot satisfy a
+;; subscription assertion (`:rf.assert/sub-equals`).
+
+(defn- resolve-sub-overrides
+  "Return the variant's resolved `:sub-overrides` map (exact query
+  vectors → values, `[:arg key]` placeholders substituted against
+  `eff-args`), or nil when the variant authors none. Pure-ish: reuses the
+  plan compiler's `substitute-args` so the render-path resolution matches
+  the plan-path resolution exactly."
+  [variant-id eff-args]
+  (let [body (registrar/handler-meta :variant variant-id)
+        ovr  (:sub-overrides body)]
+    (when (seq ovr)
+      (plan/substitute-args ovr (or eff-args {}) (atom [])))))
+
+(defn sub-overrides-scope
+  "A Reagent component that binds the variant's resolved `:sub-overrides`
+  map for its child's render extent so a Story-rendered view's subscribed
+  reads (routed through `re-frame.story.sub-overrides/read`) surface the
+  override. The binding is established INSIDE this component's render fn —
+  not at the caller's hiccup-construction time — so it is live when React
+  renders the wrapped subtree (a `binding` at hiccup-construction time
+  would have unwound before the deferred child render).
+
+  When the variant authors no overrides the map is nil; every `read`
+  then misses and the view reads its real subscription, so this wrapper
+  is render-transparent in the common case."
+  [overrides child]
+  (sub-overrides/with-overrides* overrides (fn [] child)))
+
 ;; ---- decorated-view wrapper ---------------------------------------------
 
 (defn safe-decorated-view
@@ -454,6 +497,9 @@
                           (get-in @state/shell-state-atom
                                   [:cell-overrides variant-id])})
         assertions     (runtime/read-assertions variant-id)
+        ;; rf2-5x1wt.13 — resolve the variant's view-state subscription
+        ;; overrides (arg-substituted) for the render-path binding below.
+        sub-ovr        (resolve-sub-overrides variant-id eff-args)
         substrates     (variant-substrate-set variant-id)
         multi?         (and variant-id (> (count substrates) 1))
         ;; rf2-0s4p1 — skeleton gating. The lifecycle machine reports
@@ -562,10 +608,14 @@
            [frame-provider-ns-safe {:frame variant-id}
             [:div {:key (str "variant-root:" (pr-str variant-id))
                    :data-rf-story-variant-root (pr-str variant-id)}
-             (safe-decorated-view
-               [resolved-view eff-args]
-               (:hiccup decorator-pack)
-               eff-args)]]
+             ;; rf2-5x1wt.13 — bind the variant's resolved view-state
+             ;; subscription overrides for the view-render extent (a no-op
+             ;; wrapper when the variant authors none).
+             [sub-overrides-scope sub-ovr
+              (safe-decorated-view
+                [resolved-view eff-args]
+                (:hiccup decorator-pack)
+                eff-args)]]]
            [:div {:style (:empty styles)}
             (str ":component " (pr-str view-id) " is not registered as a view")])))
      (render-errors (:errors decorator-pack))

--- a/tools/story/test/re_frame/story/plan_test.cljc
+++ b/tools/story/test/re_frame/story/plan_test.cljc
@@ -10,7 +10,8 @@
   registrar's eager merge)."
   (:require [clojure.test :refer [deftest is testing]]
             [malli.core :as m]
-            [re-frame.story.plan :as plan]))
+            [re-frame.story.plan :as plan]
+            [re-frame.story.sub-overrides :as sub-overrides]))
 
 ;; ---- helpers ------------------------------------------------------------
 
@@ -425,3 +426,148 @@
       (testing "the two contracts are not conflated — sub-overrides are NOT in view-args-schema"
         (is (not (contains? (set (get-in p [:world :view-args-schema]))
                             [:widget/state])))))))
+
+;; ===========================================================================
+;; View-state subscription overrides (rf2-5x1wt.13)
+;; ===========================================================================
+;;
+;; `:sub-overrides` is the third, lower-fidelity rung of the fidelity
+;; ladder — a map of exact subscription query vectors → data values the
+;; renderer surfaces for view-state / design exploration. The compiler
+;; resolves `[:arg key]` placeholders in the VALUES, validates each
+;; resolved value against the subscription's OUTPUT schema (distinct from
+;; the view-arg schema), lowers the map to `[:world :render
+;; :sub-overrides]`, and marks `:fidelity`. These tests run host-free by
+;; threading an explicit `:sub-lookup` map of {sub-id → sub-meta}.
+
+(deftest sub-overrides-lower-and-mark-fidelity
+  (testing "a view-state variant renders with exact query-vector overrides + :fidelity"
+    (let [m {:story.login/error
+             {:args          {:message "Invalid password"}
+              :sub-overrides {[:login/state]    :error
+                              [:login/error]    [:arg :message]
+                              [:login/attempts] 1}}}
+          p (plan/variant-plan :story.login/error {:lookup m})]
+      (testing "overrides lower to [:world :render :sub-overrides] with exact query vectors"
+        (is (= {[:login/state]    :error
+                [:login/error]    "Invalid password"   ; [:arg :message] resolved
+                [:login/attempts] 1}
+               (get-in p [:world :render :sub-overrides]))))
+      (testing ":fidelity carries :sub-overrides (and no :real-setup — pure design variant)"
+        (is (= #{:sub-overrides} (get-in p [:world :fidelity]))))
+      (testing "explain surfaces the resolved overrides + fidelity (overrides were used)"
+        (is (= {[:login/state]    :error
+                [:login/error]    "Invalid password"
+                [:login/attempts] 1}
+               (get-in p [:explain :sub-overrides :overrides])))
+        (is (= #{:sub-overrides} (get-in p [:explain :fidelity]))))
+      (testing "the [:arg] substitution into an override value is recorded"
+        (is (some #(= {:key :message :value "Invalid password"} %)
+                  (get-in p [:explain :substitutions])))))))
+
+(deftest fidelity-ladder-real-setup-vs-overrides
+  (testing "a setup-driven variant is :real-setup; adding overrides marks both rungs"
+    (let [m {:story.f/setup-only
+             {:setup [[:dispatch-sync [:counter/init 5]]]}
+             :story.f/hybrid
+             {:setup         [[:dispatch-sync [:counter/init 5]]]
+              :sub-overrides {[:counter/badge] :hot}}
+             :story.f/bare
+             {:component :views/x}}]
+      (testing "setup-only → #{:real-setup}, no :sub-overrides rung"
+        (is (= #{:real-setup} (get-in (plan/variant-plan :story.f/setup-only {:lookup m})
+                                      [:world :fidelity]))))
+      (testing "setup + overrides → both rungs"
+        (is (= #{:real-setup :sub-overrides}
+               (get-in (plan/variant-plan :story.f/hybrid {:lookup m})
+                       [:world :fidelity]))))
+      (testing "a bare render-as-mounted variant carries no :fidelity slot"
+        (is (nil? (get-in (plan/variant-plan :story.f/bare {:lookup m})
+                          [:world :fidelity])))))))
+
+(deftest sub-override-missing-arg-fails-plan-construction
+  (testing "a missing arg in an override value FAILS plan construction"
+    (let [m {:story.login/oops
+             {:args          {} ; :message not declared
+              :sub-overrides {[:login/error] [:arg :message]}}}]
+      (is (thrown-with-msg?
+            #?(:clj clojure.lang.ExceptionInfo :cljs ExceptionInfo)
+            #"story-missing-arg"
+            (plan/variant-plan :story.login/oops {:lookup m}))))))
+
+(deftest sub-override-output-schema-mismatch-fails-before-render
+  (testing "an override value violating the sub's OUTPUT schema fails plan construction"
+    (let [m {:story.login/bad
+             {:sub-overrides {[:login/attempts] "not-an-int"}}}
+          ;; the sub carries an output schema on its :sub registrar :schema slot
+          sub-lookup {:login/attempts {:schema [:int]}}]
+      (is (thrown-with-msg?
+            #?(:clj clojure.lang.ExceptionInfo :cljs ExceptionInfo)
+            #"story-sub-override-invalid"
+            (plan/variant-plan :story.login/bad
+                               {:lookup        m
+                                :sub-lookup    sub-lookup
+                                :validator-fns malli-validator})))))
+  (testing "a value that SATISFIES the output schema compiles cleanly"
+    (let [m {:story.login/ok {:sub-overrides {[:login/attempts] 3}}}
+          sub-lookup {:login/attempts {:schema [:int]}}
+          p (plan/variant-plan :story.login/ok
+                               {:lookup        m
+                                :sub-lookup    sub-lookup
+                                :validator-fns malli-validator})]
+      (is (= :ok (get-in p [:explain :sub-overrides :validation :status])))
+      (is (= 3 (get-in p [:world :render :sub-overrides [:login/attempts]])))))
+  (testing "a sub with no output schema soft-passes (the host-free floor)"
+    (let [m {:story.login/noschema {:sub-overrides {[:login/state] :whatever}}}
+          p (plan/variant-plan :story.login/noschema
+                               {:lookup        m
+                                :sub-lookup    {} ; no metadata for any sub
+                                :validator-fns malli-validator})]
+      (is (= :sub-overrides (first (get-in p [:world :fidelity]))))
+      (is (= :whatever (get-in p [:world :render :sub-overrides [:login/state]])))))
+  (testing "with no validator threaded, output-schema checking soft-passes"
+    ;; The JVM-default path (no malli validator) checks shape only at the
+    ;; renderer — a malformed value is not caught at plan construction.
+    (let [m {:story.login/nov {:sub-overrides {[:login/attempts] "nope"}}}
+          sub-lookup {:login/attempts {:schema [:int]}}
+          p (plan/variant-plan :story.login/nov {:lookup m :sub-lookup sub-lookup})]
+      (is (= "nope" (get-in p [:world :render :sub-overrides [:login/attempts]]))))))
+
+(deftest sub-overrides-compose-through-fragments
+  (testing "a composed fragment contributes :sub-overrides; variant chain wins per key"
+    (let [frag {:fragment/error-state {:sub-overrides {[:login/state] :error
+                                                       [:login/code]  500}}}
+          m    {:story.login/composed
+                {:compose       [:fragment/error-state]
+                 :sub-overrides {[:login/code] 503}}} ; variant overrides the key
+          p (plan/variant-plan :story.login/composed
+                               {:lookup          m
+                                :fragment-lookup frag})]
+      (is (= {[:login/state] :error
+              [:login/code]  503}              ; variant value wins over the fragment
+             (get-in p [:world :render :sub-overrides])))
+      (is (= #{:sub-overrides} (get-in p [:world :fidelity]))))))
+
+;; ---- pure resolver: render-path read + sub-assertion honesty -------------
+
+(deftest sub-overrides-render-path-resolver-is-exact
+  (testing "resolve returns the override value on an exact query-vector match"
+    (let [ovr {[:login/state] :error [:item 7] {:sku "X"}}]
+      (is (= :error      (sub-overrides/resolve ovr [:login/state])))
+      (is (= {:sku "X"}  (sub-overrides/resolve ovr [:item 7])))))
+  (testing "a non-exact query (different args / sub-id) MISSES — no fuzzing"
+    (let [ovr {[:item 7] {:sku "X"}}]
+      (is (sub-overrides/miss? (sub-overrides/resolve ovr [:item 8])))
+      (is (sub-overrides/miss? (sub-overrides/resolve ovr [:item])))
+      (is (sub-overrides/miss? (sub-overrides/resolve ovr [:other 7])))))
+  (testing "an override whose VALUE is nil is a genuine hit (sentinel is distinct)"
+    (let [ovr {[:login/user] nil}]
+      (is (sub-overrides/overridden? ovr [:login/user]))
+      (is (nil? (sub-overrides/resolve ovr [:login/user])))))
+  (testing "read surfaces the override and skips real-read; misses fall through"
+    (let [ovr {[:login/state] :error}]
+      (is (= :error (sub-overrides/with-overrides* ovr
+                      #(sub-overrides/read [:login/state]
+                                           (fn [] (throw (ex-info "should not run" {})))))))
+      (is (= :real  (sub-overrides/with-overrides* ovr
+                      #(sub-overrides/read [:login/other] (fn [] :real))))))))

--- a/tools/story/test/re_frame/story/sub_overrides_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/sub_overrides_cljs_test.cljs
@@ -1,0 +1,60 @@
+(ns re-frame.story.sub-overrides-cljs-test
+  "View-state subscription overrides — render-path read + the
+  sub-assertion-honesty rule (rf2-5x1wt.13).
+
+  Per `tools/story/spec/017-Testing-Story.md` §View-state subscription
+  overrides, a `:sub-overrides` value feeds the RENDER PATH only — never
+  app-db, never `compute-sub`. The honesty rule that follows is that a
+  `:sub-overrides` value does NOT satisfy `:rf.assert/sub-equals` (which
+  evaluates a sub through `compute-sub` against the frame's app-db
+  snapshot — see `re-frame.story.assertions/evaluate-sub-equals`).
+
+  These tests prove the boundary directly: with a `:sub-overrides` value
+  bound on the render-path resolver, `compute-sub` (the exact seam the
+  assertion uses) still returns the REAL app-db value, so the override
+  cannot make a false subscription assertion pass. The pure-data resolver
+  tests live JVM-side in `re-frame.story.plan-test`; this file is CLJS
+  because `compute-sub` + `reg-sub` need the framework runtime."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.subs :as subs]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.story.sub-overrides :as sub-overrides]))
+
+(use-fixtures :each
+  {:before (fn []
+             (registrar/clear-all!)
+             (try (rf/init! plain-atom/adapter) (catch :default _ nil)))})
+
+(deftest override-does-not-leak-into-compute-sub
+  (testing "a bound :sub-overrides value does NOT change what compute-sub returns"
+    ;; A real sub reading [:login :state] from app-db.
+    (rf/reg-sub :login/state (fn [db _] (get-in db [:login :state])))
+    (let [db {:login {:state :ok}}]
+      ;; Bind an override that pins the SAME query to a DIFFERENT value —
+      ;; the render path would surface :error, but compute-sub (the seam
+      ;; :rf.assert/sub-equals uses) must still see the real :ok.
+      (sub-overrides/with-overrides* {[:login/state] :error}
+        (fn []
+          (testing "the render-path resolver surfaces the override"
+            (is (= :error (sub-overrides/resolve [:login/state]))))
+          (testing "compute-sub is UNAFFECTED — it reads real app-db"
+            (is (= :ok (subs/compute-sub [:login/state] db))))
+          (testing "so a sub-equals check of the override value would FAIL"
+            ;; (= (compute-sub …) override-value) is false — the override
+            ;; cannot satisfy the subscription assertion.
+            (is (not= :error (subs/compute-sub [:login/state] db)))))))))
+
+(deftest read-seam-surfaces-override-without-touching-db
+  (testing "sub-overrides/read returns the override; real-read runs only on a miss"
+    (rf/reg-sub :login/state (fn [db _] (get-in db [:login :state])))
+    (let [db {:login {:state :ok}}
+          real-read #(subs/compute-sub [:login/state] db)]
+      (sub-overrides/with-overrides* {[:login/state] :error}
+        (fn []
+          (testing "overridden query → override value, real-read skipped"
+            (is (= :error (sub-overrides/read [:login/state]
+                                              (fn [] (throw (ex-info "real-read should not run" {})))))))
+          (testing "non-overridden query → falls through to compute-sub"
+            (is (= :ok (sub-overrides/read [:login/other] real-read)))))))))


### PR DESCRIPTION
Adds the deliberate lower-fidelity **view-state subscription override** path (Plan §B2b) for Story variants whose goal is rendering / design exploration.

## What changed

- **`schemas.cljc`** — `SubOverridesMap` + a `:sub-overrides` slot on both `Variant` and `Fragment`. Keys are exact subscription query vectors (`[sub-id & args]`); values are data that may carry `[:arg key]` placeholders.
- **`plan.cljc`** —
  - resolves `[:arg key]` placeholders inside override **values** (and keys) through the shared `substitute-args` pass; a missing arg fails with `:rf.error/story-missing-arg`;
  - composes `:sub-overrides` through composed fragments + the `:extends` chain (variant chain wins per query key);
  - validates each resolved value against the subscription's **OUTPUT** schema (distinct from the view-arg/props schema) via a new `:sub-lookup` opt — a mismatch fails plan construction **before render** with `:rf.error/story-sub-override-invalid`; a sub with no output schema (or no validator threaded) soft-passes;
  - lowers to `[:world :render :sub-overrides]`, computes `[:world :fidelity]` from the world inputs (`#{:real-setup :db-seed :sub-overrides}`, `:db-seed` reserved), and surfaces both in `explain`.
- **`sub_overrides.cljc`** (new) — the pure render-path resolver: exact query-vector match (no fuzzing; a `nil`-valued override is a genuine hit), `read` seam, and a `with-overrides` binding. Feeds the render path **only** — never app-db / `compute-sub` — so an override does NOT satisfy `:rf.assert/sub-equals`.
- **`ui/canvas.cljs`** — binds the variant's resolved overrides for the view-render extent (render-transparent when none authored).
- **`spec/017-Testing-Story.md`** — expanded §View-state subscription overrides with the compiler contract, plan-slot table, output-schema validation, the fidelity ladder, and the render-path read + sub-assertion honesty rule.

## Boundary preserved

- View-arg schemas validate explicit view **inputs**; subscription-output schemas validate values supplied by subscriptions / `:sub-overrides` — not conflated (per `.12`).
- `:rf.assert/sub-equals` still evaluates through `compute-sub` against the frame snapshot, which the resolver never touches — a `:sub-overrides` value cannot make a false subscription assertion pass.

## Tests

Plan-level (JVM, pure): lower + fidelity marking, `[:arg]` substitution recorded, missing-arg fail, output-schema mismatch fail before render, soft-pass without schema/validator, fragment composition (variant-wins-per-key), pure resolver (exact match / nil-hit / read seam). CLJS: an honesty test proving `compute-sub` is unaffected by a bound override.

## Quality gates

- `cd tools/story && clojure -M:test` — **1034 tests, 3108 assertions, 0 failures, 0 errors**
- `npm --prefix implementation run test:cljs` — **4850 tests, 15890 assertions, 0 failures, 0 errors** (new CLJS test confirmed compiled into the build)
- `bash scripts/test-fast-pr.sh` — **PASS** (core JVM, JS harness, CLJS node, README/docs anchor validators; mkdocs soft-skipped on Windows, CI runs it)
