### PR TITLE
docs(story): purge retired :play-script/:passing? as canonical across API/spec/skills/fixture (rf2-x50zc + rf2-58blj + rf2-0wir5)

### DIFF
--- a/docs/story/index.md
+++ b/docs/story/index.md
@@ -30,7 +30,7 @@ The Story loop:
 2. Click each state in the left sidebar. The canvas swaps in 30ms.
 3. Open a workspace that mounts all five side-by-side; design review against the grid.
 4. Switch to *Tests* mode; every variant's `:script` assertions run automatically; the sidebar dots flip green.
-5. Click *record* on the canvas toolbar, tap through the form once, click *stop*; out comes an EDN `:play-script` body that captures exactly what you just did. Paste it into the variant.
+5. Click *record* on the canvas toolbar, tap through the form once, click *stop*; out comes an EDN `:script` body that captures exactly what you just did (the recorder currently emits the transitional `:play-script` spelling, which the registrar lowers to `:script`). Paste it into the variant.
 6. Ship.
 
 If you've used Storybook 9 the rough shape is going to look familiar — record-and-replay is their flagship feature too. Where it diverges:

--- a/skills/re-frame2/references/tooling/story-mcp-loop.md
+++ b/skills/re-frame2/references/tooling/story-mcp-loop.md
@@ -90,7 +90,7 @@ Loop terminates. The agent reports the final variant body back to the user.
 
 - **Write surface is gated.** `register-variant` / `unregister-variant` require `re-frame.story-mcp.config/allow-writes?` truthy — set via `--allow-writes` flag, `RF_STORY_MCP_ALLOW_WRITES=true` env, or `-Drf.story-mcp.allow-writes=true` JVM property. Without it the loop is read-only (`run-variant` + `read-failures` still work against existing variants).
 - **`register-variant`'s parent story must already exist.** v1.1 omits `register-story` deliberately. The agent fails into a documented error when the `:story.<path>` parent isn't registered; the user lands the parent inline.
-- **`read-failures` does not re-run.** It reads the last-run accumulator. Pair with `run-variant` per iteration; do not assume an old `:passing? false` reflects the current body.
+- **`read-failures` does not re-run.** It reads the last-run accumulator. Pair with `run-variant` per iteration; do not assume an old `:status :fail` reflects the current body.
 
 ## Common gotchas — loop-specific
 

--- a/tools/story-mcp/spec/002-Tool-Registry.md
+++ b/tools/story-mcp/spec/002-Tool-Registry.md
@@ -460,15 +460,17 @@ contract per
 §Test Codegen.
 
 Optional `:write-back` re-registers the source variant with the
-captured recording translated to a live `:play-script` body via
+captured recording translated to a live play body via
 `reg-variant*` (preserving the existing `:component`, `:args`,
 `:decorators`, etc.). The translation routes through
 `re-frame.story/recording->play-script` — each captured event becomes
-a `[:dispatch ...]` step under `:play-script {:script [...]}`, the
-canonical AND ONLY phase-4 replay slot (per rf2-0wrud; the legacy
-`:play` slot was removed and no runner executes it). This branch is
-gated behind the same `allow-writes?` flag as `register-variant`; the
-read-only path (snippet only) needs no gate.
+a `[:dispatch ...]` step under `:play-script {:script [...]}`. The
+emitted `:play-script` is the transitional spelling the registrar
+lowers; `:script` is the public phase-4 name (spec/017 §Public
+vocabulary). The legacy `:play` slot was removed (rf2-0wrud) and no
+runner executes it. This branch is gated behind the same
+`allow-writes?` flag as `register-variant`; the read-only path
+(snippet only) needs no gate.
 
 Wire-key shape (rf2-pmwgn): the input-schema property key is
 `:write-back` (no `?`) — the same Anthropic `^[a-zA-Z0-9_.-]{1,64}$`

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/recorder.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/recorder.cljc
@@ -12,9 +12,10 @@
   suppression) — see `re-frame.story.recorder/recordable-event?`.
 
   Optional `:write-back` re-registers the source variant with the
-  captured recording translated to a live `:play-script` slot (the
-  canonical AND ONLY phase-4 replay surface per rf2-0wrud) — gated by
-  the same `allow-writes?` flag as `register-variant`
+  captured recording translated to a live play slot. The emitted EDN
+  uses the transitional `:play-script` spelling the registrar lowers;
+  `:script` is the public phase-4 name (spec/017 §Public vocabulary).
+  This is gated by the same `allow-writes?` flag as `register-variant`
   (`tools.write/assert-writes-allowed`). This is
   the self-healing-loop hook the spec mentions: agent drives canvas →
   tool returns snippet AND patches the variant in place.
@@ -71,10 +72,12 @@
   `:play-script` with the translated, replayable script.
 
   Per rf2-50jzf the legacy `:play` slot was REMOVED for `:play-script`
