### PR TITLE
fix(story): structured plan error on malformed assert steps + flag unlabeled <input> (rf2-zha5z + rf2-81ud8)

### DIFF
--- a/tools/story/src/re_frame/story/plan.cljc
+++ b/tools/story/src/re_frame/story/plan.cljc
@@ -267,20 +267,55 @@
 ;; `[:world :scripts]` so `:plays` is not dropped (§Public vocabulary —
 ;; "named scripts in the normalized plan").
 
+(defn- reject-malformed-steps!
+  "FAIL plan construction when any COERCED (but not-yet-folded) script step
+  is structurally malformed — an unknown step tag or a tag with the wrong
+  arity/shape (rf2-zha5z, spec/017 §Script step grammar). Reuses the
+  runner's `validate-script` (`runner/step-arity-ok?` + `known-step?`) — the
+  ONE encoding of the per-tag shape constraints — so the plan compiler and
+  the runtime runner agree on what a well-formed step is.
+
+  This gate MUST run BEFORE `assertions/fold-script`: the fold helpers
+  (`assertions/assert-db->atom` / `assert-dom->atom`) assume a well-formed
+  shipping step (a 3-/4-arity `:assert-db`, a recognised `:assert-dom`
+  mode), so a malformed one folded raw throws an opaque HOST exception
+  (IndexOutOfBounds / `No matching clause`) at plan-compile rather than the
+  project's structured `:rf.error/story-*` shape. Catching it here surfaces
+  the typo through the SAME error vocabulary every other plan error uses
+  (cf `reject-unknown-assertions!` / `reject-assert-in-setup!`)."
+  [id script]
+  (when-let [offenders (seq (runner/validate-script script))]
+    (fail! :rf.error/story-bad-step
+           (str "re-frame2-story: variant " id
+                " — malformed script step(s) "
+                (pr-str (mapv (fn [{:keys [idx step reason]}]
+                                {:idx idx :step step :reason reason})
+                              offenders))
+                ". Each step must be a recognised tagged step with the right "
+                "shape (e.g. [:assert-db path value] / [:assert-db path :pred "
+                "fn], [:assert-dom selector :visible|:hidden] / [:assert-dom "
+                "selector :text string]). Fix the step tag, arity, or mode.")
+           {:variant/id id :offending-steps (vec offenders)})))
+
 (defn- normalize-scripts
   "Return `{:script [step ...] :scripts [{:name :script :auto-run?} ...]}`
   for a merged body. Accepts the target `:script` spelling AND the
   shipping `:play-script` / `:plays` spellings, lowering them through the
   runner's canonical coercion. The primary `:script` is the first play.
 
-  After coercion every play's script is FOLDED (`assertions/fold-script`,
+  Each play's coerced script is first SHAPE-VALIDATED
+  (`reject-malformed-steps!`, rf2-zha5z) so a malformed `:assert-db` /
+  `:assert-dom` (or any step) FAILS with a structured `:rf.error/story-bad-
+  step` BEFORE the fold — the fold helpers assume well-formed input.
+
+  After validation every play's script is FOLDED (`assertions/fold-script`,
   rf2-5x1wt.18): a shipping `:assert-db` / `:assert-dom` step rewrites to
   the canonical `[:assert assertion-atom]` checkpoint, so EVERY in-script
   assertion — whatever sugar the author typed — resolves to the ONE
   assertion atom shape (spec/017 §Assertions — one atom, two positions).
   Each `:scripts` entry carries the folded script too, so named plays the
   runner drives also see the canonical checkpoints."
-  [body]
+  [id body]
   (let [plays (cond
                 (contains? body :script)
                 ;; Target spelling: a bare step vector, coerced the same
@@ -289,7 +324,9 @@
 
                 :else
                 (runner/variant-body->plays body))
-        plays (mapv (fn [p] (update p :script assertions/fold-script))
+        plays (mapv (fn [p]
+                      (reject-malformed-steps! id (:script p))
+                      (update p :script assertions/fold-script))
                     (vec plays))]
     {:script  (-> plays first :script (or []))
      :scripts plays}))
@@ -1153,9 +1190,9 @@
         ;; `:extends`): composed-fragment scripts in declared order, THEN
         ;; the child's own script (§Merge rules). Each fragment's script is
         ;; coerced the same way the child's is.
