### PR TITLE
fix(story): record-status mirror tracks canonical + adds :error branch (rf2-fslmh)

### DIFF
--- a/tools/story/src/re_frame/story/ui/state/tests.cljc
+++ b/tools/story/src/re_frame/story/ui/state/tests.cljc
@@ -67,18 +67,38 @@
 
 (defn- record-status
   "The unified verdict for ONE assertion record (rf2-5x1wt.19): the
-  record's own `:status` when present (the unified shape), else derived
-  from `:passed?` / `:skipped?` / `:cannot-run?`. Pure data → data — a
-  local mirror so this leaf needs no require into `re-frame.story.result`
-  (which would loop through the runtime)."
-  [{:keys [status passed? skipped? cannot-run?] :as _record}]
+  record's own `:status` when it is one of the four verdicts (the
+  unified shape), else derived from the outcome fields. Pure data →
+  data — a local mirror so this leaf needs no require into
+  `re-frame.story.result` (which would loop through the runtime via
+  `result` → `runtime`).
+
+  This MUST track `re-frame.story.result/record-status` verdict-for-
+  verdict — it cannot delegate (the cycle above) so the rule is copied
+  by hand. The canonical ordering (and the one reproduced here) is:
+
+  - an explicit `:status` that is one of the four verdicts wins;
+  - `:cannot-run?` / `:skipped?` truthy → `:cannot-run`;
+  - `:exception` / `:error` truthy → `:error` (a thrown handler / fx /
+    step — rf2-fslmh: this branch was missing, so a derived record
+    carrying `:exception`/`:error` but no explicit `:status` was mis-
+    counted as `:pass`, a false-green);
+  - `:passed?` true → `:pass`; `:passed?` false → `:fail`;
+  - otherwise `:pass` (a non-assertion / vacuous record does not fail
+    the run — the spec/007 duality).
+
+  A parity test (`record-status-mirrors-canonical`) runs a table of
+  record shapes through BOTH this mirror and the canonical, asserting
+  identical verdicts, so the two can never silently drift again."
+  [{:keys [status passed? skipped? cannot-run? exception error] :as _record}]
   (cond
-    (keyword? status)  status
-    cannot-run?        :cannot-run
-    skipped?           :cannot-run
-    (true? passed?)    :pass
-    (false? passed?)   :fail
-    :else              :pass))
+    (contains? #{:pass :fail :cannot-run :error} status) status
+    cannot-run?          :cannot-run
+    skipped?             :cannot-run
+    (or exception error) :error
+    (true? passed?)      :pass
+    (false? passed?)     :fail
+    :else                :pass))
 
 (defn aggregate-summary
   "Walk `assertions` (the vector pulled off a `run-variant` result map)

--- a/tools/story/test/re_frame/story/ui/test_widget_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/test_widget_cljs_test.cljc
@@ -21,7 +21,14 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.story :as story]
             [re-frame.story.registrar :as story-registrar]
+            [re-frame.story.result :as result]
             [re-frame.story.ui.state :as state]
+            ;; rf2-fslmh — reach the PRIVATE local mirror to assert parity
+            ;; with the canonical `result/record-status`. The mirror is a
+            ;; copy-by-hand of the canonical rule (it can't require `result`,
+            ;; which loops through the runtime); the test CAN require both,
+            ;; tests aren't on that production cycle path.
+            [re-frame.story.ui.state.tests :as state.tests]
             #?@(:cljs [[re-frame.story.ui.sidebar :as sidebar]])))
 
 ;; ---- fixtures ------------------------------------------------------------
@@ -346,6 +353,68 @@
          (testing "an unedited variant gets nil overrides (no leakage
                    from sibling variants)"
            (is (nil? (:cell-overrides opts-c))))))))
