### PR TITLE
fix(story/diff): cover assertions/checks/warnings/sub-overrides/fidelity facets + non-empty-:facets invariant (rf2-rv9tt)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -2616,10 +2616,23 @@ Each facet is projected independently and contributes to the result **only
 when it differs**, so the diff localises *where* two runs parted and stays
 small:
 
+Every behavioural slot in the run-**slice** (`run-hash-input-keys`, the
+surface `:same?` is judged over) is covered by a facet, so a diff the gate
+calls different always localises *where*:
+
 - `:app-db` — a readable key-path delta of the final app-db
   (`:added` / `:removed` / `:changed`, each entry a `{:path … :baseline …
   :current …}` over the differing leaf paths) — a 100-key db with one changed
   key yields a one-entry delta, never a database dump;
+- `:assertions` — a **verdict** delta over the assertion records, keyed by
+  the stable assertion selector `[:assertion :payload]`
+  (`:added` / `:removed` selectors + `:changed` verdict flips, each entry a
+  `{:selector … :baseline … :current …}`) — a `:pass` → `:fail` flip on one
+  assertion reads as a one-entry `:changed`, not a wall of records, and the
+  `:payload` disambiguates two same-id assertions at different paths;
+- `:checks` — a verdict delta over the check records, keyed by the `:check`
+  id (the same `:added` / `:removed` / `:changed` shape) — the check identity
+  is its id, not its underlying assertion records;
 - `:effects` — a **multiset** delta of the projected effect rows
   (`:only-baseline` / `:only-current`) — the effects one run emitted and the
   other did not (emitting an effect twice vs once IS a difference);
@@ -2628,13 +2641,35 @@ small:
   `[:app-db registered-path path]`, …), not the full diagnostic records, so a
   re-ordered-but-equal set of violations is not a diff while a genuinely-new
   failure surface is;
+- `:warnings` — a multiset delta over the projected warning rows
+  (`:op-type :warning`, `:only-baseline` / `:only-current`) — the warnings one
+  run raised and the other did not;
 - `:trace-ops` — the ordered trace `:operation` sequence (the causal op
-  spine), reported as both spines plus the `:first-divergence` index — order
-  is semantic, so a re-ordered or dropped op reads as a difference;
+  spine) projected from `:epoch-tape`, reported as both spines plus the
+  `:first-divergence` index — order is semantic, so a re-ordered or dropped op
+  reads as a difference;
+- `:sub-overrides` — a delta over the resolved `{query-vector value}` override
+  map (§View-state subscription overrides), keyed by query vector
+  (`:added` / `:removed` / `:changed`, each entry a `{:query … :baseline …
+  :current …}`) — an override added/removed or whose pinned value differs;
+- `:fidelity` — a **set** delta over the fidelity-ladder rung set
+  (`:only-baseline` / `:only-current`) — the rungs one run rested on and the
+  other did not (e.g. a baseline using `:real-setup` vs a current that fell
+  back to `:sub-overrides`);
 - `:sub-runs` — a multiset delta over the projected subscription / view
-  facts, when available;
+  facts, when available (a diagnostic facet — `:sub-runs` is **not** in the
+  run-slice, so it never decides `:same?`);
 - `:status` — the top-level run status, when it differs (a `:pass` → `:fail`
   flip is the headline a reader wants first).
+
+**The non-empty-`:facets` invariant.** A `:same? false` diff ALWAYS carries a
+non-empty `:facets`. The per-surface facets above cover every run-slice slot,
+but should some slice slot ever diverge with no specific facet firing (an
+`:epoch-tape` change that is not a trace-op delta, or a future slice key added
+without its facet), the assembler falls back to a coarse `:slice-keys` facet
+naming WHICH `run-hash-input-keys` slot perturbed the judgement
+(`[{:slice-key k} …]`). A diff NEVER returns `{:same? false :facets #{}}` — an
+undiagnosable verdict that says two runs differ without saying how.
 
 ### A readable diff, not a data dump
 
@@ -2646,9 +2681,11 @@ volatile noise.
 
 ### Pure / JVM-testable
 