-  in rf2-0wrud — `:play-script` is the canonical AND ONLY phase-4
-  replay surface (tools/story schemas.cljc). Writing a `:play` key
-  would pass the open variant `:map` validation but no runner executes
-  it, so a written-back recording would silently never replay. We
+  in rf2-0wrud — `:play-script` is the only phase-4 replay slot the
+  schema accepts today (tools/story schemas.cljc), the transitional
+  spelling the registrar lowers to the public `:script` key (spec/017
+  §Public vocabulary). Writing a `:play` key would pass the open variant
+  `:map` validation but no runner executes it, so a written-back
+  recording would silently never replay. We
   translate the captured `events` via `story/recording->play-script`
   (the live runtime counterpart to `gen-play-snippet`'s text output)
   and write that under `:play-script`.

--- a/tools/story-mcp/test/re_frame/story_mcp/tools/dedup_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools/dedup_test.clj
@@ -139,10 +139,11 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Reduction-ratio sanity. The bead requires a non-trivial ratio on a
-;; realistic story-mcp fixture; we assert against the canonical run-
+;; realistic story-mcp fixture; we assert against the current run-
 ;; variant shape (`:app-db` + `:rendered-hiccup` + `:snapshot` carrying
 ;; the same large nested map) since that's the wire surface this work
-;; targets.
+;; targets. The deduper is shape-agnostic — it collapses repeated big-db
+;; refs regardless of the surrounding verdict keys.
 ;; ---------------------------------------------------------------------------
 
 (deftest reduction-ratio-run-variant-shape
@@ -163,8 +164,8 @@
                                     :expected  big-db
                                     :actual    big-db}]
                  :elapsed-ms      42
-                 :lifecycle       :ok
-                 :passing?        true}
+                 :lifecycle       :ready
+                 :status          :pass}
         raw-size (count (pr-str payload))
         wrapped (dedup/dedup-value payload true)
         wrapped-size (count (pr-str wrapped))]

--- a/tools/story/spec/001-Authoring.md
+++ b/tools/story/spec/001-Authoring.md
@@ -437,9 +437,9 @@ to what the legacy `:play` slot delivered.
 
 Two body shapes are accepted:
 
-- **Bare vector** — `:play-script [[:dispatch-sync [:foo]] ...]`
+- **Bare vector** — `:script [[:dispatch-sync [:foo]] ...]`
   shorthand for `{:script <vector> :auto-run? true}`.
-- **Map**       — `:play-script {:script [...] :auto-run? bool :name str}`
+- **Map**       — `:script {:script [...] :auto-run? bool :name str}`
   for explicit opt-out of auto-run on mount or naming the play.
 
 The runner's `coerce-script` also tolerates bare event vectors at the

--- a/tools/story/spec/API.md
+++ b/tools/story/spec/API.md
@@ -128,13 +128,14 @@ declarative bulk-set form for the same vector; `reg-global-decorator`
 is the register-and-opt-in-in-one-call form. `clear-all!` clears the
 global vector so stale ref-by-id entries don't bleed across tests.
 
-## Variant `:play-script` slot (rf2-0wrud)
+## Variant `:script` slot (rf2-0wrud)
 
-`:play-script` is the canonical AND ONLY phase-4 play surface
-(rf2-0wrud, 2026-05-20). The legacy `:play` event-vector slot has been
-removed — pre-alpha posture, no transitional dual-acceptance. See
-[`001-Authoring.md`](001-Authoring.md) §:play-script for the full
-authoring contract.
+`:script` is the public phase-4 play surface (spec/017
+§Public vocabulary). `:play-script` is the transitional spelling the
+registrar still lowers from — author against `:script`. The legacy
+`:play` event-vector slot has been removed — pre-alpha posture, no
+transitional dual-acceptance. See [`001-Authoring.md`](001-Authoring.md)
+§`:script` for the full authoring contract.
 
 | Step                                 | Semantics                                                  |
 |--------------------------------------|------------------------------------------------------------|
@@ -149,10 +150,11 @@ authoring contract.
 | `[:click selector]`                  | Synthetic click event at selector                          |
 | `[:type selector text]`              | Synthetic input event at selector with `text`              |
 
-Body forms:
+Body forms (shown against the public `:script` key; the registrar
+lowers the transitional `:play-script` spelling to the same shape):
 
-- Bare vector — `:play-script [[:dispatch-sync [:foo]] ...]`
-- Map         — `:play-script {:script [...] :auto-run? bool :name str}`
+- Bare vector — `:script [[:dispatch-sync [:foo]] ...]`
+- Map         — `:script {:script [...] :auto-run? bool :name str}`
 
 The canonical seven `:rf.assert/*` events (per
 [`004-Assertions.md`](004-Assertions.md)) ride the `:dispatch-sync`
