### PR TITLE
feat(story/ui): wire variants-grid + flat-controls cap-and-page safeguards (rf2-ba86n.18)

### DIFF
--- a/tools/story/spec/018-Story-UI-North-Star.md
+++ b/tools/story/spec/018-Story-UI-North-Star.md
@@ -553,6 +553,21 @@ it bites in
 [`019-Story-UI-Controls-And-View-States.md`](019-Story-UI-Controls-And-View-States.md)
 §4.)
 
+The cap-and-page mitigations are WIRED into the render paths (rf2-ba86n.18):
+the sidebar bounds variant + captured-artifact rows (N1/N2); the
+variants-grid renderer bounds visible cells at the G1 cap, surfaces the
+G2/G3 matrix-size advisory, and never renders past the G3 hard cap (it
+pages instead, so a generated matrix can never freeze the canvas); the
+controls panel bounds flat-panel rows at the C2 cap and renders nested
+controls as summaries until expanded (C1/C4). Each bound is the SAME
+`re-frame.story.budgets/bound-cells` cap-and-page primitive (F1), and each
+expander is additive — revealing more never reorders the rows/cells already
+on screen, so scroll/focus survives the re-render (stable React keys:
+variant-id-keyed cells, arg-key-keyed rows, monotonic repeater row ids).
+Lazy Xray-diff mounting (compute expensive diffs only when the panel is
+expanded) is the remaining named upgrade; the embed already mounts ONE
+panel at a time, so the flood risk is already bounded.
+
 ### 10.1 Parity budgets
 
 Story pressure: S1, S7, S11.
@@ -578,11 +593,11 @@ cap as real pain, virtualization is the named upgrade.
 | N3 | Realistic project floor (must stay scannable) | **2 000 variants / 200 stories / 50 workspaces** | TARGET | gate: floor fixture, derivation stays bounded + single-pass |
 | N4 | Sidebar — filtered-tree rebuild per search keystroke | **≤ 8 ms** (documented target); gate asserts single bounded pass, no O(n²) | TARGET | gate: structural (single bounded pass); latency is a documented target |
 | C1/C4 | Controls — nested controls render depth | **lazy past depth 1** (summarise before expand) | CURRENT | spec/019 §4; `summarize-value` / `path-expanded?` |
-| C2 | Controls — flat-panel control rows before `+N more` | **60** | TARGET | gate: `controls-flat-row-cap` (`bound-cells`-style bounding) |
+| C2 | Controls — flat-panel control rows before `+N more` | **60** | CURRENT | gate: `controls-flat-row-cap`; render-wired in `ui/controls` `args-editor` (rf2-ba86n.18) |
 | C3 | Controls — inline-validation of one edited field | **≤ 4 ms** (documented target) | TARGET | documented target; structural validate is single-field, bounded |
-| G1 | Variants-grid — visible cells before page / `+N more` | **100** | TARGET | gate: bounded output (`bound-cells` / `grid-visible-cell-cap`) |
-| G2 | Variants-grid — matrix dimension product (soft warn) | **warn at ≥ 12×12 = 144** | TARGET | gate: `matrix-warn?` |
-| G3 | Variants-grid — matrix dimension product (hard cap) | **render ≤ 400; paginate beyond** | TARGET | gate: `matrix-over-hard-cap?` / `matrix-page-count` |
+| G1 | Variants-grid — visible cells before page / `+N more` | **100** | CURRENT | gate: bounded output (`bound-cells` / `grid-visible-cell-cap`); render-wired in `ui/workspace` capped-grid renderer (rf2-ba86n.18) |
+| G2 | Variants-grid — matrix dimension product (soft warn) | **warn at ≥ 12×12 = 144** | CURRENT | gate: `matrix-warn?`; render-wired advisory (rf2-ba86n.18) |
+| G3 | Variants-grid — matrix dimension product (hard cap) | **render ≤ 400; paginate beyond** | CURRENT | gate: `matrix-over-hard-cap?` / `matrix-page-count`; render-wired — grid never renders past the hard cap (rf2-ba86n.18) |
 | X1 | Failure → first useful evidence | **≤ 1 gesture; inline excerpt ≤ 2 beats** | CURRENT/TARGET | gate: excerpt-beat cap; one-gesture reach is a review-checklist bar |
 | X2 | Evidence-spine first paint (typical run, ≤ ~200 beats) | **≤ 100 ms** (documented target) | TARGET | documented target (React-bound; review-checklist / manual) |
 | X3 | Bundle size | **NO NEW BUDGET** — reference `npm run test:perf-bundle` + bundle-isolation | CURRENT | existing gate (reference, not duplicated) |

