### PR TITLE
feat(story): two-level epoch-keyed narrative projection (rf2-5x1wt.23)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -1578,6 +1578,26 @@ when the runner stamps each committed epoch with `:rf.story/script-idx`
 partition across the dispatch steps for a bare `epoch-history` tape. Every
 epoch lands in exactly one span.
 
+**Narrative navigation (the scrub backbone).** The two-level `:narrative`
+is a *tree* (spans over beats), but a Test-mode / Docs-mode **scrub** moves
+*linearly* through every beat in tape order. Four pure helpers flatten the
+tree into the ordered, addressable beat sequence the scrub walks — the
+navigation MATH, JVM-testable independent of any UI:
+
+| Helper | Returns |
+|---|---|
+| `(story/narrative-beats narrative)` | the ordered beat vector; each beat is the inner `epoch-beat` augmented with `:beat-idx` (the 0-based scrub address), `:span-idx`, owning `:step`, and `:span-caption`. Spans with no beats (a pure assertion/wait step) contribute nothing — the scrub only stops on committed epochs |
+| `(story/beat-count narrative)` | the number of scrubbable beats — the scrub slider's extent (positions `0 … (dec beat-count)`) |
+| `(story/beat-at narrative idx)` | the flattened beat at scrub position `idx`, or nil out of range |
+| `(story/beat-epoch-ids narrative)` | the ordered `:epoch-id` vector; the Nth element is the `restore-epoch` target for scrub position N. Aligned 1:1 with `narrative-beats` |
+
+The flattened sequence **agrees with the tape by construction**: every
+committed epoch appears exactly once, in tape order, regardless of how the
+spans group them — none invented, none dropped. The scrub UI (the slider /
+keyboard navigation that calls `restore-epoch` per `beat-epoch-ids`) lives
+ABOVE this boundary and is deferred; only the navigation projection ships
+in P1.
+
 **The agreement floor.** `(story/tape-shows-failure? epoch-tape
 consumed-selectors)` is the consistency invariant: a run MUST NOT be
 reported `:pass` while the tape carries failure evidence — an unconsumed
@@ -1751,7 +1771,12 @@ can copy. P1 makes it first-class:
 Combined with `restore-epoch`, this projection is the spine of **both**
 Test mode and Docs mode: the same evidence produces the test result and a
 scrubbable causal storyboard. This is the move that fuses the testing and
-storytelling halves.
+storytelling halves. The pure navigation backbone — `narrative-beats` /
+`beat-count` / `beat-at` / `beat-epoch-ids`, flattening the span tree into
+the ordered beats a scrub steps through and the `restore-epoch` targets it
+hands them — ships in P1 (§Run-result evidence projection). The scrub
+**UI** that drives `restore-epoch` from a slider is the layer above this
+boundary and is deferred.
 
 ## Canonicalization
 

--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -1028,6 +1028,43 @@
   ([epoch-tape]                     (evidence/tape-shows-failure? epoch-tape))
   ([epoch-tape consumed-selectors]  (evidence/tape-shows-failure? epoch-tape consumed-selectors)))
 
+;; ---- narrative navigation (rf2-5x1wt.23) --------------------------------
+;;
+;; Per spec/017 §Epoch tape and narrative — the pure scrub backbone. The
+;; two-level `:narrative` is a tree (spans over beats); a Test-mode /
+;; Docs-mode scrub moves linearly through every beat. These flatten the
+;; tree into the ordered, addressable beat sequence the scrub walks and the
+;; parallel `:epoch-id` vector it hands to `restore-epoch`. The scrub UI is
+;; deferred; the navigation math is JVM-testable here.
+
+(defn narrative-beats
+  "Per spec/017 §Epoch tape and narrative — flatten a two-level
+  `narrative` (the `:narrative` run-result slot) into the ordered vector of
+  beats a scrub walks linearly, each augmented with its `:beat-idx` (scrub
+  address), `:span-idx`, owning `:step`, and `:span-caption`. Pure data →
+  data."
+  [narrative]
+  (evidence/narrative-beats narrative))
+
+(defn beat-count
+  "Per spec/017 §Epoch tape and narrative — the number of scrubbable beats
+  in a two-level `narrative` (the scrub slider's extent). Pure data → data."
+  [narrative]
+  (evidence/beat-count narrative))
+
+(defn beat-at
+  "Per spec/017 §Epoch tape and narrative — the flattened beat at 0-based
+  scrub position `idx`, or nil out of range. Pure data → data."
+  [narrative idx]
+  (evidence/beat-at narrative idx))
+
+(defn beat-epoch-ids
+  "Per spec/017 §Epoch tape and narrative — the ordered `:epoch-id` vector
+  for a two-level `narrative`; the Nth element is the `restore-epoch`
+  target for scrub position N. Pure data → data."
+  [narrative]
+  (evidence/beat-epoch-ids narrative))
+
 ;; ---- run artifact + replay (rf2-5x1wt.7) --------------------------------
 ;;
 ;; Per spec/017 §Run artifact and replay — the serializable

--- a/tools/story/src/re_frame/story/play/evidence.cljc
+++ b/tools/story/src/re_frame/story/play/evidence.cljc
@@ -48,6 +48,24 @@
   bootstrap) collect under a leading `nil`-step span so no tape evidence is
   silently dropped.
 
