### PR TITLE
feat(xray): host-facing focus API for embedded Xray (Story→Xray focus, rf2-crtmq)

### DIFF
--- a/tools/xray/spec/008-Embedding-Contract.md
+++ b/tools/xray/spec/008-Embedding-Contract.md
@@ -96,6 +96,124 @@ What Xray owns:
   persisted via Xray's own localStorage slots.
 - **Live updates** from the trace bus / epoch history.
 
+## Host-facing focus API (rf2-crtmq)
+
+The embed contract above is **structural** — how a host mounts the
+shell + surrenders keybinding capture. The complementary surface is
+**focus**: a host (Story) directing an already-embedded Xray surface
+to focus a specific panel + epoch + cascade + app-db path, driven from
+a narrative beat, a failed assertion, a canvas inspect command, or a
+docs/test link.
+
+This is a **small one-way focus command, not a two-way embedding
+protocol** (StoryUI decision register §D3). It preserves the ownership
+boundary:
+
+- **Story owns the narrative / action** — it builds the command (which
+  panel, which epoch, which path) plus opaque `:source` provenance, and
+  calls `focus!`.
+- **Xray owns the diagnostic state + panel semantics** — it receives
+  the command and routes each field to the canonical `:rf.xray/*` spine
+  / tab / path / frame event. Xray decides what each focus *means*.
+
+It introduces **no second Xray runtime model.** Every command field
+maps to an EXISTING write surface; the API is a thin composer over
+them.
+
+### Entry point
+
+`day8.re-frame2-xray.focus/focus!` (re-exported as
+`day8.re-frame2-xray.core/focus!`). Two arities, exactly §D3's worked
+shape:
+
+```clojure
+(core/focus! command)             ; the command's own :frame scopes
+(core/focus! host-frame command)  ; host-frame becomes :frame when the
+                                  ; command omits one (explicit wins)
+```
+
+`focus!` fires into Xray's own `:rf/xray` shell frame (via
+`re-frame.core/with-frame defaults/default-frame-id` — the same
+no-surrounding-frame seam `runtime.cljs` mutations and `share.cljs`'s
+on-load restore use). The host never names Xray's internal frame; the
+channel is the command, not the frame split.
+
+This is **separate from open-full-Xray.** Mounting / opening /
+popping-out the whole shell stays in `mount.cljs` (`open!` /
+`open-overlay!` / `popout!`); `focus!` assumes the surface is already
+embedded and only focuses-a-panel-on-a-beat. Per §D3:
+"opening/pop-out of the full Xray shell is current; focusing a
+panel/beat/path is [the new surface]."
+
+### Command shape (the contract)
+
+```clojure
+{:frame       <frame-id>   ; the HOST frame Xray should observe (optional)
+ :panel       <tab-id>     ; which L4 tab to surface (one of the 7 below)
+ :epoch-id    <epoch-id>   ; settling epoch to pin the spine to
+ :dispatch-id <id>         ; cascade root to pin the spine to
+ :path        [<k> ...]    ; app-db path to highlight in the App-db panel
+ :source      {...}        ; OPAQUE provenance — Xray echoes it back, never reads it
+ :sync?       <bool>}      ; control: dispatch-sync (test rigs / same-tick flows)
+```
+
+Every field is optional; an empty command is a well-formed no-op focus.
+`:panel` accepts the 7 canonical tab ids (the
+`day8.re-frame2-xray.focus/valid-panels` set, also re-exported as
+`core/valid-focus-panels`):
+
+```
+#{:epoch :app-db :views :trace :machines :routes :issues}
+```
+
+(internal registry keys per [`007-UX-IA.md`](./007-UX-IA.md) §The
+4-layer chrome L3). The `:source` map is host-agnostic provenance —
+§D3's worked shape is `{:kind :story/assertion :variant/id … :assertion/id …}`,
+but Xray treats it as opaque, which is what keeps the channel
+host-agnostic: it carries Story's intent without Xray knowing it's
+Story.
+
+### Field → canonical write surface
+
+| Command field | Canonical Xray write | Owner |
+|---|---|---|
+| `:frame`       | `:rf.xray/select-frame <frame-id>` | [`007-UX-IA.md`](./007-UX-IA.md) §Frame slot contract |
+| `:panel`       | `:rf.xray/select-tab <tab-id>`     | spine tab slot |
+| `:epoch-id`    | `:rf.xray/focus-epoch <epoch-id>`  | [`018-Event-Spine.md`](./018-Event-Spine.md) §6 |
+| `:dispatch-id` | `:rf.xray/focus-cascade <id> <frame>` | [`018-Event-Spine.md`](./018-Event-Spine.md) §6 |
+| `:path`        | `:rf.xray/focus-slice-path <path>` | App-db panel slice focus |
+
+Dispatch order is **frame-first** so the per-frame epoch ring re-seeds
+(`:rf.xray/set-frame` clears the pinned dispatch-id + re-seeds
+`:epoch-history`) before any epoch / cascade pin resolves; then the
+spine pin, then the tab + path. When BOTH `:dispatch-id` and
+`:epoch-id` are supplied the cascade pin wins (it carries the frame and
+the spine derives the settling epoch from it); `:epoch-id` alone is the
+lighter selector for callers that only have an epoch.
+
+### Return shape
+
+`focus!` returns a data-shaped result mirroring `runtime.cljs`'s
+`{:ok? …}` idiom:
+
+```clojure
+{:ok? true  :applied [[:rf.xray/select-frame :checkout] …] :source {…}}
+{:ok? false :reason :unknown-panel :given :app-bd :valid #{…} :hint "…"}
+```
+
+Unknown panel is the **one rejected case** — a typo'd selector would
+otherwise silently land the L4 unknown-tab stub. Every other field is
+permissive (a missing epoch / evicted cascade degrades through the
+spine's existing placeholder UX, not an error).
+
+### Status
+
+`CURRENT` (rf2-crtmq). The Story-UI **consumption** of this API —
+wiring narrative beats / assertion rows to call `focus!` — is owned by
+the StoryUI render-shell work and is NOT part of this contract. The
+command + entry point are the contract; how a host invokes it is the
+host's surface.
+
 ## State isolation (Option-C frame-provider)
 
 Xray's shell mounts **inside the host's React tree** so embedding is
@@ -206,9 +324,11 @@ that needs it, not in a central shim layer.
   [`007-UX-IA.md`](./007-UX-IA.md) §Mountable panel contract for
   internal use (shell composition, tests, future tools); it carries
   one `opts` key — `:frame` — and is not a host-facing embed contract.
-- **No two-way binding.** The host doesn't push state into Xray
-  beyond the configure! slots; Xray doesn't push state back to the
-  host.
+- **No two-way binding.** Beyond the `configure!` slots and the
+  one-way **focus command** (§Host-facing focus API — the host pushes
+  a focus *intent*, not arbitrary state, and Xray owns what it means),
+  the host doesn't push state into Xray; Xray never pushes state back
+  to the host.
 - **No standalone styling overrides.** The embedded shell uses
   Xray's theme tokens. The host can wrap the shell in a container
   that overrides CSS variables (`--rf-xray-font-size`,

--- a/tools/xray/spec/API.md
+++ b/tools/xray/spec/API.md
@@ -175,6 +175,17 @@ implementation reality — ~40 symbols across 6 namespaces).
 (xray/target-frame)        ;; Return the host frame Xray is currently targeting.
 (xray/set-target-frame! :app/main)
 
+;; Story → Xray focus (rf2-crtmq). A host (Story) directs an already-embedded
+;; Xray surface to focus a specific panel + epoch + cascade + app-db path from
+;; a narrative beat / failed assertion / inspect command. Separate from
+;; open-full-Xray (above). One-way command; Story owns the action, Xray owns
+;; panel semantics. Full contract: 008-Embedding-Contract.md §Host-facing focus API.
+(xray/focus! {:frame :checkout :panel :app-db :epoch-id 42
+              :path [:checkout :state]
+              :source {:kind :story/assertion}})
+(xray/focus! :checkout {:panel :trace})   ;; positional host-frame form
+xray/valid-focus-panels                   ;; the 7 valid :panel ids
+
 (xray/load-theme css-string)
 ;; Programmatically swap the palette: injects `css-string` as a dedicated
 ;; <style> override appended last to <head> (so it wins on authoring order).
@@ -201,7 +212,8 @@ authoritative list.
 
 | Namespace | Source | Public surfaces |
 |---|---|---|
-| `day8.re-frame2-xray.core` | `core.cljs` | The 12 canonical re-exports above (`init!`, `open!`, `open-overlay!`, `close!`, `toggle!`, `popout!`, `status`, `target-frame`, `set-target-frame!`, `load-theme`, plus the four highest-traffic config setters re-exported for boot-time convenience: `configure!`, `set-auto-open!`, `set-editor!`, `set-show-sensitive!`). |
+| `day8.re-frame2-xray.core` | `core.cljs` | The canonical re-exports above (`init!`, `open!`, `open-overlay!`, `close!`, `toggle!`, `popout!`, `status`, `target-frame`, `set-target-frame!`, `focus!` + `valid-focus-panels` (the Story→Xray focus entry point, rf2-crtmq), `load-theme`, plus the four highest-traffic config setters re-exported for boot-time convenience: `configure!`, `set-auto-open!`, `set-editor!`, `set-show-sensitive!`). |
+| `day8.re-frame2-xray.focus` | `focus.cljc` | The host-facing **focus command** API (rf2-crtmq): `focus!` (the entry point, re-exported through `core`), `focus-command->dispatches` (pure command→`:rf.xray/*`-events translation; JVM-runnable), and `valid-panels` (the 7-tab vocabulary). The channel Story uses to focus an embedded Xray panel/epoch/path from a beat or assertion. Full contract in [`008-Embedding-Contract.md`](./008-Embedding-Contract.md) §Host-facing focus API. |
 | `day8.re-frame2-xray.panels.*` | `panels/*.cljs` | The 7 `Panel` reg-views — `epoch-panel/Panel`, `app-db-diff/Panel`, `reactive-panel/Panel`, `trace/Panel`, `machine-inspector/Panel`, `routing/Panel`, `issues-ribbon/Panel` (per [`008-Embedding-Contract.md`](./008-Embedding-Contract.md) + [`018-Event-Spine.md`](./018-Event-Spine.md) §The 7 tabs). rf2-5gl5r removed `event-detail/Panel` — the Epoch panel supersedes the Event/Handler design as the canonical "what happened in this epoch" surface. rf2-4v67l removed `chrome-a11y.panel/Panel` — a11y dogfooding is Story's domain (rf2-18t6p · `tools/story/src/re_frame/story/ui/chrome_a11y.cljs`). rf2-ga16q removed `machines-canvas.panel/Panel` — its spine-INDEPENDENT browse-all canvas relocated to the Static Machines sub-tab (the Runtime Machines tab is the event-driven lens per rf2-y9xmf). |
 | `day8.re-frame2-xray.config` | `config.cljc` | The `configure!` map dispatcher, the per-key setters (`set-editor!`, `set-project-root!`, `set-layout-host-selector!`, `set-auto-open!`, `set-keybinding-enabled!`, `set-show-sensitive!`, `set-filter-seed!`, `set-filters-storage-key!`, `update-setting!`, `reset-settings!`, `reset-suppressed-count!`) and the published constants enumerated in §Published layout-host constants above. The full normative key inventory lives in [`015-Configuration.md`](./015-Configuration.md); the **key-naming axis** (how authors navigate the key surface by topical cluster prefix — editor / launch / keybinding / settings / filters / render / trace / logging) is documented at [`015-Configuration.md` §Key-naming axis](./015-Configuration.md#key-naming-axis--navigation-map-rf2-dz35f--audit-of-audits-16) per `rf2-dz35f`. |
 | `day8.re-frame2-xray.keybinding` | `keybinding.cljs` | `attach!` / `detach!` — the symmetric, idempotent lifecycle pair for the `Ctrl+Shift+C` global listener. `detach!` is the embed-host escape hatch documented at [`015-Configuration.md`](./015-Configuration.md) §`keybinding/detach!` and [`008-Embedding-Contract.md`](./008-Embedding-Contract.md) §Full-shell embed contract — needed when an embed host's mount lifecycle runs after Xray's preload and wants to take the chord back. |

--- a/tools/xray/src/day8/re_frame2_xray/core.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/core.cljs
@@ -7,10 +7,11 @@
   canonical entry points enumerated by the spec —
   `init!` / `open!` / `open-overlay!` / `close!` / `toggle!` /
   `popout!` / `status` /
-  `target-frame` + `set-target-frame!` / `active-panel` +
-  `set-active-panel!` / `load-theme` — plus the four highest-traffic
-  boot-time config knobs exposed by `config.cljc` (`configure!` /
-  `set-editor!` / `set-auto-open!` / `set-show-sensitive!`).
+  `target-frame` + `set-target-frame!` / `focus!` (the host-facing
+  Story→Xray focus entry point, rf2-crtmq) / `load-theme` — plus the
+  four highest-traffic boot-time config knobs exposed by `config.cljc`
+  (`configure!` / `set-editor!` / `set-auto-open!` /
+  `set-show-sensitive!`).
 
   Per `spec/API.md` §Wider public surface, additional public surfaces
   live in their own namespaces: the full per-key setter inventory in
@@ -52,6 +53,7 @@
   documentation for the rationale on each."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-xray.config :as config]
+            [day8.re-frame2-xray.focus :as focus]
             [day8.re-frame2-xray.keybinding :as keybinding]
             [day8.re-frame2-xray.mount :as mount]
             [day8.re-frame2-xray.preload :as preload]
@@ -201,6 +203,31 @@
   (rf/with-frame :rf/xray
     (rf/dispatch [:rf.xray/set-target-frame frame-id]))
   nil)
+
+;; ---- Story → Xray focus (rf2-crtmq) -------------------------------------
+;;
+;; The host-facing focus entry point: a host (Story) sends a small,
+;; data-shaped focus command from a narrative beat / failed assertion /
+;; inspect command and the embedded Xray surface focuses the right
+;; panel + epoch + cascade + app-db path. Story owns the
+;; action/intent; Xray owns panel semantics. `def`-alias (not a wrapper
+;; fn) so `(= focus/focus! core/focus!)` holds and DCE inlines the call
+;; site — same posture as the mount re-exports above. The command shape
+;; + ownership boundary live in `day8.re-frame2-xray.focus`.
+
+(def focus!
+  "Focus an embedded Xray surface from a host (Story) beat / assertion /
+  inspect command. See `day8.re-frame2-xray.focus/focus!` for the full
+  command shape + ownership contract. The host-facing channel for
+  StoryUI focus links (rf2-crtmq)."
+  focus/focus!)
+
+(def valid-focus-panels
+  "The canonical host-facing Xray panel ids a focus command may target
+  — `#{:epoch :app-db :views :trace :machines :routes :issues}`. A host
+  validates a panel selector against this set before sending a focus
+  command. See `day8.re-frame2-xray.focus/valid-panels`."
+  focus/valid-panels)
 
 ;; ---- runtime theme override ---------------------------------------------
 

--- a/tools/xray/src/day8/re_frame2_xray/focus.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/focus.cljc
@@ -1,0 +1,275 @@
+(ns day8.re-frame2-xray.focus
+  "Host-facing focus API for an embedded Xray surface (rf2-crtmq).
+
+  ## What this owns
+
+  A small, **data-shaped focus command** a host (Story) sends to focus
+  an already-embedded Xray surface onto a specific panel + epoch +
+  cascade + app-db path — driven from a narrative beat, a failed
+  assertion, a canvas inspect command, or a docs/test link.
+
+  This is the channel the StoryUI decision register
+  (`ai/findings/StoryUI/06-open-decisions.md` §D3 \"Story-To-Xray Focus
+  API\") settled on: a small one-way focus command, NOT a broad two-way
+  embedding protocol.
+
+  ## The ownership boundary (load-bearing)
+
+  - **Story owns the narrative / action** — it constructs the command
+    (which panel, which epoch, which path) and the `:source` provenance
+    (which variant / assertion / beat triggered it), then calls
+    `focus!`.
+  - **Xray owns the diagnostic state + panel semantics** — it receives
+    the command and routes it to the canonical `:rf.xray/*` spine / tab
+    / path / frame events. Xray decides what \"focus the app-db panel on
+    epoch 42 at path [:checkout :state]\" *means*.
+
+  No second Xray runtime model is introduced. Every field in the
+  command maps to an EXISTING canonical write surface:
+
+  | Command field | Canonical Xray write | Owner ns |
+  |---|---|---|
+  | `:frame`       | `:rf.xray/select-frame <frame-id>` | `frame_switcher.cljs` |
+  | `:panel`       | `:rf.xray/select-tab <tab-id>`     | `registry.cljs` |
+  | `:epoch-id`    | `:rf.xray/focus-epoch <epoch-id>`  | `spine.cljs` |
+  | `:dispatch-id` | `:rf.xray/focus-cascade <id> <frame>` | `spine.cljs` |
+  | `:path`        | `:rf.xray/focus-slice-path <path>` | `app_db_diff_events.cljs` |
+
+  This namespace is a thin composer over those events — it adds no new
+  app-db slots, no new spine model, no new panel state. It mirrors the
+  posture of `day8.re-frame2-xray.runtime` (the MCP read/mutate seam):
+  a clean, host-agnostic, data-in / data-out façade over surfaces that
+  already exist.
+
+  ## Separate from open-full-Xray
+
+  Mounting / opening / popping-out the whole Xray shell stays in
+  `mount.cljs` (`open!` / `open-overlay!` / `popout!`). This namespace
+  is purely *focus-a-panel-on-a-beat* — it assumes the Xray surface is
+  already embedded (Story mounts it via the locked render-shell
+  contract). Per §D3 rule: \"opening/pop-out of the full Xray shell is
+  current; focusing a panel/beat/path is [the new surface].\"
+
+  ## Command shape (the contract)
+
+      {:frame       <frame-id>   ; the HOST frame Xray should observe
+                                 ;   (optional — omit to keep current scope)
+       :panel       <tab-id>     ; which L4 tab to surface
+                                 ;   (one of `valid-panels`)
+       :epoch-id    <epoch-id>   ; settling epoch to pin the spine to
+       :dispatch-id <id>         ; cascade root to pin the spine to
+                                 ;   (alternative to :epoch-id; both is fine)
+       :path        [<k> ...]    ; app-db path to highlight in the App-db panel
+       :source      {...}}       ; OPAQUE provenance — Story's intent context;
+                                 ;   Xray does NOT interpret it, only echoes it
+                                 ;   back for diagnostics / round-trip tests.
+
+  Every field is optional. An empty command (`{}`) is a well-formed
+  no-op focus (returns `:ok? true` with `:applied []`). A command with
+  only `:panel` just flips the tab. This keeps narrative beats terse —
+  a beat that only cares about \"show me the trace\" sends
+  `{:panel :trace}`.
+
+  The `:source` map is host-agnostic provenance. §D3's worked shape:
+
+      {:kind        :story/assertion
+       :variant/id  :story.checkout/form/submitted
+       :assertion/id :checkout-state-submitted}
+
+  Xray treats `:source` as opaque — it never reaches into its keys.
+  Story (or any other host) is free to put whatever provenance shape
+  it likes there. This is what makes the command host-agnostic: the
+  channel carries Story's intent without Xray knowing it's Story.
+
+  ## Pure core + thin CLJS shell
+
+  `focus-command->dispatches` is a pure, `.cljc`, JVM-runnable
+  translation from a command map to the ordered vector of event
+  vectors. The CLJS `focus!` fn (below, reader-conditional) resolves
+  the Xray frame and fires them via `re-frame.core/dispatch`. The pure
+  core is what the test corpus drives; the CLJS shell is the runtime
+  glue.
+
+  ## Why ordered dispatches
+
+  The events are dispatched in a fixed order — `:frame` FIRST (so the
+  per-frame epoch ring is re-seeded before any epoch / cascade pin
+  lands; `:rf.xray/set-frame` clears the pinned `:dispatch-id` and
+  re-seeds `:epoch-history`, so a later `:focus-epoch` resolves against
+  the correct frame's ring), THEN `:dispatch-id` / `:epoch-id` (the
+  spine pin), THEN `:panel` (the tab) and `:path` (the app-db slice).
+  Reversing frame and epoch would let the epoch pin resolve against the
+  wrong frame's ring."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-xray.defaults :as defaults]))
+
+;; ---------------------------------------------------------------------------
+;; The panel vocabulary
+;; ---------------------------------------------------------------------------
+;;
+;; The canonical L4-tab ids the Dynamic shell surfaces (per
+;; `tools/xray/spec/007-UX-IA.md` §The 4-layer chrome L3 + the
+;; panel-registry inventory). The `:rf.xray/select-tab` event itself
+;; does NOT guard the id (it writes any keyword onto `:selected-tab`,
+;; and the L4 detail panel renders an unknown-tab stub for a stale id);
+;; this set is the published, host-facing vocabulary so a host can
+;; validate a panel selector before sending — and so the focus API
+;; rejects a typo'd panel with a useful diagnostic rather than silently
+;; selecting a tab that renders the unknown-tab stub.
+
+(def valid-panels
+  "The canonical host-facing Xray panel (L4 tab) ids a focus command
+  may target. Matches the spine's 7-tab inventory (Epoch · app-db ·
+  Views · Trace · Machine · Routes · Issues) — internal registry keys
+  `:views` / `:routes` per `tools/xray/spec/007-UX-IA.md`."
+  #{:epoch :app-db :views :trace :machines :routes :issues})
+
+;; ---------------------------------------------------------------------------
+;; Pure command → dispatches translation (JVM-runnable)
+;; ---------------------------------------------------------------------------
+
+(defn focus-command->dispatches
+  "Pure translation of a focus `command` map into an ORDERED vector of
+  `:rf.xray/*` event vectors. JVM-runnable; no re-frame runtime,
+  no app-db. The CLJS `focus!` fn fires these in order.
+
+  `command` is the §D3 shape (every field optional):
+
+      {:frame :checkout
+       :panel :app-db
+       :epoch-id 42
+       :dispatch-id 17
+       :path [:checkout :state]
+       :source {...}}
+
+  Returns a vector of event vectors. Ordering (see ns docstring):
+
+    1. `[:rf.xray/select-frame <frame>]` — re-scope FIRST so the
+       per-frame epoch ring is re-seeded before any pin resolves.
+    2. `[:rf.xray/focus-cascade <dispatch-id> <frame>]` — when
+       `:dispatch-id` present. The cascade pin carries the frame so
+       `cascade-by-id`'s per-frame disambiguation works.
+    3. `[:rf.xray/focus-epoch <epoch-id>]` — when `:epoch-id` present
+       AND `:dispatch-id` absent. (When both are supplied the
+       cascade pin wins — it carries the frame and the spine resolves
+       the settling epoch from it; an explicit `:epoch-id` is the
+       lighter selector for callers that only have the epoch.)
+    4. `[:rf.xray/select-tab <panel>]` — when `:panel` present.
+    5. `[:rf.xray/focus-slice-path <path>]` — when `:path` present
+       (App-db panel slice highlight).
+
+  `:source` produces NO dispatch — it is opaque provenance Xray echoes
+  back via `focus!`'s return map; it never mutates Xray state.
+
+  Note this fn does NOT validate `:panel` against `valid-panels` — it
+  is a faithful translator. Validation is `focus!`'s job (it owns the
+  diagnostic return shape); a caller wanting the raw translation can
+  pass any panel keyword here."
+  [{:keys [frame panel epoch-id dispatch-id path] :as _command}]
+  (cond-> []
+    (some? frame)       (conj [:rf.xray/select-frame frame])
+    (some? dispatch-id) (conj [:rf.xray/focus-cascade dispatch-id frame])
+    (and (some? epoch-id)
+         (nil? dispatch-id))
+    (conj [:rf.xray/focus-epoch epoch-id])
+    (some? panel)       (conj [:rf.xray/select-tab panel])
+    (some? path)        (conj [:rf.xray/focus-slice-path path])))
+
+;; ---------------------------------------------------------------------------
+;; Host-facing focus entry point (CLJS — fires into the Xray frame)
+;; ---------------------------------------------------------------------------
+
+#?(:cljs
+   (defn- apply-focus!
+     "Validate + fire a (frame-merged) focus `command` into Xray's
+     `:rf/xray` shell frame. Returns the `focus!` result shape. The two
+     public `focus!` arities both funnel through here after resolving
+     the positional host-frame."
+     [{:keys [panel source sync?] :as command}]
+     (if (and (some? panel) (not (contains? valid-panels panel)))
+       {:ok?    false
+        :reason :unknown-panel
+        :given  panel
+        :valid  valid-panels
+        :hint   (str "Unknown Xray panel " (pr-str panel)
+                     ". Use one of " (pr-str valid-panels) ".")}
+       (let [dispatches (focus-command->dispatches command)]
+         ;; Fire into Xray's own shell frame (the host never sees it —
+         ;; the channel is the command, not the frame split). Mirrors
+         ;; runtime.cljs's mutation accessors + share.cljs's restore
+         ;; path, which both target `defaults/default-frame-id` for the
+         ;; no-surrounding-frame case.
+         (rf/with-frame defaults/default-frame-id
+           (doseq [event-vec dispatches]
+             (if sync?
+               (rf/dispatch-sync event-vec)
+               (rf/dispatch event-vec))))
+         {:ok?     true
+          :applied dispatches
+          :source  source}))))
+
+#?(:cljs
+   (defn focus!
+     "Focus an embedded Xray surface from a host (Story) beat / assertion
+     / inspect command.
+
+     Two arities mirror §D3's worked shape:
+
+         (focus! command)             ; the command's own `:frame` scopes
+         (focus! host-frame command)  ; `host-frame` is the frame to observe,
+                                      ;   merged into the command as `:frame`
+                                      ;   (an explicit command `:frame` wins)
+
+     The 2-arity matches §D3's `(story.xray/focus! frame-id {...})` —
+     the host names the frame Xray should observe as a positional arg,
+     keeping the command map about WHAT to focus rather than WHERE.
+
+     `command` is the §D3 focus-command map (see ns docstring +
+     `focus-command->dispatches`). Every field optional.
+
+     Dispatches each translated `:rf.xray/*` event into Xray's own
+     `:rf/xray` shell frame (via `re-frame.core/with-frame` —
+     mirroring `runtime.cljs`'s mutation accessors + `share.cljs`'s
+     restore path). The host never sees Xray's internal frame; the
+     channel is the command, not the frame split.
+
+     Returns a data-shaped result (mirroring `runtime.cljs`'s
+     `{:ok? ...}` idiom):
+
+         {:ok?     true
+          :applied [[:rf.xray/select-frame :checkout] ...]  ; events fired, in order
+          :source  {...}}                                   ; echoed provenance (or nil)
+
+     or, for a command naming an unknown panel:
+
+         {:ok?     false
+          :reason  :unknown-panel
+          :given   :app-bd
+          :valid   #{:epoch :app-db ...}
+          :hint    \"...\"}
+
+     Unknown panel is the one rejected case — a typo'd selector would
+     otherwise silently land the L4 'unknown tab' stub. Every other
+     field is permissive (a missing epoch / evicted cascade degrades
+     through the spine's existing placeholder UX, not an error here).
+
+     The command's optional `:sync?` control field fires `dispatch-sync`
+     instead of `dispatch` (test rigs + same-tick host flows); it is a
+     control key, never translated to a dispatch. Returns nothing useful
+     outside a CLJS runtime.
+
+     The two arities are EXACTLY §D3's worked shape — `(focus! command)`
+     and `(focus! frame-id command)` — there is no opts arg (the only
+     control knob, `:sync?`, rides inside the command map). This keeps
+     the arities unambiguous: a map in head position is always the
+     command; a non-map (a frame-id keyword) in head position is always
+     the positional host-frame."
+     ([command]
+      (apply-focus! command))
+     ([host-frame command]
+      ;; positional host-frame fills :frame only when the command didn't
+      ;; name one — an explicit command :frame is the more specific
+      ;; intent and wins.
+      (apply-focus! (cond-> command
+                      (and (some? host-frame) (nil? (:frame command)))
+                      (assoc :frame host-frame))))))

--- a/tools/xray/test/day8/re_frame2_xray/focus_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/focus_cljs_test.cljs
@@ -1,0 +1,242 @@
+(ns day8.re-frame2-xray.focus-cljs-test
+  "Coverage for the host-facing Story→Xray focus API (rf2-crtmq).
+
+  Two bands:
+
+  1. **Pure translation** (`focus-command->dispatches`) — JVM-runnable
+     shape: a §D3 focus-command map maps to the ordered vector of
+     `:rf.xray/*` events, every field optional, ordering frame-first.
+  2. **End-to-end focus** (`focus!`) — driving the command into the
+     real registered Xray events focuses the right panel + epoch +
+     cascade + app-db path on Xray's spine / tab / path slots. Proves
+     the command is host-agnostic: the same command shape drives Xray
+     regardless of who sent it, and `:source` provenance round-trips
+     untouched.
+
+  Per `tools/xray/spec/008-Embedding-Contract.md` §Host-facing focus
+  API + the §D3 decision (`ai/findings/StoryUI/06-open-decisions.md`):
+  Story owns the intent/action (sends the command); Xray owns panel
+  semantics (receives + focuses) — no second Xray runtime model."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-xray.focus :as focus]
+            [day8.re-frame2-xray.preload :as preload]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.trace-collector :as trace-collector]))
+
+;; ---- fixtures -----------------------------------------------------------
+
+(defn- xray-init! []
+  (preload/reset-for-test!)
+  (registry/reset-for-test!)
+  (trace-collector/reset-for-test!))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn xray-init!}))
+
+(defn- setup-xray-frame! []
+  (registry/register-xray-handlers!)
+  (frame/reg-frame :rf/xray {}))
+
+;; ---- cascade fixture (mirrors spine-cljs-test) --------------------------
+
+(defn- cascade [dispatch-id frame-id]
+  {:dispatch-id dispatch-id
+   :frame       frame-id
+   :event       nil :handler nil :fx nil
+   :effects [] :subs [] :renders [] :other []})
+
+(defn- seed-cascades!
+  "Seed the Xray trace buffer with synthetic single-event cascades so
+  the spine's by-id / head walks resolve. Mirrors the trace-event shape
+  spine-cljs-test/seed-cascades! uses — one `:rf.event/dispatched` per
+  cascade so `group-cascades`' frame-index pairs the right events."
+  [cascades-vec]
+  (let [events (map-indexed
+                 (fn [i {:keys [dispatch-id frame]}]
+                   {:id        (inc i)
+                    :op-type   :rf.event
+                    :operation :rf.event/dispatched
+                    :tags      {:rf.trace/dispatch-id dispatch-id
+                                :frame                frame
+                                :rf.event/v           [(keyword "evt" (name dispatch-id))]}})
+                 cascades-vec)]
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/sync-trace-buffer (vec events)]))))
+
+(defn- focus-sub []
+  (rf/with-frame :rf/xray
+    @(rf/subscribe [:rf.xray/focus])))
+
+(defn- selected-tab []
+  (rf/with-frame :rf/xray
+    @(rf/subscribe [:rf.xray/selected-tab])))
+
+(defn- view-scope-frame []
+  (rf/with-frame :rf/xray
+    @(rf/subscribe [:rf.xray/view-scope-frame])))
+
+(defn- focused-slice-path []
+  (rf/with-frame :rf/xray
+    @(rf/subscribe [:rf.xray/focused-slice-path])))
+
+;; =========================================================================
+;; (1) Pure translation — focus-command->dispatches
+;; =========================================================================
+
+(deftest empty-command-yields-no-dispatches
+  (is (= [] (focus/focus-command->dispatches {}))
+      "an empty focus command is a well-formed no-op")
+  (is (= [] (focus/focus-command->dispatches {:source {:kind :story/beat}}))
+      ":source alone produces no dispatch — it is opaque provenance"))
+
+(deftest panel-only-flips-the-tab
+  (is (= [[:rf.xray/select-tab :trace]]
+         (focus/focus-command->dispatches {:panel :trace}))
+      "a terse narrative beat that only cares about a panel"))
+
+(deftest frame-dispatches-first
+  (testing "frame re-scope leads so the per-frame epoch ring re-seeds
+            before any epoch / cascade pin resolves"
+    (is (= [[:rf.xray/select-frame :checkout]
+            [:rf.xray/focus-epoch 42]
+            [:rf.xray/select-tab :app-db]]
+           (focus/focus-command->dispatches
+             {:frame :checkout :epoch-id 42 :panel :app-db})))))
+
+(deftest dispatch-id-carries-frame-and-wins-over-epoch
+  (testing "the cascade pin carries the frame (per-frame by-id
+            disambiguation) and supersedes a co-supplied :epoch-id"
+    (is (= [[:rf.xray/select-frame :checkout]
+            [:rf.xray/focus-cascade 17 :checkout]
+            [:rf.xray/select-tab :app-db]
+            [:rf.xray/focus-slice-path [:checkout :state]]]
+           (focus/focus-command->dispatches
+             {:frame :checkout
+              :panel :app-db
+              :epoch-id 42
+              :dispatch-id 17
+              :path [:checkout :state]
+              :source {:kind :story/assertion}}))
+        "no :focus-epoch emitted when :dispatch-id is present")))
+
+(deftest epoch-id-alone-uses-focus-epoch
+  (is (= [[:rf.xray/focus-epoch 42]]
+         (focus/focus-command->dispatches {:epoch-id 42}))
+      ":epoch-id is the lighter selector for callers without a cascade id"))
+
+(deftest path-only-highlights-slice
+  (is (= [[:rf.xray/focus-slice-path [:user :profile :name]]]
+         (focus/focus-command->dispatches {:path [:user :profile :name]}))))
+
+(deftest valid-panels-is-the-seven-tab-inventory
+  (is (= #{:epoch :app-db :views :trace :machines :routes :issues}
+         focus/valid-panels)))
+
+;; =========================================================================
+;; (2) End-to-end — focus! drives the real Xray events
+;; =========================================================================
+
+(def ^:private fixture-cascades
+  [(cascade :c1 :checkout)
+   (cascade :c2 :checkout)
+   (cascade :c3 :checkout)])
+
+(deftest focus-app-db-panel-via-command
+  (testing "focusing app-db at a path from an assertion focuses the
+            right Xray panel + cascade + slice"
+    (setup-xray-frame!)
+    (seed-cascades! fixture-cascades)
+    (let [result (focus/focus! :checkout
+                               {:panel :app-db
+                                :dispatch-id :c1
+                                :path [:checkout :state]
+                                :source {:kind :story/assertion
+                                         :assertion/id :checkout-state-submitted}
+                                :sync? true})]
+      (is (:ok? result))
+      (is (= {:kind :story/assertion
+              :assertion/id :checkout-state-submitted}
+             (:source result))
+          "Story's provenance round-trips back untouched")
+      (is (= :app-db (selected-tab)) "App-db tab is selected")
+      (is (= :c1 (:dispatch-id (focus-sub))) "spine pinned to the cascade")
+      (is (= :checkout (:frame (focus-sub))) "spine bound to the host frame")
+      (is (= :checkout (view-scope-frame)) "L2 view scope re-bound")
+      (is (= [:checkout :state] (focused-slice-path)) "App-db slice highlighted"))))
+
+(deftest focus-trace-panel-via-narrative-beat
+  (testing "a narrative beat surfacing the trace panel for a frame"
+    (setup-xray-frame!)
+    (seed-cascades! fixture-cascades)
+    (let [result (focus/focus! {:frame :checkout :panel :trace :sync? true})]
+      (is (:ok? result))
+      (is (= :trace (selected-tab)))
+      (is (= :checkout (view-scope-frame))))))
+
+(deftest focus-views-panel-via-command
+  (testing "representative third panel — Views — focuses cleanly"
+    (setup-xray-frame!)
+    (seed-cascades! fixture-cascades)
+    (let [result (focus/focus! {:frame :checkout :panel :views
+                                :dispatch-id :c2 :sync? true})]
+      (is (:ok? result))
+      (is (= :views (selected-tab)))
+      (is (= :c2 (:dispatch-id (focus-sub)))))))
+
+(deftest command-is-host-agnostic
+  (testing "the SAME command shape drives Xray regardless of who built
+            it — no Story-specific knowledge in the channel; even a
+            command with no :source (a docs/test link, not a Story beat)
+            focuses identically"
+    (setup-xray-frame!)
+    (seed-cascades! fixture-cascades)
+    (let [result (focus/focus! {:frame :checkout :panel :issues :sync? true})]
+      (is (:ok? result))
+      (is (nil? (:source result)) ":source is optional — absent is fine")
+      (is (= :issues (selected-tab))))))
+
+(deftest unknown-panel-is-rejected
+  (testing "a typo'd panel selector is the one rejected case — would
+            otherwise silently land the L4 unknown-tab stub"
+    (setup-xray-frame!)
+    (let [result (focus/focus! {:panel :app-bd})]  ;; typo
+      (is (false? (:ok? result)))
+      (is (= :unknown-panel (:reason result)))
+      (is (= :app-bd (:given result)))
+      (is (= focus/valid-panels (:valid result)))
+      (is (= :epoch (selected-tab))
+          "Xray state is untouched — still on the default Epoch tab"))))
+
+(deftest explicit-command-frame-wins-over-positional
+  (testing "2-arity positional host-frame fills :frame only when the
+            command didn't name one"
+    (setup-xray-frame!)
+    (seed-cascades! [(cascade :c1 :other-frame)])
+    (let [result (focus/focus! :positional-frame
+                               {:frame :command-frame :panel :epoch :sync? true})]
+      (is (:ok? result))
+      (is (= [:rf.xray/select-frame :command-frame]
+             (first (:applied result)))
+          "command :frame is the more specific intent"))))
+
+(deftest positional-host-frame-fills-frame-when-command-omits-it
+  (testing "the §D3 `(focus! frame-id command)` shape — positional
+            host-frame becomes the :frame when the command doesn't name one"
+    (setup-xray-frame!)
+    (let [result (focus/focus! :checkout {:panel :epoch :sync? true})]
+      (is (:ok? result))
+      (is (= [:rf.xray/select-frame :checkout]
+             (first (:applied result)))))))
+
+(deftest empty-command-is-ok-noop
+  (setup-xray-frame!)
+  (let [result (focus/focus! {:sync? true})]
+    (is (:ok? result))
+    (is (= [] (:applied result))
+        ":sync? is a control key, never translated to a dispatch")))