-The facet diff fns (`diff-app-db`, `diff-effects`, `diff-schema-violations`,
-`diff-trace-ops`, `diff-sub-runs`) and the assembler (`diff-runs`) are pure
-data → data — two run-results in, a readable diff out — and run under
+The facet diff fns (`diff-app-db`, `diff-assertions`, `diff-checks`,
+`diff-effects`, `diff-schema-violations`, `diff-warnings`, `diff-trace-ops`,
+`diff-sub-overrides`, `diff-fidelity`, `diff-sub-runs`) and the assembler
+(`diff-runs`) are pure data → data — two run-results in, a readable diff out
+— and run under
 `clojure -M:test` with no runtime; only the artifact-replay entry path is
 impure, and when both inputs are run-results `diff-run-artifacts` is itself
 pure. The facet fns receive the **noise-stripped but shape-preserved**

--- a/tools/story/src/re_frame/story/diff.cljc
+++ b/tools/story/src/re_frame/story/diff.cljc
@@ -81,7 +81,8 @@
   `diff-trace-ops`, `diff-sub-runs`) and the assembler (`diff-runs`) are pure
   data → data: two run-results in, a readable diff out. `diff-run-artifacts`
   is the thin replay-then-`diff-runs` wrapper for the artifact inputs."
-  (:require [re-frame.story.artifact      :as artifact]
+  (:require [clojure.set                  :as set]
+            [re-frame.story.artifact      :as artifact]
             [re-frame.story.fingerprint   :as fingerprint]
             [re-frame.story.play.evidence :as evidence]))
 
@@ -297,6 +298,185 @@
       {:baseline a :current b})))
 
 ;; ===========================================================================
