### PR TITLE
docs(story): reserve :rf.story.inline/* in Story Conventions + fix citations (rf2-2ljqf)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -291,7 +291,8 @@ rather than forking it:
    thread `:fragment-lookup` / `:check-lookup` / `:lookup` so the plan can
    compose REGISTERED fragments + checks, or run host-free);
 2. an ANONYMOUS frame id is minted in the reserved `:rf.story.inline/*`
-   namespace — never a registered variant id, so the Story side-table
+   namespace ([Conventions.md §`:rf.story.*` framework carve-out](Conventions.md#the-rfstory-framework-carve-out)
+   owns the closed member set) — never a registered variant id, so the Story side-table
    queries (variant ids, variants-by-story) can't surface it and a
    concurrent registered run can't collide; the frame is stamped
    `:rf/inline? true`. That stamp is the discriminator the live-frame

--- a/tools/story/spec/Conventions.md
+++ b/tools/story/spec/Conventions.md
@@ -28,6 +28,7 @@ Story-emitted framework events and panel ids live under the framework's `:rf.*` 
 | `:rf.story/*` | Story-emitted events (`:rf.story/save-current-as-variant`) and built-in decorator ids (`:rf.story/force-fx-stub`). | [005-SOTA-Features.md](005-SOTA-Features.md) |
 | `:rf.story.panel/*` | Story-panel registration ids (`:rf.story.panel/schema-validation`, `:rf.story.panel/layout-debug`). The `panel` segment is the discriminator so a reader scanning a panel id can tell the registry kind. | [003-Render-Shell.md](003-Render-Shell.md) §Panel registration contract |
 | `:rf.story.layout-debug/*` | Built-in layout-debug decorator ids (`:rf.story.layout-debug/measure`, `:rf.story.layout-debug/outline`, `:rf.story.layout-debug/pseudo`). | [005-SOTA-Features.md](005-SOTA-Features.md) §Layout debug |
+| `:rf.story.inline/*` | Anonymous inline-plan frame ids (`:rf.story.inline/plan-1`, `:rf.story.inline/plan-2`, …), minted per-run by `mint-inline-frame-id` for an inline (map-target) plan execution. Never a registered variant id, so an inline frame can neither collide with nor appear alongside a navigable variant. | [017-Testing-Story.md](017-Testing-Story.md) §Inline plan |
 
 Third-party Story extensions MUST NOT register handlers, fx, subs, panels, or decorators under `:rf.story.*`. Library authors choose their own top-level prefix per [framework Conventions §Library-owned prefixes](../../../spec/Conventions.md#library-owned-prefixes).
 

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -1138,8 +1138,10 @@
 
 (defn- mint-inline-frame-id
   "Mint a fresh anonymous frame id for an inline-plan run, in the reserved
-  `:rf.story.inline/*` namespace (spec/Conventions.md §Reserved
-  namespaces). A monotonic counter keeps concurrent inline runs on
+  `:rf.story.inline/*` namespace (Story's spec/Conventions.md
+  §`:rf.story.*` framework carve-out, which owns the closed member set;
+  the framework's spec/Conventions.md reserves the `:rf.story.*`
+  sub-namespace). A monotonic counter keeps concurrent inline runs on
   distinct frames; the id is never a registered variant id, so an inline
   run can never collide with — or appear alongside — a navigable variant."
   []


### PR DESCRIPTION
Closes rf2-2ljqf. PR #2434 review found that `mint-inline-frame-id` mints anonymous inline-plan frame ids in the `:rf.story.inline/*` namespace, but its docstring and `017-Testing-Story.md:293` both cited *"spec/Conventions.md §Reserved namespaces"* — an anchor the framework Conventions does not actually contain (its `:rf.story/*` row is conditional "would be", not an active reservation). A citation pointing at a non-existent anchor.

## Fix — option a′ (reserve-and-delegate, tool-local)

Mike RULED option a′ on the bead: the reserve-and-delegate layering is already the documented design (Story's `Conventions.md` §`:rf.story.*` framework carve-out: *"the framework reserves the sub-namespace; Story owns the closed member set"*). The framework's row-34 `:rf.<tool>/*` convention already covers the `:rf.story.*` segment, so NO framework hot-zone edit is needed — this is entirely tool-local.

Three scoped edits:

1. **`tools/story/spec/Conventions.md`** — add a `:rf.story.inline/*` row to the §`:rf.story.*` framework carve-out closed-member table, describing it as the anonymous inline-plan frame-id namespace minted per-run by `mint-inline-frame-id` for inline (map-target) plan execution. Spec column links `017 §Inline plan` (the owning spec), matching the existing rows' format.
2. **`tools/story/src/re_frame/story/runtime.cljc`** — `mint-inline-frame-id` docstring repointed to cite *Story's `spec/Conventions.md` §`:rf.story.*` framework carve-out* as the owner of the member set, noting the framework reserves the `:rf.story.*` sub-namespace (the upward chain). Docstring-only; no behaviour change.
3. **`tools/story/spec/017-Testing-Story.md`** — the "reserved `:rf.story.inline/*` namespace" claim now links the now-real member-table entry.

## Verified references

- Minted namespace confirmed `:rf.story.inline/*` at `runtime.cljc:1148` — `(keyword "rf.story.inline" (str "plan-" ...))`.
- Existing carve-out table (`Conventions.md:26-30`) + its prose (`:24` "framework reserves the sub-namespace; Story owns the closed member set") — `:rf.story.inline/*` was NOT yet present; new row matches the `| Sub-namespace | Closed member set | Spec |` format.
- §Inline plan heading exists at `017-Testing-Story.md:275`, so the table link target resolves.
- Anchor slug `#the-rfstory-framework-carve-out` verified against in-repo precedent (`#the-rfhydrate-event` from `### The :rf/hydrate event`, `#the-rfroute-slice`): backticks / `:` / `.` / `*` stripped, spaces hyphenated.
- Out-of-scope §Reserved namespaces mentions in `story.cljc:777` / `save_variant.cljc:530` / `005-SOTA-Features.md:565` are about the general `:rf.<tool>/*` convention and the `:rf.story/*` prefix, not the inline frame-id namespace — left untouched.

## Quality gates

- `clj-kondo` on `runtime.cljc` — **0 errors, 0 warnings** (1321-line file parsed, exit 0).
- `npm run test:cljs` — **0 failures, 0 errors** (1118 files compiled, 0 warnings; 5046 tests / 16889 assertions). Story still compiles.
- No runtime/behaviour change; no framework `spec/Conventions.md` (hot-zone) edit. Doc + one docstring only.
