### PR TITLE
feat(story/controls): inline validation, diff-from-saved, summarise-before-expand (rf2-ba86n.5)

### DIFF
--- a/tools/story/src/re_frame/story/ui/controls.cljs
+++ b/tools/story/src/re_frame/story/ui/controls.cljs
@@ -32,14 +32,47 @@
   state slot the canvas reads). Stage 4 ships the toggle UI; the
   disable-by-name routing through `resolve-decorators` is a future
   refinement when the decorator stack grows more complex; today the
-  toggle is informational."
+  toggle is informational.
+
+  ## Inline validation, diff-from-saved, summarise-before-expand (rf2-ba86n.5)
+
+  Per spec/019-Story-UI-Controls-And-View-States §1/§2/§4/§6 the args
+  editor distinguishes a committed value that *violates the component's
+  Spec 010 schema* from one that merely differs from its saved
+  (declared) value:
+
+  - **Inline schema errors** — each arg-key is checked against the
+    component's registered schema via the SAME pure
+    `re-frame.story.ui.schema-validation/args-violations` walk the
+    schema-validation panel uses (no second validator). A violating row
+    shows an inline error under its widget; a panel-level banner names
+    how many args block render/test proof. Args are checked, not
+    fidelity rungs — the boundary in §5 stays intact.
+
+  - **Diff-from-saved + reset** — the 'saved' baseline is the variant's
+    resolved args WITHOUT the controls panel's `:cell-overrides`. An arg
+    whose effective value drifts from its saved value shows a 'changed'
+    dot and a per-arg reset that reverts just that one arg
+    (`state/clear-cell-override`); the panel-level 'reset overrides'
+    clears them all.
+
+  - **Summarise before expanding** — nested (`:group` / `:repeater` /
+    `:tuple`) controls render a one-line summary with a disclosure
+    toggle and lazily render their child rows only when expanded (the
+    deep-controls perf risk in §4). The expand/collapse flag is
+    *component-local ephemeral UI state* (a Reagent atom on the editor's
+    Form-2 closure) — it is deliberately NOT written to `:cell-overrides`
+    or the shell-state so controls never become hidden panel state
+    (§6 acceptance criterion)."
   (:require [clojure.string                    :as str]
+            [reagent.core                      :as r]
             [re-frame.story.registrar          :as registrar]
             [re-frame.story.args               :as args]
             [re-frame.story.decorators         :as decorators]
             [re-frame.story.malli-schema       :as msu]
             [re-frame.story.ui.controls-styles :refer [styles]]
             [re-frame.story.ui.save-variant    :as save-variant-ui]
+            [re-frame.story.ui.schema-validation :as schema-validation]
             [re-frame.story.ui.state           :as state]))
 
 ;; Styles live in `re-frame.story.ui.controls-styles` (pure-data leaf,
@@ -262,6 +295,56 @@
        (or types {})
        eff-args))))
 
+;; ---- pure: validation + diff-from-saved + summaries ---------------------
+
+(defn violations-by-key
+  "Index a `schema-validation/args-violations` vector into a
+  `{arg-key → violation}` map so the args-editor can look up a row's
+  violation in O(1). The whole-args `::schema-validation/root` violation
+  (a non-`:map` top-level schema) keys under `:rf.story.controls/root`
+  so a top-level non-map schema failure still surfaces as a panel banner
+  without colliding with any real arg-key.
+
+  Pure data → data; JVM-testable. Reuses the SAME validation the
+  schema-validation panel computes — there is no second validator."
+  [violations]
+  (reduce (fn [acc {:keys [key] :as v}]
+            (assoc acc (if (= key :re-frame.story.ui.schema-validation/root)
+                         :rf.story.controls/root
+                         key)
+                       v))
+          {}
+          violations))
+
+(defn arg-changed?
+  "True iff `arg-key`'s effective value differs from its saved (declared)
+  value. The 'saved' value is the variant's resolved args WITHOUT the
+  controls panel's runtime `:cell-overrides` — i.e. what the variant
+  would render with no UI edits. Used to surface the per-arg
+  changed-from-saved dot + reset affordance. Pure data → bool."
+  [eff-args saved-args arg-key]
+  (not= (get eff-args arg-key) (get saved-args arg-key)))
+
+(defn summarize-value
+  "One-line, non-recursive summary of a collection value for the
+  collapsed (summarise-before-expand) nested-control header. Deep
+  contents are NOT walked — that is the whole point of summarising
+  before expanding (spec/019 §4 deep-controls perf risk). Pure data →
+  string.
+
+  - map     → `\"N keys\"`
+  - set     → `\"N items\"`
+  - vector / seq → `\"N items\"`
+  - nil     → `\"empty\"`
+  - other   → `pr-str` (a scalar landing under a collection widget)"
+  [v]
+  (cond
+    (nil? v)         "empty"
+    (map? v)         (str (count v) (if (= 1 (count v)) " key" " keys"))
+    (set? v)         (str (count v) (if (= 1 (count v)) " item" " items"))
+    (sequential? v)  (str (count v) (if (= 1 (count v)) " item" " items"))
+    :else            (pr-str v)))
+
 ;; ---- widget renderers ----------------------------------------------------
 
 (defn- read-event-value [e]
@@ -277,7 +360,7 @@
   [variant-id path value]
   (state/swap-state! state/set-cell-override variant-id (vec path) value))
 
-(declare arg-widget)
+(declare arg-widget*)
 
 ;; Per-widget render fns. Each takes `[variant-id path value spec]` and
 ;; returns a hiccup form. Factoring out the per-case logic keeps the
@@ -413,23 +496,77 @@
     [:span {:style (:empty styles)}
      (str "unsupported widget " widget)]))
 