+;; WARNINGS DELTA  (multiset of warning records)
+;; ===========================================================================
+;;
+;; `:warnings` is the tape's projected `:op-type :warning` rows
+;; (`re-frame.story.play.evidence/warnings`) — one record per emitted
+;; warning, in tape order. A semantic difference is a warning one run raised
+;; and the other did not, so the delta is the same MULTISET shape as effects
+;; / sub-runs (a warning raised twice on one side and once on the other IS a
+;; difference). Both sides are noise-stripped, so equal records compare `=`.
+
+(defn diff-warnings
+  "Multiset delta over the two runs' projected `:warnings` rows (spec/017
+  §Semantic diff). Pure data → data; `nil` when the warning multisets match,
+  else `{:only-baseline […] :only-current […]}` — the warning records one
+  run raised and the other did not."
+  [baseline current]
+  (multiset-delta (:warnings baseline) (:warnings current)))
+
+;; ===========================================================================
+;; VERDICT DELTA  (assertions / checks — keyed by stable identity)
+;; ===========================================================================
+;;
+;; Assertions and checks are ordered vectors of verdict-bearing records whose
+;; IDENTITY is a stable selector (an assertion is `[:assertion :payload]`; a
+;; check is its `:check` id), not the whole record (whose `:reason` /
+;; `:expected` / `:actual` are diagnostic detail). The semantic difference is
+;; a record one run produced and the other did not, OR a record whose VERDICT
+;; (`:status`) flipped between the runs. So the delta is keyed by selector and
+;; carries three buckets: `:added` / `:removed` selectors, and `:changed`
+;; verdict flips. This mirrors the `diff-app-db` added/removed/changed shape
+;; rather than inventing a new diff vocabulary.
+
+(defn- verdict-delta
+  "Verdict delta between two selector→status maps. Pure data → data. Returns
+  `nil` when the maps are `=`, else a `cond->`-built map carrying ONLY the
+  non-empty buckets:
+
+      {:added   [{:selector … :current  status} …]   ; in current, not baseline
+       :removed [{:selector … :baseline status} …]   ; in baseline, not current
+       :changed [{:selector … :baseline a :current b} …]}  ; verdict flipped
+
+  Selectors are ordered by `pr-str` (a total, type-safe order over
+  heterogeneous selectors — a selector may mix keyword / vector / number, so
+  raw `sort` could throw)."
+  [baseline-by-sel current-by-sel]
+  (when (not= baseline-by-sel current-by-sel)
+    (let [base-sels (set (keys baseline-by-sel))
+          cur-sels  (set (keys current-by-sel))
+          added     (sort-by pr-str (remove base-sels cur-sels))
+          removed   (sort-by pr-str (remove cur-sels base-sels))
+          changed   (sort-by pr-str
+                             (filter (fn [s]
+                                       (and (contains? baseline-by-sel s)
+                                            (not= (baseline-by-sel s)
+                                                  (current-by-sel s))))
+                                     cur-sels))]
+      (cond-> {}
+        (seq added)   (assoc :added
+                             (mapv (fn [s] {:selector s
+                                            :current  (current-by-sel s)}) added))
+        (seq removed) (assoc :removed
+                             (mapv (fn [s] {:selector s
+                                            :baseline (baseline-by-sel s)}) removed))
+        (seq changed) (assoc :changed
+                             (mapv (fn [s] {:selector s
+                                            :baseline (baseline-by-sel s)
+                                            :current  (current-by-sel s)})
+                                   changed))))))
+
+(defn- assertions-by-selector
+  "Map every assertion record in a run to its `:status`, keyed by the stable
+  assertion selector `[:assertion :payload]`. Pure data → data. A duplicate
+  selector keeps the LAST record's status (verdicts of equal-identity
+  assertions agree by construction — the §Schema-rule multiset pairing mints
+  one record per consumed violation)."
+  [run]
+  (into {}
+        (map (fn [a] [[(:assertion a) (vec (:payload a))] (:status a)]))
+        (:assertions run)))
+
+(defn diff-assertions
+  "Verdict delta over the two runs' `:assertions` records, keyed by the
+  stable assertion selector `[:assertion :payload]` (spec/017 §Semantic diff).
+  Pure data → data; `nil` when both runs evaluated the same assertions to the
+  same verdicts, else the `verdict-delta` shape (`:added` / `:removed`
+  selectors + `:changed` verdict flips). A `:pass` → `:fail` flip on one
+  assertion reads as a one-entry `:changed`, not a wall of records."
+  [baseline current]
+  (verdict-delta (assertions-by-selector baseline)
+                 (assertions-by-selector current)))
+
+(defn- checks-by-id
+  "Map every check record in a run to its `:status`, keyed by the `:check`
+  id. Pure data → data."
+  [run]
+  (into {}
+        (map (fn [c] [(:check c) (:status c)]))
+        (:checks run)))
+
+(defn diff-checks
+  "Verdict delta over the two runs' `:checks` records, keyed by the `:check`
+  id (spec/017 §Semantic diff). Pure data → data; `nil` when both runs ran
+  the same checks to the same verdicts, else the `verdict-delta` shape
+  (`:added` / `:removed` check ids + `:changed` verdict flips)."
+  [baseline current]
+  (verdict-delta (checks-by-id baseline) (checks-by-id current)))
+
+;; ===========================================================================
+;; SUB-OVERRIDES DELTA  (the resolved render-path override map)
+;; ===========================================================================
+;;
+;; `:sub-overrides` is the resolved `{query-vector value}` map (spec/017
+;; §View-state subscription overrides) — the third, lower-fidelity rung the
+;; render path consults. A semantic difference is an override one run carried
+;; and the other did not, or one whose pinned VALUE differs. The query vector
+;; is the identity (each override key is an exact query vector), so the delta
+;; is keyed by query vector with added / removed / changed buckets.
+
+(defn diff-sub-overrides
+  "Delta between two runs' resolved `:sub-overrides` maps (spec/017
+  §View-state subscription overrides), keyed by the override's query vector.
+  Pure data → data; `nil` when the override maps are `=`, else:
+
+      {:added   [{:query … :current  v} …]   ; override only in current
+       :removed [{:query … :baseline v} …]   ; override only in baseline
+       :changed [{:query … :baseline a :current b} …]}  ; pinned value differs
+
+  Query vectors are ordered by `pr-str` for a stable, type-safe order."
+  [baseline current]
+  (let [base (or (:sub-overrides baseline) {})
+        cur  (or (:sub-overrides current) {})]
+    (when (not= base cur)
+      (let [base-qs (set (keys base))
+            cur-qs  (set (keys cur))
+            added   (sort-by pr-str (remove base-qs cur-qs))
+            removed (sort-by pr-str (remove cur-qs base-qs))
+            changed (sort-by pr-str
+                             (filter (fn [q] (and (contains? base q)
+                                                  (not= (base q) (cur q))))
+                                     cur-qs))]
+        (cond-> {}
+          (seq added)   (assoc :added
+                               (mapv (fn [q] {:query q :current (cur q)}) added))
+          (seq removed) (assoc :removed
+                               (mapv (fn [q] {:query q :baseline (base q)}) removed))
+          (seq changed) (assoc :changed
+                               (mapv (fn [q] {:query    q
+                                              :baseline (base q)
+                                              :current  (cur q)})
+                                     changed)))))))
+
+;; ===========================================================================
+;; FIDELITY DELTA  (the fidelity-ladder rung set)
+;; ===========================================================================
+;;
+;; `:fidelity` is a SET of the rungs a resolved plan rests on
+;; (`#{:real-setup :db-seed :sub-overrides}`, spec/017 §View-state
+;; subscription overrides — fidelity ladder). A semantic difference is a rung
+;; one run rested on and the other did not, so the delta is a set delta
+;; naming the rungs each side carried uniquely.
+
+(defn diff-fidelity
+  "Set delta over the two runs' `:fidelity` rung sets (spec/017 §View-state
+  subscription overrides — fidelity ladder). Pure data → data; `nil` when the
+  rung sets match, else `{:only-baseline #{rung …} :only-current #{rung …}}`
+  — the fidelity rungs one run rested on and the other did not (e.g. a
+  baseline that used `:real-setup` vs a current that fell back to
+  `:sub-overrides`)."
+  [baseline current]
+  (let [base (set (:fidelity baseline))
+        cur  (set (:fidelity current))]
+    (when (not= base cur)
+      (cond-> {}
+        (seq (set/difference base cur))
+        (assoc :only-baseline (set/difference base cur))
+        (seq (set/difference cur base))
+        (assoc :only-current (set/difference cur base))))))
+
+;; ===========================================================================
 ;; THE ASSEMBLER  (pure — two run-results → readable diff)
 ;; ===========================================================================
 