-        compose-script (vec (mapcat (fn [l] (:script (normalize-scripts l)))
+        compose-script (vec (mapcat (fn [l] (:script (normalize-scripts id l)))
                                     frag-layers))
-        {child-script :script scripts :scripts} (normalize-scripts child)
+        {child-script :script scripts :scripts} (normalize-scripts id child)
         script       (vec (concat compose-script child-script))
         ;; terminal assertions are CHILD-ONLY (verdict is local)
         assertions   (vec (:assertions child))

--- a/tools/story/src/re_frame/story/play/browser.cljc
+++ b/tools/story/src/re_frame/story/play/browser.cljc
@@ -323,9 +323,45 @@
         (has-text-child? node))))
 
 (def ^:private interactive-tags
-  "Tags that REQUIRE an accessible name for a screen reader. `:input`
-  excludes hidden inputs (checked at the call site)."
+  "Tags that ALWAYS require an accessible name for a screen reader,
+  regardless of attributes. `:input` is NOT here — it is conditional on
+  its `:type` (see `input-needs-name?` / `interactive-needs-name?`): a
+  text/checkbox/radio/etc. input needs a name, but a hidden / submit /
+  reset / button / image input does not (those get their name from
+  `:value` / `:alt`, or aren't rendered at all)."
   #{:button :a :select :textarea})
+
+(def ^:private input-types-needing-no-name
+  "`:input` `:type` values that do NOT require an explicit accessible name
+  in the structural floor: `:hidden` is not rendered; `:submit` / `:reset`
+  / `:button` carry a name via their `:value` (or a UA default); `:image`
+  carries its name via `:alt` (already covered by `accessible-name?`).
+  Every other input type (text, email, password, checkbox, radio, …) is a
+  named control. Strings and keywords are both accepted (`:type \"text\"`
+  and `:type :text`)."
+  #{"hidden" "submit" "reset" "button" "image"})
+
+(defn- input-needs-name?
+  "True iff an `:input` element with `attrs` is a control that requires an
+  accessible name — i.e. its `:type` is not one of the name-exempt types
+  (`input-types-needing-no-name`). A `:type`-less input defaults to
+  `\"text\"`, which DOES need a name. Pure data → data."
+  [attrs]
+  (let [t (:type attrs)
+        t (cond (keyword? t) (name t)
+                (string? t)  t
+                (nil? t)     "text"        ; UA default type
+                :else        (str t))]
+    (not (contains? input-types-needing-no-name t))))
+
+(defn- interactive-needs-name?
+  "True iff a hiccup element with `tag` / `attrs` is an interactive control
+  that requires an accessible name in the structural floor: an
+  always-interactive tag (`interactive-tags`), OR an `:input` whose `:type`
+  is not name-exempt (`input-needs-name?`). Pure data → data."
+  [tag attrs]
+  (or (contains? interactive-tags tag)
+      (and (= :input tag) (input-needs-name? attrs))))
 
 (defn- node-issues
   "Structural a11y issues for ONE hiccup element (not its descendants).
@@ -349,7 +385,7 @@
                         :detail "img element has no :alt attribute"})
 
                  ;; interactive control needs an accessible name
-                 (and (contains? interactive-tags tag)
+                 (and (interactive-needs-name? tag attrs)
                       (not (accessible-name? attrs node)))
                  (conj {:rule :control-missing-name :tag tag
                         :detail (str (name tag) " control has no accessible name "

--- a/tools/story/test/re_frame/story/plan_test.cljc
+++ b/tools/story/test/re_frame/story/plan_test.cljc
@@ -759,6 +759,62 @@
                      [:expect :assertions]))
           (str "expected " (pr-str atom-v) " to compile as a known assertion")))))
 
