### PR TITLE
fix(story): thread :cannot-run refusals into the unified run-result (rf2-q5jw4)

### DIFF
--- a/tools/story/src/re_frame/story/play/runner.cljc
+++ b/tools/story/src/re_frame/story/play/runner.cljc
@@ -513,6 +513,39 @@
            :status      status
            :finished-ms now-ms)))
 
+(defn run-state-refusals
+  "The `:cannot-run` refusal records carried by a settled run-`state`'s
+  per-step `:results` — the same step-results `finish` inspects to decide
+  the run-state status (rf2-q5jw4). Pure data → data.
+
+  A refusal is a step-result a runner could not even ATTEMPT for its
+  declared capability (a no-DOM `[:assert-dom …]` / `[:click …]` skip, or a
+  boundary `:cannot-run?`), so it must propagate into the UNIFIED run-result
+  as the distinct THIRD status (spec/017 §`:cannot-run`), not vanish into a
+  vacuous green. Each refusal projects to the
+  `{:status :cannot-run :unit :reason :message}` shape the unified result's
+  `:unmet` slot folds (`re-frame.story.requirements/aggregate-status`):
+
+      {:status  :cannot-run
+       :unit    <step>           ; the step the runner could not attempt
+       :reason  :runner-cannot-attempt-step
+       :message <diagnostic>}    ; the step-result's :message, when present
+
+  This is the SINGLE bridge from the run-state's refusal facts to the
+  unified result, so the run-state and the unified `:status` cannot disagree
+  — the false-GREEN class rf2-5x1wt.19 set out to kill (a DOM-skip-only
+  variant read `:pass` via the unified result while the run-state read
+  `:cannot-run`). Empty when no step refused."
+  [state]
+  (into []
+        (comp (filter cannot-run-step?)
+              (map (fn [r]
+                     (cond-> {:status :cannot-run
+                              :unit   (:step r)
+                              :reason :runner-cannot-attempt-step}
+                       (:message r) (assoc :message (:message r))))))
+        (:results state)))
+
 (defn done?
   "True iff every step in `:script` has been processed."
   [{:keys [step-idx total]}]

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -48,6 +48,7 @@
             [re-frame.story.loaders   :as loaders]
             [re-frame.story.plan      :as plan]
             [re-frame.story.play      :as play]
+            [re-frame.story.play.runner :as runner]
             [re-frame.story.play.runner-events :as runner-events]
             [re-frame.story.registrar :as registrar]
             [re-frame.story.result    :as result]
@@ -462,6 +463,18 @@
         ;; (per `re-frame.core/epoch-history`'s contract) while the
         ;; `:test`-alias epoch dep makes it the live tape under the gate.
         tape     (vec (rf/epoch-history variant-id))
+        ;; rf2-q5jw4 — thread the run-state's `:cannot-run` refusals into the
+        ;; unified result's `:unmet` slot. The runner's per-step `:results`
+        ;; carry the SAME refusal facts `runner/finish` reads to compute the
+        ;; run-state status (a no-DOM `[:assert-dom …]` skip, a boundary
+        ;; `:cannot-run?`), but those steps record NO `:rf.story/assertions`
+        ;; entry — so without this the unified result aggregated to `:pass`
+        ;; (vacuous green) while the run-state read `:cannot-run`. Folding the
+        ;; refusals here makes both consumers agree (spec/017 §Unified run
+        ;; result — "a run whose only unmet expectations are :cannot-run is
+        ;; itself :cannot-run"). The facade degrades to nil run-state (and so
+        ;; an empty `:unmet`) on a host with no runner-events run-state.
+        unmet    (runner/run-state-refusals (runner-events/current-state variant-id))
         unified  (result/run-result
                    {:variant/id          variant-id
                     :epoch-tape          tape
@@ -475,6 +488,11 @@
                     ;; `:rf.story/assertions` accumulator.
                     :schema-expectations (plan-schema-expectations
                                            plan executed-script)
+                    ;; rf2-q5jw4 — the per-requirement `:cannot-run` refusals
+                    ;; the runner could not even attempt (above). Folded into
+                    ;; the verdict + surfaced on `:cannot-run` by
+                    ;; `result/run-result`.
+                    :unmet               unmet
                     :app-db              (or app-db {})
                     :elapsed-ms          (- (interop/now-ms) start-ms)})]
     (merge unified

--- a/tools/story/test/re_frame/story/play/runner_events_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/play/runner_events_cljs_test.cljc
@@ -346,6 +346,36 @@
              "a skipped (no-DOM) :assert-dom contributes no passing record")))))
 
 #?(:clj
