### PR TITLE
fix(xray): Epoch handler step shows post-handler db; flow step shows its own :db diff (rf2-4wywy)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1493,11 +1493,27 @@ trace.
 
 #### §9.1.5.1 HANDLER `:db` — single FULL+DIFF rendering (rf2-vv3m6)
 
-The HANDLER step's `:db` sub-section renders the full post-cascade
-`:db-after` tree via the edn-inspector widget WITH the focused
+The HANDLER step's `:db` sub-section renders the **post-handler,
+pre-flow** `:db` tree via the edn-inspector widget WITH the focused
 epoch's `:db-before` threaded as the diff pre-image, so inline diff
 annotations paint per the R1-R8 grammar below. There is no mode
 toggle.
+
+> **Post-handler `:db`, not post-flow (rf2-4wywy)** — the rendered
+> value is the **t1 snapshot** (`:rf.event/db-pending`, post-handler /
+> pre-flow · rf2-ta0y7), surfaced by the projection as the HANDLER
+> step's `:db-post-handler`. It is NOT the epoch record's `:db-after`.
+> `:db-after` is the FINAL post-flow / post-commit state — flows write
+> app-db AFTER the handler returns (at the outermost `:after`
+> interceptor), so reading `:db-after` here CONFLATED the handler's
+> change with any flow recompute that followed it (the bug). With t1
+> the HANDLER step shows ONLY what the handler returned; the flow's own
+> contribution is rendered on the FLOW step as its own `:db` diff (the
+> t1→t2 reshape · §9.1.10.8). **Graceful fallback**: when no t1 rode
+> the stream (handler returned no `:db`, or a pre-rf2-ta0y7 runtime),
+> the sub-section falls back to the record's `:db-after` so older
+> epochs still render. The diff pre-image stays `:db-before`
+> throughout.
 
 > **Retirement (2026-05-29, rf2-vv3m6)** — the prior
 > `[diff][full][full+diff]` three-mode toggle (rf2-n2jig + rf2-yqjrd)
@@ -2325,6 +2341,12 @@ each carries `:flow-id`, `:path`, `:before`, `:after`, and
 `:duration-ms` (when stamped). The aggregate `flow-step` defn
 retired with rf2-xnb1x.
 
+Per rf2-4wywy each FLOW step additionally carries the t1 (pre-flow)
++ t2 (post-flow) db snapshots — `:db-pre-flow` (`:rf.event/db-pending`)
+and `:db-post-flow` (`:rf.event/db-pending-post-flow`) — threaded by
+`project` off the trace stream (rf2-ta0y7). One flows pass produces
+one t1→t2 transition shared across all FLOW steps of the epoch.
+
 The accompanying view-layer chrome:
 
 - **Header** — `:FLOW` badge + flow-id button to the right of
@@ -2333,11 +2355,29 @@ The accompanying view-layer chrome:
   jumps through the shared `:rf.xray/open-in-editor` allowlist —
   see §9.1.11); otherwise the id renders as a plain coloured span.
   An external-link glyph trails the id when source-jump is wired.
-- **Body** — `<glyph> [path] before → after` diff-style line,
-  left-aligned with the badge (no indent), reusing the COEFFECT
-  body styles (`coeffect-body-*`). Glyph is `~` for an update
-  (both before and after present) or `+` for a first-write (no
-  before). Values render through the edn-inspector `mini` widget.
+- **Body — the flow's OWN `:db` diff (rf2-4wywy)** — a flow's
+  contribution IS an app-db mutation: it writes `:output` into `:path`
+  AFTER the handler returned. The body renders that contribution as a
+  `:db` DIFF via the shared edn-inspector diff renderer (FULL+DIFF,
+  parity with the HANDLER `:db` sub-section §9.1.5.1 + the App-DB Diff
+  panel), under a `↳ :db <path>` sub-header. The diff is **scoped to
+  the flow's `:path`**: `:before` = t1 with the flow's pre-write value
+  at `:path`, value = t2 with the flow's post-write value at `:path`,
+  so each FLOW step shows ONLY its own slot's reshape even when several
+  flows rode the same t1→t2 transition. This keeps the flow's change
+  (e.g. `:derived` recomputed) SEPARATE from the HANDLER step's `:db`
+  (which shows only the t1 / post-handler state). Testid
+  `rf-xray-epoch-flow-db-diff-<name>`; the step root carries
+  `data-rf-xray-flow-db-diff="true"`.
+- **Fallback (pre-rf2-ta0y7 / no snapshots)** — when the step carries
+  no t1/t2 snapshots (handler returned no `:db`, or an older runtime),
+  the body falls back to the legacy `<glyph> [path] before → after`
+  diff-style scalar line, left-aligned with the badge (no indent),
+  reusing the COEFFECT body styles (`coeffect-body-*`). Glyph is `~`
+  for an update (both before and after present) or `+` for a
+  first-write (no before). Values render through the edn-inspector
+  `mini` widget. Testid `rf-xray-epoch-flow-value-<name>`; the step
+  root carries `data-rf-xray-flow-db-diff="false"`.
 - **Verb dropped** — the prior `N flows recomputed` aggregate
   verb is gone; the per-step expansion of flows makes the count
   visible in the cascade numbering itself (operator scans left
@@ -3321,7 +3361,8 @@ signal to render plainly. None set any mode flag:
 
 | Surface                              | Call site                                                                                  | Test surface                                                                |
 |--------------------------------------|--------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------|
-| Epoch HANDLER step `:db`             | `panels/epoch/view.cljs` — `handler-db-diff-block` (always threads `:before db-before`)    | `data-testid="rf-xray-epoch-handler-db-full-with-diff"`                     |
+| Epoch HANDLER step `:db`             | `panels/epoch/view.cljs` — `handler-db-diff-block` (post-handler t1 `:db-post-handler`, fallback `:db-after`; `:before db-before` · rf2-4wywy) | `data-testid="rf-xray-epoch-handler-db-full-with-diff"`                     |
+| Epoch FLOW step `:db`                | `panels/epoch/view.cljs` — `render-flow-step` (path-scoped t1→t2 diff `:db-pre-flow`→`:db-post-flow` · rf2-4wywy) | `data-testid="rf-xray-epoch-flow-db-diff-<name>"`                           |
 | App-DB panel (per `:rf/*` section)   | `panels/app_db_diff_state.cljs` — `value-body` (one mount; `:before` via `cond->`)         | App-DB panel-gallery story fixtures + segment-inspector tests               |
 | Machine Inspector snapshot drill-in  | `panels/machine_inspector.cljs` — `snapshot-block` (`:before` via `cond->` when captured)  | `data-testid="rf-xray-machine-snapshot-block-<id>"` with `data-rf-xray-diff-mode="full+diff"` |
 | Epoch SUBSCRIPTIONS step value cells | `panels/epoch/view.cljs` — `subs-value-cell` container branch (`:before` / `:added?`)      | `data-testid="rf-xray-epoch-sub-row-*"` mount                               |

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -835,6 +835,45 @@
   [events]
   (or (some-> (find-op events :rf.event/run-end) :tags) {}))
 
