### PR TITLE
feat(http-test): :after-ms delay on managed-canned fx + migrate 4 examples off the 3-hop chain (rf2-j1mo4)

### DIFF
--- a/examples/helix/login_helix/core.cljs
+++ b/examples/helix/login_helix/core.cljs
@@ -21,6 +21,7 @@
             [helix.dom          :as d]
             [helix.hooks        :as helix-hooks]
             [re-frame.core :as rf]
+            [re-frame.registrar :as registrar]
             [re-frame.schemas]
             [re-frame.machines]
             [re-frame.http-managed]
@@ -70,57 +71,40 @@
     (when-let [ls (.-localStorage js/globalThis)]
       (.setItem ls "auth/token" token))))
 
-(rf/reg-event-fx :auth.login.demo/schedule-reply
-  {:doc "Private — entered via dispatch from :auth.login.demo/managed-stub.
-         Uses `:dispatch-later` so framework time controls apply to the
-         demo latency. See examples/reagent/login for the full rationale."}
-  (fn handler-auth-login-demo-schedule-reply [_ [_ outcome args-map]]
-    {:fx [[:dispatch-later
-           {:ms    50
-            :event [:auth.login.demo/deliver-reply outcome args-map]}]]}))
-
-(rf/reg-event-fx :auth.login.demo/deliver-reply
-  {:doc "Private — fired by the :dispatch-later scheduled in
-         :auth.login.demo/schedule-reply. Delegates to the framework-
-         shipped canned-success / canned-failure fxs (Spec 014 §Testing)."}
-  (fn handler-auth-login-demo-deliver-reply [_ [_ outcome args-map]]
-    (case outcome
-      :success
-      {:fx [[:rf.http/managed-canned-success
-             (assoc args-map
-                    :value {:user  {:id    (random-uuid)
-                                    :email (-> args-map :request :body :email)}
-                            :token "demo-token-123"})]]}
-
-      :failure-401
-      {:fx [[:rf.http/managed-canned-failure
-             (assoc args-map
-                    :kind :rf.http/http-4xx
-                    :tags {:status  401
-                           :message "Invalid credentials."})]]}
-
-      :empty-success
-      {:fx [[:rf.http/managed-canned-success (assoc args-map :value {})]]})))
-
 (rf/reg-fx :auth.login.demo/managed-stub
   {:doc       "Demo override for `:rf.http/managed`. Identical behaviour
-               to the Reagent and UIx examples' stub — dispatches into
-               the private :auth.login.demo/schedule-reply event so the
-               deferred reply rides framework `:dispatch-later` (50 ms)
-               rather than raw `js/setTimeout`. Framework time controls
-               (Tool-Pair time-travel, `:dispatch-later` nil-override)
-               apply automatically."
+               to the Reagent and UIx examples' stub — delegates straight
+               to the framework-shipped canned-success / canned-failure
+               fxs with `:after-ms` (rf2-j1mo4), so the framework defers
+               the reply via `:dispatch-later` (50 ms) — observable in
+               the tape, time-travel-safe, NOT raw `js/setTimeout`. The
+               `:after-ms` parameter collapses the former schedule-reply →
+               `:dispatch-later` → deliver-reply chain into one arg on the
+               same canned effect."
    :platforms #{:server :client}}
   (fn fx-managed-login-demo [frame-ctx args-map]
     (let [{:keys [url body]} (:request args-map)
-          login?  (= "/api/login" url)
-          outcome (cond
-                    (and login? (= good-password (:password body))) :success
-                    login?                                          :failure-401
-                    :else                                           :empty-success)
-          frame   (:frame frame-ctx)]
-      (rf/dispatch [:auth.login.demo/schedule-reply outcome args-map]
-                   {:frame frame}))))
+          login? (= "/api/login" url)]
+      (cond
+        (and login? (= good-password (:password body)))
+        (let [stub (registrar/handler :fx :rf.http/managed-canned-success)]
+          (stub frame-ctx (assoc args-map
+                                 :after-ms 50
+                                 :value {:user  {:id    (random-uuid)
+                                                 :email (:email body)}
+                                         :token "demo-token-123"})))
+
+        login?
+        (let [stub (registrar/handler :fx :rf.http/managed-canned-failure)]
+          (stub frame-ctx (assoc args-map
+                                 :after-ms 50
+                                 :kind :rf.http/http-4xx
+                                 :tags {:status  401
+                                        :message "Invalid credentials."})))
+
+        :else
+        (let [stub (registrar/handler :fx :rf.http/managed-canned-success)]
+          (stub frame-ctx (assoc args-map :after-ms 50 :value {})))))))
 
 ;; ============================================================================
 ;; STATE MACHINE

--- a/examples/reagent/login/core.cljs
+++ b/examples/reagent/login/core.cljs
@@ -42,6 +42,7 @@
   ;; slim.)
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
+            [re-frame.registrar :as registrar]
             ;; The Spec 010 schema-attachment ns lives in
             ;; the day8/re-frame2-schemas artefact. The require here
             ;; loads the ns so its late-bind hooks register before
@@ -136,41 +137,6 @@
     (when-let [ls (.-localStorage js/globalThis)]
       (.setItem ls "auth/token" token))))
 
