### PR TITLE
ci(portability): gate failing on personal/home paths + literal miket, with deliberate-fixture allowlist (rf2-1ppe4)

### DIFF
--- a/.github/workflows/portability.yml
+++ b/.github/workflows/portability.yml
@@ -1,0 +1,51 @@
+# Portability gate (rf2-1ppe4, child of the rf2-v6wyb portability EPIC).
+#
+# Root-cause LOCK for the portability scrub (rf2-q4sah, #2509). Fails the
+# build if any TRACKED file reintroduces environment-specific hardcoding —
+# the maintainer's username/home token, or a personal/home absolute path
+# naming a real person (`/Users/<name>/`, `/home/<name>/`,
+# `C:/Users/<name>/`). The detection + the deliberate-fixture allowlist
+# live in the POSIX-sh script scripts/check-no-hardcoded-paths.sh; this
+# workflow just runs it (plus a shellcheck of the script itself).
+#
+# UNLIKE lint.yml / docs.yml this gate has NO surface-detect job: ANY
+# tracked file can leak a personal path, so the only correct surface is
+# "the whole tree". The script is a sub-second `git grep`, so running it on
+# every PR is cheap. It runs on PRs (the gate), on push to main (so a
+# direct-to-main edit is still caught), and via manual dispatch.
+#
+# NOTE for post-merge-workflow-sanity.yml: this workflow already runs on
+# push to main, so it is on that canary's EXCLUDE list — re-dispatching it
+# would only duplicate the push run.
+
+name: portability
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: portability-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  no-hardcoded-paths:
+    name: No hardcoded personal/home paths
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      # shellcheck ships preinstalled on the ubuntu-latest runner image.
+      # Lint the gate script itself so a future edit cannot introduce a
+      # shell bug that silently weakens the gate.
+      - name: Shellcheck the gate script
+        run: shellcheck scripts/check-no-hardcoded-paths.sh
+
+      # The script `git grep`s the tracked tree and exits non-zero with a
+      # per-hit message on any violation. No `|| true` / continue-on-error:
+      # a reintroduced personal path genuinely blocks the PR.
+      - name: Run the portability gate
+        run: sh scripts/check-no-hardcoded-paths.sh

--- a/.github/workflows/post-merge-workflow-sanity.yml
+++ b/.github/workflows/post-merge-workflow-sanity.yml
@@ -119,6 +119,7 @@ jobs:
             "test.yml"                        # already runs on push
             "docs.yml"                        # already runs on push (paths-filtered)
             "lint.yml"                        # already runs on push (via PR-merge push)
