### PR TITLE
feat(story): tagged setup/script step runner (rf2-5x1wt.17)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -720,6 +720,90 @@ un-dispatchable — a reserved-word hazard precisely in the slot where it
 bites hardest. `explain` therefore shows identical normalized forms for
 setup and script.
 
+#### Script step runner
+
+The tagged grammar is executed by the play runner: the pure step
+vocabulary + state machine in `re-frame.story.play.runner`
+(`step-types` / `step-arity-ok?` / `coerce-script` / `step-assertion` /
+`step-wait-until`) and the impure step executor in
+`re-frame.story.play.runner-events` (`exec-step!`). The runner is the
+single executor across the live canvas auto-run, the interactive
+step-debugger, and the headless run / replay paths; it does not branch
+on caller.
+
+- **Migration normalization.** Bare event-vector shorthand
+  (`[:my/event …]`) is the MIGRATION form, not the P1 public grammar.
+  `coerce-script` lifts a bare event vector to `[:dispatch event-vector]`;
+  an already-tagged step round-trips unchanged. The plan compiler
+  (`re-frame.story.plan`) applies this same coercion to BOTH `:setup` and
+  `:script`, so `[:world :setup]` and `:script` carry tagged steps
+  uniformly. Because every tag in the grammar (`:dispatch`,
+  `:wait-until`, `:wait`, `:assert`, `:focus`, …) is a known step,
+  `coerce-script` never lifts one — a tagged step is never re-wrapped as
+  a `[:dispatch [:assert …]]`.
+- **`[:dispatch event-vector]`** dispatches the event and settles to
+  `settled-boundary` (the §Concrete contract surface
+  `dispatch-and-settle!`). In `:headless` this is the `dispatch-sync*`
+  run-to-fixed-point drain, so the event has committed by the time the
+  step returns; a richer runner adds reactive / DOM flushes through its
+  flush-hooks.
+- **`[:wait-until predicate-spec]`** advances when a queue/state predicate
+  becomes true. It is DETERMINISTIC (the determinism gate accepts it;
+  only bare `[:wait ms]` is refused, §Determinism gate). The
+  predicate-spec is one of:
+  - `[:db path expected]` — `(= (get-in @app-db path) expected)`;
+  - `[:db path :pred fn-or-sym]` — `(pred (get-in @app-db path))` (a fn
+    is preferred / advanced-CLJS-safe; a symbol is the JVM/dev escape
+    hatch);
+  - `[:queue-empty]` — the frame's event queue has drained, which the
+    settled boundary guarantees before the next step runs.
+
+  In headless the preceding `[:dispatch …]` already settled to a fixed
+  point, so the predicate is checked once synchronously. A predicate that
+  never becomes true TIMES OUT READABLY — a step-fail carrying the unmet
+  predicate-spec — NEVER a silent pass.
+- **`[:wait ms]`** is the bounded wall-clock sleep, the explicit
+  determinism OPT-OUT. The determinism gate (`assert-deterministic`)
+  REFUSES a program containing a bare `[:wait ms]` with `:cannot-run`
+  rather than running it flakily. `[:wait-until pred]` is the
+  deterministic alternative and SHOULD be preferred.
+- **`[:assert assertion-vector]`** evaluates a `:rf.assert/*` assertion
+  atom at THIS exact point in the script — the in-script checkpoint
+  position of the one assertion atom (§Inline script assertions vs
+  terminal assertions). In headless the runner dispatches the wrapped
+  `:rf.assert/*` event (its headless implementation rail —
+  `re-frame.story.assertions`), and the standard reg-event-fx handler
+  records the canonical assertion record on the frame's
+  `:rf.story/assertions` slot. The checkpoint surfaces that record as the
+  step's pass/fail; it records EXACTLY ONE assertion (the wrapped atom's
+  handler is the sole recorder — the assertion-slot mirror that
+  `:assert-db` / `:assert-dom` use is skipped for `[:assert …]` to avoid
+  double-counting). `[:assert …]` is REJECTED in `:setup` at
+  plan-compile time (see below).
+- **`[:focus selector]`** (with `[:click …]` / `[:type …]` /
+  `[:assert-dom …]`) is a DOM step. It requires the `:dom` capability
+  token (§Requirement inference) and the `:dom` settled boundary
+  (§Concrete contract surface). Under a `:headless` runner it REFUSES
+  with `:cannot-run` (a no-DOM step records a skip, never a silent pass);
+  under a `:dom` / `:browser` runner it fires the synthetic focus event.
+
+**`[:assert …]` is illegal in `:setup`.** The plan compiler REJECTS an
+`[:assert …]` checkpoint in `:setup` (or its shipping `:events` spelling)
+at plan-compile time with `:rf.error/story-assert-in-setup`. Setup
+establishes preconditions; it does not judge. The author resolves the
+error by moving the assertion to `:script` (as an `[:assert …]`
+checkpoint) or to the terminal `:assertions` slot. The reject runs on the
+fully-resolved setup (inherited ⧺ composed ⧺ own), so a misplaced verdict
+surfaces before any run — the same way the other `:rf.error/story-*` plan
+errors do.
+
+**Source metadata is preserved for narrative projection.** The runner
+keeps the script step on every step-result and trace record, and the
+evidence projection (`re-frame.story.play.evidence/narrative`) attributes
+each contiguous run of committed epochs to the script step whose dispatch
+opened it — so the script spans project over the epoch beats (the spine
+the epoch-narrative work consumes).
+
 ### Inline script assertions vs terminal assertions
 
 An assertion inside `:script` (via `[:assert …]`) is a **checkpoint**: it

--- a/tools/story/src/re_frame/story/plan.cljc
+++ b/tools/story/src/re_frame/story/plan.cljc
@@ -264,6 +264,37 @@
     {:script  (-> plays first :script (or []))
      :scripts plays}))
 
+(defn- assert-step?
+  "True iff `step` is an `[:assert assertion-vector]` in-script checkpoint
+  (rf2-5x1wt.17). Per spec/017 §Script step grammar the `[:assert …]`
+  step is legal in `:script` but ILLEGAL in `:setup` — setup establishes
+  preconditions, it does not judge."
+  [step]
+  (and (vector? step)
+       (pos? (count step))
+       (= :assert (first step))))
+
+(defn- reject-assert-in-setup!
+  "FAIL plan construction when any resolved `:setup` step is an
+  `[:assert …]` checkpoint (rf2-5x1wt.17, spec/017 §Script step grammar +
+  §Setup). `:assert` is the mid-script verdict atom; placing one in
+  `:setup` confuses precondition with judgement. The variant resolves it
+  by moving the assertion to `:script` (as an `[:assert …]` checkpoint)
+  or to the terminal `:assertions` slot. The reject runs at plan-compile
+  time so the error surfaces before any run, the same way the other
+  `:rf.error/story-*` plan errors do."
+  [id setup]
+  (when-let [offenders (seq (filter assert-step? setup))]
+    (fail! :rf.error/story-assert-in-setup
+           (str "re-frame2-story: variant " id
+                " — :setup carries an [:assert …] checkpoint "
+                (pr-str (vec offenders))
+                ". An [:assert …] checkpoint is a mid-script verdict and is "
+                "ILLEGAL in :setup (which establishes preconditions, it does "
+                "not judge). Move the assertion to :script (as an "
+                "[:assert …] checkpoint) or to the terminal :assertions slot.")
+           {:variant/id id :offending-steps (vec offenders)})))
+
 ;; ============================================================================
 ;; Arg placeholder substitution
 ;; ============================================================================
