### PR TITLE
feat(story): inline plan execution for run/is/explain (rf2-5x1wt.20)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -279,6 +279,41 @@ Story variant. Inline plans MUST NOT appear in Story navigation. They
 MAY compose registered fragments and checks. They MUST return the same
 run-result shape as registered variants.
 
+**Execution (rf2-5x1wt.20).** All three verbs accept a map target as well
+as a keyword: `(story/run inline-plan opts)` / `(story/is inline-plan
+opts)` / `(story/explain inline-plan)`. `variant-plan` / `explain` compile
+a map directly (the compiler accepts an unregistered map — rf2-5x1wt.24).
+The RUN path (`story/run` / `story/is` for a map target) is the
+registry-free twin of the registered-variant lifecycle, and reuses it
+rather than forking it:
+
+1. the plan is compiled ONCE (`variant-plan` accepts the map; `opts` MAY
+   thread `:fragment-lookup` / `:check-lookup` / `:lookup` so the plan can
+   compose REGISTERED fragments + checks, or run host-free);
+2. an ANONYMOUS frame id is minted in the reserved `:rf.story.inline/*`
+   namespace — never a registered variant id, so navigation can't surface
+   it and a concurrent registered run can't collide; the frame is stamped
+   `:rf/inline? true`;
+3. the decorator stack is resolved from the plan's already-merged
+   `[:world :decorators]` refs (the variant/story side-table is NOT read);
+4. the SAME phase pipeline (loaders → setup → script) drives the run, all
+   sourced from the plan — `[:world :setup]`, `[:world :scripts]`,
+   `[:world :frame :fx-overrides]`, `[:expect :checks]` / `[:expect
+   :assertions]`;
+5. the one unified run-result is assembled from the plan + the frame's
+   accumulated assertions + the epoch tape (the same `run-result`
+   boundary), so an inline plan and a registered variant describing the
+   same behaviour produce equivalent app-db + assertion records after
+   `canonicalize` (the metamorphic relation);
+6. the anonymous frame is torn down when the run resolves; nothing is
+   registered.
+
+A plan-construction failure for a map target (an unknown composed
+fragment, a missing `[:arg …]`, a misplaced `[:assert …]` in setup, …)
+surfaces as the SAME structured `:rf.error/story-*` error result a
+registered variant's malformed plan produces — the frame is never
+allocated.
+
 ### Run artifact
 
 A run artifact is the low-level evidence emitted by generated tests,

--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -1346,17 +1346,30 @@
 
 (defn run
   "Per spec/017 §Public execution API — the `run` verb. Run `target` and
-  return a promise/future of the unified run-result (`run-result`). A
-  keyword `target` is a registered variant; map (inline-plan) targets land
-  with rf2-5x1wt.20. `opts` is the run/is opts map (`:runner` /
-  `:frame-binding` / `:platform` …); the default runner is `:headless`.
+  return a promise/future of the unified run-result (`run-result`).
 
-  Today this delegates to the variant lifecycle (`run-variant`), which
-  returns the unified shape. The verb name is the stable public surface —
-  it does NOT leak the variant-vs-plan authoring distinction (spec/017
-  §Public execution API)."
+  `target` dispatches on type (spec/017 §three verbs):
+
+  - a **keyword** is a registered variant id — resolved through the Story
+    side-table and run through the variant lifecycle;
+  - a **map** is an INLINE plan (rf2-5x1wt.20, spec/017 §Inline plan) —
+    compiled, run against a fresh anonymous frame, and torn down on
+    resolve. An inline plan is NOT registered in the side-table and is
+    absent from Story navigation; it MAY compose registered fragments +
+    checks (thread `:fragment-lookup` / `:check-lookup` in `opts` for a
+    host-free run, or rely on the side-table). It returns the SAME unified
+    run-result shape a registered variant returns.
+
+  `opts` is the run/is opts map (`:runner` / `:frame-binding` /
+  `:platform` …, plus the plan-compiler seams for a map target); the
+  default runner is `:headless`. The verb name is the stable public
+  surface — it does NOT leak the variant-vs-plan authoring distinction
+  (spec/017 §Public execution API)."
   ([target]      (run target nil))
-  ([target opts] (lifecycle/run-variant target opts)))
+  ([target opts]
+   (if (map? target)
+     (lifecycle/run-inline-plan target opts)
+     (lifecycle/run-variant target opts))))
 
 ;; ---- variant-plan / explain / render-variant (rf2-5x1wt.24) -------------
 ;;
@@ -1431,6 +1444,13 @@
   "Per spec/017 §Public execution API — the `is` verb. Run `target` and
   REPORT each assertion to clojure.test / cljs.test at per-assertion
   granularity (spec/017 §Run result — `story/is` reports per assertion).
+
+  `target` dispatches the same way `story/run` does: a keyword is a
+  registered variant; a map (without a `:status` / `:assertions` pair) is
+  an INLINE plan (rf2-5x1wt.20) — compiled + run against a fresh anonymous
+  frame, then reported per assertion. (A map that ALREADY carries a
+  `:status` + `:assertions` is treated as an already-resolved run-result
+  and reported directly — the sync path, below.)
 
   On the JVM (the canonical headless test gate) `is` runs the target,
   BLOCKS until it resolves, fires one `clojure.test` report per assertion

--- a/tools/story/src/re_frame/story/decorators.cljc
+++ b/tools/story/src/re_frame/story/decorators.cljc
@@ -196,6 +196,8 @@
   [r]
   (or (kind->bucket (:kind (:body r))) :unknown-kind))
 