+;; ---- t1 / t2 pending-`:db` snapshots (rf2-4wywy) ------------------------
+;;
+;; Per rf2-ta0y7 the router stamps two pending-`:db` snapshots on the trace
+;; stream so per-step db attribution is possible WITHOUT a core change:
+;;
+;;   t1 `:rf.event/db-pending`            — POST-handler-chain, PRE-flow
+;;                                          (what the handler returned;
+;;                                          before any flow could touch it).
+;;   t2 `:rf.event/db-pending-post-flow`  — POST-flow, PRE-commit (the
+;;                                          flow-augmented value). OMITTED
+;;                                          when no flow changed `:db`
+;;                                          (t1 == t2 carries no info).
+;;
+;; Both carry the FULL db value under `:tags :rf.event/db`. The epoch
+;; record's `:db-after` is the FINAL post-commit state (== t2 when flows
+;; fired, == t1 otherwise); reading it for the HANDLER step conflated the
+;; handler's change with the following flow change (rf2-4wywy bug). The
+;; HANDLER step now reads t1; the FLOW step shows the t1→t2 reshape as its
+;; OWN `:db` diff.
+
+(defn db-pending-t1
+  "The POST-handler, PRE-flow db value off the `:rf.event/db-pending`
+  (t1) trace event (rf2-ta0y7 · `:tags :rf.event/db`). nil when no t1
+  fired — the handler returned no `:db`, or the runtime predates
+  rf2-ta0y7. Callers fall back to the epoch record's `:db-before` /
+  `:db-after` in that case."
+  [events]
+  (some-> (find-op events :rf.event/db-pending)
+          (common/tag-of :rf.event/db)))
+
+(defn db-pending-t2
+  "The POST-flow, PRE-commit db value off the
+  `:rf.event/db-pending-post-flow` (t2) trace event (rf2-ta0y7 ·
+  `:tags :rf.event/db`). nil when no t2 fired — no flow changed `:db`
+  this epoch (t1 == t2), or the runtime predates rf2-ta0y7."
+  [events]
+  (some-> (find-op events :rf.event/db-pending-post-flow)
+          (common/tag-of :rf.event/db)))
+
 (defn handler-row
   "Build the step-N HANDLER row. ALWAYS present (every epoch has a
   dispatched event therefore a handler). Adapts to the trace stream's
@@ -877,12 +916,28 @@
                         (some-> db-changed :tags :duration-ms)
                         (some-> do-fx :tags :duration-ms))
         decomp      (effects-decomp events)