+
+;; ---- rf2-fslmh: the local mirror tracks the canonical verdict-for-verdict
+
+(def ^:private record-status-parity-cases
+  "A table of assertion-record shapes covering every branch of the
+  verdict rule (rf2-fslmh). The load-bearing rows are the `:exception`/
+  `:error`-truthy ones (5 + 6): pre-fix the mirror dropped through to
+  `:else :pass` — a thrown handler counted as a false-green. The mixed
+  rows assert precedence holds identically on both sides (an explicit
+  verdict wins; cannot-run/skipped beat error; error beats pass/fail)."
+  [;; explicit verdicts win, even against contradicting outcome fields
+   {:status :pass}
+   {:status :fail :passed? true}
+   {:status :cannot-run}
+   {:status :error :passed? true}
+   ;; derived: a thrown handler / fx / step — the missing branch
+   {:exception (ex-info "boom" {})}
+   {:error "boom"}
+   ;; error beats a contradicting passed? true (canonical ordering)
+   {:exception (ex-info "boom" {}) :passed? true}
+   ;; cannot-run / skipped beat error (checked earlier in the cond)
+   {:cannot-run? true :exception (ex-info "boom" {})}
+   {:skipped? true :error "boom"}
+   ;; the plain pass / fail / refusal / vacuous rows
+   {:passed? true}
+   {:passed? false}
+   {:cannot-run? true}
+   {:skipped? true}
+   {}
+   {:passed? nil}
+   ;; a non-verdict keyword in :status does NOT win — it falls through
+   ;; (the canonical guards on the four-verdict set, not `keyword?`)
+   {:status :running :passed? false}
+   {:status :running :exception (ex-info "boom" {})}])
+
+(deftest record-status-mirrors-canonical
+  (testing "rf2-fslmh — `ui.state.tests`' private `record-status` mirror
+            returns the SAME verdict as `result/record-status` for every
+            record shape. The mirror is a copy-by-hand of the canonical
+            rule (it can't require `result` — that loops through the
+            runtime). This parity guard is the trip-wire against the
+            drift that mis-counted a thrown-handler record as :pass."
+    (doseq [record record-status-parity-cases]
+      (is (= (result/record-status record)
+             (#'state.tests/record-status record))
+          (str "verdict mismatch for record " (pr-str record))))))
+
+(deftest record-status-error-branch-is-reachable
+  (testing "rf2-fslmh — a derived record with :exception/:error truthy and
+            NO explicit :status now resolves to :error (was :pass — the
+            false-green). This is what makes aggregate-summary's :error
+            accounting (tests.cljc :failed = :fail + :error) reachable."
+    (is (= :error (#'state.tests/record-status {:exception (ex-info "boom" {})})))
+    (is (= :error (#'state.tests/record-status {:error "boom"})))
+    (testing "and the :error bucket lands in the :failed tally"
+      (let [summary (state/aggregate-summary
+                      [{:passed? true}
+                       {:exception (ex-info "boom" {})}
+                       {:error "boom"}])]
+        (is (= 1 (:passed summary)))
+        (is (= 2 (:failed summary)) ":error records count as failures")
+        (is (false? (:all-passed? summary)))))))
 
 #?(:clj
    (deftest jvm-only-summary-from-fixture


### PR DESCRIPTION
## The false-green (rf2-fslmh)

`tools/story/src/re_frame/story/ui/state/tests.cljc` defines a **private** `record-status` — a hand-copied **local mirror** of the canonical `re-frame.story.result/record-status` (`result.cljc:81`). It can't just `:require` `result` because that namespace loops through the runtime (`result` → `runtime`), so the verdict rule is copied by hand.

The mirror had **drifted**: its `cond` was missing the `(or exception error) :error` branch the canonical carries. A derived assertion record with `:exception`/`:error` truthy but **no explicit `:status`** fell through to `:else :pass` — i.e. **a thrown handler / fx / step was silently counted as a `:pass`** (a false-green, the honesty-critical class this project guards against).

`aggregate-summary` already tallies `:error` into the headline `:failed` count (`tests.cljc:114` — `:failed = :fail + :error`), and `record-test-run` reads `:error` as `:fail` on the dot. But the mirror never **returned** `:error` on the derived path, so that `:error` accounting was **unreachable** — the comment at line 114 was a lie.

## The fix

Match `result/record-status` verdict-for-verdict so the mirror returns identical verdicts for every input shape:

```clojure
;; before
[{:keys [status passed? skipped? cannot-run?] :as _record}]
(cond
  (keyword? status)  status
  cannot-run?        :cannot-run
  skipped?           :cannot-run
  (true? passed?)    :pass
  (false? passed?)   :fail
  :else              :pass)

;; after
[{:keys [status passed? skipped? cannot-run? exception error] :as _record}]
(cond
  (contains? #{:pass :fail :cannot-run :error} status) status
  cannot-run?          :cannot-run
  skipped?             :cannot-run
  (or exception error) :error            ;; <-- the missing branch (false-green)
  (true? passed?)      :pass
  (false? passed?)     :fail
  :else                :pass)
```

Two drifts closed:
1. **Added `(or exception error) :error`** in the canonical position (after the explicit-status + cannot-run/skipped guards, before pass/fail) — the core fix.
2. **Tightened the status guard** from `(keyword? status)` → `(contains? #{:pass :fail :cannot-run :error} status)`. The canonical only honors a `status` that is one of the four verdicts (`result/statuses`); the prior `keyword?` test accepted *any* keyword (e.g. `:running`) as a verdict. Inlining the four-verdict set (rather than requiring `result/statuses`) keeps the mirror cycle-free.

Docstring expanded to state the mirror MUST track the canonical and why it can't delegate (the cycle).

## Parity guard (so it can't drift silently again)

`record-status-mirrors-canonical` (in `test_widget_cljs_test.cljc`, runs on **JVM + CLJS**) drives a table of record shapes — explicit `:status` (incl. contradicting outcome fields), `:exception`-truthy, `:error`-truthy, `passed? true/false`, `:cannot-run?`, `:skipped?`, mixed-precedence rows, a non-verdict `:status :running`, and bare/`:else` — through **both** `result/record-status` and the private mirror (`#'state.tests/record-status`), asserting equal verdicts. The test requires both namespaces, which is legal: tests aren't on the production cycle path.

`record-status-error-branch-is-reachable` confirms a derived `:exception`/`:error` record now resolves to `:error` (was `:pass`) and that the `:error` bucket lands in `aggregate-summary`'s `:failed` tally (`:failed = :fail + :error` is now actually reachable).

`result.cljc` is the canonical and was **not** touched.

## Quality gates
- `clj-kondo --parallel --fail-level error --lint tools/story` — **errors: 0** (123 pre-existing warnings, none new on the touched files; the one warning on the touched test file is the pre-existing `find-by-data-test` `Unused value` at line 195, untouched).
- `tools/story` `clojure -M:test` — **1386 tests, 4754 assertions, 0 failures, 0 errors**; the new namespace in isolation: 15 tests, 49 assertions, 0/0.
- `npm run test:cljs` — **4910 tests, 16082 assertions, 0 failures, 0 errors, 0 warnings** (the `.cljc` parity test runs here too).
- `bash scripts/test-fast-pr.sh` — **PASS fast PR spine**.