### PR TITLE
fix(story): replay-flush-hooks WRAPS rather than replaces a richer :dispatch! (rf2-y5396)

### DIFF
--- a/tools/story/src/re_frame/story/artifact.cljc
+++ b/tools/story/src/re_frame/story/artifact.cljc
@@ -156,22 +156,36 @@
 (defn- replay-flush-hooks
   "Build the settled-boundary flush-hooks for a replay (spec/017 §Script
   and `settled-boundary`). It starts from `base-hooks` (the headless hooks
-  by default — `:provides :headless`, `dispatch-sync*` drain) and wraps
+  by default — `:provides :headless`, `dispatch-sync*` drain) and WRAPS
   `:dispatch!` so every replayed dispatch carries the artifact's
-  `fx-decisions` as the per-call `:fx-overrides`. Reapplying the fx
-  decisions through the dispatch opt — not a parallel install — keeps
-  replay on the SAME settlement path as a live run and lets the boundary's
-  `:cannot-run` / `:error` refusals fire unchanged. A richer adapter caller
-  can pass its own `base-hooks` (declaring `:provides :dom`, etc.) and the
-  fx reapplication still wraps its `:dispatch!`."
+  `fx-decisions` as the per-call `:fx-overrides`.
+
+  The wrap routes the fx decisions THROUGH the inner `:dispatch!`, never
+  around it: it binds the overrides on the lexical-scope `*fx-overrides*`
+  via `rf/with-fx-overrides` and then calls `inner`, so whatever dispatch
+  path the inner hook owns picks the overrides up at envelope-build time
+  (precedence: per-call opt > lexical `with-fx-overrides` > per-frame
+  `:fx-overrides`, Spec 002 §`:fx-overrides`). For the headless default
+  `inner` is `drain-sync!` (`dispatch-sync*` drain) and the overrides ride
+  its envelope; for a richer adapter caller that passes its own
+  `base-hooks` (declaring `:provides :dom`, etc. with an enqueue +
+  `act()` / microtask `:dispatch!`) the SAME adapter dispatch path runs
+  and the overrides ride it too — replay never reaches for `dispatch-sync`
+  directly. This keeps replay on the SAME settlement path as a live run
+  and lets the boundary's `:cannot-run` / `:error` refusals fire
+  unchanged."
   [base-hooks fx-decisions]
   (let [inner (or (:dispatch! base-hooks) boundary/drain-sync!)]
     (assoc base-hooks
            :dispatch!
            (fn replay-dispatch! [frame-id event-vector]
              (if (seq fx-decisions)
-               (rf/dispatch-sync* event-vector {:frame        frame-id
-                                                :fx-overrides fx-decisions})
+               ;; WRAP, don't replace: bind the fx decisions on the
+               ;; lexical-scope overrides and route THROUGH `inner` so the
+               ;; (possibly richer-adapter) dispatch path still runs and
+               ;; the overrides ride its envelope.
+               (rf/with-fx-overrides fx-decisions
+                 (inner frame-id event-vector))
                (inner frame-id event-vector))))))
 
 (defn replay-into-frame!

--- a/tools/story/src/re_frame/story/determinism.cljc
+++ b/tools/story/src/re_frame/story/determinism.cljc
@@ -216,8 +216,9 @@
 
   - `:runs`  — replay count (default 2). N >= 2.
   - `:hooks` / `:frame-config` — threaded to `replay-run-artifact` (a `:dom`
-    adapter passes richer settled-boundary hooks; fx decisions still wrap
-    its `:dispatch!`).
+    adapter passes richer settled-boundary hooks; the fx decisions are
+    routed THROUGH that hook's `:dispatch!` — they wrap it, never replace
+    it — so the adapter dispatch path still runs on every replay).
 
   Returns one of three statuses (never a flaky verdict):
 