+  ## Narrative navigation (the scrub backbone)
+
+  The two-level `:narrative` is a TREE (spans over beats); a Test-mode /
+  Docs-mode *scrub* moves linearly through every beat in tape order. The
+  navigation helpers (`narrative-beats` / `beat-count` / `beat-at` /
+  `beat-epoch-ids`) FLATTEN the tree into the ordered, addressable beat
+  sequence the scrub walks, WITHOUT discarding the span context: each
+  flattened beat keeps its `:beat-idx` (the 0-based scrub address), its
+  owning `:span-idx` + `:step` + span `:caption`, and is otherwise the
+  inner beat verbatim. The 0-based `:beat-idx` is the scrub-slider position
+  and the index into `beat-epoch-ids`, whose Nth element is the
+  `:epoch-id` a scrub at position N hands to `restore-epoch` (spec/017
+  §Epoch tape and narrative — \"Combined with `restore-epoch`, this
+  projection is the spine of both Test mode and Docs mode\"). These are
+  PURE data primitives: the scrub UI (the slider / keyboard navigation that
+  calls `restore-epoch`) is deferred and lives above this boundary, so the
+  navigation MATH is JVM-testable independent of any UI.
+
   ## The agreement invariant
 
   `tape-shows-failure?` is the consistency floor the bead's acceptance
@@ -435,6 +453,81 @@
                          {:cursor 0 :ord 0 :acc []}
                          steps)]
         (:acc result)))))
+
+;; ===========================================================================
+;; NARRATIVE NAVIGATION  (spec/017 §Epoch tape and narrative — the scrub backbone)
+;; ===========================================================================
+;;
+;; The two-level `:narrative` is a TREE: spans over beats. A Test-mode /
+;; Docs-mode *scrub* moves LINEARLY through every beat in tape order. These
+;; pure helpers flatten the tree into the ordered, addressable beat
+;; sequence the scrub walks — each flattened beat keeps its 0-based
+;; `:beat-idx` (the scrub address) plus its owning `:span-idx` / `:step` /
+;; span `:caption`, so a UI can show "beat 3 of 7, under step
+;; [:dispatch …]". `beat-epoch-ids` is the parallel `:epoch-id` vector the
+;; scrub hands to `restore-epoch` — its Nth element is the time-travel
+;; target for scrub position N. The scrub UI itself is deferred and lives
+;; ABOVE this boundary; the navigation MATH stays JVM-testable here.
+
+(defn narrative-beats
+  "Flatten a two-level `narrative` (a span vector, the `:narrative`
+  run-result slot) into the ordered vector of beats a scrub walks linearly,
+  in tape order. Pure data → data.
+
+  Each returned beat is the inner `epoch-beat` map augmented with its
+  navigation context:
+
+  - `:beat-idx`     — the 0-based scrub address (index into this vector and
+                      into `beat-epoch-ids`);
+  - `:span-idx`     — the 0-based index of the owning span in `narrative`;
+  - `:step`         — the owning span's authored script step (nil for the
+                      leading pre-script / setup span);
+  - `:span-caption` — the owning span's `:caption`, when it carries one.
+
+  Spans with no beats (a pure assertion / wait step, or a dispatch step
+  that committed no epoch) contribute nothing to the flattened sequence —
+  the scrub only stops on beats that actually committed an epoch. The
+  beat's own slots (`:epoch-id` / `:db-before` / `:db-after` / `:effects`
+  / `:sub-runs` / `:renders` / `:trace-events` / `:trigger-event` /
+  `:dispatch-id`) ride through verbatim."
+  [narrative]
+  (into []
+        (comp
+          (map-indexed
+            (fn [span-idx {:keys [step caption epochs]}]
+              (map (fn [beat]
+                     (cond-> (assoc beat :span-idx span-idx :step step)
+                       (some? caption) (assoc :span-caption caption)))
+                   epochs)))
+          cat
+          (map-indexed (fn [beat-idx beat] (assoc beat :beat-idx beat-idx))))
+        (or narrative [])))
+
+(defn beat-count
+  "Total number of scrubbable beats in a two-level `narrative` — the number
+  of epochs the run committed, regardless of how the spans group them. Pure
+  data → data. The scrub slider's extent (positions `0 … (dec beat-count)`)."
+  [narrative]
+  (count (narrative-beats narrative)))
+
+(defn beat-at
+  "The flattened beat at 0-based scrub position `idx` in `narrative`, or nil
+  when `idx` is out of range (a defensive guard for a scrub past either
+  end). Pure data → data."
+  [narrative idx]
+  (let [beats (narrative-beats narrative)]
+    (when (and (integer? idx) (<= 0 idx) (< idx (count beats)))
+      (nth beats idx))))
+
+(defn beat-epoch-ids
+  "The ordered `:epoch-id` vector for a two-level `narrative` — the
+  `restore-epoch` targets a scrub steps through, one per scrub position.
+  Pure data → data. `(nth (beat-epoch-ids narrative) idx)` is the epoch a
+  scrub at position `idx` time-travels to via `restore-epoch`; the scrub UI
+  (deferred) wires this to the slider. Aligned 1:1 with
+  `narrative-beats` (same order, same length)."
+  [narrative]
+  (mapv :epoch-id (narrative-beats narrative)))
 
 ;; ===========================================================================
 ;; THE AGREEMENT INVARIANT  (bead acceptance: no green-while-tape-red)

