### PR TITLE
feat(story): route runtime through the variant plan + public verbs (rf2-5x1wt.22)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -101,15 +101,23 @@ spellings and enforces that an author picks ONE setup surface
 (`:setup` xor `:events`) and ONE play surface
 (`:script` xor `:play-script` xor `:plays`). The registrar's
 `schemas/lower-public-vocabulary` step folds `:setup` → `:events` and
-`:script` → `:play-script` into the stored body so every shipping
-RUNTIME reader — phase-2 events, the play runner's `variant-body->plays`,
-snapshot identity, the workspace/canvas readers, and the recorder —
-consumes the shipping slot unchanged while the tree migrates. This
-lowering is the sanctioned temporary normalization, not a long-lived
-shim: it is removed once the runtime is routed through the variant-plan
-compiler (which already normalizes both spellings, §Compiler API and
-normalization contract). Until then, a variant authored with `:setup` /
-`:script` runs identically to one authored with the shipping slots.
+`:script` → `:play-script` into the stored body so every shipping slot
+reader sees the shipping spelling while the tree migrates. The
+**`run-variant` lifecycle runtime is now routed through the variant-plan
+compiler** (rf2-5x1wt.22): `re-frame.story.runtime/prepare-context`
+compiles the normalized plan once, phase 2 dispatches the plan's
+`[:world :setup]` (the parent story's id-grammar `:events` prepended),
+and phase 4 drives the plan's `[:world :scripts]` (the named plays,
+`:plays` preserved). The compiler normalizes both spellings, so the
+lifecycle no longer depends on the lowering. The lowering REMAINS for the
+remaining shipping-slot readers that are NOT yet plan-routed — snapshot
+identity (`re-frame.story.identity`), the workspace/canvas readers, and
+the recorder — and for the play-runner's `variant-body->plays` (still
+consulted by the live-canvas auto-run + step-debugger paths). It is fully
+removed once those readers also consume the plan. A variant authored with
+`:setup` / `:script` runs identically to one authored with the shipping
+slots, and through the plan-routed lifecycle a composed `:compose`
+fragment's `:setup` is now executed in phase 2.
 
 ### Four-bucket authoring model
 
@@ -1634,11 +1642,14 @@ silent pass); a zero-assertion clean run is `:pass` (vacuously green).
 
 **The runtime consumes the folded plan.** The `.18` fold (`:assert-db` /
 `:assert-dom` → the canonical `[:assert assertion-atom]` checkpoint) is
-applied at script-resolution time (`runner-events/variant-plays` /
-`variant-play-script` / `play/variant-play-steps` all run
-`assertions/fold-script`), so the runtime drives the ONE assertion atom in
-its checkpoint position — there is **no synthetic `:rf.assert/db` /
-`:rf.assert/dom` rail**. A folded `:assert-db` dispatches the real
+applied at script-resolution time. The `run-variant` lifecycle drives the
+**plan's `[:world :scripts]`** (folded by the compiler's `normalize-scripts`,
+rf2-5x1wt.22); the live-canvas auto-run + step-debugger paths fold at their
+own resolution sites (`runner-events/variant-plays` / `variant-play-script`
+/ `play/variant-play-steps` all run `assertions/fold-script`). Either way
+the runtime drives the ONE assertion atom in its checkpoint position —
+there is **no synthetic `:rf.assert/db` / `:rf.assert/dom` rail**. A folded
+`:assert-db` dispatches the real
 `:rf.assert/path-equals` (or, for the `:pred` form, `:rf.assert/path-matches`
 wrapping a `[:fn …]` schema — a `[:fn sym]` symbol resolves at validation
 time) handler, which records the canonical record; a folded `:assert-dom` is

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -604,18 +604,28 @@
           nil))))
 
 (defn- plan-construction-error?
-  "True iff `e` is a plan-construction failure — an `ex-info` whose
-  ex-data carries a `:rf.error/id` (the marker `re-frame.story.plan/fail!`
-  stamps on every `:rf.error/story-*` failure). rf2-5x1wt.22 (§B8): the
-  runtime compiles the plan in `prepare-context`, BEFORE the frame is
+  "True iff `e` is a plan-construction failure — an `ex-info` `re-frame.
+  story.plan/fail!` threw. `fail!` stamps `:where 'rf.story/variant-plan`
+  on every `:rf.error/story-*` failure, so that marker (NOT the bare
+  presence of `:rf.error/id`) is the discriminator. rf2-5x1wt.22 (§B8):
+  the runtime compiles the plan in `prepare-context`, BEFORE the frame is
   allocated, so a malformed variant (a missing `[:arg …]`, an `[:assert …]`
   in `:setup`, a `:compose` of an unknown fragment, …) throws here. Such
   an error cannot be recorded onto a frame (none exists yet), so it is
   projected directly into a structured error result (`plan-error-result`)
   rather than routed through `handle-run-error!` (which assumes an
-  allocated frame)."
+  allocated frame).
+
+  Matching on `:where` (not on any `:rf.error/id`) is load-bearing:
+  framework runtime errors thrown LATER in the phase chain also carry an
+  `:rf.error/id` — e.g. `:rf.error/no-adapter-installed` from
+  `reg-frame` → `make-state-container` when the host installed no
+  adapter (the JVM-standalone story-mcp server). Those land after the
+  frame exists at `:pre-mount`, so they must take the frame-bound
+  record/transition branch, NOT `plan-error-result` (rf2-5x1wt.22
+  follow-through)."
   [e]
