### PR TITLE
refactor(story): shared Throwable->error-map projection + collapse plan-schema-expectations (rf2-9kpsq + rf2-2zncm + rf2-x3mol)

### DIFF
--- a/tools/story/src/re_frame/story/error.cljc
+++ b/tools/story/src/re_frame/story/error.cljc
@@ -1,0 +1,86 @@
+(ns re-frame.story.error
+  "The ONE Throwable→error-map projection + `:rf.error/exception`
+  assertion-record builder, shared across the Story runtime.
+
+  Lives at the leaf of the require graph (depends on `clojure.core` /
+  the host runtime only) so any sibling namespace — `runtime`, `frames`,
+  `play`, `render` — can `:require` it without cycle risk. Companion leaf
+  to `re-frame.story.predicates` (pure data→data) and
+  `re-frame.story.late-bind` (run-time fn resolution).
+
+  ## Why this exists (rf2-9kpsq)
+
+  The reader-conditional Throwable→`{:message :stack :data}` projection
+  was copy-pasted VERBATIM across five sites in four namespaces, and the
+  wrapping `:rf.error/exception` assertion-record was duplicated three
+  times. The copies had begun to DRIFT — one site wrapped each accessor
+  in a `when`-guard, another dropped `:stack` / `:data` entirely. A
+  reader had to diff five near-identical blocks to confirm they agreed.
+
+  Consolidating to one tested projection both removes the drift surface
+  and FIXES the two accidental divergences toward the canonical full
+  shape: `:stack` and `:data` are always present (nil when unavailable),
+  and a nil throwable is tolerated (the trace-event drain path may carry
+  a pre-extracted message without the original exception).
+
+  ## The canonical shape
+
+  `throwable->error-map` returns `{:message :stack :data}`:
+
+  - `:message` — `(.getMessage e)` (JVM) / `(str e)` (CLJS); a caller
+    MAY supply an explicit `:message` override (the trace-drain path
+    carries a pre-extracted `:exception-message` and falls back to it
+    when no throwable is in hand);
+  - `:stack`   — `(.printStackTrace e)` (JVM) / `(.-stack e)` (CLJS);
+    nil when `e` is nil;
+  - `:data`    — `(ex-data e)`; nil for a non-`ExceptionInfo` throwable
+    and nil for a nil `e` (`ex-data` already guards the instance check,
+    so no explicit `instance?` test is needed).
+
+  `exception-record` wraps that projection in the full
+  `:rf.error/exception` assertion record per IMPL-SPEC §5.5 +
+  `002-Runtime.md` §Error projection."
+  (:refer-clojure :exclude [error]))
+
+(defn throwable->error-map
+  "Project a (possibly nil) Throwable into the canonical
+  `{:message :stack :data}` error map. Reader-conditional, pure on both
+  runtimes.
+
+  `opts` (optional):
+    :message — an explicit message string used in place of the
+               throwable's own message (the trace-drain path supplies a
+               pre-extracted `:exception-message`). Falls back to the
+               throwable's message when nil/absent."
+  ([err] (throwable->error-map err nil))
+  ([err {:keys [message]}]
+   {:message (or message
+                 #?(:clj  (when err (.getMessage ^Throwable err))
+                    :cljs (when err (str err))))
+    :stack   #?(:clj  (when err (with-out-str (.printStackTrace ^Throwable err)))
+                :cljs (when err (.-stack err)))
+    ;; `ex-data` already returns nil for a non-ExceptionInfo (and a nil)
+    ;; throwable, so no explicit `instance?` guard is needed.
+    :data    (ex-data err)}))
+
+(defn exception-record
+  "Build the full `:rf.error/exception` assertion record projected when a
+  phase throws (IMPL-SPEC §5.5 + `002-Runtime.md` §Error projection). The
+  record lands in `:rf.story/assertions` so the variant's last result map
+  surfaces the failure; `:passed? false` makes the run-level aggregation
+  report a failure.
+
+  `phase` is the originating phase (`:phase-1-loaders`, `:phase-2-events`,
+  `:phase-4-play`, `:phase-teardown`, …); `event` is the originating event
+  vector (may be nil); `err` is the (possibly nil) Throwable.
+
+  `opts` is threaded to `throwable->error-map` (the trace-drain path's
+  pre-extracted `:message`)."
+  ([variant-id phase event err] (exception-record variant-id phase event err nil))
+  ([variant-id phase event err opts]
+   {:assertion  :rf.error/exception
+    :variant-id variant-id
+    :phase      phase
+    :event      event
+    :error      (throwable->error-map err opts)
+    :passed?    false}))

