### PR TITLE
refactor(xray/testbed): redo panel_gallery against de-singletoned frames + current model (rf2-durls)

### DIFF
--- a/tools/xray/testbeds/panel_gallery/core.cljs
+++ b/tools/xray/testbeds/panel_gallery/core.cljs
@@ -1,38 +1,49 @@
 (ns panel-gallery.core
-  "Boot for the Xray panel gallery testbed (rf2-sszlr — rebuilt for
-  the new 7-tab Xray shape).
+  "Boot for the Xray panel gallery testbed (rf2-durls — redone against
+  the de-singletoned shell + the four-bucket Story authoring model;
+  supersedes the rf2-sszlr boot).
 
   ## What this testbed is
 
-  A visual gallery of the seven L4 tab panels (Event / App-db / Views
-  / Trace / Machines / Issues) plus the full 4-layer Xray chrome,
-  framed exactly like Storybook frames UI components. Scroll the
-  workspace; see what each panel looks like under varying state
+  A visual gallery of the seven L4 tab panels (Epoch / App-db / Views
+  / Trace / Machines / Routing / Issues) plus the full 4-layer Xray
+  chrome, framed exactly like Storybook frames UI components. Scroll
+  the workspace; see what each panel looks like under varying state
   magnitude / payload shape / privacy posture. The gallery IS the
   surface a developer (Mike first) reaches for when asking 'what
   does this look like under load X?'.
 
-  Per `tools/xray/spec/018-Event-Spine.md` the new chrome is four
-  stacked layers — top ribbon + event list + tab bar + detail panel
-  — with seven L4 tabs replacing the legacy sidebar's 16+ panels.
-  Time Travel is folded into the spine.
+  Per `tools/xray/spec/018-Event-Spine.md` the chrome is four stacked
+  layers — top ribbon + event list + tab bar + detail panel — with
+  seven L4 tabs replacing the legacy sidebar's 16+ panels. Time Travel
+  is folded into the spine.
+
+  ## Per-variant frame isolation (de-singletoned shell — rf2-1w07r)
+
+  Every gallery variant renders inside the Story canvas's per-variant
+  `frame-provider`, so each cell is its own isolated re-frame frame
+  (its own app-db, sub-cache, router). The per-tab galleries seed that
+  frame directly with canonical Xray events (e.g. `:rf.xray/sync-epoch-
+  history`). The chrome / settings / filters galleries mount the FULL
+  shell — `shell/shell-view` now takes a `:frame-id` opt, and the
+  `chrome-shell` wrapper threads `(rf/current-frame)` (the variant
+  frame) into it, so the shell's own app-db also lives in the variant
+  frame. N chrome cells therefore stay fully isolated in one grid; the
+  variant's `:setup` events seed THAT frame, with no `:rf/xray` literal
+  and no testbed-local re-dispatch shim.
 
   ## What this boot does
 
   1. Initialises re-frame with the Reagent adapter.
   2. Registers Xray's `:rf.xray/*` events / subs / fxs (without
      mounting Xray's own shell — we want the bare panels embedded
-     in variants where relevant, plus the shell mounted via the
-     chrome gallery's per-variant frame-provider, NOT auto-mounted).
+     in variants where relevant, plus the full shell mounted via the
+     chrome gallery's per-variant frame, NOT auto-mounted).
   3. Installs Story's canonical vocabulary (the seven reg-* macros
      and the canonical tags / modes).
-  4. Registers testbed-local seed events (notably
-     `:panel-gallery.chrome/seed!` — cross-frame writer for the
-     chrome gallery; see gallery_chrome.cljs §A note on shared
-     :rf/xray state).
-  5. Loads the per-tab gallery namespaces (their `register-all!`
+  4. Loads the per-tab gallery namespaces (their `register-all!`
      fires at namespace load).
-  6. Mounts the Story shell into `#app` on `#/stories`; otherwise
+  5. Mounts the Story shell into `#app` on `#/stories`; otherwise
      renders a tiny landing page with a link in.
 
   ## Why no Xray preload
@@ -136,14 +147,16 @@
     [:a {:href "#/stories"} [:code "#/stories"]]
     " to scroll the workspaces."]
    [:p {:style {:margin-top "2em" :font-size "13px" :color "#7c8088"}}
-    "Each per-tab variant seeds its frame's slots (trace-buffer,
-    epoch-history, machine overrides) via real Xray init events.
-    The chrome gallery additionally re-seeds the global "
-    [:code ":rf/xray"]
-    " frame (the chrome's hardcoded frame-provider) via a testbed
-    seed event; the chrome workspace uses "
-    [:code ":layout :tabs"]
-    " so state never bleeds between variants."]])
+    "Each variant seeds its OWN isolated frame's slots (trace-buffer,
+    epoch-history, filters, machine overrides) via real Xray init
+    events. The chrome / settings / filters galleries mount the full
+    shell, which threads the per-variant frame into "
+    [:code "shell-view"]
+    "'s "
+    [:code ":frame-id"]
+    " opt — so N chrome cells render in one "
+    [:code ":variants-grid"]
+    " and stay fully isolated (driving one does not move the others)."]])
 
 ;; ============================================================================
 ;; MOUNT
@@ -211,100 +224,6 @@
       (mount-stories!)
       (mount-landing!))))
 