@@ -1013,11 +1044,17 @@
                          (into composed-checks))
         ;; setup APPENDS: inherited (root→parent), THEN composed fragments
         ;; (declared order), THEN the variant's own setup — variant-owned
-        ;; values land last (§Merge rules + §Total resolution order).
+        ;; values land last (§Merge rules + §Total resolution order). Each
+        ;; layer's setup is coerced through the runner's `coerce-script`
+        ;; (rf2-5x1wt.17): a bare event-vector shorthand normalizes to
+        ;; `[:dispatch event-vector]` during migration, so the stored
+        ;; `[:world :setup]` carries tagged steps uniformly (the same
+        ;; coercion `:script` gets) — bare vectors are the migration
+        ;; shorthand, never the P1 public form.
         setup-raw    (vec (concat
-                            (mapcat (fn [l] (or (pick-setup l) [])) inherited)
-                            (mapcat (fn [l] (or (pick-setup l) [])) frag-layers)
-                            (or (pick-setup child) [])))
+                            (mapcat (fn [l] (runner/coerce-script (pick-setup l))) inherited)
+                            (mapcat (fn [l] (runner/coerce-script (pick-setup l))) frag-layers)
+                            (runner/coerce-script (pick-setup child))))
         ;; script APPENDS through `:compose` only (never through
         ;; `:extends`): composed-fragment scripts in declared order, THEN
         ;; the child's own script (§Merge rules). Each fragment's script is
@@ -1040,6 +1077,11 @@
         ;; ---- arg substitution ----
         subs!        (atom [])
         setup        (substitute-args setup-raw arg-map subs!)
+        ;; rf2-5x1wt.17 — an `[:assert …]` checkpoint is ILLEGAL in :setup
+        ;; (spec/017 §Script step grammar). Reject at plan-compile time,
+        ;; on the fully-resolved setup (inherited ⧺ composed ⧺ own), so a
+        ;; misplaced verdict surfaces before any run.
+        _            (reject-assert-in-setup! id setup)
         script*      (substitute-args script arg-map subs!)
         ;; ---- view-state subscription overrides (rf2-5x1wt.13) ----
         ;; `:sub-overrides` composes like `:network`: composed-fragment

--- a/tools/story/src/re_frame/story/play/dom.cljc
+++ b/tools/story/src/re_frame/story/play/dom.cljc
@@ -144,6 +144,35 @@
                    true)
                false))))
 
