### PR TITLE
feat(story/ui): migrate Test mode to unified run-result UX (rf2-ba86n.11)

### DIFF
--- a/tools/story/src/re_frame/story/ui/test_mode/pure.cljc
+++ b/tools/story/src/re_frame/story/ui/test_mode/pure.cljc
@@ -27,6 +27,17 @@
 
 (def ^:private assertion-event? pred/assertion-event?)
 
+;; ---- the unified run-result verdicts (spec/017 §Run result) -------------
+;;
+;; The four verdicts every assertion record / check / run carries
+;; (`re-frame.story.result/statuses`). Mirrored here as a local set so the
+;; pure helpers can recognise a stamped `:status` without a require into
+;; `re-frame.story.result` (which loops through the runtime). rf2-ba86n.11.
+
+(def statuses
+  "The unified run / check / assertion verdicts (spec/017 §Run result)."
+  #{:pass :fail :cannot-run :error})
+
 ;; ---- pure: variant-has-tests? -------------------------------------------
 
 (defn- has-play-script?
@@ -92,7 +103,7 @@
   table renders. Each row carries:
 
       {:assertion :rf.assert/path-equals
-       :status    :pass|:fail|:skip
+       :status    :pass|:fail|:error|:cannot-run|:skip
        :label     \":rf.assert/path-equals [[:count] 7]\"
        :row-key   \":rf.assert/path-equals [[:count] 7]\"
        :detail    {:expected ... :actual ... :reason ...
@@ -101,6 +112,15 @@
   `:detail` is always present so the renderer can read uniformly;
   the renderer decides whether to surface it (only failing rows
   expand by default). Pure data → data; JVM-testable.
+
+  rf2-ba86n.11 — the unified run-result (`re-frame.story.result`) stamps a
+  `:status` on every assertion record (`:pass` / `:fail` / `:error` /
+  `:cannot-run`). This helper now PREFERS that stamped `:status` (the
+  unified shape, spec/017 §Run result) and only derives from `:passed?`
+  for a record minted by a status-unaware path. The legacy
+  `:passed?`-only read is the fallback, not the primary — completing the
+  Test-mode migration off the split lifecycle/assertions reading
+  (tools/story/spec/021 §1).
 
   `:row-key` is the stable identity the view uses to thread :expanded
   state across re-runs (rf2-tistm): keying on positional index opened
@@ -115,12 +135,22 @@
   The row's `:detail :source` slot accepts either."
   [record]
   (let [rec      (or record {})
+        st       (:status rec)
         passed?  (:passed? rec)
         aid      (:assertion rec)
         status   (cond
-                   (= :rf.assert/skipped aid) :skip
-                   passed?                    :pass
-                   :else                      :fail)
+                   (= :rf.assert/skipped aid)          :skip
+                   ;; rf2-ba86n.11 — the unified `:status` wins; the
+                   ;; :passed?-only derivation is the legacy fallback.
+                   (contains? statuses st)             st
+                   (:cannot-run? rec)                  :cannot-run
+                   (or (:error rec) (:exception rec))  :error
+                   passed?                             :pass
+                   ;; A record carrying neither a stamped :status nor a
+                   ;; truthy :passed? reads :fail — the conservative
+                   ;; view-side default (a missing pass signal can't be
+                   ;; rendered green). Matches the legacy contract.
+                   :else                               :fail)
         payload  (or (:payload rec) [])
         label    (let [p (pretty-payload payload)]
                    (cond-> (str aid)
@@ -289,3 +319,183 @@
       (not (pos-int? n))    []
       (< (count hv) n)      []
       :else                 (mapv :epoch-id (subvec hv (- (count hv) n))))))
+
+;; ===========================================================================
+;; UNIFIED RUN-RESULT PROJECTION  (rf2-ba86n.11, tools/story/spec/021 §1)
+;; ===========================================================================
+;;
+;; The `:test` pane consumes the ONE unified run-result `run-variant` /
+;; `reset-variant` now return (the `re-frame.story.result/run-result`
+;; shape merged with the legacy lifecycle slots — runtime.cljc
+;; `record-result-map`). These helpers project that result into the
+;; per-section render data the view renders, COMPLETING the migration off
+;; the legacy split `:lifecycle` / `:assertions` reading (spec/021 §1
+;; supersedes 009's result-reading contract):
+;;
+;;   - `run-status`         — the top-level verdict, including the distinct
+;;                            `:cannot-run` THIRD state + a `:pending`
+;;                            never-run / no-signal state.
+;;   - `check-rows`         — `:checks` grouped by check id (spec/021 §1).
+;;   - `schema-rows`        — consumed + unconsumed schema violations
+;;                            (spec/021 §1 — "schema violations, including
+;;                            consumed expected violations").
+;;   - `cannot-run-rows`    — the `:cannot-run` refusal rows (required vs
+;;                            available evidence/runner).
+;;   - `filter-rows`        — the failed-only filter over assertion rows.
+;;   - `evidence-available?`— whether the evidence spine can be linked yet
+;;                            (graceful "evidence pending" until ba86n.10).
+;;
+;; All pure data → data; JVM-testable. Render-what-is-present: a slot the
+;; substrate does not yet populate projects to an empty vector, NEVER a
+;; fabricated row.
+
+(defn run-status
+  "The top-level run verdict for `result` (spec/021 §1; spec/018 §12.6 status
+  vocabulary). Prefers the unified run-level `:status` so a tape-floor `:fail`
+  / a `:cannot-run` refusal surfaces even when the assertion counts alone
+  would read green. Falls back to a count-derived verdict ONLY when the
+  result carries no `:status` (a host without the unified shape):
+
+  - no result / nothing recorded  → `:pending`
+  - explicit unified `:status`    → that verdict (`:pass` / `:fail` /
+                                     `:error` / `:cannot-run`)
+  - else (legacy host) derive from the assertion summary:
+      zero assertions             → `:pending`  (ran, no signal)
+      any fail/error              → `:fail`
+      any cannot-run              → `:cannot-run`
+      else                        → `:pass`
+
+  `summary` is the `aggregate-summary` fold (passed/failed/cannot-run/total).
+  Pure data → data; JVM-testable."
+  [result summary]
+  (let [st (:status result)]
+    (cond
+      (nil? result)             :pending
+      (contains? statuses st)   st
+      :else
+      (let [{:keys [total failed cannot-run all-passed?]} (or summary {})]
+        (cond
+          (zero? (or total 0))     :pending
+          (pos? (or failed 0))     :fail
+          all-passed?              :pass
+          (pos? (or cannot-run 0)) :cannot-run
+          :else                    :fail)))))
+
+(defn check-rows
+  "Project the run-result's `:checks` slot (spec/017 §Checks, surfaced per
+  spec/021 §1 — checks grouped by check id) into render rows:
+
+      [{:check     <check-id>
+        :status    :pass|:fail|:error|:cannot-run
+        :passed    <n>   ; passing assertions in the group
+        :failed    <n>   ; fail + error assertions in the group
+        :total     <n>
+        :rows      [<assertion-row> …]}]   ; the underlying records,
+                                            ; so a failed check shows BOTH
+                                            ; the check id AND its records
+                                            ; (spec/017 §Run result).
+
+  Empty when the plan declared no checks (the common case today — render an
+  honest empty state, never a fabricated check). Pure data → data."
+  [result]
+  (mapv (fn [{:keys [check status assertions]}]
+          (let [rows   (mapv assertion-row (or assertions []))
+                buckets (frequencies (map :status rows))
+                passed  (get buckets :pass 0)
+                failed  (+ (get buckets :fail 0) (get buckets :error 0))]
+            {:check  check
+             :status status
+             :passed passed
+             :failed failed
+             :total  (count rows)
+             :rows   rows}))
+        (or (:checks result) [])))
+
+(defn schema-rows
+  "Project the run-result's `:schema-violations` evidence slot (the SINGLE
+  projected violation source, `re-frame.story.play.evidence/schema-
+  violations`) into render rows, marking each as consumed or unconsumed
+  (spec/021 §1 — \"schema violations, including consumed expected
+  violations\"). Pure data → data.
+
+  A violation is `:consumed?` true iff its `:selector` appears among the
+  selectors a declared `:rf.assert/schema-error` expectation exactly
+  consumed. The unified result does not carry the consumed-selector set
+  directly, so we recover it from the run's `:rf.assert/schema-error`
+  assertion records: a `:pass` schema-error record consumed the violation
+  whose selector matches its `:actual` (the consumed violation's selector,
+  per `re-frame.story.result/schema-error-record`).
+
+      [{:selector   <selector>
+        :where      <surface>
+        :failing-id <id>
+        :consumed?  <bool>
+        :reason     <str|nil>
+        :epoch-id   <id|nil>}]
+
+  An unconsumed violation reads as the agreement-floor failure cause; a
+  consumed one reads as an expected, exactly-paired violation. Empty when
+  the tape carried no schema violations. Pure data → data; JVM-testable."
+  [result]
+  (let [violations (or (:schema-violations result) [])
+        consumed   (into #{}
+                         (comp (filter #(= :rf.assert/schema-error (:assertion %)))
+                               (filter #(= :pass (or (:status %)
+                                                     (when (:passed? %) :pass))))
+                               (keep :actual))
+                         (or (:assertions result) []))]
+    (mapv (fn [{:keys [selector where failing-id reason epoch-id]}]
+            {:selector   selector
+             :where      where
+             :failing-id failing-id
+             :consumed?  (contains? consumed selector)
+             :reason     reason
+             :epoch-id   epoch-id})
+          violations)))
+
+(defn cannot-run-rows
+  "Project the run-result's `:cannot-run` slot (the per-requirement refusal
+  rows the chosen runner could not even attempt,
+  `re-frame.story.requirements/requirement-refusal`) into render rows
+  (spec/021 §1 — \"cannot-run rows with required and available evidence\"):
+
+      [{:required  #{token …}   ; the evidence/runner the unit needed
+        :available #{token …}   ; what the chosen runner provides
+        :missing   #{token …}   ; the gap (required − available)
+        :reason    <keyword>    ; :runner-lacks-capability | :no-runner-satisfies
+        :runner    <kind|nil>   ; the runner that refused
+        :unit      <step|assertion>}]
+
+  A cannot-run row says what was REQUIRED vs AVAILABLE rather than reading
+  as a failure (spec/018 §12.6 — the distinct THIRD status). Empty when the
+  chosen runner satisfied every requirement. Pure data → data; JVM-testable."
+  [result]
+  (mapv (fn [{:keys [required-runner available-runner missing reason runner unit]}]
+          {:required  (or required-runner #{})
+           :available (or available-runner #{})
+           :missing   (or missing #{})
+           :reason    reason
+           :runner    runner
+           :unit      unit})
+        (or (:cannot-run result) [])))
+
+(defn filter-rows
+  "Apply the failed-only filter to a vector of `assertion-row`s (spec/021 §1
+  — \"failed-only filtering\"). When `failed-only?` is truthy, keep only the
+  rows whose `:status` is `:fail` / `:error` / `:cannot-run` (the actionable
+  rows); otherwise return `rows` unchanged. Pure data → data; JVM-testable."
+  [rows failed-only?]
+  (if failed-only?
+    (filterv (fn [r] (#{:fail :error :cannot-run} (:status r))) rows)
+    (vec rows)))
+
+(defn evidence-available?
+  "True iff `result` carries enough retained evidence for a result→evidence
+  spine link (spec/021 §2). The evidence-spine DISPLAY (ba86n.10) is not
+  built yet, so today this gates a graceful \"evidence pending\" affordance
+  rather than a live link: it is true only when the result carries a
+  non-empty `:epoch-tape` / `:narrative` (the retained tape the spine would
+  project). Pure data → data; JVM-testable."
+  [result]
+  (boolean (or (seq (:epoch-tape result))
+               (seq (:narrative result)))))

--- a/tools/story/src/re_frame/story/ui/test_mode/state.cljs
+++ b/tools/story/src/re_frame/story/ui/test_mode/state.cljs
@@ -5,13 +5,22 @@
   rf2-8n2fz. The pane keeps its own ratom — one map keyed by variant-id.
   Each entry carries:
 
-      {:result        <run-variant-result-map>
-       :ran-at-ms     <epoch-ms>
-       :running?      <bool>
-       :expanded      #{<row-index>}
-       :play-events   <vector>     ; flat event-vec list derived from :play-script
-       :epoch-ids     <vector>     ; trailing epoch-id slice
-       :selected-step <int|nil>}
+      {:result          <unified-run-result-map>
+       :ran-at-ms       <epoch-ms>
+       :running?        <bool>
+       :expanded        #{<row-key>}      ; expanded assertion rows
+       :expanded-checks #{<check-id>}     ; expanded check groups (rf2-ba86n.11)
+       :failed-only?    <bool>            ; failed-only filter (rf2-ba86n.11)
+       :play-events     <vector>          ; flat event-vec list derived from :play-script
+       :epoch-ids       <vector>          ; trailing epoch-id slice
+       :selected-step   <int|nil>}
+
+  rf2-ba86n.11 — `:result` is the ONE unified run-result the runtime now
+  returns (`re-frame.story.result/run-result` merged with the legacy
+  lifecycle slots): a top-level `:status`, `:checks`, `:schema-violations`,
+  `:cannot-run` refusals, `:runner` / `:required-runner`, plus the
+  `:assertions` records each stamped with their own `:status`. The pane
+  reads it through `re-frame.story.ui.test-mode.pure`'s projection helpers.
 
   Re-run flips `:running?` on, calls `runtime/reset-variant`, swaps the
   result in on resolve.
@@ -146,6 +155,23 @@
                    (if (contains? s row-key)
                      (disj s row-key)
                      (conj s row-key))))))
+
+(defn toggle-check!
+  "Toggle the expand state of a check group, keyed by check id
+  (rf2-ba86n.11). Mirrors `toggle-expanded!` for the per-test rows."
+  [variant-id check-id]
+  (swap! results-atom update-in [variant-id :expanded-checks]
+         (fn [s] (let [s (or s #{})]
+                   (if (contains? s check-id)
+                     (disj s check-id)
+                     (conj s check-id))))))
+
+(defn set-failed-only!
+  "Set the failed-only filter flag for `variant-id`'s slot
+  (rf2-ba86n.11, spec/021 §1 — failed-only filtering). `on?` truthy
+  hides passing rows; falsey shows every row."
+  [variant-id on?]
+  (swap! results-atom assoc-in [variant-id :failed-only?] (boolean on?)))
 
 (defn run-variant-pane!
   "Drive a fresh `reset-variant` against the variant's frame and

--- a/tools/story/src/re_frame/story/ui/test_mode/view.cljs
+++ b/tools/story/src/re_frame/story/ui/test_mode/view.cljs
@@ -1,25 +1,49 @@
 (ns re-frame.story.ui.test-mode.view
   "The `:test` mode pane — in-canvas aggregated test-runner view.
-  Per rf2-qmjo + spec/009.
+  Per rf2-qmjo + spec/009, migrated to the unified run-result UX per
+  tools/story/spec/021-Story-UI-Test-And-Evidence.md §1 (rf2-ba86n.11).
 
   Replaces the `mode-tabs/tests-placeholder` stub that landed with the
   mode-tabs primitive (rf2-9hc8). The pane runs the variant's `:play-script`
-  sequence via `run-variant`, reads the `:assertions` vector off the
-  result, and renders an aggregated pass/fail summary inside the
+  sequence via `run-variant`, consumes the ONE unified run-result the
+  runtime returns (`re-frame.story.result/run-result` merged with the
+  legacy lifecycle slots), and renders the result/proof surface inside the
   canvas:
 
       ┌──────────────────────────────────────────────────────┐
       │  Header — variant id · parent story · Re-run button   │
       │           · last-run timestamp + elapsed              │
+      │           · runner selected vs required               │
       ├──────────────────────────────────────────────────────┤
-      │  Summary badge — status pill (pass/fail/empty) +      │
-      │           ✓ N passed · ✗ N failed · ⊘ N skipped       │
+      │  Summary badge — status pill (pass/fail/error/        │
+      │           cannot-run/pending) + ✓/✗/⊘ counts          │
       ├──────────────────────────────────────────────────────┤
-      │  Per-test table — one row per assertion record, in    │
-      │           execution order; collapsible failure detail │
-      │           surfaces :expected / :actual / :reason +    │
-      │           the source-coord stamping                   │
+      │  Checks — grouped by check id, each disclosing its    │
+      │           underlying assertion records                │
+      ├──────────────────────────────────────────────────────┤
+      │  Assertions — one row per assertion record (terminal  │
+      │           + script-checkpoint), failed-only filter,   │
+      │           collapsible :expected/:actual/:reason +     │
+      │           source-coord 'open in editor'               │
+      ├──────────────────────────────────────────────────────┤
+      │  Schema violations — consumed (expected) vs           │
+      │           unconsumed (agreement-floor failure)        │
+      ├──────────────────────────────────────────────────────┤
+      │  Cannot run — runner refusals: required vs available  │
+      ├──────────────────────────────────────────────────────┤
+      │  Evidence — result→spine link (graceful pending)      │
       └──────────────────────────────────────────────────────┘
+
+  ## Migration (rf2-ba86n.11, spec/021 §1 supersedes 009 result-reading)
+
+  The pane no longer derives status from a split `:lifecycle` /
+  `:assertions` reading. It reads the unified run-level `:status`, the
+  `:checks` groups, the `:schema-violations` evidence, and the
+  `:cannot-run` refusal rows through the pure projection helpers in
+  `re-frame.story.ui.test-mode.pure` (`run-status` / `check-rows` /
+  `schema-rows` / `cannot-run-rows` / `filter-rows` / `evidence-available?`).
+  Slots the substrate does not yet populate render an honest empty/dash
+  state — never a fabricated row.
 
   When the variant body's `:play-script` slot is empty / absent the pane
   short-circuits and renders an empty-state placeholder pointing at
@@ -102,43 +126,61 @@
          [:span " · "])
        (when (number? elapsed)
          [:span {:data-test "story-test-elapsed"}
-          (pure/format-elapsed-ms elapsed)])]]]))
+          (pure/format-elapsed-ms elapsed)])]]
+     ;; rf2-ba86n.11 — runner selected vs required (spec/021 §1). The
+     ;; unified result threads `:runner` / `:required-runner` verbatim;
+     ;; render an honest "—" when the host did not stamp them.
+     (when result
+       (let [runner   (:runner result)
+             required (:required-runner result)]
+         [:div {:style     (:runner-row styles)
+                :data-test "story-test-runner-row"}
+          [:span {:style (:runner-key styles)} "runner"]
+          [:span {:style     (:runner-badge styles)
+                  :data-test "story-test-runner-selected"}
+           (if runner (str runner) "—")]
+          [:span {:style (:runner-key styles)} "required"]
+          [:span {:style     (:runner-badge styles)
+                  :data-test "story-test-runner-required"}
+           (if (seq required) (pr-str required) "—")]]))]))
 
 (defn- summary-section
-  "Status pill + ✓ / ✗ / ⊘ counts. Renders nothing until at least
-  one run has executed; the renderer composes its own placeholder
-  in that interim state."
+  "Top-level status pill + ✓ / ✗ / ⊘ counts (spec/021 §1 — overall status,
+  including the distinct `:cannot-run` THIRD state + a `:pending`
+  never-run/no-signal state). Renders nothing until at least one run has
+  executed; the renderer composes its own placeholder in that interim
+  state."
   [variant-id]
   (let [slot   (get @state/results-atom variant-id)
         result (:result slot)]
     (when result
       (let [summary (shell-state/aggregate-summary (:assertions result))
-            {:keys [total passed failed cannot-run skipped all-passed?]} summary
+            {:keys [passed failed cannot-run total]} summary
             cannot-run (or cannot-run 0)
-            ;; rf2-5x1wt.19 — prefer the unified run-level `:status` so a
-            ;; tape-floor `:fail` / a `:cannot-run` refusal renders even when
-            ;; the assertion counts alone would read green.
-            status     (or (:status result)
-                           (cond (zero? total)      :pending
-                                 all-passed?        :pass
-                                 (pos? cannot-run)  :cannot-run
-                                 :else              :fail))
+            ;; rf2-ba86n.11 — the unified run-level verdict (spec/021 §1),
+            ;; via the pure projection. A tape-floor `:fail` / `:cannot-run`
+            ;; refusal / `:error` surfaces even when assertion counts alone
+            ;; would read green.
+            status     (pure/run-status result summary)
             pill-style (case status
                          :pass       (:pill-pass styles)
-                         :cannot-run (:pill-empty styles)
-                         (:pending)  (:pill-empty styles)
+                         :error      (:pill-error styles)
+                         :cannot-run (:pill-cannot styles)
+                         :pending    (:pill-pending styles)
                          (:pill-fail styles))
             pill-text  (case status
                          :pass       (str passed " passed")
+                         :error      "error"
                          :cannot-run (str cannot-run " cannot-run of " total)
-                         (:pending)  "no assertions recorded"
+                         :pending    "no assertions recorded"
                          (str failed " failed of " total))]
         [:div {:style     (:section styles)
                :data-test "story-test-summary-section"}
          [:div {:style (:section-h styles)} "Summary"]
          [:div {:style (:pill-row styles)}
-          [:span {:style     (merge (:pill styles) pill-style)
-                  :data-test "story-test-status-pill"}
+          [:span {:style       (merge (:pill styles) pill-style)
+                  :data-test   "story-test-status-pill"
+                  :data-status (name status)}
            pill-text]
           [:span {:style     (:counts styles)
                   :data-test "story-test-counts"}
@@ -304,68 +346,224 @@
 (defn- status-glyph
   [status]
   (case status
-    :pass [:span {:style (:status-pass styles)} "●"]
-    :fail [:span {:style (:status-fail styles)} "●"]
-    :skip [:span {:style (:status-skip styles)} "○"]
+    :pass       [:span {:style (:status-pass styles)} "●"]
+    :fail       [:span {:style (:status-fail styles)} "●"]
+    :error      [:span {:style (:status-fail styles)} "✖"]
+    :cannot-run [:span {:style (:status-skip styles)} "⊘"]
+    :skip       [:span {:style (:status-skip styles)} "○"]
     [:span {:style (:status-skip styles)} "○"]))
 
+(defn- assertion-table
+  "Render the assertion `rows` as the per-test table. `expanded` is the
+  set of expanded row-keys (`row-key`). Factored out so both the
+  assertions section and a check group can render the same table shape."
+  [variant-id rows expanded]
+  [:table {:style     (:table styles)
+           :data-test "story-test-table"}
+   [:thead
+    [:tr
+     [:th {:style (merge (:th styles) (:td-status styles))} ""]
+     [:th {:style (:th styles)} "assertion"]
+     [:th {:style (:th styles)} "detail"]]]
+   [:tbody
+    ;; rf2-tistm — :expanded is keyed by the row's stable identity
+    ;; (:row-key from assertion-row, the rendered label string) rather
+    ;; than positional index. A re-run that reorders or inserts
+    ;; assertions would otherwise open the wrong row.
+    (for [[i row] (map-indexed vector rows)]
+      (let [rk    (:row-key row)
+            open? (contains? expanded rk)
+            ;; rf2-ba86n.11 — :error / :cannot-run disclose detail too.
+            bad?  (#{:fail :error :cannot-run} (:status row))]
+        ^{:key (str rk "#" i)}
+        [:tr {:data-test      "story-test-row"
+              :data-status    (name (:status row))
+              :data-assertion (str (:assertion row))
+              :style          (when bad? (:row-fail styles))}
+         [:td {:style (merge (:td styles) (:td-status styles))}
+          (status-glyph (:status row))]
+         [:td {:style (:td styles)}
+          (:label row)]
+         [:td {:style (:td styles)}
+          (cond
+            bad?
+            [:div
+             [:button
+              {:style    (:details-tog styles)
+               :on-click (fn [_] (state/toggle-expanded! variant-id rk))
+               :aria-expanded (if open? "true" "false")}
+              (if open? "hide detail" "show detail")]
+             (when open? (row-detail (:detail row)))]
+
+            (= :skip (:status row))
+            [:span {:style (:status-skip styles)} "skipped"]
+
+            :else
+            "")]]))]])
+
+(defn- filter-toggle
+  "The failed-only filter toggle (spec/021 §1). Hides passing rows so the
+  user lands on the actionable ones. `failed-only?` is the current flag;
+  `hidden` is the count of passing rows the filter would hide (rendered as
+  a hint)."
+  [variant-id failed-only? hidden]
+  [:div {:style (:filter-row styles)}
+   [:button
+    {:style          (merge (:filter-toggle styles)
+                            (when failed-only? (:filter-on styles)))
+     :data-test      "story-test-failed-only"
+     :aria-pressed   (if failed-only? "true" "false")
+     :on-click       (fn [_] (state/set-failed-only! variant-id (not failed-only?)))}
+    (if failed-only? "✓ failed only" "failed only")]
+   (when (and failed-only? (pos? hidden))
+     [:span {:style     (:filter-hint styles)
+             :data-test "story-test-filter-hint"}
+      (str hidden " passing row" (when (not= 1 hidden) "s") " hidden")])])
+
 (defn- rows-section
-  "Per-test rows. Empty when no run has executed; renders nothing
-  when the run recorded zero assertions (the summary pill already
-  told the user)."
+  "Per-test assertion rows (spec/021 §1 — terminal + script-checkpoint
+  assertions; the substrate folds both onto one `:assertions` slot today,
+  so the pane renders them as one ordered list). Carries the failed-only
+  filter. Empty when no run has executed; renders nothing when the run
+  recorded zero assertions (the summary pill already told the user)."
+  [variant-id]
+  (let [slot         (get @state/results-atom variant-id)
+        result       (:result slot)
+        expanded     (or (:expanded slot) #{})
+        failed-only? (boolean (:failed-only? slot))]
+    (when result
+      (let [all-rows (mapv pure/assertion-row (:assertions result))]
+        (when (seq all-rows)
+          (let [shown  (pure/filter-rows all-rows failed-only?)
+                hidden (- (count all-rows) (count shown))]
+            [:div {:style     (:section styles)
+                   :data-test "story-test-rows-section"}
+             [:div {:style (:section-h styles)} "Assertions"]
+             (filter-toggle variant-id failed-only? hidden)
+             (if (seq shown)
+               (assertion-table variant-id shown expanded)
+               [:div {:style     (:filter-hint styles)
+                      :data-test "story-test-rows-all-passed"}
+                "all assertions passed — nothing to show"])]))))))
+
+(defn- checks-section
+  "Checks grouped by check id (spec/021 §1; spec/017 §Checks — a failed
+  check shows BOTH the check id AND its underlying assertion records).
+  Renders nothing when the plan declared no checks (the common case
+  today — an honest empty state, never a fabricated check group)."
   [variant-id]
   (let [slot     (get @state/results-atom variant-id)
         result   (:result slot)
-        expanded (or (:expanded slot) #{})]
+        expanded (or (:expanded slot) #{})
+        checks   (some-> result pure/check-rows)
+        expanded-checks (or (:expanded-checks slot) #{})]
+    (when (seq checks)
+      [:div {:style     (:section styles)
+             :data-test "story-test-checks-section"}
+       [:div {:style (:section-h styles)} "Checks"]
+       (for [{:keys [check status passed failed total rows]} checks]
+         (let [open? (contains? expanded-checks check)]
+           ^{:key (str check)}
+           [:div {:style     (:check-box styles)
+                  :data-test "story-test-check"
+                  :data-status (name status)}
+            [:div {:style    (:check-head styles)
+                   :on-click (fn [_] (state/toggle-check! variant-id check))
+                   :aria-expanded (if open? "true" "false")}
+             (status-glyph status)
+             [:span {:style (:check-id styles)} (str check)]
+             [:span {:style (:check-counts styles)}
+              (str passed "/" total " passed"
+                   (when (pos? failed) (str " · " failed " failed")))]]
+            (when open?
+              [:div {:style (:check-body styles)}
+               (assertion-table variant-id rows expanded)])]))])))
+
+(defn- schema-section
+  "Schema violations, marking consumed expected violations distinctly from
+  unconsumed ones (spec/021 §1). Renders nothing when the tape carried no
+  schema violations."
+  [variant-id]
+  (let [slot   (get @state/results-atom variant-id)
+        result (:result slot)
+        rows   (some-> result pure/schema-rows)]
+    (when (seq rows)
+      [:div {:style     (:section styles)
+             :data-test "story-test-schema-section"}
+       [:div {:style (:section-h styles)} "Schema violations"]
+       (for [[i {:keys [selector where failing-id consumed? reason epoch-id]}]
+             (map-indexed vector rows)]
+         ^{:key (str selector "#" i)}
+         [:div {:style       (merge (:schema-row styles)
+                                    (if consumed?
+                                      (:schema-consumed styles)
+                                      (:schema-unconsumed styles)))
+                :data-test   "story-test-schema-row"
+                :data-consumed (str consumed?)}
+          [:span {:style (merge (:schema-tag styles)
+                                (if consumed?
+                                  (:schema-tag-ok styles)
+                                  (:schema-tag-bad styles)))}
+           (if consumed? "consumed" "unconsumed")]
+          [:span {:style (:schema-sel styles)} (pr-str selector)]
+          [:div {:style (:schema-meta styles)}
+           (str (when where (str (name where) " "))
+                (when failing-id (str (pr-str failing-id) " "))
+                (when epoch-id (str "· epoch " epoch-id)))
+           (when reason [:div (str reason)])]])])))
+
+(defn- cannot-run-section
+  "Cannot-run rows — the runner refusals (spec/021 §1; spec/018 §12.6 — the
+  distinct THIRD state). Each row says what evidence/runner was REQUIRED vs
+  what was AVAILABLE, so it reads as a refusal rather than a failure.
+  Renders nothing when the chosen runner satisfied every requirement."
+  [variant-id]
+  (let [slot   (get @state/results-atom variant-id)
+        result (:result slot)
+        rows   (some-> result pure/cannot-run-rows)]
+    (when (seq rows)
+      [:div {:style     (:section styles)
+             :data-test "story-test-cannot-run-section"}
+       [:div {:style (:section-h styles)} "Cannot run"]
+       (for [[i {:keys [required available missing reason runner]}]
+             (map-indexed vector rows)]
+         ^{:key (str i)}
+         [:div {:style     (:cannot-row styles)
+                :data-test "story-test-cannot-run-row"}
+          [:div
+           [:span {:style (:cannot-key styles)} "required"]
+           [:span {:style (:cannot-val styles)} (pr-str required)]]
+          [:div
+           [:span {:style (:cannot-key styles)} "available"]
+           [:span {:style (:cannot-val styles)} (pr-str available)]]
+          (when (seq missing)
+            [:div
+             [:span {:style (:cannot-key styles)} "missing"]
+             [:span {:style (:cannot-val styles)} (pr-str missing)]])
+          [:div {:style (:schema-meta styles)}
+           (str (when reason (name reason))
+                (when runner (str " · runner " runner)))]])])))
+
+(defn- evidence-section
+  "Result → evidence-spine link (spec/021 §2). The evidence-spine DISPLAY
+  (ba86n.10) is not built yet, and the Story→Xray focus API (rf2-crtmq) is
+  not wired here, so this renders a graceful affordance honestly: when the
+  run retained an epoch tape the link target exists but the surface is
+  pending; otherwise there is no evidence to link. No fabricated link."
+  [variant-id]
+  (let [slot   (get @state/results-atom variant-id)
+        result (:result slot)]
     (when result
-      (let [rows (mapv pure/assertion-row (:assertions result))]
-        (when (seq rows)
-          [:div {:style     (:section styles)
-                 :data-test "story-test-rows-section"}
-           [:div {:style (:section-h styles)} "Per-test"]
-           [:table {:style     (:table styles)
-                    :data-test "story-test-table"}
-            [:thead
-             [:tr
-              [:th {:style (merge (:th styles) (:td-status styles))} ""]
-              [:th {:style (:th styles)} "assertion"]
-              [:th {:style (:th styles)} "detail"]]]
-            [:tbody
-             ;; rf2-tistm — :expanded is keyed by the row's stable
-             ;; identity (:row-key from assertion-row, the rendered
-             ;; label string) rather than positional index. A re-run
-             ;; that reorders or inserts assertions (e.g. a new :play-script
-             ;; step lands between two existing ones) would otherwise
-             ;; open the wrong row.
-             (for [[i row] (map-indexed vector rows)]
-               (let [rk    (:row-key row)
-                     open? (contains? expanded rk)
-                     fail? (= :fail (:status row))]
-                 ^{:key (str rk "#" i)}
-                 [:tr {:data-test     "story-test-row"
-                       :data-status   (name (:status row))
-                       :data-assertion (str (:assertion row))
-                       :style         (when fail? (:row-fail styles))}
-                  [:td {:style (merge (:td styles) (:td-status styles))}
-                   (status-glyph (:status row))]
-                  [:td {:style (:td styles)}
-                   (:label row)]
-                  [:td {:style (:td styles)}
-                   (cond
-                     fail?
-                     [:div
-                      [:button
-                       {:style    (:details-tog styles)
-                        :on-click (fn [_] (state/toggle-expanded! variant-id rk))
-                        :aria-expanded (if open? "true" "false")}
-                       (if open? "hide detail" "show detail")]
-                      (when open? (row-detail (:detail row)))]
-
-                     (= :skip (:status row))
-                     [:span {:style (:status-skip styles)} "skipped"]
-
-                     :else
-                     "")]]))]]])))))
+      (let [evidence? (pure/evidence-available? result)]
+        [:div {:style     (:evidence-row styles)
+               :data-test "story-test-evidence-row"
+               :data-evidence (str evidence?)}
+         (if evidence?
+           [:span {:style (:evidence-pending styles)}
+            "evidence spine pending — failures will link here once the "
+            "evidence panel lands"]
+           [:span {:style (:evidence-pending styles)}
+            "no retained evidence for this run"])]))))
 
 (defn- empty-state
   "Placeholder when the variant has no `:play-script` slot."
@@ -431,6 +629,16 @@
                       :aria-label "Variant tests"}
             [header variant-id]
             [summary-section variant-id]
+            ;; rf2-ba86n.11 — the unified run-result surfaces (spec/021 §1):
+            ;; checks grouped by id, the per-test assertions (terminal +
+            ;; script-checkpoint, with the failed-only filter), schema
+            ;; violations (consumed + unconsumed), and cannot-run refusals.
+            [checks-section variant-id]
             [stepper-view/stepper-section variant-id]
             [scrubber-section variant-id]
-            [rows-section variant-id]]))})))
+            [rows-section variant-id]
+            [schema-section variant-id]
+            [cannot-run-section variant-id]
+            ;; rf2-ba86n.11 — result → evidence-spine link (spec/021 §2),
+            ;; a graceful "evidence pending" until the spine display lands.
+            [evidence-section variant-id]]))})))

