### PR TITLE
refactor(xray): complete modal-chrome consolidation — palette/view adopts shared chrome (rf2-7oxvd)

### DIFF
--- a/tools/xray/spec/007-UX-IA.md
+++ b/tools/xray/spec/007-UX-IA.md
@@ -1483,26 +1483,35 @@ Three modal surfaces float over the chrome:
 
 ### Shared modal-chrome scaffold (rf2-7oxvd)
 
-Seven of Xray's eight modal/popover surfaces (Settings, Filter
+**All eight** of Xray's modal/popover surfaces (Settings, Filter
 edit-popup, Share, Mute manager, App-DB segment-inspector, EDN-inspector
-popup, Cancellation-cascade popover) render the **same backdrop + dialog
-scaffold** — a full-inset click-to-dismiss overlay wrapping a WAI-ARIA
-dialog box that carries `role="dialog"` + `aria-modal="true"` + an
-accessible name (via `aria-label` or `aria-labelledby`) + the
-focus-trap contract (focus-on-open, Tab/Shift+Tab trap, restore-on-close
-— see `theme/a11y`). That genuinely-identical scaffold is extracted to
+popup, Cancellation-cascade popover, **Command palette**) render the
+**same backdrop + dialog scaffold** — a full-inset click-to-dismiss
+overlay wrapping a WAI-ARIA dialog box that carries `role="dialog"` +
+`aria-modal="true"` + an accessible name (via `aria-label` or
+`aria-labelledby`) + the focus-trap contract (focus-on-open,
+Tab/Shift+Tab trap, restore-on-close — see `theme/a11y`). That
+genuinely-identical scaffold is extracted to
 `day8.re-frame2-xray.theme.modal-chrome`; each modal supplies its own
 divergent bits (dim colour / blur / alignment / z-index, dialog size,
 header / body content, Esc / mnemonic key handling, accessible name) as
-**slots/props**, never flags. This is a pure internal-DRY refactor: the
-rendered DOM, `data-testid`s, ARIA attributes, z-stacking, dismiss and
-focus behaviour are unchanged.
+**slots/props, never flags**. Each modal's `data-testid`s, ARIA
+attributes, z-stacking and dismiss behaviour are unchanged.
 
-The **command palette** deliberately does NOT use this scaffold: it
-ships a distinct surface (always-`:fixed` positioning, hand-rolled
-combobox/listbox ARIA, no focus-trap, Esc handled inside its text input)
-with its own ARIA contract test, so folding it onto the shared scaffold
-would change its behaviour.
+The **command palette** was the eighth and last surface to adopt the
+scaffold (Mike ruled Option A — full consolidation). Its apparent
+divergences all land on existing slots without a per-palette flag:
+always-`:fixed` (literal `:positioning :fixed` — it has no Story testbed
+cell), Esc handled inside its `:auto-focus` text input (it passes no
+chrome keydown handler, the edit-popup pattern), its `data-rf-xray-mode`
+marker via `:dialog-extra`, and its hand-rolled combobox/listbox ARIA
+staying in the dialog `children` while the dialog-level role/aria-modal/
+accessible-name comes from the shared `a11y/dialog-attrs`. Adoption also
+gives the palette the focus trap it previously lacked — the trap
+intercepts only Tab/Shift+Tab and the palette's sole focusable is the
+input (rows drive a virtual `aria-activedescendant` cursor, not real
+focus), so Tab wraps to the input and the arrow-key navigation is
+untouched.
 
 ## Discoverability
 

--- a/tools/xray/src/day8/re_frame2_xray/palette/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/palette/view.cljs
@@ -11,13 +11,21 @@
   `palette.cljs` wraps it in `reg-view` so its subscribes route to
   the surrounding `:rf/xray` frame via React context.
 