+(declare resolve-decorator-refs)
+
 (defn resolve-decorators
   "Per IMPL-SPEC §5.3 — collect, classify, and order the decorator stack
   for the variant. Returns:
@@ -225,35 +227,52 @@
   ([variant-id]
    (resolve-decorators variant-id nil))
   ([variant-id _opts]
-   (let [refs       (collect-decorator-refs variant-id)
-         resolved   (mapv resolve-ref refs)
-         {:keys [hiccup frame-setup fx-override errors]}
-         (reduce
-           (fn [acc r]
-             (if (:error r)
-               (update acc :errors conj (:error r))
-               (case (classify-kind r)
-                 :hiccup       (update acc :hiccup       conj r)
-                 :frame-setup  (update acc :frame-setup  conj r)
-                 :fx-override  (update acc :fx-override  conj r)
-                 :unknown-kind (update acc :errors conj
-                                       {:rf.error :rf.error/decorator-unknown-kind
-                                        :id       (:id r)
-                                        :kind     (:kind (:body r))
-                                        :reason   (str "decorator " (:id r)
-                                                       " has unrecognised :kind "
-                                                       (pr-str (:kind (:body r))))}))))
-           {:hiccup [] :frame-setup [] :fx-override [] :errors []}
-           resolved)]
-     {:hiccup        hiccup
-      :frame-setup   frame-setup
-      :fx-override   fx-override
-      :errors        errors
-      :fingerprints  (into {}
-                           (keep (fn [r] (when (nil? (:error r))
-                                           [(:id r)
-                                            (decorator-fingerprint (:id r))])))
-                           resolved)})))
+   (resolve-decorator-refs (collect-decorator-refs variant-id))))
+
+(defn resolve-decorator-refs
+  "Resolve, classify, and order a supplied vector of `[decorator-id & args]`
+  refs into the same `{:hiccup :frame-setup :fx-override :errors
+  :fingerprints}` shape `resolve-decorators` returns — but WITHOUT reading
+  the variant/story side-table for the ref collection.
+
+  `resolve-decorators` is the registered-variant front door: it collects
+  the global + story + variant refs from the side-table, then delegates
+  here. The inline-plan runtime path (rf2-5x1wt.20) calls this directly
+  with the plan's already-resolved `[:world :decorators]` refs (which the
+  compiler merged from the variant chain + composed fragments), so an
+  inline plan that is absent from the side-table still gets its decorator
+  stack classified the same way. The decorator BODIES are still looked up
+  against the `:decorator` registry (a decorator is a registered artefact;
+  only the variant's ref LIST differs between the two paths)."
+  [refs]
+  (let [resolved   (mapv resolve-ref refs)
+        {:keys [hiccup frame-setup fx-override errors]}
+        (reduce
+          (fn [acc r]
+            (if (:error r)
+              (update acc :errors conj (:error r))
+              (case (classify-kind r)
+                :hiccup       (update acc :hiccup       conj r)
+                :frame-setup  (update acc :frame-setup  conj r)
+                :fx-override  (update acc :fx-override  conj r)
+                :unknown-kind (update acc :errors conj
+                                      {:rf.error :rf.error/decorator-unknown-kind
+                                       :id       (:id r)
+                                       :kind     (:kind (:body r))
+                                       :reason   (str "decorator " (:id r)
+                                                      " has unrecognised :kind "
+                                                      (pr-str (:kind (:body r))))}))))
+          {:hiccup [] :frame-setup [] :fx-override [] :errors []}
+          resolved)]
+    {:hiccup        hiccup
+     :frame-setup   frame-setup
+     :fx-override   fx-override
+     :errors        errors
+     :fingerprints  (into {}
+                          (keep (fn [r] (when (nil? (:error r))
+                                          [(:id r)
+                                           (decorator-fingerprint (:id r))])))
+                          resolved)}))
 
 ;; ---- hiccup application --------------------------------------------------
 

--- a/tools/story/src/re_frame/story/frames.cljc
+++ b/tools/story/src/re_frame/story/frames.cljc
@@ -485,6 +485,91 @@
       (apply-frame-setup! variant-id (:frame-setup decorator-stack))
       variant-id)))
 
