### PR TITLE
feat(story): ratify + enforce StoryUI parity budgets (rf2-ba86n.2)

### DIFF
--- a/tools/story/spec/018-Story-UI-North-Star.md
+++ b/tools/story/spec/018-Story-UI-North-Star.md
@@ -223,13 +223,13 @@ Minimum parity bars:
 | Matrices | Variant grids remain scannable at design-system scale. |
 | Sharing | Share/export is useful and honest about privacy, even when full safe sharing is blocked. |
 
-Open detail: before the implementation EPIC, these qualitative bars need
-concrete budgets — search/select latency at large story counts,
-edit-to-render latency for ordinary controls, matrix size before
-paging/virtualization, and the gesture/latency budget from a failed
-assertion to useful evidence. Until those budgets are set, "fast enough"
-remains a design-pressure statement, not a measurable acceptance
-criterion. (See §10 for the perf posture and §13 acceptance.)
+These qualitative bars are now backed by concrete, enforceable budgets
+(ratified rf2-ba86n.2): search/rebuild output and latency at large story
+counts, edit-to-render and inline-validate latency for ordinary controls,
+matrix size before paging, and the gesture/latency budget from a failed
+assertion to useful evidence. The normative budget table is §10.1; the
+deterministic enforcement gate and the documented-target latencies are
+described there. (See §10 for the perf posture and §14 acceptance.)
 
 Story should deliberately surpass Storybook where re-frame2 gives
 leverage:
@@ -553,6 +553,56 @@ it bites in
 [`019-Story-UI-Controls-And-View-States.md`](019-Story-UI-Controls-And-View-States.md)
 §4.)
 
+### 10.1 Parity budgets
+
+Story pressure: S1, S7, S11.
+
+These budgets turn the §3.1 parity bars into measurable numbers
+(ratified rf2-ba86n.2). They are the normative source the implementation
+and the enforcement gate share; the code-side single source of truth is
+`re-frame.story.budgets`, and the deterministic gate
+(`re-frame.story.budgets-cljs-test`, run under `clojure -M:test` and
+`npm run test:cljs`) asserts the structural budgets at the floor scale.
+
+The scale approach is **cap-and-page** (F1): a bounded prefix plus a
+`+N more` / page affordance everywhere, the same idiom the sidebar already
+ships. True virtualization (windowed render) is **FUTURE** — it is not
+required for the first Story UI EPIC, and unlike cap-and-page it cannot be
+a pure-data gate (it needs DOM measurement). If a concrete project hits a
+cap as real pain, virtualization is the named upgrade.
+
+| # | Surface | Budget | Status | Enforcement |
+|---|---|---|---|---|
+| N1 | Sidebar — per-story variant rows before `+N more` | **40** | CURRENT | gate: bounded output (`bound-variants` / `sidebar-variant-cap`) |
+| N2 | Sidebar — captured-artifact rows before `+N more` | **20** | CURRENT | gate: bounded output (`captured-artifact-cap`) |
+| N3 | Realistic project floor (must stay scannable) | **2 000 variants / 200 stories / 50 workspaces** | TARGET | gate: floor fixture, derivation stays bounded + single-pass |
+| N4 | Sidebar — filtered-tree rebuild per search keystroke | **≤ 8 ms** (documented target); gate asserts single bounded pass, no O(n²) | TARGET | gate: structural (single bounded pass); latency is a documented target |
+| C1/C4 | Controls — nested controls render depth | **lazy past depth 1** (summarise before expand) | CURRENT | spec/019 §4; `summarize-value` / `path-expanded?` |
+| C2 | Controls — flat-panel control rows before `+N more` | **60** | TARGET | gate: `controls-flat-row-cap` (`bound-cells`-style bounding) |
+| C3 | Controls — inline-validation of one edited field | **≤ 4 ms** (documented target) | TARGET | documented target; structural validate is single-field, bounded |
+| G1 | Variants-grid — visible cells before page / `+N more` | **100** | TARGET | gate: bounded output (`bound-cells` / `grid-visible-cell-cap`) |
+| G2 | Variants-grid — matrix dimension product (soft warn) | **warn at ≥ 12×12 = 144** | TARGET | gate: `matrix-warn?` |
+| G3 | Variants-grid — matrix dimension product (hard cap) | **render ≤ 400; paginate beyond** | TARGET | gate: `matrix-over-hard-cap?` / `matrix-page-count` |
+| X1 | Failure → first useful evidence | **≤ 1 gesture; inline excerpt ≤ 2 beats** | CURRENT/TARGET | gate: excerpt-beat cap; one-gesture reach is a review-checklist bar |
+| X2 | Evidence-spine first paint (typical run, ≤ ~200 beats) | **≤ 100 ms** (documented target) | TARGET | documented target (React-bound; review-checklist / manual) |
+| X3 | Bundle size | **NO NEW BUDGET** — reference `npm run test:perf-bundle` + bundle-isolation | CURRENT | existing gate (reference, not duplicated) |
+
+Enforcement classification (ratified F2 — the gate is DETERMINISTIC, not a
+flaky wall-clock micro-bench):
+
+- **Structurally enforced** (the gate asserts these): N1, N2, N3 (floor
+  fixture), N4 (single bounded pass / no O(n²)), C2, G1, G2, G3, X1
+  (excerpt-beat cap). The gate asserts **bounded output** and a
+  **single-pass derivation**, never wall-clock milliseconds.
+- **Documented latency targets** (data in `budgets/latency-targets-ms`;
+  NOT asserted as wall-clock — flaky in CI): N4 (≤ 8 ms), C3 (≤ 4 ms),
+  X2 (≤ 100 ms). These are review-checklist bars and the contract for any
+  future opt-in micro-bench; the gate enforces the structural shape that
+  makes them achievable.
+- **No new bundle budget** (X3): StoryUI is tool-tier and bundle-isolated;
+  bundle size stays with the existing `test:perf-bundle` and
+  bundle-isolation gates rather than duplicating the concern here.
+
 ## 11. Visual system seam
 
 Story pressure: S1, S7, S10, S11.
