### PR TITLE
feat(story/ui): schema-generated input widgets for view-state values, flat shapes + EDN escape hatch (rf2-xon7j)

### DIFF
--- a/tools/story/spec/019-Story-UI-Controls-And-View-States.md
+++ b/tools/story/spec/019-Story-UI-Controls-And-View-States.md
@@ -78,7 +78,7 @@ Required control groups:
 | Group | Status | Backing data |
 |---|---|---|
 | Args | CURRENT/TARGET | `:args`, `:effective-args`, view-props schema, argtypes. |
-| View State | CURRENT | `:sub-overrides` + the three labelled fidelity rungs, the honesty guardrail, and the upgrade path (rf2-ba86n.7 — `re-frame.story.ui.view-state`). |
+| View State | CURRENT | `:sub-overrides` + the three labelled fidelity rungs, the honesty guardrail, the upgrade path (rf2-ba86n.7 — `re-frame.story.ui.view-state`), and schema-generated value entry per pinned override (rf2-xon7j — §5.2). |
 | Setup | CURRENT | setup-source summary off the compiled plan (`[:world :setup]` step count + dispatched event ids), surfaced in the View-State section's provenance. Event links + replay are TARGET. |
 | Network | CURRENT | route-level managed HTTP stubs surfaced as world-input provenance (off the plan's `:explain` `:network`). |
 | Effects | CURRENT | non-HTTP `:fx-overrides` surfaced as world-input provenance (off `[:world :frame :fx-overrides]`, minus `:rf.http/managed`). |
@@ -304,9 +304,47 @@ acceptance contract:
   scaffold that KEEPS the artifact a variant, adds the higher rung's
   authoring slot (`:setup` / `:db-seed`), and drops the `:sub-overrides`.
   Source is never written directly (the save-variant / author-expectations
-  idiom). Raw value entry of the upgraded state is deliberately NOT built
-  here — that is the separate, un-greenlit schema-generated input UI
-  (rf2-xon7j).
+  idiom).
+
+### 5.2 Schema-generated value entry for sub-overrides (CURRENT, rf2-xon7j)
+
+When a pinned `:sub-overrides` entry targets a sub that declares an output
+`:schema`, the View-State section generates a **typed input form** from that
+schema so the designer fills fields with the right widgets rather than
+hand-writing the override's raw EDN. A schema good enough to *validate* an
+override (the rf2-7pgiz `:where :sub-override` seam — core validates a HIT
+against the sub's declared `:schema`) is good enough to *generate* its input.
+
+Introspection reads the registered schema's **Malli EDN vector form as DATA**
+through the pure leaf `re-frame.story.malli-schema` (the same decoder the
+controls argtype derivation and the schema-validation panel use); it NEVER
+calls the pluggable validator to introspect structure (spec/010 §"The
+`:schema` value is opaque to re-frame"). No new schemas-artefact introspection
+API is required.
+
+- **Flat shapes only in the first cut** (`re-frame.story.ui.schema-form/
+  field-shape`): `:string` → text, `:int`/`:double`/`:number` → number,
+  `:boolean` → checkbox, keyword-`[:enum …]` → select, and a FLAT `[:map …]`
+  of those → a fieldset. The widget tags reuse the controls panel's scalar
+  vocabulary — one taxonomy, not two.
+
+- **The raw-EDN escape hatch is ALWAYS present.** Any shape the form cannot
+  render — a nested / recursive map, a `:vector`/`:set`/`:tuple` collection,
+  an opaque `[:fn …]` predicate, a registry ref, a compiled schema value, or
+  simply *no declared schema* (the §4 "sub override without output schema"
+  empty state) — drops to a raw-EDN textarea. The generated form NEVER blocks
+  a value; the designer can always type EDN.
+
+- **Same artifact kind, source never written directly.** Either path emits a
+  copy-paste `(story/reg-variant …-pinned {:extends … :sub-overrides { … }})`
+  scaffold (`schema-form/override-snippet`) the author pastes into source —
+  exactly the upgrade-path / save-variant idiom. The pinned value remains the
+  lowest fidelity rung (a picture for design exploration, never proof).
+
+The pure projection (`scalar-widget` / `field-shape` / `widget-default` /
+`coerce-input` / `read-edn-value` / `override-snippet`) is `.cljc` and
+JVM-tested; the React form render, the form/EDN tab toggle, and the
+value-entry dialog are CLJS-only in `re-frame.story.ui.view-state`.
 
 ## 6. Acceptance criteria
 

--- a/tools/story/src/re_frame/story/ui/schema_form.cljc
+++ b/tools/story/src/re_frame/story/ui/schema_form.cljc
@@ -1,0 +1,346 @@
+(ns re-frame.story.ui.schema-form
+  "Schema-generated input forms for view-state values (rf2-xon7j).
+
+  ## What it is
+
+  When a `:sub-overrides` target sub declares an output `:schema`, the
+  designer should fill in a TYPED FORM (text / number / checkbox / select
+  / flat fieldset) rather than hand-write the override's raw EDN. A schema
+  good enough to VALIDATE an override (the rf2-7pgiz `:where :sub-override`
+  seam — core validates a HIT against the sub's declared `:schema`) is good
+  enough to GENERATE its input. This namespace is the pure projection that
+  turns a registered schema into a flat field-shape, builds default values,
+  coerces typed input back out, and encodes the filled form into the EDN
+  `:sub-overrides` entry the View-State section emits as a copy-paste
+  scaffold (`re-frame.story.ui.view-state`).
+
+  ## SETTLE-FIRST — introspection is achieved with the EXISTING surface
+
+  Generating a form requires INTROSPECTING a schema into a field-shape
+  (key → widget-type). The mayor flagged that `re-frame.schemas` is a
+  pluggable-validator façade with only a FLAGGED-PATH walker
+  (`walk-flagged-schema` — it walks for `:sensitive?` / `:large?` flags,
+  not a general shape enumerator) and NO general introspection API; the
+  validator is pluggable, so we MUST NOT assume Malli is the installed
+  validator nor call into it to introspect structure (Spec 010 §The
+  `:schema` value is opaque to re-frame — the framework MUST NOT call the
+  registered validator to introspect schema structure).
+
+  We need no new artefact API. The re-frame2 schema REPRESENTATION is the
+  Malli EDN VECTOR FORM — `[op props? children...]` — the same data the
+  schemas-artefact walker pattern-matches on WITHOUT importing
+  `malli.core`, and the same shape `re-frame.story.malli-schema` already
+  decodes (`schema-op` / `schema-children` / `map-entry-key` /
+  `map-entry-schema`) for the controls-panel argtype derivation and the
+  schema-validation panel's args walk. We read the registered schema's EDN
+  form as data — exactly as the established Story surface does — and never
+  consult the validator. So introspection is a tiny localized READ over an
+  already-shared pure leaf, not a new general-introspection contract.
+
+  ## Flat-shapes-first + the raw-EDN escape hatch (Mike ruled, Option A)
+
+  The first cut renders the FLAT / common shapes only:
+
+  - `:string`        → text input
+  - `:int` / `:double` / `:number` → number input
+  - `:boolean`       → checkbox
+  - keyword-enum (`[:enum :a :b …]`) → select
+  - a FLAT `[:map …]` of the above → a fieldset of those widgets
+
+  Anything else — a nested / recursive map, a `:vector` / `:set` / `:tuple`
+  collection, an opaque predicate (`[:fn …]`), a registry ref, a compiled
+  schema value, or simply NO declared schema — is NOT form-renderable here.
+  For those the View-State section ALWAYS offers the raw-EDN escape hatch:
+  the designer types the value as EDN. The generated form NEVER blocks a
+  value — it is a convenience over the EDN entry that is always present
+  (spec/019 §4 — 'sub override without output schema' is a handled empty
+  state).
+
+  ## Pure / host-free
+
+  This whole namespace is pure data → data (`.cljc`, `clojure.core` +
+  the pure `malli-schema` leaf only — no Reagent, no DOM, no validator).
+  The JVM corpus pins every projection; the CLJS form render in
+  `re-frame.story.ui.view-state` paints the field-shape this ns derives."
+  (:require [clojure.string :as str]
+            #?(:clj  [clojure.edn :as edn]
+               :cljs [cljs.reader :as edn])
+            [re-frame.story.malli-schema :as msu]))
+
+;; ===========================================================================
+;; PURE: scalar-schema → widget descriptor (flat shapes only)
+;; ===========================================================================
+;;
+;; The widget vocabulary mirrors the controls-panel scalar set
+;; (`re-frame.story.ui.controls/scalar-renderers`) so the View-State form
+;; reuses the SAME widget tags + renderers (`:text` / `:number` /
+;; `:boolean` / `:select`) — no second widget taxonomy. We deliberately
+;; recognise ONLY the flat scalar shapes here; collections / nested maps /
+;; opaque predicates are NOT form-renderable and fall to the EDN escape
+;; hatch (`scalar-widget` returns nil for them).
+
+(defn scalar-widget
+  "Given a scalar Malli schema fragment, return its flat widget descriptor
+  map, or nil when the fragment is not a renderable flat scalar. Pure data
+  → data; JVM-testable.
+
+  Renderable flat scalars:
+
+  - `:string`              → `{:widget :text}`
+  - `:int` / `:double` / `:number` → `{:widget :number}`
+  - `:boolean`             → `{:widget :boolean}`
+  - `:keyword` / `:symbol` → `{:widget :text}` (coerced on entry)
+  - `[:enum a b c]` whose members are all keywords
+                           → `{:widget :select :options [a b c]}`
+
+  Everything else (a `:map` / `:vector` / `:set` / `:tuple` collection, a
+  mixed-type `:enum`, an `[:fn …]` predicate, a registry-name keyword, a
+  compiled schema value) returns nil — NOT a flat scalar, so the caller
+  drops to the EDN escape hatch."
+  [schema]
+  (cond
+    (= :string schema)  {:widget :text}
+    (= :int schema)     {:widget :number :integer? true}
+    (= :double schema)  {:widget :number}
+    (= :number schema)  {:widget :number}
+    (= :boolean schema) {:widget :boolean}
+    (= :keyword schema) {:widget :text :coerce :keyword}
+    (= :symbol schema)  {:widget :text :coerce :symbol}
+
+    (and (vector? schema) (= :enum (msu/schema-op schema)))
+    (let [options (vec (msu/schema-children schema))]
+      ;; A keyword-enum is a clean select; a mixed / non-keyword enum is
+      ;; NOT a flat select (the option encoding would be ambiguous), so it
+      ;; falls to the EDN escape hatch.
+      (when (and (seq options) (every? keyword? options))
+        {:widget :select :options options}))
+
+    :else nil))
+
+;; ===========================================================================
+;; PURE: schema → flat field-shape
+;; ===========================================================================
+
+(defn field-shape
+  "Project a sub's output `schema` into a flat FIELD-SHAPE the View-State
+  form renders, or a non-renderable descriptor that routes to the EDN
+  escape hatch. Pure data → data; JVM-testable.
+
+  Returns one of:
+
+      ;; A single flat scalar (the whole override value is one widget):
+      {:renderable? true
+       :kind        :scalar
+       :widget      <widget-descriptor>}
+
+      ;; A FLAT map of flat scalars (one widget per declared key):
+      {:renderable? true
+       :kind        :map
+       :fields      [{:key k :widget <widget-descriptor>} …]}
+
+      ;; Not form-renderable — the designer uses the raw-EDN escape hatch:
+      {:renderable? false
+       :kind        :edn
+       :reason      <human string — why no form>}
+
+  A `[:map …]` is form-renderable ONLY when EVERY declared entry is itself
+  a flat scalar (`scalar-widget` non-nil). A single non-flat entry (a
+  nested map, a collection, an opaque predicate) makes the whole map
+  non-renderable — flat-shapes-first; the escape hatch covers the rest. An
+  optional-entry marker (`[k {:optional true} child]`) is fine as long as
+  the child is a flat scalar.
+
+  `nil` / a non-vector-non-keyword schema (a compiled schema value, a
+  registry ref) is non-renderable — `:reason` names why so the section can
+  show an honest note (spec/019 §4 control empty states)."
+  [schema]
+  (cond
+    (nil? schema)
+    {:renderable? false :kind :edn :reason "no output schema declared"}
+
+    ;; A top-level flat scalar — the whole override value is one widget.
+    (when-let [w (scalar-widget schema)] w)
+    {:renderable? true :kind :scalar :widget (scalar-widget schema)}
+
+    ;; A vector form — only a FLAT `[:map …]` is renderable.
+    (and (vector? schema) (= :map (msu/schema-op schema)))
+    (let [entries (mapv (fn [entry]
+                          {:key    (msu/map-entry-key entry)
+                           :widget (scalar-widget (msu/map-entry-schema entry))})
+                        (msu/schema-children schema))]
+      (cond
+        (empty? entries)
+        {:renderable? false :kind :edn
+         :reason "empty map schema — nothing to generate"}
+
+        (every? (comp some? :widget) entries)
+        {:renderable? true :kind :map :fields entries}
+
+        :else
+        {:renderable? false :kind :edn
+         :reason (str "map has non-flat field(s): "
+                      (->> entries
+                           (remove (comp some? :widget))
+                           (map (comp pr-str :key))
+                           (str/join ", ")))}))
+
+    ;; Any other vector form (`:vector` / `:set` / `:tuple` / `:and` /
+    ;; `:or` / `:maybe` / `:multi` / `[:fn …]` / a non-keyword enum) is
+    ;; not flat-renderable.
+    (vector? schema)
+    {:renderable? false :kind :edn
+     :reason (str "non-flat schema form " (pr-str (msu/schema-op schema)))}
+
+    ;; A bare keyword that is not a recognised flat scalar = a registry
+    ;; name (`:my/user`) — opaque to a data walk.
+    (keyword? schema)
+    {:renderable? false :kind :edn
+     :reason (str "schema is a registry ref " (pr-str schema))}
+
+    ;; A compiled schema object / fn schema / anything non-data.
+    :else
+    {:renderable? false :kind :edn
+     :reason "schema is not introspectable as EDN data"}))
+
+;; ===========================================================================
+;; PURE: default values + input coercion
+;; ===========================================================================
+
+(defn widget-default
+  "A sensible empty/initial value for a flat `widget` descriptor. Pure data
+  → data. Mirrors the controls panel's `default-element-value` for the
+  scalar tags this ns supports.
+
+  - `:text`    → `\"\"`
+  - `:number`  → `nil` (an empty number input — coerced on entry)
+  - `:boolean` → `false`
+  - `:select`  → the first option (a select always has a value)"
+  [{:keys [widget options]}]
+  (case widget
+    :text    ""
+    :number  nil
+    :boolean false
+    :select  (first options)
+    nil))
+
+(defn coerce-input
+  "Coerce a raw input value for `widget` into the typed value the override
+  should carry. Pure data → data.
+
+  - `:text` with `:coerce :keyword` → a keyword (`\"loading\"` → `:loading`;
+    a leading `:` is tolerated). `:coerce :symbol` → a symbol. Plain text →
+    the string unchanged.
+  - `:number` → a long when `:integer?`, else a double; nil/blank → nil;
+    an unparseable string is returned unchanged so the form does not
+    silently swallow a typo (the live override validation surfaces it).
+  - `:boolean` → the raw value coerced to a boolean.
+  - `:select`  → the raw value passed through (the renderer hands back the
+    chosen keyword option)."
+  [{:keys [widget integer? coerce]} raw]
+  (case widget
+    :text    (cond
+               (not (string? raw)) raw
+               (= :keyword coerce)
+               (let [s (cond-> raw (str/starts-with? raw ":") (subs 1))]
+                 (when (seq s) (keyword s)))
+               (= :symbol coerce)
+               (when (seq raw) (symbol raw))
+               :else raw)
+    :number  (cond
+               (number? raw) raw
+               (and (string? raw) (seq (str/trim raw)))
+               (let [t (str/trim raw)]
+                 #?(:clj  (try (if integer? (Long/parseLong t) (Double/parseDouble t))
+                               (catch Exception _ raw))
+                    :cljs (let [n (if integer? (js/parseInt t 10) (js/parseFloat t))]
+                            (if (js/isNaN n) raw n))))
+               :else nil)
+    :boolean (boolean raw)
+    :select  raw
+    raw))
+
+(defn default-form-value
+  "Build the initial form-value for a `field-shape`. Pure data → data.
+
+  - `:scalar` → the single widget's default value.
+  - `:map`    → a `{key default}` map over the fields.
+  - `:edn`    → nil (the EDN escape hatch starts from a hand-typed string)."
+  [{:keys [kind widget fields]}]
+  (case kind
+    :scalar (widget-default widget)
+    :map    (into {} (map (fn [{:keys [key widget]}]
+                            [key (widget-default widget)]))
+                  fields)
+    nil))
+
+;; ===========================================================================
+;; PURE: the raw-EDN escape-hatch parse
+;; ===========================================================================
+
+(defn read-edn-value
+  "Best-effort read of the raw-EDN escape-hatch input `s` into a value.
+  Pure-ish (the only impurity is `read-string`, data → data here). Returns
+  `[ok? value-or-error]`. A blank string reads as `[false nil]` so the
+  dialog shows 'fill this value' rather than committing a nil override; a
+  malformed form reports `[false <error-msg>]` rather than throwing. Mirrors
+  `re-frame.story.author-expectations/read-edn` — one tolerant EDN reader
+  shape across the Story escape-hatch surfaces."
+  [s]
+  (cond
+    (nil? s)       [false nil]
+    (str/blank? s) [false nil]
+    :else
+    (try
+      [true (edn/read-string s)]
+      (catch #?(:clj Exception :cljs :default) e
+        [false #?(:clj (.getMessage ^Exception e) :cljs (str e))]))))
+
+;; ===========================================================================
+;; PURE: form-value → :sub-overrides EDN snippet
+;; ===========================================================================
+;;
+;; The View-State form NEVER writes source directly — it emits a copy-paste
+;; `:sub-overrides` scaffold the author pastes into the variant body, the
+;; SAME idiom as `view-state/upgrade-snippet`, `save-variant/gen-variant-
+;; snippet`, and `author-expectations` (source is never written directly;
+;; spec/019 §3 + §5.1). The snippet is the single override entry — query
+;; vector → filled value — pretty-printed so a multi-key map reads cleanly.
+
+(defn- pp-value
+  "Pretty-print an override `value` for the snippet. A flat map prints one
+  key per line, aligned under the opening brace; everything else prints on
+  one line via `pr-str`. Pure data → string."
+  [value indent]
+  (if (and (map? value) (seq value))
+    (let [pad     (apply str (repeat indent \space))
+          entries (->> value
+                       (sort-by (comp str key))
+                       (map (fn [[k v]] (str (pr-str k) " " (pr-str v)))))]
+      (str "{" (str/join (str "\n " pad) entries) "}"))
+    (pr-str value)))
+
+(defn override-snippet
+  "Build the copy-paste EDN scaffold that pins `query-v` to `value` as a
+  `:sub-overrides` entry on a variant `:extends`-ing `source-variant-id`.
+  Pure data → string.
+
+  KEEPS the artifact a `reg-variant` (same artifact kind, the save-variant
+  / upgrade-snippet idiom): the scaffold `:extends` the source so the
+  component / decorators / args carry forward, and adds a `:sub-overrides`
+  slot with the one filled entry for the author to paste + adjust. Source
+  is never written directly.
+
+  `value` is the typed value the form produced (or the parsed EDN from the
+  escape hatch). When `from-edn?` is true a trailing comment notes the
+  value came from the raw-EDN path (the form could not render the shape)."
+  ([source-variant-id query-v value]
+   (override-snippet source-variant-id query-v value false))
+  ([source-variant-id query-v value from-edn?]
+   (let [v-str (pp-value value 20)]
+     (str "(story/reg-variant " (pr-str source-variant-id) "-pinned\n"
+          "  {:extends " (pr-str source-variant-id) "\n"
+          "   :sub-overrides {" (pr-str query-v) " " v-str "}})\n"
+          ";; pins " (pr-str query-v)
+          " for design exploration — lowest fidelity, never proof of sub logic."
+          (when from-edn?
+            "\n;; value entered as raw EDN (the output schema was not flat-renderable).")))))

--- a/tools/story/src/re_frame/story/ui/view_state.cljc
+++ b/tools/story/src/re_frame/story/ui/view_state.cljc
@@ -51,11 +51,29 @@
   offers, per available higher rung, a scaffold snippet
   (`upgrade-snippet`) that re-emits the SAME variant (`:extends` the
   source) with a `:setup` (→ `:real-setup`) or `:db-seed` (→ `:db-seed`)
-  slot to fill in, dropping the `:sub-overrides`. Raw value entry of the
-  upgraded state is deliberately NOT built here (that is the separate,
-  un-greenlit rf2-xon7j schema-generated input UI); the upgrade emits a
+  slot to fill in, dropping the `:sub-overrides`. The upgrade emits a
   copy-paste scaffold the author completes, exactly as save-variant /
   author-expectations do (source is never written directly).
+
+  ## Schema-generated value entry (rf2-xon7j)
+
+  When a pinned sub-override targets a sub that declares an output
+  `:schema`, the section generates a TYPED INPUT FORM from that schema
+  (`re-frame.story.ui.schema-form/field-shape`) so the designer fills
+  fields with the right widgets (text / number / checkbox / select / a
+  flat fieldset) rather than hand-writing the override's raw EDN. A schema
+  good enough to VALIDATE an override (the rf2-7pgiz `:where :sub-override`
+  seam) is good enough to GENERATE its input — we read the registered
+  schema's Malli EDN VECTOR form as DATA (via the pure `malli-schema`
+  leaf), never calling the pluggable validator to introspect structure
+  (Spec 010 §The `:schema` value is opaque to re-frame).
+
+  Flat shapes only in the first cut; ANY non-flat shape (nested map,
+  collection, opaque predicate, registry ref, or simply no schema) drops
+  to the raw-EDN escape hatch, which is ALWAYS present — the form never
+  blocks a value. Either path emits the SAME copy-paste `:sub-overrides`
+  scaffold (`schema-form/override-snippet`, source never written
+  directly), exactly as the upgrade path does.
 
   ## Pure / CLJS split
 
@@ -80,7 +98,9 @@
             ;; (the `author_expectations.cljc` idiom).
             #?@(:cljs [[clojure.string :as str]
                        [reagent.core :as r]
+                       [re-frame.registrar :as rf-registrar]
                        [re-frame.story.review-dialog :as review-dialog]
+                       [re-frame.story.ui.schema-form :as schema-form]
                        [re-frame.story.ui.trace-buffer :as trace-buffer]
                        [re-frame.story.theme.typography :as typography :refer [mono-stack sans-stack]]
                        [re-frame.story.theme.colors :as colors]])))