+;; ---- summarise-before-expand (rf2-ba86n.5) ------------------------------
+;;
+;; Nested controls render a one-line summary with a disclosure toggle and
+;; lazily render their child rows only when expanded (spec/019 §4 deep-
+;; controls perf risk). The expand state is a Reagent atom holding a SET
+;; of expanded paths, carried on `opts` — `{:expanded <ratom>}`. It is
+;; ephemeral component-local UI state, NEVER `:cell-overrides` / shell-
+;; state, so controls don't become hidden panel state (§6).
+;;
+;; When `opts` carries no `:expanded` ratom (direct `arg-widget` test
+;; calls, or any non-render caller) nested controls render fully expanded
+;; — the summarise affordance is a render-shell concern, and the pure
+;; recursion stays inspectable.
+
+(defn- path-expanded?
+  "Is the nested control at `path` expanded? With no `:expanded` ratom on
+  `opts` everything is expanded (the non-render / test default)."
+  [opts path]
+  (if-let [a (:expanded opts)]
+    (contains? @a (vec path))
+    true))
+
+(defn- toggle-expanded!
+  "Flip `path`'s membership in the `:expanded` ratom's set. No-op when no
+  ratom is present."
+  [opts path]
+  (when-let [a (:expanded opts)]
+    (swap! a (fn [s]
+               (let [p (vec path)]
+                 (if (contains? s p) (disj s p) (conj s p)))))))
+
+(defn- disclosure-header
+  "Render the group/repeater/tuple header as a disclosure toggle: a
+  `▸`/`▾` triangle + the arg label + the open/close delimiter + a one-
+  line summary of the collapsed value. `extra` is optional trailing
+  hiccup (e.g. the repeater `[+]` button) appended after the summary."
+  ([variant-id path value opts group-tag delim]
+   (disclosure-header variant-id path value opts group-tag delim nil))
+  ([_variant-id path value opts group-tag delim extra]
+   (let [open? (path-expanded? opts path)]
+     [:div {:style (:group-h styles)
+            :data-controls-group group-tag}
+      [:button {:style    (:disclosure styles)
+                :data-controls-action "toggle-expand"
+                :data-controls-expanded (str open?)
+                :aria-expanded (str open?)
+                :aria-label (str (path-label path)
+                                 (if open? " collapse" " expand"))
+                :on-click (fn [_] (toggle-expanded! opts path))}
+       (str (if open? "▾ " "▸ ") (last path) " " delim)]
+      (when-not open?
+        [:span {:style (:summary styles)} (summarize-value value)])
+      extra])))
+
 (defn- group-widget
-  "Render a `:map`-derived collapsible group. The header sits in its
-  own row; each child entry renders as a nested row."
-  [variant-id path value {:keys [entries]}]
+  "Render a `:map`-derived collapsible group. The header is a disclosure
+  toggle carrying a one-line summary; child rows render only when the
+  group is expanded (summarise-before-expand, spec/019 §4)."
+  [variant-id path value {:keys [entries]} opts]
   [:div
-   [:div {:style (:group-h styles)
-          :data-controls-group ":map"}
-    (str (last path) " {} ")]
-   (into [:div]
-         (for [{ek :key ew :widget} entries
-               :let [child-path  (conj (vec path) ek)
-                     child-value (get value ek)]]
-           ^{:key (str ek)}
-           [:div {:style (:nested-row styles)
-                  :data-controls-key (str ek)}
-            [:span {:style (:sublabel styles)} (str ek)]
-            [arg-widget variant-id child-path child-value ew]]))])
+   (disclosure-header variant-id path value opts ":map" "{}")
+   (when (path-expanded? opts path)
+     (into [:div]
+           (for [{ek :key ew :widget} entries
+                 :let [child-path  (conj (vec path) ek)
+                       child-value (get value ek)]]
+             ^{:key (str ek)}
+             [:div {:style (:nested-row styles)
+                    :data-controls-key (str ek)}
+              [:span {:style (:sublabel styles)} (str ek)]
+              (arg-widget* variant-id child-path child-value ew opts)])))])
 
 (defn- vector-coerce
   "Normalise a value into a vector. `nil` → `[]`; sets become a stable
@@ -497,7 +634,7 @@
   lockstep with the entry. This pins React-key stability across a
   mid-list delete so focus / cursor on surviving rows is preserved
   (the focused input visually moves with its edit intact)."
-  [variant-id path value {:keys [element kind] :as widget-spec}]
+  [variant-id path value {:keys [element kind] :as _widget-spec} opts]
   (let [entries  (vector-coerce value)
         path-v   (vec path)
         row-keys (row-keys-for-entries variant-id path-v (count entries))
@@ -519,30 +656,30 @@
                                           (subvec entries (inc i))))]
                        (case kind
                          :set (set v)
-                         v))))]
+                         v))))
+        add-btn  [:button {:style    (:rep-button styles)
+                           :data-controls-action "add"
+                           :on-click (fn [_] (on-add))}
+                  "[+]"]]
     [:div
-     [:div {:style (:group-h styles)
-            :data-controls-group (str kind)}
-      (str (last path) " " (case kind :set "#{}" "[]") " ")
-      [:button {:style    (:rep-button styles)
-                :data-controls-action "add"
-                :on-click (fn [_] (on-add))}
-       "[+]"]]
-     (into [:div]
-           (for [[i entry-value] (map-indexed vector entries)
-                 :let [child-path (conj (vec path) i)
-                       row-key    (nth row-keys i (str "r:?-" i))]]
-             ^{:key row-key}
-             [:div {:style (:nested-row styles)
-                    :data-controls-index i
-                    :data-controls-row-key row-key}
-              [:span {:style (:sublabel styles)} (str "[" i "]")]
-              [:div
-               [arg-widget variant-id child-path entry-value element]
-               [:button {:style    (:rep-button styles)
-                         :data-controls-action "del"
-                         :on-click (fn [_] (on-del i))}
-                "[-]"]]]))]))
+     (disclosure-header variant-id path value opts (str kind)
+                        (case kind :set "#{}" "[]") add-btn)
+     (when (path-expanded? opts path)
+       (into [:div]
+             (for [[i entry-value] (map-indexed vector entries)
+                   :let [child-path (conj (vec path) i)
+                         row-key    (nth row-keys i (str "r:?-" i))]]
+               ^{:key row-key}
+               [:div {:style (:nested-row styles)
+                      :data-controls-index i
+                      :data-controls-row-key row-key}
+                [:span {:style (:sublabel styles)} (str "[" i "]")]
+                [:div
+                 (arg-widget* variant-id child-path entry-value element opts)
+                 [:button {:style    (:rep-button styles)
+                           :data-controls-action "del"
+                           :on-click (fn [_] (on-del i))}
+                  "[-]"]]])))]))
 
 (defn- tuple-widget
   "Render a `:tuple` — one row per positional element. The arity is
@@ -554,38 +691,120 @@
   identity — the namespacing prefix is for discipline-consistency
   with the repeater fix and the rf2-kgn0c sibling family, not to
   fix a focus-leak (tuple slots can't reshuffle)."
-  [variant-id path value {:keys [positions]}]
+  [variant-id path value {:keys [positions]} opts]
   (let [entries (vector-coerce value)]
     [:div
-     [:div {:style (:group-h styles)
-            :data-controls-group ":tuple"}
-      (str (last path) " () ")]
-     (into [:div]
-           (for [[i pos-widget] (map-indexed vector positions)
-                 :let [child-path  (conj (vec path) i)
-                       child-value (get entries i)
-                       row-key     (str "t:" i)]]
-             ^{:key row-key}
-             [:div {:style (:nested-row styles)
-                    :data-controls-index i
-                    :data-controls-row-key row-key}
-              [:span {:style (:sublabel styles)} (str "[" i "]")]
-              [arg-widget variant-id child-path child-value pos-widget]]))]))
+     (disclosure-header variant-id path value opts ":tuple" "()")
+     (when (path-expanded? opts path)
+       (into [:div]
+             (for [[i pos-widget] (map-indexed vector positions)
+                   :let [child-path  (conj (vec path) i)
+                         child-value (get entries i)
+                         row-key     (str "t:" i)]]
+               ^{:key row-key}
+               [:div {:style (:nested-row styles)
+                      :data-controls-index i
+                      :data-controls-row-key row-key}
+                [:span {:style (:sublabel styles)} (str "[" i "]")]
+                (arg-widget* variant-id child-path child-value pos-widget opts)])))]))
+
+(defn arg-widget*
+  "Internal widget dispatcher carrying the render-shell `opts`
+  (currently `{:expanded <ratom>}` for summarise-before-expand). `path`
+  is the vector path within the variant's args (`[arg-key & sub-keys]`);
+  for top-level scalars the path is a 1-vector. Dispatches on
+  `widget-spec`'s `:widget` slot — `:group` / `:repeater` / `:tuple`
+  recurse (threading `opts`), everything else falls through to
+  `scalar-widget`."
+  [variant-id path value widget-spec opts]
+  (case (:widget widget-spec)
+    ;; Collection widgets are plain hiccup-returning fns (no local
+    ;; state); calling them directly keeps the disclosure header +
+    ;; nested rows in one inline tree (testable + no extra reactive
+    ;; boundary). Scalars stay a `[scalar-widget ...]` component vector
+    ;; — the existing nested-dispatch test asserts on that shape.
+    :group    (group-widget    variant-id path value widget-spec opts)
+    :repeater (repeater-widget variant-id path value widget-spec opts)
+    :tuple    (tuple-widget    variant-id path value widget-spec opts)
+    [scalar-widget variant-id path value widget-spec]))
 
 (defn arg-widget
   "Generic widget dispatcher. `path` is the vector path within the
   variant's args (`[arg-key & sub-keys]`); for top-level scalars the
   path is a 1-vector. The renderer dispatches on `widget-spec`'s
   `:widget` slot — `:group` / `:repeater` / `:tuple` recurse, everything
-  else falls through to `scalar-widget`."
+  else falls through to `scalar-widget`.
+
+  The 4-arity is the canonical surface for tests + non-render callers —
+  it threads an empty `opts`, so nested controls render fully expanded
+  (no `:expanded` ratom) and the recursion stays inspectable. The
+  render path uses `arg-widget*` to thread the summarise-before-expand
+  state."
   [variant-id path value widget-spec]
-  (case (:widget widget-spec)
-    :group    [group-widget    variant-id path value widget-spec]
-    :repeater [repeater-widget variant-id path value widget-spec]
-    :tuple    [tuple-widget    variant-id path value widget-spec]
-    [scalar-widget variant-id path value widget-spec]))
+  (arg-widget* variant-id path value widget-spec nil))
 
 ;; ---- public components ---------------------------------------------------
