### PR TITLE
fix(story): evidence-slot presence map — empty :trace/:renders is not no-proof (rf2-qoxw7)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -1486,16 +1486,35 @@ A proof is honoured only when BOTH sides agree it is available:
    tape never produced FAILS CLOSED to `:cannot-run` (the proof was
    promised but not delivered), NEVER `:pass`.
 
-The token→slot map: `:effects → :effects`, `:schema → :schema-violations`,
-`:trace → :warnings`, `:hiccup-structure`/`:dom` → `:renders`,
-`:reactive-counts → :reactive-counts` (present only when the tape carried
-`:rf.sub/run` / `:rf.view/rendered` rows — a `:cljs-reactive` run whose
-tape carried none refuses, fail-closed), `:pixels`/`:a11y-engine` →
-browser-only slots. A token with NO distinct
-slot (`:app-db`) imposes no post-run check — its proof is the final db
-itself, validated by the assertion's own evaluation. Because the check
-reads the SAME `project-evidence` projection the run-result slots derive
-from, a duplicate accumulator cannot report green while the tape is empty.
+The token→slot map lists ONLY tokens whose evidence slot is non-empty for
+EVERY healthy run of an assertion requiring them — so an empty slot
+genuinely means "proof promised, not delivered": `:effects → :effects`,
+`:schema → :schema-violations`, `:reactive-counts → :reactive-counts`
+(present only when the tape carried `:rf.sub/run` / `:rf.view/rendered`
+rows — a `:cljs-reactive` run whose tape carried none refuses,
+fail-closed), `:pixels`/`:a11y-engine` → browser-only oracle slots.
+
+The always-on / **empty-is-healthy** tokens are DELIBERATELY absent — they
+impose no post-run check because an empty slot is their NORMAL passing
+state, so a presence gate would emit a false `:cannot-run`:
+
+- `:app-db` — its proof is the final db itself, validated by the
+  assertion's own evaluation.
+- `:trace` — the trace stream is always-on; its only projections
+  (`:warnings`, `:schema-violations`) are FILTERED views, not a faithful
+  presence slot for the whole stream. `:rf.assert/no-warnings` PASSES when
+  `:warnings` is empty and `:rf.assert/dispatched?` proves against trace
+  DISPATCH rows, not warnings — so a `:trace → :warnings` gate would
+  false-refuse both healthy cases.
+- `:hiccup-structure` / `:dom` — `:renders` is empty whenever an assertion
+  legitimately asserts ABSENCE (`:rf.assert/dom-hidden`, a structural-a11y
+  check that finds no offending node). The runner-selection PREFLIGHT
+  already refuses these against a runner that cannot render; a post-run
+  render-count gate would only add false refusals.
+
+Because the check reads the SAME `project-evidence` projection the
+run-result slots derive from, a duplicate accumulator cannot report green
+while the tape is empty.
 
 ### MCP is a frame binding, not a runner tier
 

