### PR TITLE
docs(skills): fix broken streaming-subscriptions anchor (rf2-uvrfv)

### DIFF
--- a/skills/re-frame2-pair/references/streaming-subscriptions.md
+++ b/skills/re-frame2-pair/references/streaming-subscriptions.md
@@ -15,7 +15,7 @@ implementation lives in `re-frame2-pair.runtime/subscribe!` /
 - [Termination](#termination)
 - [Privacy posture](#privacy-posture)
 - [Worked invocation](#worked-invocation)
-- [Diagnostics — what's currently registered?](#diagnostics--whats-currently-registered)
+- [Diagnostics — what streams are currently registered?](#diagnostics--what-streams-are-currently-registered)
 
 ## When to use this vs. `watch-epochs`
 


### PR DESCRIPTION
Fixes the broken in-doc anchor that was reddening the `MkDocs build > Validate doc links` gate **on main**, blocking all docs-gated PRs (observed blocking #2526 + #2527).

## Root cause

Commit `6ec946b1f` (rf2-qicji / #2520) renamed the heading at `skills/re-frame2-pair/references/streaming-subscriptions.md` to `## Diagnostics — what streams are currently registered?` (slug `#diagnostics--what-streams-are-currently-registered`) but did not update the TOC link at line 18, which still pointed at the old slug `#diagnostics--whats-currently-registered`.

## The fix

Single line. Updated line 18's link text + anchor to match the renamed heading.

- **Before:** `- [Diagnostics — what's currently registered?](#diagnostics--whats-currently-registered)`
- **After:**  `- [Diagnostics — what streams are currently registered?](#diagnostics--what-streams-are-currently-registered)`

## Quality gates

`python scripts/check_doc_slugs.py --verbose` (from repo root):

```
scanning 386 markdown files...
no broken links.
```

0 broken anchor links (previously reported exactly this one).