+;; ---- malformed-step rejection before the fold (rf2-zha5z) -----------------
+;;
+;; The plan compiler folds shipping `:assert-db` / `:assert-dom` steps into
+;; the canonical `[:assert …]` checkpoint. The fold helpers assume a
+;; well-formed step, so a malformed one MUST be rejected with a structured
+;; `:rf.error/story-bad-step` BEFORE the fold — never a raw host exception
+;; (IndexOutOfBounds / `No matching clause`). The gate reuses the runner's
+;; `validate-script` so the compiler and runtime agree on step shape.
+
+(deftest malformed-assert-dom-mode-rejected-before-fold
+  (testing "an :assert-dom step with an unrecognised mode FAILS plan
+           construction with a structured story-bad-step (NOT a raw
+           `No matching clause` IllegalArgumentException from the fold)"
+    (let [m {:story.x/bad-dom {:script [[:assert-dom "#x" :weird]]}}]
+      (is (thrown-with-msg?
+            #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
+            #"story-bad-step"
+            (plan-of :story.x/bad-dom m))))))
+
+(deftest malformed-assert-db-arity-rejected-before-fold
+  (testing "an :assert-db step with too few elements FAILS plan construction
+           with a structured story-bad-step (NOT a raw IndexOutOfBounds from
+           the fold's nth)"
+    (let [m {:story.x/bad-db {:script [[:assert-db [:n]]]}}]
+      (is (thrown-with-msg?
+            #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
+            #"story-bad-step"
+            (plan-of :story.x/bad-db m))))))
+
+(deftest malformed-step-error-carries-structured-data
+  (testing "the :rf.error/story-bad-step ex-data names the offending step"
+    (let [m  {:story.x/bad4 {:script [[:assert-db [:n] :pred even? :extra]]}}
+          ex (try (plan-of :story.x/bad4 m) nil
+                  (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e e))]
+      (is (some? ex))
+      (is (= :rf.error/story-bad-step (:rf.error/id (ex-data ex))))
+      (is (contains? (set (map :step (:offending-steps (ex-data ex))))
+                     [:assert-db [:n] :pred even? :extra])))))
+
+(deftest well-formed-assert-steps-still-compile
+  (testing "well-formed :assert-db / :assert-dom steps fold cleanly past the
+           new shape gate (the gate rejects only malformed steps)"
+    (let [folded (plan-of :story.x/ok-mix
+                          {:story.x/ok-mix
+                           {:script [[:assert-db [:count] 6]
+                                     [:assert-db [:n] :pred even?]
+                                     [:assert-dom "#a" :visible]
+                                     [:assert-dom "#b" :hidden]
+                                     [:assert-dom "#c" :text "hi"]]}})]
+      (is (= [[:assert [:rf.assert/path-equals [:count] 6]]
+              [:assert [:rf.assert/path-matches [:n] [:fn even?]]]
+              [:assert [:rf.assert/dom-visible "#a"]]
+              [:assert [:rf.assert/dom-hidden "#b"]]
+              [:assert [:rf.assert/dom-text "#c" "hi"]]]
+             (:script folded))))))
+
 ;; ---- pure fold helpers (assertion-ns surface) ----------------------------
 
 (deftest fold-helpers-are-pure-and-position-agnostic

--- a/tools/story/test/re_frame/story/play/browser_test.cljc
+++ b/tools/story/test/re_frame/story/play/browser_test.cljc
@@ -94,6 +94,34 @@
                 [] {:hiccup [:div [:button {:aria-label "close"}]]})]
       (is (= :pass (:status rec))))))
 
