### PR TITLE
feat(story): reactive recompute/render-count probe — project from the tape (rf2-5x1wt.30)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -31,7 +31,7 @@ a long-lived compatibility layer.**
 
 Where a rule changes shipping behaviour this document says so explicitly
 (§Shipping vs target). A reader must never assume a hook that does not
-yet exist (e.g. schema-fail wiring, a reactive recompute probe).
+yet exist (e.g. browser-tier pixel diffing).
 
 ## Shipping vs target (grounding delta)
 
@@ -51,7 +51,7 @@ code migration is not confused with greenfield design.
 | run-result key | SHIPS as `:lifecycle` | This document's top-level `:status` is **NET-NEW** (§Run result); the runtime's record-result map uses `:lifecycle` today. |
 | `:skipped?` on no-DOM assertion records | SHIPS | This IS the `:cannot-run` case at assertion granularity — reconcile, do not duplicate (§`:cannot-run`). |
 | `:rf.assert/schema-error` + schema-fail-the-run | NET-NEW | Today schema violations are trace events feeding a UI panel with **no fail mechanism** — must be wired (§Schema rule). |
-| reactive recompute / render-count probe | NET-NEW (no seam) | `compute-sub` bypasses the cache; counts live only in test files — a probe must be lifted into instrumentation first. |
+| reactive recompute / render-count probe | SHIPS as a PROJECTION (rf2-5x1wt.30) | Spec 009 already emits one `:rf.sub/run` per true sub recompute and one `:rf.view/rendered` per view render, both retained in the epoch tape. The probe is `re-frame.story.play.evidence/reactive-counts` — a pure projection over those rows, NOT a new core seam — surfaced as the `:reactive-counts` run-result slot and advertised by the `:cljs-reactive` runner. |
 | `:sub-overrides` for view-state variants | NET-NEW | Explicit lower-fidelity rendering affordance (§View-state subscription overrides); not proof of real subscription logic. |
 | view arg schema consumption | SHIPS partially / P1 hardens | Controls already derive from view schemas; P1 copies the view props schema into the plan and validates `:effective-args` before render (§View arg schemas). |
 | `variant-plan`, `explain`, `reg-fragment` / `reg-check`, runner abstraction, inline plans, run-artifacts, `canonicalize` / fingerprinting, narrative projection, `render-variant` | NET-NEW | This document. |
@@ -1184,9 +1184,13 @@ remains the base. P1 SHOULD include or retain:
   accessibility check; runs on the rendered hiccup tree without a real
   browser, §Visual, a11y, and browser checks)
 
-Future assertion candidates after instrumentation support include
-`:rf.assert/caused` and `:rf.assert/no-cascade-rerender`; both require a
-reactive/render-count probe and are not P1 unless that probe lands first.
+`:rf.assert/caused` and `:rf.assert/no-cascade-rerender` both require the
+reactive/render-count probe. That probe SHIPS (rf2-5x1wt.30) as the
+`re-frame.story.play.evidence/reactive-counts` PROJECTION over the
+`:rf.sub/run` / `:rf.view/rendered` rows the epoch tape already retains —
+not a new core seam — so these assertions run under the `:cljs-reactive`
+runner (and `:cannot-run` under `:headless` / `:hiccup`, which do not
+flush reactions).
 
 There is no `:rf.assert/no-schema-errors` author surface — schema-clean
 is the knob-free floor (§Schema rule), so the only schema author surface
@@ -1298,9 +1302,14 @@ requires; a runner is **valid** iff its token set is a superset;
 **cheapest** = first in a small cost-ordered concrete-runner list whose
 set qualifies.
 
-P1 selects only among tiers with **real seams**
-(`:headless` / `:hiccup` / `:dom` / `:browser`). `:reactive-counts`
-requires a NET-NEW recompute probe lifted into instrumentation first.
+P1 selects among the tiers with **real seams**
+(`:headless` / `:hiccup` / `:cljs-reactive` / `:dom` / `:browser`).
+`:reactive-counts` is proven by `:cljs-reactive` via the
+`re-frame.story.play.evidence/reactive-counts` projection over the
+`:rf.sub/run` / `:rf.view/rendered` rows the epoch tape already retains
+(rf2-5x1wt.30) — a projection, not a NET-NEW core seam. `:cljs-reactive`
+sits between `:hiccup` and `:dom` on the cost ladder (it flushes
+reactions; it does not drive synthetic DOM events).
 
 MCP is not a runner tier. It is a transport/control surface over the same
 `story/run` and `story/explain` APIs. A live agent run differs by frame
@@ -1382,19 +1391,25 @@ plus its own orthogonal additions:
 |---|---|
 | `:headless` | `:app-db :effects :schema :trace :pure-subs` |
 | `:hiccup` | headless ∪ `:hiccup-structure` |
-| `:dom` | hiccup ∪ `:dom` |
+| `:cljs-reactive` | hiccup ∪ `:reactive-counts` |
+| `:dom` | cljs-reactive ∪ `:dom` |
 | `:browser` | dom ∪ `:pixels :a11y-engine` |
 
-`:cljs-reactive` is deliberately ABSENT from the cost-ordered selection
-list: its only distinguishing token, `:reactive-counts`, has NO real seam
-in P1 (it is gated on a NET-NEW recompute probe lifted into
-instrumentation — §1a). The token is in the vocabulary but NO concrete
-runner advertises it, so any requirement on it resolves to `:cannot-run`
-until the probe lands. That deferral is expressed as data, not a special
-case: the token exists, no runner provides it, the set-difference is
-non-empty. A runner is **valid** for a set of required tokens iff its
-token set is a superset; **cheapest** is the first runner on the
-cost-ordered list whose set qualifies.
+`:cljs-reactive` sits between `:hiccup` and `:dom` on the cost-ordered
+selection list (rf2-5x1wt.30): its distinguishing token,
+`:reactive-counts`, has a real seam — the
+`re-frame.story.play.evidence/reactive-counts` PROJECTION over the
+`:rf.sub/run` / `:rf.view/rendered` rows the epoch tape already retains
+(§1a; a projection, not a NET-NEW core seam). It flushes reactions (so
+subs deref and views render, landing those rows) but stops short of
+synthetic DOM events. A requirement on `:reactive-counts` resolves to
+`:cljs-reactive` under `:auto`, and to `:cannot-run` under a fixed
+`:headless` / `:hiccup` runner (which do not flush reactions). A runner is
+**valid** for a set of required tokens iff its token set is a superset;
+**cheapest** is the first runner on the cost-ordered list whose set
+qualifies. The post-run fail-closed slot check still refuses a
+`:cljs-reactive` run whose tape produced no reactive rows — the projection
+being available does not weaken the floor.
 
 ### Requirement inference
 
