### PR TITLE
feat(story/ui): read-only Explain panel over story/explain (rf2-ba86n.9)

### DIFF
--- a/tools/story/src/re_frame/story/ui/command_palette.cljc
+++ b/tools/story/src/re_frame/story/ui/command_palette.cljc
@@ -4,14 +4,30 @@
             [re-frame.story.predicates :as pred]))
 
 (def searchable-kinds
-  [:story :variant :workspace :mode :decorator])
+  [:command :story :variant :workspace :mode :decorator])
 
 (def kind-labels
-  {:story     "Story"
+  {:command   "Command"
+   :story     "Story"
    :variant   "Variant"
    :workspace "Workspace"
    :mode      "Mode"
    :decorator "Decorator"})
+
+(def commands
+  "Synthetic palette entries that run a UI action rather than navigate
+  the registry (rf2-ba86n.9). Each carries an `:action` keyword the
+  impure `select-entry!` dispatches. Kept tiny + data-only so the JVM
+  search corpus can rank them alongside registry entries; the action →
+  side-effect mapping lives in the CLJS view.
+
+  - `:explain` — open the Explain panel (provenance + lowering over
+    `story/explain`) and scroll it into view. Reachable here AND from
+    the RHS inspector rail per spec/020 §4."
+  [{:kind   :command
+    :id     :explain
+    :action :explain
+    :doc    "Explain variant — source chain, merges, substitutions, lowering"}])
 
 (defn- doc-text [body]
   (let [doc (:doc body)]
@@ -36,33 +52,55 @@
        sort
        vec))
 
+(def ^:private registry-kinds
+  "The `searchable-kinds` that resolve to a registry slot — i.e. all
+  except the synthetic `:command` kind, which is folded in separately."
+  [:story :variant :workspace :mode :decorator])
+
+(defn command-entries
+  "Build the synthetic command entries (rf2-ba86n.9) in palette-entry
+  shape. Pure data → data so the search corpus can include them."
+  []
+  (mapv (fn [{:keys [kind id action doc]}]
+          {:kind       kind
+           :kind-label (get kind-labels kind (name kind))
+           :id         id
+           :id-label   (id-text id)
+           :action     action
+           :doc        (or doc "")})
+        commands))
+
 (defn entries
   "Build palette entries from a `state/registry-snapshot` map.
 
-  Stories include their child variants so the impure selector can jump
-  to the first concrete variant when a story row is chosen."
+  Synthetic `:command` entries (e.g. `Explain variant`) lead the list
+  so an action like `explain` is one keystroke away; registry entries
+  follow. Stories include their child variants so the impure selector
+  can jump to the first concrete variant when a story row is chosen."
   [snapshot]
   (let [variants (:variants snapshot)]
-    (->> searchable-kinds
-         (mapcat
-           (fn [kind]
-             (let [slot (case kind
-                          :story     :stories
-                          :variant   :variants
-                          :workspace :workspaces
-                          :mode      :modes
-                          :decorator :decorators)]
-               (map (fn [[id body]]
-                      (cond-> {:kind        kind
-                               :kind-label  (get kind-labels kind (name kind))
-                               :id          id
-                               :id-label    (id-text id)
-                               :doc         (doc-text body)
-                               :body        body}
-                        (= kind :story)
-                        (assoc :variant-ids (variants-for-story variants id))))
-                    (sort-by (comp str first) (get snapshot slot {}))))))
-         vec)))
+    (into
+      (command-entries)
+      (->> registry-kinds
+           (mapcat
+             (fn [kind]
+               (let [slot (case kind
+                            :story     :stories
+                            :variant   :variants
+                            :workspace :workspaces
+                            :mode      :modes
+                            :decorator :decorators)]
+                 (map (fn [[id body]]
+                        (cond-> {:kind        kind
+                                 :kind-label  (get kind-labels kind (name kind))
+                                 :id          id
+                                 :id-label    (id-text id)
+                                 :doc         (doc-text body)
+                                 :body        body}
+                          (= kind :story)
+                          (assoc :variant-ids (variants-for-story variants id))))
+                      (sort-by (comp str first) (get snapshot slot {}))))))
+           vec))))
 
 (defn normalize-query [query]
   (-> (or query "")
@@ -112,6 +150,7 @@
         (when (every? some? scores)
           (+ (reduce + scores)
              (case (:kind entry)
+               :command   9
                :variant   8
                :workspace 7
                :story     6

--- a/tools/story/src/re_frame/story/ui/command_palette/view.cljs
+++ b/tools/story/src/re_frame/story/ui/command_palette/view.cljs
@@ -4,6 +4,7 @@
             [reagent.core :as r]
             [re-frame.story.config :as config]
             [re-frame.story.ui.command-palette :as palette]
+            [re-frame.story.ui.explain-panel :as explain-panel]
             [re-frame.story.ui.state :as state]
             [re-frame.story.ui.toolbar :as toolbar]
             [re-frame.story.theme.typography :as typography :refer [mono-stack]]))
@@ -24,12 +25,21 @@
 (defn select-entry!
   "Apply a palette entry to shell state, then return true when handled.
 
-  Variants and workspaces are navigable. Stories jump to their first
-  registered child variant when one exists. Modes reuse the toolbar
-  toggle so persistence stays in one place. Decorators are registry
-  data only in the MVP, so selecting them simply closes the palette."
+  Commands run a UI action (e.g. open the Explain panel). Variants and
+  workspaces are navigable. Stories jump to their first registered
+  child variant when one exists. Modes reuse the toolbar toggle so
+  persistence stays in one place. Decorators are registry data only in
+  the MVP, so selecting them simply closes the palette."
   [entry]
   (case (:kind entry)
+    :command
+    (do
+      (case (:action entry)
+        ;; rf2-ba86n.9 — open the Explain panel + scroll it into view.
+        :explain (explain-panel/open!)
+        nil)
+      true)
+
     :variant
     (do
       (state/swap-state!

--- a/tools/story/src/re_frame/story/ui/explain_panel.cljc
+++ b/tools/story/src/re_frame/story/ui/explain_panel.cljc
@@ -56,12 +56,16 @@
   Reagent dep."
   (:require [clojure.string :as str]
             [re-frame.story.plan :as plan]
+            ;; The theme requires are CLJS-only — `typography`/`colors` are
+            ;; referenced solely from the `#?(:cljs (def ^:private styles …))`
+            ;; block. Keeping them inside the `:cljs` reader conditional avoids
+            ;; an unused-namespace warning in the `.cljc` clj view.
             #?@(:cljs [[reagent.core :as r]
                        [re-frame.story.config :as config]
                        [re-frame.story.review-dialog :as review-dialog]
-                       [re-frame.story.ui.state :as state]])
-            [re-frame.story.theme.typography :as typography :refer [sans-stack mono-stack]]
-            [re-frame.story.theme.colors :as colors]))
+                       [re-frame.story.ui.state :as state]
+                       [re-frame.story.theme.typography :as typography :refer [sans-stack mono-stack]]
+                       [re-frame.story.theme.colors :as colors]])))
 
 ;; ---------------------------------------------------------------------------
 ;; The panel-visibility slot + the scroll anchor id. Shared with the

