### PR TITLE
fix(xray): flow :db-diff precise endpoints + no-:db-effect-with-flow edge case (rf2-48oc4)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1499,21 +1499,34 @@ epoch's `:db-before` threaded as the diff pre-image, so inline diff
 annotations paint per the R1-R8 grammar below. There is no mode
 toggle.
 
-> **Post-handler `:db`, not post-flow (rf2-4wywy)** — the rendered
-> value is the **t1 snapshot** (`:rf.event/db-pending`, post-handler /
-> pre-flow · rf2-ta0y7), surfaced by the projection as the HANDLER
-> step's `:db-post-handler`. It is NOT the epoch record's `:db-after`.
-> `:db-after` is the FINAL post-flow / post-commit state — flows write
-> app-db AFTER the handler returns (at the outermost `:after`
-> interceptor), so reading `:db-after` here CONFLATED the handler's
-> change with any flow recompute that followed it (the bug). With t1
-> the HANDLER step shows ONLY what the handler returned; the flow's own
+> **Post-handler `:db`, not post-flow (rf2-4wywy / rf2-48oc4)** — the
+> rendered value is the **effective post-handler db** (the db AS IT
+> STOOD AT END-OF-HANDLER, pre-flow), surfaced by the projection as the
+> HANDLER step's `:db-post-handler`. It is NOT the epoch record's
+> `:db-after`. `:db-after` is the FINAL post-flow / post-commit state —
+> flows write app-db AFTER the handler returns (at the outermost
+> `:after` interceptor), so reading `:db-after` here CONFLATED the
+> handler's change with any flow recompute that followed it (the bug).
+> The HANDLER step shows ONLY what the handler returned; the flow's own
 > contribution is rendered on the FLOW step as its own `:db` diff (the
-> t1→t2 reshape · §9.1.10.8). **Graceful fallback**: when no t1 rode
-> the stream (handler returned no `:db`, or a pre-rf2-ta0y7 runtime),
-> the sub-section falls back to the record's `:db-after` so older
-> epochs still render. The diff pre-image stays `:db-before`
-> throughout.
+> reshape · §9.1.10.8). The diff pre-image stays `:db-before` throughout.
+>
+> The effective post-handler db **MUST NOT assume the handler returned a
+> `:db`** (`projection/effective-post-handler-db`):
+>
+> 1. **Handler returned `:db`** → the **t1 snapshot**
+>    (`:rf.event/db-pending`, post-handler / pre-flow · rf2-ta0y7).
+> 2. **Handler returned NO `:db` but a flow fired** (rf2-48oc4 edge
+>    case) → **`db-before`**. The substrate stamps t1 only `(when
+>    has-db?)`, so no t1 rides the stream; but t2
+>    (`:rf.event/db-pending-post-flow`) DOES fire because a flow
+>    synthesised a `:db` from app-db and changed it. The db at
+>    end-of-handler equals `db-before` (the handler wrote nothing), so
+>    the HANDLER step shows **NO `:db` change** — the flow's change is
+>    attributed to the FLOW step, not the handler.
+> 3. **Neither t1 nor t2** (no flow + no `:db`, OR a pre-rf2-ta0y7
+>    runtime) → the slot is nil and the sub-section **falls back to the
+>    record's `:db-after`** so older epochs still render.
 
 > **Retirement (2026-05-29, rf2-vv3m6)** — the prior
 > `[diff][full][full+diff]` three-mode toggle (rf2-n2jig + rf2-yqjrd)
@@ -2341,11 +2354,22 @@ each carries `:flow-id`, `:path`, `:before`, `:after`, and
 `:duration-ms` (when stamped). The aggregate `flow-step` defn
 retired with rf2-xnb1x.
 
-Per rf2-4wywy each FLOW step additionally carries the t1 (pre-flow)
-+ t2 (post-flow) db snapshots — `:db-pre-flow` (`:rf.event/db-pending`)
-and `:db-post-flow` (`:rf.event/db-pending-post-flow`) — threaded by
-`project` off the trace stream (rf2-ta0y7). One flows pass produces
-one t1→t2 transition shared across all FLOW steps of the epoch.
+Per rf2-4wywy / rf2-48oc4 each FLOW step additionally carries the
+pre-flow + post-flow db snapshots — `:db-pre-flow` and `:db-post-flow`
+— threaded by `project` off the trace stream (rf2-ta0y7). One flows
+pass produces one pre→post transition shared across all FLOW steps of
+the epoch.
+
+- `:db-pre-flow` = the **effective post-handler db**
+  (`projection/effective-post-handler-db`): the **t1 snapshot**
+  (`:rf.event/db-pending`) when the handler returned `:db`, else
+  **`db-before`** when the handler returned NO `:db` yet a flow fired
+  (the rf2-48oc4 edge case — the flow's diff baseline is the ACTUAL
+  post-handler db, which equals db-before since the handler wrote
+  nothing; the implementation MUST NOT assume the handler supplied a
+  `:db`). nil only on a pre-rf2-ta0y7 / no-flow stream.
+- `:db-post-flow` = the **t2 snapshot**
+  (`:rf.event/db-pending-post-flow`) — what the flow returned.
 
 The accompanying view-layer chrome:
 