@@ -1413,8 +1428,10 @@ tokens it requires:
   `:rf.assert/schema-error` requires `:schema`; the DOM family requires
   `:dom`; `:rf.assert/visual-snapshot` requires `:pixels` and
   `:rf.assert/a11y` requires `:a11y-engine`; the reactive-count
-  candidates `:rf.assert/caused` / `:rf.assert/no-cascade-rerender`
-  require `:reactive-counts` (so they fail closed until the probe seam).
+  assertions `:rf.assert/caused` / `:rf.assert/no-cascade-rerender`
+  require `:reactive-counts` (proven by `:cljs-reactive` via the
+  `evidence/reactive-counts` projection; `:cannot-run` under
+  `:headless` / `:hiccup`).
 
 A plan's `:required-runner` slot is the UNION of every setup-step,
 script-step, and terminal-assertion token set — capability tokens, NOT a
@@ -1448,7 +1465,8 @@ The two policies (§Runner policy):
   :runner-lacks-capability`.
 - AUTO / ESCALATE (`{:runner :auto}` / `{:escalate true}`): choose the
   CHEAPEST concrete runner whose token set satisfies ALL selected
-  requirements. When none can (a `:reactive-counts` requirement), the
+  requirements (a `:reactive-counts` requirement escalates to
+  `:cljs-reactive`). When NO concrete runner can satisfy the union, the
   whole run is `:cannot-run` with `:reason :no-runner-satisfies`.
 
 The variant-level **aggregation rule** is stated once: a variant whose
@@ -1470,8 +1488,10 @@ A proof is honoured only when BOTH sides agree it is available:
 
 The token→slot map: `:effects → :effects`, `:schema → :schema-violations`,
 `:trace → :warnings`, `:hiccup-structure`/`:dom` → `:renders`,
-`:reactive-counts → :reactive-counts` (NET-NEW, never present in P1),
-`:pixels`/`:a11y-engine` → browser-only slots. A token with NO distinct
+`:reactive-counts → :reactive-counts` (present only when the tape carried
+`:rf.sub/run` / `:rf.view/rendered` rows — a `:cljs-reactive` run whose
+tape carried none refuses, fail-closed), `:pixels`/`:a11y-engine` →
+browser-only slots. A token with NO distinct
 slot (`:app-db`) imposes no post-run check — its proof is the final db
 itself, validated by the assertion's own evaluation. Because the check
 reads the SAME `project-evidence` projection the run-result slots derive
@@ -1607,6 +1627,7 @@ warnings/effects is superseded by this projection).
 | `:warnings` | each epoch's `:trace-events` | every `:op-type :warn` trace event, in tape order |
 | `:effects` | each epoch's `:effects` row | the rows the framework already projected at settle time (`re-frame.epoch.capture/project-all`), concatenated in dispatch order, each stamped with its `:epoch-id` |
 | `:sub-runs` / `:renders` | each epoch's `:sub-runs` / `:renders` rows | concatenated in tape order, each stamped with `:epoch-id` |
+| `:reactive-counts` | the `:sub-runs` / `:renders` rows above | recompute / render counts (rf2-5x1wt.30) — `{:sub-recomputes :view-renders :by-sub-id :by-view :by-render-key :by-cause :per-epoch}`; PRESENT only when the tape carried at least one reactive row (a bare headless dispatch-only tape omits it, so the fail-closed slot check is honest). `:by-cause` credits each row to the dispatching event's `:rf.sub/cause-event-id` / `:rf.view/cause-event-id` attribution |
 | `:narrative` | the script steps over the epoch beats | the two-level projection below |
 
 **Two-level narrative.** The author's `:script` steps form the outer spans;

--- a/tools/story/src/re_frame/story/play/evidence.cljc
+++ b/tools/story/src/re_frame/story/play/evidence.cljc
@@ -271,6 +271,119 @@
         epoch-tape))
 
 ;; ===========================================================================
+;; REACTIVE-COUNTS PROJECTION  (spec/017 §1a / §Runner kinds — the recompute probe)
+;; ===========================================================================
+;;
+;; The reactive recompute / over-render probe is a PROJECTION over the
+;; SAME `:sub-runs` / `:renders` rows the framework already projects at
+;; settle time (`re-frame.epoch.capture/project-all`), NOT a new core
+;; instrumentation seam. Spec 009 already emits one `:rf.sub/run` per TRUE
+;; sub recompute (the memo wrapper's input value was NOT `=` to last-seen)
+;; and one `:rf.view/rendered` per view render, both carried into the
+;; epoch tape; this projection just COUNTS them, keyed by the surfaces a
+;; reactive-count assertion (`:rf.assert/caused` / `:rf.assert/no-cascade-rerender`)
+;; reasons about: per sub-id, per view (render-key / view-id), per epoch,
+;; and per cause-event.
+;;
+;; Because it reads only the already-projected rows, the whole projection
+;; is pure and JVM-testable — the SAME boundary the other evidence slots
+;; cross. A run only PRODUCES sub-run / render rows when the reactive
+;; substrate is actually exercised (a sub deref'd in a reactive context, a
+;; view mounted) — the `:cljs-reactive` runner's reaction-flush boundary
+;; (`settled-boundary`). A bare headless dispatch-only tape carries no such
+;; rows, so the slot is empty and a reactive-count assertion FAILS CLOSED
+;; (`requirements/validate-evidence`), exactly as the fail-closed contract
+;; demands — the probe being a projection does not weaken that floor.
+
+(defn- render-view-id
+  "The registered view-id half of a render row's `:render-key`
+  `[view-id instance-token]` tuple, or the whole row's explicit `:view-id`
+  when a host stamped one. Pure data → data; `nil` for an unkeyed row."
+  [{:keys [render-key view-id] :as _render-row}]
+  (or view-id
+      (when (and (vector? render-key) (pos? (count render-key)))
+        (first render-key))))
+
+(defn- count-by
+  "Count `rows` grouped by `key-fn`, dropping `nil` keys. Returns a map
+  `{key count}`. Pure data → data."
+  [key-fn rows]
+  (reduce (fn [acc row]
+            (let [k (key-fn row)]
+              (cond-> acc (some? k) (update k (fnil inc 0)))))
+          {}
+          rows))
+
+(defn reactive-counts
+  "Project the reactive recompute / render counts over `epoch-tape` —
+  the `:reactive-counts` evidence slot (spec/017 §1a, §Runner kinds —
+  `:cljs-reactive` proves recompute count / render cause / over-render
+  checks). Pure data → data; reads ONLY the already-projected
+  `:sub-runs` / `:renders` rows (`sub-runs` / `renders` above), so it is
+  the same one-tape projection — never a parallel accumulator.
+
+  Returns nil when the tape carries NEITHER a sub-recompute NOR a
+  view-render row (a bare headless dispatch-only run never exercised the
+  reactive substrate). A nil slot keeps the post-run fail-closed check
+  (`requirements/evidence-slot-satisfied?`) honest: a reactive-count
+  assertion against a tape with no reactive rows resolves `:cannot-run`,
+  never a silent pass. When the tape DOES carry reactive rows it returns:
+
+      {:sub-recomputes <int>          ; total :rf.sub/run rows (true recomputes)
+       :view-renders   <int>          ; total :rf.view/rendered rows
+       :by-sub-id      {sub-id count} ; recomputes keyed by sub query-id
+       :by-view        {view-id count}; renders keyed by registered view-id
+       :by-render-key  {render-key count} ; renders keyed by the full instance tuple
+       :by-cause       {event-id {:sub-recomputes <int> :view-renders <int>}}
+                                      ; recomputes / renders attributed to the
+                                      ; dispatching cascade's event-id (the
+                                      ; :rf.sub/cause-event-id / :rf.view/cause-event-id
+                                      ; attribution Spec 009 already stamps)
+       :per-epoch      [{:epoch-id <id>
+                         :sub-recomputes <int>
+                         :view-renders   <int>} …]}  ; one entry per epoch
+                                      ; that committed a reactive row, tape order
+
+  `:sub-recomputes` is the count of TRUE recomputes — `:rf.sub/run` rows
+  are emitted only on the cache-miss branch (memo-hit `:rf.sub/skip` rows
+  are NOT projected into `:sub-runs`), so this is the over-recompute
+  signal `:rf.assert/no-cascade-rerender` reads directly. `:by-cause`
+  credits each reactive row to the event that invalidated its reactive
+  input — the cause→effect attribution `:rf.assert/caused` reasons over."
+  [epoch-tape]
+  (let [sub-rows    (sub-runs epoch-tape)
+        render-rows (renders epoch-tape)]
+    (when (or (seq sub-rows) (seq render-rows))
+      (let [by-cause
+            (reduce
+              (fn [acc [k sub-delta render-delta]]
+                (cond-> acc
+                  (some? k)
+                  (update k (fn [{:keys [sub-recomputes view-renders]
+                                  :or   {sub-recomputes 0 view-renders 0}}]
+                              {:sub-recomputes (+ sub-recomputes sub-delta)
+                               :view-renders   (+ view-renders render-delta)}))))
+              {}
+              (concat (map (fn [r] [(:cause-event-id r) 1 0]) sub-rows)
+                      (map (fn [r] [(:cause-event-id r) 0 1]) render-rows)))
+            per-epoch
+            (->> (concat sub-rows render-rows)
+                 (map :epoch-id)
+                 distinct
+                 (keep identity)
+                 (mapv (fn [eid]
+                         {:epoch-id       eid
+                          :sub-recomputes (count (filter #(= eid (:epoch-id %)) sub-rows))
+                          :view-renders   (count (filter #(= eid (:epoch-id %)) render-rows))})))]
+        {:sub-recomputes (count sub-rows)
+         :view-renders   (count render-rows)
+         :by-sub-id      (count-by :sub-id sub-rows)
+         :by-view        (count-by render-view-id render-rows)
+         :by-render-key  (count-by :render-key render-rows)
+         :by-cause       by-cause
+         :per-epoch      per-epoch}))))
+
+;; ===========================================================================
 ;; TWO-LEVEL NARRATIVE PROJECTION  (spec/017 §Run result, §Epoch tape and narrative)
 ;; ===========================================================================
 ;;
@@ -607,21 +720,35 @@
        :effects           [effect-row …]      ; per-epoch :effects, concatenated
        :sub-runs          [sub-run-row …]     ; per-epoch :sub-runs, concatenated
        :renders           [render-row …]      ; per-epoch :renders, concatenated
+       :reactive-counts   {…}                 ; recompute/render counts (§1a) —
+                                              ;   PRESENT only when the tape
+                                              ;   carries reactive rows; omitted
+                                              ;   for a bare headless tape so the
+                                              ;   fail-closed slot check is honest
        :narrative         [span …]}           ; two-level script×epoch projection
 
   Every slot agrees with the tape by construction — there is no second
   capture path. `tape-shows-failure?` reads the same projection, so a run
-  cannot report green while the tape is red."
+  cannot report green while the tape is red.
+
+  The `:reactive-counts` slot is threaded `cond->` so it is ABSENT (not a
+  zero-count stub) for a tape with no reactive rows — the
+  `:reactive-counts → :reactive-counts` token→slot fail-closed check
+  (`requirements/evidence-slot-satisfied?`) keys on slot PRESENCE, so an
+  absent slot correctly refuses a reactive-count assertion the run never
+  exercised."
   ([epoch-tape] (project-evidence epoch-tape nil))
   ([epoch-tape {:keys [script] :as _opts}]
-   (let [tape (vec (or epoch-tape []))]
-     {:epoch-tape        tape
-      :schema-violations (schema-violations tape)
-      :warnings          (warnings tape)
-      :effects           (effects tape)
-      :sub-runs          (sub-runs tape)
-      :renders           (renders tape)
-      :narrative         (narrative script tape)})))
+   (let [tape (vec (or epoch-tape []))
+         rc   (reactive-counts tape)]
+     (cond-> {:epoch-tape        tape
+              :schema-violations (schema-violations tape)
+              :warnings          (warnings tape)
+              :effects           (effects tape)
+              :sub-runs          (sub-runs tape)
+              :renders           (renders tape)
+              :narrative         (narrative script tape)}
+       (some? rc) (assoc :reactive-counts rc)))))
 
 ;; ===========================================================================
 ;; DIAGNOSTICS

--- a/tools/story/src/re_frame/story/requirements.cljc
+++ b/tools/story/src/re_frame/story/requirements.cljc
@@ -23,24 +23,31 @@
   ## The capability tokens
 
   Each token names one proof surface. `capability-tokens` is the closed
-  P1 set. A token with NO real seam yet (`:reactive-counts`, gated on a
-  NET-NEW recompute probe lifted into instrumentation — spec/017 §1a) is
-  in the vocabulary but advertised by NO concrete runner, so any
-  requirement on it resolves to `:cannot-run` until the seam lands. That
-  is the fail-closed contract, expressed as data: the token exists, no
-  runner provides it, so the set-difference is non-empty.
+  P1 set. `:reactive-counts` is the reactive recompute / over-render count
+  surface (spec/017 §1a, §Runner kinds): once it was deferred pending a
+  NET-NEW instrumentation seam, but Spec 009 ALREADY emits the underlying
+  signals — one `:rf.sub/run` per true sub recompute and one
+  `:rf.view/rendered` per view render, both carried into the epoch tape
+  and projected at settle time (`re-frame.epoch.capture/project-all`). The
+  probe is therefore a PROJECTION over those rows
+  (`re-frame.story.play.evidence/reactive-counts`), NOT a new core seam,
+  and the `:cljs-reactive` runner — which flushes reactions so subs deref
+  and views render (the `settled-boundary` reaction-flush boundary) —
+  advertises it. A runner that does NOT exercise the reactive substrate
+  still refuses `:cannot-run`, and the post-run fail-closed slot check
+  catches a `:cljs-reactive` run whose tape carried no reactive rows.
 
   ## Cost-ordered concrete runners
 
   `concrete-runners` is the small cost-ordered list of runners P1 can
-  actually select among (cheapest first). `:cljs-reactive` is NOT in the
-  list — it has no real seam in P1 (its only distinguishing token,
-  `:reactive-counts`, awaits the probe), so selecting it is never the
-  cheapest satisfying choice; it is named in the kinds table for
-  completeness but is not a P1 selection target. `cheapest-runner` walks
-  this list and returns the first whose token set is a superset of the
-  required tokens — exactly the spec's \"cheapest = first in a small
-  cost-ordered concrete-runner list whose set qualifies\".
+  actually select among (cheapest first). `:cljs-reactive` IS in the list
+  now that `:reactive-counts` has a real seam (the tape projection above):
+  it sits between `:hiccup` and `:dom` on the cost ladder — it flushes
+  reactions (richer than a pure hiccup render-to-string) but stops short
+  of synthetic DOM events / a real browser. `cheapest-runner` walks this
+  list and returns the first whose token set is a superset of the required
+  tokens — exactly the spec's \"cheapest = first in a small cost-ordered
+  concrete-runner list whose set qualifies\".
 
   ## MCP is a binding, not a tier
 
@@ -86,27 +93,31 @@
 
 (def capability-tokens
   "The closed P1 set of capability tokens. A token names one proof surface
-  a runner either can or cannot produce. `:reactive-counts` is in the
-  vocabulary but has NO real seam in P1 (it awaits a recompute probe lifted
-  into instrumentation — spec/017 §1a); no concrete runner advertises it,
-  so any requirement on it fails closed to `:cannot-run`."
+  a runner either can or cannot produce. `:reactive-counts` is the reactive
+  recompute / over-render count surface (spec/017 §1a); it has a real seam
+  — the `re-frame.story.play.evidence/reactive-counts` projection over the
+  `:rf.sub/run` / `:rf.view/rendered` rows Spec 009 already lands in the
+  tape — and is advertised by the `:cljs-reactive` runner."
   #{:app-db          ; final app-db / event / cofx state — the headless floor
     :effects         ; emitted effect rows
     :schema          ; schema-validation-failure trace evidence
     :trace           ; trace-event stream (warnings, dispatched, caused, …)
     :pure-subs       ; compute-sub against the snapshot (no reactive cache)
     :hiccup-structure ; render-to-string / hiccup tree + text + handler wiring
-    :reactive-counts ; reactive recompute / over-render counts — NET-NEW seam
+    :reactive-counts ; reactive recompute / over-render counts (:cljs-reactive)
     :dom             ; DOM events, focus, visibility, browser APIs
     :pixels          ; real-browser layout / screenshots / pixel diffs
     :a11y-engine})   ; axe-style accessibility engine
 
 (def reactive-counts-token
-  "The token gated on the NET-NEW recompute probe (spec/017 §1a). No P1
-  concrete runner advertises it; a requirement on it resolves to
-  `:cannot-run` until the probe seam lands. Named so the deferral is
-  explicit at the call site and the future probe bead has one place to
-  flip."
+  "The reactive recompute / over-render count token (spec/017 §1a). The
+  `:cljs-reactive` runner advertises it — its proof is the
+  `re-frame.story.play.evidence/reactive-counts` projection over the
+  `:rf.sub/run` / `:rf.view/rendered` rows the framework already retains in
+  the epoch tape. A runner that does not flush reactions cannot prove it,
+  so a requirement on it resolves to `:cannot-run` under those runners.
+  Named so the call site reads explicitly and the projection has one place
+  to anchor."
   :reactive-counts)
 
 ;; ===========================================================================
@@ -115,8 +126,9 @@
 ;;
 ;; Cheapest first. Each runner advertises the token SET it can prove. A
 ;; richer runner is a SUPERSET of every cheaper one for the tokens that ARE
-;; ordered (app-db ⊂ hiccup ⊂ dom ⊂ browser), and adds its own orthogonal
-;; tokens. `:reactive-counts` is in NO runner's set — its seam is NET-NEW.
+;; ordered (app-db ⊂ hiccup ⊂ cljs-reactive ⊂ dom ⊂ browser), and adds its
+;; own orthogonal tokens. `:reactive-counts` enters at the `:cljs-reactive`
+;; rung (reaction flush) and rides up through `:dom` / `:browser`.
 
 (def headless-tokens
   "What `:headless` proves: app-db / events / effects / schema / trace /
@@ -128,10 +140,23 @@
   handler wiring / render-to-string facts."
   (into headless-tokens #{:hiccup-structure}))
 
+(def cljs-reactive-tokens
+  "`:cljs-reactive` proves the hiccup set AND `:reactive-counts` — the
+  reactive recompute / over-render count surface (spec/017 §Runner kinds —
+  \"reactive subscription cache, recompute count, render cause, over-render
+  checks\"). It flushes reactions (the `settled-boundary`
+  reaction-flush boundary) so subs deref and views render, landing the
+  `:rf.sub/run` / `:rf.view/rendered` rows the
+  `re-frame.story.play.evidence/reactive-counts` projection counts. It does
+  NOT add `:dom` — synthetic DOM events / focus / visibility need the
+  richer `:dom` rung."
+  (into hiccup-tokens #{:reactive-counts}))
+
 (def dom-tokens
-  "`:dom` proves the hiccup set AND DOM events / focus / visibility /
+  "`:dom` proves the cljs-reactive set (incl. `:reactive-counts` — a DOM
+  runner flushes reactions too) AND DOM events / focus / visibility /
   browser APIs."
-  (into hiccup-tokens #{:dom}))
+  (into cljs-reactive-tokens #{:dom}))
 
 (def browser-tokens
   "`:browser` proves the dom set AND real-browser layout / screenshots /
@@ -145,24 +170,27 @@
   \"cheapest = first in a small cost-ordered concrete-runner list whose set
   qualifies\").
 
-  `:cljs-reactive` is deliberately ABSENT: its only distinguishing token
-  (`:reactive-counts`) has no real seam in P1, so it is never the cheapest
-  satisfying choice for any realisable requirement. It is named in the
-  spec/017 kinds table for completeness; it is not a P1 selection target."
-  [{:runner :headless :provides headless-tokens}
-   {:runner :hiccup   :provides hiccup-tokens}
-   {:runner :dom      :provides dom-tokens}
-   {:runner :browser  :provides browser-tokens}])
+  `:cljs-reactive` sits between `:hiccup` and `:dom`: its distinguishing
+  token `:reactive-counts` now has a real seam (the
+  `re-frame.story.play.evidence/reactive-counts` projection over the
+  `:rf.sub/run` / `:rf.view/rendered` rows the framework retains), so it is
+  the cheapest runner that can prove a reactive-count requirement
+  (`:rf.assert/caused` / `:rf.assert/no-cascade-rerender`)."
+  [{:runner :headless      :provides headless-tokens}
+   {:runner :hiccup        :provides hiccup-tokens}
+   {:runner :cljs-reactive :provides cljs-reactive-tokens}
+   {:runner :dom           :provides dom-tokens}
+   {:runner :browser       :provides browser-tokens}])
 
 (def runner-kinds
-  "All runner KIND keywords spec/017 §Runner kinds names, incl. the
-  not-P1-selectable `:cljs-reactive`. `:auto` is the SELECTION mode (not a
-  kind) — handled by `normalize-run-opts`, not present here."
+  "All runner KIND keywords spec/017 §Runner kinds names. `:auto` is the
+  SELECTION mode (not a kind) — handled by `normalize-run-opts`, not present
+  here."
   #{:headless :hiccup :cljs-reactive :dom :browser})
 
 (defn- runner-descriptor
   "The concrete-runner descriptor for `runner-kind`, or nil when the kind
-  is not a P1 selection target (e.g. `:cljs-reactive`)."
+  is not a recognised concrete runner."
   [runner-kind]
   (some (fn [d] (when (= runner-kind (:runner d)) d)) concrete-runners))
 
@@ -217,8 +245,13 @@
   assertion reads the schema-violation projection; the DOM family needs
   `:dom`; visual/a11y need browser-tier tokens. The reactive-count
   assertions (`:rf.assert/caused` / `:rf.assert/no-cascade-rerender`)
-  require `:reactive-counts` — a NET-NEW seam (spec/017 §1a), so they fail
-  closed to `:cannot-run` until the recompute probe lands.
+  require `:reactive-counts` — now a real seam (the
+  `re-frame.story.play.evidence/reactive-counts` projection over the
+  `:rf.sub/run` / `:rf.view/rendered` rows the framework retains), proven
+  by the `:cljs-reactive` runner. Under a runner that does not flush
+  reactions (`:headless` / `:hiccup`) they still resolve to `:cannot-run`,
+  and the post-run fail-closed slot check refuses a `:cljs-reactive` run
+  whose tape carried no reactive rows.
 
   ## Browser-tier oracles (spec/017 §Visual, a11y, and browser checks)
 
@@ -261,8 +294,10 @@
    ;; no real browser / axe engine is needed (spec/017 §Visual, a11y, and
    ;; browser checks — \"structural a11y checks MAY require only `:hiccup`\").
    :rf.assert/a11y-structural      #{:hiccup-structure}
-   ;; NET-NEW — gated on the recompute probe; no P1 runner provides
-   ;; `:reactive-counts`, so these resolve to `:cannot-run` (spec/017 §1a).
+   ;; Reactive-count assertions require `:reactive-counts` — proven by the
+   ;; `:cljs-reactive` runner via the `evidence/reactive-counts` projection
+   ;; (spec/017 §1a). Under `:headless` / `:hiccup` they resolve to
+   ;; `:cannot-run`; `:auto` escalates to `:cljs-reactive`.
    :rf.assert/caused               #{:reactive-counts}
    :rf.assert/no-cascade-rerender  #{:reactive-counts}})
 
@@ -527,7 +562,7 @@
   {:effects          [:effects]
    :schema           [:schema-violations]
    :trace            [:warnings]          ; trace-derived projection in evidence
-   :reactive-counts  [:reactive-counts]   ; NET-NEW slot — never present in P1
+   :reactive-counts  [:reactive-counts]   ; present only when the tape carried reactive rows
    :pixels           [:pixels]            ; browser-only slot — never present headless
    :a11y-engine      [:a11y]              ; browser-only slot
    :hiccup-structure [:renders]
@@ -661,7 +696,7 @@
          plat  (if (contains? platforms platform) platform default-platform)]
      (if auto?
        {:mode :auto :frame-binding fb :platform plat}
-       (let [r (if (contains? (disj runner-kinds :cljs-reactive) runner)
+       (let [r (if (contains? runner-kinds runner)
                  runner
                  default-runner)]
          {:mode :fixed :runner r :frame-binding fb :platform plat})))))

--- a/tools/story/test/re_frame/story/play/evidence_test.cljc
+++ b/tools/story/test/re_frame/story/play/evidence_test.cljc
@@ -132,6 +132,82 @@
       (is (= [1] (mapv :epoch-id (:renders ev)))))))
 
 ;; ===========================================================================
+;; REACTIVE-COUNTS PROJECTION  (rf2-5x1wt.30, spec/017 §1a / §Runner kinds)
+;; ===========================================================================
+
+(deftest reactive-counts-nil-for-bare-headless-tape
+  (testing "a tape with no sub-run / render rows projects no :reactive-counts slot"
+    ;; A bare headless dispatch-only run never exercised the reactive
+    ;; substrate — the slot is ABSENT so the fail-closed check refuses a
+    ;; reactive-count assertion.
+    (let [tape [(epoch 1 {:effects [{:fx-id :db :outcome :ok}]})]]
+      (is (nil? (evidence/reactive-counts tape)))
+      (is (not (contains? (evidence/project-evidence tape) :reactive-counts))
+          "no reactive rows → :reactive-counts slot omitted, not a zero stub"))))
+
+(deftest reactive-counts-counts-recomputes-and-renders-from-the-tape
+  (testing "a known dispatch's sub-run + render rows count exactly from the tape"
+    ;; One epoch: two TRUE sub recomputes (two distinct subs) and two view
+    ;; renders, all credited to the dispatching event.
+    (let [tape [(epoch 1 {:trigger-event [:counter/inc]
+                          :sub-runs [{:sub-id :total  :recomputed? true
+                                      :cause-event-id :counter/inc}
+                                     {:sub-id :parity :recomputed? true
+                                      :cause-event-id :counter/inc}]
+                          :renders  [{:render-key [:counter 0] :cause-event-id :counter/inc}
+                                     {:render-key [:badge 0]   :cause-event-id :counter/inc}]})]
+          rc   (evidence/reactive-counts tape)]
+      (is (= 2 (:sub-recomputes rc)) "two :rf.sub/run rows → two recomputes")
+      (is (= 2 (:view-renders rc))   "two :rf.view/rendered rows → two renders")
+      (is (= {:total 1 :parity 1} (:by-sub-id rc)))
+      (is (= {:counter 1 :badge 1} (:by-view rc)) "keyed by registered view-id")
+      (is (= {[:counter 0] 1 [:badge 0] 1} (:by-render-key rc)))
+      ;; both recomputes + both renders credited to the dispatching event.
+      (is (= {:counter/inc {:sub-recomputes 2 :view-renders 2}} (:by-cause rc)))
+      (is (= [{:epoch-id 1 :sub-recomputes 2 :view-renders 2}] (:per-epoch rc))))))
+
+(deftest reactive-counts-aggregate-across-epochs-and-causes
+  (testing "recomputes / renders aggregate across a multi-epoch cascade, keyed by cause"
+    (let [tape [(epoch 1 {:sub-runs [{:sub-id :total :recomputed? true
+                                      :cause-event-id :a}]
+                          :renders  [{:render-key [:v 0] :cause-event-id :a}]})
+                (epoch 2 {:sub-runs [{:sub-id :total :recomputed? true
+                                      :cause-event-id :b}
+                                     {:sub-id :total :recomputed? true
+                                      :cause-event-id :b}]
+                          :renders  [{:render-key [:v 0] :cause-event-id :b}]})]
+          rc   (evidence/reactive-counts tape)]
+      (is (= 3 (:sub-recomputes rc)) "1 + 2 across the two epochs")
+      (is (= 2 (:view-renders rc))   "1 + 1")
+      (is (= {:total 3} (:by-sub-id rc)) "the over-recompute signal: :total recomputed 3×")
+      (is (= {:v 2} (:by-view rc)) "view :v rendered once per epoch → 2 across the cascade")
+      (is (= {:a {:sub-recomputes 1 :view-renders 1}
+              :b {:sub-recomputes 2 :view-renders 1}} (:by-cause rc)))
+      (is (= [{:epoch-id 1 :sub-recomputes 1 :view-renders 1}
+              {:epoch-id 2 :sub-recomputes 2 :view-renders 1}]
+             (:per-epoch rc)) "one per-epoch entry per committed reactive epoch, tape order"))))
+
+(deftest reactive-counts-rows-with-no-cause-attribution
+  (testing "a reactive row outside a cascade (no :cause-event-id) is counted but uncredited"
+    (let [tape [(epoch 1 {:sub-runs [{:sub-id :total :recomputed? true}]
+                          :renders  [{:render-key [:v 0]}]})]
+          rc   (evidence/reactive-counts tape)]
+      (is (= 1 (:sub-recomputes rc)))
+      (is (= 1 (:view-renders rc)))
+      (is (= {} (:by-cause rc)) "nil cause-event-id contributes no :by-cause entry")
+      (is (= {:total 1} (:by-sub-id rc)))
+      (is (= {:v 1} (:by-view rc))))))
+
+(deftest reactive-counts-in-project-evidence-when-tape-has-reactive-rows
+  (testing ":reactive-counts rides project-evidence and agrees with the standalone projection"
+    (let [tape [(epoch 1 {:sub-runs [{:sub-id :total :recomputed? true}]
+                          :renders  [{:render-key [:v 0]}]})]
+          ev   (evidence/project-evidence tape {:script [[:dispatch [:counter/inc]]]})]
+      (is (contains? ev :reactive-counts))
+      (is (= (evidence/reactive-counts tape) (:reactive-counts ev))
+          "the slot is the standalone projection — one tape, one projection"))))
+
+;; ===========================================================================
 ;; TWO-LEVEL NARRATIVE
 ;; ===========================================================================
 

--- a/tools/story/test/re_frame/story/requirements_test.cljc
+++ b/tools/story/test/re_frame/story/requirements_test.cljc
@@ -18,29 +18,36 @@
 
 (deftest concrete-runner-token-ladder
   (testing "the cost-ordered runners form a superset chain for ordered tokens"
-    (is (= [:headless :hiccup :dom :browser]
+    (is (= [:headless :hiccup :cljs-reactive :dom :browser]
            (mapv :runner req/concrete-runners))
-        "cheapest → richest, :cljs-reactive deliberately absent (no P1 seam)")
-    ;; headless ⊂ hiccup ⊂ dom ⊂ browser
-    (is (every? (req/runner-provides :hiccup)  (req/runner-provides :headless)))
-    (is (every? (req/runner-provides :dom)     (req/runner-provides :hiccup)))
-    (is (every? (req/runner-provides :browser) (req/runner-provides :dom)))
+        "cheapest → richest; :cljs-reactive sits between :hiccup and :dom (rf2-5x1wt.30)")
+    ;; headless ⊂ hiccup ⊂ cljs-reactive ⊂ dom ⊂ browser
+    (is (every? (req/runner-provides :hiccup)        (req/runner-provides :headless)))
+    (is (every? (req/runner-provides :cljs-reactive) (req/runner-provides :hiccup)))
+    (is (every? (req/runner-provides :dom)           (req/runner-provides :cljs-reactive)))
+    (is (every? (req/runner-provides :browser)       (req/runner-provides :dom)))
     ;; each rung adds its distinguishing token(s)
-    (is (contains? (req/runner-provides :hiccup)  :hiccup-structure))
-    (is (contains? (req/runner-provides :dom)     :dom))
-    (is (contains? (req/runner-provides :browser) :pixels))
-    (is (contains? (req/runner-provides :browser) :a11y-engine)))
+    (is (contains? (req/runner-provides :hiccup)        :hiccup-structure))
+    (is (contains? (req/runner-provides :cljs-reactive) :reactive-counts))
+    (is (contains? (req/runner-provides :dom)           :dom))
+    (is (contains? (req/runner-provides :browser)       :pixels))
+    (is (contains? (req/runner-provides :browser)       :a11y-engine)))
 
-  (testing "no P1 runner advertises the NET-NEW :reactive-counts token"
-    (is (not-any? #(contains? (:provides %) :reactive-counts)
-                  req/concrete-runners))
-    (is (= :reactive-counts req/reactive-counts-token)))
+  (testing ":reactive-counts is advertised by :cljs-reactive (and the richer rungs) — rf2-5x1wt.30"
+    (is (= :reactive-counts req/reactive-counts-token))
+    (is (not (contains? (req/runner-provides :headless) :reactive-counts)))
+    (is (not (contains? (req/runner-provides :hiccup)   :reactive-counts))
+        ":hiccup renders to string but does not flush reactions")
+    (is (contains? (req/runner-provides :cljs-reactive) :reactive-counts))
+    (is (contains? (req/runner-provides :dom)           :reactive-counts)
+        "a :dom runner flushes reactions too")
+    (is (contains? (req/runner-provides :browser)       :reactive-counts)))
 
-  (testing "cost rank is cheapest-first; non-selectable kinds sort last"
-    (is (< (req/runner-cost :headless) (req/runner-cost :hiccup)))
-    (is (< (req/runner-cost :hiccup)   (req/runner-cost :dom)))
-    (is (< (req/runner-cost :dom)      (req/runner-cost :browser)))
-    (is (> (req/runner-cost :cljs-reactive) (req/runner-cost :browser)))))
+  (testing "cost rank is cheapest-first; :cljs-reactive ranks between :hiccup and :dom"
+    (is (< (req/runner-cost :headless)      (req/runner-cost :hiccup)))
+    (is (< (req/runner-cost :hiccup)        (req/runner-cost :cljs-reactive)))
+    (is (< (req/runner-cost :cljs-reactive) (req/runner-cost :dom)))
+    (is (< (req/runner-cost :dom)           (req/runner-cost :browser)))))
 
 ;; ===========================================================================
 ;; REQUIREMENT INFERENCE — per-step and per-assertion tokens
@@ -129,18 +136,26 @@
                    :pixels)
         "a [:assert visual-snapshot] checkpoint requires :pixels")))
 
-(deftest reactive-count-assertions-cannot-run-until-probe
-  (testing "reactive-count assertions require the NET-NEW :reactive-counts seam"
+(deftest reactive-count-assertions-run-under-cljs-reactive
+  (testing "reactive-count assertions require :reactive-counts — proven by :cljs-reactive (rf2-5x1wt.30)"
     (is (= #{:reactive-counts} (req/assertion-tokens [:rf.assert/caused])))
     (is (= #{:reactive-counts}
            (req/assertion-tokens [:rf.assert/no-cascade-rerender])))
-    ;; No concrete P1 runner can satisfy it → cheapest-runner is nil →
-    ;; auto-selection refuses (the whole run is :cannot-run).
-    (is (nil? (req/cheapest-runner #{:reactive-counts})))
-    (let [refusal (req/select-runner #{:reactive-counts} {:mode :auto})]
-      (is (= :cannot-run (:status refusal)))
-      (is (= :no-runner-satisfies (:reason refusal)))
-      (is (contains? (:missing refusal) :reactive-counts)))))
+    ;; :cljs-reactive is now the cheapest runner that satisfies it (the
+    ;; projection over the :rf.sub/run / :rf.view/rendered rows).
+    (is (= :cljs-reactive (req/cheapest-runner #{:reactive-counts})))
+    (let [sel (req/select-runner #{:reactive-counts} {:mode :auto})]
+      (is (= :ok (:status sel)))
+      (is (= :cljs-reactive (:runner sel)))
+      (is (empty? (:unmet sel))))
+    ;; under :headless / :hiccup the reactive-count assertions still refuse.
+    (is (not (req/runner-satisfies? (req/runner-provides :headless) #{:reactive-counts})))
+    (is (not (req/runner-satisfies? (req/runner-provides :hiccup)   #{:reactive-counts})))
+    (let [unmet (req/unmet-assertions :headless [[:rf.assert/caused]
+                                                 [:rf.assert/no-cascade-rerender]])]
+      (is (= 2 (count unmet)))
+      (is (every? #(= :cannot-run (:status %)) unmet))
+      (is (every? #(contains? (:missing %) :reactive-counts) unmet)))))
 
 (deftest required-tokens-unions-the-plan
   (testing "required-tokens unions setup + script + assertion tokens"
@@ -199,8 +214,12 @@
 
 (deftest auto-refuses-when-no-runner-qualifies
   (testing "auto returns :cannot-run when no concrete runner can satisfy"
+    ;; No P1 runner advertises a token outside the closed capability set, so
+    ;; a requirement on an unknown token can never be satisfied — the
+    ;; fail-closed set-difference path (an unknown future proof surface that
+    ;; no runner has implemented yet).
     (let [auto (req/normalize-run-opts {:runner :auto})
-          sel  (req/select-runner #{:app-db :reactive-counts} auto)]
+          sel  (req/select-runner #{:app-db :rf.story/unimplemented-proof} auto)]
       (is (= :cannot-run (:status sel)))
       (is (= :no-runner-satisfies (:reason sel))))))
 
@@ -261,6 +280,32 @@
                                        ev :headless))
           "evidence present → no refusal; the assertion's own verdict stands"))))
 
+(deftest reactive-count-assertion-fails-closed-on-non-reactive-tape
+  (testing "a required :reactive-counts proof fails closed when the tape carried no reactive rows"
+    ;; :cljs-reactive CLAIMS :reactive-counts (preflight), but if the run's
+    ;; tape produced no sub-run / render rows the slot is absent → the
+    ;; post-run check refuses :cannot-run, never a silent pass (rf2-5x1wt.30).
+    (let [ev (evidence/project-evidence [{:epoch-id 1 :outcome :ok
+                                          :effects [{:fx-id :db :outcome :ok}]}])]
+      (is (not (req/evidence-slot-satisfied? #{:reactive-counts} ev))
+          "no reactive rows → :reactive-counts token not satisfied")
+      (let [refusal (req/validate-evidence [:rf.assert/caused] ev :cljs-reactive)]
+        (is (some? refusal))
+        (is (= :cannot-run (:status refusal)))
+        (is (= :required-evidence-missing (:reason refusal)))
+        (is (contains? (:missing-evidence refusal) :reactive-counts))))))
+
+(deftest reactive-count-assertion-passes-when-tape-carries-reactive-rows
+  (testing "a :reactive-counts proof is satisfied when the tape carries sub-run / render rows"
+    (let [tape [{:epoch-id 1 :outcome :ok
+                 :sub-runs [{:sub-id :total :recomputed? true}]
+                 :renders  [{:render-key [:v 0]}]}]
+          ev   (evidence/project-evidence tape)]
+      (is (some? (:reactive-counts ev)) "tape projected reactive counts")
+      (is (req/evidence-slot-satisfied? #{:reactive-counts} ev))
+      (is (nil? (req/validate-evidence [:rf.assert/caused] ev :cljs-reactive))
+          "evidence present → no refusal; the assertion's own verdict stands"))))
+
 (deftest validate-run-evidence-aggregates-missing-slots
   (testing "run-level evidence validation lists per-assertion missing-evidence refusals"
     (let [ev (evidence/project-evidence [])]
@@ -305,11 +350,14 @@
     (is (= :auto (:mode (req/normalize-run-opts {:escalate true}))))
     (is (= :auto (:mode (req/normalize-run-opts {:runner :auto})))))
 
-  (testing "an unknown / non-selectable runner falls back to fixed :headless"
+  (testing "an unknown runner falls back to fixed :headless"
     (is (= {:mode :fixed :runner :headless :frame-binding :fresh :platform :client}
-           (req/normalize-run-opts {:runner :bogus})))
-    (is (= :headless (:runner (req/normalize-run-opts {:runner :cljs-reactive})))
-        ":cljs-reactive is not a P1 selection target → falls back to :headless")))
+           (req/normalize-run-opts {:runner :bogus}))))
+
+  (testing ":cljs-reactive is now a valid fixed runner (rf2-5x1wt.30)"
+    (is (= :cljs-reactive (:runner (req/normalize-run-opts {:runner :cljs-reactive})))
+        ":cljs-reactive proves :reactive-counts → it is a P1 selection target")
+    (is (= :fixed (:mode (req/normalize-run-opts {:runner :cljs-reactive}))))))
 
 ;; ===========================================================================
 ;; PLAN INTEGRATION — :required-runner is computed through the registry


### PR DESCRIPTION
## What

Adds the **reactive recompute / render-count probe** (NewTestStory Plan §C2 task 1) as a **projection over the epoch tape**, not a new core instrumentation seam.

**Key finding (mayor-confirmed):** Spec 009 already emits both signals into the trace/epoch tape — one `:rf.sub/run` per TRUE sub recompute and one `:rf.view/rendered` per view render — and `re-frame.epoch.capture/project-all` structures them into each epoch's `:sub-runs` / `:renders` rows at settle time. The probe is therefore a pure projection over those rows. **No `implementation/core`, `spec/006`, or `spec/009` change; no `ui/` files touched.**

## Changes

- **`evidence.cljc`** — new `reactive-counts` projection over the already-projected `:sub-runs` / `:renders` rows: `{:sub-recomputes :view-renders :by-sub-id :by-view :by-render-key :by-cause :per-epoch}`. Keyed by sub-id, view-id, render-key, dispatching `:cause-event-id`, and per-epoch. Threaded into `project-evidence` as the `:reactive-counts` slot — PRESENT only when the tape carried at least one reactive row (a bare headless dispatch-only tape omits it, so the fail-closed slot check stays honest). Reuses the existing `.4` evidence path; **no parallel accumulator**.
- **`requirements.cljc`** — `:reactive-counts` now has a real seam, provided by a `:cljs-reactive` concrete runner inserted between `:hiccup` and `:dom` on the cost ladder (it flushes reactions so subs deref / views render, landing the rows). `:rf.assert/caused` / `:rf.assert/no-cascade-rerender` now resolve to `:cljs-reactive` under `:auto` instead of `:cannot-run`; they still `:cannot-run` under fixed `:headless` / `:hiccup`, and the post-run fail-closed slot check refuses a `:cljs-reactive` run whose tape produced no reactive rows. `:cljs-reactive` is now a valid fixed runner in `normalize-run-opts`.
- **`spec/017-Testing-Story.md`** — probe reclassified NET-NEW → SHIPS as a projection; capability ladder, token→slot map, and run-result evidence table updated.
- **tests** — pure JVM projection coverage (`evidence_test`) + fail-closed / runner-ladder coverage (`requirements_test`). A known dispatch's sub-run + render rows count exactly from the tape; `:reactive-counts` capability is now satisfiable (no longer `:cannot-run` when the reactive substrate was exercised).

The tape is read via the late-bound `rf/epoch-history` facade; `evidence.cljc` adds NO hard-`:require` on `re-frame.epoch` (its require block is unchanged: `clojure.string` only).

## Quality gates

All green:

- `tools/story` — `clojure -M:test` → **1236 tests, 3921 assertions, 0 failures, 0 errors**
- `tools/story-mcp` — `clojure -M:test` → **172 tests, 861 assertions, 0 failures, 0 errors** (downstream consumer)
- `tools/mcp-conformance` — `npm run test:story` (cum40) → **STORY-MCP MCP-CLIENT CONFORMANCE GREEN** (exit 0)
- `implementation` — `npm run test:cljs` → **4850 tests, 15890 assertions, 0 failures, 0 errors**
- `scripts/test-fast-pr.sh` → **PASS fast PR spine** (incl. README/docs anchor gates for the spec/017 edit; mkdocs soft-skipped locally, CI runs it)