### PR TITLE
feat(storyui/sidebar): five-axis signal chips, keyboard movement, list bounding (rf2-ba86n.4)

### DIFF
--- a/tools/story/src/re_frame/story/ui/sidebar.cljs
+++ b/tools/story/src/re_frame/story/ui/sidebar.cljs
@@ -337,10 +337,14 @@
   [body status]
   (let [{:keys [status fidelity world-inputs runner-requirement frame-binding]}
         (signals/variant-signals body status)]
+    ;; Each `signal-chip` is invoked as a FUNCTION (not a `[component …]`
+    ;; vector) so the returned hiccup is fully expanded — the same pattern
+    ;; `tag-badges` uses. This keeps the strip a single pure hiccup tree
+    ;; the test corpus can walk without a Reagent render pass.
     [:div {:style       (:signal-row styles)
            :data-test   "story-sidebar-signal-row"}
      [:span {:style (:signal-group styles) :data-axis "status"}
-      [signal-chip status]]
+      (signal-chip status)]
      (when (seq fidelity)
        [:span {:style (:signal-group styles) :data-axis "fidelity"}
         (for [s fidelity] (signal-chip s))])
@@ -348,9 +352,9 @@
        [:span {:style (:signal-group styles) :data-axis "world-inputs"}
         (for [s world-inputs] (signal-chip s))])
      [:span {:style (:signal-group styles) :data-axis "runner-requirement"}
-      [signal-chip runner-requirement]]
+      (signal-chip runner-requirement)]
      [:span {:style (:signal-group styles) :data-axis "frame-binding"}
-      [signal-chip frame-binding]]]))
+      (signal-chip frame-binding)]]))
 
 (defn- highlighted-label
   "rf2-yngai — render a variant / story label with the matched

--- a/tools/story/src/re_frame/story/ui/sidebar.cljs
+++ b/tools/story/src/re_frame/story/ui/sidebar.cljs
@@ -61,6 +61,7 @@
             [re-frame.story.theme.colors      :as colors]
             [re-frame.story.theme.glyphs      :as glyphs]
             [re-frame.story.ui.sidebar-search :as search]
+            [re-frame.story.ui.sidebar-signals :as signals]
             [re-frame.story.ui.sidebar-styles :refer [styles]]
             [re-frame.story.ui.state          :as state]))
 
@@ -134,6 +135,31 @@
   (->> (or tags #{})
        (sort-by name)
        vec))
+
+;; ---- pure: large-list bounding (rf2-ba86n.4) ----------------------------
+
+(def default-variant-cap
+  "Per-story variant cap before the sidebar bounds the list with a
+  '+N more' expander (spec/018 §10 — cap or page large lists; the UI
+  SHOULD fail by summarizing and offering expansion, not by flooding the
+  screen). Sized so a typical design-system story (a handful to a dozen
+  variants) is never bounded, but a matrix-scale story stays scannable
+  until the author opts to expand it."
+  40)
+
+(defn bound-variants
+  "Pure data → data: bound a story's variant seq to at most `cap` entries
+  unless `expanded?`. Returns `{:shown [...] :hidden <n>}` — `:shown` is the
+  capped (or full, when expanded) prefix and `:hidden` is the count elided
+  (0 when nothing was bounded). Keeps the sidebar bounded at realistic
+  project scale without dropping any variant from reach (the expander
+  reveals the rest). JVM-testable."
+  [variants cap expanded?]
+  (let [total (count variants)]
+    (if (or expanded? (<= total cap))
+      {:shown (vec variants) :hidden 0}
+      {:shown  (vec (take cap variants))
+       :hidden (- total cap)})))
 
 ;; ---- components ----------------------------------------------------------
 
@@ -247,6 +273,85 @@
                    :title     (str tag)}
             (name tag)]))])))
 
+;; ---- signal chips (rf2-ba86n.4) -----------------------------------------
+;;
+;; Five DISTINCT axes (spec/018 §7.1 + §12.6) — status / fidelity /
+;; world-inputs / runner-requirement / frame-binding. The pure derivation
+;; lives in `re-frame.story.ui.sidebar-signals` (JVM-testable); this layer
+;; renders each axis as its OWN chip group so args / network / fx-overrides
+;; / browser / MCP-bound are never collapsed into one 'fidelity' concept.
+;; The render-only style-key projections live here next to the styles.
+
+(def status-signal->style-key
+  "Pure data → data: map a status value to the styles map key that tints
+  its chip. Public so the test corpus can exercise the projection."
+  {:pass       :signal-status-pass
+   :fail       :signal-status-fail
+   :cannot-run :signal-status-cannot-run
+   :error      :signal-status-error
+   :running    :signal-status-running
+   :pending    :signal-status-pending
+   :blocked    :signal-status-blocked
+   :dirty      :signal-status-dirty
+   :redacted   :signal-status-redacted})
+
+(def axis->group-style-key
+  "Pure data → data: the per-axis tint applied to a non-status chip so each
+  axis reads as its own visual family (spec/018 §12.6 — fidelity, world
+  inputs, runner requirements, and frame binding are different label
+  families, never one 'fidelity' concept)."
+  {:fidelity           :signal-fidelity
+   :world-inputs       :signal-world
+   :runner-requirement :signal-runner
+   :frame-binding      :signal-frame})
+
+(defn- signal-chip
+  "Render one signal chip. `axis` selects the per-axis tint (status chips
+  additionally key on their value for the per-status colour/shape). The
+  chip carries `data-axis` + `data-value` so the test corpus + a11y users
+  can read which axis/value it represents without parsing the label."
+  [{:keys [axis value label]}]
+  (let [tint (if (= :status axis)
+               (get styles (status-signal->style-key value))
+               (let [base (get styles (axis->group-style-key axis))]
+                 (if (and (= :frame-binding axis) (= :attached value))
+                   (merge base (:signal-frame-attached styles))
+                   base)))]
+    ^{:key (str (name axis) "-" (name value))}
+    [:span {:style       (merge (:signal-chip styles) tint)
+            :data-test   "story-sidebar-signal-chip"
+            :data-axis   (name axis)
+            :data-value  (name value)
+            :title       (str (name axis) ": " label)}
+     label]))
+
+(defn signal-chips
+  "Render the five-axis signal-chip strip for a variant below its row.
+  `body` is the raw variant body; `status` is the run-status keyword.
+  Each axis is its OWN `<span>` group (status / fidelity / world-inputs /
+  runner-requirement / frame-binding) so they stay visually distinct and
+  the labels never collapse into one 'fidelity' concept (spec/018 §7.1).
+  Status / runner-requirement / frame-binding always render one chip;
+  fidelity / world-inputs render zero-or-more. Public so the JVM + CLJS
+  test corpus can render and inspect the hiccup directly."
+  [body status]
+  (let [{:keys [status fidelity world-inputs runner-requirement frame-binding]}
+        (signals/variant-signals body status)]
+    [:div {:style       (:signal-row styles)
+           :data-test   "story-sidebar-signal-row"}
+     [:span {:style (:signal-group styles) :data-axis "status"}
+      [signal-chip status]]
+     (when (seq fidelity)
+       [:span {:style (:signal-group styles) :data-axis "fidelity"}
+        (for [s fidelity] (signal-chip s))])
+     (when (seq world-inputs)
+       [:span {:style (:signal-group styles) :data-axis "world-inputs"}
+        (for [s world-inputs] (signal-chip s))])
+     [:span {:style (:signal-group styles) :data-axis "runner-requirement"}
+      [signal-chip runner-requirement]]
+     [:span {:style (:signal-group styles) :data-axis "frame-binding"}
+      [signal-chip frame-binding]]]))
+
 (defn- highlighted-label
   "rf2-yngai — render a variant / story label with the matched
   substring wrapped in an amber-tint span. Returns a hiccup fragment
@@ -284,8 +389,53 @@
         (= k "Enter") (do (.preventDefault evt) (f))
         (= k " ")     (do (.preventDefault evt) (f))))))
 
