### PR TITLE
feat(xray/testbed): redesign button-deck Views/subs — sub-driven + props-driven children, full sub lifecycle (rf2-fqzmb)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/button_deck_views_subs_lifecycle_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/button_deck_views_subs_lifecycle_cljs_test.cljs
@@ -1,0 +1,366 @@
+(ns re-frame.button-deck-views-subs-lifecycle-cljs-test
+  "Per rf2-fqzmb — substrate contract coverage for the button-deck
+  Views/subscriptions section's view + subscription LIFECYCLE.
+
+  The button-deck testbed (`tools/xray/testbeds/button_deck/core.cljs`)
+  is test-free (locked, rf2-8cevm): its BUTTONS demonstrate the
+  behaviour for Xray + re-frame2-pair inspection. The hard ASSERTIONS
+  live here — the substrate subs/views contract suite — exactly
+  mirroring the section's shape so the testbed wiring and the
+  framework contract are pinned together. Sibling to
+  `re-frame.sub-dispose-view-cljs-test` (the `:rf.sub/dispose` emit
+  axis); this file pins the cache-STATE + render-CAUSE axes.
+
+  The section has TWO children so re-render CAUSES are separable:
+
+    Child A — SUBSCRIPTION-driven. Subscribes an own L1→L2→L3 chain
+              (`:chain-root` → `:chain-doubled` → `:chain-labelled`)
+              PLUS the arg-keyed `[:button-deck/greater-than? N]` sub.
+    Child B — PROPS-driven. Receives a prop, subscribes NOTHING.
+
+  The five contract assertions (one per acceptance item):
+
+    1. Mounting A creates A's sub-cache entries — the chain L1/L2/L3
+       AND `[:button-deck/greater-than? 5]`.
+    2. Changing the sub-arg N (5 → 10) creates a DISTINCT
+       `[:button-deck/greater-than? 10]` cache entry — the
+       parameterized-sub cache is keyed by arg.
+    3. Changing a chain input recomputes L1→L2→L3 (invalidation
+       propagation down the chain).
+    4. Unmounting A disposes ALL of A's subs (last-reader-gone GC) —
+       the chain L1/L2/L3 + every `[:gt? N]` entry — and records the
+       unmount via `:rf.view/rendered` + the `:rf.sub/dispose` stream.
+    5. A render driven by an own-sub change names that sub on
+       `:rf.view/triggered-by` (Child A); a render driven by a PROPS
+       change does NOT (Child B) — the consumer reads the absence as
+       `← props changed`. (Pairs with the rf2-bhi3t render-cause Xray
+       work.)
+
+  Mechanism. A view's mount→render→deref path subscribes (a derefer
+  arriving) and the unmount path unsubscribes (the derefer dropping)
+  — the per-subscribe ref-count machinery in `re-frame.subs.cache`
+  (Spec 006 §Reference counting and disposal, rf2-cmfln). These tests
+  stand in for the view by driving the subscribe/unsubscribe pairs
+  directly with the Reagent adapter installed and inspecting the
+  frame's `:sub-cache` atom (keyed by the query-vector, per
+  `re-frame.subs/cache-key` = identity). That keeps them headless
+  (no JSDOM / Playwright) and matches the test-surface convention
+  used by `sub-dispose-view-cljs-test`. The render-cause assertion
+  (item 5) drives a real `(rf/view ...)` render inside a cascade so
+  the substrate-agnostic `views.cljs` wrapper stamps
+  `:rf.view/triggered-by` from the in-flight buffer.
+
+  The subs / views here are byte-for-byte the testbed's, registered
+  under the same `:button-deck/*` ids, so a drift between the testbed
+  and this contract surfaces as a failure here.
+
+  ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support])
+  (:require-macros [re-frame.test-support :refer [with-trace-recorder!]]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter reagent-adapter/adapter}))
+
+;; ===========================================================================
+;; The button-deck Views/subs section, replicated verbatim
+;; ===========================================================================
+;;
+;; Child A's own L1→L2→L3 chain rooted at :views/chain-input (NOT :base —
+;; that feeds the testbed's flow), plus the arg-keyed greater-than? sub.
+
+(defn- register-section-subs! []
+  (rf/reg-sub :button-deck/chain-root            ;; L1
+    (fn [db _] (get-in db [:views :chain-input])))
+  (rf/reg-sub :button-deck/chain-doubled         ;; L2
+    :<- [:button-deck/chain-root]
+    (fn [root _] (* 2 root)))
+  (rf/reg-sub :button-deck/chain-labelled        ;; L3
+    :<- [:button-deck/chain-doubled]
+    (fn [doubled _] (str "2×input = " doubled)))
+  (rf/reg-sub :button-deck/greater-than?         ;; DYNAMIC, arg-keyed
+    :<- [:button-deck/chain-root]
+    (fn [root [_ threshold]] (> root threshold))))
+
+(defn- register-section-events! []
+  (rf/reg-event-db :button-deck/seed
+    (fn [_ _] {:views {:a-mounted?  false
+                       :b-mounted?  false
+                       :threshold   5
+                       :chain-input 1
+                       :b-prop      "alpha"}}))
+  (rf/reg-event-db :button-deck/perturb-chain
+    (fn [db _] (update-in db [:views :chain-input] inc))))
+
+;; Child A's full read-set, stood up as the view's mount-time subscribes.
+;; Returns the held reactions so a test can deref / unsubscribe them as a
+;; mount → unmount pair. `threshold` is A's prop (the arg-key driver).
+(defn- mount-a!
+  [threshold]
+  {:chain     (rf/subscribe [:button-deck/chain-labelled])
+   :gt        (rf/subscribe [:button-deck/greater-than? threshold])
+   :threshold threshold})
+
+(defn- unmount-a!
+  "The unmount path: every subscribe A made on mount drops its derefer."
+  [{:keys [threshold]}]
+  (rf/unsubscribe [:button-deck/chain-labelled])
+  (rf/unsubscribe [:button-deck/greater-than? threshold]))
+
+(defn- sub-cache
+  "The frame's live sub-cache map (cache-key → entry). Keys are the
+  query-vectors themselves (cache-key = identity)."
+  []
+  @(:sub-cache (frame/frame :rf/default)))
+
+(defn- cached?
+  "Is `query-v` present in the live sub-cache?"
+  [query-v]
+  (contains? (sub-cache) query-v))
+
+;; ===========================================================================
+;; #1 — mounting A creates its sub-cache entries
+;; ===========================================================================
+
+(deftest mounting-a-creates-chain-and-arg-keyed-cache-entries
+  (testing "rf2-fqzmb #1: mounting Child A subscribes its own L1→L2→L3
+   chain AND the arg-keyed [:button-deck/greater-than? 5] sub — every
+   one lands a sub-cache entry. The chain's intermediate L1 (:chain-root)
+   + L2 (:chain-doubled) materialise via the cascade even though A only
+   names the L3 + the gt? sub directly."
+    (register-section-subs!)
+    (register-section-events!)
+    (rf/dispatch-sync [:button-deck/seed])
+
+    (is (empty? (sub-cache)) "precondition: cold cache before mount")
+
+    (let [held (mount-a! 5)]
+      (is (= "2×input = 2" @(:chain held))
+          "chain L3 computes against the seeded :chain-input")
+      (is (false? @(:gt held))
+          "gt? 5: chain-root 1 is NOT > 5")
+
+      ;; A's whole read-set is cached, including the cascaded chain inputs.
+      (is (cached? [:button-deck/chain-labelled])
+          "L3 :chain-labelled cached (A's direct deref)")
+      (is (cached? [:button-deck/chain-doubled])
+          "L2 :chain-doubled cached (cascaded input)")
+      (is (cached? [:button-deck/chain-root])
+          "L1 :chain-root cached (cascaded input)")
+      (is (cached? [:button-deck/greater-than? 5])
+          "arg-keyed [:gt? 5] cached")
+
+      (unmount-a! held))))
+
+;; ===========================================================================
+;; #2 — changing the sub-arg N creates a DISTINCT cache entry
+;; ===========================================================================
+
+(deftest changing-the-arg-creates-a-distinct-cache-entry
+  (testing "rf2-fqzmb #2: the parameterized-sub cache is keyed by arg.
+   With A mounted at N=5, changing the arg to N=10 (the testbed's
+   button 11) materialises a NEW [:button-deck/greater-than? 10] entry
+   ALONGSIDE the original [:button-deck/greater-than? 5] — two distinct
+   slots over the one registration."
+    (register-section-subs!)
+    (register-section-events!)
+    (rf/dispatch-sync [:button-deck/seed])
+
+    (let [held-5 (mount-a! 5)]
+      @(:gt held-5)
+      (is (cached? [:button-deck/greater-than? 5])
+          "[:gt? 5] cached after the N=5 mount")
+      (is (not (cached? [:button-deck/greater-than? 10]))
+          "precondition: no [:gt? 10] slot yet")
+
+      ;; The arg changes (5 → 10): the root re-renders A with the new
+      ;; prop, so A subscribes the new query-vector.
+      (let [held-10 (mount-a! 10)]
+        @(:gt held-10)
+        (is (cached? [:button-deck/greater-than? 10])
+            "[:gt? 10] is a NEW, distinct cache entry — cache keyed by arg")
+        (is (cached? [:button-deck/greater-than? 5])
+            "[:gt? 5] still present — distinct slot, not overwritten")
+        (is (not (identical? (:gt held-5) (:gt held-10)))
+            "the two args yield two distinct reactions")
+
+        (unmount-a! held-5)
+        (unmount-a! held-10)))))
+
+;; ===========================================================================
+;; #3 — changing a chain input recomputes L1→L2→L3
+;; ===========================================================================
+
+(deftest perturbing-chain-input-recomputes-the-chain
+  (testing "rf2-fqzmb #3: with A mounted, perturbing the chain input
+   (the testbed's button 12) propagates invalidation down L1 (:chain-root)
+   → L2 (:chain-doubled) → L3 (:chain-labelled). The L3 value the view
+   reads reflects the new root — the recompute reached the leaf."
+    (register-section-subs!)
+    (register-section-events!)
+    (rf/dispatch-sync [:button-deck/seed])
+
+    (let [held (mount-a! 5)]
+      (is (= "2×input = 2" @(:chain held))
+          "precondition: L3 = 2×1 against the seeded root")
+
+      ;; Perturb the L1 root. The chain reaction graph invalidates and
+      ;; recomputes through to the leaf the view derefs.
+      (rf/dispatch-sync [:button-deck/perturb-chain])
+
+      (is (= 2 (get-in (frame/frame-app-db-value :rf/default)
+                       [:views :chain-input]))
+          "L1 source advanced 1 → 2")
+      (is (= "2×input = 4" @(:chain held))
+          "L3 recomputed to 2×2 = 4 — invalidation propagated L1→L2→L3")
+      (is (false? @(:gt held))
+          "[:gt? 5] still false off the shared root (2 is not > 5)")
+
+      (unmount-a! held)))
+
+  (testing "rf2-fqzmb #3 (gt? recompute): once the root crosses the
+   threshold the arg-keyed sub flips — same shared L1 drives both legs."
+    (register-section-subs!)
+    (register-section-events!)
+    (rf/dispatch-sync [:button-deck/seed])
+    (let [held (mount-a! 1)]
+      (is (false? @(:gt held)) "precondition: root 1 is not > 1")
+      (rf/dispatch-sync [:button-deck/perturb-chain]) ;; root → 2
+      (is (true? @(:gt held)) "[:gt? 1] flipped true after root 1 → 2")
+      (unmount-a! held))))
+
+;; ===========================================================================
+;; #4 — unmounting A disposes ALL of A's subs
+;; ===========================================================================
+
+(deftest unmounting-a-disposes-every-sub-and-records-the-unmount
+  (testing "rf2-fqzmb #4: unmounting Child A (the testbed's button 13)
+   drops the last derefer on every sub A held, so the synchronous
+   last-reader-gone GC evicts ALL of them — the chain L1/L2/L3 AND
+   every [:gt? N] entry the section accumulated — and the unmount is
+   RECORDED on the :rf.sub/dispose trace stream."
+    (register-section-subs!)
+    (register-section-events!)
+    (rf/dispatch-sync [:button-deck/seed])
+
+    ;; Mount A, change the arg (so TWO [:gt? N] entries accumulate), then
+    ;; unmount — the full set must dispose.
+    (let [held-5  (mount-a! 5)
+          _       (do @(:chain held-5) @(:gt held-5))
+          held-10 (mount-a! 10)
+          _       (do @(:chain held-10) @(:gt held-10))]
+      ;; Precondition: the whole accumulated read-set is cached.
+      (doseq [k [[:button-deck/chain-labelled]
+                 [:button-deck/chain-doubled]
+                 [:button-deck/chain-root]
+                 [:button-deck/greater-than? 5]
+                 [:button-deck/greater-than? 10]]]
+        (is (cached? k) (str "precondition: " (pr-str k) " cached")))
+
+      (with-trace-recorder! [disposes {:pred #(= :rf.sub/dispose (:operation %))}]
+        ;; Unmount A: drop every derefer. chain-labelled is held by both
+        ;; mounts (ref-count 2), so it disposes only on the LAST drop —
+        ;; pinning the last-reader-gone invariant.
+        (unmount-a! held-5)
+        (is (cached? [:button-deck/chain-labelled])
+            "chain L3 still cached after the first unmount — ref-count 2→1")
+        (unmount-a! held-10)
+
+        ;; Every slot A held is gone.
+        (doseq [k [[:button-deck/chain-labelled]
+                   [:button-deck/chain-doubled]
+                   [:button-deck/chain-root]
+                   [:button-deck/greater-than? 5]
+                   [:button-deck/greater-than? 10]]]
+          (is (not (cached? k))
+              (str (pr-str k) " disposed — last reader gone")))
+        (is (empty? (sub-cache))
+            "A's whole read-set evicted; cache drained")
+
+        ;; The unmount is RECORDED: a :rf.sub/dispose fired for each
+        ;; evicted sub-id with the ref-count-drop reason.
+        (let [ids (into #{} (map #(get-in % [:tags :rf.sub/id])) @disposes)]
+          (is (contains? ids :button-deck/chain-labelled)
+              ":rf.sub/dispose recorded for the chain L3")
+          (is (contains? ids :button-deck/chain-doubled)
+              ":rf.sub/dispose recorded for the chain L2")
+          (is (contains? ids :button-deck/chain-root)
+              ":rf.sub/dispose recorded for the chain L1")
+          (is (contains? ids :button-deck/greater-than?)
+              ":rf.sub/dispose recorded for the arg-keyed sub"))
+        (is (every? #(= :no-more-derefers (get-in % [:tags :rf.sub/reason]))
+                    @disposes)
+            "every dispose carries :reason :no-more-derefers (ref-count-drop)")))))
+
+;; ===========================================================================
+;; #5 — render cause: sub-driven (A) vs props-driven (B)
+;; ===========================================================================
+;;
+;; The substrate-agnostic views.cljs wrapper stamps :rf.view/triggered-by
+;; on :rf.view/rendered when an own sub of the view changed value in the
+;; cascade; it is ABSENT on a render with no changed own sub (the
+;; consumer reads the absence as ← props / parent re-render). Child A
+;; names its sub; Child B (props-only) names nothing.
+
+(def ^:private view-rendered-pred
+  #(= :rf.view/rendered (:operation %)))
+
+(deftest child-a-render-named-by-its-sub-child-b-by-props
+  (testing "rf2-fqzmb #5: Child A (subscription-driven) re-renders ←
+   a SUB changed, so :rf.view/rendered names that sub on
+   :rf.view/triggered-by. Child B (props-driven) subscribes nothing, so
+   its re-render names NO sub — the foil. Pairs with the rf2-bhi3t Xray
+   render-cause attribution."
+    (register-section-subs!)
+    (register-section-events!)
+    (rf/dispatch-sync [:button-deck/seed])
+
+    ;; Child A — subscription-driven. Derefs the chain leaf.
+    (rf/reg-view ^{:rf/id :button-deck/child-a} child-a [_threshold]
+      [:div @(rf/subscribe [:button-deck/chain-labelled])])
+
+    ;; Child B — props-driven. Subscribes nothing; renders its prop.
+    (rf/reg-view ^{:rf/id :button-deck/child-b} child-b [prop]
+      [:div prop])
+
+    (with-trace-recorder! [traces {:pred view-rendered-pred}]
+      ;; A renders INSIDE the perturb cascade: the handler bumps the
+      ;; chain root (its first recompute reports value-changed? into the
+      ;; in-flight buffer), then A renders and its deref-sink records
+      ;; [:button-deck/chain-labelled]. The intersection resolves
+      ;; :triggered-by to A's own changed sub.
+      (let [render-a (rf/view :button-deck/child-a)]
+        (rf/reg-event-fx :button-deck/perturb-then-render-a
+          (fn [_ _]
+            @(rf/subscribe [:button-deck/chain-labelled])
+            (render-a 5)
+            {}))
+        (rf/dispatch-sync [:button-deck/perturb-then-render-a]))
+
+      ;; B renders INSIDE a cascade too, but reads NO sub. Its render
+      ;; is driven by the prop it was handed.
+      (let [render-b (rf/view :button-deck/child-b)]
+        (rf/reg-event-fx :button-deck/render-b
+          (fn [_ _]
+            (render-b "beta")
+            {}))
+        (rf/dispatch-sync [:button-deck/render-b]))
+
+      (let [a-ev (first (filter #(= :button-deck/child-a
+                                    (get-in % [:tags :rf.view/id]))
+                                @traces))
+            b-ev (first (filter #(= :button-deck/child-b
+                                    (get-in % [:tags :rf.view/id]))
+                                @traces))]
+        (is (some? a-ev) "Child A emitted :rf.view/rendered")
+        (is (= :button-deck/chain-labelled
+               (get-in a-ev [:tags :rf.view/triggered-by]))
+            "A re-render is attributed to its own changed sub (sub-driven)")
+
+        (is (some? b-ev) "Child B emitted :rf.view/rendered")
+        (is (not (contains? (:tags b-ev) :rf.view/triggered-by))
+            "B names NO sub — render driven by props, the foil to A")))))

--- a/tools/xray/testbeds/button_deck/core.cljs
+++ b/tools/xray/testbeds/button_deck/core.cljs
@@ -34,16 +34,26 @@
     App-db  — #1 scalar bump · #6 added key · #7 removed key · #8 changed
               nested value (diff-mode-3) · #9 large collection · #5 flow
               writes a derived slot.
-    Views   — #10 mount a view (L2 sub created) · #11 mount with an arg
-              ([:gt? N] cache entry) · #12 change the arg (new cache
-              entry) · #13 unmount (node gone, last-reader L2 destroyed)
-              · #14 recompute an L1→L2→L3 chain.
+    Views   — two children make re-render CAUSES separable. Child A is
+              SUBSCRIPTION-driven (an own L1→L2→L3 chain + the arg-keyed
+              `[:button-deck/greater-than? N]` sub); Child B is
+              PROPS-driven (a prop, NO subs). #10 mount A (node + the
+              sub-cache entries appear) · #11 change the arg N (a NEW
+              [:gt? N] cache entry — cache keyed by arg) · #12 change a
+              chain input (L1→L2→L3 invalidation recompute; A re-renders
+              ← a SUB changed) · #13 unmount A (node gone, ALL of A's
+              subs disposed, the unmount recorded) · #14 mount B (props
+              view, NO subs created) · #15 change B's prop (B re-renders
+              ← PROPS changed — the foil to #12). The section lives on
+              its OWN slots (`:views/*`), so mount/unmount/sub state is
+              exercised DIRECTLY — no start-at-button-1 sequencing, no
+              :base/flow confound.
     Trace   — every button emits trace; #3 a managed fx, #4 a cascade,
