### PR TITLE
feat(story/ui): view-state fidelity controls — three labelled rungs + provenance + upgrade path (rf2-ba86n.7)

### DIFF
--- a/tools/story/spec/019-Story-UI-Controls-And-View-States.md
+++ b/tools/story/spec/019-Story-UI-Controls-And-View-States.md
@@ -78,10 +78,10 @@ Required control groups:
 | Group | Status | Backing data |
 |---|---|---|
 | Args | CURRENT/TARGET | `:args`, `:effective-args`, view-props schema, argtypes. |
-| View State | TARGET | `:sub-overrides`, labelled lower fidelity. |
-| Setup | TARGET | setup summary, event links, replay affordance. |
-| Network | TARGET | route-level managed HTTP stubs. |
-| Effects | TARGET | non-HTTP `:fx-overrides`. |
+| View State | CURRENT | `:sub-overrides` + the three labelled fidelity rungs, the honesty guardrail, and the upgrade path (rf2-ba86n.7 — `re-frame.story.ui.view-state`). |
+| Setup | CURRENT | setup-source summary off the compiled plan (`[:world :setup]` step count + dispatched event ids), surfaced in the View-State section's provenance. Event links + replay are TARGET. |
+| Network | CURRENT | route-level managed HTTP stubs surfaced as world-input provenance (off the plan's `:explain` `:network`). |
+| Effects | CURRENT | non-HTTP `:fx-overrides` surfaced as world-input provenance (off `[:world :frame :fx-overrides]`, minus `:rf.http/managed`). |
 | Route | TARGET | route/params when route support is present. |
 | Runner | TARGET | selected runner, auto/escalate policy, cannot-run behaviour. |
 | Save/Authoring | CURRENT/TARGET | save-current-state-as-variant placement, representable-slice warnings, diff before save. |
@@ -251,6 +251,62 @@ When `:sub-overrides` are used, the UI MUST show:
   known;
 - that `:rf.assert/sub-equals` still tests real subscription logic, not
   the override value.
+
+### 5.1 The implemented View-State section (CURRENT, rf2-ba86n.7)
+
+The View-State controls section is built as `re-frame.story.ui.view-state`
+and mounted in the Controls panel BELOW the args editor (the orthogonal
+fidelity channel — args above are explicit controls, the View-State
+section is the rung surface). Its pure projection
+(`view-state-model` over the COMPILED variant-plan + its `:explain` — the
+single source of truth, never the bare registrar body) is JVM-testable;
+the React render + the upgrade dialog are CLJS-only. It delivers the §5
+acceptance contract:
+
+- **Three labelled rungs, never collapsed.** `fidelity-ladder` projects
+  the FIXED three-rung vocabulary (`ladder-order` =
+  `[:real-setup :db-seed :sub-overrides]`, strongest → weakest), each
+  rendered with a distinct rank (1/2/3), tone (`:real`/`:mid`/`:low` — a
+  fidelity tone, NOT a pass/fail status per
+  [`018` §12.6](018-Story-UI-North-Star.md)), label, and
+  active/inactive state read from the plan's resolved `[:world :fidelity]`
+  (computed by `re-frame.story.plan/compute-fidelity`, never typed by
+  authors). Inactive rungs are KEPT, not dropped — they are the upgrade
+  targets.
+
+- **Args stay a control channel.** The section's blurb pins that args are
+  an explicit control channel (the editor above), not a fidelity rung
+  (§5 — "view args are explicit controls, not a state-fidelity rung").
+
+- **Source / provenance.** `setup-summary` / `network-summary` /
+  `fx-overrides-summary` / `override-rows` surface WHERE the state came
+  from: the dispatched setup/script event ids, the managed HTTP routes,
+  the non-HTTP fx-override ids (excluding `:rf.http/managed`, which the
+  network channel owns), and the exact pinned subscription query vectors
+  + values.
+
+- **The honesty guardrail.** When `:sub-overrides` is the fidelity floor
+  the section surfaces — calm during exploration, explicit on claim
+  ([`018` §12.7](018-Story-UI-North-Star.md) T2) — the structural
+  boundary: an override is a render-only picture and NEVER satisfies
+  `:rf.assert/sub-equals` (which reads through `compute-sub` against
+  app-db, which the override does not touch — see
+  [`017` §View-state subscription overrides](017-Testing-Story.md#view-state-subscription-overrides)).
+  And when an override violated its sub's output schema at render
+  (`:rf.error/schema-validation-failure :where :sub-override`, the
+  rf2-7pgiz fold-in), `sub-override-failures` projects those per-frame
+  trace failures honestly — an override the real derivation could never
+  produce is reported, not silently shown.
+
+- **The upgrade path, no artifact-kind change.** `upgrade-targets` lists
+  the rungs stronger than the variant's floor; each offers an
+  `upgrade-snippet` — a copy-paste `(story/reg-variant … {:extends … })`
+  scaffold that KEEPS the artifact a variant, adds the higher rung's
+  authoring slot (`:setup` / `:db-seed`), and drops the `:sub-overrides`.
+  Source is never written directly (the save-variant / author-expectations
+  idiom). Raw value entry of the upgraded state is deliberately NOT built
+  here — that is the separate, un-greenlit schema-generated input UI
+  (rf2-xon7j).
 
 ## 6. Acceptance criteria
 

--- a/tools/story/src/re_frame/story/ui/controls.cljs
+++ b/tools/story/src/re_frame/story/ui/controls.cljs
@@ -76,7 +76,8 @@
             [re-frame.story.ui.controls-styles :refer [styles]]
             [re-frame.story.ui.save-variant    :as save-variant-ui]
             [re-frame.story.ui.schema-validation :as schema-validation]
-            [re-frame.story.ui.state           :as state]))
+            [re-frame.story.ui.state           :as state]
+            [re-frame.story.ui.view-state      :as view-state]))
 
 ;; Styles live in `re-frame.story.ui.controls-styles` (pure-data leaf,
 ;; no Reagent dep). Required as `styles` above so the in-file call
@@ -993,11 +994,21 @@
   the story (app-db / sub / DOM / schema / a11y), shows the runner cost /
   `:cannot-run` BEFORE save, and emits an `:assertions` reg-variant form.
   DISTINCT from save-current-state (state authoring) and failure promotion
