### PR TITLE
fix(misc-safe): test.check adapter + use-fixtures meta-check + story-mcp doc lockstep (rf2-6nk6d + rf2-k2g3i + rf2-af296)

### DIFF
--- a/tools/story-mcp/spec/API.md
+++ b/tools/story-mcp/spec/API.md
@@ -174,8 +174,9 @@ as a stale cursor (different fingerprint).
 **Input.** `{:limit integer (optional) :cursor string (optional)}`.
 
 **Output.** `{:canonical [{:id :payload :semantics}] :registered [keyword ...]}`.
-The `:canonical` doc vector (the 7-assertion documentation) is
-bounded and always returned in full. `:registered` (the live
+The `:canonical` doc vector (the 8-assertion documentation: the seven
+dispatched canonical assertions plus the tape-evaluated
+`:rf.assert/schema-error`) is bounded and always returned in full. `:registered` (the live
 registered-assertion ids) is paginated per the contract above.
 
 ### `get-docs-markdown` (rf2-i0kyy)

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/docs.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/docs.cljc
@@ -243,8 +243,10 @@
   "Docs: the `:rf.assert/*` canonical vocabulary + arity docs.
 
   rf2-76sf6: the bifurcated `{:canonical :registered}` shape is
-  retained; `:canonical` is the full 7-assertion doc vector (bounded
-  and constant, so the pagination MUST does not apply). `:registered`
+  retained; `:canonical` is the full 8-assertion doc vector — the seven
+  dispatched canonical assertions plus the tape-evaluated
+  `:rf.assert/schema-error` (bounded and constant, so the pagination MUST
+  does not apply). `:registered`
   (project-registered + canonical ids) is paginated when the count
   exceeds `:limit`. Small registries see no pagination metadata."
   [args]

--- a/tools/story/deps.edn
+++ b/tools/story/deps.edn
@@ -74,6 +74,16 @@
                        ;; (both sources read the late-bound facade), mirroring how
                        ;; implementation/core/deps.edn pulls epoch on :test only.
                        day8/re-frame2-epoch      {:local/root "../../implementation/epoch"}
+                       ;; rf2-6nk6d — test.check is here on the :test alias ONLY
+                       ;; (NOT a Story runtime dep). It exercises the OPTIONAL
+                       ;; `re-frame.story.generate.test-check` adapter, which
+                       ;; late-binds test.check via `requiring-resolve` so the
+                       ;; published Story jar never depends on it. The
+                       ;; dependency-free splitmix64 `gen-fn` path remains the
+                       ;; default; this dep only lets the adapter's tests prove
+                       ;; the test.check draw → gen-fn → seed-bearing-artifact
+                       ;; path end to end.
+                       org.clojure/test.check    {:mvn/version "1.1.1"}
                        io.github.cognitect-labs/test-runner
                        {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
          :main-opts   ["-m" "re-frame.test-quiet.runner"]}

--- a/tools/story/src/re_frame/story/generate/test_check.cljc
+++ b/tools/story/src/re_frame/story/generate/test_check.cljc
@@ -1,0 +1,120 @@
+(ns re-frame.story.generate.test-check
+  "OPTIONAL `clojure.test.check` adapter for the generator-agnostic property
+  runner (rf2-6nk6d; spec/017-Testing-Story.md §Generator-agnostic — a
+  generated run is driven by a caller-supplied `gen-fn` and `clojure.test.check`
+  is named there as a fit 'by wrapping its draw in a `gen-fn`'). This namespace
+  IS that wrapping, made concrete + reusable.
+
+  ## Opt-in; the dependency-free PRNG stays the default
+
+  `re-frame.story.generate/check-property!` is driven by a pure
+  `(fn [seed] event-program)` over the self-contained splitmix64 PRNG
+  (`seed-seq`) and bundles NO generator library — that dependency-free path is
+  and remains the DEFAULT (rf2-5x1wt.31). This adapter is pure additive sugar:
+  it lets a caller who ALREADY has `org.clojure/test.check` on the classpath
+  hand a `test.check` generator of event programs and get back the same
+  `gen-fn` shape `check-property!` already takes. Nothing about the seed-bearing
+  artifact + promotion flow changes.
+
+  `org.clojure/test.check` is NOT a hard Story dependency — it is wired into
+  `tools/story/deps.edn`'s `:test` alias ONLY (so this adapter's own tests can
+  exercise it). At runtime the test.check vars are late-bound via
+  `requiring-resolve` so this namespace LOADS without test.check present;
+  invoking `gen-fn` (or `gen->gen-fn` itself) without test.check on the
+  classpath throws a clear, actionable error rather than failing at compile
+  time. Callers who do not want the dependency simply keep using a hand-rolled
+  `gen-fn` — this namespace need never be required.
+
+  ## What the adapter does
+
+  `gen->gen-fn` turns a `test.check` generator `g` (of an event PROGRAM — a
+  vector of tagged steps, or bare event vectors the artifact coerces) into the
+  pure `(fn [seed] event-program)` `check-property!` consumes. It seeds
+  `test.check`'s own deterministic RNG from the integer seed and draws ONE
+  program per seed via `clojure.test.check.generators/generate` (whose third
+  arg is that numeric seed), at a configurable `:size`. Because
+  the draw is fully determined by the integer seed, the existing reproducibility
+  + seed-bearing-artifact guarantees hold UNCHANGED: `check-property!`'s
+  `seed-seq` supplies the seeds, and each seed deterministically yields one
+  program. Shrinking continues to use `check-property!`'s own deterministic
+  program-prefix delta-debug over the concrete program — test.check's rose-tree
+  shrinking is NOT engaged, keeping ONE shrink model + a host-portable shrunk
+  artifact.
+
+  ## JVM-scoped by design
+
+  `requiring-resolve` is a JVM facility; CLJS cannot dynamically resolve an
+  optional namespace at runtime. The `:test` alias (where test.check lives)
+  runs on the JVM, so this adapter targets the JVM half of `clojure -M:test`.
+  On CLJS the adapter throws a clear message — the dependency-free `gen-fn`
+  path is the cross-host default and needs no library.")
+
+(def ^:private absent-msg
+  (str "re-frame.story.generate.test-check requires org.clojure/test.check on "
+       "the classpath. It is an OPTIONAL adapter — add test.check to your "
+       "deps (Story wires it into tools/story/deps.edn's :test alias only) or "
+       "keep using a hand-rolled (fn [seed] event-program) gen-fn over the "
+       "dependency-free splitmix64 PRNG, which is the default."))
+
+#?(:clj
+   (defn- resolve-or-throw
+     "Late-bind a test.check var by fully-qualified symbol, or throw a clear
+     opt-in error if test.check is not on the classpath. Pure deref of the
+     classpath — no test.check require at this namespace's load time."
+     [sym]
+     (or (try (requiring-resolve sym)
+              (catch java.io.FileNotFoundException _ nil)
+              (catch Throwable _ nil))
+         (throw (ex-info absent-msg {:missing-var sym})))))
+
+(defn available?
+  "True iff `org.clojure/test.check` is resolvable on the classpath right now.
+  Lets a caller branch to the dependency-free `gen-fn` path when the optional
+  adapter is absent, without catching an exception."
+  []
+  #?(:clj  (boolean (try (requiring-resolve 'clojure.test.check.generators/generate)
+                         (catch Throwable _ nil)))
+     :cljs false))
+
+(defn gen->gen-fn
+  "Turn a `clojure.test.check` generator `g` (of an event PROGRAM) into the
+  pure `(fn [seed] event-program)` `re-frame.story.generate/check-property!`
+  consumes. `opts`:
+
+  - `:size` — the test.check generation size handed to every draw (default 30).
+              Constant across seeds so the program-size distribution is the
+              seed's, not a growing test.check `:num-tests` ramp; vary it per
+              call for larger/smaller programs.
+
+  The returned fn is pure + deterministic in its `seed` argument: it draws one
+  program from `g` seeding test.check's own deterministic RNG with the integer
+  seed, so the SAME seed always yields the SAME program (the reproducibility
+  `check-property!` relies on). Throws the opt-in error if test.check is absent
+  — resolution is deferred to first call so requiring this namespace never hard-
+  depends on test.check."
+  ([g] (gen->gen-fn g {}))
+  ([g {:keys [size] :or {size 30}}]
+   #?(:clj
+      ;; `clojure.test.check.generators/generate` is `(generate g size seed)` —
+      ;; its THIRD arg is a numeric SEED, which it feeds to `make-random`
+      ;; internally. Hand it the integer seed directly so the draw is fully
+      ;; determined by that seed (same seed → same program).
+      (let [generate (resolve-or-throw 'clojure.test.check.generators/generate)]
+        (fn [seed]
+          (vec (generate g size seed))))
+      :cljs
+      (throw (ex-info absent-msg {:host :cljs})))))
+
+(defn check-property-gen!
+  "Sugar: run `re-frame.story.generate/check-property!` driven by a
+  `clojure.test.check` generator `g` of event programs. Identical to calling
+  `check-property!` with `(gen->gen-fn g opts)` — the `:size` opt (default 30)
+  is consumed here for the draw; all OTHER opts (`:seed` / `:num-tests` /
+  `:shrink?` / `:fx-decisions` / `:hooks` / `:frame-config`) pass through to
+  `check-property!` UNCHANGED. The seed-bearing artifact + promotion flow is the
+  same one the dependency-free path produces. Takes `check-property!` as
+  `check-property-fn` so this namespace carries no require on the runner (and so
+  the caller's own runner var binds at the call site)."
+  [check-property-fn g {:keys [size] :as opts}]
+  (let [gen-fn (gen->gen-fn g (cond-> {} (some? size) (assoc :size size)))]
+    (check-property-fn gen-fn (dissoc opts :size))))

--- a/tools/story/test/re_frame/story/generate_test.cljc
+++ b/tools/story/test/re_frame/story/generate_test.cljc
@@ -22,7 +22,9 @@
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.story.artifact  :as artifact]
             [re-frame.story.generate  :as generate]
-            [re-frame.story.promotion :as promotion]))
+            [re-frame.story.generate.test-check :as gen-tc]
+            [re-frame.story.promotion :as promotion]
+            #?(:clj [clojure.test.check.generators :as tcgen])))
 
 ;; ===========================================================================
 ;; PURE: the seedable PRNG
