### PR TITLE
fix(story): refuse non-dispatch :setup steps + drop dead require (rf2-zaiwl + rf2-ov9dv)

### DIFF
--- a/tools/story/src/re_frame/story/requirements.cljc
+++ b/tools/story/src/re_frame/story/requirements.cljc
@@ -77,12 +77,19 @@
   Every fn here is pure data → data: tokens / requirement-sets / runner
   descriptors in, selection + refusal + validation maps out. It requires
   NOTHING from `re-frame.core`, the DOM, or a host, so the whole registry
-  + selection + validation surface runs under `clojure -M:test`. It reads
-  the spec/017 §`:cannot-run` refusal shape from
-  `re-frame.story.play.settled-boundary` (the `.2` boundary `:cannot-run`)
-  so there is ONE refusal vocabulary, not a parallel one."
-  (:require [re-frame.story.play.evidence        :as evidence]
-            [re-frame.story.play.settled-boundary :as boundary]))
+  + selection + validation surface runs under `clojure -M:test`.
+
+  Its `:cannot-run` refusal (`requirement-refusal`) is the CAPABILITY-axis
+  sibling of the BOUNDARY-axis refusal that
+  `re-frame.story.play.settled-boundary/cannot-run-refusal` builds. Both
+  share the `:status :cannot-run` discriminator (spec/017 §`:cannot-run` —
+  the distinct THIRD status, never a silent pass), but they are TWO
+  parallel refusals on two different axes (a missing capability token here;
+  a runner that does not reach the required settle boundary there), keyed
+  on their own facts — NOT one shared map. The axes are legitimately
+  distinct, so this ns names its own refusal rather than borrowing the
+  boundary one."
+  (:require [re-frame.story.play.evidence :as evidence]))
 
 ;; ===========================================================================
 ;; CAPABILITY TOKENS  (spec/017 §Runner kinds and capabilities)

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -146,15 +146,25 @@
 ;; ---- phase-2 events execution --------------------------------------------
 
 (defn- setup-step->event
-  "Extract the event vector a normalized `[:world :setup]` step carries.
-  Per spec/017 §Setup, setup steps are settled dispatches — the plan
-  compiler coerces every authored setup entry (bare event vector OR a
-  tagged `[:dispatch …]` / `[:dispatch-sync …]`) into a tagged dispatch
-  step, and an `[:assert …]` in setup is rejected at plan-compile time
-  (`re-frame.story.plan/reject-assert-in-setup!`). So a setup step is
-  always `[:dispatch event-vector]` / `[:dispatch-sync event-vector]`;
-  this returns the wrapped event vector (or the step itself when a
-  bare event vector slipped through an out-of-band path)."
+  "Lower a normalized `[:world :setup]` step to the event vector the
+  HEADLESS phase-2 executor dispatches, or `nil` when the step is not a
+  headless dispatch.
+
+  The plan compiler coerces every authored setup entry through the same
+  `coerce-script` the `:script` gets (spec/017 §Script step grammar): a
+  bare event-vector shorthand lifts to `[:dispatch …]`, so a stored setup
+  step is `[:dispatch event-vector]` / `[:dispatch-sync event-vector]`.
+  This returns the wrapped event vector for those, plus a bare event
+  vector that bypassed coercion (an out-of-band path).
+
+  A NON-dispatch step (`[:wait …]`, `[:wait-until …]`, `[:click …]`,
+  `[:type …]`, `[:focus …]`) is legal in `:setup` per the grammar table
+  and contributes its capability token to `:required-runner` — but it
+  needs `>= :dom` / `:cljs-reactive`, which the headless phase-2 path
+  cannot honour. Such a step returns `nil` here; `plan-setup-events`
+  turns that into a loud `:cannot-run`-shaped refusal rather than a
+  silent drop (spec/017 §Script and settled-boundary — a step a runner
+  cannot honour FAILS CLOSED, never under-runs and passes falsely)."
   [step]
   (cond
     (and (vector? step)
@@ -162,12 +172,19 @@
          (vector? (second step)))
     (second step)
 
-    ;; Defensive: a bare event vector (an out-of-band plan that bypassed
-    ;; coercion). Treat it as the event itself.
-    (and (vector? step) (keyword? (first step)))
+    ;; A bare event vector (an out-of-band plan that bypassed coercion):
+    ;; a re-frame event vector whose head is NOT a known step tag. Treat
+    ;; it as the event itself. A known step tag (`:wait`/`:click`/…) is
+    ;; NOT a bare event — it falls through to the refusal below.
+    (and (vector? step)
+         (keyword? (first step))
+         (not (runner/known-step? step)))
     step
 
     :else nil))
