### PR TITLE
fix(xray): cancellation-cascade dialog Esc handler — build the keydown handler, not the bare fn (rf2-op8c7)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/cancellation_cascade.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/cancellation_cascade.cljs
@@ -541,13 +541,13 @@
       ;; owns the positioning attribute, the click-outside dismiss,
       ;; `a11y/dialog-attrs` + the `a11y/dialog-ref` focus trap.
       ;;
-      ;; NB the dialog `:on-key-down` is the bare `handle-popover-keydown`
-      ;; builder (NOT `(handle-popover-keydown dispatch)`) — preserved
-      ;; verbatim from the pre-rf2-7oxvd code. That makes the dialog-level
-      ;; keydown a no-op (React calls the 1-arity builder, which returns a
-      ;; fn that is never invoked); Esc closes via the backdrop's
-      ;; correctly-built handler. Filed as a follow-on bug, not touched
-      ;; here (this refactor is behaviour-preserving).
+      ;; Both the backdrop and the dialog get the BUILT keydown handler
+      ;; `(handle-popover-keydown dispatch)` (rf2-op8c7). The dialog
+      ;; previously received the bare 1-arity builder, so React called the
+      ;; builder with the keydown event and discarded the handler fn it
+      ;; returned — making the dialog-level Esc a no-op. With the focus
+      ;; trap keeping focus inside the dialog, a dialog-focused Esc never
+      ;; reached the backdrop's handler, so Esc-on-dialog did not close.
       (modal-chrome/modal-chrome
         {:positioning          positioning
          :backdrop-style       (backdrop-style positioning)
@@ -557,7 +557,7 @@
          :backdrop-testid      "rf-xray-cancellation-cascade-popover-backdrop"
          :dialog-testid        "rf-xray-cancellation-cascade-popover-dialog"
          :on-backdrop-key-down (handle-popover-keydown dispatch)
-         :on-dialog-key-down   handle-popover-keydown
+         :on-dialog-key-down   (handle-popover-keydown dispatch)
          :backdrop-tab-index   -1
          :dialog-tab-index     0}
         (render-cascade cascade close)))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/cancellation_cascade_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/cancellation_cascade_cljs_test.cljs
@@ -322,6 +322,64 @@
         (is (= "absolute"
                (:data-rf-xray-modal-positioning (second backdrop))))))))
 
+;; ---- (8) dialog Esc keydown (rf2-op8c7) --------------------------------
+;;
+;; The popover DIALOG's `:on-key-down` MUST be the BUILT handler
+;; `(handle-popover-keydown dispatch)`, not the bare 1-arity builder.
+;; With the bug, React called the builder with the keydown event and
+;; discarded the handler fn it RETURNED, so a dialog-focused Esc was a
+;; no-op — and the `a11y/dialog-ref` focus trap kept that Esc from ever
+;; reaching the backdrop's correctly-built handler.
+;;
+;; Idiom mirrors `edn_inspector_popup_cljs_test`: pull the rendered
+;; dialog node's `:on-key-down` (exercising the actual wiring at the
+;; bug site), redef `rf/dispatch*` to capture the dispatched event, fire
+;; a fake Escape keydown through it, and assert the close event was
+;; dispatched. With the BUILT handler the close event is captured; with
+;; the bare builder the call returns an inner fn and dispatches NOTHING
+;; (capture stays nil) — so this assertion is the discriminating guard.
+
+(defn- fake-keydown-event
+  "Minimal stand-in for a React keydown SyntheticEvent — `.-key` plus
+  the no-op `preventDefault` / `stopPropagation` the handler calls."
+  [key]
+  #js {:key             key
+       :preventDefault  (fn [])
+       :stopPropagation (fn [])})
+
+(deftest popover-dialog-esc-keydown-dispatches-close
+  (testing "an Escape keydown on the popover DIALOG invokes the BUILT
+            keydown handler and dispatches :cancellation-cascade-close
+            — guards against the bare-builder no-op (rf2-op8c7)"
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/cancellation-cascade-open nil])
+      (let [tree     (cc/Popover)
+            dialog   (find-by-testid tree "rf-xray-cancellation-cascade-popover-dialog")
+            on-key   (:on-key-down (second dialog))
+            captured (atom nil)]
+        (is (some? dialog) "dialog node rendered")
+        (is (fn? on-key) "dialog carries an :on-key-down handler")
+        (with-redefs [rf/dispatch* (fn [event-v & _] (reset! captured event-v))]
+          (on-key (fake-keydown-event "Escape")))
+        (is (= [:rf.xray/cancellation-cascade-close] @captured)
+            "Esc on the dialog dispatched the close event (built handler invoked)")))))
+
+(deftest popover-dialog-keydown-ignores-non-escape
+  (testing "a non-Escape keydown on the dialog dispatches NOTHING (the
+            built handler keys on 'Escape')"
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/cancellation-cascade-open nil])
+      (let [tree     (cc/Popover)
+            dialog   (find-by-testid tree "rf-xray-cancellation-cascade-popover-dialog")
+            on-key   (:on-key-down (second dialog))
+            captured (atom nil)]
+        (with-redefs [rf/dispatch* (fn [event-v & _] (reset! captured event-v))]
+          (on-key (fake-keydown-event "Enter")))
+        (is (nil? @captured)
+            "Enter on the dialog dispatched nothing")))))
+
 ;; ---------------------------------------------------------------------------
 ;; rf2-ppzid — React unique-key warning regression guard.
 ;;