-(defn- register-testbed-seed-events!
-  "Register testbed-local seed events that don't exist on Xray's
-  public surface. Lives here, not in any panel — ZERO source-side
-  changes to Xray panels per the rf2-5nvk2 contract (carried into
-  rf2-sszlr).
-
-  - `:panel-gallery.chrome/seed!` — chrome gallery cross-frame
-    seeder. Story's variant runtime dispatches every `:events`
-    entry into the variant frame, but the chrome (`shell/shell-view`)
-    hardcodes its own `[rf/frame-provider {:frame :rf/xray}]` —
-    so writes to the variant frame are invisible to the chrome.
-    This event re-dispatches its payload into `:rf/xray` so the
-    chrome variants render their declared state.
-
-    Payload is a map: `{:trace-buffer ... :epoch-history ...
-    :selected-tab ... :paused? ... :filters {:in [] :out []}
-    :after-seeds [<event-vec> ...]}`. Each key writes the
-    corresponding `:rf/xray` slot through the canonical Xray
-    event. `:after-seeds` runs additional event vectors against
-    `:rf/xray` after the canonical seeds — used by chrome-follow-
-    on galleries (Settings / Filters edit-popup) that need to
-    dispatch modal-open + section-select events into the same frame."
-  []
-  (rf/reg-event-fx :panel-gallery.chrome/seed!
-    (fn [_cofx [_ {:keys [trace-buffer epoch-history selected-tab
-                          paused? filters after-seeds]}]]
-      ;; rf2-1w07r — re-dispatch into the SURROUNDING frame (the Story
-      ;; per-variant frame this seed event was dispatched under), which
-      ;; is the SAME frame the chrome cell now threads into
-      ;; `[shell/shell-view {:frame-id …}]` (panel_views.cljs). The
-      ;; seeds therefore land where the shell reads, per-variant — no
-      ;; longer pinned to a global `:rf/xray` literal. (`current-frame`
-      ;; in an event handler resolves to the dispatching frame.)
-      (let [seed-frame (rf/current-frame)
-            seeds
-            (cond-> []
-              ;; Trace buffer — drives event-list + every tab body
-              ;; that derives from cascades.
-              (some? trace-buffer)
-              (conj [:rf.xray/sync-trace-buffer trace-buffer])
-
-              ;; Epoch history — drives the App-db + Views tabs.
-              (some? epoch-history)
-              (conj [:rf.xray/sync-epoch-history epoch-history])
-
-              ;; Tab selection.
-              selected-tab
-              (conj [:rf.xray/select-tab selected-tab])
-
-              ;; Ribbon filters — wholesale overwrite via
-              ;; remove-all + add-each. Done in a single dispatch
-              ;; per IN / OUT mode by issuing add-filter events.
-              true
-              (into (when filters
-                      (concat
-                        (for [pill (:in filters)]
-                          [:rf.xray/add-filter :in pill])
-                        (for [pill (:out filters)]
-                          [:rf.xray/add-filter :out pill]))))
-
-              ;; Paused — toggle from the default :live to
-              ;; :live (paused).
-              paused?
-              (conj [:rf.xray/toggle-live-pause])
-
-              ;; Arbitrary follow-on dispatches into the surrounding
-              ;; frame. The chrome-follow-on galleries (rf2-mpn8m
-              ;; settings, rf2-kbrkx auto-filter) use this lane to drive
-              ;; modal-open + section-select events against the cell's
-              ;; own frame.
-              (seq after-seeds)
-              (into (vec after-seeds)))]
-        (doseq [ev seeds]
-          (rf/dispatch-sync ev {:frame seed-frame}))
-        {}))))
-
-(defn- ensure-xray-frame!
-  "Register the `:rf/xray` frame so the chrome gallery's
-  `shell-view` (whose body hardcodes `[rf/frame-provider {:frame
-  :rf/xray}]`) can resolve its subscribes without dereferencing
-  nil.
-
-  In production Xray lazily registers the frame in
-  `mount.cljs/open!` on the first Ctrl+Shift+C — but the gallery
-  testbed never opens the production shell, it embeds it through
-  the chrome variant directly. Without this defensive reg-frame
-  the first chrome variant render throws
-  `No protocol method IDeref.-deref defined for type null` because
-  the subscribe returns nil against the unregistered frame.
-  Idempotent — `reg-frame`'s surgical-update-on-re-register
-  semantics mean a second call is a no-op."
-  []
-  (rf/reg-frame :rf/xray {}))
-
 (defn ^:export run []
   ;; rf2-2c5xb — seed `:rf.xray/project-root` BEFORE the Xray handlers
   ;; register so the first chip render reads the configured root. The
@@ -328,15 +247,14 @@
   (rf/init! reagent-adapter/adapter)
   ;; Xray's :rf.xray/* events / subs / fxs land on the registry once.
   ;; The handlers operate on the current frame's app-db, so each
-  ;; variant frame the Story canvas allocates becomes its own
-  ;; isolated "Xray frame" for the duration of the variant render.
-  ;; The chrome gallery additionally seeds `:rf/xray` via the
-  ;; per-variant `:panel-gallery.chrome/seed!` event below — see
-  ;; `gallery_chrome.cljs` §A note on shared :rf/xray state.
+  ;; variant frame the Story canvas allocates becomes its own isolated
+  ;; Xray instance for the duration of the variant render — the per-tab
+  ;; galleries seed it directly, and the chrome / settings / filters
+  ;; galleries thread that same variant frame into `shell-view`'s
+  ;; `:frame-id` opt (de-singletoned shell, rf2-1w07r). No `:rf/xray`
+  ;; literal, no testbed-local seed event — the variant's `:setup`
+  ;; dispatches the canonical Xray events into its own frame.
   (xray-registry/register-xray-handlers!)
-  ;; Register `:rf/xray` so the chrome's hardcoded frame-provider
-  ;; resolves to a real frame (not nil → throw on subscribe).
-  (ensure-xray-frame!)
   ;; rf2-pqulr — install Xray theme CSS variables on :root so
   ;; embedded widgets paint with the themed palette rather than
   ;; browser defaults. Shell normally calls this from shell-view;
@@ -345,7 +263,6 @@
   ;; DOM-probed via fixed id attributes per its docstring) so this
   ;; call is safe to make regardless of boot order or hot-reload.
   (global-styles/install!)
-  (register-testbed-seed-events!)
   ;; Story's canonical vocabulary (seven reg-* macros / tags / modes
   ;; / canvas decorators) installed once at boot. Each
   ;; `gallery_<tab>.cljs` namespace also calls

