### PR TITLE
feat(story/ui): lazy Xray-diff mounting — defer panel mount + compute until expanded (rf2-ba86n.19)

### DIFF
--- a/tools/story/spec/018-Story-UI-North-Star.md
+++ b/tools/story/spec/018-Story-UI-North-Star.md
@@ -564,9 +564,18 @@ controls as summaries until expanded (C1/C4). Each bound is the SAME
 expander is additive — revealing more never reorders the rows/cells already
 on screen, so scroll/focus survives the re-render (stable React keys:
 variant-id-keyed cells, arg-key-keyed rows, monotonic repeater row ids).
-Lazy Xray-diff mounting (compute expensive diffs only when the panel is
-expanded) is the remaining named upgrade; the embed already mounts ONE
-panel at a time, so the flood risk is already bounded.
+Lazy Xray-diff mounting is now CURRENT (rf2-ba86n.19): the RHS Xray embed
+defers the panel MOUNT — and therefore the panel's expensive diff compute
+(app-db structural diff, epoch timeline) — until the embed is expanded. The
+embed already mounted ONE panel at a time with deferred microtask unmount
+(rf2-4l7t2); the upgrade gates that mount on a `:xray-embed-collapsed?`
+shell slot, so a collapsed embed renders only the (cheap, pure-data)
+chip-row picker plus a quiet placeholder and never instantiates the
+panel-host component that drives `mount-<panel>!`. Collapsing drops the
+panel-host from the tree, which releases the Xray React root via the same
+existing microtask path (rf2-4l7t2) — no teardown is duplicated. The embed
+e2e CLJS gate asserts no panel-host slot (hence no diff compute) renders
+while collapsed.
 
 ### 10.1 Parity budgets
 

--- a/tools/story/src/re_frame/story/ui/state.cljc
+++ b/tools/story/src/re_frame/story/ui/state.cljc
@@ -159,7 +159,15 @@
                          :sidebar?     true
                          :rhs?         true
                          :toolbar?     true
-                         :embed?       false}})
+                         :embed?       false}
+   ;; rf2-ba86n.19 — lazy Xray-diff mounting (spec/018 §10). When true the
+   ;; RHS Xray embed is COLLAPSED: the panel-host is not rendered, so no
+   ;; `mount-<panel>!` fires and the panel's expensive diff compute (app-db
+   ;; structural diff, epoch timeline) is deferred. Defaults false
+   ;; (expanded) so the out-of-the-box RHS paints the panel; collapsing
+   ;; releases the Xray React root via the existing microtask path
+   ;; (rf2-4l7t2). The chip-row's disclosure toggle flips this slot.
+   :xray-embed-collapsed? false})
 
 ;; ---- pure transitions (extracted to state.transitions, rf2-gcpon) -------
 
@@ -183,6 +191,12 @@
 (def record-fingerprints       state.transitions/record-fingerprints)
 (def pin-snapshot              state.transitions/pin-snapshot)
 (def toggle-panel              state.transitions/toggle-panel)
+
+;; ---- Xray-embed collapse re-exports (rf2-ba86n.19) ----------------------
+
+(def xray-embed-collapsed?       state.transitions/xray-embed-collapsed?)
+(def toggle-xray-embed-collapsed state.transitions/toggle-xray-embed-collapsed)
+(def set-xray-embed-collapsed    state.transitions/set-xray-embed-collapsed)
 
 ;; ---- chrome visibility re-exports (rf2-p3i0t / rf2-g8l8x / rf2-pucku) ---
 

--- a/tools/story/src/re_frame/story/ui/state/transitions.cljc
+++ b/tools/story/src/re_frame/story/ui/state/transitions.cljc
@@ -315,6 +315,35 @@
   [state panel-id]
   (update-in state [:panel-visibility panel-id] not))
 