### PR DESCRIPTION
## Summary

In `panels/cancellation_cascade.cljs` the Popover's inner DIALOG received the **bare 1-arity builder** `handle-popover-keydown` as `:on-dialog-key-down`. React calls that builder with the keydown event; the builder returns a handler fn that is **never invoked** — so the dialog-level Esc was a no-op. Because the `a11y/dialog-ref` focus trap keeps focus inside the dialog, a dialog-focused Esc never reached the backdrop's correctly-built handler, and Esc-on-dialog did not close the popover.

The backdrop was already wired correctly with `(handle-popover-keydown dispatch)`. The fix mirrors it on the dialog.

### Before / after

```clojure
;; before — bare builder; React invokes it with the event and drops the returned fn
:on-dialog-key-down   handle-popover-keydown

;; after — built handler; the returned closure runs on the event and dispatches close
:on-dialog-key-down   (handle-popover-keydown dispatch)
```

(`modal-chrome` does `(assoc :on-key-down on-dialog-key-down)`, so the bare builder landed directly as the React `:on-key-down`.)

### Test

Added two tests to `cancellation_cascade_cljs_test.cljs`, following the `edn_inspector_popup_cljs_test` keydown idiom (redef `rf/dispatch*` to capture the dispatched event):

- `popover-dialog-esc-keydown-dispatches-close` — pulls the **rendered dialog node's** `:on-key-down`, fires a fake `Escape`, asserts `[:rf.xray/cancellation-cascade-close]` is dispatched. **Verified failing** against the bare-builder revert (nothing is dispatched), so it is a genuine discriminating guard, not a tautology.
- `popover-dialog-keydown-ignores-non-escape` — fires `Enter`, asserts nothing is dispatched.

### Spec

No `tools/xray/spec/*` change. The cascade popover's Esc/keydown dismiss mechanics are not normatively specified in `019-Cross-Cutting-Insight.md` (or elsewhere under `tools/xray/spec/`); this fix restores the universally-expected modal-dismiss behaviour the implementation always intended, not a spec-level contract.

## Quality gates

- **CLJS suite** (`npm run test:cljs`): 5040 tests / 16869 assertions / **0 failures, 0 errors** (with fix in place). With the fix reverted, exactly the new Esc test fails — confirming the guard.
- **Xray JVM** (`clojure -M:test` from `tools/xray/`): 978 tests / 3850 assertions / **0 failures, 0 errors**.
- **clj-kondo** (`--fail-level error --lint tools/xray/src`): **errors: 0** (64 pre-existing warnings, none introduced). Test file lints **0 errors, 0 warnings**.
- **Portability**: no personal / `miket` paths in the diff.

Closes rf2-op8c7.