### PR TITLE
feat(story): implement the :db-seed fidelity rung end-to-end — accept + lower + seed + schema-validate (rf2-blw1q)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -168,7 +168,7 @@ Required normalized plan shape:
          :view-args-schema optional-schema ; explicit view input contract copied from view :rf/props
          :effective-args {...}            ; post-control-override args; drives render-variant
          :setup [setup-step ...]
-         :db-seed optional-db-or-patch    ; schema-checked direct state seed
+         :db-seed optional-db-or-patch    ; schema-checked direct state seed (§Setup — Direct app-db seeding)
          :render {:sub-overrides {query-vector data}} ; view-state affordance
          :network {[method url] {:reply {:ok data}}}  ; or {:reply {:failure data}}
          :fidelity #{:real-setup :db-seed :sub-overrides}
@@ -600,9 +600,11 @@ Rules:
 The fidelity ladder is: real setup events first, schema-checked app-db
 seed second, subscription overrides third. The third path is useful and
 legitimate, but it must be labelled. In the normalized plan, top-level
-`:sub-overrides` lowers to `[:world :render :sub-overrides]`; `:fidelity`
-is computed from the resolved world inputs, so authors SHOULD NOT have to
-type it.
+`:sub-overrides` lowers to `[:world :render :sub-overrides]` and
+`:db-seed` lowers to `[:world :db-seed]` (see §Setup — Direct app-db
+seeding); `:fidelity` is computed from the resolved world inputs, so
+authors SHOULD NOT have to type it. All three rungs are wired end-to-end
+(rf2-blw1q closed the `:db-seed` middle-rung gap).
 
 **Compiler contract (as implemented).** The plan compiler
 (`re-frame.story.plan`):
@@ -731,6 +733,42 @@ event/cofx/schema validation is part of establishing a realistic
 precondition. Direct app-db seeding MAY be added, but if supported it
 MUST validate affected app-db schemas before script execution (it
 bypasses event/cofx validation).
+
+#### Direct app-db seeding — `:db-seed` (as implemented)
+
+`:db-seed` is the implemented direct-seed slot — the MIDDLE rung of the
+fidelity ladder (`#{:real-setup :db-seed :sub-overrides}`). A variant /
+fragment authors a `{path → value}` map; the path is a top-level app-db
+key (or a path vector). The plan compiler:
+
+1. **Resolves `[:arg key]` placeholders inside the seed values** through
+   the same one-level `substitute-args` pass setup / script / network /
+   `:sub-overrides` use (a missing arg FAILS plan construction with
+   `:rf.error/story-missing-arg`).
+2. **Composes through fragments + the parent chain** — a composed
+   fragment MAY contribute `:db-seed`; fragment maps merge in declared
+   order, then the variant chain (where `:extends` context deep-merged)
+   wins per key. The result is one flat `{path → value}` map.
+3. **Lowers it to `[:world :db-seed]`** (present only when non-empty; it
+   participates in `:plan-hash` because the seed IS part of the variant's
+   identity) and **marks `[:world :fidelity]`** with `:db-seed`.
+
+The runtime, BEFORE any loaders or setup events run, merges the seed into
+the variant frame's app-db (a non-destructive top-level merge, so
+framework-reserved slots survive and a following `:real-setup` runs on
+top of the seed) and then **schema-validates the seeded app-db**. Per the
+rule above, direct seeding bypasses event / cofx validation but MUST
+validate the affected app-db schema: the runtime walks the frame's
+REGISTERED app-db schemas and validates each seeded slice, REUSING the
+existing schemas late-bind seam (`:schemas/frame-schema-entries` +
+`:schemas/validate-with-registered-fn` / `:schemas/explain-with-registered-fn`
+— the SAME validator the `:sub-return` path and the `:sub-override`
+fold-in reach; no new mechanism, no hard dep on the schemas artefact —
+when it is absent the check soft-passes). A seed that violates a
+registered schema FAILS the run with `:rf.error/story-db-seed-invalid`,
+whose ex-data carries every `:violations` entry (`{:path :value :schema
+:explain}`); the run never reaches the script. With no schemas artefact /
+no registered schema the seed is applied unchecked (the host-free floor).
 
 ### Script and `settled-boundary`
 

--- a/tools/story/src/re_frame/story/plan.cljc
+++ b/tools/story/src/re_frame/story/plan.cljc
@@ -229,7 +229,7 @@
   chain (the single source of truth for `arg-map` / `argtypes`), never read
   off `ctx`. Listing them here only buys a redundant deep-merge per compile
   and misleads a reader into thinking `ctx` is the arg source."
-  [:sub-overrides :network :fx-overrides :interceptor-overrides
+  [:sub-overrides :db-seed :network :fx-overrides :interceptor-overrides
    :decorators :loaders :loaders-teardown :loaders-complete-when
    :modes :substrates :platforms :viewport :background :xray
    :dispatch-console? :component :doc :args->events])
@@ -737,8 +737,10 @@
 ;;   :real-setup    — the variant has setup events (or a script) that
 ;;                    drive real state into the frame;
 ;;   :db-seed       — a schema-checked direct app-db seed (the world
-;;                    `:db-seed` slot; reserved — folded in when that slot
-;;                    lands so this fn does not need revisiting);
+;;                    `:db-seed` slot; rf2-blw1q — wired end-to-end: the
+;;                    compiler lowers it to `[:world :db-seed]` and the
+;;                    runtime seeds + schema-validates the frame's app-db
+;;                    BEFORE the script);
 ;;   :sub-overrides — one or more view-state subscription overrides.
 
 (defn compute-fidelity
@@ -748,18 +750,22 @@
 
   - `:real-setup`    when `setup` (or `script`) is non-empty — real
                      events drive the frame's state;
-  - `:db-seed`       when `db-seed` is present (a schema-checked direct
-                     app-db seed; reserved world slot);
+  - `:db-seed`       when `db-seed` resolves any entry (a schema-checked
+                     direct app-db seed merged into the frame BEFORE the
+                     script — rf2-blw1q);
   - `:sub-overrides` when `sub-overrides` resolves any entry.
 
   A plain events-driven variant yields `#{:real-setup}`; a pure design
-  variant that only pins sub values yields `#{:sub-overrides}`; a hybrid
-  carries both. The empty set (no setup, no seed, no overrides) is a
-  legitimate render-the-view-as-mounted variant."
+  variant that only pins sub values yields `#{:sub-overrides}`; a
+  db-seed variant yields `#{:db-seed}`; a hybrid carries the union. The
+  empty set (no setup, no seed, no overrides) is a legitimate
+  render-the-view-as-mounted variant. An EMPTY resolved seed / override
+  map is treated as absent (no rung) — the same `seq` floor `setup`
+  uses."
   [{:keys [setup script db-seed sub-overrides]}]
   (cond-> #{}
     (or (seq setup) (seq script)) (conj :real-setup)
-    (some? db-seed)               (conj :db-seed)
+    (seq db-seed)                 (conj :db-seed)
     (seq sub-overrides)           (conj :sub-overrides)))
 
 ;; ============================================================================