@@ -541,7 +561,139 @@
                      :padding "6px"
                      :font-family mono-stack
                      :font-size (:micro typography/type-scale)
-                     :white-space "pre-wrap"}}))
+                     :white-space "pre-wrap"}
+      ;; rf2-xon7j — the schema-generated value-entry surface.
+      :pin-btn      {:padding "2px 8px"
+                     :background (:bg-3 colors/tokens)
+                     :color (:text-primary colors/tokens)
+                     :border (str "1px solid " (:border-default colors/tokens))
+                     :border-radius "3px"
+                     :cursor "pointer"
+                     :font-family sans-stack
+                     :font-size (:nano typography/type-scale)
+                     :margin-left "6px"}
+      :tab-row      {:display "flex" :gap "4px" :margin-bottom "8px"}
+      :tab          {:padding "3px 10px"
+                     :background (:bg-2 colors/tokens)
+                     :color (:text-secondary colors/tokens)
+                     :border (str "1px solid " (:border-subtle colors/tokens))
+                     :border-radius "3px"
+                     :cursor "pointer"
+                     :font-family sans-stack
+                     :font-size (:micro typography/type-scale)}
+      :tab-active   {:background (:info-bg colors/tokens)
+                     :color (:info colors/tokens)
+                     :border (str "1px solid " (:info colors/tokens))}
+      :form-grid    {:display "grid"
+                     :grid-template-columns "auto 1fr"
+                     :gap "6px 10px"
+                     :align-items "baseline"
+                     :margin-bottom "8px"}
+      :form-key     {:font-family mono-stack
+                     :font-size (:micro typography/type-scale)
+                     :color (:warning colors/tokens)}
+      :form-input   {:padding "3px 6px"
+                     :background (:bg-2 colors/tokens)
+                     :color (:text-primary colors/tokens)
+                     :border (str "1px solid " (:border-default colors/tokens))
+                     :border-radius "3px"
+                     :font-family mono-stack
+                     :font-size (:micro typography/type-scale)
+                     :width "100%"
+                     :box-sizing "border-box"}
+      :edn-area     {:padding "6px"
+                     :background "#0e0e10"
+                     :color (:warning colors/tokens)
+                     :border (str "1px solid " (:border-default colors/tokens))
+                     :border-radius "3px"
+                     :font-family mono-stack
+                     :font-size (:micro typography/type-scale)
+                     :width "100%"
+                     :min-height "60px"
+                     :box-sizing "border-box"}
+      :edn-err      {:color (:danger colors/tokens)
+                     :font-size (:micro typography/type-scale)
+                     :margin-top "4px"}}))
+
+;; ---- schema-generated value entry (rf2-xon7j) ----------------------------
+;;
+;; Resolve a pinned sub-override's TARGET sub output `:schema` off the
+;; framework registrar (`re-frame.registrar/lookup :sub <sub-id>` →
+;; `:schema` — the SAME slot core's rf2-7pgiz `maybe-validate-sub-override!`
+;; reads), then project it into a flat field-shape. The schema is read as
+;; DATA (the Malli EDN vector form) via the pure `schema-form` leaf — we
+;; NEVER call the pluggable validator to introspect structure (Spec 010
+;; §The `:schema` value is opaque to re-frame). The lookup is CLJS-only (the
+;; framework registrar side-table is populated at runtime); the field-shape
+;; projection it feeds is pure + JVM-tested in `schema-form`.
+
+#?(:cljs
+   (defn- sub-output-schema
+     "Return the declared output `:schema` of the sub the override `query-v`
+      targets (the query vector's head sub-id), or nil when the sub is
+      unregistered or carries no schema. Best-effort tooling read — never
+      throws."
+     [query-v]
+     (when (vector? query-v)
+       (try
+         (:schema (rf-registrar/lookup :sub (first query-v)))
+         (catch :default _ nil)))))
+
+#?(:cljs
+   (defn override-field-shape
+     "Resolve the field-shape for the sub-override `query-v` — the flat
+      form descriptor derived from the target sub's output schema, or the
+      EDN-escape-hatch descriptor when the sub has no schema / a non-flat
+      one. Returns a `schema-form/field-shape` map. CLJS-only (reaches the
+      framework registrar); pure once the schema is resolved."
+     [query-v]
+     (schema-form/field-shape (sub-output-schema query-v))))
+
+;; ---- the value-entry dialog ratom (reuses the shared review-dialog) ------
+;;
+;; The dialog carries the per-field form value (a ratom map keyed by the
+;; override's query vector) and the raw-EDN escape-hatch text. The snippet
+;; re-generates on every edit so the previewed `:sub-overrides` scaffold
+;; tracks the form. Source is never written directly — the user copies +
+;; pastes (the save-variant / upgrade idiom).
+
+#?(:cljs
+   (defonce ^:private value-entry-dialog
+     (r/atom (assoc review-dialog/initial-state
+                    :form    nil
+                    :edn     ""
+                    :edn?    false
+                    :shape   nil
+                    :query-v nil))))
+
+#?(:cljs
+   (defn- open-value-entry-dialog!
+     "Open the schema-generated value-entry dialog for `variant-id`'s
+      sub-override on `query-v`. Seeds the form with the field-shape's
+      default value (or the row's current pinned `value` when present) and
+      starts on the FORM tab when the shape is flat-renderable, the EDN tab
+      otherwise (the escape hatch is always available)."
+     [variant-id query-v current-value]
+     (let [shape (override-field-shape query-v)
+           form  (if (some? current-value)
+                   current-value
+                   (schema-form/default-form-value shape))]
+       (reset! value-entry-dialog
+               (-> review-dialog/initial-state
+                   (assoc :open?     true
+                          :source-id variant-id
+                          :query-v   query-v
+                          :shape     shape
+                          :form      form
+                          :edn       (if (some? current-value)
+                                       (pr-str current-value) "")
+                          :edn?      (not (:renderable? shape))))))))
+
+#?(:cljs
+   (defn- close-value-entry-dialog! []
+     (reset! value-entry-dialog
+             (assoc review-dialog/initial-state
+                    :form nil :edn "" :edn? false :shape nil :query-v nil))))
 
 ;; ---- the upgrade dialog ratom (reuses the shared review-dialog) ----------
 
