### PR TITLE
refactor(story): unify canvas render through compiled-plan resolvers (rf2-ba86n.8 + din8u phase-2: 45zvx/bhaqt + hzhmv)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -476,6 +476,16 @@ inline plan. By default it prepares `:world` for rendering and renders
 the active view. It MUST NOT execute `:script` or terminal `:expect`
 unless a future option explicitly asks for a test run.
 
+When a host renders the active view, it MUST apply the variant's
+view-wrapping `:hiccup` decorators (the compiled plan's
+`[:world :decorators]`, threaded onto the render inputs) — the SAME
+decorate-and-render seam the live canvas uses
+(`re-frame.story.ui.multi-substrate/render-decorated-view`, which resolves
+the refs and wraps via `safe-decorated-view`). A host that paints the bare
+view would diverge from the live canvas for any decorated variant
+(theme / provider / chrome dropped). With no host installed (the bare JVM),
+`render-variant` returns `:cannot-run` — never a silent empty render.
+
 ### View arg schemas
 
 A registered view MAY expose a schema for its explicit args/props through
@@ -633,6 +643,18 @@ type it.
 | `[:world :fidelity]` | the resolved fidelity-ladder set (present when non-empty) |
 | `[:explain :sub-overrides]` | `{:overrides … :validation {:status :ok :violations []}}` — overrides are visible in explain |
 | `[:explain :fidelity]` | the same fidelity set, surfaced for docs / review |
+
+**Single-source resolution.** Both the live canvas and `render-variant`
+resolve the override map from the COMPILED variant-plan — the canvas
+re-substitutes the plan's composed `[:render-raw :sub-overrides]` against
+the post-control effective args through the same resolver
+(`re-frame.story.render/resolve-render-sub-overrides`) `render-variant`
+uses; neither re-reads the bare registrar body. This is what makes the two
+agree on overrides contributed by a `:compose`d fragment or an `:extends`
+parent (the plan compiler is the single merge authority — §305-306, the
+same rule decorators follow). A consumer reading `(:sub-overrides body)`
+straight off the side-table would see only the variant's OWN slot and drop
+the composed / inherited overrides.
 
 **Render-path read + the honesty rule.** Overrides feed the RENDER PATH
 only. The render-path resolver (`re-frame.story.sub-overrides`) binds the

