### PR TITLE
fix(test): convert silently-skipped map-form use-fixtures to fn form (rf2-gc7la)

### DIFF
--- a/tools/story/test/re_frame/story/ui/backgrounds_switcher_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/backgrounds_switcher_cljs_test.cljc
@@ -25,7 +25,7 @@
      (story/install-canonical-vocabulary!)))
 
 #?(:cljs
-   (use-fixtures :each {:before reset-all!}))
+   (use-fixtures :each (fn [t] (reset-all!) (t))))
 
 ;; ---- pure-ish: select! mutations ----------------------------------------
 

--- a/tools/story/test/re_frame/story/ui/dispatch_console_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/dispatch_console_cljs_test.cljc
@@ -45,7 +45,7 @@
        (try (.clear (.-localStorage js/window)) (catch :default _ nil)))))
 
 #?(:cljs
-   (use-fixtures :each {:before reset-all!}))
+   (use-fixtures :each (fn [t] (reset-all!) (t))))
 
 ;; ---- pure: parse-payload -------------------------------------------------
 

--- a/tools/story/test/re_frame/story/ui/element_inspector_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/element_inspector_cljs_test.cljc
@@ -96,8 +96,7 @@
      (reset! inspector/state {:active? false :hover nil})))
 
 #?(:cljs
-   (use-fixtures :each {:before reset-inspector!
-                        :after  reset-inspector!}))
+   (use-fixtures :each (fn [t] (reset-inspector!) (t) (reset-inspector!))))
 
 #?(:cljs
    (deftest mode-toggle-flips-active-flag

--- a/tools/story/test/re_frame/story/ui/tag_badges_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/tag_badges_cljs_test.cljc
@@ -27,7 +27,7 @@
   (state/reset-shell-state!)
   (story/install-canonical-vocabulary!))
 
-(use-fixtures :each {:before reset-all!})
+(use-fixtures :each (fn [t] (reset-all!) (t)))
 
 ;; ---- pure: tag → style-key projection -----------------------------------
 

--- a/tools/story/test/re_frame/story/ui/test_watch_mode_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/test_watch_mode_cljs_test.cljc
@@ -28,7 +28,7 @@
   (state/reset-shell-state!)
   (story/install-canonical-vocabulary!))
 
-(use-fixtures :each {:before reset-all!})
+(use-fixtures :each (fn [t] (reset-all!) (t)))
 
 ;; ---- pure: watch-mode flag ----------------------------------------------
 

--- a/tools/story/test/re_frame/story/ui/test_widget_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/test_widget_cljs_test.cljc
@@ -31,7 +31,7 @@
   (state/reset-shell-state!)
   (story/install-canonical-vocabulary!))
 
-(use-fixtures :each {:before reset-all!})
+(use-fixtures :each (fn [t] (reset-all!) (t)))
 
 ;; ---- pure: state transitions --------------------------------------------
 
@@ -362,6 +362,6 @@
                       (state/record-test-run :story.x/d fail))
              summary (state/test-summary s
                        [:story.x/a :story.x/b :story.x/c :story.x/d :story.x/e])]
-         (is (= {:total 5 :passed 3 :failed 1 :running 0 :pending 1
-                 :all-green? false}
+         (is (= {:total 5 :passed 3 :failed 1 :cannot-run 0 :running 0
+                 :pending 1 :all-green? false}
                 summary))))))

--- a/tools/story/test/re_frame/story/ui/toolbar_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/toolbar_cljs_test.cljc
@@ -70,7 +70,7 @@
   (state/reset-shell-state!)
   (story/install-canonical-vocabulary!))
 
-(use-fixtures :each {:before reset-all!})
+(use-fixtures :each (fn [t] (reset-all!) (t)))
 
 ;; ---- pure: toggle-mode axis semantics -----------------------------------
 

--- a/tools/story/test/re_frame/story/ui/viewport_switcher_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/viewport_switcher_cljs_test.cljc
@@ -28,7 +28,7 @@
      (story/install-canonical-vocabulary!)))
 
 #?(:cljs