@@ -567,6 +719,188 @@
 #?(:cljs
    (defn- close-upgrade-dialog! []
      (reset! upgrade-dialog review-dialog/initial-state)))
+
+;; ---- schema-generated value-entry render (rf2-xon7j) ---------------------
+;;
+;; The dialog has TWO tabs: a generated FORM (when the target sub's output
+;; schema is flat-renderable) and the raw-EDN escape hatch (always present).
+;; The form edits a per-field value map; the EDN tab edits a string parsed
+;; on commit. Both produce the SAME `:sub-overrides` scaffold the user
+;; copies + pastes — source is never written directly.
+
+#?(:cljs
+   (defn- field-widget
+     "Render one flat field widget for `field` (`{:key :widget}`) against
+      the form `value` map, writing typed edits back through `on-edit`
+      `(fn [k typed-value])` (the value is coerced via `schema-form/
+      coerce-input` before it lands). Closed scalar vocabulary —
+      `:text` / `:number` / `:boolean` / `:select`."
+     [{fk :key {:keys [widget options] :as wspec} :widget} value on-edit]
+     (let [v     (get value fk)
+           emit! (fn [raw] (on-edit fk (schema-form/coerce-input wspec raw)))]
+       (case widget
+         :boolean
+         [:input {:type      "checkbox"
+                  :data-test "story-view-state-field"
+                  :data-field (str fk)
+                  :aria-label (str fk)
+                  :checked   (boolean v)
+                  :on-change (fn [e] (emit! (.. e -target -checked)))}]
+
+         :select
+         [:select {:style      (:form-input styles)
+                   :data-test  "story-view-state-field"
+                   :data-field (str fk)
+                   :aria-label (str fk)
+                   :value      (str v)
+                   :on-change  (fn [e]
+                                 ;; map the chosen string back to the
+                                 ;; keyword option it names.
+                                 (let [chosen (.. e -target -value)]
+                                   (on-edit fk (some #(when (= (str %) chosen) %)
+                                                     options))))}
+          (for [opt options]
+            ^{:key (str opt)} [:option {:value (str opt)} (str opt)])]
+
+         :number
+         [:input {:type      "number"
+                  :style     (:form-input styles)
+                  :data-test "story-view-state-field"
+                  :data-field (str fk)
+                  :aria-label (str fk)
+                  :value     (if (nil? v) "" v)
+                  :on-change (fn [e] (emit! (.. e -target -value)))}]
+
+         ;; :text (and any text-coerced scalar)
+         [:input {:type      "text"
+                  :style     (:form-input styles)
+                  :data-test "story-view-state-field"
+                  :data-field (str fk)
+                  :aria-label (str fk)
+                  :value     (if (nil? v) "" (str v))
+                  :on-change (fn [e] (emit! (.. e -target -value)))}]))))
+
+#?(:cljs
+   (defn- value-form
+     "Render the generated input form for `shape` against the form `value`,
+      writing edits back through `set-form!` `(fn [next-form])`. A `:scalar`
+      shape is one widget for the whole value; a `:map` shape is a labelled
+      grid of per-key widgets. Pure-ish — the widgets call back on edit."
+     [shape value set-form!]
+     (case (:kind shape)
+       :scalar
+       [:div {:style (:form-grid styles) :data-test "story-view-state-value-form"}
+        [:span {:style (:form-key styles)} "value"]
+        (field-widget {:key :value :widget (:widget shape)}
+                      {:value value}
+                      (fn [_ typed] (set-form! typed)))]
+
+       :map
+       (into [:div {:style (:form-grid styles) :data-test "story-view-state-value-form"}]
+             (mapcat
+               (fn [{fk :key :as field}]
+                 [^{:key (str "k-" fk)} [:span {:style (:form-key styles)} (str fk)]
+                  ^{:key (str "w-" fk)}
+                  [field-widget field value
+                   (fn [k typed] (set-form! (assoc value k typed)))]])
+               (:fields shape)))
+
+       nil)))
+
+#?(:cljs
+   (defn- value-entry-snippet
+     "Build the live `:sub-overrides` scaffold for the current dialog state.
+      On the FORM tab the value is the coerced form map/scalar; on the EDN
+      tab it is the parsed escape-hatch value (the un-parseable case yields
+      a placeholder so the preview still renders honestly)."
+     [{:keys [source-id query-v form edn edn?]}]
+     (if edn?
+       (let [[ok? v] (schema-form/read-edn-value edn)]
+         (schema-form/override-snippet source-id query-v
+                                       (if ok? v :rf.story/fill-this-value)
+                                       true))
+       (schema-form/override-snippet source-id query-v form false))))
+
+#?(:cljs
+   (defn- value-entry-dialog-view
+     "Render the schema-generated value-entry dialog (visible iff open).
+      Reuses the shared review-dialog skeleton for the snippet preview +
+      copy + close; the FORM / EDN tabs + the per-field widgets render in
+      the dialog's `:hint` slot (the review-dialog is presentational, so
+      the flow-specific entry UI rides the hint, exactly like save-variant
+      threads its slice-report there)."
+     []
+     (let [dialog @value-entry-dialog]
+       (when (:open? dialog)
+         (let [{:keys [query-v shape edn edn? form]} dialog
+               renderable? (:renderable? shape)
+               edn-tab?    (boolean edn?)
+               [edn-ok? edn-err] (when edn-tab? (schema-form/read-edn-value edn))
+               snippet     (value-entry-snippet dialog)
+               set-tab!    (fn [to-edn?]
+                             (swap! value-entry-dialog assoc :edn? to-edn?))]
+           (review-dialog/review-dialog dialog
+             {:title (str "Pin value for " (pr-str query-v))
+              :hint
+              [:div {:data-test "story-view-state-value-entry"
+                     :data-renderable (str (boolean renderable?))
+                     :data-mode (if edn-tab? "edn" "form")}
+               [:div {:style {:margin-bottom "6px"}}
+                "Fill the override value and copy the generated "
+                [:code ":sub-overrides"] " entry into your stories namespace. "
+                "Source is never written directly. This is the lowest "
+                "fidelity rung — a picture for design exploration, never proof."]
+               ;; Tab row — the form tab only when the schema is flat-
+               ;; renderable; the EDN escape hatch is ALWAYS available.
+               [:div {:style (:tab-row styles)}
+                (when renderable?
+                  [:button {:style    (merge (:tab styles)
+                                             (when-not edn-tab? (:tab-active styles)))
+                            :type     "button"
+                            :data-test "story-view-state-value-tab"
+                            :data-tab "form"
+                            :on-click (fn [_] (set-tab! false))}
+                   "form"])
+                [:button {:style    (merge (:tab styles)
+                                           (when edn-tab? (:tab-active styles)))
+                          :type     "button"
+                          :data-test "story-view-state-value-tab"
+                          :data-tab "edn"
+                          :on-click (fn [_] (set-tab! true))}
+                 "raw EDN"]]
+               ;; The active surface.
+               (if edn-tab?
+                 [:div
+                  [:textarea {:style     (:edn-area styles)
+                              :data-test "story-view-state-edn"
+                              :aria-label "Override value as EDN"
+                              :value     (or edn "")
+                              :on-change (fn [e]
+                                           (swap! value-entry-dialog assoc :edn
+                                                  (.. e -target -value)))}]
+                  (when (and (seq (str edn)) (not edn-ok?))
+                    [:div {:style (:edn-err styles)
+                           :data-test "story-view-state-edn-error"}
+                     (str "not valid EDN" (when edn-err (str ": " edn-err)))])]
+                 (when renderable?
+                   [value-form shape form
+                    (fn [next-form]
+                      (swap! value-entry-dialog assoc :form next-form))]))
+               (when-not renderable?
+                 [:div {:style (:blurb styles)
+                        :data-test "story-view-state-no-form"}
+                  (str "no generated form — " (:reason shape)
+                       ". Enter the value as EDN above.")])]
+              :snippet          snippet
+              ;; The scaffold id is DERIVED (stays a variant); the id input
+              ;; is informational, the snippet is the load-bearing output.
+              :placeholder-id   (when (qualified-keyword? (:source-id dialog))
+                                  (keyword (namespace (:source-id dialog))
+                                           (str (name (:source-id dialog)) "-pinned")))
+              :on-edit-id       (fn [_])
+              :on-copy          (fn [] (review-dialog/copy-to-clipboard! snippet))
+              :on-close         close-value-entry-dialog!
+              :data-test-prefix "story-view-state-value"}))))))
 
 ;; ---- render helpers ------------------------------------------------------
 