+        ;; rf2-4wywy — the HANDLER step's `:db` must reflect ONLY the
+        ;; handler's own contribution (post-handler, PRE-flow), not the
+        ;; final post-flow state. `db-post-handler` is the t1 snapshot
+        ;; (`:rf.event/db-pending`); when t1 is absent (handler returned
+        ;; no `:db`, or pre-rf2-ta0y7 runtime) the view falls back to the
+        ;; record's `:db-after`. The `:db-diff` flat-rows are likewise
+        ;; computed against t1 when present so non-view consumers + tests
+        ;; read the handler-only change.
+        db-t1       (db-pending-t1 events)
+        db-handler  (if (some? db-t1) db-t1 db-after)
         base        {:step           :handler
                      :badge          :HANDLER
                      :flavour        flavour
                      :event-id       event-id
                      :duration-ms    duration-ms
-                     :db-diff        (db-diff-paths db-before db-after)
+                     ;; The post-handler (t1) db value — the HANDLER
+                     ;; step's `:db` sub-section renders this diffed
+                     ;; against `:db-before`. nil-safe: absent t1 leaves
+                     ;; the slot nil and the view falls back to the
+                     ;; record's `:db-after`.
+                     :db-post-handler db-t1
+                     :db-diff        (db-diff-paths db-before db-handler)
                      ;; :fx — legacy flat-entries slot (kept for non-view
                      ;; consumers; tests + pre-rf2-p2zy0 callers).
                      :fx             (or (fx-entries events) [])
@@ -1810,6 +1865,16 @@
             ;; step. `flow-rows` projection (per-row data) is
             ;; unchanged; the aggregation shape was the only thing
             ;; that changed.
+            ;; rf2-4wywy — thread the t1 (pre-flow) / t2 (post-flow) db
+            ;; snapshots onto every FLOW step so the view can render the
+            ;; flow's OWN contribution as a `:db` DIFF (the t1→t2 reshape),
+            ;; rather than the per-path before/after scalar line that read
+            ;; as a flow-internal value rather than an app-db change. The
+            ;; snapshots are shared across all flow steps of the epoch (one
+            ;; flows pass produces one t1→t2 transition); each step scopes
+            ;; the rendered diff to its own `:path`.
+            flow-db-pre  (db-pending-t1 events)
+            flow-db-post (db-pending-t2 events)
             flow-steps (mapv (fn [{:keys [flow-id path before after duration-ms]}]
                                (cond-> {:step    :flow
                                         :badge   :FLOW
@@ -1818,7 +1883,11 @@
                                         :before  before
                                         :after   after}
                                  (some? duration-ms)
-                                 (assoc :duration-ms duration-ms)))
+                                 (assoc :duration-ms duration-ms)
+                                 (some? flow-db-pre)
+                                 (assoc :db-pre-flow flow-db-pre)
+                                 (some? flow-db-post)
+                                 (assoc :db-post-flow flow-db-post)))
                              (flow-rows events))
             violations (schema-violation-rows events)
             base-steps (vec

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -2457,22 +2457,39 @@
 
   rf2-vv3m6 (2026-05-29) — the prior `[diff][full][full+diff]` mode
   toggle (rf2-n2jig / rf2-yqjrd) is retired. FULL+DIFF is the single
-  rendering: the full `:db-after` tree with inline diff annotations
-  driven off `:db-before`. The R1-R8 grammar paints gutter glyphs +
-  row washes + leaf-scalar `← was X` suffixes; auto-collapse keeps
-  unchanged subtrees folded so the density matches what the prior
-  `:diff` lens used to provide. The `:db-diff` arg is unused under
-  the single rendering but stays in the parent's `handler-body`
-  signature for projection compatibility.
+  rendering: the full post-handler `:db` tree with inline diff
+  annotations driven off `:db-before`. The R1-R8 grammar paints
+  gutter glyphs + row washes + leaf-scalar `← was X` suffixes;
+  auto-collapse keeps unchanged subtrees folded so the density matches
+  what the prior `:diff` lens used to provide.
+
+  rf2-4wywy — the rendered `:db` is the POST-HANDLER, PRE-FLOW value
+  (the projection's `:db-post-handler`, t1 · `:rf.event/db-pending`),
+  NOT the epoch record's `:db-after`. `:db-after` is the FINAL
+  post-flow / post-commit state — reading it conflated the handler's
+  change with any flow recompute that followed (flows write app-db
+  AFTER the handler). With t1 the HANDLER step shows ONLY what the
+  handler returned; the FLOW step shows the flow's OWN `:db` diff
+  (the t1→t2 reshape). Graceful fallback: when no t1 fired (handler
+  returned no `:db`, or a pre-rf2-ta0y7 runtime) the block falls back
+  to the record's `:db-after` so older epochs still render.
+
+  The `:db-diff` arg is unused under the single rendering but stays in
+  the parent's `handler-body` signature for projection compatibility.
 
   Suppressed for machine handlers — per design §Section 3 §DB DIFF
   the snapshot IS the db change (at `[:rf/runtime :machines :snapshots <id>]`) so the
   slot folds into SNAPSHOT DIFF rather than carrying a redundant
   standalone slot."
-  [_db-diff]
+  [_db-diff db-post-handler]
   (let [record    @(rf/subscribe [:rf.xray/selected-epoch-record])
         db-before (:db-before record)
-        db-after  (:db-after record)]
+        ;; rf2-4wywy — t1 (post-handler, pre-flow) is the authoritative
+        ;; HANDLER `:db`; fall back to the record's post-flow `:db-after`
+        ;; only when the runtime stamped no t1.
+        db-after  (if (some? db-post-handler)
+                    db-post-handler
+                    (:db-after record))]
     [:div {:data-testid "rf-xray-epoch-handler-db-diff"
            ;; rf2-xvu24 — canonical `data-rf-xray-diff-mode` axis. Now
            ;; a constant post-rf2-vv3m6; kept for selector compatibility
@@ -2521,7 +2538,7 @@
   Either, both, or neither may render — sections are
   `seq`-conditioned. The `:db` part stays in its own dedicated
   block (the [diff][full][full+diff] toggle) above."
-  [{:keys [flavour event-id db-diff fx-vec other-effects machine] :as _row}]
+  [{:keys [flavour event-id db-diff db-post-handler fx-vec other-effects machine] :as _row}]
   (let [machine? (= :reg-machine flavour)]
     [:div {:data-testid "rf-xray-epoch-handler-body"}
      ;; Source / machine spec block — rf2-66wis
@@ -2531,9 +2548,11 @@
      (when machine
        (machine-block machine event-id))
      ;; :db diff — always present for non-machine handlers (rf2-93436);
-     ;; folded into SNAPSHOT DIFF for machines
+     ;; folded into SNAPSHOT DIFF for machines. rf2-4wywy — the
+     ;; post-handler (t1) db is threaded so the diff shows ONLY the
+     ;; handler's contribution, not the post-flow state.
      (when-not machine?
-       (handler-db-diff-block db-diff))
+       (handler-db-diff-block db-diff db-post-handler))
      ;; :fx — the canonical vector-of-vectors, FULL via edn-inspector.
      ;; rf2-5t8y8 — sub-header carries a trailing entry-count chip ("N
      ;; entr{y,ies}") that the edn-inspector vector-header chrome alone
@@ -2600,19 +2619,46 @@
   registered flow carries `:file`/`:line` meta from `reg-flow`).
 
   The projection emits N flow step maps for a cascade with N flow
-  recomputes; the body row renders the diff (path · before → after)
-  beneath the badge, left-aligned with no extra indent — same body
-  layout as the COEFFECT step."
-  [{:keys [flow-id path before after duration-ms step-number]}]
+  recomputes.
+
+  rf2-4wywy — the body renders the flow's OWN contribution as a `:db`
+  DIFF rather than the prior `[path] before → after` scalar line. A
+  flow's contribution IS an app-db mutation (it writes `:output` into
+  `:path` AFTER the handler returned); rendering it as a `:db` diff
+  via the shared edn-inspector diff renderer (parity with the HANDLER
+  step's `:db` sub-section + the App-DB Diff panel) reads as 'what the
+  flow changed in app-db', and — crucially — keeps it SEPARATE from
+  the HANDLER step's `:db` (which now shows only the t1 / post-handler
+  state). The diff is scoped to the flow's `:path` so each FLOW step
+  shows only its own slot's reshape (the projection threads the shared
+  t1/t2 db snapshots onto every flow step; `assoc-in` at the flow's
+  path against t1 / t2 isolates this flow's contribution).
+
+  Graceful fallback: when the projection carried no t1/t2 snapshots
+  (handler returned no `:db`, or a pre-rf2-ta0y7 runtime) the body
+  falls back to the per-path `[path] before → after` scalar line."
+  [{:keys [flow-id path before after duration-ms step-number
+           db-pre-flow db-post-flow]}]
   (let [flow-meta  (when (keyword? flow-id)
                      (try (rf/handler-meta :flow flow-id)
                           (catch :default _ nil)))
         coord      (when (and flow-meta (string? (:file flow-meta)))
                      {:file (:file flow-meta) :line (:line flow-meta)})
-        label      (proj/ns-keyword flow-id)]
+        label      (proj/ns-keyword flow-id)
+        ;; rf2-4wywy — render a `:db` diff scoped to this flow's path.
+        ;; t1 (db-pre-flow) lacks this flow's write; t2 (db-post-flow)
+        ;; carries it. Scoping to the path isolates THIS flow's slot
+        ;; even when several flows rode the same t1→t2 transition. When
+        ;; either snapshot is absent we render the scalar fallback.
+        db-diff?   (boolean
+                     (and (some? db-pre-flow) (some? db-post-flow)
+                          (sequential? path) (seq path)))
+        diff-before (when db-diff? (assoc-in db-pre-flow path before))
+        diff-after  (when db-diff? (assoc-in db-post-flow path after))]
     [:div {:data-testid (str "rf-xray-epoch-step-flow-" (name flow-id))
            :data-step-kw "flow"
-           :data-flow-id (name flow-id)}
+           :data-flow-id (name flow-id)
+           :data-rf-xray-flow-db-diff (str db-diff?)}
      (numbered-circle step-number :FLOW)
      (step-header
        {:step :flow
@@ -2628,22 +2674,34 @@
         :testid (str "rf-xray-epoch-flow-" (name flow-id))
         :duration-ms duration-ms}
        nil)
-     ;; Body — `[path] before → after` diff line, left-aligned with
-     ;; the badge (no extra indent). Mirrors the COEFFECT step's
-     ;; body layout (pair-debug 2026-05-26).
-     (when (sequential? path)
-       [:div {:data-testid (str "rf-xray-epoch-flow-value-" (name flow-id))
-              :style coeffect-body-style}
-        [:span {:style coeffect-body-plus-style}
-         (if (some? before) "~" "+")]
-        [:span {:style coeffect-body-path-style}
-         (proj/path-display path)]
-        (when (some? before)
-          [:span {:style diff-before-style} [ei/mini before 30]])
-        (when (and (some? before) (some? after))
-          [:span {:style coeffect-body-path-style} "→"])
-        (when (some? after)
-          [:span {:style coeffect-body-value-style} [ei/mini after 30]])])]))
+     (if db-diff?
+       ;; rf2-4wywy — the flow's own `:db` diff via the shared
+       ;; edn-inspector diff renderer (FULL+DIFF, parity with HANDLER
+       ;; `:db`). `:before` = t1-scoped, value = t2-scoped at this
+       ;; flow's path → the inspector paints the flow's slot reshape.
+       [:div {:data-testid (str "rf-xray-epoch-flow-db-diff-" (name flow-id))
+              :style handler-db-all-style}
+        (sub-header ":db" (proj/path-display path))
+        [ei/edn-inspector diff-after
+         {:site-id [:rf.xray.epoch/flow-db-diff flow-id]
+          :before  diff-before
+          :default-expanded-depth 3}]]
+       ;; Fallback — `[path] before → after` scalar line, left-aligned
+       ;; with the badge (no extra indent). Mirrors the COEFFECT step's
+       ;; body layout (pair-debug 2026-05-26).
+       (when (sequential? path)
+         [:div {:data-testid (str "rf-xray-epoch-flow-value-" (name flow-id))
+                :style coeffect-body-style}
+          [:span {:style coeffect-body-plus-style}
+           (if (some? before) "~" "+")]
+          [:span {:style coeffect-body-path-style}
+           (proj/path-display path)]
+          (when (some? before)
+            [:span {:style diff-before-style} [ei/mini before 30]])
+          (when (and (some? before) (some? after))
+            [:span {:style coeffect-body-path-style} "→"])
+          (when (some? after)
+            [:span {:style coeffect-body-value-style} [ei/mini after 30]])]))]))
 
 ;; ---- FX step -------------------------------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -57,6 +57,8 @@
 (def ^:private do-fx-ev             teb/do-fx-ev)
 (def ^:private fx-handled-ev        teb/fx-handled-ev)
 (def ^:private flow-recomputed-ev   teb/flow-recomputed-ev)
