### PR TITLE
feat(story): eight-slice capture model for save-current-as-variant (rf2-ba86n.6)

### DIFF
--- a/tools/story/spec/019-Story-UI-Controls-And-View-States.md
+++ b/tools/story/spec/019-Story-UI-Controls-And-View-States.md
@@ -141,11 +141,43 @@ the user-story sweep):
   losslessly yet, the UI MUST say what will be omitted or require the
   user to choose a supported slice.
 
-Open detail: the exact projection save-current-state writes when the
-current UI state mixes args, sub-overrides, db seed, route, network,
-fx-overrides, viewport, and transient controls is not yet locked. State
-it as an explicit open-detail for the implementation EPIC, not a product
-fork.
+Save-current-state is reachable from **Controls** (the
+`save as new variant…` button on the controls panel) **and the command
+palette** (`Save current canvas state as a new variant`). Both drive the
+same `re-frame.story.save-variant/save-current-as-variant!` flow over the
+focused variant; the palette entry no-ops when no variant is focused.
+
+#### Per-slice projection (rf2-ba86n.6)
+
+The exact projection save-current-state writes is now locked as a
+**capture-or-warn** model, classified per slice by the pure
+`re-frame.story.save-variant/capture-slices`. Each of the eight slices
+resolves to one honest status — the flow NEVER fabricates a live
+projection for a slice whose substrate is not wired:
+
+| Slice | Status | Projection |
+|---|---|---|
+| Args | projectable | Live effective args (five-layer precedence chain, [`002-Runtime.md`](002-Runtime.md)) → the snippet's `:args` slot. |
+| Transient controls | projectable | In-flight `:cell-overrides` — folded into `:args` by `resolve-args`, not a separate slot. |
+| Sub-overrides | captured-as-declared / not-wired | No live View-State controls (TARGET); the source body's declared `:sub-overrides` carry forward via `:extends` (warned), else not-wired (rf2-7pgiz). |
+| DB seed | captured-as-declared / not-wired | The schema-checked app-db-seed fidelity rung is not wired (rf2-blw1q); the source's declared `:setup` events carry forward via `:extends` (warned), else not-wired. |
+| Route | not-wired | Route sub-override is not consumed yet (rf2-7pgiz) — route state is not captured. |
+| Network | captured-as-declared / not-wired | No live Network controls; the source's declared `:network` carries forward via `:extends` (warned), else not-wired. |
+| FX-overrides | captured-as-declared / not-wired | No live Effects controls; the source's declared `:fx-overrides` carries forward via `:extends` (warned), else not-wired. |
+| Viewport | captured-as-declared / not-wired (FORK) | Viewport is **chrome-wide** state, not a per-variant body slot. The source body's declared `:viewport` carries forward via `:extends` (warned); the live chrome-wide selection is NOT projected into the saved variant. |
+
+Slices that are not a clean live projection surface a non-blocking
+warning in the save dialog (the honesty floor): the user sees, before
+pasting, exactly what is captured live, what carries forward as declared,
+and what is not yet projectable.
+
+**Product fork (flagged, not silently decided):** whether a saved variant
+should pin the *live chrome-wide viewport* at all — and, more broadly,
+the canonical projection when a future surface lets args AND a live
+sub-override slice both be set — is not settled by this spec. The
+implementation takes the conservative honest default (capture declared,
+warn the rest) and leaves the lock for a deliberate ruling rather than
+guessing.
 
 ## 4. Control empty states and deep-controls risk
 

--- a/tools/story/src/re_frame/story/save_variant.cljc
+++ b/tools/story/src/re_frame/story/save_variant.cljc
@@ -42,6 +42,7 @@
             [re-frame.story.args                 :as args]
             [re-frame.story.config               :as config]
             [re-frame.story.predicates           :as pred]
+            [re-frame.story.registrar            :as registrar]
             [re-frame.story.review-dialog        :as review-dialog]
             [re-frame.story.ui.schema-validation :as schema-validation]
             [re-frame.story.ui.state             :as state]))
@@ -90,6 +91,183 @@
   soft-pass)."
   [args-snapshot schema validator-fns]
   (schema-validation/args-violations args-snapshot schema validator-fns))
