### PR TITLE
feat(story): golden-slice support — canonicalized run regression artifacts (rf2-5x1wt.32)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -1764,9 +1764,12 @@ can copy. P1 makes it first-class:
   run-result slots, the two-level narrative, and the green-while-red
   agreement floor — is pinned in [§Run-result evidence
   projection](#run-result-evidence-projection).
-- Golden slices are deferred. P1.5 MAY let a curated variant carry a
-  `:golden` slice once canonicalization has an adversarial corpus proving
-  that semantic differences perturb the hash and volatile fields do not.
+- Golden slices (the deferred P1.5 surface) are now landed: a curated run
+  may be frozen as a `:rf.test/golden` slice — the `canonicalize`d
+  behavioural surface — and a later run asserted to canonicalize `=` to it.
+  The contract is pinned in [§Golden slices](#golden-slices); it builds
+  directly on the now-proven canonicalization (the determinism gate +
+  semantic diff are its adversarial corpus).
 
 Combined with `restore-epoch`, this projection is the spine of **both**
 Test mode and Docs mode: the same evidence produces the test result and a
@@ -2461,6 +2464,121 @@ run-results (`strip-noise` — the volatile / per-run-stamp / `:rf.story/*`
 strip without the map-flattening ordering pass `canonicalize` applies), so
 they read named slots while seeing none of the per-run noise.
 
+## Golden slices {#golden-slices}
+
+A **golden slice** is a curated canonicalized run regression artifact — the
+deferred P1.5 surface (§Shared primitive lock), unblocked now that
+`canonicalize` is proven by the determinism gate and the semantic diff. It
+freezes a run's behaviour once and asserts later runs still match it:
+
+    capture: golden  = canonicalize(behavioural-slice(run))
+    compare: match?  = (= golden  canonicalize(behavioural-slice(new-run)))
+
+It is the **third artifact below Story** — not a Story variant (no curation
+lineage, no navigation slot) and not a run artifact (no replayable
+`:event-program`); it is a frozen canonical EXPECTATION. It MUST NOT add a
+slot to the run-result schema (§Run result): it freezes the canonicalized
+SLICE of an existing result, it does not extend the result shape.
+
+### Why canonicalize, not store the raw run
+
+A raw run carries per-RUN noise a fresh-frame replay restamps every time
+(the process-global epoch / dispatch / trace-id counters, the
+`:rf.test.replay/*` frame id, the wall-clock `:committed-at` / `:time` /
+`:elapsed-ms`). Storing a raw run as a golden would make every rerun a false
+mismatch. So a golden MUST store the `canonicalize`d slice — the SAME
+primitive (§Canonicalization) the determinism gate compares N replays
+through and the semantic diff projects before comparing. A golden mismatch
+is therefore always a SEMANTIC difference (app-db, effect, assertion
+verdict, schema failure, trace spine), never volatile drift. This is exactly
+why the surface was deferred until `canonicalize` was proven: the golden
+REUSES that one strip path rather than inventing a second canonicaliser to
+drift apart.
+
+### The behavioural slice
+
+The slice frozen into a golden is `fingerprint/run-hash-input-keys` — the
+behavioural surface (`:status`, final `:app-db`, the `:epoch-tape`, the
+`:assertions` / `:checks` verdicts, the projected `:effects` /
+`:schema-violations` / `:warnings`, and the resolved `:sub-overrides` /
+`:fidelity`). This is the SAME slice `run-hash` hashes and the determinism
+gate (`compare-runs`) and the semantic diff (`diff-runs`'s `:same?`
+judgement) compare — so a golden match, a determinism `:deterministic`, and
+a diff `{:same? true}` are the **one judgement under three names**. The pure
+provenance a run also carries (`:frame` replay id, `:run-artifact`
+back-link, `:replay-steps`) is excluded for the same reason `run-hash`
+excludes it: it legitimately differs per run and would make a golden
+brittle.
+
+### The `:rf.test/golden` slice shape
+
+```clojure
+{:golden/kind :rf.test/golden
+ :canonical   <canonicalize(behavioural-slice(run))> ; the frozen expectation
+ :run-hash    <run-hash(run)>                         ; cheap pre-check
+ :slice-keys  [k …]                                   ; the frozen surface
+ :golden/meta {:variant/id … :doc … :created-at … :source …} ; optional curation
+ :run-result  {…}}                                    ; optional, for the readable diff
+```
+
+`:canonical` is the load-bearing slot — the frozen, host-portable canonical
+projection compared on every later run. `:run-hash` is the cheap
+discriminator (a mismatched hash short-circuits to "different"; a matching
+hash is CONFIRMED by canonical equality, so a hash collision can never
+report a false GREEN). `:slice-keys` records the surface the slice was taken
+over, so a future slice-key change is detectable rather than silent.
+`:golden/meta` carries curation provenance and is NEVER part of the compared
+`:canonical` — re-curating a golden's doc does not perturb the regression
+baseline. `:run-result` is the optional retained source slice (captured with
+`:keep-run-result true`) that powers the readable mismatch diff (below).
+
+### Capture / compare contract
+
+```clojure
+(story/capture-golden target opts)  ; -> :rf.test/golden slice
+(story/golden-match?  golden run opts) ; -> boolean
+(story/compare-golden golden run opts) ; -> readable report
+```
+
+- **`capture-golden`** freezes a `target` into a golden slice. `target` is a
+  run-result (used directly — the PURE path, `clojure -M:test` with no
+  runtime) or a `:rf.test/run-artifact` (REPLAYED into a fresh frame via
+  `replay-run-artifact` first, so a golden frozen from an artifact captures
+  the fresh-frame run the determinism gate + diff would produce). `opts` MAY
+  carry `:meta`, `:keep-run-result`, and the replay opts (`:frame` /
+  `:hooks` / `:frame-config`).
+- **`golden-match?`** returns true iff the new run's `canonicalize`d
+  behavioural slice is `=` to the golden's frozen `:canonical`. It checks
+  the cheap `:run-hash` first, then confirms with canonical equality (the
+  AUTHORITY). The match is robust to per-run noise — frame / epoch / trace
+  ids and timestamps do NOT cause a false mismatch, because `canonicalize`
+  strips them on both sides (reusing the determinism strip rules) — and
+  sensitive to a real semantic difference, which perturbs the canonical
+  value.
+- **`compare-golden`** returns a READABLE report: `{:match? true …}` on
+  match, else `{:match? false :run-hash … :golden-run-hash … :diff …}`. On
+  mismatch the report MUST DELEGATE to the semantic diff
+  (`diff-runs` / `diff-run-artifacts`, §Semantic diff) — it MUST NOT
+  reinvent the diff — so the report localises WHERE the run parted from the
+  baseline (a one-key app-db drift reads as a one-entry `:app-db` facet, an
+  effect-only change as `:effects`, a status flip as `:status`). The
+  delegated diff reads named run-result slots, which the lossy `:canonical`
+  ordering cannot supply; so the readable diff requires the golden's source
+  slice (kept via `:keep-run-result true`, or supplied as
+  `:golden-run-result`). Absent it, the report still states the mismatch
+  FACT (both run-hashes) with `:diff :unavailable-no-run-result`.
+
+### Pure / JVM-testable
+
+The slice + capture + match / report logic (`behavioural-slice`,
+`slice-canonical`, `make-golden`, `golden?`, `golden-match?`,
+`compare-golden`) is pure data → data — a run-result in, a golden / verdict
+out — and runs under `clojure -M:test` with no runtime. The only impurity is
+the artifact / plan capture path, which replays into a fresh frame via the
+existing `replay-run-artifact` seam. The golden module `:require`s ONLY the
+pure fingerprint / diff modules + the artifact replay seam, so it introduces
+no hard `:require` of a test-only dep into the production Story path.
+
 ## Relationship to the workshop surface (storytelling is in-scope)
 
 Story is a **workshop**, not only a test engine. The shipping authoring
@@ -2527,8 +2645,9 @@ P1 is complete when:
   diff, snapshot-identity, `:plan-hash`, and
   inline-plan-to-registered-variant equivalence;
 - the run-result is unified and carries an epoch-keyed two-level
-  `:narrative` projection; golden slices are deferred until the
-  canonicalization corpus proves stable;
+  `:narrative` projection; golden slices (§Golden slices) freeze the
+  `canonicalize`d behavioural slice and compare a later run `=` to it, with
+  a mismatch report delegated to the semantic diff;
 - `render-variant` and the controls panel drive the same plan; view arg
   schemas validate `:effective-args` and derive controls/docs where
   possible; the Storybook→Story map ships;

--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -102,6 +102,11 @@
             ;; Re-exported as `diff-run-artifacts` below (spec/017 §Semantic
             ;; diff). Builds read-only on `.7` replay + `.3`/`.8` canonicalize.
             [re-frame.story.diff        :as diff]
+            ;; rf2-5x1wt.32 — golden slices (the deferred P1.5 surface).
+            ;; Re-exported as `capture-golden` / `golden-match?` /
+            ;; `compare-golden` below (spec/017 §Golden slices). Builds
+            ;; read-only on `.3`/`.8` canonicalize + `.7` replay + `.9` diff.
+            [re-frame.story.golden      :as golden]
             ;; rf2-5x1wt.25 — the run-artifact → variant promotion bridge.
             ;; Re-exported as `materialize-variant-plan` (pure) +
             ;; `promote-run-artifact!` (the explicit-only registration path)
@@ -1172,6 +1177,52 @@
   `:frame-config` (threaded to the replay)."
   ([baseline current]      (diff/diff-run-artifacts baseline current))
   ([baseline current opts] (diff/diff-run-artifacts baseline current opts)))
+
+;; ---- golden slices (rf2-5x1wt.32) ---------------------------------------
+;;
+;; Per spec/017 §Golden slices — a curated canonicalized run regression
+;; artifact: freeze a run's behavioural slice via `canonicalize` (the slice
+;; `run-hash` hashes), then assert a later run still canonicalizes `=` to it.
+;; The deferred P1.5 surface, unblocked now that `.3`/`.8`'s `canonicalize`
+;; is proven by the determinism gate + semantic diff. Builds read-only on
+;; `canonicalize` (the strip path) + `.7` replay (the artifact path) + `.9`
+;; diff (the readable mismatch report — delegated, not reinvented).
+
+(defn capture-golden
+  "Per spec/017 §Golden slices — freeze a curated `:rf.test/golden` slice
+  from `target` (a run-result, used directly; or a `:rf.test/run-artifact`,
+  replayed into a fresh frame first). The slice is the `canonicalize`d
+  behavioural surface (the slot `run-hash` hashes), so a golden mismatch is
+  a SEMANTIC difference, never volatile drift. `opts` MAY carry `:meta`
+  (curation provenance), `:keep-run-result` (retain the source slice for a
+  readable `compare-golden` mismatch diff), and `:frame` / `:hooks` /
+  `:frame-config` (threaded to the replay)."
+  ([target]      (golden/capture-golden target))
+  ([target opts] (golden/capture-golden target opts)))
+
+(defn golden-match?
+  "Per spec/017 §Golden slices — true iff `run` matches the `golden` slice:
+  the run's canonicalized behavioural slice is `=` to the golden's frozen
+  `:canonical`. Robust to per-run noise (frame / epoch / trace ids,
+  timestamps — `canonicalize` strips them on both sides) and sensitive to a
+  real semantic difference. `run` MAY be a run-result (pure) or a
+  `:rf.test/run-artifact` (replayed first); `opts` MAY carry `:frame` /
+  `:hooks` / `:frame-config`."
+  ([golden run]      (golden/golden-match? golden run))
+  ([golden run opts] (golden/golden-match? golden run opts)))
+
+(defn compare-golden
+  "Per spec/017 §Golden slices — compare `run` against the `golden` slice
+  and return a READABLE report. On match `{:match? true …}`; on mismatch
+  `{:match? false :run-hash … :golden-run-hash … :diff …}`, where `:diff`
+  DELEGATES to `diff-run-artifacts`/`diff-runs` (the §Semantic-diff facet
+  machinery, NOT a reinvented diff) to localise WHERE the run parted from
+  the baseline. The readable diff needs the golden's source slice — capture
+  with `:keep-run-result true` (or pass `:golden-run-result`); absent it the
+  report still states the mismatch fact. `opts` MAY carry
+  `:golden-run-result` + the replay opts."
+  ([golden run]      (golden/compare-golden golden run))
+  ([golden run opts] (golden/compare-golden golden run opts)))
 
 (defn destroy-variant!
   "Tear down a variant frame allocated via `run-variant`. Per IMPL-

--- a/tools/story/src/re_frame/story/golden.cljc
+++ b/tools/story/src/re_frame/story/golden.cljc
@@ -1,0 +1,290 @@
+(ns re-frame.story.golden
+  "Golden slices — curated canonicalized run/epoch regression artifacts
+  (NewTestStory rf2-5x1wt.32, spec/017-Testing-Story.md §Golden slices).
+  The deferred P1.5 surface, unblocked now that canonicalization has been
+  proven by the determinism gate (rf2-5x1wt.8) + the semantic diff
+  (rf2-5x1wt.9).
+
+  ## What a golden slice is
+
+  A golden slice is a CURATED regression baseline: the
+  `re-frame.story.fingerprint/canonicalize`d projection of a run's
+  BEHAVIOURAL surface, captured once and compared against on every later
+  run. It answers ONE question — does this run still behave the way the
+  curated baseline says it should?
+
+      capture: golden  = canonicalize(behavioural-slice(run))
+      compare: match?  = (= golden  canonicalize(behavioural-slice(new-run)))
+
+  It is NOT a Story variant (no curation lineage, no navigation slot) and
+  NOT a run artifact (it carries no replayable `:event-program`). It is the
+  THIRD artifact below Story — a frozen canonical expectation. It does NOT
+  add a slot to the run-result schema (`re-frame.story.result`); it freezes
+  the canonicalized SLICE of an existing result.
+
+  ## Why canonicalize, not store the raw run
+
+  A raw run carries per-RUN noise a fresh-frame replay restamps every time:
+  the process-global epoch / dispatch / trace-id counters, the
+  `:rf.test.replay/*` frame id, the wall-clock `:committed-at` / `:time` /
+  `:elapsed-ms`. Storing a raw run as a golden would make EVERY rerun a
+  false mismatch. So the golden is the `canonicalize`d slice — the same
+  primitive the determinism gate compares N replays through and the
+  semantic diff projects before comparing — so a golden mismatch means a
+  SEMANTIC difference (app-db, effect, assertion verdict, schema failure,
+  trace spine), never volatile drift. This is exactly why the bead was
+  deferred until `.3`/`.8`'s `canonicalize` was proven: the golden reuses
+  that one strip path rather than inventing a second one.
+
+  ## The behavioural slice
+
+  The slice frozen into a golden is `fingerprint/run-hash-input-keys` — the
+  behavioural surface (`:status`, final `:app-db`, the `:epoch-tape`, the
+  `:assertions` / `:checks` verdicts, the projected `:effects` /
+  `:schema-violations` / `:warnings`, and the resolved `:sub-overrides` /
+  `:fidelity`). This is the SAME slice `run-hash` hashes and the
+  determinism gate (`re-frame.story.determinism/compare-runs`) and the
+  semantic diff (`re-frame.story.diff/diff-runs`'s `:same?` judgement)
+  compare — so a golden match, a determinism `:deterministic`, and a diff
+  `{:same? true}` are the one judgement under three names. The pure
+  provenance a run also carries (`:frame` replay id, `:run-artifact`
+  back-link, `:replay-steps`) is excluded for exactly the reason `run-hash`
+  excludes it: it legitimately differs per run.
+
+  ## Capture / compare contract
+
+  - `capture-golden` — freeze a run-result (or a `:rf.test/run-artifact`,
+    or a normalized plan, via `->run-result`) into a `:rf.test/golden`
+    slice. Pure when handed a run-result; impure (replays into a fresh
+    frame) when handed an artifact / plan.
+  - `golden-match?` — true iff a new run canonicalizes `=` to the golden's
+    frozen slice. The fast path checks the cheap `:run-hash` first, then
+    confirms with canonical equality (a hash collision can never report a
+    false GREEN — equality is the authority).
+  - `compare-golden` — the READABLE report. On match `{:match? true …}`; on
+    mismatch it DELEGATES to `re-frame.story.diff/diff-runs` (NOT a
+    reinvented diff) to localise WHERE the run parted from the golden, so a
+    one-key app-db drift reads as a one-entry `:app-db` facet.
+
+  ## Pure / JVM-testable
+
+  The slice + canonical capture + the match / report logic
+  (`behavioural-slice`, `slice-canonical`, `make-golden`, `golden?`,
+  `golden-match?`, `compare-golden`) are pure data → data: a run-result in,
+  a golden / verdict out — so they run under `clojure -M:test` with no
+  runtime. The only impurity is `->run-result`, which (for an artifact /
+  plan input) replays into a fresh frame via `.7`'s `replay-run-artifact`.
+
+  This ns is bundle-isolated tooling; it `:require`s ONLY the pure
+  fingerprint / diff modules + the artifact replay seam (which itself uses
+  the late-bound `rf/epoch-history` facade), so it introduces NO hard
+  `:require` of a test-only dep into the production Story path."
+  (:require [re-frame.story.artifact    :as artifact]
+            [re-frame.story.diff        :as diff]
+            [re-frame.story.fingerprint :as fingerprint]))
+
+;; ===========================================================================
+;; THE :rf.test/golden SLICE
+;; ===========================================================================
+
+(def golden-kind
+  "The `:golden/kind` tag every golden slice carries (spec/017 §Golden
+  slices). A distinct value so a consumer tells a golden slice apart from a
+  run artifact (`:rf.test/run-artifact`), a normalized plan, or a curated
+  variant body."
+  :rf.test/golden)
+
+(defn behavioural-slice
+  "The behavioural surface of a `run`-result — `select-keys` over
+  `fingerprint/run-hash-input-keys`. Pure data → data.
+
+  This is the SAME slice `run-hash` hashes and the determinism gate +
+  semantic diff compare, so a golden freezes exactly the surface those two
+  judge. The pure provenance a run also carries (`:frame` replay id,
+  `:run-artifact` back-link, `:replay-steps`) is excluded — it legitimately
+  differs per run and would make a golden brittle."
+  [run]
+  (select-keys run fingerprint/run-hash-input-keys))
+
+(defn slice-canonical
+  "The `canonicalize`d behavioural slice of a `run` — the frozen value a
+  golden stores and `golden-match?` compares against. Pure data → data.
+
+  `canonicalize` strips the per-run stamps (epoch / dispatch / trace ids,
+  frame id, timestamps — recursively, including inside the `:epoch-tape`
+  beats) and imposes a total ordering, so two semantically-equal runs yield
+  the SAME canonical slice. This is THE equality the golden contract rests
+  on."
+  [run]
+  (fingerprint/canonicalize (behavioural-slice run)))
+
+(defn make-golden
+  "Construct a `:rf.test/golden` slice from a `run`-result. Pure data →
+  data — no runtime, JVM-runnable.
+
+  The slice freezes the `canonicalize`d behavioural surface (`:canonical`)
+  plus the cheap `:run-hash` discriminator and the `:run-hash-input-keys`
+  the slice was taken over (so a future slice-key change is detectable, not
+  silent).
+
+  `opts` (optional):
+
+  - `:meta` — curation provenance (`:variant/id` / `:doc` / `:created-at` /
+    `:source`) stamped under `:golden/meta`. It is NEVER part of the
+    compared `:canonical`, so re-curating a golden's doc never perturbs the
+    regression baseline.
+  - `:keep-run-result` — when truthy, retain the source `run`-result's
+    behavioural slice under `:run-result`. The lossless `:canonical` form
+    flattens maps into `[k v …]` vectors, so it cannot drive the readable
+    `compare-golden` diff (which reads named slots — `:app-db`, `:effects`,
+    …); retaining the slice lets a mismatch DELEGATE to
+    `re-frame.story.diff/diff-runs` for a localised, readable report. It is
+    the behavioural SLICE (not the whole result), so it carries no extra
+    provenance and is itself canonicalize-comparable.
+
+  Shape:
+
+      {:golden/kind :rf.test/golden
+       :canonical   <canonicalize(behavioural-slice(run))>
+       :run-hash    <run-hash(run)>            ; cheap pre-check
+       :slice-keys  [k …]                      ; the frozen surface
+       :golden/meta {…}                        ; optional curation provenance
+       :run-result  {…}}                       ; optional, for the readable diff"
+  ([run] (make-golden run nil))
+  ([run {:keys [meta keep-run-result] :as _opts}]
+   (cond-> {:golden/kind golden-kind
+            :canonical   (slice-canonical run)
+            :run-hash    (fingerprint/run-hash run)
+            :slice-keys  fingerprint/run-hash-input-keys}
+     (seq meta)      (assoc :golden/meta meta)
+     keep-run-result (assoc :run-result (behavioural-slice run)))))
+
+(defn golden?
+  "True iff `x` is a `:rf.test/golden` slice — the `:golden/kind` tag plus a
+  frozen `:canonical` value. Pure data → data."
+  [x]
+  (boolean
+    (and (map? x)
+         (= golden-kind (:golden/kind x))
+         (contains? x :canonical))))
+
+;; ===========================================================================
+;; CAPTURE  (run-result → golden; artifact / plan → fresh-frame replay)
+;; ===========================================================================
+
+(defn- ->run-result
+  "Coerce a capture/compare `target` into a run-result. A run-result
+  (carrying a `:status`) is used directly — the PURE path. A
+  `:rf.test/run-artifact` (or a normalized plan, via the determinism gate's
+  `->artifact` fold inside `replay-run-artifact`'s caller) is replayed into
+  a FRESH frame via `re-frame.story.artifact/replay-run-artifact` (the
+  IMPURE path), threading `opts` (`:frame` / `:hooks` / `:frame-config`).
+
+  Replaying the artifact means a golden captured from an artifact freezes
+  exactly the FRESH-frame run the determinism gate + semantic diff would
+  produce — so capture-from-artifact and capture-from-result agree."
+  [target opts]
+  (if (artifact/run-artifact? target)
+    (artifact/replay-run-artifact target opts)
+    target))
+
+(defn capture-golden
+  "Capture a `:rf.test/golden` slice from `target` (spec/017 §Golden
+  slices). The curated-baseline capture path.
+
+  `target` is one of:
+
+  - a run-result (the shared §Run result shape, carrying `:status`) — used
+    directly, the PURE path (`clojure -M:test` with no runtime);
+  - a `:rf.test/run-artifact` — REPLAYED into a fresh frame via
+    `replay-run-artifact` to obtain a run-result first (the impure path);
+    so a golden frozen from an artifact captures the fresh-frame run.
+
+  `opts` (all optional):
+
+  - `:meta`            — curation provenance (`:variant/id` / `:doc` /
+                         `:created-at` / `:source`) stamped under
+                         `:golden/meta`; never part of the compared
+                         `:canonical`.
+  - `:keep-run-result` — retain the captured run's behavioural slice under
+                         `:run-result` so a later `compare-golden` mismatch
+                         can produce a readable, delegated diff
+                         (see `make-golden`).
+  - `:frame` / `:hooks` / `:frame-config` — threaded to
+                         `replay-run-artifact` for the artifact path.
+
+  Returns the `:rf.test/golden` slice (see `make-golden`)."
+  ([target] (capture-golden target nil))
+  ([target {:keys [meta keep-run-result] :as opts}]
+   (make-golden (->run-result target (dissoc opts :meta :keep-run-result))
+                {:meta meta :keep-run-result keep-run-result})))
+
+;; ===========================================================================
+;; COMPARE  (canonical equality + the readable, delegated report)
+;; ===========================================================================
+
+(defn golden-match?
+  "True iff `run` matches the `golden` slice — the run's canonicalized
+  behavioural slice is `=` to the golden's frozen `:canonical` (spec/017
+  §Golden slices). Pure when `run` is a run-result.
+
+  Two-stage to avoid a false GREEN: the cheap `:run-hash` is checked first
+  (mismatched hash ⇒ definitely different, short-circuit), then canonical
+  equality is the AUTHORITY (a hash collision can never report a match
+  because the canonical values still differ). The match is robust to
+  per-run noise — frame ids, timestamps, epoch / dispatch / trace ids do
+  NOT cause a false mismatch because `canonicalize` strips them on both
+  sides — and sensitive to a real semantic difference (app-db, effect,
+  assertion verdict, schema failure, trace spine), which perturbs the
+  canonical value.
+
+  `run` MAY be a run-result (pure) or a `:rf.test/run-artifact` (replayed
+  into a fresh frame first — pass `opts` for `:frame` / `:hooks` /
+  `:frame-config`)."
+  ([golden run] (golden-match? golden run nil))
+  ([golden run opts]
+   (let [result (->run-result run opts)]
+     (and (= (:run-hash golden) (fingerprint/run-hash result))
+          (= (:canonical golden) (slice-canonical result))))))
+
+(defn compare-golden
+  "Compare a `run` against the `golden` slice and return a READABLE report
+  (spec/017 §Golden slices). The curated-baseline compare path.
+
+  On MATCH: `{:match? true :run-hash <hash>}`.
+
+  On MISMATCH: `{:match? false :run-hash <new> :golden-run-hash <frozen>
+  :diff <readable-diff>}` — the diff DELEGATES to
+  `re-frame.story.diff/diff-runs` (the §Semantic-diff facet machinery, NOT
+  a reinvented diff) so the report localises WHERE the run parted from the
+  baseline: a one-key app-db drift reads as a one-entry `:app-db` facet, an
+  effect-only change as an `:effects` facet, a status flip as `:status`,
+  and so on (`:facets #{…}` names them up front).
+
+  The diff is taken between the GOLDEN'S source run-result and the new run.
+  The golden's `:canonical` form re-orders maps into sorted `[k v …]`
+  vectors, which destroys the named-slot access (`:app-db`, `:effects`, …)
+  the diff facets read — so the delegated diff needs the golden's source
+  run-SLICE, kept under `:run-result` when the golden was captured with
+  `:keep-run-result true` (or supplied here as `:golden-run-result`). Absent
+  it, the report still states the mismatch FACT (both run-hashes) but marks
+  `:diff :unavailable-no-run-result` — capture with `:keep-run-result true`
+  when a readable mismatch diff is wanted.
+
+  `opts` (all optional): `:golden-run-result` — the run-result the golden
+  was captured from (for the delegated diff); `:frame` / `:hooks` /
+  `:frame-config` — threaded to `replay-run-artifact` when `run` is an
+  artifact."
+  ([golden run] (compare-golden golden run nil))
+  ([golden run {:keys [golden-run-result] :as opts}]
+   (let [result    (->run-result run (dissoc opts :golden-run-result))
+         match?    (and (= (:run-hash golden) (fingerprint/run-hash result))
+                        (= (:canonical golden) (slice-canonical result)))
+         base-run  (or golden-run-result (:run-result golden))]
+     (if match?
+       {:match? true :run-hash (fingerprint/run-hash result)}
+       (cond-> {:match?          false
+                :run-hash        (fingerprint/run-hash result)
+                :golden-run-hash (:run-hash golden)}
+         base-run       (assoc :diff (diff/diff-runs base-run result))
+         (not base-run) (assoc :diff :unavailable-no-run-result))))))