--- a/tools/story/src/re_frame/story/ui/controls.cljs
+++ b/tools/story/src/re_frame/story/ui/controls.cljs
@@ -66,6 +66,7 @@
     (§6 acceptance criterion)."
   (:require [clojure.string                    :as str]
             [reagent.core                      :as r]
+            [re-frame.story.budgets            :as budgets]
             [re-frame.story.registrar          :as registrar]
             [re-frame.story.args               :as args]
             [re-frame.story.decorators         :as decorators]
@@ -503,6 +504,32 @@
     [:span {:style (:empty styles)}
      (str "unsupported widget " widget)]))
 
+;; ---- flat-panel row cap (rf2-ba86n.18 / C2) -----------------------------
+;;
+;; A controls panel whose top-level arg count exceeds
+;; `budgets/controls-flat-row-cap` (60) renders the first `cap` rows and a
+;; `+N more` expander rather than flooding the panel (spec/018 §10). The
+;; reveal flag rides the SAME component-local `:expanded` ratom that drives
+;; the nested summarise-before-expand state, under a reserved sentinel so it
+;; never collides with a real nested-control path. Pure helpers stay
+;; JVM-/data-testable.
+
+(def flat-expanded-sentinel
+  "Reserved key the flat-panel-cap reveal flag occupies in the controls
+  editor's `:expanded` ratom set. A namespaced keyword (not a vector path)
+  so it can never collide with a nested-control path (paths are vectors of
+  arg-keys / indices). Public so the gate can assert the bounding contract."
+  ::flat-expanded)
+
+(defn bound-arg-rows
+  "Pure data → data: bound the sorted top-level arg entries `entries` (a seq
+  of `[k v]` pairs) to at most `budgets/controls-flat-row-cap` rows unless
+  `expanded?`. Returns `{:shown [...] :hidden <n>}` via the shared
+  `budgets/bound-cells` so the controls panel uses the SAME cap-and-page
+  idiom (F1) as the sidebar and the variants-grid. JVM-testable."
+  [entries expanded?]
+  (budgets/bound-cells entries budgets/controls-flat-row-cap (boolean expanded?)))
+
 ;; ---- summarise-before-expand (rf2-ba86n.5) ------------------------------
 ;;
 ;; Nested controls render a one-line summary with a disclosure toggle and
@@ -834,6 +861,18 @@
   - keeps args a control surface, not a fidelity rung — every value
     here is an explicit view input.
 
+  FLAT-PANEL CAP (rf2-ba86n.18 / C2): a panel whose top-level arg count
+  exceeds `budgets/controls-flat-row-cap` (60) renders the first `cap` rows
+  and a `+N more` expander rather than flooding the panel (spec/018 §10 —
+  cap or page; fail by summarizing, not flooding). The reveal flag is the
+  SAME component-local ephemeral `expanded` ratom that drives the nested
+  summarise-before-expand state, keyed under the reserved
+  `::flat-expanded` sentinel so it never collides with a real nested-control
+  path and is never written to `:cell-overrides` / shell-state (controls
+  must not become hidden panel state, spec/019 §6). The validation banner
+  still counts ALL violations (capped or not — the honest 'N args block
+  proof' signal is never paged away).
+
   HOT PATH (rf2-wb4y3): every keystroke in a control row writes through
   `:cell-overrides`, the shell-state ratom re-renders this component,
   which re-runs the whole derivation. We resolve args ONCE here and
@@ -872,13 +911,34 @@
          (validation-banner (count viols))
          (if (empty? eff-args)
            [:div {:style (:empty styles)} "no args resolved"]
-           (for [[k v] (sort-by key eff-args)]
-             ^{:key k}
-             (args-row variant-id k v (get argtypes k {:widget :text})
-                       {:violation   (get viols-by-key k)
-                        :changed?    (arg-changed? eff-args saved-args k)
-                        :overridden? (contains? overrides k)
-                        :opts        opts})))
+           ;; rf2-ba86n.18 / C2 — flat-panel row cap. Bound the sorted
+           ;; top-level rows at `controls-flat-row-cap` (60) with a
+           ;; `+N more` expander rather than flooding the panel. The reveal
+           ;; flag rides the component-local `expanded` ratom under the
+           ;; reserved `flat-expanded-sentinel` so it stays ephemeral UI
+           ;; state (never `:cell-overrides` / shell-state, spec/019 §6).
+           (let [flat-open? (contains? @expanded flat-expanded-sentinel)
+                 {:keys [shown hidden]} (bound-arg-rows (sort-by key eff-args)
+                                                        flat-open?)]
+             [:div
+              (for [[k v] shown]
+                ^{:key k}
+                (args-row variant-id k v (get argtypes k {:widget :text})
+                          {:violation   (get viols-by-key k)
+                           :changed?    (arg-changed? eff-args saved-args k)
+                           :overridden? (contains? overrides k)
+                           :opts        opts}))
+              (when (pos? hidden)
+                [:button {:style       (:more styles)
+                          :type        "button"
+                          :data-controls-more "true"
+                          :data-controls-hidden (str hidden)
+                          :aria-label  (str "Show " hidden
+                                            " more control rows")
+                          :on-click    (fn [_]
+                                         (swap! expanded conj
+                                                flat-expanded-sentinel))}
+                 (str "+" hidden " more…")])]))
          (when (seq overrides)
            [:button {:style    (:button styles)
                      :data-controls-action "reset-all"

--- a/tools/story/src/re_frame/story/ui/controls_styles.cljs
+++ b/tools/story/src/re_frame/story/ui/controls_styles.cljs
@@ -155,4 +155,19 @@
    :summary     {:color (:text-tertiary colors/tokens)
                  :font-style "italic"
                  :margin-left "4px"
-                 :font-size (:micro typography/type-scale)}})
+                 :font-size (:micro typography/type-scale)}
+   ;; rf2-ba86n.18 — flat-panel row cap (C2, budgets/controls-flat-row-cap).
+   ;; A controls panel whose top-level arg count exceeds the cap renders the
+   ;; first `cap` rows and a "+N more" expander rather than flooding the
+   ;; panel (spec/018 §10 — cap or page; fail by summarizing, not flooding).
+   ;; Mirrors the sidebar's `:variant-more` affordance language.
+   :more        {:padding "4px 0 2px"
+                 :color (:text-tertiary colors/tokens)
+                 :font-family mono-stack
+                 :font-size (:micro typography/type-scale)
+                 :font-style "italic"
+                 :background "none"
+                 :border "none"
+                 :cursor "pointer"
+                 :user-select "none"
+                 :text-align "left"}})

