### PR TITLE
feat(story/test-mode): present visual + a11y check results (rf2-ba86n.15)

### DIFF
--- a/tools/story/src/re_frame/story/ui/test_mode/pure.cljc
+++ b/tools/story/src/re_frame/story/ui/test_mode/pure.cljc
@@ -13,7 +13,9 @@
 
   Everything in this namespace is `.cljc` so it runs unchanged on both
   the JVM (for the test corpus) and CLJS (consumed by `view.cljs`)."
-  (:require [re-frame.story.predicates :as pred]
+  (:require [clojure.string            :as str]
+            [re-frame.story.assertions :as assertions]
+            [re-frame.story.predicates :as pred]
             [re-frame.story.registrar  :as registrar]))
 
 ;; ---- aliases on the leaf predicates ns ----------------------------------
@@ -508,3 +510,152 @@
   [result]
   (boolean (or (seq (:epoch-tape result))
                (seq (:narrative result)))))
+
+;; ===========================================================================
+;; VISUAL + A11Y CHECK RESULTS  (rf2-ba86n.15, tools/story/spec/021 §4)
+;; ===========================================================================
+;;
+;; The run path (post-#2484) evaluates the browser-tier oracle family —
+;; `:rf.assert/a11y-structural` (the `:hiccup` structural-a11y check),
+;; `:rf.assert/a11y` (the axe-style browser check), and
+;; `:rf.assert/visual-snapshot` (the `:pixels` screenshot check) — through
+;; `re-frame.story.play.browser/eval-browser-assertion`. Each rides the ONE
+;; assertion-record shape (`re-frame.story.play.browser` — "a finding is an
+;; assertion record like any other"); they accumulate alongside every other
+;; assertion in the run-result's `:assertions` slot, with NO parallel slot.
+;;
+;; These helpers project those records into the per-section render data the
+;; dedicated visual/a11y results component renders (spec/021 §4):
+;;
+;;   - the structural a11y VIOLATIONS as a readable {:finding :locus} list
+;;     (not the raw `:actual` issue-map blob the generic assertions table
+;;     would `pr-str`);
+;;   - the axe-style a11y violations ({:id :impact :help}) likewise;
+;;   - the visual-snapshot screenshot/identity presentation (the reused
+;;     `content-hash` snapshot identity — a real pixel diff lands later with
+;;     the `:pixels` runner);
+;;   - the honest `:cannot-run` row for a browser-tier check the headless /
+;;     hiccup runner could not even attempt (spec/017 §`:cannot-run` — never
+;;     a false pass or silent blank).
+;;
+;; All pure data → data; JVM-testable. The browser-tier records are READ off
+;; the unified `:assertions` slot — the SAME source Test mode + docs project
+;; — so this is not a re-derivation of the run path's verdicts.
+
+(defn- humanize-rule
+  "Render a structural-a11y `:rule` keyword as a short readable finding
+  phrase (`:img-missing-alt` → `\"image missing alt text\"`). Falls back to
+  the kebab-spelling of an unknown rule so a future rule still reads. Pure."
+  [rule]
+  (case rule
+    :img-missing-alt      "image missing alt text"
+    :control-missing-name "interactive control has no accessible name"
+    :positive-tabindex    "positive tabIndex breaks the natural focus order"
+    (some-> rule name (str/replace "-" " "))))
+
+(defn structural-a11y-findings
+  "Project a `:rf.assert/a11y-structural` record's `:actual` issue vector
+  (`re-frame.story.play.browser/structural-issues` — `{:rule :tag :detail}`
+  maps) into a readable findings list (spec/021 §4 — \"render the structural
+  a11y VIOLATIONS as a readable list … with the finding + locus\"):
+
+      [{:finding <human phrase>   ; the issue, in words
+        :locus   <\"<tag>\">      ; where in the rendered tree, e.g. \"<button>\"
+        :detail  <str>            ; the executor's verbatim detail line
+        :rule    <keyword>}]      ; the raw rule id, for keying / data-attr
+
+  `:locus` is the offending element's hiccup tag (the structural check works
+  over the rendered hiccup TREE, so the tag is the locus the `:hiccup` tier
+  can prove — a real-browser selector/source link is the axe / `:browser`
+  tier's job). Empty when the record carried no issues. Pure data → data;
+  JVM-testable."
+  [record]
+  (mapv (fn [{:keys [rule tag detail]}]
+          {:finding (humanize-rule rule)
+           :locus   (when tag (str "<" (name tag) ">"))
+           :detail  detail
+           :rule    rule})
+        (or (:actual record) [])))
+
+(defn axe-a11y-findings
+  "Project a `:rf.assert/a11y` record's `:actual` violation vector
+  (`re-frame.story.play.browser/eval-a11y` — `{:id :impact :help}` maps, the
+  axe-core surface) into a readable findings list (spec/021 §4 — a11y
+  findings with the finding + locus). Empty when no violation. Pure data →
+  data; JVM-testable."
+  [record]
+  (mapv (fn [{:keys [id impact help]}]
+          {:finding (or help (some-> id name) "a11y violation")
+           :locus   (some-> id name)
+           :impact  impact
+           :rule    id})
+        (or (:actual record) [])))
+
+(defn browser-result-rows
+  "Project the run-result's browser-tier oracle records (visual / a11y /
+  structural-a11y — `re-frame.story.assertions/browser-assertion-ids`, read
+  off the unified `:assertions` slot) into the render rows the dedicated
+  visual/a11y results component renders (spec/021 §4). One row per
+  browser-tier record, in record order:
+
+      {:assertion :rf.assert/a11y-structural
+       :kind      :a11y-structural        ; :visual | :a11y | :a11y-structural
+       :status    :pass|:fail|:cannot-run|:error
+       :reason    <str>                   ; the executor's diagnostic line
+       :count     <n|nil>                 ; finding count (a11y kinds)
+       :findings  [{:finding :locus …} …] ; readable list (a11y kinds)
+       :snapshot  <content-hash|nil>      ; visual identity (visual kind)
+       :baseline  <content-hash|nil>      ; visual baseline (visual kind)}
+
+  A `:cannot-run` row (a browser-tier check the headless / hiccup runner
+  could not even attempt) carries its `:reason` so it reads as a refusal,
+  never a false pass or a silent blank (spec/017 §`:cannot-run`). The status
+  is the record's unified `:status` (the run path stamped it); the legacy
+  `:passed?`-only read is the fallback. Empty when the run recorded no
+  browser-tier checks (the common headless case — an honest empty state,
+  never a fabricated row). Pure data → data; JVM-testable."
+  [result]
+  (let [browser? (fn [rec] (contains? assertions/browser-assertion-ids
+                                      (:assertion rec)))
+        kind-of  (fn [aid]
+                   (condp = aid
+                     assertions/id-visual-snapshot :visual
+                     assertions/id-a11y            :a11y
+                     assertions/id-a11y-structural :a11y-structural
+                     :browser))
+        status-of (fn [rec]
+                    (let [st (:status rec)]
+                      (cond
+                        (contains? statuses st)            st
+                        (:cannot-run? rec)                 :cannot-run
+                        (or (:error rec) (:exception rec)) :error
+                        (:passed? rec)                     :pass
+                        :else                              :fail)))]
+    (->> (or (:assertions result) [])
+         (filterv browser?)
+         (mapv (fn [rec]
+                 (let [aid    (:assertion rec)
+                       kind   (kind-of aid)
+                       status (status-of rec)]
+                   (cond-> {:assertion aid
+                            :kind      kind
+                            :status    status
+                            :reason    (some-> (:reason rec) str)}
+                     (= kind :a11y-structural)
+                     (assoc :count    (:count rec)
+                            :findings (if (= status :cannot-run)
+                                        []
+                                        (structural-a11y-findings rec)))
+
+                     (= kind :a11y)
+                     (assoc :count    (:count rec)
+                            :findings (if (= status :cannot-run)
+                                        []
+                                        (axe-a11y-findings rec)))
+
+                     (= kind :visual)
+                     (assoc :snapshot (when (not= status :cannot-run)
+                                        (:actual rec))
+                            :baseline (when (and (not= status :cannot-run)
+                                                 (not (keyword? (:expected rec))))
+                                        (:expected rec))))))))))

--- a/tools/story/src/re_frame/story/ui/test_mode/view.cljs
+++ b/tools/story/src/re_frame/story/ui/test_mode/view.cljs
@@ -84,6 +84,7 @@
             [re-frame.story.ui.test-mode.pure          :as pure]
             [re-frame.story.ui.test-mode.state         :as state]
             [re-frame.story.ui.test-mode.stepper-view  :as stepper-view]
+            [re-frame.story.ui.test-mode.visual-a11y-view :as visual-a11y-view]
             [re-frame.story.ui.test-mode.view-styles   :refer [styles]]
             [re-frame.story.theme.typography :as typography :refer [mono-stack]]
             [re-frame.story.theme.colors :as colors]))
