### PR TITLE
fix(story): evidence-spine db-Δ marker tests transition, not key presence (rf2-v917m)

### DIFF
--- a/tools/story/src/re_frame/story/ui/evidence_spine.cljc
+++ b/tools/story/src/re_frame/story/ui/evidence_spine.cljc
@@ -133,16 +133,22 @@
       {:direct?     <bool>   ; any committed db-transition / effect / trace
        :attributed? <bool>}  ; any post-settle sub-run / render row
 
-  A beat with a `:db-before`/`:db-after` transition, ANY effect row, OR any
-  trace event reads as carrying direct evidence. A beat with sub-run /
-  render rows reads as carrying attributed evidence. The two are NOT
-  mutually exclusive — most settled dispatch beats carry both, and the
-  renderer labels each present strength distinctly so attributed evidence
-  is never presented as direct."
+  A beat with an actual `:db-before`/`:db-after` transition (the two
+  differ), ANY effect row, OR any trace event reads as carrying direct
+  evidence. A beat with sub-run / render rows reads as carrying attributed
+  evidence. The two are NOT mutually exclusive — most settled dispatch beats
+  carry both, and the renderer labels each present strength distinctly so
+  attributed evidence is never presented as direct.
+
+  Note the db test compares VALUES, not key presence: `evidence/epoch-beat`
+  ALWAYS materializes `:db-before` / `:db-after` (they sit in its base map,
+  not its `cond->` tail), so `contains?` would read true for every projected
+  beat — including a read-only dispatch that changed nothing. A beat counts
+  as carrying direct db-evidence only when the two values DIFFER; absent keys
+  (older beats) read as nil = nil → no transition."
   [beat]
   {:direct?     (boolean
-                  (or (contains? beat :db-before)
-                      (contains? beat :db-after)
+                  (or (not= (:db-before beat) (:db-after beat))
                       (seq (:effects beat))
                       (seq (:trace-events beat))))
    :attributed? (boolean
@@ -169,13 +175,16 @@
   carries.
 
   `:db` is a synthetic 0/1 marker — a beat either committed an app-db
-  transition (`:db-before`/`:db-after` present) or it did not. The
-  rendered shape `db Δ` reads as 'app-db changed at this beat' rather than
-  inventing a diff (the diff itself is Xray's, surfaced via focus)."
+  transition (its `:db-before` / `:db-after` values DIFFER) or it did not.
+  The rendered shape `db Δ` reads as 'app-db changed at this beat' rather
+  than inventing a diff (the diff itself is Xray's, surfaced via focus).
+  The test compares values, not key presence: `evidence/epoch-beat` always
+  materializes both keys, so a key-presence test would show the `db Δ` chip
+  on every beat — even a dispatch that changed nothing."
   [beat]
   (let [schema-n (count (filter evidence/schema-violation-trace?
                                 (:trace-events beat)))
-        db?      (or (contains? beat :db-before) (contains? beat :db-after))
+        db?      (not= (:db-before beat) (:db-after beat))
         entries  [{:k :db       :label "db Δ"     :count (if db? 1 0) :strength :direct}
                   {:k :effects  :label "effects"  :count (count (:effects beat)) :strength :direct}
                   {:k :schemas  :label "schemas"  :count schema-n :strength :direct}

--- a/tools/story/test/re_frame/story/ui/evidence_spine_test.cljc
+++ b/tools/story/test/re_frame/story/ui/evidence_spine_test.cljc
@@ -81,6 +81,61 @@
     (is (= {:direct? false :attributed? false}
            (spine/beat-evidence-strength {})))))
 
+;; ---------------------------------------------------------------------------
+;; rf2-v917m regression — the db-evidence marker must test for an ACTUAL
+;; transition (`:db-before` ≠ `:db-after`), not key PRESENCE. `epoch-beat`
+;; ALWAYS materializes `:db-before` / `:db-after` (they sit in its base map,
+;; not its `cond->` tail), so a key-presence test reads true for EVERY
+;; projected beat — including a read-only dispatch that committed no db
+;; change. These cases drive a real `epoch-beat`-projected beat (the gap the
+;; earlier hand-built beats never exercised, because they all omitted or
+;; differed the db keys) and pin: no transition → NOT direct db-evidence /
+;; NO `db Δ` chip; a real transition → direct + chip present.
+;; ---------------------------------------------------------------------------
+
+(def ^:private no-db-change-record
+  "An epoch record whose dispatch changed no app-db (e.g. a read-only / no-op
+  event): `:db-before` and `:db-after` are equal, no effects, no trace."
+  {:epoch-id    200
+   :dispatch-id 200
+   :trigger-event [:counter/noop]
+   :db-before   {:count 6}
+   :db-after    {:count 6}
+   :effects     []
+   :sub-runs    []
+   :renders     []
+   :trace-events []
+   :outcome     :ok})
+
+(deftest db-evidence-tests-transition-not-key-presence
+  (testing "a REAL epoch-beat-projected beat with equal db-before/db-after
+            carries the keys (epoch-beat always materializes them) but is
+            NOT direct db-evidence and emits NO `db Δ` chip (rf2-v917m)"
+    (let [beat (evidence/epoch-beat no-db-change-record)]
+      ;; the keys ARE present — proving the old contains? test would mis-fire
+      (is (contains? beat :db-before))
+      (is (contains? beat :db-after))
+      (is (= (:db-before beat) (:db-after beat)) "no transition occurred")
+      ;; ...yet strength must report no direct evidence (no effects/trace either)
+      (is (= {:direct? false :attributed? false}
+             (spine/beat-evidence-strength beat)))
+      ;; ...and the summary must carry NO db marker
+      (let [by-k (into {} (map (juxt :k :count)) (spine/beat-summary beat))]
+        (is (nil? (:db by-k)) "no `db Δ` chip when db did not change"))))
+  (testing "a REAL epoch-beat-projected beat WITH a db transition is direct
+            db-evidence and emits the `db Δ` chip (rf2-v917m)"
+    (let [beat (evidence/epoch-beat
+                (assoc no-db-change-record :db-after {:count 7}))]
+      (is (:direct? (spine/beat-evidence-strength beat)))
+      (let [by-k (into {} (map (juxt :k :count)) (spine/beat-summary beat))]
+        (is (= 1 (:db by-k)) "`db Δ` chip present when db changed"))))
+  (testing "absent db keys (an older beat) read as no transition, robustly"
+    (is (= {:direct? false :attributed? false}
+           (spine/beat-evidence-strength {})))
+    (is (nil? (-> (spine/beat-summary {})
+                  (->> (into {} (map (juxt :k :count))))
+                  :db)))))
+
 ;; ===========================================================================
 ;; compact summary  (spec/020 §3)
 ;; ===========================================================================


### PR DESCRIPTION
## The bug (always-true db marker)

`re-frame.story.play.evidence/epoch-beat` ALWAYS materializes `:db-before` and `:db-after` in its base map (they sit before its `cond->` tail — only `:dispatch-id` / `:trigger-event` / `:outcome` are conditional). So the evidence-spine's key-presence test

```clojure
(or (contains? beat :db-before) (contains? beat :db-after))
```

read `true` for EVERY projected beat. The `:direct?` evidence flag and the `db Δ` summary chip fired unconditionally — even for a read-only dispatch that committed no app-db change.

The existing pure tests passed only because they hand-built beats that omitted or *differed* the db keys; none drove a real `epoch-beat`-projected beat, so the gap went unnoticed (review-wave finding, PR #2468 / ba86n.10).

## The fix (test the transition, both sites)

Both sites now compare VALUES, not key presence — a beat carries db-evidence only when `:db-before` and `:db-after` actually DIFFER:

`beat-evidence-strength` (`:direct?`, ~:144):
```diff
-                  (or (contains? beat :db-before)
-                      (contains? beat :db-after)
+                  (or (not= (:db-before beat) (:db-after beat))
                       (seq (:effects beat))
                       (seq (:trace-events beat))))
```

`beat-summary` (`db?` marker, ~:178):
```diff
-        db?      (or (contains? beat :db-before) (contains? beat :db-after))
+        db?      (not= (:db-before beat) (:db-after beat))
```

Absent db keys (older beats) read as `nil = nil` → no transition, so the test stays robust. Both docstrings updated to explain why values, not presence.

## The test (closes the named coverage gap)

Added `db-evidence-tests-transition-not-key-presence`, which drives a REAL `evidence/epoch-beat`-projected beat:
- equal `:db-before`/`:db-after` (keys present — proving the old `contains?` test would mis-fire — but no transition) → asserts `{:direct? false :attributed? false}` and NO `db Δ` chip;
- a transitioned beat → asserts `:direct?` and the `db Δ` chip present;
- absent db keys → robustly read as no change.

## Quality gates

- `clj-kondo --parallel --fail-level error --lint tools/story` — **errors: 0** (123 pre-existing warnings tree-wide; none in the touched files).
- `tools/story` `clojure -M:test` — 1407 tests / 4851 assertions, 0 failures, 0 errors. (evidence-spine ns alone: 12 tests / 68 assertions, green.)
- `implementation` `npm run test:cljs` — build 0 warnings; 4939 tests / 16192 assertions, 0 failures, 0 errors.
- `scripts/test-fast-pr.sh` — PASS (markdown gates auto-skipped; no `.md` changes).