### PR TITLE
feat(story/ui): a11y finding source-links + drop dead all-clear interpolation (rf2-ffu8t)

### DIFF
--- a/tools/story/spec/021-Story-UI-Test-And-Evidence.md
+++ b/tools/story/spec/021-Story-UI-Test-And-Evidence.md
@@ -254,6 +254,24 @@ The UI MUST:
 - show visual diffs beside app evidence;
 - show a11y findings with selector/source/context links.
 
+The selector/source-link requirement is met per tier (CURRENT, rf2-ffu8t):
+
+- **axe `:rf.assert/a11y` (the `:browser` tier)** carries a real source
+  link. The executor (`re-frame.story.play.browser/eval-a11y`) recovers the
+  offending-element CSS selector(s) from the axe violation's `:nodes` →
+  `:target` (`axe-finding`) — the SAME selectors the a11y panel's overlay
+  decorates — and threads them onto the finding as `:selector` (the primary
+  link) + `:targets` (every node selector). The result UI
+  (`re-frame.story.ui.test-mode.visual_a11y_view`) renders the selector as
+  the finding's locus/source link.
+- **structural `:rf.assert/a11y-structural` (the `:hiccup` tier)** has NO
+  real source coordinate to surface, and the UI does not fabricate one. The
+  `:hiccup-structure` runner walks an in-memory rendered hiccup tree, not a
+  DOM, so there is no CSS selector and no file/line coord on the tree to
+  recover. A structural finding surfaces its offending hiccup TAG as the
+  locus (the strongest honest signal the tier can prove) and offers no
+  selector slot. A real selector for the same surface is the axe tier's job.
+
 Visual-diff UX MUST define:
 
 - baseline source: golden slice, previous run, or named visual baseline;
@@ -285,7 +303,10 @@ The Test-mode and evidence-linkage contract is satisfied when:
   fidelity, and respects egress redaction;
 - visual/a11y results show browser-evidence requirements, render
   cannot-run distinctly, and present diffs/findings beside app evidence
-  with source links;
+  with source links — the axe `:browser`-tier finding carries the
+  offending-element CSS selector recovered from the violation's `:nodes`
+  (CURRENT, rf2-ffu8t); the structural `:hiccup`-tier finding surfaces its
+  hiccup tag (no DOM selector exists at that tier — see §4);
 - failed runs do not first confront the user with a raw app-db diff, trace
   tree, or EDN blob.
 

--- a/tools/story/src/re_frame/story/play/browser.cljc
+++ b/tools/story/src/re_frame/story/play/browser.cljc
@@ -210,6 +210,44 @@
 ;; AXE-STYLE A11Y  (`:rf.assert/a11y`, requires :a11y-engine)
 ;; ===========================================================================
 
+(defn- violation-targets
+  "The CSS selector(s) axe-core attached to a violation's `:nodes`, in
+  document order (rf2-ffu8t — the SOURCE LINK a11y findings MUST carry,
+  tools/story/spec/021 §4 + §5). Each axe node carries `:target` — a vector
+  of CSS selectors pointing at the offending element(s); `re-frame.story.ui.
+  a11y/record-violation-overlay!` already queries against exactly these to
+  decorate the DOM. `select-keys [:id :impact :help]` DISCARDED `:nodes`,
+  so the finding could only surface the rule id as its locus; this recovers
+  the selectors so the result UI can link to the source element.
+
+  Returns a flat vector of selector strings (deduped, order-preserving); an
+  empty vector when the violation carries no `:nodes` / `:target`. Pure data
+  → data; the violation is read as CLJS data (the live atom is normalised via
+  `js->clj` before it reaches the executor), so this is JVM-testable."
+  [violation]
+  (into []
+        (comp (mapcat (fn [node] (:target node)))
+              (filter string?)
+              (distinct))
+        (:nodes violation)))
+
+(defn- axe-finding
+  "Project ONE axe violation into the finding map the result UI renders
+  (rf2-ffu8t). Carries the axe surface (`:id` / `:impact` / `:help`) plus the
+  recovered source-link selectors:
+
+  - `:selector` — the FIRST target selector (the primary source link, nil
+    when the violation carried no node target);
+  - `:targets`  — every target selector (so a multi-node violation can list
+    them all).
+
+  Pure data → data."
+  [violation]
+  (let [targets (violation-targets violation)]
+    (cond-> (select-keys violation [:id :impact :help])
+      (seq targets) (assoc :selector (first targets)
+                           :targets  targets))))
+
 (defn eval-a11y
   "Evaluate an axe-style `:rf.assert/a11y` assertion (spec/017 §Visual,
   a11y, and browser checks — requires `:browser` / `:a11y-engine`). Returns
