### PR TITLE
fix(story): route tape-evaluated [:assert …] checkpoints away from dispatch (rf2-8y47c + rf2-fh7g4)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -813,16 +813,31 @@ on caller.
 - **`[:assert assertion-vector]`** evaluates a `:rf.assert/*` assertion
   atom at THIS exact point in the script — the in-script checkpoint
   position of the one assertion atom (§Inline script assertions vs
-  terminal assertions). In headless the runner dispatches the wrapped
-  `:rf.assert/*` event (its headless implementation rail —
-  `re-frame.story.assertions`), and the standard reg-event-fx handler
-  records the canonical assertion record on the frame's
-  `:rf.story/assertions` slot. The checkpoint surfaces that record as the
-  step's pass/fail; it records EXACTLY ONE assertion (the wrapped atom's
-  handler is the sole recorder — the assertion-slot mirror that
-  `:assert-db` / `:assert-dom` use is skipped for `[:assert …]` to avoid
-  double-counting). `[:assert …]` is REJECTED in `:setup` at
-  plan-compile time (see below).
+  terminal assertions). The checkpoint routes by assertion family,
+  matching how each family is evaluated everywhere else:
+  - **Dispatchable assertions** (the canonical handler-backed ids —
+    `:rf.assert/path-equals` / `path-matches` / `sub-equals` /
+    `dispatched?` / `state-is` / `no-warnings` / `effect-emitted`) are
+    DISPATCHED into the frame. The standard reg-event-fx handler
+    (`re-frame.story.assertions`) records the canonical assertion record
+    on the frame's `:rf.story/assertions` slot, and the checkpoint
+    surfaces that record as the step's pass/fail. It records EXACTLY ONE
+    assertion (the wrapped atom's handler is the sole recorder — the
+    assertion-slot mirror that `:assert-db` / `:assert-dom` use is skipped
+    for `[:assert …]` to avoid double-counting).
+  - **DOM-family assertions** (`:rf.assert/dom-visible` / `dom-hidden` /
+    `dom-text`) are evaluated by the DOM executor directly (no dispatch);
+    a no-DOM headless runner records `:cannot-run`.
+  - **Tape-evaluated assertions** carry NO reg-event-fx handler — they are
+    minted by the result boundary against the epoch tape, NOT dispatched.
+    This is the schema-error declaration (§Schema rule), the causal /
+    cascade family (§Causal and cascade assertions), and the browser-tier
+    oracle family (§Visual, a11y, and browser checks). An in-script
+    checkpoint for one of these records a no-op step (the result boundary
+    owns the verdict); dispatching it would mint a spurious
+    `:rf.error/no-such-handler` trace AND skip the real tape evaluation.
+
+  `[:assert …]` is REJECTED in `:setup` at plan-compile time (see below).
 - **`[:focus selector]`** (with `[:click …]` / `[:type …]` /
   `[:assert-dom …]`) is a DOM step. It requires the `:dom` capability
   token (§Requirement inference) and the `:dom` settled boundary

--- a/tools/story/src/re_frame/story/play/runner_events.cljc
+++ b/tools/story/src/re_frame/story/play/runner_events.cljc
@@ -591,6 +591,39 @@
 
 (declare exec-assert-dom-atom!)
 