+
+(defn validation-banner
+  "Panel-level banner naming how many committed args violate the
+  component's Spec 010 schema. Per spec/019 §1/§6 invalid committed
+  values block render/test PROOF — the banner is the honest 'this state
+  is not a valid render' signal that sits above the rows. Returns nil
+  (rendered nothing) when `n` is 0. A plain hiccup-returning fn so the
+  banner's `:data-controls-validation` marker renders inline."
+  [n]
+  (when (pos? n)
+    [:div {:style     (:banner styles)
+           :role      "alert"
+           :data-controls-validation "invalid"
+           :data-controls-violation-count (str n)}
+     (str "⚠ " n (if (= 1 n) " arg violates" " args violate")
+          " the component's schema — fix before claiming a valid render/test.")]))
+
+(defn args-row
+  "One top-level arg row: the label (with a changed-from-saved dot +
+  per-arg reset when the arg drifts from its saved value), the widget,
+  and an inline schema error under the widget when the committed value
+  violates the component's Spec 010 schema.
+
+  A plain hiccup-returning fn (NOT a nested Reagent component) so the
+  args-editor renders the row's `:data-controls-*` markers + the diff /
+  reset / inline-error affordances inline in one tree — the per-row
+  state it needs (`violation` / `changed?` / `overridden?`) is already
+  computed by the editor, so there is no reactive boundary to draw here.
+
+  `violation` is the per-key entry from `violations-by-key` (or nil).
+  `changed?` is the diff-from-saved flag (drives the amber dot).
+  `overridden?` is true when a runtime override exists at this arg-key
+  (drives the per-arg reset — a same-value override is still resettable).
+  `opts` carries the summarise-before-expand ratom."
+  [variant-id k value widget-spec {:keys [violation changed? overridden? opts]}]
+  [:div {:style                  (:row styles)
+         :data-controls-arg      (str k)
+         :data-controls-changed  (str (boolean changed?))
+         :data-controls-invalid  (str (some? violation))}
+   [:span {:style (:label styles)}
+    (str k)
+    (when (or changed? overridden?)
+      [:span {:style (:diff-row styles)}
+       (when changed?
+         [:span {:style (:diff-dot styles) :title "changed from saved"} " ●"])
+       [:button {:style    (:reset-arg styles)
+                 :data-controls-action "reset-arg"
+                 :aria-label (str "reset " k " to saved")
+                 :on-click (fn [_]
+                             (state/swap-state!
+                               state/clear-cell-override variant-id k))}
+        "reset"]])]
+   [:div
+    (arg-widget* variant-id [k] value widget-spec opts)
+    (when violation
+      [:div {:style (:error styles)
+             :data-controls-error (str k)}
+       (str "schema: " (let [expl (schema-validation/format-explain (:explain violation))]
+                         (if (seq expl)
+                           expl
+                           (str "does not match " (pr-str (:schema violation))))))])]])
 
 (defn args-editor
   "Render the args editor for `variant-id`. Reads the resolved args via
@@ -594,37 +813,72 @@
   argtypes (`:map` / `:vector` / `:set` / `:tuple`) recurse into nested
   rows (rf2-agshe).
 
+  Per rf2-ba86n.5 this is a Form-2 component: the outer closure holds the
+  `:expanded` ratom — a SET of expanded nested-control paths — so
+  summarise-before-expand state is component-local ephemeral UI state,
+  NOT `:cell-overrides` / shell-state (controls must not become hidden
+  panel state, spec/019 §6). The inner fn:
+
+  - resolves the EFFECTIVE args (with `:cell-overrides`) and the SAVED
+    baseline (without) so it can flag per-arg diff-from-saved;
+  - runs the SAME `schema-validation/args-violations` walk the schema-
+    validation panel uses, indexes it by key, and surfaces an inline
+    error per violating row + a panel banner;
+  - keeps args a control surface, not a fidelity rung — every value
+    here is an explicit view input.
+
   HOT PATH (rf2-wb4y3): every keystroke in a control row writes through
   `:cell-overrides`, the shell-state ratom re-renders this component,
   which re-runs the whole derivation. We resolve args ONCE here and
   thread the result into `resolve-argtypes` — without the thread the
   resolution ran twice (once here, once inside `resolve-argtypes`'s
-  fallback-inference branch). Same precedence chain, no duplicated work."
-  [variant-id]
-  (let [shell      @state/shell-state-atom
-        eff-args   (args/resolve-args
-                     variant-id
-                     {:active-modes (:active-modes shell)
-                      :cell-overrides
-                      (get-in shell [:cell-overrides variant-id])})
-        argtypes   (resolve-argtypes variant-id eff-args)]
-    [:div {:style (:section styles)}
-     [:div {:style (:section-h styles)} "Args"]
-     (if (empty? eff-args)
-       [:div {:style (:empty styles)} "no args resolved"]
-       (for [[k v] (sort-by key eff-args)]
-         ^{:key k}
-         [:div {:style (:row styles)
-                :data-controls-arg (str k)}
-          [:span {:style (:label styles)} (str k)]
-          [arg-widget variant-id [k] v
-           (get argtypes k {:widget :text})]]))
-     (when (seq (get-in shell [:cell-overrides variant-id]))
-       [:button {:style    (:button styles)
-                 :on-click (fn [_]
-                             (state/swap-state!
-                               state/clear-cell-overrides variant-id))}
-        "reset overrides"])]))
+  fallback-inference branch). Same precedence chain, no duplicated work.
+  The saved-baseline resolution adds one more pass; it is cheap (a five-
+  layer deep-merge over registry reads, no validation)."
+  [_variant-id]
+  ;; Component-local expanded-set (a SET of expanded nested-control
+  ;; paths). Ephemeral UI state — never persisted, never shell-state, so
+  ;; controls don't become hidden panel state (§6). Path-keyed, so it
+  ;; degrades harmlessly across a variant switch (a path absent in the
+  ;; new variant simply matches no control); deliberately not reset on
+  ;; switch — re-expanding the same path is cheap and remembering the
+  ;; user's disclosure choice across sibling variants is the kinder UX.
+  (let [expanded (r/atom #{})]
+    (fn [variant-id]
+      (let [shell        @state/shell-state-atom
+            overrides    (get-in shell [:cell-overrides variant-id])
+            eff-args     (args/resolve-args
+                           variant-id
+                           {:active-modes   (:active-modes shell)
+                            :cell-overrides overrides})
+            saved-args   (args/resolve-args
+                           variant-id
+                           {:active-modes (:active-modes shell)})
+            argtypes     (resolve-argtypes variant-id eff-args)
+            schema       (schema-validation/resolve-component-schema variant-id)
+            vfns         (schema-validation/validator-fns)
+            viols        (schema-validation/args-violations eff-args schema vfns)
+            viols-by-key (violations-by-key viols)
+            opts         {:expanded expanded}]
+        [:div {:style (:section styles)}
+         [:div {:style (:section-h styles)} "Args"]
+         (validation-banner (count viols))
+         (if (empty? eff-args)
+           [:div {:style (:empty styles)} "no args resolved"]
+           (for [[k v] (sort-by key eff-args)]
+             ^{:key k}
+             (args-row variant-id k v (get argtypes k {:widget :text})
+                       {:violation   (get viols-by-key k)
+                        :changed?    (arg-changed? eff-args saved-args k)
+                        :overridden? (contains? overrides k)
+                        :opts        opts})))
+         (when (seq overrides)
+           [:button {:style    (:button styles)
+                     :data-controls-action "reset-all"
+                     :on-click (fn [_]
+                                 (state/swap-state!
+                                   state/clear-cell-overrides variant-id))}
+            "reset overrides"])]))))
 
 ;; rf2-xi9zk: the controls-panel `mode-picker` is **superseded** by the
 ;; chrome-level toolbar (`re-frame.story.ui.toolbar`). Modes are

--- a/tools/story/src/re_frame/story/ui/controls_styles.cljs
+++ b/tools/story/src/re_frame/story/ui/controls_styles.cljs
@@ -100,4 +100,59 @@
                  :cursor "pointer"
                  :font-size (:micro typography/type-scale)
                  :margin-left "4px"}