+;; ---- Xray-embed collapse (rf2-ba86n.19) ---------------------------------
+;;
+;; Lazy Xray-diff mounting (spec/018 §10): the RHS Xray embed defers its
+;; panel MOUNT — and therefore the expensive diff compute the panel runs
+;; (app-db structural diff, epoch timeline) — until the embed is expanded.
+;; The slot defaults to expanded (false) so the out-of-the-box RHS still
+;; paints the panel; the user can collapse the band to halt compute when
+;; they're not inspecting. Collapsing unmounts the panel-host component,
+;; which releases the Xray React root via the existing microtask path
+;; (rf2-4l7t2) — no duplicate teardown lives here.
+
+(defn xray-embed-collapsed?
+  "Whether the RHS Xray embed is collapsed (panel mount + diff compute
+  deferred). Defaults to false (expanded) when the slot is unset. Pure
+  data → data; JVM-testable."
+  [state]
+  (boolean (:xray-embed-collapsed? state)))
+
+(defn toggle-xray-embed-collapsed
+  "Flip the RHS Xray embed's collapsed state. A nil/unset slot reads as
+  expanded (false), so the first toggle collapses. Pure data → data."
+  [state]
+  (assoc state :xray-embed-collapsed? (not (xray-embed-collapsed? state))))
+
+(defn set-xray-embed-collapsed
+  "Set the RHS Xray embed's collapsed state to `value`. Pure data → data."
+  [state value]
+  (assoc state :xray-embed-collapsed? (boolean value)))
+
 ;; ---- chrome visibility (rf2-p3i0t / rf2-g8l8x / rf2-pucku) --------------
 
 (def chrome-visibility-defaults

--- a/tools/story/src/re_frame/story/ui/xray_embed.cljs
+++ b/tools/story/src/re_frame/story/ui/xray_embed.cljs
@@ -248,7 +248,38 @@
                    :color (:text-tertiary colors/tokens)
                    :font-family sans-stack
                    :font-size (:caption typography/type-scale)
-                   :font-style "italic"}})
+                   :font-style "italic"}
+   ;; rf2-ba86n.19 — lazy Xray-diff mounting. The disclosure toggle that
+   ;; collapses / expands the embed. Sits at the LEFT edge of the chip-row
+   ;; (before the panel chips) so it reads as 'this whole band folds'. The
+   ;; chevron points right when collapsed, rotates down when expanded.
+   :disclosure    {:display "inline-flex"
+                   :align-items "center"
+                   :justify-content "center"
+                   :padding "2px"
+                   :background "transparent"
+                   :color (:text-secondary colors/tokens)
+                   :border "none"
+                   :cursor "pointer"
+                   :line-height "0"
+                   :transition (:chip motion/transitions)}
+   :disclosure-glyph {:display "inline-flex"
+                      :transition (:chip motion/transitions)
+                      :transform "rotate(90deg)"}
+   :disclosure-glyph-collapsed {:transform "rotate(0deg)"}
+   ;; rf2-ba86n.19 — the collapsed placeholder. Replaces the panel-host
+   ;; (and therefore the panel's expensive diff compute) while collapsed.
+   ;; A single quiet line; clicking it expands.
+   :collapsed-rest {:display "flex"
+                    :align-items "center"
+                    :flex "1 1 auto"
+                    :min-height "0"
+                    :padding "10px 8px"
+                    :cursor "pointer"
+                    :color (:text-tertiary colors/tokens)
+                    :font-family sans-stack
+                    :font-size (:caption typography/type-scale)
+                    :font-style "italic"}})
 
 ;; ---- chip rendering ------------------------------------------------------
 
@@ -436,6 +467,30 @@
                 :data-test "story-xray-panel-host"
                 :style (:panel-host styles)}])})))
 
+;; ---- disclosure toggle (rf2-ba86n.19) ------------------------------------
+
+(defn disclosure-toggle
+  "Render the collapse/expand disclosure button for the embed. Clicking
+  flips `:xray-embed-collapsed?` on the shell ratom. The chevron points
+  right when collapsed and rotates down when expanded.
+
+  Public so tests can introspect the toggle's hiccup + click handler
+  without driving the full host."
+  [collapsed?]
+  [:button
+   {:style (:disclosure styles)
+    :data-test "story-xray-disclosure"
+    :aria-expanded (str (not collapsed?))
+    :aria-label (if collapsed? "Expand Xray embed" "Collapse Xray embed")
+    :title (if collapsed?
+             "Expand the Xray panel (resume diff compute)"
+             "Collapse the Xray panel (defer diff compute)")
+    :on-click (fn [_]
+                (state/swap-state! state/toggle-xray-embed-collapsed))}
+   [:span {:style (merge (:disclosure-glyph styles)
+                         (when collapsed? (:disclosure-glyph-collapsed styles)))}
+    [glyphs/chevron-right 11]]])
+
 ;; ---- public surface: the embed panel -------------------------------------
 
 (defn xray-embed-panel
@@ -462,14 +517,24 @@
        "Xray is not loaded in this build — embed surface unavailable."]
 
       :else
