### PR TITLE
StoryUI visual foundation: shared status/space tokens, canvas-first shell, Story↔Xray seam (rf2-ba86n.3)

### DIFF
--- a/tools/story/spec/016-Design-Tokens.md
+++ b/tools/story/spec/016-Design-Tokens.md
@@ -243,6 +243,88 @@ Per rf2-i3i5j AC#3 — **no hex literals at call sites in
 - [`014-Chrome-Features.md`](014-Chrome-Features.md) §Sidebar tag-as-
   badge affordance — the seven canonical tag-palette pairs.
 
+## §Status vocabulary (rf2-ba86n.3)
+
+> Shipped: [`theme/status.cljc`](../src/re_frame/story/theme/status.cljc).
+> Visual-foundation pass — [`018-Story-UI-North-Star.md`](018-Story-UI-North-Star.md) §12.6.
+
+### Lock
+
+The nine tool-wide status values (`:pending` / `:running` / `:pass` /
+`:fail` / `:error` / `:cannot-run` / `:blocked` / `:dirty` /
+`:redacted`) resolve through ONE shared constructor —
+`theme.status/descriptor` — so a status reads identically in every
+region (sidebar signal chip, sidebar status dot, test-mode result pill,
+evidence-spine beat, play-status banner). Before this namespace each
+region re-specified its own status→colour map; they agreed by
+convention, not by construction. Spec/018 §12.6 makes the vocabulary
+normative and tool-wide; this namespace makes it constructed.
+
+### The four discriminators (spec/018 §12.6)
+
+> Do not encode everything as red/green. `pending`, `fail`, `error`,
+> `cannot-run`, `blocked`, `dirty`, and `redacted` MUST remain
+> distinguishable in colour, **icon, text, and shape**.
+
+Each descriptor therefore carries four channels, not one:
+
+| Channel     | Slot                | Purpose                                                       |
+|-------------|---------------------|---------------------------------------------------------------|
+| Colour      | `:fg` `:bg` `:border` | resolved from `theme.colors/tokens` — zero raw hex            |
+| Icon        | `:glyph`            | one structural char (`✓ ✗ ! ⊘ ▣ ● ◌ ◐ ▢`) — survives HCM      |
+| Shape       | `:shape`            | `:solid` / `:outline` / `:dashed` / `:ring` / `:half`         |
+| Text        | `:label`            | canonical short human label                                    |
+
+Plus an `:emphasis` presentation hint (`:high` / `:normal` / `:low`)
+so regions can size/weight a status without re-deriving the priority
+order, and an `order` vector + `rollup` fn so an aggregate (a sidebar
+story row over many variants) surfaces its worst member.
+
+### Public API
+
+| Fn / def              | Use                                                          |
+|-----------------------|--------------------------------------------------------------|
+| `descriptor`          | full `{:fg :bg :border :glyph :shape :label :emphasis}` map  |
+| `chip-style`          | inline `:style` map (ground + fg + shape-derived border)     |
+| `fg` / `bg` / `glyph` / `label` | the individual channels                            |
+| `rollup`              | most-attention-demanding status from a seq (per `order`)     |
+| `order`               | canonical priority vector (error → … → pass)                 |
+
+### Zero-raw + single-source contract
+
+Status tints are NEVER respecified at a call site. `sidebar.cljs`'s
+`:signal-status-*` keys + `:dot-*` keys derive from `chip-style` / `fg`;
+test-mode + evidence regions consume the same constructor. A drift in
+one region is now impossible — there is one map.
+
+## §Spacing + radius rhythm (rf2-ba86n.3)
+
+> Shipped: [`theme/space.cljc`](../src/re_frame/story/theme/space.cljc).
+> Visual-foundation pass — [`018-Story-UI-North-Star.md`](018-Story-UI-North-Star.md) §12.2.
+
+### Lock
+
+Spacing keys onto a **4px base scale** (`:px-0` … `:px-8` → `0` … `32px`)
+and radius onto a tight five-step scale (`:none` / `:xs` / `:sm` /
+`:md` / `:pill`). Spec/018 §12.2 demands "high information density with
+stable spacing; strong alignment and grouping" — before this namespace
+the chrome's padding / gap / margin were scattered raw px strings, so
+the rhythm was implicit and drifted between regions (one panel `12px`,
+its sibling `10px`, no rule). The scale makes the rhythm constructed.
+
+### Public API
+
+| Fn / def        | Use                                                    |
+|-----------------|--------------------------------------------------------|
+| `scale`         | `{:px-0 … :px-8}` CSS-string map                       |
+| `pad` / `gap`   | `(pad 5)` → `"12px"`; `gap` aliases `pad`, named at call site |
+| `radius`        | `{:none :xs :sm :md :pill}` border-radius map          |
+
+Radius rounds **functionally, never decoratively** — chips/pills round
+`:pill` (10px), inputs/buttons `:sm` (3px), panels `:md` (4px); nothing
+rounds at a "large rounded decorative surface" scale (spec/018 §12.2
+explicitly rejects it).
+
 ## §Motion (rf2-3lt89)
 
 > Shipped: [`theme/motion.cljc`](../src/re_frame/story/theme/motion.cljc).

--- a/tools/story/src/re_frame/story/theme/colors.cljc
+++ b/tools/story/src/re_frame/story/theme/colors.cljc
@@ -139,6 +139,15 @@
    :row-fail-bg        "#2A1818"   ; failing test row tint
    :scrub-row-bg       "#1F2C3F"   ; scrubber-current row tint (cool blue)
 
+   ;; ── Story↔Xray seam (spec/018 §11 + §12.9) ──
+   ;; The RHS hosts Story (warm) above Xray (cool). The seam tokens give
+   ;; the Xray section header a COOL-violet cast that echoes Xray's own
+   ;; `#7C5CFF` identity, so the user reads 'diagnostic boundary' from
+   ;; temperature alone — without restyling Xray's panel interior. The
+   ;; seam is quiet: one accent, one border (spec/018 §12.9).
+   :seam-xray          "#9D8CFF"   ; cool-violet accent — the Xray section label
+   :seam-xray-soft     "#241F3A"   ; deep violet backdrop — the Xray header underline
+
    ;; ── per-tag palette (sidebar badges) ──
    :tag-dev-bg     "#1F2D44"
    :tag-dev-fg     "#9FC4FF"