--- a/tools/story/src/re_frame/story/canonical.cljc
+++ b/tools/story/src/re_frame/story/canonical.cljc
@@ -57,22 +57,33 @@
 #?(:cljs
    (defn- render-host-scope
      "A Reagent component that renders the active `:view` under the host
-     substrate, binding the resolved `:sub-overrides` for the render extent
-     (the same pattern the canvas's `sub-overrides-scope` uses); the
-     binding never touches app-db / `compute-sub`.
+     substrate — wrapped in the variant's `:hiccup` decorators — binding the
+     resolved `:sub-overrides` for the render extent (the same pattern the
+     canvas's `sub-overrides-scope` uses); the binding never touches app-db /
+     `compute-sub`.
 
-     NOTE (rf2-7pgiz): this binding is currently INERT — a design
-     variant's pinned sub values do NOT yet surface to a normally-authored
-     view. No subscribe seam consults `*overrides*`, and the dynamic
-     binding established here does not survive into the view's deferred
-     React render (the view's `@(rf/subscribe)` runs in its own reaction,
-     after this binding has unwound). Surfacing the override at render
-     needs a core subscribe shim — pinned + surfaced under rf2-7pgiz. See
-     `re-frame.story.sub-overrides` ns docstring §STATUS."
-     [{:keys [view frame effective-args sub-overrides]}]
+     Per rf2-hzhmv / rf2-ba86n.8 the host paints through the SHARED
+     `ui-multi-substrate/render-decorated-view` seam the canvas single-pane
+     path uses, threading the compiled plan's `[:world :decorators]` refs
+     (`render-inputs`' `:decorators`, the single-merge-authority output —
+     rf2-g74i9 / spec/017 §305-306). Before this consolidation the host
+     rendered the BARE view, so a decorated variant diverged from the canvas
+     (theme/provider/chrome dropped); now `render-variant` and the live shell
+     paint the SAME decorated tree.
+
+     NOTE (rf2-7pgiz): the `:sub-overrides` binding is currently INERT — a
+     design variant's pinned sub values do NOT yet surface to a
+     normally-authored view. No subscribe seam consults `*overrides*`, and
+     the dynamic binding established here does not survive into the view's
+     deferred React render (the view's `@(rf/subscribe)` runs in its own
+     reaction, after this binding has unwound). Surfacing the override at
+     render needs a core subscribe shim — pinned + surfaced under rf2-7pgiz.
+     See `re-frame.story.sub-overrides` ns docstring §STATUS."
+     [{:keys [view frame effective-args sub-overrides decorators]}]
      (sub-overrides/with-overrides* sub-overrides
        (fn []
-         (ui-multi-substrate/render-view :reagent frame view effective-args)))))
+         (ui-multi-substrate/render-decorated-view
+           :reagent frame view effective-args decorators)))))
 
 #?(:cljs
    (defn- install-render-host!
@@ -80,11 +91,13 @@
      render-prep core (`re-frame.story.render/prepare-render`) is host-free
      + JVM-testable; the actual painting of the active view is this CLJS
      hook. It renders the active `:view` under the host substrate's render
-     fn (`re-frame.story.ui.multi-substrate`), wrapped in the
+     fn, wrapped in the variant's `:hiccup` decorators via the SHARED
+     `re-frame.story.ui.multi-substrate/render-decorated-view` seam the
+     canvas single-pane path also uses (rf2-hzhmv / rf2-ba86n.8), inside the
      `render-host-scope` component so the resolved `:sub-overrides` bind at
      React render time (spec/017 §View-state subscription overrides). The
-     result is a hiccup tree (the Reagent default) — the SAME render the
-     canvas paints, so render-variant and the live shell agree.
+     result is a hiccup tree (the Reagent default) — the SAME decorated
+     render the canvas paints, so render-variant and the live shell agree.
 
      The bare JVM installs NO render host, so `render-variant` returns
      `:cannot-run` there rather than a silent empty render."

--- a/tools/story/src/re_frame/story/ui/canvas.cljs
+++ b/tools/story/src/re_frame/story/ui/canvas.cljs
@@ -26,6 +26,7 @@
             [re-frame.story.args :as args]
             [re-frame.story.decorators :as decorators]
             [re-frame.story.plan :as plan]
+            [re-frame.story.render :as render]
             [re-frame.story.runtime :as runtime]
             [re-frame.story.sub-overrides :as sub-overrides]
             [re-frame.story.ui.assertion-strip :as assertion-strip]
@@ -310,16 +311,27 @@
 ;; `re-frame.story.sub-overrides` ns docstring §STATUS.
 
 (defn- resolve-sub-overrides
-  "Return the variant's resolved `:sub-overrides` map (exact query
-  vectors → values, `[:arg key]` placeholders substituted against
-  `eff-args`), or nil when the variant authors none. Pure-ish: reuses the
-  plan compiler's `substitute-args` so the render-path resolution matches
-  the plan-path resolution exactly."
+  "Return the variant's resolved `:sub-overrides` map (exact query vectors →
+  values, `[:arg key]` placeholders substituted against `eff-args`), or nil
+  when the variant authors none.
+
+  Routes through the COMPILED variant-plan (`plan/variant-plan`) and the
+  SHARED `render/resolve-render-sub-overrides` resolver — the SAME source
+  `render-variant` reads — NOT the bare registrar body (rf2-45zvx /
+  rf2-bhaqt, rf2-din8u invariant). Reading `(:sub-overrides body)` off the
+  side-table saw ONLY the variant's OWN slot, dropping overrides contributed
+  by a `:compose`d fragment or an `:extends` parent (the plan compiler
+  COMPOSES them into `[:render-raw :sub-overrides]` — plan.cljc §sub-overrides
+  composition). The canvas and `render-variant` therefore diverged for
+  composed / extended overrides; routing both through the compiled plan
+  removes the divergence (single source of truth).
+
+  `eff-args` is the post-control effective args; `resolve-render-sub-overrides`
+  re-substitutes the RAW (pre-`[:arg]`) overrides against them so a
+  control-driven override value reflects the live control, exactly as on the
+  render-variant path."
   [variant-id eff-args]
