### PR TITLE
feat(story): fold terminal + script assertions onto one atom (rf2-5x1wt.18)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -1054,10 +1054,63 @@ It is allowed in exactly two positions: `:assertions` (terminal) and
 `[:dispatch-sync [:rf.assert/*]]` event rail is the runner's **headless
 implementation**, never an authoring form.
 
-The shipping `:assert-db` step folds to `:rf.assert/path-equals`; a
-`:rf.assert/dom-*` family carries a `:dom` token (folding the shipping
-`:assert-dom`). Assertions in `:assertions` are own-only terminal
-expectations; they MUST NOT inherit through `:extends`.
+**One record shape, regardless of position.** Both positions resolve to
+the SAME assertion atom and produce the SAME assertion record. A terminal
+`:assertions` entry and the SAME atom written as an in-script `[:assert …]`
+checkpoint are byte-for-byte identical atoms; the only difference is *when*
+the verdict runs (terminal = after the script; checkpoint = at that exact
+script position). The mid-script checkpoint dispatches its wrapped atom
+through the canonical `:rf.assert/*` handler, so it lands the canonical
+record — never a second, position-specific shape.
+
+**The shipping ergonomic steps fold onto the one atom.** The plan compiler
+rewrites the shipping `:assert-db` / `:assert-dom` script steps into the
+canonical `[:assert assertion-atom]` checkpoint during script
+normalization, so every in-script assertion — whatever sugar the author
+typed — collapses to the one atom:
+
+| Shipping step | Folds to |
+|---------------|----------|
+| `[:assert-db path expected]` | `[:assert [:rf.assert/path-equals path expected]]` |
+| `[:assert-db path :pred f]` | `[:assert [:rf.assert/path-matches path [:fn f]]]` |
+| `[:assert-dom sel :visible]` | `[:assert [:rf.assert/dom-visible sel]]` |
+| `[:assert-dom sel :hidden]` | `[:assert [:rf.assert/dom-hidden sel]]` |
+| `[:assert-dom sel :text txt]` | `[:assert [:rf.assert/dom-text sel txt]]` |
+
+The `:assert-db` predicate form folds to `:rf.assert/path-matches` wrapping
+the predicate in a Malli `[:fn …]` schema — the one canonical way to
+express an arbitrary predicate against a path, so no parallel
+predicate-assertion id is introduced.
+
+**The DOM family carries the `:dom` runner requirement.** The DOM
+assertion family `:rf.assert/dom-visible` / `:rf.assert/dom-hidden` /
+`:rf.assert/dom-text` is **NET-NEW** (the shipping vocabulary had only the
+seven below plus an ad-hoc synthetic `:rf.assert/dom` record the runtime
+minted). Each folded DOM id rides the `:dom` capability token via the
+requirement registry (§Runner requirements), so a folded `:assert-dom`
+step keeps the exact runner requirement the raw step had. The DOM runner
+that *evaluates* these ids lands later; until then a headless run that
+reaches one refuses with `:cannot-run` (the `:dom` gate), never a silent
+pass.
+
+**The seven shipping ids are preserved.** The fold collapses *authoring
+sugar* onto existing atoms; it does not retire any of the seven shipping
+`:rf.assert/*` ids (listed under §Canonical P1 assertions). `:rf.assert/
+path-equals` and `:rf.assert/path-matches` gain the `:assert-db` fold
+targets; the DOM family is the only NET-NEW addition this fold introduces.
+
+**Unknown ids fail plan construction.** Every authored assertion atom —
+terminal `:assertions` OR an in-script `[:assert …]` checkpoint (including
+the folded `:assert-db` / `:assert-dom` steps) — MUST name a recognised
+`:rf.assert/*` id. An unknown id FAILS plan construction with
+`:rf.error/story-unknown-assertion`, before any run, rather than recording
+a vacuous `:rf.assert/unknown` pseudo-record at run time. There is no
+`:rf.assert/no-schema-errors` author surface — schema-clean is the
+knob-free runner floor (§Schema rule), enforced by post-run evidence-slot
+validation, not an opt-in assertion.
+
+Assertions in `:assertions` are own-only terminal expectations; they MUST
+NOT inherit through `:extends`.
 
 ### Checks
 
