### PR TITLE
fix(story/promotion): reset promote-confirmation on open + flip stale spec/021 BLOCKED bullets (rf2-lc0cp + rf2-1w67a)

### DIFF
--- a/tools/story/spec/021-Story-UI-Test-And-Evidence.md
+++ b/tools/story/spec/021-Story-UI-Test-And-Evidence.md
@@ -50,7 +50,8 @@
   [`020-Story-UI-Inspector-And-Xray.md`](020-Story-UI-Inspector-And-Xray.md)
   §2.1.
 - Run-artifact promotion substrate for generated-failure promotion
-  (BLOCKED; §3).
+  (CURRENT — `re-frame.story.promotion` + its UI `re-frame.story.ui.promotion`
+  now exist; §3).
 
 ## Out of scope
 
@@ -110,8 +111,9 @@ Test mode SHOULD support:
 - cannot-run filtering;
 - per-assertion diff/detail;
 - copy repro as inline plan or run artifact;
-- promote generated failure to variant (§3, BLOCKED until run-artifact
-  promotion exists);
+- promote generated failure to variant (§3, CURRENT — the promotion UI
+  `re-frame.story.ui.promotion` over the run-artifact promotion substrate
+  now exists);
 - link assertion failures to the evidence spine and Xray focus (§2) where
   the result carries enough coordinates.
 

--- a/tools/story/src/re_frame/story/ui/promotion.cljc
+++ b/tools/story/src/re_frame/story/ui/promotion.cljc
@@ -294,10 +294,15 @@
    (def initial-dialog-state
      "Idle promotion-dialog state. `:open?` flips true on `open!`; the
      `:artifact-id` / `:draft` slots populate as the author drives the
-     flow."
+     flow. `:promoted-id` holds the registered id after a successful promote
+     (it gates the green confirmation) — it lives on the dialog state, NOT a
+     component-local ratom, so `open!`/`close!` reset it as part of the
+     lifecycle and a freshly-opened artifact always reads as un-promoted
+     (rf2-lc0cp)."
      {:open?       false
       :artifact-id nil
-      :draft       nil}))
+      :draft       nil
+      :promoted-id nil}))
 
 #?(:cljs
    (defonce ^{:doc "Reagent ratom holding the promotion dialog state."}
@@ -334,15 +339,29 @@
      (when (and config/enabled? (contains? @captured-atom artifact-id))
        (let [entry (get @captured-atom artifact-id)
              now   (.now js/Date)]
+         ;; Full reset (incl. `:promoted-id nil`) — a freshly-opened artifact
+         ;; ALWAYS reads as un-promoted; no stale confirmation from a prior
+         ;; artifact's promote leaks across (rf2-lc0cp).
          (reset! dialog-atom
                  {:open?       true
                   :artifact-id artifact-id
-                  :draft       (entry->initial-draft entry now)})
+                  :draft       (entry->initial-draft entry now)
+                  :promoted-id nil})
          nil))))
 
 #?(:cljs
    (defn close! []
      (reset! dialog-atom initial-dialog-state)
+     nil))
+
+#?(:cljs
+   (defn mark-promoted!
+     "Record `promoted-id` as the registered variant id after a successful
+     promote — gates the green confirmation. Stored on the dialog state (not
+     a component-local ratom) so the next `open!`/`close!` clears it as part
+     of the lifecycle (rf2-lc0cp)."
+     [promoted-id]
+     (swap! dialog-atom assoc :promoted-id promoted-id)
      nil))
 
 #?(:cljs
@@ -573,48 +592,52 @@
      Public so tests can render the dialog hiccup directly after seeding the
      dialog + capture ratoms."
      []