--- a/tools/xray/testbeds/panel_gallery/gallery_chrome.cljs
+++ b/tools/xray/testbeds/panel_gallery/gallery_chrome.cljs
@@ -1,43 +1,59 @@
 (ns panel-gallery.gallery-chrome
   "Story coverage for the **full 4-layer Xray chrome**
-  (rf2-sszlr — gallery rebuild for spec/018-Event-Spine).
+  (rf2-durls — redo against the de-singletoned shell + the four-bucket
+  Story authoring model; supersedes the rf2-sszlr / rf2-1w07r gallery).
 
-  The variants mount `shell/shell-view` — the entire ribbon + event-
-  list + tab-bar + detail-panel stack. Per spec/018 §2 the chrome is
-  four stacked layers.
+  The variants mount `:panel-gallery.chrome/Shell` — the entire ribbon
+  + event-list + tab-bar + detail-panel stack (`shell/shell-view`). Per
+  spec/018-Event-Spine §2 the chrome is four stacked layers.
 
-  ## A note on shared :rf/xray state
+  ## Per-cell frame isolation (de-singletoned shell — rf2-1w07r)
 
-  `shell/shell-view`'s body explicitly wraps itself in
-  `[rf/frame-provider {:frame :rf/xray}]`, so EVERY subscribe inside
-  the chrome resolves to the global `:rf/xray` frame regardless of
-  the variant frame the Story canvas pre-allocated for each variant.
-  Variant `:events` dispatched into the variant frame therefore
-  DON'T flow into the chrome's reads.
+  `shell/shell-view` now takes a `:frame-id` opt (default
+  `defaults/default-frame-id` = `:rf/xray`). The `chrome-shell` wrapper
+  (`panel_views.cljs`) is `reg-view*`-registered, so its render runs
+  under the Story per-variant `frame-provider` and `(rf/current-frame)`
+  resolves to the variant frame the canvas allocated for THIS cell. We
+  thread that frame into `[shell/shell-view {:frame-id …}]`, so each
+  chrome cell's app-db (focused epoch, selected tab, theme, modal
+  open-state, filters) lives in its OWN variant frame.
 
-  To exercise distinct chrome states per variant, this gallery
-  registers a testbed-local seed event
-  `:panel-gallery.chrome/seed!` that re-dispatches its payload into
-  `:rf/xray` directly. The handler is registered in `core.cljs`
-  alongside the gallery boot. Variants here invoke that seed event
-  via Story `:events`.
+  Story's runtime dispatches every `:setup` step into the SAME variant
+  frame (`runtime/dispatch-sync ev {:frame variant-id}`). So a variant
+  seeds its chrome state with the CANONICAL Xray events directly — no
+  re-dispatch indirection, no `:rf/xray` literal, no shared-state
+  serialisation. N chrome cells render simultaneously in a
+  `:variants-grid` and stay fully isolated: driving one does not move
+  the others.
 
-  Because of the shared `:rf/xray` state, the workspace uses
-  `:layout :tabs` (not `:variants-grid`) — one variant rendered at a
-  time, each one re-seeding `:rf/xray` on tab activation. A grid
-  would mount all chrome cells simultaneously, and the last-seeded
-  variant's state would bleed into all cells.
+  Pre rf2-1w07r the shell hardcoded `[frame-provider {:frame :rf/xray}]`,
+  so every cell's subscribes collided on the single global `:rf/xray`
+  app-db; the gallery had to serialise rendering and re-dispatch its
+  seeds into `:rf/xray` through a testbed-local `:panel-gallery.chrome/
+  seed!` event. The parameterized shell retires all of that.
+
+  ## Seed events
+
+  Each variant's `:setup` fires the same real Xray events the shell
+  itself dispatches at runtime, against the variant frame:
+
+    - `:rf.xray/sync-trace-buffer`  — the LIVE trace buffer (drives the
+                                      event-list L2 + every tab body).
+    - `:rf.xray/sync-epoch-history` — the epoch ring (drives App-db +
+                                      Views tabs).
+    - `:rf.xray/select-tab`         — the active L4 tab.
+    - `:rf.xray/add-filter`         — one ribbon pill (IN / OUT). Each
+                                      cell starts with empty
+                                      `:active-filters`, so the variant
+                                      simply adds its declared pills.
+    - `:rf.xray/toggle-live-pause`  — flip the LIVE feed to paused.
 
   ## Feature-detect notes
 
     - Auto-filter pills (rf2-ak4ms) — basic ribbon pill round-trip is
