### PR TITLE
feat(story/ui): author expectations from stories (rf2-ba86n.12)

### DIFF
--- a/tools/story/spec/021-Story-UI-Test-And-Evidence.md
+++ b/tools/story/spec/021-Story-UI-Test-And-Evidence.md
@@ -117,6 +117,56 @@ Test mode SHOULD support:
 - link assertion failures to the evidence spine and Xray focus (§2) where
   the result carries enough coordinates.
 
+## 1a. Authoring expectations onto a story (S5)
+
+Story pressure: S5.
+
+The S5 workflow — a useful story becomes a regression test without a
+separate fixture — has a CURRENT authoring surface: the expectation-author
+UI `re-frame.story.ui.author-expectations` over the pure
+`re-frame.story.author-expectations` substrate (rf2-ba86n.12). It is a thin
+layer; it reimplements NO assertion vocabulary and NO runner-cost model.
+
+It MUST:
+
+- let the author add/generate expectations for app-db, subscriptions,
+  rendered hiccup/DOM, schema behaviour, and browser/a11y evidence — each
+  authored expectation folds onto the canonical
+  `re-frame.story.assertions` `:rf.assert/*` atom for that surface (the ONE
+  vocabulary, never a parallel expectation model);
+- show the runner cost / `:cannot-run` **before save** — for each
+  expectation, the capability tokens it requires, the cheapest concrete
+  runner that can prove it, and whether it `:cannot-run` under the default
+  headless runner — read from the EXISTING
+  `re-frame.story.requirements` registry (`assertion-tokens` /
+  `cheapest-runner` / `select-runner`), so the cost is honest and never
+  discovered only at run time;
+- make the saved expectations EXPLICIT variant DATA — a `(reg-variant …
+  {:assertions […]})` form whose authored atoms are merged with the source
+  variant's already-declared `:assertions` (additive, round-trips through
+  the registrar), authored via `:extends` of the source — NOT hidden UI
+  state.
+
+It is reachable from the Controls panel (`add expectations…`, beside
+`save as new variant…`) and the command palette (`Add expectations to this
+story`).
+
+Authoring expectations is **distinct** from save-current-state-as-variant
+([`019-Story-UI-Controls-And-View-States.md`](019-Story-UI-Controls-And-View-States.md)
+§3 — intentional STATE authoring of the live canvas) and from
+generated-failure promotion (§3 — a captured run ARTIFACT). The three flows
+share the review-then-commit dialog skeleton but have separate entry points
+and source semantics: save-current's source is the live args snapshot,
+promotion's source is a captured artifact, and authoring's source is the
+author's declared INTENT (the expectation). Conflating any two is an
+explicit not-EPIC-ready condition.
+
+The read-only display of a variant's authored (declared, un-run)
+expectations — each atom with its runner-cost / `:cannot-run` flag — is the
+`authored-expectation-strip` companion in
+`re-frame.story.ui.assertion-strip` (distinct from the run-result strip,
+which carries verdicts).
+
 ## 2. Result → evidence linkage
 
 Story pressure: S4.

