### PR TITLE
fix(xray/epoch): resolve subscriptions-row inputs by sub-id so parameterized subs show their real input (rf2-87c8a)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1839,6 +1839,23 @@ into a single canonical home at
   drives the displayed label, so the chip resolves the sub's
   REGISTRATION coord. Pre-fix this cell rendered a bare decorative
   `external-link` glyph with no coord resolution + no click handler.
+- **SUBSCRIPTIONS `inputs` column (rf2-87c8a).** The middle column of
+  the active SUBSCRIPTIONS table shows the sub's STATIC input topology —
+  the sub-ids of its registered `:input-signals`, resolved by the
+  SUB-ID off `(rf/handler-meta :sub <sub-id>)` via the `sub-input-signals`
+  helper (parity with the `sub-coord` lookup, which also keys by sub-id).
+  `:input-signals` is registered on the sub-id, so every parameterized
+  instance (`[:button-deck/greater-than? 5]`) shows its REAL input sub
+  (`chain-root`) regardless of whether it re-ran inside a cascade this
+  epoch. Each input sub-id paints through `edn-inspector/mini`. The
+  `app-db` label renders ONLY for a genuine Level-1 reader (empty
+  `:input-signals`). Pre-fix the column read the row's `:inputs` slot,
+  which the projection sourced purely from the `:rf.sub/cause-sub`
+  cascade attribution — OMITTED outside an in-flight cascade, so a
+  fresh-run derived/parameterized sub fell through to the `app-db`
+  fallback and was mislabeled a Level-1 reader. (A runtime with no
+  captured meta but a cascade-attributed `:inputs` slot still paints
+  that upstream sub as a graceful fallback for replayed traces.)
 - **SUBSCRIPTIONS `caused by <event-id>` cell (rf2-1cc03).** Below the
   sub-name + `coord-chip`, the same sub-name cell carries a CONDITIONAL
   `caused by <event-id>` chrome — a `<div>` (testid
@@ -2048,7 +2065,7 @@ and silently rendered empty rows. The binding inventory:
 | `:handler` machine cascade (rf2-u69j7) | `:rf.machine/guard-evaluated` · `:rf.machine/action-ran` · `:rf.machine/transition` · `:rf.machine.timer/cancelled` (closed set: `machine-cascade-trace-ops`) | guard rows read `:guard-id`, `:outcome` (closed set `:pass / :fail / :threw` — rf2-82a0u); action rows read `:action-id`, `:phase` (closed set `:exit / :transition / :entry / :always / :after-action / :initial-entry / :destroy-exit` — rf2-82a0u), `:outcome` (rich map; `:fx` + `:data` hoisted onto the row), `:input`, `:exception`; transition rows read `:machine-id`, `:event`, `:before`, `:after`, `:microsteps` (state vectors hoisted off `:before`/`:after`); timer rows read `:state`, `:delay`, `:reason` (closed set `:on-exit / :on-destroy / :on-resolution / :on-supersede / :on-frame-destroy` — rf2-82a0u). Source-coord lookup reads `(rf/handler-meta :machine id) → :rf/machine → :rf.machine/source-coords` (rf2-8bp3), keyed by `[:actions <id>] | [:guards <id>]`. |
 | `:flow` | `:rf.flow/computed` (NOT `:rf.flow/recomputed` — rf2-yhgk8 aligned the read against `re-frame.flows`'s canonical emit) | `:flow-id`, `:path`, `:before`, `:result` (the view-side `:after` slot maps to the substrate's `:result`), `:elapsed-ms` |
 | `:fx` | `:rf.fx/handled` / `:rf.fx/override-applied` / `:rf.fx/skipped-on-platform` | `:rf.fx/id`, `:rf.fx/args`, `:rf.fx/elapsed-ms` (rf2-ipaza aligned the duration read against the substrate's canonical name) |
-| `:subscriptions` | `:rf.sub/run` / `:rf.sub/skip` | `:rf.sub/id`, `:rf.sub/query-v`, `:rf.sub/value-changed?`, `:rf.sub/prev-value`, `:rf.sub/value`, `:rf.sub/cascade?`, `:rf.sub/cause-sub`, `:rf.sub/elapsed-ms` (rf2-kfh1v aligned the reads against these) |
+| `:subscriptions` | `:rf.sub/run` / `:rf.sub/skip` | `:rf.sub/id`, `:rf.sub/query-v`, `:rf.sub/value-changed?`, `:rf.sub/prev-value`, `:rf.sub/value`, `:rf.sub/cascade?`, `:rf.sub/cause-sub`, `:rf.sub/elapsed-ms` (rf2-kfh1v aligned the reads against these). **`inputs` column source (rf2-87c8a):** the column is NOT trace-sourced — the view resolves the sub's STATIC input topology via `(rf/handler-meta :sub <sub-id>) → :input-signals` keyed by the SUB-ID (first element of the query-v), so every parameterized instance `[:sub-id arg…]` shows its REAL input sub. `app-db` is the label only for a genuine Level-1 reader (`:input-signals` empty). The `:rf.sub/cause-sub` cascade attribution feeds the `caused by <event-id>` chrome (rf2-1cc03), not the `inputs` column — pre-rf2-87c8a the projection's `:inputs` slot sourced from `:rf.sub/cause-sub`, which was OMITTED outside an in-flight cascade and so mislabeled fresh-run derived/parameterized subs (`[:button-deck/greater-than? 5]`) as `app-db`. |
 | `:subscriptions` disposed (rf2-wpfjo) | `:rf.sub/dispose` (emitted by `re-frame.subs.cache/emit-dispose!` per rf2-mrnur — every cache eviction site funnels through ONE emit shape) | `:rf.sub/id`, `:rf.sub/query-v`, `:rf.sub/reason` (closed set `:no-more-derefers / :hot-reload / :cache-clear`), `:frame`. Surfaced via `projection/disposed-subs-rows`; the SUBSCRIPTIONS step carries an optional `:disposed-rows` slot (omit-by-absence). The step renders a DISPOSED sub-section when populated and reads `N recomputed (...); L disposed` in its header. A dispose-only cascade (no run/skip) still renders the step. |
 | `:views` | `:rf.view/rendered` (NOT the simpler `:rf.view/render` marker) | `:rf.view/id`, `:rf.view/deref-subs`, `:rf.view/elapsed-ms`, `:rf.view/mount?`, `:rf.view/triggered-by` (rf2-6djth aligned the read against the rich marker). The projection derives a `:cause` slot per row (rf2-bhi3t) from `:rf.view/mount?` + `:rf.view/triggered-by` — `:mount` (first render) / `{:kind :sub :sub-id <id>}` (a deref'd sub changed value) / `:props` (a re-render with no own sub change → the orthogonal `:rf/props` channel). The VIEWS table paints it as a `← :sub-id` / `← props` chip; no substrate/instrumentation change — fully tool-side inference. |
 | `:views` unmounted (rf2-gmw1i) | `:rf.view/unmounted` (already emitted by `re-frame.views/emit-view-unmounted!` per rf2-9hoos + rf2-te71r) | `:rf.view/id`, `:rf.view/render-key`, `:frame`. Surfaced via `projection/unmounted-views-rows`; the VIEWS step carries an optional `:unmounted-rows` slot (omit-by-absence when none fired). The step renders an UNMOUNTED sub-section when populated and reads `N re-rendered; M unmounted` in its header. |

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -3159,6 +3159,41 @@
       (when (and m (string? (:file m)))
         {:file (:file m) :line (:line m) :ns (:ns m)}))))
 