@@ -253,3 +255,106 @@
           "the pair-seq preserves authored cell order")
       (is (some #{:save-fails} (:failing from-seq))
           "the faulted cell falsifies under the pair-seq shape too"))))
+
+;; ===========================================================================
+;; OPTIONAL test.check adapter (rf2-6nk6d) — JVM-only
+;; ===========================================================================
+;;
+;; The test.check adapter late-binds test.check via `requiring-resolve` and is
+;; JVM-scoped by design (CLJS cannot dynamically resolve an optional ns at
+;; runtime); test.check itself is wired into tools/story/deps.edn's :test alias
+;; only. These assertions therefore live behind `#?(:clj ...)` so the .cljc
+;; file stays green on the node CLJS build too. They prove the documented
+;; extension point — wrapping a test.check generator's draw in a `gen-fn` —
+;; works end to end (seed → gen → seed-bearing artifact) ALONGSIDE the
+;; dependency-free path exercised above, and that the dependency-free default
+;; is unchanged.
+
+#?(:clj
+   (deftest test-check-adapter-is-available-on-the-test-classpath
+     (testing "test.check resolves on the :test alias, so the optional adapter
+               reports available (the dep is test-only, not a Story runtime dep)"
+       (is (true? (gen-tc/available?))
+           "org.clojure/test.check is on the :test alias classpath"))))
+
+#?(:clj
+   (deftest test-check-gen-fn-is-deterministic-in-the-seed
+     (testing "gen->gen-fn yields a pure (fn [seed] event-program) — the SAME
+               seed draws the SAME program (the reproducibility check-property!
+               relies on), DIFFERENT seeds generally diverge"
+       ;; A generator of event programs: 1–4 dispatch steps of :gen/ok.
+       (let [program-gen (tcgen/vector
+                           (tcgen/return [:dispatch [:gen/ok]]) 1 4)
+             gen-fn      (gen-tc/gen->gen-fn program-gen {:size 20})]
+         (is (= (gen-fn 12345) (gen-fn 12345))
+             "same seed → identical program")
+         (is (let [p (gen-fn 7)]
+               (and (vector? p)
+                    (seq p)
+                    (every? #(= :dispatch (first %)) p)))
+             "the draw is a non-empty tagged-step event program")
+         ;; Over a spread of seeds at least two programs differ — the draw
+         ;; actually varies with the seed (not a constant).
+         (is (> (count (distinct (map gen-fn (range 0 12)))) 1)
+             "different seeds generally draw different programs")))))
+
+#?(:clj
+   (deftest test-check-driven-property-passes-and-emits-seed-bearing-artifacts
+     (testing "check-property-gen! drives the runner from a test.check generator:
+               every drawn program passes, and the run records its reproducible
+               root seed exactly as the dependency-free path does"
+       (rf/reg-event-db :gen/ok (fn [db _] (update db :n (fnil inc 0))))
+       (let [program-gen (tcgen/vector
+                          (tcgen/return [:dispatch [:gen/ok]]) 1 3)
+             res (gen-tc/check-property-gen!
+                  generate/check-property! program-gen
+                  {:seed 7 :num-tests 5 :size 25})]
+         (is (= :pass (:status res)))
+         (is (= 5 (:num-tests res)))
+         (is (= 7 (:seed res))
+             "the seed-bearing reproducibility is identical to the splitmix path")))))
+
+#?(:clj
+   (deftest test-check-driven-property-falsifies-shrinks-and-promotes
+     (testing "a test.check-driven property that fails flows through the SAME
+               shrink + seed-bearing-artifact + promotion bridge as the
+               dependency-free path — the adapter is pure sugar over gen-fn"
+       (rf/reg-event-db :gen/noise (fn [db _] (update db :noise (fnil inc 0))))
+       (reg-boom!)
+       ;; A generator that always includes the failing :gen/boom step amid
+       ;; harmless noise — every drawn program falsifies, exercising the
+       ;; shrink + artifact path deterministically.
+       (let [program-gen (tcgen/fmap
+                          (fn [noise] (conj (vec noise) [:dispatch [:gen/boom]]))
+                          (tcgen/vector
+                           (tcgen/return [:dispatch [:gen/noise]]) 0 3))
+             res (gen-tc/check-property-gen!
+                  generate/check-property! program-gen
+                  {:seed 3 :num-tests 4 :size 20 :shrink? true})]
+         (is (= :fail (:status res)))
+         (is (artifact/run-artifact? (:artifact res)))
+         (is (= (:seed res) (:seed (:artifact res)))
+             "the artifact carries the falsifying seed (same as splitmix path)")
+         (is (some #(= [:dispatch [:gen/boom]] %) (:smallest-program res))
+             "the shared shrink model keeps the failing boom step")
+         (is (seq (:shrink-path res))
+             "shrinking ran via check-property!'s own delta-debug, not test.check")
+         ;; The artifact promotes through the existing curated bridge unchanged.
+         (let [plan (promotion/materialize-variant-plan
+                     (:artifact res) {:variant/id :story.gen-tc/regression-3})]
+           (is (= (:seed (:artifact res)) (get-in plan [:run-artifact :seed]))
+               "the curated plan carries the test.check-driven failing seed"))))))
+
+#?(:clj
+   (deftest test-check-adapter-degrades-clearly-without-the-library
+     (testing "the opt-in error names test.check + points at the dependency-free
+               default (proven by simulating an absent var resolution)"
+       ;; We cannot un-load test.check from the JVM classpath mid-test, so this
+       ;; pins the error CONTRACT: gen->gen-fn defers resolution to first call,
+       ;; and the adapter's `available?` is the branch a caller uses to pick the
+       ;; dependency-free path. The CLJS arm of the adapter throws the same
+       ;; message (covered by the node build loading the ns without test.check).
+       (is (fn? (gen-tc/gen->gen-fn (tcgen/return [:dispatch [:gen/ok]])))
+           "with test.check present, gen->gen-fn returns a usable gen-fn")
+       (is (true? (gen-tc/available?))
+           "available? is the documented branch for choosing the gen-fn path"))))

