### PR TITLE
fix(story): determinism/generate cleanups + honest seed-reproducibility contract (rf2-12wg5 + rf2-4cdhy + rf2-f3ofr)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -2503,11 +2503,15 @@ pass and are throwaway; a failing one is the interesting case. Generated runs
 **emit artifacts FIRST**: every generated run produces a `:rf.test/run-artifact`
 carrying the `:seed` it was generated from (and, for a shrunk failure, the
 `:shrink-path`), so a generated failure is replayable off-CI and promotable
-into a curated regression variant (§Promotion). The `:seed` / `:shrink-path`
-artifact slots already exist (§Artifacts — Run artifact); the generated-run
-producer fills them. **Curated promotion only** — a generated failure becomes
-a named variant ONLY through the explicit `promote-run-artifact!` call
-(§Promotion), never automatically.
+into a curated regression variant (§Promotion). The artifact also carries the
+CONCRETE `:event-program` — the host-portable tagged-step data — and
+cross-host replay (author on a CLJS browser, CI gate on JVM) rides THAT
+program, not the raw `:seed` (the `:seed` reproduces the program only WITHIN
+the host that generated it — see §Generator-agnostic). The `:seed` /
+`:shrink-path` artifact slots already exist (§Artifacts — Run artifact); the
+generated-run producer fills them. **Curated promotion only** — a generated
+failure becomes a named variant ONLY through the explicit
+`promote-run-artifact!` call (§Promotion), never automatically.
 
 The base ships in `re-frame.story.generate`, re-exported as
 `story/check-property!` (the property entry point) + `story/sweep-faults!`
@@ -2522,8 +2526,23 @@ steps, or bare event vectors the artifact coerces). This namespace bundles
 generator, a hand-rolled state-machine walk, a recorded-interaction fuzzer)
 is the caller's, by wrapping its draw in a `gen-fn`. The seed sequence is a
 pure, seedable splitmix64 PRNG (`seed-seq`), so a property over N seeds is
-fully reproducible: the same root seed replays the same N programs. Recording
-the root `:seed` on the result makes the whole run reproducible.
+reproducible WITHIN A HOST: on the same host, the same root seed replays the
+same N programs, and recording the root `:seed` on the result reproduces the
+whole run there.
+
+**Seed reproducibility is within-host; cross-host replay rides the recorded
+`:event-program`.** `next-seed`'s exact 64-bit bit-pattern differs JVM↔CLJS:
+the JVM mixes with native wrapping `long` arithmetic, while CLJS computes the
+mix in `js/BigInt` and then truncates the result into the JS safe-integer
+range (a JS `number` cannot hold 64 exact bits). The same root `:seed` therefore
+unfolds DIFFERENT program seeds on the two hosts, so a recorded bare `:seed`
+reproduces a failure only on the host that produced it. This is intentional —
+the value proposition does NOT depend on cross-host seed portability, because
+every emitted artifact carries the CONCRETE `:event-program` (host-portable
+tagged-step data); a promoted regression replays that program verbatim on any
+host (§Promotion / §Run artifact and replay). The recorded `:seed` is
+provenance — "this is the seed that drew this program on this host" — not the
+cross-host reproducer.
 
 ### Shrinking — deterministic program-prefix delta-debug
 