+
+(defn- non-dispatch-setup-step? [step]
+  (nil? (setup-step->event step)))
 
 (defn- plan-setup-events
   "The phase-2 event vectors for a run: the parent STORY's `:events`
@@ -184,14 +201,38 @@
 
   An INLINE plan (rf2-5x1wt.20) has no parent story (it is unregistered),
   so `story-id` resolves nil and only the plan's own `[:world :setup]`
-  drives phase 2 — the plan is already the complete setup program."
+  drives phase 2 — the plan is already the complete setup program.
+
+  REFUSES (throws `:rf.error/story-setup-step-unrunnable`) when a setup
+  step is a non-dispatch step (`[:wait …]` / `[:click …]` / `[:type …]`
+  / `[:focus …]` / `[:wait-until …]`). Such a step is legal in `:setup`
+  and lifts `:required-runner` to `:dom` / `:cljs-reactive`, but the
+  headless phase-2 path can only `dispatch-sync` — it cannot honour a
+  DOM/reactive boundary. Per spec/017 §Script and settled-boundary a
+  step a runner cannot honour FAILS CLOSED (`:cannot-run`); silently
+  dropping it (the prior `(keep …)` behaviour) is the forbidden
+  under-run that vanishes a precondition the author wrote. The throw is
+  caught by the orchestrator and projected as an `:error` run result."
   [variant-id plan]
   (let [story-id     (args/parent-story-id variant-id)
         story-body   (when story-id (registrar/handler-meta :story story-id))
         story-events (or (:events story-body) [])
         plan-setup   (get-in plan [:world :setup] [])]
+    (when-let [offenders (seq (filter non-dispatch-setup-step? plan-setup))]
+      (throw (ex-info
+               (str "re-frame2-story: variant " variant-id
+                    " — :setup carries a non-dispatch step "
+                    (pr-str (vec offenders))
+                    " that the headless runner cannot execute. A "
+                    ":wait / :wait-until / :click / :type / :focus step is "
+                    "legal in :setup but requires a :dom / :cljs-reactive "
+                    "runner; run this variant under a richer runner, or move "
+                    "the step to :script.")
+               {:rf.error/id     :rf.error/story-setup-step-unrunnable
+                :variant/id      variant-id
+                :offending-steps (vec offenders)})))
     (vec (concat story-events
-                 (keep setup-step->event plan-setup)))))
+                 (map setup-step->event plan-setup)))))
 
 (defn- run-events!
   "Phase 2: dispatch every phase-2 event into the variant's frame,

--- a/tools/story/test/re_frame/story_runtime_test.clj
+++ b/tools/story/test/re_frame/story_runtime_test.clj
@@ -949,6 +949,53 @@
         (is (false? (:passed? exc)))))
     (story/destroy-variant! :story.planerr/v)))
 
+(deftest run-variant-non-dispatch-setup-step-is-refused
+  (testing "a :setup carrying a non-dispatch step (e.g. [:wait …] / [:click …])
+            is REFUSED at phase-2 with :rf.error/story-setup-step-unrunnable
+            rather than SILENTLY DROPPED (rf2-zaiwl). The step is legal in
+            :setup and lifts :required-runner to :dom/:cljs-reactive, but the
+            headless runner cannot honour that boundary — so it fails closed
+            (:cannot-run shape) instead of vanishing the precondition."
+    (rf/reg-event-db :test/seed-z (fn [db _] (assoc db :seeded? true)))
+    (doseq [[vid bad-step] [[:story.zaiwl/wait  [:wait 100]]
+                            [:story.zaiwl/click [:click "[data-test=open]"]]]]
+      (story/reg-variant vid
+        {:setup [[:dispatch [:test/seed-z]] bad-step]})
+      (let [r (async/deref-blocking (story/run-variant vid) 5000)]
+        (is (= :error (:lifecycle r))
+            "the unrunnable setup step rolled the lifecycle to :error")
+        (is (= :error (:status r))
+            "the unified verdict is :error, not a vacuous green")
+        (let [exc (->> (:assertions r)
+                       (filter #(= :rf.error/story-setup-step-unrunnable
+                                   (get-in % [:error :data :rf.error/id])))
+                       first)]
+          (is (some? exc)
+              "the structured :rf.error/story-setup-step-unrunnable id rides
+               the recorded exception record (not a silent drop)")
+          (is (false? (:passed? exc)))
+          (is (= [bad-step]
+                 (get-in exc [:error :data :offending-steps]))
+              "the refusal names the offending non-dispatch step")))
+      (story/destroy-variant! vid))))
+
+(deftest run-variant-legit-setup-steps-still-compile-and-run
+  (testing "the legit setup shapes — a tagged [:dispatch …] AND a bare event
+            vector (coerced to [:dispatch …]) — still run cleanly through
+            phase 2 (rf2-zaiwl positive control: the refusal targets ONLY
+            non-dispatch steps)"
+    (rf/reg-event-db :test/seed-a (fn [db _] (assoc db :a true)))
+    (rf/reg-event-db :test/seed-b (fn [db _] (assoc db :b true)))
+    (story/reg-variant :story.zaiwl/ok
+      {:setup [[:dispatch [:test/seed-a]]   ; tagged dispatch
+               [:test/seed-b]]})            ; bare event vector → [:dispatch …]
+    (let [r (async/deref-blocking (story/run-variant :story.zaiwl/ok) 5000)]
+      (is (= :ready (:lifecycle r))
+          "both legit setup shapes ran without refusal")
+      (is (true? (-> r :app-db :a)) "the tagged [:dispatch …] setup step ran")
+      (is (true? (-> r :app-db :b)) "the bare-event-vector setup step ran"))
+    (story/destroy-variant! :story.zaiwl/ok)))
+
 ;; ---- plan-construction-error? discrimination (rf2-x3mol) -----------------
 ;;
 ;; PR #2430 (rf2-5x1wt.22) narrowed `plan-construction-error?` from the