+
+;; ---------------------------------------------------------------------------
+;; Pure: the eight-slice capture model (rf2-ba86n.6)
+;;
+;; spec/019 §3 lists the slices a save-current-state flow MAY have to
+;; project — args, sub-overrides, db-seed, route, network, fx-overrides,
+;; viewport, transient-controls — and §3's open-detail leaves the exact
+;; projection unlocked. The HONESTY FLOOR is load-bearing: the flow must
+;; never fabricate a projection for a slice whose live substrate isn't
+;; wired. So each slice resolves to one of three honest statuses:
+;;
+;;   :projectable          — a live, controls-driven projection exists and
+;;                           lands in the generated reg-variant body. Today
+;;                           this is `:args` (the five-layer precedence chain
+;;                           per spec/002), which already FOLDS the
+;;                           transient `:cell-overrides` in — so transient-
+;;                           controls is captured-as-args, not a second slot.
+;;   :captured-as-declared — the slice has NO live controls surface yet, but
+;;                           the SOURCE variant body declares a value. We
+;;                           carry it forward verbatim (via `:extends`) and
+;;                           WARN that it is the declared value, not a live
+;;                           projection of the current canvas.
+;;   :not-wired            — the slice has no live controls surface AND the
+;;                           source declares nothing. We capture nothing and
+;;                           WARN that the slice is not yet projectable.
+;;
+;; The slice→shell/substrate wiring map (the "where does each slice's live
+;; value come from?" reference):
+;;
+;;   slice              live source                       substrate
+;;   -----              -----------                       ---------
+;;   args               :cell-overrides + :active-modes   args/resolve-args → :args
+;;   transient-controls in-flight :cell-overrides          folds into :args (no 2nd slot)
+;;   sub-overrides      — (View State group is TARGET)     reg-variant :sub-overrides
+;;   db-seed            — (fidelity rung not wired, blw1q) reg-variant :setup/:db
+;;   route              — (route sub not consumed, 7pgiz)  —
+;;   network            — (no live Network controls)       reg-variant :network
+;;   fx-overrides       — (no live Effects controls)       reg-variant :fx-overrides
+;;   viewport           shell :viewport (CHROME-WIDE)      — (chrome-wide, not a body slot)
+;;
+;; Viewport is the one genuine PRODUCT FORK (flagged for the mayor in the
+;; PR): the live viewport is chrome-wide shell state, NOT a per-variant
+;; body slot the way the reg-variant body's other slices are. spec/019 §3
+;; / §5 do not settle whether a saved variant should pin the viewport at
+;; all. The conservative honest default below: capture it as-declared from
+;; the SOURCE body's `:viewport` slot when present (so a variant that
+;; already pins a viewport round-trips), and otherwise WARN that the live
+;; chrome-wide viewport is not projected into the saved variant.
+;; ---------------------------------------------------------------------------
+
+(def slice-order
+  "Canonical render/report order for the eight save-current slices
+  (spec/019 §3). `:args` and `:transient-controls` lead because they are
+  the projectable pair; the rest follow in the spec's listed order."
+  [:args :transient-controls :sub-overrides :db-seed
+   :route :network :fx-overrides :viewport])
+
+(def slice-labels
+  "Human labels for the slice report rows."
+  {:args               "Args"
+   :transient-controls "Transient controls"
+   :sub-overrides      "Sub-overrides"
+   :db-seed            "DB seed"
+   :route              "Route"
+   :network            "Network"
+   :fx-overrides       "FX-overrides"
+   :viewport           "Viewport"})
+
+(defn- declared-slot
+  "Read a declared slot from the resolved SOURCE variant body, or nil.
+  `variant-body` is `(registrar/handler-meta :variant id)` (may be nil
+  for an unregistered source — then every declared slot is nil)."
+  [variant-body k]
+  (when (map? variant-body) (get variant-body k)))
+
+(defn capture-slices
+  "Return the eight-slice capture report for a save-current-state flow.
+  Pure data → vector of slice descriptors in `slice-order`. The HONESTY
+  FLOOR (rf2-ba86n.6): each slice is classified honestly — a slice is
+  only `:projectable` when a LIVE controls projection exists; otherwise
+  it is `:captured-as-declared` (the source body declares a value we
+  carry forward via `:extends`) or `:not-wired` (nothing to capture, and
+  a warning is surfaced). The flow NEVER fabricates a live projection for
+  an unwired slice.
+
+  Inputs:
+  - `args-snapshot` — the resolved effective args (the live `:args`
+                      projection; transient `:cell-overrides` already
+                      folded in by `resolve-args`).
+  - `variant-body`  — the resolved source variant body (or nil) — read
+                      for declared `:sub-overrides` / `:network` /
+                      `:fx-overrides` / `:setup` / `:viewport` slots.
+  - `shell`         — the shell-state map — read for the live chrome-wide
+                      `:viewport` selection (the viewport fork).
+
+  Each descriptor:
+  - `:slice`  — the slice keyword (one of `slice-order`).
+  - `:label`  — the human label.
+  - `:status` — `:projectable` | `:captured-as-declared` | `:not-wired`.
+  - `:emit?`  — true iff the slice contributes a slot to the generated
+                reg-variant body (only `:args` today; `:extends` carries
+                the `:captured-as-declared` slices implicitly).
+  - `:value`  — the captured value (present for `:projectable` and
+                `:captured-as-declared`; absent/nil for `:not-wired`).
+  - `:note`   — the honest one-line explanation rendered in the report."
+  [args-snapshot variant-body shell]
+  (let [sub-ovr   (declared-slot variant-body :sub-overrides)
+        network   (declared-slot variant-body :network)
+        fx-ovr    (declared-slot variant-body :fx-overrides)
+        setup     (or (declared-slot variant-body :setup)
+                      (declared-slot variant-body :events))
+        body-vp   (declared-slot variant-body :viewport)
+        live-vp   (:viewport shell)
+        declared  (fn [slice label value note]
+                    {:slice slice :label label :status :captured-as-declared
+                     :emit? false :value value :note note})
+        not-wired (fn [slice label note]
+                    {:slice slice :label label :status :not-wired
+                     :emit? false :note note})]
+    [{:slice  :args :label (slice-labels :args)
+      :status :projectable :emit? true :value args-snapshot
+      :note   "Live effective args (five-layer precedence chain, spec/002) — projected into the snippet."}
+
+     {:slice  :transient-controls :label (slice-labels :transient-controls)
+      :status :projectable :emit? false :value args-snapshot
+      :note   "In-flight control edits — folded into :args by resolve-args, not a separate slot."}
+
+     (if (some? sub-ovr)
+       (declared :sub-overrides (slice-labels :sub-overrides) sub-ovr
+                 "No live View-State controls yet — the source's declared :sub-overrides carry forward via :extends, captured-as-declared (not a live projection).")
+       (not-wired :sub-overrides (slice-labels :sub-overrides)
+                  "No live View-State controls and none declared on the source — sub-overrides are not yet projectable (rf2-7pgiz)."))
+
+     ;; db-seed: the schema-checked app-db seed fidelity rung is not wired
+     ;; (rf2-blw1q). The closest declared analogue on the source body is
+     ;; `:setup` (real setup events) — surfaced as captured-as-declared so
+     ;; the report is honest about what carries forward via :extends.
+     (if (some? setup)
+       (declared :db-seed (slice-labels :db-seed) setup
+                 "DB-seed fidelity rung not wired (rf2-blw1q) — the source's declared :setup events carry forward via :extends, captured-as-declared.")
+       (not-wired :db-seed (slice-labels :db-seed)
+                  "DB-seed fidelity rung not wired (rf2-blw1q) and no :setup declared — not yet projectable."))
+
+     (not-wired :route (slice-labels :route)
+                "Route sub-override is not consumed yet (rf2-7pgiz) — route state is not captured.")
+
+     (if (some? network)
+       (declared :network (slice-labels :network) network
+                 "No live Network controls yet — the source's declared :network stubs carry forward via :extends, captured-as-declared.")
+       (not-wired :network (slice-labels :network)
+                  "No live Network controls and none declared on the source — network state is not yet projectable."))
+
+     (if (some? fx-ovr)
+       (declared :fx-overrides (slice-labels :fx-overrides) fx-ovr
+                 "No live Effects controls yet — the source's declared :fx-overrides carry forward via :extends, captured-as-declared.")
+       (not-wired :fx-overrides (slice-labels :fx-overrides)
+                  "No live Effects controls and none declared on the source — fx-overrides are not yet projectable."))
+
+     ;; viewport — the flagged PRODUCT FORK. Chrome-wide live state, not a
+     ;; per-variant body slot. Honest default: carry the SOURCE body's
+     ;; declared :viewport forward (captured-as-declared) when present;
+     ;; otherwise warn the live chrome-wide selection is not projected.
+     (if (some? body-vp)
+       (declared :viewport (slice-labels :viewport) body-vp
+                 "Viewport is chrome-wide state, not a per-variant body slot (FORK) — the source's declared :viewport carries forward via :extends.")
+       (not-wired :viewport (slice-labels :viewport)
+                  (str "Viewport is chrome-wide state, not a per-variant body slot (FORK) — the live selection ("
+                       (pr-str live-vp)
+                       ") is NOT projected into the saved variant.")))]))
+
+(defn slice-warnings
+  "Filter `capture-slices`' report to the rows the user MUST see — every
+  slice that is NOT a clean live projection. Returns the descriptors for
+  `:captured-as-declared` + `:not-wired` slices (the honesty-floor
+  warnings), in `slice-order`. Pure data → vector; JVM-testable."
+  [slice-report]
+  (vec (remove (fn [{:keys [status]}] (= status :projectable)) slice-report)))
 
 ;; ---------------------------------------------------------------------------
 ;; Pure: code-gen — `(reg-variant ... :args {...})` snippet
