### PR TITLE
feat(story): browser-tier visual + a11y assertions (rf2-5x1wt.28)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -1143,9 +1143,11 @@ remains the base. P1 SHOULD include or retain:
 - `:rf.assert/dom-visible` / `:rf.assert/dom-hidden` / `:rf.assert/dom-text`
   (NET-NEW; the `:dom` family the shipping `:assert-dom` step folds to —
   §Assertions — one atom, two positions)
-- `:rf.assert/visual-snapshot` (`:browser`)
-- `:rf.assert/a11y` (`:browser` for axe-style; MAY require only `:hiccup`
-  for explicitly structural checks)
+- `:rf.assert/visual-snapshot` (`:browser` / `:pixels`)
+- `:rf.assert/a11y` (`:browser` / `:a11y-engine` for axe-style)
+- `:rf.assert/a11y-structural` (`:hiccup` — the explicitly STRUCTURAL
+  accessibility check; runs on the rendered hiccup tree without a real
+  browser, §Visual, a11y, and browser checks)
 
 Future assertion candidates after instrumentation support include
 `:rf.assert/caused` and `:rf.assert/no-cascade-rerender`; both require a
@@ -2080,6 +2082,67 @@ MUST opt into their required runner:
 They SHOULD reuse the same run-result shape, and SHOULD pair pixel/DOM
 findings with app-db, args, trace, and epoch evidence when possible.
 
+### The browser-tier assertion ids (rf2-5x1wt.28)
+
+Three assertion ids cover the visual / a11y surface; each carries its
+capability requirement through the requirement registry
+(`re-frame.story.requirements/assertion-capabilities`) and is recognised by
+the plan compiler (`re-frame.story.assertions/known-assertion-ids`):
+
+| Assertion | Token | Runner | Proof |
+|---|---|---|---|
+| `:rf.assert/visual-snapshot` | `:pixels` | `:browser` | real-browser screenshot + pixel diff (or the reused `content-hash` snapshot identity) |
+| `:rf.assert/a11y` | `:a11y-engine` | `:browser` | axe-style scan (reuses the `re-frame.story.ui.a11y` axe-core hook) |
+| `:rf.assert/a11y-structural` | `:hiccup-structure` | `:hiccup` | pure structural a11y facts over the rendered hiccup tree |
+
+`:rf.assert/visual-snapshot` and `:rf.assert/a11y` are browser-only. The
+NET-NEW `:rf.assert/a11y-structural` is the spec's *structural a11y checks
+MAY require only `:hiccup`* rung: it inspects the rendered hiccup TREE
+(data) for structural facts — an `:img` with no `:alt`, an interactive
+control with no accessible name, a positive `:tabIndex` — without a real
+browser or the axe engine. Because the hiccup tree is data, it is fully
+JVM-testable and the `:hiccup` runner satisfies it. Semantic checks that
+genuinely need layout/contrast (colour contrast, computed visibility) stay
+on `:rf.assert/a11y`.
+
+### The executor: reuse, not a second system
+
+The browser-tier executor (`re-frame.story.play.browser`) is the SAME
+shape as the DOM executor (`re-frame.story.play.dom`): pure-data evaluators
+with a single host probe (`browser-available?`) isolated at the edge. It
+produces the ONE assertion record (§Run result — Assertion record) every
+other assertion produces — a visual/a11y finding rides the EXISTING
+assertion-record accumulator, NOT a parallel result accumulator. **No new
+run-result slot is added**; a finding is an assertion record like any
+other, so Test mode, CI, `clojure.test`, and MCP read it through the
+unified result with no special-casing.
+
+The executor REUSES the two seams the tree already ships rather than adding
+a differ or a second axe loader:
+
+- visual — `re-frame.story.identity/snapshot-identity` (the `content-hash`
+  visual-regression KEY the MCP `snapshot-identity` tool already surfaces)
+  is the snapshot identity the finding records; a real pixel diff lands
+  with the `:pixels` browser runner;
+- a11y — `re-frame.story.ui.a11y` (the in-browser axe-core panel + its
+  `violations-by-frame` atom the MCP `run-a11y` tool already reads). The
+  CLJS-only panel REGISTERS its violations-reader into a one-way late-bound
+  seam (`register-a11y-reader!`); the below-the-UI `.cljc` executor reads
+  through it without a compile-time dependency on the UI ns (the
+  bundle-isolation rule: nothing in a production path `:require`s the UI).
+
+### Fail-closed: headless returns `:cannot-run`
+
+A browser-tier assertion under a runner that lacks its token resolves to
+`:cannot-run` — the distinct THIRD status, never a silent pass
+(§`:cannot-run`). This is enforced on two sides: the capability gate
+(§Runner requirements) refuses a `:pixels` / `:a11y-engine` requirement
+under a headless runner at selection time, and the executor itself returns
+a `:cannot-run` record when `browser-available?` is false (JVM, node, or a
+CLJS REPL with no `js/window`). A headless run therefore returns
+`:cannot-run` for `:rf.assert/visual-snapshot` and `:rf.assert/a11y`; the
+structural check runs at `:hiccup`.
+
 ## CI policy
 
 CI MUST keep cheap headless plan tests on the normal path. CI SHOULD run
@@ -2093,6 +2156,34 @@ The Story play/script gate MUST continue to exist under a current name.
 If `test:story-play-scripts` is renamed, docs and package scripts MUST be
 updated together. Browser-tier visual/a11y gates MUST run only variants
 whose assertions require them, or a deliberate selected subset.
+
+### Browser-tier gate policy (rf2-5x1wt.28)
+
+The structural-a11y check (`:rf.assert/a11y-structural`, `:hiccup`) carries
+NO browser dependency, so it runs on the NORMAL test path — the executor's
+structural-issue walk is a pure JVM/CLJS test (`clojure -M:test` /
+`npm run test:cljs`), needing no dedicated browser gate. The
+browser-only ids (`:rf.assert/visual-snapshot` / `:rf.assert/a11y`) require
+a real-browser runner (`:pixels` / `:a11y-engine`); their gate runs ONLY
+the variants whose assertions require those tokens (the `:required-runner`
+union selects them), or a deliberately curated subset — never the whole
+corpus dragged to `:browser`.
+
+The `:cannot-run` policy for the browser-tier gate is **route to a richer
+runner**: a variant carrying a `:pixels` / `:a11y-engine` assertion is
+selected INTO the browser gate (where it can be proven), rather than being
+failed or reported inconclusive on the cheap headless path. On the cheap
+headless path a browser-tier assertion is `:cannot-run` and the gate's
+policy there is **report inconclusive** (the headless gate proves the
+headless floor; it does not fail a run merely for carrying a browser-tier
+assertion it was never meant to attempt). This split keeps the cheap path
+cheap and confines real-browser cost to the variants that genuinely need
+it.
+
+This is the normative POLICY; the concrete CI workflow that wires a
+dedicated browser-tier gate (selecting variants by `:required-runner` and
+running them under a `:pixels` / `:a11y-engine` runner) is a separate
+piece of work and is NOT part of this spec change.
 
 ## Promotion
 

