### PR TITLE
docs(story): roll out testing docs + cannot-run/browser CI policy (rf2-5x1wt.27)

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -116,31 +116,78 @@ path **and** it loads one of the already-staged smoke surfaces (or
 accept the extra compile if it must stage a new one). Everything else
 runs nightly by default.
 
-### Forthcoming — headless plan gate + `:cannot-run` policy (NewTestStory EPIC rf2-5x1wt)
+### Story-as-test: headless plan gate, `:cannot-run` policy, fast-vs-browser split (NewTestStory EPIC rf2-5x1wt)
 
-The NewTestStory work (normative in
-[`tools/story/spec/017-Testing-Story.md`](tools/story/spec/017-Testing-Story.md))
-introduces a **headless variant-plan gate** that runs Story variants and
-inline plans through the `:headless` runner — fast, JVM/node, no browser.
-This becomes the default per-PR Story-as-test path; the existing
-browser-rendered `test:story-play-scripts` gate (which exercises the live
-shell + assertion-strip) stays as the browser-tier complement, not the
-default for ordinary state/effect/schema/trace assertions. Consistent
-with the project's CLJS-unit-tests-not-Playwright default, new Story/test
-coverage targets the headless plan gate first; reach for the browser gate
-only when an assertion genuinely needs browser behaviour.
+The NewTestStory testing substrate is **complete and promoted** — the
+normative contract is
+[`tools/story/spec/017-Testing-Story.md`](tools/story/spec/017-Testing-Story.md)
+(§CI policy is the authority for the gate rules below). The substrate
+ships the variant-plan compiler, the three execution verbs
+(`story/run` / `story/is` / `story/explain`), inline plans, the shared
+run-result + `:cannot-run` third status, the schema floor, the
+epoch-tape evidence projection, the determinism gate, the semantic diff,
+and run-artifact replay/promotion. This section records how that maps
+onto CI policy; the concrete workflow files are not restructured by the
+substrate work.
 
-Every CI gate that runs plans MUST define a **`:cannot-run` policy**.
-`:cannot-run` is a distinct third result state (not pass, fail, or skip):
-a runner returns it when an assertion or step requires evidence the
-selected runner cannot produce (e.g. a `:browser`-only visual snapshot
-under a `:headless` runner). Per gate, the policy is one of: **fail the
-gate** (the assertion was required), **report inconclusive** (record but
-do not fail), or **route to a richer runner** (re-run the affected
-variant/assertion under a browser-tier gate). The headless plan gate's
-default policy is to treat `:cannot-run` as inconclusive and surface the
-count, deferring browser-only assertions to the browser-tier gate that
-can prove them — never silently passing them.
+**Headless plan gate (the default per-PR Story-as-test path).** Story
+variants and inline plans run through the `:headless` runner — fast,
+JVM/node, no browser — and that is the default for ordinary
+state/effect/schema/trace assertions. Consistent with the project's
+CLJS-unit-tests-not-Playwright default, new Story/test coverage targets
+the headless path first; reach for a browser-tier assertion only when it
+genuinely needs browser behaviour. The pure substrate (compiler,
+requirement registry, determinism verdict logic, evidence projection)
+runs under `clojure -M:test` and `npm run test:cljs` with no runtime.
+
+**Fast vs browser-tier separation (already in place).** The gate split
+documented above (PR-smoke vs nightly-full) IS the fast-vs-browser-tier
+separation for Story-as-test, and it predates this work:
+
+- the **fast** path is the per-PR CLJS/JVM unit suite (`npm run
+  test:cljs`, the per-artefact `clojure -M:test` jobs, `jvm-tools-story`)
+  plus the single-testbed browser-rendered `test:story-play-scripts`
+  PR-smoke in the `story-xray-browser` job (§Story/Xray gate above);
+- the **browser tier** is the live-shell sweep on the nightly path
+  (`test:story-feature-load`, `test:story-static`, the full
+  `test:story-play-scripts` and `test:browser*`) in
+  `expensive-tests.yml`.
+
+A *dedicated* browser-tier gate that selects variants by their
+`:required-runner` capability set (`:pixels` / `:a11y-engine`) and runs
+ONLY those under a real-browser runner is the spec's deferred follow-on
+(017 §Browser-tier gate policy explicitly scopes the workflow wiring out
+of the spec change). The structural-a11y check
+(`:rf.assert/a11y-structural`) carries no browser dependency and runs on
+the normal `npm run test:cljs` / `clojure -M:test` path.
+
+**`:cannot-run` policy (MUST, per gate).** Every CI gate that runs plans
+MUST define a `:cannot-run` policy. `:cannot-run` is a distinct third
+result state (not pass, fail, or skip): a runner returns it when an
+assertion or step requires evidence the selected runner cannot produce
+(e.g. a `:browser`-only visual snapshot under a `:headless` runner). Per
+gate, the policy is one of: **fail the gate** (the assertion was
+required), **report inconclusive** (record but do not fail), or **route
+to a richer runner** (re-run the affected variant/assertion under a
+browser-tier gate). The headless plan gate's default policy is to treat a
+browser-tier `:cannot-run` as **inconclusive** and surface the count,
+deferring browser-only assertions to the browser-tier gate that can prove
+them — never silently passing them. A variant whose only unmet
+expectations are `:cannot-run` is itself `:cannot-run`, never a silent
+pass (017 §`:cannot-run` aggregation rule).
+
+**Failed-run artifacts.** A failed plan run can emit a
+`:rf.test/run-artifact` — the serializable, data-shaped record of one run
+(seed, event program, fx decisions, epoch tape, trace, result) — enough
+to replay it deterministically and re-derive the same evidence
+(017 §Artifacts — Run artifact, §Run artifact and replay). A gate MAY
+capture and upload that artifact for a failed run so the failure is
+replayable off-CI; the artifact also feeds the determinism gate and the
+semantic diff, and MAY be promoted into a curated regression variant via
+`story/promote-run-artifact!`. Wiring an `upload-artifact` step into a
+specific workflow gate is a CI-mechanics decision, not part of the
+substrate; the substrate guarantees the artifact exists and is
+canonicalizable.
 
 ## Local commands
 

