### PR TITLE
feat(story): deeper checks + generated artifact flows (rf2-5x1wt.31)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -1192,6 +1192,47 @@ not a new core seam — so these assertions run under the `:cljs-reactive`
 runner (and `:cannot-run` under `:headless` / `:hiccup`, which do not
 flush reactions).
 
+#### Causal and cascade assertions (rf2-5x1wt.31)
+
+`:rf.assert/caused` and `:rf.assert/no-cascade-rerender` are **causal**
+assertions: they project a CAUSE→EFFECT relationship from the SAME reactive
+evidence the tape already carries — the `:rf.sub/run` / `:rf.view/rendered`
+rows stamped with the dispatching cascade's `:cause-event-id` (Spec 009
+§`:rf.sub/cause-event-id`), surfaced in the `reactive-counts` `:by-cause`
+projection. They add **no new trace op-type and no new accumulator** — the
+tape is the source of truth (§Risks — evidence projections drift).
+
+Like `:rf.assert/schema-error` they carry NO `reg-event-fx` handler: they are
+NOT dispatched into the frame. They are **tape-evaluated** in the result
+boundary (`re-frame.story.result/match-causal-expectations`) against the
+projected `:reactive-counts` / `:sub-runs` / `:renders`. The declared atom
+names the cause event and (optionally) the effect surface + a count bound:
+
+```clojure
+[:rf.assert/caused              {:event :counter/inc :sub :total}]      ; e recomputed :total ≥ 1
+[:rf.assert/caused              {:event :counter/inc :view :badge :exactly 1}]
+[:rf.assert/no-cascade-rerender {:event :unrelated/event}]              ; e caused 0 effects
+[:rf.assert/no-cascade-rerender {:event :counter/inc :view :counter :max 2}]
+```
+
+- `:event` (required) is the **cause** — the dispatching cascade's event-id.
+  An atom that names no `:event` FAILS (a causal assertion that asserts
+  nothing measurable).
+- `:sub` / `:view` (optional) select the **effect surface** measured: the
+  recompute count of the named sub, or the render count of the named view.
+  Absent, the surface is the cause's total recompute + render count.
+- `:min` / `:max` / `:exactly` bound the effect count. The per-id DEFAULT is
+  `:rf.assert/caused` → `{:min 1}` (the cause produced the effect at least
+  once) and `:rf.assert/no-cascade-rerender` → `{:min 0 :max 0}` (the cause
+  did NOT over-render); an author MAY override either bound.
+
+These are PURE expectations, **not** agreement-floor signals — an over-render
+is a `:fail` of a declared `:rf.assert/no-cascade-rerender`, not a tape-floor
+failure on its own (`tape-shows-failure?` does not read reactive counts). A
+run with NO reactive rows is caught upstream by the `:reactive-counts`
+fail-closed evidence-slot check (it reports `:cannot-run`, never a silent
+pass against an empty projection).
+
 There is no `:rf.assert/no-schema-errors` author surface — schema-clean
 is the knob-free floor (§Schema rule), so the only schema author surface
 is `:rf.assert/schema-error`. Additional assertions MAY be added for
@@ -2454,6 +2495,75 @@ with no runtime; the headless replay path settles synchronously to a fixed
 point via the headless flush-hooks, so the live-frame replay also runs
 headless.
 
+## Generated runs and artifacts
+
+A property-style Story run GENERATES an event program from a seed, replays it
+(§Run artifact and replay), and judges the result. Most generated programs
+pass and are throwaway; a failing one is the interesting case. Generated runs
+**emit artifacts FIRST**: every generated run produces a `:rf.test/run-artifact`
+carrying the `:seed` it was generated from (and, for a shrunk failure, the
+`:shrink-path`), so a generated failure is replayable off-CI and promotable
+into a curated regression variant (§Promotion). The `:seed` / `:shrink-path`
+artifact slots already exist (§Artifacts — Run artifact); the generated-run
+producer fills them. **Curated promotion only** — a generated failure becomes
+a named variant ONLY through the explicit `promote-run-artifact!` call
+(§Promotion), never automatically.
+
+The base ships in `re-frame.story.generate`, re-exported as
+`story/check-property!` (the property entry point) + `story/sweep-faults!`
+(the fault-lattice sweep below).
+
+### Generator-agnostic; reproducible from the seed
+
+A generated run is driven by a caller-supplied `gen-fn` — a pure
+`(fn [seed] event-program)` returning a deterministic event program (tagged
+steps, or bare event vectors the artifact coerces). This namespace bundles
+**no generator library**; the CHOICE of generator (a `clojure.test.check`
+generator, a hand-rolled state-machine walk, a recorded-interaction fuzzer)
+is the caller's, by wrapping its draw in a `gen-fn`. The seed sequence is a
+pure, seedable splitmix64 PRNG (`seed-seq`), so a property over N seeds is
+fully reproducible: the same root seed replays the same N programs. Recording
+the root `:seed` on the result makes the whole run reproducible.
+
+### Shrinking — deterministic program-prefix delta-debug
+
+When a generated program FAILS (`:fail` / `:error`; a `:cannot-run` is
+inconclusive, not a falsification), `shrink-program!` searches for a SMALLER
+failing program by deterministic delta-debugging over the event program: it
+drops step windows (largest chunks first, then finer) and keeps any reduction
+that STILL fails, until no single-step removal keeps the failure. The
+`:shrink-path` records the ordered sequence of KEPT reductions, so a consumer
+sees how the minimal failing case was reached. Shrinking reuses the SAME
+replay path as the original run, so a shrunk artifact replays identically; a
+`:max-replays` cap bounds the search (a partial shrink is still a smaller,
+valid artifact).
+
+### Fault lattice sweep
+
+A fault lattice sweep (`sweep-faults!`) replays ONE base program across a
+small lattice of FAULT cells, where each cell is a different `:fx-decisions`
+map — the **same fx-override world input** `replay-run-artifact` already
+reapplies, and the same surface the `:network` world slot lowers to. A
+"fault" is just an fx override that fails / delays / mis-replies; there is
+**no new fault-injection contract surface**. The sweep collects one
+seed-bearing `:rf.test/run-artifact` per cell (each carrying its faulted
+`:fx-decisions` so it replays against the same fault) and reports the cells
+whose run FAILED, so an author can see which fault states falsify the program
+and promote any cell's artifact (§Promotion). The `:cannot-run` policy is the
+runner's existing one — a cell whose program cannot run under the chosen
+runner refuses, it does not falsify.
+
+### Pure / JVM-testable
+
+The seed PRNG (`next-seed` / `seed-seq`), the failure predicate (`failing?`),
+the shrink candidate enumeration (`drop-candidates`), and seed-bearing
+artifact construction (`generated-artifact`) are pure data → data and run
+under `clojure -M:test` with no host. The run / shrink / sweep DRIVERS
+(`check-property!`, `shrink-program!`, `sweep-faults!`) replay into fresh
+`:rf.test.replay/*` frames (torn down by the replay path), so the JVM gate
+exercises the full generated-run → artifact → promotion flow against a live
+frame synchronously.
+
 ## Determinism gate
 
 The determinism gate answers one question: does this plan / artifact
@@ -2957,6 +3067,13 @@ P1 is complete when:
   pretending to prove real subscription logic;
 - visual and a11y assertions are first-class runner-tiered assertions (a
   hosted visual review service remains out of scope);
+- causal / cascade assertions (`:rf.assert/caused` /
+  `:rf.assert/no-cascade-rerender`) project cause→effect from the existing
+  `:cause-event-id` reactive evidence (no new trace op-type, no second
+  accumulator); generated / property-style runs emit seed-bearing
+  `:rf.test/run-artifact`s with shrink data and a fault-lattice sweep over the
+  existing fx-override world input; a generated failure promotes through the
+  existing curated bridge with its seed + source link preserved;
 - the unit-test cookbook ships, and the Story play/script CI gate stays
   green.
 

--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -112,6 +112,14 @@
             ;; `promote-run-artifact!` (the explicit-only registration path)
             ;; below (spec/017 §Promotion — Promotion bridge).
             [re-frame.story.promotion   :as promotion]
+            ;; rf2-5x1wt.31 — generated / property-style runs that emit
+            ;; seed-bearing run artifacts (+ shrink) and a fault-lattice
+            ;; sweep. Re-exported as `check-property!` / `sweep-faults!`
+            ;; below (spec/017 §Generated runs and artifacts). Builds
+            ;; read-only on `.7` replay + the `:seed` / `:shrink-path`
+            ;; artifact slots; a generated failure feeds the promotion
+            ;; bridge unchanged (artifacts first, curated promotion only).
+            [re-frame.story.generate    :as generate]
             ;; rf2-5x1wt.19 — the ONE unified run-result + the assertion /
             ;; check record shapes + the clojure.test report projection.
             ;; Re-exported as `run-result` / `result-status` /
@@ -1159,6 +1167,40 @@
   registered variant id."
   [artifact opts]
   (promotion/promote-run-artifact! artifact opts))
