### PR TITLE
refactor(story): route test_mode epoch calls through late-bound rf/ facade (rf2-quphj)

### DIFF
--- a/tools/story/src/re_frame/story/ui/test_mode/state.cljs
+++ b/tools/story/src/re_frame/story/ui/test_mode/state.cljs
@@ -40,7 +40,7 @@
     and the top-level `test-view` component (the sole consumer of the
     helpers below)."
   (:require [reagent.core                 :as r]
-            [re-frame.epoch               :as epoch]
+            [re-frame.core                :as rf]
             [re-frame.interop             :as interop]
             [re-frame.story.async         :as async]
             [re-frame.story.play          :as play]
@@ -87,7 +87,7 @@
         ;; — the same shape the legacy `:play` slot carried, so the
         ;; scrubber's slot-shape stays stable.
         play-events  (play/variant-play-events variant-id)
-        history      (epoch/epoch-history variant-id)
+        history      (rf/epoch-history variant-id)
         epoch-ids    (pure/epoch-id-slice history (count play-events))]
     (swap! results-atom assoc variant-id
            {:result        result
@@ -142,7 +142,7 @@
     (when-not (:running? s)
       (swap! results-atom assoc-in [variant-id :selected-step] idx)
       (when target-id
-        (epoch/restore-epoch variant-id target-id)))))
+        (rf/restore-epoch variant-id target-id)))))
 
 (defn toggle-expanded!
   "Toggle the expand state of an assertion row, keyed by stable

--- a/tools/story/src/re_frame/story/ui/test_mode/stepper_state.cljs
+++ b/tools/story/src/re_frame/story/ui/test_mode/stepper_state.cljs
@@ -23,14 +23,14 @@
        :statuses       <vector>       ; `stepper-pure/enrich-statuses` rows
        :breakpoints    #{<int>}       ; step indices that pause auto-play
        :epoch-stack    <vector>       ; per-step :epoch-id pre-images, for
-                                      ;   step-back via epoch/restore-epoch
+                                      ;   step-back via rf/restore-epoch
        :interval-id    <int|nil>      ; the auto-play setInterval handle
        :tick-ms        <int>}         ; ms between auto-play steps
 
   ## Step-back semantics
 
   The runtime substrate only steps FORWARD (`step-once!`). To support
-  step-back we leverage the same `epoch/restore-epoch` substrate the
+  step-back we leverage the same `rf/restore-epoch` substrate the
   scrubber uses: BEFORE each forward step we capture the variant frame's
   current `:epoch-id` (the head of `epoch-history`) and push it onto
   `:epoch-stack`. A step-back POPS the stack and `restore-epoch`s the
@@ -50,7 +50,7 @@
   unmounts, or when the stepper hits the end of the play sequence.
   Clears the interval and the per-frame play state."
   (:require [reagent.core                                 :as r]
-            [re-frame.epoch                               :as epoch]
+            [re-frame.core                                :as rf]
             [re-frame.story.play                          :as play]
             [re-frame.story.runtime                       :as runtime]
             [re-frame.story.assertions                    :as assertions]
@@ -69,7 +69,7 @@
   Returns nil when the history is empty (production elision / disabled
   ring buffer)."
   [variant-id]
-  (-> (epoch/epoch-history variant-id) last :epoch-id))
+  (-> (rf/epoch-history variant-id) last :epoch-id))
 
 (defn- recompute-statuses
   "Pure: re-derive the enriched step list from a slot. Called after every
@@ -165,7 +165,7 @@
 
 (defn step-back!
   "Restore the variant frame to its previous epoch and decrement the
-  cursor. Uses `epoch/restore-epoch` against the top-of-stack id;
+  cursor. Uses `rf/restore-epoch` against the top-of-stack id;
   no-ops when the stepper is parked at step 0 or not active.
 
   Step-back never re-dispatches the popped event — that would create a
@@ -180,7 +180,7 @@
             new-stack (vec (butlast stack))
             target-id (peek new-stack)]
         (when target-id
-          (epoch/restore-epoch variant-id target-id))
+          (rf/restore-epoch variant-id target-id))
         ;; Pop the substrate's last-run step + result so the row outcomes
         ;; track the cursor and a re-step re-runs the popped step cleanly.
         (play/stepper-step-back! variant-id)
@@ -203,7 +203,7 @@
             ;; first pre-image we pushed on `begin!`).
             seed  (first stack)]
         (when seed
-          (epoch/restore-epoch variant-id seed))
+          (rf/restore-epoch variant-id seed))
         ;; Also reset the assertion accumulator so a fresh forward run
         ;; doesn't pile new records on top of the old ones.
         (assertions/reset-trace-accumulators! variant-id)

