### PR TITLE
fix(story): thread :network per-route reply data into the run artifact (rf2-tymyh)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -334,6 +334,7 @@ Required P1 shape:
  :seed optional
  :event-program [...]
  :fx-decisions [...]
+ :network {[method url] {:reply …}}  ; optional — per-route HTTP stubs, re-installed on replay
  :epoch-tape [...]
  :trace [...]
  :result run-result
@@ -2100,11 +2101,21 @@ hashes the whole `:world` slot. A semantic change to any per-route reply
 (success payload, failure `:kind`, status) therefore perturbs the
 `:plan-hash`; a `canonicalize`-volatile change does not.
 
-> **Deferred — run-artifact wiring.** The per-route reply data is
-> preserved in `explain`, `:plan-hash`, and (through `[:world :network]`)
-> the narrative evidence. Threading it into the low-level run artifact
-> awaits the run-artifact namespace (rf2-5x1wt.7); this section is
-> updated to wire it in once that lands.
+**Run-artifact wiring (rf2-tymyh).** The per-route reply data is
+preserved in `explain`, `:plan-hash`, (through `[:world :network]`) the
+narrative evidence, AND the low-level run artifact. When a plan is
+coerced to a `:rf.test/run-artifact` (the determinism gate / golden
+capture's `re-frame.story.determinism/->artifact`), its
+`[:world :network]` route map is carried onto the artifact's `:network`
+slot alongside the `[:world :frame :fx-overrides]` redirect on
+`:fx-decisions`. `replay-run-artifact` then **re-installs** those route
+stubs (`re-frame.core/install-managed-request-stubs!`, the same seam a
+live run uses) around the replay, so a replayed `:network` request
+matches its route and synthesises the recorded reply rather than
+fail-closing on "no stub matched". Carrying only the `:fx-decisions`
+redirect would point the replay at a stub fx registered with NO routes,
+so every replayed request would fail-closed — the `:network` artifact
+slot is what makes the round-trip succeed (§Run artifact and replay).
 
 ## Unit and integration testing adjustments
 
@@ -2442,6 +2453,7 @@ A run artifact is a map carrying:
  :seed          optional
  :event-program [step …]               ; the dispatch program (setup ⧺ script)
  :fx-decisions  {fx-id override}       ; the fx overrides reapplied on replay
+ :network       {[method url] {:reply …}} ; per-route HTTP stubs re-installed on replay
  :epoch-tape    [epoch-record …]       ; the captured tape, when retained
  :trace         [trace-event …]        ; optional flat trace
  :result        run-result             ; the projected run-result (§Run result)
@@ -2463,6 +2475,15 @@ A run artifact is a map carrying:
   per-frame frame-config `:fx-overrides` slot carry (Spec 002
   §`:fx-overrides`). Replay REAPPLIES them, so a run that stubbed an HTTP
   effect replays against the same stub rather than firing the live effect.
+- `:network` is the per-route HTTP reply map (`{[method url] {:reply …}}`,
+  §The network surface) captured from the plan's `[:world :network]` slot
+  when the artifact was materialized (rf2-tymyh). The `:network` world slot
+  lowers to a `:fx-decisions` redirect (`{:rf.http/managed
+  :rf.http/managed-test-stub}`) — but that redirect targets a stub fx that
+  is only registered WITH the routes by
+  `install-managed-request-stubs!`. So `:fx-decisions` alone is not enough:
+  replay carries `:network` to RE-INSTALL the route stubs (below), without
+  which a replayed `:network` request would fail-closed.
 
 `re-frame.story.artifact/make-run-artifact` is the **pure** constructor
 (data → data, JVM-runnable): it coerces the `:event-program`, folds
@@ -2494,6 +2515,17 @@ Replay MUST:
   for `dispatch-sync` directly; the boundary's `:cannot-run` / `:error`
   refusals fire unchanged, so a step that needs a richer boundary than the
   replay runner provides refuses rather than under-flushing.
+- **Re-install the `:network` route stubs** (when the artifact carries a
+  non-empty `:network` map) — replay calls
+  `re-frame.core/install-managed-request-stubs!` with the route map for the
+  duration of the replay (then uninstalls in a `finally`), the SAME seam a
+  live `:network` run uses. This registers `:rf.http/managed-test-stub`
+  WITH the routes, so the `:fx-decisions` redirect resolves to a stub that
+  matches each request and synthesises the recorded reply. Without this a
+  replayed `:network` request would fail-closed on "no stub matched"
+  (rf2-tymyh). The install routes through `re-frame.http-test-support`
+  (Spec 014 §Testing) and raises `:rf.error/http-artefact-missing` if that
+  namespace is absent — the same opt-in a live `:network` run requires.
 - **Capture a NEW epoch tape** — read from `re-frame.core/epoch-history`
   after the program settles, NOT the artifact's captured tape. The replay
   proves what the program does NOW.

--- a/tools/story/src/re_frame/story/artifact.cljc
+++ b/tools/story/src/re_frame/story/artifact.cljc
@@ -19,6 +19,7 @@
        :seed          optional
        :event-program [step …]        ; the dispatch program (setup ⧺ script)
        :fx-decisions  {fx-id override} ; reapplied fx overrides / decisions
+       :network       {[m url] {:reply …}} ; per-route HTTP stubs (reinstalled)
        :epoch-tape    [epoch-record …] ; the captured tape (when retained)
        :trace         [trace-event …]  ; optional flat trace
        :result        run-result       ; the projected run-result
@@ -41,11 +42,25 @@
   stubbed `:http/get` replays against the same stub rather than hitting a
   live effect.
 
+  `:network` is the serializable record of the variant's per-route HTTP
+  reply data (`{[method url] {:reply …}}`, spec/017 §The network surface),
+  captured from the plan's `[:world :network]` slot at materialize time.
+  The `:network` world slot LOWERS to a `:fx-decisions` redirect
+  (`{:rf.http/managed :rf.http/managed-test-stub}`), so the redirect alone
+  survives in `:fx-decisions` — but the redirect points at a stub fx that
+  is only registered (with the routes) by
+  `re-frame.http-test-support/install-managed-request-stubs!`. Carrying the
+  route map in `:network` lets replay RE-INSTALL those route stubs before
+  replaying, so a replayed `:network` request matches its route and
+  synthesises the recorded reply rather than fail-closing on
+  \"no stub matched\" (rf2-tymyh, spec/017 §The network surface).
+
   ## Replay
 
   `(replay-run-artifact artifact opts)` replays the artifact's dispatch
-  program into a FRESH frame, reapplying the fx decisions, captures a NEW
-  epoch tape, and projects it through the merged `.4` evidence boundary
+  program into a FRESH frame, reapplying the fx decisions, RE-INSTALLING
+  the `:network` route stubs (when present), captures a NEW epoch tape, and
+  projects it through the merged `.4` evidence boundary
   (`re-frame.story.play.evidence/project-evidence`). The returned
   run-result is the SHARED run-result shape (spec/017 §Run result) — the
   same shape the runner returns and the same one `canonicalize` /
@@ -83,10 +98,16 @@
   §Artifacts — Run artifact). `:artifact/kind` + `:event-program` are the
   load-bearing slots; the rest are optional evidence / provenance.
 