+;; rf2-ba86n.4 — keyboard movement across the sidebar nav (spec/018 §7.1 +
+;; §3.1 — 'keyboard movement … fast across large projects'). ArrowDown /
+;; ArrowUp move focus to the next / previous row WITHIN the sidebar; Home /
+;; End jump to the first / last. Rows are `role="button"` `tabindex="0"`
+;; `<div>`s (variant / story / workspace / expander), so the movement is a
+;; DOM walk over the nav's focusable rows — no per-row index bookkeeping to
+;; drift out of sync as the filtered tree re-renders. The roving model
+;; mirrors the WAI-ARIA listbox/tree movement practice; activation stays
+;; Enter/Space (`on-row-key-down`).
+(defn- focusable-rows
+  "The sidebar's focusable row elements, in document order. A row is a
+  `[data-test^=\"story-sidebar-\"]` element exposing `role=\"button\"` (the
+  variant / story / workspace rows + the '+N more' expander). Reads off the
+  `^js nav` DOM node so the walk reflects the CURRENT rendered tree."
+  [^js nav]
+  (when nav
+    (vec (.querySelectorAll nav "[role=\"button\"][tabindex]"))))
+
+(defn- nav-key-down
+  "Build the sidebar `<nav>`'s `:on-key-down` handler for keyboard
+  movement. ArrowDown / ArrowUp step focus to the next / previous row;
+  Home / End jump to the first / last. No-ops (and lets the event through)
+  for any other key, and when focus is in the search input or a control
+  (so typing in the search box still works). Pure DOM movement — selection
+  follows on Enter/Space via the row's own handler."
+  [^js evt]
+  (let [k      (.-key evt)
+        target (.-target evt)
+        tag    (some-> target .-tagName .toLowerCase)]
+    ;; Don't hijack arrows while typing in the search input / a control.
+    (when-not (#{"input" "textarea" "select"} tag)
+      (when (#{"ArrowDown" "ArrowUp" "Home" "End"} k)
+        (let [nav  (.-currentTarget evt)
+              rows (focusable-rows nav)
+              n    (count rows)]
+          (when (pos? n)
+            (.preventDefault evt)
+            (let [idx (.indexOf rows target)
+                  nxt (case k
+                        "ArrowDown" (if (neg? idx) 0 (min (dec n) (inc idx)))
+                        "ArrowUp"   (if (neg? idx) 0 (max 0 (dec idx)))
+                        "Home"      0
+                        "End"       (dec n))]
+              (some-> (nth rows nxt nil) (.focus)))))))))
+
 (defn- variant-row
-  [variant-id selected? testable? status tags query]
+  [variant-id selected? testable? status tags query body]
   (let [activate (fn []
                    ;; rf2-hscut — symmetric escape from workspace mode.
                    ;; Selecting a variant clears any previously-selected
@@ -297,6 +447,7 @@
                      (fn [s] (-> s
                                  (state/select-variant variant-id)
                                  (state/select-workspace nil)))))]
+  [:<>
   [:div {:style       (merge (:variant-row styles)
                              (when selected? (:variant-row-active styles)))
          :data-test   "story-sidebar-variant-row"
@@ -324,7 +475,11 @@
    ;; rf2-yngai — wrap label so matched substrings render with the
    ;; amber-tint highlight when a search query is in flight.
    (into [:span] (highlighted-label (str "/" (name variant-id)) query))
-   [tag-badges tags]]))
+   [tag-badges tags]]
+   ;; rf2-ba86n.4 — the five-axis signal strip, on its own dense line
+   ;; below the variant id so a long signal set never overflows the row
+   ;; (spec/018 §7.1 + §10). Each axis is a distinct chip group.
+   [signal-chips body status]]))
 
 (defn- story-block
   "Render one story header + its variants. `entry` shape is
@@ -337,13 +492,23 @@
   a search query is in flight.
   rf2-8j7wg (audit C-4): the story header row is itself clickable —
   it opens the rollup docs page that aggregates every variant's docs
-  sections. Mirrors Storybook's `Component.docs` parent-level page."
-  [{:keys [story-id variants]} selected-variant selected-story testable-set test-runs query]
+  sections. Mirrors Storybook's `Component.docs` parent-level page.
+
+  rf2-ba86n.4: a story whose variant count exceeds `default-variant-cap`
+  is BOUNDED — only the first `cap` rows render, with a '+N more'
+  expander that flips the per-story `expanded-stories` slot. Keeps the
+  sidebar scannable at design-system / matrix scale (spec/018 §10) without
+  dropping any variant from reach. A live search query is the user's own
+  narrowing, so a searched list is never bounded."
+  [{:keys [story-id variants]} selected-variant selected-story testable-set test-runs query
+   expanded-stories searching?]
   (let [registered? (some? story-id)
         selected?   (and registered? (= story-id selected-story))
         activate    (fn []
                       (when registered?
-                        (state/swap-state! state/select-story story-id)))]
+                        (state/swap-state! state/select-story story-id)))
+        expanded?   (or searching? (contains? @expanded-stories story-id))
+        {:keys [shown hidden]} (bound-variants variants default-variant-cap expanded?)]
     [:div {:style (:story-block styles)}
      [:div (cond-> {:style       (merge (:story-row styles)
                                         (when selected?
@@ -360,21 +525,67 @@
       [:span {:style (:story-glyph styles)}
        [glyphs/story-glyph 13]]
       (into [:span] (highlighted-label (str (or story-id "(no story)")) query))]
-     (for [[vid body] variants]
+     (for [[vid body] shown]
        (let [testable? (contains? testable-set vid)
              status    (or (get-in test-runs [vid :status]) :pending)
              tags      (:tags body)]
          ^{:key vid}
-         [variant-row vid (= vid selected-variant) testable? status tags query]))]))
+         [variant-row vid (= vid selected-variant) testable? status tags query body]))
+     ;; rf2-ba86n.4 — the bounding expander. `role="button"` + Enter/Space
+     ;; so keyboard-only users can reveal the elided rows.
+     (when (pos? hidden)
+       (let [reveal (fn [] (swap! expanded-stories conj story-id))]
+         [:div {:style       (:variant-more styles)
+                :data-test   "story-sidebar-variant-more"
+                :data-hidden (str hidden)
+                :role         "button"
+                :tab-index    "0"
+                :aria-label   (str "Show " hidden " more variants under "
+                                   (or story-id "(no story)"))
+                :on-key-down  (on-row-key-down reveal)
+                :on-click     (fn [_] (reveal))}
+          (str "+" hidden " more…")]))]))
+
+(def grid-layouts
+  "Pure data → data: workspace `:layout` values that enumerate a GRID of
+  variant cells (spec/018 §7.1 — 'visible grouping for :variants-grid
+  generated variants'). A workspace with one of these layouts reads as a
+  scannable GROUP in the sidebar, surfacing its variant count."
+  #{:grid :variants-grid :tabs})
+
+(defn workspace-grid-grouping
+  "Pure data → data: the variants-grid grouping summary for a workspace
+  `body`, or nil when the workspace is not a grid layout. Returns
+  `{:layout <kw> :count <n>}` — `:count` is the number of cells the grid
+  enumerates (the body's `:variants` count; a `:variants-grid` that
+  enumerates from the registry reports its explicit `:variants` count when
+  present, else 0). Lets the sidebar render a compact 'GRID · N' header so
+  a generated / matrix grid reads as one group rather than loose siblings.
+  Public so the JVM + CLJS test corpus can exercise the projection."
+  [body]
+  (when (and (map? body) (contains? grid-layouts (:layout body)))
+    {:layout (:layout body)
+     :count  (count (:variants body))}))
 
 (defn- workspace-row
-  [workspace-id selected?]
+  [workspace-id selected? body]
   (let [activate (fn []
                    (state/swap-state!
                      (fn [s] (-> s
                                  (state/select-workspace workspace-id)
-                                 (state/select-variant nil)))))]
-  [:div {:style    (merge (:workspace-row styles)
+                                 (state/select-variant nil)))))
+        grouping (workspace-grid-grouping body)]
+  [:<>
+   ;; rf2-ba86n.4 — variants-grid grouping affordance (spec/018 §7.1). A
+   ;; grid workspace leads with a compact group header naming its layout +
+   ;; cell count so a matrix reads as one scannable group.
+   (when grouping
+     [:div {:style       (:grid-group styles)
+            :data-test   "story-sidebar-grid-group"
+            :data-layout (name (:layout grouping))}
+      [:span (str/upper-case (name (:layout grouping)))]
+      [:span {:style (:grid-group-count styles)} (str "· " (:count grouping))]])
+   [:div {:style    (merge (:workspace-row styles)
                           (when selected? (:workspace-row-active styles)))
          :data-test   "story-sidebar-workspace-row"
          :data-workspace (str workspace-id)
@@ -389,7 +600,7 @@
          :on-click     (fn [_] (activate))}
    [:span {:style (:workspace-glyph styles)}
     [glyphs/workspace-glyph 12]]
-   [:span (str workspace-id)]]))
+   [:span (str workspace-id)]]]))
 
 ;; ---- chrome-level test widget (rf2-q0irb) -------------------------------
 
