### PR TITLE
refactor(story): plan compiler is the single :extends merge authority — decorators too (rf2-f6z88 + rf2-g74i9)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -935,7 +935,7 @@ behaviour/judgement.** New keys self-classify by that principle.
 Inherited through `:extends`:
 
 - `:world` context, including setup, args/argtypes, frame config, render
-  fixtures, network stubs, platforms, and workshop context;
+  fixtures, network stubs, decorators, platforms, and workshop context;
 - checks, because checks are the inheritable expectation form;
 - tags.
 
@@ -943,6 +943,17 @@ Not inherited through `:extends`:
 
 - ordinary terminal assertions;
 - script steps.
+
+Decorators are `:world` context: a child that declares no `:decorators`
+INHERITS the parent's stack; a child that declares its own REPLACES them
+(child-wins, the same scalar context-key rule as the other world slots —
+no per-key concat). Decorator resolution therefore reads from the
+compiled plan's merged `[:world :decorators]`, for BOTH the registered
+path and the inline path (the same single-merge-authority rule §305-306
+pins for inline plans). The variant/story side-table raw body is NOT the
+decorator source — the registrar stores it raw with `:extends` intact,
+and the plan compiler is the single merge authority that resolves the
+chain.
 
 Script is behaviour under test. A child variant MUST NOT silently run a
 parent script. A parent's ordinary assertions describe the parent's

--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -253,8 +253,9 @@
      the decorator's *registration site* (see `reg-decorator`), not here.
      Per IMPL-SPEC §2.6 and Phase-2 §5.1 #10.
 
-     `:extends` resolution happens at registration time — see
-     `re-frame.story.extends/resolve-extends`."
+     `:extends` is stored RAW (intact, parents UNmerged) and resolved by
+     the plan compiler — the single merge authority — when the variant is
+     compiled; see `re-frame.story.plan/compile-body` (rf2-f6z88)."
      [id metadata]
      (macros/gen-reg-call (meta &form) *file*
                           (symbol (str (ns-name *ns*)))

--- a/tools/story/src/re_frame/story/decorators.cljc
+++ b/tools/story/src/re_frame/story/decorators.cljc
@@ -38,14 +38,33 @@
   `:assertions` (per IMPL-SPEC §5.5)."
   (:require [re-frame.story.args      :as args]
             [re-frame.story.config    :as config]
+            [re-frame.story.plan      :as plan]
             [re-frame.story.registrar :as registrar]))
 
 ;; ---- collection -----------------------------------------------------------
 
 (defn- variant-decorator-refs
-  "Return the variant body's `:decorators` vector, or `[]`."
+  "Return the variant's RESOLVED `:decorators` ref vector, or `[]`.
+
+  Reads the COMPILED plan's `[:world :decorators]` — NOT the raw
+  side-table body (rf2-g74i9, spec/017 §305-306). The plan compiler
+  (`re-frame.story.plan`) is the single `:extends` merge authority: it
+  walks the `:extends` parent chain and folds each ancestor's
+  `:decorators` into `[:world :decorators]` (`context-keys` inheritance,
+  child-wins per `merge-context`). Reading the raw body's `:decorators`
+  straight off the side-table — as this fn used to — saw ONLY the
+  child's own slot, so an `:extends` child that declared no
+  `:decorators` resolved an EMPTY stack and the parent's decorators were
+  silently dropped (inheritance dead). Routing through the plan makes
+  the registered path share the same merged refs the inline-plan runtime
+  path already consumes from `[:world :decorators]`, so both paths agree.
+
+  `decorators → plan` is acyclic (plan does NOT require decorators). The
+  compile is the same pure data→data the runtime's plan compile is; the
+  per-variant cost is one extra compile per resolution, which the single-
+  merge-authority invariant pays for (no second merge engine to diverge)."
   [variant-id]
-  (or (:decorators (registrar/handler-meta :variant variant-id)) []))
+  (or (get-in (plan/variant-plan variant-id) [:world :decorators]) []))
 
 (defn- story-decorator-refs
   "Return the parent story's `:decorators` vector, or `[]`."

--- a/tools/story/src/re_frame/story/registrar.cljc
+++ b/tools/story/src/re_frame/story/registrar.cljc
@@ -37,12 +37,16 @@
   1. Validates the body against the matching `re-frame.story.schemas`
      schema.
   2. Cross-validates `:tags` against the registered tag vocabulary.
-  3. Resolves `:extends` (variants only) — Stage 2 punts the cycle check
-     to `re-frame.story.extends`.
-  4. Stamps source-coords (per spec/009 / spec/001) — the macro layer
+  3. Stamps source-coords (per spec/009 / spec/001) — the macro layer
      captures these from `&form` and threads them via the
      `*pending-coords*` dynamic var (mirroring `re-frame.source-coords`).
-  5. Writes the resolved body into the side-table.
+  4. Writes the RAW body into the side-table.
+
+  `:extends` is NOT resolved here (rf2-f6z88 — Mike RULED (a)): the raw
+  variant body is stored with `:extends` intact and the plan compiler
+  (`re-frame.story.plan`) is the SINGLE merge authority, walking the
+  parent chain per spec/017 §8.4 (setup APPENDS, checks INHERIT). See
+  `reg-variant*` below.
 
   Hot-reload semantics mirror `re-frame.registrar`: re-registering the
   same id replaces the slot atomically; nothing in the runtime is
@@ -65,8 +69,7 @@
   - Play execution
   - Snapshot identity computation"
   (:require [re-frame.story.late-bind :as late-bind]
-            [re-frame.story.schemas   :as schemas]
-            [re-frame.story.extends   :as extends]))
+            [re-frame.story.schemas   :as schemas]))
 
 ;; ---- source-coord plumbing ------------------------------------------------
 ;;