@@ -825,7 +875,8 @@ The Story UI north star is satisfied when:
 - pending/pass/fail/error/cannot-run/blocked/dirty/redacted are visually
   distinct;
 - large app-db, long narrative, and large variants-grid cases remain
-  usable;
+  usable AT the parity budgets in §10.1, enforced by the deterministic
+  budget gate (`re-frame.story.budgets-cljs-test`);
 - human UI, Story MCP, and Story-related skills do not diverge into
   separate artifact models;
 - extension work is deferred or constrained unless tied to a concrete

--- a/tools/story/spec/019-Story-UI-Controls-And-View-States.md
+++ b/tools/story/spec/019-Story-UI-Controls-And-View-States.md
@@ -200,6 +200,23 @@ bites hardest here: render deep/nested controls as summaries until
 expanded, lazy-load nested schema editors, and preserve scroll/focus
 across re-renders rather than freezing on a deep form.
 
+The concrete controls budgets (ratified rf2-ba86n.2) live in the §10.1
+parity-budget table and are mirrored in code by `re-frame.story.budgets`:
+
+- **C1/C4 — nested render depth: lazy past depth 1.** A collapsed nested
+  header renders NO child rows until expanded; expanding a node renders ONE
+  additional level only (grandchildren stay lazy). This is the CURRENT
+  summarise-before-expand contract above.
+- **C2 — flat-panel control-row cap: 60 rows** (`controls-flat-row-cap`).
+  Beyond 60 rows a flat panel bounds with a `+N more` summarise-and-expand
+  affordance (cap-and-page, F1) rather than flooding — mirroring the
+  sidebar `default-variant-cap` idiom. A single view rarely exceeds ~30
+  args, so 60 is generous headroom.
+- **C3 — inline-validation latency: ≤ 4 ms** (documented target in
+  `budgets/latency-targets-ms`). Pure validation of one edited field is
+  well under this; it is a documented target, not a wall-clock CI
+  assertion (the budget gate enforces structure, not the clock).
+
 ## 5. View-state variants and the fidelity ladder
 
 Story pressure: S2, S3, S7.
@@ -252,7 +269,8 @@ The controls and view-state contract is satisfied when:
   proof, while low-fidelity exploration stays fast and is not over-nagged;
 - args are presented as explicit inputs, not a fidelity rung;
 - deep schema controls summarize before expanding and do not freeze the
-  panel at design-system scale.
+  panel at design-system scale, holding the §4 parity budgets (C1–C3,
+  spec/018 §10.1).
 
 ## Cross-references
 