@@ -639,8 +973,15 @@
      "The sub-override provenance — the exact pinned query vectors + values
      (spec/019 §5 — 'the exact query vectors overridden'), the plan-time
      output-schema validation status, and any LIVE `:where :sub-override`
-     schema-validation failures."
-     [{:keys [present? rows validation]} failures]
+     schema-validation failures.
+
+     rf2-xon7j: each pinned row carries an `edit value` affordance that
+     opens the schema-generated value-entry dialog pre-seeded with the
+     row's current value — a TYPED FORM when the target sub's output schema
+     is flat-renderable, the raw-EDN escape hatch otherwise (always
+     available). The dialog emits a copy-paste `:sub-overrides` scaffold
+     (source never written directly)."
+     [variant-id {:keys [present? rows validation]} failures]
      [:div {:data-test "story-view-state-overrides"}
       (if present?
         [:div
@@ -653,7 +994,17 @@
                         :data-test "story-view-state-override-row"
                         :data-query (pr-str query-v)}
                   [:span {:style (:ovr-query styles)} (pr-str query-v)]
-                  [:span {:style (:ovr-value styles)} (str "→ " (pr-str value))]]))
+                  [:span {:style (:ovr-value styles)}
+                   (str "→ " (pr-str value))
+                   [:button {:style    (:pin-btn styles)
+                             :type     "button"
+                             :data-test "story-view-state-edit-value-btn"
+                             :data-query (pr-str query-v)
+                             :title    "Edit this pinned value via a schema-generated form (or raw EDN)"
+                             :on-click (fn [_]
+                                         (open-value-entry-dialog!
+                                           variant-id query-v value))}
+                    "edit value"]]]))
          ;; plan-time output-schema validation status.
          (when (and validation (= :ok (:status validation)))
            [:div {:style (:empty styles)
@@ -800,11 +1151,13 @@
                   (setup-provenance setup)
                   (network-provenance network)
                   (fx-provenance fx-overrides)
-                  [override-provenance overrides override-failures]]
+                  [override-provenance variant-id overrides override-failures]]
                  ;; ---- honesty guardrail (sub-overrides floor) ----
                  (when low-fidelity?
                    [honesty-guardrail])
                  ;; ---- upgrade path ----
                  [upgrade-path variant-id upgrade-targets]]))
             ;; the upgrade scaffold dialog (portal-less inline; visible iff open)