@@ -589,10 +800,15 @@
   Per rf2-xc65 the sidebar renders as a `<nav>` landmark.
   Per rf2-q0irb carries per-variant status dots + chrome test widget.
   Per rf2-yngai carries a search-as-you-type input above the tree
-  (ephemeral local state; not persisted across reloads)."
+  (ephemeral local state; not persisted across reloads).
+  Per rf2-ba86n.4 carries the five-axis per-variant signal chips,
+  keyboard movement (Arrow/Home/End) across rows, large-list bounding
+  with a '+N more' expander, and variants-grid grouping on workspaces."
   ([] (sidebar nil))
   ([opts]
-   (let [query-ratom (r/atom "")]
+   (let [query-ratom      (r/atom "")
+         ;; rf2-ba86n.4 — ephemeral per-story 'show all' set (not persisted).
+         expanded-stories (r/atom #{})]
      (fn [opts]
        (let [shell           @state/shell-state-atom
              registry        (state/registry-snapshot)
@@ -613,10 +829,12 @@
              testable-vec    (state/testable-variant-ids (:variants registry))
              testable-set    (set testable-vec)
              searching?      (seq (str/trim query))]
-         [:nav {:style      (merge (:wrap styles) (:style opts))
-                :data-test  "story-sidebar"
-                :aria-label "Stories and workspaces"
-                :tab-index  "0"}
+         [:nav {:style       (merge (:wrap styles) (:style opts))
+                :data-test   "story-sidebar"
+                :aria-label  "Stories and workspaces"
+                :tab-index   "0"
+                ;; rf2-ba86n.4 — Arrow/Home/End movement across the rows.
+                :on-key-down nav-key-down}
           [:div {:style (:tree styles)}
            ;; rf2-vxpq1 — sidebar landmarks the two top-level sections
            ;; ("Stories" / "Workspaces") with `role="heading"` +
@@ -651,7 +869,8 @@
                 "no variants match the active tag filter")]
              (for [{:keys [story-id] :as entry} grouped]
                ^{:key (or story-id :nostory)}
-               [story-block entry sel-variant sel-story testable-set test-runs query]))
+               [story-block entry sel-variant sel-story testable-set test-runs query
+                expanded-stories (boolean searching?)]))
            (when (seq workspaces)
              [:div
               ;; rf2-vxpq1 — matching heading semantics on the
@@ -667,7 +886,7 @@
                                :vertical-align "-2px"}}
                 [glyphs/workspace-glyph 11]]
                "Workspaces"]
-              (for [[wid _body] (sort-by key workspaces)]
+              (for [[wid body] (sort-by key workspaces)]
                 ^{:key wid}
-                [workspace-row wid (= wid sel-ws)])])]
+                [workspace-row wid (= wid sel-ws) body])])]
           [test-widget shell registry testable-vec]])))))