-              #5 a flow recompute, #14 a sub-chain recompute.
-    Issues  — #15 handler exception (db rolls back) · #16 interceptor
-              exception · #17 coeffect exception · #18 effect exception
-              (post-commit, best-effort) · #19 slow fx flagged ·
-              #20 event-args schema violation · #21 app-db schema
+              #5 a flow recompute, #12 a sub-chain recompute.
+    Issues  — #16 handler exception (db rolls back) · #17 interceptor
+              exception · #18 coeffect exception · #19 effect exception
+              (post-commit, best-effort) · #20 slow fx flagged ·
+              #21 event-args schema violation · #22 app-db schema
               violation (survives rollback).
 
   ## Test surface, not tutorial
@@ -89,20 +99,35 @@
 ;;
 ;; One flat, named seed. `:baseline` is the shared counter every button
 ;; bumps. `:shapes` is the playground the App-db diff buttons mutate.
-;; `:base` feeds the L1→L2→L3 sub chain. `:view` holds the frame-scoped
-;; UI state the Views buttons toggle (mount/threshold) — kept in app-db
-;; (not a component-local atom) so it is observable in Xray.
+;; `:base` feeds button #5's flow only.
+;;
+;; `:views` holds the Views/subscriptions section's OWN state — kept on
+;; its own slots, NOT linked to `:baseline`/`:base`, so the section's
+;; mount/unmount/sub behaviour is exercised DIRECTLY (no start-at-button-1
+;; sequencing, no :base/flow confound). It is app-db state (not a
+;; component-local atom) so it is observable in Xray:
+;;
+;;   :a-mounted? / :b-mounted?  — the two children's mount slots.
+;;   :threshold                 — N, the changeable arg to the dynamic
+;;                                sub `[:button-deck/greater-than? N]`.
+;;   :chain-input               — the root of Child A's own L1→L2→L3
+;;                                chain (button #12 perturbs it).
+;;   :b-prop                    — the prop fed to the props-driven
+;;                                Child B (button #15 changes it).
 
 (def initial-db
   {:baseline 0
    :shapes   {}
    :base     1
    :auth     {:token "seed-token"}
-   :view     {:mounted?  false
-              :threshold 5}})
+   :views    {:a-mounted?  false
+              :b-mounted?  false
+              :threshold   5
+              :chain-input 1
+              :b-prop      "alpha"}})
 
 (rf/reg-event-db :button-deck/reset
-  {:doc "Button 0 — re-seed app-db and unmount any child view. Start clean."}
+  {:doc "Button 0 — re-seed app-db and unmount both child views. Start clean."}
   (fn handler-reset [_db _ev]
     initial-db))
 