@@ -326,13 +329,27 @@
     id))
 
 (defn reg-variant*
-  "Runtime helper for `reg-variant` macro. Per IMPL-SPEC §10 Stage 2:
+  "Runtime helper for `reg-variant` macro. Per IMPL-SPEC §10 + spec/017
+  §8.4 (rf2-f6z88 — Mike RULED (a): the plan compiler is the SINGLE
+  `:extends` merge authority):
 
-  1. Validate the body shape.
-  2. Resolve `:extends` (merge parent body, child wins).
+  1. Validate the AUTHORED body shape.
+  2. Lower the public vocabulary into the shipping slots.
   3. Cross-check tag membership.
   4. Stamp source coords.
-  5. Write to the side-table."
+  5. Write the RAW body — `:extends` INTACT, parents UNmerged — to the
+     side-table.
+
+  `:extends` is NOT resolved here. The straight registration-time merge
+  (`extends/resolve-extends`, a child-wins-wholesale REPLACE that also
+  STRIPPED `:extends`) used to pre-fold the parent body, which left the
+  plan compiler's per-field merge logic (setup APPENDS, checks INHERIT —
+  spec/017 §8.4) dead for every registered variant: it saw a single-
+  element `:extends` chain. By storing the raw body we make the compiler's
+  `resolve-source-chain` walk the chain on the default side-table lookup,
+  so registered variants and explicit-`:lookup` tests share ONE merge
+  engine (`re-frame.story.plan/compile-body`). There is no second merge
+  here to diverge."
   [id body]
   (maybe-auto-install!)
   (assert-id! :variant id)
@@ -346,19 +363,10 @@
         ;; stored body carries the shipping slots every downstream
         ;; consumer reads (per spec/017 §Public vocabulary; removed when
         ;; the runtime reads the normalized plan — rf2-5x1wt.17 / .22).
+        ;; `:extends` is preserved verbatim — the plan compiler resolves
+        ;; it (rf2-f6z88).
         lowered  (schemas/lower-public-vocabulary body)
