### PR TITLE
feat(story/status): render glyph + shape discriminators; lock the status vocab (rf2-gsqbp + rf2-lcl6n)

### DIFF
--- a/tools/story/src/re_frame/story/theme/status.cljc
+++ b/tools/story/src/re_frame/story/theme/status.cljc
@@ -33,8 +33,11 @@
     the state survives colour-blindness AND Windows High-Contrast Mode
     (where `forced-colors` strips the inline colour — see
     `theme.motion/motion-css`).
-  - `:shape` — `:solid` / `:outline` / `:dashed` / `:ring` — the chip /
-    dot border treatment, a third non-colour channel.
+  - `:shape` — `:solid` / `:outline` / `:dashed` / `:ring` / `:half` —
+    the chip / dot border treatment, a third non-colour channel. Each
+    shape renders a VISUALLY DISTINCT border (solid edge / dashed edge /
+    double ring / one-sided accent bar), so the shape discriminates even
+    when the hue is stripped (see `shape-decoration`).
   - `:label` — the canonical short human label.
 
   Plus a presentation hint:
@@ -98,14 +101,16 @@
   label) plus an `:emphasis` presentation hint. Colours resolve through
   `theme.colors/tokens` — zero raw hex (rf2-i3i5j).
 
-  Shape vocabulary:
+  Shape vocabulary (each renders a DISTINCT border — see
+  `shape-decoration`):
   - `:solid`   — filled ground, no special border (settled states).
-  - `:outline` — 1px solid border in the fg colour (states that need a
-                 second channel: cannot-run, error).
-  - `:dashed`  — 1px dashed border (redacted — reads as 'removed').
-  - `:ring`    — transparent ground + neutral 1px ring (pending — the
-                 reserved-but-empty slot).
-  - `:half`    — a partial / in-flight treatment (running)."
+  - `:outline` — 1px SOLID border in the status colour (states that need
+                 a second channel: cannot-run, error).
+  - `:dashed`  — 1px DASHED border (redacted — reads as 'removed').
+  - `:ring`    — 2px DOUBLE border (pending — the reserved-but-empty slot
+                 reads as a hollow double-ring, never a solid edge).
+  - `:half`    — 3px SOLID left-accent bar (running — a one-sided
+                 in-flight mark, visibly a partial treatment)."
   {:pending    {:fg (:text-tertiary colors/tokens)
                 :bg "transparent"
                 :border (:border-default colors/tokens)
@@ -180,28 +185,54 @@
   [status]
   (:label (descriptor status)))
 
-(defn- border-style
-  "Map a descriptor `:shape` to the CSS border the chip wears."
+(defn- shape-decoration
+  "Map a descriptor `:shape` to the inline-style FRAGMENT that gives the
+  chip its non-colour SHAPE channel (spec/018 §12.6 — distinguishable in
+  shape, not only colour). Returns a style-map fragment merged into
+  `chip-style`, or `nil` for `:solid` (the filled ground carries the
+  signal alone). Each shape renders VISUALLY DISTINCT so the five shapes
+  are genuinely five channels, not two:
+
+  - `:solid`   — no border; the filled `:bg` ground is the signal.
+  - `:outline` — a 1px SOLID border in the status colour (error /
+                 cannot-run — a crisp ring that reads 'flagged').
+  - `:dashed`  — a 1px DASHED border (redacted — reads as 'removed').
+  - `:ring`    — a 2px DOUBLE border (pending — the reserved-but-empty
+                 slot reads as a hollow double-ring, never a solid edge).
+  - `:half`    — a 3px SOLID left-accent BAR (running — a one-sided
+                 in-flight mark, visibly a partial treatment not a full
+                 border).
+
+  Distinct CSS per shape — `border` vs `border-style: double` vs a
+  one-sided `border-left` — so the shape survives a greyscale / forced-
+  colors pass where the hue collapses."
   [{:keys [shape border]}]
   (case shape
-    :outline (str "1px solid " border)
-    :dashed  (str "1px dashed " border)
-    :ring    (str "1px solid " border)
-    :half    (str "1px solid " border)
+    :outline {:border (str "1px solid " border)}
+    :dashed  {:border (str "1px dashed " border)}
+    :ring    {:border (str "2px double " border)}
+    :half    {:border-left (str "3px solid " border)}
     ;; :solid — no explicit border; the ground carries the signal.
     nil))
 
 (defn chip-style
   "Build an inline `:style` map for a status chip / pill. Composes the
-  descriptor's ground + foreground + the shape-derived border. Regions
+  descriptor's ground + foreground + the shape-derived decoration. Regions
   layer their own padding / radius / type-scale on top — this fn owns
   ONLY the status-bearing colour + shape so every region's chip reads
-  the same status the same way. Pure data → data."
+  the same status the same way. The colour channel (`:background` /
+  `:color`) plus the shape channel (`:border` / `:border-left`, see
+  `shape-decoration`) are both carried so a chip survives a colour-blind
+  / Windows-HCM pass on shape alone. Pure data → data.
+
+  Public read-shape (the canvas + sidebar consume this directly):
+  always a `:style`-mergeable map with `:background` + `:color`, plus a
+  shape decoration for every non-`:solid` status."
   [status]
   (let [d (descriptor status)]
-    (cond-> {:background (:bg d)
-             :color      (:fg d)}
-      (border-style d) (assoc :border (border-style d)))))
+    (merge {:background (:bg d)
+            :color      (:fg d)}
+           (shape-decoration d))))
 
 (defn rollup
   "Given a seq of statuses, return the single most-attention-demanding

--- a/tools/story/src/re_frame/story/ui/sidebar.cljs
+++ b/tools/story/src/re_frame/story/ui/sidebar.cljs
@@ -61,6 +61,7 @@
             [re-frame.story.registrar         :as registrar]
             [re-frame.story.theme.colors      :as colors]
             [re-frame.story.theme.glyphs      :as glyphs]
+            [re-frame.story.theme.status      :as status]
             [re-frame.story.ui.promotion      :as promotion]
             [re-frame.story.ui.sidebar-search :as search]
             [re-frame.story.ui.sidebar-signals :as signals]
@@ -336,20 +337,35 @@
   "Render one signal chip. `axis` selects the per-axis tint (status chips
   additionally key on their value for the per-status colour/shape). The
   chip carries `data-axis` + `data-value` so the test corpus + a11y users