--- a/tools/story/test/re_frame/story/ui/test_mode/stepper_state_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/test_mode/stepper_state_cljs_test.cljs
@@ -3,12 +3,12 @@
   §Play step-debugger).
 
   The substantive runtime calls (`runtime/reset-variant`,
-  `play/begin-stepper!`, `epoch/restore-epoch`) are exercised by the
+  `play/begin-stepper!`, `rf/restore-epoch`) are exercised by the
   feature-load browser gate. These unit tests pin the mutator semantics
   by redef-ing the substrate calls so the slot transitions can be
   observed deterministically without booting the runtime."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
-            [re-frame.epoch :as epoch]
+            [re-frame.core :as rf]
             [re-frame.story.assertions :as assertions]
             [re-frame.story.play :as play]
             [re-frame.story.registrar :as registrar]
@@ -53,7 +53,7 @@
       (seed-slot! vid events)
       (with-redefs [play/step-once!    (fn [v]
                                          (swap! dispatched conj v))
-                    epoch/epoch-history (fn [_]
+                    rf/epoch-history (fn [_]
                                           [{:epoch-id :epoch/before-a}])
                     assertions/read-assertions (fn [_] [])]
         (st/step! vid)
@@ -70,7 +70,7 @@
       (seed-slot! vid [[:e/a]])
       (swap! st/results-atom assoc-in [vid :cursor] 1)
       (with-redefs [play/step-once!    (fn [v] (swap! dispatched conj v))
-                    epoch/epoch-history (fn [_] [{:epoch-id :x}])
+                    rf/epoch-history (fn [_] [{:epoch-id :x}])
                     assertions/read-assertions (fn [_] [])]
         (st/step! vid)
         (is (empty? @dispatched) "play/step-once! is NOT called")
@@ -84,7 +84,7 @@
       (seed-slot! vid [[:e/a]])
       (swap! st/results-atom assoc-in [vid :active?] false)
       (with-redefs [play/step-once!    (fn [v] (swap! dispatched conj v))
-                    epoch/epoch-history (fn [_] [{:epoch-id :x}])
+                    rf/epoch-history (fn [_] [{:epoch-id :x}])
                     assertions/read-assertions (fn [_] [])]
         (st/step! vid)
         (is (empty? @dispatched))))))
@@ -105,9 +105,9 @@
                          (assoc :epoch-stack [:epoch/seed
                                               :epoch/before-a
                                               :epoch/before-b]))))