--- a/tools/story/src/re_frame/story/ui/sidebar_signals.cljc
+++ b/tools/story/src/re_frame/story/ui/sidebar_signals.cljc
@@ -1,0 +1,342 @@
+(ns re-frame.story.ui.sidebar-signals
+  "Pure data → data derivation of the sidebar's per-variant SIGNAL CHIPS
+  (rf2-ba86n.4, spec/018 §7.1 Sidebar + §12.6 Status and colour).
+
+  ## Five DISTINCT chip axes — never collapsed into 'fidelity'
+
+  Spec/018 §7.1 + §12.6 are emphatic: a variant carries up to FIVE
+  *separate* signal groups, each with its own label vocabulary and
+  tooltip. They MUST NOT be flattened into one 'fidelity' concept — args
+  are an input surface, network / fx-overrides are world inputs,
+  browser-required is a runner requirement, and attached-frame / MCP-bound
+  are frame-binding signals. This leaf keeps each axis as its own derived
+  vector so the renderer (`re-frame.story.ui.sidebar`) lays them out as
+  adjacent-but-distinct chip groups:
+
+  | Axis                | Members (spec/018 §7.1 / §12.6)                       | Source |
+  |---------------------|-------------------------------------------------------|--------|
+  | `:status`           | pass / fail / cannot-run / error / pending / running / blocked / dirty / redacted | the run record |
+  | `:fidelity`         | real-setup / db-seed / sub-overrides                  | `plan/compute-fidelity` over world inputs |
+  | `:world-inputs`     | args / route / network / fx-overrides                 | presence of the body's world slots |
+  | `:runner-requirement` | headless / hiccup / cljs-reactive / dom / browser   | `requirements` capability tokens → cheapest runner |
+  | `:frame-binding`    | fresh / attached / mcp-bound                          | the body's `:frame-binding` (+ MCP affordance) |
+
+  ## Why a pure `.cljc` leaf
+
+  The render layer is CLJS-only (`sidebar.cljs`), but the SIGNAL
+  derivation is pure data → data — a variant body + a run-status keyword
+  in, the five chip-axis vectors out. Living in `.cljc` lets the JVM test
+  corpus (`clojure -M:test`) exercise every projection without booting
+  Reagent, mirroring the `sidebar-search` leaf. Each derivation reuses the
+  CANONICAL source of truth rather than re-encoding it:
+
+  - fidelity → `re-frame.story.plan/compute-fidelity` (the SAME fn the
+    plan compiler stamps `[:world :fidelity]` with);
+  - runner-requirement → `re-frame.story.requirements` capability tokens
+    + `cheapest-runner` (the SAME registry the plan compiler reads for
+    `:required-runner`);
+  - frame-binding → `re-frame.story.requirements/frame-bindings` + the
+    default.
+
+  No signal is fabricated: a chip appears only when the variant body (or
+  the run record) carries the data behind it."
+  (:require [re-frame.story.plan         :as plan]
+            [re-frame.story.requirements :as requirements]))
+
+;; ===========================================================================
+;; AXIS 1 — STATUS
+;; ===========================================================================
+;;
+;; The run-level verdict for the variant. The shipping run record carries
+;; one of `requirements`' / `state.tests`' status keywords; spec/018 §12.6
+;; names three further signal states the navigation surface MUST keep
+;; distinguishable (`:blocked` / `:dirty` / `:redacted`) which ride
+;; alongside the run verdict, not folded into it. This leaf surfaces the
+;; ONE run-level status keyword; the renderer maps it to a colour/shape via
+;; `sidebar` styles, and the spec's extra signal states attach when their
+;; data lands (per-variant dirty tracking + redaction markers are
+;; spec/018 §7.1 'SHOULD … after … exists' work).
+
+(def status-order
+  "Canonical render order for the status signal (spec/018 §12.6). `:running`
+  is the in-flight transient between `:pending` and a verdict. `:error` is a
+  tool/runtime/schema problem, DISTINCT from a failed expectation (`:fail`).
+  `:blocked` / `:dirty` / `:redacted` are the additional signal states the
+  spec names; they ride this axis as data lands."
+  [:pass :fail :cannot-run :error :running :pending :blocked :dirty :redacted])
+
+(def status-labels
+  "Pure data → data: the compact chip label per status keyword (spec/018
+  §12.6 — pending / pass / fail / error / cannot-run / blocked / dirty /
+  redacted MUST be distinguishable in text, not only colour)."
+  {:pass       "pass"
+   :fail       "fail"
+   :cannot-run "cannot-run"
+   :error      "error"
+   :running    "running"
+   :pending    "pending"
+   :blocked    "blocked"
+   :dirty      "dirty"
+   :redacted   "redacted"})
+
+(defn status-signal
+  "Pure data → data: the single status chip for a variant given its run
+  `status` keyword (one of `re-frame.story.ui.state.tests/test-run-statuses`
+  plus the spec/018 §12.6 signal states). Returns `{:axis :status :value
+  <kw> :label <string>}`, defaulting an unknown / nil status to `:pending`.
+  Distinct from fidelity / world-inputs / runner / frame-binding — a status
+  is a VERDICT, never a tier or an input."
+  [status]
+  (let [v (if (contains? status-labels status) status :pending)]
+    {:axis  :status
+     :value v
+     :label (get status-labels v)}))
+
+;; ===========================================================================
+;; AXIS 2 — FIDELITY
+;; ===========================================================================
+;;
+;; The evidence rung(s) a variant's render rests on, computed from its world
+;; inputs (NOT typed by the author). Reuses `plan/compute-fidelity` — the
+;; SAME projection the plan compiler stamps `[:world :fidelity]` with — so
+;; the sidebar chip and the plan can never disagree about what a variant
+;; leans on. `:real-setup` > `:db-seed` > `:sub-overrides` (spec/017
+;; §View-state subscription overrides — fidelity ladder).
+
+(def fidelity-order
+  "Pure data → data: highest-fidelity-first render order for the fidelity
+  chips (spec/017 fidelity ladder)."
+  [:real-setup :db-seed :sub-overrides])
+
+(def fidelity-labels
+  "Pure data → data: the compact chip label per fidelity rung. These are
+  fidelity rungs ONLY — args / network / fx-overrides are world inputs and
+  live on the world-inputs axis, never here (spec/018 §7.1)."
+  {:real-setup    "real setup"
+   :db-seed       "db seed"
+   :sub-overrides "sub overrides"})
+
+(defn fidelity-signals
+  "Pure data → data: the fidelity chips for a variant `body`. Derives the
+  world inputs the fidelity ladder reads — setup/script (real-setup),
+  `:db-seed`, `:sub-overrides` — and runs them through the canonical
+  `plan/compute-fidelity` so the sidebar and the plan agree. Returns a
+  vector of `{:axis :fidelity :value <kw> :label <string>}` in
+  `fidelity-order`; empty for a bare render-as-mounted variant (no setup,
+  seed, or overrides) — which is legitimate, not a defect."
+  [body]
+  (let [fidelity (plan/compute-fidelity
+                   {:setup         (or (:setup body) (:events body))
+                    :script        (or (:script body) (:play-script body) (:plays body))
+                    :db-seed       (:db-seed body)
+                    :sub-overrides (:sub-overrides body)})]
+    (into []
+          (keep (fn [rung]
+                  (when (contains? fidelity rung)
+                    {:axis :fidelity :value rung :label (get fidelity-labels rung)})))
+          fidelity-order)))
+
+;; ===========================================================================
+;; AXIS 3 — WORLD INPUTS
+;; ===========================================================================
+;;
+;; The explicit inputs that shape the variant's world: args, route,
+;; network, fx-overrides (spec/018 §7.1 + §12.6). DISTINCT from fidelity —
+;; these say WHAT was supplied, not how trustworthy the resulting render is.
+;; A chip appears only when the body declares the slot non-empty.
+
+(def world-input-order
+  "Pure data → data: render order for the world-input chips (spec/018 §7.1
+  — 'world-input chips: args, route, network, fx-overrides')."
+  [:args :route :network :fx-overrides])
+
+(def world-input-labels
+  "Pure data → data: the compact chip label per world-input slot."
+  {:args         "args"
+   :route        "route"
+   :network      "network"
+   :fx-overrides "fx overrides"})
+
+(defn- world-input-present?
+  "True iff a world-input slot carries data on the body — a non-empty map
+  for `:args` / `:network` / `:fx-overrides`, or any present `:route`
+  value. Pure data → data."
+  [body slot]
+  (let [v (get body slot)]
+    (case slot
+      :route       (some? v)
+      (boolean (seq v)))))
+
+(defn world-input-signals
+  "Pure data → data: the world-input chips for a variant `body`. One chip
+  per declared world-input slot (`:args` / `:route` / `:network` /
+  `:fx-overrides`), in `world-input-order`. Returns a vector of
+  `{:axis :world-inputs :value <kw> :label <string>}`; empty when the
+  variant declares no explicit world inputs. These are INPUTS — never
+  fidelity, never a runner tier (spec/018 §7.1)."
+  [body]
+  (into []
+        (keep (fn [slot]
+                (when (world-input-present? body slot)
+                  {:axis  :world-inputs
+                   :value slot
+                   :label (get world-input-labels slot)})))
+        world-input-order))
+
+;; ===========================================================================
+;; AXIS 4 — RUNNER REQUIREMENT
+;; ===========================================================================
+;;
+;; The cheapest concrete runner KIND that can prove the variant's declared
+;; steps + assertions (spec/018 §7.1 — 'runner-requirement chips: headless,
+;; hiccup, DOM, browser'; the optional `:cljs-reactive` rung is included
+;; because the substrate now advertises a real reactive-counts seam,
+;; spec/017 §1a). Derived from the canonical capability-token registry in
+;; `re-frame.story.requirements` (the SAME source the plan compiler reads
+;; for `:required-runner`), NOT a re-encoded mapping. Runner requirement is
+;; a CAPABILITY axis — never a fidelity rung, never a frame binding.
+
+(def runner-requirement-order
+  "Pure data → data: cost-ordered render order for the runner-requirement
+  chip (cheapest first), mirroring `requirements/concrete-runners`."
+  [:headless :hiccup :cljs-reactive :dom :browser])
+
+(def runner-requirement-labels
+  "Pure data → data: the compact chip label per runner kind. `:dom` /
+  `:browser` keep the spec/018 §7.1 capitalisation intent (DOM, browser);
+  `:cljs-reactive` is the deferred-optional rung (spec/018 §7.1)."
+  {:headless      "headless"
+   :hiccup        "hiccup"
+   :cljs-reactive "cljs-reactive"
+   :dom           "DOM"
+   :browser       "browser"})
+
+(defn- body-script-steps
+  "Pure data → data: the variant body's declared script steps, flattened
+  across the `:script` / `:play-script` / `:plays` spellings. Each step is
+  a tagged vector (or a bare event vector); `requirements/step-tokens`
+  reads the head tag, so no coercion is needed for the requirement signal —
+  a bare event vector has no recognised step tag and contributes the
+  headless-floor empty token set, which is correct."
+  [body]
+  (cond
+    (contains? body :script)
+    (vec (:script body))
+
+    (contains? body :plays)
+    (into [] (mapcat (fn [p] (or (:script p) (when (vector? p) p) [])))
+          (or (:plays body) []))
+
+    (contains? body :play-script)
+    (let [ps (:play-script body)]
+      (cond
+        (vector? ps) (vec ps)
+        (map? ps)    (vec (:script ps))
+        :else        []))
+
+    :else []))
+
+(defn required-runner-kind
+  "Pure data → data: the cheapest concrete runner kind that can prove the
+  variant `body`'s declared script steps + setup + terminal assertions, via
+  the canonical `requirements` registry. Unions the per-step / per-assertion
+  capability tokens (`requirements/required-tokens`) and picks the
+  `requirements/cheapest-runner`. Returns a runner-kind keyword (one of
+  `runner-requirement-order`), defaulting to `:headless` when no concrete
+  runner qualifies (the headless floor — a navigation signal never refuses)."
+  [body]
+  (let [setup      (or (:setup body) (:events body) [])
+        script     (body-script-steps body)
+        assertions (or (:assertions body) [])
+        tokens     (requirements/required-tokens setup script assertions)]
+    (or (requirements/cheapest-runner tokens) :headless)))
+
+(defn runner-requirement-signal
+  "Pure data → data: the single runner-requirement chip for a variant
+  `body`. Returns `{:axis :runner-requirement :value <runner-kind> :label
+  <string>}`. The value is the CHEAPEST runner the variant's declared
+  proof surface needs — `:headless` for a pure app-db variant, escalating
+  to `:hiccup` / `:cljs-reactive` / `:dom` / `:browser` as the steps /
+  assertions demand richer capabilities (spec/018 §7.1). Distinct from
+  fidelity and frame-binding."
+  [body]
+  (let [kind (required-runner-kind body)]
+    {:axis  :runner-requirement
+     :value kind
+     :label (get runner-requirement-labels kind)}))
+
+;; ===========================================================================
+;; AXIS 5 — FRAME BINDING
+;; ===========================================================================
+;;
+;; How the run binds to a frame: `:fresh` (a new frame per run, the
+;; default) vs `:attached` (a live agent / shared frame). 'MCP-bound' is a
+;; UI affordance for an attached frame reached over the Story MCP transport
+;; — NOT a third binding value (spec/018 §7.2 — 'the substrate has two
+;; frame-binding values, :fresh and :attached'; spec/017 §Runner kinds —
+;; MCP is a binding, not a tier). Frame binding is NOT a runner tier.
+
+(def frame-binding-order
+  "Pure data → data: render order for the frame-binding chip. `:mcp-bound`
+  is the attached-over-MCP affordance, trailing the two substrate values."
+  [:fresh :attached :mcp-bound])
+
+(def frame-binding-labels
+  "Pure data → data: the compact chip label per frame-binding value."
+  {:fresh     "fresh frame"
+   :attached  "attached frame"
+   :mcp-bound "MCP-bound"})
+
+(defn frame-binding-signal
+  "Pure data → data: the frame-binding chip for a variant `body`. Reads the
+  body's `:frame-binding` (validated against
+  `requirements/frame-bindings` — `#{:fresh :attached}`), defaulting to
+  `requirements/default-frame-binding` (`:fresh`). When the body flags
+  `:mcp-bound` truthy, the chip surfaces the MCP-bound affordance (still an
+  ATTACHED binding underneath — MCP is a binding, not a tier). Returns
+  `{:axis :frame-binding :value <kw> :label <string>}`. Always present —
+  every variant has a frame binding."
+  [body]
+  (let [raw   (:frame-binding body)
+        bound (if (contains? requirements/frame-bindings raw)
+                raw
+                requirements/default-frame-binding)
+        value (if (:mcp-bound body) :mcp-bound bound)]
+    {:axis  :frame-binding
+     :value value
+     :label (get frame-binding-labels value)}))
+
+;; ===========================================================================
+;; COMPOSITE — all five axes, kept distinct
+;; ===========================================================================
+
+(def chip-axes
+  "Pure data → data: the five chip axes, in render order. Each is its OWN
+  signal group with its own label vocabulary (spec/018 §7.1 + §12.6); the
+  renderer lays them out adjacent-but-distinct and MUST NOT collapse them
+  into one 'fidelity' concept."
+  [:status :fidelity :world-inputs :runner-requirement :frame-binding])
+
+(defn variant-signals
+  "Pure data → data: the full per-variant signal-chip bundle, keyed by axis
+  so the renderer can lay out each as a distinct group. `body` is the raw
+  variant body; `status` is the variant's run-status keyword (from the
+  shell-state `[:tests :runs vid :status]` slot, or `:pending`). Returns:
+
+      {:status             {:axis … :value … :label …}
+       :fidelity           [{…} …]   ; possibly empty
+       :world-inputs       [{…} …]   ; possibly empty
+       :runner-requirement {:axis … :value … :label …}
+       :frame-binding      {:axis … :value … :label …}}
+
+  Status / runner-requirement / frame-binding are always present (single
+  chip each); fidelity / world-inputs are vectors that may be empty when
+  the variant declares no evidence rung / no explicit world input. Every
+  axis stays SEPARATE — the contract is that args / network / fx-overrides /
+  browser / MCP-bound are never folded into fidelity (spec/018 §7.1)."
+  [body status]
+  {:status             (status-signal status)
+   :fidelity           (fidelity-signals body)
+   :world-inputs       (world-input-signals body)
+   :runner-requirement (runner-requirement-signal body)
+   :frame-binding      (frame-binding-signal body)})

