### PR TITLE
feat(story): wire requirements selection + a11y-structural executor into the run path (rf2-baah3 + rf2-9ikj0)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -1626,6 +1626,29 @@ Because the check reads the SAME `project-evidence` projection the
 run-result slots derive from, a duplicate accumulator cannot report green
 while the tape is empty.
 
+### Run-path wiring (rf2-baah3)
+
+The run path (`re-frame.story.runtime` — `run-variant` / `run-inline-plan`)
+THREADS this registry end-to-end, so the selection + refusal + validation
+above are run-time behaviour, not merely pure facts the registry can
+compute:
+
+1. it normalizes the run opts (`normalize-run-opts`) and SELECTS the runner
+   (`select-runner`) from the plan's `:required-runner` once, up front (the
+   cheapest capable runner under `:auto`, or the caller's fixed runner);
+2. it surfaces the chosen `:runner` and the plan's `:required-runner` on the
+   unified result;
+3. it folds the per-requirement refusals into the result's `:unmet` /
+   `:cannot-run` slot — the `:auto` no-capable-runner refusal, the
+   fixed-runner per-unit `unmet-assertions` / `unmet-steps` gaps, AND the
+   post-run `validate-run-evidence` fail-closed slot check (read against the
+   SAME `project-evidence` projection the result slots derive from).
+
+So an UNMET requirement (a `:pixels` `:rf.assert/visual-snapshot` under
+`:headless`) makes the run `:cannot-run` — the distinct THIRD status — never
+a false pass; a met-and-passing headless run is not falsely refused (the
+empty-is-healthy slots impose no gate).
+
 ### MCP is a frame binding, not a runner tier
 
 MCP is NOT a runner. It is a transport/control surface over the same
@@ -2358,6 +2381,27 @@ a differ or a second axe loader:
   seam (`register-a11y-reader!`); the below-the-UI `.cljc` executor reads
   through it without a compile-time dependency on the UI ns (the
   bundle-isolation rule: nothing in a production path `:require`s the UI).
+
+### Run-path routing (rf2-9ikj0)
+
+The browser-tier executor is reached from the run path the SAME way the DOM
+family is: the in-script `[:assert …]` executor
+(`re-frame.story.play.runner-events`) routes a browser-tier oracle atom to
+`browser/eval-browser-assertion` and records its canonical assertion record
+on the frame's accumulator (the terminal `:assertions` route through the
+SAME executor). It is NOT classified as a tape-evaluated family — it has its
+own executor, so a `:rf.assert/a11y-structural` checkpoint EVALUATES rather
+than recording a no-op skip.
+
+`:rf.assert/a11y-structural` walks the rendered hiccup TREE, which the run
+path supplies through the `:render-hiccup` late-bind seam (`frame-id →
+hiccup-tree`): a `:hiccup`-or-richer host installs it so the structural-a11y
+check runs on the normal test path. When NO tree is available (the bare
+headless floor — no `:render-hiccup` host), the check FAILS CLOSED to
+`:cannot-run` rather than passing vacuously over a nil tree — the honesty
+floor (§`:cannot-run`). The browser-only pair (`:rf.assert/visual-snapshot`
+/ `:rf.assert/a11y`) record `:cannot-run` headless through their own
+`browser-available?` guard.
 
 ### Fail-closed: headless returns `:cannot-run`
 

--- a/tools/story/src/re_frame/story/late_bind.cljc
+++ b/tools/story/src/re_frame/story/late_bind.cljc
@@ -47,7 +47,22 @@
                                      view. Signature: `(f render-inputs) →
                                      host-render-result`. Absent on the bare
                                      JVM (no DOM / substrate), so
