### PR TITLE
fix(story/golden): fail closed on bad capture target + lift the GREEN/RED authority (rf2-vvub1 + rf2-9fd9c)

### DIFF
--- a/tools/story/src/re_frame/story/golden.cljc
+++ b/tools/story/src/re_frame/story/golden.cljc
@@ -76,10 +76,14 @@
   plan input) replays into a fresh frame via `.7`'s `replay-run-artifact`.
 
   This ns is bundle-isolated tooling; it `:require`s ONLY the pure
-  fingerprint / diff modules + the artifact replay seam (which itself uses
-  the late-bound `rf/epoch-history` facade), so it introduces NO hard
-  `:require` of a test-only dep into the production Story path."
+  fingerprint / diff / determinism modules + the artifact replay seam
+  (which itself uses the late-bound `rf/epoch-history` facade), so it
+  introduces NO hard `:require` of a test-only dep into the production
+  Story path. The determinism dependency is the pure `->artifact` plan
+  coercion (no runtime), reused so the plan capture path folds a plan to a
+  replayable artifact through the SAME seam the determinism gate uses."
   (:require [re-frame.story.artifact    :as artifact]
+            [re-frame.story.determinism :as determinism]
             [re-frame.story.diff        :as diff]
             [re-frame.story.fingerprint :as fingerprint]))
 