--- a/tools/story/src/re_frame/story/theme/space.cljc
+++ b/tools/story/src/re_frame/story/theme/space.cljc
@@ -1,0 +1,89 @@
+(ns re-frame.story.theme.space
+  "Story spacing + radius rhythm tokens (spec/018 §12.2 — 'high
+  information density with stable spacing; strong alignment and
+  grouping').
+
+  Before this namespace the chrome's padding / gap / radius values were
+  scattered raw `\"6px\"` / `\"12px\"` / `\"3px\"` strings at call sites,
+  so the spacing rhythm was implicit and drifted between regions — one
+  panel padded `12px`, its sibling `10px`, with no rule. A workshop UI
+  the user leaves open all day lives or dies on stable spacing; this
+  namespace makes the rhythm a constructed 4px scale rather than a
+  per-call-site guess.
+
+  ## The 4px scale
+
+  Spacing keys onto a base unit of 4px — the smallest rhythm a dense
+  operator UI can afford while staying scannable. Every padding / gap /
+  margin in the chrome SHOULD resolve to one of these steps so regions
+  align to a shared grid.
+
+      :px-0   0      flush
+      :px-1   2px    hairline gap (chip-internal)
+      :px-2   4px    tight gap (signal chips, icon+label)
+      :px-3   6px    row gap
+      :px-4   8px    standard gap / section inner pad
+      :px-5  12px    region pad (the workshop default)
+      :px-6  16px    canvas frame pad / generous block
+      :px-7  24px    empty-state / dialog pad
+      :px-8  32px    hero empty-state pad
+
+  ## Radius scale
+
+  Story's surfaces round on a tight scale — chips/pills round fully
+  (`:pill`), inputs + panels round subtly (`:sm` / `:md`), nothing
+  rounds 'decoratively' (spec/018 §12.2 — avoid 'large rounded
+  decorative surfaces').
+
+      :none  0
+      :xs    2px    inline highlights, search-hit marks
+      :sm    3px    buttons, inputs
+      :md    4px    panels, mounted-panel hosts
+      :pill  10px   chips, badges, status pills
+
+  ## How call sites consume it
+
+      (:require [re-frame.story.theme.space :as space])
+
+      {:padding (space/pad 5)            ; \"12px\"
+       :gap     (space/gap 4)            ; \"8px\"
+       :border-radius (:pill space/radius)}
+
+  Pure data → data; JVM-portable."
+  {:no-doc true})
+
+(def scale
+  "The 4px spacing scale. CSS strings so call sites drop them straight
+  into inline `:style` maps. Keys are `:px-0` … `:px-8` so the rhythm
+  step reads at the call site."
+  {:px-0 "0"
+   :px-1 "2px"
+   :px-2 "4px"
+   :px-3 "6px"
+   :px-4 "8px"
+   :px-5 "12px"
+   :px-6 "16px"
+   :px-7 "24px"
+   :px-8 "32px"})
+
+(def ^:private step->key
+  {0 :px-0 1 :px-1 2 :px-2 3 :px-3 4 :px-4 5 :px-5 6 :px-6 7 :px-7 8 :px-8})
+
+(defn pad
+  "Return the CSS length for spacing step `n` (0–8). `(pad 5)` → \"12px\".
+  Out-of-range `n` clamps to the nearest end of the scale. Pure."
+  [n]
+  (get scale (step->key (-> n (max 0) (min 8))) "0"))
+
+;; `gap` is an alias for `pad` — same scale, named at the call site for
+;; flexbox `:gap` slots so the intent reads (a gap vs an inner pad).
+(def gap pad)
+
+(def radius
+  "Border-radius scale. Tight — Story rounds functionally, never
+  decoratively (spec/018 §12.2)."
+  {:none "0"
+   :xs   "2px"
+   :sm   "3px"
+   :md   "4px"
+   :pill "10px"})

--- a/tools/story/src/re_frame/story/theme/status.cljc
+++ b/tools/story/src/re_frame/story/theme/status.cljc
@@ -1,0 +1,214 @@
+(ns re-frame.story.theme.status
+  "Story's shared **status colour vocabulary** (spec/018 §12.6 + §11).
+
+  This is the single source of truth for the nine tool-wide status
+  values every Story region inherits — the sidebar signal chips, the
+  test-mode result rows, the evidence-spine beats, the play-status
+  banner, and the Story↔Xray seam all key off these tokens so a
+  `:pass` reads identically whether it is a sidebar dot, a result pill,
+  or an evidence beat.
+
+  ## Why a shared status layer
+
+  Before this namespace each region encoded its own
+  status→colour map (the sidebar's `:signal-status-*` keys, the
+  test-mode view's pass/fail pills, the play-status banner's tints).
+  The maps agreed by convention, not by construction — a drift in one
+  region produced a tool that read `:fail` as one red in the sidebar
+  and a different red in the result row. Spec/018 §12.6 makes the
+  vocabulary normative and tool-wide; this namespace makes it
+  *constructed* rather than *conventional*.
+
+  ## The contract (spec/018 §12.6)
+
+  > Do not encode everything as red/green. `pending`, `fail`, `error`,
+  > `cannot-run`, `blocked`, `dirty`, and `redacted` MUST remain
+  > distinguishable in colour, **icon, text, and shape**.
+
+  So each status carries FOUR discriminators, not one:
+
+  - `:fg` / `:bg` / `:border` — the colour treatment (resolved from
+    `theme.colors/tokens`; zero raw hex per rf2-i3i5j).
+  - `:glyph` — a single structural character (`✓ ✗ ! ⊘ ▣ ● ◌ ◐ ▢`) so
+    the state survives colour-blindness AND Windows High-Contrast Mode
+    (where `forced-colors` strips the inline colour — see
+    `theme.motion/motion-css`).
+  - `:shape` — `:solid` / `:outline` / `:dashed` / `:ring` — the chip /
+    dot border treatment, a third non-colour channel.
+  - `:label` — the canonical short human label.
+
+  Plus a presentation hint:
+
+  - `:emphasis` — `:high` / `:normal` / `:low`. `:fail` / `:error`
+    demand attention (`:high`); `:pass` recedes unless filtering
+    (`:low`); the rest sit at `:normal`. Regions MAY use this to size /
+    weight a status without re-deriving the priority order.
+
+  ## Nine canonical statuses
+
+  | status       | meaning (spec/018 §12.6)                                   |
+  |--------------|------------------------------------------------------------|
+  | `:pending`   | not yet run, currently running, or awaiting evidence       |
+  | `:running`   | a run is in flight (the live sibling of `:pending`)        |
+  | `:pass`      | settled success; low emphasis unless filtering             |
+  | `:fail`      | expectation failed; primary attention                      |
+  | `:error`     | tool/runtime/schema problem; DISTINCT from a failed expect |
+  | `:cannot-run`| required evidence or runner missing; neutral warning       |
+  | `:blocked`   | known-missing substrate or disabled unsafe operation       |
+  | `:dirty`     | current controls/render differ from the saved variant      |
+  | `:redacted`  | data was intentionally removed or hidden                   |
+
+  `:running` is split out from `:pending` because the live workshop
+  distinguishes \"queued\" from \"in flight\" — the spec lists `pending`
+  as covering both, so `:running` aliases to `:pending`'s neutral
+  posture but wears the warning hue + a half-ring shape so a run in
+  progress is legible at a glance. Callers that only model the spec's
+  eight may map `:running` → `:pending`.
+
+  ## How call sites consume it
+
+      (:require [re-frame.story.theme.status :as status])
+
+      ;; full descriptor (colour + glyph + shape + label + emphasis):
+      (status/descriptor :fail)
+      ;; => {:fg \"#F47171\" :bg \"#3F1818\" :border \"#F47171\"
+      ;;     :glyph \"✗\" :shape :outline :label \"Fail\" :emphasis :high}
+
+      ;; a chip / pill style map (drop into an inline :style):
+      (status/chip-style :cannot-run)
+
+      ;; just the foreground colour (e.g. for a dot / glyph tint):
+      (status/fg :pass)
+
+  Pure data → data; JVM-portable so the test corpus can assert the
+  vocabulary without a render pass."
+  {:no-doc true}
+  (:require [re-frame.story.theme.colors :as colors]))
+
+(def order
+  "Canonical priority order, most-attention-demanding first. Regions
+  that sort or roll up mixed-status sets (the sidebar story-row rollup,
+  the test-mode aggregate pill) walk this vector so a story carrying
+  one `:fail` among many `:pass`es surfaces the `:fail`."
+  [:error :fail :cannot-run :blocked :dirty :running :pending :redacted :pass])
+
+(def descriptors
+  "The canonical status → descriptor map. Each descriptor carries the
+  four discriminators spec/018 §12.6 mandates (colour / glyph / shape /
+  label) plus an `:emphasis` presentation hint. Colours resolve through
+  `theme.colors/tokens` — zero raw hex (rf2-i3i5j).
+
+  Shape vocabulary:
+  - `:solid`   — filled ground, no special border (settled states).
+  - `:outline` — 1px solid border in the fg colour (states that need a
+                 second channel: cannot-run, error).
+  - `:dashed`  — 1px dashed border (redacted — reads as 'removed').
+  - `:ring`    — transparent ground + neutral 1px ring (pending — the
+                 reserved-but-empty slot).
+  - `:half`    — a partial / in-flight treatment (running)."
+  {:pending    {:fg (:text-tertiary colors/tokens)
+                :bg "transparent"
+                :border (:border-default colors/tokens)
+                :glyph "◌" :shape :ring :label "Pending" :emphasis :low}
+   :running    {:fg (:warning colors/tokens)
+                :bg (:warning-bg colors/tokens)
+                :border (:warning colors/tokens)
+                :glyph "◐" :shape :half :label "Running" :emphasis :normal}
+   :pass       {:fg (:success colors/tokens)
+                :bg (:success-bg colors/tokens)
+                :border (:success colors/tokens)
+                :glyph "✓" :shape :solid :label "Pass" :emphasis :low}
+   :fail       {:fg (:danger colors/tokens)
+                :bg (:danger-bg colors/tokens)
+                :border (:danger colors/tokens)
+                :glyph "✗" :shape :solid :label "Fail" :emphasis :high}
+   ;; error is DISTINCT from fail — same danger hue but an OUTLINE so it
+   ;; never reads as a plain failed expectation (spec/018 §12.6).
+   :error      {:fg (:danger colors/tokens)
+                :bg (:danger-bg colors/tokens)
+                :border (:danger colors/tokens)
+                :glyph "!" :shape :outline :label "Error" :emphasis :high}
+   ;; cannot-run is a NEUTRAL warning, not a failure — warning hue on a
+   ;; neutral ground + outline so it reads 'could not observe', not 'bad'.
+   :cannot-run {:fg (:warning colors/tokens)
+                :bg (:bg-3 colors/tokens)
+                :border (:warning colors/tokens)
+                :glyph "⊘" :shape :outline :label "Can't run" :emphasis :normal}
+   :blocked    {:fg (:mono-1 colors/tokens)
+                :bg (:mono-3 colors/tokens)
+                :border (:mono-2 colors/tokens)
+                :glyph "▣" :shape :solid :label "Blocked" :emphasis :normal}
+   :dirty      {:fg (:accent-amber colors/tokens)
+                :bg (:accent-amber-soft colors/tokens)
+                :border (:accent-amber-deep colors/tokens)
+                :glyph "●" :shape :solid :label "Dirty" :emphasis :normal}
+   :redacted   {:fg (:text-tertiary colors/tokens)
+                :bg (:bg-3 colors/tokens)
+                :border (:border-strong colors/tokens)
+                :glyph "▢" :shape :dashed :label "Redacted" :emphasis :low}})
+
+(def ^:private fallback
+  "Unknown statuses degrade to `:pending`'s neutral descriptor rather
+  than blanking — a typo in a status keyword should still paint a
+  legible reserved slot, never throw."
+  (:pending descriptors))
+
+(defn descriptor
+  "Return the full descriptor map for `status`, or the neutral
+  `:pending` fallback when `status` is unknown / nil. Pure."
+  [status]
+  (get descriptors status fallback))
+
+(defn fg
+  "Foreground colour for `status` (the dot / glyph / text tint)."
+  [status]
+  (:fg (descriptor status)))
+
+(defn bg
+  "Background tint for `status` (the chip / pill ground)."
+  [status]
+  (:bg (descriptor status)))
+
+(defn glyph
+  "The structural discriminator glyph for `status` — the non-colour
+  channel that survives colour-blindness + Windows HCM."
+  [status]
+  (:glyph (descriptor status)))
+
+(defn label
+  "The canonical short human label for `status`."
+  [status]
+  (:label (descriptor status)))
+
+(defn- border-style
+  "Map a descriptor `:shape` to the CSS border the chip wears."
+  [{:keys [shape border]}]
+  (case shape
+    :outline (str "1px solid " border)
+    :dashed  (str "1px dashed " border)
+    :ring    (str "1px solid " border)
+    :half    (str "1px solid " border)
+    ;; :solid — no explicit border; the ground carries the signal.
+    nil))
+
+(defn chip-style
+  "Build an inline `:style` map for a status chip / pill. Composes the
+  descriptor's ground + foreground + the shape-derived border. Regions
+  layer their own padding / radius / type-scale on top — this fn owns
+  ONLY the status-bearing colour + shape so every region's chip reads
+  the same status the same way. Pure data → data."
+  [status]
+  (let [d (descriptor status)]
+    (cond-> {:background (:bg d)
+             :color      (:fg d)}
+      (border-style d) (assoc :border (border-style d)))))
+
+(defn rollup
+  "Given a seq of statuses, return the single most-attention-demanding
+  one per `order`. Empty / all-nil → `:pending`. Used by the sidebar
+  story-row rollup + any aggregate pill so a mixed set surfaces its
+  worst member. Pure."
+  [statuses]
+  (let [present (set (remove nil? statuses))]
+    (or (some present order)
+        :pending)))

--- a/tools/story/src/re_frame/story/ui/controls_styles.cljs
+++ b/tools/story/src/re_frame/story/ui/controls_styles.cljs
@@ -13,7 +13,7 @@
                  :color (:text-primary colors/tokens)
                  :font-family mono-stack
                  :font-size (:caption typography/type-scale)
-                 :border-top "1px solid #444"}
+                 :border-top (str "1px solid " (:border-default colors/tokens))}
    :section     {:margin-bottom "12px"}
    :section-h   {:font-weight "bold"
                  :color (:text-secondary colors/tokens)
@@ -31,7 +31,7 @@
                  :gap "8px"
                  :padding "2px 0"
                  :padding-left "12px"
-                 :border-left "1px solid #3a3a3a"
+                 :border-left (str "1px solid " (:border-strong colors/tokens))
                  :margin-left "4px"
                  :align-items "center"}
    :group-h     {:color (:info colors/tokens)
@@ -43,14 +43,14 @@
                  :font-size (:micro typography/type-scale)}
    :input       {:background (:bg-canvas colors/tokens)
                  :color (:text-primary colors/tokens)
-                 :border "1px solid #444"
+                 :border (str "1px solid " (:border-default colors/tokens))
                  :padding "2px 6px"
                  :font-family mono-stack
                  :font-size (:caption typography/type-scale)
                  :width "100%"}
    :textarea    {:background (:bg-canvas colors/tokens)
                  :color (:text-primary colors/tokens)
-                 :border "1px solid #444"
+                 :border (str "1px solid " (:border-default colors/tokens))
                  :padding "4px 6px"
                  :font-family mono-stack
                  :font-size (:caption typography/type-scale)
@@ -58,7 +58,7 @@
                  :min-height "48px"
                  :resize "vertical"}
    :color-input {:background (:bg-canvas colors/tokens)
-                 :border "1px solid #444"
+                 :border (str "1px solid " (:border-default colors/tokens))
                  :padding "0"
                  :width "36px"
                  :height "20px"
@@ -83,10 +83,10 @@
                  :font-size (:micro typography/type-scale)
                  :user-select "none"}
    :chip-active {:background (:accent-amber colors/tokens)
-                 :color "white"}
+                 :color (:text-on-accent colors/tokens)}
    :button      {:padding "4px 8px"
                  :background (:accent-amber colors/tokens)
-                 :color "white"
+                 :color (:text-on-accent colors/tokens)
                  :border "none"
                  :border-radius "3px"
                  :cursor "pointer"
@@ -95,7 +95,7 @@
    :rep-button  {:padding "2px 6px"
                  :background (:bg-3 colors/tokens)
                  :color (:text-primary colors/tokens)
-                 :border "1px solid #444"
+                 :border (str "1px solid " (:border-default colors/tokens))
                  :border-radius "3px"
                  :cursor "pointer"
                  :font-size (:micro typography/type-scale)
@@ -109,7 +109,7 @@
    ;; the two surfaces read as one validation language.
    :error       {:color (:danger colors/tokens)
                  :background (:danger-bg colors/tokens)
-                 :border-left "3px solid #ff4040"
+                 :border-left (str "3px solid " (:danger colors/tokens))
                  :padding "2px 6px"
                  :margin-top "2px"
                  :font-size (:micro typography/type-scale)}
@@ -117,7 +117,7 @@
    ;; render / test proof is gated until the violation clears.
    :banner      {:color (:danger colors/tokens)
                  :background (:danger-bg colors/tokens)
-                 :border "1px solid #ff4040"
+                 :border (str "1px solid " (:danger colors/tokens))
                  :border-radius "3px"
                  :padding "4px 6px"
                  :margin-bottom "6px"
@@ -134,7 +134,7 @@
    :reset-arg   {:padding "0 4px"
                  :background (:bg-3 colors/tokens)
                  :color (:text-secondary colors/tokens)
-                 :border "1px solid #444"
+                 :border (str "1px solid " (:border-default colors/tokens))
                  :border-radius "3px"
                  :cursor "pointer"
                  :font-size (:micro typography/type-scale)}

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -96,7 +96,6 @@
             [re-frame.story.ui.workspace :as workspace]
             [re-frame.story.backgrounds :as backgrounds]
             [re-frame.story.viewport :as viewport]
-            [re-frame.story.theme.colors :as colors]
             [re-frame.story.theme.depth :as depth]
             [re-frame.story.theme.motion :as motion]))
 
@@ -568,12 +567,15 @@
      ;; empty state when Xray is not on the classpath.
      [:section {:style (:rhs-section styles)
                 :data-rf-rhs-section "xray"}
+      ;; The Story↔Xray seam (spec/018 §12.9): this is the ONE RHS band
+      ;; whose header goes COOL. The violet accent + violet underline
+      ;; echo Xray's own identity so the diagnostic boundary reads from
+      ;; temperature alone — Story still owns the title row + chip row,
+      ;; only the accent points at the embedded surface.
       [:div {:style (merge (:rhs-section-h styles)
-                           (:rhs-section-h-accent styles))}
+                           (:rhs-section-h-xray styles))}
        [:span "Xray"]
-       [:span {:style {:font-weight "400"
-                       :color (:text-tertiary colors/tokens)
-                       :letter-spacing "0.04em"}}
+       [:span {:style (:rhs-section-sub-xray styles)}
         "diagnostic"]]
       [xray-embed/xray-embed-panel]]
      ;; rf2-ba86n.9 — Explain panel. The Story-owned provenance +