--- a/tools/story/src/re_frame/story/ui/workspace.cljc
+++ b/tools/story/src/re_frame/story/ui/workspace.cljc
@@ -71,6 +71,7 @@
   Per IMPL-SPEC §2.8.4 the `:variants-grid` layout is the v1 devcards-
   style multi-variant pane."
   (:require [re-frame.story.registrar :as registrar]
+            [re-frame.story.budgets :as budgets]
             #?@(:cljs [[reagent.core :as r]
                        [re-frame.core :as rf]
                        [re-frame.story.args :as args]
@@ -150,6 +151,51 @@
     ;; unknown — degrade to empty
     []))
 
+;; ---- pure: variants-grid cap-and-page (rf2-ba86n.18 / G1–G3) ------------
+;;
+;; A `:variants-grid` / `:grid` enumerates one cell per variant of the
+;; anchor story. At matrix / design-system scale that can be hundreds of
+;; cells — rendering them all freezes the canvas (spec/018 §10 — never
+;; freeze or flood). The grid uses the SAME cap-and-page idiom (F1) as the
+;; sidebar and the controls panel, wiring the shared `budgets/bound-cells`
+;; helper + the matrix dimension guard. Pure data → data so the budget gate
+;; exercises the bounding contract at floor scale without a DOM.
+
+(defn bound-grid-cells
+  "Pure data → data: bound a grid's `cells` vector for render.
+  Returns `{:shown [...] :hidden <n> :warn? <bool> :over-hard-cap? <bool>
+  :total <n>}`.
+
+  - `:shown` is the first `budgets/grid-visible-cell-cap` (100) cells (G1)
+    unless `expanded?`, in which case it is the full set UP TO
+    `budgets/matrix-hard-cap` (400). Beyond the hard cap the grid NEVER
+    renders all cells (G3 — paginate, never freeze): expansion still tops
+    out at the hard cap and `:over-hard-cap?` flags that the tail is paged.
+  - `:hidden` is the count paged out of `:shown`.
+  - `:warn?` is true when the total reaches `budgets/matrix-warn-threshold`
+    (144) — the soft advisory the renderer surfaces (G2).
+  - `:over-hard-cap?` is true when the total exceeds the hard cap (G3).
+
+  Routes through `budgets/bound-cells` (the shared cap-and-page primitive)
+  so the grid and the budget gate move with one number. JVM-testable."
+  [cells expanded?]
+  (let [cells (vec cells)
+        total (count cells)
+        over? (budgets/matrix-over-hard-cap? [total])
+        ;; G3 — even when the user expands, never render past the hard cap.
+        ;; The visible budget is the per-page cap (100); expansion lifts it
+        ;; to the hard cap (400) but no further. Over the hard cap we force
+        ;; the bound (`expanded?` must NOT short-circuit `bound-cells` to
+        ;; the full set — that is the freeze G3 forbids).
+        cap   (if expanded? budgets/matrix-hard-cap budgets/grid-visible-cell-cap)
+        {:keys [shown hidden]} (budgets/bound-cells cells cap
+                                                    (and expanded? (not over?)))]
+    {:shown          shown
+     :hidden         hidden
+     :total          total
+     :warn?          (budgets/matrix-warn? [total])
+     :over-hard-cap? over?}))
+
 ;; ---- styling -------------------------------------------------------------
 
 #?(:cljs