-  (let [body (registrar/handler-meta :variant variant-id)
-        ovr  (:sub-overrides body)]
-    (when (seq ovr)
-      (plan/substitute-args ovr (or eff-args {}) (atom [])))))
+  (render/resolve-render-sub-overrides (plan/variant-plan variant-id) eff-args))
 
 (defn sub-overrides-scope
   "A Reagent component that binds the variant's resolved `:sub-overrides`
@@ -345,43 +357,19 @@
 
 ;; ---- decorated-view wrapper ---------------------------------------------
 
-(defn safe-decorated-view
-  "Wrap `view-hiccup` with the variant's `:hiccup`-kind decorators,
-  catching any exception thrown by a `:wrap` fn so the canvas never
-  bubbles into a render-tree crash that blanks the shell.
+(def safe-decorated-view
+  "Wrap `view-hiccup` with the variant's `:hiccup`-kind decorators, catching
+  any exception a `:wrap` fn throws so the canvas never bubbles into a
+  render-tree crash that blanks the shell (IMPL-SPEC §2.2 + §5.5 — failures
+  render inline; the rf2-zme7 'never blank the canvas' rule).
 
-  Per IMPL-SPEC §2.2 + §5.5 the canvas's contract is 'failures render
-  inline rather than aborting'. The Stage 4 path collected
-  `resolve-decorators` errors only — runtime throws from inside a
-  user-supplied `:wrap` fn used to propagate up Reagent's render
-  machinery and React unmounted the whole shell (rf2-zme7). This wrapper
-  closes that loop: a thrown exception becomes a hiccup error block
-  alongside the variant frame.
-
-  Returns either the decorator-applied hiccup tree, or, on throw, a
-  hiccup error block that names the offending decorator stack."
-  [view-hiccup hiccup-decorators effective-args]
-  (try
-    (decorators/apply-hiccup-decorators
-      hiccup-decorators
-      view-hiccup
-      effective-args)
-    (catch :default e
-      [:div {:style (:error styles)}
-       [:div "Decorator wrap threw — variant rendered without decorators."]
-       [:div {:style {:margin-top "4px"}}
-        (str (.-message e))]
-       (when-let [ids (seq (keep :id hiccup-decorators))]
-         [:div {:style {:margin-top "4px" :color (:danger colors/tokens)}}
-          (str "decorators in stack: "
-               (str/join ", " (map pr-str ids)))])
-       ;; Render the variant body itself uncoated so the user still sees
-       ;; *something* — the page never blanks on a decorator failure.
-       [:div {:style {:margin-top "8px"
-                      :padding "8px"
-                      :background (:bg-canvas colors/tokens)
-                      :border "1px dashed #555"}}
-        view-hiccup]])))
+  rf2-hzhmv / rf2-ba86n.8 — the decorate-and-render primitive is the SHARED
+  seam in `re-frame.story.ui.multi-substrate`, called by BOTH the canvas
+  single-pane path (below), the workspace cell, AND the `render-variant`
+  host hook (`re-frame.story.canonical/render-host-scope`), so the live
+  canvas and render-variant paint the identical decorated tree. Re-exported
+  here so the canvas / workspace call sites keep one import."
+  multi-substrate/safe-decorated-view)
 
 ;; ---- error projection ---------------------------------------------------
 

--- a/tools/story/src/re_frame/story/ui/multi_substrate.cljs
+++ b/tools/story/src/re_frame/story/ui/multi_substrate.cljs
@@ -33,6 +33,7 @@
             [reagent.core :as r]
             [re-frame.core :as rf]
             [re-frame.story.args :as args]
+            [re-frame.story.decorators :as decorators]
             [re-frame.story.registrar :as registrar]
             [re-frame.story.ui.state :as state]
             [re-frame.story.theme.typography :as typography :refer [mono-stack]]
@@ -156,6 +157,78 @@
     (render-fn variant-id view-id eff-args)
     [:div {:style {:color (:text-secondary colors/tokens) :font-style "italic"}}
      (str "substrate :" (name substrate) " is not registered")]))