--- a/tools/story/src/re_frame/story/requirements.cljc
+++ b/tools/story/src/re_frame/story/requirements.cljc
@@ -553,27 +553,68 @@
 (def token->evidence-slots
   "Map each capability token to the run-evidence SLOT(S) whose PRESENCE in
   the projected evidence (`evidence/project-evidence`) proves the token was
-  actually exercised. A token with NO slot (e.g. `:app-db`, always present)
-  needs no post-run check — its proof is the final db itself, validated by
-  the assertion's own evaluation. Only tokens whose proof is a DISTINCT
+  actually exercised. A token with NO slot needs no post-run check — its
+  proof is the assertion's own evaluation, not a distinct stream the runner
+  could fail to produce.
+
+  ## The empty-slot-means-no-proof invariant
+
+  A token belongs here ONLY when an EMPTY/absent slot genuinely means the
+  runner promised a proof it never delivered — i.e. the slot is non-empty
+  for EVERY healthy run of an assertion requiring that token. The listed
+  tokens satisfy that:
+
+  - `:effects` / `:schema` — `:rf.assert/effect-emitted` /
+    `:rf.assert/schema-error` are HEALTHY only when the tape carried the
+    matching row; empty = the promised effect / schema-failure never
+    happened = genuinely no proof.
+  - `:reactive-counts` — present only when the tape carried `:rf.sub/run` /
+    `:rf.view/rendered` rows; absent means the reactive substrate was never
+    exercised, so a `:rf.assert/caused` / `:rf.assert/no-cascade-rerender`
+    run on it has no proof.
+  - `:pixels` / `:a11y-engine` — browser-only oracle streams; empty = no
+    screenshot / no axe scan = no proof.
+
+  ## Tokens DELIBERATELY absent (empty-is-HEALTHY — rf2-qoxw7)
+
+  Tokens whose slot is empty in the NORMAL passing case must NOT be listed —
+  keying a fail-closed presence check on them emits a FALSE `:cannot-run`
+  for healthy runs:
+
+  - `:trace` — the trace-event stream is always-on for any run; the only
+    projections `evidence/project-evidence` exposes (`:warnings`,
+    `:schema-violations`) are FILTERED views, not a faithful presence slot
+    for the whole stream. `:rf.assert/no-warnings` PASSES precisely when
+    `:warnings` is EMPTY, and `:rf.assert/dispatched?` proves against trace
+    DISPATCH rows, not warnings — so `:trace → :warnings` would false-refuse
+    both healthy cases. Its proof is the assertion's own trace evaluation.
+  - `:hiccup-structure` / `:dom` — `:renders` is empty whenever an assertion
+    legitimately asserts ABSENCE (`:rf.assert/dom-hidden`, a structural-a11y
+    check that finds no offending node) or runs against a tree that
+    committed no render row. The proof is the assertion's own inspection of
+    the rendered tree, not the COUNT of render rows. The runner-selection
+    preflight (`select-runner` / `unmet-assertions`) already fail-closes
+    these against a runner that cannot render at all; a post-run render-count
+    gate would only add false refusals.
+
+  Only tokens whose proof is a DISTINCT, always-non-empty-when-healthy
   evidence stream are listed; an empty/absent slot for a REQUIRED such token
   is the fail-closed trigger (spec/017 §`:cannot-run` — post-run validation
   confirms the required evidence slots are present)."
   {:effects          [:effects]
    :schema           [:schema-violations]
-   :trace            [:warnings]          ; trace-derived projection in evidence
    :reactive-counts  [:reactive-counts]   ; present only when the tape carried reactive rows
    :pixels           [:pixels]            ; browser-only slot — never present headless
-   :a11y-engine      [:a11y]              ; browser-only slot
-   :hiccup-structure [:renders]
-   :dom              [:renders]})
+   :a11y-engine      [:a11y]})            ; browser-only slot
 
 (defn evidence-slot-satisfied?
   "True iff EVERY evidence slot the `required-tokens` demand is POPULATED in
   the projected `evidence` map (`evidence/project-evidence` output). Pure
   data → data. A token with no entry in `token->evidence-slots` (e.g.
-  `:app-db`) imposes no slot requirement (its proof is the db itself). A
-  required token whose slot is absent / empty is NOT satisfied — the proof
+  `:app-db`, `:trace`, `:hiccup-structure` — the always-on / empty-is-healthy
+  tokens, see that map's docstring) imposes no slot requirement: its proof is
+  the assertion's own evaluation, not a distinct stream. A required token
+  whose slot IS in the map but is absent / empty is NOT satisfied — the proof
   was promised by the runner but the tape did not deliver it.
 
   This is the post-run half of the fail-closed contract: NEVER report a

--- a/tools/story/test/re_frame/story/requirements_test.cljc
+++ b/tools/story/test/re_frame/story/requirements_test.cljc
@@ -306,6 +306,80 @@
       (is (nil? (req/validate-evidence [:rf.assert/caused] ev :cljs-reactive))
           "evidence present → no refusal; the assertion's own verdict stands"))))
 