@@ -190,19 +368,25 @@
   violations; defaults to no violations. 4-arity stamps the violations
   vector onto the dialog state so the save dialog can render the
   rf2-lancu 'Args do not match the variant's Spec 010 schema' hint
-  pre-paste."
+  pre-paste. 5-arity (rf2-ba86n.6) additionally stamps the eight-slice
+  capture report so the dialog can render the per-slice honesty-floor
+  warnings (which slices are captured-as-declared / not-yet-projectable)."
   ([state source-variant-id args-snapshot now-ms]
-   (open state source-variant-id args-snapshot now-ms nil))
-  ([_state source-variant-id args-snapshot now-ms violations]
+   (open state source-variant-id args-snapshot now-ms nil nil))
+  ([state source-variant-id args-snapshot now-ms violations]
+   (open state source-variant-id args-snapshot now-ms violations nil))
+  ([_state source-variant-id args-snapshot now-ms violations slices]
    (let [base (review-dialog/open review-dialog/initial-state
                                   source-variant-id
                                   {:args       args-snapshot
-                                   :violations (vec violations)}
+                                   :violations (vec violations)
+                                   :slices     (vec slices)}
                                   now-ms
                                   default-id-prefix)]
      (-> base
          (assoc :args args-snapshot)
-         (assoc :violations (vec violations))))))
+         (assoc :violations (vec violations))
+         (assoc :slices (vec slices))))))
 
 (defn close
   "Close the dialog — returns the idle state."
@@ -239,11 +423,15 @@
 
 (defn set-open-dialog-fn!
   "Register the UI-layer dialog-open callback. The callback is invoked
-  as `(callback source-variant-id args-snapshot now-ms violations)`
+  as `(callback source-variant-id args-snapshot now-ms violations slices)`
   where `violations` is the vector returned by
-  `schema-validation/args-violations` against the live
-  component schema (rf2-lancu — may be empty/nil).
-  Idempotent — calling again replaces."
+  `schema-validation/args-violations` against the live component schema
+  (rf2-lancu — may be empty/nil) and `slices` is the eight-slice capture
+  report from `capture-slices` (rf2-ba86n.6 — carries the per-slice
+  honesty-floor warnings the dialog renders). Idempotent — calling again
+  replaces. The registered callback is invoked with all five positional
+  args, so it must accept arity-5 (a variadic `& _` tail is the easy way
+  to ignore the args it does not bind)."
   [f]
   (reset! open-dialog-fn f))
 
@@ -294,12 +482,23 @@
                                      (schema-validation/resolve-component-schema target)
                                      (schema-validation/validator-fns))
                              :clj  [])
+               ;; rf2-ba86n.6 — the eight-slice capture report. The honesty
+               ;; floor: every slice without a live projection is captured-
+               ;; as-declared (carried via :extends) or not-wired, and warned
+               ;; about. Never fabricated. Read the resolved source body so
+               ;; declared :sub-overrides / :network / :fx-overrides /
+               ;; :setup / :viewport slots surface as captured-as-declared.
+               slices     (capture-slices
+                            snapshot
+                            (registrar/handler-meta :variant target)
+                            shell)
                record     {:source-id  target
                            :args       snapshot
                            :violations violations
+                           :slices     slices
                            :now-ms     now-ms}]
            (when-let [cb @open-dialog-fn]
-             (cb target snapshot now-ms violations))
+             (cb target snapshot now-ms violations slices))
            record))))))
 
 ;; ---------------------------------------------------------------------------