-  can read which axis/value it represents without parsing the label."
+  can read which axis/value it represents without parsing the label.
+
+  Status chips additionally render the status descriptor's `:glyph`
+  (`✓ ✗ ! ⊘ …`) as a leading mark — the spec/018 §12.6 headline channel
+  that keeps the status distinguishable under colour-blindness AND
+  Windows High-Contrast Mode (where `forced-colors` strips the inline
+  tint). The glyph is `aria-hidden` because the text label + `data-value`
+  already carry the value to AT / the test corpus — the glyph is a
+  redundant VISUAL channel, never a second voice for screen readers."
   [{:keys [axis value label]}]
-  (let [tint (if (= :status axis)
-               (get styles (status-signal->style-key value))
-               (let [base (get styles (axis->group-style-key axis))]
-                 (if (and (= :frame-binding axis) (= :attached value))
-                   (merge base (:signal-frame-attached styles))
-                   base)))]
+  (let [status? (= :status axis)
+        tint    (if status?
+                  (get styles (status-signal->style-key value))
+                  (let [base (get styles (axis->group-style-key axis))]
+                    (if (and (= :frame-binding axis) (= :attached value))
+                      (merge base (:signal-frame-attached styles))
+                      base)))
+        glyph   (when status? (status/glyph value))]
     ^{:key (str (name axis) "-" (name value))}
     [:span {:style       (merge (:signal-chip styles) tint)
             :data-test   "story-sidebar-signal-chip"
             :data-axis   (name axis)
             :data-value  (name value)
             :title       (str (name axis) ": " label)}
+     (when glyph
+       [:span {:style       (:signal-chip-glyph styles)
+               :data-test   "story-sidebar-signal-glyph"
+               :aria-hidden "true"}
+        glyph])
      label]))
 
 (defn signal-chips

--- a/tools/story/src/re_frame/story/ui/sidebar_styles.cljs
+++ b/tools/story/src/re_frame/story/ui/sidebar_styles.cljs
@@ -315,6 +315,15 @@
                      :flex-shrink   "0"
                      :background    (:bg-3 colors/tokens)
                      :color         (:text-secondary colors/tokens)}