@@ -596,9 +598,7 @@
                   :data-rf-rhs-section "explain"}
         [:div {:style (:rhs-section-h styles)}
          [:span "Explain"]
-         [:span {:style {:font-weight "400"
-                         :color (:text-tertiary colors/tokens)
-                         :letter-spacing "0.04em"}}
+         [:span {:style (:rhs-section-sub styles)}
           "provenance + lowering"]]
         [explain-panel/explain-panel]])
      ;; rf2-ba86n.10 — Evidence spine. The Story-owned narrative/evidence
@@ -622,9 +622,7 @@
                   :data-rf-rhs-section "evidence"}
         [:div {:style (:rhs-section-h styles)}
          [:span "Evidence"]
-         [:span {:style {:font-weight "400"
-                         :color (:text-tertiary colors/tokens)
-                         :letter-spacing "0.04em"}}
+         [:span {:style (:rhs-section-sub styles)}
           "narrative + Xray focus"]]
         [evidence-spine/evidence-spine-panel]])
      (when (:controls vis)
@@ -632,9 +630,7 @@
                   :data-rf-rhs-section "controls"}
         [:div {:style (:rhs-section-h styles)}
          [:span "Controls"]
-         [:span {:style {:font-weight "400"
-                         :color (:text-tertiary colors/tokens)
-                         :letter-spacing "0.04em"}}
+         [:span {:style (:rhs-section-sub styles)}
           "args + modes"]]
         [controls/panel variant-id]])
      ;; rf2-q9kv5 — Dispatch Console panel. Free-form event dispatch into