--- a/tools/story/src/re_frame/story/ui/test_mode/view_styles.cljs
+++ b/tools/story/src/re_frame/story/ui/test_mode/view_styles.cljs
@@ -71,6 +71,16 @@
                    :color            (:danger colors/tokens)}
    :pill-empty    {:background       (:bg-3 colors/tokens)
                    :color            (:text-secondary colors/tokens)}
+   ;; rf2-ba86n.11 — `:error` reads as a louder fail; `:cannot-run` is the
+   ;; distinct THIRD state (spec/018 §12.6 — visually distinct from
+   ;; pass/fail/error); `:pending` is the muted never-run/no-signal state.
+   :pill-error    {:background       (:danger-bg colors/tokens)
+                   :color            (:danger colors/tokens)
+                   :border           (str "1px solid " (:danger colors/tokens))}
+   :pill-cannot   {:background       (:warning-bg colors/tokens)
+                   :color            (:warning colors/tokens)}
+   :pill-pending  {:background       (:bg-3 colors/tokens)
+                   :color            (:text-tertiary colors/tokens)}
    :counts        {:color            (:text-secondary colors/tokens)
                    :font-family      mono-stack
                    :font-size        (:caption typography/type-scale)}
@@ -132,6 +142,111 @@
                    :font-family      mono-stack
                    :margin-top       "8px"
                    :display          "block"}
