### PR TITLE
refactor(story): lift auto-runnable-plays filter + thread render :error plan slots (rf2-4gw9p + rf2-jh42p)

### DIFF
--- a/tools/story/src/re_frame/story/play/runner.cljc
+++ b/tools/story/src/re_frame/story/play/runner.cljc
@@ -415,6 +415,24 @@
   [plays]
   (boolean (and (vector? plays) (> (count plays) 1))))
 
+(defn auto-runnable?
+  "True iff a single play auto-runs: it declares `:auto-run? true` AND
+  carries a non-empty `:script`. The empty-script guard keeps a play
+  that opts in but has nothing to do from spuriously firing. Pure data
+  → data."
+  [play]
+  (boolean (and (:auto-run? play) (seq (:script play)))))
+
+(defn auto-runnable-plays
+  "The subset of `plays` that auto-run on mount — those passing
+  `auto-runnable?`. This is the SINGLE definition of 'which plays
+  auto-run'; both the runtime orchestrator (`runtime/run-phase-4!`) and
+  the shell driver (`runner-events/auto-run!`) delegate here so the rule
+  lives in one place. Returns a vector (order-preserving). Pure data →
+  data."
+  [plays]
+  (filterv auto-runnable? plays))
+
 ;; ---- run-state state machine ---------------------------------------------
 
 (def ^:const status-idle       :idle)

--- a/tools/story/src/re_frame/story/play/runner_events.cljc
+++ b/tools/story/src/re_frame/story/play/runner_events.cljc
@@ -1004,9 +1004,7 @@
   ([variant-id done-cb]
    (when config/enabled?
      (let [plays      (variant-plays variant-id)
-           auto-plays (filterv (fn [p] (and (:auto-run? p)
-                                            (seq (:script p))))
-                               plays)]
+           auto-plays (runner/auto-runnable-plays plays)]
        (cond
          (empty? auto-plays)
          nil

--- a/tools/story/src/re_frame/story/render.cljc
+++ b/tools/story/src/re_frame/story/render.cljc
@@ -285,11 +285,24 @@
   rf2-9kpsq — the `:error` sub-map is the shared
   `re-frame.story.error/throwable->error-map` projection (was a drifted
   copy that dropped `:stack`; consolidation restores the canonical
-  `{:message :stack :data}` shape)."
-  [target e]
-  {:status :error
-   :frame  (when (keyword? target) target)
-   :error  (story-error/throwable->error-map e)})
+  `{:message :stack :data}` shape).
+
+  rf2-jh42p — when the throw happened AFTER `prepare-render` succeeded
+  (the host render fn threw), the prepared `:plan` / `:plan-hash` /
+  `:effective-args` already exist, so thread them onto the result to match
+  the documented shape (spec/017 §Args — P1 render API: those slots are
+  always present once prepared). The `:frame` slot prefers the prepared
+  frame id (an inline-map target has no keyword frame, but the plan still
+  resolved one) and falls back to the keyword target. When `prepared` is
+  nil (plan CONSTRUCTION threw — no plan exists), only `:frame` + `:error`
+  carry, as before."
+  ([target e] (error-result target e nil))
+  ([target e prepared]
+   (cond-> {:status :error
+            :frame  (or (:frame prepared) (when (keyword? target) target))
+            :error  (story-error/throwable->error-map e)}
+     prepared (merge (select-keys prepared
+                                  [:plan :plan-hash :effective-args])))))
 
 (defn render-variant
   "Render `target`'s active workshop view from its normalized variant plan
@@ -344,8 +357,11 @@
                  (-> (select-keys prepared
                                   [:plan :plan-hash :frame :effective-args :validation])
                      (assoc :status :rendered :rendered rendered)))