@@ -1289,6 +1295,19 @@
         ;; resolved overrides below feed validation + the run path.
         sub-overrides-raw (merge frag-sub-ovr (:sub-overrides ctx))
         sub-overrides (substitute-args sub-overrides-raw arg-map subs!)
+        ;; ---- :db-seed world slot (rf2-blw1q) ----
+        ;; The MIDDLE fidelity rung: a direct app-db state seed
+        ;; (`{path → value}`). Composes through the parent chain (ctx,
+        ;; deep-merged via `merge-context` through `:extends`) + composed
+        ;; fragments' seed maps (later wins per declared order, then the
+        ;; variant chain — the SAME ordering `:sub-overrides` / `:network`
+        ;; follow). Seed values MAY carry `[:arg key]` placeholders (a
+        ;; control-driven seed slice), so substitute before lowering. The
+        ;; runtime seeds + schema-validates the resolved map BEFORE the
+        ;; script (spec/017 §Setup); a violation FAILS the run with
+        ;; `:rf.error/story-db-seed-invalid`.
+        frag-db-seed (reduce (fn [m l] (merge m (:db-seed l))) {} frag-layers)
+        db-seed      (substitute-args (merge frag-db-seed (:db-seed ctx)) arg-map subs!)
         ;; ---- strict-conflict composition (rf2-5x1wt.15) ----
         ;; The strict-conflict override MAPS (`:fx-overrides` /
         ;; `:interceptor-overrides`) compose per-KEY: the variant chain
@@ -1396,7 +1415,7 @@
         ;; overrides — fidelity ladder).
         fidelity     (compute-fidelity {:setup         setup
                                         :script        script*
-                                        :db-seed       (:db-seed ctx)
+                                        :db-seed       db-seed
                                         :sub-overrides sub-overrides})
         ;; ---- runner requirement ----
         required     (compute-required-runner setup script* assertions)
@@ -1426,6 +1445,18 @@
                               :platforms      platforms}
                        (some? schema)        (assoc :view-args-schema schema)
                        (some? sub-overrides) (assoc-in [:render :sub-overrides] sub-overrides)
+                       ;; rf2-blw1q — the resolved direct app-db seed
+                       ;; (`{path → value}`, `[:arg]` placeholders
+                       ;; substituted). In `:world` so it participates in
+                       ;; `:plan-hash` (the seed IS part of the variant's
+                       ;; identity) and feeds the now-LIVE `:fidelity`
+                       ;; `:db-seed` rung. Present only when non-empty; a
+                       ;; variant with no seed carries no slot. The runtime
+                       ;; reads `[:world :db-seed]`, merges it into the
+                       ;; frame's app-db BEFORE the script, and
+                       ;; schema-validates the seeded app-db (spec/017
+                       ;; §Setup).
+                       (seq db-seed)         (assoc :db-seed db-seed)
                        ;; rf2-5x1wt.13 — the fidelity ladder, computed from
                        ;; the resolved world inputs. In `:world` so it
                        ;; participates in `:plan-hash` (fingerprint's
@@ -1514,6 +1545,16 @@
                                         :validation (when sub-ovr-val
                                                       {:status     (:status sub-ovr-val)
                                                        :violations (:violations sub-ovr-val)})})
+                      ;; rf2-blw1q — the resolved direct app-db seed (post
+                      ;; `[:arg]` substitution). `explain` surfaces it so a
+                      ;; reviewer / doc page sees exactly which app-db
+                      ;; slices the variant seeds; `:fidelity` labels it the
+                      ;; `:db-seed` rung. The seeded-app-db schema
+                      ;; validation is a RUN-TIME check (it needs the
+                      ;; frame's registered app-db schemas), so it is NOT a
+                      ;; plan-compile slot here — a violation surfaces as
+                      ;; `:rf.error/story-db-seed-invalid` at run time.
+                      :db-seed      (when (seq db-seed) {:seed db-seed})
                       :fidelity     fidelity
                       :setup-order  setup
                       :script-order script*

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -38,6 +38,7 @@
   production code that accidentally calls `run-variant` does not throw
   — it returns empty."
   (:require [re-frame.core            :as rf]
+            [re-frame.late-bind       :as late-bind]
             [re-frame.story.args      :as args]
             [re-frame.story.assertions :as assertions]
             [re-frame.story.async     :as async]
@@ -376,7 +377,8 @@
 (defn install-canonical-runtime-events!
   "Register the runtime's internal helper events: `::append-assertion`
   for projecting exception captures + assertion records onto the
-  variant frame's `:rf.story/assertions` accumulator. Idempotent.
+  variant frame's `:rf.story/assertions` accumulator, and `::apply-db-seed`
+  for the `:db-seed` fidelity rung (rf2-blw1q). Idempotent.
 
   Mirrors the `install-canonical-<X>!` shape used by every sibling
   installer in `canonical/canonical-installers`. Was the vague
@@ -386,7 +388,24 @@
     (rf/reg-event-db
       ::append-assertion
       (fn [db [_ record]]
-        (update db :rf.story/assertions (fnil conj []) record)))))
+        (update db :rf.story/assertions (fnil conj []) record)))
+    ;; rf2-blw1q — the `:db-seed` direct app-db seed. Merges the resolved
+    ;; `{path → value}` seed map into the frame's app-db via `assoc-in`
+    ;; (a top-level keyword path is normalised to a 1-element vector), the
+    ;; SAME merge `::apply-app-db-patch` (the `:frame-setup` decorator
+    ;; seam) uses. A MERGE (not a wholesale replace) so framework-reserved
+    ;; slots the frame already carries (e.g. `:rf.story/assertions`)
+    ;; survive — the seed establishes the author's state on top, then
+    ;; phase-2 `:setup` events run over it (the fidelity ladder composes:
+    ;; `:db-seed` then `:real-setup`).
+    (rf/reg-event-db
+      ::apply-db-seed
+      (fn [db [_ seed]]
+        (reduce-kv
+          (fn [d path v]
+            (assoc-in d (if (vector? path) path [path]) v))
+          db
+          seed)))))
 
 ;; ---- assertions read -----------------------------------------------------
 
