### PR TITLE
fix(epoch): thread :cause-event-id onto :renders projection rows — closes a :view-surface false-green (rf2-9gquv)

### DIFF
--- a/implementation/epoch/src/re_frame/epoch/capture.cljc
+++ b/implementation/epoch/src/re_frame/epoch/capture.cljc
@@ -416,6 +416,19 @@
                     re-render (rf2-8wrzz.1); absent on a structural render.
     :elapsed-ms   — (when present) the render duration in fractional ms
                     (rf2-8wrzz.1).
+    :cause-event-id — (when present) the event-id of the cascade whose
+                    handler-body invalidated a reactive input this view
+                    deref'd, triggering the re-render (rf2-1cc03 /
+                    rf2-9gquv). The `:rf.view/rendered` op stamps
+                    `:rf.view/cause-event-id` (views.cljs) under the same
+                    OMITTED-vs-nil semantics as the sub-row's
+                    `:rf.sub/cause-event-id`: absent (not nil) for a render
+                    outside any in-flight cascade (mount / structural render)
+                    or when no cause was derivable. This is the slot the
+                    causal/cascade `:view` surface reads
+                    (`evidence/reactive-counts` `:by-cause`,
+                    `result/causal-count`) — without it every `:renders` row
+                    keys as nil and view-render attribution silently reads 0.
 
   The optional slots are threaded only when the trace tag carries them so
   the row stays minimal for renders outside a cascade / structural
@@ -430,7 +443,9 @@
         (some? (:rf.view/triggered-by tags))
         (assoc :triggered-by (:rf.view/triggered-by tags))
         (some? (:rf.view/elapsed-ms tags))
-        (assoc :elapsed-ms (:rf.view/elapsed-ms tags))))))
+        (assoc :elapsed-ms (:rf.view/elapsed-ms tags))
+        (contains? tags :rf.view/cause-event-id)
+        (assoc :cause-event-id (:rf.view/cause-event-id tags))))))
 
 (defn project-all
   "Walk the captured trace events ONCE and emit the three `:sub-runs`,

--- a/implementation/epoch/test/re_frame/epoch_attribution_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_attribution_test.clj
@@ -852,6 +852,64 @@
       (is (= 0.3 (:elapsed-ms row)) ":elapsed-ms still preserved"))))
 
 ;; ===========================================================================
+;; rf2-9gquv — the :renders projection carries :cause-event-id (the cascade
+;;             whose handler-body invalidated a reactive input this view read)
+;; ===========================================================================
+;;
+;; The false-green guard at the projection boundary. The :rf.view/rendered op
+;; stamps :rf.view/cause-event-id (views.cljs, rf2-1cc03) exactly as the
+;; :rf.sub/run op stamps :rf.sub/cause-event-id — but render-row formerly
+;; dropped it, so every projected render row keyed as nil and the Story
+;; causal/cascade :view surface silently measured 0 (an over-render could
+;; never be caught: a SILENT GREEN). This pins that the render row carries
+;; the cause end-to-end, mirroring the sub-row.
+
+(deftest renders-projection-carries-cause-event-id
+  (testing "rf2-9gquv — a :rf.view/rendered op carrying :rf.view/cause-event-id
+            (the cascade that invalidated a reactive input this view read)
+            lands :cause-event-id on the :renders projection row, end-to-end —
+            the slot the Story :view causal surface reads. Pre-fix render-row
+            dropped it and the surface silently measured 0 (false GREEN)."
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/dispatch-sync [:seed] {:frame :test/main})
+
+    ;; Post-settle :rf.view/rendered carrying the cause attribution (mirrors
+    ;; the reactive re-render emit at views.cljs:320-321).
+    (trace/emit! :rf.view :rf.view/rendered
+                 {:rf.view/render-key     [:counter-view 0]
+                  :frame                  :test/main
+                  :rf.view/mount?         false
+                  :rf.view/cause-event-id :counter-inc})
+
+    (let [epoch (last-epoch :test/main)
+          row   (render-row-for epoch [:counter-view 0])]
+      (is (some? row) "the :renders projection carries the render row")
+      (is (= :counter-inc (:cause-event-id row))
+          ":cause-event-id is threaded onto the :renders row — mirroring how
+           the :sub-runs row carries :cause-event-id (capture.cljc)"))))
+
+(deftest renders-projection-omits-cause-event-id-on-structural-render
+  (testing "rf2-9gquv — a render OUTSIDE any cascade (mount / structural —
+            the op carries no :rf.view/cause-event-id) lands a :renders row
+            WITHOUT :cause-event-id. OMITTED-vs-nil parity with the sub-row:
+            absent tag → absent slot, never an attributed nil."
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/dispatch-sync [:seed] {:frame :test/main})
+
+    (trace/emit! :rf.view :rf.view/rendered
+                 {:rf.view/render-key [:structural-view 0]
+                  :frame              :test/main
+                  :rf.view/mount?     false})
+
+    (let [epoch (last-epoch :test/main)
+          row   (render-row-for epoch [:structural-view 0])]
+      (is (some? row) "the structural render still produces a :renders row")
+      (is (not (contains? row :cause-event-id))
+          ":cause-event-id absent when the op carried no cause tag"))))
+
+;; ===========================================================================
 ;; rf2-dq2b7 — mount-attribution atom merge: epoch-id + deps share one entry
 ;; ===========================================================================
 

--- a/tools/story/test/re_frame/story/result_test.cljc
+++ b/tools/story/test/re_frame/story/result_test.cljc
@@ -16,6 +16,7 @@
   - schema / warning / effect projections AGREE with the epoch tape;
   - `story/is` reports per assertion (`result->reports`)."
   (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.epoch.capture   :as capture]
             [re-frame.story.result   :as result]
             [re-frame.story.play.evidence :as evidence]
             [re-frame.story.requirements  :as requirements]))