--- a/tools/story/src/re_frame/story/author_expectations.cljc
+++ b/tools/story/src/re_frame/story/author_expectations.cljc
@@ -1,0 +1,500 @@
+(ns re-frame.story.author-expectations
+  "Author EXPECTATIONS onto a story — the S5 workflow where a useful story
+  becomes a regression test without a separate fixture (rf2-ba86n.12;
+  `tools/story/spec/021-Story-UI-Test-And-Evidence.md` §S5,
+  `019-Story-UI-Controls-And-View-States.md`).
+
+  ## What this flow is — and is NOT
+
+  Expectation authoring ADDS assertions to a story. The author picks an
+  expectation KIND (app-db value, subscription value, rendered hiccup/DOM,
+  schema behaviour, browser/a11y evidence), fills its operands, and the
+  flow emits the canonical `re-frame.story.assertions` atom(s) folded onto
+  the variant body's `:assertions` slot. The saved expectations become
+  EXPLICIT variant DATA (a `(reg-variant … {:assertions […]})` form the
+  author pastes into source), NOT hidden UI state.
+
+  It is DISTINCT from its two siblings, which it MUST NOT conflate:
+
+  - **save-current-state-as-variant** (`re-frame.story.save-variant`,
+    rf2-ba86n.6, spec/019 §3) captures the live canvas STATE (args
+    snapshot) into a new variant. It authors a state, not an expectation.
+  - **generated-failure promotion** (`re-frame.story.ui.promotion`,
+    rf2-ba86n.13, spec/021 §3) turns a captured run ARTIFACT into a named
+    regression variant. Its source is a captured run, not a hand-authored
+    expectation.
+
+  This flow's source is the author's INTENT: \"I expect this story to hold
+  X.\" The three flows share the `review-dialog` review-then-commit
+  skeleton but never the same entry point or artifact-kind semantics.
+
+  ## The honesty floor — runner cost / `:cannot-run` BEFORE save
+
+  Every authored expectation declares the capability tokens it needs (via
+  the EXISTING `re-frame.story.requirements` registry — this flow reads it,
+  it does NOT redefine the runner model). So the dialog can show, for each
+  expectation BEFORE it is saved:
+
+  - the capability tokens the expectation requires;
+  - the cheapest concrete runner that can prove it (`cheapest-runner`);
+  - whether it `:cannot-run` under the default headless runner (a DOM /
+    pixels / a11y-engine / reactive-counts expectation cannot run headless)
+    — surfaced as an honest `:cannot-run` flag, not hidden.
+
+  A `:cannot-run` expectation is still authorable (it is legitimate to
+  declare a browser-tier expectation a headless run will refuse) — the
+  point is the user SEES the cost before committing, never discovering it
+  only at run time.
+
+  ## Reuse, don't reinvent
+
+  - The assertion VOCABULARY is `re-frame.story.assertions` (the canonical
+    `:rf.assert/*` atoms). This ns builds those atoms from the author's
+    operands; it does NOT define a parallel expectation model.
+  - The runner COST / `:cannot-run` decision is `re-frame.story.requirements`
+    (`assertion-tokens` / `cheapest-runner` / `select-runner` /
+    `unmet-assertions`). This ns reads it.
+  - The schema-kind expectation CONSUMES the existing schema-resolution
+    surface — it folds onto `:rf.assert/path-matches` (a Malli schema at a
+    path) and `:rf.assert/schema-error` (an expected boundary violation),
+    both already in the canonical vocabulary. It does NOT redefine or
+    unify the schema resolvers (that is the pending ayu6n/p5ivc/vnedo
+    decision's lane).
+
+  ## Pure / CLJS split
+
+  Mirrors `save_variant.cljc` + `promotion.cljc`: the catalog, the atom
+  builders, the per-expectation cost projection, the draft transitions, and
+  the `(reg-variant …)` snippet are pure `.cljc` (JVM-testable without a
+  host). The dialog ratom + the Reagent render live in the CLJS-only
+  `re-frame.story.ui.author-expectations`."
+  (:require [clojure.string :as str]
+            #?(:clj  [clojure.edn :as edn]
+               :cljs [cljs.reader :as edn])
+            [re-frame.story.assertions   :as assertions]
+            [re-frame.story.predicates   :as pred]
+            [re-frame.story.requirements :as requirements]))
+
+;; ===========================================================================
+;; THE EXPECTATION-KIND CATALOG  (the authorable expectation surface)
+;; ===========================================================================
+;;
+;; Each kind names ONE authorable expectation. It carries the human label,
+;; the canonical assertion id it folds onto (so the runner cost is read
+;; from the requirement registry keyed on that id), the operand fields the
+;; author fills, and a pure `:->atom` builder that turns the filled operand
+;; map into the canonical `[:rf.assert/* …]` atom. The acceptance criteria
+;; (rf2-ba86n.12) name five expectation surfaces — app-db, subscriptions,
+;; rendered hiccup/DOM, schema behaviour, browser/a11y evidence — and each
+;; resolves to a kind below that folds onto the EXISTING vocabulary.
+
+(defn- read-edn
+  "Best-effort read of an EDN operand string into a value. Pure-ish (the
+  only impurity is `read-string`, which is data → data here). Returns
+  `[ok? value-or-error]`. A blank string reads as nil with `ok? false`
+  (so the dialog can show 'fill this operand' rather than committing a nil
+  expectation). Tolerant: a malformed form reports `ok? false` with the
+  error message rather than throwing."
+  [s]
+  (cond
+    (nil? s)            [false nil]
+    (str/blank? s)      [false nil]
+    :else
+    (try
+      [true (edn/read-string s)]
+      (catch #?(:clj Exception :cljs :default) e
+        [false #?(:clj (.getMessage ^Exception e) :cljs (str e))]))))
+
+(defn- parse-path
+  "Parse an app-db path operand string into a vector. Accepts the printed
+  vector form `[:a :b]` (read as EDN) or a bare keyword `:a` (lifted to
+  `[:a]`). Returns `[ok? path-or-error]`. Pure data → data."
+  [s]
+  (let [[ok? v] (read-edn s)]
+    (cond
+      (not ok?)     [false v]
+      (vector? v)   [true v]
+      (keyword? v)  [true [v]]
+      :else         [false (str "path must be a vector or keyword, got " (pr-str v))])))
+
+(def expectation-kinds
+  "The ordered catalog of authorable expectation kinds. Each descriptor:
+
+  - `:kind`     — the kind keyword (stable id the dialog + tests key on).
+  - `:label`    — human label for the kind picker.
+  - `:surface`  — the acceptance-criteria surface it serves (`:app-db` /
+                  `:subscriptions` / `:dom` / `:schema` / `:browser`) — so
+                  the dialog can group / explain coverage.
+  - `:assertion-id` — the canonical `:rf.assert/*` id it folds onto (the
+                  key the requirement registry reads for the runner cost).
+  - `:operands` — ordered vector of operand field descriptors
+                  `{:field :label :placeholder :parse}` where `:parse` is a
+                  pure `(string) → [ok? value-or-error]` operand parser.
+  - `:doc`      — one-line description shown under the kind in the picker.
+
+  The builder `expectation->atom` reads `:kind` + the filled operand map
+  and produces the canonical atom; the cost projection reads
+  `:assertion-id` against the requirement registry."
+  [{:kind         :app-db-equals
+    :label        "App-db value equals"
+    :surface      :app-db
+    :assertion-id :rf.assert/path-equals
+    :doc          "Assert the value at an app-db path equals an expected value (:rf.assert/path-equals)."
+    :operands     [{:field :path :label "path" :placeholder "[:counter :value]" :parse parse-path}
+                   {:field :expected :label "expected" :placeholder "5" :parse read-edn}]}
+
+   {:kind         :app-db-matches
+    :label        "App-db value matches schema"
+    :surface      :app-db
+    :assertion-id :rf.assert/path-matches
+    :doc          "Assert the value at an app-db path validates against a Malli schema (:rf.assert/path-matches)."
+    :operands     [{:field :path :label "path" :placeholder "[:user]" :parse parse-path}
+                   {:field :schema :label "malli schema" :placeholder "[:map [:id :int]]" :parse read-edn}]}
+
+   {:kind         :sub-equals
+    :label        "Subscription value equals"
+    :surface      :subscriptions
+    :assertion-id :rf.assert/sub-equals
+    :doc          "Assert a subscription returns an expected value, via compute-sub against the settled state (:rf.assert/sub-equals)."
+    :operands     [{:field :query-v :label "query vector" :placeholder "[:counter/value]" :parse read-edn}
+                   {:field :expected :label "expected" :placeholder "5" :parse read-edn}]}
+
+   {:kind         :dispatched
+    :label        "Event was dispatched"
+    :surface      :app-db
+    :assertion-id :rf.assert/dispatched?
+    :doc          "Assert a matching event was dispatched during the run (:rf.assert/dispatched?)."
+    :operands     [{:field :event :label "event id or vector" :placeholder ":counter/inc" :parse read-edn}]}
+
+   {:kind         :effect-emitted
+    :label        "Effect was emitted"
+    :surface      :app-db
+    :assertion-id :rf.assert/effect-emitted
+    :doc          "Assert a user effect was emitted during the run (:rf.assert/effect-emitted)."
+    :operands     [{:field :fx-id :label "fx id" :placeholder ":http/get" :parse read-edn}]}
+
+   {:kind         :no-warnings
+    :label        "No warnings"
+    :surface      :app-db
+    :assertion-id :rf.assert/no-warnings
+    :doc          "Assert no warning-level trace events fired during the run (:rf.assert/no-warnings)."
+    :operands     []}
+
+   {:kind         :dom-text
+    :label        "Rendered DOM text"
+    :surface      :dom
+    :assertion-id :rf.assert/dom-text
+    :doc          "Assert a selector's rendered text — needs a DOM-capable runner (:rf.assert/dom-text)."
+    :operands     [{:field :selector :label "selector" :placeholder "\".count\"" :parse read-edn}
+                   {:field :text :label "text" :placeholder "\"5\"" :parse read-edn}]}
+
+   {:kind         :dom-visible
+    :label        "Rendered element visible"
+    :surface      :dom
+    :assertion-id :rf.assert/dom-visible
+    :doc          "Assert a selector is visible in the rendered DOM — needs a DOM-capable runner (:rf.assert/dom-visible)."
+    :operands     [{:field :selector :label "selector" :placeholder "\".submit\"" :parse read-edn}]}
+
+   {:kind         :a11y-structural
+    :label        "Structural a11y (hiccup tree)"
+    :surface      :browser
+    :assertion-id :rf.assert/a11y-structural
+    :doc          "Assert structural accessibility over the rendered hiccup tree — runs at the :hiccup tier (:rf.assert/a11y-structural)."
+    :operands     []}
+
+   {:kind         :a11y
+    :label        "Accessibility scan (axe)"
+    :surface      :browser
+    :assertion-id :rf.assert/a11y
+    :doc          "Assert an axe-style accessibility scan passes — needs a browser runner (:rf.assert/a11y)."
+    :operands     []}
+
+   {:kind         :visual-snapshot
+    :label        "Visual snapshot"
+    :surface      :browser
+    :assertion-id :rf.assert/visual-snapshot
+    :doc          "Assert a visual snapshot matches its baseline — needs a browser runner with pixels (:rf.assert/visual-snapshot)."
+    :operands     []}
+
+   {:kind         :schema-error
+    :label        "Expected schema violation"
+    :surface      :schema
+    :assertion-id :rf.assert/schema-error
+    :doc          "Assert the run is EXPECTED to emit one schema-validation failure on a named surface (:rf.assert/schema-error)."
+    :operands     [{:field :where-spec :label "spec map" :placeholder "{:where :event :event :user/save}"
+                    :parse read-edn :optional? true}]}])
+
+(defn kind-descriptor
+  "The catalog descriptor for `kind`, or nil. Pure data → data."
+  [kind]
+  (some (fn [d] (when (= kind (:kind d)) d)) expectation-kinds))
+
+(def surface-labels
+  "Human labels for the acceptance-criteria expectation surfaces. Used by
+  the dialog's coverage hint so the author sees which surfaces their
+  authored expectations span (app-db / subscriptions / DOM / schema /
+  browser·a11y)."
+  {:app-db        "App-db"
+   :subscriptions "Subscriptions"
+   :dom           "Rendered DOM"
+   :schema        "Schema behaviour"
+   :browser       "Browser / a11y"})
+
+;; ===========================================================================
+;; OPERAND PARSING + ATOM CONSTRUCTION
+;; ===========================================================================
+;;
+;; An authored expectation row is `{:kind <kind> :operands {field → raw-str}}`.
+;; `parse-operands` runs each field's parser, returning the parsed-value map
+;; plus the per-field errors. `expectation->atom` builds the canonical
+;; `[:rf.assert/* …]` atom from the parsed operands — the SAME atom the
+;; runner evaluates, so what the author reviews IS what runs.
+
+(defn parse-operands
+  "Parse a row's raw operand strings against its kind's parser specs.
+  Pure data → data. Returns:
+
+      {:values {field → parsed-value}      ; only successfully-parsed fields
+       :errors {field → error-string}      ; per-field parse errors
+       :ok?    <bool>}                      ; every required operand parsed
+
+  An unknown kind yields `{:values {} :errors {} :ok? false}` (the dialog
+  guards on a known kind before reaching here, but the fn is total)."
+  [{:keys [kind operands] :as _row}]
+  (if-let [desc (kind-descriptor kind)]
+    (let [specs (:operands desc)
+          res   (reduce
+                  (fn [acc {:keys [field parse optional?]}]
+                    (let [raw      (get operands field)
+                          blank?   (or (nil? raw) (str/blank? raw))
+                          [ok? v]  (parse raw)]
+                      (cond
+                        ;; an OPTIONAL operand left blank is simply absent —
+                        ;; no value, no error (e.g. a bare schema-error).
+                        (and optional? blank?) acc
+                        ok?                    (assoc-in acc [:values field] v)
+                        :else                  (assoc-in acc [:errors field]
+                                                          (if (string? v) v "fill this operand")))))
+                  {:values {} :errors {}}
+                  specs)]
+      (assoc res :ok? (empty? (:errors res))))
+    {:values {} :errors {} :ok? false}))
+
+(defn expectation->atom
+  "Build the canonical `[:rf.assert/* …]` assertion atom for an authored
+  `row` (`{:kind :operands}`). Pure data → data. Returns the atom on a
+  clean parse, or nil when the row's operands do not parse (the caller
+  guards on `parse-operands`'s `:ok?` before committing).
+
+  The atom is built from the SAME `re-frame.story.assertions` vocabulary
+  the runner evaluates — this fn maps operands onto an atom shape, it does
+  not define a new assertion kind."
+  [{:keys [kind] :as row}]
+  (let [{:keys [ok? values]} (parse-operands row)]
+    (when ok?
+      (case kind
+        :app-db-equals    [:rf.assert/path-equals  (:path values) (:expected values)]
+        :app-db-matches   [:rf.assert/path-matches (:path values) (:schema values)]
+        :sub-equals       [:rf.assert/sub-equals   (:query-v values) (:expected values)]
+        :dispatched       [:rf.assert/dispatched?  (:event values)]
+        :effect-emitted   [:rf.assert/effect-emitted (:fx-id values)]
+        :no-warnings      [:rf.assert/no-warnings]
+        :dom-text         [:rf.assert/dom-text     (:selector values) (:text values)]
+        :dom-visible      [:rf.assert/dom-visible  (:selector values)]
+        :a11y-structural  [:rf.assert/a11y-structural]
+        :a11y             [:rf.assert/a11y]
+        :visual-snapshot  [:rf.assert/visual-snapshot]
+        :schema-error     (let [spec (:where-spec values)]
+                            (if (map? spec)
+                              [:rf.assert/schema-error spec]
+                              [:rf.assert/schema-error]))
+        nil))))
+
+;; ===========================================================================
+;; RUNNER COST / `:cannot-run` BEFORE SAVE  (the honesty floor)
+;; ===========================================================================
+;;
+;; The keystone acceptance criterion: the runner cost / `:cannot-run` is
+;; visible BEFORE save. We read the EXISTING `re-frame.story.requirements`
+;; registry — `assertion-tokens` for the capability set, `cheapest-runner`
+;; for the runner that can prove it, and the default-headless check for the
+;; honest `:cannot-run`. No parallel cost model.
+
+(def default-author-runner
+  "The runner an authored expectation is costed against by default — the
+  same `:headless` floor a plain `story/run` uses
+  (`re-frame.story.requirements/default-runner`). The cost projection
+  reports `:cannot-run?` true when the expectation needs more than this
+  runner can prove, so the author sees the escalation cost before saving."
+  requirements/default-runner)
+
+(defn expectation-cost
+  "Project the runner cost of one authored expectation `atom` (a canonical
+  `[:rf.assert/* …]` vector) — the honesty-floor data the dialog shows
+  BEFORE save. Pure data → data; reads ONLY the existing requirement
+  registry. Returns:
+
+      {:required        #{token …}      ; capability tokens the atom needs
+       :cheapest-runner <kind|nil>      ; cheapest concrete runner that proves it
+                                        ;   (nil = NO runner can — e.g. a
+                                        ;    requirement no P1 runner advertises)
+       :headless?       <bool>          ; can the default headless runner prove it?
+       :cannot-run?     <bool>          ; true iff it needs more than the default
+                                        ;   runner — the honest before-save flag
+       :missing         #{token …}}     ; tokens the default runner lacks (the gap)
+
+  A `nil` atom (an unparsed row) projects an empty / unknown cost so the
+  dialog can render the row without throwing."
+  [atom]
+  (if (nil? atom)
+    {:required #{} :cheapest-runner nil :headless? true :cannot-run? false :missing #{}}
+    (let [required (requirements/assertion-tokens atom)
+          headless (requirements/runner-provides default-author-runner)
+          missing  (requirements/missing-tokens required headless)]
+      {:required        required
+       :cheapest-runner (requirements/cheapest-runner required)
+       :headless?       (empty? missing)
+       :cannot-run?     (seq missing)
+       :missing         missing})))
+
+(defn row-cost
+  "Convenience: parse `row` and project its `expectation-cost`. Pure data →
+  data. Returns the cost map (with an empty/headless cost for an unparsed
+  row), so the dialog can render a per-row cost stripe live as the author
+  fills operands."
+  [row]
+  (expectation-cost (expectation->atom row)))
+
+(defn draft-summary
+  "Summarize a whole expectation `draft` (its `:rows` vector) for the
+  before-save honesty banner. Pure data → data. Returns:
+
+      {:count        <int>             ; total authored rows
+       :ready        <int>             ; rows whose operands parse
+       :atoms        [atom …]          ; the canonical atoms for ready rows
+       :required     #{token …}        ; union of every ready atom's tokens
+       :cheapest-runner <kind|nil>     ; cheapest runner proving ALL ready atoms
+       :cannot-run-rows [{:row :atom :cost} …]  ; rows that can't run headless
+       :surfaces     #{surface …}}     ; acceptance surfaces the draft spans
+
+  `:cheapest-runner` is the cheapest concrete runner whose token set is a
+  superset of the WHOLE draft's required union (`requirements/cheapest-runner`),
+  so the author sees the single runner that would prove every authored
+  expectation at once. `:cannot-run-rows` lists the rows that the default
+  headless runner refuses — the honest before-save list."
+  [{:keys [rows] :as _draft}]
+  (let [rows*       (vec (or rows []))
+        ready-rows  (filter (fn [r] (:ok? (parse-operands r))) rows*)
+        atoms       (mapv expectation->atom ready-rows)
+        required    (reduce into #{} (map requirements/assertion-tokens atoms))
+        surfaces    (into #{}
+                          (keep (fn [r] (:surface (kind-descriptor (:kind r)))))
+                          rows*)
+        cannot-rows (into []
+                          (keep (fn [r]
+                                  (let [c (row-cost r)]
+                                    (when (:cannot-run? c)
+                                      {:row r :atom (expectation->atom r) :cost c}))))
+                          rows*)]
+    {:count           (count rows*)
+     :ready           (count ready-rows)
+     :atoms           atoms
+     :required        required
+     :cheapest-runner (requirements/cheapest-runner required)
+     :cannot-run-rows cannot-rows
+     :surfaces        surfaces}))
+
+;; ===========================================================================
+;; SNIPPET — expectations as EXPLICIT variant DATA (the round-trip)
+;; ===========================================================================
+;;
+;; The saved expectations become explicit variant DATA: a `(reg-variant …)`
+;; form whose `:assertions` slot carries the authored atoms, MERGED with the
+;; variant's already-declared `:assertions` so re-authoring is additive and
+;; round-trips. We emit it onto an `:extends` of the source variant so the
+;; new variant inherits the source's world/component/decorators and adds the
+;; expectations — explicit data the author pastes into source, never hidden
+;; UI state.
+
+(defn merge-assertions
+  "Merge `existing` declared assertions with newly `authored` atoms,
+  preserving order and dropping exact duplicates (an author re-adding an
+  expectation already declared is idempotent). Pure data → vector. The
+  authored atoms append after the existing ones, so re-authoring is
+  additive — the round-trip the acceptance criteria require."
+  [existing authored]
+  (let [existing* (vec (or existing []))
+        seen      (set existing*)]
+    (into existing*
+          (remove seen)
+          (or authored []))))
+
+(defn- pr-assertions-vector
+  "Pretty-print an assertions vector as a multi-line EDN form, each atom on
+  its own line aligned under the opening `[` of `:assertions [`. Empty
+  renders as `[]`. Uses the shared `predicates/indent-after` so the
+  continuation indent stays in lockstep with the recorder / save-variant
+  snippets. Pure data → string."
+  [atoms]
+  (if (empty? atoms)
+    "[]"
+    (str "["
+         (->> atoms
+              (map pr-str)
+              (str/join (pred/indent-after "   :assertions [")))
+         "]")))
+
+(defn gen-expectations-snippet
+  "Build the `(reg-variant …)` EDN snippet that adds authored expectations
+  to a story. Pure data → string. The saved expectations become explicit
+  variant DATA — an `:assertions` slot carrying the canonical atoms, merged
+  with the source variant's already-declared assertions (additive
+  round-trip). `opts`:
+
+      :variant-id    required — the new variant id (e.g. :story.counter/expects-5)
+      :extends       optional — source variant id; the new variant inherits
+                                its component / decorators / world via :extends
+      :existing      optional — the source variant's already-declared
+                                :assertions, merged with the authored atoms
+      :authored      required — the authored canonical atoms (from
+                                `expectation->atom` over the draft rows)
+      :doc           optional — a docstring
+      :alias         optional — the reg-variant alias (default \"story\")
+
+  The output is `read-string`-able EDN that round-trips through the Story
+  registrar. The author pastes it into source — source is never written
+  directly (same escape hatch as save-variant / recorder / promotion)."
+  [{:keys [variant-id extends existing authored doc alias]
+    :or   {alias "story"}}]
+  (let [merged    (merge-assertions existing authored)
+        body-keys (cond-> []
+                    doc     (conj [:doc (pr-str doc)])
+                    extends (conj [:extends (pr-str extends)])
+                    true    (conj [:assertions (pr-assertions-vector merged)])
+                    true    (conj [:tags (pr-str #{:test})]))
+        body-str  (->> body-keys
+                       (map (fn [[k v]] (str k " " v)))
+                       (str/join "\n   "))]
+    (str "(" alias "/reg-variant "
+         (pr-str (or variant-id :story.expectations/example))
+         "\n  {" body-str "})")))
+
+;; ===========================================================================
+;; DEFAULT NEW-VARIANT ID
+;; ===========================================================================
+
+(def ^:const default-id-prefix
+  "Per-flow prefix for the auto-derived new-variant id. Distinct from
+  save-variant's \"saved\" and promotion's \"regression\" so an authored-
+  expectations variant reads as an expectation, not a state snapshot or a
+  captured regression."
+  "expects")
+
+(defn assertions-known?
+  "True iff every atom in `atoms` is a recognised P1 assertion id
+  (`re-frame.story.assertions/assertion-id-known?`). Pure data → bool.
+  The dialog asserts this before offering the snippet so an authored
+  expectation can never reference an id plan construction would reject."
+  [atoms]
+  (every? (fn [a] (assertions/assertion-id-known? (assertions/assertion-atom-id a)))
+          (or atoms [])))

--- a/tools/story/src/re_frame/story/ui/assertion_strip.cljs
+++ b/tools/story/src/re_frame/story/ui/assertion_strip.cljs
@@ -52,6 +52,8 @@
   CLJS-only for the same reason."
   (:require [clojure.string :as str]
             [reagent.core :as r]
+            [re-frame.story.assertions :as assertions]
+            [re-frame.story.author-expectations :as author]
             [re-frame.story.ui.test-mode.pure :as tm-pure]
             [re-frame.story.theme.typography :as typography :refer [mono-stack]]
             [re-frame.story.theme.colors :as colors]))
@@ -492,3 +494,92 @@
                       ;; on the element Reagent hands to React.
                       ^{:key (str gi "/" ri "/" rkey)}
                       [render-row row open? toggle])))]))])))))