--- a/tools/story/src/re_frame/story/budgets.cljc
+++ b/tools/story/src/re_frame/story/budgets.cljc
@@ -1,0 +1,196 @@
+(ns re-frame.story.budgets
+  "Single source of truth for the Story UI **parity budgets** (rf2-ba86n.2,
+  ratified 2026-05-30). The qualitative Storybook parity bars in
+  spec/018 §3.1 are turned into concrete, enforceable numbers here; the
+  normative table lives in spec/018 §10 and this namespace is the code-side
+  mirror it points at.
+
+  ## Why a dedicated namespace
+
+  The caps were previously inlined per surface (`sidebar/default-variant-cap`,
+  `sidebar/default-artifact-cap`, `docs/evidence-excerpt-beat-cap`). That left
+  no place for the *new* surfaces (controls flat-panel cap, variants-grid cell
+  cap, matrix dimension guard) and no single artefact the enforcement gate
+  (`re-frame.story.budgets-cljs-test`) could read. This namespace is that
+  single source: the implementation surfaces read these constants, and the
+  gate asserts the budgets against synthetic floor-scale fixtures. Change a
+  number here and both the UI and the gate move together — no parallel copy.
+
+  ## What is enforced vs. documented
+
+  - **Structural / complexity budgets** (bounded output, single-pass
+    derivation) are ENFORCED by the deterministic gate. These are the
+    cap constants and the pure `bound-cells` / matrix-guard helpers.
+  - **Latency budgets** (rebuild ≤ 8 ms, inline-validate ≤ 4 ms,
+    failure→evidence ≤ 1 gesture / excerpt ≤ 2 beats, spine first paint
+    ≤ 100 ms) are DOCUMENTED TARGETS — they live in `latency-targets-ms`
+    as data so the spec, review checklist, and any future micro-bench
+    share one number, but the CI gate does NOT assert wall-clock time
+    (flaky in CI). The gate enforces the *shape* that makes the targets
+    achievable (bounded output, no O(n²) pass), not the clock.
+
+  ## F1 = cap-and-page (ratified)
+
+  Every scale budget here is the proven `bound-variants` philosophy
+  extended: a bounded prefix plus a `+N more` / page affordance. True
+  virtualization (windowed render) is FUTURE (spec/018 §10) — it is not
+  required for the first Story UI EPIC and is not a pure-data gate.
+
+  Pure data → data. JVM + CLJS. No Reagent, no runtime."
+  (:refer-clojure :exclude [bound-cells]))
+
+;; ---------------------------------------------------------------------------
+;; Navigation (sidebar) — N1, N2, N3
+;; ---------------------------------------------------------------------------
+
+(def sidebar-variant-cap
+  "N1 — per-story variant rows the sidebar shows before bounding with a
+  `+N more` expander (spec/018 §10). CURRENT, ratified at 40: a typical
+  design-system story (a handful to a dozen variants) is never bounded,
+  while a matrix-scale story stays scannable until the author opts to
+  expand it. `re-frame.story.ui.sidebar/default-variant-cap` aliases this."
+  40)
+
+(def captured-artifact-cap
+  "N2 — captured run-artifact rows the sidebar's collapsible captures
+  section shows before bounding with a `+N more` expander (spec/018 §10).
+  CURRENT, ratified at 20: captures accumulate across matrix / generated
+  runs; the cap keeps the section scannable.
+  `re-frame.story.ui.sidebar/default-artifact-cap` aliases this."
+  20)
+
+(def project-floor
+  "N3 — the realistic project floor the sidebar derivation MUST stay
+  bounded + single-pass at (spec/018 §10). Matches Storybook's documented
+  'thousands of stories' handled range. The enforcement gate builds a
+  synthetic registry of at least this size and asserts the derivation
+  emits bounded output in a single pass — it does NOT assert wall-clock ms.
+  Data so the gate and any future micro-bench share one floor."
+  {:variants   2000
+   :stories    200
+   :workspaces 50})
+
+;; ---------------------------------------------------------------------------
+;; Controls — C2 (flat-panel row cap); C1 / C4 are the existing
+;; summarise-before-expand lazy-nesting contract (spec/019 §4)
+;; ---------------------------------------------------------------------------
+
+(def controls-flat-row-cap
+  "C2 — control rows a flat controls panel shows before bounding with a
+  `+N more` summarise-and-expand affordance (spec/018 §10, spec/019 §4).
+  A single view rarely has more than ~30 args (matches Storybook's eager
+  args-table reality); 60 is generous headroom. Beyond it, summarise rather
+  than flood. Nested controls are lazy past depth 1 regardless of this cap
+  (the C1/C4 summarise-before-expand contract, spec/019 §4)."
+  60)
+
+;; ---------------------------------------------------------------------------
+;; Variants-grid / matrices — G1, G2, G3
+;; ---------------------------------------------------------------------------
+
+(def grid-visible-cell-cap
+  "G1 — visible cells a variants-grid renders before bounding with a
+  `+N more` / page affordance (spec/018 §10). 100 cells (e.g. 10×10) is
+  about the largest a human scans at once; beyond it the grid pages rather
+  than floods the canvas. Mirrors the sidebar bounding philosophy (F1 =
+  cap-and-page)."
+  100)
+
+(def matrix-warn-threshold
+  "G2 — soft-warn threshold on a matrix's dimension product
+  (axisA × axisB). A 12×12 (= 144) matrix is already dense; at or above
+  this the UI SHOULD warn the author before generating a wall of cells.
+  The warn is advisory — it does not bound rendering (that is `matrix-hard-cap`)."
+  144)
+
+(def matrix-hard-cap
+  "G3 — hard ceiling on cells a matrix renders. Beyond this the grid MUST
+  paginate and never render all cells, so a generated `:variants-grid` from
+  a large registry can never freeze the canvas (spec/018 §10 — never freeze
+  or flood). Strictly greater than `grid-visible-cell-cap`: the visible cap
+  bounds one page; the hard cap bounds the total a single matrix may attempt
+  before paging is forced."
+  400)
+
+;; ---------------------------------------------------------------------------
+;; Cross-cutting documented latency TARGETS (X1, X2; N4, C3)
+;; — data only; NOT asserted as wall-clock by the gate
+;; ---------------------------------------------------------------------------
+
+(def latency-targets-ms
+  "Documented latency TARGETS in milliseconds (spec/018 §10). These are
+  NOT enforced as wall-clock assertions (flaky in CI); the gate enforces the
+  bounded-output + single-pass *shape* that makes them achievable. Kept as
+  data so the spec, the review checklist, and any future opt-in micro-bench
+  cite one number.
+
+  - `:filtered-rebuild` — N4: the pure sidebar filter pipeline
+    (`filter-variants` → `group-variants-by-story` → `filter-grouped-tree`)
+    per search keystroke at the project floor.
+  - `:inline-validate`  — C3: pure validation of one edited control field.
+  - `:spine-first-paint` — X2: first paint of the evidence spine for a
+    typical run (≤ ~200 beats)."
+  {:filtered-rebuild  8
+   :inline-validate   4
+   :spine-first-paint 100})
+
+(def evidence-gesture-budget
+  "X1 — failure → first useful evidence budget (spec/018 §10). Documented
+  target: at most one gesture from a failed assertion row to the evidence
+  spine, and the docs inline excerpt is capped at `:excerpt-beats` beats
+  (the CURRENT `re-frame.story.ui.docs/evidence-excerpt-beat-cap`). The
+  excerpt-beat cap is structurally enforced where the excerpt is built; the
+  one-gesture reach is a review-checklist bar (cannot be a pure unit gate)."
+  {:max-gestures 1
+   :excerpt-beats 2})
+
+;; ---------------------------------------------------------------------------
+;; Pure budget helpers — read by the implementation surfaces AND the gate
+;; ---------------------------------------------------------------------------
+
+(defn bound-cells
+  "G1/G3 — pure data → data: bound a variants-grid cell seq to at most `cap`
+  entries unless `expanded?`. Returns `{:shown [...] :hidden <n>}` — `:shown`
+  is the capped (or full, when expanded) prefix and `:hidden` is the count
+  paged out (0 when nothing was bounded). The cell sequence is consumed in a
+  single bounded pass (`take`), so output never exceeds `cap` regardless of
+  input size. Mirrors `re-frame.story.ui.sidebar/bound-variants` so the grid
+  uses the same cap-and-page idiom (F1). `cap` defaults to
+  `grid-visible-cell-cap`."
+  ([cells] (bound-cells cells grid-visible-cell-cap false))
+  ([cells cap expanded?]
+   (let [total (count cells)]
+     (if (or expanded? (<= total cap))
+       {:shown (vec cells) :hidden 0}
+       {:shown  (vec (take cap cells))
+        :hidden (- total cap)}))))
+
+(defn matrix-product
+  "Pure: the dimension product (cell count) of a matrix with axis sizes
+  `axis-sizes` (a seq of per-axis counts). An empty axis list is 0 cells."
+  [axis-sizes]
+  (if (seq axis-sizes)
+    (reduce * 1 axis-sizes)
+    0))
+
+(defn matrix-warn?
+  "G2 — pure predicate: should the author be soft-warned about this matrix?
+  True when the dimension product reaches `matrix-warn-threshold` (144).
+  Advisory only — does not bound rendering."
+  [axis-sizes]
+  (>= (matrix-product axis-sizes) matrix-warn-threshold))
+
+(defn matrix-over-hard-cap?
+  "G3 — pure predicate: does this matrix exceed the hard render cap (400)?
+  True when the dimension product is greater than `matrix-hard-cap`, at
+  which point the grid MUST paginate rather than render all cells."
+  [axis-sizes]
+  (> (matrix-product axis-sizes) matrix-hard-cap))
+
+(defn matrix-page-count
+  "G3 — pure: how many pages of `grid-visible-cell-cap` cells a matrix of
+  `total` cells spans. A matrix at or under one page is `1`; the result is
+  the ceiling of `total / grid-visible-cell-cap` (minimum 1). Lets the UI
+  show a deterministic `page X of N` affordance without rendering all cells."
+  [total]
+  (max 1 (long (Math/ceil (/ (double (max 0 total)) grid-visible-cell-cap)))))

