### PR TITLE
chore(portability): scrub personal-path leaks to the neutral me/my-app convention (rf2-q4sah)

### DIFF
--- a/implementation/core/src/re_frame/source_coords.cljc
+++ b/implementation/core/src/re_frame/source_coords.cljc
@@ -217,7 +217,7 @@
 ;; resolved the file.
 ;;
 ;; Live failure shape (rf2-wvsxg):
-;;   project-root  C:/Users/miket/code/re-frame2/tools/xray/testbeds
+;;   project-root  C:/Users/me/code/my-app/tools/xray/testbeds
 ;;   :file         day8/re_frame2_xray/views/edn_inspector.cljs
 ;;   composed      C:/.../tools/xray/testbeds/day8/.../edn_inspector.cljs
 ;;   actual        C:/.../tools/xray/src/day8/.../edn_inspector.cljs

--- a/implementation/core/test/re_frame/source_coords_editor_uri_test.clj
+++ b/implementation/core/test/re_frame/source_coords_editor_uri_test.clj
@@ -423,10 +423,10 @@
             absolute URI when the host has plumbed :project-root through"
     ;; Recreates the bead's exact failure: source-coord file shipped as
     ;; `panel_gallery/event_detail_stories.cljs` (classpath-relative);
-    ;; with Mike's local re-frame2 worktree as the project root, the URI
-    ;; must absolute-path the file the OS-side editor handler resolves.
+    ;; with a local checkout as the project root, the URI must
+    ;; absolute-path the file the OS-side editor handler resolves.
     (is (= (str "vscode://file/"
-                "C:/Users/miket/code/re-frame2/tools/xray/testbeds/"
+                "C:/Users/me/code/my-app/tools/xray/testbeds/"
                 "panel_gallery/event_detail_stories.cljs:115:3")
            (eu/editor-uri
              :vscode
@@ -434,4 +434,4 @@
               :line 115
               :column 3}
              {:project-root
-              "C:/Users/miket/code/re-frame2/tools/xray/testbeds"})))))
+              "C:/Users/me/code/my-app/tools/xray/testbeds"})))))

--- a/tools/re-frame2-pair-mcp/README.md
+++ b/tools/re-frame2-pair-mcp/README.md
@@ -167,8 +167,8 @@ will fail to start until the references are updated.
 
 Stale references:
   [global] mcpServers.re-frame-pair2
-    - arg: C:/Users/miket/code/re-frame2/tools/pair2-mcp/out/server.js
-      suggested: C:/Users/miket/code/re-frame2/tools/re-frame2-pair-mcp/out/server.js
+    - arg: C:/Users/me/code/my-app/tools/pair2-mcp/out/server.js
+      suggested: C:/Users/me/code/my-app/tools/re-frame2-pair-mcp/out/server.js
 
 Remediation: open ~/.claude.json in an editor, replace each
 'tools/pair2-mcp/' fragment with 'tools/re-frame2-pair-mcp/',

--- a/tools/re-frame2-pair-mcp/test/probe-mcp-path-test.cjs
+++ b/tools/re-frame2-pair-mcp/test/probe-mcp-path-test.cjs
@@ -76,9 +76,9 @@ function cleanup(dir) {
         're-frame-pair2': {
           command: 'node',
           args: [
-            'C:/Users/miket/code/re-frame2/tools/pair2-mcp/out/server.js',
+            'C:/Users/me/code/my-app/tools/pair2-mcp/out/server.js',
           ],
-          cwd: 'C:/Users/miket/code/re-frame2/implementation',
+          cwd: 'C:/Users/me/code/my-app/implementation',
           env: { SHADOW_CLJS_NREPL_PORT: '58376' },
         },
       },
@@ -126,9 +126,9 @@ function cleanup(dir) {
         're-frame2-pair': {
           command: 'node',
           args: [
-            'C:/Users/miket/code/re-frame2/tools/re-frame2-pair-mcp/out/server.js',
+            'C:/Users/me/code/my-app/tools/re-frame2-pair-mcp/out/server.js',
           ],
-          cwd: 'C:/Users/miket/code/re-frame2/implementation',
+          cwd: 'C:/Users/me/code/my-app/implementation',
         },
       },
     });