--- a/tools/story/src/re_frame/story/ui/explain_panel.cljc
+++ b/tools/story/src/re_frame/story/ui/explain_panel.cljc
@@ -1,0 +1,589 @@
+(ns re-frame.story.ui.explain-panel
+  "The Explain panel — a read-only provenance + lowering surface over
+  the `story/explain` data (rf2-ba86n.9, spec/020 §4 / spec/017
+  §Explain API).
+
+  ## What it is — and is NOT
+
+  This panel answers ONE question for the focused variant: *where did
+  this plan come from, and how was it lowered?* It renders the
+  `:explain` map the pure plan compiler attaches
+  (`re-frame.story.plan/explain`): the source + parent chains, composed
+  fragments/checks, field-level merge decisions, strict-conflict
+  winners/losers, arg substitutions + effective-args, and the network /
+  sub-override / runner lowering.
+
+  It is a **Story-owned** surface. Per spec/020 §4 it is net-new Story
+  UI over explain data and does NOT depend on Xray — it must NOT pull
+  any `day8.re-frame2-xray.*` symbol onto the production/story bundle.
+  Provenance + lowering is Story's job; app-db diffing, trace, and
+  time-travel are Xray's (spec/020 §1.2). The Explain panel is the
+  static-plan companion to Xray's runtime diagnostics — they sit in the
+  same RHS inspector rail but never share code.
+
+  ## Render what's there — never fabricate
+
+  The panel renders the slots spec/020 §4 / spec/017 §Explain API list.
+  Some slots are only populated when the variant exercises that feature
+  (`:network` is nil unless the variant authors routes; `:sub-overrides`
+  is nil unless it pins subs; `:compose` / `:strict-conflicts` are empty
+  unless it composes fragments). Where a slot is absent in the CURRENT
+  explain output the panel renders it as a graceful 'not available' /
+  empty state — it never invents data the compiler didn't emit. Slots
+  the spec marks as future (`:plan-hash` inputs, evidence projections)
+  are intentionally NOT rendered: they are not shipped explain data.
+
+  ## Pure / CLJS split
+
+  Mirrors `docs.cljc`: the section-projection logic is pure `.cljc`
+  (`explain-sections` + the per-section shapers) so the JVM corpus can
+  pin the projection without a host; the React rendering + the
+  raw-EDN/copy-to-clipboard affordances are `#?(:cljs ...)`.
+
+  ## Reachability
+
+  - **Inspector**: the shell's RHS inspector rail mounts
+    `explain-panel` as a labelled section (gated on a focused variant),
+    alongside the Xray embed + Controls.
+  - **Command palette**: a synthetic `:command` entry (`Explain
+    variant`) opens the panel + scrolls it into view.
+
+  ## Elision
+
+  CLJS rendering reaches `explain-panel` only via the
+  `config/enabled?`-gated shell mount, so production builds never invoke
+  it; closure DCEs the lot. The pure `.cljc` helpers carry no DOM /
+  Reagent dep."
+  (:require [clojure.string :as str]
+            [re-frame.story.plan :as plan]
+            #?@(:cljs [[reagent.core :as r]
+                       [re-frame.story.config :as config]
+                       [re-frame.story.review-dialog :as review-dialog]
+                       [re-frame.story.ui.state :as state]])
+            [re-frame.story.theme.typography :as typography :refer [sans-stack mono-stack]]
+            [re-frame.story.theme.colors :as colors]))
+
+;; ---------------------------------------------------------------------------
+;; The panel-visibility slot + the scroll anchor id. Shared with the
+;; shell (RHS mount) + the command palette (open-and-scroll command).
+;; ---------------------------------------------------------------------------
+
+(def panel-key
+  "The `:panel-visibility` slot key the shell + command palette toggle
+  to show/hide the Explain section."
+  :explain)
+
+(def anchor-id
+  "DOM id on the Explain RHS section so the command palette can scroll
+  it into view after opening it."
+  "story-explain-panel")
+
+;; ---------------------------------------------------------------------------
+;; Pure: compute the explain map for a variant (catching compile errors)
+;; ---------------------------------------------------------------------------
+
+(defn explain-for
+  "Return `{:explain <map>}` for `variant-id`, or `{:error <msg>}` when
+  the plan compiler throws (a missing arg, an unknown variant, an
+  unresolved strict conflict, a schema violation). Pure-ish — reads the
+  Story side-table through the compiler's default `:lookup`. Never
+  throws; a compile failure is surfaced to the user as an error state
+  rather than blanking the panel.
+
+  `nil` variant-id yields `{:error ...}` so the caller renders the
+  no-variant empty state via a separate branch — this fn is only called
+  with a concrete id."
+  [variant-id]
+  (try
+    {:explain (plan/explain variant-id)}
+    (catch #?(:clj Throwable :cljs :default) e
+      {:error (or #?(:clj (.getMessage ^Throwable e)
+                     :cljs (.-message e))
+                  (str e))})))
+
+;; ---------------------------------------------------------------------------
+;; Pure: per-section projection
+;;
+;; Each section descriptor is data → data so the JVM corpus can assert
+;; the full ordered inventory + the present?/empty distinction without
+;; a host. The CLJS renderer dispatches on `:render-as` to paint each.
+;;
+;; `:render-as` vocabulary:
+;;   :chain      — an ordered vector of ids rendered as a breadcrumb
+;;   :kv         — a {k v} map rendered as a key/value table
+;;   :pairs      — a vector of {:key :value} maps rendered as a 2-col table
+;;   :steps      — an ordered vector of step/check/assertion forms
+;;   :compose    — the composed fragment/check vector
+;;   :conflicts  — the strict-conflict trail
+;;   :network    — the network lowering ({:routes :lowered-to})
+;;   :sub-ovr    — the sub-override lowering ({:overrides :validation})
+;;   :runner     — the required-runner capability set
+;;   :badges     — a set rendered as inline chips (platforms / tags / fidelity)
+;; ---------------------------------------------------------------------------
+
+(defn- present?
+  "True when an explain slot carries renderable content. Empty
+  collections + nil read as absent → the section renders its
+  'not available' empty state. `false` / `0` are not explain values so
+  the simple seq/some? test is sufficient."
+  [v]
+  (cond
+    (nil? v)        false
+    (coll? v)       (seq v)
+    :else           true))
+
+(defn explain-sections
+  "Project an `:explain` map into the ordered vector of section
+  descriptors the panel renders (spec/020 §4 / spec/017 §Explain API).
+
+  Each descriptor:
+
+      {:id        stable id (DOM + test hook)
+       :label     human section label
+       :render-as render dispatch keyword (see ns comment)
+       :present?  whether the slot carries content
+       :value     the raw slot value (nil/empty when absent)
+       :note      optional 'when this is empty it means …' hint}
+
+  The ordering is provenance → composition → args → lowering →
+  execution → metadata, which is the order a reviewer reads a plan:
+  *where it came from*, *what merged*, *what the args resolved to*,
+  *how features lowered*, *what runs*, *what it's tagged*.
+
+  Pure data → data; JVM-testable. Renders EVERY spec-listed slot —
+  absent ones carry `:present? false` so the renderer paints an honest
+  empty state rather than dropping the section (a dropped section would
+  read as 'this variant has no source chain' which is never true)."
+  [explain]
+  (let [e (or explain {})
+        section (fn [id label render-as value & [note]]
+                  {:id        id
+                   :label     label
+                   :render-as render-as
+                   :present?  (present? value)
+                   :value     value
+                   :note      note})]
+    [;; ---- provenance ----
+     (section "source-chain" "Source chain" :chain (:source-chain e)
+              "the extends root → variant chain the plan composed from")
+     (section "parent-chain" "Parent chain" :chain (:parent-chain e)
+              "no parents → this variant declares no :extends")
+     (section "compose" "Composed fragments / checks" :compose (:compose e)
+              "no :compose directive on this variant")
+     ;; ---- composition decisions ----
+     (section "merge" "Merge decisions" :kv (:merge e)
+              "the per-slot merge strategy the compiler applied")
+     (section "strict-conflicts" "Strict conflicts" :conflicts (:strict-conflicts e)
+              "no composed-fragment conflicts to resolve")
+     ;; ---- args ----
+     (section "args" "Args" :kv (:args e)
+              "no args resolved on this variant")
+     (section "substitutions" "Arg substitutions" :pairs (:substitutions e)
+              "no [:arg …] placeholders were substituted")
+     (section "effective-args" "Effective args" :kv (:effective-args e)
+              "the post-substitution args fed to the view")
+     (section "view-args-validation" "View-args validation" :kv (:view-args-validation e)
+              "no view-args schema on file for this variant")
+     ;; ---- lowering ----
+     (section "network" "Network lowering" :network (:network e)
+              "this variant authors no :network routes")
+     (section "sub-overrides" "Sub-override lowering" :sub-ovr (:sub-overrides e)
+              "this variant pins no view-state subscription overrides")
+     (section "fidelity" "Fidelity" :badges (:fidelity e)
+              "real-setup fidelity — no overrides lower the evidence rung")
+     ;; ---- execution ----
+     (section "setup-order" "Setup order" :steps (:setup-order e)
+              "no :setup / :events steps")
+     (section "script-order" "Script order" :steps (:script-order e)
+              "no :script / :play steps")
+     (section "checks" "Checks" :steps (:checks e)
+              "no inherited or composed checks")
+     (section "assertions" "Assertions" :steps (:assertions e)
+              "no terminal assertions")
+     (section "required-runner" "Runner requirements" :runner (:required-runner e)
+              "app-db-only — resolves to the :headless runner")
+     ;; ---- metadata ----
+     (section "platforms" "Platforms" :badges (:platforms e)
+              "defaults to #{:client}")
+     (section "tags" "Tags" :badges (:tags e)
+              "no tags on this variant or its parents")
+     (section "source" "Source coords" :kv (:source e)
+              "no source coordinates captured at registration")]))
+
+;; ---------------------------------------------------------------------------
+;; Pure: small string shapers shared by the renderer + the test corpus
+;; ---------------------------------------------------------------------------
+
+(defn chain-label
+  "Render a source/parent chain vector as a `a → b → c` breadcrumb
+  string. Empty chain → the empty-state marker is the caller's job;
+  this returns \"\" so the test corpus can assert the join shape."
+  [chain]
+  (str/join "  →  " (map pr-str (or chain []))))
+
+(defn conflict-summary
+  "One-line human summary of a single strict-conflict entry — the
+  winning source beat the losing sources by `:rule`. Pure so the JVM
+  corpus can pin the phrasing."
+  [{:keys [field key winner winning-source losing-sources rule]}]
+  (str (pr-str field) " / " (pr-str key)
+       " — " (pr-str (or winning-source :?)) " wins"
+       (when (seq losing-sources)
+         (str " over " (str/join ", " (map pr-str losing-sources))))
+       " (" (name (or rule :?)) ")"
+       (when (some? winner) (str " = " (pr-str winner)))))
+
+(defn raw-edn
+  "Pretty-ish EDN string of the explain map for the raw-EDN view +
+  copy-to-clipboard. `pr-str` keeps it parseable + paste-ready for
+  agent use; the renderer wraps it in a scrollable `<pre>`."
+  [explain]
+  (pr-str explain))
+
+;; ---------------------------------------------------------------------------
+;; CLJS-only rendering
+;; ---------------------------------------------------------------------------
+
+#?(:cljs
+   (def ^:private styles
+     {:wrap          {:font-family   sans-stack
+                      :font-size     (:body-tight typography/type-scale)
+                      :color         (:text-primary colors/tokens)
+                      :padding-bottom "12px"}
+      :variant-id    {:font-family   mono-stack
+                      :font-size     (:caption typography/type-scale)
+                      :color         (:accent-amber colors/tokens)
+                      :margin        "0 0 2px 0"
+                      :word-break    "break-all"}
+      :blurb         {:color         (:text-tertiary colors/tokens)
+                      :font-size     (:caption typography/type-scale)
+                      :margin-bottom "10px"
+                      :line-height   (:line-height-tight typography/type-scale)}
+      :section       {:margin-top    "12px"}
+      :section-h     {:display       "flex"
+                      :align-items   "baseline"
+                      :justify-content "space-between"
+                      :gap           "8px"
+                      :color         (:text-secondary colors/tokens)
+                      :text-transform "uppercase"
+                      :font-size     (:micro typography/type-scale)
+                      :letter-spacing (:label typography/letter-spacing)
+                      :margin-bottom "4px"
+                      :padding-bottom "3px"
+                      :border-bottom (str "1px solid " (:border-subtle colors/tokens))}
+      :absent-tag    {:color         (:text-tertiary colors/tokens)
+                      :font-style    "italic"
+                      :text-transform "none"
+                      :letter-spacing "normal"
+                      :font-size     (:micro typography/type-scale)}
+      :empty         {:color         (:text-tertiary colors/tokens)
+                      :font-style    "italic"
+                      :font-size     (:caption typography/type-scale)
+                      :padding       "2px 0 4px 0"}
+      :chain         {:font-family   mono-stack
+                      :font-size     (:caption typography/type-scale)
+                      :color         (:info colors/tokens)
+                      :word-break    "break-all"
+                      :line-height   (:line-height-mono typography/type-scale)}
+      :table         {:width         "100%"
+                      :border-collapse "collapse"
+                      :font-family   mono-stack
+                      :font-size     (:caption typography/type-scale)}
+      :td            {:padding       "3px 6px 3px 0"
+                      :border-bottom (str "1px solid " (:border-subtle colors/tokens))
+                      :color         (:text-primary colors/tokens)
+                      :vertical-align "top"
+                      :white-space   "pre-wrap"
+                      :word-break    "break-word"}
+      :td-key        {:color         (:info colors/tokens)
+                      :white-space   "nowrap"
+                      :padding-right "10px"}
+      :td-val        {:color         (:tag-experimental-fg colors/tokens)}
+      :list          {:margin        0
+                      :padding-left  "16px"
+                      :font-family   mono-stack
+                      :font-size     (:caption typography/type-scale)
+                      :color         (:text-primary colors/tokens)
+                      :line-height   (:line-height-mono typography/type-scale)}
+      :badge-row     {:display       "flex"
+                      :flex-wrap     "wrap"
+                      :gap           "4px"
+                      :margin-top    "2px"}
+      :badge         {:font-family   mono-stack
+                      :font-size     (:nano typography/type-scale)
+                      :background    (:bg-3 colors/tokens)
+                      :color         (:text-secondary colors/tokens)
+                      :border        (str "1px solid " (:border-subtle colors/tokens))
+                      :border-radius "8px"
+                      :padding       "1px 7px"}
+      :conflict      {:font-family   mono-stack
+                      :font-size     (:caption typography/type-scale)
+                      :color         (:warning colors/tokens)
+                      :padding       "2px 0"
+                      :line-height   (:line-height-mono typography/type-scale)}
+      :toolbar       {:display       "flex"
+                      :gap           "6px"
+                      :margin-bottom "8px"}
+      :btn           {:font-family   sans-stack
+                      :font-size     (:caption typography/type-scale)
+                      :background    (:bg-3 colors/tokens)
+                      :color         (:text-secondary colors/tokens)
+                      :border        (str "1px solid " (:border-default colors/tokens))
+                      :border-radius "6px"
+                      :padding       "3px 9px"
+                      :cursor        "pointer"
+                      :user-select   "none"}
+      :btn-on        {:background    (:accent-amber colors/tokens)
+                      :color         (:text-on-accent colors/tokens)
+                      :border        (str "1px solid " (:accent-amber-deep colors/tokens))}
+      :pre           {:font-family   mono-stack
+                      :font-size     (:caption typography/type-scale)
+                      :background    (:bg-input colors/tokens)
+                      :color         (:text-primary colors/tokens)
+                      :border        (str "1px solid " (:border-subtle colors/tokens))
+                      :border-radius "4px"
+                      :padding       "8px"
+                      :margin        0
+                      :max-height    "320px"
+                      :overflow      "auto"
+                      :white-space   "pre-wrap"
+                      :word-break    "break-word"}
+      :copied        {:color         (:success colors/tokens)
+                      :font-size     (:caption typography/type-scale)
+                      :align-self    "center"}
+      :error         {:color         (:danger colors/tokens)
+                      :font-family   mono-stack
+                      :font-size     (:caption typography/type-scale)
+                      :background    (:danger-bg colors/tokens)
+                      :border        (str "1px solid " (:danger colors/tokens))
+                      :border-radius "4px"
+                      :padding       "8px"
+                      :white-space   "pre-wrap"
+                      :word-break    "break-word"}
+      :no-variant    {:color         (:text-tertiary colors/tokens)
+                      :font-style    "italic"
+                      :font-size     (:caption typography/type-scale)
+                      :padding       "4px 0"}}))
+
+#?(:cljs
+   (defn- pretty
+     "Render a scalar/collection explain value. `pr-str` for everything
+     so keywords / maps / vectors stay visibly typed (a string shows
+     quoted)."
+     [v]
+     (if (nil? v) "nil" (pr-str v))))
+
+#?(:cljs
+   (defn- kv-table
+     "Render a {k v} map as a 2-column key/value table."
+     [m]
+     [:table {:style (:table styles)}
+      [:tbody
+       (for [[k v] (if (map? m) (sort-by (comp str key) m) m)]
+         ^{:key (str k)}
+         [:tr
+          [:td {:style (merge (:td styles) (:td-key styles))} (pretty k)]
+          [:td {:style (merge (:td styles) (:td-val styles))} (pretty v)]])]]))
+
+#?(:cljs
+   (defn- pairs-table
+     "Render a vector of `{:key :value}` substitution maps."
+     [pairs]
+     [:table {:style (:table styles)}
+      [:tbody
+       (for [[i {:keys [key value]}] (map-indexed vector pairs)]
+         ^{:key i}
+         [:tr
+          [:td {:style (merge (:td styles) (:td-key styles))} (pretty key)]
+          [:td {:style (merge (:td styles) (:td-val styles))} (pretty value)]])]]))
+
+#?(:cljs
+   (defn- steps-list
+     "Render an ordered vector of forms (setup / script / checks /
+     assertions) as a numbered mono list."
+     [forms]
+     [:ol {:style (:list styles)}
+      (for [[i form] (map-indexed vector forms)]
+        ^{:key i}
+        [:li (pr-str form)])]))
+
+#?(:cljs
+   (defn- badge-row
+     "Render a set/coll as inline mono chips (platforms / tags /
+     fidelity / runner capability tokens)."
+     [items]
+     [:div {:style (:badge-row styles)}
+      (for [item (sort-by str items)]
+        ^{:key (str item)}
+        [:span {:style (:badge styles)} (pr-str item)])]))
+
+#?(:cljs
+   (defn- conflict-list
+     [conflicts]
+     [:div
+      (for [[i c] (map-indexed vector conflicts)]
+        ^{:key i}
+        [:div {:style (:conflict styles)} (conflict-summary c)])]))
+
+#?(:cljs
+   (defn- network-view
+     "Render the network lowering — per-route reply stubs + the managed-
+     stub fx the routes lower to."
+     [{:keys [routes lowered-to]}]
+     [:div
+      (when (seq routes)
+        [kv-table routes])
+      (when (seq lowered-to)
+        [:div {:style (:section styles)}
+         [:div {:style (:empty styles)} "lowered to:"]
+         [kv-table lowered-to]])]))
+
+#?(:cljs
+   (defn- sub-ovr-view
+     "Render the sub-override lowering — the resolved override map + the
+     output-schema validation outcome."
+     [{:keys [overrides validation]}]
+     [:div
+      (when (seq overrides)
+        [kv-table overrides])
+      (when validation
+        [:div {:style (:section styles)}
+         [:div {:style (:empty styles)} "validation:"]
+         [kv-table validation]])]))
+
+#?(:cljs
+   (defn- render-section-body
+     "Dispatch on `:render-as` to paint one section's body."
+     [{:keys [render-as value]}]
+     (case render-as
+       :chain     [:div {:style (:chain styles)} (chain-label value)]
+       :kv        [kv-table value]
+       :pairs     [pairs-table value]
+       :steps     [steps-list value]
+       :compose   [:ol {:style (:list styles)}
+                   (for [[i {:keys [kind id]}] (map-indexed vector value)]
+                     ^{:key i}
+                     [:li (str (name kind) " " (pr-str id))])]
+       :conflicts [conflict-list value]
+       :network   [network-view value]
+       :sub-ovr   [sub-ovr-view value]
+       :runner    [badge-row value]
+       :badges    [badge-row value]
+       ;; defensive: an unknown render-as falls back to raw EDN so the
+       ;; section never blanks on a future slot.
+       [:div {:style (:chain styles)} (pretty value)])))
+
+#?(:cljs
+   (defn- section-view
+     "Render one explain section — header (label + absent tag) and the
+     body, OR the honest empty state when the slot carries no content."
+     [{:keys [id label present? note] :as section}]
+     [:div {:style     (:section styles)
+            :data-test "story-explain-section"
+            :data-explain-section id
+            :data-present (str (boolean present?))}
+      [:div {:style (:section-h styles)}
+       [:span label]
+       (when-not present?
+         [:span {:style (:absent-tag styles)} "not available"])]
+      (if present?
+        (render-section-body section)
+        [:div {:style (:empty styles)} (or note "—")])]))
+
+#?(:cljs
+   (defn- raw-edn-pane
+     "Render the raw-EDN escape hatch — a scrollable `<pre>` of the
+     explain map for human reading + agent paste."
+     [explain]
+     [:pre {:style (:pre styles)
+            :data-test "story-explain-raw-edn"}
+      (raw-edn explain)]))
+
+#?(:cljs
+   (defn explain-panel
+     "The Explain RHS inspector body (spec/020 §4). Reads the focused
+     variant from shell state, compiles its explain map via the pure
+     plan compiler (NOT Xray — provenance + lowering is Story-owned),
+     and renders every spec-listed slot with graceful 'not available'
+     empty states. Carries a raw-EDN toggle + copy-to-clipboard.
+
+     States:
+     - no variant focused → a quiet 'select a variant' line;
+     - compile error → the structured plan-construction error;
+     - otherwise → the section inventory (or the raw EDN when toggled)."
+     []
+     (let [show-raw? (r/atom false)
+           copied?   (r/atom false)]
+       (fn []
+         (let [shell      @state/shell-state-atom
+               variant-id (:selected-variant shell)]
+           (cond
+             (not variant-id)
+             [:div {:style     (:no-variant styles)
+                    :data-test "story-explain-no-variant"}
+              "Select a variant to explain its plan."]
+
+             :else
+             (let [{:keys [explain error]} (explain-for variant-id)]
+               [:div {:style     (:wrap styles)
+                      :data-test "story-explain-panel"
+                      :data-variant-id (str variant-id)}
+                [:div {:style (:variant-id styles)} (str variant-id)]
+                [:div {:style (:blurb styles)}
+                 "Provenance + lowering for this plan. Read-only; "
+                 "static-plan companion to the Xray runtime panels."]
+                (if error
+                  [:div {:style     (:error styles)
+                         :data-test "story-explain-error"}
+                   error]
+                  [:div
+                   ;; ---- toolbar: raw-EDN toggle + copy ----
+                   [:div {:style (:toolbar styles)}
+                    [:button
+                     {:style     (merge (:btn styles)
+                                        (when @show-raw? (:btn-on styles)))
+                      :data-test "story-explain-toggle-raw"
+                      :aria-pressed (str (boolean @show-raw?))
+                      :title     "Toggle raw EDN view of the explain map"
+                      :on-click  (fn [_] (swap! show-raw? not))}
+                     (if @show-raw? "Sections" "Raw EDN")]
+                    [:button
+                     {:style     (:btn styles)
+                      :data-test "story-explain-copy"
+                      :title     "Copy the explain map as EDN to the clipboard"
+                      :on-click  (fn [_]
+                                   (review-dialog/copy-to-clipboard! (raw-edn explain))
+                                   (reset! copied? true)
+                                   (js/setTimeout #(reset! copied? false) 1400))}
+                     "Copy EDN"]
+                    (when @copied?
+                      [:span {:style     (:copied styles)
+                              :data-test "story-explain-copied"}
+                       "copied"])]
+                   (if @show-raw?
+                     [raw-edn-pane explain]
+                     [:div {:data-test "story-explain-sections"}
+                      (for [section (explain-sections explain)]
+                        ^{:key (:id section)}
+                        [section-view section])])])])))))))
+
+;; ---------------------------------------------------------------------------
+;; CLJS-only: command-palette helper — open the panel + scroll it in.
+;; ---------------------------------------------------------------------------
+
+#?(:cljs
+   (defn open!
+     "Open the Explain RHS section (flip its `:panel-visibility` slot on)
+     and scroll it into view. Wired from the command palette's
+     `Explain variant` command. No-op when Story is disabled."
+     []
+     (when config/enabled?
+       (state/swap-state! assoc-in [:panel-visibility panel-key] true)
+       (js/setTimeout
+         (fn []
+           (when (exists? js/document)
+             (when-let [el (.getElementById js/document anchor-id)]
+               (try
+                 (.scrollIntoView el #js {:behavior "smooth" :block "start"})
+                 (catch :default _ nil)))))
+         0))))

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -589,7 +589,7 @@
      ;; scrolls here when the user has toggled it off.
      (when (and variant-id
                 (not (false? (get vis explain-panel/panel-key)))) ;; nil/true → show
-       [:section {:id (explain-panel/anchor-id)
+       [:section {:id explain-panel/anchor-id
                   :style (:rhs-section styles)
                   :data-rf-rhs-section "explain"}
         [:div {:style (:rhs-section-h styles)}

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -70,6 +70,7 @@
             [re-frame.story.ui.dispatch-console :as dispatch-console]
             [re-frame.story.ui.docs :as docs]
             [re-frame.story.ui.element-inspector :as element-inspector]
+            [re-frame.story.ui.explain-panel :as explain-panel]
             [re-frame.story.ui.help :as help]
             [re-frame.story.ui.keybindings :as keybindings]
             [re-frame.story.ui.mode-tabs :as mode-tabs]
@@ -573,6 +574,31 @@
                        :letter-spacing "0.04em"}}
         "diagnostic"]]
       [xray-embed/xray-embed-panel]]
+     ;; rf2-ba86n.9 — Explain panel. The Story-owned provenance +
+     ;; lowering surface over `story/explain` data (spec/020 §4). Sits
+     ;; directly under the Xray embed: same RHS inspector rail, but a
+     ;; STATIC-plan lens (where did this plan come from / how was it
+     ;; lowered) versus Xray's RUNTIME diagnostics. It consumes the pure
+     ;; plan compiler's `:explain` map and pulls NO Xray symbol — the
+     ;; two never share code (spec/020 §1.2 + §4 Xray-independence).
+     ;;
+     ;; Gated on a focused variant (the explain map is per-variant) and
+     ;; the `:explain` visibility slot. The slot defaults to ON when
+     ;; unset (nil) so the inspector entry is reachable out of the box;
+     ;; the command palette's `Explain variant` command flips it on +
+     ;; scrolls here when the user has toggled it off.
+     (when (and variant-id
+                (not (false? (get vis explain-panel/panel-key)))) ;; nil/true → show
+       [:section {:id (explain-panel/anchor-id)
+                  :style (:rhs-section styles)
+                  :data-rf-rhs-section "explain"}
+        [:div {:style (:rhs-section-h styles)}
+         [:span "Explain"]
+         [:span {:style {:font-weight "400"
+                         :color (:text-tertiary colors/tokens)
+                         :letter-spacing "0.04em"}}
+          "provenance + lowering"]]
+        [explain-panel/explain-panel]])
      (when (:controls vis)
        [:section {:style (:rhs-section styles)
                   :data-rf-rhs-section "controls"}

--- a/tools/story/test/re_frame/story/ui/explain_panel_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/explain_panel_cljs_test.cljs
@@ -1,0 +1,142 @@
+(ns re-frame.story.ui.explain-panel-cljs-test
+  "CLJS-side regression net for the Explain panel (rf2-ba86n.9,
+  spec/020 §4).
+
+  Pairs with the host-free projection coverage in
+  `re_frame/story/ui/explain_panel_test.cljc`. This namespace pins the
+  reachability + render wiring that needs a CLJS runtime:
+
+  - **command-palette reachability** — the synthetic `Explain variant`
+    command appears in the palette corpus, ranks for an `explain`
+    query, and `select-entry!` runs `explain-panel/open!` which flips
+    the `:explain` panel-visibility slot on. This is the bead's
+    'reachable from the command palette' acceptance.
+
+  - **render-with-explain state** — for a registered variant the panel
+    renders the section inventory (one `story-explain-section` node per
+    spec slot) plus the raw-EDN / copy toolbar; absent slots carry
+    `data-present=false`.
+
+  - **render-no-variant state** — with no focused variant the panel
+    renders the quiet 'select a variant' empty state.
+
+  - **render-error state** — an unknown variant surfaces the structured
+    compile error rather than blanking.
+
+  Per the Story testing posture (CLJS unit tests, not Playwright) the
+  panel render is exercised by calling the form-2 component's inner
+  render fn directly and walking the hiccup with `re-frame.test-helpers`."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core             :as rf]
+            [re-frame.frame            :as frame]
+            [re-frame.registrar        :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.story            :as story]
+            [re-frame.test-helpers     :as th]
+            [re-frame.story.ui.command-palette :as palette]
+            [re-frame.story.ui.command-palette.view :as palette-view]
+            [re-frame.story.ui.explain-panel :as explain-panel]
+            [re-frame.story.ui.state   :as state]))
+
+;; ---- fixtures ------------------------------------------------------------
+
+(defn reset-all! []
+  (story/clear-all!)
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (try (rf/init! plain-atom/adapter)
+       (catch :default _ nil))
+  (state/reset-shell-state!)
+  (story/install-canonical-vocabulary!)
+  (frame/ensure-default-frame!))
+
+(use-fixtures :each {:before reset-all! :after reset-all!})
+
+(defn- reg-counter! []
+  ;; A minimal registered story + variant so the plan compiler resolves
+  ;; the keyword target to a real plan. No `:component` needed — the
+  ;; view-args-schema slot is simply absent (rendered 'not available').
+  (story/reg-story :story.explain {:doc "Explain probe"})
+  (story/reg-variant :story.explain/basic
+                     {:args {:label "Hi"}
+                      :tags #{:test}}))
+
+;; ===========================================================================
+;; command-palette reachability
+;; ===========================================================================
+
+(deftest command-entry-present-in-corpus
+  (testing "the synthetic Explain command is built into the palette corpus"
+    (let [entries  (palette/entries (state/registry-snapshot))
+          commands (filterv #(= :command (:kind %)) entries)]
+      (is (= 1 (count commands)) "exactly one synthetic command")
+      (is (= :explain (:id (first commands))))
+      (is (= :explain (:action (first commands)))))))
+
+(deftest command-entry-ranks-for-explain-query
+  (testing "an `explain` query surfaces the command at the top of results"
+    (reg-counter!)
+    (let [entries (palette/entries (state/registry-snapshot))
+          results (palette/search entries "explain")
+          top     (first results)]
+      (is (= :command (:kind top)))
+      (is (= :explain (:id top))))))
+
+(deftest select-command-opens-panel-visibility-slot
+  (testing "selecting the Explain command flips :panel-visibility :explain on"
+    (reg-counter!)
+    ;; Start hidden so the open! flip is observable.
+    (state/swap-state! assoc-in [:panel-visibility explain-panel/panel-key] false)
+    (is (false? (get-in (state/get-state) [:panel-visibility explain-panel/panel-key])))
+    (let [entry (->> (palette/entries (state/registry-snapshot))
+                     (filter #(= :command (:kind %)))
+                     first)
+          handled (palette-view/select-entry! entry)]
+      (is (true? handled) "command selection reports handled")
+      (is (true? (get-in (state/get-state)
+                         [:panel-visibility explain-panel/panel-key]))
+          "open! turned the Explain panel-visibility slot on"))))
+
+;; ===========================================================================
+;; render states
+;; ===========================================================================
+
+(defn- render-panel
+  "Invoke the form-2 component's inner render fn (the panel reads
+  `state/shell-state-atom`, so seed selection first)."
+  []
+  (let [render-fn (explain-panel/explain-panel)]
+    (render-fn)))
+
+(deftest render-no-variant-shows-empty-state
+  (testing "with no focused variant the panel renders the quiet empty state"
+    (let [tree (render-panel)]
+      (is (some? (th/find-by-attr tree :data-test "story-explain-no-variant")))
+      (is (nil? (th/find-by-attr tree :data-test "story-explain-panel"))))))
+
+(deftest render-with-variant-shows-section-inventory
+  (testing "for a registered variant the panel renders every spec section
+            plus the raw-EDN / copy toolbar"
+    (reg-counter!)
+    (state/swap-state! state/select-variant :story.explain/basic)
+    (let [tree     (render-panel)
+          sections (th/find-all-by-attr tree :data-test "story-explain-section")
+          present  (mapv #(get (second %) :data-present) sections)]
+      (is (some? (th/find-by-attr tree :data-test "story-explain-panel")))
+      (is (= (count (explain-panel/explain-sections {})) (count sections))
+          "one section node per spec slot")
+      (is (some #(= "true" %) present)
+          "at least one slot is present (source-chain always is)")
+      (is (some? (th/find-by-attr tree :data-test "story-explain-toggle-raw"))
+          "raw-EDN toggle present")
+      (is (some? (th/find-by-attr tree :data-test "story-explain-copy"))
+          "copy-to-clipboard button present"))))
+
+(deftest render-error-shows-structured-error
+  (testing "an unknown variant target surfaces the compile error, not a blank"
+    (state/swap-state! state/select-variant :story.explain/does-not-exist)
+    (let [tree (render-panel)]
+      (is (some? (th/find-by-attr tree :data-test "story-explain-error"))
+          "compile error rendered")
+      (is (nil? (th/find-by-attr tree :data-test "story-explain-sections"))
+          "no section inventory when the plan failed to compile"))))

--- a/tools/story/test/re_frame/story/ui/explain_panel_test.cljc
+++ b/tools/story/test/re_frame/story/ui/explain_panel_test.cljc
@@ -1,0 +1,180 @@
+(ns re-frame.story.ui.explain-panel-test
+  "JVM-portable regression net for the Explain panel's pure projection
+  (rf2-ba86n.9, spec/020 §4 / spec/017 §Explain API).
+
+  Covers the host-free surface:
+
+  - `explain-sections` — the ordered section inventory, the
+    present?/absent distinction, and that EVERY spec-listed slot is
+    rendered (absent ones marked, never dropped).
+  - `explain-for`       — error-trapping over the pure plan compiler
+    (a missing arg / unknown variant surfaces as `:error`, not a
+    thrown exception).
+  - the string shapers (`chain-label` / `conflict-summary` / `raw-edn`).
+
+  CLJS-side (the React render of each `:render-as`, the raw-EDN toggle,
+  copy-to-clipboard, the open!/scroll command) lives in
+  `explain_panel_cljs_test.cljs`; this corpus pins the pure projection
+  only — no host, no Reagent."
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.string :as str]
+            #?(:clj  [clojure.edn :as edn]
+               :cljs [cljs.reader :as edn])
+            [re-frame.story.ui.explain-panel :as explain]))
+
+;; ---------------------------------------------------------------------------
+;; A representative explain map. Mirrors the slot shape the plan compiler
+;; emits (re-frame.story.plan/build-plan): a composed, arg-substituted,
+;; network + sub-override lowering plan so the present? branches are
+;; exercised, plus the always-present provenance/execution/metadata slots.
+;; ---------------------------------------------------------------------------
+
+(def ^:private full-explain
+  {:source-chain [:story.cp/base :story.cp/child]
+   :parent-chain [:story.cp/base]
+   :compose      [{:kind :fragment :id :frag/auth}
+                  {:kind :check :id :check/a11y}]
+   :merge        {:setup      :append-inherited-compose-own
+                  :args       :deep-merge-inherited-compose-own
+                  :checks     :inherit-then-compose
+                  :assertions :child-only
+                  :script     :compose-then-child
+                  :fx-overrides :strict-variant-owned-wins
+                  :interceptor-overrides :strict-variant-owned-wins}
+   :strict-conflicts [{:field :fx-overrides
+                       :key   :rf.http/managed
+                       :winner :variant-stub
+                       :winning-source :variant
+                       :losing-sources [:frag/auth]
+                       :rule  :variant-owned-wins}]
+   :args         {:label "Hi" :count 3}
+   :substitutions [{:key :label :value "Hi"}]
+   :effective-args {:label "Hi" :count 3}
+   :view-args-validation {:status :ok :missing [] :malformed []}
+   :network      {:routes     {[:get "/api/cart"] {:reply {:ok {:items []}}}}
+                  :lowered-to {:rf.http/managed :rf.http/managed-test-stub}}
+   :sub-overrides {:overrides  {[:cart/total] 42}
+                   :validation {:status :ok :violations []}}
+   :fidelity     #{:real-setup :sub-overrides}
+   :setup-order  [[:dispatch [:cp/init]]]
+   :script-order [[:dispatch [:cp/inc]]]
+   :checks       [:check/a11y]
+   :assertions   [[:rf.assert/no-warnings]]
+   :required-runner #{:dom}
+   :platforms    #{:client}
+   :tags         #{:test :a11y}
+   :source       {:file "cp.cljc" :line 12 :column 3}})
+
+;; ---------------------------------------------------------------------------
+;; explain-sections — inventory + ordering + every spec-listed slot
+;; ---------------------------------------------------------------------------
+
+(def ^:private expected-section-ids
+  ["source-chain" "parent-chain" "compose"
+   "merge" "strict-conflicts"
+   "args" "substitutions" "effective-args" "view-args-validation"
+   "network" "sub-overrides" "fidelity"
+   "setup-order" "script-order" "checks" "assertions" "required-runner"
+   "platforms" "tags" "source"])
+
+(deftest sections-cover-every-spec-slot-in-order
+  (testing "the section inventory renders every spec/020 §4 / spec/017
+            §Explain API slot, in the provenance → composition → args →
+            lowering → execution → metadata order"
+    (is (= expected-section-ids
+           (mapv :id (explain/explain-sections full-explain)))))
+  (testing "every section carries the descriptor slots the renderer reads"
+    (doseq [s (explain/explain-sections full-explain)]
+      (is (some? (:id s)))
+      (is (some? (:label s)))
+      (is (keyword? (:render-as s)))
+      (is (contains? s :present?))
+      (is (contains? s :value)))))
+
+(deftest full-explain-marks-populated-slots-present
+  (testing "with a fully-featured plan every section is present? true"
+    (let [by-id (into {} (map (juxt :id identity)
+                              (explain/explain-sections full-explain)))]
+      (doseq [id expected-section-ids]
+        (is (true? (boolean (:present? (get by-id id))))
+            (str id " should be present in a fully-featured explain map"))))))
+
+(deftest empty-explain-marks-optional-slots-absent
+  (testing "an empty explain map renders the full inventory, with the
+            optional slots marked not-available (never dropped)"
+    (let [sections (explain/explain-sections {})
+          by-id    (into {} (map (juxt :id identity) sections))]
+      (is (= expected-section-ids (mapv :id sections))
+          "the inventory is the same — absent slots are NOT dropped")
+      (doseq [id expected-section-ids]
+        (is (false? (boolean (:present? (get by-id id))))
+            (str id " should be absent for an empty explain map")))
+      (testing "absent sections carry a human 'when empty this means…' note"
+        (is (every? (comp string? :note) (vals by-id)))))))
+
+(deftest nil-explain-is-safe
+  (testing "nil explain projects the same inventory, all absent — no throw"
+    (let [sections (explain/explain-sections nil)]
+      (is (= expected-section-ids (mapv :id sections)))
+      (is (every? (complement :present?) sections)))))
+
+(deftest network-and-sub-override-slots-carry-lowering
+  (testing "the network section value carries routes + the managed-stub lowering"
+    (let [net (->> (explain/explain-sections full-explain)
+                   (filter #(= "network" (:id %)))
+                   first)]
+      (is (= :network (:render-as net)))
+      (is (= {:rf.http/managed :rf.http/managed-test-stub}
+             (get-in net [:value :lowered-to])))))
+  (testing "the sub-override section value carries overrides + validation"
+    (let [so (->> (explain/explain-sections full-explain)
+                  (filter #(= "sub-overrides" (:id %)))
+                  first)]
+      (is (= :sub-ovr (:render-as so)))
+      (is (= {:status :ok :violations []}
+             (get-in so [:value :validation]))))))
+
+;; ---------------------------------------------------------------------------
+;; explain-for — error trapping over the pure compiler
+;; ---------------------------------------------------------------------------
+
+(deftest explain-for-traps-unknown-variant
+  (testing "an unregistered keyword target surfaces as :error, not a throw"
+    (let [result (explain/explain-for :story.nope/missing)]
+      (is (nil? (:explain result)))
+      (is (string? (:error result)))
+      (is (not (str/blank? (:error result)))))))
+
+(deftest explain-for-compiles-inline-plan
+  (testing "an inline plan map compiles to an :explain map (no host needed)"
+    (let [result (explain/explain-for {:variant/id :inline/x})]
+      (is (nil? (:error result))
+          (str "expected clean compile, got: " (:error result)))
+      (is (map? (:explain result)))
+      ;; the always-present provenance slot proves we got a real plan
+      (is (= [:inline/x] (get-in result [:explain :source-chain]))))))
+
+;; ---------------------------------------------------------------------------
+;; string shapers
+;; ---------------------------------------------------------------------------
+
+(deftest chain-label-joins-with-arrows
+  (is (= ":story.cp/base  →  :story.cp/child"
+         (explain/chain-label [:story.cp/base :story.cp/child])))
+  (testing "empty chain → empty string (caller renders the empty state)"
+    (is (= "" (explain/chain-label [])))
+    (is (= "" (explain/chain-label nil)))))
+
+(deftest conflict-summary-names-winner-and-losers
+  (let [s (explain/conflict-summary
+            (first (:strict-conflicts full-explain)))]
+    (is (str/includes? s ":variant wins"))
+    (is (str/includes? s ":frag/auth")
+        "names the full qualified losing source")
+    (is (str/includes? s "variant-owned-wins"))))
+
+(deftest raw-edn-roundtrips
+  (testing "raw-edn produces a parseable EDN string of the explain map"
+    (let [s (explain/raw-edn full-explain)]
+      (is (string? s))
+      (is (= full-explain (edn/read-string s))))))


### PR DESCRIPTION
First build-child of the StoryUI epic (ba86n.1 specs merged): a **Story-owned, read-only Explain panel** — provenance + lowering over the existing `story/explain` data, per **spec/020 §4** (Explain panel) and **spec/017 §Explain API**.

It is explicitly **NOT an Xray diagnostic panel**: it renders the pure plan compiler''s `:explain` map (`re-frame.story.plan/explain`) and pulls no Xray symbol. It is the *static-plan* companion to Xray''s *runtime* diagnostics — the two sit in the same RHS inspector rail but never share code (spec/020 §1.2 + §4 Xray-independence).

## New panel namespace

`re-frame.story.ui.explain-panel` (`.cljc`), mirroring the `docs.cljc` pure-`.cljc`-projection + `#?(:cljs …)`-render split:

- `explain-sections` — pure, JVM-testable projection of the `:explain` map into the ordered spec slot inventory. Renders **what''s there**; absent slots are marked "not available" (never dropped, never fabricated).
- `explain-for` — error-trapping over `plan/explain`; a missing arg / unknown variant surfaces a structured compile error rather than blanking.
- `chain-label` / `conflict-summary` / `raw-edn` — pure string shapers.
- CLJS render: per-section tables / numbered lists / inline badge chips, a **raw-EDN toggle** + **copy-to-clipboard** (shared `review-dialog/copy-to-clipboard!`), and clean no-variant / error empty states.

## Wiring

- **Inspector**: new RHS `:explain` section in `shell.cljs` `right-panel` (id `story-explain-panel`), placed under the Xray embed. Gated on a focused variant + the `:explain` panel-visibility slot (defaults ON when unset → reachable out of the box).
- **Command palette**: a synthetic `:command` palette entry (`Explain variant`) added to `command_palette.cljc`; `command_palette/view.cljs` `select-entry!` runs `explain-panel/open!`, which flips the `:explain` visibility slot on and scrolls the panel into view.

## Explain slots rendered (spec/020 §4 / spec/017 §Explain API)

Provenance → composition → args → lowering → execution → metadata:

`:source-chain`, `:parent-chain`, `:compose` (fragments/checks), `:merge` (per-slot strategy), `:strict-conflicts` (winner / losing-sources / rule), `:args`, `:substitutions`, `:effective-args`, `:view-args-validation`, `:network` (routes + managed-stub lowering), `:sub-overrides` (overrides + output-schema validation), `:fidelity`, `:setup-order`, `:script-order`, `:checks`, `:assertions`, `:required-runner`, `:platforms`, `:tags`, `:source` coords.

**Rendered as "not available" when absent in the CURRENT explain output** (the honest empty state, not a dropped section): `:parent-chain` (no `:extends`), `:compose` / `:strict-conflicts` (no composed fragments), `:network` (no routes authored), `:sub-overrides` (no pinned subs), `:view-args-validation` / `:source` (no schema / coords on file). Future slots the spec marks as not-yet-shipped (`:plan-hash` inputs, evidence projections) are intentionally **not** rendered.

## Xray-independence confirmation

- `explain_panel.cljc` requires only `re-frame.story.plan`, `theme.{typography,colors}`, and CLJS-only `config` / `review-dialog` / `ui.state` — **zero `day8.re-frame2-xray.*` requires** (static grep clean; only doc-comment mentions of "Xray").
- `plan.cljc`''s transitive deps are all pure Story (args / assertions / registrar / requirements / malli-schema / play.runner / framework-registrar) — no Xray.
- `npm run test:bundle-isolation` **PASS** (17 artefact entries; 35 internal sentinels absent).
- story-mcp has **no require** of the panel / command-palette / shell — `npm run test:story` (mcp-conformance) ends **STORY-MCP MCP-CLIENT CONFORMANCE GREEN**.

## Quality gates

- **clj-kondo lint fix (was the red gate):** `clj-kondo --parallel --fail-level error --lint tools/story` now reports **errors: 0** (121 warnings, all pre-existing/informational). Fixed `shell.cljs:592` (`anchor-id` is a `def`-bound string, not a fn — dropped the call parens so the section `:id` references the string) + moved the CLJS-only `theme.typography`/`theme.colors` requires in `explain_panel.cljc` into the `#?@(:cljs ...)` reader conditional (they are used only in the `#?(:cljs (def styles ...))` block), clearing the two unused-namespace warnings in the `.cljc` clj view.
- `tools/story` JVM (`clojure -M:test`): **1347 tests, 0 failures, 0 errors** (incl. new `explain_panel_test.cljc` — 10 tests / 163 assertions — and the existing command-palette pure corpus, unaffected).
- CLJS node integration (`npm run test:cljs`): **4872 tests, 0 failures, 0 errors** (incl. new `explain_panel_cljs_test.cljs`); clean compile, 0 warnings.
- `tools/story-mcp` JVM (`clojure -M:test`): **172 tests, 0 failures, 0 errors**.
- `tools/mcp-conformance` `npm run test:story`: **GREEN**.
- `npm run test:bundle-isolation`: **PASS**; `npm run test:reagent-slim:bundle-isolation` not separately run (no slim-relevant surface touched — change is tools/story-internal).
- `bash scripts/test-fast-pr.sh`: **PASS fast PR spine**.

No spec edits (spec/020 §4 already merged; rendered as-is). No Xray spec touched. `fingerprint.cljc` untouched.
