### PR TITLE
fix(xray+core): epoch :outcome reflects failures + per-step inline errors in Epoch (rf2-ahhgn)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -2017,7 +2017,7 @@ verbatim; no DOM concern bleeds into the data layer.
 
 | Sub | Reads | Yields |
 |-----|-------|--------|
-| `:rf.xray/epoch-pipeline` | `:rf.xray/focus` · `:rf.xray/epoch-history` (via the shared `panels.shared.focus-resolver`) | `{:status :no-focus | :focused | :epoch-evicted, :epoch-id, :record, :steps}` |
+| `:rf.xray/epoch-pipeline` | `:rf.xray/focus` · `:rf.xray/epoch-history` (via the shared `panels.shared.focus-resolver`) | `{:status :no-focus | :focused | :epoch-evicted, :epoch-id, :record, :steps, :outcome :ok｜:error}` — `:outcome` is the rf2-ahhgn tool-side outcome (`projection/epoch-outcome`; `:error` when any step carries an exception or violation), NOT the framework epoch-record slot (§9.1.10.5) |
 | `:rf.xray.epoch/expanded-rows` | `:epoch-panel-expanded-rows` slot | `#{[step-kw row-id] …}` |
 | `:rf.xray.epoch/subs-filter-mode` | `:epoch-panel-subs-filter-mode` slot | keyword `:all / :changed / :unchanged` (rf2-tzmmf — SUBSCRIPTIONS step's `[all][changed][unchanged]` button-bar; supersedes rf2-kfh1v's boolean `subs-show-unchanged?`. Default `:changed` preserves the rf2-kfh1v hide-unchanged-by-default rationale) |
 
@@ -2300,6 +2300,102 @@ Sections / step are conditional — `:violations` slot is absent
 when no violation attached to that step. Hot-reload drift no
 longer rides any pipeline step (rf2-7gf7v); it surfaces in the
 Issues panel only.