-      in main; rich filter popup hasn't landed. The
-      `ribbon-filters-loaded` variant exercises the basic
-      add-filter dispatch.
-    - Settings popup (rf2-9poxq) — `:rf.xray/open-settings` is a
-      stub event in registry.cljs. No Settings modal renders yet;
-      gallery variants for the modal wait on the Settings impl
-      landing."
+      in main; the rich filter popup gallery lives in `gallery_filters`.
+    - Settings popup (rf2-9poxq / rf2-ttnst) — its variants live in
+      `gallery_settings`."
   (:require [re-frame.story :as story]
             [panel-gallery.fixtures :as fixtures]
             [panel-gallery.fixtures-app-db :as fixtures-app-db]
@@ -46,6 +62,40 @@
 
 (defn register-gallery-view! []
   (panel-views/register!))
+
+;; ---- setup builders ------------------------------------------------------
+;;
+;; Each chrome variant seeds its own variant frame with the canonical
+;; Xray events. These helpers keep the `:setup` vectors declarative —
+;; the variant passes the state it wants and the helper lowers it to the
+;; event sequence Story dispatch-syncs into the variant frame.
+
+(defn- seed-filters
+  "Lower a `{:in [pill …] :out [pill …]}` filter map into a sequence of
+  `[:rf.xray/add-filter mode pill]` events. Each variant frame starts
+  with empty `:active-filters`, so adding the declared pills is the
+  whole story — no remove-all needed."
+  [{:keys [in out]}]
+  (concat (for [pill in]  [:rf.xray/add-filter :in pill])
+          (for [pill out] [:rf.xray/add-filter :out pill])))
+
+(defn- chrome-setup
+  "Build the `:setup` event vector for a chrome variant from a
+  declarative state map. Order matters only in that filters add after
+  the buffer seed; the shell reads each slot reactively.
+
+    :trace-buffer  — vector → `:rf.xray/sync-trace-buffer`
+    :epoch-history — vector → `:rf.xray/sync-epoch-history`
+    :selected-tab  — kw     → `:rf.xray/select-tab`
+    :filters       — {:in … :out …} → one `:rf.xray/add-filter` per pill
+    :paused?       — true   → `:rf.xray/toggle-live-pause`"
+  [{:keys [trace-buffer epoch-history selected-tab filters paused?]}]
+  (cond-> []
+    (some? trace-buffer)  (conj [:rf.xray/sync-trace-buffer trace-buffer])
+    (some? epoch-history) (conj [:rf.xray/sync-epoch-history epoch-history])
+    selected-tab          (conj [:rf.xray/select-tab selected-tab])
+    (some? filters)       (into (seed-filters filters))
+    paused?               (conj [:rf.xray/toggle-live-pause])))
 
 (defn register-all!
   "Register the chrome Story surface. Idempotent under
@@ -61,11 +111,12 @@
             detail per spec/018 §2."})
 
   (story/reg-story :story.xray.chrome
-    {:doc        "Visual gallery of the full Xray 4-layer chrome.
-                 Each variant re-seeds the global :rf/xray frame via
-                 `:panel-gallery.chrome/seed!`; the chrome reads its
-                 hardcoded :rf/xray frame; the :tabs workspace
-                 layout serialises rendering so state never bleeds."
+    {:doc        "Visual gallery of the full Xray 4-layer chrome. Each
+                 variant mounts the shell in its OWN isolated frame
+                 (the de-singletoned shell threads the Story per-variant
+                 frame) and seeds that frame with the canonical Xray
+                 events. Cells in the grid are fully isolated — driving
+                 one does not move the others."
      :component  :panel-gallery.chrome/Shell
      :tags       #{:dev :feature/xray-chrome}
      :substrates #{:reagent}})
@@ -78,9 +129,9 @@
                  Trace buffer has six cascades; the event-list (L2)
                  surfaces them; the detail panel (L4) renders the
                  epoch panel with the head cascade focused."
-     :events     [[:panel-gallery.chrome/seed!
-                   {:trace-buffer  (fixtures/n-cascades 6)
-                    :selected-tab  :epoch}]]
+     :setup      (chrome-setup
+                   {:trace-buffer (fixtures/n-cascades 6)
+                    :selected-tab :epoch})
      :tags       #{:dev :state/small}
      :substrates #{:reagent}})
 
@@ -89,10 +140,10 @@
     {:doc        "Chrome with the App-db tab pre-selected. Trace
                  buffer has cascades; epoch-history has the five-key-
                  change buffer; the detail panel renders app-db-diff."
-     :events     [[:panel-gallery.chrome/seed!
+     :setup      (chrome-setup
                    {:trace-buffer  (fixtures/n-cascades 3)
                     :epoch-history (fixtures-app-db/five-key-changes-buffer)
-                    :selected-tab  :app-db}]]
+                    :selected-tab  :app-db})
      :tags       #{:dev :state/small}
      :substrates #{:reagent}})
 
@@ -103,10 +154,10 @@
                  epoch-history; the epoch lacks render rows so the
                  panel surfaces the no-renders branch — a real
                  production state worth pinning."
-     :events     [[:panel-gallery.chrome/seed!
+     :setup      (chrome-setup
                    {:trace-buffer  (fixtures/n-cascades 2)
                     :epoch-history (fixtures-app-db/single-key-change-buffer)
-                    :selected-tab  :views}]]
+                    :selected-tab  :views})
      :tags       #{:dev :state/small}
      :substrates #{:reagent}})
 
@@ -115,9 +166,9 @@
     {:doc        "Chrome with the Trace tab pre-selected. Trace
                  buffer carries 10 events spanning every op-type;
                  the detail panel renders the raw-event feed."
-     :events     [[:panel-gallery.chrome/seed!
+     :setup      (chrome-setup
                    {:trace-buffer (fixtures-trace/ten-events-buffer)
-                    :selected-tab :trace}]]
+                    :selected-tab :trace})
      :tags       #{:dev :state/small}
      :substrates #{:reagent}})
 
@@ -127,9 +178,9 @@
                  machine-registry overrides; the panel surfaces the
                  :no-machines empty-state — a real production state
                  worth pinning in the gallery."
-     :events     [[:panel-gallery.chrome/seed!
+     :setup      (chrome-setup
                    {:trace-buffer (fixtures/n-cascades 2)
-                    :selected-tab :machines}]]
+                    :selected-tab :machines})
      :tags       #{:dev :state/small}
      :substrates #{:reagent}})
 
@@ -139,9 +190,9 @@
                  buffer carries an issue mix (errors / warnings /
                  info); the panel projection surfaces the issue
                  feed."
-     :events     [[:panel-gallery.chrome/seed!
+     :setup      (chrome-setup
                    {:trace-buffer (fixtures-trace/error-buffer)
-                    :selected-tab :issues}]]
+                    :selected-tab :issues})
      :tags       #{:dev :state/small}
      :substrates #{:reagent}})
 
@@ -150,9 +201,9 @@
     {:doc        "Mode pill in LIVE mode (default). Trace buffer has
                  cascades; spine auto-focuses on head; mode pill
                  renders as `● LIVE`."
-     :events     [[:panel-gallery.chrome/seed!
+     :setup      (chrome-setup
                    {:trace-buffer (fixtures/n-cascades 4)
-                    :selected-tab :event}]]
+                    :selected-tab :epoch})
      :tags       #{:dev :state/small}
      :substrates #{:reagent}})
 
@@ -162,10 +213,10 @@
                  `:paused?` flag is set; the LIVE buffer continues
                  collecting but auto-scrolling stops. Mode pill
                  renders as `● LIVE (paused)`."
-     :events     [[:panel-gallery.chrome/seed!
+     :setup      (chrome-setup
                    {:trace-buffer (fixtures/n-cascades 4)
                     :paused?      true
-                    :selected-tab :event}]]
+                    :selected-tab :epoch})
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
 
@@ -175,10 +226,10 @@
                  Only the `[+]` add-pill is visible alongside the
                  nav cluster + frame picker + mode pill + right
                  icons."
-     :events     [[:panel-gallery.chrome/seed!
+     :setup      (chrome-setup
                    {:trace-buffer (fixtures/n-cascades 3)
-                    :selected-tab :event
-                    :filters      {:in [] :out []}}]]
+                    :selected-tab :epoch
+                    :filters      {:in [] :out []}})
      :tags       #{:dev :state/small}
      :substrates #{:reagent}})
 
@@ -189,46 +240,28 @@
                  visual contract per spec/018 §7 — IN pills tint
                  green, OUT pills tint magenta; each carries an `✎`
                  edit affordance."
-     :events     [[:panel-gallery.chrome/seed!
+     :setup      (chrome-setup
                    {:trace-buffer (fixtures/n-cascades 4)
-                    :selected-tab :event
+                    :selected-tab :epoch
                     :filters      {:in  [{:pattern ":cart/*"}
                                          {:pattern ":auth/*"}]
-                                   :out [{:pattern ":mouse-move"}]}}]]
+                                   :out [{:pattern ":mouse-move"}]}})
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
 
   ;; ----- workspace ---------------------------------------------------
   ;;