@@ -187,7 +233,31 @@
       :empty         {:color (:text-tertiary colors/tokens)
                       :font-style "italic"
                       :padding "24px"
-                      :text-align "center"}}))
+                      :text-align "center"}
+      ;; rf2-ba86n.18 / G1 — the "+N more" cap-and-page expander a grid
+      ;; renders when its cell count exceeds the visible cap. Mirrors the
+      ;; sidebar's `:variant-more` affordance language (spec/018 §10).
+      :grid-more     {:padding "8px 0 2px"
+                      :color (:text-tertiary colors/tokens)
+                      :font-family mono-stack
+                      :font-size (:caption typography/type-scale)
+                      :font-style "italic"
+                      :background "none"
+                      :border "none"
+                      :cursor "pointer"
+                      :user-select "none"
+                      :text-align "left"}
+      ;; rf2-ba86n.18 / G2 — the soft matrix-size advisory shown above a
+      ;; dense grid (≥ 144 cells). Advisory only; the grid still renders its
+      ;; capped page below. The G3 hard-cap note reuses this style.
+      :grid-warn     {:padding "6px 8px"
+                      :margin-bottom "8px"
+                      :color (:warning colors/tokens)
+                      :background (:bg-2 colors/tokens)
+                      :border-left (str "3px solid " (:warning colors/tokens))
+                      :border-radius "3px"
+                      :font-family mono-stack
+                      :font-size (:caption typography/type-scale)}}))
 
 ;; ---- the Reagent renderer ------------------------------------------------
 
@@ -605,6 +675,82 @@
                 "custom render: " (pr-str (:render active-cell))]
                nil))]]))))
 
+;; ---- capped grid renderer (rf2-ba86n.18 / G1–G3) ------------------------
+;;
+;; The `:grid` / `:variants-grid` (isolated) layouts enumerate one cell per
+;; variant. At matrix / design-system scale that is a flood risk
+;; (spec/018 §10 — never freeze the canvas). This renderer wires the shared
+;; cap-and-page bounding (`bound-grid-cells`): the first 100 cells render
+;; (G1), a `+N more` expander reveals the rest up to the 400 hard cap (G3 —
+;; never render all past the hard cap), and a soft advisory surfaces past
+;; 144 cells (G2). The expand flag is a per-mount `r/atom` — ephemeral
+;; component-local UI state, never shell-state. The workspace root remounts
+;; on workspace swap (workspace-id-keyed `<section>`) so the atom's lifetime
+;; matches one workspace selection, mirroring `tabs-renderer` /
+;; `shared-grid-renderer`.
+
+#?(:cljs
+   (defn- grid-cell-hiccup
+     "Render one resolved cell to keyed hiccup (variant / prose / custom).
+     Shared by the capped grid renderer so the cell dispatch lives in one
+     place."
+     [i cell]
+     (case (:type cell)
+       :variant
+       ^{:key (cell-key i cell)}
+       [variant-cell (:variant-id cell)]
+       :prose
+       ^{:key (cell-key i cell)}
+       [prose-block (:body cell)]
+       :custom
+       ^{:key (cell-key i cell)}
+       [:div {:style (:cell styles)}
+        "custom render: " (pr-str (:render cell))]
+       nil)))
+
+#?(:cljs
+   (defn- capped-grid-renderer
+     "Reagent component for the `:grid` / isolated `:variants-grid` layout
+     with cap-and-page bounding (G1–G3). Renders the bounded cell page, the
+     matrix-size advisory (G2/G3), and a `+N more` expander (G1).
+
+     Cells render in a CSS grid; the expander + advisory sit outside it so
+     they read as page chrome, not cells. Per spec/018 §10 the grid fails by
+     summarizing + offering expansion, never by flooding the canvas."
+     [cells]
+     (r/with-let [expanded? (r/atom false)]
+       (let [{:keys [shown hidden total warn? over-hard-cap?]}
+             (bound-grid-cells cells @expanded?)]
+         [:div {:data-test-grid-total (str total)}
+          ;; G2/G3 — soft matrix-size advisory above the grid. Advisory
+          ;; only: the capped page still renders below.
+          (when warn?
+            [:div {:style (:grid-warn styles)
+                   :role  "status"
+                   :data-test-grid-warn (str total)
+                   :data-test-grid-over-hard-cap (str (boolean over-hard-cap?))}
+             (if over-hard-cap?
+               (str "⚠ " total " cells exceed the " budgets/matrix-hard-cap
+                    "-cell hard cap — the grid is paged and will never render "
+                    "all cells. Narrow the story's variants or filter.")
+               (str "⚠ dense matrix: " total " cells (≥ "
+                    budgets/matrix-warn-threshold
+                    "). Consider narrowing the variants axis."))])
+          [:div {:style (:grid styles)}
+           (for [[i cell] (map-indexed vector shown)]
+             (grid-cell-hiccup i cell))]
+          ;; G1 — the cap-and-page expander. Reveals the elided cells up to
+          ;; the hard cap (G3); over the hard cap the tail stays paged.
+          (when (pos? hidden)
+            [:button {:style       (:grid-more styles)
+                      :type        "button"
+                      :data-test   "story-workspace-grid-more"
+                      :data-test-grid-hidden (str hidden)
+                      :aria-label  (str "Show " hidden " more grid cells")
+                      :on-click    (fn [_] (reset! expanded? true))}
+             (str "+" hidden " more"
+                  (if over-hard-cap? " (paged)" "") "…")])]))))
+
 #?(:cljs
    (defn workspace-view
      "Render a workspace. Resolves the cells and dispatches per layout.
@@ -676,18 +822,12 @@
                    ^{:key (cell-key i cell)}
                    [variant-cell (:variant-id cell)]))]
 
