### PR TITLE
fix(story): surface :consumed-selectors on run-result; Test mode reads it (rf2-uyebc)

### DIFF
--- a/tools/story/src/re_frame/story/result.cljc
+++ b/tools/story/src/re_frame/story/result.cljc
@@ -34,8 +34,11 @@
     slots (`:epoch-tape` / `:schema-violations` / `:warnings` / `:effects`
     / `:sub-runs` / `:renders` / `:narrative`) are `.4` projections; the
     judgement slots (`:assertions` / `:checks`) are folded from the
-    accumulator; `:app-db` / `:run-hash` / `:plan-hash` / `:runner` /
-    `:required-runner` / `:fidelity` / `:elapsed-ms` round out the shape.
+    accumulator; `:consumed-selectors` carries the agreement-floor's
+    exactly-consumed schema-violation selector set (the single source of
+    truth Test mode reads, never re-derives); `:app-db` / `:run-hash` /
+    `:plan-hash` / `:runner` / `:required-runner` / `:fidelity` /
+    `:elapsed-ms` round out the shape.
   - ASSERTION-RECORD — one evaluated assertion (`.18`'s atom shape, plus a
     `:status`). The `:status` is derived from `:passed?` / `:skipped?` /
     `:cannot-run?` so the run aggregation reads ONE field uniformly.
@@ -539,7 +542,12 @@
                           from the agreement floor (§Schema rule), unioned
                           with whatever `:schema-expectations` consumed. A
                           pure escape hatch for callers that pre-compute the
-                          match; defaults to `#{}` (the strict floor).
+                          match; defaults to `#{}` (the strict floor). The
+                          UNION (the input set plus the schema-expectation
+                          consumption) is surfaced verbatim on the result as
+                          `:consumed-selectors` — the single source of truth
+                          for \"which violations were exactly consumed\", so
+                          Test mode reads it rather than re-deriving the set.
   - `:unmet`            — the per-requirement `:cannot-run` refusals for
                           expectations the runner could not attempt
                           (`requirements/unmet-assertions` /
@@ -610,10 +618,20 @@
         identity-slots (select-keys parts [:variant/id :plan-hash :run-hash
                                             :runner :required-runner :fidelity
                                             :elapsed-ms])]
-    (cond-> (merge {:status      status
-                    :assertions  records
-                    :checks      checks
-                    :app-db      app-db}
+    (cond-> (merge {:status             status
+                    :assertions         records
+                    :checks             checks
+                    ;; The agreement-floor consumed-selector set is SURFACED on
+                    ;; the result (it is already computed above for the floor)
+                    ;; rather than discarded — `:consumed-selectors` is the
+                    ;; single source of truth for "which schema violations were
+                    ;; exactly consumed", so downstream consumers (Test mode's
+                    ;; `schema-rows`) READ it instead of re-deriving the set
+                    ;; from each `:rf.assert/schema-error :pass` record's
+                    ;; `:actual`. Always present (an empty `#{}` when nothing
+                    ;; was consumed) so the read needs no presence guard.
+                    :consumed-selectors consumed
+                    :app-db             app-db}
                    evidence-slots
                    identity-slots)
       (seq unmet) (assoc :cannot-run unmet))))

--- a/tools/story/src/re_frame/story/ui/test_mode/pure.cljc
+++ b/tools/story/src/re_frame/story/ui/test_mode/pure.cljc
@@ -420,11 +420,14 @@
 
   A violation is `:consumed?` true iff its `:selector` appears among the
   selectors a declared `:rf.assert/schema-error` expectation exactly