-  (a captured artifact) — spec/021 §S5."
+  (a captured artifact) — spec/021 §S5.
+
+  rf2-ba86n.7: the View-State section (`view-state/view-state-section`)
+  sits BELOW the args editor — the orthogonal fidelity-ladder channel
+  (the three labelled rungs + source/provenance + the honesty guardrail
+  + the upgrade path). Args are an explicit CONTROL channel (above), NOT
+  a fidelity rung; the View-State section is the rung surface. The order
+  reads top-down: explicit inputs → state fidelity → decorators →
+  authoring actions (spec/019 §1 control-group order)."
   [variant-id]
   [:div {:style (:wrap styles)}
    (when variant-id
      [args-editor variant-id])
+   (when variant-id
+     [view-state/view-state-section variant-id])
    (when variant-id
      [decorator-list variant-id])
    [save-variant-ui/save-variant-button variant-id]

--- a/tools/story/src/re_frame/story/ui/view_state.cljc
+++ b/tools/story/src/re_frame/story/ui/view_state.cljc
@@ -1,0 +1,810 @@
+(ns re-frame.story.ui.view-state
+  "The View-State controls section — the fidelity-ladder surface in the
+  Controls panel (rf2-ba86n.7, spec/019 §1 'View State' group + §5 the
+  fidelity ladder; spec/017 §View-state subscription overrides;
+  spec/018 §12.6/§12.7 'fidelity is not a status' + the honest-fidelity
+  controls model).
+
+  ## What it is
+
+  Controls already edit the `:args` channel (the explicit view inputs —
+  `re-frame.story.ui.controls/args-editor`). THIS section edits + labels
+  the ORTHOGONAL question: *how realistic is the state the view renders
+  against?* That is the fidelity ladder, and it is THREE distinct rungs
+  (spec/017 §View-state subscription overrides):
+
+    1. **Real setup events** (`:real-setup`)  — highest fidelity; real
+       event handlers + app-db evolution drove the state.
+    2. **Schema-checked app-db seed** (`:db-seed`) — mid; the view renders
+       against a validated state shape.
+    3. **Sub-overrides** (`:sub-overrides`) — lowest; pinned subscription
+       values surface at render (the rf2-7pgiz seam). Useful for design
+       exploration, but a *picture for the eye*, never proof.
+
+  The section renders the ladder with each rung labelled DISTINCT (rank,
+  name, fidelity-tone, active/inactive), the rungs the variant actually
+  rests on (`[:world :fidelity]`), and — for every rung — a SOURCE /
+  PROVENANCE summary (where the state came from: which setup events,
+  which network routes, which fx overrides, which pinned subs).
+
+  ## The honesty guardrail (load-bearing)
+
+  When `:sub-overrides` is active the section surfaces — calm during
+  exploration, explicit on claim (spec/018 §12.7 T2) — the structural
+  honesty boundary: a sub-override NEVER satisfies `:rf.assert/sub-equals`.
+  The assertion evaluates the sub through `compute-sub` against the
+  frame's app-db snapshot, which the override does not touch
+  (`re-frame.story.sub-overrides` ns docstring; spec/017 §Render-path
+  read + the honesty rule). The override is a render-path read only.
+
+  And when an override targets a sub with an output `:schema` and the
+  pinned value VIOLATES it, core emits `:rf.error/schema-validation-
+  failure :where :sub-override` (rf2-7pgiz fold-in; spec/010 §Sub
+  override). Those failures land in the variant's per-frame trace buffer;
+  this section surfaces them honestly (an override that the real
+  derivation could never produce is reported, not silently shown).
+
+  ## The upgrade path (no artifact-kind change)
+
+  A user can UPGRADE a low-fidelity state to a higher rung WITHOUT
+  changing the artifact kind — it stays a `reg-variant`. The section
+  offers, per available higher rung, a scaffold snippet
+  (`upgrade-snippet`) that re-emits the SAME variant (`:extends` the
+  source) with a `:setup` (→ `:real-setup`) or `:db-seed` (→ `:db-seed`)
+  slot to fill in, dropping the `:sub-overrides`. Raw value entry of the
+  upgraded state is deliberately NOT built here (that is the separate,
+  un-greenlit rf2-xon7j schema-generated input UI); the upgrade emits a
+  copy-paste scaffold the author completes, exactly as save-variant /
+  author-expectations do (source is never written directly).
+
+  ## Pure / CLJS split
+
+  Mirrors `explain_panel.cljc` + `schema_validation.cljc`: the
+  projection helpers (`fidelity-ladder`, `provenance-summaries`,
+  `override-rows`, `upgrade-targets`, `upgrade-snippet`) are pure `.cljc`
+  so the JVM corpus pins them host-free; the React render + the upgrade
+  dialog wiring are `#?(:cljs …)`.
+
+  ## Elision
+
+  The CLJS render reaches this section only through the
+  `config/enabled?`-gated controls panel mount, so production builds
+  never invoke it and closure DCEs the lot (same contract as the rest of
+  the Story UI). The pure `.cljc` helpers carry no DOM / Reagent dep."
+  (:require [re-frame.story.plan :as plan]
+            [re-frame.story.ui.schema-validation :as schema-validation]
+            ;; `clojure.string` is consumed ONLY by the `:cljs` render
+            ;; helpers (`str/join` in the provenance lines); the pure
+            ;; `.cljc` projection needs no string lib, so it rides the
+            ;; `:cljs` require and the `:clj`-mode lint sees no dead require
+            ;; (the `author_expectations.cljc` idiom).
+            #?@(:cljs [[clojure.string :as str]
+                       [reagent.core :as r]
+                       [re-frame.story.review-dialog :as review-dialog]
+                       [re-frame.story.ui.trace-buffer :as trace-buffer]
+                       [re-frame.story.theme.typography :as typography :refer [mono-stack sans-stack]]
+                       [re-frame.story.theme.colors :as colors]])))
+
+;; ===========================================================================
+;; PURE: the fidelity ladder
+;; ===========================================================================
+;;
+;; The ladder is a FIXED three-rung vocabulary, strongest → weakest
+;; (spec/017 §View-state subscription overrides — fidelity ladder; spec/019
+;; §5). The rungs are labelled DISTINCT — they are never collapsed into one
+;; "fidelity" reading (spec/018 §12.6 — "fidelity is not a status … the
+;; labels MUST NOT collapse them"). The active set is the plan's
+;; `[:world :fidelity]` (computed by `re-frame.story.plan/compute-fidelity`
+;; so authors never type it). A rung not in the active set is rendered as
+;; an inactive rung the variant COULD upgrade to, not dropped.
+
+(def ladder-rungs
+  "The fidelity ladder, strongest → weakest. Each descriptor:
+
+      {:rung   the `:fidelity`-set keyword
+       :rank   1 (highest) … 3 (lowest) — the rung's ordinal
+       :tone   the status tone (`:real` / `:mid` / `:low`) the renderer
+               colours by; NOT a pass/fail status (spec/018 §12.6)
+       :label  short human name
+       :proves what real evidence this rung establishes
+       :note   the one-line honest reading of the rung}
+
+  The order IS the ladder; `:rank` is redundant-but-explicit so a reviewer
+  / test can read the ordinal without counting. Pure data."
+  [{:rung   :real-setup
+    :rank   1
+    :tone   :real
+    :label  "Real setup events"
+    :proves "real event handlers + app-db evolution"
+    :note   "highest fidelity — the state was driven by dispatched events."}
+   {:rung   :db-seed
+    :rank   2
+    :tone   :mid
+    :label  "Schema-checked app-db seed"
+    :proves "the view against a validated state shape"
+    :note   "mid fidelity — a direct app-db seed, schema-checked, no event path."}
+   {:rung   :sub-overrides
+    :rank   3
+    :tone   :low
+    :label  "Sub-overrides"
+    :proves "nothing — a render-only picture of the view"
+    :note   (str "lowest fidelity — pinned subscription values surface at render. "
+                 "A picture for the eye, never proof of subscription logic.")}])
+
+(def ladder-order
+  "The rung keywords in strongest → weakest order (the bare ladder)."
+  (mapv :rung ladder-rungs))
+
+(defn plan-fidelity
+  "Return the resolved `:fidelity` SET for a compiled `plan` — the rungs
+  the variant actually rests on, read from `[:world :fidelity]` (present
+  only when non-empty; an as-mounted variant has none). Pure data → set."
+  [plan]
+  (or (get-in plan [:world :fidelity]) #{}))
+
+(defn fidelity-ladder
+  "Project the fixed three-rung ladder against a compiled `plan`,
+  marking each rung active/inactive per the plan's resolved
+  `[:world :fidelity]`. Returns the `ladder-rungs` vector with an
+  `:active?` flag added to each descriptor, strongest → weakest. Pure
+  data → data; JVM-testable.
+
+  A pure design variant yields `:sub-overrides` active only; an
+  events-driven variant yields `:real-setup` active; a hybrid marks
+  both. Inactive rungs are KEPT (not dropped) so the surface always
+  shows the full ladder — the inactive rungs are the upgrade targets."
+  [plan]
+  (let [active (plan-fidelity plan)]
+    (mapv (fn [rung] (assoc rung :active? (contains? active (:rung rung))))
+          ladder-rungs)))
+
+(defn lowest-active-rank
+  "The `:rank` of the LOWEST-fidelity active rung in `plan` (3 when a
+  sub-override is the floor, 1 when only real setup), or nil when the
+  variant rests on no rung (a bare as-mounted render). A variant can be
+  upgraded only above its lowest active rung. Pure data → int|nil."
+  [plan]
+  (let [active (plan-fidelity plan)]
+    (->> ladder-rungs
+         (filter #(contains? active (:rung %)))
+         (map :rank)
+         (reduce (fn [acc r] (if acc (max acc r) r)) nil))))
+
+;; ===========================================================================
+;; PURE: source / provenance summaries
+;; ===========================================================================
+;;
+;; Every fidelity rung's evidence has a SOURCE. The controls surface MUST
+;; show WHERE the state came from (spec/019 §1 — Setup / Network / Effects
+;; group "backing data"; the acceptance criterion "setup/network/fx
+;; summaries show source/provenance"). These are read-only summaries off
+;; the COMPILED plan + its `:explain` map (the single source of truth, the
+;; same slots the Explain panel reads — never the bare registrar body).
+
+(defn setup-summary
+  "Provenance summary for the `:real-setup` rung — the resolved setup +
+  script step counts off the compiled `plan` (`[:world :setup]` +
+  `:script`). Returns
+
+      {:rung :real-setup
+       :present? bool
+       :setup-count int
+       :script-count int
+       :events [event-id …]   ; the dispatched event ids, in order
+       :source :events}
+
+  `:present?` is true iff the variant has any setup or script step. The
+  event ids are projected from `[:dispatch [ev …]]` steps so a reviewer
+  sees WHICH events drove the state. Pure data → data."
+  [plan]
+  (let [setup  (get-in plan [:world :setup])
+        script (:script plan)
+        ev-id  (fn [step]
+                 ;; `[:dispatch [ev-id …]]` → ev-id; non-dispatch steps → nil.
+                 (when (and (vector? step) (= :dispatch (first step)))
+                   (let [ev (second step)]
+                     (when (vector? ev) (first ev)))))
+        events (into [] (keep ev-id) (concat setup script))]
+    {:rung         :real-setup
+     :present?     (boolean (or (seq setup) (seq script)))
+     :setup-count  (count setup)
+     :script-count (count script)
+     :events       events
+     :source       :events}))
+
+(defn db-seed-summary
+  "Provenance summary for the `:db-seed` rung — whether a schema-checked
+  direct app-db seed is present on the compiled `plan` (`[:world
+  :db-seed]`, a reserved world slot). Returns
+
+      {:rung :db-seed :present? bool :source :db-seed}
+
+  The seed slot is reserved (rf2-blw1q — not yet wired to authoring), so
+  `:present?` is normally false; the summary still renders the rung so
+  the ladder + the upgrade target are honest. Pure data → data."
+  [plan]
+  {:rung     :db-seed
+   :present? (some? (get-in plan [:world :db-seed]))
+   :source   :db-seed})
+
+(defn network-summary
+  "Provenance summary for the network world input — the per-route managed
+  HTTP stubs off the compiled plan's `:explain` `:network` slot
+  (`{:routes {[method url] {:reply …}} :lowered-to {fx-id stub-fx}}`).
+  Network is a WORLD INPUT, not a fidelity rung (spec/018 §12.6); it is
+  summarised here as state-source provenance alongside the rungs. Returns
+
+      {:present? bool :route-count int :routes [[method url] …]
+       :lowered-to {fx-id stub-fx}}
+
+  Pure data → data."
+  [explain]
+  (let [routes (get-in explain [:network :routes])]
+    {:present?    (boolean (seq routes))
+     :route-count (count routes)
+     :routes      (vec (keys routes))
+     :lowered-to  (get-in explain [:network :lowered-to])}))
+
+(defn fx-overrides-summary
+  "Provenance summary for the non-HTTP fx-override world input — the
+  `[:world :frame :fx-overrides]` map off the compiled `plan` MINUS the
+  managed-HTTP fx (which the Network summary already owns; spec/017 §The
+  network surface — `:network` is the higher-level affordance for
+  `:rf.http/managed`). A world input, not a fidelity rung. Returns
+
+      {:present? bool :fx-count int :fx-ids [fx-id …]}
+
+  Pure data → data."
+  [plan]
+  (let [overrides (-> (get-in plan [:world :frame :fx-overrides])
+                      (dissoc plan/managed-fx-id))]
+    {:present? (boolean (seq overrides))
+     :fx-count (count overrides)
+     :fx-ids   (vec (sort-by str (keys overrides)))}))
+
+(defn override-rows
+  "Project the resolved sub-override map + its output-schema validation
+  off the compiled plan's `:explain` `:sub-overrides` slot
+  (`{:overrides {query-v value} :validation {:status :violations […]}}`)
+  into per-query rows. Returns
+
+      {:present? bool
+       :rows [{:query-v query-vector :value value} …]
+       :validation {:status :ok|:invalid :violations […]}}
+
+  Each row names the EXACT query vector pinned + the pinned value
+  (spec/019 §5 — 'the exact query vectors overridden'). The validation
+  slot is the PLAN-TIME output-schema check (distinct from the live
+  render-time `:where :sub-override` trace failures the panel also
+  surfaces). Pure data → data."
+  [explain]
+  (let [overrides (get-in explain [:sub-overrides :overrides])]
+    {:present?   (boolean (seq overrides))
+     :rows       (into []
+                       (map (fn [[q v]] {:query-v q :value v}))
+                       overrides)
+     :validation (get-in explain [:sub-overrides :validation])}))
+
+;; ===========================================================================
+;; PURE: live override schema-validation failures (rf2-7pgiz)
+;; ===========================================================================
+;;
+;; The plan-time `override-rows` validation catches an override value that
+;; violates a sub's output schema BEFORE render (the compiler fails the
+;; plan). But the rf2-7pgiz seam ALSO validates at the render-time deref
+;; point: an override HIT against a sub with an output `:schema` whose
+;; pinned value violates it emits `:rf.error/schema-validation-failure`
+;; with `:where :sub-override`, lands in the variant's per-frame trace
+;; buffer, and surfaces nil (spec/010 §Sub override). This section surfaces
+;; those failures honestly — an override the real derivation could never
+;; produce is reported, not silently shown. We reuse the schema-validation
+;; panel's projection so there is ONE failure-projection path.
+
+(defn sub-override-failures
+  "Filter `trace-events` (raw rows from the variant's trace buffer) to the
+  `:rf.error/schema-validation-failure` events whose `:where` is
+  `:sub-override`, projected through the SAME
+  `schema-validation/project-failures` the schema-validation panel uses
+  (no second projector). Returns a vector of failure rows (oldest first).
+  Pure data → data; JVM-testable."
+  [trace-events]
+  (into []
+        (filter #(= :sub-override (:where %)))
+        (schema-validation/project-failures trace-events)))
+
+;; ===========================================================================
+;; PURE: the upgrade path (no artifact-kind change)
+;; ===========================================================================
+;;
+;; A user can UPGRADE a low-fidelity state to a higher rung WITHOUT
+;; changing the artifact kind — it stays a `reg-variant` (spec/019 §5
+;; acceptance: "users can upgrade a low-fidelity state without changing
+;; artifact kind"). The upgrade is a copy-paste SCAFFOLD (source is never
+;; written directly — the save-variant / author-expectations idiom), not a
+;; raw-value editor (that is the separate, un-greenlit rf2-xon7j surface).
+
+(defn upgrade-targets
+  "The fidelity rungs `plan` can be UPGRADED TO — every rung STRONGER than
+  its lowest active rung (lower `:rank`). A pure-`:sub-overrides` variant
+  (lowest rank 3) can upgrade to `:db-seed` (2) and `:real-setup` (1); a
+  variant already at `:real-setup` (rank 1) has no stronger target.
+  Returns the matching `ladder-rungs` descriptors, strongest → weakest.
+  A variant resting on no rung (no active fidelity) yields no targets —
+  there is nothing to upgrade FROM. Pure data → data."
+  [plan]
+  (if-let [floor (lowest-active-rank plan)]
+    (filterv #(< (:rank %) floor) ladder-rungs)
+    []))
+
+(defn upgraded-variant-id
+  "Derive the new variant id for an upgrade of `source-variant-id` — the
+  source id with an `-upgraded` suffix, in the source's namespace (or
+  `story.upgraded` when the source is unqualified). The upgrade KEEPS the
+  artifact a `reg-variant`; this is its new id. Pure data → keyword."
+  [source-variant-id]
+  (keyword (or (namespace source-variant-id) "story.upgraded")
+           (str (name (or source-variant-id :variant)) "-upgraded")))
+
+(defn upgrade-snippet
+  "Build the copy-paste EDN scaffold that UPGRADES `source-variant-id` to
+  the `target-rung` fidelity, KEEPING it a `reg-variant` (same artifact
+  kind). Pure data → string.
+
+  The scaffold `:extends` the source (so `:component` / `:decorators` /
+  args carry forward) and adds the rung's authoring slot for the author
+  to fill — `:setup` for `:real-setup`, `:db-seed` for `:db-seed` — while
+  dropping the `:sub-overrides` (the upgrade replaces the picture with
+  real evidence). Raw values are placeholders the author completes; this
+  surface deliberately does not type them (rf2-xon7j is separate).
+
+  Hand-built body (rather than `save-variant/gen-variant-snippet`, which
+  only emits `:args`) so the rung slot reads honestly, but reusing the
+  same `(story/reg-variant <id> {:extends <src> …})` shape + alias."
+  [source-variant-id target-rung]
+  (let [new-id (upgraded-variant-id source-variant-id)
+        slot   (case target-rung
+                 :real-setup
+                 ":setup   [[:dispatch [:your/setup-event {}]]] ; real events — proves handlers + app-db"
+                 :db-seed
+                 ":db-seed {} ; schema-checked direct app-db seed — fill the validated state shape")]
+    (str "(story/reg-variant " (pr-str new-id) "\n"
+         "  {:extends " (pr-str source-variant-id) "\n"
+         "   " slot "})\n"
+         ";; upgrade of " (pr-str source-variant-id)
+         " — drop :sub-overrides; the artifact stays a variant.")))
+
+;; ===========================================================================
+;; PURE: the composed section model (host-free)
+;; ===========================================================================
+
+(defn view-state-model
+  "Compose the full host-free View-State model for `plan` + its `explain`
+  + the variant's `trace-events`. One pure projection the CLJS renderer
+  paints and the JVM corpus pins. Returns
+
+      {:ladder        [rung-with-:active? …]   ; the three labelled rungs
+       :lowest-rank   int|nil                  ; the floor rung's rank
+       :setup         setup-summary
+       :db-seed       db-seed-summary
+       :network       network-summary
+       :fx-overrides  fx-overrides-summary
+       :overrides     override-rows            ; the pinned subs + plan-time validation
+       :override-failures [failure-row …]      ; live :where :sub-override schema failures
+       :upgrade-targets [rung …]               ; stronger rungs to upgrade to
+       :low-fidelity? bool}                    ; sub-overrides is the floor
+
+  Pure data → data; JVM-testable end-to-end."
+  [plan explain trace-events]
+  {:ladder            (fidelity-ladder plan)
+   :lowest-rank       (lowest-active-rank plan)
+   :setup             (setup-summary plan)
+   :db-seed           (db-seed-summary plan)
+   :network           (network-summary explain)
+   :fx-overrides      (fx-overrides-summary plan)
+   :overrides         (override-rows explain)
+   :override-failures (sub-override-failures trace-events)
+   :upgrade-targets   (upgrade-targets plan)
+   :low-fidelity?     (contains? (plan-fidelity plan) :sub-overrides)})
+
+(defn compile-model
+  "Compile `variant-id` (default side-table lookup) into the host-free
+  `view-state-model`, threading the variant's `trace-events`. Returns the
+  model, or `{:error <msg>}` when the plan compiler throws (a missing
+  arg, an unknown variant, a sub-override that violates its output
+  schema). Never throws — a compile failure is a render state, not a
+  blank panel (mirrors `explain-panel/explain-for`). Pure-ish: reads the
+  Story side-table through the compiler's default lookup."
+  [variant-id trace-events]
+  #?(:clj
+     (try
+       (view-state-model (plan/variant-plan variant-id)
+                         (plan/explain variant-id)
+                         trace-events)
+       (catch Throwable e
+         {:error (or (.getMessage e) (str e))}))
+     :cljs
+     (try
+       (view-state-model (plan/variant-plan variant-id)
+                         (plan/explain variant-id)
+                         trace-events)
+       (catch :default e
+         {:error (or (.-message e) (str e))}))))
+
+;; ===========================================================================
+;; CLJS: rendering
+;; ===========================================================================
+
+#?(:cljs
+   (def ^:private tone->color
+     "Map a rung's `:tone` (NOT a pass/fail status — spec/018 §12.6) to a
+     border/accent colour. `:real` reads healthy-green, `:mid`
+     informational-blue, `:low` calm-amber (the 'work in progress' /
+     low-fidelity tone — calm during exploration, not a red failure)."
+     {:real (:success colors/tokens)
+      :mid  (:info colors/tokens)
+      :low  (:warning colors/tokens)}))
+
+#?(:cljs
+   (def ^:private tone->bg
+     {:real (:success-bg colors/tokens)
+      :mid  (:info-bg colors/tokens)
+      :low  (:warning-bg colors/tokens)}))
+
+#?(:cljs
+   (def ^:private styles
+     {:section      {:margin-bottom "12px"}
+      :section-h    {:font-weight "bold"
+                     :color (:text-secondary colors/tokens)
+                     :text-transform "uppercase"
+                     :font-size (:micro typography/type-scale)
+                     :letter-spacing "0.5px"
+                     :margin-bottom "4px"}
+      :blurb        {:color (:text-tertiary colors/tokens)
+                     :font-style "italic"
+                     :font-size (:micro typography/type-scale)
+                     :margin-bottom "6px"}
+      :ladder       {:display "flex"
+                     :flex-direction "column"
+                     :gap "4px"
+                     :margin-bottom "8px"}
+      :rung         {:display "grid"
+                     :grid-template-columns "20px 1fr auto"
+                     :gap "8px"
+                     :align-items "baseline"
+                     :padding "4px 6px"
+                     :border-radius "3px"
+                     :border-left "3px solid transparent"}
+      :rung-rank    {:font-family mono-stack
+                     :font-weight "bold"
+                     :color (:text-tertiary colors/tokens)}
+      :rung-label   {:font-weight "bold"}
+      :rung-note    {:color (:text-tertiary colors/tokens)
+                     :font-size (:micro typography/type-scale)
+                     :grid-column "2 / 4"}
+      :rung-state   {:font-family mono-stack
+                     :font-size (:nano typography/type-scale)
+                     :text-transform "uppercase"
+                     :letter-spacing "0.5px"
+                     :align-self "center"}
+      :prov         {:margin "2px 0 0 0"
+                     :padding "3px 6px"
+                     :background (:bg-3 colors/tokens)
+                     :border-radius "3px"
+                     :font-size (:micro typography/type-scale)
+                     :color (:text-secondary colors/tokens)}
+      :prov-label   {:color (:info colors/tokens)
+                     :font-weight "bold"
+                     :margin-right "6px"}
+      :guardrail    {:padding "5px 7px"
+                     :margin "4px 0"
+                     :background (:warning-bg colors/tokens)
+                     :border-left (str "3px solid " (:warning colors/tokens))
+                     :border-radius "3px"
+                     :color (:text-primary colors/tokens)
+                     :font-size (:micro typography/type-scale)
+                     :line-height "1.5"}
+      :override-row {:display "grid"
+                     :grid-template-columns "1fr 1fr"
+                     :gap "6px"
+                     :padding "2px 0"
+                     :border-bottom (str "1px dotted " (:border-subtle colors/tokens))
+                     :font-family mono-stack
+                     :font-size (:micro typography/type-scale)}
+      :ovr-query    {:color (:warning colors/tokens)}
+      :ovr-value    {:color (:info colors/tokens)}
+      :fail         {:padding "4px 6px"
+                     :margin "2px 0"
+                     :background (:danger-bg colors/tokens)
+                     :border-left (str "3px solid " (:danger colors/tokens))
+                     :color (:danger colors/tokens)
+                     :font-size (:micro typography/type-scale)}
+      :empty        {:color (:text-tertiary colors/tokens)
+                     :font-style "italic"
+                     :font-size (:micro typography/type-scale)}
+      :upgrade-row  {:display "flex"
+                     :gap "6px"
+                     :align-items "center"
+                     :flex-wrap "wrap"
+                     :margin-top "4px"}
+      :upgrade-btn  {:padding "3px 8px"
+                     :background (:bg-3 colors/tokens)
+                     :color (:text-primary colors/tokens)
+                     :border (str "1px solid " (:border-default colors/tokens))
+                     :border-radius "3px"
+                     :cursor "pointer"
+                     :font-family sans-stack
+                     :font-size (:micro typography/type-scale)}
+      :error        {:color (:danger colors/tokens)
+                     :background (:danger-bg colors/tokens)
+                     :border (str "1px solid " (:danger colors/tokens))
+                     :border-radius "3px"
+                     :padding "6px"
+                     :font-family mono-stack
+                     :font-size (:micro typography/type-scale)
+                     :white-space "pre-wrap"}}))
+
+;; ---- the upgrade dialog ratom (reuses the shared review-dialog) ----------
+
+#?(:cljs
+   (defonce ^:private upgrade-dialog
+     (r/atom review-dialog/initial-state)))
+
+#?(:cljs
+   (defn- open-upgrade-dialog!
+     "Open the upgrade scaffold dialog for `source-variant-id` → the
+     `target-rung` fidelity. The snippet is fixed (a scaffold the author
+     fills), so we seed the review-dialog with the pre-built snippet and
+     no editable id field — the user copies + pastes into source."
+     [source-variant-id target-rung]
+     (let [snippet (upgrade-snippet source-variant-id target-rung)]
+       (reset! upgrade-dialog
+               (-> review-dialog/initial-state
+                   (assoc :open?     true
+                          :source-id source-variant-id
+                          :context   {:target-rung target-rung
+                                      :snippet     snippet}))))))
+
+#?(:cljs
+   (defn- close-upgrade-dialog! []
+     (reset! upgrade-dialog review-dialog/initial-state)))
+
+;; ---- render helpers ------------------------------------------------------
+
+#?(:cljs
+   (defn- rung-view
+     "Render one labelled ladder rung. Each rung reads DISTINCT — rank,
+     name, fidelity-tone border, active/inactive state — so the three are
+     never collapsed into one fidelity reading (spec/018 §12.6)."
+     [{:keys [rung rank tone label note active?]}]
+     [:div {:style (merge (:rung styles)
+                          {:border-left-color (tone->color tone)
+                           :background (when active? (tone->bg tone))
+                           :opacity (if active? 1 0.62)})
+            :data-test "story-view-state-rung"
+            :data-rung (name rung)
+            :data-rung-rank (str rank)
+            :data-rung-tone (name tone)
+            :data-rung-active (str (boolean active?))}
+      [:span {:style (:rung-rank styles)} (str rank)]
+      [:span {:style (:rung-label styles)} label]
+      [:span {:style (merge (:rung-state styles)
+                            {:color (tone->color tone)})}
+       (if active? "in use" "available")]
+      [:span {:style (:rung-note styles)} note]]))
+
+#?(:cljs
+   (defn- provenance-line
+     "One read-only provenance line — a labelled source summary. `detail`
+     is the right-hand human string (where the state came from)."
+     [test-id label detail]
+     [:div {:style (:prov styles)
+            :data-test "story-view-state-provenance"
+            :data-provenance test-id}
+      [:span {:style (:prov-label styles)} label]
+      [:span detail]]))
+
+#?(:cljs
+   (defn- setup-provenance
+     [{:keys [present? setup-count script-count events]}]
+     (when present?
+       (provenance-line
+         "setup"
+         "Setup source"
+         (str setup-count " setup + " script-count " script step(s)"
+              (when (seq events)
+                (str " → " (str/join ", " (map pr-str events)))))))))
+
+#?(:cljs
+   (defn- network-provenance
+     [{:keys [present? route-count routes]}]
+     (when present?
+       (provenance-line
+         "network"
+         "Network source"
+         (str route-count " managed route(s): "
+              (str/join ", " (map pr-str routes)))))))
+
+#?(:cljs
+   (defn- fx-provenance
+     [{:keys [present? fx-count fx-ids]}]
+     (when present?
+       (provenance-line
+         "fx-overrides"
+         "FX source"
+         (str fx-count " fx override(s): "
+              (str/join ", " (map pr-str fx-ids)))))))
+
+#?(:cljs
+   (defn- override-provenance
+     "The sub-override provenance — the exact pinned query vectors + values
+     (spec/019 §5 — 'the exact query vectors overridden'), the plan-time
+     output-schema validation status, and any LIVE `:where :sub-override`
+     schema-validation failures."
+     [{:keys [present? rows validation]} failures]
+     [:div {:data-test "story-view-state-overrides"}
+      (if present?
+        [:div
+         (provenance-line "sub-overrides" "Override source"
+                          (str (count rows) " pinned subscription(s)"))
+         (into [:div {:style {:margin "2px 0"}}]
+               (for [{:keys [query-v value]} rows]
+                 ^{:key (pr-str query-v)}
+                 [:div {:style (:override-row styles)
+                        :data-test "story-view-state-override-row"
+                        :data-query (pr-str query-v)}
+                  [:span {:style (:ovr-query styles)} (pr-str query-v)]
+                  [:span {:style (:ovr-value styles)} (str "→ " (pr-str value))]]))
+         ;; plan-time output-schema validation status.
+         (when (and validation (= :ok (:status validation)))
+           [:div {:style (:empty styles)
+                  :data-test "story-view-state-override-validation-ok"}
+            "output-schema check: ok"])]
+        [:div {:style (:empty styles)} "no subscription overrides pinned"])
+      ;; LIVE render-time :where :sub-override schema-validation failures.
+      (when (seq failures)
+        (into [:div {:data-test "story-view-state-override-failures"}]
+              (for [{:keys [id failing-id explain]} failures]
+                ^{:key id}
+                [:div {:style (:fail styles)
+                       :data-test "story-view-state-override-failure"
+                       :data-failing-id (when failing-id (str failing-id))}
+                 (str "⚠ override on " (if failing-id (pr-str failing-id) "a sub")
+                      " violates its output schema — surfaced nil, not the pinned value"
+                      (let [expl (schema-validation/format-explain explain)]
+                        (when (seq expl) (str " (" expl ")"))))])))]))
+
+#?(:cljs
+   (defn- honesty-guardrail
+     "The load-bearing honesty bar shown when `:sub-overrides` is the
+     fidelity floor. Calm during exploration (spec/018 §12.7 T2) but
+     explicit about the structural boundary: an override is a render-only
+     picture and NEVER satisfies `:rf.assert/sub-equals` (the assertion
+     reads through `compute-sub` against app-db, which the override does
+     not touch — spec/017 §the honesty rule)."
+     []
+     [:div {:style (:guardrail styles)
+            :role  "note"
+            :data-test "story-view-state-guardrail"}
+      [:div {:style {:font-weight "bold"}} "Low-fidelity: a picture, not proof"]
+      [:div
+       "Sub-overrides surface pinned values at render — no events, no app-db. "
+       "They are for design exploration and hard-to-reach states. An override "
+       [:strong "never satisfies "]
+       [:code ":rf.assert/sub-equals"]
+       " — that assertion tests real subscription logic through "
+       [:code "compute-sub"]
+       " against app-db, which the override does not touch. Upgrade to a "
+       "real-setup or db-seed rung to prove subscription logic."]]))
+
+#?(:cljs
+   (defn- upgrade-path
+     "The upgrade affordance — one button per stronger rung the variant
+     can upgrade to, WITHOUT changing the artifact kind (it stays a
+     variant). Each button opens a copy-paste scaffold dialog (raw value
+     entry is the separate rf2-xon7j surface, not built here)."
+     [variant-id targets]
+     (when (seq targets)
+       [:div {:data-test "story-view-state-upgrade"}
+        [:div {:style (:blurb styles)}
+         "Upgrade this state to a higher fidelity rung — stays a variant:"]
+        (into [:div {:style (:upgrade-row styles)}]
+              (for [{:keys [rung label]} targets]
+                ^{:key (name rung)}
+                [:button {:style    (:upgrade-btn styles)
+                          :type     "button"
+                          :data-test "story-view-state-upgrade-btn"
+                          :data-upgrade-rung (name rung)
+                          :title    (str "Scaffold an upgrade to " label
+                                         " — same variant, copy + paste into source")
+                          :on-click (fn [_]
+                                      (open-upgrade-dialog! variant-id rung))}
+                 (str "↑ " label)]))])))
+
+#?(:cljs
+   (defn- upgrade-dialog-view
+     "Render the upgrade scaffold dialog (visible iff open). Reuses the
+     shared review-dialog skeleton — a fixed scaffold snippet + copy +
+     close. No editable id (the scaffold's id is derived); the author
+     completes the rung slot after pasting into source."
+     []
+     (let [dialog @upgrade-dialog]
+       (when (:open? dialog)
+         (let [{:keys [source-id context]} dialog
+               {:keys [target-rung snippet]} context]
+           (review-dialog/review-dialog dialog
+             {:title            (str "Upgrade " (pr-str source-id)
+                                     " to " (name target-rung) " fidelity")
+              :hint             [:div
+                                 (str "Copy this scaffold into your stories namespace and fill the "
+                                      (name target-rung)
+                                      " slot. The upgraded artifact stays a variant — "
+                                      "drop the :sub-overrides once real evidence drives the state. "
+                                      "Source is never written directly.")]
+              :snippet          snippet
+              ;; The scaffold's id is DERIVED (the upgrade keeps it a
+              ;; variant); the id input shows it but does not drive the
+              ;; fixed scaffold snippet — `:on-edit-id` is a no-op (raw
+              ;; value entry is the separate rf2-xon7j surface).
+              :placeholder-id   (upgraded-variant-id source-id)
+              :on-edit-id       (fn [_])
+              :on-copy          (fn [] (review-dialog/copy-to-clipboard! snippet))
+              :on-close         close-upgrade-dialog!
+              :data-test-prefix "story-view-state-upgrade"}))))))
+
+;; ---- the public section --------------------------------------------------
+
+#?(:cljs
+   (defn view-state-section
+     "The View-State controls section for `variant-id` (spec/019 §1 'View
+     State' group + §5 the fidelity ladder). Form-2 — the inner fn derefs
+     the variant's trace buffer so live `:where :sub-override` schema
+     failures re-render in.
+
+     Renders:
+     - the THREE labelled fidelity rungs (distinct rank / tone / state);
+     - per-rung + world-input SOURCE / PROVENANCE summaries (setup,
+       network, fx-overrides, sub-overrides);
+     - the honesty guardrail when sub-overrides is the floor;
+     - any live override schema-validation failures;
+     - the upgrade path (scaffold to a stronger rung, same artifact kind).
+
+     A note pins that args (the section above) are a separate CONTROL
+     channel, not a fidelity rung (spec/019 §5 — 'view args are explicit
+     controls, not a state-fidelity rung')."
+     [_variant-id]
+     (let [_buf (when _variant-id (trace-buffer/ensure-buffer! _variant-id))]
+       (fn [variant-id]
+         (let [events (when variant-id @(trace-buffer/ensure-buffer! variant-id))
+               model  (compile-model variant-id events)]
+           [:div {:style     (:section styles)
+                  :data-test "story-view-state-section"
+                  :data-variant-id (str variant-id)}
+            [:div {:style (:section-h styles)} "View State"]
+            (if (:error model)
+              [:div {:style     (:error styles)
+                     :data-test "story-view-state-error"}
+               (:error model)]
+              (let [{:keys [ladder setup network fx-overrides overrides
+                            override-failures upgrade-targets low-fidelity?]} model]
+                [:div
+                 [:div {:style (:blurb styles)}
+                  "How realistic is the rendered state? Three distinct rungs — "
+                  "args (above) are a separate control channel, not a fidelity rung."]
+                 ;; ---- the three labelled rungs ----
+                 (into [:div {:style (:ladder styles)}]
+                       (for [rung ladder]
+                         ^{:key (name (:rung rung))}
+                         [rung-view rung]))
+                 ;; ---- per-rung + world-input provenance ----
+                 [:div {:style (:section styles)}
+                  (setup-provenance setup)
+                  (network-provenance network)
+                  (fx-provenance fx-overrides)
+                  [override-provenance overrides override-failures]]
+                 ;; ---- honesty guardrail (sub-overrides floor) ----
+                 (when low-fidelity?
+                   [honesty-guardrail])
+                 ;; ---- upgrade path ----
+                 [upgrade-path variant-id upgrade-targets]]))
+            ;; the upgrade scaffold dialog (portal-less inline; visible iff open)
+            [upgrade-dialog-view]])))))