@@ -1079,6 +1132,9 @@ remains the base. P1 SHOULD include or retain:
 - `:rf.assert/no-warnings`
 - `:rf.assert/effect-emitted`
 - `:rf.assert/schema-error` (NET-NEW; §Schema rule)
+- `:rf.assert/dom-visible` / `:rf.assert/dom-hidden` / `:rf.assert/dom-text`
+  (NET-NEW; the `:dom` family the shipping `:assert-dom` step folds to —
+  §Assertions — one atom, two positions)
 - `:rf.assert/visual-snapshot` (`:browser`)
 - `:rf.assert/a11y` (`:browser` for axe-style; MAY require only `:hiccup`
   for explicitly structural checks)

--- a/tools/story/src/re_frame/story/assertions.cljc
+++ b/tools/story/src/re_frame/story/assertions.cljc
@@ -55,14 +55,15 @@
     `:passed? true` (used by Stage 5's `run-variant` test entry, and by
     consumer tests via the public `assertions-passing?`).
   - `canonical-assertion-ids` — the set of registered event ids."
-  (:require [re-frame.core             :as rf]
-            [re-frame.elision          :as elision]
-            [re-frame.interop          :as interop]
-            [re-frame.subs             :as subs]
-            [re-frame.story.config     :as config]
-            [re-frame.story.predicates :as pred]
-            [re-frame.story.registrar  :as registrar]
-            [malli.core                :as malli]))
+  (:require [re-frame.core               :as rf]
+            [re-frame.elision            :as elision]
+            [re-frame.interop            :as interop]
+            [re-frame.subs               :as subs]
+            [re-frame.story.config       :as config]
+            [re-frame.story.predicates   :as pred]
+            [re-frame.story.registrar    :as registrar]
+            [re-frame.story.requirements :as requirements]
+            [malli.core                  :as malli]))
 
 ;; ---------------------------------------------------------------------------
 ;; Per-frame trace-bus accumulators (warnings + emitted fx + dispatched)
@@ -451,7 +452,9 @@
 
 (def canonical-assertion-ids
   "Per spec/007 line 304 — the canonical seven assertion event ids,
-  registered at Story boot."
+  registered at Story boot. These are the SHIPPING seven the fold
+  preserves (rf2-5x1wt.18, spec/017 §Assertions — one atom, two
+  positions)."
   #{id-path-equals
     id-path-matches
     id-sub-equals
@@ -459,6 +462,146 @@
     id-state-is
     id-no-warnings
     id-effect-emitted})
