### PR TITLE
fix(story): tail-cleanup cluster — frame-keyed report-once + load-bearing test coverage (rf2-ilatz + rf2-oy4c9 + rf2-x0t0n + rf2-8e2nd)

### DIFF
--- a/tools/story/src/re_frame/story/invariants.cljc
+++ b/tools/story/src/re_frame/story/invariants.cljc
@@ -313,16 +313,30 @@
 ;; report-once / exception-isolation logic is itself testable.
 ;;
 ;; report-once policy: a violation is reported at most ONCE per
-;; (invariant, epoch-id) pair (spec/017 §A1 "exactly once per failing
-;; epoch"). The listener threads a `seen` set of `[invariant-id epoch-id]`
-;; tuples through an atom so a re-fire of the same record (a back-filled
-;; render re-notify, rf2-qs6dl) does not double-count.
+;; (invariant, frame, epoch-id) triple (spec/017 §A1 "exactly once per
+;; failing epoch"). The listener threads a `seen` set of
+;; `[invariant-id frame epoch-id]` tuples through an atom so a re-fire of
+;; the same record (a back-filled render re-notify, rf2-qs6dl) does not
+;; double-count.
+;;
+;; The `:frame` component is defensive. `with-invariants` observes EVERY
+;; frame's epochs, so report-once must be per-frame. It is collision-proof
+;; today only incidentally — epoch-ids come from a single global counter
+;; (`re-frame.epoch.state/next-epoch-id`), so `[invariant-id epoch-id]`
+;; cannot collide across frames. Should epoch-ids ever become per-frame (a
+;; plausible refactor — per-frame rings already exist), two frames could
+;; both produce epoch-id 1, and a violation in frame B's epoch 1 would be
+;; SILENTLY DROPPED under a frame-less key once frame A reported. Keying on
+;; `:frame` (already on every violation via the diagnostic spine) is
+;; equivalent today and robust under a per-frame-id world (rf2-ilatz).
 
 (defn dedup-key
   "The report-once key for a violation against an epoch: the
-  `[invariant-id epoch-id]` tuple. Pure."
+  `[invariant-id frame epoch-id]` triple. Including `:frame` keeps
+  report-once per-frame even if epoch-ids stop being globally unique
+  (rf2-ilatz). Pure."
   [violation]
-  [(:invariant violation) (:epoch-id violation)])
+  [(:invariant violation) (:frame violation) (:epoch-id violation)])
 
 (defn on-epoch!
   "The per-epoch listener step: check every `invariants` against `epoch`,
@@ -330,7 +344,7 @@
   keys + every violation into `state-atom`. Never throws — `check-all`
   isolates predicate exceptions and `report-violation!` uses `do-report`.
 
-  `state-atom` holds `{:seen #{[inv-id epoch-id] …} :violations [v …]}`.
+  `state-atom` holds `{:seen #{[inv-id frame epoch-id] …} :violations [v …]}`.
   Returns the violations reported on THIS call (for testing)."
   [state-atom invariants epoch]
   (let [violations (check-all invariants epoch)

--- a/tools/story/test/re_frame/story/invariants_test.cljc
+++ b/tools/story/test/re_frame/story/invariants_test.cljc
@@ -234,6 +234,31 @@
       (is (= 2 (count (filter #(= :fail (:type %)) reports))))
       (is (= 2 (count (:violations @state)))))))
 
+(deftest on-epoch-reports-once-per-frame-same-epoch-id
+  (testing "two frames with the SAME epoch-id each report once (dedup-key is per-frame, rf2-ilatz)"
+    ;; `with-invariants` observes EVERY frame's epochs, so report-once must
+    ;; be keyed per-frame. Epoch-ids are globally unique today (single
+    ;; global counter), but should they ever become per-frame, two frames
+    ;; could both emit epoch-id 1 — a frame-less dedup-key would SILENTLY
+    ;; DROP the second frame's violation. This asserts both frames report.
+    (let [coerced (inv/coerce-invariants [(fn [e] (pos? (:n (:db-after e))))])
+          state   (atom {:seen #{} :violations []})
+          ep-a    (epoch 1 {:frame :frame/a :db-after {:n -1}})
+          ep-b    (epoch 1 {:frame :frame/b :db-after {:n -1}})
+          reports (with-captured-reports
+                    (fn []
+                      (inv/on-epoch! state coerced ep-a)
+                      (inv/on-epoch! state coerced ep-b)
+                      ;; Re-fires of each frame's epoch must NOT re-report.
+                      (inv/on-epoch! state coerced ep-a)
+                      (inv/on-epoch! state coerced ep-b)))]
+      (is (= 2 (count (filter #(= :fail (:type %)) reports)))
+          "one :fail per frame even though both share epoch-id 1")
+      (is (= 2 (count (:violations @state))))
+      (is (= #{:frame/a :frame/b}
+             (into #{} (map :frame) (:violations @state)))
+          "the two violations come from the two distinct frames"))))
+
 (deftest on-epoch-isolates-and-reports-broken-predicate
   (testing "a throwing predicate reports a :fail and never escapes on-epoch!"
     (let [coerced (inv/coerce-invariants [(fn [_] (throw (ex-info "boom" {})))])

--- a/tools/story/test/re_frame/story/plan_network_test.cljc
+++ b/tools/story/test/re_frame/story/plan_network_test.cljc
@@ -152,6 +152,35 @@
                 :analytics/track :analytics/noop-stub}
                (get-in p [:world :frame :fx-overrides])))))))
 
+(deftest network-and-composed-fragment-managed-fx-override-conflict-fails
+  (testing ":network + a COMPOSED FRAGMENT's :fx-overrides on :rf.http/managed
+            is the same hard conflict as a direct author override (rf2-x0t0n).
+
+            check-network-fx-conflict! runs against ctx-fx =
+            (merge composed-fx (:fx-overrides ctx)) (plan.cljc:1238/1250), so a
+            fragment contributing :rf.http/managed (landing in composed-fx)
+            collides with the variant's :network exactly as a direct override
+            would. The DIRECT path is covered above; this exercises the
+            compose branch so a future refactor of the strict-conflict merge
+            cannot silently regress it."
+    (let [fragments {:fragment.http/managed-override
+                     {:fx-overrides {:rf.http/managed :some/fragment-stub}}}
+          variants  {:story.checkout/compose-conflict
+                     {:network {cart-route {:reply {:ok {:items []}}}}
+                      :compose [:fragment.http/managed-override]}}
+          compile   #(plan/variant-plan :story.checkout/compose-conflict
+                                        {:lookup          variants
+                                         :fragment-lookup fragments})]
+      (is (thrown-with-msg?
+            #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
+            #"story-network-fx-conflict"
+            (compile)))
+      (let [data (try (compile)
+                      (catch #?(:clj Exception :cljs :default) e (ex-data e)))]
+        (is (= :rf.error/story-network-fx-conflict (:rf.error/id data)))
+        (is (= :rf.http/managed (:fx-id data)))
+        (is (= :story.checkout/compose-conflict (:variant/id data)))))))
+
 ;; ===========================================================================
 ;; explain — per-route stubs + lowering visible
 ;; ===========================================================================

--- a/tools/story/test/re_frame/story/plan_test.cljc
+++ b/tools/story/test/re_frame/story/plan_test.cljc
@@ -61,6 +61,20 @@
       (is (= [[:dispatch [:a]]] (get-in p [:world :setup])))
       (is (= [[:dispatch [:b]]] (:script p))))))
 
+(deftest inline-map-target-without-variant-id-compiles
+  (testing "a map target with NO :variant/id is allowed (spec: :variant/id
+            optional) and compiles to a plan whose :variant/id is nil
+            (rf2-8e2nd — variant-plan reads (:variant/id target), nil when
+            absent)"
+    (let [p (plan/variant-plan {:setup  [[:dispatch [:a]]]
+                                :script [[:dispatch [:b]]]})]
+      (is (nil? (:variant/id p))
+          "the optional :variant/id resolves to nil")
+      (is (= [[:dispatch [:a]]] (get-in p [:world :setup])))
+      (is (= [[:dispatch [:b]]] (:script p)))
+      (is (= [nil] (:source-chain p))
+          "the single anonymous body is the whole source chain"))))
+
 ;; ---- args + [:arg key] substitution -------------------------------------
 
 (deftest variant-with-args-compiles
@@ -257,6 +271,21 @@
           p (plan-of :story.r/d m)]
       (is (contains? (:required-runner p) :dom))
       (is (contains? (:required-runner p) :app-db)))))
+
+(deftest dom-setup-step-requires-dom-token
+  (testing "a DOM SETUP step alone lifts the required-runner to include :dom
+            — isolating the setup contribution (rf2-8e2nd). The script is
+            DOM-free and there are NO DOM assertions, so :dom can ONLY have
+            come from the [:click …] step in :setup (requirements walks
+            `(map step-tokens setup)`)."
+    (let [m {:story.r/ds
+             {:setup  [[:click "[data-test=open]"]]
+              :script [[:dispatch [:a]]]}}
+          p (plan-of :story.r/ds m)]
+      (is (contains? (:required-runner p) :dom)
+          ":dom is contributed by the setup step alone")
+      (is (contains? (:required-runner p) :app-db)
+          "the DOM-free :dispatch script still contributes :app-db"))))
 
 ;; ---- explain -------------------------------------------------------------
 

--- a/tools/story/test/re_frame/story_runtime_test.clj
+++ b/tools/story/test/re_frame/story_runtime_test.clj
@@ -391,6 +391,44 @@
                  :content-hash)]
       (is (not= hd hl)))))
 
