### PR TITLE
refactor(story): single-projection result boundary + runner-finish refusal tests (rf2-whcxq + rf2-wk079 + rf2-bkiuj + rf2-taq2j)

### DIFF
--- a/tools/story/src/re_frame/story/play/evidence.cljc
+++ b/tools/story/src/re_frame/story/play/evidence.cljc
@@ -360,39 +360,51 @@
   are NOT projected into `:sub-runs`), so this is the over-recompute
   signal `:rf.assert/no-cascade-rerender` reads directly. `:by-cause`
   credits each reactive row to the event that invalidated its reactive
-  input — the cause→effect attribution `:rf.assert/caused` reasons over."
-  [epoch-tape]
-  (let [sub-rows    (sub-runs epoch-tape)
-        render-rows (renders epoch-tape)]
-    (when (or (seq sub-rows) (seq render-rows))
-      (let [by-cause
-            (reduce
-              (fn [acc [k sub-delta render-delta]]
-                (cond-> acc
-                  (some? k)
-                  (update k (fn [{:keys [sub-recomputes view-renders]
-                                  :or   {sub-recomputes 0 view-renders 0}}]
-                              {:sub-recomputes (+ sub-recomputes sub-delta)
-                               :view-renders   (+ view-renders render-delta)}))))
-              {}
-              (concat (map (fn [r] [(:cause-event-id r) 1 0]) sub-rows)
-                      (map (fn [r] [(:cause-event-id r) 0 1]) render-rows)))
-            per-epoch
-            (->> (concat sub-rows render-rows)
-                 (map :epoch-id)
-                 distinct
-                 (keep identity)
-                 (mapv (fn [eid]
-                         {:epoch-id       eid
-                          :sub-recomputes (count (filter #(= eid (:epoch-id %)) sub-rows))
-                          :view-renders   (count (filter #(= eid (:epoch-id %)) render-rows))})))]
-        {:sub-recomputes (count sub-rows)
-         :view-renders   (count render-rows)
-         :by-sub-id      (count-by :sub-id sub-rows)
-         :by-view        (count-by render-view-id render-rows)
-         :by-render-key  (count-by :render-key render-rows)
-         :by-cause       by-cause
-         :per-epoch      per-epoch}))))
+  input — the cause→effect attribution `:rf.assert/caused` reasons over.
+
+  The 3-arity (`sub-rows`, `render-rows` pre-projected) is the one-walk
+  entry point `project-evidence` uses: it already projects the
+  `:sub-runs` / `:renders` slots, so it threads those SAME row vectors in
+  rather than have this fn re-walk the tape for them (one tape, one
+  projection — never a second walk)."
+  ([epoch-tape]
+   (reactive-counts (sub-runs epoch-tape) (renders epoch-tape)))
+  ([sub-rows render-rows]
+   (when (or (seq sub-rows) (seq render-rows))
+     (let [by-cause
+           (reduce
+             (fn [acc [k sub-delta render-delta]]
+               (cond-> acc
+                 (some? k)
+                 (update k (fn [{:keys [sub-recomputes view-renders]
+                                 :or   {sub-recomputes 0 view-renders 0}}]
+                             {:sub-recomputes (+ sub-recomputes sub-delta)
+                              :view-renders   (+ view-renders render-delta)}))))
+             {}
+             (concat (map (fn [r] [(:cause-event-id r) 1 0]) sub-rows)
+                     (map (fn [r] [(:cause-event-id r) 0 1]) render-rows)))
+           ;; :per-epoch is O(rows): group both row vectors by :epoch-id in
+           ;; ONE pass each (the sibling :by-* slots already do this via
+           ;; count-by), then assemble per distinct epoch-id in tape order —
+           ;; not an O(epochs × rows) re-filter per epoch.
+           sub-by-epoch    (group-by :epoch-id sub-rows)
+           render-by-epoch (group-by :epoch-id render-rows)
+           per-epoch
+           (->> (concat sub-rows render-rows)
+                (map :epoch-id)
+                distinct
+                (keep identity)
+                (mapv (fn [eid]
+                        {:epoch-id       eid
+                         :sub-recomputes (count (get sub-by-epoch eid))
+                         :view-renders   (count (get render-by-epoch eid))})))]
+       {:sub-recomputes (count sub-rows)
+        :view-renders   (count render-rows)
+        :by-sub-id      (count-by :sub-id sub-rows)
+        :by-view        (count-by render-view-id render-rows)
+        :by-render-key  (count-by :render-key render-rows)
+        :by-cause       by-cause
+        :per-epoch      per-epoch}))))
 
 ;; ===========================================================================
 ;; TWO-LEVEL NARRATIVE PROJECTION  (spec/017 §Run result, §Epoch tape and narrative)
@@ -676,6 +688,28 @@
   [{:keys [outcome] :as _effect-row}]
   (= :error outcome))
 
+(defn evidence-shows-failure?
+  "True iff the ALREADY-PROJECTED run evidence carries a floor failure
+  signal — the agreement-floor predicate over pre-derived slots. Pure data →
+  data. This is the single-projection entry point: a caller that has already
+  run `schema-violations` / `effects` over the tape (e.g.
+  `project-evidence`) threads those vectors in rather than have the floor
+  re-walk the tape a second/third time. `tape-shows-failure?` is the
+  raw-tape convenience that projects then delegates here.
+
+  `epoch-tape` is still needed for the `:outcome` check (a per-epoch slot,
+  not one of the projected vectors); `violations` / `effects` are the
+  projected `schema-violations` / `effects` outputs; `consumed-selectors`
+  is the set of violation selectors the run's `:rf.assert/schema-error`
+  expectations exactly consumed (subtracted from the violation signal so an
+  EXPECTED schema failure does not trip the floor)."
+  [epoch-tape violations effects consumed-selectors]
+  (let [unconsumed (remove #(contains? consumed-selectors (:selector %)) violations)]
+    (boolean
+      (or (seq unconsumed)
+          (some failed-outcome? epoch-tape)
+          (some error-effect? effects)))))
+
 (defn tape-shows-failure?
   "True iff the retained `epoch-tape` carries evidence that the run did NOT
   fully succeed. Pure data → data. The bead's agreement invariant: a run
@@ -694,17 +728,19 @@
   The `consumed-selectors` arg (a set of violation selectors the run's
   `:rf.assert/schema-error` expectations consumed) is subtracted from the
   schema-violation signal so an EXPECTED schema failure does not trip the
-  floor. Omit it (or pass `#{}`) for the strict floor."
+  floor. Omit it (or pass `#{}`) for the strict floor.
+
+  This projects `schema-violations` / `effects` from the raw tape then
+  delegates to `evidence-shows-failure?`; a caller that has already
+  projected those slots (the `run-result` assembly) should call
+  `evidence-shows-failure?` directly to avoid a redundant re-walk."
   ([epoch-tape]
    (tape-shows-failure? epoch-tape #{}))
   ([epoch-tape consumed-selectors]
-   (let [violations  (schema-violations epoch-tape)
-         unconsumed   (remove #(contains? consumed-selectors (:selector %)) violations)
-         eff          (effects epoch-tape)]
-     (boolean
-       (or (seq unconsumed)
-           (some failed-outcome? epoch-tape)
-           (some error-effect? eff))))))
+   (evidence-shows-failure? epoch-tape
+                            (schema-violations epoch-tape)
+                            (effects epoch-tape)
+                            consumed-selectors)))
 
 ;; ===========================================================================
 ;; THE PROJECTION BOUNDARY  (epoch records → run-result evidence slots)
@@ -750,14 +786,20 @@
   exercised."
   ([epoch-tape] (project-evidence epoch-tape nil))
   ([epoch-tape {:keys [script] :as _opts}]
-   (let [tape (vec (or epoch-tape []))
-         rc   (reactive-counts tape)]
+   (let [tape        (vec (or epoch-tape []))
+         ;; Project the structured reactive rows ONCE: they are both the
+         ;; `:sub-runs` / `:renders` slots AND the input `reactive-counts`
+         ;; reads — threaded down so neither walks the tape a second time
+         ;; (one tape, one projection).
+         sub-rows    (sub-runs tape)
+         render-rows (renders tape)
+         rc          (reactive-counts sub-rows render-rows)]
      (cond-> {:epoch-tape        tape
               :schema-violations (schema-violations tape)
               :warnings          (warnings tape)
               :effects           (effects tape)
-              :sub-runs          (sub-runs tape)
-              :renders           (renders tape)
+              :sub-runs          sub-rows
+              :renders           render-rows
               :narrative         (narrative script tape)}
        (some? rc) (assoc :reactive-counts rc)))))
 

--- a/tools/story/src/re_frame/story/result.cljc
+++ b/tools/story/src/re_frame/story/result.cljc
@@ -317,21 +317,30 @@
   violation does not trip the floor. A violation left unconsumed keeps its
   selector OUT of the set, so the floor still fails the run on it (§Schema
   rule step 4). A `:fail` record for each unmatched expectation fails the
-  run on a MISSING expected violation (step 3)."
-  [schema-expectations epoch-tape]
-  (let [violations  (evidence/schema-violations epoch-tape)
-        exps        (mapv assertions/schema-error-expectation
-                          (or schema-expectations []))
-        {:keys [matched unmatched unconsumed]} (pair-expectations exps violations)
-        records     (into (mapv (fn [{:keys [expectation violation]}]
-                                  (schema-error-record expectation violation))
-                                matched)
-                          (mapv (fn [exp] (schema-error-record exp nil))
-                                unmatched))]
-    {:records            records
-     :consumed-selectors (into #{} (map (comp :selector :violation)) matched)
-     :unmatched          unmatched
-     :unconsumed         unconsumed}))
+  run on a MISSING expected violation (step 3).
+
+  The 2-arity projects the violations from the raw `epoch-tape`; the
+  `[schema-expectations violations :as :projected]` 3-arity takes the
+  ALREADY-PROJECTED `evidence/schema-violations` vector (the `run-result`
+  assembly's `evidence-slots`) so the assembly does not walk the tape for
+  the same violations a second time — one tape, one projection."
+  ([schema-expectations epoch-tape]
+   (match-schema-expectations schema-expectations
+                              (evidence/schema-violations epoch-tape)
+                              :projected))
+  ([schema-expectations violations _projected]
+   (let [exps        (mapv assertions/schema-error-expectation
+                           (or schema-expectations []))
+         {:keys [matched unmatched unconsumed]} (pair-expectations exps violations)
+         records     (into (mapv (fn [{:keys [expectation violation]}]
+                                   (schema-error-record expectation violation))
+                                 matched)
+                           (mapv (fn [exp] (schema-error-record exp nil))
+                                 unmatched))]
+     {:records            records
+      :consumed-selectors (into #{} (map (comp :selector :violation)) matched)
+      :unmatched          unmatched
+      :unconsumed         unconsumed})))
 
 ;; ===========================================================================
 ;; CAUSAL / CASCADE EXPECTATIONS  (spec/017 §Causal and cascade assertions,
@@ -550,6 +559,14 @@
     :as   parts}]
   (let [tape           (vec (or epoch-tape []))
         evidence-slots (evidence/project-evidence tape {:script script})
+        ;; The tape is projected ONCE (`project-evidence` above); the
+        ;; schema-violation + effect vectors it already produced are threaded
+        ;; into the schema match and the agreement floor below rather than
+        ;; re-projected from the raw tape. This reinforces the ns's stated
+        ;; "one tape, one projection, single source of truth" invariant — the
+        ;; floor and the schema matcher read the SAME projected evidence the
+        ;; result's slots carry, never a second derivation.
+        violations     (:schema-violations evidence-slots)
         ;; EXACT schema-error consumption (§Schema rule, rf2-5x1wt.21): pair
         ;; each declared `:rf.assert/schema-error` against the tape's
         ;; projected violations. The minted records (a `:pass` for each
@@ -558,7 +575,7 @@
         ;; exactly-consumed selectors excuse those violations from the floor,
         ;; while an UNCONSUMED violation keeps its selector OUT of the set so
         ;; the floor still fails the run on it.
-        schema-match   (match-schema-expectations schema-expectations tape)
+        schema-match   (match-schema-expectations schema-expectations violations :projected)
         ;; Causal / cascade expectations (§Causal and cascade assertions,
         ;; rf2-5x1wt.31): project each declared `:rf.assert/caused` /
         ;; `:rf.assert/no-cascade-rerender` against the SAME reactive
@@ -576,7 +593,12 @@
                              (:consumed-selectors schema-match))
         unmet          (vec (or unmet []))
         base-status    (requirements/aggregate-status records unmet)
-        tape-red?      (evidence/tape-shows-failure? tape consumed)
+        ;; Agreement floor over the SAME projected evidence — the violations
+        ;; + effects `project-evidence` already derived, not a re-walk of the
+        ;; raw tape (the tape is still needed for the per-epoch `:outcome`
+        ;; signal). One tape, one projection.
+        tape-red?      (evidence/evidence-shows-failure?
+                         tape violations (:effects evidence-slots) consumed)
         ;; The agreement floor escalates ONLY a would-be pass — a real
         ;; :fail / :error / :cannot-run already outranks it (the floor never
         ;; downgrades a higher verdict).

--- a/tools/story/test/re_frame/story/play/runner_test.cljc
+++ b/tools/story/test/re_frame/story/play/runner_test.cljc
@@ -219,6 +219,126 @@
                                          (runner/step-exception 0 [:dispatch [:bad]] "boom"))]
     (is (= :fail (:status (runner/finish exc 1))))))
 
+;; ---- finish :cannot-run aggregation (rf2-taq2j) -------------------------
+;;
+;; finish has a THREE-way precedence (the runner-state analogue of
+;; requirements/aggregate-status): :fail > :cannot-run > :pass. A run whose
+;; ONLY non-pass step-results are refusals (a no-DOM :skipped? skip or a
+;; boundary :cannot-run?) must terminate :cannot-run — NEVER a silent :pass.
+;; This is the headline "cannot-run is a distinct third status, never a
+;; silent pass" invariant, guarded at the requirements + settled-boundary
+;; layers but previously UNTESTED at the runner-state finish consumers see.
+;; A real refusal is the shape the step executor mints:
+;;   (step-fail idx step {:skipped? true :message "no DOM — …"})  → :passed? false + :skipped?
+;;   (step-fail idx step {:cannot-run? true :message "…"})        → :passed? false + :cannot-run?
+
+(deftest finish-skip-only-run-is-cannot-run-not-pass
+  (testing "a run whose only non-pass step is a no-DOM :skipped? refusal
+            terminates :cannot-run, NOT a silent :pass"
+    (let [step  [:assert-dom "[data-test=x]" :visible]
+          base  (-> {:script [[:dispatch [:a]] step]}
+                    runner/parse-spec
+                    runner/initial-state
+                    (runner/start 0))
+          state (-> base
+                    (runner/record-step-result (runner/step-pass 0 [:dispatch [:a]]))
+                    (runner/record-step-result
+                      (runner/step-fail 1 step {:skipped? true :message "no DOM — cannot prove"})))]
+      (is (= :cannot-run (:status (runner/finish state 100)))
+          "skip-only refusal → :cannot-run (the fail-closed third status)")
+      (is (not= :pass (:status (runner/finish state 100)))
+          "the refusal must NOT collapse into a vacuous green"))))
+
+(deftest finish-cannot-run-refusal-only-is-cannot-run
+  (testing "a boundary :cannot-run? refusal (no skip) also terminates :cannot-run"
+    (let [step  [:assert-dom "[data-test=x]" :visible]
+          state (-> {:script [step]}
+                    runner/parse-spec
+                    runner/initial-state
+                    (runner/start 0)
+                    (runner/record-step-result
+                      (runner/step-fail 0 step {:cannot-run? true :message "capability refused"})))]
+      (is (= :cannot-run (:status (runner/finish state 100)))))))
+
+(deftest finish-fail-outranks-refusal
+  (testing ":fail wins over :cannot-run — a genuine failing assertion
+            alongside a refusal terminates :fail (precedence)"
+    (let [fail-step [:assert-db [:k] 1]
+          skip-step [:assert-dom "[data-test=x]" :visible]
+          state     (-> {:script [fail-step skip-step]}
+                        runner/parse-spec
+                        runner/initial-state
+                        (runner/start 0)
+                        (runner/record-step-result
+                          (runner/step-fail 0 fail-step {:message "expected 1"}))
+                        (runner/record-step-result
+                          (runner/step-fail 1 skip-step {:skipped? true :message "no DOM"})))]
+      (is (= :fail (:status (runner/finish state 100)))
+          ":fail (a real failing step) outranks the refusal"))))
+
+(deftest finish-exception-outranks-refusal
+  (testing "an exception alongside a refusal terminates :fail (precedence)"
+    (let [exc-step  [:dispatch [:bad]]
+          skip-step [:assert-dom "[data-test=x]" :visible]
+          state     (-> {:script [exc-step skip-step]}
+                        runner/parse-spec
+                        runner/initial-state
+                        (runner/start 0)
+                        (runner/record-step-result
+                          (runner/step-exception 0 exc-step "boom"))
+                        (runner/record-step-result
+                          (runner/step-fail 1 skip-step {:skipped? true :message "no DOM"})))]
+      (is (= :fail (:status (runner/finish state 100)))))))
+
+;; ---- run-state-refusals projection (rf2-taq2j) --------------------------
+
+(deftest run-state-refusals-projects-one-record-per-refusing-step
+  (testing "run-state-refusals projects each :skipped? / :cannot-run? step
+            into the {:status :cannot-run :unit :reason :message} shape the
+            unified result's :unmet slot folds; non-refusal steps are excluded"
+    (let [pass-step [:dispatch [:a]]
+          skip-step [:assert-dom "[data-test=x]" :visible]
+          cr-step   [:click "[data-test=y]"]
+          state     (-> {:script [pass-step skip-step cr-step]}
+                        runner/parse-spec
+                        runner/initial-state
+                        (runner/start 0)
+                        (runner/record-step-result (runner/step-pass 0 pass-step))
+                        (runner/record-step-result
+                          (runner/step-fail 1 skip-step {:skipped? true :message "no DOM — cannot prove"}))
+                        (runner/record-step-result
+                          (runner/step-fail 2 cr-step {:cannot-run? true :message "capability refused"})))
+          refusals  (runner/run-state-refusals state)]
+      (is (= 2 (count refusals)) "one refusal record per refusing step (skip + cannot-run?)")
+      (is (= [{:status :cannot-run :unit skip-step
+               :reason :runner-cannot-attempt-step :message "no DOM — cannot prove"}
+              {:status :cannot-run :unit cr-step
+               :reason :runner-cannot-attempt-step :message "capability refused"}]
+             refusals)
+          "each refusal projects the :status/:unit/:reason/:message shape, in step order")
+      (is (every? #(= :cannot-run (:status %)) refusals)))))
+
+(deftest run-state-refusals-empty-when-none-refused
+  (testing "run-state-refusals is empty for a clean pass run (no step refused)"
+    (let [state (-> {:script [[:assert-db [:k] 1]]}
+                    runner/parse-spec
+                    runner/initial-state
+                    (runner/start 0)
+                    (runner/record-step-result (runner/step-pass 0 [:assert-db [:k] 1])))]
+      (is (= [] (runner/run-state-refusals state))))))
+
+(deftest run-state-refusals-omits-message-when-absent
+  (testing "a refusal with no :message omits the :message slot (cond-> shape)"
+    (let [step  [:assert-dom "[data-test=x]" :visible]
+          state (-> {:script [step]}
+                    runner/parse-spec
+                    runner/initial-state
+                    (runner/start 0)
+                    (runner/record-step-result (runner/step-fail 0 step {:skipped? true})))
+          [r]   (runner/run-state-refusals state)]
+      (is (= {:status :cannot-run :unit step :reason :runner-cannot-attempt-step} r)
+          "no :message slot when the step-result carried none"))))
+
 (deftest done-pred
   (let [empty-state (runner/initial-state {:script []})
         with-steps  (runner/initial-state {:script [[:wait 1]]})]


### PR DESCRIPTION
## What

Result-boundary cluster: behavior-preserving recompute reduction across the run-result SSOT (every Story run / Test mode / CI / MCP / golden capture flows through it) + the missing runner-state `:cannot-run` coverage. **No slot output changes — same values, computed once.**

### rf2-whcxq (P3, hot path — `result.cljc`)
`run-result` re-projected the tape 2-3× per assembly: `schema-violations` walked **3×** (`project-evidence` + `match-schema-expectations` + `tape-shows-failure?`), `effects` **2×**. The tape is now projected **once** (`project-evidence`); the already-projected `:schema-violations` / `:effects` vectors are threaded into the schema matcher and the agreement floor instead of being re-derived from the raw tape.
- `match-schema-expectations` gains a `[schema-expectations violations :projected]` arity (the 2-arity still projects from the tape).

### rf2-wk079 (P4 — `evidence.cljc`)
`project-evidence` projected `:sub-runs` / `:renders` for its own slots **and** `reactive-counts` re-walked the tape for the same rows. The structured rows are now projected once and threaded into `reactive-counts`' new `[sub-rows render-rows]` arity (the 1-arity still projects from the tape). Preserves the `9gquv` `:by-cause` `:cause-event-id` behavior (rebased on current main).

### rf2-bkiuj (P4 — `evidence.cljc`)
`reactive-counts` `:per-epoch` was `O(epochs × rows)` — re-filtering both row vectors per distinct epoch-id. Now `group-by :epoch-id` once → `O(rows)`, reading consistently with the sibling `count-by` slots. `:per-epoch` shape + tape order unchanged.

### rf2-taq2j (P2, test-only — `runner_test.cljc`)
`finish`'s `:cannot-run` aggregation branch + `run-state-refusals` were untested at the runner-state layer — the "cannot-run is never a silent pass" invariant was guarded at requirements + settled-boundary but **not** at the `finish` consumers actually see. Added:
- a skip-only run and a `:cannot-run?`-only run each → `:cannot-run` (NOT `:pass`);
- `:fail` and an exception each **outrank** a refusal (precedence);
- `run-state-refusals` projects the `{:status :cannot-run :unit :reason :message}` shape — one per refusing step, empty when none refused, `:message` omitted when absent.

No implementation change for taq2j (it is a test bead). Verified the tests are genuinely fail-closed: a throwaway mutation collapsing `:cannot-run`→`:pass` flipped exactly 3 of them red, then reverted.

## Behavior-preserving

The run-result / evidence output is the agreement-floor SSOT and is **unchanged** — the refactors only remove redundant re-walks of the same tape. Full story suite stays green post-rebase. No spec/017 change: the documented public signatures (`story/project-evidence`, `story/tape-shows-failure? [tape consumed-selectors]`, `match-schema-expectations [exps epoch-tape]`) and the `:per-epoch` / `:reactive-counts` shapes are all unchanged; the new arities are additive and `evidence-shows-failure?` is an internal helper.

## Quality gates

- `tools/story` `clojure -M:test` — **1288 tests / 4156 assertions, 0 failures, 0 errors** (post-rebase)
- `tools/story-mcp` `clojure -M:test` — **172 tests / 861 assertions, 0 failures, 0 errors**
- `tools/mcp-conformance` `npm run test:story` — **EXIT 0, "STORY-MCP MCP-CLIENT CONFORMANCE GREEN"**
- `bash scripts/test-fast-pr.sh` — **4865 tests / 15925 assertions, 0 failures, 0 errors → PASS fast PR spine**
- runner-test namespace alone — **57 tests / 179 assertions, 0 failures** (was ~49 pre-taq2j)