-   :empty       {:color (:text-tertiary colors/tokens) :font-style "italic"}})
+   :empty       {:color (:text-tertiary colors/tokens) :font-style "italic"}
+   ;; ---- rf2-ba86n.5: validation, diff-from-saved, summarise-before-expand
+   ;;
+   ;; Inline schema error rendered under a control whose committed value
+   ;; violates the component's Spec 010 schema. The danger-bg ground +
+   ;; left rule mirror the schema-validation panel's `:violation` style so
+   ;; the two surfaces read as one validation language.
+   :error       {:color (:danger colors/tokens)
+                 :background (:danger-bg colors/tokens)
+                 :border-left "3px solid #ff4040"
+                 :padding "2px 6px"
+                 :margin-top "2px"
+                 :font-size (:micro typography/type-scale)}
+   ;; Panel-level banner shown when ≥1 committed arg violates the schema —
+   ;; render / test proof is gated until the violation clears.
+   :banner      {:color (:danger colors/tokens)
+                 :background (:danger-bg colors/tokens)
+                 :border "1px solid #ff4040"
+                 :border-radius "3px"
+                 :padding "4px 6px"
+                 :margin-bottom "6px"
+                 :font-size (:micro typography/type-scale)}
+   ;; The arg-changed-from-saved dot + per-arg reset affordance. The dot
+   ;; is amber (Story's "work in progress" signal); the reset is a tight
+   ;; inline glyph button sharing the rep-button ground.
+   :diff-row    {:display "inline-flex"
+                 :gap "4px"
+                 :align-items "center"}
+   :diff-dot    {:color (:accent-amber colors/tokens)
+                 :font-weight "bold"
+                 :title "changed from saved"}
+   :reset-arg   {:padding "0 4px"
+                 :background (:bg-3 colors/tokens)
+                 :color (:text-secondary colors/tokens)
+                 :border "1px solid #444"
+                 :border-radius "3px"
+                 :cursor "pointer"
+                 :font-size (:micro typography/type-scale)}
+   ;; The summarise-before-expand toggle for nested (group / repeater /
+   ;; tuple) controls. The disclosure triangle + the one-line summary of
+   ;; the collapsed value sit in the group header row (rf2-ba86n.5 / the
+   ;; deep-controls perf risk in spec 019 §4).
+   :disclosure  {:cursor "pointer"
+                 :user-select "none"
+                 :color (:info colors/tokens)
+                 :font-weight "bold"
+                 :background "none"
+                 :border "none"
+                 :padding "0"
+                 :font-family mono-stack
+                 :font-size (:caption typography/type-scale)
+                 :text-align "left"}
+   :summary     {:color (:text-tertiary colors/tokens)
+                 :font-style "italic"
+                 :margin-left "4px"
+                 :font-size (:micro typography/type-scale)}})