### PR DESCRIPTION
Small cleanup, two disjoint files.

## rf2-zaiwl — `runtime.cljc`: silent-drop of non-dispatch `:setup` steps → loud refusal

`setup-step->event` lowered only `[:dispatch …]` / `[:dispatch-sync …]` (and a bare event vector) to a phase-2 dispatch; every other shape fell to `:else nil` and was **silently discarded** by the `(keep …)` in `plan-setup-events`. So a `:setup` carrying `[:wait …]` / `[:click …]` / `[:type …]` / `[:focus …]` / `[:wait-until …]` compiled and ran with the step **vanished** — the worst failure mode (a precondition the author wrote just disappears).

**Divergence from the bead's literal ask (flagged for the mayor).** The bead proposed broadening `reject-assert-in-setup!` to reject *all* non-dispatch steps at **plan-compile**. spec/017 §Script step grammar contradicts that: the grammar table marks **only `[:assert …]`** as illegal in `:setup`; DOM/wait steps are explicitly legal in `:setup` and deliberately lift `:required-runner` to `:dom` / `:cljs-reactive` (the shipped `dom-setup-step-requires-dom-token` test, rf2-8e2nd, pins exactly this — a `[:click …]` in `:setup` contributing the `:dom` token). Rejecting them at plan-compile would contradict the spec and break that test.

So the fix is placed at the spec-correct boundary: the **headless phase-2 executor**. A non-dispatch setup step reaching the dispatch-only path means a `:dom`/`:cljs-reactive` step is being run by a runner that cannot honour its settle boundary — exactly the `:cannot-run` fail-closed contract (spec/017 §Script + settled-boundary: "a `:headless` runner **refuses** it rather than under-flushing and passing falsely"). `plan-setup-events` now throws `:rf.error/story-setup-step-unrunnable` naming the offending step; the orchestrator projects it as an `:error` run result. Plan-compile and the requirements/token contract are untouched, so `dom-setup-step-requires-dom-token` still passes.

Legit setup shapes (tagged `[:dispatch …]` and bare-event-vector → `[:dispatch …]`) still compile and run unchanged.

**spec note deferred to doc-sweep** (spec/017 is held). The runtime-boundary refusal is consistent with the existing §Script + settled-boundary text; no spec edit made here.

## rf2-ov9dv — `requirements.cljc`: dead require + overclaiming docstring

GREP confirmed the `settled-boundary` require (aliased `boundary`) is genuinely dead: **zero `boundary/<fn>` call sites**; the only textual occurrence was a docstring string at line 396. Removed the dead require. The ns docstring claimed "ONE refusal vocabulary, not a parallel one", but `requirement-refusal` builds its own map keyed on capability-axis facts (`:required-runner`/`:available-runner`/`:missing`), distinct from `settled-boundary/cannot-run-refusal`'s boundary-axis shape. Softened the docstring to describe the two parallel refusals (capability axis here, boundary axis there) honestly — they share only the `:status :cannot-run` discriminator. The `requirement-refusal` docstring was already honest ("the capability-axis form"); behaviour is unchanged (the full suite is the guard).

## Quality gates
- `tools/story` `clojure -M:test` — **1331 tests / 4322 assertions, 0 failures, 0 errors** (incl. 2 new zaiwl tests: non-dispatch setup step refused for `[:wait …]` and `[:click …]`; legit dispatch + bare-vector setup still runs)
- `tools/story-mcp` `clojure -M:test` — **172 tests / 861 assertions, 0 failures, 0 errors**
- `tools/mcp-conformance` `npm run test:story` (cum40) — **GREEN** (exit 0)
- `scripts/test-fast-pr.sh` — **PASS** (core JVM 795/3516, CLJS node 4866/15934, all 0 failures)