### PR TITLE
refactor(story): ONE shared compiled-plan view-args resolver (rf2-din8u phase-1; ayu6n+p5ivc+vnedo)

### DIFF
--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -242,7 +242,7 @@ The metadata map accepted by `reg-view` / `reg-view*`. The `^{:rf/id ...}` symbo
     [:rf/id        {:optional true} :keyword]                                ;; explicit id override (auto-derived from *ns* + symbol when absent)
     [:rf/args      {:optional true} [:vector :symbol]]                       ;; the macro-captured args-vector symbols (defn-shape introspection)
     [:rf/form      {:optional true} [:enum :form-1 :form-2 :form-3]]         ;; the view body's Reagent form discriminator
-    [:rf/props     {:optional true} :any]                                    ;; Malli schema for the view's props (when supplied); composes with the base :schema key per [010](010-Schemas.md)
+    [:rf/props     {:optional true} :any]                                    ;; Malli schema for the view's props (when supplied); the canonical props-schema slot, resolved first-match over `[:rf/props :schema]` (not composed — `:rf/props` wins outright over `:schema` for the view-args boundary) per [010](010-Schemas.md)
     ]])
 ```
 

--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -496,15 +496,26 @@ schemas) and it does not seed app-db.
 
 **Metadata key (M0-confirmed).** `reg-view` stamps a view's symbol
 metadata (minus `:rf/id`) onto its `:view` registrar slot, so the props
-schema rides on that slot. The compiler resolves it **first match wins**:
-`:rf/props` (the spec-named props key, for a port that adopts it) →
-`:spec` (the live Spec 010 boundary-schema slot the framework already
-exposes) → `:schema` (the Story-only alias the controls / schema-
-validation panels already read). Story consumes the key the framework
-exposes rather than inventing a parallel one; the controls-panel
-derivation (`re-frame.story.ui.controls`) reads the same slot, so a view
-that declares a props schema gets controls AND validation from one
-source.
+schema rides on that slot. The compiler resolves it **first match wins**
+over `[:rf/props :schema]`: `:rf/props` (the canonical props-schema key
+per [Spec-Schemas §`:rf/registration-metadata`](../../../spec/Spec-Schemas.md#rfregistration-metadata),
+primary) → `:schema` (the post-M-54 `reg-*` metadata key, the alternative
+location). `:rf/props` wins outright when present — there is NO
+composition (a view's only schema surface is its props). `:spec` is NOT a
+resolution key: it is dead post-M-54 (the framework reads `:schema` only
+on `reg-*` metadata, with no back-compat shim — see
+[MIGRATION §M-54](../../../migration/from-re-frame-v1/README.md#m-54-schema-vocabulary-unification--spec--schema)).
+
+Every Story consumer reads this schema through the ONE shared resolver
+`re-frame.story.view-args/compiled-view-args-schema`, which compiles the
+variant-plan and returns the schema the compiler wrote to
+`[:world :view-args-schema]` — the single source of truth (the compiled-
+plan invariant). No consumer reads the bare registrar body. So the
+controls-panel derivation (`re-frame.story.ui.controls`) and the schema-
+validation panel (`re-frame.story.ui.schema-validation`) read the SAME
+compiled slot, and a view that declares a props schema gets controls AND
+validation from one source — even when its `:component` is
+`:extends`-inherited or `:compose`-d in.
 
 **Plan slots.** When the variant's resolved `:component` view carries a
 schema, the compiler writes:

--- a/tools/story/src/re_frame/story/malli_schema.cljc
+++ b/tools/story/src/re_frame/story/malli_schema.cljc
@@ -57,3 +57,36 @@
     (if (properties? (first r))
       (second r)
       (first r))))
+
+;; ---- view-args (props) schema key resolution -----------------------------
+;;
+;; The ONE canonical first-match order for a view's explicit-input (props)
+;; schema, shared by the plan compiler (`re-frame.story.plan`, which writes
+;; the resolved schema to `[:world :view-args-schema]`) and the
+;; compiled-plan resolver (`re-frame.story.view-args`). Lives at this leaf
+;; (alongside the Malli introspection helpers, no plan dependency) so both
+;; consumers agree on the slots WITHOUT a require cycle (view-args requires
+;; plan; plan must not require view-args).
+;;
+;; Per the rf2-p5ivc (b) ruling: first match wins over `[:rf/props :schema]`;
+;; `:rf/props` is canonical and wins over `:schema` (no composition). `:spec`
+;; is NOT here — it is dead post-M-54 (the framework reads `:schema` only on
+;; `reg-*` metadata; see migration/from-re-frame-v1/README.md §M-54).
+
+(def view-args-schema-keys
+  "View-metadata keys carrying the explicit-input (props) schema, in
+  resolution order (first present wins): `:rf/props` (canonical) then
+  `:schema` (the post-M-54 alternative location). `:spec` is deliberately
+  ABSENT — it is dead post-M-54 (no framework reads it)."
+  [:rf/props :schema])
+
+(defn view-args-schema
+  "Return the explicit view-args/props schema from a `view-meta` map (the
+  `:view` registrar slot), or nil when none is present. Picks the first
+  of `view-args-schema-keys` that is set — `:rf/props` wins over
+  `:schema`; no composition. This is the LOW-LEVEL key picker over an
+  already-resolved view-meta map."
+  [view-meta]
+  (when (map? view-meta)
+    (some (fn [k] (let [s (get view-meta k)] (when (some? s) s)))
+          view-args-schema-keys)))

--- a/tools/story/src/re_frame/story/plan.cljc
+++ b/tools/story/src/re_frame/story/plan.cljc
@@ -509,33 +509,33 @@
 ;;
 ;; **Metadata key.** The spec names `:rf/props` for the props schema and
 ;; `:rf/args` for macro-captured argument *symbols* (introspection, NOT a
-;; validation schema — so it is never consumed here). The live framework
-;; view-metadata contract (Spec 010) carries the boundary schema on
-;; `:spec`, with `:schema` as the Story-only alias the controls /
-;; schema-validation panels already read. We therefore resolve, first
-;; match wins: `:rf/props` (the spec-named props key, when a port adopts
-;; it) → `:spec` (the live Spec 010 slot) → `:schema` (the alias). This
-;; consumes the key the framework already exposes rather than inventing a
-;; parallel one (§View arg schemas — "M0 MUST confirm the exact key").
+;; validation schema — so it is never consumed here). The first-match key
+;; order — `:rf/props` (canonical, `spec/Spec-Schemas.md`
+;; §`:rf/registration-metadata`) then `:schema` (the post-M-54 `reg-*`
+;; metadata key) — is the canonical resolution shared with every Story
+;; consumer through `re-frame.story.malli-schema/view-args-schema`. `:rf/props`
+;; wins over `:schema`; there is NO composition (a view's only schema
+;; surface is its props — the rf2-p5ivc (b) ruling). `:spec` is NOT a slot:
+;; it is dead post-M-54 (the framework reads `:schema` only on `reg-*`
+;; metadata — see migration/from-re-frame-v1/README.md §M-54).
 ;;
 ;; **Boundary.** This validates EXPLICIT view inputs only. Values
 ;; returned from subscriptions are validated by subscription-output
 ;; schemas (§View-state subscription overrides); the two are different
 ;; contracts and are not conflated here.
 
-(def ^:private view-args-schema-keys
-  "View-metadata keys carrying the explicit-input (props) schema, in
-  resolution order (first present wins). See the section comment."
-  [:rf/props :spec :schema])
+(def view-args-schema-keys
+  "Re-export of `re-frame.story.malli-schema/view-args-schema-keys` — the
+  canonical first-match key order `[:rf/props :schema]`."
+  msu/view-args-schema-keys)
 
-(defn view-args-schema
-  "Return the explicit view-args/props schema from a `view-meta` map (the
-  `:view` registrar slot), or nil when none is present. Picks the first
-  of `view-args-schema-keys` that is set."
-  [view-meta]
-  (when (map? view-meta)
-    (some (fn [k] (let [s (get view-meta k)] (when (some? s) s)))
-          view-args-schema-keys)))
+(def view-args-schema
+  "Re-export of `re-frame.story.malli-schema/view-args-schema` — the
+  first-match key picker over a resolved `view-meta` map. The compiler
+  uses it to write `[:world :view-args-schema]`; the shared resolver
+  `re-frame.story.view-args/compiled-view-args-schema` (which consumers
+  call) reads that compiled slot back."
+  msu/view-args-schema)
 
 (defn- map-entry-optional?
   "True iff a Malli `[:map …]` entry `[k props? child]` is marked
@@ -1044,8 +1044,8 @@
 (defn- default-view-lookup
   "Default view-metadata lookup — reads the **framework** `:view`
   registrar slot (where `reg-view` stamps a view's symbol metadata, incl.
-  any props/`:spec`/`:schema` slot). Production bundles that elide views
-  return nil; pure tests thread an explicit `:view-lookup`."
+  any `:rf/props` / `:schema` props-schema slot). Production bundles that
+  elide views return nil; pure tests thread an explicit `:view-lookup`."
   [view-id]
   (framework-registrar/handler-meta :view view-id))
 
@@ -1495,8 +1495,8 @@
     (and the keyword target itself). Defaults to the side-table.
   - `:view-lookup` — a 1-arg fn `(view-id) → view-meta` OR a
     `{view-id → view-meta}` map, used to resolve the `:component` view's
-    props/`:spec`/`:schema` slot for view-args validation. Defaults to
-    the framework `:view` registrar (§View arg schemas).
+    `:rf/props` / `:schema` props-schema slot for view-args validation.
+    Defaults to the framework `:view` registrar (§View arg schemas).
   - `:validator-fns` — `{:validate (fn …) :explain (fn …)}` for
     malformed-value checking of `:effective-args`; with none supplied
     only required-key presence is checked.

--- a/tools/story/src/re_frame/story/ui/controls.cljs
+++ b/tools/story/src/re_frame/story/ui/controls.cljs
@@ -70,6 +70,7 @@
             [re-frame.story.args               :as args]
             [re-frame.story.decorators         :as decorators]
             [re-frame.story.malli-schema       :as msu]
+            [re-frame.story.view-args          :as view-args]
             [re-frame.story.ui.author-expectations :as author-expectations]
             [re-frame.story.ui.controls-styles :refer [styles]]
             [re-frame.story.ui.save-variant    :as save-variant-ui]
@@ -259,7 +260,17 @@
   we don't re-run `args/resolve-args` (which itself deep-merges five
   precedence layers and re-reads the registrar). The single-arity
   overload preserves the canonical surface for tests + non-render
-  callers; the render path threads its own resolution."
+  callers; the render path threads its own resolution.
+
+  SCHEMA SOURCE (rf2-vnedo / rf2-din8u): the auto-derivation schema is
+  the COMPILED variant-plan's `[:world :view-args-schema]`, read through
+  the ONE shared resolver `view-args/compiled-view-args-schema` (memoized
+  per variant + registrar tick). This is the SAME slot the schema-
+  validation panel validates against, so a `:rf/props`-declared view now
+  gets BOTH derived controls AND validation from one source — the
+  divergence where this fn read `:schema`-only off the bare body (missing
+  `:rf/props`, and any `:extends`-inherited / `:compose`-d `:component`)
+  is gone."
   ([variant-id]
    (resolve-argtypes variant-id (args/resolve-args variant-id)))
   ([variant-id eff-args]
@@ -268,17 +279,12 @@
          sb      (when story (registrar/handler-meta :story story))
          types   (merge (normalize-argtypes (:argtypes sb))
                         (normalize-argtypes (:argtypes vb)))
-         ;; Prefer an explicit `:schema` slot on the variant/story body
-         ;; (forward-compatible — Spec 010 will land an `:rf/schema`
-         ;; slot on variants for the auto-derivation path). Fall back
-         ;; to the registered :view's `:schema` slot (when reg-view
-         ;; starts carrying one). Per spec/001 §Schema-derivation pipeline.
-         component-id (or (:component vb) (:component sb))
-         component-body (when component-id
-                          (registrar/handler-meta :view component-id))
-         derive-schema (or (:schema vb)
-                           (:schema sb)
-                           (:schema component-body))
+         ;; The view-args (props) schema off the COMPILED plan — the
+         ;; single source of truth (`[:world :view-args-schema]`), resolved
+         ;; first-match `[:rf/props :schema]` through the shared resolver.
+         ;; Per spec/001 §Schema-derivation pipeline + the rf2-din8u
+         ;; compiled-plan invariant.
+         derive-schema (view-args/compiled-view-args-schema variant-id)
          schema-entries (when (and (vector? derive-schema)
                                    (= :map (schema-op derive-schema)))
                           (into {}

--- a/tools/story/src/re_frame/story/ui/schema_validation.cljc
+++ b/tools/story/src/re_frame/story/ui/schema_validation.cljc
@@ -26,23 +26,23 @@
 
   Storybook 8 has no schema-introspection equivalent. JSON Schema /
   PropTypes are descriptive metadata, not runtime conformance — Story
-  consumes the same `:spec` slot the framework's dev-mode validator
+  consumes the same `:schema` slot the framework's dev-mode validator
   consumes and renders failures from the live trace bus. The reader
   sees 'the args you're rendering this variant with violate the
   component's contract' immediately.
 
   ## Schema lookup
 
-  The panel looks for the component schema in this order (first match
-  wins):
-
-    1. The variant body's `:schema` slot — explicit per-variant
-       override (forward-compatible with the `:rf/schema` Spec 010
-       slot per IMPL-SPEC §9.4).
-    2. The parent story body's `:schema` slot — story-wide schema.
-    3. The framework registrar's `:view` metadata for the variant's
-       `:component`, looking at `:spec` (Spec 010 canonical) then
-       `:schema` (legacy / Story-only alias).
+  The panel resolves the component (view-args / props) schema off the
+  COMPILED variant-plan — the single source of truth — through the ONE
+  shared resolver `re-frame.story.view-args/compiled-view-args-schema`.
+  That resolver routes through `re-frame.story.plan/variant-plan` (so an
+  `:extends`-inherited / `:compose`-d `:component` resolves) and reads the
+  schema the compiler wrote to `[:world :view-args-schema]`, resolved
+  first-match `[:rf/props :schema]` off the component view's `:view`
+  metadata (rf2-din8u / rf2-p5ivc (b)). The controls panel derives its
+  argtypes from the SAME slot, so validation and controls share one
+  source.
 
   When no schema is on file, the args section reports 'no schema
   registered' and the trace section still surfaces any
@@ -81,8 +81,8 @@
                        [re-frame.story.args       :as args]
                        [re-frame.story.config     :as config]
                        [re-frame.story.registrar  :as story-registrar]
-                       [re-frame.story.ui.trace-buffer :as trace-buffer]
-                       [re-frame.registrar        :as framework-registrar]])
+                       [re-frame.story.view-args  :as view-args]
+                       [re-frame.story.ui.trace-buffer :as trace-buffer]])
             [re-frame.story.theme.typography :as typography :refer [mono-stack]]
             [re-frame.story.theme.colors :as colors]))
 
@@ -289,29 +289,25 @@
 
 #?(:cljs
    (defn resolve-component-schema
-     "Resolve the component schema for `variant-id`, looking in:
+     "Resolve the component (view-args / props) schema for `variant-id`
+     off the COMPILED variant-plan — the single source of truth
+     (`[:world :view-args-schema]`), resolved first-match `[:rf/props
+     :schema]` through the ONE shared resolver
+     `re-frame.story.view-args/compiled-view-args-schema` (memoized per
+     variant + registrar tick). Returns the schema value, or nil when none
+     is registered.
 
-       1. The variant body's `:schema` slot.
-       2. The parent story body's `:schema` slot.
-       3. The framework registrar's `:view` metadata for the
-          `:component` id, looking at `:spec` first (Spec 010
-          canonical) then `:schema`.
+     This is the SAME slot the controls panel derives argtypes from
+     (`re-frame.story.ui.controls/resolve-argtypes`), so validation and
+     controls share one source (rf2-din8u / rf2-vnedo). Routing through the
+     compiled plan also resolves an `:extends`-inherited / `:compose`-d
+     `:component` that the previous bare-body read (`(:component vb)` /
+     `(:component sb)`) missed.
 
-     Returns the schema value, or nil when none is registered.
-
-     The panel's CLJS-only render path calls this; the pure
-     helpers (`args-violations`) take a pre-resolved schema and
-     are JVM-friendly."
+     The panel's CLJS-only render path calls this; the pure helpers
+     (`args-violations`) take a pre-resolved schema and are JVM-friendly."
      [variant-id]
-     (let [vb         (story-registrar/handler-meta :variant variant-id)
-           story-id   (args/parent-story-id variant-id)
-           sb         (when story-id (story-registrar/handler-meta :story story-id))
-           comp-id    (or (:component vb) (:component sb))
-           view-meta  (when comp-id (framework-registrar/handler-meta :view comp-id))]
-       (or (:schema vb)
-           (:schema sb)
-           (:spec   view-meta)
-           (:schema view-meta)))))
+     (view-args/compiled-view-args-schema variant-id)))
 
 ;; ---- CLJS: validator lookup via late-bind -------------------------------
 

--- a/tools/story/src/re_frame/story/view_args.cljc
+++ b/tools/story/src/re_frame/story/view_args.cljc
@@ -1,0 +1,129 @@
+(ns re-frame.story.view-args
+  "The ONE shared view-args-schema resolver (rf2-din8u phase-1, ratifying
+  the rf2-p5ivc (b) ruling + closing rf2-ayu6n / rf2-vnedo).
+
+  ## The invariant this enforces
+
+  The compiled variant-plan is the single source of truth. Every Story
+  consumer that wants a variant's view-args (props) schema — the
+  schema-validation panel, the controls-panel argtype derivation, the
+  save-variant snapshot validator — reads it THROUGH this resolver, which
+  compiles the plan (`re-frame.story.plan/variant-plan`) and returns the
+  schema the compiler wrote to `[:world :view-args-schema]`. No consumer
+  reads the bare registrar body and re-derives `:component` /
+  `:rf/props` / `:schema` by hand.
+
+  This matters because `:component` (the view whose schema we resolve) can
+  be `:extends`-inherited or `:compose`-d in. The plan compiler resolves
+  `:component` through the parent chain (`ctx`); a consumer that reads
+  `(:component variant-body)` off the bare side-table body misses an
+  inherited / composed component and silently resolves no schema. The
+  three pre-ruling resolvers each diverged here (plan.cljc read off the
+  resolved `view-meta` first-match `[:rf/props :spec :schema]`;
+  schema_validation read `[(:schema vb) (:schema sb) (:spec view-meta)
+  (:schema view-meta)]` off four bare slots; controls read `[:schema]`
+  only) — none agreed, and all but the plan's copy read the bare body.
+  This ns is the consolidation.
+
+  ## Key resolution (the canonical first-match order)
+
+  The first-match key picker (`malli-schema/view-args-schema` over
+  `[:rf/props :schema]`) lives in the pure leaf `re-frame.story.malli-
+  schema`, shared with the plan compiler (which uses it to write
+  `[:world :view-args-schema]`). Per the rf2-p5ivc (b) ruling: `:rf/props`
+  (canonical) wins over `:schema` (the post-M-54 alternative location); no
+  composition; `:spec` is dead post-M-54 and dropped. See that ns + the
+  migration §M-54 record.
+
+  ## Memoization
+
+  The default (production) path memoizes the compiled schema per
+  `[variant-id mutation-tick]`, where `mutation-tick` is the registrar's
+  monotonic write counter (`re-frame.story.registrar/current-mutation-
+  tick`). Reading the compiled plan per render is therefore cheap: between
+  two registrar writes, repeated calls for the same variant return the
+  cached schema in O(1); any registration / hot-reload bumps the tick and
+  invalidates the slot. The schema does not depend on the runtime
+  effective-args (control overrides / active modes) — only the variant's
+  registered body + its `:extends`/`:compose` chain — so the variant-id is
+  the only run-varying part of the key.
+
+  ## Purity / elision
+
+  The resolver is pure data → data over the plan. The whole ns lives
+  behind the §6 elision contract along with the rest of the Story runtime;
+  the default lookup reads the Story side-table, which is empty in a
+  production bundle."
+  (:require [re-frame.story.malli-schema :as msu]
+            [re-frame.story.plan         :as plan]
+            [re-frame.story.registrar    :as registrar]))
+
+;; ---- key resolution (re-exported from the leaf for the in-ns surface) ----
+;;
+;; The picker itself lives in `malli-schema` (no plan dep) so the plan
+;; compiler and this resolver share it without a require cycle. Re-export
+;; here so callers that already speak `view-args/view-args-schema` keep one
+;; import.
+
+(def view-args-schema-keys
+  "Re-export of `malli-schema/view-args-schema-keys` — the canonical
+  first-match key order `[:rf/props :schema]`."
+  msu/view-args-schema-keys)
+
+(def view-args-schema
+  "Re-export of `malli-schema/view-args-schema` — the low-level key picker
+  over an already-resolved `view-meta` map. Consumers that have a
+  variant-id (not a pre-resolved view-meta) call `compiled-view-args-
+  schema` instead, which routes through the compiled plan so an
+  `:extends`-inherited / `:compose`-d `:component` resolves."
+  msu/view-args-schema)
+
+;; ---- compiled-plan resolver (the ONE shared entry) -----------------------
+
+(defonce ^:private cache
+  ;; {variant-id schema} valid for one `mutation-tick`. A single tick slot,
+  ;; not a {tick → {id → schema}} nest: every registrar write invalidates
+  ;; ALL cached schemas (a hot-reloaded view changes its props schema), so
+  ;; carrying stale-tick entries buys nothing. Mirrors the registrar's
+  ;; `variants-with-tags-cache` shape.
+  (atom {:tick -1 :by-id {}}))
+
+(defn- compile-schema
+  "Compile `variant-id` into a plan (default side-table lookup) and return
+  the `[:world :view-args-schema]` it wrote, or nil. A plan-construction
+  failure (an unregistered variant, a missing `[:arg]`, a malformed view
+  input under a registered validator, …) yields nil rather than throwing —
+  this resolver is a best-effort tooling read (the controls + schema panels
+  render gracefully with no schema), not the authoritative compile path
+  that fails registration."
+  [variant-id]
+  (try
+    (-> (plan/variant-plan variant-id) :world :view-args-schema)
+    (catch #?(:clj Exception :cljs :default) _ nil)))
+
+(defn compiled-view-args-schema
+  "Return the view-args (props) schema for a REGISTERED `variant-id`,
+  resolved off the COMPILED variant-plan (`[:world :view-args-schema]`) —
+  the single source of truth. Routes through `plan/variant-plan` with the
+  DEFAULT side-table lookup so an `:extends`-inherited or `:compose`-d
+  `:component` resolves the same way the runner / render / docs paths see
+  it. Returns nil when the variant is unregistered, declares no
+  `:component`, or its component view carries no `:rf/props` / `:schema`
+  slot.
+
+  Memoized per `[variant-id mutation-tick]` (see the ns docstring): cheap
+  to call per render. The result is identical to
+  `(get-in (plan/variant-plan variant-id) [:world :view-args-schema])` but
+  does not recompile the plan on every call between two registrar writes."
+  [variant-id]
+  (let [tick (registrar/current-mutation-tick)
+        c    @cache]
+    (if (and (= tick (:tick c)) (contains? (:by-id c) variant-id))
+      (get (:by-id c) variant-id)
+      (let [schema (compile-schema variant-id)]
+        (swap! cache
+               (fn [{prev-tick :tick prev-by :by-id}]
+                 (if (= prev-tick tick)
+                   {:tick tick :by-id (assoc prev-by variant-id schema)}
+                   {:tick tick :by-id {variant-id schema}})))
+        schema))))

--- a/tools/story/test/re_frame/story/plan_test.cljc
+++ b/tools/story/test/re_frame/story/plan_test.cljc
@@ -435,16 +435,20 @@
       (is (= {:x 1} (get-in p [:world :effective-args]))))))
 
 (deftest schema-key-precedence
-  (testing ":rf/props wins over :spec which wins over :schema"
+  (testing ":rf/props wins over :schema; :spec is DEAD (dropped post-M-54)"
     (let [props  [:map [:a :string]]
           spec   [:map [:b :string]]
           schema [:map [:c :string]]]
-      (testing ":rf/props chosen when present"
-        (is (= props (plan/view-args-schema {:rf/props props :spec spec :schema schema}))))
-      (testing ":spec chosen when no :rf/props (the live Spec 010 slot)"
-        (is (= spec (plan/view-args-schema {:spec spec :schema schema}))))
-      (testing ":schema chosen as the last-resort alias"
+      (testing ":rf/props chosen when present (canonical, wins over :schema)"
+        (is (= props (plan/view-args-schema {:rf/props props :schema schema}))))
+      (testing ":schema chosen when no :rf/props (the post-M-54 location)"
         (is (= schema (plan/view-args-schema {:schema schema}))))
+      (testing ":spec is NOT a resolution key — a view carrying ONLY :spec
+                resolves no schema (the framework reads :schema only post-M-54;
+                see migration §M-54). rf2-ayu6n: the stale :spec key is gone."
+        (is (nil? (plan/view-args-schema {:spec spec}))))
+      (testing ":rf/props still wins even when a dead :spec is also present"
+        (is (= props (plan/view-args-schema {:rf/props props :spec spec :schema schema}))))
       (testing "nil when no schema slot present"
         (is (nil? (plan/view-args-schema {:title "x"})))))))
 
@@ -484,9 +488,19 @@
       (testing ":sub-overrides lower to their own [:world :render :sub-overrides] slot"
         (is (= {[:widget/state] :error}
                (get-in p [:world :render :sub-overrides]))))
-      (testing "the two contracts are not conflated — sub-overrides are NOT in view-args-schema"
-        (is (not (contains? (set (get-in p [:world :view-args-schema]))
-                            [:widget/state])))))))
+      (testing "the two contracts are not conflated — the view-args schema's
+                map-entry keys are the explicit-arg keys only, never a
+                sub-override query vector (rf2-p5ivc nit: the prior
+                set-membership assertion here was tautological)"
+        ;; A sub-override key is a QUERY VECTOR (`[:widget/state]`); the
+        ;; view-args schema's entries are scalar arg keys (`:label`). Pull
+        ;; the schema's entry keys and assert the sub-override query vector
+        ;; (and its sub-id) are absent — the real conflation guard.
+        (let [schema     (get-in p [:world :view-args-schema])
+              entry-keys (set (map first (drop 1 schema)))]
+          (is (= #{:label} entry-keys))
+          (is (not (contains? entry-keys [:widget/state])))
+          (is (not (contains? entry-keys :widget/state))))))))
 
 ;; ===========================================================================
 ;; View-state subscription overrides (rf2-5x1wt.13)

--- a/tools/story/test/re_frame/story/ui/controls_nested_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/controls_nested_cljs_test.cljc
@@ -20,6 +20,7 @@
   `:node-test` / `:browser-test` targets (ns suffix `-cljs-test` is
   picked up by both `cljs-test$` and `-cljs-test$` regexes)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            #?(:cljs [re-frame.core :as rf])
             #?(:cljs [re-frame.story :as story])
             #?(:cljs [re-frame.story.ui.controls :as controls])
             [re-frame.story.ui.state :as state]))
@@ -125,20 +126,34 @@
      (testing "an unrecognised vector schema-op degrades to :text"
        (is (= :text (:widget (controls/infer-widget [:fn 'pos?])))))))
 
-;; ---- CLJS: resolve-argtypes from a variant :schema ----------------------
+;; ---- CLJS: resolve-argtypes from the component view's props schema -------
+;;
+;; rf2-din8u / rf2-vnedo — the auto-derivation schema is the COMPILED
+;; variant-plan's `[:world :view-args-schema]`, resolved first-match
+;; `[:rf/props :schema]` off the variant's `:component` VIEW metadata. These
+;; exercise the PRODUCTION path: a REGISTERED view carries the props schema
+;; under `:rf/props`; the variant points its `:component` at it; the plan
+;; compiles via the DEFAULT side-table lookup (no `:lookup` / `:view-lookup`
+;; arg). This is the CI-blind-spot gate — the pre-ruling resolver read
+;; `:schema` off the bare variant body, which both missed `:rf/props` AND
+;; never saw the compiled `:component`.
 
 #?(:cljs
-   (deftest resolve-argtypes-picks-up-variant-schema
-     (testing "an explicit :schema on the variant body drives the inference"
+   (deftest resolve-argtypes-picks-up-component-props-schema
+     (testing "the :component view's :rf/props schema drives the inference,
+               resolved off the compiled plan"
+       (rf/reg-view* :view.nest/widget
+         {:rf/props [:map
+                     [:title :string]
+                     [:items [:vector :string]]
+                     [:meta  [:map [:author :string] [:rating :int]]]]}
+         (fn [_] [:div]))
        (story/reg-variant :story.nest/v
-         {:schema [:map
-                   [:title :string]
-                   [:items [:vector :string]]
-                   [:meta  [:map [:author :string] [:rating :int]]]]
-          :args   {:title "Hello"
-                   :items ["a" "b"]
-                   :meta  {:author "ada" :rating 5}}
-          :events []})
+         {:component :view.nest/widget
+          :args      {:title "Hello"
+                      :items ["a" "b"]
+                      :meta  {:author "ada" :rating 5}}
+          :events    []})
        (let [t (controls/resolve-argtypes :story.nest/v)]
          ;; :title scalar
          (is (= :text (-> t :title :widget)))
@@ -152,12 +167,16 @@
 
 #?(:cljs
    (deftest resolve-argtypes-author-argtypes-win
-     (testing "an explicit :argtypes entry trumps the schema-derived widget"
+     (testing "an explicit :argtypes entry trumps the component-schema-
+               derived widget"
+       (rf/reg-view* :view.nest/labelled
+         {:rf/props [:map [:label :string]]}
+         (fn [_] [:div]))
        (story/reg-variant :story.nest/v2
-         {:schema   [:map [:label :string]]
-          :argtypes {:label {:widget :select :options ["a" "b"]}}
-          :args     {:label "a"}
-          :events   []})
+         {:component :view.nest/labelled
+          :argtypes  {:label {:widget :select :options ["a" "b"]}}
+          :args      {:label "a"}
+          :events    []})
        (let [t (controls/resolve-argtypes :story.nest/v2)]
          (is (= :select (-> t :label :widget)))
          (is (= ["a" "b"] (-> t :label :options)))))))

--- a/tools/story/test/re_frame/story/ui/controls_validation_diff_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/controls_validation_diff_cljs_test.cljc
@@ -29,6 +29,7 @@
   body is CLJS-only (`#?(:cljs ...)`). The ns suffix `-cljs-test` is
   picked up by both `cljs-test$` and `-cljs-test$` regexes."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            #?(:cljs [re-frame.core :as rf])
             #?(:cljs [re-frame.story :as story])
             #?(:cljs [re-frame.story.ui.controls :as controls])
             [re-frame.story.ui.state :as state]))
