### PR TITLE
fix(core): reg-view public meta carries the absolutised coord (symmetric with reg-event) so view 'open in editor' works (rf2-quir9)

### DIFF
--- a/implementation/core/src/re_frame/core_reg_view_macro.cljc
+++ b/implementation/core/src/re_frame/core_reg_view_macro.cljc
@@ -89,8 +89,30 @@
            id-meta  (:rf/id sym-meta)
            id       (or id-meta (keyword (str current-ns-sym) (str sym)))
            ;; Anything on the symbol other than :rf/id is treated as slot
-           ;; metadata (matches Clojure's defn idiom: ^{:doc "..."} sym).
-           slot-meta (dissoc sym-meta :rf/id)]
+           ;; metadata (matches Clojure's defn idiom: ^{:doc "..."} sym) —
+           ;; EXCEPT the reader's source-position keys.
+           ;;
+           ;; Per rf2-quir9: the CLJS analyzer's indexing reader stamps
+           ;; `:file` / `:line` / `:column` (+ `:source` / `:end-*`) onto
+           ;; the view SYMBOL, and that `:file` is CLASSPATH-RELATIVE
+           ;; (`"button_deck/core.cljs"`). If we let those ride into the
+           ;; registry slot they become `user-meta` in
+           ;; `source-coords/merge-coords`, where user keys WIN over the
+           ;; pending coords — so the relative reader `:file` clobbers the
+           ;; rf2-wvsxg-absolutised value bound into `*pending-coords*` (see
+           ;; `coord-form` below), shipping a relative `:file` into
+           ;; `(rf/handler-meta :view id)` and breaking Xray / IDE
+           ;; open-in-editor for views. The `reg-event-*` path never hits
+           ;; this because it splices args verbatim and contributes no
+           ;; symbol-position meta as user-meta — its public `:file` is the
+           ;; absolutised `*pending-coords*` value. Stripping the reader
+           ;; position keys here makes `*pending-coords*` the SINGLE source
+           ;; of source-coords for the view's public meta, symmetric with
+           ;; `reg-event-*`. `:source` is the reader's whole-form-text key
+           ;; (not a user slot) and is dropped alongside.
+           slot-meta (dissoc sym-meta
+                             :rf/id
+                             :file :line :column :source :end-line :end-column)]
        (when (nil? parsed)
          (throw (ex-info
                   ":rf.error/reg-view-bad-args"

--- a/implementation/core/test/re_frame/source_coords_test.clj
+++ b/implementation/core/test/re_frame/source_coords_test.clj
@@ -25,6 +25,10 @@
     reg-error-projector"
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            ;; rf2-quir9 — exercise the view-macro expander directly to
+            ;; assert the reader's symbol-position meta is stripped before
+            ;; it can clobber the absolutised *pending-coords*.
+            [re-frame.core-reg-view-macro :as rvm]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
@@ -279,3 +283,80 @@
       ;; resource.
       (is (.endsWith ^String f "re_frame/source_coords_test.clj")
           ":file should end with the classpath-relative tail"))))
+
+;; ---- rf2-quir9: reg-view PUBLIC meta carries the absolutised coord --------
+;;
+;; The asymmetry being fixed: `reg-event-*` ships an ABSOLUTE `:file` in its
+;; public `(rf/handler-meta :event id)` (above), but `reg-view` was shipping
+;; a CLASSPATH-RELATIVE `:file`. Root cause: the CLJS analyzer's indexing
+;; reader stamps `:file` / `:line` / `:column` (+ `:source` / `:end-*`) onto
+;; the view SYMBOL with a classpath-relative `:file`; the macro treated that
+;; as user slot-meta and passed it to `reg-view*`, where
+;; `source-coords/merge-coords` lets user-meta WIN over `*pending-coords*` —
+;; so the relative reader `:file` clobbered the rf2-wvsxg-absolutised value.
+;; The fix strips the reader's position keys from the slot-meta so
+;; `*pending-coords*` is the single source of source-coords for the view's
+;; public meta, symmetric with `reg-event-*`.
+
+(deftest reg-view-emits-absolute-file-symmetric-with-reg-event
+  (testing "rf2-quir9: reg-view fired against a real classpath-resident file
+  (this test ns) ships an ABSOLUTE :file in its PUBLIC handler-meta, matching
+  the always-on error-coord registry — symmetric with reg-event-db (so Xray /
+  IDE open-in-editor resolves the path the same way for views)."
+    (rf/reg-view ^{:rf/id :rf2-quir9/absolute-view-sample} quir9-view []
+      [:div "hi"])
+    (let [pub  (rf/handler-meta :view :rf2-quir9/absolute-view-sample)
+          errc (sc/error-coords-for :view :rf2-quir9/absolute-view-sample)
+          f    (:file pub)]
+      (is (string? f) "public :file should be present")
+      ;; The public :file must equal the error-coord registry's absolutised
+      ;; value — the two source-coord sinks now agree (they previously
+      ;; diverged: error-coord absolute, public relative).
+      (is (= f (:file errc))
+          "public handler-meta :file == error-coord :file (single source of truth)")
+      ;; And it must look absolute to the URI builder (no project-root
+      ;; prepend), exactly like the reg-event-db case above.
+      (let [uri (eu/editor-uri :vscode pub {:project-root "/wrong/project/root"})]
+        (is (.contains ^String uri f)
+            "view :file should appear absolute in the URI")
+        (is (not (.contains ^String uri "/wrong/project/root"))
+            "view :file must be absolute (URI builder doesn't prepend project-root)"))
+      (is (.endsWith ^String f "re_frame/source_coords_test.clj")
+          "view :file should end with this test ns's classpath-relative tail"))))
+
+(deftest reg-view-strips-reader-symbol-position-meta
+  (testing "rf2-quir9: the reader's symbol-position meta (relative :file /
+  :line / :column / :source / :end-*) must NOT leak into the registry slot —
+  if it did, merge-coords would let the RELATIVE reader :file override the
+  absolutised *pending-coords*. The expander is exercised directly with a
+  view symbol carrying the exact reader-stamped shape the CLJS analyzer's
+  indexing reader produces."
+    (let [reader-sym (with-meta 'child-view
+                       {:source 'child-view
+                        :file   "button_deck/core.cljs"   ;; RELATIVE — the trap
+                        :line   1 :column 11
+                        :end-line 1 :end-column 21
+                        :doc    "a real slot-meta key — must survive"})
+          exp        (rvm/expand-reg-view {:line 1 :column 1 :file "button_deck/core.cljs"}
+                                          'button-deck.core "button_deck/core.cljs"
+                                          reader-sym '([] [:div]))
+          ;; expansion: (do (binding [...] (reg-view* id slot-meta fn)) (def ...) id)
+          binding-form (nth exp 1)
+          regview-call (nth binding-form 2)        ;; (reg-view* id slot-meta fn)
+          slot-meta    (nth regview-call 2)]
+      (is (not (contains? slot-meta :file))
+          ":file (relative reader key) must be stripped from slot-meta")
+      (is (not (contains? slot-meta :line))
+          ":line (reader key) must be stripped from slot-meta")
+      (is (not (contains? slot-meta :column))
+          ":column (reader key) must be stripped from slot-meta")
+      (is (not (contains? slot-meta :source))
+          ":source (reader whole-form-text key) must be stripped from slot-meta")
+      (is (not (contains? slot-meta :end-line))
+          ":end-line (reader key) must be stripped from slot-meta")
+      (is (not (contains? slot-meta :end-column))
+          ":end-column (reader key) must be stripped from slot-meta")
+      ;; A genuine user slot-meta key (e.g. :doc on the symbol) survives —
+      ;; the strip targets only the reader's position keys, not user meta.
+      (is (= "a real slot-meta key — must survive" (:doc slot-meta))
+          "genuine user slot-meta (:doc) must be preserved"))))