+  `:network` is the per-route HTTP reply map (`{[method url] {:reply …}}`)
+  carried so replay can re-install the managed-request stubs the
+  `:fx-decisions` redirect points at (rf2-tymyh, spec/017 §The network
+  surface — \"the runner installs the route map via
+  install-managed-request-stubs!\").
+
   Enumerated so `select-keys` can normalize a hand-built / over-stuffed
   map down to the artifact surface without dropping a future-added slot
   silently elsewhere."
-  #{:artifact/kind :seed :event-program :fx-decisions :epoch-tape
+  #{:artifact/kind :seed :event-program :fx-decisions :network :epoch-tape
     :trace :result :shrink-path :created-at :source})
 
 (defn run-artifact?
@@ -187,6 +208,37 @@
                (rf/with-fx-overrides fx-decisions
                  (inner frame-id event-vector))
                (inner frame-id event-vector))))))
+
+(defn with-network-stubs!
+  "Run `thunk` with the artifact's `:network` per-route HTTP stubs
+  installed, then uninstall them (spec/017 §The network surface). When the
+  artifact carries a non-empty `:network` route map, this installs the
+  managed-request stub fx (`:rf.http/managed-test-stub`) with those routes
+  via `re-frame.core/install-managed-request-stubs!` — the SAME seam a live
+  run uses — so the `:fx-decisions` redirect (`{:rf.http/managed
+  :rf.http/managed-test-stub}`) resolves to a stub that matches the routes
+  rather than fail-closing on \"no stub matched\". The stubs are
+  uninstalled in a `finally` so a replay never leaks the stub fx into a
+  later test.
+
+  When the artifact carries no `:network` routes, `thunk` runs unchanged
+  (no install, no uninstall) — so an artifact without HTTP stays clear of
+  the test-support surface entirely. `re-frame.core/install-managed-
+  request-stubs!` is late-bound (Spec 014 §Testing): the call routes
+  through `re-frame.http-test-support`, which a caller exercising a
+  `:network` artifact already has on its require closure (exactly as the
+  live `:network` run path requires), and raises
+  `:rf.error/http-artefact-missing` if it does not — never silently
+  fail-closing the request."
+  [artifact thunk]
+  (let [network (:network artifact)]
+    (if (seq network)
+      (try
+        (rf/install-managed-request-stubs! network)
+        (thunk)
+        (finally
+          (rf/uninstall-managed-request-stubs!)))
+      (thunk))))
 
 (defn replay-into-frame!
   "Replay an artifact's `:event-program` into the LIVE `frame-id`,
@@ -295,14 +347,20 @@
        (rf/reg-frame frame-id (merge {:doc "rf2-5x1wt.7 run-artifact replay frame"}
                                      frame-config)))
      (try
-       (let [outcomes (replay-into-frame! frame-id artifact hooks)
-             tape     (vec (rf/epoch-history frame-id))
-             app-db   (rf/get-frame-db frame-id)]
-         (replay-result {:epoch-tape tape
-                         :artifact   artifact
-                         :outcomes   outcomes
-                         :frame-id   frame-id
-                         :app-db     app-db}))
+       ;; Re-install the artifact's `:network` route stubs (when any) for the
+       ;; duration of the replay, so the `:fx-decisions` managed-stub redirect
+       ;; resolves to a stub that matches the recorded routes rather than
+       ;; fail-closing (rf2-tymyh, spec/017 §The network surface).
+       (with-network-stubs! artifact
+         (fn []
+           (let [outcomes (replay-into-frame! frame-id artifact hooks)
+                 tape     (vec (rf/epoch-history frame-id))
+                 app-db   (rf/get-frame-db frame-id)]
+             (replay-result {:epoch-tape tape
+                             :artifact   artifact
+                             :outcomes   outcomes
+                             :frame-id   frame-id
+                             :app-db     app-db}))))
        (finally
          (when own-frame?
            (try (rf/destroy-frame! frame-id)

--- a/tools/story/src/re_frame/story/determinism.cljc
+++ b/tools/story/src/re_frame/story/determinism.cljc
@@ -73,15 +73,21 @@
     `:event-program` + `:fx-decisions`);
   - a normalized variant plan (a map with `:world` / `:script`) — its
     `[:world :setup]` ⧺ `:script` fold into the artifact `:event-program`
-    (the same setup-first fold `make-run-artifact` applies) and its
-    `[:world :frame :fx-overrides]` become the artifact `:fx-decisions`;
+    (the same setup-first fold `make-run-artifact` applies), its
+    `[:world :frame :fx-overrides]` become the artifact `:fx-decisions`,
+    and its `[:world :network]` per-route reply map becomes the artifact
+    `:network` slot (so replay re-installs the managed-request stubs the
+    `:fx-decisions` redirect points at — rf2-tymyh, spec/017 §The network
+    surface). Without the `:network` route map a replayed `:network`
+    variant would fail-closed on every request (the redirect survives but
+    the route stubs do not);
   - any other map carrying `:setup` / `:script` / `:event-program` — folded
     by `make-run-artifact` directly.
 
-  Reading the plan's `[:world :setup]` / `:script` is the only contact this
-  ns has with the plan compiler (`re-frame.story.plan`); it WRITES nothing
-  there. An already-built artifact short-circuits so a recorder's captured
-  program replays verbatim."
+  Reading the plan's `[:world :setup]` / `:script` / `:network` is the only
+  contact this ns has with the plan compiler (`re-frame.story.plan`); it
+  WRITES nothing there. An already-built artifact short-circuits so a
+  recorder's captured program replays verbatim."
   [target]
   (cond
     (artifact/run-artifact? target)
@@ -89,13 +95,17 @@
 
     ;; A normalized variant plan: setup lives under [:world :setup], the
     ;; primary script under :script, fx decisions under [:world :frame
-    ;; :fx-overrides]. Fold setup ⧺ script into the event program.
+    ;; :fx-overrides], the per-route HTTP reply map under [:world :network].
+    ;; Fold setup ⧺ script into the event program; carry the network routes
+    ;; so replay re-installs the managed-request stubs.
     (and (map? target) (contains? target :world))
     (artifact/make-run-artifact
-      {:setup        (get-in target [:world :setup] [])
-       :script       (get target :script [])
-       :fx-decisions (get-in target [:world :frame :fx-overrides] {})
-       :source       {:tool :determinism-gate :variant/id (:variant/id target)}})
+      (cond-> {:setup        (get-in target [:world :setup] [])
+               :script       (get target :script [])
+               :fx-decisions (get-in target [:world :frame :fx-overrides] {})
+               :source       {:tool :determinism-gate :variant/id (:variant/id target)}}
+        (seq (get-in target [:world :network]))
+        (assoc :network (get-in target [:world :network]))))
 
     :else
     (artifact/make-run-artifact target)))