@@ -252,7 +290,7 @@
        :passed?   passed?
        :status    (if passed? :pass :fail)
        :expected  :no-a11y-violations
-       :actual    (mapv #(select-keys % [:id :impact :help]) counted)
+       :actual    (mapv axe-finding counted)
        :count     (count counted)
        :reason    (if passed?
                     (str "no axe-core a11y violations"

--- a/tools/story/src/re_frame/story/ui/a11y.cljs
+++ b/tools/story/src/re_frame/story/ui/a11y.cljs
@@ -86,9 +86,25 @@
 ;; SAME axe-core findings the panel accumulated WITHOUT the executor needing
 ;; a compile-time dependency on this CLJS-only UI ns. Read-only — the
 ;; executor only reads `frame-id` → violations.
+;;
+;; The panel stores the raw axe-core JS violation objects (it reads them via
+;; `^js` interop in `violation-row`); the `.cljc` executor consumes CLJS data
+;; (`select-keys` / `:nodes` / `:target` keyword access — see
+;; `browser/axe-finding`). So the reader NORMALISES each violation to CLJS
+;; data at this boundary via `js->clj :keywordize-keys`, recovering the
+;; `:nodes` → `:target` selector(s) the source-link projection needs
+;; (rf2-ffu8t — `select-keys [:id :impact :help]` formerly discarded them).
+(defn- ->clj-violations
+  "Normalise the per-frame violations bag to CLJS data for the executor seam.
+  `nil` (no run yet) passes through as nil so the executor falls back to its
+  supplied `:violations` / `:cannot-run`. rf2-ffu8t."
+  [vs]
+  (when (some? vs)
+    (js->clj vs :keywordize-keys true)))
+
 (defonce ^:private _a11y-reader-registered
   (do (browser/register-a11y-reader!
-        (fn [frame-id] (get @violations-by-frame frame-id)))
+        (fn [frame-id] (->clj-violations (get @violations-by-frame frame-id))))
       true))
 
 (defn reset-state!

--- a/tools/story/src/re_frame/story/ui/test_mode/pure.cljc
+++ b/tools/story/src/re_frame/story/ui/test_mode/pure.cljc
@@ -566,8 +566,14 @@
 
   `:locus` is the offending element's hiccup tag (the structural check works
   over the rendered hiccup TREE, so the tag is the locus the `:hiccup` tier
-  can prove — a real-browser selector/source link is the axe / `:browser`
-  tier's job). Empty when the record carried no issues. Pure data → data;
+  can prove). The structural tier has NO real source coordinate to thread
+  (rf2-ffu8t): the `:hiccup-structure` runner walks an in-memory hiccup tree,
+  not a DOM, so there is no CSS selector and no file/line coord to recover —
+  the tree carries none. Honesty over fabrication: the §4 source-link MUST is
+  met by the axe `:browser` tier (`axe-a11y-findings`, which recovers a real
+  selector from the violation's `:nodes`); a structural finding surfaces its
+  hiccup tag as the locus and offers NO selector slot, rather than minting a
+  fake coordinate. Empty when the record carried no issues. Pure data → data;
   JVM-testable."
   [record]
   (mapv (fn [{:keys [rule tag detail]}]
@@ -579,16 +585,33 @@
 
 (defn axe-a11y-findings
   "Project a `:rf.assert/a11y` record's `:actual` violation vector
-  (`re-frame.story.play.browser/eval-a11y` — `{:id :impact :help}` maps, the
-  axe-core surface) into a readable findings list (spec/021 §4 — a11y
-  findings with the finding + locus). Empty when no violation. Pure data →
+  (`re-frame.story.play.browser/eval-a11y` — `{:id :impact :help :selector
+  :targets}` maps, the axe-core surface) into a readable findings list
+  (spec/021 §4 + §5 — a11y findings with the finding + locus + SOURCE LINK).
+
+      [{:finding  <help text | rule id | \"a11y violation\">
+        :locus    <CSS selector | rule id>   ; the source link, see below
+        :selector <CSS selector | nil>        ; the offending element selector
+        :targets  [<CSS selector> …]          ; every node selector (multi-node)
+        :impact   <impact level | nil>
+        :rule     <rule id>}]
+
+  `:locus` is the SOURCE LINK the §4 MUST requires (\"a11y findings with
+  selector/source/context links\"). The axe `:browser` tier carries a real
+  selector (recovered from the violation's `:nodes` → `:target` by
+  `browser/axe-finding`, rf2-ffu8t), so `:locus` is that selector — the
+  result UI links it to the offending DOM element. When a violation carried
+  no node target (rare — e.g. a page-level rule) `:locus` falls back to the
+  rule id so the finding still reads. Empty when no violation. Pure data →
   data; JVM-testable."
   [record]
-  (mapv (fn [{:keys [id impact help]}]
-          {:finding (or help (some-> id name) "a11y violation")
-           :locus   (some-> id name)
-           :impact  impact
-           :rule    id})
+  (mapv (fn [{:keys [id impact help selector targets]}]
+          {:finding  (or help (some-> id name) "a11y violation")
+           :locus    (or selector (some-> id name))
+           :selector selector
+           :targets  (vec targets)
+           :impact   impact
+           :rule     id})
         (or (:actual record) [])))
 
 (defn browser-result-rows

--- a/tools/story/src/re_frame/story/ui/test_mode/visual_a11y_view.cljs
+++ b/tools/story/src/re_frame/story/ui/test_mode/visual_a11y_view.cljs
@@ -140,17 +140,30 @@
 
 (defn- findings-list
   "Render an a11y findings list (structural or axe) readably — the finding
-  in words + its locus (the offending hiccup tag / axe rule id), the
-  executor's detail line, and (axe) the impact level. Never a raw EDN blob."
+  in words + its locus (the SOURCE LINK: the offending element's CSS selector
+  for axe `:browser`-tier findings, or the hiccup tag for structural ones),
+  the executor's detail line, and (axe) the impact level. Never a raw EDN
+  blob.
+
+  Per rf2-ffu8t the axe tier now carries a real `:selector` (recovered from
+  the violation's `:nodes` → `:target`); when present the locus is tagged
+  `data-selector` so the result UI exposes the source link the spec/021 §4
+  MUST requires. A structural finding has no selector (the `:hiccup` tier
+  walks an in-memory tree, not a DOM — see `pure/structural-a11y-findings`),
+  so it surfaces only its hiccup-tag locus, honestly."
   [findings]
   [:ul {:style (:findings styles) :data-test "story-va-findings"}
-   (for [[i {:keys [finding locus detail impact rule]}] (map-indexed vector findings)]
+   (for [[i {:keys [finding locus detail impact rule selector]}] (map-indexed vector findings)]
      ^{:key (str rule "#" i)}
      [:li {:style       (:finding-row styles)
            :data-test   "story-va-finding"
            :data-rule   (str rule)}
       (when locus
-        [:span {:style (:locus styles) :data-test "story-va-locus"} locus])
+        [:span (cond-> {:style     (:locus styles)
+                        :data-test "story-va-locus"}
+                 selector (assoc :data-selector selector
+                                 :title         (str "source: " selector)))
+         locus])
       [:span {:style (:finding-txt styles)} finding]
       (when impact
         [:span {:style (:impact styles)} impact])
@@ -161,7 +174,7 @@
   "One a11y check card (structural or axe). On `:cannot-run` shows the
   refusal reason; on a clean pass shows an all-clear line; on a fail shows
   the readable findings list."
-  [{:keys [kind status reason count findings]}]
+  [{:keys [kind status reason findings]}]
   [:div {:style       (:card styles)
          :data-test   "story-va-card"
          :data-kind   (name kind)
@@ -180,7 +193,7 @@
 
      :else
      [:div {:style (:all-clear styles) :data-test "story-va-all-clear"}
-      (str "no " (when (= count 0) "") "violations")])])
+      "no violations"])])
 
 (defn- visual-card
   "One visual-snapshot check card. On `:cannot-run` (the headless / no-pixel

--- a/tools/story/test/re_frame/story/play/browser_test.cljc
+++ b/tools/story/test/re_frame/story/play/browser_test.cljc
@@ -173,6 +173,47 @@
         (finally (reset! browser/a11y-reader saved))))))
 
 ;; ===========================================================================
+;; AXE FINDING SELECTOR RECOVERY — :nodes → :target source link (rf2-ffu8t)
+;; ===========================================================================
+;;
+;; `eval-a11y` is :cannot-run headless (browser-available? false on the JVM),
+;; so the selector-recovery projection is unit-tested on its pure helpers
+;; (`violation-targets` / `axe-finding`, private — deref'd via the var). The
+;; executor formerly did `select-keys [:id :impact :help]`, DISCARDING the
+;; axe `:nodes` that carry the offending-element CSS selectors; these pin the
+;; recovery so the source-link MUST (spec/021 §4 + §5) is met.
+
+(deftest violation-targets-recovers-node-selectors
+  (let [violation-targets @#'browser/violation-targets]
+    (testing "the CSS selectors are recovered from :nodes → :target, deduped"
+      (is (= ["main > img:nth-child(2)"]
+             (violation-targets
+               {:id "image-alt"
+                :nodes [{:target ["main > img:nth-child(2)"]}]})))
+      (is (= ["#a" "#b"]
+             (violation-targets
+               {:nodes [{:target ["#a"]} {:target ["#b" "#a"]}]}))
+          "multi-node targets flatten, order-preserving + deduped"))
+    (testing "a violation with no :nodes / :target recovers no selector"
+      (is (= [] (violation-targets {:id "page-rule"})))
+      (is (= [] (violation-targets {:nodes []})))
+      (is (= [] (violation-targets {:nodes [{:target []}]}))))))
+
+(deftest axe-finding-threads-selector-onto-the-record
+  (let [axe-finding @#'browser/axe-finding]
+    (testing "the axe finding carries :id/:impact/:help PLUS the recovered
+              :selector (first target) and :targets (all)"
+      (is (= {:id "image-alt" :impact "critical" :help "Images must have alt"
+              :selector "main > img" :targets ["main > img"]}
+             (axe-finding {:id     "image-alt" :impact "critical"
+                           :help   "Images must have alt"
+                           :nodes  [{:target ["main > img"]}]}))))
+    (testing "a node-target-less violation projects WITHOUT a fabricated selector"
+      (let [f (axe-finding {:id "page-rule" :impact "minor" :help "h"})]
+        (is (= {:id "page-rule" :impact "minor" :help "h"} f))
+        (is (nil? (:selector f)) "no selector slot when there is no node target")))))
+
+;; ===========================================================================
 ;; DISPATCH ENTRY — one router per browser-tier atom
 ;; ===========================================================================
 

--- a/tools/story/test/re_frame/story/ui/test_mode/visual_a11y_pure_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/test_mode/visual_a11y_pure_cljs_test.cljc
@@ -58,8 +58,35 @@
                           :help "Elements must have sufficient colour contrast"}]})]
     (is (= 1 (count rows)))
     (is (= "Elements must have sufficient colour contrast" (:finding (first rows))))
+    ;; rf2-ffu8t — a violation with no node target falls the locus back to the
+    ;; rule id so the finding still reads; no fabricated selector.
     (is (= "color-contrast" (:locus (first rows))))
+    (is (nil? (:selector (first rows))) "no selector fabricated when axe carried no node target")
     (is (= "serious" (:impact (first rows))))))
+
+(deftest axe-findings-surface-selector-source-link
+  (testing "rf2-ffu8t — the axe finding's recovered :selector is the SOURCE
+            LINK (spec/021 §4 + §5): :locus is the selector, not the rule id,
+            and :selector / :targets carry the offending-element coordinates"
+    (let [rows (pure/axe-a11y-findings
+                 {:actual [{:id       "image-alt"
+                            :impact   "critical"
+                            :help     "Images must have alternate text"
+                            :selector "main > img:nth-child(2)"
+                            :targets  ["main > img:nth-child(2)"]}]})
+          row  (first rows)]
+      (is (= "main > img:nth-child(2)" (:locus row))
+          "the selector is the source-link locus, NOT the rule id")
+      (is (= "main > img:nth-child(2)" (:selector row)))
+      (is (= ["main > img:nth-child(2)"] (:targets row)))
+      (is (= "image-alt" (:rule row)) "the rule id is still carried for keying")))
+  (testing "a multi-node violation carries every target selector"
+    (let [row (first (pure/axe-a11y-findings
+                       {:actual [{:id       "label"
+                                  :selector "#a"
+                                  :targets  ["#a" "#b"]}]}))]
+      (is (= "#a" (:selector row)) "the primary source link is the first target")
+      (is (= ["#a" "#b"] (:targets row))))))
 
 ;; ---- browser-result-rows: selection + kinds -----------------------------
 
@@ -104,7 +131,37 @@
     (is (= 1 (count (:findings row))))
     (is (= "image missing alt text" (:finding (first (:findings row)))))
     (is (= "<img>" (:locus (first (:findings row)))))
+    ;; rf2-ffu8t — the structural tier has NO real source coord (it walks an
+    ;; in-memory hiccup tree, not a DOM); it surfaces the hiccup-tag locus and
+    ;; offers no selector, rather than fabricating one.
+    (is (nil? (:selector (first (:findings row))))
+        "structural findings carry no selector — honest, not fabricated")
     (is (string? (:reason row)) "the diagnostic reason is threaded through")))