+
+### §9.1.10.4 Inline EXCEPTION attachment + per-step ✓/✗ status (rf2-ahhgn)
+
+> **Motivation.** A handler / interceptor / coeffect / fx / flow
+> EXCEPTION (distinct from a schema VIOLATION) leaves a
+> `:rf.error/*` cascade trace but, pre-rf2-ahhgn, surfaced
+> NOWHERE in the Epoch panel — the cascade rendered as if it ran
+> clean. Clicking button-15 (`:button-deck/throw-handler`) showed
+> nothing explaining the failure, and the framework epoch
+> `:outcome` read `:ok`. This section adds inline per-step error
+> cards + a per-step pass/fail glyph + a tool-side outcome so a
+> failed event is visible where the operator is already looking.
+
+**Per-step ✓/✗ status primitive.** Every pipeline step carries a
+`:status` of `:ok` / `:error` (`projection/step-status`). The view
+paints a glyph immediately after the step's badge pill —
+`badge/step-status-glyph` (✓ / ✗) coloured by
+`badge/step-status-colour` (`:success` green / `:error` red). A
+clean step paints the quiet green ✓; a failed step paints the bold
+red ✗ so the operator eye-scans the cascade for the failing step
+without reading every label. `step-status` reads the step's
+stamped `:status` slot first, then falls back to scanning the
+step-level + row-level `:errors` / `:violations` vecs (so a step
+that gained a schema violation via `attach-violations` — which does
+not stamp `:status` — still reads `:error`). **rf2-kt6js reuses
+this exact `:status` shape + the `badge/step-status-*` resolver for
+its SIDE-EFFECTS sub-steps' per-effect ticks — it is a shared
+primitive, not a one-off.**
+
+**Exception harvesting + attachment.** The projection harvests the
+`cascade-exception-ops` subset into per-step error records
+(`projection/exception-row` → `exception-rows`) and attaches each
+to its owning step via `attach-exceptions` (a sibling of
+`attach-violations`, run immediately after it). Each touched step
+gains the attached record under `:errors` (step-level) or its
+matching row's `:errors` (FX row-level) AND `:status :error`.
+
+| Trace op | Owning step | Granularity |
+|----------|-------------|-------------|
+| `:rf.error/handler-exception` | HANDLER | step-level (handler / interceptor / coeffect throw — the chain is the unit that threw) |
+| `:rf.error/fx-handler-exception` | FX, row whose `:fx-id` = `:failing-id` | row-level (fallback step-level) |
+| `:rf.error/no-such-fx` | FX | step-level (fallback) |
+| `:rf.error/flow-eval-exception` | FLOW | step-level (fallback HANDLER when no FLOW step) |
+
+The error MESSAGE rides `[:tags :exception-message]` (handler / fx
+throws — `re-frame.router/emit-handler-exception!` stamps the
+exception's `.getMessage`) with `[:tags :reason]` as fallback; the
+failing handler's SOURCE-COORD rides the hoisted top-level
+`:rf.trace/trigger-handler :source-coord` slot (with
+`:rf.trace/call-site` as fallback). These are the SAME slots the
+Issues panel's `short-description` / `source-coord` read — the bead's
+original probe checked `:message` / `:source` / `:error-id`, which
+the substrate does not stamp (the empty-tags symptom).
+
+**Inline error card.** `view/error-block` renders a red-edged card
+(sibling to the amber schema-violation card; `:bg-violation`
+background, `:error` border) carrying: a `✗ Exception` title bar +
+`Rolled back` recovery chip; a one-line human headline keyed off the
+op + interceptor `:phase` ("The event handler threw." / "An
+interceptor / coeffect threw (:before)." / "The :http/post effect
+threw."); the verbatim `ex-info` message (monospace); and a
+jump-to-source link reading `file:line` (the shared `coord-link`,
+degrading to muted "source unavailable" when no coord was captured).
+HANDLER / FLOW inject `(error-blocks step-key errors)` under their
+body; FX injects per-row cards via `fx-row-with-violations` plus a
+step-level `(error-blocks :fx errors)` for unmatched fx ids.
+
+### §9.1.10.5 Epoch outcome — tool-side, NOT the framework slot (rf2-ahhgn)
+
+The `:rf.xray/epoch-pipeline` composite sub carries an `:outcome`
+(`:ok` / `:error`) from `projection/epoch-outcome` — `:error` when
+ANY projected step reads `step-status :error`. The Panel paints a
+red **outcome banner** above the pipeline on `:error` ("This event
+failed — see the ✗ step below.") and stamps `data-rf-xray-outcome`
+on the panel root; a clean cascade paints no banner (silence is the
+success signal — no green reassurance chrome on the common case).
+
+**This is the TOOL-SIDE outcome** — the same trace-derived
+`:error`/`:ok` signal `event-status-colour/cascade-outcome` already
+computes for the L2 list / Event header / Trace bar (a cascade
+carrying an `:rf.error/*` trace reads `:error`). It is
+**DELIBERATELY NOT** the framework `:rf/epoch-record` `:outcome`
+slot, which stays `:ok` for a recovered handler exception **by
+spec**: the reference runtime recovers handler exceptions through
+the interceptor error-capture seam and settles `:ok` with the error
+trace under `:trace-events` (per
+[spec/Spec-Schemas §`:rf/epoch-record` §Outcomes](../../../spec/Spec-Schemas.md#rfepoch-record)
++ [spec/009 §`:rf.epoch/*`](../../../spec/009-Instrumentation.md#op-type-vocabulary)
+— `:halted-handler-exception` is RESERVED for a future
+drain-aborting runtime). Surfacing the framework slot's `:ok` as the
+panel's outcome was the rf2-ahhgn bug; deriving from the trace
+stream fixes it **without a framework-contract change** — which
+would have rippled into `restore-epoch`'s non-`:ok` refusal + Story
+outcome chips + MCP wire consumers + the pinned
+`outcome-enum-projection-pins-mapping` test. No spec/009 /
+Spec-Schemas edit was needed (rf2-ahhgn settle-first finding).
 
 ### §9.1.10.6 FX section header + per-action attribution (rf2-uffov · rf2-m8ac9)
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/badge.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/badge.cljc
@@ -344,3 +344,57 @@
     :threw     "✗"
     :cancelled "·"
     "·"))
+
+;; ---- Per-step pass/fail status primitive (rf2-ahhgn) --------------------
+;;
+;; Every pipeline step (DISPATCH / COEFFECT / HANDLER / FLOW / FX /
+;; SUBSCRIPTIONS / VIEWS) carries a `:status` of `:ok` or `:error`
+;; (projection/`step-status`). The view paints a ✓ (ok) / ✗ (error)
+;; glyph on each step header off this primitive so the operator
+;; eye-scans the cascade for the FAILING step without reading every
+;; label — the failure that pre-rf2-ahhgn was invisible (handler /
+;; interceptor / coeffect / fx exceptions surfaced NOWHERE in the
+;; cascade).
+;;
+;; This is the GENERAL per-step status shape rf2-kt6js's SIDE-EFFECTS
+;; sub-steps reuse for their per-effect ticks (:db / :fx / other) — one
+;; glyph + token resolver, not a one-off. The closed `:ok` / `:error`
+;; set mirrors the machine-cascade row outcome chrome above (✓ green /
+;; ✗ red); a step with no failure reads `:ok` and paints the quiet ✓.
+
+(def step-status-set
+  "Closed set of per-step statuses (rf2-ahhgn). Tests + the view's
+  glyph-resolver bail-out read this set."
+  #{:ok :error})
+
+(defn step-status?
+  "Predicate — `status` keyword is a member of `step-status-set`."
+  [status]
+  (contains? step-status-set status))
+
+(defn step-status-token-key
+  "Theme-token keyword for a per-step status glyph colour (rf2-ahhgn):
+    :ok    → :success  (✓ green)
+    :error → :error    (✗ red)
+  Falls back to `:success` for unknown statuses so a never-failed step
+  paints the quiet success tick."
+  [status]
+  (case status
+    :error :error
+    :success))
+
+(defn step-status-colour
+  "CSS-variable string for a per-step status glyph (rf2-ahhgn)."
+  [status]
+  (get tokens/tokens (step-status-token-key status)
+       (get tokens/tokens :success)))
+
+(defn step-status-glyph
+  "Single-char glyph for a per-step status (rf2-ahhgn):
+    :ok    → \"✓\"
+    :error → \"✗\"
+  Defaults to the success tick for unknown statuses."
+  [status]
+  (case status
+    :error "✗"
+    "✓"))

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -1669,6 +1669,230 @@
 ;; consumes them. The Epoch panel's pipeline now stays
 ;; exclusively for runtime-cascade events.
 
+;; ---- INLINE EXCEPTION attachment (rf2-ahhgn) ----------------------------
+;;
+;; A handler / interceptor / coeffect / fx EXCEPTION (distinct from a
+;; schema VIOLATION) leaves a `:rf.error/*` cascade trace but, pre-rf2-ahhgn,
+;; surfaced NOWHERE in the Epoch panel — the cascade rendered as if it ran
+;; clean and the epoch read `:outcome :ok` (the framework recovers handler
+;; exceptions through the interceptor error-capture seam and settles `:ok`
+;; deliberately — per spec/009 §`:rf.epoch/*` + Spec-Schemas §`:rf/epoch-record`
+;; §Outcomes; we do NOT touch that framework slot — see rf2-ahhgn settle-first).
+;;
+;; This block harvests the cascade-level exception traces and attaches each
+;; to its OWNING pipeline step, mirroring the schema-`attach-violations`
+;; mechanism. The error MESSAGE rides `[:tags :exception-message]` (or
+;; `[:tags :reason]`); the failing handler's SOURCE-COORD rides the hoisted
+;; top-level `:rf.trace/trigger-handler :source-coord` slot (or
+;; `:rf.trace/call-site`) — confirmed against `re-frame.router/
+;; emit-handler-exception!` + `re-frame.trace/build-event` (rf2-ahhgn
+;; settle-first prong 2; the bead's probe checked `:message` / `:source`,
+;; which the substrate does not stamp).
+;;
+;; The error-record + per-step `:status` (`:ok` / `:error`) primitive this
+;; introduces is GENERAL — rf2-kt6js's future SIDE-EFFECTS sub-steps reuse
+;; the same `step-status` + `error-record` shape rather than rolling a
+;; one-off.
+
+(def cascade-exception-ops
+  "Closed set of cascade-level `:rf.error/*` trace ops the Epoch panel
+  surfaces as INLINE per-step exceptions (rf2-ahhgn). Schema-validation
+  failures are NOT here — they ride the distinct `schema-violation-rows`
+  + `attach-violations` path (they carry `:explain` + `:where` + recovery
+  chrome, not an exception message). New exception ops extend this set
+  AND the `exception-op->step` table in lockstep.
+
+  - `:rf.error/handler-exception` — a handler / interceptor `:before` or
+    `:after` / injected-coeffect threw; the chain captured it into
+    `:rf/interceptor-error` and the router emitted this op (the `:db`/`:fx`
+    did NOT apply — db rolled back). Owns the HANDLER step.
+  - `:rf.error/fx-handler-exception` — a registered fx-handler threw during
+    the post-commit fx walk. Owns the FX step (best-effort per-row match on
+    `:rf.fx/id`; falls back to step-level).
+  - `:rf.error/no-such-fx` — the handler returned an fx-id with no
+    registered handler. Owns the FX step.
+  - `:rf.error/flow-eval-exception` — a flow's compute fn threw (pre-commit
+    abort). Owns the FLOW step (step-level; the throwing flow aborted the
+    cascade)."
+  #{:rf.error/handler-exception
+    :rf.error/fx-handler-exception
+    :rf.error/no-such-fx
+    :rf.error/flow-eval-exception})
+
+(def ^:private exception-op->step
+  "Map a cascade-exception trace op → the `:step` keyword of the pipeline
+  step it attaches to (rf2-ahhgn). The router emits a handler / interceptor
+  / coeffect throw all as `:rf.error/handler-exception` (the interceptor
+  chain is the unit that threw), so all three attach to HANDLER — correct
+  for the headline button-15 (handler) + button-16 (interceptor) cases and
+  acceptable for button-17 (the coeffect throw aborts the handler chain)."
+  {:rf.error/handler-exception    :handler
+   :rf.error/fx-handler-exception :fx
+   :rf.error/no-such-fx           :fx
+   :rf.error/flow-eval-exception  :flow})
+
+(defn- exception-message
+  "Lift the human-readable failure message off an exception trace event
+  (rf2-ahhgn). Reads `[:tags :exception-message]` (handler / fx throws —
+  `re-frame.router/emit-handler-exception!` stamps the exception's
+  `.getMessage`) then `[:tags :reason]` (the canonical terse summary).
+  nil when neither is present."
+  [ev]
+  (let [msg (or (common/tag-of ev :exception-message)
+                (common/tag-of ev :reason))]
+    (when (and (string? msg) (not= "" msg)) msg)))
+
+(defn- exception-source-coord
+  "Resolve the `{:file :line}` source-coord of the failing handler off an
+  exception trace event (rf2-ahhgn). The handler's reg-site coord rides
+  the hoisted top-level `:rf.trace/trigger-handler :source-coord` slot
+  (per `re-frame.trace/build-event`); the dispatch call-site
+  (`:rf.trace/call-site`) is the fallback. nil when neither carries a
+  `:file`."
+  [ev]
+  (let [coord (or (some-> (:rf.trace/trigger-handler ev) :source-coord)
+                  (:rf.trace/call-site ev)
+                  (common/tag-of ev :rf.trace/call-site))]
+    (when (and (map? coord) (:file coord)) coord)))
+
+(defn exception-row
+  "Project one cascade-exception trace event into the per-step error
+  record (rf2-ahhgn). Mirrors the issues-ribbon projection shape so the
+  inline display reads the same message + coord the Issues panel does:
+
+      {:operation  <error-op kw>           ;; e.g. :rf.error/handler-exception
+       :message    <string-or-nil>         ;; the exception message / reason
+       :coord      <{:file :line}-or-nil>  ;; failing handler's source-coord
+       :failing-id <kw-or-nil>             ;; the failing handler / fx id
+       :phase      <kw-or-nil>             ;; :before / :after (interceptor)
+       :recovery   <kw-or-nil>             ;; e.g. :no-recovery
+       :raw        <trace-event>}          ;; the underlying trace event
+
+  Pure-data; the view's `error-block` renders message + coord + jump-to-
+  source. Empty slots are tolerated absent by the view."
+  [ev]
+  {:operation  (op ev)
+   :message    (exception-message ev)
+   :coord      (exception-source-coord ev)
+   :failing-id (or (common/tag-of ev :rf.fx/id)
+                   (common/tag-of ev :failing-id)
+                   (common/tag-of ev :handler-id))
+   :phase      (common/tag-of ev :phase)
+   :recovery   (or (:recovery ev) (common/tag-of ev :recovery))
+   :raw        ev})
+
+(defn exception-rows
+  "Walk every cascade-exception trace event in `events` (the
+  `cascade-exception-ops` subset) into a vec of `exception-row` records
+  in trace order (rf2-ahhgn). Empty vec when none fired."
+  [events]
+  (vec
+    (for [ev events
+          :when (contains? cascade-exception-ops (op ev))]
+      (exception-row ev))))
+
+(defn- attach-to-fx-error-row
+  "Attach an fx exception row to the FX step's matching `:fx-id` row
+  (rf2-ahhgn). When `:failing-id` matches a row's `:fx-id`, attach there;
+  otherwise attach to the step-level `:errors`. Mirrors
+  `attach-to-fx-row` for schema violations."
+  [step row]
+  (let [fx-id (:failing-id row)]
+    (if (some #(= fx-id (:fx-id %)) (:rows step))
+      (update step :rows
+              (fn [rows]
+                (mapv (fn [r]
+                        (if (= fx-id (:fx-id r))
+                          (update r :errors (fnil conj []) row)
+                          r))
+                      rows)))
+      (update step :errors (fnil conj []) row))))
+
+(defn attach-exceptions
+  "Take a projected step vector + a vec of `exception-row` records and
+  return the step vector with each exception attached to its owning step
+  (rf2-ahhgn — per `exception-op->step`). Returns `steps` unchanged when
+  `rows` is empty.
+
+  Attachment is step-level for HANDLER / FLOW (the exception aborted that
+  step's work) and row-level (matching `:fx-id`) for FX, falling back to
+  step-level when no row matches. Each touched step additionally gains
+  `:status :error` so the per-step ✓/✗ primitive paints the failure
+  glyph; the same `:status` slot is what rf2-kt6js's SIDE-EFFECTS sub-
+  steps will reuse."
+  [steps rows]
+  (if (empty? rows)
+    steps
+    (reduce
+      (fn [s row]
+        (let [target-step (get exception-op->step (:operation row))
+              i           (index-of #(= target-step (:step %)) s)]
+          (if i
+            (update s i
+                    (fn [step]
+                      (-> (if (= :fx target-step)
+                            (attach-to-fx-error-row step row)
+                            (update step :errors (fnil conj []) row))
+                          (assoc :status :error))))
+            ;; No owning step in the cascade (e.g. a flow-eval throw with
+            ;; no FLOW step projected) — attach to the HANDLER step as the
+            ;; catch-all so the failure never disappears entirely.
+            (if-let [h (index-of #(= :handler (:step %)) s)]
+              (update s h
+                      (fn [step]
+                        (-> step
+                            (update :errors (fnil conj []) row)
+                            (assoc :status :error))))
+              s))))
+      steps
+      rows)))
+
+;; ---- per-step status + epoch outcome (rf2-ahhgn) ------------------------
+
+(defn step-status
+  "The pass/fail status of a projected step (rf2-ahhgn) — `:error` when
+  the step (or any of its rows) carries an attached exception or schema
+  violation, else `:ok`. The view paints a ✓ (`:ok`) / ✗ (`:error`)
+  glyph on every step header off this primitive; rf2-kt6js's SIDE-EFFECTS
+  sub-steps reuse the same shape for their per-effect ticks.
+
+  Reads the step's own `:status` slot first (stamped by `attach-
+  exceptions`), then falls back to scanning the step-level + row-level
+  `:errors` / `:violations` vecs so a step that gained a violation via
+  `attach-violations` (which does not stamp `:status`) still reads
+  `:error`. Pure-data over an already-attached step."
+  [step]
+  (let [row-has? (fn [k] (some #(seq (get % k)) (:rows step)))]
+    (if (or (= :error (:status step))
+            (seq (:errors step))
+            (seq (:violations step))
+            (row-has? :errors)
+            (row-has? :violations))
+      :error
+      :ok)))
+
+(defn epoch-outcome
+  "Derive the Epoch panel's consumer-facing outcome for a projected step
+  vector (rf2-ahhgn) — `:error` when ANY step settled `:error` (an
+  exception or a schema violation fired this cascade), else `:ok`.
+
+  This is the TOOL-SIDE outcome the Epoch panel surfaces — the SAME
+  trace-derived `:error`/`:ok` signal `event-status-colour/cascade-outcome`
+  computes for the L2 list / Event header / Trace bar (a cascade carrying
+  an `:rf.error/*` trace reads `:error`). It is DELIBERATELY NOT the
+  framework epoch-record `:outcome` slot, which stays `:ok` for a
+  recovered handler exception by spec (Spec-Schemas §`:rf/epoch-record`
+  §Outcomes line 245 — the reference runtime recovers + settles `:ok`;
+  `:halted-handler-exception` is reserved for a future drain-aborting
+  runtime). Surfacing the framework slot's `:ok` as the panel's outcome
+  is the rf2-ahhgn bug; deriving from the trace stream fixes it without a
+  framework-contract change (which would ripple into `restore-epoch`'s
+  non-`:ok` refusal + Story / MCP consumers — see rf2-ahhgn settle-first)."
+  [steps]
+  (if (some #(= :error (step-status %)) steps)
+    :error
+    :ok))
+
 (defn cascade-rolled-back?
   "True iff any `:app-db` schema violation in `rows` carries
   `:rollback? true`. The view layer reads this off the cascade
@@ -1989,6 +2213,7 @@
                                  (assoc :db-post-flow flow-db-post)))
                              (flow-rows events))
             violations (schema-violation-rows events)
+            exceptions (exception-rows events)
             base-steps (vec
                         (concat
                           [(dispatch-row events fallback)]
@@ -2013,7 +2238,13 @@
                            ]))
             present    (filterv some? base-steps)
             attached   (attach-violations present violations)
-            steps      (mark-rolled-back-downstream attached violations)]
+            ;; rf2-ahhgn — attach cascade-level exceptions (handler /
+            ;; interceptor / coeffect / fx / flow throws) to their owning
+            ;; step AFTER schema violations so both inline-failure surfaces
+            ;; coexist; `attach-exceptions` additionally stamps `:status
+            ;; :error` on each touched step for the per-step ✓/✗ primitive.
+            with-errs  (attach-exceptions attached exceptions)
+            steps      (mark-rolled-back-downstream with-errs violations)]
         steps))))
 
 (defn number-steps

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -203,6 +203,19 @@
    :font-size   "10px"
    :margin-left "4px"})
 
+;; rf2-ahhgn — per-step pass/fail status glyph. Rides immediately after
+;; the badge pill so the ✓/✗ reads as a property OF the step. Quiet ✓
+;; on success (green, low weight — not alarmist); bold ✗ on failure
+;; (red) so a failing step jumps out of an otherwise-clean cascade. The
+;; colour resolves off `badge/step-status-colour` at render time
+;; (per-step), so it is NOT folded into this hoisted base.
+(def ^:private step-header-status-glyph-base-style
+  {:font-family mono-stack
+   :font-size   "12px"
+   :font-weight 700
+   :line-height 1
+   :flex        "0 0 auto"})
+
 ;; -- sub-header -----------------------------------------------------------
 
 (def ^:private sub-header-style
@@ -1191,6 +1204,39 @@
    :border-radius "3px"
    :padding "6px 8px"})
 
+;; -- inline EXCEPTION card (rf2-ahhgn) ------------------------------------
+;;
+;; A handler / interceptor / coeffect / fx / flow EXCEPTION renders as a
+;; red-edged card under its owning step (sibling to the amber schema-
+;; violation card). Distinct chrome from violations: a violation is an
+;; expected-ish boundary rejection (amber, "Aborted"/"Skipped"); an
+;; exception is a genuine bug (red `✗`, the exception MESSAGE verbatim).
+;; The card reuses the violation block's flex/padding skeleton so the two
+;; failure surfaces read as a family, with the error tone swapped in.
+
+(def ^:private error-block-style
+  (assoc schema-violation-block-style
+         :border (str "1px solid " error-colour)))
+
+(def ^:private error-block-title-style
+  (assoc schema-violation-title-style
+         :color error-colour))
+
+(def ^:private error-block-message-style
+  ;; The exception message is verbatim text the developer wrote in their
+  ;; `ex-info` — render it monospace (it often quotes code / ids) and in
+  ;; the primary text colour so it reads as the punchline of the card.
+  {:color       text-primary-colour
+   :font-family mono-stack
+   :font-size   "12px"
+   :line-height 1.5
+   :word-break  "break-word"
+   :margin      "2px 0"})
+
+(def ^:private error-block-recovery-chip-style
+  (assoc schema-violation-rollback-chip-style
+         :text-transform "none"))
+
 (def ^:private rolled-back-mute-style
   {:opacity 0.55})
 
@@ -1292,6 +1338,27 @@
 (def ^:private panel-scroll-style
   {:flex 1 :overflow "auto" :padding "21px"})
 
+;; rf2-ahhgn — epoch outcome banner. A failed cascade (an exception or
+;; schema violation fired) paints a thin red banner at the top of the
+;; pipeline so the operator reads "this event failed" the moment they
+;; land on the panel — without scanning for the ✗ step. The per-step
+;; ✗ glyphs + inline error cards then pinpoint WHERE. A clean cascade
+;; renders NO banner (silence is the success signal — no green
+;; reassurance chrome cluttering the common case).
+(def ^:private outcome-banner-error-style
+  {:display       "flex"
+   :align-items   "center"
+   :gap           "8px"
+   :padding       "6px 10px"
+   :margin-bottom "13px"
+   :background    bg-violation-colour
+   :border        (str "1px solid " error-colour)
+   :border-radius "3px"
+   :color         error-colour
+   :font-family   sans-stack
+   :font-size     "12px"
+   :font-weight   600})
+
 ;; ---- expansion state helpers ---------------------------------------------
 ;;
 ;; The Epoch panel's row-expansion surface (`:rf.xray.epoch/toggle-
@@ -1377,6 +1444,8 @@
 ;; alongside its defn — rf2-w8evg.)
 (declare violation-blocks)
 (declare violation-block)
+(declare error-blocks)
+(declare error-block)
 
 (defn- numbered-circle
   "Render the numbered circle — 21px diameter, painted in the step's
@@ -1426,13 +1495,34 @@
 ;; with the default `:color "inherit"` + `:margin-left "4px"` knobs,
 ;; which match this panel's prior shape exactly.
 
+(defn- step-status-glyph
+  "Render the per-step ✓/✗ pass-fail glyph (rf2-ahhgn). `status` is the
+  `:ok` / `:error` keyword from `projection/step-status`; the colour +
+  glyph resolve off the shared `badge/step-status-*` primitive (the
+  same one rf2-kt6js's SIDE-EFFECTS sub-steps reuse). `testid` keys the
+  `-status` suffix + the `data-rf-xray-step-status` attribute tests +
+  the issues-ribbon eye-scan read."
+  [status testid]
+  [:span {:data-testid (str testid "-status")
+          :data-rf-xray-step-status (name (or status :ok))
+          :aria-label (if (= :error status) "step failed" "step ok")
+          :title (if (= :error status) "this step failed" "this step ran cleanly")
+          :style (assoc step-header-status-glyph-base-style
+                        :color (badge/step-status-colour status))}
+   (badge/step-status-glyph status)])
+
 (defn- step-header
-  "Render a step's header row — badge pill + verb/label + optional
-  duration. The flex layout keeps the duration right-aligned via
-  `margin-left: auto`. The whole header is wrapped in an interactive
-  `<div>` so clicking anywhere on the row toggles `expanded?` when
-  the step carries expandable content (`expandable?` true)."
-  [{:keys [badge verb expandable? expanded? testid duration-ms]} on-toggle]
+  "Render a step's header row — badge pill + per-step ✓/✗ status glyph
+  (rf2-ahhgn) + verb/label + optional duration. The flex layout keeps
+  the duration right-aligned via `margin-left: auto`. The whole header
+  is wrapped in an interactive `<div>` so clicking anywhere on the row
+  toggles `expanded?` when the step carries expandable content
+  (`expandable?` true).
+
+  `:status` is the step's `:ok` / `:error` pass-fail (rf2-ahhgn) — the
+  glyph is omitted when no status is supplied so test callers + non-step
+  headers (none today) stay unchanged."
+  [{:keys [badge verb expandable? expanded? testid duration-ms status]} on-toggle]
   [:div {:data-testid (str testid "-header")
          :on-click    (when (and expandable? on-toggle)
                         (fn [e]
@@ -1442,6 +1532,8 @@
                   step-header-pointer-style
                   step-header-default-cursor-style)}
    (badge-pill badge)
+   (when status
+     (step-status-glyph status testid))
    [:span {:data-testid (str testid "-verb")
            :style step-header-verb-style}
     verb]
@@ -1785,6 +1877,7 @@
                   (dispatch-source-label source coord)]))
        :expandable? false
        :testid "rf-xray-epoch-dispatch"
+       :status (proj/step-status step)
        :duration-ms duration-ms}
       nil)
     (dispatch-body step)
@@ -1845,7 +1938,7 @@
   injecting N user-defined cofx; system-injected cofx (e.g.
   framework-auto `:db`, `:event`) are filtered at projection time
   (rf2-cq0ch + the `system-cofx-ids` set)."
-  [{:keys [id value step-number violations]}]
+  [{:keys [id value step-number violations] :as step}]
   (let [cofx-meta  (when (keyword? id)
                      (try (rf/handler-meta :cofx id)
                           (catch :default _ nil)))
@@ -1868,7 +1961,8 @@
                                      {:style       coeffect-verb-link-button-style
                                       :plain-style coeffect-verb-plain-style})
         :expandable? false
-        :testid (str "rf-xray-epoch-coeffect-" (name id))}
+        :testid (str "rf-xray-epoch-coeffect-" (name id))
+        :status (proj/step-status step)}
        nil)
      ;; Body — `+ [:cofx-id] <value>` diff-style line. Per pair-debug
      ;; 2026-05-26 the body sits left-aligned with the badge (no
@@ -2615,7 +2709,7 @@
   `:violations` slot still renders generically — currently empty
   for HANDLER in practice — but the call site stays in case future
   violation kinds attach here."
-  [{:keys [flavour event-id duration-ms step-number violations]
+  [{:keys [flavour event-id duration-ms step-number violations errors]
     :as step}]
   [:div {:data-testid "rf-xray-epoch-step-handler"
          :data-step-kw "handler"
@@ -2627,9 +2721,15 @@
       :verb (handler-verb-link flavour event-id)
       :expandable? false
       :testid "rf-xray-epoch-handler"
+      :status (proj/step-status step)
       :duration-ms duration-ms}
      nil)
    (handler-body step)
+   ;; rf2-ahhgn — a handler / interceptor / coeffect EXCEPTION attaches
+   ;; here as an inline error card (button-15/16/17). Rendered BELOW the
+   ;; handler body so the operator reads what the handler tried to do,
+   ;; then the failure that aborted it.
+   (error-blocks :handler errors)
    (violation-blocks :handler violations)])
 
 ;; ---- FLOW step -----------------------------------------------------------
@@ -2669,7 +2769,8 @@
   (a pre-rf2-ta0y7 runtime, or neither t1 nor t2 on the stream) the
   body falls back to the per-path `[path] before → after` scalar line."
   [{:keys [flow-id path before after duration-ms step-number
-           db-pre-flow db-post-flow]}]
+           db-pre-flow db-post-flow errors]
+    :as step}]
   (let [flow-meta  (when (keyword? flow-id)
                      (try (rf/handler-meta :flow flow-id)
                           (catch :default _ nil)))
@@ -2704,6 +2805,7 @@
                                       :plain-style coeffect-verb-plain-style})
         :expandable? false
         :testid (str "rf-xray-epoch-flow-" (name flow-id))
+        :status (proj/step-status step)
         :duration-ms duration-ms}
        nil)
      (if db-diff?
@@ -2733,7 +2835,10 @@
           (when (and (some? before) (some? after))
             [:span {:style coeffect-body-path-style} "→"])
           (when (some? after)
-            [:span {:style coeffect-body-value-style} [ei/mini after 30]])]))]))
+            [:span {:style coeffect-body-value-style} [ei/mini after 30]])]))
+     ;; rf2-ahhgn — a flow-eval exception (the flow's compute fn threw,
+     ;; aborting the cascade pre-commit) attaches here as an inline card.
+     (error-blocks :flow errors)]))
 
 ;; ---- FX step -------------------------------------------------------------
 
@@ -2843,14 +2948,17 @@
            (str "(" (name phase) ")")])])]))
 
 (defn- fx-row-with-violations
-  "Render one fx row + any violations attached to that row (rf2-xgeag).
-  Per-row attachment matches when the projection's `attach-to-fx-row`
-  resolved the violation's `:failing-id` against an `fx-id` in the
-  FX step's `:rows`."
+  "Render one fx row + any violations / exceptions attached to that row
+  (rf2-xgeag / rf2-ahhgn). Per-row attachment matches when the
+  projection's `attach-to-fx-row` (schema) / `attach-to-fx-error-row`
+  (exception) resolved the `:failing-id` against an `fx-id` in the FX
+  step's `:rows`. A throwing fx (button-18) surfaces its message + coord
+  inline on its own row."
   [idx row]
   [:div {:key (str "fx-row-" idx)
          :data-testid (str "rf-xray-epoch-fx-row-wrapper-" idx)}
    (fx-row-view idx row)
+   (error-blocks (keyword (str "fx-row-" idx)) (:errors row))
    (violation-blocks (keyword (str "fx-row-" idx)) (:violations row))])
 
 (defn render-fx-step
@@ -2866,7 +2974,7 @@
   `:failing-id` matches an fx-id; otherwise they attach to the
   step-level `:violations` slot (rendered at the foot of the
   step)."
-  [{:keys [rows step-number threw violations]}]
+  [{:keys [rows step-number threw violations errors] :as step}]
   (let [k (or threw 0)]
     [:div {:data-testid "rf-xray-epoch-step-fx"
            :data-step-kw "fx"
@@ -2883,10 +2991,14 @@
                  [:span {:style fx-threw-style}
                   (str k " threw")])]
         :expandable? false
-        :testid "rf-xray-epoch-fx"}
+        :testid "rf-xray-epoch-fx"
+        :status (proj/step-status step)}
        nil)
      [:div {:style margin-top-5-style}
       (map-indexed fx-row-with-violations rows)]
+     ;; rf2-ahhgn — fx exceptions that didn't match a row (no-such-fx,
+     ;; or an fx-id absent from `:rows`) attach to the step level.
+     (error-blocks :fx errors)
      (violation-blocks :fx violations)]))
 
 ;; ---- SUBSCRIPTIONS step --------------------------------------------------
@@ -3241,7 +3353,7 @@
   bar's click dispatches into that same captured frame — so toggle
   writes + reads hit THIS instance's Xray app-db (N isolated shells
   stay independent), not the `:rf/xray` singleton."
-  [{:keys [rows disposed-rows step-number violations]}]
+  [{:keys [rows disposed-rows step-number violations] :as step}]
   (let [frame         (rf/current-frame)
         mode          @(rf/subscribe frame
                                      [:rf.xray.epoch/subs-filter-mode])
@@ -3277,7 +3389,8 @@
                  [:span {:style subs-disposed-count-style}
                   (str l " disposed")])]
         :expandable? false
-        :testid "rf-xray-epoch-subscriptions"}
+        :testid "rf-xray-epoch-subscriptions"
+        :status (proj/step-status step)}
        nil)
      (when (pos? n)
        (subscriptions-table visible-rows))
@@ -3473,7 +3586,7 @@
   surfaces are non-empty; collapses to `N re-rendered` or `M
   unmounted` when one half is absent. The unmounted sub-section
   is omitted entirely when no unmount-trace events fired."
-  [{:keys [rows unmounted-rows step-number]}]
+  [{:keys [rows unmounted-rows step-number] :as step}]
   (let [n (count rows)
         m (count unmounted-rows)
         verb (cond
@@ -3491,7 +3604,8 @@
         :badge :VIEWS
         :verb verb
         :expandable? false
-        :testid "rf-xray-epoch-views"}
+        :testid "rf-xray-epoch-views"
+        :status (proj/step-status step)}
        nil)
      (when (pos? n)
        (views-table rows))
@@ -3788,6 +3902,101 @@
      (map-indexed (fn [i v] (violation-block step-key i v))
                   violations)]))
 
+;; ---- inline EXCEPTION card (rf2-ahhgn) ----------------------------------
+
+(defn- error-recovery-label
+  "Short recovery chip text for an exception card (rf2-ahhgn). A handler
+  exception rolls back the cascade (`:no-recovery`) — render that as the
+  red `Rolled back` chip so the operator reads the blast radius. Other
+  recovery keywords render name-d; nil recovery omits the chip."
+  [recovery]
+  (case recovery
+    :no-recovery "Rolled back"
+    (when (keyword? recovery) (name recovery))))
+
+(defn- error-block-label
+  "Render the card's one-line failure headline (rf2-ahhgn) — the failing
+  unit + a human verb keyed off the exception op + phase. E.g.
+  'The event handler threw.' / 'An interceptor threw (:before).' /
+  'The :http/post effect threw.'"
+  [{:keys [operation phase failing-id]}]
+  (case operation
+    :rf.error/handler-exception
+    (cond
+      (= :before phase) "An interceptor / coeffect threw (:before)."
+      (= :after phase)  "An interceptor threw (:after)."
+      :else             "The event handler threw.")
+    :rf.error/fx-handler-exception
+    (str "The " (proj/ns-keyword failing-id) " effect threw.")
+    :rf.error/no-such-fx
+    (str "No fx handler registered for " (proj/ns-keyword failing-id) ".")
+    :rf.error/flow-eval-exception
+    "A flow's computation threw."
+    "An exception was thrown."))
+
+(defn error-block
+  "Render one inline EXCEPTION card (rf2-ahhgn) for a projected
+  `exception-row`. Four pieces, top to bottom:
+
+    1. Title bar: `✗` + 'Exception' + right-aligned recovery chip
+       (`Rolled back` for a handler exception).
+    2. Failure headline: a one-line human verb (`error-block-label`).
+    3. Exception message: the verbatim `ex-info` message (monospace).
+    4. Source-coord jump-to-source link: `↗ file:line` opening the
+       failing handler's registration site via `:rf.xray/open-in-editor`
+       (the same coord-link the schema-violation card uses); omitted
+       when no coord was captured (fn-form / production build).
+
+  `step-key` + `idx` give stable test ids. The card paints the failing
+  step's blast radius right where the work happened — the inline half of
+  rf2-ahhgn."
+  [step-key idx {:keys [message coord recovery] :as row}]
+  (let [recovery-label (error-recovery-label recovery)
+        testid-base    (str "rf-xray-epoch-error-"
+                            (name (or step-key :unknown)) "-" idx)]
+    [:div {:key (str "error-" step-key "-" idx)
+           :data-testid testid-base
+           :data-error-op (when (:operation row) (name (:operation row)))
+           :style error-block-style}
+     ;; 1. Title bar — ✗ + 'Exception' + recovery chip
+     [:div {:style error-block-title-style}
+      [:span {:aria-hidden true} "✗"]
+      [:span {:data-testid (str testid-base "-title")} "Exception"]
+      [:span {:style schema-violation-title-spacer-style}]
+      (when recovery-label
+        [:span {:data-testid (str testid-base "-recovery")
+                :style error-block-recovery-chip-style}
+         recovery-label])]
+     ;; 2. Failure headline (human verb)
+     [:p {:data-testid (str testid-base "-headline")
+          :style violation-prose-style}
+      (error-block-label row)]
+     ;; 3. Exception message (verbatim, monospace) — the punchline
+     (when (and (string? message) (not (str/blank? message)))
+       [:div {:data-testid (str testid-base "-message")
+              :style error-block-message-style}
+        message])
+     ;; 4. Jump-to-source — failing handler's reg-site coord
+     [:div {:style schema-violation-actions-style}
+      (violation-open-source-action
+        {:label  (let [{:keys [file line]} coord]
+                   (if file
+                     (cond-> file line (str ":" line))
+                     "source unavailable"))
+         :coord  coord
+         :testid (str testid-base "-source")})]]))
+
+(defn error-blocks
+  "Render every exception in `errors` as an inline card inside the
+  current step's body (rf2-ahhgn). `step-key` is the owning step keyword
+  (stable test ids). nil-safe — a clean step passes nil/empty and renders
+  nothing."
+  [step-key errors]
+  (when (seq errors)
+    [:div {:data-testid (str "rf-xray-epoch-errors-" (name step-key))}
+     (map-indexed (fn [i e] (error-block step-key i e))
+                  errors)]))
+
 ;; `rolled-back-banner` retired per rf2-w8evg — the rf2-8resu
 ;; redesign moved the `:where :app-db` violation from HANDLER to the
 ;; FX step's `:db` row, so the standalone HANDLER-level "cascade
@@ -4015,6 +4224,19 @@
            :style empty-state-style}
      msg]))
 
+(defn outcome-banner
+  "Render the top-of-cascade outcome banner (rf2-ahhgn). Painted only
+  when `outcome` is `:error` — a failed cascade. A clean cascade renders
+  nothing (silence is the success signal). The banner names the failure
+  at a glance; the per-step ✗ glyphs + inline error cards locate it."
+  [outcome]
+  (when (= :error outcome)
+    [:div {:data-testid "rf-xray-epoch-outcome-banner"
+           :data-rf-xray-outcome "error"
+           :style outcome-banner-error-style}
+     [:span {:aria-hidden true} "✗"]
+     [:span "This event failed — see the ✗ step below."]]))
+
 ;; ---- public Panel --------------------------------------------------------
 
 (rf/reg-view Panel
@@ -4022,26 +4244,33 @@
   a composite that resolves the focused epoch off the spine and
   projects its `:trace-events` into the pipeline-step rows. Renders
   the numbered cascade when steps are present; an empty-state when
-  the focus carries no record or the record carries no trace events."
+  the focus carries no record or the record carries no trace events.
+
+  rf2-ahhgn — when the cascade failed (`:outcome :error`) a red banner
+  rides above the pipeline so the failure is visible the moment the
+  operator lands on the panel."
   []
-  (let [{:keys [status steps dispatch-id epoch-history]}
+  (let [{:keys [status steps dispatch-id epoch-history outcome]}
         @(rf/subscribe [:rf.xray/epoch-pipeline])]
     [:section {:data-testid "rf-xray-epoch-panel"
+               :data-rf-xray-outcome (when outcome (name outcome))
                :style panel-root-style}
      [:div {:style panel-scroll-style}
       (cond
         (= :focused status)
         (if (seq steps)
-          ;; rf2-x25e0 — build the `{dispatch-id → epoch-id}` index
-          ;; once per panel render. Threaded through `ctx` to the
-          ;; DISPATCH step's `:fx-dispatch` / `:fx-dispatch-later`
-          ;; parent-epoch resolver (O(1) lookup instead of an O(N)
-          ;; epoch-history scan per render).
-          (pipeline-view steps
-                         {:dispatch-id           dispatch-id
-                          :epoch-history         epoch-history
-                          :dispatch-id->epoch-id (proj/dispatch-id->epoch-id-index
-                                                   epoch-history)})
+          [:<>
+           (outcome-banner outcome)
+           ;; rf2-x25e0 — build the `{dispatch-id → epoch-id}` index
+           ;; once per panel render. Threaded through `ctx` to the
+           ;; DISPATCH step's `:fx-dispatch` / `:fx-dispatch-later`
+           ;; parent-epoch resolver (O(1) lookup instead of an O(N)
+           ;; epoch-history scan per render).
+           (pipeline-view steps
+                          {:dispatch-id           dispatch-id
+                           :epoch-history         epoch-history
+                           :dispatch-id->epoch-id (proj/dispatch-id->epoch-id-index
+                                                    epoch-history)})]
           (empty-state-view :no-events))
 
         :else

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch_panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch_panel.cljs
@@ -88,6 +88,14 @@
         {:status         status
          :epoch-id       (or focus-epoch-id (:epoch-id record))
          :record         record
+         ;; rf2-ahhgn — the TOOL-SIDE outcome (`:ok` / `:error`) derived
+         ;; from the projected steps (any step carrying an exception or
+         ;; schema violation reads `:error`). Surfaced so the panel
+         ;; header signals a failed cascade — the framework epoch-record
+         ;; `:outcome` slot stays `:ok` for a recovered handler exception
+         ;; by spec, and is NOT the panel's outcome (see
+         ;; `projection/epoch-outcome`).
+         :outcome        (proj/epoch-outcome steps)
          ;; rf2-yx1ae — the CHILD-DISPATCHES section's view resolves
          ;; child epoch-ids via `find-child-epoch` against this cascade's
          ;; `:dispatch-id` + the epoch-history. Pinning them on the

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/badge_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/badge_cljs_test.cljc
@@ -154,3 +154,34 @@
     (is (= "▲" (badge/cascade-outcome-glyph :fail)))
     (is (= "✗" (badge/cascade-outcome-glyph :threw)))
     (is (= "·" (badge/cascade-outcome-glyph :cancelled)))))
+
+;; ---- rf2-ahhgn — per-step pass/fail status primitive --------------------
+
+(deftest step-status-set-test
+  (testing "rf2-ahhgn — the per-step status closed set is {:ok :error}"
+    (is (= #{:ok :error} badge/step-status-set))
+    (is (badge/step-status? :ok))
+    (is (badge/step-status? :error))
+    (is (not (badge/step-status? :NOT-A-STATUS)))))
+
+(deftest step-status-glyph-test
+  (testing "rf2-ahhgn — :ok → ✓, :error → ✗, unknown → ✓ (quiet default)"
+    (is (= "✓" (badge/step-status-glyph :ok)))
+    (is (= "✗" (badge/step-status-glyph :error)))
+    (is (= "✓" (badge/step-status-glyph :whatever)))))
+
+(deftest step-status-token-key-test
+  (testing "rf2-ahhgn — :error → :error token (red); everything else →
+            :success token (green) so a clean step paints the quiet ✓"
+    (is (= :error   (badge/step-status-token-key :error)))
+    (is (= :success (badge/step-status-token-key :ok)))
+    (is (= :success (badge/step-status-token-key nil)))))
+
+(deftest step-status-colour-resolves-css-var-test
+  (testing "rf2-ahhgn — the colour resolver returns a CSS-variable string
+            for both statuses (theme-driven, like every other chrome)"
+    (doseq [s [:ok :error]]
+      (let [c (badge/step-status-colour s)]
+        (is (string? c))
+        (is (re-find #"var\(--rf-xray-" c)
+            (str "expected CSS variable for " s ", got " c))))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -69,6 +69,8 @@
 (def ^:private machine-timer-cancel-ev teb/machine-timer-cancel-ev)
 (def ^:private schema-violation-ev     teb/schema-violation-ev)
 (def ^:private schema-hot-reload-ev    teb/schema-hot-reload-ev)
+(def ^:private handler-exception-ev    teb/handler-exception-ev)
+(def ^:private fx-handler-exception-ev teb/fx-handler-exception-ev)
 
 (defn- record
   "Build a synthetic `:rf/epoch-record` for projection."
@@ -2078,3 +2080,161 @@
           steps (proj/project rec)]
       (is (not-any? #(= :schema-hot-reload (:step %)) steps)
           "no SCHEMA-HOT-RELOAD tail step appended"))))
+
+;; ---- rf2-ahhgn — inline exception attachment + per-step status ----------
+;;
+;; The live button-15 (`:button-deck/throw-handler`) scenario: the handler
+;; threw, the router caught it (db rolled back), the epoch settled with the
+;; framework `:outcome :ok` (by spec — the reference runtime recovers + does
+;; NOT emit `:halted-handler-exception`) and a `:rf.error/handler-exception`
+;; trace landed under `:trace-events`. Pre-rf2-ahhgn the Epoch panel surfaced
+;; NONE of it. These tests pin (a) the message + coord projection, (b) the
+;; per-step `:status` primitive, (c) the tool-side `epoch-outcome :error`,
+;; and (d) the top-level `project` attachment end-to-end.
+
+(deftest exception-row-reads-message-and-coord-test
+  (testing "rf2-ahhgn — `exception-row` lifts the message off
+            `:exception-message` (NOT `:message` — the bead's probe checked
+            the wrong key) and the source-coord off the hoisted
+            `:rf.trace/trigger-handler :source-coord`"
+    (let [ev  (handler-exception-ev
+                :button-deck/throw-handler
+                "button-deck / handler (intentional — exercises the handler error surface)"
+                {:file "button_deck/core.cljs" :line 322})
+          row (proj/exception-row ev)]
+      (is (= :rf.error/handler-exception (:operation row)))
+      (is (= "button-deck / handler (intentional — exercises the handler error surface)"
+             (:message row))
+          "message resolves through :exception-message")
+      (is (= {:file "button_deck/core.cljs" :line 322} (:coord row))
+          "coord resolves through :rf.trace/trigger-handler :source-coord")
+      (is (= :button-deck/throw-handler (:failing-id row)))
+      (is (= :no-recovery (:recovery row)))))
+
+  (testing "rf2-ahhgn — falls back to `:reason` for the message + nil-safe
+            coord when neither trigger-handler nor call-site carries a file"
+    (let [ev  (handler-exception-ev :foo/bar nil)
+          row (proj/exception-row ev)]
+      ;; handler-exception-ev stamps `:reason "Event handler threw."`
+      (is (= "Event handler threw." (:message row)))
+      (is (nil? (:coord row))))))
+
+(deftest exception-rows-harvests-cascade-exceptions-test
+  (testing "rf2-ahhgn — `exception-rows` harvests the `cascade-exception-ops`
+            subset (handler / fx exceptions) and ignores non-exception traces"
+    (let [events [(dispatched-ev [:e] :ui nil)
+                  (handler-exception-ev :e "boom" nil)
+                  (run-end-ev 1)
+                  (fx-handler-exception-ev :http/post "fx boom" nil)]
+          rows   (proj/exception-rows events)]
+      (is (= 2 (count rows)))
+      (is (= #{:rf.error/handler-exception :rf.error/fx-handler-exception}
+             (set (map :operation rows))))))
+
+  (testing "rf2-ahhgn — empty vec when no exception traces fired"
+    (is (= [] (proj/exception-rows
+                [(dispatched-ev [:e] :ui nil) (run-end-ev 1)])))))
+
+(deftest attach-exceptions-handler-test
+  (testing "rf2-ahhgn — a `:rf.error/handler-exception` attaches to the
+            HANDLER step's `:errors` + stamps `:status :error`"
+    (let [steps [{:step :dispatch :badge :DISPATCH}
+                 {:step :handler  :badge :HANDLER}
+                 {:step :fx       :badge :FX :rows []}]
+          rows  [(proj/exception-row
+                   (handler-exception-ev :e "boom" {:file "a.cljs" :line 1}))]
+          out   (proj/attach-exceptions steps rows)
+          h     (nth out 1)]
+      (is (= 1 (count (:errors h))) "HANDLER carries the exception")
+      (is (= :error (:status h)) "HANDLER stamped :status :error")
+      (is (nil? (:errors (nth out 0))) "DISPATCH untouched")
+      (is (nil? (:status (nth out 0))) "DISPATCH not flagged"))))
+
+(deftest attach-exceptions-fx-row-test
+  (testing "rf2-ahhgn — a `:rf.error/fx-handler-exception` attaches to the
+            FX step's matching `:fx-id` row + stamps the step `:status :error`"
+    (let [steps [{:step :fx :badge :FX
+                  :rows [{:fx-id :db :status :ok}
+                         {:fx-id :http/post :status :error}]}]
+          rows  [(proj/exception-row
+                   (fx-handler-exception-ev :http/post "fx boom" nil))]
+          out   (proj/attach-exceptions steps rows)
+          fx    (first out)]
+      (is (= :error (:status fx)))
+      (is (nil? (:errors (first (:rows fx)))) ":db row untouched")
+      (is (= 1 (count (:errors (second (:rows fx)))))
+          "http/post row carries the exception")))
+
+  (testing "rf2-ahhgn — an fx exception with no matching row falls back to
+            the FX step-level `:errors`"
+    (let [steps [{:step :fx :badge :FX :rows [{:fx-id :db}]}]
+          rows  [(proj/exception-row
+                   (fx-handler-exception-ev :unknown/fx "boom" nil))]
+          out   (proj/attach-exceptions steps rows)]
+      (is (= 1 (count (:errors (first out)))))))
+
+  (testing "rf2-ahhgn — empty rows leaves steps unchanged"
+    (let [steps [{:step :handler}]]
+      (is (= steps (proj/attach-exceptions steps []))))))
+
+(deftest step-status-test
+  (testing "rf2-ahhgn — `:ok` for a clean step, `:error` when the step (or
+            a row) carries an exception or violation"
+    (is (= :ok    (proj/step-status {:step :handler})))
+    (is (= :error (proj/step-status {:step :handler :status :error})))
+    (is (= :error (proj/step-status {:step :handler :errors [{:message "x"}]})))
+    (is (= :error (proj/step-status {:step :handler :violations [{:where :app-db}]})))
+    (is (= :error (proj/step-status {:step :fx :rows [{:fx-id :db :errors [{}]}]}))
+        "row-level :errors lift the step to :error")
+    (is (= :error (proj/step-status {:step :fx :rows [{:fx-id :db :violations [{}]}]}))
+        "row-level :violations lift the step to :error")
+    (is (= :ok (proj/step-status {:step :fx :rows [{:fx-id :db}]}))
+        "clean rows keep :ok")))
+
+(deftest epoch-outcome-test
+  (testing "rf2-ahhgn — `:error` when ANY step errored, else `:ok`"
+    (is (= :ok    (proj/epoch-outcome [{:step :dispatch} {:step :handler}])))
+    (is (= :error (proj/epoch-outcome [{:step :dispatch}
+                                       {:step :handler :status :error}])))
+    (is (= :error (proj/epoch-outcome [{:step :handler
+                                        :violations [{:where :app-db}]}]))
+        "schema violations (no :status stamp) still read :error")
+    (is (= :ok (proj/epoch-outcome [])) "empty step vec → :ok")))
+
+(deftest project-attaches-handler-exception-end-to-end-test
+  (testing "rf2-ahhgn — the live button-15 scenario: a handler-exception
+            trace under `:trace-events` surfaces on the HANDLER step inline
+            (message + coord) AND the projected cascade reads `:error`. The
+            handler step also carries `:status :error` so the view paints ✗."
+    (let [rec   (record [(dispatched-ev [:button-deck/throw-handler] :ui
+                                        {:file "core.cljs" :line 481})
+                         (handler-exception-ev
+                           :button-deck/throw-handler
+                           "button-deck / handler (intentional — exercises the handler error surface)"
+                           {:file "button_deck/core.cljs" :line 322})]
+                        :button-deck/throw-handler)
+          steps   (proj/project rec)
+          handler (some #(when (= :handler (:step %)) %) steps)]
+      (is (some? handler))
+      (is (= :error (proj/step-status handler))
+          "HANDLER step reads :error")
+      (is (= :error (:status handler))
+          "HANDLER step carries the stamped :status :error")
+      (is (= 1 (count (:errors handler)))
+          "the handler-exception attached as an inline error")
+      (let [err (first (:errors handler))]
+        (is (= "button-deck / handler (intentional — exercises the handler error surface)"
+               (:message err)))
+        (is (= {:file "button_deck/core.cljs" :line 322} (:coord err))))
+      (is (= :error (proj/epoch-outcome steps))
+          "the epoch outcome reflects the exception (NOT :ok)")))
+
+  (testing "rf2-ahhgn — a clean cascade reads :ok with no attached errors"
+    (let [rec   (record [(dispatched-ev [:counter/inc] :ui nil)
+                         (db-changed-ev [[[:count] 0 1 :modified]])
+                         (run-end-ev 1)]
+                        :counter/inc)
+          steps (proj/project rec)]
+      (is (= :ok (proj/epoch-outcome steps)))
+      (is (every? #(nil? (:errors %)) steps))
+      (is (every? #(= :ok (proj/step-status %)) steps)))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -2201,3 +2201,124 @@
           "decoded sub-block is omitted when no Malli explain is present")
       (is (some? (th/find-by-testid tree (str base "-explain")))
           "the humanized explain still renders (unchanged behaviour)"))))
+
+;; ---- rf2-ahhgn — inline exception card + per-step ✓/✗ + outcome banner ---
+
+(deftest error-block-renders-message-and-coord-test
+  (testing "rf2-ahhgn — `error-block` renders the red exception card with
+            the title, human headline, the verbatim message, and a
+            jump-to-source link reading `file:line`"
+    (let [row  {:operation :rf.error/handler-exception
+                :message "button-deck / handler (intentional — exercises the handler error surface)"
+                :coord {:file "button_deck/core.cljs" :line 322}
+                :failing-id :button-deck/throw-handler
+                :recovery :no-recovery}
+          tree (view/error-block :handler 0 row)
+          base "rf-xray-epoch-error-handler-0"]
+      (is (some? (th/find-by-testid tree base))
+          "the exception card wrapper renders")
+      (is (string/includes? (text-of tree (str base "-title")) "Exception")
+          "title reads 'Exception'")
+      (is (string/includes? (text-of tree (str base "-recovery")) "Rolled back")
+          ":no-recovery → 'Rolled back' chip")
+      (is (string/includes? (text-of tree (str base "-headline"))
+                            "event handler threw")
+          "headline names the handler failure")
+      (is (string/includes? (text-of tree (str base "-message"))
+                            "intentional")
+          "the verbatim ex-info message renders")
+      (is (string/includes? (text-of tree (str base "-source"))
+                            "button_deck/core.cljs:322")
+          "the jump-to-source link reads file:line"))))
+
+(deftest error-block-fx-headline-test
+  (testing "rf2-ahhgn — an fx-handler exception names the failing fx-id"
+    (let [tree (view/error-block :fx 0
+                 {:operation :rf.error/fx-handler-exception
+                  :message "fx boom" :failing-id :http/post
+                  :recovery :no-recovery})]
+      (is (string/includes? (text-of tree "rf-xray-epoch-error-fx-0-headline")
+                            ":http/post")
+          "headline names the failing effect"))))
+
+(deftest error-block-degrades-when-coord-absent-test
+  (testing "rf2-ahhgn — no coord → the source link reads a muted
+            'source unavailable' fallback rather than a dead link"
+    (let [tree (view/error-block :handler 0
+                 {:operation :rf.error/handler-exception
+                  :message "boom" :coord nil})]
+      (is (string/includes?
+            (text-of tree "rf-xray-epoch-error-handler-0-source")
+            "source unavailable")))))
+
+(deftest error-blocks-nil-safe-test
+  (testing "rf2-ahhgn — `error-blocks` renders nothing for empty / nil"
+    (is (nil? (view/error-blocks :handler nil)))
+    (is (nil? (view/error-blocks :handler [])))))
+
+(deftest handler-step-renders-inline-exception-test
+  (testing "rf2-ahhgn — the live button-15 shape: a handler step carrying
+            an attached exception renders the inline error card AND the
+            header's ✗ status glyph"
+    (let [step {:step :handler :badge :HANDLER :step-number 3
+                :flavour :reg-event-db :event-id :button-deck/throw-handler
+                :db-diff [] :fx [] :machine nil
+                :status :error
+                :errors [{:operation :rf.error/handler-exception
+                          :message "boom in handler"
+                          :coord {:file "core.cljs" :line 322}
+                          :failing-id :button-deck/throw-handler
+                          :recovery :no-recovery}]}
+          tree (view/render-handler-step step)]
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-error-handler-0"))
+          "the inline exception card renders under the HANDLER step")
+      (is (string/includes?
+            (text-of tree "rf-xray-epoch-error-handler-0-message")
+            "boom in handler"))
+      (let [glyph (th/find-by-testid tree "rf-xray-epoch-handler-status")]
+        (is (some? glyph) "the per-step status glyph renders")
+        (is (= "error" (:data-rf-xray-step-status (th/attrs glyph)))
+            "the glyph data-attr reports :error")
+        (is (string/includes? (th/text-content glyph) "✗")
+            "a failed step paints the ✗ glyph")))))
+
+(deftest handler-step-clean-paints-ok-glyph-test
+  (testing "rf2-ahhgn — a clean handler step paints the quiet ✓ glyph and
+            renders no error card"
+    (let [step {:step :handler :badge :HANDLER :step-number 3
+                :flavour :reg-event-db :event-id :counter/inc
+                :db-diff [] :fx [] :machine nil}
+          tree (view/render-handler-step step)
+          glyph (th/find-by-testid tree "rf-xray-epoch-handler-status")]
+      (is (= "ok" (:data-rf-xray-step-status (th/attrs glyph))))
+      (is (string/includes? (th/text-content glyph) "✓"))
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-errors-handler"))
+          "a clean step renders no error block"))))
+
+(deftest fx-step-renders-per-row-exception-test
+  (testing "rf2-ahhgn — a throwing fx (button-18) surfaces its message on
+            its own FX row via `fx-row-with-violations`"
+    (let [step {:step :fx :badge :FX :step-number 4 :threw 1
+                :rows [{:fx-id :db :status :ok}
+                       {:fx-id :button-deck/ping :status :error
+                        :errors [{:operation :rf.error/fx-handler-exception
+                                  :message "fx threw on purpose"
+                                  :failing-id :button-deck/ping
+                                  :recovery :no-recovery}]}]}
+          tree (view/render-fx-step step)]
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-error-fx-row-1-0"))
+          "the throwing fx row carries its inline error card")
+      (is (string/includes?
+            (text-of tree "rf-xray-epoch-error-fx-row-1-0-message")
+            "fx threw on purpose")))))
+
+(deftest outcome-banner-renders-on-error-test
+  (testing "rf2-ahhgn — the outcome banner renders for `:error` and is
+            absent for `:ok` (silence is the success signal)"
+    (is (some? (th/find-by-testid (view/outcome-banner :error)
+                                  "rf-xray-epoch-outcome-banner"))
+        "an errored cascade paints the red banner")
+    (is (nil? (view/outcome-banner :ok))
+        "a clean cascade paints no banner")
+    (is (nil? (view/outcome-banner nil))
+        "a nil outcome paints no banner")))

--- a/tools/xray/test/day8/re_frame2_xray/test_helpers/trace_event_builders.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/test_helpers/trace_event_builders.cljc
@@ -370,3 +370,51 @@
        :path              path
        :mismatching-value mismatching-value
        :recovery          :logged-and-skipped}))
+
+;; ---- cascade exceptions (rf2-ahhgn) ------------------------------------
+
+(defn handler-exception-ev
+  "`:rf.error/handler-exception` trace (rf2-ahhgn) — a handler /
+  interceptor / injected-coeffect threw; the router emits this from
+  `emit-handler-exception!`. Mirrors that emit shape: the message rides
+  `[:tags :exception-message]`, the handler id rides `[:tags :handler-id]`
+  / `[:tags :failing-id]`, the optional interceptor `:phase` rides
+  `[:tags :phase]`, and the failing handler's SOURCE-COORD rides the
+  hoisted top-level `:rf.trace/trigger-handler :source-coord` slot.
+  Drives the HANDLER step's inline error card + the per-step ✗ status.
+
+  2-arg form: event-id + message. The 3-arg form adds the source-coord;
+  the 4-arg form adds the interceptor `:phase` (`:before` / `:after`)."
+  ([event-id message] (handler-exception-ev event-id message nil nil))
+  ([event-id message coord] (handler-exception-ev event-id message coord nil))
+  ([event-id message coord phase]
+   (cond-> (ev :error :rf.error/handler-exception
+               (cond-> {:event-id          event-id
+                        :handler-id        event-id
+                        :failing-id        event-id
+                        :exception-message message
+                        :reason            "Event handler threw."}
+                 phase (assoc :phase phase)))
+     true     (assoc :recovery :no-recovery)
+     coord    (assoc :rf.trace/trigger-handler {:kind         :event
+                                                :id           event-id
+                                                :source-coord coord}))))
+
+(defn fx-handler-exception-ev
+  "`:rf.error/fx-handler-exception` trace (rf2-ahhgn) — a registered
+  fx-handler threw during the post-commit fx walk. The fx-id rides
+  `[:tags :rf.fx/id]` so the projection's `attach-to-fx-error-row` can
+  match it to the FX step's `:db`/user-fx rows; the message rides
+  `[:tags :exception-message]`. Drives the FX step's inline error card
+  (per-row when the fx-id matches, step-level otherwise)."
+  ([fx-id message] (fx-handler-exception-ev fx-id message nil))
+  ([fx-id message coord]
+   (cond-> (ev :error :rf.error/fx-handler-exception
+               {:rf.fx/id          fx-id
+                :failing-id        fx-id
+                :exception-message message
+                :reason            "Effect handler threw."})
+     true  (assoc :recovery :no-recovery)
+     coord (assoc :rf.trace/trigger-handler {:kind         :fx
+                                             :id           fx-id
+                                             :source-coord coord}))))


### PR DESCRIPTION
Closes rf2-ahhgn.

## Problem

Clicking button-15 (`:button-deck/throw-handler` — handler exception, db rolls back) showed NOTHING explaining the failure in the Epoch panel, and the epoch `:outcome` read `:ok` despite the throw. The error trace WAS recorded (`:rf.error/handler-exception`, `db-rolled-back? true`); the panel surfaced none of it and the outcome didn't signal it.

## What changed

**(A) Tool-side epoch outcome.** `projection/epoch-outcome` (`:ok`/`:error`) derived from the projected steps, surfaced on the `:rf.xray/epoch-pipeline` composite sub + a red outcome banner above the cascade on `:error` (silence on `:ok`). This is the SAME trace-derived signal `event-status-colour/cascade-outcome` already gives the L2 list / Event header / Trace bar.

**(B) Per-step inline errors + ✓/✗ status.** Every pipeline step carries a `:status` (`:ok`/`:error`); the view paints a ✓/✗ glyph on each step header. A handler / interceptor / coeffect / fx / flow exception is harvested (`projection/exception-rows`) and attached to its owning step (`attach-exceptions`, sibling of `attach-violations`); `view/error-block` renders the verbatim exception message + jump-to-source coord inline where it happened. The handler step on button-15 now renders a red ✗ + an error card with the message + `file:line`.

## kt6js compatibility

The per-step `:status` slot + the `badge/step-status-glyph` / `step-status-colour` / `step-status-token-key` resolver are a SHARED primitive (closed `#{:ok :error}` set). rf2-kt6js's future SIDE-EFFECTS sub-steps reuse this exact shape for their per-effect ✓/✗ ticks rather than rolling a one-off — ahhgn generalizes the per-step status to ALL steps; kt6js specializes the FX step's sub-steps on top of it.

## Settle-first findings

1. **Outcome emission point + STOP-VALVE.** The epoch `:outcome` enum lives on the framework `:rf/epoch-record` `:outcome` slot + the `:rf.epoch/{snapshotted,outcome}` trace ops (spec/009 §`:rf.epoch/*`, Spec-Schemas §`:rf/epoch-record` §Outcomes). **By spec the reference runtime recovers a handler exception through the interceptor error-capture seam and settles `:ok`** with the error trace under `:trace-events`; `:halted-handler-exception` is RESERVED for a future drain-aborting runtime. Changing that slot would ripple into `restore-epoch`'s non-`:ok` refusal + Story outcome chips + MCP wire consumers + the pinned `outcome-enum-projection-pins-mapping` test. **The Epoch panel never read that slot** — it projects steps from `:trace-events`. So the fix is tool-side (derive `:error` from the trace stream) with **NO framework-contract change** — the STOP-VALVE was avoided, no spec/009 / Spec-Schemas edit needed.
2. **Error message + coord location (prong 2).** The message rides `[:tags :exception-message]` (fallback `[:tags :reason]`); the failing handler's source-coord rides the hoisted top-level `:rf.trace/trigger-handler :source-coord` (fallback `:rf.trace/call-site`) — confirmed against `re-frame.router/emit-handler-exception!` + `re-frame.trace/build-event`. The bead's probe checked `:message`/`:source`/`:error-id`, which the substrate does NOT stamp (the empty-tags symptom).

## Hot-zone

⚠️ Touches `tools/xray/spec/021-Dynamic-Panel-Designs.md` only among hot-zone surfaces (added §9.1.10.4 inline-exception + per-step status, §9.1.10.5 tool-side outcome; extended the §9.1.10.1 sub-shape row). **No top-level `spec/*`, `deps.edn`, `shadow-cljs.edn`, or `.github/workflows/*` touched** — in particular spec/009 + Spec-Schemas were NOT edited (settle-first finding 1). No `--admin` used.

## Quality gates

- `npm run test:cljs` — **PASS** (5065 tests / 16966 assertions, 0 failures). New tests: `projection_cljs_test` (exception-row / exception-rows / attach-exceptions / step-status / epoch-outcome / end-to-end button-15), `view_cljs_test` (error-block / per-step ✓/✗ glyph / per-row fx exception / outcome banner), `badge_cljs_test` (step-status primitive).
- `npm run test:xray-feature-gate` — **PASS** (exit 0; 14 scenarios, 0 failures, 13 matrix rows).
- `npm run test:bundle-isolation` — **PASS** (17 entries, 35 internal sentinels absent; uix/helix reagent-free ok).
- clj-kondo on all 9 touched files — **0 new errors/warnings** (16 pre-existing unused-private-var warnings; my change actually removed one, `violation-open-source-action`, now used by `error-block`).

## Surface lane

`panels/epoch/{projection.cljc,view.cljs,badge.cljc}` + `epoch_panel.cljs` + the epoch test files + `tools/xray/spec/021`. Did NOT touch button_deck or the substrate subs/views test suite (fqzmb's lane). Issues ribbon + Issues tab untouched (rf2-gbz39 is a separate held decision).