+               ;; Host render threw — `prepared` already carries
+               ;; :plan/:plan-hash/:effective-args, so thread them onto the
+               ;; :error result (rf2-jh42p) rather than dropping the context.
                (catch #?(:clj Throwable :cljs :default) e
-                 (error-result target e)))
+                 (error-result target e prepared)))
              ;; No host render hook (the bare JVM / a pre-boot CLJS build):
              ;; the render-prep is complete, but nothing can paint the view.
              (cannot-run-result prepared :no-render-host))

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -625,9 +625,7 @@
   (if-not loaders-complete?
     [ctx (async/resolved (read-assertions variant-id))]
     (let [plays      (get-in plan [:world :scripts] [])
-          auto-plays (filterv (fn [p] (and (:auto-run? p)
-                                            (seq (:script p))))
-                              plays)
+          auto-plays (runner/auto-runnable-plays plays)
           ;; The folded steps the auto-plays ran, concatenated in order —
           ;; the script the unified result's two-level narrative spans.
           executed   (vec (mapcat :script auto-plays))

--- a/tools/story/test/re_frame/story/play/runner_test.cljc
+++ b/tools/story/test/re_frame/story/play/runner_test.cljc
@@ -574,6 +574,35 @@
   (is (false? (runner/multi? [{:name "one"}])))
   (is (true?  (runner/multi? [{:name "one"} {:name "two"}]))))
 
+(deftest auto-runnable?-predicate
+  ;; rf2-jh42p sibling rf2-4gw9p: the ONE definition of "this play
+  ;; auto-runs" — :auto-run? true AND a non-empty :script.
+  (testing "auto-run? true + non-empty script → runnable"
+    (is (true? (runner/auto-runnable? {:auto-run? true :script [[:dispatch [:a]]]}))))
+  (testing ":auto-run? false → not runnable, even with a script"
+    (is (false? (runner/auto-runnable? {:auto-run? false :script [[:dispatch [:a]]]}))))
+  (testing "empty / missing :script → not runnable, even when opted in"
+    (is (false? (runner/auto-runnable? {:auto-run? true :script []})))
+    (is (false? (runner/auto-runnable? {:auto-run? true}))))
+  (testing "missing :auto-run? → not runnable"
+    (is (false? (runner/auto-runnable? {:script [[:dispatch [:a]]]})))))
+
+(deftest auto-runnable-plays-filters-order-preserving
+  (testing "the shared filter both runtime/run-phase-4! and
+            runner-events/auto-run! delegate to (rf2-4gw9p) keeps only the
+            auto-run? + non-empty-script plays, in order"
+    (let [plays [{:name "a" :auto-run? true  :script [[:dispatch [:a]]]}
+                 {:name "b" :auto-run? false :script [[:dispatch [:b]]]}
+                 {:name "c" :auto-run? true  :script []}
+                 {:name "d" :auto-run? true  :script [[:dispatch [:d]]]}]]
+      (is (= ["a" "d"] (mapv :name (runner/auto-runnable-plays plays))))
+      (testing "result is a vector (filterv), matching both call sites"
+        (is (vector? (runner/auto-runnable-plays plays))))))
+  (testing "no auto-run plays → empty vector"
+    (is (= [] (runner/auto-runnable-plays
+                [{:name "x" :auto-run? false :script [[:dispatch [:x]]]}])))
+    (is (= [] (runner/auto-runnable-plays [])))))
+
 (deftest play-key-extraction
   (is (= "p" (runner/play-key {:name "p"})))
   (is (nil?  (runner/play-key {:name nil})))

--- a/tools/story/test/re_frame/story/render_test.cljc
+++ b/tools/story/test/re_frame/story/render_test.cljc
@@ -275,12 +275,42 @@
       (is (= :error (:status r)))
       (is (= :test/boom (get-in r [:error :data :rf.error/id]))))))
 