+            "portability.yml"                 # already runs on push to main
           )
           is_excluded() {
             local f="$1"

--- a/scripts/check-no-hardcoded-paths.sh
+++ b/scripts/check-no-hardcoded-paths.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env sh
+# scripts/check-no-hardcoded-paths.sh
+#
+# Portability gate (rf2-1ppe4, child of the rf2-v6wyb portability EPIC).
+#
+# Root-cause LOCK for the portability scrub (rf2-q4sah, #2509): fail CI on
+# any tracked file that reintroduces environment-specific hardcoding —
+#
+#   (1) the literal token `miket` (the maintainer's home-dir / username),
+#       ANYWHERE in a tracked file; and
+#   (2) a personal/home absolute path whose user component names a real
+#       person — `/Users/<name>/`, `/home/<name>/`, or a drive-letter
+#       `C:/Users/<name>/` (forward- OR back-slashed) — for any <name> in
+#       the explicit PERSONAL_NAMES list below.
+#
+# It deliberately does NOT key on Windows path SHAPE (drive letters,
+# backslashes) — those are legitimate cross-platform test coverage. The
+# scrub re-rooted every such fixture onto the sanctioned NEUTRAL
+# placeholders (`me` / `my-app` / `myapp` / `proj` / `u`), which carry no
+# personal name and therefore never match. The gate keys purely on the
+# PERSONAL name token, so neutral placeholders pass by construction.
+#
+# Cross-platform: POSIX sh. Runs identically on the Linux CI runner, on
+# macOS, and under Git Bash on Windows. No bashisms (`[[`, arrays, `<<<`).
+# The maintainer base is Mac/Linux; the CI runner is ubuntu-latest.
+#
+# Scope: TRACKED files only, via `git grep`. Gitignored trees
+# (`ai/`, `site/`, `node_modules/`, `.shadow-cljs/`, `target/`, the staged
+# `docs/spec` + `docs/migration` copies) are excluded for free because
+# `git grep` never sees them. The one tracked tree we skip explicitly is
+# `.beads/` — the issue-tracker data legitimately records bead prose that
+# mentions `miket` (e.g. this bead's own description).
+#
+# Exit: 0 = clean; 1 = at least one violation (per-hit message printed).
+
+set -eu
+
+# ----------------------------------------------------------------------------
+# PERSONAL_NAMES — path-component names that name a real person and so must
+# NOT appear in a tracked absolute path. Space-separated, lower-case.
+#
+# Keep this list small and explicit. Add a name here only when it is a real
+# maintainer/contributor home-dir component that could leak into a path.
+# The NEUTRAL placeholders (`me`, `my-app`, `myapp`, `proj`, `u`) are
+# deliberately absent — they are the sanctioned stand-ins and must pass.
+# ----------------------------------------------------------------------------
+PERSONAL_NAMES="mike miket"
+
+# ----------------------------------------------------------------------------
+# ALLOWLIST — tracked files that legitimately contain `miket` or a
+# personal-named path BY DESIGN. Each entry is explicit and justified; this
+# is a reviewed list, not a silent skip. Matched verbatim against the
+# repo-relative, forward-slashed paths `git grep` emits.
+#
+# TWO TIERS (see bead rf2-1ppe4 NOTES):
+#
+#   PERMANENT — redaction test fixtures. They MUST carry user-named paths
+#   to prove the scrubbing/redaction logic actually redacts them; replacing
+#   the names with placeholders would defeat the test.
+#     - skills/shared/tests/fixtures/02-redaction.md
+#     - skills/shared/tests/retro_protocol_test.clj
+#     - tools/machines-viz/test/day8/re_frame2_machines_viz/share_cljs_test.cljs
+#
+#   TEMPORARY — local worktree-guard + git-hook tooling that encodes the
+#   maintainer's mayor/worktree layout (`C:/Users/miket/...`). Local
+#   workflow tooling, never shipped. Allowlisted ONLY until rf2-lalk6
+#   de-personalises the guard scripts; their entries become
+#   unnecessary-but-harmless then and may be removed.
+#     - CLAUDE.md
+#     - scripts/assert-worker-worktree.ps1
+#     - scripts/git-hooks/README.md
+#     - scripts/git-hooks/lib/check-mayor-commit-boundary.sh
+#     - scripts/git-hooks/pre-commit
+#
+# THIS script itself is allowlisted: it names `mike`/`miket` in the
+# PERSONAL_NAMES list and in this comment by necessity.
+#     - scripts/check-no-hardcoded-paths.sh
+# ----------------------------------------------------------------------------
+is_allowlisted() {
+  case "$1" in
+    # PERMANENT — redaction fixtures (prove scrubbing; names are the test input).
+    skills/shared/tests/fixtures/02-redaction.md) return 0 ;;
+    skills/shared/tests/retro_protocol_test.clj) return 0 ;;
+    tools/machines-viz/test/day8/re_frame2_machines_viz/share_cljs_test.cljs) return 0 ;;
+    # TEMPORARY — local guard + hook tooling (de-personalised by rf2-lalk6 later).
+    CLAUDE.md) return 0 ;;
+    scripts/assert-worker-worktree.ps1) return 0 ;;
+    scripts/git-hooks/README.md) return 0 ;;
+    scripts/git-hooks/lib/check-mayor-commit-boundary.sh) return 0 ;;
+    scripts/git-hooks/pre-commit) return 0 ;;
+    # This gate script (carries the PERSONAL_NAMES list + this comment).
+    scripts/check-no-hardcoded-paths.sh) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Build the extended-regexp alternation for personal-named paths. A name is
+# a violation only as the USER COMPONENT of an absolute path root:
+#
+#     /Users/<name>/    /home/<name>/    <drive>:[\\/]+Users[\\/]+<name>
+#
+# Both `/` and `\` separators are accepted on the Windows drive-letter form
+# so a `C:\Users\mike\...` leak is caught as readily as `C:/Users/mike/...`.
+# The trailing `[\\/]` ensures we match the name as a full path component
+# (so `mike` does not match inside `mikennedy`).
+names_alt=""
+for n in $PERSONAL_NAMES; do
+  if [ -z "$names_alt" ]; then
+    names_alt="$n"
+  else
+    names_alt="$names_alt|$n"
+  fi
+done
+path_pattern="(/Users/|/home/|[A-Za-z]:[\\/]+Users[\\/]+)($names_alt)[\\/]"
+
+# Two detection patterns:
+#   1. literal `miket` anywhere (the maintainer username/home token).
+#   2. a personal-named absolute path root (any PERSONAL_NAMES entry).
+# `git grep -I` skips binary files; `-n` gives line numbers; `-E` extended
+# regexp. `:!.beads` excludes the tracked issue-tracker data.
+miket_hits=$(git grep -I -n -E 'miket' -- ':!.beads' || true)
+path_hits=$(git grep -I -n -E "$path_pattern" -- ':!.beads' || true)
+
+# Merge, drop allowlisted files, and report. Each `git grep` line is
+# `path:lineno:content`; the path is everything up to the first colon.
+violations=0
+report_hits() {
+  reason="$1"
+  hits="$2"
+  [ -z "$hits" ] && return 0
+  printf '%s\n' "$hits" | while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    file=${line%%:*}
+    if is_allowlisted "$file"; then
+      continue
+    fi
+    printf 'VIOLATION (%s): %s\n' "$reason" "$line"
+  done
+}
+
+# Run reporting in a way that lets us both PRINT every hit and COUNT
+# non-allowlisted ones. The while-subshell cannot mutate `violations`, so
+# we capture the printed report and count its lines.
+miket_report=$(report_hits "literal 'miket'" "$miket_hits")
+path_report=$(report_hits "personal-named path" "$path_hits")
+
+if [ -n "$miket_report" ]; then
+  printf '%s\n' "$miket_report"
+  violations=$((violations + $(printf '%s\n' "$miket_report" | grep -c '^VIOLATION')))
+fi
+if [ -n "$path_report" ]; then
+  printf '%s\n' "$path_report"
+  violations=$((violations + $(printf '%s\n' "$path_report" | grep -c '^VIOLATION')))
+fi
+
+if [ "$violations" -ne 0 ]; then
+  printf '\n'
+  printf 'Portability gate FAILED: %s hardcoded personal/home path violation(s).\n' "$violations" >&2
+  printf 'Use the neutral placeholders instead (me / my-app / myapp / proj / u),\n' >&2
+  printf 'or — if the path is a deliberate redaction fixture or local guard tool —\n' >&2
+  printf 'add it to the explicit ALLOWLIST in scripts/check-no-hardcoded-paths.sh\n' >&2
+  printf 'with a justification. See bead rf2-1ppe4.\n' >&2
+  exit 1
+fi
+
+printf 'Portability gate OK: no hardcoded personal/home paths in tracked files.\n'
+exit 0