-     (let [promoted (r/atom nil)]
-       (fn []
-         (let [dialog @dialog-atom]
-           (when (:open? dialog)
-             (let [{:keys [artifact-id draft]} dialog
-                   entry      (get @captured-atom artifact-id)
-                   artifact   (:artifact entry)]
-               (when artifact
-                 (let [snippet  (promotion-snippet artifact draft)
-                       has-id?  (some? (:variant-id draft))
-                       rv-state {:open?     true
-                                 :draft-id  (:variant-id draft)
-                                 :source-id (:extends draft)}]
-                   (review-dialog/review-dialog rv-state
-                     {:title  "Promote captured run artifact to regression variant"
-                      :hint   [:div
-                               [:div (str "Promoting captured artifact "
-                                          (pr-str artifact-id)
-                                          " (" (:label entry) "). This is DISTINCT "
-                                          "from save-current-state — the source is a "
-                                          "captured run, not the live canvas. The "
-                                          "original artifact stays as evidence.")]
-                               (curation-controls artifact draft)
-                               (when-let [pid @promoted]
-                                 (promote-confirmation pid))]
-                      :snippet           snippet
-                      :placeholder-id    :story.regression/example
-                      :placeholder-input ":story.your-story/regression-042"
-                      :on-edit-id        set-draft-id!
-                      :on-copy           (fn [] (review-dialog/copy-to-clipboard! snippet))
-                      ;; rf2-ba86n.13 — the PRIMARY action drives the
-                      ;; substrate's `promote-run-artifact!` register path
-                      ;; (review-dialog renders it as the accent button left
-                      ;; of 'copy'). Disabled until the draft carries a
-                      ;; promoted id (the substrate throws on a missing id).
-                      :primary           {:label     "promote to variant"
-                                          :disabled? (not has-id?)
-                                          :title     (if has-id?
-                                                       "Register this curated regression variant"
-                                                       "Name the variant first (edit the id above)")
-                                          :on-click  (fn []
-                                                       (when-let [pid (promote! artifact-id draft)]
-                                                         (reset! promoted pid)))}
-                      :on-close          close!
-                      :data-test-prefix  "story-promotion"}))))))))))
+     ;; form-2 (the render closes over the dialog ratom deref each pass). The
+     ;; promote-confirmation gate reads `:promoted-id` from `dialog-atom` — NOT
+     ;; a component-local ratom — so `open!`/`close!` reset it as part of the
+     ;; lifecycle and a freshly-opened artifact never inherits a prior promote's
+     ;; stale confirmation (rf2-lc0cp).
+     (fn []
+       (let [dialog @dialog-atom]
+         (when (:open? dialog)
+           (let [{:keys [artifact-id draft promoted-id]} dialog
+                 entry      (get @captured-atom artifact-id)
+                 artifact   (:artifact entry)]
+             (when artifact
+               (let [snippet  (promotion-snippet artifact draft)
+                     has-id?  (some? (:variant-id draft))
+                     rv-state {:open?     true
+                               :draft-id  (:variant-id draft)
+                               :source-id (:extends draft)}]
+                 (review-dialog/review-dialog rv-state
+                   {:title  "Promote captured run artifact to regression variant"
+                    :hint   [:div
+                             [:div (str "Promoting captured artifact "
+                                        (pr-str artifact-id)
+                                        " (" (:label entry) "). This is DISTINCT "
+                                        "from save-current-state — the source is a "
+                                        "captured run, not the live canvas. The "
+                                        "original artifact stays as evidence.")]
+                             (curation-controls artifact draft)
+                             (when-let [pid promoted-id]
+                               (promote-confirmation pid))]
+                    :snippet           snippet
+                    :placeholder-id    :story.regression/example
+                    :placeholder-input ":story.your-story/regression-042"
+                    :on-edit-id        set-draft-id!
+                    :on-copy           (fn [] (review-dialog/copy-to-clipboard! snippet))
+                    ;; rf2-ba86n.13 — the PRIMARY action drives the
+                    ;; substrate's `promote-run-artifact!` register path
+                    ;; (review-dialog renders it as the accent button left
+                    ;; of 'copy'). Disabled until the draft carries a
+                    ;; promoted id (the substrate throws on a missing id).
+                    :primary           {:label     "promote to variant"
+                                        :disabled? (not has-id?)
+                                        :title     (if has-id?
+                                                     "Register this curated regression variant"
+                                                     "Name the variant first (edit the id above)")
+                                        :on-click  (fn []
+                                                     (when-let [pid (promote! artifact-id draft)]
+                                                       (mark-promoted! pid)))}
+                    :on-close          close!
+                    :data-test-prefix  "story-promotion"})))))))))

--- a/tools/story/test/re_frame/story/ui/promotion_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/promotion_cljs_test.cljc
@@ -294,3 +294,55 @@
            (is (= 0 (:setup-count draft)) "conservative cut — whole program is behaviour")
            (is (= :story.counter/happy (:extends draft))
                "extends the origin variant for component/decorator inheritance"))))))