--- a/tools/story/src/re_frame/story/ui/state.cljc
+++ b/tools/story/src/re_frame/story/ui/state.cljc
@@ -18,6 +18,9 @@
                            walker (rf2-agshe). The `-scalar` wrapper
                            handles the bare top-level arg-key case.
   - `clear-cell-overrides` — drop all overrides for the focused variant.
+  - `clear-cell-override`  — drop one top-level arg-key's override,
+                             reverting that arg to its saved value (the
+                             controls panel's per-arg reset, rf2-ba86n.5).
   - `filter-variants`    — pure fn: given a set of variant bodies + the
                            shell state, return the visible subset.
   - `group-variants-by-story` — pure fn: build the sidebar tree.
@@ -171,6 +174,7 @@
 (def set-cell-override         state.transitions/set-cell-override)
 (def set-cell-override-scalar  state.transitions/set-cell-override-scalar)
 (def clear-cell-overrides      state.transitions/clear-cell-overrides)
+(def clear-cell-override       state.transitions/clear-cell-override)
 (def ensure-repeater-row-ids   state.transitions/ensure-repeater-row-ids)
 (def repeater-row-ids          state.transitions/repeater-row-ids)
 (def append-repeater-row-id    state.transitions/append-repeater-row-id)

--- a/tools/story/src/re_frame/story/ui/state/transitions.cljc
+++ b/tools/story/src/re_frame/story/ui/state/transitions.cljc
@@ -171,6 +171,37 @@
                         m)
                   m)))))
 
+(defn clear-cell-override
+  "Drop the override for a single top-level `arg-key` under `variant-id`,
+  reverting that one arg to its saved (declared) value while leaving
+  every other override intact. Backs the controls panel's per-arg
+  'reset' affordance (rf2-ba86n.5).
+
+  Also drops any repeater row-id bookkeeping anchored on a path whose
+  head is `arg-key` (rf2-c8kfy) so a reset collection re-syncs its row
+  ids from scratch against the reverted entry count. Other args' row
+  ids are untouched. When the last override for the variant is cleared
+  the empty `:cell-overrides` entry is pruned so callers reading
+  `(seq (get-in state [:cell-overrides variant-id]))` observe the same
+  'no overrides' shape `clear-cell-overrides` leaves."
+  [state variant-id arg-key]
+  (-> state
+      (update-in [:cell-overrides variant-id] dissoc arg-key)
+      (update :cell-overrides
+              (fn [m]
+                (if (empty? (get m variant-id))
+                  (dissoc m variant-id)
+                  m)))
+      (update :rf.story/repeater-row-ids
+              (fn [m]
+                (if (seq m)
+                  (into {}
+                        (remove (fn [[[v path] _ids]]
+                                  (and (= v variant-id)
+                                       (= arg-key (first path)))))
+                        m)
+                  m)))))
+
 ;; ---- repeater stable row-ids (rf2-c8kfy) ---------------------------------
 ;;
 ;; The controls-panel `repeater-widget` (vector / set) renders one DOM row

--- a/tools/story/test/re_frame/story/ui/controls_nested_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/controls_nested_cljs_test.cljc
@@ -260,3 +260,62 @@
           s2 (state/set-cell-override-scalar s1 :story.a/x  :meta {:author "bob"})]
       (is (= {:author "bob"}
              (get-in s2 [:cell-overrides :story.a/x :meta]))))))
+
+;; ---- JVM + CLJS: per-arg clear-cell-override (rf2-ba86n.5) ---------------
+
+(deftest clear-cell-override-drops-one-arg-keeps-others
+  (testing "clear-cell-override reverts a single arg-key, leaving the
+            variant's other overrides intact"
+    (let [s0 state/default-shell-state
+          s1 (-> s0
+                 (state/set-cell-override-scalar :story.a/x :label "hi")
+                 (state/set-cell-override-scalar :story.a/x :n     42))
+          s2 (state/clear-cell-override s1 :story.a/x :label)]
+      (is (nil? (get-in s2 [:cell-overrides :story.a/x :label])))
+      (is (= 42 (get-in s2 [:cell-overrides :story.a/x :n]))))))
+
+(deftest clear-cell-override-prunes-empty-variant-entry
+  (testing "clearing the LAST override for a variant prunes the empty
+            :cell-overrides entry — callers reading
+            (seq (get-in state [:cell-overrides variant])) see 'no
+            overrides', matching clear-cell-overrides"
+    (let [s0 state/default-shell-state
+          s1 (state/set-cell-override-scalar s0 :story.a/x :label "hi")
+          s2 (state/clear-cell-override s1 :story.a/x :label)]
+      (is (not (contains? (:cell-overrides s2) :story.a/x))))))
+
+(deftest clear-cell-override-leaves-other-variants
+  (testing "clearing one variant's arg does not touch another variant's
+            overrides"
+    (let [s0 state/default-shell-state
+          s1 (-> s0
+                 (state/set-cell-override-scalar :story.a/x :label "hi")
+                 (state/set-cell-override-scalar :story.b/y :label "yo"))
+          s2 (state/clear-cell-override s1 :story.a/x :label)]
+      (is (not (contains? (:cell-overrides s2) :story.a/x)))
+      (is (= "yo" (get-in s2 [:cell-overrides :story.b/y :label]))))))
+
+(deftest clear-cell-override-drops-matching-repeater-row-ids
+  (testing "clearing a collection arg drops only the repeater row-id
+            bookkeeping anchored on that arg-key; sibling collection
+            row-ids survive (rf2-c8kfy lockstep)"
+    (let [s0 state/default-shell-state
+          ;; Two collection args under one variant, each with row ids.
+          s1 (-> s0
+                 (state/set-cell-override-scalar :story.a/x :items ["a" "b"])
+                 (state/ensure-repeater-row-ids :story.a/x [:items] 2)
+                 (state/set-cell-override-scalar :story.a/x :tags  ["t"])
+                 (state/ensure-repeater-row-ids :story.a/x [:tags] 1))
+          s2 (state/clear-cell-override s1 :story.a/x :items)]
+      ;; :items row-ids gone, :tags row-ids intact.
+      (is (= [] (state/repeater-row-ids s2 :story.a/x [:items])))
+      (is (= 1 (count (state/repeater-row-ids s2 :story.a/x [:tags])))))))
+
+(deftest clear-cell-override-unknown-key-is-noop
+  (testing "clearing an arg-key with no override leaves the state
+            effectively unchanged (the variant entry is pruned only
+            when it becomes empty)"
+    (let [s0 state/default-shell-state
+          s1 (state/set-cell-override-scalar s0 :story.a/x :label "hi")
+          s2 (state/clear-cell-override s1 :story.a/x :missing)]
+      (is (= "hi" (get-in s2 [:cell-overrides :story.a/x :label]))))))