--- a/tools/story/src/re_frame/story/determinism.cljc
+++ b/tools/story/src/re_frame/story/determinism.cljc
@@ -165,8 +165,17 @@
   [results]
   (let [n        (count results)
         slice    (fn [r] (select-keys r fingerprint/run-hash-input-keys))
+        ;; Canonicalize each run-slice ONCE and reuse the result for BOTH the
+        ;; hash and the equality. `fingerprint/run-hash` would re-canonicalize
+        ;; the same slice internally (`canonical-hash` → `canonicalize`), so
+        ;; hashing the canon directly via `content-hash` avoids the second
+        ;; pass while staying byte-identical: `run-hash` ≡ `(content-hash
+        ;; (canonicalize (slice r)))`, since `content-hash` only orders (it
+        ;; does NOT re-strip) and `canonicalize` is already the stripped,
+        ;; ordered form. The two-stage contract — the hash is the cheap
+        ;; discriminator, canonical `=` is the authority — is preserved exactly.
         canons   (mapv (comp fingerprint/canonicalize slice) results)
-        hashes   (mapv fingerprint/run-hash results)
+        hashes   (mapv fingerprint/content-hash canons)
         base     (first canons)
         diverged (first (keep-indexed
                           (fn [i c] (when (and (pos? i) (not= base c)) i))

--- a/tools/story/src/re_frame/story/generate.cljc
+++ b/tools/story/src/re_frame/story/generate.cljc
@@ -60,9 +60,12 @@
 ;;
 ;; A pure, reproducible 64-bit splitmix64 step. Given a seed it returns the
 ;; NEXT seed; `seed-seq` unfolds a deterministic seed sequence from a root
-;; seed. No host RNG, no `rand` — the same root seed always yields the same
-;; sequence, which is what makes a property run reproducible from its
-;; recorded `:seed`.
+;; seed. No host RNG, no `rand` — WITHIN a host the same root seed always
+;; yields the same sequence, which is what makes a property run reproducible
+;; from its recorded `:seed` on that host. The bit-pattern differs JVM↔CLJS
+;; (`next-seed` below), so seed-reproducibility is within-host; cross-host
+;; replay rides the artifact's recorded `:event-program` (spec/017
+;; §Generator-agnostic).
 
 ;; The splitmix64 constants, written as SIGNED two's-complement longs (the
 ;; JVM reader rejects a hex literal whose value exceeds Long/MAX_VALUE, so the
@@ -75,14 +78,22 @@
      (def ^:private ^:const splitmix-mul-2  -7723592293110705685))) ; 0x94D049BB133111EB
 
 (defn next-seed
-  "The splitmix64 successor of `seed` — a pure 64-bit mix. Deterministic:
-  the same `seed` always returns the same successor. Pure data → data.
+  "The splitmix64 successor of `seed` — a pure 64-bit mix. Deterministic
+  WITHIN a host: the same `seed` always returns the same successor on the
+  same host. Pure data → data.
 
   CLJS computes in `js/BigInt` (doubles cannot hold 64 exact bits) and
   returns a JS number truncated into the safe-integer range for ergonomic
   use as a seed; the JVM uses native wrapping `long` arithmetic. The exact
-  bit-pattern differs across hosts, but WITHIN a host the sequence is stable
-  and reproducible, which is all a recorded `:seed` needs."
+  bit-pattern therefore DIFFERS across hosts (CLJS truncates to
+  `MAX_SAFE_INTEGER`; the JVM keeps the full signed 64-bit mix), so the same
+  root seed unfolds different program seeds JVM↔CLJS. A recorded `:seed` is
+  thus reproducible only WITHIN the host that produced it; cross-host replay
+  (author on CLJS, CI gate on JVM) rides the recorded CONCRETE
+  `:event-program` instead — which IS host-portable (tagged-step data). This
+  within-host scope is by design: the artifact's `:event-program` carries the
+  cross-host reproducer, so the seed never needs to (spec/017
+  §Generator-agnostic)."
   [seed]
   #?(:clj
      (let [z (unchecked-add (unchecked-long seed) splitmix-gamma)
@@ -104,8 +115,11 @@
 
 (defn seed-seq
   "A deterministic sequence of `n` seeds unfolded from `root-seed` via
-  `next-seed`. Pure data → data — the same `root-seed` always yields the same
-  `n` seeds, so a property run over the sequence is reproducible. The first
+  `next-seed`. Pure data → data — WITHIN a host the same `root-seed` always
+  yields the same `n` seeds, so a property run over the sequence is reproducible
+  on that host. Because `next-seed`'s bit-pattern differs JVM↔CLJS, the seed
+  sequence diverges across hosts; cross-host replay rides the recorded
+  `:event-program` (see `next-seed` / spec/017 §Generator-agnostic). The first
   element is the splitmix successor of `root-seed` (so the root seed itself is
   never reused as a program seed)."
   [root-seed n]
@@ -292,8 +306,13 @@
   `gen-fn` is a pure `(fn [seed] event-program)`; `opts`:
 
   - `:seed`         — the ROOT seed the `n` program seeds unfold from
-                      (`seed-seq`). Default 0. Recording it makes the whole
-                      property run reproducible.
+                      (`seed-seq`). Default 0. Recording it reproduces the whole
+                      property run WITHIN the host that produced it; it is
+                      provenance, not a cross-host reproducer (the splitmix
+                      bit-pattern differs JVM↔CLJS — see `next-seed`). A
+                      falsifying run's recorded `:event-program` is what
+                      replays the concrete failure cross-host (spec/017
+                      §Generator-agnostic).
   - `:num-tests`    — `n`, the number of generated programs (default 100).
   - `:shrink?`      — shrink a failing program toward a minimal failing case
                       (default true). When false the first failing program is
@@ -398,7 +417,12 @@
   cell's artifact carries the faulted `:fx-decisions` so it replays against the
   same fault, and is promotable (§Promotion) — artifacts first."
   [base-program fault-lattice {:keys [seed hooks frame-config] :as _opts}]
-  (let [cells   (if (map? fault-lattice) (seq fault-lattice) (seq fault-lattice))
+  ;; `(seq fault-lattice)` handles BOTH accepted shapes uniformly: a map seqs
+  ;; to its `[cell-id fx-decisions]` entry pairs, a pair-seq seqs to its pairs
+  ;; — and the cell destructure `(fn [[cell-id fx-decisions]] …)` consumes
+  ;; either. The map?/seq distinction is genuinely vacuous (no order or
+  ;; seqability concern differs between the arms), so there is one branch.
+  (let [cells   (seq fault-lattice)
         results (mapv
                   (fn [[cell-id fx-decisions]]
                     (let [a       (artifact/make-run-artifact

--- a/tools/story/test/re_frame/story/determinism_test.cljc
+++ b/tools/story/test/re_frame/story/determinism_test.cljc
@@ -189,7 +189,24 @@
       (is (nil? (:run-hash c)))
       (is (= 2 (get-in c [:divergence :run])) "run 2 is the first divergence")
       (is (not= (get-in c [:divergence :run-hash-0])
-                (get-in c [:divergence :run-hash-n]))))))
+                (get-in c [:divergence :run-hash-n])))))
+
+  ;; rf2-12wg5 — compare-runs canonicalizes each run-slice ONCE and derives
+  ;; the hash from the canon (via content-hash) rather than re-canonicalizing
+  ;; inside run-hash. The reported hashes MUST stay byte-identical to run-hash,
+  ;; so a recorded :run-hash and a determinism-gate hash never disagree.
+  (testing "the reported hashes are byte-identical to fp/run-hash (no double canon)"
+    (let [r0 {:status :pass :app-db {:n 1 :nested {:b 2 :a 1}}
+              :warnings #{:w2 :w1}}
+          r1 {:status :pass :app-db {:n 1 :nested {:a 1 :b 2}}
+              ;; volatile + per-run stamps differ but must be stripped equal
+              :elapsed-ms 99 :warnings #{:w1 :w2}}
+          c  (det/compare-runs [r0 r1])]
+      (is (:deterministic? c) "the two runs differ only in volatile fields")
+      (is (= [(fp/run-hash r0) (fp/run-hash r1)] (:hashes c))
+          "content-hash of the canon equals run-hash for every run")
+      (is (= (fp/run-hash r0) (:run-hash c))
+          "the shared run-hash is the canonical run-hash"))))
 
 ;; ===========================================================================
 ;; HEADLESS gate: against a live frame  (the §A4 acceptance)

--- a/tools/story/test/re_frame/story/generate_test.cljc
+++ b/tools/story/test/re_frame/story/generate_test.cljc
@@ -29,9 +29,16 @@
 ;; ===========================================================================
 
 (deftest seed-sequence-is-reproducible
-  (testing "the same root seed yields the SAME sequence (reproducibility)"
+  ;; rf2-f3ofr — seed-reproducibility is WITHIN-host: `next-seed`'s bit-pattern
+  ;; differs JVM↔CLJS (CLJS truncates the splitmix64 mix into MAX_SAFE_INTEGER),
+  ;; so a recorded bare `:seed` reproduces a run only on the host that produced
+  ;; it. Within a host the sequence is fully deterministic (asserted here);
+  ;; cross-host replay rides the recorded concrete `:event-program` (asserted in
+  ;; `generated-failure-promotes-through-the-existing-bridge`). The spec
+  ;; (spec/017 §Generator-agnostic) now qualifies the claim as within-host.
+  (testing "WITHIN a host the same root seed yields the SAME sequence (reproducibility)"
     (is (= (generate/seed-seq 12345 8) (generate/seed-seq 12345 8))
-        "a property run replays identically from its recorded :seed"))
+        "a property run replays identically from its recorded :seed on the same host"))
   (testing "different root seeds diverge"
     (is (not= (generate/seed-seq 1 8) (generate/seed-seq 2 8))))
   (testing "seed-seq length + the root seed is never reused as a program seed"
@@ -176,7 +183,15 @@
       (is (= (:seed artifact) (get-in plan [:run-artifact :seed]))
           "the curated plan's provenance carries the falsifying seed")
       (is (contains? (:run-artifact plan) :event-program)
-          "the source link is replayable (carries the event program)"))))
+          "the source link is replayable (carries the event program)")
+      ;; rf2-f3ofr — the CONCRETE :event-program (host-portable tagged-step
+      ;; data) is the cross-host reproducer, NOT the within-host-only :seed.
+      ;; The promoted plan must carry enough program to replay the failure on
+      ;; ANY host (CLJS author → JVM CI), so a non-empty tagged-step vector is
+      ;; the genuine cross-host bridge.
+      (is (let [prog (get-in plan [:run-artifact :event-program])]
+            (and (vector? prog) (seq prog) (every? vector? prog)))
+          "the cross-host reproducer is the concrete tagged-step program, not the seed"))))
 
 ;; ===========================================================================
 ;; HEADLESS: fault lattice sweep
@@ -209,3 +224,32 @@
       ;; The :save-fails cell errored → it is in :failing.
       (is (some #{:save-fails} (:failing res))
           "the faulted cell falsifies and is reported in :failing"))))
