### PR TITLE
fix(story/decorators): fold FULL decorator stack into compiled plan (rf2-5fibj)

### DIFF
--- a/tools/story/src/re_frame/story/decorators.cljc
+++ b/tools/story/src/re_frame/story/decorators.cljc
@@ -36,65 +36,41 @@
   Unknown decorator-ids surface as an entry in the returned `:errors`
   vector; the runtime then projects those into the variant's
   `:assertions` (per IMPL-SPEC §5.5)."
-  (:require [re-frame.story.args      :as args]
-            [re-frame.story.config    :as config]
-            [re-frame.story.plan      :as plan]
+  (:require [re-frame.story.plan      :as plan]
             [re-frame.story.registrar :as registrar]))
 
 ;; ---- collection -----------------------------------------------------------
 
-(defn- variant-decorator-refs
-  "Return the variant's RESOLVED `:decorators` ref vector, or `[]`.
+(defn- collect-decorator-refs
+  "Return the variant's FULL ordered `[decorator-ref ...]` list — globals
+  (outermost), then the parent story's `:decorators`, then the variant
+  chain — by reading the COMPILED plan's `[:world :decorators]`, NOT by
+  re-assembling the three sources here (rf2-5fibj / rf2-din8u).
 
-  Reads the COMPILED plan's `[:world :decorators]` — NOT the raw
-  side-table body (rf2-g74i9, spec/017 §305-306). The plan compiler
-  (`re-frame.story.plan`) is the single `:extends` merge authority: it
-  walks the `:extends` parent chain and folds each ancestor's
-  `:decorators` into `[:world :decorators]` (`context-keys` inheritance,
-  child-wins per `merge-context`). Reading the raw body's `:decorators`
-  straight off the side-table — as this fn used to — saw ONLY the
-  child's own slot, so an `:extends` child that declared no
-  `:decorators` resolved an EMPTY stack and the parent's decorators were
-  silently dropped (inheritance dead). Routing through the plan makes
-  the registered path share the same merged refs the inline-plan runtime
-  path already consumes from `[:world :decorators]`, so both paths agree.
+  The plan compiler (`re-frame.story.plan`) is now the SINGLE source of
+  the full stack: it folds `(concat globals story variant-chain)` into
+  `[:world :decorators]` (rf2-5fibj), the SAME set this fn used to
+  `concat` at resolve time. Reading it off the plan means the registered
+  front-door path (`resolve-decorators`, which the canvas calls), the
+  inline-plan runtime path (`resolve-decorator-refs` over the plan's
+  refs), and `render-variant` (which reads `render-inputs`' `:decorators`,
+  also off `[:world :decorators]`) ALL resolve the identical stack — no
+  second assembly engine to diverge. Before rf2-5fibj this fn prepended
+  globals + story while the plan carried only the variant chain, so
+  `render-variant` (reading the plan alone) dropped globals + story and
+  diverged from the live canvas.
+
+  Globals + story are AMBIENT (project config + parent-story body), not
+  part of the variant body — the plan resolves them through
+  `config/get-global-decorators` + the `:story` side-table; this fn just
+  consumes the result. Active modes contribute no decorators at v1 — per
+  IMPL-SPEC §3.1 modes carry `:args` only.
 
   `decorators → plan` is acyclic (plan does NOT require decorators). The
-  compile is the same pure data→data the runtime's plan compile is; the
-  per-variant cost is one extra compile per resolution, which the single-
-  merge-authority invariant pays for (no second merge engine to diverge)."
+  per-variant cost is one plan compile per resolution, which the single-
+  source invariant pays for (no second merge engine to diverge)."
   [variant-id]
   (or (get-in (plan/variant-plan variant-id) [:world :decorators]) []))
-
-(defn- story-decorator-refs
-  "Return the parent story's `:decorators` vector, or `[]`."
-  [variant-id]
-  (let [story-id (args/parent-story-id variant-id)
-        body     (when story-id (registrar/handler-meta :story story-id))]
-    (or (:decorators body) [])))
-
-(defn- global-decorator-refs
-  "Return the ordered global-decorators ref vector, or `[]`. Per
-  rf2-835ey — Storybook `preview.ts` `decorators: [...]` parity.
-  Earliest-registered first."
-  []
-  (config/get-global-decorators))
-
-(defn- collect-decorator-refs
-  "Build the ordered `[decorator-ref ...]` list for the variant.
-
-  Global decorators come first (outermost when applied as hiccup
-  wrappers), story decorators second, variant decorators last. Active
-  modes contribute no decorators at v1 — per IMPL-SPEC §3.1 modes carry
-  `:args` only.
-
-  Per rf2-835ey the global-decorators layer prepends — symmetric to
-  `global-args` being Layer 1 of args-resolution. The full stack is
-  `(concat globals story variant)`."
-  [variant-id]
-  (vec (concat (global-decorator-refs)
-               (story-decorator-refs variant-id)
-               (variant-decorator-refs variant-id))))
 
 ;; ---- resolution -----------------------------------------------------------
 
@@ -254,15 +230,16 @@
   :fingerprints}` shape `resolve-decorators` returns — but WITHOUT reading
   the variant/story side-table for the ref collection.
 
-  `resolve-decorators` is the registered-variant front door: it collects
-  the global + story + variant refs from the side-table, then delegates
-  here. The inline-plan runtime path (rf2-5x1wt.20) calls this directly
-  with the plan's already-resolved `[:world :decorators]` refs (which the
-  compiler merged from the variant chain + composed fragments), so an
-  inline plan that is absent from the side-table still gets its decorator
-  stack classified the same way. The decorator BODIES are still looked up
-  against the `:decorator` registry (a decorator is a registered artefact;
-  only the variant's ref LIST differs between the two paths)."
+  `resolve-decorators` is the registered-variant front door: it reads the
+  FULL `[:world :decorators]` stack (globals + story + variant chain) off
+  the compiled plan (rf2-5fibj), then delegates here. The inline-plan
+  runtime path (rf2-5x1wt.20) and `render-variant` (via `render-inputs`'
+  `:decorators`) call this directly with the SAME `[:world :decorators]`
+  refs, so an inline plan absent from the side-table — and the live canvas
+  + render-variant alike — all classify the identical stack. The decorator
+  BODIES are still looked up against the `:decorator` registry (a decorator
+  is a registered artefact; only the variant's ref LIST is sourced from the
+  plan)."
   [refs]
   (let [resolved   (mapv resolve-ref refs)
         {:keys [hiccup frame-setup fx-override errors]}

--- a/tools/story/src/re_frame/story/plan.cljc
+++ b/tools/story/src/re_frame/story/plan.cljc
@@ -118,6 +118,7 @@
   tests."
   (:require [re-frame.story.args         :as args]
             [re-frame.story.assertions   :as assertions]
+            [re-frame.story.config       :as config]
             [re-frame.story.registrar    :as registrar]
             [re-frame.story.requirements :as requirements]
             [re-frame.story.malli-schema :as msu]
@@ -1070,6 +1071,25 @@
   [check-id]
   (registrar/handler-meta :check check-id))
 
+(defn- default-global-decorators
+  "Default global-decorators ref vector — reads the project-wide
+  `config/get-global-decorators` (rf2-835ey — Storybook `preview.ts`
+  `decorators: [...]` parity, the outermost wrap layer). Production
+  bundles with Story elided register no globals, so the vector is empty
+  there; pure tests thread an explicit `:global-decorators`."
+  []
+  (config/get-global-decorators))
+
+(defn- default-story-decorators-lookup
+  "Default story-level `:decorators` lookup — reads the parent story body's
+  `:decorators` slot off the Story side-table `:story` kind. The full
+  decorator stack folded into `[:world :decorators]` is `(concat globals
+  story variant-chain)`, with the parent story's decorators sitting between
+  the project-wide globals and the variant chain. Production bundles elide
+  the side-table; pure tests thread an explicit `:story-decorators`."
+  [story-id]
+  (:decorators (registrar/handler-meta :story story-id)))
+
 (defn expand-checks
   "Expand a plan's `:expect :checks` ids into the
   `{check-id [assertion-atom …]}` map the unified run-result groups its
@@ -1116,16 +1136,43 @@
   - `:sub-lookup` — a 1-arg fn `(sub-id) → sub-meta` OR a `{sub-id →
     sub-meta}` map resolving a subscription's registration metadata (for
     its OUTPUT schema, against which `:sub-overrides` values are validated
-    — rf2-5x1wt.13). Defaults to the framework `:sub` registrar."
+    — rf2-5x1wt.13). Defaults to the framework `:sub` registrar.
+  - `:global-decorators` — the project-wide global-decorators ref vector
+    (or a 0-arg fn returning one) prepended to `[:world :decorators]` as
+    the outermost wrap layer (rf2-5fibj / rf2-835ey). Defaults to
+    `config/get-global-decorators`; pure tests pass an explicit vector.
+  - `:story-decorators` — a 1-arg fn `(story-id) → decorators-vec` OR a
+    `{story-id → decorators-vec}` map resolving the parent story's
+    `:decorators` slot (folded between globals and the variant chain —
+    rf2-5fibj). Defaults to the Story side-table `:story` kind."
   ([id body lookup] (compile-body id body lookup nil))
   ([id body lookup {:keys [view-lookup validator-fns sub-lookup
-                           fragment-lookup check-lookup] :as _opts}]
+                           fragment-lookup check-lookup
+                           global-decorators story-decorators] :as _opts}]
   (let [view-lookup  (coerce-kind-lookup :view-lookup view-lookup default-view-lookup)
         sub-lookup   (coerce-kind-lookup :sub-lookup sub-lookup default-sub-lookup)
         frag-lookup  (coerce-kind-lookup :fragment-lookup fragment-lookup
                                          default-fragment-lookup)
         chk-lookup   (coerce-kind-lookup :check-lookup check-lookup
                                          default-check-lookup)
+        ;; ---- ambient decorator layers (rf2-5fibj) ----
+        ;; The full decorator stack folded into `[:world :decorators]` is
+        ;; `(concat globals story variant-chain)` — the SAME set
+        ;; `decorators/collect-decorator-refs` used to assemble at resolve
+        ;; time. Folding it HERE makes the compiled plan the single source
+        ;; of truth (rf2-din8u): the canvas (via `resolve-decorators`) and
+        ;; `render-variant` (via `render-inputs`' `:decorators`) both read
+        ;; `[:world :decorators]`, so they paint the IDENTICAL decorator
+        ;; tree. Globals + story decorators are AMBIENT (not part of the
+        ;; variant body or its `:extends` chain), resolved through the
+        ;; project config + the parent-story body — both overridable for
+        ;; pure JVM tests, exactly like the view / sub / fragment lookups.
+        global-decos (cond
+                       (nil? global-decorators) (default-global-decorators)
+                       (fn?  global-decorators) (global-decorators)
+                       :else                    global-decorators)
+        story-deco-lk (coerce-kind-lookup :story-decorators story-decorators
+                                          default-story-decorators-lookup)
         chain        (resolve-source-chain id body lookup)
         bodies       (map :body chain)         ; root-first
         inherited    (vec (butlast bodies))    ; root → immediate parent
@@ -1356,6 +1403,21 @@
         ;; ---- source coords ----
         source       (:source child)
         platforms    (or (:platforms ctx) #{:client})
+        ;; ---- full decorator stack (rf2-5fibj) ----
+        ;; `(concat globals story variant-chain)` — globals outermost, then
+        ;; the parent story's `:decorators`, then the variant-chain slot
+        ;; (`(:decorators ctx)` — the `:extends`-merged, child-wins refs).
+        ;; The SAME ordered set `decorators/collect-decorator-refs` used to
+        ;; assemble at resolve time; folding it onto `[:world :decorators]`
+        ;; here makes the compiled plan the single source of truth, so the
+        ;; canvas + render-variant resolve the identical stack (rf2-din8u).
+        ;; Each layer falls through to `[]` when absent — the empty-collection
+        ;; concat is render-transparent.
+        story-decos  (vec (when-let [sid (args/parent-story-id id)]
+                            (story-deco-lk sid)))
+        full-decos   (vec (concat global-decos
+                                  story-decos
+                                  (or (:decorators ctx) [])))
         world        (cond-> {:setup          setup
                               :args           arg-map
                               :argtypes       argtypes
@@ -1386,7 +1448,11 @@
                        ;; completion predicate from the plan alone.
                        (contains? ctx :loaders-complete-when) (assoc :loaders-complete-when (:loaders-complete-when ctx))
                        (contains? ctx :loaders-teardown) (assoc :loaders-teardown (:loaders-teardown ctx))
-                       (contains? ctx :decorators)  (assoc :decorators (:decorators ctx))
+                       ;; rf2-5fibj — the FULL stack (globals + story +
+                       ;; variant chain), not just `(:decorators ctx)`. Folded
+                       ;; when non-empty so a bare variant carries no slot
+                       ;; (render-transparent), exactly as before.
+                       (seq full-decos)             (assoc :decorators full-decos)
                        (contains? ctx :modes)       (assoc :modes (:modes ctx))
                        (contains? ctx :substrates)  (assoc :substrates (:substrates ctx))
                        (contains? ctx :viewport)    (assoc :viewport (:viewport ctx))
@@ -1507,6 +1573,12 @@
     sub-meta}` map resolving a subscription's registration metadata for
     its OUTPUT schema, against which `:sub-overrides` values are validated
     (rf2-5x1wt.13). Defaults to the framework `:sub` registrar.