+
+;; ---------------------------------------------------------------------------
+;; DOM assertion family — the fold target for the shipping `:assert-dom`
+;; step (rf2-5x1wt.18, spec/017 §Assertions — one atom, two positions).
+;;
+;; These ids are NET-NEW (the shipping vocabulary had only the seven above
+;; plus the ad-hoc synthetic `:rf.assert/dom` record `:assert-dom` minted).
+;; The DOM runner that EVALUATES them lands later (the `:dom` capability is
+;; wired now via `re-frame.story.requirements`); the fold names them so an
+;; `:assert-dom` step lowers onto the SAME assertion atom shape as every
+;; other assertion, regardless of script position. A headless run that
+;; reaches one refuses with `:cannot-run` (the `:dom` capability gate),
+;; never a silent pass — that is the fail-closed contract, not this fold's
+;; concern.
+;; ---------------------------------------------------------------------------
+
+(def ^:const id-dom-visible     :rf.assert/dom-visible)
+(def ^:const id-dom-hidden      :rf.assert/dom-hidden)
+(def ^:const id-dom-text        :rf.assert/dom-text)
+
+(def dom-assertion-ids
+  "The DOM assertion family (rf2-5x1wt.18, NET-NEW). The shipping
+  `:assert-dom selector :visible|:hidden|:text` step folds onto these so
+  a DOM expectation rides the ONE assertion atom. Each carries the `:dom`
+  runner requirement via `re-frame.story.requirements/assertion-capabilities`
+  (spec/017 §Runner requirements); the DOM runner that proves them lands
+  later."
+  #{id-dom-visible
+    id-dom-hidden
+    id-dom-text})
+
+(def known-assertion-ids
+  "Every assertion id the P1 vocabulary recognises — the shipping seven,
+  the folded DOM family, and the wider set declared in the requirement
+  registry (`re-frame.story.requirements/assertion-capabilities`: the
+  schema / visual / a11y / reactive-count ids whose runners land later).
+  Plan construction validates authored assertion atoms against this set
+  (`assertion-id-known?`); an unknown id FAILS plan construction with a
+  useful error (rf2-5x1wt.18, spec/017 §Assertions). Reading the
+  requirement registry keeps this list a derived view of the ONE id
+  source of truth rather than a hand-maintained parallel set."
+  (into (into canonical-assertion-ids dom-assertion-ids)
+        (keys requirements/assertion-capabilities)))
+
+(defn assertion-id-known?
+  "True iff `id` is a recognised P1 assertion id (`known-assertion-ids`).
+  Pure data → data. Used by the plan compiler to FAIL plan construction
+  on an unknown assertion atom rather than letting it record a vacuous
+  `:rf.assert/unknown` pseudo-record at run time (rf2-5x1wt.18)."
+  [id]
+  (contains? known-assertion-ids id))
+
+;; ---------------------------------------------------------------------------
+;; Assertion-atom fold (rf2-5x1wt.18, spec/017 §Assertions — one atom,
+;; two positions)
+;;
+;; The assertion atom is the data vector `[:rf.assert/id & args]`. It is
+;; legal in exactly two positions: terminal `:assertions` and the in-script
+;; `[:assert …]` checkpoint. Both positions produce ONE assertion-record
+;; shape (the `[:assert …]` checkpoint dispatches the wrapped atom, whose
+;; reg-event-fx handler records the canonical record — rf2-5x1wt.17).
+;;
+;; The shipping ergonomic script steps `:assert-db` / `:assert-dom` are NOT
+;; authoring-distinct assertion kinds — they are sugar that FOLDS onto the
+;; one atom:
+;;
+;;   [:assert-db path expected]        → [:rf.assert/path-equals path expected]
+;;   [:assert-db path :pred fn-or-sym] → [:rf.assert/path-matches path [:fn …]]
+;;   [:assert-dom sel :visible]        → [:rf.assert/dom-visible sel]
+;;   [:assert-dom sel :hidden]         → [:rf.assert/dom-hidden sel]
+;;   [:assert-dom sel :text txt]       → [:rf.assert/dom-text sel txt]
+;;
+;; `fold-assert-step` returns the canonical `[:assert assertion-atom]`
+;; checkpoint for a shipping `:assert-db` / `:assert-dom` step, so the plan
+;; compiler can rewrite a script uniformly to the ONE atom in its
+;; checkpoint position — collapsing the two parallel record-minting paths
+;; (`runner-events`' synthetic `:rf.assert/db` / `:rf.assert/dom` records)
+;; onto the canonical assertion handlers. Pure data → data.
+;; ---------------------------------------------------------------------------
+
+(defn- assert-db->atom
+  "Fold a shipping `[:assert-db …]` step into its canonical assertion atom.
+  The equality form folds to `:rf.assert/path-equals`; the predicate form
+  folds to `:rf.assert/path-matches` wrapping the predicate in a Malli
+  `[:fn …]` schema (the one canonical way to express an arbitrary
+  predicate against a path). A symbol predicate is preserved verbatim in
+  the `[:fn …]` schema — the assertion handler's Malli path resolves it
+  the same way the shipping `:assert-db :pred` rail did."
+  [step]
+  (let [path (nth step 1)]
+    (if (and (= 4 (count step)) (= :pred (nth step 2)))
+      [id-path-matches path [:fn (nth step 3)]]
+      [id-path-equals path (nth step 2)])))
+
+(defn- assert-dom->atom
+  "Fold a shipping `[:assert-dom …]` step into its canonical DOM-family
+  assertion atom (`:rf.assert/dom-visible` / `:rf.assert/dom-hidden` /
+  `:rf.assert/dom-text`). Carries the selector (and text) as the atom's
+  payload; the `:dom` runner requirement rides the folded id via the
+  requirement registry."
+  [step]
+  (let [selector (nth step 1)
+        mode     (nth step 2)]
+    (case mode
+      :visible [id-dom-visible selector]
+      :hidden  [id-dom-hidden  selector]
+      :text    [id-dom-text    selector (nth step 3)])))
+
+(defn fold-assert-step
+  "Fold a shipping ergonomic assertion step (`[:assert-db …]` /
+  `[:assert-dom …]`) into the canonical `[:assert assertion-atom]`
+  checkpoint, so terminal `:assertions` and EVERY in-script assertion
+  position resolve to the ONE assertion atom (rf2-5x1wt.18). Returns the
+  rewritten `[:assert …]` step for a foldable step, or the step unchanged
+  for any other step (`:dispatch`, `:wait`, an already-`[:assert …]`
+  checkpoint, a bare event vector). Pure data → data — used by the plan
+  compiler's script normalization."
+  [step]
+  (case (and (vector? step) (pos? (count step)) (first step))
+    :assert-db  [:assert (assert-db->atom step)]
+    :assert-dom [:assert (assert-dom->atom step)]
+    step))
+
+(defn fold-script
+  "Fold every shipping `:assert-db` / `:assert-dom` step in a coerced
+  `script` vector onto the canonical `[:assert assertion-atom]` checkpoint
+  (rf2-5x1wt.18). Leaves non-assertion steps and already-canonical
+  `[:assert …]` checkpoints untouched. Pure data → data."
+  [script]
+  (mapv fold-assert-step (or script [])))
+
+(defn assertion-atom-id
+  "The `:rf.assert/*` id at the head of an assertion atom, or nil for a
+  non-atom. An assertion atom is `[:rf.assert/id & args]`; this is the id
+  every fold target + authored atom is validated against (`assertion-id-
+  known?`). Pure data → data."
+  [assertion-atom]
+  (when (and (vector? assertion-atom) (pos? (count assertion-atom)))
+    (let [h (first assertion-atom)]
+      (when (keyword? h) h))))
 
 ;; ---------------------------------------------------------------------------
 ;; Boot — register the seven canonical handlers