-  ## Modal layer
+  ## Modal layer (rf2-7oxvd)
 
   Phase 1 layers the palette over the Xray shell's `shell-view`
   (mounted there so subscribes resolve through the shell's frame
-  provider). The backdrop swallows clicks outside the dialog and
-  closes the palette; the dialog itself stops propagation so input
-  / row clicks don't bubble.
+  provider). The backdrop + dialog scaffold is the shared
+  `theme/modal-chrome` contract — the eighth and last Xray modal to
+  adopt it. The palette supplies its own `backdrop-style` /
+  `dialog-style`, the `:label \"Command palette\"` accessible name, the
+  `data-rf-xray-mode` marker (via `:dialog-extra`) and the
+  click-outside dismiss (`:on-dismiss`); `modal-chrome` owns the
+  click-outside wiring, the `a11y/dialog-attrs` (role / aria-modal /
+  accessible name) and the `a11y/dialog-ref` focus trap. The palette
+  is always `:fixed` (it has no Story testbed cell, so no
+  `:rf.xray/modal-positioning` subscribe — it passes the literal
+  `:fixed`).
 
   ## Keyboard handling
 
@@ -25,7 +33,20 @@
   cursor, Enter invokes, Ctrl+Enter (or Cmd+Enter on mac) invokes
   in a pop-out, ESC closes. The shell-level Cmd/Ctrl+K listener
   handles open; ESC inside the input also closes so the user does
-  not need to drop modifier hands.
+  not need to drop modifier hands. Because the input owns Esc, the
+  palette passes NO chrome keydown handler (the edit-popup pattern).
+
+  ## Focus trap + the combobox cursor (rf2-7oxvd)
+
+  Adopting `modal-chrome` brings the `a11y/dialog-ref` focus trap the
+  palette previously lacked. The trap intercepts only `Tab` /
+  `Shift+Tab`; the palette's sole real focusable is the search input
+  (the result `<li>`s carry no tabindex — the cursor is a VIRTUAL
+  selection tracked via `aria-activedescendant`, focus never leaves the
+  input). So `Tab` simply wraps back to the input and the arrow-key
+  navigation is untouched. `dialog-ref` also respects the input's
+  `:auto-focus` — it skips focus-on-open when a descendant already
+  holds focus — so there is no double-focus on mount.
 
   ## Why every deferred dispatch captures the surrounding frame (rf2-w8lxg / rf2-r0o63 / rf2-nesy9)
 
@@ -56,6 +77,7 @@
   literal), so N isolated instances each route to their own frame."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-xray.palette.sources :as sources]
+            [day8.re-frame2-xray.theme.modal-chrome :as modal-chrome]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens sans-stack mono-stack type-scale]]))
 
@@ -281,21 +303,31 @@
   (let [query   (or @(rf/subscribe [:rf.xray/palette-query]) "")
         results @(rf/subscribe [:rf.xray/palette-results])
         cursor  @(rf/subscribe [:rf.xray/palette-cursor])]
-    [:div {:data-testid "rf-xray-palette-backdrop"
-           :on-click    #(dispatch [:rf.xray/palette-close])
-           :style       (backdrop-style)}
-     [:div {:data-testid "rf-xray-palette-dialog"
-            :data-rf-xray-mode "palette"
-            ;; rf2-tt7ax — modal/listbox ARIA: the dialog wrapper
-            ;; carries `role="dialog"` + `aria-modal="true"` so screen
-            ;; readers announce the surface as a modal and the assistive
-            ;; layer keeps focus inside; `aria-label` provides the
-            ;; accessible name (no visible title bar).
-            :role        "dialog"
-            :aria-modal  "true"
-            :aria-label  "Command palette"
-            :on-click    #(.stopPropagation %)
-            :style       (dialog-style)}
+    ;; rf2-7oxvd — shared backdrop + dialog scaffold. The palette keeps
+    ;; its own `backdrop-style` / `dialog-style` and its `:auto-focus`
+    ;; input owning Esc (handled in `handle-input-keydown`, exactly the
+    ;; edit-popup pattern), so it passes NO chrome keydown handler.
+    ;; `modal-chrome` owns the click-outside dismiss, the
+    ;; `a11y/dialog-attrs` (rf2-tt7ax role/aria-modal + the `:label`
+    ;; accessible name — no visible title bar) and the `a11y/dialog-ref`
+    ;; focus trap. The trap intercepts only Tab/Shift+Tab; the palette's
+    ;; sole focusable is the input (rows drive the combobox cursor via
+    ;; `aria-activedescendant`, not real focus), so Tab wraps back to the
+    ;; input and the activedescendant navigation is untouched. The
+    ;; `data-rf-xray-mode` marker rides in via `:dialog-extra`. The
+    ;; palette is always `:fixed` (no `:rf.xray/modal-positioning` —
+    ;; it has no Story testbed cell), so the positioning is the literal
+    ;; `:fixed`.
+    (modal-chrome/modal-chrome
+      {:positioning      :fixed
+       :backdrop-style   (backdrop-style)
+       :dialog-style     (dialog-style)
+       :on-dismiss       #(dispatch [:rf.xray/palette-close])
+       :label            "Command palette"
+       :backdrop-testid  "rf-xray-palette-backdrop"
+       :dialog-testid    "rf-xray-palette-dialog"
+       :dialog-tab-index "-1"
+       :dialog-extra     {:data-rf-xray-mode "palette"}}
       [:div {:style (input-row-style)}
        [:span {:aria-hidden "true"
                :style (icon-style :command)} "⌘"]
@@ -363,4 +395,4 @@
         [:span "pop-out"]]
        [:div
         [:span {:style (footer-key-style)} "ESC"]
-        [:span "close"]]]]]))
+        [:span "close"]]])))