### PR DESCRIPTION
Root-cause **LOCK** for the portability EPIC (rf2-v6wyb), landing after the scrub (rf2-q4sah, #2509). Adds a fast CI gate that fails the build if any **tracked** file reintroduces environment-specific hardcoding, so the scrub cannot silently regress.

## What it detects (fail CI)
- The literal maintainer username/home token (`miket`) **anywhere** in a tracked file.
- A personal/home absolute path whose user component names a real person — `/Users/<name>/`, `/home/<name>/`, or a drive-letter `C:/Users/<name>/` (forward- **or** back-slashed) — for any `<name>` in the explicit, commented `PERSONAL_NAMES` list (currently `mike miket`).

The gate keys on the **personal NAME**, not on the **Windows path SHAPE**. Drive letters / backslashes are legitimate cross-platform test coverage and are *not* flagged per se.

## Files
- **`scripts/check-no-hardcoded-paths.sh`** — POSIX-sh `git grep` gate (tracked-only). Exits non-zero with a per-hit `VIOLATION (reason): path:lineno:content` message. Skips the tracked `.beads/` tracker data (its prose legitimately mentions the token); gitignored trees (`ai/`, `site/`, `node_modules/`, `.shadow-cljs/`, staged `docs/spec` + `docs/migration`) are excluded for free since `git grep` is tracked-only.
- **`.github/workflows/portability.yml`** — runs `shellcheck` on the script, then the gate, on **PRs + push to main + manual dispatch**. No surface-detect job: *any* tracked file can leak a personal path, so the only correct surface is the whole tree — and the `git grep` is sub-second, so running it on every PR is cheap.
- **`.github/workflows/post-merge-workflow-sanity.yml`** — adds `portability.yml` to the canary's `EXCLUDE` list (it already runs on push to main, per that file's documented policy).