--- a/tools/story/test/re_frame/story/ui/view_state_test.cljc
+++ b/tools/story/test/re_frame/story/ui/view_state_test.cljc
@@ -1,0 +1,241 @@
+(ns re-frame.story.ui.view-state-test
+  "JVM-portable regression net for the View-State fidelity-controls' pure
+  projection (rf2-ba86n.7, spec/019 §1/§5 + spec/017 §View-state
+  subscription overrides).
+
+  Covers the host-free surface — no host, no Reagent:
+
+  - `fidelity-ladder`        — the fixed THREE labelled rungs, each
+    marked active/inactive per the plan's `[:world :fidelity]`; the
+    ladder is never collapsed to two.
+  - `lowest-active-rank` / `upgrade-targets` — the upgrade path (stronger
+    rungs above the floor), and that an upgrade keeps the artifact a
+    variant (`upgrade-snippet` is a `reg-variant` `:extends` scaffold).
+  - the provenance summaries (`setup-summary`, `network-summary`,
+    `fx-overrides-summary`, `override-rows`) — source/provenance shown.
+  - `sub-override-failures` — the live `:where :sub-override` schema-fail
+    projection (the honesty surface for an override the real derivation
+    could never produce).
+  - `view-state-model` / `compile-model` — the composed model + error
+    trapping over the pure plan compiler.
+
+  CLJS render (the rung-view hiccup, the dialog, the guardrail) is left
+  to a smoke / cljs test; this corpus pins the pure projection only."
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.string :as str]
+            [re-frame.story.ui.view-state :as vs]))
+
+;; ---------------------------------------------------------------------------
+;; Representative compiled-plan + explain fixtures, mirroring the slots the
+;; plan compiler emits (re-frame.story.plan/build-plan): a pure design
+;; variant (sub-overrides only), an events-driven variant, and a hybrid +
+;; network + fx-override variant.
+;; ---------------------------------------------------------------------------
+
+(def ^:private design-plan
+  "A pure design variant — pins one sub, no setup/seed → `#{:sub-overrides}`."
+  {:variant/id :story.login/error
+   :world {:fidelity #{:sub-overrides}
+           :render   {:sub-overrides {[:login/state] :error
+                                      [:login/msg]   "Invalid password"}}}})
+
+(def ^:private design-explain
+  {:sub-overrides {:overrides  {[:login/state] :error
+                                [:login/msg]   "Invalid password"}
+                   :validation {:status :ok :violations []}}
+   :fidelity      #{:sub-overrides}})
+
+(def ^:private events-plan
+  "An events-driven variant — real setup → `#{:real-setup}`."
+  {:variant/id :story.cart/with-items
+   :world  {:fidelity #{:real-setup}
+            :setup    [[:dispatch [:cart/add {:sku "A"}]]
+                       [:dispatch [:cart/add {:sku "B"}]]]
+            :frame    {:fx-overrides {:analytics/track (fn [_])
+                                      :rf.http/managed :stub}}
+            :network  {[:get "/api/cart"] {:reply {:ok {:items []}}}}}
+   :script [[:dispatch [:cart/checkout]]]})
+
+(def ^:private events-explain
+  {:network  {:routes     {[:get "/api/cart"] {:reply {:ok {:items []}}}}
+              :lowered-to {:rf.http/managed :rf.http/managed-test-stub}}
+   :fidelity #{:real-setup}})
+
+(def ^:private bare-plan
+  "A render-as-mounted variant — no fidelity rung at all."
+  {:variant/id :story.badge/default
+   :world {}})
+
+;; ---------------------------------------------------------------------------
+;; fidelity-ladder — three DISTINCT rungs, never collapsed
+;; ---------------------------------------------------------------------------
+
+(deftest ladder-is-exactly-three-rungs-strongest-to-weakest
+  (testing "the fidelity ladder is exactly the three rungs, ordered
+            strongest → weakest — never collapsed to two"
+    (is (= [:real-setup :db-seed :sub-overrides] vs/ladder-order))
+    (is (= 3 (count vs/ladder-rungs)))
+    (testing "each rung carries a distinct rank + tone + label"
+      (is (= [1 2 3] (mapv :rank vs/ladder-rungs)))
+      (is (= [:real :mid :low] (mapv :tone vs/ladder-rungs)))
+      (is (= 3 (count (distinct (map :label vs/ladder-rungs))))))))
+
+(deftest ladder-marks-active-rungs-keeps-inactive
+  (testing "a pure design variant marks ONLY :sub-overrides active, keeps
+            the stronger rungs as inactive upgrade targets (never dropped)"
+    (let [ladder (vs/fidelity-ladder design-plan)
+          by-rung (into {} (map (juxt :rung identity) ladder))]
+      (is (= 3 (count ladder)) "all three rungs are always shown")
+      (is (true?  (:active? (by-rung :sub-overrides))))
+      (is (false? (:active? (by-rung :real-setup))))
+      (is (false? (:active? (by-rung :db-seed))))))
+  (testing "an events-driven variant marks :real-setup active"
+    (let [by-rung (into {} (map (juxt :rung identity)
+                                (vs/fidelity-ladder events-plan)))]
+      (is (true?  (:active? (by-rung :real-setup))))
+      (is (false? (:active? (by-rung :sub-overrides))))))
+  (testing "a bare variant marks no rung active"
+    (is (every? (complement :active?) (vs/fidelity-ladder bare-plan)))))
+
+(deftest sub-overrides-rung-labelled-low-fidelity-never-proof
+  (testing "the :sub-overrides rung is labelled lowest-fidelity and as
+            proving nothing — the honest reading the surface surfaces"
+    (let [r (first (filter #(= :sub-overrides (:rung %)) vs/ladder-rungs))]
+      (is (= :low (:tone r)))
+      (is (= 3 (:rank r)))
+      (is (str/includes? (:note r) "never proof"))
+      (is (str/includes? (:proves r) "nothing")))))
+
+;; ---------------------------------------------------------------------------
+;; the upgrade path — keeps the artifact a variant
+;; ---------------------------------------------------------------------------
+
+(deftest lowest-active-rank-is-the-fidelity-floor
+  (is (= 3 (vs/lowest-active-rank design-plan)))
+  (is (= 1 (vs/lowest-active-rank events-plan)))
+  (testing "a hybrid floors at its WEAKEST active rung"
+    (is (= 3 (vs/lowest-active-rank
+               {:world {:fidelity #{:real-setup :sub-overrides}}}))))
+  (testing "a bare variant has no floor"
+    (is (nil? (vs/lowest-active-rank bare-plan)))))
+
+(deftest upgrade-targets-are-the-stronger-rungs
+  (testing "a pure sub-override variant can upgrade to db-seed + real-setup"
+    (is (= [:real-setup :db-seed]
+           (mapv :rung (vs/upgrade-targets design-plan)))))
+  (testing "a real-setup variant has no stronger rung to upgrade to"
+    (is (empty? (vs/upgrade-targets events-plan))))
+  (testing "a bare variant has nothing to upgrade FROM"
+    (is (empty? (vs/upgrade-targets bare-plan)))))
+
+(deftest upgrade-snippet-keeps-the-artifact-a-variant
+  (testing "the upgrade scaffold is a reg-variant :extends-ing the source
+            — same artifact kind, drops :sub-overrides, adds the rung slot"
+    (let [snip (vs/upgrade-snippet :story.login/error :real-setup)]
+      (is (str/includes? snip "story/reg-variant")
+          "stays a reg-variant — artifact kind unchanged")
+      (is (str/includes? snip ":extends :story.login/error")
+          "extends the source so component/decorators/args carry forward")
+      (is (str/includes? snip ":setup")
+          "adds the :real-setup authoring slot")
+      (is (str/includes? snip "drop :sub-overrides"))))
+  (testing "the db-seed upgrade scaffolds the :db-seed slot"
+    (is (str/includes? (vs/upgrade-snippet :story.login/error :db-seed)
+                       ":db-seed")))
+  (testing "the derived upgraded id sits in the source's namespace"
+    (is (= :story.login/error-upgraded
+           (vs/upgraded-variant-id :story.login/error)))))
+
+;; ---------------------------------------------------------------------------
+;; provenance summaries — source shown
+;; ---------------------------------------------------------------------------
+
+(deftest setup-summary-shows-event-provenance
+  (testing "the setup summary counts setup + script steps and names the
+            dispatched event ids — where the state came from"
+    (let [s (vs/setup-summary events-plan)]
+      (is (true? (:present? s)))
+      (is (= 2 (:setup-count s)))
+      (is (= 1 (:script-count s)))
+      (is (= [:cart/add :cart/add :cart/checkout] (:events s)))
+      (is (= :events (:source s)))))
+  (testing "a design variant has no setup provenance"
+    (is (false? (:present? (vs/setup-summary design-plan))))))
+
+(deftest network-summary-shows-route-provenance
+  (let [n (vs/network-summary events-explain)]
+    (is (true? (:present? n)))
+    (is (= 1 (:route-count n)))
+    (is (= [[:get "/api/cart"]] (:routes n)))
+    (is (= {:rf.http/managed :rf.http/managed-test-stub} (:lowered-to n))))
+  (testing "no routes → absent"
+    (is (false? (:present? (vs/network-summary design-explain))))))
+
+(deftest fx-overrides-summary-excludes-managed-http
+  (testing "the fx-override summary lists non-HTTP fx overrides, EXCLUDING
+            :rf.http/managed (the Network summary owns that route channel)"
+    (let [f (vs/fx-overrides-summary events-plan)]
+      (is (true? (:present? f)))
+      (is (= 1 (:fx-count f)))
+      (is (= [:analytics/track] (:fx-ids f)))
+      (is (not (some #{:rf.http/managed} (:fx-ids f)))))))
+
+(deftest override-rows-show-exact-query-vectors
+  (testing "the override rows name the EXACT query vectors pinned + the
+            pinned values, plus the plan-time output-schema validation"
+    (let [o (vs/override-rows design-explain)]
+      (is (true? (:present? o)))
+      (is (= 2 (count (:rows o))))
+      (is (= #{[:login/state] [:login/msg]}
+             (set (map :query-v (:rows o)))))
+      (is (= :ok (get-in o [:validation :status])))))
+  (testing "no overrides → absent"
+    (is (false? (:present? (vs/override-rows events-explain))))))
+
+;; ---------------------------------------------------------------------------
+;; live :where :sub-override schema-fail projection (the honesty surface)
+;; ---------------------------------------------------------------------------
+
+(deftest sub-override-failures-filters-the-where-sub-override-events
+  (testing "only :rf.error/schema-validation-failure events whose :where
+            is :sub-override are surfaced — the override-violated-its-
+            output-schema honesty case (rf2-7pgiz fold-in)"
+    (let [events [{:op-type :error :operation :rf.error/schema-validation-failure
+                   :id 1 :time 100 :tags {:where :sub-override :sub-id :login/state
+                                          :explain {:errors [{:path [] :message "bad"}]}}}
+                  {:op-type :error :operation :rf.error/schema-validation-failure
+                   :id 2 :time 200 :tags {:where :sub-return :sub-id :other}}
+                  {:op-type :error :operation :rf.error/schema-validation-failure
+                   :id 3 :time 300 :tags {:where :app-db}}
+                  {:op-type :event :operation :some/event :id 4 :time 400 :tags {}}]
+          fails (vs/sub-override-failures events)]
+      (is (= 1 (count fails)) "only the :sub-override failure")
+      (is (= :sub-override (:where (first fails))))
+      (is (= :login/state (:failing-id (first fails))))))
+  (testing "no failures → empty"
+    (is (empty? (vs/sub-override-failures [])))))
+
+;; ---------------------------------------------------------------------------
+;; the composed model + error trapping
+;; ---------------------------------------------------------------------------
+
+(deftest view-state-model-composes-the-full-surface
+  (testing "the composed model carries the ladder, provenance, overrides,
+            failures, upgrade targets, and the low-fidelity flag"
+    (let [m (vs/view-state-model design-plan design-explain [])]
+      (is (= 3 (count (:ladder m))))
+      (is (= 3 (:lowest-rank m)))
+      (is (true? (:low-fidelity? m)) "sub-overrides is the floor")
+      (is (true? (get-in m [:overrides :present?])))
+      (is (= [:real-setup :db-seed] (mapv :rung (:upgrade-targets m))))))
+  (testing "an events-driven plan is NOT low-fidelity and has no upgrade"
+    (let [m (vs/view-state-model events-plan events-explain [])]
+      (is (false? (:low-fidelity? m)))
+      (is (empty? (:upgrade-targets m)))
+      (is (true? (get-in m [:network :present?]))))))
+
+(deftest compile-model-traps-unknown-variant
+  (testing "an unregistered keyword target surfaces :error, not a throw"
+    (let [m (vs/compile-model :story.nope/missing [])]
+      (is (string? (:error m)))
+      (is (not (str/blank? (:error m)))))))


### PR DESCRIPTION
Implements **rf2-ba86n.7** — the StoryUI view-state fidelity controls.

Adds `re-frame.story.ui.view-state` (the View-State controls section) and mounts it in the Controls panel **below** the args editor — the orthogonal fidelity channel per `spec/019` §1/§5 + `spec/017` §View-state subscription overrides. Pure projection (`view-state-model` over the COMPILED variant-plan + its `:explain` — the single source of truth) is JVM-testable; React render + the upgrade dialog are CLJS-only.

## The three rungs, labelled distinct
`fidelity-ladder` projects the FIXED three-rung vocabulary `[:real-setup :db-seed :sub-overrides]` (strongest → weakest — **never collapsed to two**, per Mike's 7pgiz=(A) ruling). Each rung renders a distinct **rank** (1/2/3), **tone** (`:real`/`:mid`/`:low` — a *fidelity tone, not a pass/fail status* per `018` §12.6), label, and **active/inactive** state read from the plan's resolved `[:world :fidelity]`. Inactive rungs are KEPT (not dropped) — they are the upgrade targets.

Args stay an explicit **control channel** (the editor above), not a fidelity rung — the section's blurb pins this.

## The honesty guardrail
When `:sub-overrides` is the fidelity floor, the section surfaces — calm during exploration, explicit on claim (`018` §12.7 T2) — the structural boundary: **an override is a render-only picture and NEVER satisfies `:rf.assert/sub-equals`** (which reads through `compute-sub` against app-db, which the override does not touch). And when an override violated its sub's output schema at render (`:rf.error/schema-validation-failure :where :sub-override`, the **rf2-7pgiz fold-in**), `sub-override-failures` projects those per-frame trace failures honestly — an override the real derivation could never produce is reported, not silently shown.

## Source / provenance
`setup-summary` / `network-summary` / `fx-overrides-summary` / `override-rows` surface WHERE the state came from: dispatched setup/script event ids, managed HTTP routes, non-HTTP fx-override ids (excluding `:rf.http/managed`, owned by the network channel), and the exact pinned subscription query vectors + values.

## The upgrade path — no artifact-kind change
`upgrade-targets` lists the rungs stronger than the variant's floor; each offers an `upgrade-snippet` — a copy-paste `(story/reg-variant … {:extends … })` scaffold that **keeps the artifact a variant**, adds the higher rung's authoring slot (`:setup` / `:db-seed`), and drops `:sub-overrides`. Source is never written directly (the save-variant / author-expectations idiom). Raw value entry of the upgraded state is deliberately **NOT** built here — that is the separate, un-greenlit rf2-xon7j surface.

## Spec
`spec/019-Story-UI-Controls-And-View-States.md` §1 (control-group table) + §5 (new §5.1) updated to CURRENT with the implementation contract. No hot-zone (`shadow-cljs.edn`) touch — reuses existing surfaces, no new testbed/build-id/port.

## Quality gates
| Gate | Command | Result |
|---|---|---|
| Story JVM | `clojure -M:test` (from `tools/story/`) | **1505 tests / 5598 assertions, 0 failures, 0 errors** (incl. 13 new view-state tests / 63 assertions) |
| CLJS substrate contract | `npm run test:cljs` (from `implementation/`) | **5011 tests / 16763 assertions, 0 failures, 0 errors** |
| clj-kondo | `clj-kondo --fail-level error --lint tools/story/src` | **0 errors** (the 2 unused-private-var warnings in `controls.cljs` are pre-existing on HEAD; new files add 0 warnings) |
| mkdocs | `mkdocs build --strict` | **exit 0, no warnings** — note: `tools/story/spec/*` is outside `docs_dir` so not built by mkdocs; ran for regression safety |
| Doc anchors | `check_doc_slugs.py` + `check_readme_links.py` | **exit 0** (validates `tools/<tool>/spec/**`; new cross-doc links resolve) |
| xray-feature-gate | — | **not applicable** — change is entirely in Story `ui/`; touches no Xray feature in the matrix |
| Browser smoke | — | **not applicable** — no Story controls-panel `*.spec.cjs` testbed exists (test-free examples policy); regression coverage is the JVM-portable pure-projection test (the established Story-UI pattern) |

Closes rf2-ba86n.7.