--- a/tools/story/src/re_frame/story/plan.cljc
+++ b/tools/story/src/re_frame/story/plan.cljc
@@ -100,11 +100,13 @@
   ## What this layer DEFERS
 
   The runner itself + evidence projection are downstream of this compiler.
-  In particular, wiring the per-route `:network` reply data into the run
-  artifact awaits the run-artifact ns (rf2-5x1wt.7); this layer keeps the
-  reply map at `[:world :network]` and lowers it to the managed-stub
-  fx-override the runner installs, so that bead slots in without reshaping
-  the plan.
+  This layer keeps the per-route `:network` reply map at `[:world :network]`
+  and lowers it to the managed-stub fx-override the runner installs. The
+  run-artifact wiring that threads `[:world :network]` onto the artifact's
+  `:network` slot so replay RE-INSTALLS the route stubs landed in
+  `re-frame.story.determinism/->artifact` + `re-frame.story.artifact`
+  (rf2-tymyh, on top of the run-artifact ns rf2-5x1wt.7) — without
+  reshaping the plan, exactly as this layer anticipated.
 
   ## Purity / elision
 
@@ -735,13 +737,14 @@
 ;;
 ;; The compiler keeps the per-route reply data at `[:world :network]` (the
 ;; source of truth that feeds `:plan-hash` via `plan-hash-input-keys`'s
-;; `:world` slot, and `explain`, and — once rf2-5x1wt.7's run-artifact ns
-;; lands — the run artifact) AND **lowers** it to the existing managed-
-;; request stub machinery: the variant frame overrides `:rf.http/managed`
-;; with the stub fx that `re-frame.http-test-support/install-managed-
-;; request-stubs!` registers. We do NOT invent a new HTTP mock — the
-;; lowering names the existing seam so the (deferred) runner installs the
-;; route map and points the frame's `:fx-overrides` at the stub fx.
+;; `:world` slot, `explain`, and — threaded onto the artifact's `:network`
+;; slot by `re-frame.story.determinism/->artifact`, rf2-tymyh — the run
+;; artifact) AND **lowers** it to the existing managed-request stub
+;; machinery: the variant frame overrides `:rf.http/managed` with the stub
+;; fx that `re-frame.http-test-support/install-managed-request-stubs!`
+;; registers. We do NOT invent a new HTTP mock — the lowering names the
+;; existing seam; the runner (and `replay-run-artifact`, via the `:network`
+;; slot) installs the route map and points `:fx-overrides` at the stub fx.
 ;;
 ;; `:network` is NOT a replacement for generic `:fx-overrides`; it is the
 ;; higher-level affordance for `:rf.http/managed` specifically. Generic