--- a/tools/story/test/re_frame/story/ui/controls_validation_diff_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/controls_validation_diff_cljs_test.cljc
@@ -1,0 +1,310 @@
+(ns re-frame.story.ui.controls-validation-diff-cljs-test
+  "Tests for the Story Controls panel's rf2-ba86n.5 surfaces:
+
+  - **inline schema validation** — `violations-by-key` indexing + the
+    `validation-banner` / inline-error rendering in `args-editor`;
+  - **diff-from-saved + per-arg reset** — `arg-changed?` + the
+    changed-dot / per-arg `reset` affordance;
+  - **summarise-before-expand** — `summarize-value` + the disclosure
+    header that collapses nested controls by default and lazily renders
+    children only when expanded.
+
+  ## Tiers
+
+  - **CLJS-only pure** — `violations-by-key`, `arg-changed?`,
+    `summarize-value` live in the CLJS-only `controls` ns. All pure
+    data → data.
+  - **CLJS-only render** — `args-editor` (Form-2) returns hiccup; the
+    collection / row / banner pieces are plain hiccup-returning fns so
+    the whole tree is inline and walkable.
+
+  The inline-error test branches on the live validator's observed
+  behaviour (`validator-fns` is 'either nil or callable' per the schema-
+  validation panel's own test): with a validator present it asserts the
+  banner + inline error; without, it asserts the documented soft-pass.
+  The pure walk that PRODUCES violations is covered in
+  `schema-validation-cljs-test`.
+
+  The file is a `.cljc` for symmetry with sibling controls tests; every
+  body is CLJS-only (`#?(:cljs ...)`). The ns suffix `-cljs-test` is
+  picked up by both `cljs-test$` and `-cljs-test$` regexes."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            #?(:cljs [re-frame.story :as story])
+            #?(:cljs [re-frame.story.ui.controls :as controls])
+            [re-frame.story.ui.state :as state]))
+
+;; ---- fixtures ------------------------------------------------------------
+
+#?(:cljs
+   (defn reset-fixture [test-fn]
+     (story/clear-all!)
+     (state/reset-shell-state!)
+     (story/install-canonical-vocabulary!)
+     (test-fn))
+   :clj
+   (defn reset-fixture [test-fn]
+     (state/reset-shell-state!)
+     (test-fn)))
+
+(use-fixtures :each reset-fixture)
+
+;; ---- helpers -------------------------------------------------------------
+;;
+;; Hiccup walking: `for`-produced child seqs are NOT vectors, so a naive
+;; `(tree-seq vector? rest tree)` never descends into them. We walk
+;; explicitly — recursing into vector children AND seq children — mirroring
+;; the sibling `controls-scalar-widgets-cljs-test/walk-find` idiom.
+
+#?(:cljs
+   (defn- attrs
+     "Return the attribute map of a hiccup node (second element when it's
+     a map, else nil)."
+     [node]
+     (let [a (when (vector? node) (second node))]
+       (when (map? a) a))))
+
+#?(:cljs
+   (defn- all-nodes
+     "Depth-first vector of every hiccup VECTOR node in `tree` (descending
+     through both vector children and `for`-produced seq children)."
+     [tree]
+     (let [acc (atom [])]
+       (letfn [(walk [node]
+                 (cond
+                   (vector? node) (do (swap! acc conj node)
+                                      (doseq [c (rest node)] (walk c)))
+                   (seq? node)    (doseq [c node] (walk c))))]
+         (walk tree))
+       @acc)))
+
+#?(:cljs
+   (defn- find-node
+     "First hiccup node satisfying `pred` (pred receives the node)."
+     [tree pred]
+     (some (fn [n] (when (pred n) n)) (all-nodes tree))))
+
+#?(:cljs
+   (defn- node-with-attr
+     "First hiccup node whose attribute `k` equals `v` (or, when `v` is
+     omitted, whose attribute `k` is present)."
+     ([tree k] (find-node tree (fn [n] (contains? (attrs n) k))))
+     ([tree k v] (find-node tree (fn [n] (= v (get (attrs n) k)))))))
+
+#?(:cljs
+   (defn- button-with-action
+     "First `:button` node whose `:data-controls-action` is `action`."
+     [tree action]
+     (find-node tree
+                (fn [n] (and (= :button (first n))
+                             (= action (:data-controls-action (attrs n))))))))
+
+#?(:cljs
+   (defn- render
+     "Render the Form-2 args-editor for `variant-id` to hiccup."
+     [variant-id]
+     ((controls/args-editor variant-id) variant-id)))
+
+;; ---- pure: violations-by-key --------------------------------------------
+
+#?(:cljs
+   (deftest violations-by-key-indexes-by-arg-key
+     (testing "violations-by-key turns the args-violations vector into a
+               {arg-key → violation} map"
+       (let [viols [{:key :name :value 42 :schema :string :explain nil}
+                    {:key :age  :value "x" :schema :int    :explain nil}]
+             by-k  (controls/violations-by-key viols)]
+         (is (= 2 (count by-k)))
+         (is (= 42 (get-in by-k [:name :value])))
+         (is (= "x" (get-in by-k [:age :value])))))))
+
+#?(:cljs
+   (deftest violations-by-key-remaps-root-key
+     (testing "the schema-validation ::root sentinel (whole-args non-:map
+               failure) remaps to :rf.story.controls/root so it never
+               collides with a real arg-key but still counts"
+       (let [viols [{:key :re-frame.story.ui.schema-validation/root
+                     :value {:a 1} :schema :string :explain nil}]
+             by-k  (controls/violations-by-key viols)]
+         (is (contains? by-k :rf.story.controls/root))
+         (is (= {:a 1} (get-in by-k [:rf.story.controls/root :value])))))))
+
+#?(:cljs
+   (deftest violations-by-key-empty
+     (testing "an empty violations vector indexes to an empty map"
+       (is (= {} (controls/violations-by-key []))))))
+
+;; ---- pure: arg-changed? -------------------------------------------------
+
+#?(:cljs
+   (deftest arg-changed?-true-on-diff
+     (testing "an arg whose effective value differs from its saved value
+               is flagged changed"
+       (is (controls/arg-changed? {:a 2} {:a 1} :a)))))
+
+#?(:cljs
+   (deftest arg-changed?-false-on-equal
+     (testing "an arg whose effective value equals its saved value is not
+               flagged changed — even with an override present (same-value
+               override)"
+       (is (not (controls/arg-changed? {:a 1} {:a 1} :a))))))
+
+#?(:cljs
+   (deftest arg-changed?-handles-missing-keys
+     (testing "a key absent from saved but present in effective is changed;
+               a key absent from both is not"
+       (is (controls/arg-changed? {:a 1} {} :a))
+       (is (not (controls/arg-changed? {} {} :a))))))
+
+;; ---- pure: summarize-value ----------------------------------------------
+
+#?(:cljs
+   (deftest summarize-value-collections
+     (testing "summarize-value gives a non-recursive one-line summary"
+       (is (= "empty"   (controls/summarize-value nil)))
+       (is (= "1 key"   (controls/summarize-value {:a 1})))
+       (is (= "2 keys"  (controls/summarize-value {:a 1 :b 2})))
+       (is (= "1 item"  (controls/summarize-value [:x])))
+       (is (= "3 items" (controls/summarize-value [:x :y :z])))
+       (is (= "2 items" (controls/summarize-value #{:x :y})))
+       ;; a scalar landing under a collection widget pr-strs
+       (is (= "\"x\""   (controls/summarize-value "x"))))))
+
+#?(:cljs
+   (deftest summarize-value-does-not-recurse
+     (testing "deep contents are NOT walked — only the top-level count
+               appears (the point of summarising before expanding)"
+       (is (= "1 key"
+              (controls/summarize-value
+                {:deep {:and {:nested {:tree :here}}}}))))))
+
+;; ---- CLJS render: summarise-before-expand -------------------------------
+
+#?(:cljs
+   (deftest group-collapsed-by-default-renders-summary-not-children
+     (testing "a :group widget is collapsed by default — the disclosure
+               header is present + collapsed, and the nested child rows
+               are NOT in the tree (summarise-before-expand, spec/019 §4)"
+       (story/reg-variant :story.ba86n/grp
+         {:schema [:map [:meta [:map [:author :string] [:rating :int]]]]
+          :args   {:meta {:author "ada" :rating 5}}
+          :events []})
+       (let [tree   (render :story.ba86n/grp)
+             toggle (button-with-action tree "toggle-expand")]
+         (is (some? toggle) "disclosure toggle present")
+         (is (= "false" (:data-controls-expanded (attrs toggle)))
+             "collapsed by default")
+         ;; The nested :author key row is NOT rendered while collapsed.
+         ;; (Keys stringify WITH the leading colon — `(str :author)`.)
+         (is (nil? (node-with-attr tree :data-controls-key ":author")))))))
+
+#?(:cljs
+   (deftest disclosure-toggle-expands-and-reveals-children
+     (testing "clicking the disclosure toggle flips the (component-local)
+               expand state and a re-render reveals the nested child rows"
+       (story/reg-variant :story.ba86n/grp2
+         {:schema [:map [:meta [:map [:author :string]]]]
+          :args   {:meta {:author "ada"}}
+          :events []})
+       ;; ONE editor instance — the expand ratom lives on its closure, so
+       ;; the toggle + re-render must go through the same instance.
+       (let [editor (controls/args-editor :story.ba86n/grp2)
+             tree-1 (editor :story.ba86n/grp2)
+             toggle (button-with-action tree-1 "toggle-expand")
+             on-click (:on-click (attrs toggle))]
+         (is (fn? on-click))
+         ;; Collapsed first: no nested :author row.
+         (is (nil? (node-with-attr tree-1 :data-controls-key ":author")))
+         (on-click nil)
+         (let [tree-2 (editor :story.ba86n/grp2)]
+           ;; Expanded now: the nested :author row IS present.
+           (is (some? (node-with-attr tree-2 :data-controls-key ":author"))))))))
+
+;; ---- CLJS render: inline schema error + banner --------------------------
+
+#?(:cljs
+   (deftest args-editor-marks-rows-with-validity-attribute
+     (testing "every arg row carries a data-controls-invalid attribute so
+               downstream tooling / the browser smoke can detect blocked
+               renders"
+       (story/reg-variant :story.ba86n/val
+         {:args {:title "hi"} :events []})
+       (let [tree (render :story.ba86n/val)
+             row  (node-with-attr tree :data-controls-arg ":title")]
+         (is (some? row))
+         (is (contains? (attrs row) :data-controls-invalid))))))
+
+#?(:cljs
+   (deftest inline-error-and-banner-track-the-live-validator
+     (testing "a committed value that violates the variant's :schema
+               surfaces an inline error + a panel banner when a live
+               validator is present, and soft-passes otherwise"
+       (story/reg-variant :story.ba86n/bad
+         {:schema [:map [:age :int]]
+          ;; :age is a string but the schema says :int.
+          :args   {:age "not-a-number"}
+          :events []})
+       (let [tree    (render :story.ba86n/bad)
+             banner  (node-with-attr tree :data-controls-validation "invalid")
+             err-row (node-with-attr tree :data-controls-error)
+             age-row (node-with-attr tree :data-controls-arg ":age")]
+         (if banner
+           ;; Live validator flagged the violation — the BEFORE-render
+           ;; claims contract: banner + inline error + row marked invalid.
+           (do
+             (is (pos? (js/parseInt
+                         (:data-controls-violation-count (attrs banner)))))
+             (is (some? err-row) "inline error renders for the violating arg")
+             (is (= "true" (:data-controls-invalid (attrs age-row)))))
+           ;; Soft-pass — no validator on the classpath (per Spec 010).
+           (do
+             (is (nil? err-row))
+             (is (= "false" (:data-controls-invalid (attrs age-row))))))))))
+
+;; ---- CLJS render: diff-from-saved dot + per-arg reset -------------------
+
+#?(:cljs
+   (deftest changed-arg-shows-dot-and-per-arg-reset
+     (testing "an arg overridden to a value differing from saved shows the
+               changed dot (data-controls-changed=\"true\") and a per-arg
+               reset button; clicking reset clears only that arg's override"
+       (story/reg-variant :story.ba86n/diff
+         {:args {:title "saved" :other "keep"} :events []})
+       (state/swap-state! state/set-cell-override-scalar
+                          :story.ba86n/diff :title "edited")
+       (state/swap-state! state/set-cell-override-scalar
+                          :story.ba86n/diff :other "changed-too")
+       (let [tree      (render :story.ba86n/diff)
+             title-row (node-with-attr tree :data-controls-arg ":title")]
+         (is (= "true" (:data-controls-changed (attrs title-row))))
+         (let [reset-btn (button-with-action title-row "reset-arg")]
+           (is (some? reset-btn))
+           ((:on-click (attrs reset-btn)) nil)
+           ;; :title override gone, :other override survives.
+           (is (nil? (get-in (state/get-state)
+                             [:cell-overrides :story.ba86n/diff :title])))
+           (is (= "changed-too"
+                  (get-in (state/get-state)
+                          [:cell-overrides :story.ba86n/diff :other]))))))))
+
+#?(:cljs
+   (deftest unchanged-arg-has-no-changed-dot
+     (testing "an arg at its saved value carries data-controls-changed=
+               \"false\" — no diff dot"
+       (story/reg-variant :story.ba86n/same
+         {:args {:title "saved"} :events []})
+       (let [tree (render :story.ba86n/same)
+             row  (node-with-attr tree :data-controls-arg ":title")]
+         (is (= "false" (:data-controls-changed (attrs row))))))))
+
+#?(:cljs
+   (deftest reset-overrides-button-present-when-overrides-exist
+     (testing "the panel-level 'reset overrides' button appears only when
+               at least one override exists for the focused variant"
+       (story/reg-variant :story.ba86n/resetall
+         {:args {:a 1} :events []})
+       ;; No overrides yet → no reset-all button.
+       (is (nil? (button-with-action (render :story.ba86n/resetall) "reset-all")))
+       ;; Add an override → reset-all appears.
+       (state/swap-state! state/set-cell-override-scalar
+                          :story.ba86n/resetall :a 2)
+       (is (some? (button-with-action (render :story.ba86n/resetall) "reset-all"))))))