--- a/tools/story/src/re_frame/story/ui/command_palette.cljc
+++ b/tools/story/src/re_frame/story/ui/command_palette.cljc
@@ -23,11 +23,20 @@
 
   - `:explain` — open the Explain panel (provenance + lowering over
     `story/explain`) and scroll it into view. Reachable here AND from
-    the RHS inspector rail per spec/020 §4."
+    the RHS inspector rail per spec/020 §4.
+  - `:save-current-as-variant` (rf2-ba86n.6) — capture the focused
+    variant's live canvas state as a new variant. The SAME flow as the
+    Controls-panel 'save as new variant…' button (spec/019 §3 — the flow
+    is available from Controls AND the palette). A no-op when no variant
+    is focused; the action handler guards on the live selection."
   [{:kind   :command
     :id     :explain
     :action :explain
-    :doc    "Explain variant — source chain, merges, substitutions, lowering"}])
+    :doc    "Explain variant — source chain, merges, substitutions, lowering"}
+   {:kind   :command
+    :id     :save-current-as-variant
+    :action :save-current-as-variant
+    :doc    "Save current canvas state as a new variant — capture live args, review + copy the reg-variant form"}])
 
 (defn- doc-text [body]
   (let [doc (:doc body)]

--- a/tools/story/src/re_frame/story/ui/command_palette/view.cljs
+++ b/tools/story/src/re_frame/story/ui/command_palette/view.cljs
@@ -3,6 +3,7 @@
   (:require [clojure.string :as str]
             [reagent.core :as r]
             [re-frame.story.config :as config]
+            [re-frame.story.save-variant :as save-variant]
             [re-frame.story.ui.command-palette :as palette]
             [re-frame.story.ui.explain-panel :as explain-panel]
             [re-frame.story.ui.state :as state]
@@ -37,6 +38,12 @@
       (case (:action entry)
         ;; rf2-ba86n.9 — open the Explain panel + scroll it into view.
         :explain (explain-panel/open!)
+        ;; rf2-ba86n.6 — capture the focused variant's live canvas state
+        ;; as a new variant. Same flow as the Controls-panel button
+        ;; (spec/019 §3). `save-current-as-variant!` reads the live
+        ;; selection from shell-state and no-ops (returns nil) when no
+        ;; variant is focused, so the palette action needs no extra guard.
+        :save-current-as-variant (save-variant/save-current-as-variant!)
         nil)
       true)
 

--- a/tools/story/src/re_frame/story/ui/save_variant.cljs
+++ b/tools/story/src/re_frame/story/ui/save_variant.cljs
@@ -53,12 +53,20 @@
   `schema-validation/args-violations` against the live component
   schema — used by the dialog to render a non-blocking 'Args do not
   match the variant's Spec 010 schema' hint when non-empty. May be
-  nil/empty (no schema registered, or all args conform)."
+  nil/empty (no schema registered, or all args conform).
+
+  `slices` (rf2-ba86n.6) is the eight-slice capture report from
+  `save-variant/capture-slices` — the dialog renders its honesty-floor
+  warnings (which slices are captured-as-declared / not-yet-projectable)
+  so a saved variant is honest about what it does and does NOT capture.
+  May be nil (legacy 3/4-arity callers)."
   ([source-variant-id args-snapshot now-ms]
-   (open-dialog! source-variant-id args-snapshot now-ms nil))
+   (open-dialog! source-variant-id args-snapshot now-ms nil nil))
   ([source-variant-id args-snapshot now-ms violations]
+   (open-dialog! source-variant-id args-snapshot now-ms violations nil))
+  ([source-variant-id args-snapshot now-ms violations slices]
    (swap! ui-dialog save-variant/open
-          source-variant-id args-snapshot now-ms violations)))
+          source-variant-id args-snapshot now-ms violations slices)))
 
 (defn- close-dialog! []
   (swap! ui-dialog save-variant/close))
@@ -176,6 +184,73 @@
               " = "
               (pr-str (:value v)))])]]))
 
