### PR TITLE
fix(story): exclude inline-plan frames from navigation enumeration (rf2-r16iv)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -291,9 +291,17 @@ rather than forking it:
    thread `:fragment-lookup` / `:check-lookup` / `:lookup` so the plan can
    compose REGISTERED fragments + checks, or run host-free);
 2. an ANONYMOUS frame id is minted in the reserved `:rf.story.inline/*`
-   namespace — never a registered variant id, so navigation can't surface
-   it and a concurrent registered run can't collide; the frame is stamped
-   `:rf/inline? true`;
+   namespace — never a registered variant id, so the Story side-table
+   queries (variant ids, variants-by-story) can't surface it and a
+   concurrent registered run can't collide; the frame is stamped
+   `:rf/inline? true`. That stamp is the discriminator the live-frame
+   navigation enumeration (`variant-frames` / `variant-frame?`) consults:
+   an inline frame carries `:rf/story?` (it IS Story-managed) yet is
+   EXCLUDED from the navigable-variant enumeration because it is also
+   stamped `:rf/inline?`. The MUST-NOT is thus enforced for the whole
+   in-flight window between allocation and teardown — not merely by the
+   side-table absence (which alone would leave the live frame transiently
+   navigable while a run is in flight);
 3. the decorator stack is resolved from the plan's already-merged
    `[:world :decorators]` refs (the variant/story side-table is NOT read);
 4. the SAME phase pipeline (loaders → setup → script) drives the run, all

--- a/tools/story/src/re_frame/story/frames.cljc
+++ b/tools/story/src/re_frame/story/frames.cljc
@@ -642,11 +642,24 @@
 ;; ---- frame-meta introspection --------------------------------------------
 
 (defn variant-frame?
-  "True iff `frame-id` is a variant frame (was allocated via
-  `allocate!`). Reads the frame's `:rf/story?` slot on its frame-meta
-  (per Spec-Schemas §`:rf/frame-meta` — flat shape)."
+  "True iff `frame-id` is a NAVIGABLE variant frame (was allocated via
+  `allocate!`). Reads the frame's frame-meta (per Spec-Schemas
+  §`:rf/frame-meta` — flat shape): true iff it carries `:rf/story?` AND is
+  NOT stamped `:rf/inline?`.
+
+  An inline-plan frame (allocated via `allocate-inline!`) shares the
+  `:rf/story?` stamp — it IS a Story-managed frame — but is stamped
+  `:rf/inline? true` and MUST NOT appear in Story navigation (spec/017
+  §Inline plan, UNCONDITIONALLY — not merely post-teardown). Excluding it
+  here makes `:rf/inline?` load-bearing: it is the discriminator that keeps
+  an in-flight inline frame out of the live-frame enumeration during the
+  window between `allocate-inline!` and `destroy-inline!`, closing the
+  transient gap that side-table absence alone (no registration) does not
+  cover (rf2-r16iv)."
   [frame-id]
-  (true? (:rf/story? (rf/frame-meta frame-id))))
+  (let [m (rf/frame-meta frame-id)]
+    (and (true? (:rf/story? m))
+         (not (:rf/inline? m)))))
 
 (defn variant-frames
   "Return every registered variant frame id. Stage 4's UI shell uses

--- a/tools/story/test/re_frame/story/inline_plan_test.clj
+++ b/tools/story/test/re_frame/story/inline_plan_test.clj
@@ -29,6 +29,7 @@
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.story     :as story]
             [re-frame.story.assertions :as assertions]
+            [re-frame.story.frames :as frames]
             [re-frame.story.play.runner-events :as re]))
 
 (defn- reset-rf! [test-fn]
@@ -120,6 +121,45 @@
         "the inline plan appears under no story")
     (is (empty? (story/variant-frames))
         "the anonymous inline frame was torn down — no lingering nav frame")))