+              ;; rf2-ba86n.18 / G1–G3: `:grid` and isolated
+              ;; `:variants-grid` enumerate one cell per variant — a flood
+              ;; risk at matrix scale. The capped renderer bounds visible
+              ;; cells (G1), warns past the matrix thresholds (G2/G3), and
+              ;; offers a `+N more` expander rather than freezing the canvas
+              ;; (spec/018 §10). Cells stay variant-id-keyed inside it, so
+              ;; the rf2-kgn0c frame-allocation invariant is preserved.
               :else
-              [:div {:style (:grid styles)}
-               (for [[i cell] (map-indexed vector cells)]
-                 (case (:type cell)
-                   :variant
-                   ^{:key (cell-key i cell)}
-                   [variant-cell (:variant-id cell)]
-                   :prose
-                   ^{:key (cell-key i cell)}
-                   [prose-block (:body cell)]
-                   :custom
-                   ^{:key (cell-key i cell)}
-                   [:div {:style (:cell styles)}
-                    "custom render: " (pr-str (:render cell))]
-                   nil))])])))))
+              [capped-grid-renderer cells])])))))

--- a/tools/story/test/re_frame/story/budgets_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/budgets_cljs_test.cljc
@@ -40,7 +40,9 @@
             [re-frame.story.budgets :as budgets]
             [re-frame.story.ui.state.filters :as filters]
             [re-frame.story.ui.sidebar-search :as search]
+            [re-frame.story.ui.workspace :as workspace]
             #?@(:cljs [[re-frame.story.ui.sidebar :as sidebar]
+                       [re-frame.story.ui.controls :as controls]
                        [re-frame.story.ui.docs :as docs]])))
 
 ;; ---------------------------------------------------------------------------
@@ -200,6 +202,90 @@
     (is (= 24 (budgets/matrix-product [2 3 4])))))
 
 ;; ---------------------------------------------------------------------------