+(deftest structural-a11y-detects-unlabeled-input
+  ;; rf2-81ud8 — an interactive <input> with no accessible name is a genuine
+  ;; structural a11y issue; the structural floor now flags it (the docstring
+  ;; no longer claims a call-site check that did not exist).
+  (testing "an :input with no accessible name and a named type is flagged"
+    (let [rec (browser/eval-structural-a11y [] {:hiccup [:div [:input {:type "text"}]]})]
+      (is (= :fail (:status rec)))
+      (is (= :control-missing-name (-> rec :actual first :rule)))
+      (is (= :input (-> rec :actual first :tag)))))
+  (testing "a :type-less :input defaults to text and is flagged when unnamed"
+    (let [rec (browser/eval-structural-a11y [] {:hiccup [:div [:input {}]]})]
+      (is (= :fail (:status rec)))
+      (is (= :control-missing-name (-> rec :actual first :rule)))))
+  (testing "a labeled :input is clean (aria-label / title supply the name)"
+    (is (= :pass (:status (browser/eval-structural-a11y
+                            [] {:hiccup [:div [:input {:type "text" :aria-label "name"}]]}))))
+    (is (= :pass (:status (browser/eval-structural-a11y
+                            [] {:hiccup [:div [:input {:type :email :title "email"}]]}))))))
+
+(deftest structural-a11y-name-exempt-input-types-pass
+  ;; rf2-81ud8 — hidden / submit / reset / button / image inputs do NOT need
+  ;; an explicit accessible name (not rendered, or named via :value / :alt).
+  (testing "name-exempt input types are clean even without an accessible name"
+    (doseq [t ["hidden" "submit" "reset" "button" "image" :hidden :submit]]
+      (let [rec (browser/eval-structural-a11y [] {:hiccup [:div [:input {:type t}]]})]
+        (is (= :pass (:status rec))
+            (str "input :type " (pr-str t) " should not require a name"))))))
+
 (deftest structural-a11y-detects-positive-tabindex
   (testing "a positive :tabIndex is a structural issue (both spellings)"
     (let [rec  (browser/eval-structural-a11y [] {:hiccup [:div {:tabIndex 3} "x"]})


### PR DESCRIPTION
Two P4 bug fixes on disjoint files in the Story tool, one PR.

## rf2-zha5z — `plan.cljc` + `assertions.cljc`

The plan compiler folded shipping `:assert-db` / `:assert-dom` setup/script-sugar steps in `normalize-scripts` **before** any step-shape validation. The fold helpers (`assertions/assert-db->atom` does `(nth step 1/2)`; `assert-dom->atom` uses a `(case mode …)` with no default) assume well-formed input, so a malformed step threw a **raw host exception** at plan-compile (`IndexOutOfBounds` for a short `:assert-db`, `IllegalArgumentException "No matching clause"` for a typo'd `:assert-dom` mode) instead of the project's structured `:rf.error/story-*` shape.

**Fix (option a — reuse `validate-script`, one error vocabulary):** added `reject-malformed-steps!` in `plan.cljc`, invoked inside `normalize-scripts` on the **coerced-but-not-yet-folded** script, **before** `assertions/fold-script`. It calls the runner's existing `runner/validate-script` (which already encodes the per-tag shape via `step-arity-ok?` + `known-step?`) and raises a clean `:rf.error/story-bad-step` with the offending steps. No new shape rules invented — the compiler and runtime now share the runner's single encoding. `assertions.cljc` was **not** modified (the structured gate lands entirely in the compiler, which is the cleaner single-gate design the bead preferred). Well-formed `:assert-db` / `:assert-dom` plans still fold and compile unchanged.

## rf2-81ud8 — `play/browser.cljc` (chose: ADD `:input` handling)

`interactive-tags` was `#{:button :a :select :textarea}` but its docstring claimed `:input` "excludes hidden inputs (checked at the call site)" — `:input` was not in the set and no such check existed (stale comment + real coverage gap: an unlabeled `<input>` went unflagged).

**Chose the ADD path over doc-only** (closes the genuine coverage gap; CORRECTNESS). Added `input-needs-name?` + `interactive-needs-name?`: an `:input` is now flagged `:control-missing-name` when unlabeled, **except** name-exempt `:type` values `#{hidden submit reset button image}` (not rendered, or named via `:value`/`:alt`). A `:type`-less input defaults to `text` (needs a name). `:type` is accepted as either string or keyword. The existing clean-tree test's `[:input {:type "text" :aria-label "name"}]` stays clean. Docstring now matches the code.

## Tests

- `plan_test.cljc`: malformed `:assert-dom` mode and short `:assert-db` arity are rejected with `:rf.error/story-bad-step` (fails-pre as a raw throw, passes-post); ex-data names the offending step; well-formed `:assert-db`/`:assert-dom` mix still folds + compiles.
- `browser_test.cljc`: unlabeled `:input` (text + `:type`-less) flagged; labeled (aria-label/title) clean; all name-exempt `:type` values pass.

## Quality gates

- `tools/story` `clojure -M:test` — **green** (1335 tests, 4329 assertions, 0 failures, 0 errors)
- `tools/story-mcp` `clojure -M:test` — **green** (172 tests, 861 assertions, 0/0)
- `tools/mcp-conformance` `npm run test:story` — **green** (`STORY-MCP MCP-CLIENT CONFORMANCE GREEN`, exit 0)
- `scripts/test-fast-pr.sh` — **green** (JVM spine 795/3516 0/0; CLJS node integration 4866/15934 0/0; all script-policy/helper tests pass)