-        resolved (extends/resolve-extends
-                   lowered
-                   (fn [pid] (handler-meta :variant pid))
-                   ;; rf2-ee38b.3: :play-script and :plays are sibling
-                   ;; encodings of the play surface. When the child
-                   ;; overrides one, drop the inherited other so the
-                   ;; merged body doesn't carry both (which the schema's
-                   ;; mutual-exclusion :fn would reject). Parents are
-                   ;; already stored lowered, so the public `:script` /
-                   ;; `:plays` distinction is collapsed before this point.
-                   [#{:play-script :plays}])
-        body     (-> resolved
+        body     (-> lowered
                      merge-coords
                      (->> (validate-shape! :variant id)))
         _        (validate-tag-membership! id (:tags body))]

--- a/tools/story/test/re_frame/story_authoring_surface_test.clj
+++ b/tools/story/test/re_frame/story_authoring_surface_test.clj
@@ -17,8 +17,17 @@
     the round-trip through the registered :decorators slot AND
     resolve-decorators materialises the per-ref body.
   - **Decorator inheritance via `:extends`** — child variant
-    `:extends` parent; child's `:decorators` append to (NOT replace)
-    the parent's; story → variant inheritance order is preserved.
+    `:extends` parent; the PLAN COMPILER is the single merge authority
+    (rf2-f6z88 / rf2-g74i9): a child that declares no `:decorators`
+    INHERITS the parent's stack, a child that declares its own REPLACES
+    them (child-wins, no concat); story → variant inheritance order is
+    preserved. `resolve-decorators` reads the compiled plan's
+    `[:world :decorators]`, not the raw side-table body.
+  - **§8.4 compiler-authoritative merge via the default side-table** —
+    a registered parent + child with `:extends` + `:checks` + `:setup`
+    compiles through the DEFAULT side-table lookup (no explicit
+    `:lookup`) so the registered path and explicit-`:lookup` tests share
+    ONE merge engine: setup APPENDS, checks INHERIT, decorators INHERIT.
   - **Meta → story → variant chain** — story's `:tags` /
     `:argtypes` / `:substrates` cascade into the variant's effective
     body where the variant didn't declare its own; the variant's
@@ -39,6 +48,7 @@
             [re-frame.story.decorators :as decorators]
             [re-frame.story.frames     :as frames]
             [re-frame.story.loaders    :as loaders]
+            [re-frame.story.plan       :as plan]
             [re-frame.story.play       :as play]
             [re-frame.story.ui.docs    :as docs]))
 