### PR DESCRIPTION
@
## What

Adds the small, data-shaped **focus command** that lets a host (Story) focus an already-embedded Xray surface onto a specific panel + epoch + cascade + app-db path — from a narrative beat, failed assertion, canvas inspect command, or docs/test link (bead **rf2-crtmq**).

Before this PR, Story could open / pop-out Xray whole, but Xrays embedding exposed **no host-facing focus props** — there was no channel to say "show the app-db panel, epoch 42, path `[:checkout :state]`". This is that channel.

Follows StoryUI decision register **§D3**: a **one-way focus command, not a two-way embedding protocol**, preserving the ownership boundary — **Story owns the narrative/action** (builds + sends the command, with opaque `:source` provenance); **Xray owns the diagnostic state + panel semantics** (receives + focuses). **No second Xray runtime model**: every command field maps to an *existing* `:rf.xray/*` write surface. Kept **separate from open-full-Xray** (`mount.cljs`) — `focus!` assumes the surface is already embedded.

## Command shape (the contract, per §D3)

```clojure
(core/focus! {:frame :checkout :panel :app-db :epoch-id 42 :dispatch-id 17
              :path [:checkout :state]
              :source {:kind :story/assertion :assertion/id :checkout-state-submitted}})
(core/focus! :checkout {:panel :trace})   ;; positional host-frame form
```