@@ -184,10 +185,16 @@
      (testing "a :group widget is collapsed by default — the disclosure
                header is present + collapsed, and the nested child rows
                are NOT in the tree (summarise-before-expand, spec/019 §4)"
+       ;; rf2-din8u / rf2-vnedo — the controls schema is the COMPILED plan's
+       ;; view-args-schema (off the :component view's :rf/props), not a bare
+       ;; variant-body :schema slot. Register the component view + point at it.
+       (rf/reg-view* :view.ba86n/grp
+         {:rf/props [:map [:meta [:map [:author :string] [:rating :int]]]]}
+         (fn [_] [:div]))
        (story/reg-variant :story.ba86n/grp
-         {:schema [:map [:meta [:map [:author :string] [:rating :int]]]]
-          :args   {:meta {:author "ada" :rating 5}}
-          :events []})
+         {:component :view.ba86n/grp
+          :args      {:meta {:author "ada" :rating 5}}
+          :events    []})
        (let [tree   (render :story.ba86n/grp)
              toggle (button-with-action tree "toggle-expand")]
          (is (some? toggle) "disclosure toggle present")
@@ -201,10 +208,13 @@
    (deftest disclosure-toggle-expands-and-reveals-children
      (testing "clicking the disclosure toggle flips the (component-local)
                expand state and a re-render reveals the nested child rows"
+       (rf/reg-view* :view.ba86n/grp2
+         {:rf/props [:map [:meta [:map [:author :string]]]]}
+         (fn [_] [:div]))
        (story/reg-variant :story.ba86n/grp2
-         {:schema [:map [:meta [:map [:author :string]]]]
-          :args   {:meta {:author "ada"}}
-          :events []})
+         {:component :view.ba86n/grp2
+          :args      {:meta {:author "ada"}}
+          :events    []})
        ;; ONE editor instance — the expand ratom lives on its closure, so
        ;; the toggle + re-render must go through the same instance.
        (let [editor (controls/args-editor :story.ba86n/grp2)
@@ -235,14 +245,17 @@
 
 #?(:cljs
    (deftest inline-error-and-banner-track-the-live-validator
-     (testing "a committed value that violates the variant's :schema
-               surfaces an inline error + a panel banner when a live
+     (testing "a committed value that violates the component view's props
+               schema surfaces an inline error + a panel banner when a live
                validator is present, and soft-passes otherwise"
+       (rf/reg-view* :view.ba86n/bad
+         {:rf/props [:map [:age :int]]}
+         (fn [_] [:div]))
        (story/reg-variant :story.ba86n/bad
-         {:schema [:map [:age :int]]
+         {:component :view.ba86n/bad
           ;; :age is a string but the schema says :int.
-          :args   {:age "not-a-number"}
-          :events []})
+          :args      {:age "not-a-number"}
+          :events    []})
        (let [tree    (render :story.ba86n/bad)
              banner  (node-with-attr tree :data-controls-validation "invalid")
              err-row (node-with-attr tree :data-controls-error)

--- a/tools/story/test/re_frame/story/view_args_test.cljc
+++ b/tools/story/test/re_frame/story/view_args_test.cljc
@@ -1,0 +1,193 @@
+(ns re-frame.story.view-args-test
+  "Production-path regression gate for the ONE shared view-args-schema
+  resolver (rf2-din8u phase-1 / rf2-p5ivc (b) / rf2-ayu6n / rf2-vnedo).
+
+  THE CI BLIND SPOT this closes. The pre-ruling tests for view-args
+  resolution all threaded an explicit `:view-lookup` / `:lookup` (the
+  host-free pure path), which masked the divergence: the consumers
+  (`controls/resolve-argtypes`, `schema-validation/resolve-component-
+  schema`) read the BARE registrar body, not the compiled plan. These
+  tests instead exercise the PRODUCTION path:
+
+    - a REGISTERED variant (written to the Story side-table);
+    - a REGISTERED `:component` view carrying its props schema under
+      `:rf/props` (written to the framework `:view` registrar);
+    - compiled via the DEFAULT side-table lookup — NO `:lookup` /
+      `:view-lookup` arg.
+
+  Proving: a registered `:rf/props`-declared variant resolves its
+  view-args schema off the compiled plan's `[:world :view-args-schema]`,
+  through the shared resolver, with the canonical `[:rf/props :schema]`
+  first-match order and NO `:spec` key (dead post-M-54).
+
+  Pure JVM + CLJS — `view-args.cljc` + `plan.cljc` + both registrars are
+  JVM-runnable, so the DEFAULT lookup works under `clojure -M:test`."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.story.view-args :as view-args]
+            [re-frame.story.registrar :as registrar]
+            [re-frame.registrar       :as framework-registrar]))
+
+;; ---- fixtures ------------------------------------------------------------
+;;
+;; Each test wipes both registrars (the Story side-table + the framework
+;; `:view` registrar) so the DEFAULT lookup sees only what the test
+;; registers. The shared resolver memoizes on the Story side-table's
+;; mutation-tick, so a `clear-all!` (which bumps the tick) also invalidates
+;; the resolver cache between tests.
+
+(defn reset-fixture [test-fn]
+  (registrar/clear-all!)
+  (framework-registrar/clear-kind! :view)
+  (test-fn))
+
+(use-fixtures :each reset-fixture)
+
+(defn- reg-view-meta!
+  "Register a `:view` slot carrying `metadata` (a props-schema map) on the
+  framework registrar — the slot the plan compiler's default view-lookup
+  reads. A `:handler-fn` stub keeps the slot well-formed; the resolver
+  only reads the schema slots."
+  [view-id metadata]
+  (framework-registrar/register! :view view-id
+                                 (assoc metadata :handler-fn (fn [_] nil))))
+
+;; ---- the key picker (rf2-ayu6n: stale :spec dropped) ---------------------
+
+(deftest view-args-schema-keys-drop-spec
+  (testing "the canonical key order is [:rf/props :schema] — :spec is gone"
+    (is (= [:rf/props :schema] view-args/view-args-schema-keys))))
+
+(deftest view-args-schema-first-match-no-composition
+  (testing ":rf/props wins outright over :schema (no composition)"
+    (is (= [:map [:a :string]]
+           (view-args/view-args-schema {:rf/props [:map [:a :string]]
+                                        :schema   [:map [:b :string]]}))))
+  (testing ":schema is the fallback location when :rf/props is absent"
+    (is (= [:map [:b :string]]
+           (view-args/view-args-schema {:schema [:map [:b :string]]}))))
+  (testing "a view carrying ONLY :spec resolves NO schema (dead post-M-54)"
+    (is (nil? (view-args/view-args-schema {:spec [:map [:c :string]]})))))
+
+;; ---- the compiled-plan resolver (PRODUCTION path, DEFAULT lookup) --------
+
+(deftest compiled-resolver-reads-rf-props-off-default-lookup
+  (testing "a REGISTERED :rf/props-declared variant resolves its schema off
+            the compiled plan via the DEFAULT side-table lookup"
+    (let [schema [:map [:label :string] [:count :int]]]
+      (reg-view-meta! :views/widget {:rf/props schema})
+      (registrar/reg-variant* :story.prod/ok
+                              {:component :views/widget
+                               :args      {:label "Hi" :count 3}
+                               :events    []})
+      ;; No :lookup / :view-lookup — the DEFAULT side-table + framework
+      ;; `:view` registrar path the production runtime takes.
+      (is (= schema (view-args/compiled-view-args-schema :story.prod/ok))))))
+
+(deftest compiled-resolver-rf-props-wins-over-schema-on-default-lookup
+  (testing ":rf/props wins over :schema on the registered view, end-to-end"
+    (reg-view-meta! :views/dual {:rf/props [:map [:a :string]]
+                                 :schema   [:map [:b :string]]})
+    (registrar/reg-variant* :story.prod/dual
+                            {:component :views/dual
+                             :args      {:a "x"}
+                             :events    []})
+    (is (= [:map [:a :string]]
+           (view-args/compiled-view-args-schema :story.prod/dual)))))
+
+(deftest compiled-resolver-schema-fallback-on-default-lookup
+  (testing "a view carrying its schema under :schema (no :rf/props) still
+            resolves — :schema is the post-M-54 fallback location"
+    (reg-view-meta! :views/schemaed {:schema [:map [:title :string]]})
+    (registrar/reg-variant* :story.prod/schemaed
+                            {:component :views/schemaed
+                             :args      {:title "T"}
+                             :events    []})
+    (is (= [:map [:title :string]]
+           (view-args/compiled-view-args-schema :story.prod/schemaed)))))
+
+(deftest compiled-resolver-spec-only-view-resolves-nil
+  (testing "a view whose ONLY schema slot is the dead :spec key resolves no
+            schema on the production path (rf2-ayu6n — :spec is dead)"
+    (reg-view-meta! :views/specced {:spec [:map [:x :string]]})
+    (registrar/reg-variant* :story.prod/specced
+                            {:component :views/specced
+                             :args      {:x "v"}
+                             :events    []})
+    (is (nil? (view-args/compiled-view-args-schema :story.prod/specced)))))
+
+(deftest compiled-resolver-resolves-extends-inherited-component
+  (testing "an :extends-INHERITED :component resolves its schema — the
+            divergence the bare-body resolvers (reading (:component
+            variant-body)) missed (rf2-din8u compiled-plan invariant)"
+    (reg-view-meta! :views/base {:rf/props [:map [:label :string]]})
+    ;; The parent declares :component; the child inherits it via :extends
+    ;; and declares no :component of its own. A bare-body read of the child
+    ;; would find no :component → no schema. The compiled plan resolves the
+    ;; parent chain, so the schema flows down.
+    (registrar/reg-variant* :story.prod/parent
+                            {:component :views/base
+                             :args      {:label "P"}
+                             :events    []})
+    (registrar/reg-variant* :story.prod/child
+                            {:extends :story.prod/parent
+                             :args    {:label "C"}
+                             :events  []})
+    (is (= [:map [:label :string]]
+           (view-args/compiled-view-args-schema :story.prod/child))
+        "the inherited :component's props schema resolves off the compiled plan")))
+
+(deftest compiled-resolver-matches-compiled-plan-slot
+  (testing "the resolver returns EXACTLY the plan's [:world :view-args-schema]
+            — one source of truth, not a re-derivation"
+    (let [schema [:map [:label :string]]]
+      (reg-view-meta! :views/same {:rf/props schema})
+      (registrar/reg-variant* :story.prod/same
+                              {:component :views/same
+                               :args      {:label "Hi"}
+                               :events    []})
+      ;; The shared resolver and the controls/schema-validation panels MUST
+      ;; agree because they read the same compiled slot.
+      (is (= schema (view-args/compiled-view-args-schema :story.prod/same))))))
+
+(deftest compiled-resolver-unregistered-variant-is-nil
+  (testing "an unregistered variant resolves nil (best-effort tooling read —
+            no throw)"
+    (is (nil? (view-args/compiled-view-args-schema :story.prod/nope)))))
+
+(deftest compiled-resolver-no-component-is-nil
+  (testing "a registered variant with no :component resolves nil"
+    (registrar/reg-variant* :story.prod/plain
+                            {:args {:x 1} :events []})
+    (is (nil? (view-args/compiled-view-args-schema :story.prod/plain)))))
+
+(deftest compiled-resolver-view-without-schema-is-nil
+  (testing "a registered :component view carrying NO schema slot resolves nil"
+    (reg-view-meta! :views/bare {})
+    (registrar/reg-variant* :story.prod/bare
+                            {:component :views/bare
+                             :args      {:x 1}
+                             :events    []})
+    (is (nil? (view-args/compiled-view-args-schema :story.prod/bare)))))
+
+;; ---- memoization invalidates on registrar mutation ----------------------
+
+(deftest compiled-resolver-memo-invalidates-on-reregistration
+  (testing "the per-(variant-id, mutation-tick) memo invalidates when the
+            view is hot-reloaded with a new props schema"
+    (reg-view-meta! :views/hot {:rf/props [:map [:a :string]]})
+    (registrar/reg-variant* :story.prod/hot
+                            {:component :views/hot
+                             :args      {:a "x"}
+                             :events    []})
+    (is (= [:map [:a :string]]
+           (view-args/compiled-view-args-schema :story.prod/hot)))
+    ;; Re-register the variant (bumps the Story side-table mutation-tick),
+    ;; pointing at a view with a different schema → the memo invalidates.
+    (reg-view-meta! :views/hot {:rf/props [:map [:a :string] [:b :int]]})
+    (registrar/reg-variant* :story.prod/hot
+                            {:component :views/hot
+                             :args      {:a "x" :b 1}
+                             :events    []})
+    (is (= [:map [:a :string] [:b :int]]
+           (view-args/compiled-view-args-schema :story.prod/hot))
+        "the resolver re-reads the compiled plan after the tick bump")))


### PR DESCRIPTION
## Summary

**rf2-din8u PHASE-1** — establishes the shared compiled-plan view-args resolver foundation and consolidates the view-args / schema / controls consumers. Ratifies the invariant: **the compiled variant-plan is the single source of truth; no Story consumer reads the bare registrar body.** Closes **rf2-ayu6n + rf2-p5ivc + rf2-vnedo** (the "one shared resolver" half). **din8u stays OPEN** (phase-2: canvas sub-overrides 45zvx/bhaqt + render-variant decorators hzhmv).

## The shared compiled-plan resolver (+ memoization)

New leaf ns **`re-frame.story.view-args`**:
- `compiled-view-args-schema` compiles the variant-plan via the **DEFAULT side-table lookup** (so an `:extends`-inherited / `:compose`-d `:component` resolves the same way the runner / render / docs paths see it) and returns the schema the compiler wrote to `[:world :view-args-schema]` — the single source of truth.
- **Memoized per `[variant-id mutation-tick]`** (mirrors the registrar's `variants-with-tags-cache`): reading the compiled plan per render is O(1) between registrar writes; any registration / hot-reload bumps the tick and invalidates.
- The canonical first-match key picker (`view-args-schema-keys` / `view-args-schema`) moves to the pure leaf `re-frame.story.malli-schema` (no plan dep → no require cycle), shared by the plan compiler (which writes the slot) and the resolver (which reads it back). `plan.cljc` re-exports it.

## Dispositions

- **rf2-ayu6n** — dropped the stale `:spec` middle key (dead post-M-54: the framework reads `:schema` only on `reg-*` metadata, no shim). The order is now `[:rf/props :schema]`. Corrected the false ":spec is the live slot" comment + spec text. The three divergent resolvers (`plan` `[:rf/props :spec :schema]`, `schema_validation` four bare slots, `controls` `:schema`-only) are unified into one.
- **rf2-p5ivc (option b, Mike-ruled)** — one resolver; `:rf/props` wins outright over `:schema`; **NO composition** (a view's only schema surface is its props). Narrowed `Spec-Schemas.md` `:rf/props` "composes with :schema" for the view-args boundary; aligned `spec/017`. Dropped the tautological `plan_test` set-membership assertion in favour of a real conflation check.
- **rf2-vnedo** — `controls/resolve-argtypes` + `schema-validation/resolve-component-schema` both route through the shared resolver, so a `:rf/props`-declared view now gets **BOTH derived controls AND validation** from one source. The PR's "one source" claim is now true.

## Note on the dispatch brief vs the ratified ruling
The dispatch brief's step 3 mentioned implementing *composes-with*. The **ratified bead ruling** (rf2-p5ivc NOTES, Mike 2026-05-30) is explicitly **option (b): first-match, NO composition, drop `:spec`**. I followed the bead ruling (it is the authoritative, dated, enumerated decision). Flagging the discrepancy for visibility.

## Production-path regression gate (the CI blind spot)
New `view_args_test` exercises the path prior tests masked by feeding raw bodies: a **REGISTERED** variant + **REGISTERED** `:component` view compiled via the **DEFAULT** lookup (no `:lookup` arg). Covers `:rf/props`-wins, `:schema` fallback, dead-`:spec`→nil, an **`:extends`-inherited `:component`** (the divergence bare-body resolvers missed), the resolver == compiled-plan-slot identity, and memo invalidation on re-registration. The CLJS controls tests are migrated off the divergent variant-body `:schema` convention onto the production `:component`-view `:rf/props` shape.

## Hot-zone flag
`spec/Spec-Schemas.md` §`:rf/props` — edited the ONE line (the composition clause) per the ruling; sole toucher; minimal. Did NOT touch `budgets.cljc` / sidebar / theme / shell / spec-018, `canvas.cljs` / render-variant (phase-2), or the mayor checkout.

## Quality gates
- **clj-kondo** `--parallel --fail-level error --lint tools/story`: **errors: 0** (123 pre-existing warnings, none from changed files).
- `tools/story` `clojure -M:test`: **0 failures, 0 errors** (1467 tests / 5122 assertions; new view_args_test: 12 tests).
- `implementation` `npm run test:cljs`: compile **0 warnings**; **0 failures, 0 errors** (4969 tests / 16300 assertions; incl. migrated controls + schema-validation CLJS tests).
- `tools/story-mcp` `clojure -M:test`: **0 failures, 0 errors** (172 tests).
- `tools/mcp-conformance` `npm run test:story`: **GREEN** (exit 0).
- `scripts/test-fast-pr.sh`: core JVM + JS harness + CLJS node green; markdown link/anchor + doc-slug validators **pass** (after fixing relative-link depth in spec/017). mkdocs `--strict` soft-skipped locally (not on PATH; CI runs it).