+(deftest snapshot-identity-distinct-modes-same-args
+  (testing "two DISTINCT modes registering IDENTICAL args still produce
+            DIFFERENT snapshot hashes — proving the top-level :active-modes
+            slot is load-bearing, not vacuously covered by :effective-args
+            (rf2-oy4c9 / guards the rf2-z86vu 'do not simplify away' slot).
+            Contrast snapshot-identity-changes-with-mode, whose two modes
+            carry DIFFERENT args, so its hash difference is explained by
+            :effective-args alone and survives deleting :active-modes."
+    (story/reg-story :story.id-mode-same
+      {:component :app/v :args {:theme :light}})
+    ;; Two distinct mode IDS with byte-for-byte IDENTICAL :args.
+    (story/reg-mode :Mode.app/a {:args {:theme :dark}})
+    (story/reg-mode :Mode.app/b {:args {:theme :dark}})
+    (story/reg-variant :story.id-mode-same/v {:events []})
+    (let [args-a (args/resolve-args :story.id-mode-same/v
+                                    {:active-modes [:Mode.app/a]})
+          args-b (args/resolve-args :story.id-mode-same/v
+                                    {:active-modes [:Mode.app/b]})
+          ha (-> (story/snapshot-identity :story.id-mode-same/v
+                                          {:active-modes [:Mode.app/a]})
+                 :content-hash)
+          hb (-> (story/snapshot-identity :story.id-mode-same/v
+                                          {:active-modes [:Mode.app/b]})
+                 :content-hash)]
+      ;; Precondition: the args path CANNOT explain the difference.
+      (is (= args-a args-b)
+          "the two modes resolve identical :effective-args")
+      ;; The whole point: the mode id set IS identity-bearing. This fails
+      ;; if the :active-modes top-level slot is removed from snapshot-tuple.
+      (is (not= ha hb)
+          "distinct modes with identical args still hash differently")
+      ;; Direct slot witness — the snapshot-tuple keeps the mode-id set.
+      (is (not= (:active-modes (ident/snapshot-tuple :story.id-mode-same/v
+                                                     {:active-modes [:Mode.app/a]}))
+                (:active-modes (ident/snapshot-tuple :story.id-mode-same/v
+                                                     {:active-modes [:Mode.app/b]})))
+          "the :active-modes slot distinguishes the two contexts"))))
+
 (deftest snapshot-identity-changes-with-substrate
   (testing "different substrate produces different hash"
     (story/reg-story :story.id-sub


### PR DESCRIPTION
Four disjoint tail-cleanup fixes (one PR), all in `tools/story`. No production behaviour change beyond the defensive dedup-key; the rest is test-coverage that locks documented-but-vacuously-covered invariants.

## Fixes

### rf2-ilatz (P3, `invariants.cljc`) — frame-key the report-once dedup
The report-once `dedup-key` was `[invariant-id epoch-id]` — correct ONLY because epoch-ids come from a single global counter (`re-frame.epoch.state/next-epoch-id`). `with-invariants` observes EVERY frame's epochs, so report-once must be per-frame. Should epoch-ids ever become per-frame (a plausible refactor — per-frame rings already exist), two frames could both emit epoch-id 1, and a violation in frame B's epoch 1 would be SILENTLY DROPPED under the frame-less key once frame A reported.
- dedup-key is now `[invariant-id frame epoch-id]` (`:frame` already rides every violation via the diagnostic spine — equivalent today, collision-proof under a per-frame-id world).
- New test `on-epoch-reports-once-per-frame-same-epoch-id`: two frames sharing epoch-id 1 each report exactly once (fails under the old frame-less key).

### rf2-oy4c9 (P4 test, `story_runtime_test.clj`) — prove `:active-modes` is load-bearing
`snapshot-identity-changes-with-mode` compared two modes with DIFFERENT args, so the hash difference was fully explained by `:effective-args` — the test passed even if the top-level `:active-modes` slot (explicitly marked "do not simplify away", rf2-z86vu) were deleted.
- New test `snapshot-identity-distinct-modes-same-args`: two distinct modes registering IDENTICAL args. Asserts equal `:effective-args` (precondition: the args path cannot explain the difference) yet distinct `:content-hash`, plus a direct `snapshot-tuple` `:active-modes` slot witness. Deleting the slot now fails the test.

### rf2-x0t0n (P4 test, `plan_network_test.cljc`) — compose-path network conflict
The existing `:network` vs `:rf.http/managed` conflict test covered only the DIRECT author override. `check-network-fx-conflict!` runs against `ctx-fx = (merge composed-fx (:fx-overrides ctx))`, so a composed FRAGMENT supplying `:rf.http/managed` (landing in `composed-fx`) collides exactly like a direct override — correct-by-reading but untested.
- New test `network-and-composed-fragment-managed-fx-override-conflict-fails`: a variant `:compose`s a fragment whose `:fx-overrides` sets `:rf.http/managed` while authoring `:network`; asserts `:rf.error/story-network-fx-conflict`.

### rf2-8e2nd (P4 test, `plan_test.cljc`) — setup-runner + nil-id coverage
- New test `dom-setup-step-requires-dom-token`: a DOM `[:click …]` in `:setup` alone lifts `:required-runner` to include `:dom`, with a DOM-free script and no DOM assertions, so the setup contribution is isolated (targets the live `requirements/plan-required-runner` path).
- New test `inline-map-target-without-variant-id-compiles`: a map target with no `:variant/id` (spec: optional) compiles to a plan with `:variant/id nil` and the anonymous body as the whole source-chain.

## Quality gates
- `tools/story` `clojure -M:test` — **1308 tests, 4232 assertions, 0 failures, 0 errors**
- `tools/story-mcp` `clojure -M:test` — **172 tests, 861 assertions, 0 failures, 0 errors**
- `tools/mcp-conformance` `npm run test:story` — **GREEN (exit 0)**
- `scripts/test-fast-pr.sh` — core JVM (795 tests, 0 failures) + JS harness helpers all pass; CLJS node integration (4866 tests, 15934 assertions, 0 failures, 0 errors) green