--- a/tools/story/src/re_frame/story/plan.cljc
+++ b/tools/story/src/re_frame/story/plan.cljc
@@ -103,6 +103,7 @@
   `:lookup` (a `{variant-id → raw-body}` map or a 1-arg fn) for pure
   tests."
   (:require [re-frame.story.args         :as args]
+            [re-frame.story.assertions   :as assertions]
             [re-frame.story.registrar    :as registrar]
             [re-frame.story.requirements :as requirements]
             [re-frame.story.malli-schema :as msu]
@@ -250,7 +251,15 @@
   "Return `{:script [step ...] :scripts [{:name :script :auto-run?} ...]}`
   for a merged body. Accepts the target `:script` spelling AND the
   shipping `:play-script` / `:plays` spellings, lowering them through the
-  runner's canonical coercion. The primary `:script` is the first play."
+  runner's canonical coercion. The primary `:script` is the first play.
+
+  After coercion every play's script is FOLDED (`assertions/fold-script`,
+  rf2-5x1wt.18): a shipping `:assert-db` / `:assert-dom` step rewrites to
+  the canonical `[:assert assertion-atom]` checkpoint, so EVERY in-script
+  assertion — whatever sugar the author typed — resolves to the ONE
+  assertion atom shape (spec/017 §Assertions — one atom, two positions).
+  Each `:scripts` entry carries the folded script too, so named plays the
+  runner drives also see the canonical checkpoints."
   [body]
   (let [plays (cond
                 (contains? body :script)
@@ -260,7 +269,8 @@
 
                 :else
                 (runner/variant-body->plays body))
-        plays (vec plays)]
+        plays (mapv (fn [p] (update p :script assertions/fold-script))
+                    (vec plays))]
     {:script  (-> plays first :script (or []))
      :scripts plays}))
 
@@ -294,6 +304,51 @@
                 "not judge). Move the assertion to :script (as an "
                 "[:assert …] checkpoint) or to the terminal :assertions slot.")
            {:variant/id id :offending-steps (vec offenders)})))
