### PR TITLE
fix(story): capture exception trace into :stack — no stderr trace after green (rf2-qk0h9)

### DIFF
--- a/tools/story/src/re_frame/story/error.cljc
+++ b/tools/story/src/re_frame/story/error.cljc
@@ -31,8 +31,12 @@
     MAY supply an explicit `:message` override (the trace-drain path
     carries a pre-extracted `:exception-message` and falls back to it
     when no throwable is in hand);
-  - `:stack`   — `(.printStackTrace e)` (JVM) / `(.-stack e)` (CLJS);
-    nil when `e` is nil;
+  - `:stack`   — the rendered stack trace string. On the JVM we MUST
+    capture via an explicit `PrintWriter`: the no-arg
+    `Throwable.printStackTrace()` writes to `System/err` (a Java stream
+    `with-out-str` does NOT intercept — it only rebinds Clojure's
+    `*out*`), so capturing the trace requires handing `printStackTrace`
+    a writer directly. On CLJS it is `(.-stack e)`. nil when `e` is nil;
   - `:data`    — `(ex-data e)`; nil for a non-`ExceptionInfo` throwable
     and nil for a nil `e` (`ex-data` already guards the instance check,
     so no explicit `instance?` test is needed).
@@ -57,7 +61,16 @@
    {:message (or message
                  #?(:clj  (when err (.getMessage ^Throwable err))
                     :cljs (when err (str err))))
-    :stack   #?(:clj  (when err (with-out-str (.printStackTrace ^Throwable err)))
+    ;; `with-out-str` rebinds Clojure's `*out*`, but the no-arg
+    ;; `Throwable.printStackTrace()` writes to `System/err` — so the
+    ;; trace LEAKED to stderr (trailing every green test run with a bare
+    ;; stack trace) while `:stack` captured the empty string (rf2-qk0h9).
+    ;; Hand `printStackTrace` an explicit `PrintWriter` so the trace
+    ;; lands in `:stack` and nothing escapes to the console.
+    :stack   #?(:clj  (when err
+                        (let [sw (java.io.StringWriter.)]
+                          (.printStackTrace ^Throwable err (java.io.PrintWriter. sw))
+                          (str sw)))
                 :cljs (when err (.-stack err)))
     ;; `ex-data` already returns nil for a non-ExceptionInfo (and a nil)
     ;; throwable, so no explicit `instance?` guard is needed.

--- a/tools/story/test/re_frame/story_error_test.clj
+++ b/tools/story/test/re_frame/story_error_test.clj
@@ -9,6 +9,7 @@
   drift is gone — every routed site now yields the SAME
   `{:message :stack :data}` shape."
   (:require [clojure.test :refer [deftest is testing]]
+            [clojure.string :as str]
             [re-frame.story.error :as story-error]))
 
 ;; ---- throwable->error-map -------------------------------------------------
@@ -24,9 +25,15 @@
       (is (= {:why :test} (:data m))
           ":data is the ex-data of an ExceptionInfo")
       (is (string? (:stack m))
-          ":stack is a string on the JVM (the with-out-str capture of
-           .printStackTrace — the behaviour is preserved verbatim from the
-           pre-consolidation copies)"))))
+          ":stack is a string on the JVM")
+      ;; rf2-qk0h9 regression guard: the trace must be CAPTURED into
+      ;; :stack, not leaked to System/err. The buggy `with-out-str`
+      ;; capture of the no-arg `.printStackTrace` returned "" (still a
+      ;; string — so the bare `string?` assertion above passed while the
+      ;; trace trailed every green run on stderr). Asserting the rendered
+      ;; trace text is actually present pins the explicit-PrintWriter fix.
+      (is (str/includes? (:stack m) "boom")
+          ":stack carries the rendered trace (captured, not leaked to stderr)"))))
 
 (deftest throwable->error-map-non-ex-info-has-nil-data
   (testing "a plain Throwable (no ex-data) yields :data nil WITHOUT an


### PR DESCRIPTION
## Summary

Fixes rf2-qk0h9 — a stack trace trailing a green Story test run (after `0 failures, 0 errors`, exit 0).

## Root cause (diagnosis corrected)

The bead hypothesised the trace came from a `merge-with` over heterogeneous per-ns summary shapes in `re-frame.test-quiet.runner`. **That diagnosis was incorrect** — the runner does no `merge-with`, and the trace is unrelated to cross-ns summary aggregation.

The real culprit is `re-frame.story.error/throwable->error-map` (`tools/story/src/re_frame/story/error.cljc`):

```clojure
:stack #?(:clj (when err (with-out-str (.printStackTrace ^Throwable err)))  ; BUG
          :cljs (when err (.-stack err)))
```

The no-arg `Throwable.printStackTrace()` writes to `System/err`. `with-out-str` only rebinds Clojure's `*out*` — it does **not** intercept the Java `System/err` stream. So the trace **leaked to stderr** while `:stack` captured the empty string `""`.

Proven with a clean probe:
- `(with-out-str (.printStackTrace ex))` → captured length **0** (leaks to stderr)
- `(.printStackTrace ex (PrintWriter. sw))` → captured length **777** (captured)

### Why it looked like a `merge-with` trace after green

`clojure.test/run-tests` realises the lazy `(map test-ns namespaces)` seq **inside** `(apply merge-with + ...)`. A Story teardown handler that throws has its caught exception projected through `throwable->error-map`; the captured `Throwable` retains the full throw-time stack (`dispatch-sync → … → run-tests → merge-with → main`), which then leaked to stderr just before the green summary. `merge-with` was a red herring at the bottom of the leaked frame.

## Fix

Hand `printStackTrace` an explicit `PrintWriter` over a `StringWriter` so the trace lands in `:stack` and nothing escapes to the console. The CLJS branch is unchanged. Strengthened `story_error_test` to assert the rendered trace text is actually present in `:stack` (the prior `string?` assertion passed on the buggy empty string, masking the leak).

## Note on surface lane

The brief scoped me to `implementation/test-quiet/**` on the (incorrect) merge-with hypothesis. The settled root cause lives in `tools/story/src/re_frame/story/error.cljc` — a single isolated, non-hot-zone source file, disjoint from the parallel xray/epoch worker. Fixing at the actual root cause is the only way to satisfy the bead goal ("make the trace GONE") and matches the brief's "prefer the cleanest root-cause fix" directive. No `implementation/test-quiet/**` change was needed (no defect there).

## Quality gates

**Full Story JVM suite (`clojure -M:test`), streams split:**

| | BEFORE | AFTER |
|---|---|---|
| exit code | 0 | 0 |
| stdout | `Ran 1544 tests … 0 failures, 0 errors.` | `Ran 1544 tests … 0 failures, 0 errors.` |
| **stderr lines** | **~2000 (leaked traces, incl. the `merge-with` trace immediately before the green summary)** | **0** |

The leaked `merge-with` trace (and ~20 other Story error-path traces) are GONE. Aggregation numbers unchanged (1544 tests; assertion count +1 from the new regression assertion).

**clj-kondo** on both touched files: `errors: 0, warnings: 0` (0 new).

Closes rf2-qk0h9.