### PR TITLE
docs(story): doc-currency sweep — spec/017 prose + diff/invariants docstrings (rf2-33ifk + rf2-c5ik2 + rf2-wdxwt + rf2-fq3d6 + rf2-ev7wn)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -333,7 +333,7 @@ Required P1 shape:
 {:artifact/kind :rf.test/run-artifact
  :seed optional
  :event-program [...]
- :fx-decisions [...]
+ :fx-decisions {fx-id override}
  :network {[method url] {:reply …}}  ; optional — per-route HTTP stubs, re-installed on replay
  :epoch-tape [...]
  :trace [...]
@@ -773,11 +773,15 @@ not every step is legal in both positions:
 Future steps MAY add drag, keypress, pointer, file, route, or agent/MCP
 operations. Every step MUST declare its runner requirement.
 
-**Bare event-vector shorthand is NOT supported.** The grammar is
-uniformly tagged because an app event genuinely named `:dispatch`,
-`:click`, `:wait`, `:type`, or `:focus` would otherwise be silently
-un-dispatchable — a reserved-word hazard precisely in the slot where it
-bites hardest. `explain` therefore shows identical normalized forms for
+**Bare event-vector shorthand is NOT the P1 public form** — bare vectors
+are accepted ONLY as a transitional MIGRATION lift (see §Script step
+runner > Migration normalization, where `coerce-script` lifts a bare event
+vector to `[:dispatch event-vector]`), and that lift is slated for removal
+at GA. The P1 public grammar is uniformly tagged because an app event
+genuinely named `:dispatch`, `:click`, `:wait`, `:type`, or `:focus` would
+otherwise be silently un-dispatchable — a reserved-word hazard precisely in
+the slot where it bites hardest; the lift never re-wraps a step whose head
+is a known tag. `explain` therefore shows identical normalized forms for
 setup and script.
 
 #### Script step runner
@@ -1602,20 +1606,20 @@ only by FRAME BINDING (`:fresh` vs `:attached`) — modeled as the
 API) collapse into the canonical selection shape:
 
 ```clojure
-{:runner :headless | :hiccup | :dom | :browser | :auto
+{:runner :headless | :hiccup | :cljs-reactive | :dom | :browser | :auto
  :escalate boolean              ; synonym for :runner :auto when true
  :frame-binding :fresh | :attached
  :platform :client | :server}
 ```
 
 `:escalate true` OR `:runner :auto` collapse into `{:mode :auto}` (the
-cheapest qualifying runner is chosen); any other `:runner` → `{:mode
-:fixed :runner <kind>}`. The default is fixed `:headless`. An
-unrecognised or non-P1-selectable `:runner` (e.g. `:cljs-reactive`) falls
-back to the fixed `:headless` policy — an unknown tier never silently
-escalates. `:frame-binding` and `:platform` carry through untouched so the
-(deferred) three-verb surface and the MCP transport thread the SAME
-normalization.
+cheapest qualifying runner is chosen); any other recognised `:runner` (one
+of the `runner-kinds`) → `{:mode :fixed :runner <kind>}`. The default is
+fixed `:headless`. An unrecognised `:runner` not in `runner-kinds` (e.g.
+`:gpu`) falls back to the fixed `:headless` policy — an unknown tier never
+silently escalates. `:frame-binding` and `:platform` carry through
+untouched so the (deferred) three-verb surface and the MCP transport thread
+the SAME normalization.
 
 ## Run result
 