@@ -326,16 +327,55 @@
 ;; the `:rf.sub/run` / `:rf.view/rendered` rows stamped with the dispatching
 ;; cascade's `:cause-event-id` (rf2-5x1wt.30 `evidence/reactive-counts`). A
 ;; reactive epoch is one whose sub-runs / renders carry `:cause-event-id`.
+;;
+;; rf2-9gquv — these epochs are PROJECTION-DERIVED, not hand-stamped. The
+;; prior `reactive-epoch` synthesised `{:render-key [view-id 0]
+;; :cause-event-id cause}` render rows directly — a shape the REAL
+;; `capture/render-row` projection never produced, because `render-row`
+;; dropped `:rf.view/cause-event-id` off the trace event. That synthetic
+;; tape masked a false-GREEN: the projection emitted render rows with NO
+;; `:cause-event-id`, so the `:view` causal surface silently measured 0 and
+;; `:rf.assert/no-cascade-rerender {:view v}` could never catch an
+;; over-render. We now drive the rows through `capture/render-row` /
+;; `capture/sub-run-row` over real `:rf.view/rendered` / `:rf.sub/run` trace
+;; events, so the tape carries `:cause-event-id` ONLY because the projection
+;; threads it. Pre-fix (projection not threading) these epochs carry no
+;; render-row `:cause-event-id` and the `:view` assertions fail; post-fix
+;; they pass — closing the false-green at the projection boundary.
+
+(defn- rendered-trace-event
+  "A real `:rf.view/rendered` trace event for view `view-id` caused by
+  `cause`, mirroring the views.cljs emit-site tags (rf2-1cc03)."
+  [view-id cause]
+  {:operation :rf.view/rendered
+   :tags      {:rf.view/render-key     [view-id 0]
+               :rf.view/id             view-id
+               :rf.view/cause-event-id cause}})
+
+(defn- sub-run-trace-event
+  "A real `:rf.sub/run` trace event for sub `sub-id` caused by `cause`,
+  mirroring the reactive-recompute emit-site tags."
+  [sub-id cause]
+  {:operation :rf.sub/run
+   :tags      {:rf.sub/id              sub-id
+               :rf.sub/query-v         [sub-id]
+               :rf.sub/value-changed?  true
+               :rf.sub/cause-event-id  cause}})
 
 (defn- reactive-epoch
   "An epoch carrying reactive rows attributed to `cause` — `n-subs` sub
-  recomputes of `sub-id` and `n-renders` renders of `view-id`."
+  recomputes of `sub-id` and `n-renders` renders of `view-id`.
+
+  rf2-9gquv: the rows are PROJECTION-DERIVED via `capture/sub-run-row` /
+  `capture/render-row` over real trace events, NOT hand-stamped. The
+  `:cause-event-id` slot rides each row only because the projection threads
+  it — so these epochs exercise the genuine production shape."
   [cause sub-id n-subs view-id n-renders]
   (epoch {:trigger-event [cause]
-          :sub-runs (vec (repeat n-subs {:sub-id sub-id :recomputed? true
-                                         :cause-event-id cause}))
-          :renders  (vec (repeat n-renders {:render-key [view-id 0]
-                                            :cause-event-id cause}))}))
+          :sub-runs (mapv (fn [_] (capture/sub-run-row (sub-run-trace-event sub-id cause)))
+                          (range n-subs))
+          :renders  (mapv (fn [_] (capture/render-row (rendered-trace-event view-id cause)))
+                          (range n-renders))}))
 
 (deftest causal-caused-passes-when-the-cause-produced-the-effect
   (testing ":rf.assert/caused {:event e} passes when e caused >= 1 reactive effect"
@@ -418,6 +458,70 @@
           rec  (first (filter #(= :rf.assert/no-cascade-rerender (:assertion %))
                               (:assertions r)))]
       (is (= :pass (:status rec)) "2 renders within the explicit [0 2] bound"))))
