### PR TITLE
feat(story): render-variant + workshop vocabulary through the plan compiler (rf2-5x1wt.24)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -2608,8 +2608,81 @@ and test.
 | view wrapping (theme/provider/chrome) | `:decorator` |
 | the state matrix (theme × viewport × …) | `:variants-grid` / `:modes` |
 
-A Storybook→Story concept map (arg / argType / decorator / parameter /
-viewport → Story field) MUST ship in docs so migrants are at home.
+### Workshop superset — what the plan carries (rf2-5x1wt.24)
+
+The variant-plan compiler is the SINGLE compiler for render AND test, so
+the workshop vocabulary rides the SAME normalized plan the runner
+consumes (`re-frame.story.plan/variant-plan`). The compiler preserves
+every workshop slot under `:world`:
+
+| Authored slot | Plan slot | Meaning |
+|---|---|---|
+| `:component` | `[:world :component]` | the active view id `render-variant` paints |
+| `:args` / `:argtypes` | `[:world :args]` / `[:world :argtypes]` | control values + control metadata |
+| (resolved) | `[:world :effective-args]` | the args feeding the view — at plan time the resolved arg-map; `render-variant` layers the live control overrides on top |
+| `:decorators` | `[:world :decorators]` | view-wrapping decorators (theme / provider / chrome) — NOT fx overrides |
+| `:fx-overrides` | `[:world :frame :fx-overrides]` | effect overrides — a frame slot, a distinct surface from `:decorators` |
+| `:modes` / `:substrates` | `[:world :modes]` / `[:world :substrates]` | saved-tuple modes + the substrate set |
+| `:viewport` / `:background` | `[:world :viewport]` / `[:world :background]` | per-variant viewport + canvas background |
+| `:sub-overrides` | `[:world :render :sub-overrides]` | view-state overrides (the design-fidelity rung) |
+| `:variants-grid` | (workspace-level — `reg-workspace`) | the state matrix is a WORKSPACE layout, not a per-variant body slot; it enumerates registered variants rather than riding one |
+
+### `render-variant` — render through the same plan
+
+`(story/render-variant target opts)` is the workshop render verb (§Args,
+controls, and `render-variant`). It normalizes `target` through the SAME
+`variant-plan` compiler the runner uses (a keyword resolves a registered
+variant; a map is an inline plan), layers `opts`'s `:control-overrides` on
+top of the plan's `[:world :effective-args]` (deep-merge, the same
+precedence the run path uses), **re-validates** the post-control effective
+args against the `[:world :view-args-schema]`, computes the `:plan-hash`
+over the normalized plan, resolves the active view + render inputs, and
+renders the view through the host renderer.
+
+- A control that drives an invalid view input ⇒ `:invalid-args` (render
+  STOPS before the view is called). A control driving a control-bound
+  `:sub-overrides` value re-resolves against the post-control effective
+  args, so the live view reflects the control.
+- The `:plan-hash` is `fingerprint/plan-hash` over the SAME normalized
+  plan, so a runner (`story/run`) and `render-variant` agree on it
+  whenever the behaviour-relevant inputs match — render and run cannot
+  diverge on what the plan was.
+- `render-variant` prepares `:world` and renders the active view; it does
+  NOT execute `:script` or terminal `:expect` (rendering is not a test
+  run). The host render is a CLJS late-bound hook (`:render-host`); the
+  bare JVM has none, so `render-variant` returns `:cannot-run` there
+  rather than a silent empty render.
+
+### Storybook → Story concept map
+
+A migrant from Storybook is at home with this mapping (the full prose
+version ships in the docs guide):
+
+| Storybook | re-frame2 Story | Notes |
+|---|---|---|
+| `Meta` / `export default` (CSF) | `reg-story` | the story-level defaults (component, args, argTypes, tags) |
+| `Story` / named export | `reg-variant` | one curated variant; ALSO a test (Story-as-test duality) |
+| `args` | `:args` | control values; `[:arg key]` placeholders thread them into setup/script |
+| `argTypes` | `:argtypes` | control metadata; schema-derived from the view arg schema where possible |
+| `args` after controls panel | `:effective-args` | the post-control args `render-variant` feeds the view |
+| `decorators` | `:decorators` | view wrapping ONLY (theme/provider/chrome); fx mocking is `:fx-overrides` |
+| `parameters` | `:viewport` / `:background` / `:modes` / `:xray` / … | named workshop slots, not one opaque bag |
+| `parameters.viewport` | `:viewport` | per-variant viewport |
+| `parameters.backgrounds` | `:background` | per-variant canvas background |
+| Chromatic modes / globals | `:modes` | saved tuples deep-merged into args |
+| `loaders` | `:loaders` (+ `:loaders-teardown`) | async preconditions before render |
+| `play` function | `:script` | ordered behaviour; tagged steps, not imperative `userEvent` calls |
+| `expect(...)` in `play` | `:assertions` / `[:assert …]` | the one assertion atom, terminal or mid-script checkpoint |
+| MSW network mocks | `:network` | route-level managed-HTTP stubs (lowered to the managed-request stub fx) |
+| `render` / custom render | `:component` + `:sub-overrides` | the active view + the design-fidelity view-state overrides |
+| docs / autodocs | `:doc` + the narrative projection | the scrubbable epoch-tape storyboard is the asset Storybook cannot copy |
+
+The deliberate divergences from Storybook: a Story variant IS a test (one
+artifact, two outputs); `parameters` are named, typed slots rather than an
+opaque bag; the `play` script is data-shaped tagged steps (replayable +
+`=`-comparable) rather than imperative `userEvent` calls; and the
+`render-variant` render path drives the SAME plan the runner does, so the
+workshop preview and the regression test never disagree.
 
 ## P1 non-goals
 

--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -123,6 +123,12 @@
             [re-frame.story.async       :as async]
             [re-frame.story.lifecycle   :as lifecycle]
             [re-frame.story.query       :as query]
+            ;; rf2-5x1wt.24 — the variant-plan compiler (re-exported as
+            ;; `variant-plan` / `explain`) + the `render-variant` workshop
+            ;; render verb that drives the SAME plan the runner consumes
+            ;; (spec/017 §Args, controls, and `render-variant`).
+            [re-frame.story.plan        :as plan]
+            [re-frame.story.render      :as render]
             ;; rf2-5x1wt.19 — `story/is` bridges per-assertion run-result
             ;; reports to clojure.test / cljs.test (spec/017 §Public
             ;; execution API — the three verbs). `do-report` is the one
@@ -1351,6 +1357,64 @@
   §Public execution API)."
   ([target]      (run target nil))
   ([target opts] (lifecycle/run-variant target opts)))