+
+;; ---- authored-expectation strip (rf2-ba86n.12) ---------------------------
+;;
+;; The component above renders RUN-RESULT assertion records (each carries a
+;; `:passed?` verdict). This strip renders AUTHORED expectations — canonical
+;; `[:rf.assert/* …]` atoms that have NOT YET run (the explicit `:assertions`
+;; variant DATA the authoring flow emits). It is the read-only display of a
+;; variant's declared expectations: the atom + its runner cost / `:cannot-run`
+;; honesty flag (read from the EXISTING requirement registry via
+;; `author/expectation-cost`), so a reader sees what a story expects AND what
+;; runner each expectation needs, without having to run it. Distinct from the
+;; run-result strip — no verdict glyph, a runner-cost stripe instead.
+
+(def ^:private authored-styles
+  {:wrap   {:margin-top "8px"
+            :display "flex"
+            :flex-direction "column"
+            :gap "4px"}
+   :row    {:display "flex"
+            :align-items "baseline"
+            :gap "8px"
+            :padding "4px 8px"
+            :border-left "3px solid transparent"
+            :background (:bg-2 colors/tokens)
+            :border-radius "0 3px 3px 0"
+            :font-family mono-stack
+            :font-size (:caption typography/type-scale)}
+   :row-ok     {:border-left-color (:info colors/tokens)}
+   :row-cannot {:border-left-color (:warning colors/tokens)}
+   :id     {:flex "0 0 auto"
+            :color (:text-primary colors/tokens)
+            :font-weight "bold"}
+   :args   {:flex "1 1 auto"
+            :color (:text-secondary colors/tokens)
+            :white-space "nowrap" :overflow "hidden" :text-overflow "ellipsis"
+            :min-width "0"}
+   :cost   {:flex "0 0 auto"
+            :font-size (:micro typography/type-scale)
+            :color (:text-tertiary colors/tokens)}
+   :cost-cannot {:color (:warning colors/tokens)}})
+
+(defn authored-row
+  "Render one AUTHORED expectation atom (un-run) with its runner cost. Pure
+  shape: takes the canonical `[:rf.assert/* …]` atom, returns hiccup. The
+  cost (`author/expectation-cost`) reads the EXISTING requirement registry —
+  the cheapest runner that proves it + whether it `:cannot-run` headless —
+  so the declared expectation reads with its honesty floor attached."
+  [atom]
+  (let [id    (assertions/assertion-atom-id atom)
+        args  (vec (rest atom))
+        {:keys [cheapest-runner cannot-run?]} (author/expectation-cost atom)]
+    [:div {:data-test "story-authored-expectation-row"
+           :data-id   (str id)
+           :data-cannot-run (str (boolean cannot-run?))
+           :style     (merge (:row authored-styles)
+                             (if cannot-run?
+                               (:row-cannot authored-styles)
+                               (:row-ok authored-styles)))}
+     [:span {:style (:id authored-styles)
+             :data-test "story-authored-expectation-id"}
+      (str id)]
+     (when (seq args)
+       [:span {:style (:args authored-styles)
+               :title (str/join " " (map pr-str args))}
+        (truncate (str/join " " (map pr-str args)))])
+     [:span {:style     (merge (:cost authored-styles)
+                              (when cannot-run? (:cost-cannot authored-styles)))
+             :data-test "story-authored-expectation-cost"
+             :data-runner (str cheapest-runner)}
+      (if cannot-run?
+        (str "⚠ " (when cheapest-runner (name cheapest-runner)) " · cannot run headless")
+        (str "runner: " (if cheapest-runner (name cheapest-runner) "none")))]]))
+
+(defn authored-expectation-strip
+  "Reagent component rendering a variant's AUTHORED (declared, un-run)
+  expectations — the canonical assertion atoms on its `:assertions` slot.
+  `atoms` is the vector of `[:rf.assert/* …]` atoms. Renders nothing when
+  empty; otherwise one `authored-row` per atom, each carrying its runner
+  cost / `:cannot-run` honesty flag. Read-only — this is the display
+  companion to the authoring flow, NOT the run-result strip above."
+  [atoms]
+  (when (seq atoms)
+    [:div {:style     (:wrap authored-styles)
+           :data-test "story-authored-expectation-strip"
+           :data-count (str (count atoms))}
+     (doall
+       (for [[i atom] (map-indexed vector atoms)]
+         ^{:key (str "authored-" i)}
+         [authored-row atom]))]))