+(defn focus!
+  "Focus the element matched by `selector-or-node` and dispatch a
+  synthetic `focus` + `focusin` event so handlers wired to either
+  observe it (rf2-5x1wt.17). Returns true on success, false on
+  no-such-node or no-DOM. JVM → false.
+
+  `[:focus selector]` is a DOM step (spec/017 §Script step grammar): a
+  headless runner refuses it with `:cannot-run` (the capability registry
+  requires `:dom`); under a `:dom` / `:browser` runner it runs here."
+  [selector-or-node]
+  #?(:clj  false
+     :cljs (let [node (cond
+                        (string? selector-or-node) (query selector-or-node)
+                        (some?  selector-or-node)  selector-or-node
+                        :else                      nil)]
+             (if (some? node)
+               (do
+                 ;; Native `.focus()` moves the document's active element;
+                 ;; the synthetic events make the transition observable to
+                 ;; handlers bound to either `focus` (non-bubbling) or
+                 ;; `focusin` (bubbling).
+                 (try (.focus node) (catch :default _ nil))
+                 (try (.dispatchEvent node (js/Event. "focus"   #js {:bubbles false :cancelable false}))
+                      (catch :default _ nil))
+                 (try (.dispatchEvent node (js/Event. "focusin" #js {:bubbles true  :cancelable false}))
+                      (catch :default _ nil))
+                 true)
+               false))))
+
 ;; ---- assertion helpers --------------------------------------------------
 
 (defn assert-visible

--- a/tools/story/src/re_frame/story/play/evidence.cljc
+++ b/tools/story/src/re_frame/story/play/evidence.cljc
@@ -276,11 +276,14 @@
   "Script-step tags that DISPATCH an event into the frame and therefore
   open a narrative span over the epochs they settle. `:dispatch` and
   `:dispatch-sync` both commit at least one epoch; DOM-driving steps
-  (`:click` / `:type`) commit epochs through the synthetic event they
-  fire. Pure assertion / wait steps (`:assert-db` / `:assert-dom` /
-  `:wait` / `:wait-until`) commit no epoch of their own — their beats (if
-  any) belong to the preceding dispatch — so they are NOT span-openers."
-  #{:dispatch :dispatch-sync :click :type})
+  (`:click` / `:type` / `:focus`) commit epochs through the synthetic
+  event they fire. Pure assertion / wait steps (`:assert` / `:assert-db`
+  / `:assert-dom` / `:wait` / `:wait-until`) commit no epoch of their own
+  — their beats (if any) belong to the preceding dispatch — so they are
+  NOT span-openers. (An `[:assert …]` checkpoint DOES dispatch its wrapped
+  `:rf.assert/*` atom, but that is a verdict, not behaviour-under-test, so
+  it is deliberately excluded from span attribution.)"
+  #{:dispatch :dispatch-sync :click :type :focus})
 
 (defn- step-tag
   "The head keyword of a tagged script step, or nil for an untagged /

--- a/tools/story/src/re_frame/story/play/runner.cljc
+++ b/tools/story/src/re_frame/story/play/runner.cljc
@@ -22,13 +22,46 @@
   A bare vector is also accepted: `:play-script [[:dispatch [...]] ...]`
   — equivalent to `{:script <vector>}` with `:auto-run? true`.
 
-  ## Step types
+  ## The tagged step grammar (spec/017 §Script step grammar)
+
+  P1 uses ONE tagged step grammar across `:setup` and `:script`. Every
+  step declares its minimum runner; the boundary ladder
+  (`re-frame.story.play.settled-boundary`) governs settlement and the
+  capability registry (`re-frame.story.requirements`) governs which
+  runner can prove it. Bare event-vector shorthand is NOT the public form
+  — it is normalized to `[:dispatch event-vector]` during migration
+  (`coerce-script`) because an app event genuinely named `:dispatch` /
+  `:click` / `:wait` / `:focus` would otherwise be silently
+  un-dispatchable (a reserved-word hazard).
+
+  `[:wait-until predicate-spec]` advances when a queue/state predicate
+  becomes true, so it is DETERMINISTIC (the determinism gate accepts it;
+  only bare `[:wait ms]` is refused). The predicate-spec is one of
+  `[:db path expected]`, `[:db path :pred fn]`, or `[:queue-empty]`. A
+  predicate that never becomes true TIMES OUT READABLY with a step-fail,
+  never a silent pass.
+
+  `[:assert [:rf.assert/id & args]]` evaluates the assertion atom at this
+  exact point in the script (the ONE assertion atom in its mid-script
+  checkpoint position; the terminal `:assertions` slot is the other). In
+  headless the checkpoint dispatches the wrapped `:rf.assert/*` event
+  (the runner's headless implementation rail) and surfaces the recorded
+  outcome. `[:assert …]` is REJECTED in `:setup` at plan-compile time
+  (`re-frame.story.plan`): setup establishes preconditions, it does not
+  judge.
+
+  `[:focus selector]` / `[:click selector]` / `[:type selector text]` /
+  `[:assert-dom …]` are DOM steps; under a headless runner they refuse
+  with `:cannot-run` (the capability registry requires `:dom`), and they
+  run under a `:dom` / `:browser` runner.
 
   | Step                               | Semantics                                                     |
   |------------------------------------|---------------------------------------------------------------|
-  | `[:dispatch event-vec]`            | `rf/dispatch` (async) into the frame                          |
-  | `[:dispatch-sync event-vec]`       | `rf/dispatch-sync` (synchronous) into the frame               |
-  | `[:wait ms]`                       | Sleep N ms (`setTimeout` CLJS / `Thread/sleep` JVM)            |
+  | `[:dispatch event-vec]`            | settled dispatch — drain through `settled-boundary`           |
+  | `[:dispatch-sync event-vec]`       | low-level synchronous dispatch escape (not the author form)   |
+  | `[:wait-until predicate-spec]`     | deterministic settle-on-condition (queue/state)               |
+  | `[:wait ms]`                       | bounded wall-clock sleep — the explicit determinism opt-out   |
+  | `[:assert assertion-vector]`       | in-script checkpoint assertion (illegal in `:setup`)          |
   | `[:assert-db path value]`          | Assert `(= (get-in @app-db path) value)`                      |
   | `[:assert-db path :pred fn-or-sym]`| Assert custom predicate — `fn` is preferred (works under advanced CLJS); `symbol` is the JVM/dev escape hatch (resolved at run time, fragile under advanced CLJS munging) |
   | `[:assert-dom selector :visible]`  | Assert selector resolves to a visible DOM node                |
@@ -36,6 +69,7 @@
   | `[:assert-dom selector :text txt]` | Assert selector's text-content matches `txt`                  |
   | `[:click selector]`                | Synthetic click event at selector                             |
   | `[:type selector text]`            | Synthetic `input` event at selector with `text`               |
+  | `[:focus selector]`                | Synthetic focus event at selector                             |
 
   Steps run sequentially. A failed `:assert-*` step is RECORDED — the
   run continues so the user sees all failures, not just the first
@@ -65,19 +99,25 @@
 ;; ---- step-type vocabulary ------------------------------------------------
 
 (def step-types
-  "The canonical step-type tags the runner recognises."
-  #{:dispatch :dispatch-sync :wait
-    :assert-db :assert-dom
-    :click :type})
+  "The canonical step-type tags the runner recognises — the one tagged
+  step grammar across `:setup` and `:script` (spec/017 §Script step
+  grammar, rf2-5x1wt.17). `:assert` is the in-script checkpoint atom
+  (the wrapped `:rf.assert/*` assertion); `:wait-until` is the
+  deterministic settle-on-condition; `:focus` is the DOM focus step."
+  #{:dispatch :dispatch-sync :wait :wait-until
+    :assert :assert-db :assert-dom
+    :click :type :focus})
 
 (def assertion-step-types
-  "Steps whose outcome contributes to the play's pass/fail status."
-  #{:assert-db :assert-dom})
+  "Steps whose outcome contributes to the play's pass/fail status —
+  including the `[:assert …]` in-script checkpoint (rf2-5x1wt.17), which
+  evaluates a `:rf.assert/*` atom at this exact point in the script."
+  #{:assert :assert-db :assert-dom})
 
 (def async-yield-step-types
   "Steps that put work on an async queue the runner cannot directly
-  flush — `:click` / `:type` (synthetic DOM events whose handlers
-  re-enter the dispatch chain) and `:wait` (the runner sleeps
+  flush — `:click` / `:type` / `:focus` (synthetic DOM events whose
+  handlers re-enter the dispatch chain) and `:wait` (the runner sleeps
   explicitly). The driver yields one tick AFTER these steps so the
   queued effects drain before the next step runs.
 
@@ -90,9 +130,14 @@
   settling `:dispatch` synchronously removes that hazard for the queued
   authoring form too.
 
-  Steps NOT in this set (`:dispatch`, `:dispatch-sync`, `:assert-db`,
-  `:assert-dom`) recur synchronously on CLJS."
-  #{:click :type :wait})
+  `:wait-until` is NOT here either: in headless the predicate is checked
+  synchronously once the preceding dispatch has settled (rf2-5x1wt.17),
+  so it recurs synchronously like the assertion steps. A richer runner's
+  bounded poll handles its own scheduling.
+
+  Steps NOT in this set (`:dispatch`, `:dispatch-sync`, `:wait-until`,
+  `:assert`, `:assert-db`, `:assert-dom`) recur synchronously on CLJS."
+  #{:click :type :focus :wait})
 
 (declare step-type)
 
@@ -138,6 +183,37 @@
                       (and (= 2 (count step))
                            (number? (nth step 1))
                            (not (neg? (nth step 1)))))
+    ;; `[:wait-until predicate-spec]` — deterministic settle-on-condition.
+    ;; The predicate-spec is `[:db path expected]`, `[:db path :pred fn]`,
+    ;; or `[:queue-empty]` (rf2-5x1wt.17). A 2-arity vector whose payload
+    ;; is itself a tagged predicate-spec vector.
+    :wait-until     (boolean
+                      (and (= 2 (count step))
+                           (let [pspec (nth step 1)]
+                             (and (vector? pspec)
+                                  (pos? (count pspec))
+                                  (case (first pspec)
+                                    :db          (or
+                                                   ;; [:db path expected]
+                                                   (and (= 3 (count pspec))
+                                                        (vector? (nth pspec 1))
+                                                        (not= :pred (nth pspec 2)))
+                                                   ;; [:db path :pred fn-or-sym]
+                                                   (and (= 4 (count pspec))
+                                                        (vector? (nth pspec 1))
+                                                        (= :pred (nth pspec 2))
+                                                        (let [r (nth pspec 3)]
+                                                          (or (fn? r) (symbol? r)))))
+                                    :queue-empty (= 1 (count pspec))
+                                    false)))))
+    ;; `[:assert assertion-vector]` — the in-script checkpoint atom. The
+    ;; wrapped form is a `:rf.assert/*` event vector (rf2-5x1wt.17).
+    :assert         (boolean
+                      (and (= 2 (count step))
+                           (let [a (nth step 1)]
+                             (and (vector? a)
+                                  (pos? (count a))
+                                  (keyword? (first a))))))
     :assert-db      (boolean
                       (and (>= (count step) 3)
                            (vector? (nth step 1))
@@ -170,6 +246,9 @@
                       (and (= 3 (count step))
                            (string? (nth step 1))
                            (string? (nth step 2))))
+    :focus          (boolean
+                      (and (= 2 (count step))
+                           (string? (nth step 1))))
     false))
 
 ;; ---- legacy bare-event-vector lift --------------------------------------
@@ -493,6 +572,8 @@
     :dispatch       (str "dispatch " (pr-str (second step)))
     :dispatch-sync  (str "dispatch-sync " (pr-str (second step)))
     :wait           (str "wait " (second step) "ms")
+    :wait-until     (str "wait-until " (pr-str (second step)))
+    :assert         (str "assert " (pr-str (second step)))
     :assert-db      (cond
                       (and (= 4 (count step)) (= :pred (nth step 2)))
                       (let [ref (nth step 3)]
@@ -515,6 +596,7 @@
     :click          (str "click " (pr-str (second step)))
     :type           (str "type "  (pr-str (second step))
                          " " (pr-str (nth step 2)))
+    :focus          (str "focus " (pr-str (second step)))
     (str "unknown " (pr-str step))))
 
 ;; ---- script validation --------------------------------------------------
@@ -559,13 +641,14 @@
 ;; ---- selector helpers ---------------------------------------------------
 
 (defn step-selector
-  "Return the DOM selector string from a `:click` / `:type` /
+  "Return the DOM selector string from a `:click` / `:type` / `:focus` /
   `:assert-dom` step, or nil. Used by the UI's click-to-highlight
   failing-element affordance."
   [step]
   (case (step-type step)
     :click       (nth step 1 nil)
     :type        (nth step 1 nil)
+    :focus       (nth step 1 nil)
     :assert-dom  (nth step 1 nil)
     nil))
 
@@ -583,6 +666,38 @@
   [step]
   (when (= :wait (step-type step))
     (nth step 1 nil)))
+
+(defn step-assertion
+  "Return the wrapped `:rf.assert/*` assertion atom from an
+  `[:assert assertion-vector]` checkpoint step, or nil (rf2-5x1wt.17).
+  This is the ONE assertion atom in its in-script position — the same
+  vector the terminal `:assertions` slot carries."
+  [step]
+  (when (= :assert (step-type step))
+    (nth step 1 nil)))
+
+(defn step-wait-until
+  "Decompose a `[:wait-until predicate-spec]` step into
+  `{:kind :db|:queue-empty :path <vec> :mode :equals|:pred :expected <val>
+  :pred-ref <fn-or-sym> :pred-fn? <bool>}` (rf2-5x1wt.17). Returns nil
+  for a non-`:wait-until` step.
+
+  - `[:db path expected]`       → `{:kind :db :path … :mode :equals :expected …}`
+  - `[:db path :pred fn-or-sym]`→ `{:kind :db :path … :mode :pred :pred-ref … :pred-fn? …}`
+  - `[:queue-empty]`            → `{:kind :queue-empty}`"
+  [step]
+  (when (= :wait-until (step-type step))
+    (let [pspec (nth step 1 nil)]
+      (case (first pspec)
+        :db          (let [path (nth pspec 1)]
+                       (if (and (= 4 (count pspec)) (= :pred (nth pspec 2)))
+                         (let [ref (nth pspec 3)]
+                           {:kind :db :path path :mode :pred
+                            :pred-ref ref :pred-fn? (fn? ref)})
+                         {:kind :db :path path :mode :equals
+                          :expected (nth pspec 2)}))
+        :queue-empty {:kind :queue-empty}
+        nil))))
 
 (defn step-assert-db
   "Decompose an `:assert-db` step into `{:path <vec> :mode :equals|:pred

--- a/tools/story/src/re_frame/story/play/runner_events.cljc
+++ b/tools/story/src/re_frame/story/play/runner_events.cljc
@@ -535,6 +535,129 @@
       (runner/step-fail idx step
                         {:message (str "type failed — no node matched " (pr-str selector))}))))
 
+(defn- exec-focus!
+  "Execute a `[:focus selector]` step — a DOM focus event (rf2-5x1wt.17).
+  Parallels `exec-click!`: a no-DOM headless runner records a
+  `{:skipped? true}` no-op (the capability registry already refuses the
+  step at preflight, so this is the belt-and-braces runtime guard); a
+  DOM/browser runner fires the synthetic focus and records a step-skip."
+  [_frame-id idx step]
+  (let [selector (runner/step-selector step)]
+    (cond
+      (not (dom/dom-available?))
+      (runner/step-fail idx step
+                        {:skipped? true
+                         :message  (str "no DOM — cannot focus " (pr-str selector))})
+
+      (dom/focus! selector)
+      (runner/step-skip idx step)
+
+      :else
+      (runner/step-fail idx step
+                        {:message (str "focus failed — no node matched " (pr-str selector))}))))
+
+(defn- exec-assert!
+  "Execute an `[:assert [:rf.assert/id & args]]` in-script checkpoint
+  (rf2-5x1wt.17). Evaluates the wrapped assertion atom at THIS point in
+  the script (spec/017 §Inline script assertions vs terminal
+  assertions). In headless this dispatches the `:rf.assert/*` event
+  through `settled-boundary` — the runner's headless implementation rail
+  (`re-frame.story.assertions`) — then reads the freshly recorded
+  outcome from the frame's `:rf.story/assertions` slot and projects it
+  into a runner step-pass / step-fail. So the checkpoint records an
+  assertion AT THIS POINT, and a failing checkpoint flips the play's
+  terminal status to `:fail`.
+
+  The wrapped atom is dispatched as the event vector, so the standard
+  `:rf.assert/*` reg-event-fx handler records the `:passed?` record on
+  the frame's app-db. We bridge that record back into the runner step
+  stream (the SAME bridge `dispatch-step-result` uses for the
+  `:dispatch-sync [:rf.assert/*]` rail), so the in-script `[:assert …]`
+  and a terminal assertion produce the same assertion-record shape."
+  [frame-id idx step]
+  (let [atom-v   (runner/step-assertion step)
+        prev     (assertion-count frame-id)
+        required (boundary/step-required-boundary step)
+        hooks    (current-flush-hooks frame-id)
+        settle   (try
+                   (boundary/dispatch-and-settle! frame-id atom-v hooks required step)
+                   (catch #?(:clj Throwable :cljs :default) e
+                     {:status :error
+                      :error  #?(:clj (.getMessage ^Throwable e) :cljs (str e))
+                      :step   step}))]
+    (play/drain-pending-exceptions! frame-id :phase-4-play)
+    (or (boundary-result->step idx step settle)
+        ;; The wrapped :rf.assert/* handler recorded its outcome on the
+        ;; frame's :rf.story/assertions slot. Read what landed since the
+        ;; pre-dispatch count and surface it as the checkpoint's result.
+        (let [all   (vec (:rf.story/assertions (read-frame-db frame-id)))
+              new   (subvec all (min prev (count all)))
+              rec   (last new)]
+          (cond
+            (nil? rec)            (runner/step-skip idx step)
+            (false? (:passed? rec))
+            (runner/step-fail idx step
+                              {:expected (:expected rec)
+                               :actual   (:actual rec)
+                               :message  (or (:reason rec)
+                                             (str (:assertion rec) " "
+                                                  (pr-str (:payload rec)) " failed"))})
+            :else                 (runner/step-pass idx step))))))
+
+(defn- queue-empty?
+  "True iff `frame-id`'s event queue has drained (rf2-5x1wt.17). Under a
+  settled-boundary runner the preceding `[:dispatch …]` step ran the
+  router to a FIXED POINT (`settled-boundary` — the `dispatch-sync*`
+  run-to-completion drain in headless), so by the time a following
+  `[:wait-until [:queue-empty]]` is evaluated the queue is, by contract,
+  drained. The predicate is the explicit, readable settle-on-drain form;
+  it is satisfied whenever the runner has reached the settled boundary,
+  which the step driver guarantees before this step runs. Returns true."
+  [_frame-id]
+  ;; The settled-boundary contract (re-frame.story.play.settled-boundary)
+  ;; guarantees the queue has drained to a fixed point before the next
+  ;; step executes; there is no partial-drain state to observe here.
+  true)
+
+(defn- wait-until-satisfied?
+  "Evaluate a decomposed `:wait-until` predicate against `frame-id`'s
+  current state (rf2-5x1wt.17). Pure-ish — reads the frame snapshot, no
+  dispatch. Returns a boolean."
+  [frame-id {:keys [kind path mode expected pred-ref pred-fn?]}]
+  (case kind
+    :db          (let [db     (read-frame-db frame-id)
+                       actual (get-in db path)]
+                   (case mode
+                     :equals (= expected actual)
+                     :pred   (let [f (if pred-fn? pred-ref (resolve-predicate pred-ref))]
+                               (boolean (and f (try (f actual)
+                                                    (catch #?(:clj Throwable :cljs :default) _ false)))))
+                     false))
+    :queue-empty (queue-empty? frame-id)
+    false))
+
+(defn- exec-wait-until!
+  "Execute a `[:wait-until predicate-spec]` step (rf2-5x1wt.17) — the
+  DETERMINISTIC settle-on-condition. In headless the preceding
+  `[:dispatch …]` already drained to a fixed point, so the predicate is
+  checked once synchronously: satisfied → step-skip (advance);
+  unsatisfied → step-fail TIMING OUT READABLY with the unmet
+  predicate-spec, NEVER a silent pass. (A richer DOM/browser runner that
+  needs to await an async flush re-checks under a bounded poll; that
+  poll is the adapter caller's concern — the headless contract is the
+  one-shot deterministic check this fn implements.)"
+  [frame-id idx step]
+  (let [pspec   (runner/step-wait-until step)]
+    (if (wait-until-satisfied? frame-id pspec)
+      (runner/step-skip idx step)
+      (runner/step-fail idx step
+                        {:cannot-run? false
+                         :expected (nth step 1)
+                         :message  (str "wait-until " (pr-str (nth step 1))
+                                        " never became true (deterministic "
+                                        "queue/state predicate did not hold "
+                                        "after the preceding dispatch settled)")}))))
+
 (defn exec-step!
   "Execute ONE step against `frame-id`. Returns a step-result record
   (per `runner/step-pass` / `step-fail` / `step-skip` / `step-exception`).
@@ -546,10 +669,13 @@
   (case (runner/step-type step)
     :dispatch       (exec-dispatch!      frame-id idx step)
     :dispatch-sync  (exec-dispatch-sync! frame-id idx step)
+    :assert         (exec-assert!        frame-id idx step)
     :assert-db      (exec-assert-db!     frame-id idx step)
     :assert-dom     (exec-assert-dom!    frame-id idx step)
+    :wait-until     (exec-wait-until!    frame-id idx step)
     :click          (exec-click!         frame-id idx step)
     :type           (exec-type!          frame-id idx step)
+    :focus          (exec-focus!         frame-id idx step)
     :wait           (runner/step-skip idx step)   ; driver handles the actual sleep
     (runner/unknown-step idx step)))
 
@@ -633,13 +759,19 @@
   pass/fail is already represented by the `:rf.assert/*` records their
   dispatched events recorded.
 
+  Returns nil for the `[:assert …]` in-script checkpoint too
+  (rf2-5x1wt.17): that step DISPATCHES its wrapped `:rf.assert/*` atom,
+  whose reg-event-fx handler ALREADY recorded a canonical assertion
+  record on the slot — mirroring the step result on top would double-
+  count. The checkpoint's slot record IS the wrapped atom's record.
+
   A `:skipped?` DOM step (no-DOM JVM context) is NOT recorded as a
   failure — the step couldn't run, so it contributes no assertion
   outcome to the slot (matching the run-state's `:passed? false` +
   `:skipped? true` shape, which `finish` already tolerates)."
   [frame-id step result]
   (let [stype (runner/step-type step)]
-    (when (contains? runner/assertion-step-types stype)
+    (when (contains? #{:assert-db :assert-dom} stype)
       (let [aid (case stype
                   :assert-db  assert-db-id
                   :assert-dom assert-dom-id)]

--- a/tools/story/src/re_frame/story/play/settled_boundary.cljc
+++ b/tools/story/src/re_frame/story/play/settled_boundary.cljc
@@ -120,6 +120,7 @@
    :dispatch-sync  :headless
    :wait           :headless
    :wait-until     :headless
+   :assert         :headless   ; in-script checkpoint — the wrapped atom may need more (e.g. DOM); its capability tokens, not its boundary, gate that
    :assert-db      :headless
    :assert-dom     :dom
    :click          :dom

--- a/tools/story/src/re_frame/story/schemas.cljc
+++ b/tools/story/src/re_frame/story/schemas.cljc
@@ -403,11 +403,14 @@
 ;; ---- :play-script step DSL (rf2-8i2a9) -----------------------------------
 
 (def PlayStep
-  "A single step in a rich `:play-script` body. Recognised tags:
+  "A single step in a rich `:script` body — the one tagged step grammar
+  (spec/017 §Script step grammar). Recognised tags:
 
-  - `[:dispatch event-vec]`              — async dispatch into the frame
-  - `[:dispatch-sync event-vec]`         — synchronous dispatch
-  - `[:wait ms]`                         — sleep N ms
+  - `[:dispatch event-vec]`              — settled dispatch (settled-boundary)
+  - `[:dispatch-sync event-vec]`         — synchronous dispatch escape
+  - `[:wait-until predicate-spec]`       — deterministic settle-on-condition
+  - `[:wait ms]`                         — sleep N ms (determinism opt-out)
+  - `[:assert assertion-vec]`            — in-script `:rf.assert/*` checkpoint
   - `[:assert-db path value]`            — equality assertion
   - `[:assert-db path :pred fn-sym]`     — predicate assertion
   - `[:assert-dom selector :visible]`    — DOM presence assertion
@@ -415,10 +418,11 @@
   - `[:assert-dom selector :text txt]`   — DOM text-content assertion
   - `[:click selector]`                  — synthetic click
   - `[:type selector text]`              — synthetic input
+  - `[:focus selector]`                  — synthetic focus
 
   Plain event vectors are ALSO accepted at the script level — the
-  runner lifts them to `[:dispatch <event-vec>]` for ergonomic
-  authoring sugar.
+  runner lifts them to `[:dispatch <event-vec>]` as MIGRATION shorthand
+  (spec/017 §Script step grammar — not the P1 public form).
 
   Schema is left loose here (`[:vector :any]` + first-element keyword)
   so authors get clear runner error messages rather than schema

--- a/tools/story/test/re_frame/story/plan_test.cljc
+++ b/tools/story/test/re_frame/story/plan_test.cljc
@@ -160,10 +160,20 @@
 ;; ---- shipping-vocabulary normalization ----------------------------------
 
 (deftest events-normalizes-to-world-setup
-  (testing "shipping :events lowers to [:world :setup]"
+  (testing "shipping :events lowers to [:world :setup], bare event vectors
+            lifting to tagged [:dispatch …] (rf2-5x1wt.17 migration
+            normalization — bare shorthand is the migration form, not the
+            P1 public grammar)"
     (let [m {:story.legacy/e {:events [[:counter/init 3]]}}
           p (plan-of :story.legacy/e m)]
-      (is (= [[:counter/init 3]] (get-in p [:world :setup]))))))
+      (is (= [[:dispatch [:counter/init 3]]] (get-in p [:world :setup])))))
+  (testing "already-tagged setup steps round-trip unchanged"
+    (let [m {:story.legacy/e2 {:setup [[:dispatch [:counter/init 3]]
+                                       [:dispatch-sync [:counter/seed]]]}}
+          p (plan-of :story.legacy/e2 m)]
+      (is (= [[:dispatch [:counter/init 3]]
+              [:dispatch-sync [:counter/seed]]]
+             (get-in p [:world :setup]))))))
 
 (deftest play-script-normalizes-to-script
   (testing "shipping :play-script lowers to :script (bare vectors lift to :dispatch)"

--- a/tools/story/test/re_frame/story/play/step_runner_test.cljc
+++ b/tools/story/test/re_frame/story/play/step_runner_test.cljc
@@ -1,0 +1,295 @@
+(ns re-frame.story.play.step-runner-test
+  "The tagged setup/script step runner (NewTestStory rf2-5x1wt.17,
+  spec/017-Testing-Story.md §Script step grammar + §Setup and script).
+
+  Three layers, all under `clojure -M:test` (JVM) + the node-runtime CLJS
+  build:
+
+  - PURE grammar — `runner/step-types` / `step-arity-ok?` / `coerce-script`
+    / `step-assertion` / `step-wait-until` recognise the tagged steps
+    (`[:dispatch]` / `[:wait-until]` / `[:wait]` / `[:assert]` / `[:focus]`)
+    and lift bare event-vector shorthand to `[:dispatch …]` during
+    migration. No re-frame dep.
+  - PLAN-COMPILE rejection — an `[:assert …]` checkpoint in `:setup` FAILS
+    plan construction (`re-frame.story.plan`) with
+    `:rf.error/story-assert-in-setup`.
+  - HEADLESS execution against a live frame — `runner-events/exec-step!`
+    drives a tagged `[:dispatch …]` through `settled-boundary`, settles a
+    `[:wait-until pred]` on a queue/state predicate (timing out readably),
+    records an `[:assert …]` checkpoint at its point in the script, and
+    REFUSES `[:focus …]` headless with `:cannot-run`.
+
+  The headless execution layer drives `exec-step!` directly (a private
+  var reached via var-quote — the established Story-test seam) so a single
+  step's behaviour is observable without standing up the async run loop."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core              :as rf]
+            [re-frame.frame             :as frame]
+            [re-frame.registrar         :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.story             :as story]
+            [re-frame.story.assertions  :as assertions]
+            [re-frame.story.plan        :as plan]
+            [re-frame.story.play.runner :as runner]
+            [re-frame.story.play.runner-events :as re]
+            [re-frame.story.play.settled-boundary :as boundary]
+            [re-frame.story.requirements :as requirements]))
+
+;; ===========================================================================
+;; PURE: the tagged step grammar
+;; ===========================================================================
+
+(deftest step-types-include-new-tags
+  (testing "the one tagged grammar recognises :assert / :wait-until / :focus"
+    (is (contains? runner/step-types :assert))
+    (is (contains? runner/step-types :wait-until))
+    (is (contains? runner/step-types :focus))
+    (is (= :assert     (runner/step-type [:assert [:rf.assert/path-equals [:k] 1]])))
+    (is (= :wait-until (runner/step-type [:wait-until [:db [:k] 1]])))
+    (is (= :focus      (runner/step-type [:focus "[data-test=in]"])))
+    (is (true? (runner/known-step? [:assert [:rf.assert/path-equals [:k] 1]])))
+    (is (true? (runner/known-step? [:wait-until [:queue-empty]])))
+    (is (true? (runner/known-step? [:focus "sel"])))))
+
+(deftest assert-step-is-an-assertion-class-step
+  (testing ":assert contributes to pass/fail (it is an assertion-class step)"
+    (is (contains? runner/assertion-step-types :assert))
+    (is (true? (runner/assertion? [:assert [:rf.assert/path-equals [:k] 1]])))))
+
+(deftest assert-arity
+  (testing "[:assert assertion-vector] requires a tagged assertion atom"
+    (is (true?  (runner/step-arity-ok? [:assert [:rf.assert/path-equals [:k] 1]])))
+    (is (true?  (runner/step-arity-ok? [:assert [:rf.assert/no-warnings]])))
+    (is (false? (runner/step-arity-ok? [:assert])))
+    (is (false? (runner/step-arity-ok? [:assert "not-a-vec"])))
+    (is (false? (runner/step-arity-ok? [:assert []])))
+    (is (false? (runner/step-arity-ok? [:assert ["not-keyword"]])))))
+
+(deftest wait-until-arity
+  (testing "[:wait-until predicate-spec] accepts :db equals / :db :pred /
+            :queue-empty forms"
+    (is (true?  (runner/step-arity-ok? [:wait-until [:db [:k] 1]])))
+    (is (true?  (runner/step-arity-ok? [:wait-until [:db [:a :b] :pred even?]])))
+    (is (true?  (runner/step-arity-ok? [:wait-until [:db [:a :b] :pred 'my/pred?]])))
+    (is (true?  (runner/step-arity-ok? [:wait-until [:queue-empty]])))
+    (is (false? (runner/step-arity-ok? [:wait-until])))
+    (is (false? (runner/step-arity-ok? [:wait-until [:unknown-pred]])))
+    (is (false? (runner/step-arity-ok? [:wait-until [:db "not-a-vec" 1]])))
+    (is (false? (runner/step-arity-ok? [:wait-until [:queue-empty :extra]])))))
+
+(deftest focus-arity
+  (testing "[:focus selector] requires a string selector"
+    (is (true?  (runner/step-arity-ok? [:focus "sel"])))
+    (is (false? (runner/step-arity-ok? [:focus])))
+    (is (false? (runner/step-arity-ok? [:focus 42])))))
+
+(deftest wait-is-still-the-determinism-opt-out
+  (testing "[:wait ms] keeps its tag distinct from [:wait-until] — the
+            determinism gate refuses [:wait ms] but not [:wait-until]"
+    (is (= :wait       (runner/step-type [:wait 100])))
+    (is (= :wait-until (runner/step-type [:wait-until [:db [:k] 1]])))
+    (is (not= :wait    (runner/step-type [:wait-until [:db [:k] 1]])))))
+
+(deftest step-accessors
+  (testing "step-assertion unwraps the [:assert …] atom"
+    (is (= [:rf.assert/path-equals [:k] 1]
+           (runner/step-assertion [:assert [:rf.assert/path-equals [:k] 1]])))
+    (is (nil? (runner/step-assertion [:dispatch [:e]]))))
+  (testing "step-wait-until decomposes the predicate-spec"
+    (is (= {:kind :db :path [:k] :mode :equals :expected 1}
+           (runner/step-wait-until [:wait-until [:db [:k] 1]])))
+    (is (= {:kind :queue-empty}
+           (runner/step-wait-until [:wait-until [:queue-empty]])))
+    (let [d (runner/step-wait-until [:wait-until [:db [:k] :pred pos?]])]
+      (is (= :pred (:mode d)))
+      (is (true? (:pred-fn? d)))
+      (is (identical? pos? (:pred-ref d)))))
+  (testing "step-selector covers :focus"
+    (is (= "sel" (runner/step-selector [:focus "sel"])))))
+
+(deftest step-summary-new-steps
+  (is (= "wait-until [:db [:k] 1]" (runner/step-summary [:wait-until [:db [:k] 1]])))
+  (is (= "assert [:rf.assert/path-equals [:k] 1]"
+         (runner/step-summary [:assert [:rf.assert/path-equals [:k] 1]])))
+  (is (= "focus \"sel\"" (runner/step-summary [:focus "sel"]))))
+
+;; ---- migration: bare event vectors normalize, tagged steps round-trip ----
+
+(deftest bare-event-vectors-normalize-during-migration
+  (testing "coerce-script lifts a bare event vector to [:dispatch …] — the
+            migration shorthand, NOT the P1 public form (spec/017 §Script
+            step grammar)"
+    (is (= [[:dispatch [:counter/inc]]
+            [:dispatch [:counter/dec]]]
+           (runner/coerce-script [[:counter/inc] [:counter/dec]]))))
+  (testing "the tagged steps are NEVER mistaken for bare event vectors —
+            they round-trip unchanged"
+    (let [tagged [[:dispatch [:e]]
+                  [:wait-until [:db [:k] 1]]
+                  [:assert [:rf.assert/path-equals [:k] 1]]
+                  [:focus "sel"]
+                  [:wait 50]]]
+      (is (= tagged (runner/coerce-script tagged))))))
+
+;; ===========================================================================
+;; PLAN COMPILE: [:assert …] is rejected in :setup
+;; ===========================================================================
+
+(defn- err-id [thunk]
+  (try (thunk) ::no-throw
+       (catch #?(:clj Exception :cljs :default) e
+         (:rf.error/id (ex-data e)))))
+
+(deftest assert-in-setup-is-rejected-at-plan-compile
+  (testing "[:assert …] in :setup FAILS plan construction (spec/017 §Script
+            step grammar — illegal in :setup)"
+    (is (= :rf.error/story-assert-in-setup
+           (err-id #(plan/variant-plan
+                      {:variant/id :story.bad/setup-assert
+                       :setup  [[:dispatch [:seed/a]]
+                                [:assert [:rf.assert/path-equals [:k] 1]]]
+                       :script [[:dispatch [:act/b]]]}
+                      {})))))
+  (testing "[:assert …] in :script compiles fine — only :setup rejects it"
+    (let [p (plan/variant-plan
+              {:variant/id :story.ok/script-assert
+               :setup  [[:dispatch [:seed/a]]]
+               :script [[:dispatch [:act/b]]
+                        [:assert [:rf.assert/path-equals [:k] 1]]]}
+              {})]
+      (is (= [[:dispatch [:act/b]]
+              [:assert [:rf.assert/path-equals [:k] 1]]]
+             (:script p)))))
+  (testing "a bare-event-shorthand setup that happens to start with the
+            :assert keyword still rejects after migration normalization"
+    ;; `[:assert …]` is a known step, so coerce-script does NOT lift it to
+    ;; `[:dispatch [:assert …]]` — it stays a checkpoint and the reject fires.
+    (is (= :rf.error/story-assert-in-setup
+           (err-id #(plan/variant-plan
+                      {:variant/id :story.bad/events-assert
+                       :events [[:assert [:rf.assert/no-warnings]]]}
+                      {}))))))
+
+;; ===========================================================================
+;; REQUIRED-RUNNER: [:focus] requires :dom, the others are headless
+;; ===========================================================================
+
+(deftest focus-step-requires-dom-in-plan
+  (testing "a [:focus …] script step lifts :required-runner to #{:dom}"
+    (let [p (plan/variant-plan
+              {:variant/id :story.focus/v
+               :script [[:dispatch [:e]] [:focus "[data-test=in]"]]}
+              {})]
+      (is (contains? (:required-runner p) :dom))))
+  (testing "an all-headless script (dispatch + wait-until + assert) needs no
+            DOM capability"
+    (let [p (plan/variant-plan
+              {:variant/id :story.headless/v
+               :script [[:dispatch [:e]]
+                        [:wait-until [:db [:k] 1]]
+                        [:assert [:rf.assert/path-equals [:k] 1]]]}
+              {})]
+      (is (not (contains? (:required-runner p) :dom))))))
+
+;; ===========================================================================
+;; HEADLESS execution against a live frame
+;; ===========================================================================
+
+(def ^:private exec-step! @#'re/exec-step!)
+
+(def ^:private step-frame :story.step-runner/frame)
+
+(defn- reset-rf! [test-fn]
+  (story/clear-all!)
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (try (rf/init! plain-atom/adapter)
+       (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) _ nil))
+  (reset! assertions/trace-accumulators {})
+  (reset! re/run-state {})
+  ;; The canonical `:rf.assert/*` handlers must be installed so an
+  ;; `[:assert …]` checkpoint's dispatched atom records onto the slot.
+  (story/install-canonical-vocabulary!)
+  (frame/ensure-default-frame!)
+  (frame/reg-frame step-frame {:doc "tagged step-runner test frame"})
+  (rf/reg-event-db :step/inc (fn [db _] (update db :n (fnil inc 0))))
+  (rf/reg-event-db :step/set (fn [db [_ v]] (assoc db :v v)))
+  (test-fn))
+
+(use-fixtures :each reset-rf!)
+
+(deftest tagged-dispatch-drains-through-settled-boundary
+  (testing "a [:dispatch …] step settles to a fixed point in headless —
+            the event has committed by the time exec-step! returns"
+    (let [res (exec-step! step-frame 0 [:dispatch [:step/inc]])]
+      (is (nil? (:passed? res)) "a plain dispatch contributes no pass/fail")
+      (is (= 1 (:n (rf/get-frame-db step-frame)))
+          "the dispatch drained synchronously through settled-boundary"))))
+
+(deftest wait-until-settles-when-predicate-true
+  (testing "[:wait-until [:db path expected]] advances (step-skip) once the
+            preceding dispatch made the predicate true"
+    (rf/dispatch-sync* [:step/set 42] {:frame step-frame})
+    (let [res (exec-step! step-frame 0 [:wait-until [:db [:v] 42]])]
+      (is (nil? (:passed? res)) "a satisfied wait-until is a step-skip (advance)")
+      (is (not (:exception res)))))
+  (testing "[:wait-until [:db path :pred fn]] settles on a predicate"
+    (rf/dispatch-sync* [:step/inc] {:frame step-frame})
+    (let [res (exec-step! step-frame 0 [:wait-until [:db [:n] :pred pos?]])]
+      (is (nil? (:passed? res)))))
+  (testing "[:wait-until [:queue-empty]] settles — the queue drained at the
+            settled boundary"
+    (let [res (exec-step! step-frame 0 [:wait-until [:queue-empty]])]
+      (is (nil? (:passed? res))))))
+
+(deftest wait-until-times-out-readably-when-predicate-never-true
+  (testing "an unmet [:wait-until pred] records a step-fail with a readable
+            message — never a silent pass (spec/017 §Script step grammar)"
+    (let [res (exec-step! step-frame 0 [:wait-until [:db [:never] :appears]])]
+      (is (false? (:passed? res)) "unmet wait-until is a FAIL, not a skip")
+      (is (= [:db [:never] :appears] (:expected res)))
+      (is (re-find #"never became true" (:message res))))))
+
+(deftest assert-checkpoint-records-at-this-point-in-the-script
+  (testing "[:assert [:rf.assert/path-equals …]] records a PASSING assertion
+            on the frame's :rf.story/assertions slot when true at this point"
+    (rf/dispatch-sync* [:step/set :ready] {:frame step-frame})
+    (let [res (exec-step! step-frame 0 [:assert [:rf.assert/path-equals [:v] :ready]])]
+      (is (true? (:passed? res)) "the checkpoint passed at this point")
+      (let [recs (:rf.story/assertions (rf/get-frame-db step-frame))]
+        (is (= 1 (count recs)) "exactly one assertion record landed")
+        (is (= :rf.assert/path-equals (:assertion (last recs))))
+        (is (true? (:passed? (last recs)))))))
+  (testing "a FAILING checkpoint records :passed? false and surfaces a
+            step-fail"
+    (rf/dispatch-sync* [:step/set :ready] {:frame step-frame})
+    (let [res (exec-step! step-frame 1 [:assert [:rf.assert/path-equals [:v] :NOPE]])]
+      (is (false? (:passed? res)) "the checkpoint failed at this point")
+      (let [recs (:rf.story/assertions (rf/get-frame-db step-frame))]
+        (is (false? (:passed? (last recs)))))))
+  (testing "the checkpoint records exactly ONE assertion (no double-count
+            from the assertion-slot mirror bridge)"
+    (rf/dispatch-sync* [:step/set 7] {:frame step-frame})
+    (let [before (count (:rf.story/assertions (rf/get-frame-db step-frame)))]
+      (exec-step! step-frame 0 [:assert [:rf.assert/path-equals [:v] 7]])
+      (is (= 1 (- (count (:rf.story/assertions (rf/get-frame-db step-frame))) before))
+          "the wrapped :rf.assert/* handler is the SOLE recorder for [:assert …]"))))
+
+(deftest focus-refuses-cannot-run-under-headless
+  (testing "[:focus selector] returns a :cannot-run-shaped step-fail under a
+            headless runner (no DOM) — never a silent pass (spec/017
+            §`:cannot-run`)"
+    (let [res (exec-step! step-frame 0 [:focus "[data-test=in]"])]
+      (is (false? (:passed? res)))
+      (is (true? (:skipped? res)) "headless focus is a no-DOM skip, not a pass")
+      (is (re-find #"no DOM" (:message res)))))
+  (testing "the boundary ladder agrees: a headless runner does not satisfy
+            the :dom boundary [:focus] requires"
+    (is (= :dom (boundary/step-required-boundary [:focus "sel"])))
+    (is (not (boundary/satisfies-boundary? :headless :dom))))
+  (testing "the capability registry agrees: [:focus] requires the :dom token
+            a :headless runner lacks"
+    (is (= #{:dom} (requirements/step-tokens [:focus "sel"])))
+    (is (false? (requirements/runner-satisfies?
+                  (requirements/runner-provides :headless)
+                  (requirements/step-tokens [:focus "sel"]))))))


### PR DESCRIPTION
@
## What

Implements the P1 **tagged setup/script step grammar** in the Story play runner (`tools/story/spec/017-Testing-Story.md` §Script step grammar), bead **rf2-5x1wt.17** — the critical-path runner hub for NewTestStory.

The runner (`re-frame.story.play.runner` pure + `re-frame.story.play.runner-events` impure) is the single executor across the live canvas auto-run, the interactive step-debugger, and the headless run / replay paths. Builds on the merged deps `.2` (`settled-boundary` / `dispatch-and-settle!`), `.11` (`:setup`/`:script` vocab), `.16` (capability registry).

### The grammar implemented

| Step | Behaviour |
|---|---|
| `[:dispatch event-vector]` | settled dispatch through `settled-boundary` (unchanged; `.2`) |
| `[:wait-until predicate-spec]` | **NEW** deterministic settle-on-condition — `[:db path expected]` / `[:db path :pred fn]` / `[:queue-empty]`; satisfied → advance, unmet → readable timeout step-fail, never a silent pass |
| `[:wait ms]` | bounded wall-clock sleep — the determinism opt-out the determinism gate (`.8`) refuses |
| `[:assert assertion-vector]` | **NEW** in-script `:rf.assert/*` checkpoint — dispatches the wrapped atom (headless rail), surfaces the recorded outcome; exactly one slot record (no mirror double-count) |
| `[:focus selector]` | **NEW** DOM step — `:cannot-run` under headless (no DOM), runs under `:dom`/`:browser`; requires the `:dom` capability token + boundary |

### Other changes

- **Migration normalization** — bare event-vector shorthand lifts to `[:dispatch …]` for **both** `:script` and `:setup` (the plan compiler now coerces setup through the same `coerce-script` path); bare vectors are the migration form, not the P1 public grammar.
- **`[:assert …]` rejected in `:setup`** at plan-compile time → `:rf.error/story-assert-in-setup` (setup establishes preconditions, it does not judge). Runs on the fully-resolved setup (inherited ⧺ composed ⧺ own).
- **Evidence** — `:focus` joins the narrative span-openers so script spans project over epoch beats.
- **spec/017** — new `#### Script step runner` subsection documenting the tagged grammar, migration normalization, the `:setup` reject, the `[:wait]`→determinism-refusal, the `[:wait-until]` predicate forms, and the `[:focus]`→`:dom` routing.

### Files

- runner: `runner.cljc`, `runner_events.cljc`, `dom.cljc` (new `focus!`), `settled_boundary.cljc` (`:assert` boundary), `evidence.cljc` (`:focus` span-opener)
- plan: `plan.cljc` (setup coercion + `[:assert]`-in-`:setup` reject), `schemas.cljc` (PlayStep docstring)
- tests: new `play/step_runner_test.cljc`; `plan_test.cljc` updated for setup migration normalization
- spec: `tools/story/spec/017-Testing-Story.md`

### Collision note

Stays in lane: `requirements.cljc` (`.16`) is read-only here (only its capability tokens are consulted). The held sibling `.30` (reactive-count probe) will touch `requirements.cljc` + `plan.cljc`; my `plan.cljc` edits are cohesive (one `reject-assert-in-setup!` helper + one wired call + the setup-coercion line) so `.30` rebases cleanly.

## Quality gates

| Gate | Result |
|---|---|
| `cd tools/story && clojure -M:test` | PASS — 1087 tests, 3357 assertions, 0 failures, 0 errors |
| `npm --prefix implementation run test:cljs` | PASS — 4850 tests, 15890 assertions, 0 failures, 0 errors |
| `bash scripts/test-fast-pr.sh` | PASS — node-runtime CLJS + README/docs anchor validators (mkdocs soft-skipped: not on PATH locally; CI runs it) |
@