@@ -2355,29 +2379,34 @@ The accompanying view-layer chrome:
   jumps through the shared `:rf.xray/open-in-editor` allowlist —
   see §9.1.11); otherwise the id renders as a plain coloured span.
   An external-link glyph trails the id when source-jump is wired.
-- **Body — the flow's OWN `:db` diff (rf2-4wywy)** — a flow's
-  contribution IS an app-db mutation: it writes `:output` into `:path`
-  AFTER the handler returned. The body renders that contribution as a
-  `:db` DIFF via the shared edn-inspector diff renderer (FULL+DIFF,
-  parity with the HANDLER `:db` sub-section §9.1.5.1 + the App-DB Diff
-  panel), under a `↳ :db <path>` sub-header. The diff is **scoped to
-  the flow's `:path`**: `:before` = t1 with the flow's pre-write value
-  at `:path`, value = t2 with the flow's post-write value at `:path`,
-  so each FLOW step shows ONLY its own slot's reshape even when several
-  flows rode the same t1→t2 transition. This keeps the flow's change
-  (e.g. `:derived` recomputed) SEPARATE from the HANDLER step's `:db`
-  (which shows only the t1 / post-handler state). Testid
+- **Body — the flow's OWN `:db` diff (rf2-4wywy / rf2-48oc4)** — a
+  flow's contribution IS an app-db mutation: it writes `:output` into
+  `:path` AFTER the handler returned. The body renders that
+  contribution as a `:db` DIFF via the shared edn-inspector diff
+  renderer (FULL+DIFF, parity with the HANDLER `:db` sub-section
+  §9.1.5.1 + the App-DB Diff panel), under a `↳ :db <path>` sub-header.
+  The diff is **scoped to the flow's `:path`**: `:before` =
+  `:db-pre-flow` with the flow's pre-write value at `:path`, value =
+  `:db-post-flow` with the flow's post-write value at `:path`, so each
+  FLOW step shows ONLY its own slot's reshape even when several flows
+  rode the same pre→post transition. Because `:db-pre-flow` is the
+  EFFECTIVE post-handler db, this renders correctly EVEN WHEN the
+  handler returned no `:db` (the diff baseline is `db-before`, NOT a
+  scalar fallback — rf2-48oc4). This keeps the flow's change (e.g.
+  `:derived` recomputed) SEPARATE from the HANDLER step's `:db` (which
+  shows only the post-handler state). Testid
   `rf-xray-epoch-flow-db-diff-<name>`; the step root carries
   `data-rf-xray-flow-db-diff="true"`.
 - **Fallback (pre-rf2-ta0y7 / no snapshots)** — when the step carries