-  consumed. The unified result does not carry the consumed-selector set
-  directly, so we recover it from the run's `:rf.assert/schema-error`
-  assertion records: a `:pass` schema-error record consumed the violation
-  whose selector matches its `:actual` (the consumed violation's selector,
-  per `re-frame.story.result/schema-error-record`).
+  consumed. That set is the run-result's `:consumed-selectors` slot (the
+  agreement-floor set `re-frame.story.result/run-result` surfaces) — the
+  single source of truth, READ here rather than re-derived. A legacy /
+  partial result that predates the slot is tolerated via a fallback that
+  recovers the set from the run's `:rf.assert/schema-error` assertion
+  records (a `:pass` schema-error record consumed the violation whose
+  selector matches its `:actual`, per
+  `re-frame.story.result/schema-error-record`).
 
       [{:selector   <selector>
         :where      <surface>
@@ -438,12 +441,18 @@
   the tape carried no schema violations. Pure data → data; JVM-testable."
   [result]
   (let [violations (or (:schema-violations result) [])
-        consumed   (into #{}
-                         (comp (filter #(= :rf.assert/schema-error (:assertion %)))
-                               (filter #(= :pass (or (:status %)
-                                                     (when (:passed? %) :pass))))
-                               (keep :actual))
-                         (or (:assertions result) []))]
+        ;; Read the canonical consumed-selector set the run-result surfaces
+        ;; (single source of truth). Only when the key is ABSENT — a legacy /
+        ;; partial result that predates the slot — fall back to re-deriving it
+        ;; from the `:rf.assert/schema-error :pass` records' `:actual`.
+        consumed   (if (contains? result :consumed-selectors)
+                     (or (:consumed-selectors result) #{})
+                     (into #{}
+                           (comp (filter #(= :rf.assert/schema-error (:assertion %)))
+                                 (filter #(= :pass (or (:status %)
+                                                       (when (:passed? %) :pass))))
+                                 (keep :actual))
+                           (or (:assertions result) [])))]
     (mapv (fn [{:keys [selector where failing-id reason epoch-id]}]
             {:selector   selector
              :where      where

--- a/tools/story/test/re_frame/story/result_test.cljc
+++ b/tools/story/test/re_frame/story/result_test.cljc
@@ -283,7 +283,9 @@
       (is (= :pass (:status r)))
       (is (= 1 (count (filter #(= :rf.assert/schema-error (:assertion %))
                               (:assertions r)))))
-      (is (= 1 (count (:schema-violations r))) "the violation is still projected")))
+      (is (= 1 (count (:schema-violations r))) "the violation is still projected")
+      (is (= #{[:event :checkout/submit]} (:consumed-selectors r))
+          "rf2-uyebc — the consumed selector set is SURFACED on the result")))
 
   (testing "an UNEXPECTED schema violation FAILS the run (no expectation)"
     (let [r (result/run-result
@@ -319,6 +321,25 @@
           r    (result/run-result {:epoch-tape tape :app-db {:clean true}})]
       (is (= :fail (:status r)) "rollback to a clean db does NOT hide the tape violation")
       (is (= 1 (count (:schema-violations r)))))))
+
+(deftest run-result-surfaces-consumed-selectors
+  ;; rf2-uyebc — `run-result` computes the agreement-floor consumed-selector
+  ;; set anyway; it now SURFACES that value as `:consumed-selectors` so Test
+  ;; mode reads the single source of truth rather than re-deriving it.
+  (testing "always present — an empty `#{}` when nothing was consumed"
+    (let [r (result/run-result {:epoch-tape [(epoch {})]})]
+      (is (contains? r :consumed-selectors) "the slot is always assoc'd")
+      (is (= #{} (:consumed-selectors r)) "empty when no violations consumed")))
+  (testing "an explicit `:consumed-selectors` input is unioned with the
+            schema-expectation consumption and surfaced verbatim"
+    (let [extra [:cofx :pre-computed]
+          r     (result/run-result
+                  {:epoch-tape [(schema-epoch :event :checkout/submit)]
+                   :schema-expectations
+                   [[:rf.assert/schema-error {:where :event :event :checkout/submit}]]
+                   :consumed-selectors #{extra}})]
+      (is (= #{[:event :checkout/submit] extra} (:consumed-selectors r))
+          "the surfaced set is the UNION of the input + the matched consumption"))))
 
 ;; ===========================================================================
 ;; CAUSAL / CASCADE EXPECTATIONS (rf2-5x1wt.31, §Causal and cascade assertions)

--- a/tools/story/test/re_frame/story_ui_test.clj
+++ b/tools/story/test/re_frame/story_ui_test.clj
@@ -995,6 +995,50 @@
       (is (true?  (:consumed? (first rows)))  "exactly-consumed expected violation")
       (is (false? (:consumed? (second rows))) "unconsumed → agreement-floor failure")
       (is (= "invalid role" (:reason (second rows))))))
+  (testing "rf2-uyebc — schema-rows READS the result's `:consumed-selectors`
+            slot (single source of truth) rather than re-deriving it"
+    (let [result {:schema-violations
+                  [{:selector [:event :auth/login] :where :event
+                    :failing-id :auth/login :epoch-id 3}
+                   {:selector [:app-db [:user] [:role]] :where :app-db
+                    :failing-id nil :epoch-id 4 :reason "invalid role"}]
+                  :consumed-selectors #{[:event :auth/login]}
+                  :assertions []}
+          rows   (test-mode/schema-rows result)]
+      (is (true?  (:consumed? (first rows)))  "selector in :consumed-selectors")
+      (is (false? (:consumed? (second rows)))
+          "selector absent from :consumed-selectors")))
+  (testing "rf2-uyebc — when `:consumed-selectors` and the `:actual` of a
+            `:pass` schema-error record DIVERGE, schema-rows trusts the
+            canonical slot (proving it no longer re-derives from `:actual`)"
+    (let [result {:schema-violations
+                  [{:selector [:event :auth/login] :where :event}
+                   {:selector [:app-db [:user] [:role]] :where :app-db}]
+                  ;; canonical set consumes the SECOND selector …
+                  :consumed-selectors #{[:app-db [:user] [:role]]}
+                  ;; … but a stale `:pass` record's `:actual` names the FIRST.
+                  ;; If schema-rows re-derived from `:actual` the first row
+                  ;; would read :consumed?; reading the slot, the SECOND does.
+                  :assertions
+                  [{:assertion :rf.assert/schema-error :status :pass
+                    :actual [:event :auth/login]}]}
+          rows   (test-mode/schema-rows result)]
+      (is (false? (:consumed? (first rows)))
+          "first selector NOT in :consumed-selectors despite matching :actual")
+      (is (true?  (:consumed? (second rows)))
+          "second selector IS in :consumed-selectors — slot is authoritative")))
+  (testing "rf2-uyebc — empty `:consumed-selectors` present ⇒ nothing consumed
+            (the slot is honoured even when empty; no fallback re-derivation)"
+    (let [result {:schema-violations
+                  [{:selector [:event :auth/login] :where :event}]
+                  :consumed-selectors #{}
+                  ;; a :pass record exists, but the empty slot wins
+                  :assertions
+                  [{:assertion :rf.assert/schema-error :status :pass
+                    :actual [:event :auth/login]}]}
+          rows   (test-mode/schema-rows result)]
+      (is (false? (:consumed? (first rows)))
+          "empty :consumed-selectors ⇒ no re-derivation, nothing consumed")))
   (testing "no violations → empty"
     (is (= [] (test-mode/schema-rows {})))))
 


### PR DESCRIPTION
## rf2-uyebc — run-result discards `:consumed-selectors`, forcing Test-mode re-derivation

Review-wave finding (PR #2467 / ba86n.11).

### The discarded value
`re-frame.story.result/run-result` computes the agreement-floor consumed-selector set:

```clojure
consumed (into (or consumed-selectors #{}) (:consumed-selectors schema-match))
```

It uses `consumed` for the agreement floor (`evidence/evidence-shows-failure?`) — but the result-map assembly's `cond->` NEVER assoc'd `:consumed-selectors` onto the returned map; the value was discarded. So `ui/test_mode/pure.cljc`'s `schema-rows` RE-DERIVED the consumed set by scanning each `:rf.assert/schema-error :pass` record's `:actual`. A single-source-of-truth drift risk, correct today only because `:actual` happens to carry the consumed violation's selector.

### The fix (additive, minimal)

1. **`result.cljc` — surface the already-computed value.** The result-map `merge` now carries `:consumed-selectors consumed` (always present; `#{}` when nothing consumed, so the read needs no presence guard). This aligns code with the documented contract: the `run-result` docstring already documented `:consumed-selectors`, and the ns-level RUN-RESULT slot list now lists it as an output. Additive — no consumer breaks on the new key.

2. **`pure.cljc` — read, don't re-derive.** `schema-rows` now reads `:consumed-selectors` off the result map. A tolerant fallback re-derives from `:actual` ONLY when the key is absent (a legacy / partial result that predates the slot):

   ```clojure
   consumed (if (contains? result :consumed-selectors)
              (or (:consumed-selectors result) #{})
              ;; legacy fallback: re-derive from :rf.assert/schema-error :pass :actual
              ...)
   ```

### Tests
- `result_test.cljc`: `run-result` surfaces `:consumed-selectors` (the wiring test asserts the surfaced set; a new `run-result-surfaces-consumed-selectors` deftest covers the always-present empty `#{}` default and the input-union behaviour).
- `story_ui_test.clj`: `schema-rows` READS the slot, including a **divergence** case where the canonical `:consumed-selectors` and a stale `:pass` record's `:actual` name DIFFERENT selectors (proving it trusts the slot, not the re-derivation), plus an empty-slot case (the slot is honoured even when empty).

## Quality gates
- `clj-kondo --parallel --fail-level error --lint tools/story` — **0 errors** (123 pre-existing warnings, none in touched files).
- `tools/story` `clojure -M:test` — 1407 tests / 4851 assertions, 0 failures, 0 errors.
- `tools/story-mcp` `clojure -M:test` — 172 tests / 861 assertions, 0 failures, 0 errors.
- `implementation` `npm run test:cljs` — build 0 warnings; 4939 tests / 16192 assertions, 0 failures, 0 errors.
- `tools/mcp-conformance` `npm run test:story` — CONFORMANCE GREEN, exit 0.
- `bash scripts/test-fast-pr.sh` — PASS fast PR spine.