+(defn- sub-input-signals
+  "The sub's STATIC input topology — the sub-ids of its registered
+  `:input-signals`, resolved by the SUB-ID (first element of the
+  query-v) off `(rf/handler-meta :sub sub-id)` (rf2-87c8a).
+
+  `:input-signals` is registered on the SUB-ID, not the full instance
+  query-v: the `:<-` chain a `reg-sub` declares is the same for every
+  parameterized instance (`[:sub-id arg…]` all share one registration).
+  Keying the lookup by the sub-id is therefore the correct, deterministic
+  source for the `inputs` column — present whether or not the sub re-ran
+  inside a cascade this epoch.
+
+  Returns a vector of input SUB-IDs (each input-signal's first element,
+  e.g. `[[:chain-root]] → [:chain-root]`) so the inputs cell paints them
+  as `mini` keywords. Returns nil when:
+    - the sub-id can't be resolved (anonymous sub / no meta captured), or
+    - `:input-signals` is empty — a genuine Level-1 app-db reader, where
+      the cell falls back to the `app-db` source label.
+
+  Pre-rf2-87c8a the inputs cell read the row's `:inputs` slot, which the
+  projection sources purely from `:rf.sub/cause-sub` (the cascade
+  attribution — which upstream sub's value-change drove THIS re-run).
+  That tag is OMITTED outside an in-flight cascade, so any derived sub
+  that ran fresh (e.g. the parameterized `[:button-deck/greater-than? 5]`
+  on first mount) fell through to the `app-db` fallback and was mislabeled
+  a Level-1 reader. The cascade attribution still surfaces — via the
+  `caused by <event-id>` chrome (rf2-1cc03) — it is just no longer the
+  source for the static-topology `inputs` column."
+  [sub-id]
+  (when (some? sub-id)
+    (let [m (try (rf/handler-meta :sub sub-id) (catch :default _ nil))
+          signals (:input-signals m)]
+      (when (seq signals)
+        (mapv (fn [sig] (if (vector? sig) (first sig) sig)) signals)))))
+
 (defn- subscriptions-table
   "Render the SUBSCRIPTIONS table — 3 columns (sub / inputs / changed).
   Per the bead body's §SUBSCRIPTIONS (Step 7) shape (rf2-kfh1v).
@@ -3235,16 +3270,32 @@
          ;; inputs cell
          [:div {:data-rf-xray-resizable-col "inputs"
                 :style subs-cell-inputs-style}
+          ;; rf2-87c8a — the inputs column shows the sub's STATIC input
+          ;; topology, resolved by the SUB-ID off `:input-signals`
+          ;; (`sub-input-signals`), NOT the cascade attribution the row's
+          ;; `:inputs` slot carries (that was nil outside a cascade →
+          ;; "app-db" fallback, which mislabeled fresh-run derived /
+          ;; parameterized subs as Level-1 readers).
+          ;;
           ;; rf2-8w8er — each input keyword routes through `mini` so
           ;; the input column lights up as keywords, not plain text.
           ;; "app-db" stays as a label (it's a source descriptor, not
-          ;; a CLJS value).
-          (cond
-            (vector? inputs)
-            (into [:div {:style subs-inputs-list-style}]
-                  (map (fn [i] [:div [ei/mini i 40]]) inputs))
-            (some? inputs) [ei/mini inputs 40]
-            :else          "app-db")]
+          ;; a CLJS value) — rendered only for a genuine Level-1 reader
+          ;; whose `:input-signals` is empty.
+          (let [input-ids (sub-input-signals sub-id)]
+            (cond
+              (seq input-ids)
+              (into [:div {:style subs-inputs-list-style}]
+                    (map (fn [i] [:div [ei/mini i 40]]) input-ids))
+              ;; rf2-87c8a fallback: a runtime with no captured meta but
+              ;; a cascade-attributed `:inputs` slot still paints that
+              ;; upstream sub (preserves the pre-fix shape for traces
+              ;; replayed against a frame where the sub isn't registered).
+              (vector? inputs)
+              (into [:div {:style subs-inputs-list-style}]
+                    (map (fn [i] [:div [ei/mini i 40]]) inputs))
+              (some? inputs) [ei/mini inputs 40]
+              :else          "app-db"))]
          ;; value cell
          [:div {:data-rf-xray-resizable-col "value"
                 :style subs-cell-changed-style}

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -1991,6 +1991,81 @@
             (is (nil? chip)
                 "coord chip drops out cleanly when no coord is resolvable")))))))
 