@@ -683,6 +684,14 @@
             [rows-section variant-id]
             [schema-section variant-id]
             [cannot-run-section variant-id]
+            ;; rf2-ba86n.15 — visual + a11y check RESULTS (spec/021 §4).
+            ;; Reads the browser-tier oracle records (structural-a11y /
+            ;; axe-a11y / visual-snapshot) off the SAME unified `:assertions`
+            ;; slot and presents them readably (violations as a
+            ;; finding+locus list; screenshot identity; honest cannot-run),
+            ;; rather than as the raw `:actual` EDN blob the generic
+            ;; assertions table would show.
+            [visual-a11y-view/visual-a11y-section variant-id]
             ;; rf2-ba86n.11 — result → evidence-spine link (spec/021 §2),
             ;; a graceful "evidence pending" until the spine display lands.
             [evidence-section variant-id]

--- a/tools/story/src/re_frame/story/ui/test_mode/visual_a11y_view.cljs
+++ b/tools/story/src/re_frame/story/ui/test_mode/visual_a11y_view.cljs
@@ -1,0 +1,233 @@
+(ns re-frame.story.ui.test-mode.visual-a11y-view
+  "The `:test` mode pane's VISUAL + A11Y check-results section (rf2-ba86n.15,
+  tools/story/spec/021-Story-UI-Test-And-Evidence.md §4 — visual and a11y
+  checks). Unblocked by #2484, which wired the structural-a11y executor into
+  the run path so the run path now produces `:rf.assert/a11y-structural`
+  verdicts + browser-tier visual results in the unified
+  `re-frame.story.result` run-result.
+
+  ## What this presents (spec/021 §4)
+
+  Visual / a11y checks are runner-tiered assertions on the SAME run-result
+  model (`re-frame.story.play.browser` — \"a finding is an assertion record
+  like any other; no new run-result slot\"). The generic assertions table
+  (`view/rows-section`) already lists every record, but it renders a
+  browser-tier finding as a raw `:actual` EDN blob. This dedicated component
+  presents those findings READABLY:
+
+  - **structural a11y violations** — a `{:finding :locus}` list (the issue
+    in words + the offending hiccup tag), pass/fail per the unified
+    `:status`;
+  - **axe-style a11y violations** — the `{:id :impact :help}` axe surface,
+    likewise readable;
+  - **visual checks** — the captured screenshot/snapshot identity (the
+    reused `content-hash` regression key) and any baseline it diffed
+    against;
+  - **honest `:cannot-run`** — a browser-tier check the headless / hiccup
+    runner could NOT attempt shows `:cannot-run` with its reason (reusing
+    the warning-tinted `:cannot-run` vocabulary), never a false pass or a
+    silent blank (spec/017 §`:cannot-run`).
+
+  ## Reuse, not re-derivation
+
+  The rows come from `re-frame.story.ui.test-mode.pure/browser-result-rows`,
+  which READS the browser-tier records off the unified run-result's
+  `:assertions` slot — the SAME source Test mode + docs already project
+  (`re-frame.story.assertions/browser-assertion-ids` selects them). No
+  parallel result vocabulary, no second accumulator.
+
+  ## Elision
+
+  CLJS-only. Reached only through `view/test-view`, which the shell mounts
+  behind the `config/enabled?` gate, so production builds never invoke it —
+  closure DCEs the lot."
+  (:require [re-frame.story.ui.test-mode.pure        :as pure]
+            [re-frame.story.ui.test-mode.state       :as state]
+            [re-frame.story.theme.typography :as typography :refer [mono-stack]]
+            [re-frame.story.theme.colors :as colors]))
+
+;; ---- styles (theme tokens only — no shell restyle) -----------------------
+
+(def ^:private styles
+  {:section     {:margin-top "16px"}
+   :section-h   {:font-weight    "bold"
+                 :color          (:text-secondary colors/tokens)
+                 :text-transform "uppercase"
+                 :font-size      (:micro typography/type-scale)
+                 :letter-spacing "0.5px"
+                 :margin-bottom  "8px"
+                 :border-bottom  (str "1px solid " (:border-default colors/tokens))
+                 :padding-bottom "4px"}
+   :card        {:border        (str "1px solid " (:border-default colors/tokens))
+                 :border-radius "4px"
+                 :margin-bottom "6px"
+                 :background    (:bg-2 colors/tokens)
+                 :font-family   mono-stack
+                 :font-size     (:caption typography/type-scale)}
+   :card-head   {:display       "flex"
+                 :align-items   "center"
+                 :gap           "8px"
+                 :padding       "6px 10px"}
+   :kind-label  {:color       (:text-primary colors/tokens)
+                 :font-weight "bold"}
+   :reason      {:color       (:text-secondary colors/tokens)
+                 :font-size   (:micro typography/type-scale)
+                 :margin-left "auto"
+                 :text-align  "right"}
+   :findings    {:list-style  "none"
+                 :margin      "0"
+                 :padding     "0 10px 8px 10px"}
+   :finding-row {:padding       "4px 0"
+                 :border-top    (str "1px solid " (:border-default colors/tokens))
+                 :display       "flex"
+                 :gap           "8px"
+                 :align-items   "baseline"}
+   :finding-txt {:color (:text-primary colors/tokens)}
+   :locus       {:color         (:info colors/tokens)
+                 :background    (:bg-3 colors/tokens)
+                 :padding       "1px 6px"
+                 :border-radius "3px"
+                 :font-size     (:micro typography/type-scale)
+                 :white-space   "nowrap"}
+   :impact      {:color          (:warning colors/tokens)
+                 :text-transform "uppercase"
+                 :font-size      (:micro typography/type-scale)
+                 :letter-spacing "0.4px"}
+   :detail      {:color     (:text-tertiary colors/tokens)
+                 :font-size (:micro typography/type-scale)}
+   :all-clear   {:color      (:success colors/tokens)
+                 :padding    "4px 10px 8px 10px"
+                 :font-style "italic"}
+   :snap-box    {:padding "4px 10px 8px 10px"}
+   :snap-key    {:color          (:text-tertiary colors/tokens)
+                 :text-transform "uppercase"
+                 :font-size      (:micro typography/type-scale)
+                 :letter-spacing "0.4px"
+                 :margin-right   "6px"}
+   :snap-val    {:color (:text-primary colors/tokens)}
+   :cannot-box  {:padding    "4px 10px 8px 10px"
+                 :color      (:warning colors/tokens)
+                 :font-style "italic"}})
+
+(def ^:private status-pill
+  {:pass       {:bg (:success-bg colors/tokens) :fg (:success colors/tokens) :glyph "✓" :label "pass"}
+   :fail       {:bg (:danger-bg colors/tokens)  :fg (:danger colors/tokens)  :glyph "✗" :label "fail"}
+   :error      {:bg (:danger-bg colors/tokens)  :fg (:danger colors/tokens)  :glyph "✖" :label "error"}
+   :cannot-run {:bg (:warning-bg colors/tokens) :fg (:warning colors/tokens) :glyph "⊘" :label "cannot-run"}})
+
+(def ^:private kind-title
+  {:visual         "Visual snapshot"
+   :a11y           "Accessibility (axe)"
+   :a11y-structural "Accessibility (structural)"
+   :browser        "Browser check"})
+
+(defn- pill
+  "The status pill for one browser-tier row — pass / fail / error, plus the
+  distinct THIRD `:cannot-run` state (spec/018 §12.6)."
+  [status]
+  (let [{:keys [bg fg glyph label]} (get status-pill status (:fail status-pill))]
+    [:span {:style       {:padding        "2px 8px"
+                          :border-radius  "8px"
+                          :background     bg
+                          :color          fg
+                          :font-size      (:micro typography/type-scale)
+                          :font-weight    "bold"
+                          :text-transform "uppercase"
+                          :letter-spacing "0.4px"}
+            :data-test   "story-va-status-pill"
+            :data-status (name status)}
+     (str glyph " " label)]))
+
+(defn- findings-list
+  "Render an a11y findings list (structural or axe) readably — the finding
+  in words + its locus (the offending hiccup tag / axe rule id), the
+  executor's detail line, and (axe) the impact level. Never a raw EDN blob."
+  [findings]
+  [:ul {:style (:findings styles) :data-test "story-va-findings"}
+   (for [[i {:keys [finding locus detail impact rule]}] (map-indexed vector findings)]
+     ^{:key (str rule "#" i)}
+     [:li {:style       (:finding-row styles)
+           :data-test   "story-va-finding"
+           :data-rule   (str rule)}
+      (when locus
+        [:span {:style (:locus styles) :data-test "story-va-locus"} locus])
+      [:span {:style (:finding-txt styles)} finding]
+      (when impact
+        [:span {:style (:impact styles)} impact])
+      (when (and detail (not= detail finding))
+        [:span {:style (:detail styles)} detail])])])
+
+(defn- a11y-card
+  "One a11y check card (structural or axe). On `:cannot-run` shows the
+  refusal reason; on a clean pass shows an all-clear line; on a fail shows
+  the readable findings list."
+  [{:keys [kind status reason count findings]}]
+  [:div {:style       (:card styles)
+         :data-test   "story-va-card"
+         :data-kind   (name kind)
+         :data-status (name status)}
+   [:div {:style (:card-head styles)}
+    [pill status]
+    [:span {:style (:kind-label styles)} (get kind-title kind "a11y check")]
+    [:span {:style (:reason styles)} reason]]
+   (cond
+     (= status :cannot-run)
+     [:div {:style (:cannot-box styles) :data-test "story-va-cannot-run"}
+      "cannot run on this runner — this browser-tier check was not attempted"]
+
+     (seq findings)
+     (findings-list findings)
+
+     :else
+     [:div {:style (:all-clear styles) :data-test "story-va-all-clear"}
+      (str "no " (when (= count 0) "") "violations")])])
+
+(defn- visual-card
+  "One visual-snapshot check card. On `:cannot-run` (the headless / no-pixel
+  runner) shows the refusal honestly; otherwise presents the captured
+  screenshot/snapshot identity (the reused `content-hash` regression key)
+  and any baseline it diffed against. A real pixel-diff image lands with the
+  `:pixels` browser runner; the identity is the regression artifact today."
+  [{:keys [status reason snapshot baseline]}]
+  [:div {:style       (:card styles)
+         :data-test   "story-va-card"
+         :data-kind   "visual"
+         :data-status (name status)}
+   [:div {:style (:card-head styles)}
+    [pill status]
+    [:span {:style (:kind-label styles)} (get kind-title :visual)]
+    [:span {:style (:reason styles)} reason]]
+   (if (= status :cannot-run)
+     [:div {:style (:cannot-box styles) :data-test "story-va-cannot-run"}
+      "cannot run on this runner — a screenshot/pixel diff needs a real browser (:pixels)"]
+     [:div {:style (:snap-box styles) :data-test "story-va-snapshot"}
+      [:div
+       [:span {:style (:snap-key styles)} "snapshot"]
+       [:span {:style (:snap-val styles)} (if (some? snapshot) (pr-str snapshot) "—")]]
+      (when (some? baseline)
+        [:div
+         [:span {:style (:snap-key styles)} "baseline"]
+         [:span {:style (:snap-val styles)} (pr-str baseline)]])])])
+
+(defn visual-a11y-section
+  "The visual + a11y check-results section for `variant-id` (spec/021 §4).
+  Reads the browser-tier oracle records off the unified run-result's
+  `:assertions` slot via `pure/browser-result-rows` and presents each
+  readably (structural-a11y violations as a `{:finding :locus}` list, axe
+  violations likewise, visual snapshot identity, honest `:cannot-run`).
+
+  Renders NOTHING when the run recorded no browser-tier checks — the common
+  headless case (an honest empty state, never a fabricated card)."
+  [variant-id]
+  (let [slot   (get @state/results-atom variant-id)
+        result (:result slot)
+        rows   (some-> result pure/browser-result-rows)]
+    (when (seq rows)
+      [:div {:style     (:section styles)
+             :data-test "story-test-visual-a11y-section"}
+       [:div {:style (:section-h styles)} "Visual & accessibility"]
+       (for [[i {:keys [kind] :as row}] (map-indexed vector rows)]
+         ^{:key (str kind "#" i)}
+         (if (= kind :visual)
+           [visual-card row]
+           [a11y-card row]))])))