+;; rf2-ba86n.18 — the WIRED render-path bounding (perf fixtures)
+;;
+;; The tests above assert the pure budget primitives. These exercise the
+;; helpers the RENDER PATHS actually call (`workspace/bound-grid-cells`,
+;; `controls/bound-arg-rows`) against floor-scale fixtures — the proof that
+;; the variants-grid and controls panel emit bounded output at the 2 000-
+;; variant floor without rendering all cells / rows (spec/018 §10).
+;; ---------------------------------------------------------------------------
+
+(deftest variants-grid-render-path-is-bounded
+  (testing "the grid renderer's `bound-grid-cells` caps visible cells at the
+            G1 cell cap, however large the enumerated grid (floor scale)"
+    (let [cells (vec (range floor))
+          {:keys [shown hidden total warn? over-hard-cap?]}
+          (workspace/bound-grid-cells cells false)]
+      (is (= floor total) "the helper reports the true total")
+      (is (= budgets/grid-visible-cell-cap (count shown))
+          "visible cells are capped at the G1 visible cell cap")
+      (is (= (- floor budgets/grid-visible-cell-cap) hidden)
+          "the remainder is paged (reachable), not dropped")
+      (is warn? "a floor-scale grid trips the G2 dense-matrix advisory")
+      (is over-hard-cap? "a floor-scale grid trips the G3 hard-cap flag")))
+  (testing "G3 — even EXPANDED, a grid past the hard cap never renders all
+            cells: expansion tops out at the hard cap, the tail stays paged
+            (never freeze the canvas)"
+    (let [cells (vec (range floor))
+          {:keys [shown hidden over-hard-cap?]}
+          (workspace/bound-grid-cells cells true)]
+      (is (= budgets/matrix-hard-cap (count shown))
+          "expanded render is bounded by the hard cap, not the full set")
+      (is (= (- floor budgets/matrix-hard-cap) hidden)
+          "the over-hard-cap tail is still paged after expansion")
+      (is over-hard-cap?)))
+  (testing "a grid AT/UNDER the visible cap is never bounded and never warns"
+    (let [cells (vec (range budgets/grid-visible-cell-cap))
+          {:keys [shown hidden warn? over-hard-cap?]}
+          (workspace/bound-grid-cells cells false)]
+      (is (= budgets/grid-visible-cell-cap (count shown)))
+      (is (zero? hidden))
+      (is (not warn?) "100 cells is under the 144 warn threshold")
+      (is (not over-hard-cap?))))
+  (testing "a mid-size grid (≤ hard cap) EXPANDS fully — one page-all gesture
+            reveals every cell when that is safe (≤ 400)"
+    (let [cells (vec (range 300))
+          {:keys [shown hidden warn? over-hard-cap?]}
+          (workspace/bound-grid-cells cells true)]
+      (is (= 300 (count shown)) "≤ hard cap: expansion reveals the full grid")
+      (is (zero? hidden))
+      (is warn? "300 cells is past the 144 warn threshold")
+      (is (not over-hard-cap?) "300 cells is under the 400 hard cap"))))
+
+;; ---------------------------------------------------------------------------
+;; C2 — controls flat-panel row cap render path (CLJS-only — controls.cljs)
+;; ---------------------------------------------------------------------------
+
+#?(:cljs
+   (deftest controls-flat-panel-render-path-is-bounded
+     (testing "the controls editor's `bound-arg-rows` caps visible rows at the
+               C2 flat-row cap, however many args a variant declares"
+       (let [entries (mapv (fn [i] [(keyword (str "arg" i)) i]) (range floor))
+             {:keys [shown hidden]} (controls/bound-arg-rows entries false)]
+         (is (= budgets/controls-flat-row-cap (count shown))
+             "visible rows are capped at the C2 flat-row cap")
+         (is (= (- floor budgets/controls-flat-row-cap) hidden)
+             "the remainder is paged behind +N more, not dropped")
+         (is (= floor (+ (count shown) hidden))
+             "shown + hidden = total — nothing lost")))
+     (testing "a panel AT/UNDER the cap is never bounded"
+       (let [entries (mapv (fn [i] [(keyword (str "arg" i)) i])
+                           (range budgets/controls-flat-row-cap))
+             {:keys [hidden]} (controls/bound-arg-rows entries false)]
+         (is (zero? hidden))))
+     (testing "expanded? reveals every row (one explicit page-all gesture)"
+       (let [entries (mapv (fn [i] [(keyword (str "arg" i)) i]) (range 150))
+             {:keys [shown hidden]} (controls/bound-arg-rows entries true)]
+         (is (= 150 (count shown)))
+         (is (zero? hidden))))
+     (testing "the flat-expanded sentinel is a keyword (never a vector path),
+               so it can never collide with a nested-control path in the
+               shared `:expanded` ratom set"
+       (is (keyword? controls/flat-expanded-sentinel))
+       (is (not (vector? controls/flat-expanded-sentinel))))))
+
+;; ---------------------------------------------------------------------------
 ;; Ratified numbers — the budget table matches the ratification verbatim
 ;; ---------------------------------------------------------------------------
 
@@ -242,4 +328,11 @@
              {:keys [shown hidden]} (sidebar/bound-variants
                                       vs budgets/sidebar-variant-cap false)]
          (is (= budgets/sidebar-variant-cap (count shown)))
-         (is (= (- floor budgets/sidebar-variant-cap) hidden))))))
+         (is (= (- floor budgets/sidebar-variant-cap) hidden))))
+     (testing "rf2-ba86n.18 — the controls flat-panel cap render path reads
+               the C2 budget single-source (no parallel copy)"
+       (let [entries (mapv (fn [i] [(keyword (str "a" i)) i])
+                           (range (inc budgets/controls-flat-row-cap)))
+             {:keys [shown]} (controls/bound-arg-rows entries false)]
+         (is (= budgets/controls-flat-row-cap (count shown))
+             "bound-arg-rows caps at budgets/controls-flat-row-cap")))))

--- a/tools/story/test/re_frame/story_ui_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_ui_cljs_test.cljs
@@ -369,6 +369,12 @@
        (remove nil?)
        set))
 