+
+;; ============================================================================
+;; Assertion-id validation (rf2-5x1wt.18)
+;; ============================================================================
+
+(defn- script-assertion-atoms
+  "Collect the assertion atoms an `[:assert assertion-atom]` checkpoint
+  carries from a folded `script` (rf2-5x1wt.18). The shipping
+  `:assert-db` / `:assert-dom` steps are already folded to `[:assert …]`
+  by `normalize-scripts`, so this single walk covers every in-script
+  assertion position uniformly. Pure data → data."
+  [script]
+  (into [] (keep (fn [step] (when (assert-step? step) (second step)))) script))
+
+(defn- reject-unknown-assertions!
+  "FAIL plan construction when any authored assertion atom — terminal
+  `:assertions` OR an in-script `[:assert …]` checkpoint — names an id
+  that is not in the recognised P1 vocabulary
+  (`assertions/known-assertion-ids`, rf2-5x1wt.18, spec/017 §Assertions).
+  Catching it at compile time surfaces the typo before any run, the same
+  way the other `:rf.error/story-*` plan errors do — never letting an
+  unknown id record a vacuous `:rf.assert/unknown` pseudo-record at run
+  time. `script-assertions` are the atoms pulled from `[:assert …]`
+  checkpoints (post-fold); `terminal-assertions` are the child's own
+  `:assertions` atoms."
+  [id script-assertions terminal-assertions]
+  (let [offenders (into []
+                        (comp (remove nil?)
+                              (remove (fn [a]
+                                        (assertions/assertion-id-known?
+                                          (assertions/assertion-atom-id a)))))
+                        (concat terminal-assertions script-assertions))]
+    (when (seq offenders)
+      (fail! :rf.error/story-unknown-assertion
+             (str "re-frame2-story: variant " id
+                  " — unknown assertion id(s) "
+                  (pr-str (mapv assertions/assertion-atom-id offenders))
+                  " in " (pr-str (vec offenders))
+                  ". An assertion atom must name a recognised :rf.assert/* id "
+                  "(the shipping seven, the DOM family, or a registered "
+                  "requirement id). Check the spelling, or fold a shipping "
+                  ":assert-db / :assert-dom step rather than inventing an id.")
+             {:variant/id id
+              :offending-assertions (vec offenders)
+              :known-ids assertions/known-assertion-ids}))))
 
 ;; ============================================================================
 ;; Arg placeholder substitution
@@ -1083,6 +1138,15 @@
         ;; misplaced verdict surfaces before any run.
         _            (reject-assert-in-setup! id setup)
         script*      (substitute-args script arg-map subs!)