+
+;; ---- variant-plan / explain / render-variant (rf2-5x1wt.24) -------------
+;;
+;; The variant-plan compiler is the ONE normalization both the runner and
+;; the workshop render path consume (spec/017 §Variant plan — every
+;; registered variant + inline plan MUST be normalized before execution).
+;; `variant-plan` / `explain` re-export the pure compiler; `render-variant`
+;; is the workshop render verb that drives the same plan.
+
+(defn variant-plan
+  "Per spec/017 §Variant plan — compile `target` into the normalized
+  variant plan (the `:world` / `:script` / `:expect` superset). A keyword
+  `target` resolves a registered variant; a map is an inline plan. `opts`
+  threads the compiler seams (`:lookup` / `:view-lookup` / `:validator-fns`
+  / `:sub-lookup` / `:fragment-lookup` / `:check-lookup`); production reads
+  the registrars. Pure data → data — the same plan the runner and
+  `render-variant` consume."
+  ([target]      (plan/variant-plan target))
+  ([target opts] (plan/variant-plan target opts)))
+
+(defn explain
+  "Per spec/017 §Explain API — the `:explain` map for `target` (source +
+  parent chain, composed fragments/checks, field-level merge decisions,
+  strict conflicts, args + substitutions, view-arg schema + effective-args
+  validation, final setup/script order, checks/assertions, runner
+  requirements, platforms, tags). Convenience over
+  `(:explain (variant-plan target opts))`."
+  ([target]      (plan/explain target))
+  ([target opts] (plan/explain target opts)))
+
+(defn render-variant
+  "Per spec/017 §Args, controls, and `render-variant` — render `target`'s
+  active workshop view from its normalized variant plan (the SAME plan the
+  test runner consumes — one plan, not two paths). A keyword `target`
+  resolves a registered variant; a map is an inline plan.
+
+  `opts` accepts `:control-overrides` (live control-panel arg overrides,
+  deep-merged on top of the plan's effective args — the post-control args)
+  plus the plan-compiler seams. Returns:
+
+      {:status         :rendered | :invalid-args | :cannot-run | :error
+       :plan           normalized-plan
+       :plan-hash      string
+       :frame          frame-id
+       :effective-args {...}          ; POST control-override
+       :validation     optional-validation-result
+       :rendered       host-render-result}
+
+  It prepares `:world` for rendering and renders the active view; it does
+  NOT execute `:script` or terminal `:expect` (rendering is not a test
+  run). The `:plan-hash` is computed over the SAME normalized plan as
+  `story/run`, so a runner and `render-variant` agree on it whenever the
+  behaviour-relevant inputs match (rf2-5x1wt.24). A control override that
+  drives an invalid view input STOPS render before the view is called
+  (`:invalid-args`); on the bare JVM (no host renderer) the verb returns
+  `:cannot-run` rather than a silent empty render."
+  ([target]      (render/render-variant target))
+  ([target opts] (render/render-variant target opts)))
 
 (defn- emit-reports!
   "Fire `clojure.test` / `cljs.test` `do-report` for each report map in

--- a/tools/story/src/re_frame/story/canonical.cljc
+++ b/tools/story/src/re_frame/story/canonical.cljc
@@ -28,11 +28,13 @@
             [re-frame.story.loaders      :as loaders]
             [re-frame.story.play         :as play]
             [re-frame.story.registrar    :as registrar]
+            [re-frame.story.render       :as render]
             [re-frame.story.runtime      :as runtime]
             [re-frame.story.save-variant :as save-variant]
             [re-frame.story.ui.cofx      :as ui-cofx]
             #?(:cljs [re-frame.story.ui.panels          :as ui-panels])
-            #?(:cljs [re-frame.story.ui.multi-substrate :as ui-multi-substrate])))
+            #?(:cljs [re-frame.story.ui.multi-substrate :as ui-multi-substrate])
+            #?(:cljs [re-frame.story.sub-overrides       :as sub-overrides])))
 
 (defn- install-late-bind-shims!
   "Wire the late-bound shims so the frames runtime can tap into the
@@ -44,6 +46,39 @@
     (fn [frame-id]
       (assertions/drop-trace-accumulators! frame-id)
       (play/drop-pending-exceptions! frame-id))))
+
+#?(:cljs
+   (defn- render-host-scope
+     "A Reagent component that renders the active `:view` under the host
+     substrate, binding the resolved `:sub-overrides` for the render extent
+     INSIDE the render fn (not at hiccup-construction time, which would have
+     unwound before React's deferred child render — the same pattern the
+     canvas's `sub-overrides-scope` uses). A design variant's pinned sub
+     values surface through `sub-overrides/read`; the binding never touches
+     app-db / `compute-sub`."
+     [{:keys [view frame effective-args sub-overrides]}]
+     (sub-overrides/with-overrides* sub-overrides
+       (fn []
+         (ui-multi-substrate/render-view :reagent frame view effective-args)))))
+
+#?(:cljs
+   (defn- install-render-host!
+     "Wire the `render-variant` host-render hook (rf2-5x1wt.24). The
+     render-prep core (`re-frame.story.render/prepare-render`) is host-free
+     + JVM-testable; the actual painting of the active view is this CLJS
+     hook. It renders the active `:view` under the host substrate's render
+     fn (`re-frame.story.ui.multi-substrate`), wrapped in the
+     `render-host-scope` component so the resolved `:sub-overrides` bind at
+     React render time (spec/017 §View-state subscription overrides). The
+     result is a hiccup tree (the Reagent default) — the SAME render the
+     canvas paints, so render-variant and the live shell agree.
+
+     The bare JVM installs NO render host, so `render-variant` returns
+     `:cannot-run` there rather than a silent empty render."
+     []
+     (render/install-render-host!
+       (fn [render-inputs]
+         [render-host-scope render-inputs]))))
 
 (def ^:private canonical-installers
   "Ordered vector of installer fns invoked by `install!`. Each takes
@@ -62,6 +97,7 @@
    layout-debug/install-canonical-layout-debug!
    ui-cofx/install-canonical-cofx!
    #?@(:cljs [ui-multi-substrate/install-reagent-substrate!
+              install-render-host!
               ui-panels/install-canonical-panels!])])
 
 ;; ---- auto-install gate (rf2-p1ydc) ---------------------------------------

--- a/tools/story/src/re_frame/story/plan.cljc
+++ b/tools/story/src/re_frame/story/plan.cljc
@@ -1180,8 +1180,15 @@
         ;; vectors — `[:arg]` substitution walks them too, so a query arg
         ;; can also be control-driven.
         frag-sub-ovr (reduce (fn [m l] (merge m (:sub-overrides l))) {} frag-layers)
-        sub-overrides (substitute-args (merge frag-sub-ovr (:sub-overrides ctx))
-                                       arg-map subs!)
+        ;; The RAW merged overrides BEFORE `[:arg key]` substitution — kept
+        ;; on the plan (`[:world :render :sub-overrides-raw]`) so the render
+        ;; path (rf2-5x1wt.24 `render-variant`) can RE-resolve the
+        ;; placeholders against the POST-control effective args (a control
+        ;; that drives an override value, e.g. `{[:login/error] [:arg
+        ;; :message]}`, must reflect the live control). The plan-time
+        ;; resolved overrides below feed validation + the run path.
+        sub-overrides-raw (merge frag-sub-ovr (:sub-overrides ctx))
+        sub-overrides (substitute-args sub-overrides-raw arg-map subs!)
         ;; ---- strict-conflict composition (rf2-5x1wt.15) ----
         ;; The strict-conflict override MAPS (`:fx-overrides` /
         ;; `:interceptor-overrides`) compose per-KEY: the variant chain
