### PR TITLE
docs(mkdocs): remove footer — drop copyright line + generator notice (rf2-yk8uv)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,8 +6,6 @@ site_url: https://day8.github.io/re-frame2/
 repo_name: day8/re-frame2
 repo_url: https://github.com/day8/re-frame2
 
-copyright: Copyright &copy; 2014-2026 Michael Thompson
-
 # All published markdown lives under docs/ at build time. The narrative
 # guide already lives under docs/guide/. The normative spec lives at the
 # repo root in spec/ — the docs.yml CI step copies spec/ into docs/spec/
@@ -144,6 +142,7 @@ extra_css:
   - cljs/playground.css
 
 extra:
+  generator: false
   social:
     - icon: fontawesome/brands/github-alt
       link: https://github.com/day8


### PR DESCRIPTION
## Summary

Removes the mkdocs site footer per rf2-yk8uv. Two config-only edits in `mkdocs.yml`:

1. **Removed the `copyright:` line** — was `Copyright &copy; 2014-2026 Michael Thompson`. This drops the copyright footer text.
2. **Added `generator: false`** under the existing `extra:` block — suppresses the Material theme auto-generated "Made with Material for MkDocs" footer notice.

`extra.social` is preserved.

## Quality gates

- `mkdocs` is **not installed in the worker env** (`mkdocs: command not found`), so `mkdocs build --strict` is **CI-deferred** to the docs gate. No global tooling was installed.
- YAML validated locally: the file parses cleanly (handling mkdocs custom `!ENV` / `!!python/name:` tags). Asserted post-edit: `copyright` key absent, `extra.generator == false`, `extra.social` preserved.
- The diff is exactly the two intended edits, nothing else touched.

Closes rf2-yk8uv.