### PR DESCRIPTION
Builds the remaining StoryUI controls surfaces on top of the existing scalar/collection widget taxonomy in `tools/story/src/re_frame/story/ui/controls.cljs` (spec/019 — Story UI Controls and View-State Variants). No greenfield; extends the existing args editor.

## Control types
The taxonomy already covered **scalar** (text / textarea / number / boolean / date / color), **enum** (select / radio), **boolean** (toggle), **color** (picker), **collection** (`:repeater` for vector/set), and **structured** (`:group` for map, `:tuple`). This PR layers the missing controls behaviours over them.

## Inline schema validation (before render/test claims)
- Each arg-key is checked against the component's Spec 010 schema using the **same** pure `schema-validation/args-violations` walk the schema-validation panel uses — `resolve-component-schema` + `validator-fns` (late-bound) + `args-violations`. No second validator.
- A violating row renders an inline error under its widget (reusing `schema-validation/format-explain`); a panel-level **banner** (`role="alert"`) names how many committed args block a valid render/test claim.
- Soft-passes per Spec 010 §Recommended soft-pass when no validator is on the classpath.
- New pure helper `violations-by-key` indexes the violation vector (`::schema-validation/root` → `:rf.story.controls/root` so a whole-args non-map failure still banners without colliding with a real arg-key).