@@ -313,18 +493,49 @@
   [run]
   (fingerprint/project (fingerprint/strip-run-stamps run)))
 
+(defn- diverging-slice-keys
+  "The `fingerprint/run-hash-input-keys` slots whose CANONICAL projection
+  differs between two run-results. Pure data → data. Each slot is
+  canonicalized in isolation (the same projection `:same?` uses over the
+  whole slice), so this names exactly which run-hash slot perturbed the
+  hash. Returns an ordered (slice-order) vector of `{:slice-key …}` entries —
+  empty only when the slice slots all match (which the `:same?` test already
+  ruled out by the time this is consulted)."
+  [baseline current]
+  (into []
+        (comp (filter (fn [k]
+                        (not= (fingerprint/canonicalize (get baseline k))
+                              (fingerprint/canonicalize (get current k)))))
+              (map (fn [k] {:slice-key k})))
+        fingerprint/run-hash-input-keys))
+
 (def facet-fns
   "The ordered facet name → diff-fn map (spec §Semantic diff). Ordered so
-  the headline facets (`:status`, `:app-db`) read first. Each fn takes the
-  two NOISE-STRIPPED run-results (`strip-noise`) and returns the facet's
-  readable delta or `nil` (no difference). A new facet is added here once and
-  flows into `diff-runs` and `:facets` automatically."
+  the headline facets (`:status`, `:app-db`, the `:assertions` / `:checks`
+  verdicts) read first. Each fn takes the two NOISE-STRIPPED run-results
+  (`strip-noise`) and returns the facet's readable delta or `nil` (no
+  difference). A new facet is added here once and flows into `diff-runs` and
+  `:facets` automatically.
+
+  EVERY behavioural slot in `re-frame.story.fingerprint/run-hash-input-keys`
+  (the slice `:same?` is judged over) is covered by a facet here, so a diff
+  the gate calls different always localises WHERE. `:trace-ops` covers the
+  `:epoch-tape` slot's causal op spine; `:sub-runs` is NOT a slice key (it is
+  diagnostic, excluded from the run-hash slice — rf2-e6uod) but is kept as a
+  useful view-fact facet. Any residual divergence with no specific facet is
+  caught by `diff-runs`' coarse slice-key fallback (the non-empty-`:facets`
+  invariant)."
   (array-map
     :status            diff-status
     :app-db            (fn [b c] (diff-app-db (:app-db b) (:app-db c)))
+    :assertions        diff-assertions
+    :checks            diff-checks
     :effects           diff-effects
     :schema-violations diff-schema-violations
+    :warnings          diff-warnings
     :trace-ops         diff-trace-ops
+    :sub-overrides     diff-sub-overrides
+    :fidelity          diff-fidelity
     :sub-runs          diff-sub-runs))
 
 (defn diff-runs
@@ -352,6 +563,13 @@
   `:facets` set names them up front so a consumer can branch without probing
   each slot.
 
+  INVARIANT (rf2-rv9tt): a `:same? false` diff ALWAYS carries a non-empty
+  `:facets`. The per-surface facets cover every `run-hash-input-keys` slot,
+  but if some slice slot ever diverges with no specific facet firing, the
+  coarse `:slice-keys` fallback names WHICH `run-hash-input-keys` slot
+  perturbed the judgement (`[{:slice-key k} …]`) — never `{:same? false
+  :facets #{}}`, which would be an undiagnosable diff.
+
   The `:same?` judgement is canonical equality of the run-SLICE
   (`fingerprint/run-hash-input-keys` — the behavioural surface, NOT the whole
   result), the EXACT slice + judgement `re-frame.story.determinism/compare-runs`
@@ -377,7 +595,15 @@
                        (assoc acc facet d)
                        acc))
                    {}