+(def ^:private db-pending-ev        teb/db-pending-ev)
+(def ^:private db-pending-post-flow-ev teb/db-pending-post-flow-ev)
 (def ^:private sub-run-ev           teb/sub-run-ev)
 (def ^:private view-render-ev       teb/view-rendered-ev)
 (def ^:private view-unmounted-ev    teb/view-unmounted-ev)
@@ -953,6 +955,141 @@
                           :rf.flow/after 1}}]
       (is (= [] (proj/flow-rows [ev]))
           "legacy op-name produces zero rows — no silent fallthrough"))))
+
+;; ---- t1 / t2 db attribution (rf2-4wywy) ---------------------------------
+;;
+;; button-deck button 5 (`:button-deck/increment-flow`): the handler bumps
+;; `:base`; the `:button-deck/derived` flow then recomputes `:derived =
+;; 2 × :base` into app-db AFTER the handler. The HANDLER step's `:db` must
+;; reflect ONLY the handler's change (`:base` bumped, NO `:derived`); the
+;; FLOW step must show the flow's OWN contribution (`:derived` recomputed)
+;; as a SEPARATE `:db` diff. The two must not be conflated.
+;;
+;; The fix reads the t1 (`:rf.event/db-pending`, post-handler/pre-flow) +
+;; t2 (`:rf.event/db-pending-post-flow`, post-flow) snapshots off the trace
+;; stream (rf2-ta0y7). The epoch record's `:db-after` is the FINAL
+;; post-flow state — reading it for the HANDLER step was the bug.
+
+(deftest db-pending-t1-t2-readers-test
+  (testing "rf2-4wywy — t1 reader pulls the post-handler db off
+            `:rf.event/db-pending`'s `:rf.event/db` tag"
+    (is (= {:base 2 :baseline 1}
+           (proj/db-pending-t1 [(db-pending-ev {:base 2 :baseline 1})])))
+    (is (nil? (proj/db-pending-t1 []))
+        "absent t1 → nil (caller falls back to record :db-after)"))
+  (testing "rf2-4wywy — t2 reader pulls the post-flow db off
+            `:rf.event/db-pending-post-flow`'s `:rf.event/db` tag"
+    (is (= {:base 2 :baseline 1 :derived 4}
+           (proj/db-pending-t2 [(db-pending-post-flow-ev {:base 2 :baseline 1 :derived 4})])))
+    (is (nil? (proj/db-pending-t2 []))
+        "absent t2 → nil (no flow changed :db this epoch)")))
+
+(deftest handler-step-db-reflects-post-handler-not-post-flow-test
+  (testing "rf2-4wywy ACCEPTANCE — the HANDLER step's `:db` reflects ONLY
+            the handler's change (post-handler / t1). The epoch record's
+            `:db-after` carries the FLOW-augmented `:derived` slot, but the
+            HANDLER step must NOT surface it — `:db-post-handler` (t1) is
+            the authoritative HANDLER `:db`."
+    (let [t1     {:base 2 :baseline 1 :derived 2}  ; post-handler: :base/:baseline bumped, :derived UNTOUCHED (still 2)
+          t2     {:base 2 :baseline 1 :derived 4}  ; post-flow: :derived recomputed 2 → 4
+          record {:event-id     :button-deck/increment-flow
+                  :db-before    {:base 1 :baseline 0 :derived 2}
+                  ;; the record's :db-after is the FINAL post-flow state
+                  :db-after     t2
+                  :trace-events [(dispatched-ev [:button-deck/increment-flow])
+                                 (db-pending-ev t1)
+                                 (flow-recomputed-ev :button-deck/derived [:derived] 2 4)
+                                 (db-pending-post-flow-ev t2)
+                                 (run-end-ev 0.3)]}
+          steps  (proj/project record)
+          h      (first (filter #(= :handler (:step %)) steps))]
+      (is (some? h) "HANDLER step present")
+      (is (= t1 (:db-post-handler h))
+          "HANDLER `:db-post-handler` is the t1 (post-handler / pre-flow) db")
+      (is (= 2 (:derived (:db-post-handler h)))
+          "the HANDLER step's :derived is the PRE-flow value (2), NOT the
+           flow's recomputed value (4) — the handler did not touch it")
+      ;; The flat-row `:db-diff` (non-view consumers) is computed against
+      ;; t1, so it shows ONLY the handler's path changes, no :derived.
+      (let [diff-paths (set (map first (:db-diff h)))]
+        (is (contains? diff-paths [:base])
+            ":db-diff carries the handler's :base bump")
+        (is (not (contains? diff-paths [:derived]))
+            ":db-diff must NOT carry the flow's :derived recompute — that
+             belongs to the FLOW step, not the HANDLER step")))))
+
+(deftest flow-step-carries-its-own-db-diff-snapshots-test
+  (testing "rf2-4wywy ACCEPTANCE — the FLOW step carries the t1 (pre-flow)
+            + t2 (post-flow) db snapshots so the view renders the flow's
+            OWN `:db` diff (`:derived` recomputed) separately from the
+            handler's change."
+    (let [t1     {:base 2 :baseline 1 :derived 2}  ; pre-flow: :derived still 2
+          t2     {:base 2 :baseline 1 :derived 4}  ; post-flow: :derived recomputed
+          record {:event-id     :button-deck/increment-flow
+                  :db-before    {:base 1 :baseline 0 :derived 2}
+                  :db-after     t2
+                  :trace-events [(dispatched-ev [:button-deck/increment-flow])
+                                 (db-pending-ev t1)
+                                 (flow-recomputed-ev :button-deck/derived [:derived] 2 4)
+                                 (db-pending-post-flow-ev t2)
+                                 (run-end-ev 0.3)]}
+          steps  (proj/project record)
+          flows  (filter #(= :flow (:step %)) steps)
+          f      (first flows)]
+      (is (= 1 (count flows)) "one FLOW step for the single recompute")
+      (is (= :button-deck/derived (:flow-id f)))
+      (is (= [:derived] (:path f)))
+      (is (= t1 (:db-pre-flow f))
+          "FLOW step carries t1 (pre-flow) so the view diff's `:before` =
+           the db BEFORE this flow's write")
+      (is (= t2 (:db-post-flow f))
+          "FLOW step carries t2 (post-flow) so the view diff's value =
+           the db WITH this flow's write")
+      ;; The t1→t2 reshape IS the flow's contribution: :derived 2 → 4.
+      (is (= 2 (:derived (:db-pre-flow f)))
+          "pre-flow db carries :derived at its PRE-recompute value (2)")
+      (is (= 4 (:derived (:db-post-flow f)))
+          "post-flow db carries :derived = 2 × :base = 4"))))
+
+(deftest handler-step-db-falls-back-to-record-when-no-t1-test
+  (testing "rf2-4wywy — graceful fallback: when no t1 fired (handler
+            returned no `:db`, or a pre-rf2-ta0y7 runtime) the HANDLER
+            step carries no `:db-post-handler`; the view falls back to
+            the record's `:db-after`. The flat `:db-diff` then reads the
+            db-before → db-after change (prior behaviour preserved)."
+    (let [record {:event-id     :legacy/no-t1
+                  :db-before    {:counter 1}
+                  :db-after     {:counter 2}
+                  :trace-events [(dispatched-ev [:legacy/no-t1])
+                                 (run-end-ev 0.2)]}
+          steps  (proj/project record)
+          h      (first (filter #(= :handler (:step %)) steps))]
+      (is (some? h))
+      (is (nil? (:db-post-handler h))
+          "no t1 on the stream → :db-post-handler absent")
+      (is (contains? (set (map first (:db-diff h))) [:counter])
+          "without t1 the :db-diff falls back to db-before → db-after"))))
+
+(deftest flow-step-falls-back-to-scalar-when-no-snapshots-test
+  (testing "rf2-4wywy — when no t1/t2 snapshots rode the stream (pre-
+            rf2-ta0y7 fixture) the FLOW step carries no `:db-pre-flow` /
+            `:db-post-flow`; the view renders the legacy scalar
+            before→after line. Projection-side: the slots are simply
+            absent."
+    (let [record {:event-id     :counter/inc
+                  :trace-events [(dispatched-ev [:counter/inc])
+                                 (flow-recomputed-ev :total-parity [:total] 5 6)]}
+          steps  (proj/project record)
+          f      (first (filter #(= :flow (:step %)) steps))]
+      (is (some? f))
+      (is (not (contains? f :db-pre-flow))
+          "no t1 → :db-pre-flow absent (view falls back to scalar line)")
+      (is (not (contains? f :db-post-flow))
+          "no t2 → :db-post-flow absent")
+      ;; the per-path scalar slots survive for the fallback rendering
+      (is (= [:total] (:path f)))
+      (is (= 5 (:before f)))
+      (is (= 6 (:after f))))))
 
 ;; ---- FX -----------------------------------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/real_substrate_projection_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/real_substrate_projection_cljs_test.cljs
@@ -39,6 +39,10 @@
   projection tests."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            ;; rf2-4wywy — load-time hook so `reg-flow` resolves + the
+            ;; flows `:after` interceptor (which stamps the t1/t2
+            ;; pending-`:db` trace pair) is wired into the router.
+            [re-frame.flows]
             [re-frame.frame :as frame]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
@@ -135,3 +139,71 @@
                substrate's `:rf.event/db-changed-paths` tag. If this
                fails after a substrate-side rename, the synth fixtures
                will still be green — pin the canonical names here."))))))
+
+;; ---- rf2-4wywy — live t1/t2 db attribution ------------------------------
+;;
+;; button-deck button 5 shape: a reg-event-db handler bumps `:base`; a
+;; reg-flow recomputes `:derived = 2 × :base` into app-db AFTER the
+;; handler. The fix relies on the router stamping `:rf.event/db-pending`
+;; (t1, post-handler/pre-flow) + `:rf.event/db-pending-post-flow` (t2,
+;; post-flow). This test forecloses drift: it drives the LIVE substrate +
+;; the LIVE flows `:after` interceptor, then asserts the projection lit up
+;; the handler-only db (t1) on the HANDLER step + the t1→t2 pair on the
+;; FLOW step. If a substrate-side rename drops the t1/t2 emit, the
+;; attribution collapses here against reality, not against a synth fixture.
+
+(defn- register-flow-bearing-handler! []
+  ;; :base ++ in the handler; the flow derives :derived = 2 × :base AFTER.
+  (rf/reg-event-db
+    :rf.tyivx/increment-flow
+    (fn [db _] (update db :base (fnil inc 0))))
+  (rf/reg-flow
+    {:id     :rf.tyivx/derived
+     :inputs [[:base]]
+     :output (fn [base] (* 2 (or base 0)))
+     :path   [:derived]}))
+
+(deftest real-substrate-emits-t1-t2-for-handler-vs-flow-attribution
+  (testing "rf2-4wywy — a LIVE flow-bearing cascade emits t1
+            (`:rf.event/db-pending`, post-handler) + t2
+            (`:rf.event/db-pending-post-flow`, post-flow). The
+            projection reads t1 onto the HANDLER step's
+            `:db-post-handler` (NO `:derived`) and the t1→t2 pair onto
+            the FLOW step's `:db-pre-flow` / `:db-post-flow` (`:derived`
+            recomputed). The two must not be conflated."
+    (setup!)
+    (register-flow-bearing-handler!)
+    ;; Seed :base so the flow has a defined input, then bump it.
+    (rf/dispatch-sync [:rf.tyivx/increment-flow]) ; primes :base = 1, :derived = 2
+    (trace-collector/reset-for-test!)
+    (rf/dispatch-sync [:rf.tyivx/increment-flow]) ; :base 1 → 2 ; flow :derived 2 → 4
+    (let [buf (vec (trace-collector/buffer-for-test))
+          op? (fn [op] (some #(= op (:operation %)) buf))]
+      (is (op? :rf.event/db-pending)
+          "substrate emitted t1 `:rf.event/db-pending` (post-handler)")
+      (is (op? :rf.event/db-pending-post-flow)
+          "substrate emitted t2 `:rf.event/db-pending-post-flow` (post-flow)")
+      (is (op? :rf.flow/computed)
+          "the flow recomputed → `:rf.flow/computed` emitted")
+      (let [record    {:epoch-id      2
+                       :event-id      :rf.tyivx/increment-flow
+                       :trigger-event [:rf.tyivx/increment-flow]
+                       :dispatch-id   2
+                       ;; the record's :db-after is the FINAL post-flow db
+                       :db-before     {:base 1 :derived 2}
+                       :db-after      {:base 2 :derived 4}
+                       :trace-events  buf}
+            projected (proj/project record)
+            h         (first (filter #(= :handler (:step %)) projected))
+            f         (first (filter #(= :flow (:step %)) projected))]
+        (is (some? h) "HANDLER step present")
+        (is (= {:base 2 :derived 2} (:db-post-handler h))
+            "HANDLER `:db-post-handler` (t1) = :base bumped, :derived STILL
+             the PRE-flow value (2) — the handler did not touch :derived")
+        (is (some? f) "FLOW step present")
+        (is (= :rf.tyivx/derived (:flow-id f)))
+        (is (= {:base 2 :derived 2} (:db-pre-flow f))
+            "FLOW `:db-pre-flow` (t1) lacks the flow's recompute")
+        (is (= {:base 2 :derived 4} (:db-post-flow f))
+            "FLOW `:db-post-flow` (t2) carries :derived = 2 × :base = 4 —
+             the flow's OWN contribution, separate from the handler")))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -600,6 +600,53 @@
           "no standalone :db diff under machine handlers — folded into
            SNAPSHOT DIFF per design"))))
 
+;; ---- FLOW step `:db` diff (rf2-4wywy) -----------------------------------
+
+(deftest flow-step-renders-db-diff-when-snapshots-present-test
+  (testing "rf2-4wywy — when the FLOW step carries the t1 (pre-flow) +
+            t2 (post-flow) db snapshots, its body renders the flow's OWN
+            `:db` diff via the shared edn-inspector diff renderer
+            (`rf-xray-epoch-flow-db-diff-<id>`), NOT the legacy scalar
+            before→after line. This is what keeps the flow's `:derived`
+            recompute SEPARATE from the HANDLER step's `:db`."
+    (frame/reg-frame :rf/xray {})
+    ;; testids embed `(name flow-id)` — `:button-deck/derived` → `derived`.
+    (let [tree (rf/with-frame :rf/xray
+                 (view/render-flow-step
+                   {:step :flow :badge :FLOW :step-number 4
+                    :flow-id :button-deck/derived
+                    :path [:derived] :before 2 :after 4
+                    :db-pre-flow  {:base 2 :baseline 1 :derived 2}
+                    :db-post-flow {:base 2 :baseline 1 :derived 4}}))]
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-flow-db-diff-derived"))
+          "FLOW step renders a `:db` diff sub-block when snapshots present")
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-flow-value-derived"))
+          "the legacy scalar before→after line is NOT rendered when the
+           `:db` diff is shown")
+      (is (= "true"
+             (-> tree (th/find-by-testid "rf-xray-epoch-step-flow-derived")
+                 second :data-rf-xray-flow-db-diff))
+          "the step root flags `:db`-diff mode for tooling / e2e"))))
+
+(deftest flow-step-falls-back-to-scalar-when-no-snapshots-test
+  (testing "rf2-4wywy — without t1/t2 snapshots (pre-rf2-ta0y7 runtime /
+            fixture) the FLOW step falls back to the legacy
+            `[path] before → after` scalar line so older epochs still
+            render."
+    (frame/reg-frame :rf/xray {})
+    (let [tree (rf/with-frame :rf/xray
+                 (view/render-flow-step
+                   {:step :flow :badge :FLOW :step-number 4
+                    :flow-id :total-parity
+                    :path [:total] :before 5 :after 6}))]
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-flow-value-total-parity"))
+          "the scalar before→after line renders on fallback")
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-flow-db-diff-total-parity"))
+          "no `:db` diff sub-block when snapshots are absent")
+      (is (= "false"
+             (-> tree (th/find-by-testid "rf-xray-epoch-step-flow-total-parity")
+                 second :data-rf-xray-flow-db-diff))))))
+
 (deftest handler-body-renders-source-placeholder-test
   (testing "rf2-66wis — HANDLER body carries a source-code slot.
             When no handler-meta has been stamped the slot renders

--- a/tools/xray/test/day8/re_frame2_xray/test_helpers/trace_event_builders.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/test_helpers/trace_event_builders.cljc
@@ -155,6 +155,26 @@
                              :rf.fx/args       args
                              :rf.fx/elapsed-ms duration-ms}))
 
+;; ---- pending-`:db` snapshots (t1 / t2) — rf2-ta0y7 / rf2-4wywy ----------
+
+(defn db-pending-ev
+  "`:rf.event/db-pending` trace (t1) — the POST-handler, PRE-flow db
+  value the handler chain returned, stamped under `:tags :rf.event/db`
+  (rf2-ta0y7). The Epoch HANDLER step's `:db` sub-section reads this
+  so it shows ONLY the handler's contribution, not the post-flow
+  state (rf2-4wywy)."
+  [db]
+  (ev :rf.event :rf.event/db-pending {:rf.event/db db}))
+
+(defn db-pending-post-flow-ev
+  "`:rf.event/db-pending-post-flow` trace (t2) — the POST-flow,
+  PRE-commit (flow-augmented) db value, stamped under
+  `:tags :rf.event/db` (rf2-ta0y7). OMITTED at the emit site when no
+  flow changed `:db` (t1 == t2). The Epoch FLOW step reads the t1→t2
+  pair to render the flow's OWN `:db` diff (rf2-4wywy)."
+  [db]
+  (ev :rf.event :rf.event/db-pending-post-flow {:rf.event/db db}))
+
 ;; ---- flows -------------------------------------------------------------
 
 (defn flow-recomputed-ev


### PR DESCRIPTION
## What

Fixes **rf2-4wywy** (P2 bug). The Epoch panel's HANDLER step `:db` rendered the epoch record's `:db-after` — the FINAL post-flow / post-commit state. Flows write app-db **after** the handler returns (at the outermost `:after` interceptor), so the HANDLER step conflated the handler's own change with any flow recompute that followed it.

**Reproduction (button-deck button 5, `:button-deck/increment-flow`):** the handler bumps `:base`; the `:button-deck/derived` flow then recomputes `:derived = 2 × :base` into app-db. Before this fix, the HANDLER step's `:db` showed the flow's `:derived` change as if the handler had made it.

## SETTLE-FIRST finding — data exists → panel fix (no core change)

The router already stamps the pending-`:db` pair on the trace stream (rf2-ta0y7), each carrying the full db under `:tags :rf.event/db`, and the epoch write keeps both on the record's `:trace-events`:

- **t1** `:rf.event/db-pending` — POST-handler-chain, PRE-flow (what the handler returned).
- **t2** `:rf.event/db-pending-post-flow` — POST-flow, PRE-commit (the flow-augmented value). Omitted when no flow changed `:db`.

So the **post-handler db is t1**, and the **flow's own contribution is the t1→t2 reshape**. This was confirmed against the live record + the substrate trace tests (`flows_t2_trace_test.clj`). **No core flow/epoch capture change was needed** — this is purely a `tools/xray` projection + view fix. (Stop-valve was NOT triggered.)

## Fix (`tools/xray`)

**Projection** (`panels/epoch/projection.cljc`):
- `db-pending-t1` / `db-pending-t2` readers off the trace stream.
- HANDLER row carries `:db-post-handler` (t1) and computes its flat `:db-diff` against t1.
- FLOW steps carry `:db-pre-flow` (t1) + `:db-post-flow` (t2).

**View** (`panels/epoch/view.cljs`):
- `handler-db-diff-block` renders t1 (post-handler), falling back to the record's `:db-after` when no t1 rode the stream (handler returned no `:db` / pre-rf2-ta0y7 runtime). Diff pre-image stays `:db-before`.
- `render-flow-step` renders the flow's **own `:db` diff** via the shared edn-inspector diff renderer (parity with the HANDLER `:db` sub-section + the App-DB Diff panel), scoped to the flow's `:path` (t1→t2). Falls back to the legacy `[path] before → after` scalar line when snapshots are absent.

## Before / after — handler-vs-flow db attribution (button 5)

`db-before = {:base 1 :derived 2 …}`, t1 `= {:base 2 :derived 2 …}`, t2 `= {:base 2 :derived 4 …}`.

| Step | Before (bug) | After (fix) |
|---|---|---|
| HANDLER `:db` | `:base` 1→2 **and** `:derived` 2→4 (post-flow `:db-after`) | `:base` 1→2 only (t1) — `:derived` shown at its **pre-flow** value, unchanged |
| FLOW `:db` | scalar `[:derived] 2 → 4` (read as a flow-internal value) | `:db` diff `~ [:derived] 2 → 4` (the flow's own app-db contribution, scoped to its path) |

The handler's and the flow's db changes are no longer conflated.

## Quality gates

All run from the worker worktree:

- **Xray JVM** (`clojure -M:test` in `tools/xray/`): **974 tests, 3833 assertions, 0 failures, 0 errors**.
- **CLJS node-test** (`npm run test:cljs`): **5034 tests, 16848 assertions, 0 failures, 0 errors** (covers the new `.cljs` view + live-substrate tests).
- **Xray feature-gate browser smoke** (`npm run test:xray-feature-gate:smoke`): **4 scenarios, 0 failures, 10 matrix rows**; all builds compiled 0 warnings.
- **clj-kondo** (`--fail-level error --lint tools/xray/src`): **0 errors** (the 64 warnings are pre-existing in unrelated files; none in the epoch panel).
- Epoch projection ns is `.cljc` and runs under the Xray JVM suite above, so no separate epoch-artefact run was needed (no `implementation/epoch` source was touched).

## Tests added

- Projection acceptance: HANDLER `:db` = handler-only (no `:derived`); FLOW step carries its t1/t2 pair; t1/t2 readers; graceful fallback when no snapshots.
- View: FLOW step renders the `:db` diff sub-block when snapshots present, falls back to the scalar line otherwise.
- Live-substrate: a real flow-bearing cascade emits t1/t2 that the projection attributes correctly to HANDLER (t1) vs FLOW (t1→t2).

## Spec

`tools/xray/spec/021-Dynamic-Panel-Designs.md`: §9.1.5.1 (HANDLER `:db` = post-handler t1, with fallback), §9.1.10.8 (FLOW step `:db` diff + fallback), and the diff-surface table updated.
