### PR TITLE
feat(story/ui): human share/export/copy/static UX with reproducibility labels — reframe (rf2-ba86n.16)

### DIFF
--- a/tools/story/spec/022-Story-UI-Docs-And-Share.md
+++ b/tools/story/spec/022-Story-UI-Docs-And-Share.md
@@ -1,12 +1,27 @@
 # Story UI — Docs Mode and Share
 
 > The Story `:docs` mode as curated, executable variant documentation
-> with evidence excerpts; and the egress surface — share URLs, static
-> export, copied EDN / inline plans / run artifacts, screenshots, and
-> promoted variants — all flowing through one common redaction/elision
-> seam before data leaves the process. This spec **extends**
-> [`008-Docs-Mode.md`](008-Docs-Mode.md) with evidence excerpts and the
-> egress contract.
+> with evidence excerpts; and the **human-facing egress** surface — share
+> URLs, static export, copied EDN, screenshots, and promoted variants —
+> shipping freely and each labelled with its **reproducibility status**
+> (fully / partially / view-only) so a recipient knows what they can
+> replay. This spec **extends** [`008-Docs-Mode.md`](008-Docs-Mode.md)
+> with evidence excerpts and the reproducibility contract.
+>
+> **Reframe (authoritative, Mike 2026-05-30; rf2-ba86n.16).** Human-facing
+> egress of a developer's OWN running app is NOT a privacy concern: a
+> local developer already has programmatic access to their own secrets,
+> so redacting human egress is futile and is NOT the goal. The two real
+> redaction points — the AI/MCP boundary and logs — are handled
+> elsewhere (rf2-m25hd verified the MCP gate; rf2-6773q scrubbed logs;
+> the common-seam dependency rf2-qarwq is CLOSED). So the human share /
+> copy / static / screenshot commands SHIP — enabled, working, **not**
+> disabled-pending-a-seam and **not** privacy-gated. What survives is the
+> genuinely valuable half of the T4 tension: a shared / exported / copied
+> artifact states whether the recipient can **reproduce** it. This spec
+> previously encoded the pre-reframe "route all egress through a common
+> redaction seam, treat share as privacy-sensitive" model; that framing
+> is superseded by the reproducibility-honesty contract below.
 
 ## Builds on
 
@@ -17,46 +32,53 @@
   AutoDocs-equivalent docs pane (header, prose, args, decorators,
   parameters, tags) and its read-only contract.
 - [`013-Static-Build.md`](013-Static-Build.md) — `story:build`, the
-  static HTML export; the egress contract here applies to its output.
+  static HTML export; the reproducibility contract here labels its output.
 - [`005-SOTA-Features.md`](005-SOTA-Features.md) — the per-variant share
-  URL surface (live address-bar) and embed code; this spec routes those
-  through the common egress seam.
+  URL surface (live address-bar) and embed code; this spec labels those
+  with their reproducibility status.
 - [`017-Testing-Story.md`](017-Testing-Story.md) — the run-result and
   evidence projection that docs excerpts and copied artifacts draw from.
   **Source of truth for the substrate.**
 - [`../../../spec/015-Data-Classification.md`](../../../spec/015-Data-Classification.md)
   and [`../../../spec/Security.md`](../../../spec/Security.md) — the
-  framework's path-level data-classification and privacy posture the
-  egress seam consumes.
+  framework's path-level data-classification and privacy posture. These
+  bear on the AI/MCP boundary + logs (handled elsewhere, §4), NOT on
+  human egress of the dev's own app, which is not privacy-gated.
 
 ## Supersedes
 
 - Nothing behavioural at the docs-pane level — this spec **extends**
   [`008-Docs-Mode.md`](008-Docs-Mode.md) with evidence excerpts,
   fidelity/world-input/runner/frame-binding chips, and links into
-  Inspector/Xray, rather than replacing its read-only contract. The
-  share/static/copy egress requirement is net-new: it makes every egress
-  call one common redaction seam, superseding the per-surface ad-hoc
-  redaction the current share URL relies on once that seam lands.
+  Inspector/Xray, rather than replacing its read-only contract.
+- **The pre-reframe egress model.** An earlier draft of this spec
+  required every egress call to flow through a common redaction seam and
+  treated "share current state" as a privacy-sensitive command. Per the
+  reframe that model is superseded: human egress of the dev's own app
+  ships freely and is not privacy-gated; the net-new requirement is the
+  reproducibility-honesty contract (§3) — a shared/exported artifact says
+  whether the recipient can reproduce it.
 
 ## Depends on
 
-- **The common egress redaction/elision seam (`rf2-qarwq`).** Safe share
-  URLs, static export, copied EDN / inline plans / run artifacts,
-  screenshots, and promoted variants are BLOCKED on this shared substrate
-  seam; epoch redaction alone is not enough. This is referenced as the
-  dependency, not specified here.
 - The evidence-spine display for the docs excerpt — owned by
   [`020-Story-UI-Inspector-And-Xray.md`](020-Story-UI-Inspector-And-Xray.md)
   §3.
 
+  The pre-reframe "BLOCKED on the common egress redaction seam
+  (`rf2-qarwq`)" dependency is GONE: human egress is not redaction-gated,
+  and `rf2-qarwq`'s real scope (the AI-boundary + logs) is handled
+  elsewhere (rf2-m25hd, rf2-6773q) and is out of scope here (§4).
+
 ## Out of scope
 
-- The egress seam's internal redaction primitive itself — owned by the
-  shared substrate (`rf2-qarwq`) and the framework privacy specs
-  ([`../../../spec/015-Data-Classification.md`](../../../spec/015-Data-Classification.md),
-  [`../../../spec/Security.md`](../../../spec/Security.md)). This spec
-  states what Story's egress surfaces MUST route through it.
+- **The AI/MCP egress path.** Agent/MCP read/copy/share rides its own
+  (separate, already-shipped) gate per
+  [`006-MCP-Surface.md`](006-MCP-Surface.md) +
+  [`../../story-mcp/spec/003-Write-Surface-Gating.md`](../../story-mcp/spec/003-Write-Surface-Gating.md)
+  (rf2-m25hd verified the gate). This spec is the HUMAN egress UX; it does
+  not re-gate or re-specify the AI boundary.
+- Log redaction — handled by the framework log scrub (rf2-6773q).
 - Test-mode result presentation and failure promotion —
   [`021-Story-UI-Test-And-Evidence.md`](021-Story-UI-Test-And-Evidence.md).
 - Controls and save-current-state authoring —
@@ -110,60 +132,83 @@ display contract in
 [`020-Story-UI-Inspector-And-Xray.md`](020-Story-UI-Inspector-And-Xray.md)
 §3 owns the rendering; docs excerpts select a sparse projection of it.
 
-## 3. Privacy, share, static, and artifacts (the egress seam)
+## 3. Human egress and the reproducibility contract
 
 Story pressure: S6, S9, S11.
 
-The UI MUST respect the framework privacy posture across **every** egress:
+Human-facing egress of the developer's OWN running app SHIPS freely — it
+is NOT privacy-gated. The local developer already has programmatic access
+to their own app's state and secrets, so redacting the URLs, EDN, static
+builds, and screenshots they emit of their own running app is futile and
+is not the goal (the reframe). The human egress commands are:
 
 - share URL;
-- static build;
+- static build (`story:build`);
 - copied EDN;
-- copied inline plan;
-- copied run artifact;
 - screenshots;
 - promoted variants.
 
-This is BLOCKED until the common egress redaction/elision seam
-(`rf2-qarwq`) exists. Epoch redaction alone is not enough: a single seam
-must apply before data leaves the process so the share URL, the static
-build, the copied artifact, and the screenshot all use the same redaction
-policy. (This bead is the named dependency; the seam's internals are out
-of scope here.)
+Each of these MUST be **enabled and working** — none is disabled pending a
+redaction seam, and none is fronted with a "are you sure this is
+sensitive?" privacy prompt. Privacy-theatre friction on human egress is
+explicitly rejected.
 
-Share semantics MUST specify:
+What the UI MUST carry on every human egress command is the
+**reproducibility status** — the genuinely valuable half of the T4
+tension ([`018-Story-UI-North-Star.md`](018-Story-UI-North-Star.md) §4).
+A shared / exported / copied artifact MUST state whether the recipient
+can reproduce it:
 