--- a/tools/story/src/re_frame/story/frames.cljc
+++ b/tools/story/src/re_frame/story/frames.cljc
@@ -46,6 +46,7 @@
   (:require [re-frame.core             :as rf]
             [re-frame.story.config     :as config]
             [re-frame.story.decorators :as decorators]
+            [re-frame.story.error      :as story-error]
             [re-frame.story.late-bind  :as late-bind]
             [re-frame.story.loaders    :as loaders]
             [re-frame.story.registrar  :as registrar]
@@ -176,20 +177,13 @@
 
   `phase` is one of `:phase-loaders-teardown` (variant body's
   `:loaders-teardown` events — rf2-lqs0b) or `:phase-teardown`
-  (`:frame-setup` decorator `:teardown` events — rf2-dg2uh)."
+  (`:frame-setup` decorator `:teardown` events — rf2-dg2uh).
+
+  Thin wrapper over the shared `re-frame.story.error/exception-record`
+  (rf2-9kpsq) — the Throwable→`{:message :stack :data}` projection + the
+  `:rf.error/exception` shape are the ONE canonical form."
   [variant-id phase event err]
-  {:assertion  :rf.error/exception
-   :variant-id variant-id
-   :phase      phase
-   :event      event
-   :error      {:message #?(:clj  (.getMessage ^Throwable err)
-                            :cljs (str err))
-                :stack   #?(:clj  (with-out-str (.printStackTrace ^Throwable err))
-                            :cljs (.-stack err))
-                :data    (when (instance? #?(:clj clojure.lang.ExceptionInfo
-                                             :cljs ExceptionInfo) err)
-                           (ex-data err))}
-   :passed?    false})
+  (story-error/exception-record variant-id phase event err))
 
 (defonce ^:private teardown-capture-counter (atom 0))
 

--- a/tools/story/src/re_frame/story/play.cljc
+++ b/tools/story/src/re_frame/story/play.cljc
@@ -73,6 +73,7 @@
             [re-frame.story.assertions :as assertions]
             [re-frame.story.async      :as async]
             [re-frame.story.config     :as config]
+            [re-frame.story.error      :as story-error]
             [re-frame.story.frames     :as frames]
             [re-frame.story.late-bind  :as late-bind]
             [re-frame.story.play.runner :as runner]
@@ -194,21 +195,14 @@
         (let [event-vec (get-in ev [:tags :event])
               msg       (get-in ev [:tags :exception-message])
               exc       (get-in ev [:tags :exception])]
+          ;; rf2-9kpsq — the trace event may carry a pre-extracted
+          ;; `:exception-message` (and a possibly-nil `:exception`); thread
+          ;; it as the explicit `:message` override on the shared
+          ;; projection so the message survives even without the throwable.
           (assertions/record!
             frame-id
-            {:assertion :rf.error/exception
-             :variant-id frame-id
-             :phase     phase
-             :event     event-vec
-             :error     {:message (or msg
-                                      #?(:clj (when exc (.getMessage ^Throwable exc))
-                                         :cljs (when exc (str exc))))
-                         :stack   #?(:clj  (when exc (with-out-str (.printStackTrace ^Throwable exc)))
-                                      :cljs (when exc (.-stack exc)))
-                         :data    (when (instance? #?(:clj clojure.lang.ExceptionInfo
-                                                      :cljs ExceptionInfo) exc)
-                                    (ex-data exc))}
-             :passed?   false})))
+            (story-error/exception-record frame-id phase event-vec exc
+                                          {:message msg}))))
       (swap! pending-exceptions assoc frame-id []))))
 
 (defn install-trace-listener!
@@ -250,19 +244,9 @@
   (try
     (rf/dispatch-sync event {:frame frame-id})
     (catch #?(:clj Throwable :cljs :default) e
-      (let [record {:assertion :rf.error/exception
-                    :variant-id frame-id
-                    :phase     :phase-4-play
-                    :event     event
-                    :error     {:message #?(:clj  (.getMessage ^Throwable e)
-                                            :cljs (str e))
-                                :stack   #?(:clj  (with-out-str (.printStackTrace ^Throwable e))
-                                            :cljs (.-stack e))
-                                :data    (when (instance? #?(:clj clojure.lang.ExceptionInfo
-                                                             :cljs ExceptionInfo) e)
-                                           (ex-data e))}
-                    :passed?   false}]
-        (assertions/record! frame-id record))))
+      (assertions/record!
+        frame-id
+        (story-error/exception-record frame-id :phase-4-play event e))))
   ;; After the drain settles, walk any captured handler-exception
   ;; trace events into assertion records. Safe to dispatch-sync now —
   ;; the drain has ended.
