### PR TITLE
fix(story/assertions): trace-bus assertions read the epoch tape (SSOT) (rf2-q651r + 9sanv + ntrv0 + bmpn2 + e0rpy)

### DIFF
--- a/tools/story/src/re_frame/story/assertions.cljc
+++ b/tools/story/src/re_frame/story/assertions.cljc
@@ -16,6 +16,10 @@
   | `:rf.assert/no-warnings`       | `[]`                           | No `:warning` trace events since play start |
   | `:rf.assert/effect-emitted`    | `[fx-id (optional pred)]`      | fx-id emitted during play? |
 
+  A NET-NEW eighth canonical id — `:rf.assert/schema-error` (rf2-5x1wt.21)
+  — is *recognised* but is NOT one of the seven REGISTERED handlers: it is
+  tape-evaluated in `result.cljc`, never dispatched (see `canonical-assertion-ids`).
+
   ## Record, don't throw (per IMPL-SPEC §2.3)
 
   Each `:rf.assert/*` event is dispatched through the standard re-frame
@@ -35,9 +39,12 @@
 
   The seven canonical assertions register at Story boot via
   `install-canonical-assertions!`. Production CLJS builds (with
-  `re-frame.story.config/enabled?` false) skip the registrations —
-  any unknown assertion at run-time records a `:rf.assert/unknown`
-  pseudo-record rather than throwing.
+  `re-frame.story.config/enabled?` false) skip the registrations.
+  An unknown assertion id FAILS plan construction with
+  `:rf.error/story-unknown-assertion` (`assertion-id-known?` /
+  `known-assertion-ids`, rf2-5x1wt.18) — there is NO run-time
+  `:rf.assert/unknown` pseudo-record; an unrecognised id never reaches
+  a handler.
 
   Per the `downstream EPs consume foundation` rule each assertion is a
   regular re-frame event registered against `re-frame.core/reg-event-fx`
@@ -54,39 +61,177 @@
   - `passing?` — predicate on the result list: true iff every entry has
     `:passed? true` (used by Stage 5's `run-variant` test entry, and by
     consumer tests via the public `assertions-passing?`).
-  - `canonical-assertion-ids` — the set of registered event ids."
-  (:require [clojure.string              :as str]
-            [re-frame.core               :as rf]
-            [re-frame.elision            :as elision]
-            [re-frame.interop            :as interop]
-            [re-frame.subs               :as subs]
-            [re-frame.story.config       :as config]
-            [re-frame.story.predicates   :as pred]
-            [re-frame.story.registrar    :as registrar]
-            [re-frame.story.requirements :as requirements]
-            [malli.core                  :as malli]))
+  - `canonical-assertion-ids` — the recognised canonical assertion ids:
+    the seven REGISTERED `reg-event-fx` handlers PLUS the tape-evaluated
+    `:rf.assert/schema-error` (rf2-5x1wt.21), which plan construction
+    recognises but which is deliberately NEVER installed as a handler
+    (it is evaluated against the epoch tape in `result.cljc`, not
+    dispatched into the frame). So the set is eight ids, only seven of
+    which are registered."
+  (:require [clojure.string               :as str]
+            [re-frame.core                :as rf]
+            [re-frame.elision             :as elision]
+            [re-frame.interop             :as interop]
+            [re-frame.subs                :as subs]
+            [re-frame.story.config        :as config]
+            [re-frame.story.late-bind     :as late-bind]
+            [re-frame.story.play.evidence :as evidence]
+            [re-frame.story.predicates    :as pred]
+            [re-frame.story.registrar     :as registrar]
+            [re-frame.story.requirements  :as requirements]
+            [malli.core                   :as malli]))
 
 ;; ---------------------------------------------------------------------------
-;; Per-frame trace-bus accumulators (warnings + emitted fx + dispatched)
+;; Trace-bus facts for `:rf.assert/no-warnings` / `:rf.assert/effect-emitted`
+;; / `:rf.assert/dispatched?` — PROJECTED FROM THE EPOCH TAPE (the SSOT)
 ;;
-;; `:rf.assert/no-warnings` needs to know which warning-level trace
-;; events fired during the play sequence. `:rf.assert/effect-emitted`
-;; needs to know which fx-ids the cascade emitted. `:rf.assert/dispatched?`
-;; needs to know which event vectors fired. We expose one per-frame
-;; side-table keyed by frame-id that the play-runner clears at play
-;; start and the assertion handlers consult at evaluation time.
+;; These three assertions reason about three trace-bus facts:
 ;;
-;; This is NOT a new framework registry — it's a Story-internal atom
-;; (analogous to `re-frame.story.ui.trace-buffer/buffers`) that the
-;; runtime populates from the standard trace bus.
+;;   - `:rf.assert/no-warnings`   — which `:warning` trace events fired;
+;;   - `:rf.assert/effect-emitted` — which fx-ids the cascade emitted;
+;;   - `:rf.assert/dispatched?`   — which event vectors were dispatched.
 ;;
-;; Shape:
-;;   {frame-id {:warnings    [trace-event ...]
-;;              :emitted-fx  #{fx-id ...}
-;;              :dispatched  [event-vec ...]}}
+;; rf2-q651r — single source of truth. The framework RETAINS exactly these
+;; facts in the epoch tape (`re-frame.core/epoch-history`), and
+;; `re-frame.story.play.evidence` already PROJECTS them as the run-result
+;; `:warnings` / `:effects` evidence slots. Previously these three handlers
+;; read a SECOND, parallel per-frame accumulator (`trace-accumulators`),
+;; fed by a distinct trace listener in `re-frame.story.play` — a second
+;; capture path that could drift from the tape (different filtering),
+;; reintroducing the documented "false GREEN" the evidence boundary closed.
+;; Schema-error (rf2-5x1wt.21) and causal/cascade (rf2-5x1wt.31) assertions
+;; were already migrated to tape-evaluation in `result.cljc`; these three
+;; were the stragglers. They now read the SAME tape projection the
+;; run-result slots do, so an in-script `[:assert [:rf.assert/no-warnings]]`
+;; checkpoint cannot disagree with the run-result `:warnings` slot.
 ;;