| Command field | Canonical Xray write |
|---|---|
| `:frame` | `:rf.xray/select-frame` |
| `:panel` | `:rf.xray/select-tab` |
| `:epoch-id` | `:rf.xray/focus-epoch` |
| `:dispatch-id` | `:rf.xray/focus-cascade` |
| `:path` | `:rf.xray/focus-slice-path` |

`:source` is opaque (Xray echoes it back, never reads it — what keeps the channel host-agnostic). `:sync?` is a control key. Dispatch order is **frame-first** so the per-frame epoch ring re-seeds before any epoch/cascade pin resolves. Unknown `:panel` is the one rejected case (`{:ok? false :reason :unknown-panel ...}`). Mirrors `runtime.cljs`s data-in/data-out `{:ok? ...}` idiom.

## Files

- **`focus.cljc`** (new) — `focus!` entry point (2 arities = D3s `(focus! command)` / `(focus! frame-id command)`), `focus-command->dispatches` (pure, JVM-runnable translation), `valid-panels`.
- **`core.cljs`** — re-exports `focus!` + `valid-focus-panels` through the canonical facade.
- **`008-Embedding-Contract.md` + `API.md`** — document the contract, command shape, field→surface table, return shape, status (`CURRENT`).
- **`focus_cljs_test.cljs`** (new) — pure-translation + end-to-end coverage.