+;; rf2-ba86n.18 — `find-tabs-renderer-call` (defined with the tabs helpers
+;; below) ALSO extracts the capped-grid renderer's `[fn cells]` call; the
+;; grid-key tests just below it use it, so forward-declare to avoid an
+;; undeclared-var warning (the helper body lives with its siblings).
+(declare find-tabs-renderer-call)
+
 (deftest workspace-grid-cells-key-on-variant-id-rf2-kgn0c
   (testing ":grid layout cells use variant-id-derived React keys so
             React mounts fresh cells when a workspace swap changes the
@@ -383,10 +389,16 @@
     (story/reg-workspace :Workspace.rf2-kgn0c.b/grid
       {:layout   :grid
        :variants [:story.rf2-kgn0c.b/p :story.rf2-kgn0c.b/q]})
-    (let [keys-a (collect-cell-keys
-                   (workspace/workspace-view :Workspace.rf2-kgn0c.a/grid))
-          keys-b (collect-cell-keys
-                   (workspace/workspace-view :Workspace.rf2-kgn0c.b/grid))]
+    ;; rf2-ba86n.18 — the `:grid` branch now mounts the capped-grid
+    ;; renderer (`[capped-grid-renderer cells]`); extract + invoke its
+    ;; inner fn (same `[fn cells]` shape as tabs) to get the rendered
+    ;; cell tree, then walk for variant-id keys.
+    (let [render  (fn [ws-id]
+                    (let [{renderer :fn cells :cells}
+                          (find-tabs-renderer-call (workspace/workspace-view ws-id))]
+                      (renderer cells)))
+          keys-a  (collect-cell-keys (render :Workspace.rf2-kgn0c.a/grid))
+          keys-b  (collect-cell-keys (render :Workspace.rf2-kgn0c.b/grid))]
       (is (= 2 (count keys-a)) "workspace-a yields one key per cell")
       (is (= 2 (count keys-b)) "workspace-b yields one key per cell")
       (is (empty? (set/intersection keys-a keys-b))
@@ -409,10 +421,14 @@
       {:layout :variants-grid})
     (story/reg-workspace :Workspace.rf2-kgn0c-vg.b/all
       {:layout :variants-grid})
-    (let [keys-a (collect-cell-keys
-                   (workspace/workspace-view :Workspace.rf2-kgn0c-vg.a/all))
-          keys-b (collect-cell-keys
-                   (workspace/workspace-view :Workspace.rf2-kgn0c-vg.b/all))]
+    ;; rf2-ba86n.18 — isolated `:variants-grid` also mounts the capped-grid
+    ;; renderer; extract + invoke its inner fn to reach the cell tree.
+    (let [render  (fn [ws-id]
+                    (let [{renderer :fn cells :cells}
+                          (find-tabs-renderer-call (workspace/workspace-view ws-id))]
+                      (renderer cells)))
+          keys-a  (collect-cell-keys (render :Workspace.rf2-kgn0c-vg.a/all))
+          keys-b  (collect-cell-keys (render :Workspace.rf2-kgn0c-vg.b/all))]
       (is (seq keys-a))
       (is (seq keys-b))
       (is (empty? (set/intersection keys-a keys-b))
@@ -459,8 +475,11 @@
   "Walk `tree` for a hiccup vector of the shape `[fn cells-vec]` where
   cells-vec is a non-empty vector of cell maps. Returns
   `{:fn renderer :cells cells}` or nil. The workspace-view mounts
-  `:tabs` as `[tabs-renderer cells]` so this is the unambiguous shape
-  of the tabs branch."
+  `:tabs` as `[tabs-renderer cells]` AND `:grid` / isolated
+  `:variants-grid` as `[capped-grid-renderer cells]` (rf2-ba86n.18) —
+  both share this `[fn cells]` shape, so this helper extracts either
+  renderer's inner call. Callers invoke `(renderer cells)` to get the
+  rendered hiccup tree they walk."
   [tree]
   (->> (tree-seq coll? seq tree)
        (filter (fn [node]
@@ -674,7 +693,13 @@
        :variants [:story.rf2-ktnl8.gt/a
                   :story.rf2-ktnl8.gt/b
                   :story.rf2-ktnl8.gt/c]})
-    (let [grid-tree  (workspace/workspace-view :Workspace.rf2-ktnl8.gt/grid)
+    ;; rf2-ba86n.18 — `:grid` mounts the capped-grid renderer; invoke its
+    ;; inner fn to reach the rendered cells (3 variants < the 100 visible
+    ;; cap, so all three render and the layout-difference contract holds).
+    (let [{grid-fn :fn grid-cells :cells}
+                     (find-tabs-renderer-call
+                       (workspace/workspace-view :Workspace.rf2-ktnl8.gt/grid))
+          grid-tree  (grid-fn grid-cells)
           grid-n     (count-variant-cells-in grid-tree)
           {tabs-fn :fn tabs-cells :cells}
                      (find-tabs-renderer-call


### PR DESCRIPTION
Wires the shipped parity budgets (`re-frame.story.budgets`, ba86n.2) into the unified-canvas render paths so large grids / controls panels **cap-and-page instead of flooding** the canvas (spec/018 §10). Unblocked by the unified canvas (#2491) + the parity budgets.

## Budgets / virtualization wired where

| Budget | Where wired | Behaviour |
|---|---|---|
| **G1** `grid-visible-cell-cap` (100) | `ui/workspace` new `capped-grid-renderer` | first 100 cells render; `+N more` expander reveals the rest |
| **G2** `matrix-warn-threshold` (144) | same renderer | soft matrix-size advisory above the grid (advisory only) |
| **G3** `matrix-hard-cap` (400) | same renderer | grid **never renders past 400** — over the hard cap the tail stays paged even when expanded, so a generated matrix can never freeze the canvas |
| **C2** `controls-flat-row-cap` (60) | `ui/controls` `args-editor` | first 60 top-level rows render; `+N more` expander reveals the rest |

All four route through the SAME `budgets/bound-cells` cap-and-page primitive (F1) — change a number in `budgets.cljc` and the render path + the gate move together. The matrix guard uses `budgets/matrix-warn?` / `matrix-over-hard-cap?`.

The new `bound-grid-cells` is a pure cljc helper (JVM-testable); `bound-arg-rows` mirrors it for controls. Over the hard cap, `bound-grid-cells` does NOT let `expanded?` short-circuit `bound-cells` to the full set (that would be the freeze G3 forbids) — expansion tops out at the hard cap.

## Scroll/focus survives re-render

Every expander is **additive** — revealing more never reorders the rows/cells already on screen. Existing cells/rows keep their stable React keys (variant-id-keyed cells per rf2-kgn0c, arg-key-keyed rows, monotonic repeater row ids per rf2-c8kfy), so focus/scroll on a visible row/cell survives the expansion re-render. The grid expand flag is a per-mount `r/atom` (ephemeral, lifetime = one workspace selection via the workspace-id-keyed remount); the controls flat-cap reveal rides the existing component-local `:expanded` ratom under a reserved `::flat-expanded` keyword sentinel — never `:cell-overrides` / shell-state (controls must not become hidden panel state, spec/019 §6).

## Perf fixtures

Extended the existing budget gate (`budgets_cljs_test`, ba86n.2 — did NOT rebuild it) with floor-scale (2000-variant) tests that exercise the **wired render-path helpers**, not just the pure primitives:
- `variants-grid-render-path-is-bounded` (JVM + CLJS): `workspace/bound-grid-cells` caps visible cells at G1, warns at G2, flags G3, and proves expansion never renders past the hard cap (paged tail).
- `controls-flat-panel-render-path-is-bounded` (CLJS): `controls/bound-arg-rows` caps at C2, reveals all on expand, and the flat-expanded sentinel is a keyword (never a vector path → can't collide with a nested-control path).
- single-source assertion that `bound-arg-rows` reads `budgets/controls-flat-row-cap`.

The three existing grid-key tests (rf2-kgn0c / rf2-ktnl8) were updated to reach cells through the capped renderer (same `[fn cells]` shape as the tabs renderer, so they reuse `find-tabs-renderer-call`).

## Reused vs new

- **Reused (not duplicated):** `budgets/bound-cells` + matrix guard (ba86n.2); the sidebar `bound-variants` cap-and-page idiom (ba86n.4); the controls summarise-before-expand deep-nesting laziness (ba86n.5, C1/C4 — already shipped); the budget gate's structural-cap floor fixture (ba86n.2).
- **New:** the `capped-grid-renderer` + `bound-grid-cells` (workspace), the C2 flat-row cap + `bound-arg-rows` (controls), the `:grid-more` / `:grid-warn` / `:more` styles, the floor-scale render-path perf fixtures.

## STOP-valve follow-on

**Lazy Xray-diff mounting** (compute expensive diffs only when the panel is expanded) is deferred as a follow-on rather than padding this PR. The Xray embed already mounts **one panel at a time** with deferred microtask unmount (rf2-4l7t2), so the flood risk is already bounded; deferring the mount until expansion is the named upgrade. A follow-on bead should be filed.

## Quality gates

- `clj-kondo --parallel --fail-level error --lint tools/story` — **0 errors** (124 pre-existing warnings, none new — the `r/with-let` symbol false-positives match existing components).
- `tools/story` `clojure -M:test` — **1488 tests / 5522 assertions / 0 failures**.
- `npm run test:cljs` — **4996 tests / 16728 assertions / 0 failures / 0 warnings**.
- `npm run test:bundle-isolation` — **PASS** (tools/story→budgets is an internal require; nothing leaks to production bundles).
- `scripts/test-fast-pr.sh` — **PASS** (core JVM, JS harness, CLJS node integration, README + docs anchor validators; mkdocs soft-skipped on Windows).

Spec: only the spec/018 §10 perf/scale subsection touched (budgets C2/G1/G2/G3 → CURRENT render-wired; mitigations note records the wiring + the lazy Xray-diff follow-on).