+
+;; ---- generated / property-style runs (rf2-5x1wt.31) ---------------------
+;;
+;; Per spec/017 §Generated runs and artifacts — a property over N generated
+;; event programs that emits a SEED-bearing `:rf.test/run-artifact` for every
+;; run and, on falsification, a SHRUNK failing artifact (carrying its `:seed`
+;; + `:shrink-path`) ready to feed the promotion bridge. Artifacts first;
+;; curated promotion only. Generator-agnostic (a caller `gen-fn` of the seed)
+;; over a pure seedable PRNG; the fault-lattice sweep replays one base program
+;; across `:fx-decisions` fault cells using the existing fx-override world
+;; input — no new fault-injection contract.
+
+(defn check-property!
+  "Per spec/017 §Generated runs and artifacts — run a property over `:num-tests`
+  generated event programs and, on FAILURE, return the shrunk, seed-bearing
+  failing `:rf.test/run-artifact`. `gen-fn` is a pure `(fn [seed]
+  event-program)`; `opts` MAY carry `:seed` (the reproducible root seed),
+  `:num-tests`, `:shrink?`, `:fx-decisions` (the world the property runs
+  against), `:hooks` / `:frame-config`. Returns `{:status :pass …}` or
+  `{:status :fail :seed … :shrink-path … :artifact <run-artifact> …}`; the
+  `:artifact` feeds `promote-run-artifact!` for a curated regression variant."
+  [gen-fn opts]
+  (generate/check-property! gen-fn opts))
+
+(defn sweep-faults!
+  "Per spec/017 §Fault lattice sweep — replay `base-program` across a
+  `fault-lattice` of `:fx-decisions` cells (each cell a fault — an fx override
+  that fails / delays / mis-replies) and collect one seed-bearing
+  `:rf.test/run-artifact` per cell. Derived from the existing fx-override
+  world input + run-artifact surface; no new fault-injection contract. `opts`
+  MAY carry `:seed` / `:hooks` / `:frame-config`. Returns `{:cells [{:cell
+  :status :artifact :result} …] :failing [cell-id …]}`."
+  [base-program fault-lattice opts]
+  (generate/sweep-faults! base-program fault-lattice opts))
 
 ;; ---- semantic diff over run artifacts (rf2-5x1wt.9) ---------------------
 ;;

--- a/tools/story/src/re_frame/story/assertions.cljc
+++ b/tools/story/src/re_frame/story/assertions.cljc
@@ -800,6 +800,129 @@
      :selector (schema-error-selector spec)}))
 
 ;; ---------------------------------------------------------------------------