+   ;; rf2-ba86n.3 / rf2-gsqbp — the status GLYPH channel (spec/018 §12.6).
+   ;; Status chips lead with the descriptor's structural glyph (✓ ✗ ! …)
+   ;; so the status survives colour-blindness AND Windows HCM, where
+   ;; `forced-colors` strips the chip tint and the colour channel is gone.
+   ;; A hair of right-margin separates the mark from the text label; it
+   ;; inherits the chip's `:color` so the glyph rides the same hue as the
+   ;; status (and goes mono in forced-colors, where SHAPE + glyph carry it).
+   :signal-chip-glyph {:margin-right "3px"
+                       :font-weight  "600"}
    ;; ── status axis (spec/018 §12.6 — distinguishable in colour, icon,
    ;;    text, and shape; NOT everything red/green) ──
    ;;

--- a/tools/story/test/re_frame/story/theme/status_vocab_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/theme/status_vocab_cljs_test.cljc
@@ -1,0 +1,274 @@
+(ns re-frame.story.theme.status-vocab-cljs-test
+  "Lock-tests for the shared status colour vocabulary (rf2-lcl6n /
+  rf2-gsqbp, spec/018 §12.6). `theme.status` is the single constructed
+  source of truth — the sidebar signal chips, the test-mode result rows,
+  the evidence beats, and the play-status banner all key off these
+  tokens — and its own docstring states it is JVM-portable 'so the test
+  corpus can assert the vocabulary without a render pass.' This is that
+  corpus.
+
+  Runs on BOTH the JVM (cognitect.test-runner under `clojure -M:test`)
+  and the CLJS node-test build (shadow's `:node-test` target; the
+  `cljs-test$` ns-regexp picks up this `-cljs-test` ns). The pure
+  `theme.status` vocabulary is `.cljc` so it asserts on both platforms;
+  the two derivation locks that reach into `.cljs` files the JVM can't
+  `:require` (the sidebar style derivation + the empty-canvas render
+  hook) are gated `#?(:cljs …)`, mirroring `sidebar-chips-cljs-test`.
+
+  ## What these lock (the drift the .3 PR claimed but did not guard)
+
+  1. **Descriptor completeness** — every one of the nine canonical
+     statuses carries all FOUR discriminators (colour / glyph / shape /
+     label) §12.6 mandates, plus the `:emphasis` hint. A future edit
+     dropping a glyph or a shape is caught here.
+  2. **Distinct channels** — the nine glyphs are distinct, the shapes
+     genuinely discriminate (a `:ring` ≠ an `:outline` at the rendered
+     border), and the colours are token-resolved (zero raw hex).
+  3. **Order + rollup** — `order` lists exactly the nine statuses in the
+     documented priority; `rollup` surfaces the worst member of a mixed
+     set.
+  4. **The documented nine** — the `descriptors` key set matches the
+     nine statuses the namespace + spec/018 §12.6 document, no more, no
+     fewer.
+  5. **Single-source derivation** (CLJS) — the sidebar's
+     `:signal-status-*` style keys are EQUAL to `status/chip-style`
+     output, so a drift in one region is structurally impossible.
+  6. **Empty-canvas hook** (CLJS) — the `story-canvas-empty` render hook
+     spec/018 §12.5 promises still renders."
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.string :as str]
+            [re-frame.story.theme.status :as status]
+            #?@(:cljs [[re-frame.story.ui.sidebar :as sidebar]
+                       [re-frame.story.ui.sidebar-styles :refer [styles]]
+                       [re-frame.story.ui.shell :as shell]
+                       [re-frame.story.ui.state :as state]])))
+
+;; The nine canonical statuses spec/018 §12.6 documents (the namespace's
+;; own table). `:running` is Story's live sibling of the spec's `pending`
+;; (see `theme.status` docstring); the other eight are the spec's list.
+(def expected-statuses
+  #{:pending :running :pass :fail :error :cannot-run :blocked :dirty :redacted})
+
+;; The four discriminators §12.6 mandates ("distinguishable in colour,
+;; icon, text, and shape") + the one presentation hint.
+(def discriminator-keys #{:fg :bg :border :glyph :shape :label})
+(def required-keys (conj discriminator-keys :emphasis))
+
+(def valid-shapes #{:solid :outline :dashed :ring :half})
+(def valid-emphasis #{:high :normal :low})
+
+;; ---- 1 + 2: descriptor completeness + distinct channels -----------------
+
+(deftest descriptors-match-the-documented-nine
+  (testing "the descriptor set is EXACTLY the nine documented statuses —
+            no status quietly added or dropped (spec/018 §12.6 table)"
+    (is (= expected-statuses (set (keys status/descriptors)))))
+  (testing "`order` is exactly the nine statuses, each listed once"
+    (is (= expected-statuses (set status/order)))
+    (is (= (count status/order) (count (set status/order))))
+    (is (= 9 (count status/order)))))
+
+(deftest every-descriptor-carries-all-four-discriminators
+  (testing "each status carries colour (:fg/:bg/:border) + :glyph + :shape
+            + :label + :emphasis — the §12.6 four channels are all present,
+            so no region can fall back to colour-only"
+    (doseq [s expected-statuses]
+      (let [d (status/descriptor s)]
+        (testing (str s)
+          (is (every? #(contains? d %) required-keys)
+              (str s " is missing one of " required-keys))
+          ;; colour channel — three non-blank strings
+          (is (every? (fn [k] (and (string? (get d k))
+                                   (not (str/blank? (get d k)))))
+                      [:fg :bg :border]))
+          ;; glyph channel — a single non-blank structural character
+          (is (and (string? (:glyph d)) (not (str/blank? (:glyph d)))))
+          ;; shape channel — one of the five documented shapes
+          (is (contains? valid-shapes (:shape d)))
+          ;; text channel — a non-blank human label
+          (is (and (string? (:label d)) (not (str/blank? (:label d)))))
+          ;; presentation hint
+          (is (contains? valid-emphasis (:emphasis d))))))))
+
+(deftest channels-are-distinct
+  (testing "the nine glyphs are all distinct — the glyph channel
+            discriminates all nine, never collapses two states to one mark"
+    (let [glyphs (mapv #(:glyph (status/descriptor %)) (vec expected-statuses))]
+      (is (= 9 (count (set glyphs))) (str "duplicate glyph in " glyphs))))
+  (testing "every documented shape is actually used by some status — the
+            five-shape vocabulary is real, not aspirational"
+    (is (= valid-shapes (set (map #(:shape (status/descriptor %))
+                                  expected-statuses))))))
+
+(deftest zero-raw-hex-resolved-colours
+  (testing "every colour resolves to a non-nil string (token-derived, never
+            a dangling keyword) — rf2-i3i5j zero-raw-hex contract"
+    (doseq [s expected-statuses
+            k [:fg :bg :border]]
+      (let [v (get (status/descriptor s) k)]
+        (is (string? v) (str s " " k " did not resolve to a string"))))))
+
+;; ---- 3: the shape channel genuinely discriminates -----------------------
+
+(deftest chip-style-shape-channel-discriminates
+  (testing "chip-style ALWAYS carries the colour channel (:background +
+            :color) for every status"
+    (doseq [s expected-statuses]
+      (let [cs (status/chip-style s)]
+        (is (contains? cs :background))
+        (is (contains? cs :color)))))
+  (testing "the five shapes render VISUALLY DISTINCT decorations — the
+            shape channel is genuinely five values, not the degraded two
+            (solid-border vs dashed) the .3 PR shipped (rf2-gsqbp)"
+    ;; :solid — no border decoration; the filled ground is the signal.
+    (let [pass (status/chip-style :pass)]
+      (is (not (contains? pass :border)))
+      (is (not (contains? pass :border-left))))
+    ;; :outline — 1px SOLID border (error / cannot-run).
+    (let [err (status/chip-style :error)]
+      (is (str/starts-with? (:border err) "1px solid")))
+    ;; :dashed — 1px DASHED border (redacted).
+    (let [red (status/chip-style :redacted)]
+      (is (str/includes? (:border red) "dashed")))
+    ;; :ring — 2px DOUBLE border (pending — a hollow double-ring, NOT a
+    ;; plain solid edge: this is the channel the .3 PR collapsed).
+    (let [pend (status/chip-style :pending)]
+      (is (str/includes? (:border pend) "double")))
+    ;; :half — a one-sided left-accent BAR (running), NOT a full border.
+    (let [run (status/chip-style :running)]
+      (is (contains? run :border-left))
+      (is (not (contains? run :border)))))
+  (testing "outline / ring / half no longer collapse to the same CSS —
+            the regression rf2-gsqbp fixed stays fixed"
+    (let [outline (:border      (status/chip-style :error))
+          ring    (:border      (status/chip-style :pending))
+          half    (:border-left (status/chip-style :running))]
+      (is (not= outline ring))
+      (is (not= outline half))
+      (is (not= ring half)))))
+
+;; ---- 4: rollup surfaces the worst member --------------------------------
+
+(deftest rollup-surfaces-worst-member
+  (testing "a mixed set surfaces its most-attention-demanding member per
+            `order` (one :fail among many :pass → :fail)"
+    (is (= :fail  (status/rollup [:pass :pass :fail :pass])))
+    (is (= :error (status/rollup [:pass :fail :error :pending])))
+    (is (= :pass  (status/rollup [:pass :pass :pass]))))
+  (testing "blocked / dirty / running outrank pending + pass + redacted"
+    (is (= :blocked (status/rollup [:pass :pending :blocked :redacted])))
+    (is (= :dirty   (status/rollup [:pass :pending :dirty :redacted])))
+    (is (= :running (status/rollup [:pass :pending :running :redacted]))))
+  (testing "an empty / all-nil set degrades to :pending, never throws"
+    (is (= :pending (status/rollup [])))
+    (is (= :pending (status/rollup [nil nil])))
+    (is (= :pending (status/rollup nil)))))
+
+(deftest unknown-status-degrades-to-pending
+  (testing "an unknown / nil status paints the neutral :pending slot,
+            never blanks or throws"
+    (is (= (status/descriptor :pending) (status/descriptor :bogus)))
+    (is (= (status/descriptor :pending) (status/descriptor nil)))))
+
+;; ---- 5: single-source derivation (CLJS — sidebar style is .cljs) --------
+
+#?(:cljs
+   (deftest sidebar-signal-status-derives-from-chip-style
+     (testing "the sidebar's :signal-status-* style keys EQUAL
+               status/chip-style output — the single-source guarantee
+               (a drift in one region is structurally impossible)"
+       (doseq [[stat style-key] sidebar/status-signal->style-key]
+         (is (= (status/chip-style stat) (get styles style-key))
+             (str style-key " drifted from (status/chip-style " stat ")"))))))
+
+#?(:cljs
+   (deftest sidebar-status-style-key-covers-all-nine
+     (testing "every documented status has a sidebar style-key projection
+               — no status is unreachable from the sidebar"
+       (is (= expected-statuses (set (keys sidebar/status-signal->style-key)))))))
+
+#?(:cljs
+   (deftest sidebar-status-dots-derive-from-fg
+     (testing "the per-variant status dots tint from status/fg — the same
+               single source the chips read"
+       (is (= {:background (status/fg :pass)}    (:dot-pass styles)))
+       (is (= {:background (status/fg :fail)}    (:dot-fail styles)))
+       (is (= (status/fg :running) (:background (:dot-running styles)))))))
+
+;; ---- glyph channel rendered in the sidebar chip (rf2-gsqbp) -------------
+
+#?(:cljs
+   (defn- walk-find-data-test
+     "Collect every hiccup node whose props carry `:data-test` = `tag`."
+     [tree tag]
+     (let [hits (transient [])]
+       (letfn [(walk [node]
+                 (cond
+                   (and (vector? node) (map? (second node))
+                        (= tag (get (second node) :data-test)))
+                   (do (conj! hits node) (doseq [c (drop 2 node)] (walk c)))
+                   (vector? node) (doseq [c (rest node)] (walk c))
+                   (seq? node)    (doseq [c node] (walk c))
+                   :else nil))]
+         (walk tree))
+       (persistent! hits))))
+
+#?(:cljs
+   (deftest sidebar-status-chip-renders-the-glyph
+     (testing "the status chip in the rendered signal strip carries the
+               descriptor's :glyph — the spec/018 §12.6 headline channel
+               that survives colour-blindness + Windows HCM (rf2-gsqbp)"
+       (let [tree   (sidebar/signal-chips {} :fail)
+             glyphs (walk-find-data-test tree "story-sidebar-signal-glyph")]
+         (is (= 1 (count glyphs)) "exactly one status glyph in the strip")
+         (let [[_tag props glyph] (first glyphs)]
+           ;; the rendered mark is the descriptor's glyph for :fail
+           (is (= (status/glyph :fail) glyph))
+           ;; aria-hidden — the label + data-value already voice the value
+           ;; to AT, so the glyph is a redundant VISUAL channel only.
+           (is (= "true" (:aria-hidden props)))))))
+   )
+
+#?(:cljs
+   (deftest sidebar-status-chip-keeps-label-and-data-value
+     (testing "rendering the glyph does NOT regress the text label or the
+               data-value / title channels (AT + test corpus still read it)"
+       (let [tree  (sidebar/signal-chips {} :pass)
+             chips (walk-find-data-test tree "story-sidebar-signal-chip")
+             status-chip (first (filter #(= "status" (:data-axis (second %)))
+                                        chips))
+             props (second status-chip)]
+         (is (= "pass" (:data-value props)))
+         (is (str/includes? (:title props) "status"))
+         ;; the label text is still present as a child of the chip
+         (is (some string? (drop 2 status-chip))))))
+   )
+
+#?(:cljs
+   (deftest non-status-chips-carry-no-status-glyph
+     (testing "only the STATUS axis renders a glyph — fidelity / world /
+               runner / frame chips have no status descriptor glyph"
+       (let [tree   (sidebar/signal-chips
+                      {:args {:n 1} :network {[:get "/x"] {}}
+                       :script [[:click "#go"]] :frame-binding :attached}
+                      :pass)
+             glyphs (walk-find-data-test tree "story-sidebar-signal-glyph")]
+         ;; exactly one glyph — the single status chip — across the whole
+         ;; multi-axis strip.
+         (is (= 1 (count glyphs))))))
+   )
+
+;; ---- 6: the story-canvas-empty render hook (CLJS — shell is .cljs) ------
+
+#?(:cljs
+   (deftest story-canvas-empty-hook-renders
+     (testing "with no variant / workspace / story selected, the main pane
+               renders the spec/018 §12.5 calm empty state carrying the
+               `story-canvas-empty` hook (the hook the .3 review flagged
+               as unguarded)"
+       (state/reset-shell-state!)
+       (let [tree (#'shell/main-pane)
+             hits (walk-find-data-test tree "story-canvas-empty")]
+         (is (= 1 (count hits))
+             "the empty-canvas hook renders exactly once for the empty state"))))
+   )