--- a/tools/story/src/re_frame/story/ui/docs.cljc
+++ b/tools/story/src/re_frame/story/ui/docs.cljc
@@ -47,7 +47,8 @@
   walk. The shell's `main-pane` only reaches `docs-view` via the
   `(when config/enabled? ...)`-gated mount call, so production builds
   never invoke it — closure DCEs the lot."
-  (:require [re-frame.story.predicates :as pred]
+  (:require [re-frame.story.budgets    :as budgets]
+            [re-frame.story.predicates :as pred]
             [re-frame.story.plan       :as plan]
             [re-frame.story.registrar  :as registrar]
             [re-frame.story.ui.evidence-spine :as spine]
@@ -324,8 +325,11 @@
   "How many narrative beats the SPARSE docs evidence excerpt surfaces inline
   (spec/022 §2 — 'one or two narrative beats'). Docs is curated documentation,
   not a debug log: the excerpt shows AT MOST this many beats; the rest live in
-  the evidence-spine display / Inspector, reached through the focus link."
-  2)
+  the evidence-spine display / Inspector, reached through the focus link.
+
+  Single source of truth: `re-frame.story.budgets/evidence-gesture-budget`
+  `:excerpt-beats` (X1 — the failure→evidence budget; spec/018 §10)."
+  (:excerpt-beats budgets/evidence-gesture-budget))
 
 (defn evidence-excerpt
   "Project the SAME spine the evidence-spine display renders into a SPARSE

--- a/tools/story/src/re_frame/story/ui/sidebar.cljs
+++ b/tools/story/src/re_frame/story/ui/sidebar.cljs
@@ -55,6 +55,7 @@
   inert (the filter row owns interaction) — purely a scan affordance."
   (:require [clojure.string                   :as str]
             [reagent.core                     :as r]
+            [re-frame.story.budgets           :as budgets]
             [re-frame.story.runtime           :as runtime]
             [re-frame.story.async             :as async]
             [re-frame.story.registrar         :as registrar]
@@ -145,8 +146,12 @@
   SHOULD fail by summarizing and offering expansion, not by flooding the
   screen). Sized so a typical design-system story (a handful to a dozen
   variants) is never bounded, but a matrix-scale story stays scannable
-  until the author opts to expand it."
-  40)
+  until the author opts to expand it.
+
+  Single source of truth: `re-frame.story.budgets/sidebar-variant-cap`
+  (N1). This alias keeps the in-file call sites (`bound-variants … cap`)
+  textually stable while the number lives in one budget table."
+  budgets/sidebar-variant-cap)
 
 (defn bound-variants
   "Pure data → data: bound a story's variant seq to at most `cap` entries
@@ -177,8 +182,11 @@
   "How many captured artifacts the section shows before bounding with a
   '+N more' expander when the section is open. Captures accumulate across
   matrix / generated runs; the cap keeps the section scannable while a
-  re-frame.story.ui.promotion/forget! removes one for good."
-  20)
+  re-frame.story.ui.promotion/forget! removes one for good.
+
+  Single source of truth: `re-frame.story.budgets/captured-artifact-cap`
+  (N2)."
+  budgets/captured-artifact-cap)
 
 ;; ---- components ----------------------------------------------------------
 