-;; Writes are gated under `config/enabled?`; production builds leave
-;; the atom empty and the assertion handlers read empty defaults.
+;; The projections are PURE (tape data → fact), so the handlers stay pure
+;; data → data; the handler shell reads `rf/epoch-history` once and threads
+;; the projected facts in. Production builds (Story disabled) and hosts
+;; without the epoch artefact see an empty tape (the late-bound
+;; `epoch-history` facade degrades to `[]`), so the handlers read empty
+;; facts — exactly as the run-result evidence slots do.
+;;
+;; ## Privacy
+;;
+;; The retired play-listener default-suppressed `:sensitive? true` events
+;; (Spec 009 §Privacy) before they reached the accumulator. The tape
+;; projections preserve that posture for the only fact that carries a
+;; payload — dispatched event vectors: `dispatched-events` drops the
+;; `:trigger-event` of any epoch flagged `:rf.epoch/sensitive?` while the
+;; `:rf.privacy/show-sensitive?` flag is off, so a sensitive event vector
+;; never lands raw on an assertion record's `:actual`. Warning records
+;; carry only `:operation` / `:category` metadata (no payload), so the
+;; `:warnings` projection — which agrees with the run-result slot — counts
+;; them without a payload-leak risk.
+;; ---------------------------------------------------------------------------
+
+(defn- frame-tape
+  "The retained epoch tape for `frame-id` via the late-bound
+  `re-frame.core/epoch-history` facade (the SSOT the run-result evidence
+  slots read). Degrades to `[]` on a host without the epoch artefact
+  (production Story jars) — exactly what the run-result projection sees.
+  Tolerant: any read error returns `[]`."
+  [frame-id]
+  (try
+    (vec (rf/epoch-history frame-id))
+    (catch #?(:clj Throwable :cljs :default) _ [])))
+
+(defn dispatched-events
+  "Project the events dispatched against `frame-id` from its epoch tape —
+  the per-epoch `:trigger-event` (the cascade-top event each committed
+  epoch settled), in tape order. Pure-ish (the only read is the late-bound
+  tape). The SSOT for `:rf.assert/dispatched?` + the loaders'
+  `:loaders-complete-when` vector form.
+
+  Assertion events (`:rf.assert/*`) are excluded — an `[:assert …]`
+  checkpoint dispatches its wrapped atom, which commits an epoch, but a
+  verdict is not behaviour-under-test (mirrors the retired listener's
+  `assertion-event?` skip + `evidence/narrative`'s span-attribution rule).
+
+  Privacy (Spec 009 §Privacy): the `:trigger-event` of an epoch flagged
+  `:rf.epoch/sensitive?` is dropped while `:rf.privacy/show-sensitive?` is
+  off, so a sensitive event vector never reaches an assertion record's
+  `:actual`. With the flag on, sensitive trigger-events pass through."
+  [frame-id]
+  (let [show? (config/get-show-sensitive)]
+    (into []
+          (comp (remove (fn [{:keys [rf.epoch/sensitive?]}]
+                          (and sensitive? (not show?))))
+                (keep :trigger-event)
+                (remove pred/assertion-event?))
+          (frame-tape frame-id))))
+
+(defn- non-framework-fx?
+  "True iff `fx-id` is a user fx (not the ubiquitous framework `:db` / `:fx`
+  aggregators). Mirrors the retired listener's `framework-fx-id?` gate so
+  `:rf.assert/effect-emitted` reflects USER fx only (rf2-ee38b.3)."
+  [fx-id]
+  (not (contains? #{:db :fx} fx-id)))
+
+(defn emitted-fx
+  "Project the set of USER fx-ids emitted against `frame-id`. The SSOT for
+  `:rf.assert/effect-emitted`. Two sources, both tape-grounded:
+
+  1. The epoch tape's `:effects` rows (`evidence/effects`) — every fx the
+     cascade actually HANDLED (the run-result `:effects` slot reads the
+     same projection), excluding the framework `:db` / `:fx` aggregators.
+  2. The per-frame stub-call log (`re-frame.story.frames/stub-call-log`,
+     read via the `:stub-observed-fx-ids` late-bind hook) — a STUBBED fx
+     lands on the tape under its REWRITTEN stub id
+     (`:rf.story.fx-stub/<dec>+<fx>`), not its original id, so the
+     authoritative record of which ORIGINAL fx-ids a `force-fx-stub`
+     redirected is the stub log `re-frame.story.fx-stubs` already owns.
+     This is NOT a re-introduced parallel accumulator: it is the single
+     canonical source for stub-redirected fx, the one fact the epoch tape
+     cannot carry under the original id.
+
+  Pure-ish (the only reads are the late-bound tape + the stub-log hook).
+  Production builds without the epoch artefact / without fx-stubs see both
+  sources empty."
+  [frame-id]
+  (let [from-tape (into #{}
+                        (comp (keep :fx-id) (filter non-framework-fx?))
+                        (evidence/effects (frame-tape frame-id)))
+        from-stub (if-let [f (late-bind/get-fn :stub-observed-fx-ids)]
+                    (try (set (f frame-id))
+                         (catch #?(:clj Throwable :cljs :default) _ #{}))
+                    #{})]
+    (into from-tape from-stub)))
+
+(defn warnings
+  "Project the warning trace records emitted against `frame-id` from its
+  epoch tape (`evidence/warnings`) — the SAME projection the run-result
+  `:warnings` slot reads, so `:rf.assert/no-warnings` and the slot AGREE
+  (rf2-q651r). Pure-ish (the only read is the late-bound tape)."
+  [frame-id]
+  (evidence/warnings (frame-tape frame-id)))
+
+;; ---------------------------------------------------------------------------
+;; Per-frame trace side-table (privacy-gated) — NO LONGER THE EVIDENCE SOURCE
+;;
+;; rf2-q651r retired this atom AS THE EVIDENCE SOURCE for the three
+;; trace-bus assertions: they now project from the epoch tape (above), so
+;; there is no second evidence path that can drift into the documented
+;; "false GREEN". The atom is RETAINED — not removed — because three
+;; non-evidence consumers still drive it, and full removal would have to
+;; coordinate across lanes this change does not own:
+;;
+;;   1. `re-frame.story.ui.test_mode.stepper-state` (a separate UI lane)
+;;      calls `reset-trace-accumulators!` when it rewinds a stepped run;
+;;   2. the per-frame trace listener in `re-frame.story.play` is the
+;;      load-bearing PRIVACY-suppression seam (Spec 009 §Privacy) — it
+;;      default-drops `:sensitive? true` events and bumps the UI redaction
+;;      counter; its suppression behaviour is pinned by
+;;      `sensitive-trace-cljs-test` against this side-table;
+;;   3. the `force-fx-stub` tap (`re-frame.story.fx-stubs/tap-stub-event!`)
+;;      records redirected fx-ids here for dev-tool surfacing.
+;;
+;; So the atom is a privacy-gated DEV side-table, decoupled from the
+;; assertion verdict. It is keyed by frame-id and reset at play start.
+;; (Follow-up: fully fold this side-table into the tape + stub-log once the
+;; UI stepper-rewind lane can be touched in the same change — rf2-q651r
+;; note.)
 ;; ---------------------------------------------------------------------------
 
 (def ^:private empty-frame-accumulators
@@ -96,43 +241,48 @@
 
 (defonce
   ^{:doc "frame-id → {:warnings [...] :emitted-fx #{...} :dispatched [...]}.
-         The play-runner calls `reset-trace-accumulators!` at play start
-         and `drop-trace-accumulators!` at frame teardown."}
+         A privacy-gated DEV side-table (NOT the assertion evidence source
+         since rf2-q651r — the three trace-bus assertions project from the
+         epoch tape). The play-runner calls `reset-trace-accumulators!` at
+         play start and `drop-trace-accumulators!` at frame teardown."}
   trace-accumulators
   (atom {}))
 
 (defn reset-trace-accumulators!
-  "Clear every per-frame trace-bus accumulator for `frame-id`. The
-  play-runner calls this at play start. Production callers (without
-  config/enabled?) no-op."
+  "Clear every per-frame trace side-table entry for `frame-id`. The
+  play-runner + the UI stepper-rewind call this at play start. Production
+  callers (without config/enabled?) no-op."
   [frame-id]
   (when config/enabled?
     (swap! trace-accumulators assoc frame-id empty-frame-accumulators))
   nil)
 
 (defn drop-trace-accumulators!
-  "Discard the per-frame accumulator entry. Called from frame teardown
-  so destroyed variants don't leak memory."
+  "Discard the per-frame side-table entry. Called from frame teardown so
+  destroyed variants don't leak memory."
   [frame-id]
   (swap! trace-accumulators dissoc frame-id)
   nil)
 
 (defn record-warning!
-  "Append a warning trace event to `frame-id`'s accumulator."
+  "Append a warning trace event to `frame-id`'s side-table (privacy seam +
+  dev surfacing; NOT the `:rf.assert/no-warnings` evidence source)."
   [frame-id ev]
   (when config/enabled?
     (swap! trace-accumulators update-in [frame-id :warnings] (fnil conj []) ev))
   nil)
 
 (defn record-emitted-fx!
-  "Add `fx-id` to `frame-id`'s emitted-fx accumulator."
+  "Add `fx-id` to `frame-id`'s side-table emitted-fx set (dev surfacing;
+  NOT the `:rf.assert/effect-emitted` evidence source)."
   [frame-id fx-id]
   (when config/enabled?
     (swap! trace-accumulators update-in [frame-id :emitted-fx] (fnil conj #{}) fx-id))
   nil)
 
 (defn record-dispatched!
-  "Append `event-vec` to `frame-id`'s dispatched-events accumulator."
+  "Append `event-vec` to `frame-id`'s side-table dispatched vector (dev
+  surfacing; NOT the `:rf.assert/dispatched?` evidence source)."
   [frame-id event-vec]
   (when config/enabled?
     (swap! trace-accumulators update-in [frame-id :dispatched] (fnil conj []) event-vec))
@@ -431,13 +581,14 @@
                             " but got " (pr-str actual)))}))
 
 (defn- evaluate-dispatched?
-  [frame-id [needle]]
-  (let [observed (frame-dispatched frame-id)
-        matched  (some #(event-matches? % needle) observed)
-        passed?  (boolean matched)]
+  "`observed` is the tape-projected dispatched-events vector
+  (`dispatched-events`). Pure data → data."
+  [observed [needle]]
+  (let [matched (some #(event-matches? % needle) observed)
+        passed? (boolean matched)]
     {:passed?  passed?
      :expected needle
-     :actual   observed
+     :actual   (vec observed)
      :reason   (if passed?
                  "matching event was dispatched during play"
                  (str "no dispatched event matched "
@@ -464,22 +615,26 @@
                         " but state is " (pr-str actual)))}))
 
 (defn- evaluate-no-warnings
-  [frame-id _payload]
-  (let [warnings (frame-warnings frame-id)
-        passed?  (empty? warnings)]
+  "`warning-records` is the tape-projected warning vector (`warnings`,
+  i.e. `evidence/warnings` over the frame's epoch tape — the SAME
+  projection the run-result `:warnings` slot reads). Pure data → data."
+  [warning-records _payload]
+  (let [passed? (empty? warning-records)]
     {:passed?  passed?
      :expected :no-warnings
-     :actual   (mapv :operation warnings)
-     :count    (count warnings)
+     :actual   (mapv :operation warning-records)
+     :count    (count warning-records)
      :reason   (if passed?
                  "no warning-level trace events captured during play"
-                 (str (count warnings)
+                 (str (count warning-records)
                       " warning trace event(s) captured during play"))}))
 
 (defn- evaluate-effect-emitted
-  [frame-id [fx-id pred]]
-  (let [emitted   (frame-fx frame-id)
-        present?  (contains? emitted fx-id)
+  "`emitted` is the tape-projected USER fx-id set (`emitted-fx`: the epoch
+  tape's `:effects` rows ∪ the stub-call log's redirected fx-ids). Pure
+  data → data."
+  [emitted [fx-id pred]]
+  (let [present?  (contains? emitted fx-id)
         passed?   (boolean (and present? (or (nil? pred)
                                              (try (pred fx-id) (catch #?(:clj Throwable :cljs :default) _ false)))))]
     {:passed?  passed?
@@ -928,14 +1083,21 @@
 
 (defn- handler-for-evaluator
   "Build the `reg-event-fx` handler body for `assertion-id` whose
-  evaluator returns the record extras given `(db, payload)` (or
-  `(frame-id, payload)` for trace-bus-driven assertions).
+  evaluator returns the record extras.
 
   The handler reads `:db` directly from cofx — which the router has
   populated with the variant frame's app-db (spec/002 §Routing initial
   context) — and returns `{:db (update db :rf.story/assertions conj record)}`.
   This is the record-don't-throw contract per IMPL-SPEC §2.3: the
-  assertion's failure mode is a `:db` write, not an exception."
+  assertion's failure mode is a `:db` write, not an exception.
+
+  The three trace-bus-driven assertions (`:dispatched?` / `:no-warnings`
+  / `:effect-emitted`) project their fact from the frame's EPOCH TAPE (the
+  SSOT — `dispatched-events` / `warnings` / `emitted-fx`), the SAME source
+  the run-result evidence slots read (rf2-q651r). The prior committed
+  epochs (the play steps before this assertion's own dispatch) are already
+  on the tape when this handler runs; the assertion's own epoch has not yet
+  settled — and assertion events are excluded from the projection anyway."
   [assertion-id evaluator-kind]
   (fn [{:keys [db] :as cofx} event-vec]
     (let [start-ms     (interop/now-ms)
@@ -946,10 +1108,10 @@
                          :path-equals     (evaluate-path-equals     frame-id db payload)
                          :path-matches    (evaluate-path-matches    frame-id db payload)
                          :sub-equals      (evaluate-sub-equals      frame-id db payload)
-                         :dispatched?     (evaluate-dispatched?     frame-id payload)
+                         :dispatched?     (evaluate-dispatched?     (dispatched-events frame-id) payload)
                          :state-is        (evaluate-state-is        db payload)
-                         :no-warnings     (evaluate-no-warnings     frame-id payload)
-                         :effect-emitted  (evaluate-effect-emitted  frame-id payload))
+                         :no-warnings     (evaluate-no-warnings     (warnings frame-id) payload)
+                         :effect-emitted  (evaluate-effect-emitted  (emitted-fx frame-id) payload))
           elapsed-ms   (- (interop/now-ms) start-ms)
           record       (assertion-record assertion-id payload
                                          (:passed? extras)

--- a/tools/story/src/re_frame/story/canonical.cljc
+++ b/tools/story/src/re_frame/story/canonical.cljc
@@ -42,6 +42,13 @@
   `re-frame.story.late-bind` (mirroring the framework's pattern)."
   []
   (late-bind/set-fn! :tap-stub-event fx-stubs/tap-stub-event!)
+  ;; rf2-q651r — `:rf.assert/effect-emitted` projects from the epoch tape,
+  ;; but a STUBBED fx lands on the tape under its REWRITTEN stub id, not its
+  ;; original id. The authoritative record of which ORIGINAL fx-ids a
+  ;; `force-fx-stub` redirected is the stub-call log `fx-stubs` owns; the
+  ;; assertions module reads it via this hook (it cannot `:require`
+  ;; fx-stubs / frames without a cycle).
+  (late-bind/set-fn! :stub-observed-fx-ids fx-stubs/observed-fx-ids)
   (late-bind/set-fn! :drop-assertion-accumulators
     (fn [frame-id]
       (assertions/drop-trace-accumulators! frame-id)

--- a/tools/story/src/re_frame/story/fx_stubs.cljc
+++ b/tools/story/src/re_frame/story/fx_stubs.cljc
@@ -155,24 +155,29 @@
     (set (keep :fx-id entries))))
 
 ;; ---------------------------------------------------------------------------
-;; Wire the stub-event log into the assertion accumulator
+;; Wire the stub-event log into the assertion trace side-table
 ;;
-;; The Stage 3 `frames/ensure-stub-event!` registers an event-fx under
-;; `:rf.story.fx-stub/<decorator-id>` that appends to the log. Stage 5
-;; needs that event to ALSO record into the assertion module's
-;; per-frame `:emitted-fx` slot so `:rf.assert/effect-emitted` works.
+;; The Stage 3 `frames/ensure-stub-event!` registers an fx handler under
+;; `:rf.story.fx-stub/<decorator-id>` that appends to the per-frame
+;; stub-call log + calls `tap-stub-event!`.
 ;;
-;; Rather than re-register a different event shape, we expose a
-;; `tap-stub-event!` helper the frames runtime can call from inside
-;; the stub event's :db handler. The actual call site is in
-;; `re-frame.story.frames/ensure-stub-event!` (Stage 3) — Stage 5
-;; updates that function to call `tap-stub-event!`.
+;; rf2-q651r — `:rf.assert/effect-emitted` now projects from the epoch
+;; tape, but a STUBBED fx lands on the tape under its REWRITTEN stub id,
+;; not its original id. So the assertion's emitted-fx SSOT unions the tape
+;; effects with `observed-fx-ids` (read from the stub-call log, the
+;; authoritative record of which ORIGINAL fx-ids were redirected — see the
+;; `:stub-observed-fx-ids` late-bind hook). `tap-stub-event!` no longer
+;; feeds the effect-emitted evidence; it remains only for the dev-surface
+;; side-table mirror.
 ;; ---------------------------------------------------------------------------
 
 (defn tap-stub-event!
-  "Record (via the assertion module) that `fx-id` fired against
-  `frame-id`. The frames runtime's `ensure-stub-event!` calls this
-  when the stub event handles a redirected fx call."
+  "Mirror that `fx-id` fired against `frame-id` into the assertion module's
+  trace side-table (dev surfacing). The frames runtime's
+  `ensure-stub-event!` calls this when the stub event handles a redirected
+  fx call. NOTE (rf2-q651r): this is NOT the `:rf.assert/effect-emitted`
+  evidence source — that projects from the epoch tape ∪ the stub-call log
+  (`observed-fx-ids`)."
   [frame-id fx-id]
   (assertions/record-emitted-fx! frame-id fx-id)
   nil)

--- a/tools/story/src/re_frame/story/late_bind.cljc
+++ b/tools/story/src/re_frame/story/late_bind.cljc
@@ -19,9 +19,21 @@
   - `:tap-stub-event`              — fx-stubs → frames. Called on
                                      every stub-event firing so the
                                      assertion module's per-frame
-                                     emitted-fx accumulator records
+                                     emitted-fx side-table records
                                      the call. Signature: `(f frame-id
                                      fx-id) → nil`.
+
+  - `:stub-observed-fx-ids`        — fx-stubs → assertions. Returns the
+                                     set of ORIGINAL fx-ids a frame's
+                                     `force-fx-stub` decorators redirected
+                                     (read from the stub-call log). The
+                                     assertions module unions it with the
+                                     epoch tape's effects for
+                                     `:rf.assert/effect-emitted` (rf2-q651r
+                                     — a stubbed fx lands on the tape under
+                                     its rewritten stub id, not its
+                                     original). Signature: `(f frame-id) →
+                                     #{fx-id …}`.
 
   - `:drop-assertion-accumulators` — assertions+play → frames. Called
                                      on frame teardown so per-frame

--- a/tools/story/src/re_frame/story/loaders.cljc
+++ b/tools/story/src/re_frame/story/loaders.cljc
@@ -376,19 +376,21 @@
   (keyword? pred))
 
 (defn- dispatched-events-set
-  "Read the dispatched-events set for `frame-id`."
+  "Read the dispatched-events set for `frame-id` from the epoch tape (the
+  SSOT — `assertions/dispatched-events` projects each committed epoch's
+  `:trigger-event`). rf2-q651r migrated this off the retired
+  `trace-accumulators` parallel path onto the SAME tape projection the
+  run-result evidence + `:rf.assert/dispatched?` read."
   [frame-id]
   (try
-    (set (assertions/frame-dispatched frame-id))
+    (set (assertions/dispatched-events frame-id))
     (catch #?(:clj Throwable :cljs :default) _ #{})))
 
 (defn- vector-of-events-satisfied?
   "Per IMPL-SPEC §2.4 — a vector of event vectors form is interpreted
   as 'loaders complete when ALL listed events have fired against the
-  variant's frame'. We consult the assertions module's per-frame
-  dispatched-events accumulator (populated by the play-runner's trace
-  listener and the runtime's own phase-1/2 trace listener — Stage 5
-  reaches across)."
+  variant's frame'. We consult the epoch-tape dispatched-events projection
+  (`dispatched-events-set`, the SSOT since rf2-q651r)."
   [frame-id events-required]
   (let [observed (or (dispatched-events-set frame-id) #{})]
     (every? (fn [needle] (contains? observed needle)) events-required)))
@@ -408,9 +410,9 @@
     Handlers set this to `true` when their custom condition is met.
   - a vector of event vectors — `[[:fixture/loaded] [:auth/ready]]`.
     Interpreted as 'loaders complete when ALL listed events have fired
-    against the variant's frame.' The runtime checks the assertions
-    module's dispatched-events accumulator (which Story populates from
-    the trace bus).
+    against the variant's frame.' The runtime checks the epoch-tape
+    dispatched-events projection (`assertions/dispatched-events`, the
+    SSOT since rf2-q651r — the SAME tape the run-result evidence reads).
 
   Stage 5 (rf2-h8et)."
   [frame-id variant-body]

--- a/tools/story/src/re_frame/story/play.cljc
+++ b/tools/story/src/re_frame/story/play.cljc
@@ -4,11 +4,19 @@
   rf2-0wrud (2026-05-20): the variant body's legacy `:play`
   event-vector slot was REMOVED. `:play-script` is the canonical AND
   ONLY phase-4 surface. This module retains the per-frame trace
-  listener (which feeds the assertion accumulators consumed by
-  `:rf.assert/dispatched?` / `:rf.assert/effect-emitted` /
-  `:rf.assert/no-warnings`) and the step-by-step play-stepper helpers.
-  The rich-DSL execution itself lives in
-  `re-frame.story.play.runner-events`.
+  listener and the step-by-step play-stepper helpers. The rich-DSL
+  execution itself lives in `re-frame.story.play.runner-events`.
+
+  rf2-q651r: `:rf.assert/dispatched?` / `:rf.assert/effect-emitted` /
+  `:rf.assert/no-warnings` no longer read the trace side-table this
+  listener feeds — they PROJECT their fact from the epoch tape (the
+  SSOT, `re-frame.story.assertions/dispatched-events` / `warnings` /
+  `emitted-fx`), the same source the run-result evidence slots read. The
+  listener is retained because it is the load-bearing PRIVACY-suppression
+  seam (Spec 009 §Privacy — default-dropping `:sensitive?` events + the
+  UI redaction counter) and the synchronous handler-exception capture
+  (`pending-exceptions`). The `trace-accumulators` side-table it still
+  writes is a privacy-gated DEV surface, decoupled from the verdict.
 
   ## What this module does
 
@@ -21,26 +29,22 @@
   §2.3 the assertion never throws; the play sequence runs to completion
   regardless of which assertions fail.
 
-  ## Trace-bus accumulators
-
-  Per the IMPL-SPEC §5.1 assertion list shape, three assertions need
-  per-frame trace-bus knowledge:
-
-  - `:rf.assert/no-warnings`   — was any `:warning` trace event emitted?
-  - `:rf.assert/effect-emitted` — was a given fx-id emitted?
-  - `:rf.assert/dispatched?`   — was a given event dispatched?
+  ## Trace-bus side-table (privacy seam + dev surface)
 
   We register a per-frame trace listener at the start of the play
-  sequence that, via the assertion module's `trace-accumulators` atom:
+  sequence. Its two LOAD-BEARING jobs:
 
-  - records `:warning` and `:error` `:op-type` events into the
-    frame's `:warnings` slot,
-  - records every `:rf.event/dispatched` event vector into the
-    frame's `:dispatched` slot,
-  - records every fx call (operations under `:rf.fx/do-fx` /
-    `:rf.fx/handled` op-type `:rf.fx`) into the frame's `:emitted-fx` slot.
+  - PRIVACY (Spec 009 §Privacy): default-drop `:sensitive? true` events
+    and bump the UI redaction counter (`config/note-suppressed!`);
+  - synchronous handler-exception capture into `pending-exceptions`
+    (drained into the assertions list between dispatches).
 
-  The accumulators clear at play-start and live until frame teardown
+  It ALSO mirrors `:warning` / `:rf.event/dispatched` / fx events into
+  the assertion module's `trace-accumulators` side-table for dev-tool
+  surfacing. rf2-q651r — that side-table is NO LONGER the evidence source
+  for `:rf.assert/no-warnings` / `:rf.assert/effect-emitted` /
+  `:rf.assert/dispatched?`: those project from the epoch tape (the SSOT).
+  The side-table clears at play-start and lives until frame teardown
   (per `assertions/drop-trace-accumulators!`).
 
   ## Async surface

--- a/tools/story/test/re_frame/story_assertions_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_assertions_cljs_test.cljs
@@ -195,14 +195,17 @@
 ;; optional predicate rejects it, the evaluator must record :passed?
 ;; false with the pred-reject reason (and a thrown predicate is treated
 ;; as a rejection, never propagated).
+;;
+;; rf2-q651r — the evaluator is now a pure fn: its first arg is the
+;; tape-projected emitted-fx SET (`assertions/emitted-fx`), not a frame-id.
+;; We pass the set directly (the realistic shape: the fx WAS emitted).
 
 (def ^:private evaluate-effect-emitted @#'assertions/evaluate-effect-emitted)
 
 (deftest cljs-evaluate-effect-emitted-pred-rejects-present-fx
   (testing "fx present but optional predicate returns false → fail with
             the pred-reject reason"
-    (assertions/record-emitted-fx! :rf/default :http)
-    (let [out (evaluate-effect-emitted :rf/default [:http (constantly false)])]
+    (let [out (evaluate-effect-emitted #{:http} [:http (constantly false)])]
       (is (false? (:passed? out)))
       (is (contains? (:actual out) :http)
           ":actual still reports the emitted-fx set (the fx WAS present)")
@@ -211,16 +214,14 @@
 (deftest cljs-evaluate-effect-emitted-pred-accepts-present-fx
   (testing "fx present and predicate accepts → pass (the positive arm of
             the same branch, for contrast)"
-    (assertions/record-emitted-fx! :rf/default :http)
-    (let [out (evaluate-effect-emitted :rf/default [:http (constantly true)])]
+    (let [out (evaluate-effect-emitted #{:http} [:http (constantly true)])]
       (is (true? (:passed? out)))
       (is (re-find #"emitted during play" (:reason out))))))
 
 (deftest cljs-evaluate-effect-emitted-pred-throws-is-rejection
   (testing "a predicate that throws is swallowed and treated as a
             rejection — never propagates"
-    (assertions/record-emitted-fx! :rf/default :http)
-    (let [out (evaluate-effect-emitted :rf/default
+    (let [out (evaluate-effect-emitted #{:http}
                                        [:http (fn [_] (throw (ex-info "x" {})))])]
       (is (false? (:passed? out))
           "thrown predicate → not passed, no exception escapes"))))

--- a/tools/story/test/re_frame/story_assertions_test.clj
+++ b/tools/story/test/re_frame/story_assertions_test.clj
@@ -18,6 +18,14 @@
   - `assertions-passing?` predicate.
   - The canonical seven register at boot."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            ;; rf2-q651r — the three trace-bus assertions + the q651r
+            ;; regression below project from the epoch tape (the SSOT).
+            ;; Requiring the epoch artefact installs its late-bind hooks so
+            ;; `rf/epoch-history` records a live tape under `clojure -M:test`
+            ;; (the dep rides the shared `:test` alias). Without this the
+            ;; facade degrades to `[]` and the regression has no tape to
+            ;; read.
+            [re-frame.epoch            :as epoch]
             [re-frame.core             :as rf]
             [re-frame.frame            :as frame]
             [re-frame.machines         :as machines]
@@ -43,6 +51,10 @@
   (config/set-global-args! {})
   ;; Clear per-frame assertion accumulators between tests.
   (reset! assertions/trace-accumulators {})
+  ;; rf2-q651r — clear the epoch tape + listeners between tests so the
+  ;; tape-projected assertions read only their own freshly-captured tape.
+  (epoch/clear-history!)
+  (epoch/clear-epoch-listeners!)
   (story/install-canonical-vocabulary!)
   (frame/ensure-default-frame!)
   (test-fn))
@@ -402,3 +414,175 @@
       (is (= a (:atom exp)))
       (is (= {:where :event :event :x} (:spec exp)))
       (is (= [:event :x] (:selector exp))))))
+
+;; ===========================================================================
+;; evaluate-no-warnings — the FAIL branch (rf2-bmpn2)
+;;
+;; Of the seven canonical evaluators, no-warnings' FAILING branch (warnings
+;; present) was the only one untested at any layer: the JVM
+;; `no-warnings-pass-when-silent` covers only the empty/pass path, and the
+;; evidence/result projection tests exercise the :warnings SLOT but never
+;; the evaluator's :count / :actual / reason projection. The evaluator is
+;; now a pure fn over the tape-projected warning records (rf2-q651r), so we
+;; reach the fail branch directly via the established var-quote seam.
+;; ===========================================================================
+
+(def ^:private evaluate-no-warnings @#'assertions/evaluate-no-warnings)
+
+(deftest evaluate-no-warnings-fail-branch
+  (testing "warnings present → :passed? false, with :count / :actual / reason"
+    ;; Two projected warning records (the shape `evidence/warnings` yields:
+    ;; `{:operation … :category … :epoch-id … :trace-id …}`).
+    (let [warning-records [{:operation :rf.warning/slow-sub :category :perf
+                            :epoch-id 1 :trace-id 10}
+                           {:operation :rf.warning/deprecated :category :api
+                            :epoch-id 2 :trace-id 20}]
+          out (evaluate-no-warnings warning-records [])]
+      (is (false? (:passed? out))
+          "the empty? test inverts: warnings present → fail")
+      (is (= 2 (:count out))
+          ":count projects the number of warning records")
+      (is (= [:rf.warning/slow-sub :rf.warning/deprecated] (:actual out))
+          ":actual is the (mapv :operation warnings) projection — the ops only")
+      (is (re-find #"2 warning" (:reason out))
+          ":reason names the count"))))
+
+(deftest evaluate-no-warnings-pass-branch-pure
+  (testing "no warnings → :passed? true, :count 0, empty :actual (the pure pass arm)"
+    (let [out (evaluate-no-warnings [] [])]
+      (is (true? (:passed? out)))
+      (is (= 0 (:count out)))
+      (is (= [] (:actual out)))
+      (is (re-find #"no warning" (:reason out))))))
+
+;; ===========================================================================
+;; Causal pure-fn gaps — causal-bounds + causal-effect-surface (rf2-e0rpy)
+;;
+;; These pure projection fns back the rf2-5x1wt.31 causal assertions and
+;; had NO direct unit test — only indirect result_test coverage that never
+;; reached three branches: causal-bounds :exactly, causal-bounds :min over
+;; :caused, and causal-effect-surface :sub-over-:view precedence.
+;; ===========================================================================
+
+(deftest causal-bounds-exactly-shorthand
+  (testing ":exactly pins BOTH bounds to n, regardless of the per-id default"
+    (is (= {:min 2 :max 2}
+           (assertions/causal-bounds :rf.assert/caused {:exactly 2}))
+        ":exactly on :caused pins min=max=2 (overriding the {:min 1} default)")
+    (is (= {:min 0 :max 0}
+           (assertions/causal-bounds :rf.assert/no-cascade-rerender {:exactly 0}))
+        ":exactly 0 on :no-cascade-rerender pins both to 0")
+    (is (= {:min 3 :max 3}
+           (assertions/causal-bounds :rf.assert/no-cascade-rerender {:exactly 3}))
+        ":exactly overrides the no-cascade default {:min 0 :max 0}")))
+
+(deftest causal-bounds-min-override-on-caused
+  (testing ":min override on :rf.assert/caused — 'caused at least n times'"
+    (is (= {:min 3}
+           (assertions/causal-bounds :rf.assert/caused {:min 3}))
+        ":min 3 overrides the default {:min 1}; :max stays absent (unbounded)")
+    (is (= {:min 1}
+           (assertions/causal-bounds :rf.assert/caused {}))
+        "default for :caused is {:min 1} (the contrast — no override)")
+    (is (= {:min 2 :max 5}
+           (assertions/causal-bounds :rf.assert/caused {:min 2 :max 5}))
+        "both :min and :max may override on :caused")))
+
+(deftest causal-effect-surface-sub-over-view-precedence
+  (testing ":sub takes precedence over :view when BOTH are present"
+    (is (= [:sub :a]
+           (assertions/causal-effect-surface {:sub :a :view :b}))
+        "a spec naming both measures the sub recompute (sub wins)")
+    (is (= [:sub :a]   (assertions/causal-effect-surface {:sub :a})))
+    (is (= [:view :b]  (assertions/causal-effect-surface {:view :b})))
+    (is (= [:any]      (assertions/causal-effect-surface {}))
+        "neither :sub nor :view → the cause's total recompute+render count")))
+
+;; ===========================================================================
+;; rf2-q651r — SSOT regression: an in-script [:assert [:rf.assert/no-warnings]]
+;; AGREES with the run-result :warnings slot (no atom/tape divergence).
+;;
+;; PRE-fix the three trace-bus assertions read the `trace-accumulators`
+;; atom — a SECOND capture path fed by the play listener, which routed
+;; `:op-type :error` events (e.g. :rf.error/no-such-handler) into the
+;; warnings accumulator. So a play that dispatched an unregistered event
+;; recorded a "warning" in the atom (the in-script [:no-warnings] FAILED)
+;; while the run-result :warnings slot — projected from the tape, keyed on
+;; `:op-type :warning` — stayed EMPTY (the slot said pass). The atom and the
+;; slot DISAGREED. POST-fix both read the tape projection, so they AGREE.
+;; ===========================================================================
+
+(deftest no-warnings-agrees-with-warnings-slot-on-error-only-run
+  (testing "an error-only run: the in-script [:no-warnings] verdict matches the
+            tape-projected :warnings slot (the SSOT — no atom divergence)"
+    ;; Dispatching an unregistered event emits `:op-type :error`
+    ;; (:rf.error/no-such-handler), NOT `:op-type :warning`. The tape's
+    ;; :warnings projection (and therefore the run-result slot) stays empty;
+    ;; the in-script no-warnings assertion reads the SAME projection.
+    (story/reg-variant :story.ssot/error-only
+      {:events []
+       :play-script [[:dispatch-sync [:no/such-handler]]
+                     [:dispatch-sync [:rf.assert/no-warnings]]]})
+    (let [r        (async/deref-blocking
+                     (story/run-variant :story.ssot/error-only) 5000)
+          no-warn  (->> (:assertions r)
+                        (filter #(= :rf.assert/no-warnings (:assertion %)))
+                        last)]
+      (is (zero? (count (:warnings r)))
+          "the run-result :warnings slot is empty — an :error op is not a :warning")
+      (is (true? (:passed? no-warn))
+          "the in-script [:no-warnings] PASSES — it reads the same tape projection")
+      (is (= (count (:warnings r)) (:count no-warn))
+          "the assertion :count AGREES with the run-result :warnings slot count
+           — one SSOT, no atom/tape divergence"))
+    (story/destroy-variant! :story.ssot/error-only)))
+
+(deftest dispatched?-projects-from-tape-trigger-events
+  (testing ":rf.assert/dispatched? reads the epoch-tape :trigger-event
+            projection (the SSOT), matching both a literal vector and a
+            bare keyword head — including a re-dispatched (nested) event"
+    (rf/reg-event-fx :ssot/outer (fn [_ _] {:fx [[:dispatch [:ssot/inner 42]]]}))
+    (rf/reg-event-db :ssot/inner (fn [db [_ n]] (assoc db :inner n)))
+    (story/reg-variant :story.ssot/dispatched
+      {:events []
+       :play-script [[:dispatch-sync [:ssot/outer]]
+                     [:dispatch-sync [:rf.assert/dispatched? [:ssot/inner 42]]]
+                     [:dispatch-sync [:rf.assert/dispatched? :ssot/inner]]
+                     [:dispatch-sync [:rf.assert/dispatched? [:never/fired]]]]})
+    (let [r       (async/deref-blocking
+                    (story/run-variant :story.ssot/dispatched) 5000)
+          by-need (->> (:assertions r)
+                       (filter #(= :rf.assert/dispatched? (:assertion %)))
+                       (map (juxt :expected :passed?))
+                       (into {}))]
+      (is (true?  (get by-need [:ssot/inner 42]))
+          "the re-dispatched event's trigger-event epoch is on the tape (literal match)")
+      (is (true?  (get by-need :ssot/inner))
+          "a bare keyword needle matches the trigger-event's head id")
+      (is (false? (get by-need [:never/fired]))
+          "an event never dispatched does not appear on the tape → fail"))
+    (story/destroy-variant! :story.ssot/dispatched)))
+
+(deftest effect-emitted-projects-from-tape-effects
+  (testing ":rf.assert/effect-emitted reads the epoch-tape :effects projection
+            (the SSOT) for a real (non-stubbed) user fx"
+    (rf/reg-fx :ssot.fx/real {:platforms #{:client :server}} (fn [_ _] nil))
+    (rf/reg-event-fx :ssot/emit-real (fn [_ _] {:fx [[:ssot.fx/real {:url "x"}]]}))
+    (story/reg-variant :story.ssot/effect
+      {:events []
+       :play-script [[:dispatch-sync [:ssot/emit-real]]
+                     [:dispatch-sync [:rf.assert/effect-emitted :ssot.fx/real]]
+                     [:dispatch-sync [:rf.assert/effect-emitted :ssot.fx/never]]]})
+    (let [r       (async/deref-blocking
+                    (story/run-variant :story.ssot/effect) 5000)
+          by-need (->> (:assertions r)
+                       (filter #(= :rf.assert/effect-emitted (:assertion %)))
+                       (map (juxt :expected :passed?))
+                       (into {}))]
+      (is (some #(= :ssot.fx/real (:fx-id %)) (:effects r))
+          "the user fx is on the run-result :effects slot (the tape projection)")
+      (is (true?  (get by-need :ssot.fx/real))
+          "effect-emitted sees the fx via the SAME tape :effects projection")
+      (is (false? (get by-need :ssot.fx/never))
+          "an fx never emitted → fail"))
+    (story/destroy-variant! :story.ssot/effect)))

--- a/tools/story/test/re_frame/story_play_test.clj
+++ b/tools/story/test/re_frame/story_play_test.clj
@@ -325,36 +325,33 @@
     (story/destroy-variant! :story.v2g9/loader-vector)))
 
 (deftest loaders-complete-when-vector-without-listener-stalls
-  ;; rf2-v2g9 — negative companion to the fix. We simulate the pre-fix
-  ;; behaviour by clearing the listener-fed accumulator between the
-  ;; loader dispatch and the predicate evaluation, then re-running the
-  ;; predicate directly. With an empty accumulator the vector form is
-  ;; false — which is the bug the fix prevents in the live pipeline.
-  (testing "vector form with an empty accumulator (pre-fix simulation) returns false"
+  ;; rf2-v2g9 / rf2-q651r — negative companion to the fix. The vector form
+  ;; reads the epoch-tape dispatched-events projection (the SSOT since
+  ;; rf2-q651r — `assertions/dispatched-events`), NOT the retired
+  ;; `trace-accumulators` atom. We drive the projection directly via
+  ;; with-redefs: an empty projection (no loader epoch yet) → false; once
+  ;; the tape carries the required event → true.
+  (testing "vector form with an empty tape projection returns false"
     (let [frame-id :story.v2g9/stalled
           body {:loaders-complete-when [[:fixture/loaded]]}]
-      (reset! assertions/trace-accumulators {})
-      (is (false? (loaders/evaluate-complete-when frame-id body))
-          "predicate is false when the accumulator has no record of the required event")
-      ;; And once the listener-fed accumulator carries the event, the
-      ;; predicate flips to true (the post-fix observable).
-      (assertions/record-dispatched! frame-id [:fixture/loaded])
-      (is (true? (loaders/evaluate-complete-when frame-id body))
-          "predicate is true once the trace listener has fed the accumulator"))))
+      (with-redefs [assertions/dispatched-events (constantly [])]
+        (is (false? (loaders/evaluate-complete-when frame-id body))
+            "predicate is false when the tape carries no record of the required event"))
+      (with-redefs [assertions/dispatched-events (constantly [[:fixture/loaded]])]
+        (is (true? (loaders/evaluate-complete-when frame-id body))
+            "predicate is true once the tape projection carries the loader event")))))
 
 (deftest loaders-complete-when-evaluate-vector-form
-  (testing "vector-of-events evaluation reads the assertions dispatched-events accumulator"
-    ;; Pre-seed the accumulator (this is what the trace listener does
-    ;; during the play sequence).
+  (testing "vector-of-events evaluation reads the epoch-tape dispatched-events projection"
+    ;; rf2-q651r — the projection is the SSOT; drive it directly.
     (let [frame-id :story.predfn/vector
           variant-body {:loaders-complete-when [[:fixture/loaded] [:auth/ready]]}]
-      (assertions/record-dispatched! frame-id [:fixture/loaded])
-      (is (false? (loaders/evaluate-complete-when frame-id variant-body))
-          "missing one of the required events — predicate is false")
-      (assertions/record-dispatched! frame-id [:auth/ready])
-      (is (true? (loaders/evaluate-complete-when frame-id variant-body))
-          "both events observed — predicate is true")
-      (reset! assertions/trace-accumulators {}))))
+      (with-redefs [assertions/dispatched-events (constantly [[:fixture/loaded]])]
+        (is (false? (loaders/evaluate-complete-when frame-id variant-body))
+            "missing one of the required events — predicate is false"))
+      (with-redefs [assertions/dispatched-events (constantly [[:fixture/loaded] [:auth/ready]])]
+        (is (true? (loaders/evaluate-complete-when frame-id variant-body))
+            "both events observed — predicate is true")))))
 
 (deftest loaders-complete-when-fn-form
   (testing "literal fn predicate is invoked with the frame's app-db"


### PR DESCRIPTION
## What & why

Bundle of five `assertions.cljc`-centred fixes. The headline is a single-source-of-truth migration; the rest are doc + test fixes in the same file.

### rf2-q651r (P2, headline — SSOT)

`:rf.assert/no-warnings`, `:rf.assert/effect-emitted`, `:rf.assert/dispatched?` — and the loaders' `:loaders-complete-when` vector form — read their fact from the **epoch tape** (the single source of truth `re-frame.story.play.evidence` projects into the run-result `:warnings`/`:effects` slots) instead of the parallel `trace-accumulators` atom.

That atom was a **second capture path** fed by a distinct play-listener with different filtering — e.g. it routed `:op-type :error` trace ops (like `:rf.error/no-such-handler`) into the warnings bucket, so an error-only run made an in-script `[:assert [:rf.assert/no-warnings]]` **FAIL** while the tape-projected run-result `:warnings` slot stayed **empty** (pass). The atom and the slot **disagreed** — exactly the documented "false GREEN" class the evidence boundary closed. Schema-error (.21) and causal (.31) assertions were already tape-evaluated in `result.cljc`; these three + loaders were the stragglers.

- New tape projections on `assertions.cljc`:
  - `dispatched-events` — per-epoch `:trigger-event`, privacy-gated (drops `:rf.epoch/sensitive?` epochs under the show-sensitive flag), assertion-events excluded.
  - `emitted-fx` — tape `:effects` fx-ids ∪ the stub-call log (via a new `:stub-observed-fx-ids` late-bind hook). A **stubbed** fx lands on the tape under its *rewritten* stub id, not its original id, so the stub log `fx-stubs` already owns is the canonical source for the original id — **not** a re-introduced parallel accumulator.
  - `warnings` — `evidence/warnings` over the frame's tape (the same projection the `:warnings` slot reads, so the assertion and the slot **agree**).
  - The three evaluators became **pure fns** over these projected facts.

- **`trace-accumulators` atom retained, NOT removed** — and documented why. It is now a privacy-gated **dev side-table**, no longer the evidence source (so it can no longer drift into a false GREEN). Three live, non-test consumers keep it alive, and full removal would have to reach across lanes this change does not own:
  1. `ui/test_mode/stepper_state.cljs` (a separate UI lane — Mike's) drives `reset-trace-accumulators!` on stepper rewind;
  2. the `play.cljc` per-frame listener is the load-bearing **Spec 009 §Privacy** suppression seam (default-drops `:sensitive?` events + bumps the UI redaction counter) and the synchronous handler-exception capture (`pending-exceptions`), both pinned by `sensitive-trace-cljs-test`;
  3. the `force-fx-stub` tap mirrors redirected fx-ids there for dev surfacing.

  Filed as the documented follow-up (fold the side-table once the UI stepper-rewind lane can be touched in the same change).

### rf2-9sanv (P3, doc)
ns docstring no longer claims an unknown id records a `:rf.assert/unknown` pseudo-record — it FAILS plan construction with `:rf.error/story-unknown-assertion` (correct since .18).

### rf2-ntrv0 (P4, doc)
The "Public surface" bullet + the "seven canonical assertions" header now state `canonical-assertion-ids` is **eight** ids — the seven REGISTERED handlers plus the tape-evaluated `:rf.assert/schema-error`, which is recognised by plan construction but deliberately **never** installed as a handler.

### rf2-bmpn2 (P3, test)
`evaluate-no-warnings` FAIL branch (`:count` / `:actual` / reason projection) now covered directly via the var-quote seam — previously the only canonical evaluator with an untested failing path.

### rf2-e0rpy (P3, test)
`causal-bounds` `:exactly` shorthand + `:min`-override-on-`:caused`, and `causal-effect-surface` `:sub`-over-`:view` precedence — covered as pure-fn unit tests (previously only reached indirectly).

### SSOT regression (q651r acceptance)
`no-warnings-agrees-with-warnings-slot-on-error-only-run` — an error-only run's in-script `[:no-warnings]` AGREES with the run-result `:warnings` slot (both empty; **fails-pre** under the atom which counted the `:error` op, **passes-post** under the tape). Plus `dispatched?`/`effect-emitted` regressions projecting from the tape `:trigger-event`/`:effects` slots (including a re-dispatched nested event).

## Quality gates

- `tools/story` `clojure -M:test` — **1285 tests, 0 failures**
- `tools/story-mcp` `clojure -M:test` — **172 tests, 0 failures**
- `tools/mcp-conformance` `npm run test:story` (cum40) — **STORY-MCP MCP-CLIENT CONFORMANCE GREEN**
- `bash scripts/test-fast-pr.sh` — **PASS** (core JVM 795/0, CLJS node 4866/0, path-policy, gate-report, markdown gates all green)

Closes rf2-q651r, rf2-9sanv, rf2-ntrv0, rf2-bmpn2, rf2-e0rpy.