## Deferred follow-on (NOT in this PR)

The **Story-UI consumption** — wiring narrative beats / assertion rows to *call* `focus!` — is owned by the `.29` ultimate Story UI render-shell work (Mike is live-editing `tools/story/.../ui/**`). This PR delivers the contract + entry point only; no `tools/story/src/.../ui/**` file is touched. Per the `09-ultimate-story-ui.md` matrix: "Trace/epoch detail — Story links narrative beats to Xray focus **after rf2-crtmq**."

## Scope guards honoured

- Did **not** touch any `tools/story/src/re_frame/story/ui/**` file.
- Did **not** create a new top-level repo spec (StoryUI D1 is open); documented only in existing `tools/xray/spec/*` (+ a Story-side note was unnecessary — no Story-side fn added; the API is Xray-owned).

## Quality gates

- `cd tools/xray && clojure -M:test` — **969 tests, 3808 assertions, 0 failures**
- `npm run test:xray-feature-gate` — **14 scenarios, 0 failures, 13 matrix rows**
- `npm run test:cljs` — **4865 tests, 15925 assertions, 0 failures** (includes the new `focus_cljs_test`)
- `scripts/test-fast-pr.sh` — **PASS** (4865 tests; README + docs anchor gates pass; mkdocs --strict soft-skipped locally on Windows, runs in CI)
@