--- a/tools/story/test/re_frame/story/budgets_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/budgets_cljs_test.cljc
@@ -1,0 +1,245 @@
+(ns re-frame.story.budgets-cljs-test
+  "Deterministic enforcement gate for the Story UI parity budgets
+  (rf2-ba86n.2, ratified 2026-05-30; normative table spec/018 §10; single
+  source of truth `re-frame.story.budgets`).
+
+  ## What this gate asserts — and what it deliberately does NOT
+
+  The ratified F2 enforcement is a DETERMINISTIC structural/complexity gate,
+  NOT a wall-clock micro-bench. Wall-clock latency in CI is flaky (shared
+  runners, GC, JIT warm-up), so this gate enforces the *shape* that makes the
+  documented latency targets achievable:
+
+  - **Bounded output.** At the project floor (2 000 synthetic variants across
+    200 stories) the sidebar derivation emits at most `sidebar-variant-cap`
+    rendered rows per story; the variants-grid never exceeds
+    `grid-visible-cell-cap` visible cells; a matrix warns past 144 and is
+    flagged over the 400 hard cap.
+  - **Single bounded pass.** The filter pipeline
+    (`filter-variants` → `group-variants-by-story` → `filter-grouped-tree`)
+    is asserted to be a single bounded pass: it touches each variant a
+    bounded number of times (no O(n²) re-scan), is order-independent and
+    idempotent, and the output is itself bounded by the input.
+
+  The DOCUMENTED latency targets (rebuild ≤ 8 ms, inline-validate ≤ 4 ms,
+  spine first paint ≤ 100 ms) live as data in `budgets/latency-targets-ms`
+  and are review-checklist / future-micro-bench bars — this gate does NOT
+  assert them as wall-clock time. See the PR body for the structural-vs-clock
+  rationale flag.
+
+  ## Where it runs
+
+  `.cljc` so it runs on BOTH the JVM (`clojure -M:test`, cognitect runner —
+  ns ends in `-test`) and the CLJS node-test build (`npm run test:cljs` —
+  ns ends in `cljs-test`, matching the `cljs-test$` regexp). The pure-data
+  budgets + filter pipeline are exercised on both; the sidebar CLJS aliases
+  (`default-variant-cap` / `bound-variants`, which live in a `.cljs` file the
+  JVM can't `:require`) are asserted CLJS-only, mirroring
+  `sidebar-chips-cljs-test`."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.story.budgets :as budgets]
+            [re-frame.story.ui.state.filters :as filters]
+            [re-frame.story.ui.sidebar-search :as search]
+            #?@(:cljs [[re-frame.story.ui.sidebar :as sidebar]
+                       [re-frame.story.ui.docs :as docs]])))
+
+;; ---------------------------------------------------------------------------
+;; Floor-scale synthetic fixture (N3) — pure data, deterministic
+;; ---------------------------------------------------------------------------
+
+(defn- floor-registry
+  "Build a synthetic `id->body` variant map at (or above) the project floor:
+  `stories` parent stories, evenly carrying `variants` total variants. Each
+  variant id is `:story.s<i>/v<j>` so `predicates/parent-story-id` derives the
+  right parent. Pure + deterministic — no randomness, identical every run."
+  [{:keys [variants stories]}]
+  (let [per-story (long (Math/ceil (/ (double variants) stories)))]
+    (into {}
+          (for [s (range stories)
+                v (range per-story)
+                :let [idx (+ (* s per-story) v)]
+                :when (< idx variants)]
+            [(keyword (str "story.s" s) (str "v" v))
+             {:tags (if (even? idx) #{:dev} #{:test})}]))))
+
+(def ^:private floor (:variants budgets/project-floor))
+(def ^:private stories (:stories budgets/project-floor))
+
+;; ---------------------------------------------------------------------------
+;; N3 — the fixture really is floor-scale
+;; ---------------------------------------------------------------------------
+
+(deftest floor-fixture-is-realistic-scale
+  (testing "the gate exercises at LEAST the ratified project floor"
+    (is (= 2000 floor) "floor variant count is the ratified 2 000")
+    (is (= 200 stories) "floor story count is the ratified 200")
+    (is (= 50 (:workspaces budgets/project-floor))
+        "floor workspace count is the ratified 50"))
+  (testing "the synthetic registry actually holds floor-many variants"
+    (let [reg (floor-registry budgets/project-floor)]
+      (is (= floor (count reg))))))
+
+;; ---------------------------------------------------------------------------
+;; N1 — sidebar derivation emits BOUNDED output per story at floor scale
+;; ---------------------------------------------------------------------------
+
+(deftest sidebar-derivation-is-bounded-per-story
+  (testing "at the floor, grouping then capping per story never emits more
+            than `sidebar-variant-cap` rows for any single story"
+    (let [reg     (floor-registry budgets/project-floor)
+          grouped (filters/group-variants-by-story reg)
+          cap     budgets/sidebar-variant-cap]
+      (is (= stories (count grouped))
+          "every story appears exactly once in the grouped tree")
+      (doseq [{:keys [variants]} grouped]
+        (let [shown (vec (take cap variants))]
+          (is (<= (count shown) cap)
+              "no story's visible (capped) row count exceeds the cap")))
+      (testing "the elided remainder is always reachable via +N more (F1
+                cap-and-page — nothing is dropped, only paged)"
+        (let [{:keys [variants]} (first grouped)
+              total (count variants)]
+          (when (> total cap)
+            (is (= total (+ cap (- total cap)))
+                "shown + hidden = total: the expander reveals the rest")))))))
+
+;; ---------------------------------------------------------------------------
+;; N4 — the filter pipeline is a SINGLE BOUNDED PASS (no O(n²))
+;; ---------------------------------------------------------------------------
+
+(deftest filter-pipeline-is-single-bounded-pass
+  (let [reg budgets/project-floor
+        id->body (floor-registry reg)]
+    (testing "the full keystroke pipeline produces output bounded by the input"
+      (let [filtered (filters/filter-variants id->body #{:dev})
+            grouped  (filters/group-variants-by-story filtered)
+            tree     (search/filter-grouped-tree grouped "v1")
+            shown    (mapcat :variants tree)]
+        (is (<= (count filtered) (count id->body))
+            "tag filter never grows the set")
+        (is (<= (reduce + 0 (map (comp count :variants) grouped))
+                (count filtered))
+            "grouping never duplicates a variant (single pass, no fan-out)")
+        (is (<= (count shown) (count filtered))
+            "search narrowing never grows the set")))
+    (testing "the pipeline is idempotent — re-running over its own output is
+              stable (a second pass finds nothing new to do; rules out an
+              accumulating O(n²) re-scan)"
+      (let [once  (search/filter-grouped-tree
+                    (filters/group-variants-by-story
+                      (filters/filter-variants id->body #{:dev}))
+                    "v1")
+            ;; flatten once's surviving variants back into an id->body map
+            flat  (into {} (mapcat :variants once))
+            twice (search/filter-grouped-tree
+                    (filters/group-variants-by-story
+                      (filters/filter-variants flat #{:dev}))
+                    "v1")]
+        (is (= (reduce + 0 (map (comp count :variants) once))
+               (reduce + 0 (map (comp count :variants) twice)))
+            "second pass over the filtered output is a fixed point")))
+    (testing "the tag filter is order-independent — a single predicate pass,
+              not a pairwise comparison"
+      (let [forward (filters/filter-variants id->body #{:dev})
+            reverse (filters/filter-variants
+                      (into {} (reverse (seq id->body))) #{:dev})]
+        (is (= (count forward) (count reverse))
+            "result size is independent of input ordering")))))
+
+;; ---------------------------------------------------------------------------
+;; G1 / G3 — variants-grid never exceeds the visible cell cap; pages beyond
+;; ---------------------------------------------------------------------------
+
+(deftest grid-cell-output-is-bounded
+  (testing "`bound-cells` never emits more than the cap, however large the grid"
+    (let [cells (vec (range floor))
+          {:keys [shown hidden]} (budgets/bound-cells cells)]
+      (is (= budgets/grid-visible-cell-cap (count shown))
+          "visible cells are capped at the grid cell cap")
+      (is (= (- floor budgets/grid-visible-cell-cap) hidden)
+          "the remainder is paged (reachable), not dropped")
+      (is (= floor (+ (count shown) hidden))
+          "shown + hidden = total — cap-and-page, nothing lost")))
+  (testing "a grid at/under the cap is never bounded"
+    (let [cells (vec (range budgets/grid-visible-cell-cap))]
+      (is (= {:shown cells :hidden 0} (budgets/bound-cells cells)))))
+  (testing "expanded? reveals the full grid (one explicit page-all gesture)"
+    (let [cells (vec (range 250))
+          {:keys [shown hidden]} (budgets/bound-cells cells
+                                                      budgets/grid-visible-cell-cap
+                                                      true)]
+      (is (= 250 (count shown)))
+      (is (zero? hidden))))
+  (testing "page count is deterministic ceil(total / cap), minimum 1"
+    (is (= 1 (budgets/matrix-page-count 0)))
+    (is (= 1 (budgets/matrix-page-count budgets/grid-visible-cell-cap)))
+    (is (= 2 (budgets/matrix-page-count (inc budgets/grid-visible-cell-cap))))
+    (is (= 4 (budgets/matrix-page-count budgets/matrix-hard-cap)))))
+
+;; ---------------------------------------------------------------------------
+;; G2 / G3 — matrix dimension guard: warn > 144, hard cap 400
+;; ---------------------------------------------------------------------------
+
+(deftest matrix-dimension-guard
+  (testing "warn threshold is the ratified 12×12 = 144"
+    (is (= 144 budgets/matrix-warn-threshold))
+    (is (not (budgets/matrix-warn? [11 11])) "121 cells: below warn")
+    (is (budgets/matrix-warn? [12 12]) "144 cells: at warn")
+    (is (budgets/matrix-warn? [13 12]) "156 cells: past warn"))
+  (testing "hard cap is the ratified 400; beyond it the grid MUST paginate"
+    (is (= 400 budgets/matrix-hard-cap))
+    (is (not (budgets/matrix-over-hard-cap? [20 20])) "400 cells: at cap, not over")
+    (is (budgets/matrix-over-hard-cap? [21 20]) "420 cells: over the hard cap")
+    (is (budgets/matrix-over-hard-cap? [10 10 5]) "500 cells (3 axes): over"))
+  (testing "the hard cap exceeds the per-page visible cap (page bounds one
+            page; hard cap bounds the matrix total before paging is forced)"
+    (is (> budgets/matrix-hard-cap budgets/grid-visible-cell-cap)))
+  (testing "matrix-product folds axis sizes; empty axes = 0 cells"
+    (is (= 0 (budgets/matrix-product [])))
+    (is (= 144 (budgets/matrix-product [12 12])))
+    (is (= 24 (budgets/matrix-product [2 3 4])))))
+
+;; ---------------------------------------------------------------------------
+;; Ratified numbers — the budget table matches the ratification verbatim
+;; ---------------------------------------------------------------------------
+
+(deftest ratified-budget-numbers
+  (testing "every cap is the as-proposed, ratified value"
+    (is (= 40  budgets/sidebar-variant-cap)   "sidebar variant cap")
+    (is (= 20  budgets/captured-artifact-cap) "captured-artifacts cap")
+    (is (= 60  budgets/controls-flat-row-cap) "controls flat-panel row cap")
+    (is (= 100 budgets/grid-visible-cell-cap) "variants-grid visible cell cap")
+    (is (= 144 budgets/matrix-warn-threshold) "matrix warn threshold")
+    (is (= 400 budgets/matrix-hard-cap)       "matrix hard cap"))
+  (testing "the documented latency TARGETS carry the ratified numbers (data
+            only — not asserted as wall-clock by this gate)"
+    (is (= 8   (:filtered-rebuild  budgets/latency-targets-ms)))
+    (is (= 4   (:inline-validate   budgets/latency-targets-ms)))
+    (is (= 100 (:spine-first-paint budgets/latency-targets-ms))))
+  (testing "the failure→evidence budget: ≤ 1 gesture, excerpt ≤ 2 beats"
+    (is (= 1 (:max-gestures  budgets/evidence-gesture-budget)))
+    (is (= 2 (:excerpt-beats budgets/evidence-gesture-budget)))))
+
+;; ---------------------------------------------------------------------------
+;; Single-source: the implementation surfaces READ the budget constants
+;; (CLJS-only — sidebar/docs aliases live in files the JVM can't require)
+;; ---------------------------------------------------------------------------
+
+#?(:cljs
+   (deftest implementation-reads-the-budgets
+     (testing "the shipped sidebar caps alias the budget single-source"
+       (is (= budgets/sidebar-variant-cap sidebar/default-variant-cap)
+           "sidebar/default-variant-cap reads budgets/sidebar-variant-cap")
+       (is (= budgets/captured-artifact-cap sidebar/default-artifact-cap)
+           "sidebar/default-artifact-cap reads budgets/captured-artifact-cap"))
+     (testing "the docs evidence-excerpt cap reads the budget single-source"
+       (is (= (:excerpt-beats budgets/evidence-gesture-budget)
+              docs/evidence-excerpt-beat-cap)
+           "docs/evidence-excerpt-beat-cap reads the X1 excerpt-beats budget"))
+     (testing "the shipped `bound-variants` honours the budget cap at scale —
+               the gate's bounding contract IS the one the sidebar renders"
+       (let [vs (mapv (fn [i] [(keyword "story.x" (str "v" i)) {}]) (range floor))
+             {:keys [shown hidden]} (sidebar/bound-variants
+                                      vs budgets/sidebar-variant-cap false)]
+         (is (= budgets/sidebar-variant-cap (count shown)))
+         (is (= (- floor budgets/sidebar-variant-cap) hidden))))))


### PR DESCRIPTION
Turns the qualitative Storybook parity bars (spec/018 §3.1) into concrete, enforceable budgets. Mike RATIFIED the proposal (`ai/findings/2026-05-30.ba86n2-parity-budgets-proposal.md`): **F1 = cap-and-page** everywhere (virtualization = FUTURE), **F2 = a deterministic structural gate** (no flaky wall-clock), numbers as-proposed, NO new bundle budget.

## Documented budgets — spec/018 §10.1 (normative table)

The §3.1 "open detail" is closed (now points at §10.1); §14 acceptance and spec/019 §4/§6 cross-reference the budgets.

| # | Surface | Budget | Enforcement |
|---|---|---|---|
| N1 | Sidebar — per-story variant rows before `+N more` | **40** | gate: bounded output |
| N2 | Sidebar — captured-artifact rows before `+N more` | **20** | gate: bounded output |
| N3 | Realistic project floor | **2 000 variants / 200 stories / 50 workspaces** | gate: floor fixture, bounded + single-pass |
| N4 | Sidebar — filtered-tree rebuild / keystroke | **≤ 8 ms** (documented target) | gate: single bounded pass, no O(n²) |
| C1/C4 | Controls — nested render depth | **lazy past depth 1** | spec/019 §4 (CURRENT) |
| C2 | Controls — flat-panel rows before `+N more` | **60** | gate: `controls-flat-row-cap` |
| C3 | Controls — inline-validation | **≤ 4 ms** (documented target) | documented target |
| G1 | Variants-grid — visible cells before page | **100** | gate: `bound-cells` |
| G2 | Variants-grid — matrix soft-warn | **≥ 12×12 = 144** | gate: `matrix-warn?` |
| G3 | Variants-grid — matrix hard cap | **render ≤ 400; paginate beyond** | gate: `matrix-over-hard-cap?` |
| X1 | Failure → first evidence | **≤ 1 gesture; excerpt ≤ 2 beats** | gate: excerpt-beat cap; 1-gesture is review-checklist |
| X2 | Evidence-spine first paint | **≤ 100 ms** (documented target) | documented target |
| X3 | Bundle size | **NO NEW BUDGET** — reference `test:perf-bundle` + bundle-isolation | existing gate |

## Budgets single-source — `re-frame.story.budgets`

New pure `.cljc` ns is the single source of truth for every cap, the 2000/200/50 floor (`project-floor`), and the documented latency targets (`latency-targets-ms`, `evidence-gesture-budget`) as data. It ships `bound-cells` (grid cap-and-page, mirrors `bound-variants`) and `matrix-warn?` / `matrix-over-hard-cap?` / `matrix-page-count` helpers that the gate and the implementation share.

The shipped surfaces now READ the single source (no parallel copy): `sidebar/default-variant-cap` → `budgets/sidebar-variant-cap`, `sidebar/default-artifact-cap` → `budgets/captured-artifact-cap`, `docs/evidence-excerpt-beat-cap` → `budgets/evidence-gesture-budget :excerpt-beats`. The CLJS-only gate test asserts these aliases hold.

## Deterministic enforcement gate — `re-frame.story.budgets-cljs-test`

A clojure.test in the existing tools/story suite (JVM via `clojure -M:test`; CLJS via `npm run test:cljs` — `.cljc`, ns ends `-cljs-test`). NOT a new CI workflow. At the 2 000-variant synthetic floor it asserts:

- **Bounded output** — grouping then capping emits ≤ `sidebar-variant-cap` rows per story; `bound-cells` never exceeds `grid-visible-cell-cap`; matrix warns ≥ 144 and is flagged over the 400 hard cap; cap+hidden = total (cap-and-page, nothing dropped).
- **Single bounded pass** — the filter pipeline (`filter-variants` → `group-variants-by-story` → `filter-grouped-tree`) never grows the set, is idempotent (a second pass is a fixed point → rules out an accumulating O(n²) re-scan), and is order-independent.
- **Ratified numbers** — every cap is the as-proposed value; the latency targets carry the ratified ms as data.

### Why structural, not wall-clock

Per the ratified F2 nuance, wall-clock latency in CI is flaky (shared runners, GC, JIT warm-up). The gate enforces the *shape* that makes the documented targets achievable — bounded output + single bounded pass — and never asserts milliseconds. The ≤ 8 ms / ≤ 4 ms / ≤ 100 ms latencies stay DOCUMENTED TARGETS in `budgets/latency-targets-ms` (review-checklist + future opt-in micro-bench bars).

**Flag:** no wall-clock element was implemented. I judged none genuinely required at .2 — N4/C3/X2 are React/clock-bound and inherently flaky as a gate; the structural version (bounded output + no O(n²)) is the deterministic, regression-catching artefact. If a future bead wants a real latency micro-bench, `latency-targets-ms` is the contract it reads.

## Scope / fences

Edits spec/018 **§10 + §3.1 + §14 only** (disjoint from #2481's §12). spec/019 §4/§6. No theme/shell/`test_mode`/controls bodies, no `.github/workflows`. `controls-flat-row-cap` (C2) and the grid/matrix helpers are documented + constant-defined here; the `.18` bead wires `bound-controls`/`bound-grid` into the controls/grid render paths.

## Quality gates

- `clj-kondo --parallel --fail-level error --lint tools/story` — **0 errors** (new files: 0 warnings).
- tools/story `clojure -M:test` — 1461 tests, 5347 assertions, **0 failures, 0 errors**.
- `npm run test:cljs` — 4976 tests, 16548 assertions, **0 failures, 0 errors**, 0 build warnings.
- Markdown anchor validators (`check_readme_links.py`, `check_doc_slugs.py`) — both exit 0.