### PR DESCRIPTION
Finalizes the spec/018 §12.6 status vocabulary surfaced by the ba86n.3 (#2481) visual-foundation review: the four channels §12.6 promises (colour / glyph / shape / label) are now actually rendered, and the JVM-portable lock-tests the .3 PR claimed are now present.

## rf2-gsqbp — deliver the discriminator channels

**Shape channel (`theme/status.cljc`).** The private border helper previously mapped `:outline` / `:ring` / `:half` to the identical `"1px solid <border>"`, collapsing the five-shape vocabulary to two values (solid-border vs dashed) at the rendered chip. Each shape now renders a visually DISTINCT decoration:

| shape | status(es) | rendering |
|---|---|---|
| `:solid` | pass / fail / blocked / dirty | no border (filled ground is the signal) |
| `:outline` | error / cannot-run | `1px solid` |
| `:dashed` | redacted | `1px dashed` |
| `:ring` | pending | `2px double` (hollow double-ring, never a solid edge) |
| `:half` | running | one-sided `3px solid` left-accent bar (a partial / in-flight mark) |

`:outline` / `:ring` / `:half` now resolve to three different CSS treatments, so the shape channel survives a greyscale / `forced-colors` pass where the hue is gone.

**Glyph channel (sidebar `signal-chip`).** The sidebar status chip rendered only the text label + tint, never the descriptor's `:glyph`. Status chips now lead with the `:glyph` (`✓ ✗ ! ⊘ ◌ ◐ ▣ ● ▢`) — the §12.6 headline channel that keeps status distinguishable under colour-blindness AND Windows HCM. The mark is `aria-hidden` because the text label + `data-value` + `title` already voice the value to AT / the test corpus, so the glyph is a redundant VISUAL channel only. Label / `data-value` / `title` are preserved (no regression).

Result: a sidebar status chip now carries colour + glyph + shape + label — the four §12.6 channels, actually visible.

## rf2-lcl6n — lock-tests

New JVM-portable lock-test `tools/story/test/re_frame/story/theme/status_vocab_cljs_test.cljc` (runs on both `clojure -M:test` and `npm run test:cljs`). Asserts:

- **Descriptor completeness** — every one of the nine statuses carries all four discriminators (`:fg`/`:bg`/`:border` + `:glyph` + `:shape` + `:label`) plus `:emphasis`; the nine glyphs are distinct; every documented shape is used; colours resolve token-derived (zero raw hex).
- **Order + rollup** — `order` is exactly the nine statuses each listed once; `rollup` surfaces the worst member of a mixed set; empty / all-nil → `:pending`; unknown → `:pending` (never throws).
- **Shape channel discriminates** — the five shapes render distinct CSS; `:outline` ≠ `:ring` ≠ `:half` (the regression this PR fixed stays fixed).
- **The documented nine** — the `descriptors` key set matches the nine statuses, no more / no fewer.
- **Single-source derivation** (CLJS) — sidebar `:signal-status-*` == `status/chip-style` output; dots == `status/fg`; all nine reachable.
- **Glyph rendered** (CLJS) — the status chip in the rendered strip carries the descriptor glyph (`aria-hidden`); only the status axis carries one; label / `data-value` not regressed.
- **`story-canvas-empty` hook** (CLJS) — renders for the empty shell state.

## API-stable confirmation (canvas-fold safe)

`theme/status`'s public read-API is unchanged: `chip-style` / `fg` / `bg` / `descriptor` / `glyph` / `label` / `rollup` / `order` / `descriptors` are all preserved, and `chip-style` still returns a style map with `:background` + `:color`. The only change is the private border helper (`border-style` → `shape-decoration`), which the concurrent canvas-fold cannot reach. No descriptor key renamed. canvas-fold's read of `chip-style` / `fg` is unaffected.

Spec untouched — §12.6's contract already matches the delivered reality.

## Quality gates

- `clj-kondo --parallel --fail-level error --lint tools/story` — **errors: 0** (124 pre-existing warnings; the one `Unused value` in the new file matches the accepted transient-walk idiom in `sidebar_chips_cljs_test` / `tag_badges_cljs_test`)
- `tools/story` `clojure -M:test` — **1480 tests / 5491 assertions, 0 failures, 0 errors** (new ns: 7 tests / 126 assertions on JVM)
- `npm run test:cljs` — **4990 tests / 16695 assertions, 0 failures, 0 errors**
- `npm run test:bundle-isolation` — **PASS** (17 entries, 35 sentinels absent; uix/helix reagent-free)
- `bash scripts/test-fast-pr.sh` — **PASS fast PR spine**