### PR TITLE
fix(xray): wrap shell-view in its frame-provider at mount so it stops leaking into the inspected frame's epoch :renders (rf2-tqlmq)

### DIFF
--- a/implementation/epoch/test/re_frame/epoch_attribution_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_attribution_test.clj
@@ -67,6 +67,18 @@
            unlike the post-settle render / sub-run / mount cases (back-filled
            to their CAUSING cascade), an orphan belongs to NO cascade and is
            dropped at the capture seam.
+    inv-7  a tool / inspector frame's OWN render (a view rendered under a
+           `:rf.trace/frame-no-emit? true` frame) never lands in the INSPECTED
+           app frame's epoch `:renders` — the frame-no-emit gate suppresses the
+           render-trace emit at source, so no back-fill ever runs (rf2-tqlmq,
+           the cross-frame / observer sibling of inv-3). The defect: Xray's
+           own `shell-view` rendered ONE LEVEL ABOVE its `:rf/xray`
+           frame-provider, so its `:rf.view/rendered` carried `:frame :rf/default`
+           (fall-through) and back-filled into the inspected app's boot epoch.
+           The fix wraps `shell-view` in the frame-provider AT THE MOUNT so its
+           render resolves to the trace-disabled frame; this invariant pins that
+           the gate then suppresses the emit (so the observer cannot pollute the
+           observed tape).
 
   Supporting cases pin the boundary behaviour each fix also relies on:
   in-flight emits ride their own cascade (not back-filled); the back-fill
@@ -102,6 +114,11 @@
   (reset! schemas/schemas-by-frame {})
   (flows/reset-last-inputs!)
   (trace/clear-listeners!)
+  ;; rf2-tqlmq — the per-frame trace-emission gate (`:rf.trace/frame-no-emit?`)
+  ;; is process-sticky (it tracks frame registrations, which `reset! frames {}`
+  ;; does not unwind). inv-7 registers a trace-disabled observer frame; clear
+  ;; the set between tests so a prior case's registration cannot leak in.
+  (trace/clear-frame-no-emit!)
   (epoch/clear-history!)
   (epoch/clear-epoch-listeners!)
   (reset! @#'state/config {:depth 50 :trace-events-keep 5 :redact-fn nil})
@@ -789,6 +806,102 @@
             "the child's dispatch-id marker stays buffered for the child's own
              settle; the nil-id orphan is discarded")
         (state/drop-frame-buffer! frame)))))