@@ -711,6 +730,79 @@
   (play/install-trace-listener! variant-id)
   ctx)
 
+(defn- db-seed-violations
+  "Validate the seeded `db` against the frame's REGISTERED app-db schemas
+  (rf2-blw1q + spec/017 §Setup — direct seeding bypasses event / cofx
+  validation but MUST validate the affected app-db schema). Returns a
+  (possibly empty) vector of `{:path :value :explain}` violations.
+
+  REUSES the existing schemas late-bind seam — the SAME
+  `:schemas/validate-with-registered-fn` / `:schemas/explain-with-registered-fn`
+  the `:sub-return` path + the rf2-7pgiz `:sub-override` fold-in reach, and
+  `:schemas/frame-schema-entries` to enumerate the frame's registered
+  `{path → schema-meta}`. No new validation mechanism, and no hard dep on
+  the schemas artefact: when it is absent every hook resolves nil and the
+  walk SOFT-PASSES (the host-free floor — a Story-only build pays nothing).
+  When the schemas artefact IS present its registered validator (Malli on
+  the CLJS reference) is the same one the framework's dev-mode hot path
+  uses, so the seed is held to exactly the contract a real handler commit
+  would be (spec/010 §Production builds)."
+  [frame-id db]
+  (let [entries-fn  (late-bind/get-fn :schemas/frame-schema-entries)
+        validate-fn (late-bind/get-fn :schemas/validate-with-registered-fn)
+        explain-fn  (late-bind/get-fn :schemas/explain-with-registered-fn)]
+    (if (or (nil? entries-fn) (nil? validate-fn))
+      ;; No schemas artefact / no validator → soft-pass (nothing to check).
+      []
+      (into []
+            (keep (fn [[reg-path schema-meta]]
+                    (let [schema    (:schema schema-meta)
+                          reg-slice (get-in db reg-path)]
+                      (when (and (some? schema)
+                                 (not (validate-fn schema reg-slice)))
+                        {:path    reg-path
+                         :value   reg-slice
+                         :schema  schema
+                         :explain (when explain-fn (explain-fn schema reg-slice))}))))
+            (entries-fn frame-id)))))
+
+(defn- run-db-seed!
+  "Phase 0.5 (rf2-blw1q): seed the variant frame's app-db from the plan's
+  `[:world :db-seed]` slot, then SCHEMA-VALIDATE the seeded app-db — BEFORE
+  any loaders (phase 1) or setup events (phase 2) run. The MIDDLE fidelity
+  rung: a direct app-db state seed merged into the frame ahead of the
+  script (spec/017 §Setup + §View-state subscription overrides — the
+  fidelity ladder).
+
+  No-op when the variant carries no seed (the common case carries no
+  `[:world :db-seed]` slot, so the merge dispatch + the schema walk are
+  skipped entirely).
+
+  Per spec/017 §Setup direct seeding bypasses event / cofx validation but
+  MUST validate the affected app-db schema. A seed that violates a
+  registered schema THROWS a structured `:rf.error/story-db-seed-invalid`
+  ex-info carrying every `{:path :value :explain}` violation; the
+  orchestrator's `handle-run-error!` projects it onto the run result as a
+  failed `:rf.error/story-db-seed-invalid` assertion (the run never reaches
+  the script — a malformed precondition is not a thing to assert against)."
+  [{:keys [variant-id plan] :as ctx}]
+  (when-let [seed (not-empty (get-in plan [:world :db-seed]))]
+    (rf/dispatch-sync [::apply-db-seed seed] {:frame variant-id})
+    (let [violations (db-seed-violations variant-id (rf/get-frame-db variant-id))]
+      (when (seq violations)
+        (throw (ex-info
+                 (str "re-frame2-story: variant " variant-id
+                      " — :db-seed does not satisfy the registered app-db "
+                      "schema(s) at path(s) "
+                      (pr-str (mapv :path violations))
+                      ". A direct app-db seed bypasses event/cofx validation "
+                      "but MUST validate the affected app-db schema "
+                      "(spec/017 §Setup).")
+                 {:rf.error/id :rf.error/story-db-seed-invalid
+                  :variant/id  variant-id
+                  :violations  violations})))))
+  ctx)
+
 (defn- run-phase-1!
   "Phase 1: drive loaders to completion. Thin wrapper that returns
   `ctx` so the orchestrator stays a clean threaded pipeline.
@@ -891,6 +983,38 @@
                        :reason     (exception-message e)
                        :error      (story-error/throwable->error-map e)}]))
 