+
+;; rf2-4cdhy — sweep-faults! accepts a fault-lattice as EITHER a map
+;; {cell-id fx-decisions} OR a seq of [cell-id fx-decisions] pairs, and both
+;; produce identical sweeps cell-for-cell (the collapsed `(seq fault-lattice)`
+;; handles both — a map seqs to its entry pairs, a pair-seq seqs to its pairs).
+(deftest sweep-faults-accepts-map-and-pair-seq-equivalently
+  (testing "a map lattice and the same lattice as a [cell-id fx] pair-seq sweep identically"
+    (rf/reg-fx :app.fx/save {:platforms #{:client :server}} (fn [_ _] :ok))
+    (rf/reg-fx :app.fx/save-broken {:platforms #{:client :server}}
+               (fn [_ _] (throw (ex-info "fault: save failed" {}))))
+    (rf/reg-event-fx :app/save (fn [_ _] {:fx [[:app.fx/save {}]]}))
+    (let [base        [[:dispatch [:app/save]]]
+          ;; The SAME lattice in both shapes, in the same cell order.
+          as-map      {:healthy {} :save-fails {:app.fx/save :app.fx/save-broken}}
+          as-pair-seq [[:healthy {}] [:save-fails {:app.fx/save :app.fx/save-broken}]]
+          from-map    (generate/sweep-faults! base as-map      {:seed 7})
+          from-seq    (generate/sweep-faults! base as-pair-seq {:seed 7})
+          cell-shape  (fn [c] {:cell (:cell c)
+                               :status (:status c)
+                               :fx-decisions (:fx-decisions (:artifact c))})]
+      (is (= (mapv cell-shape (:cells from-map))
+             (mapv cell-shape (:cells from-seq)))
+          "both shapes sweep the same cells, in the same order, with the same faults")
+      (is (= (:failing from-map) (:failing from-seq))
+          "both shapes report the same failing cell ids")
+      (is (= [:healthy :save-fails] (mapv :cell (:cells from-seq)))
+          "the pair-seq preserves authored cell order")
+      (is (some #{:save-fails} (:failing from-seq))
+          "the faulted cell falsifies under the pair-seq shape too"))))


### PR DESCRIPTION
Bundle on the determinism/generate surface. Three fixes, one PR.

## rf2-12wg5 (P4, `determinism.cljc`) — double-canonicalize in `compare-runs`

`compare-runs` canonicalized each run-slice TWICE: once explicitly into
`canons`, and again inside `fingerprint/run-hash` (which re-canonicalizes the
same slice via `canonical-hash`). Now each slice is canonicalized exactly
once: the hashes are derived from the already-canonicalized `canons` via
`fingerprint/content-hash` (which only *orders* — it does NOT re-strip).

This is byte-identical to the old behaviour because
`run-hash(r) ≡ content-hash(canonicalize(slice r))` — `canonicalize` is the
stripped+ordered form, and `canonical-form` is idempotent on its own output,
so feeding the canon through `content-hash` reproduces the exact 8-char hash.
Verified empirically across maps/sets/nested/empty/volatile-key slices. The
two-stage contract (hash = cheap discriminator, canonical `=` = authority) is
preserved. `fingerprint.cljc` was NOT touched (held); the fix lives entirely
in `determinism.cljc` using the public `content-hash`.

Same SHAPE as golden's rf2-9fd9c — distinct call site, owned here.

## rf2-4cdhy (P4, `generate.cljc`) — dead branch in `sweep-faults!`

`(if (map? fault-lattice) (seq fault-lattice) (seq fault-lattice))` — both
arms identical. Collapsed to `(seq fault-lattice)`. A map seqs to its
`[cell-id fx-decisions]` entry pairs; a pair-seq seqs to its pairs; the cell
destructure `(fn [[cell-id fx-decisions]] …)` consumes either — the branch was
genuinely vacuous (no order/seqability concern differed). Added a test proving
a map lattice and the same lattice as a pair-seq sweep identically (same cells,
order, faults, failing ids).

## rf2-f3ofr (P3, `generate.cljc` + `spec/017`) — seed reproducibility is within-host

**Path chosen: (b) — make the contract HONEST.**

`next-seed`'s splitmix64 bit-pattern differs JVM↔CLJS (the CLJS path computes
in `js/BigInt` then truncates the mix into `MAX_SAFE_INTEGER`), so a recorded
bare `:seed` reproduces a run only WITHIN the host that generated it. This
contradicted spec/017's unqualified "the whole run reproducible" /
"replayable off-CI" (CI=JVM, authoring=CLJS commonly differ).

I took (b) rather than (a) because the value proposition does **not** depend on
cross-host seed portability: every emitted artifact already carries the
CONCRETE `:event-program` (host-portable tagged-step data), and the promotion
bridge replays *that* program verbatim on any host — verified in
`generated-failure-promotes-through-the-existing-bridge`. A path-(a) fix
(full-64-bit CLJS seed) would force `:seed` to become a BigInt on CLJS (a JS
`number` cannot hold 64 exact bits), rippling into the artifact schema,
serialization, and every `:seed` consumer — the "gnarly BigInt port" the bead
warns against, for zero added capability. The masterpiece call is to state the
real contract, not to over-engineer a portable PRNG nobody needs.

Changes:
- Qualified spec/017 §Generated runs and §Generator-agnostic: seed-repro is
  within-host; cross-host replay rides the recorded `:event-program`.
- Qualified the `next-seed` / `seed-seq` / `check-property!` `:seed` docstrings
  + the PRNG section comment to match.
- No code-logic change to the PRNG — the divergence is by design and now
  documented as such.
- Tests: `seed-sequence-is-reproducible` documents the within-host scope; the
  promotion test now asserts the cross-host reproducer is the concrete
  tagged-step `:event-program`, not the seed.

No follow-on bead filed — (b) fully resolves the contract divergence; (a) was
considered and rejected on merit (above), not deferred.

## Quality gates
- `tools/story`: `clojure -M:test` — 1274 tests / 4110 assertions, 0 failures, 0 errors (green)
- `tools/story-mcp`: `clojure -M:test` — 172 tests / 861 assertions, 0 failures (green)
- `tools/mcp-conformance`: `npm run test:story` — STORY-MCP MCP-CLIENT CONFORMANCE GREEN
- `implementation`: `npm run test:cljs` — 4865 tests / 15925 assertions, 0 failures (validates the CLJS PRNG branch + the `.cljc` Story tests under CLJS)
- `scripts/test-fast-pr.sh` — PASS (incl. README/docs anchor validators; mkdocs soft-skipped locally, runs on CI)