### PR TITLE
feat(story): unified run-result + story/is clojure.test bridge (rf2-5x1wt.19)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -1544,6 +1544,86 @@ already hashes `:epoch-tape` alongside the projected `:schema-violations` /
 `:warnings` / `:effects`, so a divergent projection perturbs the
 run-equivalence hash.
 
+### Unified run result {#unified-run-result}
+
+There is **one run-result shape**, assembled by **one boundary** —
+`re-frame.story.result/run-result` (re-exported as `story/run-result`).
+Before unification three result vocabularies coexisted and could disagree
+(the documented "false GREEN"): the runtime's `:lifecycle`-keyed map, the
+play runner's per-step `run-state` machine, and `replay-result`'s tape-
+projected shape. They are now folded onto the ONE shape, derived — wherever
+the tape carries the evidence — from `evidence/project-evidence` (the single
+tape projection; there is **no parallel accumulator**). The judgement slots
+(`:assertions` / `:checks`) fold the `:rf.story/assertions` accumulator (the
+ONE non-tape input — an assertion verdict is the one fact the tape does not
+carry); every evidential slot is a `.4` projection.
+
+**The three record shapes carry a unified `:status`.** Each assertion record
+and check record carries `:status ∈ #{:pass :fail :cannot-run :error}`
+alongside the `.18` atom / accumulator fields, so the run aggregation reads
+ONE field. `result/record-status` derives it: an explicit `:status` wins;
+else `:cannot-run?` / a no-DOM `:skipped?` → `:cannot-run` (the §`:cannot-run`
+rule generalizes the shipping `:skipped?`); `:exception` / `:error` →
+`:error`; `:passed?` true/false → `:pass` / `:fail`; a record with no
+outcome is vacuously `:pass` (the §Story-as-test duality).
+
+**Check records group assertions.** `result/check-records` pairs the plan's
+expanded `{check-id [assertion-atom …]}` (via `plan/expand-checks`, §Total
+resolution order step 8) against the run's evaluated records — each check id
+groups the records its atoms produced (matched by assertion id **and**
+payload, so two same-id assertions in one check disambiguate), and the
+check's `:status` aggregates its group. A failed check shows BOTH the check
+id AND the underlying records (§Checks).
+
+**The verdict — the aggregation rule, stated once.**
+`requirements/aggregate-status` is the ONE rule over the assertion records +
+the `:cannot-run` refusals: `:error` > `:fail` > `:cannot-run` > `:pass`.
+The agreement floor (`tape-shows-failure?`) then escalates a would-be
+`:pass` to `:fail` when the tape carries unconsumed failure evidence — so a
+run NEVER reads green while the tape is red, and the verdict derives from the
+PROJECTED evidence, not a sibling accumulator. A run whose only unmet
+expectations are `:cannot-run` is itself `:cannot-run` (a refusal, never a
+silent pass); a zero-assertion clean run is `:pass` (vacuously green).
+
+**The runtime consumes the folded plan.** The `.18` fold (`:assert-db` /
+`:assert-dom` → the canonical `[:assert assertion-atom]` checkpoint) is
+applied at script-resolution time (`runner-events/variant-plays` /
+`variant-play-script` / `play/variant-play-steps` all run
+`assertions/fold-script`), so the runtime drives the ONE assertion atom in
+its checkpoint position — there is **no synthetic `:rf.assert/db` /
+`:rf.assert/dom` rail**. A folded `:assert-db` dispatches the real
+`:rf.assert/path-equals` (or, for the `:pred` form, `:rf.assert/path-matches`
+wrapping a `[:fn …]` schema — a `[:fn sym]` symbol resolves at validation
+time) handler, which records the canonical record; a folded `:assert-dom` is
+evaluated by the DOM executor and records a canonical `:rf.assert/dom-*`
+record. One assertion-record vocabulary, one recorder.
+
+**Test mode and CI consume the unified result.** The Story Test mode
+aggregation (`ui.state.tests/aggregate-summary` / `record-test-run` /
+`test-summary`) buckets by each record's unified `:status` and counts
+`:cannot-run` distinctly (the sidebar dot renders pass / fail / cannot-run /
+running / pending). The CI runner's terminal-state read recognizes
+`:cannot-run` as a terminal verdict (`ci-runner/terminal?`), and the play
+runner's `finish` computes `:pass` / `:fail` / `:cannot-run` by the same
+aggregation rule (a run whose only non-pass steps are refusals is
+`:cannot-run`).
+
+**The `story/is` → clojure.test / cljs.test bridge.** `(story/is target
+opts)` runs `target` and REPORTS each assertion to clojure.test / cljs.test
+at per-assertion granularity. The pure projection
+`result/result->reports` turns a unified result into the ordered vector of
+report maps — one `{:type :pass|:fail|:error …}` per assertion record, plus
+a trailing run-level report when the verdict is not covered by a single
+assertion (a tape-floor `:fail`, a run-level `:cannot-run`, or a vacuous-
+green `:pass` so a zero-assertion run still emits one positive signal). A
+`:cannot-run` assertion reports `:fail` (the runner proved nothing — never a
+silent pass). On the JVM (the canonical headless test gate) `story/is`
+blocks on the run promise and fires `clojure.test/do-report` synchronously,
+returning the unified result; on CLJS — where the run is async — it returns
+the promise (chain `then`, or use the `cljs.test` `(async done …)` form and
+call `story/report-result!` when it resolves). `report-result!` is the pure-
+report seam both runtimes share.
+
 ## Public execution API — the three verbs
 
 The primary API is **three verbs** dispatching on target type — a keyword

--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -107,8 +107,23 @@
             ;; `promote-run-artifact!` (the explicit-only registration path)
             ;; below (spec/017 §Promotion — Promotion bridge).
             [re-frame.story.promotion   :as promotion]
+            ;; rf2-5x1wt.19 — the ONE unified run-result + the assertion /
+            ;; check record shapes + the clojure.test report projection.
+            ;; Re-exported as `run-result` / `result-status` /
+            ;; `result-passed?` and backs the `story/is` bridge below
+            ;; (spec/017 §Run result + §Unified run result).
+            [re-frame.story.result      :as result]
+            ;; rf2-5x1wt.19 — `story/is` blocks on the JVM run promise +
+            ;; chains the CLJS one (the headless-test bridge).
+            [re-frame.story.async       :as async]
             [re-frame.story.lifecycle   :as lifecycle]
             [re-frame.story.query       :as query]
+            ;; rf2-5x1wt.19 — `story/is` bridges per-assertion run-result
+            ;; reports to clojure.test / cljs.test (spec/017 §Public
+            ;; execution API — the three verbs). `do-report` is the one
+            ;; seam both flavours expose for programmatic test reporting.
+            #?(:clj  [clojure.test :as test]
+               :cljs [cljs.test    :as test])
             ;; Runtime modules — args resolution, decorators.
             [re-frame.story.args        :as args]
             [re-frame.story.decorators  :as decorators]
@@ -1174,6 +1189,121 @@
   canonical `:rf.assert/*` event ids registered at boot."
   []
   assertions/canonical-assertion-ids)
+
+;; ---- unified run-result + the three verbs (rf2-5x1wt.19) ----------------
+;;
+;; Per spec/017 §Run result + §Unified run result + §Public execution API:
+;; ONE run-result shape, and `story/is` bridges it to clojure.test /
+;; cljs.test at per-assertion granularity. The pure result assembly + the
+;; report projection live in `re-frame.story.result`; these are the public
+;; re-exports + the impure `is` emission.
+
+(defn run-result
+  "Per spec/017 §Run result + §Unified run result — assemble the ONE
+  unified run-result from a run's evidence + accumulated assertions + plan
+  slots. Pure data → data; the single boundary every runner / Test mode /
+  CI / `clojure.test` / MCP consumes so they cannot disagree about what
+  happened. `parts` carries `:epoch-tape` / `:assertions` / `:script` /
+  `:check->atoms` / `:consumed-selectors` / `:unmet` / `:app-db` and the
+  identity / timing slots (see `re-frame.story.result/run-result`)."
+  [parts]
+  (result/run-result parts))
+
+(defn result-status
+  "Per spec/017 §Run result — the unified verdict of a run-result:
+  `:pass` | `:fail` | `:cannot-run` | `:error`."
+  [result]
+  (:status result))
+
+(defn result-passed?
+  "Per spec/017 §Run result — true iff the run-result's `:status` is
+  `:pass`. A `:cannot-run` is NOT a pass (the runner proved nothing)."
+  [result]
+  (result/passed? result))
+
+(defn result->reports
+  "Per spec/017 §Public execution API — project a unified `result` into the
+  ordered vector of clojure.test report maps (`{:type :pass|:fail|:error
+  …}`), one per assertion record plus a run-level report when the verdict
+  is not covered by a single assertion (a tape-floor `:fail`, a run-level
+  `:cannot-run`, or a vacuous-green `:pass`). Pure data → data — the same
+  projection `story/is` emits, exposed for tooling that wants the reports
+  without firing `do-report`."
+  [result]
+  (result/result->reports result))
+
+(defn run
+  "Per spec/017 §Public execution API — the `run` verb. Run `target` and
+  return a promise/future of the unified run-result (`run-result`). A
+  keyword `target` is a registered variant; map (inline-plan) targets land
+  with rf2-5x1wt.20. `opts` is the run/is opts map (`:runner` /
+  `:frame-binding` / `:platform` …); the default runner is `:headless`.
+
+  Today this delegates to the variant lifecycle (`run-variant`), which
+  returns the unified shape. The verb name is the stable public surface —
+  it does NOT leak the variant-vs-plan authoring distinction (spec/017
+  §Public execution API)."
+  ([target]      (run target nil))
+  ([target opts] (lifecycle/run-variant target opts)))
+
+(defn- emit-reports!
+  "Fire `clojure.test` / `cljs.test` `do-report` for each report map in
+  `reports` (the `result->reports` projection). Pure side-effect — used by
+  `is`. Each report's `:message` already names the assertion + target, so
+  `do-report` lands one pass/fail/error per assertion in the active test
+  run's tally."
+  [_target reports]
+  (doseq [r reports]
+    (test/do-report r))
+  nil)
+
+(defn is
+  "Per spec/017 §Public execution API — the `is` verb. Run `target` and
+  REPORT each assertion to clojure.test / cljs.test at per-assertion
+  granularity (spec/017 §Run result — `story/is` reports per assertion).
+
+  On the JVM (the canonical headless test gate) `is` runs the target,
+  BLOCKS until it resolves, fires one `clojure.test` report per assertion
+  (plus a run-level report for a tape-floor `:fail` / run-level
+  `:cannot-run` / vacuous-green `:pass`), and returns the unified
+  run-result. On CLJS — where the run is async and the caller cannot block
+  — `is` returns the run promise; chain `then` (or use `cljs.test`'s async
+  `(async done …)` form) and call `(story/report-result! result)` when it
+  resolves. `report-result!` is the pure-report seam both runtimes share.
+
+  A `target` that is ALREADY a unified run-result map (a `:status`-bearing
+  map) is reported directly — the sync path for tests that ran the variant
+  themselves (e.g. via `deref-blocking`)."
+  ([target] (is target nil))
+  ([target opts]
+   (cond
+     ;; Already a unified result — report it synchronously.
+     (and (map? target) (contains? target :status) (contains? target :assertions))
+     (do (emit-reports! (:variant/id target) (result/result->reports target))
+         target)
+
+     :else
+     (let [p (run target opts)]
+       #?(:clj
+          (let [result (async/deref-blocking p 30000)]
+            (emit-reports! target (result/result->reports result))
+            result)
+          :cljs
+          ;; CLJS run is async; report when it resolves and hand the
+          ;; promise back so a `(cljs.test/async done …)` test can await it.
+          (async/then p (fn [result]
+                          (emit-reports! target (result/result->reports result))
+                          result)))))))
+
+(defn report-result!
+  "Per spec/017 §Public execution API — fire the per-assertion clojure.test
+  / cljs.test reports for an ALREADY-RESOLVED unified `result`. The pure-
+  report seam `story/is` uses; call it directly in a CLJS
+  `(cljs.test/async done …)` test once the `story/run` promise resolves.
+  Returns the result."
+  [result]
+  (emit-reports! (:variant/id result) (result/result->reports result))
+  result)
 
 (defn execute-play!
   "Per IMPL-SPEC §5.4 phase 4 — run the play sequence against a variant

--- a/tools/story/src/re_frame/story/assertions.cljc
+++ b/tools/story/src/re_frame/story/assertions.cljc
@@ -55,7 +55,8 @@
     `:passed? true` (used by Stage 5's `run-variant` test entry, and by
     consumer tests via the public `assertions-passing?`).
   - `canonical-assertion-ids` — the set of registered event ids."
-  (:require [re-frame.core               :as rf]
+  (:require [clojure.string              :as str]
+            [re-frame.core               :as rf]
             [re-frame.elision            :as elision]
             [re-frame.interop            :as interop]
             [re-frame.subs               :as subs]
@@ -310,22 +311,76 @@
                       " at " (pr-str path)
                       " but got "  (pr-str actual)))}))
 