+(deftest parameterized-sub-inputs-resolve-by-sub-id-test
+  (testing "rf2-87c8a — the SUBSCRIPTIONS `inputs` column resolves a
+            row's input by the SUB-ID off `:input-signals`, NOT the
+            cascade attribution the row's `:inputs` slot carries. A
+            PARAMETERIZED derived sub (`[:chain-root>? 5]`, declared
+            `:<- [:chain-root]`) ran fresh with NO cascade attribution
+            (`:inputs nil`); pre-fix the cell fell through to the
+            `app-db` fallback and mislabeled it a Level-1 reader. The
+            fix keys `:input-signals` by the sub-id (first element of
+            the query-v), so the cell reads its REAL input sub
+            (`chain-root`) regardless of cascade state."
+    (epoch-orchestrator/install!)
+    (frame/reg-frame :rf/xray {})
+    (rf/with-frame :rf/xray
+      ;; L1 — reads app-db directly (genuine `:input-signals []`).
+      (rf/reg-sub :rf.87c8a-fixture/chain-root
+        (fn [db _] (get db :chain-input 0)))
+      ;; Parameterized L2 — `:<-` chain on the SUB-ID; every
+      ;; `[:chain-root>? N]` instance shares this one registration.
+      (rf/reg-sub :rf.87c8a-fixture/chain-root>?
+        :<- [:rf.87c8a-fixture/chain-root]
+        (fn [root [_ threshold]] (> root threshold)))
+      ;; `reg-sub` ALWAYS stashes `:input-signals` in the registrar meta
+      ;; (`re-frame.subs/parse-reg-sub-args`), so resolution is a hard
+      ;; precondition — not a may-or-may-not branch. Pin it so a
+      ;; regression in handler-meta resolution can't silently no-op the
+      ;; assertions below.
+      (is (= [[:rf.87c8a-fixture/chain-root]]
+             (:input-signals (rf/handler-meta
+                               :sub :rf.87c8a-fixture/chain-root>?)))
+          "the parameterized sub's `:input-signals` resolves by sub-id
+           (arg-free) to the input sub's query-v")
+      (is (= [] (:input-signals (rf/handler-meta
+                                 :sub :rf.87c8a-fixture/chain-root)))
+          "the L1 root has empty `:input-signals` (genuine app-db reader)")
+      (let [step {:step :subscriptions :badge :SUBSCRIPTIONS :step-number 5
+                  :rows [{;; the PARAMETERIZED instance — arg in the
+                          ;; query-v, `:inputs nil` (ran with no cascade
+                          ;; attribution, the rf2-87c8a symptom).
+                          :sub-id  :rf.87c8a-fixture/chain-root>?
+                          :sub-vec [:rf.87c8a-fixture/chain-root>? 5]
+                          :inputs  nil :changed? true :before 1 :after 2}
+                         {;; the L1 root — genuinely reads app-db.
+                          :sub-id  :rf.87c8a-fixture/chain-root
+                          :sub-vec [:rf.87c8a-fixture/chain-root]
+                          :inputs  nil :changed? true :before 0 :after 1}]
+                  :changed 2 :unchanged 0}
+            tree        (view/render-subscriptions-step step)
+            ;; Scope the assertion to each row's INPUTS cell specifically:
+            ;; the sub-id `:…/chain-root>?` ALSO contains "chain-root", so
+            ;; asserting on the whole row text would be a false positive.
+            ;; Search WITHIN each row's subtree so the shared `inputs`
+            ;; header cell (which also stamps `data-rf-xray-resizable-col`)
+            ;; doesn't shift the indexing.
+            param-row    (th/find-by-testid tree "rf-xray-epoch-sub-row-0")
+            l1-row       (th/find-by-testid tree "rf-xray-epoch-sub-row-1")
+            param-inputs (some-> (th/find-by-attr
+                                   param-row :data-rf-xray-resizable-col "inputs")
+                                 th/text-content)
+            l1-inputs    (some-> (th/find-by-attr
+                                   l1-row :data-rf-xray-resizable-col "inputs")
+                                 th/text-content)]
+        (is (some? param-row) "the parameterized sub row renders")
+        (is (some? l1-row) "the L1 root row renders")
+        (is (string/includes? param-inputs "chain-root")
+            "the parameterized sub's INPUTS cell reads its REAL input
+             sub (chain-root), resolved by sub-id from `:input-signals`")
+        (is (not (string/includes? param-inputs "app-db"))
+            "the parameterized sub's INPUTS cell is NOT the `app-db`
+             fallback — the rf2-87c8a bug (a fresh-run derived sub
+             mislabeled as a Level-1 reader)")
+        (is (string/includes? l1-inputs "app-db")
+            "a genuine Level-1 reader (empty `:input-signals`) still
+             shows the `app-db` source label in its INPUTS cell")))))
+
 (deftest first-run-container-sub-renders-added-chrome-test
   (testing "rf2-kp7bw — a first-run subscription whose value is a
             CONTAINER (map / vector / set) renders the whole subtree


### PR DESCRIPTION
@-