## Allowlist (must NOT trip — explicit, reviewed, per-entry justified in the script)
Two tiers, per bead rf2-1ppe4 NOTES:

**PERMANENT — redaction test fixtures** (must carry user-named paths to *prove* the scrubbing logic redacts them):
- `skills/shared/tests/fixtures/02-redaction.md` — carries `C:/Users/mike/…`, `/home/mike/…` as redaction input.
- `skills/shared/tests/retro_protocol_test.clj` — carries the path-shape strings `"C:/Users"`, `"/Users/"`, `"/home/"` for the redaction test (no personal name; allowlisted per bead intent / defensively).
- `tools/machines-viz/test/day8/re_frame2_machines_viz/share_cljs_test.cljs` — carries `/Users/mike/…` source-coord leaks to assert they are scrubbed before share.

**TEMPORARY — local worktree-guard + git-hook tooling** that encodes the maintainer's mayor/worktree layout (`C:/Users/miket/...`); local workflow tooling, never shipped. Allowlisted ONLY until rf2-lalk6 de-personalises the guard scripts (entries become unnecessary-but-harmless then):
- `CLAUDE.md`
- `scripts/assert-worker-worktree.ps1`
- `scripts/git-hooks/README.md`
- `scripts/git-hooks/lib/check-mayor-commit-boundary.sh`
- `scripts/git-hooks/pre-commit`

Plus the gate script itself (`scripts/check-no-hardcoded-paths.sh`) — it names the tokens in `PERSONAL_NAMES` + comments by necessity.

These 5+4 files are exactly the tracked files that currently contain the token by design (`git grep -I -l "miket"` returns the 5 guard files; `mike` as a path component returns only the 3 redaction fixtures). No genuine leak remains for this bead to scrub.

## Quality gates
- **Passes on the current tree** — `sh scripts/check-no-hardcoded-paths.sh` → `Portability gate OK: no hardcoded personal/home paths in tracked files.` (exit 0), both before and after rebasing onto latest `main`, and with all three new/modified files staged (simulating the committed state).
- **Catches a planted violation** — staged a temp file containing `C:/Users/miket/...`, `/Users/mike/...`, `/home/mike/...`, and a neutral `C:/Users/me/code/my-app`. The gate emitted 4 `VIOLATION` lines (the `miket` line trips both the literal-token rule and the personal-named-path rule; `mike` paths each trip once) and exited 1. It did **NOT** flag the neutral `C:/Users/me/code/my-app` line. Plant removed; re-run returns exit 0.
- **Does NOT false-positive on the neutral `me` / `my-app` path-shape tests** — the ~86 `C:/Users/me/code/my-app` / `/home/me/proj` occurrences across `tools/story`, `tools/re-frame2-pair-mcp`, `implementation/core`, docs, etc. all pass, because the gate matches the personal name, not the path shape. Neutral stand-ins `me` / `my-app` / `myapp` / `proj` / `u` are deliberately absent from `PERSONAL_NAMES`.
- **Shell lint** — `sh -n` syntax-check passes; runs clean under `dash` (the closest local proxy to the runner's `/bin/sh`). `shellcheck` is not installed locally, so the workflow runs it on `ubuntu-latest` (preinstalled there) as a step.
- **YAML valid** — both `portability.yml` and the edited `post-merge-workflow-sanity.yml` parse under `yaml.safe_load`.

Bead: rf2-1ppe4 (child of rf2-v6wyb). Does not merge — leaving for review.