@@ -237,12 +247,15 @@
 ;; ===========================================================================
 
 (deftest extends-inherits-decorators-when-child-declares-none
-  (testing "decorator inheritance via :extends happens through key
-            absence — the child INHERITS the parent's :decorators only
-            when the child does NOT declare its own. Per spec/007
-            §Composed variants the merge semantics are plain
-            `(merge parent child)`. The contract rf2-ctlm5 pins:
-            inheritance is via key-absence, NOT vector-append."
+  (testing "decorator inheritance via :extends is resolved by the PLAN
+            COMPILER — the single merge authority (rf2-f6z88 / rf2-g74i9,
+            spec/017 §305-306). The registrar stores the RAW body
+            (`:extends` intact, parent NOT merged); the compiler walks
+            the chain and folds the parent's :decorators into
+            `[:world :decorators]`. A child that declares no :decorators
+            INHERITS the parent's stack, surfaced through
+            `resolve-decorators` (which reads the plan, not the
+            side-table)."
     (story/reg-decorator :inherited-deco
       {:kind :hiccup :wrap (fn [body _] [:div.inherited body])})
     (story/reg-variant :story.inherit-bare/parent
@@ -252,21 +265,25 @@
       {:extends :story.inherit-bare/parent
        :events  []})
     (let [body (story/handler-meta :variant :story.inherit-bare/child)]
-      (is (= [[:inherited-deco]] (:decorators body))
-          "child with no :decorators inherits the parent's stack")
-      (is (nil? (:extends body))
-          ":extends slot is stripped from the resolved body (consumed
-           at registration time)"))
+      (is (= :story.inherit-bare/parent (:extends body))
+          ":extends is stored RAW on the side-table body — the plan
+           compiler (not the registrar) is the merge authority")
+      (is (nil? (:decorators body))
+          "the child declared no :decorators; the side-table body carries
+           none — inheritance is resolved downstream at plan-compile"))
     (let [pack (story/resolve-decorators :story.inherit-bare/child)]
       (is (= [:inherited-deco] (mapv :id (:hiccup pack)))
-          "resolved hiccup stack carries the inherited decorator"))))
+          "resolved hiccup stack INHERITS the parent's decorator via the
+           compiled plan's [:world :decorators]"))))
 
 (deftest extends-child-decorators-replace-parent
   (testing "when the child declares its OWN :decorators, the child's
-            slot REPLACES the parent's. This is the spec/007 merge
-            semantics — `(merge parent child)` — and applies to every
-            top-level body slot uniformly. The same rule covers :args,
-            :events, :tags, :modes, etc."
+            slot REPLACES the parent's. The PLAN COMPILER is the merge
+            authority (rf2-f6z88, spec/017 §305-306): `:decorators` is a
+            scalar context key, so `merge-context` is child-wins — the
+            child's vector replaces the parent's (no concat / no append).
+            The same child-wins rule covers :args, :events, :tags,
+            :modes, etc."
     (story/reg-decorator :parent-deco
       {:kind :hiccup :wrap (fn [body _] [:div.parent body])})
     (story/reg-decorator :child-deco
@@ -280,11 +297,62 @@
        :events     []})
     (let [body (story/handler-meta :variant :story.inherit-replace/child)]
       (is (= [[:child-deco]] (:decorators body))
-          "child's :decorators replaces parent's — NO concat / NO
-           append; the child's slot is the final value"))
+          "the raw side-table body carries the child's OWN :decorators
+           verbatim")
+      (is (= :story.inherit-replace/parent (:extends body))
+          ":extends is stored RAW — the compiler resolves the chain"))
     (let [pack (story/resolve-decorators :story.inherit-replace/child)]
       (is (= [:child-deco] (mapv :id (:hiccup pack)))
           "resolved hiccup stack reflects ONLY the child's decorators"))))
+
+;; ===========================================================================
+;; §8.4 — the plan compiler is the SINGLE merge authority, EVEN through the
+;; DEFAULT side-table lookup (rf2-f6z88 / rf2-g74i9, spec/017 §Merge rules).
+;;
+;; This is the load-bearing regression: the registrar now stores the RAW
+;; body (`:extends` intact, parent NOT merged at registration), so a
+;; registered variant compiled through the DEFAULT side-table lookup (no
+;; explicit `:lookup` arg) must walk the parent chain exactly like the
+;; explicit-`:lookup` plan_test cases. setup APPENDS, checks INHERIT, and
+;; (the rf2-g74i9 fix) decorators INHERIT — all from ONE merge engine
+;; (`re-frame.story.plan/compile-body`). A registration-time straight-merge
+;; would have left the compiler seeing a single-element chain and these
+;; per-field semantics dead.
+;; ===========================================================================
+
+(deftest extends-compiler-authority-through-default-side-table
+  (testing "a registered parent+child with :extends + :checks + :setup +
+            :decorators compiles via the DEFAULT side-table lookup (no
+            :lookup arg): setup APPENDS, checks INHERIT, decorators INHERIT"
+    (story/reg-decorator :s84-parent-deco
+      {:kind :hiccup :wrap (fn [body _] [:div.s84 body])})
+    (story/reg-variant :story.s84/parent
+      {:setup      [[:dispatch [:s84/p1]] [:dispatch [:s84/p2]]]
+       :checks     [:check/no-runtime-errors]
+       :decorators [[:s84-parent-deco]]})
+    (story/reg-variant :story.s84/child
+      {:extends :story.s84/parent
+       :setup   [[:dispatch [:s84/c1]]]
+       :checks  [:check/extra]})
+    ;; DEFAULT side-table lookup — NO :lookup arg. This is the path the
+    ;; runtime uses; it must agree with the explicit-:lookup plan tests.
+    (let [p (plan/variant-plan :story.s84/child)]
+      (testing "source chain is root-first (chain walked from the side-table)"
+        (is (= [:story.s84/parent :story.s84/child] (:source-chain p))))
+      (testing "setup APPENDS parent→child (the silent-regression site)"
+        (is (= [[:dispatch [:s84/p1]] [:dispatch [:s84/p2]] [:dispatch [:s84/c1]]]
+               (get-in p [:world :setup]))))
+      (testing "checks INHERIT root→child (inheritable expectation form)"
+        (is (= [:check/no-runtime-errors :check/extra]
+               (get-in p [:expect :checks]))))
+      (testing "decorators INHERIT (rf2-g74i9 — child declared none)"
+        (is (= [[:s84-parent-deco]] (get-in p [:world :decorators])))))
+    ;; And the registered front door (resolve-decorators) sees the same
+    ;; inherited pack — proving the registered path reads the compiled
+    ;; plan, not the raw side-table body.
+    (let [pack (story/resolve-decorators :story.s84/child)]
+      (is (= [:s84-parent-deco] (mapv :id (:hiccup pack)))
+          "resolve-decorators inherits the parent's decorator via the plan"))))
 
 ;; ===========================================================================
 ;; Meta → story → variant inheritance (rf2-ctlm5 §Decorator inheritance)

--- a/tools/story/test/re_frame/story_authoring_validation_test.clj
+++ b/tools/story/test/re_frame/story_authoring_validation_test.clj
@@ -13,12 +13,14 @@
     gen-reg-call` and `expand-reg-story`. The expansion form binds
     `*pending-coords*` from `(meta &form)` and calls the runtime
     `reg-*!` helper, which runs the malli schema check + tag-vocab
-    cross-check + extends resolution. The cross-cutting contract is:
-    an invalid body raises `:rf.error/<kind>-shape` / `:rf.error/
-    unknown-tag` / `:rf.error/extends-unknown` / `:rf.error/extends-
-    cycle` with a clear message and an `ex-data` map carrying the
-    error key. We assert the error shape for each kind so a future
-    schema change that drops a key from `ex-data` is caught.
+    cross-check. (`:extends` is NOT resolved at registration — rf2-f6z88:
+    the raw body is stored, `:extends` intact, and the plan compiler is
+    the single merge authority; the `:rf.error/story-extends-unknown`
+    error surfaces at plan-compile, not registration.) The cross-cutting
+    contract is: an invalid body raises `:rf.error/<kind>-shape` /
+    `:rf.error/unknown-tag` with a clear message and an `ex-data` map
+    carrying the error key. We assert the error shape for each kind so a
+    future schema change that drops a key from `ex-data` is caught.
 
   - **Source-coord stamping.** Every `reg-*` macro stamps `:file` +
     `:line` + `:ns` + `:column` from `&form` meta into the registered
@@ -36,7 +38,8 @@
   `:source` to point back at the same `(reg-story ...)` call."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.story :as story]
-            [re-frame.story.macros :as macros]))
+            [re-frame.story.macros :as macros]
+            [re-frame.story.plan :as plan]))
 
 ;; ---- fixtures -------------------------------------------------------------
 
@@ -354,12 +357,18 @@
 ;; ===========================================================================
 
 (deftest reg-variant-extends-unknown-carries-parent-id
-  (testing ":extends to an unregistered variant carries the missing parent id"
+  (testing ":extends to an unregistered parent no longer throws at
+            REGISTRATION (rf2-f6z88 — the raw body is stored, `:extends`
+            intact); the error surfaces at PLAN-COMPILE (the merge
+            authority) and carries the missing parent id."
+    ;; Registration succeeds — raw body stored with the unknown parent.
+    (story/reg-variant :story.x/child
+      {:extends :story.x/no-such-parent
+       :events  []})
+    ;; Plan compile is where the unknown parent FAILS, carrying the id.
     (try
-      (story/reg-variant :story.x/child
-        {:extends :story.x/no-such-parent
-         :events  []})
-      (is false "expected an exception")
+      (plan/variant-plan :story.x/child)
+      (is false "expected a plan-compile exception")
       (catch clojure.lang.ExceptionInfo e
         (is (= :rf.error/story-extends-unknown (:rf.error/id (ex-data e))))
         (is (= :story.x/no-such-parent (:parent (ex-data e))))))))
@@ -403,9 +412,14 @@
       (is (not (contains? body :plays))
           "the inherited :plays was dropped"))))
 
-(deftest reg-variant-extends-inherits-play-surface-when-child-silent
-  (testing "a child that declares NEITHER play encoding inherits the
-            parent's :play-script unchanged"
+(deftest reg-variant-extends-does-not-inherit-play-surface
+  (testing "SCRIPT IS NOT INHERITED through :extends (spec/017 §942-945:
+            context flows down, behaviour/judgement is local). A child
+            that declares NEITHER play encoding does NOT silently run the
+            parent's :play-script. The registrar stores the RAW body
+            (rf2-f6z88) — `:extends` intact, parent NOT merged — so the
+            child's body carries no play surface, and the plan compiler
+            (the merge authority) takes script from the CHILD ONLY."
     (story/reg-variant :story.extplay/parent3
       {:events      []
        :play-script {:script [[:dispatch [:p/keep]]]}})
@@ -413,8 +427,15 @@
       {:extends :story.extplay/parent3
        :doc     "no play override"})
     (let [body (story/handler-meta :variant :story.extplay/child3)]
-      (is (contains? body :play-script) "inherited :play-script kept")
-      (is (= [[:dispatch [:p/keep]]] (:script (:play-script body)))))))
+      (is (= :story.extplay/parent3 (:extends body))
+          ":extends stored raw — the parent body is NOT merged in")
+      (is (not (contains? body :play-script))
+          "the parent's :play-script is NOT inherited — script is local")
+      (is (not (contains? body :plays))
+          "no play surface inherited at all"))
+    ;; The compiler confirms it: the silent child's compiled script is empty.
+    (is (= [] (:script (plan/variant-plan :story.extplay/child3)))
+        "compiled plan takes script CHILD-ONLY — the parent's is not run")))
 
 ;; ===========================================================================
 ;; CANONICAL-ID-GRAMMAR ERROR

--- a/tools/story/test/re_frame/story_decorator_chain_test.clj
+++ b/tools/story/test/re_frame/story_decorator_chain_test.clj
@@ -162,12 +162,13 @@
 (deftest extends-inherits-decorators-when-child-declares-none
   (testing ":extends gives a child variant access to its parent's
             :decorators only when the child does NOT declare its own
-            :decorators slot. Per spec/007 §Composed variants the
-            merge semantics are plain `(merge parent child)` — child
-            keys WIN key-by-key; no per-key concat.
-
-            This pins the rf2-ctlm5 §Decorator inheritance acceptance:
-            inheritance happens via key absence, NOT vector append."
+            :decorators slot. The PLAN COMPILER is the merge authority
+            (rf2-f6z88 / rf2-g74i9, spec/017 §305-306): the registrar
+            stores the RAW body (`:extends` intact); the compiler walks
+            the chain and folds `:decorators` into `[:world :decorators]`
+            child-wins (no per-key concat). `resolve-decorators` reads
+            the compiled plan, so a bare child INHERITS the parent's
+            decorator stack."
     (story/reg-decorator :parent-only-deco
       {:kind :hiccup :wrap (fn [body _] [:div.parent-only body])})
     (story/reg-decorator :child-replacement
@@ -189,19 +190,23 @@
       {:extends    :story.ext.dec/parent
        :decorators [[:child-replacement]]
        :events     []})
-    ;; Case 1: bare child inherits parent's :decorators.
+    ;; Case 1: bare child inherits parent's :decorators via the plan.
     (let [body (story/handler-meta :variant :story.ext.dec/inherit-bare)]
-      (is (= [[:parent-only-deco]] (:decorators body))
-          ":extends with no override → inherit parent's :decorators"))
+      (is (= :story.ext.dec/parent (:extends body))
+          ":extends stored RAW on the side-table body")
+      (is (nil? (:decorators body))
+          "bare child declares no :decorators; the raw body carries none —
+           inheritance is resolved downstream at plan-compile"))
     (let [pack (story/resolve-decorators :story.ext.dec/inherit-bare)]
       (is (= [:parent-only-deco] (mapv :id (:hiccup pack)))
-          "resolved hiccup stack reflects the inherited vector"))
+          "resolved hiccup stack INHERITS the parent's decorator via the
+           compiled plan's [:world :decorators]"))
     ;; Case 2: child with its own :decorators REPLACES parent's.
     (let [body (story/handler-meta :variant :story.ext.dec/inherit-and-replace)]
       (is (= [[:child-replacement]] (:decorators body))
-          ":extends with explicit :decorators → child wins (merge
-           semantics, no concat); this is the spec/007 §Composed
-           variants contract"))
+          "the raw body carries the child's OWN :decorators verbatim")
+      (is (= :story.ext.dec/parent (:extends body))
+          ":extends stored RAW — compiler resolves child-wins (no concat)"))
     (let [pack (story/resolve-decorators :story.ext.dec/inherit-and-replace)]
       (is (= [:child-replacement] (mapv :id (:hiccup pack)))
           "resolved hiccup stack reflects ONLY the child's decorators —

--- a/tools/story/test/re_frame/story_test.clj
+++ b/tools/story/test/re_frame/story_test.clj
@@ -23,6 +23,7 @@
             [re-frame.story.canonical :as canonical]
             [re-frame.story.config :as story-config]
             [re-frame.story.extends :as extends]
+            [re-frame.story.plan :as plan]
             [re-frame.story.registrar :as registrar]
             [re-frame.story.schemas :as schemas]))
 
@@ -228,8 +229,12 @@
 
 ;; ---- :extends resolution -----------------------------------------------
 
-(deftest extends-resolves-at-registration-time
-  (testing ":extends merges parent into child, child wins"
+(deftest extends-stored-raw-at-registration-resolved-by-compiler
+  (testing ":extends is stored RAW at registration (`:extends` intact,
+            parent NOT merged); the PLAN COMPILER is the single merge
+            authority (rf2-f6z88, spec/017 §305-306). The side-table body
+            keeps the child's own slots verbatim; the compiled plan
+            inherits the parent's :decorators via [:world :decorators]."
     (story/reg-variant :story.auth.login/loading
       {:events     [[:auth/initialise]
                     [:auth/email-changed "alice@example.com"]
@@ -244,19 +249,38 @@
                  [:auth/login-pressed]]
        :tags    #{:dev :docs}})
     (let [body (story/handler-meta :variant :story.auth.login/loading-with-prefill)]
-      (is (nil? (:extends body)) ":extends is stripped from the resolved body")
-      (is (= 4 (count (:events body))) "child :events wins")
-      (is (= [[:force-fx-stub :http {:status :pending}]] (:decorators body))
-          ":decorators inherited from parent")
-      (is (= #{:dev :docs} (:tags body)) "child :tags wins"))))
+      (is (= :story.auth.login/loading (:extends body))
+          ":extends is stored RAW — NOT stripped at registration")
+      (is (= 4 (count (:events body))) "child's own :events stored verbatim")
+      (is (nil? (:decorators body))
+          "child declared no :decorators; the raw body carries none —
+           inheritance is the compiler's job, not the registrar's")
+      (is (= #{:dev :docs} (:tags body)) "child's own :tags stored verbatim"))
+    ;; The plan compiler resolves the chain: setup APPENDS, :decorators
+    ;; inherit child-wins. The child declared no decorators, so it
+    ;; inherits the parent's.
+    (let [plan (plan/variant-plan :story.auth.login/loading-with-prefill)]
+      (is (= [[:force-fx-stub :http {:status :pending}]]
+             (get-in plan [:world :decorators]))
+          "compiled plan INHERITS the parent's :decorators"))))
 
 (deftest extends-unknown-parent
-  (testing ":extends to an unregistered variant raises :rf.error/extends-unknown"
+  (testing ":extends to an unregistered parent no longer throws at
+            REGISTRATION (rf2-f6z88 — the raw body is stored with
+            `:extends` intact); the error surfaces at PLAN-COMPILE, where
+            the compiler is the merge authority and walks the chain
+            (spec/017 §305-306)."
+    ;; Registration succeeds — the raw body is stored, :extends intact.
+    (story/reg-variant :story.auth.login/child
+      {:extends :story.auth.login/no-such-parent
+       :events  []})
+    (is (= :story.auth.login/no-such-parent
+           (:extends (story/handler-meta :variant :story.auth.login/child)))
+        "registration stores the raw body with the unknown parent intact")
+    ;; Plan compile is where the unknown parent FAILS.
     (try
-      (story/reg-variant :story.auth.login/child
-        {:extends :story.auth.login/no-such-parent
-         :events  []})
-      (is false "expected an exception")
+      (plan/variant-plan :story.auth.login/child)
+      (is false "expected a plan-compile exception")
       (catch clojure.lang.ExceptionInfo e
         (is (= :rf.error/story-extends-unknown (:rf.error/id (ex-data e))))))))
 


### PR DESCRIPTION
## Summary

Makes the **plan compiler the single `:extends` merge authority** for registered Story variants — including decorators. No shims; aligns the registered path with the inline-plan path the spec already mandates (spec/017 §305-306).

### Registrar — raw-body storage (rf2-f6z88)
`reg-variant*` now stores the **RAW** variant body: `:extends` intact, parents UNmerged. The registration-time straight-merge (`extends/resolve-extends` — a child-wins-wholesale REPLACE that also STRIPPED `:extends`) is dropped, along with the now-unused `extends` require. That merge pre-folded the parent body, leaving the plan compiler's per-field logic (setup APPENDS, checks INHERIT — spec/017 §Merge rules) dead for every registered variant (it saw a single-element `:extends` chain). Storing raw makes the compiler's `resolve-source-chain` walk the chain on the default side-table lookup, so registered variants and explicit-`:lookup` tests share one merge engine.

### `decorators.cljc` — decorators-from-plan (rf2-g74i9, self-contained)
`variant-decorator-refs` read `(:decorators (handler-meta :variant id))` straight off the side-table, so a registered `:extends` child that declared no `:decorators` resolved an EMPTY stack (inheritance dead). It now reads the compiled plan's merged `[:world :decorators]`:

```clojure
(or (get-in (plan/variant-plan variant-id) [:world :decorators]) [])
```

This is exactly what the inline-plan runtime path already consumes (spec/017 §305-306), so the registered and inline paths now agree. `decorators → plan` is acyclic (plan does NOT require decorators). **`runtime.cljc` is untouched** — its caller (`runtime.cljc:589`) keeps calling `resolve-decorators` unchanged.

### Test dispositions (6 updated + 1 new regression)
- **Decorator-inheritance (now PASS via g74i9):**
  - `extends-inherits-decorators-when-child-declares-none` (`story_authoring_surface_test.clj`) — asserts raw body keeps `:extends` / no `:decorators`, and `resolve-decorators` INHERITS the parent's pack via the plan.
  - `story_decorator_chain_test.clj` `extends-inherits-decorators-when-child-declares-none` — same: bare child inherits via the compiled plan.
- **Error-timing moved to plan-compile:**
  - `extends-unknown-parent` (`story_test.clj`) + `reg-variant-extends-unknown-carries-parent-id` (`story_authoring_validation_test.clj`) — `reg-variant` no longer throws on an unknown parent; the `:rf.error/story-extends-unknown` error now surfaces at `plan/variant-plan`. Assertions updated.
- **Script NOT inherited via `:extends` (spec/017 §942-945):**
  - `reg-variant-extends-inherits-play-surface-when-child-silent` → renamed `reg-variant-extends-does-not-inherit-play-surface` — a silent child does NOT inherit the parent's `:play-script`; compiled script is child-only (`[]`).
- **Raw body:**
  - `extends-resolves-at-registration-time` → renamed `extends-stored-raw-at-registration-resolved-by-compiler` — body is raw (`:extends` intact, parent NOT merged); the compiled plan inherits the parent's `:decorators`.
- **Docstring re-pointed:** `extends-child-decorators-replace-parent` (and the `story.cljc` `reg-variant` docstring) now cite the plan compiler as the merge authority.
- **NEW §8.4 regression** — `extends-compiler-authority-through-default-side-table`: a registered parent+child with `:extends` + `:checks` + `:setup` + `:decorators` compiled via the **DEFAULT side-table lookup (no `:lookup` arg)` asserts setup APPENDS, checks INHERIT, and decorators INHERIT — proving the registered path goes through the same merge engine.

### spec/017
`§Merge rules`: decorators listed as `:world` context inherited through `:extends` (child-wins, no concat); decorator resolution reads the compiled plan's `[:world :decorators]` for BOTH paths (matching the §305-306 inline rule). Disjoint from nyjoa's §assertions.

## Quality gates
- **clj-kondo** `--parallel --fail-level error --lint tools/story` — **0 errors** (123 pre-existing warnings, none in touched files)
- `tools/story` `clojure -M:test` — **1417 tests / 0 fail / 0 error** (baseline 1416 + new §8.4 regression)
- `implementation` `npm run test:cljs` — **4944 tests / 0 fail / 0 error**, compile **0 warnings**
- `tools/story-mcp` `clojure -M:test` — **172 tests / 0 fail / 0 error**
- `tools/mcp-conformance` `npm run test:story` — **STORY-MCP MCP-CLIENT CONFORMANCE GREEN**
- `scripts/test-fast-pr.sh` — **PASS** (incl. markdown anchor validators for spec/017; mkdocs soft-skipped, CI runs it)