+
+;; ---- rf2-9gquv: the projection threads :cause-event-id onto render rows --
+;;
+;; These tests guard the false-green directly at the projection boundary —
+;; the layer the prior synthetic `reactive-epoch` masked. They drive a REAL
+;; `:rf.view/rendered` trace event through `capture/render-row` and assert
+;; the `:view` causal surface reads the cause-attributed render. Pre-fix
+;; (render-row dropping `:rf.view/cause-event-id`) the row carries no
+;; `:cause-event-id`, so `causal-count` / `reactive-counts` :by-cause credit
+;; 0 renders to the cause — `:rf.assert/caused {:view}` falsely FAILS and
+;; `:rf.assert/no-cascade-rerender {:view}` falsely PASSES (the silent
+;; green). Post-fix the row carries it and both judge correctly.
+
+(deftest render-row-projection-carries-cause-event-id
+  (testing "capture/render-row threads :rf.view/cause-event-id off the
+            :rf.view/rendered trace event (mirroring the sub-row, rf2-9gquv)"
+    (let [row (capture/render-row (rendered-trace-event :counter :counter/inc))]
+      (is (= :counter/inc (:cause-event-id row))
+          "the render row MUST carry the cause-event-id the trace event stamped")
+      (is (= [:counter 0] (:render-key row)))))
+
+  (testing "a render with NO cause tag (mount / structural) omits the slot —
+            OMITTED-vs-nil parity with the sub-row"
+    (let [row (capture/render-row {:operation :rf.view/rendered
+                                   :tags {:rf.view/render-key [:counter 0]
+                                          :rf.view/id :counter}})]
+      (is (not (contains? row :cause-event-id))
+          "absent cause tag → absent slot, not nil"))))
+
+(deftest view-over-render-is-detected-end-to-end
+  (testing "a genuine view over-render IS caught by :rf.assert/no-cascade-rerender
+            via the real projection (rf2-9gquv false-green guard)"
+    ;; 3 projection-derived renders of :counter attributed to :counter/inc.
+    ;; Pre-fix the projected rows carry no :cause-event-id → measured 0 within
+    ;; the default [0 0] bound → silent PASS (the false green). Post-fix the
+    ;; rows carry the cause → measured 3 > 0 → the over-render FAILS as it must.
+    (let [tape [(reactive-epoch :counter/inc :total 1 :counter 3)]
+          r    (result/run-result
+                 {:epoch-tape tape
+                  :causal-expectations
+                  [[:rf.assert/no-cascade-rerender {:event :counter/inc :view :counter}]]})
+          rec  (first (filter #(= :rf.assert/no-cascade-rerender (:assertion %))
+                              (:assertions r)))]
+      (is (= :fail (:status rec)) "the 3 renders MUST be detected, not silently 0")
+      (is (= 3 (get-in rec [:actual :count]))
+          "the cause-attributed render count rides the real projection")))
+
+  (testing "a genuine cause IS credited to the view by :rf.assert/caused {:view}"
+    (let [tape [(reactive-epoch :counter/inc :total 1 :counter 2)]
+          r    (result/run-result
+                 {:epoch-tape tape
+                  :causal-expectations
+                  [[:rf.assert/caused {:event :counter/inc :view :counter}]]})
+          rec  (first (filter #(= :rf.assert/caused (:assertion %)) (:assertions r)))]
+      (is (= :pass (:status rec)) "2 cause-attributed renders → caused passes")
+      (is (= 2 (get-in rec [:actual :count])))))
+
+  (testing "the :by-cause evidence credits view-renders to the cause (not nil)"
+    (let [tape    [(reactive-epoch :counter/inc :total 1 :counter 2)]
+          rc      (evidence/reactive-counts tape)
+          credited (get (:by-cause rc) :counter/inc)]
+      (is (= 2 (:view-renders credited))
+          "the projected render rows key on :counter/inc, not nil")
+      (is (= 1 (:sub-recomputes credited))))))
 
 (deftest causal-against-non-reactive-run-is-cannot-run
   (testing "a causal assertion against a run with NO reactive rows resolves


### PR DESCRIPTION
## The false-green (P1)

The `:rf.view/rendered` trace event carries `:rf.view/cause-event-id` (stamped at `implementation/core/src/re_frame/views.cljs:320-321`, rf2-1cc03), but the epoch projection's `render-row` (`implementation/epoch/src/re_frame/epoch/capture.cljc`) **never threaded it onto the projected `:renders` row** — even though the sibling `sub-run-row` already threads `:cause-event-id`. So every projected render row keyed as `nil`.

Downstream in the Story `.31` causal/cascade feature this is a **silent GREEN** — the exact false-green class `result.cljc` was built to kill:

- `evidence/reactive-counts` `:by-cause` credits renders via `(:cause-event-id r)` → always `nil` → dropped → view-renders never attributed to any cause.
- `result/causal-count` `:view` surface filters renders by `(= event (:cause-event-id r))` → always `0`.
- `:rf.assert/no-cascade-rerender {:event e :view v}` could **never** detect a view over-render (count `0` within the default `[0 0]` bound → silent PASS).
- `:rf.assert/caused {:event e :view v}` always falsely **failed**.

The `:sub` surface was already correct (sub-rows carry `:cause-event-id`); only the view path was broken.

### Why the existing tests didn't catch it

The `.31` causal tests were themselves false-green: `tools/story/test/re_frame/story/result_test.cljc`'s `reactive-epoch` helper **hand-stamped** `{:render-key [view-id 0] :cause-event-id cause}` directly onto render rows — a shape the real `render-row` projection never produced. No test drove a render through the actual projection.

## The fix

1. **`capture.cljc` `render-row`** — thread `:cause-event-id` from the `:rf.view/rendered` trace event onto the `:renders` row via the same `contains?`-guarded `cond->` clause `sub-run-row` uses (OMITTED-vs-nil parity: absent for mount / structural renders outside a cascade). Pure additive; canonical key `:cause-event-id` matches what `evidence`/`result` read.

2. **`result_test.cljc`** — replaced the hand-stamped `reactive-epoch` synthetic render rows with **projection-derived** rows driven through `capture/render-row` / `capture/sub-run-row` over real trace events. The `:cause-event-id` now rides each row *only because the projection threads it*. Added a net-new `view-over-render-is-detected-end-to-end` deftest proving a genuine over-render IS caught by `:rf.assert/no-cascade-rerender` and a genuine cause IS credited by `:rf.assert/caused {:view}` + `reactive-counts :by-cause`.

3. **`epoch_attribution_test.clj`** — added impl-layer `renders-projection-carries-cause-event-id` (+ the structural-render omission sibling), mirroring the existing `renders-projection-carries-triggered-by-and-elapsed-ms` end-to-end pattern.

### Genuinely fails pre-fix / passes post-fix

Verified by reverting only `capture.cljc` and re-running:

- `result_test`: 12 failures pre-fix (over-render silently measured `0`/`:pass`; render-row `:cause-event-id` nil; `:by-cause` view-renders 0) → 0 post-fix.
- `epoch_attribution_test`: `renders-projection-carries-cause-event-id` fails pre-fix (`:cause-event-id` nil) → passes post-fix.

The `:sub` surface is unregressed (its tests pass in both runs).

## Quality gates

| Gate | Result |
| --- | --- |
| `implementation`: `npm run test:cljs` | 4865 tests / 15925 assertions — **0 failures, 0 errors** |
| `tools/story`: `clojure -M:test` | 1266 tests / 4075 assertions — **0 failures, 0 errors** |
| `tools/story-mcp`: `clojure -M:test` | 172 tests / 861 assertions — **0 failures, 0 errors** |
| `tools/mcp-conformance`: `npm run test:story` | **STORY-MCP MCP-CLIENT CONFORMANCE GREEN** |
| `tools/xray`: `clojure -M:test` | 969 tests / 3808 assertions — **0 failures, 0 errors** (no cause-attribution regression, a1d9b3ab2) |
| `bash scripts/test-fast-pr.sh` | **PASS fast PR spine** |

refs rf2-5x1wt.31 rf2-5x1wt.30 rf2-1cc03