+(defn- tape-evaluated-assertion?
+  "True iff the assertion atom `atom-v` (`[:rf.assert/id & args]`) is
+  evaluated AGAINST THE EPOCH TAPE in the result boundary rather than by
+  dispatching a `reg-event-fx` handler into the frame (rf2-8y47c +
+  rf2-fh7g4).
+
+  Three assertion families carry NO `reg-event-fx` handler and are minted
+  by the result boundary (`re-frame.story.result`), not by a dispatch:
+
+  - `:rf.assert/schema-error` — paired against the projected
+    `:rf.error/schema-validation-failure` evidence (rf2-5x1wt.21).
+  - the causal / cascade family (`:rf.assert/caused` /
+    `:rf.assert/no-cascade-rerender`) — paired against the
+    `:reactive-counts` `:by-cause` projection (rf2-5x1wt.31).
+  - the browser-tier oracle family (`:rf.assert/visual-snapshot` /
+    `:rf.assert/a11y` / `:rf.assert/a11y-structural`) — projected by the
+    browser executor into the same assertion record (rf2-5x1wt.28).
+
+  This is the SINGLE classifier the in-script `[:assert …]` executor
+  consults so a tape-evaluated checkpoint is NEVER dispatched into the
+  frame (which, with no handler, would mint a spurious
+  `:rf.error/no-such-handler` trace and skip the real tape evaluation).
+  It deliberately reads the existing `re-frame.story.assertions`
+  predicates / id-sets — the ONE source of truth for which family an id
+  belongs to — so a future tape-evaluated family is covered by adding it
+  there, with no special-case to grow here. The DOM family is NOT here:
+  it has its own inline executor (`exec-assert-dom-atom!`), routed ahead
+  of this classifier."
+  [atom-v]
+  (or (assertions/schema-error? atom-v)
+      (assertions/causal? atom-v)
+      (contains? assertions/browser-assertion-ids (first atom-v))))
+
 (defn- exec-assert!
   "Execute an `[:assert [:rf.assert/id & args]]` in-script checkpoint
   (rf2-5x1wt.17). Evaluates the wrapped assertion atom at THIS point in
@@ -602,22 +635,39 @@
   / `:assert-dom` executor minting synthetic `:rf.assert/db` /
   `:rf.assert/dom` records.
 
-  Two atom families:
+  Three routes, by atom family:
 
   - The DOM family (`:rf.assert/dom-visible` / `:rf.assert/dom-hidden` /
     `:rf.assert/dom-text`) has no reg-event-fx handler yet (the DOM runner
     that proves it lands later); it is EVALUATED directly through the DOM
     executor (`exec-assert-dom-atom!`), recording a canonical
     `:rf.assert/dom-*` record on the slot.
-  - Every other `:rf.assert/*` atom dispatches the event through
-    `settled-boundary` — the standard reg-event-fx handler records the
-    `:passed?` record on the frame's `:rf.story/assertions` slot — and we
-    bridge that record back into the runner step stream so a failing
+  - The tape-evaluated families (`tape-evaluated-assertion?`: schema-error,
+    the causal / cascade family, the browser-tier oracle family) ALSO carry
+    no reg-event-fx handler — they are minted by the result boundary
+    against the epoch tape, not by a dispatch. An in-script checkpoint for
+    one of these records a no-op step-skip (the boundary owns its verdict);
+    dispatching it would mint a spurious `:rf.error/no-such-handler` trace
+    AND skip the real tape evaluation (rf2-8y47c + rf2-fh7g4).
+  - Every other (dispatchable) `:rf.assert/*` atom dispatches the event
+    through `settled-boundary` — the standard reg-event-fx handler records
+    the `:passed?` record on the frame's `:rf.story/assertions` slot — and
+    we bridge that record back into the runner step stream so a failing
     checkpoint flips the play's terminal status to `:fail`."
   [frame-id idx step]
   (let [atom-v (runner/step-assertion step)]
-    (if (contains? assertions/dom-assertion-ids (first atom-v))
+    (cond
+      (contains? assertions/dom-assertion-ids (first atom-v))
       (exec-assert-dom-atom! frame-id idx step atom-v)
+
+      ;; Tape-evaluated families carry no reg-event-fx handler; the result
+      ;; boundary owns their verdict. Record a no-op step-skip — never a
+      ;; dispatch (which would hit :rf.error/no-such-handler) (rf2-8y47c +
+      ;; rf2-fh7g4).
+      (tape-evaluated-assertion? atom-v)
+      (runner/step-skip idx step)
+
+      :else
       (let [prev     (assertion-count frame-id)
             required (boundary/step-required-boundary step)
             hooks    (current-flush-hooks frame-id)

--- a/tools/story/test/re_frame/story/play/runner_events_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/play/runner_events_cljs_test.cljc
@@ -860,3 +860,150 @@
                "the three increments + assertion run atomically — final count is exactly 6")
            (is (= 6 @n)
                "no stray increments leaked from concurrent paths"))))))