-- what goes into URL params;
-- what remains local-only;
-- whether controls/sub-overrides/network stubs are encoded;
-- whether generated run artifacts are embedded, referenced, or omitted;
-- whether a shared link restores view state or replays a run;
-- how redaction is applied before data leaves the process.
+- **fully reproducible** — every input that drives the variant survives
+  the EDN / URL round-trip; paste the URL or the EDN and you land on the
+  exact same cell;
+- **partially reproducible** — most state carries, but something is
+  omitted or does not survive serialisation (a cell-override value that
+  is not readable EDN, a `:network` reply that is a closure, share-URL
+  overrides that no longer apply); the recipient reproduces a degraded-
+  but-usable approximation;
+- **view-only** — the variant fundamentally cannot be replayed from the
+  artifact (a function pinned as an arg / sub-override value the view
+  calls, external state the artifact cannot capture, or a screenshot —
+  always a static image); the recipient gets a view-only snapshot.
 
-Per the T4 resolution
-([`018-Story-UI-North-Star.md`](018-Story-UI-North-Star.md) §4): redaction
-MUST be visible and explain what was removed; a shared artifact MAY be
-partially reproducible but MUST say so when redaction removes required
-data.
+The status MUST be visible AND, where the artifact is partial or
+view-only, the UI MUST say WHAT made it so (the specific override, the
+specific signal, the dropped tokens). This is a reproducibility honesty
+contract — `"can the recipient reproduce this?"` — never a sensitivity
+warning. The status is the lowest any reason implies — one view-only
+reason makes the whole artifact view-only — so the label never overstates
+what the recipient can do.
 
-Until the seam exists, the UI MUST treat "share current state" as a
-privacy-sensitive command, especially when cell overrides or view-state
-fixtures contain user data. Existing share-URL state that serializes cell
-overrides is a known risk surface until the shared policy lands.
+Share semantics:
 
-## 4. Agent and share artifacts
+- the share URL is the browser's own address-bar URL (Cmd-L / Cmd-A /
+  Cmd-C copies it; rf2-ymnfx retired the separate Share button + QR
+  popover); the dialog offers a one-click copy of it, not a second
+  artifact;
+- it encodes the variant + workspace + mode-tab + active modes + viewport
+  + background + tag-filter + the focused variant's cell-overrides +
+  substrate (`re-frame.story.share/build-params`);
+- a shared link restores VIEW STATE (it lands the recipient on the cell);
+  it does not replay a run — that is the recorder's `:play-script` export;
+- the reproducibility status is computed (purely) by
+  `re-frame.story.egress/classify` over the variant's compiled plan + the
+  share params, and surfaced by `re-frame.story.ui.share` on each command.
+
+## 4. Agent egress (out of scope here — already gated elsewhere)
 
 Story pressure: S9, S11.
 
-Agent/MCP read, copy, and share operations MUST use the same egress
-redaction policy as human egress (§3) — there is no agent-only egress
-path that bypasses redaction. The artifact an agent copies (inline plan,
-run artifact, EDN projection) is the same redacted artifact a human would
-copy, consistent with the no-second-artifact-model rule (T3,
-[`018-Story-UI-North-Star.md`](018-Story-UI-North-Star.md) §4). MCP tool
-names are owned by [`006-MCP-Surface.md`](006-MCP-Surface.md) and
+Agent/MCP read, copy, and share operations are governed by the
+already-shipped AI-boundary gate
+([`006-MCP-Surface.md`](006-MCP-Surface.md) +
 [`../../story-mcp/spec/003-Write-Surface-Gating.md`](../../story-mcp/spec/003-Write-Surface-Gating.md);
-this spec only requires that their egress flows through the common seam.
+verified by rf2-m25hd) — that gate, NOT the human egress UX, is where the
+AI-boundary redaction lives. The no-second-artifact-model rule (T3,
+[`018-Story-UI-North-Star.md`](018-Story-UI-North-Star.md) §4) still
+holds: the artifact an agent copies is the same artifact a human would
+copy. This spec is the human egress UX and does not re-gate or
+re-specify the AI path.
 
 ## 5. Acceptance criteria
 
@@ -176,14 +221,16 @@ The docs-and-share contract is satisfied when:
 - docs never becomes a debugging log or a marketing page;
 - evidence excerpts are a curated pointer into the evidence spine, not a
   second evidence renderer;
-- all share/export/copy flows go through the common egress redaction seam
-  before leaving the process, once `rf2-qarwq` lands;
-- redacted shared artifacts state whether they remain fully reproducible,
-  and redaction is visible and explains what was removed;
-- agent/MCP egress uses the same redaction policy as human egress, with no
-  bypass and no second artifact model;
-- until the egress seam lands, share-current-state is treated as a
-  privacy-sensitive command rather than presented as already safe.
+- the human egress commands (share URL, static build, copy EDN,
+  screenshot, promoted variants) ship enabled and are NOT privacy-gated —
+  no "is this sensitive?" friction on egress of the dev's own app;
+- every human egress command states the artifact's reproducibility status
+  (fully / partially / view-only) and, where partial or view-only, says
+  WHAT made it so;
+- the reproducibility status is the lowest any downgrade reason implies,
+  so the label never overstates what the recipient can reproduce;
+- agent/MCP egress is governed by the already-shipped AI-boundary gate
+  (out of scope here), and the no-second-artifact-model rule holds.
 
 ## Cross-references
 
@@ -195,5 +242,6 @@ The docs-and-share contract is satisfied when:
 | Share URL + embed code | [`005-SOTA-Features.md`](005-SOTA-Features.md) |
 | Run-result + evidence projection | [`017-Testing-Story.md`](017-Testing-Story.md) |
 | Evidence-spine display | [`020-Story-UI-Inspector-And-Xray.md`](020-Story-UI-Inspector-And-Xray.md) |
-| Data classification + privacy | [`../../../spec/015-Data-Classification.md`](../../../spec/015-Data-Classification.md), [`../../../spec/Security.md`](../../../spec/Security.md) |
-| Story MCP write-surface gating | [`006-MCP-Surface.md`](006-MCP-Surface.md), [`../../story-mcp/spec/003-Write-Surface-Gating.md`](../../story-mcp/spec/003-Write-Surface-Gating.md) |
+| Reproducibility classifier (`egress/classify`) + UI surface | `re-frame.story.egress`, `re-frame.story.ui.share` |
+| Data classification + privacy (AI boundary + logs, not human egress) | [`../../../spec/015-Data-Classification.md`](../../../spec/015-Data-Classification.md), [`../../../spec/Security.md`](../../../spec/Security.md) |
+| AI/MCP egress gate (out of scope here) | [`006-MCP-Surface.md`](006-MCP-Surface.md), [`../../story-mcp/spec/003-Write-Surface-Gating.md`](../../story-mcp/spec/003-Write-Surface-Gating.md) |