--- a/docs/guide/13-testing.md
+++ b/docs/guide/13-testing.md
@@ -318,7 +318,7 @@ It's a `doseq` of `dispatch-sync` calls; it just reads as one intention instead 
 (ts/assert-path-equals [:auth :state] :validating {:frame :test/auth-flow})
 ```
 
-A mismatch fires a `clojure.test`-style failure through `do-report`, so it slots into your test report like any `is`. And there's a deliberate symmetry here worth flagging: `assert-path-equals` mirrors the `:rf.assert/path-equals` event used inside Story `:play` blocks (see [Spec 007 §Play functions](../../spec/007-Stories.md#play-functions)). Learn one surface and you can read the other without a translation table — the same assertion vocabulary spans your unit tests and your stories.
+A mismatch fires a `clojure.test`-style failure through `do-report`, so it slots into your test report like any `is`. And there's a deliberate symmetry here worth flagging: `assert-path-equals` mirrors the `:rf.assert/path-equals` event used inside a Story variant's `:script` (the public authoring vocabulary is `:setup` for preconditions and `:script` for behaviour under test; the normative contract is [`017-Testing-Story.md`](https://github.com/day8/re-frame2/blob/main/tools/story/spec/017-Testing-Story.md)). Learn one surface and you can read the other without a translation table — the same assertion vocabulary spans your unit tests and your stories.
 
 ## JVM versus CLJS: where things run
 

--- a/docs/story/api/play-script.md
+++ b/docs/story/api/play-script.md
@@ -4,6 +4,21 @@ This chapter is about the surface that turns a variant body's `:play-script` slo
 
 `:play-script` is the **canonical AND ONLY** phase-4 play surface as of 2026-05-20 — the legacy `:play` event-vector slot has been removed under pre-alpha posture, with no transitional dual-acceptance.
 
+> **Public authoring vocabulary — `:setup` / `:script`.** The P1 public
+> authoring slots are `:setup` (preconditions) and `:script` (behaviour
+> under test); they supersede the shipping `:events` and `:play-script`
+> spellings this page documents. Because the project is pre-alpha this is
+> a clean rename, not a long-lived compatibility layer — the shipping
+> slots remain only while the tree migrates (and the recorder still emits
+> the shipping spellings, so the EDN shown here is exact for today's
+> tool). The normative contract — the four-bucket plan, the three
+> execution verbs (`story/run` / `story/is` / `story/explain`),
+> `:cannot-run`, composition, the schema floor, `render-variant`, and the
+> epoch-tape evidence projection — lives in
+> [`017-Testing-Story.md`](https://github.com/day8/re-frame2/blob/main/tools/story/spec/017-Testing-Story.md).
+> For the consumer-facing recipe sheet in P1 vocabulary, see the
+> [Testing cookbook](../08-testing-cookbook.md).
+
 ## The grammar — ten step forms
 
 Every step is a bare vector. Phase 4 of the variant lifecycle iterates the script in order, dispatch-syncs each step into the variant's frame, drains to completion between steps, and records the result.

--- a/docs/story/index.md
+++ b/docs/story/index.md
@@ -55,6 +55,21 @@ We'll walk through the surface roughly in the order you'd reach for it. First st
 - [5. Snapshot identity + QR sharing](05-snapshot-identity.md) — content-hashed snapshots that survive renames. The visual-regression integration story.
 - [6. Time-travel in Story](06-time-travel.md) — Xray embedded in the RHS, scoped per variant frame.
 - [7. Multi-substrate side-by-side](07-multi-substrate.md) — the same variant under Reagent, UIx, Helix. For adapter authors and component-library maintainers.
+- [8. Testing cookbook](08-testing-cookbook.md) — the flat recipe sheet: a handler, a sub, a view, a machine, a route, a schema, a frame, a trace, an inline plan, and a Story variant — each with *which verb, which assertion, which runner*, in the P1 `:setup` / `:script` vocabulary.
+
+!!! note "Authoring vocabulary — `:setup` / `:script`"
+
+    The public authoring slots are **`:setup`** (preconditions) and
+    **`:script`** (behaviour under test). Some tutorial code blocks below
+    still show the shipping `:events` / `:play-script` spellings — those
+    are a clean pre-alpha rename, not a long-lived compatibility layer,
+    and the recorder still emits the shipping form today, so the EDN shown
+    is exact for the current tool. The normative contract — the four-bucket
+    plan, the three execution verbs (`story/run` / `story/is` /
+    `story/explain`), `:cannot-run`, composition, and the epoch-tape
+    evidence projection — lives in
+    [`017-Testing-Story.md`](https://github.com/day8/re-frame2/blob/main/tools/story/spec/017-Testing-Story.md);
+    the [Testing cookbook](08-testing-cookbook.md) is the consumer extract.
 
 ## Three load-bearing rules
 

--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -2192,6 +2192,21 @@ If `test:story-play-scripts` is renamed, docs and package scripts MUST be
 updated together. Browser-tier visual/a11y gates MUST run only variants
 whose assertions require them, or a deliberate selected subset.
 
+### Failed-run artifacts in CI
+
+A failed plan run MAY emit its `:rf.test/run-artifact` (§Artifacts — Run
+artifact, §Run artifact and replay) so the failure is replayable off-CI.
+The artifact is the serializable, data-shaped record of the one run —
+seed, event program, fx decisions, epoch tape, trace, and run-result —
+enough to replay it deterministically (§Run artifact and replay) and to
+feed the determinism gate (§Determinism gate) and the semantic diff
+(§Semantic diff). A gate MAY capture the artifact for a failed run and
+upload it as a CI artifact; it MAY also be promoted into a curated
+regression variant via `story/promote-run-artifact!` (§Promotion). The
+substrate GUARANTEES the artifact exists and is canonicalizable; wiring
+an upload step into a specific workflow gate is a CI-mechanics decision,
+NOT part of this spec.
+
 ### Browser-tier gate policy (rf2-5x1wt.28)
 
 The structural-a11y check (`:rf.assert/a11y-structural`, `:hiccup`) carries


### PR DESCRIPTION
Terminal bead of the NewTestStory EPIC (rf2-5x1wt.27). Aligns the testing
docs with the now-complete substrate and formalizes CI policy as
normative docs/spec. **No `.github/workflows/*` changes.**

## What changed

**Docs (public `:setup` / `:script` vocabulary):**
- `docs/guide/13-testing.md` — repoint the superseded
  `spec/007-Stories.md#play-functions` cross-link (flagged by the cookbook
  bead) to the normative `tools/story/spec/017-Testing-Story.md`; fix the
  stale `:play` wording to the public `:script` slot.
- `docs/story/api/play-script.md` — add a P1-vocabulary note: the shipping
  `:events` / `:play-script` slots are a clean pre-alpha rename to
  `:setup` / `:script`. The recorder still emits the shipping form, so the
  page's EDN stays exact for today's tool; the note points at 017 + the
  cookbook rather than rewriting shipping-accurate code blocks.
- `docs/story/index.md` — list chapter 8 (Testing cookbook) in the chapter
  index (it was in the mkdocs nav but absent from the index) and add an
  authoring-vocabulary note covering the rename + the shipping-spelling
  tutorials below it.

**CI policy (documentation/spec only):**
- `TESTING.md` — replace the "Forthcoming" section with the completed
  Story-as-test CI policy: the headless plan gate as the per-PR default,
  the **already-in-place** fast-vs-browser-tier split (the
  `story-xray-browser` PR-smoke vs the `expensive-tests.yml` nightly
  sweep), the per-gate **`:cannot-run` policy (MUST)**, and **failed-run
  artifact** emission/upload.
- `tools/story/spec/017-Testing-Story.md` — add a "Failed-run artifacts in
  CI" subsection to §CI policy: a failed plan run MAY emit its
  `:rf.test/run-artifact` for off-CI replay; wiring an upload step into a
  workflow gate is a CI-mechanics decision, not part of the spec.

## Acceptance criteria

- **Docs match public vocabulary** — guide cross-link repointed + `:play`
  → `:script`; play-script API doc + Story index carry the `:setup` /
  `:script` rename note pointing at 017 and the cookbook.
- **Explicit `:cannot-run` policy** — TESTING.md states it as a per-gate
  MUST with the three options; 017 §CI policy is the normative authority.
- **Fast and browser gates separated** — documented as already in place
  (PR-smoke vs nightly-full); no re-engineering.
- **Failed plan runs can emit artifacts** — documented in both TESTING.md
  and 017 §CI policy.

## `.github/workflows/*` change

**None.** The fast-vs-browser separation already exists and all existing
gates pass; per the bead's hot-zone guard I made no additive workflow edit
because the two candidate items are operator CI-mechanics decisions, not
clear-cut safe additions:

- a *dedicated* browser-tier gate that selects variants by their
  `:required-runner` capability set (`:pixels` / `:a11y-engine`) — 017
  §Browser-tier gate policy explicitly scopes this workflow wiring out of
  the spec;
- a failed-run `upload-artifact` step on a specific gate.

Both are flagged as **CI-mechanics follow-ons for the operator** rather
than risking an unreviewed hot-zone workflow change. The policy they would
implement is now documented.

## Quality gates

- `python -m mkdocs build --strict` — **PASS** (exit 0; mkdocs not on PATH
  as a binary locally, run via the installed Python module 1.6.1; all new
  links/anchors resolve).
- `python scripts/check_doc_slugs.py` — **PASS** (exit 0).
- `python scripts/check_readme_links.py --ci` — **PASS** (exit 0).
- `scripts/test-fast-pr.sh --with-docs` spine: lockstep drift, skill/MCP
  drift, **core JVM (795 tests, 3516 assertions, 0 failures/errors)**, JS
  harness helpers — all **PASS**. The final `test:cljs` step failed only
  with `'shadow-cljs' is not recognized` — environmental (fresh worktree
  with no `npm install`), not a test failure, and unreachable by a
  markdown-only change; CI runs it.
- `git diff --check` — clean.

Disjoint by construction from the concurrent test-fixture worker
(rf2-gc7la): this PR touches only docs + spec markdown, no test files, no
workflows.