+(deftest render-variant-host-throw-carries-prepared-slots
+  ;; rf2-jh42p — on the host-render-throw path, prepare-render already
+  ;; produced :plan / :plan-hash / :effective-args, so the :error result
+  ;; MUST thread them onto the documented shape rather than dropping them.
+  ;; Pre-fix these slots are absent (this test fails); post-fix they ride.
+  (testing "a host-render throw projects to :error WITH the prepared plan
+            context (spec/017 §Args — :plan/:plan-hash/:effective-args)"
+    (render/install-render-host!
+      (fn [_] (throw (ex-info "boom" {:rf.error/id :test/boom}))))
+    (let [body {:component :view.button/primary :args {:label "Go"}}
+          r    (render/render-variant
+                 :story.button/primary
+                 {:lookup {:story.button/primary body}})]
+      (is (= :error (:status r)))
+      (is (= :story.button/primary (:frame r)))
+      (is (= {:label "Go"} (:effective-args r)))
+      (is (string? (:plan-hash r)))
+      (is (map? (:plan r)))
+      (testing "the threaded :plan-hash matches the prepared plan's hash"
+        (let [prep (render/prepare-render
+                     :story.button/primary
+                     {:lookup {:story.button/primary body}})]
+          (is (= (:plan-hash prep) (:plan-hash r))))))))
+
 (deftest render-variant-unknown-variant-is-error
   (testing "an unknown keyword target throws in the compiler → :error"
     (let [r (render/render-variant :story.nope/missing {:lookup {}})]
       (is (= :error (:status r)))
       (is (= :rf.error/story-unknown-variant
-             (get-in r [:error :data :rf.error/id]))))))
+             (get-in r [:error :data :rf.error/id])))
+      (testing "plan-CONSTRUCTION throw carries no plan slots (none prepared)"
+        ;; The frame-free shape (spec/017): plan construction threw before a
+        ;; plan/effective-args existed, so only :frame + :error ride.
+        (is (not (contains? r :plan)))
+        (is (not (contains? r :plan-hash)))
+        (is (not (contains? r :effective-args)))))))
 
 ;; ===========================================================================
 ;; Inline-plan map target (§B10 — render-variant for BOTH registered +


### PR DESCRIPTION
Small code-cleanup cluster — two disjoint P4 fixes, behaviour-preserving.

## rf2-4gw9p — duplicated auto-runnable-plays filter

The "auto-runnable plays" filter (`:auto-run?` AND non-empty `:script`) was byte-identical in `runtime/run-phase-4!` (`runtime.cljc`) and `runner-events/auto-run!` (`runner_events.cljc`). Lifted to a single pure predicate pair in `re-frame.story.play.runner` — the host-free leaf ns that already hosts the parallel play predicates (`multi?`, `find-play`, `default-play-key`):

- `runner/auto-runnable?` — `:auto-run? true` AND non-empty `:script`.
- `runner/auto-runnable-plays` — order-preserving `filterv` over the above.

Both call sites now delegate (`runner/auto-runnable-plays`). No new ns; both files already `:require [re-frame.story.play.runner :as runner]`. Behaviour-identical.

## rf2-jh42p — render-variant :error dropped prepared plan slots

`render-variant`'s `:error` result omitted the documented `:plan` / `:plan-hash` / `:effective-args` slots even on the host-render-throw path, where `prepare-render` had already produced them. `error-result` now takes an optional `prepared` map and threads `:plan` / `:plan-hash` / `:effective-args` (and prefers the prepared `:frame`) onto the result, matching the documented shape (spec/017 §Args — P1 render API). The host-throw catch passes `prepared`; the outer plan-CONSTRUCTION catch passes nothing (no plan exists there → still `:frame` + `:error` only).

Spec note deferred to doc-sweep (spec/017 surface is held for the mayor's ba86n.1 work).

## Tests

- `runner_test`: `auto-runnable?-predicate` + `auto-runnable-plays-filters-order-preserving` pin the shared rule and the order-preserving `filterv` shape both call sites depend on.
- `render_test`: `render-variant-host-throw-carries-prepared-slots` asserts the `:error` result carries `:plan`/`:plan-hash`/`:effective-args` on the host-throw path (verified fails-pre with 4 nil-slot assertions against `origin/main` source, passes-post). The `unknown-variant` test is extended to pin the no-plan-slots shape on the plan-construction-throw path.

## Quality gates

- `tools/story` `clojure -M:test` — 1319 tests, 4281 assertions, 0 failures / 0 errors
- `tools/story-mcp` `clojure -M:test` — 172 tests, 861 assertions, 0 failures / 0 errors
- `tools/mcp-conformance` `npm run test:story` — GREEN (13 OK checks, exit 0)
- `bash scripts/test-fast-pr.sh` — PASS (4866 tests, 15934 assertions, 0 failures / 0 errors)
