### PR TITLE
fix(testbeds): derive project-root from build-env, drop hardcoded personal path — cross-platform open-in-editor (rf2-5dphw)

### DIFF
--- a/implementation/package.json
+++ b/implementation/package.json
@@ -15,6 +15,7 @@
     "todomvc-common": "1.0.5"
   },
   "scripts": {
+    "dev": "node scripts/dev-testbed.cjs",
     "test:cljs": "shadow-cljs compile node-test && node out/node-test.js",
     "test:cljs-perf-emit-nightly": "shadow-cljs compile node-test-perf-nightly && node out/node-test-perf-nightly.js",
     "test:browser": "shadow-cljs compile browser-test && node scripts/serve-and-run-browser-tests.cjs",

--- a/implementation/scripts/dev-testbed.cjs
+++ b/implementation/scripts/dev-testbed.cjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+/*
+ * `dev` — cross-platform testbed dev launcher (rf2-5dphw).
+ *
+ * Resolves the repo root from THIS script's own location (via node's
+ * `path` module, which behaves identically on Windows / macOS / Linux),
+ * exports it as the `RF2_TESTBED_PROJECT_ROOT` environment variable, and
+ * spawns `shadow-cljs watch <build...>` with the remaining CLI args.
+ *
+ * Why: the Xray / Story dev testbeds turn a source-coord into an editor
+ * URI by prepending an on-disk project-root. The shared helper
+ * `re-frame.testbed.config` reads that root from a `goog-define`
+ * (`re-frame.testbed.config/repo-root`) that the affected shadow-cljs
+ * builds seed from this env var via `#shadow/env`. So the on-disk root
+ * baked into a testbed build is the ACTUAL repo root of whatever clone
+ * ran the build — never a hardcoded personal path. 'Open in editor'
+ * therefore works on a fresh clone at any path, on any OS, with no
+ * `?project-root=` override needed.
+ *
+ * Usage:
+ *
+ *   npm run dev -- :examples/button-deck
+ *   npm run dev -- :testbeds/panel-gallery
+ *   npm run dev -- :examples/counter-with-stories :examples/login-form
+ *
+ * Any extra `shadow-cljs watch` args pass straight through. Launching
+ * `npx shadow-cljs watch ...` directly still works — the env var is just
+ * unset, so the helper falls back to the `?project-root=` query string
+ * (or a graceful open-in-editor no-op).
+ */
+
+'use strict';
+
+const { spawn } = require('child_process');
+const { REPO_ROOT, IMPL_ROOT } = require('./_path-policy.cjs');
+
+const builds = process.argv.slice(2);
+if (builds.length === 0) {
+  console.error(
+    'Usage: npm run dev -- <build> [<build>...]\n' +
+      '  e.g. npm run dev -- :examples/button-deck',
+  );
+  process.exit(1);
+}
+
+const isWin = process.platform === 'win32';
+const cmd = isWin ? 'npx.cmd' : 'npx';
+const args = ['shadow-cljs', 'watch', ...builds];
+
+// Normalise to forward slashes so the value reads identically across
+// platforms when it becomes a string prefix in `re-frame.testbed.config`.
+const repoRoot = REPO_ROOT.split('\\').join('/');
+
+console.log(`> RF2_TESTBED_PROJECT_ROOT=${repoRoot}`);
+console.log(`> ${cmd} ${args.join(' ')}`);
+
+const child = spawn(cmd, args, {
+  cwd: IMPL_ROOT,
+  stdio: 'inherit',
+  shell: isWin,
+  env: { ...process.env, RF2_TESTBED_PROJECT_ROOT: repoRoot },
+});
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code == null ? 0 : code);
+});

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -123,6 +123,15 @@
                 ;; `:examples/counter-with-stories` and
                 ;; `:story-static/counter-with-stories` builds below.
                 "../tools/story/testbeds"