@@ -284,39 +309,66 @@
   (fn handler-write-large [db _ev]
     (-> db bump (assoc-in [:shapes :large] (vec (range 200))))))
 
-;; -- 10..13. Views / subscriptions: mount, arg, change-arg, unmount ----------
-(rf/reg-event-db :button-deck/mount-view
-  {:doc "Button 10 — mount the child view (sets :view/mounted? true). The
-         child subscribes :button-deck/parity, creating an L2 sub; Views
-         shows the node + sub appear."}
-  (fn handler-mount-view [db _ev]
-    (-> db bump (assoc-in [:view :mounted?] true))))
+;; -- 10..15. Views / subscriptions — sub-driven Child A + props-driven Child B
+;;
+;; The whole section lives on the `:views` slots, decoupled from the
+;; counter: a button MAY bump `:baseline`, but mount/unmount/sub state is
+;; never linked to a counter VALUE. Two children separate the re-render
+;; CAUSE — Child A re-renders ← a SUB changed (#12); Child B re-renders ←
+;; PROPS changed (#15).
+
+(rf/reg-event-db :button-deck/mount-a
+  {:doc "Button 10 — mount the SUBSCRIPTION-driven Child A (sets
+         :views/a-mounted? true). On mount A subscribes its own
+         L1→L2→L3 chain (:chain-root → :chain-doubled → :chain-labelled)
+         PLUS the arg-keyed `[:button-deck/greater-than? N]` sub — so
+         Views shows the node and those sub-cache entries appear."}
+  (fn handler-mount-a [db _ev]
+    (-> db bump (assoc-in [:views :a-mounted?] true))))
 
 (rf/reg-event-db :button-deck/set-threshold
-  {:doc "Buttons 11/12 — set the threshold N (the changeable argument to
-         the dynamic sub `[:button-deck/greater-than? N]`). A new N is a
-         distinct sub cache entry."}
+  {:doc "Button 11 — change the sub-arg N (5 → 10). `[:button-deck/
+         greater-than? N]` is keyed by its arg, so the new N is a NEW,
+         distinct sub-cache entry alongside the old one."}
   (fn handler-set-threshold [db [_ n]]
-    (-> db bump (assoc-in [:view :threshold] n))))
+    (-> db bump (assoc-in [:views :threshold] n))))
 
-(rf/reg-event-db :button-deck/unmount-view
-  {:doc "Button 13 — unmount the child view. Views shows the node
-         disappear; its L2 subs are destroyed once the last reader is
-         gone."}
-  (fn handler-unmount-view [db _ev]
-    (-> db bump (assoc-in [:view :mounted?] false))))
+(rf/reg-event-db :button-deck/perturb-chain
+  {:doc "Button 12 — perturb Child A's chain input (:views/chain-input).
+         With A mounted, Views shows the L1 (:chain-root) → L2
+         (:chain-doubled) → L3 (:chain-labelled) invalidation recompute,
+         and A re-renders BECAUSE A SUB CHANGED (← :button-deck/chain-
+         labelled), not because its props changed."}
+  (fn handler-perturb-chain [db _ev]
+    (-> db bump (update-in [:views :chain-input] inc))))
 
-;; -- 14. recompute a sub chain (perturb :base with the chain mounted) --------
-(rf/reg-event-db :button-deck/perturb-base
-  {:doc "Button 14 — perturb :base. With the chain view mounted, Views
-         shows the L1 (:base) → L2 (doubled) → L3 (labelled) invalidation
-         recompute."}
-  (fn handler-perturb-base [db _ev]
-    (-> db bump (update :base inc))))
+(rf/reg-event-db :button-deck/unmount-a
+  {:doc "Button 13 — unmount Child A (sets :views/a-mounted? false). The
+         node disappears and ALL of A's subs are disposed once the last
+         reader is gone (the chain L1/L2/L3 + every [:gt? N] cache
+         entry); the unmount is recorded."}
+  (fn handler-unmount-a [db _ev]
+    (-> db bump (assoc-in [:views :a-mounted?] false))))
 
-;; -- 15. exception in the handler → Issues: handler-exception, db rolls back -
+(rf/reg-event-db :button-deck/mount-b
+  {:doc "Button 14 — mount the PROPS-driven Child B (sets
+         :views/b-mounted? true). B receives a prop and subscribes
+         NOTHING, so Views shows the node appear with NO new sub-cache
+         entries."}
+  (fn handler-mount-b [db _ev]
+    (-> db bump (assoc-in [:views :b-mounted?] true))))
+
+(rf/reg-event-db :button-deck/set-b-prop
+  {:doc "Button 15 — change Child B's prop. B re-renders BECAUSE ITS
+         PROPS CHANGED (no sub cause) — the foil to button 12's
+         sub-driven re-render."}
+  (fn handler-set-b-prop [db _ev]
+    (-> db bump (update-in [:views :b-prop]
+                           {"alpha" "beta" "beta" "gamma" "gamma" "alpha"}))))
+
+;; -- 16. exception in the handler → Issues: handler-exception, db rolls back -
 (rf/reg-event-db :button-deck/throw-handler
-  {:doc "Button 15 — throw in the handler. The router catches it; the :db
+  {:doc "Button 16 — throw in the handler. The router catches it; the :db
          effect (the baseline bump) rolls back; Issues shows
          `:rf.error/handler-exception` with the source coord."}
   (fn handler-throw [db _ev]
@@ -324,23 +376,23 @@
     (throw (ex-info "button-deck / handler (intentional — exercises the handler error surface)"
                     {:surface :handler-exception}))))
 
-;; -- 16. exception in an interceptor (:before) → Issues: interceptor exc. ----
+;; -- 17. exception in an interceptor (:before) → Issues: interceptor exc. ----
 (rf/reg-event-db :button-deck/throw-interceptor
-  {:doc "Button 16 — an interceptor throws in :before. Issues shows the
+  {:doc "Button 17 — an interceptor throws in :before. Issues shows the
          interceptor exception; the handler never runs."}
   [throwing-interceptor]
   (fn handler-after-throwing-interceptor [db _ev] (bump db)))
 
-;; -- 17. exception in a coeffect handler → Issues: cofx error ----------------
+;; -- 18. exception in a coeffect handler → Issues: cofx error ----------------
 (rf/reg-event-fx :button-deck/throw-cofx
-  {:doc "Button 17 — a coeffect throws on injection. Issues shows the
+  {:doc "Button 18 — a coeffect throws on injection. Issues shows the
          cofx error; the handler never runs."}
   [(rf/inject-cofx :button-deck/throwing-cofx)]
   (fn handler-after-throwing-cofx [{:keys [db]} _ev] {:db (bump db)}))
 
-;; -- 18. exception in an effect handler (post-commit) → Issues: fx error -----
+;; -- 19. exception in an effect handler (post-commit) → Issues: fx error -----
 (rf/reg-event-fx :button-deck/throw-fx
-  {:doc "Button 18 — the :db commits (baseline bumps), then a post-commit
+  {:doc "Button 19 — the :db commits (baseline bumps), then a post-commit
          fx throws. Issues shows the fx error; post-commit fx are
          best-effort per the FX atomicity asymmetry, so the db delta
          survives."}
@@ -348,9 +400,9 @@
     {:db (bump db)
      :fx [[:button-deck/boom {}]]}))
 
-;; -- 19. slow effect (~600ms managed fx) → Issues: slow-fx flagged -----------
+;; -- 20. slow effect (~600ms managed fx) → Issues: slow-fx flagged -----------
 (rf/reg-event-fx :button-deck/slow
-  {:doc "Button 19 — issue a ~600ms managed fx. Status moves :loading;
+  {:doc "Button 20 — issue a ~600ms managed fx. Status moves :loading;
          Issues flags the slow fx; the reply lands :loaded ~600ms later."}
   (fn handler-slow [{:keys [db]} _ev]
     {:db (-> db bump (assoc :slow-status :loading))
@@ -362,17 +414,17 @@
   (fn handler-slow-done [db _ev]
     (assoc db :slow-status :loaded)))
 
-;; -- 20. schema violation, bad event args → Issues / Schema-timeline ---------
+;; -- 21. schema violation, bad event args → Issues / Schema-timeline ---------
 (rf/reg-event-db :button-deck/bad-event-args
-  {:doc "Button 20 — dispatched with a bad arg (a string where a pos-int
+  {:doc "Button 21 — dispatched with a bad arg (a string where a pos-int
          is required). The handler is skipped; Issues / Schema-timeline
          shows `:rf.error/schema-validation-failure :where :event`."
    :schema [:cat [:= :button-deck/bad-event-args] pos-int?]}
   (fn handler-bad-event-args [db _ev] (bump db)))
 
-;; -- 21. schema violation, app-db write → Issues: app-db schema failure ------
+;; -- 22. schema violation, app-db write → Issues: app-db schema failure ------
 (rf/reg-event-db :button-deck/bad-app-db-write
-  {:doc "Button 21 — write an int into [:auth :token] (the registered
+  {:doc "Button 22 — write an int into [:auth :token] (the registered
          app-schema requires a string). The post-handler app-db
          validation rolls the :db back; Issues shows the app-db schema
          failure, which survives the rollback."}
@@ -384,59 +436,83 @@
 ;; ============================================================================
 
 ;; L1 — read app-db directly.
-(rf/reg-sub :button-deck/baseline  (fn [db _] (:baseline db)))
-(rf/reg-sub :button-deck/mounted?  (fn [db _] (get-in db [:view :mounted?])))
-(rf/reg-sub :button-deck/threshold (fn [db _] (get-in db [:view :threshold])))
-(rf/reg-sub :button-deck/base      (fn [db _] (:base db)))
+(rf/reg-sub :button-deck/baseline    (fn [db _] (:baseline db)))
+(rf/reg-sub :button-deck/a-mounted?  (fn [db _] (get-in db [:views :a-mounted?])))
+(rf/reg-sub :button-deck/b-mounted?  (fn [db _] (get-in db [:views :b-mounted?])))
+(rf/reg-sub :button-deck/threshold   (fn [db _] (get-in db [:views :threshold])))
+(rf/reg-sub :button-deck/b-prop      (fn [db _] (get-in db [:views :b-prop])))
 
-;; L2 — derived from :baseline. Created when the child view first reads it
-;; and destroyed when the last reader unmounts — the observable Views
-;; create/destroy surface.
-(rf/reg-sub :button-deck/parity
-  :<- [:button-deck/baseline]
-  (fn [n _] (if (even? n) "even" "odd")))
+;; Child A's OWN L1 → L2 → L3 chain, rooted at :views/chain-input (NOT
+;; :base — that feeds button #5's flow). Button #12 perturbs the root;
+;; with A mounted, Views shows the L1 → L2 → L3 invalidation recompute.
+(rf/reg-sub :button-deck/chain-root            ;; L1
+  (fn [db _] (get-in db [:views :chain-input])))
 
-;; L2 — DYNAMIC, parameterised by the threshold carried in the query
-;; vector. `[:button-deck/greater-than? n]` cascades from :baseline; a
-;; different n is a distinct cache entry over the same registration.
+(rf/reg-sub :button-deck/chain-doubled         ;; L2
+  :<- [:button-deck/chain-root]
+  (fn [root _] (* 2 root)))
+
+(rf/reg-sub :button-deck/chain-labelled        ;; L3
+  :<- [:button-deck/chain-doubled]
+  (fn [doubled _] (str "2×input = " doubled)))
+
+;; DYNAMIC, parameterised by the threshold N carried in the query
+;; vector: `[:button-deck/greater-than? n]`. It cascades from the chain
+;; root (a section-owned value, so the sub's behaviour is NOT linked to
+;; a counter value). A different n is a DISTINCT cache entry over the
+;; same registration — button #11 (5 → 10) creates a new [:gt? 10]
+;; entry alongside the original [:gt? 5].
 (rf/reg-sub :button-deck/greater-than?
-  :<- [:button-deck/baseline]
-  (fn [n [_ threshold]] (> n threshold)))
-
-;; The L1 → L2 → L3 chain rooted at :base (button #14 perturbs the root).
-(rf/reg-sub :button-deck/base-doubled         ;; L2
-  :<- [:button-deck/base]
-  (fn [base _] (* 2 base)))
-
-(rf/reg-sub :button-deck/base-labelled        ;; L3
-  :<- [:button-deck/base-doubled]
-  (fn [doubled _] (str "2×base = " doubled)))
+  :<- [:button-deck/chain-root]
+  (fn [root [_ threshold]] (> root threshold)))
 
 ;; ============================================================================
-;; CHILD VIEW (mounted / unmounted by buttons 10..14)
+;; CHILD VIEWS — two children, separable re-render causes
 ;; ============================================================================
 ;;
-;; While mounted it reads the L2 parity sub, the changeable-arg
-;; greater-than? sub, and the L1→L2→L3 chain — so the Views lens shows
-;; the node + its sub-cache entries appear, change with the threshold,
-;; and the chain recompute.
+;; Child A is SUBSCRIPTION-driven; Child B is PROPS-driven. Keeping the
+;; two causes on two separate components is what lets Xray attribute a
+;; re-render to "← a sub changed" (A) vs "← props changed" (B).
 
-(reg-view child-view []
-  (let [n         @(subscribe [:button-deck/baseline])
-        threshold @(subscribe [:button-deck/threshold])]
-    [:div {:data-testid "button-deck-child"
+;; --- Child A — subscription-driven -----------------------------------------
+;;
+;; On mount A subscribes its own L1→L2→L3 chain AND the arg-keyed
+;; `[:button-deck/greater-than? threshold]` sub — so the Views lens
+;; shows the node + those sub-cache entries appear, the chain recompute
+;; (button #12), and a NEW [:gt? N] cache entry when the arg changes
+;; (button #11). `threshold` arrives as a PROP from the root (which
+;; reads :views/threshold), so the arg-key is driven by app-db state
+;; while the deref itself is A's own subscription.
+
+(reg-view child-a [threshold]
+  (let [labelled @(subscribe [:button-deck/chain-labelled])
+        over?    @(subscribe [:button-deck/greater-than? threshold])]
+    [:div {:data-testid "button-deck-child-a"
            :style {:border "1px solid #d8d2ff" :border-radius "6px"
                    :padding "0.5em 0.75em" :margin "0.5em 0"
                    :background "#fcfbff"}}
      [:div {:style {:font-size "11px" :color "#7C5CFF" :font-weight "bold"
                     :text-transform "uppercase" :letter-spacing "0.04em"}}
-      "Child view (mounted)"]
-     [:div "parity: " [:strong @(subscribe [:button-deck/parity])]]
-     [:div "greater-than? " threshold ": "
-      [:strong (str @(subscribe [:button-deck/greater-than? threshold]))]]
-     [:div "chain: " [:strong @(subscribe [:button-deck/base-labelled])]]
-     [:div {:style {:color "#888" :font-size "11px"}}
-      "baseline = " n]]))
+      "Child A — subscription-driven"]
+     [:div "chain (L1→L2→L3): " [:strong labelled]]
+     [:div "greater-than? " threshold ": " [:strong (str over?)]]]))
+
+;; --- Child B — props-driven ------------------------------------------------
+;;
+;; B receives a single prop and subscribes NOTHING. Mounting it (button
+;; #14) creates no sub-cache entries; changing the prop (button #15)
+;; re-renders B because its PROPS changed — the foil to A's sub-driven
+;; re-render.
+
+(reg-view child-b [prop]
+  [:div {:data-testid "button-deck-child-b"
+         :style {:border "1px solid #d8efd8" :border-radius "6px"
+                 :padding "0.5em 0.75em" :margin "0.5em 0"
+                 :background "#fbfffb"}}
+   [:div {:style {:font-size "11px" :color "#2e8b57" :font-weight "bold"
+                  :text-transform "uppercase" :letter-spacing "0.04em"}}
+    "Child B — props-driven (no subs)"]
+   [:div "prop: " [:strong prop]]])
 
 ;; ============================================================================
 ;; THE BUTTON LADDER
@@ -465,31 +541,33 @@
     [:button-deck/change-value]]
    [9  "Write a large collection" "edn-inspector: collapse / expand + elision"
     [:button-deck/write-large]]
-   [:section "Views / subscriptions"]
-   [10 "Mount a view"          "Views: a new node (and its L2 sub) appears"
-    [:button-deck/mount-view]]
-   [11 "Mount-arg → threshold 5" "Views: a sub cache entry keyed by [:gt? 5]"
-    [:button-deck/set-threshold 5]]
-   [12 "Change the arg → 10"   "Views: a new cache entry for the new arg [:gt? 10]"
+   [:section "Views / subscriptions — sub-driven A vs props-driven B"]
+   [10 "Mount Child A (sub-driven)"  "Views: node + A's sub-cache entries appear (chain L1/L2/L3 + [:gt? 5])"
+    [:button-deck/mount-a]]
+   [11 "Change the sub-arg N → 10"   "Views: a NEW cache entry [:gt? 10] (parameterized-sub cache keyed by arg)"
     [:button-deck/set-threshold 10]]
-   [13 "Unmount the view"      "Views: node disappears; L2 sub destroyed (last reader gone)"
-    [:button-deck/unmount-view]]
-   [14 "Recompute a sub chain" "Views: L1 (:base) → L2 → L3 invalidation recompute"
-    [:button-deck/perturb-base]]
+   [12 "Perturb A's chain input"     "Views: L1→L2→L3 invalidation recompute; A re-renders ← a SUB changed"
+    [:button-deck/perturb-chain]]
+   [13 "Unmount Child A"             "Views: node gone; ALL of A's subs disposed (last reader gone); unmount recorded"
+    [:button-deck/unmount-a]]
+   [14 "Mount Child B (props-driven)" "Views: node appears with NO subs created"
+    [:button-deck/mount-b]]
+   [15 "Change B's prop"             "Views: B re-renders ← PROPS changed (foil to #12's sub-driven re-render)"
+    [:button-deck/set-b-prop]]
    [:section "Errors / Issues — each a real feature, not a buggy demo"]
-   [15 "Exception in the handler"     "Issues: handler-exception + source coord; db rolls back"
+   [16 "Exception in the handler"     "Issues: handler-exception + source coord; db rolls back"
     [:button-deck/throw-handler]]
-   [16 "Exception in an interceptor"  "Issues: interceptor exception (:before); handler skipped"
+   [17 "Exception in an interceptor"  "Issues: interceptor exception (:before); handler skipped"
     [:button-deck/throw-interceptor]]
-   [17 "Exception in a coeffect"      "Issues: cofx error; handler skipped"
+   [18 "Exception in a coeffect"      "Issues: cofx error; handler skipped"
     [:button-deck/throw-cofx]]
-   [18 "Exception in an effect"       "Issues: fx error (post-commit, best-effort); db delta survives"
+   [19 "Exception in an effect"       "Issues: fx error (post-commit, best-effort); db delta survives"
     [:button-deck/throw-fx]]
-   [19 "Slow effect (~600ms)"         "Issues: slow-fx flagged; status loading → loaded"
+   [20 "Slow effect (~600ms)"         "Issues: slow-fx flagged; status loading → loaded"
     [:button-deck/slow]]
-   [20 "Bad event args"               "Issues / Schema-timeline: event-args schema failure"
+   [21 "Bad event args"               "Issues / Schema-timeline: event-args schema failure"
     [:button-deck/bad-event-args "not-a-number"]]
-   [21 "Bad app-db write"             "Issues: app-db schema failure (survives rollback)"
+   [22 "Bad app-db write"             "Issues: app-db schema failure (survives rollback)"
     [:button-deck/bad-app-db-write]]])
 
 (defn- testid-for [event]
@@ -539,16 +617,22 @@
              :style {:padding "0.4em 0.8em" :cursor "pointer"
                      :border "1px solid #cfc8ff" :border-radius "6px"
                      :background "#f4f1ff" :margin "0.5em 0"}}
-    "0. Reset — re-seed app-db, unmount the child view"]
+    "0. Reset — re-seed app-db, unmount both child views"]
    ;; The ladder.
    (for [row ladder]
      (if (= :section (first row))
        ^{:key (second row)} [section-heading (second row)]
        (let [[n label caption event] row]
          ^{:key n} [ladder-button n label caption event])))
-   ;; The child view, mounted / unmounted by buttons 10..14.
-   (when @(subscribe [:button-deck/mounted?])
-     [child-view])])
+   ;; The two children, mounted / unmounted by buttons 10..15. Child A
+   ;; (sub-driven) takes the threshold N as a prop — read from
+   ;; :views/threshold here so the arg-key is driven by app-db state
+   ;; while A owns the actual deref. Child B (props-driven) takes its
+   ;; prop directly.
+   (when @(subscribe [:button-deck/a-mounted?])
+     [child-a @(subscribe [:button-deck/threshold])])
+   (when @(subscribe [:button-deck/b-mounted?])
+     [child-b @(subscribe [:button-deck/b-prop])])])
 
 ;; ============================================================================
 ;; MOUNT


### PR DESCRIPTION
Redesign the button-deck testdeck's Views/subscriptions section to cleanly exercise the view + subscription **lifecycle**, backed by a CLJS substrate contract test. The testbed buttons demonstrate the behaviour (Xray + pair inspection); the testbed stays test-free per rf2-8cevm — the hard assertions live in the substrate subs/views contract suite.

## What changed

**Decoupled from the counter.** The section now lives on its own `:views` slots (`:a-mounted?`, `:b-mounted?`, `:threshold`, `:chain-input`, `:b-prop`). A button may still bump `:baseline`, but mount/unmount/sub state is never linked to a counter value — so the section is exercised directly (no "start at button 1 and run through" sequencing, no `:base`/flow confound that the old button 14 had; `:base` is left to button #5's flow alone).

**Two children → separable re-render causes.**
- **Child A — subscription-driven.** Subscribes its own L1→L2→L3 chain (`:chain-root` → `:chain-doubled` → `:chain-labelled`) plus the arg-keyed `[:button-deck/greater-than? N]` sub. The threshold `N` arrives as a prop (read from `:views/threshold`) so the arg-key is driven by app-db state while A owns the deref.
- **Child B — props-driven.** Receives one prop, subscribes nothing.

**Buttons (section is now 6; Issues renumbered 16-22):**
1. **10 Mount A** → node + sub-cache entries appear (chain L1/L2/L3 + `[:gt? 5]`).
2. **11 Change sub-arg N (5→10)** → a NEW `[:gt? 10]` cache entry (parameterized-sub cache keyed by arg).
3. **12 Perturb A's chain input** → L1→L2→L3 invalidation recompute; A re-renders ← a SUB changed.
4. **13 Unmount A** → node gone, ALL of A's subs disposed (last reader gone), unmount recorded.
5. **14 Mount B** → props view, NO subs created.
6. **15 Change B's prop** → B re-renders ← PROPS changed (foil to #12).

**Substrate contract tests** (`re-frame.button-deck-views-subs-lifecycle-cljs-test`, Reagent adapter, headless — sibling to `sub-dispose-view-cljs-test`): mount A creates the chain L1/L2/L3 + `[:gt? 5]` cache entries; changing the arg creates a distinct `[:gt? 10]` entry; perturbing the chain root recomputes L1→L2→L3; unmounting A disposes every sub (chain + every `[:gt? N]`) on last-reader-gone GC and records the unmount via `:rf.sub/dispose`; render-cause foil — Child A's re-render is named on `:rf.view/triggered-by`, Child B's is absent (= props-driven).

## Supersedes rf2-1umxr

This redesign supersedes **rf2-1umxr** (the `:button-deck/parity` L2 child-view wiring mismatch — same section). The old child read L1 subs directly while the docstrings/captions claimed it created/destroyed an L2 `:parity` sub it never subscribed. The redesigned Child A genuinely subscribes everything it advertises (the chain + the arg-keyed sub), so the create/dispose surface the testbed demonstrates is real. The mayor will close rf2-1umxr on merge — not closed here.

## Quality gates

- `npm run test:cljs` — **5051 tests, 16928 assertions, 0 failures, 0 errors** (includes the 6 new contract deftests).
- Build the button_deck testbed (`shadow-cljs compile examples/button-deck`) — **424 compiled, 0 warnings** (buttons wire up + compile).
- clj-kondo on the two touched files — **0 errors, 0 warnings**.
- `npm run test:bundle-isolation` — **PASS** (17 artefact entries, 35 sentinels absent; uix/helix/reagent-free PASS).

## Lane

Touched only `tools/xray/testbeds/button_deck/core.cljs` + the new CLJS substrate subs/views contract test under `implementation/`. No epoch-panel, `spec/009`, or instrumentation files touched (worker ahhgn's lane).