@@ -669,9 +665,7 @@
                   :data-rf-rhs-section "dispatch"}
         [:div {:style (:rhs-section-h styles)}
          [:span "Dispatch"]
-         [:span {:style {:font-weight "400"
-                         :color (:text-tertiary colors/tokens)
-                         :letter-spacing "0.04em"}}
+         [:span {:style (:rhs-section-sub styles)}
           "free-form events"]]
         [dispatch-console/panel variant-id]])
      ;; Stage 6: render any registered :right-placement story panels.
@@ -775,11 +769,19 @@
        ;; (the user navigated FROM the rollup into a leaf).
        story-id [docs/docs-rollup-view story-id]
        :else
-       [:div {:style {:padding "32px"
-                      :color (:text-tertiary colors/tokens)
-                      :font-style "italic"
-                      :text-align "center"}}
-        "Select a variant or workspace from the sidebar."])]))
+       ;; Calm first-run / empty state (spec/018 §12.5). Not an
+       ;; explanatory poster — a quiet centred prompt on the transparent
+       ;; canvas that names what is missing (no selection) and the
+       ;; command available now (pick from the sidebar). The amber
+       ;; diamond echoes the sidebar's story glyph so the eye knows
+       ;; where to look.
+       [:div {:style       (:empty-canvas styles)
+              :data-test   "story-canvas-empty"}
+        [:div {:style (:empty-canvas-glyph styles)} "◆"]
+        [:div {:style (:empty-canvas-title styles)}
+         "No variant selected"]
+        [:div {:style (:empty-canvas-hint styles)}
+         "Pick a story, variant, or workspace from the sidebar to render it here."]])]))
 
 (defn shell
   "The top-level shell component. Composes the sidebar, main pane, and

--- a/tools/story/src/re_frame/story/ui/shell_styles.cljs
+++ b/tools/story/src/re_frame/story/ui/shell_styles.cljs
@@ -3,10 +3,35 @@
   dependency. Extracted from `shell.cljs` per rf2-gv5kq so the shell
   ns trends toward the 250-LoC leaf-size ceiling (rf2-zkca8).
 
+  ## Visual-foundation pass (rf2-ba86n.3, spec/018 §12)
+
+  This is the flagship shell composition the whole Story UI inherits.
+  The decisions here set the language every region picks up:
+
+  - **Canvas-first.** The shell reads as CANVAS (focal) flanked by
+    supporting rails. The main pane carries no chrome ground of its own
+    so the variant render surface is the visual protagonist (§12.1); the
+    sidebar + inspector sit one elevation back on `:bg-1` so the eye
+    lands on the work, not the frame.
+  - **Structural bands, not nested cards.** Page regions are panes /
+    bands (§12.2 — 'Page regions should be structural bands or panes,
+    not nested decorative cards'). Cards are reserved for repeated items
+    and dialogs, which live in their own region files.
+  - **The Story↔Xray seam (§12.9).** The RHS stacks Story-owned
+    sections (Explain / Evidence / Controls / Dispatch — WARM amber
+    section labels) above an embedded Xray panel (COOL-violet section
+    label). One border, one title row per section; the temperature
+    split tells the user 'Story brought me here; Xray is showing the
+    detail' without a stitched-together feel.
+  - **Shared tokens.** Spacing resolves through `theme.space` (the 4px
+    rhythm), colour through `theme.colors` (zero raw hex — rf2-i3i5j),
+    depth through `theme.depth`. No literal px / hex strings live here.
+
   CLJS-only."
-  (:require [re-frame.story.theme.typography :as typography :refer [sans-stack mono-stack]]
+  (:require [re-frame.story.theme.typography :as typography :refer [sans-stack]]
             [re-frame.story.theme.colors :as colors]
-            [re-frame.story.theme.depth :as depth]))
+            [re-frame.story.theme.depth :as depth]
+            [re-frame.story.theme.space :as space]))
 
 (def styles
   {:root      {:display "flex"
@@ -25,13 +50,20 @@
                :overflow "hidden"}
    :body-narrow {:flex-direction "column"
                  :overflow "auto"}
+   ;; CANVAS-FIRST (§12.1) — the main pane carries NO ground of its own.
+   ;; It sits transparent over the shell's atmospheric backdrop so the
+   ;; framed variant (which DOES carry `:bg-canvas` + the amber edge) is
+   ;; the only lifted surface in the centre column. The eye lands on the
+   ;; work, not on the chrome around it.
    :main      {:display "flex"
                :flex-direction "column"
                :flex "1"
                :min-width "0"
                :overflow "hidden"}
-   :right     {:width "320px"
-               :flex-shrink "0"
+   ;; The inspector rail sits ONE elevation back (:bg-1) from the canvas
+   ;; so it reads as supporting chrome, never as a competing surface
+   ;; (§12.4 — selected rendered state is the first visual priority).
+   :right     {:flex-shrink "0"
                :display "flex"
                :flex-direction "column"
                :border-left (str "1px solid " (:border-default colors/tokens))
@@ -41,13 +73,15 @@
    :right-narrow {:width "auto"
                   :max-height "42vh"
                   :border-left "none"
-                  :border-top "1px solid #444"}
+                  :border-top (str "1px solid " (:border-default colors/tokens))}
+   ;; The splitter is a quiet seam, not a chrome element — it reads as
+   ;; the edge between panes, lighting up amber only while dragged.
    :splitter  {:width "10px"
                :flex "0 0 10px"
-               :background (:bg-canvas colors/tokens)
+               :background "transparent"
                :border "0"
-               :border-left "1px solid #333"
-               :border-right "1px solid #333"
+               :border-left (str "1px solid " (:border-subtle colors/tokens))
+               :border-right (str "1px solid " (:border-subtle colors/tokens))
                :cursor "col-resize"
                :padding "0"
                :position "relative"}
@@ -57,22 +91,9 @@
                    :width "2px"
                    :height "36px"
                    :transform "translateY(-50%)"
-                   :background (:text-tertiary colors/tokens)
-                   :box-shadow "3px 0 0 #6a6a6a"}
+                   :border-radius (:pill space/radius)
+                   :background (:border-strong colors/tokens)}
    :splitter-active {:background (:accent-amber-soft colors/tokens)}
-   :tab-bar   {:display "flex"
-               :background (:bg-2 colors/tokens)
-               :border-bottom "1px solid #444"
-               :font-family mono-stack
-               :font-size (:caption typography/type-scale)}
-   :tab       {:padding "6px 12px"
-               :cursor "pointer"
-               :color (:text-secondary colors/tokens)
-               :border-right "1px solid #444"}
-   :tab-active {:color "white"
-                :background (:bg-canvas colors/tokens)
-                :border-bottom "1px solid #1e1e1e"
-                :margin-bottom "-1px"}
    ;; rf2-pxeko — `?` help-button chip lives top-LEFT of the viewport.
    ;; The top-RIGHT corner is reserved for the Test-Codegen REC chip
    ;; (`recorder/rec-chip` in the toolbar) plus the recording-overlay
@@ -82,37 +103,88 @@
    ;; conflict with the sidebar (which is part of the flex layout, not
    ;; fixed-positioned) or any other chrome affordance.
    :help-slot {:position "fixed"
-               :top      "8px"
-               :left     "12px"
+               :top      (space/pad 4)
+               :left     (space/pad 5)
                :z-index  1500}
-   ;; rf2-8rvu4 — RHS section headers. Pre-rf2-8rvu4 the right-panel
-   ;; stacked Xray / Controls / Dispatch console / panel registrations
-   ;; with only a thin border-top between widgets, reading as one tall
-   ;; column. The section-header pattern gives each widget a labelled
-   ;; band so the panel parses as N labelled sections.
+   ;; ── RHS section bands (§12.3 Inspector + §12.9 the Xray seam) ──
+   ;;
+   ;; Each inspector tenant (Xray / Explain / Evidence / Controls /
+   ;; Dispatch / story-panels) renders as a labelled structural band.
+   ;; Pre-rf2-8rvu4 the rail stacked widgets with only a thin border
+   ;; between them, reading as one tall column; the section-header
+   ;; pattern gives each widget a labelled band so the panel parses as
+   ;; N labelled sections. The visual-foundation pass keeps that shape
+   ;; and adds the Story↔Xray temperature seam.
    :rhs-section
-   {:padding        "12px 12px 0 12px"
+   {:padding        (str (space/pad 5) " " (space/pad 5) " 0 " (space/pad 5))
     :background     (:bg-1 colors/tokens)}
    :rhs-section-h
    {:display        "flex"
     :align-items    "center"
-    :justify-content "space-between"
+    :gap            (space/gap 3)
     :font-family    sans-stack
     :font-size      (:nano typography/type-scale)
     :font-weight    "600"
     :letter-spacing "0.08em"
     :text-transform "uppercase"
     :color          (:text-tertiary colors/tokens)
-    :margin-bottom  "8px"
-    :padding-bottom "6px"
-    ;; Section dividers vary in weight: an amber-tinted hairline
-    ;; replaces the uniform #444 line — same trick Xray uses for
-    ;; spine boundaries.
+    :margin-bottom  (space/pad 4)
+    :padding-bottom (space/pad 3)
+    ;; Story-owned sections wear a WARM amber-tinted hairline — the
+    ;; same trick Xray uses for its own spine boundaries, but in
+    ;; Story's identity colour so the band reads 'workshop'.
     :border-bottom  (str "1px solid " (:border-subtle colors/tokens))
     :box-shadow     (str "0 1px 0 " (:accent-amber-soft colors/tokens))}
-   :rhs-section-h-accent
-   {;; The Xray section gets a stronger accent so the diagnostic
-    ;; surface reads as the RHS's primary tenant.
-    :color (:accent-amber colors/tokens)}
+   ;; A muted sublabel that sits after the section title (e.g. 'args +
+   ;; modes', 'provenance + lowering') — the second word in the header
+   ;; row that tells the user what the band is for without a tooltip.
+   :rhs-section-sub
+   {:font-weight    "400"
+    :color          (:text-tertiary colors/tokens)
+    :letter-spacing "0.04em"}
+   ;; ── the Xray seam header (§12.9) ──
+   ;; The Xray band's header is the ONE place the RHS goes cool. The
+   ;; violet accent + violet-tinted underline echo Xray's own identity
+   ;; so the diagnostic boundary reads from temperature. Story still
+   ;; owns this chrome (the title row, the chip row below it) — only the
+   ;; ACCENT points at the embedded surface (§12.9 — 'Story owns outer
+   ;; inspector chrome … Xray owns diagnostic panel interiors').
+   :rhs-section-h-xray
+   {:color          (:seam-xray colors/tokens)
+    :box-shadow     (str "0 1px 0 " (:seam-xray-soft colors/tokens))}
+   :rhs-section-sub-xray
+   {:color          (:seam-xray colors/tokens)
+    :opacity        "0.7"}
    :rhs-section-body
-   {:padding-bottom "12px"}})
+   {:padding-bottom (space/pad 5)}
+   ;; ── calm empty state (§12.5) — 'no variant or workspace selected' ──
+   ;; Not an explanatory poster: a quiet centred prompt that names what
+   ;; is missing and the command available now (pick from the sidebar).
+   ;; Lives on the transparent main pane so it reads as 'the canvas is
+   ;; waiting', not as a chrome panel.
+   :empty-canvas
+   {:flex            "1"
+    :display         "flex"
+    :flex-direction  "column"
+    :align-items     "center"
+    :justify-content "center"
+    :gap             (space/gap 3)
+    :padding         (space/pad 8)
+    :text-align      "center"
+    :color           (:text-tertiary colors/tokens)}
+   :empty-canvas-glyph
+   {:font-size       (:hero typography/type-scale)
+    :color           (:accent-amber colors/tokens)
+    :opacity         "0.5"}
+   :empty-canvas-title
+   {:font-family     sans-stack
+    :font-size       (:display typography/type-scale)
+    :font-weight     (str (:semibold typography/weights))
+    :color           (:text-secondary colors/tokens)
+    :letter-spacing  (:display typography/letter-spacing)}
+   :empty-canvas-hint
+   {:font-family     sans-stack
+    :font-size       (:caption typography/type-scale)
+    :color           (:text-tertiary colors/tokens)
+    :max-width       "32ch"
+    :line-height     (:line-height-body typography/type-scale)}})