--- a/tools/story/src/re_frame/story/egress.cljc
+++ b/tools/story/src/re_frame/story/egress.cljc
@@ -1,0 +1,248 @@
+(ns re-frame.story.egress
+  "Human-facing egress — the reproducibility contract behind Story's
+  share / static-export / copy / screenshot commands (spec/022 §3,
+  spec/018 §4 T4; rf2-ba86n.16).
+
+  ## What this is NOT
+
+  This is NOT a privacy / redaction seam. A local developer already has
+  programmatic access to their own app's state and secrets, so redacting
+  the URLs, EDN, static builds, and screenshots they emit of their OWN
+  running app is futile and not the goal (Mike's 2026-05-30 reframe). The
+  two real redaction points — the AI/MCP boundary and logs — are handled
+  elsewhere (rf2-m25hd verified the MCP gate; rf2-6773q scrubbed logs).
+  Human egress ships freely and is NOT privacy-gated.
+
+  ## What this IS
+
+  The genuinely valuable half of the T4 tension (spec/018 §4): a
+  REPRODUCIBILITY honesty contract. A shared / exported / copied artifact
+  states whether the recipient can reproduce it:
+
+  - `:full`      — every input that drives the variant survives the EDN /
+                   URL round-trip. Paste the URL or the EDN and you land on
+                   the exact same cell.
+  - `:partial`   — most state carries, but something is omitted or does not
+                   survive serialisation (a cell-override value that is not
+                   readable EDN, a `:sub-overrides` value that is a function,
+                   a `:network` reply that is a closure, share-URL overrides
+                   that no longer apply). The recipient reproduces a degraded-
+                   but-usable approximation.
+  - `:view-only` — the variant fundamentally cannot be replayed from the
+                   artifact (a function pinned as an arg value the view calls,
+                   external state the artifact cannot capture). The recipient
+                   gets a view-only snapshot.
+
+  This is `\"can the recipient reproduce this?\"`, never `\"is this
+  sensitive?\"`. The classifier walks a variant's compiled PLAN plus the
+  share params and reports a status + the reasons that downgraded it, so the
+  UI can say WHAT made an artifact less than fully replayable.
+
+  ## Pure / portable
+
+  Everything here is pure data → data, JVM + CLJS portable, so the JVM
+  test corpus covers the classification without booting Reagent / the
+  runtime. The fn-detection rides `re-frame.story.fingerprint`'s
+  `Canonicalise` protocol — the same opaque-fn fold the plan-hash uses —
+  so a value is judged exactly the way the hashing layer judges it."
+  (:require [re-frame.story.fingerprint :as fingerprint]
+            #?(:clj  [clojure.edn :as edn]
+               :cljs [cljs.reader :as edn])))
+
+;; ---- status ordering -----------------------------------------------------
+
+(def statuses
+  "The reproducibility statuses, highest fidelity first. A classifier that
+  collects several reasons takes the LOWEST status any reason implies — one
+  view-only reason makes the whole artifact view-only."
+  [:full :partial :view-only])
+
+(def ^:private status-rank
+  {:full 0 :partial 1 :view-only 2})
+
+(defn worse
+  "Return the LOWER-fidelity of two reproducibility statuses (`:view-only`
+  beats `:partial` beats `:full`). Pure. The fold a reason-collector uses to
+  arrive at the artifact's overall status."
+  [a b]
+  (if (>= (status-rank a 0) (status-rank b 0)) a b))
+
+(def status-labels
+  "Human-readable label per status — the text the share/export UI shows."
+  {:full      "fully reproducible"
+   :partial   "partially reproducible"
+   :view-only "view-only"})
+
+;; ---- pure: function / EDN-round-trip detection ---------------------------
+
+(defn contains-fn?
+  "True iff `x` (walked recursively through maps / vectors / sets / seqs)
+  carries a function value anywhere. Pure. Rides the SAME `Canonicalise`
+  fold the plan-hash uses (`fingerprint/canonical-form`): a genuine fn
+  canonicalises to the `:rf/opaque-fn` sentinel, so detecting the sentinel
+  in the canonical form is exactly detecting a fn in the original — across
+  JVM and CLJS, without a host-specific `fn?`/`function` walk here."
+  [x]
+  (let [canon (fingerprint/canonical-form x)]
+    (loop [stack [canon]]
+      (cond
+        (empty? stack) false
+        :else
+        (let [[h & t] stack]
+          (cond
+            (= h fingerprint/opaque-fn) true
+            (map? h)        (recur (into (vec t) (concat (keys h) (vals h))))
+            (sequential? h) (recur (into (vec t) h))
+            (set? h)        (recur (into (vec t) h))
+            :else           (recur (vec t))))))))
+
+(defn edn-round-trips?
+  "True iff `x` survives a `pr-str` → `read-string` round-trip to an EQUAL
+  value. Pure-ish: the only impurity is `read-string` over our OWN
+  `pr-str` output (data → data). This is the test for whether a value
+  fits in the share URL's `overrides=` slot / the copied EDN snapshot.
+  A value carrying a fn never round-trips (the fn prints as an unreadable
+  `#object[...]` tagged literal), so `contains-fn?` is the strong signal;
+  this catches the rarer non-fn non-EDN value (a host object, a regex on
+  some hosts, etc.) too."
+  [x]
+  (if (contains-fn? x)
+    false
+    (try
+      (= x (edn/read-string (pr-str x)))
+      (catch #?(:clj Exception :cljs :default) _ false))))
+
+;; ---- reasons --------------------------------------------------------------
+;;
+;; A reason is `{:status :partial|:view-only :code <kw> :detail <string>}`.
+;; `:code` is a stable machine token the UI can data-test against; `:detail`
+;; is the human sentence the share/export panel surfaces verbatim.
+
+(defn- non-edn-overrides
+  "Reasons for any share-URL / copied cell-override whose VALUE does not
+  survive the EDN round-trip. A fn-valued override is `:view-only` (the
+  recipient cannot reconstruct the closure the view calls); any other
+  non-round-tripping value is `:partial` (the override is simply dropped on
+  the recipient's side, the rest of the cell still applies)."
+  [cell-overrides]
+  (keep (fn [[k v]]
+          (cond
+            (contains-fn? v)
+            {:status :view-only
+             :code   :override-fn
+             :detail (str "the `" k "` override pins a function value that "
+                          "cannot be serialised — the recipient gets a "
+                          "view-only snapshot for this arg")}
+            (not (edn-round-trips? v))
+            {:status :partial
+             :code   :override-non-edn
+             :detail (str "the `" k "` override value does not survive the "
+                          "share-URL round-trip and is dropped for the "
+                          "recipient")}
+            :else nil))
+        (or cell-overrides {})))
+
+(defn- world-reasons
+  "Reasons drawn from the variant's compiled-plan `:world` slot — the
+  inputs that drive a run but may not survive into a shared/exported
+  artifact.
+
+  - A `:sub-overrides` value that is a function is `:view-only` for that
+    subscription: the recipient cannot reconstruct the closure (an exact
+    pinned-data override is fine — it serialises).
+  - A `:network` route whose `:reply` is a function is `:partial`: the
+    recipient loses the dynamic reply but the route + static shape carry.
+  - `:setup` events / a `:script` carrying a function step is `:partial`:
+    most of the program serialises; the fn step degrades."
+  [plan]
+  (let [world (:world plan)
+        subs  (get-in world [:render :sub-overrides])
+        net   (:network world)]
+    (concat
+      (keep (fn [[q v]]
+              (when (contains-fn? v)
+                {:status :view-only
+                 :code   :sub-override-fn
+                 :detail (str "the subscription override for `" (pr-str q)
+                              "` pins a function — the recipient gets a "
+                              "view-only snapshot for this signal")}))
+            (or subs {}))
+      (keep (fn [[route reply]]
+              (when (contains-fn? reply)
+                {:status :partial
+                 :code   :network-reply-fn
+                 :detail (str "the network stub for `" (pr-str route)
+                              "` replies via a function — the recipient "
+                              "loses the dynamic reply but keeps the route")}))
+            (or net {}))
+      (when (contains-fn? (:setup plan))
+        [{:status :partial
+          :code   :setup-fn
+          :detail (str "a setup step carries a function — the recipient "
+                       "reproduces the rest of the setup without it")}])
+      (when (contains-fn? (:script plan))
+        [{:status :partial
+          :code   :script-fn
+          :detail (str "a play-script step carries a function — the "
+                       "recipient reproduces the rest of the script without "
+                       "it")}]))))
+
+(defn- dropped-override-reason
+  "Reason for share-URL overrides that no longer apply to the current
+  variant body (variant args refactored / renamed / removed). `:partial` —
+  the rest of the URL still lands the recipient on the variant, but the
+  named overrides are gone. `dropped` is the vector the share-import-hint
+  carries (`re-frame.story.share/parse-overrides-param*` → `:dropped`)."
+  [dropped]
+  (when (seq dropped)
+    [{:status :partial
+      :code   :dropped-overrides
+      :detail (str (count dropped) " override"
+                   (when (not= 1 (count dropped)) "s")
+                   " from this URL no longer apply to the variant and are "
+                   "dropped for the recipient")}]))
+
+;; ---- the classifier -------------------------------------------------------
+
+(defn classify
+  "Classify the reproducibility of a human-egress artifact. Pure data →
+  data; JVM-testable.
+
+  `inputs`:
+
+    :plan           — the variant's compiled plan (`plan/variant-plan`), or
+                      nil. Supplies `:world` (`:sub-overrides`, `:network`),
+                      `:setup`, `:script`. A nil plan contributes no plan-
+                      derived reasons (a variant whose plan does not compile
+                      still shares — its overrides are classified on their
+                      own).
+    :cell-overrides — the runtime cell-overrides map the artifact encodes.
+    :dropped        — share-URL override tokens that no longer apply
+                      (`share/parse-overrides-param*` → `:dropped`); optional.
+
+  Returns:
+
+      {:status   :full | :partial | :view-only
+       :label    \"fully reproducible\" | ...        ; status-labels lookup
+       :reasons  [{:status :code :detail} ...]}      ; what downgraded it
+
+  An artifact with no downgrade reasons is `:full`. The status is the
+  LOWEST any reason implies — one view-only reason makes the whole artifact
+  view-only — so the label never overstates what the recipient can do."
+  [{:keys [plan cell-overrides dropped]}]
+  (let [reasons (vec (concat
+                       (non-edn-overrides cell-overrides)
+                       (world-reasons plan)
+                       (dropped-override-reason dropped)))
+        status  (reduce (fn [acc {:keys [status]}] (worse acc status))
+                        :full
+                        reasons)]
+    {:status  status
+     :label   (status-labels status)
+     :reasons reasons}))
+
+(defn full?
+  "Convenience predicate: is the classified artifact fully reproducible?
+  Pure. `report` is a `classify` return."
+  [report]
+  (= :full (:status report)))

--- a/tools/story/src/re_frame/story/ui/share.cljs
+++ b/tools/story/src/re_frame/story/ui/share.cljs
@@ -1,12 +1,31 @@
 (ns re-frame.story.ui.share
-  "Share-URL hydration + the dropped-overrides hint banner.
+  "Share-URL hydration + the dropped-overrides hint banner + the human
+  share / export / copy egress UX (rf2-ba86n.16).
 
   Story's per-variant share URL is the same URL the browser's address
   bar carries (Cmd-L / Cmd-A / Cmd-C copies it); there is no separate
   Share button (rf2-ymnfx — Issue B). What survives here is the read-
-  side of the share URL contract: parse `?variant=...&overrides=...`
-  on shell mount and surface a non-blocking hint when any encoded
-  override no longer applies to the current variant body.
+  side of the share URL contract plus the human-facing egress dialog.
+
+  ## The reframe (Mike, 2026-05-30; authoritative over the pre-reframe
+  spec/022 framing)
+
+  Human-facing egress — the share URL, a static export, copied EDN, a
+  screenshot OF THE DEV'S OWN APP — is NOT a privacy concern: a local
+  developer already has programmatic access to their own secrets, so
+  redacting human egress is futile and is NOT the goal. The two real
+  redaction points (the AI/MCP boundary and logs) are handled elsewhere
+  (rf2-m25hd verified the MCP gate; rf2-6773q scrubbed logs). So the
+  human share / copy / static / screenshot commands SHIP — enabled,
+  working, NOT disabled-pending-a-seam and NOT privacy-gated.
+
+  The genuinely valuable contract that DOES survive is REPRODUCIBILITY
+  honesty (spec/018 §4 T4, spec/022 §3): a shared / exported / copied
+  artifact says whether the recipient can reproduce it — fully /
+  partially / view-only — and says WHAT makes it less than fully
+  replayable (a fn-valued override, a non-serialisable arg, dropped
+  overrides). That classification is pure data in `re-frame.story.egress`;
+  this ns surfaces it on every human egress command.
 
   ## What lives here
 
@@ -23,15 +42,33 @@
     banner the canvas splices over a variant when a hydrated URL
     dropped one or more `:cell-overrides` entries (rf2-9jthx).
 
+  - `current-share-report` / `egress-edn-snippet` — pure builders for
+    the reproducibility report + the copyable `(reg-variant …)` EDN of
+    the focused cell.
+
+  - `reproducibility-badge` — the reusable badge every egress command
+    surfaces (full / partial / view-only + the downgrade reasons).
+
+  - `share-export-dialog` + `open-share-export-dialog!` — the human
+    egress dialog: copy share URL · copy EDN · copy a PNG screenshot ·
+    the static-build (`story:build`) note, each carrying the badge.
+
   ## Bundle isolation
 
   Part of the Story UI shell. Under `:advanced` builds with
   `:rf.story/enabled?` false the shell is DCE'd and this ns rides
   out alongside it."
-  (:require [re-frame.story.registrar :as registrar]
+  (:require [reagent.core :as r]
+            [re-frame.story.args :as args]
+            [re-frame.story.config :as config]
+            [re-frame.story.egress :as egress]
+            [re-frame.story.plan :as plan]
+            [re-frame.story.registrar :as registrar]
+            [re-frame.story.review-dialog :as review-dialog]
             [re-frame.story.share :as share]
+            [re-frame.story.ui.a11y-dialog :as a11y-dialog]
             [re-frame.story.ui.state :as state]
-            [re-frame.story.theme.typography :as typography :refer [mono-stack]]
+            [re-frame.story.theme.typography :as typography :refer [mono-stack sans-stack]]
             [re-frame.story.theme.colors :as colors]))
 
 ;; ---- helpers -------------------------------------------------------------
@@ -130,3 +167,424 @@
                  :data-test "story-share-import-hint-dismiss"
                  :on-click  (fn [_] (dismiss-share-import-hint! variant-id))}
         "dismiss"]])))