@@ -184,16 +184,16 @@ function cleanup(dir) {
   try {
     const fp = writeFixture(dir, '.claude.json', {
       projects: {
-        'C:/Users/miket/code/re-frame2': {
+        'C:/Users/me/code/my-app': {
           mcpServers: {
             'pair-old': {
               command:
-                'C:/Users/miket/code/re-frame2/tools/pair2-mcp/out/server.js',
+                'C:/Users/me/code/my-app/tools/pair2-mcp/out/server.js',
               args: [],
             },
           },
         },
-        'C:/Users/miket/code/some-other-project': {
+        'C:/Users/me/code/some-other-project': {
           mcpServers: {
             playwright: {
               command: 'npx',
@@ -213,7 +213,7 @@ function cleanup(dir) {
       'stale-project: only the one stale entry surfaces (playwright is clean)',
     );
     assert(
-      result.stale[0].scope === 'project:C:/Users/miket/code/re-frame2',
+      result.stale[0].scope === 'project:C:/Users/me/code/my-app',
       'stale-project: scope identifies the project path',
     );
     assert(
@@ -236,7 +236,7 @@ function cleanup(dir) {
         'pair-win': {
           command: 'node',
           args: [
-            'C:\\Users\\miket\\code\\re-frame2\\tools\\pair2-mcp\\out\\server.js',
+            'C:\\Users\\me\\code\\my-app\\tools\\pair2-mcp\\out\\server.js',
           ],
         },
       },
@@ -344,17 +344,17 @@ function cleanup(dir) {
 // ------------------------------------------------------------------
 (function testSuggestedReplacement() {
   const input =
-    'C:/Users/miket/code/re-frame2/tools/pair2-mcp/out/server.js';
+    'C:/Users/me/code/my-app/tools/pair2-mcp/out/server.js';
   const out = suggestedReplacement(input);
   assert(
     out ===
-      'C:/Users/miket/code/re-frame2/tools/re-frame2-pair-mcp/out/server.js',
+      'C:/Users/me/code/my-app/tools/re-frame2-pair-mcp/out/server.js',
     'suggested-replacement: legacy fragment swapped to current',
   );
   // Backslash input should also produce a normalised forward-slash
   // suggestion (best practice — Node accepts either on Windows).
   const win = suggestedReplacement(
-    'C:\\Users\\miket\\code\\re-frame2\\tools\\pair2-mcp\\out\\server.js',
+    'C:\\Users\\me\\code\\my-app\\tools\\pair2-mcp\\out\\server.js',
   );
   assert(
     win.includes('tools/re-frame2-pair-mcp/out/server.js'),

--- a/tools/story/test/re_frame/story_open_in_editor_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_open_in_editor_cljs_test.cljs
@@ -221,13 +221,13 @@
             resolves to an absolute on-disk URI when the host has
             plumbed :rf.story/project-root through Story's configure!"
     (config/set-project-root!
-      "C:/Users/miket/code/re-frame2/tools/xray/testbeds")
+      "C:/Users/me/code/my-app/tools/xray/testbeds")
     (let [hiccup (open-in-editor/open-chip
                    {:file "panel_gallery/event_detail_stories.cljs"
                     :line 115
                     :column 3})]
       (is (= (str "vscode://file/"
-                  "C:/Users/miket/code/re-frame2/tools/xray/testbeds/"
+                  "C:/Users/me/code/my-app/tools/xray/testbeds/"
                   "panel_gallery/event_detail_stories.cljs:115:3")
              (:href (second hiccup)))))))
 
@@ -259,13 +259,13 @@
            panel-gallery shape)"))
     ;; Post-fix shape: `story/configure!` seeds the atom; URI is absolute.
     (config/set-project-root!
-      "C:/Users/miket/code/re-frame2/tools/xray/testbeds")
+      "C:/Users/me/code/my-app/tools/xray/testbeds")
     (let [hiccup-post (open-in-editor/open-chip
                         {:file "panel_gallery/gallery_app_db.cljs"
                          :line 42
                          :column 7})]
       (is (= (str "vscode://file/"
-                  "C:/Users/miket/code/re-frame2/tools/xray/testbeds/"
+                  "C:/Users/me/code/my-app/tools/xray/testbeds/"
                   "panel_gallery/gallery_app_db.cljs:42:7")
              (:href (second hiccup-post)))
           "with :rf.story/project-root the URI is absolute — the
@@ -392,13 +392,13 @@
 (deftest windows-path-uri-shape
   (testing "rf2-muvs8 — Windows project-root + relative source-coord
             produces a URI VSCode's OS handler can resolve"
-    (config/set-project-root! "C:/Users/miket/code/re-frame2")
+    (config/set-project-root! "C:/Users/me/code/my-app")
     (let [hiccup (open-in-editor/open-chip
                    {:file "tools/story/src/re_frame/story/ui/open_in_editor.cljs"
                     :line 92
                     :column 5})]
       (is (= (str "vscode://file/"
-                  "C:/Users/miket/code/re-frame2/"
+                  "C:/Users/me/code/my-app/"
                   "tools/story/src/re_frame/story/ui/open_in_editor.cljs:92:5")
              (:href (second hiccup)))
           "absolute Windows URI shape — drive letter + forward slashes

--- a/tools/testbed-support/src/re_frame/testbed/config.cljs
+++ b/tools/testbed-support/src/re_frame/testbed/config.cljs
@@ -11,7 +11,7 @@
   `story/configure!`); there is no baked default. But the dev testbeds
   that drive Xray / Story have to PASS a root to `configure!`, and they
   previously each hardcoded the author's absolute Windows checkout
-  (`C:/Users/miket/code/re-frame2/tools/xray/testbeds`) as that value —
+  (`C:/Users/me/code/my-app/tools/xray/testbeds`) as that value —
   six copies of one machine-specific string. On any other clone, any
   other directory, and every Mac/Linux maintainer, 'open in editor'
   resolved to a path that does not exist.

--- a/tools/xray/test/day8/re_frame2_xray/config_test.clj
+++ b/tools/xray/test/day8/re_frame2_xray/config_test.clj
@@ -430,9 +430,9 @@
             resolves to an absolute on-disk URI when :project-root is
             plumbed (mirror of Story's rf2-zfy1e regression)"
     (config/set-project-root!
-      "C:/Users/miket/code/re-frame2/tools/xray/testbeds")
+      "C:/Users/me/code/my-app/tools/xray/testbeds")
     (is (= (str "vscode://file/"
-                "C:/Users/miket/code/re-frame2/tools/xray/testbeds/"
+                "C:/Users/me/code/my-app/tools/xray/testbeds/"
                 "panel_gallery/event_detail_stories.cljs:115:3")
            (config/editor-uri
              {:file "panel_gallery/event_detail_stories.cljs"

--- a/tools/xray/test/day8/re_frame2_xray/open_in_editor_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/open_in_editor_cljs_test.cljs
@@ -167,13 +167,13 @@
             resolves to an absolute on-disk URI when the host has
             plumbed :rf.xray/project-root through xray-config/configure!"
     (config/set-project-root!
-      "C:/Users/miket/code/re-frame2/tools/xray/testbeds")
+      "C:/Users/me/code/my-app/tools/xray/testbeds")
     (let [hiccup (open-in-editor/open-chip
                    {:file "panel_gallery/event_detail_stories.cljs"
                     :line 115
                     :column 3})]
       (is (= (str "vscode://file/"
-                  "C:/Users/miket/code/re-frame2/tools/xray/testbeds/"
+                  "C:/Users/me/code/my-app/tools/xray/testbeds/"
                   "panel_gallery/event_detail_stories.cljs:115:3")
              (:href (second hiccup)))))))
 
@@ -277,9 +277,9 @@
             served port — the URI depends only on config, never on
             `Location.href`."
     (config/set-project-root!
-      "C:/Users/miket/code/re-frame2/tools/xray/testbeds")
+      "C:/Users/me/code/my-app/tools/xray/testbeds")
     (is (= (str "vscode://file/"
-                "C:/Users/miket/code/re-frame2/tools/xray/testbeds/"
+                "C:/Users/me/code/my-app/tools/xray/testbeds/"
                 "panel_gallery/fixtures_epoch.cljs:42:1")
            (open-in-editor/resolve-uri
              {:file "panel_gallery/fixtures_epoch.cljs"


### PR DESCRIPTION
Mechanical de-personalization scrub for **rf2-q4sah** (parent EPIC rf2-v6wyb). Replaces genuine personal-path leaks (`C:/Users/miket/code/re-frame2[...]`) with the sanctioned neutral placeholder `C:/Users/me/code/my-app` already used across most Xray/Story tests + docs. Only the personal root changed; every deliberate Windows path-SHAPE assertion (drive-letter / forward-slash / backslash / `vscode://file/` shapes) is preserved — that is the cross-platform coverage that must stay.

## Re-baseline (live target list)
Per the bead's RE-BASELINE note (audit pre-dated PR #2504), I re-grepped fresh `main`:

```
git grep -lI "miket" -- . ':!ai/' ':!.beads/'
```

Hits (13), split into scrub-targets vs allowlist:

**Scrubbed (8 — genuine leaks):**
- `implementation/core/src/re_frame/source_coords.cljc` — comment example (~line 220)
- `implementation/core/test/re_frame/source_coords_editor_uri_test.clj` — string-composition test + comment
- `tools/xray/test/day8/re_frame2_xray/config_test.clj`
- `tools/xray/test/day8/re_frame2_xray/open_in_editor_cljs_test.cljs`
- `tools/story/test/re_frame/story_open_in_editor_cljs_test.cljs`
- `tools/testbed-support/src/re_frame/testbed/config.cljs` — docstring example (~line 14) (NOT cleaned by #2504; still on `miket`)
- `tools/re-frame2-pair-mcp/README.md` — sample probe-output paths (~lines 170-171)
- `tools/re-frame2-pair-mcp/test/probe-mcp-path-test.cjs` — fixture roots

**Left untouched (deliberate — EPIC guardrail, allowlist):**
- `CLAUDE.md`
- `scripts/assert-worker-worktree.ps1`
- `scripts/git-hooks/README.md`
- `scripts/git-hooks/lib/check-mayor-commit-boundary.sh`
- `scripts/git-hooks/pre-commit`

These encode the author's deliberate mayor/worker worktree-boundary guard layout by design; the guard-tooling cross-platform rewrite is owned by **rf2-lalk6**, not this bead.

## What I scrubbed vs what I kept deliberately within edited files
- **Test fixtures** (`config_test.clj`, both `open_in_editor_cljs_test.cljs`, `source_coords_editor_uri_test.clj`): swapped only the `:project-root` input string and the matching composed-URI literal. These are pure string-composition tests — a neutral root passes identically. The `windows-path-uri-shape` test (drive-letter + forward-slashes) and the backslash-tail assertions are unchanged.
- **pair-mcp probe** (`probe-mcp-path-test.cjs` + `README.md`): the probe's whole purpose is detecting the pre-rename `tools/pair2-mcp/` token vs the current `tools/re-frame2-pair-mcp/`. I **kept** that `pair2-mcp`/`re-frame2-pair-mcp` distinction and the deliberate backslash-vs-forward-slash shape fixtures — only the personal user-home root (`C:/Users/miket/code/re-frame2` → `C:/Users/me/code/my-app`, plus one `C:/Users/miket/code/some-other-project` → `.../me/...`) was neutralised. The probe matches on the `tools/pair2-mcp/` fragment, so detection behaviour is unchanged (35/35 fixtures still pass). In the README "sample output" block the `arg:` line correctly still shows `pair2-mcp` (the stale path being detected) and the `suggested:` line `re-frame2-pair-mcp` (the fix) — changing the `arg:` token would break the illustration, so only the personal root moved there.

## Final confirmation (allowlist-only)
After scrub, `git grep -lI "miket" -- . ':!ai/' ':!.beads/'` returns ONLY the 5 allowlisted deliberate files:
```
CLAUDE.md
scripts/assert-worker-worktree.ps1
scripts/git-hooks/README.md
scripts/git-hooks/lib/check-mayor-commit-boundary.sh
scripts/git-hooks/pre-commit
```
No redaction fixtures (`skills/shared/tests/fixtures/`, `tools/machines-viz/.../share_cljs_test.cljs`) appeared in the baseline — none carried `miket` in this checkout.

## Quality gates
| Command | Result |
| --- | --- |
| `clj-kondo --lint` (6 edited `.clj*` files) | **errors: 0**, 2 warnings — both pre-existing unused-`:require` warnings (`source_coords.cljc:49`, `open_in_editor_cljs_test.cljs:29`), unrelated to a string scrub |
| `node test/probe-mcp-path-test.cjs` (pair-mcp) | **35 passed, 0 failed** |
| `clojure -M:test` — `tools/xray/` | **969 tests, 3808 assertions, 0 failures, 0 errors** |
| `clojure -M:test` — `implementation/core/` | **803 tests, 3548 assertions, 0 failures, 0 errors** |
| `clojure -M:test` — `tools/story/` | **1528 tests, 5710 assertions, 0 failures, 0 errors** |
| `npm run test:cljs` (node-runtime CLJS, covers the `.cljs` editor tests) | **5021 tests, 16795 assertions, 0 failures, 0 errors** — log shows the live scrubbed URI `cursor://file/C:/Users/me/code/my-app/...` composing correctly |

## Unblocks
Unblocks **rf2-1ppe4** (CI portability gate) — after this merges, the gate allowlist drops these files.
