### PR TITLE
fix(xray): attribute render cause props-vs-sub in Views/Epoch (rf2-bhi3t)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -489,7 +489,12 @@ FLOW`), not the prior depth-first indented tree. Columns, left → right:
   Level-1 sub reads app-db; the fan-out is a plain edge, no path detail — see §3.2 constraint 1).
 - **Level-1 subs** (extractors) — each drawn with its changed/unchanged state.
 - **Level-2 subs** (derived via `:<-`; *optional* layer; precise `:<-` edges).
-- **Views** (right-most — **the focus**) — each tagged re-rendered + *why*.
+- **Views** (right-most — **the focus**) — each tagged re-rendered + *why*. A view re-renders for
+  exactly one of two reasons: a **subscription** it derefs changed value, or its **props** changed
+  (the orthogonal `:rf/props` channel). The per-view cause sub-label attributes which (rf2-bhi3t):
+  `← :sub-id` when `:rf.view/triggered-by` is present, `← props` on a re-render whose own subs all
+  held value. A mount carries no cause — the `(mounted)` label conveys the first render. The parent
+  is never named (rf2-8ve8z) — `props` is the attribution, not the specific parent component.
 
 **Node + edge encoding (colour/edge first, per Visual encoding §022 — NOT glyphs):**
 
@@ -2030,7 +2035,7 @@ and silently rendered empty rows. The binding inventory:
 | `:fx` | `:rf.fx/handled` / `:rf.fx/override-applied` / `:rf.fx/skipped-on-platform` | `:rf.fx/id`, `:rf.fx/args`, `:rf.fx/elapsed-ms` (rf2-ipaza aligned the duration read against the substrate's canonical name) |
 | `:subscriptions` | `:rf.sub/run` / `:rf.sub/skip` | `:rf.sub/id`, `:rf.sub/query-v`, `:rf.sub/value-changed?`, `:rf.sub/prev-value`, `:rf.sub/value`, `:rf.sub/cascade?`, `:rf.sub/cause-sub`, `:rf.sub/elapsed-ms` (rf2-kfh1v aligned the reads against these) |
 | `:subscriptions` disposed (rf2-wpfjo) | `:rf.sub/dispose` (emitted by `re-frame.subs.cache/emit-dispose!` per rf2-mrnur — every cache eviction site funnels through ONE emit shape) | `:rf.sub/id`, `:rf.sub/query-v`, `:rf.sub/reason` (closed set `:no-more-derefers / :hot-reload / :cache-clear`), `:frame`. Surfaced via `projection/disposed-subs-rows`; the SUBSCRIPTIONS step carries an optional `:disposed-rows` slot (omit-by-absence). The step renders a DISPOSED sub-section when populated and reads `N recomputed (...); L disposed` in its header. A dispose-only cascade (no run/skip) still renders the step. |
-| `:views` | `:rf.view/rendered` (NOT the simpler `:rf.view/render` marker) | `:rf.view/id`, `:rf.view/deref-subs`, `:rf.view/elapsed-ms`, `:rf.view/mount?`, `:rf.view/triggered-by` (rf2-6djth aligned the read against the rich marker) |
+| `:views` | `:rf.view/rendered` (NOT the simpler `:rf.view/render` marker) | `:rf.view/id`, `:rf.view/deref-subs`, `:rf.view/elapsed-ms`, `:rf.view/mount?`, `:rf.view/triggered-by` (rf2-6djth aligned the read against the rich marker). The projection derives a `:cause` slot per row (rf2-bhi3t) from `:rf.view/mount?` + `:rf.view/triggered-by` — `:mount` (first render) / `{:kind :sub :sub-id <id>}` (a deref'd sub changed value) / `:props` (a re-render with no own sub change → the orthogonal `:rf/props` channel). The VIEWS table paints it as a `← :sub-id` / `← props` chip; no substrate/instrumentation change — fully tool-side inference. |
 | `:views` unmounted (rf2-gmw1i) | `:rf.view/unmounted` (already emitted by `re-frame.views/emit-view-unmounted!` per rf2-9hoos + rf2-te71r) | `:rf.view/id`, `:rf.view/render-key`, `:frame`. Surfaced via `projection/unmounted-views-rows`; the VIEWS step carries an optional `:unmounted-rows` slot (omit-by-absence when none fired). The step renders an UNMOUNTED sub-section when populated and reads `N re-rendered; M unmounted` in its header. |
 
 ### §9.1.10.2 Per-step elapsed time (rf2-nqt3d · rf2-dwuq3)

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -1334,10 +1334,39 @@
 
 ;; ---- VIEWS step ----------------------------------------------------------
 
+(defn render-cause
+  "Classify WHY a view rendered this cascade (rf2-bhi3t), purely from
+  data the substrate already stamps on `:rf.view/rendered`:
+
+    `:mount`                     — the instance's FIRST render
+                                   (`:rf.view/mount?` true). Not a
+                                   re-render-attribution question.
+    {:kind :sub :sub-id <id>}    — a SUBSCRIPTION the view derefs
+                                   changed value: `:rf.view/triggered-by`
+                                   (the first sub in the view's read-set
+                                   whose value changed — rf2-8wrzz.1).
+    :props                       — a re-render where NONE of the view's
+                                   own subs changed value. The view
+                                   re-rendered anyway, so the cause is
+                                   the orthogonal `:rf/props` channel
+                                   (a prop changed / parent re-rendered).
+                                   We never name the parent (rf2-8ve8z).
+
+  A view re-renders for exactly one of two reasons — a sub it derefs
+  changed, or its props changed — so the absence of a `triggered-by`
+  on a re-render IS the props signal. Pure; takes the already-projected
+  `:mount?` + `:triggered-by` row slots."
+  [mount? triggered-by]
+  (cond
+    (true? mount?)      :mount
+    (some? triggered-by) {:kind :sub :sub-id triggered-by}
+    :else                :props))
+
 (defn view-rows
   "Project view-render events into rows. Each row carries the view-id,
-  the subs the view dereffed during this render, and the wall-clock
-  duration of the render-fn.
+  the subs the view dereffed during this render, the wall-clock
+  duration of the render-fn, and the render `:cause` (rf2-bhi3t —
+  `:mount` / `{:kind :sub :sub-id <id>}` / `:props`).
 
   Per rf2-6djth the projection reads `:rf.view/rendered` (the rich
   per-render marker — rf2-25zo2 / rf2-9hoos / rf2-8wrzz.1) rather than
@@ -1350,16 +1379,19 @@
   [events]
   (vec
     (for [ev (filter-op events :rf.view/rendered)]
-      {:view-id      (or (common/tag-of ev :rf.view/id)
-                         (common/tag-of ev :view-id))
-       :subs-read    (or (common/tag-of ev :rf.view/deref-subs)
-                         (common/tag-of ev :rf.view/subs)
-                         (common/tag-of ev :subs-read)
-                         [])
-       :mount?       (common/tag-of ev :rf.view/mount?)
-       :triggered-by (common/tag-of ev :rf.view/triggered-by)
-       :duration-ms  (or (common/tag-of ev :rf.view/elapsed-ms)
-                         (common/tag-of ev :duration-ms))})))
+      (let [mount?       (common/tag-of ev :rf.view/mount?)
+            triggered-by (common/tag-of ev :rf.view/triggered-by)]
+        {:view-id      (or (common/tag-of ev :rf.view/id)
+                           (common/tag-of ev :view-id))
+         :subs-read    (or (common/tag-of ev :rf.view/deref-subs)
+                           (common/tag-of ev :rf.view/subs)
+                           (common/tag-of ev :subs-read)
+                           [])
+         :mount?       mount?
+         :triggered-by triggered-by
+         :cause        (render-cause mount? triggered-by)
+         :duration-ms  (or (common/tag-of ev :rf.view/elapsed-ms)
+                           (common/tag-of ev :duration-ms))}))))
 
 (defn unmounted-views-rows
   "Project `:rf.view/unmounted` events into rows (rf2-gmw1i). Each row

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -1026,6 +1026,22 @@
    :margin-left "8px"
    :font-size   "10px"})
 
+;; rf2-bhi3t — the per-row render-cause chip ("← props" / "← :sub-id").
+;; Sub-driven re-renders tint accent (the reactive cause — same family
+;; as the sub column); props-driven re-renders tint tertiary (the muted
+;; orthogonal `:rf/props` channel). Mounts render no chip — the cause
+;; question is about RE-renders, and the (mounted) signal lives elsewhere.
+(def ^:private views-row-cause-base-style
+  {:margin-left "8px"
+   :font-size   "10px"
+   :font-family mono-stack})
+
+(def ^:private views-row-cause-sub-style
+  (assoc views-row-cause-base-style :color accent-colour))
+
+(def ^:private views-row-cause-props-style
+  (assoc views-row-cause-base-style :color text-tertiary-colour))
+
 (def ^:private views-anonymous-style
   {:color text-tertiary-colour :font-style "italic"})
 
@@ -3287,12 +3303,48 @@
       (when (and m (string? (:file m)))
         {:file (:file m) :line (:line m) :ns (:ns m)}))))
 
+(defn- render-cause-chip
+  "Render the per-row render-cause attribution chip (rf2-bhi3t).
+
+  A view re-renders for exactly one of two reasons — a SUBSCRIPTION it
+  derefs changed value, or its PROPS changed (the orthogonal `:rf/props`
+  channel). This chip answers that first debugging question inline:
+
+    `{:kind :sub :sub-id <id>}`  →  `← :sub-id` (accent-tinted; the sub
+                                    routes through `ei/mini` so it carries
+                                    the same syntax-token chrome the subs
+                                    column uses).
+    `:props`                     →  `← props` (tertiary-tinted; muted).
+    `:mount`                     →  nil (the cause question is about
+                                    RE-renders; a first render has no
+                                    re-render cause).
+
+  `idx` keys the `data-testid` per row."
+  [cause idx]
+  (cond
+    (and (map? cause) (= :sub (:kind cause)))
+    [:span {:data-testid (str "rf-xray-epoch-view-row-cause-" idx)
+            :data-rf-render-cause "sub"
+            :style views-row-cause-sub-style}
+     "← " [ei/mini (:sub-id cause) 60]]
+
+    (= :props cause)
+    [:span {:data-testid (str "rf-xray-epoch-view-row-cause-" idx)
+            :data-rf-render-cause "props"
+            :style views-row-cause-props-style}
+     "← props"]
+
+    :else nil))
+
 (defn- views-table
   "Render the VIEWS table — 2 columns (views / subs). Per the bead
   body's §VIEWS (Step 8) shape (rf2-6djth).
 
   Each row carries:
     - view-id (hyperlinked via the registrar's `:view` meta coord)
+    - the render cause (rf2-bhi3t — `← :sub-id` when a deref'd sub
+      changed value, `← props` when a re-render had no own sub change;
+      the orthogonal `:rf/props` channel)
     - duration (when stamped, rendered as a muted chip below the id)
     - the subs the view dereffed during this render (one per line —
       vectors via `pr-str`, scalars via `ns-keyword`).
@@ -3323,7 +3375,7 @@
                                    subs-row-style-with-border
                                    subs-row-style)})
       :row-cells
-      (fn [{:keys [view-id subs-read duration-ms]} i]
+      (fn [{:keys [view-id subs-read duration-ms cause]} i]
         [;; view cell
          [:div {:data-rf-xray-resizable-col "view"
                 :style views-cell-view-style}
@@ -3342,6 +3394,7 @@
               "<anonymous view>"])
            (coord-chip/coord-chip (view-coord view-id)
                                   (str "rf-xray-epoch-view-row-coord-" i))]
+          (render-cause-chip cause i)
           (when (number? duration-ms)
             [:span {:style views-row-duration-style}
              (proj/format-duration-ms duration-ms)])]

--- a/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_view.cljs
@@ -257,15 +257,29 @@
 (defn- view-node
   "Render a view node — the cascade leaf + focus. Success-tinted box
   labelled `(rerendered)` (or `(mounted)`); carries the per-view
-  `:triggered-by` cause + `:elapsed-ms` timing as a sub-label
-  (rf2-8wrzz.1). Hovering toggles the pink DOM highlight (rf2-8l03l)."
+  render CAUSE + `:elapsed-ms` timing as a sub-label (rf2-8wrzz.1).
+
+  A view re-renders for exactly one of two reasons — a SUBSCRIPTION it
+  derefs changed value, or its PROPS changed (the orthogonal `:rf/props`
+  channel). The cause sub-label attributes which (rf2-bhi3t):
+  `← :sub-id` when `:triggered-by` is present, `← props` on a re-render
+  whose own subs all held value (the props channel). A mount carries no
+  cause — the `(mounted)` label already conveys the first render.
+  Hovering toggles the pink DOM highlight (rf2-8l03l)."
   [{:keys [id slug label action triggered-by elapsed-ms x y w h]}]
   (let [meta      (when id (rf/handler-meta :view id))
         disp-name (view-display-name id meta)
         coord     (when (string? (:file meta))
                     {:file (:file meta) :line (:line meta) :ns (:ns meta)})
-        sub-label (str "(" (if (= :mount action) "mounted" "rerendered") ")")
-        cause     (when triggered-by (str "← " (format-id triggered-by)))
+        mount?    (= :mount action)
+        sub-label (str "(" (if mount? "mounted" "rerendered") ")")
+        ;; rf2-bhi3t — props-driven re-render attribution. On a re-render
+        ;; with no `:triggered-by`, none of the view's own subs changed
+        ;; value, so the cause is props. Mounts show no cause.
+        cause     (cond
+                    triggered-by (str "← " (format-id triggered-by))
+                    mount?       nil
+                    :else        "← props")
         timing    (elapsed-label elapsed-ms)
         meta-line (->> [cause timing] (remove nil?) (string/join " · "))]
     [:g {:data-testid (str "rf-xray-reactive-view-node-" slug)

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -1481,6 +1481,51 @@
       (is (= [[:counter/total] [:counter/threshold]] (:subs-read row)))
       (is (= 1.2 (:duration-ms row))))))
 
+(deftest render-cause-classifier-test
+  (testing "rf2-bhi3t — `render-cause` classifies WHY a view rendered
+            purely from the substrate's `:rf.view/mount?` +
+            `:rf.view/triggered-by` slots"
+    (testing "first render → :mount (mount? true wins even with a
+              triggered-by present)"
+      (is (= :mount (proj/render-cause true nil)))
+      (is (= :mount (proj/render-cause true :counter/total))))
+
+    (testing "re-render whose deref'd sub changed value → {:kind :sub
+              :sub-id <id>}"
+      (is (= {:kind :sub :sub-id :counter/total}
+             (proj/render-cause false :counter/total)))
+      (is (= {:kind :sub :sub-id [:counter/total 7]}
+             (proj/render-cause false [:counter/total 7]))))
+
+    (testing "re-render with NO own sub change → :props (the orthogonal
+              :rf/props channel — the view re-rendered anyway)"
+      (is (= :props (proj/render-cause false nil)))
+      ;; nil mount? (absent slot) defaults to the re-render branch
+      (is (= :props (proj/render-cause nil nil))))))
+
+(deftest views-step-attributes-render-cause-test
+  (testing "rf2-bhi3t — each view-row carries a `:cause` attributing the
+            re-render to a sub-change vs a props-change. A view re-renders
+            for exactly one of two reasons (a deref'd sub changed, or its
+            props changed); the row makes that the first-class answer."
+    (let [s    (proj/views-step
+                 [;; Child A: re-rendered because :child-a/value changed
+                  (view-render-ev :app/ChildA [[:child-a/value]] 0.4
+                                  {:triggered-by :child-a/value})
+                  ;; Child B: re-rendered with NO own sub change → props
+                  (view-render-ev :app/ChildB [[:child-b/label]] 0.3 {})
+                  ;; Fresh mount → :mount (not a re-render cause)
+                  (view-render-ev :app/ChildC [] 0.2 {:mount? true})])
+          rows (:rows s)
+          [a b c] rows]
+      (is (= 3 (count rows)))
+      (is (= {:kind :sub :sub-id :child-a/value} (:cause a))
+          "sub-driven re-render attributes to the cause sub")
+      (is (= :props (:cause b))
+          "props-driven re-render (no own sub changed) attributes to props")
+      (is (= :mount (:cause c))
+          "fresh mount carries :mount, not a re-render cause"))))
+
 (deftest unmounted-views-rows-test
   (testing "rf2-gmw1i — `unmounted-views-rows` projects each
             `:rf.view/unmounted` trace event into a row with `:view-id`,

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -687,6 +687,36 @@
       (is (string/includes? subs ":counter/threshold")
           "every consumed sub renders, one per line"))))
 
+(deftest views-row-shows-render-cause-test
+  (testing "rf2-bhi3t — the VIEWS table attributes WHY each view
+            re-rendered: `← :sub-id` when a deref'd sub changed value,
+            `← props` when the re-render had no own sub change (the
+            orthogonal :rf/props channel). A fresh mount carries no
+            cause chip."
+    (let [step {:step :views :badge :VIEWS :step-number 6
+                :rows [{:view-id :app/ChildA
+                        :subs-read [[:child-a/value]]
+                        :cause {:kind :sub :sub-id :child-a/value}
+                        :duration-ms 0.4}
+                       {:view-id :app/ChildB
+                        :subs-read [[:child-b/label]]
+                        :cause :props
+                        :duration-ms 0.3}
+                       {:view-id :app/ChildC
+                        :subs-read []
+                        :cause :mount
+                        :duration-ms 0.2}]}
+          tree (view/render-views-step step)
+          a    (text-of tree "rf-xray-epoch-view-row-cause-0")
+          b    (text-of tree "rf-xray-epoch-view-row-cause-1")]
+      (is (some? a) "sub-driven row renders a cause chip")
+      (is (string/includes? a ":child-a/value")
+          "sub-driven cause names the cause sub")
+      (is (string/includes? b "props")
+          "props-driven re-render reads `← props`")
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-view-row-cause-2"))
+          "a fresh mount carries no render-cause chip"))))
+
 (deftest views-row-graceful-degrades-when-id-absent-test
   (testing "rf2-6djth — a row whose view-id is nil renders an
             anonymous-view placeholder rather than the bare keyword

--- a/tools/xray/test/day8/re_frame2_xray/panels/reactive_panel_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/reactive_panel_view_cljs_test.cljs
@@ -205,6 +205,42 @@
       (is (re-find #":cart/total" meta) "shows the triggered-by cause sub")
       (is (re-find #"2ms" meta) "shows the render timing"))))
 
+(deftest view-node-attributes-props-driven-rerender
+  (testing "rf2-bhi3t — a re-render with NO triggered-by (none of the
+            view's own subs changed value) attributes the cause to the
+            orthogonal :rf/props channel: the sub-label reads `← props`,
+            NOT a blank/missing cause and NOT a mislabelled sub."
+    (facade/install!)
+    (frame/reg-frame :rf/xray {})
+    (seed-reactive-data!
+      {:has-cascade? true :frame :rf/app :focus {:current :ep-1}
+       :counts {} :level-1-subs [] :level-2-subs []
+       :view-rows [{:view-id :cart/Badge :action :rerender
+                    :reason {:kind :structural} :elapsed-ms 0.5}]})
+    (let [tree (view/reactive-panel)
+          meta (text-of tree "rf-xray-reactive-view-meta-_cart_Badge")]
+      (is (some? meta) "view-node meta label renders")
+      (is (re-find #"rerendered" meta) "labelled (rerendered)")
+      (is (re-find #"← props" meta)
+          "props-driven re-render attributes the cause to props"))))
+
+(deftest view-node-mount-carries-no-render-cause
+  (testing "rf2-bhi3t — a fresh MOUNT carries no render-cause sub-label
+            (the `(mounted)` label already conveys the first render; the
+            cause question is about RE-renders)."
+    (facade/install!)
+    (frame/reg-frame :rf/xray {})
+    (seed-reactive-data!
+      {:has-cascade? true :frame :rf/app :focus {:current :ep-1}
+       :counts {} :level-1-subs [] :level-2-subs []
+       :view-rows [{:view-id :cart/Fresh :action :mount
+                    :reason {:kind :structural}}]})
+    (let [tree (view/reactive-panel)
+          meta (text-of tree "rf-xray-reactive-view-meta-_cart_Fresh")]
+      (is (re-find #"mounted" meta) "labelled (mounted)")
+      (is (not (re-find #"← " meta))
+          "no cause arrow on a mount"))))
+
 (deftest shared-sub-node-carries-fan-out-annotation
   (testing "rf2-ad7zx.6 — a sub read by ≥2 views is shared; the node
             carries a ×N annotation + fans out to N view nodes."

--- a/tools/xray/test/day8/re_frame2_xray/test_helpers/trace_event_builders.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/test_helpers/trace_event_builders.cljc
@@ -246,7 +246,19 @@
   `:rf.view/render` marker; only `:rf.view/rendered` carries
   `:rf.view/id` + `:rf.view/deref-subs` + `:rf.view/elapsed-ms`).
 
-  Two-arg form omits elapsed-ms; three-arg stamps it."
+  Two-arg form omits elapsed-ms; three-arg stamps it. The four-arg
+  form takes an `opts` map carrying the cascade-attribution slots the
+  substrate stamps conditionally (rf2-25zo2 / rf2-8wrzz.1) so render-
+  cause fixtures (rf2-bhi3t) match the emit shape one-for-one:
+
+    `:elapsed-ms`   — wall-clock render duration.
+    `:mount?`       — `true` on the instance's first render (mount),
+                      `false`/absent on a re-render. Stamped only when
+                      `true` (the substrate's `:rf.view/mount?` cond->
+                      shape — absent means re-render).
+    `:triggered-by` — the single sub-id whose value changed in the
+                      view's read-set (the per-view re-render cause).
+                      Absent on a structural / props-driven re-render."
   ([view-id deref-subs]
    (view-rendered-ev view-id deref-subs nil))
   ([view-id deref-subs elapsed-ms]
@@ -254,7 +266,14 @@
        (cond-> {:rf.view/id         view-id
                 :rf.view/deref-subs deref-subs}
          (some? elapsed-ms)
-         (assoc :rf.view/elapsed-ms elapsed-ms)))))
+         (assoc :rf.view/elapsed-ms elapsed-ms))))
+  ([view-id deref-subs elapsed-ms {:keys [mount? triggered-by]}]
+   (ev :rf.view :rf.view/rendered
+       (cond-> {:rf.view/id         view-id
+                :rf.view/deref-subs deref-subs}
+         (some? elapsed-ms)   (assoc :rf.view/elapsed-ms elapsed-ms)
+         (true? mount?)       (assoc :rf.view/mount? true)
+         (some? triggered-by) (assoc :rf.view/triggered-by triggered-by)))))
 
 (defn view-unmounted-ev
   "`:rf.view/unmounted` trace — drives the VIEWS UNMOUNTED sub-section


### PR DESCRIPTION
## What

A view re-renders for exactly one of two reasons: a **subscription** it derefs changed value, or its **props** changed (the orthogonal `:rf/props` channel). Xray surfaced the **sub-driven** cause (the per-view `:rf.view/triggered-by` shows as `← :sub-id`) but left the **props-driven** re-render with no attribution:

- the **Epoch Views table** showed no render cause at all, and
- the **Reactive panel** `view-node` showed a bare `(rerendered)` with no reason.

When debugging re-renders, "sub or props?" is the first question — this PR makes it the first-class inline answer.

## Settle-first finding (mandatory per the bead)

Investigated against a **fresh build of current main** (ran `npm run test:cljs` clean before any edit — 5041 tests green, ruling out the rf2-59hx3 stale-build trap). **Confirmed real gap**, NOT a stale artifact:

- The core trace already stamps everything needed on `:rf.view/rendered` — `:rf.view/mount?`, `:rf.view/triggered-by`, `:rf.view/deref-subs` (rf2-25zo2 / rf2-9hoos / rf2-8wrzz.1). No instrumentation gap.
- The gap was purely **tool-side display**: a re-render with no `:triggered-by` (none of the view's own subs changed value, so the cause is props) was shown blank in the Reactive panel and absent entirely in the Epoch Views table.

## Fix — tool-side only (no core / no spec-009 touch)

The cause is fully derivable from data already in the trace, so the fix lives entirely inside `tools/xray`:

- **projection** (`panels/epoch/projection.cljc`): a pure `render-cause` classifier + a per-row `:cause` slot — `:mount` / `{:kind :sub :sub-id <id>}` / `:props`.
- **Epoch Views table** (`panels/epoch/view.cljs`): a render-cause chip — `← :sub-id` (accent-tinted, via `ei/mini` for syntax-token chrome) when a deref'd sub changed value, `← props` (muted) on a props-driven re-render. Mounts carry no chip.
- **Reactive panel** (`reactive_panel_view.cljs` `view-node`): `← props` on a props-driven re-render instead of a blank cause; mounts still carry no cause. The parent is never named (rf2-8ve8z) — `props` is the attribution.
- **test fixture** (`trace_event_builders.cljc`): a 4-arity `view-rendered-ev` opts form (`:mount?` / `:triggered-by`) mirroring the substrate emit shape.

**No core render trace change. No spec/009 change.** Default tool-side expectation met.

## Spec

`tools/xray/spec/021-Dynamic-Panel-Designs.md` updated (the owning panels/epoch + reactive-flow-graph doc) — documents the `:cause` derivation + the props-vs-sub attribution + the `← :sub-id` / `← props` chips. **007-UX-IA.md untouched** (worker 7oxvd's lane). **No modal files touched.**

## Quality gates

- `npm run test:cljs` — **PASS** (5046 tests / 16889 assertions, 0 failures; +5 new attribution tests: `render-cause` classifier, projection `:cause` slot, Epoch table chip, Reactive node props + mount cases — all CLJS unit, no Playwright per the Causa/Story/Xray default)
- `npm run test:xray-feature-gate` — **PASS** (14 scenarios, 0 failures, 13 matrix rows)
- `clj-kondo` on touched files — **0 new errors/warnings** (baseline 18 == post-change 18; all pre-existing unrelated unused-var warnings)
- `npm run test:bundle-isolation` — **PASS** (Xray stays out of production bundles)

Closes rf2-bhi3t.