-            [upgrade-dialog-view]])))))
+            [upgrade-dialog-view]
+            ;; the schema-generated value-entry dialog (rf2-xon7j; visible iff open)
+            [value-entry-dialog-view]])))))

--- a/tools/story/test/re_frame/story/ui/schema_form_test.cljc
+++ b/tools/story/test/re_frame/story/ui/schema_form_test.cljc
@@ -1,0 +1,177 @@
+(ns re-frame.story.ui.schema-form-test
+  "JVM-portable regression net for the schema-generated input-form pure
+  projection (rf2-xon7j, spec/019 §5.1 + §4 control empty states).
+
+  Covers the host-free surface — no host, no Reagent, no validator:
+
+  - `scalar-widget`     — flat scalar → widget descriptor; non-flat → nil.
+  - `field-shape`       — schema → renderable scalar / flat map / EDN
+                          escape-hatch descriptor (the flat-shapes-first
+                          boundary + the always-present escape hatch).
+  - `widget-default` / `default-form-value` — initial form values.
+  - `coerce-input`      — typed coercion of raw input back out.
+  - `override-snippet`  — the copy-paste `:sub-overrides` scaffold (same
+                          artifact kind, source never written directly)."
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.string :as str]
+            [re-frame.story.ui.schema-form :as sf]))
+
+;; ---------------------------------------------------------------------------
+;; scalar-widget — the flat scalar vocabulary; non-flat → nil
+;; ---------------------------------------------------------------------------
+
+(deftest scalar-widget-maps-the-flat-shapes
+  (testing "each flat scalar maps to its widget tag"
+    (is (= {:widget :text}                (sf/scalar-widget :string)))
+    (is (= {:widget :number :integer? true} (sf/scalar-widget :int)))
+    (is (= {:widget :number}              (sf/scalar-widget :double)))
+    (is (= {:widget :number}              (sf/scalar-widget :number)))
+    (is (= {:widget :boolean}             (sf/scalar-widget :boolean)))
+    (is (= {:widget :text :coerce :keyword} (sf/scalar-widget :keyword))))
+  (testing "a keyword-enum becomes a select over its options"
+    (is (= {:widget :select :options [:loading :ready :error]}
+           (sf/scalar-widget [:enum :loading :ready :error])))))
+
+(deftest scalar-widget-rejects-non-flat-shapes
+  (testing "collections / nested maps / opaque predicates are NOT flat scalars"
+    (is (nil? (sf/scalar-widget [:map [:k :string]])))
+    (is (nil? (sf/scalar-widget [:vector :int])))
+    (is (nil? (sf/scalar-widget [:set :keyword])))
+    (is (nil? (sf/scalar-widget [:tuple :int :int])))
+    (is (nil? (sf/scalar-widget [:fn 'pos?]))))
+  (testing "a mixed-type / non-keyword enum is NOT a flat select (ambiguous encoding)"
+    (is (nil? (sf/scalar-widget [:enum "a" "b"])))
+    (is (nil? (sf/scalar-widget [:enum 1 2 3])))
+    (is (nil? (sf/scalar-widget [:enum]))))
+  (testing "a registry-name keyword is opaque to a data walk"
+    (is (nil? (sf/scalar-widget :my/user)))))
+
+;; ---------------------------------------------------------------------------
+;; field-shape — renderable scalar / flat map / EDN escape hatch
+;; ---------------------------------------------------------------------------
+
+(deftest field-shape-single-scalar-is-renderable
+  (testing "a top-level flat scalar renders as one widget"
+    (is (= {:renderable? true :kind :scalar :widget {:widget :text}}
+           (sf/field-shape :string)))
+    (is (= :select (get-in (sf/field-shape [:enum :a :b]) [:widget :widget])))))
+
+(deftest field-shape-flat-map-is-renderable
+  (testing "a flat map of flat scalars renders one field per declared key"
+    (let [shape (sf/field-shape [:map
+                                 [:state [:enum :loading :ready :error]]
+                                 [:msg   :string]
+                                 [:count :int]])]
+      (is (true? (:renderable? shape)))
+      (is (= :map (:kind shape)))
+      (is (= [:state :msg :count] (mapv :key (:fields shape))))
+      (is (= [:select :text :number] (mapv (comp :widget :widget) (:fields shape))))))
+  (testing "an optional-marked flat entry is still renderable"
+    (let [shape (sf/field-shape [:map [:msg {:optional true} :string]])]
+      (is (true? (:renderable? shape)))
+      (is (= [:msg] (mapv :key (:fields shape)))))))
+
+(deftest field-shape-non-flat-falls-to-edn-escape-hatch
+  (testing "no declared schema → EDN escape hatch with an honest reason"
+    (let [shape (sf/field-shape nil)]
+      (is (false? (:renderable? shape)))
+      (is (= :edn (:kind shape)))
+      (is (str/includes? (:reason shape) "no output schema"))))
+  (testing "a map with a NESTED field is non-renderable (flat-shapes-first)"
+    (let [shape (sf/field-shape [:map
+                                 [:ok :boolean]
+                                 [:nested [:map [:deep :string]]]])]
+      (is (false? (:renderable? shape)))
+      (is (= :edn (:kind shape)))
+      (is (str/includes? (:reason shape) ":nested"))))
+  (testing "a collection / tuple / predicate schema is non-renderable"
+    (is (false? (:renderable? (sf/field-shape [:vector :int]))))
+    (is (false? (:renderable? (sf/field-shape [:tuple :int :int]))))
+    (is (false? (:renderable? (sf/field-shape [:fn 'map?])))))
+  (testing "a registry ref is non-renderable but names itself"
+    (let [shape (sf/field-shape :my/user)]
+      (is (false? (:renderable? shape)))
+      (is (str/includes? (:reason shape) ":my/user"))))
+  (testing "an empty map schema is non-renderable"
+    (is (false? (:renderable? (sf/field-shape [:map]))))))
+
+;; ---------------------------------------------------------------------------
+;; defaults + coercion
+;; ---------------------------------------------------------------------------
+
+(deftest widget-defaults-are-sensible-empties
+  (is (= ""    (sf/widget-default {:widget :text})))
+  (is (nil?    (sf/widget-default {:widget :number})))
+  (is (false?  (sf/widget-default {:widget :boolean})))
+  (is (= :a    (sf/widget-default {:widget :select :options [:a :b]}))))
+
+(deftest default-form-value-builds-the-initial-form
+  (testing "a scalar shape defaults to its widget default"
+    (is (= "" (sf/default-form-value {:kind :scalar :widget {:widget :text}}))))
+  (testing "a map shape defaults to a per-key default map"
+    (is (= {:state :loading :msg "" :count nil}
+           (sf/default-form-value
+             {:kind   :map
+              :fields [{:key :state :widget {:widget :select :options [:loading :ready]}}
+                       {:key :msg   :widget {:widget :text}}
+                       {:key :count :widget {:widget :number :integer? true}}]}))))
+  (testing "an EDN shape has no generated default"
+    (is (nil? (sf/default-form-value {:kind :edn})))))
+
+(deftest coerce-input-types-the-raw-value
+  (testing "text passes through; keyword-coercion strips a leading colon"
+    (is (= "hi"      (sf/coerce-input {:widget :text} "hi")))
+    (is (= :loading  (sf/coerce-input {:widget :text :coerce :keyword} "loading")))
+    (is (= :loading  (sf/coerce-input {:widget :text :coerce :keyword} ":loading")))
+    (is (nil?        (sf/coerce-input {:widget :text :coerce :keyword} ""))))
+  (testing "number coerces to int / double; blank → nil; a typo stays raw"
+    (is (= 42        (sf/coerce-input {:widget :number :integer? true} "42")))
+    (is (= 3.5       (sf/coerce-input {:widget :number} "3.5")))
+    (is (nil?        (sf/coerce-input {:widget :number} "")))
+    (is (= "x"       (sf/coerce-input {:widget :number} "x"))))
+  (testing "boolean + select"
+    (is (true?  (sf/coerce-input {:widget :boolean} true)))
+    (is (false? (sf/coerce-input {:widget :boolean} nil)))
+    (is (= :ready (sf/coerce-input {:widget :select :options [:ready :error]} :ready)))))
+
+;; ---------------------------------------------------------------------------
+;; read-edn-value — the raw-EDN escape hatch
+;; ---------------------------------------------------------------------------
+
+(deftest read-edn-value-parses-the-escape-hatch
+  (testing "a valid EDN form reads ok"
+    (is (= [true :error]            (sf/read-edn-value ":error")))
+    (is (= [true {:state :ready}]   (sf/read-edn-value "{:state :ready}")))
+    (is (= [true [1 2 3]]           (sf/read-edn-value "[1 2 3]"))))
+  (testing "blank / nil read as not-ok (fill this value), never committing nil"
+    (is (= [false nil] (sf/read-edn-value "")))
+    (is (= [false nil] (sf/read-edn-value "   ")))
+    (is (= [false nil] (sf/read-edn-value nil))))
+  (testing "a malformed form reports not-ok with a message, never throws"
+    (let [[ok? msg] (sf/read-edn-value "{:a ")]
+      (is (false? ok?))
+      (is (string? msg)))))
+
+;; ---------------------------------------------------------------------------
+;; override-snippet — same artifact kind, source never written directly
+;; ---------------------------------------------------------------------------
+
+(deftest override-snippet-pins-a-value-keeping-the-artifact-a-variant
+  (testing "the scaffold is a reg-variant :extends-ing the source with one pinned entry"
+    (let [snip (sf/override-snippet :story.login/explore [:login/state] :error)]
+      (is (str/includes? snip "story/reg-variant")
+          "stays a reg-variant — artifact kind unchanged")
+      (is (str/includes? snip ":extends :story.login/explore")
+          "extends the source so component/decorators/args carry forward")
+      (is (str/includes? snip ":sub-overrides"))
+      (is (str/includes? snip "[:login/state] :error")
+          "the pinned query vector → value")
+      (is (str/includes? snip "never proof")
+          "the honest lowest-fidelity reading rides on the scaffold")))
+  (testing "a flat-map value prints cleanly"
+    (let [snip (sf/override-snippet :story.s/v [:q] {:state :ready :msg "ok"})]
+      (is (str/includes? snip ":state :ready"))
+      (is (str/includes? snip ":msg \"ok\""))))
+  (testing "the from-edn? flag notes the raw-EDN path"
+    (let [snip (sf/override-snippet :story.s/v [:q] {:x 1} true)]
+      (is (str/includes? snip "raw EDN")))))


### PR DESCRIPTION
## What

When a `:sub-overrides` target sub declares an output `:schema`, the View-State controls section (the rf2-ba86n.7 surface) now **generates a typed input form** from that schema so a designer fills fields with the right widgets instead of hand-writing the override's raw EDN. Per-pinned-row an `edit value` affordance opens a value-entry dialog; the filled form (or raw EDN) emits a copy-paste `:sub-overrides` scaffold — source is never written directly. Implements the feature spec/019 §5.1 explicitly deferred as "the separate … rf2-xon7j schema-generated input UI".

Mike ruled **Option A**: flat-shapes-first + raw-EDN escape hatch, reading the re-frame2 schema representation as the source of truth.

## SETTLE-FIRST outcome — PROCEEDED (no new artefact API)

The mayor flagged that `re-frame.schemas` is a pluggable-validator façade with only a flagged-path walker (`walk-flagged-schema` — `:sensitive?`/`:large?` flags, not a shape enumerator) and **no general introspection API**; the validator is pluggable (not necessarily Malli) and Spec 010 forbids calling it to introspect structure.

Resolved without any new schemas-artefact API: the re-frame2 schema **representation** is the Malli EDN **vector form** (`[op props? children…]`), which the existing pure leaf `re-frame.story.malli-schema` already decodes as DATA (`schema-op` / `schema-children` / `map-entry-key` / `map-entry-schema`) — the same walk the controls argtype derivation and the schema-validation panel use. The new code reads the registered schema's EDN form via that leaf and **never calls the validator** to introspect structure. So introspection is a tiny localized read over an already-shared pure surface, not a new contract. No stop-valve needed.

## Shapes supported + the EDN escape hatch

`re-frame.story.ui.schema-form/field-shape` renders these **flat** shapes:
- `:string` → text · `:int`/`:double`/`:number` → number · `:boolean` → checkbox · keyword-`[:enum …]` → select · flat `[:map …]` of those → a fieldset (one widget per key).

The widget tags reuse the controls panel's scalar vocabulary (one taxonomy, not two).

**Raw-EDN escape hatch is ALWAYS present.** Any non-flat shape — nested/recursive map, `:vector`/`:set`/`:tuple` collection, opaque `[:fn …]` predicate, registry ref, compiled schema value, or simply *no declared schema* (the spec/019 §4 "sub override without output schema" empty state) — drops to a raw-EDN textarea. The form never blocks a value. Either path emits the same `(story/reg-variant …-pinned {:extends … :sub-overrides {…}})` scaffold (same artifact kind; the save-variant / upgrade-snippet idiom), and the pinned value stays the lowest fidelity rung (never proof).

Pure projection (`scalar-widget` / `field-shape` / `widget-default` / `coerce-input` / `read-edn-value` / `override-snippet`) is `.cljc` + JVM-tested; the React form, the form/EDN tab toggle, and the value-entry dialog are CLJS-only in `view-state`.

## Quality gates

| Gate | Command | Result |
|---|---|---|
| Pure schema-form (JVM) | `clojure -M:test --namespace re-frame.story.ui.schema-form-test` | **10 tests, 70 assertions, 0 failures, 0 errors** |
| Story JVM suite | `clojure -M:test` (tools/story) | **1515 tests, 5668 assertions, 0 failures, 0 errors** |
| CLJS node suite | `npm run test:cljs` (implementation) | **5011 tests, 16763 assertions, 0 failures, 0 errors** |
| clj-kondo | `clj-kondo --fail-level error --lint tools/story/src` | **0 errors** (exit 0; new files warning-clean) |
| Bundle isolation | `npm run test:bundle-isolation` | **PASS** (17 artefact entries, 35 sentinels absent; uix/helix/reagent-free PASS) |

`mkdocs build --strict`: not required — `tools/story/spec/*` is an internal spec doc, not in the mkdocs tree (verified).

## Spec kept current

`tools/story/spec/019-Story-UI-Controls-And-View-States.md`: new **§5.2** documents the schema-generated value-entry surface, the SETTLE-FIRST introspection approach, the flat-shape set, and the always-present escape hatch; §1 control-group row + §5.1 updated (§5.1 no longer says raw value entry is un-built).

## Hot-zone

None touched. No new testbed/build-id (reused existing surfaces; the form-generation path is fully JVM-tested, so no testbed churn — the testbed subs carry no output `:schema`, and adding a sub-override variant would break exact variant-count test assertions). `re-frame.registrar` is required by `view-state` consistent with the existing `plan.cljc` / `dispatch_console_events.cljc` consumers — no new dependency direction.