--- a/tools/story/src/re_frame/story/assertions.cljc
+++ b/tools/story/src/re_frame/story/assertions.cljc
@@ -572,17 +572,57 @@
     id-dom-hidden
     id-dom-text})
 
+;; ---------------------------------------------------------------------------
+;; Browser-tier assertion family — visual snapshot + axe-style a11y +
+;; structural a11y (rf2-5x1wt.28, NET-NEW; spec/017 §Visual, a11y, and
+;; browser checks + §Canonical P1 assertions).
+;;
+;; These are NOT a separate visual-testing system — they are richer
+;; runner-tiered assertions on the SAME variant/result model. They ride the
+;; ONE assertion-record shape every other assertion produces; the executor
+;; (`re-frame.story.play.browser`) projects findings into that record. Each
+;; carries its capability requirement via the requirement registry
+;; (`re-frame.story.requirements/assertion-capabilities`):
+;;
+;;   :rf.assert/visual-snapshot  → :pixels       (real browser; headless → :cannot-run)
+;;   :rf.assert/a11y             → :a11y-engine   (axe-style; headless → :cannot-run)
+;;   :rf.assert/a11y-structural  → :hiccup-structure (hiccup tree; runs at :hiccup)
+;;
+;; The visual / axe-a11y runners are browser-tier and refuse with
+;; `:cannot-run` under a headless runner (the fail-closed contract — never
+;; a silent pass — is the `re-frame.story.requirements` capability gate's
+;; concern, not this id declaration's). The structural-a11y check is pure
+;; over the rendered hiccup tree, so the `:hiccup` runner proves it.
+;; ---------------------------------------------------------------------------
+
+(def ^:const id-visual-snapshot  :rf.assert/visual-snapshot)
+(def ^:const id-a11y             :rf.assert/a11y)
+(def ^:const id-a11y-structural  :rf.assert/a11y-structural)
+
+(def browser-assertion-ids
+  "The browser-tier oracle assertion family (rf2-5x1wt.28). Visual snapshot
+  and axe-style a11y are browser-only (`:pixels` / `:a11y-engine`); the
+  structural a11y check rides the `:hiccup` tier. All three ride the ONE
+  assertion atom + the ONE assertion-record shape — they are runner-tiered
+  assertions, NOT a separate visual-testing system (spec/017 §Visual, a11y,
+  and browser checks)."
+  #{id-visual-snapshot
+    id-a11y
+    id-a11y-structural})
+
 (def known-assertion-ids
   "Every assertion id the P1 vocabulary recognises — the shipping seven,
-  the folded DOM family, and the wider set declared in the requirement
-  registry (`re-frame.story.requirements/assertion-capabilities`: the
-  schema / visual / a11y / reactive-count ids whose runners land later).
-  Plan construction validates authored assertion atoms against this set
-  (`assertion-id-known?`); an unknown id FAILS plan construction with a
-  useful error (rf2-5x1wt.18, spec/017 §Assertions). Reading the
-  requirement registry keeps this list a derived view of the ONE id
-  source of truth rather than a hand-maintained parallel set."
-  (into (into canonical-assertion-ids dom-assertion-ids)
+  the folded DOM family, the browser-tier oracle family (visual / a11y /
+  structural-a11y), and the wider set declared in the requirement registry
+  (`re-frame.story.requirements/assertion-capabilities`: the schema /
+  visual / a11y / reactive-count ids whose runners land later or are
+  browser-tiered). Plan construction validates authored assertion atoms
+  against this set (`assertion-id-known?`); an unknown id FAILS plan
+  construction with a useful error (rf2-5x1wt.18, spec/017 §Assertions).
+  Reading the requirement registry keeps this list a derived view of the
+  ONE id source of truth rather than a hand-maintained parallel set."
+  (into (into (into canonical-assertion-ids dom-assertion-ids)
+              browser-assertion-ids)
         (keys requirements/assertion-capabilities)))
 
 (defn assertion-id-known?

--- a/tools/story/src/re_frame/story/play/browser.cljc
+++ b/tools/story/src/re_frame/story/play/browser.cljc
@@ -1,0 +1,442 @@
+(ns re-frame.story.play.browser
+  "Browser-tier assertion oracles — visual snapshot, axe-style a11y, and
+  structural a11y (NewTestStory rf2-5x1wt.28,
+  `tools/story/spec/017-Testing-Story.md` §Visual, a11y, and browser
+  checks + §Canonical P1 assertions).
+
+  ## Not a separate visual-testing system
+
+  Spec/017 §Visual, a11y, and browser checks: *visual, a11y, and browser
+  checks are NOT a separate testing system; they are runner-tiered
+  assertions on the same Story variant or inline plan.* This ns is the
+  executor for those richer assertions — it produces the ONE assertion
+  record (`re-frame.story.result` shape, the `.19` boundary) every other
+  assertion produces, so a visual/a11y finding rides the EXISTING
+  assertion-record accumulator, NOT a parallel result vocabulary. It adds
+  no new run-result slot; a finding is an assertion record like any other.
+
+  ## Reuse the existing hooks (§C4 item 2 — prefer reuse, minimal)
+
+  Two seams already exist in the tree; this ns REUSES them rather than
+  adding a differ / a second axe loader:
+
+  - VISUAL — `re-frame.story.identity` `snapshot-identity` /
+    `content-hash` is the canonical visual-regression KEY (stable across
+    hosts; the MCP `snapshot-identity` tool already surfaces it). The
+    `:rf.assert/visual-snapshot` finding records that key as the snapshot
+    IDENTITY. A real-browser pixel diff requires `:pixels` (a screenshot +
+    differ that lands with the browser runner); the headless/JVM contract
+    here is the fail-closed `:cannot-run` refusal.
+  - A11Y (axe-style) — `re-frame.story.ui.a11y` runs axe-core in-browser
+    and stores violations in `violations-by-frame` (the same atom the MCP
+    `run-a11y` tool reads). The `:rf.assert/a11y` finding projects those
+    violations. axe-core is CLJS/browser-only (`:a11y-engine`); the
+    headless/JVM contract is `:cannot-run`. This ns does NOT `:require` the
+    CLJS-only UI ns into this `.cljc` (which would break the JVM classpath
+    and the production-bundle isolation). Instead the a11y panel REGISTERS
+    its violations-reader into the shared late-bound seam
+    (`register-a11y-reader!`) at load time, and the evaluator reads through
+    it (`live-a11y-violations`) — a one-way, opt-in facade, the same
+    posture as the story-mcp `cljs-resolve` seam. The caller MAY also
+    supply `:violations` directly (the runner reads the atom and threads
+    it), keeping the evaluator itself pure.
+
+  ## Structural a11y rides `:hiccup` (the JVM-testable rung)
+
+  `:rf.assert/a11y-structural` is the spec's *structural a11y checks MAY
+  require only `:hiccup`* rung. It inspects the rendered hiccup TREE (data)
+  for structural accessibility facts — an `:img` with no `:alt`, an
+  interactive control with no accessible name, a positive `:tabIndex`, a
+  duplicate `:id` — WITHOUT a real browser or the axe engine. Because the
+  hiccup tree is pure data, `eval-structural-a11y` is fully JVM-testable
+  and the `:hiccup` runner satisfies it (`#{:hiccup-structure}` in the
+  requirement registry).
+
+  ## Fail-closed: headless returns `:cannot-run`, never a silent pass
+
+  The capability gate (`re-frame.story.requirements`) is the single
+  authority on WHICH runner may attempt an assertion; under a headless
+  runner a `:pixels` / `:a11y-engine` requirement refuses there. This ns's
+  browser-tier evaluators add a SECOND fail-closed guard at the executor
+  itself: when the browser environment is unavailable (`browser-available?`
+  false — JVM, node-runtime, or a CLJS REPL with no `js/window`) the
+  visual / axe-a11y evaluators return a `:cannot-run` record rather than
+  fabricating a pass. This is the testable contract the bead pins: a
+  headless run returns `:cannot-run` for browser-tier assertions.
+
+  ## Pure / JVM-testable
+
+  Every evaluator is data → data: the visual evaluator takes the snapshot
+  identity (or computes it from variant inputs); the a11y evaluator takes
+  the violations vector (read from the live atom by the late-bound facade,
+  or supplied directly); the structural evaluator takes the hiccup tree.
+  The only impurity is `browser-available?` (a host probe) and
+  `live-a11y-violations` (a late-bound atom read), both isolated so the
+  evaluators stay testable on the JVM with no host."
+  (:require [clojure.string            :as str]
+            [re-frame.story.assertions :as assertions]))
+
+;; ===========================================================================
+;; ENVIRONMENT PROBE  (the fail-closed guard at the executor)
+;; ===========================================================================
+
+(defn browser-available?
+  "True iff a REAL browser environment is reachable (a `js/window` with a
+  document). JVM → false; CLJS node-runtime → false; CLJS in a browser →
+  true. The visual / axe-a11y evaluators consult this and return
+  `:cannot-run` when it is false — the second fail-closed guard (the first
+  is the capability gate in `re-frame.story.requirements`). Mirrors
+  `re-frame.story.play.dom/dom-available?` but additionally requires a
+  `js/window` (the pixel/a11y engines need the full window, not just a
+  detached document)."
+  []
+  #?(:clj  false
+     :cljs (boolean
+             (and (exists? js/window)
+                  (exists? js/document)
+                  (some? (.-querySelector js/document))))))
+
+;; ===========================================================================
+;; LATE-BOUND a11y HOOK  (reuse `re-frame.story.ui.a11y`, no hard require)
+;; ===========================================================================
+;;
+;; `re-frame.story.ui.a11y` is CLJS-only (`.cljs`); a `.cljc` production ns
+;; MUST NOT `:require` it (it would break the JVM classpath and leak the UI
+;; into production bundles). The dependency points the WRONG way for a hard
+;; require — the executor is below the UI. So the seam is INVERTED and
+;; one-way: the a11y panel REGISTERS a violations-reader fn here at load
+;; time (`register-a11y-reader!`), and the evaluator reads through it. A
+;; JVM / headless build / a browser that never opened the panel leaves the
+;; reader nil and the evaluator falls back to the supplied `:violations`
+;; (or `:cannot-run`). This mirrors the story-mcp `cljs-resolve` posture
+;; (read the CLJS-side surface without a compile-time dependency) without
+;; relying on `resolve` (unavailable at CLJS runtime).
+
+(defonce ^{:doc "The late-bound axe-violations reader the a11y panel
+                installs via `register-a11y-reader!`. `frame-id` → violations
+                vector (or nil). nil until the panel registers it."}
+  a11y-reader
+  (atom nil))
+
+(defn register-a11y-reader!
+  "Install the axe-violations reader `reader-fn` (`frame-id` → violations
+  vector). The CLJS a11y panel (`re-frame.story.ui.a11y`) calls this at
+  load time with a fn that reads its `violations-by-frame` atom — the
+  one-way seam that lets this below-the-UI executor reuse the existing axe
+  hook WITHOUT a compile-time dependency on the CLJS-only UI ns. Idempotent
+  (last writer wins)."
+  [reader-fn]
+  (reset! a11y-reader reader-fn)
+  nil)
+
+(defn live-a11y-violations
+  "The axe-core violations the in-browser a11y panel
+  (`re-frame.story.ui.a11y`) accumulated for `frame-id`, or nil when no
+  reader has been registered (JVM, a headless build, or a browser that
+  never opened the panel). Reads through the late-bound `a11y-reader` seam
+  — this ns does NOT `:require` the CLJS-only UI ns. Returns a vector of
+  axe violation maps (`:id` / `:impact` / `:help` / `:nodes`) or nil."
+  [frame-id]
+  (when-let [reader @a11y-reader]
+    (try (reader frame-id)
+         (catch #?(:clj Throwable :cljs :default) _ nil))))
+
+;; ===========================================================================
+;; THE CANNOT-RUN FINDING  (rides the ONE assertion-record shape)
+;; ===========================================================================
+
+(defn- cannot-run-finding
+  "A browser-tier finding the executor could NOT prove — the second
+  fail-closed guard. Rides the ONE assertion-record shape (`:assertion` /
+  `:passed?` / `:status` / `:reason`) so it accumulates with every other
+  assertion; the `:status :cannot-run` makes it the distinct THIRD status
+  (spec/017 §`:cannot-run`), never a silent pass."
+  [assertion-id payload reason]
+  {:assertion   assertion-id
+   :payload     (vec payload)
+   :passed?     false
+   :cannot-run? true
+   :status      :cannot-run
+   :reason      reason})
+
+;; ===========================================================================
+;; VISUAL SNAPSHOT  (`:rf.assert/visual-snapshot`, requires :pixels)
+;; ===========================================================================
+
+(defn eval-visual-snapshot
+  "Evaluate a `:rf.assert/visual-snapshot` assertion (spec/017 §Visual,
+  a11y, and browser checks — requires `:browser` / `:pixels`). Returns the
+  ONE assertion-record shape.
+
+  `payload` is the assertion atom's args (`[]` or `[opts]`). `ctx` carries:
+
+  - `:snapshot-identity` — the reused visual-regression key
+    (`re-frame.story.identity/snapshot-identity`, the
+    `{:variant-id :content-hash …}` record). This is the snapshot IDENTITY
+    the finding records (reuse, not a new differ — §C4 item 2).
+  - `:baseline` — an optional baseline snapshot record to diff against; when
+    present the finding `:passed?` iff the content-hash matches.
+
+  In a headless / JVM / node environment (`browser-available?` false) this
+  returns `:cannot-run` — the testable contract: a headless run returns
+  `:cannot-run` for browser-tier assertions. A real pixel diff lands with
+  the `:pixels` browser runner; under that runner the content-hash identity
+  is the regression key and `:baseline` mismatch is the failure."
+  [payload {:keys [snapshot-identity baseline] :as _ctx}]
+  (if-not (browser-available?)
+    (cannot-run-finding assertions/id-visual-snapshot payload
+                        (str "visual snapshot requires a real browser "
+                             "(:pixels); the headless runner cannot capture "
+                             "or diff a screenshot"))
+    (let [hash      (:content-hash snapshot-identity)
+          base-hash (:content-hash baseline)
+          passed?   (or (nil? baseline) (= hash base-hash))]
+      {:assertion assertions/id-visual-snapshot
+       :payload   (vec payload)
+       :passed?   passed?
+       :status    (if passed? :pass :fail)
+       :expected  (if baseline base-hash :rf.story/any-snapshot)
+       :actual    hash
+       :reason    (cond
+                    (nil? baseline)
+                    (str "captured visual snapshot identity " (pr-str hash))
+                    passed?
+                    (str "visual snapshot matches baseline " (pr-str base-hash))
+                    :else
+                    (str "visual snapshot " (pr-str hash)
+                         " differs from baseline " (pr-str base-hash)))})))
+
+;; ===========================================================================
+;; AXE-STYLE A11Y  (`:rf.assert/a11y`, requires :a11y-engine)
+;; ===========================================================================
+
+(defn eval-a11y
+  "Evaluate an axe-style `:rf.assert/a11y` assertion (spec/017 §Visual,
+  a11y, and browser checks — requires `:browser` / `:a11y-engine`). Returns
+  the ONE assertion-record shape.
+
+  `payload` is the assertion atom's args (`[]` or `[opts]`, where `opts`
+  MAY carry `:max-impact` to fail only on violations at or above an impact
+  level). `ctx` carries:
+
+  - `:violations` — the axe-core violations vector to evaluate; when
+    absent, the live panel atom is read via `live-a11y-violations` for
+    `:frame-id` (reuse of the existing axe hook — §C4 item 2).
+  - `:frame-id` — the variant frame whose live violations to read.
+
+  In a headless / JVM / node environment (`browser-available?` false) this
+  returns `:cannot-run` — axe-core is browser-only. Under the
+  `:a11y-engine` browser runner it `:passed?` iff no violation (above the
+  optional `:max-impact` floor) was found, projecting the violations into
+  the finding's `:actual` so a failure reads diagnostically. This pairs the
+  pixel/a11y finding with the variant frame (spec/017: SHOULD pair findings
+  with app-db / args / trace / epoch evidence)."
+  [payload {:keys [violations frame-id] :as _ctx}]
+  (if-not (browser-available?)
+    (cannot-run-finding assertions/id-a11y payload
+                        (str "axe-style a11y requires a real browser "
+                             "(:a11y-engine); the headless runner cannot run "
+                             "axe-core"))
+    (let [opts       (when (map? (first payload)) (first payload))
+          max-impact (:max-impact opts)
+          impact-rank {"minor" 0 "moderate" 1 "serious" 2 "critical" 3}
+          floor       (get impact-rank max-impact 0)
+          vs          (vec (or violations (live-a11y-violations frame-id) []))
+          ;; a violation counts iff its impact is at or above the floor
+          counted     (filterv (fn [v]
+                                  (>= (get impact-rank (:impact v) 1) floor))
+                                vs)
+          passed?     (empty? counted)]
+      {:assertion assertions/id-a11y
+       :payload   (vec payload)
+       :passed?   passed?
+       :status    (if passed? :pass :fail)
+       :expected  :no-a11y-violations
+       :actual    (mapv #(select-keys % [:id :impact :help]) counted)
+       :count     (count counted)
+       :reason    (if passed?
+                    (str "no axe-core a11y violations"
+                         (when max-impact (str " at/above " (pr-str max-impact))))
+                    (str (count counted) " axe-core a11y violation(s)"
+                         (when max-impact (str " at/above " (pr-str max-impact)))))})))
+
+;; ===========================================================================
+;; STRUCTURAL A11Y  (`:rf.assert/a11y-structural`, requires :hiccup-structure)
+;; ===========================================================================
+;;
+;; The pure-over-hiccup rung. It walks the rendered hiccup tree (data) for
+;; structural accessibility facts a `:hiccup` runner can prove WITHOUT a
+;; real browser / axe engine. The rules are a deliberately small, defensible
+;; structural floor; richer semantic checks (colour contrast, computed
+;; layout) genuinely need the browser / axe and belong to `:rf.assert/a11y`.
+
+(defn- hiccup-element?
+  "True iff `node` is a hiccup element vector `[tag & rest]` with a keyword
+  tag. Pure data → data."
+  [node]
+  (and (vector? node) (pos? (count node)) (keyword? (first node))))
+
+(defn- element-tag
+  "The bare tag of a hiccup element, with any `#`-id / `.`-class suffix
+  stripped (`:input.big#name` → `:input`). Pure data → data."
+  [node]
+  (let [t (name (first node))
+        bare (-> t (str/split #"[.#]") first)]
+    (keyword bare)))
+
+(defn- element-attrs
+  "The attribute map of a hiccup element, or `{}` when the second element
+  is not a map. Pure data → data."
+  [node]
+  (let [a (nth node 1 nil)]
+    (if (map? a) a {})))
+
+(defn- element-children
+  "The child nodes of a hiccup element (after the optional attribute map).
+  Pure data → data."
+  [node]
+  (let [a (nth node 1 nil)]
+    (if (map? a) (drop 2 node) (drop 1 node))))
+
+(defn- has-text-child?
+  "True iff the element has any non-blank string descendant (an accessible
+  name from text content). Pure data → data."
+  [node]
+  (letfn [(walk [n]
+            (cond
+              (string? n) (not (str/blank? n))
+              (hiccup-element? n)
+              (some walk (element-children n))
+              (sequential? n) (some walk n)
+              :else false))]
+    (boolean (some walk (element-children node)))))
+
+(defn- accessible-name?
+  "True iff `attrs` / `node` carry an accessible name — an `:alt`,
+  `:aria-label`, `:aria-labelledby`, `:title`, or non-blank text content.
+  Pure data → data."
+  [attrs node]
+  (boolean
+    (or (some (fn [k] (let [v (get attrs k)]
+                        (and (string? v) (not (str/blank? v)))))
+              [:alt :aria-label :aria-labelledby :title])
+        (has-text-child? node))))
+
+(def ^:private interactive-tags
+  "Tags that REQUIRE an accessible name for a screen reader. `:input`
+  excludes hidden inputs (checked at the call site)."
+  #{:button :a :select :textarea})
+
+(defn- node-issues
+  "Structural a11y issues for ONE hiccup element (not its descendants).
+  Returns a vector of issue maps `{:rule … :tag … :detail …}`. Pure data →
+  data. The rules are the structural floor:
+
+  - `:img-missing-alt`         — an `:img` with no `:alt` attribute;
+  - `:control-missing-name`    — an interactive control with no accessible
+                                  name (no text / aria-label / title);
+  - `:positive-tabindex`       — a `:tabIndex`/`:tab-index` > 0 (breaks the
+                                  natural focus order)."
+  [node]
+  (let [tag   (element-tag node)
+        attrs (element-attrs node)
+        issues (cond-> []
+                 ;; img must declare :alt (empty string is allowed — that is
+                 ;; the explicit "decorative" signal; a MISSING :alt is the
+                 ;; issue).
+                 (and (= :img tag) (not (contains? attrs :alt)))
+                 (conj {:rule :img-missing-alt :tag tag
+                        :detail "img element has no :alt attribute"})
+
+                 ;; interactive control needs an accessible name
+                 (and (contains? interactive-tags tag)
+                      (not (accessible-name? attrs node)))
+                 (conj {:rule :control-missing-name :tag tag
+                        :detail (str (name tag) " control has no accessible name "
+                                     "(no text content, :aria-label, or :title)")}))
+        ;; positive tabindex (either spelling)
+        ti (or (:tabIndex attrs) (:tab-index attrs))]
+    (cond-> issues
+      (and (number? ti) (pos? ti))
+      (conj {:rule :positive-tabindex :tag tag
+             :detail (str "positive :tabIndex " ti
+                          " breaks the natural focus order")}))))
+
+(defn structural-issues
+  "Walk the rendered hiccup `tree` (data) and collect every structural a11y
+  issue (`node-issues` per element, depth-first). Pure data → data — the
+  JVM-testable core of `:rf.assert/a11y-structural`. Returns a vector of
+  issue maps in document order."
+  [tree]
+  (letfn [(walk [n acc]
+            (cond
+              (hiccup-element? n)
+              (let [acc' (into acc (node-issues n))]
+                (reduce (fn [a c] (walk c a)) acc' (element-children n)))
+              (sequential? n)
+              (reduce (fn [a c] (walk c a)) acc n)
+              :else acc))]
+    (walk tree [])))
+
+(defn eval-structural-a11y
+  "Evaluate a `:rf.assert/a11y-structural` assertion (spec/017 §Visual,
+  a11y, and browser checks — structural a11y MAY require only `:hiccup`).
+  Returns the ONE assertion-record shape. Pure data → data — runs on the
+  JVM under `clojure -M:test`.
+
+  `payload` is the assertion atom's args (`[]` or `[opts]`). `ctx` carries
+  `:hiccup` — the rendered hiccup tree (render-to-hiccup, the `:hiccup`
+  runner's proof surface). The check `:passed?` iff `structural-issues`
+  finds none; a failure projects the issues into `:actual` so the finding
+  reads diagnostically. No browser is needed — the hiccup tree is data, so
+  the `:hiccup` runner proves it."
+  [payload {:keys [hiccup] :as _ctx}]
+  (let [issues  (structural-issues hiccup)
+        passed? (empty? issues)]
+    {:assertion assertions/id-a11y-structural
+     :payload   (vec payload)
+     :passed?   passed?
+     :status    (if passed? :pass :fail)
+     :expected  :no-structural-a11y-issues
+     :actual    issues
+     :count     (count issues)
+     :reason    (if passed?
+                  "no structural a11y issues in the rendered hiccup tree"
+                  (str (count issues)
+                       " structural a11y issue(s) in the rendered hiccup tree: "
+                       (str/join ", " (map (comp name :rule) issues))))}))
+
+;; ===========================================================================
+;; DISPATCH  (one entry the runner calls per browser-tier assertion atom)
+;; ===========================================================================
+
+(defn browser-assertion?
+  "True iff `assertion-atom` is one of the browser-tier oracle assertions
+  this ns evaluates (`re-frame.story.assertions/browser-assertion-ids`).
+  Pure data → data — the runner uses this to route an atom here rather than
+  to the dispatched `:rf.assert/*` handler path."
+  [assertion-atom]
+  (contains? assertions/browser-assertion-ids
+             (assertions/assertion-atom-id assertion-atom)))
+
+(defn eval-browser-assertion
+  "Evaluate ONE browser-tier oracle assertion atom against `ctx`, returning
+  the ONE assertion-record shape (spec/017 §Visual, a11y, and browser
+  checks — runner-tiered assertions on the SAME result model). Routes by the
+  atom's id:
+
+  - `:rf.assert/visual-snapshot` → `eval-visual-snapshot` (`:pixels`)
+  - `:rf.assert/a11y`            → `eval-a11y` (`:a11y-engine`)
+  - `:rf.assert/a11y-structural` → `eval-structural-a11y` (`:hiccup`)
+
+  `ctx` is the per-run context (`:snapshot-identity` / `:baseline` /
+  `:violations` / `:frame-id` / `:hiccup`), supplied by the caller. A
+  non-browser-tier atom returns nil (the caller routes it elsewhere)."
+  [assertion-atom ctx]
+  (let [id      (assertions/assertion-atom-id assertion-atom)
+        payload (vec (rest assertion-atom))]
+    (condp = id
+      assertions/id-visual-snapshot (eval-visual-snapshot payload ctx)
+      assertions/id-a11y            (eval-a11y payload ctx)
+      assertions/id-a11y-structural (eval-structural-a11y payload ctx)
+      nil)))

--- a/tools/story/src/re_frame/story/requirements.cljc
+++ b/tools/story/src/re_frame/story/requirements.cljc
@@ -218,7 +218,32 @@
   `:dom`; visual/a11y need browser-tier tokens. The reactive-count
   assertions (`:rf.assert/caused` / `:rf.assert/no-cascade-rerender`)
   require `:reactive-counts` — a NET-NEW seam (spec/017 §1a), so they fail
-  closed to `:cannot-run` until the recompute probe lands."
+  closed to `:cannot-run` until the recompute probe lands.
+
+  ## Browser-tier oracles (spec/017 §Visual, a11y, and browser checks)
+
+  The two pixel/a11y-engine ids are runner-tiered assertions on the SAME
+  variant/result model, NOT a separate visual-testing system:
+
+  - `:rf.assert/visual-snapshot` requires `:pixels` — a real-browser
+    screenshot + pixel diff (or, reusing the existing visual-regression
+    seam, the `re-frame.story.identity` content-hash as the snapshot
+    IDENTITY key). No P1 headless/hiccup runner advertises `:pixels`, so a
+    headless run resolves to `:cannot-run`.
+  - `:rf.assert/a11y` requires `:a11y-engine` — an axe-style scan, reusing
+    the existing `re-frame.story.ui.a11y` axe-core hook (the
+    `violations-by-frame` atom the MCP `run-a11y` tool already reads). No
+    P1 headless/hiccup runner advertises `:a11y-engine`, so a headless run
+    resolves to `:cannot-run`.
+
+  `:rf.assert/a11y-structural` is the STRUCTURAL accessibility check that
+  needs only `:hiccup-structure` — it inspects the rendered hiccup TREE
+  (data) for structural a11y facts (img missing `:alt`, control missing an
+  accessible name, …) without a real browser / axe engine. Because the
+  hiccup tree is pure data, the `:hiccup` runner satisfies it and the
+  executor (`re-frame.story.play.browser/eval-structural-a11y`) is fully
+  JVM-testable. This is the spec's \"structural a11y checks MAY require
+  only `:hiccup`\" rung (§Visual, a11y, and browser checks)."
   {:rf.assert/path-equals          #{:app-db}
    :rf.assert/path-matches         #{:app-db}
    :rf.assert/sub-equals           #{:app-db :pure-subs}
@@ -232,6 +257,10 @@
    :rf.assert/dom-text             #{:dom}
    :rf.assert/visual-snapshot      #{:pixels}
    :rf.assert/a11y                 #{:a11y-engine}
+   ;; Structural a11y rides the :hiccup tier — the hiccup tree is data, so
+   ;; no real browser / axe engine is needed (spec/017 §Visual, a11y, and
+   ;; browser checks — \"structural a11y checks MAY require only `:hiccup`\").
+   :rf.assert/a11y-structural      #{:hiccup-structure}
    ;; NET-NEW — gated on the recompute probe; no P1 runner provides
    ;; `:reactive-counts`, so these resolve to `:cannot-run` (spec/017 §1a).
    :rf.assert/caused               #{:reactive-counts}

--- a/tools/story/src/re_frame/story/ui/a11y.cljs
+++ b/tools/story/src/re_frame/story/ui/a11y.cljs
@@ -50,6 +50,7 @@
             [re-frame.core :as rf]
             [re-frame.trace :as trace]
             [re-frame.story.config :as config]
+            [re-frame.story.play.browser :as browser]
             [re-frame.story.registrar :as story-registrar]
             [re-frame.story.ui.state :as state]
             [re-frame.story.theme.typography :as typography :refer [mono-stack]]
@@ -79,6 +80,16 @@
   (swap! violations-by-frame dissoc frame-id)
   (swap! run-state           dissoc frame-id)
   nil)
+
+;; Register this panel's violations atom into the below-the-UI browser-tier
+;; executor's one-way seam (rf2-5x1wt.28), so `:rf.assert/a11y` can reuse the
+;; SAME axe-core findings the panel accumulated WITHOUT the executor needing
+;; a compile-time dependency on this CLJS-only UI ns. Read-only — the
+;; executor only reads `frame-id` → violations.
+(defonce ^:private _a11y-reader-registered
+  (do (browser/register-a11y-reader!
+        (fn [frame-id] (get @violations-by-frame frame-id)))
+      true))
 
 (defn reset-state!
   "Clear every per-frame slot. Test-fixture helper. Note that the

--- a/tools/story/test/re_frame/story/play/browser_test.cljc
+++ b/tools/story/test/re_frame/story/play/browser_test.cljc
@@ -1,0 +1,186 @@
+(ns re-frame.story.play.browser-test
+  "Tests for the browser-tier assertion oracles — visual snapshot, axe-style
+  a11y, and structural a11y (NewTestStory rf2-5x1wt.28,
+  `tools/story/spec/017-Testing-Story.md` §Visual, a11y, and browser
+  checks).
+
+  Every evaluator is PURE data → data (the only impurity, `browser-available?`,
+  is false on the JVM — exactly the headless contract under test), so the
+  whole suite runs under `clojure -M:test` with no host. The §C4 acceptance
+  bullets:
+
+  - a visual assertion runs when the browser runner is selected/requested
+    (modeled here: with `browser-available?` true it evaluates the snapshot
+    identity; on the JVM it is `:cannot-run`);
+  - an axe-style a11y assertion runs under the browser runner (likewise);
+  - a structural a11y assertion runs at `:hiccup` (a pure hiccup-tree walk,
+    JVM-testable here);
+  - a HEADLESS run returns `:cannot-run` for the browser-tier (`:pixels` /
+    `:a11y-engine`) assertions — the fail-closed contract.
+
+  The capability/requirement + cannot-run contract for these ids lives in
+  `re-frame.story.requirements-test`; this suite covers the EXECUTOR."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.story.assertions    :as assertions]
+            [re-frame.story.requirements  :as req]
+            [re-frame.story.play.browser  :as browser]))
+
+;; ===========================================================================
+;; HEADLESS FAIL-CLOSED — browser-tier assertions return :cannot-run
+;; ===========================================================================
+
+(deftest headless-visual-snapshot-cannot-run
+  (testing "a headless run returns :cannot-run for :rf.assert/visual-snapshot"
+    ;; On the JVM `browser-available?` is false — the headless contract.
+    (is (false? (browser/browser-available?)))
+    (let [rec (browser/eval-visual-snapshot [] {:snapshot-identity {:content-hash "abcd1234"}})]
+      (is (= :rf.assert/visual-snapshot (:assertion rec)))
+      (is (= :cannot-run (:status rec)) "headless visual snapshot is :cannot-run, never a silent pass")
+      (is (true? (:cannot-run? rec)))
+      (is (false? (:passed? rec)))
+      (is (string? (:reason rec))))))
+
+(deftest headless-axe-a11y-cannot-run
+  (testing "a headless run returns :cannot-run for axe-style :rf.assert/a11y"
+    (let [rec (browser/eval-a11y [] {:violations [{:id "label" :impact "critical"}]})]
+      (is (= :rf.assert/a11y (:assertion rec)))
+      (is (= :cannot-run (:status rec)) "headless axe a11y is :cannot-run, never a silent pass")
+      (is (true? (:cannot-run? rec)))
+      (is (false? (:passed? rec))))))
+
+(deftest cannot-run-finding-rides-the-assertion-record-shape
+  (testing ":cannot-run findings carry the ONE assertion-record shape"
+    (let [rec (browser/eval-visual-snapshot [{:opt 1}] {})]
+      ;; same slots every other assertion record carries (.19 shape)
+      (is (contains? rec :assertion))
+      (is (contains? rec :payload))
+      (is (contains? rec :passed?))
+      (is (contains? rec :status))
+      (is (= [{:opt 1}] (:payload rec)) "payload is preserved on the record"))))
+
+;; ===========================================================================
+;; STRUCTURAL A11Y — runs at :hiccup (pure hiccup-tree walk, JVM-testable)
+;; ===========================================================================
+
+(deftest structural-a11y-clean-tree-passes
+  (testing "a structurally-clean hiccup tree passes :rf.assert/a11y-structural"
+    (let [tree [:div
+                [:img {:alt "a kitten"}]
+                [:button "Submit"]
+                [:a {:href "/x"} "home"]
+                [:input {:type "text" :aria-label "name"}]]
+          rec  (browser/eval-structural-a11y [] {:hiccup tree})]
+      (is (= :rf.assert/a11y-structural (:assertion rec)))
+      (is (= :pass (:status rec)))
+      (is (true? (:passed? rec)))
+      (is (= 0 (:count rec)))
+      (is (empty? (:actual rec))))))
+
+(deftest structural-a11y-detects-img-missing-alt
+  (testing "an :img with no :alt is a structural issue"
+    (let [rec (browser/eval-structural-a11y [] {:hiccup [:div [:img {:src "/k.png"}]]})]
+      (is (= :fail (:status rec)))
+      (is (false? (:passed? rec)))
+      (is (= 1 (:count rec)))
+      (is (= :img-missing-alt (-> rec :actual first :rule))))))
+
+(deftest structural-a11y-detects-control-missing-name
+  (testing "an interactive control with no accessible name is a structural issue"
+    (let [rec (browser/eval-structural-a11y [] {:hiccup [:div [:button {:class "x"}]]})]
+      (is (= :fail (:status rec)))
+      (is (= :control-missing-name (-> rec :actual first :rule)))))
+  (testing "a control with aria-label is fine"
+    (let [rec (browser/eval-structural-a11y
+                [] {:hiccup [:div [:button {:aria-label "close"}]]})]
+      (is (= :pass (:status rec))))))
+
+(deftest structural-a11y-detects-positive-tabindex
+  (testing "a positive :tabIndex is a structural issue (both spellings)"
+    (let [rec  (browser/eval-structural-a11y [] {:hiccup [:div {:tabIndex 3} "x"]})
+          rec2 (browser/eval-structural-a11y [] {:hiccup [:div {:tab-index 5} "y"]})]
+      (is (= :fail (:status rec)))
+      (is (= :positive-tabindex (-> rec :actual first :rule)))
+      (is (= :fail (:status rec2)) ":tab-index spelling is also caught")))
+  (testing "tabIndex 0 / -1 are NOT issues"
+    (is (= :pass (:status (browser/eval-structural-a11y [] {:hiccup [:div {:tabIndex 0} "x"]}))))
+    (is (= :pass (:status (browser/eval-structural-a11y [] {:hiccup [:div {:tabIndex -1} "x"]}))))))
+
+(deftest structural-a11y-walks-nested-and-tag-suffix
+  (testing "the walk recurses into children and strips #id/.class tag suffixes"
+    (let [tree [:section
+                [:div.row
+                 [:img.thumb {:src "/a.png"}]    ; missing alt
+                 [:button.btn#go]]]              ; missing name
+          rec  (browser/eval-structural-a11y [] {:hiccup tree})]
+      (is (= :fail (:status rec)))
+      (is (= #{:img-missing-alt :control-missing-name}
+             (set (map :rule (:actual rec))))
+          "the .class/#id suffix on the tag does not hide the element kind"))))
+
+(deftest structural-a11y-runs-at-hiccup-tier
+  (testing ":rf.assert/a11y-structural requires only :hiccup-structure"
+    (is (= #{:hiccup-structure}
+           (req/assertion-tokens [:rf.assert/a11y-structural])))
+    (is (= :hiccup (req/cheapest-runner #{:hiccup-structure}))
+        "the cheapest runner proving structural a11y is :hiccup, NOT :browser")
+    ;; a hiccup runner satisfies it; headless does not.
+    (is (req/runner-satisfies? (req/runner-provides :hiccup) #{:hiccup-structure}))
+    (is (not (req/runner-satisfies? (req/runner-provides :headless) #{:hiccup-structure})))))
+
+;; ===========================================================================
+;; LIVE a11y READER SEAM — the inverted, late-bound hook
+;; ===========================================================================
+
+(deftest a11y-reader-seam-is-reusable-and-nil-safe
+  (testing "live-a11y-violations reads through the registered reader; nil-safe when absent"
+    (let [saved @browser/a11y-reader]
+      (try
+        (reset! browser/a11y-reader nil)
+        (is (nil? (browser/live-a11y-violations :frame/x)) "no reader → nil")
+        (browser/register-a11y-reader!
+          (fn [fid] (when (= :frame/x fid) [{:id "color-contrast" :impact "serious"}])))
+        (is (= [{:id "color-contrast" :impact "serious"}]
+               (browser/live-a11y-violations :frame/x)))
+        (is (nil? (browser/live-a11y-violations :frame/other)))
+        (finally (reset! browser/a11y-reader saved))))))
+
+;; ===========================================================================
+;; DISPATCH ENTRY — one router per browser-tier atom
+;; ===========================================================================
+
+(deftest browser-assertion-predicate
+  (testing "browser-assertion? recognises the three oracle ids only"
+    (is (browser/browser-assertion? [:rf.assert/visual-snapshot]))
+    (is (browser/browser-assertion? [:rf.assert/a11y]))
+    (is (browser/browser-assertion? [:rf.assert/a11y-structural]))
+    (is (not (browser/browser-assertion? [:rf.assert/path-equals [:n] 1])))
+    (is (not (browser/browser-assertion? [:rf.assert/dom-visible "[x]"])))))
+
+(deftest eval-browser-assertion-routes-by-id
+  (testing "eval-browser-assertion routes each oracle atom to its evaluator"
+    ;; structural runs JVM-side (hiccup tree)
+    (let [rec (browser/eval-browser-assertion
+                [:rf.assert/a11y-structural] {:hiccup [:div [:img]]})]
+      (is (= :rf.assert/a11y-structural (:assertion rec)))
+      (is (= :fail (:status rec))))
+    ;; visual / a11y are :cannot-run headless
+    (is (= :cannot-run (:status (browser/eval-browser-assertion
+                                  [:rf.assert/visual-snapshot] {}))))
+    (is (= :cannot-run (:status (browser/eval-browser-assertion
+                                  [:rf.assert/a11y] {}))))
+    ;; a non-oracle atom is not handled here
+    (is (nil? (browser/eval-browser-assertion [:rf.assert/path-equals [:n] 1] {})))))
+
+;; ===========================================================================
+;; ID + KNOWN-SET INTEGRATION — the new id is recognised by the vocabulary
+;; ===========================================================================
+
+(deftest browser-tier-ids-are-known-assertions
+  (testing "the browser-tier ids are in the recognised vocabulary"
+    (is (contains? assertions/browser-assertion-ids :rf.assert/visual-snapshot))
+    (is (contains? assertions/browser-assertion-ids :rf.assert/a11y))
+    (is (contains? assertions/browser-assertion-ids :rf.assert/a11y-structural))
+    ;; plan construction accepts them (assertion-id-known?)
+    (is (assertions/assertion-id-known? :rf.assert/visual-snapshot))
+    (is (assertions/assertion-id-known? :rf.assert/a11y))
+    (is (assertions/assertion-id-known? :rf.assert/a11y-structural))))

--- a/tools/story/test/re_frame/story/requirements_test.cljc
+++ b/tools/story/test/re_frame/story/requirements_test.cljc
@@ -64,6 +64,45 @@
       (is (not (req/runner-satisfies? (req/runner-provides :headless) hiccup-req))
           ":headless cannot prove hiccup structure"))))
 
+(deftest browser-tier-assertion-tokens
+  (testing "the browser-tier oracle assertions declare their capability tokens (rf2-5x1wt.28)"
+    ;; visual snapshot + axe-a11y are browser-only
+    (is (= #{:pixels}      (req/assertion-tokens [:rf.assert/visual-snapshot])))
+    (is (= #{:a11y-engine} (req/assertion-tokens [:rf.assert/a11y])))
+    (is (= :browser (req/cheapest-runner #{:pixels})))
+    (is (= :browser (req/cheapest-runner #{:a11y-engine})))
+    ;; structural a11y is the :hiccup rung — the NET-NEW id (rf2-5x1wt.28)
+    (is (= #{:hiccup-structure} (req/assertion-tokens [:rf.assert/a11y-structural])))
+    (is (= :hiccup (req/cheapest-runner #{:hiccup-structure}))
+        "structural a11y rides :hiccup, NOT :browser")
+    ;; headless refuses the browser-only pair; the :hiccup runner proves
+    ;; structural a11y but headless does not.
+    (is (not (req/runner-satisfies? (req/runner-provides :headless) #{:pixels})))
+    (is (not (req/runner-satisfies? (req/runner-provides :headless) #{:a11y-engine})))
+    (is (not (req/runner-satisfies? (req/runner-provides :headless) #{:hiccup-structure})))
+    (is (req/runner-satisfies? (req/runner-provides :hiccup)  #{:hiccup-structure}))
+    (is (req/runner-satisfies? (req/runner-provides :browser) #{:pixels :a11y-engine}))))
+
+(deftest headless-cannot-run-browser-tier-assertions
+  (testing "fixed :runner :headless reports :cannot-run for browser-tier assertions"
+    (let [unmet (req/unmet-assertions
+                  :headless
+                  [[:rf.assert/visual-snapshot]
+                   [:rf.assert/a11y]
+                   [:rf.assert/a11y-structural]  ; :hiccup — also unmet under :headless
+                   [:rf.assert/path-equals [:n] 1]])]
+      (is (= 3 (count unmet)) "the three browser/hiccup-tier assertions refuse; app-db does not")
+      (is (every? #(= :cannot-run (:status %)) unmet))
+      (is (= #{[:rf.assert/visual-snapshot]
+               [:rf.assert/a11y]
+               [:rf.assert/a11y-structural]}
+             (set (map :unit unmet)))))
+    ;; under :auto, the browser-only pair escalates to :browser; structural
+    ;; alone escalates only to :hiccup.
+    (let [auto (req/normalize-run-opts {:runner :auto})]
+      (is (= :browser (:runner (req/select-runner #{:pixels :a11y-engine} auto))))
+      (is (= :hiccup  (:runner (req/select-runner #{:hiccup-structure} auto)))))))
+
 (deftest dom-step-requires-dom-or-browser
   (testing "a DOM step requires :dom (or richer :browser)"
     (is (= #{:dom} (req/step-tokens [:click "[data-test=go]"])))


### PR DESCRIPTION
Plan §C4 "Browser-Tier Workshop Oracles" (NewTestStory rf2-5x1wt.28). Adds first-class browser-tier assertion oracles as richer runner assertions on the **same** variant/result model — not a separate visual-testing system.

## What lands

**New assertion ids + capability requirements** (`re-frame.story.requirements/assertion-capabilities`):

| Assertion | Token | Runner | Status |
|---|---|---|---|
| `:rf.assert/visual-snapshot` | `:pixels` | `:browser` | already registered (`.16`) |
| `:rf.assert/a11y` | `:a11y-engine` | `:browser` | already registered (`.16`) |
| `:rf.assert/a11y-structural` | `:hiccup-structure` | `:hiccup` | **NET-NEW** |

The structural a11y id is the spec's "structural a11y checks MAY require only `:hiccup`" rung — a pure walk of the rendered hiccup tree (img missing `:alt`, control missing accessible name, positive tabindex), fully JVM-testable, no browser needed.

**New executor `re-frame.story.play.browser`** (`.cljc`) — mirrors `play/dom`: pure-data evaluators with one host probe (`browser-available?`) at the edge. Findings ride the **existing** assertion-record shape (`.19`); **no parallel result accumulator, no new run-result slot** added.

**Reuse, not rebuild** (§C4 item 1+2):
- visual → reuses `re-frame.story.identity` `content-hash` (the existing visual-regression key the MCP `snapshot-identity` tool surfaces) as the snapshot identity.
- a11y → reuses the existing `re-frame.story.ui.a11y` axe-core hook (`violations-by-frame`, the atom the MCP `run-a11y` tool reads), via a one-way late-bound reader seam — the executor does **not** `:require` the CLJS-only UI ns (bundle-isolation preserved); the panel registers its reader.

**Fail-closed** (§C4 test): a headless run returns `:cannot-run` for the browser-only ids (capability gate + executor `browser-available?` guard, two-sided).

**spec/017** §Visual, a11y, and browser checks: documents the three ids, the executor reuse posture, the fail-closed contract, and the browser-tier CI gate policy (`:cannot-run` policy = route-to-richer-runner on the browser gate / report-inconclusive on the cheap path). **CI workflow files NOT edited** (HOT-ZONE). A concrete browser-tier gate wiring is flagged as a separate follow-on below.

## Collision avoidance
Did **not** touch `story.cljc`, `plan.cljc`, `runtime.cljc`, `runner*.cljc`, `result.cljc`, or `.github/workflows/*`. Write surface was `assertions.cljc` (new ids), `requirements.cljc` (ADD entries), the new `play/browser.cljc` executor, `ui/a11y.cljs` (reader registration), tests, and spec/017.

## Quality gates

| Gate | Result |
|---|---|
| `tools/story` → `clojure -M:test` | PASS — 1175 tests, 3757 assertions, 0 failures, 0 errors |
| `tools/story-mcp` → `clojure -M:test` (downstream JVM consumer) | PASS — 172 tests, 861 assertions, 0 failures |
| `tools/mcp-conformance` → `npm run test:story` (cum40) | PASS — "STORY-MCP MCP-CLIENT CONFORMANCE GREEN" |
| `implementation` → `npm run test:cljs` | PASS — 4850 tests, 15890 assertions, 0 failures, 0 errors |
| `scripts/test-fast-pr.sh` | PASS — CLJS spine + markdown link/anchor gates (mkdocs soft-skip local; CI runs it) |
| `implementation` → `npm run test:bundle-isolation` | PASS — 17 artefact entries, 35 sentinels absent (UI ns does not leak) |

story-mcp `canonical-assertion-docs` stays at 8 (the new structural id lives in the requirement registry / `known-assertion-ids`, same treatment as the existing visual/a11y/dom ids — not in `canonical-assertion-ids`), so cum40 + the onboarding-doc lockstep stay green with no doc bump needed.

## Deferred follow-on
The normative browser-tier CI gate **policy** is documented in spec/017. Wiring a concrete dedicated browser-tier gate in `.github/workflows/*` (select variants by `:required-runner`, run under a `:pixels`/`:a11y-engine` runner) is a HOT-ZONE edit out of this lane — should be a separate sequential bead.