### PR TITLE
feat(story): terminal :assertions auto-run after script settles (rf2-nyjoa)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -887,9 +887,42 @@ the epoch-narrative work consumes).
 
 An assertion inside `:script` (via `[:assert …]`) is a **checkpoint**: it
 must be true at that exact point in the script. An assertion in
-`:assertions` is **terminal**: it runs after script completion. The same
+`:assertions` is **terminal**: it **AUTO-RUNS** after script completion and
+contributes a `:pass` / `:fail` verdict to the run result. The same
 expectation SHOULD NOT be duplicated in both places unless the timing
 distinction matters.
+
+**Terminal `:assertions` auto-run against the FINAL settled state.** After
+the script phase settles (after the auto-plays complete, or — for a variant
+with no script — after setup settles), the runtime EVALUATES every terminal
+`:assertions` entry and records its verdict as an assertion record on the
+frame's `:rf.story/assertions` slot, exactly like an in-script `[:assert …]`
+checkpoint. The two positions differ only in *when* the verdict runs:
+terminal = "check the FINAL settled state" (post-script), checkpoint =
+"check here, now" (at that exact script position). There is no
+"doc/explain-only" terminal assertion — a terminal `:assertions` entry is a
+live expectation that passes or fails the run.
+
+Terminal assertions route through the SAME executor the in-script
+checkpoints use, so they evaluate by the SAME family rules
+(§Script step runner, `[:assert …]`):
+
+- **Handler-backed (dispatchable) atoms** (`:rf.assert/path-equals` /
+  `path-matches` / `sub-equals` / `dispatched?` / `state-is` /
+  `no-warnings` / `effect-emitted`) are DISPATCHED into the frame; the
+  reg-event-fx handler records the canonical record.
+- **DOM-family atoms** are evaluated by the DOM executor (`:cannot-run`
+  under a headless runner).
+- **Tape-evaluated atoms** (`:rf.assert/schema-error`, the causal / cascade
+  family, the browser-tier oracle family) are NOT dispatched here — they are
+  minted by the result boundary against the epoch tape (§Schema rule,
+  §Causal and cascade assertions, §Visual, a11y, and browser checks), so the
+  terminal auto-run records a no-op for them and does NOT double-process the
+  verdict.
+
+This applies equally to **registered variants** and **inline plans** — both
+source their terminal atoms from the compiled plan's `[:expect :assertions]`
+and run them through the one terminal-assertion lifecycle step.
 
 ## Composition
 

--- a/tools/story/src/re_frame/story/play/runner_events.cljc
+++ b/tools/story/src/re_frame/story/play/runner_events.cljc
@@ -749,6 +749,64 @@
       :wait           (runner/step-skip idx step)   ; driver handles the actual sleep
       (runner/unknown-step idx step))))
 
