### PR TITLE
fix(docs): cross-platform font resolution in generate-placeholder-images.py (rf2-5a01r)

### DIFF
--- a/docs/scripts/generate-placeholder-images.py
+++ b/docs/scripts/generate-placeholder-images.py
@@ -19,7 +19,7 @@ Usage (from repo root):
 
 from __future__ import annotations
 
-import os
+import sys
 from pathlib import Path
 from PIL import Image, ImageDraw, ImageFont
 
@@ -75,18 +75,71 @@ COLOURS = {
 }
 
 
-def find_font(size: int) -> ImageFont.FreeTypeFont:
-    """Best-effort font lookup; falls back to the bundled default."""
-    candidates = [
+# Per-OS TrueType candidates, ordered most-likely-present first. The
+# running platform's list is tried first; the others follow as defensive
+# fallbacks (e.g. a Linux box with a macOS font mounted). Every entry is a
+# common system path or font directory — no single hardcoded path is load-
+# bearing, and the PIL default backstops any platform with none of these.
+_FONT_CANDIDATES = {
+    "win32": [
         "C:/Windows/Fonts/segoeui.ttf",
         "C:/Windows/Fonts/arial.ttf",
+        "C:/Windows/Fonts/calibri.ttf",
+        "C:/Windows/Fonts/tahoma.ttf",
+    ],
+    "darwin": [
         "/System/Library/Fonts/Helvetica.ttc",
+        "/System/Library/Fonts/HelveticaNeue.ttc",
+        "/System/Library/Fonts/Supplemental/Arial.ttf",
+        "/Library/Fonts/Arial.ttf",
+        str(Path.home() / "Library" / "Fonts" / "Arial.ttf"),
+    ],
+    # Linux + other POSIX: distro font trees plus the user font dir.
+    "linux": [
         "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
-    ]
-    for path in candidates:
-        if os.path.exists(path):
+        "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+        "/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",
+        "/usr/share/fonts/truetype/freefont/FreeSans.ttf",
+        "/usr/share/fonts/dejavu/DejaVuSans.ttf",
+        "/usr/share/fonts/liberation/LiberationSans-Regular.ttf",
+        str(Path.home() / ".fonts" / "DejaVuSans.ttf"),
+        str(Path.home() / ".local" / "share" / "fonts" / "DejaVuSans.ttf"),
+    ],
+}
+
+
+def _ordered_candidates() -> list[str]:
+    """Candidate font paths, the running OS first then the rest as fallbacks."""
+    if sys.platform.startswith("win"):
+        primary = "win32"
+    elif sys.platform == "darwin":
+        primary = "darwin"
+    else:
+        primary = "linux"  # treat all other POSIX platforms as Linux-like
+    ordered = list(_FONT_CANDIDATES[primary])
+    for key, paths in _FONT_CANDIDATES.items():
+        if key != primary:
+            ordered.extend(paths)
+    return ordered
+
+
+def find_font(size: int) -> ImageFont.ImageFont:
+    """Resolve a TrueType font cross-platform.
+
+    Tries the running OS's common font locations first, then the other
+    platforms' as defensive fallbacks. When no TrueType is found anywhere
+    (e.g. a minimal CI image), degrades gracefully to PIL's bundled default
+    so the script never hard-fails on a missing platform path.
+    """
+    for path in _ordered_candidates():
+        if Path(path).exists():
             return ImageFont.truetype(path, size)
-    return ImageFont.load_default()
+    # Final fallback: PIL's bundled default. Pillow >= 10.1 honours `size`
+    # (older builds ignore it but still return a usable font).
+    try:
+        return ImageFont.load_default(size=size)
+    except TypeError:
+        return ImageFont.load_default()
 
 
 def draw_placeholder(out: Path, caption: str, tool: str) -> None:


### PR DESCRIPTION
Fixes **rf2-5a01r** (P3 bug, part of portability EPIC rf2-v6wyb).

`docs/scripts/generate-placeholder-images.py` resolved its TrueType font from a thin, Windows-first candidate list. On the maintainer base (Mac/Linux) and in minimal CI images the preferred paths are absent, so text rendering fell straight through to a tiny un-sized default — and the bead flags the Windows Fonts dir paths as the only load-bearing option.

## What changed

`find_font` is now genuinely cross-platform:

- **Per-OS, ordered candidate lists.** Separate lists for `win32`, `darwin`, and `linux`/other-POSIX. The **running OS's list is tried first**; the other platforms' lists follow as defensive fallbacks (e.g. a Linux box with a macOS font mounted). Each entry is a common system font path or font directory — no single hardcoded path is load-bearing.
  - Windows: `C:/Windows/Fonts/{segoeui,arial,calibri,tahoma}.ttf`
  - macOS: `/System/Library/Fonts/Helvetica.ttc`, `HelveticaNeue.ttc`, `/System/Library/Fonts/Supplemental/Arial.ttf`, `/Library/Fonts/Arial.ttf`, `~/Library/Fonts/Arial.ttf`
  - Linux/POSIX: DejaVu / Liberation / FreeSans under `/usr/share/fonts/...`, plus user dirs `~/.fonts` and `~/.local/share/fonts`
- **Graceful default fallback.** When no preferred TTF exists anywhere, it degrades to PIL's bundled default via `ImageFont.load_default(size=...)` (size-aware on Pillow >= 10.1; the `TypeError` branch keeps older Pillow working). The script **never hard-fails** on a platform with no system TTF.
- Dropped the `os` import in favour of `pathlib.Path.exists`; added `sys` for platform detection.

### Why this succeeds on Mac/Linux without a Windows Fonts dir

On macOS `sys.platform == "darwin"` puts the `/System/Library/Fonts` + `/Library/Fonts` entries first; on Linux `/usr/share/fonts/...` (DejaVu/Liberation, present on virtually every distro and most CI images) comes first. The Windows paths are only ever consulted as defensive fallbacks and are simply skipped when absent. If a stripped CI image ships none of these, the PIL `load_default` backstop renders the placeholders anyway — so generation completes on all three OSes.

## Quality gates

- **Ran the script (Windows, Python 3.14, Pillow 12.0.0):** `python docs/scripts/generate-placeholder-images.py` printed `Generated 22 placeholders.` and wrote all 22 PNGs without error. (The regenerated PNGs were reverted from the commit; only the script change ships, since the committed placeholders are unchanged artifacts.)
- **Simulated the Mac/Linux / minimal-CI case** by forcing every `.ttf`/`.ttc` candidate to be absent: `find_font` returns a usable `FreeTypeFont` from `load_default` and a subsequent draw call succeeds (no crash).
- **Verified OS-first ordering** for `win32` / `darwin` / `linux` / other-POSIX (freebsd resolves Linux-like).
- `python -m py_compile` clean.
- **Lint/style:** no Python lint/style config (ruff/flake8/black/pyproject) exists in the repo, so none to run.
- `git grep -nE "C:/Windows/Fonts"` over the script now matches only entries inside the `win32` list — alongside the `darwin` and `linux` lists — so no hardcoded Windows-only path remains as the sole option.