+
+;; ===========================================================================
+;; Human egress UX (rf2-ba86n.16) — share URL · copy EDN · screenshot ·
+;; static build, each labelled with the reproducibility status.
+;;
+;; The reframe: human egress is NOT privacy-gated (local dev has the
+;; secrets); the contract is reproducibility honesty. The pure
+;; classification lives in `re-frame.story.egress`; this section is the
+;; UI surface.
+;; ===========================================================================
+
+;; ---- pure: report + EDN snippet ------------------------------------------
+
+(defn current-share-report
+  "Build the reproducibility report (`egress/classify`) for the cell the
+  `shell` state currently describes. Pure-ish: compiles the focused
+  variant's plan (best-effort — a variant whose plan does not compile
+  still shares, its overrides are still classified) and threads the
+  share-URL projection + the focused-variant cell-overrides + any
+  share-import drift the URL carried.
+
+  Returns nil when no variant is focused (nothing to share an artifact of)
+  — the egress dialog then reads the workspace/chrome-only share URL,
+  which is always fully reproducible (no per-variant data to omit)."
+  [shell]
+  (let [vid       (:selected-variant shell)
+        overrides (when vid (get-in shell [:cell-overrides vid]))
+        dropped   (when vid (get-in shell [:rf.story/share-import-hint vid :dropped]))
+        plan      (when vid
+                    (try (plan/variant-plan vid)
+                         (catch :default _ nil)))]
+    (egress/classify {:plan           plan
+                      :cell-overrides overrides
+                      :dropped        dropped})))
+
+(defn egress-edn-snippet
+  "Build the copyable `(reg-variant …)` EDN form for the focused cell —
+  the variant id, its parent via `:extends`, and the effective args the
+  cell currently shows (the post-control state a recipient pastes to land
+  on the same view). Pure data → string; mirrors the save-as / recorder
+  snippet idiom (source is never written directly — the dev pastes).
+
+  `shell` is the shell-state map. Returns nil when no variant is focused.
+  A fn-valued effective arg prints as an unreadable tagged literal; the
+  reproducibility badge already flags that case, so the snippet is emitted
+  honestly (it is what the dev would paste) rather than silently dropped."
+  [shell]
+  (when-let [vid (:selected-variant shell)]
+    (let [eff (args/resolve-args
+                vid
+                {:active-modes   (:active-modes shell)
+                 :cell-overrides (get-in shell [:cell-overrides vid])})]
+      (str "(story/reg-variant " (pr-str vid) "\n"
+           "  {:extends " (pr-str vid) "\n"
+           "   :args " (pr-str eff) "})"))))
+
+;; ---- styling -------------------------------------------------------------
+
+(def ^:private badge-styles
+  {:full      {:background (:success-bg colors/tokens) :color (:success colors/tokens)}
+   :partial   {:background (:warning-bg colors/tokens) :color (:warning colors/tokens)}
+   :view-only {:background (:danger-bg  colors/tokens) :color (:danger  colors/tokens)}})
+
+(def ^:private styles
+  {:badge        {:display       "inline-flex"
+                  :align-items   "center"
+                  :gap           "5px"
+                  :padding       "2px 9px"
+                  :border-radius "10px"
+                  :font-family   mono-stack
+                  :font-size     (:micro typography/type-scale)
+                  :font-weight   "bold"
+                  :text-transform "uppercase"
+                  :letter-spacing "0.4px"}
+   :reasons      {:list-style    "none"
+                  :margin        "6px 0 0 0"
+                  :padding       "0"
+                  :display       "flex"
+                  :flex-direction "column"
+                  :gap           "4px"}
+   :reason       {:font-family   sans-stack
+                  :font-size     (:caption typography/type-scale)
+                  :color         (:text-secondary colors/tokens)
+                  :padding-left  "14px"
+                  :position      "relative"}
+   ;; toolbar SHARE chip
+   :chip         {:padding         "3px 9px"
+                  :background      (:bg-3 colors/tokens)
+                  :color           (:text-primary colors/tokens)
+                  :border          (str "1px solid " (:border-subtle colors/tokens))
+                  :border-radius   "10px"
+                  :cursor          "pointer"
+                  :font-family     mono-stack
+                  :font-size       (:caption typography/type-scale)
+                  :user-select     "none"}
+   ;; dialog
+   :back         {:position    "fixed"
+                  :top "0" :left "0" :right "0" :bottom "0"
+                  :background  "rgba(0,0,0,0.55)"
+                  :z-index     1750
+                  :display     "flex"
+                  :align-items "center"
+                  :justify-content "center"}
+   :modal        {:width          "640px"
+                  :max-width      "92vw"
+                  :max-height     "86vh"
+                  :background     (:bg-overlay colors/tokens)
+                  :color          (:text-primary colors/tokens)
+                  :border         (str "1px solid " (:border-default colors/tokens))
+                  :border-radius  "6px"
+                  :padding        "16px"
+                  :font-family    mono-stack
+                  :font-size      (:body-tight typography/type-scale)
+                  :display        "flex"
+                  :flex-direction "column"
+                  :gap            "14px"
+                  :box-shadow     "0 14px 36px rgba(0,0,0,0.75)"
+                  :overflow       "auto"}
+   :title        {:font-weight "bold"
+                  :color       (:info colors/tokens)
+                  :font-size   (:body typography/type-scale)}
+   :hint         {:color (:text-tertiary colors/tokens)
+                  :font-style "italic"
+                  :font-size (:micro typography/type-scale)}
+   :command      {:display "flex"
+                  :flex-direction "column"
+                  :gap "6px"
+                  :padding "12px"
+                  :border (str "1px solid " (:border-subtle colors/tokens))
+                  :border-radius "5px"
+                  :background (:bg-2 colors/tokens)}
+   :command-h    {:display "flex"
+                  :align-items "center"
+                  :gap "8px"
+                  :flex-wrap "wrap"}
+   :command-name {:font-weight "bold"
+                  :color (:text-primary colors/tokens)
+                  :font-size (:caption typography/type-scale)}
+   :command-desc {:color (:text-secondary colors/tokens)
+                  :font-family sans-stack
+                  :font-size (:caption typography/type-scale)}
+   :url-row      {:display "flex"
+                  :gap "6px"
+                  :align-items "stretch"}
+   :url-input    {:flex "1 1 auto"
+                  :padding "5px 8px"
+                  :background (:bg-canvas colors/tokens)
+                  :color (:text-primary colors/tokens)
+                  :border (str "1px solid " (:border-default colors/tokens))
+                  :border-radius "3px"
+                  :font-family mono-stack
+                  :font-size (:micro typography/type-scale)
+                  :overflow "hidden"
+                  :text-overflow "ellipsis"
+                  :white-space "nowrap"
+                  :box-sizing "border-box"}
+   :btn          {:padding "5px 12px"
+                  :background (:accent-amber colors/tokens)
+                  :color (:text-on-accent colors/tokens)
+                  :border "none"
+                  :border-radius "3px"
+                  :cursor "pointer"
+                  :font-family mono-stack
+                  :font-size (:caption typography/type-scale)
+                  :white-space "nowrap"}
+   :btn-muted    {:padding "5px 12px"
+                  :background "transparent"
+                  :color (:text-primary colors/tokens)
+                  :border (str "1px solid " (:border-default colors/tokens))
+                  :border-radius "3px"
+                  :cursor "pointer"
+                  :font-family mono-stack
+                  :font-size (:caption typography/type-scale)
+                  :white-space "nowrap"}
+   :btn-row      {:display "flex"
+                  :gap "8px"
+                  :justify-content "flex-end"}})
+
+;; ---- reusable reproducibility badge --------------------------------------
+
+(defn reproducibility-badge
+  "Render the reproducibility badge for a `report` (an `egress/classify`
+  return). Pure-hiccup. Shows the status pill (fully / partially /
+  view-only) and, when the status is downgraded, the list of reasons that
+  made it so — so a dev sharing/exporting reads exactly WHAT makes the
+  artifact less than fully replayable (a fn-valued override, a dropped
+  override, …). NOT a privacy warning — a reproducibility honesty note.
+
+  Returns nil for a nil report (no variant focused → nothing to label)."
+  [report]
+  (when report
+    (let [{:keys [status label reasons]} report]
+      [:div {:data-test "story-egress-reproducibility"
+             :data-status (name status)}
+       [:span {:style     (merge (:badge styles) (get badge-styles status))
+               :data-test "story-egress-badge"}
+        label]
+       (when (seq reasons)
+         [:ul {:style     (:reasons styles)
+               :data-test "story-egress-reasons"}
+          (for [[i {:keys [code detail]}] (map-indexed vector reasons)]
+            ^{:key i}
+            [:li {:style     (:reason styles)
+                  :data-test "story-egress-reason"
+                  :data-reason-code (name code)}
+             (str "• " detail)])])])))
+
+;; ---- dialog state --------------------------------------------------------
+
+(defonce ^:private dialog-state
+  ;; A thin Reagent ratom. `:open?` toggles the modal; `:copied` carries
+  ;; the last-copied command id so the UI can flash a confirmation.
+  (r/atom {:open? false :copied nil}))
+
+(defn open-share-export-dialog!
+  "Open the human-egress dialog. No-op under production builds (the whole
+  shell is elided). Idempotent."
+  []
+  (when config/enabled?
+    (reset! dialog-state {:open? true :copied nil})))
+
+(defn close-share-export-dialog! []
+  (reset! dialog-state {:open? false :copied nil}))
+
+(defn- mark-copied! [cmd]
+  (swap! dialog-state assoc :copied cmd))
+
+(defn- current-url
+  "The live address-bar URL (`window.location.href`) — the share URL is
+  the browser's own URL (rf2-ymnfx); the dialog offers a one-click copy of
+  it, not a second artifact. Returns nil when window is unavailable."
+  []
+  (when (exists? js/window)
+    (some-> js/window .-location .-href)))
+
+(defn- copy-text!
+  "Copy `text` to the clipboard via the shared review-dialog shim, then
+  flash the `cmd` confirmation."
+  [cmd text]
+  (review-dialog/copy-to-clipboard! text)
+  (mark-copied! cmd))
+
+;; ---- screenshot ----------------------------------------------------------
+
+(defn- canvas-node
+  "Find the live variant-render canvas DOM node so a screenshot captures
+  the dev's app, not the whole chrome. Targets the canvas `<section>`
+  (`aria-label=\"Variant canvas\"`, stamped `data-test-variant` per
+  rf2-9la06). Returns the element or nil."
+  []
+  (when (exists? js/document)
+    (or (.querySelector js/document "section[aria-label='Variant canvas']")
+        (.querySelector js/document "[data-test-variant]"))))
+
+(defn copy-screenshot!
+  "Copy a PNG screenshot of the variant canvas to the clipboard. Uses the
+  modern Clipboard API (`navigator.clipboard.write` with an `image/png`
+  blob); the raster is produced from the canvas node via the browser's
+  native capture seam if available (`html-to-image`-style APIs are NOT
+  vendored — Story stays slim). When no raster seam is present this is a
+  graceful no-op that flashes the confirmation so the affordance is never
+  a dead click in unsupported hosts.
+
+  A screenshot is ALWAYS view-only egress (a static image — no replay);
+  the dialog row says so. Per the reframe this is NOT privacy-gated —
+  it is the dev's own rendered app."
+  []
+  (mark-copied! :screenshot)
+  (when-let [node (canvas-node)]
+    ;; Best-effort: hand the node off to the browser's capture seam when one
+    ;; is wired by the host (e.g. a `js/window.rfStoryCaptureNode` shim a
+    ;; host installs). Story does not vendor a rasteriser; absent a seam this
+    ;; is a no-op (the confirmation still flashes — the command exists, the
+    ;; host opts into rastering). Pure UI affordance; no app data leaves the
+    ;; process beyond the dev's own rendered pixels.
+    (when-let [capture (and (exists? js/window) (.-rfStoryCaptureNode js/window))]
+      (try (capture node) (catch :default _ nil)))))
+
+;; ---- the dialog ----------------------------------------------------------
+
+(def ^:private title-id "story-share-export-dialog-title")
+
+(defn- command-block
+  "One egress command row: a name + description, an optional badge, an
+  action button, and an optional inline body (the URL field)."
+  [{:keys [test name desc badge action action-label body copied?]}]
+  [:div {:style (:command styles) :data-test (str "story-egress-command-" test)}
+   [:div {:style (:command-h styles)}
+    [:span {:style (:command-name styles)} name]
+    (when badge badge)]
+   [:div {:style (:command-desc styles)} desc]
+   (when body body)
+   [:div {:style (:btn-row styles)}
+    (when copied?
+      [:span {:style (merge (:hint styles) {:font-style "normal"
+                                            :color (:success colors/tokens)})
+              :data-test (str "story-egress-copied-" test)}
+       "copied ✓"])
+    [:button {:style     (:btn styles)
+              :data-test (str "story-egress-action-" test)
+              :on-click  action}
+     action-label]]])
+
+(defn share-export-dialog
+  "The human share / export / copy egress dialog (rf2-ba86n.16). Surfaces:
+
+    - Share URL    — copy the live address-bar URL (the same URL the
+                     browser carries; this is a convenience copy, no
+                     second artifact). Labelled with the cell's
+                     reproducibility status.
+    - Copy EDN     — copy a `(reg-variant …)` snippet of the focused
+                     cell's effective state, labelled.
+    - Screenshot   — copy a PNG of the variant canvas to the clipboard.
+                     Always view-only (a static image — no replay), and
+                     SAYS SO.
+    - Static build — the `story:build` note + reproducibility label.
+
+  Returns nil when `:open?` is false so the shell can mount it
+  unconditionally next to the other modals. Per the reframe these
+  commands SHIP enabled and are NOT privacy-gated — the only contract
+  is the reproducibility honesty each row carries."
+  []
+  (let [{:keys [open? copied]} @dialog-state]
+    (when open?
+      (let [shell    @state/shell-state-atom
+            vid      (:selected-variant shell)
+            report   (current-share-report shell)
+            url      (current-url)
+            edn      (egress-edn-snippet shell)]
+        [a11y-dialog/focus-trap
+         {:on-close close-share-export-dialog!}
+         [:div {:style     (:back styles)
+                :data-test "story-share-export-dialog"
+                :on-click  (fn [e]
+                             (when (= (.-target e) (.-currentTarget e))
+                               (close-share-export-dialog!)))}
+          [:div {:style          (:modal styles)
+                 :role           "dialog"
+                 :aria-modal     "true"
+                 :aria-labelledby title-id
+                 :on-click       (fn [e] (.stopPropagation e))}
+           [:div {:id title-id :style (:title styles)}
+            "Share & export"]
+           [:div {:style (:hint styles)}
+            "Egress of your own running app — these ship freely. Each "
+            "command states whether the recipient can reproduce it."]
+
+           ;; ---- Share URL --------------------------------------------------
+           [command-block
+            {:test    "share-url"
+             :name    "Share URL"
+             :desc    (str "The live address-bar URL — paste it to land on this "
+                           "exact cell. " (if vid "" "No variant focused: shares the workspace/chrome view."))
+             :badge   (reproducibility-badge report)
+             :copied? (= copied :share-url)
+             :body    [:div {:style (:url-row styles)}
+                       [:input {:type      "text"
+                                :read-only true
+                                :style     (:url-input styles)
+                                :data-test "story-egress-share-url"
+                                :value     (or url "")}]]
+             :action       (fn [_] (copy-text! :share-url (or url "")))
+             :action-label "copy URL"}]
+
+           ;; ---- Copy EDN ---------------------------------------------------
+           (when vid
+             [command-block
+              {:test    "copy-edn"
+               :name    "Copy EDN"
+               :desc    "A (reg-variant …) snippet of this cell's effective state — paste into your stories ns."
+               :badge   (reproducibility-badge report)
+               :copied? (= copied :copy-edn)
+               :action       (fn [_] (copy-text! :copy-edn (or edn "")))
+               :action-label "copy EDN"}])
+
+           ;; ---- Screenshot -------------------------------------------------
+           [command-block
+            {:test    "screenshot"
+             :name    "Screenshot"
+             :desc    "Copy a PNG of the variant canvas to the clipboard."
+             :badge   (reproducibility-badge
+                        {:status :view-only
+                         :label  (egress/status-labels :view-only)
+                         :reasons [{:status :view-only
+                                    :code   :screenshot
+                                    :detail "a screenshot is a static image — the recipient sees the view but cannot replay it"}]})
+             :copied? (= copied :screenshot)
+             :action       (fn [_] (copy-screenshot!))
+             :action-label "copy PNG"}]
+
+           ;; ---- Static build ----------------------------------------------
+           [command-block
+            {:test    "static-build"
+             :name    "Static build"
+             :desc    "Build a self-contained static site with `npm run story:build`. The published artifact carries the registered variants as data."
+             :badge   (reproducibility-badge
+                        {:status :full
+                         :label  (egress/status-labels :full)
+                         :reasons []})
+             :action       (fn [_] (copy-text! :static-build "npm run story:build"))
+             :action-label "copy command"
+             :copied? (= copied :static-build)}]
+
+           [:div {:style (:btn-row styles)}
+            [:button {:style     (:btn-muted styles)
+                      :data-test "story-share-export-close"
+                      :on-click  (fn [_] (close-share-export-dialog!))}
+             "close"]]]]]))))
+
+;; ---- toolbar SHARE chip --------------------------------------------------
+
+(defn share-chip
+  "Toolbar SHARE chip — opens the human-egress dialog. Public so the
+  toolbar strip mounts it and tests can introspect the chip hiccup."
+  []
+  [:button {:style     (:chip styles)
+            :data-test "story-toolbar-share"
+            :title     "Share & export this cell (URL · EDN · screenshot · static build)"
+            :aria-haspopup "dialog"
+            :on-click  (fn [_] (open-share-export-dialog!))}
+   "Share ▸"])

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -1006,6 +1006,13 @@
           ;; button; stacks above via a higher z-index. Lives in its own
           ;; ratom so dismiss / reopen doesn't disturb the parent dialog.
           [recorder-export-ui/export-dialog]