+(defn- resolve-sym-pred
+  "Resolve a predicate symbol to a callable fn. JVM uses
+  `requiring-resolve`; CLJS resolves via a best-effort `goog.global` walk
+  on munged dotted names (fragile under advanced compilation — the fn-
+  direct authoring path is advanced-safe). Returns nil on miss. Mirrors
+  `re-frame.story.play.runner-events/resolve-predicate`; kept here so the
+  `[:fn sym]` schema fold (rf2-5x1wt.18 `:assert-db :pred` form) resolves
+  at validation time without a require into the impure runner-events ns."
+  [sym]
+  (when sym
+    (try
+      #?(:clj
+         (when-let [v (requiring-resolve (symbol sym))]
+           (when (var? v) @v))
+         :cljs
+         (let [ns-part (namespace sym) name-part (name sym)]
+           (when (and ns-part name-part)
+             (let [parts (-> (str ns-part "." name-part)
+                             (str/replace #"-" "_")
+                             (str/split #"\."))]
+               (loop [obj js/window ks parts]
+                 (cond
+                   (nil? obj)  nil
+                   (empty? ks) (when (fn? obj) obj)
+                   :else       (recur (aget obj (first ks)) (rest ks))))))))
+      (catch #?(:clj Throwable :cljs :default) _ nil))))
+
+(defn- resolve-fn-schema
+  "Rewrite a `[:fn sym]` schema (the rf2-5x1wt.18 `:assert-db :pred` fold's
+  symbol form) into `[:fn resolved-fn]` so Malli can validate it without
+  sci (`[:fn 'sym]` needs sci — unavailable). A `[:fn fn]` (the fn-direct
+  fold) and every non-`:fn` schema pass through unchanged. Pure-ish — the
+  symbol resolution is the only runtime read. Returns the (possibly
+  resolved) schema, or `::unresolved-pred` when the symbol could not be
+  resolved (so `malli-validate` can report a useful failure rather than
+  letting Malli throw an opaque sci error)."
+  [schema]
+  (if (and (vector? schema) (= :fn (first schema)) (symbol? (second schema)))
+    (if-let [f (resolve-sym-pred (second schema))]
+      [:fn f]
+      ::unresolved-pred)
+    schema))
+
 (defn- malli-validate
   "Best-effort Malli validation. Returns `[passed? explanation]`. Malli
   is a Story dep (per tools/story/deps.edn) so the require resolves on
   both runtimes; production `:advanced` builds with Story disabled DCE
-  the entire assertion vocabulary anyway."
+  the entire assertion vocabulary anyway.
+
+  rf2-5x1wt.19 — a `[:fn sym]` schema (the `:assert-db :pred` symbol fold,
+  §B5.9) is resolved to `[:fn resolved-fn]` first (`resolve-fn-schema`),
+  because Malli's `[:fn 'sym]` form needs sci (unavailable). An
+  unresolvable symbol reports a readable failure rather than an opaque
+  sci error."
   [schema value]
-  (try
-    (let [ok? (boolean (malli/validate schema value))
-          ex  (when-not ok?
-                (try (malli/explain schema value)
-                     (catch #?(:clj Throwable :cljs :default) _ nil)))]
-      [ok? (when ex (pr-str ex))])
-    (catch #?(:clj Throwable :cljs :default) e
-      [false (str "malli validation threw: "
-                  #?(:clj (.getMessage ^Throwable e)
-                     :cljs (str e)))])))
+  (let [schema (resolve-fn-schema schema)]
+    (if (= ::unresolved-pred schema)
+      [false (str "could not resolve :pred symbol in schema "
+                  "(symbol resolution is fragile under advanced CLJS; "
+                  "pass the predicate as a fn directly to avoid this)")]
+      (try
+        (let [ok? (boolean (malli/validate schema value))
+              ex  (when-not ok?
+                    (try (malli/explain schema value)
+                         (catch #?(:clj Throwable :cljs :default) _ nil)))]
+          [ok? (when ex (pr-str ex))])
+        (catch #?(:clj Throwable :cljs :default) e
+          [false (str "malli validation threw: "
+                      #?(:clj (.getMessage ^Throwable e)
+                         :cljs (str e)))])))))
 
 (defn- evaluate-path-matches
   [frame-id db [path schema]]

--- a/tools/story/src/re_frame/story/plan.cljc
+++ b/tools/story/src/re_frame/story/plan.cljc
@@ -1023,6 +1023,29 @@
                          (str "re-frame2-story: " opt-key " must be a fn or a map")
                          {opt-key lookup})))
 
+(defn expand-checks
+  "Expand a plan's `:expect :checks` ids into the
+  `{check-id [assertion-atom …]}` map the unified run-result groups its
+  check records by (rf2-5x1wt.19, spec/017 §Total resolution order step 8
+  — \"expand checks into grouped assertions\"; §Checks — a failed check
+  shows BOTH the check id AND the underlying records). Pure data → data.
+
+  `check-ids` is the plan's resolved `[:expect :checks]` vector (check
+  identity preserved); `check-lookup` is a 1-arg fn `(check-id) →
+  check-body` OR a `{check-id → check-body}` map resolving each check's
+  registration body (its `:assertions` slot is the assertion atoms the
+  check packs). Defaults to the Story side-table `:check` kind. An
+  unregistered check id maps to an empty atom vector (it groups nothing —
+  the run-level aggregation still sees any ungrouped records), so a missing
+  check never throws at result-assembly time."
+  ([check-ids] (expand-checks check-ids nil))
+  ([check-ids check-lookup]
+   (let [lookup (coerce-kind-lookup :check-lookup check-lookup default-check-lookup)]
+     (into {}
+           (map (fn [cid]
+                  [cid (vec (:assertions (lookup cid)))]))
+           (or check-ids [])))))
+
 (defn compile-body
   "Compile a raw variant `body` (the child) registered under `id` into a
   normalized plan. `lookup` is a 1-arg fn returning raw parent bodies.

--- a/tools/story/src/re_frame/story/play.cljc
+++ b/tools/story/src/re_frame/story/play.cljc
@@ -377,11 +377,16 @@
   recognises, in order, so the step-debugger walks the same sequence the
   auto-run path executes.
 
-  Pure data → data; works on JVM + CLJS."
+  Pure data → data; works on JVM + CLJS.
+
+  rf2-5x1wt.19 — the script is FOLDED (`assertions/fold-script`) so the
+  stepper walks the SAME canonical `[:assert …]` checkpoints the auto-run
+  path drives: a shipping `:assert-db` / `:assert-dom` step is rewritten to
+  the one assertion atom before the stepper executes it."
   [variant-id]
   (let [body (registrar/handler-meta :variant variant-id)
         spec (runner/parse-spec (:play-script body))]
-    (vec (:script spec))))
+    (assertions/fold-script (vec (:script spec)))))
 
 (defn play-stepper-active?
   [frame-id]

--- a/tools/story/src/re_frame/story/play/ci_runner.cljc
+++ b/tools/story/src/re_frame/story/play/ci_runner.cljc
@@ -177,10 +177,12 @@
 ;; ---- terminal-state helpers ---------------------------------------------
 
 (defn terminal?
-  "True iff `state` represents a run that has reached `:pass` or
-  `:fail`. Pure data → data."
+  "True iff `state` represents a run that has reached a terminal verdict —
+  `:pass` / `:fail` / `:cannot-run` (rf2-5x1wt.19 — `:cannot-run` is the
+  unified distinct THIRD status, spec/017 §`:cannot-run`). Pure data →
+  data."
   [state]
-  (boolean (#{:pass :fail} (:status state))))
+  (boolean (#{:pass :fail :cannot-run} (:status state))))
 
 (defn project-state
   "Project a runner state map into the small shape the CI runner

--- a/tools/story/src/re_frame/story/play/runner.cljc
+++ b/tools/story/src/re_frame/story/play/runner.cljc
@@ -417,10 +417,11 @@
 
 ;; ---- run-state state machine ---------------------------------------------
 
-(def ^:const status-idle    :idle)
-(def ^:const status-running :running)
-(def ^:const status-pass    :pass)
-(def ^:const status-fail    :fail)
+(def ^:const status-idle       :idle)
+(def ^:const status-running    :running)
+(def ^:const status-pass       :pass)
+(def ^:const status-fail       :fail)
+(def ^:const status-cannot-run :cannot-run)
 
 (defn initial-state
   "Build the initial state map for a run. Pure data → data.
@@ -474,18 +475,42 @@
              (some? (:passed? result)))
         (update :failures inc))))
 
-(defn finish
-  "Transition `state` to the terminal `:pass` / `:fail` status.
+(defn- cannot-run-step?
+  "True iff a step-result is a `:cannot-run` refusal — a capability /
+  boundary refusal (`:cannot-run?`) or a no-DOM skip (`:skipped?`). These
+  are the distinct THIRD status (spec/017 §`:cannot-run`): the step could
+  not be attempted, not a genuine fail."
+  [r]
+  (boolean (or (:cannot-run? r) (:skipped? r))))
 
-  - If any step recorded an exception or any assertion failed → `:fail`.
+(defn finish
+  "Transition `state` to the terminal `:pass` / `:fail` / `:cannot-run`
+  status (rf2-5x1wt.19 — `:cannot-run` is the unified distinct THIRD
+  status, spec/017 §`:cannot-run`).
+
+  - A genuine failure (an exception, or a failing assertion that is NOT a
+    `:cannot-run` refusal) → `:fail`.
+  - Else, when the ONLY non-pass step-results are `:cannot-run` refusals
+    (a capability / boundary refusal or a no-DOM skip) → `:cannot-run`.
   - Otherwise → `:pass`.
 
-  Pure data → data."
+  This mirrors the variant-level aggregation rule
+  (`requirements/aggregate-status`): a run whose only unmet expectations
+  are refusals is itself `:cannot-run`, never a silent pass. Pure data →
+  data."
   [state now-ms]
-  (let [failed? (or (pos? (:failures state 0))
-                    (some #(some? (:exception %)) (:results state)))]
+  (let [results       (:results state)
+        exception?    (some #(some? (:exception %)) results)
+        real-failures (filter (fn [r] (and (false? (:passed? r))
+                                            (not (cannot-run-step? r))))
+                              results)
+        refusals      (filter cannot-run-step? results)
+        status        (cond
+                        (or exception? (seq real-failures)) status-fail
+                        (seq refusals)                      status-cannot-run
+                        :else                               status-pass)]
     (assoc state
-           :status      (if failed? status-fail status-pass)
+           :status      status
            :finished-ms now-ms)))
 
 (defn done?
@@ -504,10 +529,11 @@
   the status chip and the trace banner."
   [{:keys [status step-idx total]}]
   (case status
-    :idle    "IDLE"
-    :running (str "RUNNING (step " (inc step-idx) "/" total ")")
-    :pass    (str "PASS (" total " steps)")
-    :fail    (str "FAIL (" step-idx "/" total " steps)")
+    :idle       "IDLE"
+    :running    (str "RUNNING (step " (inc step-idx) "/" total ")")
+    :pass       (str "PASS (" total " steps)")
+    :fail       (str "FAIL (" step-idx "/" total " steps)")
+    :cannot-run (str "CANNOT-RUN (" total " steps)")
     (str status)))
 
 (defn assertion?

--- a/tools/story/src/re_frame/story/play/runner_events.cljc
+++ b/tools/story/src/re_frame/story/play/runner_events.cljc
@@ -146,9 +146,36 @@
     (registrar/handler-meta :variant variant-id)
     (catch #?(:clj Throwable :cljs :default) _ nil)))
 
+;; ---- folded-plan consumption (rf2-5x1wt.19) ------------------------------
+;;
+;; The runtime CONSUMES the `.18`-folded plan: every play's script is folded
+;; through `assertions/fold-script` at resolution time, so a shipping
+;; `:assert-db` / `:assert-dom` step is rewritten to the canonical
+;; `[:assert assertion-atom]` checkpoint BEFORE the run loop drives it
+;; (spec/017 §Assertions — one atom, two positions; NewTestStory rf2-5x1wt.19
+;; §B5.9). The `.18` worker deferred runtime consumption to this bead; this
+;; is where it lands. After folding, `exec-step!` only ever sees the ONE
+;; assertion atom in its `[:assert …]` checkpoint position — there is no
+;; longer a synthetic `:rf.assert/db` / `:rf.assert/dom` rail (a folded
+;; `:assert-db` dispatches the real `:rf.assert/path-equals` handler; a
+;; folded `:assert-dom` routes through the DOM executor recording a
+;; canonical `:rf.assert/dom-*` record). One assertion-record vocabulary,
+;; not two.
+
+(defn- fold-spec
+  "Fold a parsed play spec's `:script` through `assertions/fold-script` so
+  shipping `:assert-db` / `:assert-dom` steps become canonical
+  `[:assert …]` checkpoints (rf2-5x1wt.19). Pure data → data; preserves
+  `:auto-run?` / `:name`."
+  [spec]
+  (cond-> spec
+    (contains? spec :script) (update :script assertions/fold-script)))
+
 (defn variant-play-script
-  "Resolve the `:play-script` body on `variant-id` and parse it. Returns
-  the normalised spec map per `runner/parse-spec`. Variants without
+  "Resolve the `:play-script` body on `variant-id`, parse it, and FOLD its
+  script (rf2-5x1wt.19). Returns the normalised spec map per
+  `runner/parse-spec` with every shipping `:assert-db` / `:assert-dom` step
+  rewritten to the canonical `[:assert …]` checkpoint. Variants without
   `:play-script` return `{:script [] :auto-run? true}`.
 
   Note (rf2-tl7zk): variants declaring `:plays` resolve to the FIRST
@@ -158,14 +185,15 @@
   [variant-id]
   (let [body  (handler-meta variant-id)
         plays (runner/variant-body->plays body)]
-    (cond
-      ;; Multi-play (:plays slot) — default to the first play.
-      (and (seq plays) (contains? body :plays))
-      (first plays)
+    (fold-spec
+      (cond
+        ;; Multi-play (:plays slot) — default to the first play.
+        (and (seq plays) (contains? body :plays))
+        (first plays)
 
-      ;; Single-script (:play-script slot) — legacy path.
-      :else
-      (runner/parse-spec (when body (:play-script body))))))
+        ;; Single-script (:play-script slot) — legacy path.
+        :else
+        (runner/parse-spec (when body (:play-script body)))))))
 
 ;; ---- multi-play warning (one-shot) ---------------------------------------
 
@@ -208,13 +236,17 @@
                (contains? body :play-script)
                (contains? body :plays))
       (warn-both-slots-once! variant-id))
-    (runner/variant-body->plays body)))
+    ;; rf2-5x1wt.19 — FOLD every resolved play's script so the runtime
+    ;; consumes the `.18`-folded plan: `:assert-db` / `:assert-dom` steps
+    ;; become canonical `[:assert …]` checkpoints before the run loop.
+    (mapv fold-spec (runner/variant-body->plays body))))
 
 (defn resolve-play
-  "Resolve a `(variant-id, play-key)` pair to the parsed play spec, or
-  nil. `play-key` may be nil — meaning 'the default play' (first
+  "Resolve a `(variant-id, play-key)` pair to the parsed, FOLDED play spec,
+  or nil. `play-key` may be nil — meaning 'the default play' (first
   entry for multi-play, the single script for `:play-script`).
-  rf2-tl7zk multi-play."
+  rf2-tl7zk multi-play. The script is folded (rf2-5x1wt.19) via
+  `variant-plays`."
   [variant-id play-key]
   (let [plays (variant-plays variant-id)]
     (if (nil? play-key)
@@ -273,7 +305,6 @@
 ;; ---- step executors ------------------------------------------------------
 
 (declare read-frame-db)
-(declare record-assertion-slot!)
 
 (defn- assertion-count
   "Count of records currently in the frame's `:rf.story/assertions`. Tolerant."
@@ -410,11 +441,13 @@
   compilation — the closure compiler mangles author namespace names,
   so the munged-dotted-name walk won't find them. The advanced-safe
   authoring path is to pass the predicate as a FN DIRECTLY in the
-  `:assert-db [path] :pred <fn>` step; the runner short-circuits the
-  resolver in that case (see `exec-assert-db!`).
+  `:wait-until [:db path :pred <fn>]` predicate (or the `:assert-db …
+  :pred <fn>` form, which folds to `:rf.assert/path-matches [:fn fn]`);
+  the resolver is only reached for the symbol escape-hatch.
 
   rf2-inbad: this fn remains for the symbol-form escape hatch (JVM
-  tests + :dev CLJS) but is NOT the primary authoring path."
+  tests + :dev CLJS) — used by `[:wait-until [:db … :pred sym]]` — but is
+  NOT the primary authoring path."
   [sym]
   (when sym
     (try
@@ -447,61 +480,61 @@
     (fn? ref)     "<fn>"
     :else         (pr-str ref)))
 
-(defn- exec-assert-db!
-  [frame-id idx step]
-  (let [{:keys [path mode expected pred-ref pred-fn?]} (runner/step-assert-db step)
-        db (read-frame-db frame-id)]
-    (case mode
-      :equals
-      (let [actual (get-in db path)]
-        (if (= expected actual)
-          (runner/step-pass idx step)
-          (runner/step-fail idx step
-                            {:expected expected
-                             :actual   actual
-                             :message  (str "assert-db " (pr-str path)
-                                            " — expected " (pr-str expected)
-                                            ", got " (pr-str actual))})))
+;; ---- DOM-family assertion atom executor (rf2-5x1wt.19) -------------------
+;;
+;; The DOM family (`:rf.assert/dom-visible` / `:rf.assert/dom-hidden` /
+;; `:rf.assert/dom-text`) is the fold target for the shipping `:assert-dom`
+;; step (`.18`). It has no reg-event-fx handler yet (the DOM runner that
+;; PROVES it lands later — the `:dom` capability is wired now via
+;; `requirements`), so an `[:assert [:rf.assert/dom-* …]]` checkpoint is
+;; EVALUATED directly through the DOM executor (`dom/assert-visible` /
+;; `dom/assert-text`) and records a CANONICAL `:rf.assert/dom-*` record on
+;; the frame's `:rf.story/assertions` slot. There is no synthetic
+;; `:rf.assert/dom` id — the canonical folded id is the one recorded.
 
-      :pred
-      ;; rf2-inbad: prefer the fn-direct path (advanced-CLJS-safe). Fall
-      ;; back to symbol resolution for the JVM / :dev CLJS escape hatch.
-      (let [pred-fn (if pred-fn? pred-ref (resolve-predicate pred-ref))
-            label   (pred-label pred-ref)
-            actual  (get-in db path)]
-        (cond
-          (nil? pred-fn)
-          (runner/step-fail idx step
-                            {:message (str "assert-db :pred — could not resolve "
-                                           label
-                                           " (symbol resolution is fragile under"
-                                           " advanced CLJS; pass the predicate as a"
-                                           " fn directly to avoid this)")})
+(def ^:private dom-atom->mode
+  "Map a DOM-family assertion id to the `dom/assert-visible` mode it
+  evaluates. `:rf.assert/dom-text` is handled separately (it calls
+  `dom/assert-text`)."
+  {:rf.assert/dom-visible :visible
+   :rf.assert/dom-hidden  :hidden})
 
-          :else
-          (try
-            (if (pred-fn actual)
-              (runner/step-pass idx step)
-              (runner/step-fail idx step
-                                {:expected (str "predicate " label " returns truthy")
-                                 :actual   actual
-                                 :message  (str "assert-db " (pr-str path)
-                                                " — predicate " label " returned false")}))
-            (catch #?(:clj Throwable :cljs :default) e
-              (runner/step-fail idx step
-                                {:message (str "assert-db :pred " label " threw — "
-                                               #?(:clj (.getMessage ^Throwable e)
-                                                  :cljs (str e)))}))))))))
-
-(defn- exec-assert-dom!
-  [_frame-id idx step]
-  (let [{:keys [selector mode text]} (runner/step-assert-dom step)
-        result (if (= :text mode)
-                 (dom/assert-text selector text)
-                 (dom/assert-visible selector mode))]
-    (if (:passed? result)
-      (runner/step-pass idx step)
-      (runner/step-fail idx step result))))
+(defn- exec-assert-dom-atom!
+  "Evaluate a folded DOM-family assertion atom `[:rf.assert/dom-* selector
+  & args]` at this checkpoint (rf2-5x1wt.19). Drives the DOM executor,
+  records the CANONICAL `:rf.assert/dom-*` record on the frame slot (so the
+  unified result's `:assertions` carries the real folded id, not a
+  synthetic one), and returns the runner step-result. A no-DOM headless
+  context records a `{:skipped? true}` step — `:cannot-run` at assertion
+  granularity (the slot mirror keeps it OUT of the recorded outcomes so it
+  is not a vacuous pass), never a silent green."
+  [frame-id idx step atom-v]
+  (let [aid      (first atom-v)
+        selector (nth atom-v 1 nil)
+        result   (if (= :rf.assert/dom-text aid)
+                   (dom/assert-text selector (nth atom-v 2 nil))
+                   (dom/assert-visible selector (get dom-atom->mode aid :visible)))]
+    ;; Record the canonical DOM-family assertion record on the slot (unless
+    ;; the step was a no-DOM skip — a skip proved nothing, so it must not
+    ;; read as a vacuous pass).
+    (when-not (:skipped? result)
+      (assertions/record!
+        frame-id
+        (cond-> {:assertion    aid
+                 :passed?      (boolean (:passed? result))
+                 :payload      (vec (rest atom-v))
+                 :source-coord (:source (registrar/handler-meta :variant frame-id))}
+          (contains? result :expected) (assoc :expected (:expected result))
+          (contains? result :actual)   (assoc :actual   (:actual result))
+          (:message result)            (assoc :reason   (:message result)))))
+    (cond
+      (:skipped? result) (runner/step-fail idx step
+                                           {:skipped? true
+                                            :message  (or (:message result)
+                                                          (str "no DOM — cannot prove "
+                                                               (pr-str atom-v)))})
+      (:passed? result)  (runner/step-pass idx step)
+      :else              (runner/step-fail idx step result))))
 
 (defn- exec-click!
   [_frame-id idx step]
@@ -556,53 +589,62 @@
       (runner/step-fail idx step
                         {:message (str "focus failed — no node matched " (pr-str selector))}))))
 
+(declare exec-assert-dom-atom!)
+
 (defn- exec-assert!
   "Execute an `[:assert [:rf.assert/id & args]]` in-script checkpoint
   (rf2-5x1wt.17). Evaluates the wrapped assertion atom at THIS point in
   the script (spec/017 §Inline script assertions vs terminal
-  assertions). In headless this dispatches the `:rf.assert/*` event
-  through `settled-boundary` — the runner's headless implementation rail
-  (`re-frame.story.assertions`) — then reads the freshly recorded
-  outcome from the frame's `:rf.story/assertions` slot and projects it
-  into a runner step-pass / step-fail. So the checkpoint records an
-  assertion AT THIS POINT, and a failing checkpoint flips the play's
-  terminal status to `:fail`.
+  assertions). This is the SINGLE in-script assertion executor — after
+  the `.18` fold the runtime consumes (rf2-5x1wt.19), a shipping
+  `:assert-db` / `:assert-dom` step has already been rewritten to this
+  `[:assert …]` checkpoint, so there is no longer a parallel `:assert-db`
+  / `:assert-dom` executor minting synthetic `:rf.assert/db` /
+  `:rf.assert/dom` records.
 
-  The wrapped atom is dispatched as the event vector, so the standard
-  `:rf.assert/*` reg-event-fx handler records the `:passed?` record on
-  the frame's app-db. We bridge that record back into the runner step
-  stream (the SAME bridge `dispatch-step-result` uses for the
-  `:dispatch-sync [:rf.assert/*]` rail), so the in-script `[:assert …]`
-  and a terminal assertion produce the same assertion-record shape."
+  Two atom families:
+
+  - The DOM family (`:rf.assert/dom-visible` / `:rf.assert/dom-hidden` /
+    `:rf.assert/dom-text`) has no reg-event-fx handler yet (the DOM runner
+    that proves it lands later); it is EVALUATED directly through the DOM
+    executor (`exec-assert-dom-atom!`), recording a canonical
+    `:rf.assert/dom-*` record on the slot.
+  - Every other `:rf.assert/*` atom dispatches the event through
+    `settled-boundary` — the standard reg-event-fx handler records the
+    `:passed?` record on the frame's `:rf.story/assertions` slot — and we
+    bridge that record back into the runner step stream so a failing
+    checkpoint flips the play's terminal status to `:fail`."
   [frame-id idx step]
-  (let [atom-v   (runner/step-assertion step)
-        prev     (assertion-count frame-id)
-        required (boundary/step-required-boundary step)
-        hooks    (current-flush-hooks frame-id)
-        settle   (try
-                   (boundary/dispatch-and-settle! frame-id atom-v hooks required step)
-                   (catch #?(:clj Throwable :cljs :default) e
-                     {:status :error
-                      :error  #?(:clj (.getMessage ^Throwable e) :cljs (str e))
-                      :step   step}))]
-    (play/drain-pending-exceptions! frame-id :phase-4-play)
-    (or (boundary-result->step idx step settle)
-        ;; The wrapped :rf.assert/* handler recorded its outcome on the
-        ;; frame's :rf.story/assertions slot. Read what landed since the
-        ;; pre-dispatch count and surface it as the checkpoint's result.
-        (let [all   (vec (:rf.story/assertions (read-frame-db frame-id)))
-              new   (subvec all (min prev (count all)))
-              rec   (last new)]
-          (cond
-            (nil? rec)            (runner/step-skip idx step)
-            (false? (:passed? rec))
-            (runner/step-fail idx step
-                              {:expected (:expected rec)
-                               :actual   (:actual rec)
-                               :message  (or (:reason rec)
-                                             (str (:assertion rec) " "
-                                                  (pr-str (:payload rec)) " failed"))})
-            :else                 (runner/step-pass idx step))))))
+  (let [atom-v (runner/step-assertion step)]
+    (if (contains? assertions/dom-assertion-ids (first atom-v))
+      (exec-assert-dom-atom! frame-id idx step atom-v)
+      (let [prev     (assertion-count frame-id)
+            required (boundary/step-required-boundary step)
+            hooks    (current-flush-hooks frame-id)
+            settle   (try
+                       (boundary/dispatch-and-settle! frame-id atom-v hooks required step)
+                       (catch #?(:clj Throwable :cljs :default) e
+                         {:status :error
+                          :error  #?(:clj (.getMessage ^Throwable e) :cljs (str e))
+                          :step   step}))]
+        (play/drain-pending-exceptions! frame-id :phase-4-play)
+        (or (boundary-result->step idx step settle)
+            ;; The wrapped :rf.assert/* handler recorded its outcome on the
+            ;; frame's :rf.story/assertions slot. Read what landed since the
+            ;; pre-dispatch count and surface it as the checkpoint's result.
+            (let [all   (vec (:rf.story/assertions (read-frame-db frame-id)))
+                  new   (subvec all (min prev (count all)))
+                  rec   (last new)]
+              (cond
+                (nil? rec)            (runner/step-skip idx step)
+                (false? (:passed? rec))
+                (runner/step-fail idx step
+                                  {:expected (:expected rec)
+                                   :actual   (:actual rec)
+                                   :message  (or (:reason rec)
+                                                 (str (:assertion rec) " "
+                                                      (pr-str (:payload rec)) " failed"))})
+                :else                 (runner/step-pass idx step))))))))
 
 (defn- queue-empty?
   "True iff `frame-id`'s event queue has drained (rf2-5x1wt.17). Under a
@@ -664,20 +706,33 @@
   Pure-shape return — the run-state mutation is the caller's job.
 
   `:wait` is special-cased OUT of this fn — it requires an async
-  yield (`setTimeout` / `Thread/sleep`) the driver schedules around."
+  yield (`setTimeout` / `Thread/sleep`) the driver schedules around.
+
+  rf2-5x1wt.19 — the runtime consumes the `.18`-folded plan: every script
+  is folded at resolution time (`runner-events/variant-plays` /
+  `play/variant-play-steps`), so a shipping `:assert-db` / `:assert-dom`
+  step has already become the canonical `[:assert assertion-atom]`
+  checkpoint by the time it reaches here. A raw `:assert-db` / `:assert-dom`
+  (a hand-built step that bypassed resolution) is folded inline as a
+  belt-and-braces guard so there is ONE in-script assertion executor and
+  ONE assertion-record vocabulary — never a synthetic `:rf.assert/db` /
+  `:rf.assert/dom` rail."
   [frame-id idx step]
-  (case (runner/step-type step)
-    :dispatch       (exec-dispatch!      frame-id idx step)
-    :dispatch-sync  (exec-dispatch-sync! frame-id idx step)
-    :assert         (exec-assert!        frame-id idx step)
-    :assert-db      (exec-assert-db!     frame-id idx step)
-    :assert-dom     (exec-assert-dom!    frame-id idx step)
-    :wait-until     (exec-wait-until!    frame-id idx step)
-    :click          (exec-click!         frame-id idx step)
-    :type           (exec-type!          frame-id idx step)
-    :focus          (exec-focus!         frame-id idx step)
-    :wait           (runner/step-skip idx step)   ; driver handles the actual sleep
-    (runner/unknown-step idx step)))
+  (let [stype (runner/step-type step)]
+    (case stype
+      :dispatch       (exec-dispatch!      frame-id idx step)
+      :dispatch-sync  (exec-dispatch-sync! frame-id idx step)
+      :assert         (exec-assert!        frame-id idx step)
+      ;; A raw shipping assertion step that escaped folding — fold it inline
+      ;; to the canonical checkpoint and run the ONE assert executor.
+      (:assert-db
+       :assert-dom)   (exec-assert! frame-id idx (assertions/fold-assert-step step))
+      :wait-until     (exec-wait-until!    frame-id idx step)
+      :click          (exec-click!         frame-id idx step)
+      :type           (exec-type!          frame-id idx step)
+      :focus          (exec-focus!         frame-id idx step)
+      :wait           (runner/step-skip idx step)   ; driver handles the actual sleep
+      (runner/unknown-step idx step))))
 
 ;; ---- single-step driver (rf2-ee38b.3 — step-debugger re-base) ------------
 ;;
@@ -709,7 +764,9 @@
                    (runner/step-exception idx step
                                           #?(:clj  (.getMessage ^Throwable e)
                                              :cljs (str e)))))]
-    (record-assertion-slot! frame-id step result)
+    ;; rf2-5x1wt.19 — `exec-step!` (via `exec-assert!`) already wrote the
+    ;; canonical assertion record onto `:rf.story/assertions`; no synthetic
+    ;; slot mirror here.
     (emit-trace! frame-id nil idx step result)
     result))
 
@@ -725,87 +782,33 @@
                (f)
                nil)))
 
-;; ---- assertion-slot bridge (rf2-ee38b.3 / rf2-uhq5j extension) ----------
+;; ---- assertion-slot recording (rf2-5x1wt.19) ----------------------------
 ;;
-;; Rich-DSL `:assert-db` / `:assert-dom` step outcomes used to land ONLY
-;; in the runner's `run-state` atom. The `:rf.story/assertions` app-db
-;; slot — read by `run-variant`'s result map, `assertions-passing?`, the
-;; test-mode pane, the inline assertion strip, and the Xray assertions
-;; panel — never saw them, so a failing rich-DSL assertion read as a
-;; false GREEN through every slot consumer (only the toolbar chip + the
-;; CI/Playwright runner, which read `run-state` directly, observed it).
+;; ONE assertion-record vocabulary. After the runtime consumes the `.18`-
+;; folded plan (`variant-plays` / `variant-play-steps` fold every script),
+;; every in-script assertion arrives as the canonical `[:assert
+;; assertion-atom]` checkpoint, and `exec-assert!` is the SOLE recorder:
 ;;
-;; The `:rf.assert/*` events (which ride `:dispatch-sync` steps) DO write
-;; the slot via their reg-event-fx handlers, so the contract was silently
-;; style-dependent. We close the gap by mirroring every assertion-class
-;; step result into `:rf.story/assertions` — the same record shape the
-;; `:rf.assert/*` handlers + the runtime's exception projection use.
-
-(def ^:const assert-db-id
-  "Synthetic assertion id stamped on `:rf.story/assertions` records for
-  rich-DSL `:assert-db` steps. In the `:rf.assert/*` reserved namespace
-  so `predicates/assertion-id?` and the pane's status logic treat it
-  uniformly with the canonical seven."
-  :rf.assert/db)
-
-(def ^:const assert-dom-id
-  "Synthetic assertion id for rich-DSL `:assert-dom` steps."
-  :rf.assert/dom)
-
-(defn- assertion-step-record
-  "Project an assertion-class step-result (`:assert-db` / `:assert-dom`)
-  into the `:rf.story/assertions` record shape. Returns nil for non-
-  assertion-class steps (`:dispatch` / `:wait` / `:click` / ...), whose
-  pass/fail is already represented by the `:rf.assert/*` records their
-  dispatched events recorded.
-
-  Returns nil for the `[:assert …]` in-script checkpoint too
-  (rf2-5x1wt.17): that step DISPATCHES its wrapped `:rf.assert/*` atom,
-  whose reg-event-fx handler ALREADY recorded a canonical assertion
-  record on the slot — mirroring the step result on top would double-
-  count. The checkpoint's slot record IS the wrapped atom's record.
-
-  A `:skipped?` DOM step (no-DOM JVM context) is NOT recorded as a
-  failure — the step couldn't run, so it contributes no assertion
-  outcome to the slot (matching the run-state's `:passed? false` +
-  `:skipped? true` shape, which `finish` already tolerates)."
-  [frame-id step result]
-  (let [stype (runner/step-type step)]
-    (when (contains? #{:assert-db :assert-dom} stype)
-      (let [aid (case stype
-                  :assert-db  assert-db-id
-                  :assert-dom assert-dom-id)]
-        (cond->
-          {:assertion    aid
-           :passed?      (boolean (:passed? result))
-           :payload      (vec (rest step))
-           :source-coord (:source (registrar/handler-meta :variant frame-id))}
-          (contains? result :expected) (assoc :expected (:expected result))
-          (contains? result :actual)   (assoc :actual   (:actual result))
-          (:message result)            (assoc :reason   (:message result))
-          (:skipped? result)           (assoc :skipped? true))))))
-
-(defn- record-assertion-slot!
-  "Mirror an assertion-class step result into the frame's
-  `:rf.story/assertions` slot so every slot consumer agrees with the
-  run-state. No-op for non-assertion steps and for skipped DOM steps
-  (which record no outcome)."
-  [frame-id step result]
-  (when-let [rec (assertion-step-record frame-id step result)]
-    ;; A skipped DOM step ran but produced no pass/fail — keep it out of
-    ;; the slot so it doesn't read as a vacuous pass (slot consumers treat
-    ;; `:passed? true` as a pass).
-    (when-not (:skipped? rec)
-      (assertions/record! frame-id rec)))
-  nil)
+;;   - a non-DOM `:rf.assert/*` atom dispatches its reg-event-fx handler,
+;;     which writes the canonical record onto `:rf.story/assertions`;
+;;   - a DOM-family atom is evaluated by `exec-assert-dom-atom!`, which
+;;     writes a canonical `:rf.assert/dom-*` record.
+;;
+;; There is no longer a synthetic `:rf.assert/db` / `:rf.assert/dom` slot-
+;; mirror bridge: the folded checkpoint's OWN record IS the slot record, so
+;; mirroring the step-result on top would double-count. `record-result!`
+;; therefore only updates the run-state + emits the trace event; the slot
+;; write already happened inside `exec-assert!`. This is the move that
+;; collapsed the documented "false GREEN" — run-state and the
+;; `:rf.story/assertions` slot now derive from the ONE canonical record.
 
 (defn- record-result!
-  "Append `result` to the run-state for `frame-id`, mirror assertion-
-  class outcomes into the `:rf.story/assertions` app-db slot, and emit
-  the trace event."
+  "Append `result` to the run-state for `frame-id` and emit the per-step
+  trace event. The `:rf.story/assertions` slot write already happened
+  inside `exec-assert!` (the canonical folded-atom record), so this no
+  longer mirrors a synthetic record on top (rf2-5x1wt.19)."
   [frame-id play-key name idx step result]
   (update-state! frame-id play-key runner/record-step-result result)
-  (record-assertion-slot! frame-id step result)
   (emit-trace! frame-id name idx step result)
   nil)
 

--- a/tools/story/src/re_frame/story/result.cljc
+++ b/tools/story/src/re_frame/story/result.cljc
@@ -1,0 +1,355 @@
+(ns re-frame.story.result
+  "The ONE unified run-result — the single shape every Story runner,
+  Test mode, CI, `clojure.test`, and MCP consume (NewTestStory
+  rf2-5x1wt.19, `tools/story/spec/017-Testing-Story.md` §Run result +
+  §Unified run result).
+
+  ## One result, one source of truth
+
+  Spec/017 §Run result: *all runners MUST return the same shape*, and the
+  evidential slots are *projections from one retained epoch tape*, not a
+  second capture path. Before this ns three result vocabularies coexisted:
+
+  - `runtime.cljc`'s `record-result-map` (`:lifecycle`, a flat
+    `:assertions` vector, no top-level `:status`);
+  - `runner.cljc`'s per-step `run-state` machine (`:pass` / `:fail` /
+    per-step `:results`, read directly by the toolbar chip + CI runner);
+  - `artifact.cljc`'s `replay-result` (the FIRST unified shape — top-level
+    `:status`, the `.4` tape projection, a `:run-artifact` back-link).
+
+  The documented \"false GREEN\" was exactly the disagreement between
+  run-state and the assertions slot. This ns folds the three onto ONE
+  shape, derived — wherever the tape carries the evidence — from `.4`'s
+  `re-frame.story.play.evidence/project-evidence` (the single tape
+  projection; this ns does NOT add a parallel accumulator). The assertion
+  outcomes that are NOT in the tape (the `:rf.assert/*` records the
+  handlers wrote to `:rf.story/assertions`) are the ONLY non-tape input:
+  this ns adapts that accumulator into the unified assertion records and
+  computes the verdict.
+
+  ## The three record shapes (spec/017 §Run result)
+
+  - RUN-RESULT — the top-level shape. `:status` ∈
+    `#{:pass :fail :cannot-run :error}` is the verdict; the evidential
+    slots (`:epoch-tape` / `:schema-violations` / `:warnings` / `:effects`
+    / `:sub-runs` / `:renders` / `:narrative`) are `.4` projections; the
+    judgement slots (`:assertions` / `:checks`) are folded from the
+    accumulator; `:app-db` / `:run-hash` / `:plan-hash` / `:runner` /
+    `:required-runner` / `:fidelity` / `:elapsed-ms` round out the shape.
+  - ASSERTION-RECORD — one evaluated assertion (`.18`'s atom shape, plus a
+    `:status`). The `:status` is derived from `:passed?` / `:skipped?` /
+    `:cannot-run?` so the run aggregation reads ONE field uniformly.
+  - CHECK-RECORD — a named check id grouping the assertion records its
+    assertions produced (spec/017 §Checks — a failed check shows BOTH the
+    check id and the underlying records).
+
+  ## Status — the aggregation rule, stated once
+
+  `aggregate-status` (in `re-frame.story.requirements`, reused here) is the
+  ONE rule: `:error` > `:fail` > `:cannot-run` > `:pass`, AND a run whose
+  tape shows unconsumed failure evidence cannot read `:pass` (the agreement
+  floor, `evidence/tape-shows-failure?`). A run with zero assertions whose
+  tape is clean is `:pass` (the spec/007 §Story-as-test duality — a variant
+  with no assertions is vacuously green).
+
+  ## Pure / JVM-testable
+
+  Every fn here is pure data → data: assertion records + projected evidence
+  + plan slots in, the unified result out. It requires NOTHING from
+  `re-frame.core` / the DOM, so the whole assembly runs under
+  `clojure -M:test`. The runner reads the tape + the accumulator and hands
+  the vectors here; the assembly never touches the runtime."
+  (:require [re-frame.story.play.evidence :as evidence]
+            [re-frame.story.requirements  :as requirements]))
+
+;; ===========================================================================
+;; STATUS — the four verdicts (spec/017 §Run result)
+;; ===========================================================================
+
+(def statuses
+  "The four run / assertion / check verdicts (spec/017 §Run result):
+
+  - `:pass`       — every expectation the runner could attempt held;
+  - `:fail`       — at least one expectation failed (or the tape shows
+                    unconsumed failure evidence);
+  - `:cannot-run` — the ONLY unmet expectations were ones the runner could
+                    not even attempt (the distinct THIRD status, §`:cannot-run`);
+  - `:error`      — a handler / fx / step threw."
+  #{:pass :fail :cannot-run :error})
+
+(defn record-status
+  "Derive the `:status` for ONE assertion record from its outcome fields.
+  Pure data → data. An explicit `:status` already on the record wins (the
+  record was minted by a status-aware path); otherwise:
+
+  - `:cannot-run?` true   → `:cannot-run` (the runner could not prove it);
+  - `:exception` / `:error` truthy → `:error`;
+  - `:passed?` true       → `:pass`;
+  - `:passed?` false      → `:fail`;
+  - `:passed?` nil        → `:pass` (a non-assertion / vacuous record does
+                            not fail the run — the spec/007 duality)."
+  [{:keys [status passed? cannot-run? skipped? exception error] :as _record}]
+  (cond
+    (contains? statuses status) status
+    cannot-run?                 :cannot-run
+    skipped?                    :cannot-run   ; §`:cannot-run` generalizes the shipping :skipped?
+    (or exception error)        :error
+    (true? passed?)             :pass
+    (false? passed?)            :fail
+    :else                       :pass))
+
+;; ===========================================================================
+;; ASSERTION RECORD — the `.18` atom shape + a unified `:status`
+;; ===========================================================================
+
+(defn assertion-record
+  "Normalize a raw assertion accumulator entry (the shape the
+  `:rf.assert/*` handlers wrote to `:rf.story/assertions`, plus the
+  runtime's exception projections) into the unified assertion record
+  (spec/017 §Run result — Assertion record). Pure data → data.
+
+  The accumulator entry already carries `:assertion` / `:payload` /
+  `:passed?` / `:expected` / `:actual` / `:reason` / `:dispatch-id` /
+  `:source-coord` / `:elapsed-ms` (from `re-frame.story.assertions`'
+  `assertion-record`); this stamps the derived `:status` so the run
+  aggregation reads ONE field, and renames `:source-coord` → `:source`
+  (the spec/017 slot name) while keeping `:source-coord` for back-compat
+  readers. A record that already carries a `:status` is left as-is.
+
+  This is the §B5.5 'adapt the existing assertion accumulator ONLY for
+  assertion outcomes that are not already in the tape' boundary: the
+  assertion verdict is the one slot the tape does NOT carry, so it is the
+  one slot this ns adapts rather than projects."
+  [raw]
+  (let [st (record-status raw)]
+    (cond-> (assoc raw :status st)
+      (and (contains? raw :source-coord)
+           (not (contains? raw :source))) (assoc :source (:source-coord raw)))))
+
+(defn assertion-records
+  "Normalize a raw assertion accumulator vector into unified assertion
+  records, in accumulator order. Pure data → data."
+  [raw-assertions]
+  (mapv assertion-record (or raw-assertions [])))
+
+;; ===========================================================================
+;; CHECK RECORD — group assertions under their originating check id
+;; ===========================================================================
+;;
+;; A check is a named, reusable assertion pack (spec/017 §Checks). A failed
+;; check result MUST show BOTH the check id AND the underlying assertion
+;; records. The plan carries the expanded check→assertion-atoms mapping;
+;; the run carries the evaluated records. `check-records` pairs them: each
+;; check id groups the records its assertion atoms produced (matched by the
+;; assertion atom's id + payload), and the check's `:status` aggregates its
+;; group via the ONE aggregation rule.
+
+(defn- atom-id
+  "The `:rf.assert/*` id at the head of an assertion atom, or nil."
+  [a]
+  (when (and (vector? a) (pos? (count a)))
+    (let [h (first a)] (when (keyword? h) h))))
+
+(defn- atom-payload
+  "The payload (args after the id) of an assertion atom."
+  [a]
+  (when (vector? a) (vec (rest a))))
+
+(defn- record-matches-atom?
+  "True iff assertion `record` was produced by assertion `atom-v` — same
+  `:rf.assert/*` id AND same payload. Pure data → data. The payload match
+  disambiguates two `:rf.assert/path-equals` against different paths within
+  one check."
+  [record atom-v]
+  (and (= (:assertion record) (atom-id atom-v))
+       (= (vec (:payload record)) (atom-payload atom-v))))
+
+(defn check-record
+  "Build ONE check record (spec/017 §Run result — Check record) for
+  `check-id` over its `assertion-atoms` (the atoms the plan expanded the
+  check into) against the run's evaluated `records`. Pure data → data.
+
+  The group is every evaluated record matching one of the check's atoms
+  (by id + payload); the check `:status` aggregates the group via the ONE
+  aggregation rule (`requirements/aggregate-status`). An atom with no
+  matching record (the assertion never ran) contributes nothing to the
+  group — the run-level aggregation still sees the ungrouped records, so a
+  check that did not run does not mask the run verdict.
+
+  Returns `{:check check-id :status … :assertions [record …]}`."
+  [check-id assertion-atoms records]
+  (let [group (into []
+                    (filter (fn [r]
+                              (some #(record-matches-atom? r %) assertion-atoms)))
+                    records)]
+    {:check      check-id
+     :status     (requirements/aggregate-status group nil)
+     :assertions group}))
+
+(defn check-records
+  "Build the run's check records from the plan's `check->atoms`
+  (`{check-id [assertion-atom …]}` — the expanded check assertions) and the
+  run's evaluated assertion `records`. Pure data → data. Empty when the
+  plan declares no checks. The checks are emitted in `check->atoms`
+  iteration order; pass an ordered map (or a vector of `[id atoms]` pairs)
+  to pin order."
+  [check->atoms records]
+  (into []
+        (map (fn [[check-id atoms]] (check-record check-id atoms records)))
+        (or check->atoms [])))
+
+;; ===========================================================================
+;; THE UNIFIED RUN RESULT  (spec/017 §Run result)
+;; ===========================================================================
+
+(defn run-result
+  "Assemble the ONE unified run-result (spec/017 §Run result) from a run's
+  evidence + accumulated assertions + plan slots. Pure data → data — the
+  single boundary from a settled run to the API-stable result, so Story
+  Test mode, CI, `clojure.test`, MCP, and the golden/diff tools cannot
+  disagree about what happened.
+
+  `parts` carries:
+
+  - `:epoch-tape`       — the retained `:rf/epoch-record` vector (the
+                          evidence source; `.4`'s `project-evidence` reads
+                          it). May be empty for a host without the epoch
+                          artefact — the evidential slots are then empty.
+  - `:assertions`       — the RAW assertion accumulator entries (the
+                          `:rf.story/assertions` slot). Normalized here into
+                          unified assertion records — the ONE non-tape
+                          input (§B5.5).
+  - `:script`           — the coerced script-step vector, for the two-level
+                          `:narrative` projection (`.4`).
+  - `:check->atoms`     — `{check-id [assertion-atom …]}`, the plan's
+                          expanded checks, grouped into `:checks`.
+  - `:consumed-selectors` — the schema-violation selectors the run's
+                          `:rf.assert/schema-error` expectations consumed
+                          (excused from the agreement floor, §Schema rule).
+                          Defaults to `#{}` (the strict floor).
+  - `:unmet`            — the per-requirement `:cannot-run` refusals for
+                          expectations the runner could not attempt
+                          (`requirements/unmet-assertions` /
+                          `unmet-steps`). Folded into the status + surfaced
+                          on `:cannot-run`.
+  - `:app-db`           — the final (post-run) app-db, redacted upstream.
+  - `:variant/id` / `:plan-hash` / `:run-hash` / `:runner` /
+    `:required-runner` / `:fidelity` / `:elapsed-ms` — passed through
+    verbatim when present (the API-stable identity / timing slots).
+
+  The verdict: `requirements/aggregate-status` over the assertion records +
+  the `:unmet` refusals gives the assertion-side status; the agreement
+  floor (`evidence/tape-shows-failure?`) escalates a `:pass` to `:fail`
+  when the tape carries unconsumed failure evidence — so a run NEVER reads
+  green while the tape is red, and the verdict is computed from the
+  PROJECTED evidence, not a sibling accumulator."
+  [{:keys [epoch-tape assertions script check->atoms consumed-selectors
+           unmet app-db]
+    :as   parts}]
+  (let [tape           (vec (or epoch-tape []))
+        evidence-slots (evidence/project-evidence tape {:script script})
+        records        (assertion-records assertions)
+        checks         (check-records check->atoms records)
+        consumed       (or consumed-selectors #{})
+        unmet          (vec (or unmet []))
+        base-status    (requirements/aggregate-status records unmet)
+        tape-red?      (evidence/tape-shows-failure? tape consumed)
+        ;; The agreement floor escalates ONLY a would-be pass — a real
+        ;; :fail / :error / :cannot-run already outranks it (the floor never
+        ;; downgrades a higher verdict).
+        status         (if (and (= :pass base-status) tape-red?)
+                         :fail
+                         base-status)
+        identity-slots (select-keys parts [:variant/id :plan-hash :run-hash
+                                            :runner :required-runner :fidelity
+                                            :elapsed-ms])]
+    (cond-> (merge {:status      status
+                    :assertions  records
+                    :checks      checks
+                    :app-db      app-db}
+                   evidence-slots
+                   identity-slots)
+      (seq unmet) (assoc :cannot-run unmet))))
+
+;; ===========================================================================
+;; clojure.test / cljs.test BRIDGE PROJECTION  (spec/017 §Unified run result)
+;; ===========================================================================
+;;
+;; `story/is` reports a run-result to clojure.test / cljs.test at
+;; per-assertion granularity. The PURE projection here turns a unified
+;; result into the vector of test reports `story/is` emits (one per
+;; assertion record, plus a run-level report for a tape-floor / cannot-run
+;; verdict that no single assertion carries). The impure `is`-emission lives
+;; in `re-frame.story` (it threads `clojure.test/do-report` / the cljs
+;; reader-conditional); this ns keeps the projection JVM-testable.
+
+(defn assertion->report
+  "Project ONE unified assertion record into the clojure.test report map
+  shape (`{:type :pass|:fail|:error :message … :expected … :actual …}`).
+  Pure data → data. A `:cannot-run` assertion reports `:fail` with a
+  refusal message (the runner could not prove it — that is a failed
+  expectation for test purposes, never a silent pass)."
+  [{:keys [assertion status payload expected actual reason] :as _record}]
+  (let [base-msg (str assertion " " (pr-str (or payload [])))]
+    (case status
+      :pass        {:type :pass :message base-msg}
+      :error       {:type :error :message (str base-msg " — " (or reason "errored"))
+                    :actual (or actual reason)}
+      :cannot-run  {:type :fail
+                    :message (str base-msg " — :cannot-run ("
+                                  (or reason "runner cannot prove this assertion") ")")
+                    :expected expected :actual :rf.story/cannot-run}
+      ;; :fail (and any unexpected status)
+      {:type :fail
+       :message (str base-msg (when reason (str " — " reason)))
+       :expected expected :actual actual})))
+
+(defn result->reports
+  "Project a unified `result` into the ordered vector of clojure.test
+  report maps `story/is` emits — one per assertion record (per-assertion
+  granularity, spec/017 §Public execution API), and a trailing run-level
+  report when the run verdict is NOT covered by an assertion (a
+  tape-floor-driven `:fail`, or a `:cannot-run` / `:error` carried only by
+  the run, not a single assertion). Pure data → data.
+
+  A `:pass` run with assertions emits only the per-assertion passes; a
+  zero-assertion `:pass` run emits ONE run-level pass so the test sees a
+  positive signal (the vacuous-green duality). A run whose verdict is
+  worse than any single assertion (the tape floor flipped a green
+  assertion set to `:fail`) emits a run-level report carrying the floor
+  failure so the test surfaces it."
+  [{:keys [status assertions schema-violations cannot-run] :as _result}]
+  (let [per-assertion (mapv assertion->report assertions)
+        worst         (requirements/aggregate-status assertions cannot-run)
+        ;; The run verdict exceeds the assertion-level verdict (the tape
+        ;; floor escalated it, or a run-level cannot-run/error) → emit a
+        ;; run-level report so the floor failure is not silently dropped.
+        run-level
+        (cond
+          (and (= :fail status) (not= :fail worst))
+          [{:type :fail
+            :message (str "run :fail — epoch tape shows unconsumed failure evidence"
+                          (when (seq schema-violations)
+                            (str " (" (count schema-violations) " schema violation(s))")))
+            :expected :rf.story/clean-tape
+            :actual   (or (seq schema-violations) :rf.story/tape-failure)}]
+
+          (and (= :cannot-run status) (empty? assertions))
+          [{:type :fail
+            :message "run :cannot-run — the runner could not attempt this plan"
+            :expected :rf.story/runnable
+            :actual   :rf.story/cannot-run}]
+
+          (and (= :pass status) (empty? per-assertion))
+          [{:type :pass
+            :message "run :pass — no assertions (vacuously green)"}]
+
+          :else [])]
+    (into per-assertion run-level)))
+
+(defn passed?
+  "True iff a unified `result`'s `:status` is `:pass`. Pure data → data —
+  the one-line predicate `story/is` / the cljs.test adapter pattern checks.
+  A `:cannot-run` is NOT a pass (the runner proved nothing)."
+  [result]
+  (= :pass (:status result)))

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -38,7 +38,6 @@
   production code that accidentally calls `run-variant` does not throw
   — it returns empty."
   (:require [re-frame.core            :as rf]
-            [re-frame.epoch           :as epoch]
             [re-frame.story.args      :as args]
             [re-frame.story.assertions :as assertions]
             [re-frame.story.async     :as async]
@@ -356,7 +355,15 @@
   consumers keep reading their slots while the unified shape lands."
   [{:keys [variant-id decorator-stack effective-args snapshot executed-script]} start-ms]
   (let [app-db   (rf/get-frame-db variant-id)
-        tape     (vec (epoch/epoch-history variant-id))
+        ;; rf2-5x1wt.19 follow-through — read the epoch tape through the
+        ;; late-bound `re-frame.core/epoch-history` facade (mirroring
+        ;; `re-frame.story.artifact`'s replay-path read), NOT a hard
+        ;; `[re-frame.epoch …]` require. Story's published surface (and
+        ;; its downstream consumer `tools/story-mcp`) carry no epoch dep on
+        ;; the production classpath; the facade degrades to `[]` there
+        ;; (per `re-frame.core/epoch-history`'s contract) while the
+        ;; `:test`-alias epoch dep makes it the live tape under the gate.
+        tape     (vec (rf/epoch-history variant-id))
         unified  (result/run-result
                    {:variant/id   variant-id
                     :epoch-tape   tape

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -38,6 +38,7 @@
   production code that accidentally calls `run-variant` does not throw
   — it returns empty."
   (:require [re-frame.core            :as rf]
+            [re-frame.epoch           :as epoch]
             [re-frame.story.args      :as args]
             [re-frame.story.assertions :as assertions]
             [re-frame.story.async     :as async]
@@ -46,9 +47,11 @@
             [re-frame.story.frames    :as frames]
             [re-frame.story.identity  :as ident]
             [re-frame.story.loaders   :as loaders]
+            [re-frame.story.plan      :as plan]
             [re-frame.story.play      :as play]
             [re-frame.story.play.runner-events :as runner-events]
             [re-frame.story.registrar :as registrar]
+            [re-frame.story.result    :as result]
             [re-frame.interop         :as interop]
             [re-frame.trace           :as trace]
             ;; rf2-qwm0a — listener API lives in
@@ -64,9 +67,12 @@
   rather than an exception. The shape matches a successful run with
   no registrations to act on."
   [variant-id]
-  {:frame           variant-id
+  {:status          :pass            ; rf2-5x1wt.19 — the unified verdict; a
+                                     ; no-registration run is vacuously green
+   :frame           variant-id
    :app-db          {}
    :assertions      []
+   :checks          []
    :rendered-hiccup nil
    :elapsed-ms      0
    :snapshot        nil
@@ -315,20 +321,57 @@
 ;; used to be. The named-phase decomposition also gives tests a finer entry
 ;; surface: a primed ctx can be fed into a single phase fn in isolation.
 
+(defn- variant-checks
+  "Resolve a variant's `:checks` ids into the
+  `{check-id [assertion-atom …]}` map the unified result groups by
+  (rf2-5x1wt.19). Reads the variant body's `:checks` and expands each
+  through the Story side-table `:check` kind (`plan/expand-checks`).
+  Tolerant — any resolution failure yields an empty map (checks then
+  group nothing; the run-level aggregation still sees ungrouped records)."
+  [variant-id]
+  (try
+    (let [body (frames/variant-body variant-id)]
+      (plan/expand-checks (:checks body)))
+    (catch #?(:clj Throwable :cljs :default) _ {})))
+
 (defn- record-result-map
-  "Build the result map returned by `run-variant`. Pure data; gathers
-  whatever the runtime accumulated against the variant's frame."
-  [variant-id decorator-stack effective-args snapshot start-ms]
-  (let [app-db (rf/get-frame-db variant-id)]
-    {:frame           variant-id
-     :app-db          (or app-db {})
-     :assertions      (or (:rf.story/assertions app-db) [])
-     :rendered-hiccup nil       ;; Stage 4 fills this in
-     :elapsed-ms      (- (interop/now-ms) start-ms)
-     :snapshot        snapshot
-     :decorators      decorator-stack
-     :effective-args  effective-args
-     :lifecycle       (loaders/current-state variant-id)}))
+  "Build the unified run-result returned by `run-variant` (rf2-5x1wt.19,
+  spec/017 §Run result + §Unified run result). Gathers whatever the
+  runtime accumulated against the variant's frame and assembles the ONE
+  shared shape via `result/run-result`:
+
+  - the evidential slots (`:status` floor, `:epoch-tape`,
+    `:schema-violations`, `:warnings`, `:effects`, `:sub-runs`,
+    `:renders`, `:narrative`) are PROJECTED from the retained epoch tape
+    (`.4`'s `evidence/project-evidence`, via `result/run-result`) — NOT a
+    parallel accumulator;
+  - the judgement slots (`:assertions` / `:checks`) fold the
+    `:rf.story/assertions` accumulator (the ONE non-tape input) into
+    unified records + groups them under their check ids;
+  - the top-level `:status` is the unified verdict.
+
+  The legacy `:lifecycle` / `:frame` / `:snapshot` / `:decorators` /
+  `:effective-args` / `:rendered-hiccup` slots are PRESERVED (API stable,
+  spec/017 §1a — `:status` is NET-NEW alongside `:lifecycle`), so existing
+  consumers keep reading their slots while the unified shape lands."
+  [{:keys [variant-id decorator-stack effective-args snapshot executed-script]} start-ms]
+  (let [app-db   (rf/get-frame-db variant-id)
+        tape     (vec (epoch/epoch-history variant-id))
+        unified  (result/run-result
+                   {:variant/id   variant-id
+                    :epoch-tape   tape
+                    :assertions   (or (:rf.story/assertions app-db) [])
+                    :script       executed-script
+                    :check->atoms (variant-checks variant-id)
+                    :app-db       (or app-db {})
+                    :elapsed-ms   (- (interop/now-ms) start-ms)})]
+    (merge unified
+           {:frame           variant-id
+            :rendered-hiccup nil       ;; Stage 4 fills this in
+            :snapshot        snapshot
+            :decorators      decorator-stack
+            :effective-args  effective-args
+            :lifecycle       (loaders/current-state variant-id)})))
 
 (defn- prepare-context
   "Resolve the per-run inputs that every phase needs: the decorator
@@ -381,8 +424,11 @@
   ctx)
 
 (defn- run-phase-4!
-  "Phase 4: run the play-script. Returns the play-promise — the
-  orchestrator chains `then` on it to know when to build the result.
+  "Phase 4: run the play-script. Returns `[ctx' play-promise]` — `ctx'`
+  carries `:executed-script` (the folded steps the auto-plays ran, for the
+  unified result's two-level narrative — rf2-5x1wt.19), and the
+  orchestrator chains `then` on the promise to know when to build the
+  result.
 
   rf2-0wrud (2026-05-20): drives the rich-DSL `:play-script` runner via
   `runner-events/run!`. Variants without `:play-script` / `:plays`
@@ -391,56 +437,68 @@
   by wrapping each entry in `[:dispatch-sync <event-vec>]` inside a
   `:play-script` body.
 
+  rf2-5x1wt.19 — `runner-events/variant-plays` now returns FOLDED play
+  scripts (shipping `:assert-db` / `:assert-dom` rewritten to the canonical
+  `[:assert …]` checkpoint), so the runtime consumes the `.18`-folded plan
+  and the executed-script narrative carries the one assertion atom.
+
   Phase 3 (render) is Stage 4's UI-shell concern and is not driven
   from this orchestrator."
-  [{:keys [variant-id loaders-complete?]}]
+  [{:keys [variant-id loaders-complete?] :as ctx}]
   (if-not loaders-complete?
-    (async/resolved (read-assertions variant-id))
-    (let [plays (runner-events/variant-plays variant-id)
+    [ctx (async/resolved (read-assertions variant-id))]
+    (let [plays      (runner-events/variant-plays variant-id)
           auto-plays (filterv (fn [p] (and (:auto-run? p)
                                             (seq (:script p))))
-                              plays)]
+                              plays)
+          ;; The folded steps the auto-plays ran, concatenated in order —
+          ;; the script the unified result's two-level narrative spans.
+          executed   (vec (mapcat :script auto-plays))
+          ctx'       (assoc ctx :executed-script executed)]
       (if (empty? auto-plays)
-        (async/resolved (read-assertions variant-id))
-        (async/promise
-          (fn [resolve]
-            ;; Run each auto-play sequentially. The `:rf.assert/*` events
-            ;; dispatched-sync from `[:dispatch-sync ...]` steps record
-            ;; into `:rf.story/assertions` on the frame via the standard
-            ;; assertion handlers. Once every auto-play has finished, the
-            ;; orchestrator builds the result map from the frame's
-            ;; accumulated assertions.
-            (letfn [(step! [remaining]
-                      (if (empty? remaining)
-                        (resolve (read-assertions variant-id))
-                        (let [spec (first remaining)]
-                          (runner-events/run! variant-id (:name spec) spec
-                                              (fn [_state]
-                                                (step! (rest remaining)))))))]
-              (step! auto-plays))))))))
+        [ctx' (async/resolved (read-assertions variant-id))]
+        [ctx'
+         (async/promise
+           (fn [resolve]
+             ;; Run each auto-play sequentially. The `:rf.assert/*` events
+             ;; the folded `[:assert …]` checkpoints dispatch record into
+             ;; `:rf.story/assertions` on the frame via the standard
+             ;; assertion handlers. Once every auto-play has finished, the
+             ;; orchestrator builds the result map from the frame's
+             ;; accumulated assertions.
+             (letfn [(step! [remaining]
+                       (if (empty? remaining)
+                         (resolve (read-assertions variant-id))
+                         (let [spec (first remaining)]
+                           (runner-events/run! variant-id (:name spec) spec
+                                               (fn [_state]
+                                                 (step! (rest remaining)))))))]
+               (step! auto-plays))))]))))
 
 (defn- finalise-run!
   "Build and deliver the result map once phase 4's promise settles.
   Stage 5 (rf2-h8et) makes this chain load-bearing: `execute-play!`
   resolves the promise to the assertions vector, and we want the
   result map to read the post-play app-db."
-  [resolve play-promise {:keys [variant-id decorator-stack effective-args snapshot]} start-ms]
+  [resolve play-promise ctx start-ms]
   (-> play-promise
       (async/then
         (fn [_]
-          (resolve (record-result-map variant-id decorator-stack
-                                      effective-args snapshot start-ms))
+          (resolve (record-result-map ctx start-ms))
           nil))))
 
 (defn- handle-run-error!
   "Catch-branch for the orchestrator: record the exception as a
   phase-0-setup assertion (covers any sync throw from the phase chain),
   transition the lifecycle machine to `:error`, then resolve with the
-  best result map we can build from whatever the run accumulated."
+  best result map we can build from whatever the run accumulated. The
+  recorded `:rf.error/exception` assertion (`:passed? false`) flows into
+  the unified result's `:assertions`, so the aggregation reports `:fail`
+  (the error record is a failed expectation) even when the tape is sparse."
   [resolve variant-id e start-ms]
   (record-error! variant-id :phase-0-setup nil e)
   (loaders/error! variant-id (ex-data e))
-  (resolve (record-result-map variant-id nil nil nil start-ms)))
+  (resolve (record-result-map {:variant-id variant-id} start-ms)))
 
 (defn- unknown-variant-result
   "The error result returned when `frames/variant-body` finds no
@@ -448,9 +506,11 @@
   branch of `run-variant` reads as a single expression."
   [variant-id]
   (assoc (empty-result variant-id)
-         :lifecycle :error
+         :status     :error
+         :lifecycle  :error
          :assertions [{:assertion  :rf.error/unknown-variant
                        :variant-id variant-id
+                       :status     :error
                        :passed?    false}]))
 
 (defn run-variant
@@ -489,8 +549,8 @@
                                         run-phase-0!
                                         run-phase-1!
                                         run-phase-2!)
-                       play-promise (run-phase-4! ctx)]
-                   (finalise-run! resolve play-promise ctx start-ms))
+                       [ctx' play-promise] (run-phase-4! ctx)]
+                   (finalise-run! resolve play-promise ctx' start-ms))
                  (catch #?(:clj Throwable :cljs :default) e
                    (handle-run-error! resolve variant-id e start-ms)))))))))))
 

--- a/tools/story/src/re_frame/story/ui/state/tests.cljc
+++ b/tools/story/src/re_frame/story/ui/state/tests.cljc
@@ -48,72 +48,109 @@
 ;; surfaces.
 
 (def test-run-statuses
-  "Canonical run-state ids, in render order.
+  "Canonical run-state ids, in render order (rf2-5x1wt.19 adds
+  `:cannot-run` — the unified result's distinct THIRD status, spec/017
+  §`:cannot-run`).
 
-  - `:pass`     last run: every assertion passed (and at least one assertion).
-  - `:fail`     last run: ≥1 assertion failed.
-  - `:running`  run currently in flight.
-  - `:pending`  no run recorded yet (or run produced zero assertions)."
-  [:pass :fail :running :pending])
+  - `:pass`        last run: every assertion passed (and at least one assertion).
+  - `:fail`        last run: ≥1 assertion failed.
+  - `:cannot-run`  last run: the only unmet expectations were ones the
+                   runner could not even attempt (a refusal, not a pass).
+  - `:running`     run currently in flight.
+  - `:pending`     no run recorded yet (or run produced zero assertions)."
+  [:pass :fail :cannot-run :running :pending])
 
 (defn mark-test-running
   "Stamp `variant-id` as :running. Idempotent."
   [state variant-id]
   (assoc-in state [:tests :runs variant-id] {:status :running}))
 
+(defn- record-status
+  "The unified verdict for ONE assertion record (rf2-5x1wt.19): the
+  record's own `:status` when present (the unified shape), else derived
+  from `:passed?` / `:skipped?` / `:cannot-run?`. Pure data → data — a
+  local mirror so this leaf needs no require into `re-frame.story.result`
+  (which would loop through the runtime)."
+  [{:keys [status passed? skipped? cannot-run?] :as _record}]
+  (cond
+    (keyword? status)  status
+    cannot-run?        :cannot-run
+    skipped?           :cannot-run
+    (true? passed?)    :pass
+    (false? passed?)   :fail
+    :else              :pass))
+
 (defn aggregate-summary
   "Walk `assertions` (the vector pulled off a `run-variant` result map)
-  and produce the aggregated pass/fail/skip counts:
+  and produce the aggregated pass/fail/cannot-run counts:
 
       {:total       <n>
        :passed      <n>
        :failed      <n>
+       :cannot-run  <n>
        :skipped     <n>
        :all-passed? <bool>}
 
-  `:skipped` counts records carrying `:assertion :rf.assert/skipped` —
-  re-frame2's v1 runtime doesn't emit this id, but the slot stays open
-  so spec/004 additions flow through without a pane refactor.
-  `:all-passed?` is true iff `:total > 0 AND :failed = 0 AND :skipped = 0`.
+  rf2-5x1wt.19 — buckets by each record's unified `:status` (spec/017
+  §Run result), so a `:cannot-run` assertion (a runner refusal — the
+  distinct THIRD status) is counted distinctly and NOT folded into
+  `:failed`. `:skipped` is the alias count kept for the legacy
+  `:rf.assert/skipped` id (re-frame2's runtime doesn't emit it, but the
+  slot stays open). `:all-passed?` is true iff `:total > 0 AND :failed = 0
+  AND :cannot-run = 0 AND :skipped = 0` — a refusal is NOT all-green.
 
   Lives here (not `test-mode.pure`) so both the test-mode pane AND the
   sidebar / chrome-level test widget can call one canonical fold
   without a require cycle (sidebar can't require test-mode, which
   would loop back through shell-state). Pure data → data; JVM-testable."
   [assertions]
-  (let [items     (or assertions [])
-        skipped?  (fn [r] (= :rf.assert/skipped (:assertion r)))
-        skipped   (count (filter skipped? items))
-        active    (remove skipped? items)
-        passed    (count (filter :passed? active))
-        failed    (- (count active) passed)
-        total     (count items)]
+  (let [items      (or assertions [])
+        legacy-skip? (fn [r] (= :rf.assert/skipped (:assertion r)))
+        skipped    (count (filter legacy-skip? items))
+        active     (remove legacy-skip? items)
+        buckets    (frequencies (map record-status active))
+        passed     (get buckets :pass 0)
+        cannot-run (get buckets :cannot-run 0)
+        ;; :fail + :error both count as failures for the headline tally.
+        failed     (+ (get buckets :fail 0) (get buckets :error 0))
+        total      (count items)]
     {:total       total
      :passed      passed
      :failed      failed
+     :cannot-run  cannot-run
      :skipped     skipped
-     :all-passed? (and (pos? total) (zero? failed) (zero? skipped))}))
+     :all-passed? (and (pos? total) (zero? failed) (zero? cannot-run) (zero? skipped))}))
 
 (defn record-test-run
   "Write the aggregate of a `run-variant` result into `[:tests :runs]`.
 
   `summary` is the map returned by `aggregate-summary` —
-  `{:total :passed :failed :skipped :all-passed?}` — extended with
-  optional `:ran-at-ms` and `:elapsed-ms`. A run that recorded zero
-  assertions lands as `:pending` (rather than `:pass`/`:fail`) so the
-  sidebar dot reads grey — the variant ran but produced no signal."
+  `{:total :passed :failed :cannot-run :skipped :all-passed?}` — extended
+  with optional `:ran-at-ms` / `:elapsed-ms` and (rf2-5x1wt.19) the run's
+  unified `:status` (so the sidebar dot reflects the run-level verdict,
+  including a tape-floor `:fail` or a `:cannot-run` refusal that the
+  assertion counts alone might miss).
+
+  Status precedence: an explicit run `:status` wins; otherwise it is
+  derived from the counts — zero assertions → `:pending` (grey — ran but
+  no signal); all-passed → `:pass`; any `:cannot-run` (and no fail) →
+  `:cannot-run`; else → `:fail`."
   [state variant-id summary]
-  (let [{:keys [total passed failed skipped all-passed?
-                ran-at-ms elapsed-ms]} (or summary {})
+  (let [{:keys [total passed failed cannot-run skipped all-passed?
+                ran-at-ms elapsed-ms status]} (or summary {})
         status (cond
+                 (contains? #{:pass :fail :cannot-run :error} status)
+                 (if (= :error status) :fail status)   ; :error reads as :fail on the dot
                  (zero? (or total 0)) :pending
                  all-passed?          :pass
+                 (pos? (or cannot-run 0)) :cannot-run
                  :else                :fail)]
     (assoc-in state [:tests :runs variant-id]
               {:status     status
                :total      (or total 0)
                :passed     (or passed 0)
                :failed     (or failed 0)
+               :cannot-run (or cannot-run 0)
                :skipped    (or skipped 0)
                :ran-at-ms  ran-at-ms
                :elapsed-ms elapsed-ms})))
@@ -139,15 +176,18 @@
       {:total      <count of variant-ids>
        :passed     <count whose last run was :pass>
        :failed     <count whose last run was :fail>
+       :cannot-run <count whose last run was :cannot-run>
        :running    <count currently in flight>
        :pending    <count with no recorded run>
-       :all-green? <bool — total > 0 AND failed = 0 AND running = 0
-                          AND pending = 0>}
+       :all-green? <bool — total > 0 AND failed = 0 AND cannot-run = 0
+                          AND running = 0 AND pending = 0>}
 
-  Pure data → data; the JVM corpus exercises it against a fixture map
-  without booting Reagent. `all-green?` mirrors `aggregate-summary`'s
-  `:all-passed?` — true only when every variant has a recorded green
-  run; a sea of `:pending` reads as 'not green yet', not 'all green'."
+  rf2-5x1wt.19 — `:cannot-run` (the unified distinct THIRD status) is
+  counted distinctly; a refusal is NOT green. Pure data → data; the JVM
+  corpus exercises it against a fixture map without booting Reagent.
+  `all-green?` mirrors `aggregate-summary`'s `:all-passed?` — true only
+  when every variant has a recorded green run; a sea of `:pending` reads
+  as 'not green yet', not 'all green'."
   [state variant-ids]
   (let [runs    (get-in state [:tests :runs])
         ;; Single O(N) frequencies pass — read each variant's status
@@ -155,18 +195,21 @@
         buckets (frequencies
                   (map (fn [vid] (or (get-in runs [vid :status]) :pending))
                        variant-ids))
-        total   (count variant-ids)
-        passed  (get buckets :pass    0)
-        failed  (get buckets :fail    0)
-        running (get buckets :running 0)
-        pending (get buckets :pending 0)]
+        total      (count variant-ids)
+        passed     (get buckets :pass       0)
+        failed     (get buckets :fail       0)
+        cannot-run (get buckets :cannot-run 0)
+        running    (get buckets :running    0)
+        pending    (get buckets :pending    0)]
     {:total      total
      :passed     passed
      :failed     failed
+     :cannot-run cannot-run
      :running    running
      :pending    pending
      :all-green? (and (pos? total)
                       (zero? failed)
+                      (zero? cannot-run)
                       (zero? running)
                       (zero? pending))}))
 

--- a/tools/story/src/re_frame/story/ui/test_mode/state.cljs
+++ b/tools/story/src/re_frame/story/ui/test_mode/state.cljs
@@ -90,7 +90,12 @@
             :selected-step nil})
     (let [summary (-> (state/aggregate-summary (:assertions result))
                       (assoc :ran-at-ms  now
-                             :elapsed-ms (:elapsed-ms result)))]
+                             :elapsed-ms (:elapsed-ms result)
+                             ;; rf2-5x1wt.19 — thread the unified run-level
+                             ;; `:status` so the sidebar dot reflects a
+                             ;; tape-floor `:fail` / `:cannot-run` refusal
+                             ;; the assertion counts alone might miss.
+                             :status     (:status result)))]
       (state/swap-state! state/record-test-run variant-id summary))))
 
 (defn select-step!

--- a/tools/story/src/re_frame/story/ui/test_mode/view.cljs
+++ b/tools/story/src/re_frame/story/ui/test_mode/view.cljs
@@ -113,15 +113,26 @@
         result (:result slot)]
     (when result
       (let [summary (shell-state/aggregate-summary (:assertions result))
-            {:keys [total passed failed skipped all-passed?]} summary
-            pill-style (cond
-                         (zero? total)  (:pill-empty styles)
-                         all-passed?    (:pill-pass styles)
-                         :else          (:pill-fail styles))
-            pill-text  (cond
-                         (zero? total) "no assertions recorded"
-                         all-passed?   (str passed " passed")
-                         :else         (str failed " failed of " total))]
+            {:keys [total passed failed cannot-run skipped all-passed?]} summary
+            cannot-run (or cannot-run 0)
+            ;; rf2-5x1wt.19 — prefer the unified run-level `:status` so a
+            ;; tape-floor `:fail` / a `:cannot-run` refusal renders even when
+            ;; the assertion counts alone would read green.
+            status     (or (:status result)
+                           (cond (zero? total)      :pending
+                                 all-passed?        :pass
+                                 (pos? cannot-run)  :cannot-run
+                                 :else              :fail))
+            pill-style (case status
+                         :pass       (:pill-pass styles)
+                         :cannot-run (:pill-empty styles)
+                         (:pending)  (:pill-empty styles)
+                         (:pill-fail styles))
+            pill-text  (case status
+                         :pass       (str passed " passed")
+                         :cannot-run (str cannot-run " cannot-run of " total)
+                         (:pending)  "no assertions recorded"
+                         (str failed " failed of " total))]
         [:div {:style     (:section styles)
                :data-test "story-test-summary-section"}
          [:div {:style (:section-h styles)} "Summary"]
@@ -135,7 +146,9 @@
            "  "
            [:span {:style (:count-fail styles)} (str "✗ " failed " failed")]
            "  "
-           [:span {:style (:count-skip styles)} (str "⊘ " skipped " skipped")]]]]))))
+           ;; rf2-5x1wt.19 — the distinct THIRD status, rendered (spec/017
+           ;; §`:cannot-run` — Story UI MUST render `:cannot-run` distinctly).
+           [:span {:style (:count-skip styles)} (str "⊘ " cannot-run " cannot-run")]]]]))))
 
 (defn- tick-style-for
   "Pick the style map for a single tick based on `status`."

--- a/tools/story/test/re_frame/story/play/runner_events_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/play/runner_events_cljs_test.cljc
@@ -215,7 +215,11 @@
 
 #?(:clj
    (deftest assert-db-equals-pass-and-fail
-     (testing ":assert-db pass / fail outcomes against frame app-db"
+     (testing ":assert-db pass / fail outcomes against frame app-db. Per
+              rf2-5x1wt.19 the runtime consumes the folded plan: a shipping
+              :assert-db step is rewritten to the canonical
+              [:assert [:rf.assert/path-equals …]] checkpoint, so the
+              recorded step type is :assert."
        (rf/reg-event-db :rt/set-status
          (fn [db [_ v]] (assoc db :status v)))
        (story/reg-variant :story.runner/assert-db
@@ -228,26 +232,38 @@
        (let [final (run-blocking :story.runner/assert-db)]
          (is (= :fail (:status final)))
          (is (= 1 (:failures final)))
-         (let [assert-results (filterv #(= :assert-db (:type %)) (:results final))]
+         ;; rf2-5x1wt.19 — folded :assert-db steps run as :assert checkpoints.
+         (let [assert-results (filterv #(= :assert (:type %)) (:results final))]
            (is (= 2 (count assert-results)))
            (is (true?  (:passed? (nth assert-results 0))))
-           (is (false? (:passed? (nth assert-results 1))))
-           (is (= :wrong  (:expected (nth assert-results 1))))
-           (is (= :loaded (:actual   (nth assert-results 1)))))))))
+           (is (false? (:passed? (nth assert-results 1)))))
+         ;; The canonical :rf.assert/path-equals records carry the diagnostics.
+         (let [slot (story/read-assertions :story.runner/assert-db)
+               pe   (filterv #(= :rf.assert/path-equals (:assertion %)) slot)]
+           (is (= 2 (count pe)))
+           (is (true?  (:passed? (nth pe 0))))
+           (is (false? (:passed? (nth pe 1))))
+           (is (= :wrong  (:expected (nth pe 1))))
+           (is (= :loaded (:actual   (nth pe 1)))))))))
 
-;; ---- rf2-ee38b.3: rich-DSL assert outcomes reach :rf.story/assertions ----
+;; ---- rf2-ee38b.3 / rf2-5x1wt.19: folded assert outcomes reach the slot ---
 ;;
-;; Before this fix a failing `:assert-db` / `:assert-dom` step landed
+;; Before rf2-ee38b.3 a failing `:assert-db` / `:assert-dom` step landed
 ;; ONLY in run-state; the `:rf.story/assertions` app-db slot stayed empty
 ;; so `run-variant`'s :assertions slot, `assertions-passing?`, the test
-;; pane, the inline strip, and the Xray panel all read FALSE-GREEN. The
-;; bridge in `record-result!` mirrors assertion-class outcomes into the
-;; slot. These tests must FAIL without the bridge.
+;; pane, the inline strip, and the Xray panel all read FALSE-GREEN.
+;;
+;; rf2-5x1wt.19 — the runtime now consumes the `.18`-folded plan: a shipping
+;; `:assert-db` step is rewritten to the canonical `[:assert
+;; [:rf.assert/path-equals …]]` checkpoint, whose reg-event-fx handler
+;; records the CANONICAL `:rf.assert/path-equals` record on the slot. There
+;; is no longer a synthetic `:rf.assert/db` / `:rf.assert/dom` rail — one
+;; assertion-record vocabulary.
 
 #?(:clj
    (deftest assert-db-failure-lands-in-assertions-slot
-     (testing "a failing rich-DSL :assert-db step records a :passed? false
-              entry into :rf.story/assertions (not just run-state) so the
+     (testing "a failing folded :assert-db step records a :passed? false
+              :rf.assert/path-equals record into :rf.story/assertions so the
               slot consumers + assertions-passing? observe the failure"
        (rf/reg-event-db :rt/set-status
          (fn [db [_ v]] (assoc db :status v)))
@@ -259,21 +275,20 @@
        (async/deref-blocking (story/run-variant :story.bridge/db-fail) 5000)
        (run-blocking :story.bridge/db-fail)
        (let [slot (story/read-assertions :story.bridge/db-fail)
-             db-recs (filterv #(= :rf.assert/db (:assertion %)) slot)]
-         (is (= 1 (count db-recs))
-             "the failing rich-DSL :assert-db landed exactly one slot record")
-         (is (false? (:passed? (first db-recs)))
+             pe-recs (filterv #(= :rf.assert/path-equals (:assertion %)) slot)]
+         (is (= 1 (count pe-recs))
+             "the failing folded :assert-db landed exactly one canonical record")
+         (is (false? (:passed? (first pe-recs)))
              "the slot record carries :passed? false")
-         (is (= :loaded (:expected (first db-recs))))
-         (is (= :idle   (:actual   (first db-recs))))
+         (is (= :loaded (:expected (first pe-recs))))
+         (is (= :idle   (:actual   (first pe-recs))))
          (is (false? (story/assertions-passing? slot))
-             "assertions-passing? now sees the rich-DSL failure (was
-              false-green before rf2-ee38b.3)")))))
+             "assertions-passing? sees the folded failure")))))
 
 #?(:clj
    (deftest assert-db-pass-lands-in-assertions-slot
-     (testing "a passing rich-DSL :assert-db step records a :passed? true
-              entry so the slot is non-empty + still passes"
+     (testing "a passing folded :assert-db step records a :passed? true
+              :rf.assert/path-equals entry so the slot is non-empty + passes"
        (rf/reg-event-db :rt/set-status
          (fn [db [_ v]] (assoc db :status v)))
        (story/reg-variant :story.bridge/db-pass
@@ -284,16 +299,17 @@
        (async/deref-blocking (story/run-variant :story.bridge/db-pass) 5000)
        (run-blocking :story.bridge/db-pass)
        (let [slot    (story/read-assertions :story.bridge/db-pass)
-             db-recs (filterv #(= :rf.assert/db (:assertion %)) slot)]
-         (is (= 1 (count db-recs)))
-         (is (true? (:passed? (first db-recs))))
+             pe-recs (filterv #(= :rf.assert/path-equals (:assertion %)) slot)]
+         (is (= 1 (count pe-recs)))
+         (is (true? (:passed? (first pe-recs))))
          (is (true? (story/assertions-passing? slot)))))))
 
 #?(:clj
    (deftest run-variant-result-reflects-rich-dsl-assert-failure
      (testing "the run-variant result map's :assertions slot carries the
-              rich-DSL failure — the cljs.test adapter path (assertions-
-              passing? on the result) is no longer false-green"
+              folded failure as a canonical :rf.assert/path-equals record —
+              the cljs.test adapter path (assertions-passing? on the result)
+              is no longer false-green; and the unified :status is :fail"
        (rf/reg-event-db :rt/set-status
          (fn [db [_ v]] (assoc db :status v)))
        (story/reg-variant :story.bridge/result
@@ -302,30 +318,37 @@
                                  [:assert-db [:status] :loaded]]}})
        (let [result (async/deref-blocking
                       (story/run-variant :story.bridge/result) 5000)]
-         (is (some (fn [r] (and (= :rf.assert/db (:assertion r))
+         (is (= :fail (:status result))
+             "the unified run-result :status is :fail (rf2-5x1wt.19)")
+         (is (some (fn [r] (and (= :rf.assert/path-equals (:assertion r))
                                 (false? (:passed? r))))
                    (:assertions result))
-             "the result map's :assertions slot includes the failed assert-db")
+             "the result map's :assertions slot includes the failed assertion")
          (is (false? (story/assertions-passing? result))
              "assertions-passing? on the result map flips to false")))))
 
 #?(:clj
-   (deftest assert-db-skipped-dom-not-recorded-as-slot-pass
-     (testing "a no-DOM :assert-dom step (JVM) records NO slot entry —
-              it must not read as a vacuous slot pass (false-green)"
+   (deftest assert-dom-skipped-on-jvm-is-cannot-run
+     (testing "a no-DOM :assert-dom step (JVM) records NO slot pass — it
+              folds to :rf.assert/dom-visible, is evaluated by the DOM
+              executor (no DOM → skipped), and the run is :cannot-run, not a
+              false-green pass (rf2-5x1wt.19, spec/017 §`:cannot-run`)"
        (story/reg-variant :story.bridge/dom-skip
          {:events      []
           :play-script {:auto-run? false
                         :script    [[:assert-dom "div.foo" :visible]]}})
        (async/deref-blocking (story/run-variant :story.bridge/dom-skip) 5000)
-       (run-blocking :story.bridge/dom-skip)
-       (let [slot (story/read-assertions :story.bridge/dom-skip)]
-         (is (empty? (filterv #(= :rf.assert/dom (:assertion %)) slot))
-             "a skipped (no-DOM) :assert-dom contributes no slot record")))))
+       (let [final (run-blocking :story.bridge/dom-skip)
+             slot  (story/read-assertions :story.bridge/dom-skip)]
+         (is (= :cannot-run (:status final))
+             "a DOM-skip-only run is :cannot-run, not :pass or :fail")
+         (is (empty? (filterv #(true? (:passed? %)) slot))
+             "a skipped (no-DOM) :assert-dom contributes no passing record")))))
 
 #?(:clj
    (deftest assert-db-pred-form
-     (testing ":assert-db :pred resolves a symbol and applies it"
+     (testing ":assert-db :pred folds to :rf.assert/path-matches [:fn sym];
+              the symbol resolves at validation time (rf2-5x1wt.19)"
        (rf/reg-event-db :rt/set-n
          (fn [db [_ v]] (assoc db :n v)))
        (story/reg-variant :story.runner/pred
@@ -336,14 +359,20 @@
                                     [:assert-db [:n] :pred 'clojure.core/neg?]]}})
        (async/deref-blocking (story/run-variant :story.runner/pred) 5000)
        (let [final  (run-blocking :story.runner/pred)
-             results (filterv #(= :assert-db (:type %)) (:results final))]
+             ;; folded :assert-db :pred → [:assert [:rf.assert/path-matches …]]
+             results (filterv #(= :assert (:type %)) (:results final))
+             pm      (filterv #(= :rf.assert/path-matches (:assertion %))
+                              (story/read-assertions :story.runner/pred))]
          (is (= :fail (:status final)))
-         (is (true?  (:passed? (nth results 0))))
-         (is (false? (:passed? (nth results 1))))))))
+         (is (= 2 (count results)))
+         (is (true?  (:passed? (nth pm 0))) "pos? against 7 passes")
+         (is (false? (:passed? (nth pm 1))) "neg? against 7 fails")))))
 
 #?(:clj
    (deftest assert-db-pred-fn-direct
-     (testing ":assert-db :pred accepts a fn directly (rf2-inbad — advanced-CLJS-safe)"
+     (testing ":assert-db :pred accepts a fn directly (rf2-inbad —
+              advanced-CLJS-safe); it folds to :rf.assert/path-matches
+              [:fn fn] which Malli validates by calling the fn (rf2-5x1wt.19)"
        (rf/reg-event-db :rt/set-n
          (fn [db [_ v]] (assoc db :n v)))
        (story/reg-variant :story.runner/pred-fn
@@ -355,19 +384,21 @@
                                     [:assert-db [:n] :pred (fn [x] (= x 7))]]}})
        (async/deref-blocking (story/run-variant :story.runner/pred-fn) 5000)
        (let [final   (run-blocking :story.runner/pred-fn)
-             results (filterv #(= :assert-db (:type %)) (:results final))]
+             pm      (filterv #(= :rf.assert/path-matches (:assertion %))
+                              (story/read-assertions :story.runner/pred-fn))]
          (is (= :fail (:status final))
              "neg? against 7 fails — overall status is :fail")
-         (is (= 3 (count results)))
-         (is (true?  (:passed? (nth results 0))) "pos? against 7 passes")
-         (is (false? (:passed? (nth results 1))) "neg? against 7 fails")
-         (is (true?  (:passed? (nth results 2))) "anonymous fn passes")
-         (is (re-find #"<fn>" (:message (nth results 1)))
-             "failure message renders fn ref as <fn> — no compiler-munged leakage")))))
+         (is (= 3 (count pm)))
+         (is (true?  (:passed? (nth pm 0))) "pos? against 7 passes")
+         (is (false? (:passed? (nth pm 1))) "neg? against 7 fails")
+         (is (true?  (:passed? (nth pm 2))) "anonymous fn passes")))))
 
 #?(:clj
    (deftest assert-db-pred-bogus-symbol-fails-gracefully
-     (testing ":assert-db :pred with an unresolvable symbol fails gracefully (rf2-inbad)"
+     (testing ":assert-db :pred with an unresolvable symbol fails gracefully:
+              it folds to :rf.assert/path-matches [:fn 'bogus]; the symbol
+              cannot resolve, so the assertion reports a readable failure
+              rather than an opaque sci error (rf2-5x1wt.19)"
        (rf/reg-event-db :rt/set-n
          (fn [db [_ v]] (assoc db :n v)))
        (story/reg-variant :story.runner/pred-bogus
@@ -376,13 +407,12 @@
                         :script    [[:dispatch-sync [:rt/set-n 7]]
                                     [:assert-db [:n] :pred 'no.such.ns/missing-pred]]}})
        (async/deref-blocking (story/run-variant :story.runner/pred-bogus) 5000)
-       (let [final   (run-blocking :story.runner/pred-bogus)
-             results (filterv #(= :assert-db (:type %)) (:results final))]
+       (let [final (run-blocking :story.runner/pred-bogus)
+             pm    (filterv #(= :rf.assert/path-matches (:assertion %))
+                            (story/read-assertions :story.runner/pred-bogus))]
          (is (= :fail (:status final)))
-         (is (= 1 (count results)))
-         (is (false? (:passed? (first results))))
-         (is (re-find #"could not resolve" (:message (first results)))
-             "user-facing message mentions resolution failure")))))
+         (is (= 1 (count pm)))
+         (is (false? (:passed? (first pm))))))))
 
 #?(:clj
    (deftest run-records-results-in-order
@@ -516,7 +546,10 @@
 
 #?(:clj
    (deftest dom-step-skipped-on-jvm
-     (testing "DOM-touching steps record :skipped? on JVM (no DOM)"
+     (testing "DOM-touching steps record :skipped? on JVM (no DOM); a run
+              whose only unmet steps are no-DOM skips is :cannot-run — the
+              distinct THIRD status, not a fail or a silent pass
+              (rf2-5x1wt.19, spec/017 §`:cannot-run`)"
        (story/reg-variant :story.runner/dom
          {:events []
           :play-script {:auto-run? false
@@ -525,7 +558,8 @@
        (async/deref-blocking (story/run-variant :story.runner/dom) 5000)
        (let [final   (run-blocking :story.runner/dom)
              results (:results final)]
-         (is (= :fail (:status final)))
+         (is (= :cannot-run (:status final))
+             "no-DOM click + assert-dom → :cannot-run (a refusal, not a fail)")
          (is (every? (fn [r] (or (:skipped? r) (true? (:passed? r)))) results))))))
 
 ;; ---- multi-play (rf2-tl7zk) ----------------------------------------------

--- a/tools/story/test/re_frame/story/result_test.cljc
+++ b/tools/story/test/re_frame/story/result_test.cljc
@@ -1,0 +1,270 @@
+(ns re-frame.story.result-test
+  "Tests for the ONE unified run-result + the assertion / check record
+  shapes + the clojure.test report projection (NewTestStory rf2-5x1wt.19,
+  `tools/story/spec/017-Testing-Story.md` §Run result + §Unified run
+  result).
+
+  Every fn under test is PURE data → data, so the whole suite runs under
+  `clojure -M:test` with no host: raw assertion accumulator entries +
+  projected epoch evidence + plan slots in, the unified run-result /
+  records / reports out. The §B5 acceptance bullets:
+
+  - a passing variant yields `:status :pass`;
+  - a failing assertion yields `:status :fail`;
+  - cannot-run yields `:status :cannot-run`;
+  - check records group assertions;
+  - schema / warning / effect projections AGREE with the epoch tape;
+  - `story/is` reports per assertion (`result->reports`)."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.story.result   :as result]
+            [re-frame.story.play.evidence :as evidence]
+            [re-frame.story.requirements  :as requirements]))
+
+;; ===========================================================================
+;; STATUS — the four verdicts, derived from one field
+;; ===========================================================================
+
+(deftest record-status-derivation
+  (testing "an explicit :status on the record wins"
+    (is (= :cannot-run (result/record-status {:status :cannot-run :passed? true}))))
+  (testing ":passed? true/false → :pass / :fail"
+    (is (= :pass (result/record-status {:passed? true})))
+    (is (= :fail (result/record-status {:passed? false}))))
+  (testing ":cannot-run? / legacy :skipped? → :cannot-run (the THIRD status)"
+    (is (= :cannot-run (result/record-status {:passed? false :cannot-run? true})))
+    (is (= :cannot-run (result/record-status {:passed? false :skipped? true}))))
+  (testing "an exception / error → :error"
+    (is (= :error (result/record-status {:passed? false :exception true})))
+    (is (= :error (result/record-status {:passed? false :error {:msg "boom"}}))))
+  (testing "a record with no outcome is vacuously :pass (the duality)"
+    (is (= :pass (result/record-status {:assertion :rf.assert/x})))))
+
+;; ===========================================================================
+;; ASSERTION RECORD — the `.18` atom shape + a unified :status
+;; ===========================================================================
+
+(deftest assertion-record-stamps-status-and-source
+  (testing "a raw accumulator entry gains a derived :status + :source alias"
+    (let [raw {:assertion :rf.assert/path-equals :payload [[:k] 1]
+               :passed? true :expected 1 :actual 1
+               :source-coord {:file "x.cljs" :line 3}}
+          rec (result/assertion-record raw)]
+      (is (= :pass (:status rec)))
+      (is (= {:file "x.cljs" :line 3} (:source rec)) ":source-coord aliased to :source")
+      (is (= {:file "x.cljs" :line 3} (:source-coord rec)) "original slot kept")
+      (is (= :rf.assert/path-equals (:assertion rec)))))
+  (testing "a failing entry → :fail; a record carrying its own :status is left"
+    (is (= :fail (:status (result/assertion-record {:passed? false}))))
+    (is (= :cannot-run (:status (result/assertion-record
+                                  {:status :cannot-run :passed? false}))))))
+
+;; ===========================================================================
+;; CHECK RECORD — group assertions under their check id
+;; ===========================================================================
+
+(deftest check-records-group-by-atom-id-and-payload
+  (testing "a check groups exactly the records its atoms produced (id+payload)"
+    (let [records [{:assertion :rf.assert/path-equals :payload [[:a] 1] :status :pass}
+                   {:assertion :rf.assert/no-warnings  :payload []      :status :pass}
+                   {:assertion :rf.assert/path-equals :payload [[:b] 2] :status :fail}]
+          check->atoms {:check/clean [[:rf.assert/no-warnings]]
+                        :check/a     [[:rf.assert/path-equals [:a] 1]]}
+          recs (result/check-records check->atoms records)]
+      (is (= 2 (count recs)))
+      (let [clean (first (filter #(= :check/clean (:check %)) recs))
+            a     (first (filter #(= :check/a (:check %)) recs))]
+        (is (= :pass (:status clean)))
+        (is (= 1 (count (:assertions clean))))
+        (is (= :rf.assert/no-warnings (:assertion (first (:assertions clean)))))
+        (is (= :pass (:status a)))
+        ;; the [:b] 2 path-equals record is NOT grouped under :check/a
+        ;; (different payload) — payload disambiguates same-id assertions.
+        (is (= 1 (count (:assertions a)))))))
+
+  (testing "a failing check shows the check id AND the failing record"
+    (let [records [{:assertion :rf.assert/path-equals :payload [[:s] :x] :status :fail
+                    :expected :x :actual :y}]
+          recs (result/check-records {:check/state [[:rf.assert/path-equals [:s] :x]]}
+                                     records)
+          c    (first recs)]
+      (is (= :check/state (:check c)))
+      (is (= :fail (:status c)))
+      (is (= :y (:actual (first (:assertions c)))))))
+
+  (testing "an unmatched check atom groups nothing (the assertion never ran)"
+    (let [recs (result/check-records {:check/missing [[:rf.assert/path-equals [:z] 9]]}
+                                     [])]
+      (is (= :pass (:status (first recs))) "an empty group is vacuously :pass")
+      (is (empty? (:assertions (first recs)))))))
+
+;; ===========================================================================
+;; RUN RESULT — the unified shape + the agreement floor
+;; ===========================================================================
+
+(defn- epoch
+  "Build a minimal `:rf/epoch-record` for the projection tests."
+  [m]
+  (merge {:epoch-id (gensym "e") :outcome :ok :trace-events []
+          :effects [] :sub-runs [] :renders []}
+         m))
+
+(deftest passing-variant-yields-pass
+  (testing "a passing assertion set + clean tape → :status :pass (§B5)"
+    (let [r (result/run-result
+              {:variant/id :story.x/v
+               :epoch-tape [(epoch {})]
+               :assertions [{:assertion :rf.assert/path-equals :passed? true}]
+               :script     [[:dispatch [:e]]]})]
+      (is (= :pass (:status r)))
+      (is (= :story.x/v (:variant/id r)))
+      (is (vector? (:assertions r)))
+      (is (= :pass (:status (first (:assertions r))))))))
+
+(deftest failing-assertion-yields-fail
+  (testing "a failing assertion → :status :fail (§B5)"
+    (let [r (result/run-result
+              {:epoch-tape [(epoch {})]
+               :assertions [{:assertion :rf.assert/path-equals :passed? true}
+                            {:assertion :rf.assert/path-equals :passed? false}]})]
+      (is (= :fail (:status r))))))
+
+(deftest cannot-run-yields-cannot-run
+  (testing "a run whose only unmet expectation is :cannot-run → :cannot-run (§B5)"
+    (let [refusal (requirements/requirement-refusal
+                    #{:pixels} #{:app-db} [:rf.assert/visual-snapshot]
+                    :runner-lacks-capability :headless)
+          r (result/run-result
+              {:epoch-tape [(epoch {})]
+               :assertions [{:assertion :rf.assert/path-equals :passed? true}]
+               :unmet      [refusal]})]
+      (is (= :cannot-run (:status r)))
+      (is (= [refusal] (:cannot-run r)) "the refusal surfaces on :cannot-run")))
+  (testing "a :cannot-run assertion record (no real fail) → :cannot-run"
+    (let [r (result/run-result
+              {:assertions [{:assertion :rf.assert/dom-visible
+                             :status :cannot-run :passed? false}]})]
+      (is (= :cannot-run (:status r))))))
+
+(deftest error-outranks-fail
+  (testing "an :error assertion record → :status :error (precedence)"
+    (let [r (result/run-result
+              {:assertions [{:assertion :rf.assert/x :passed? false}
+                            {:assertion :rf.error/exception :passed? false
+                             :exception true}]})]
+      (is (= :error (:status r))))))
+
+;; ---- the agreement floor: no green while the tape is red -----------------
+
+(deftest tape-floor-flips-green-to-fail
+  (testing "a passing assertion set CANNOT report :pass while the tape carries
+            a schema violation (the agreement floor — §Run-result evidence
+            projection)"
+    (let [tape [(epoch {:trace-events
+                        [{:operation :rf.error/schema-validation-failure
+                          :tags {:where :event :failing-id :checkout/submit}}]})]
+          r    (result/run-result
+                 {:epoch-tape tape
+                  :assertions [{:assertion :rf.assert/path-equals :passed? true}]})]
+      (is (= :fail (:status r))
+          "a clean assertion set + a red tape is :fail, not a false GREEN")
+      ;; the projection AGREES with the tape (§B5 — projections agree)
+      (is (= 1 (count (:schema-violations r))))
+      (is (= [:event :checkout/submit] (:selector (first (:schema-violations r))))))))
+
+(deftest consumed-schema-violation-does-not-trip-the-floor
+  (testing "a schema violation the run EXACTLY consumed does not flip a pass"
+    (let [sel  [:event :checkout/submit]
+          tape [(epoch {:trace-events
+                        [{:operation :rf.error/schema-validation-failure
+                          :tags {:where :event :failing-id :checkout/submit}}]})]
+          r    (result/run-result
+                 {:epoch-tape tape
+                  :assertions [{:assertion :rf.assert/schema-error :passed? true}]
+                  :consumed-selectors #{sel}})]
+      (is (= :pass (:status r))
+          "the consumed violation is excused — the floor does not trip"))))
+
+;; ---- projections AGREE with the tape (§B5) -------------------------------
+
+(deftest result-projections-agree-with-the-tape
+  (testing "the run-result's schema / warning / effect / render slots ARE the
+            evidence projection of the tape (one source of truth — §B5)"
+    (let [tape [(epoch {:trace-events
+                        [{:operation :rf.error/schema-validation-failure
+                          :tags {:where :app-db :failing-id :db :registered-path [:k] :path [:k]}}
+                         {:op-type :warn :operation :rf.warn/x :tags {:category :perf}}]
+                        :effects [{:fx-id :http :outcome :ok}]
+                        :renders [{:view :v}]})]
+          r        (result/run-result {:epoch-tape tape})
+          expected (evidence/project-evidence tape nil)]
+      (is (= (:schema-violations expected) (:schema-violations r)))
+      (is (= (:warnings expected)          (:warnings r)))
+      (is (= (:effects expected)           (:effects r)))
+      (is (= (:renders expected)           (:renders r)))
+      ;; tape carries a schema violation → the run is :fail by the floor
+      (is (= :fail (:status r))))))
+
+(deftest zero-assertion-clean-run-is-vacuously-green
+  (testing "a run with no assertions + a clean tape is :pass (the duality)"
+    (is (= :pass (:status (result/run-result {:epoch-tape [(epoch {})]}))))
+    (is (= :pass (:status (result/run-result {}))))))
+
+;; ===========================================================================
+;; clojure.test / cljs.test BRIDGE PROJECTION — story/is reports per assertion
+;; ===========================================================================
+
+(deftest result->reports-one-per-assertion
+  (testing "story/is emits one report per assertion record (§B5)"
+    (let [r       (result/run-result
+                    {:assertions [{:assertion :rf.assert/path-equals :payload [[:a] 1]
+                                   :passed? true}
+                                  {:assertion :rf.assert/path-equals :payload [[:b] 2]
+                                   :passed? false :expected 2 :actual 3}]})
+          reports (result/result->reports r)]
+      (is (= 2 (count reports)) "one report per assertion")
+      (is (= :pass (:type (first reports))))
+      (is (= :fail (:type (second reports))))
+      (is (= 2 (:expected (second reports))))
+      (is (= 3 (:actual (second reports)))))))
+
+(deftest result->reports-cannot-run-reports-fail
+  (testing "a :cannot-run assertion reports :fail (the runner proved nothing —
+            never a silent pass)"
+    (let [r       (result/run-result
+                    {:assertions [{:assertion :rf.assert/visual-snapshot
+                                   :status :cannot-run :passed? false
+                                   :reason "needs :browser"}]})
+          reports (result/result->reports r)]
+      (is (= :fail (:type (first reports))))
+      (is (re-find #":cannot-run" (:message (first reports)))))))
+
+(deftest result->reports-zero-assertion-pass-emits-one-pass
+  (testing "a vacuous-green run emits ONE run-level pass so the test sees a
+            positive signal"
+    (let [reports (result/result->reports (result/run-result {}))]
+      (is (= 1 (count reports)))
+      (is (= :pass (:type (first reports)))))))
+
+(deftest result->reports-tape-floor-fail-emits-run-level-report
+  (testing "when the tape floor flipped a green assertion set to :fail, a
+            run-level report carries the floor failure (not silently dropped)"
+    (let [tape [(epoch {:trace-events
+                        [{:operation :rf.error/schema-validation-failure
+                          :tags {:where :event :failing-id :x}}]})]
+          r       (result/run-result
+                    {:epoch-tape tape
+                     :assertions [{:assertion :rf.assert/path-equals :passed? true}]})
+          reports (result/result->reports r)]
+      (is (= :fail (:status r)))
+      ;; one per-assertion pass + one run-level floor fail
+      (is (= 2 (count reports)))
+      (is (= :pass (:type (first reports))))
+      (is (= :fail (:type (last reports))))
+      (is (re-find #"unconsumed failure" (:message (last reports)))))))
+
+(deftest passed?-only-pass
+  (testing "result/passed? is true ONLY for :pass — :cannot-run is not a pass"
+    (is (true?  (result/passed? {:status :pass})))
+    (is (false? (result/passed? {:status :fail})))
+    (is (false? (result/passed? {:status :cannot-run})))
+    (is (false? (result/passed? {:status :error})))))

--- a/tools/story/test/re_frame/story/story_is_test.clj
+++ b/tools/story/test/re_frame/story/story_is_test.clj
@@ -1,0 +1,113 @@
+(ns re-frame.story.story-is-test
+  "Headless `story/is` clojure.test bridge tests (NewTestStory
+  rf2-5x1wt.19, `tools/story/spec/017-Testing-Story.md` §Public execution
+  API — the three verbs; §Run result — `story/is` reports per assertion).
+
+  JVM-only (`.clj`): on the JVM `story/is` BLOCKS on the run promise and
+  fires one `clojure.test` report per assertion synchronously, so the
+  reports can be captured by rebinding `clojure.test/report`. The CLJS
+  path is async (returns a promise); its pure report projection is covered
+  by `re-frame.story.result-test/result->reports-*`.
+
+  The bridge is verified by collecting every `clojure.test/do-report` map
+  `story/is` emits into an atom (the standard report-capture seam) and
+  asserting the per-assertion granularity + the verdict-driven run-level
+  report."
+  (:require [clojure.test :refer [deftest is testing use-fixtures] :as t]
+            [re-frame.core      :as rf]
+            [re-frame.frame     :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.story     :as story]
+            [re-frame.story.assertions :as assertions]
+            [re-frame.story.play.runner-events :as re]))
+
+(defn- reset-rf! [test-fn]
+  (story/clear-all!)
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (try (rf/init! plain-atom/adapter)
+       (catch clojure.lang.ExceptionInfo _ nil))
+  (reset! assertions/trace-accumulators {})
+  (reset! re/run-state {})
+  (story/install-canonical-vocabulary!)
+  (frame/ensure-default-frame!)
+  (rf/reg-event-db :is/set-status (fn [db [_ v]] (assoc db :status v)))
+  (test-fn))
+
+(use-fixtures :each reset-rf!)
+
+(defn- capture-reports
+  "Run `thunk` with `clojure.test/report` rebound to collect every report
+  map into a vector, so a `story/is` call's emitted reports can be
+  inspected. Returns `[thunk-return reports-vector]`. The capture excludes
+  the outer test's own pass/fail bookkeeping by collecting ONLY the
+  `:pass` / `:fail` / `:error` report maps `story/is` fires."
+  [thunk]
+  (let [collected (atom [])]
+    (binding [t/report (fn [m]
+                         (when (#{:pass :fail :error} (:type m))
+                           (swap! collected conj m)))]
+      (let [ret (thunk)]
+        [ret @collected]))))
+
+(deftest story-is-reports-per-assertion-pass
+  (testing "story/is fires one :pass report per passing assertion + returns
+            the unified result (§B5 — story/is reports per assertion)"
+    (story/reg-variant :story.is/pass
+      {:tags        #{:test}
+       :play-script {:script [[:dispatch-sync [:is/set-status :loaded]]
+                              [:assert-db [:status] :loaded]
+                              [:assert-db [:status] :loaded]]}})
+    (let [[result reports] (capture-reports #(story/is :story.is/pass))]
+      (is (= :pass (:status result)) "the unified verdict is :pass")
+      (is (= 2 (count reports)) "one report per assertion (2 assertions)")
+      (is (every? #(= :pass (:type %)) reports)))))
+
+(deftest story-is-reports-per-assertion-fail
+  (testing "story/is fires a :fail report for a failing assertion (§B5)"
+    (story/reg-variant :story.is/fail
+      {:tags        #{:test}
+       :play-script {:script [[:dispatch-sync [:is/set-status :idle]]
+                              [:assert-db [:status] :loaded]]}})
+    (let [[result reports] (capture-reports #(story/is :story.is/fail))]
+      (is (= :fail (:status result)))
+      (is (= 1 (count reports)))
+      (is (= :fail (:type (first reports))))
+      (is (re-find #":rf.assert/path-equals" (:message (first reports)))
+          "the report names the failing assertion id"))))
+
+(deftest story-is-zero-assertion-emits-one-pass
+  (testing "a variant with no assertions is vacuously green — story/is emits
+            ONE run-level :pass so the test sees a positive signal"
+    (story/reg-variant :story.is/empty
+      {:tags        #{:test}
+       :play-script {:script [[:dispatch-sync [:is/set-status :ready]]]}})
+    (let [[result reports] (capture-reports #(story/is :story.is/empty))]
+      (is (= :pass (:status result)))
+      (is (= 1 (count reports)))
+      (is (= :pass (:type (first reports)))))))
+
+(deftest story-is-accepts-an-already-resolved-result
+  (testing "story/is reports a unified result map directly (the sync path for
+            tests that ran the variant themselves)"
+    (let [result {:status :fail :variant/id :story.is/direct
+                  :assertions [{:assertion :rf.assert/path-equals
+                                :status :fail :passed? false
+                                :payload [[:k] 1] :expected 1 :actual 2}]}
+          [ret reports] (capture-reports #(story/is result))]
+      (is (= result ret) "the result is returned verbatim")
+      (is (= 1 (count reports)))
+      (is (= :fail (:type (first reports)))))))
+
+(deftest story-run-returns-unified-result
+  (testing "story/run returns a promise/future of the unified run-result"
+    (story/reg-variant :story.is/run
+      {:tags        #{:test}
+       :play-script {:script [[:dispatch-sync [:is/set-status :loaded]]
+                              [:assert-db [:status] :loaded]]}})
+    (let [p (story/run :story.is/run)
+          result (.get ^java.util.concurrent.CompletableFuture p)]
+      (is (= :pass (:status result)))
+      (is (= :pass (story/result-status result)))
+      (is (true? (story/result-passed? result))))))

--- a/tools/story/test/re_frame/story_play_test.clj
+++ b/tools/story/test/re_frame/story_play_test.clj
@@ -209,10 +209,15 @@
       (story/destroy-variant! :story.stepper/v))))
 
 (deftest play-stepper-walks-every-step-type
-  (testing "rf2-ee38b.3: the step-debugger walks ALL step types — :wait,
-            :assert-db, :assert-dom, :click, :type — not just the dispatch
-            steps the legacy variant-play-events projection surfaced. The
-            cursor/total count every step and assert outcomes surface."
+  (testing "rf2-ee38b.3 / rf2-5x1wt.19: the step-debugger walks ALL step
+            types — :wait, :assert-db, :assert-dom, :click, :type — not
+            just the dispatch steps the legacy variant-play-events
+            projection surfaced. The cursor/total count every step and
+            assert outcomes surface. Per rf2-5x1wt.19 the stepper consumes
+            the FOLDED plan: a shipping :assert-db / :assert-dom step is
+            rewritten to the canonical [:assert assertion-atom] checkpoint,
+            so the recorded step type is :assert and the slot record carries
+            the canonical :rf.assert/path-equals (no synthetic :rf.assert/db)."
     (rf/reg-event-db :st/set-n (fn [db [_ v]] (assoc db :n v)))
     (story/reg-variant :story.stepper/full
       {:events []
@@ -228,7 +233,7 @@
       (loaders/start-loaders! :story.stepper/full)
       (loaders/finish-loaders! :story.stepper/full)
       (play/begin-stepper! :story.stepper/full)
-      ;; The substrate seeds the FULL six-step script.
+      ;; The substrate seeds the FULL six-step folded script.
       (is (= 6 (count (:remaining (get @play/stepper-state :story.stepper/full))))
           "all six steps (incl. :wait / :assert-* / :click) are queued")
       ;; Walk every step.
@@ -238,15 +243,21 @@
         (is (= 6 (count results)) "one result recorded per step")
         (is (= :dispatch-sync (:type (nth results 0))))
         (is (= :wait          (:type (nth results 1))))
+        ;; rf2-5x1wt.19 — folded :assert-db / :assert-dom steps are :assert
+        ;; checkpoints now.
+        (is (= :assert (:type (nth results 2))))
         (is (true?  (:passed? (nth results 2))) ":assert-db [:n] 5 passes")
+        (is (= :assert (:type (nth results 3))))
         (is (false? (:passed? (nth results 3))) ":assert-db [:n] 99 fails")
         (is (:skipped? (nth results 4)) ":assert-dom records :skipped? (no DOM)"))
-      ;; The failing :assert-db landed in the :rf.story/assertions slot.
+      ;; The failing :assert-db landed in the :rf.story/assertions slot as
+      ;; the CANONICAL :rf.assert/path-equals record (rf2-5x1wt.19).
       (let [slot (story/read-assertions :story.stepper/full)]
-        (is (some (fn [r] (and (= :rf.assert/db (:assertion r))
+        (is (some (fn [r] (and (= :rf.assert/path-equals (:assertion r))
                                (false? (:passed? r))))
                   slot)
-            "the stepped rich-DSL :assert-db failure reached the slot too"))
+            "the stepped folded :assert-db failure reached the slot as the
+             canonical :rf.assert/path-equals record"))
       (play/end-stepper! :story.stepper/full)
       (story/destroy-variant! :story.stepper/full))))
 


### PR DESCRIPTION
## Summary

KEYSTONE unification (NewTestStory §B5). Folds Story's three result vocabularies — the runtime's `:lifecycle` map, the play-runner per-step `run-state` machine, and `replay-result` — onto **ONE unified run-result**, assembled by one boundary (`re-frame.story.result/run-result`). Evidential slots are projections from the `.4` epoch tape (no parallel accumulator); the assertion verdict is the one non-tape input. Closes the documented "false GREEN".

### What changed

- **New `re-frame.story.result`** — the run-result / assertion-record / check-record schemas + the unified assembly. `:status` ∈ `#{:pass :fail :cannot-run :error}` derived per record; checks group their assertions by id+payload; the verdict follows `requirements/aggregate-status` plus the agreement floor (`tape-shows-failure?` — no green while the tape is red). Reuses `.4`'s `evidence/project-evidence` as the single tape projection (does not duplicate it).
- **Runtime consumes the `.18`-folded plan** — every script is folded at resolution time (`runner-events/variant-plays` / `variant-play-script`, `play/variant-play-steps`), so `:assert-db` / `:assert-dom` become the canonical `[:assert atom]` checkpoint. The synthetic `:rf.assert/db|dom` rail is gone — one assertion-record vocabulary, one recorder (`exec-assert!`, with a DOM-family executor for `:rf.assert/dom-*`). A `:pred` symbol resolves at validation time so the folded `:rf.assert/path-matches [:fn sym]` works (Malli's `[:fn 'sym]` needs sci).
- **`runtime/record-result-map`** assembles the unified result (keeping `:lifecycle` for API stability; `:status` is NET-NEW per spec §1a).
- **Test mode + CI** consume the unified `:status` — `aggregate-summary` / `record-test-run` / `test-summary` count `:cannot-run` distinctly; `runner/finish` + `ci-runner/terminal?` recognize the third status; the test-mode summary renders it.
- **`story/run` / `story/is` / `story/explain`** verbs + `run-result` / `result-status` / `result-passed?` / `result->reports` / `report-result!` re-exports. `story/is` bridges per-assertion run-result reports to clojure.test / cljs.test (JVM blocks + fires `do-report`; CLJS returns the promise to chain).
- **spec/017 §Unified run result** documents the shape, status rules, tape-derived projection, folded-plan consumption, and the `story/is` bridge.

### Tests

- New `result_test.cljc` (pure): status derivation, assertion/check records, check grouping, the agreement floor, projections-agree-with-the-tape, the `result->reports` projection.
- New `story_is_test.clj` (headless JVM): `story/is` reports per assertion (pass/fail/zero-assertion/already-resolved); `story/run` returns the unified result.
- Updated the `:assert-db`/`:assert-dom`/`:pred` runner-events tests + the stepper test to the folded/canonical behavior; a DOM-skip-only run is now `:cannot-run`.

## Quality gates

| Gate | Result |
|---|---|
| `cd tools/story && clojure -M:test` | PASS — 1117 tests, 3475 assertions, 0 failures, 0 errors |
| `npm --prefix implementation run test:cljs` | PASS — 4850 tests, 15890 assertions, 0 failures, 0 errors (0 warnings) |
| `bash scripts/test-fast-pr.sh` | PASS — CLJS node integration + markdown link/anchor gates green (mkdocs soft-skipped: not on PATH locally; CI runs it) |