-(rf/reg-event-fx :auth.login.demo/schedule-reply
-  {:doc "Private — entered via dispatch from :auth.login.demo/managed-stub.
-         Uses `:dispatch-later` so framework time controls (Tool-Pair
-         time-travel, the documented `:dispatch-later` nil-override
-         seam) apply to the demo latency. No user dispatches this
-         directly."}
-  (fn handler-auth-login-demo-schedule-reply [_ [_ outcome args-map]]
-    {:fx [[:dispatch-later
-           {:ms    50
-            :event [:auth.login.demo/deliver-reply outcome args-map]}]]}))
-
-(rf/reg-event-fx :auth.login.demo/deliver-reply
-  {:doc "Private — fired by the :dispatch-later scheduled in
-         :auth.login.demo/schedule-reply. Delegates to the framework-
-         shipped `:rf.http/managed-canned-success` /
-         `:rf.http/managed-canned-failure` (Spec 014 §Testing)."}
-  (fn handler-auth-login-demo-deliver-reply [_ [_ outcome args-map]]
-    (case outcome
-      :success
-      {:fx [[:rf.http/managed-canned-success
-             (assoc args-map
-                    :value {:user  {:id    (random-uuid)
-                                    :email (-> args-map :request :body :email)}
-                            :token "demo-token-123"})]]}
-
-      :failure-401
-      {:fx [[:rf.http/managed-canned-failure
-             (assoc args-map
-                    :kind :rf.http/http-4xx
-                    :tags {:status  401
-                           :message "Invalid credentials."})]]}
-
-      :empty-success
-      {:fx [[:rf.http/managed-canned-success (assoc args-map :value {})]]})))
-
 (rf/reg-fx :auth.login.demo/managed-stub
   {:doc       "Demo override for `:rf.http/managed`: routes by URL +
                request body to canned login responses so the example
@@ -181,32 +147,43 @@
                POST /api/login otherwise → 401 failure.
                Anything else (e.g. /api/auth/lock) → empty success.
 
-               Dispatches into the private
-               :auth.login.demo/schedule-reply event so the deferred
-               reply rides framework `:dispatch-later` (50 ms) rather
-               than raw `js/setTimeout`. The delay lets the
-               `:submitting` UI state be observable; the reply itself
-               lands via the framework-shipped canned-success /
-               canned-failure fxs so the reply shape
+               Delegates straight to the framework-shipped canned-success
+               / canned-failure fxs (Spec 014 §Testing) with `:after-ms`
+               (rf2-j1mo4): the framework defers the reply via
+               `:dispatch-later` (50 ms) — observable in the tape,
+               time-travel-safe, NOT raw `js/setTimeout`. The delay lets
+               the `:submitting` UI state be observable; the reply shape
                (`{:kind :success :value ...}` / `{:kind :failure
-               :failure ...}`) reaches the inner `:auth.login/success`
-               / `:auth.login/failure` sub-events via the explicit
-               `:on-success` / `:on-failure` form.
-
-               Framework time controls (Tool-Pair time-travel, the
-               documented `:dispatch-later` nil-override seam) apply
-               automatically."
+               :failure ...}`) reaches the inner `:auth.login/success` /
+               `:auth.login/failure` sub-events via the explicit
+               `:on-success` / `:on-failure` form. Collapses the former
+               schedule-reply → `:dispatch-later` → deliver-reply chain
+               into one `:after-ms` parameter (the delay is a parameter
+               of the same canned effect, not a new fx)."
    :platforms #{:server :client}}
   (fn fx-managed-login-demo [frame-ctx args-map]
     (let [{:keys [url body]} (:request args-map)
-          login?  (= "/api/login" url)
-          outcome (cond
-                    (and login? (= good-password (:password body))) :success
-                    login?                                          :failure-401
-                    :else                                           :empty-success)
-          frame   (:frame frame-ctx)]
-      (rf/dispatch [:auth.login.demo/schedule-reply outcome args-map]
-                   {:frame frame}))))
+          login? (= "/api/login" url)]
+      (cond
+        (and login? (= good-password (:password body)))
+        (let [stub (registrar/handler :fx :rf.http/managed-canned-success)]
+          (stub frame-ctx (assoc args-map
+                                 :after-ms 50
+                                 :value {:user  {:id    (random-uuid)
+                                                 :email (:email body)}
+                                         :token "demo-token-123"})))
+
+        login?
+        (let [stub (registrar/handler :fx :rf.http/managed-canned-failure)]
+          (stub frame-ctx (assoc args-map
+                                 :after-ms 50
+                                 :kind :rf.http/http-4xx
+                                 :tags {:status  401
+                                        :message "Invalid credentials."})))
+
+        :else
+        (let [stub (registrar/handler :fx :rf.http/managed-canned-success)]
+          (stub frame-ctx (assoc args-map :after-ms 50 :value {})))))))
 
 ;; ============================================================================
 ;; STATE MACHINE  (CP-5)

--- a/examples/reagent/managed_http_counter/core.cljs
+++ b/examples/reagent/managed_http_counter/core.cljs
@@ -143,26 +143,18 @@
 
 ;; -- Cancel an in-flight request ---------------------------------------------
 ;;
-;; A "long" request defers its synthetic failure-reply via
-;; `:dispatch-later` so the :loading state is observable in a browser
-;; long enough for the cancel UI to interact with it. The Spec 014
-;; contract is that an in-flight request dispatches `:rf.http/aborted`
-;; on cancellation; routing the deferred reply through the framework's
-;; `:dispatch-later` + `:rf.http/managed-canned-failure` mimics that
-;; contract end-to-end without requiring a real long-running endpoint
-;; — and framework time controls (Tool-Pair time-travel, the
-;; documented `:dispatch-later` nil-override) apply automatically.
-
-(rf/reg-event-fx :managed-http-counter.demo/deliver-long-reply
-  {:doc "Private — invoked via :dispatch-later from :counter/start-long.
-         Synthesises a deferred :rf.http/managed-canned-failure reply
-         so the :loading UI state is observable before the failure
-         lands. No user dispatches this directly."}
-  (fn handler-deliver-long-reply [_ [_ args-map]]
-    {:fx [[:rf.http/managed-canned-failure
-           (assoc args-map
-                  :kind :rf.http/transport
-                  :tags {:message "Demo: long request did not resolve."})]]}))
+;; A "long" request defers its synthetic failure-reply via the
+;; canned-failure stub's `:after-ms` (rf2-j1mo4) so the :loading state is
+;; observable in a browser long enough for the cancel UI to interact with
+;; it. The Spec 014 contract is that an in-flight request dispatches
+;; `:rf.http/aborted` on cancellation; routing a deferred
+;; `:rf.http/managed-canned-failure` reply via `:after-ms` mimics that
+;; contract end-to-end without requiring a real long-running endpoint —
+;; the framework schedules it through `:dispatch-later` internally, so
+;; time controls (Tool-Pair time-travel, the documented `:dispatch-later`
+;; nil-override) apply automatically. `:after-ms` collapses the former
+;; `:dispatch-later` → deliver-long-reply → canned-failure chain into one
+;; parameter of the same canned effect.
 
 (rf/reg-event-fx :counter/start-long
   (fn [{:keys [db]} [_ msg]]
@@ -173,18 +165,19 @@
       (some-> msg :rf/reply :kind some?)
       {:db (assoc db :counter/status :idle)}
 
-      ;; Defer the canned-failure via :dispatch-later so the :loading UI
-      ;; state is observable before it lands. The +1 / Fail / Retry-recover
+      ;; Defer the canned-failure via :after-ms so the :loading UI state
+      ;; is observable before it lands. The +1 / Fail / Retry-recover
       ;; paths above still hit the framework's :rf.http/managed; only this
       ;; "long-running" demo defers a synthetic reply.
       :else
       {:db (assoc db :counter/status :loading :counter/error nil)
-       :fx [[:dispatch-later
-             {:ms    750
-              :event [:managed-http-counter.demo/deliver-long-reply
-                      {:request    {:method :get :url "api/long"}
-                       :request-id :counter/long
-                       :decode     :json}]}]]})))
+       :fx [[:rf.http/managed-canned-failure
+             {:request    {:method :get :url "api/long"}
+              :request-id :counter/long
+              :decode     :json
+              :after-ms   750
+              :kind       :rf.http/transport
+              :tags       {:message "Demo: long request did not resolve."}}]]})))
 
 (rf/reg-event-fx :counter/cancel
   (fn [{:keys [db]} _]

--- a/examples/reagent/realworld/core.cljs
+++ b/examples/reagent/realworld/core.cljs
@@ -31,6 +31,7 @@
   (:require [clojure.string :as str]
             [reagent2.dom.client :as rdc]
             [re-frame.core :as rf]
+            [re-frame.registrar :as registrar]
             ;; Managed-HTTP ships in day8/re-frame2-http.
             ;; Requiring re-frame.http-managed at app boot is what
             ;; triggers its load-time fx registrations (`:rf.http/managed`
@@ -196,10 +197,12 @@
 ;; to an empty-payload success — enough for the app shell + main feed
 ;; to render.
 ;;
-;; The override uses :rf.http/managed-canned-success directly with a
-;; per-URL :value payload. This is the same shape Spec 014 §Testing
-;; documents — just routed by URL inspection in a wrapper fx so the
-;; demo doesn't have to know one URL ahead of time.
+;; The override delegates straight to :rf.http/managed-canned-success
+;; with a per-URL :value payload and an `:after-ms` delay (rf2-j1mo4) so
+;; the framework defers the reply via `:dispatch-later` — observable in
+;; the tape, time-travel-safe, NOT raw `js/setTimeout`. This is the same
+;; shape Spec 014 §Testing documents — just routed by URL inspection in a
+;; wrapper fx so the demo doesn't have to know one URL ahead of time.
 ;; ----------------------------------------------------------------------------
 
 (def ^:private demo-articles
@@ -308,47 +311,25 @@
 
       :else {})))
 
-(rf/reg-event-fx :realworld.demo/schedule-reply
-  {:doc "Private — entered via dispatch from :realworld.demo/http-stub.
-         Uses `:dispatch-later` so framework time controls (Tool-Pair
-         time-travel, the documented `:dispatch-later` nil-override
-         seam) apply to the demo latency. No user dispatches this
-         directly."}
-  (fn handler-conduit-demo-schedule-reply [_ [_ args-map payload]]
-    {:fx [[:dispatch-later
-           {:ms    20
-            :event [:realworld.demo/deliver-reply args-map payload]}]]}))
-
-(rf/reg-event-fx :realworld.demo/deliver-reply
-  {:doc "Private — fired by the :dispatch-later scheduled in
-         :realworld.demo/schedule-reply. Delegates to the
-         framework-shipped `:rf.http/managed-canned-success` with the
-         per-URL canned Conduit payload."}
-  (fn handler-conduit-demo-deliver-reply [_ [_ args-map payload]]
-    {:fx [[:rf.http/managed-canned-success (assoc args-map :value payload)]]}))
-
 (rf/reg-fx :realworld.demo/http-stub
   {:doc       "Demo override for :rf.http/managed: routes by URL to
                canned Conduit-shaped responses so the example runs
                standalone without a backend.
 
-               Dispatches into the private :realworld.demo/schedule-reply
-               event so the deferred reply rides framework
-               `:dispatch-later` (20 ms) rather than raw
-               `js/setTimeout`. The delay lets the `:loading` UI state
-               be observable in the demo; the reply itself lands via
-               the framework-shipped `:rf.http/managed-canned-success`
-               (Spec 014 §Testing).
-
-               Framework time controls (Tool-Pair time-travel, the
-               documented `:dispatch-later` nil-override seam) apply
-               automatically."
+               Delegates straight to the framework-shipped
+               `:rf.http/managed-canned-success` (Spec 014 §Testing) with
+               the per-URL canned payload and `:after-ms` (rf2-j1mo4): the
+               framework defers the reply via `:dispatch-later` (20 ms) —
+               observable in the tape, time-travel-safe, NOT raw
+               `js/setTimeout`. The delay lets the `:loading` UI state be
+               observable; `:after-ms` collapses the former schedule-reply
+               → `:dispatch-later` → deliver-reply chain into one
+               parameter of the same canned effect."
    :platforms #{:server :client}}
   (fn fx-managed-demo-stub [frame-ctx args-map]
     (let [payload (demo-payload-for-args args-map)
-          frame   (:frame frame-ctx)]
-      (rf/dispatch [:realworld.demo/schedule-reply args-map payload]
-                   {:frame frame}))))
+          stub    (registrar/handler :fx :rf.http/managed-canned-success)]
+      (stub frame-ctx (assoc args-map :after-ms 20 :value payload)))))
 
 ;; React root named `react-root` (not `root`) so it does NOT collide with
 ;; the `root-view` reg-view above. Held in an atom and populated lazily

--- a/implementation/http/src/re_frame/http_test_support.cljc
+++ b/implementation/http/src/re_frame/http_test_support.cljc
@@ -77,13 +77,98 @@
   Plus the four stub macros / fns listed above (and the matching late-bind
   hook publications under `:http/install-managed-request-stubs!`,
   `:http/uninstall-managed-request-stubs!`, `:http/with-managed-request-stubs*`)."
-  (:require [re-frame.fx                   :as fx]
+  (:require [re-frame.events               :as events]
+            [re-frame.fx                   :as fx]
             [re-frame.http-encoding        :as encoding]
             [re-frame.http-machine-wrapper :as machine-wrapper]
             [re-frame.http-middleware      :as middleware]
             [re-frame.late-bind            :as late-bind]))
 
 #?(:clj (set! *warn-on-reflection* true))
+
+;; ---- optional `:after-ms` delay (rf2-j1mo4) ------------------------------
+;;
+;; Per Mike's ruling (B, 2026-05-30): a delay is a PARAMETER of the same
+;; effect, not a new effect — so rather than minting `-later` fx ids the
+;; existing canned-stub fxs take an optional `:after-ms` arg.
+;;
+;;   - absent / 0 / non-positive → reply lands immediately (current
+;;     behaviour, unchanged);
+;;   - positive N               → reply lands after an N-ms
+;;     `:dispatch-later` tick.
+;;
+;; The timer is the framework-native `:dispatch-later` (NOT raw
+;; `interop/set-timeout!`), so the deferred reply is observable in the
+;; tape and time-travel-safe — Tool-Pair time-travel and the documented
+;; `:dispatch-later` nil-override seam apply automatically. This is the
+;; single framework-owned home for what the example demo stubs previously
+;; open-coded as a per-app three-hop chain (stub-fx → schedule-reply →
+;; `:dispatch-later` → deliver-reply → canned-success).
+;;
+;; The deliverer is one self-recursive framework event. First entry (with
+;; a positive `:after-ms`) schedules the `:dispatch-later` re-dispatching
+;; itself with `:after-ms` stripped; the deferred entry (no `:after-ms`)
+;; re-fires the named canned fx, which synthesises the reply through the
+;; ordinary immediate path. Routing the re-fire back through the fx id
+;; (rather than calling the handler body directly) keeps the canned fx
+;; visible in the tape on the deferred tick exactly as it is on the
+;; immediate path.
+
+(def ^:private deliver-canned-reply-id :rf.http/deliver-canned-reply)
+
+(events/reg-event-fx deliver-canned-reply-id
+  {:doc "Framework-private (rf2-j1mo4). Delivers a canned HTTP reply, optionally
+         after an `:after-ms` delay. Dispatched by the `:rf.http/managed-canned-*`
+         fxs when their args-map carries a positive `:after-ms`; self-recurses
+         once through `:dispatch-later` to honour the delay, then re-fires the
+         named canned fx for immediate synthesis. No user dispatches this
+         directly."}
+  (fn deliver-canned-reply [_ [_ fx-id args-map]]
+    (let [after-ms (:after-ms args-map)]
+      (if (and after-ms (pos? after-ms))
+        ;; Schedule the (now-immediate) re-fire after the delay. Stripping
+        ;; `:after-ms` is what makes the deferred entry take the immediate
+        ;; branch below — exactly one timer tick, never a loop.
+        {:fx [[:dispatch-later
+               {:ms    after-ms
+                :event [deliver-canned-reply-id fx-id (dissoc args-map :after-ms)]}]]}
+        ;; No (remaining) delay — re-fire the canned fx for immediate synthesis.
+        {:fx [[fx-id args-map]]}))))
+
+(defn- with-after-ms
+  "Decorate a canned-stub fx handler body so a positive `:after-ms` on the
+  args-map defers the reply via the framework `:dispatch-later` timer
+  (rf2-j1mo4). Absent / 0 / non-positive `:after-ms` runs `body-fn`
+  immediately — byte-for-byte the pre-rf2-j1mo4 behaviour. `fx-id` is the
+  canned fx's own id, threaded so the deferred re-fire targets the same fx.
+
+  On the deferred path the re-fire runs inside a DIFFERENT event context
+  (the framework deliverer), so the originating event is no longer
+  reachable through `(:event frame-ctx)`. We resolve it eagerly on the
+  immediate dispatch and pin it onto the args-map as `:rf.http/origin-
+  event` BEFORE deferring; on the deferred re-entry the wrapper threads
+  that pinned origin back onto `frame-ctx` as `:event` so the body's
+  `encoding/resolve-origin-event` addresses the caller's originating
+  handler — not the framework deliverer event."
+  [fx-id body-fn]
+  (fn after-ms-aware-handler [frame-ctx args-map]
+    (let [after-ms (:after-ms args-map)]
+      (if (and after-ms (pos? after-ms))
+        ;; Deferred path — pin the origin, then hand off to the deliverer
+        ;; event which schedules the `:dispatch-later`.
+        (when-let [dispatch! (late-bind/get-fn :router/dispatch!)]
+          (let [pinned (assoc args-map :rf.http/origin-event
+                              (encoding/resolve-origin-event frame-ctx args-map))]
+            (dispatch! [deliver-canned-reply-id fx-id pinned]
+                       (cond-> {} (:frame frame-ctx) (assoc :frame (:frame frame-ctx))))))
+        ;; Immediate path. On the deferred re-entry the ambient `:event`
+        ;; is the framework deliverer; restore the caller's pinned origin
+        ;; so reply addressing is identical to the synchronous path.
+        (let [ctx (if-let [origin (:rf.http/origin-event args-map)]
+                    (assoc frame-ctx :event origin)
+                    frame-ctx)]
+          (body-fn ctx args-map))))
+    nil))
 
 ;; ---- canned-stub fx registrations ----------------------------------------
 ;;
@@ -93,19 +178,25 @@
 ;; code must not. The handler bodies live in `re-frame.http-machine-wrapper`
 ;; (rf2-3i9b) so the `with-managed-request-stubs*` helper — which composes
 ;; against `canned-success-handler` / `canned-failure-handler` directly —
-;; still reaches them without circular requires.
+;; still reaches them without circular requires. The `with-after-ms`
+;; decorator (rf2-j1mo4) adds the optional `:after-ms` delay around those
+;; same bodies without changing their contract.
 
 (fx/reg-fx :rf.http/managed-canned-success
            {:doc "Spec 014 — synthesised success reply (test stub).
                   Registration gated on explicit `re-frame.http-test-support`
-                  require per rf2-cdmle."}
-           machine-wrapper/canned-success-handler)
+                  require per rf2-cdmle. Optional `:after-ms` (rf2-j1mo4)
+                  defers the reply via `:dispatch-later`."}
+           (with-after-ms :rf.http/managed-canned-success
+                          machine-wrapper/canned-success-handler))
 
 (fx/reg-fx :rf.http/managed-canned-failure
            {:doc "Spec 014 — synthesised failure reply (test stub).
                   Registration gated on explicit `re-frame.http-test-support`
-                  require per rf2-cdmle."}
-           machine-wrapper/canned-failure-handler)
+                  require per rf2-cdmle. Optional `:after-ms` (rf2-j1mo4)
+                  defers the reply via `:dispatch-later`."}
+           (with-after-ms :rf.http/managed-canned-failure
+                          machine-wrapper/canned-failure-handler))
 
 ;; ---- with-managed-request-stubs ------------------------------------------
 ;;

--- a/implementation/http/test/re_frame/http_managed_test.clj
+++ b/implementation/http/test/re_frame/http_managed_test.clj
@@ -161,6 +161,102 @@
       ;; Only the initial dispatch fired :ping; no reply.
       (is (= 1 @seen)))))
 
+;; ---- 3b. :after-ms delay on the canned-stub fxs (rf2-j1mo4) ----------------
+;;
+;; Mike-ruled (B): a delay is a PARAMETER of the existing canned fx, not a
+;; new `-later` fx id. Absent / 0 `:after-ms` = the immediate behaviour the
+;; tests above already pin; a positive `:after-ms` defers the reply via the
+;; framework-native `:dispatch-later` (observable in the tape, time-travel-
+;; safe — NOT raw `set-timeout!`).
+
+(defn- canned-success-reply-event
+  "Register :j1mo4/load whose reply branch records the success value, and
+  dispatch it through the canned-success stub with the given extra args
+  merged onto the managed args-map. Returns immediately; callers poll
+  `await-reply!` for the landed reply."
+  [extra-args]
+  (rf/reg-event-fx :j1mo4/load
+    (fn [{:keys [db]} [_ msg]]
+      (if-let [reply (:rf/reply msg)]
+        {:db (assoc-in db [:j1mo4 :value] (:value reply))}
+        {:fx [[:rf.http/managed
+               (merge {:request {:method :get :url "/j1mo4"}
+                       :decode  :json}
+                      extra-args)]]})))
+  (rf/dispatch-sync [:j1mo4/load {}]
+                    {:fx-overrides {:rf.http/managed :rf.http/managed-canned-success}}))
+
+(deftest after-ms-absent-is-immediate
+  (testing "no :after-ms — the canned-success reply lands immediately, exactly
+            as the pre-rf2-j1mo4 behaviour (sync dispatch-sync drain delivers
+            the reply with no timer tick)"
+    (canned-success-reply-event {:value {:n 1}})
+    ;; Immediate path runs inside the dispatch-sync drain — the reply is
+    ;; already present without polling a timer.
+    (is (= {:n 1} (get-in (rf/get-frame-db :rf/default) [:j1mo4 :value]))
+        "reply landed synchronously")))
+
+(deftest after-ms-zero-is-immediate
+  (testing ":after-ms 0 (and any non-positive value) is treated as immediate —
+            absent/0 must preserve current behaviour"
+    (canned-success-reply-event {:value {:n 2} :after-ms 0})
+    (is (= {:n 2} (get-in (rf/get-frame-db :rf/default) [:j1mo4 :value]))
+        "reply landed synchronously with :after-ms 0")))
+
+(deftest after-ms-positive-defers-via-dispatch-later
+  (testing ":after-ms N defers the canned reply by one :dispatch-later tick —
+            the reply is NOT present synchronously, lands after the timer, and
+            the deferred dispatch is observable in the tape with
+            :source :fx-dispatch-later (NOT raw set-timeout!)"
+    (let [traces      (atom [])
+          listener-id ::j1mo4-after-ms]
+      (try
+        (trace/register-listener! listener-id (fn [ev] (swap! traces conj ev)))
+        (canned-success-reply-event {:value {:n 3} :after-ms 30})
+        ;; The reply must NOT be present synchronously — the dispatch-sync
+        ;; drain only schedules the :dispatch-later; nothing has delivered yet.
+        (is (nil? (get-in (rf/get-frame-db :rf/default) [:j1mo4 :value]))
+            "reply deferred — not present immediately after dispatch-sync")
+        ;; After the timer tick the reply lands.
+        (let [db (await-reply! #(some? (get-in % [:j1mo4 :value])))]
+          (is (= {:n 3} (get-in db [:j1mo4 :value]))
+              "deferred reply landed after the :dispatch-later tick"))
+        ;; Tape observability: the deferred re-dispatch of the framework
+        ;; deliverer event rode :dispatch-later, so its :rf.event/dispatched
+        ;; trace carries :source :fx-dispatch-later. This is the load-bearing
+        ;; "observable in the tape, not raw set-timeout!" assertion.
+        (let [later (filter #(and (= :rf.event/dispatched (:operation %))
+                                  (= :fx-dispatch-later (:source %)))
+                            @traces)]
+          (is (seq later)
+              "a :dispatch-later-sourced dispatch appears in the tape")
+          (is (some #(= :rf.http/deliver-canned-reply
+                        (first (:rf.event/v (:tags %))))
+                    later)
+              "the deferred dispatch is the framework canned-reply deliverer"))
+        (finally
+          (trace/unregister-listener! listener-id))))))
+
+(deftest after-ms-positive-on-failure-defers
+  (testing ":after-ms N also defers the canned-FAILURE reply by a
+            :dispatch-later tick (symmetric with the success path)"
+    (rf/reg-event-fx :j1mo4/fail-delayed
+      (fn [_ _]
+        {:fx [[:rf.http/managed
+               {:request    {:method :get :url "/j1mo4/fail"}
+                :after-ms   30
+                :on-failure [:j1mo4/failed]}]]}))
+    (rf/reg-event-db :j1mo4/failed
+      (fn [db [_ payload]] (assoc db :j1mo4-error payload)))
+    (rf/dispatch-sync [:j1mo4/fail-delayed]
+                      {:fx-overrides {:rf.http/managed :rf.http/managed-canned-failure}})
+    ;; Deferred — not present synchronously after the dispatch-sync drain.
+    (is (nil? (:j1mo4-error (rf/get-frame-db :rf/default)))
+        "failure reply deferred — not present immediately")
+    (let [db (await-reply! #(some? (:j1mo4-error %)))]
+      (is (= :rf.http/transport (get-in db [:j1mo4-error :failure :kind]))
+          "deferred failure reply landed after the :dispatch-later tick"))))
+
 ;; ---- 4. real JVM transport: GET success -----------------------------------
 
 (deftest jvm-real-get-success

--- a/implementation/http/test/re_frame/http_test_support_test.clj
+++ b/implementation/http/test/re_frame/http_test_support_test.clj
@@ -9,8 +9,11 @@
    - load-time registration of the two canned-stub fxs:
       - `:rf.http/managed-canned-success`
       - `:rf.http/managed-canned-failure`
-     Each delegates to `re-frame.http-machine-wrapper/canned-success-handler`
-     / `canned-failure-handler`.
+     Each wraps `re-frame.http-machine-wrapper/canned-success-handler`
+     / `canned-failure-handler` in the rf2-j1mo4 `:after-ms` delay
+     decorator: absent / 0 `:after-ms` delegates straight through
+     (immediate reply); a positive `:after-ms` defers via the framework
+     `:dispatch-later`.
    - the stub macros / fns:
       - `with-managed-request-stubs`
       - `with-managed-request-stubs*`
@@ -23,15 +26,15 @@
      `re-frame.core-http`'s defwrapper surface).
 
   This smoke pins the load-time side effects: fx registrations land,
-  fx ids bind to the wrapper's canned-* vars, and the stub-family
-  late-bind hooks are non-nil after the require. The deeper end-to-end
+  the fx ids delegate (on the immediate path) to the machine-wrapper
+  canned-* bodies, and the stub-family late-bind hooks are non-nil after
+  the require. The deeper end-to-end
   behaviour (canned reply → late-bind dispatch → reply lands in
   app-db) is exercised by `re-frame.http-managed-test` and the
   corresponding CLJS smoke under `implementation/adapters/*`."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.late-bind :as late-bind]
             [re-frame.registrar :as registrar]
-            [re-frame.http-machine-wrapper :as machine-wrapper]
             [re-frame.http-test-support :as http-test-support]))
 
 ;; Ensure each test starts from a known registrar — clear, then reload
@@ -49,16 +52,40 @@
     (is (some? (registrar/lookup :fx :rf.http/managed-canned-failure))
         ":rf.http/managed-canned-failure registered")))
 
-(deftest canned-stub-fxs-bind-the-machine-wrapper-handlers
-  (testing "the registered handlers ARE the machine-wrapper canned-* vars
-            (not a shim) — so Spec 014 §Testing's args-map contract
-            carries through unchanged"
-    (is (identical? machine-wrapper/canned-success-handler
-                    (registrar/handler :fx :rf.http/managed-canned-success))
-        ":rf.http/managed-canned-success → machine-wrapper/canned-success-handler")
-    (is (identical? machine-wrapper/canned-failure-handler
-                    (registrar/handler :fx :rf.http/managed-canned-failure))
-        ":rf.http/managed-canned-failure → machine-wrapper/canned-failure-handler")))
+(deftest canned-stub-fxs-delegate-to-machine-wrapper-handlers
+  (testing "rf2-j1mo4 — the registered handlers wrap the machine-wrapper
+            canned-* vars in the `with-after-ms` delay decorator. On the
+            immediate path (no `:after-ms`) the wrapper delegates straight
+            through to the machine-wrapper body, so Spec 014 §Testing's
+            args-map contract carries through unchanged; a positive
+            `:after-ms` defers via the framework `:dispatch-later`.
+
+            The handlers are deliberately NOT `identical?` to the
+            machine-wrapper vars anymore — the delay is a parameter of the
+            same effect, threaded by wrapping the reg-fx body. We pin the
+            delegation by driving the immediate path through a stub
+            late-bind router and asserting the wrapper body fired the
+            machine-wrapper reply walk (a dispatch through `:router/dispatch!`)."
+    (let [dispatched (atom [])
+          ;; Save the live router hook and RESTORE it in finally — never
+          ;; null it. Nulling `:router/dispatch!` is global state that
+          ;; would silently break every subsequent test's `:dispatch`
+          ;; cascade (it is published once at router load, not per-test).
+          original   (late-bind/get-fn :router/dispatch!)]
+      (late-bind/set-fn! :router/dispatch!
+                         (fn [ev opts] (swap! dispatched conj [ev opts])))
+      (try
+        ;; Immediate path — no :after-ms. The wrapper must delegate to the
+        ;; machine-wrapper body, which calls dispatch-reply-via-late-bind!.
+        ((registrar/handler :fx :rf.http/managed-canned-success)
+         {:frame :rf/default :event [:t/load]}
+         {:value {:ok true}})
+        (is (= 1 (count @dispatched))
+            "immediate canned-success delegated to the machine-wrapper body (one reply dispatch)")
+        (is (= :success (-> @dispatched first first (nth 1) :rf/reply :kind))
+            "the synthesised reply is the machine-wrapper's success envelope")
+        (finally
+          (late-bind/set-fn! :router/dispatch! original))))))
 
 (deftest stub-family-late-bind-hooks-publish-on-test-support-load
   (testing "rf2-lwmgw — loading re-frame.http-test-support publishes the

--- a/spec/014-HTTPRequests.md
+++ b/spec/014-HTTPRequests.md
@@ -907,6 +907,28 @@ The fx vectors the helpers synthesise are exactly the same shape as the hand-wri
 
 The stubs reuse the same dispatch shape the real fx produces so the test handler's reply branch sees the canonical envelope. Same pattern as the existing http-stub idiom (see `examples_test.clj` and `ssr_end_to_end_test.clj` for prior art).
 
+#### `:after-ms` — deferring a canned reply
+
+Both canned-stub fxs accept an optional `:after-ms` arg. It is a **parameter of the same effect**, not a separate `-later` fx:
+
+| `:after-ms` | Reply timing |
+|---|---|
+| absent / `0` / non-positive | immediate — the reply dispatches inside the same drain (the default, unchanged) |
+| positive `N` | deferred — the reply lands after an `N`-ms `:dispatch-later` tick |
+
+```clojure
+;; Immediate (default): reply lands in the same dispatch-sync drain.
+{:fx [[:rf.http/managed-canned-success {:value {:user {...}}}]]}
+
+;; Deferred: reply lands 50 ms later, so a `:loading` / `:submitting`
+;; UI state is observable before it resolves.
+{:fx [[:rf.http/managed-canned-success {:value {:user {...}} :after-ms 50}]]}
+```
+
+The delay rides the framework-native `:dispatch-later` timer — it is **observable in the tape** (the deferred dispatch self-tags `:source :fx-dispatch-later` with `:source-detail {:ms N}`) and time-travel-safe (Tool-Pair time-travel and the documented `:dispatch-later` nil-override seam both apply). It is **not** raw `js/setTimeout` / `interop/set-timeout!`. Reply addressing is identical to the immediate path — the originating event (or the explicit `:on-success` / `:on-failure`) still receives the canonical `{:kind ... }` envelope after the delay. `:after-ms` is the single mechanism a demo stub uses to simulate latency; it replaces the former per-app three-hop boilerplate (stub-fx → schedule-reply → `:dispatch-later` → deliver-reply → canned reply) with one arg on the canned effect.
+
+**Interaction with `:fx-overrides`.** When `:fx-overrides {:rf.http/managed :rf.http/managed-canned-success}` redirects the production fx to a canned stub, the override target receives the **same args-map** the handler built for `:rf.http/managed` — so an `:after-ms` placed there flows straight through to the canned stub. A handler can therefore stay backend-agnostic (it never mentions `:after-ms`) while a test or demo dials in latency purely through the override, OR a demo stub that wraps the canned fx (the worked examples' pattern) can stamp `:after-ms` on the args-map before delegating. The override only redirects `:rf.http/managed`; the deferred reply the canned fx synthesises internally re-fires the canned fx by its own id (not `:rf.http/managed`), so it does not depend on the override staying installed across the delay, and reply addressing is identical to the immediate path.
+
 ### Test-support require — the HTTP test surface gate
 
 The canned-stub fxs above AND the `with-managed-request-stubs` family of macros / fns are **test-only**; production / SSR code paths must not be able to reach them. The framework gates registration behind an explicit require:


### PR DESCRIPTION
Implements rf2-j1mo4 (design RULED — implementation task). Mike-ruled **(B)** 2026-05-30: a delay is a **parameter of the same effect**, not a new `-later` fx id.

## What changed

Add an optional `:after-ms` arg to the existing `:rf.http/managed-canned-success` / `:rf.http/managed-canned-failure` fxs:

- **absent / `0` / non-positive** → reply lands immediately (current behaviour, byte-for-byte unchanged)
- **positive `N`** → reply lands after an `N`-ms tick on the **framework-native `:dispatch-later`** (observable in the tape as `:source :fx-dispatch-later` / `:source-detail {:ms N}`, time-travel-safe — **NOT** raw `interop/set-timeout!` / `js/setTimeout`)

### Mechanism (no new fx-id; one framework-private deliverer event)
`with-after-ms` decorates the canned-stub fx bodies at the `reg-fx` site. On a positive `:after-ms` it pins the originating event as `:rf.http/origin-event` and hands off to one self-recursive framework-private event `:rf.http/deliver-canned-reply`: the first entry schedules `:dispatch-later` re-dispatching itself with `:after-ms` stripped; the deferred entry re-fires the named canned fx for immediate synthesis. The pinned origin is restored onto `frame-ctx` on the deferred re-entry, so **reply addressing is identical to the immediate path**. The `with-managed-request-stubs` family (synchronous matchers) is untouched.

### Example migrations (4 of the 5)
Migrated the demo stubs off the per-app three-hop boilerplate (stub-fx → `schedule-reply` → `:dispatch-later` → `deliver-reply` → canned reply) to a single `:after-ms` arg on the canned effect:

- `examples/reagent/login` (50 ms)
- `examples/helix/login_helix` (50 ms)
- `examples/reagent/managed_http_counter` — `:counter/start-long` (750 ms)
- `examples/reagent/realworld` (20 ms)

**`nine_states` is intentionally left unchanged**: the bead's framing assumed all 5 carried the 3-hop chain, but `nine_states` has none — its `:nine-states.http/managed-demo` calls the canned handlers **synchronously** via `registrar/handler`, and its headless fixtures (`test/nine_states/core_test.cljs`) assert synchronously right after `dispatch-sync` (the file even comments "the demo stub resolves synchronously"). Adding `:after-ms` would break those tests, so it stays the deliberately-instant example. (It already uses the clean direct-`registrar/handler` shape — the migration target minus the delay.)

### Spec 014 §Testing diff (hot-zone — sole toucher)
- new `#### :after-ms — deferring a canned reply` subsection: immediate-vs-deferred table, `:dispatch-later` tape-observability + time-travel note, the "replaces the three-hop boilerplate" framing
- **`:fx-overrides` interaction note**: `:after-ms` rides the same args-map the override target receives; the deferred re-fire targets the canned fx by its own id (not `:rf.http/managed`), so it does not depend on the override staying installed across the delay

## Quality gates (run from worktree)

- `clojure -M:test` (http JVM): **277 tests, 1435 assertions, 0 failures, 0 errors** (4 new `:after-ms` tests: absent = immediate, `0` = immediate, positive defers via observable `:dispatch-later`, failure path defers). Baseline was 273.
- `npm run test:cljs` (node CLJS): **5021 tests, 16795 assertions, 0 failures, 0 errors** — includes the realworld / nine_states example fixtures.
- `shadow-cljs compile` of all 4 migrated example builds: **0 warnings**.
- `clj-kondo --fail-level error --lint implementation/http/src` + the 4 migrated examples: **0 errors** (one pre-existing unused-`middleware`-require warning in `http_test_support.cljc`, present on baseline, left as-is).
- `python scripts/check_doc_slugs.py`: clean. `python scripts/check_readme_links.py`: clean.
- `mkdocs build --strict` (spec staged into `docs/spec`): **built successfully**, no WARNING/ERROR (spec/014 is referenced by link, not nav — pre-existing).

Note: the 3 adapter browser smokes (`npm run test:examples`) 404'd — no static server/build was staged in this environment; they exercise the adapter testbeds, not the migrated examples. The CLJS unit suite is the real regression gate and is green.

A test-isolation bug was found and fixed mid-flight: a new test had nulled the global `:router/dispatch!` hook in `finally` (it now save-restores), which had been silently breaking the routing-corners test ns downstream.