--- a/tools/story/src/re_frame/story/ui/sidebar_styles.cljs
+++ b/tools/story/src/re_frame/story/ui/sidebar_styles.cljs
@@ -6,7 +6,8 @@
   CLJS-only."
   (:require [re-frame.story.theme.typography :as typography :refer [mono-stack sans-stack]]
             [re-frame.story.theme.colors :as colors]
-            [re-frame.story.theme.motion :as motion]))
+            [re-frame.story.theme.motion :as motion]
+            [re-frame.story.theme.status :as status]))
 
 (def styles
   {:wrap         {:width "260px"
@@ -152,19 +153,23 @@
    :empty        {:color (:text-tertiary colors/tokens)
                   :font-style "italic"
                   :padding "8px 12px"}
-   ;; rf2-q0irb — status dot + chrome-level test widget.
+   ;; rf2-q0irb — status dot + chrome-level test widget. The dot tints
+   ;; derive from the SHARED status vocabulary (rf2-ba86n.3 —
+   ;; `theme.status`) so a `:pass` dot is the same green as a `:pass`
+   ;; signal chip / result pill. Pending shows an empty ring (the
+   ;; reserved-but-unrun slot).
    :dot          {:width "8px"
                   :height "8px"
                   :border-radius "50%"
                   :flex-shrink "0"
                   :display "inline-block"}
-   :dot-pass     {:background (:success colors/tokens)}
-   :dot-fail     {:background (:danger colors/tokens)}
-   :dot-running  {:background (:warning colors/tokens)
+   :dot-pass     {:background (status/fg :pass)}
+   :dot-fail     {:background (status/fg :fail)}
+   :dot-running  {:background (status/fg :running)
                   :opacity "0.7"}
    :dot-pending  {:background "transparent"
-                  :border "1px solid #5a5a5a"}
-   :widget       {:border-top "1px solid #333"
+                  :border (str "1px solid " (:border-strong colors/tokens))}
+   :widget       {:border-top (str "1px solid " (:border-default colors/tokens))
                   :margin-top "auto"
                   :padding "10px 12px"
                   :display "flex"
@@ -189,7 +194,7 @@
    :widget-btn   {:margin-top "4px"
                   :padding "4px 10px"
                   :background (:accent-amber colors/tokens)
-                  :color "white"
+                  :color (:text-on-accent colors/tokens)
                   :border "none"
                   :border-radius "3px"
                   :cursor "pointer"
@@ -209,7 +214,7 @@
    :watch-btn    {:padding         "2px 8px"
                   :background      "transparent"
                   :color           (:text-tertiary colors/tokens)
-                  :border          "1px solid #444"
+                  :border          (str "1px solid " (:border-default colors/tokens))
                   :border-radius   "10px"
                   :cursor          "pointer"
                   :font-family     mono-stack
@@ -220,7 +225,7 @@
                   :gap             "4px"}
    :watch-btn-on {:background (:success-bg colors/tokens)
                   :color      (:success colors/tokens)
-                  :border     "1px solid #4ec9b0"}
+                  :border     (str "1px solid " (:success colors/tokens))}
    ;; rf2-nwiwr — tag-as-badge affordance on variant rows.
    :tag-badges   {:display     "inline-flex"
                   :flex-wrap   "wrap"
@@ -312,26 +317,24 @@
                      :color         (:text-secondary colors/tokens)}
    ;; ── status axis (spec/018 §12.6 — distinguishable in colour, icon,
    ;;    text, and shape; NOT everything red/green) ──
-   :signal-status-pass       {:background (:success-bg colors/tokens) :color (:success colors/tokens)}
-   :signal-status-fail       {:background (:danger-bg  colors/tokens) :color (:danger  colors/tokens)}
-   ;; cannot-run is a neutral warning, NOT a failure (spec/018 §12.6).
-   :signal-status-cannot-run {:background (:bg-3 colors/tokens)
-                              :color (:warning colors/tokens)
-                              :border (str "1px solid " (:warning colors/tokens))}
-   ;; error is DISTINCT from fail — outlined danger so it never reads as a
-   ;; plain failed expectation.
-   :signal-status-error      {:background (:danger-bg colors/tokens)
-                              :color (:danger colors/tokens)
-                              :border (str "1px solid " (:danger colors/tokens))}
-   :signal-status-running    {:background (:warning-bg colors/tokens) :color (:warning colors/tokens)}
-   :signal-status-pending    {:background "transparent"
-                              :color (:text-tertiary colors/tokens)
-                              :border (str "1px solid " (:border-default colors/tokens))}
-   :signal-status-blocked    {:background (:mono-3 colors/tokens) :color (:mono-1 colors/tokens)}
-   :signal-status-dirty      {:background (:accent-amber-soft colors/tokens) :color (:accent-amber colors/tokens)}
-   :signal-status-redacted   {:background (:bg-3 colors/tokens)
-                              :color (:text-tertiary colors/tokens)
-                              :border (str "1px dashed " (:border-strong colors/tokens))}
+   ;;
+   ;; rf2-ba86n.3: the per-status tints now DERIVE from the shared status
+   ;; vocabulary (`theme.status/chip-style`) rather than being respecified
+   ;; here. This is the single-source-of-truth move — a `:fail` chip in
+   ;; the sidebar, a `:fail` pill in test mode, and a `:fail` evidence
+   ;; beat all resolve to the same colour + shape because they share one
+   ;; constructor. The shape discriminator (outline / dashed / ring)
+   ;; rides through `chip-style` so cannot-run / error / pending /
+   ;; redacted stay distinguishable beyond hue.
+   :signal-status-pass       (status/chip-style :pass)
+   :signal-status-fail       (status/chip-style :fail)
+   :signal-status-cannot-run (status/chip-style :cannot-run)
+   :signal-status-error      (status/chip-style :error)
+   :signal-status-running    (status/chip-style :running)
+   :signal-status-pending    (status/chip-style :pending)
+   :signal-status-blocked    (status/chip-style :blocked)
+   :signal-status-dirty      (status/chip-style :dirty)
+   :signal-status-redacted   (status/chip-style :redacted)
    ;; ── fidelity axis — purple-violet tint (shared with the :docs tag
    ;;    palette) so it reads as its own family, never as a world input ──
    :signal-fidelity {:background (:tag-docs-bg colors/tokens)

--- a/tools/story/src/re_frame/story/ui/test_mode/stepper_styles.cljs
+++ b/tools/story/src/re_frame/story/ui/test_mode/stepper_styles.cljs
@@ -56,7 +56,7 @@
                     :padding-bottom   "4px"
                     :padding-left     "10px"
                     :background       (:accent-amber colors/tokens)
-                    :color            "white"
+                    :color            (:text-on-accent colors/tokens)
                     :border-style     "solid"
                     :border-width     "1px"
                     :border-color     (:accent-amber colors/tokens)
@@ -99,7 +99,7 @@
                     :margin           "4px 0 2px 0"
                     :max-height       "180px"
                     :overflow-y       "auto"
-                    :border-top       "1px solid #2d2d30"
+                    :border-top       (str "1px solid " (:border-subtle colors/tokens))
                     :padding-top      "6px"}
    :step-row       {:display              "flex"
                     :align-items          "center"

--- a/tools/story/src/re_frame/story/ui/test_mode/view_styles.cljs
+++ b/tools/story/src/re_frame/story/ui/test_mode/view_styles.cljs
@@ -19,7 +19,7 @@
    :h1            {:font-family      mono-stack
                    :font-size        (:display typography/type-scale)
                    :font-weight      "bold"
-                   :color            "white"
+                   :color            (:text-primary colors/tokens)
                    :margin           "0 0 4px 0"}
    :sub           {:color            (:text-secondary colors/tokens)
                    :font-family      mono-stack
@@ -32,7 +32,7 @@
                    :margin           "12px 0 8px 0"}
    :rerun-btn     {:padding          "6px 14px"
                    :background       (:accent-amber colors/tokens)
-                   :color            "white"
+                   :color            (:text-on-accent colors/tokens)
                    :border           "none"
                    :border-radius    "3px"
                    :cursor           "pointer"
@@ -52,7 +52,7 @@
                    :font-size        (:micro typography/type-scale)
                    :letter-spacing   "0.5px"
                    :margin-bottom    "8px"
-                   :border-bottom    "1px solid #444"
+                   :border-bottom    (str "1px solid " (:border-default colors/tokens))
                    :padding-bottom   "4px"}
    :pill-row      {:display          "flex"
                    :align-items      "center"
@@ -95,12 +95,12 @@
                    :padding          "6px 8px"
                    :background       (:bg-2 colors/tokens)
                    :color            (:text-secondary colors/tokens)
-                   :border-bottom    "1px solid #444"
+                   :border-bottom    (str "1px solid " (:border-default colors/tokens))
                    :text-transform   "uppercase"
                    :font-size        (:micro typography/type-scale)
                    :letter-spacing   "0.5px"}
    :td            {:padding          "6px 8px"
-                   :border-bottom    "1px solid #2d2d30"
+                   :border-bottom    (str "1px solid " (:border-subtle colors/tokens))
                    :color            (:text-primary colors/tokens)
                    :vertical-align   "top"}
    :td-status     {:width            "20px"
@@ -120,7 +120,7 @@
                    :padding          "0"
                    :text-decoration  "underline"}
    :detail-box    {:background       (:bg-2 colors/tokens)
-                   :border-left      "3px solid #f48771"
+                   :border-left      (str "3px solid " (:danger colors/tokens))
                    :padding          "8px 12px"
                    :margin-top       "6px"
                    :color            (:text-primary colors/tokens)
@@ -182,7 +182,7 @@
                    :font-family      mono-stack
                    :font-size        (:micro typography/type-scale)}
    ;; checks grouped by check id (spec/021 §1)
-   :check-box     {:border           "1px solid #2d2d30"
+   :check-box     {:border           (str "1px solid " (:border-subtle colors/tokens))
                    :border-radius    "4px"
                    :margin-bottom    "6px"
                    :background       (:bg-2 colors/tokens)}
@@ -239,7 +239,7 @@
    ;; result → evidence link (spec/021 §2)
    :evidence-row  {:margin-top       "10px"
                    :padding          "8px 12px"
-                   :border           "1px dashed #3a3a3a"
+                   :border           (str "1px dashed " (:border-strong colors/tokens))
                    :border-radius    "4px"
                    :background       (:bg-2 colors/tokens)
                    :color            (:text-secondary colors/tokens)
@@ -252,7 +252,7 @@
    :scrub-wrap    {:margin           "8px 0 0 0"
                    :padding          "8px 10px"
                    :background       (:bg-2 colors/tokens)
-                   :border           "1px solid #3a3a3a"
+                   :border           (str "1px solid " (:border-strong colors/tokens))
                    :border-radius    "4px"}
    :scrub-h       {:font-weight      "bold"
                    :color            (:text-secondary colors/tokens)
@@ -287,7 +287,7 @@
                    :color            (:text-secondary colors/tokens)}
    :tick-skip     {:background       (:bg-2 colors/tokens)
                    :color            (:text-tertiary colors/tokens)}
-   :tick-selected {:outline          "2px solid #9cdcfe"
+   :tick-selected {:outline          (str "2px solid " (:info colors/tokens))
                    :outline-offset   "1px"}
    :scrub-slider  {:width            "100%"
                    :margin           "4px 0"}
@@ -300,7 +300,7 @@
                    :flex-wrap        "wrap"}
    :scrub-release {:padding          "2px 8px"
                    :background       (:border-strong colors/tokens)
-                   :color            "white"
+                   :color            (:text-primary colors/tokens)
                    :border           "none"
                    :border-radius    "3px"
                    :cursor           "pointer"

--- a/tools/story/src/re_frame/story/ui/xray_embed.cljs
+++ b/tools/story/src/re_frame/story/ui/xray_embed.cljs
@@ -185,16 +185,19 @@
                    :overflow "hidden"
                    :gap "8px"}
    ;; rf2-v1ach — chip-row picker. Sits above the mounted panel slot;
-   ;; the user clicks a chip to swap which panel renders. Uses Xray's
-   ;; cool slate palette via a thin amber-tinted seam — the chip-row
-   ;; is Story chrome (warm amber accents) but the chips themselves
-   ;; visually point at the Xray panel below.
+   ;; the user clicks a chip to swap which panel renders. The chip-row
+   ;; is Story-owned chrome but visually points at the Xray panel below.
+   ;; rf2-ba86n.3 — the chip-row's underline wears the cool Story↔Xray
+   ;; SEAM tint (spec/018 §12.9) so the whole Xray band — section header
+   ;; AND chip row — reads as the diagnostic boundary, distinct from the
+   ;; warm Story-owned sections stacked above it. One quiet border; Xray
+   ;; still owns the panel interior below.
    :chip-row      {:display "flex"
                    :align-items "center"
                    :gap "4px"
                    :flex-wrap "wrap"
                    :padding-bottom "6px"
-                   :border-bottom (str "1px solid " (:border-subtle colors/tokens))
+                   :border-bottom (str "1px solid " (:seam-xray-soft colors/tokens))
                    :font-family sans-stack}
    :chip          {:padding "3px 10px"
                    :background (:bg-3 colors/tokens)


### PR DESCRIPTION
## StoryUI visual foundation — shell, shared visual language, and the Story↔Xray seam (rf2-ba86n.3)

First-draft visual-foundation pass per **spec/018 §12** (the visual quality contract) and `ai/findings/StoryUI/10-visual-design-direction.md`. This sets the shared language every Story region inherits. **Draft for Mike's react-to-review — not auto-merged.**

The work is two layers: (1) a **shared theme layer** (new `status` + `space` token namespaces; the status vocabulary was previously re-specified per-region) and (2) **shell composition** (canvas-first hierarchy, calm empty state, and the Story↔Xray temperature seam). Region BODY logic is untouched — only shared tokens + the shell + per-region `*_styles.cljs` token-alignment.

### Visual decisions (where to look + react)

**Status colour vocabulary — now a single constructed source of truth.**
New `theme/status.cljc` is the canonical map for the nine tool-wide statuses (`pending / running / pass / fail / error / cannot-run / blocked / dirty / redacted`). Each carries **four discriminators** per §12.6 ("distinguishable in colour, icon, text, and shape"), not just hue:
- colour (`:fg/:bg/:border` from `colors/tokens`),
- a structural **glyph** (`✓ ✗ ! ⊘ ▣ ● ◌ ◐ ▢`) that survives colour-blindness + Windows HCM,
- a **shape** (`:solid / :outline / :dashed / :ring / :half`) as a third non-colour channel,
- a short **label**, plus an `:emphasis` hint + an `order`/`rollup` for aggregates.

`error` is danger-hued but **outlined** so it never reads as a plain `fail`; `cannot-run` is a neutral-ground warning outline (not a failure); `pending` is an empty ring; `redacted` is dashed. The sidebar's `:signal-status-*` and `:dot-*` keys now **derive** from `status/chip-style` / `status/fg` — a `:fail` is the same red+shape in a sidebar chip, a status dot, and (going forward) a result pill. Before this, regions agreed by convention; now by construction.

**Spacing rhythm.** New `theme/space.cljc` — a 4px base scale (`:px-0…:px-8`) + a tight radius scale (`:none/:xs/:sm/:md/:pill`). Replaces scattered raw-px guesses so regions align to one grid (§12.2 "stable spacing; strong alignment"). Radius rounds functionally, never decoratively.

**Palette + zero-raw cleanup.** Kept the locked warm-slate + amber identity. Added two seam tokens (`:seam-xray` cool-violet + `:seam-xray-soft`). Swept the remaining **VS-Code-Dark+ raw-hex residue** out of every `*_styles.cljs` (`#1e1e1e #2d2d30 #444 #333 #3a3a3a #9cdcfe #f48771 #ff4040 #4ec9b0 #5a5a5a #6a6a6a` + stray `"white"`) onto `colors`/`status` tokens — the zero-raw contract (rf2-i3i5j) now actually holds across the chrome.

**Canvas-first composition (§12.1/§12.4).** The main pane carries **no ground of its own** — it sits transparent over the shell backdrop so the variant render frame (which already wears `:bg-canvas` + the amber `:canvas-edge`) is the only lifted surface in the centre column. The inspector rail sits one elevation back (`:bg-1`). The eye lands on the work, not the chrome. The splitter is now a quiet hairline seam that lights amber only while dragged (was a heavy double-ruled grey bar).

**The Story↔Xray seam (§12.9) — the headline.** The RHS stacks Story-owned sections (Explain / Evidence / Controls / Dispatch — **warm amber** section labels + amber-tinted underline) above the embedded **Xray** band whose header + chip-row underline go **cool violet** (echoing Xray's own `#7C5CFF` identity). One border, one title row per section. The temperature split makes "Story brought me here; Xray is showing the detail" legible without restyling Xray's panel interior. Story still owns all the outer chrome; only the accent points at the embedded surface.

**Calm empty state (§12.5).** "No variant selected" is now a quiet centred prompt on the transparent canvas (amber diamond echoing the sidebar story glyph + a one-line "pick from the sidebar" hint) — not an italic throwaway, not an explanatory poster.

**Motion.** Untouched and honoured — the existing staggered shell-mount choreography + `prefers-reduced-motion` seam stand; nothing new animates.

### Key screens / states changed
- RHS inspector rail (Xray cool-seam header + chip row vs warm Story section headers).
- Empty canvas (`data-test="story-canvas-empty"`).
- Sidebar status dots + signal chips (now derived from shared status vocabulary).
- Splitter grip (quiet hairline).
- Controls / test-mode / stepper styling (token-aligned; behaviour unchanged).

### What I did NOT do (deferred polish)
- No region-body logic touched (sidebar.cljs / controls.cljs / canvas.cljs / docs.cljc / test_mode/ / promotion.cljc / evidence_spine.cljc / explain_panel.cljc behaviour unchanged).
- Did not rewire test-mode `:pill-*` / evidence beats to consume `status/chip-style` yet — that's a follow-on region pass (kept scope to the shell + the sidebar's derivation as the proof-of-pattern).
- No new motion choreography, no new keyboard commands, no responsive/bottom-sheet rework (existing rails + narrow-mode preserved).
- Did not touch the `framed-canvas` layout wrapper padding (behavioural layout, not shared language).
- spec/018 §12 left as-is (it is the contract; this PR implements it). Token contracts documented in **016-Design-Tokens.md** (the canonical token home) — added `§Status vocabulary` + `§Spacing + radius rhythm` sections.

### Files touched (all under `tools/story`)
- New: `theme/status.cljc`, `theme/space.cljc`
- `theme/colors.cljc` (+seam tokens), `ui/shell.cljs` (seam + empty state + dropped unused `colors` require), `ui/shell_styles.cljs` (rewrite: tokens + composition + seam), `ui/sidebar_styles.cljs` (status derivation + zero-raw), `ui/controls_styles.cljs`, `ui/test_mode/view_styles.cljs`, `ui/test_mode/stepper_styles.cljs`, `ui/xray_embed.cljs` (chip-row seam tint), `spec/016-Design-Tokens.md`.

## Quality gates
- **clj-kondo** `--parallel --fail-level error --lint tools/story`: **0 errors** (123 warnings — identical to baseline; zero new).
- **tools/story** `clojure -M:test`: 1408 tests / 4860 assertions, **0 failures, 0 errors**.
- **`npm run test:cljs`**: build 0 warnings; 4941 tests / 16200 assertions, **0 failures, 0 errors**.
- **`npm run test:bundle-isolation`**: PASS (35 internal sentinels absent; shell pulls no Xray internals into production bundles) + uix-helix-reagent-free PASS.
- **core JVM** `implementation/core` `clojure -M:test`: PASS.
- **markdown link/anchor + skill/MCP drift validators**: PASS (016 doc links resolve).
- `bash scripts/test-fast-pr.sh` aborted only on `python: command not found` in the bash login-shell (a known Windows-PATH quirk on this machine); each gate it would have run was executed directly and passed (validators run via PowerShell `python`).