@@ -1876,7 +1880,7 @@ variant or an inline map.
 P1 run/is opts:
 
 ```clojure
-{:runner :headless | :hiccup | :dom | :browser | :auto
+{:runner :headless | :hiccup | :cljs-reactive | :dom | :browser | :auto
  :escalate boolean              ; synonym for :runner :auto when true
  :frame-binding :fresh | :attached
  :platform :client | :server}
@@ -2137,9 +2141,11 @@ The epoch tape is also the substrate for **invariant sentinels** — the
 "this MUST hold after every committed epoch" assertion form (NewTestStory
 §A1 / §A2). Two surfaces share one notion of an invariant: a live
 fixture (`with-invariants`) and a pure post-hoc utility
-(`first-bad-epoch`). Both live in `re-frame.story.invariants`; the
-fixture USES the utility for its "which epoch failed?" reporting so the
-live and post-hoc verdicts agree by construction.
+(`first-bad-epoch`). Both live in `re-frame.story.invariants` and both
+evaluate through `check-epoch` (the one per-epoch evaluation primitive),
+so a violation the live sentinel reports and the violation
+`first-bad-epoch` returns are computed identically — the live and post-hoc
+verdicts agree by construction.
 
 ### What an invariant is
 

--- a/tools/story/src/re_frame/story/diff.cljc
+++ b/tools/story/src/re_frame/story/diff.cljc
@@ -22,18 +22,25 @@
   ## What the diff covers (spec §Semantic diff)
 
   Each facet is projected from the canonical run-result and compared
-  independently, so a diff localises WHERE two runs parted:
+  independently, so a diff localises WHERE two runs parted. `facet-fns` is
+  the authoritative ordered enumeration; it ships these ten:
 
+  - `:status`            — the top-level run status, when it differs;
   - `:app-db`            — a readable key-path delta of the final app-db
                            (`:added` / `:removed` / `:changed` paths, each a
                            `{:path … :baseline … :current …}`-style entry);
+  - `:assertions`        — terminal assertion verdicts that diverge, by id;
+  - `:checks`            — mid-script `[:assert …]` checkpoint verdicts that
+                           diverge;
   - `:effects`           — effects emitted by one run and not the other
                            (multiset delta — `:only-baseline` / `:only-current`);
   - `:schema-violations` — schema failures by surface selector
                            (`re-frame.story.play.evidence/violation-selector`);
+  - `:warnings`          — warning records present in one run and not the other;
   - `:trace-ops`         — the trace `:operation` sequence (the causal op
                            spine), as an ordered alignment of the two;
-  - `:status`            — the top-level run status, when it differs.
+  - `:sub-overrides`     — the `{query-vector data}` sub-override map delta;
+  - `:fidelity`          — the `#{fidelity-token …}` set delta.
 
   The facet set is EXACTLY the canonical run-slice
   (`fingerprint/run-hash-input-keys`) the `:same?` judgement compares —
@@ -81,9 +88,12 @@
 
   ## Pure / JVM-testable
 
-  The facet diff fns (`diff-app-db`, `diff-effects`, `diff-schema-violations`,
-  `diff-trace-ops`, …) and the assembler (`diff-runs`) are pure data → data:
-  two run-results in, a readable diff out. `diff-sub-runs` is pure too but is
+  The ten facet diff fns wired into `facet-fns` — `diff-status`,
+  `diff-app-db`, `diff-assertions`, `diff-checks`, `diff-effects`,
+  `diff-schema-violations`, `diff-warnings`, `diff-trace-ops`,
+  `diff-sub-overrides`, `diff-fidelity` — plus the coarse `diverging-slice-keys`
+  fallback and the assembler (`diff-runs`) are pure data → data: two
+  run-results in, a readable diff out. `diff-sub-runs` is pure too but is
   diagnostic-only — not wired into `diff-runs` (it is outside the `:same?`
   slice). `diff-run-artifacts` is the thin replay-then-`diff-runs` wrapper for
   the artifact inputs."

--- a/tools/story/src/re_frame/story/invariants.cljc
+++ b/tools/story/src/re_frame/story/invariants.cljc
@@ -24,9 +24,10 @@
     retained epoch tape and an invariant, it returns the first epoch
     where the invariant fails (enriched with the trigger event, the
     db-diff, and the trace events), or `nil` when the invariant holds
-    across the whole tape. The fixture USES this utility to answer
-    \"which epoch failed?\" so the live and post-hoc surfaces agree by
-    construction.
+    across the whole tape. Both surfaces share `check-epoch` (the one
+    per-epoch evaluation primitive), so a violation the live sentinel
+    reports and the violation `first-bad-epoch` returns are computed
+    identically — the live and post-hoc surfaces agree by construction.
 
   ## Invariant shape
 