-                   facet-fns)]
+                   facet-fns)
+          ;; The non-empty-:facets invariant (rf2-rv9tt): the per-surface
+          ;; facets cover every run-hash slice slot, but if NONE fired the
+          ;; canonical forms still differ — so localise the divergence to the
+          ;; specific `run-hash-input-keys` slot(s) rather than returning an
+          ;; undiagnosable `{:same? false :facets #{}}`.
+          deltas (if (seq deltas)
+                   deltas
+                   {:slice-keys (diverging-slice-keys b c)})]
       (assoc deltas
              :same?  false
              :facets (set (keys deltas))))))

--- a/tools/story/test/re_frame/story/diff_test.cljc
+++ b/tools/story/test/re_frame/story/diff_test.cljc
@@ -162,6 +162,110 @@
     (is (nil? (diff/diff-status {:status :pass} {:status :pass})))))
 
 ;; ===========================================================================
+;; PURE: warnings / assertions / checks / sub-overrides / fidelity facets
+;; (rf2-rv9tt — the run-hash slice slots that previously had NO facet)
+;; ===========================================================================
+
+(deftest diff-warnings-multiset-delta
+  (testing "identical warning rows produce no delta"
+    (let [w {:operation :slow-sub :category :performance}]
+      (is (nil? (diff/diff-warnings {:warnings [w]} {:warnings [w]})))))
+
+  (testing "a warning raised only by baseline is :only-baseline"
+    (let [d (diff/diff-warnings
+              {:warnings [{:operation :slow-sub :category :performance}]}
+              {:warnings []})]
+      (is (= [{:operation :slow-sub :category :performance}] (:only-baseline d)))
+      (is (nil? (:only-current d))))))
+
+(deftest diff-assertions-verdict-delta
+  (testing "the same assertion verdict on both sides is no diff"
+    (let [a {:assertion :rf.assert/path-equals :payload [[:n] 1] :status :pass}]
+      (is (nil? (diff/diff-assertions {:assertions [a]} {:assertions [a]})))))
+
+  (testing "a pass → fail verdict flip is a one-entry :changed keyed by selector"
+    (let [d (diff/diff-assertions
+              {:assertions [{:assertion :rf.assert/path-equals :payload [[:n] 1]
+                             :status :pass}]}
+              {:assertions [{:assertion :rf.assert/path-equals :payload [[:n] 1]
+                             :status :fail}]})]
+      (is (= [{:selector [:rf.assert/path-equals [[:n] 1]]
+               :baseline :pass :current :fail}]
+             (:changed d)))
+      (is (nil? (:added d)))
+      (is (nil? (:removed d)))))
+
+  (testing "an assertion only current evaluated is :added by selector"
+    (let [d (diff/diff-assertions
+              {:assertions []}
+              {:assertions [{:assertion :rf.assert/no-warnings :payload []
+                             :status :fail}]})]
+      (is (= [{:selector [:rf.assert/no-warnings []] :current :fail}] (:added d)))))
+
+  (testing "the payload disambiguates two same-id assertions at different paths"
+    (let [d (diff/diff-assertions
+              {:assertions [{:assertion :rf.assert/path-equals :payload [[:a] 1]
+                             :status :pass}
+                            {:assertion :rf.assert/path-equals :payload [[:b] 2]
+                             :status :pass}]}
+              {:assertions [{:assertion :rf.assert/path-equals :payload [[:a] 1]
+                             :status :pass}
+                            {:assertion :rf.assert/path-equals :payload [[:b] 2]
+                             :status :fail}]})]
+      (is (= [{:selector [:rf.assert/path-equals [[:b] 2]]
+               :baseline :pass :current :fail}]
+             (:changed d))
+          "only the [:b] assertion flipped — the [:a] one is silent"))))
+
+(deftest diff-checks-verdict-delta
+  (testing "the same check verdict on both sides is no diff"
+    (let [c {:check :checkout/valid :status :pass :assertions []}]
+      (is (nil? (diff/diff-checks {:checks [c]} {:checks [c]})))))
+
+  (testing "a check that flipped pass → fail is a one-entry :changed by check id"
+    (let [d (diff/diff-checks
+              {:checks [{:check :checkout/valid :status :pass :assertions []}]}
+              {:checks [{:check :checkout/valid :status :fail :assertions []}]})]
+      (is (= [{:selector :checkout/valid :baseline :pass :current :fail}]
+             (:changed d))
+          "the check identity is its id; the underlying records are not the key"))))
+
+(deftest diff-sub-overrides-keyed-delta
+  (testing "identical override maps produce no delta"
+    (let [m {[:login/state] :error}]
+      (is (nil? (diff/diff-sub-overrides {:sub-overrides m} {:sub-overrides m})))))
+
+  (testing "an override whose pinned value differs is :changed by query vector"
+    (let [d (diff/diff-sub-overrides
+              {:sub-overrides {[:login/state] :error}}
+              {:sub-overrides {[:login/state] :loading}})]
+      (is (= [{:query [:login/state] :baseline :error :current :loading}]
+             (:changed d)))))
+
+  (testing "an override only current carries is :added"
+    (let [d (diff/diff-sub-overrides
+              {:sub-overrides {}}
+              {:sub-overrides {[:item 7] {:name "x"}}})]
+      (is (= [{:query [:item 7] :current {:name "x"}}] (:added d))))))
+
+(deftest diff-fidelity-set-delta
+  (testing "identical fidelity rung sets produce no delta"
+    (is (nil? (diff/diff-fidelity {:fidelity #{:real-setup}}
+                                  {:fidelity #{:real-setup}}))))
+
+  (testing "a rung current rested on but baseline did not is :only-current"
+    (let [d (diff/diff-fidelity {:fidelity #{:real-setup}}
+                                {:fidelity #{:real-setup :sub-overrides}})]
+      (is (= #{:sub-overrides} (:only-current d)))
+      (is (nil? (:only-baseline d)))))
+
+  (testing "rungs on each side that the other lacks are split"
+    (let [d (diff/diff-fidelity {:fidelity #{:real-setup}}
+                                {:fidelity #{:sub-overrides}})]
+      (is (= #{:real-setup} (:only-baseline d)))
+      (is (= #{:sub-overrides} (:only-current d))))))
+
+;; ===========================================================================
 ;; PURE: the assembler — :same? and the multi-facet readable diff
 ;; ===========================================================================
 
@@ -192,6 +296,112 @@
       (is (= #{:status :effects} (:facets d)))
       (is (= {:baseline :pass :current :fail} (:status d)))
       (is (= [{:fx :http/get :outcome :error}] (get-in d [:effects :only-current]))))))
+
+;; ===========================================================================
+;; PURE: the assembler covers EVERY run-hash slice slot (rf2-rv9tt)
+;; — each previously-silent surface now names its facet through diff-runs
+;; ===========================================================================
+
+(deftest diff-runs-covers-every-slice-surface
+  (testing "a warnings-ONLY delta surfaces the :warnings facet (was {:facets #{}})"
+    (let [base {:status :pass :warnings []}
+          cur  {:status :pass :warnings [{:operation :slow-sub :category :perf}]}
+          d    (diff/diff-runs base cur)]
+      (is (false? (:same? d)))
+      (is (= #{:warnings} (:facets d)))
+      (is (seq (:facets d)) "the previously-silent warnings delta is now named")))
+
+  (testing "an assertions-ONLY verdict flip surfaces the :assertions facet"
+    (let [base {:status :pass :assertions [{:assertion :rf.assert/eq :payload [1 1]
+                                            :status :pass}]}
+          cur  {:status :pass :assertions [{:assertion :rf.assert/eq :payload [1 1]
+                                            :status :fail}]}
+          d    (diff/diff-runs base cur)]
+      (is (false? (:same? d)))
+      (is (= #{:assertions} (:facets d)))
+      (is (= [{:selector [:rf.assert/eq [1 1]] :baseline :pass :current :fail}]
+             (get-in d [:assertions :changed])))))
+
+  (testing "a checks-ONLY verdict flip surfaces the :checks facet"
+    (let [base {:status :pass :checks [{:check :c/login :status :pass :assertions []}]}
+          cur  {:status :pass :checks [{:check :c/login :status :fail :assertions []}]}
+          d    (diff/diff-runs base cur)]
+      (is (false? (:same? d)))
+      (is (= #{:checks} (:facets d)))))
+
+  (testing "a sub-overrides-ONLY delta surfaces the :sub-overrides facet"
+    (let [base {:status :pass :sub-overrides {[:login/state] :error}}
+          cur  {:status :pass :sub-overrides {[:login/state] :loading}}
+          d    (diff/diff-runs base cur)]
+      (is (false? (:same? d)))
+      (is (= #{:sub-overrides} (:facets d)))))
+
+  (testing "a fidelity-ONLY delta surfaces the :fidelity facet"
+    (let [base {:status :pass :fidelity #{:real-setup}}
+          cur  {:status :pass :fidelity #{:real-setup :sub-overrides}}
+          d    (diff/diff-runs base cur)]
+      (is (false? (:same? d)))
+      (is (= #{:fidelity} (:facets d))))))
+
+;; ===========================================================================
+;; PURE: the non-empty-:facets INVARIANT (rf2-rv9tt — the masterpiece guarantee)
+;; ===========================================================================
+
+(deftest diff-runs-never-returns-empty-facets
+  (testing "an :epoch-tape divergence that is NOT a trace-op change falls back
+            to a coarse :slice-keys facet naming the diverging slot"
+    ;; The trace-op spine is identical (both have op :go); the divergence is a
+    ;; NON-op epoch field. No specific facet fires, so the invariant fallback
+    ;; must name the :epoch-tape slice key rather than return :facets #{}.
+    (let [base {:status :pass
+                :epoch-tape [{:epoch-id 1 :outcome :ok :db-after {:n 1}
+                              :trace-events [{:operation :go :op-type :event}]}]}
+          cur  {:status :pass
+                :epoch-tape [{:epoch-id 1 :outcome :ok :db-after {:n 2}
+                              :trace-events [{:operation :go :op-type :event}]}]}
+          d    (diff/diff-runs base cur)]
+      (is (false? (:same? d)))
+      (is (seq (:facets d)) "INVARIANT: :same? false ⟹ :facets non-empty")
+      (is (= #{:slice-keys} (:facets d)))
+      (is (= [{:slice-key :epoch-tape}] (:slice-keys d))
+          "the coarse fallback names WHICH run-hash slot perturbed the judgement")))
+
+  (testing "INVARIANT property: across many slice-key perturbations, a
+            :same? false diff NEVER carries an empty :facets set"
+    ;; One perturbation per run-hash slice key — the exact slice :same? is
+    ;; judged over. Each must yield a non-empty :facets (a named facet or the
+    ;; coarse fallback), never the undiagnosable {:same? false :facets #{}}.
+    (let [base {:status     :pass
+                :app-db     {:n 1}
+                :epoch-tape [{:epoch-id 1 :outcome :ok :db-after {:n 1}
+                              :effects [] :sub-runs []
+                              :trace-events [{:operation :go :op-type :event}]}]
+                :assertions [{:assertion :rf.assert/eq :payload [1 1] :status :pass}]
+                :checks     [{:check :c/x :status :pass :assertions []}]
+                :effects    [{:fx :http/get}]
+                :schema-violations []
+                :warnings   []
+                :sub-overrides {}
+                :fidelity   #{:real-setup}}
+          perturbations
+          [(assoc base :status :fail)
+           (assoc base :app-db {:n 2})
+           (update base :epoch-tape
+                   (fn [t] (assoc-in t [0 :trace-events]
+                                     [{:operation :stop :op-type :event}])))
+           (assoc base :assertions [{:assertion :rf.assert/eq :payload [1 1]
+                                     :status :fail}])
+           (assoc base :checks [{:check :c/x :status :fail :assertions []}])
+           (assoc base :effects [{:fx :analytics/track}])
+           (assoc base :schema-violations [{:selector [:event :go]}])
+           (assoc base :warnings [{:operation :slow :category :perf}])
+           (assoc base :sub-overrides {[:login/state] :error})
+           (assoc base :fidelity #{:real-setup :sub-overrides})]]
+      (doseq [cur perturbations]
+        (let [d (diff/diff-runs base cur)]
+          (is (false? (:same? d)) (str "perturbation should differ: " (pr-str cur)))
+          (is (seq (:facets d))
+              (str "INVARIANT VIOLATED — empty :facets for: " (pr-str cur))))))))
 
 ;; ===========================================================================
 ;; PURE: the load-bearing property — volatile noise is stripped FIRST


### PR DESCRIPTION
## What

`diff-runs` judged `:same?` over the full `run-hash-input-keys` slice
(`#{:status :app-db :epoch-tape :assertions :checks :effects :schema-violations :warnings :sub-overrides :fidelity}`)
but the facet-fns only covered `:status :app-db :effects :schema-violations :trace-ops`.
Two runs differing ONLY in `:assertions` / `:checks` / `:warnings` /
`:sub-overrides` / `:fidelity` returned the **undiagnosable**
`{:same? false :facets #{}}` — contradicting the spec/017 §Semantic-diff
contract ("carrying ONLY the facets that differ"). This is consumed by
`compare-golden`, so a golden mismatch on those surfaces produced an empty
report.

Verified on the JVM pre-fix: `:warnings` / `:assertions` / `:checks` /
`:sub-overrides` / `:fidelity` only-deltas all returned `{:same? false :facets #{}}`.

## The fix

New facet fns for the uncovered slice surfaces, reusing existing patterns
(no new diff shape invented):

- `diff-warnings`      — **multiset** delta over the projected warning rows (like `:effects` / `:sub-runs`)
- `diff-assertions`    — **verdict** delta keyed by the stable selector `[:assertion :payload]` (`:added` / `:removed` / `:changed` verdict flips)
- `diff-checks`        — verdict delta keyed by `:check` id (same shape)
- `diff-sub-overrides` — keyed delta over the resolved `{query-vector value}` map
- `diff-fidelity`      — **set** delta over the fidelity-ladder rung set

**The masterpiece guarantee — the non-empty-`:facets` invariant:** `diff-runs`
NEVER returns `:same? false` with an empty `:facets`. If some slice slot
diverges with no specific facet firing (an `:epoch-tape` change that is not a
trace-op delta, or a future slice key added without its facet), it falls back
to a coarse `:slice-keys` facet naming WHICH `run-hash-input-keys` slot
perturbed the judgement (`[{:slice-key k} …]`).

Note (sibling rf2-e6uod): `:sub-runs` is intentionally NOT a slice key — it
stays a diagnostic facet and never decides `:same?`. No facet was added for a
non-slice key.

## Tests

- Per-facet unit tests for warnings / assertions / checks / sub-overrides / fidelity.
- Assembler tests proving each previously-silent surface now yields a
  non-empty `:facets` through `diff-runs`.
- Invariant tests: an `:epoch-tape` non-op divergence falls back to
  `:slice-keys`; a property test pins `:same? false` => `:facets` non-empty
  across one perturbation per slice key.
- Fails-pre confirmed via live JVM repro; passes-post in the suite.

## Spec

`tools/story/spec/017-Testing-Story.md` §Semantic diff updated: the
now-covered surfaces and the non-empty-`:facets` invariant.

## Quality gates

- `tools/story` `clojure -M:test` — **GREEN** (1250 tests, 4001 assertions, 0 failures / 0 errors)
- `tools/story-mcp` `clojure -M:test` — **GREEN** (172 tests, 861 assertions, 0 / 0)
- `tools/mcp-conformance` `npm run test:story` — **GREEN** (STORY-MCP MCP-CLIENT CONFORMANCE GREEN)
- `implementation` `npm run test:cljs` — **GREEN** (4865 tests, 15925 assertions, 0 / 0)
- `scripts/test-fast-pr.sh` — **PASS**