+
+;; ---- tape-evaluated in-script [:assert …] checkpoints (rf2-8y47c + fh7g4) --
+;;
+;; An in-script `[:assert [:rf.assert/schema-error …]]` /
+;; `[:assert [:rf.assert/caused …]]` / `[:assert [:rf.assert/no-cascade-
+;; rerender …]]` checkpoint names a TAPE-EVALUATED assertion family: these
+;; ids carry NO `reg-event-fx` handler — the result boundary mints their
+;; verdict against the epoch tape (`re-frame.story.result`). Before the
+;; `tape-evaluated-assertion?` guard, `exec-assert!` special-cased ONLY the
+;; DOM family, so every other id (schema-error / causal) fell through to
+;; `boundary/dispatch-and-settle!` — i.e. it was DISPATCHED into the frame.
+;; With no handler that hit `re-frame.router.diagnostics/handle-no-handler!`
+;; → a spurious `:rf.error/no-such-handler` error trace on the tape (which
+;; can trip `evidence/tape-shows-failure?` into a false `:fail`), AND the
+;; real tape evaluation was skipped. The fix routes these to a no-op
+;; step-skip — the result boundary still owns the verdict.
+;;
+;; These tests drive the in-script checkpoint end-to-end and assert (a) NO
+;; `:rf.error/no-such-handler` trace lands, and (b) the checkpoint records a
+;; no-assertion step-skip (`:passed? nil`) — never a dispatch.
+
+#?(:clj
+   (defn- run-capturing-no-handler-errors
+     "Drive `variant-id` to terminal with a trace listener that collects any
+     `:rf.error/no-such-handler` events targeting the variant's frame.
+     Returns `[final-state no-handler-events]`."
+     [variant-id]
+     (require '[re-frame.trace.tooling :as trace-tooling])
+     (let [reg!      (resolve 're-frame.trace.tooling/register-listener!)
+           unreg     (resolve 're-frame.trace.tooling/unregister-listener!)
+           collected (atom [])
+           lid       ::no-handler-capture]
+       (reg! lid
+             (fn [ev]
+               (when (and (= :rf.error/no-such-handler (:operation ev))
+                          (= variant-id (get-in ev [:tags :frame])))
+                 (swap! collected conj ev))))
+       (try
+         (async/deref-blocking (story/run-variant variant-id) 5000)
+         [(run-blocking variant-id) @collected]
+         (finally (when unreg (unreg lid)))))))
+
+#?(:clj
+   (deftest in-script-schema-error-checkpoint-is-tape-evaluated-not-dispatched
+     (testing "an in-script [:assert [:rf.assert/schema-error …]] checkpoint
+              is recorded as a no-op step-skip — NOT dispatched into the
+              frame — so no :rf.error/no-such-handler trace lands (rf2-8y47c)"
+       (rf/reg-event-db :rt/touch
+         (fn [db _] (update db :n (fnil inc 0))))
+       (story/reg-variant :story.tape/schema-error
+         {:events      []
+          :play-script {:auto-run? false
+                        :script    [[:dispatch-sync [:rt/touch]]
+                                    [:assert [:rf.assert/schema-error
+                                              {:where :event :event :rt/touch}]]]}})
+       (let [[final no-handler] (run-capturing-no-handler-errors
+                                  :story.tape/schema-error)
+             checkpoint (->> (:results final)
+                             (filter #(= :assert (:type %)))
+                             first)]
+         (is (empty? no-handler)
+             "NO :rf.error/no-such-handler trace fired — the schema-error
+              atom was NOT dispatched into the frame")
+         (is (some? checkpoint) "the [:assert …] checkpoint produced a result")
+         (is (nil? (:passed? checkpoint))
+             "the tape-evaluated checkpoint is a no-op step-skip — the result
+              boundary owns its verdict, so it neither passes nor fails here")
+         (is (empty? (filterv #(= :rf.assert/schema-error (:assertion %))
+                              (story/read-assertions :story.tape/schema-error)))
+             "no :rf.assert/schema-error slot record was minted by a dispatch")))))
+
+#?(:clj
+   (deftest in-script-no-cascade-rerender-checkpoint-is-tape-evaluated-not-dispatched
+     (testing "an in-script [:assert [:rf.assert/no-cascade-rerender …]]
+              checkpoint (the causal family) is a no-op step-skip — NOT
+              dispatched — so no :rf.error/no-such-handler trace lands
+              (rf2-fh7g4)"
+       (rf/reg-event-db :rt/touch
+         (fn [db _] (update db :n (fnil inc 0))))
+       (story/reg-variant :story.tape/no-cascade
+         {:events      []
+          :play-script {:auto-run? false
+                        :script    [[:dispatch-sync [:rt/touch]]
+                                    [:assert [:rf.assert/no-cascade-rerender
+                                              {:event :rt/touch :sub :some/sub}]]]}})
+       (let [[final no-handler] (run-capturing-no-handler-errors
+                                  :story.tape/no-cascade)
+             checkpoint (->> (:results final)
+                             (filter #(= :assert (:type %)))
+                             first)]
+         (is (empty? no-handler)
+             "NO :rf.error/no-such-handler trace fired — the causal atom was
+              NOT dispatched into the frame")
+         (is (some? checkpoint) "the [:assert …] checkpoint produced a result")
+         (is (nil? (:passed? checkpoint))
+             "the tape-evaluated causal checkpoint is a no-op step-skip")
+         (is (empty? (filterv #(= :rf.assert/no-cascade-rerender (:assertion %))
+                              (story/read-assertions :story.tape/no-cascade)))
+             "no causal slot record was minted by a dispatch")))))
+
+#?(:clj
+   (deftest in-script-caused-checkpoint-is-tape-evaluated-not-dispatched
+     (testing "an in-script [:assert [:rf.assert/caused …]] checkpoint is a
+              no-op step-skip — NOT dispatched — so no
+              :rf.error/no-such-handler trace lands (rf2-fh7g4)"
+       (rf/reg-event-db :rt/touch
+         (fn [db _] (update db :n (fnil inc 0))))
+       (story/reg-variant :story.tape/caused
+         {:events      []
+          :play-script {:auto-run? false
+                        :script    [[:dispatch-sync [:rt/touch]]
+                                    [:assert [:rf.assert/caused
+                                              {:event :rt/touch :sub :some/sub}]]]}})
+       (let [[final no-handler] (run-capturing-no-handler-errors
+                                  :story.tape/caused)
+             checkpoint (->> (:results final)
+                             (filter #(= :assert (:type %)))
+                             first)]
+         (is (empty? no-handler)
+             "NO :rf.error/no-such-handler trace fired for the :caused atom")
+         (is (nil? (:passed? checkpoint))
+             "the tape-evaluated causal checkpoint is a no-op step-skip")))))
+
+;; ---- unit: the tape-evaluated-assertion? classifier (rf2-8y47c + fh7g4) ----
+;;
+;; The single authoritative classifier the in-script executor consults so a
+;; tape-evaluated family is never dispatched. Runs on BOTH runtimes (pure
+;; data → boolean), reached via var-quote (the established Story-test seam).
+
+(def ^:private tape-evaluated-assertion? @#'re/tape-evaluated-assertion?)
+
+(deftest tape-evaluated-assertion?-classifies-every-non-dispatched-family
+  (testing "schema-error, the causal family, and the browser-tier oracle
+            family are tape-evaluated (no reg-event-fx handler); the
+            dispatchable seven + the DOM family are NOT"
+    (is (true? (boolean (tape-evaluated-assertion? [:rf.assert/schema-error {}]))))
+    (is (true? (boolean (tape-evaluated-assertion? [:rf.assert/caused {:event :e}]))))
+    (is (true? (boolean (tape-evaluated-assertion? [:rf.assert/no-cascade-rerender {:event :e}]))))
+    (is (true? (boolean (tape-evaluated-assertion? [:rf.assert/visual-snapshot]))))
+    (is (true? (boolean (tape-evaluated-assertion? [:rf.assert/a11y]))))
+    (is (true? (boolean (tape-evaluated-assertion? [:rf.assert/a11y-structural]))))
+    (is (false? (boolean (tape-evaluated-assertion? [:rf.assert/path-equals [:k] 1])))
+        "a dispatchable canonical assertion (has a reg-event-fx handler) is NOT tape-evaluated")
+    (is (false? (boolean (tape-evaluated-assertion? [:rf.assert/state-is :loaded])))
+        "another of the dispatchable seven is NOT tape-evaluated")
+    (is (false? (boolean (tape-evaluated-assertion? [:rf.assert/dom-visible "div"])))
+        "the DOM family is routed to its OWN inline executor, not this classifier")))


### PR DESCRIPTION
## What

`exec-assert!` (the in-script `[:assert …]` checkpoint executor) special-cased only the DOM assertion family for the no-dispatch path. Every other `:rf.assert/*` atom fell through to `boundary/dispatch-and-settle!` — i.e. it was dispatched into the frame.

But three families carry NO `reg-event-fx` handler and are minted by the result boundary against the epoch tape, not by a dispatch:

- `:rf.assert/schema-error` (rf2-8y47c) — paired against projected schema-validation-failure evidence.
- the causal / cascade family `:rf.assert/caused` / `:rf.assert/no-cascade-rerender` (rf2-fh7g4) — paired against the `:reactive-counts` `:by-cause` projection.
- the browser-tier oracle family `:rf.assert/visual-snapshot` / `a11y` / `a11y-structural` — projected by the browser executor (latent sibling of the same defect).

Dispatching one of these no-handler events hit `re-frame.router.diagnostics/handle-no-handler!` → a spurious `:rf.error/no-such-handler` error trace on the tape (which can trip `evidence/tape-shows-failure?` into a false `:fail`), AND the real tape evaluation was skipped.

## The fix

One authoritative classifier in `runner_events.cljc`:

```clojure
(defn- tape-evaluated-assertion? [atom-v]
  (or (assertions/schema-error? atom-v)
      (assertions/causal? atom-v)
      (contains? assertions/browser-assertion-ids (first atom-v))))
```

It reads the existing `re-frame.story.assertions` predicates / id-sets — the single source of truth for which family an id belongs to — so a future tape-evaluated family is covered by adding it there, with no special-case to grow in the runner.

`exec-assert!` now routes three ways:
1. DOM family → inline DOM executor (`exec-assert-dom-atom!`).
2. tape-evaluated family → no-op `step-skip` (the result boundary owns the verdict).
3. the dispatchable seven → `dispatch-and-settle!`.

This is the in-script `[:assert]` checkpoint fix only; terminal `:assertions` auto-run semantics (rf2-nyjoa) are untouched.

## Tests

Added to `runner_events_cljs_test.cljc`:
- three JVM run-variant integration tests driving in-script `[:assert [:rf.assert/schema-error …]]`, `[:assert [:rf.assert/caused …]]`, and `[:assert [:rf.assert/no-cascade-rerender …]]` checkpoints end-to-end; each asserts NO `:rf.error/no-such-handler` trace lands + the checkpoint records a no-op step-skip + no slot record was minted by a dispatch.
- a both-runtimes unit test pinning the `tape-evaluated-assertion?` classifier across every family (schema-error / causal / browser → true; the dispatchable seven + DOM family → false).

Confirmed fails-pre / passes-post via a temporary `(and false …)` probe: all three integration tests failed with exactly the spurious `:rf.error/no-such-handler` trace before the routing change, and pass after.

## Spec

`spec/017-Testing-Story.md` §Script step grammar — the `[:assert …]` bullet now documents the three-way routing (dispatchable / DOM / tape-evaluated) instead of the inaccurate "the runner dispatches the wrapped event".

## Quality gates

- `tools/story` `clojure -M:test` — **green** (1268 tests, 4085 assertions, 0 failures, 0 errors)
- `tools/story-mcp` `clojure -M:test` — **green** (172 tests, 861 assertions, 0 failures, 0 errors)
- `tools/mcp-conformance` `npm run test:story` — **green** (STORY-MCP MCP-CLIENT CONFORMANCE GREEN)
- `bash scripts/test-fast-pr.sh` — **PASS** (core JVM 795/0/0; CLJS node 4866/0/0; JS harness helpers green; README + docs anchor validators pass; mkdocs soft-skipped on Windows, runs on CI)