+  - `:global-decorators` / `:story-decorators` — the ambient decorator
+    layers folded into the FULL `[:world :decorators]` stack (rf2-5fibj):
+    a global-decorators ref vector (or 0-arg fn) defaulting to
+    `config/get-global-decorators`, and a `(story-id) → decorators-vec`
+    lookup defaulting to the Story side-table `:story` kind. Pure tests
+    thread explicit values; the live runtime uses the defaults.
 
   Returns the normalized plan map: `:variant/id`, `:source-chain`,
   `:world` (incl. `:effective-args` and `:view-args-schema` when a view
@@ -1525,7 +1597,8 @@
   ([target {:keys [lookup] :as opts}]
    (let [lookup-fn    (coerce-kind-lookup :lookup lookup default-lookup)
          compile-opts (select-keys opts [:view-lookup :validator-fns :sub-lookup
-                                         :fragment-lookup :check-lookup])]
+                                         :fragment-lookup :check-lookup
+                                         :global-decorators :story-decorators])]
      (cond
        (keyword? target)
        (if-let [body (lookup-fn target)]

--- a/tools/story/src/re_frame/story/ui/canvas.cljs
+++ b/tools/story/src/re_frame/story/ui/canvas.cljs
@@ -7,7 +7,11 @@
     fingerprint detector ticks.
   - Calls `run-variant` with the active modes / cell-overrides / substrate.
   - Renders the variant's `:component` (registered re-frame view) under
-    the `:hiccup` decorator stack from `resolve-decorators`.
+    the `:hiccup` decorator stack from `resolve-decorators` — which reads
+    the FULL stack (globals + story + variant chain) off the compiled
+    plan's `[:world :decorators]` (rf2-5fibj / rf2-din8u), the SAME refs
+    `render-variant`'s host applies, so canvas + render-variant paint the
+    identical decorated tree.
   - Surfaces variant-level errors inline (per IMPL-SPEC §2.2 +
     `:assertions`).
 

--- a/tools/story/test/re_frame/story/canvas_plan_resolution_test.cljc
+++ b/tools/story/test/re_frame/story/canvas_plan_resolution_test.cljc
@@ -34,6 +34,7 @@
   registrar are all JVM-runnable, so the DEFAULT lookup works under both
   `clojure -M:test` and `npm run test:cljs`."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.story.config     :as config]
             [re-frame.story.decorators :as decorators]
             [re-frame.story.late-bind  :as late-bind]
             [re-frame.story.plan       :as plan]
@@ -58,10 +59,19 @@
 (defn reset-fixture [test-fn]
   (registrar/clear-all!)
   (framework-registrar/clear-kind! :sub)
+  ;; The global-decorators vector is a process-global config atom (NOT part
+  ;; of the side-table `clear-all!` wipes), so a test that sets globals
+  ;; would leak into siblings. Clear it before each test and restore the
+  ;; pre-test value after (rf2-5fibj).
+  (config/set-global-decorators! [])
   ;; `:sub-overrides` validation soft-passes when a sub carries no output
   ;; schema (the host-free floor), so an unregistered :sub is fine here.
-  (let [snapshot @late-bind/hooks]
-    (try (test-fn) (finally (reset! late-bind/hooks snapshot)))))
+  (let [snapshot       @late-bind/hooks
+        globals-before (config/get-global-decorators)]
+    (try (test-fn)
+         (finally
+           (reset! late-bind/hooks snapshot)
+           (config/set-global-decorators! globals-before)))))
 
 (use-fixtures :each reset-fixture)
 
@@ -186,6 +196,57 @@
                 pack's :hiccup ids"
         (is (= canvas-ids
                (mapv :id (:hiccup (decorators/resolve-decorator-refs rv-refs)))))))))