+        ;; rf2-5x1wt.18 — every authored assertion atom (terminal
+        ;; `:assertions` AND an in-script `[:assert …]` checkpoint, incl.
+        ;; the folded `:assert-db` / `:assert-dom` steps) MUST name a
+        ;; recognised :rf.assert/* id. An unknown id FAILS plan
+        ;; construction here, before any run (spec/017 §Assertions). The
+        ;; script is already folded (`normalize-scripts`), so one walk over
+        ;; the `[:assert …]` checkpoints covers every in-script position.
+        _            (reject-unknown-assertions!
+                       id (script-assertion-atoms script*) assertions)
         ;; ---- view-state subscription overrides (rf2-5x1wt.13) ----
         ;; `:sub-overrides` composes like `:network`: composed-fragment
         ;; override maps merge in declared order (a later fragment wins a

--- a/tools/story/test/re_frame/story/plan_test.cljc
+++ b/tools/story/test/re_frame/story/plan_test.cljc
@@ -10,6 +10,7 @@
   registrar's eager merge)."
   (:require [clojure.test :refer [deftest is testing]]
             [malli.core :as m]
+            [re-frame.story.assertions :as assertions]
             [re-frame.story.plan :as plan]
             [re-frame.story.sub-overrides :as sub-overrides]))
 
@@ -581,3 +582,147 @@
                                            (fn [] (throw (ex-info "should not run" {})))))))
       (is (= :real  (sub-overrides/with-overrides* ovr
                       #(sub-overrides/read [:login/other] (fn [] :real))))))))
+
+;; ===========================================================================
+;; Assertion-atom fold (rf2-5x1wt.18, spec/017 §Assertions — one atom,
+;; two positions)
+;; ===========================================================================
+;;
+;; The fold collapses terminal `:assertions` and EVERY in-script assertion
+;; position onto ONE assertion atom. A terminal `:assertions` entry and a
+;; script `[:assert …]` entry produce the SAME atom shape; the shipping
+;; `:assert-db` / `:assert-dom` sugar folds onto the canonical atoms; an
+;; unknown id FAILS plan construction.
+
+;; ---- one atom, two positions ---------------------------------------------
+
+(deftest terminal-and-script-assertion-produce-same-atom-shape
+  (testing "a terminal :assertions entry and an in-script [:assert …] entry
+           resolve to the IDENTICAL assertion atom (one atom, two positions)"
+    (let [atom-v [:rf.assert/path-equals [:n] 0]
+          m {:story.counter/checkpoint
+             {:script     [[:dispatch [:counter/dec]]
+                           [:assert atom-v]]
+              :assertions [atom-v]}}
+          p (plan-of :story.counter/checkpoint m)
+          terminal     (first (get-in p [:expect :assertions]))
+          checkpoint   (-> p :script (->> (filter #(= :assert (first %))) first) second)]
+      ;; same id, same payload, same vector — no per-position divergence
+      (is (= atom-v terminal))
+      (is (= atom-v checkpoint))
+      (is (= terminal checkpoint)))))
+
+;; ---- :assert-db fold ------------------------------------------------------
+
+(deftest assert-db-folds-to-path-equals
+  (testing ":assert-db equality form folds to the canonical [:assert
+           [:rf.assert/path-equals …]] checkpoint — same result as authoring
+           the atom directly"
+    (let [folded   (plan-of :story.x/folded
+                            {:story.x/folded {:script [[:assert-db [:count] 6]]}})
+          authored (plan-of :story.x/authored
+                            {:story.x/authored
+                             {:script [[:assert [:rf.assert/path-equals [:count] 6]]]}})]
+      (is (= [[:assert [:rf.assert/path-equals [:count] 6]]] (:script folded)))
+      ;; the fold emits exactly what the author would have typed by hand
+      (is (= (:script authored) (:script folded)))))
+  (testing ":assert-db :pred form folds to :rf.assert/path-matches wrapping
+           the predicate in a Malli [:fn …] schema (the one canonical way to
+           express a predicate against a path)"
+    (let [pred even?
+          p (plan-of :story.x/pred
+                     {:story.x/pred {:script [[:assert-db [:count] :pred pred]]}})
+          step (first (:script p))]
+      (is (= :assert (first step)))
+      (is (= [:rf.assert/path-matches [:count] [:fn pred]] (second step))))))
+
+;; ---- :assert-dom fold + runner requirement -------------------------------
+
+(deftest assert-dom-folds-to-dom-family
+  (testing ":assert-dom :visible / :hidden / :text fold onto the DOM
+           assertion family (rf2-5x1wt.18, NET-NEW ids)"
+    (let [p (plan-of :story.x/dom
+                     {:story.x/dom
+                      {:script [[:assert-dom "#a" :visible]
+                                [:assert-dom "#b" :hidden]
+                                [:assert-dom "#c" :text "hello"]]}})]
+      (is (= [[:assert [:rf.assert/dom-visible "#a"]]
+              [:assert [:rf.assert/dom-hidden "#b"]]
+              [:assert [:rf.assert/dom-text "#c" "hello"]]]
+             (:script p))))))
+
+(deftest dom-fold-carries-dom-runner-requirement
+  (testing "a folded :assert-dom step contributes the :dom capability token to
+           :required-runner (the requirement rides the folded id)"
+    (let [p (plan-of :story.x/dom-req
+                     {:story.x/dom-req {:script [[:assert-dom "#x" :visible]]}})]
+      (is (contains? (:required-runner p) :dom))))
+  (testing "a headless-only :assert-db fold demands NO :dom token"
+    (let [p (plan-of :story.x/db-req
+                     {:story.x/db-req {:script [[:assert-db [:n] 1]]}})]
+      (is (not (contains? (:required-runner p) :dom))))))
+
+;; ---- unknown assertion ids fail plan construction ------------------------
+
+(deftest unknown-terminal-assertion-id-fails-plan-construction
+  (testing "an unknown id in terminal :assertions FAILS plan construction"
+    (let [m {:story.x/bad {:assertions [[:rf.assert/typo [:n] 1]]}}]
+      (is (thrown-with-msg?
+            #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
+            #"story-unknown-assertion"
+            (plan-of :story.x/bad m))))))
+
+(deftest unknown-script-checkpoint-assertion-id-fails-plan-construction
+  (testing "an unknown id in an in-script [:assert …] checkpoint FAILS plan
+           construction (same id-validation as the terminal position)"
+    (let [m {:story.x/bad2 {:script [[:assert [:rf.assert/nope]]]}}]
+      (is (thrown-with-msg?
+            #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
+            #"story-unknown-assertion"
+            (plan-of :story.x/bad2 m))))))
+
+(deftest unknown-assertion-error-carries-structured-data
+  (testing "the :rf.error/story-unknown-assertion ex-data names the bad id"
+    (let [m {:story.x/bad3 {:assertions [[:rf.assert/whoops]]}}
+          ex (try (plan-of :story.x/bad3 m) nil
+                  (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e e))]
+      (is (some? ex))
+      (is (= :rf.error/story-unknown-assertion (:rf.error/id (ex-data ex))))
+      (is (contains? (set (:offending-assertions (ex-data ex)))
+                     [:rf.assert/whoops])))))
+
+(deftest every-shipping-and-folded-id-is-known
+  (testing "the seven shipping ids + the folded DOM family pass id validation
+           (a variant authoring each compiles cleanly)"
+    (doseq [atom-v [[:rf.assert/path-equals [:n] 0]
+                    [:rf.assert/path-matches [:n] :int]
+                    [:rf.assert/sub-equals [:sub/x] 1]
+                    [:rf.assert/dispatched? [:e]]
+                    [:rf.assert/state-is :m :s]
+                    [:rf.assert/no-warnings]
+                    [:rf.assert/effect-emitted :fx]
+                    [:rf.assert/dom-visible "#x"]
+                    [:rf.assert/dom-hidden "#x"]
+                    [:rf.assert/dom-text "#x" "t"]]]
+      (is (= [atom-v]
+             (get-in (plan-of :story.x/ok {:story.x/ok {:assertions [atom-v]}})
+                     [:expect :assertions]))
+          (str "expected " (pr-str atom-v) " to compile as a known assertion")))))
+
+;; ---- pure fold helpers (assertion-ns surface) ----------------------------
+
+(deftest fold-helpers-are-pure-and-position-agnostic
+  (testing "assertions/fold-assert-step folds the shipping sugar steps"
+    (is (= [:assert [:rf.assert/path-equals [:n] 5]]
+           (assertions/fold-assert-step [:assert-db [:n] 5])))
+    (is (= [:assert [:rf.assert/dom-visible "#x"]]
+           (assertions/fold-assert-step [:assert-dom "#x" :visible]))))
+  (testing "fold-assert-step is identity for non-foldable steps"
+    (is (= [:dispatch [:e]] (assertions/fold-assert-step [:dispatch [:e]])))
+    (is (= [:assert [:rf.assert/no-warnings]]
+           (assertions/fold-assert-step [:assert [:rf.assert/no-warnings]])))
+    (is (= [:wait 10] (assertions/fold-assert-step [:wait 10]))))
+  (testing "known-assertion-ids covers the seven shipping ids + the DOM family"
+    (is (every? assertions/assertion-id-known? assertions/canonical-assertion-ids))
+    (is (every? assertions/assertion-id-known? assertions/dom-assertion-ids))
+    (is (not (assertions/assertion-id-known? :rf.assert/totally-made-up)))))


### PR DESCRIPTION
@-

## Quality gates

- `cd tools/story && clojure -M:test` — **PASS** (1096 tests / 3390 assertions, 0 failures, 0 errors)
- `npm --prefix implementation run test:cljs` — **PASS** (4850 tests / 15890 assertions, 0 failures, 0 errors)
- `bash scripts/test-fast-pr.sh --with-docs` — **PASS** (mkdocs soft-skipped locally, runs in CI)

_(QG section added by mayor from the worker's completion report.)_
