### PR TITLE
feat(core): redact sensitive/large values at log+telemetry sinks (rf2-6773q)

### DIFF
--- a/implementation/core/src/re_frame/marks.cljc
+++ b/implementation/core/src/re_frame/marks.cljc
@@ -673,6 +673,41 @@
           has-prev? (assoc :rf.sub/prev-value (redact-with-paths (:rf.sub/prev-value tags) sens large))
           prop-l?   (assoc :large? true))))))
 
+(defn- frame-has-declarations?
+  "True when `frame-id` carries any schema- or marks-sourced elision
+  declaration (sensitive or large). Cheap registry read used to gate
+  the full-db walk so the no-marks common case stays
+  reference-preserving (no `elide-wire-value` rebuild). Mirrors the
+  bead's `no extra work for values with no marks` constraint."
+  [frame-id]
+  (boolean (or (seq (elision/sensitive-declarations frame-id))
+               (seq (elision/declarations frame-id)))))
+
+(defn- project-db-tags
+  "Walk the `:rf.event/db` slot carried by the `:rf.event/db-pending`
+  (t1) and `:rf.event/db-pending-post-flow` (t2) trace events (router
+  `flows-after-interceptor`, rf2-ta0y7). The slot stamps the FULL
+  pending `app-db` value, so — unlike the per-registration event / fx /
+  cofx / sub slots — its declared paths are the FRAME's app-db elision
+  registry (schema `:sensitive?` / `:large?` plus `add-marks` /
+  `set-marks`), rooted at the db root. We route it through the schema-
+  first wire walker `re-frame.elision/elide-wire-value` — the SAME
+  normative emission site the epoch off-box `projected-record` uses for
+  `:db-before` / `:db-after` — so sensitive slots elide to `:rf/redacted`
+  and large slots to `:rf.size/large-elided` before the snapshot reaches
+  any trace listener or epoch-capture sink. Per rf2-6773q.
+
+  Gated on `frame-has-declarations?` so a frame with no marks keeps the
+  reference-identity the `:rf.event/db` stamp promises (rf2-ta0y7's
+  pointer-sized, copy-free posture) — the walker rebuilds maps, so we
+  must not invoke it when there is nothing to elide."
+  [tags frame-id]
+  (if (and (contains? tags :rf.event/db)
+           (frame-has-declarations? frame-id))
+    (assoc tags :rf.event/db
+           (elision/elide-wire-value (:rf.event/db tags) {:frame frame-id}))
+    tags))
+
 (defn- project-machine-tags
   "Walk machine-snapshot tag shapes (`:rf.machine/transition`,
   `:rf.machine/snapshot-updated`): `:before` and `:after` are full
@@ -733,6 +768,12 @@
 
                       (and (map? tags) (contains? tags :rf.event/coeffects))
                       (project-cofx-tags)
+
+                      ;; The t1 / t2 pending-`:db` emits stamp the full
+                      ;; app-db under `:rf.event/db`; redact against the
+                      ;; frame's elision registry (rf2-6773q).
+                      (and (map? tags) (contains? tags :rf.event/db))
+                      (project-db-tags frame-id)
 
                       (and (map? tags) (= :rf.cofx/run operation))
                       (project-cofx-run-tags)

--- a/implementation/core/test/re_frame/marks_test.clj
+++ b/implementation/core/test/re_frame/marks_test.clj
@@ -242,6 +242,89 @@
       (is (= :rf/redacted (nth ev 1))))
     (trace-tooling/unregister-listener! :whole)))
 