-  (boolean (:rf.error/id (ex-data e))))
+  (= 'rf.story/variant-plan (:where (ex-data e))))
 
 (defn- exception-message [e]
   #?(:clj  (.getMessage ^Throwable e)

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -143,17 +143,62 @@
 
 ;; ---- phase-2 events execution --------------------------------------------
 
-(defn- run-events!
-  "Phase 2: dispatch every event in `:events` (story-level concat
-  variant-level) into the variant's frame, draining between each. Per
-  IMPL-SPEC §5.4 phase 2."
-  [variant-id]
-  (let [variant-body (frames/variant-body variant-id)
-        story-id     (args/parent-story-id variant-id)
+(defn- setup-step->event
+  "Extract the event vector a normalized `[:world :setup]` step carries.
+  Per spec/017 §Setup, setup steps are settled dispatches — the plan
+  compiler coerces every authored setup entry (bare event vector OR a
+  tagged `[:dispatch …]` / `[:dispatch-sync …]`) into a tagged dispatch
+  step, and an `[:assert …]` in setup is rejected at plan-compile time
+  (`re-frame.story.plan/reject-assert-in-setup!`). So a setup step is
+  always `[:dispatch event-vector]` / `[:dispatch-sync event-vector]`;
+  this returns the wrapped event vector (or the step itself when a
+  bare event vector slipped through an out-of-band path)."
+  [step]
+  (cond
+    (and (vector? step)
+         (#{:dispatch :dispatch-sync} (first step))
+         (vector? (second step)))
+    (second step)
+
+    ;; Defensive: a bare event vector (an out-of-band plan that bypassed
+    ;; coercion). Treat it as the event itself.
+    (and (vector? step) (keyword? (first step)))
+    step
+
+    :else nil))
+
+(defn- plan-setup-events
+  "The phase-2 event vectors for a run: the parent STORY's `:events`
+  (resolved by id-grammar, NOT part of the variant plan — the plan
+  compiler only resolves the `:extends` chain + composed fragments)
+  prepended to the NORMALIZED PLAN's `[:world :setup]` steps
+  (rf2-5x1wt.22, §B8 — phase 2 consumes the plan's `:setup`).
+
+  The story-level events keep their existing id-grammar resolution so
+  `story.foo/bar` still inherits `story.foo`'s preconditions; the
+  variant-chain + composed-fragment setup comes from the plan, where
+  `:extends` setup APPENDS root→child and `:setup` / `:events` are both
+  lowered to the one slot (spec/017 §Merge rules)."
+  [variant-id plan]
+  (let [story-id     (args/parent-story-id variant-id)
         story-body   (when story-id (registrar/handler-meta :story story-id))
         story-events (or (:events story-body) [])
-        var-events   (or (:events variant-body) [])
-        all-events   (concat story-events var-events)]
+        plan-setup   (get-in plan [:world :setup] [])]
+    (vec (concat story-events
+                 (keep setup-step->event plan-setup)))))
+
+(defn- run-events!
+  "Phase 2: dispatch every phase-2 event into the variant's frame,
+  draining between each. Per IMPL-SPEC §5.4 phase 2.
+
+  rf2-5x1wt.22 (§B8) — the variant-chain + composed-fragment setup now
+  comes from the NORMALIZED PLAN's `[:world :setup]` (the tagged dispatch
+  steps the compiler lowered `:setup` / `:events` into), routed through
+  `plan-setup-events`. The parent story's `:events` (resolved by id
+  grammar, not part of the plan) are prepended. The `dispatch-sync` +
+  per-event exception-drain semantics are preserved verbatim."
+  [variant-id plan]
+  (let [all-events (plan-setup-events variant-id plan)]
     (capture-phase-errors
       variant-id :phase-2-events
       (fn []
@@ -423,17 +468,30 @@
             :lifecycle       (loaders/current-state variant-id)})))
 
 (defn- prepare-context
-  "Resolve the per-run inputs that every phase needs: the decorator
-  stack, the effective args, and the identity snapshot. Returns a map;
-  pure aside from the registrar reads.
+  "Resolve the per-run inputs that every phase needs: the NORMALIZED
+  PLAN, the decorator stack, the effective args, and the identity
+  snapshot. Returns a map; pure aside from the registrar reads.
+
+  rf2-5x1wt.22 (§B8 — Runtime Migration) — the shipping run-variant path
+  now routes through the variant-plan compiler (`re-frame.story.plan`).
+  `prepare-context` compiles the normalized plan ONCE and threads it
+  down the phase pipeline (spec/017 §Variant plan — every registered
+  variant MUST be normalized before execution). Phase 2 consumes the
+  plan's `[:world :setup]` (the tagged setup steps); phase 4 consumes
+  its `[:world :scripts]` (the named scripts — `:plays` preserved). A
+  plan-construction failure (an unknown variant, a missing `[:arg …]`,
+  a misplaced `[:assert …]` in setup, …) throws here; the orchestrator's
+  try/catch (`handle-run-error!`) projects it onto the run result so the
+  error reports the same way it did before the routing.
 
   rf2-0wrud (2026-05-20): the legacy `:play` event-vector slot was
-  removed; phase-4 reads `:play-script` (parsed via the runner) and
-  drives the rich-DSL step executor through `runner-events/run!`."
+  removed; phase-4 drives the rich-DSL step executor through
+  `runner-events/run!`."
   [variant-id variant-body opts]
   (let [{:keys [active-modes]} opts]
     {:variant-id      variant-id
      :variant-body    variant-body
+     :plan            (plan/variant-plan variant-id)
      :decorator-stack (decorators/resolve-decorators variant-id
                                                      {:active-modes active-modes})
      :effective-args  (args/resolve-args variant-id opts)
@@ -464,11 +522,12 @@
   (assoc ctx :loaders-complete? (run-loaders! variant-id)))
 
 (defn- run-phase-2!
-  "Phase 2: dispatch every `:events` entry, then mark events complete
-  on the lifecycle machine."
-  [{:keys [variant-id loaders-complete?] :as ctx}]
+  "Phase 2: dispatch the plan's `[:world :setup]` (+ the parent story's
+  `:events`), then mark events complete on the lifecycle machine.
+  rf2-5x1wt.22 (§B8) — setup is sourced from the normalized plan."
+  [{:keys [variant-id loaders-complete? plan] :as ctx}]
   (when loaders-complete?
-    (run-events! variant-id)
+    (run-events! variant-id plan)
     (loaders/finish-events! variant-id))
   ctx)
 
@@ -486,17 +545,25 @@
   by wrapping each entry in `[:dispatch-sync <event-vec>]` inside a
   `:play-script` body.
 
-  rf2-5x1wt.19 — `runner-events/variant-plays` now returns FOLDED play
-  scripts (shipping `:assert-db` / `:assert-dom` rewritten to the canonical
-  `[:assert …]` checkpoint), so the runtime consumes the `.18`-folded plan
-  and the executed-script narrative carries the one assertion atom.
+  rf2-5x1wt.19 — the resolved play scripts are FOLDED (shipping
+  `:assert-db` / `:assert-dom` rewritten to the canonical `[:assert …]`
+  checkpoint), so the executed-script narrative carries the one
+  assertion atom.
+
+  rf2-5x1wt.22 (§B8) — the play set now comes from the NORMALIZED PLAN's
+  `[:world :scripts]` (the named scripts the compiler's `normalize-scripts`
+  produces — `:plays` preserved as named scripts, spec/017 §Public
+  vocabulary), NOT a second `runner-events/variant-plays` read of the
+  registered body. The compiler already coerces + folds every script, so
+  the plan's `:scripts` carry the `{:script :auto-run? :name}` shape the
+  runner drives directly.
 
   Phase 3 (render) is Stage 4's UI-shell concern and is not driven
   from this orchestrator."
-  [{:keys [variant-id loaders-complete?] :as ctx}]
+  [{:keys [variant-id loaders-complete? plan] :as ctx}]
   (if-not loaders-complete?
     [ctx (async/resolved (read-assertions variant-id))]
-    (let [plays      (runner-events/variant-plays variant-id)
+    (let [plays      (get-in plan [:world :scripts] [])
           auto-plays (filterv (fn [p] (and (:auto-run? p)
                                             (seq (:script p))))
                               plays)
@@ -536,6 +603,45 @@
           (resolve (record-result-map ctx start-ms))
           nil))))
 
+(defn- plan-construction-error?
+  "True iff `e` is a plan-construction failure — an `ex-info` whose
+  ex-data carries a `:rf.error/id` (the marker `re-frame.story.plan/fail!`
+  stamps on every `:rf.error/story-*` failure). rf2-5x1wt.22 (§B8): the
+  runtime compiles the plan in `prepare-context`, BEFORE the frame is
+  allocated, so a malformed variant (a missing `[:arg …]`, an `[:assert …]`
+  in `:setup`, a `:compose` of an unknown fragment, …) throws here. Such
+  an error cannot be recorded onto a frame (none exists yet), so it is
+  projected directly into a structured error result (`plan-error-result`)
+  rather than routed through `handle-run-error!` (which assumes an
+  allocated frame)."
+  [e]
+  (boolean (:rf.error/id (ex-data e))))
+
+(defn- exception-message [e]
+  #?(:clj  (.getMessage ^Throwable e)
+     :cljs (str e)))
+
+(defn- plan-error-result
+  "The error result returned when `re-frame.story.plan/variant-plan`
+  FAILS to compile the variant (rf2-5x1wt.22, §B8). The frame is not
+  allocated when plan construction throws, so the result is built
+  directly from the exception — mirroring `unknown-variant-result`'s
+  frame-free shape. The `:rf.error/story-*` id rides the assertion record
+  so tools surface the plan failure the same way a registration failure
+  surfaces."
+  [variant-id e]
+  (assoc (empty-result variant-id)
+         :status     :error
+         :lifecycle  :error
+         :assertions [{:assertion  (or (:rf.error/id (ex-data e))
+                                       :rf.error/story-plan-invalid)
+                       :variant-id variant-id
+                       :status     :error
+                       :passed?    false
+                       :reason     (exception-message e)
+                       :error      {:message (exception-message e)
+                                    :data    (ex-data e)}}]))
+
 (defn- handle-run-error!
   "Catch-branch for the orchestrator: record the exception as a
   phase-0-setup assertion (covers any sync throw from the phase chain),
@@ -543,11 +649,21 @@
   best result map we can build from whatever the run accumulated. The
   recorded `:rf.error/exception` assertion (`:passed? false`) flows into
   the unified result's `:assertions`, so the aggregation reports `:fail`
-  (the error record is a failed expectation) even when the tape is sparse."
+  (the error record is a failed expectation) even when the tape is sparse.
+
+  rf2-5x1wt.22 (§B8) — a plan-construction failure (thrown in
+  `prepare-context`, before frame allocation) cannot be recorded onto a
+  frame, so it is projected directly via `plan-error-result`. Every other
+  throw lands after the frame exists and routes through the frame-bound
+  record/transition path."
   [resolve variant-id e start-ms]
-  (record-error! variant-id :phase-0-setup nil e)
-  (loaders/error! variant-id (ex-data e))
-  (resolve (record-result-map {:variant-id variant-id} start-ms)))
+  (if (and (plan-construction-error? e)
+           (= :pre-mount (loaders/current-state variant-id)))
+    (resolve (plan-error-result variant-id e))
+    (do
+      (record-error! variant-id :phase-0-setup nil e)
+      (loaders/error! variant-id (ex-data e))
+      (resolve (record-result-map {:variant-id variant-id} start-ms)))))
 
 (defn- unknown-variant-result
   "The error result returned when `frames/variant-body` finds no

--- a/tools/story/test/re_frame/story_runtime_test.clj
+++ b/tools/story/test/re_frame/story_runtime_test.clj
@@ -808,6 +808,110 @@
     (story/destroy-variant! :story.reset/v)))
 
 ;; ===========================================================================
+;; PLAN-ROUTED RUNTIME (rf2-5x1wt.22 — §B8 Runtime Migration)
+;;
+;; The runtime now routes phase 2 (setup) and phase 4 (script) through the
+;; normalized variant plan (`re-frame.story.plan`) rather than reading the
+;; shipping `:events` / `:play-script` slots off the registered body. These
+;; tests pin the migration's load-bearing behaviour: the PUBLIC `:setup` /
+;; `:script` vocabulary runs, composed-fragment setup is executed in
+;; phase 2 (a behaviour the pre-migration runtime did NOT deliver — it
+;; ignored `:compose` entirely for setup), and named `:plays` remain
+;; driven as named scripts.
+;; ===========================================================================
+
+(deftest run-variant-public-setup-and-script-vocabulary
+  (testing "a variant authored with the PUBLIC :setup / :script keys runs
+            through the plan-routed runtime (setup applied, script asserts)"
+    (rf/reg-event-db :test/seed
+      (fn [db _] (assoc db :seeded? true :count 0)))
+    (rf/reg-event-db :test/bump
+      (fn [db _] (update db :count inc)))
+    (story/reg-variant :story.public/v
+      {:setup  [[:test/seed]]
+       :script [[:dispatch [:test/bump]]
+                [:assert [:rf.assert/path-equals [:count] 1]]]})
+    (let [r (async/deref-blocking (story/run-variant :story.public/v) 5000)]
+      (is (= :ready (:lifecycle r)))
+      (is (true? (-> r :app-db :seeded?))
+          ":setup ran through the plan's [:world :setup]")
+      (is (= 1 (-> r :app-db :count))
+          ":script :dispatch ran through the plan's [:world :scripts]")
+      (is (= :pass (:status r))
+          "the in-script [:assert …] checkpoint passed")
+      (let [pe (->> (:assertions r)
+                    (filter #(= :rf.assert/path-equals (:assertion %)))
+                    first)]
+        (is (some? pe) "the checkpoint assertion was recorded")
+        (is (true? (:passed? pe)))))
+    (story/destroy-variant! :story.public/v)))
+
+(deftest run-variant-composed-fragment-setup-runs-in-phase-2
+  (testing "a :compose fragment's :setup is executed in phase 2 — the plan
+            compiler resolves :compose, so fragment preconditions land in
+            the frame (the pre-migration runtime ignored :compose for setup)"
+    (rf/reg-event-db :test/frag-seed
+      (fn [db _] (assoc db :from-fragment :alice)))
+    (rf/reg-event-db :test/observe-frag
+      (fn [db _] (assoc db :observed (:from-fragment db))))
+    (story/reg-fragment :fragment.test/seeded
+      {:setup [[:test/frag-seed]]})
+    (story/reg-variant :story.compose/v
+      {:compose [:fragment.test/seeded]
+       :setup   [[:test/observe-frag]]})
+    (let [r (async/deref-blocking (story/run-variant :story.compose/v) 5000)]
+      (is (= :ready (:lifecycle r)))
+      (is (= :alice (-> r :app-db :from-fragment))
+          "the composed fragment's :setup ran")
+      (is (= :alice (-> r :app-db :observed))
+          "fragment setup APPENDS BEFORE the variant's own setup (the
+           variant's observe step saw the fragment's seed)"))
+    (story/destroy-variant! :story.compose/v)))
+
+(deftest run-variant-named-plays-from-plan
+  (testing "a variant's named :plays are driven as named scripts from the
+            plan's [:world :scripts] (auto-run? default: first true, rest
+            false — only the first auto-play executes on run)"
+    (rf/reg-event-db :test/init-n
+      (fn [db [_ n]] (assoc db :n n)))
+    (story/reg-variant :story.plays/v
+      {:plays [{:name      "happy"
+                :script    [[:dispatch-sync [:test/init-n 3]]
+                            [:assert [:rf.assert/path-equals [:n] 3]]]}
+               {:name      "edge"
+                :auto-run? false
+                :script    [[:dispatch-sync [:test/init-n 0]]
+                            [:assert [:rf.assert/path-equals [:n] 0]]]}]})
+    (let [r (async/deref-blocking (story/run-variant :story.plays/v) 5000)]
+      (is (= :ready (:lifecycle r)))
+      (is (= 3 (-> r :app-db :n))
+          "only the first (auto-run?) play executed")
+      (is (= :pass (:status r))
+          "the first play's checkpoint passed"))
+    (story/destroy-variant! :story.plays/v)))
+
+(deftest run-variant-plan-error-projects-as-run-error
+  (testing "a plan-construction failure (an [:assert …] checkpoint placed
+            in :setup) surfaces through the run-error projection rather
+            than crashing the orchestrator"
+    (rf/reg-event-db :test/noop (fn [db _] db))
+    (story/reg-variant :story.planerr/v
+      {:setup [[:dispatch [:test/noop]]
+               [:assert [:rf.assert/path-equals [:x] 1]]]})
+    (let [r (async/deref-blocking (story/run-variant :story.planerr/v) 5000)]
+      (is (= :error (:lifecycle r))
+          "the plan-compile failure rolled the lifecycle to :error")
+      (is (= :error (:status r))
+          "the unified verdict is :error")
+      (let [exc (->> (:assertions r)
+                     (filter #(= :rf.error/story-assert-in-setup (:assertion %)))
+                     first)]
+        (is (some? exc)
+            "the structured :rf.error/story-* id rides the assertion record")
+        (is (false? (:passed? exc)))))
+    (story/destroy-variant! :story.planerr/v)))
+
+;; ===========================================================================
 ;; FRAME-META INTROSPECTION
 ;; ===========================================================================
 


### PR DESCRIPTION
## What

Routes the shipping `run-variant` lifecycle behind the variant-plan compiler (`re-frame.story.plan`), per `tools/story/spec/017-Testing-Story.md` §B8 (Runtime Migration). The `story/run` / `story/is` / `story/explain` public verbs already delegate to this lifecycle, so this is the final wiring that puts the normalized plan on the shipping execution path.

### Changes (`tools/story/src/re_frame/story/runtime.cljc`)

- **`prepare-context`** compiles the normalized plan once (`plan/variant-plan`) and threads it down the phase pipeline — every variant is normalized before execution (§Variant plan).
- **Phase 2** dispatches the plan's `[:world :setup]` (the parent story's id-grammar `:events` prepended), via a new `plan-setup-events` + `setup-step->event`. The `dispatch-sync` + per-event exception-drain semantics are preserved verbatim.
- **Phase 4** drives the plan's `[:world :scripts]` (named `:plays` preserved as named scripts) instead of a second `runner-events/variant-plays` read of the registered body. The compiler already coerces + folds every script (`normalize-scripts`).
- **Plan-construction failures** (thrown in `prepare-context`, *before* frame allocation) are projected directly via a new `plan-error-result` — the frame does not exist yet to record onto, so this mirrors `unknown-variant-result`'s frame-free shape and stamps the `:rf.error/story-*` id on the assertion record.
- A composed `:compose` fragment's `:setup` is **now executed in phase 2** (the pre-migration runtime ignored `:compose` for setup — a genuine fix the plan routing delivers).

### Preserved (§B8 tasks 5–7)

- Lifecycle semantics (`:pre-mount → … → :ready` / `:error`), snapshot identity, and loader-failure reporting are unchanged — verified by the existing runtime suite + the play/script CI gate (incl. the loader-throws / render-throws / failing-event diagnostics variants).
- Test mode remains a **pure reader** of the unified result, not a separate runner: `ui.test-mode.state/run-variant-pane!` calls `runtime/reset-variant` (the unified runner) and `store-result!` swaps the result into `results-atom`. No change required.
- `:plays` are preserved as named scripts in the plan.
- The `lower-public-vocabulary` lowering REMAINS for the not-yet-plan-routed shipping-slot readers (snapshot identity, workspace/canvas, recorder, the live-canvas `variant-body->plays`); spec/017 §Public vocabulary updated to state the partial migration accurately.

### Spec

`tools/story/spec/017-Testing-Story.md` updated: §Public vocabulary now states the `run-variant` lifecycle is plan-routed (with the remaining shipping-slot readers called out), and the §Unified-run-result fold note distinguishes the plan-compiler fold (lifecycle) from the live-canvas/step-debugger fold sites.

### Tests

4 JVM regression tests added to `tools/story/test/re_frame/story_runtime_test.clj`:
- `run-variant-public-setup-and-script-vocabulary` — public `:setup` / `:script` run through the plan.
- `run-variant-composed-fragment-setup-runs-in-phase-2` — fragment setup executes + appends before the variant's own setup.
- `run-variant-named-plays-from-plan` — named `:plays` drive from `[:world :scripts]`; first auto-play only.
- `run-variant-plan-error-projects-as-run-error` — a plan-compile failure surfaces as `:error` rather than crashing the orchestrator.

## Collision avoidance (∥ with .23 epoch-narrative)

Did NOT edit `evidence.cljc` or `result.cljc`'s schema. The runtime CONSUMES `result/run-result` (unchanged). Files touched: `runtime.cljc`, `story_runtime_test.clj`, `spec/017` only.

## Quality gates

| Gate | Command | Result |
|------|---------|--------|
| Story JVM (incl. 4 new regression tests) | `tools/story` `clojure -M:test` | **PASS** — 1126 tests, 3545 assertions, 0 fail/0 err |
| story-mcp JVM (downstream consumer) | `tools/story-mcp` `clojure -M:test` | **PASS** — 172 tests, 861 assertions, 0 fail/0 err |
| CLJS node suite | `implementation` `npm run test:cljs` | **PASS** — 4850 tests, 15890 assertions, 0 fail/0 err |
| Play/script CI gate | `implementation` `npm run test:story-play-scripts` | **PASS** — 29 play rows, 0 unexpected outcomes |
| MCP conformance | `implementation` `npm run test:mcp-conformance` | **PASS** — all 6 gates green (incl. story-mcp e2e + wire-vocab 48/599) |
| Fast PR spine (+ markdown gates) | `scripts/test-fast-pr.sh --with-docs` | **PASS** — core JVM (795), JS harness helpers, CLJS node, README + docs-corpus anchor validators; mkdocs soft-skipped locally (no mkdocs on PATH; CI runs it) |