+
+(deftest inline-plan-absent-from-navigation-while-in-flight
+  (testing "an inline frame is absent from variant-frames / variant-frame?
+            WHILE it is allocated — the transient window between
+            `allocate-inline!` and `destroy-inline!` (rf2-r16iv). spec/017
+            §Inline plan: 'Inline plans MUST NOT appear in Story navigation'
+            is UNCONDITIONAL — not merely post-teardown. The pre-existing
+            absent-from-navigation test only checks AFTER `run-target`
+            returns; on the JVM the run is synchronous so the in-flight
+            window is already closed at assertion time. Here we allocate the
+            inline frame and assert mid-flight, BEFORE tearing it down — the
+            case the post-teardown test misses. Drives `variant-frame?` to
+            read the `:rf/inline?` stamp `allocate-inline!` writes, making
+            the stamp load-bearing (no longer dead metadata)."
+    (let [inline-id :rf.story.inline/plan-transient]
+      ;; Allocate an inline frame directly (the registry-free twin of
+      ;; `allocate!`): empty decorator stack + no fx-overrides, events-only
+      ;; fast-path. This mirrors what `run-inline-plan` does mid-run.
+      (frames/allocate-inline! inline-id {} {} true)
+      (try
+        ;; The frame IS live — it exists in the runtime's frame registry.
+        (is (contains? (set (rf/frame-ids)) inline-id)
+            "precondition: the inline frame is allocated and live")
+        ;; It carries BOTH stamps — it is a Story-managed frame…
+        (let [m (rf/frame-meta inline-id)]
+          (is (true? (:rf/story? m)) "inline frame carries the :rf/story? stamp")
+          (is (true? (:rf/inline? m)) "inline frame carries the :rf/inline? stamp"))
+        ;; …yet `variant-frame?` excludes it (reads :rf/inline?) and so it
+        ;; is absent from the navigable enumeration the UI shell walks.
+        (is (false? (frames/variant-frame? inline-id))
+            "an allocated inline frame is NOT a navigable variant frame")
+        (is (not (contains? (frames/variant-frames) inline-id))
+            "an in-flight inline frame is absent from variant-frames")
+        (is (not (contains? (story/variant-frames) inline-id))
+            "…through the public story/variant-frames surface too")
+        (finally
+          (frames/destroy-inline! inline-id {} nil)))
+      (is (empty? (frames/variant-frames))
+          "post-teardown: no lingering nav frame (the pre-existing guard)"))))
 
 ;; ===========================================================================
 ;; Inline plan can use a REGISTERED check


### PR DESCRIPTION
## Summary

Closes the transient-window leak from **rf2-r16iv (P2 BUG)**: an in-flight inline-plan frame transiently appeared in Story navigation because the `:rf/inline?` stamp was never read by any consumer.

`frames/allocate-inline!` stamps an anonymous inline-plan frame with `:rf/story? true` AND `:rf/inline? true`. Both the code (`frames.cljc:498`, `runtime.cljc:932`) and the spec (`tools/story/spec/017-Testing-Story.md`) document `:rf/inline?` as the discriminator that keeps an inline run out of Story navigation. But `variant-frame?` / `variant-frames` — the live-frame enumeration the Stage-4 UI shell walks — filtered **only** on `:rf/story?`, never consulting `:rf/inline?`.

So the `:rf/inline?` stamp was **dead metadata**: written + documented, read by no consumer (grep confirmed: only writes + docstrings). Between `allocate-inline!` and `destroy-inline!`, an in-flight inline frame satisfied `variant-frame?` and was returned by `variant-frames`, violating spec/017 §Inline plan — *"Inline plans MUST NOT appear in Story navigation"* — which is **unconditional**, not merely post-teardown.

The "absent from navigation by construction (no registration)" claim was only half true: side-table absence (the `story/ids :variant` / `variants-by-story` queries) keeps it out of the side-table reads, but the live-frame enumeration is keyed off frame-meta, not the side-table.

## The fix

`variant-frame?` now returns true iff the frame carries `:rf/story?` **AND** is **not** stamped `:rf/inline?`:

```clojure
(let [m (rf/frame-meta frame-id)]
  (and (true? (:rf/story? m))
       (not (:rf/inline? m))))
```

This makes `:rf/inline?` **load-bearing** — it is now the real discriminator the live-frame enumeration consults, enforcing the MUST-NOT for the whole in-flight window between allocation and teardown. Pure predicate change in the core `frames` ns; the UI shell consumes the predicate unchanged and will correctly stop showing inline frames mid-flight.

`spec/017` §Inline plan step 2 updated to state the stamp's load-bearing role in the live-frame enumeration explicitly (previously it attributed exclusion only to the anonymous-id / no-registration construction).

## Transient-window test

Added `inline-plan-absent-from-navigation-while-in-flight`. It allocates an inline frame directly via `frames/allocate-inline!` and asserts — **WHILE the frame is allocated, before teardown** — that:
- the frame IS live (`rf/frame-ids` contains it) and carries BOTH `:rf/story?` + `:rf/inline?` stamps;
- `variant-frame?` returns `false` for it;
- it is absent from `variant-frames` (and the public `story/variant-frames` surface).

This is the transient window the pre-existing `inline-plan-absent-from-navigation` test misses: that test asserts `(empty? (story/variant-frames))` only AFTER `run-target` returns, and on the JVM the run is synchronous so the in-flight window is already closed at assertion time (the JVM-sync-hides-async-window class, same as rf2-q5jw4). The new test verified **fails pre-fix** (3 in-flight assertions fail) and **passes post-fix**.

## Quality gates

- `tools/story` `clojure -M:test` — **green** (1274 tests, 4109 assertions, 0 failures, 0 errors)
- `tools/story-mcp` `clojure -M:test` — **green** (172 tests, 861 assertions, 0 failures, 0 errors)
- `tools/mcp-conformance` `npm run test:story` — **green** (STORY-MCP MCP-CLIENT CONFORMANCE GREEN, exit 0)
- `bash scripts/test-fast-pr.sh` — **PASS** (JVM 795 + CLJS node 4865 tests, 0 failures; script/helper + markdown link/anchor gates pass; mkdocs soft-skip local, runs in CI)

Refs rf2-yi39n + rf2-5x1wt.20 + PR #2434.