-      (with-redefs [epoch/restore-epoch (fn [v eid]
-                                          (swap! restored conj [v eid]))
-                    epoch/epoch-history (fn [_] [{:epoch-id :x}])
+      (with-redefs [rf/restore-epoch (fn [v eid]
+                                       (swap! restored conj [v eid]))
+                    rf/epoch-history (fn [_] [{:epoch-id :x}])
                     assertions/read-assertions (fn [_] [])]
         (st/step-back! vid)
         (let [s (get @st/results-atom vid)]
@@ -122,9 +122,9 @@
     (let [vid      :story.unit/back-start
           restored (atom [])]
       (seed-slot! vid [[:e/a]])
-      (with-redefs [epoch/restore-epoch (fn [v eid]
-                                          (swap! restored conj [v eid]))
-                    epoch/epoch-history (fn [_] [{:epoch-id :x}])
+      (with-redefs [rf/restore-epoch (fn [v eid]
+                                       (swap! restored conj [v eid]))
+                    rf/epoch-history (fn [_] [{:epoch-id :x}])
                     assertions/read-assertions (fn [_] [])]
         (st/step-back! vid)
         (is (empty? @restored))
@@ -145,9 +145,9 @@
                          (assoc :epoch-stack [:epoch/seed
                                               :epoch/before-a
                                               :epoch/before-b]))))
-      (with-redefs [epoch/restore-epoch (fn [v eid]
-                                          (swap! restored conj [v eid]))
-                    epoch/epoch-history (fn [_] [{:epoch-id :x}])
+      (with-redefs [rf/restore-epoch (fn [v eid]
+                                       (swap! restored conj [v eid]))
+                    rf/epoch-history (fn [_] [{:epoch-id :x}])
                     assertions/reset-trace-accumulators!
                                         (fn [v] (swap! cleared conj v))
                     assertions/read-assertions (fn [_] [])]
@@ -170,8 +170,8 @@
                          (assoc :cursor 1)
                          (assoc :auto-playing? true)
                          (assoc :interval-id 999))))
-      (with-redefs [epoch/restore-epoch (fn [_ _] nil)
-                    epoch/epoch-history (fn [_] [])
+      (with-redefs [rf/restore-epoch (fn [_ _] nil)
+                    rf/epoch-history (fn [_] [])
                     assertions/reset-trace-accumulators! (fn [_] nil)
                     assertions/read-assertions (fn [_] [])
                     js/clearInterval (fn [_] nil)]

--- a/tools/story/test/re_frame/story/ui/test_mode_state_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/test_mode_state_cljs_test.cljs
@@ -12,7 +12,7 @@
   platform pure assertions on `assertion-row :row-key` live in
   `re-frame.story-ui-test` (JVM)."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.epoch :as epoch]
+            [re-frame.core :as rf]
             [re-frame.story.ui.test-mode.state :as tm-state]))
 
 ;; ---- fixtures ------------------------------------------------------------
@@ -37,11 +37,11 @@
       (swap! tm-state/results-atom assoc variant-id
              {:running?  true
               :epoch-ids epoch-ids})
-      (with-redefs [epoch/restore-epoch (fn [vid eid]
-                                          (swap! restored conj [vid eid]))]
+      (with-redefs [rf/restore-epoch (fn [vid eid]
+                                       (swap! restored conj [vid eid]))]
         (tm-state/select-step! variant-id 1))
       (is (= [] @restored)
-          "epoch/restore-epoch is not called while :running? is true")
+          "rf/restore-epoch is not called while :running? is true")
       (is (nil? (get-in @tm-state/results-atom [variant-id :selected-step]))
           ":selected-step is NOT mutated while :running? is true — preserving
            the prior scrubber position so the post-resolve render is
@@ -57,8 +57,8 @@
       (swap! tm-state/results-atom assoc variant-id
              {:running?  false
               :epoch-ids epoch-ids})
-      (with-redefs [epoch/restore-epoch (fn [vid eid]
-                                          (swap! restored conj [vid eid]))]
+      (with-redefs [rf/restore-epoch (fn [vid eid]
+                                       (swap! restored conj [vid eid]))]
         (tm-state/select-step! variant-id 1))
       (is (= [[variant-id :epoch/b]] @restored)
           "the idle path still calls restore-epoch against the targeted slot")


### PR DESCRIPTION
## What

`tools/story/.../ui/test_mode/state.cljs` and `.../ui/test_mode/stepper_state.cljs` hard-required `[re-frame.epoch :as epoch]` and called `epoch/epoch-history` + `epoch/restore-epoch` directly. This is a production-classpath purity wart: the rest of `tools/story` reaches the same surface through the **late-bound `re-frame.core` facade** (`rf/epoch-history`, `rf/restore-epoch`).

## The require/alias swap

In both files:
- Dropped `[re-frame.epoch :as epoch]`; added `[re-frame.core :as rf]`.
- Rewrote call sites: `epoch/epoch-history` → `rf/epoch-history`, `epoch/restore-epoch` → `rf/restore-epoch`.
- Updated the docstring/comment prose refs in `stepper_state.cljs` to match the now-current alias.

Behaviour is identical — `re-frame.core/{epoch-history,restore-epoch}` are `defwrapper`s that dispatch through the `:epoch/*` late-bind hook table to the registered `re-frame.epoch` impls (and degrade to empty-vec/false when the epoch artefact is absent).

## In-repo precedent followed

Mirrors `re_frame/story/artifact.cljc:357` (`(rf/epoch-history frame-id)`), `runtime.cljc:514`, `assertions.cljc`, `golden.cljc` — all read the surface via `[re-frame.core :as rf]`. `tools/story/deps.edn` documents the invariant: "the published Story jar carries no epoch dep (both sources read the late-bound facade)".

## Test follow-on (required by the require change)

The two CLJS unit tests (`test_mode_state_cljs_test.cljs`, `test_mode/stepper_state_cljs_test.cljs`) `with-redefs`-ed the substrate via the `re-frame.epoch` var. Because production now reads `re-frame.core/{restore-epoch,epoch-history}` — whose value resolves through the late-bind table at call time, **not** via the `re-frame.epoch` var — a redef on the `re-frame.epoch` var would no longer be observed. Re-pointed the redefs at `rf/restore-epoch` + `rf/epoch-history` so the mocks still take effect. (`npm run test:cljs` exercises these and passes.)

## Bundle-isolation confirmation

The production-bundle gate passes; `test_mode` no longer carries any `re-frame.epoch` require, so it cannot pull the epoch artefact into a production bundle. `git grep` confirms zero `epoch/` alias usages or `re-frame.epoch` requires remain under `tools/story/src/.../ui/test_mode/`.

## Quality gates

- **clj-kondo** `--parallel --fail-level error --lint tools/story`: **errors: 0** (120 pre-existing warnings, none in the touched files).
- `tools/story` `clojure -M:test`: 1365 tests / 4606 assertions, **0 failures, 0 errors**.
- `npm run test:cljs`: 4882 tests / 15983 assertions, **0 failures, 0 errors** (build: 0 warnings).
- `npm run test:bundle-isolation`: **PASS** (35 internal sentinels absent; budgets ok).
- `scripts/test-fast-pr.sh`: **PASS**.