+;; ---------------------------------------------------------------------------
+;; rf2-qoxw7 — empty :trace / :renders is NOT no-proof. The trace stream is
+;; always-on and its :warnings projection is empty precisely when a
+;; :no-warnings / :dispatched? assertion is HEALTHY; :renders is empty when a
+;; DOM/structural assertion legitimately asserts ABSENCE. Keying a post-run
+;; presence gate on those slots would emit a false :cannot-run for the normal
+;; passing case. These tokens are deliberately absent from
+;; `token->evidence-slots`.
+;; ---------------------------------------------------------------------------
+
+(deftest trace-token-imposes-no-evidence-slot
+  (testing ":trace is NOT in the token->evidence-slots presence map (rf2-qoxw7)"
+    ;; :trace has no faithful presence slot — :warnings / :schema-violations
+    ;; are FILTERED projections, not the whole always-on trace stream.
+    (is (nil? (get req/token->evidence-slots :trace))
+        ":trace -> :warnings would false-refuse :no-warnings / :dispatched?")
+    (is (nil? (get req/token->evidence-slots :hiccup-structure))
+        "empty :renders is healthy for an absence assertion")
+    (is (nil? (get req/token->evidence-slots :dom))))
+
+  (testing ":no-warnings + :dispatched? require :trace"
+    (is (= #{:trace}          (req/assertion-tokens [:rf.assert/no-warnings])))
+    (is (= #{:app-db :trace}  (req/assertion-tokens [:rf.assert/dispatched? [:e]])))))
+
+(deftest no-warnings-on-clean-tape-is-not-cannot-run
+  (testing ":rf.assert/no-warnings on a clean (empty-:warnings) tape does NOT false-:cannot-run (rf2-qoxw7)"
+    ;; A clean headless run: one committed epoch, no warning trace events.
+    (let [tape [{:epoch-id 1 :outcome :ok :trace-events []}]
+          ev   (evidence/project-evidence tape)]
+      (is (empty? (:warnings ev)) "clean run → empty :warnings — the HEALTHY state")
+      ;; The whole point: an empty :warnings slot must NOT be read as
+      ;; "trace proof not delivered".
+      (is (req/evidence-slot-satisfied? #{:trace} ev)
+          ":trace imposes no slot, so an empty :warnings slot still satisfies")
+      (is (nil? (req/validate-evidence [:rf.assert/no-warnings] ev :headless))
+          "no false :required-evidence-missing — the assertion's own verdict (PASS) stands"))))
+
+(deftest dispatched-on-warning-free-tape-is-not-cannot-run
+  (testing ":rf.assert/dispatched? on a warning-free tape does NOT false-:cannot-run (rf2-qoxw7)"
+    ;; An event was dispatched (one epoch committed) but emitted no warning —
+    ;; :dispatched? proves against trace DISPATCH rows, not :warnings, so the
+    ;; empty :warnings slot is the wrong (and now removed) gate.
+    (let [tape [{:epoch-id 1 :outcome :ok
+                 :trigger-event [:counter/inc]
+                 :trace-events  [{:operation :rf.event/dispatch :op-type :info}]}]
+          ev   (evidence/project-evidence tape)]
+      (is (empty? (:warnings ev)) "dispatch with no warning → empty :warnings")
+      (is (req/evidence-slot-satisfied? #{:app-db :trace} ev))
+      (is (nil? (req/validate-evidence [:rf.assert/dispatched? [:counter/inc]]
+                                       ev :headless))
+          "no false refusal — the :app-db + :trace tokens impose no presence gate"))))
+
+(deftest dom-absence-assertion-is-not-cannot-run-on-empty-renders
+  (testing "a :dom assertion on a tape with no render rows does NOT false-:cannot-run (rf2-qoxw7)"
+    ;; :rf.assert/dom-hidden legitimately PASSES when an element is absent /
+    ;; the tree committed no render row; :renders is the wrong presence gate.
+    (let [ev (evidence/project-evidence [{:epoch-id 1 :outcome :ok :renders []}])]
+      (is (empty? (:renders ev)))
+      (is (req/evidence-slot-satisfied? #{:dom} ev)
+          ":dom imposes no render-count gate — preflight already fail-closes it")
+      (is (nil? (req/validate-evidence [:rf.assert/dom-hidden "[x]"] ev :dom))
+          "no false :required-evidence-missing for an absence assertion"))))
+
+(deftest validate-run-evidence-clean-trace-tape-is-ok
+  (testing "run-level validation of :no-warnings + :dispatched? on a clean tape is :ok (rf2-qoxw7)"
+    ;; The regression the bead pins: before the fix, validate-run-evidence
+    ;; would return :cannot-run for this normal passing plan once wired in.
+    (let [ev (evidence/project-evidence [{:epoch-id 1 :outcome :ok :trace-events []}])]
+      (is (= :ok (:status (req/validate-run-evidence
+                            [[:rf.assert/no-warnings]
+                             [:rf.assert/dispatched? [:counter/inc]]]
+                            ev :headless)))
+          "neither trace-requiring assertion false-refuses on empty :warnings"))))
+
 (deftest validate-run-evidence-aggregates-missing-slots
   (testing "run-level evidence validation lists per-assertion missing-evidence refusals"
     (let [ev (evidence/project-evidence [])]


### PR DESCRIPTION
## What

`tools/story/src/re_frame/story/requirements.cljc` `token->evidence-slots` mapped `:trace → [:warnings]`, and the post-run fail-closed check (`evidence-slot-satisfied?` / `validate-evidence` / `validate-run-evidence`) treats an EMPTY required slot as "proof not delivered" → `:cannot-run`. But two trace-requiring assertions are HEALTHY precisely when `:warnings` is empty:

- `:rf.assert/no-warnings` (requires `#{:trace}`) PASSES on zero warnings.
- `:rf.assert/dispatched?` (requires `#{:app-db :trace}`) proves against trace DISPATCH rows, not warnings.

So once `validate-run-evidence` is wired into the runner (rf2-baah3), both would emit a FALSE `:cannot-run` for their normal passing case. `:warnings` is a FILTERED projection of the always-on trace stream, not a faithful presence slot for `:trace` — `project-evidence` exposes no general trace-events slot, so `:trace` has no faithful presence-of-evidence slot at all.

The same empty-is-healthy problem applies to `:hiccup-structure`/`:dom → [:renders]`: an assertion that legitimately asserts ABSENCE (`:rf.assert/dom-hidden`, a structural-a11y check finding no offending node) or runs against a tree that committed no render row has empty `:renders` while passing. The runner-selection PREFLIGHT already fail-closes these against a non-rendering runner; a post-run render-count gate only adds false refusals.

## Fix

Drop `:trace`, `:hiccup-structure`, and `:dom` from `token->evidence-slots`. The map now lists ONLY tokens whose slot is non-empty for EVERY healthy run requiring them — so an empty slot genuinely means "proof promised, not delivered": `:effects`, `:schema`, `:reactive-counts`, `:pixels`, `:a11y-engine`. The dropped tokens are always-on / empty-is-healthy; their proof is the assertion's own evaluation (the same posture `:app-db` already had). No behaviour change today — `validate-run-evidence` is not yet wired into the runner — but it is now correct before .31 wires it.

Docstrings on `token->evidence-slots` and `evidence-slot-satisfied?` updated; `tools/story/spec/017-Testing-Story.md` §Fail-closed evidence-slot validation token→slot block updated to match.

## Tests

New tests in `requirements_test.cljc` proving a `:no-warnings` / `:dispatched?` assertion on a clean (empty-`:warnings`) tape does NOT false-`:cannot-run`, a `:dom-hidden` absence assertion on an empty-`:renders` tape does NOT false-`:cannot-run`, the dropped tokens impose no slot, and run-level `validate-run-evidence` of `:no-warnings` + `:dispatched?` on a clean tape is `:ok`.

## Quality gates

- `cd tools/story && clojure -M:test` → 1241 tests, 3936 assertions, 0 failures, 0 errors
- `cd tools/story-mcp && clojure -M:test` → 172 tests, 861 assertions, 0 failures, 0 errors
- `cd tools/mcp-conformance && npm run test:story` → STORY-MCP MCP-CLIENT CONFORMANCE GREEN (exit 0)
- `npm --prefix implementation run test:cljs` → 4850 tests, 15890 assertions, 0 failures, 0 errors
- `bash scripts/test-fast-pr.sh` → PASS fast PR spine (markdown link/anchor gates ran + passed; mkdocs soft-skipped locally)