-      (let [active-panel (effective-panel shell variant-id)]
+      (let [active-panel (effective-panel shell variant-id)
+            ;; rf2-ba86n.19 — lazy Xray-diff mounting (spec/018 §10). When
+            ;; collapsed we DON'T render `panel-host-component`, so no
+            ;; `mount-<panel>!` fires and the panel's expensive diff compute
+            ;; (app-db structural diff, epoch timeline) is deferred until the
+            ;; user expands. The chip-row picker still paints (cheap — it's
+            ;; pure data + click handlers, no Xray symbol), so the author's
+            ;; lens choice survives a collapse round-trip.
+            collapsed?   (state/xray-embed-collapsed? shell)]
         [:div {:style (:wrap styles)
                :data-test "story-xray-embed"
-               :data-active-panel (name active-panel)}
-         ;; chip-row + popout
+               :data-active-panel (name active-panel)
+               :data-xray-embed-collapsed (str collapsed?)}
+         ;; chip-row + disclosure + popout
          [:div {:style (:chip-row styles)
                 :role "tablist"
                 :aria-label "Xray panel picker"}
+          [disclosure-toggle collapsed?]
           (for [{:keys [panel label title]} panel-catalog]
             ^{:key panel}
             [chip panel label title (= panel active-panel)])
@@ -481,24 +546,42 @@
             :on-click (fn [_] (popout-full-shell!))}
            [:span "Pop out"]
            [glyphs/external-link 11]]]
-         ;; the panel-host. rf2-4l7t2: NO React key on this slot —
-         ;; the host class persists across panel-id swaps so
-         ;; `:component-did-update` handles the in-place mount round-
-         ;; trip. Keying the slot on `active-panel` (the pre-fix
-         ;; "belt-and-braces" shape) would force a full unmount/remount
-         ;; of the host on every chip click, and the synchronous
-         ;; `.unmount` of the Xray-owned React root would fire inside
-         ;; the parent's chip-click render cycle — exactly the
-         ;; "Attempted to synchronously unmount a root while React was
-         ;; already rendering" warning React 18+ guards against. The
-         ;; host's `:component-did-update` lifecycle keyed by panel-id
-         ;; argv-diff drives the swap; the inner unmount runs deferred
-         ;; (see `release!` inside `panel-host-component`).
+         ;; rf2-ba86n.19 — lazy Xray-diff mounting (spec/018 §10). When
+         ;; collapsed a quiet placeholder stands in for the panel-host;
+         ;; crucially it does NOT render `panel-host-component`, so the
+         ;; Xray mount + its expensive diff compute never fire while
+         ;; collapsed. Clicking the placeholder expands. When the embed was
+         ;; previously expanded, dropping the panel-host from the tree
+         ;; unmounts it → its `:component-will-unmount` releases the Xray
+         ;; React root via the existing microtask path (rf2-4l7t2); no
+         ;; teardown is duplicated here.
          ;;
-         ;; Variant focus changes still re-render this hiccup via the
-         ;; outer `effective-panel` resolution; the host's argv-diff
-         ;; in `:component-did-update` re-runs the mount when the
-         ;; resolved panel-id changes, and same-panel-id variant
-         ;; changes are absorbed by the Xray panel's own subs
-         ;; (`:rf.xray/focus` tracks the variant-driven cascade).
-         [panel-host-component active-panel]]))))
+         ;; The panel-host slot (when expanded). rf2-4l7t2: NO React key on
+         ;; this slot — the host class persists across panel-id swaps so
+         ;; `:component-did-update` handles the in-place mount round-trip.
+         ;; Keying the slot on `active-panel` (the pre-fix "belt-and-braces"
+         ;; shape) would force a full unmount/remount of the host on every
+         ;; chip click, and the synchronous `.unmount` of the Xray-owned
+         ;; React root would fire inside the parent's chip-click render
+         ;; cycle — exactly the "Attempted to synchronously unmount a root
+         ;; while React was already rendering" warning React 18+ guards
+         ;; against. The host's `:component-did-update` lifecycle keyed by
+         ;; panel-id argv-diff drives the swap; the inner unmount runs
+         ;; deferred (see `release!` inside `panel-host-component`).
+         ;;
+         ;; Variant focus changes still re-render this hiccup via the outer
+         ;; `effective-panel` resolution; the host's argv-diff in
+         ;; `:component-did-update` re-runs the mount when the resolved
+         ;; panel-id changes, and same-panel-id variant changes are absorbed
+         ;; by the Xray panel's own subs (`:rf.xray/focus` tracks the
+         ;; variant-driven cascade).
+         (if collapsed?
+           [:div {:style (:collapsed-rest styles)
+                  :data-test "story-xray-embed-collapsed"
+                  :on-click (fn [_]
+                              (state/swap-state! state/set-xray-embed-collapsed false))}
+            (str (or (some #(when (= active-panel (:panel %)) (:label %))
+                           panel-catalog)
+                     "Xray")
+                 " panel collapsed — expand to compute diffs.")]
+           [panel-host-component active-panel])]))))