-  ;; ## :variants-grid with the shared-state caveat
-  ;;
-  ;; All cells render simultaneously, but the chrome internally
-  ;; hardcodes `[rf/frame-provider {:frame :rf/xray}]` inside
-  ;; `shell-view`'s body — so every chrome cell reads the SAME
-  ;; `:rf/xray` app-db. Each variant's `:events` seed writes that
-  ;; one shared db; the LAST variant to run's seed wins in the grid.
-  ;;
-  ;; That's a real limitation. The grid still proves the chrome
-  ;; mounts + renders under each declared state shape (the cell
-  ;; mounts the shell against the seed), and clicking a single
-  ;; variant in the canvas (side panel selection) re-runs its seed
-  ;; against `:rf/xray` deterministically. The workspace cell view
-  ;; is the secondary surface; the canvas-mode single-variant view
-  ;; (sidebar pick) is where per-variant chrome state is fully
-  ;; observable.
-  ;;
-  ;; A `:tabs` layout would in principle render one variant at a
-  ;; time, but Story v1 wires `:tabs` through the same
-  ;; simultaneously-rendered cell path as `:variants-grid`
-  ;; (`tools/story/src/re_frame/story/ui/workspace.cljc` §workspace-
-  ;; view: the `:else` branch handles both). Genuine one-at-a-time
-  ;; tab rendering is a follow-on Story enhancement; until then the
-  ;; grid is the workspace surface.
+  ;; `:variants-grid` — all ten cells render simultaneously. Each cell's
+  ;; `chrome-shell` threads ITS variant frame into the de-singletoned
+  ;; shell (rf2-1w07r), and Story seeds each cell's frame independently,
+  ;; so the cells are fully isolated: every cell paints its own declared
+  ;; state with no last-seed-wins bleed. Single-column so the four-layer
+  ;; chrome has room to breathe.
   (story/reg-workspace :Workspace.xray.chrome/all
-    {:doc      "All ten chrome variants. The chrome internally
-                wraps :rf/xray via a hardcoded frame-provider, so
-                workspace cells share interior state — see canvas-
-                mode (sidebar pick) for per-variant chrome state."
+    {:doc      "All ten chrome variants in one auto-grid. Each cell
+                mounts the shell in its own isolated frame and paints
+                its declared state independently — driving one cell
+                does not move the others."
      :layout   :variants-grid
      :story    :story.xray.chrome
      :columns  1

--- a/tools/xray/testbeds/panel_gallery/gallery_filters.cljs
+++ b/tools/xray/testbeds/panel_gallery/gallery_filters.cljs
@@ -1,6 +1,7 @@
 (ns panel-gallery.gallery-filters
   "Story coverage for the **Auto-filter pill cluster + edit popup**
-  (rf2-kbrkx follow-on to rf2-ak4ms + rf2-sszlr chrome gallery).
+  (rf2-durls redo of the rf2-kbrkx gallery against the de-singletoned
+  shell + four-bucket Story model).
 
   The auto-filter feature spans two visual surfaces:
 
@@ -12,23 +13,43 @@
        pre-populated with the row's event-id).
 
   Each variant renders the full Xray 4-layer chrome via
-  `:panel-gallery.chrome/Shell` and seeds `:rf/xray` to drive the
-  ribbon + (optionally) open the edit popup against the expected
-  trigger shape.
+  `:panel-gallery.chrome/Shell` and seeds the ribbon + (optionally)
+  opens the edit popup against the expected trigger shape.
 
-  ## Frame discipline (same caveat as gallery-chrome)
+  ## Frame discipline (de-singletoned shell — rf2-1w07r)
 
-  The chrome's `shell-view` body wraps itself in `[rf/frame-provider
-  {:frame :rf/xray}]`. All seed events route through the testbed's
-  `:panel-gallery.chrome/seed!` `:after-seeds` lane so the writes
-  land on `:rf/xray` (where the chrome + modal read), not on the
-  variant frame Story pre-allocated."
+  The chrome's `shell-view` takes a `:frame-id` opt; the `chrome-shell`
+  wrapper threads the Story per-variant frame (`(rf/current-frame)`)
+  into it, so the ribbon + the modal it mounts read from THIS variant's
+  frame. Story's runtime dispatches every `:setup` step into that same
+  variant frame, so a variant seeds its pills + opens the popup with the
+  CANONICAL Xray events directly — no `:rf/xray` literal, no re-dispatch
+  indirection. Cells in the grid are fully isolated."
   (:require [re-frame.story :as story]
             [panel-gallery.fixtures :as fixtures]
             [panel-gallery.panel-views :as panel-views]))
 
 (defn register-gallery-view! []
   (panel-views/register!))
+
+(defn- filters-setup
+  "Build the `:setup` event vector for an auto-filter variant. Seeds the
+  trace buffer + active tab, adds the declared ribbon pills (each cell
+  starts with empty `:active-filters`), then runs any popup-trigger
+  events — all dispatched into the variant frame the chrome cell reads.
+
+    :trace-buffer — vector → `:rf.xray/sync-trace-buffer`
+    :selected-tab — kw     → `:rf.xray/select-tab`
+    :filters      — {:in [pill …] :out [pill …]} → one add-filter per pill
+    :triggers     — extra event vectors (e.g. `:rf.xray/open-edit-popup`)"
+  [{:keys [trace-buffer selected-tab filters triggers]}]
+  (let [{:keys [in out]} filters]
+    (cond-> []
+      (some? trace-buffer) (conj [:rf.xray/sync-trace-buffer trace-buffer])
+      selected-tab         (conj [:rf.xray/select-tab selected-tab])
+      (some? filters)      (into (concat (for [pill in]  [:rf.xray/add-filter :in pill])
+                                         (for [pill out] [:rf.xray/add-filter :out pill])))
+      (seq triggers)       (into (vec triggers)))))
 
 (defn register-all!
   "Register the auto-filter Story surface. Idempotent under
@@ -49,7 +70,7 @@
                  a mixed-loaded ribbon, the edit popup in :add /
                  :pill / :context trigger shapes, and the right-
                  click context-menu shortcut to the OUT-filter
-                 draft."
+                 draft — each in its own isolated frame."
      :component  :panel-gallery.chrome/Shell
      :tags       #{:dev :feature/xray-filters}
      :substrates #{:reagent}})
@@ -63,10 +84,10 @@
                  trailing `[ + ]` add affordance is visible
                  alongside the nav cluster + frame picker + mode
                  pill + right icons."
-     :events     [[:panel-gallery.chrome/seed!
+     :setup      (filters-setup
                    {:trace-buffer (fixtures/n-cascades 3)
-                    :selected-tab :event
-                    :filters      {:in [] :out []}}]]
+                    :selected-tab :epoch
+                    :filters      {:in [] :out []}})
      :tags       #{:dev :state/empty}
      :substrates #{:reagent}})
 
@@ -80,9 +101,9 @@
                  pill cluster's visual contract under a realistic
                  mixed load — green IN tint vs magenta OUT tint,
                  with `✎` edit affordances on each."
-     :events     [[:panel-gallery.chrome/seed!
+     :setup      (filters-setup
                    {:trace-buffer (fixtures/n-cascades 4)
-                    :selected-tab :event
+                    :selected-tab :epoch
                     :filters
                     {:in  [{:pattern :cart/add}
                            {:pattern ":auth/*"}
@@ -91,7 +112,7 @@
                            {:pattern :anim-frame}
                            {:pattern ":telemetry/*"}
                            {:pattern "presence"}
-                           {:pattern ":heartbeat"}]}}]]
+                           {:pattern ":heartbeat"}]}})
      :tags       #{:dev :state/large}
      :substrates #{:reagent}})
 
@@ -102,13 +123,12 @@
     {:doc        "Edit popup open via the trailing `[ + ]` add
                  affordance. Trigger `{:source :add :mode :in}` —
                  popup arrives empty + IN default; no `[Delete]`."
-     :events     [[:panel-gallery.chrome/seed!
+     :setup      (filters-setup
                    {:trace-buffer (fixtures/n-cascades 3)
-                    :selected-tab :event
+                    :selected-tab :epoch
                     :filters      {:in [] :out []}
-                    :after-seeds
-                    [[:rf.xray/open-edit-popup
-                      {:source :add :mode :in}]]}]]
+                    :triggers
+                    [[:rf.xray/open-edit-popup {:source :add :mode :in}]]})
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
 
@@ -119,17 +139,17 @@
                  Trigger `{:source :pill :mode :in :idx 0 :pill
                  {:pattern :auth/*}}` — popup pre-populated with
                  `:auth/*`, IN selected, `[Delete]` visible."
-     :events     [[:panel-gallery.chrome/seed!
+     :setup      (filters-setup
                    {:trace-buffer (fixtures/n-cascades 3)
-                    :selected-tab :event
+                    :selected-tab :epoch
                     :filters      {:in  [{:pattern :auth/*}]
                                    :out []}
-                    :after-seeds
+                    :triggers
                     [[:rf.xray/open-edit-popup
                       {:source :pill
                        :mode   :in
                        :idx    0
-                       :pill   {:pattern :auth/*}}]]}]]
+                       :pill   {:pattern :auth/*}}]]})
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
 
@@ -143,22 +163,21 @@
                  :pill {:pattern :mouse-move}}` — popup pre-
                  populated with the row's event-id + OUT default;
                  no `[Delete]` (it's an Add)."
-     :events     [[:panel-gallery.chrome/seed!
+     :setup      (filters-setup
                    {:trace-buffer (fixtures/n-cascades 4)
-                    :selected-tab :event
+                    :selected-tab :epoch
                     :filters      {:in [] :out []}
-                    :after-seeds
-                    [[:rf.xray/hide-event-type :mouse-move]]}]]
+                    :triggers
+                    [[:rf.xray/hide-event-type :mouse-move]]})
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
 
   ;; ----- workspace ---------------------------------------------------
   (story/reg-workspace :Workspace.xray.filters/all
-    {:doc      "All five auto-filter variants. The chrome
-                internally wraps :rf/xray via a hardcoded frame-
-                provider, so workspace cells share interior state —
-                see canvas-mode (sidebar pick) for per-variant
-                fidelity."
+    {:doc      "All five auto-filter variants in one grid, each
+                mounting the shell in its own isolated frame — the
+                pill cluster + edit-popup states render side-by-side
+                with no shared-state bleed."
      :layout   :variants-grid
      :story    :story.xray.filters
      :columns  1

--- a/tools/xray/testbeds/panel_gallery/gallery_settings.cljs
+++ b/tools/xray/testbeds/panel_gallery/gallery_settings.cljs
@@ -1,38 +1,52 @@
 (ns panel-gallery.gallery-settings
-  "Story coverage for the **Settings popup modal** (rf2-mpn8m
-  follow-on to rf2-9poxq + rf2-sszlr chrome gallery).
+  "Story coverage for the **Settings popup modal** (rf2-durls redo of
+  the rf2-mpn8m gallery against the de-singletoned shell + four-bucket
+  Story model).
 
-  The Settings popup mounts at `shell-view` root — same frame-
-  provider discipline as `palette/Modal` and `filters/Modal`. Each
-  variant here renders the full Xray 4-layer chrome via
-  `:panel-gallery.chrome/Shell` AND seeds the chrome's `:rf/xray`
-  slots so the popup opens against the declared tab + pre-populated
-  settings state.
+  Each variant renders the full Xray 4-layer chrome via
+  `:panel-gallery.chrome/Shell` and opens the Settings popup
+  pre-positioned on a tab with pre-populated settings state.
 
-  ## Frame discipline
+  ## Frame discipline (de-singletoned shell — rf2-1w07r)
 
-  The chrome's `shell-view` body hardcodes `[rf/frame-provider
-  {:frame :rf/xray}]` so every subscribe inside the chrome — and
-  every subscribe inside the modal it mounts — reads from the
-  global `:rf/xray` frame regardless of the variant frame Story
-  pre-allocated. Variants therefore route their seed events
-  through `:panel-gallery.chrome/seed!`'s `:after-seeds` lane,
-  which dispatches each event with `{:frame :rf/xray}` so the
-  writes land on the frame the modal reads.
+  The chrome's `shell-view` takes a `:frame-id` opt; the `chrome-shell`
+  wrapper threads the Story per-variant frame (`(rf/current-frame)`)
+  into it, so the shell — and the modal it mounts — read from THIS
+  variant's frame. Story's runtime dispatches every `:setup` step into
+  that same variant frame, so a variant seeds its chrome + opens the
+  popup with the CANONICAL Xray events directly — no `:rf/xray` literal,
+  no re-dispatch indirection. Cells in the grid are fully isolated.
 
-  ## Shared-state caveat (same as gallery-chrome)
-
-  Because every variant writes to the same `:rf/xray` frame, a
-  `:variants-grid` layout renders every cell simultaneously and
-  the last-seeded variant wins in the shared interior. Use canvas
-  mode (sidebar pick) for per-variant fidelity — the grid still
-  proves the modal mounts + paints across each declared shape."
+  (Pre rf2-1w07r the shell hardcoded `[frame-provider {:frame :rf/xray}]`,
+  so the gallery routed its seeds through a testbed-local
+  `:panel-gallery.chrome/seed!` event's `:after-seeds` lane to land
+  writes on the shared `:rf/xray` frame. The parameterized shell retires
+  that workaround.)"
   (:require [re-frame.story :as story]
             [panel-gallery.fixtures :as fixtures]
             [panel-gallery.panel-views :as panel-views]))
 
 (defn register-gallery-view! []
   (panel-views/register!))
+
+(defn- settings-setup
+  "Build the `:setup` event vector for a Settings-popup variant. Seeds
+  the trace buffer + active tab, applies any pre-populated settings
+  writes, then opens the popup on the requested tab — all dispatched
+  into the variant frame the chrome cell reads.
+
+    :trace-buffer  — vector → `:rf.xray/sync-trace-buffer`
+    :selected-tab  — kw     → `:rf.xray/select-tab`
+    :settings      — extra event vectors run BEFORE the popup opens
+                     (e.g. `:rf.xray/settings-update` pre-population)
+    :settings-tab  — kw     → opens the popup on this tab"
+  [{:keys [trace-buffer selected-tab settings settings-tab]}]
+  (cond-> []
+    (some? trace-buffer) (conj [:rf.xray/sync-trace-buffer trace-buffer])
+    selected-tab         (conj [:rf.xray/select-tab selected-tab])
+    (seq settings)       (into (vec settings))
+    true                 (conj [:rf.xray/settings-open])
+    settings-tab         (conj [:rf.xray/settings-select-tab settings-tab])))
 
 (defn register-all!
   "Register the Settings popup Story surface. Idempotent under
@@ -51,16 +65,14 @@
             was removed earlier per rf2-jh9ws (no endpoint exists);
             Theme tab retired per rf2-ou3pn — the ribbon's sun/moon
             icon is now the canonical light/dark affordance; Filters
-            tab retired per rf2-wknb3 — full pill management lives
-            in the ribbon + per-pill edit popup + mute manager."})
+            tab retired per rf2-wknb3 — full pill management lives in
+            the ribbon + per-pill edit popup + mute manager."})
 
   (story/reg-story :story.xray.settings-popup
     {:doc        "Visual gallery of the Xray Settings popup modal.
                  Each variant opens the popup pre-positioned on a
-                 different tab with different pre-populated values.
-                 All writes route through the chrome seed event's
-                 `:after-seeds` lane so they land on `:rf/xray`
-                 (where the chrome + modal read)."
+                 different tab with different pre-populated values, in
+                 its own isolated frame (the de-singletoned shell)."
      :component  :panel-gallery.chrome/Shell
      :tags       #{:dev :feature/xray-settings-popup}
      :substrates #{:reagent}})
@@ -74,15 +86,14 @@
                  slider seeded mid-range (14 px), panel-position
                  :right-rail (default), auto-open-on-error OFF
                  (default)."
-     :events     [[:panel-gallery.chrome/seed!
+     :setup      (settings-setup
                    {:trace-buffer (fixtures/n-cascades 3)
-                    :selected-tab :event
-                    :after-seeds
+                    :selected-tab :epoch
+                    :settings
                     [[:rf.xray/settings-update :general :text-size 14]
                      [:rf.xray/settings-update :general :panel-position :right-rail]
-                     [:rf.xray/settings-update :general :auto-open-on-error? false]
-                     [:rf.xray/settings-open]
-                     [:rf.xray/settings-select-tab :general]]}]]
+                     [:rf.xray/settings-update :general :auto-open-on-error? false]]
+                    :settings-tab :general})
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
 
@@ -103,12 +114,10 @@
                  READ-ONLY — a chord catalogue mirroring spec/007-
                  UX-IA.md §Keyboard plus a master 'Handle keys?'
                  toggle. Rebind UI lands in v1.1."
-     :events     [[:panel-gallery.chrome/seed!
+     :setup      (settings-setup
                    {:trace-buffer (fixtures/n-cascades 3)
-                    :selected-tab :event
-                    :after-seeds
-                    [[:rf.xray/settings-open]
-                     [:rf.xray/settings-select-tab :keybindings]]}]]
+                    :selected-tab :epoch
+                    :settings-tab :keybindings})
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
 
@@ -122,12 +131,10 @@
                  inspector-collapse-threshold) plus a destructive
                  'Clear buffer now' button. Clicking Clear opens a
                  confirmation modal (Cancel / Clear)."
-     :events     [[:panel-gallery.chrome/seed!
+     :setup      (settings-setup
                    {:trace-buffer (fixtures/n-cascades 3)
-                    :selected-tab :event
-                    :after-seeds
-                    [[:rf.xray/settings-open]
-                     [:rf.xray/settings-select-tab :buffer]]}]]
+                    :selected-tab :epoch
+                    :settings-tab :buffer})
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
 
@@ -136,12 +143,10 @@
     {:doc        "Settings popup open on Diff tab. The opt-in
                  :highlight-fn-ref-changes? toggle for the hiccup-diff
                  micro-engine (rf2-i39w2 Phase 3)."
-     :events     [[:panel-gallery.chrome/seed!
+     :setup      (settings-setup
                    {:trace-buffer (fixtures/n-cascades 3)
-                    :selected-tab :event
-                    :after-seeds
-                    [[:rf.xray/settings-open]
-                     [:rf.xray/settings-select-tab :diff]]}]]
+                    :selected-tab :epoch
+                    :settings-tab :diff})
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
 
@@ -150,20 +155,16 @@
 
   ;; ----- workspace ---------------------------------------------------
   ;;
-  ;; Same shared-state caveat as `Workspace.xray.chrome/all` — every
-  ;; cell shares `:rf/xray` (the chrome's hardcoded frame-provider).
-  ;; The last variant to seed wins the shared interior; canvas-mode
-  ;; (sidebar pick) is where per-variant fidelity is fully observable.
+  ;; `:variants-grid` — each cell mounts the shell in its own variant
+  ;; frame (the de-singletoned shell threads the per-cell frame), so the
+  ;; four popups render side-by-side with no shared-state bleed.
   (story/reg-workspace :Workspace.xray.settings-popup/all
-    {:doc      "All Settings popup variants (General / Keybindings
-                / Buffer / Diff). The chrome internally wraps
-                :rf/xray via a hardcoded frame-provider, so
-                workspace cells share interior state — see canvas-
-                mode (sidebar pick) for per-variant fidelity. The
-                Theme tab retired per rf2-ou3pn — the ribbon's
-                sun/moon icon is the canonical light/dark
-                affordance. The Filters tab retired per rf2-wknb3
-                — full pill management lives in the ribbon strip +
+    {:doc      "All Settings popup variants (General / Keybindings /
+                Buffer / Diff) in one grid, each in its own isolated
+                frame. The Theme tab retired per rf2-ou3pn — the
+                ribbon's sun/moon icon is the canonical light/dark
+                affordance. The Filters tab retired per rf2-wknb3 —
+                full pill management lives in the ribbon strip +
                 per-pill edit popup + mute manager modal."
      :layout   :variants-grid
      :story    :story.xray.settings-popup


### PR DESCRIPTION
Closes rf2-durls.

## Settle-first findings

**The gallery was mid-migration.** `panel_views.cljs` was already updated for the de-singletoned shell (rf2-1w07r) — `chrome-shell` threads `(rf/current-frame)` into `[shell/shell-view {:frame-id …}]` and its docstring describes per-cell `:variants-grid` isolation. But the three full-shell galleries still ran the old **singleton-surrender** scaffolding:

- `gallery_chrome.cljs` — 10 variants seeding via the testbed-local `:panel-gallery.chrome/seed!` re-dispatch event, with a docstring claiming a `:tabs` workspace that contradicted the actual `:variants-grid`, and a "shared `:rf/xray` state" caveat.
- `gallery_settings.cljs` (4 variants) + `gallery_filters.cljs` (5 variants) — chrome-follow-on galleries routing modal-open / section-select events through the seed event's `:after-seeds` lane to land writes on the global `:rf/xray` frame.
- `core.cljs` — registered the `:panel-gallery.chrome/seed!` event + an `ensure-xray-frame!` that `reg-frame`'d the bare `:rf/xray` literal.

**De-singletoned model (verified end-to-end):**
- `shell/shell-view` takes a `:frame-id` opt (default `defaults/default-frame-id` = `:rf/xray`); with a distinct frame-id, N shells are isolated (`shell.cljs` §`:frame-id` opt; `defaults.cljs`).
- Story's canvas wraps each variant in `[frame-provider-ns-safe {:frame variant-id}]`, so `(rf/current-frame)` inside the chrome cell resolves to the variant frame (`ui/canvas.cljs`).
- Story's runtime dispatches every `:setup`/`:events` step via `(rf/dispatch-sync ev {:frame variant-id})` (`runtime.cljc`), and `ensure-variant-frame!` → `frames/allocate!` `reg-frame`'s each variant frame (`ui/shell.cljs`).
- So the chrome cell reads exactly the frame the variant's setup seeds — the singleton hack, `ensure-xray-frame!`, and the `:rf/xray` literal are all obsolete.
- All canonical seed events (`:rf.xray/sync-trace-buffer`, `sync-epoch-history`, `select-tab`, `add-filter`, `toggle-live-pause`) and modal events (`:rf.xray/settings-open`/`settings-select-tab`/`settings-update`, `open-edit-popup`, `hide-event-type`) are real registered handlers — dispatchable directly into the variant frame.

**Reference pattern:** the per-tab galleries (`gallery_epoch.cljs` et al.) were already context-isolated (seed canonical events into the variant frame via `:events`, `:variants-grid`, no singleton hack). The redo makes the full-shell cells match.

## Redo summary

- **`gallery_chrome.cljs`** — each variant's `:setup` now fires the canonical Xray events directly into its own variant frame via a small declarative `chrome-setup` helper. Removed the `:panel-gallery.chrome/seed!` indirection; rewrote docstrings for per-cell isolation; corrected the workspace doc (no shared-state caveat). Fixed the stale `:event` tab id (retired by rf2-5gl5r) → `:epoch`.
- **`gallery_settings.cljs`** + **`gallery_filters.cljs`** — same treatment via `settings-setup` / `filters-setup` helpers; the `:after-seeds` modal/section events become direct `:setup` events into the variant frame.
- **`core.cljs`** — dropped `register-testbed-seed-events!` and `ensure-xray-frame!` entirely; updated boot docstring + landing-view copy for the de-singletoned model. `global-styles/install!` + project-root config preserved.
- Adopted the four-bucket Story vocabulary's **public `:setup`** spelling (superseding transitional `:events`); these are pure rendering galleries (no scripts/assertions), so `:setup` is the correct verb.
- Per-tab galleries unchanged (already the reference pattern).

**Spec unchanged because** `tools/xray/spec/008-Embedding-Contract.md` §259-265 already documents the de-singletoned "N shells side-by-side pass a DISTINCT `:frame-id` per cell … fully isolated" contract (written for rf2-1w07r). This redo brings the testbed into compliance with the already-documented spec — the spec was ahead of the testbed, not vice versa. The 021 / project-root mentions are accurate and untouched.

## Quality gates

- **Build** — `npx shadow-cljs compile :testbeds/panel-gallery`: 593 files compiled, **0 warnings**, panels mount.
- **`npm run test:cljs`** — 5051 tests / 16928 assertions, **0 failures, 0 errors** (node-test build 0 warnings; includes the panel-gallery inventory smoke that drives `gallery-chrome` / `gallery-settings` / `gallery-filters` `register-all!`).
- **`npm run test:xray-feature-gate`** — 14 scenarios, **0 failures**, 13 matrix rows (incl. the panel-gallery theme-tokens probe; `:testbeds/panel-gallery` build 0 warnings).
- **`npm run test:bundle-isolation`** — PASS (17 artefact entries, 35 sentinels absent; uix/helix/reagent-free PASS).
- **clj-kondo** on the 4 touched files — 0 errors, 0 warnings.

No hot-zone touched: the `:testbeds/panel-gallery` build-id + `:dev-http 8765` already exist in `shadow-cljs.edn`; this is a content-only redo.