+;; Causal / cascade assertions — `:rf.assert/caused` +
+;; `:rf.assert/no-cascade-rerender` (rf2-5x1wt.31, spec/017 §Causal and
+;; cascade assertions). NET-NEW, tape-evaluated like `:rf.assert/schema-error`.
+;;
+;; Both PROJECT a cause→effect relationship from the SAME reactive evidence
+;; the framework already retains in the epoch tape — the `:rf.sub/run` /
+;; `:rf.view/rendered` rows stamped with the dispatching cascade's
+;; `:cause-event-id` (Spec 009 §`:rf.sub/cause-event-id`, surfaced in the
+;; `re-frame.story.play.evidence/reactive-counts` `:by-cause` projection,
+;; rf2-5x1wt.30). They add NO new trace op-type and NO new accumulator — the
+;; tape is the source of truth (spec/017 §Risks — "evidence projections
+;; drift: use the epoch tape as source of truth").
+;;
+;; Like `:rf.assert/schema-error` they carry NO `reg-event-fx` handler: they
+;; are not dispatched into the frame, they are evaluated in the result
+;; boundary (`re-frame.story.result/match-causal-expectations`) against the
+;; projected `:reactive-counts`. They require the `:reactive-counts`
+;; capability (the `:cljs-reactive` runner; `:cannot-run` under
+;; `:headless` / `:hiccup`), so a run with NO reactive rows fails closed via
+;; the post-run evidence-slot check — never a silent pass.
+;;
+;; The declared atom is `[:rf.assert/caused spec]` / `[:rf.assert/no-cascade-
+;; rerender spec]`, where `spec` names the CAUSE event and (optionally) the
+;; EFFECT surface + a count bound:
+;;
+;;   {:event   <event-id>      ; the cause — the dispatching cascade's event-id
+;;    :sub      <sub-id>        ; optional effect surface: a recomputed sub
+;;    :view     <view-id>      ; optional effect surface: a rendered view
+;;    :min      <int>          ; lower bound on the effect count (default 1 for
+;;                             ;   :caused — "at least one"; default 0 for
+;;                             ;   :no-cascade-rerender)
+;;    :max      <int>}         ; upper bound on the effect count (default 0 for
+;;                             ;   :no-cascade-rerender — "no rerender"; absent
+;;                             ;   = unbounded for :caused)
+;;
+;; The two ids share ONE spec parser + ONE bound model; they differ only in
+;; their DEFAULT bound (`:caused` defaults to `{:min 1}` — the cause produced
+;; the effect; `:no-cascade-rerender` defaults to `{:max 0}` — the cause did
+;; NOT over-render). An author MAY override either bound on either id.
+;; ---------------------------------------------------------------------------
+
+(def ^:const id-caused              :rf.assert/caused)
+(def ^:const id-no-cascade-rerender :rf.assert/no-cascade-rerender)
+
+(def causal-assertion-ids
+  "The causal / cascade assertion family (rf2-5x1wt.31, NET-NEW). Both are
+  tape-evaluated against the `:reactive-counts` `:by-cause` projection (NOT
+  dispatched into the frame, NOT a parallel accumulator) and require the
+  `:reactive-counts` capability via the requirement registry
+  (`re-frame.story.requirements/assertion-capabilities`)."
+  #{id-caused
+    id-no-cascade-rerender})
+
+(defn causal?
+  "True iff `assertion-atom` is a `[:rf.assert/caused …]` or
+  `[:rf.assert/no-cascade-rerender …]` declaration. Pure data → data."
+  [assertion-atom]
+  (contains? causal-assertion-ids (assertion-atom-id assertion-atom)))
+
+(defn causal-spec
+  "The spec map of a `[:rf.assert/caused spec]` / `[:rf.assert/no-cascade-
+  rerender spec]` atom (the second element), or `{}` when the atom carries
+  none. Pure data → data. A bare `[:rf.assert/caused]` (no spec) is
+  degenerate — it names no cause, so the matcher fails it readably rather
+  than vacuously passing."
+  [assertion-atom]
+  (let [s (nth (vec assertion-atom) 1 nil)]
+    (if (map? s) s {})))
+
+(defn causal-effect-surface
+  "The effect surface a causal `spec` measures — `[:sub sub-id]` when it
+  names a `:sub`, `[:view view-id]` when it names a `:view`, or `[:any]`
+  (the cause's total recompute+render count) when it names neither. Pure
+  data → data. `:sub` takes precedence over `:view` when both are present
+  (an author measuring a specific sub recompute)."
+  [{:keys [sub view] :as _spec}]
+  (cond
+    (some? sub)  [:sub sub]
+    (some? view) [:view view]
+    :else        [:any]))
+
+(defn causal-bounds
+  "The effective `{:min :max}` count bounds for a causal expectation, applying
+  the per-id DEFAULT then the author override. Pure data → data.
+  `assertion-id` selects the default:
+  `:rf.assert/caused` → `{:min 1}` (the cause produced the effect at least
+  once; `:max` absent = unbounded); `:rf.assert/no-cascade-rerender` →
+  `{:min 0 :max 0}` (the cause produced NO such effect). An explicit `:min`
+  / `:max` in `spec` overrides its default; an explicit `:exactly n` pins
+  both bounds to `n`."
+  [assertion-id {:keys [min max exactly] :as _spec}]
+  (let [defaults (if (= assertion-id id-no-cascade-rerender)
+                   {:min 0 :max 0}
+                   {:min 1})]
+    (cond-> defaults
+      (some? exactly) (assoc :min exactly :max exactly)
+      (some? min)     (assoc :min min)
+      (some? max)     (assoc :max max))))
+
+(defn causal-expectation
+  "Project a declared causal assertion atom into its expectation record —
+  the shape the result boundary's causal matcher
+  (`re-frame.story.result/match-causal-expectations`) evaluates against the
+  projected `:reactive-counts`. Pure data → data.
+
+  Returns `{:atom atom :id id :spec spec :event cause-event-id
+            :surface [:sub|:view|:any …] :min n :max n-or-nil}`. `:event` is
+  the cause the expectation names (nil for a degenerate bare atom — the
+  matcher fails it); `:surface` is the effect surface measured; `:min` /
+  `:max` are the effective count bounds (`causal-bounds`)."
+  [assertion-atom]
+  (let [id    (assertion-atom-id assertion-atom)
+        spec  (causal-spec assertion-atom)
+        {:keys [min max]} (causal-bounds id spec)]
+    {:atom    assertion-atom
+     :id      id
+     :spec    spec
+     :event   (:event spec)
+     :surface (causal-effect-surface spec)
+     :min     min
+     :max     max}))
+
+;; ---------------------------------------------------------------------------
 ;; Boot — register the seven canonical handlers
 ;; ---------------------------------------------------------------------------
 

--- a/tools/story/src/re_frame/story/generate.cljc
+++ b/tools/story/src/re_frame/story/generate.cljc
@@ -1,0 +1,424 @@
+(ns re-frame.story.generate
+  "Generated / property-style Story runs that emit run artifacts carrying
+  their SEED and SHRINK data — and promote only curated failures
+  (NewTestStory rf2-5x1wt.31, `tools/story/spec/017-Testing-Story.md`
+  §Generated runs and artifacts).
+
+  ## Generated runs emit artifacts FIRST
+
+  A property-style Story run generates an event PROGRAM from a seed, replays
+  it (`re-frame.story.artifact/replay-run-artifact`), and judges the
+  resulting run-result. Most generated programs PASS and are throwaway; a
+  failing one is the interesting case. This ns wires generated runs to the
+  EXISTING run-artifact surface: every generated run produces a
+  `:rf.test/run-artifact` carrying the `:seed` it was generated from (and,
+  for a shrunk failure, the `:shrink-path`), so a generated failure is
+  replayable off-CI and promotable into a curated regression variant
+  (§Promotion) — artifacts FIRST, promotion only when curated. The `:seed` /
+  `:shrink-path` artifact slots already exist (§Artifacts — Run artifact,
+  rf2-5x1wt.7); this ns is the producer that fills them.
+
+  ## Generator-agnostic — a `gen-fn` of the seed
+
+  This ns does NOT bundle a generator library. A generated run is driven by a
+  caller-supplied `gen-fn` — a pure `(fn [seed] event-program)` that, given a
+  numeric seed, returns a deterministic event program (a vector of tagged
+  steps, or bare event vectors the artifact coerces). The seed sequence is a
+  pure, seedable splitmix64 PRNG (`seed-seq`), so a property run over N seeds
+  is fully reproducible: the same root seed replays the same N programs. This
+  keeps the substrate self-contained (no new dependency) while leaving the
+  CHOICE of generator to the caller — a `clojure.test.check` generator, a
+  hand-rolled state-machine walk, or a recorded-interaction fuzzer all fit by
+  wrapping their draw in a `gen-fn`.
+
+  ## Shrinking — deterministic program-prefix delta-debug
+
+  When a generated program FAILS, `shrink-program` searches for a SMALLER
+  failing program by deterministic delta-debugging over the event program:
+  it tries to drop steps (largest chunks first, then finer), keeping any
+  reduction that STILL fails the same way, until no single-step removal keeps
+  the failure. The `:shrink-path` records the ordered sequence of candidate
+  programs that were KEPT (each a smaller failing program than the last), so a
+  consumer can see how the minimal failing case was reached. Shrinking reuses
+  the SAME replay path as the original run — no separate execution model — so
+  a shrunk artifact replays identically.
+
+  ## Pure / impure split
+
+  The seed PRNG (`seed-seq`), the failure predicate (`failing?`), and the
+  shrink CANDIDATE enumeration (`drop-candidates`) are pure data → data and
+  JVM-testable with no host. The run + shrink DRIVERS (`run-seed!`,
+  `shrink-program!`, `check-property!`) are the impure seam — they call
+  `replay-run-artifact` into fresh `:rf.test.replay/*` frames (torn down by
+  the replay path), so the JVM `clojure -M:test` gate exercises the full
+  generated-run → artifact flow against a live frame synchronously."
+  (:require [re-frame.story.artifact :as artifact]))
+
+;; ===========================================================================
+;; SEEDABLE PRNG  (pure — splitmix64)
+;; ===========================================================================
+;;
+;; A pure, reproducible 64-bit splitmix64 step. Given a seed it returns the
+;; NEXT seed; `seed-seq` unfolds a deterministic seed sequence from a root
+;; seed. No host RNG, no `rand` — the same root seed always yields the same
+;; sequence, which is what makes a property run reproducible from its
+;; recorded `:seed`.
+
+;; The splitmix64 constants, written as SIGNED two's-complement longs (the
+;; JVM reader rejects a hex literal whose value exceeds Long/MAX_VALUE, so the
+;; unsigned 0x9E37…/0xBF58…/0x94D0… constants are spelled as their signed
+;; equivalents). CLJS computes the same mix in `js/BigInt`.
+#?(:clj
+   (do
+     (def ^:private ^:const splitmix-gamma  -7046029254386353131)  ; 0x9E3779B97F4A7C15
+     (def ^:private ^:const splitmix-mul-1  -4658895280553007687)  ; 0xBF58476D1CE4E5B9
+     (def ^:private ^:const splitmix-mul-2  -7723592293110705685))) ; 0x94D049BB133111EB
+
+(defn next-seed
+  "The splitmix64 successor of `seed` — a pure 64-bit mix. Deterministic:
+  the same `seed` always returns the same successor. Pure data → data.
+
+  CLJS computes in `js/BigInt` (doubles cannot hold 64 exact bits) and
+  returns a JS number truncated into the safe-integer range for ergonomic
+  use as a seed; the JVM uses native wrapping `long` arithmetic. The exact
+  bit-pattern differs across hosts, but WITHIN a host the sequence is stable
+  and reproducible, which is all a recorded `:seed` needs."
+  [seed]
+  #?(:clj
+     (let [z (unchecked-add (unchecked-long seed) splitmix-gamma)
+           z (unchecked-multiply (bit-xor z (unsigned-bit-shift-right z 30))
+                                 splitmix-mul-1)
+           z (unchecked-multiply (bit-xor z (unsigned-bit-shift-right z 27))
+                                 splitmix-mul-2)]
+       (bit-xor z (unsigned-bit-shift-right z 31)))
+     :cljs
+     (let [m   (js/BigInt "0xFFFFFFFFFFFFFFFF")
+           z   (bit-and (+ (js/BigInt seed) (js/BigInt "0x9E3779B97F4A7C15")) m)
+           z   (bit-and (* (bit-xor z (bit-shift-right z (js/BigInt 30)))
+                           (js/BigInt "0xBF58476D1CE4E5B9")) m)
+           z   (bit-and (* (bit-xor z (bit-shift-right z (js/BigInt 27)))
+                           (js/BigInt "0x94D049BB133111EB")) m)
+           z   (bit-xor z (bit-shift-right z (js/BigInt 31)))]
+       ;; Truncate into JS safe-integer range for an ergonomic numeric seed.
+       (js/Number (bit-and z (js/BigInt js/Number.MAX_SAFE_INTEGER))))))
+
+(defn seed-seq
+  "A deterministic sequence of `n` seeds unfolded from `root-seed` via
+  `next-seed`. Pure data → data — the same `root-seed` always yields the same
+  `n` seeds, so a property run over the sequence is reproducible. The first
+  element is the splitmix successor of `root-seed` (so the root seed itself is
+  never reused as a program seed)."
+  [root-seed n]
+  (->> root-seed
+       (iterate next-seed)
+       rest
+       (take (max 0 n))
+       vec))
+
+;; ===========================================================================
+;; THE RUN ARTIFACT FOR A GENERATED RUN  (pure construction)
+;; ===========================================================================
+
+(defn generated-artifact
+  "Build the `:rf.test/run-artifact` for a generated run from its `seed`,
+  generated `event-program`, and optional `:fx-decisions` / `:shrink-path` /
+  `:source`. Pure data → data — `re-frame.story.artifact/make-run-artifact`
+  coerces the program + stamps `:artifact/kind`; this fills the `:seed`
+  provenance slot (and `:shrink-path` for a shrunk failure) the generated
+  flow is about. The default `:source` records that the artifact came from
+  the property runner, so a promoted variant explains it was generated."
+  [{:keys [seed event-program fx-decisions shrink-path source] :as _parts}]
+  (artifact/make-run-artifact
+    (cond-> {:seed          seed
+             :event-program (vec event-program)
+             :fx-decisions  (or fx-decisions {})
+             :source        (or source {:tool :rf.story/property-run :seed seed})}
+      (some? shrink-path) (assoc :shrink-path shrink-path))))
+
+;; ===========================================================================
+;; FAILURE PREDICATE  (pure)
+;; ===========================================================================
+
+(defn failing?
+  "True iff a replay `run-result`'s `:status` is a genuine FAILURE — `:fail`
+  or `:error`. A `:cannot-run` is NOT a failure (the runner could not attempt
+  it; a property over a wrong-runner program is inconclusive, not falsified),
+  and `:pass` is not. Pure data → data — the property's falsification signal."
+  [run-result]
+  (contains? #{:fail :error} (:status run-result)))
+
+;; ===========================================================================
+;; SHRINK CANDIDATE ENUMERATION  (pure — deterministic delta-debug)
+;; ===========================================================================
+
+(defn drop-candidates
+  "The ordered candidate programs to try when shrinking `program` at
+  granularity `chunk-size` — each is `program` with one contiguous
+  `chunk-size`-step window removed, scanning left to right. Pure data → data;
+  deterministic. A `chunk-size` >= the program length yields the empty
+  program as the sole candidate; a `chunk-size` <= 0 yields none.
+
+  This is the classic ddmin reduction lattice: shrinking tries the LARGEST
+  chunks first (halving on failure to reduce further) so the search reaches a
+  small failing case in few replays, deterministically."
+  [program chunk-size]
+  (let [v (vec program)
+        n (count v)]
+    (if (or (<= chunk-size 0) (zero? n))
+      []
+      (->> (range 0 n chunk-size)
+           (mapv (fn [start]
+                   (let [end (min n (+ start chunk-size))]
+                     (into (subvec v 0 start) (subvec v end)))))))))
+
+;; ===========================================================================
+;; RUN ONE SEED  (impure — fresh-frame replay)
+;; ===========================================================================
+
+(defn run-seed!
+  "Generate the event program for `seed` via `gen-fn`, replay it into a FRESH
+  frame, and return `{:seed :event-program :result :artifact}`. Impure — it
+  replays into a `:rf.test.replay/*` frame (allocated + torn down by
+  `replay-run-artifact`).
+
+  `gen-fn` is a pure `(fn [seed] event-program)`; `opts` may carry
+  `:fx-decisions` (reapplied on every dispatch of the generated program) and
+  the `:hooks` / `:frame-config` `replay-run-artifact` accepts. The returned
+  `:artifact` is the run's `:rf.test/run-artifact` carrying the `:seed` (and
+  the replay's projected `:result`), so EVERY generated run — pass or fail —
+  has a replayable, seed-bearing artifact (artifacts first)."
+  [gen-fn seed {:keys [fx-decisions hooks frame-config] :as _opts}]
+  (let [program     (vec (gen-fn seed))
+        base        (artifact/make-run-artifact
+                      {:event-program program
+                       :fx-decisions  (or fx-decisions {})})
+        replay-opts (cond-> {}
+                      hooks        (assoc :hooks hooks)
+                      frame-config (assoc :frame-config frame-config))
+        result      (artifact/replay-run-artifact base replay-opts)
+        artifact    (generated-artifact
+                      {:seed          seed
+                       :event-program program
+                       :fx-decisions  fx-decisions
+                       :source        {:tool :rf.story/property-run :seed seed}})]
+    {:seed          seed
+     :event-program program
+     :result        (assoc result :seed seed)
+     :artifact      (assoc artifact :result (assoc result :seed seed))}))
+
+;; ===========================================================================
+;; SHRINK A FAILING PROGRAM  (impure — fresh-frame replays)
+;; ===========================================================================
+
+(defn shrink-program!
+  "Delta-debug `failing-program` toward a SMALLER program that still FAILS,
+  replaying each candidate into a fresh frame. Returns
+  `{:program minimal-failing-program :shrink-path [program …] :result …}` —
+  `:program` is the smallest failing program found, `:shrink-path` the ordered
+  sequence of KEPT reductions (each smaller + still-failing than the last,
+  EXCLUDING the original), and `:result` the minimal program's replay result.
+
+  Impure — each candidate is replayed via `re-frame.story.artifact/replay-run-
+  artifact` (fresh `:rf.test.replay/*` frames). The reduction keeps a
+  candidate iff its replay still `failing?`; granularity halves from the
+  program length down to single-step removals (the ddmin schedule), so the
+  search is deterministic and terminates. `opts` threads `:fx-decisions` /
+  `:hooks` / `:frame-config` to the replays.
+
+  `max-replays` (default 200) caps the search so a pathological program cannot
+  replay unboundedly; on reaching the cap the smallest failing program found
+  so far is returned (a partial shrink is still a smaller, valid artifact)."
+  ([failing-program opts] (shrink-program! failing-program opts 200))
+  ([failing-program {:keys [fx-decisions hooks frame-config] :as _opts} max-replays]
+   (let [replay-opts (cond-> {}
+                       hooks        (assoc :hooks hooks)
+                       frame-config (assoc :frame-config frame-config))
+         replay!     (fn [program]
+                       (let [a (artifact/make-run-artifact
+                                 {:event-program program
+                                  :fx-decisions  (or fx-decisions {})})]
+                         (artifact/replay-run-artifact a replay-opts)))]
+     (loop [current     (vec failing-program)
+            chunk-size  (max 1 (quot (count failing-program) 2))
+            shrink-path []
+            best-result nil
+            replays     0]
+       (let [candidates (drop-candidates current chunk-size)
+             ;; First candidate that still fails — keep it and restart the
+             ;; reduction at the same granularity against the smaller program.
+             [kept kept-result n-tried]
+             (reduce (fn [_ cand]
+                       (let [r (replay! cand)]
+                         (if (failing? r)
+                           (reduced [cand r 1])
+                           [nil nil 1])))
+                     [nil nil 0]
+                     candidates)
+             replays' (+ replays (count candidates))]
+         (cond
+           ;; Cap reached — return the best (smallest failing) so far.
+           (>= replays' max-replays)
+           {:program     (if kept kept current)
+            :shrink-path (cond-> shrink-path kept (conj kept))
+            :result      (or kept-result best-result)}
+
+           ;; A smaller failing program — keep it, restart at this granularity.
+           (some? kept)
+           (recur kept
+                  (max 1 (min chunk-size (quot (count kept) 2)))
+                  (conj shrink-path kept)
+                  kept-result
+                  replays')
+
+           ;; No reduction at this granularity — refine, or finish at size 1.
+           (> chunk-size 1)
+           (recur current (max 1 (quot chunk-size 2)) shrink-path best-result replays')
+
+           :else
+           {:program     current
+            :shrink-path shrink-path
+            :result      best-result}))))))
+
+;; ===========================================================================
+;; CHECK A PROPERTY OVER N SEEDS  (impure — the generated-run entry point)
+;; ===========================================================================
+
+(defn check-property!
+  "Run a property over `n` generated programs and return a result that —
+  on falsification — carries the SHRUNK, seed-bearing failing
+  `:rf.test/run-artifact` (rf2-5x1wt.31, spec/017 §Generated runs and
+  artifacts). The generated-run entry point.
+
+  `gen-fn` is a pure `(fn [seed] event-program)`; `opts`:
+
+  - `:seed`         — the ROOT seed the `n` program seeds unfold from
+                      (`seed-seq`). Default 0. Recording it makes the whole
+                      property run reproducible.
+  - `:num-tests`    — `n`, the number of generated programs (default 100).
+  - `:shrink?`      — shrink a failing program toward a minimal failing case
+                      (default true). When false the first failing program is
+                      reported as-is.
+  - `:fx-decisions` — fx overrides reapplied on every generated dispatch (the
+                      world the property runs against). Ride the artifact's
+                      `:fx-decisions` so a fault-injected property replays
+                      against the same stubs.
+  - `:hooks` / `:frame-config` — threaded to the replays (a `:dom` adapter
+                      supplies richer settled-boundary hooks).
+
+  Returns one of:
+
+  - `{:status :pass :num-tests n :seed root-seed}` — every generated program
+    passed (or was `:cannot-run`, which does not falsify).
+  - `{:status :fail :seed failing-seed :root-seed root-seed :num-tests tried
+      :smallest-program [step …] :shrink-path [program …] :artifact <run-
+      artifact> :result <run-result>}` — a program FAILED. The `:artifact` is
+    the failing run-artifact carrying its `:seed` + (when shrunk) its
+    `:shrink-path`, ready to feed `re-frame.story.promotion/promote-run-
+    artifact!` for a CURATED regression variant — artifacts first, promotion
+    only when an author decides (§Promotion). The `:shrink-path` is the
+    ordered sequence of kept reductions from the original failing program to
+    the minimal one.
+
+  Each program runs into its OWN fresh `:rf.test.replay/*` frame (torn down by
+  the replay path), so the property observes no cross-program app-db leak."
+  [gen-fn {:keys [seed num-tests shrink? fx-decisions hooks frame-config] :as opts}]
+  (let [root-seed (or seed 0)
+        n         (or num-tests 100)
+        shrink?   (if (contains? opts :shrink?) (boolean shrink?) true)
+        run-opts  (cond-> {}
+                    (some? fx-decisions) (assoc :fx-decisions fx-decisions)
+                    (some? hooks)        (assoc :hooks hooks)
+                    (some? frame-config) (assoc :frame-config frame-config))
+        seeds     (seed-seq root-seed n)]
+    (loop [seeds   seeds
+           tried   0]
+      (if (empty? seeds)
+        {:status    :pass
+         :num-tests tried
+         :seed      root-seed}
+        (let [s   (first seeds)
+              run (run-seed! gen-fn s run-opts)]
+          (if (failing? (:result run))
+            ;; Falsified — shrink (if asked), then build the failing artifact
+            ;; carrying its seed + shrink-path.
+            (let [program  (:event-program run)
+                  shrunk   (when shrink?
+                             (shrink-program! program run-opts))
+                  smallest (if shrunk (:program shrunk) program)
+                  spath    (when (and shrunk (seq (:shrink-path shrunk)))
+                             (:shrink-path shrunk))
+                  result   (or (:result shrunk) (:result run))
+                  artifact (generated-artifact
+                             {:seed          s
+                              :event-program smallest
+                              :fx-decisions  fx-decisions
+                              :shrink-path   spath
+                              :source        {:tool      :rf.story/property-run
+                                              :seed      s
+                                              :root-seed root-seed
+                                              :shrunk?   (boolean spath)}})]
+              {:status           :fail
+               :seed             s
+               :root-seed        root-seed
+               :num-tests        (inc tried)
+               :original-program program
+               :smallest-program smallest
+               :shrink-path      (vec spath)
+               :result           (assoc result :seed s)
+               :artifact         (assoc artifact :result (assoc result :seed s))})
+            (recur (rest seeds) (inc tried))))))))
+
+;; ===========================================================================
+;; FAULT LATTICE SWEEP  (impure — derived from the existing fx-override world)
+;; ===========================================================================
+;;
+;; A fault lattice sweep replays ONE base program across a small lattice of
+;; FAULT cells, where each cell is a different `:fx-decisions` map (the same
+;; fx-override world input `replay-run-artifact` already reapplies, and the
+;; same surface the `:network` world slot lowers to). It collects one
+;; seed-bearing artifact per cell, so an author can see which fault states
+;; falsify the program. This is DERIVED entirely from the existing
+;; fx-override world input + the run-artifact surface — no new fault-injection
+;; contract: a "fault" is just a different override map.
+
+(defn sweep-faults!
+  "Replay `base-program` across a `fault-lattice` of `:fx-decisions` cells and
+  collect one `:rf.test/run-artifact` per cell (rf2-5x1wt.31, spec/017
+  §Fault lattice sweep). Impure — each cell replays into a fresh frame.
+
+  `fault-lattice` is a map `{cell-id fx-decisions}` (or a seq of `[cell-id
+  fx-decisions]` pairs) — each `fx-decisions` is the SAME `{fx-id override}`
+  shape the artifact + `:fx-overrides` world input carry (a 'fault' is an fx
+  override that fails / delays / mis-replies). `opts` threads `:seed` (stamped
+  on each cell's artifact for provenance), `:hooks`, `:frame-config`.
+
+  Returns `{:cells [{:cell cell-id :status … :artifact <run-artifact>
+  :result <run-result>} …] :failing [cell-id …]}` — one entry per cell in
+  lattice order, plus the ids of the cells whose run FAILED (`failing?`). Each
+  cell's artifact carries the faulted `:fx-decisions` so it replays against the
+  same fault, and is promotable (§Promotion) — artifacts first."
+  [base-program fault-lattice {:keys [seed hooks frame-config] :as _opts}]
+  (let [cells   (if (map? fault-lattice) (seq fault-lattice) (seq fault-lattice))
+        results (mapv
+                  (fn [[cell-id fx-decisions]]
+                    (let [a       (artifact/make-run-artifact
+                                    {:event-program base-program
+                                     :fx-decisions  (or fx-decisions {})})
+                          ropts   (cond-> {}
+                                    hooks        (assoc :hooks hooks)
+                                    frame-config (assoc :frame-config frame-config))
+                          result  (artifact/replay-run-artifact a ropts)
+                          artifact (generated-artifact
+                                     {:seed          seed
+                                      :event-program base-program
+                                      :fx-decisions  fx-decisions
+                                      :source        {:tool  :rf.story/fault-sweep
+                                                      :cell  cell-id
+                                                      :seed  seed}})]
+                      {:cell     cell-id
+                       :status   (:status result)
+                       :result   result
+                       :artifact (assoc artifact :result result)}))
+                  cells)]
+    {:cells   results
+     :failing (into [] (comp (filter #(failing? (:result %))) (map :cell)) results)}))

--- a/tools/story/src/re_frame/story/result.cljc
+++ b/tools/story/src/re_frame/story/result.cljc
@@ -334,6 +334,147 @@
      :unconsumed         unconsumed}))
 
 ;; ===========================================================================
+;; CAUSAL / CASCADE EXPECTATIONS  (spec/017 §Causal and cascade assertions,
+;; rf2-5x1wt.31)
+;; ===========================================================================
+;;
+;; `:rf.assert/caused` and `:rf.assert/no-cascade-rerender` PROJECT a
+;; cause→effect relationship from the SAME reactive evidence the tape already
+;; carries — the `:rf.sub/run` / `:rf.view/rendered` rows stamped with the
+;; dispatching cascade's `:cause-event-id` (Spec 009), surfaced in the
+;; `evidence/reactive-counts` `:by-cause` projection (rf2-5x1wt.30). They are
+;; tape-evaluated like `:rf.assert/schema-error`: NOT dispatched into the
+;; frame, NOT a parallel accumulator — the tape is the source of truth
+;; (spec/017 §Risks — "evidence projections drift").
+;;
+;; The measured COUNT for a causal expectation is read off `:reactive-counts`:
+;;
+;;   surface [:any]      → the cause's total (sub-recomputes + view-renders)
+;;                         from `(:by-cause rc)`;
+;;   surface [:sub sid]  → the cause's sub-recomputes whose sub-id is `sid`;
+;;   surface [:view vid] → the cause's view-renders whose view-id is `vid`.
+;;
+;; A `[:sub …]` / `[:view …]` surface needs per-(cause × surface) counts that
+;; `:by-cause` (cause-keyed totals) does not carry, so the matcher re-projects
+;; them from the already-projected `:sub-runs` / `:renders` rows
+;; (`evidence/sub-runs` / `renders`) — the SAME rows `:by-cause` counts,
+;; filtered to the named cause AND surface. No new evidence stream.
+
+(defn- causal-count
+  "The measured effect COUNT for a causal `expectation` against the run's
+  projected `evidence` (the `evidence/project-evidence` output). Pure data →
+  data. Reads ONLY the already-projected reactive rows — `:reactive-counts`
+  for the `[:any]` cause total, the `:sub-runs` / `:renders` rows for a named
+  `:sub` / `:view` surface. Returns 0 when the cause produced no matching
+  effect."
+  [{:keys [event surface] :as _expectation} evidence]
+  (let [rc (:reactive-counts evidence)]
+    (case (first surface)
+      :any  (let [{:keys [sub-recomputes view-renders]
+                   :or   {sub-recomputes 0 view-renders 0}}
+                  (get (:by-cause rc) event)]
+              (+ sub-recomputes view-renders))
+      :sub  (let [sid (second surface)]
+              (count (filter (fn [r] (and (= event (:cause-event-id r))
+                                          (= sid (:sub-id r))))
+                             (:sub-runs evidence))))
+      :view (let [vid (second surface)]
+              (count (filter (fn [r] (and (= event (:cause-event-id r))
+                                          (= vid (or (:view-id r)
+                                                     (when (vector? (:render-key r))
+                                                       (first (:render-key r)))))))
+                             (:renders evidence))))
+      0)))
+
+(defn- causal-in-bounds?
+  "True iff `n` satisfies the expectation's `[:min :max]` count bounds (an
+  absent `:max` is unbounded above). Pure data → data."
+  [{:keys [min max] :as _expectation} n]
+  (and (>= n (or min 0))
+       (or (nil? max) (<= n max))))
+
+(defn causal-record
+  "Mint the unified assertion record for ONE causal expectation (spec/017
+  §Causal and cascade assertions, §Run result — Assertion record). Pure
+  data → data.
+
+  `n` is the measured effect count (`causal-count`). `reactive?` is whether
+  the run carried ANY reactive evidence (a `:reactive-counts` slot). The
+  verdict, in precedence:
+
+  - a degenerate atom that names no `:event` → `:fail` (it asserts nothing
+    measurable);
+  - NO reactive evidence → `:cannot-run` — the run never exercised the
+    reactive substrate, so the cause→effect relationship could not be
+    measured (fail closed; NEVER a silent pass against an empty projection,
+    §Causal and cascade assertions);
+  - else the expectation passes iff `n` is within the `[:min :max]` bounds.
+
+  The record carries the declared spec as `:expected` and the measured count
+  + bounds as `:actual` so a failing / refused expectation reads
+  diagnostically."
+  [{:keys [atom id spec event surface min max] :as expectation} n reactive?]
+  (let [degenerate? (nil? event)
+        in-bounds?  (causal-in-bounds? expectation n)
+        status      (cond
+                      degenerate?            :fail
+                      (not reactive?)        :cannot-run
+                      in-bounds?             :pass
+                      :else                  :fail)]
+    {:assertion   id
+     :payload     (vec (rest atom))
+     :passed?     (= :pass status)
+     :status      status
+     :cannot-run? (= :cannot-run status)
+     :expected    spec
+     :actual      {:event event :surface surface :count n :min min :max max}
+     :reason      (cond
+                    degenerate?
+                    (str (name id) " names no :event — a causal assertion MUST "
+                         "name the cause event-id it projects")
+                    (not reactive?)
+                    (str (name id) " requires reactive evidence, but the run "
+                         "carried no :rf.sub/run / :rf.view/rendered rows — "
+                         ":cannot-run (run under the :cljs-reactive runner)")
+                    in-bounds?
+                    (str "event " (pr-str event) " caused " n " "
+                         (pr-str surface) " effect(s), within bounds "
+                         "[" min " " (or max "∞") "]")
+                    :else
+                    (str "event " (pr-str event) " caused " n " "
+                         (pr-str surface) " effect(s), outside expected bounds "
+                         "[" min " " (or max "∞") "]"))}))
+
+(defn match-causal-expectations
+  "Evaluate declared causal / cascade expectations against the run's
+  projected reactive `evidence` (spec/017 §Causal and cascade assertions,
+  rf2-5x1wt.31). Pure data → data — the boundary the `run-result` assembly
+  consumes.
+
+  `causal-atoms` is the vector of declared `[:rf.assert/caused …]` /
+  `[:rf.assert/no-cascade-rerender …]` atoms; `evidence` is the
+  `evidence/project-evidence` output (the SINGLE reactive source — the
+  `:reactive-counts` / `:sub-runs` / `:renders` projections, never a second
+  accumulator). Returns `{:records [assertion-record …]}`, one per declared
+  expectation.
+
+  Note these are PURE expectations, NOT agreement-floor signals: an
+  over-render is a `:fail` of a `:rf.assert/no-cascade-rerender` declaration,
+  not a tape-floor failure on its own (`evidence/tape-shows-failure?` does not
+  read reactive counts). A run with NO reactive rows (no `:reactive-counts`
+  slot) resolves each causal expectation to `:cannot-run` — fail closed, never
+  a silent pass against an empty projection (this is the matcher's own
+  fail-closed guard; it mirrors the post-run `:reactive-counts` evidence-slot
+  check (`requirements/validate-evidence`) so the verdict is correct even
+  where that check is not separately invoked)."
+  [causal-atoms evidence]
+  (let [reactive? (contains? evidence :reactive-counts)]
+    {:records (mapv (fn [a]
+                      (let [exp (assertions/causal-expectation a)]
+                        (causal-record exp (causal-count exp evidence) reactive?)))
+                    (or causal-atoms []))}))
+
+;; ===========================================================================
 ;; THE UNIFIED RUN RESULT  (spec/017 §Run result)
 ;; ===========================================================================
 
@@ -369,6 +510,20 @@
                           exactly-consumed selectors are excused from the
                           agreement floor. The minted schema-error records
                           are appended to `:assertions`.
+  - `:causal-expectations` — the vector of declared `:rf.assert/caused` /
+                          `:rf.assert/no-cascade-rerender` atoms (from the
+                          plan's `[:expect :assertions]` + checks + in-script
+                          `[:assert …]` checkpoints). Tape-evaluated against
+                          the projected `:reactive-counts` `:by-cause` /
+                          `:sub-runs` / `:renders` projection (§Causal and
+                          cascade assertions, rf2-5x1wt.31) — NOT dispatched,
+                          NOT a parallel accumulator. The minted records are
+                          appended to `:assertions`. These are PURE
+                          expectations, not floor signals (an over-render is a
+                          `:fail` of the declaration, not a tape-floor
+                          failure); a run with no reactive rows is caught
+                          upstream by the `:reactive-counts` fail-closed
+                          evidence-slot check (`:cannot-run`).
   - `:consumed-selectors` — additional schema-violation selectors to excuse
                           from the agreement floor (§Schema rule), unioned
                           with whatever `:schema-expectations` consumed. A
@@ -391,7 +546,7 @@
   green while the tape is red, and the verdict is computed from the
   PROJECTED evidence, not a sibling accumulator."
   [{:keys [epoch-tape assertions script check->atoms consumed-selectors
-           schema-expectations unmet app-db]
+           schema-expectations causal-expectations unmet app-db]
     :as   parts}]
   (let [tape           (vec (or epoch-tape []))
         evidence-slots (evidence/project-evidence tape {:script script})
@@ -404,8 +559,18 @@
         ;; while an UNCONSUMED violation keeps its selector OUT of the set so
         ;; the floor still fails the run on it.
         schema-match   (match-schema-expectations schema-expectations tape)
-        records        (into (assertion-records assertions)
-                             (:records schema-match))
+        ;; Causal / cascade expectations (§Causal and cascade assertions,
+        ;; rf2-5x1wt.31): project each declared `:rf.assert/caused` /
+        ;; `:rf.assert/no-cascade-rerender` against the SAME reactive
+        ;; evidence the tape already carries (`:reactive-counts` `:by-cause`,
+        ;; `:sub-runs`, `:renders`). Pure expectations, NOT floor signals —
+        ;; the minted records join `:assertions` and the verdict reads them
+        ;; through `aggregate-status`. A run with no reactive rows is caught
+        ;; upstream by the `:reactive-counts` fail-closed evidence-slot check.
+        causal-match   (match-causal-expectations causal-expectations evidence-slots)
+        records        (-> (assertion-records assertions)
+                           (into (:records schema-match))
+                           (into (:records causal-match)))
         checks         (check-records check->atoms records)
         consumed       (into (or consumed-selectors #{})
                              (:consumed-selectors schema-match))

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -428,6 +428,41 @@
                (concat terminal check-atoms script-atoms)))
     (catch #?(:clj Throwable :cljs :default) _ [])))
 
+(defn- plan-assertion-atoms
+  "Collect EVERY declared assertion atom for a normalized PLAN, across the
+  three positions in the ONE assertion-atom vocabulary (mirroring
+  `plan-schema-expectations`): the terminal `[:expect :assertions]`, the
+  expanded `[:expect :checks]` atoms, and the in-script `[:assert …]`
+  checkpoints of the executed script. Pure aside from the check expansion's
+  registrar reads; tolerant (any failure yields no atoms). Used to feed the
+  tape-evaluated expectation matchers (`:rf.assert/caused` /
+  `:rf.assert/no-cascade-rerender`, rf2-5x1wt.31) that — like
+  `:rf.assert/schema-error` — carry NO `reg-event-fx` handler and so must be
+  collected from the plan, not the `:rf.story/assertions` accumulator."
+  [plan executed-script]
+  (try
+    (let [terminal     (vec (get-in plan [:expect :assertions]))
+          check-atoms  (mapcat val (plan-checks plan))
+          script-atoms (into []
+                             (keep (fn [step]
+                                     (when (and (vector? step)
+                                                (= :assert (first step)))
+                                       (second step))))
+                             (or executed-script []))]
+      (vec (concat terminal check-atoms script-atoms)))
+    (catch #?(:clj Throwable :cljs :default) _ [])))
+
+(defn- plan-causal-expectations
+  "Collect every declared `:rf.assert/caused` / `:rf.assert/no-cascade-
+  rerender` atom for a normalized PLAN (rf2-5x1wt.31, spec/017 §Causal and
+  cascade assertions). These are tape-evaluated against the projected
+  `:reactive-counts` `:by-cause` projection (NOT dispatched into the frame,
+  NOT a parallel accumulator), so — like `:rf.assert/schema-error` —
+  collecting the DECLARED atoms here is the single path that feeds the
+  result boundary's causal matcher (`result/match-causal-expectations`)."
+  [plan executed-script]
+  (filterv assertions/causal? (plan-assertion-atoms plan executed-script)))
+
 (defn- record-result-map
   "Build the unified run-result returned by `run-variant` (rf2-5x1wt.19,
   spec/017 §Run result + §Unified run result). Gathers whatever the
@@ -487,6 +522,15 @@
                     ;; dispatched — collected from the plan, not the
                     ;; `:rf.story/assertions` accumulator.
                     :schema-expectations (plan-schema-expectations
+                                           plan executed-script)
+                    ;; rf2-5x1wt.31 — the declared causal / cascade
+                    ;; expectations (`:rf.assert/caused` /
+                    ;; `:rf.assert/no-cascade-rerender`), tape-evaluated
+                    ;; against the projected `:reactive-counts` `:by-cause`
+                    ;; projection (§Causal and cascade assertions). Like the
+                    ;; schema-error expectations they are tape-evaluated, NOT
+                    ;; dispatched — collected from the plan.
+                    :causal-expectations (plan-causal-expectations
                                            plan executed-script)
                     ;; rf2-q5jw4 — the per-requirement `:cannot-run` refusals
                     ;; the runner could not even attempt (above). Folded into

--- a/tools/story/test/re_frame/story/generate_test.cljc
+++ b/tools/story/test/re_frame/story/generate_test.cljc
@@ -1,0 +1,211 @@
+(ns re-frame.story.generate-test
+  "Tests for generated / property-style Story runs that emit seed-bearing run
+  artifacts + shrink data, and the fault-lattice sweep (rf2-5x1wt.31,
+  spec/017-Testing-Story.md §Generated runs and artifacts + §Fault lattice
+  sweep).
+
+  Two layers, both under `clojure -M:test` (JVM) + the node-runtime CLJS
+  build:
+
+  - PURE: the seedable PRNG (`next-seed` / `seed-seq` reproducible from a
+    root seed), the failure predicate, the shrink candidate enumeration, and
+    seed-bearing artifact construction.
+  - HEADLESS (against a live frame): `check-property!` generates programs,
+    replays them into FRESH frames, and on falsification returns a SHRUNK,
+    seed-bearing failing `:rf.test/run-artifact` that promotes through the
+    existing bridge; `sweep-faults!` collects one artifact per fault cell."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core   :as rf]
+            [re-frame.epoch  :as epoch]
+            [re-frame.frame  :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.story.artifact  :as artifact]
+            [re-frame.story.generate  :as generate]
+            [re-frame.story.promotion :as promotion]))
+
+;; ===========================================================================
+;; PURE: the seedable PRNG
+;; ===========================================================================
+
+(deftest seed-sequence-is-reproducible
+  (testing "the same root seed yields the SAME sequence (reproducibility)"
+    (is (= (generate/seed-seq 12345 8) (generate/seed-seq 12345 8))
+        "a property run replays identically from its recorded :seed"))
+  (testing "different root seeds diverge"
+    (is (not= (generate/seed-seq 1 8) (generate/seed-seq 2 8))))
+  (testing "seed-seq length + the root seed is never reused as a program seed"
+    (let [s (generate/seed-seq 99 5)]
+      (is (= 5 (count s)))
+      (is (not (some #{99} s)) "root seed itself is not in the program-seed sequence")))
+  (testing "next-seed is a pure, deterministic successor"
+    (is (= (generate/next-seed 7) (generate/next-seed 7)))))
+
+;; ===========================================================================
+;; PURE: failure predicate + shrink candidate enumeration
+;; ===========================================================================
+
+(deftest failing-predicate
+  (testing ":fail / :error falsify; :pass / :cannot-run do not"
+    (is (generate/failing? {:status :fail}))
+    (is (generate/failing? {:status :error}))
+    (is (not (generate/failing? {:status :pass})))
+    (is (not (generate/failing? {:status :cannot-run}))
+        ":cannot-run is inconclusive, not a falsification")))
+
+(deftest drop-candidates-enumeration
+  (testing "drop-candidates removes one contiguous chunk-size window, L→R"
+    (is (= [[:b :c :d] [:a :c :d] [:a :b :d] [:a :b :c]]
+           (generate/drop-candidates [:a :b :c :d] 1))
+        "chunk-size 1: drop each single step in turn (one candidate per step)")
+    (is (= [[:c :d] [:a :b]]
+           (generate/drop-candidates [:a :b :c :d] 2))
+        "chunk-size 2: drop the first pair, then the second pair"))
+  (testing "a chunk >= length yields the empty program; <= 0 yields none"
+    (is (= [[]] (generate/drop-candidates [:a :b] 2)))
+    (is (= []  (generate/drop-candidates [:a :b] 0)))
+    (is (= []  (generate/drop-candidates [] 3)))))
+
+;; ===========================================================================
+;; PURE: seed-bearing artifact construction
+;; ===========================================================================
+
+(deftest generated-artifact-carries-seed-and-shrink
+  (testing "a generated artifact is a :rf.test/run-artifact carrying its :seed"
+    (let [a (generate/generated-artifact
+              {:seed 42 :event-program [[:counter/inc]]})]
+      (is (artifact/run-artifact? a))
+      (is (= 42 (:seed a)))
+      (is (= [[:dispatch [:counter/inc]]] (:event-program a))
+          "a bare event vector lifts to a tagged dispatch program")
+      (is (= :rf.story/property-run (get-in a [:source :tool])))))
+  (testing "a shrunk failure carries its :shrink-path; absent when not shrunk"
+    (let [shrunk (generate/generated-artifact
+                   {:seed 1 :event-program [[:a]] :shrink-path [[[:a] [:b]]]})
+          plain  (generate/generated-artifact {:seed 1 :event-program [[:a]]})]
+      (is (= [[[:a] [:b]]] (:shrink-path shrunk)))
+      (is (not (contains? plain :shrink-path))))))
+
+;; ===========================================================================
+;; HEADLESS: against a live frame
+;; ===========================================================================
+
+(defn- reset-rf! [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (epoch/clear-history!)
+  (epoch/clear-epoch-listeners!)
+  (try (rf/init! plain-atom/adapter)
+       (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) _ nil))
+  (frame/ensure-default-frame!)
+  (test-fn))
+
+(use-fixtures :each reset-rf!)
+
+(deftest check-property-passes-and-records-num-tests
+  (testing "a property that always holds passes over N seeds"
+    ;; A handler that always succeeds — every generated program passes.
+    (rf/reg-event-db :gen/ok (fn [db _] (update db :n (fnil inc 0))))
+    (let [res (generate/check-property!
+                (fn [_seed] [[:dispatch [:gen/ok]]])
+                {:seed 7 :num-tests 5})]
+      (is (= :pass (:status res)))
+      (is (= 5 (:num-tests res)))
+      (is (= 7 (:seed res)) "the reproducible root seed is recorded"))))
+
+;; A throwing fx + the handler that emits it — an fx-handler exception lands
+;; an `:outcome :error` effect row in the tape, which the agreement floor
+;; (`evidence/tape-shows-failure?` via `error-effect?`) reads as `:fail`.
+;; `:platforms #{:client :server}` so it fires on the JVM (`:server`) gate.
+(defn- reg-boom! []
+  (rf/reg-fx :gen.fx/boom {:platforms #{:client :server}}
+             (fn [_ _] (throw (ex-info "fault: boom" {}))))
+  (rf/reg-event-fx :gen/boom (fn [_ _] {:fx [[:gen.fx/boom {}]]})))
+
+(deftest check-property-falsifies-and-emits-seed-bearing-artifact
+  (testing "a property that fails yields a seed-bearing failing artifact"
+    (reg-boom!)
+    (let [res (generate/check-property!
+                (fn [_seed] [[:dispatch [:gen/boom]]])
+                {:seed 3 :num-tests 4 :shrink? false})]
+      (is (= :fail (:status res)))
+      (is (some? (:seed res)) "the failing program's seed is recorded")
+      (is (artifact/run-artifact? (:artifact res)))
+      (is (= (:seed res) (:seed (:artifact res)))
+          "the artifact carries the falsifying seed")
+      (is (= :fail (:status (:result res)))))))
+
+(deftest check-property-shrinks-toward-a-minimal-failing-program
+  (testing "shrinking drops irrelevant steps, keeping the minimal failing case"
+    ;; :gen/noise is harmless; :gen/boom emits the failing effect. A program
+    ;; with many noise steps + one boom should shrink toward just the boom.
+    (rf/reg-event-db :gen/noise (fn [db _] (update db :noise (fnil inc 0))))
+    (reg-boom!)
+    (let [program [[:dispatch [:gen/noise]] [:dispatch [:gen/noise]]
+                   [:dispatch [:gen/boom]]
+                   [:dispatch [:gen/noise]] [:dispatch [:gen/noise]]]
+          res (generate/check-property!
+                (fn [_seed] program)
+                {:seed 1 :num-tests 1 :shrink? true})]
+      (is (= :fail (:status res)))
+      (is (<= (count (:smallest-program res)) (count program))
+          "the shrunk program is no larger than the original")
+      (is (some #(= [:dispatch [:gen/boom]] %) (:smallest-program res))
+          "the minimal failing program retains the boom step")
+      (is (= :fail (:status (:result res))) "the shrunk program still fails")
+      (is (seq (:shrink-path res)) "the shrink-path records the kept reductions")
+      (is (= (:smallest-program res) (:event-program (:artifact res)))
+          "the artifact carries the shrunk program"))))
+
+(deftest generated-failure-promotes-through-the-existing-bridge
+  (testing "a generated failure's artifact promotes into a curated variant,
+            preserving the source link + the seed/shrink provenance"
+    (reg-boom!)
+    (let [res      (generate/check-property!
+                     (fn [_seed] [[:dispatch [:gen/boom]]])
+                     {:seed 5 :num-tests 2 :shrink? true})
+          artifact (:artifact res)
+          ;; materialize-variant-plan is PURE — registers nothing; it proves
+          ;; the generated failure flows through the promotion bridge with
+          ;; its seed-bearing source link intact.
+          plan     (promotion/materialize-variant-plan
+                     artifact {:variant/id :story.gen/regression-5})]
+      (is (= :fail (:status res)))
+      (is (= :rf.test/run-artifact (get-in plan [:run-artifact :artifact/kind]))
+          "the materialized plan preserves the source-artifact link")
+      (is (= (:seed artifact) (get-in plan [:run-artifact :seed]))
+          "the curated plan's provenance carries the falsifying seed")
+      (is (contains? (:run-artifact plan) :event-program)
+          "the source link is replayable (carries the event program)"))))
+
+;; ===========================================================================
+;; HEADLESS: fault lattice sweep
+;; ===========================================================================
+
+(deftest sweep-faults-collects-one-artifact-per-cell
+  (testing "a fault sweep replays the base program across fx-override cells,
+            collecting one seed-bearing artifact per cell + the failing ids"
+    ;; :app.fx/save is the 'real' effect. The :fail fault stub raises; the
+    ;; :ok cell uses no override (the real fx records cleanly).
+    (rf/reg-fx :app.fx/save {:platforms #{:client :server}}
+               (fn [_ _] :ok))
+    (rf/reg-fx :app.fx/save-broken {:platforms #{:client :server}}
+               (fn [_ _]
+                 (throw (ex-info "fault: save failed" {}))))
+    (rf/reg-event-fx :app/save (fn [_ _] {:fx [[:app.fx/save {}]]}))
+    (let [base   [[:dispatch [:app/save]]]
+          lattice {:healthy {}
+                   :save-fails {:app.fx/save :app.fx/save-broken}}
+          res    (generate/sweep-faults! base lattice {:seed 11})]
+      (is (= 2 (count (:cells res))) "one cell per lattice entry")
+      (let [by-cell (into {} (map (juxt :cell identity)) (:cells res))]
+        (is (artifact/run-artifact? (:artifact (:healthy by-cell))))
+        (is (artifact/run-artifact? (:artifact (:save-fails by-cell))))
+        (is (= {:app.fx/save :app.fx/save-broken}
+               (:fx-decisions (:artifact (:save-fails by-cell))))
+            "the faulted cell's artifact carries its fault overrides for replay")
+        (is (= 11 (:seed (:artifact (:healthy by-cell))))
+            "each cell's artifact carries the sweep seed for provenance"))
+      ;; The :save-fails cell errored → it is in :failing.
+      (is (some #{:save-fails} (:failing res))
+          "the faulted cell falsifies and is reported in :failing"))))

--- a/tools/story/test/re_frame/story/result_test.cljc
+++ b/tools/story/test/re_frame/story/result_test.cljc
@@ -318,6 +318,129 @@
       (is (= :fail (:status r)) "rollback to a clean db does NOT hide the tape violation")
       (is (= 1 (count (:schema-violations r)))))))
 
+;; ===========================================================================
+;; CAUSAL / CASCADE EXPECTATIONS (rf2-5x1wt.31, §Causal and cascade assertions)
+;; ===========================================================================
+;;
+;; The matcher reads the SAME reactive evidence the tape already carries —
+;; the `:rf.sub/run` / `:rf.view/rendered` rows stamped with the dispatching
+;; cascade's `:cause-event-id` (rf2-5x1wt.30 `evidence/reactive-counts`). A
+;; reactive epoch is one whose sub-runs / renders carry `:cause-event-id`.
+
+(defn- reactive-epoch
+  "An epoch carrying reactive rows attributed to `cause` — `n-subs` sub
+  recomputes of `sub-id` and `n-renders` renders of `view-id`."
+  [cause sub-id n-subs view-id n-renders]
+  (epoch {:trigger-event [cause]
+          :sub-runs (vec (repeat n-subs {:sub-id sub-id :recomputed? true
+                                         :cause-event-id cause}))
+          :renders  (vec (repeat n-renders {:render-key [view-id 0]
+                                            :cause-event-id cause}))}))
+
+(deftest causal-caused-passes-when-the-cause-produced-the-effect
+  (testing ":rf.assert/caused {:event e} passes when e caused >= 1 reactive effect"
+    (let [tape [(reactive-epoch :counter/inc :total 1 :counter 1)]
+          r    (result/run-result
+                 {:epoch-tape tape
+                  :causal-expectations [[:rf.assert/caused {:event :counter/inc}]]})
+          rec  (first (filter #(= :rf.assert/caused (:assertion %)) (:assertions r)))]
+      (is (= :pass (:status r)))
+      (is (= :pass (:status rec)))
+      (is (= 2 (get-in rec [:actual :count])) "1 sub + 1 render = 2 total effects")))
+
+  (testing ":rf.assert/caused {:event e :sub s} measures the named sub only"
+    (let [tape [(reactive-epoch :counter/inc :total 3 :counter 1)]
+          r    (result/run-result
+                 {:epoch-tape tape
+                  :causal-expectations [[:rf.assert/caused {:event :counter/inc :sub :total}]]})
+          rec  (first (filter #(= :rf.assert/caused (:assertion %)) (:assertions r)))]
+      (is (= :pass (:status rec)))
+      (is (= 3 (get-in rec [:actual :count])) "3 recomputes of :total")))
+
+  (testing ":rf.assert/caused {:event e :view v} measures the named view only"
+    (let [tape [(reactive-epoch :counter/inc :total 1 :counter 2)]
+          r    (result/run-result
+                 {:epoch-tape tape
+                  :causal-expectations [[:rf.assert/caused {:event :counter/inc :view :counter}]]})
+          rec  (first (filter #(= :rf.assert/caused (:assertion %)) (:assertions r)))]
+      (is (= :pass (:status rec)))
+      (is (= 2 (get-in rec [:actual :count])) "2 renders of :counter"))))
+
+(deftest causal-caused-fails-when-the-cause-did-not-produce-the-effect
+  (testing ":rf.assert/caused for an event that caused no reactive effect FAILS"
+    (let [tape [(reactive-epoch :counter/inc :total 1 :counter 1)]
+          r    (result/run-result
+                 {:epoch-tape tape
+                  :causal-expectations [[:rf.assert/caused {:event :other/event}]]})
+          rec  (first (filter #(= :rf.assert/caused (:assertion %)) (:assertions r)))]
+      (is (= :fail (:status r)))
+      (is (= :fail (:status rec)))
+      (is (= 0 (get-in rec [:actual :count])))))
+
+  (testing "a degenerate :rf.assert/caused (no :event) FAILS readably"
+    (let [tape [(reactive-epoch :counter/inc :total 1 :counter 1)]
+          r    (result/run-result
+                 {:epoch-tape tape
+                  :causal-expectations [[:rf.assert/caused {}]]})
+          rec  (first (filter #(= :rf.assert/caused (:assertion %)) (:assertions r)))]
+      (is (= :fail (:status rec)))
+      (is (re-find #"names no :event" (:reason rec))))))
+
+(deftest causal-no-cascade-rerender-bounds
+  (testing ":rf.assert/no-cascade-rerender passes when the event caused NO effect"
+    (let [tape [(reactive-epoch :counter/inc :total 1 :counter 1)]
+          r    (result/run-result
+                 {:epoch-tape tape
+                  :causal-expectations
+                  [[:rf.assert/no-cascade-rerender {:event :unrelated/event}]]})
+          rec  (first (filter #(= :rf.assert/no-cascade-rerender (:assertion %))
+                              (:assertions r)))]
+      (is (= :pass (:status rec)) "unrelated event caused 0 effects, within [0 0]")))
+
+  (testing ":rf.assert/no-cascade-rerender FAILS when the event over-rendered"
+    (let [tape [(reactive-epoch :counter/inc :total 1 :counter 3)]
+          r    (result/run-result
+                 {:epoch-tape tape
+                  :causal-expectations
+                  [[:rf.assert/no-cascade-rerender {:event :counter/inc :view :counter}]]})
+          rec  (first (filter #(= :rf.assert/no-cascade-rerender (:assertion %))
+                              (:assertions r)))]
+      (is (= :fail (:status r)))
+      (is (= :fail (:status rec)))
+      (is (= 3 (get-in rec [:actual :count])))))
+
+  (testing "an explicit :max bound on :no-cascade-rerender admits N renders"
+    (let [tape [(reactive-epoch :counter/inc :total 1 :counter 2)]
+          r    (result/run-result
+                 {:epoch-tape tape
+                  :causal-expectations
+                  [[:rf.assert/no-cascade-rerender {:event :counter/inc :view :counter :max 2}]]})
+          rec  (first (filter #(= :rf.assert/no-cascade-rerender (:assertion %))
+                              (:assertions r)))]
+      (is (= :pass (:status rec)) "2 renders within the explicit [0 2] bound"))))
+
+(deftest causal-against-non-reactive-run-is-cannot-run
+  (testing "a causal assertion against a run with NO reactive rows resolves
+            :cannot-run (fail closed — never a silent pass)"
+    ;; A bare dispatch-only tape carries no :reactive-counts slot.
+    (let [tape [(epoch {:effects [{:fx-id :db :outcome :ok}]})]
+          r    (result/run-result
+                 {:epoch-tape tape
+                  :causal-expectations [[:rf.assert/caused {:event :counter/inc}]]})
+          rec  (first (filter #(= :rf.assert/caused (:assertion %)) (:assertions r)))]
+      (is (= :cannot-run (:status rec)))
+      (is (= :cannot-run (:status r)) "the run aggregates to :cannot-run")
+      (is (re-find #"requires reactive evidence" (:reason rec))))))
+
+(deftest causal-expectations-are-not-floor-signals
+  (testing "an over-render does NOT trip the agreement floor on its own —
+            only a declared :no-cascade-rerender judges it"
+    ;; A reactive tape with no schema/effect failure + NO causal expectation
+    ;; is a clean :pass, even with many renders.
+    (let [tape [(reactive-epoch :counter/inc :total 5 :counter 9)]
+          r    (result/run-result {:epoch-tape tape})]
+      (is (= :pass (:status r)) "renders alone are not a tape failure"))))
+
 ;; ---- projections AGREE with the tape (§B5) -------------------------------
 
 (deftest result-projections-agree-with-the-tape


### PR DESCRIPTION
Closes the NewTestStory EPIC''s last non-UI implementation bead (rf2-5x1wt.31). Builds all four deeper-check capabilities on the LANDED foundations — each DERIVED from existing evidence/runner policy, with no new trace op-type, no new fault-injection contract, and no new dependency.

## What landed

**1. Causal / cascade assertions** (`:rf.assert/caused` + `:rf.assert/no-cascade-rerender`)
These were already declared in the requirement registry + had the `reactive-counts` projection (rf2-5x1wt.30) but no evaluator. They are now tape-evaluated in the result boundary — exactly like `:rf.assert/schema-error`: NOT dispatched into the frame, NOT a parallel accumulator. The matcher (`result/match-causal-expectations`) projects a cause→effect relationship from the existing `:cause-event-id` reactive evidence (the `reactive-counts` `:by-cause` / `:sub-runs` / `:renders` projection). The declared atom names the cause `:event` and optionally an effect surface (`:sub` / `:view`) + count bound (`:min` / `:max` / `:exactly`). A non-reactive run resolves `:cannot-run` (fail closed). No new trace op-type was needed — so no decision-fork was filed.

**2. Generated / property-style runs → seed/shrink artifacts** (`generate/check-property!`)
A generator-agnostic property runner (caller hands a pure `(fn [seed] event-program)`) over a self-contained seedable splitmix64 PRNG — reproducible from the recorded root `:seed`, no `test.check` dependency. Every generated run emits a `:rf.test/run-artifact` carrying its `:seed`; a failure shrinks via deterministic delta-debug, recording the `:shrink-path`. Both artifact slots already existed (rf2-5x1wt.7); this is the producer that fills them.

**3. Curated promotion of generated failures**
A generated failure''s artifact flows through the existing promotion bridge (`materialize-variant-plan` / `promote-run-artifact!`) with the seed + source-artifact link preserved (the bridge already kept `:seed`/`:shrink-path` in `provenance-link-keys`). Test-verified end-to-end.

**4. Fault lattice sweep** (`generate/sweep-faults!`)
Replays one base program across a lattice of `:fx-decisions` fault cells using the EXISTING fx-override world input (the same surface `:network` lowers to). One seed-bearing artifact per cell + the failing cell ids. A "fault" is just an fx override — no new fault-injection contract, so no decision-fork was filed.

Re-exported on the `re-frame.story` facade as `check-property!` / `sweep-faults!`. spec/017 updated (Causal and cascade assertions §; Generated runs and artifacts §; Fault lattice sweep §; P1 acceptance bullet) — localized to the deeper-checks sections.

## Production-classpath safety
New `generate.cljc` requires only `re-frame.story.artifact` (which reads the late-bound `rf/epoch-history` facade — no hard `[re-frame.epoch]` require). No test-only require leaks into a production ns.

## Deferred / follow-on
- **rf2-6nk6d** (P3, filed + linked): optional `clojure.test.check` adapter for `check-property!` — pure additive sugar over the generator-agnostic surface; the seedable PRNG path stays the dependency-free default.

## Quality gates
- `tools/story` `clojure -M:test`: **1264 tests, 4066 assertions, 0 failures, 0 errors** (green)
- `tools/story-mcp` `clojure -M:test`: **172 tests, 861 assertions, 0 failures, 0 errors** (green)
- `tools/mcp-conformance` `npm run test:story`: **STORY-MCP MCP-CLIENT CONFORMANCE GREEN**
- `implementation` `npm run test:cljs`: **4865 tests, 15925 assertions, 0 failures, 0 errors** (green — validates the `:cljs` BigInt PRNG branch)
- `scripts/test-fast-pr.sh`: **PASS** (core JVM + CLJS node integration + markdown link/anchor gates; mkdocs soft-skipped on Windows as designed)