+
+   ;; ---- unified run-result surfaces (rf2-ba86n.11) ----------------
+   ;; runner selected vs required badge (spec/021 §1)
+   :runner-row    {:display          "flex"
+                   :align-items      "center"
+                   :gap              "8px"
+                   :flex-wrap        "wrap"
+                   :margin-top       "6px"
+                   :color            (:text-secondary colors/tokens)
+                   :font-family      mono-stack
+                   :font-size        (:micro typography/type-scale)}
+   :runner-badge  {:padding          "2px 7px"
+                   :border-radius    "3px"
+                   :background       (:bg-3 colors/tokens)
+                   :color            (:text-primary colors/tokens)
+                   :font-family      mono-stack
+                   :font-size        (:micro typography/type-scale)}
+   :runner-key    {:color            (:text-tertiary colors/tokens)
+                   :text-transform   "uppercase"
+                   :letter-spacing   "0.4px"}
+   ;; failed-only filter toggle (spec/021 §1)
+   :filter-row    {:display          "flex"
+                   :align-items      "center"
+                   :gap              "8px"
+                   :margin-bottom    "8px"}
+   :filter-toggle {:padding          "3px 10px"
+                   :border           (str "1px solid " (:border-strong colors/tokens))
+                   :border-radius    "3px"
+                   :background       "none"
+                   :color            (:text-secondary colors/tokens)
+                   :cursor           "pointer"
+                   :font-family      mono-stack
+                   :font-size        (:micro typography/type-scale)}
+   :filter-on     {:background       (:accent-amber-soft colors/tokens)
+                   :color            (:accent-amber colors/tokens)
+                   :border           (str "1px solid " (:accent-amber-deep colors/tokens))}
+   :filter-hint   {:color            (:text-tertiary colors/tokens)
+                   :font-family      mono-stack
+                   :font-size        (:micro typography/type-scale)}
+   ;; checks grouped by check id (spec/021 §1)
+   :check-box     {:border           "1px solid #2d2d30"
+                   :border-radius    "4px"
+                   :margin-bottom    "6px"
+                   :background       (:bg-2 colors/tokens)}
+   :check-head    {:display          "flex"
+                   :align-items      "center"
+                   :gap              "8px"
+                   :padding          "6px 10px"
+                   :cursor           "pointer"
+                   :font-family      mono-stack
+                   :font-size        (:caption typography/type-scale)}
+   :check-id      {:color            (:text-primary colors/tokens)
+                   :font-weight      "bold"}
+   :check-counts  {:color            (:text-secondary colors/tokens)
+                   :font-size        (:micro typography/type-scale)
+                   :margin-left      "auto"}
+   :check-body    {:padding          "0 10px 8px 10px"}
+   ;; schema-violation rows (spec/021 §1)
+   :schema-row    {:padding          "6px 10px"
+                   :border-left      "3px solid"
+                   :margin-bottom    "5px"
+                   :background       (:bg-2 colors/tokens)
+                   :font-family      mono-stack
+                   :font-size        (:caption typography/type-scale)}
+   :schema-consumed {:border-left-color (:success colors/tokens)}
+   :schema-unconsumed {:border-left-color (:danger colors/tokens)}
+   :schema-tag    {:display          "inline-block"
+                   :padding          "1px 6px"
+                   :border-radius    "8px"
+                   :font-size        (:micro typography/type-scale)
+                   :text-transform   "uppercase"
+                   :letter-spacing   "0.4px"
+                   :margin-right     "8px"}
+   :schema-tag-ok {:background       (:success-bg colors/tokens)
+                   :color            (:success colors/tokens)}
+   :schema-tag-bad {:background      (:danger-bg colors/tokens)
+                   :color            (:danger colors/tokens)}
+   :schema-sel    {:color            (:text-primary colors/tokens)}
+   :schema-meta   {:color            (:text-tertiary colors/tokens)
+                   :font-size        (:micro typography/type-scale)
+                   :margin-top       "3px"}
+   ;; cannot-run rows (spec/021 §1; spec/018 §12.6 — distinct THIRD state)
+   :cannot-row    {:padding          "6px 10px"
+                   :border-left      (str "3px solid " (:warning colors/tokens))
+                   :margin-bottom    "5px"
+                   :background       (:warning-bg colors/tokens)
+                   :font-family      mono-stack
+                   :font-size        (:caption typography/type-scale)}
+   :cannot-key    {:color            (:warning colors/tokens)
+                   :text-transform   "uppercase"
+                   :font-size        (:micro typography/type-scale)
+                   :letter-spacing   "0.4px"
+                   :margin-right     "6px"}
+   :cannot-val    {:color            (:text-primary colors/tokens)}
+   ;; result → evidence link (spec/021 §2)
+   :evidence-row  {:margin-top       "10px"
+                   :padding          "8px 12px"
+                   :border           "1px dashed #3a3a3a"
+                   :border-radius    "4px"
+                   :background       (:bg-2 colors/tokens)
+                   :color            (:text-secondary colors/tokens)
+                   :font-family      mono-stack
+                   :font-size        (:micro typography/type-scale)}
+   :evidence-pending {:color         (:text-tertiary colors/tokens)
+                      :font-style    "italic"}
 
    ;; ---- step-through scrubber (rf2-lc36w) -------------------------
    :scrub-wrap    {:margin           "8px 0 0 0"

--- a/tools/story/test/re_frame/story_ui_test.clj
+++ b/tools/story/test/re_frame/story_ui_test.clj
@@ -902,6 +902,129 @@
           "different payloads produce distinct row-keys — keys do not collide
            on a re-run that inserts a sibling path-equals on a different path"))))
 
+(deftest test-mode-assertion-row-unified-status
+  (testing "rf2-ba86n.11 — assertion-row PREFERS the unified `:status` over
+            the legacy :passed? read (spec/021 §1 migration)"
+    (is (= :cannot-run (:status (test-mode/assertion-row
+                                  {:assertion :rf.assert/caused
+                                   :status    :cannot-run
+                                   :passed?   false})))
+        "a stamped :cannot-run wins — NOT folded into :fail")
+    (is (= :error (:status (test-mode/assertion-row
+                             {:assertion :rf.assert/path-equals
+                              :status    :error
+                              :passed?   false})))
+        "a stamped :error reads :error, not :fail")
+    (is (= :pass (:status (test-mode/assertion-row
+                            {:assertion :rf.assert/path-equals
+                             :status    :pass
+                             :passed?   false})))
+        "the stamped :status wins even when :passed? disagrees")
+    (testing "unstamped records still derive :cannot-run / :error from flags"
+      (is (= :cannot-run (:status (test-mode/assertion-row
+                                    {:assertion :rf.assert/caused
+                                     :cannot-run? true}))))
+      (is (= :error (:status (test-mode/assertion-row
+                               {:assertion :rf.assert/path-equals
+                                :error "boom"})))))))
+
+(deftest test-mode-run-status
+  (testing "rf2-ba86n.11 — run-status prefers the unified run-level :status"
+    (is (= :pass       (test-mode/run-status {:status :pass} {})))
+    (is (= :fail       (test-mode/run-status {:status :fail} {})))
+    (is (= :error      (test-mode/run-status {:status :error} {})))
+    (is (= :cannot-run (test-mode/run-status {:status :cannot-run} {}))))
+  (testing "no result → :pending; a result without :status derives from counts"
+    (is (= :pending (test-mode/run-status nil nil)))
+    (is (= :pending (test-mode/run-status {} {:total 0})))
+    (is (= :pass    (test-mode/run-status {} {:total 2 :failed 0 :all-passed? true})))
+    (is (= :fail    (test-mode/run-status {} {:total 2 :failed 1})))
+    (is (= :cannot-run (test-mode/run-status {} {:total 2 :failed 0 :cannot-run 1})))))
+
+(deftest test-mode-check-rows
+  (testing "rf2-ba86n.11 — check-rows groups the result's :checks by id, with
+            pass/fail counts + the underlying assertion rows (spec/021 §1)"
+    (let [result {:checks [{:check  :auth/logged-in
+                            :status :fail
+                            :assertions [{:assertion :rf.assert/path-equals
+                                          :status :pass :payload [[:user] 1]}
+                                         {:assertion :rf.assert/path-equals
+                                          :status :fail :payload [[:role] :admin]}]}]}
+          rows   (test-mode/check-rows result)]
+      (is (= 1 (count rows)))
+      (let [r (first rows)]
+        (is (= :auth/logged-in (:check r)))
+        (is (= :fail (:status r)))
+        (is (= 1 (:passed r)))
+        (is (= 1 (:failed r)))
+        (is (= 2 (:total r)))
+        (is (= 2 (count (:rows r))) "underlying assertion rows are projected"))))
+  (testing "no checks → empty (honest empty state, never a fabricated check)"
+    (is (= [] (test-mode/check-rows {})))
+    (is (= [] (test-mode/check-rows {:checks []})))))
+
+(deftest test-mode-schema-rows
+  (testing "rf2-ba86n.11 — schema-rows marks consumed vs unconsumed
+            violations (spec/021 §1 — incl. consumed expected violations)"
+    (let [result {:schema-violations
+                  [{:selector [:event :auth/login] :where :event
+                    :failing-id :auth/login :epoch-id 3}
+                   {:selector [:app-db [:user] [:role]] :where :app-db
+                    :failing-id nil :epoch-id 4 :reason "invalid role"}]
+                  ;; a :pass schema-error record consumed the first selector
+                  :assertions
+                  [{:assertion :rf.assert/schema-error :status :pass
+                    :actual [:event :auth/login]}]}
+          rows   (test-mode/schema-rows result)]
+      (is (= 2 (count rows)))
+      (is (true?  (:consumed? (first rows)))  "exactly-consumed expected violation")
+      (is (false? (:consumed? (second rows))) "unconsumed → agreement-floor failure")
+      (is (= "invalid role" (:reason (second rows))))))
+  (testing "no violations → empty"
+    (is (= [] (test-mode/schema-rows {})))))
+
+(deftest test-mode-cannot-run-rows
+  (testing "rf2-ba86n.11 — cannot-run-rows surfaces required vs available
+            evidence/runner for each refusal (spec/021 §1; spec/018 §12.6)"
+    (let [result {:cannot-run
+                  [{:status :cannot-run
+                    :required-runner  #{:dom}
+                    :available-runner #{:headless}
+                    :missing          #{:dom}
+                    :reason           :runner-lacks-capability
+                    :runner           :headless
+                    :unit             [:click "#go"]}]}
+          rows   (test-mode/cannot-run-rows result)]
+      (is (= 1 (count rows)))
+      (let [r (first rows)]
+        (is (= #{:dom}      (:required r)))
+        (is (= #{:headless} (:available r)))
+        (is (= #{:dom}      (:missing r)))
+        (is (= :runner-lacks-capability (:reason r)))
+        (is (= :headless    (:runner r))))))
+  (testing "no refusals → empty"
+    (is (= [] (test-mode/cannot-run-rows {})))))
+
+(deftest test-mode-filter-rows
+  (testing "rf2-ba86n.11 — failed-only filter keeps only actionable rows
+            (:fail/:error/:cannot-run) when on (spec/021 §1)"
+    (let [rows [{:status :pass}  {:status :fail}  {:status :error}
+                {:status :cannot-run} {:status :skip} {:status :pass}]]
+      (is (= 6 (count (test-mode/filter-rows rows false)))
+          "filter off → every row")
+      (let [kept (test-mode/filter-rows rows true)]
+        (is (= 3 (count kept)))
+        (is (= [:fail :error :cannot-run] (mapv :status kept))
+            ":pass / :skip rows are filtered out")))))
+
+(deftest test-mode-evidence-available?
+  (testing "rf2-ba86n.11 — evidence-available? gates the graceful pending
+            affordance on a retained tape/narrative (spec/021 §2)"
+    (is (true?  (test-mode/evidence-available? {:epoch-tape [{:epoch-id 1}]})))
+    (is (true?  (test-mode/evidence-available? {:narrative [{:span 1}]})))
+    (is (false? (test-mode/evidence-available? {:epoch-tape [] :narrative []})))
+    (is (false? (test-mode/evidence-available? {})))))
+
 (deftest test-mode-format-elapsed-ms
   (testing "format-elapsed-ms switches at the 1s boundary"
     (is (= "0 ms"   (test-mode/format-elapsed-ms 0)))


### PR DESCRIPTION
Completes the Test-mode migration off the legacy split `:lifecycle` / `:assertions` reading onto the ONE unified run-result (`re-frame.story.result/run-result`, merged with the legacy lifecycle slots by `runtime.cljc`). Per **`tools/story/spec/021-Story-UI-Test-And-Evidence.md` §1**, which supersedes the 009 result-reading contract (the spec marker landed via ba86n.1; this is the CODE migration). Footprint stays in the `test_mode/` region.

## Unified-result slots now rendered (spec/021 §1)

- **Top-level status** — pill driven by `pure/run-status` (the unified `:status`): `:pass` / `:fail` / `:error` / `:cannot-run` / `:pending`. The legacy count-derived status path is removed; the count fallback now fires only for a host that carries no `:status`.
- **Runner selected vs required** — a header badge reading `:runner` / `:required-runner` (honest `—` when unstamped).
- **Checks** — grouped by check id (`pure/check-rows`); a failed check discloses BOTH the check id AND its underlying assertion records.
- **Terminal + script-checkpoint assertions** — the per-test "Assertions" table over the unified records. The substrate folds both positions onto one `:assertions` slot today (no record-level discriminant), so they render as one ordered list (documented honestly).
- **Consumed schema errors** — `pure/schema-rows` projects `:schema-violations`, marking each consumed (expected, exactly-paired) vs unconsumed (agreement-floor failure). Consumed-selectors recovered from the `:rf.assert/schema-error` pass records.
- **Cannot-run rows** — `pure/cannot-run-rows` over the `:cannot-run` refusals: required vs available vs missing evidence/runner (the distinct THIRD state, spec/018 §12.6).
- **Source links** — preserved (per-assertion open-in-editor chip).
- **Failed-only filter** — `pure/filter-rows` + a toggle keeping only `:fail`/`:error`/`:cannot-run`, with a hidden-count hint.
- **Result → evidence links** — a graceful `evidence-section` ("evidence spine pending" / "no retained evidence") gated by `pure/evidence-available?`. The spine display (ba86n.10) and Story→Xray focus API (rf2-crtmq) are not built yet, so no fabricated link is wired.

## Legacy reading removed

- `summary-section` no longer derives status from a `:lifecycle` / assertion-count `cond`; it reads the unified verdict via `run-status`.
- `assertion-row` now PREFERS the record's stamped `:status` (the unified shape) over the legacy `:passed?`-only derivation, recognising `:error` / `:cannot-run`. The conservative view-side `:fail` default is preserved for unstamped/malformed records.

## Honest empty states

Slots the substrate does not yet populate (checks, schema violations, cannot-run) render nothing / a dash — never a fabricated row. Terminal-assertion *evaluation* (rf2-nyjoa) is out of scope: terminal assertions render from the result if present, no evaluation logic added.

## Tests

New JVM-testable pure helpers (`run-status` / `check-rows` / `schema-rows` / `cannot-run-rows` / `filter-rows` / `evidence-available?`) + the unified-status `assertion-row` path covered by new deftests in `story_ui_test.clj` (8 tests, 59 assertions).

## Quality gates

- `clj-kondo --parallel --fail-level error --lint tools/story` — **errors: 0** (120 pre-existing warnings in test files, untouched).
- `tools/story` `clojure -M:test` — 1354 tests / 4547 assertions, **0 failures, 0 errors**.
- `npm run test:cljs` — 1093 compiled, **0 warnings**; 4872 tests / 15951 assertions, **0 failures, 0 errors**.
- `tools/story-mcp` `clojure -M:test` — 172 tests / 861 assertions, **0 failures, 0 errors**.
- `tools/mcp-conformance` `npm run test:story` — **GREEN**, exit 0.
- `bash scripts/test-fast-pr.sh` — **PASS**.