@@ -339,13 +323,13 @@
              ;; A failure inside execute-play itself (not the dispatched
              ;; events) becomes a phase-4-setup record. The play has not
              ;; necessarily completed but we still resolve the promise so
-             ;; the caller sees the accumulator.
-             (assertions/record! variant-id
-                                 {:assertion :rf.error/exception
-                                  :phase     :phase-4-setup
-                                  :error     {:message #?(:clj (.getMessage ^Throwable e)
-                                                          :cljs (str e))}
-                                  :passed?   false})
+             ;; the caller sees the accumulator. rf2-9kpsq — routed through
+             ;; the shared projection (was a drifted message-only copy that
+             ;; dropped :stack / :data); :event is nil (the failure is in
+             ;; the play harness, not a dispatched event).
+             (assertions/record!
+               variant-id
+               (story-error/exception-record variant-id :phase-4-setup nil e))
              (resolve (read-assertions-after variant-id)))))))))
 
 ;; ---------------------------------------------------------------------------

--- a/tools/story/src/re_frame/story/render.cljc
+++ b/tools/story/src/re_frame/story/render.cljc
@@ -78,6 +78,7 @@
   disabled renders nothing (`config/enabled?` is false)."
   (:require [re-frame.story.args        :as args]
             [re-frame.story.config      :as config]
+            [re-frame.story.error       :as story-error]
             [re-frame.story.fingerprint :as fingerprint]
             [re-frame.story.late-bind   :as late-bind]
             [re-frame.story.plan        :as plan]))