+
+;; ===========================================================================
+;; CLJS-only: the promote-confirmation gate is part of the dialog lifecycle
+;; (rf2-lc0cp) — `mark-promoted!` records the green confirmation; `open!`
+;; resets it so a freshly-opened artifact ALWAYS reads as un-promoted.
+;; ===========================================================================
+
+#?(:cljs
+   (deftest mark-promoted-gates-confirmation-and-open-resets-it
+     (testing "the confirmation shows after mark-promoted! and clears on open!"
+       (reset! ui-promo/captured-atom {})
+       (reset! ui-promo/dialog-atom ui-promo/initial-dialog-state)
+       (let [art-a (artifact/make-run-artifact
+                     {:event-program [[:dispatch [:counter/inc]]]
+                      :seed          1 :result {:status :fail}})
+             art-b (artifact/make-run-artifact
+                     {:event-program [[:dispatch [:counter/dec]]]
+                      :seed          2 :result {:status :fail}})
+             id-a  (ui-promo/capture! art-a :story.counter/happy)
+             id-b  (ui-promo/capture! art-b :story.counter/happy)
+             comp  (ui-promo/promotion-dialog)
+             flat  #(str (comp))]
+         ;; --- promote A: confirmation appears ---
+         (ui-promo/open! id-a)
+         (is (not (str/includes? (flat) "story-promotion-confirmation"))
+             "a freshly-opened artifact reads as un-promoted")
+         (ui-promo/mark-promoted! :story.counter/regression-a)
+         (is (str/includes? (flat) "story-promotion-confirmation")
+             "after mark-promoted! the green confirmation renders")
+         (is (str/includes? (flat) "regression-a")
+             "the confirmation names the promoted id")
+         ;; --- open B: stale confirmation MUST NOT leak across (rf2-lc0cp) ---
+         (ui-promo/open! id-b)
+         (is (nil? (:promoted-id @ui-promo/dialog-atom))
+             "open! resets :promoted-id — B starts un-promoted")
+         (is (not (str/includes? (flat) "story-promotion-confirmation"))
+             "B shows NO stale 'Promoted to A' confirmation")
+         (is (not (str/includes? (flat) "regression-a"))
+             "no trace of A's promoted id on B's fresh dialog")))))
+
+#?(:cljs
+   (deftest close-resets-confirmation
+     (testing "close! clears a recorded confirmation as part of the lifecycle"
+       (reset! ui-promo/captured-atom {})
+       (reset! ui-promo/dialog-atom ui-promo/initial-dialog-state)
+       (let [id (ui-promo/capture! (sample-artifact) :story.counter/happy)]
+         (ui-promo/open! id)
+         (ui-promo/mark-promoted! :story.counter/regression-1)
+         (is (= :story.counter/regression-1 (:promoted-id @ui-promo/dialog-atom)))
+         (ui-promo/close!)
+         (is (nil? (:promoted-id @ui-promo/dialog-atom))
+             "close! returns the dialog to the idle, un-promoted state")))))


### PR DESCRIPTION
Two promotion-area finalization items from the ba86n.13 (#2475) review.

## rf2-lc0cp — stale promote-confirmation across artifacts (CORRECTNESS)

The promotion dialog''s green **"Promoted to X"** confirmation was gated by a form-2 component-local `promoted` ratom that `open!`/`close!` never reset — only a remount did, and the dialog is mounted **once** in `shell.cljs`. Repro: promote artifact A → close → open artifact B → B''s fresh dialog falsely showed "Promoted to A" before B was promoted.

**Fix (open! reset):** fold the confirmation state into the dialog state ratom (`dialog-atom`) as a `:promoted-id` slot — the single source `open!`/`close!` already reset wholesale. `open!` now resets `:promoted-id nil` explicitly; a new `mark-promoted!` transition records the id after a successful promote; the render reads `:promoted-id` from the dialog state instead of a closure-local ratom. A freshly-opened artifact therefore ALWAYS reads as un-promoted and the stale-confirmation leak is structurally impossible. The in-flight promote→confirm flow for the SAME artifact is unchanged (promote on-click → `mark-promoted!` → confirmation renders).

**Tests added** (`promotion_cljs_test.cljc`):
- `mark-promoted-gates-confirmation-and-open-resets-it` — promote A (confirmation renders), open B → B shows NO `story-promotion-confirmation` and no trace of A''s id.
- `close-resets-confirmation` — `close!` clears the recorded confirmation.

## rf2-1w67a — stale spec/021 BLOCKED bullets (SPEC CURRENCY)

`spec/021-Story-UI-Test-And-Evidence.md` still labelled promotion **BLOCKED** in two places, stale now that §3 + the promotion UI (`re-frame.story.ui.promotion`) shipped in ba86n.13 / #2475:
- **Depends-on** bullet ("Run-artifact promotion substrate … (BLOCKED; §3)") → **CURRENT**, naming the shipped substrate + UI.
- **§1 Test-mode** bullet ("promote generated failure to variant (§3, BLOCKED until run-artifact promotion exists)") → **CURRENT**, naming the shipped promotion UI.

Edits confined to those two stale bullets; matched the spec''s existing CURRENT/BLOCKED status-label vocabulary (§"Status labels"). §3 already read CURRENT.

## Quality gates
- `clj-kondo --parallel --fail-level error --lint tools/story` — **errors: 0** (only pre-existing warnings; none in promotion.cljc).
- `tools/story` `clojure -M:test` — **1406 tests / 4842 assertions / 0 failures, 0 errors**.
- `npm run test:cljs` — **4941 tests / 16200 assertions / 0 failures, 0 errors, 0 warnings**.
- `bash scripts/test-fast-pr.sh` — **PASS** (incl. markdown link/anchor gates for the spec/021 edit).