--- a/tools/story/test/re_frame/story/artifact_test.cljc
+++ b/tools/story/test/re_frame/story/artifact_test.cljc
@@ -20,7 +20,8 @@
             [re-frame.registrar :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.story.artifact :as artifact]
-            [re-frame.story.fingerprint :as fingerprint]))
+            [re-frame.story.fingerprint :as fingerprint]
+            [re-frame.story.play.settled-boundary :as boundary]))
 
 ;; ===========================================================================
 ;; PURE: schema + construction
@@ -205,6 +206,48 @@
         (is (= :pass (:status res)))
         (is (= [:stub] @hits)
             "the fx decision remapped :rep.fx/real → :rep.fx/stub on replay")))))
+
+(deftest replay-wraps-not-replaces-richer-dispatch-when-fx-decisions-present
+  (testing "a richer adapter's :dispatch! is INVOKED (not bypassed) when
+            fx-decisions are present — the fx reapplication WRAPS the supplied
+            :dispatch! and routes the overrides through it, rather than
+            short-circuiting to dispatch-sync* directly (rf2-y5396).
+
+            Pre-fix: replay-flush-hooks called dispatch-sync* directly on the
+            fx-decisions branch and never touched `inner`, so a richer
+            (:dom / :cljs-reactive) adapter's enqueue + flush path was
+            silently skipped — this probe would record no call. Post-fix: the
+            probe :dispatch! runs AND the fx-overrides still apply."
+    (let [dispatch-calls (atom [])
+          fx-hits        (atom [])]
+      ;; A 'real' effect remapped to a stub by the fx decision, so we can also
+      ;; confirm the override rides the wrapped dispatch path (not just that
+      ;; the probe ran). `:platforms #{:client :server}` so the fx fire on the
+      ;; JVM (`:server`) test platform as well as in the browser.
+      (rf/reg-fx :rep.fx/real {:platforms #{:client :server}}
+                 (fn [_ _] (swap! fx-hits conj :real)))
+      (rf/reg-fx :rep.fx/stub {:platforms #{:client :server}}
+                 (fn [_ _] (swap! fx-hits conj :stub)))
+      (rf/reg-event-fx :rep/fire (fn [_ _] {:fx [[:rep.fx/real {}]]}))
+      (let [;; A richer adapter-style hooks map: a custom :dispatch! that
+            ;; RECORDS it was invoked, then delegates to the real headless
+            ;; drain so the replay still settles. `:provides :headless` so the
+            ;; settled-boundary does not refuse the bare [:dispatch …] step.
+            probe-hooks {:provides  :headless
+                         :dispatch! (fn probe-dispatch! [frame-id event-vector]
+                                      (swap! dispatch-calls conj event-vector)
+                                      (boundary/drain-sync! frame-id event-vector))
+                         :flush!    {:headless (fn [_frame-id] nil)}}
+            a   (artifact/make-run-artifact
+                  {:event-program [[:dispatch [:rep/fire]]]
+                   :fx-decisions  {:rep.fx/real :rep.fx/stub}})
+            res (artifact/replay-run-artifact a {:hooks probe-hooks})]
+        (is (= :pass (:status res)))
+        (is (= [[:rep/fire]] @dispatch-calls)
+            "the supplied richer :dispatch! WAS invoked — the fx reapplication
+             wrapped it instead of bypassing it with a direct dispatch-sync*")
+        (is (= [:stub] @fx-hits)
+            "the fx override still rode the wrapped dispatch path (real → stub)")))))
 
 (deftest replay-isolation-fresh-frame-each-time
   (testing "two replays of the same artifact each run into their own fresh


### PR DESCRIPTION
## What

`replay-flush-hooks` (`tools/story/src/re_frame/story/artifact.cljc`) **replaced** the supplied inner `:dispatch!` instead of **wrapping** it when `fx-decisions` were present. The fx-decisions branch called `rf/dispatch-sync*` directly and never invoked `inner`; `inner` was used only on the empty-fx-decisions branch.

For the headless default this was behaviourally identical (`inner == drain-sync!`), so the bug was latent. But for a future `:dom` / `:cljs-reactive` adapter that supplies a custom `:dispatch!` (enqueue + `act()` / microtask flush), a replay carrying any `fx-decisions` would silently **bypass** the adapter's dispatch path and call `dispatch-sync*` directly — desyncing dispatch from flush (headless dispatch + DOM flush) and violating the settled-boundary contract the docstrings + spec/017 repeatedly promise ("replay never reaches for `dispatch-sync` directly", "the fx decisions wrap its `:dispatch!`"). The gap propagated into the determinism gate, which threads `:hooks` straight through and inherited the same "wraps :dispatch!" claim.

## The fix — wrap, don't replace

Route the fx-overrides **through** `inner` by binding the lexical-scope `*fx-overrides*` via `rf/with-fx-overrides`, then calling `inner`:

```clojure
(if (seq fx-decisions)
  (rf/with-fx-overrides fx-decisions
    (inner frame-id event-vector))
  (inner frame-id event-vector))
```

The overrides ride the inner hook's own dispatch envelope at build time (precedence per-call > lexical `with-fx-overrides` > per-frame, Spec 002 §`:fx-overrides`), so the (possibly richer-adapter) dispatch path always runs. Genuinely wraps, never replaces.

- **Headless default** (`inner == drain-sync!`): the overrides ride its `dispatch-sync*` envelope — same behaviour as before, determinism gate replays still apply the stub.
- **Richer adapter** (custom `:dispatch!`): the adapter's own dispatch path runs AND the overrides ride it.

Both fix sites aligned: the actual code lives in `artifact.cljc`; `determinism.cljc` carries only the docstring claim (it threads `:hooks` straight through `replay-run-artifact`), so its `:hooks` docstring was corrected to match. The `artifact.cljc` `replay-flush-hooks` docstring was rewritten to describe the wrap-through-`inner` behaviour.

**spec/017** (`tools/story/spec/017-Testing-Story.md` §Run artifact and replay) already described the intended behaviour ("`:fx-decisions` ride the per-call `:fx-overrides` … routed through the **same** `settled-boundary` … Replay never reaches for `dispatch-sync` directly"; "the fx decisions still wrap its `:dispatch!`"). The old code **violated** that spec; this fix realigns code to spec, so **no spec edit was needed**.

## Regression test

`replay-wraps-not-replaces-richer-dispatch-when-fx-decisions-present` (artifact_test.cljc): supplies a richer probe `:dispatch!` that records it was invoked (then delegates to the real headless drain so the replay still settles), with `fx-decisions` present. Asserts the probe WAS invoked AND the fx-override still fired (`:rep.fx/real` → `:rep.fx/stub`).

- **Fails pre-fix** — verified by temporarily restoring the buggy direct-`dispatch-sync*` body: the probe was never invoked (`@dispatch-calls` empty), 1 failure.
- **Passes post-fix** — probe invoked, override applied, 0 failures.

The headless-default determinism test (`gate-reapplies-fx-decisions-deterministically`) still passes — no regression on the default path.

## Quality gates

- `tools/story`: `clojure -M:test` — **1283 tests, 4157 assertions, 0 failures, 0 errors** (determinism gate + artifact replay tests green)
- `tools/story-mcp`: `clojure -M:test` — **172 tests, 861 assertions, 0 failures, 0 errors**
- `tools/mcp-conformance`: `npm run test:story` — **STORY-MCP MCP-CLIENT CONFORMANCE GREEN** (exit 0)
- `bash scripts/test-fast-pr.sh` — **PASS fast PR spine** (incl. `npm run test:cljs`: 4866 tests, 15934 assertions, 0 failures, 0 errors — confirms the `.cljc` change resolves in CLJS too; mkdocs soft-skipped locally, CI runs it)