+;; ---- inline-plan allocation (rf2-5x1wt.20) -------------------------------
+;;
+;; An inline plan (spec/017 §Inline plan) is an executable plan map that is
+;; NOT registered as a Story variant — so `allocate!`'s side-table reads
+;; (the `variant-body` lookup for the events-only classification, the
+;; decorator-stack resolution from the variant/story `:decorators` slots)
+;; have nothing to read. `allocate-inline!` is the registry-free twin:
+;; everything it needs is already on the compiled plan + the supplied
+;; decorator stack (resolved from the plan's `[:world :decorators]` refs via
+;; `decorators/resolve-decorator-refs`). The allocated frame is stamped
+;; `:rf/inline? true` so tools / navigation can tell an inline run's frame
+;; apart from a registered variant's frame — an inline plan MUST NOT appear
+;; in Story navigation.
+
+(defn- inline-frame-config
+  "Construct the `reg-frame` config map for an inline-plan frame. Mirrors
+  `variant-frame-config` but stamps `:rf/inline? true` (the inline run's
+  anonymous frame is never a navigable variant)."
+  [frame-id fx-overrides]
+  (cond-> {:doc        (str "Inline-plan frame for " frame-id ".")
+           :preset     :story
+           :rf/story?  true
+           :rf/inline? true
+           :rf/variant frame-id}
+    (seq fx-overrides) (assoc :fx-overrides fx-overrides)))
+
+(defn allocate-inline!
+  "Allocate an anonymous frame for an inline plan run (rf2-5x1wt.20,
+  spec/017 §Inline plan). Registry-free twin of `allocate!`:
+
+  - `frame-id` — the anonymous frame id the runtime minted (NOT a
+    registered variant id);
+  - `decorator-stack` — `decorators/resolve-decorator-refs` over the plan's
+    `[:world :decorators]` refs (the runtime resolves it upstream);
+  - `plan-fx-overrides` — the plan's `[:world :frame :fx-overrides]` lowered
+    map (e.g. the managed-HTTP stub the compiler folded `:network` into);
+  - `events-only?` — whether the plan drives no loaders / frame-setup, so
+    the lifecycle takes the `:pre-mount → :ready` fast-path (rf2-043cm).
+
+  Registers the `:fx-override`-decorator stubs, drives the lifecycle by the
+  supplied shape, applies any `:frame-setup` decorators' `:init` events, and
+  returns the frame-id. The frame's effective `:fx-overrides` is the
+  decorator-stack's materialised stubs UNDER the plan's lowered map (the
+  plan map wins — it already merged the author/network overrides). Does NOT
+  register anything in the Story side-table."
+  [frame-id decorator-stack plan-fx-overrides events-only?]
+  (when config/enabled?
+    (install-canonical-frame-events!)
+    (let [fx-stack     (decorators/fx-overrides-map (:fx-override decorator-stack))
+          decor-fx     (register-fx-overrides! fx-stack)
+          fx-overrides (merge decor-fx plan-fx-overrides)
+          config-map   (inline-frame-config frame-id fx-overrides)]
+      (rf/reg-frame frame-id config-map)
+      (if events-only?
+        (loaders/mount-ready! frame-id)
+        (loaders/mount!       frame-id))
+      (apply-frame-setup! frame-id (:frame-setup decorator-stack))
+      frame-id)))
+
+(defn destroy-inline!
+  "Tear down an inline-plan frame (rf2-5x1wt.20). The registry-free twin of
+  `destroy!`: an inline frame has no registered body, so the side-table
+  reads `destroy!` makes (the variant `:loaders-teardown`, the decorator
+  re-resolution) have nothing to read. `decorator-stack` is the SAME stack
+  `allocate-inline!` was handed; `loaders-teardown` is the plan's
+  `[:world :loaders-teardown]` events (empty for the common headless case).
+
+  Walks `:loaders-teardown` then the `:frame-setup` decorators' `:teardown`
+  events (reverse-declaration order), then `destroy-frame!`. Exceptions are
+  caught and projected as `:rf.error/exception` records the same way
+  `destroy!` does; the walk never aborts."
+  [frame-id decorator-stack loaders-teardown]
+  (when config/enabled?
+    (loaders/clear-watchers! frame-id)
+    (clear-stub-call-log! frame-id)
+    (when-let [drop (late-bind/get-fn :drop-assertion-accumulators)]
+      (try (drop frame-id) (catch #?(:clj Throwable :cljs :default) _ nil)))
+    (when (seq loaders-teardown)
+      (try (apply-loaders-teardown! frame-id loaders-teardown)
+        (catch #?(:clj Throwable :cljs :default) _ nil)))
+    (try (apply-frame-teardown! frame-id (:frame-setup decorator-stack))
+      (catch #?(:clj Throwable :cljs :default) _ nil))
+    (rf/destroy-frame! frame-id)
+    nil))
+
 ;; ---- destruction ----------------------------------------------------------
 
 (defn destroy!

--- a/tools/story/src/re_frame/story/lifecycle.cljc
+++ b/tools/story/src/re_frame/story/lifecycle.cljc
@@ -78,6 +78,16 @@
   ([variant-id]       (runtime/reset-variant variant-id nil))
   ([variant-id opts]  (runtime/reset-variant variant-id opts)))
 
+(defn run-inline-plan
+  "Per spec/017 §Inline plan (rf2-5x1wt.20) — run an inline plan MAP and
+  return a promise/future of the unified run-result (the SAME shape a
+  registered-variant run returns). The plan is compiled, run against a
+  fresh anonymous frame, and the frame is torn down on resolve; it is
+  NEVER registered in the Story side-table. Delegates to
+  `re-frame.story.runtime/run-inline-plan`."
+  ([inline-plan]      (runtime/run-inline-plan inline-plan nil))
+  ([inline-plan opts] (runtime/run-inline-plan inline-plan opts)))
+
 (defn watch-variant
   "Subscribe to lifecycle transitions for `variant-id`'s frame. Per
   IMPL-SPEC §3.2. `callback` receives

--- a/tools/story/src/re_frame/story/plan.cljc
+++ b/tools/story/src/re_frame/story/plan.cljc
@@ -1326,6 +1326,12 @@
                        (seq fx-overrides)     (assoc-in [:frame :fx-overrides] fx-overrides)
                        (seq interceptor-overrides) (assoc-in [:frame :interceptor-overrides] interceptor-overrides)
                        (contains? ctx :loaders)     (assoc :loaders (:loaders ctx))
+                       ;; rf2-5x1wt.20 — carry `:loaders-complete-when` onto
+                       ;; the plan's `:world` (it inherits through `:extends`
+                       ;; into `ctx`) so the inline-plan run path (which has
+                       ;; no registered body) drives phase-1 loaders + the
+                       ;; completion predicate from the plan alone.
+                       (contains? ctx :loaders-complete-when) (assoc :loaders-complete-when (:loaders-complete-when ctx))
                        (contains? ctx :loaders-teardown) (assoc :loaders-teardown (:loaders-teardown ctx))
                        (contains? ctx :decorators)  (assoc :decorators (:decorators ctx))
                        (contains? ctx :modes)       (assoc :modes (:modes ctx))

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -178,7 +178,11 @@
   `story.foo/bar` still inherits `story.foo`'s preconditions; the
   variant-chain + composed-fragment setup comes from the plan, where
   `:extends` setup APPENDS root→child and `:setup` / `:events` are both
-  lowered to the one slot (spec/017 §Merge rules)."
+  lowered to the one slot (spec/017 §Merge rules).
+
+  An INLINE plan (rf2-5x1wt.20) has no parent story (it is unregistered),
+  so `story-id` resolves nil and only the plan's own `[:world :setup]`
+  drives phase 2 — the plan is already the complete setup program."
   [variant-id plan]
   (let [story-id     (args/parent-story-id variant-id)
         story-body   (when story-id (registrar/handler-meta :story story-id))
@@ -236,13 +240,20 @@
   machine that's already terminal-for-mount. Both helpers would
   silently no-op (the `:ready` node only accepts `:errored`), but
   routing past them keeps the phase reads honest: `current-state`
-  stays `:ready` end-to-end."
-  [variant-id]
-  (if (= :ready (loaders/current-state variant-id))
+  stays `:ready` end-to-end.
+
+  rf2-5x1wt.20 — the loader BODY (`:loaders` + `:loaders-complete-when`)
+  defaults to the registered variant body but MAY be supplied explicitly,
+  so the inline-plan path (which has no registration) feeds the loader
+  slots the compiler carried onto the plan's `:world`. The default keeps
+  the registered path reading the side-table verbatim."
+  ([variant-id] (run-loaders! variant-id (frames/variant-body variant-id)))
+  ([variant-id loader-body]
+   (if (= :ready (loaders/current-state variant-id))
     ;; Events-only fast-path (rf2-043cm). Lifecycle already terminal-
     ;; for-mount; the loader cascade has nothing to do.
     true
-    (let [variant-body (frames/variant-body variant-id)
+    (let [variant-body loader-body
           loader-events (or (:loaders variant-body) [])]
       (loaders/start-loaders! variant-id)
       (capture-phase-errors
@@ -267,7 +278,7 @@
             true)
           (do
             (record-loader-incomplete! variant-id variant-body)
-            false))))))
+            false)))))))
 
 ;; ---- error recording -----------------------------------------------------
 
@@ -365,44 +376,47 @@
 ;; used to be. The named-phase decomposition also gives tests a finer entry
 ;; surface: a primed ctx can be fed into a single phase fn in isolation.
 
-(defn- variant-checks
-  "Resolve a variant's `:checks` ids into the
+(defn- plan-checks
+  "Resolve a normalized PLAN's `[:expect :checks]` ids into the
   `{check-id [assertion-atom …]}` map the unified result groups by
-  (rf2-5x1wt.19). Reads the variant body's `:checks` and expands each
-  through the Story side-table `:check` kind (`plan/expand-checks`).
-  Tolerant — any resolution failure yields an empty map (checks then
-  group nothing; the run-level aggregation still sees ungrouped records)."
-  [variant-id]
+  (rf2-5x1wt.19). Expands each check id through the Story side-table
+  `:check` kind (`plan/expand-checks`). Sourcing the check ids from the
+  plan (rather than re-reading the variant body) means a REGISTERED
+  variant and an INLINE plan (rf2-5x1wt.20 — unregistered) resolve their
+  checks identically: the compiler already merged inherited + composed
+  check ids into `[:expect :checks]`. Tolerant — any resolution failure
+  yields an empty map (checks then group nothing; the run-level
+  aggregation still sees ungrouped records)."
+  [plan]
   (try
-    (let [body (frames/variant-body variant-id)]
-      (plan/expand-checks (:checks body)))
+    (plan/expand-checks (get-in plan [:expect :checks]))
     (catch #?(:clj Throwable :cljs :default) _ {})))
 
-(defn- variant-schema-expectations
-  "Collect every declared `[:rf.assert/schema-error spec]` atom for
-  `variant-id` (rf2-5x1wt.21, spec/017 §Schema rule). These declare the
+(defn- plan-schema-expectations
+  "Collect every declared `[:rf.assert/schema-error spec]` atom for a
+  normalized PLAN (rf2-5x1wt.21, spec/017 §Schema rule). These declare the
   EXPECTED schema violations the result boundary exactly-consumes against
   the projected tape evidence — so a missing/different violation fails the
-  run, an exactly-expected violation passes. Pure aside from the registrar
-  reads; tolerant (any resolution failure yields no expectations, so the
-  strict floor — every violation fails — applies).
+  run, an exactly-expected violation passes. Pure aside from the check
+  expansion's registrar reads; tolerant (any failure yields no
+  expectations, so the strict floor — every violation fails — applies).
 
-  Sources, all in the ONE assertion-atom vocabulary:
+  Sources, all in the ONE assertion-atom vocabulary, all read off the
+  compiled plan so a registered variant and an inline plan share the path:
 
-  - the variant body's terminal `:assertions` (own-only verdict);
-  - the expanded `:checks` assertion atoms (an inheritable schema
-    expectation rides a check, §Checks);
+  - the plan's terminal `[:expect :assertions]` (own-only verdict);
+  - the expanded `[:expect :checks]` assertion atoms (an inheritable
+    schema expectation rides a check, §Checks);
   - the auto-play `executed-script`'s in-script `[:assert …]` checkpoints
     (a mid-script schema expectation).
 
   `:rf.assert/schema-error` is NOT dispatched into the frame (it has no
   reg-event-fx handler — it is tape-evaluated), so collecting the DECLARED
   atoms here is the single path that feeds the consumption matcher."
-  [variant-id executed-script]
+  [plan executed-script]
   (try
-    (let [body          (frames/variant-body variant-id)
-          terminal      (vec (:assertions body))
-          check-atoms   (mapcat val (variant-checks variant-id))
+    (let [terminal      (vec (get-in plan [:expect :assertions]))
+          check-atoms   (mapcat val (plan-checks plan))
           script-atoms  (into []
                               (keep (fn [step]
                                       (when (and (vector? step)
@@ -432,8 +446,12 @@
   The legacy `:lifecycle` / `:frame` / `:snapshot` / `:decorators` /
   `:effective-args` / `:rendered-hiccup` slots are PRESERVED (API stable,
   spec/017 §1a — `:status` is NET-NEW alongside `:lifecycle`), so existing
-  consumers keep reading their slots while the unified shape lands."
-  [{:keys [variant-id decorator-stack effective-args snapshot executed-script]} start-ms]
+  consumers keep reading their slots while the unified shape lands.
+
+  Checks + schema-expectations are sourced from the compiled `:plan`
+  (rf2-5x1wt.20), so a registered variant and an INLINE plan assemble the
+  same result through one path."
+  [{:keys [variant-id decorator-stack effective-args snapshot executed-script plan]} start-ms]
   (let [app-db   (rf/get-frame-db variant-id)
         ;; rf2-5x1wt.19 follow-through — read the epoch tape through the
         ;; late-bound `re-frame.core/epoch-history` facade (mirroring
@@ -449,14 +467,14 @@
                     :epoch-tape          tape
                     :assertions          (or (:rf.story/assertions app-db) [])
                     :script              executed-script
-                    :check->atoms        (variant-checks variant-id)
+                    :check->atoms        (plan-checks plan)
                     ;; rf2-5x1wt.21 — the declared `:rf.assert/schema-error`
                     ;; expectations, EXACT-consumed against the projected
                     ;; tape violations (§Schema rule). Tape-evaluated, NOT
-                    ;; dispatched — collected from the body, not the
+                    ;; dispatched — collected from the plan, not the
                     ;; `:rf.story/assertions` accumulator.
-                    :schema-expectations (variant-schema-expectations
-                                           variant-id executed-script)
+                    :schema-expectations (plan-schema-expectations
+                                           plan executed-script)
                     :app-db              (or app-db {})
                     :elapsed-ms          (- (interop/now-ms) start-ms)})]
     (merge unified
@@ -517,9 +535,17 @@
 
 (defn- run-phase-1!
   "Phase 1: drive loaders to completion. Thin wrapper that returns
-  `ctx` so the orchestrator stays a clean threaded pipeline."
-  [{:keys [variant-id] :as ctx}]
-  (assoc ctx :loaders-complete? (run-loaders! variant-id)))
+  `ctx` so the orchestrator stays a clean threaded pipeline.
+
+  rf2-5x1wt.20 — the loader body defaults to the registered variant body
+  (`run-loaders!` 1-arity); an inline run threads `:loader-body` on the
+  ctx (the plan's `:world` loader slots), so an inline plan's loaders run
+  through the SAME phase fn without reading the side-table."
+  [{:keys [variant-id loader-body] :as ctx}]
+  (assoc ctx :loaders-complete?
+         (if (contains? ctx :loader-body)
+           (run-loaders! variant-id loader-body)
+           (run-loaders! variant-id))))
 
 (defn- run-phase-2!
   "Phase 2: dispatch the plan's `[:world :setup]` (+ the parent story's
@@ -728,6 +754,162 @@
                    (finalise-run! resolve play-promise ctx' start-ms))
                  (catch #?(:clj Throwable :cljs :default) e
                    (handle-run-error! resolve variant-id e start-ms)))))))))))
+
+;; ---- inline plan execution (rf2-5x1wt.20) --------------------------------
+;;
+;; An inline plan (spec/017 §Inline plan) is an executable plan MAP that is
+;; NOT registered as a Story variant: it MUST NOT appear in Story
+;; navigation, it MAY compose registered fragments + checks, and it MUST
+;; return the SAME run-result shape as a registered variant. `story/run`,
+;; `story/is`, and `story/explain` already accept a map target (the verbs
+;; dispatch on target type — a keyword is a registry lookup, a map is an
+;; inline plan); `variant-plan` / `explain` compile a map directly
+;; (rf2-5x1wt.24). This is the RUN path for a map target.
+;;
+;; The design reuses the registered run pipeline rather than forking it:
+;;
+;;   - the plan is compiled once (`plan/variant-plan` accepts the map);
+;;   - an ANONYMOUS frame id is minted in the reserved `:rf.story.inline/*`
+;;     namespace (NEVER a registered variant id, so navigation can't surface
+;;     it and a concurrent registered run can't collide);
+;;   - the decorator stack is resolved from the plan's `[:world :decorators]`
+;;     refs (registry-free — the variant/story side-table is not read);
+;;   - the SAME phase fns (`run-phase-1!` / `run-phase-2!` / `run-phase-4!`)
+;;     drive loaders → setup → script, all sourced from the plan;
+;;   - `record-result-map` assembles the one unified result from the plan +
+;;     the frame's accumulated assertions + the epoch tape;
+;;   - the anonymous frame is torn down once the run resolves.
+
+(defonce ^:private inline-frame-counter (atom 0))
+
+(defn- mint-inline-frame-id
+  "Mint a fresh anonymous frame id for an inline-plan run, in the reserved
+  `:rf.story.inline/*` namespace (spec/Conventions.md §Reserved
+  namespaces). A monotonic counter keeps concurrent inline runs on
+  distinct frames; the id is never a registered variant id, so an inline
+  run can never collide with — or appear alongside — a navigable variant."
+  []
+  (keyword "rf.story.inline" (str "plan-" (swap! inline-frame-counter inc))))
+
+(defn- prepare-inline-context
+  "Resolve the per-run inputs an inline-plan run needs from its COMPILED
+  `plan` (rf2-5x1wt.20). Registry-free twin of `prepare-context`:
+
+  - `:variant-id`      — the minted anonymous frame id (the run's frame);
+  - `:plan`            — the supplied compiled plan, threaded down the
+                          phases unchanged (it is already normalized);
+  - `:decorator-stack` — `decorators/resolve-decorator-refs` over the
+                          plan's `[:world :decorators]` refs (the compiler
+                          merged the variant chain + composed fragments
+                          into that vector);
+  - `:effective-args`  — the plan's `[:world :effective-args]` (resolved at
+                          compile time);
+  - `:loader-body`     — the loader slots (`:loaders` /
+                          `:loaders-complete-when`) the compiler carried
+                          onto `:world`, so phase 1 runs the inline plan's
+                          loaders without a registry read;
+  - `:snapshot`        — nil; an unregistered inline plan has no navigable
+                          snapshot identity.
+
+  Pure aside from the decorator-body registrar reads (a decorator is a
+  registered artefact even when the plan is not)."
+  [frame-id plan]
+  {:variant-id      frame-id
+   :plan            plan
+   :decorator-stack (decorators/resolve-decorator-refs
+                      (get-in plan [:world :decorators] []))
+   :effective-args  (get-in plan [:world :effective-args] {})
+   :loader-body     {:loaders               (get-in plan [:world :loaders])
+                     :loaders-complete-when (get-in plan [:world :loaders-complete-when])}
+   :snapshot        nil})
+
+(defn- inline-events-only?
+  "True iff the inline `plan` drives no loaders / loaders-complete-when and
+  carries no `:frame-setup` decorators — so the lifecycle takes the
+  `:pre-mount → :ready` fast-path (rf2-043cm). Mirrors
+  `loaders/events-only-variant?`, reading the loader slots off the plan's
+  `:world` rather than a registered body."
+  [plan decorator-stack]
+  (and (empty? (get-in plan [:world :loaders]))
+       (nil?   (get-in plan [:world :loaders-complete-when]))
+       (empty? (:frame-setup decorator-stack))))
+
+(defn- run-inline-phase-0!
+  "Phase 0 for an inline run: allocate the ANONYMOUS frame from the plan
+  (registry-free), then seed the assertion accumulators + install the
+  play-runner trace listener — the same ordering `run-phase-0!` uses so
+  loader-phase events are captured."
+  [{:keys [variant-id plan decorator-stack] :as ctx}]
+  (frames/allocate-inline! variant-id
+                           decorator-stack
+                           (get-in plan [:world :frame :fx-overrides])
+                           (inline-events-only? plan decorator-stack))
+  (assertions/reset-trace-accumulators! variant-id)
+  (play/install-trace-listener! variant-id)
+  ctx)
+
+(defn run-inline-plan
+  "Execute an inline plan MAP (rf2-5x1wt.20, spec/017 §Inline plan) and
+  return a promise/future of the unified run-result — the SAME shape a
+  registered variant run returns.
+
+  `inline-plan` is the inline plan body (a map). `opts` is the run opts
+  threaded to the plan compiler (`:lookup` / `:fragment-lookup` /
+  `:check-lookup` / `:view-lookup` / `:sub-lookup` / `:validator-fns` — so
+  the plan MAY compose REGISTERED fragments + checks, or thread explicit
+  lookups for a host-free run). The plan is compiled ONCE, run against a
+  fresh anonymous frame, and the frame is torn down when the run resolves.
+
+  A plan-construction failure (an unknown composed fragment, a missing
+  `[:arg …]`, a misplaced `[:assert …]` in setup, …) surfaces as the same
+  structured `:rf.error/story-*` error result a registered variant's
+  malformed plan produces — the frame is never allocated in that case.
+
+  The inline plan is NOT registered in the Story side-table; it is absent
+  from Story navigation by construction (no registration + an anonymous
+  frame stamped `:rf/inline?`)."
+  ([inline-plan] (run-inline-plan inline-plan nil))
+  ([inline-plan opts]
+   (if-not config/enabled?
+     (async/resolved (empty-result (:variant/id inline-plan)))
+     (let [start-ms     (interop/now-ms)
+           compile-opts (select-keys opts [:lookup :fragment-lookup :check-lookup
+                                           :view-lookup :sub-lookup :validator-fns])
+           ;; Compile the plan up front so a construction failure (an
+           ;; unknown composed fragment, a missing `[:arg …]`, an
+           ;; `[:assert …]` in setup, …) is projected directly — no frame
+           ;; is allocated, mirroring `plan-error-result`'s frame-free shape.
+           plan-or-err  (try {:plan (plan/variant-plan inline-plan compile-opts)}
+                          (catch #?(:clj Throwable :cljs :default) e {:error e}))]
+       (if-let [e (:error plan-or-err)]
+         (async/resolved (plan-error-result (:variant/id inline-plan) e))
+         (let [plan     (:plan plan-or-err)
+               frame-id (mint-inline-frame-id)]
+           (async/promise
+             (fn [resolve]
+               (try
+                 (let [ctx          (-> (prepare-inline-context frame-id plan)
+                                        run-inline-phase-0!
+                                        run-phase-1!
+                                        run-phase-2!)
+                       [ctx' play-promise] (run-phase-4! ctx)]
+                   (-> play-promise
+                       (async/then
+                         (fn [_]
+                           (let [result (record-result-map ctx' start-ms)]
+                             (frames/destroy-inline!
+                               frame-id (:decorator-stack ctx')
+                               (get-in plan [:world :loaders-teardown]))
+                             (resolve result))
+                           nil))))
+                 (catch #?(:clj Throwable :cljs :default) e
+                   (record-error! frame-id :phase-0-setup nil e)
+                   (loaders/error! frame-id (ex-data e))
+                   (let [result (record-result-map
+                                  {:variant-id frame-id :plan plan} start-ms)]
+                     (try (frames/destroy-inline! frame-id nil nil)
+                       (catch #?(:clj Throwable :cljs :default) _ nil))
+                     (resolve result))))))))))))
 
 ;; ---- reset-variant -------------------------------------------------------
 

--- a/tools/story/test/re_frame/story/inline_plan_test.clj
+++ b/tools/story/test/re_frame/story/inline_plan_test.clj
@@ -1,0 +1,261 @@
+(ns re-frame.story.inline-plan-test
+  "Headless inline-plan execution tests (NewTestStory rf2-5x1wt.20,
+  `tools/story/spec/017-Testing-Story.md` §Inline plan + §three verbs).
+
+  An inline plan is an executable plan MAP that is NOT registered as a
+  Story variant. `story/run` / `story/is` / `story/explain` accept a map
+  target (a keyword target is a registered variant; a map is an inline
+  plan). The §B6 acceptance bullets, verified here:
+
+  - an inline plan runs HEADLESSLY (the same unified run-result a
+    registered variant returns);
+  - an inline plan is ABSENT from Story navigation (nothing is registered);
+  - an inline plan can use a REGISTERED check;
+  - an inline plan CANNOT reference a missing fragment (it fails cleanly);
+  - `story/is` reports through the test framework for a map target;
+  - an inline plan and a registered variant describing the SAME behaviour
+    produce equivalent final app-db + assertion records AFTER
+    `canonicalize` (the metamorphic relation, §three verbs / §20).
+
+  JVM-only (`.clj`): on the JVM `story/run` returns a `CompletableFuture`
+  that resolves synchronously to the unified result, and `story/is` BLOCKS
+  on it + fires one `clojure.test` report per assertion. The CLJS run is
+  async; its plan compilation + report projection are covered host-free by
+  the plan / result suites."
+  (:require [clojure.test :refer [deftest is testing use-fixtures] :as t]
+            [re-frame.core      :as rf]
+            [re-frame.frame     :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.story     :as story]
+            [re-frame.story.assertions :as assertions]
+            [re-frame.story.play.runner-events :as re]))
+
+(defn- reset-rf! [test-fn]
+  (story/clear-all!)
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (try (rf/init! plain-atom/adapter)
+       (catch clojure.lang.ExceptionInfo _ nil))
+  (reset! assertions/trace-accumulators {})
+  (reset! re/run-state {})
+  (story/install-canonical-vocabulary!)
+  (frame/ensure-default-frame!)
+  ;; A tiny event the inline plans drive — the app under test.
+  (rf/reg-event-db :inline/set-status (fn [db [_ v]] (assoc db :status v)))
+  (rf/reg-event-db :inline/inc        (fn [db _]     (update db :n (fnil inc 0))))
+  (test-fn))
+
+(use-fixtures :each reset-rf!)
+
+(defn- run-target [target]
+  (.get ^java.util.concurrent.CompletableFuture (story/run target)))
+
+(defn- capture-reports
+  "Run `thunk` with `clojure.test/report` rebound to collect every
+  `:pass`/`:fail`/`:error` report map `story/is` fires. Returns
+  `[thunk-return reports-vector]`."
+  [thunk]
+  (let [collected (atom [])]
+    (binding [t/report (fn [m]
+                         (when (#{:pass :fail :error} (:type m))
+                           (swap! collected conj m)))]
+      [(thunk) @collected])))
+
+;; ===========================================================================
+;; Inline plan runs headlessly
+;; ===========================================================================
+
+(deftest inline-plan-runs-headless-pass
+  (testing "a map target runs headlessly and yields the unified run-result
+            (§B6 — inline plan runs headlessly). The verdict is driven by the
+            in-script `[:assert …]` checkpoint — the same surface a registered
+            variant's verdict comes from (terminal :assertions are declarative;
+            the lifecycle records in-script checkpoints)."
+    (let [result (run-target {:script [[:dispatch [:inline/set-status :loaded]]
+                                       [:assert [:rf.assert/path-equals [:status] :loaded]]]})]
+      (is (= :pass (:status result)) "the unified verdict is :pass")
+      (is (= :loaded (:status (:app-db result))) "setup/script drove app-db")
+      (is (= :ready (:lifecycle result)))
+      (is (every? :passed? (:assertions result)) "the checkpoint passed"))))
+
+(deftest inline-plan-runs-headless-fail
+  (testing "a failing in-script checkpoint in an inline plan yields :status :fail"
+    (let [result (run-target {:script [[:dispatch [:inline/set-status :idle]]
+                                       [:assert [:rf.assert/path-equals [:status] :loaded]]]})]
+      (is (= :fail (:status result)))
+      (is (not (every? :passed? (:assertions result)))))))
+
+(deftest inline-plan-setup-and-script-both-drive-state
+  (testing "an inline plan's :setup establishes preconditions, :script runs after"
+    (let [result (run-target {:setup  [[:dispatch [:inline/inc]]]
+                              :script [[:dispatch [:inline/inc]]
+                                       [:dispatch [:inline/inc]]
+                                       [:assert [:rf.assert/path-equals [:n] 3]]]})]
+      (is (= :pass (:status result)))
+      (is (= 3 (:n (:app-db result)))))))
+
+(deftest inline-plan-loaders-run-from-the-plan
+  (testing "an inline plan declaring :loaders runs phase-1 loaders off the
+            plan's :world (no registry read) before :setup / :script"
+    (let [result (run-target {:loaders [[:inline/set-status :loaded]]
+                              :script  [[:assert [:rf.assert/path-equals [:status] :loaded]]]})]
+      (is (= :pass (:status result)) "the loader event ran the app to :loaded")
+      (is (= :loaded (:status (:app-db result))))
+      (is (= :ready (:lifecycle result))))))
+
+;; ===========================================================================
+;; Inline plan is ABSENT from Story navigation
+;; ===========================================================================
+
+(deftest inline-plan-absent-from-navigation
+  (testing "running an inline plan registers NOTHING in the Story side-table
+            and leaves no variant frame behind (§B6 — absent from navigation)"
+    (is (empty? (story/ids :variant)) "precondition: no variants registered")
+    (run-target {:script [[:dispatch [:inline/set-status :ok]]
+                          [:assert [:rf.assert/path-equals [:status] :ok]]]})
+    (is (empty? (story/ids :variant))
+        "no variant id was registered by the inline run")
+    (is (empty? (story/variants-by-story))
+        "the inline plan appears under no story")
+    (is (empty? (story/variant-frames))
+        "the anonymous inline frame was torn down — no lingering nav frame")))
+
+;; ===========================================================================
+;; Inline plan can use a REGISTERED check
+;; ===========================================================================
+
+(deftest inline-plan-composes-registered-check
+  (testing "an inline plan composing a registered check resolves the check id
+            into the plan + groups its records under the check id, exactly the
+            way a registered variant does (§B6 — registered check). The check's
+            atom is ALSO an in-script checkpoint so it actually records, proving
+            the registered check resolved and ran."
+    (story/reg-check :check.inline/status-loaded
+      {:assertions [[:rf.assert/path-equals [:status] :loaded]]})
+    ;; The compiled plan carries the composed check id under [:expect :checks].
+    (let [plan (story/variant-plan {:compose [:check.inline/status-loaded]
+                                    :script  [[:dispatch [:inline/set-status :loaded]]]})]
+      (is (= [:check.inline/status-loaded] (get-in plan [:expect :checks]))
+          "the registered check id resolves into the inline plan's :expect"))
+    (let [result (run-target {:compose [:check.inline/status-loaded]
+                              :script  [[:dispatch [:inline/set-status :loaded]]
+                                        [:assert [:rf.assert/path-equals [:status] :loaded]]]})]
+      (is (= :pass (:status result)))
+      (let [check (first (filter #(= :check.inline/status-loaded (:check %))
+                                 (:checks result)))]
+        (is (some? check) "the run-result groups records under the check id")
+        (is (= :pass (:status check)) "the composed check aggregates :pass")
+        (is (every? :passed? (:assertions check))
+            "the registered check's assertion ran + passed")))))
+
+(deftest inline-plan-composes-registered-fragment
+  (testing "an inline plan composing a registered fragment appends the
+            fragment's setup + script (§B6 — composed fragments/checks)"
+    (story/reg-fragment :fragment.inline/seed
+      {:setup [[:dispatch [:inline/set-status :seeded]]]})
+    (let [result (run-target {:compose [:fragment.inline/seed]
+                              :script  [[:assert [:rf.assert/path-equals [:status] :seeded]]]})]
+      (is (= :pass (:status result)) "the fragment setup seeded the app-db")
+      (is (= :seeded (:status (:app-db result)))))))
+
+;; ===========================================================================
+;; Inline plan CANNOT reference a missing fragment — fails cleanly
+;; ===========================================================================
+
+(deftest inline-plan-missing-fragment-fails-cleanly
+  (testing "an inline plan composing an unregistered fragment FAILS plan
+            construction with a structured error result — no frame allocated,
+            no exception escapes (§B6 — missing fragment fails cleanly)"
+    (let [result (run-target {:compose [:fragment.inline/does-not-exist]
+                              :script  [[:dispatch [:inline/set-status :ok]]]})]
+      (is (= :error (:status result)))
+      (is (= :rf.error/story-compose-unknown
+             (:assertion (first (:assertions result))))
+          "the structured :compose-unknown error rides the assertion record")
+      (is (empty? (story/ids :variant))
+          "nothing was registered by the failed inline run")
+      (is (empty? (story/variant-frames))
+          "no frame lingers from the failed inline run"))))
+
+(deftest inline-plan-missing-arg-fails-cleanly
+  (testing "an inline plan with an [:arg …] placeholder for an undeclared arg
+            FAILS plan construction cleanly (the args contract is not exempt
+            for inline plans)"
+    (let [result (run-target {:script [[:dispatch [:inline/set-status [:arg :missing]]]]})]
+      (is (= :error (:status result)))
+      (is (= :rf.error/story-missing-arg
+             (:assertion (first (:assertions result))))))))
+
+;; ===========================================================================
+;; story/is reports through the test framework for a map target
+;; ===========================================================================
+
+(deftest story-is-reports-per-assertion-for-map-target
+  (testing "story/is fires one report per assertion for an inline plan
+            (§B6 — story/is reports through the test framework for a map
+            target)"
+    (let [[result reports]
+          (capture-reports
+            #(story/is {:script [[:dispatch [:inline/set-status :loaded]]
+                                 [:assert [:rf.assert/path-equals [:status] :loaded]]
+                                 [:assert [:rf.assert/path-equals [:status] :loaded]]]}))]
+      (is (= :pass (:status result)) "the unified verdict is :pass")
+      (is (= 2 (count reports)) "one report per recorded assertion")
+      (is (every? #(= :pass (:type %)) reports)))))
+
+(deftest story-is-reports-fail-for-map-target
+  (testing "story/is fires a :fail report for a failing inline-plan assertion"
+    (let [[result reports]
+          (capture-reports
+            #(story/is {:script [[:dispatch [:inline/set-status :idle]]
+                                 [:assert [:rf.assert/path-equals [:status] :loaded]]]}))]
+      (is (= :fail (:status result)))
+      (is (= 1 (count reports)))
+      (is (= :fail (:type (first reports))))
+      (is (re-find #":rf.assert/path-equals" (:message (first reports)))))))
+
+;; ===========================================================================
+;; Metamorphic relation: inline plan ≡ registered variant after canonicalize
+;; ===========================================================================
+
+(deftest inline-and-registered-equivalent-after-canonicalize
+  (testing "an inline plan and a registered variant describing the SAME
+            behaviour produce equivalent final app-db + assertion records
+            AFTER canonicalize (§B6 — the metamorphic relation)"
+    (let [behaviour {:setup      [[:dispatch [:inline/inc]]]
+                     :script     [[:dispatch [:inline/inc]]
+                                  [:assert [:rf.assert/path-equals [:n] 2]]]
+                     :assertions [[:rf.assert/path-equals [:n] 2]]
+                     :tags       #{:test}}]
+      (story/reg-variant :story.inline/equivalent behaviour)
+      (let [registered (run-target :story.inline/equivalent)
+            inline     (run-target behaviour)]
+        (testing "both reach the same verdict + app-db before canonicalize"
+          (is (= :pass (:status registered)))
+          (is (= :pass (:status inline)))
+          (is (= 2 (:n (:app-db registered))))
+          (is (= 2 (:n (:app-db inline)))))
+        (testing "canonicalized final app-db is equal (frame ids stripped)"
+          (is (= (story/canonicalize (:app-db registered))
+                 (story/canonicalize (:app-db inline)))))
+        (testing "canonicalized assertion records are equal (variant/frame
+                  ids reconciled + stripped)"
+          (is (= (story/canonicalize (:assertions registered))
+                 (story/canonicalize (:assertions inline)))))
+        (testing "the two runs share a canonical run-hash"
+          (is (= (story/run-hash registered)
+                 (story/run-hash inline))))))))
+
+;; ===========================================================================
+;; explain accepts a map target (rf2-5x1wt.24 base; confirmed for the verb)
+;; ===========================================================================
+
+(deftest explain-accepts-inline-plan-map
+  (testing "story/explain compiles a map target directly (no registration)"
+    (let [ex (story/explain {:variant/id :inline/explained
+                             :setup      [[:dispatch [:inline/inc]]]
+                             :script     [[:dispatch [:inline/inc]]]})]
+      (is (= [:inline/explained] (:source-chain ex)))
+      (is (= [[:dispatch [:inline/inc]]] (:setup-order ex)))
+      (is (empty? (story/ids :variant)) "explain registered nothing"))))


### PR DESCRIPTION
## Summary

Lands **inline-plan execution** (NewTestStory §B6, rf2-5x1wt.20). The three public verbs now accept an inline plan **MAP** target as well as a registered-variant keyword:

- `(story/run inline-plan opts)` / `(story/is inline-plan opts)` / `(story/explain inline-plan)`

`explain` / `variant-plan` already compiled a map directly (rf2-5x1wt.24); this PR lands the missing **RUN path** for `story/run` + `story/is`.

## How it works

The inline run is the **registry-free twin** of the registered-variant lifecycle, reusing it rather than forking it:

1. the plan is compiled **once** (`plan/variant-plan` accepts the map; `opts` threads `:fragment-lookup` / `:check-lookup` / `:lookup` so an inline plan can compose **registered** fragments + checks, or run host-free);
2. an **anonymous frame id** is minted in the reserved `:rf.story.inline/*` namespace (never a registered variant id, so no navigation/collision), stamped `:rf/inline? true`;
3. the decorator stack resolves from the plan's already-merged `[:world :decorators]` refs (the variant/story side-table is **not** read);
4. the **same** phase pipeline (loaders → setup → script) drives the run, all sourced from the plan;
5. the **one** unified run-result is assembled from the plan + the frame's accumulated assertions + the epoch tape (the same `result/run-result` boundary) — so an inline plan and a registered variant describing the same behaviour produce **equivalent app-db + assertion records after `canonicalize`**;
6. the anonymous frame is torn down when the run resolves; **nothing is registered**.

A plan-construction failure for a map target (unknown composed fragment, missing `[:arg …]`, `[:assert …]` in setup, …) surfaces as the **same** structured `:rf.error/story-*` error result a registered variant's malformed plan produces (frame never allocated).

To unify the path, runtime checks + schema-expectations now source from the **compiled plan** (not a re-read of the registered body); `run-loaders!` / `run-phase-1!` take an optional loader body so an inline plan's loaders run without a registry read; `decorators/resolve-decorator-refs` resolves a supplied ref vector registry-free; `frames/allocate-inline!` / `destroy-inline!` are the registry-free frame twins; the compiler now carries `:loaders-complete-when` onto `[:world]`.

**Backward compatibility:** the keyword target path is unchanged — `story-mcp` keeps calling `story/run` with a keyword variant id (verified by story-mcp + cum40 below).

## Files changed

- `tools/story/src/re_frame/story.cljc` — `run` / `is` dispatch on target type (map → inline; keyword → variant); docstrings.
- `tools/story/src/re_frame/story/runtime.cljc` — `run-inline-plan` orchestrator + `prepare-inline-context` + `run-inline-phase-0!` + anonymous-frame minting; checks/schema-expectations sourced from the plan; `run-loaders!`/`run-phase-1!` optional loader-body.
- `tools/story/src/re_frame/story/frames.cljc` — `allocate-inline!` / `destroy-inline!` (registry-free frame twins; `:rf/inline?` stamp).
- `tools/story/src/re_frame/story/decorators.cljc` — `resolve-decorator-refs` (resolve a supplied ref vector without reading the variant/story side-table).
- `tools/story/src/re_frame/story/lifecycle.cljc` — `run-inline-plan` delegator.
- `tools/story/src/re_frame/story/plan.cljc` — carry `:loaders-complete-when` onto `[:world]`.
- `tools/story/spec/017-Testing-Story.md` — document the inline-plan run path (§Inline plan).
- `tools/story/test/re_frame/story/inline_plan_test.clj` — 13 new JVM tests covering every §B6 bullet.

**Did NOT touch** `assertions.cljc` or `requirements.cljc` (the concurrent .28 browser-tier lane).

## Quality gates

| Gate | Command | Result |
|------|---------|--------|
| Story JVM | `tools/story` → `clojure -M:test` | PASS — 1172 tests / 3726 assertions, 0 failures, 0 errors (incl. 13 new inline-plan tests) |
| story-mcp JVM (downstream consumer) | `tools/story-mcp` → `clojure -M:test` | PASS — 172 tests / 861 assertions, 0 failures, 0 errors |
| cum40 (story-mcp MCP-client conformance) | `tools/mcp-conformance` → `npm run test:story` | PASS — `STORY-MCP MCP-CLIENT CONFORMANCE GREEN` |
| Implementation CLJS | `implementation` → `npm run test:cljs` | PASS — 4850 tests / 15890 assertions, 0 failures, 0 errors |
| Story CLJS compile | `implementation` → `npm run story:build` | PASS — 0 warnings |
| Fast PR spine | `scripts/test-fast-pr.sh` | PASS — `PASS fast PR spine` |