--- a/tools/story/src/re_frame/story/ui/author_expectations.cljc
+++ b/tools/story/src/re_frame/story/ui/author_expectations.cljc
@@ -1,0 +1,579 @@
+(ns re-frame.story.ui.author-expectations
+  "Expectation-authoring UX — add EXPECTATIONS to a story so a useful story
+  becomes a regression test (rf2-ba86n.12, spec/021 §S5, spec/019).
+
+  ## What this surface is — and is NOT
+
+  The author picks an expectation KIND (app-db value, subscription value,
+  rendered hiccup/DOM, schema behaviour, browser/a11y evidence), fills its
+  operands, and the dialog shows — per row, BEFORE save — the runner cost
+  and whether it `:cannot-run` under the default headless runner. On save
+  the authored expectations become EXPLICIT variant DATA: a `(reg-variant
+  … {:assertions […]})` form merged with the source variant's declared
+  assertions, which the author copies into source. Nothing is hidden UI
+  state.
+
+  Thin UI over the pure `re-frame.story.author-expectations` substrate —
+  this ns reimplements NO expectation logic, NO runner-cost model, and NO
+  assertion vocabulary. It wires the draft ratom, the kind picker, the
+  operand inputs, the per-row cost stripe, and the review-then-commit
+  dialog.
+
+  DISTINCT from its two siblings (which it MUST NOT conflate):
+  save-current-state-as-variant (`re-frame.story.ui.save-variant`, the live
+  args snapshot) and generated-failure promotion
+  (`re-frame.story.ui.promotion`, a captured run artifact). All three share
+  the `review-dialog` skeleton but never the same entry point.
+
+  ## Pure / CLJS split
+
+  Mirrors `save_variant.cljs` + `promotion.cljc`: the catalog / atom
+  builders / cost projection / snippet live in the pure `.cljc` substrate;
+  the dialog ratom, the keystroke transitions, and the Reagent render are
+  `#?(:cljs …)`. Production builds short-circuit on `config/enabled?`."
+  (:require [re-frame.story.author-expectations :as author]
+            ;; `clojure.string` + `review-dialog` are consumed ONLY by the
+            ;; `:cljs` dialog surface below (the pure draft transitions in
+            ;; this ns need neither), so they ride the `:cljs` require — a
+            ;; `:clj`-mode lint sees no dead require. `review-dialog` is
+            ;; `.cljc`; its pure transitions are JVM-available, but this ns
+            ;; only calls them from `:cljs` code.
+            #?@(:cljs [[clojure.string :as str]
+                       [reagent.core :as r]
+                       [re-frame.story.config :as config]
+                       [re-frame.story.registrar :as registrar]
+                       [re-frame.story.review-dialog :as review-dialog]
+                       [re-frame.story.ui.state :as state]
+                       [re-frame.story.theme.typography :as typography :refer [mono-stack sans-stack]]
+                       [re-frame.story.theme.colors :as colors]])))
+
+;; ===========================================================================
+;; PURE: draft shape + transitions
+;; ===========================================================================
+;;
+;; The draft carries the authored rows (each `{:row-id :kind :operands}`)
+;; plus the new-variant id + doc. The transitions are pure data → data so
+;; the JVM test corpus can pin the add/remove/edit semantics without a host.
+
+(def empty-row-operands {})
+
+(defn new-row
+  "Build a fresh authored-expectation row of `kind` with a stable `row-id`.
+  Pure data → data. `:operands` starts empty (the author fills them); the
+  dialog seeds defaults from the kind's placeholder if it wants, but the
+  draft default is empty so a blank row reads as 'fill this'."
+  [row-id kind]
+  {:row-id   row-id
+   :kind     kind
+   :operands empty-row-operands})
+
+(defn initial-draft
+  "The idle authoring draft. `:rows` is empty; `:variant-id` / `:doc` /
+  `:next-row-id` populate as the author drives the flow. Pure data."
+  []
+  {:variant-id  nil
+   :doc         nil
+   :rows        []
+   :next-row-id 0})
+
+(defn add-row
+  "Append a new row of `kind` to the draft, minting a stable row id from
+  `:next-row-id`. Pure data → data."
+  [draft kind]
+  (let [rid (:next-row-id draft 0)]
+    (-> draft
+        (update :rows (fnil conj []) (new-row rid kind))
+        (assoc :next-row-id (inc rid)))))
+
+(defn remove-row
+  "Drop the row with `row-id` from the draft. Pure data → data."
+  [draft row-id]
+  (update draft :rows (fn [rows] (vec (remove #(= row-id (:row-id %)) rows)))))
+
+(defn set-operand
+  "Set `field`'s raw operand string on the row `row-id`. Pure data → data.
+  The raw string is stored verbatim (parsing happens at projection time via
+  `author/parse-operands`) so the input value the author sees is never
+  clobbered mid-keystroke."
+  [draft row-id field value]
+  (update draft :rows
+          (fn [rows]
+            (mapv (fn [row]
+                    (if (= row-id (:row-id row))
+                      (assoc-in row [:operands field] value)
+                      row))
+                  rows))))
+
+(defn set-variant-id
+  "Set the new-variant id on the draft. `id` may be a keyword or a raw
+  string the author is typing. Pure data → data."
+  [draft id]
+  (assoc draft :variant-id id))
+
+(defn set-doc
+  "Set the new-variant docstring on the draft. Pure data → data."
+  [draft doc]
+  (assoc draft :doc doc))
+
+(defn draft-atoms
+  "Project the draft's ready rows into canonical assertion atoms. Pure data
+  → vector. Re-exposed here so the snippet generator + tests read one
+  helper rather than re-walking the rows."
+  [draft]
+  (:atoms (author/draft-summary draft)))
+
+;; ===========================================================================
+;; CLJS-ONLY: dialog ratom + lifecycle
+;; ===========================================================================
+
+#?(:cljs
+   (def initial-dialog-state
+     "Idle author-expectations dialog state. `:open?` flips true on `open!`;
+      `:source-id` / `:draft` populate as the author drives the flow."
+     {:open?     false
+      :source-id nil
+      :draft     (initial-draft)}))
+
+#?(:cljs
+   (defonce ^{:doc "Reagent ratom holding the author-expectations dialog state."}
+     dialog-atom
+     (r/atom initial-dialog-state)))
+
+#?(:cljs
+   (defn- existing-assertions
+     "The source variant body's already-declared `:assertions` (or
+      `:expect :assertions`), so the snippet merges authored atoms onto them
+      additively (the round-trip). Reads the resolved body via the Story
+      registrar; nil → empty."
+     [source-id]
+     (let [body (registrar/handler-meta :variant source-id)]
+       (or (:assertions body)
+           (get-in body [:expect :assertions])
+           []))))
+
+#?(:cljs
+   (defn open!
+     "Open the authoring dialog against `source-variant-id`. Seeds an empty
+      draft with a default `expects-<ms>` id under the source's story
+      namespace (when the source is a qualified keyword). No-op when Story
+      is disabled."
+     [source-variant-id]
+     (when config/enabled?
+       (let [now-ms (.now js/Date)
+             def-id (review-dialog/default-variant-id-with-prefix
+                      source-variant-id now-ms author/default-id-prefix)]
+         (reset! dialog-atom
+                 {:open?     true
+                  :source-id source-variant-id
+                  :draft     (-> (initial-draft)
+                                 (set-variant-id def-id))})
+         nil))))
+
+#?(:cljs
+   (defn close! []
+     (reset! dialog-atom initial-dialog-state)
+     nil))
+
+#?(:cljs
+   (defn- update-draft! [f & args]
+     (apply swap! dialog-atom update :draft f args)))
+
+#?(:cljs (defn add-row!    [kind]            (update-draft! add-row kind)))
+#?(:cljs (defn remove-row! [row-id]          (update-draft! remove-row row-id)))
+#?(:cljs (defn set-operand! [row-id field v] (update-draft! set-operand row-id field v)))
+#?(:cljs (defn set-doc!     [doc]            (update-draft! set-doc doc)))
+
+#?(:cljs
+   (defn set-variant-id!
+     "Per-keystroke new-variant-id edit. Parses the raw input into a keyword
+      best-effort; stores the raw string on parse failure so the input value
+      the author sees is not clobbered mid-keystroke."
+     [s]
+     (update-draft! set-variant-id
+                    (or (review-dialog/parse-variant-id-string s) s))))
+
+;; ===========================================================================
+;; CLJS-ONLY: styling
+;; ===========================================================================
+
+#?(:cljs
+   (def ^:private styles
+     {:section    {:margin "8px 0 0 0"}
+      :label      {:font-family    mono-stack
+                   :font-size      (:micro typography/type-scale)
+                   :color          (:text-tertiary colors/tokens)
+                   :margin         "0 0 3px 0"
+                   :text-transform "uppercase"
+                   :letter-spacing "0.04em"}
+      :picker-row {:display "flex" :gap "6px" :flex-wrap "wrap" :margin-bottom "6px"}
+      :kind-chip  {:font-family   mono-stack
+                   :font-size     (:micro typography/type-scale)
+                   :background    (:bg-2 colors/tokens)
+                   :color         (:text-secondary colors/tokens)
+                   :border        "1px solid #444"
+                   :border-radius "10px"
+                   :padding       "2px 9px"
+                   :cursor        "pointer"
+                   :user-select   "none"}
+      :row        {:display       "flex"
+                   :flex-direction "column"
+                   :gap           "4px"
+                   :padding       "6px 8px"
+                   :margin        "4px 0"
+                   :background    (:bg-2 colors/tokens)
+                   :border        "1px solid #3a3a44"
+                   :border-radius "4px"}
+      :row-head   {:display "flex" :align-items "baseline" :gap "8px"}
+      :row-kind   {:font-family mono-stack
+                   :font-weight "bold"
+                   :color       (:info colors/tokens)
+                   :font-size   (:caption typography/type-scale)}
+      :row-doc    {:flex "1 1 auto"
+                   :color (:text-tertiary colors/tokens)
+                   :font-size (:nano typography/type-scale)
+                   :font-style "italic"
+                   :white-space "nowrap" :overflow "hidden" :text-overflow "ellipsis"}
+      :remove-btn {:background "transparent"
+                   :border     "none"
+                   :color      (:text-tertiary colors/tokens)
+                   :cursor     "pointer"
+                   :font-size  (:caption typography/type-scale)
+                   :padding    "0 4px"}
+      :operand-row {:display "flex" :align-items "baseline" :gap "6px"}
+      :operand-lbl {:font-family mono-stack
+                    :font-size (:nano typography/type-scale)
+                    :color (:text-tertiary colors/tokens)
+                    :width "84px" :text-align "right" :flex "0 0 auto"}
+      :operand-in  {:padding       "3px 6px"
+                    :background    "#0e0e10"
+                    :color         "white"
+                    :border        "1px solid #444"
+                    :border-radius "3px"
+                    :font-family   mono-stack
+                    :font-size     (:caption typography/type-scale)
+                    :flex          "1 1 auto"
+                    :box-sizing    "border-box"}
+      :operand-err {:color (:danger colors/tokens)
+                    :font-size (:nano typography/type-scale)
+                    :font-family mono-stack}
+      ;; per-row cost stripe — the honesty floor (cost BEFORE save)
+      :cost        {:display "flex" :align-items "baseline" :gap "8px"
+                    :font-family mono-stack
+                    :font-size (:nano typography/type-scale)
+                    :padding "2px 0 0 0"}
+      :cost-ok     {:color (:success colors/tokens)}
+      :cost-cannot {:color (:warning colors/tokens)}
+      :doc-input   {:padding       "5px 8px"
+                    :background    (:bg-2 colors/tokens)
+                    :color         "white"
+                    :border        "1px solid #444"
+                    :border-radius "3px"
+                    :font-family   sans-stack
+                    :font-size     (:body-tight typography/type-scale)
+                    :width         "100%"
+                    :box-sizing    "border-box"}
+      :banner      {:padding       "8px 10px"
+                    :margin        "8px 0 0 0"
+                    :background    "#22242c"
+                    :color         "#c8c8d0"
+                    :border        "1px solid #3a3a44"
+                    :border-radius "3px"
+                    :font-family   mono-stack
+                    :font-size     (:micro typography/type-scale)
+                    :line-height   "1.5"}
+      :banner-warn {:background "#332a2a" :color "#d8b48f" :border "1px solid #704a40"}
+      :empty       {:color (:text-tertiary colors/tokens)
+                    :font-style "italic"
+                    :font-size (:micro typography/type-scale)
+                    :padding "6px 0"}}))
+
+;; ===========================================================================
+;; CLJS-ONLY: per-row cost stripe + operand inputs
+;; ===========================================================================
+
+#?(:cljs
+   (defn- cost-stripe
+     "Render the per-row runner-cost / `:cannot-run` stripe — the honesty
+      floor shown BEFORE save. Reads `author/row-cost` (which reads the
+      EXISTING requirement registry); shows the cheapest runner that proves
+      the expectation and, when it needs more than the default headless
+      runner, an explicit `cannot run headless` flag with the missing
+      tokens. Never hides the cost."
+     [row]
+     (let [{:keys [required cheapest-runner cannot-run? missing]} (author/row-cost row)]
+       [:div {:style       (:cost styles)
+              :data-test    "story-author-expectation-cost"
+              :data-cannot-run (str (boolean cannot-run?))
+              :data-runner  (str cheapest-runner)}
+        [:span {:style (if cannot-run? (:cost-cannot styles) (:cost-ok styles))}
+         (if cannot-run? "⚠ " "✓ ")]
+        [:span "runner: " (if cheapest-runner (name cheapest-runner) "none")]
+        (when (seq required)
+          [:span {:style {:color (:text-tertiary colors/tokens)}}
+           "needs " (pr-str required)])
+        (when cannot-run?
+          [:span {:style (:cost-cannot styles)
+                  :data-test "story-author-expectation-cannot-run"}
+           "cannot run headless — missing " (pr-str missing)])])))
+
+#?(:cljs
+   (defn- operand-input
+     "Render one operand input for an authored row, with its parse error
+      stripe when the current raw value does not parse."
+     [row {:keys [field label placeholder]} error]
+     [:div {:style (:operand-row styles)
+            :data-test "story-author-expectation-operand"
+            :data-field (name field)}
+      [:span {:style (:operand-lbl styles)} (str label ":")]
+      [:input {:type        "text"
+               :style       (:operand-in styles)
+               :data-test   "story-author-expectation-operand-input"
+               :aria-label  (str label " operand")
+               :value       (or (get-in row [:operands field]) "")
+               :placeholder placeholder
+               :on-change   (fn [e] (set-operand! (:row-id row) field (.. e -target -value)))}]
+      (when error
+        [:span {:style (:operand-err styles)
+                :data-test "story-author-expectation-operand-error"}
+         error])]))
+
+#?(:cljs
+   (defn- expectation-row
+     "Render one authored-expectation row: the kind header + remove control,
+      its operand inputs (with per-field parse errors), and the per-row cost
+      stripe (cost BEFORE save)."
+     [row]
+     (let [desc   (author/kind-descriptor (:kind row))
+           parsed (author/parse-operands row)
+           errors (:errors parsed)]
+       [:div {:style     (:row styles)
+              :data-test "story-author-expectation-row"
+              :data-kind (name (:kind row))
+              :data-row-id (str (:row-id row))}
+        [:div {:style (:row-head styles)}
+         [:span {:style (:row-kind styles)} (:label desc)]
+         [:span {:style (:row-doc styles)} (:doc desc)]
+         [:button {:style     (:remove-btn styles)
+                   :type      "button"
+                   :data-test "story-author-expectation-remove"
+                   :aria-label "Remove this expectation"
+                   :on-click  (fn [_] (remove-row! (:row-id row)))}
+          "×"]]
+        ;; `operand-input` / `cost-stripe` are pure render fns (no local
+        ;; state), so they are CALLED directly — their hiccup expands inline
+        ;; into this row rather than hiding behind a component boundary (so a
+        ;; directly-invoked `expectation-row` fully realises for tests). The
+        ;; React `:key` rides on the returned hiccup vector via `with-meta`
+        ;; (the meta DOES transfer because the value already IS a vector).
+        (doall
+          (for [spec (:operands desc)]
+            (with-meta (operand-input row spec (get errors (:field spec)))
+                       {:key (name (:field spec))})))
+        (cost-stripe row)])))
+
+;; ===========================================================================
+;; CLJS-ONLY: the authoring controls block (above the snippet)
+;; ===========================================================================
+
+#?(:cljs
+   (defn- kind-picker
+     "The kind picker — one chip per authorable expectation kind. Clicking a
+      chip appends a fresh row of that kind. Grouped only by render order;
+      each chip carries its surface as a data attr so tests can pin
+      coverage."
+     []
+     [:div {:data-test "story-author-expectation-kind-picker"}
+      [:div {:style (:label styles)} "add expectation"]
+      [:div {:style (:picker-row styles)}
+       (for [{:keys [kind label surface]} author/expectation-kinds]
+         ^{:key (name kind)}
+         [:span {:style       (:kind-chip styles)
+                 :data-test   "story-author-expectation-kind-chip"
+                 :data-kind   (name kind)
+                 :data-surface (name surface)
+                 :role        "button"
+                 :tab-index   "0"
+                 :title       (get author/surface-labels surface)
+                 :on-click    (fn [_] (add-row! kind))}
+          (str "+ " label)])]]))
+
+#?(:cljs
+   (defn- coverage-banner
+     "The before-save honesty banner: how many expectations are authored vs
+      ready, which acceptance surfaces they span, the single cheapest runner
+      that would prove the whole draft, and the explicit list of rows that
+      `:cannot-run` headless. Reads the pure `author/draft-summary`."
+     [draft]
+     (let [{:keys [count ready cheapest-runner cannot-run-rows surfaces]}
+           (author/draft-summary draft)
+           any-cannot? (seq cannot-run-rows)]
+       [:div {:style     (merge (:banner styles) (when any-cannot? (:banner-warn styles)))
+              :data-test "story-author-expectation-summary"
+              :data-count (str count)
+              :data-ready (str ready)
+              :data-cheapest-runner (str cheapest-runner)
+              :data-cannot-run-count (str (clojure.core/count cannot-run-rows))}
+        [:div {:style {:font-weight "bold" :margin-bottom "4px"}}
+         (str ready " of " count " expectation"
+              (when (not= count 1) "s") " ready"
+              (when cheapest-runner
+                (str " — cheapest runner that proves all: " (name cheapest-runner))))]
+        (when (seq surfaces)
+          [:div {:data-test "story-author-expectation-surfaces"}
+           "surfaces: "
+           (str/join " · "
+                     (keep #(get author/surface-labels %)
+                           (sort surfaces)))])
+        (when any-cannot?
+          [:div {:data-test "story-author-expectation-cannot-run-summary"
+                 :style {:margin-top "4px"}}
+           (str (clojure.core/count cannot-run-rows)
+                " expectation"
+                (when (not= 1 (clojure.core/count cannot-run-rows)) "s")
+                " cannot run under the default headless runner "
+                "(browser / DOM / reactive evidence) — visible here BEFORE save, "
+                "never discovered only at run time.")])])))
+
+#?(:cljs
+   (defn- authoring-controls
+     "The authoring block the dialog renders ABOVE the review-dialog snippet:
+      the kind picker, the authored rows (each with operand inputs + the
+      per-row cost stripe), the docstring input, and the coverage banner."
+     [draft]
+     [:div {:data-test "story-author-expectation-controls"}
+      (kind-picker)
+      (if (seq (:rows draft))
+        [:div {:data-test "story-author-expectation-rows"}
+         (for [row (:rows draft)]
+           ^{:key (:row-id row)}
+           [expectation-row row])]
+        [:div {:style (:empty styles)
+               :data-test "story-author-expectation-empty"}
+         "No expectations yet — pick a kind above to start authoring."])
+      [:div {:style (:section styles)}
+       [:div {:style (:label styles)} "doc (optional)"]
+       [:input {:type        "text"
+                :data-test   "story-author-expectation-doc-input"
+                :style       (:doc-input styles)
+                :aria-label  "New variant docstring"
+                :value       (or (:doc draft) "")
+                :placeholder "Why these expectations matter…"
+                :on-change   (fn [e] (set-doc! (.. e -target -value)))}]]
+      (coverage-banner draft)]))
+
+;; ===========================================================================
+;; CLJS-ONLY: the dialog
+;; ===========================================================================
+
+#?(:cljs
+   (defn build-snippet
+     "Build the `(reg-variant …)` snippet for the current dialog state. Pure
+      over the deref'd dialog map — the authored expectations become explicit
+      `:assertions` variant DATA, merged with the source variant's declared
+      assertions (the additive round-trip)."
+     [{:keys [source-id draft] :as _dialog}]
+     (author/gen-expectations-snippet
+       {:variant-id (or (:variant-id draft) :story.expectations/example)
+        :extends    source-id
+        :existing   (existing-assertions source-id)
+        :authored   (draft-atoms draft)
+        :doc        (when (and (string? (:doc draft)) (seq (str/trim (:doc draft))))
+                      (str/trim (:doc draft)))})))
+
+#?(:cljs
+   (defn author-dialog
+     "Render the author-expectations modal. Visible iff `:open?` on the
+      dialog ratom. The author picks expectation kinds, fills operands, sees
+      the per-row + draft-level runner cost / `:cannot-run` BEFORE save, and
+      copies the `(reg-variant … {:assertions […]})` form into source
+      (source is never written directly).
+
+      Public so tests can render the dialog hiccup directly after seeding the
+      dialog ratom."
+     []
+     (fn []
+       (let [dialog @dialog-atom]
+         (when (:open? dialog)
+           (let [{:keys [source-id draft]} dialog
+                 snippet (build-snippet dialog)]
+             (review-dialog/review-dialog
+               {:open?     true
+                :draft-id  (:variant-id draft)
+                :source-id source-id}
+               {:title             "Add expectations to this story"
+                :hint              [:div
+                                    [:div (str "Authoring expectations onto "
+                                               (pr-str source-id)
+                                               ". Saved expectations become EXPLICIT "
+                                               ":assertions data on a new variant (via "
+                                               ":extends), merged with any already declared "
+                                               "— not hidden UI state. This is DISTINCT from "
+                                               "save-current-state and failure promotion.")]
+                                    (authoring-controls draft)]
+                :snippet           snippet
+                :placeholder-id    :story.expectations/example
+                :placeholder-input ":story.your-story/expects-flow"
+                :on-edit-id        set-variant-id!
+                :on-copy           (fn [] (review-dialog/copy-to-clipboard! snippet))
+                :on-close          close!
+                :data-test-prefix  "story-author-expectation"})))))))
+
+;; ===========================================================================
+;; CLJS-ONLY: the entry-point button (controls panel)
+;; ===========================================================================
+
+#?(:cljs
+   (def ^:private button-styles
+     {:button          {:padding       "4px 8px"
+                        :background    (:bg-2 colors/tokens)
+                        :color         (:text-primary colors/tokens)
+                        :border        (str "1px solid " (:info colors/tokens))
+                        :border-radius "3px"
+                        :cursor        "pointer"
+                        :font-size     (:micro typography/type-scale)
+                        :margin-top    "8px"
+                        :font-family   mono-stack}
+      :button-disabled {:padding       "4px 8px"
+                        :background    (:bg-2 colors/tokens)
+                        :color         "#777"
+                        :border        "1px solid #444"
+                        :border-radius "3px"
+                        :cursor        "not-allowed"
+                        :font-size     (:micro typography/type-scale)
+                        :margin-top    "8px"
+                        :font-family   mono-stack}}))
+
+#?(:cljs
+   (defn author-expectations-button
+     "Render the 'add expectations…' button. Opens the authoring dialog
+      against `variant-id`. Disabled when no variant is focused. Lives on the
+      controls panel beside 'save as new variant…' — the two are distinct
+      flows sharing a home (spec/019 §3, spec/021 §S5).
+
+      Public so tests can introspect the button hiccup without driving the
+      full controls panel."
+     [variant-id]
+     (let [enabled? (some? variant-id)]
+       [:button
+        {:style     (if enabled? (:button button-styles) (:button-disabled button-styles))
+         :disabled  (not enabled?)
+         :data-test "story-author-expectation-button"
+         :title     (if enabled?
+                      "Author expectations onto this story (becomes a regression test)"
+                      "Select a variant to author expectations")
+         :on-click  (fn [_] (when enabled? (open! variant-id)))}
+        "add expectations…"])))
+
+;; ===========================================================================
+;; CLJS-ONLY: palette action entry-point
+;; ===========================================================================
+
+#?(:cljs
+   (defn open-for-focused-variant!
+     "Open the authoring dialog against the shell's focused variant. The
+      command-palette action target. No-op (returns nil) when no variant is
+      focused, so the palette entry needs no extra guard."
+     []
+     (when config/enabled?
+       (when-let [vid (:selected-variant (state/get-state))]
+         (open! vid)))))

