### PR TITLE
refactor(story): fold the assertions side-table into the tape; relocate Spec 009 privacy suppression to the egress layer (rf2-luzky)

### DIFF
--- a/tools/story/spec/001-Authoring.md
+++ b/tools/story/spec/001-Authoring.md
@@ -100,7 +100,7 @@ The auto-install hook is wired via the `re-frame.story.late-bind`
 shim (`:ensure-canonical-installed` key) to avoid a circular require
 between `re-frame.story.registrar` (consumer) and
 `re-frame.story.canonical` (producer). Same pattern Story uses for
-`:tap-stub-event` / `:drop-assertion-accumulators`.
+`:stub-observed-fx-ids` / `:drop-assertion-accumulators`.
 
 ## Mental model — the three pillars (rf2-kemcu + rf2-adtmk + rf2-x6u3l)
 

--- a/tools/story/spec/009-Test-Mode.md
+++ b/tools/story/spec/009-Test-Mode.md
@@ -482,9 +482,10 @@ threads the variant frame's epoch history (per
 `:epoch-stack`. Step-back POPS the stack and `epoch/restore-epoch`s
 against the new head, then decrements the cursor. Rewind restores
 against the bottom-of-stack epoch (the pre-play state) and resets
-the cursor to 0 plus clears the assertion accumulator (via
-`assertions/reset-trace-accumulators!`) so a fresh forward run
-doesn't pile new records on top of the old ones.
+the cursor to 0. That epoch-restore alone rewinds the frame's
+`[:rf.story/assertions]` slot (rf2-luzky — the assertions live in the
+frame's app-db, so a fresh forward run starts clean without a separate
+accumulator reset).
 
 Step-back never re-dispatches the popped event — that would create a
 fresh epoch and break the deterministic 1-to-1 cursor↔epoch mapping.

--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -1875,8 +1875,9 @@ the runner reads the retained tape via `re-frame.core/epoch-history` and
 merges the projection into the run-result. There is exactly one source of
 truth — Story UI, CI, docs, agents, and the golden/diff tools cannot
 disagree about what happened, and no parallel accumulator can drift from
-the tape evidence (the shipping per-frame `trace-accumulators` siphon for
-warnings/effects is superseded by this projection).
+the tape evidence (the former per-frame `trace-accumulators` siphon for
+warnings/effects was superseded by this projection and fully removed in
+rf2-luzky).
 
 `(story/project-evidence epoch-tape {:script coerced-script})` is pure —
 `:rf/epoch-record` vector in, evidence map out — so it runs under

--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -2925,8 +2925,12 @@ so the gate is not blinded by them:
 
 - **wall-clock timestamps** — `:committed-at` (epoch record), `:time`
   (trace event), `:elapsed-ms` (run / assertion record);
-- **elapsed durations** — `:elapsed-ms`, the `:rf.event/elapsed-ms` trace
-  tag;
+- **elapsed durations** — `:elapsed-ms`, and the dev-only handler
+  wall-clock trace tags `:rf.event/elapsed-ms` (event run),
+  `:rf.fx/elapsed-ms` (fx handler), and `:rf.cofx/elapsed-ms` (cofx
+  handler); two semantically-equal runs replayed into fresh frames measure
+  different handler durations (JIT / scheduling jitter), so all three are
+  stripped or a TIMED fx / cofx would false-drift the gate;
 - **generated dispatch ids** — `:dispatch-id`, the `:rf.trace/dispatch-id`
   trace tag;
 - **generated frame ids** — `:frame` (the fresh `:rf.test.replay/*` id),

--- a/tools/story/src/re_frame/story/assertions.cljc
+++ b/tools/story/src/re_frame/story/assertions.cljc
@@ -207,89 +207,29 @@
   (evidence/warnings (frame-tape frame-id)))
 
 ;; ---------------------------------------------------------------------------
-;; Per-frame trace side-table (privacy-gated) — NO LONGER THE EVIDENCE SOURCE
+;; Trace side-table — FULLY REMOVED (rf2-luzky)
 ;;
-;; rf2-q651r retired this atom AS THE EVIDENCE SOURCE for the three
-;; trace-bus assertions: they now project from the epoch tape (above), so
-;; there is no second evidence path that can drift into the documented
-;; "false GREEN". The atom is RETAINED — not removed — because three
-;; non-evidence consumers still drive it, and full removal would have to
-;; coordinate across lanes this change does not own:
+;; rf2-q651r retired the `trace-accumulators` atom AS THE EVIDENCE SOURCE
+;; for the three trace-bus assertions (they project from the epoch tape
+;; above); rf2-luzky removed the atom ENTIRELY. The facts it once mirrored
+;; (warnings / emitted-fx / dispatched) are answerable from the canonical
+;; tape + the stub-call log (the SSOT), so the parallel atom — and its
+;; `record-warning!` / `record-emitted-fx!` / `record-dispatched!` feeds +
+;; the `reset-trace-accumulators!` / `drop-trace-accumulators!` helpers —
+;; carried no fact the tape does not already hold. The three concerns that
+;; once rode through this module's listener feed now live where they belong:
 ;;
-;;   1. `re-frame.story.ui.test_mode.stepper-state` (a separate UI lane)
-;;      calls `reset-trace-accumulators!` when it rewinds a stepped run;
-;;   2. the per-frame trace listener in `re-frame.story.play` is the
-;;      load-bearing PRIVACY-suppression seam (Spec 009 §Privacy) — it
-;;      default-drops `:sensitive? true` events and bumps the UI redaction
-;;      counter; its suppression behaviour is pinned by
-;;      `sensitive-trace-cljs-test` against this side-table;
-;;   3. the `force-fx-stub` tap (`re-frame.story.fx-stubs/tap-stub-event!`)
-;;      records redirected fx-ids here for dev-tool surfacing.
-;;
-;; So the atom is a privacy-gated DEV side-table, decoupled from the
-;; assertion verdict. It is keyed by frame-id and reset at play start.
-;; (Follow-up: fully fold this side-table into the tape + stub-log once the
-;; UI stepper-rewind lane can be touched in the same change — rf2-q651r
-;; note.)
+;;   - PRIVACY suppression (default-drop `:sensitive? true` + the
+;;     `config/note-suppressed!` redaction-counter bump) is the egress seam
+;;     in `re-frame.story.play`'s per-frame trace listener — it was always
+;;     the gate at the head of that listener, never a property of this atom;
+;;   - the synchronous handler-exception capture is `re-frame.story.play`'s
+;;     `pending-exceptions` atom (likewise never this side-table);
+;;   - stub-redirected fx-ids are the stub-call log's
+;;     (`re-frame.story.fx-stubs/observed-fx-ids`, read via the
+;;     `:stub-observed-fx-ids` late-bind hook above) — the one fact the tape
+;;     cannot carry under the original id.
 ;; ---------------------------------------------------------------------------