--- a/tools/story/test/re_frame/story/play/evidence_test.cljc
+++ b/tools/story/test/re_frame/story/play/evidence_test.cljc
@@ -189,6 +189,110 @@
       (is (= 1 total-beats) "the single epoch is not dropped")
       (is (= [1] (mapv :epoch-id (:epochs (first n)))) "front-loaded onto the first step"))))
 
+(deftest narrative-beat-carries-full-spec-shape
+  (testing "each inner beat carries every spec/017 §Run result beat slot"
+    (let [script [[:dispatch [:checkout/submit]]]
+          tape   [(epoch 1 {:dispatch-id   100
+                            :trigger-event [:checkout/submit]
+                            :db-before     {:step :a}
+                            :db-after      {:step :b}
+                            :effects       [{:fx-id :db :outcome :ok}]
+                            :sub-runs      [{:sub-id :total :recomputed? true}]
+                            :renders       [{:render-key [:cart 0]}]
+                            :trace-events  [(run-start-trace 10 [:checkout/submit] 100)]})]
+          beat   (first (:epochs (first (evidence/narrative script tape))))]
+      (is (= 1 (:epoch-id beat)))
+      (is (= 100 (:dispatch-id beat)))
+      (is (= [:checkout/submit] (:trigger-event beat)))
+      (is (= {:step :a} (:db-before beat)))
+      (is (= {:step :b} (:db-after beat)))
+      (is (= [{:fx-id :db :outcome :ok}] (:effects beat)))
+      (is (= [{:sub-id :total :recomputed? true}] (:sub-runs beat)))
+      (is (= [{:render-key [:cart 0]}] (:renders beat)))
+      (is (= 1 (count (:trace-events beat)))))))
+
+(deftest narrative-span-carries-author-caption
+  (testing "a [:dispatch evec {:caption …}] step surfaces the caption on its span"
+    (let [script [[:dispatch [:checkout/submit] {:caption "submit the order"}]]
+          tape   [(epoch 1 {:trigger-event [:checkout/submit]})]
+          span   (first (evidence/narrative script tape))]
+      (is (= "submit the order" (:caption span)))
+      ;; a step with no caption map carries no :caption key
+      (let [no-cap (first (evidence/narrative [[:dispatch [:x]]]
+                                              [(epoch 1 {})]))]
+        (is (not (contains? no-cap :caption)))))))
+
+;; ===========================================================================
+;; NARRATIVE NAVIGATION — the scrub backbone (rf2-5x1wt.23)
+;; ===========================================================================
+
+(deftest narrative-beats-flatten-tree-in-tape-order
+  (testing "the two-level tree flattens to an ordered beat sequence with nav context"
+    (let [script [[:dispatch [:a]] [:assert-db [:k] 1] [:dispatch [:b]]]
+          tape   [(epoch 1 {:rf.story/script-idx nil :trigger-event [:setup]})
+                  (epoch 2 {:rf.story/script-idx 0   :trigger-event [:a]})
+                  (epoch 3 {:rf.story/script-idx 0   :trigger-event [:a2]})
+                  (epoch 4 {:rf.story/script-idx 2   :trigger-event [:b]})]
+          n      (evidence/narrative script tape)
+          beats  (evidence/narrative-beats n)]
+      (is (= 4 (count beats)) "the assert step contributes no beat; every committed epoch appears")
+      (is (= [0 1 2 3] (mapv :beat-idx beats)) "beat-idx is the dense 0-based scrub address")
+      (is (= [1 2 3 4] (mapv :epoch-id beats)) "beats are in tape order")
+      ;; span context rides through: setup leads (span 0, nil step), step 0
+      ;; owns its two beats (span 1), the :dispatch [:b] beat is span 3.
+      (is (= [0 1 1 3] (mapv :span-idx beats)))
+      (is (= [nil [:dispatch [:a]] [:dispatch [:a]] [:dispatch [:b]]]
+             (mapv :step beats)) "each beat carries its owning span's step"))))
+
+(deftest narrative-beats-skip-empty-spans
+  (testing "pure assertion / wait spans (no beats) contribute nothing to the scrub"
+    (let [script [[:assert-db [:k] 1] [:wait 10]]
+          tape   [(epoch 1 {})]
+          beats  (evidence/narrative-beats (evidence/narrative script tape))]
+      (is (= 1 (count beats)) "only the one leading committed epoch is scrubbable")
+      (is (= 0 (:beat-idx (first beats))))
+      (is (nil? (:step (first beats))) "it leads under the nil setup span"))))
+
+(deftest narrative-beats-carry-span-caption
+  (testing "a captioned span stamps :span-caption onto each of its beats"
+    (let [script [[:dispatch [:a] {:caption "do the thing"}]]
+          tape   [(epoch 1 {}) (epoch 2 {})]
+          beats  (evidence/narrative-beats (evidence/narrative script tape))]
+      (is (= ["do the thing" "do the thing"] (mapv :span-caption beats))))))
+
+(deftest beat-count-and-beat-at-and-epoch-ids
+  (testing "scrub extent, addressing, and restore-epoch targets"
+    (let [script [[:dispatch [:a]]]
+          tape   [(epoch 10 {}) (epoch 11 {}) (epoch 12 {})]
+          n      (evidence/narrative script tape)]
+      (is (= 3 (evidence/beat-count n)) "scrub slider extent = committed-epoch count")
+      (is (= 10 (:epoch-id (evidence/beat-at n 0))))
+      (is (= 12 (:epoch-id (evidence/beat-at n 2))))
+      (is (nil? (evidence/beat-at n 3))  "scrub past the end is nil")
+      (is (nil? (evidence/beat-at n -1)) "scrub before the start is nil")
+      (is (= [10 11 12] (evidence/beat-epoch-ids n))
+          "the ordered restore-epoch targets, one per scrub position")
+      ;; beat-epoch-ids aligns 1:1 with narrative-beats
+      (is (= (evidence/beat-epoch-ids n)
+             (mapv :epoch-id (evidence/narrative-beats n)))))))
+
+(deftest navigation-agrees-with-the-tape
+  (testing "the flattened scrub sequence agrees with the retained epoch tape (§B9)"
+    ;; Every committed epoch in the tape appears exactly once in the scrub,
+    ;; in tape order — no beat invented, none dropped, regardless of the
+    ;; span grouping. This is the §B9 'narrative data AGREES with the
+    ;; retained epoch tape' acceptance, at the navigation layer.
+    (let [script   [[:dispatch [:a]] [:wait 5] [:dispatch [:b]]]
+          tape     [(epoch 1 {:rf.story/script-idx 0})
+                    (epoch 2 {:rf.story/script-idx 0})
+                    (epoch 3 {:rf.story/script-idx 2})]
+          n        (evidence/narrative script tape)
+          beat-ids (evidence/beat-epoch-ids n)]
+      (is (= (mapv :epoch-id tape) beat-ids)
+          "scrub epoch-ids are exactly the tape's epoch-ids, in order")
+      (is (= (count tape) (evidence/beat-count n))
+          "one scrub position per committed epoch — none dropped, none invented"))))
+
 ;; ===========================================================================
 ;; AGREEMENT INVARIANT — no green while tape is red
 ;; ===========================================================================


### PR DESCRIPTION
@-

## Quality gates

- `cd tools/story && clojure -M:test` — **1129 tests / 3558 assertions, 0F/0E**
- `cd tools/story-mcp && clojure -M:test` — **172 / 861, 0F/0E**
- story-mcp MCP-client conformance (`npm run test:story`) — **GREEN, exit 0**
- `npm --prefix implementation run test:cljs` — **4850 / 15890, 0F/0E**
- `bash scripts/test-fast-pr.sh` — **PASS** (mkdocs soft-skipped locally, runs in CI)

_(QG section added by mayor from the worker's completion report.)_