+
+(deftest canvas-and-render-variant-agree-on-full-decorator-stack
+  (testing "the canvas + render-variant resolve the SAME FULL decorator
+            stack — GLOBAL + parent-STORY + variant — off the ONE compiled
+            [:world :decorators] (rf2-5fibj). The prior
+            `canvas-and-render-variant-agree-on-decorators` test exercised
+            only variant + :extends decorators, so the host-path drop of
+            globals + story slipped CI green (the din8u CI-blind-spot, one
+            layer up): the plan folded only the variant chain, the canvas
+            re-assembled globals+story+variant, so they DIVERGED."
+    (registrar/reg-decorator* :deco/global-theme
+                              {:kind :hiccup :wrap (fn [body _] [:div.global body])})
+    (registrar/reg-decorator* :deco/story-frame
+                              {:kind :hiccup :wrap (fn [body _] [:div.story body])})
+    (registrar/reg-decorator* :deco/variant-pad
+                              {:kind :hiccup :wrap (fn [body _] [:div.variant body])})
+    ;; GLOBAL decorator (the layer the host path dropped) — Storybook
+    ;; preview.ts parity, rf2-835ey.
+    (config/set-global-decorators! [[:deco/global-theme]])
+    ;; parent-STORY decorator (the OTHER layer the host path dropped) — the
+    ;; variant id's namespace resolves to this story.
+    (registrar/reg-story* :story.fullstack
+                          {:decorators [[:deco/story-frame]]})
+    ;; the variant adds its own decorator on top.
+    (registrar/reg-variant* :story.fullstack/v
+                            {:component  :views/widget
+                             :decorators [[:deco/variant-pad]]
+                             :events     []})
+    (let [;; render-variant's render-inputs carry the FULL stack off the plan.
+          prepared    (render/prepare-render :story.fullstack/v)
+          rv-refs     (get-in prepared [:render-inputs :decorators])
+          ;; the canvas resolves the same plan-sourced refs into its pack.
+          canvas-pack (decorators/resolve-decorators :story.fullstack/v)
+          canvas-ids  (mapv :id (:hiccup canvas-pack))]
+      (testing "the compiled plan carries the FULL stack in order: global
+                outermost, then story, then variant (NOT just the variant
+                chain — the pre-rf2-5fibj plan dropped globals + story)"
+        (is (= [[:deco/global-theme] [:deco/story-frame] [:deco/variant-pad]]
+               rv-refs)))
+      (testing "the canvas pack resolves the SAME full stack in the SAME order"
+        (is (= [:deco/global-theme :deco/story-frame :deco/variant-pad]
+               canvas-ids)))
+      (testing "both paths agree: render-variant's refs resolve to the canvas
+                pack's :hiccup ids — IDENTICAL decorated tree"
+        (is (= canvas-ids
+               (mapv :id (:hiccup (decorators/resolve-decorator-refs rv-refs))))))
+      (testing "and applying the stack wraps the leaf globals-outermost,
+                variant-innermost (the rendered tree both paths paint)"
+        (is (= [:div.global [:div.story [:div.variant [:span "leaf"]]]]
+               (decorators/apply-hiccup-decorators
+                 (:hiccup canvas-pack) [:span "leaf"] {})))))))
 
 (deftest render-variant-applies-decorators-through-shared-seam
   (testing "render-variant's host renders the SAME decorator refs the canvas


### PR DESCRIPTION
Completes the **rf2-din8u** invariant for the FULL decorator stack (from the rf2-ba86n.8 review). The compiled variant-plan is now the single source of truth for the entire decorator stack, and BOTH the live canvas and `render-variant` read it.

## The divergence

- **canvas single-pane** (`ui/canvas.cljs`) applied `decorators/resolve-decorators` → `collect-decorator-refs` = **globals + story + variant**.
- **render-variant host** (`render.cljc` → `canonical.cljc` → `multi_substrate/render-decorated-view`) applied only the compiled `[:world :decorators]`, which `plan.cljc` folded from `(:decorators ctx)` = the **variant `:extends`/`:compose` chain ONLY**. Global decorators (`config/get-global-decorators`, rf2-835ey) + parent-story `:decorators` were DROPPED.

So a variant carrying a global decorator or a parent-story decorator rendered WRAPPED on the live canvas but BARE through `render-variant`. The prior `canvas-and-render-variant-agree-on-decorators` test exercised only variant + `:extends`, so the gap was CI-green (the din8u CI-blind-spot, one layer up).

## The fix (din8u-consistent — the plan as single source for the FULL stack)

1. **plan full-stack fold** (`plan.cljc`): `compile-body` folds `(concat globals story variant-chain)` into `[:world :decorators]` — globals outermost, then the parent-story `:decorators`, then the `:extends`-merged variant chain (`(:decorators ctx)`). Globals + story are AMBIENT (project config + parent-story body), resolved through `config/get-global-decorators` + the `:story` side-table — both overridable via new `:global-decorators` / `:story-decorators` opts for pure JVM tests, exactly like the existing view / sub / fragment lookups. Folded only when non-empty (a bare variant carries no slot → render-transparent).
2. **canvas → plan routing** (`decorators.cljc`): `collect-decorator-refs` now READS the full `[:world :decorators]` off the plan instead of re-assembling the three sources. The two removed private helpers (`global-decorator-refs`, `story-decorator-refs`) and the `args`/`config` requires are gone — there is no second assembly engine to diverge. The canvas (via `resolve-decorators`, its unchanged front door) is therefore plan-sourced; its rendered stack is UNCHANGED (still globals+story+variant).
3. **render-variant parity**: `render-variant` already reads `[:world :decorators]` (via `render-inputs`' `:decorators`) → now gets the full stack for free. Canvas + render-variant resolve the IDENTICAL decorator tree.
4. `theme/status` + the multi-substrate seam's read-API are untouched.

`spec/017` unchanged: the FULL stack was always the documented intent (`[:world :decorators]` as the single source); this PR makes the compiler honour it. No section needed editing.

## The global+story production-path test

`canvas_plan_resolution_test.cljc` gains `canvas-and-render-variant-agree-on-full-decorator-stack` — a registered variant compiled via the DEFAULT lookup with a GLOBAL decorator AND a parent-STORY decorator (not just variant `:extends`). Asserts the plan carries the full stack in order `[global story variant]`, the canvas pack resolves the same, both paths agree on the `:hiccup` ids, and the applied wrap is globals-outermost / variant-innermost. This is the exact shape the prior test omitted. The file fixture now also clears/restores the global-decorators config atom so the test does not leak into siblings.

## Quality gates

- `clj-kondo --parallel --fail-level error --lint tools/story` — **errors: 0** (123 pre-existing warnings in test/testbed files; none in changed files).
- `tools/story` `clojure -M:test` — **1488 tests / 5510 assertions, 0 failures, 0 errors**.
- `implementation` `npm run test:cljs` — **4994 tests / 16703 assertions, 0 failures, 0 errors** (0 compile warnings).
- `implementation` `npm run test:bundle-isolation` — **PASS**.
- `tools/story-mcp` `clojure -M:test` — **172 tests / 861 assertions, 0 failures, 0 errors**.
- `tools/mcp-conformance` `npm run test:story` — **STORY-MCP MCP-CLIENT CONFORMANCE GREEN**.
- `scripts/test-fast-pr.sh` — **PASS fast PR spine**.