+
+;; ===========================================================================
+;; INVARIANT 7 — a tool / inspector frame's OWN render never pollutes the
+;;                INSPECTED app frame's epoch :renders (rf2-tqlmq — the
+;;                cross-frame / observer sibling of inv-3)
+;; ===========================================================================
+;;
+;; The LIVE repro (build :examples/button-deck): the :rf/default boot epoch's
+;; :renders carried ["shell-view" 27] (mount + update) — Xray's OWN shell-view,
+;; the observer, leaking into the observed app's render tape. Root cause:
+;; `shell-view` is a `reg-view` (its :rf.view/rendered carries
+;; `(provider/current-frame)`), but mount.cljs rendered it BARE — its own
+;; `[frame-provider {:frame :rf/xray}]` sat INSIDE its body around the panels —
+;; so `shell-view`'s OWN render resolved `current-frame` to `:rf/default` by
+;; fall-through and back-filled into the inspected app's boot epoch.
+;;
+;; The fix (mount-wrap) moves the provider OUT one level so `shell-view`'s own
+;; render resolves to the trace-disabled `:rf/xray` frame. This invariant pins
+;; the load-bearing consequence: a `:rf.view/rendered` tagged with a
+;; `:rf.trace/frame-no-emit? true` frame is SUPPRESSED at `trace/emit!` (the
+;; gate keys off the emit's `:frame` tag — trace.cljc/`tagged-frame-trace-
+;; disabled?`), so the back-fill machinery never even sees it and the observed
+;; frame's :renders stays clean. The contrapositive case proves the test
+;; discriminates: the SAME render, were it tagged with the app frame
+;; (the pre-fix fall-through), DOES land — i.e. the suppression, not some
+;; unrelated filter, is what keeps the tape clean.
+
+(deftest inv-7-tool-frame-render-does-not-pollute-inspected-app-epoch
+  (testing "rf2-tqlmq — a render emitted under a trace-disabled (tool /
+            inspector) frame, while an APP frame has a settled epoch in flight,
+            does NOT land in the app frame's epoch :renders. The frame-no-emit
+            gate suppresses the emit at source so no back-fill runs. The
+            cross-frame / observer sibling of inv-3 (whose lag was WITHIN one
+            frame; this leak is ACROSS frames — observer into observed)."
+    (let [app      :test/app
+          observer :test/observer]
+      ;; Mirror the runtime: the observer frame registers
+      ;; `:rf.trace/frame-no-emit? true` (what `mount/ensure-xray-frame!` does
+      ;; for `:rf/xray`); reg-frame routes the flag to the trace gate.
+      (rf/reg-frame app {})
+      (rf/reg-frame observer {:rf.trace/frame-no-emit? true})
+      (is (trace/frame-trace-disabled? observer)
+          "the observer frame is registered trace-disabled (reg-frame honoured
+           :rf.trace/frame-no-emit?)")
+      (is (not (trace/frame-trace-disabled? app))
+          "the inspected app frame is NOT trace-disabled")
+
+      (rf/reg-event-db :app/seed (fn [_ _] {:counter 0}))
+      (rf/reg-event-db :app/inc  (fn [db _] (update db :counter inc)))
+
+      ;; The app frame produces a boot epoch (a last-settled epoch the
+      ;; back-fill would attribute to).
+      (rf/dispatch-sync [:app/seed] {:frame app})
+      (rf/dispatch-sync [:app/inc]  {:frame app})
+      (let [app-epoch (last-epoch app)]
+        ;; The observer's OWN render fires post-settle (React-commit timing),
+        ;; tagged with the observer frame — exactly what the mount-wrap makes
+        ;; `shell-view`'s render carry. The gate must suppress it.
+        (emit-render! observer :shell-view)
+
+        (let [e (epoch-by-id app app-epoch)]
+          (is (= :app/inc (:event-id e))
+              "the app frame's last epoch is its own :app/inc cascade")
+          (is (not (contains? (rendered-view-ids e) :shell-view))
+              "the inspector's shell-view render did NOT leak into the
+               inspected app frame's epoch :renders — the frame-no-emit gate
+               suppressed the emit before any back-fill (rf2-tqlmq)")
+          (is (empty? (rendered-view-ids e))
+              "the app frame's epoch carries NO renders at all from the
+               observer's post-settle commit — the observer is invisible to the
+               observed tape"))))))
+
+(deftest inv-7-contrapositive-untagged-render-still-back-fills
+  (testing "rf2-tqlmq — the discriminator. The SAME post-settle render, were it
+            tagged with the APP frame (the PRE-fix fall-through: shell-view
+            rendering above its provider resolved to the app's :rf/default), DOES
+            back-fill into the app epoch. Proves inv-7's clean result is the
+            frame-no-emit SUPPRESSION at work, not an unrelated filter — and is
+            the exact leak the bug exhibited."
+    (let [app :test/app]
+      (rf/reg-frame app {})
+      (rf/reg-event-db :app/seed (fn [_ _] {:counter 0}))
+      (rf/reg-event-db :app/inc  (fn [db _] (update db :counter inc)))
+
+      (rf/dispatch-sync [:app/seed] {:frame app})
+      (rf/dispatch-sync [:app/inc]  {:frame app})
+      (let [app-epoch (last-epoch app)]
+        ;; Render tagged with the APP frame (NOT trace-disabled) — the pre-fix
+        ;; fall-through. This is precisely the leak the live repro showed.
+        (emit-render! app :shell-view)
+
+        (let [e (epoch-by-id app app-epoch)]
+          (is (contains? (rendered-view-ids e) :shell-view)
+              "a render tagged with the (non-disabled) app frame DOES back-fill
+               into the app epoch — this is the leak the mount-wrap fixes by
+               retagging shell-view's render with the trace-disabled frame"))))))
 
 ;; ===========================================================================
 ;; rf2-8wrzz.1 — the :renders projection carries per-view cause + timing

--- a/tools/xray/src/day8/re_frame2_xray/mount.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/mount.cljs
@@ -264,7 +264,24 @@
 
 (defn- mount-shell-into! [node mode]
   (ensure-xray-frame!)
-  (let [unmount (substrate-adapter/render [shell/shell-view {:mode mode}] node nil)]
+  ;; rf2-tqlmq — wrap `shell-view` ITSELF in the shell's frame-provider at
+  ;; the mount so the whole shell (not just its panels) renders in the
+  ;; Xray frame. `shell-view` is a `reg-view`, so its `:rf.view/rendered`
+  ;; trace carries `(provider/current-frame)`; rendered BARE (no enclosing
+  ;; provider — its own provider sits INSIDE its body, around the panels)
+  ;; `current-frame` fell through to `:rf/default`, so the shell-view's own
+  ;; render trace leaked into the inspected app frame's epoch `:renders`.
+  ;; With the provider moved out one level, `shell-view`'s render resolves
+  ;; to `default-frame-id` (the trace-disabled `:rf/xray` frame registered
+  ;; by `ensure-xray-frame!` just above) and the existing
+  ;; `:rf.trace/frame-no-emit?` gate (trace.cljc/`tagged-frame-trace-
+  ;; disabled?`, which keys off the render emit's `:frame` tag) suppresses
+  ;; it. Threads the shell's actual frame-id (NOT a `:rf/xray` literal),
+  ;; matching the frame `ensure-xray-frame!` registered.
+  (let [unmount (substrate-adapter/render
+                  [rf/frame-provider {:frame shell/default-frame-id}
+                   [shell/shell-view {:mode mode}]]
+                  node nil)]
     (set-mode-attrs! node mode)
     (reset! mount-state
             {:node     node
@@ -955,7 +972,18 @@
               (set! (.-id node) "rf-xray-popout-root")
               (.setAttribute node "data-rf-xray-mode" "popout")
               (.appendChild body node)
-              (let [unmount      (substrate-adapter/render [shell/shell-view {:mode :popout}] node nil)
+              (let [unmount      (substrate-adapter/render
+                                    ;; rf2-tqlmq — same mount-wrap as
+                                    ;; `mount-shell-into!`: wrap the popout
+                                    ;; shell in the shell's frame-provider so
+                                    ;; its own `:rf.view/rendered` trace
+                                    ;; resolves to the trace-disabled Xray
+                                    ;; frame instead of falling through to
+                                    ;; `:rf/default` and leaking into the
+                                    ;; inspected app frame's epoch `:renders`.
+                                    [rf/frame-provider {:frame shell/default-frame-id}
+                                     [shell/shell-view {:mode :popout}]]
+                                    node nil)
                     overlay-node (install-opener-gone-overlay! doc)
                     watchdog-id  (start-opener-gone-watchdog! win overlay-node)
                     state        {:ok?          true


### PR DESCRIPTION
## What & why

Xray's own `day8.re-frame2-xray.shell/shell-view` was appearing in the **inspected** app frame's epoch `:renders` (observed live on `:examples/button-deck`: the `:rf/default` boot epoch carried `["shell-view" 27]` as both a mount and an update). The observer was polluting the observed app's render tape — any render-count / over-render reasoning off the Views lens was inflated by Xray's chrome.

**Root cause.** `shell-view` is a `reg-view`, so its `:rf.view/rendered` trace carries `(provider/current-frame)`. Both mount paths rendered it **bare** — its own `[rf/frame-provider {:frame :rf/xray} …]` sat *inside* its body, wrapping only the panels — so `shell-view`'s own render resolved `current-frame` to `:rf/default` by fall-through. The panels (inside the provider) resolved to `:rf/xray` and were correctly suppressed; `shell-view` itself was not.

**Fix (targeted mount-wrap).** Move the provider out one level: wrap `shell-view` itself at the mount in `[rf/frame-provider {:frame shell/default-frame-id} [shell-view …]]`, so the whole shell renders under the Xray frame and is caught by the existing `:rf.trace/frame-no-emit?` gate. Applied to **both** mount paths — the inline/overlay path (`mount-shell-into!`) and the popout path (`popout!`). Threads the shell's **actual** frame-id (`shell/default-frame-id`, the same Var the mount already passes implicitly), not a hardcoded `:rf/xray` literal.

Per the bead's NOTES correction (Mike, 2026-05-31): the "SIBLING — warn on render fall-through to `:rf/default`" idea was **withdrawn** and is **not** implemented here. Fall-through to `:rf/default` is correct by-design for legacy single-frame apps; this is the targeted mount-wrap only.

## SETTLE-FIRST finding — does `:rf.trace/frame-no-emit?` cover render emits?

**Yes — the gate already covers render-trace emits. Mount-wrap alone is the fix; no gate change needed.**

- `:rf.view/rendered` is emitted via the `:trace/emit!` hook with `:frame frame-id` in its tags, where `frame-id = (provider/current-frame)` resolved once per render (`implementation/core/src/re_frame/views.cljs:504`, `:518`/`:534`).
- The frame-no-emit gate keys off exactly that tag: `trace/emit!` short-circuits when `(tagged-frame-trace-disabled? tags)` — i.e. when `(:frame tags)` is in the trace-disabled set (`implementation/core/src/re_frame/trace.cljc:226-234`, `:397-399`).
- So the only reason `shell-view` leaked is that its render's `:frame` was `:rf/default` (fall-through), not `:rf/xray`. Retagging it (the mount-wrap) is sufficient — the gate then suppresses the emit at source, before any epoch back-fill runs.

The pre-existing belt-and-braces `self-noise/xray-internal-cascade?` filter operates on event-headed cascades, not standalone `:rf.view/rendered` renders, which is why it couldn't catch this leak — confirming the mount-wrap is the right structural fix.

## Two mount paths wrapped

- `mount-shell-into!` (`tools/xray/src/day8/re_frame2_xray/mount.cljs`) — covers inline (`open!`) and overlay (`open-overlay!`).
- the popout path (`popout!`, same file).

## Behaviour-neutral confirmation

`shell-view`'s two out-of-render subscribes (`:rf.xray/modal-positioning`, `:rf.xray/mode`) already pass `frame-id` **explicitly** (`(rf/subscribe frame-id [...])`) and do not rely on React-context fall-through. `global-styles/install!` is a side-effect, not a subscribe. The wrap only changes what `provider/current-frame` resolves to during `shell-view`'s own render (the render-trace `:frame` tag) — every subscribe still targets the same frame as before. The Xray feature-gate smoke (real browser mount + render) confirms the shell mounts and renders unchanged.

## Regression test

`implementation/epoch/test/re_frame/epoch_attribution_test.clj` — new **inv-7** (the cross-frame / observer sibling of inv-3):

- `inv-7-tool-frame-render-does-not-pollute-inspected-app-epoch` — a `:rf.view/rendered` emitted under a `:rf.trace/frame-no-emit? true` frame, while an app frame has a settled epoch, does **not** land in the app frame's epoch `:renders` (the gate suppresses the emit at source; no back-fill runs).
- `inv-7-contrapositive-untagged-render-still-back-fills` — the discriminator: the **same** render tagged with the (non-disabled) app frame **does** back-fill (the exact pre-fix leak), proving inv-7's clean result is the frame-no-emit suppression at work, not an unrelated filter.

Also added `(trace/clear-frame-no-emit!)` to the suite's `reset-runtime` fixture so the process-sticky gate set is clean between tests.

## tools/xray/spec currency

**tools/xray/spec unchanged because the spec already requires this.** `tools/xray/spec/013-Trace-Consumer.md` §Self-noise filter §Framework-side already states: "`:rf/xray` is registered with `:rf.trace/frame-no-emit? true` … `emit!`/`emit-error!` short-circuit for any event whose frame is so marked, so the bulk of Xray's self-noise never reaches the listener at all." The documented contract is correct; this PR fixes the **implementation** (the bare mount) to satisfy it — the whole shell now renders under the trace-disabled frame.

## Quality gates

| Gate | Command | Result |
|------|---------|--------|
| Xray JVM | `clojure -M:test` (from `tools/xray/`) | **969 tests, 3808 assertions, 0 failures, 0 errors** |
| Epoch JVM (new inv-7) | `clojure -M:test` (from `implementation/epoch/`) | **219 tests, 817 assertions, 0 failures, 0 errors** — inv-7 (2 deftests, 6 assertions) passes |
| Node CLJS contract | `npm run test:cljs` (from `implementation/`) | **4998 tests, 16742 assertions, 0 failures, 0 errors** — includes `mount_cljs_test.cljs` (run with the wrap) |
| Xray browser smoke | `npm run test:xray-feature-gate:smoke` | **4 scenarios, 0 failures, 10 matrix rows** — shell mounts + renders cleanly in-browser with the wrap |
| Lint | `clj-kondo --fail-level error --lint tools/xray/src` | **errors: 0** (touched `mount.cljs`: 0 errors, 0 warnings) |

Closes rf2-tqlmq.