-                                     `render-variant` returns `:cannot-run`."
+                                     `render-variant` returns `:cannot-run`.
+
+  - `:render-hiccup`               — a host that can render the active view
+                                     to a HICCUP TREE (data) → the play
+                                     runner's browser-tier executor
+                                     (`re-frame.story.play.runner-events` →
+                                     `re-frame.story.play.browser`). Signature:
+                                     `(f frame-id) → hiccup-tree | nil`. This
+                                     is the `:hiccup-structure` proof surface
+                                     `:rf.assert/a11y-structural` consumes on
+                                     the run path: a `:hiccup`-or-richer host
+                                     installs it so the structural-a11y check
+                                     can walk the rendered tree. The bare
+                                     headless floor leaves it nil, so the
+                                     executor refuses `:cannot-run` (never a
+                                     vacuous pass over a nil tree)."
   )
 
 (defonce

--- a/tools/story/src/re_frame/story/play/runner_events.cljc
+++ b/tools/story/src/re_frame/story/play/runner_events.cljc
@@ -43,6 +43,7 @@
             [re-frame.story.config      :as config]
             [re-frame.story.late-bind   :as late-bind]
             [re-frame.story.play        :as play]
+            [re-frame.story.play.browser :as browser]
             [re-frame.story.play.dom    :as dom]
             [re-frame.story.play.runner :as runner]
             [re-frame.story.play.settled-boundary :as boundary]
@@ -556,13 +557,138 @@
 
 (declare exec-assert-dom-atom!)
 
+;; ---- browser-tier assertion atom executor (rf2-9ikj0) --------------------
+;;
+;; The browser-tier oracle family (`:rf.assert/visual-snapshot` /
+;; `:rf.assert/a11y` / `:rf.assert/a11y-structural`) has its dedicated pure
+;; executor in `re-frame.story.play.browser` (`eval-browser-assertion`,
+;; rf2-5x1wt.28) — but until now that executor was ORPHANED from the run
+;; path: `exec-assert!` routed EVERY browser-tier atom to a no-op step-skip
+;; via `tape-evaluated-assertion?`, so a `[:assert [:rf.assert/a11y-structural
+;; …]]` checkpoint recorded nothing and a headless run never surfaced the
+;; honest `:cannot-run` for the browser-only pair. rf2-9ikj0 wires the
+;; executor IN, mirroring how the DOM family is routed to
+;; `exec-assert-dom-atom!`:
+;;
+;;   - `:rf.assert/a11y-structural` is the `:hiccup` rung — it walks the
+;;     rendered hiccup TREE (data). When a host can supply that tree (the
+;;     `:render-hiccup` late-bind seam — a `:hiccup`-or-richer runner), the
+;;     check EVALUATES (:pass / :fail) on the normal run path. When NO hiccup
+;;     tree is available (the bare headless floor), it FAILS CLOSED to
+;;     `:cannot-run` — NEVER a vacuous pass over a nil tree.
+;;   - `:rf.assert/visual-snapshot` / `:rf.assert/a11y` are browser-only
+;;     (`:pixels` / `:a11y-engine`); the executor's own `browser-available?`
+;;     fail-closed guard returns `:cannot-run` under a headless run.
+;;
+;; The canonical assertion record the executor produces is recorded on the
+;; frame's `:rf.story/assertions` slot (the ONE accumulator
+;; `record-result-map` / `result/run-result` folds into the unified verdict),
+;; exactly as the DOM family is. A `:cannot-run` finding rides the SAME
+;; refusal shape (`:status :cannot-run`) the rest of the run path uses, so a
+;; browser-tier assertion the runner could not prove surfaces as the distinct
+;; THIRD status, never a false pass/fail.
+
+(defn- render-hiccup-for
+  "Resolve the rendered hiccup tree for `frame-id` via the `:render-hiccup`
+  late-bind seam (`re-frame.story.late-bind`), or nil when no host installed
+  one (the bare headless floor — no `:hiccup-structure` proof). Tolerant: a
+  throwing host yields nil. This is the `:hiccup`-tier proof surface
+  `:rf.assert/a11y-structural` walks."
+  [frame-id]
+  (when-let [f (late-bind/get-fn :render-hiccup)]
+    (try (f frame-id)
+         (catch #?(:clj Throwable :cljs :default) _ nil))))
+
+(defn- browser-assertion-ctx
+  "Build the per-run `ctx` `browser/eval-browser-assertion` consumes for
+  `frame-id`. Carries `:frame-id` (so the a11y evaluator can read the live
+  axe-violations atom) and the rendered `:hiccup` tree from the
+  `:render-hiccup` seam (so the structural-a11y evaluator can walk it). The
+  visual evaluator computes its own snapshot identity; nothing more is
+  threaded here."
+  [frame-id hiccup]
+  {:frame-id frame-id
+   :hiccup   hiccup})
+
+(defn- structural-a11y-cannot-run-finding
+  "The `:cannot-run` record for an `:rf.assert/a11y-structural` checkpoint on
+  a runner that cannot supply a rendered hiccup tree (the bare headless floor
+  — no `:render-hiccup` host, no `:hiccup-structure` proof). Rides the ONE
+  refusal shape (`:status :cannot-run`) so it is the distinct THIRD status,
+  never a vacuous pass over a nil tree (the honesty floor — spec/017
+  §`:cannot-run`)."
+  [payload]
+  {:assertion   assertions/id-a11y-structural
+   :payload     (vec payload)
+   :passed?     false
+   :cannot-run? true
+   :status      :cannot-run
+   :reason      (str "structural a11y requires a rendered hiccup tree "
+                     "(:hiccup-structure); the headless runner produced none "
+                     "(no :render-hiccup host)")})
+
+(defn- exec-assert-browser-atom!
+  "Evaluate a browser-tier oracle assertion atom `[:rf.assert/visual-snapshot
+  | :rf.assert/a11y | :rf.assert/a11y-structural & args]` at this checkpoint
+  (rf2-9ikj0 — wire the previously-orphaned `browser/eval-browser-assertion`
+  into the run path). Mirrors `exec-assert-dom-atom!`: drives the pure
+  executor, records the CANONICAL assertion record on the frame slot (so the
+  unified result's `:assertions` carries the real browser-tier id), and
+  returns the runner step-result.
+
+  - `:rf.assert/a11y-structural` runs at the `:hiccup` tier: it walks the
+    rendered hiccup tree from the `:render-hiccup` seam. With NO tree
+    available it FAILS CLOSED to `:cannot-run` (never a vacuous pass over a
+    nil tree); with a tree it EVALUATES (:pass / :fail).
+  - `:rf.assert/visual-snapshot` / `:rf.assert/a11y` are browser-only; the
+    executor's `browser-available?` guard returns `:cannot-run` headless.
+
+  A `:cannot-run` finding is recorded on the slot (so the run aggregates to
+  `:cannot-run`, never a silent pass) and surfaced as a step-fail carrying the
+  refusal."
+  [frame-id idx step atom-v]
+  (let [aid    (assertions/assertion-atom-id atom-v)
+        hiccup (render-hiccup-for frame-id)
+        result (if (and (= assertions/id-a11y-structural aid) (nil? hiccup))
+                 ;; Honesty floor: a11y-structural with no hiccup tree cannot
+                 ;; be proven — refuse rather than pass over an empty tree.
+                 (structural-a11y-cannot-run-finding (vec (rest atom-v)))
+                 (browser/eval-browser-assertion
+                   atom-v (browser-assertion-ctx frame-id hiccup)))]
+    ;; Record the canonical browser-tier assertion record on the slot so the
+    ;; unified verdict folds it (a :cannot-run record aggregates to the THIRD
+    ;; status; a :fail flips the run to :fail).
+    (assertions/record!
+      frame-id
+      (cond-> {:assertion    aid
+               :passed?      (boolean (:passed? result))
+               :payload      (vec (rest atom-v))
+               :source-coord (:source (registrar/handler-meta :variant frame-id))}
+        (contains? result :status)   (assoc :status   (:status result))
+        (:cannot-run? result)        (assoc :cannot-run? true)
+        (contains? result :expected) (assoc :expected (:expected result))
+        (contains? result :actual)   (assoc :actual   (:actual result))
+        (:reason result)             (assoc :reason   (:reason result))))
+    (cond
+      (:cannot-run? result)
+      (runner/step-fail idx step
+                        {:cannot-run? true
+                         :reason      (:reason result)
+                         :message     (or (:reason result)
+                                          (str "cannot run " (pr-str atom-v)))})
+      (:passed? result) (runner/step-pass idx step)
+      :else             (runner/step-fail idx step
+                                          {:expected (:expected result)
+                                           :actual   (:actual result)
+                                           :message  (:reason result)}))))
+
 (defn- tape-evaluated-assertion?
   "True iff the assertion atom `atom-v` (`[:rf.assert/id & args]`) is
   evaluated AGAINST THE EPOCH TAPE in the result boundary rather than by
   dispatching a `reg-event-fx` handler into the frame (rf2-8y47c +
   rf2-fh7g4).
 
-  Three assertion families carry NO `reg-event-fx` handler and are minted
+  Two assertion families carry NO `reg-event-fx` handler and are minted
   by the result boundary (`re-frame.story.result`), not by a dispatch:
 
   - `:rf.assert/schema-error` — paired against the projected
@@ -570,9 +696,6 @@
   - the causal / cascade family (`:rf.assert/caused` /
     `:rf.assert/no-cascade-rerender`) — paired against the
     `:reactive-counts` `:by-cause` projection (rf2-5x1wt.31).
-  - the browser-tier oracle family (`:rf.assert/visual-snapshot` /
-    `:rf.assert/a11y` / `:rf.assert/a11y-structural`) — projected by the
-    browser executor into the same assertion record (rf2-5x1wt.28).
 
   This is the SINGLE classifier the in-script `[:assert …]` executor
   consults so a tape-evaluated checkpoint is NEVER dispatched into the
@@ -581,13 +704,20 @@
   It deliberately reads the existing `re-frame.story.assertions`
   predicates / id-sets — the ONE source of truth for which family an id
   belongs to — so a future tape-evaluated family is covered by adding it
-  there, with no special-case to grow here. The DOM family is NOT here:
-  it has its own inline executor (`exec-assert-dom-atom!`), routed ahead
-  of this classifier."
+  there, with no special-case to grow here.
+
+  Two families are NOT here — each has its own inline executor routed
+  AHEAD of this classifier: the DOM family (`exec-assert-dom-atom!`) and
+  the browser-tier oracle family (`exec-assert-browser-atom!`, rf2-9ikj0).
+  The browser-tier family was PREVIOUSLY mis-classified here, which made
+  `browser/eval-browser-assertion` dead weight w.r.t. the run path: a
+  `:rf.assert/a11y-structural` checkpoint recorded a no-op step-skip
+  instead of evaluating the rendered hiccup tree, and the browser-only
+  pair never surfaced their honest `:cannot-run`. They are now routed to
+  the dedicated executor, so they are NO LONGER tape-evaluated."
   [atom-v]
   (or (assertions/schema-error? atom-v)
-      (assertions/causal? atom-v)
-      (contains? assertions/browser-assertion-ids (first atom-v))))
+      (assertions/causal? atom-v)))
 
 (defn- exec-assert!
   "Execute an `[:assert [:rf.assert/id & args]]` in-script checkpoint
@@ -600,20 +730,28 @@
   / `:assert-dom` executor minting synthetic `:rf.assert/db` /
   `:rf.assert/dom` records.
 
-  Three routes, by atom family:
+  Four routes, by atom family:
 
   - The DOM family (`:rf.assert/dom-visible` / `:rf.assert/dom-hidden` /
     `:rf.assert/dom-text`) has no reg-event-fx handler yet (the DOM runner
     that proves it lands later); it is EVALUATED directly through the DOM
     executor (`exec-assert-dom-atom!`), recording a canonical
     `:rf.assert/dom-*` record on the slot.
+  - The browser-tier oracle family (`:rf.assert/visual-snapshot` /
+    `:rf.assert/a11y` / `:rf.assert/a11y-structural`) is EVALUATED directly
+    through `exec-assert-browser-atom!` (rf2-9ikj0 — the previously-orphaned
+    `browser/eval-browser-assertion` wired into the run path). At the
+    `:hiccup` tier `:rf.assert/a11y-structural` walks the rendered hiccup
+    tree and records a real `:pass` / `:fail`; with no tree (the headless
+    floor) it records `:cannot-run`. The browser-only pair record
+    `:cannot-run` under a headless run (their `browser-available?` guard).
   - The tape-evaluated families (`tape-evaluated-assertion?`: schema-error,
-    the causal / cascade family, the browser-tier oracle family) ALSO carry
-    no reg-event-fx handler — they are minted by the result boundary
-    against the epoch tape, not by a dispatch. An in-script checkpoint for
-    one of these records a no-op step-skip (the boundary owns its verdict);
-    dispatching it would mint a spurious `:rf.error/no-such-handler` trace
-    AND skip the real tape evaluation (rf2-8y47c + rf2-fh7g4).
+    the causal / cascade family) carry no reg-event-fx handler — they are
+    minted by the result boundary against the epoch tape, not by a dispatch.
+    An in-script checkpoint for one of these records a no-op step-skip (the
+    boundary owns its verdict); dispatching it would mint a spurious
+    `:rf.error/no-such-handler` trace AND skip the real tape evaluation
+    (rf2-8y47c + rf2-fh7g4).
   - Every other (dispatchable) `:rf.assert/*` atom dispatches the event
     through `settled-boundary` — the standard reg-event-fx handler records
     the `:passed?` record on the frame's `:rf.story/assertions` slot — and
@@ -624,6 +762,13 @@
     (cond
       (contains? assertions/dom-assertion-ids (first atom-v))
       (exec-assert-dom-atom! frame-id idx step atom-v)
+
+      ;; Browser-tier oracle family — route to the dedicated executor
+      ;; (rf2-9ikj0). a11y-structural runs at :hiccup; visual / a11y fail
+      ;; closed to :cannot-run headless. NEVER a no-op skip (which is what
+      ;; left the executor orphaned).
+      (contains? assertions/browser-assertion-ids (first atom-v))
+      (exec-assert-browser-atom! frame-id idx step atom-v)
 
       ;; Tape-evaluated families carry no reg-event-fx handler; the result
       ;; boundary owns their verdict. Record a no-op step-skip — never a

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -49,9 +49,11 @@
             [re-frame.story.loaders   :as loaders]
             [re-frame.story.plan      :as plan]
             [re-frame.story.play      :as play]
+            [re-frame.story.play.evidence :as evidence]
             [re-frame.story.play.runner :as runner]
             [re-frame.story.play.runner-events :as runner-events]
             [re-frame.story.registrar :as registrar]
+            [re-frame.story.requirements :as requirements]
             [re-frame.story.result    :as result]
             [re-frame.interop         :as interop]
             [re-frame.trace           :as trace]
@@ -477,6 +479,59 @@
   [plan executed-script]
   (filterv assertions/causal? (plan-assertion-atoms plan executed-script)))
 
+(defn- selection-refusal
+  "The `requirements/select-runner` refusal as a one-element `:unmet` vector
+  when no runner could be chosen (`:auto` and NO concrete runner satisfies
+  the plan's required tokens — `:reason :no-runner-satisfies`), or `[]` when
+  a runner WAS chosen (`{:status :ok …}`). rf2-baah3. Pure data → data."
+  [runner-selection]
+  (if (= :cannot-run (:status runner-selection))
+    [runner-selection]
+    []))
+
+(defn- requirements-unmet
+  "The per-requirement `:cannot-run` refusals derived from the requirements
+  registry for a run (rf2-baah3 — wire `re-frame.story.requirements` into the
+  run path). Pure data → data. Three sources, unioned:
+
+  1. the `select-runner` refusal, when `:auto` selection found NO capable
+     runner (`selection-refusal`);
+  2. the FIXED-RUNNER per-unit refusals — every terminal/in-script ASSERTION
+     (`requirements/unmet-assertions`) and every setup/script STEP
+     (`requirements/unmet-steps`) whose required capability tokens the chosen
+     runner lacks (a `:pixels` `visual-snapshot` / a `:dom` `[:click …]`
+     under `:headless`);
+  3. the POST-RUN, fail-closed evidence-slot validation
+     (`requirements/validate-run-evidence`) — an assertion that REQUIRED a
+     proof but whose evidence SLOT the tape never produced fails closed to
+     `:cannot-run` (the proof was promised, not delivered).
+
+  Under `:auto` selection the chosen runner satisfies every requirement, so
+  (2) is empty (the cheapest CAPABLE runner was chosen); under fixed
+  `:headless` it surfaces the per-requirement gaps. Both the fixed and auto
+  policies feed the SAME `:unmet` slot `result/run-result` folds into the
+  verdict (a run whose only unmet expectations are `:cannot-run` is itself
+  `:cannot-run`, never a vacuous pass — spec/017 §`:cannot-run`)."
+  [plan runner-selection evidence-slots executed-script]
+  (let [runner    (:runner runner-selection)
+        ;; All declared assertion atoms (terminal + check + in-script) — the
+        ;; SAME collector the schema/causal expectation filters read.
+        atoms     (plan-assertion-atoms plan executed-script)
+        ;; setup + script steps — the executed script the auto-plays ran,
+        ;; plus the plan's setup program.
+        steps     (into (vec (get-in plan [:world :setup] []))
+                        (or executed-script []))
+        ;; Post-run evidence validation reads the SAME projected evidence the
+        ;; result slots derive from (no second derivation).
+        evidence  (or evidence-slots {})
+        post-run  (when runner
+                    (:missing-evidence
+                      (requirements/validate-run-evidence atoms evidence runner)))]
+    (vec (concat (selection-refusal runner-selection)
+                 (when runner (requirements/unmet-assertions runner atoms))
+                 (when runner (requirements/unmet-steps runner steps))
+                 (or post-run [])))))
+
 (defn- record-result-map
   "Build the unified run-result returned by `run-variant` (rf2-5x1wt.19,
   spec/017 §Run result + §Unified run result). Gathers whatever the
@@ -501,7 +556,8 @@
   Checks + schema-expectations are sourced from the compiled `:plan`
   (rf2-5x1wt.20), so a registered variant and an INLINE plan assemble the
   same result through one path."
-  [{:keys [variant-id decorator-stack effective-args snapshot executed-script plan]} start-ms]
+  [{:keys [variant-id decorator-stack effective-args snapshot executed-script
+           plan runner-selection]} start-ms]
   (let [app-db   (rf/get-frame-db variant-id)
         ;; rf2-5x1wt.19 follow-through — read the epoch tape through the
         ;; late-bound `re-frame.core/epoch-history` facade (mirroring
@@ -512,24 +568,41 @@
         ;; (per `re-frame.core/epoch-history`'s contract) while the
         ;; `:test`-alias epoch dep makes it the live tape under the gate.
         tape     (vec (rf/epoch-history variant-id))
-        ;; rf2-q5jw4 — thread the run-state's `:cannot-run` refusals into the
-        ;; unified result's `:unmet` slot. The runner's per-step `:results`
-        ;; carry the SAME refusal facts `runner/finish` reads to compute the
-        ;; run-state status (a no-DOM `[:assert-dom …]` skip, a boundary
-        ;; `:cannot-run?`), but those steps record NO `:rf.story/assertions`
-        ;; entry — so without this the unified result aggregated to `:pass`
-        ;; (vacuous green) while the run-state read `:cannot-run`. Folding the
-        ;; refusals here makes both consumers agree (spec/017 §Unified run
-        ;; result — "a run whose only unmet expectations are :cannot-run is
-        ;; itself :cannot-run"). The facade degrades to nil run-state (and so
-        ;; an empty `:unmet`) on a host with no runner-events run-state.
-        unmet    (runner/run-state-refusals (runner-events/current-state variant-id))
+        ;; rf2-baah3 — project the tape ONCE here so the post-run evidence
+        ;; validation (`requirements-unmet` → `validate-run-evidence`) reads
+        ;; the SAME projected slots `result/run-result` derives the result
+        ;; slots from. One tape, one projection — a duplicate accumulator
+        ;; cannot report a proof present while the tape's slot is empty.
+        evidence (evidence/project-evidence tape {:script executed-script})
+        ;; rf2-q5jw4 — the run-state's `:cannot-run` refusals (a no-DOM
+        ;; `[:assert-dom …]` skip, a boundary `:cannot-run?`): steps that
+        ;; recorded NO `:rf.story/assertions` entry, so without this fold the
+        ;; unified result aggregated to `:pass` (vacuous green) while the
+        ;; run-state read `:cannot-run`. The facade degrades to nil run-state
+        ;; (empty refusals) on a host with no runner-events run-state.
+        run-state-unmet (runner/run-state-refusals
+                          (runner-events/current-state variant-id))
+        ;; rf2-baah3 — the requirements-registry refusals: the `:auto`
+        ;; no-capable-runner refusal, the fixed-runner per-unit capability
+        ;; gaps (`unmet-assertions` / `unmet-steps`), and the post-run
+        ;; fail-closed evidence-slot validation (`validate-run-evidence`).
+        ;; Wired through `runner-selection` (chosen in `prepare-context`).
+        req-unmet (requirements-unmet plan runner-selection evidence executed-script)
+        ;; The unified `:unmet` slot folds BOTH refusal sources (spec/017
+        ;; §Unified run result — "a run whose only unmet expectations are
+        ;; :cannot-run is itself :cannot-run").
+        unmet    (into (vec run-state-unmet) req-unmet)
         unified  (result/run-result
                    {:variant/id          variant-id
                     :epoch-tape          tape
                     :assertions          (or (:rf.story/assertions app-db) [])
                     :script              executed-script
                     :check->atoms        (plan-checks plan)
+                    ;; rf2-baah3 — the CHOSEN runner + the plan's required
+                    ;; capability set, surfaced on the result so Test mode /
+                    ;; CI / MCP read which runner ran + what it needed.
+                    :runner              (:runner runner-selection)
+                    :required-runner     (get plan :required-runner #{})
                     ;; rf2-5x1wt.21 — the declared `:rf.assert/schema-error`
                     ;; expectations, EXACT-consumed against the projected
                     ;; tape violations (§Schema rule). Tape-evaluated, NOT
@@ -561,6 +634,29 @@
             :effective-args  effective-args
             :lifecycle       (loaders/current-state variant-id)})))
 
+(defn- resolve-runner-selection
+  "Normalize the run `opts` and SELECT the runner for `plan` (rf2-baah3 —
+  wire `re-frame.story.requirements` into the run path). Returns the
+  `requirements/select-runner` outcome — either `{:status :ok :runner …
+  :unmet …}` (a runner was chosen; under `:auto` it satisfies all, under
+  fixed `:headless` its `:unmet` may be non-empty) or a
+  `requirements/requirement-refusal` (`:auto` and NO runner satisfies, e.g.
+  a `:reactive-counts` requirement → `:no-runner-satisfies`).
+
+  `normalize-run-opts` collapses `:runner` / `:escalate` into the canonical
+  `{:mode :fixed|:auto :runner …}` shape (the ONE normalization the spec
+  pins, §Run / `is` opts); `select-runner` then chooses the cheapest capable
+  runner under `:auto`, or runs the whole plan single-pass under the fixed
+  runner. The plan's `:required-runner` slot is the union capability set the
+  compiler already filled through this SAME registry (`plan/compute-required-
+  runner` → `requirements/plan-required-runner`), so selection reads the ONE
+  source of truth, never a re-derivation. Pure aside from nothing — `opts`
+  and `plan` in, the selection map out."
+  [plan opts]
+  (let [norm-opts (requirements/normalize-run-opts opts)
+        required  (get plan :required-runner #{})]
+    (requirements/select-runner required norm-opts)))
+
 (defn- prepare-context
   "Resolve the per-run inputs that every phase needs: the NORMALIZED
   PLAN, the decorator stack, the effective args, and the identity
@@ -582,14 +678,20 @@
   removed; phase-4 drives the rich-DSL step executor through
   `runner-events/run!`."
   [variant-id variant-body opts]
-  (let [{:keys [active-modes]} opts]
-    {:variant-id      variant-id
-     :variant-body    variant-body
-     :plan            (plan/variant-plan variant-id)
-     :decorator-stack (decorators/resolve-decorators variant-id
-                                                     {:active-modes active-modes})
-     :effective-args  (args/resolve-args variant-id opts)
-     :snapshot        (ident/snapshot-identity variant-id opts)}))
+  (let [{:keys [active-modes]} opts
+        plan (plan/variant-plan variant-id)]
+    {:variant-id       variant-id
+     :variant-body     variant-body
+     :plan             plan
+     ;; rf2-baah3 — select the runner for this plan up front (the cheapest
+     ;; capable runner under :auto, or the fixed runner the caller asked for).
+     ;; Threaded down so `record-result-map` can surface the chosen runner +
+     ;; fold UNMET requirements into the unified result's :cannot-run.
+     :runner-selection (resolve-runner-selection plan opts)
+     :decorator-stack  (decorators/resolve-decorators variant-id
+                                                      {:active-modes active-modes})
+     :effective-args   (args/resolve-args variant-id opts)
+     :snapshot         (ident/snapshot-identity variant-id opts)}))
 
 (defn- run-phase-0!
   "Phase 0: allocate the variant frame with its decorator stack, then
@@ -923,16 +1025,23 @@
                           snapshot identity.
 
   Pure aside from the decorator-body registrar reads (a decorator is a
-  registered artefact even when the plan is not)."
-  [frame-id plan]
-  {:variant-id      frame-id
-   :plan            plan
-   :decorator-stack (decorators/resolve-decorator-refs
-                      (get-in plan [:world :decorators] []))
-   :effective-args  (get-in plan [:world :effective-args] {})
-   :loader-body     {:loaders               (get-in plan [:world :loaders])
-                     :loaders-complete-when (get-in plan [:world :loaders-complete-when])}
-   :snapshot        nil})
+  registered artefact even when the plan is not).
+
+  rf2-baah3 — `:runner-selection` is selected from the SAME compiled plan +
+  run `opts` a registered run uses (`resolve-runner-selection`), so an inline
+  plan threads requirements selection identically — an UNMET requirement
+  surfaces `:cannot-run` on the inline path too."
+  ([frame-id plan] (prepare-inline-context frame-id plan nil))
+  ([frame-id plan opts]
+   {:variant-id       frame-id
+    :plan             plan
+    :runner-selection (resolve-runner-selection plan opts)
+    :decorator-stack  (decorators/resolve-decorator-refs
+                        (get-in plan [:world :decorators] []))
+    :effective-args   (get-in plan [:world :effective-args] {})
+    :loader-body      {:loaders               (get-in plan [:world :loaders])
+                       :loaders-complete-when (get-in plan [:world :loaders-complete-when])}
+    :snapshot         nil}))
 
 (defn- inline-events-only?
   "True iff the inline `plan` drives no loaders / loaders-complete-when and
@@ -999,7 +1108,7 @@
            (async/promise
              (fn [resolve]
                (try
-                 (let [ctx          (-> (prepare-inline-context frame-id plan)
+                 (let [ctx          (-> (prepare-inline-context frame-id plan opts)
                                         run-inline-phase-0!
                                         run-phase-1!
                                         run-phase-2!)

--- a/tools/story/test/re_frame/story/play/runner_events_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/play/runner_events_cljs_test.cljc
@@ -1052,15 +1052,22 @@
 (def ^:private tape-evaluated-assertion? @#'re/tape-evaluated-assertion?)
 
 (deftest tape-evaluated-assertion?-classifies-every-non-dispatched-family
-  (testing "schema-error, the causal family, and the browser-tier oracle
-            family are tape-evaluated (no reg-event-fx handler); the
-            dispatchable seven + the DOM family are NOT"
+  (testing "schema-error and the causal family are tape-evaluated (no
+            reg-event-fx handler); the dispatchable seven, the DOM family,
+            and the browser-tier oracle family are NOT"
     (is (true? (boolean (tape-evaluated-assertion? [:rf.assert/schema-error {}]))))
     (is (true? (boolean (tape-evaluated-assertion? [:rf.assert/caused {:event :e}]))))
     (is (true? (boolean (tape-evaluated-assertion? [:rf.assert/no-cascade-rerender {:event :e}]))))
-    (is (true? (boolean (tape-evaluated-assertion? [:rf.assert/visual-snapshot]))))
-    (is (true? (boolean (tape-evaluated-assertion? [:rf.assert/a11y]))))
-    (is (true? (boolean (tape-evaluated-assertion? [:rf.assert/a11y-structural]))))
+    ;; rf2-9ikj0 — the browser-tier oracle family now has its OWN inline
+    ;; executor (`exec-assert-browser-atom!`), so it is NO LONGER
+    ;; tape-evaluated: a11y-structural EVALUATES at :hiccup, visual / a11y
+    ;; fail closed to :cannot-run headless — neither is a no-op skip.
+    (is (false? (boolean (tape-evaluated-assertion? [:rf.assert/visual-snapshot])))
+        "visual-snapshot is routed to the browser executor, not this classifier")
+    (is (false? (boolean (tape-evaluated-assertion? [:rf.assert/a11y])))
+        "a11y is routed to the browser executor, not this classifier")
+    (is (false? (boolean (tape-evaluated-assertion? [:rf.assert/a11y-structural])))
+        "a11y-structural is routed to the browser executor, not this classifier")
     (is (false? (boolean (tape-evaluated-assertion? [:rf.assert/path-equals [:k] 1])))
         "a dispatchable canonical assertion (has a reg-event-fx handler) is NOT tape-evaluated")
     (is (false? (boolean (tape-evaluated-assertion? [:rf.assert/state-is :loaded])))

--- a/tools/story/test/re_frame/story/runtime_runpath_test.clj
+++ b/tools/story/test/re_frame/story/runtime_runpath_test.clj
@@ -1,0 +1,191 @@
+(ns re-frame.story.runtime-runpath-test
+  "End-to-end run-path wiring tests (rf2-baah3 + rf2-9ikj0).
+
+  These drive `story/run` to terminal on the JVM (where the future resolves
+  synchronously) and assert the run-path now THREADS the requirements
+  registry + routes the browser-tier a11y-structural executor — the two
+  surfaces that existed but were orphaned from the run path:
+
+  - rf2-baah3 — `re-frame.story.requirements` (`normalize-run-opts` →
+    `select-runner` → `unmet-assertions` / `unmet-steps` →
+    `validate-run-evidence`) is wired into `run-variant` / `run-inline-plan`:
+    an UNMET requirement surfaces `:cannot-run` (the distinct THIRD status,
+    never a false pass), the cheapest capable runner is selected, and the
+    result carries `:runner` / `:required-runner`.
+
+  - rf2-9ikj0 — `re-frame.story.play.browser/eval-browser-assertion` is
+    routed from the run path's in-script `[:assert …]` executor: an
+    `:rf.assert/a11y-structural` checkpoint EVALUATES (:pass / :fail) at the
+    `:hiccup` tier against the rendered hiccup tree (the `:render-hiccup`
+    seam); a tier that cannot supply the tree records `:cannot-run`.
+
+  JVM-only (`.clj`): `story/run` returns a `CompletableFuture` that resolves
+  synchronously to the unified result. The selection / requirement-function
+  unit coverage lives in `re-frame.story.requirements-test`; the browser
+  executor unit coverage lives in `re-frame.story.play.browser-test`. This
+  suite proves the END-TO-END wiring through the run path."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core      :as rf]
+            [re-frame.frame     :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.story     :as story]
+            [re-frame.story.assertions :as assertions]
+            [re-frame.story.late-bind  :as late-bind]))
+
+(defn- reset-rf! [test-fn]
+  (story/clear-all!)
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (try (rf/init! plain-atom/adapter)
+       (catch clojure.lang.ExceptionInfo _ nil))
+  (reset! assertions/trace-accumulators {})
+  ;; Drop any stray :render-hiccup host from a prior test (the run-path
+  ;; a11y-structural tier-proof seam) so the no-host :cannot-run case is clean.
+  (swap! late-bind/hooks dissoc :render-hiccup)
+  (story/install-canonical-vocabulary!)
+  (frame/ensure-default-frame!)
+  (rf/reg-event-db :rp/set-status (fn [db [_ v]] (assoc db :status v)))
+  (test-fn))
+
+(use-fixtures :each reset-rf!)
+
+(defn- run-target
+  ([target] (.get ^java.util.concurrent.CompletableFuture (story/run target)))
+  ([target opts] (.get ^java.util.concurrent.CompletableFuture (story/run target opts))))
+
+(defn- a11y-structural-record [result]
+  (first (filter #(= :rf.assert/a11y-structural (:assertion %))
+                 (:assertions result))))
+
+;; ===========================================================================
+;; rf2-baah3 — requirements selection / validation wired into the run path
+;; ===========================================================================
+
+(deftest unmet-requirement-surfaces-cannot-run
+  (testing "a terminal :rf.assert/visual-snapshot (requires :pixels) under the
+            default :headless runner makes the run :cannot-run — the distinct
+            THIRD status, NEVER a false pass (rf2-baah3 — requirements wired
+            into run-variant)"
+    (let [result (run-target {:setup      [[:dispatch [:rp/set-status :ready]]]
+                              :assertions [[:rf.assert/visual-snapshot]]})]
+      (is (= :cannot-run (:status result))
+          "the unmet :pixels requirement aggregates the run to :cannot-run")
+      (is (seq (:cannot-run result))
+          "the :cannot-run slot carries the per-requirement refusal(s)")
+      (is (some #(contains? (set (:missing %)) :pixels) (:cannot-run result))
+          "a refusal attributes the missing :pixels token")
+      (is (= :headless (:runner result))
+          "the chosen runner is surfaced on the result")
+      (is (contains? (set (:required-runner result)) :pixels)
+          "the plan's :required-runner capability set is surfaced + carries :pixels"))))
+
+(deftest healthy-headless-run-is-not-falsely-refused
+  (testing "a healthy headless run (an :app-db assertion the :headless runner
+            CAN prove) reads :pass with NO :cannot-run — the requirements
+            wiring must not false-refuse a run whose tokens the runner provides
+            (rf2-baah3 / rf2-qoxw7 — empty-is-healthy slots impose no gate)"
+    (let [result (run-target {:script [[:dispatch [:rp/set-status :loaded]]
+                                       [:assert [:rf.assert/path-equals [:status] :loaded]]]})]
+      (is (= :pass (:status result)) "a met-and-passing headless run is :pass")
+      (is (empty? (:cannot-run result)) "no spurious :cannot-run refusal")
+      (is (= :headless (:runner result)))
+      (is (every? :passed? (:assertions result))))))
+
+(deftest auto-selects-cheapest-capable-runner
+  (testing "under :auto the cheapest CAPABLE runner is selected — :headless for
+            an app-db-only plan, :hiccup for a :hiccup-structure requirement
+            (rf2-baah3 — select-runner threaded through normalize-run-opts)"
+    (let [headless (run-target {:script [[:dispatch [:rp/set-status :loaded]]
+                                         [:assert [:rf.assert/path-equals [:status] :loaded]]]}
+                               {:runner :auto})]
+      (is (= :headless (:runner headless))
+          "an app-db-only plan escalates no further than :headless under :auto"))
+    ;; Install a render-hiccup host so a11y-structural can run at :hiccup; the
+    ;; selection itself (cheapest = :hiccup for :hiccup-structure) is the point.
+    (late-bind/set-fn! :render-hiccup (fn [_frame] [:div "ok"]))
+    (let [hiccup (run-target {:assertions [[:rf.assert/a11y-structural]]}
+                             {:runner :auto})]
+      (is (= :hiccup (:runner hiccup))
+          "a :hiccup-structure requirement escalates to the cheapest capable runner :hiccup")
+      (is (contains? (set (:required-runner hiccup)) :hiccup-structure)))))
+
+(deftest fixed-headless-refuses-hiccup-structure-requirement
+  (testing "under fixed :headless a :hiccup-structure (a11y-structural)
+            requirement refuses :cannot-run at PREFLIGHT — the fixed runner
+            runs single-pass and refuses per-requirement (rf2-baah3)"
+    (let [result (run-target {:assertions [[:rf.assert/a11y-structural]]}
+                             {:runner :headless})]
+      (is (= :cannot-run (:status result)))
+      (is (some #(contains? (set (:missing %)) :hiccup-structure)
+                (:cannot-run result))
+          "the refusal attributes the missing :hiccup-structure token"))))
+
+;; ===========================================================================
+;; rf2-9ikj0 — a11y-structural executor routed into the run path
+;; ===========================================================================
+
+(deftest a11y-structural-evaluates-and-fails-at-hiccup
+  (testing "an in-script [:assert [:rf.assert/a11y-structural]] checkpoint
+            EVALUATES at :hiccup against the rendered tree and FAILS the run
+            when the tree carries a structural issue (rf2-9ikj0 — the
+            previously-orphaned executor is wired in)"
+    ;; The host renders a tree with an :img missing :alt — a structural issue.
+    (late-bind/set-fn! :render-hiccup (fn [_frame] [:div [:img {:src "/k.png"}]]))
+    (let [result (run-target {:script [[:dispatch [:rp/set-status :ready]]
+                                       [:assert [:rf.assert/a11y-structural]]]}
+                             {:runner :hiccup})]
+      (is (= :fail (:status result))
+          "a structural-a11y finding fails the run (no longer a no-op skip)")
+      (let [rec (a11y-structural-record result)]
+        (is (some? rec) "the a11y-structural assertion record landed on the slot")
+        (is (false? (:passed? rec)) "the img-missing-alt issue is a :fail")
+        (is (= :fail (:status rec)))))))
+
+(deftest a11y-structural-evaluates-and-passes-at-hiccup
+  (testing "a structurally-clean rendered tree PASSES :rf.assert/a11y-structural
+            on the normal :hiccup run path (rf2-9ikj0)"
+    (late-bind/set-fn! :render-hiccup
+                       (fn [_frame] [:div [:img {:src "/k.png" :alt "a kitten"}]
+                                     [:button "Go"]]))
+    (let [result (run-target {:script [[:dispatch [:rp/set-status :ready]]
+                                       [:assert [:rf.assert/a11y-structural]]]}
+                             {:runner :hiccup})]
+      (is (= :pass (:status result)) "a clean tree passes structural a11y")
+      (let [rec (a11y-structural-record result)]
+        (is (some? rec))
+        (is (true? (:passed? rec)))
+        (is (= :pass (:status rec)))))))
+
+(deftest a11y-structural-cannot-run-without-a-hiccup-tree
+  (testing "with NO :render-hiccup host the :hiccup runner cannot supply a
+            rendered tree, so :rf.assert/a11y-structural records :cannot-run —
+            NEVER a vacuous pass over a nil tree (rf2-9ikj0 honesty floor)"
+    ;; No :render-hiccup host installed (the fixture cleared it). The runner is
+    ;; :hiccup so the PREFLIGHT capability check passes (:hiccup provides
+    ;; :hiccup-structure); the executor's own tree-availability guard refuses.
+    (let [result (run-target {:script [[:dispatch [:rp/set-status :ready]]
+                                       [:assert [:rf.assert/a11y-structural]]]}
+                             {:runner :hiccup})]
+      (is (= :cannot-run (:status result))
+          "no rendered tree → :cannot-run, never a false pass/fail")
+      (let [rec (a11y-structural-record result)]
+        (is (some? rec) "a :cannot-run record landed on the slot")
+        (is (= :cannot-run (:status rec)))
+        (is (true? (:cannot-run? rec)))
+        (is (false? (:passed? rec)))))))
+
+(deftest visual-snapshot-cannot-run-headless-through-run-path
+  (testing "a :rf.assert/visual-snapshot checkpoint routed through the run-path
+            executor records :cannot-run headless (browser-only :pixels) — the
+            executor's browser-available? guard, surfaced end-to-end (rf2-9ikj0)"
+    (let [result (run-target {:script [[:dispatch [:rp/set-status :ready]]
+                                       [:assert [:rf.assert/visual-snapshot]]]}
+                             {:runner :browser})]
+      ;; :browser is selected (so preflight does NOT refuse the :pixels token),
+      ;; but the JVM has no real browser → the executor refuses :cannot-run.
+      (is (= :cannot-run (:status result)))
+      (let [rec (first (filter #(= :rf.assert/visual-snapshot (:assertion %))
+                               (:assertions result)))]
+        (is (some? rec) "the visual-snapshot record landed (no longer dropped)")
+        (is (= :cannot-run (:status rec)))))))


### PR DESCRIPTION
Two run-path wiring gaps, unblocked by the nyjoa merge. Both surfaces already existed (pure, tested at the function level) but were ORPHANED from the run path; this wires the EXISTING surfaces in — no reimplementation. Shared surface (the run path), one worker.

## rf2-baah3 — requirements selection / validation into run-variant

`re-frame.story.requirements` (`normalize-run-opts` → `select-runner` → `unmet-assertions` / `unmet-steps` → `validate-run-evidence`) had ZERO call sites in `runtime.cljc`. Now threaded end-to-end:

- `prepare-context` / `prepare-inline-context` normalize the run opts and SELECT the runner from the plan `:required-runner` once, up front (cheapest capable under `:auto`; the caller's fixed runner otherwise). The selection rides ctx.
- `record-result-map` surfaces the chosen `:runner` + the plan `:required-runner` on the result, and folds the per-requirement `:cannot-run` refusals into `:unmet`/`:cannot-run`:
  - the `:auto` no-capable-runner refusal (`:no-runner-satisfies`);
  - the fixed-runner per-unit capability gaps (`unmet-assertions` over terminal+in-script atoms; `unmet-steps` over setup+script steps);
  - the post-run, fail-closed evidence-slot validation (`validate-run-evidence`), read against the SAME `project-evidence` projection the result slots derive from (one tape, one projection).

**The :cannot-run paths**: an UNMET requirement (a `:pixels` `:rf.assert/visual-snapshot` under `:headless`; a `:hiccup-structure` a11y-structural under fixed `:headless`) makes the run `:cannot-run` — the distinct THIRD status, never a false pass. A met-and-passing headless run is NOT falsely refused (the empty-is-healthy slots impose no gate — rf2-qoxw7 guarded by an explicit test).

## rf2-9ikj0 — a11y-structural executor routed into the run path

`browser/eval-browser-assertion` (+ `eval-structural-a11y`) had no run-path caller — `exec-assert!` routed every browser-tier atom to a no-op step-skip via `tape-evaluated-assertion?`. Now:

- `exec-assert!` routes the browser-tier oracle family to a dedicated `exec-assert-browser-atom!` (mirroring how the DOM family is routed to `exec-assert-dom-atom!`). The family is NO LONGER classified as tape-evaluated.
- `:rf.assert/a11y-structural` runs at the `:hiccup` tier: it walks the rendered hiccup tree supplied through a NEW `:render-hiccup` late-bind seam (`frame-id → hiccup-tree`). A `:hiccup`-or-richer host installs it; the bare headless floor leaves it nil.
- **The :cannot-run paths**: no hiccup tree available → `:cannot-run` (NEVER a vacuous pass over a nil tree — the honesty floor); `:rf.assert/visual-snapshot` / `:rf.assert/a11y` stay `:cannot-run` headless via the executor's own `browser-available?` guard. The canonical record (pass / fail / cannot-run) rides the ONE `:rf.story/assertions` accumulator `result/run-result` folds.

## The tests

`tools/story/test/re_frame/story/runtime_runpath_test.clj` drives `story/run` end-to-end on the JVM:
- baah3: unmet requirement → `:cannot-run` (+ `:runner` / `:required-runner` surfaced); healthy headless run not falsely refused; `:auto` selects the cheapest capable runner (`:headless` / `:hiccup`); fixed `:headless` refuses a `:hiccup-structure` requirement.
- 9ikj0: a11y-structural EVALUATES and FAILS at `:hiccup` (img-missing-alt); EVALUATES and PASSES on a clean tree; `:cannot-run` with no `:render-hiccup` host; visual-snapshot `:cannot-run` headless through the run-path executor.

Updated the `tape-evaluated-assertion?` classifier unit test (`runner_events_cljs_test.cljc`) for the rerouted browser family. spec/017 §Runner requirements + §Visual/a11y/browser checks document the run-path wiring + the `:render-hiccup` tier-proof seam (lane-disjoint from nyjoa §assertions / f6z88 §8.4).

## Quality gates

- `clj-kondo --parallel --fail-level error --lint tools/story` — **0 errors** (123 pre-existing warnings, none in changed files).
- `tools/story` `clojure -M:test` — **1424 tests, 0 failures, 0 errors** (+8 new).
- `tools/story-mcp` `clojure -M:test` — **172 tests, 0 failures, 0 errors**.
- `implementation` `npm run test:cljs` — **4944 tests, 0 failures, 0 errors, 0 warnings**.
- `tools/mcp-conformance` `npm run test:story` — **STORY-MCP MCP-CLIENT CONFORMANCE GREEN** (all 13 checks OK).
- `scripts/test-fast-pr.sh` — **PASS** (incl. README/docs anchor validators; mkdocs soft-skipped locally, CI runs it).