--- a/tools/story/test/re_frame/story/artifact_test.cljc
+++ b/tools/story/test/re_frame/story/artifact_test.cljc
@@ -17,10 +17,14 @@
             [re-frame.core   :as rf]
             [re-frame.epoch  :as epoch]
             [re-frame.frame  :as frame]
+            [re-frame.http-managed]       ;; production managed-HTTP fx surface (:rf.http/managed)
+            [re-frame.http-test-support]  ;; stub install seam + canned-stub handlers
             [re-frame.registrar :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.story.artifact :as artifact]
+            [re-frame.story.determinism :as determinism]
             [re-frame.story.fingerprint :as fingerprint]
+            [re-frame.story.plan :as plan]
             [re-frame.story.play.settled-boundary :as boundary]))
 
 ;; ===========================================================================
@@ -300,3 +304,103 @@
       (is (= :rep/caller-frame (:frame res)))
       (is (contains? @frame/frames :rep/caller-frame)
           "the caller-supplied frame is NOT destroyed"))))
+
+;; ===========================================================================
+;; :network route stubs survive replay (rf2-tymyh)
+;; ===========================================================================
+;;
+;; The `:network` world slot (spec/017 §The network surface) lowers to a
+;; `:fx-decisions` redirect (`{:rf.http/managed :rf.http/managed-test-stub}`)
+;; PLUS the per-route reply map at `[:world :network]`. Before rf2-tymyh the
+;; run artifact captured ONLY the redirect (via `:fx-decisions`), so a
+;; replayed `:network` variant reapplied the redirect to a stub fx that was
+;; never registered with the routes — every request fail-closed on "no stub
+;; matched" (http_test_support.cljc `stub-handler`'s :else branch), silently
+;; diverging from the original run. The fix threads `[:world :network]` into
+;; the artifact's `:network` slot (`determinism/->artifact`) and re-installs
+;; those route stubs around the replay (`artifact/with-network-stubs!`), so a
+;; replayed request matches its route and synthesises the recorded reply.
+;;
+;; FAIL-PRE / PASS-POST: drop the `:network` capture or the re-install and
+;; `:got` becomes the synthesised "no stub matched" transport failure instead
+;; of the recorded `:ok` / `:failure` reply.
+
+(defn- register-network-event!
+  "Register a test event that issues a managed-HTTP request to `route`
+  ([method url]) and records the reply (success value or failure) into
+  app-db under `:got`. The reply rides back to this same origin event as
+  `:rf/reply` (Spec 014 §Reply addressing), so a re-installed stub's
+  synthesised reply is observable in the replay's final app-db."
+  [event-id [method url]]
+  (rf/reg-event-fx event-id
+    (fn [{:keys [db]} [_ msg]]
+      (if-let [reply (:rf/reply msg)]
+        {:db (assoc db :got reply)}
+        {:fx [[:rf.http/managed {:request {:method method :url url}
+                                 :decode  :json}]]}))))
+
+(defn- network-artifact
+  "Compile a `:network` variant plan for `routes`, coerce it through the
+  determinism gate's `->artifact` (the materialize-to-artifact seam), and
+  return the run artifact. `script` is the dispatch program."
+  [routes script]
+  (let [variant-id :story.net/v
+        plan       (plan/variant-plan
+                     variant-id
+                     {:lookup {variant-id {:network routes
+                                           :script  script}}})]
+    (determinism/->artifact plan)))
+
+(deftest network-artifact-captures-routes-and-redirect
+  (testing "->artifact threads [:world :network] into the artifact :network
+            slot AND [:world :frame :fx-overrides] into :fx-decisions"
+    (let [routes {[:get "/api/cart"] {:reply {:ok {:items []}}}}
+          art    (network-artifact routes [[:dispatch [:net/get-cart]]])]
+      (is (= routes (:network art))
+          "the per-route reply map is carried on the artifact (rf2-tymyh)")
+      (is (= {:rf.http/managed :rf.http/managed-test-stub} (:fx-decisions art))
+          "the managed-stub redirect rides :fx-decisions as before"))))
+
+(deftest replay-reinstalls-network-success-route
+  (testing "a replayed :network variant has its SUCCESS request matched by the
+            re-installed route stub — not fail-closed (rf2-tymyh)"
+    (register-network-event! :net/get-cart [:get "/api/cart"])
+    (let [routes {[:get "/api/cart"] {:reply {:ok {:items [{:sku "A"}]}}}}
+          art    (network-artifact routes [[:dispatch [:net/get-cart]]])
+          res    (artifact/replay-run-artifact art)
+          got    (:got (:app-db res))]
+      (is (= :pass (:status res)))
+      (is (= :success (:kind got))
+          "the re-installed route stub matched — NOT the 'no stub matched'
+           transport failure that fail-closes pre-fix")
+      (is (= {:items [{:sku "A"}]} (:value got))
+          "the synthesised reply carries the recorded route payload"))))
+
+(deftest replay-reinstalls-network-failure-route
+  (testing "a replayed :network variant has its FAILURE request matched by the
+            re-installed route stub — the recorded failure :kind, not a
+            'no stub matched' fail-closed transport failure (rf2-tymyh)"
+    (register-network-event! :net/checkout [:post "/api/checkout"])
+    (let [routes {[:post "/api/checkout"]
+                  {:reply {:failure {:kind :rf.http/http-4xx :status 409}}}}
+          art    (network-artifact routes [[:dispatch [:net/checkout]]])
+          res    (artifact/replay-run-artifact art)
+          got    (:got (:app-db res))]
+      (is (= :failure (:kind got))
+          "the re-installed route stub synthesised the recorded failure")
+      (is (= :rf.http/http-4xx (get-in got [:failure :kind]))
+          "the recorded failure :kind survived — NOT :rf.http/transport
+           ('no stub matched'), which is what fail-closes pre-fix")
+      (is (= 409 (get-in got [:failure :status]))
+          "the recorded failure tags survived the round-trip"))))
+
+(deftest replay-without-network-leaves-stub-surface-untouched
+  (testing "an artifact WITHOUT :network installs no stubs — with-network-stubs!
+            runs the thunk unchanged so a plain replay never touches the
+            test-support surface (rf2-tymyh)"
+    (rf/reg-event-db :net/noop (fn [db _] (assoc db :ran true)))
+    (let [art (artifact/make-run-artifact {:event-program [[:dispatch [:net/noop]]]})
+          res (artifact/replay-run-artifact art)]
+      (is (= :pass (:status res)))
+      (is (true? (:ran (:app-db res))))
+      (is (nil? (:network art)) "no :network slot on a non-HTTP artifact"))))


### PR DESCRIPTION
## Problem

The `:network` world slot (spec/017 §The network surface) lowers to a `:fx-decisions` redirect (`{:rf.http/managed :rf.http/managed-test-stub}`) **plus** the per-route reply map at `[:world :network]`. The low-level run artifact captured **only** the redirect (via `:fx-decisions`) and had zero `:network` references. So `replay-run-artifact` reapplied the redirect to a stub fx that was never registered with the routes — every replayed `:network` request fail-closed on `"no stub matched"` (`http_test_support.cljc` `stub-handler` `:else` branch), silently diverging from the original run. This was the explicit deferral in PR #2418, gated on the now-landed run-artifact ns (rf2-5x1wt.7).

## The fix — artifact threading

- **`artifact.cljc`**: `:network` is now a first-class (optional) artifact slot (`artifact-keys`). New `with-network-stubs!` installs the route map via the late-bound `re-frame.core/install-managed-request-stubs!` (the **same** seam a live run uses — no reinvented HTTP mock) and uninstalls in a `finally`. `replay-run-artifact` brackets the replay with it. No-op when the artifact carries no routes, so a non-HTTP artifact never touches the test-support surface; raises `:rf.error/http-artefact-missing` (never silently fail-closes) if a `:network` artifact is replayed without `re-frame.http-test-support` on the require closure — the same opt-in the live path requires.
- **`determinism.cljc`**: `->artifact` carries `[:world :network]` onto the artifact `:network` slot alongside the existing `:fx-decisions` redirect. Both the determinism gate **and** golden capture route through `->artifact` + `replay-run-artifact`, so both now round-trip a `:network` variant.
- **`plan.cljc`**: the two deferral comments updated to reflect the landed wiring (comment-only).
- **`spec/017`** §The network surface + §Run artifact and replay (§-sections only): document the `:network` artifact slot + the replay re-install; the `> Deferred — run-artifact wiring` note replaced with the landed contract.

The `:network` slot is **excluded** from `run-hash-input-keys` (it rides the provenance-only `:run-artifact` back-link), so the determinism hash is unperturbed — the gate now compares behavioural slices where every replay's request SUCCEEDS instead of all-fail-closed.

## Replay round-trip test (`artifact_test.cljc`)

A `:network` variant plan → `determinism/->artifact` (materialize) → `replay-run-artifact`, asserting the request SUCCEEDS (route stub re-installed) rather than fail-closing. **Fail-pre** (synthesised `:rf.http/transport` "no stub matched" failure) / **pass-post** (recorded `:ok` / `:failure` reply):
- `replay-reinstalls-network-success-route` — success route returns the recorded `:value` payload.
- `replay-reinstalls-network-failure-route` — failure route returns the recorded failure `:kind` + tags (not `:rf.http/transport`).
- `network-artifact-captures-routes-and-redirect` — `->artifact` carries both `:network` and `:fx-decisions`.
- `replay-without-network-leaves-stub-surface-untouched` — a non-HTTP artifact installs no stubs.

## Quality gates

- `tools/story`: `clojure -M:test` — **green** (1320 tests, 0 failures, 0 errors; new ns: 15 tests / 68 assertions).
- `tools/story-mcp`: `clojure -M:test` — **green** (172 tests, 0 failures, 0 errors).
- `tools/mcp-conformance`: `npm run test:story` — **green** (`STORY-MCP MCP-CLIENT CONFORMANCE GREEN`, exit 0, 13 OK checks).
- `scripts/test-fast-pr.sh` — **PASS** (core JVM 795 tests; CLJS node integration 4866 tests; JS harness helpers; README + docs-corpus anchor validators triggered by the spec edit, both pass; mkdocs soft-skipped on Windows — CI runs it, no new anchors/links added).