+;; ---- terminal assertions (rf2-nyjoa) -------------------------------------
+;;
+;; A variant's terminal `:assertions` are the handler-backed "check the
+;; FINAL settled state" surface (spec/017 §Inline script assertions vs
+;; terminal assertions): each is the SAME assertion atom an in-script
+;; `[:assert …]` checkpoint wraps, but evaluated ONCE after the script
+;; phase has settled rather than at a mid-script point. Mike RULED B
+;; (rf2-nyjoa): they AUTO-RUN — they contribute `:pass` / `:fail` verdicts
+;; recorded as assertion-records on `:rf.story/assertions`, exactly like an
+;; in-script checkpoint.
+;;
+;; This reuses the ONE in-script executor (`exec-assert!`) rather than a
+;; parallel evaluator: each terminal atom is wrapped in its `[:assert …]`
+;; checkpoint shape and run through `exec-assert!`, which routes by atom
+;; family precisely as the mid-script position does —
+;;
+;;   - handler-backed atoms (`:rf.assert/path-equals` / `path-matches` /
+;;     `sub-equals` / `dispatched?` / `state-is` / `no-warnings` /
+;;     `effect-emitted`) are DISPATCHED through `settled-boundary`; the
+;;     reg-event-fx handler records the canonical record on the slot;
+;;   - DOM-family atoms are evaluated by the DOM executor;
+;;   - tape-evaluated atoms (`:rf.assert/schema-error`, the causal / cascade
+;;     family, the browser-tier oracle family) record a no-op step-skip and
+;;     are NEVER dispatched — the result boundary owns their verdict against
+;;     the epoch tape. So this path does NOT double-process the schema /
+;;     causal kinds the plan collector already feeds to `result/run-result`'s
+;;     tape matchers (rf2-nyjoa critical guard — the `exec-assert!`
+;;     `tape-evaluated-assertion?` branch is the single source of truth for
+;;     that split).
+
+(defn run-terminal-assertions!
+  "Evaluate `frame-id`'s terminal handler-backed `:assertions` against the
+  FINAL settled state, AFTER the script phase (rf2-nyjoa). `atoms` is the
+  plan's `[:expect :assertions]` vector — the bare assertion atoms
+  (`[:rf.assert/id & args]`), the same atoms an in-script `[:assert …]`
+  checkpoint wraps.
+
+  Each atom is wrapped in its canonical `[:assert atom]` checkpoint shape
+  and run through the ONE in-script executor (`exec-assert!`), so the
+  verdict lands on `:rf.story/assertions` via the SAME recording path the
+  mid-script checkpoints use — no parallel evaluator, no second record
+  shape. The per-atom step-results are discarded (terminal assertions are
+  not a runner step stream; their verdict is the slot record
+  `record-result-map` / `result/run-result` folds into the unified status).
+
+  The tape-evaluated families (schema-error / causal / browser-tier) carry
+  no reg-event-fx handler; `exec-assert!` records a no-op step-skip for them
+  and never dispatches — the result boundary already evaluates them against
+  the epoch tape from the plan, so they are NOT double-processed here.
+
+  Idempotent w.r.t. an empty / nil `atoms` (no-op). Production callers
+  (Story disabled) no-op."
+  [frame-id atoms]
+  (when (and config/enabled? (seq atoms))
+    (doseq [[idx atom-v] (map-indexed vector atoms)]
+      (exec-assert! frame-id idx [:assert atom-v])))
+  nil)
+
 ;; ---- single-step driver (rf2-ee38b.3 — step-debugger re-base) ------------
 ;;
 ;; The play step-debugger (`re-frame.story.ui.test-mode.stepper-state`)

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -633,6 +633,38 @@
     (loaders/finish-events! variant-id))
   ctx)
 