-  no t1/t2 snapshots (handler returned no `:db`, or an older runtime),
-  the body falls back to the legacy `<glyph> [path] before → after`
-  diff-style scalar line, left-aligned with the badge (no indent),
-  reusing the COEFFECT body styles (`coeffect-body-*`). Glyph is `~`
-  for an update (both before and after present) or `+` for a
-  first-write (no before). Values render through the edn-inspector
-  `mini` widget. Testid `rf-xray-epoch-flow-value-<name>`; the step
-  root carries `data-rf-xray-flow-db-diff="false"`.
+  no pre/post snapshots (a pre-rf2-ta0y7 runtime, or a flow on a stream
+  with neither t1 nor t2), the body falls back to the legacy
+  `<glyph> [path] before → after` diff-style scalar line, left-aligned
+  with the badge (no indent), reusing the COEFFECT body styles
+  (`coeffect-body-*`). Glyph is `~` for an update (both before and
+  after present) or `+` for a first-write (no before). Values render
+  through the edn-inspector `mini` widget. Testid
+  `rf-xray-epoch-flow-value-<name>`; the step root carries
+  `data-rf-xray-flow-db-diff="false"`.
 - **Verb dropped** — the prior `N flows recomputed` aggregate
   verb is gone; the per-step expansion of flows makes the count
   visible in the cascade numbering itself (operator scans left
@@ -3361,8 +3390,8 @@ signal to render plainly. None set any mode flag:
 
 | Surface                              | Call site                                                                                  | Test surface                                                                |
 |--------------------------------------|--------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------|
-| Epoch HANDLER step `:db`             | `panels/epoch/view.cljs` — `handler-db-diff-block` (post-handler t1 `:db-post-handler`, fallback `:db-after`; `:before db-before` · rf2-4wywy) | `data-testid="rf-xray-epoch-handler-db-full-with-diff"`                     |
-| Epoch FLOW step `:db`                | `panels/epoch/view.cljs` — `render-flow-step` (path-scoped t1→t2 diff `:db-pre-flow`→`:db-post-flow` · rf2-4wywy) | `data-testid="rf-xray-epoch-flow-db-diff-<name>"`                           |
+| Epoch HANDLER step `:db`             | `panels/epoch/view.cljs` — `handler-db-diff-block` (effective post-handler db `:db-post-handler` = t1, else `db-before` when no-`:db`-with-flow, else fallback `:db-after`; `:before db-before` · rf2-4wywy / rf2-48oc4) | `data-testid="rf-xray-epoch-handler-db-full-with-diff"`                     |
+| Epoch FLOW step `:db`                | `panels/epoch/view.cljs` — `render-flow-step` (path-scoped pre→post diff `:db-pre-flow` (effective post-handler db) → `:db-post-flow` (t2) · rf2-4wywy / rf2-48oc4) | `data-testid="rf-xray-epoch-flow-db-diff-<name>"`                           |
 | App-DB panel (per `:rf/*` section)   | `panels/app_db_diff_state.cljs` — `value-body` (one mount; `:before` via `cond->`)         | App-DB panel-gallery story fixtures + segment-inspector tests               |
 | Machine Inspector snapshot drill-in  | `panels/machine_inspector.cljs` — `snapshot-block` (`:before` via `cond->` when captured)  | `data-testid="rf-xray-machine-snapshot-block-<id>"` with `data-rf-xray-diff-mode="full+diff"` |
 | Epoch SUBSCRIPTIONS step value cells | `panels/epoch/view.cljs` — `subs-value-cell` container branch (`:before` / `:added?`)      | `data-testid="rf-xray-epoch-sub-row-*"` mount                               |

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -874,6 +874,55 @@
   (some-> (find-op events :rf.event/db-pending-post-flow)
           (common/tag-of :rf.event/db)))
 
+(defn no-db-effect-with-flow?
+  "True iff the handler returned NO `:db` effect yet a flow still ran
+  this epoch (rf2-48oc4 edge case). The discriminator off the trace
+  stream: NO t1 (`:rf.event/db-pending` fires only `(when has-db?)` —
+  router `flows-after-interceptor`, rf2-ta0y7) AND a t2
+  (`:rf.event/db-pending-post-flow`) DID fire (a flow synthesised a
+  `:db` from app-db and changed it).
+
+  In this case the db AT END-OF-HANDLER equals the db that stood before
+  the cascade (`db-before`) — the handler wrote nothing to `:db`. The
+  HANDLER step must therefore show NO `:db` change, and the FLOW step
+  must diff against that `db-before` baseline rather than fall back to a
+  scalar line. Distinct from the pre-rf2-ta0y7 fallback (no t1 AND no
+  t2), where the absence of t1 means the runtime simply never stamped
+  the snapshot — there the HANDLER step falls back to the record's
+  `:db-after`."
+  [events]
+  (and (nil? (db-pending-t1 events))
+       (some? (db-pending-t2 events))))
+
+(defn effective-post-handler-db
+  "The db value AS IT STOOD AT END-OF-HANDLER (post-handler-effects,
+  PRE-flow-transform) — the authoritative baseline for BOTH the HANDLER
+  step's `:db` and the FLOW step's diff `:before` (rf2-48oc4).
+
+  The implementation MUST NOT assume the handler returned a `:db`. Three
+  emit shapes the substrate produces (router `flows-after-interceptor`,
+  rf2-ta0y7):
+
+  1. Handler RETURNED a `:db` effect → t1 (`:rf.event/db-pending`) fired
+     carrying that value. The post-handler db IS t1.
+
+  2. Handler returned NO `:db` effect but a flow still fired → t1 is NOT
+     emitted, yet t2 (`:rf.event/db-pending-post-flow`) fires with the
+     flow-augmented db. Here the post-handler db is `db-before`: the
+     handler wrote nothing, so app-db at end-of-handler equals the db
+     that stood before the cascade (`no-db-effect-with-flow?`).
+
+  3. Neither t1 nor t2 (no flow + handler wrote no `:db`, OR a
+     pre-rf2-ta0y7 runtime that never stamped t1) → nil. Callers fall
+     back to the epoch record's `:db-after` (preserving the legacy
+     rendering for older epochs)."
+  [events db-before]
+  (let [t1 (db-pending-t1 events)]
+    (cond
+      (some? t1)                       t1
+      (no-db-effect-with-flow? events) db-before
+      :else                            nil)))
+
 (defn handler-row
   "Build the step-N HANDLER row. ALWAYS present (every epoch has a
   dispatched event therefore a handler). Adapts to the trace stream's