--- a/tools/story/test/re_frame/story/panels_e2e/xray_embed_e2e_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/panels_e2e/xray_embed_e2e_cljs_test.cljs
@@ -201,6 +201,101 @@
                              (ui-state/get-state) variant-id))
                 "effective-panel resolves the override directly")))))))
 
+;; ---- lazy Xray-diff mounting: no compute on a collapsed embed -----------
+;;
+;; rf2-ba86n.19 (spec/018 §10) — the embed defers the panel MOUNT until it
+;; is expanded. `panel-host-component` is the SOLE caller of `mount-fn-for`
+;; → `mount-<panel>!` (the fn that runs the panel's expensive diff compute:
+;; app-db structural diff, epoch timeline). So the render-path proof that
+;; "no diff is computed on a collapsed embed" reduces to: while collapsed,
+;; the embed hiccup MUST NOT contain a `panel-host-component` slot — there
+;; is no mount target, hence no `mount-<panel>!`, hence no diff compute.
+;;
+;; The `expand-tree` walker (e2e helper) does NOT invoke class-3 components,
+;; so a `[panel-host-component pid]` vector surfaces in the tree as-is when
+;; present; its absence is decisive.
+
+(defn- panel-host-slot
+  "Find the `[panel-host-component <panel-id>]` slot in an embed tree, or
+  nil. The slot is the 2-element fn-headed vector whose second element is
+  one of the catalogued panel-ids (the resolved panel argv)."
+  [tree]
+  (some (fn [child]
+          (when (and (vector? child)
+                     (= 2 (count child))
+                     (contains? xray-embed/panel-ids (second child)))
+            child))
+        (e2e/find-by-test-id tree "story-xray-embed")))
+
+(deftest collapsed-embed-does-not-mount-panel-host
+  (testing "rf2-ba86n.19 — a COLLAPSED embed renders no panel-host slot, so
+            no mount-<panel>! fires and the panel's expensive diff is never
+            computed; expanding restores the panel-host"
+    (e2e/with-story-and-xray-frames
+      {:register-stories register-variant!}
+      (fn []
+        (e2e/select-variant! variant-id)
+        ;; Expanded (default) → the panel-host slot IS present (the mount
+        ;; target the diff-compute path hangs off).
+        (let [expanded-tree (xray-embed/xray-embed-panel)]
+          (is (some? (panel-host-slot expanded-tree))
+              "default (expanded) embed mounts the panel-host → diff compute path live")
+          (is (= "false" (get-in (e2e/find-by-test-id expanded-tree "story-xray-embed")
+                                 [1 :data-xray-embed-collapsed]))
+              "data-xray-embed-collapsed reflects the expanded state"))
+        ;; Collapse the embed (the same write the disclosure toggle does).
+        (ui-state/swap-state! ui-state/set-xray-embed-collapsed true)
+        (let [collapsed-tree (xray-embed/xray-embed-panel)
+              wrapper        (e2e/find-by-test-id collapsed-tree "story-xray-embed")
+              placeholder    (e2e/find-by-test-id collapsed-tree "story-xray-embed-collapsed")]
+          (is (nil? (panel-host-slot collapsed-tree))
+              "COLLAPSED embed renders NO panel-host slot → mount-<panel>! is
+               never invoked → the panel's expensive diff is not computed
+               (rf2-ba86n.19 acceptance)")
+          (is (some? placeholder)
+              "collapsed embed shows the quiet placeholder in place of the panel")
+          (is (= "true" (get-in wrapper [1 :data-xray-embed-collapsed]))
+              "data-xray-embed-collapsed reflects the collapsed state")
+          ;; The chip-row picker still paints while collapsed (cheap; no Xray
+          ;; symbol) so the author's lens choice survives a collapse.
+          (is (= 7 (count (e2e/find-all-by-test-id collapsed-tree "story-xray-panel-chip")))
+              "chip-row picker survives a collapse (no compute, just data)"))
+        ;; Expand again → panel-host slot returns (mount resumes on next commit).
+        (ui-state/swap-state! ui-state/set-xray-embed-collapsed false)
+        (let [reexpanded-tree (xray-embed/xray-embed-panel)]
+          (is (some? (panel-host-slot reexpanded-tree))
+              "expanding restores the panel-host slot → mount + diff compute resume"))))))
+
+(deftest disclosure-toggle-flips-collapsed-state
+  (testing "rf2-ba86n.19 — the disclosure toggle's on-click flips the
+            embed-collapsed shell slot (expanded → collapsed → expanded)"
+    (e2e/with-story-and-xray-frames
+      {:register-stories register-variant!}
+      (fn []
+        (e2e/select-variant! variant-id)
+        (let [tree    (xray-embed/xray-embed-panel)
+              toggle  (e2e/find-by-test-id tree "story-xray-disclosure")
+              handler (e2e/handler-for toggle :on-click)]
+          (is (some? toggle) "disclosure toggle present in the chip-row")
+          (is (= "true" (get-in toggle [1 :aria-expanded]))
+              "toggle starts aria-expanded=true (embed expanded by default)")
+          (is (fn? handler) ":on-click wired on the disclosure toggle")
+          ;; Default expanded → first click collapses.
+          (is (false? (ui-state/xray-embed-collapsed? (ui-state/get-state)))
+              "starts expanded")
+          (handler (e2e/fake-event {}))
+          (is (true? (ui-state/xray-embed-collapsed? (ui-state/get-state)))
+              "first click collapses the embed")
+          ;; Re-derive the toggle from the new tree + click again → expands.
+          (let [tree2    (xray-embed/xray-embed-panel)
+                toggle2  (e2e/find-by-test-id tree2 "story-xray-disclosure")
+                handler2 (e2e/handler-for toggle2 :on-click)]
+            (is (= "false" (get-in toggle2 [1 :aria-expanded]))
+                "aria-expanded reflects the collapsed state")
+            (handler2 (e2e/fake-event {}))
+            (is (false? (ui-state/xray-embed-collapsed? (ui-state/get-state)))
+                "second click re-expands the embed")))))))
+
 ;; ---- React lifecycle invariant ------------------------------------------
 ;;
 ;; The `panel-host-component` symbol is the React class owning the DOM

--- a/tools/story/test/re_frame/story/ui/chrome_visibility_test.cljc
+++ b/tools/story/test/re_frame/story/ui/chrome_visibility_test.cljc
@@ -98,3 +98,36 @@
 (deftest chrome-pane-visible-unknown-pane
   (testing "unknown pane kw → defaults visible (forward-compat)"
     (is (true? (transitions/chrome-pane-visible? :unknown {})))))
+
+;; ---- Xray-embed collapse (rf2-ba86n.19) ---------------------------------
+;;
+;; Lazy Xray-diff mounting: the `:xray-embed-collapsed?` slot defers the
+;; panel mount + its diff compute until expanded. Pure transition coverage
+;; here; the render-path proof (no panel-host in the tree while collapsed)
+;; lives in the embed e2e CLJS test.
+
+(deftest xray-embed-collapsed-default-expanded
+  (testing "unset slot reads as expanded (false)"
+    (is (false? (transitions/xray-embed-collapsed? {})))
+    (is (false? (transitions/xray-embed-collapsed? {:xray-embed-collapsed? nil}))))
+  (testing "explicit slot is read through"
+    (is (true?  (transitions/xray-embed-collapsed? {:xray-embed-collapsed? true})))
+    (is (false? (transitions/xray-embed-collapsed? {:xray-embed-collapsed? false})))))
+
+(deftest toggle-xray-embed-collapsed-flip
+  (testing "first toggle from default collapses (expanded → collapsed)"
+    (is (true? (transitions/xray-embed-collapsed?
+                 (transitions/toggle-xray-embed-collapsed {})))))
+  (testing "double toggle round-trips back to expanded"
+    (let [a (transitions/toggle-xray-embed-collapsed {})
+          b (transitions/toggle-xray-embed-collapsed a)]
+      (is (false? (transitions/xray-embed-collapsed? b))))))
+
+(deftest set-xray-embed-collapsed-coerces
+  (testing "set true / set false / coerce truthy"
+    (is (true?  (transitions/xray-embed-collapsed?
+                  (transitions/set-xray-embed-collapsed {} true))))
+    (is (false? (transitions/xray-embed-collapsed?
+                  (transitions/set-xray-embed-collapsed {:xray-embed-collapsed? true} false))))
+    (is (true?  (transitions/xray-embed-collapsed?
+                  (transitions/set-xray-embed-collapsed {} "truthy"))))))


### PR DESCRIPTION
STOP-valve follow-on from **rf2-ba86n.18** (#2493). The remaining spec/018 §10 perf item: lazy Xray-diff mounting.

## The change — defer mount + short-circuit compute

The RHS Xray embed (`ui/xray_embed`) already mounted ONE panel at a time with deferred microtask unmount (rf2-4l7t2), so the flood risk was already bounded. This upgrade defers the panel **MOUNT** itself — and therefore the panel's expensive diff compute (app-db structural diff, epoch timeline) — until the embed is **expanded**.

- **New `:xray-embed-collapsed?` shell slot** (defaults `false` = expanded, so the out-of-the-box RHS still paints the panel — no behaviour change for the common case). Pure transitions in `ui/state/transitions`: `xray-embed-collapsed?` / `toggle-xray-embed-collapsed` / `set-xray-embed-collapsed`, re-exported from `ui/state`.
- **`xray-embed-panel` gates the `panel-host-component` render on the collapsed state.** `panel-host-component` is the *sole* caller of `mount-fn-for` → `mount-<panel>!` (the fn that runs the diff). So while collapsed the embed renders only the cheap, pure-data chip-row picker plus a quiet placeholder — **no mount target, hence no diff compute**. The author's lens choice survives a collapse round-trip (the chips still paint; no Xray symbol is touched).
- **Reuse of the existing microtask-release path (not a new mechanism).** Collapsing drops the `panel-host-component` from the hiccup tree → its `:component-will-unmount` fires `release!`, which releases the Xray React root on the next microtask (rf2-4l7t2). No teardown is duplicated here.
- A chip-row **disclosure toggle** (chevron, rotates right→down) flips the slot; the collapsed placeholder is itself a click-to-expand affordance.

## The no-diff-on-collapsed test (acceptance)

`tools/story/test/re_frame/story/panels_e2e/xray_embed_e2e_cljs_test.cljs`:

- **`collapsed-embed-does-not-mount-panel-host`** — the acceptance gate. While collapsed the embed hiccup contains **NO `panel-host-component` slot** (the mount target the diff-compute path hangs off), so `mount-<panel>!` is never invoked and the panel's expensive diff is never computed. Also asserts the placeholder + chip-row survive the collapse, and that expanding restores the panel-host (mount + compute resume).
- **`disclosure-toggle-flips-collapsed-state`** — the toggle's `:on-click` round-trips the shell slot (expanded → collapsed → expanded), `aria-expanded` tracks it.
- Pure transition coverage added to `chrome_visibility_test.cljc` (default-expanded, toggle flip + round-trip, set coercion).

spec/018 §10: the lazy-Xray-diff perf item marked **CURRENT** (render-wired); only that item changed.

## Quality gates
- `clj-kondo --parallel --fail-level error --lint tools/story`: **0 errors** (124 pre-existing warnings in untouched files; none in changed files)
- `tools/story` `clojure -M:test`: 1492 tests, 5535 assertions, **0 failures, 0 errors**
- `npm run test:cljs`: 4998 tests, 16742 assertions, **0 failures, 0 errors, 0 warnings**
- `npm run test:bundle-isolation`: **PASS** — xray_embed stays out of production bundles
- `scripts/test-fast-pr.sh`: **PASS** (core JVM, JS harness helpers, CLJS node integration, README + docs-corpus anchor validators; mkdocs soft-skipped on Windows, CI runs it)