--- a/tools/xray/src/day8/re_frame2_xray/theme/modal_chrome.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/theme/modal_chrome.cljs
@@ -1,10 +1,10 @@
 (ns day8.re-frame2-xray.theme.modal-chrome
   "Shared modal-chrome scaffold (rf2-7oxvd).
 
-  Seven of Xray's eight modal surfaces — Settings, Filter edit-popup,
+  ALL EIGHT of Xray's modal surfaces — Settings, Filter edit-popup,
   Share, Mute manager, App-DB segment-inspector, EDN-inspector popup,
-  and the Cancellation-cascade popover — render the SAME two-`:div`
-  scaffold:
+  the Cancellation-cascade popover and the Command palette — render
+  the SAME two-`:div` scaffold:
 
       [:div BACKDROP            ;; full-inset overlay, click-outside dismiss
        [:div DIALOG …content…]] ;; the WAI-ARIA dialog box
@@ -44,16 +44,29 @@
       `:dialog-extra` (merged last so the caller can override anything,
       including the testid).
 
-  ## Why the palette is NOT a caller
+  ## The palette is a caller too (rf2-7oxvd, Option A)
 
-  The command palette (`palette/view`) deliberately ships a DIFFERENT
-  scaffold: no `:rf.xray/modal-positioning` honouring (always `:fixed`),
-  no `a11y/dialog-ref` focus-trap, hand-rolled combobox/listbox ARIA,
-  and Esc handled only inside its text input. It has its own ARIA
-  contract test (`palette/aria-cljs-test`) distinct from the six-modal
-  `modals-aria-cljs-test`. Folding it onto this scaffold would CHANGE
-  its behaviour (add a focus trap it does not have), so it stays as-is
-  per the bead's stop-on-divergence guidance.
+  The command palette (`palette/view`) was the eighth and last modal
+  to adopt this scaffold. Its apparent divergences all land cleanly on
+  the existing slots — no per-palette flag, no new slot:
+
+    * always-`:fixed` (no `:rf.xray/modal-positioning` subscribe) → it
+      passes the literal `:positioning :fixed`;
+    * Esc handled inside its `:auto-focus` text input → it passes NO
+      chrome keydown handler (the edit-popup pattern);
+    * the `data-rf-xray-mode \"palette\"` marker → `:dialog-extra`;
+    * its hand-rolled combobox/listbox ARIA stays in the `children`
+      (the dialog-level role/aria-modal/accessible-name comes from
+      `a11y/dialog-attrs` via `:label`, exactly the contract its
+      `palette/aria-cljs-test` already asserts).
+
+  Adopting the chrome ALSO gives the palette the `a11y/dialog-ref`
+  focus trap it previously lacked — a strict a11y improvement. The
+  trap intercepts only Tab/Shift+Tab, and the palette's sole focusable
+  is the input (rows drive a virtual `aria-activedescendant` cursor,
+  not real focus), so Tab wraps to the input and the arrow-key
+  navigation is untouched. (Earlier partial passes left the palette
+  out under the C-stance; Mike ruled Option A — full consolidation.)
 
   ## Tab-index
 


### PR DESCRIPTION
Completes the Option-A modal-chrome consolidation Mike ruled on rf2-7oxvd. The earlier partial pass (commit 146f68093) built the shared `theme/modal-chrome` scaffold and migrated 7 of 8 modals; this PR brings the 8th and last holdout — the command palette — onto the shared contract, and audits that the 7 retain no leftover duplication.

## Consolidation outcome — clean 8/8

The command palette is now a clean caller. Every apparent divergence lands on an **existing slot** — no per-palette flag, no new slot, no leaky abstraction (stop-valve not triggered):

- always-`:fixed` (the palette has no Story testbed cell, so no `:rf.xray/modal-positioning` subscribe) → literal `:positioning :fixed`
- Esc handled inside the `:auto-focus` search input → palette passes **no** chrome keydown handler (the same shape as `filters/edit-popup`)
- `data-rf-xray-mode "palette"` marker → `:dialog-extra`
- hand-rolled combobox/listbox ARIA stays in the dialog `children`; the dialog-level `role`/`aria-modal`/accessible-name now comes from the shared `a11y/dialog-attrs` via `:label "Command palette"` — exactly the contract `palette/aria-cljs-test` already asserts.

Adoption also gives the palette the `a11y/dialog-ref` **focus trap it previously lacked** — a strict a11y improvement, in the spirit of Option A ("a11y fixes land once"). The trap intercepts only Tab/Shift+Tab; the palette's sole real focusable is the search input (result rows drive a *virtual* `aria-activedescendant` cursor, not real focus), so Tab wraps back to the input and the arrow-key navigation is untouched. `dialog-ref` also respects the input's pre-existing `:auto-focus`, so there is no double-focus on mount.

### Audit of the 7 already-migrated modals
All 7 (settings, filters/edit-popup, share, spine-filters mute manager, app-db segment-inspector, edn-inspector popup, cancellation-cascade) delegate backdrop / dialog / `dialog-attrs` / `dialog-ref` to `modal-chrome` and supply only their own styles / headers / keydown as caller-supplied values. A repo-wide grep for hand-rolled `role="dialog"` / `:aria-modal` / `dialog-ref` / `:data-rf-xray-modal-positioning` found the only remaining hand-rolled dialog scaffold was in `palette/view` (now removed). No mop-up needed — the 7 were clean.

## Spec
`tools/xray/spec/007-UX-IA.md` §"Shared modal-chrome scaffold" updated to the 8/8 end-state (replaces the prior "the command palette deliberately does NOT use this scaffold" C-stance paragraph). The `modal_chrome` ns docstring's "Why the palette is NOT a caller" section is likewise replaced with "The palette is a caller too".

## Quality gates
All run from the worker worktree `C:\Users\miket\code\re-frame2-worktrees\xray-modal-chrome-complete-7oxvd`:

- **`npm run test:cljs`** (includes `palette/aria-cljs-test` + the 6-modal `modals-aria-cljs-test` + `palette-invoke` e2e) — **PASS**: 5041 tests, 16870 assertions, 0 failures, 0 errors.
- **`npm run test:xray-feature-gate`** (nightly-full sweep, live browser) — **PASS**: 14 scenarios, 0 failures, 13 matrix rows.
- **`npm run test:bundle-isolation`** — **PASS**: 17 artefact entries, 35 internal sentinels absent, 3 allow-list budgets ok; uix/helix reagent-free PASS.
- **clj-kondo** on the two touched cljs files (+ `palette.cljs`) — **0 errors, 0 warnings**.
- **Render + dismiss + a11y**: the palette renders and dismisses (Esc inside input + backdrop-click + ✕) via the `palette-invoke` e2e + feature-gate palette scenario; `modals-aria` proves the labelled-dialog + focus-ref contract for the other surfaces; the palette's own `aria-cljs-test` proves its combobox/listbox + `role="dialog"`/`aria-modal`/`aria-label` contract survives the chrome adoption.

Lane: touched only `tools/xray` modal files (`palette/view.cljs`, `theme/modal_chrome.cljs`) + `tools/xray/spec/007-UX-IA.md`. No panel/epoch/reactive-panel/render-trace surfaces touched (bhi3t's lane).

Closes rf2-7oxvd.