@@ -1401,7 +1408,16 @@
              :tags            (reduce (fn [acc layer] (merge-tags acc (:tags layer)))
                                       #{} bodies)
              :explain         explain}
-      source (assoc :source source)))))
+      source (assoc :source source)
+      ;; rf2-5x1wt.24 — the RAW (pre-`[:arg]`-substitution) sub-overrides.
+      ;; A SIBLING of `:world` (NOT inside it) so it stays OUT of
+      ;; `plan-hash-input-keys` — it is fully derivable from the resolved
+      ;; `[:world :render :sub-overrides]` + `:effective-args`, so hashing
+      ;; it would be redundant noise. `render-variant` re-resolves it
+      ;; against the POST-control effective args so a control that drives an
+      ;; override value reflects the live control (see
+      ;; `re-frame.story.render/resolve-render-sub-overrides`).
+      (seq sub-overrides-raw) (assoc-in [:render-raw :sub-overrides] sub-overrides-raw)))))
 
 (defn variant-plan
   "Compile `target` into a normalized variant plan (§Variant plan).

--- a/tools/story/src/re_frame/story/render.cljc
+++ b/tools/story/src/re_frame/story/render.cljc
@@ -1,0 +1,352 @@
+(ns re-frame.story.render
+  "`render-variant` — the workshop render verb that drives the SAME
+  variant-plan the test runner consumes (NewTestStory rf2-5x1wt.24,
+  `tools/story/spec/017-Testing-Story.md` §Args, controls, and
+  `render-variant` + §Storytelling superset).
+
+  ## One plan, two outputs
+
+  spec/017 §Args: *`render-variant` renders the workshop view from the
+  SAME plan the runner consumes. The live controls / visual-narrative
+  experience and the test runner drive one plan, not two paths.* This ns
+  is that single render entry point. It:
+
+  1. normalizes `target` through `re-frame.story.plan/variant-plan` (the
+     ONE compiler — a keyword target resolves a registered variant, a map
+     target is an inline plan, exactly as `story/run`);
+  2. layers the control-panel overrides (`:control-overrides`) on top of
+     the plan's `[:world :effective-args]` to produce the POST-OVERRIDE
+     effective args — the args that actually feed the rendered view;
+  3. re-validates those post-override effective args against the plan's
+     `[:world :view-args-schema]` (the §View-arg-schema contract), so a
+     control that drives an invalid value STOPS render before the view is
+     called (the `:invalid-args` status);
+  4. resolves the active view id + the render inputs (`:sub-overrides`,
+     `:decorators`, `:effective-args`) the host renderer needs;
+  5. renders the active view through the late-bound `:render-host` hook
+     (the host-render seam — CLJS-only; absent on the bare JVM, where the
+     verb returns `:cannot-run` because nothing can render);
+  6. returns the documented result shape.
+
+  ## What it does NOT do
+
+  `render-variant` prepares `:world` for rendering and renders the active
+  view. It MUST NOT execute `:script` or terminal `:expect` — rendering a
+  workshop view is not a test run (spec/017 §Args — *MUST NOT execute
+  `:script` or terminal `:expect` unless a future option explicitly asks
+  for a test run*). The plan's `:script` / `:expect` ride the result's
+  `:plan` slot (so a caller can see them), but this verb never drives them.
+
+  ## Result shape (spec/017 §Args — P1 render API)
+
+      {:status         :rendered | :invalid-args | :cannot-run | :error
+       :plan           normalized-plan
+       :plan-hash      string
+       :frame          frame-id
+       :effective-args {...}          ; POST control-override
+       :validation     optional-validation-result
+       :rendered       host-render-result}
+
+  - `:rendered`    — present on `:rendered` (the host render hook's return,
+                     e.g. a hiccup tree / React element / a render handle).
+  - `:validation`  — present whenever a view-arg schema was on file (the
+                     `:ok` outcome on a successful render; the `:invalid`
+                     outcome on `:invalid-args`).
+  - `:cannot-run`  — carries the capability refusal (spec/017
+                     §`:cannot-run`) when no host can render.
+  - `:error`       — carries the thrown ex-data when the host render fn
+                     throws.
+
+  ## Plan-hash agreement (acceptance — rf2-5x1wt.24)
+
+  The `:plan-hash` is `re-frame.story.fingerprint/plan-hash` over the SAME
+  normalized plan, so a runner (`story/run`) and `render-variant` agree on
+  the `:plan-hash` whenever the behaviour-relevant plan inputs match. A
+  control override that changes `[:world :effective-args]` perturbs the
+  hash exactly as it would on the run path — render and run cannot diverge
+  on what the plan was.
+
+  ## Purity / elision
+
+  `prepare-render` is pure data → data (it threads the same explicit
+  `:lookup` / `:view-lookup` / `:validator-fns` / `:sub-lookup` opts the
+  plan compiler takes), so the render-prep core is JVM-runnable under
+  `clojure -M:test` with NO host. The host render itself is the late-bound
+  `:render-host` hook a CLJS host installs; the bare JVM has none, so
+  `render-variant` returns `:cannot-run` there — never a silent empty
+  render. Per the §6 elision contract, a production CLJS build with Story
+  disabled renders nothing (`config/enabled?` is false)."
+  (:require [re-frame.story.args        :as args]
+            [re-frame.story.config      :as config]
+            [re-frame.story.fingerprint :as fingerprint]
+            [re-frame.story.late-bind   :as late-bind]
+            [re-frame.story.plan        :as plan]))
+
+;; ===========================================================================
+;; Render statuses
+;; ===========================================================================
+
+(def statuses
+  "The four `render-variant` statuses (spec/017 §Args — P1 render API):
+
+  - `:rendered`     — the active view was prepared + rendered;
+  - `:invalid-args` — the POST-override effective args violate the view-arg
+                      schema (render stopped BEFORE the view call);
+  - `:cannot-run`   — no host can render (the bare JVM, or Story disabled);
+  - `:error`        — the host render fn threw."
+  #{:rendered :invalid-args :cannot-run :error})
+
+;; ===========================================================================
+;; Host-render hook
+;; ===========================================================================
+
+(def ^:private render-host-hook-key
+  "The `re-frame.story.late-bind` hook key the CLJS host registers its
+  render fn under. The fn signature is `(render-inputs) → host-result`,
+  where `render-inputs` is the map `prepare-render` returns (the active
+  view id, the post-override effective args, the resolved sub-overrides,
+  the decorator stack, the frame id, and the plan). Absent on the bare JVM
+  (no DOM / no substrate), so `render-variant` returns `:cannot-run`."
+  :render-host)
+
+(defn install-render-host!
+  "Register the host render fn under the `:render-host` late-bind hook.
+  The CLJS shell calls this once at boot (from
+  `install-canonical-vocabulary!`); the fn takes the `prepare-render`
+  output map and returns the host render result (a hiccup tree / React
+  element / a mounted-handle). Idempotent (re-registration replaces)."
+  [render-fn]
+  (late-bind/set-fn! render-host-hook-key render-fn)
+  nil)
+
+(defn render-host-fn
+  "Return the installed `:render-host` fn, or nil when no host registered
+  one (the bare JVM render-prep-only path)."
+  []
+  (late-bind/get-fn render-host-hook-key))
+
+;; ===========================================================================
+;; Effective-args control overrides (rf2-5x1wt.24)
+;; ===========================================================================
+;;
+;; spec/017 §Args: `:effective-args` are *the args after control-panel
+;; overrides*. The plan compiler records the PLAN-TIME effective args (the
+;; resolved arg-map, BEFORE controls) at `[:world :effective-args]`;
+;; `render-variant` layers the live control overrides on top to produce the
+;; POST-override effective args that feed the rendered view. Both are the
+;; same deep-merge precedence the run path uses (`args/deep-merge`,
+;; later-wins), so a control override changes the effective args — and the
+;; plan-hash — exactly as it would on a run.
+
+(defn apply-control-overrides
+  "Layer control-panel `overrides` on top of the plan's `plan-eff-args`
+  (the resolved plan-time effective args). Pure data → data — deep-merge,
+  later wins (`args/deep-merge`), matching the run-path arg precedence
+  (`re-frame.story.args/resolve-args` — `variant-args < cell-overrides`).
+  A nil/empty `overrides` returns the plan effective args unchanged."
+  [plan-eff-args overrides]
+  (if (seq overrides)
+    (args/deep-merge (or plan-eff-args {}) overrides)
+    (or plan-eff-args {})))
+
+;; ===========================================================================
+;; Sub-override re-substitution against the post-override effective args
+;; ===========================================================================
+;;
+;; The plan compiler substitutes `[:arg key]` placeholders in the
+;; `:sub-overrides` VALUES against the plan-time args. When a control
+;; override changes an arg that a sub-override value references (e.g.
+;; `{[:login/error] [:arg :message]}` driven by a `:message` control), the
+;; render path must re-resolve the overrides against the POST-override
+;; effective args so the live view reflects the control. We re-run the SAME
+;; one-level substitution (`plan/substitute-args`) the plan compiler +
+;; the canvas render path use, against the post-override args. The plan
+;; already proved the overrides valid at compile time; re-substituting a
+;; control value cannot introduce a missing-arg (the control supplies the
+;; value), so this never throws under the render path.
+
+(defn resolve-render-sub-overrides
+  "Re-resolve the variant's `:sub-overrides` against the POST-override
+  effective args, so a control-driven override value (e.g.
+  `{[:login/error] [:arg :message]}` with a `:message` control) reflects
+  the LIVE control rather than the plan-time arg. Pure data → data; nil
+  when the plan carries no overrides.
+
+  Re-substitutes the RAW (pre-`[:arg]`) overrides the plan kept at
+  `[:render-raw :sub-overrides]` against `eff-args` — the SAME one-level
+  `plan/substitute-args` the plan compiler + the canvas render path use.
+  Falls back to the already-resolved `[:world :render :sub-overrides]` slot
+  for a plan that carries no raw form (e.g. a hand-built inline plan that
+  pre-resolved its overrides)."
+  [plan eff-args]
+  (if-let [raw (get-in plan [:render-raw :sub-overrides])]
+    (plan/substitute-args raw (or eff-args {}) (atom []))
+    (let [ovr (get-in plan [:world :render :sub-overrides])]
+      (when (seq ovr)
+        (plan/substitute-args ovr (or eff-args {}) (atom []))))))
+
+;; ===========================================================================
+;; Render preparation — the pure, JVM-testable core
+;; ===========================================================================
+
+(defn prepare-render
+  "Prepare the render inputs for `target` from its normalized variant
+  plan. Pure data → data — the JVM-testable core of `render-variant`.
+
+  `opts` accepts the plan-compiler opts (`:lookup` / `:view-lookup` /
+  `:validator-fns` / `:sub-lookup` / `:fragment-lookup` / `:check-lookup`)
+  PLUS:
+
+  - `:control-overrides` — the live control-panel arg overrides (a
+    `{arg-key value}` map), deep-merged on top of the plan's effective
+    args (spec/017 §Args — the post-control-override args).
+
+  Returns one of:
+
+  - `{:status :invalid-args :plan … :plan-hash … :frame … :effective-args
+      … :validation invalid-validation}` — the POST-override effective args
+    violate the plan's view-arg schema. Render is STOPPED before the active
+    view is called (spec/017 §View-arg-schema failures stop render).
+
+  - `{:status :prepared :plan … :plan-hash … :frame … :effective-args …
+      :validation ok-validation-or-nil :render-inputs {…}}` — the render
+    inputs are ready. `:render-inputs` carries `:view` (the active view
+    id), `:effective-args`, `:sub-overrides`, `:decorators`, `:frame`, and
+    `:plan`, the map the host `:render-host` hook consumes.
+
+  Plan construction itself may throw a `:rf.error/story-*` ex-info (an
+  unknown variant, a missing `[:arg …]`, a plan-time view-arg violation —
+  the COMPILE-TIME effective args, before controls); `render-variant`
+  catches that and projects it to `:error`. This fn re-validates the
+  POST-CONTROL effective args (the plan validated the pre-control ones), so
+  a control that drives an invalid value is the `:invalid-args` path here,
+  distinct from a malformed registration."
+  ([target] (prepare-render target nil))
+  ([target {:keys [control-overrides validator-fns] :as opts}]
+   (let [compile-opts (select-keys opts [:lookup :view-lookup :validator-fns
+                                         :sub-lookup :fragment-lookup :check-lookup])
+         plan         (plan/variant-plan target compile-opts)
+         frame        (:variant/id plan)
+         plan-eff     (get-in plan [:world :effective-args] {})
+         eff-args     (apply-control-overrides plan-eff control-overrides)
+         schema       (get-in plan [:world :view-args-schema])
+         ;; Re-validate the POST-override effective args. The plan already
+         ;; validated the PRE-override (resolved) args; a control override
+         ;; can drive a value the registration never carried, so the live
+         ;; render path re-checks before calling the view (spec/017 §Args —
+         ;; view-arg-schema failures stop render).
+         validation   (when schema
+                        (plan/validate-effective-args schema eff-args validator-fns))
+         ;; The plan-hash is over the normalized plan — render + run agree
+         ;; on it (rf2-5x1wt.24 acceptance). When controls change the
+         ;; effective args, reflect them in the hashed plan so the hash
+         ;; tracks what is actually rendered.
+         render-plan  (assoc-in plan [:world :effective-args] eff-args)
+         plan-hash    (fingerprint/plan-hash render-plan)
+         base         {:plan           render-plan
+                       :plan-hash      plan-hash
+                       :frame          frame
+                       :effective-args eff-args}]
+     (if (and validation (= :invalid (:status validation)))
+       (assoc base :status :invalid-args :validation validation)
+       (let [sub-overrides (resolve-render-sub-overrides plan eff-args)
+             render-inputs  (cond-> {:view           (get-in plan [:world :component])
+                                     :effective-args eff-args
+                                     :decorators     (get-in plan [:world :decorators])
+                                     :frame          frame
+                                     :plan           render-plan}
+                              (some? sub-overrides) (assoc :sub-overrides sub-overrides))]
+         (cond-> (assoc base :status :prepared :render-inputs render-inputs)
+           (some? validation) (assoc :validation validation)))))))
+
+;; ===========================================================================
+;; render-variant — the public verb
+;; ===========================================================================
+
+(defn- cannot-run-result
+  "The `:cannot-run` render result — no host can render (spec/017
+  §`:cannot-run`, the distinct THIRD status). Reuses the capability-axis
+  refusal vocabulary: rendering an active view requires the
+  `:hiccup-structure` proof (a host that can render-to-hiccup), which the
+  bare JVM lacks."
+  [prepared reason]
+  (-> (select-keys prepared [:plan :plan-hash :frame :effective-args :validation])
+      (assoc :status           :cannot-run
+             :required-runner  #{:hiccup-structure}
+             :available-runner #{}
+             :reason           reason)))
+
+(defn- error-result
+  "The `:error` render result — plan construction or the host render fn
+  threw. Carries the structured ex-data so tools surface the failure the
+  same way a run error surfaces."
+  [target e]
+  {:status :error
+   :frame  (when (keyword? target) target)
+   :error  {:message #?(:clj  (.getMessage ^Throwable e)
+                        :cljs (str e))
+            :data    (ex-data e)}})
+
+(defn render-variant
+  "Render `target`'s active workshop view from its normalized variant plan
+  (spec/017 §Args, controls, and `render-variant`). `target` is a keyword
+  (a registered variant) or a map (an inline plan) — the SAME target shapes
+  `story/run` normalizes.
+
+  `opts`:
+
+  - `:control-overrides` — live control-panel arg overrides, deep-merged on
+    top of the plan's effective args (the post-control-override args).
+  - `:lookup` / `:view-lookup` / `:validator-fns` / `:sub-lookup` /
+    `:fragment-lookup` / `:check-lookup` — threaded to the plan compiler
+    (host-free test seams; production reads the registrars).
+
+  Returns the documented result map (see ns docstring + spec/017 §Args —
+  P1 render API):
+
+      {:status         :rendered | :invalid-args | :cannot-run | :error
+       :plan           normalized-plan
+       :plan-hash      string
+       :frame          frame-id
+       :effective-args {...}
+       :validation     optional-validation-result
+       :rendered       host-render-result}
+
+  It prepares `:world` for rendering and renders the active view; it does
+  NOT execute `:script` or terminal `:expect` (rendering is not a test
+  run). When Story is disabled (a production CLJS build), it returns
+  `:cannot-run` immediately — the render verb never throws under elision."
+  ([target] (render-variant target nil))
+  ([target opts]
+   (if-not config/enabled?
+     ;; Production / disabled: nothing to render. The verb fails closed
+     ;; into `:cannot-run` rather than throwing (the §6 elision contract).
+     {:status :cannot-run :frame (when (keyword? target) target)
+      :required-runner #{:hiccup-structure} :available-runner #{}
+      :reason :story-disabled}
+     (try
+       (let [prepared (prepare-render target opts)]
+         (case (:status prepared)
+           :invalid-args
+           ;; Re-shape to the public result: drop the internal :status
+           ;; alias, surface the documented slots (spec/017 P1 render API).
+           (select-keys prepared
+                        [:status :plan :plan-hash :frame :effective-args :validation])
+
+           :prepared
+           (if-let [host (render-host-fn)]
+             (try
+               (let [rendered (host (:render-inputs prepared))]
+                 (-> (select-keys prepared
+                                  [:plan :plan-hash :frame :effective-args :validation])
+                     (assoc :status :rendered :rendered rendered)))
+               (catch #?(:clj Throwable :cljs :default) e
+                 (error-result target e)))
+             ;; No host render hook (the bare JVM / a pre-boot CLJS build):
+             ;; the render-prep is complete, but nothing can paint the view.
+             (cannot-run-result prepared :no-render-host))
+
+           ;; Defensive — prepare-render only returns the two states above.
+           (cannot-run-result prepared :render-prep-incomplete)))
+       (catch #?(:clj Throwable :cljs :default) e
+         (error-result target e))))))