+(defn- db-seed-error?
+  "True iff `e` is the structured `:db-seed` schema-validation failure
+  `run-db-seed!` throws (rf2-blw1q). Discriminated on `:rf.error/id` —
+  the seed throw stamps `:rf.error/story-db-seed-invalid` with a
+  `:violations` vector. The frame IS allocated when it throws (the seed
+  ran against it), so it takes the frame-bound branch, but we record it as
+  its OWN structured assertion (id `:rf.error/story-db-seed-invalid` +
+  the path/value/explain violations) rather than the opaque
+  `:rf.error/exception` shape, so tooling routes on the seed-failure id."
+  [e]
+  (= :rf.error/story-db-seed-invalid (:rf.error/id (ex-data e))))
+
+(defn- record-seed-error!
+  "Append the structured `:rf.error/story-db-seed-invalid` assertion to the
+  variant frame's `:rf.story/assertions` accumulator (rf2-blw1q). The
+  record carries the `:violations` vector (`{:path :value :explain}` per
+  violating slice) so the result surfaces the exact schema misses the seed
+  produced (spec/017 §Setup). `:passed? false` makes the run aggregate to
+  `:fail`."
+  [variant-id e]
+  (let [data   (ex-data e)
+        record {:assertion  :rf.error/story-db-seed-invalid
+                :variant-id variant-id
+                :status     :error
+                :passed?    false
+                :reason     (exception-message e)
+                :violations (:violations data)}]
+    (try
+      (rf/dispatch-sync [::append-assertion record] {:frame variant-id})
+      (catch #?(:clj Throwable :cljs :default) _ nil))
+    record))
+
 (defn- handle-run-error!
   "Catch-branch for the orchestrator: record the exception as a
   phase-0-setup assertion (covers any sync throw from the phase chain),
@@ -904,11 +1028,26 @@
   `prepare-context`, before frame allocation) cannot be recorded onto a
   frame, so it is projected directly via `plan-error-result`. Every other
   throw lands after the frame exists and routes through the frame-bound
-  record/transition path."
+  record/transition path.
+
+  rf2-blw1q — a `:db-seed` schema-validation failure (`run-db-seed!`)
+  throws AFTER the frame is allocated, so it takes the frame-bound branch,
+  but is recorded as its own structured `:rf.error/story-db-seed-invalid`
+  assertion (carrying the path/value/explain violations) rather than the
+  opaque `:rf.error/exception` shape."
   [resolve variant-id e start-ms]
-  (if (and (plan-construction-error? e)
-           (= :pre-mount (loaders/current-state variant-id)))
+  (cond
+    (and (plan-construction-error? e)
+         (= :pre-mount (loaders/current-state variant-id)))
     (resolve (plan-error-result variant-id e))
+
+    (db-seed-error? e)
+    (do
+      (record-seed-error! variant-id e)
+      (loaders/error! variant-id (ex-data e))
+      (resolve (record-result-map {:variant-id variant-id} start-ms)))
+
+    :else
     (do
       (record-error! variant-id :phase-0-setup nil e)
       (loaders/error! variant-id (ex-data e))
@@ -961,6 +1100,7 @@
                (try
                  (let [ctx          (-> (prepare-context variant-id variant-body opts)
                                         run-phase-0!
+                                        run-db-seed!
                                         run-phase-1!
                                         run-phase-2!)
                        [ctx' play-promise] (run-phase-4! ctx)]
@@ -1110,6 +1250,7 @@
                (try
                  (let [ctx          (-> (prepare-inline-context frame-id plan opts)
                                         run-inline-phase-0!
+                                        run-db-seed!
                                         run-phase-1!
                                         run-phase-2!)
                        [ctx' play-promise] (run-phase-4! ctx)]
@@ -1123,7 +1264,12 @@
                              (resolve result))
                            nil))))
                  (catch #?(:clj Throwable :cljs :default) e
-                   (record-error! frame-id :phase-0-setup nil e)
+                   ;; rf2-blw1q — a `:db-seed` schema-validation failure
+                   ;; records as its own structured assertion; every other
+                   ;; throw stays the opaque `:rf.error/exception` shape.
+                   (if (db-seed-error? e)
+                     (record-seed-error! frame-id e)
+                     (record-error! frame-id :phase-0-setup nil e))
                    (loaders/error! frame-id (ex-data e))
                    (let [result (record-result-map
                                   {:variant-id frame-id :plan plan} start-ms)]

--- a/tools/story/src/re_frame/story/schemas.cljc
+++ b/tools/story/src/re_frame/story/schemas.cljc
@@ -593,6 +593,30 @@
   rung of the fidelity ladder)."
   [:map-of SubQueryVector :any])
 
+(def DbSeed
+  "Schema for the `:db-seed` slot on a variant / fragment body — the
+  MIDDLE rung of the fidelity ladder (rf2-blw1q + spec/017 §View-state
+  subscription overrides — `#{:real-setup :db-seed :sub-overrides}`). A
+  direct app-db state seed: a `path → value` map merged into the variant
+  frame's app-db BEFORE script execution.
+
+  Per `tools/story/spec/017-Testing-Story.md` §Setup direct app-db
+  seeding bypasses event / cofx validation but MUST validate the affected
+  app-db schemas before the script runs — so the plan compiler lowers
+  `:db-seed` to `[:world :db-seed]` and the runtime validates the seeded
+  app-db against the frame's REGISTERED app-db schemas
+  (`:schemas/frame-schema-entries` + `:schemas/validate-with-registered-fn`,
+  the SAME late-bind seam `:sub-return` + the `:sub-override` fold-in
+  reuse). A seed that violates a registered schema FAILS the run with
+  `:rf.error/story-db-seed-invalid`.
+
+  The seed VALUE is left loose (`:any`) at this layer — the precise
+  conformance is the per-frame app-db schema check at run time, which
+  carries the exact path/value/explain diagnostic. The key shape is a
+  top-level app-db slice (a keyword or a path vector), matching the
+  `[:frame-setup :app-db-patch]` decorator slot the runtime reuses."
+  [:map-of [:or :keyword [:vector :any]] :any])
+
 (def NetworkSpec
   "Schema for the `:network` slot on a story / variant / fragment body —
   first-class managed-HTTP request stubs (rf2-5x1wt.14). A map of
@@ -724,6 +748,18 @@
     ;; `:rf.assert/sub-equals`. See `SubOverridesMap` + spec/017
     ;; §View-state subscription overrides.
     [:sub-overrides         {:optional true} SubOverridesMap]
+    ;; rf2-blw1q — `:db-seed` is the MIDDLE fidelity rung (spec/017
+    ;; §View-state subscription overrides — `#{:real-setup :db-seed
+    ;; :sub-overrides}`): a direct app-db state seed (a `path → value`
+    ;; map) merged into the variant frame's app-db BEFORE script
+    ;; execution. The plan compiler lowers it to `[:world :db-seed]` and
+    ;; marks `[:world :fidelity]` with `:db-seed`; the runtime seeds the
+    ;; frame and schema-validates the seeded app-db against the frame's
+    ;; registered app-db schemas — direct seeding bypasses event / cofx
+    ;; validation but MUST validate the affected app-db schema (spec/017
+    ;; §Setup). A seed that violates a registered schema FAILS the run
+    ;; with `:rf.error/story-db-seed-invalid`. See `DbSeed`.
+    [:db-seed               {:optional true} DbSeed]
     ;; rf2-5x1wt.15 — strict-conflict effect/interceptor override slots.
     ;; `:fx-overrides` is the first-class fx-override surface (spec/017
     ;; §The effect-override surface); `:interceptor-overrides` the
@@ -848,6 +884,11 @@
     ;; fragment / the variant wins per key) and mark the resolved plan
     ;; `:fidelity` with `:sub-overrides`. See `SubOverridesMap`.
     [:sub-overrides         {:optional true} SubOverridesMap]
+    ;; rf2-blw1q — a fragment MAY contribute `:db-seed`; the seeds
+    ;; deep-merge into the composing variant's seed map (a later fragment
+    ;; / the variant wins per key) and mark the resolved plan `:fidelity`
+    ;; with `:db-seed`. See `DbSeed`.
+    [:db-seed               {:optional true} DbSeed]
     [:fx-overrides          {:optional true} [:map-of :keyword :any]]
     [:interceptor-overrides {:optional true} [:map-of :keyword :any]]
     [:loaders               {:optional true} [:vector EventVector]]

--- a/tools/story/src/re_frame/story/ui/view_state.cljc
+++ b/tools/story/src/re_frame/story/ui/view_state.cljc
@@ -239,9 +239,12 @@
 
       {:rung :db-seed :present? bool :source :db-seed}
 
-  The seed slot is reserved (rf2-blw1q — not yet wired to authoring), so
-  `:present?` is normally false; the summary still renders the rung so
-  the ladder + the upgrade target are honest. Pure data → data."
+  The `:db-seed` rung is wired end-to-end (rf2-blw1q): a variant that
+  authors a `:db-seed` map lowers it to `[:world :db-seed]` and the
+  runtime seeds + schema-validates the frame's app-db before the script.
+  `:present?` is true iff the compiled plan carries a non-empty seed; the
+  summary still renders the rung when absent so the ladder + the upgrade
+  target stay honest. Pure data → data."
   [plan]
   {:rung     :db-seed
    :present? (some? (get-in plan [:world :db-seed]))

--- a/tools/story/test/re_frame/story/plan_test.cljc
+++ b/tools/story/test/re_frame/story/plan_test.cljc
@@ -623,6 +623,98 @@
              (get-in p [:world :render :sub-overrides])))
       (is (= #{:sub-overrides} (get-in p [:world :fidelity]))))))
 
+;; ---- :db-seed — the MIDDLE fidelity rung (rf2-blw1q) ---------------------
+;;
+;; `:db-seed` is the schema-checked direct app-db seed. The compiler accepts
+;; it (the schema no longer silently ignores it), lowers it to `[:world
+;; :db-seed]` (`[:arg]` placeholders substituted, fragments + the parent
+;; chain composed), and marks `[:world :fidelity]` with `:db-seed`. The
+;; seeded-app-db schema validation is a RUN-TIME check (runtime_test) — it
+;; needs the frame's registered app-db schemas.
+
+(deftest db-seed-lowers-and-marks-fidelity
+  (testing "a :db-seed variant lowers to [:world :db-seed] and marks the rung"
+    (let [m {:story.cart/seeded
+             {:db-seed {:cart {:items [{:sku "A" :qty 2}]}
+                        :user/id 42}}}
+          p (plan/variant-plan :story.cart/seeded {:lookup m})]
+      (testing "the seed lowers verbatim to the world slot"
+        (is (= {:cart {:items [{:sku "A" :qty 2}]} :user/id 42}
+               (get-in p [:world :db-seed]))))
+      (testing ":fidelity carries :db-seed (and no :real-setup — a pure seed variant)"
+        (is (= #{:db-seed} (get-in p [:world :fidelity]))))
+      (testing "explain surfaces the resolved seed + fidelity"
+        (is (= {:cart {:items [{:sku "A" :qty 2}]} :user/id 42}
+               (get-in p [:explain :db-seed :seed])))
+        (is (= #{:db-seed} (get-in p [:explain :fidelity])))))))
+
+(deftest db-seed-author-no-longer-silently-ignored
+  (testing "an author's :db-seed is accepted by the schema (not dropped) and lowers"
+    ;; The Variant schema validates the body at registration; reg-variant
+    ;; would reject an unknown-shape :db-seed. Compiling the body proves the
+    ;; slot is accepted AND survives into the plan (the pre-rf2-blw1q bug was
+    ;; silent-accept-then-silent-ignore).
+    (let [m {:story.x/seed {:db-seed {:k 1}}}
+          p (plan/variant-plan :story.x/seed {:lookup m})]
+      (is (= {:k 1} (get-in p [:world :db-seed])))
+      (is (contains? (get-in p [:world :fidelity]) :db-seed)))))
+
+(deftest db-seed-arg-substitution
+  (testing "[:arg key] placeholders in a seed value resolve before lowering"
+    (let [m {:story.cart/argseed
+             {:args    {:qty 7}
+              :db-seed {:cart {:qty [:arg :qty]}}}}
+          p (plan/variant-plan :story.cart/argseed {:lookup m})]
+      (is (= {:cart {:qty 7}} (get-in p [:world :db-seed])))
+      (is (some #(= {:key :qty :value 7} %) (get-in p [:explain :substitutions]))))))
+
+(deftest db-seed-inherits-through-extends
+  (testing "a child :db-seed deep-merges over the parent's seed (context flows down)"
+    (let [m {:story.p/base  {:db-seed {:cart {:items []} :flags {:a true}}}
+             :story.p/child {:extends :story.p/base
+                             :db-seed {:cart {:items [1 2]}}}}
+          p (plan/variant-plan :story.p/child {:lookup m})]
+      ;; deep-merge: child wins :cart, parent's :flags survives.
+      (is (= {:cart {:items [1 2]} :flags {:a true}}
+             (get-in p [:world :db-seed])))
+      (is (= #{:db-seed} (get-in p [:world :fidelity]))))))
+
+(deftest db-seed-composes-through-fragments
+  (testing "a composed fragment contributes :db-seed; the variant wins per key"
+    (let [frag {:fragment/seed {:db-seed {:cart {:items []} :session :guest}}}
+          m    {:story.cart/composed
+                {:compose [:fragment/seed]
+                 :db-seed {:session :member}}} ; variant overrides the key
+          p (plan/variant-plan :story.cart/composed
+                               {:lookup m :fragment-lookup frag})]
+      (is (= {:cart {:items []} :session :member}
+             (get-in p [:world :db-seed])))
+      (is (= #{:db-seed} (get-in p [:world :fidelity]))))))
+
+(deftest db-seed-empty-is-no-rung
+  (testing "an empty resolved :db-seed activates no rung + carries no world slot"
+    (let [m {:story.cart/emptyseed {:db-seed {}}}
+          p (plan/variant-plan :story.cart/emptyseed {:lookup m})]
+      (is (nil? (get-in p [:world :db-seed])))
+      (is (nil? (get-in p [:world :fidelity]))))))
+
+(deftest compute-fidelity-three-rungs
+  (testing "compute-fidelity computes each of the three rungs independently"
+    (is (= #{} (plan/compute-fidelity {})))
+    (is (= #{:real-setup}
+           (plan/compute-fidelity {:setup [[:dispatch [:e]]]})))
+    (is (= #{:db-seed}
+           (plan/compute-fidelity {:db-seed {:k 1}})))
+    (is (= #{:sub-overrides}
+           (plan/compute-fidelity {:sub-overrides {[:q] 1}})))
+    (testing "an empty seed / override map is treated as absent (no rung)"
+      (is (= #{} (plan/compute-fidelity {:db-seed {} :sub-overrides {}}))))
+    (testing "all three rungs together"
+      (is (= #{:real-setup :db-seed :sub-overrides}
+             (plan/compute-fidelity {:setup         [[:dispatch [:e]]]
+                                     :db-seed       {:k 1}
+                                     :sub-overrides {[:q] 1}}))))))
+
 ;; ---- pure resolver: render-path read + sub-assertion honesty -------------
 
 (deftest sub-overrides-render-path-resolver-is-exact

--- a/tools/story/test/re_frame/story/runtime_db_seed_test.clj
+++ b/tools/story/test/re_frame/story/runtime_db_seed_test.clj
@@ -1,0 +1,207 @@
+(ns re-frame.story.runtime-db-seed-test
+  "End-to-end run-path tests for the `:db-seed` fidelity rung (rf2-blw1q).
+
+  `:db-seed` is the MIDDLE rung of spec/017's fidelity ladder
+  (`#{:real-setup :db-seed :sub-overrides}`): a schema-checked direct
+  app-db seed. These tests drive `story/run` to terminal on the JVM and
+  assert the runtime BEHAVIOUR the plan compiler can't (the seed is
+  applied to a live frame; the seeded app-db is schema-validated):
+
+  - a valid `:db-seed` seeds the variant frame's app-db BEFORE the script,
+    and a `:real-setup` event runs ON TOP of the seed (the ladder
+    composes);
+  - a seed that VIOLATES the frame's registered app-db schema FAILS the
+    run with a structured `:rf.error/story-db-seed-invalid` carrying the
+    `{:path :value :explain}` violations (spec/017 §Setup — direct seeding
+    bypasses event/cofx validation but MUST validate the affected app-db
+    schema);
+  - with NO schemas artefact / no validator the seed is applied unchecked
+    (the host-free floor).
+
+  Validation reuses the EXISTING schemas late-bind seam — the runtime
+  reaches `:schemas/frame-schema-entries` +
+  `:schemas/validate-with-registered-fn` / `:schemas/explain-with-registered-fn`
+  through `re-frame.late-bind` (the SAME seam the `:sub-return` path + the
+  rf2-7pgiz `:sub-override` fold-in use). The schemas artefact is NOT on
+  Story's classpath, so these tests REGISTER those hooks directly (backed
+  by Malli, which IS on the classpath) exactly as the artefact would —
+  which is itself proof the runtime takes no hard dep on the schemas
+  artefact and drives the validation purely through the late-bind seam."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [malli.core         :as m]
+            [re-frame.core      :as rf]
+            [re-frame.frame     :as frame]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.story     :as story]
+            [re-frame.story.assertions :as assertions]))
+
+;; ---- a host-free stand-in for the schemas artefact's late-bind seam ------
+;;
+;; A per-frame `{frame-id {reg-path schema-meta}}` registry + the Malli-
+;; backed validator/explainer, published under the SAME hook keys the real
+;; schemas artefact uses. This is the contract the runtime's
+;; `db-seed-violations` reaches — proving the reuse without a hard dep.
+
+(def ^:private frame-schemas (atom {}))
+
+(defn- reg-app-schema! [frame-id reg-path schema]
+  (swap! frame-schemas assoc-in [frame-id reg-path] {:schema schema}))
+
+(defn- install-schema-seam! []
+  (late-bind/set-fn! :schemas/frame-schema-entries
+                     (fn [frame-id] (get @frame-schemas frame-id {})))
+  (late-bind/set-fn! :schemas/validate-with-registered-fn
+                     (fn [schema value] (m/validate schema value)))
+  (late-bind/set-fn! :schemas/explain-with-registered-fn
+                     (fn [schema value] (m/explain schema value))))
+
+(defn- uninstall-schema-seam! []
+  (swap! late-bind/hooks dissoc
+         :schemas/frame-schema-entries
+         :schemas/validate-with-registered-fn
+         :schemas/explain-with-registered-fn))
+
+(defn- reset-rf! [test-fn]
+  (story/clear-all!)
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! frame-schemas {})
+  (try (rf/init! plain-atom/adapter)
+       (catch clojure.lang.ExceptionInfo _ nil))
+  (reset! assertions/trace-accumulators {})
+  ;; Clear any schema seam a prior test left so the no-validator floor case
+  ;; is clean; tests that want validation install it explicitly.
+  (uninstall-schema-seam!)
+  (story/install-canonical-vocabulary!)
+  (frame/ensure-default-frame!)
+  (rf/reg-event-db :cart/add-item
+                   (fn [db [_ item]]
+                     (update-in db [:cart :items] (fnil conj []) item)))
+  (test-fn))
+
+(use-fixtures :each reset-rf!)
+
+(defn- run-target
+  ([target] (.get ^java.util.concurrent.CompletableFuture (story/run target)))
+  ([target opts] (.get ^java.util.concurrent.CompletableFuture (story/run target opts))))
+
+(defn- seed-error-record [result]
+  (first (filter #(= :rf.error/story-db-seed-invalid (:assertion %))
+                 (:assertions result))))
+
+;; ===========================================================================
+;; schema acceptance — :db-seed is a TYPED slot, no longer silently ignored
+;; ===========================================================================
+
+(deftest db-seed-is-accepted-by-the-variant-schema
+  (testing "reg-variant ACCEPTS a well-shaped :db-seed (the typed slot — the
+            pre-rf2-blw1q bug was silent-accept-then-ignore)"
+    (is (some? (story/reg-variant :story.cart/typed {:db-seed {:cart {:items []}}}))
+        "a {path → value} :db-seed registers without a shape error")))
+
+(deftest malformed-db-seed-is-rejected-by-the-variant-schema
+  (testing "a non-map :db-seed is REJECTED at registration (no longer silently
+            accepted) — :rf.error/variant-shape"
+    (let [ex (try (story/reg-variant :story.cart/malformed {:db-seed [1 2 3]})
+                  nil
+                  (catch clojure.lang.ExceptionInfo e e))]
+      (is (some? ex) "a non-map :db-seed throws a shape error")
+      (is (= :rf.error/variant-shape (:rf.error/id (ex-data ex)))))))
+
+;; ===========================================================================
+;; valid seed → app-db seeded before the script
+;; ===========================================================================
+
+(deftest valid-db-seed-seeds-app-db-before-script
+  (testing "a valid :db-seed merges into the frame's app-db BEFORE the script,
+            and a :real-setup event runs ON TOP of the seed (the ladder composes)"
+    (story/reg-variant
+      :story.cart/seeded
+      {:db-seed {:cart {:items [{:sku "A" :qty 1}]}}
+       :script  [[:dispatch-sync [:cart/add-item {:sku "B" :qty 2}]]]})
+    (let [result (run-target :story.cart/seeded)]
+      (is (= :pass (:status result))
+          "a valid-seed run with no failing assertion is :pass")
+      (testing "the seed established the precondition, then the script appended"
+        (is (= [{:sku "A" :qty 1} {:sku "B" :qty 2}]
+               (get-in result [:app-db :cart :items]))
+            "the :db-seed item is present AND the script's dispatched item appended"))
+      (testing "no seed-validation failure was recorded"
+        (is (nil? (seed-error-record result)))))))
+
+(deftest db-seed-validates-against-registered-schema-and-passes
+  (testing "a seed that SATISFIES the frame's registered app-db schema runs clean"
+    (install-schema-seam!)
+    (reg-app-schema! :story.cart/ok [:cart]
+                     [:map [:items [:vector [:map [:sku :string] [:qty :int]]]]])
+    (story/reg-variant
+      :story.cart/ok
+      {:db-seed {:cart {:items [{:sku "A" :qty 1}]}}})
+    (let [result (run-target :story.cart/ok)]
+      (is (= :pass (:status result)))
+      (is (nil? (seed-error-record result)))
+      (is (= [{:sku "A" :qty 1}] (get-in result [:app-db :cart :items]))))))
+
+;; ===========================================================================
+;; invalid seed → structured :rf.error/story-db-seed-invalid
+;; ===========================================================================
+
+(deftest db-seed-violating-schema-fails-run-structured
+  (testing "a :db-seed that VIOLATES the registered app-db schema FAILS the run
+            with a structured :rf.error/story-db-seed-invalid (path/value/explain),
+            per spec/017 §Setup"
+    (install-schema-seam!)
+    (reg-app-schema! :story.cart/bad [:cart]
+                     [:map [:items [:vector [:map [:sku :string] [:qty :int]]]]])
+    (story/reg-variant
+      :story.cart/bad
+      ;; :qty is a string — violates [:qty :int].
+      {:db-seed {:cart {:items [{:sku "A" :qty "two"}]}}})
+    (let [result (run-target :story.cart/bad)]
+      (is (= :error (:status result))
+          "a schema-violating seed errors the run (never a vacuous pass)")
+      (is (= :error (:lifecycle result)))
+      (let [rec (seed-error-record result)]
+        (is (some? rec) "the structured :rf.error/story-db-seed-invalid assertion landed")
+        (is (false? (:passed? rec)))
+        (testing "the record carries the structured path/value/explain violations"
+          (let [viol (first (:violations rec))]
+            (is (= [:cart] (:path viol)) "the violation names the registered app-db path")
+            (is (= {:items [{:sku "A" :qty "two"}]} (:value viol))
+                "the violation carries the rejected seeded slice")
+            (is (some? (:explain viol)) "the violation carries the validator's explanation")))))))
+
+(deftest db-seed-violation-stops-before-script
+  (testing "a schema-violating seed FAILS before the script runs — a malformed
+            precondition is not a thing to assert against"
+    (install-schema-seam!)
+    (reg-app-schema! :story.cart/halt [:cart]
+                     [:map [:items [:vector :map]]])
+    (story/reg-variant
+      :story.cart/halt
+      {:db-seed {:cart {:items "not-a-vector"}}
+       :script  [[:dispatch-sync [:cart/add-item {:sku "Z"}]]]})
+    (let [result (run-target :story.cart/halt)]
+      (is (= :error (:status result)))
+      (testing "the script never ran — the :cart/add-item dispatch did not land"
+        (is (not= "Z" (some-> (get-in result [:app-db :cart :items]) first :sku)))))))
+
+;; ===========================================================================
+;; host-free floor — no schemas artefact / no validator → seed applied unchecked
+;; ===========================================================================
+
+(deftest db-seed-soft-passes-without-schemas-artefact
+  (testing "with NO schemas late-bind seam installed the seed is applied
+            unchecked (the host-free floor) — Story without the schemas
+            artefact pays nothing"
+    ;; The fixture left the schema seam UNINSTALLED.
+    (story/reg-variant
+      :story.cart/nohost
+      {:db-seed {:cart {:items [{:sku "A" :qty "even-a-string-is-fine-here"}]}}})
+    (let [result (run-target :story.cart/nohost)]
+      (is (= :pass (:status result)) "no validator → no validation → clean run")
+      (is (nil? (seed-error-record result)))
+      (is (= [{:sku "A" :qty "even-a-string-is-fine-here"}]
+             (get-in result [:app-db :cart :items]))))))


### PR DESCRIPTION
Implements **rf2-blw1q** (Mike ruled **Option A** — implement the rung end-to-end, not the remove-dead-read option). The `:db-seed` slot is the MIDDLE rung of spec/017's fidelity ladder (`#{:real-setup :db-seed :sub-overrides}`) but was a dead read: referenced by `compute-fidelity` yet never accepted, lowered, seeded, or schema-validated.

## The 4 breaks → fixes

| # | Break | Fix |
|---|-------|-----|
| 1 | `schemas.cljc` `Variant`/`Fragment` `:map` had no `:db-seed` entry and isn't `:closed` → an author's `:db-seed` was **silently accepted then silently ignored** | Added a typed `DbSeed` slot (`{path → value}`) to both `Variant` + `Fragment`. A non-map `:db-seed` is now **rejected** at registration (`:rf.error/variant-shape`). |
| 2 | `plan.cljc` `:db-seed` was absent from `context-keys` → `(:db-seed ctx)` was always nil; the rung could never compute | Added `:db-seed` to `context-keys` (inherits through `:extends`) + composes through `:compose` fragments (same merge `:sub-overrides`/`:network` follow). |
| 3 | The compiler never wrote `[:world :db-seed]` | Lowers the resolved seed (`[:arg]` placeholders substituted) to `[:world :db-seed]`, surfaces it in `:explain`, and `compute-fidelity` now reads the live resolved seed (empty seed/override map = no rung). |
| 4 | `runtime.cljc` never seeded app-db nor validated it | New `run-db-seed!` phase (after frame allocation, **BEFORE** loaders/setup) merges the seed into the frame's app-db, then schema-validates the seeded app-db. |

## §Setup validation + structured error

Per spec/017 §Setup, direct app-db seeding **bypasses event/cofx validation but MUST validate the affected app-db schema before script execution**. `db-seed-violations` walks the frame's **registered app-db schemas** and validates each seeded slice. A violation throws a structured **`:rf.error/story-db-seed-invalid`** carrying every `{:path :value :schema :explain}` violation; it is recorded as a structured assertion via `record-seed-error!`, and the run **never reaches the script** (a malformed precondition is not a thing to assert against). The seed merge is non-destructive (top-level), so framework-reserved slots survive and a following `:real-setup` runs on top — the ladder composes.

## Reuses the existing validation seam (no new mechanism, no hard dep)

Validation reaches `:schemas/frame-schema-entries` + **`:schemas/validate-with-registered-fn`** + `:schemas/explain-with-registered-fn` through `re-frame.late-bind` — the **SAME seam** the `:sub-return` path and the rf2-7pgiz `:sub-override` fold-in use. No new validation mechanism was invented, and the runtime takes **no hard dep on the schemas artefact**: when it is absent every hook resolves nil and the check **soft-passes** (the host-free floor — a Story-only build pays nothing).

## view_state.cljc (ba86n.7)

Already reads `[:world :fidelity]` / `[:world :db-seed]`, so the now-live rung renders true with no render change. Only the `db-seed-summary` docstring (which claimed the slot was "reserved … not yet wired to authoring") is corrected to reflect the now-live wiring.

## Tests added

- **Plan-compile** (`plan_test.cljc`): accept + lower, `[:arg]` substitution, `:extends` deep-merge, fragment composition, empty-seed = no rung, and a direct `compute-fidelity` three-rung test.
- **Runtime** (`runtime_db_seed_test.clj`, JVM): seed-before-script (ladder composes), valid-schema pass, schema-violation → structured `:rf.error/story-db-seed-invalid` (path/value/explain), violation stops before the script, host-free soft-pass with no seam installed, and schema accept/reject at registration. The schemas late-bind hooks are registered directly (Malli-backed) exactly as the artefact would — itself proof the runtime drives validation purely through the seam with no hard dep.

## Quality gates

| Gate | Command | Result |
|------|---------|--------|
| CLJS node tests | `npm run test:cljs` (from `implementation/`) | **5021 tests, 16795 assertions, 0 failures, 0 errors, 0 warnings** |
| Story JVM tests | `clojure -M:test` (from `tools/story/`) | **1542 tests, 5751 assertions, 0 failures, 0 errors** (db-seed runtime ns: 7 tests / 21 assertions; plan-test ns: 57 tests / 187 assertions) |
| clj-kondo (src) | `clj-kondo --fail-level error --lint tools/story/src` | **errors: 0** (the 2 plan.cljc warnings are pre-existing on the clean baseline; no new warnings in edited files) |
| clj-kondo (tests) | `clj-kondo --lint <new+edited test files>` | **errors: 0, warnings: 0** |
| doc slugs | `python scripts/check_doc_slugs.py` | **exit 0** |
| mkdocs | `mkdocs build --strict` | **N/A** — `tools/story/spec/` is not under the mkdocs `docs_dir: docs` (confirmed: no tracked copy of `017-Testing-Story.md` under `docs/`) |