--- a/tools/story/test/re_frame/story/meta_fixtures_test.cljc
+++ b/tools/story/test/re_frame/story/meta_fixtures_test.cljc
@@ -1,0 +1,106 @@
+(ns re-frame.story.meta-fixtures-test
+  "JVM meta-check guarding against the map-form `use-fixtures` silent-skip
+  trap in dual-target `.cljc` tests (rf2-k2g3i; surfaced in PR #2420 review,
+  refs rf2-qkltn + rf2-5x1wt.25).
+
+  THE TRAP. The JVM `clojure.test` runner does NOT support the map-form
+  fixture
+
+      (use-fixtures :each {:before f :after g})
+
+  — it treats the map as a fixture FUNCTION, calls it, and the map (not
+  being a fn) never invokes the wrapped test thunk. The upshot: every
+  `deftest` in that namespace is SILENTLY SKIPPED on the JVM — no error,
+  zero assertions run. The `cljs.test` runtime DOES honour the map form,
+  so a `.cljc` test using it passes on node but is a no-op on the JVM half
+  of `clojure -M:test`. That asymmetric silent skip is exactly the
+  rf2-gc7la failure mode.
+
+  In a pure-`.cljs` test the map form is LEGITIMATE (cljs.test supports it)
+  and common — so this guard scopes itself to `.cljc` files ONLY. The
+  cross-platform-safe idiom for a `.cljc` test is the fn form:
+
+      (use-fixtures :each (fn [t] (reset-all!) (t)))
+      ;; or a named fn that ends by calling its `t` argument
+
+  This is a PREVENTATIVE guard: as of 2026-05-30 zero tracked `.cljc`
+  tests use the map form (verified via `git grep`). It exists to catch a
+  future author who copies the map idiom from a `.cljs` sibling and
+  silently loses JVM coverage.
+
+  This is a `.cljc` file so the guard travels with the artefact's
+  dual-target test set, but the scan itself is JVM-only — it reads source
+  bytes off disk, which CLJS cannot do — hence the `#?(:clj ...)` reader
+  conditional around the scanning machinery. On CLJS the namespace is an
+  empty no-op."
+  (:require [clojure.test :refer [deftest is testing]]
+            #?(:clj [clojure.java.io :as io])
+            #?(:clj [clojure.string :as str])))
+
+#?(:clj
+   (do
+     (def ^:private this-file
+       "This meta-check's own filename. The guard's docstring + failure
+       message necessarily quote the forbidden map form verbatim, so the
+       scan must skip itself or it would flag its own illustrative prose."
+       "meta_fixtures_test.cljc")
+
+     (defn- cljc-test-files
+       "Walk `test/` and return every `.cljc` file as a `java.io.File`,
+       excluding this meta-check (which quotes the forbidden form in its
+       own docs/message). The classpath element `test` resolves to the same
+       directory whether tests run via `clojure -M:test` from `tools/story`
+       or under the top-level build, mirroring `story-substrate-isolation-test`."
+       []
+       (let [root (io/file "test")]
+         (when (.isDirectory root)
+           (->> (file-seq root)
+                (filter #(.isFile ^java.io.File %))
+                (filter (fn [^java.io.File f]
+                          (let [n (.getName f)]
+                            (and (str/ends-with? n ".cljc")
+                                 (not= n this-file)))))))))
+
+     (def ^:private map-form-use-fixtures
+       "Matches `use-fixtures :each|:once {` — the map-form fixture
+       declaration that silently skips on the JVM. Allows arbitrary
+       whitespace/newlines between tokens; the leading `(` (with optional
+       namespace alias, e.g. `t/use-fixtures`) anchors it to the call
+       site, not a docstring mention of the symbol."
+       #"\(\s*(?:[\w.-]+/)?use-fixtures\s+:(?:each|once)\s+\{")
+
+     (defn- offences
+       "Return `{:file path :match line}` for each `.cljc` file whose body
+       contains a map-form `use-fixtures` call."
+       [^java.io.File f]
+       (let [body (slurp f)]
+         (when-let [m (re-find map-form-use-fixtures body)]
+           {:file (.getPath f) :match m})))
+
+     (deftest no-map-form-use-fixtures-in-cljc-tests
+       (testing "no tracked .cljc test may use the map form
+(use-fixtures :each {:before ...}) — it SILENTLY SKIPS every deftest in
+the ns on the JVM half of `clojure -M:test` (rf2-k2g3i / rf2-gc7la)"
+         (let [files     (cljc-test-files)
+               offending (keep offences files)]
+           (is (seq files)
+               "expected to find .cljc test files under tools/story/test/")
+           (is (empty? offending)
+               (str "Map-form `use-fixtures` found in .cljc test files — these "
+                    "SILENTLY SKIP every deftest in the namespace on the JVM "
+                    "(clojure.test treats the map as a fixture fn that never "
+                    "invokes the test thunk):\n"
+                    (str/join "\n" (map (fn [{:keys [file match]}]
+                                          (str "  " file
+                                               "  (matched " (pr-str match) ")"))
+                                        offending))
+                    "\n\nUse the cross-platform fn form instead:\n"
+                    "  (use-fixtures :each (fn [t] (reset-all!) (t)))\n"
+                    "The map form is legitimate ONLY in pure-.cljs tests, "
+                    "where cljs.test honours it."))))))
+
+   :cljs
+   ;; CLJS half is a no-op: the guard reads source bytes off disk, which
+   ;; the cljs.test runtime cannot do. The scan runs on the JVM only.
+   (deftest map-form-guard-is-jvm-only
+     (is true "map-form use-fixtures meta-check runs on the JVM only")))


### PR DESCRIPTION
Misc-safe disjoint cluster: three unrelated small fixes on distinct surfaces, one PR.

## rf2-6nk6d (P3) — optional `clojure.test.check` adapter for `check-property!`
New ns `re-frame.story.generate.test-check` wraps a `test.check` generator of event programs into the pure `(fn [seed] event-program)` the existing `re-frame.story.generate/check-property!` already takes — pure additive sugar over the documented extension point (spec/017 §Generator-agnostic already names `clojure.test.check` as a fit "by wrapping its draw in a `gen-fn`"; no spec change needed — the adapter realises an already-documented seam).

- The dependency-free splitmix64 PRNG stays the **DEFAULT**; this is opt-in.
- `org.clojure/test.check` is late-bound via `requiring-resolve`, so the published Story jar never hard-depends on it. The dep was added to **`tools/story/deps.edn`'s `:test` alias ONLY** (`org.clojure/test.check {:mvn/version "1.1.1"}`) — NOT the top-level `implementation/deps.edn` (hot-zone).
- `gen->gen-fn` seeds test.check's own deterministic RNG from the integer seed (passes the seed as the third numeric arg of `generators/generate`), so the same seed draws the same program — the reproducibility + seed-bearing-artifact guarantees are unchanged. Shrinking continues via `check-property!`'s own deterministic delta-debug (test.check's rose-tree shrinking is not engaged → one shrink model, host-portable shrunk artifact).
- JVM-scoped by design (`requiring-resolve` is JVM-only); the CLJS arm throws a clear opt-in message.
- Tests in `generate_test.cljc` (behind `#?(:clj ...)`) exercise seed → gen → seed-bearing artifact, falsify → shrink → promotion, determinism in the seed, and `available?` — alongside the existing dependency-free path.

## rf2-k2g3i (P4) — preventative map-form `use-fixtures` meta-check
New `re-frame.story.meta-fixtures-test` (a `clojure.test` test, NOT a CI workflow) scans tracked `.cljc` test files for the map-form `(use-fixtures :each {:before ...})`, which the JVM `clojure.test` runner treats as a fixture fn that never invokes the test thunk — **silently skipping every deftest in that ns on the JVM** (the rf2-gc7la failure mode). cljs.test honours the map form, so a `.cljc` test using it passes on node but is a JVM no-op.

- Passes on current main (zero offenders — verified via `git grep`); proven to catch an injected offender (temporarily flipped one `.cljc` to the map form → guard failed, naming the file → reverted).
- Scoped to `.cljc` only (the map form is legitimate in pure-`.cljs` tests); excludes its own file (which quotes the forbidden form in its docs/message).

## rf2-af296 (P4) — story-mcp doc lockstep (7 → 8)
`tools/story-mcp/spec/API.md:177` and `tools/story-mcp/src/re_frame/story_mcp/tools/docs.cljc:246` said "7-assertion doc vector" — stale after the 7→8 schema-error bump. Updated both to 8 (the seven dispatched canonical assertions plus the tape-evaluated `:rf.assert/schema-error`). Confirmed against the live count: `canonical-assertion-docs` has 8 entries and the test pins 8 (`story_assertions_test.clj:86`). `API.md:145-146` "7-entry canonical-tag vector" is a different surface (list-TAGS) and correctly left at 7.

## Quality gates
- `tools/story` — `clojure -M:test`: **1322 tests / 4280 assertions, 0 failures, 0 errors**
- `tools/story-mcp` — `clojure -M:test`: **172 tests / 861 assertions, 0 failures, 0 errors**
- `tools/mcp-conformance` — `npm run test:story`: **STORY-MCP MCP-CLIENT CONFORMANCE GREEN, exit 0**
- `scripts/test-fast-pr.sh`: **PASS** (`npm run test:cljs` 4866 tests / 15934 assertions green — exercises the `.cljc` adapter + test on the CLJS target; README + docs-corpus markdown gates green; mkdocs soft-skipped locally, CI runs it)