--- a/tools/story/src/re_frame/story/ui/multi_substrate.cljs
+++ b/tools/story/src/re_frame/story/ui/multi_substrate.cljs
@@ -143,6 +143,20 @@
   []
   (register-substrate! :reagent reagent-render))
 
+(defn render-view
+  "Render `view-id` under `substrate` with `eff-args`, via the registered
+  substrate render fn — the clean reusable seam the `render-variant`
+  host-render hook (rf2-5x1wt.24) consumes. Returns the substrate's render
+  result (a hiccup vector for `:reagent`); a missing substrate yields an
+  inline diagnostic hiccup rather than throwing, so the render verb's
+  caller always sees *something*. `(fn [variant-id view-id args] …)` is the
+  substrate-render contract."
+  [substrate variant-id view-id eff-args]
+  (if-let [render-fn (get @substrate->render-fn substrate)]
+    (render-fn variant-id view-id eff-args)
+    [:div {:style {:color (:text-secondary colors/tokens) :font-style "italic"}}
+     (str "substrate :" (name substrate) " is not registered")]))
+
 ;; ---- failure-tolerant cell render ---------------------------------------
 
 (defn- safe-render-cell

--- a/tools/story/test/re_frame/story/render_test.cljc
+++ b/tools/story/test/re_frame/story/render_test.cljc
@@ -1,0 +1,370 @@
+(ns re-frame.story.render-test
+  "Tests for `render-variant` + the workshop-superset plan slots
+  (rf2-5x1wt.24).
+
+  Per `tools/story/spec/017-Testing-Story.md` §Args, controls, and
+  `render-variant` + §Storytelling superset, and
+  `ai/findings/NewTestStory` §B10. The render-prep core
+  (`re-frame.story.render/prepare-render`) is a pure data → data fn, so
+  every test runs on both the JVM and CLJS without a host: variant bodies
+  + view metadata are supplied through explicit `:lookup` / `:view-lookup`
+  maps. The host-render path (`render-variant` proper) is exercised by
+  installing a fake `:render-host` hook so the `:rendered` shape + the
+  no-host `:cannot-run` refusal are both pinned."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [malli.core :as m]
+            [re-frame.story.fingerprint :as fingerprint]
+            [re-frame.story.late-bind :as late-bind]
+            [re-frame.story.plan :as plan]
+            [re-frame.story.render :as render]))
+
+;; ---- fixtures ------------------------------------------------------------
+;;
+;; The host-render hook is a process-global late-bind slot shared with the
+;; canonical-vocabulary shims (`:tap-stub-event`, `:drop-assertion-
+;; accumulators`). We MUST NOT `late-bind/clear!` (that wipes those shims +
+;; breaks every sibling test ns). Instead we snapshot the hooks map before
+;; each test (so a stray `:render-host` from a prior test is gone) and
+;; restore it after — surgical, never global.
+
+(use-fixtures :each
+  (fn [t]
+    (let [snapshot @late-bind/hooks]
+      ;; Drop only the render-host slot so the no-host :cannot-run tests
+      ;; start clean; leave every canonical shim in place.
+      (swap! late-bind/hooks dissoc :render-host)
+      (try (t) (finally (reset! late-bind/hooks snapshot))))))
+
+;; ---- helpers -------------------------------------------------------------
+
+(def ^:private malli-validator
+  "The `{:validate :explain}` validator pair the render-prep threads for
+  malformed-value checking — a real Malli runtime, so the JVM tests can
+  pin the malformed-value path, not only required-key presence."
+  {:validate (fn [schema value] (m/validate schema value))
+   :explain  (fn [schema value] (m/explain schema value))})
+
+(defn- prepare
+  "Run `prepare-render` against an explicit body `lookup` + optional
+  `view-lookup` / opts. The render-prep core; no host needed."
+  ([target lookup] (prepare target lookup nil))
+  ([target lookup view-lookup] (prepare target lookup view-lookup nil))
+  ([target lookup view-lookup extra]
+   (render/prepare-render
+     target
+     (cond-> {:lookup lookup}
+       (some? view-lookup) (assoc :view-lookup view-lookup)
+       (map? extra)        (merge extra)))))
+
+;; ===========================================================================
+;; Workshop-superset plan slots (§B10 task #1)
+;; ===========================================================================
+
+(deftest workshop-vocabulary-flows-through-the-plan
+  (testing "argtypes / decorators / modes / substrates / viewport / background
+            / component all ride the normalized plan's :world"
+    (let [body {:component   :view.button/primary
+                :args        {:label "Go"}
+                :argtypes    {:label {:control :text}}
+                :decorators  [[:decorator.theme/dark]]
+                :modes       #{:mode/dark}
+                :substrates  #{:reagent :uix}
+                :viewport    :viewport/mobile
+                :background  :background/dark}
+          p    (plan/variant-plan :story.button/primary {:lookup {:story.button/primary body}})
+          w    (:world p)]
+      (is (= :view.button/primary (:component w)))
+      (is (= {:label {:control :text}} (:argtypes w)))
+      (is (= [[:decorator.theme/dark]] (:decorators w)))
+      (is (= #{:mode/dark} (:modes w)))
+      (is (= #{:reagent :uix} (:substrates w)))
+      (is (= :viewport/mobile (:viewport w)))
+      (is (= :background/dark (:background w)))
+      (testing ":effective-args is recorded as the post-substitution args"
+        (is (= {:label "Go"} (:effective-args w)))))))
+
+;; ===========================================================================
+;; prepare-render — the documented shape (§B10 task #5)
+;; ===========================================================================
+
+(deftest prepare-render-returns-prepared-shape
+  (testing "a renderable variant prepares the documented slots"
+    (let [body {:component :view.button/primary :args {:label "Go"}}
+          r    (prepare :story.button/primary {:story.button/primary body})]
+      (is (= :prepared (:status r)))
+      (is (= :story.button/primary (:frame r)))
+      (is (= {:label "Go"} (:effective-args r)))
+      (is (string? (:plan-hash r)))
+      (is (map? (:plan r)))
+      (testing ":render-inputs carry what the host renderer needs"
+        (let [ri (:render-inputs r)]
+          (is (= :view.button/primary (:view ri)))
+          (is (= {:label "Go"} (:effective-args ri)))
+          (is (= :story.button/primary (:frame ri))))))))
+
+;; ===========================================================================
+;; Controls update :effective-args + render through the SAME plan (§B10 test 1)
+;; ===========================================================================
+
+(deftest control-overrides-update-effective-args
+  (testing "control-overrides deep-merge on top of the plan effective args"
+    (let [body {:component :view.button/primary :args {:label "Go" :size :md}}
+          r    (prepare :story.button/primary {:story.button/primary body}
+                        nil {:control-overrides {:label "Stop"}})]
+      (is (= :prepared (:status r)))
+      (testing "the override wins; un-overridden args persist (deep-merge)"
+        (is (= {:label "Stop" :size :md} (:effective-args r))))
+      (testing "the post-override args feed the render inputs"
+        (is (= {:label "Stop" :size :md}
+               (get-in r [:render-inputs :effective-args])))))))
+
+(deftest control-overrides-perturb-plan-hash
+  (testing "a control override that changes :effective-args perturbs the
+            plan-hash — render tracks what is actually rendered"
+    (let [body {:component :view.button/primary :args {:label "Go"}}
+          lk   {:story.button/primary body}
+          base (prepare :story.button/primary lk)
+          ovr  (prepare :story.button/primary lk nil {:control-overrides {:label "Stop"}})]
+      (is (not= (:plan-hash base) (:plan-hash ovr)))
+      (testing "an override equal to the plan value does NOT change the hash"
+        (let [same (prepare :story.button/primary lk nil
+                            {:control-overrides {:label "Go"}})]
+          (is (= (:plan-hash base) (:plan-hash same))))))))
+
+;; ===========================================================================
+;; View-arg schema failures stop render before an invalid view call (§B10 test 2)
+;; ===========================================================================
+
+(def ^:private button-view-meta
+  "A registered-view metadata map carrying a props schema (the `:rf/props`
+  spec-named key) — a required `:label` string + an optional `:size`."
+  {:rf/props [:map
+              [:label :string]
+              [:size {:optional true} :keyword]]})
+
+(deftest plan-time-missing-required-arg-fails-construction
+  (testing "a required view input absent at PLAN time fails plan
+            construction (the compile-time floor — render never starts)"
+    ;; No :args at all → :label missing → variant-plan throws.
+    (is (thrown-with-msg?
+          #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
+          #"story-view-args-invalid"
+          (prepare :story.button/bad
+                   {:story.button/bad {:component :view.button/primary}}
+                   {:view.button/primary button-view-meta})))))
+
+(deftest control-override-that-violates-schema-is-invalid-args
+  (testing "a control that drives a MISSING required arg is :invalid-args —
+            render stops before the view call (post-control re-validation)"
+    ;; The plan is valid (:label present); a control override nils it out,
+    ;; so the POST-override effective args drop the required key.
+    (let [body {:component :view.button/primary :args {:label "Go"}}
+          r    (render/prepare-render
+                 :story.button/primary
+                 {:lookup      {:story.button/primary body}
+                  :view-lookup {:view.button/primary button-view-meta}
+                  :validator-fns malli-validator
+                  ;; Override :label to a non-string — malformed value.
+                  :control-overrides {:label 42}})]
+      (is (= :invalid-args (:status r)))
+      (is (= :invalid (get-in r [:validation :status])))
+      (is (= [:label] (-> r :validation :malformed first :path)))
+      (testing "no :render-inputs are produced (render stopped pre-view)"
+        (is (not (contains? r :render-inputs)))))))
+
+(deftest valid-effective-args-prepare-with-ok-validation
+  (testing "valid post-override args carry an :ok validation outcome"
+    (let [body {:component :view.button/primary :args {:label "Go"}}
+          r    (render/prepare-render
+                 :story.button/primary
+                 {:lookup      {:story.button/primary body}
+                  :view-lookup {:view.button/primary button-view-meta}
+                  :validator-fns malli-validator})]
+      (is (= :prepared (:status r)))
+      (is (= :ok (get-in r [:validation :status]))))))
+
+;; ===========================================================================
+;; render-variant returns the documented shape + does NOT run script/expect
+;; (§B10 test 3)
+;; ===========================================================================
+
+(deftest render-variant-renders-via-host-hook
+  (testing "with a host hook installed, render-variant returns :rendered +
+            the documented slots, and the host saw the prepared render inputs"
+    (let [seen (atom nil)]
+      (render/install-render-host!
+        (fn [inputs] (reset! seen inputs) [:fake-rendered (:view inputs)]))
+      (let [body {:component :view.button/primary :args {:label "Go"}}
+            r    (render/render-variant
+                   :story.button/primary
+                   {:lookup {:story.button/primary body}})]
+        (is (= :rendered (:status r)))
+        (is (= :story.button/primary (:frame r)))
+        (is (= {:label "Go"} (:effective-args r)))
+        (is (string? (:plan-hash r)))
+        (is (= [:fake-rendered :view.button/primary] (:rendered r)))
+        (testing "the host received the render inputs, NOT a test run"
+          (is (= :view.button/primary (:view @seen)))
+          (is (= {:label "Go"} (:effective-args @seen))))))))
+
+(deftest render-variant-does-not-run-script-or-expect
+  (testing "render-variant prepares world + renders the view; it NEVER
+            dispatches the :script or evaluates terminal :expect"
+    (let [dispatched (atom [])]
+      (render/install-render-host!
+        (fn [inputs]
+          ;; A correct host renders the view; it must not be handed (and
+          ;; must not run) the plan's :script / :expect.
+          (is (not (contains? inputs :script)))
+          [:rendered]))
+      (let [body {:component  :view.button/primary
+                  :args       {:label "Go"}
+                  :script     [[:dispatch [:should/not-run]]]
+                  :assertions [[:rf.assert/path-equals [:x] 1]]}
+            r    (render/render-variant
+                   :story.button/primary
+                   {:lookup {:story.button/primary body}})]
+        (is (= :rendered (:status r)))
+        (testing "the plan still carries the script/expect (visible, not run)"
+          (is (= [[:dispatch [:should/not-run]]] (get-in r [:plan :script])))
+          (is (= [[:rf.assert/path-equals [:x] 1]]
+                 (get-in r [:plan :expect :assertions]))))
+        (testing "nothing was dispatched (render is not a run)"
+          (is (= [] @dispatched)))))))
+
+(deftest render-variant-no-host-is-cannot-run
+  (testing "without a host render hook (the bare JVM), render-variant
+            returns :cannot-run — never a silent empty render"
+    (let [body {:component :view.button/primary :args {:label "Go"}}
+          r    (render/render-variant
+                 :story.button/primary
+                 {:lookup {:story.button/primary body}})]
+      (is (= :cannot-run (:status r)))
+      (is (= #{:hiccup-structure} (:required-runner r)))
+      (is (= #{} (:available-runner r)))
+      (is (= :no-render-host (:reason r)))
+      (testing "the prepared plan + hash still ride the refusal"
+        (is (string? (:plan-hash r)))
+        (is (= :story.button/primary (:frame r)))))))
+
+(deftest render-variant-invalid-args-skips-host
+  (testing "an :invalid-args result is returned BEFORE the host hook runs"
+    (let [called (atom false)]
+      (render/install-render-host! (fn [_] (reset! called true) [:rendered]))
+      (let [body {:component :view.button/primary :args {:label "Go"}}
+            r    (render/render-variant
+                   :story.button/primary
+                   {:lookup      {:story.button/primary body}
+                    :view-lookup {:view.button/primary button-view-meta}
+                    :validator-fns malli-validator
+                    :control-overrides {:label 42}})]
+        (is (= :invalid-args (:status r)))
+        (is (false? @called))
+        (testing "the documented :invalid-args slots are present"
+          (is (= :story.button/primary (:frame r)))
+          (is (= :invalid (get-in r [:validation :status]))))))))
+
+(deftest render-variant-host-throw-is-error
+  (testing "a throw from the host render fn is projected to :error"
+    (render/install-render-host!
+      (fn [_] (throw (ex-info "boom" {:rf.error/id :test/boom}))))
+    (let [body {:component :view.button/primary :args {:label "Go"}}
+          r    (render/render-variant
+                 :story.button/primary
+                 {:lookup {:story.button/primary body}})]
+      (is (= :error (:status r)))
+      (is (= :test/boom (get-in r [:error :data :rf.error/id]))))))
+
+(deftest render-variant-unknown-variant-is-error
+  (testing "an unknown keyword target throws in the compiler → :error"
+    (let [r (render/render-variant :story.nope/missing {:lookup {}})]
+      (is (= :error (:status r)))
+      (is (= :rf.error/story-unknown-variant
+             (get-in r [:error :data :rf.error/id]))))))
+
+;; ===========================================================================
+;; Inline-plan map target (§B10 — render-variant for BOTH registered +
+;; inline plans)
+;; ===========================================================================
+
+(deftest render-variant-accepts-inline-plan-map
+  (testing "a map target is an inline plan — rendered the same as a
+            registered keyword (no registration needed)"
+    (render/install-render-host! (fn [inputs] [:rendered (:view inputs)]))
+    (let [r (render/render-variant
+              {:variant/id :story.inline/v
+               :component  :view.button/primary
+               :args       {:label "Inline"}})]
+      (is (= :rendered (:status r)))
+      (is (= :story.inline/v (:frame r)))
+      (is (= {:label "Inline"} (:effective-args r)))
+      (is (= [:rendered :view.button/primary] (:rendered r))))))
+
+;; ===========================================================================
+;; Runner ↔ render-variant agree on :plan-hash where inputs match
+;; (§B10 test 4)
+;; ===========================================================================
+
+(deftest render-variant-plan-hash-matches-the-runner-plan-hash
+  (testing "render-variant's :plan-hash == fingerprint/plan-hash over the
+            normalized plan a runner consumes (behaviour-relevant inputs match)"
+    (let [body {:component :view.button/primary
+                :args      {:label "Go"}
+                :setup     [[:dispatch [:counter/init 5]]]
+                :script    [[:dispatch [:counter/inc]]]}
+          lk   {:story.button/primary body}
+          ;; the plan the RUNNER would compile + hash
+          runner-plan (plan/variant-plan :story.button/primary {:lookup lk})
+          runner-hash (fingerprint/plan-hash runner-plan)
+          ;; the plan-hash render-variant reports (no control overrides →
+          ;; the effective args match the runner's resolved args)
+          render-prep (prepare :story.button/primary lk)]
+      (is (= runner-hash (:plan-hash render-prep)))
+      (testing "the runner's plan still carries the (un-run) script/expect"
+        (is (= [[:dispatch [:counter/inc]]] (:script runner-plan)))))))
+
+;; ===========================================================================
+;; Decorators are view-wrapping; fx-overrides live in :fx-overrides
+;; (§B10 test 5)
+;; ===========================================================================
+
+(deftest decorators-are-view-wrapping-fx-overrides-are-separate
+  (testing "decorators ride :world :decorators (view wrapping); fx overrides
+            ride [:world :frame :fx-overrides] — distinct surfaces"
+    (let [body {:component    :view.button/primary
+                :args         {:label "Go"}
+                :decorators   [[:decorator.theme/dark]]
+                :fx-overrides {:http/get :stub.http/ok}}
+          r    (prepare :story.button/primary {:story.button/primary body})
+          plan (:plan r)]
+      (is (= :prepared (:status r)))
+      (testing "decorators are view-wrapping render inputs"
+        (is (= [[:decorator.theme/dark]] (get-in r [:render-inputs :decorators])))
+        (is (= [[:decorator.theme/dark]] (get-in plan [:world :decorators]))))
+      (testing "fx-overrides are a frame slot, NOT a render-input decorator"
+        (is (= {:http/get :stub.http/ok}
+               (get-in plan [:world :frame :fx-overrides])))
+        (is (not= (get-in plan [:world :decorators])
+                  (get-in plan [:world :frame :fx-overrides])))))))
+
+;; ===========================================================================
+;; sub-overrides re-resolve against the post-control effective args
+;; ===========================================================================
+
+(deftest sub-overrides-reflect-control-overrides
+  (testing "a sub-override value driven by an [:arg key] re-resolves against
+            the POST-control effective args (a control drives the design state)"
+    (render/install-render-host! (fn [inputs] inputs))
+    (let [body {:component     :view.login/form
+                :args          {:message "Invalid password"}
+                :sub-overrides {[:login/state] :error
+                                [:login/error] [:arg :message]}}
+          r    (render/render-variant
+                 :story.login/error
+                 {:lookup {:story.login/error body}
+                  :control-overrides {:message "Account locked"}})]
+      (is (= :rendered (:status r)))
+      (testing "the rendered inputs carry the control-driven override value"
+        (is (= {[:login/state] :error
+                [:login/error] "Account locked"}
+               (get-in r [:rendered :sub-overrides])))))))


### PR DESCRIPTION
## What

NewTestStory plan **B10** — carry the storytelling/workshop surfaces through the **same** variant-plan compiler the test runner consumes, and add the `story/render-variant` workshop render verb.

- **Workshop superset (task #1).** The plan compiler already preserved the workshop vocabulary under `:world` (`:component`, `:args`/`:argtypes`, `:decorators`, `:fx-overrides` lowered to `[:world :frame :fx-overrides]`, `:modes`, `:substrates`, `:viewport`, `:background`, `:sub-overrides`). `:variants-grid` is a workspace-level layout (`reg-workspace`), not a per-variant body slot, so it stays at the workspace level. Pinned by a test.
- **`:effective-args` post-control (tasks #2/#3).** `render-variant` layers `:control-overrides` on top of the plan's `[:world :effective-args]` (deep-merge, the same precedence the run path uses) and **re-validates** the post-control args against the `[:world :view-args-schema]`. A control driving an invalid view input is `:invalid-args` (render stops before the view call).
- **`render-variant` (tasks #4/#5/#6).** New ns `re-frame.story.render` — a pure, JVM-testable `prepare-render` core plus the public verb. Supports BOTH registered keyword targets and inline plan maps. Returns `{:status :rendered | :invalid-args | :cannot-run | :error, :plan, :plan-hash, :frame, :effective-args, :validation, :rendered}`. It prepares world/render inputs and renders the active view through a late-bound CLJS `:render-host` hook; it does **NOT** run `:script` or terminal `:expect`. The bare JVM has no host hook, so the verb returns `:cannot-run` (never a silent empty render).
- **Plan-hash agreement (acceptance).** `render-variant`'s `:plan-hash` equals `fingerprint/plan-hash` over the same normalized plan the runner consumes; a control override that changes `:effective-args` perturbs it identically on both paths.
- **Sub-overrides re-resolution.** The plan keeps the raw (pre-`[:arg]`) `:sub-overrides` at a `:render-raw` sibling slot (outside `:world`, so out of the plan-hash) so a control-driven override value re-resolves against the post-control effective args.
- **Docs (task #7).** spec/017 "Relationship to the workshop surface" gains a workshop-superset plan-slot table, the `render-variant` render contract, and the **Storybook to Story concept map** (with the deliberate divergences called out).

## Result shape

    (story/render-variant target opts)
    ;; -> {:status :rendered | :invalid-args | :cannot-run | :error
    ;;     :plan normalized-plan :plan-hash "..." :frame :story.x/y
    ;;     :effective-args {...}          ; POST control-override
    ;;     :validation {:status :ok|:invalid ...}
    ;;     :rendered host-render-result}

## Quality gates

| Gate | Command | Result |
|---|---|---|
| Story JVM | `tools/story` then `clojure -M:test` | PASS — 1160 tests, 3684 assertions, 0 failures, 0 errors |
| story-mcp JVM (downstream consumer) | `tools/story-mcp` then `clojure -M:test` | PASS — 172 tests, 861 assertions, 0 failures, 0 errors |
| cum40 conformance (story-mcp MCP-client) | `tools/mcp-conformance` then `npm run test:story` | PASS — STORY-MCP MCP-CLIENT CONFORMANCE GREEN, exit 0 |
| CLJS node | `implementation` then `npm run test:cljs` | PASS — 4850 tests, 15890 assertions, 0 failures, 0 errors |
| Production elision | `implementation` then `npm run test:elision` | PASS — 40/40 absent in production bundle |
| Fast PR spine + markdown gates | `scripts/test-fast-pr.sh` | PASS (mkdocs --strict soft-skipped locally — not on PATH; CI runs it) |
| Doc-slug anchor validator | `python scripts/check_doc_slugs.py` | PASS — exit 0 |

## Notes
- No production ns hard-requires a test-only dep; the render path uses the existing late-bound facades (the `:render-host` hook plus the untouched `epoch-history` facade in the runtime).
- Bead `.20` (inline plans) and `.30` (reactive probe) are held pending this merge; the `plan.cljc` inline-map path and the `render-variant` map-target path are clean and reusable for `.20` to build on.