## Diff-from-saved + reset
- The **saved** baseline is the variant's resolved args *without* `:cell-overrides`; `arg-changed?` compares effective vs saved per key.
- A changed arg shows an amber **changed dot**; a **per-arg reset** reverts just that arg via a new `state/clear-cell-override` transition (drops only the matching repeater row-ids per rf2-c8kfy lockstep; prunes the variant's `:cell-overrides` entry when it becomes empty). The panel-level **reset overrides** still clears all.

## Summarise before expanding
- Nested `:group` / `:repeater` / `:tuple` controls render a one-line disclosure summary (`summarize-value`, non-recursive) with a `▸`/`▾` toggle and lazily render child rows only when expanded (spec/019 §4 deep-controls perf risk).
- Expand state is a **component-local Reagent atom** on the editor's Form-2 closure (a set of expanded paths) — never `:cell-overrides`, never shell-state.

## Args-vs-fidelity boundary (§6)
Args remain a **control surface, not a fidelity rung**. The summarise-before-expand flag is deliberately ephemeral component-local UI state so controls never become hidden panel state. Sub-overrides / db-seed fidelity rungs are out of scope (ba86n.7 / §5).

The collection / row / banner / disclosure pieces render as plain hiccup-returning fns so the editor is one inline tree (testable); Reagent reactivity is preserved because `path-expanded?` derefs the expanded ratom during the editor's own render.

## Spec
spec/019 already specifies these behaviours (§1 inline validation, §2 widget taxonomy, §4 summarise-before-expand, §5 args-vs-fidelity, §6 acceptance); the implementation conforms — **spec unchanged**.

## Tests
- New `controls_validation_diff_cljs_test.cljc`: pure helpers (`violations-by-key`, `arg-changed?`, `summarize-value`) + CLJS render assertions (collapse-by-default / toggle-expand reveals children, inline error + banner tracking the live validator, diff-dot + per-arg reset clears one arg, reset-all visibility).
- `controls_nested_cljs_test.cljc`: `clear-cell-override` transition coverage (per-arg drop, empty-entry prune, sibling-variant isolation, repeater row-id lockstep, unknown-key no-op).

## Quality gates
- **clj-kondo** `--parallel --fail-level error --lint tools/story` — **errors: 0** (warnings pre-existing; the test's referred-but-unused `deftest`/`is`/`testing` on the JVM branch match the sibling `controls_scalar_widgets_cljs_test.cljc` idiom).
- `tools/story` `clojure -M:test` — 1359 tests, 0 failures, 0 errors.
- `npm run test:cljs` — 4892 tests, 0 failures, 0 errors (compile clean).
- `tools/story-mcp` `clojure -M:test` — 172 tests, 0 failures, 0 errors.
- `tools/mcp-conformance` `npm run test:story` — STORY-MCP MCP-CLIENT CONFORMANCE GREEN.
- `scripts/test-fast-pr.sh` — PASS fast PR spine.