+(defn- settle-terminal-assertions!
+  "Evaluate the plan's terminal handler-backed `:assertions` against the
+  FINAL settled state (rf2-nyjoa — Mike RULED B: terminal `:assertions`
+  AUTO-RUN). Called AFTER the script phase settles (after the auto-plays
+  complete, or — for a variant with no script — after phase-2 setup), so the
+  terminal atoms read 'check the FINAL settled state' while an in-script
+  `[:assert …]` checkpoint stays 'check here, now'.
+
+  Routes through the SAME executor the in-script checkpoints use
+  (`runner-events/run-terminal-assertions!` → `exec-assert!`), so the
+  verdict lands on `:rf.story/assertions` via the ONE recording path —
+  `record-result-map` / `result/run-result` already folds that accumulator
+  into the unified `:pass` / `:fail`. The terminal atoms are the plan's
+  `[:expect :assertions]` (the SAME slot `plan-assertion-atoms` reads), so a
+  REGISTERED variant and an INLINE plan both route here.
+
+  The tape-evaluated kinds (`:rf.assert/schema-error`, the causal / cascade
+  family, the browser-tier oracle family) are NOT double-processed: they
+  carry no reg-event-fx handler, so `exec-assert!` records a no-op step-skip
+  for them and never dispatches — `result/run-result` already evaluates them
+  against the epoch tape from the plan's `:schema-expectations` /
+  `:causal-expectations` (collected by `plan-schema-expectations` /
+  `plan-causal-expectations`). Only the handler-backed terminal atoms (the
+  previously-inert surface) are evaluated here. Tolerant — any failure is
+  swallowed (record-don't-throw)."
+  [variant-id plan]
+  (try
+    (runner-events/run-terminal-assertions!
+      variant-id (get-in plan [:expect :assertions]))
+    (catch #?(:clj Throwable :cljs :default) _ nil))
+  nil)
+
 (defn- run-phase-4!
   "Phase 4: run the play-script. Returns `[ctx' play-promise]` — `ctx'`
   carries `:executed-script` (the folded steps the auto-plays ran, for the
@@ -672,7 +704,11 @@
           executed   (vec (mapcat :script auto-plays))
           ctx'       (assoc ctx :executed-script executed)]
       (if (empty? auto-plays)
-        [ctx' (async/resolved (read-assertions variant-id))]
+        ;; No script ran, but the world settled (phase-2 setup committed).
+        ;; The terminal `:assertions` check the FINAL settled state, so they
+        ;; still auto-run here (rf2-nyjoa).
+        [ctx' (async/resolved (do (settle-terminal-assertions! variant-id plan)
+                                  (read-assertions variant-id)))]
         [ctx'
          (async/promise
            (fn [resolve]
@@ -680,11 +716,13 @@
              ;; the folded `[:assert …]` checkpoints dispatch record into
              ;; `:rf.story/assertions` on the frame via the standard
              ;; assertion handlers. Once every auto-play has finished, the
-             ;; orchestrator builds the result map from the frame's
-             ;; accumulated assertions.
+             ;; terminal `:assertions` are evaluated against the FINAL
+             ;; settled state (rf2-nyjoa) and the orchestrator builds the
+             ;; result map from the frame's accumulated assertions.
              (letfn [(step! [remaining]
                        (if (empty? remaining)
-                         (resolve (read-assertions variant-id))
+                         (do (settle-terminal-assertions! variant-id plan)
+                             (resolve (read-assertions variant-id)))
                          (let [spec (first remaining)]
                            (runner-events/run! variant-id (:name spec) spec
                                                (fn [_state]

--- a/tools/story/test/re_frame/story/inline_plan_test.clj
+++ b/tools/story/test/re_frame/story/inline_plan_test.clj
@@ -87,6 +87,27 @@
       (is (= :fail (:status result)))
       (is (not (every? :passed? (:assertions result)))))))
 
+(deftest inline-plan-terminal-assertions-only-auto-run
+  (testing "an INLINE plan with ONLY a terminal :assertions block (no
+            in-script [:assert], no :script) AUTO-RUNS the terminal assertion
+            against the FINAL settled state and produces a verdict — the same
+            lifecycle a registered variant gets (rf2-nyjoa). Both a PASS and a
+            FAIL are pinned so the verdict is load-bearing, not vacuous."
+    (let [pass (run-target {:setup      [[:dispatch [:inline/set-status :loaded]]]
+                            :assertions [[:rf.assert/path-equals [:status] :loaded]]})]
+      (is (= :pass (:status pass))
+          "the inline terminal assertion auto-ran and passed → :pass")
+      (is (= :ready (:lifecycle pass)))
+      (let [rec (first (filter #(= :rf.assert/path-equals (:assertion %))
+                               (:assertions pass)))]
+        (is (some? rec) "the terminal assertion recorded with no checkpoint")
+        (is (true? (:passed? rec)))))
+    (let [fail (run-target {:setup      [[:dispatch [:inline/set-status :idle]]]
+                            :assertions [[:rf.assert/path-equals [:status] :loaded]]})]
+      (is (= :fail (:status fail))
+          "a failing inline terminal assertion flips the verdict to :fail")
+      (is (not (every? :passed? (:assertions fail)))))))
+
 (deftest inline-plan-setup-and-script-both-drive-state
   (testing "an inline plan's :setup establishes preconditions, :script runs after"
     (let [result (run-target {:setup  [[:dispatch [:inline/inc]]]

--- a/tools/story/test/re_frame/story/play/runner_events_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/play/runner_events_cljs_test.cljc
@@ -162,6 +162,66 @@
         (is (= 1 (:idx out)))
         (is (= step (:step out)))))))
 
+;; ---- CLJS+JVM: terminal assertions auto-run (rf2-nyjoa) -----------------
+;;
+;; `run-terminal-assertions!` is the lifecycle entry the runtime calls after
+;; the script phase settles. It reuses the ONE in-script executor
+;; (`exec-assert!`) per terminal atom, so a handler-backed atom records its
+;; verdict on `:rf.story/assertions` (same path the checkpoints use) and a
+;; tape-evaluated atom is NEVER dispatched (no double-processing). Exercised
+;; directly here on a live bridge frame on both runtimes.
+
+(defn- seed-db!
+  "Merge `m` into `bridge-frame`'s app-db via a real dispatch-sync, so the
+  terminal assertion has a FINAL settled state to read."
+  [m]
+  (rf/dispatch-sync [::seed-db m] {:frame bridge-frame})
+  (:rf.story/assertions (rf/get-frame-db bridge-frame)))
+
+(deftest run-terminal-assertions-records-handler-backed-pass-and-fail
+  (testing "run-terminal-assertions! dispatches each handler-backed terminal
+            atom through the ONE executor, recording the canonical pass/fail
+            record on :rf.story/assertions — no parallel evaluator"
+    (rf/reg-event-db ::seed-db (fn [db [_ m]] (merge db m)))
+    (seed-db! {:status :loaded})
+    (re/run-terminal-assertions!
+      bridge-frame
+      [[:rf.assert/path-equals [:status] :loaded]    ; passes
+       [:rf.assert/path-equals [:status] :idle]])    ; fails
+    (let [recs (vec (:rf.story/assertions (rf/get-frame-db bridge-frame)))
+          pe   (filterv #(= :rf.assert/path-equals (:assertion %)) recs)]
+      (is (= 2 (count pe)) "both handler-backed terminal atoms recorded")
+      (is (true?  (:passed? (first pe)))  "the matching expectation passed")
+      (is (false? (:passed? (second pe))) "the mismatching expectation failed"))))
+
+(deftest run-terminal-assertions-skips-tape-evaluated-no-double-process
+  (testing "a tape-evaluated terminal atom (:rf.assert/schema-error) is NOT
+            dispatched by run-terminal-assertions! — it carries no
+            reg-event-fx handler; the result boundary owns its verdict
+            against the tape, so no handler-backed record is minted here
+            (rf2-nyjoa critical guard against double-processing)"
+    (rf/reg-event-db ::seed-db (fn [db [_ m]] (merge db m)))
+    (seed-db! {:status :loaded})
+    (re/run-terminal-assertions!
+      bridge-frame
+      [[:rf.assert/path-equals [:status] :loaded]
+       [:rf.assert/schema-error {:where :event :event :some/evt}]])
+    (let [recs (vec (:rf.story/assertions (rf/get-frame-db bridge-frame)))]
+      (is (= 1 (count (filterv #(= :rf.assert/path-equals (:assertion %)) recs)))
+          "the handler-backed atom recorded exactly once")
+      (is (empty? (filterv #(= :rf.assert/schema-error (:assertion %)) recs))
+          "the tape-evaluated schema-error atom minted NO record here —
+           it is not dispatched (no double-processing)"))))
+
+(deftest run-terminal-assertions-empty-is-noop
+  (testing "run-terminal-assertions! with no atoms records nothing"
+    (rf/reg-event-db ::seed-db (fn [db [_ m]] (merge db m)))
+    (seed-db! {:status :loaded})
+    (re/run-terminal-assertions! bridge-frame [])
+    (re/run-terminal-assertions! bridge-frame nil)
+    (is (empty? (:rf.story/assertions (rf/get-frame-db bridge-frame)))
+        "an empty / nil terminal-assertions vector is a clean no-op")))
+
 ;; ---- CLJS-runnable: pure-data coverage of the script lift ---------------
 ;;
 ;; (rf2-uhq5j) the former `bare-event-vector-lift-via-coerce` test here

--- a/tools/story/test/re_frame/story_runtime_test.clj
+++ b/tools/story/test/re_frame/story_runtime_test.clj
@@ -928,6 +928,107 @@
           "the first play's checkpoint passed"))
     (story/destroy-variant! :story.plays/v)))
 
+;; ===========================================================================
+;; TERMINAL ASSERTIONS AUTO-RUN (rf2-nyjoa — Mike RULED B)
+;;
+;; The terminal `:assertions` slot is the handler-backed "check the FINAL
+;; settled state" surface. It AUTO-RUNS after the script phase settles and
+;; contributes :pass / :fail verdicts recorded as assertion records on the
+;; SAME `:rf.story/assertions` accumulator the in-script `[:assert …]`
+;; checkpoints write — folded into the unified `:status` by
+;; `result/run-result`. These pin the canonical reg-variant example (a
+;; variant with ONLY a terminal `:assertions` block, no in-script
+;; `[:assert]`), the pass + fail verdicts, and the no-double-processing
+;; guarantee for the tape-evaluated kinds.
+;; ===========================================================================
+
+(deftest run-variant-terminal-assertions-only-pass
+  (testing "the CANONICAL reg-variant example — a variant with ONLY a
+            terminal :assertions block (no in-script [:assert], no :script)
+            now AUTO-RUNS the terminal assertion against the FINAL settled
+            state and produces a :pass verdict (rf2-nyjoa)"
+    (rf/reg-event-db :test/seed-state
+      (fn [db _] (assoc-in db [:checkout :state] :submitted)))
+    (story/reg-variant :story.nyjoa/pass
+      {:setup      [[:test/seed-state]]
+       :assertions [[:rf.assert/path-equals [:checkout :state] :submitted]]})
+    (let [r (async/deref-blocking (story/run-variant :story.nyjoa/pass) 5000)]
+      (is (= :ready (:lifecycle r)))
+      (is (= :pass (:status r))
+          "the terminal assertion auto-ran and passed → :pass")
+      (let [rec (->> (:assertions r)
+                     (filter #(= :rf.assert/path-equals (:assertion %)))
+                     first)]
+        (is (some? rec)
+            "the terminal assertion was recorded on :rf.story/assertions
+             with no in-script checkpoint authoring it")
+        (is (true? (:passed? rec)))
+        (is (= [[:checkout :state] :submitted] (:payload rec)))))
+    (story/destroy-variant! :story.nyjoa/pass)))
+
+(deftest run-variant-terminal-assertions-only-fail
+  (testing "a FAILING terminal assertion (no in-script [:assert]) flips the
+            unified verdict to :fail (rf2-nyjoa)"
+    (rf/reg-event-db :test/seed-other
+      (fn [db _] (assoc-in db [:checkout :state] :draft)))
+    (story/reg-variant :story.nyjoa/fail
+      {:setup      [[:test/seed-other]]
+       :assertions [[:rf.assert/path-equals [:checkout :state] :submitted]]})
+    (let [r (async/deref-blocking (story/run-variant :story.nyjoa/fail) 5000)]
+      (is (= :ready (:lifecycle r)))
+      (is (= :fail (:status r))
+          "the terminal assertion auto-ran and failed → :fail")
+      (let [rec (->> (:assertions r)
+                     (filter #(= :rf.assert/path-equals (:assertion %)))
+                     first)]
+        (is (some? rec))
+        (is (false? (:passed? rec))
+            "the failing terminal assertion recorded :passed? false")))
+    (story/destroy-variant! :story.nyjoa/fail)))
+
+(deftest run-variant-terminal-assertion-evaluates-final-state-after-script
+  (testing "a terminal assertion evaluates the FINAL settled state — it sees
+            the state AFTER the script's dispatches commit, not the
+            pre-script state (rf2-nyjoa: terminal = check the FINAL state)"
+    (rf/reg-event-db :test/set-n (fn [db [_ n]] (assoc db :n n)))
+    (story/reg-variant :story.nyjoa/after-script
+      {:script     [[:dispatch [:test/set-n 7]]]
+       :assertions [[:rf.assert/path-equals [:n] 7]]})
+    (let [r (async/deref-blocking
+              (story/run-variant :story.nyjoa/after-script) 5000)]
+      (is (= 7 (-> r :app-db :n)) "the script dispatch committed")
+      (is (= :pass (:status r))
+          "the terminal assertion saw the post-script value 7"))
+    (story/destroy-variant! :story.nyjoa/after-script)))
+
+(deftest run-variant-terminal-tape-evaluated-not-double-counted
+  (testing "a tape-evaluated terminal assertion (:rf.assert/schema-error) is
+            NOT double-processed by the terminal auto-run — it carries no
+            reg-event-fx handler, so the auto-run records NO handler-backed
+            record for it; the result boundary owns its single verdict
+            against the epoch tape. Pinned alongside a handler-backed
+            terminal assertion in the same block so the split is exercised
+            (rf2-nyjoa critical guard)."
+    (rf/reg-event-db :test/seed-ok (fn [db _] (assoc db :ok? true)))
+    (story/reg-variant :story.nyjoa/mixed
+      {:setup      [[:test/seed-ok]]
+       :assertions [[:rf.assert/path-equals [:ok?] true]
+                    [:rf.assert/schema-error {:where :event :event :some/evt}]]})
+    (let [r (async/deref-blocking (story/run-variant :story.nyjoa/mixed) 5000)
+          path-recs (->> (:assertions r)
+                         (filter #(= :rf.assert/path-equals (:assertion %))))
+          schema-recs (->> (:assertions r)
+                           (filter #(= :rf.assert/schema-error (:assertion %))))]
+      (is (= 1 (count path-recs))
+          "the handler-backed terminal assertion recorded EXACTLY ONE record
+           (not double-counted)")
+      (is (true? (:passed? (first path-recs))))
+      (is (<= (count schema-recs) 1)
+          "the schema-error expectation is minted at most ONCE — by the
+           result boundary's tape matcher, NOT a second time by the terminal
+           auto-run dispatching a (non-existent) handler"))
+    (story/destroy-variant! :story.nyjoa/mixed)))
+
 (deftest run-variant-plan-error-projects-as-run-error
   (testing "a plan-construction failure (an [:assert …] checkpoint placed
             in :setup) surfaces through the run-error projection rather


### PR DESCRIPTION
Mike RULED **B** (rf2-nyjoa): terminal handler-backed `:assertions` AUTO-RUN. They are the "check the FINAL settled state" surface and must contribute `:pass` / `:fail` verdicts, recorded as assertion-records exactly like the in-script `[:assert …]` checkpoints.

## The lifecycle change

After the script phase settles — after the auto-plays complete, or, for a variant with no script, after phase-2 setup — `runtime/run-phase-4!` now evaluates the plan's terminal `[:expect :assertions]` via the new public `runner-events/run-terminal-assertions!`. That fn wraps each terminal atom in its `[:assert atom]` checkpoint shape and runs it through the ONE in-script executor (`exec-assert!`).

**No parallel evaluator.** The verdict lands on `:rf.story/assertions` via the SAME recording path the in-script checkpoints use; `result/run-result` already folds that accumulator into the unified `:status`. The terminal atoms are sourced from the compiled plan's `[:expect :assertions]` (the same slot `plan-assertion-atoms` reads).

Semantics: terminal `:assertions` = "check the FINAL settled state" (post-script); `[:assert …]` stays "check here, now."

## Handler-backed vs tape-evaluated (no double-processing)

`exec-assert!` routes by atom family, so the terminal auto-run inherits the exact split the checkpoint position already enforces:

- **Handler-backed** (`path-equals` / `path-matches` / `sub-equals` / `dispatched?` / `state-is` / `no-warnings` / `effect-emitted`) → DISPATCHED through `settled-boundary`; the reg-event-fx handler records the canonical record. These were the previously-INERT terminal surface — now evaluated.
- **DOM-family** → DOM executor (`:cannot-run` headless).
- **Tape-evaluated** (`:rf.assert/schema-error`, the causal/cascade family `:rf.assert/caused` / `:rf.assert/no-cascade-rerender`, the browser-tier oracle family) → carry NO reg-event-fx handler, so `exec-assert!` records a no-op step-skip and NEVER dispatches. The result boundary continues to own their verdict against the epoch tape (the plan's `:schema-expectations` / `:causal-expectations`, collected by `plan-schema-expectations` / `plan-causal-expectations`). The single classifier `tape-evaluated-assertion?` is the source of truth for the split, so they are NOT re-run here.

## Registered + inline coverage

Both the registered path (`run-variant`) and the inline path (`run-inline-plan`) route through the SAME shared `run-phase-4!` and source their terminal atoms from the compiled plan, so the lifecycle is identical for both.

## Canonical-example test

A variant with ONLY a terminal `:assertions` block (no in-script `[:assert]`, no script) now produces a verdict:
- registered: `run-variant-terminal-assertions-only-pass` (→ `:pass`) + `…-only-fail` (→ `:fail`) + `…-evaluates-final-state-after-script` + `…-tape-evaluated-not-double-counted`.
- inline: `inline-plan-terminal-assertions-only-auto-run` (pass + fail).
- executor-level (both runtimes): `run-terminal-assertions-records-handler-backed-pass-and-fail`, `…-skips-tape-evaluated-no-double-process`, `…-empty-is-noop`.

## spec/017 update

The §Inline script assertions vs terminal assertions section now states terminal `:assertions` AUTO-RUN against the FINAL settled state and contribute verdicts (recorded like an in-script checkpoint), with the handler-backed / DOM / tape-evaluated routing spelled out and the registered+inline equivalence noted — resolving the prior "doc/explain-only" ambiguity. Only that section was edited.

## Quality gates

- `clj-kondo --parallel --fail-level error --lint tools/story` — **0 errors** (123 pre-existing warnings, none in touched lines).
- `tools/story` `clojure -M:test` — 1416 tests, 4886 assertions, **0 failures, 0 errors**.
- `implementation` `npm run test:cljs` — 4944 tests, 16206 assertions, **0 failures, 0 errors, 0 warnings**.
- `tools/story-mcp` `clojure -M:test` — 172 tests, **0 failures, 0 errors**.
- `tools/mcp-conformance` `npm run test:story` — **STORY-MCP MCP-CLIENT CONFORMANCE GREEN**.
- `bash scripts/test-fast-pr.sh` — **PASS** (markdown link/anchor gates ran for the spec/017 edit; mkdocs soft-skipped locally).