+   (deftest assert-dom-skipped-unified-result-is-cannot-run
+     (testing "the UNIFIED run-result (story/run-variant's resolved value),
+              not just run-state, reads :cannot-run for a DOM-skip-only
+              variant on the headless JVM (rf2-q5jw4, spec/017 §Unified run
+              result). Before the fix record-result-map dropped the
+              run-state's :cannot-run refusals: a no-DOM [:assert-dom …] skip
+              records NO :rf.story/assertions entry, so result/run-result
+              aggregated zero records + a clean tape to :pass (vacuous
+              green) while run-state correctly read :cannot-run — the exact
+              consumer-disagreement false-GREEN .19 set out to kill. This
+              exercises the unified-result PATH (the existing
+              assert-dom-skipped-on-jvm-is-cannot-run test discards the
+              result and checks only run-blocking's run-state)."
+       (story/reg-variant :story.bridge/dom-skip-unified
+         {:events      []
+          :play-script {:script [[:assert-dom "div.foo" :visible]]}})
+       (let [result (async/deref-blocking
+                      (story/run-variant :story.bridge/dom-skip-unified) 5000)]
+         (is (= :cannot-run (:status result))
+             "the unified result :status is :cannot-run, NOT a vacuous :pass")
+         (is (seq (:cannot-run result))
+             "the unified result surfaces the run-state's :cannot-run refusals")
+         (is (false? (story/result-passed? result))
+             "story/result-passed? on the unified result is false — a
+              :cannot-run run proved nothing, so it is never a silent pass")
+         (is (empty? (filterv #(true? (:passed? %)) (:assertions result)))
+             "no assertion record reads :passed? true — the skip is not
+              folded into a green record")))))
+
+#?(:clj
    (deftest assert-db-pred-form
      (testing ":assert-db :pred folds to :rf.assert/path-matches [:fn sym];
               the symbol resolves at validation time (rf2-5x1wt.19)"


### PR DESCRIPTION
@
## What

`record-result-map` (`tools/story/src/re_frame/story/runtime.cljc`) assembled the unified run-result WITHOUT passing the `:unmet` slot that `result/run-result` accepts, so the run-state's `:cannot-run` refusals never reached the unified verdict. A DOM-skip-only variant on the headless JVM therefore aggregated to `:pass` (vacuous green) via `story/is` + Test mode — while `runner/finish`'s run-state correctly reported `:cannot-run` by inspecting the same per-step `:skipped?` / `:cannot-run?` results. Consumers disagreed → a resurfaced false-GREEN for DOM assertions under the default headless runner, the exact class rf2-5x1wt.19 set out to kill (spec/017 §Unified run result: "a run whose only unmet expectations are `:cannot-run` is itself `:cannot-run`").

## Fix

- `runner.cljc` — new pure helper `run-state-refusals`: projects a settled run-state's `:cannot-run` step-results (the SAME `cannot-run-step?` step-results `finish` reads) into the `{:status :cannot-run :unit :reason :message}` refusal shape the unified `:unmet` slot folds. One bridge from run-state truth to the unified result, so the two cannot disagree.
- `runtime.cljc` — `record-result-map` reads `runner-events/current-state` for the variant and threads `run-state-refusals` into `result/run-result`'s existing `:unmet` parameter. `aggregate-status` already folds a non-empty `:unmet` into `:cannot-run`, and `result/run-result` already surfaces it on `:cannot-run`. Degrades to an empty `:unmet` when there is no run-state (e.g. the error / loader-incomplete paths).

No change to `evidence.cljc` / `requirements.cljc` (sibling workers' lanes) or `ui/**`. No new test-only require into a production ns. The refusal predicate reuses the existing `runner/cannot-run-step?` semantics — no new (over-broad) predicate.

## Regression

`assert-dom-skipped-unified-result-is-cannot-run` exercises the UNIFIED-result PATH: `(:status @(story/run-variant <dom-skip-variant>))` is `:cannot-run` (not `:pass`), `:cannot-run` slot is populated, and `story/result-passed?` is false. The existing `assert-dom-skipped-on-jvm-is-cannot-run` discarded the result map and checked only `run-blocking`'s run-state, which is why this slipped through. Confirmed: the new test FAILS pre-fix (3 assertions: `:status` reads `:pass`, `:cannot-run` is nil, `result-passed?` is true) and PASSES post-fix.

## Quality gates

- `tools/story` `clojure -M:test` — 1237 tests, 3925 assertions, 0 failures, 0 errors
- `tools/story-mcp` `clojure -M:test` — 172 tests, 861 assertions, 0 failures, 0 errors
- `tools/mcp-conformance` `npm run test:story` — STORY-MCP CONFORMANCE GREEN (exit 0, 13 checks)
- `implementation` `npm run test:cljs` — 4865 tests, 15925 assertions, 0 failures, 0 errors
- `scripts/test-fast-pr.sh` — PASS fast PR spine
@