--- a/tools/story/src/re_frame/story/ui/command_palette.cljc
+++ b/tools/story/src/re_frame/story/ui/command_palette.cljc
@@ -28,7 +28,13 @@
     variant's live canvas state as a new variant. The SAME flow as the
     Controls-panel 'save as new variant…' button (spec/019 §3 — the flow
     is available from Controls AND the palette). A no-op when no variant
-    is focused; the action handler guards on the live selection."
+    is focused; the action handler guards on the live selection.
+
+  - `:author-expectations` (rf2-ba86n.12) — author EXPECTATIONS onto the
+    focused story so a useful story becomes a regression test (spec/021
+    §S5). Distinct from `:save-current-as-variant` (state authoring) and
+    failure promotion (a captured artifact). A no-op when no variant is
+    focused; the action handler guards on the live selection."
   [{:kind   :command
     :id     :explain
     :action :explain
@@ -36,7 +42,11 @@
    {:kind   :command
     :id     :save-current-as-variant
     :action :save-current-as-variant
-    :doc    "Save current canvas state as a new variant — capture live args, review + copy the reg-variant form"}])
+    :doc    "Save current canvas state as a new variant — capture live args, review + copy the reg-variant form"}
+   {:kind   :command
+    :id     :author-expectations
+    :action :author-expectations
+    :doc    "Add expectations to this story — author app-db / sub / DOM / schema / a11y expectations, see runner cost before save, copy the :assertions form"}])
 
 (defn- doc-text [body]
   (let [doc (:doc body)]

--- a/tools/story/src/re_frame/story/ui/command_palette/view.cljs
+++ b/tools/story/src/re_frame/story/ui/command_palette/view.cljs
@@ -4,6 +4,7 @@
             [reagent.core :as r]
             [re-frame.story.config :as config]
             [re-frame.story.save-variant :as save-variant]
+            [re-frame.story.ui.author-expectations :as author-expectations]
             [re-frame.story.ui.command-palette :as palette]
             [re-frame.story.ui.explain-panel :as explain-panel]
             [re-frame.story.ui.state :as state]
@@ -44,6 +45,12 @@
         ;; selection from shell-state and no-ops (returns nil) when no
         ;; variant is focused, so the palette action needs no extra guard.
         :save-current-as-variant (save-variant/save-current-as-variant!)
+        ;; rf2-ba86n.12 — author EXPECTATIONS onto the focused story
+        ;; (spec/021 §S5). Same dialog as the Controls-panel 'add
+        ;; expectations…' button. Distinct from save-current-state.
+        ;; `open-for-focused-variant!` reads the live selection and no-ops
+        ;; when no variant is focused, so the action needs no extra guard.
+        :author-expectations (author-expectations/open-for-focused-variant!)
         nil)
       true)
 
