### PR TITLE
fix(story/diff): facet-set == canonical slice + drop spurious root leaf (rf2-e6uod + rf2-5l0a5 + rf2-bd6ei)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -2724,11 +2724,19 @@ what counts as the same run. The pure provenance a run-result also carries
 
 Each facet is projected independently and contributes to the result **only
 when it differs**, so the diff localises *where* two runs parted and stays
-small:
+small.
 
-Every behavioural slot in the run-**slice** (`run-hash-input-keys`, the
-surface `:same?` is judged over) is covered by a facet, so a diff the gate
-calls different always localises *where*:
+**INVARIANT — the facet set IS the canonical slice.** The `diff-runs` facet
+names are EXACTLY `run-hash-input-keys`, the slice `:same?` is judged over
+(`:trace-ops` is the readable projection of the `:epoch-tape` slot's causal op
+spine, so it stands in for `:epoch-tape` 1:1). This is bidirectional and both
+directions are load-bearing: every slice slot is covered (so a diff the gate
+calls different always localises *where*), AND no facet sits *outside* the
+slice (so no facet is dead — a facet for a slot the `:same?` judgement ignores
+could never fire through `diff-runs`, and would overstate coverage while
+disagreeing with the determinism gate / golden verdict). `:status` is in both
+the facet set and the slice; it is listed last below as the headline a reader
+wants first.
 
 - `:app-db` — a readable key-path delta of the final app-db
   (`:added` / `:removed` / `:changed`, each entry a `{:path … :baseline …
@@ -2766,11 +2774,18 @@ calls different always localises *where*:
   (`:only-baseline` / `:only-current`) — the rungs one run rested on and the
   other did not (e.g. a baseline using `:real-setup` vs a current that fell
   back to `:sub-overrides`);
-- `:sub-runs` — a multiset delta over the projected subscription / view
-  facts, when available (a diagnostic facet — `:sub-runs` is **not** in the
-  run-slice, so it never decides `:same?`);
 - `:status` — the top-level run status, when it differs (a `:pass` → `:fail`
   flip is the headline a reader wants first).
+
+`:sub-runs` is **not** a facet. It is deliberately excluded from the run-slice
+(`run-hash-input-keys`) — sub-runs are over-recomputed evidence, not a
+determinism input — so a `:sub-runs`-only delta does not perturb the `:same?`
+judgement, exactly as the determinism gate and the golden verdict treat it.
+Wiring a `:sub-runs` facet into `diff-runs` would make it dead code (it could
+never fire on a pure sub-runs delta) and would let the diff overstate coverage
+relative to the slice it shares with the gate. `diff-sub-runs` survives as a
+standalone **diagnostic** fn for callers that want to inspect the view-fact
+delta directly; it is not part of the `:same?` judgement.
 
 **The non-empty-`:facets` invariant.** A `:same? false` diff ALWAYS carries a
 non-empty `:facets`. The per-surface facets above cover every run-slice slot,
@@ -2793,8 +2808,10 @@ volatile noise.
 
 The facet diff fns (`diff-app-db`, `diff-assertions`, `diff-checks`,
 `diff-effects`, `diff-schema-violations`, `diff-warnings`, `diff-trace-ops`,
-`diff-sub-overrides`, `diff-fidelity`, `diff-sub-runs`) and the assembler
+`diff-sub-overrides`, `diff-fidelity`) and the assembler
 (`diff-runs`) are pure data → data — two run-results in, a readable diff out
+(the diagnostic-only `diff-sub-runs` is pure too but is not wired into
+`diff-runs` — it is outside the `:same?` slice)
 — and run under
 `clojure -M:test` with no runtime; only the artifact-replay entry path is
 impure, and when both inputs are run-results `diff-run-artifacts` is itself

--- a/tools/story/src/re_frame/story/diff.cljc
+++ b/tools/story/src/re_frame/story/diff.cljc
@@ -33,10 +33,14 @@
                            (`re-frame.story.play.evidence/violation-selector`);
   - `:trace-ops`         — the trace `:operation` sequence (the causal op
                            spine), as an ordered alignment of the two;
-  - `:sub-runs`          — subscription / view facts when available (the
-                           per-epoch sub-run rows the evidence boundary
-                           projects);
   - `:status`            — the top-level run status, when it differs.
+
+  The facet set is EXACTLY the canonical run-slice
+  (`fingerprint/run-hash-input-keys`) the `:same?` judgement compares —
+  nothing outside it. `:sub-runs` is deliberately NOT in that slice
+  (over-recomputed evidence, not a determinism input), so it carries NO
+  `diff-runs` facet; `diff-sub-runs` survives only as a standalone diagnostic
+  fn (rf2-e6uod / rf2-5l0a5).
 
   ## A readable diff, not a data dump
 
@@ -78,9 +82,11 @@
   ## Pure / JVM-testable
 
   The facet diff fns (`diff-app-db`, `diff-effects`, `diff-schema-violations`,
-  `diff-trace-ops`, `diff-sub-runs`) and the assembler (`diff-runs`) are pure
-  data → data: two run-results in, a readable diff out. `diff-run-artifacts`
-  is the thin replay-then-`diff-runs` wrapper for the artifact inputs."
+  `diff-trace-ops`, …) and the assembler (`diff-runs`) are pure data → data:
+  two run-results in, a readable diff out. `diff-sub-runs` is pure too but is
+  diagnostic-only — not wired into `diff-runs` (it is outside the `:same?`
+  slice). `diff-run-artifacts` is the thin replay-then-`diff-runs` wrapper for
+  the artifact inputs."
   (:require [clojure.set                  :as set]
             [re-frame.story.artifact      :as artifact]
             [re-frame.story.fingerprint   :as fingerprint]
@@ -99,13 +105,29 @@
 
 (defn- leaf-paths
   "Every leaf path through a nested map, paired with its value. A non-map
-  value is a leaf at its own path; an EMPTY map is a leaf (its emptiness is
-  semantic — `{:k {}}` vs `{:k {:a 1}}` differs at `[:k]`). Pure data →
-  data; returns `{[path …] value}`."
+  value is a leaf at its own path; a NON-ROOT empty map is a leaf (its
+  emptiness is semantic — `{:k {}}` vs `{:k {:a 1}}` differs at `[:k]`). Pure
+  data → data; returns `{[path …] value}`.
+
+  The ROOT is special-cased (rf2-bd6ei): an empty root map contributes NO
+  leaf at all, so an app-db cleared to `{}` does not read as a spurious
+  `{[] {}}` root leaf (which would surface as `:added`/`:removed` at the
+  nonsensical `[]` path). A populated-vs-empty difference still diffs
+  correctly — the populated side's leaves are `:removed`/`:added`, the empty
+  side simply contributes nothing."
   [x]
   (letfn [(walk [prefix v acc]
-            (if (and (map? v) (seq v))
+            (cond
+              ;; A non-empty map recurses into its entries.
+              (and (map? v) (seq v))
               (reduce-kv (fn [a k vv] (walk (conj prefix k) vv a)) acc v)
+              ;; An EMPTY map at the root is not a leaf — contribute nothing,
+              ;; so a `{}` app-db yields no spurious `[]` root leaf. At a
+              ;; non-root prefix the empty map IS a semantic leaf.
+              (and (map? v) (empty? v) (empty? prefix))
+              acc
+              ;; A scalar, or a (non-root) empty map, is a leaf at its path.
+              :else
               (assoc acc prefix v)))]
     (walk [] x {})))
 
@@ -199,10 +221,18 @@
   (multiset-delta (:effects baseline) (:effects current)))
 
 (defn diff-sub-runs
-  "Multiset delta over the two runs' projected `:sub-runs` rows — the
-  subscription / view facts, when available (spec §Semantic diff). Pure
-  data → data; `nil` when the sub-run multisets match (including when both
-  runs carry no sub-runs), else `{:only-baseline […] :only-current […]}`."
+  "DIAGNOSTIC-ONLY multiset delta over the two runs' projected `:sub-runs`
+  rows — the subscription / view facts, when available. Pure data → data;
+  `nil` when the sub-run multisets match (including when both runs carry no
+  sub-runs), else `{:only-baseline […] :only-current […]}`.
+
+  NOT part of the `:same?` judgement and NOT registered in `facet-fns`
+  (rf2-e6uod / rf2-5l0a5). `:sub-runs` is deliberately excluded from
+  `fingerprint/run-hash-input-keys` — sub-runs are over-recomputed evidence,
+  not a determinism input — so a `:sub-runs`-only delta does NOT make
+  `diff-runs` report `:same? false`, exactly as the determinism gate and the
+  golden verdict treat it. This fn exists for callers that want to inspect the
+  view-fact delta directly; it deliberately does not flow through `diff-runs`."
   [baseline current]
   (multiset-delta (:sub-runs baseline) (:sub-runs current)))
 
@@ -517,14 +547,23 @@
   difference). A new facet is added here once and flows into `diff-runs` and
   `:facets` automatically.
 
-  EVERY behavioural slot in `re-frame.story.fingerprint/run-hash-input-keys`
-  (the slice `:same?` is judged over) is covered by a facet here, so a diff
-  the gate calls different always localises WHERE. `:trace-ops` covers the
-  `:epoch-tape` slot's causal op spine; `:sub-runs` is NOT a slice key (it is
-  diagnostic, excluded from the run-hash slice — rf2-e6uod) but is kept as a
-  useful view-fact facet. Any residual divergence with no specific facet is
-  caught by `diff-runs`' coarse slice-key fallback (the non-empty-`:facets`
-  invariant)."
+  INVARIANT — facet-set == canonical slice keys. The facet names here are
+  EXACTLY `re-frame.story.fingerprint/run-hash-input-keys`, the slice
+  `:same?` is judged over (`:trace-ops` is the readable projection of the
+  `:epoch-tape` slot's causal op spine, so it stands in for `:epoch-tape`).
+  Two consequences both matter:
+
+  - every slice slot is covered, so a diff the gate calls different always
+    localises WHERE (any residual gap is caught by `diff-runs`' coarse
+    slice-key fallback — the non-empty-`:facets` invariant);
+  - NO facet sits OUTSIDE the slice. `:sub-runs` is deliberately excluded from
+    the run-hash slice (over-recomputed evidence, not a determinism input —
+    rf2-e6uod / rf2-5l0a5), so it is NOT registered here: a `:sub-runs`-only
+    delta does not perturb the `:same?` slice, so a facet for it could never
+    fire through `diff-runs` (it would be dead code that overstated coverage
+    and disagreed with the determinism gate / golden verdict). `diff-sub-runs`
+    survives as a standalone diagnostic fn (call it directly), NOT as part of
+    the `:same?` judgement."
   (array-map
     :status            diff-status
     :app-db            (fn [b c] (diff-app-db (:app-db b) (:app-db c)))
@@ -535,8 +574,7 @@
     :warnings          diff-warnings
     :trace-ops         diff-trace-ops
     :sub-overrides     diff-sub-overrides
-    :fidelity          diff-fidelity
-    :sub-runs          diff-sub-runs))
+    :fidelity          diff-fidelity))
 
 (defn diff-runs
   "Diff two run-results — the PURE core (spec §Semantic diff). Pure data →

--- a/tools/story/test/re_frame/story/diff_test.cljc
+++ b/tools/story/test/re_frame/story/diff_test.cljc
@@ -7,7 +7,9 @@
   build:
 
   - PURE: the facet diffs (`diff-app-db`, `diff-effects`,
-    `diff-schema-violations`, `diff-trace-ops`, `diff-sub-runs`) and the
+    `diff-schema-violations`, `diff-trace-ops`, …) and the diagnostic-only
+    `diff-sub-runs` (NOT wired into `diff-runs` — outside the `:same?` slice,
+    rf2-e6uod / rf2-5l0a5) and the
     assembler (`diff-runs`) over HAND-BUILT run-results — the §A5 acceptance
     bullets:
       • a small readable diff for an app-db change;
@@ -26,8 +28,9 @@
             [re-frame.frame     :as frame]
             [re-frame.registrar :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story.artifact :as artifact]
-            [re-frame.story.diff     :as diff]))
+            [re-frame.story.artifact    :as artifact]
+            [re-frame.story.diff        :as diff]
+            [re-frame.story.fingerprint :as fingerprint]))
 
 ;; ===========================================================================
 ;; PURE: app-db delta  (§A5 — a small readable diff for an app-db change)
@@ -58,7 +61,35 @@
     (let [d (diff/diff-app-db {:user {:profile {:age 30}}}
                               {:user {:profile {:age 31}}})]
       (is (= [{:path [:user :profile :age] :baseline 30 :current 31}]
-             (:changed d))))))
+             (:changed d)))))
+
+  ;; rf2-bd6ei — a run that clears app-db to {} must not emit a spurious root
+  ;; leaf {:path [] :current {}} / {:path [] :baseline {}}; the real
+  ;; populated-vs-empty difference must still diff correctly.
+  (testing "current cleared to {} reports the removed key, NOT a spurious [] leaf"
+    (let [d (diff/diff-app-db {:a 1} {})]
+      (is (= [{:path [:a] :baseline 1}] (:removed d))
+          "the populated baseline's key is :removed")
+      (is (nil? (:added d))
+          "NO spurious {:path [] :current {}} root leaf for the empty side")
+      (is (= #{:removed} (set (keys d)))
+          "only the genuine difference, nothing at the [] root")))
+
+  (testing "baseline empty {} vs populated current is the symmetric case"
+    (let [d (diff/diff-app-db {} {:a 1})]
+      (is (= [{:path [:a] :current 1}] (:added d)))
+      (is (nil? (:removed d))
+          "NO spurious {:path [] :baseline {}} root leaf for the empty side")
+      (is (= #{:added} (set (keys d))))))
+
+  (testing "a NON-ROOT empty map is STILL a semantic leaf ({:k {}} vs {:k {:a 1}})"
+    (let [d (diff/diff-app-db {:k {}} {:k {:a 1}})]
+      (is (= [{:path [:k :a] :current 1}] (:added d)))
+      (is (= [{:path [:k] :baseline {}}] (:removed d))
+          "the [:k] empty-map leaf is preserved — only the ROOT is special-cased")))
+
+  (testing "two empty roots are equal — no delta"
+    (is (nil? (diff/diff-app-db {} {})))))
 
 ;; ===========================================================================
 ;; PURE: effect-only diff  (§A5 — an effect-only diff)
@@ -147,7 +178,8 @@
           "current is a proper prefix — only the length differs"))))
 
 (deftest diff-sub-runs-multiset-delta
-  (testing "a sub-run only one side produced surfaces as a view fact diff"
+  (testing "diff-sub-runs is a DIAGNOSTIC fn — called directly it still
+            reports a view-fact delta (rf2-e6uod / rf2-5l0a5)"
     (let [d (diff/diff-sub-runs
               {:sub-runs [{:query [:visible-todos] :value 3}]}
               {:sub-runs [{:query [:visible-todos] :value 5}]})]
@@ -342,6 +374,49 @@
           d    (diff/diff-runs base cur)]
       (is (false? (:same? d)))
       (is (= #{:fidelity} (:facets d))))))
+
+;; ===========================================================================
+;; PURE: facet-set == canonical slice keys (rf2-e6uod / rf2-5l0a5)
+;; — the diff's facet set is EXACTLY the run-hash slice :same? is judged over,
+;;   so no facet is dead (fires on a slot outside the slice) and no slice slot
+;;   is uncovered. `:trace-ops` is the readable projection of the `:epoch-tape`
+;;   slot, so it stands in for it 1:1 in the equality.
+;; ===========================================================================
+
+(deftest facet-set-equals-canonical-slice
+  (testing "facet-fns keys == run-hash-input-keys (with :trace-ops ⇄ :epoch-tape)"
+    (let [facet-names (set (keys diff/facet-fns))
+          slice-keys  (set fingerprint/run-hash-input-keys)]
+      (is (= (disj facet-names :trace-ops)
+             (disj slice-keys :epoch-tape))
+          "the facet set and the canonical slice are the SAME surface — the
+           only naming difference is :trace-ops (the readable :epoch-tape
+           projection) standing in for :epoch-tape")
+      (is (contains? facet-names :trace-ops)
+          ":trace-ops covers the :epoch-tape slice slot")
+      (is (contains? slice-keys :epoch-tape))))
+
+  (testing ":sub-runs is NOT a facet — it is deliberately outside the slice"
+    (is (not (contains? (set (keys diff/facet-fns)) :sub-runs))
+        ":sub-runs carries no diff-runs facet (over-recomputed evidence, not a
+         determinism input)")
+    (is (not (contains? (set fingerprint/run-hash-input-keys) :sub-runs))
+        ":sub-runs is excluded from the run-hash slice — the facet set honors
+         that exclusion rather than overstating coverage")))
+
+(deftest diff-runs-sub-runs-only-delta-is-same
+  (testing "two runs differing ONLY in :sub-runs diff to {:same? true} — the
+            :sub-runs delta does NOT decide :same? (it is outside the slice,
+            rf2-e6uod / rf2-5l0a5)"
+    (let [base {:status :pass :app-db {:n 1}
+                :sub-runs [{:query [:visible-todos] :value 3}]}
+          cur  (assoc base :sub-runs [{:query [:visible-todos] :value 5}])
+          d    (diff/diff-runs base cur)]
+      (is (= {:same? true} d)
+          "a pure :sub-runs delta is behaviourally identical to the gate — so
+           diff-runs agrees with the determinism / golden verdict")
+      (is (not (contains? (:facets d) :sub-runs))
+          "no :sub-runs facet ever fires through diff-runs"))))
 
 ;; ===========================================================================
 ;; PURE: the non-empty-:facets INVARIANT (rf2-rv9tt — the masterpiece guarantee)


### PR DESCRIPTION
Three fixes in `tools/story/src/re_frame/story/diff.cljc`, bundled into one PR because they share that file (avoids self-collision).

## The three fixes

### 1. rf2-e6uod + rf2-5l0a5 — `:sub-runs` facet was dead through `diff-runs` (same root)
`:sub-runs` had a `diff-runs` facet (`diff-sub-runs` in `facet-fns`) yet is **deliberately excluded** from `fingerprint/run-hash-input-keys` — the slice `:same?` is judged over (sub-runs are over-recomputed evidence, not a determinism input). Consequence: a `:sub-runs`-only delta never perturbs the slice, so the facet could **never fire** through `diff-runs` (verified on JVM: `{:same? true}`). The facet was dead code that overstated coverage and disagreed with the determinism gate / golden verdict — the same dependency-level inconsistency `golden-match?` (5l0a5) inherited.

**Resolution (masterpiece): honor the exclusion, don't widen the slice.** Widening the slice would change what determinism/golden consider "the same run" — a semantic the spec deliberately set. So `:sub-runs` is **removed from `facet-fns`**, making the facet set EXACTLY the canonical slice keys. `diff-sub-runs` survives as a standalone **diagnostic** fn (docstring updated to say it is not part of the `:same?` judgement).

New spec invariant in `spec/017` §Semantic diff: **facet-set == canonical slice keys** (`:trace-ops` stands in for `:epoch-tape` 1:1). Bidirectional — every slice slot is covered AND no facet sits outside the slice.

### 2. rf2-bd6ei — spurious root leaf `{:path [] :current {}}`
`leaf-paths` treated an empty ROOT map as a leaf, so `diff-app-db {:a 1} {}` emitted a nonsensical `:added`/`:removed` entry at the `[]` root path (reachable whenever a run clears app-db to `{}`). Fixed by special-casing the root: an empty root map contributes no leaf, while a **non-root** empty map (`{:k {}}`) stays a semantic leaf and a real populated-vs-empty difference still diffs correctly (both directions).

Before: `diff-app-db {:a 1} {}` → `{:added [{:path [] :current {}}], :removed [{:path [:a] :baseline 1}]}`
After: `{:removed [{:path [:a] :baseline 1}]}`

## Tests (`diff_test.cljc`)
- `facet-set-equals-canonical-slice` — pins `facet-fns` keys == `run-hash-input-keys` (with `:trace-ops` ⇄ `:epoch-tape`); `:sub-runs` is in neither.
- `diff-runs-sub-runs-only-delta-is-same` — a `:sub-runs`-only delta is `{:same? true}`, no `:sub-runs` facet ever fires (explicit per the resolution).
- `diff-sub-runs` standalone test retained (diagnostic fn still works when called directly).
- bd6ei: `diff-app-db` with one side `{}` reports the real difference and **no** `[]` root leaf (both directions); a nested empty map remains a leaf; `{}` vs `{}` is no delta. Fails-pre / passes-post confirmed on JVM.
- rv9tt's non-empty-`:facets` invariant tests re-run green (unchanged).

## Quality gates
- `tools/story` `clojure -M:test` — **1266 tests, 0 failures** (incl. rv9tt invariant tests)
- `tools/story-mcp` `clojure -M:test` — **172 tests, 0 failures**
- `tools/mcp-conformance` `npm run test:story` — **GREEN, exit 0**
- `bash scripts/test-fast-pr.sh` — **PASS** (core JVM + CLJS node + JS harness + README/docs anchor validators; mkdocs soft-skipped locally, CI runs it)