### PR TITLE
docs(story-spec): clear egress-reframe residue — 008 banner + drop promoted-variants from 022 egress set (rf2-df9eq + rf2-652bf)

### DIFF
--- a/tools/story/spec/008-Docs-Mode.md
+++ b/tools/story/spec/008-Docs-Mode.md
@@ -9,7 +9,9 @@
 > The Story-UI docs contract carries this read-only pane forward and adds
 > evidence excerpts, fidelity / world-input / runner / frame-binding
 > chips, a view-arg schema table, test + visual/a11y status summaries,
-> and the common egress redaction seam for share / static / copy.
+> and the human share / export surface (share URL, copy EDN, screenshot,
+> static build) — shipping freely and each labelled with its
+> reproducibility status (fully / partially / view-only).
 
 ## Why a dedicated docs pane
 

--- a/tools/story/spec/022-Story-UI-Docs-And-Share.md
+++ b/tools/story/spec/022-Story-UI-Docs-And-Share.md
@@ -2,7 +2,7 @@
 
 > The Story `:docs` mode as curated, executable variant documentation
 > with evidence excerpts; and the **human-facing egress** surface — share
-> URLs, static export, copied EDN, screenshots, and promoted variants —
+> URLs, static export, copied EDN, and screenshots —
 > shipping freely and each labelled with its **reproducibility status**
 > (fully / partially / view-only) so a recipient knows what they can
 > replay. This spec **extends** [`008-Docs-Mode.md`](008-Docs-Mode.md)
@@ -145,8 +145,14 @@ is not the goal (the reframe). The human egress commands are:
 - share URL;
 - static build (`story:build`);
 - copied EDN;
-- screenshots;
-- promoted variants.
+- screenshots.
+
+Promotion (turning a captured run artifact into a named variant) is NOT in
+this set: it is registrar-WRITE authoring owned by
+[`021-Story-UI-Test-And-Evidence.md`](021-Story-UI-Test-And-Evidence.md)
+§3, not an outbound artifact. A promoted variant becomes a first-class
+registered variant that is then shareable through the four egress commands
+above.
 
 Each of these MUST be **enabled and working** — none is disabled pending a
 redaction seam, and none is fronted with a "are you sure this is
@@ -222,8 +228,8 @@ The docs-and-share contract is satisfied when:
 - evidence excerpts are a curated pointer into the evidence spine, not a
   second evidence renderer;
 - the human egress commands (share URL, static build, copy EDN,
-  screenshot, promoted variants) ship enabled and are NOT privacy-gated —
-  no "is this sensitive?" friction on egress of the dev's own app;
+  screenshot) ship enabled and are NOT privacy-gated — no "is this
+  sensitive?" friction on egress of the dev's own app;
 - every human egress command states the artifact's reproducibility status
   (fully / partially / view-only) and, where partial or view-only, says
   WHAT made it so;


### PR DESCRIPTION
Doc/spec-coherence cluster: clears two pieces of pre-reframe egress residue in the Story spec, left behind when #2507 flipped `022-Story-UI-Docs-And-Share.md` from the "common egress redaction seam / privacy-sensitive" model to the reproducibility-honesty contract (human egress of the dev's own app ships un-gated + labelled full/partial/view-only; the only redaction points — AI/MCP boundary + logs — are handled elsewhere: rf2-m25hd + rf2-6773q). Doc/spec edits only, no code.

## rf2-df9eq — 008 banner

`tools/story/spec/008-Docs-Mode.md:12` forward-reference banner still described 022's contribution with the exact framing 022 now rejects.

**Before:**
> ...test + visual/a11y status summaries, and the common egress redaction seam for share / static / copy.

**After:**
> ...test + visual/a11y status summaries, and the human share / export surface (share URL, copy EDN, screenshot, static build) — shipping freely and each labelled with its reproducibility status (fully / partially / view-only).

## rf2-652bf — drop "promoted variants" from 022 egress enumeration

`022` §3 (~line 149) and §5 acceptance (~line 224) enumerated "promoted variants" as a labelled human-egress command. But promotion is registrar-WRITE authoring (spec/021 §3), not outbound egress. Confirmed against #2507's shipped `share.cljs`: the egress dialog badges exactly **four** commands — `share-url`, `copy-edn`, `screenshot`, `static-build` (lines 519/537/547/562) — and the promotion dialog (`re-frame.story.ui.promotion`) carries no reproducibility badge. The spec over-claimed a fifth labelled-egress command the implementation does not (and should not) deliver.

**§3 before:** egress list `share URL · static build · copied EDN · screenshots · promoted variants`
**§3 after:** egress list `share URL · static build · copied EDN · screenshots`, followed by a note that promotion is NOT in the set — it is registrar-WRITE authoring owned by spec/021 §3, and a promoted variant becomes a first-class registered variant shareable through the four egress commands.

**§5 acceptance before:** `(share URL, static build, copy EDN, screenshot, promoted variants)`
**§5 acceptance after:** `(share URL, static build, copy EDN, screenshot)`

Also dropped "promoted variants" from the §1 banner one-line summary of the egress set (same over-claim, same file).

## Quality gates

- `python scripts/check_doc_slugs.py` → **exit 0** (PASS). New cross-link to `021-Story-UI-Test-And-Evidence.md` is a sibling file, already linked from §"Out of scope"; relative depth correct.
- `mkdocs build --strict` → **N/A**. `mkdocs.yml` `docs_dir: docs`; `tools/story/spec/` is not under the mkdocs docs tree, so these files are not part of the mkdocs build (matches the #2507 worker's report).
- Residue grep `git grep -n "common egress redaction seam\|promoted variants" tools/story/spec/008-Docs-Mode.md tools/story/spec/022-Story-UI-Docs-And-Share.md` → only remaining hit is `022:68` ("The pre-reframe \"BLOCKED on the common egress redaction seam ...\" dependency is GONE") — the already-correct reframed historical reference authored by #2507; intentionally left untouched. Both pre-reframe phrasings removed from the live contract.
- No code touched → no clj-kondo/cljs/JVM gates needed.

Closes rf2-df9eq, rf2-652bf.