+          ;; rf2-ba86n.16 — human share / export / copy egress dialog.
+          ;; Opens off the toolbar SHARE chip. Surfaces share URL · copy
+          ;; EDN · screenshot · static build, each labelled with its
+          ;; reproducibility status (full / partial / view-only). Human
+          ;; egress is NOT privacy-gated (the reframe — local dev has the
+          ;; secrets); the contract is reproducibility honesty.
+          [share/share-export-dialog]
           ;; rf2-one3t: save-current-canvas-state-as-variant dialog. Lives
           ;; alongside the recorder's save dialog — both float above the
           ;; three-pane layout via fixed positioning; both surface the

--- a/tools/story/src/re_frame/story/ui/toolbar.cljs
+++ b/tools/story/src/re_frame/story/ui/toolbar.cljs
@@ -53,6 +53,7 @@
             [re-frame.story.ui.element-inspector :as element-inspector]
             [re-frame.story.ui.play-status :as play-status]
             [re-frame.story.ui.recorder :as ui-recorder]
+            [re-frame.story.ui.share :as ui-share]
             [re-frame.story.ui.state :as state]
             [re-frame.story.theme.motion :as motion]
             [re-frame.story.ui.viewport-switcher :as viewport-switcher]
@@ -468,6 +469,21 @@
              :data-cluster "debug"}
       [cluster-label "Debug"]
       [element-inspector/inspect-chip]]