-
-(def ^:private empty-frame-accumulators
-  {:warnings   []
-   :emitted-fx #{}
-   :dispatched []})
-
-(defonce
-  ^{:doc "frame-id → {:warnings [...] :emitted-fx #{...} :dispatched [...]}.
-         A privacy-gated DEV side-table (NOT the assertion evidence source
-         since rf2-q651r — the three trace-bus assertions project from the
-         epoch tape). The play-runner calls `reset-trace-accumulators!` at
-         play start and `drop-trace-accumulators!` at frame teardown."}
-  trace-accumulators
-  (atom {}))
-
-(defn reset-trace-accumulators!
-  "Clear every per-frame trace side-table entry for `frame-id`. The
-  play-runner + the UI stepper-rewind call this at play start. Production
-  callers (without config/enabled?) no-op."
-  [frame-id]
-  (when config/enabled?
-    (swap! trace-accumulators assoc frame-id empty-frame-accumulators))
-  nil)
-
-(defn drop-trace-accumulators!
-  "Discard the per-frame side-table entry. Called from frame teardown so
-  destroyed variants don't leak memory."
-  [frame-id]
-  (swap! trace-accumulators dissoc frame-id)
-  nil)
-
-(defn record-warning!
-  "Append a warning trace event to `frame-id`'s side-table (privacy seam +
-  dev surfacing; NOT the `:rf.assert/no-warnings` evidence source)."
-  [frame-id ev]
-  (when config/enabled?
-    (swap! trace-accumulators update-in [frame-id :warnings] (fnil conj []) ev))
-  nil)
-
-(defn record-emitted-fx!
-  "Add `fx-id` to `frame-id`'s side-table emitted-fx set (dev surfacing;
-  NOT the `:rf.assert/effect-emitted` evidence source)."
-  [frame-id fx-id]
-  (when config/enabled?
-    (swap! trace-accumulators update-in [frame-id :emitted-fx] (fnil conj #{}) fx-id))
-  nil)
-
-(defn record-dispatched!
-  "Append `event-vec` to `frame-id`'s side-table dispatched vector (dev
-  surfacing; NOT the `:rf.assert/dispatched?` evidence source)."
-  [frame-id event-vec]
-  (when config/enabled?
-    (swap! trace-accumulators update-in [frame-id :dispatched] (fnil conj []) event-vec))
-  nil)
-
-(defn frame-warnings   [frame-id] (get-in @trace-accumulators [frame-id :warnings]   []))
-(defn frame-fx         [frame-id] (get-in @trace-accumulators [frame-id :emitted-fx] #{}))
-(defn frame-dispatched [frame-id] (get-in @trace-accumulators [frame-id :dispatched] []))
 
 ;; ---------------------------------------------------------------------------
 ;; Programmatic record helper

--- a/tools/story/src/re_frame/story/canonical.cljc
+++ b/tools/story/src/re_frame/story/canonical.cljc
@@ -41,7 +41,6 @@
   assertion + play modules without a circular require. The hub lives in
   `re-frame.story.late-bind` (mirroring the framework's pattern)."
   []
-  (late-bind/set-fn! :tap-stub-event fx-stubs/tap-stub-event!)
   ;; rf2-q651r — `:rf.assert/effect-emitted` projects from the epoch tape,
   ;; but a STUBBED fx lands on the tape under its REWRITTEN stub id, not its
   ;; original id. The authoritative record of which ORIGINAL fx-ids a
@@ -49,9 +48,10 @@
   ;; assertions module reads it via this hook (it cannot `:require`
   ;; fx-stubs / frames without a cycle).
   (late-bind/set-fn! :stub-observed-fx-ids fx-stubs/observed-fx-ids)
+  ;; rf2-luzky — the assertions side-table is gone; only the play module's
+  ;; per-frame `pending-exceptions` slot needs frame-teardown eviction.
   (late-bind/set-fn! :drop-assertion-accumulators
     (fn [frame-id]
-      (assertions/drop-trace-accumulators! frame-id)
       (play/drop-pending-exceptions! frame-id))))
 
 #?(:cljs

--- a/tools/story/src/re_frame/story/fingerprint.cljc
+++ b/tools/story/src/re_frame/story/fingerprint.cljc
@@ -250,8 +250,25 @@
   `:frame` id and per-run id / timing counters here; the SEMANTIC tags
   (`:rf.trace/event-id`, `:rf.event/v` payload, `:rf.event/db` value) are
   NOT in this set, so a real behavioural difference still perturbs the
-  canonical value."
-  #{:frame :rf.trace/dispatch-id :rf.trace/trace-id :rf.event/elapsed-ms})
+  canonical value.
+
+  ## Per-run handler-timing stamps (the determinism strip)
+
+  `:rf.event/elapsed-ms` (event run), `:rf.fx/elapsed-ms` (fx handler), and
+  `:rf.cofx/elapsed-ms` (cofx handler) are the dev-only wall-clock durations
+  the framework stamps onto a `:rf.event/run-end` / `:rf.fx/handled` /
+  `:rf.cofx/run` trace event's `:tags` (Spec 009; emitted under
+  `interop/debug-enabled?`, DCE'd in production). They are pure per-RUN
+  timing jitter — two semantically-equal runs replayed into FRESH frames
+  measure DIFFERENT handler durations (e.g. 4ms vs 0ms under JIT / scheduling
+  noise), so they MUST be stripped or the determinism gate
+  (`re-frame.story.determinism/assert-deterministic`) false-drifts to
+  `:non-deterministic` whenever a replayed program runs a TIMED fx / cofx.
+  `:rf.event/elapsed-ms` was already stripped; `:rf.fx/elapsed-ms` and
+  `:rf.cofx/elapsed-ms` are its symmetric companions — all three are
+  handler wall-clock, none is behaviour."
+  #{:frame :rf.trace/dispatch-id :rf.trace/trace-id
+    :rf.event/elapsed-ms :rf.fx/elapsed-ms :rf.cofx/elapsed-ms})
 
 (defn- trace-event?
   "True iff `m` is a trace event (Spec 009 §Trace event shape): a map

--- a/tools/story/src/re_frame/story/frames.cljc
+++ b/tools/story/src/re_frame/story/frames.cljc
@@ -61,20 +61,16 @@
 ;; ---- fx-override-stub registration ---------------------------------------
 ;;
 ;; Cross-namespace forward references go through the
-;; `re-frame.story.late-bind` hub rather than per-shim atoms. Two hooks:
+;; `re-frame.story.late-bind` hub rather than per-shim atoms. One hook:
 ;;
-;;   :tap-stub-event              — fx-stubs binds this; the stub-event
-;;                                  handler calls it with `(frame-id
-;;                                  fx-id)` so the assertion module's
-;;                                  per-frame emitted-fx accumulator
-;;                                  records the call. Stage 3-only
-;;                                  builds leave it unset and the call
-;;                                  no-ops.
+;;   :drop-assertion-accumulators — play binds this; the frame-teardown
+;;                                  path calls it with `(frame-id)` so the
+;;                                  per-frame `pending-exceptions` slot
+;;                                  evicts its entry.
 ;;
-;;   :drop-assertion-accumulators — assertions+play bind this; the
-;;                                  frame-teardown path calls it with
-;;                                  `(frame-id)` so per-frame
-;;                                  accumulators evict their entries.
+;; (rf2-luzky removed the `:tap-stub-event` hook — the stub-call log below
+;; is already the SSOT for stub-redirected fx-ids, so the dev-mirror tap it
+;; drove is gone.)
 ;;
 ;; `re-frame.story/install-canonical-vocabulary!` is the producer side.
 
@@ -110,13 +106,11 @@
 
   Per spec/002 §Per-frame and per-call overrides the `:fx-overrides`
   map redirects `fx-id → fx-id`. So the stub MUST be a registered
-  `:fx` handler, not an event handler. The stub:
-
-  1. Taps `late-bind/get-fn :tap-stub-event` with `(frame fx-id)` so the assertion
-     module's emitted-fx accumulator records the call (so
-     `:rf.assert/effect-emitted` can observe it).
-  2. Appends the call to the per-frame `stub-call-log` atom for
-     inspection / dev-tool surfacing.
+  `:fx` handler, not an event handler. The stub appends the call to the
+  per-frame `stub-call-log` atom — the SSOT `observed-fx-ids` reads so
+  `:rf.assert/effect-emitted` can observe the original fx-id was emitted
+  (a stubbed fx lands on the epoch tape under its rewritten stub id, not
+  its original id).
 
   The fx handler runs synchronously inside re-frame's `do-fx` walk
   with signature `(ctx args)` per Spec 002 §Effect handlers; `ctx`
@@ -127,8 +121,6 @@
   (rf/reg-fx
     stub-id
     (fn [{:keys [frame] :as _ctx} fx-payload]
-      (when-let [tap (late-bind/get-fn :tap-stub-event)]
-        (try (tap frame fx-id) (catch #?(:clj Throwable :cljs :default) _ nil)))
       (swap! stub-call-log update frame (fnil conj [])
              {:stub-id  stub-id
               :fx-id    fx-id

--- a/tools/story/src/re_frame/story/fx_stubs.cljc
+++ b/tools/story/src/re_frame/story/fx_stubs.cljc
@@ -32,11 +32,11 @@
        variant frame's config so re-frame's router redirects any
        dispatch of `<fx-id>` to the stub event.
 
-  Stage 5 adds: per-frame trace-bus accumulator updates so
-  `:rf.assert/effect-emitted` can observe that the fx was emitted
-  *as if it had run*. The `force-fx-stub` decorator's stub event also
-  appends the fx-id to the frame's emitted-fx accumulator (see
-  `re-frame.story.assertions/record-emitted-fx!`).
+  The stub event appends the original `:fx-id` to the per-frame stub-call
+  log; `:rf.assert/effect-emitted` observes that the fx was emitted *as if
+  it had run* by reading that log via `observed-fx-ids` (the SSOT for
+  stub-redirected fx-ids — rf2-q651r / rf2-luzky), unioned with the epoch
+  tape's effects.
 
   ## Why a registered decorator and not a magic builtin
 
@@ -64,7 +64,6 @@
   decorator registration single-shot while allowing per-reference
   configuration."
   (:require [re-frame.core         :as rf]
-            [re-frame.story.assertions :as assertions]
             [re-frame.story.config :as config]
             [re-frame.story.frames :as frames]
             [re-frame.story.registrar :as registrar]))
@@ -155,29 +154,19 @@
     (set (keep :fx-id entries))))
 
 ;; ---------------------------------------------------------------------------
-;; Wire the stub-event log into the assertion trace side-table
+;; Stub-redirected fx-ids are the stub-call log's SSOT (rf2-q651r / rf2-luzky)
 ;;
 ;; The Stage 3 `frames/ensure-stub-event!` registers an fx handler under
 ;; `:rf.story.fx-stub/<decorator-id>` that appends to the per-frame
-;; stub-call log + calls `tap-stub-event!`.
+;; stub-call log. `:rf.assert/effect-emitted` projects from the epoch tape,
+;; but a STUBBED fx lands on the tape under its REWRITTEN stub id, not its
+;; original id — so the assertion's emitted-fx SSOT unions the tape effects
+;; with `observed-fx-ids` (the stub-call log read via the
+;; `:stub-observed-fx-ids` late-bind hook), the authoritative record of
+;; which ORIGINAL fx-ids were redirected.
 ;;
-;; rf2-q651r — `:rf.assert/effect-emitted` now projects from the epoch
-;; tape, but a STUBBED fx lands on the tape under its REWRITTEN stub id,
-;; not its original id. So the assertion's emitted-fx SSOT unions the tape
-;; effects with `observed-fx-ids` (read from the stub-call log, the
-;; authoritative record of which ORIGINAL fx-ids were redirected — see the
-;; `:stub-observed-fx-ids` late-bind hook). `tap-stub-event!` no longer
-;; feeds the effect-emitted evidence; it remains only for the dev-surface
-;; side-table mirror.
+;; rf2-luzky dropped the former `tap-stub-event!` dev-surface mirror (it fed
+;; the removed `trace-accumulators` side-table). The stub-call log
+;; `observed-fx-ids` reads is already the single source for stubbed fx, so
+;; the mirror carried no fact the SSOT does not already hold.
 ;; ---------------------------------------------------------------------------
-
-(defn tap-stub-event!
-  "Mirror that `fx-id` fired against `frame-id` into the assertion module's
-  trace side-table (dev surfacing). The frames runtime's
-  `ensure-stub-event!` calls this when the stub event handles a redirected
-  fx call. NOTE (rf2-q651r): this is NOT the `:rf.assert/effect-emitted`
-  evidence source — that projects from the epoch tape ∪ the stub-call log
-  (`observed-fx-ids`)."
-  [frame-id fx-id]
-  (assertions/record-emitted-fx! frame-id fx-id)
-  nil)

--- a/tools/story/src/re_frame/story/late_bind.cljc
+++ b/tools/story/src/re_frame/story/late_bind.cljc
@@ -16,13 +16,6 @@
 
   ## Hook keys
 
-  - `:tap-stub-event`              — fx-stubs → frames. Called on
-                                     every stub-event firing so the
-                                     assertion module's per-frame
-                                     emitted-fx side-table records
-                                     the call. Signature: `(f frame-id
-                                     fx-id) → nil`.
-
   - `:stub-observed-fx-ids`        — fx-stubs → assertions. Returns the
                                      set of ORIGINAL fx-ids a frame's
                                      `force-fx-stub` decorators redirected
@@ -35,10 +28,11 @@
                                      original). Signature: `(f frame-id) →
                                      #{fx-id …}`.
 
-  - `:drop-assertion-accumulators` — assertions+play → frames. Called
-                                     on frame teardown so per-frame
-                                     accumulators evict their entries.
-                                     Signature: `(f frame-id) → nil`.
+  - `:drop-assertion-accumulators` — play → frames. Called on frame
+                                     teardown so the play module's
+                                     per-frame `pending-exceptions` slot
+                                     evicts its entry. Signature:
+                                     `(f frame-id) → nil`.
 
   - `:render-host`                 — story (via the canonical
                                      `install-render-host!`) → render. The

--- a/tools/story/src/re_frame/story/play.cljc
+++ b/tools/story/src/re_frame/story/play.cljc
@@ -8,15 +8,19 @@
   execution itself lives in `re-frame.story.play.runner-events`.
 
   rf2-q651r: `:rf.assert/dispatched?` / `:rf.assert/effect-emitted` /
-  `:rf.assert/no-warnings` no longer read the trace side-table this
-  listener feeds — they PROJECT their fact from the epoch tape (the
+  `:rf.assert/no-warnings` PROJECT their fact from the epoch tape (the
   SSOT, `re-frame.story.assertions/dispatched-events` / `warnings` /
-  `emitted-fx`), the same source the run-result evidence slots read. The
-  listener is retained because it is the load-bearing PRIVACY-suppression
-  seam (Spec 009 §Privacy — default-dropping `:sensitive?` events + the
-  UI redaction counter) and the synchronous handler-exception capture
-  (`pending-exceptions`). The `trace-accumulators` side-table it still
-  writes is a privacy-gated DEV surface, decoupled from the verdict.
+  `emitted-fx`), the same source the run-result evidence slots read.
+
+  rf2-luzky: the per-frame listener's `trace-accumulators` dev-mirror feed
+  (the `record-warning!` / `record-emitted-fx!` / `record-dispatched!`
+  calls) is REMOVED along with the side-table itself — those facts are
+  answerable from the tape + stub-call log, so the mirror carried nothing
+  the SSOT does not. The listener is retained PURELY as the egress seam:
+  the load-bearing PRIVACY-suppression gate (Spec 009 §Privacy —
+  default-dropping `:sensitive?` events + the `config/note-suppressed!`
+  redaction counter) and the synchronous handler-exception capture
+  (`pending-exceptions`). It no longer touches any assertions accumulator.
 
   ## What this module does
 
@@ -29,23 +33,21 @@
   §2.3 the assertion never throws; the play sequence runs to completion
   regardless of which assertions fail.
 
-  ## Trace-bus side-table (privacy seam + dev surface)
+  ## Privacy egress seam (the per-frame trace listener)
 
   We register a per-frame trace listener at the start of the play
-  sequence. Its two LOAD-BEARING jobs:
+  sequence. Its two — and only — LOAD-BEARING jobs:
 
   - PRIVACY (Spec 009 §Privacy): default-drop `:sensitive? true` events
-    and bump the UI redaction counter (`config/note-suppressed!`);
+    BEFORE anything else and bump the UI redaction counter
+    (`config/note-suppressed!`);
   - synchronous handler-exception capture into `pending-exceptions`
     (drained into the assertions list between dispatches).
 
-  It ALSO mirrors `:warning` / `:rf.event/dispatched` / fx events into
-  the assertion module's `trace-accumulators` side-table for dev-tool
-  surfacing. rf2-q651r — that side-table is NO LONGER the evidence source
-  for `:rf.assert/no-warnings` / `:rf.assert/effect-emitted` /
-  `:rf.assert/dispatched?`: those project from the epoch tape (the SSOT).
-  The side-table clears at play-start and lives until frame teardown
-  (per `assertions/drop-trace-accumulators!`).
+  rf2-luzky removed this listener's former `trace-accumulators` dev-mirror
+  feed: `:rf.assert/no-warnings` / `:rf.assert/effect-emitted` /
+  `:rf.assert/dispatched?` project from the epoch tape + stub-call log (the
+  SSOT), so the parallel mirror was redundant.
 
   ## Async surface
 
@@ -80,11 +82,14 @@
             [re-frame.story.registrar  :as registrar]))
 
 ;; ---------------------------------------------------------------------------
-;; Per-frame trace listener
+;; Per-frame trace listener — the Spec 009 §Privacy egress seam
 ;;
 ;; One listener per variant frame. Filters trace events by `:frame`
-;; (per spec/009 §Dispatch correlation) and routes them into the
-;; assertion module's per-frame accumulators. Idempotent.
+;; (per spec/009 §Dispatch correlation) and (a) drops `:sensitive?`
+;; events + bumps the redaction counter, (b) captures synchronous
+;; handler-exceptions into `pending-exceptions`. Idempotent. It does NOT
+;; feed any assertions accumulator (rf2-luzky — the dev-mirror is gone;
+;; assertions project from the epoch tape + stub-call log).
 ;; ---------------------------------------------------------------------------
 
 (defn- listener-id [frame-id]
@@ -95,21 +100,6 @@
   ;; Per Spec 009 §Per-frame routing: the canonical tag key is :frame
   ;; (rf2-shaa1 dropped the :frame-id alias from impl emit sites).
   (get-in ev [:tags :frame]))
-
-;; rf2-ee38b.3: `:db` (and `:fx`) are framework fx-ids that nearly every
-;; handler emits — including the assertion handlers themselves. Recording
-;; them into the per-frame `:emitted-fx` accumulator made
-;; `[:rf.assert/effect-emitted :db]` vacuously always-true. We exclude
-;; the framework fx-ids so `:rf.assert/effect-emitted` reflects USER fx
-;; only. (`:fx`, the effect-vector aggregator, is similarly ubiquitous +
-;; not a meaningful assertion target.)
-(def ^:private framework-fx-ids
-  "Framework fx-ids excluded from the `:emitted-fx` accumulator."
-  #{:db :fx})
-
-(defn- framework-fx-id?
-  [fx-id]
-  (contains? framework-fx-ids fx-id))
 
 ;; Per-frame pending-exception accumulator. The listener captures
 ;; `:rf.error/handler-exception` synchronously (from inside the running
@@ -128,20 +118,32 @@
   (swap! pending-exceptions update frame-id (fnil conj []) ev))
 
 (defn- listener-for-frame
-  "Build the trace-event listener for `frame-id`. Routes each event
-  into the right accumulator. Skips events that don't target the
+  "Build the trace-event listener for `frame-id` — the Spec 009 §Privacy
+  egress seam for the play-runner. Skips events that don't target the
   frame so cross-frame traffic (e.g. the default frame's lifecycle
-  events) stays out of the variant's accumulators.
+  events) stays out of this frame's egress path.
 
   Listener executes INSIDE the running dispatch drain, so it never
   re-enters dispatch-sync — it stores side-effects in atoms and lets
   the play-runner drain them between events.
 
-  Per Spec 009 §Privacy + rf2-bclgj: events whose `:sensitive?` flag
-  is true are dropped before any accumulator updates when the global
-  `:rf.privacy/show-sensitive?` flag is false (the default). The
-  suppressed-events counter bumps for the targeted frame so the UI
-  can surface a `[● REDACTED]` hint."
+  Two LOAD-BEARING jobs (rf2-luzky — the `trace-accumulators` dev mirror
+  this listener once also fed is removed; warnings / fx / dispatched are
+  answered from the epoch tape + stub-call log, the SSOT):
+
+  1. PRIVACY (Spec 009 §Privacy + rf2-bclgj): events whose `:sensitive?`
+     flag is true are DROPPED here when the global
+     `:rf.privacy/show-sensitive?` flag is false (the default). The
+     suppressed-events counter bumps (`config/note-suppressed!`) for the
+     targeted frame so the UI can surface a `[● REDACTED]` hint. This is
+     the egress gate — it runs BEFORE the listener does anything else, so
+     a sensitive event never reaches the exception capture below.
+
+  2. Synchronous handler-exception capture: a non-suppressed
+     `:rf.error/handler-exception` event is stashed into
+     `pending-exceptions`, which the play-runner drains AFTER each
+     dispatch-sync settles (so it can record an assertion via
+     dispatch-sync without re-entering the in-flight drain)."
   [frame-id]
   (fn [ev]
     (when (= frame-id (frame-of ev))
@@ -149,27 +151,11 @@
         (config/suppress-sensitive? ev)
         (config/note-suppressed! frame-id)
 
-        :else
-        (case (:op-type ev)
-          :warning      (assertions/record-warning! frame-id ev)
-          :error        (do (assertions/record-warning! frame-id ev)
-                            (when (= :rf.error/handler-exception (:operation ev))
-                              (record-pending-exception! frame-id ev)))
-          :rf.event     (when (= :rf.event/dispatched (:operation ev))
-                          (let [event-vec (get-in ev [:tags :rf.event/v])]
-                            (when (and event-vec
-                                       (not (assertions/assertion-event? event-vec)))
-                              (assertions/record-dispatched! frame-id event-vec))))
-          :rf.fx        (case (:operation ev)
-                          :rf.fx/do-fx (let [fx-map (get-in ev [:tags :rf.event/fx])]
-                                         (when (map? fx-map)
-                                           (doseq [fx-id (keys fx-map)
-                                                   :when (not (framework-fx-id? fx-id))]
-                                             (assertions/record-emitted-fx! frame-id fx-id))))
-                          (let [fx-id (get-in ev [:tags :rf.fx/id])]
-                            (when (and fx-id (not (framework-fx-id? fx-id)))
-                              (assertions/record-emitted-fx! frame-id fx-id))))
-          nil)))))
+        (and (= :error (:op-type ev))
+             (= :rf.error/handler-exception (:operation ev)))
+        (record-pending-exception! frame-id ev)
+
+        :else nil))))
 
 (defn drain-pending-exceptions!
   "Append any pending exception trace events from `frame-id` as
@@ -206,9 +192,9 @@
       (swap! pending-exceptions assoc frame-id []))))
 
 (defn install-trace-listener!
-  "Register a per-frame trace listener that feeds the assertion module's
-  accumulators. Idempotent — re-registering replaces. Returns the
-  listener id."
+  "Register the per-frame privacy egress seam (the trace listener that
+  default-drops `:sensitive?` events + captures handler-exceptions).
+  Idempotent — re-registering replaces. Returns the listener id."
   [frame-id]
   (when config/enabled?
     (let [id (listener-id frame-id)]
@@ -305,7 +291,6 @@
      (async/promise
        (fn [resolve]
          (try
-           (assertions/reset-trace-accumulators! variant-id)
            (swap! pending-exceptions assoc variant-id [])
            (when install-listener?
              (install-trace-listener! variant-id))
@@ -388,7 +373,7 @@
   the dispatch-bearing events."
   [frame-id]
   (when config/enabled?
-    (assertions/reset-trace-accumulators! frame-id)
+    (swap! pending-exceptions assoc frame-id [])
     (install-trace-listener! frame-id)
     (swap! stepper-state assoc frame-id
            {:remaining (variant-play-steps frame-id)

--- a/tools/story/src/re_frame/story/play/evidence.cljc
+++ b/tools/story/src/re_frame/story/play/evidence.cljc
@@ -11,10 +11,11 @@
   storage / source of truth is ONE tape so Story UI, CI, docs, agents, and
   the future golden/diff tools cannot disagree about what happened. Before
   this ns, schema failures, warnings, and effects were captured into a
-  parallel per-frame accumulator (`re-frame.story.assertions`'
-  `trace-accumulators`), which can drift from the trace evidence the Xray
-  UI already reads — a second capture path that could report green while
-  the tape shows a failure (the documented \"false GREEN\").
+  parallel per-frame accumulator (the former `re-frame.story.assertions`
+  `trace-accumulators` side-table, removed in rf2-luzky), which could drift
+  from the trace evidence the Xray UI already reads — a second capture path
+  that could report green while the tape showed a failure (the documented
+  \"false GREEN\").
 
   This ns makes the epoch tape the evidence boundary. Given the vector of
   `:rf/epoch-record` maps the framework retains for a frame
@@ -186,11 +187,11 @@
 ;;
 ;; A warning is any trace event whose `:op-type` is `:warning` (Spec 009
 ;; §Trace event shape / §Op-type vocabulary — `:warning`, NOT `:warn`; the
-;; same stream `re-frame.story.assertions`' `record-warning!` accumulator
-;; used to siphon — that siphon keys off `:op-type :warning`
-;; (`re-frame.story.play.cljc`), and every framework emit site uses
-;; `(trace/emit! :warning …)`, now projected from the retained tape
-;; instead). `:rf.assert/no-warnings` reads this projection.
+;; same stream the former `re-frame.story.assertions` `record-warning!`
+;; side-table feed used to siphon — that siphon keyed off `:op-type
+;; :warning`, and every framework emit site uses `(trace/emit! :warning …)`.
+;; rf2-luzky removed the side-table; this is now the only projection, read
+;; by `:rf.assert/no-warnings`).
 
 (def warning-operation
   "The trace `:op-type` that marks a warning severity. Spec 009 §Trace event

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -714,19 +714,20 @@
 
 (defn- run-phase-0!
   "Phase 0: allocate the variant frame with its decorator stack, then
-  install the play-runner's trace listener.
+  install the play-runner's privacy egress listener.
 
   The listener install order matters (rf2-v2g9): it must be in place
-  BEFORE phase-1 loaders fire so the assertions module's dispatched-
-  events accumulator captures loader-phase events. `:loaders-complete-
-  when`'s vector form consults that accumulator to gate the loaders-
-  complete transition; an empty accumulator during loaders would never
-  match. We seed the accumulators here so the listener has a clean
-  slot; `execute-play!` resets them again at play start so play-time
-  assertion semantics (\"during play\") are preserved."
+  BEFORE phase-1 loaders fire so the privacy gate suppresses sensitive
+  loader-phase events and loader-phase handler-exceptions are captured.
+  We clear the per-frame `pending-exceptions` slot so the listener has a
+  clean slot; `execute-play!` clears it again at play start.
+
+  rf2-luzky: the `:loaders-complete-when` vector form now reads the epoch
+  tape (`assertions/dispatched-events`, the SSOT) rather than a side-table
+  accumulator, so there is no accumulator to seed here."
   [{:keys [variant-id decorator-stack] :as ctx}]
   (frames/allocate! variant-id decorator-stack)
-  (assertions/reset-trace-accumulators! variant-id)
+  (swap! play/pending-exceptions assoc variant-id [])
   (play/install-trace-listener! variant-id)
   ctx)
 
@@ -1196,15 +1197,16 @@
 
 (defn- run-inline-phase-0!
   "Phase 0 for an inline run: allocate the ANONYMOUS frame from the plan
-  (registry-free), then seed the assertion accumulators + install the
-  play-runner trace listener — the same ordering `run-phase-0!` uses so
-  loader-phase events are captured."
+  (registry-free), then clear the per-frame `pending-exceptions` slot +
+  install the play-runner privacy egress listener — the same ordering
+  `run-phase-0!` uses so loader-phase events are captured (rf2-luzky: no
+  side-table to seed)."
   [{:keys [variant-id plan decorator-stack] :as ctx}]
   (frames/allocate-inline! variant-id
                            decorator-stack
                            (get-in plan [:world :frame :fx-overrides])
                            (inline-events-only? plan decorator-stack))
-  (assertions/reset-trace-accumulators! variant-id)
+  (swap! play/pending-exceptions assoc variant-id [])
   (play/install-trace-listener! variant-id)
   ctx)
 

--- a/tools/story/src/re_frame/story/ui/test_mode/stepper_state.cljs
+++ b/tools/story/src/re_frame/story/ui/test_mode/stepper_state.cljs
@@ -53,7 +53,6 @@
             [re-frame.core                                :as rf]
             [re-frame.story.play                          :as play]
             [re-frame.story.runtime                       :as runtime]
-            [re-frame.story.assertions                    :as assertions]
             [re-frame.story.ui.test-mode.stepper-pure     :as stepper-pure]))
 
 ;; ---- ratom ---------------------------------------------------------------
@@ -204,9 +203,10 @@
             seed  (first stack)]
         (when seed
           (rf/restore-epoch variant-id seed))
-        ;; Also reset the assertion accumulator so a fresh forward run
-        ;; doesn't pile new records on top of the old ones.
-        (assertions/reset-trace-accumulators! variant-id)
+        ;; rf2-luzky — the assertions side-table is gone; restoring the
+        ;; pre-play epoch above already rewinds `[:rf.story/assertions]`
+        ;; (it lives in the frame's app-db), so a fresh forward run starts
+        ;; clean without an explicit accumulator reset.
         ;; Reset the substrate's run cursor (every step back to pending)
         ;; so the rewound stepper re-runs the whole script cleanly.
         (play/stepper-rewind! variant-id)

--- a/tools/story/test/re_frame/story/assertion_redaction_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/assertion_redaction_cljs_test.cljs
@@ -30,7 +30,6 @@
             [re-frame.registrar        :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.story            :as story]
-            [re-frame.story.assertions :as assertions]
             [re-frame.story.async      :as async-lib]
             [re-frame.story.loaders    :as loaders]
             [re-frame.story.ui.state   :as state]))
@@ -48,7 +47,6 @@
                 (get-in db [:rf/runtime :machines :snapshots machine-id])))
   (machines/reset-timers!)
   (loaders/clear-watchers!)
-  (reset! assertions/trace-accumulators {})
   (state/reset-shell-state!)
   (story/install-canonical-vocabulary!)
   (frame/ensure-default-frame!))

--- a/tools/story/test/re_frame/story/inline_plan_test.clj
+++ b/tools/story/test/re_frame/story/inline_plan_test.clj
@@ -28,7 +28,6 @@
             [re-frame.registrar :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.story     :as story]
-            [re-frame.story.assertions :as assertions]
             [re-frame.story.frames :as frames]
             [re-frame.story.play.runner-events :as re]))
 
@@ -38,7 +37,6 @@
   (reset! frame/frames {})
   (try (rf/init! plain-atom/adapter)
        (catch clojure.lang.ExceptionInfo _ nil))
-  (reset! assertions/trace-accumulators {})
   (reset! re/run-state {})
   (story/install-canonical-vocabulary!)
   (frame/ensure-default-frame!)

--- a/tools/story/test/re_frame/story/play/runner_events_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/play/runner_events_cljs_test.cljc
@@ -20,7 +20,6 @@
             [re-frame.core              :as rf]
             [re-frame.frame             :as frame]
             [re-frame.story             :as story]
-            [re-frame.story.assertions  :as assertions]
             [re-frame.story.loaders     :as loaders]
             [re-frame.story.play        :as legacy-play]
             [re-frame.story.play.runner-events :as re]
@@ -76,7 +75,6 @@
   (machines/reset-timers!)
   (loaders/clear-watchers!)
   #?(:clj (config/set-global-args! {}))
-  (reset! assertions/trace-accumulators {})
   (reset! legacy-play/stepper-state {})
   (reset! re/run-state {})
   (story/install-canonical-vocabulary!)

--- a/tools/story/test/re_frame/story/play/step_runner_test.cljc
+++ b/tools/story/test/re_frame/story/play/step_runner_test.cljc
@@ -28,7 +28,6 @@
             [re-frame.registrar         :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.story             :as story]
-            [re-frame.story.assertions  :as assertions]
             [re-frame.story.plan        :as plan]
             [re-frame.story.play.runner :as runner]
             [re-frame.story.play.runner-events :as re]
@@ -205,7 +204,6 @@
   (reset! frame/frames {})
   (try (rf/init! plain-atom/adapter)
        (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) _ nil))
-  (reset! assertions/trace-accumulators {})
   (reset! re/run-state {})
   ;; The canonical `:rf.assert/*` handlers must be installed so an
   ;; `[:assert …]` checkpoint's dispatched atom records onto the slot.

--- a/tools/story/test/re_frame/story/render_test.cljc
+++ b/tools/story/test/re_frame/story/render_test.cljc
@@ -21,7 +21,7 @@
 ;; ---- fixtures ------------------------------------------------------------
 ;;
 ;; The host-render hook is a process-global late-bind slot shared with the
-;; canonical-vocabulary shims (`:tap-stub-event`, `:drop-assertion-
+;; canonical-vocabulary shims (`:stub-observed-fx-ids`, `:drop-assertion-
 ;; accumulators`). We MUST NOT `late-bind/clear!` (that wipes those shims +
 ;; breaks every sibling test ns). Instead we snapshot the hooks map before
 ;; each test (so a stray `:render-host` from a prior test is gone) and

--- a/tools/story/test/re_frame/story/runtime_db_seed_test.clj
+++ b/tools/story/test/re_frame/story/runtime_db_seed_test.clj
@@ -34,8 +34,7 @@
             [re-frame.late-bind :as late-bind]
             [re-frame.registrar :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story     :as story]
-            [re-frame.story.assertions :as assertions]))
+            [re-frame.story     :as story]))
 
 ;; ---- a host-free stand-in for the schemas artefact's late-bind seam ------
 ;;
@@ -70,7 +69,6 @@
   (reset! frame-schemas {})
   (try (rf/init! plain-atom/adapter)
        (catch clojure.lang.ExceptionInfo _ nil))
-  (reset! assertions/trace-accumulators {})
   ;; Clear any schema seam a prior test left so the no-validator floor case
   ;; is clean; tests that want validation install it explicitly.
   (uninstall-schema-seam!)

--- a/tools/story/test/re_frame/story/runtime_runpath_test.clj
+++ b/tools/story/test/re_frame/story/runtime_runpath_test.clj
@@ -30,7 +30,6 @@
             [re-frame.registrar :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.story     :as story]
-            [re-frame.story.assertions :as assertions]
             [re-frame.story.late-bind  :as late-bind]))
 
 (defn- reset-rf! [test-fn]
@@ -39,7 +38,6 @@
   (reset! frame/frames {})
   (try (rf/init! plain-atom/adapter)
        (catch clojure.lang.ExceptionInfo _ nil))
-  (reset! assertions/trace-accumulators {})
   ;; Drop any stray :render-hiccup host from a prior test (the run-path
   ;; a11y-structural tier-proof seam) so the no-host :cannot-run case is clean.
   (swap! late-bind/hooks dissoc :render-hiccup)

--- a/tools/story/test/re_frame/story/sensitive_trace_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/sensitive_trace_cljs_test.cljc
@@ -15,9 +15,10 @@
     against the `show-sensitive?` flag.
   - **`configure!`**: the `:rf.privacy/show-sensitive?` opts key wires
     through to the config atom.
-  - **Play listener**: the per-frame trace listener default-suppresses
-    sensitive events from the assertions module's accumulators
-    (warnings, dispatched-events, emitted-fx).
+  - **Play listener**: the per-frame trace listener (the Spec 009 privacy
+    egress seam, rf2-luzky) default-drops sensitive events at the gate
+    (bumping the redaction counter) before its handler-exception capture
+    runs.
   - **Recorder listener**: a sensitive event does not land in the
     recorder's captured-events vector.
 
@@ -29,7 +30,6 @@
   redaction indicator is verified by the CLJS ui-cljs test arm."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.story            :as story]
-            [re-frame.story.assertions :as assertions]
             [re-frame.story.config     :as config]
             [re-frame.story.play       :as play]
             [re-frame.story.recorder   :as recorder]))
@@ -91,6 +91,22 @@
    :sensitive? true
    :tags       {:rf.trace/dispatch-id 3
                 :frame                frame-id}})
+
+(defn- handler-exception-event
+  "Build a `:rf.error/handler-exception` trace event for `frame-id`. The
+  play-listener's surviving non-privacy job is to capture these into
+  `play/pending-exceptions`. `sensitive?` flags whether the privacy gate
+  should drop it before capture."
+  [frame-id sensitive?]
+  (cond-> {:op-type   :error
+           :operation :rf.error/handler-exception
+           :id        4
+           :time      1700000000030
+           :tags      {:rf.trace/dispatch-id 4
+                       :frame                frame-id
+                       :event                [:auth/login]
+                       :exception-message    "boom"}}
+    sensitive? (assoc :sensitive? true)))
 
 ;; ---------------------------------------------------------------------------
 ;; Pure config helpers
@@ -186,65 +202,95 @@
   (is (zero? (config/suppressed-count :story.a/b))))
 
 ;; ---------------------------------------------------------------------------
-;; Play listener — accumulator routing default-suppresses
+;; Play listener — the Spec 009 §Privacy egress seam (rf2-luzky)
+;;
+;; rf2-luzky folded the `trace-accumulators` dev side-table away; the
+;; play-listener's surviving jobs are the PRIVACY gate (default-drop
+;; `:sensitive?` + bump `config/note-suppressed!`) and the synchronous
+;; handler-exception capture into `play/pending-exceptions`. These tests
+;; pin the privacy INVARIANT directly against those observable outputs —
+;; not via the removed side-table accessors:
+;;
+;;   - a SENSITIVE event is dropped at the gate (the suppressed-events
+;;     counter bumps; the exception capture never sees it);
+;;   - a NON-sensitive event passes the gate (the counter stays zero; a
+;;     handler-exception reaches `pending-exceptions`);
+;;   - with `show-sensitive?` true the gate is open (a sensitive event is
+;;     NOT dropped and the counter stays zero).
+;;
+;; The listener is private; invoke the fn the `listener-for-frame` builder
+;; returns directly with synthetic events (the global trace bus spans the
+;; whole process).
 ;; ---------------------------------------------------------------------------
 
+(defn- pending-for [frame-id]
+  (get @play/pending-exceptions frame-id []))
+
 (deftest play-listener-suppresses-sensitive-warnings
-  (testing "by default a :sensitive? warning event doesn't reach the warnings accumulator"
+  (testing "by default a :sensitive? warning event is dropped at the privacy gate"
     (let [frame-id :story.sensitive/v
           build    @#'play/listener-for-frame
           listen   (build frame-id)
           ev       (sensitive-warning-event frame-id)]
-      ;; Reset the accumulators per the play-runner's contract.
-      (assertions/reset-trace-accumulators! frame-id)
-      ;; The listener is the fn returned by the (private)
-      ;; `listener-for-frame` builder; rather than emitting through
-      ;; the global trace bus (which spans the whole process), invoke
-      ;; the per-frame listener directly with our synthetic event.
+      (swap! play/pending-exceptions assoc frame-id [])
       (listen ev)
-      (is (empty? (assertions/frame-warnings frame-id))
-          "the warnings accumulator should be empty — the sensitive event was suppressed")
+      (is (empty? (pending-for frame-id))
+          "the sensitive warning never reached the listener body")
       (is (pos? (config/suppressed-count frame-id))
-          "the suppressed-events counter should have bumped"))))
+          "the suppressed-events counter bumped — the redaction hint stays accurate"))))
 
-(deftest play-listener-suppresses-sensitive-dispatched
-  (testing "by default a :sensitive? :rf.event/dispatched is dropped from the dispatched accumulator"
+(deftest play-listener-suppresses-sensitive-handler-exception
+  (testing "by default a :sensitive? handler-exception is dropped before capture"
     (let [frame-id :story.sensitive/v
           build    @#'play/listener-for-frame
           listen   (build frame-id)
-          ev       (sensitive-dispatch-event frame-id [:auth/login {:user "a"
-                                                                    :password "pw"}])]
-      (assertions/reset-trace-accumulators! frame-id)
+          ev       (handler-exception-event frame-id true)]
+      (swap! play/pending-exceptions assoc frame-id [])
       (listen ev)
-      (is (empty? (assertions/frame-dispatched frame-id))
-          "the dispatched-events accumulator stays empty")
-      (is (pos? (config/suppressed-count frame-id))))))
+      (is (empty? (pending-for frame-id))
+          "the sensitive handler-exception never reached pending-exceptions")
+      (is (pos? (config/suppressed-count frame-id))
+          "the suppressed-events counter bumped"))))
 
 (deftest play-listener-passes-sensitive-when-opted-in
-  (testing "with show-sensitive? true the listener routes sensitive events normally"
+  (testing "with show-sensitive? true the gate is open — a sensitive handler-exception is captured"
     (config/set-show-sensitive! true)
     (let [frame-id :story.sensitive/v
           build    @#'play/listener-for-frame
           listen   (build frame-id)
-          ev       (sensitive-dispatch-event frame-id [:auth/login {:user "a"}])]
-      (assertions/reset-trace-accumulators! frame-id)
+          ev       (handler-exception-event frame-id true)]
+      (swap! play/pending-exceptions assoc frame-id [])
       (listen ev)
-      (is (seq (assertions/frame-dispatched frame-id))
-          "the dispatched-events accumulator captured the event")
+      (is (= 1 (count (pending-for frame-id)))
+          "the sensitive handler-exception was captured (the gate is open)")
       (is (zero? (config/suppressed-count frame-id))
           "the suppressed-events counter stays at zero"))))
 
-(deftest play-listener-still-records-non-sensitive
-  (testing "regression: non-sensitive events flow through both default and opt-in modes"
+(deftest play-listener-captures-non-sensitive-handler-exception
+  (testing "regression: a non-sensitive handler-exception is captured under default settings"
+    (let [frame-id :story.regression/v
+          build    @#'play/listener-for-frame
+          listen   (build frame-id)
+          ev       (handler-exception-event frame-id false)]
+      (swap! play/pending-exceptions assoc frame-id [])
+      (listen ev)
+      (is (= 1 (count (pending-for frame-id)))
+          "the non-sensitive handler-exception landed in pending-exceptions")
+      (is (zero? (config/suppressed-count frame-id))
+          "no suppression — the counter stays at zero"))))
+
+(deftest play-listener-ignores-non-sensitive-non-error
+  (testing "a plain dispatched event is neither suppressed nor captured (no side-table to feed)"
     (let [frame-id :story.regression/v
           build    @#'play/listener-for-frame
           listen   (build frame-id)
           ev       (plain-dispatch-event frame-id [:counter/inc])]
-      (assertions/reset-trace-accumulators! frame-id)
+      (swap! play/pending-exceptions assoc frame-id [])
       (listen ev)
-      (is (= [[:counter/inc]] (assertions/frame-dispatched frame-id))
-          "non-sensitive event landed in the accumulator under default settings")
-      (is (zero? (config/suppressed-count frame-id))))))
+      (is (empty? (pending-for frame-id))
+          "a dispatched event is not a handler-exception — nothing captured")
+      (is (zero? (config/suppressed-count frame-id))
+          "non-sensitive — no suppression"))))
 
 ;; ---------------------------------------------------------------------------
 ;; Recorder listener — sensitive events skipped

--- a/tools/story/test/re_frame/story/story_is_test.clj
+++ b/tools/story/test/re_frame/story/story_is_test.clj
@@ -19,7 +19,6 @@
             [re-frame.registrar :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.story     :as story]
-            [re-frame.story.assertions :as assertions]
             [re-frame.story.play.runner-events :as re]))
 
 (defn- reset-rf! [test-fn]
@@ -28,7 +27,6 @@
   (reset! frame/frames {})
   (try (rf/init! plain-atom/adapter)
        (catch clojure.lang.ExceptionInfo _ nil))
-  (reset! assertions/trace-accumulators {})
   (reset! re/run-state {})
   (story/install-canonical-vocabulary!)
   (frame/ensure-default-frame!)

--- a/tools/story/test/re_frame/story/ui/docs_markdown_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/docs_markdown_cljs_test.cljs
@@ -15,7 +15,6 @@
             [re-frame.registrar        :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.story            :as story]
-            [re-frame.story.assertions :as assertions]
             [re-frame.story.loaders    :as loaders]
             [re-frame.story.ui.docs    :as docs]
             [re-frame.story.ui.markdown :as md]
@@ -34,7 +33,6 @@
                 (get-in db [:rf/runtime :machines :snapshots machine-id])))
   (machines/reset-timers!)
   (loaders/clear-watchers!)
-  (reset! assertions/trace-accumulators {})
   (state/reset-shell-state!)
   (story/install-canonical-vocabulary!)
   (frame/ensure-default-frame!))

--- a/tools/story/test/re_frame/story/ui/docs_mode_pane_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/docs_mode_pane_cljs_test.cljs
@@ -33,7 +33,6 @@
             [re-frame.registrar        :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.story            :as story]
-            [re-frame.story.assertions :as assertions]
             [re-frame.story.loaders    :as loaders]
             [re-frame.story.predicates :as pred]
             [re-frame.story.ui.docs    :as docs]
@@ -53,7 +52,6 @@
                 (get-in db [:rf/runtime :machines :snapshots machine-id])))
   (machines/reset-timers!)
   (loaders/clear-watchers!)
-  (reset! assertions/trace-accumulators {})
   (state/reset-shell-state!)
   (story/install-canonical-vocabulary!)
   (frame/ensure-default-frame!))

--- a/tools/story/test/re_frame/story/ui/docs_rollup_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/docs_rollup_cljs_test.cljs
@@ -25,7 +25,6 @@
             [re-frame.registrar        :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.story            :as story]
-            [re-frame.story.assertions :as assertions]
             [re-frame.story.loaders    :as loaders]
             [re-frame.story.ui.docs    :as docs]
             [re-frame.story.ui.state   :as state]
@@ -44,7 +43,6 @@
                 (get-in db [:rf/runtime :machines :snapshots machine-id])))
   (machines/reset-timers!)
   (loaders/clear-watchers!)
-  (reset! assertions/trace-accumulators {})
   (state/reset-shell-state!)
   (story/install-canonical-vocabulary!)
   (frame/ensure-default-frame!))

--- a/tools/story/test/re_frame/story/ui/render_shell_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/render_shell_cljs_test.cljs
@@ -42,7 +42,6 @@
             [re-frame.registrar        :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.story            :as story]
-            [re-frame.story.assertions :as assertions]
             [re-frame.story.loaders    :as loaders]
             [re-frame.story.plan       :as plan]
             [re-frame.story.render     :as render]
@@ -64,7 +63,6 @@
                 (get-in db [:rf/runtime :machines :snapshots machine-id])))
   (machines/reset-timers!)
   (loaders/clear-watchers!)
-  (reset! assertions/trace-accumulators {})
   (state/reset-shell-state!)
   (story/install-canonical-vocabulary!)
   (frame/ensure-default-frame!))

--- a/tools/story/test/re_frame/story/ui/test_mode/stepper_state_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/test_mode/stepper_state_cljs_test.cljs
@@ -136,8 +136,7 @@
   (testing "rewind! restores against the bottom-of-stack epoch and zeros
             cursor"
     (let [vid      :story.unit/rewind
-          restored (atom [])
-          cleared  (atom [])]
+          restored (atom [])]
       (seed-slot! vid [[:e/a] [:e/b]])
       (swap! st/results-atom update vid
              (fn [s] (-> s
@@ -148,15 +147,12 @@
       (with-redefs [rf/restore-epoch (fn [v eid]
                                        (swap! restored conj [v eid]))
                     rf/epoch-history (fn [_] [{:epoch-id :x}])
-                    assertions/reset-trace-accumulators!
-                                        (fn [v] (swap! cleared conj v))
                     assertions/read-assertions (fn [_] [])]
         (st/rewind! vid)
         (is (= [[vid :epoch/seed]] @restored)
-            "restored against the SEED epoch-id (bottom of stack)")
-        (is (= [vid] @cleared)
-            "assertion accumulator is cleared so a fresh forward run
-             doesn't pile new records on top of the old ones")
+            "restored against the SEED epoch-id (bottom of stack) — rf2-luzky:
+             that epoch-restore alone rewinds [:rf.story/assertions]; there is
+             no longer a side-table accumulator to clear separately")
         (let [s (get @st/results-atom vid)]
           (is (= 0 (:cursor s)))
           (is (= [:epoch/seed] (:epoch-stack s))))))))
@@ -172,7 +168,6 @@
                          (assoc :interval-id 999))))
       (with-redefs [rf/restore-epoch (fn [_ _] nil)
                     rf/epoch-history (fn [_] [])
-                    assertions/reset-trace-accumulators! (fn [_] nil)
                     assertions/read-assertions (fn [_] [])
                     js/clearInterval (fn [_] nil)]
         (st/rewind! vid)

--- a/tools/story/test/re_frame/story/ui/test_mode_pane_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/test_mode_pane_cljs_test.cljs
@@ -32,7 +32,6 @@
             [re-frame.registrar        :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.story            :as story]
-            [re-frame.story.assertions :as assertions]
             [re-frame.story.async      :as async-lib]
             [re-frame.story.loaders    :as loaders]
             [re-frame.story.ui.state   :as state]
@@ -52,7 +51,6 @@
                 (get-in db [:rf/runtime :machines :snapshots machine-id])))
   (machines/reset-timers!)
   (loaders/clear-watchers!)
-  (reset! assertions/trace-accumulators {})
   (reset! tm-state/results-atom {})
   (state/reset-shell-state!)
   (story/install-canonical-vocabulary!)

--- a/tools/story/test/re_frame/story_assertions_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_assertions_cljs_test.cljs
@@ -31,7 +31,6 @@
                 (get-in db [:rf/runtime :machines :snapshots machine-id])))
   (machines/reset-timers!)
   (loaders/clear-watchers!)
-  (reset! assertions/trace-accumulators {})
   (story/install-canonical-vocabulary!)
   (frame/ensure-default-frame!))
 

--- a/tools/story/test/re_frame/story_assertions_test.clj
+++ b/tools/story/test/re_frame/story_assertions_test.clj
@@ -50,7 +50,6 @@
   (loaders/clear-watchers!)
   (config/set-global-args! {})
   ;; Clear per-frame assertion accumulators between tests.
-  (reset! assertions/trace-accumulators {})
   ;; rf2-q651r — clear the epoch tape + listeners between tests so the
   ;; tape-projected assertions read only their own freshly-captured tape.
   (epoch/clear-history!)
@@ -586,3 +585,43 @@
       (is (false? (get by-need :ssot.fx/never))
           "an fx never emitted → fail"))
     (story/destroy-variant! :story.ssot/effect)))
+
+;; ===========================================================================
+;; rf2-luzky — fold coverage: a STUBBED fx is answerable from the stub-call
+;; log SSOT, not the removed `trace-accumulators` side-table / dropped
+;; `tap-stub-event!` mirror.
+;;
+;; A stubbed fx lands on the epoch tape under its REWRITTEN stub id
+;; (`:rf.story.fx-stub/<dec>+<fx>`), not its original id — so the tape
+;; :effects projection alone can't answer `[:rf.assert/effect-emitted
+;; <original-fx>]`. `emitted-fx` unions the tape effects with
+;; `fx-stubs/observed-fx-ids` (the stub-call log, read via the
+;; `:stub-observed-fx-ids` late-bind hook). This proves dropping the
+;; `tap-stub-event!` dev-mirror lost no coverage: the original-fx fact is
+;; still answerable from the canonical stub-call log.
+;; ===========================================================================
+
+(deftest effect-emitted-projects-stubbed-fx-from-stub-log
+  (testing ":rf.assert/effect-emitted sees a force-fx-stub'd fx via the
+            stub-call log SSOT (the original fx-id, not the rewritten stub id)"
+    (rf/reg-fx :ssot.fx/http {:platforms #{:client :server}} (fn [_ _] nil))
+    (rf/reg-event-fx :ssot/login (fn [_ _] {:fx [[:ssot.fx/http {:url "/login"}]]}))
+    (story/reg-variant :story.ssot/stubbed
+      {:decorators  [[:rf.story/force-fx-stub :ssot.fx/http {:status :ok}]]
+       :events      []
+       :play-script [[:dispatch-sync [:ssot/login]]
+                     [:dispatch-sync [:rf.assert/effect-emitted :ssot.fx/http]]
+                     [:dispatch-sync [:rf.assert/effect-emitted :ssot.fx/never]]]})
+    (let [r       (async/deref-blocking
+                    (story/run-variant :story.ssot/stubbed) 5000)
+          by-need (->> (:assertions r)
+                       (filter #(= :rf.assert/effect-emitted (:assertion %)))
+                       (map (juxt :expected :passed?))
+                       (into {}))]
+      (is (contains? (assertions/emitted-fx :story.ssot/stubbed) :ssot.fx/http)
+          "emitted-fx answers the ORIGINAL fx-id from the stub-call log union")
+      (is (true?  (get by-need :ssot.fx/http))
+          "effect-emitted PASSES for the stubbed fx's original id")
+      (is (false? (get by-need :ssot.fx/never))
+          "an fx never emitted (stubbed or otherwise) → fail"))
+    (story/destroy-variant! :story.ssot/stubbed)))

--- a/tools/story/test/re_frame/story_authoring_surface_test.clj
+++ b/tools/story/test/re_frame/story_authoring_surface_test.clj
@@ -42,7 +42,6 @@
             [re-frame.registrar        :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.story            :as story]
-            [re-frame.story.assertions :as assertions]
             [re-frame.story.async      :as async]
             [re-frame.story.config     :as config]
             [re-frame.story.decorators :as decorators]
@@ -64,7 +63,6 @@
   (machines/reset-timers!)
   (loaders/clear-watchers!)
   (config/set-global-args! {})
-  (reset! assertions/trace-accumulators {})
   (reset! play/stepper-state            {})
   (reset! frames/stub-call-log          {})
   (story/install-canonical-vocabulary!)

--- a/tools/story/test/re_frame/story_decorator_chain_test.clj
+++ b/tools/story/test/re_frame/story_decorator_chain_test.clj
@@ -37,7 +37,6 @@
             [re-frame.registrar        :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.story            :as story]
-            [re-frame.story.assertions :as assertions]
             [re-frame.story.async      :as async]
             [re-frame.story.config     :as config]
             [re-frame.story.decorators :as decorators]
@@ -57,7 +56,6 @@
   (machines/reset-timers!)
   (loaders/clear-watchers!)
   (config/set-global-args! {})
-  (reset! assertions/trace-accumulators {})
   (reset! play/stepper-state            {})
   (reset! frames/stub-call-log          {})
   (story/install-canonical-vocabulary!)
@@ -130,8 +128,8 @@
                     [:seed-user]
                     [:rf.story/force-fx-stub :analytics {:ack? true}]]
        :events     [[:record/observed]]
-       ;; :emit/track dispatches in :play-script so the assertion accumulator
-       ;; (reset at play-start by reset-trace-accumulators!) sees it.
+       ;; :emit/track dispatches in :play-script so the tape + stub-call log
+       ;; (the SSOT :rf.assert/effect-emitted projects from — rf2-luzky) sees it.
        :play-script [[:dispatch-sync [:rf.assert/path-equals [:seen-user :name] "alice"]]
                     [:dispatch-sync [:emit/track]]
                     [:dispatch-sync [:rf.assert/effect-emitted :analytics]]]})
@@ -239,8 +237,8 @@
                     [:rf.story/force-fx-stub :analytics {:ack? true}]]
        :events     [[:inc-and-track] [:inc-and-track]]
        ;; :play-script emits one more inc-and-track so :rf.assert/effect-emitted
-       ;; sees a fresh emission (the events-phase emissions are wiped by
-       ;; reset-trace-accumulators! at play start by design).
+       ;; sees the emission via the tape + stub-call log SSOT (rf2-luzky —
+       ;; there is no play-start accumulator reset).
        :play-script [[:dispatch-sync [:rf.assert/path-equals [:counter] 102]]
                     [:dispatch-sync [:inc-and-track]]
                     [:dispatch-sync [:rf.assert/effect-emitted :analytics]]

--- a/tools/story/test/re_frame/story_fx_stubs_per_fx_scenarios_test.clj
+++ b/tools/story/test/re_frame/story_fx_stubs_per_fx_scenarios_test.clj
@@ -33,7 +33,6 @@
             [re-frame.registrar        :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.story            :as story]
-            [re-frame.story.assertions :as assertions]
             [re-frame.story.async      :as async]
             [re-frame.story.config     :as config]
             [re-frame.story.frames     :as frames]
@@ -53,7 +52,6 @@
   (machines/reset-timers!)
   (loaders/clear-watchers!)
   (config/set-global-args! {})
-  (reset! assertions/trace-accumulators {})
   (reset! play/stepper-state            {})
   (reset! frames/stub-call-log          {})
   (story/install-canonical-vocabulary!)

--- a/tools/story/test/re_frame/story_fx_stubs_test.clj
+++ b/tools/story/test/re_frame/story_fx_stubs_test.clj
@@ -20,7 +20,6 @@
             [re-frame.registrar        :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.story            :as story]
-            [re-frame.story.assertions :as assertions]
             [re-frame.story.async      :as async]
             [re-frame.story.config     :as config]
             [re-frame.story.decorators :as decorators]
@@ -41,7 +40,6 @@
   (machines/reset-timers!)
   (loaders/clear-watchers!)
   (config/set-global-args! {})
-  (reset! assertions/trace-accumulators {})
   (reset! play/stepper-state            {})
   (reset! frames/stub-call-log          {})
   (story/install-canonical-vocabulary!)

--- a/tools/story/test/re_frame/story_play_test.clj
+++ b/tools/story/test/re_frame/story_play_test.clj
@@ -39,8 +39,8 @@
   (machines/reset-timers!)
   (loaders/clear-watchers!)
   (config/set-global-args! {})
-  (reset! assertions/trace-accumulators {})
-  (reset! play/stepper-state                       {})
+  (reset! play/pending-exceptions {})
+  (reset! play/stepper-state      {})
   (story/install-canonical-vocabulary!)
   (frame/ensure-default-frame!)
   (test-fn))
@@ -163,17 +163,21 @@
     (story/destroy-variant! :story.ee/db)))
 
 ;; ===========================================================================
-;; Frame teardown clears accumulator entries
+;; Frame teardown clears per-frame accumulator entries
+;;
+;; rf2-luzky removed the `trace-accumulators` side-table; the only per-frame
+;; accumulator the teardown hook (`:drop-assertion-accumulators`) now evicts
+;; is the play module's `pending-exceptions` slot.
 ;; ===========================================================================
 
 (deftest teardown-clears-accumulators
-  (testing "destroy-variant! clears per-frame accumulator slots"
+  (testing "destroy-variant! clears the per-frame pending-exceptions slot"
     (story/reg-variant :story.tear/v
       {:events []
        :play-script [[:dispatch-sync [:rf.assert/path-equals [:x] :nope]]]})
     (async/deref-blocking (story/run-variant :story.tear/v) 5000)
     (story/destroy-variant! :story.tear/v)
-    (is (not (contains? @assertions/trace-accumulators :story.tear/v)))))
+    (is (not (contains? @play/pending-exceptions :story.tear/v)))))
 
 ;; ===========================================================================
 ;; Play stepper

--- a/tools/story/testbeds/counter_with_stories/stories_cljs_test.cljs
+++ b/tools/story/testbeds/counter_with_stories/stories_cljs_test.cljs
@@ -22,7 +22,6 @@
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.story     :as story]
             [re-frame.story.async      :as async-lib]
-            [re-frame.story.assertions :as assertions]
             [re-frame.story.loaders    :as loaders]
             [re-frame.story.play       :as play]
             [re-frame.test-support     :as test-support]
@@ -48,7 +47,6 @@
   (frame/ensure-default-frame!)
   (machines/reset-timers!)
   (loaders/clear-watchers!)
-  (reset! assertions/trace-accumulators {})
   ;; Always re-fire the Story registrations so each test starts with
   ;; a freshly-resolved registry (clears any leftover stories from
   ;; previous tests and ensures the lifecycle machine is freshly


### PR DESCRIPTION
Fully folds the `re-frame.story.assertions/trace-accumulators` side-table away (rf2-luzky). Mike ruled **Option A** (the full fold). Warnings / emitted-fx / dispatched are now derived from the canonical epoch tape + the stub-call log (the SSOT); the parallel atom carried no fact the tape does not already hold.

## SETTLE-FIRST design — the privacy seam (proceeded, clean relocation)

The design step found the relocation is **clean** — proceeded without stop-valving.

**Key finding:** the Spec 009 privacy-suppression default-drop and the `config/note-suppressed!` redaction-counter bump were *already* structurally at the **head** of the `re-frame.story.play` per-frame trace listener (the egress seam) — they were never a property of the side-table. The synchronous handler-exception capture was likewise already `play/pending-exceptions` (a separate atom). The side-table was fed *only* by the listener's three `record-*!` calls, which sit *after* the privacy gate and were already non-evidence (the assertions project from the tape since rf2-q651r).

So the fold only had to **drop the listener's three `record-*!` dev-mirror feeds**. The privacy gate, the counter bump, and the exception capture stay byte-for-byte where they were. No privacy machinery moved; the redundant mirror that hung off it was removed.

**Invariant preserved.** `sensitive-trace-cljs-test` is the acceptance gate. The old tests used side-table emptiness as a *proxy* for "the gate dropped the event". The migrated tests assert the gate's real observable outputs directly:
- a sensitive event → `config/suppressed-count` bumps + the exception capture never sees it (dropped at the gate);
- a non-sensitive `:rf.error/handler-exception` → captured into `pending-exceptions`, counter stays 0;
- `show-sensitive?` true → the gate is open (sensitive handler-exception captured, counter stays 0).

Sensitive events are still default-dropped and the redaction counter still bumps identically — the relocation is cleaner, not riskier.

## The fold (atom + all feeds gone)

- **assertions.cljc** — deleted `trace-accumulators`, `record-warning!`/`record-emitted-fx!`/`record-dispatched!`, `frame-warnings`/`frame-fx`/`frame-dispatched`, `reset-trace-accumulators!`/`drop-trace-accumulators!`. The tape projections (`dispatched-events`/`emitted-fx`/`warnings`) and the redaction projection are untouched.
- **play.cljc** — listener keeps only the privacy gate + `pending-exceptions` capture; dropped the three `record-*!` feeds and the now-dead `framework-fx-id?`/`framework-fx-ids` helpers. `execute-play!` / `begin-stepper!` clear `pending-exceptions` instead of resetting the removed side-table.
- **fx_stubs.cljc** — dropped `tap-stub-event!` (`observed-fx-ids` over the stub-call log is already the SSOT for stub-redirected fx). **frames.cljc / canonical.cljc / late_bind.cljc** — dropped the `:tap-stub-event` late-bind hook wiring.
- **runtime.cljc** — phase-0 / inline-phase-0 clear `pending-exceptions` instead of seeding the removed side-table (the `:loaders-complete-when` vector form already reads the tape).
- **stepper_state.cljs (UI lane — minimal re-point)** — `rewind!` no longer calls `reset-trace-accumulators!`. The epoch-restore it already does rewinds the in-app-db `[:rf.story/assertions]` slot, so a fresh forward run starts clean without a separate accumulator reset. No other change to the UI lane.
- Doc-comment + spec touch-ups (story spec 001/009/017, evidence.cljc) so no stale references to the removed symbols remain.

## Tests

- `sensitive-trace-cljs-test` migrated (the acceptance gate) — asserts the privacy gate's egress outputs directly; passes unchanged in behaviour.
- New JVM `effect-emitted-projects-stubbed-fx-from-stub-log` — proves dropping `tap-stub-event!` lost no coverage (a stubbed fx's *original* id is still answerable from the stub-call log SSOT, the one fact the tape can't carry under the original id).
- Existing tape-projection coverage (`dispatched?-projects-from-tape-trigger-events`, `effect-emitted-projects-from-tape-effects`, `no-warnings-agrees-with-warnings-slot-on-error-only-run`) now runs without the side-table.
- ~18 test fixtures had `(reset! assertions/trace-accumulators {})` removed; unused `assertions` requires pruned where the reset was the only use.

## Quality gates

- **JVM Story** (`clojure -M:test` from `tools/story/`): 1544 tests, 5756 assertions, **0 failures, 0 errors**.
- **CLJS node** (`npm --prefix implementation run test:cljs`): 5027 tests, 16809 assertions, **0 failures, 0 errors** (includes the migrated sensitive-trace gate).
- **clj-kondo** (`--fail-level error --lint tools/story/src`): **0 errors**.
- **bundle-isolation** (`npm run test:bundle-isolation`): **PASS** — no tool leak into production bundles.
- **elision** (`npm run test:elision`): **PASS** — production 40/40 absent, control 40/40 present (no DCE regression).

Closes rf2-luzky.