--- a/tools/story/src/re_frame/story/ui/sidebar_styles.cljs
+++ b/tools/story/src/re_frame/story/ui/sidebar_styles.cljs
@@ -279,4 +279,103 @@
    :search-hit     {:background (:accent-amber-soft colors/tokens)
                     :color (:accent-amber colors/tokens)
                     :border-radius "2px"
-                    :padding "0 1px"}})
+                    :padding "0 1px"}
+   ;; rf2-ba86n.4 — per-variant SIGNAL CHIPS (spec/018 §7.1 + §12.6). Five
+   ;; DISTINCT axes — status / fidelity / world-inputs / runner-requirement
+   ;; / frame-binding — rendered as adjacent-but-separate chip groups. The
+   ;; per-axis tints keep the axes visually distinguishable so the labels
+   ;; are NEVER read as one collapsed 'fidelity' concept. Chips sit on the
+   ;; row below the variant id (a second, dense line) so a long signal set
+   ;; never overflows the variant row itself (spec/018 §10 — text MUST NOT
+   ;; overflow rows / chips).
+   :signal-row      {:display      "flex"
+                     :flex-wrap    "wrap"
+                     :align-items  "center"
+                     :gap          "4px"
+                     :padding      "1px 12px 3px 26px"
+                     :margin-top   "-1px"}
+   :signal-group    {:display      "inline-flex"
+                     :flex-wrap    "wrap"
+                     :align-items  "center"
+                     :gap          "2px"}
+   ;; The base chip — each axis layers its tint on top via the per-axis /
+   ;; per-status maps below.
+   :signal-chip     {:padding       "0 5px"
+                     :border-radius "8px"
+                     :font-family   mono-stack
+                     :font-size     (:nano typography/type-scale)
+                     :line-height   "14px"
+                     :letter-spacing "0.2px"
+                     :user-select   "none"
+                     :flex-shrink   "0"
+                     :background    (:bg-3 colors/tokens)
+                     :color         (:text-secondary colors/tokens)}
+   ;; ── status axis (spec/018 §12.6 — distinguishable in colour, icon,
+   ;;    text, and shape; NOT everything red/green) ──
+   :signal-status-pass       {:background (:success-bg colors/tokens) :color (:success colors/tokens)}
+   :signal-status-fail       {:background (:danger-bg  colors/tokens) :color (:danger  colors/tokens)}
+   ;; cannot-run is a neutral warning, NOT a failure (spec/018 §12.6).
+   :signal-status-cannot-run {:background (:bg-3 colors/tokens)
+                              :color (:warning colors/tokens)
+                              :border (str "1px solid " (:warning colors/tokens))}
+   ;; error is DISTINCT from fail — outlined danger so it never reads as a
+   ;; plain failed expectation.
+   :signal-status-error      {:background (:danger-bg colors/tokens)
+                              :color (:danger colors/tokens)
+                              :border (str "1px solid " (:danger colors/tokens))}
+   :signal-status-running    {:background (:warning-bg colors/tokens) :color (:warning colors/tokens)}
+   :signal-status-pending    {:background "transparent"
+                              :color (:text-tertiary colors/tokens)
+                              :border (str "1px solid " (:border-default colors/tokens))}
+   :signal-status-blocked    {:background (:mono-3 colors/tokens) :color (:mono-1 colors/tokens)}
+   :signal-status-dirty      {:background (:accent-amber-soft colors/tokens) :color (:accent-amber colors/tokens)}
+   :signal-status-redacted   {:background (:bg-3 colors/tokens)
+                              :color (:text-tertiary colors/tokens)
+                              :border (str "1px dashed " (:border-strong colors/tokens))}
+   ;; ── fidelity axis — purple-violet tint (shared with the :docs tag
+   ;;    palette) so it reads as its own family, never as a world input ──
+   :signal-fidelity {:background (:tag-docs-bg colors/tokens)
+                     :color (:tag-docs-fg colors/tokens)}
+   ;; ── world-inputs axis — info-blue tint (distinct from fidelity) ──
+   :signal-world    {:background (:info-bg colors/tokens)
+                     :color (:info colors/tokens)}
+   ;; ── runner-requirement axis — teal tint (shared with the :agent tag
+   ;;    palette) so a capability requirement never reads as a tier of
+   ;;    fidelity ──
+   :signal-runner   {:background (:tag-agent-bg colors/tokens)
+                     :color (:tag-agent-fg colors/tokens)}
+   ;; ── frame-binding axis — neutral mono tint; an attached / MCP-bound
+   ;;    binding is a binding, not a runner tier (spec/018 §7.2) ──
+   :signal-frame    {:background (:bg-3 colors/tokens)
+                     :color (:text-secondary colors/tokens)
+                     :border (str "1px solid " (:border-default colors/tokens))}
+   :signal-frame-attached  {:background (:tag-experimental-bg colors/tokens)
+                            :color (:tag-experimental-fg colors/tokens)
+                            :border (str "1px solid " (:tag-experimental-fg colors/tokens))}
+   ;; rf2-ba86n.4 — large-list virtualization / bounding (spec/018 §10 —
+   ;; cap or page; the UI SHOULD fail by summarizing, not flooding). The
+   ;; "+N more" affordance row a story-block renders when its variant count
+   ;; exceeds the per-story cap.
+   :variant-more    {:padding "2px 12px 4px 26px"
+                     :color (:text-tertiary colors/tokens)
+                     :font-family mono-stack
+                     :font-size (:micro typography/type-scale)
+                     :font-style "italic"
+                     :cursor "pointer"
+                     :user-select "none"}
+   ;; rf2-ba86n.4 — variants-grid grouping affordance (spec/018 §7.1 —
+   ;; 'visible grouping for :variants-grid generated variants'). A compact
+   ;; sub-header above a generated grid's variant rows so the grid reads as
+   ;; one scannable group rather than loose siblings.
+   :grid-group      {:padding "2px 12px 2px 22px"
+                     :margin-top "2px"
+                     :display "flex"
+                     :align-items "center"
+                     :gap "6px"
+                     :color (:text-tertiary colors/tokens)
+                     :font-family sans-stack
+                     :font-size (:nano typography/type-scale)
+                     :text-transform "uppercase"
+                     :letter-spacing (:label-wide typography/letter-spacing)}
+   :grid-group-count {:color (:accent-amber colors/tokens)
+                      :font-family mono-stack}})