@@ -168,10 +170,12 @@ The pure runner lives at
 
 ## Recorder facade
 
-The recorder captures canvas-dispatched events into a `:play-script`
-body for codegen back into a `reg-variant` snippet. The facade
-exposes six entries on `re-frame.story` (per spec/005 §Recorder +
-[001-Authoring.md](001-Authoring.md) §Recorder); the richer
+The recorder captures canvas-dispatched events into a play body for
+codegen back into a `reg-variant` snippet. The emitted EDN uses the
+transitional `:play-script` spelling the registrar lowers; `:script` is
+the public phase-4 key authors target (spec/017 §Public vocabulary).
+The facade exposes six entries on `re-frame.story` (per spec/005
+§Recorder + [001-Authoring.md](001-Authoring.md) §Recorder); the richer
 recorder-driven `:play-script` translator (rf2-d5u89 — derives `:click`
 / `:type` / `:wait` steps from the recorder's `:entries` stream) lives
 under the recorder's sub-namespace.


### PR DESCRIPTION
Doc/prose/fixture sweep that purges the **retired public vocabulary** (`:play-script` / `:passing?`) wherever it was still presented as the *canonical / target / public* form. Aligns those surfaces to `tools/story/spec/017-Testing-Story.md §Public vocabulary`: `:script` is the public phase-4 name (`:play-script` is the transitional spelling the registrar lowers); `:status` (not `:passing?`) is the run-result verdict. No executable logic changes — emission stays correct, the deduper test stays green and shape-agnostic.

Scoped to surfaces presenting the OLD name as canonical/target. Accurate-to-current-behaviour references that describe `:play-script` as the *shipping* runner/recorder slot (002-Runtime, 004, 005-SOTA, 009-Test-Mode, story.cljc, recorder.cljc runner notes, docs/story/api/play-script.md) are deliberately **left as-is** — out of scope.

## Per-bead checklist

### rf2-x50zc — Story public-vocab doc sweep
- [x] `tools/story/spec/API.md` — renamed `## Variant :play-script slot` → `## Variant :script slot`; present `:play-script` as the transitional spelling the registrar lowers; kept the lowering note; switched the two body-form examples to `:script`; added a §Public-vocabulary cross-ref to the recorder-facade prose so a reader isn't left thinking `:play-script` is the target.
- [x] `tools/story/spec/001-Authoring.md` — within the already-migrated §`:script` section, switched the "Two body shapes are accepted" examples from `:play-script [[...]]` / `:play-script {...}` to `:script`.
- [x] `docs/story/index.md` — qualified Story-loop step 5 so the slot is named `:script` (noting the recorder currently emits the transitional `:play-script` spelling the registrar lowers), removing the step-4/step-5 inconsistency.

### rf2-58blj — story-mcp recorder/spec residue
- [x] `tools/story-mcp/src/re_frame/story_mcp/tools/recorder.cljc` — reworded the ns docstring (`:16`) and `write-back!` docstring (`:73-75`) "canonical AND ONLY phase-4 surface" claims to mirror §Public vocabulary; honest about the recorder still EMITTING the transitional `:play-script`.
- [x] `tools/story-mcp/spec/002-Tool-Registry.md` — reworded the `:write-back` paragraph (`:468`) the same way.

### rf2-0wir5 — un-migrated :passing?
- [x] `skills/re-frame2/references/tooling/story-mcp-loop.md` — prereq bullet (`:93`) `:passing? false` → `:status :fail`.
- [x] `tools/story-mcp/test/re_frame/story_mcp/tools/dedup_test.clj` — migrated the synthetic fixture to the unified shape (`:status :pass`, `:lifecycle :ready`, dropped `:passing?` and the retired `:lifecycle :ok` verdict-lifecycle) and reworded the "canonical run-variant shape" comment. `:lifecycle :ready` is the unified loader-state value (matches 002-Tool-Registry.md, API.md, dev.cljc, tools_test.clj). Deduper is shape-agnostic — test intent + green status preserved.

## Quality gates

| Gate | Command | Result |
|---|---|---|
| story-mcp tests | `clojure -M:test` (from `tools/story-mcp/`) | **GREEN** — 175 tests, 898 assertions, 0 failures, 0 errors |
| clj-kondo | `clj-kondo --fail-level error --lint tools/story-mcp/src` | **0 errors** (20 pre-existing warnings, none from this change) |
| docs build | `python -m mkdocs build --strict` (repo root) | **PASS** — built in 8.26s, exit 0 (only pre-existing INFO notices) |
| mcp-conformance | `npm --prefix implementation run test:mcp-conformance` | **ALL GREEN** — incl. wire-vocab 48 tests / 600 assertions, 0 failures |

Refs rf2-x50zc + rf2-58blj + rf2-0wir5.