@@ -173,20 +177,51 @@
 ;; ===========================================================================
 
 (defn- ->run-result
-  "Coerce a capture/compare `target` into a run-result. A run-result
-  (carrying a `:status`) is used directly — the PURE path. A
-  `:rf.test/run-artifact` (or a normalized plan, via the determinism gate's
-  `->artifact` fold inside `replay-run-artifact`'s caller) is replayed into
-  a FRESH frame via `re-frame.story.artifact/replay-run-artifact` (the
-  IMPURE path), threading `opts` (`:frame` / `:hooks` / `:frame-config`).
+  "Coerce a capture/compare `target` into a run-result, FAILING CLOSED on an
+  unrecognized input. Dispatched on the target's shape:
 
-  Replaying the artifact means a golden captured from an artifact freezes
+  - a `:rf.test/run-artifact` — replayed into a FRESH frame via
+    `re-frame.story.artifact/replay-run-artifact` (the IMPURE path),
+    threading `opts` (`:frame` / `:hooks` / `:frame-config`);
+  - a normalized plan (a map carrying `:world`) — folded to a replayable
+    artifact via the determinism gate's pure `re-frame.story.determinism/
+    ->artifact` (the SAME `[:world :setup]` ⧺ `:script` fold the gate uses),
+    then replayed into a FRESH frame, also IMPURE;
+  - a run-result (a map carrying `:status`) — used directly, the PURE path
+    (`clojure -M:test`, no runtime).
+
+  Replaying an artifact / plan means a golden frozen from one captures
   exactly the FRESH-frame run the determinism gate + semantic diff would
-  produce — so capture-from-artifact and capture-from-result agree."
+  produce — so capture-from-artifact, capture-from-plan, and
+  capture-from-result agree.
+
+  Any other input (a map that is neither a run-artifact, a plan, nor a
+  run-result, or a non-map) is REJECTED with `:rf.error/golden-bad-target`
+  rather than silently frozen — a golden captured from garbage is worse
+  than a loud failure, because it freezes a near-empty baseline that then
+  reports false GREEN forever (the silent-wrong path this guard closes)."
   [target opts]
-  (if (artifact/run-artifact? target)
+  (cond
+    (artifact/run-artifact? target)
     (artifact/replay-run-artifact target opts)
-    target))
+
+    (and (map? target) (contains? target :world))
+    (artifact/replay-run-artifact (determinism/->artifact target) opts)
+
+    (and (map? target) (contains? target :status))
+    target
+
+    :else
+    (throw (ex-info ":rf.error/golden-bad-target"
+                    {:rf.error/id :rf.error/golden-bad-target
+                     :where    'rf.story/capture-golden
+                     :recovery :fix-target
+                     :reason   (str "re-frame2-story: capture/compare-golden "
+                                    "target is not a run-result (no :status), a "
+                                    ":rf.test/run-artifact, nor a normalized plan "
+                                    "(no :world) — refusing to freeze a golden "
+                                    "from an unrecognized input")
+                     :target   target}))))
 
 (defn capture-golden
   "Capture a `:rf.test/golden` slice from `target` (spec/017 §Golden
@@ -198,7 +233,16 @@
     directly, the PURE path (`clojure -M:test` with no runtime);
   - a `:rf.test/run-artifact` — REPLAYED into a fresh frame via
     `replay-run-artifact` to obtain a run-result first (the impure path);
-    so a golden frozen from an artifact captures the fresh-frame run.
+    so a golden frozen from an artifact captures the fresh-frame run;
+  - a normalized variant plan (a map carrying `:world`) — folded to a
+    replayable artifact via the determinism gate's pure `->artifact`, then
+    replayed like an artifact (the impure path), so a golden frozen from a
+    plan captures the same fresh-frame run the determinism gate + diff
+    would produce.
+
+  Any other input is REJECTED with `:rf.error/golden-bad-target` (see
+  `->run-result`) — capture FAILS CLOSED rather than freezing a garbage
+  golden from an unrecognized shape.
 
   `opts` (all optional):
 
@@ -223,29 +267,59 @@
 ;; COMPARE  (canonical equality + the readable, delegated report)
 ;; ===========================================================================
 
+(defn- canonical+hash
+  "Canonicalize a coerced run-`result`'s behavioural slice ONCE and return
+  `{:canonical … :run-hash …}` off that single canonical value. Pure data →
+  data.
+
+  `run-hash` and `slice-canonical` both `canonicalize` the same behavioural
+  slice; computing the canonical slice once (and hashing the canonical
+  value via `fingerprint/content-hash`, which orders-but-does-not-strip an
+  ALREADY-stripped+ordered value — so it equals `run-hash`'s
+  `canonical-hash` of the raw slice) avoids running `canonicalize` twice per
+  match / compare. The equivalence `content-hash(canonicalize(slice)) =
+  run-hash(result)` is locked by the golden_test run-hash agreement
+  assertions."
+  [result]
+  (let [canon (slice-canonical result)]
+    {:canonical canon
+     :run-hash  (fingerprint/content-hash canon)}))
+
+(defn- matches?
+  "The ONE GREEN/RED authority over an ALREADY-coerced run-`result` (spec/017
+  §Golden slices). True iff `result` matches the `golden` slice. Pure data →
+  data — both `golden-match?` and `compare-golden` route through this so the
+  two-stage equality cannot drift between the predicate and the report.
+
+  Two-stage to avoid a false GREEN: the cheap `:run-hash` is checked first
+  (a mismatched hash ⇒ definitely different, short-circuit), then canonical
+  equality is the AUTHORITY (a hash collision can never report a match
+  because the canonical values still differ)."
+  [golden {:keys [canonical run-hash]}]
+  (and (= (:run-hash golden) run-hash)
+       (= (:canonical golden) canonical)))
+
 (defn golden-match?
   "True iff `run` matches the `golden` slice — the run's canonicalized
   behavioural slice is `=` to the golden's frozen `:canonical` (spec/017
   §Golden slices). Pure when `run` is a run-result.
 
-  Two-stage to avoid a false GREEN: the cheap `:run-hash` is checked first
-  (mismatched hash ⇒ definitely different, short-circuit), then canonical
-  equality is the AUTHORITY (a hash collision can never report a match
-  because the canonical values still differ). The match is robust to
+  Routes through the shared `matches?` authority (the two-stage `:run-hash`
+  pre-check then canonical-equality confirmation, lifted so the predicate
+  and `compare-golden`'s report cannot drift). The match is robust to
   per-run noise — frame ids, timestamps, epoch / dispatch / trace ids do
   NOT cause a false mismatch because `canonicalize` strips them on both
   sides — and sensitive to a real semantic difference (app-db, effect,
   assertion verdict, schema failure, trace spine), which perturbs the
   canonical value.
 
-  `run` MAY be a run-result (pure) or a `:rf.test/run-artifact` (replayed
-  into a fresh frame first — pass `opts` for `:frame` / `:hooks` /
-  `:frame-config`)."
+  `run` MAY be a run-result (pure), a `:rf.test/run-artifact`, or a
+  normalized plan (the latter two replayed into a fresh frame first — pass
+  `opts` for `:frame` / `:hooks` / `:frame-config`); any other shape is
+  rejected (see `->run-result`)."
   ([golden run] (golden-match? golden run nil))
   ([golden run opts]
-   (let [result (->run-result run opts)]
-     (and (= (:run-hash golden) (fingerprint/run-hash result))
-          (= (:canonical golden) (slice-canonical result))))))
+   (matches? golden (canonical+hash (->run-result run opts)))))
 
 (defn compare-golden
   "Compare a `run` against the `golden` slice and return a READABLE report
@@ -278,13 +352,12 @@
   ([golden run] (compare-golden golden run nil))
   ([golden run {:keys [golden-run-result] :as opts}]
    (let [result    (->run-result run (dissoc opts :golden-run-result))
-         match?    (and (= (:run-hash golden) (fingerprint/run-hash result))
-                        (= (:canonical golden) (slice-canonical result)))
+         {:keys [run-hash] :as ch} (canonical+hash result)
          base-run  (or golden-run-result (:run-result golden))]
-     (if match?
-       {:match? true :run-hash (fingerprint/run-hash result)}
+     (if (matches? golden ch)
+       {:match? true :run-hash run-hash}
        (cond-> {:match?          false
-                :run-hash        (fingerprint/run-hash result)
+                :run-hash        run-hash
                 :golden-run-hash (:run-hash golden)}
          base-run       (assoc :diff (diff/diff-runs base-run result))
          (not base-run) (assoc :diff :unavailable-no-run-result))))))

--- a/tools/story/test/re_frame/story/golden_test.cljc
+++ b/tools/story/test/re_frame/story/golden_test.cljc
@@ -30,6 +30,15 @@
             [re-frame.story.golden      :as golden]))
 
 ;; ===========================================================================
+;; This ns is the rf2-5x1wt.32 golden-slice coverage, extended by:
+;;   • rf2-vvub1 — the §Capture path FAILS CLOSED: a normalized plan is now
+;;     coerced + replayed (not silently frozen as a near-empty golden), and
+;;     an unrecognized target is REJECTED with :rf.error/golden-bad-target;
+;;   • rf2-9fd9c — golden-match? + compare-golden share ONE GREEN/RED
+;;     authority (no inline-drift) and canonicalize the run ONCE per call.
+;; ===========================================================================
+
+;; ===========================================================================
 ;; FIXTURES — hand-built run-results
 ;; ===========================================================================
 
@@ -231,6 +240,87 @@
       (is (= #{:app-db} (:facets (:diff r)))))))
 
 ;; ===========================================================================
+;; PURE: rf2-9fd9c — golden-match? + compare-golden share ONE authority
+;; ===========================================================================
+
+(deftest match-and-compare-agree
+  (testing "golden-match? and compare-golden's :match? agree for EVERY run —
+            they route through the one shared GREEN/RED predicate, so the
+            verdict can never drift between the boolean and the report"
+    (let [g     (golden/make-golden (run-result {:app-db {:n 1} :ops [:a :b]})
+                                    {:keep-run-result true})
+          runs  [;; equivalent ⇒ both GREEN
+                 (run-result {:app-db {:n 1} :ops [:a :b]})
+                 ;; key-order-only ⇒ both GREEN (canonical)
+                 (run-result {:app-db (sorted-map :n 1)})
+                 ;; app-db drift ⇒ both RED
+                 (run-result {:app-db {:n 2} :ops [:a :b]})
+                 ;; status flip ⇒ both RED
+                 (run-result {:status :fail :app-db {:n 1} :ops [:a :b]})
+                 ;; op-spine change ⇒ both RED
+                 (run-result {:app-db {:n 1} :ops [:a :x]})]]
+      (doseq [run runs]
+        (is (= (golden/golden-match? g run)
+               (:match? (golden/compare-golden g run)))
+            (str "golden-match? and compare-golden disagree for " (pr-str run)))))))
+
+(deftest compare-golden-run-hash-matches-fingerprint
+  (testing "the :run-hash compare-golden reports is the canonical
+            fingerprint/run-hash of the run — the single-canonicalize perf
+            path (content-hash of the canonical slice) equals the two-stage
+            run-hash, so the optimization is behaviour-preserving"
+    (let [matchy   (run-result {:app-db {:n 1}})
+          g        (golden/make-golden matchy {:keep-run-result true})
+          changed  (run-result {:app-db {:n 2}})
+          r-match  (golden/compare-golden g matchy)
+          r-miss   (golden/compare-golden g changed)]
+      (is (= (fingerprint/run-hash matchy) (:run-hash r-match))
+          "match report :run-hash == fingerprint/run-hash")
+      (is (= (fingerprint/run-hash changed) (:run-hash r-miss))
+          "mismatch report :run-hash == fingerprint/run-hash")
+      (is (= (:run-hash g) (:golden-run-hash r-miss))
+          "the frozen golden hash is reported as :golden-run-hash"))))
+
+;; ===========================================================================
+;; PURE: rf2-vvub1 — capture FAILS CLOSED on an unrecognized target
+;; ===========================================================================
+
+(deftest capture-golden-rejects-bad-target
+  (testing "a target that is neither a run-result (no :status), a
+            run-artifact, nor a normalized plan (no :world) is REJECTED with
+            :rf.error/golden-bad-target — NOT silently frozen into a
+            near-empty golden (the rf2-vvub1 silent-wrong path, closed)"
+    (doseq [bad [{:some :map :no :status-world-or-kind}
+                 {:event-program [[:dispatch [:x]]]} ; missing :artifact/kind ⇒ not a run-artifact
+                 42
+                 "not-a-map"
+                 nil]]
+      (is (thrown-with-msg?
+            #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
+            #":rf.error/golden-bad-target"
+            (golden/capture-golden bad))
+          (str "capture-golden must reject " (pr-str bad)))))
+
+  (testing "the rejection carries the structured :rf.error/id + the offending
+            target for diagnosis"
+    (let [bad {:not :recognized}
+          e   (try (golden/capture-golden bad)
+                   (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e e))]
+      (is (= :rf.error/golden-bad-target (:rf.error/id (ex-data e))))
+      (is (= bad (:target (ex-data e))))))
+
+  (testing "golden-match? / compare-golden ALSO fail closed on a bad run target"
+    (let [g (golden/make-golden (run-result {:app-db {:n 1}}))]
+      (is (thrown-with-msg?
+            #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
+            #":rf.error/golden-bad-target"
+            (golden/golden-match? g {:no :status})))
+      (is (thrown-with-msg?
+            #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
+            #":rf.error/golden-bad-target"
+            (golden/compare-golden g {:no :status}))))))
+
+;; ===========================================================================
 ;; HEADLESS: capture / compare over real replays  (live frame)
 ;; ===========================================================================
 
@@ -272,3 +362,42 @@
       (is (contains? (:facets (:diff r)) :app-db))
       (is (= [{:path [:v] :baseline 1 :current 2}]
              (get-in r [:diff :app-db :changed]))))))
+
+;; ===========================================================================
+;; HEADLESS: rf2-vvub1 — a normalized PLAN capture path actually replays
+;; ===========================================================================
+
+(deftest capture-golden-from-plan-replays-not-frozen
+  (testing "a normalized plan (a map with :world) is FOLDED to a replayable
+            artifact + replayed into a fresh frame — its behavioural slice
+            reflects the REAL run (a non-empty :app-db / :status), NOT a
+            silently-frozen near-empty plan map (the rf2-vvub1 bug)"
+    (rf/reg-event-db :golden/seed (fn [db [_ v]] (assoc db :v v)))
+    (rf/reg-event-db :golden/bump (fn [db _] (update db :v inc)))
+    (let [plan {:variant/id :story.golden/plan
+                :world  {:setup [[:dispatch [:golden/seed 10]]]}
+                :script [[:dispatch [:golden/bump]]]}
+          g    (golden/capture-golden plan {:keep-run-result true})]
+      (is (golden/golden? g))
+      ;; The frozen slice must be the REPLAYED run-result, not the plan map:
+      ;; a real run carries a :status and a non-empty :app-db. A silently-
+      ;; frozen plan would freeze {:v nil}/no :status and read near-empty.
+      (is (= {:v 11} (:app-db (:run-result g)))
+          "the plan was replayed (seed 10 then bump ⇒ 11), not frozen as data")
+      (is (= :pass (:status (:run-result g)))
+          "the frozen slice carries the run's :status — proving it is a run-result")
+      ;; And the golden re-matches a re-replay of the SAME plan (fresh-frame
+      ;; volatile drift causes no false mismatch).
+      (is (true? (golden/golden-match? g plan))
+          "the same plan replayed again matches the captured golden")
+      (is (true? (:match? (golden/compare-golden g plan))))))
+
+  (testing "a golden captured from a plan does NOT match a divergent plan"
+    (rf/reg-event-db :golden/seed (fn [db [_ v]] (assoc db :v v)))
+    (let [plan-a {:variant/id :story.golden/a :world {} :script [[:dispatch [:golden/seed 1]]]}
+          plan-b {:variant/id :story.golden/b :world {} :script [[:dispatch [:golden/seed 2]]]}
+          g      (golden/capture-golden plan-a {:keep-run-result true})
+          r      (golden/compare-golden g plan-b)]
+      (is (false? (golden/golden-match? g plan-b)))
+      (is (false? (:match? r)))
+      (is (contains? (:facets (:diff r)) :app-db)))))


### PR DESCRIPTION
Bundle of two golden-slice fixes, both in `tools/story/src/re_frame/story/golden.cljc` (+ `golden_test.cljc`).

## rf2-vvub1 (P3, correctness-adjacent) — fail closed on an unrecognized capture target

The ns docstring + `->run-result` docstring claimed a "normalized plan" capture path "via the determinism gate's `->artifact`", but the code never implemented it: `->run-result` checked only `run-artifact?` and otherwise returned the target verbatim. A **normalized plan** (a map with `:world` but no `:artifact/kind`) is not a run-artifact, so it fell through and was silently treated AS a run-result — `make-golden` then `select-keys`-froze a near-empty slice (no `:status`/`:app-db`/…), so the golden read **false GREEN forever**.

This is the inverse stale-doc case: the docstring *overstated* a capability.

**Fix — implement the documented path AND fail closed.** Because the plan→artifact coercion is *trivially derivable* from an existing pure fn (`determinism/->artifact`, which already folds `[:world :setup] ⧺ :script` into a replayable artifact), the masterpiece move is to make the documented capability real rather than delete it. `->run-result` now dispatches on shape:

- `:rf.test/run-artifact` → `replay-run-artifact` (impure);
- normalized plan (`:world`) → `determinism/->artifact` then `replay-run-artifact` (impure, same seam the determinism gate uses — so capture-from-plan agrees with capture-from-artifact/-result);
- run-result (`:status`) → used directly (pure);
- **anything else → REJECTED with `:rf.error/golden-bad-target`** (structured `ex-info`, matching `extends.cljc`'s convention) rather than silently frozen.

ns / `capture-golden` / `golden-match?` docstrings corrected to the real three-input contract + the reject. The spec (`tools/story/spec/017` §Golden slices) already mentioned the "artifact / plan capture path" in its Pure/JVM section; this makes the contract bullet + code agree without a spec edit (no §-section change needed).

## rf2-9fd9c (P4, DRY/perf) — one GREEN/RED authority, canonicalize once

`golden-match?` and `compare-golden` each re-inlined the same two-stage `(and run-hash= canonical=)` check (drift risk) and canonicalized the run **twice** per call (`run-hash` and `slice-canonical` both canonicalize the same behavioural slice).

- Lifted the verdict into one private `matches?` predicate over an already-coerced result; both callers route through it.
- Added `canonical+hash`: canonicalizes the behavioural slice **once**, derives the hash from the canonical value via `fingerprint/content-hash`. `content-hash(canonicalize(slice)) == run-hash(result)` is verified empirically and **locked by a test**. Behaviour-preserving.

## Tests (`golden_test.cljc`, +5 deftests)

- `capture-golden-from-plan-replays-not-frozen` (HEADLESS) — a plan replays (`:app-db {:v 11}`, `:status :pass`), NOT a frozen near-empty plan map; re-matches a re-replay; does not match a divergent plan. (Fails-pre: old code froze the plan with no `:app-db`.)
- `capture-golden-rejects-bad-target` (PURE) — garbage map / non-map / artifact-without-kind rejected with `:rf.error/golden-bad-target` on capture AND compare; carries structured `:rf.error/id` + `:target`.
- `match-and-compare-agree` (PURE) — `golden-match?` and `compare-golden`'s `:match?` agree across the equivalence/drift matrix (shared authority).
- `compare-golden-run-hash-matches-fingerprint` (PURE) — reported `:run-hash` == `fingerprint/run-hash` (locks the single-canonicalize perf path).
- Existing 9 golden tests unchanged and green (non-empty-`:facets` invariant preserved via `diff/diff-runs`).

`diff.cljc` was NOT touched — only its public `diff-runs` contract is consumed.

## Quality gates
- `tools/story`  `clojure -M:test` — **1268 tests / 4091 assertions, 0 failures**
- `tools/story-mcp`  `clojure -M:test` — **172 / 861, 0 failures**
- `tools/mcp-conformance`  `npm run test:story` — **STORY-MCP MCP-CLIENT CONFORMANCE GREEN**
- `scripts/test-fast-pr.sh` — **PASS** (CLJS node integration 4865 / 15925, 0 failures; README/docs anchor validators pass; mkdocs soft-skip local — CI runs it)