+;; ---------------------------------------------------------------------------
+;; rf2-ba86n.6 — the eight-slice capture report.
+;;
+;; spec/019 §3 requires the save flow to be HONEST about which canvas
+;; slices it can represent losslessly and which it cannot: "if the
+;; current state contains data that cannot be represented losslessly yet,
+;; the UI MUST say what will be omitted". The pure
+;; `save-variant/capture-slices` classifies every slice; this component
+;; renders the warnings (every slice that is NOT a clean live projection)
+;; so the user knows, BEFORE pasting, that a saved variant captures args
+;; live, carries declared slices forward via `:extends`, and does NOT yet
+;; project sub-overrides / db-seed / route / network / fx-overrides, nor
+;; the chrome-wide viewport. The honesty floor is load-bearing — we warn,
+;; never silently drop or fabricate.
+;; ---------------------------------------------------------------------------
+
+(def ^:private slice-status-styles
+  "Per-status stripe colours for the slice-report rows."
+  {:captured-as-declared {:background "#2a2f3a" :color "#9fb4d0" :border "#3a5070"}
+   :not-wired            {:background "#332a2a" :color "#d09f9f" :border "#704040"}})
+
+(defn slice-report
+  "Render the non-blocking eight-slice capture report (rf2-ba86n.6). Lists
+  every slice that is NOT a clean live projection — `:captured-as-declared`
+  (carried forward via `:extends`) and `:not-wired` (not yet projectable)
+  — with its honest note. Returns nil when every slice projects cleanly
+  (nothing to warn about). Public so tests can render it directly."
+  [slices]
+  (let [warnings (save-variant/slice-warnings slices)]
+    (when (seq warnings)
+      [:div {:data-test "story-save-variant-slice-report"
+             :data-warning-count (count warnings)
+             :style {:padding "8px 10px"
+                     :margin "8px 0 0 0"
+                     :background "#22242c"
+                     :color "#c8c8d0"
+                     :border "1px solid #3a3a44"
+                     :border-radius "3px"
+                     :font-family mono-stack
+                     :font-size (:micro typography/type-scale)
+                     :line-height "1.5"}}
+       [:div {:style {:font-weight "bold" :margin-bottom "6px"}}
+        "What this save captures — and what it does not"]
+       (for [{:keys [slice label status note]} warnings]
+         (let [sty (slice-status-styles status)]
+           ^{:key (str slice)}
+           [:div {:data-test "story-save-variant-slice-row"
+                  :data-slice (name slice)
+                  :data-slice-status (name status)
+                  :style {:display "flex"
+                          :align-items "baseline"
+                          :gap "8px"
+                          :padding "3px 6px"
+                          :margin "3px 0"
+                          :background (:background sty)
+                          :border (str "1px solid " (:border sty))
+                          :border-radius "3px"}}
+            [:span {:style {:font-weight "bold"
+                            :color (:color sty)
+                            :white-space "nowrap"}}
+             label]
+            [:span {:style {:color "#a8a8b0"}}
+             (if (= status :captured-as-declared)
+               "captured as declared"
+               "not yet projectable")]
+            [:span {:style {:flex 1}} note]]))])))
+
 (defn save-dialog
   "Render the save-variant modal. Visible iff `:open?` is true on the
   dialog ratom. The snippet re-generates on every keystroke as the user
@@ -187,12 +262,17 @@
   violating keys. Non-blocking — the user can still paste; the snippet
   carries the violating args as captured (paste at your own risk).
 
+  rf2-ba86n.6: the eight-slice capture report renders below the snippet,
+  warning which slices are captured-as-declared (carried via `:extends`)
+  and which are not yet projectable — the honesty floor for a saved
+  variant (spec/019 §3).
+
   Public so tests can render the dialog hiccup directly after seeding
   the dialog ratom."
   []
   (let [dialog @ui-dialog]
     (when (:open? dialog)
-      (let [{:keys [draft-id source-id args violations]} dialog
+      (let [{:keys [draft-id source-id args violations slices]} dialog
             snippet (save-variant/gen-variant-snippet
                       {:variant-id (or draft-id :story.saved/example)
                        :extends    source-id
@@ -204,7 +284,8 @@
                                           (pr-str source-id)
                                           " — edit the new variant id and copy + paste into your "
                                           "stories namespace. Source is never written directly.")]
-                               (violations-hint violations)]
+                               (violations-hint violations)
+                               (slice-report slices)]
            :snippet           snippet
            :placeholder-id    :story.saved/example
            :placeholder-input ":story.your-story/saved-flow"

--- a/tools/story/test/re_frame/story/ui/explain_panel_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/explain_panel_cljs_test.cljs
@@ -68,10 +68,13 @@
 (deftest command-entry-present-in-corpus
   (testing "the synthetic Explain command is built into the palette corpus"
     (let [entries  (palette/entries (state/registry-snapshot))
-          commands (filterv #(= :command (:kind %)) entries)]
-      (is (= 1 (count commands)) "exactly one synthetic command")
-      (is (= :explain (:id (first commands))))
-      (is (= :explain (:action (first commands)))))))
+          commands (filterv #(= :command (:kind %)) entries)
+          explain  (first (filter #(= :explain (:id %)) commands))]
+      ;; rf2-ba86n.6 added the :save-current-as-variant command, so the
+      ;; corpus now carries more than one synthetic command — assert the
+      ;; Explain command is PRESENT rather than the sole entry.
+      (is (some? explain) "the Explain command is in the corpus")
+      (is (= :explain (:action explain))))))
 
 (deftest command-entry-ranks-for-explain-query
   (testing "an `explain` query surfaces the command at the top of results"

--- a/tools/story/test/re_frame/story/ui/save_variant_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/save_variant_cljs_test.cljc
@@ -213,3 +213,132 @@
              "the offending key name appears in the hint")
          (is (str/includes? flat "story-save-variant-snippet")
              "the snippet still renders — the hint is non-blocking")))))
+
+;; ---- rf2-ba86n.6: eight-slice capture model -----------------------------
+
+(deftest capture-slices-covers-all-eight-slices
+  (testing "every slice in spec/019 §3 is classified — none silently dropped"
+    (let [report (save-variant/capture-slices {:n 1} nil {})
+          slices (set (map :slice report))]
+      (is (= (set save-variant/slice-order) slices)
+          "the report covers exactly the eight canonical slices")
+      (is (= save-variant/slice-order (mapv :slice report))
+          "rows render in the canonical slice-order"))))
+
+(deftest capture-slices-args-is-projectable
+  (testing "args (+ transient-controls) are the projectable pair; args emits"
+    (let [report   (save-variant/capture-slices {:n 7} nil {})
+          by-slice (into {} (map (juxt :slice identity)) report)]
+      (is (= :projectable (-> by-slice :args :status)))
+      (is (true? (-> by-slice :args :emit?)) "args contributes the :args slot")
+      (is (= {:n 7} (-> by-slice :args :value)))
+      (is (= :projectable (-> by-slice :transient-controls :status)))
+      (is (false? (-> by-slice :transient-controls :emit?))
+          "transient-controls folds into :args — no second slot"))))
+
+(deftest capture-slices-unwired-slices-warn-not-fabricate
+  (testing "with a bare source body, the not-yet-wired slices are :not-wired
+            — captured nothing, honest warning, never a fabricated value"
+    (let [report   (save-variant/capture-slices {:n 1} nil {:viewport :tablet})
+          by-slice (into {} (map (juxt :slice identity)) report)]
+      (doseq [s [:sub-overrides :db-seed :route :network :fx-overrides :viewport]]
+        (is (= :not-wired (-> by-slice s :status))
+            (str s " is honestly not-wired with no declared source value"))
+        (is (false? (-> by-slice s :emit?)) (str s " emits no body slot"))
+        (is (string? (-> by-slice s :note)) (str s " carries an honest note")))
+      (is (str/includes? (-> by-slice :route :note) "7pgiz")
+          "route names the blocking bead")
+      (is (str/includes? (-> by-slice :db-seed :note) "blw1q")
+          "db-seed names the blocking bead")
+      (is (str/includes? (-> by-slice :viewport :note) "FORK")
+          "viewport is flagged as the product fork")
+      (is (str/includes? (-> by-slice :viewport :note) ":tablet")
+          "viewport note names the live chrome-wide selection it is NOT projecting"))))
+
+(deftest capture-slices-declared-source-slots-are-captured-as-declared
+  (testing "when the source variant body declares the unwired slices, they are
+            captured-as-declared (carried forward via :extends), warned, honest"
+    (let [body     {:sub-overrides {[:s] :v}
+                    :network       {[:get "/u"] {:reply {}}}
+                    :fx-overrides  {:my/fx 1}
+                    :setup         [[:e]]
+                    :viewport      :tablet}
+          report   (save-variant/capture-slices {:n 1} body {})
+          by-slice (into {} (map (juxt :slice identity)) report)]
+      (doseq [[s v] {:sub-overrides {[:s] :v}
+                     :network       {[:get "/u"] {:reply {}}}
+                     :fx-overrides  {:my/fx 1}
+                     :db-seed       [[:e]]
+                     :viewport      :tablet}]
+        (is (= :captured-as-declared (-> by-slice s :status))
+            (str s " carries the declared source value forward"))
+        (is (= v (-> by-slice s :value)) (str s " value is the declared slot")))
+      (is (= :not-wired (-> by-slice :route :status))
+          "route has no declared source slot — still not-wired"))))
+
+(deftest slice-warnings-filters-projectable
+  (testing "slice-warnings keeps only the rows the user must see — every slice
+            that is NOT a clean live projection"
+    (let [report   (save-variant/capture-slices {:n 1} nil {})
+          warnings (save-variant/slice-warnings report)]
+      (is (every? #(not= :projectable (:status %)) warnings)
+          "no projectable rows in the warnings")
+      (is (not (some #(= :args (:slice %)) warnings))
+          "args (projectable) is filtered out")
+      (is (some #(= :route (:slice %)) warnings)
+          "route (not-wired) is surfaced"))))
+
+(deftest open-6-arity-stamps-slices
+  (testing "rf2-ba86n.6 — open's 6-arity stamps the slice report on the dialog"
+    (let [report (save-variant/capture-slices {:n 1} nil {})
+          s      (save-variant/open save-variant/initial-dialog-state
+                                    :story.x/y {:n 1} 0 [] report)]
+      (is (true? (:open? s)))
+      (is (= report (:slices s)) "the slice report rides the dialog state"))))
+
+(deftest open-4-arity-defaults-slices-to-empty-vec
+  (testing "rf2-ba86n.6 — back-compat: pre-slices arities default :slices to []"
+    (is (= [] (:slices (save-variant/open save-variant/initial-dialog-state
+                                          :story.x/y {:n 1} 0))))
+    (is (= [] (:slices (save-variant/open save-variant/initial-dialog-state
+                                          :story.x/y {:n 1} 0 []))))))
+
+#?(:cljs
+   (deftest slice-report-renders-warnings-when-present
+     (testing "rf2-ba86n.6 — the slice-report component renders a row per
+               non-projectable slice with its status + honest note"
+       (let [report (save-variant/capture-slices {:n 1} nil {:viewport :tablet})
+             flat   (str (ui-sv/slice-report report))]
+         (is (str/includes? flat "story-save-variant-slice-report")
+             "the report container is present")
+         (is (str/includes? flat "story-save-variant-slice-row")
+             "individual slice rows render")
+         (is (str/includes? flat "not yet projectable")
+             "not-wired slices carry the 'not yet projectable' label")
+         (is (str/includes? flat "FORK")
+             "the viewport fork is surfaced to the user")))))
+
+#?(:cljs
+   (deftest slice-report-nil-when-all-projectable
+     (testing "rf2-ba86n.6 — when every slice projects cleanly there is
+               nothing to warn about and the report renders nil"
+       (let [all-clean [{:slice :args :status :projectable}
+                        {:slice :transient-controls :status :projectable}]]
+         (is (nil? (ui-sv/slice-report all-clean)))))))
+
+#?(:cljs
+   (deftest save-dialog-renders-slice-report-when-open
+     (testing "rf2-ba86n.6 — the open dialog renders the slice report below
+               the snippet so the save is honest about what it captures"
+       (reset! ui-sv/ui-dialog
+               (save-variant/open save-variant/initial-dialog-state
+                                  :story.x/source
+                                  {:n 1}
+                                  12345
+                                  []
+                                  (save-variant/capture-slices {:n 1} nil {})))
+       (let [flat (str (ui-sv/save-dialog))]
+         (is (str/includes? flat "story-save-variant-slice-report")
+             "the slice report renders inside the open dialog")
+         (is (str/includes? flat "story-save-variant-snippet")
+             "the snippet still renders — the report is non-blocking")))))

--- a/tools/story/test/re_frame/story_save_variant_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_save_variant_cljs_test.cljs
@@ -122,7 +122,7 @@
   (state/swap-state! state/select-variant :story.snap/v)
   (let [captured (atom nil)]
     (save-variant/set-open-dialog-fn!
-      (fn [source-id args _]
+      (fn [source-id args & _]
         (reset! captured {:source-id source-id :args args})))
     (let [result (save-variant/save-current-as-variant!)]
       (is (some? @captured))

--- a/tools/story/test/re_frame/story_save_variant_test.clj
+++ b/tools/story/test/re_frame/story_save_variant_test.clj
@@ -209,13 +209,49 @@
     (state/swap-state! state/select-variant :story.snap/v)
     (let [captured (atom nil)]
       (save-variant/set-open-dialog-fn!
-        (fn [source-id args _now-ms _violations]
+        (fn [source-id args _now-ms _violations & _]
           (reset! captured {:source-id source-id :args args})))
       (let [result (save-variant/save-current-as-variant!)]
         (is (some? @captured) "the callback fired")
         (is (= :story.snap/v (:source-id @captured)))
         (is (= 7 (-> @captured :args :n)))
         (is (= :story.snap/v (:source-id result)))))))
+
+;; ---- rf2-ba86n.6: the eight-slice capture report rides the trigger -------
+
+(deftest save-current-as-variant!-carries-slice-report
+  (testing "the trigger computes the eight-slice capture report and passes
+            it through both the callback and the returned record"
+    (story/reg-variant :story.snap/sliced {:args {:n 3} :events []})
+    (state/swap-state! state/select-variant :story.snap/sliced)
+    (let [captured (atom nil)]
+      (save-variant/set-open-dialog-fn!
+        (fn [_source-id _args _now-ms _violations slices]
+          (reset! captured slices)))
+      (let [result (save-variant/save-current-as-variant!)
+            slices (:slices result)]
+        (is (= (set save-variant/slice-order)
+               (set (map :slice slices)))
+            "every canonical slice is classified — none silently dropped")
+        (is (= slices @captured)
+            "the same report rides the callback's 5th arg")
+        (is (= :projectable (:status (first (filter #(= :args (:slice %)) slices))))
+            "args is the projectable slice")))))
+
+(deftest save-current-as-variant!-declared-slots-captured-as-declared
+  (testing "a source variant declaring the not-yet-wired slices captures them
+            as-declared (carried forward via :extends) — honest, not dropped"
+    (story/reg-variant :story.snap/declared
+      {:args         {:n 1}
+       :sub-overrides {[:s] :v}
+       :events       []})
+    (state/swap-state! state/select-variant :story.snap/declared)
+    (save-variant/set-open-dialog-fn! (fn [& _] nil))
+    (let [result   (save-variant/save-current-as-variant!)
+          by-slice (into {} (map (juxt :slice identity)) (:slices result))]
+      (is (= :captured-as-declared (-> by-slice :sub-overrides :status))
+          "the declared :sub-overrides carry forward as-declared")
+      (is (= {[:s] :v} (-> by-slice :sub-overrides :value))))))
 
 (deftest save-current-as-variant!-nil-when-no-focus
   (testing "without a focused variant the trigger is a no-op"
@@ -233,7 +269,7 @@
     (state/swap-state! state/select-variant nil)
     (let [captured (atom nil)]
       (save-variant/set-open-dialog-fn!
-        (fn [source-id args _ _]
+        (fn [source-id args & _]
           (reset! captured {:source-id source-id :args args})))
       (save-variant/save-current-as-variant! {:variant-id :story.snap/override})
       (is (= :story.snap/override (:source-id @captured)))
@@ -253,7 +289,7 @@
     (state/swap-state! state/select-variant :story.event/v)
     (let [captured (atom nil)]
       (save-variant/set-open-dialog-fn!
-        (fn [source-id args _ _]
+        (fn [source-id args & _]
           (reset! captured {:source-id source-id :args args})))
       (rf/dispatch-sync [save-variant/id-save-current-as-variant])
       (is (= :story.event/v (:source-id @captured)))
@@ -265,7 +301,7 @@
     (state/swap-state! state/select-variant nil)
     (let [captured (atom nil)]
       (save-variant/set-open-dialog-fn!
-        (fn [source-id args _ _]
+        (fn [source-id args & _]
           (reset! captured {:source-id source-id :args args})))
       (rf/dispatch-sync [save-variant/id-save-current-as-variant
                          {:variant-id :story.event/explicit}])
@@ -284,7 +320,7 @@
     ;; Capture via the impure trigger; harvest snapshot from the callback.
     (let [captured (atom nil)]
       (save-variant/set-open-dialog-fn!
-        (fn [source-id args _ _]
+        (fn [source-id args & _]
           (reset! captured {:source-id source-id :args args})))
       (save-variant/save-current-as-variant!)
       (let [snippet  (save-variant/gen-variant-snippet

--- a/tools/story/test/re_frame/story_ui_test.clj
+++ b/tools/story/test/re_frame/story_ui_test.clj
@@ -326,6 +326,21 @@
     (is (= 2 (command-palette/move-active-index 0 -1 3)))
     (is (= 0 (command-palette/move-active-index 0 1 0)))))
 
+(deftest command-palette-carries-save-current-command
+  (testing "rf2-ba86n.6 — the save-current-state flow is reachable from the
+            command palette (spec/019 §3), as a synthetic :command entry"
+    (let [entries (command-palette/command-entries)
+          save    (first (filter #(= :save-current-as-variant (:id %)) entries))]
+      (is (some? save) "the save-current command entry is present")
+      (is (= :command (:kind save)))
+      (is (= :save-current-as-variant (:action save))
+          "the entry carries the action the view dispatches"))
+    (testing "the command is findable by search"
+      (let [entries (command-palette/entries {})
+            hit     (first (command-palette/search entries "save variant"))]
+        (is (= :save-current-as-variant (:id hit))
+            "searching 'save variant' surfaces the save-current command")))))
+
 ;; ---- mode-tabs (rf2-9hc8) ------------------------------------------------
 
 (deftest mode-tabs-canonical-set


### PR DESCRIPTION
## Summary

Extends the save-current-canvas-state-as-variant flow (spec/019 §3) with an
explicit, per-slice projection model that honours the **honesty floor**: each
of the eight slices is classified honestly and the flow NEVER fabricates a live
projection for a slice whose substrate is not wired. Builds on the existing
`save_variant.cljs` / `save_variant.cljc` (args-only capture + rf2-lancu
schema-violation hint) — extended, not greenfield.

## Placement

Save-current-state is reachable from **both**:
- **Controls** — the existing `save as new variant…` button on the controls
  panel (`re-frame.story.ui.controls/panel` → `save-variant-button`), unchanged.
- **Command palette** — a new synthetic `:command` entry
  (`Save current canvas state as a new variant`, action
  `:save-current-as-variant`) in `command_palette.cljc`; the view dispatches it
  through the same `save-current-as-variant!` flow. No-ops when no variant is
  focused (the trigger guards on the live selection).

Both drive the same pure flow — one capture path, two entry points.

## Per-slice projection table (8 slices)

| Slice | Status | Substrate it reuses |
|---|---|---|
| **Args** | `:projectable` | `args/resolve-args` (five-layer precedence, spec/002) → snippet `:args` slot |
| **Transient controls** | `:projectable` (no 2nd slot) | in-flight `:cell-overrides` — folded into `:args` by `resolve-args` |
| **Sub-overrides** | captured-as-declared / **not-wired (warn)** | source body `:sub-overrides` (carried via `:extends`); no live View-State controls (rf2-7pgiz) |
| **DB seed** | captured-as-declared / **not-wired (warn)** | source body `:setup` (carried via `:extends`); seed fidelity rung not wired (rf2-blw1q) |
| **Route** | **not-wired (warn)** | route sub-override not consumed (rf2-7pgiz) — nothing to capture |
| **Network** | captured-as-declared / **not-wired (warn)** | source body `:network` (carried via `:extends`); no live Network controls |
| **FX-overrides** | captured-as-declared / **not-wired (warn)** | source body `:fx-overrides` (carried via `:extends`); no live Effects controls |
| **Viewport** | captured-as-declared / **not-wired (warn)** — **FORK** | source body `:viewport` (carried via `:extends`); live chrome-wide selection NOT projected |

`capture-slices` (pure, JVM-testable) reads the resolved source variant body
(`registrar/handler-meta :variant`) for declared slot values + the shell-state
for the live chrome-wide viewport. `slice-warnings` filters to the rows the user
must see (everything that is NOT a clean live projection). The save dialog
renders these as a non-blocking slice report below the snippet — the user sees,
before pasting, exactly what is captured live, what carries forward as declared,
and what is not yet projectable.

## Slices that warn-as-unsupported

`sub-overrides`, `db-seed`, `route`, `network`, `fx-overrides`, `viewport` — each
either carries the source body's declared value forward (`:captured-as-declared`,
warned as "captured as declared, not a live projection") or warns
`:not-wired` ("not yet projectable"), naming the blocking bead where relevant
(rf2-7pgiz for sub-overrides/route, rf2-blw1q for db-seed). Honest, never silent.

## Flagged product fork (for the mayor / Mike to rule)

**Viewport.** The live viewport is **chrome-wide shell state**, NOT a per-variant
body slot the way the other reg-variant body slices are. spec/019 §3 / §5 do not
settle whether a saved variant should pin the live chrome-wide viewport at all.
The conservative honest default here: carry the SOURCE body's declared
`:viewport` forward (captured-as-declared, via `:extends`) when present, and
otherwise WARN that the live chrome-wide selection is NOT projected into the
saved variant. The note is explicitly tagged `FORK`. The broader question — the
canonical projection when a future surface lets args AND a live sub-override
slice both be set — is likewise left for a deliberate ruling. Documented, not
decided silently.

## Kept separate from promotion

Generated-failure promotion (ba86n.13, not yet built) stays a fully distinct
flow — different entry point, different artifact-kind semantics. This PR touches
nothing in the promotion surface; save-current remains the
intentional-authoring path (`:rf.story/save-current-as-variant`).

## shell.cljs

Not touched. The palette entry reuses the existing synthetic-command mechanism;
the Controls trigger already existed. No new shell panel registered.

## Spec

spec/019 §3 (save-current section only) updated to lock the capture-or-warn
projection table and flag the viewport fork; no other section edited.

## Quality gates

- **clj-kondo** `--parallel --fail-level error --lint tools/story` → **errors: 0** (no new warnings in changed files)
- `tools/story` `clojure -M:test` → 1380 tests, **0 failures, 0 errors**
- `npm run test:cljs` → 4912 tests, **0 failures, 0 errors, 0 warnings**
- `tools/story-mcp` `clojure -M:test` → 172 tests, **0 failures, 0 errors**
- `tools/mcp-conformance` `npm run test:story` → **CONFORMANCE GREEN**
- `bash scripts/test-fast-pr.sh` → **PASS fast PR spine**

Closes rf2-ba86n.6.