@@ -916,27 +965,36 @@
                         (some-> db-changed :tags :duration-ms)
                         (some-> do-fx :tags :duration-ms))
         decomp      (effects-decomp events)
-        ;; rf2-4wywy — the HANDLER step's `:db` must reflect ONLY the
-        ;; handler's own contribution (post-handler, PRE-flow), not the
-        ;; final post-flow state. `db-post-handler` is the t1 snapshot
-        ;; (`:rf.event/db-pending`); when t1 is absent (handler returned
-        ;; no `:db`, or pre-rf2-ta0y7 runtime) the view falls back to the
-        ;; record's `:db-after`. The `:db-diff` flat-rows are likewise
-        ;; computed against t1 when present so non-view consumers + tests
-        ;; read the handler-only change.
-        db-t1       (db-pending-t1 events)
-        db-handler  (if (some? db-t1) db-t1 db-after)
+        ;; rf2-4wywy / rf2-48oc4 — the HANDLER step's `:db` must reflect
+        ;; ONLY the handler's own contribution (post-handler, PRE-flow),
+        ;; never the final post-flow state. `db-post-handler` is the
+        ;; EFFECTIVE post-handler db (see `effective-post-handler-db`):
+        ;;
+        ;;   - t1 (`:rf.event/db-pending`) when the handler returned `:db`;
+        ;;   - `db-before` when the handler returned NO `:db` yet a flow
+        ;;     fired (rf2-48oc4 edge case — the post-handler db equals
+        ;;     db-before, so the HANDLER step shows NO `:db` change rather
+        ;;     than the flow's change);
+        ;;   - nil otherwise (no flow + no `:db`, or pre-rf2-ta0y7), where
+        ;;     the slot stays nil and the view falls back to the record's
+        ;;     `:db-after`.
+        ;;
+        ;; The `:db-diff` flat-rows are computed against this same
+        ;; effective baseline so non-view consumers + tests read the
+        ;; handler-only change (empty in the no-`:db`-with-flow case).
+        db-post-handler (effective-post-handler-db events db-before)
+        db-handler  (if (some? db-post-handler) db-post-handler db-after)
         base        {:step           :handler
                      :badge          :HANDLER
                      :flavour        flavour
                      :event-id       event-id
                      :duration-ms    duration-ms
-                     ;; The post-handler (t1) db value — the HANDLER
+                     ;; The effective post-handler db value — the HANDLER
                      ;; step's `:db` sub-section renders this diffed
-                     ;; against `:db-before`. nil-safe: absent t1 leaves
-                     ;; the slot nil and the view falls back to the
+                     ;; against `:db-before`. nil-safe: an absent baseline
+                     ;; leaves the slot nil and the view falls back to the
                      ;; record's `:db-after`.
-                     :db-post-handler db-t1
+                     :db-post-handler db-post-handler
                      :db-diff        (db-diff-paths db-before db-handler)
                      ;; :fx — legacy flat-entries slot (kept for non-view
                      ;; consumers; tests + pre-rf2-p2zy0 callers).
@@ -1865,15 +1923,24 @@
             ;; step. `flow-rows` projection (per-row data) is
             ;; unchanged; the aggregation shape was the only thing
             ;; that changed.
-            ;; rf2-4wywy — thread the t1 (pre-flow) / t2 (post-flow) db
+            ;; rf2-4wywy / rf2-48oc4 — thread the pre-flow / post-flow db
             ;; snapshots onto every FLOW step so the view can render the
             ;; flow's OWN contribution as a `:db` DIFF (the t1→t2 reshape),
             ;; rather than the per-path before/after scalar line that read
             ;; as a flow-internal value rather than an app-db change. The
             ;; snapshots are shared across all flow steps of the epoch (one
-            ;; flows pass produces one t1→t2 transition); each step scopes
-            ;; the rendered diff to its own `:path`.
-            flow-db-pre  (db-pending-t1 events)
+            ;; flows pass produces one transition); each step scopes the
+            ;; rendered diff to its own `:path`.
+            ;;
+            ;; PRE endpoint = the EFFECTIVE post-handler db (the db AS IT
+            ;; STOOD AT END-OF-HANDLER): t1 when the handler returned `:db`,
+            ;; else `db-before` when the handler wrote NO `:db` yet a flow
+            ;; fired (rf2-48oc4 — the flow's baseline is the actual
+            ;; post-handler db, which equals db-before). POST endpoint = t2
+            ;; (what the flow returned). When neither endpoint resolves
+            ;; (pre-rf2-ta0y7 / no flow snapshots) the FLOW step carries no
+            ;; pair and the view falls back to the scalar before→after line.
+            flow-db-pre  (effective-post-handler-db events db-before)
             flow-db-post (db-pending-t2 events)
             flow-steps (mapv (fn [{:keys [flow-id path before after duration-ms]}]
                                (cond-> {:step    :flow

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -2463,16 +2463,23 @@
   auto-collapse keeps unchanged subtrees folded so the density matches
   what the prior `:diff` lens used to provide.
 
-  rf2-4wywy — the rendered `:db` is the POST-HANDLER, PRE-FLOW value
-  (the projection's `:db-post-handler`, t1 · `:rf.event/db-pending`),
-  NOT the epoch record's `:db-after`. `:db-after` is the FINAL
-  post-flow / post-commit state — reading it conflated the handler's
-  change with any flow recompute that followed (flows write app-db
-  AFTER the handler). With t1 the HANDLER step shows ONLY what the
-  handler returned; the FLOW step shows the flow's OWN `:db` diff
-  (the t1→t2 reshape). Graceful fallback: when no t1 fired (handler
-  returned no `:db`, or a pre-rf2-ta0y7 runtime) the block falls back
-  to the record's `:db-after` so older epochs still render.
+  rf2-4wywy / rf2-48oc4 — the rendered `:db` is the EFFECTIVE
+  POST-HANDLER db (the projection's `:db-post-handler`), NOT the epoch
+  record's `:db-after`. `:db-after` is the FINAL post-flow / post-commit
+  state — reading it conflated the handler's change with any flow
+  recompute that followed (flows write app-db AFTER the handler). The
+  HANDLER step shows ONLY what the handler returned; the FLOW step shows
+  the flow's OWN `:db` diff (the pre→post reshape).
+
+  The projection resolves `:db-post-handler` without assuming the
+  handler returned a `:db` (`projection/effective-post-handler-db`):
+  the t1 snapshot (`:rf.event/db-pending`) when the handler returned
+  `:db`; `db-before` when the handler returned NO `:db` yet a flow
+  fired (rf2-48oc4 — the HANDLER step then shows NO `:db` change, since
+  the post-handler db equals db-before); nil otherwise. Graceful
+  fallback: when the projection left the slot nil (no flow + no `:db`,
+  or a pre-rf2-ta0y7 runtime) the block falls back to the record's
+  `:db-after` so older epochs still render.
 
   The `:db-diff` arg is unused under the single rendering but stays in
   the parent's `handler-body` signature for projection compatibility.
@@ -2621,22 +2628,30 @@
   The projection emits N flow step maps for a cascade with N flow
   recomputes.
 
-  rf2-4wywy — the body renders the flow's OWN contribution as a `:db`
-  DIFF rather than the prior `[path] before → after` scalar line. A
-  flow's contribution IS an app-db mutation (it writes `:output` into
-  `:path` AFTER the handler returned); rendering it as a `:db` diff
-  via the shared edn-inspector diff renderer (parity with the HANDLER
-  step's `:db` sub-section + the App-DB Diff panel) reads as 'what the
-  flow changed in app-db', and — crucially — keeps it SEPARATE from
-  the HANDLER step's `:db` (which now shows only the t1 / post-handler
-  state). The diff is scoped to the flow's `:path` so each FLOW step
-  shows only its own slot's reshape (the projection threads the shared
-  t1/t2 db snapshots onto every flow step; `assoc-in` at the flow's
-  path against t1 / t2 isolates this flow's contribution).
+  rf2-4wywy / rf2-48oc4 — the body renders the flow's OWN contribution
+  as a `:db` DIFF rather than the prior `[path] before → after` scalar
+  line. A flow's contribution IS an app-db mutation (it writes
+  `:output` into `:path` AFTER the handler returned); rendering it as a
+  `:db` diff via the shared edn-inspector diff renderer (parity with the
+  HANDLER step's `:db` sub-section + the App-DB Diff panel) reads as
+  'what the flow changed in app-db', and — crucially — keeps it SEPARATE
+  from the HANDLER step's `:db` (which shows only the post-handler
+  state). The diff endpoints are the projection's `:db-pre-flow` (the
+  EFFECTIVE post-handler db) and `:db-post-flow` (t2 · what the flow
+  returned). Scoped to the flow's `:path` so each FLOW step shows only
+  its own slot's reshape (the projection threads the shared snapshots
+  onto every flow step; `assoc-in` at the flow's path against pre / post
+  isolates this flow's contribution).
 
-  Graceful fallback: when the projection carried no t1/t2 snapshots
-  (handler returned no `:db`, or a pre-rf2-ta0y7 runtime) the body
-  falls back to the per-path `[path] before → after` scalar line."
+  rf2-48oc4 — `:db-pre-flow` is the effective post-handler db, so the
+  diff renders correctly EVEN WHEN the handler returned no `:db`: in
+  that case the projection threads `db-before` (the actual post-handler
+  db) as `:db-pre-flow`, NOT nil, so this branch renders a real diff
+  rather than the scalar fallback.
+
+  Graceful fallback: when the projection carried no pre/post snapshots
+  (a pre-rf2-ta0y7 runtime, or neither t1 nor t2 on the stream) the
+  body falls back to the per-path `[path] before → after` scalar line."
   [{:keys [flow-id path before after duration-ms step-number
            db-pre-flow db-post-flow]}]
   (let [flow-meta  (when (keyword? flow-id)
@@ -2645,11 +2660,12 @@
         coord      (when (and flow-meta (string? (:file flow-meta)))
                      {:file (:file flow-meta) :line (:line flow-meta)})
         label      (proj/ns-keyword flow-id)
-        ;; rf2-4wywy — render a `:db` diff scoped to this flow's path.
-        ;; t1 (db-pre-flow) lacks this flow's write; t2 (db-post-flow)
-        ;; carries it. Scoping to the path isolates THIS flow's slot
-        ;; even when several flows rode the same t1→t2 transition. When
-        ;; either snapshot is absent we render the scalar fallback.
+        ;; rf2-4wywy / rf2-48oc4 — render a `:db` diff scoped to this
+        ;; flow's path. db-pre-flow (effective post-handler db) lacks this
+        ;; flow's write; db-post-flow (t2) carries it. Scoping to the path
+        ;; isolates THIS flow's slot even when several flows rode the same
+        ;; pre→post transition. When either endpoint is absent (pre-
+        ;; rf2-ta0y7 / no snapshots) we render the scalar fallback.
         db-diff?   (boolean
                      (and (some? db-pre-flow) (some? db-post-flow)
                           (sequential? path) (seq path)))

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -1091,6 +1091,108 @@
       (is (= 5 (:before f)))
       (is (= 6 (:after f))))))
 
+;; ---- no-`:db`-effect-but-has-flow edge case (rf2-48oc4) -----------------
+;;
+;; A handler can return NO `:db` effect yet still trigger a flow. The
+;; substrate then stamps NO t1 (`:rf.event/db-pending` fires only
+;; `(when has-db?)` — router `flows-after-interceptor`, rf2-ta0y7) but
+;; DOES stamp t2 (`:rf.event/db-pending-post-flow`) with the flow-augmented
+;; db (a flow synthesised one from app-db and changed it). The post-handler
+;; db here equals `db-before` (the handler wrote nothing). The HANDLER step
+;; must show NO `:db` change; the FLOW step must diff the flow's
+;; contribution against `db-before` — NOT fall back to the scalar line, and
+;; NOT attribute the flow's change to the handler.
+
+(deftest no-db-effect-with-flow-discriminator-test
+  (testing "rf2-48oc4 — `no-db-effect-with-flow?` is true iff no t1 but a
+            t2 fired (handler wrote no `:db`, a flow synthesised + changed
+            one)"
+    (is (true? (proj/no-db-effect-with-flow?
+                 [(db-pending-post-flow-ev {:a 1 :derived 2})]))
+        "no t1 + t2 present → true")
+    (is (false? (proj/no-db-effect-with-flow?
+                  [(db-pending-ev {:a 1})
+                   (db-pending-post-flow-ev {:a 1 :derived 2})]))
+        "t1 present → false (handler DID return :db; standard case)")
+    (is (false? (proj/no-db-effect-with-flow? []))
+        "neither t1 nor t2 → false (no flow / pre-rf2-ta0y7)")))
+
+(deftest effective-post-handler-db-resolution-test
+  (testing "rf2-48oc4 — `effective-post-handler-db` resolution order"
+    (is (= {:a 1} (proj/effective-post-handler-db
+                    [(db-pending-ev {:a 1})] {:a 0}))
+        "t1 present → t1 (handler-supplied db), regardless of db-before")
+    (is (= {:a 0} (proj/effective-post-handler-db
+                    [(db-pending-post-flow-ev {:a 0 :derived 9})] {:a 0}))
+        "no t1 + t2 (no-:db-with-flow) → db-before (the actual
+         post-handler db; handler wrote nothing)")
+    (is (nil? (proj/effective-post-handler-db [] {:a 0}))
+        "neither t1 nor t2 → nil (caller falls back to record :db-after);
+         the pre-rf2-ta0y7 / no-flow path is left to the legacy fallback")))
+
+(deftest handler-step-shows-no-db-change-when-handler-wrote-no-db-test
+  (testing "rf2-48oc4 ACCEPTANCE (b) — when the handler returned NO `:db`
+            but a flow fired, the HANDLER step shows NO `:db` change: the
+            effective post-handler db equals `db-before`, so the `:db-diff`
+            is EMPTY and `:db-post-handler` carries db-before (NOT the
+            flow-augmented post-flow state)."
+    (let [db-before {:base 1 :derived 2}
+          ;; handler wrote no :db → t1 absent. The flow recomputes
+          ;; :derived from :base into app-db → t2 fires with the augmented db.
+          t2        {:base 1 :derived 4}
+          record    {:event-id     :synthetic/flow-only
+                     :db-before    db-before
+                     :db-after     t2
+                     :trace-events [(dispatched-ev [:synthetic/flow-only])
+                                    ;; NO db-pending-ev — the handler
+                                    ;; returned no :db effect.
+                                    (flow-recomputed-ev :synthetic/derived [:derived] 2 4)
+                                    (db-pending-post-flow-ev t2)
+                                    (run-end-ev 0.2)]}
+          steps     (proj/project record)
+          h         (first (filter #(= :handler (:step %)) steps))]
+      (is (some? h) "HANDLER step present")
+      (is (= db-before (:db-post-handler h))
+          "the HANDLER step's effective post-handler db = db-before (the
+           handler wrote nothing); NOT the post-flow t2")
+      (is (= [] (:db-diff h))
+          "HANDLER `:db-diff` is EMPTY — the handler made no :db change;
+           the flow's :derived recompute must NOT surface here")
+      (is (not (contains? (set (map first (:db-diff h))) [:derived]))
+          "the flow's :derived change does NOT leak into the HANDLER step"))))
+
+(deftest flow-step-diffs-against-db-before-when-handler-wrote-no-db-test
+  (testing "rf2-48oc4 ACCEPTANCE (a) — when the handler returned NO `:db`
+            but a flow fired, the FLOW step's diff baseline is the ACTUAL
+            post-handler db (= db-before), threaded as `:db-pre-flow`; the
+            POST endpoint is t2 (`:db-post-flow`). The step renders a real
+            `:db` diff rather than the scalar fallback."
+    (let [db-before {:base 1 :derived 2}
+          t2        {:base 1 :derived 4}
+          record    {:event-id     :synthetic/flow-only
+                     :db-before    db-before
+                     :db-after     t2
+                     :trace-events [(dispatched-ev [:synthetic/flow-only])
+                                    (flow-recomputed-ev :synthetic/derived [:derived] 2 4)
+                                    (db-pending-post-flow-ev t2)
+                                    (run-end-ev 0.2)]}
+          steps     (proj/project record)
+          f         (first (filter #(= :flow (:step %)) steps))]
+      (is (some? f) "FLOW step present")
+      (is (= :synthetic/derived (:flow-id f)))
+      (is (= [:derived] (:path f)))
+      (is (= db-before (:db-pre-flow f))
+          "FLOW diff PRE endpoint = the actual post-handler db (db-before)
+           — NOT nil, so the view renders a real :db diff, not the scalar
+           fallback")
+      (is (= t2 (:db-post-flow f))
+          "FLOW diff POST endpoint = t2 (what the flow returned)")
+      ;; The t1(=db-before)→t2 reshape IS the flow's contribution.
+      (is (= 2 (:derived (:db-pre-flow f)))
+          "pre-flow :derived = its value before the flow recomputed it")
+      (is (= 4 (:derived (:db-post-flow f)))
+          "post-flow :derived = the flow's recomputed value"))))
+
 ;; ---- FX -----------------------------------------------------------------
 
 (deftest fx-step-conditional-test


### PR DESCRIPTION
Follow-up to **rf2-4wywy** (#2515). A VERIFY-THEN-REFINE bead: confirm #2515 covers the two refinements, implement only what is genuinely missing.

## STEP-0 verify finding

| Refinement | Status |
|---|---|
| **R1 — precise flow `:db` diff endpoints** (handler-returned → flow-returned) | **Already covered by #2515.** The FLOW step diffs t1 (`:rf.event/db-pending`, handler-returned → `:db-pre-flow`) → t2 (`:rf.event/db-pending-post-flow`, flow-returned → `:db-post-flow`). Endpoints confirmed exactly handler-returned vs flow-returned. Kept green. |
| **R2 — no-`:db`-effect-but-has-flow edge case** | **NOT covered — the genuinely-new part.** Implemented here. |

### Why R2 was broken before this PR

When a handler returns **no `:db` effect** yet triggers a flow, the substrate (`router/flows-after-interceptor`, rf2-ta0y7) stamps **NO t1** (`:rf.event/db-pending` fires only `(when has-db?)`) but **DOES stamp t2** — a flow synthesised a `:db` from app-db and changed it. With t1 absent, #2515's HANDLER row fell back to the record's `:db-after` (the **post-flow** state), so:

- the HANDLER step wrongly showed the **flow's** change as the handler's; and
- the FLOW step fell back to the scalar `before → after` line instead of diffing the flow's contribution against the real post-handler db.

## The fix (projection-only; `view.cljs` changes are docstring/comment)

The post-handler db must **not assume the handler returned a `:db`**.

- New `effective-post-handler-db`: **t1** when the handler returned `:db`; else **`db-before`** when no t1 but a flow fired (the *actual* post-handler db — the handler wrote nothing, so end-of-handler db == db-before); else **nil** (pre-rf2-ta0y7 / no flow → caller falls back to record `:db-after`, legacy behaviour preserved).
- New `no-db-effect-with-flow?` discriminator (**no t1 + t2 present**) gates the `db-before` path so the pre-rf2-ta0y7 fallback (no t1 **and** no t2) stays intact.

Wired into:
- **HANDLER row** — `:db-post-handler` + `:db-diff` read the effective post-handler db. In the edge case the diff is `db-before → db-before` = **empty** → HANDLER shows **no `:db` change** (R2b).
- **FLOW step** — `:db-pre-flow` is the effective post-handler db (= `db-before` in the edge case, **not nil**), so the view renders a real path-scoped `:db` diff against `db-before` rather than the scalar fallback (R2a).

## Tests (`tools/xray` `projection_cljs_test`)

- `no-db-effect-with-flow-discriminator-test`
- `effective-post-handler-db-resolution-test`
- `handler-step-shows-no-db-change-when-handler-wrote-no-db-test` — **acceptance R2b**
- `flow-step-diffs-against-db-before-when-handler-wrote-no-db-test` — **acceptance R2a**

The button-5 acceptance (handler writes `:base`, flow writes `:derived`) plus all #2515 t1/t2 + legacy-fallback tests stay green.

## Spec

`tools/xray/spec/021` §9.1.5.1 (effective post-handler db resolution, MUST-NOT-assume-`:db`), §9.1.10.8 (`:db-pre-flow` = effective post-handler db; renders correctly with no handler `:db`), surface table updated.

## Quality gates

- **Xray JVM** `clojure -M:test` — **978 tests / 3850 assertions, 0 failures, 0 errors** (was 974/3833 at #2515; +4 tests / +17 assertions).
- **clj-kondo** `--fail-level error --lint tools/xray/src` — **0 errors**. No new warnings in the touched files.
- **xray-feature-gate smoke** `npm run test:xray-feature-gate:smoke` — **4 scenarios, 0 failures, 10 matrix rows**. Panel-gallery build compiled 0 warnings.
- `test:cljs` not run — no `implementation/core` changes (tools-only).