### PR TITLE
docs(story): correct :sub-overrides render-path docstrings + STOP-valve the core subscribe seam (rf2-7pgiz)

### DIFF
--- a/tools/story/src/re_frame/story/canonical.cljc
+++ b/tools/story/src/re_frame/story/canonical.cljc
@@ -58,11 +58,17 @@
    (defn- render-host-scope
      "A Reagent component that renders the active `:view` under the host
      substrate, binding the resolved `:sub-overrides` for the render extent
-     INSIDE the render fn (not at hiccup-construction time, which would have
-     unwound before React's deferred child render — the same pattern the
-     canvas's `sub-overrides-scope` uses). A design variant's pinned sub
-     values surface through `sub-overrides/read`; the binding never touches
-     app-db / `compute-sub`."
+     (the same pattern the canvas's `sub-overrides-scope` uses); the
+     binding never touches app-db / `compute-sub`.
+
+     NOTE (rf2-7pgiz): this binding is currently INERT — a design
+     variant's pinned sub values do NOT yet surface to a normally-authored
+     view. No subscribe seam consults `*overrides*`, and the dynamic
+     binding established here does not survive into the view's deferred
+     React render (the view's `@(rf/subscribe)` runs in its own reaction,
+     after this binding has unwound). Surfacing the override at render
+     needs a core subscribe shim — pinned + surfaced under rf2-7pgiz. See
+     `re-frame.story.sub-overrides` ns docstring §STATUS."
      [{:keys [view frame effective-args sub-overrides]}]
      (sub-overrides/with-overrides* sub-overrides
        (fn []

--- a/tools/story/src/re_frame/story/sub_overrides.cljc
+++ b/tools/story/src/re_frame/story/sub_overrides.cljc
@@ -44,9 +44,34 @@
   Every fn here is pure data → data, so the resolver is JVM-runnable and
   the test suite needs no host. The render path (`re-frame.story.ui.
   canvas`, CLJS) reads the plan's `[:world :render :sub-overrides]` map
-  and threads it through `with-overrides` so a Story-rendered view's
-  subscribed reads consult `resolve` first; production bundles elide the
-  whole runtime, so the binding is never set there."
+  and binds it through `with-overrides`; production bundles elide the
+  whole runtime, so the binding is never set there.
+
+  ## STATUS — the consuming subscribe-seam is NOT yet wired (rf2-7pgiz)
+
+  This namespace is the read-SIDE resolver, but as of rf2-7pgiz NO
+  subscribe / `compute-sub` / view-render seam consults it: a
+  normally-authored view's `@(rf/subscribe [:q])` hits the real
+  framework subscribe and the bound `*overrides*` map is never read, so
+  a `:sub-overrides` value does NOT actually surface at render. Two
+  facts compound here:
+
+    1. There is no consumer — `subscribe` does not check `*overrides*`.
+    2. Even if it did, a `binding`-bound dynamic var does NOT survive
+       into a view's DEFERRED React render: the canvas binds `*overrides*`
+       during the override-scope component's own render, but the view's
+       `@(rf/subscribe)` runs later, in its own reaction, with the binding
+       already unwound (empirically confirmed under react-dom/server —
+       a parent-render binding reads `:unbound` in a child component's
+       render). The robust survive-into-deferred-render mechanism is
+       React context, which is exactly what `re-frame.adapter.context`
+       uses to propagate the frame-id.
+
+  Mike RULED (a) on rf2-7pgiz: build the frame-scoped subscribe shim so
+  the override surfaces at render (zero-cost when unbound; stays a
+  labelled low-fidelity rung; honesty guarantee preserved). That seam is
+  a NEW core subscribe hook — high-stakes — so it is pinned + surfaced
+  for review under rf2-7pgiz rather than guessed at here."
   (:refer-clojure :exclude [resolve read]))
 
 ;; ============================================================================
@@ -105,9 +130,15 @@
   "Render-path read for a subscribed `query-v`: return the override value
   when one is registered for the active extent, otherwise call `real-read`
   (a 0-arg thunk that performs the genuine subscription) and return its
-  value. This is the seam a Story-rendered view's subscribed reads route
-  through so an override surfaces at render WITHOUT ever touching app-db
-  or `compute-sub`.
+  value. This is the resolve-or-fall-through helper the eventual
+  subscribe-seam will route through so an override surfaces at render
+  WITHOUT ever touching app-db or `compute-sub`.
+
+  NOTE (rf2-7pgiz): as of this commit NO subscribe / view-render seam
+  calls `read` — a normally-authored view's `@(rf/subscribe)` does not
+  route through here, so the override does not yet surface at render. See
+  the ns docstring §STATUS. `read` is exercised by the resolver tests
+  only until the core subscribe shim lands.
 
   `real-read` is invoked ONLY on a miss, so subscribing to a non-
   overridden query is exactly as it would be without overrides — no extra
@@ -131,9 +162,13 @@
    (defmacro with-overrides
      "Evaluate `body` with `*overrides*` bound to `overrides` for its
      dynamic extent. Sugar over `with-overrides*`. The Story render path
-     wraps the variant's view render in this so a `read`-through
-     subscribed value surfaces an override; outside the binding (and in
-     production) every `read` falls through to the real subscription."
+     wraps the variant's view render in this; outside the binding (and in
+     production) `*overrides*` is nil and `resolve` always misses.
+
+     NOTE (rf2-7pgiz): binding `*overrides*` here is currently INERT for a
+     normally-authored view — no subscribe seam consults it, and the
+     dynamic binding does not survive into the view's deferred React
+     render. See the ns docstring §STATUS."
      [overrides & body]
      `(binding [*overrides* ~overrides]
         ~@body)))

--- a/tools/story/src/re_frame/story/ui/canvas.cljs
+++ b/tools/story/src/re_frame/story/ui/canvas.cljs
@@ -298,10 +298,16 @@
 ;; override map (arg-substituting `[:arg key]` placeholders against the
 ;; effective args, the SAME one-level substitution the plan compiler uses)
 ;; and binds it through `sub-overrides/with-overrides*` for the view-
-;; render extent. A Story-rendered view's subscribed reads that route
-;; through `sub-overrides/read` then surface the override; the binding
-;; never touches app-db or `compute-sub`, so it cannot satisfy a
-;; subscription assertion (`:rf.assert/sub-equals`).
+;; render extent. The binding never touches app-db or `compute-sub`, so
+;; it can never satisfy a subscription assertion (`:rf.assert/sub-equals`).
+;;
+;; STATUS (rf2-7pgiz): this binding is currently INERT — a normally-
+;; authored view's subscribed reads do NOT yet surface the override. No
+;; subscribe seam consults `sub-overrides/read` / `*overrides*`, and the
+;; dynamic binding established below does not survive into the view's
+;; deferred React render. Surfacing the override at render needs a core
+;; subscribe shim — pinned + surfaced under rf2-7pgiz. See the
+;; `re-frame.story.sub-overrides` ns docstring §STATUS.
 
 (defn- resolve-sub-overrides
   "Return the variant's resolved `:sub-overrides` map (exact query
@@ -317,16 +323,23 @@
 
 (defn sub-overrides-scope
   "A Reagent component that binds the variant's resolved `:sub-overrides`
-  map for its child's render extent so a Story-rendered view's subscribed
-  reads (routed through `re-frame.story.sub-overrides/read`) surface the
-  override. The binding is established INSIDE this component's render fn —
-  not at the caller's hiccup-construction time — so it is live when React
-  renders the wrapped subtree (a `binding` at hiccup-construction time
-  would have unwound before the deferred child render).
+  map for its child's render extent. The binding never touches app-db /
+  `compute-sub`.
 
-  When the variant authors no overrides the map is nil; every `read`
-  then misses and the view reads its real subscription, so this wrapper
-  is render-transparent in the common case."
+  STATUS (rf2-7pgiz): this binding is currently INERT for a normally-
+  authored view. Two facts compound: (1) no subscribe seam consults
+  `*overrides*` / `re-frame.story.sub-overrides/read`; (2) the dynamic
+  binding established in THIS component's render does NOT survive into the
+  wrapped view's render — the child view renders in its own reaction,
+  after this `binding` has unwound, so its `@(rf/subscribe)` reads the
+  real subscription (empirically confirmed under react-dom/server). The
+  robust survive-into-deferred-render mechanism is React context (what
+  `re-frame.adapter.context` uses for the frame-id). Surfacing the
+  override at render needs a core subscribe shim — pinned + surfaced under
+  rf2-7pgiz. See the `re-frame.story.sub-overrides` ns docstring §STATUS.
+
+  When the variant authors no overrides the map is nil and this wrapper is
+  render-transparent."
   [overrides child]
   (sub-overrides/with-overrides* overrides (fn [] child)))
 


### PR DESCRIPTION
## Summary — STOP-VALVE hit; doc corrections landed

Bead **rf2-7pgiz**: Mike RULED (a) — build the frame-scoped subscribe shim so a normally-authored view's `@(rf/subscribe [:q])` surfaces a `:sub-overrides` value at render (zero-cost when unbound; stays a labelled low-fidelity rung; honesty guarantee preserved). The bead carries an explicit STOP-valve: *if making this work cleanly requires a NEW core subscribe API/hook, do not guess — implement as far as is clean, then STOP and surface the design.*

**I hit the STOP-valve.** Surfacing the override to a normally-authored view requires a **new core subscribe seam**, which is high-stakes and must be reviewed before implementing. This PR lands the honesty-preserving **doc corrections only** and surfaces the pinned design below. **rf2-7pgiz stays OPEN.**

## The seam — pinned (with empirical proof)

I traced the full path: view `@(rf/subscribe [:q])` → `re-frame.subs/subscribe` (returns a reaction the view derefs) → build-and-cache against the frame app-db. The bound `re-frame.story.sub-overrides/*overrides*` is **never consulted** anywhere on this path (confirmed: no existing core late-bind hook substitutes a sub value — the `:views/*` hooks in `subscribe` are observational only).

Two facts compound, the second decisive:

1. **No consumer.** `subscribe` does not check `*overrides*`. (This is the bead's headline gap.)
2. **A dynamic-var binding does NOT survive into a view's deferred React render.** I proved this with a react-dom/server probe (then deleted it):
   - Parent component binds a dynamic var in its render, returns child **in component position** → child render reads `:unbound`.
   - Parent **calls the view fn directly inside the binding** → view body reads `:bound`.

   In the real canvas tree the view is several component-position layers deep (frame-provider + `:hiccup` decorators), so the binding is unwound by the time the view's `subscribe` runs. The mechanism that DOES survive arbitrary component nesting is **React context** — exactly what `re-frame.adapter.context` already uses to propagate the frame-id into deferred child renders (`function-component-current-frame` reads `_currentValue`).

**Conclusion:** the existing `*overrides*` dynamic var is structurally insufficient for the real tree. The robust seam mirrors the frame-id precedent.

## Proposed core-seam design (for review — NOT implemented)

1. **Carry the override map via React context**, like the frame-id. Either a new `createContext` in `re-frame.adapter.context` (CLJS-only, DCE'd in prod) or a Story-owned context object. Story's `sub-overrides-scope` / `render-host-scope` wrap the view in this Provider (survives decorator/provider nesting). The dynamic var `*overrides*` is kept only as a JVM/test convenience (the resolver tests use it) — the render-path source of truth becomes the context.
2. **New core late-bind hook** consulted in `re-frame.subs/subscribe`, e.g. `:subs/resolve-sub-override` — published CLJS-only by the adapter/Story, reading the override context's `_currentValue`. In `subscribe`, gated by `interop/debug-enabled?` (`goog/DEBUG`, the same elision gate the existing `:views/*` subscribe hooks use): when the hook is published AND resolves a hit for `query-v`, return a constant reaction — `(adapter/make-derived-value [] (constantly override-value))` — instead of build-and-cache. On a miss (or unbound hook, or production) fall through unchanged.
3. **Zero-cost when unbound:** under `:advanced` + `goog.DEBUG=false` the whole block DCEs (proven pattern — identical to the two `:views/*` hooks already in `subscribe`). In dev when no override context is active the hook resolves a miss cheaply. **Bundle-isolation holds structurally** — core stays tools-free; Story/adapter publishes the hook.
4. **Honesty guarantee untouched:** the override feeds only the reaction the view derefs; it never writes app-db and never reaches `compute-sub`, which `:rf.assert/sub-equals` uses. So an override still cannot satisfy a subscription assertion.

**Why surfaced, not implemented:** this adds a new value-substitution hook to the production subscribe path + a context object + reactivity semantics. Per the STOP-valve and the "core changes are high-stakes" stance, this needs a mayor/Mike go before landing.

## What this PR DOES land — doc corrections (honesty)

The over-claiming docstrings the bead lists now state the binding is currently **inert** and point at a new `re-frame.story.sub-overrides` ns `§STATUS` note:
- `sub_overrides.cljc` — ns docstring (added §STATUS), `read`, `with-overrides`.
- `canonical.cljc` — `render-host-scope` docstring.
- `canvas.cljs` — `sub-overrides-scope` docstring + the section comment block (lines ~302/321). Doc-only, as scoped by the bead.

No executable code changed (diff is docstrings/comments only).

## Acceptance e2e test — deferred with the seam

The bead's e2e gate (a normally-authored view rendered through the canvas with a `:sub-overrides` for `[:q]` shows the override value) lands **with** the core seam — adding a passing version now would be misleading while the path is inert. The honesty-guarantee tests (`override-does-not-leak-into-compute-sub`, `read-seam-surfaces-override-without-touching-db`) already exist and stay green.

## Quality gates
- `clj-kondo --parallel --fail-level error --lint` on all three files: **0 errors** (1 pre-existing unrelated `re-frame.story.render` unused-require warning, present on stock origin/main).
- `npm run test:cljs` (node-test compile + run): **4944 tests, 16206 assertions, 0 failures, 0 errors**.
- Story JVM `clojure -M:test`: **1416 tests, 4886 assertions, 0 failures, 0 errors**.
- bundle-isolation: structurally unaffected — doc-only edits to Story tools, no new requires, no core touch, no production code path changed.