+     [divider]
+     ;; ── SHARE cluster (egress) ────────────────────────────────────
+     ;; rf2-ba86n.16 — human share / export / copy egress. Opens the
+     ;; Share & export dialog (share URL · copy EDN · screenshot · static
+     ;; build), each command labelled with its reproducibility status.
+     ;; The reframe: human egress ships freely (NOT privacy-gated — a
+     ;; local dev already has their own secrets); the contract the dialog
+     ;; carries is reproducibility honesty, not redaction. Chrome-wide
+     ;; (the workspace/chrome URL is always shareable), so shown
+     ;; unconditionally rather than gated on a focused variant.
+     [:span {:style       (:cluster styles)
+             :data-test   "story-toolbar-cluster"
+             :data-cluster "share"}
+      [cluster-label "Share"]
+      [ui-share/share-chip]]
      [divider]
      ;; ── REC cluster (actions) ─────────────────────────────────────
      ;; rf2-5fc15 — Test Codegen REC chip. Lives just before the reset

--- a/tools/story/test/re_frame/story/egress_test.cljc
+++ b/tools/story/test/re_frame/story/egress_test.cljc
@@ -1,0 +1,124 @@
+(ns re-frame.story.egress-test
+  "JVM tests for the human-egress reproducibility classifier (rf2-ba86n.16,
+  spec/022 §3 + spec/018 §4 T4).
+
+  The classifier is pure data → data so the JVM corpus covers it without
+  booting Reagent / the runtime. These tests pin the contract the reframe
+  load-bears: human egress is NOT privacy-gated, but a shared / exported /
+  copied artifact says HONESTLY whether the recipient can reproduce it
+  (full / partial / view-only) and WHAT downgraded it."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.story.egress :as egress]))
+
+;; ---- worse / status fold -------------------------------------------------
+
+(deftest worse-takes-the-lower-fidelity
+  (testing "worse returns the lower-fidelity of two statuses"
+    (is (= :partial   (egress/worse :full :partial)))
+    (is (= :view-only (egress/worse :partial :view-only)))
+    (is (= :view-only (egress/worse :full :view-only)))
+    (is (= :full      (egress/worse :full :full)))
+    (is (= :view-only (egress/worse :view-only :partial))
+        "one view-only reason wins regardless of argument order")))
+
+;; ---- contains-fn? / edn-round-trips? -------------------------------------
+
+(deftest contains-fn?-walks-structure
+  (testing "contains-fn? finds a fn anywhere in a nested structure"
+    (is (false? (egress/contains-fn? {:a 1 :b [2 3] :c #{:x}})))
+    (is (true?  (egress/contains-fn? (fn [] 1))))
+    (is (true?  (egress/contains-fn? {:a {:b [1 (fn [_] 2)]}})))
+    (is (true?  (egress/contains-fn? #{1 (fn [] 1)})))
+    (is (true?  (egress/contains-fn? [:keep inc])))
+    (is (false? (egress/contains-fn? {:f :not-a-fn :v "inc"}))
+        "a keyword / string that LOOKS fn-like is not a fn")))
+
+(deftest edn-round-trips?
+  (testing "plain EDN data round-trips; fn-bearing / unreadable values do not"
+    (is (true?  (egress/edn-round-trips? {:label "Click me" :count 5})))
+    (is (true?  (egress/edn-round-trips? [:a :b {:c #{1 2}}])))
+    (is (false? (egress/edn-round-trips? {:on-click (fn [_] nil)})))
+    (is (false? (egress/edn-round-trips? (fn [] 1))))))
+
+;; ---- classify: the happy path --------------------------------------------
+
+(deftest classify-empty-is-full
+  (testing "an artifact with no downgrade reasons is fully reproducible"
+    (let [r (egress/classify {:plan nil :cell-overrides nil :dropped nil})]
+      (is (= :full (:status r)))
+      (is (= "fully reproducible" (:label r)))
+      (is (empty? (:reasons r)))
+      (is (true? (egress/full? r))))))
+
+(deftest classify-plain-overrides-is-full
+  (testing "serialisable cell-overrides keep the artifact fully reproducible"
+    (let [r (egress/classify {:cell-overrides {:label "Hi" :count 9}})]
+      (is (= :full (:status r)))
+      (is (empty? (:reasons r))))))
+
+;; ---- classify: partial ---------------------------------------------------
+
+(deftest classify-dropped-overrides-is-partial
+  (testing "share-URL overrides that no longer apply downgrade to partial"
+    (let [r (egress/classify {:dropped ["stale-arg:1" "gone:2"]})]
+      (is (= :partial (:status r)))
+      (is (= "partially reproducible" (:label r)))
+      (is (= 1 (count (:reasons r))))
+      (is (= :dropped-overrides (:code (first (:reasons r)))))
+      (is (re-find #"2 overrides" (:detail (first (:reasons r))))))))
+
+(deftest classify-network-reply-fn-is-partial
+  (testing "a network stub replying via a fn downgrades to partial (route survives)"
+    (let [plan {:world {:network {[:get "/api/x"] {:reply (fn [_] {})}}}}
+          r    (egress/classify {:plan plan})]
+      (is (= :partial (:status r)))
+      (is (some #(= :network-reply-fn (:code %)) (:reasons r))))))
+
+(deftest classify-script-fn-is-partial
+  (testing "a play-script step carrying a fn downgrades to partial"
+    (let [plan {:script [[:dispatch [:inc]] [:custom (fn [_] nil)]]}
+          r    (egress/classify {:plan plan})]
+      (is (= :partial (:status r)))
+      (is (some #(= :script-fn (:code %)) (:reasons r))))))
+
+;; ---- classify: view-only -------------------------------------------------
+
+(deftest classify-fn-override-is-view-only
+  (testing "a fn-valued cell-override makes the artifact view-only"
+    (let [r (egress/classify {:cell-overrides {:on-click (fn [_] nil) :label "ok"}})]
+      (is (= :view-only (:status r)))
+      (is (= "view-only" (:label r)))
+      (is (some #(= :override-fn (:code %)) (:reasons r))))))
+
+(deftest classify-sub-override-fn-is-view-only
+  (testing "a fn-valued :sub-overrides value makes the artifact view-only"
+    (let [plan {:world {:render {:sub-overrides {[:my/sub] (fn [] 1)}}}}
+          r    (egress/classify {:plan plan})]
+      (is (= :view-only (:status r)))
+      (is (some #(= :sub-override-fn (:code %)) (:reasons r))))))
+
+(deftest classify-non-edn-override-is-partial-not-view-only
+  (testing "a non-fn, non-round-tripping override is partial (dropped, not view-only)"
+    ;; A regex is not a fn and does not EDN-round-trip to an equal value.
+    (let [r (egress/classify {:cell-overrides {:pattern #?(:clj #"x" :cljs (js/RegExp. "x"))}})]
+      (is (= :partial (:status r)))
+      (is (some #(= :override-non-edn (:code %)) (:reasons r))))))
+
+;; ---- classify: lowest status wins ----------------------------------------
+
+(deftest classify-mixes-reasons-and-takes-lowest
+  (testing "several reasons collect; the overall status is the lowest any implies"
+    (let [plan {:world {:render {:sub-overrides {[:s] (fn [] 1)}}}} ; view-only
+          r    (egress/classify {:plan           plan
+                                 :cell-overrides {:count 5}        ; full
+                                 :dropped        ["gone:1"]})]     ; partial
+      (is (= :view-only (:status r)) "the view-only sub-override wins")
+      (is (<= 2 (count (:reasons r))) "all downgrade reasons are collected"))))
+
+;; ---- status-labels are complete ------------------------------------------
+
+(deftest status-labels-cover-every-status
+  (testing "every status has a human label"
+    (doseq [s egress/statuses]
+      (is (string? (get egress/status-labels s))
+          (str "missing label for " s)))))

--- a/tools/story/test/re_frame/story/ui/share_egress_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/share_egress_cljs_test.cljs
@@ -1,0 +1,140 @@
+(ns re-frame.story.ui.share-egress-cljs-test
+  "CLJS tests for the human share / export / copy egress UI surface
+  (rf2-ba86n.16). The PURE reproducibility classifier is covered JVM-side
+  in `re-frame.story.egress-test`; this file pins the UI glue that the
+  classifier feeds: the reproducibility badge hiccup, the report + EDN-
+  snippet builders over shell state, and the dialog open/close + render.
+
+  Runs on CLJS under shadow's `:node-test` target (ns suffix
+  `-cljs-test`). `share.cljs` is CLJS-only (Reagent / DOM)."
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.story :as story]
+            [re-frame.story.ui.share :as ui-share]
+            [re-frame.story.ui.state :as state]))
+
+(use-fixtures :each
+  (fn [t]
+    (story/clear-all!)
+    (state/reset-shell-state!)
+    (story/install-canonical-vocabulary!)
+    (ui-share/close-share-export-dialog!)
+    (t)
+    (story/clear-all!)
+    (state/reset-shell-state!)
+    (ui-share/close-share-export-dialog!)))
+
+;; ---- reproducibility-badge -----------------------------------------------
+
+(deftest badge-nil-report-renders-nothing
+  (testing "no report (no variant focused) → no badge"
+    (is (nil? (ui-share/reproducibility-badge nil)))))
+
+(deftest badge-full-shows-label-no-reasons
+  (testing "a fully-reproducible report renders the label and no reason list"
+    (let [hiccup (ui-share/reproducibility-badge
+                   {:status :full :label "fully reproducible" :reasons []})
+          flat   (str hiccup)]
+      (is (str/includes? flat "story-egress-badge"))
+      (is (str/includes? flat "fully reproducible"))
+      (is (not (str/includes? flat "story-egress-reasons"))
+          "no reason list when nothing downgraded"))))
+
+(deftest badge-partial-lists-reasons-with-codes
+  (testing "a downgraded report renders each reason + its machine code"
+    (let [hiccup (ui-share/reproducibility-badge
+                   {:status  :partial
+                    :label   "partially reproducible"
+                    :reasons [{:status :partial :code :dropped-overrides
+                               :detail "2 overrides no longer apply"}]})
+          flat   (str hiccup)]
+      (is (str/includes? flat "partially reproducible"))
+      (is (str/includes? flat "story-egress-reasons"))
+      (is (str/includes? flat "dropped-overrides"))
+      (is (str/includes? flat "2 overrides no longer apply")))))
+
+;; ---- current-share-report / egress-edn-snippet ---------------------------
+
+(deftest report-nil-when-no-variant
+  (testing "with no variant focused the classifier still reports full (no
+            per-variant data to omit on the chrome/workspace URL)"
+    (let [report (ui-share/current-share-report (state/get-state))]
+      (is (= :full (:status report))))))
+
+(deftest report-flags-fn-override-as-view-only
+  (testing "a fn-valued cell-override on the focused variant → view-only"
+    (story/reg-variant :story.egress/btn {:tags #{:dev} :events []})
+    (state/swap-state!
+      (fn [s] (-> s
+                  (assoc :selected-variant :story.egress/btn)
+                  (assoc-in [:cell-overrides :story.egress/btn]
+                            {:on-click (fn [_] nil) :label "ok"}))))
+    (let [report (ui-share/current-share-report (state/get-state))]
+      (is (= :view-only (:status report)))
+      (is (some #(= :override-fn (:code %)) (:reasons report))))))
+
+(deftest edn-snippet-emits-reg-variant-form
+  (testing "the copy-EDN snippet is a (reg-variant …) form pinning :extends
+            + the effective args of the focused cell"
+    (story/reg-variant :story.egress/counter {:tags #{:dev} :events [] :args {:n 1}})
+    (state/swap-state!
+      (fn [s] (-> s
+                  (assoc :selected-variant :story.egress/counter)
+                  (assoc-in [:cell-overrides :story.egress/counter] {:n 7}))))
+    (let [snip (ui-share/egress-edn-snippet (state/get-state))]
+      (is (str/starts-with? snip "(story/reg-variant "))
+      (is (str/includes? snip ":story.egress/counter"))
+      (is (str/includes? snip ":extends"))
+      (is (str/includes? snip ":n 7") "the cell-override beats the variant default")
+      (is (str/ends-with? snip "})")))))
+
+(deftest edn-snippet-nil-without-variant
+  (testing "no variant focused → no EDN snippet"
+    (is (nil? (ui-share/egress-edn-snippet (state/get-state))))))
+
+;; ---- dialog open / close / render ----------------------------------------
+
+(deftest dialog-closed-renders-nil
+  (testing "the dialog renders nil while closed"
+    (ui-share/close-share-export-dialog!)
+    (is (nil? (ui-share/share-export-dialog)))))
+
+(deftest dialog-open-renders-every-egress-command
+  (testing "the open dialog renders all four human-egress commands, each
+            shipping (NOT disabled-pending-a-seam) + carrying a
+            reproducibility label"
+    (story/reg-variant :story.egress/d {:tags #{:dev} :events [] :args {:n 1}})
+    (state/swap-state! #(assoc % :selected-variant :story.egress/d))
+    (ui-share/open-share-export-dialog!)
+    ;; `command-block` is a child Reagent component — `str` over the dialog
+    ;; hiccup shows each command's invocation PROPS (`:test "share-url"` …),
+    ;; not the child's expanded `data-test`. Assert on the props (the
+    ;; idiomatic shallow-hiccup check for child components).
+    (let [flat (str (ui-share/share-export-dialog))]
+      (is (str/includes? flat "story-share-export-dialog"))
+      ;; all four commands present and enabled (no disabled-pending-a-seam)
+      (is (str/includes? flat ":test \"share-url\""))
+      (is (str/includes? flat ":test \"copy-edn\""))
+      (is (str/includes? flat ":test \"screenshot\""))
+      (is (str/includes? flat ":test \"static-build\""))
+      ;; reproducibility labelling present on the rows (badges expand eagerly)
+      (is (str/includes? flat "story-egress-reproducibility"))
+      (is (str/includes? flat "fully reproducible"))
+      ;; the screenshot row honestly states view-only
+      (is (str/includes? flat "view-only"))
+      ;; NOT privacy-gated: no privacy-theatre friction on human egress
+      (is (not (str/includes? (str/lower-case flat) "privacy-sensitive")))
+      (is (not (str/includes? (str/lower-case flat) "blocked until"))))))
+
+(deftest dialog-share-chip-opens-dialog
+  (testing "the toolbar SHARE chip's on-click opens the dialog"
+    (ui-share/close-share-export-dialog!)
+    (is (nil? (ui-share/share-export-dialog)) "closed before the click")
+    (let [chip     (ui-share/share-chip)
+          attrs    (second chip)
+          on-click (:on-click attrs)]
+      (is (= "story-toolbar-share" (:data-test attrs)))
+      (is (fn? on-click))
+      (on-click nil)
+      (is (some? (ui-share/share-export-dialog))
+          "clicking the chip opens the dialog (it now renders a tree)"))))


### PR DESCRIPTION
Implements **rf2-ba86n.16** — the StoryUI EPIC's last child. The human-facing egress UX: **share URL · copy EDN · screenshot · static build**, each shipping enabled and each surfacing the artifact's **reproducibility status** (fully / partially / view-only) plus, where partial/view-only, *what* made it so.

## Reframe applied (authoritative — Mike 2026-05-30)

- **Human egress ships un-gated.** Egress of the dev's OWN running app (share URL, copied EDN, static export, screenshots) is NOT a privacy concern — a local dev already has programmatic access to their own secrets, so redacting human egress is futile. Every human egress command is enabled and working: **not disabled-pending-a-seam, not privacy-gated.**
- **No privacy-gating built on human egress.** There is no "are you sure this is sensitive?" friction anywhere — the CLJS test asserts the dialog carries no `privacy-sensitive` / `blocked until` text.
- **Reproducibility honesty is the surviving contract.** A shared/exported/copied artifact states whether the recipient can reproduce it (full/partial/view-only) and says what downgraded it (a fn-valued override → view-only; a non-EDN override / network-reply-fn / dropped overrides → partial). This is `"can the recipient reproduce this?"`, never `"is this sensitive?"`.
- **AI/MCP egress is out of scope here — already done.** The AI boundary gate (rf2-m25hd verified) and the log scrub (rf2-6773q) live elsewhere; this bead is the human UX. The pre-reframe common-redaction-seam dependency (rf2-qarwq) is CLOSED.

## What's built

- `re-frame.story.egress` (new, pure `.cljc`) — `classify` computes `:full`/`:partial`/`:view-only` over a variant's compiled plan + share params. Fn-detection rides `fingerprint`'s `Canonicalise` opaque-fn fold (same judgement the plan-hash uses). Lowest-status-wins fold.
- `re-frame.story.ui.share` — reusable `reproducibility-badge`, `current-share-report` + `egress-edn-snippet` builders, the `share-export-dialog` (URL · EDN · screenshot · static build) and the toolbar `share-chip`.
- `toolbar` — a SHARE cluster chip opens the dialog (chrome-wide). `shell` — mounts the dialog next to the other modals.
- `spec/022` — flipped from the pre-reframe BLOCKED / privacy-sensitive / common-redaction-seam model to the reproducibility-honesty contract; AI/MCP egress moved to out-of-scope. Reproducibility contract kept intact.

## controls.cljs

**Not touched** — stayed entirely on the dedicated share/toolbar/shell surfaces, so the in-flight `worker/schema-input-ui-xon7j` rebase is unaffected.

## Quality gates (all run from the worktree)

| Gate | Command | Result |
|---|---|---|
| clj-kondo | `clj-kondo --fail-level error --lint tools/story/src` | **errors: 0** (70 pre-existing warnings in untouched files; my files: 0/0) |
| Story JVM | `clojure -M:test` (from `tools/story/`) | **1518 tests / 5640 assertions — 0 failures, 0 errors** |
| CLJS | `npm run test:cljs` (from `implementation/`) | **5021 tests / 16795 assertions — 0 failures, 0 errors** |
| Bundle isolation | `npm run test:bundle-isolation` | **PASS** — share/export/egress DCE'd from production (35 sentinels absent) |
| Docs slugs | `python scripts/check_doc_slugs.py` | **PASS** |
| Docs build | `python -m mkdocs build --strict` | **PASS** (`tools/story/spec` is outside the mkdocs `docs_dir`, so 022 is not in the built tree; strict build still green) |

Browser smoke: none applies — Story-UI coverage is pure-projection JVM tests (`egress_test.cljc`) + CLJS surface tests (`share_egress_cljs_test.cljs`) per the test-free-examples policy. No share/export testbed exercises this surface.

Closes rf2-ba86n.16 (17/17 on the StoryUI epic). Do not merge — review bead rf2-8q37g follows.