+
+;; ---- browser-result-rows: axe fail carries the selector source link -----
+
+(deftest browser-rows-axe-fail-carries-selector-source-link
+  (testing "rf2-ffu8t — an axe :rf.assert/a11y fail surfaces the recovered
+            selector (the violation's :nodes → :target) end-to-end as the
+            finding's SOURCE LINK (spec/021 §4 + §5 MUST)"
+    (let [result {:assertions
+                  [{:assertion :rf.assert/a11y
+                    :status    :fail
+                    :count     1
+                    :reason    "1 axe-core a11y violation(s)"
+                    :actual    [{:id       "image-alt"
+                                 :impact   "critical"
+                                 :help     "Images must have alternate text"
+                                 :selector "main > img:nth-child(2)"
+                                 :targets  ["main > img:nth-child(2)"]}]}]}
+          row    (first (pure/browser-result-rows result))
+          finding (first (:findings row))]
+      (is (= :a11y (:kind row)))
+      (is (= :fail (:status row)))
+      (is (= "main > img:nth-child(2)" (:locus finding))
+          "the selector is the source-link locus surfaced by the projection")
+      (is (= "main > img:nth-child(2)" (:selector finding)))
+      (is (= "critical" (:impact finding))))))
 
 ;; ---- browser-result-rows: honest :cannot-run ----------------------------
 


### PR DESCRIPTION
From the rf2-42f19 paired review of rf2-ba86n.15 (PR #2486). Two items in the Story visual+a11y result UI. `bd show rf2-ffu8t` is authoritative.

## What changed

**(1) [P3, spec-MUST gap] a11y findings now carry the selector/source link spec/021 §4 + §5 require.**

Root cause was upstream in the browser executor: `eval-a11y` did `select-keys [:id :impact :help]` on each axe violation, **discarding** the `:nodes` that carry the offending-element CSS selectors.

- `browser/eval-a11y` now projects via a new `axe-finding` helper that recovers the selector(s) from the violation's `:nodes` → `:target` (`violation-targets` — flat, deduped, order-preserving) and threads them onto the finding as `:selector` (primary link) + `:targets` (every node selector). These are the **same** selectors `re-frame.story.ui.a11y/record-violation-overlay!` already decorates.
- `pure/axe-a11y-findings` surfaces `:selector` as the finding's locus/source link, falling back to the rule id **only** when a violation carried no node target (no fabricated selector).
- `visual_a11y_view/findings-list` renders the selector as a source link (`data-selector` + `title`) on the locus span.
- **Structural findings honestly carry NO selector**: the `:hiccup` tier walks an in-memory rendered tree, not a DOM, so there is no CSS selector / file-line coord to recover. Labelled honestly in `structural-a11y-findings`'s docstring + spec/021 §4/§5 rather than fabricating a coordinate. The structural finding keeps its hiccup-tag locus.

**(2) [P4, dead code]** Dropped the inert `(str "no " (when (= count 0) "") "violations")` (the `when` always yielded `""`) → `"no violations"`. The now-unused `count` binding was removed from the `a11y-card` destructure.

## SETTLE-FIRST note (the executor record change)

Per the bead's settle-first directive I read the executor's current a11y record shape and what axe returns. axe violations are raw JS objects (`:id` / `:impact` / `:help` / `:nodes`), each node carrying `:target` — a **vector of CSS selectors** (the panel reads `(aget targets 0)` for the first). The minimal clean addition: a `:selector` (first target — the primary source link) + `:targets` (all) slot on each `:actual` finding map; the record otherwise unchanged. Because the panel stores raw JS objects but the `.cljc` executor consumes CLJS data (`select-keys` / keyword access), the reader seam now `js->clj :keywordize-keys`-normalises the violations bag at the boundary — the panel keeps its `^js` interop, the executor gets keyworded `:nodes`/`:target`. No bloat to the record beyond the two source-link slots.

## Quality gates

- `npm run test:cljs` — **5053 tests, 16941 assertions, 0 failures / 0 errors** (the .15 pure test ns + the executor `browser_test` green; build 0 warnings). New cases: axe selector source-link end-to-end, structural-has-no-selector, no-target fallback, `violation-targets` / `axe-finding` recovery.
- clj-kondo on touched files — **0 new errors/warnings** (1 pre-existing unused-`state` warning in `a11y.cljs`, present on origin/main, untouched).
- `npm run test:bundle-isolation` — **PASS** (Story does not leak Xray/production; `js->clj` add stays dev-only behind the elision gate).
- a11y result UI selector link confirmed via the projection contract (`axe-findings-surface-selector-source-link`, `browser-rows-axe-fail-carries-selector-source-link`) + the view's `data-selector` render; honest empty/`:cannot-run` states still hold (`browser-rows-cannot-run-shows-reason-not-a-false-pass`, all-clear unchanged behaviour).

Closes rf2-ffu8t.