@@ -237,44 +244,57 @@
            (reset! listener nil)))
        :reagent-render
        (fn []
-         (when @open?
-           (let [results (palette/search
-                           (palette/entries (state/registry-snapshot))
-                           @query
-                           30)
-                 result-count (count results)
-                 active (palette/clamp-active-index @active-index result-count)]
-             (when (not= active @active-index)
-               (reset! active-index active))
-             (render-palette
-               {:query             @query
-                :results           results
-                :active            active
-                :input-ref         #(reset! input %)
-                :on-close          (fn [_] (close!))
-                :on-input-change   (fn [event]
-                                     (reset! query (.. event -target -value))
-                                     (reset! active-index 0))
-                :on-input-keydown  (fn [event]
-                                     (case (.-key event)
-                                       "ArrowDown"
-                                       (do (.preventDefault event)
-                                           (swap! active-index
-                                                  palette/move-active-index 1 result-count))
-                                       "ArrowUp"
-                                       (do (.preventDefault event)
-                                           (swap! active-index
-                                                  palette/move-active-index -1 result-count))
-                                       "Enter"
-                                       (do (.preventDefault event)
-                                           (when-let [entry (get results active)]
-                                             (select-entry! entry)
-                                             (close!)))
-                                       "Escape"
-                                       (do (.preventDefault event)
-                                           (close!))
-                                       nil))
-                :on-row-hover      (fn [idx] (reset! active-index idx))
-                :on-row-select     (fn [entry]
-                                     (select-entry! entry)
-                                     (close!))}))))})))
+         ;; The palette overlay is conditional on its own `@open?`; the
+         ;; author-expectations modal (rf2-ba86n.12) is rendered
+         ;; UNCONDITIONALLY as a sibling so it surfaces whether opened from
+         ;; the controls-panel button OR a `:author-expectations` palette
+         ;; action — and regardless of whether the controls panel is
+         ;; currently visible. It is a `position: fixed` overlay reading its
+         ;; own defonce ratom, so a single mount here (the always-present
+         ;; palette host) is the canonical mount point; it renders nil while
+         ;; its ratom is closed. The shell's own dialog mounts (save-variant
+         ;; / promotion) live in `shell.cljs`; this one rides the palette
+         ;; host to keep the authoring flow's mount in its own lane.
+         [:<>
+          (when @open?
+            (let [results (palette/search
+                            (palette/entries (state/registry-snapshot))
+                            @query
+                            30)
+                  result-count (count results)
+                  active (palette/clamp-active-index @active-index result-count)]
+              (when (not= active @active-index)
+                (reset! active-index active))
+              (render-palette
+                {:query             @query
+                 :results           results
+                 :active            active
+                 :input-ref         #(reset! input %)
+                 :on-close          (fn [_] (close!))
+                 :on-input-change   (fn [event]
+                                      (reset! query (.. event -target -value))
+                                      (reset! active-index 0))
+                 :on-input-keydown  (fn [event]
+                                      (case (.-key event)
+                                        "ArrowDown"
+                                        (do (.preventDefault event)
+                                            (swap! active-index
+                                                   palette/move-active-index 1 result-count))
+                                        "ArrowUp"
+                                        (do (.preventDefault event)
+                                            (swap! active-index
+                                                   palette/move-active-index -1 result-count))
+                                        "Enter"
+                                        (do (.preventDefault event)
+                                            (when-let [entry (get results active)]
+                                              (select-entry! entry)
+                                              (close!)))
+                                        "Escape"
+                                        (do (.preventDefault event)
+                                            (close!))
+                                        nil))
+                 :on-row-hover      (fn [idx] (reset! active-index idx))
+                 :on-row-select     (fn [entry]
+                                      (select-entry! entry)
+                                      (close!))})))
+          [author-expectations/author-dialog]])})))

--- a/tools/story/src/re_frame/story/ui/controls.cljs
+++ b/tools/story/src/re_frame/story/ui/controls.cljs
@@ -70,6 +70,7 @@
             [re-frame.story.args               :as args]
             [re-frame.story.decorators         :as decorators]
             [re-frame.story.malli-schema       :as msu]
+            [re-frame.story.ui.author-expectations :as author-expectations]
             [re-frame.story.ui.controls-styles :refer [styles]]
             [re-frame.story.ui.save-variant    :as save-variant-ui]
             [re-frame.story.ui.schema-validation :as schema-validation]
@@ -920,11 +921,18 @@
   state (effective args after the five-layer precedence chain) and
   surfaces an EDN `(reg-variant ...)` form in a review-then-commit
   modal — the SB9 story-from-UI parity affordance (per
-  spec/005-SOTA-Features §Save current canvas state as variant)."
+  spec/005-SOTA-Features §Save current canvas state as variant).
+
+  rf2-ba86n.12: the 'add expectations…' button authors EXPECTATIONS onto
+  the story (app-db / sub / DOM / schema / a11y), shows the runner cost /
+  `:cannot-run` BEFORE save, and emits an `:assertions` reg-variant form.
+  DISTINCT from save-current-state (state authoring) and failure promotion
+  (a captured artifact) — spec/021 §S5."
   [variant-id]
   [:div {:style (:wrap styles)}
    (when variant-id
      [args-editor variant-id])
    (when variant-id
      [decorator-list variant-id])
-   [save-variant-ui/save-variant-button variant-id]])
+   [save-variant-ui/save-variant-button variant-id]
+   [author-expectations/author-expectations-button variant-id]])