### PR DESCRIPTION
## What

Fixes rf2-quir9 (P2 bug). Clicking a VIEW's **open-in-editor / go-to-source** in Xray failed (the OS editor scheme handler rejected the path) while the same affordance for `reg-event-db` / `reg-sub` worked.

## Asymmetry → root cause → fix

`reg-event-*` ships an **ABSOLUTE** `:file` in its public `(rf/handler-meta :event id)` — the rf2-wvsxg-absolutised coord bound into `*pending-coords*` at macro-expansion. `reg-view` was shipping a **CLASSPATH-RELATIVE** `:file` (`"button_deck/core.cljs"`), which the editor cannot resolve.

**Why the asymmetry:** the CLJS analyzer's indexing reader stamps `:file` / `:line` / `:column` (+ `:source` / `:end-line` / `:end-column`) onto the view **SYMBOL**, and that `:file` is classpath-relative. `expand-reg-view` treated everything on the symbol (other than `:rf/id`) as user slot-meta and passed it to `reg-view*`, where `source-coords/merge-coords` lets **user-meta WIN** over `*pending-coords*` — so the relative reader `:file` clobbered the absolutised value. `reg-event-*` never hits this: it splices args verbatim and contributes no symbol-position meta as user-meta, so its public `:file` stays the absolutised `*pending-coords*` value.

**Fix (Option A — the root fix the bead recommends):** strip the reader's source-position keys (`:file :line :column :source :end-line :end-column`) from the view's `slot-meta` in `expand-reg-view`, so `*pending-coords*` is the **single source** of source-coords for the view's public meta — symmetric with `reg-event-*`. This fixes `handler-meta[:view]` for **every** consumer (Xray Views panel, re-frame-pair, IDE jump-to-source, and the DOM source-coord annotation), not just the Xray panel. Genuine user slot-meta (e.g. `^{:doc ...}` on the symbol) is preserved.

`handler-meta[:view] :file` is now ABSOLUTE, equal to the always-on error-coord registry's `:file`, symmetric with `handler-meta[:event]`. The verifying test asserts `public :file == error-coord :file`.

Zero production cost: the strip runs at macro-expansion time, **before** the `interop/debug-enabled?` gate, so the dev-gated coord-emission path (rf2-wvsxg / rf2-3un2g) is untouched — the elision probe still shows the production coord absent.

## Tests (added to `source_coords_test.clj`)

- `reg-view-emits-absolute-file-symmetric-with-reg-event` — a `reg-view` fired against a real classpath-resident file ships an ABSOLUTE public `:file` that equals the error-coord registry's `:file` and passes through the URI builder without a project-root prepend, exactly like the existing `reg-event-db` case.
- `reg-view-strips-reader-symbol-position-meta` — a view symbol carrying the exact reader-stamped shape (relative `:file`/`:line`/`:column`/`:source`/`:end-*`) must not leak those keys into the `reg-view*` slot-meta, while a genuine `:doc` slot-meta key survives.

## Quality gates

- `clojure -M:test` (core JVM): **805 tests, 3560 assertions, 0 failures, 0 errors**
- `npm run test:cljs` (node CLJS): **5021 tests, 16795 assertions, 0 failures, 0 errors**
- `npm run test:elision`: **production 40/40 absent, control 40/40 present** (dev-gating holds)
- `clj-kondo --fail-level error --lint implementation/core/src`: **0 errors**