+;; ---- :rf.event/db (t1/t2 pending-db snapshot) redaction (rf2-6773q) ------
+;;
+;; The `:rf.event/db-pending` (t1) and `:rf.event/db-pending-post-flow`
+;; (t2) trace events stamp the FULL pending `app-db` under `:tags
+;; :rf.event/db` (router `flows-after-interceptor`, rf2-ta0y7). Because
+;; the slot carries the whole db, its declared paths are the FRAME's
+;; app-db elision registry — schema `:sensitive?` / `:large?` plus
+;; `add-marks` / `set-marks` — rooted at the db root. The marks
+;; chokepoint routes the slot through `elide-wire-value` so sensitive
+;; slots elide BEFORE the snapshot reaches any trace listener / epoch
+;; sink. NB: a handler that REPLACES app-db wipes `[:rf/runtime
+;; :elision]`, so we seed, then mark, then write into the marked path
+;; (mirrors `sub-auto-propagates-when-app-db-has-sensitive-marks`).
+
+(deftest db-pending-sensitive-app-db-path-redacts
+  (rf/reg-event-db :db/seed (fn [_ _] {:user {:ssn nil :name "A"}}))
+  (rf/dispatch-sync [:db/seed])
+  (rf/set-marks :rf/default {[:user :ssn] :sensitive})
+  (rf/reg-event-db :db/write-ssn
+    (fn [db _] (assoc-in db [:user :ssn] "123-45-6789")))
+  (let [traces (collect-traces! :db-sensitive)]
+    (rf/dispatch-sync [:db/write-ssn])
+    (let [[t1] (filterv #(= :rf.event/db-pending (:operation %)) @traces)
+          db   (-> t1 :tags :rf.event/db)]
+      (is (some? t1) ":rf.event/db-pending fired")
+      (is (= :rf/redacted (get-in db [:user :ssn]))
+          "the sensitive app-db slot is redacted in the t1 db snapshot")
+      (is (= "A" (get-in db [:user :name]))
+          "an unmarked sibling slot passes through unchanged"))
+    (trace-tooling/unregister-listener! :db-sensitive)))
+
+(deftest db-pending-large-app-db-path-emits-marker
+  (rf/reg-event-db :db/seed (fn [_ _] {:docs {:csv nil :note "ok"}}))
+  (rf/dispatch-sync [:db/seed])
+  (rf/set-marks :rf/default {[:docs :csv] :large})
+  (let [big (apply str (repeat 500 "X"))]
+    (rf/reg-event-db :db/write-csv
+      (fn [db _] (assoc-in db [:docs :csv] big)))
+    (let [traces (collect-traces! :db-large)]
+      (rf/dispatch-sync [:db/write-csv])
+      (let [[t1] (filterv #(= :rf.event/db-pending (:operation %)) @traces)
+            slot (-> t1 :tags :rf.event/db (get-in [:docs :csv]))]
+        (is (some? t1) ":rf.event/db-pending fired")
+        (is (elision/marker? slot)
+            "the large app-db slot elides to an :rf.size/large-elided marker")
+        (is (= [:docs :csv] (get-in slot [:rf.size/large-elided :path])))
+        (is (= "ok" (-> t1 :tags :rf.event/db (get-in [:docs :note])))
+            "an unmarked sibling slot passes through unchanged"))
+      (trace-tooling/unregister-listener! :db-large))))
+
+(deftest db-pending-unmarked-db-passes-through-by-reference
+  ;; No marks / declarations on the frame → the t1 `:rf.event/db` stamp
+  ;; is the SAME persistent reference the handler returned (rf2-ta0y7's
+  ;; copy-free posture). The marks chokepoint must NOT rebuild the value
+  ;; when there is nothing to elide.
+  (let [payload {:counter 1 :nested {:k :v}}]
+    (rf/reg-event-db :db/return-shared (fn [_ _] payload))
+    (let [traces (collect-traces! :db-unmarked)]
+      (rf/dispatch-sync [:db/return-shared])
+      (let [[t1] (filterv #(= :rf.event/db-pending (:operation %)) @traces)]
+        (is (some? t1) ":rf.event/db-pending fired")
+        (is (identical? payload (-> t1 :tags :rf.event/db))
+            "unmarked db snapshot is the same reference (no walk, no copy)"))
+      (trace-tooling/unregister-listener! :db-unmarked))))
+
+(deftest db-pending-schema-sensitive-app-db-path-redacts
+  ;; Schema-sourced `:sensitive?` slot metadata (not add-marks) also
+  ;; drives the t1 db-snapshot redaction — the schema + marks sources
+  ;; union at the elision registry, and the chokepoint reads the same
+  ;; registry via `elide-wire-value`.
+  (rf/reg-app-schema [:auth]
+                     [:map [:token {:sensitive? true} [:maybe :string]]])
+  (rf/populate-sensitive-from-schemas!)
+  (rf/reg-event-db :db/login
+    (fn [db _] (assoc-in db [:auth :token] "Bearer xyz")))
+  (let [traces (collect-traces! :db-schema-sensitive)]
+    (rf/dispatch-sync [:db/login])
+    (let [[t1] (filterv #(= :rf.event/db-pending (:operation %)) @traces)]
+      (is (some? t1) ":rf.event/db-pending fired")
+      (is (= :rf/redacted (-> t1 :tags :rf.event/db (get-in [:auth :token])))
+          "the schema-declared sensitive slot is redacted in the db snapshot"))
+    (trace-tooling/unregister-listener! :db-schema-sensitive)))
+
 ;; ---- redact-with-paths primitive ---------------------------------------
 
 (deftest redact-with-paths-walks-nested


### PR DESCRIPTION
## What

Closes the one genuine gap in CORE's log/telemetry redaction surface (rf2-6773q): the **pending-`:db` trace snapshots** stamped the full raw `app-db` under `:tags :rf.event/db` without routing it through the redaction walker.

The `:rf.event/db-pending` (t1) and `:rf.event/db-pending-post-flow` (t2) trace events (router `flows-after-interceptor`, rf2-ta0y7) carry the **entire pending app-db** under `:tags :rf.event/db`. The marks-projection chokepoint (`re-frame.marks/project-trace-event`) walked every other value-bearing tag slot — event args (`:rf.event/v`/`:event`), fx args (`:rf.fx/args`), cofx values (`:rf.event/coeffects`/`:rf.cofx/value`), sub outputs (`:rf.sub/value`), machine snapshots — but had **no branch for `:rf.event/db`**. So any frame with schema `:sensitive?`/`:large?` slots or `add-marks`/`set-marks` declarations leaked the raw app-db at those slots to every trace listener and the epoch-capture buffer.

The fix reuses the existing policy (no new redaction logic): `project-trace-event` now routes the `:rf.event/db` slot through `re-frame.elision/elide-wire-value` against the frame — the **same normative emission site** the epoch off-box `projected-record` uses for `:db-before`/`:db-after`. The slot carries the whole db rooted at the db root, so its declared paths are exactly the per-frame `[:rf/runtime :elision]` registry (schema + marks, unioned). Sensitive slots elide to `:rf/redacted`, large slots to `:rf.size/large-elided`, before the snapshot reaches any sink.

Gated on a cheap `frame-has-declarations?` registry read so the no-marks common case stays **reference-preserving** — `elide-wire-value`'s walker rebuilds maps, so it is only invoked when there is something to elide. rf2-ta0y7's copy-free, pointer-sized `:db` stamp is unchanged for unmarked frames.

## Audit table (CORE log / telemetry / trace sinks)

| Sink | Carries raw sensitive/large value? | Status |
|---|---|---|
| `re-frame.trace/emit!` + `emit-error!` (all trace) | routes through `build-event` -> `maybe-project-marks` -> `project-trace-event` | **covered** (chokepoint) |
| `:rf.event/db-pending` / `:rf.event/db-pending-post-flow` (`:rf.event/db` = full app-db) | **YES — full app-db, slot not walked** | **FIXED** |
| `:rf.event/dispatched` / `:event/db-changed` (`:rf.event/v`) | event vector | already covered (`project-event-tags`) |
| `:rf.fx/handled` (`:rf.fx/args`) | fx args | already covered (`project-fx-tags`) |
| cofx (`:rf.event/coeffects`, `:rf.cofx/run`) | cofx values | already covered |
| `:rf.sub/run` (`:rf.sub/value`/`:prev-value`) | sub output | already covered (`project-sub-tags`) |
| machine ops (`:before`/`:after`/`:snapshot`) | snapshot | already covered (`project-machine-tags`) |
| `re-frame.error-emit/dispatch-on-error!` tight record (`:event`) | event vector for off-box shippers | already covered (`elide-wire-value`) |
| `re-frame.event-emit/dispatch-on-event!` record (`:event`) | event vector for off-box shippers | already covered (`elide-wire-value`) |
| router handler-exception trace `tags :event` | interceptor-redacted (`:rf/redacted-event`) + marks chokepoint | already covered |
| `:on-error` policy-event `tags :event` | interceptor-redacted `emit-event` (in-app recovery surface, not a log sink) | verified — interceptor-redacted; off-box record path elides separately |
| epoch on-box ring buffer / `register-epoch-listener!` (raw record) | **intentionally raw** (on-box devtools / `restore-epoch`); off-box egress uses `projected-record` (epoch artefact, not core) | by-design, NON-goal |
| `views/warn_once.cljs`, `substrate/spine.cljs` `console.warn` | only reg-ids + React element type tags | no value carried |
| `interop` log fns (`.cljs`/`.clj`) | no value-logging fn exists | n/a |

Net: **1 fixed**, all other CORE sinks verified covered or by-design out of scope (the bead's NON-goal: human-facing / on-box egress).

## Quality gates

| Command | Result |
|---|---|
| `clojure -M:test` (core JVM, from `implementation/core`) | **799 tests, 3527 assertions, 0 failures, 0 errors** |
| `npm run test:cljs` (node-runtime CLJS contract, from `implementation/`) | **4998 tests, 16742 assertions, 0 failures, 0 errors** |
| `clj-kondo --fail-level error --lint implementation/core/src` | **0 errors** (186 pre-existing warnings; none in `marks.cljc` are new) |
| `npm run test:elision` (production elision probe) | **PASS — production 40/40 absent; control 40/40 present** |

## Tests added (`marks_test.clj`)

- `db-pending-sensitive-app-db-path-redacts` — `set-marks {[:user :ssn] :sensitive}`, write to that path, assert t1 `:rf.event/db` shows `:rf/redacted` at the slot and an unmarked sibling passes through.
- `db-pending-large-app-db-path-emits-marker` — `set-marks {[:docs :csv] :large}`, assert the slot elides to an `:rf.size/large-elided` marker.
- `db-pending-schema-sensitive-app-db-path-redacts` — schema `{:sensitive? true}` slot metadata drives the same redaction (schema source, not marks).
- `db-pending-unmarked-db-passes-through-by-reference` — unmarked frame: t1 `:rf.event/db` is the **same persistent reference** (no walk, no copy), preserving rf2-ta0y7's posture.

Spec note: Spec 015 L505/L545 model the db-bearing trace slot as `:tags :app-db-after`; the reference implementation carries the db value on the t1/t2 `:rf.event/db` slot (the `:event/db-changed` trace carries only `:rf.event/v`). The redaction obligation attaches wherever the db value actually rides — `:rf.event/db` — which is what this PR walks. Flagged for a possible spec-vs-impl slot-name reconciliation, but no contract change needed: the redaction outcome (sensitive db slots elide before any sink) now holds.