+
+;; ---- shared decorate-and-render seam (rf2-hzhmv / rf2-ba86n.8) -----------
+;;
+;; The canvas single-pane path AND the `render-variant` host hook
+;; (`re-frame.story.canonical/render-host-scope`) paint the SAME variant
+;; through the SAME decorate-and-render seam, so a decorated variant looks
+;; identical on the live canvas and through `render-variant`. Before this
+;; consolidation only the canvas applied the variant's `:hiccup` decorators
+;; — the host hook rendered the BARE view (rf2-hzhmv), diverging from the
+;; canvas for any decorated variant. The decorator REFS both consume are the
+;; compiled plan's already-merged `[:world :decorators]` (the single merge
+;; authority, rf2-g74i9 / spec/017 §305-306), so the registered + inline
+;; paths agree too.
+
+(def ^:private decorator-error-styles
+  {:wrap   {:background (:danger-bg colors/tokens)
+            :border "1px solid #be4040"
+            :color (:danger colors/tokens)
+            :padding "8px"
+            :margin-top "8px"
+            :font-family mono-stack
+            :font-size (:caption typography/type-scale)
+            :border-radius "3px"}
+   :uncoated {:margin-top "8px"
+              :padding "8px"
+              :background (:bg-canvas colors/tokens)
+              :border "1px dashed #555"}})
+
+(defn safe-decorated-view
+  "Wrap `view-hiccup` with the `:hiccup`-kind `hiccup-decorators`, catching
+  any exception a `:wrap` fn throws so a decorator failure renders an inline
+  error block (with the bare view beneath it) rather than bubbling into a
+  render-tree crash that blanks the shell (IMPL-SPEC §2.2 / §5.5 — failures
+  render inline rather than aborting). `effective-args` is the resolved args
+  map every `:wrap` fn receives as `[body effective-args]`.
+
+  The ONE decorate primitive both the canvas single-pane path and the
+  `render-variant` host hook call, so the two agree on the decorated tree
+  (rf2-hzhmv / rf2-ba86n.8)."
+  [view-hiccup hiccup-decorators effective-args]
+  (try
+    (decorators/apply-hiccup-decorators hiccup-decorators view-hiccup effective-args)
+    (catch :default e
+      [:div {:style (:wrap decorator-error-styles)}
+       [:div "Decorator wrap threw — variant rendered without decorators."]
+       [:div {:style {:margin-top "4px"}} (str (.-message e))]
+       (when-let [ids (seq (keep :id hiccup-decorators))]
+         [:div {:style {:margin-top "4px" :color (:danger colors/tokens)}}
+          (str "decorators in stack: " (str/join ", " (map pr-str ids)))])
+       ;; Render the variant body itself uncoated so the user still sees
+       ;; *something* — the page never blanks on a decorator failure.
+       [:div {:style (:uncoated decorator-error-styles)} view-hiccup]])))
+
+(defn render-decorated-view
+  "Render `view-id` under `substrate` with `eff-args` (via `render-view`),
+  then wrap the result with the variant's `:hiccup` decorators resolved from
+  `decorator-refs` (the compiled plan's `[:world :decorators]`). This is the
+  single decorate-and-render seam (rf2-hzhmv / rf2-ba86n.8): the
+  `render-variant` host hook calls it so a render-variant render of a
+  decorated variant paints the SAME tree the live canvas paints.
+
+  `decorator-refs` is a vector of `[decorator-id & args]` refs (raw refs, as
+  the plan carries them); only the `:hiccup`-kind decorators wrap the view —
+  `:frame-setup` / `:fx-override` decorators are frame concerns applied at
+  allocate time, not view-wrapping. A nil/empty `decorator-refs` is
+  render-transparent (the bare view)."
+  [substrate variant-id view-id eff-args decorator-refs]
+  (let [view-hiccup (render-view substrate variant-id view-id eff-args)]
+    (if (seq decorator-refs)
+      (let [hiccup-decorators (:hiccup (decorators/resolve-decorator-refs decorator-refs))]
+        (safe-decorated-view view-hiccup hiccup-decorators eff-args))
+      view-hiccup)))
 
 ;; ---- failure-tolerant cell render ---------------------------------------
 

--- a/tools/story/test/re_frame/story/canvas_plan_resolution_test.cljc
+++ b/tools/story/test/re_frame/story/canvas_plan_resolution_test.cljc
@@ -1,0 +1,227 @@
+(ns re-frame.story.canvas-plan-resolution-test
+  "Production-path regression gate for the rf2-din8u phase-2 consolidation:
+  the canvas + `render-variant` resolve sub-overrides AND decorators off the
+  ONE compiled variant-plan, not the bare registrar body (rf2-45zvx /
+  rf2-bhaqt / rf2-hzhmv / rf2-ba86n.8).
+
+  ## The CI blind spot this closes
+
+  Per the rf2-din8u ruling, EVERY fix must add a regression test exercising
+  the PRODUCTION path — a REGISTERED variant compiled via the DEFAULT
+  side-table lookup (NO `:lookup` arg). The pre-ruling tests fed RAW bodies
+  through explicit `:lookup` maps, which masked the divergence: the canvas
+  `resolve-sub-overrides` read `(:sub-overrides (registrar/handler-meta
+  :variant id))` straight off the side-table, seeing ONLY the variant's OWN
+  slot — dropping overrides contributed by a `:compose`d fragment or an
+  `:extends` parent (which the plan compiler COMPOSES into
+  `[:render-raw :sub-overrides]`). render-variant read the composed source;
+  the live canvas read the bare body; they disagreed.
+
+  These tests instead register variants / fragments on the side-table and
+  compile via the DEFAULT lookup — the path the live runtime takes — and
+  prove:
+
+    1. composed-fragment + `:extends`-chain `:sub-overrides` resolve through
+       the canvas's resolver (the SAME `render/resolve-render-sub-overrides`
+       over `plan/variant-plan` render-variant uses) — rf2-45zvx / rf2-bhaqt;
+    2. the canvas decorator resolution and render-variant's render-inputs
+       resolve the SAME `[:world :decorators]` (composed + inherited) —
+       rf2-hzhmv (resolution agreement) / rf2-ba86n.8;
+    3. `render-variant` honestly returns `:cannot-run` with no host (the
+       single render path's cannot-render state) — rf2-ba86n.8.
+
+  Pure JVM + CLJS: `plan.cljc` + `render.cljc` + `decorators.cljc` + the
+  registrar are all JVM-runnable, so the DEFAULT lookup works under both
+  `clojure -M:test` and `npm run test:cljs`."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.story.decorators :as decorators]
+            [re-frame.story.late-bind  :as late-bind]
+            [re-frame.story.plan       :as plan]
+            [re-frame.story.registrar  :as registrar]
+            [re-frame.story.render     :as render]
+            [re-frame.registrar        :as framework-registrar]))
+
+;; ---- fixtures ------------------------------------------------------------
+;;
+;; Wipe the Story side-table + framework registrars so the DEFAULT lookup
+;; sees only what each test registers. `clear-all!` bumps the mutation-tick
+;; (invalidating any plan-level memo between tests).
+;;
+;; The `:render-host` hook is a process-global late-bind slot. On CLJS the
+;; canonical auto-install (fired by every `reg-*`) wires it, so the no-host
+;; `:cannot-run` assertion must DROP `:render-host` AFTER its registrations
+;; (see `render-variant-cannot-run-with-no-host`). We MUST NOT
+;; `late-bind/clear!` (that wipes the canonical shims every sibling test ns
+;; relies on). The fixture snapshots + restores the whole hooks map so any
+;; per-test dissoc is surgical and reverts cleanly (mirrors `render-test`).
+
+(defn reset-fixture [test-fn]
+  (registrar/clear-all!)
+  (framework-registrar/clear-kind! :sub)
+  ;; `:sub-overrides` validation soft-passes when a sub carries no output
+  ;; schema (the host-free floor), so an unregistered :sub is fine here.
+  (let [snapshot @late-bind/hooks]
+    (try (test-fn) (finally (reset! late-bind/hooks snapshot)))))
+
+(use-fixtures :each reset-fixture)
+
+;; The canvas's resolution (post rf2-45zvx): route through the COMPILED plan
+;; via the shared render-variant resolver — NOT the bare registrar body.
+;; This mirrors `re-frame.story.ui.canvas/resolve-sub-overrides` exactly
+;; (canvas is CLJS-only, so the production logic it now calls is asserted
+;; here at the CLJC seam both paths share).
+(defn- canvas-sub-overrides
+  [variant-id eff-args]
+  (render/resolve-render-sub-overrides (plan/variant-plan variant-id) eff-args))
+
+;; ===========================================================================
+;; rf2-45zvx / rf2-bhaqt — composed-fragment + :extends-chain :sub-overrides
+;; ===========================================================================
+
+(deftest composed-fragment-sub-overrides-resolve-on-canvas-path
+  (testing "a REGISTERED variant whose :sub-overrides come (partly) from a
+            :compose'd fragment resolves the fragment's overrides through the
+            canvas resolver — the bare-body read dropped them (rf2-45zvx /
+            rf2-bhaqt)"
+    (registrar/reg-fragment* :fragment.login/errored
+                             {:sub-overrides {[:login/state] :error}})
+    (registrar/reg-variant* :story.login/from-fragment
+                            {:compose       [:fragment.login/errored]
+                             :sub-overrides {[:login/attempts] 3}
+                             :events        []})
+    (let [resolved (canvas-sub-overrides :story.login/from-fragment {})]
+      (testing "the variant's OWN override resolves"
+        (is (= 3 (get resolved [:login/attempts]))))
+      (testing "the COMPOSED fragment's override ALSO resolves — the bare-body
+                read (`(:sub-overrides body)`) would have dropped it"
+        (is (= :error (get resolved [:login/state]))))
+      (testing "the canvas resolver agrees with the plan's composed slot"
+        (is (= (get-in (plan/variant-plan :story.login/from-fragment)
+                       [:world :render :sub-overrides])
+               resolved))))))
+
+(deftest extends-chain-sub-overrides-resolve-on-canvas-path
+  (testing "a child variant that :extends a parent with :sub-overrides and
+            declares its OWN inherits the merged map through the canvas
+            resolver (rf2-45zvx — the :extends chain)"
+    (registrar/reg-variant* :story.ext.subovr/parent
+                            {:sub-overrides {[:login/state] :error}
+                             :events        []})
+    (registrar/reg-variant* :story.ext.subovr/child
+                            {:extends       :story.ext.subovr/parent
+                             :sub-overrides {[:login/attempts] 5}
+                             :events        []})
+    (let [resolved (canvas-sub-overrides :story.ext.subovr/child {})]
+      (testing "the child's OWN override resolves"
+        (is (= 5 (get resolved [:login/attempts]))))
+      (testing "the parent-chain override is INHERITED (rf2-din8u: the plan
+                compiler is the single :extends merge authority)"
+        (is (= :error (get resolved [:login/state])))))))
+
+(deftest sub-override-arg-placeholder-reflects-control-on-canvas-path
+  (testing "an override VALUE driven by [:arg key] re-resolves against the
+            post-control effective args on the canvas path — the SAME
+            re-substitution render-variant does. The canvas passes the
+            variant's resolved effective args (incl. defaults), so the
+            placeholder always has a value to substitute."
+    (registrar/reg-variant* :story.login/argdriven
+                            {:args          {:message "default"}
+                             :sub-overrides {[:login/error] [:arg :message]}
+                             :events        []})
+    (let [plan-eff (get-in (plan/variant-plan :story.login/argdriven)
+                           [:world :effective-args])]
+      (testing "the plan-time arg resolves against the variant's effective args"
+        (is (= "default"
+               (get (canvas-sub-overrides :story.login/argdriven plan-eff)
+                    [:login/error]))))
+      (testing "a control override re-substitutes the live value"
+        (is (= "live!"
+               (get (canvas-sub-overrides :story.login/argdriven
+                                          (assoc plan-eff :message "live!"))
+                    [:login/error])))))))
+
+(deftest variant-with-no-sub-overrides-resolves-nil
+  (testing "a registered variant authoring NO :sub-overrides resolves nil
+            (render-transparent — no wrapper)"
+    (registrar/reg-variant* :story.plain/v {:events []})
+    (is (nil? (canvas-sub-overrides :story.plain/v {})))))
+
+;; ===========================================================================
+;; rf2-hzhmv / rf2-ba86n.8 — canvas + render-variant resolve the SAME
+;; decorators off the compiled [:world :decorators]
+;; ===========================================================================
+
+(deftest canvas-and-render-variant-agree-on-decorators
+  (testing "the canvas decorator resolution and render-variant's
+            render-inputs resolve the SAME composed + inherited
+            [:world :decorators] — single source of truth (rf2-hzhmv /
+            rf2-ba86n.8)"
+    (registrar/reg-decorator* :deco/theme-dark
+                              {:kind :hiccup :wrap (fn [body _] [:div.dark body])})
+    (registrar/reg-decorator* :deco/centered
+                              {:kind :hiccup :wrap (fn [body _] [:div.centered body])})
+    ;; Parent declares a decorator; child inherits via :extends and ADDS none
+    ;; of its own — so the child's decorator stack comes ENTIRELY from the
+    ;; parent chain (the case a bare-body read would resolve EMPTY).
+    (registrar/reg-variant* :story.deco/parent
+                            {:component  :views/widget
+                             :decorators [[:deco/theme-dark]]
+                             :events     []})
+    (registrar/reg-variant* :story.deco/child
+                            {:extends :story.deco/parent
+                             :events  []})
+    (let [;; render-variant's render-inputs carry the RAW refs off the plan.
+          prepared       (render/prepare-render :story.deco/child)
+          rv-refs        (get-in prepared [:render-inputs :decorators])
+          ;; the canvas resolves the same refs into its :hiccup pack.
+          canvas-pack    (decorators/resolve-decorators :story.deco/child)
+          canvas-ids     (mapv :id (:hiccup canvas-pack))]
+      (testing "render-variant's render-inputs carry the inherited decorator
+                refs off the compiled plan"
+        (is (= [[:deco/theme-dark]] rv-refs)))
+      (testing "the canvas resolves the SAME inherited decorator (NOT empty —
+                the bare-body read dropped the :extends-inherited stack)"
+        (is (= [:deco/theme-dark] canvas-ids)))
+      (testing "both paths agree: render-variant's refs resolve to the canvas
+                pack's :hiccup ids"
+        (is (= canvas-ids
+               (mapv :id (:hiccup (decorators/resolve-decorator-refs rv-refs)))))))))
+
+(deftest render-variant-applies-decorators-through-shared-seam
+  (testing "render-variant's host renders the SAME decorator refs the canvas
+            applies — proven by resolving the render-inputs' refs and applying
+            them the way the shared seam does (rf2-hzhmv)"
+    (registrar/reg-decorator* :deco/wrap-a
+                              {:kind :hiccup :wrap (fn [body _] [:div.a body])})
+    (registrar/reg-variant* :story.deco/applied
+                            {:component  :views/widget
+                             :decorators [[:deco/wrap-a]]
+                             :events     []})
+    (let [prepared (render/prepare-render :story.deco/applied)
+          refs     (get-in prepared [:render-inputs :decorators])
+          hiccup-d (:hiccup (decorators/resolve-decorator-refs refs))
+          ;; The shared `safe-decorated-view` seam applies the :hiccup
+          ;; decorators outermost-first; render-variant's host calls exactly
+          ;; this (via multi-substrate/render-decorated-view).
+          wrapped  (decorators/apply-hiccup-decorators hiccup-d [:span "leaf"] {})]
+      (testing "the decorator wraps the rendered tree (NOT bare — the
+                pre-fix host dropped :decorators entirely)"
+        (is (= [:div.a [:span "leaf"]] wrapped))))))
+
+;; ===========================================================================
+;; rf2-ba86n.8 — the single render path's cannot-render honesty
+;; ===========================================================================
+
+(deftest render-variant-cannot-run-with-no-host
+  (testing "with no render host installed, render-variant returns :cannot-run
+            for a registered variant — never a silent empty render
+            (the single render path's honest cannot-render state)"
+    (registrar/reg-variant* :story.norender/v
+                            {:component :views/widget :events []})
+    ;; Drop the render host AFTER registration — on CLJS the `reg-variant*`
+    ;; auto-install wires it; the fixture restores it after this test.
+    (swap! late-bind/hooks dissoc :render-host)
+    (let [r (render/render-variant :story.norender/v)]
+      (is (= :cannot-run (:status r)))
+      (is (= :no-render-host (:reason r)))
+      (is (= :story.norender/v (:frame r))))))

--- a/tools/story/test/re_frame/story/ui/render_shell_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/render_shell_cljs_test.cljs
@@ -36,7 +36,6 @@
     cell. Pin the shape so the user sees a loading-affordance-style
     inline message rather than a blank cell."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [clojure.string :as str]
             [re-frame.core             :as rf]
             [re-frame.frame            :as frame]
             [re-frame.machines         :as machines]
@@ -45,6 +44,8 @@
             [re-frame.story            :as story]
             [re-frame.story.assertions :as assertions]
             [re-frame.story.loaders    :as loaders]
+            [re-frame.story.plan       :as plan]
+            [re-frame.story.render     :as render]
             [re-frame.story.runtime    :as runtime]
             [re-frame.story.ui.canvas  :as canvas]
             [re-frame.story.ui.multi-substrate :as multi-substrate]
@@ -298,3 +299,101 @@
         ;; outer wrap renders.
         (is (= :div (first hiccup))
             "grid outer wrap rendered")))))