@@ -208,9 +209,10 @@
 ;; epoch tape. It walks the tape forward and returns the FIRST epoch where
 ;; the invariant fails, enriched with the trigger event, the db-diff, and
 ;; the trace events (the spec's named enrichment slots), or `nil` when the
-;; invariant holds across the whole tape. `with-invariants` uses this for
-;; its "which epoch failed?" reporting, so the live and post-hoc surfaces
-;; agree.
+;; invariant holds across the whole tape. `first-bad-epoch` and the live
+;; `with-invariants` sentinel both evaluate through `check-epoch` (the one
+;; per-epoch primitive), so the violation each surface reports is computed
+;; identically — the live and post-hoc surfaces agree.
 
 (defn- db-diff
   "A shallow before→after diff for the report: the set of top-level


### PR DESCRIPTION
Doc-currency sweep: five doc<->code mismatches in `tools/story` corrected so the docs match the SHIPPED code. Each was verified against the live source first; no code logic changed (two are .cljc ns-docstring/comment-only edits, three are spec/017 prose).

## The five corrections (verified against code)

1. **rf2-33ifk — spec/017 §Run/is opts + §Public execution API.** Both `:runner` enum blocks omitted `:cljs-reactive`, and the §Run/is opts prose used `:cljs-reactive` as its "falls back to `:headless`" example. Post-`rf2-5x1wt.30`, `:cljs-reactive` IS in `requirements.cljc` `runner-kinds` / `concrete-runners`, and `normalize-run-opts` returns `{:mode :fixed :runner :cljs-reactive}` for it (requirements.cljc:185-189, 166-183, 740-742). Added `:cljs-reactive` to both enums and reworded the fall-back example to a genuinely-unrecognised runner (`:gpu` / "not in `runner-kinds`").

2. **rf2-c5ik2 — spec/017 canonical §Run artifact schema.** The Required-P1-shape block showed `:fx-decisions [...]` (a vector); the impl (`artifact.cljc` defaults it to `{}` and threads it as the `{fx-id->override}` `:fx-overrides` map) and the replay section both treat it as a map. Fixed the line to `:fx-decisions {fx-id override}`. The `:network` line landed by #2461 (immediately below) was left untouched.

3. **rf2-wdxwt — spec/017 §Script step grammar.** The "Bare event-vector shorthand is NOT supported" paragraph contradicted the adjacent §Migration normalization subsection, where `coerce-script` lifts a bare event vector to `[:dispatch event-vector]`. Code verified: `play/runner.cljc` `coerce-script` lifts bare vectors and never re-wraps a known tag. Reworded to "NOT the P1 public form — accepted ONLY as a transitional migration lift (removed at GA)" so the two passages read coherently.

4. **rf2-fq3d6 — invariants.cljc ns-docstring + inline comment + spec/017 §Invariant sentinels.** All three claimed `with-invariants` USES `first-bad-epoch` for its "which epoch failed?" reporting. It does not: the live path is `on-epoch!` → `check-all` → `check-epoch` (invariants.cljc:344-350); `first-bad-epoch` is only called by itself. The genuinely-shared primitive is `check-epoch` (already named so at invariants.cljc:153). Reworded all three to "both surfaces evaluate through `check-epoch`, so the violations are computed identically".

5. **rf2-ev7wn — diff.cljc ns-docstring.** "What the diff covers" listed 6 facets but `facet-fns` (diff.cljc:567-577) ships **ten** (`:status :app-db :assertions :checks :effects :schema-violations :warnings :trace-ops :sub-overrides :fidelity`). Extended the header list to all ten and updated the "Pure / JVM-testable" fn list to name all ten `diff-*` fns + the `diverging-slice-keys` fallback. `:sub-runs` stays documented as the deliberate diagnostic-only exclusion. Docstring only — diff logic untouched. (Note: the bead said "11 incl. :sub-runs"; the SHIPPED `facet-fns` is ten — `:sub-runs` is correctly NOT registered — so the doc now matches code, not the bead's count.)

## Quality gates

- `tools/story` `clojure -M:test` — **1329 tests, 4309 assertions, 0 failures, 0 errors** (loads + exercises the edited diff.cljc / invariants.cljc namespaces).
- `tools/story-mcp` `clojure -M:test` — **172 tests, 861 assertions, 0 failures, 0 errors**.
- `tools/mcp-conformance` `npm run test:story` — **STORY-MCP MCP-CLIENT CONFORMANCE GREEN** (all conformance steps OK).
- `scripts/test-fast-pr.sh` — core JVM **795 tests, 0 failures**; JS harness helpers + path/surface/feature-load gates all pass. The doc anchor validators (`check_doc_slugs.py`, `check_readme_links.py --ci`) both pass (exit 0) over the spec/017 edit. (The CLJS node-integration step soft-failed only because shadow-cljs isn't installed in this fresh worktree's `implementation/` — environmental, unrelated to these doc-only edits.)

Doc-only change set; no new tests.