+                ;; tools/testbed-support (rf2-5dphw — shared testbed-config
+                ;; helper). Single ns `re-frame.testbed.config` that derives
+                ;; the open-in-editor project-root from the build-env
+                ;; `re-frame.testbed.config/repo-root` goog-define (seeded
+                ;; per build below via `#shadow/env`), replacing the six
+                ;; hardcoded personal-path defaults the Xray / Story
+                ;; testbeds previously copied. Bundle-isolation contract
+                ;; holds (nothing under implementation/ :requires it).
+                "../tools/testbed-support/src"
                 ;; Per rf2-kx74 examples/ is grouped per substrate. Each
                 ;; substrate root is its own shadow-cljs source path so
                 ;; the per-example namespaces (counter.core,
@@ -595,12 +604,20 @@
   ;; Xray preload auto-mounts inline so the frame-picker switching
   ;; between :above and :below is one click away.
   :examples/two-frame-isolation
-  {:target     :browser
-   :output-dir "out/examples/two-frame-isolation"
-   :asset-path "."
-   :modules    {:main {:init-fn two-frame-isolation.core/run}}
-   :devtools   {:preloads [re-frame2-pair.runtime
-                           day8.re-frame2-xray.preload]}}
+  {:target           :browser
+   :output-dir       "out/examples/two-frame-isolation"
+   :asset-path       "."
+   ;; rf2-5dphw — seed the build-env project-root for open-in-editor. The
+   ;; `dev` npm script exports RF2_TESTBED_PROJECT_ROOT (node-resolved
+   ;; repo root, cross-platform); the shared `re-frame.testbed.config`
+   ;; helper joins it with the tool subdir. `#shadow/env` reads the env
+   ;; var at config load (default "" when unset → graceful no-op).
+   :compiler-options {:closure-defines
+                      {re-frame.testbed.config/repo-root
+                       #shadow/env ["RF2_TESTBED_PROJECT_ROOT" ""]}}
+   :modules          {:main {:init-fn two-frame-isolation.core/run}}
+   :devtools         {:preloads [re-frame2-pair.runtime
+                                 day8.re-frame2-xray.preload]}}
 
   ;; Single-frame button-deck testbed (rf2-gsr6z) — the deliberately
   ;; simple Xray driving surface that SUPERSEDES the old step-deck. A
@@ -618,12 +635,17 @@
   ;; preload auto-mounts inline so every lens reads the single frame.
   ;; Served at http://localhost:8031 via the top-level `:dev-http` map.
   :examples/button-deck
-  {:target     :browser
-   :output-dir "out/examples/button-deck"
-   :asset-path "."
-   :modules    {:main {:init-fn button-deck.core/run}}
-   :devtools   {:preloads [re-frame2-pair.runtime
-                           day8.re-frame2-xray.preload]}}
+  {:target           :browser
+   :output-dir       "out/examples/button-deck"
+   :asset-path       "."
+   ;; rf2-5dphw — build-env project-root for open-in-editor (see
+   ;; :examples/two-frame-isolation above for the mechanism).
+   :compiler-options {:closure-defines
+                      {re-frame.testbed.config/repo-root
+                       #shadow/env ["RF2_TESTBED_PROJECT_ROOT" ""]}}
+   :modules          {:main {:init-fn button-deck.core/run}}
+   :devtools         {:preloads [re-frame2-pair.runtime
+                                 day8.re-frame2-xray.preload]}}
 
   ;; Xray panel-gallery testbed (rf2-1o7mp) — visual gallery of Xray
   ;; panels under varying state magnitude. Sources live under
@@ -644,11 +666,16 @@
   ;; by `release`, so the preload never reaches a production bundle
   ;; (testbed isn't released anyway — it's served via dev-http only).
   :testbeds/panel-gallery
-  {:target     :browser
-   :output-dir "out/testbeds/panel-gallery"
-   :asset-path "."
-   :modules    {:main {:init-fn panel-gallery.core/run}}
-   :devtools   {:preloads [re-frame2-pair.runtime]}}
+  {:target           :browser
+   :output-dir       "out/testbeds/panel-gallery"
+   :asset-path       "."
+   ;; rf2-5dphw — build-env project-root for open-in-editor (see
+   ;; :examples/two-frame-isolation above for the mechanism).
+   :compiler-options {:closure-defines
+                      {re-frame.testbed.config/repo-root
+                       #shadow/env ["RF2_TESTBED_PROJECT_ROOT" ""]}}
+   :modules          {:main {:init-fn panel-gallery.core/run}}
+   :devtools         {:preloads [re-frame2-pair.runtime]}}
 
   :examples/temperature
   {:target     :browser
@@ -883,10 +910,15 @@
   ;; examples/counter build (via the Story-sentinel addition to
   ;; scripts/check-bundle-isolation.cjs).
   :examples/counter-with-stories
-  {:target     :browser
-   :output-dir "out/examples/counter-with-stories"
-   :asset-path "."
-   :modules    {:main {:init-fn counter-with-stories.core/run}}}
+  {:target           :browser
+   :output-dir       "out/examples/counter-with-stories"
+   :asset-path       "."
+   ;; rf2-5dphw — build-env project-root for open-in-editor (see
+   ;; :examples/two-frame-isolation above for the mechanism).
+   :compiler-options {:closure-defines
+                      {re-frame.testbed.config/repo-root
+                       #shadow/env ["RF2_TESTBED_PROJECT_ROOT" ""]}}
+   :modules          {:main {:init-fn counter-with-stories.core/run}}}
 
   ;; (removed rf2-9jfo1.2) :examples/xray-rhs-smoke build target —
   ;; the original Playwright `spec.cjs` was deleted by rf2-piucm in
@@ -907,11 +939,16 @@
   ;; Xray preload is wired so a reader can press Ctrl+Shift+C to
   ;; observe Story's frame-per-variant isolation in real time.
   :examples/login-form
-  {:target     :browser
-   :output-dir "out/examples/login-form"
-   :asset-path "."
-   :modules    {:main {:init-fn login-form.core/run}}
-   :devtools   {:preloads [day8.re-frame2-xray.preload]}}
+  {:target           :browser
+   :output-dir       "out/examples/login-form"
+   :asset-path       "."
+   ;; rf2-5dphw — build-env project-root for open-in-editor (see
+   ;; :examples/two-frame-isolation above for the mechanism).
+   :compiler-options {:closure-defines
+                      {re-frame.testbed.config/repo-root
+                       #shadow/env ["RF2_TESTBED_PROJECT_ROOT" ""]}}
+   :modules          {:main {:init-fn login-form.core/run}}
+   :devtools         {:preloads [day8.re-frame2-xray.preload]}}
 
   ;; Story static-export build (rf2-8wgpm) — see
   ;; tools/story/spec/013-Static-Build.md. Same source tree as
@@ -932,7 +969,15 @@
   {:target           :browser
    :output-dir       "out/story-static/counter-with-stories"
    :asset-path       "."
-   :compiler-options {:closure-defines {re-frame.story.config/static-mode? true}}
+   ;; rf2-5dphw — the build-env project-root define rides alongside the
+   ;; static-mode? define here (see :examples/two-frame-isolation for the
+   ;; mechanism). In a published static export the open-in-editor chip is
+   ;; effectively dev-only, so the slot is harmless; seeding it keeps the
+   ;; static entry structurally identical to the dev entry.
+   :compiler-options {:closure-defines
+                      {re-frame.story.config/static-mode? true
+                       re-frame.testbed.config/repo-root
+                       #shadow/env ["RF2_TESTBED_PROJECT_ROOT" ""]}}
    :modules          {:main {:init-fn counter-with-stories.story-static/run}}}
 
   ;; Pattern-WebSocket worked example (rf2-yf97). Canonical worked

--- a/tools/story/testbeds/counter_with_stories/core.cljs
+++ b/tools/story/testbeds/counter_with_stories/core.cljs
@@ -30,7 +30,10 @@
             ;; subs, and exposes `install-listener!` for the boot
             ;; sequence below.
             [counter-with-stories.elision-demo :as elision]
-            [counter-with-stories.stories])
+            [counter-with-stories.stories]
+            ;; Shared testbed-config helper (rf2-5dphw): derives the
+            ;; open-in-editor project-root from the build env.
+            [re-frame.testbed.config :as testbed-config])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; -- The live-app root view ------------------------------------------------
@@ -46,43 +49,31 @@
    [views/counter-card {:label "Count"}]
    [elision/elision-card]])
 
-;; -- rf2-r1uod — Xray 'Open in editor' project-root for the live testbed.
+;; -- rf2-r1uod / rf2-5dphw — Xray 'Open in editor' project-root.
 ;;
 ;; Story testbeds register source-coords with classpath-relative `:file`
 ;; slots (e.g. `"counter_with_stories/core.cljs"`); OS-side editor URI
 ;; handlers (`vscode://file/<path>...` etc.) resolve `<path>` against the
-;; filesystem and reject relative paths. Mike's live testbed runs from
-;; the mayor checkout `C:/Users/miket/code/re-frame2`; the Story
-;; testbeds source-path under shadow-cljs is `../tools/story/testbeds`
-;; so the absolute on-disk root that prepends to a coord like
-;; `counter_with_stories/core.cljs:42` is the testbeds dir below.
+;; filesystem and reject relative paths, so a testbed must hand Story an
+;; absolute on-disk root that prepends to a coord like
+;; `counter_with_stories/core.cljs:42`. That root is `<repo>/tools/story/
+;; testbeds` (the Story testbeds source-path under shadow-cljs).
 ;;
-;; The value is plumbed via `story/configure! :rf.story/project-root` and bridged
-;; into Xray's slot by `re-frame.story.xray-preset/propagate-project-
-;; root!` so both Story's own 'Open' chips and Xray-as-RHS's chips (the
-;; Event lens Handler / Dispatch / Interceptors, Trace rows, Issues
+;; The value is plumbed via `story/configure! :rf.story/project-root` and
+;; bridged into Xray's slot by `re-frame.story.xray-preset/propagate-
+;; project-root!` so both Story's own 'Open' chips and Xray-as-RHS's chips
+;; (the Event lens Handler / Dispatch / Interceptors, Trace rows, Issues
 ;; ribbon) resolve against the same root.
 ;;
-;; Symmetric to shop's rf2-6jyf6; other hosts (CI, other devs) can
-;; override at runtime via the `?project-root=...` query string — no
-;; code change needed.
-
-(def ^:private default-project-root
-  "C:/Users/miket/code/re-frame2/tools/story/testbeds")
-
-(defn- query-param
-  "Return the named URL query param as a string, or nil when absent
-  / blank. Pure-data helper — kept private to this testbed since the
-  query-string override is a per-host knob (not a Story-API surface)."
-  [name]
-  (when (exists? js/window)
-    (let [params (-> js/window .-location .-search
-                     (js/URLSearchParams.))
-          v      (.get params name)]
-      (when (and (string? v) (seq v)) v))))
-
+;; rf2-5dphw — the root is DERIVED from the build environment (the
+;; build-time `re-frame.testbed.config/repo-root` goog-define joined with
+;; this testbed's tool-relative subdir), NOT a hardcoded personal path, so
+;; a fresh clone at any path on any OS gets working open-in-editor. A
+;; `?project-root=<path>` query string still overrides per session (CI,
+;; another dev's machine) — no code change needed. See
+;; `re-frame.testbed.config` for the cross-platform mechanism.
 (defn- resolve-project-root []
-  (or (query-param "project-root") default-project-root))
+  (testbed-config/resolve-project-root "tools/story/testbeds"))
 
 ;; -- Routing between app and story shell ----------------------------------
 ;;

--- a/tools/story/testbeds/counter_with_stories/story_static.cljs
+++ b/tools/story/testbeds/counter_with_stories/story_static.cljs
@@ -29,7 +29,10 @@
             ;; Source the stories ns so all `reg-*` calls fire on namespace
             ;; load. The variant bodies reference views / events / subs by
             ;; id; the stories ns transitively requires them.
-            [counter-with-stories.stories]))
+            [counter-with-stories.stories]
+            ;; Shared testbed-config helper (rf2-5dphw): derives the
+            ;; open-in-editor project-root from the build env.
+            [re-frame.testbed.config :as testbed-config]))
 
 (defn ^:export run
   "Mount the Story shell at `#app`. Idempotent on hot-reload (which
@@ -54,8 +57,10 @@
   ;; keeps the two `run` fns structurally identical and makes future
   ;; "live-on-static" experiments (e.g. a published site that links
   ;; back into the author's editor) trivial.
+  ;; rf2-5dphw — project-root derived from the build env (see
+  ;; `re-frame.testbed.config`), not a hardcoded personal path.
   (story/configure! {:rf.story/global-args  {:locale :en}
-                     :rf.story/project-root "C:/Users/miket/code/re-frame2/tools/story/testbeds"})
+                     :rf.story/project-root (testbed-config/resolve-project-root "tools/story/testbeds")})
   ;; Seed the live-app's :count slot so any embedded `counter-card`
   ;; view that renders under the variant canvas starts from a
   ;; deterministic value rather than `nil`.

--- a/tools/story/testbeds/login_form/core.cljs
+++ b/tools/story/testbeds/login_form/core.cljs
@@ -21,7 +21,10 @@
             [login-form.events]
             [login-form.subs]
             [login-form.views :as views]
-            [login-form.stories])
+            [login-form.stories]
+            ;; Shared testbed-config helper (rf2-5dphw): derives the
+            ;; open-in-editor project-root from the build env.
+            [re-frame.testbed.config :as testbed-config])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; ---------------------------------------------------------------------------
@@ -64,22 +67,13 @@
 ;; to shop's rf2-6jyf6.
 ;; ---------------------------------------------------------------------------
 
-(def ^:private default-project-root
-  "C:/Users/miket/code/re-frame2/tools/story/testbeds")
-
-(defn- query-param
-  "Return the named URL query param as a string, or nil when absent /
-  blank. Pure-data helper — kept private to this testbed since the
-  query-string override is a per-host knob (not a Story-API surface)."
-  [name]
-  (when (exists? js/window)
-    (let [params (-> js/window .-location .-search
-                     (js/URLSearchParams.))
-          v      (.get params name)]
-      (when (and (string? v) (seq v)) v))))
-
+;; rf2-5dphw — open-in-editor project-root derived from the build
+;; environment (the build-time `re-frame.testbed.config/repo-root`
+;; goog-define joined with this testbed's tool-relative subdir), not a
+;; hardcoded personal path. `?project-root=<path>` still overrides per
+;; session. See `re-frame.testbed.config` for the cross-platform mechanism.
 (defn- resolve-project-root []
-  (or (query-param "project-root") default-project-root))
+  (testbed-config/resolve-project-root "tools/story/testbeds"))
 
 ;; ---------------------------------------------------------------------------
 ;; Hash-routing between the live app and the Story shell

--- a/tools/testbed-support/src/re_frame/testbed/config.cljs
+++ b/tools/testbed-support/src/re_frame/testbed/config.cljs
@@ -1,0 +1,107 @@
+(ns re-frame.testbed.config
+  "Shared testbed-config helper — derives the on-disk project-root the
+  Xray / Story testbeds hand to their 'open in editor' resolvers
+  (rf2-5dphw).
+
+  ## Why this exists
+
+  Xray and Story turn a source-coord (`button_deck/core.cljs:42`) into an
+  editor URI by prepending an on-disk *project-root*. SHIPPED code reads
+  that root from host config (`xray-config/configure!` /
+  `story/configure!`); there is no baked default. But the dev testbeds
+  that drive Xray / Story have to PASS a root to `configure!`, and they
+  previously each hardcoded the author's absolute Windows checkout
+  (`C:/Users/miket/code/re-frame2/tools/xray/testbeds`) as that value —
+  six copies of one machine-specific string. On any other clone, any
+  other directory, and every Mac/Linux maintainer, 'open in editor'
+  resolved to a path that does not exist.
+
+  ## The fix (cross-platform, build-env derived)
+
+  `repo-root` is a `goog-define`d string, default `\"\"`. The dev launcher
+  (`implementation/scripts/dev-testbed.cjs`, wired as the `dev` npm
+  script) resolves the repo root from its OWN location via node's
+  `path` module — which works identically on Windows, macOS, and Linux —
+  exports it as the `RF2_TESTBED_PROJECT_ROOT` env var, and spawns
+  `shadow-cljs`. The 6 affected builds in
+  `implementation/shadow-cljs.edn` seed the define from that env var via
+  `#shadow/env`, so the absolute root is the ACTUAL repo root of whatever
+  checkout did the build — never a literal.
+
+  `resolve-project-root` then joins that root with the tool-relative
+  testbed subdir (`\"tools/xray/testbeds\"` /  `\"tools/story/testbeds\"`)
+  the caller passes. A `?project-root=<path>` query string still wins as
+  the per-session escape hatch (CI, a reader on a different machine, a
+  testbed served from a copied bundle). When neither the override nor the
+  build-time root is present, this returns `nil` and the testbed simply
+  configures no root — 'open in editor' degrades to a no-op rather than a
+  broken link, exactly the graceful-absence behaviour
+  `set-project-root!` already encodes for blank input.
+
+  ## Why a goog-define and not a literal
+
+  The repo root cannot be known when the source is authored (it differs
+  per clone), so it must be supplied at build time. A goog-define seeded
+  from the build environment is the smallest cross-platform-correct
+  mechanism: one define + one shared helper, no per-file string, no
+  OS-specific path assumptions."
+  (:require [clojure.string :as str]))
+
+;; ---- the compile-time, build-env-derived repo root -----------------------
+;;
+;; @define {string}
+;; Defaults to "" (no root known). Seeded per build from the
+;; RF2_TESTBED_PROJECT_ROOT env var via `#shadow/env` in
+;; implementation/shadow-cljs.edn :closure-defines. The `dev` npm script
+;; (implementation/scripts/dev-testbed.cjs) exports that env var with the
+;; node-resolved repo root before spawning shadow-cljs.
+(goog-define repo-root "")
+
+(defn- non-blank
+  "Return `s` when it is a non-blank string, else nil."
+  [s]
+  (when (and (string? s) (seq (str/trim s))) s))
+
+(defn- query-param
+  "Return the named URL query param as a trimmed non-blank string, or nil
+  when absent / blank / running outside a browser. The per-session
+  override knob — not a Xray/Story-API surface, so kept private."
+  [param-name]
+  (when (exists? js/window)
+    (let [params (-> js/window .-location .-search (js/URLSearchParams.))]
+      (non-blank (.get params param-name)))))
+
+(defn- strip-trailing-slash
+  [s]
+  (if (and (> (count s) 1) (str/ends-with? s "/"))
+    (subs s 0 (dec (count s)))
+    s))
+
+(defn resolve-project-root
+  "Resolve the on-disk project-root a testbed should hand to its
+  open-in-editor resolver, for the given tool-relative testbed subdir
+  (e.g. `\"tools/xray/testbeds\"` or `\"tools/story/testbeds\"`).
+
+  Resolution order:
+
+    1. `?project-root=<path>` query string — the per-session escape
+       hatch. Wins over everything; used verbatim. (CI, a reader on a
+       different machine, a copied bundle served elsewhere.)
+    2. The build-time `repo-root` goog-define joined with `subdir` —
+       the default for a normal `npm run dev ...` launch.
+    3. `nil` — neither is available. The caller configures no root and
+       open-in-editor is a graceful no-op (matching `set-project-root!`'s
+       blank-input contract).
+
+  `subdir` is normalised so callers may pass it with or without a
+  leading slash."
+  [subdir]
+  (or (query-param "project-root")
+      (when-let [root (non-blank repo-root)]
+        (let [root*   (strip-trailing-slash (str/trim root))
+              subdir* (-> (or subdir "")
+                          str/trim
+                          (str/replace #"^/+" ""))]
+          (if (seq subdir*)
+            (str root* "/" subdir*)
+            root*)))))

--- a/tools/xray/testbeds/button_deck/core.cljs
+++ b/tools/xray/testbeds/button_deck/core.cljs
@@ -77,7 +77,10 @@
             ;; Xray's `configure!` to seed `:project-root` so the Event
             ;; lens 'open' chip resolves a classpath-relative `:file` to
             ;; an absolute on-disk URI.
-            [day8.re-frame2-xray.config :as xray-config])
+            [day8.re-frame2-xray.config :as xray-config]
+            ;; Shared testbed-config helper (rf2-5dphw): derives the
+            ;; open-in-editor project-root from the build env.
+            [re-frame.testbed.config :as testbed-config])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; ============================================================================
@@ -554,20 +557,13 @@
 (defonce react-root
   (rdc/create-root (js/document.getElementById "app")))
 
-(def ^:private default-project-root
-  "C:/Users/miket/code/re-frame2/tools/xray/testbeds")
-
-(defn- query-param
-  "Return the named URL query param as a string, or nil when absent /
-  blank. A per-host knob (not a Xray-API surface), so kept private."
-  [param-name]
-  (when (exists? js/window)
-    (let [params (-> js/window .-location .-search (js/URLSearchParams.))
-          v      (.get params param-name)]
-      (when (and (string? v) (seq v)) v))))
-
+;; rf2-5dphw — open-in-editor project-root is derived from the build
+;; environment, not a hardcoded personal path. `re-frame.testbed.config`
+;; joins the build-time repo-root goog-define with this testbed's
+;; tool-relative subdir; `?project-root=<path>` still overrides per
+;; session. See that ns for the cross-platform mechanism.
 (defn- resolve-project-root []
-  (or (query-param "project-root") default-project-root))
+  (testbed-config/resolve-project-root "tools/xray/testbeds"))
 
 (defn ^:export run []
   ;; Configure Xray BEFORE `rf/init!` so the preload's auto-open reads the

--- a/tools/xray/testbeds/panel_gallery/core.cljs
+++ b/tools/xray/testbeds/panel_gallery/core.cljs
@@ -117,7 +117,10 @@
             ;; mount with the edn-inspector gallery above; the
             ;; variants pass `:full-with-diff? true` to opt into
             ;; the mode-3 chrome (R3 chip + R4 rail).
-            [panel-gallery.gallery-diff-mode-3]))
+            [panel-gallery.gallery-diff-mode-3]
+            ;; Shared testbed-config helper (rf2-5dphw): derives the
+            ;; open-in-editor project-root from the build env.
+            [re-frame.testbed.config :as testbed-config]))
 
 ;; ============================================================================
 ;; LANDING — the URL `/` view (no `#/stories` hash)
@@ -169,24 +172,17 @@
 ;; never reaches into the document. The unit test
 ;; `panel-gallery-project-root-invariant-to-host-url` pins that contract.
 
-(def ^:private default-project-root
-  "Default on-disk root for the panel-gallery testbed. Matches the source-
-  path declared in `implementation/shadow-cljs.edn` for the
-  `:testbeds/panel-gallery` build."
-  "C:/Users/miket/code/re-frame2/tools/xray/testbeds")
-
-(defn- query-param
-  "Return the named URL query param as a string, or nil when absent /
-  blank. Pure data helper — kept private to this testbed since the
-  query-string override is a per-host knob (not a Xray-API surface)."
-  [param-name]
-  (when (exists? js/window)
-    (let [params (-> js/window .-location .-search (js/URLSearchParams.))
-          v      (.get params param-name)]
-      (when (and (string? v) (seq v)) v))))
-
+;; rf2-5dphw — open-in-editor project-root derived from the build
+;; environment (the build-time `re-frame.testbed.config/repo-root`
+;; goog-define joined with this testbed's tool-relative subdir), not a
+;; hardcoded personal path. `?project-root=<path>` still overrides per
+;; session. The URI build stays invariant to the host page URL — the
+;; resolver reads the configured root, not `window.location`; the
+;; query-param branch only influences which root we PASS to `configure!`.
+;; The unit test `panel-gallery-project-root-invariant-to-host-url` pins
+;; that contract.
 (defn- resolve-project-root []
-  (or (query-param "project-root") default-project-root))
+  (testbed-config/resolve-project-root "tools/xray/testbeds"))
 
 (defonce ^:private app-root (atom nil))
 

--- a/tools/xray/testbeds/two_frame_isolation/core.cljs
+++ b/tools/xray/testbeds/two_frame_isolation/core.cljs
@@ -81,7 +81,10 @@
             ;; rf2-6jyf6 — Xray's `configure!` to seed `:project-root`
             ;; so the Event lens 'open' chip resolves a classpath-relative
             ;; `:file` slot to an absolute on-disk URI.
-            [day8.re-frame2-xray.config :as xray-config])
+            [day8.re-frame2-xray.config :as xray-config]
+            ;; Shared testbed-config helper (rf2-5dphw): derives the
+            ;; open-in-editor project-root from the build env.
+            [re-frame.testbed.config :as testbed-config])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; ============================================================================
@@ -147,21 +150,13 @@
 (defonce react-root
   (rdc/create-root (js/document.getElementById "app")))
 
-(def ^:private default-project-root
-  "C:/Users/miket/code/re-frame2/tools/xray/testbeds")
-
-(defn- query-param
-  "Return the named URL query param as a string, or nil when absent /
-  blank. Pure-data helper — kept private to this testbed since the
-  query-string override is a per-host knob (not a Xray-API surface)."
-  [param-name]
-  (when (exists? js/window)
-    (let [params (-> js/window .-location .-search (js/URLSearchParams.))
-          v      (.get params param-name)]
-      (when (and (string? v) (seq v)) v))))
-
+;; rf2-5dphw — open-in-editor project-root derived from the build
+;; environment (the build-time `re-frame.testbed.config/repo-root`
+;; goog-define joined with this testbed's tool-relative subdir), not a
+;; hardcoded personal path. `?project-root=<path>` still overrides per
+;; session. See `re-frame.testbed.config` for the cross-platform mechanism.
 (defn- resolve-project-root []
-  (or (query-param "project-root") default-project-root))
+  (testbed-config/resolve-project-root "tools/xray/testbeds"))
 
 (defn ^:export run []
   ;; Configure Xray BEFORE `rf/init!` so the preload's auto-open reads


### PR DESCRIPTION
## What & why

Six dev testbeds hardcoded the author's absolute Windows checkout (`C:/Users/miket/code/re-frame2/tools/{xray,story}/testbeds`) as the default project-root that Xray/Story use to turn source-coords into editor URIs. On any other clone, any other directory, and every Mac/Linux maintainer, 'open in editor' / 'go to code' resolved to a nonexistent path. The only escape was the per-session `?project-root=` query param.

**Severity bound (honoured):** SHIPPED src is clean — `day8.re-frame2-xray.config` + the editor-uri resolver read the project-root from host config; there is no personal-path default in shipped code. This was a broken-dev-experience defect confined to the 6 dev testbeds. Shipped src is **not** touched.

## Fix — rec (a): build-env-derived default + one shared helper

1. **DRY** — new shared helper ns `re-frame.testbed.config` at `tools/testbed-support/src/re_frame/testbed/config.cljs` replaces the six copies of the `default-project-root` / `query-param` / `resolve-project-root` triplet.
2. **Derived, not literal** — `re-frame.testbed.config/repo-root` is a `goog-define` (default `""`). `resolve-project-root` joins it with the caller's tool-relative subdir (`"tools/xray/testbeds"` / `"tools/story/testbeds"`).
3. **Per-session override kept** — `?project-root=<path>` query string still wins over the derived default.
4. All 6 testbed files call the shared helper.

### Cross-platform mechanism (how the repo root is exported portably)

A new dev launcher `implementation/scripts/dev-testbed.cjs` (wired as the `dev` npm script) resolves the repo root from its **own file location** via node's `path` module (`path.resolve(__dirname, ...)` in the existing `_path-policy.cjs`) — which behaves identically on Windows, macOS, and Linux — normalises to forward slashes, exports it as the `RF2_TESTBED_PROJECT_ROOT` env var, and spawns `shadow-cljs watch`. node runs everywhere shadow-cljs does, so this is portable by construction (no bash-only / PowerShell-only mechanism).

The 6 affected builds seed the goog-define from that env var:

```clojure
:compiler-options {:closure-defines
                   {re-frame.testbed.config/repo-root
                    #shadow/env ["RF2_TESTBED_PROJECT_ROOT" ""]}}
```

`#shadow/env` reads the env var at config-load (default `""` when unset).

### How a fresh clone at a different path / on Mac/Linux gets working open-in-editor WITHOUT the query param

Run `npm run dev -- :examples/button-deck` (or any affected build). The launcher resolves *that clone's* repo root from its own on-disk location and exports it; `#shadow/env` bakes it into the goog-define; the helper joins it with the testbed subdir. So the absolute root baked into the build is the actual repo root of whatever checkout ran the build — never a literal. No `?project-root=` needed. Launching `npx shadow-cljs watch ...` directly still works: the env var is just unset, the define stays `""`, and the helper falls back to the query param (or a graceful no-op, matching `set-project-root!`'s blank-input contract).

## Hot-zone touch (flagged)

`implementation/shadow-cljs.edn` is hot-zone. Touched **only**: one new source path (`../tools/testbed-support/src`) and the `:closure-defines` of the 6 affected builds (`:examples/two-frame-isolation`, `:examples/button-deck`, `:testbeds/panel-gallery`, `:examples/counter-with-stories`, `:examples/login-form`, `:story-static/counter-with-stories`). No unrelated build config reflowed. Sole toucher this session (cry25 does not touch it).

## Quality gates

| Gate | Command | Result |
|---|---|---|
| node-runtime CLJS | `npm run test:cljs` | **PASS** — Ran 5011 tests, 16763 assertions, 0 failures, 0 errors |
| testbed build (dev, define wired) | `RF2_TESTBED_PROJECT_ROOT=<repo> npx shadow-cljs compile examples/button-deck` | **PASS** — 424 files, 0 warnings; verified `CLOSURE_DEFINES` carries the resolved root in `main.js` and the helper joins it to `tools/xray/testbeds` |
| Story testbed build (`:advanced` release) | `RF2_TESTBED_PROJECT_ROOT=<repo> npm run story:build` | **PASS** — `:story-static/counter-with-stories` released, 0 warnings; merged `:closure-defines` (static-mode? + repo-root) compiled under `:advanced`; derived root baked in bundle, old personal path absent (grep count 0) |
| clj-kondo | `clj-kondo --fail-level error --lint tools/xray/testbeds tools/story/testbeds tools/testbed-support/src` | **PASS** — errors: 0 (5 pre-existing warnings in untouched files; new helper ns lints clean) |
| bundle-isolation | `npm run test:bundle-isolation` | **PASS** — new helper does not leak into production bundles |

## Verification

`git grep "miket" -- 'tools/xray/testbeds/**/*.cljs' 'tools/story/testbeds/**/*.cljs'` is **clean** (no match). The one residual stale comment (counter_with_stories/core.cljs) referencing the mayor checkout was also removed.

## Out of scope (per the bead, tracked separately)

Test fixtures using the personal path as sample data, doc examples, and the deliberate worktree-guard scripts — untouched.