@@ -279,13 +280,16 @@
 (defn- error-result
   "The `:error` render result — plan construction or the host render fn
   threw. Carries the structured ex-data so tools surface the failure the
-  same way a run error surfaces."
+  same way a run error surfaces.
+
+  rf2-9kpsq — the `:error` sub-map is the shared
+  `re-frame.story.error/throwable->error-map` projection (was a drifted
+  copy that dropped `:stack`; consolidation restores the canonical
+  `{:message :stack :data}` shape)."
   [target e]
   {:status :error
    :frame  (when (keyword? target) target)
-   :error  {:message #?(:clj  (.getMessage ^Throwable e)
-                        :cljs (str e))
-            :data    (ex-data e)}})
+   :error  (story-error/throwable->error-map e)})
 
 (defn render-variant
   "Render `target`'s active workshop view from its normalized variant plan

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -43,6 +43,7 @@
             [re-frame.story.async     :as async]
             [re-frame.story.config    :as config]
             [re-frame.story.decorators :as decorators]
+            [re-frame.story.error     :as story-error]
             [re-frame.story.frames    :as frames]
             [re-frame.story.identity  :as ident]
             [re-frame.story.loaders   :as loaders]
@@ -283,22 +284,6 @@
 
 ;; ---- error recording -----------------------------------------------------
 
-(defn- error-record
-  "Build an error projection map per IMPL-SPEC §5.5."
-  [variant-id phase event err]
-  {:assertion :rf.error/exception
-   :variant-id variant-id
-   :phase     phase
-   :event     event
-   :error     {:message #?(:clj  (.getMessage ^Throwable err)
-                           :cljs (str err))
-               :stack   #?(:clj  (with-out-str (.printStackTrace ^Throwable err))
-                            :cljs (.-stack err))
-               :data    (when (instance? #?(:clj clojure.lang.ExceptionInfo
-                                            :cljs ExceptionInfo) err)
-                          (ex-data err))}
-   :passed?   false})
-
 (defn- loader-incomplete-record
   "Build the non-throwing projection used when a loader predicate is
   false. The runtime cannot advance into events/play while the loader
@@ -317,7 +302,7 @@
   accumulator. Per IMPL-SPEC §5.5 errors continue the play sequence
   rather than aborting — the full picture is captured."
   [variant-id phase event err]
-  (let [record (error-record variant-id phase event err)]
+  (let [record (story-error/exception-record variant-id phase event err)]
     (try
       (rf/dispatch-sync [::append-assertion record] {:frame variant-id})
       (catch #?(:clj Throwable :cljs :default) dispatch-err
@@ -393,51 +378,20 @@
     (plan/expand-checks (get-in plan [:expect :checks]))
     (catch #?(:clj Throwable :cljs :default) _ {})))
 
-(defn- plan-schema-expectations
-  "Collect every declared `[:rf.assert/schema-error spec]` atom for a
-  normalized PLAN (rf2-5x1wt.21, spec/017 §Schema rule). These declare the
-  EXPECTED schema violations the result boundary exactly-consumes against
-  the projected tape evidence — so a missing/different violation fails the
-  run, an exactly-expected violation passes. Pure aside from the check
-  expansion's registrar reads; tolerant (any failure yields no
-  expectations, so the strict floor — every violation fails — applies).
-
-  Sources, all in the ONE assertion-atom vocabulary, all read off the
-  compiled plan so a registered variant and an inline plan share the path:
-
-  - the plan's terminal `[:expect :assertions]` (own-only verdict);
-  - the expanded `[:expect :checks]` assertion atoms (an inheritable
-    schema expectation rides a check, §Checks);
-  - the auto-play `executed-script`'s in-script `[:assert …]` checkpoints
-    (a mid-script schema expectation).
-
-  `:rf.assert/schema-error` is NOT dispatched into the frame (it has no
-  reg-event-fx handler — it is tape-evaluated), so collecting the DECLARED
-  atoms here is the single path that feeds the consumption matcher."
-  [plan executed-script]
-  (try
-    (let [terminal      (vec (get-in plan [:expect :assertions]))
-          check-atoms   (mapcat val (plan-checks plan))
-          script-atoms  (into []
-                              (keep (fn [step]
-                                      (when (and (vector? step)
-                                                 (= :assert (first step)))
-                                        (second step))))
-                              (or executed-script []))]
-      (filterv assertions/schema-error?
-               (concat terminal check-atoms script-atoms)))
-    (catch #?(:clj Throwable :cljs :default) _ [])))
-
 (defn- plan-assertion-atoms
   "Collect EVERY declared assertion atom for a normalized PLAN, across the
-  three positions in the ONE assertion-atom vocabulary (mirroring
-  `plan-schema-expectations`): the terminal `[:expect :assertions]`, the
-  expanded `[:expect :checks]` atoms, and the in-script `[:assert …]`
-  checkpoints of the executed script. Pure aside from the check expansion's
-  registrar reads; tolerant (any failure yields no atoms). Used to feed the
-  tape-evaluated expectation matchers (`:rf.assert/caused` /
-  `:rf.assert/no-cascade-rerender`, rf2-5x1wt.31) that — like
-  `:rf.assert/schema-error` — carry NO `reg-event-fx` handler and so must be
+  three positions in the ONE assertion-atom vocabulary: the terminal
+  `[:expect :assertions]`, the expanded `[:expect :checks]` atoms, and the
+  in-script `[:assert …]` checkpoints of the executed script. Pure aside
+  from the check expansion's registrar reads; tolerant (any failure yields
+  no atoms).
+
+  This is the SINGLE collector; the predicate-specific helpers
+  (`plan-schema-expectations`, `plan-causal-expectations`) are each a
+  `filterv` over its output (rf2-2zncm). Feeds the tape-evaluated
+  expectation matchers (`:rf.assert/schema-error`, `:rf.assert/caused` /
+  `:rf.assert/no-cascade-rerender`, rf2-5x1wt.31) that — unlike a
+  `reg-event-fx`-backed assertion — carry NO handler and so must be
   collected from the plan, not the `:rf.story/assertions` accumulator."
   [plan executed-script]
   (try
@@ -451,6 +405,25 @@
                              (or executed-script []))]
       (vec (concat terminal check-atoms script-atoms)))
     (catch #?(:clj Throwable :cljs :default) _ [])))
+
+(defn- plan-schema-expectations
+  "Collect every declared `[:rf.assert/schema-error spec]` atom for a
+  normalized PLAN (rf2-5x1wt.21, spec/017 §Schema rule). These declare the
+  EXPECTED schema violations the result boundary exactly-consumes against
+  the projected tape evidence — so a missing/different violation fails the
+  run, an exactly-expected violation passes.
+
+  `:rf.assert/schema-error` is NOT dispatched into the frame (it has no
+  reg-event-fx handler — it is tape-evaluated), so collecting the DECLARED
+  atoms here is the single path that feeds the consumption matcher.
+
+  Defined as a FILTER over the shared `plan-assertion-atoms` collector —
+  the same pattern `plan-causal-expectations` uses (rf2-2zncm). The
+  collector already wraps the three positions in a tolerant try/catch, so
+  `filterv` over its `(vec (concat …))` output is identical to filtering
+  the bare `concat` (filterv ignores the extra vec)."
+  [plan executed-script]
+  (filterv assertions/schema-error? (plan-assertion-atoms plan executed-script)))
 
 (defn- plan-causal-expectations
   "Collect every declared `:rf.assert/caused` / `:rf.assert/no-cascade-
@@ -737,8 +710,7 @@
                        :status     :error
                        :passed?    false
                        :reason     (exception-message e)
-                       :error      {:message (exception-message e)
-                                    :data    (ex-data e)}}]))
+                       :error      (story-error/throwable->error-map e)}]))
 
 (defn- handle-run-error!
   "Catch-branch for the orchestrator: record the exception as a

--- a/tools/story/test/re_frame/story_error_test.clj
+++ b/tools/story/test/re_frame/story_error_test.clj
@@ -1,0 +1,107 @@
+(ns re-frame.story-error-test
+  "JVM tests for `re-frame.story.error` — the ONE shared Throwable→error-map
+  projection + `:rf.error/exception` assertion-record builder (rf2-9kpsq).
+
+  The projection used to be copy-pasted verbatim across five sites in four
+  namespaces, with the wrapping record duplicated three times; the copies
+  had begun to drift (one site guarded each accessor, another dropped
+  `:stack` / `:data`). These tests pin the canonical shape and confirm the
+  drift is gone — every routed site now yields the SAME
+  `{:message :stack :data}` shape."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.story.error :as story-error]))
+
+;; ---- throwable->error-map -------------------------------------------------
+
+(deftest throwable->error-map-projects-the-canonical-shape
+  (testing "an ExceptionInfo projects to {:message :stack :data} with every
+            slot populated"
+    (let [m (story-error/throwable->error-map
+              (ex-info "boom" {:why :test}))]
+      (is (= #{:message :stack :data} (set (keys m)))
+          "exactly the three canonical keys")
+      (is (= "boom" (:message m)))
+      (is (= {:why :test} (:data m))
+          ":data is the ex-data of an ExceptionInfo")
+      (is (string? (:stack m))
+          ":stack is a string on the JVM (the with-out-str capture of
+           .printStackTrace — the behaviour is preserved verbatim from the
+           pre-consolidation copies)"))))
+
+(deftest throwable->error-map-non-ex-info-has-nil-data
+  (testing "a plain Throwable (no ex-data) yields :data nil WITHOUT an
+            explicit instance? guard — ex-data already returns nil for a
+            non-ExceptionInfo"
+    (let [m (story-error/throwable->error-map (RuntimeException. "plain"))]
+      (is (= "plain" (:message m)))
+      (is (nil? (:data m)))
+      (is (string? (:stack m))))))
+
+(deftest throwable->error-map-tolerates-nil-throwable
+  (testing "a nil throwable yields all-nil slots (the trace-drain path may
+            carry no exception object)"
+    (let [m (story-error/throwable->error-map nil)]
+      (is (= {:message nil :stack nil :data nil} m)))))
+
+(deftest throwable->error-map-explicit-message-override
+  (testing "an explicit :message override wins over the throwable's own
+            message (the trace-drain path threads a pre-extracted
+            :exception-message)"
+    (is (= "pre-extracted"
+           (:message (story-error/throwable->error-map
+                       (ex-info "original" {}) {:message "pre-extracted"}))))
+    (testing "and survives even without a throwable in hand"
+      (is (= "pre-extracted"
+             (:message (story-error/throwable->error-map
+                         nil {:message "pre-extracted"})))))
+    (testing "a nil override falls back to the throwable's message"
+      (is (= "original"
+             (:message (story-error/throwable->error-map
+                         (ex-info "original" {}) {:message nil})))))))
+
+;; ---- exception-record -----------------------------------------------------
+
+(deftest exception-record-wraps-the-projection
+  (testing "exception-record builds the full :rf.error/exception assertion
+            record with the canonical error projection embedded"
+    (let [e (ex-info "kaboom" {:k :v})
+          r (story-error/exception-record :story.x/v :phase-2-events
+                                          [:some/event 1] e)]
+      (is (= :rf.error/exception (:assertion r)))
+      (is (= :story.x/v          (:variant-id r)))
+      (is (= :phase-2-events     (:phase r)))
+      (is (= [:some/event 1]     (:event r)))
+      (is (false?                (:passed? r)))
+      (is (= (story-error/throwable->error-map e) (:error r))
+          "the :error slot is exactly the shared projection")
+      (is (= "kaboom" (-> r :error :message)))
+      (is (= {:k :v}  (-> r :error :data)))
+      (is (string?    (-> r :error :stack))))))
+
+(deftest exception-record-threads-message-override
+  (testing "the opts arity threads :message through to the embedded
+            projection (the drain path's pre-extracted message)"
+    (let [r (story-error/exception-record :story.x/v :phase-1-loaders nil nil
+                                          {:message "from trace"})]
+      (is (= "from trace" (-> r :error :message)))
+      (is (nil? (-> r :error :stack)))
+      (is (nil? (-> r :error :data))))))
+
+;; ---- drift is gone: every routed record shares the projection -------------
+
+(deftest all-exception-records-share-the-canonical-error-shape
+  (testing "records built for every phase carry IDENTICAL :error key sets —
+            the previously-drifted :stack / :data fields are now consistent
+            across all sites (rf2-9kpsq)"
+    (let [e          (ex-info "x" {:d 1})
+          phases     [:phase-0-setup :phase-1-loaders :phase-2-events
+                      :phase-4-play :phase-4-setup :phase-teardown
+                      :phase-loaders-teardown]
+          error-keys (->> phases
+                          (map (fn [p]
+                                 (set (keys (:error (story-error/exception-record
+                                                      :story.x/v p nil e))))))
+                          set)]
+      (is (= #{#{:message :stack :data}} error-keys)
+          "every phase's :error sub-map has exactly the canonical key set —
+           no site drops :stack or :data"))))

--- a/tools/story/test/re_frame/story_runtime_test.clj
+++ b/tools/story/test/re_frame/story_runtime_test.clj
@@ -911,6 +911,85 @@
         (is (false? (:passed? exc)))))
     (story/destroy-variant! :story.planerr/v)))
 
+;; ---- plan-construction-error? discrimination (rf2-x3mol) -----------------
+;;
+;; PR #2430 (rf2-5x1wt.22) narrowed `plan-construction-error?` from the
+;; over-broad "`:rf.error/id` present" to "`:where` = `'rf.story/variant-
+;; plan`". The discrimination is load-bearing: a FRAMEWORK runtime error
+;; thrown AFTER frame allocation that ALSO carries an `:rf.error/id` (the
+;; cited case is `:rf.error/no-adapter-installed` from `reg-frame` →
+;; `make-state-container` on a host with no adapter installed) MUST take
+;; the frame-bound record/transition branch (`record-error!` +
+;; `loaders/error!`), NOT `plan-error-result` (which would stamp the raw
+;; `:rf.error/id` as the assertion id, misreporting a runtime failure as a
+;; plan-construction failure). The pre-existing suite pinned only the
+;; POSITIVE branch (a true plan error projects correctly); these pin the
+;; NEGATIVE branch + the precise `:where`-marker scoping.
+
+(deftest plan-construction-error?-discriminates-on-where-marker
+  (testing "the predicate keys on :where 'rf.story/variant-plan ONLY — an
+            :rf.error/id-bearing error WITHOUT that marker is NOT a plan-
+            construction error (it must route through the frame-bound
+            path), while a :where-marked plan failure IS"
+    (let [plan-construction-error? @#'runtime/plan-construction-error?]
+      ;; NEGATIVE: a framework runtime error carrying :rf.error/id but no
+      ;; :where marker — the #2430 cum40 regression case. Must be false so
+      ;; handle-run-error! takes the frame-bound branch, NOT plan-error-result.
+      (is (false? (plan-construction-error?
+                    (ex-info "no adapter installed"
+                             {:rf.error/id :rf.error/no-adapter-installed})))
+          "an :rf.error/id-bearing runtime error with NO :where marker is
+           NOT a plan-construction error")
+      ;; A non-plan :where symbol (registrar / extends / macros stamp
+      ;; distinct :where symbols) is likewise not a plan-construction error.
+      (is (false? (plan-construction-error?
+                    (ex-info "reg failure"
+                             {:rf.error/id :rf.error/story-reg-variant-invalid
+                              :where        'rf.story/reg-variant})))
+          "a sibling :where symbol does not satisfy the predicate")
+      ;; An error with no ex-data at all is not a plan-construction error.
+      (is (false? (plan-construction-error? (ex-info "bare" {})))
+          "an error with empty ex-data is not a plan-construction error")
+      ;; POSITIVE control: only the :where 'rf.story/variant-plan marker
+      ;; (what plan/fail! stamps) makes the predicate true.
+      (is (true? (plan-construction-error?
+                   (ex-info "plan invalid"
+                            {:rf.error/id :rf.error/story-assert-in-setup
+                             :where        'rf.story/variant-plan})))
+          "a plan/fail! error (:where 'rf.story/variant-plan) IS a plan-
+           construction error"))))
+
+(deftest post-frame-rf-error-id-routes-through-frame-bound-path
+  (testing "a framework runtime error carrying an :rf.error/id thrown AFTER
+            frame allocation routes through handle-run-error!'s frame-bound
+            record path (an :rf.error/exception assertion at :phase-0-setup)
+            — it is NOT misrouted as a plan-construction error (which would
+            stamp the raw :rf.error/id as the assertion id)"
+    (story/reg-variant :story.postframe/v {:events []})
+    ;; Redef a phase fn that runs AFTER run-phase-0! (so the frame is
+    ;; allocated and the lifecycle is past :pre-mount) to throw an ex-info
+    ;; carrying an :rf.error/id but NO :where 'rf.story/variant-plan marker
+    ;; — simulating the :rf.error/no-adapter-installed case the #2430 fix
+    ;; guards against.
+    (with-redefs [runtime/run-phase-2!
+                  (fn [_ctx]
+                    (throw (ex-info "no adapter installed"
+                                    {:rf.error/id :rf.error/no-adapter-installed})))]
+      (let [r (async/deref-blocking (story/run-variant :story.postframe/v) 5000)]
+        (is (= :error (:lifecycle r))
+            "the post-frame throw rolled the lifecycle to :error via
+             loaders/error!")
+        (let [recs (:assertions r)]
+          (is (some #(and (= :rf.error/exception (:assertion %))
+                          (= :phase-0-setup (:phase %)))
+                    recs)
+              "the error was recorded via the frame-bound record-error!
+               path as an :rf.error/exception at :phase-0-setup")
+          (is (not-any? #(= :rf.error/no-adapter-installed (:assertion %)) recs)
+              "the raw :rf.error/id was NOT stamped as the assertion id —
+               i.e. it did NOT misroute through plan-error-result"))))
+    (story/destroy-variant! :story.postframe/v)))
+
 ;; ===========================================================================
 ;; FRAME-META INTROSPECTION
 ;; ===========================================================================


### PR DESCRIPTION
Tail cluster A (runtime-area, all share the `runtime.cljc` require graph → one PR). Three fixes.

## rf2-9kpsq (P2 clarity — the masterpiece win)

The reader-conditional `Throwable → {:message :stack :data}` projection was copy-pasted **verbatim across 5 sites in 4 namespaces**, and the wrapping `:rf.error/exception` assertion-record was duplicated **3×**. The copies had begun to **drift**:

- `play/execute-play!` dropped `:stack` and `:data` (message-only);
- `render/error-result` dropped `:stack`;
- `play/drain-pending-exceptions!` wrapped each accessor in a `when`-guard.

**Fix:** extract one leaf ns **`re-frame.story.error`** (depends on `clojure.core` / host only — no cycle risk, sits alongside `predicates` / `late-bind`):

- `throwable->error-map` — the canonical projection;
- `exception-record` — the full `:rf.error/exception` assertion record wrapping it.

All 5 projection sites + 3 record duplications now route through it (`runtime/record-error!` + `plan-error-result`, `frames/teardown-exception-record`, `play/dispatch-one!` + `drain-pending-exceptions!` + `execute-play!`, `render/error-result`).

### Chosen unified error-map shape

```clojure
{:message <(.getMessage e) | (str e) | explicit-override>   ; nil when e is nil
 :stack   <(.printStackTrace e) | (.-stack e)>              ; nil when e is nil
 :data    (ex-data e)}                                      ; nil for non-ExceptionInfo / nil e
```

Decisions baked into the canonical form:

- **Keep `:stack` and `:data` everywhere** — consolidation FIXES the two drifted sites toward the documented full shape (`spec/002-Runtime.md` §Error projection already specifies `{:message ... :stack ... :data ...}`, so this aligns the impl to the spec rather than changing a contract).
- **Tolerate a nil throwable** — the trace-drain path may carry a pre-extracted `:exception-message` without the original exception; an optional `{:message …}` override threads it through (the only legitimate divergence from the drifted `when`-guard variant, now explicit).
- **Drop the redundant `instance? ExceptionInfo` guard on `:data`** — `ex-data` already returns nil for a non-`ExceptionInfo` (and a nil) throwable, so the guard was dead code.

No behavioural change on the common path; one tested projection replaces five hand-maintained copies.

## rf2-2zncm (P3 clarity, `runtime.cljc`)

`plan-schema-expectations` inlined `plan-assertion-atoms`' entire three-position collection (terminal `[:expect :assertions]` + expanded `[:expect :checks]` + in-script `[:assert …]`). Collapsed to `(filterv schema-error? (plan-assertion-atoms …))` — exactly the pattern the sibling `plan-causal-expectations` already used. `plan-assertion-atoms` is now the **single collector**, reordered ahead of both filter-helpers; each filter trivially wraps it. Behaviour-preserving: `filterv` over the collector's `(vec (concat …))` is identical to filtering the bare `concat`.

## rf2-x3mol (P2 test, `runtime`-area)

PR #2430 narrowed `plan-construction-error?` from "`:rf.error/id` present" to "`:where = 'rf.story/variant-plan`". The pre-existing suite pinned only the POSITIVE branch. Added the missing NEGATIVE-branch coverage:

- **`plan-construction-error?-discriminates-on-where-marker`** — a focused predicate unit test: an `:rf.error/id`-bearing error WITHOUT the `:where` marker (the cited `:rf.error/no-adapter-installed` / #2430 cum40 case), a sibling `:where` symbol, and an empty-ex-data error all return `false`; only the `:where 'rf.story/variant-plan` marker returns `true`. **Verified it fails-pre**: temporarily broadening the predicate back to `(contains? (ex-data e) :rf.error/id)` makes this test fail.
- **`post-frame-rf-error-id-routes-through-frame-bound-path`** — an integration test: a post-frame throw carrying `:rf.error/id` (no `:where`) routes through `handle-run-error!`'s frame-bound `record-error!` path (`:rf.error/exception` at `:phase-0-setup`), NOT through `plan-error-result` (which would misroute by stamping the raw `:rf.error/id` as the assertion id).

Plus a new `story_error_test.clj` for the leaf ns: the canonical shape, the nil-throwable + explicit-message-override paths, and a drift-regression test asserting every phase's `:error` sub-map carries the identical `{:message :stack :data}` key set.

## Spec

No `spec/017` change needed: `spec/002-Runtime.md` already documents the canonical `:rf.error/exception` shape as `{:message ... :stack ... :data ...}` and states the sites "produce the same record shape via the same" mechanism — this PR makes that literally true (it was aspirational before the drift fix).

## Quality gates

| Gate | Result |
|------|--------|
| `tools/story` — `clojure -M:test` | **0 failures, 0 errors** (1311 tests / 4244 assertions) |
| `tools/story-mcp` — `clojure -M:test` | **0 failures, 0 errors** (172 tests / 861 assertions) |
| `tools/mcp-conformance` — `npm run test:story` (cum40) | **GREEN** (exit 0) |
| `scripts/test-fast-pr.sh` | **PASS** (core JVM 795/3516, JS harness helpers, CLJS node 4866/15934 — all 0/0) |

**Do NOT merge** (per dispatch instructions).