--- a/tools/story/test/re_frame/story/ui/test_mode/visual_a11y_pure_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/test_mode/visual_a11y_pure_cljs_test.cljc
@@ -1,0 +1,165 @@
+(ns re-frame.story.ui.test-mode.visual-a11y-pure-cljs-test
+  "JVM + CLJS pure-data tests for the visual + a11y check-RESULTS projection
+  (rf2-ba86n.15, tools/story/spec/021-Story-UI-Test-And-Evidence.md §4).
+
+  The substantive UI is CLJS, but the projection the dedicated visual/a11y
+  results component (`re-frame.story.ui.test-mode.visual-a11y-view`)
+  consumes is `.cljc` + pure (`pure/browser-result-rows` and friends), so
+  the JVM test corpus pins the contract without booting Reagent.
+
+  The browser-tier oracle records under test are exactly the shapes the run
+  path (post-#2484) produces via
+  `re-frame.story.play.browser/eval-browser-assertion`:
+
+  - `:rf.assert/a11y-structural` — `:actual` is the `{:rule :tag :detail}`
+    issue vector from `browser/structural-issues`;
+  - `:rf.assert/a11y` — `:actual` is the `{:id :impact :help}` axe vector;
+  - `:rf.assert/visual-snapshot` — `:actual` is the content-hash snapshot
+    identity, `:expected` the baseline;
+  - any of the three can be `:cannot-run` (the headless / hiccup refusal)."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.story.ui.test-mode.pure :as pure]))
+
+;; ---- structural-a11y-findings -------------------------------------------
+
+(deftest structural-findings-readable-finding-and-locus
+  (testing "each issue projects to a {:finding :locus :detail :rule} row"
+    (let [rec  {:assertion :rf.assert/a11y-structural
+                :status    :fail
+                :count     2
+                :actual    [{:rule :img-missing-alt :tag :img
+                             :detail "img element has no :alt attribute"}
+                            {:rule :control-missing-name :tag :button
+                             :detail "button control has no accessible name"}]}
+          rows (pure/structural-a11y-findings rec)]
+      (is (= 2 (count rows)))
+      (is (= "image missing alt text" (:finding (first rows))))
+      (is (= "<img>" (:locus (first rows))))
+      (is (= :img-missing-alt (:rule (first rows))))
+      (is (= "interactive control has no accessible name" (:finding (second rows))))
+      (is (= "<button>" (:locus (second rows)))))))
+
+(deftest structural-findings-unknown-rule-falls-back-readably
+  (testing "an unknown rule kebab-spells rather than dropping the finding"
+    (let [rows (pure/structural-a11y-findings
+                 {:actual [{:rule :some-future-rule :tag :div :detail "d"}]})]
+      (is (= "some future rule" (:finding (first rows))))
+      (is (= "<div>" (:locus (first rows)))))))
+
+(deftest structural-findings-empty-on-no-issues
+  (is (= [] (pure/structural-a11y-findings {:actual []})))
+  (is (= [] (pure/structural-a11y-findings {}))))
+
+;; ---- axe-a11y-findings ---------------------------------------------------
+
+(deftest axe-findings-project-id-impact-help
+  (let [rows (pure/axe-a11y-findings
+               {:actual [{:id "color-contrast" :impact "serious"
+                          :help "Elements must have sufficient colour contrast"}]})]
+    (is (= 1 (count rows)))
+    (is (= "Elements must have sufficient colour contrast" (:finding (first rows))))
+    (is (= "color-contrast" (:locus (first rows))))
+    (is (= "serious" (:impact (first rows))))))
+
+;; ---- browser-result-rows: selection + kinds -----------------------------
+
+(deftest browser-rows-select-only-browser-tier-records
+  (testing "the projection reads ONLY the three browser-tier ids off the
+            unified :assertions slot (the same source Test mode projects)"
+    (let [result {:assertions
+                  [{:assertion :rf.assert/path-equals :status :pass}
+                   {:assertion :rf.assert/a11y-structural :status :pass
+                    :count 0 :actual []}
+                   {:assertion :rf.assert/no-warnings :status :pass}
+                   {:assertion :rf.assert/a11y :status :cannot-run
+                    :reason "axe needs a real browser"}
+                   {:assertion :rf.assert/visual-snapshot :status :cannot-run
+                    :reason "visual needs :pixels"}]}
+          rows   (pure/browser-result-rows result)]
+      (is (= 3 (count rows)) "only the 3 browser-tier records surface")
+      (is (= [:a11y-structural :a11y :visual] (mapv :kind rows))))))
+
+(deftest browser-rows-empty-when-headless-run-has-no-browser-checks
+  (testing "the common headless case projects to no rows — an honest empty
+            state, never a fabricated card"
+    (is (= [] (pure/browser-result-rows
+                {:assertions [{:assertion :rf.assert/path-equals :status :pass}]})))
+    (is (= [] (pure/browser-result-rows {:assertions []})))
+    (is (= [] (pure/browser-result-rows {})))))
+
+;; ---- browser-result-rows: structural-a11y fail --------------------------
+
+(deftest browser-rows-structural-fail-carries-readable-findings
+  (let [result {:assertions
+                [{:assertion :rf.assert/a11y-structural
+                  :status    :fail
+                  :count     1
+                  :reason    "1 structural a11y issue(s) in the rendered hiccup tree: img-missing-alt"
+                  :actual    [{:rule :img-missing-alt :tag :img
+                               :detail "img element has no :alt attribute"}]}]}
+        row    (first (pure/browser-result-rows result))]
+    (is (= :a11y-structural (:kind row)))
+    (is (= :fail (:status row)))
+    (is (= 1 (:count row)))
+    (is (= 1 (count (:findings row))))
+    (is (= "image missing alt text" (:finding (first (:findings row)))))
+    (is (= "<img>" (:locus (first (:findings row)))))
+    (is (string? (:reason row)) "the diagnostic reason is threaded through")))
+
+;; ---- browser-result-rows: honest :cannot-run ----------------------------
+
+(deftest browser-rows-cannot-run-shows-reason-not-a-false-pass
+  (testing "spec/017 §:cannot-run — a browser-tier check the runner could
+            not attempt carries its reason and is NOT a pass; no findings"
+    (let [result {:assertions
+                  [{:assertion   :rf.assert/a11y
+                    :status      :cannot-run
+                    :cannot-run? true
+                    :passed?     false
+                    :reason      "axe-style a11y requires a real browser (:a11y-engine)"}
+                   {:assertion   :rf.assert/visual-snapshot
+                    :status      :cannot-run
+                    :cannot-run? true
+                    :passed?     false
+                    :reason      "visual snapshot requires a real browser (:pixels)"}]}
+          rows   (pure/browser-result-rows result)
+          [axe vis] rows]
+      (is (= :cannot-run (:status axe)))
+      (is (not= :pass (:status axe)))
+      (is (= [] (:findings axe)) "no findings fabricated on cannot-run")
+      (is (re-find #"real browser" (:reason axe)))
+      (is (= :cannot-run (:status vis)))
+      (is (nil? (:snapshot vis)) "no snapshot identity fabricated on cannot-run")
+      (is (re-find #":pixels" (:reason vis))))))
+
+;; ---- browser-result-rows: visual snapshot presentation ------------------
+
+(deftest browser-rows-visual-snapshot-presents-identity-and-baseline
+  (testing "a captured visual snapshot presents the content-hash identity;
+            a keyword :expected (:rf.story/any-snapshot) is not a baseline"
+    (let [captured {:assertions [{:assertion :rf.assert/visual-snapshot
+                                  :status :pass
+                                  :actual "abc123"
+                                  :expected :rf.story/any-snapshot}]}
+          row      (first (pure/browser-result-rows captured))]
+      (is (= :visual (:kind row)))
+      (is (= "abc123" (:snapshot row)))
+      (is (nil? (:baseline row)) ":rf.story/any-snapshot is no baseline")))
+  (testing "a baseline-diffing visual snapshot presents both hashes"
+    (let [diffed {:assertions [{:assertion :rf.assert/visual-snapshot
+                                :status :fail
+                                :actual "new-hash"
+                                :expected "base-hash"}]}
+          row    (first (pure/browser-result-rows diffed))]
+      (is (= "new-hash" (:snapshot row)))
+      (is (= "base-hash" (:baseline row))))))
+
+;; ---- browser-result-rows: legacy :passed? fallback ----------------------
+
+(deftest browser-rows-fall-back-to-passed-when-status-unstamped
+  (testing "a record minted by a status-unaware path still reads pass/fail
+            from :passed? (the legacy fallback, not the primary)"
+    (let [result {:assertions [{:assertion :rf.assert/a11y-structural
+                                :passed? true :actual []}]}
+          row    (first (pure/browser-result-rows result))]
+      (is (= :pass (:status row))))))


### PR DESCRIPTION
## Summary

Present the visual + a11y check **RESULTS** the run path now produces (post-#2484, which wired the structural-a11y executor into the run path so the unified `re-frame.story.result` run-result now carries `:rf.assert/a11y-structural` verdicts + browser-tier visual results), per `tools/story/spec/021-Story-UI-Test-And-Evidence.md` §4.

This is the RESULTS-DISPLAY side (the expectation-AUTHORING flow is rf2-ba86n.12's lane). The generic assertions table already lists every record, but renders a browser-tier finding as a raw `:actual` EDN blob; this adds a dedicated results component that presents them readably.

## a11y-violation + visual-result presentation

- **structural a11y** (`:rf.assert/a11y-structural`, the `:hiccup` tier) — violations render as a readable `{:finding :locus}` list: the issue in words (`image missing alt text`, `interactive control has no accessible name`, …) + the offending hiccup tag as the locus (`<img>`, `<button>`), not the raw `{:rule :tag :detail}` blob. Pass/fail per the unified `:status`.
- **axe-style a11y** (`:rf.assert/a11y`, `:a11y-engine`) — the `{:id :impact :help}` axe surface, likewise readable (help text + rule id + impact).
- **visual snapshot** (`:rf.assert/visual-snapshot`, `:pixels`) — presents the captured screenshot/snapshot identity (the reused `content-hash` regression key) and any baseline it diffed against. A real pixel-diff image lands later with the `:pixels` browser runner; the identity is the regression artifact today.

## Honest `:cannot-run`

A browser-tier check the headless / hiccup runner could not even attempt renders a distinct warning-tinted `:cannot-run` card carrying the executor's reason ("…requires a real browser (:pixels)" / "(:a11y-engine)") — never a false pass or a silent blank (spec/017 §`:cannot-run`). No findings / snapshot identity are fabricated on a `:cannot-run` row.

## Run-result reuse (not re-derivation)

`pure/browser-result-rows` READS the browser-tier records off the unified run-result's `:assertions` slot — the SAME source Test mode + docs already project — selecting them via `re-frame.story.assertions/browser-assertion-ids`. The records ride the ONE assertion-record shape (`re-frame.story.play.browser` — "a finding is an assertion record like any other; no new run-result slot"). No parallel result vocabulary, no second accumulator. Status reads the unified `:status` the run path stamped (legacy `:passed?` is the fallback).

## Files

- `tools/story/src/re_frame/story/ui/test_mode/pure.cljc` — `browser-result-rows` + `structural-a11y-findings` / `axe-a11y-findings` (pure, JVM-testable).
- `tools/story/src/re_frame/story/ui/test_mode/visual_a11y_view.cljs` — dedicated CLJS results component (consumes existing theme tokens; does not restyle the shell).
- `tools/story/src/re_frame/story/ui/test_mode/view.cljs` — one-line section hook after `cannot-run-section`.
- `tools/story/test/re_frame/story/ui/test_mode/visual_a11y_pure_cljs_test.cljc` — 10 tests / 39 assertions over the projection (selection, structural findings, axe findings, honest cannot-run, visual identity + baseline, legacy fallback).

Fences respected: did NOT touch `assertion_strip.cljs`, `command_palette.cljc`, or `shell.cljs`. `test_mode/` touched minimally (one section hook). Spec/021 §4 already specifies this behavior normatively — implemented, not re-specced.

## Quality gates

- `clj-kondo --parallel --fail-level error --lint tools/story` — **errors: 0** (123 pre-existing corpus warnings, none in changed files).
- `tools/story` `clojure -M:test` — 0 failures, 0 errors (new ns: 10 tests / 39 assertions pass).
- `npm run test:cljs` — build 0 warnings (the `.cljs` component compiles clean); 4956 tests, 0 failures, 0 errors.
- `npm run test:bundle-isolation` — PASS (no Xray/story-internal leak).
- `bash scripts/test-fast-pr.sh` — PASS fast PR spine.