-   (use-fixtures :each {:before reset-all!}))
+   (use-fixtures :each (fn [t] (reset-all!) (t))))
 
 ;; ---- pure-ish: select! mutations ----------------------------------------
 

--- a/tools/story/test/re_frame/story/xray_preset_test.cljc
+++ b/tools/story/test/re_frame/story/xray_preset_test.cljc
@@ -29,7 +29,7 @@
                (frame/ensure-default-frame!)))
   (story/install-canonical-vocabulary!))
 
-(use-fixtures :each {:before reset-all!})
+(use-fixtures :each (fn [t] (reset-all!) (t)))
 
 ;; ---- pure: merge-preset --------------------------------------------------
 


### PR DESCRIPTION
## Summary

The JVM `clojure -M:test` runner treats the map form `(use-fixtures :each {:before f})` as a **fixture fn that never invokes the wrapped test**, so any `.cljc` namespace registering a JVM-visible map-form fixture alongside JVM-visible `deftest`s contributed **0 assertions and was silently skipped** (false green). The map form is only valid on the CLJS runner (it supports async `:before`/`:after`).

This converts the JVM-relevant `.cljc` fixtures to the standard one-arg fn form `(fn [t] (before) (t) (after))` — the form used by the suites that already run correctly on both targets (cf. `artifact_test.cljc`). Setup/teardown behavior is preserved exactly. None of the converted CLJS fixtures are async, so the fn form is safe on both targets.

### Converted namespaces (9 files, all `**/test/**` `.cljc`)

Genuine JVM bug victims (were reporting **0 tests** on the JVM gate):
- `re-frame.story.xray-preset-test` — 0 → **7 tests / 10 assertions**
- `re-frame.story.ui.toolbar-cljs-test` — 0 → **9 / 27**
- `re-frame.story.ui.test-watch-mode-cljs-test` — 0 → **11 / 12**
- `re-frame.story.ui.test-widget-cljs-test` — 0 → **13 / 27** (incl. 1 previously-hidden failure, fixed)
- `re-frame.story.ui.tag-badges-cljs-test` — 0 → **1 / 1** (the JVM-only `sorted-tags` test was swallowed by the unconditional broken fixture)

Consistency conversions (fixture was `#?(:cljs ...)`-wrapped so the JVM path was never bugged; converted to fn form to remove the latent trap, counts unchanged on JVM):
- `re-frame.story.ui.element-inspector-cljs-test`
- `re-frame.story.ui.dispatch-console-cljs-test`
- `re-frame.story.ui.viewport-switcher-cljs-test`
- `re-frame.story.ui.backgrounds-switcher-cljs-test`

### Left untouched (correct by design)
- `re-frame.test-helpers-app-fixture-cljs-test` (`implementation/core`) already splits `#?(:clj fn-form)` / `#?(:cljs map-form)` deliberately — its CLJS tests are **async** and need the map form to suspend across the async body. The JVM path uses the fn form, so it was never bugged.

### Previously-hidden failure surfaced + fixed
`jvm-only-summary-from-fixture` (`test_widget`) asserted a stale whole-map shape missing the `:cannot-run 0` key that `state/test-summary` has carried since rf2-5x1wt.19. The product code is correct; the test assertion was stale and never ran (skipped). Updated the expected map to include `:cannot-run 0`. No product source changed.

## Quality gates

| Gate | Result | Assertion-count delta |
|------|--------|------------------------|
| `tools/story` `clojure -M:test` (the gate that was silently skipping) | **PASS** | 1188 tests / 3802 assertions → **1229 / 3879** (+41 tests / +77 assertions surfaced) |
| `npm --prefix implementation run test:cljs` (node-test) | **PASS** | 4850 / 15890, unchanged (fn-form conversions safe on CLJS) |
| `scripts/test-fast-pr.sh` | **PASS** | (includes the CLJS gate above; markdown link/anchor validators green; mkdocs soft-skipped locally — CI runs it) |