### PR TITLE
fix(story): enforce settled-boundary :timeout-ms + 3 small tidy-ups (rf2-avjxi/ews47/dbq3t/r14tn)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -730,9 +730,17 @@ the existing framework drain and a flush-hook seam over it.
   returns `{:status :settled :boundary <required>}` on success, a
   `:cannot-run` refusal when the runner's `:provides` does not reach the
   required boundary (the event is **not** dispatched — fail-closed), or
-  `{:status :error …}` when a flush/dispatch throws. A flush timeout
-  reports `:cannot-run` or `:error` per policy (`flush-timeout-result`) —
-  **never a silent pass**.
+  `{:status :error …}` when a flush/dispatch throws. When the hooks declare
+  `:timeout-ms`, the flush phase is bounded: a wall-clock deadline
+  (`re-frame.interop/now-ms` + `:timeout-ms`) is stamped before the flush
+  loop and re-checked after each flush fn returns; an over-budget flush
+  phase stops and reports `:cannot-run` (reason `:flush-timeout`, via
+  `flush-timeout-result`) — **never a silent pass**. Because the flush fns
+  run synchronously, this bounds a sequence of slow flushes and detects an
+  over-budget flush once it returns; it does not preempt a single flush fn
+  that hangs forever (that is the caller's own thread/timeout box). With no
+  `:timeout-ms` the flush phase is unbounded (the headless default's only
+  flush is the synchronous `dispatch-sync*` drain, which cannot time out).
 
 The play runner's `[:dispatch …]` step (`re-frame.story.play.runner-events/
 exec-dispatch!`) routes through `dispatch-and-settle!`, so in headless it

--- a/tools/story/src/re_frame/story/late_bind.cljc
+++ b/tools/story/src/re_frame/story/late_bind.cljc
@@ -26,7 +26,16 @@
   - `:drop-assertion-accumulators` — assertions+play → frames. Called
                                      on frame teardown so per-frame
                                      accumulators evict their entries.
-                                     Signature: `(f frame-id) → nil`."
+                                     Signature: `(f frame-id) → nil`.
+
+  - `:render-host`                 — story (via the canonical
+                                     `install-render-host!`) → render. The
+                                     CLJS host's view-render seam, consumed
+                                     by `render-variant` to paint the active
+                                     view. Signature: `(f render-inputs) →
+                                     host-render-result`. Absent on the bare
+                                     JVM (no DOM / substrate), so
+                                     `render-variant` returns `:cannot-run`."
   )
 
 (defonce

--- a/tools/story/src/re_frame/story/play/settled_boundary.cljc
+++ b/tools/story/src/re_frame/story/play/settled_boundary.cljc
@@ -36,6 +36,19 @@
                    :dom           (fn [frame-id] ...)}  ; + act()/microtask
        :timeout-ms optional-number}                     ; richer-boundary bound
 
+  `:timeout-ms` is a wall-clock budget on the flush phase. `dispatch-and-settle!`
+  ENFORCES it: it stamps a deadline (`re-frame.interop/now-ms` +
+  `:timeout-ms`) before the flush loop and, after EACH flush fn returns,
+  checks whether the deadline has passed. An over-budget flush phase stops
+  the ladder and returns `flush-timeout-result` (a fail-closed `:cannot-run`
+  refusal, reason `:flush-timeout`) — NEVER a silent settled pass. Because
+  the flush fns run synchronously, this bounds a *sequence* of slow flushes
+  and detects an over-budget flush once it returns; it does NOT preempt a
+  single flush fn that hangs forever (that needs the caller's own
+  thread/timeout box — out of scope for this host-free contract ns). With
+  no `:timeout-ms` the flush phase is unbounded (the headless default, whose
+  only flush is the synchronous `dispatch-sync*` drain, cannot time out).
+
   `headless-flush-hooks` is the default the JVM / node-runtime headless
   runner uses: `:provides :headless`, `:dispatch!` and the `:headless`
   flush both routed through `re-frame.core/dispatch-sync*` so a queued
@@ -64,7 +77,8 @@
   flush fns are injected by adapter callers; this ns only *names* the
   ladder, *routes* a dispatch through the supplied hooks, and *refuses*
   when the supplied boundary is too weak."
-  (:require [re-frame.core :as rf]))
+  (:require [re-frame.core   :as rf]
+            [re-frame.interop :as interop]))
 
 ;; ---- the boundary ladder -------------------------------------------------
 
@@ -206,6 +220,25 @@
   (let [p (:provides hooks)]
     (if (boundary? p) p :headless)))
 
+;; ---- timeout helper ------------------------------------------------------
+
+(defn flush-timeout-result
+  "Build the result for a richer-boundary flush that exceeded its declared
+  maximum (the hooks' `:timeout-ms`). Per spec/017 a flush timeout reports
+  `:cannot-run` or `:error` per the caller's policy — NEVER a silent pass.
+  `policy` is `:cannot-run` (default) or `:error`. `dispatch-and-settle!`
+  calls this with the default `:cannot-run` policy when the flush phase
+  exceeds `:timeout-ms`."
+  ([required provided step] (flush-timeout-result required provided step :cannot-run))
+  ([required provided step policy]
+   (case policy
+     :error {:status :error
+             :error  (str "settled-boundary flush for " required
+                          " exceeded its declared maximum")
+             :step   step}
+     ;; default :cannot-run
+     (cannot-run-refusal required provided step :flush-timeout))))
+
 ;; ---- the dispatch-and-settle entry point ---------------------------------
 
 (defn dispatch-and-settle!
@@ -224,7 +257,9 @@
     the runner flushed up to (and including) the required boundary.
   - a `cannot-run-refusal` map — the runner's `:provides` does not reach
     `required`; the event is NOT dispatched (fail-closed, no partial /
-    under-flushed pass).
+    under-flushed pass). The same `:cannot-run` shape (reason
+    `:flush-timeout`, via `flush-timeout-result`) is returned when the
+    flush phase exceeds the hooks' `:timeout-ms` budget.
   - `{:status :error :error <message> :step …}` — a flush fn threw or the
     `:dispatch!` hook threw. NEVER a silent pass.
 
@@ -233,7 +268,16 @@
   provides `:dom` runs the `:headless`, `:cljs-reactive`, and `:dom`
   flushes in turn. A missing flush fn for a level the runner claims to
   provide is treated as a no-op for that level (the cheaper level still
-  drained the queue)."
+  drained the queue).
+
+  When `hooks` declares a `:timeout-ms`, the flush phase is bounded: a
+  deadline is stamped before the loop and re-checked after each flush fn
+  returns. An over-budget flush phase stops and returns
+  `flush-timeout-result` (`:cannot-run`, reason `:flush-timeout`) — the
+  event has already been dispatched, but the settle is refused rather than
+  falsely reported settled. The synchronous-flush caveat (a single hanging
+  flush fn is not preempted) is documented on the ns docstring's flush-hook
+  seam."
   ([frame-id event-vector hooks]
    (dispatch-and-settle! frame-id event-vector hooks :headless nil))
   ([frame-id event-vector hooks required]
@@ -246,36 +290,35 @@
        ;; needs a richer boundary than the runner provides is refused.
        (cannot-run-refusal required provided step)
        (try
-         (let [dispatch! (or (:dispatch! hooks) drain-sync!)
-               flushes   (:flush! hooks)]
+         (let [dispatch!  (or (:dispatch! hooks) drain-sync!)
+               flushes    (:flush! hooks)
+               timeout-ms (:timeout-ms hooks)
+               deadline   (when (number? timeout-ms)
+                            (+ (interop/now-ms) timeout-ms))
+               ;; The flush levels to run: every registered level up to and
+               ;; including `required`, in ladder order. The headless flush
+               ;; is folded into `:dispatch!` (`drain-sync!`), so its hook is
+               ;; a no-op; the richer flushes carry the adapter's reactive /
+               ;; DOM work.
+               levels     (take-while #(boundary>= required %) boundary-levels)]
            (dispatch! frame-id event-vector)
-           ;; Run each registered flush up to and including `required`,
-           ;; in ladder order. The headless flush is folded into
-           ;; `:dispatch!` (`drain-sync!`), so its hook is a no-op; the
-           ;; richer flushes carry the adapter's reactive / DOM work.
-           (doseq [level boundary-levels
-                   :while (boundary>= required level)]
-             (when-let [f (get flushes level)]
-               (f frame-id)))
-           {:status :settled :boundary required})
+           ;; Run each flush, re-checking the `:timeout-ms` deadline after
+           ;; each returns. An over-budget flush phase stops the ladder and
+           ;; refuses with a fail-closed `:flush-timeout` (`flush-timeout-result`)
+           ;; rather than reporting a settled pass it did not earn.
+           (loop [[level & more] levels]
+             (cond
+               (nil? level)
+               {:status :settled :boundary required}
+
+               (and deadline (> (interop/now-ms) deadline))
+               (flush-timeout-result required provided step)
+
+               :else
+               (do (when-let [f (get flushes level)]
+                     (f frame-id))
+                   (recur more)))))
          (catch #?(:clj Throwable :cljs :default) e
            {:status :error
             :error  #?(:clj (.getMessage ^Throwable e) :cljs (str e))
             :step   step}))))))
-
-;; ---- timeout helper ------------------------------------------------------
-
-(defn flush-timeout-result
-  "Build the result for a richer-boundary flush that exceeded its declared
-  maximum. Per spec/017 a flush timeout reports `:cannot-run` or `:error`
-  per the caller's policy — NEVER a silent pass. `policy` is
-  `:cannot-run` (default) or `:error`."
-  ([required provided step] (flush-timeout-result required provided step :cannot-run))
-  ([required provided step policy]
-   (case policy
-     :error {:status :error
-             :error  (str "settled-boundary flush for " required
-                          " exceeded its declared maximum")
-             :step   step}
-     ;; default :cannot-run
-     (cannot-run-refusal required provided step :flush-timeout))))

--- a/tools/story/src/re_frame/story/promotion.cljc
+++ b/tools/story/src/re_frame/story/promotion.cljc
@@ -274,8 +274,8 @@
 
   Returns the registered variant id on success (the value
   `reg-variant*` returns)."
-  [artifact {:keys [variant-id] :as opts}]
-  (let [variant-id (or variant-id (:variant/id opts))]
+  [artifact opts]
+  (let [variant-id (:variant/id opts)]
     (when (nil? variant-id)
       (throw (ex-info ":rf.error/story-promote-no-id"
                       {:rf.error/id :rf.error/story-promote-no-id

--- a/tools/story/test/re_frame/story/invariants_test.cljc
+++ b/tools/story/test/re_frame/story/invariants_test.cljc
@@ -200,10 +200,10 @@
        (binding [clojure.test/report (fn [m] (swap! reports conj m))]
          (f))
        :cljs
-       ;; cljs.test reports through the test-environment :report-counters
-       ;; / a dynamic var; rebind the report multimethod's sink via
-       ;; with-redefs on `cljs.test/report` is not portable, so we use the
-       ;; testing-context's report var binding.
+       ;; `cljs.test/report` is a multimethod (a `def`, not a `^:dynamic`
+       ;; var), so we swap its root via `with-redefs` for the dynamic
+       ;; extent of `f`. `do-report` resolves `report` at call time, so
+       ;; every report `f` emits routes to our sink and is captured here.
        (with-redefs [cljs.test/report (fn [m] (swap! reports conj m))]
          (f)))
     @reports))

--- a/tools/story/test/re_frame/story/play/settled_boundary_test.cljc
+++ b/tools/story/test/re_frame/story/play/settled_boundary_test.cljc
@@ -191,6 +191,61 @@
         (is (re-find #"flush boom" (:error res)))
         (is (not= :settled (:status res)) "a flush failure is never a settled pass")))))
 
+(deftest timeout-ms-bounds-flush-phase-and-refuses
+  (testing "a flush phase that exceeds the hooks' :timeout-ms stops the
+            ladder and returns a fail-closed :cannot-run/:flush-timeout
+            (never a settled pass) — the dispatch fired but the settle is
+            refused, and the over-budget flush level does NOT run"
+    (let [ran    (atom [])
+          hooks  {:provides   :dom
+                  ;; deadline is already past on entry (negative budget), so
+                  ;; the loop refuses before running ANY richer flush —
+                  ;; deterministic, no wall-clock sleep needed.
+                  :timeout-ms -1
+                  :dispatch!  (fn [frame-id evec]
+                                (boundary/drain-sync! frame-id evec))
+                  :flush!     {:headless      (fn [_] (swap! ran conj :headless))
+                               :cljs-reactive (fn [_] (swap! ran conj :reactive))
+                               :dom           (fn [_] (swap! ran conj :dom))}}]
+      (rf/reg-event-db :timeout/fired (fn [db _] (assoc db :fired true)))
+      (let [res (boundary/dispatch-and-settle! bf [:timeout/fired] hooks :dom [:click "b"])]
+        (is (= :cannot-run    (:status res)))
+        (is (= :flush-timeout (:reason res)))
+        (is (= :dom           (:required-boundary res)))
+        (is (= :dom           (:provided-boundary res)))
+        (is (= [:click "b"]   (:step res)))
+        (is (not= :settled (:status res)) "a flush timeout is never a settled pass")
+        (is (empty? @ran)
+            "the over-budget flush phase ran no flush fn (deadline already past)")
+        (is (true? (:fired (rf/get-frame-db bf)))
+            "the event was dispatched before the bounded flush phase refused")))))
+
+(deftest timeout-ms-generous-budget-settles-normally
+  (testing "a :timeout-ms larger than the flush phase lets settlement
+            complete normally (the knob bounds, it does not break the
+            happy path)"
+    (let [ran   (atom [])
+          hooks {:provides   :dom
+                 :timeout-ms 60000
+                 :dispatch!  (fn [frame-id evec]
+                               (boundary/drain-sync! frame-id evec))
+                 :flush!     {:cljs-reactive (fn [_] (swap! ran conj :reactive))
+                              :dom           (fn [_] (swap! ran conj :dom))}}]
+      (rf/reg-event-db :timeout/ok (fn [db _] (assoc db :ok true)))
+      (let [res (boundary/dispatch-and-settle! bf [:timeout/ok] hooks :dom [:click "b"])]
+        (is (= :settled (:status res)))
+        (is (= :dom     (:boundary res)))
+        (is (= [:reactive :dom] @ran) "all flushes ran under a generous budget")
+        (is (true? (:ok (rf/get-frame-db bf))))))))
+
+(deftest no-timeout-ms-is-unbounded
+  (testing "with no :timeout-ms the flush phase is unbounded — settlement
+            completes regardless of flush duration (the headless default)"
+    (rf/reg-event-db :noop (fn [db _] db))
+    (let [res (boundary/dispatch-and-settle!
+                bf [:noop] boundary/headless-flush-hooks :headless [:dispatch [:noop]])]
+      (is (= :settled (:status res))))))
+
 (deftest drain-sync-settles-synchronous-redispatch
   (testing "drain-sync! (the named headless boundary) is the framework
             dispatch-sync* drain — re-dispatched events settle before return"

--- a/tools/story/test/re_frame/story/promotion_test.cljc
+++ b/tools/story/test/re_frame/story/promotion_test.cljc
@@ -172,6 +172,20 @@
       (is (empty? (registrar/registrations :variant))
             "a no-id promotion registers nothing"))))
 
+(deftest promote-honours-only-namespaced-variant-id
+  (testing ":variant/id is the SOLE accepted key — the previously-undocumented
+            unqualified :variant-id spelling is NOT honoured (symmetric with
+            materialize-variant-plan + spec + the rest of the bridge)"
+    (let [art (sample-artifact)]
+      ;; An opts map carrying ONLY the unqualified :variant-id is treated as
+      ;; a no-id promotion: it throws and registers nothing.
+      (is (thrown-with-msg?
+            #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
+            #"story-promote-no-id"
+            (promotion/promote-run-artifact! art {:variant-id :story.counter/unqualified})))
+      (is (empty? (registrar/registrations :variant))
+          "the unqualified :variant-id registers nothing"))))
+
 (deftest promote-registers-the-named-variant
   (testing "the explicit named call DOES register a curated variant"
     (let [art (sample-artifact)


### PR DESCRIPTION
Tail of the small-misc DISJOINT cluster — four fixes across four free files, one PR.

## Fixes

### rf2-avjxi (P3, `settled_boundary.cljc`) — DECISION: ENFORCE
`:timeout-ms` / `flush-timeout-result` were declared in the flush-hooks map but `dispatch-and-settle!` never read or enforced them — a dead knob, with `flush-timeout-result` having zero production callers.

Chose **ENFORCE** over remove: a portable wall-clock deadline is available via `re-frame.interop/now-ms` (the same helper `assertions.cljc` already uses), so the knob can be made live rather than deleted. `dispatch-and-settle!` now stamps a deadline (`now-ms + :timeout-ms`) before the flush loop and re-checks it after each flush fn returns; an over-budget flush phase stops the ladder and returns `flush-timeout-result` — a fail-closed `:cannot-run` (reason `:flush-timeout`), never a silent settled pass.

**Honest caveat (documented on the ns docstring + spec/017):** because flush fns run synchronously, this bounds a *sequence* of slow flushes and detects an over-budget flush once it returns; it does NOT preempt a single flush fn that hangs forever (that is the caller's own thread/timeout box, out of scope for this host-free contract ns). With no `:timeout-ms` the flush phase is unbounded — the headless default's only flush is the synchronous `dispatch-sync*` drain, which cannot time out.

`flush-timeout-result` was moved above `dispatch-and-settle!` (it is now its caller). Three new tests: over-budget refusal (negative budget → `:cannot-run`/`:flush-timeout`, dispatch fired but no flush ran), generous-budget happy path, and unbounded-with-no-timeout.

### rf2-ews47 (P3, `promotion.cljc`)
`promote-run-artifact!` accepted an undocumented unqualified `:variant-id` key and fell back to `:variant/id` — asymmetric with `materialize-variant-plan` / spec / tests, which honour only `:variant/id`. Dropped the `:variant-id` destructure + fallback (pre-alpha, no shim) so `:variant/id` is the single key. New test asserts a bare `:variant-id` no longer registers (throws `story-promote-no-id`).

### rf2-dbq3t (P4, `invariants_test.cljc`) — doc-only
The `:cljs` branch of `with-captured-reports` carried a self-contradictory comment claiming `with-redefs` on `cljs.test/report` "is not portable" then using exactly that. Replaced with an accurate comment: `cljs.test/report` is a multimethod (`def`, not `^:dynamic`), `with-redefs` swaps its root for the dynamic extent, and `do-report` resolves `report` at call time so captures route to the sink.

### rf2-r14tn (P4, `late_bind.cljc`) — doc-only
Added the `:render-host` hook key (added by .24) to the registry docstring's "Hook keys" list: producer `story/install-render-host!` (the canonical install), consumer `render-variant`, signature `(render-inputs) → host-render-result`, absent on the bare JVM.

## Quality gates
- `tools/story` `clojure -M:test` — 1277 tests, 4117 assertions, **0 failures, 0 errors**
- `tools/story-mcp` `clojure -M:test` — 172 tests, 861 assertions, **0 failures, 0 errors**
- `tools/mcp-conformance` `npm run test:story` — **STORY-MCP MCP-CLIENT CONFORMANCE GREEN**
- `scripts/test-fast-pr.sh` — core JVM 795 tests / 0 failures; script-policy + script-helpers all green; CLJS node integration 4865 tests / 15925 assertions / **0 failures, 0 errors** (run directly after `npm install` in `implementation/`)

Refs rf2-avjxi, rf2-ews47, rf2-dbq3t, rf2-r14tn.