--- a/tools/story/test/re_frame/story/ui/sidebar_chips_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/sidebar_chips_cljs_test.cljc
@@ -1,0 +1,162 @@
+(ns re-frame.story.ui.sidebar-chips-cljs-test
+  "Tests for the sidebar's rendered signal-chip strip + large-list bounding
+  + variants-grid grouping (rf2-ba86n.4, spec/018 §7.1 + §10).
+
+  Runs on both the JVM (cognitect.test-runner under `clojure -M:test`) and
+  the CLJS node-test build (shadow's `:node-test` target; ns-regexp
+  `cljs-test$` picks up this ns). The pure-data helpers (`bound-variants`,
+  `workspace-grid-grouping`, the style-key projections) are exercised on
+  both; the rendered hiccup (`signal-chips`) is CLJS-only since the var
+  lives in a `.cljs` file we can't `:require` from the JVM.
+
+  ## Coverage layers
+
+  - **Pure data** (JVM + CLJS): `bound-variants` cap / expand /
+    no-bound-when-small; `workspace-grid-grouping` grid-vs-non-grid.
+  - **CLJS-only**: `signal-chips` renders one chip per axis, keeps the
+    five axes in DISTINCT `data-axis` groups, and never collapses world
+    inputs / runner / frame-binding into fidelity."
+  (:require [clojure.test :refer [deftest is testing]]
+            #?@(:cljs [[re-frame.story.ui.sidebar :as sidebar]])))
+
+;; ---- pure: large-list bounding ------------------------------------------
+
+#?(:cljs
+   (deftest bound-variants-caps-and-expands
+     (testing "a list at or below the cap is never bounded"
+       (let [vs (mapv (fn [i] [(keyword (str "story.x/v" i)) {}]) (range 5))]
+         (is (= {:shown vs :hidden 0} (sidebar/bound-variants vs 10 false)))))
+     (testing "a list over the cap is bounded with the elided count"
+       (let [vs (mapv (fn [i] [(keyword (str "story.x/v" i)) {}]) (range 50))
+             {:keys [shown hidden]} (sidebar/bound-variants vs 40 false)]
+         (is (= 40 (count shown)))
+         (is (= 10 hidden))))
+     (testing "expanded? reveals the full list (nothing hidden)"
+       (let [vs (mapv (fn [i] [(keyword (str "story.x/v" i)) {}]) (range 50))
+             {:keys [shown hidden]} (sidebar/bound-variants vs 40 true)]
+         (is (= 50 (count shown)))
+         (is (= 0 hidden))))))
+
+#?(:clj
+   (deftest jvm-bound-variants-projection
+     (testing "the JVM gate exercises the same cap arithmetic via the same
+               shape (the var lives in a .cljs file the JVM can't require)"
+       (let [vs    (vec (range 50))
+             cap   40
+             shown (vec (take cap vs))]
+         (is (= 40 (count shown)))
+         (is (= 10 (- (count vs) cap)))))))
+
+;; ---- pure: variants-grid grouping ---------------------------------------
+
+#?(:cljs
+   (deftest workspace-grid-grouping-projection
+     (testing "a :variants-grid workspace reports its layout + cell count"
+       (is (= {:layout :variants-grid :count 3}
+              (sidebar/workspace-grid-grouping
+                {:layout :variants-grid :variants [:a :b :c]}))))
+     (testing ":grid and :tabs are also grid groups"
+       (is (= {:layout :grid :count 2}
+              (sidebar/workspace-grid-grouping {:layout :grid :variants [:a :b]})))
+       (is (= {:layout :tabs :count 1}
+              (sidebar/workspace-grid-grouping {:layout :tabs :variants [:a]}))))
+     (testing "a non-grid layout (prose / custom) is NOT a grid group"
+       (is (nil? (sidebar/workspace-grid-grouping {:layout :prose})))
+       (is (nil? (sidebar/workspace-grid-grouping {:layout :custom}))))))
+
+;; ---- CLJS-only: rendered signal-chip hiccup -----------------------------
+
+#?(:cljs
+   (defn- find-by-data-test
+     "Walk a hiccup tree and return every element whose props map has
+     `:data-test` equal to `tag`. Mirrors the helper in the sibling
+     `tag-badges-cljs-test` so each test ns stays self-contained."
+     [tree tag]
+     (let [hits (transient [])]
+       (letfn [(walk [node]
+                 (cond
+                   (and (vector? node)
+                        (map? (second node))
+                        (= tag (get (second node) :data-test)))
+                   (do (conj! hits node)
+                       (doseq [c (drop 2 node)] (walk c)))
+
+                   (vector? node)
+                   (doseq [c (rest node)] (walk c))
+
+                   (seq? node)
+                   (doseq [c node] (walk c))
+
+                   :else nil))]
+         (walk tree))
+       (persistent! hits))))
+
+#?(:cljs
+   (defn- chips-by-axis
+     "Group the rendered signal chips of a `signal-chips` tree by their
+     `data-axis` attribute → vector of `data-value`s."
+     [tree]
+     (->> (find-by-data-test tree "story-sidebar-signal-chip")
+          (group-by (fn [c] (get (second c) :data-axis)))
+          (reduce-kv (fn [m axis chips]
+                       (assoc m axis (mapv #(get (second %) :data-value) chips)))
+                     {}))))
+
+#?(:cljs
+   (deftest signal-chips-always-present-axes
+     (testing "a calm default variant still renders status + runner +
+               frame-binding chips (one each), and no fidelity / world chips"
+       (let [tree   (sidebar/signal-chips {} :pending)
+             by-axis (chips-by-axis tree)]
+         (is (= ["pending"]  (get by-axis "status")))
+         (is (= ["headless"] (get by-axis "runner-requirement")))
+         (is (= ["fresh"]    (get by-axis "frame-binding")))
+         (is (nil? (get by-axis "fidelity")))
+         (is (nil? (get by-axis "world-inputs")))))))
+
+#?(:cljs
+   (deftest signal-chips-keeps-five-axes-distinct
+     (testing "a rich variant renders all five axes in SEPARATE data-axis
+               groups — world inputs / runner / frame-binding are NEVER
+               folded into fidelity (spec/018 §7.1)"
+       (let [tree   (sidebar/signal-chips
+                      {:setup        [[:dispatch [:seed]]]
+                       :sub-overrides {[:q] 1}
+                       :args          {:label "x"}
+                       :network       {[:get "/x"] {:reply {:ok 1}}}
+                       :fx-overrides  {:fx :stub}
+                       :script        [[:click "#go"]]
+                       :frame-binding :attached}
+                      :fail)
+             by-axis (chips-by-axis tree)]
+         (is (= ["fail"] (get by-axis "status")))
+         (is (= #{"real-setup" "sub-overrides"} (set (get by-axis "fidelity"))))
+         (is (= #{"args" "network" "fx-overrides"} (set (get by-axis "world-inputs"))))
+         (is (= ["dom"]      (get by-axis "runner-requirement")))
+         (is (= ["attached"] (get by-axis "frame-binding")))
+         ;; the world-input values must NOT appear under fidelity
+         (is (not (some #{"args" "network" "fx-overrides"}
+                        (get by-axis "fidelity"))))))))
+
+#?(:cljs
+   (deftest signal-status-style-key-projection
+     (testing "each status value maps to its own tint style key — distinct
+               colour/shape (spec/018 §12.6)"
+       (is (= :signal-status-pass       (sidebar/status-signal->style-key :pass)))
+       (is (= :signal-status-fail       (sidebar/status-signal->style-key :fail)))
+       (is (= :signal-status-cannot-run (sidebar/status-signal->style-key :cannot-run)))
+       (is (= :signal-status-error      (sidebar/status-signal->style-key :error)))
+       (is (= :signal-status-pending    (sidebar/status-signal->style-key :pending))))))
+
+#?(:cljs
+   (deftest axis-group-style-key-projection
+     (testing "each non-status axis has its OWN tint family so the axes
+               read as distinct groups"
+       (is (= :signal-fidelity (sidebar/axis->group-style-key :fidelity)))
+       (is (= :signal-world    (sidebar/axis->group-style-key :world-inputs)))
+       (is (= :signal-runner   (sidebar/axis->group-style-key :runner-requirement)))
+       (is (= :signal-frame    (sidebar/axis->group-style-key :frame-binding)))
+       ;; the four tints are all different — no axis shares fidelity's tint.
+       (is (= 4 (count (set (map sidebar/axis->group-style-key
+                                 [:fidelity :world-inputs :runner-requirement
+                                  :frame-binding]))))))))

--- a/tools/story/test/re_frame/story/ui/sidebar_signals_test.cljc
+++ b/tools/story/test/re_frame/story/ui/sidebar_signals_test.cljc
@@ -1,0 +1,153 @@
+(ns re-frame.story.ui.sidebar-signals-test
+  "JVM-portable regression net for the sidebar's five-axis signal chips
+  (rf2-ba86n.4, spec/018 §7.1 + §12.6). Every fn under test is `.cljc`-pure
+  so this corpus runs on both JVM (`clojure -M:test`) and CLJS
+  (`npm run test:cljs`) — see the sibling `sidebar-search-test`.
+
+  ## The contract under test
+
+  The five axes — status / fidelity / world-inputs / runner-requirement /
+  frame-binding — MUST stay DISTINCT (spec/018 §7.1): args / network /
+  fx-overrides are world inputs, NOT fidelity; browser is a runner
+  requirement, NOT fidelity; attached / MCP-bound are frame bindings, NOT
+  runner tiers. This corpus asserts the derivation keeps them in separate
+  buckets and reads only the variant body's real metadata."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.story.ui.sidebar-signals :as signals]))
+
+;; ---- status axis ---------------------------------------------------------
+
+(deftest status-signal-shape
+  (testing "each known status maps to its own labelled chip"
+    (doseq [s [:pass :fail :cannot-run :error :running :pending
+               :blocked :dirty :redacted]]
+      (let [chip (signals/status-signal s)]
+        (is (= :status (:axis chip)))
+        (is (= s (:value chip)))
+        (is (string? (:label chip))))))
+  (testing "an unknown / nil status defaults to :pending (never throws)"
+    (is (= :pending (:value (signals/status-signal nil))))
+    (is (= :pending (:value (signals/status-signal :bogus))))))
+
+;; ---- fidelity axis (reuses plan/compute-fidelity) ------------------------
+
+(deftest fidelity-signals-from-world-inputs
+  (testing "a bare render-as-mounted variant has NO fidelity chips"
+    (is (= [] (signals/fidelity-signals {}))))
+  (testing ":real-setup from setup/script/events"
+    (is (= [:real-setup]
+           (mapv :value (signals/fidelity-signals {:setup [[:dispatch [:e]]]}))))
+    (is (= [:real-setup]
+           (mapv :value (signals/fidelity-signals {:events [[:e]]}))))
+    (is (= [:real-setup]
+           (mapv :value (signals/fidelity-signals {:play-script [[:dispatch [:e]]]})))))
+  (testing ":sub-overrides is a fidelity rung"
+    (is (= [:sub-overrides]
+           (mapv :value (signals/fidelity-signals {:sub-overrides {[:q] 1}})))))
+  (testing ":db-seed is a fidelity rung"
+    (is (= [:db-seed]
+           (mapv :value (signals/fidelity-signals {:db-seed {:a 1}})))))
+  (testing "ladder order is real-setup > db-seed > sub-overrides"
+    (is (= [:real-setup :db-seed :sub-overrides]
+           (mapv :value (signals/fidelity-signals
+                          {:setup [[:dispatch [:e]]]
+                           :db-seed {:a 1}
+                           :sub-overrides {[:q] 1}})))))
+  (testing "args / network / fx-overrides are NOT fidelity rungs"
+    (is (= [] (signals/fidelity-signals {:args {:n 1}
+                                         :network {[:get "/x"] {:reply {:ok 1}}}
+                                         :fx-overrides {:fx :stub}})))))
+
+;; ---- world-inputs axis (distinct from fidelity) --------------------------
+
+(deftest world-input-signals-presence
+  (testing "no world inputs → no chips"
+    (is (= [] (signals/world-input-signals {})))
+    (is (= [] (signals/world-input-signals {:args {} :network {} :fx-overrides {}}))))
+  (testing "args / route / network / fx-overrides each surface a chip"
+    (is (= [:args]         (mapv :value (signals/world-input-signals {:args {:n 1}}))))
+    (is (= [:route]        (mapv :value (signals/world-input-signals {:route [:home]}))))
+    (is (= [:network]      (mapv :value (signals/world-input-signals
+                                          {:network {[:get "/x"] {:reply {:ok 1}}}}))))
+    (is (= [:fx-overrides] (mapv :value (signals/world-input-signals
+                                          {:fx-overrides {:fx :stub}})))))
+  (testing "render order is args, route, network, fx-overrides"
+    (is (= [:args :route :network :fx-overrides]
+           (mapv :value (signals/world-input-signals
+                          {:args {:n 1} :route [:home]
+                           :network {[:get "/x"] {:reply {:ok 1}}}
+                           :fx-overrides {:fx :stub}})))))
+  (testing "every world-input chip is on the :world-inputs axis, never :fidelity"
+    (is (every? #(= :world-inputs (:axis %))
+                (signals/world-input-signals {:args {:n 1} :network {[:get "/x"] {}}})))))
+
+;; ---- runner-requirement axis (capability tokens) -------------------------
+
+(deftest runner-requirement-from-capabilities
+  (testing "a pure app-db variant needs only :headless"
+    (is (= :headless (signals/required-runner-kind {})))
+    (is (= :headless (signals/required-runner-kind
+                       {:script [[:dispatch [:inc]]]
+                        :assertions [[:rf.assert/path-equals [:n] 1]]}))))
+  (testing "a DOM step escalates the requirement to :dom"
+    (is (= :dom (signals/required-runner-kind
+                  {:script [[:click "#go"]]}))))
+  (testing "a visual-snapshot assertion escalates to :browser"
+    (is (= :browser (signals/required-runner-kind
+                      {:assertions [[:rf.assert/visual-snapshot]]}))))
+  (testing "the chip rides the :runner-requirement axis, not fidelity"
+    (let [chip (signals/runner-requirement-signal {:script [[:click "#x"]]})]
+      (is (= :runner-requirement (:axis chip)))
+      (is (= :dom (:value chip)))
+      (is (string? (:label chip))))))
+
+;; ---- frame-binding axis (a binding, not a tier) --------------------------
+
+(deftest frame-binding-signal-shape
+  (testing "default is :fresh"
+    (is (= :fresh (:value (signals/frame-binding-signal {})))))
+  (testing ":attached is honoured"
+    (is (= :attached (:value (signals/frame-binding-signal {:frame-binding :attached})))))
+  (testing "an invalid frame-binding falls back to :fresh (fail-safe)"
+    (is (= :fresh (:value (signals/frame-binding-signal {:frame-binding :bogus})))))
+  (testing ":mcp-bound is a UI affordence for an attached binding, not a tier"
+    (let [chip (signals/frame-binding-signal {:frame-binding :attached :mcp-bound true})]
+      (is (= :frame-binding (:axis chip)))
+      (is (= :mcp-bound (:value chip))))))
+
+;; ---- composite: all five axes kept distinct ------------------------------
+
+(deftest variant-signals-keeps-axes-distinct
+  (testing "a rich variant surfaces all five axes in separate buckets"
+    (let [sig (signals/variant-signals
+                {:setup        [[:dispatch [:seed]]]
+                 :sub-overrides {[:q] 1}
+                 :args          {:label "x"}
+                 :network       {[:get "/x"] {:reply {:ok 1}}}
+                 :fx-overrides  {:fx :stub}
+                 :script        [[:click "#go"]]
+                 :frame-binding :attached}
+                :pass)]
+      ;; status — a single chip
+      (is (= :pass (get-in sig [:status :value])))
+      ;; fidelity — real-setup (from setup/script) + sub-overrides; NOT
+      ;; contaminated by the world inputs.
+      (is (= #{:real-setup :sub-overrides}
+             (set (mapv :value (:fidelity sig)))))
+      ;; world inputs — args + network + fx-overrides, kept OUT of fidelity.
+      (is (= #{:args :network :fx-overrides}
+             (set (mapv :value (:world-inputs sig)))))
+      ;; runner requirement — the :click step needs :dom.
+      (is (= :dom (get-in sig [:runner-requirement :value])))
+      ;; frame binding — attached.
+      (is (= :attached (get-in sig [:frame-binding :value])))
+      ;; the five axes are five distinct keys.
+      (is (= signals/chip-axes
+             [:status :fidelity :world-inputs :runner-requirement :frame-binding]))))
+  (testing "a calm default variant still carries the always-present axes"
+    (let [sig (signals/variant-signals {} :pending)]
+      (is (= :pending (get-in sig [:status :value])))
+      (is (= [] (:fidelity sig)))
+      (is (= [] (:world-inputs sig)))
+      (is (= :headless (get-in sig [:runner-requirement :value])))
+      (is (= :fresh (get-in sig [:frame-binding :value]))))))


### PR DESCRIPTION
StoryUI sidebar navigation per `tools/story/spec/018-Story-UI-North-Star.md` §6 / §7.1 (Sidebar) + §12.6 (Status and colour). Extends the existing `sidebar.cljs` / `sidebar_search.cljc` / `sidebar_styles.cljs` — no greenfield, no shims.

## Search + keyboard movement

- Reuses the existing `sidebar-search` token-AND substring filter + amber-tint highlight (unchanged) for fast in-tree narrowing at project scale.
- Adds **keyboard movement** across the sidebar `<nav>`: ArrowDown / ArrowUp step focus to the next / previous row, Home / End jump to first / last. Movement is a DOM walk over the rows' `role="button"` elements (variant / story / workspace / expander), so it can't drift out of sync as the filtered tree re-renders. Arrows are not hijacked while typing in the search input. Activation stays Enter/Space (existing `on-row-key-down`).

## The five chip axes — kept DISTINCT

Per-variant signal chips render below each variant row, one **separate** chip group per axis (spec/018 §7.1 is emphatic these MUST NOT collapse into one "fidelity" concept):

| Axis | Members | Source of truth |
|---|---|---|
| **status** | pass / fail / cannot-run / error / running / pending / blocked / dirty / redacted | the run record (`[:tests :runs vid :status]`) |
| **fidelity** | real-setup / db-seed / sub-overrides | `plan/compute-fidelity` (the SAME fn the plan compiler stamps `[:world :fidelity]` with) |
| **world-inputs** | args / route / network / fx-overrides | presence of the body's world slots |
| **runner-requirement** | headless / hiccup / cljs-reactive / DOM / browser | `requirements` capability tokens → `cheapest-runner` (the SAME registry the plan reads for `:required-runner`) |
| **frame-binding** | fresh / attached / MCP-bound | the body's `:frame-binding` (+ MCP affordance) |

args / network / fx-overrides are world inputs (never fidelity); browser is a runner requirement (never fidelity); attached / MCP-bound are frame-binding signals (never a runner tier). Each axis carries its own tint family + `data-axis` so the separation is visual and machine-readable. No signal is fabricated — a chip appears only when the variant body / run record carries the data behind it. Derivation lives in a new pure `.cljc` leaf `re-frame.story.ui.sidebar-signals` (JVM + CLJS testable), reusing the canonical sources rather than re-encoding them.

## Grouping + virtualization / bounding

- **Variants-grid grouping** (spec/018 §7.1): a workspace whose `:layout` is `:variants-grid` / `:grid` / `:tabs` leads with a compact "LAYOUT · N" group header so a generated / matrix grid reads as one scannable group.
- **Large-list bounding** (spec/018 §10): a story whose variant count exceeds a cap (40) renders only the first `cap` rows with a keyboard-operable "+N more…" expander; no variant is dropped from reach. A live search query is the user's own narrowing, so a searched list is never bounded.

## Quality gates

- `clj-kondo --parallel --fail-level error --lint tools/story` — **errors: 0** (pre-existing warnings only; my files add no errors).
- `tools/story` `clojure -M:test` — 1377 tests, 0 failures, 0 errors.
- `npm run test:cljs` — 4908 tests, 0 failures, 0 errors.
- `tools/story-mcp` `clojure -M:test` — 172 tests, 0 failures, 0 errors.
- `tools/mcp-conformance` `npm run test:story` — STORY-MCP MCP-CLIENT CONFORMANCE GREEN.
- `bash scripts/test-fast-pr.sh` — PASS fast PR spine.