--- a/tools/story/test/re_frame/story/author_expectations_test.cljc
+++ b/tools/story/test/re_frame/story/author_expectations_test.cljc
@@ -1,0 +1,241 @@
+(ns re-frame.story.author-expectations-test
+  "Tests for the pure expectation-authoring substrate (rf2-ba86n.12,
+  spec/021 §S5, spec/019).
+
+  Runs on the JVM under `clojure -M:test` AND on CLJS under shadow's
+  `:node-test` build — the substrate is pure data → data (catalog / atom
+  builders / cost projection / snippet), so it pins the contract the dialog
+  + assertion-strip + palette entry depend on without a host. The ns suffix
+  `-test` lands it in the JVM runner; the `-cljs-test` companion
+  (`author_expectations_cljs_test`) carries the dialog-transition coverage."
+  (:require [clojure.string :as str]
+            #?(:clj  [clojure.edn :as edn]
+               :cljs [cljs.reader :as edn])
+            [clojure.test :refer [deftest is testing]]
+            [re-frame.story.assertions          :as assertions]
+            [re-frame.story.author-expectations :as author]
+            [re-frame.story.requirements        :as requirements]))
+
+;; ===========================================================================
+;; CATALOG — covers the five acceptance surfaces
+;; ===========================================================================
+
+(deftest catalog-covers-the-acceptance-surfaces
+  (testing "every authorable kind names a recognised canonical assertion id"
+    (doseq [{:keys [kind assertion-id]} author/expectation-kinds]
+      (is (assertions/assertion-id-known? assertion-id)
+          (str kind " folds onto a known assertion id"))))
+  (testing "the catalog spans every acceptance-criteria surface (rf2-ba86n.12)"
+    (let [surfaces (into #{} (map :surface) author/expectation-kinds)]
+      ;; app-db, subscriptions, rendered DOM, schema behaviour, browser/a11y
+      (is (= #{:app-db :subscriptions :dom :schema :browser} surfaces)
+          "app-db / subscriptions / DOM / schema / browser are all authorable")))
+  (testing "kind-descriptor round-trips by kind"
+    (doseq [{:keys [kind] :as d} author/expectation-kinds]
+      (is (= d (author/kind-descriptor kind))))))
+
+;; ===========================================================================
+;; OPERAND PARSING + ATOM CONSTRUCTION — builds the CANONICAL vocabulary
+;; ===========================================================================
+
+(deftest expectation->atom-builds-canonical-atoms
+  (testing "app-db value equals → :rf.assert/path-equals"
+    (is (= [:rf.assert/path-equals [:counter :value] 5]
+           (author/expectation->atom
+             {:kind :app-db-equals
+              :operands {:path "[:counter :value]" :expected "5"}}))))
+  (testing "a bare keyword path lifts to a single-element path vector"
+    (is (= [:rf.assert/path-equals [:open?] true]
+           (author/expectation->atom
+             {:kind :app-db-equals
+              :operands {:path ":open?" :expected "true"}}))))
+  (testing "subscription equals → :rf.assert/sub-equals"
+    (is (= [:rf.assert/sub-equals [:counter/value] 5]
+           (author/expectation->atom
+             {:kind :sub-equals
+              :operands {:query-v "[:counter/value]" :expected "5"}}))))
+  (testing "app-db matches schema → :rf.assert/path-matches"
+    (is (= [:rf.assert/path-matches [:user] [:map [:id :int]]]
+           (author/expectation->atom
+             {:kind :app-db-matches
+              :operands {:path "[:user]" :schema "[:map [:id :int]]"}}))))
+  (testing "no-warnings is a nullary atom"
+    (is (= [:rf.assert/no-warnings]
+           (author/expectation->atom {:kind :no-warnings :operands {}}))))
+  (testing "DOM text → :rf.assert/dom-text"
+    (is (= [:rf.assert/dom-text ".count" "5"]
+           (author/expectation->atom
+             {:kind :dom-text :operands {:selector "\".count\"" :text "\"5\""}}))))
+  (testing "schema-error with a spec map → :rf.assert/schema-error spec"
+    (is (= [:rf.assert/schema-error {:where :event :event :user/save}]
+           (author/expectation->atom
+             {:kind :schema-error
+              :operands {:where-spec "{:where :event :event :user/save}"}}))))
+  (testing "schema-error with no spec → bare atom"
+    (is (= [:rf.assert/schema-error]
+           (author/expectation->atom {:kind :schema-error :operands {}}))))
+  (testing "an unparsable operand yields nil (the caller guards)"
+    (is (nil? (author/expectation->atom
+                {:kind :app-db-equals :operands {:path "" :expected "5"}}))
+        "a blank required operand fails the parse → no atom")
+    (is (nil? (author/expectation->atom
+                {:kind :app-db-equals :operands {:path "[:a" :expected "5"}}))
+        "a malformed EDN operand fails the parse → no atom")))
+
+(deftest parse-operands-reports-per-field-errors
+  (testing "ok? true when every operand parses"
+    (let [{:keys [ok? values errors]}
+          (author/parse-operands
+            {:kind :app-db-equals :operands {:path "[:a]" :expected "1"}})]
+      (is ok?)
+      (is (= {:path [:a] :expected 1} values))
+      (is (empty? errors))))
+  (testing "ok? false + a per-field error when an operand is blank"
+    (let [{:keys [ok? errors]}
+          (author/parse-operands
+            {:kind :app-db-equals :operands {:path "[:a]" :expected ""}})]
+      (is (not ok?))
+      (is (contains? errors :expected))))
+  (testing "a malformed EDN operand carries the reader error string"
+    (let [{:keys [ok? errors]}
+          (author/parse-operands
+            {:kind :sub-equals :operands {:query-v "[:a" :expected "1"}})]
+      (is (not ok?))
+      (is (string? (:query-v errors))))))
+
+;; ===========================================================================
+;; RUNNER COST / :cannot-run BEFORE SAVE — reads the EXISTING registry
+;; ===========================================================================
+
+(deftest expectation-cost-reads-the-requirement-registry
+  (testing "an app-db expectation runs headless (no escalation cost)"
+    (let [cost (author/expectation-cost [:rf.assert/path-equals [:a] 1])]
+      (is (= #{:app-db} (:required cost)))
+      (is (:headless? cost))
+      (is (not (:cannot-run? cost)))
+      (is (= :headless (:cheapest-runner cost)))
+      (is (empty? (:missing cost)))))
+  (testing "a sub-equals expectation needs :pure-subs but still runs headless"
+    (let [cost (author/expectation-cost [:rf.assert/sub-equals [:s] 1])]
+      (is (= #{:app-db :pure-subs} (:required cost)))
+      (is (not (:cannot-run? cost)))
+      (is (= :headless (:cheapest-runner cost)))))
+  (testing "a DOM expectation CANNOT run headless — visible before save"
+    (let [cost (author/expectation-cost [:rf.assert/dom-text ".x" "y"])]
+      (is (= #{:dom} (:required cost)))
+      (is (:cannot-run? cost) "the honest before-save cannot-run flag")
+      (is (= :dom (:cheapest-runner cost)) "cheapest runner that CAN prove it")
+      (is (contains? (:missing cost) :dom) "the missing token is surfaced")))
+  (testing "a visual-snapshot expectation needs a browser runner"
+    (let [cost (author/expectation-cost [:rf.assert/visual-snapshot])]
+      (is (:cannot-run? cost))
+      (is (= :browser (:cheapest-runner cost)))))
+  (testing "structural a11y rides the :hiccup tier (cannot run headless, cheaper than browser)"
+    (let [cost (author/expectation-cost [:rf.assert/a11y-structural])]
+      (is (:cannot-run? cost))
+      (is (= :hiccup (:cheapest-runner cost)))))
+  (testing "cost agrees with the requirement registry it reads"
+    (is (= (requirements/assertion-tokens [:rf.assert/dom-visible ".x"])
+           (:required (author/expectation-cost [:rf.assert/dom-visible ".x"])))))
+  (testing "a nil atom (unparsed row) projects an empty, non-throwing cost"
+    (let [cost (author/expectation-cost nil)]
+      (is (not (:cannot-run? cost)))
+      (is (empty? (:required cost))))))
+
+(deftest row-cost-projects-live-from-a-row
+  (testing "a ready DOM row reports cannot-run before it is even an atom elsewhere"
+    (is (:cannot-run?
+          (author/row-cost
+            {:kind :dom-text :operands {:selector "\".x\"" :text "\"y\""}}))))
+  (testing "an unparsed row projects a non-throwing headless cost"
+    (is (not (:cannot-run?
+               (author/row-cost {:kind :app-db-equals :operands {}}))))))
+
+;; ===========================================================================
+;; DRAFT SUMMARY — the before-save honesty banner data
+;; ===========================================================================
+
+(deftest draft-summary-aggregates-cost-and-surfaces
+  (let [draft {:rows [{:row-id 0 :kind :app-db-equals
+                       :operands {:path "[:a]" :expected "1"}}
+                      {:row-id 1 :kind :dom-text
+                       :operands {:selector "\".x\"" :text "\"y\""}}
+                      {:row-id 2 :kind :app-db-equals
+                       :operands {:path "" :expected "1"}}]}  ; not ready
+        {:keys [count ready atoms required cheapest-runner cannot-run-rows surfaces]}
+        (author/draft-summary draft)]
+    (testing "counts authored vs ready"
+      (is (= 3 count))
+      (is (= 2 ready) "the blank-path row is not ready"))
+    (testing "atoms are the canonical vocabulary for ready rows only"
+      (is (= [[:rf.assert/path-equals [:a] 1]
+              [:rf.assert/dom-text ".x" "y"]]
+             atoms)))
+    (testing "required is the union of every ready atom's tokens"
+      (is (= #{:app-db :dom} required)))
+    (testing "cheapest runner proves the WHOLE draft (escalates to :dom for the DOM row)"
+      (is (= :dom cheapest-runner)))
+    (testing "cannot-run-rows lists the DOM row — the honest before-save list"
+      (is (= 1 (clojure.core/count cannot-run-rows)))
+      (is (= [:rf.assert/dom-text ".x" "y"] (:atom (first cannot-run-rows)))))
+    (testing "surfaces span the authored kinds"
+      (is (= #{:app-db :dom} surfaces)))))
+
+;; ===========================================================================
+;; SNIPPET — expectations become EXPLICIT variant DATA (the round-trip)
+;; ===========================================================================
+
+(deftest merge-assertions-is-additive-and-dedupes
+  (testing "authored atoms append after existing, order preserved"
+    (is (= [[:rf.assert/path-equals [:a] 1]
+            [:rf.assert/no-warnings]]
+           (author/merge-assertions
+             [[:rf.assert/path-equals [:a] 1]]
+             [[:rf.assert/no-warnings]]))))
+  (testing "an exact duplicate is dropped (re-authoring is idempotent)"
+    (is (= [[:rf.assert/path-equals [:a] 1]]
+           (author/merge-assertions
+             [[:rf.assert/path-equals [:a] 1]]
+             [[:rf.assert/path-equals [:a] 1]]))))
+  (testing "nil existing / authored are tolerated"
+    (is (= [[:rf.assert/no-warnings]]
+           (author/merge-assertions nil [[:rf.assert/no-warnings]])))
+    (is (= [] (author/merge-assertions nil nil)))))
+
+(deftest gen-expectations-snippet-round-trips
+  (let [snippet (author/gen-expectations-snippet
+                  {:variant-id :story.counter/expects-5
+                   :extends    :story.counter/happy-path
+                   :existing   [[:rf.assert/no-warnings]]
+                   :authored   [[:rf.assert/path-equals [:counter :value] 5]]
+                   :doc        "the counter holds 5 after two increments"})]
+    (testing "the snippet is a reg-variant form carrying :assertions DATA"
+      (is (str/includes? snippet "reg-variant"))
+      (is (str/includes? snippet ":story.counter/expects-5"))
+      (is (str/includes? snippet ":extends :story.counter/happy-path"))
+      (is (str/includes? snippet ":assertions"))
+      (is (str/includes? snippet ":tags #{:test}")
+          "an authored-expectations variant is a runnable test by default"))
+    (testing "the snippet read-string-s back to the merged variant body"
+      (let [form (edn/read-string snippet)
+            ;; (alias/reg-variant <id> <body>) — body is the 3rd element
+            body (nth form 2)]
+        (is (= :story.counter/happy-path (:extends body)))
+        (is (= "the counter holds 5 after two increments" (:doc body)))
+        (is (= [[:rf.assert/no-warnings]
+                [:rf.assert/path-equals [:counter :value] 5]]
+               (:assertions body))
+            "existing + authored assertions merged, the round-trip")))))
+
+(deftest assertions-known-validates-against-the-vocabulary
+  (is (author/assertions-known?
+        [[:rf.assert/path-equals [:a] 1] [:rf.assert/dom-text ".x" "y"]]))
+  (is (not (author/assertions-known?
+             [[:rf.assert/not-a-real-assertion]]))
+      "an unknown id is rejected so the snippet can never reference one"))
+
+(deftest default-id-prefix-is-distinct-from-siblings
+  (testing "the prefix distinguishes authored-expectations from save / promotion"
+    (is (= "expects" author/default-id-prefix))
+    (is (not= "saved" author/default-id-prefix))
+    (is (not= "regression" author/default-id-prefix))))

--- a/tools/story/test/re_frame/story/ui/author_expectations_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/author_expectations_cljs_test.cljc
@@ -1,0 +1,204 @@
+(ns re-frame.story.ui.author-expectations-cljs-test
+  "Tests for the expectation-authoring UI surface (rf2-ba86n.12, spec/021
+  §S5).
+
+  Two tiers (mirrors `save_variant_cljs_test` / `promotion_cljs_test`):
+
+  - **JVM + CLJS** (pure draft transitions in `ui.author-expectations`) —
+    add / remove / edit-operand / draft-atoms. These pin the contract the
+    dialog ratom swaps over, and run host-free.
+
+  - **CLJS-only** (the dialog ratom + button hiccup + dialog render depend
+    on Reagent / DOM) — the button disabled state, the kind-picker /
+    per-row cost stripe / coverage banner hiccup, and that the rendered
+    dialog carries the cost-before-save honesty + the :assertions snippet.
+
+  Runs on the JVM under `clojure -M:test` and on CLJS under shadow's
+  `:node-test` build (ns suffix `-cljs-test`)."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.story.ui.author-expectations :as ui]
+            #?@(:cljs [[clojure.string :as str]
+                       [re-frame.story.registrar :as registrar]])))
+
+;; ===========================================================================
+;; JVM + CLJS — pure draft transitions
+;; ===========================================================================
+
+(deftest add-row-mints-stable-ids
+  (testing "add-row appends a fresh row of the kind with a stable id"
+    (let [d  (ui/initial-draft)
+          d1 (ui/add-row d :app-db-equals)
+          d2 (ui/add-row d1 :dom-text)]
+      (is (= 2 (count (:rows d2))))
+      (is (= [:app-db-equals :dom-text] (mapv :kind (:rows d2))))
+      (is (= [0 1] (mapv :row-id (:rows d2)))
+          "row ids are stable + monotonic so React keys survive edits"))))
+
+(deftest remove-row-drops-by-id
+  (let [d (-> (ui/initial-draft)
+              (ui/add-row :app-db-equals)
+              (ui/add-row :no-warnings))]
+    (is (= [1] (mapv :row-id (:rows (ui/remove-row d 0)))))
+    (is (= 2 (count (:rows d))) "remove is non-mutating")))
+
+(deftest set-operand-stores-raw-string
+  (testing "set-operand stores the raw value verbatim (parsed at projection)"
+    (let [d (-> (ui/initial-draft)
+                (ui/add-row :app-db-equals)
+                (ui/set-operand 0 :path "[:a]")
+                (ui/set-operand 0 :expected "5"))]
+      (is (= "[:a]" (get-in (first (:rows d)) [:operands :path])))
+      (is (= "5" (get-in (first (:rows d)) [:operands :expected]))))))
+
+(deftest set-variant-id-and-doc
+  (let [d (-> (ui/initial-draft)
+              (ui/set-variant-id :story.x/expects-1)
+              (ui/set-doc "why"))]
+    (is (= :story.x/expects-1 (:variant-id d)))
+    (is (= "why" (:doc d)))))
+
+(deftest draft-atoms-projects-ready-rows
+  (testing "draft-atoms yields canonical atoms for the ready rows only"
+    (let [d (-> (ui/initial-draft)
+                (ui/add-row :app-db-equals)
+                (ui/set-operand 0 :path "[:a]")
+                (ui/set-operand 0 :expected "1")
+                (ui/add-row :no-warnings)         ; nullary, always ready
+                (ui/add-row :sub-equals))]        ; operands blank → not ready
+      (is (= [[:rf.assert/path-equals [:a] 1]
+              [:rf.assert/no-warnings]]
+             (ui/draft-atoms d))))))
+
+;; ===========================================================================
+;; CLJS-only — button hiccup
+;; ===========================================================================
+
+#?(:cljs
+   (deftest button-disabled-without-variant
+     (testing "the button is disabled + hinted when no variant is focused"
+       (let [attrs (second (ui/author-expectations-button nil))]
+         (is (true? (:disabled attrs)))
+         (is (str/includes? (:title attrs) "Select a variant"))
+         (is (= "story-author-expectation-button" (:data-test attrs)))))))
+
+#?(:cljs
+   (deftest button-enabled-with-variant
+     (testing "the button enables when a variant is focused"
+       (let [attrs (second (ui/author-expectations-button :story.x/y))]
+         (is (false? (:disabled attrs)))
+         (is (fn? (:on-click attrs)))))))
+
+;; ===========================================================================
+;; CLJS-only — dialog ratom + render
+;; ===========================================================================
+
+#?(:cljs
+   (defn- render-dialog
+     "Realise the form-2 author-dialog into hiccup (call the component, then
+      its returned render fn)."
+     []
+     ((ui/author-dialog))))
+
+#?(:cljs
+   (deftest dialog-not-rendered-when-closed
+     (testing "the dialog renders nil while its ratom is closed"
+       (reset! ui/dialog-atom ui/initial-dialog-state)
+       (is (nil? (render-dialog))))))
+
+#?(:cljs
+   (deftest open-seeds-an-empty-draft-with-default-id
+     (testing "open! flips :open? and seeds a default expects-<ms> id"
+       (registrar/clear-all!)
+       (ui/open! :story.counter/happy-path)
+       (let [d @ui/dialog-atom]
+         (is (:open? d))
+         (is (= :story.counter/happy-path (:source-id d)))
+         (is (empty? (:rows (:draft d))) "starts with no expectations")
+         (is (qualified-keyword? (:variant-id (:draft d))))
+         (is (str/includes? (name (:variant-id (:draft d))) "expects")
+             "the default id carries the 'expects' prefix"))
+       (ui/close!))))
+
+#?(:cljs
+   (deftest dialog-shows-cost-before-save-and-cannot-run
+     (testing "the open dialog renders the per-row cost + a cannot-run flag
+               for a DOM expectation — the honesty floor BEFORE save"
+       (registrar/clear-all!)
+       (ui/open! :story.counter/happy-path)
+       ;; author one headless app-db expectation + one DOM expectation
+       (ui/add-row! :app-db-equals)
+       (ui/set-operand! 0 :path "[:counter :value]")
+       (ui/set-operand! 0 :expected "5")
+       (ui/add-row! :dom-text)
+       (ui/set-operand! 1 :selector "\".count\"")
+       (ui/set-operand! 1 :text "\"5\"")
+       (let [flat (str (render-dialog))]
+         (is (str/includes? flat "story-author-expectation-dialog"))
+         ;; both authored rows are present as components (the per-row cost
+         ;; stripe lives inside each `expectation-row`)
+         (is (str/includes? flat "story-author-expectation-rows"))
+         (is (str/includes? flat "expectation_row")
+             "the authored rows render as expectation-row components")
+         ;; the draft coverage banner reports the cheapest runner + the
+         ;; explicit cannot-run honesty BEFORE save (escalates to :dom)
+         (is (str/includes? flat "story-author-expectation-summary"))
+         (is (str/includes? flat ":data-cheapest-runner \":dom\"")
+             "the cheapest runner that proves the whole draft is surfaced")
+         (is (str/includes? flat "story-author-expectation-cannot-run-summary"))
+         (is (str/includes? flat "cannot run under the default headless runner")
+             "the cannot-run honesty is visible BEFORE save")
+         ;; the snippet carries the authored expectations as :assertions DATA
+         (is (str/includes? flat "story-author-expectation-snippet"))
+         (is (str/includes? flat ":assertions"))
+         (is (str/includes? flat ":rf.assert/path-equals"))
+         (is (str/includes? flat ":rf.assert/dom-text"))
+         (is (str/includes? flat ":extends"))
+         (is (str/includes? flat ":story.counter/happy-path")))
+       (ui/close!))))
+
+#?(:cljs
+   (deftest expectation-row-renders-per-row-cost-stripe
+     (testing "an authored DOM row renders its per-row cost stripe with the
+               cannot-run-headless flag — the honesty floor at the row level
+               (realised directly, since the strip lives inside the component)"
+       (let [row  {:row-id 0 :kind :dom-text
+                   :operands {:selector "\".count\"" :text "\"5\""}}
+             flat (str (#'ui/expectation-row row))]
+         (is (str/includes? flat "story-author-expectation-cost"))
+         (is (str/includes? flat "story-author-expectation-cannot-run"))
+         (is (str/includes? flat "cannot run headless"))
+         (is (str/includes? flat ":dom") "the cheapest runner is shown")))))
+
+#?(:cljs
+   (deftest dialog-merges-existing-declared-assertions
+     (testing "the snippet merges the source variant's declared :assertions
+               with the authored atoms (the additive round-trip)"
+       (registrar/clear-all!)
+       (registrar/install-canonical-tags!)
+       ;; register a source variant that already declares an assertion
+       (registrar/reg-variant* :story.counter/has-assert
+         {:assertions [[:rf.assert/no-warnings]]
+          :tags       #{:test}})
+       (ui/open! :story.counter/has-assert)
+       (ui/add-row! :app-db-equals)
+       (ui/set-operand! 0 :path "[:n]")
+       (ui/set-operand! 0 :expected "1")
+       (let [flat (str (render-dialog))]
+         (is (str/includes? flat ":rf.assert/no-warnings") "existing kept")
+         (is (str/includes? flat ":rf.assert/path-equals") "authored added"))
+       (ui/close!))))
+
+#?(:cljs
+   (deftest kind-picker-covers-all-surfaces
+     (testing "the rendered dialog kind-picker offers a chip per catalog kind"
+       (registrar/clear-all!)
+       (ui/open! :story.x/y)
+       (let [flat (str (render-dialog))]
+         (is (str/includes? flat "story-author-expectation-kind-picker"))
+         ;; one chip per kind — spot-check the five acceptance surfaces
+         (is (str/includes? flat "app-db-equals"))
+         (is (str/includes? flat "sub-equals"))
+         (is (str/includes? flat "dom-text"))
+         (is (str/includes? flat "schema-error"))
+         (is (str/includes? flat "a11y")))
+       (ui/close!))))


### PR DESCRIPTION
## What

Implements the S5 workflow (spec/021 §S5, spec/019): a useful story becomes a regression test without a separate fixture. The author **authors expectations** onto a story — distinct from save-current-as-variant (ba86n.6) and generated-failure promotion (ba86n.13).

## The authoring flow

- Open from the Controls panel (`add expectations…`, beside `save as new variant…`) or the command palette (`Add expectations to this story`).
- Pick an expectation **kind** from a catalog covering all five acceptance surfaces — **app-db** (`path-equals` / `path-matches` / `dispatched?` / `effect-emitted` / `no-warnings`), **subscriptions** (`sub-equals`), **rendered DOM** (`dom-text` / `dom-visible`), **schema behaviour** (`schema-error` + the app-db `path-matches` Malli rung), and **browser/a11y** (`a11y-structural` / `a11y` / `visual-snapshot`).
- Fill operands (live-parsed, per-field errors); each authored expectation folds onto the canonical `re-frame.story.assertions` `:rf.assert/*` atom for its surface — the ONE vocabulary, never a parallel expectation model.
- Copy the generated `(reg-variant … {:assertions […]})` form into source (source is never written directly — same escape hatch as save-variant / promotion).

## Runner cost / `:cannot-run` visible BEFORE save (the honesty floor)

Each expectation's cost is read from the **existing** `re-frame.story.requirements` registry (`assertion-tokens` / `cheapest-runner` / `missing-tokens`) — never a parallel cost model:

- a **per-row** cost stripe shows the cheapest runner that can prove it + an explicit `cannot run headless — missing #{…}` flag when it needs DOM / pixels / a11y-engine / reactive evidence;
- a **draft-level** coverage banner shows how many expectations are ready, which surfaces they span, the single cheapest runner that would prove the whole draft, and the explicit list of rows that `:cannot-run` headless.

So a browser-tier expectation's cost is honest *before* commit, never discovered only at run time.

## Saved expectations are EXPLICIT variant DATA (the round-trip)

The snippet's `:assertions` slot carries the authored canonical atoms **merged** with the source variant's already-declared `:assertions` (additive, exact-duplicate-deduped), authored via `:extends` of the source. It `read-string`s back to the merged variant body and round-trips through the registrar — explicit DATA, not hidden UI state. A read-only `authored-expectation-strip` (in `re-frame.story.ui.assertion-strip`) displays a variant's declared, un-run expectations with their runner cost (distinct from the run-result strip, which carries verdicts).

## Kept separate from .6 / .13

The three flows share the `review-dialog` review-then-commit skeleton but have separate entry points and source semantics:

- **save-current-state** (.6): source = the live args snapshot (STATE authoring);
- **promotion** (.13): source = a captured run ARTIFACT;
- **this flow**: source = the author's declared INTENT (the EXPECTATION).

Conflating any two is an explicit not-EPIC-ready condition (documented in the new spec/021 §1a).

## Schema flag

For the schema-kind expectation I consumed the **existing** canonical vocabulary — `:rf.assert/path-matches` (a Malli schema at an app-db path) and `:rf.assert/schema-error` (an expected boundary violation). I did **not** redefine or unify the schema resolvers; the pending schema-cluster decision (ayu6n/p5ivc/vnedo) owns that lane.

## Files

- `tools/story/src/re_frame/story/author_expectations.cljc` — pure substrate (catalog, atom builders, cost projection, snippet).
- `tools/story/src/re_frame/story/ui/author_expectations.cljc` — CLJS dialog + controls button + palette target.
- `tools/story/src/re_frame/story/ui/assertion_strip.cljs` — `authored-expectation-strip` display.
- `tools/story/src/re_frame/story/ui/command_palette*.clj{c,s}` — palette entry + dialog mount on the palette host (avoids touching `shell.cljs`).
- `tools/story/src/re_frame/story/ui/controls.cljs` — the `add expectations…` button.
- `tools/story/spec/021-Story-UI-Test-And-Evidence.md` — §1a (CURRENT authoring surface; separation from .6/.13).
- tests: `author_expectations_test.cljc` (pure, JVM+CLJS) + `author_expectations_cljs_test.cljc` (dialog/transitions).

## Quality gates

- **clj-kondo** `--parallel --fail-level error --lint tools/story`: **0 errors** (my files: 0 warnings).
- `tools/story` `clojure -M:test`: 0 failures, 0 errors.
- `npm run test:cljs`: **0 warnings**, 0 failures, 0 errors.
- `tools/story-mcp` `clojure -M:test`: 0 failures, 0 errors.
- `tools/mcp-conformance` `npm run test:story`: GREEN.
- `scripts/test-fast-pr.sh`: PASS (incl. markdown anchor validators for the spec change).