+
+;; ===========================================================================
+;; rf2-hzhmv / rf2-ba86n.8 — render-variant host APPLIES decorators
+;;
+;; The host-application gap rf2-hzhmv flagged: the render-variant host hook
+;; (`canonical/render-host-scope`) used to render the BARE view, dropping the
+;; variant's :decorators — so a render-variant render of a decorated variant
+;; diverged from the live canvas (which wraps via safe-decorated-view). The
+;; consolidation routes BOTH through the shared
+;; `multi-substrate/render-decorated-view` seam, so they paint the same tree.
+;; These CLJS tests prove the HOST actually applies the decorators — the
+;; existing render_test §decorators-are-view-wrapping only pinned that
+;; :decorators RIDE render-inputs, never that the host APPLIES them. Uses a
+;; REGISTERED variant via the DEFAULT lookup (the production path the
+;; rf2-din8u gate mandates).
+;; ===========================================================================
+
+(deftest render-decorated-view-wraps-via-shared-seam
+  (testing "the shared render-decorated-view seam (the host hook + the canvas
+            both call it) wraps the rendered view in the variant's :hiccup
+            decorators resolved from the compiled plan's [:world :decorators]"
+    (story/reg-decorator :deco/themed
+      {:kind :hiccup :wrap (fn [body _] [:div.themed body])})
+    (rf/reg-sub :probe/label (fn [db _] (:label db)))
+    (rf/reg-view* :views/probe (fn [_] [:span.leaf "leaf"]))
+    (story/reg-variant :story.hostdeco/v
+      {:component  :views/probe
+       :decorators [[:deco/themed]]
+       :events     []})
+    (let [plan        (plan/variant-plan :story.hostdeco/v)
+          deco-refs   (get-in plan [:world :decorators])
+          rendered    (multi-substrate/render-decorated-view
+                        :reagent :story.hostdeco/v :views/probe {} deco-refs)
+          ;; the OUTERMOST node must be the decorator wrap, not the bare view.
+          outer       (first rendered)]
+      (is (= [[:deco/themed]] deco-refs)
+          "the compiled plan carries the decorator refs at [:world :decorators]")
+      (is (= :div.themed outer)
+          "render-decorated-view wraps the view in the :hiccup decorator —
+           the host no longer paints the bare view (rf2-hzhmv)"))))
+
+(deftest render-decorated-view-bare-when-no-decorators
+  (testing "a variant with NO :decorators renders bare through the shared
+            seam — render-transparent (no spurious wrapper)"
+    (rf/reg-view* :views/plain (fn [_] [:span.leaf "leaf"]))
+    (story/reg-variant :story.hostnodeco/v
+      {:component :views/plain :events []})
+    (let [plan      (plan/variant-plan :story.hostnodeco/v)
+          deco-refs (get-in plan [:world :decorators])
+          rendered  (multi-substrate/render-decorated-view
+                      :reagent :story.hostnodeco/v :views/plain {} deco-refs)]
+      (is (nil? deco-refs) "no decorators on the plan")
+      ;; render-view returns the bare [view eff-args] vector for :reagent.
+      (is (not= :div.themed (first rendered))
+          "no decorator wrapper engaged — the bare view passes through"))))
+
+(deftest render-variant-and-canvas-resolve-same-inherited-decorators
+  (testing "render-variant's render-inputs and the canvas decorator pack
+            resolve the SAME :extends-inherited decorator off the compiled
+            plan — the registered (DEFAULT-lookup) production path
+            (rf2-hzhmv / rf2-ba86n.8 / rf2-g74i9)"
+    (story/reg-decorator :deco/parent-themed
+      {:kind :hiccup :wrap (fn [body _] [:div.parent-themed body])})
+    (story/reg-variant :story.inhdeco/parent
+      {:component  :views/probe
+       :decorators [[:deco/parent-themed]]
+       :events     []})
+    ;; child inherits the parent's decorator via :extends, declares none.
+    (story/reg-variant :story.inhdeco/child
+      {:extends :story.inhdeco/parent
+       :events  []})
+    (let [prepared    (render/prepare-render :story.inhdeco/child)
+          rv-refs     (get-in prepared [:render-inputs :decorators])
+          canvas-ids  (mapv :id (:hiccup (story/resolve-decorators :story.inhdeco/child)))]
+      (is (= [[:deco/parent-themed]] rv-refs)
+          "render-variant carries the INHERITED decorator refs (NOT empty —
+           the bare-body read would have dropped the :extends-inherited stack)")
+      (is (= [:deco/parent-themed] canvas-ids)
+          "the canvas resolves the SAME inherited decorator — both off the
+           compiled plan's [:world :decorators]"))))
+
+(deftest render-variant-renders-decorated-variant-end-to-end
+  (testing "render-variant returns :rendered for a registered decorated
+            variant (the host is installed by the canonical vocabulary), so
+            the single render path paints — not :cannot-run"
+    (story/reg-decorator :deco/e2e
+      {:kind :hiccup :wrap (fn [body _] [:div.e2e body])})
+    (rf/reg-view* :views/e2e (fn [_] [:span "v"]))
+    (story/reg-variant :story.e2edeco/v
+      {:component  :views/e2e
+       :decorators [[:deco/e2e]]
+       :events     []})
+    (let [r (render/render-variant :story.e2edeco/v)]
+      (is (= :rendered (:status r))
+          "the host is installed (CLJS canonical vocabulary) → :rendered")
+      (is (some? (:rendered r))
+          "the host returns a render result (the render-host-scope component
+           vector) — the single render path paints the decorated tree"))))


### PR DESCRIPTION
## din8u phase-2 — the compiled variant-plan is the single source of truth

Folds **rf2-ba86n.8** (unify canvas rendering through render-variant) + din8u PHASE-2 = **rf2-45zvx + rf2-bhaqt** (canvas sub-override resolution) + **rf2-hzhmv** (render-variant decorators). All share `canvas.cljs` + the render-variant host + the compiled-plan resolvers, so they ship as one worker per the dispatch.

The ruling (din8u, RATIFIED a): canvas render + sub-override resolution + render-variant read the compiled plan through SHARED resolvers, NEVER the bare registrar body. din8u phase-1 built the shared view-args resolver + `[:world :decorators]` resolution (rf2-g74i9) + memoization; this extends that pattern to sub-overrides and to the render-variant host.

## The unified render path

One decorate-and-render seam lives in `re-frame.story.ui.multi-substrate`:
- `safe-decorated-view` — the failure-tolerant `:hiccup`-decorator wrapper (was duplicated in `canvas.cljs`; now the single implementation, re-exported from `canvas` so the canvas + workspace call sites keep one import).
- `render-decorated-view` — render the view under a substrate, then wrap with the variant's `:hiccup` decorators resolved from the compiled plan's `[:world :decorators]`.

Both the canvas single-pane path and the `render-variant` host hook (`canonical/render-host-scope`) now paint through this seam, so a decorated variant looks identical on the live canvas and through `render-variant`. Cannot-render states stay explicit (`:cannot-run` when no host is installed).

## The sub-override-from-compiled-plan fix (rf2-45zvx / rf2-bhaqt)

`canvas/resolve-sub-overrides` previously read `(:sub-overrides (registrar/handler-meta :variant id))` straight off the side-table — seeing ONLY the variant's OWN slot and dropping overrides contributed by a `:compose`d fragment or an `:extends` parent (the plan compiler COMPOSES them into `[:render-raw :sub-overrides]`). It now routes through the COMPILED plan via `render/resolve-render-sub-overrides` — the SAME resolver `render-variant` uses — re-substituting the raw overrides against the post-control effective args. The canvas and render-variant no longer diverge on composed / extended overrides. rf2-bhaqt is rf2-45zvx's symptom (closes with it).

## The decorators-from-plan fix (rf2-hzhmv)

The render-variant host hook destructured `{:keys [view frame effective-args sub-overrides]}` — `:decorators` was threaded onto `:render-inputs` by `prepare-render` but NEVER applied, so a render-variant render of a decorated variant painted the BARE view (theme/provider/chrome dropped). The host now destructures `:decorators` and renders through `render-decorated-view`, resolving the refs (rf2-g74i9 already routes `[:world :decorators]` through the compiled plan for the registered path) and wrapping via the shared `safe-decorated-view`.

## Production-path regression tests (the din8u CI-blind-spot gate)

Every fix adds a regression test on the PRODUCTION path — a **registered** variant compiled via the **DEFAULT** lookup (no `:lookup` arg), the path existing tests masked by feeding raw bodies through explicit lookup maps:

- `tools/story/test/re_frame/story/canvas_plan_resolution_test.cljc` (JVM + CLJS): composed-fragment + `:extends`-chain `:sub-overrides` resolve through the canvas resolver; `[:arg]` placeholder re-substitution reflects control overrides; canvas + render-variant resolve the SAME inherited decorators; render-variant honestly returns `:cannot-run` with no host.
- `tools/story/test/re_frame/story/ui/render_shell_cljs_test.cljs` additions (CLJS host path): the shared `render-decorated-view` seam wraps the rendered view in the variant's `:hiccup` decorator; bare when none; render-variant + canvas resolve the same `:extends`-inherited decorator; `render-variant` returns `:rendered` end-to-end for a registered decorated variant.

Spec 017 updated: documents the single-source sub-override resolution (canvas + render-variant both read the compiled plan) and the host's mandatory decorator application via the shared seam.

## Quality gates

- **clj-kondo --parallel --fail-level error --lint tools/story** — **0 errors** (the one `render is required but never used` warning in `canonical.cljc` is a pre-existing clj-kondo false positive for the `#?(:cljs …)` usage of `render/install-render-host!`).
- `tools/story` `clojure -M:test` — 1480 tests, 0 failures, 0 errors.
- `npm run test:cljs` — 1109 compiled, **0 warnings**; 4980 tests, 0 failures, 0 errors.
- `npm run test:bundle-isolation` — PASS (17 artefact entries, 35 sentinels absent; uix/helix reagent-free PASS).
- `tools/story-mcp` `clojure -M:test` — 172 tests, 0 failures, 0 errors.
- `tools/mcp-conformance` `npm run test:story` — STORY-MCP MCP-CLIENT CONFORMANCE GREEN.
- `bash scripts/test-fast-pr.sh` — PASS fast PR spine.