--- a/tools/story/test/re_frame/story/golden_test.cljc
+++ b/tools/story/test/re_frame/story/golden_test.cljc
@@ -1,0 +1,274 @@
+(ns re-frame.story.golden-test
+  "Tests for golden slices — curated canonicalized run regression artifacts
+  (rf2-5x1wt.32, spec/017-Testing-Story.md §Golden slices).
+
+  Two layers, both under `clojure -M:test` (JVM) + the node-runtime CLJS
+  build:
+
+  - PURE: capture / match / readable-report over HAND-BUILT run-results —
+    the §Golden-slice acceptance bullets:
+      • a golden slice round-trips (canonicalizing the same run twice is
+        equal);
+      • `golden-match?` is true for a behaviourally-equivalent run and
+        false for a real semantic difference;
+      • volatile fields (frame / epoch / trace ids, timestamps) do NOT
+        cause a false mismatch — because the slice is compared via
+        `canonicalize`, reusing `.8`'s strip rules;
+      • a mismatch report DELEGATES to `re-frame.story.diff/diff-runs` (the
+        readable facet diff), not a reinvented diff.
+  - HEADLESS (against a live frame): `capture-golden` / `golden-match?` over
+    a real replay — a golden captured from an artifact matches a re-replay
+    of the same program, and a divergent program does not."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core      :as rf]
+            [re-frame.epoch     :as epoch]
+            [re-frame.frame     :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.story.artifact    :as artifact]
+            [re-frame.story.fingerprint :as fingerprint]
+            [re-frame.story.golden      :as golden]))
+
+;; ===========================================================================
+;; FIXTURES — hand-built run-results
+;; ===========================================================================
+
+(defn- tape-with-ops
+  "A minimal epoch tape whose single epoch carries trace events with the
+  given `:operation`s, in order."
+  [ops]
+  [{:epoch-id 1
+    :trace-events (mapv (fn [op] {:operation op :op-type :event}) ops)}])
+
+(defn- run-result
+  "A minimal hand-built run-result over the behavioural slice
+  (`fingerprint/run-hash-input-keys`)."
+  [{:keys [status app-db effects ops]
+    :or   {status :pass app-db {} effects [] ops [:rf.event/run-start]}}]
+  {:status status
+   :app-db app-db
+   :effects effects
+   :sub-runs []
+   :assertions []
+   :checks []
+   :schema-violations []
+   :warnings []
+   :epoch-tape (tape-with-ops ops)})
+
+(defn- noisy-run
+  "A run-result whose epoch tape + app-db carry per-run stamps a fresh-frame
+  replay would write differently every time (frame id, epoch id,
+  committed-at, trace :id / :time), wrapping the same semantic `db-after`."
+  [{:keys [frame epoch-id committed-at trace-id db-after status]
+    :or   {status :pass}}]
+  {:status status
+   :app-db db-after
+   :frame  frame
+   :effects [] :sub-runs [] :assertions [] :checks []
+   :schema-violations [] :warnings []
+   :epoch-tape
+   [{:epoch-id epoch-id :frame frame :committed-at committed-at
+     :outcome :ok :db-before {} :db-after db-after
+     :effects [] :sub-runs [] :renders []
+     :trace-events [{:operation :rf.event/run-start :op-type :event
+                     :id trace-id :time committed-at
+                     :tags {:rf.trace/event-id :app/go}}]}]})
+
+;; ===========================================================================
+;; PURE: capture + round-trip  (a golden round-trips; capture is idempotent)
+;; ===========================================================================
+
+(deftest make-golden-shape
+  (testing "a golden carries the kind tag, a frozen :canonical, the run-hash,
+            and the slice keys it was taken over"
+    (let [g (golden/make-golden (run-result {:app-db {:n 1}}))]
+      (is (golden/golden? g))
+      (is (= :rf.test/golden (:golden/kind g)))
+      (is (contains? g :canonical))
+      (is (= (fingerprint/run-hash (run-result {:app-db {:n 1}})) (:run-hash g)))
+      (is (= fingerprint/run-hash-input-keys (:slice-keys g)))
+      (is (not (contains? g :golden/meta)) "no meta unless supplied")
+      (is (not (contains? g :run-result)) "no run-result unless :keep-run-result"))))
+
+(deftest make-golden-meta-and-keep-run-result
+  (testing ":meta rides under :golden/meta and is NOT part of :canonical"
+    (let [run (run-result {:app-db {:n 1}})
+          g1  (golden/make-golden run)
+          g2  (golden/make-golden run {:meta {:variant/id :story.checkout/ok
+                                              :doc "checkout happy path"}})]
+      (is (= {:variant/id :story.checkout/ok :doc "checkout happy path"}
+             (:golden/meta g2)))
+      (is (= (:canonical g1) (:canonical g2))
+          "curation provenance never perturbs the regression baseline")))
+
+  (testing ":keep-run-result retains the behavioural slice for the readable diff"
+    (let [run (run-result {:app-db {:n 1}})
+          g   (golden/make-golden run {:keep-run-result true})]
+      (is (= (golden/behavioural-slice run) (:run-result g))))))
+
+(deftest golden-round-trips
+  (testing "canonicalizing the same run twice yields the SAME golden :canonical
+            — the round-trip property the golden contract rests on"
+    (let [run (run-result {:app-db {:user {:name "ada"} :n 3}
+                           :effects [{:fx :http/get :args {:url "/a"}}]})
+          g1  (golden/make-golden run)
+          g2  (golden/make-golden run)]
+      (is (= (:canonical g1) (:canonical g2)))
+      (is (= (:run-hash g1) (:run-hash g2)))
+      (is (golden/golden-match? g1 run)
+          "a golden matches the very run it was captured from"))))
+
+;; ===========================================================================
+;; PURE: golden-match?  (equivalent ⇒ true, real difference ⇒ false)
+;; ===========================================================================
+
+(deftest golden-match-true-for-equivalent-run
+  (testing "a behaviourally-equivalent run (same slice) matches"
+    (let [g (golden/make-golden (run-result {:app-db {:n 1} :ops [:a :b]}))]
+      (is (true? (golden/golden-match? g (run-result {:app-db {:n 1} :ops [:a :b]}))))))
+
+  (testing "map key ORDER in app-db does not affect the match (canonical)"
+    (let [g (golden/make-golden (run-result {:app-db {:a 1 :b 2}}))]
+      (is (true? (golden/golden-match? g (run-result {:app-db (sorted-map :b 2 :a 1)})))))))
+
+(deftest golden-match-false-for-semantic-difference
+  (testing "an app-db change fails the match"
+    (let [g (golden/make-golden (run-result {:app-db {:n 1}}))]
+      (is (false? (golden/golden-match? g (run-result {:app-db {:n 2}}))))))
+
+  (testing "an effect-only change fails the match"
+    (let [g (golden/make-golden (run-result {:effects [{:fx :db/save}]}))]
+      (is (false? (golden/golden-match? g (run-result {:effects []}))))))
+
+  (testing "a status flip fails the match"
+    (let [g (golden/make-golden (run-result {:status :pass}))]
+      (is (false? (golden/golden-match? g (run-result {:status :fail}))))))
+
+  (testing "a diverging trace op spine fails the match"
+    (let [g (golden/make-golden (run-result {:ops [:a :b :c]}))]
+      (is (false? (golden/golden-match? g (run-result {:ops [:a :x :c]})))))))
+
+;; ===========================================================================
+;; PURE: the load-bearing property — volatile fields do NOT cause a false miss
+;; ===========================================================================
+
+(deftest golden-match-ignores-volatile-fields
+  (testing "two runs differing ONLY in per-run stamps (frame / epoch / trace
+            ids, timestamps) still MATCH — the golden compares via canonicalize,
+            reusing .8's strip rules"
+    (let [captured (noisy-run {:frame :rf.test.replay/frame-aaa :epoch-id 5
+                               :committed-at 1000 :trace-id 17 :db-after {:n 1}})
+          g        (golden/make-golden captured)
+          rerun    (noisy-run {:frame :rf.test.replay/frame-zzz :epoch-id 99
+                               :committed-at 2000 :trace-id 88 :db-after {:n 1}})]
+      (is (true? (golden/golden-match? g rerun))
+          "frame ids, epoch ids, timestamps, trace ids are NOT mismatches")))
+
+  (testing "a real app-db change is STILL caught amid the per-run noise"
+    (let [captured (noisy-run {:frame :rf.test.replay/frame-aaa :epoch-id 5
+                               :committed-at 1000 :trace-id 17 :db-after {:n 1}})
+          g        (golden/make-golden captured)
+          changed  (noisy-run {:frame :rf.test.replay/frame-zzz :epoch-id 99
+                               :committed-at 2000 :trace-id 88 :db-after {:n 2}})]
+      (is (false? (golden/golden-match? g changed))
+          "the canonical compare surfaces the SEMANTIC change, not volatile drift"))))
+
+;; ===========================================================================
+;; PURE: compare-golden — the readable report delegates to diff/diff-runs
+;; ===========================================================================
+
+(deftest compare-golden-match-report
+  (testing "a match reports {:match? true} with the run-hash"
+    (let [run (run-result {:app-db {:n 1}})
+          g   (golden/make-golden run)
+          r   (golden/compare-golden g run)]
+      (is (true? (:match? r)))
+      (is (= (fingerprint/run-hash run) (:run-hash r)))
+      (is (not (contains? r :diff)) "a match carries no diff"))))
+
+(deftest compare-golden-mismatch-delegates-to-diff
+  (testing "a mismatch with a kept run-result DELEGATES to diff/diff-runs for a
+            localised, readable report"
+    (let [captured (run-result {:app-db {:n 1}})
+          g        (golden/make-golden captured {:keep-run-result true})
+          changed  (run-result {:app-db {:n 2}})
+          r        (golden/compare-golden g changed)]
+      (is (false? (:match? r)))
+      (is (= (:run-hash g) (:golden-run-hash r)))
+      (is (= (fingerprint/run-hash changed) (:run-hash r)))
+      ;; The diff is the diff/diff-runs facet shape — NOT a reinvented diff.
+      (is (false? (get-in r [:diff :same?])))
+      (is (= #{:app-db} (:facets (:diff r))))
+      (is (= [{:path [:n] :baseline 1 :current 2}]
+             (get-in r [:diff :app-db :changed]))
+          "the readable report localises the one-key app-db drift")))
+
+  (testing "an effect-only mismatch surfaces ONLY the :effects facet"
+    (let [captured (run-result {:effects [{:fx :db/save}]})
+          g        (golden/make-golden captured {:keep-run-result true})
+          changed  (run-result {:effects []})
+          r        (golden/compare-golden g changed)]
+      (is (false? (:match? r)))
+      (is (= #{:effects} (:facets (:diff r))))))
+
+  (testing "a mismatch with NO retained run-result still states the mismatch FACT"
+    (let [g       (golden/make-golden (run-result {:app-db {:n 1}}))
+          changed (run-result {:app-db {:n 2}})
+          r       (golden/compare-golden g changed)]
+      (is (false? (:match? r)))
+      (is (= :unavailable-no-run-result (:diff r))
+          "without :keep-run-result the readable diff is unavailable, but the
+           hash mismatch is reported")))
+
+  (testing "a supplied :golden-run-result drives the diff even when the golden
+            did not retain one"
+    (let [captured (run-result {:app-db {:n 1}})
+          g        (golden/make-golden captured)
+          changed  (run-result {:app-db {:n 2}})
+          r        (golden/compare-golden g changed
+                                          {:golden-run-result captured})]
+      (is (false? (:match? r)))
+      (is (= #{:app-db} (:facets (:diff r)))))))
+
+;; ===========================================================================
+;; HEADLESS: capture / compare over real replays  (live frame)
+;; ===========================================================================
+
+(defn- reset-rf! [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (epoch/clear-history!)
+  (epoch/clear-epoch-listeners!)
+  (try (rf/init! plain-atom/adapter)
+       (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) _ nil))
+  (frame/ensure-default-frame!)
+  (test-fn))
+
+(use-fixtures :each reset-rf!)
+
+(deftest capture-golden-from-artifact-matches-rerun
+  (testing "a golden captured from an artifact (replayed into a fresh frame)
+            matches a re-replay of the same program — fresh-frame volatile
+            drift causes no false mismatch"
+    (rf/reg-event-db :golden/inc (fn [db _] (update db :n (fnil inc 0))))
+    (let [art (artifact/make-run-artifact
+                {:event-program [[:dispatch [:golden/inc]] [:dispatch [:golden/inc]]]})
+          g   (golden/capture-golden art {:keep-run-result true})]
+      (is (golden/golden? g))
+      (is (true? (golden/golden-match? g art))
+          "the same program replayed again matches the captured golden")
+      (is (true? (:match? (golden/compare-golden g art)))))))
+
+(deftest compare-golden-divergent-program-surfaces-app-db-facet
+  (testing "a golden captured from one program does NOT match a divergent
+            program, and the report surfaces a readable :app-db facet"
+    (rf/reg-event-db :golden/set (fn [db [_ v]] (assoc db :v v)))
+    (let [a (artifact/make-run-artifact {:event-program [[:dispatch [:golden/set 1]]]})
+          b (artifact/make-run-artifact {:event-program [[:dispatch [:golden/set 2]]]})
+          g (golden/capture-golden a {:keep-run-result true})
+          r (golden/compare-golden g b)]
+      (is (false? (golden/golden-match? g b)))
+      (is (false? (:match? r)))
+      (is (contains? (:facets (:diff r)) :app-db))
+      (is (= [{:path [:v] :baseline 1 :current 2}]
+             (get-in r [:diff :app-db :changed]))))))


### PR DESCRIPTION
## Summary

Adds the deferred **P1.5 golden-slice** surface (rf2-5x1wt.32), unblocked now that canonicalization is proven by the determinism gate (`.8`) and the semantic diff (`.9`). A golden slice is a curated canonicalized run regression artifact: it freezes a run's behavioural surface as the `canonicalize`d slice, and a later run is asserted to canonicalize `=` to it.

This builds the support PRIMITIVES (not a golden corpus — that is authored later), reusing the merged deps read-only:
- `.3`/`.8` `fingerprint/canonicalize` for the strip (so volatile frame/epoch/trace ids + timestamps never cause a false mismatch);
- `.7` `artifact/replay-run-artifact` for the artifact capture path;
- `.9` `diff/diff-runs` for the readable mismatch report (delegated, **not** reinvented).

## The `:golden` shape + capture/compare API

```clojure
{:golden/kind :rf.test/golden
 :canonical   <canonicalize(behavioural-slice(run))>  ; the frozen expectation
 :run-hash    <run-hash(run)>                          ; cheap pre-check
 :slice-keys  [k ...]                                  ; the frozen surface
 :golden/meta {...}                                    ; optional curation provenance
 :run-result  {...}}                                   ; optional, for the readable diff
```

- `(story/capture-golden target opts)` — freeze a run-result (pure) or a `:rf.test/run-artifact` (replayed into a fresh frame first) into a golden slice. `opts`: `:meta`, `:keep-run-result`, `:frame`/`:hooks`/`:frame-config`.
- `(story/golden-match? golden run opts)` — true iff the new run's canonicalized behavioural slice is `=` to the golden's `:canonical`. Cheap `:run-hash` pre-check; canonical equality is the authority (a hash collision can never report a false GREEN).
- `(story/compare-golden golden run opts)` — readable report; on mismatch delegates to `diff-runs` to localise the differing facet (`:app-db` / `:effects` / `:status` / ...).

The frozen slice is `fingerprint/run-hash-input-keys` — the SAME surface `run-hash` hashes and the determinism gate + semantic diff compare, so a golden match, a determinism `:deterministic`, and a diff `{:same? true}` are the one judgement under three names.

## Files changed

- `tools/story/src/re_frame/story/golden.cljc` (new) — the golden module.
- `tools/story/test/re_frame/story/golden_test.cljc` (new) — JVM + CLJS (`.cljc`).
- `tools/story/src/re_frame/story.cljc` — appended `:as golden` require + the three re-export verbs (after the `.9` diff re-export group).
- `tools/story/spec/017-Testing-Story.md` — new golden-slices section; updated the narrative + P1-acceptance deferral bullets to point at the now-landed section.

## Collision avoidance (.22 runs concurrently)

Did **not** touch `runtime.cljc`, `play.cljc`, `runner*.cljc`, `ci_runner.cljc`, `result.cljc`, or `ui/test_mode/*`. The only shared file is `story.cljc`, where the require + re-exports are **appended** (separate groups from .22's verb-routing) so the merge is trivial.

## Quality gates

| Gate | Result |
|---|---|
| `tools/story` -> `clojure -M:test` | PASS — 1139 tests, 3601 assertions, 0 failures, 0 errors (golden-test: 10 tests / 43 assertions) |
| `tools/story-mcp` -> `clojure -M:test` (downstream consumer, required — touched `story.cljc`) | PASS — 172 tests, 861 assertions, 0 failures, 0 errors |
| `npm --prefix implementation run test:cljs` | PASS — 4850 tests, 15890 assertions, 0 failures, 0 errors |
| `scripts/test-fast-pr.sh` | PASS — fast PR spine (incl. README/docs link+anchor validators for the spec change; mkdocs soft-skipped locally) |
| `git diff --check` | clean (LF->CRLF warnings only) |
