### PR TITLE
feat(xray/epoch): SIDE EFFECTS step with :db/:fx/other sub-steps + per-effect status (rf2-kt6js)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1329,7 +1329,7 @@ Each step renders a uppercase badge pill at its numbered circle:
 | `:COEFFECT`           | `:magenta`       | purple |
 | `:HANDLER`            | `:accent`        | blue (single Xray accent) |
 | `:FLOW`               | `:accent`        | blue (paired with HANDLER) |
-| `:FX`                 | `:orange`        | functional amber (post-commit irreversible) |
+| `:SIDE-EFFECTS`       | `:orange`        | functional amber (post-commit irreversible; the pre-rf2-kt6js `:FX` step) |
 | `:SUBSCRIPTIONS`      | `:magenta-pink`  | pink (rf2-cgm4f split from COEFFECT violet) |
 | `:VIEWS`              | `:success`       | green |
 | `:SCHEMA-HOT-RELOAD`  | `:warning`       | warning amber (rf2-17vxj · renamed rf2-xgeag for the narrowed hot-reload-only scope) |
@@ -2127,8 +2127,8 @@ unchanged); only the aggregation moved.
 |-----------------|-----------------------------------------------------|--------------------------|
 | `:event`        | DISPATCH                                            | step-level               |
 | `:cofx`         | COEFFECT step whose `:id` = `:failing-id`           | step-level (per cofx)    |
-| `:app-db`       | FX step `:db` row (the implicit commit fx) — per rf2-8resu | row-level         |
-| `:fx-args`      | FX step, row whose `:fx-id` = `:failing-id`         | row-level (fallback step)|
+| `:app-db`       | SIDE EFFECTS step `:db` row (the handler's app-db write) — per rf2-8resu / rf2-kt6js | row-level         |
+| `:fx-args`      | SIDE EFFECTS step, row whose `:fx-id` = `:failing-id` | row-level (fallback step)|
 | `:sub-return`   | SUBSCRIPTIONS step, row whose `:sub-id` = `:failing-id` | row-level (fallback step) |
 | `:machine-data` | HANDLER, machine-cascade row whose machine id = `:failing-id` (the failing machine). When the violation triggered full-cascade rollback (`:rollback? true`), the rollback fact is signalled via the §Rollback blast-radius mute pass (no special tail step); the violation itself stays attached to the machine-cascade row. Per rf2-jbbp7 (see [spec/005 §Schema validation](../../../spec/005-StateMachines.md#schema-validation), [spec/010 §Per-step recovery row 7](../../../spec/010-Schemas.md#per-step-recovery)). | row-level (fallback step) |
 
@@ -2292,14 +2292,13 @@ row drops out cleanly and the humanized / raw map renders alone.
 When the cascade carries an `:app-db` violation with
 `:rollback? true`, the projection's
 `mark-rolled-back-downstream` pass flags every step AFTER the
-FX step with `:rolled-back? true`. The view's pipeline wrapper
-applies a `:opacity 0.55` overlay to those steps. The FX step
-itself stays visible — the violation rides on its `:db` row
-(per the attachment table above, post-rf2-8resu) so the operator
-reads the failing commit inline with the implicit commit fx. The
-operator sees the blast radius at a glance instead of reading
-downstream rows that claim success for fx that never actually
-fired.
+SIDE EFFECTS step with `:rolled-back? true`. The view's pipeline
+wrapper applies a `:opacity 0.55` overlay to those steps. The SIDE
+EFFECTS step itself stays visible — the violation rides on its `:db`
+row (per the attachment table above, post-rf2-8resu / rf2-kt6js) so
+the operator reads the failing commit inline. The operator sees the
+blast radius at a glance instead of reading downstream rows that
+claim success for fx that never actually fired.
 
 #### What does NOT change
 
@@ -2414,46 +2413,84 @@ outcome chips + MCP wire consumers + the pinned
 `outcome-enum-projection-pins-mapping` test. No spec/009 /
 Spec-Schemas edit was needed (rf2-ahhgn settle-first finding).
 
-### §9.1.10.6 FX section header + per-action attribution (rf2-uffov · rf2-m8ac9)
+### §9.1.10.6 SIDE EFFECTS step — `:db` / `:fx` / other sub-steps (rf2-kt6js · rf2-uffov · rf2-m8ac9)
 
-The FX step has rendered per-fx rows since rf2-sc3r1. rf2-uffov
-extends it with header + attribution; Mike's pair-debug commit
-`adaabb8aa` (2026-05-26, rf2-m8ac9) reshaped the header. Current
-shape:
+The pre-rf2-kt6js single `:fx` step became the **SIDE EFFECTS** step
+(badge `:SIDE-EFFECTS`, the same `:orange` post-commit hue). It is the
+cascade's post-commit-effects lens, composed of up to **three OPTIONAL
+sub-steps in fixed order `:db → :fx → other`**, each shown only when it
+has rows and each carrying its own per-effect `✓/✗` tick (reusing the
+shared rf2-ahhgn `step-status` + `badge/step-status-*` primitive —
+**not a one-off**):
 
-- **Header chrome** — badge `:FX` (uppercase pill, single-token
-  hue per §9.1.4), a muted-italic `(side effects)` caption beside
-  the badge, and a threw-count chip in `:error` tone that surfaces
-  **only when non-zero**. The prior `N fired (M succeeded, K threw,
-  L skipped)` count summary was dropped per Mike's pair-debug
-  rationale: the per-row glyphs (`✓ / ✗`) already convey per-fx
-  outcome, so the count summary was noise in the step header. The
-  threw chip is the at-a-glance error signal that survives.
-- **Per-action attribution** — when the cascade was driven by a
-  machine handler, each FX row that maps to a fx-id emitted by an
-  action's outcome `:fx` slot carries `:attributed-to {:action-id
-  …, :phase …}` (rf2-9c27r + rf2-uffov). The view renders an
-  italic `← <action-id> (<phase>)` chip alongside the row so the
-  operator reads `fx X emitted by action Y in phase Z` in one
-  line. Best-effort: first-attribution wins when the same fx-id
-  is emitted by multiple actions in the same cascade (cascade
-  order).
-- **Conditional emit unchanged** — section omits when no fx-handler
-  events fired.
-- **Args rendering (rf2-ef2hy)** — each fx row's args mount the
-  shared edn-inspector widget with `:default-expanded-depth 1`.
-  Top-level keys (`:strategy`, `:from`, `:to`) are visible inline;
-  nested maps collapse to clickable `▸` chevrons (`{…N keys}`). The
-  FX step is a dense table the operator scans, then drills into one
-  row's args — depth 1 hits the right scan-then-drill posture.
-  `:zoomable?` is on so the popup overlay opens for a complex fx
-  args map.
+- **`:db` sub-step** — the handler's app-db write (the `:db` effect).
+  `✓` on a successful commit; `✗` when the post-commit app-db schema
+  check rejected the write and the cascade rolled back — the `:where
+  :app-db` violation reason box attaches to the `:db` row via
+  `attach-to-fx-db-row`. The `:db` sub-step ALWAYS appears when a `:db`
+  commit happened, **including a plain reg-event-db that returns only
+  `:db`** (no `:fx`). Reconciles with rf2-4wywy: this is the HANDLER db
+  write (post-handler / pre-flow); the FLOW step's own `:db` diff (the
+  flow's t1→t2 reshape) stays a SEPARATE step.
+- **`:fx` sub-step** — one row per entry in the handler's `:fx` vector,
+  each carrying the rf2-g1mfc open-code chip + a per-effect success
+  tick: `✓` ran / `✗` threw / `↺` overridden / `·` skipped-on-platform.
+  For ASYNC / deferred fx (`dispatch-later`, `http`, a slow fx) the `✓`
+  means **ACTIONED** (the fx handler was invoked ok), not awaited —
+  matching the trace's `:rf.fx/handled` semantics.
+- **`other` sub-step** — one row per TOP-LEVEL effect key on the
+  handler's returned map beyond `:db` / `:fx` (the historical
+  `{:db .. :fx .. :other-key ..}` form). In re-frame2 the effect map is
+  the closed `{:db :fx}` shape (spec/002 §The binary fx-handler
+  signature — "the v1 :dispatch-n top-level key is gone") and the
+  runtime's `run-fx-effects!` reads ONLY `:fx`; any other key is
+  silently DROPPED — never executed, never traced. So each `other` row
+  is a `·` not-run **DIAGNOSTIC** flagging a declared effect the runtime
+  ignored (almost always a bug — the effect belongs inside `:fx`). In
+  the canonical `{:db :fx}` shape there are NO `other` rows.
 
-  Sibling: the HANDLER step's `:fx` section (§9.1.10.5 lineage,
-  rf2-p2zy0) uses the same widget with `:default-expanded-depth 16`
-  (full-expand). Both share the widget; per-call-site depth reflects
-  each section's role — HANDLER reads INTENT (full), FX reads
-  EXECUTION (compact + drill).
+**ALWAYS APPEARS.** Unlike the pre-rf2-kt6js `:fx` step (which showed
+only when an `:fx` fired), the SIDE EFFECTS step appears whenever ANY
+side effect occurred. The `:db`-commit signal is the framework's
+`:rf.event/db-changed` trace (a second one with `:rf.trace/phase
+:rollback` flags a schema-fail rollback) — NOT a fx-id-less
+`:rf.fx/handled` (which the substrate never emits; `re-frame.fx/emit-
+handled!` always stamps `:rf.fx/id`, and the `:db` install path
+`re-frame.router/commit-db-effect!` routes through `:rf.event/db-changed`,
+not the fx pipeline). The pre-rf2-kt6js heuristic looked for that
+non-existent emit, so a clean reg-event-db surfaced no side-effects step
+at all — the bug rf2-kt6js fixes tool-side.
+
+**Settle-first (rf2-kt6js — confirmed against the live substrate; NO
+framework-instrumentation change).** Per-`:fx` success is ALREADY
+RECORDED: each `:fx`-vector entry emits exactly one of `:rf.fx/handled`
+/ `:rf.fx/override-applied` / `:rf.fx/skipped-on-platform` /
+`:rf.error/fx-handler-exception` / `:rf.error/no-such-fx`
+(`re-frame.fx/handle-one-fx`). The `:db` commit + schema-fail are
+recorded by `:rf.event/db-changed` + `:rf.error/schema-validation-
+failure :where :app-db`. "Other" effects don't exist on the trace
+stream because the runtime never touches them. So the whole step is a
+PRESENTATION over already-recorded data — implemented tool-side in
+`projection/side-effects-step`, no core / spec-009 edit.
+
+**Header chrome** — badge `:SIDE-EFFECTS`, a muted-italic
+`(post-commit)` caption, and a threw-count chip in `:error` tone that
+surfaces **only when non-zero**. The per-row + per-sub-step glyphs
+(`✓ / ✗`) carry per-effect outcome; the count summary is omitted as
+noise (the rf2-m8ac9 rationale carries over).
+
+**Per-action attribution** — when the cascade was driven by a machine
+handler, each `:fx` sub-step row that maps to a fx-id emitted by an
+action's outcome `:fx` slot carries `:attributed-to {:action-id …,
+:phase …}` (rf2-9c27r + rf2-uffov). The view renders an italic
+`← <action-id> (<phase>)` chip. First-attribution wins (cascade order).
+
+**Args rendering (rf2-ef2hy)** — each `:fx` / `other` row's args/value
+mount the shared edn-inspector widget with `:default-expanded-depth 1`
+(scan-then-drill); `:zoomable?` opens the popup overlay for a complex
+map. Sibling: the HANDLER step's `:fx` section (§9.1.10.5 lineage,
+rf2-p2zy0) uses depth 16 (full-expand) — HANDLER reads INTENT, SIDE
+EFFECTS reads EXECUTION.
 
 ### §9.1.10.7 COEFFECT step chrome (rf2-s1jw4 · pair-debug 2026-05-26)
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/badge.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/badge.cljc
@@ -29,7 +29,7 @@
 ;;     :COEFFECT      "#a855f7"                  ; light purple
 ;;     :HANDLER       "var(--devtools-active)"   ; blue
 ;;     :FLOW          "var(--devtools-active)"   ; blue
-;;     :FX            "rgb(154, 103, 0)"         ; orange/brown
+;;     :SIDE-EFFECTS  "rgb(154, 103, 0)"         ; orange/brown
 ;;     :SUBSCRIPTIONS "#ec4899"                  ; pink
 ;;     :VIEWS         "var(--devtools-success)"  ; green
 ;;
@@ -46,8 +46,9 @@
 ;;                              continue to read a violet-family hue.)
 ;;     var(--devtools-active) — `:accent` (the single blue identity)
 ;;     rgb(154,103,0)         — :orange (functional amber, perf-slow
-;;                              tier — close enough hue for the FX
-;;                              step's irreversible/post-commit signal)
+;;                              tier — close enough hue for the SIDE
+;;                              EFFECTS step's irreversible/post-commit
+;;                              signal; the pre-rf2-kt6js `:FX` step)
 ;;     #ec4899                — :magenta-pink (the SUBSCRIPTIONS mock
 ;;                              hue, added as a new palette token in
 ;;                              rf2-cgm4f so the SUBSCRIPTIONS pill is
@@ -89,7 +90,7 @@
    :COEFFECT          :magenta
    :HANDLER           :accent
    :FLOW              :accent
-   :FX                :orange
+   :SIDE-EFFECTS      :orange
    :SUBSCRIPTIONS     :magenta-pink
    :VIEWS             :success
    :SCHEMA-HOT-RELOAD :warning
@@ -103,7 +104,7 @@
    :COEFFECT          "COEFFECT"
    :HANDLER           "HANDLER"
    :FLOW              "FLOW"
-   :FX                ":fx"
+   :SIDE-EFFECTS      "SIDE EFFECTS"
    :SUBSCRIPTIONS     "SUBSCRIPTIONS"
    :VIEWS             "VIEWS"
    :SCHEMA-HOT-RELOAD "SCHEMA HOT-RELOAD"

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -11,7 +11,8 @@
 
   - no `:rf.cofx/run` events → no COEFFECT rows
   - no `:rf.flow/computed` events → no FLOW step
-  - no `:rf.fx/handled` events → no FX step
+  - no side effect (no `:db` commit, no `:fx`, no other effect) →
+    no SIDE EFFECTS step
   - HANDLER step adapts to the handler's flavour:
       reg-event-db / reg-event-fx / reg-machine
 
@@ -1059,147 +1060,294 @@
 ;; with rf2-xnb1x; the splicing in `project` consumes `flow-rows`
 ;; directly.
 
-;; ---- FX step -------------------------------------------------------------
+;; ---- SIDE EFFECTS step (rf2-kt6js) --------------------------------------
+;;
+;; The cascade's post-commit side effects render as ONE numbered step —
+;; SIDE EFFECTS — composed of THREE optional sub-steps, each reusing the
+;; shared per-step `:status` (`:ok` / `:error`) primitive (rf2-ahhgn) for
+;; its per-effect tick:
+;;
+;;   :db    — the handler's app-db write (the `:db` effect). PASS on a
+;;            successful commit; FAILED when the post-commit app-db schema
+;;            check rejected the write and the cascade rolled back. Shown
+;;            whenever a `:db` commit was attempted — INCLUDING a plain
+;;            reg-event-db that returns only `:db` (no `:fx`).
+;;   :fx    — the entries in the handler's `:fx` vector, each `[fx-id arg]`
+;;            with the rf2-g1mfc open-code chip + a per-effect success tick
+;;            (✓ ran / ✗ threw / ↺ overridden / · skipped-on-platform).
+;;   other  — any TOP-LEVEL effect key beyond `:db` / `:fx` on the
+;;            handler's returned map (the historical
+;;            `{:db .. :fx .. :other-key ..}` form).
+;;
+;; SETTLE-FIRST (rf2-kt6js, confirmed against the live substrate):
+;;
+;; - PER-`:fx` SUCCESS IS ALREADY RECORDED. Every entry in the `:fx`
+;;   vector emits exactly one of `:rf.fx/handled` / `:rf.fx/override-
+;;   applied` / `:rf.fx/skipped-on-platform` / `:rf.error/fx-handler-
+;;   exception` / `:rf.error/no-such-fx` (spec 009 §`re-frame.fx`;
+;;   `re-frame.fx/handle-one-fx`). The per-fx tick reads that op directly
+;;   — NO framework-instrumentation change (no (A) prong).
+;;
+;; - THE `:db` COMMIT IS RECORDED BY `:rf.event/db-changed`, NOT a
+;;   fx-id-less `:rf.fx/handled`. `re-frame.fx/emit-handled!` ALWAYS
+;;   stamps `:rf.fx/id`; the framework's `:db` install path
+;;   (`re-frame.router/commit-db-effect!`) emits `:rf.event/db-changed`
+;;   (and a second one with `:rf.trace/phase :rollback` on a schema-fail
+;;   rollback) — it does NOT route `:db` through the fx pipeline. The
+;;   pre-rf2-kt6js heuristic looked for a non-existent fx-id-less
+;;   `:rf.fx/handled`, so the `:db` row only ever appeared on the
+;;   rollback path; a clean reg-event-db showed NO side-effects step at
+;;   all. Keying off `:rf.event/db-changed` fixes the ALWAYS-APPEARS
+;;   contract tool-side.
+;;
+;; - "OTHER" TOP-LEVEL EFFECTS ARE NOT EXECUTED BY THE re-frame2 RUNTIME.
+;;   The effect map is the closed `{:db :fx}` shape (spec/002 §The binary
+;;   fx-handler signature — "the v1 :dispatch-n top-level key is gone";
+;;   spec/002 §`:fx` ordering and atomicity guarantees). `re-frame.router/
+;;   run-fx-effects!` reads ONLY `(:fx effects)`; `:db` commits separately;
+;;   any other top-level key is silently ignored (no trace, no run). So
+;;   "other" is a DIAGNOSTIC sub-step: when the handler's returned map
+;;   (off the `:effects-decomp` `:other-effects` slot) carries a key
+;;   beyond `:db` / `:fx`, surface it as a `:skipped` (not-run) effect so
+;;   the operator sees the dropped effect rather than wondering why
+;;   nothing fired. No framework change records these — they don't exist
+;;   on the trace stream because the runtime never touched them.
 
-(defn fx-rows
-  "Project the `:rf.fx/handled` / `:rf.fx/override-applied` /
-  `:rf.fx/skipped-on-platform` stream into per-handler rows. Each row
-  carries `:fx-id`, `:status` (`:ok / :overridden / :skipped /
-  :error / :rollback`), `:args`, and `:duration-ms`.
+(def ^:private fx-outcome-op->status
+  "Map a per-fx trace op → the fx-row `:status` (rf2-kt6js, lifted from
+  the inline `status-fn`). Closed set — a `:fx`-vector entry surfaces
+  exactly one of these ops per `re-frame.fx/handle-one-fx`."
+  {:rf.fx/handled                 :ok
+   :rf.fx/override-applied        :overridden
+   :rf.fx/skipped-on-platform     :skipped
+   :rf.error/fx-handler-exception :error
+   :rf.error/no-such-fx           :error})
 
-  Per rf2-8resu — the implicit `:db` commit is rendered as the FIRST
-  row of the FX step (the framework treats `:db` as an implicit fx
-  whose commit happens before any user-emitted fx fire). The row's
-  `:fx-id` is the keyword `:db`; the row's `:status` is `:ok` for a
-  successful commit, `:rollback` when an `:where :app-db` schema
-  violation rolled the cascade back. `:where :app-db` violations
-  attach to this row (per `attach-to-fx-db-row`); when the commit
-  rolls back, no user-emitted fx fire (per Spec 010), so the FX step
-  in a rollback case contains only the `:db` row.
-
-  Per rf2-uffov: user-fx rows additionally carry `:attributed-to`
-  (the machine action that emitted the fx) when the cascade was
-  driven by a machine handler — sourced from
-  `:rf.machine/action-ran`'s `:outcome :fx` slot (rf2-9c27r). The
-  attribution is best-effort: matched by `(= fx-id (first fx-tuple))`
-  against the action's emitted fx vector. When a fx-id is emitted by
-  multiple actions in the same cascade, the FIRST attribution wins
-  (cascade order). The synthesised `:db` row does not carry
-  `:attributed-to`."
+(defn- fx-attribution-map
+  "Build the `{fx-id → {:action-id … :phase …}}` per-action attribution
+  map for a cascade (rf2-uffov). Each entry maps a fx-id (first element
+  of a machine action's emitted fx tuple) to the FIRST action that
+  emitted it (cascade order). Empty map for non-machine cascades."
   [events]
-  (let [status-fn (fn [op-kw]
-                    (case op-kw
-                      :rf.fx/handled               :ok
-                      :rf.fx/override-applied      :overridden
-                      :rf.fx/skipped-on-platform   :skipped
-                      :rf.error/fx-handler-exception :error
-                      :rf.error/no-such-fx         :error
-                      :ok))
-        ;; rf2-8resu — `:db` row status. A `:where :app-db` schema
-        ;; violation with `:rollback? true` means the commit was
-        ;; rolled back; otherwise the commit succeeded.
-        db-rolled-back?
-        (some (fn [ev]
-                (and (= :rf.error/schema-validation-failure (op ev))
-                     (= :app-db (common/tag-of ev :where))
-                     (true? (common/tag-of ev :rollback?))))
-              events)
-        ;; rf2-8resu — detect that an implicit `:db` commit was
-        ;; attempted (or fired) in this cascade. Two signals, EITHER
-        ;; sufficient:
-        ;;   (a) An `:rf.fx/handled` trace WITHOUT `:rf.fx/id` — the
-        ;;       framework's emission for the implicit `:db` commit
-        ;;       path when the commit succeeds.
-        ;;   (b) A `:where :app-db` schema violation — implies a
-        ;;       `:db` commit WAS attempted (even if it rolled back +
-        ;;       the framework suppressed the `:rf.fx/handled` emit).
-        ;; Either signal means the operator's :db row should render.
-        db-commit?
-        (or db-rolled-back?
-            (some (fn [ev]
-                    (and (= :rf.fx/handled (op ev))
-                         (nil? (common/tag-of ev :rf.fx/id))))
-                  events))
-        ;; Per rf2-uffov — build the per-action fx attribution map
-        ;; once for this projection pass. Each entry maps a fx-id
-        ;; (the first element of the action's emitted fx tuple) to
-        ;; the FIRST machine action that emitted it. This is the
-        ;; per-action attribution surfaced on the FX section's rows.
-        attribution-map
-        (reduce
-          (fn [acc ev]
-            (if (and (= :rf.machine/action-ran (op ev))
-                     (map? (common/tag-of ev :outcome)))
-              (let [{:keys [fx]} (common/tag-of ev :outcome)
-                    action-id    (common/tag-of ev :action-id)
-                    phase        (common/tag-of ev :phase)]
-                (reduce
-                  (fn [a entry]
-                    (let [fx-id (cond
-                                  (and (vector? entry) (pos? (count entry)))
-                                  (first entry)
-                                  (keyword? entry) entry)]
-                      (if (and fx-id (not (contains? a fx-id)))
-                        (assoc a fx-id {:action-id action-id :phase phase})
-                        a)))
-                  acc
-                  (or fx [])))
-              acc))
-          {}
-          events)
-        ;; The user-emitted fx rows. Drop fx-id-less rows here (the
-        ;; implicit `:db` trace is surfaced via the synthesised :db
-        ;; row prepended below — rf2-8resu).
-        user-rows
-        (vec
-          (for [ev events
-                :let [o (op ev)
-                      fx-id (common/tag-of ev :rf.fx/id)]
-                :when (and (or (= "rf.fx" (op-ns ev))
-                               (contains? #{:rf.error/fx-handler-exception
-                                            :rf.error/no-such-fx} o))
-                           (some? fx-id))]
-            (cond-> {:fx-id       fx-id
-                     :status      (status-fn o)
-                     :args        (common/tag-of ev :rf.fx/args)
-                     ;; rf2-ipaza — substrate stamps the per-fx-handler
-                     ;; invocation duration as `:rf.fx/elapsed-ms` on
-                     ;; `:rf.fx/handled` (rf2-hhh92 · `re-frame.fx`;
-                     ;; spec 009 §241). Legacy `:duration-ms` retained
-                     ;; as a fixture-compat fallback for older runtimes.
-                     :duration-ms (or (common/tag-of ev :rf.fx/elapsed-ms)
-                                      (common/tag-of ev :duration-ms))}
-              (get attribution-map fx-id)
-              (assoc :attributed-to (get attribution-map fx-id)))))]
-    ;; rf2-8resu — prepend synthesised :db row when the implicit
-    ;; commit fired. Status reflects rollback if any :where :app-db
-    ;; violation flagged the cascade as rolled back.
-    (if db-commit?
-      (vec (cons {:fx-id  :db
-                  :status (if db-rolled-back? :rollback :ok)}
-                 user-rows))
-      user-rows)))
+  (reduce
+    (fn [acc ev]
+      (if (and (= :rf.machine/action-ran (op ev))
+               (map? (common/tag-of ev :outcome)))
+        (let [{:keys [fx]} (common/tag-of ev :outcome)
+              action-id    (common/tag-of ev :action-id)
+              phase        (common/tag-of ev :phase)]
+          (reduce
+            (fn [a entry]
+              (let [fx-id (cond
+                            (and (vector? entry) (pos? (count entry)))
+                            (first entry)
+                            (keyword? entry) entry)]
+                (if (and fx-id (not (contains? a fx-id)))
+                  (assoc a fx-id {:action-id action-id :phase phase})
+                  a)))
+            acc
+            (or fx [])))
+        acc))
+    {}
+    events))
 
-(defn fx-step
-  "FX step row (one row aggregating every fx-handler invocation). nil
-  when no fx-handler events fired (the step is OMITTED — conditional).
-
-  Per rf2-uffov the step carries header counters splitting the rows
-  by outcome — `N fired (M succeeded, K threw)`. The view consumes
-  these directly so the header reads as 'at-a-glance correctness'."
+(defn db-rolled-back?
+  "True iff a `:where :app-db` schema-validation failure flagged the
+  cascade rolled back (rf2-kt6js; lifted from the rf2-8resu inline
+  signal). The `:db` sub-step paints ✗ in this case; the schema reason
+  attaches to the `:db` row via `attach-to-fx-db-row`."
   [events]
-  (let [rows (fx-rows events)]
-    (when (seq rows)
-      (let [by-status  (frequencies (map :status rows))
-            succeeded  (+ (get by-status :ok 0)
-                          (get by-status :overridden 0))
-            skipped    (get by-status :skipped 0)
-            threw      (get by-status :error 0)]
-        {:step      :fx
-         :badge     :FX
-         :rows      rows
-         :succeeded succeeded
-         :skipped   skipped
+  (boolean
+    (some (fn [ev]
+            (and (= :rf.error/schema-validation-failure (op ev))
+                 (= :app-db (common/tag-of ev :where))
+                 (true? (common/tag-of ev :rollback?))))
+          events)))
+
+(defn db-commit?
+  "True iff this cascade attempted a `:db` commit (rf2-kt6js). Two
+  signals, EITHER sufficient:
+
+    (a) A `:rf.event/db-changed` trace — the framework's `commit-db-
+        effect!` emits this for EVERY actual `:db` install (forward
+        commit), and a second one with `:rf.trace/phase :rollback` on a
+        schema-fail rollback. This is the canonical `:db`-commit signal,
+        present for a plain reg-event-db that returns only `:db`.
+    (b) A `:where :app-db` schema violation — implies a commit was
+        ATTEMPTED even on the abort path.
+
+  Pre-rf2-kt6js this keyed off a fx-id-less `:rf.fx/handled` that the
+  substrate never emits (`emit-handled!` always stamps `:rf.fx/id`), so
+  the `:db` row only ever appeared on rollback. Keying off `:rf.event/
+  db-changed` is what makes the SIDE EFFECTS step ALWAYS appear on a
+  bare `:db`."
+  [events]
+  (or (db-rolled-back? events)
+      (some? (find-op events :rf.event/db-changed))))
+
+(defn db-effect-row
+  "The `:db` sub-step row — the handler's app-db write rendered as a
+  single per-effect tick (rf2-kt6js). nil when no `:db` commit was
+  attempted (a reg-event-fx that returned no `:db`). `:status` is
+  `:error` on a schema-fail rollback (so `step-status` paints ✗ and the
+  attached `:where :app-db` violation carries the reason box), else
+  `:ok`.
+
+  Reconciles with rf2-4wywy: this is the HANDLER db write (the post-
+  handler / pre-flow `:db` effect). The FLOW step's `:db` diff (the
+  flow's own t1→t2 reshape) stays a SEPARATE step."
+  [events]
+  (when (db-commit? events)
+    {:fx-id  :db
+     :status (if (db-rolled-back? events) :error :ok)}))
+
+(defn fx-effect-rows
+  "The `:fx` sub-step rows — one per entry in the handler's `:fx` vector
+  (rf2-kt6js, the user-emitted fx rows formerly carried inline in
+  `fx-rows`). Each row carries `:fx-id`, `:status` (`:ok / :overridden /
+  :skipped / :error` per `fx-outcome-op->status`), `:args`,
+  `:duration-ms`, and — for machine cascades — `:attributed-to`
+  (rf2-uffov · rf2-9c27r). Each row's `fx-id` carries the rf2-g1mfc
+  open-code chip at the view layer.
+
+  Reads the `:rf.fx/*` + fx-error trace ops directly (per-fx success is
+  ALREADY RECORDED — see the SIDE EFFECTS step settle-first note); the
+  implicit `:db` commit is NOT here (it has its own `db-effect-row`)."
+  [events]
+  (let [attribution-map (fx-attribution-map events)]
+    (vec
+      (for [ev events
+            :let [o     (op ev)
+                  fx-id (common/tag-of ev :rf.fx/id)]
+            :when (and (or (= "rf.fx" (op-ns ev))
+                           (contains? #{:rf.error/fx-handler-exception
+                                        :rf.error/no-such-fx} o))
+                       (some? fx-id))]
+        (cond-> {:fx-id       fx-id
+                 :status      (get fx-outcome-op->status o :ok)
+                 :args        (common/tag-of ev :rf.fx/args)
+                 ;; rf2-ipaza — substrate stamps the per-fx-handler
+                 ;; invocation duration as `:rf.fx/elapsed-ms` on
+                 ;; `:rf.fx/handled` (rf2-hhh92 · `re-frame.fx`;
+                 ;; spec 009 §241). Legacy `:duration-ms` retained
+                 ;; as a fixture-compat fallback for older runtimes.
+                 :duration-ms (or (common/tag-of ev :rf.fx/elapsed-ms)
+                                  (common/tag-of ev :duration-ms))}
+          (get attribution-map fx-id)
+          (assoc :attributed-to (get attribution-map fx-id)))))))
+
+(defn other-effect-rows
+  "The `other` sub-step rows — one per TOP-LEVEL effect key on the
+  handler's returned map beyond `:db` / `:fx` (rf2-kt6js). Sourced from
+  `effects-decomp`'s `:other-effects` slot (the return map MINUS `:db`
+  and `:fx`).
+
+  In re-frame2 the effect map is the closed `{:db :fx}` shape and the
+  runtime (`re-frame.router/run-fx-effects!`) reads ONLY `:fx`; any
+  other top-level key is silently DROPPED — never executed, never
+  traced. So each `other` row is a DIAGNOSTIC: `:status :skipped`
+  (not-run) flags that the handler declared an effect the runtime
+  ignored — almost always a bug (the effect belongs inside `:fx`).
+
+  Empty vec when the handler returned the canonical `{:db :fx}` shape
+  (the overwhelming common case), or when no do-fx fired."
+  [events]
+  (let [other (:other-effects (effects-decomp events))]
+    (if (map? other)
+      (vec (for [[fx-id value] other]
+             {:fx-id  fx-id
+              :value  value
+              :status :skipped}))
+      [])))
+
+(def side-effects-sub-kind-order
+  "The fixed render order of SIDE EFFECTS sub-steps (rf2-kt6js):
+  `:db → :fx → other`. Drives both the step's `:sub-kinds` slot and the
+  view's `sub-rows-of` grouping."
+  [:db :fx :other])
+
+(defn sub-rows-of
+  "The flat `:rows` of a (post-attachment) SIDE EFFECTS `step` belonging
+  to sub-step `kind` (`:db / :fx / :other`), in row order (rf2-kt6js).
+  Each row carries a `:sub-kind` tag the view groups by. Reading the
+  flat slot — rather than a duplicated per-sub-step row vector — is what
+  lets the rf2-ahhgn / rf2-xgeag attachment machinery
+  (`attach-to-fx-db-row` / `attach-to-fx-row` / `attach-to-fx-error-row`,
+  all of which mutate the step's `:rows`) flow through to the rendered
+  sub-step unchanged."
+  [step kind]
+  (filterv #(= kind (:sub-kind %)) (:rows step)))
+
+(defn sub-step-status
+  "The per-effect `:status` rollup for a SIDE EFFECTS sub-step (rf2-kt6js)
+  — `:error` iff any of its (post-attachment) rows reads `:error` via the
+  shared `step-status`-style scan (its own `:status` is `:error` /
+  `:rollback`, OR it carries an attached `:errors` / `:violations`), else
+  `:ok`. Reuses the rf2-ahhgn closed `:ok` / `:error` shape so the view
+  paints a sub-step ✓/✗ off `badge/step-status-*` alongside the per-row
+  ticks. Defined over the flat-row group so attached errors/violations
+  (which land AFTER `side-effects-step` builds the step) lift the
+  sub-step to `:error`."
+  [rows]
+  (if (some (fn [r]
+              (or (contains? #{:error :rollback} (:status r))
+                  (seq (:errors r))
+                  (seq (:violations r))))
+            rows)
+    :error
+    :ok))
+
+(defn side-effects-step
+  "The SIDE EFFECTS step (rf2-kt6js) — replaces the pre-rf2-kt6js single
+  `:fx` step. Composed of up to three OPTIONAL sub-steps in fixed order
+  `:db → :fx → other`, each shown only when it has rows:
+
+    :db    — the handler's app-db write (`db-effect-row`).
+    :fx    — the `:fx`-vector entries (`fx-effect-rows`).
+    other  — top-level non-`:db`/`:fx` effects (`other-effect-rows`).
+
+  nil (step OMITTED) when NO side effect occurred — no `:db` commit, no
+  `:fx`, no other effect. Unlike the pre-rf2-kt6js `:fx` step, this
+  ALWAYS appears when a `:db` commit happened, INCLUDING a plain
+  reg-event-db with no `:fx` (`db-commit?` keys off `:rf.event/db-
+  changed`).
+
+  ## Single-source-of-truth row shape
+
+  The step carries ONE flat `:rows` slot (`:db` row first, then `:fx`
+  rows, then `other` rows), each row tagged with `:sub-kind`
+  (`:db / :fx / :other`); plus `:sub-kinds` — the ordered vec of the
+  kinds present. The view groups rows back into sub-steps via
+  `sub-rows-of` and computes each sub-step's ✓/✗ via `sub-step-status`.
+
+  This single-row-vector shape is load-bearing: the rf2-ahhgn /
+  rf2-xgeag attachment machinery (`attach-to-fx-db-row` /
+  `attach-to-fx-row` / `attach-to-fx-error-row`) runs in `project`
+  AFTER this builder and mutates the step's `:rows` to attach schema
+  violations + exceptions by matching `:failing-id` against a row's
+  `:fx-id`. Because the rendered sub-steps READ THE SAME `:rows`
+  (not a duplicated copy), those attachments surface inline on the
+  right sub-step row without the attachment code needing to know
+  sub-steps exist.
+
+  The header carries a threw-count chip (`:threw`) that surfaces only
+  when non-zero."
+  [events]
+  (let [db-row   (db-effect-row events)
+        fx-rows  (fx-effect-rows events)
+        other    (other-effect-rows events)
+        tag      (fn [kind rows] (mapv #(assoc % :sub-kind kind) rows))
+        all-rows (vec (concat (tag :db (when db-row [db-row]))
+                              (tag :fx fx-rows)
+                              (tag :other other)))]
+    (when (seq all-rows)
+      (let [present (filterv #(seq (sub-rows-of {:rows all-rows} %))
+                             side-effects-sub-kind-order)
+            threw   (count (filter #(= :error (:status %)) all-rows))]
+        {:step      :side-effects
+         :badge     :SIDE-EFFECTS
+         :sub-kinds present
+         :rows      all-rows
          :threw     threw}))))
 
 ;; ---- SUBSCRIPTIONS step --------------------------------------------------
@@ -1521,8 +1669,9 @@
 ;;   ---------------|-----------------------------------------------
 ;;   :event         | DISPATCH (one step)
 ;;   :cofx          | COEFFECT step matching :failing-id against :id
-;;   :app-db        | FX step :db row (the implicit commit fx; rf2-8resu)
-;;   :fx-args       | FX step (row-level :fx-id match)
+;;   :app-db        | SIDE EFFECTS step :db row (the handler db write;
+;;                  | rf2-8resu / rf2-kt6js)
+;;   :fx-args       | SIDE EFFECTS step (row-level :fx-id match)
 ;;   :sub-return    | SUBSCRIPTIONS step (row-level :sub-id match)
 ;;   :hot-reload    | Issues panel only — no pipeline step (rf2-7gf7v)
 
@@ -1538,10 +1687,10 @@
   (update row :violations (fnil conj []) violation))
 
 (defn- attach-to-fx-row
-  "When `step` is the FX step + the violation's `:failing-id` matches
-  an `fx-id` in the step's `:rows`, attach the violation to that
-  row's `:violations` vec. Otherwise attach to the step-level
-  `:violations`. Returns the updated step."
+  "When `step` is the SIDE EFFECTS step + the violation's `:failing-id`
+  matches an `fx-id` in the step's flat `:rows` slot, attach the
+  violation to that row's `:violations` vec. Otherwise attach to the
+  step-level `:violations`. Returns the updated step."
   [step row]
   (let [fx-id (:failing-id row)]
     (if (some #(= fx-id (:fx-id %)) (:rows step))
@@ -1555,10 +1704,11 @@
       (attach-step-violation step row))))
 
 (defn- attach-to-fx-db-row
-  "Per rf2-8resu — attach a `:where :app-db` schema-violation to the
-  FX step's `:db` row (the implicit commit fx). Falls back to the
-  step-level `:violations` if the `:db` row isn't present (shouldn't
-  happen — an :app-db violation implies a `:db` commit attempted)."
+  "Per rf2-8resu / rf2-kt6js — attach a `:where :app-db` schema-violation
+  to the SIDE EFFECTS step's `:db` row (the handler's app-db write).
+  Falls back to the step-level `:violations` if the `:db` row isn't
+  present (shouldn't happen — an :app-db violation implies a `:db`
+  commit attempted)."
   [step row]
   (if (some #(= :db (:fx-id %)) (:rows step))
     (update step :rows
@@ -1629,18 +1779,19 @@
                 s)))
 
           :app-db
-          ;; rf2-8resu — :where :app-db violations attach to the FX
-          ;; step's :db row (the implicit commit fx). Was previously
-          ;; HANDLER step per rf2-xgeag, but the :db commit IS an fx
-          ;; (the framework's first fx); attaching there matches the
-          ;; semantic unit that failed.
-          (let [i (index-of #(= :fx (:step %)) s)]
+          ;; rf2-8resu / rf2-kt6js — :where :app-db violations attach to
+          ;; the SIDE EFFECTS step's :db row (the handler's app-db write).
+          ;; Was the FX step's :db row pre-rf2-kt6js; the :fx step became
+          ;; the SIDE EFFECTS step (`:db` / `:fx` / other sub-steps), and
+          ;; the :db row still carries the `:fx-id :db` marker so the
+          ;; row-level attach matches unchanged.
+          (let [i (index-of #(= :side-effects (:step %)) s)]
             (if i
               (update s i attach-to-fx-db-row row)
               s))
 
           :fx-args
-          (let [i (index-of #(= :fx (:step %)) s)]
+          (let [i (index-of #(= :side-effects (:step %)) s)]
             (if i
               (update s i attach-to-fx-row row)
               s))
@@ -1707,10 +1858,10 @@
     `:rf/interceptor-error` and the router emitted this op (the `:db`/`:fx`
     did NOT apply — db rolled back). Owns the HANDLER step.
   - `:rf.error/fx-handler-exception` — a registered fx-handler threw during
-    the post-commit fx walk. Owns the FX step (best-effort per-row match on
-    `:rf.fx/id`; falls back to step-level).
+    the post-commit fx walk. Owns the SIDE EFFECTS step (best-effort
+    per-row match on `:rf.fx/id`; falls back to step-level).
   - `:rf.error/no-such-fx` — the handler returned an fx-id with no
-    registered handler. Owns the FX step.
+    registered handler. Owns the SIDE EFFECTS step.
   - `:rf.error/flow-eval-exception` — a flow's compute fn threw (pre-commit
     abort). Owns the FLOW step (step-level; the throwing flow aborted the
     cascade)."
@@ -1727,8 +1878,8 @@
   for the headline button-15 (handler) + button-16 (interceptor) cases and
   acceptable for button-17 (the coeffect throw aborts the handler chain)."
   {:rf.error/handler-exception    :handler
-   :rf.error/fx-handler-exception :fx
-   :rf.error/no-such-fx           :fx
+   :rf.error/fx-handler-exception :side-effects
+   :rf.error/no-such-fx           :side-effects
    :rf.error/flow-eval-exception  :flow})
 
 (defn- exception-message
@@ -1792,10 +1943,10 @@
       (exception-row ev))))
 
 (defn- attach-to-fx-error-row
-  "Attach an fx exception row to the FX step's matching `:fx-id` row
-  (rf2-ahhgn). When `:failing-id` matches a row's `:fx-id`, attach there;
-  otherwise attach to the step-level `:errors`. Mirrors
-  `attach-to-fx-row` for schema violations."
+  "Attach an fx exception row to the SIDE EFFECTS step's matching
+  `:fx-id` row (rf2-ahhgn / rf2-kt6js). When `:failing-id` matches a
+  row's `:fx-id`, attach there; otherwise attach to the step-level
+  `:errors`. Mirrors `attach-to-fx-row` for schema violations."
   [step row]
   (let [fx-id (:failing-id row)]
     (if (some #(= fx-id (:fx-id %)) (:rows step))
@@ -1830,7 +1981,7 @@
           (if i
             (update s i
                     (fn [step]
-                      (-> (if (= :fx target-step)
+                      (-> (if (= :side-effects target-step)
                             (attach-to-fx-error-row step row)
                             (update step :errors (fnil conj []) row))
                           (assoc :status :error))))
@@ -1908,20 +2059,21 @@
 
 (defn mark-rolled-back-downstream
   "When the cascade carries an `:app-db` rollback violation, mark
-  every step downstream of the FX step (SUBSCRIPTIONS / VIEWS / any
-  standalone hot-reload tail) with `:rolled-back? true`. The view
-  paints those steps with mute chrome. Pure fn over the step vector.
+  every step downstream of the SIDE EFFECTS step (SUBSCRIPTIONS /
+  VIEWS / any standalone hot-reload tail) with `:rolled-back? true`.
+  The view paints those steps with mute chrome. Pure fn over the step
+  vector.
 
-  Per rf2-8resu: the FX step itself is NOT marked rolled-back — its
-  `:db` row (first row) carries the red ✗ + violation sub-block
-  that's the visible rollback indicator. Muting the entire FX step
-  would hide the very signal the operator needs. Other FX rows
-  don't exist in a rollback cascade (per Spec 010, user fx don't
-  fire when the commit rolls back) — so the FX step in a rollback
-  contains only the :db row, visibly red."
+  Per rf2-8resu / rf2-kt6js: the SIDE EFFECTS step itself is NOT marked
+  rolled-back — its `:db` row carries the red ✗ + violation sub-block
+  that's the visible rollback indicator. Muting the entire step would
+  hide the very signal the operator needs. User-fx rows don't exist in
+  a rollback cascade (per Spec 010, `:fx` doesn't walk when the commit
+  rolls back) — so the SIDE EFFECTS step in a rollback carries only the
+  :db sub-step, visibly red."
   [steps rows]
   (if (cascade-rolled-back? rows)
-    (let [fx-idx (index-of #(= :fx (:step %)) steps)]
+    (let [fx-idx (index-of #(= :side-effects (:step %)) steps)]
       (if (number? fx-idx)
         (vec
           (map-indexed (fn [i step]
@@ -2112,7 +2264,10 @@
                         into a single step group by the view layer)
       :handler        — always present; adapts to handler flavour
       :flow           — only when flows fired
-      :fx             — only when fx-handlers fired
+      :side-effects   — when ANY side effect occurred (a :db commit —
+                        including a bare reg-event-db — and/or :fx and/or
+                        other top-level effects); :db / :fx / other
+                        sub-steps each shown only when present (rf2-kt6js)
       :subscriptions  — only when subs recomputed
       :views          — only when views re-rendered
 
@@ -2224,7 +2379,7 @@
                           ;; sub-section's [diff][all] toggle which
                           ;; surfaces the same data IN-context.
                           flow-steps
-                          [(fx-step events)
+                          [(side-effects-step events)
                            ;; CHILD DISPATCHES step removed pair-debug
                            ;; 2026-05-26 — redundant with the FX step which
                            ;; already surfaces each `:dispatch` /
@@ -2277,7 +2432,8 @@
 ;;
 ;; Per-step `:duration-ms` is stamped at projection time (each step row
 ;; reads its substrate-emitted duration off the matching trace event:
-;; `:rf.event/run-end` for HANDLER, `:rf.fx/handled` for FX rows, etc).
+;; `:rf.event/run-end` for HANDLER, `:rf.fx/handled` for SIDE EFFECTS
+;; :fx rows, etc).
 ;; The cascade total + long-step predicate are pure aggregations over
 ;; the already-projected step rows so the view layer never re-walks the
 ;; trace stream for chrome decisions.
@@ -2539,10 +2695,12 @@
   - rf2-xgeag: SCHEMA-VIOLATIONS retired (violations attach to owning
     pipeline step inline); + SCHEMA-HOT-RELOAD for the hot-reload-only
     standalone tail step (drift has no owning cascade step).
+  - rf2-kt6js: FX → SIDE-EFFECTS (the single :fx step became the SIDE
+    EFFECTS step with :db / :fx / other sub-steps).
 
   The view's badge resolver bails to `:text-tertiary` on an unknown
   badge, so adding to this set is purely additive."
-  #{:DISPATCH :COEFFECT :HANDLER :FLOW :FX :SUBSCRIPTIONS :VIEWS
+  #{:DISPATCH :COEFFECT :HANDLER :FLOW :SIDE-EFFECTS :SUBSCRIPTIONS :VIEWS
     :SCHEMA-HOT-RELOAD :CHILD-DISPATCHES :APP-DB-DIFF})
 
 (defn valid-badge?

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -2840,14 +2840,15 @@
      ;; aborting the cascade pre-commit) attaches here as an inline card.
      (error-blocks :flow errors)]))
 
-;; ---- FX step -------------------------------------------------------------
+;; ---- SIDE EFFECTS step (rf2-kt6js — the pre-rf2-kt6js FX step) ----------
 
 (defn- fx-coord
   "Pull the registered fx-handler's source coord off
   `(rf/handler-meta :fx fx-id)`. Returns nil when no meta is captured.
   Mirrors the sibling `sub-coord` shape (rf2-g1mfc — bring the
-  click-to-source affordance to FX-step rows on parity with the
-  HANDLER verb, the SUBSCRIPTIONS rows, and the VIEWS rows).
+  click-to-source affordance to the SIDE EFFECTS step's :fx rows on
+  parity with the HANDLER verb, the SUBSCRIPTIONS rows, and the VIEWS
+  rows).
 
   The `:file` here is ABSOLUTE: `reg-fx` registers through the same
   `core-reg-macros/defreg-macro` → `with-coords-form` → `coords-form`
@@ -2863,8 +2864,8 @@
         {:file (:file m) :line (:line m) :ns (:ns m)}))))
 
 (defn- fx-row-view
-  "Render one fx-handler row inside the FX step — green check + fx-id
-  + truncated args.
+  "Render one fx-handler row inside the SIDE EFFECTS step's :db / :fx
+  sub-steps — per-effect tick glyph + fx-id + truncated args.
 
   Argument order matches `map-indexed`'s `(f idx item)` convention
   (rf2-cq0ch — companion swap with `coeffect-row-view`).
@@ -2961,45 +2962,140 @@
    (error-blocks (keyword (str "fx-row-" idx)) (:errors row))
    (violation-blocks (keyword (str "fx-row-" idx)) (:violations row))])
 
-(defn render-fx-step
-  "Render the FX step (only present when fx-handlers fired).
+;; ---- SIDE EFFECTS sub-steps (rf2-kt6js) ---------------------------------
 
-  Pair-debug 2026-05-26: the prior verb that read `N fired (M
-  succeeded, K threw)` is dropped — the row glyphs (✓/✗) already
-  convey per-fx outcome; the count summary is noise in the
-  step header. Threw-count surfaces as a chip only if non-zero so
-  the operator still sees errors at-a-glance.
+(def ^:private side-effects-sub-label
+  "Map a SIDE EFFECTS sub-step `:kind` → its sub-header label. `:db` and
+  `:fx` render as the literal keyword (lowercase, matching the
+  `sub-header` keyword-identity convention); `other` renders as the
+  plain word."
+  {:db    ":db"
+   :fx    ":fx"
+   :other "other"})
 
-  rf2-xgeag — `:fx-args` boundary violations attach per-row when
-  `:failing-id` matches an fx-id; otherwise they attach to the
-  step-level `:violations` slot (rendered at the foot of the
-  step)."
-  [{:keys [rows step-number threw violations errors] :as step}]
+(defn- sub-step-header
+  "Render a SIDE EFFECTS sub-step header (rf2-kt6js) — the
+  corner-down-right sub-header glyph + the shared per-step ✓/✗ status
+  glyph (rf2-ahhgn `step-status-glyph`, the exact primitive the
+  top-level step headers reuse) + the sub-step label + a trailing
+  entry-count chip. `kind` is `:db / :fx / :other`; `status` is the
+  sub-step's `:ok` / `:error` rollup; `n` is the row count."
+  [kind status n]
+  (let [testid (str "rf-xray-epoch-side-effects-sub-" (name kind))]
+    [:div {:data-testid (str testid "-header")
+           :style sub-header-style}
+     [:span {:style sub-header-glyph-style}
+      (icons/corner-down-right)]
+     (step-status-glyph status testid)
+     [:span (get side-effects-sub-label kind (name kind))]
+     [:span {:style sub-header-trailing-style}
+      (str n " effect" (when (not= 1 n) "s"))]]))
+
+(defn- other-effect-row-view
+  "Render one `other` sub-step row (rf2-kt6js) — a top-level effect key
+  the runtime DID NOT execute (re-frame2's effect map is the closed
+  `{:db :fx}` shape; any other key is dropped). The `·` skipped glyph +
+  muted tone signal not-run; the fx-id + value render so the operator
+  sees exactly which declared effect the runtime ignored."
+  [idx {:keys [fx-id value]}]
+  [:div {:key (str "other-" idx)
+         :data-testid (str "rf-xray-epoch-side-effects-other-row-" idx)
+         :data-fx-status "skipped"
+         :style fx-row-style}
+   [:span {:style (assoc diff-glyph-bold-style :color text-tertiary-colour)
+           :title "this effect was not run — re-frame2 executes only :db and :fx"}
+    "·"]
+   [:span {:style fx-row-id-style}
+    (proj/ns-keyword fx-id)]
+   (when (some? value)
+     [:span {:style fx-row-args-style}
+      [ei/edn-inspector value
+       {:site-id [:rf.xray.epoch/other-effect-row fx-id idx]
+        :card? false
+        :zoomable? true
+        :default-expanded-depth 1}]])])
+
+(defn- render-side-effects-sub-step
+  "Render one SIDE EFFECTS sub-step group (rf2-kt6js): its
+  status-bearing sub-header + its rows. `:db` / `:fx` rows render via
+  `fx-row-with-violations` (the per-effect ✓/✗ tick + open-code chip +
+  inline error / violation cards); `other` rows render via
+  `other-effect-row-view` (the `·` not-run diagnostic).
+
+  `step` is the WHOLE side-effects step; `kind` selects the group. Rows
+  are read off the step's flat `:rows` via `proj/sub-rows-of` (so
+  post-attachment errors / violations surface inline) and rendered at
+  their GLOBAL flat-row index so the per-row testids are stable across
+  groups + match the index the attachment machinery resolved by
+  `:fx-id`."
+  [step kind]
+  (let [rows   (proj/sub-rows-of step kind)
+        all    (:rows step)
+        ;; global flat-row index of each sub-row (identity-stable —
+        ;; rows are distinct maps once tagged with :sub-kind).
+        idx-of (fn [row] (some (fn [[i r]] (when (identical? r row) i))
+                               (map-indexed vector all)))]
+    [:div {:data-testid (str "rf-xray-epoch-side-effects-sub-" (name kind))}
+     (sub-step-header kind (proj/sub-step-status rows) (count rows))
+     [:div {:style margin-top-5-style}
+      (for [row rows
+            :let [i (idx-of row)]]
+        ^{:key (str (name kind) "-" i)}
+        [(if (= :other kind) other-effect-row-view fx-row-with-violations)
+         i row])]]))
+
+(defn render-side-effects-step
+  "Render the SIDE EFFECTS step (rf2-kt6js — replaces the pre-rf2-kt6js
+  FX step). ALWAYS present when ANY side effect occurred — including a
+  bare reg-event-db that returns only `:db` (the step's `:db` sub-step
+  keys off `:rf.event/db-changed`, not a non-existent fx-id-less
+  `:rf.fx/handled`).
+
+  Composed of up to three OPTIONAL sub-step groups in fixed order
+  `:db → :fx → other` (`:sub-kinds`), each shown only when it has rows,
+  each carrying its own per-effect ✓/✗ tick (reusing the shared
+  rf2-ahhgn `step-status` primitive via `proj/sub-step-status`):
+
+    :db    — the handler's app-db write — ✓ committed / ✗ schema-fail
+             rollback (the `:where :app-db` violation reason box rides
+             the row via `attach-to-fx-db-row`).
+    :fx    — the `:fx`-vector entries — each with the rf2-g1mfc
+             open-code chip + a per-effect tick (✓ ran / ✗ threw / ↺
+             overridden / · skipped-on-platform). For async / deferred
+             fx the ✓ means ACTIONED (handler invoked ok), not awaited.
+    other  — top-level non-`:db`/`:fx` effects the runtime DROPPED —
+             rendered `·` not-run (diagnostic).
+
+  Threw-count chip surfaces only when non-zero. `:fx-args` / fx
+  exception attachments that didn't match a row attach to the step
+  level (rf2-xgeag / rf2-ahhgn) and render at the foot."
+  [{:keys [sub-kinds step-number threw violations errors] :as step}]
   (let [k (or threw 0)]
-    [:div {:data-testid "rf-xray-epoch-step-fx"
-           :data-step-kw "fx"
+    [:div {:data-testid "rf-xray-epoch-step-side-effects"
+           :data-step-kw "side-effects"
            :data-fx-threw (str k)}
-     (numbered-circle step-number :FX)
+     (numbered-circle step-number :SIDE-EFFECTS)
      (step-header
-       {:step :fx
-        :badge :FX
+       {:step :side-effects
+        :badge :SIDE-EFFECTS
         :verb [:span {:style fx-verb-style}
-               [:span {:data-testid "rf-xray-epoch-fx-caption"
+               [:span {:data-testid "rf-xray-epoch-side-effects-caption"
                        :style fx-caption-style}
-                "(side effects)"]
+                "(post-commit)"]
                (when (pos? k)
                  [:span {:style fx-threw-style}
                   (str k " threw")])]
         :expandable? false
-        :testid "rf-xray-epoch-fx"
+        :testid "rf-xray-epoch-side-effects"
         :status (proj/step-status step)}
        nil)
-     [:div {:style margin-top-5-style}
-      (map-indexed fx-row-with-violations rows)]
+     (for [kind sub-kinds]
+       ^{:key (name kind)}
+       [render-side-effects-sub-step step kind])
      ;; rf2-ahhgn — fx exceptions that didn't match a row (no-such-fx,
      ;; or an fx-id absent from `:rows`) attach to the step level.
-     (error-blocks :fx errors)
-     (violation-blocks :fx violations)]))
+     (error-blocks :side-effects errors)
+     (violation-blocks :side-effects violations)]))
 
 ;; ---- SUBSCRIPTIONS step --------------------------------------------------
 
@@ -4187,7 +4283,7 @@
     :coeffect          (render-coeffect-step step)
     :handler           (render-handler-step step)
     :flow              (render-flow-step step)
-    :fx                (render-fx-step step)
+    :side-effects      (render-side-effects-step step)
     :subscriptions     (render-subscriptions-step step)
     :views             (render-views-step step)
     ;; :schema-hot-reload case retired per rf2-7gf7v — the

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/badge_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/badge_cljs_test.cljc
@@ -28,11 +28,12 @@
   (testing "every badge label resolves to a non-blank string.
 
   Labels are uppercase keyword names by default (DISPATCH, COEFFECT,
-  HANDLER, ...). Labels that lead with `:` are EDN-key-style and
-  render through `badge-pill`'s mono-font, no-uppercase path
-  (post-rf2-xu5iv: `:FX` now renders as `\":fx\"` per commit
-  862288aca's badge-styling change). Both styles are valid; this
-  test just pins that every badge has a label."
+  HANDLER, SIDE EFFECTS, ...). Labels that lead with `:` are
+  EDN-key-style and render through `badge-pill`'s mono-font,
+  no-uppercase path. Both styles are valid; this test just pins that
+  every badge has a label. (rf2-kt6js: the pre-rf2-kt6js `:FX` badge —
+  which rendered as `\":fx\"` — became `:SIDE-EFFECTS` → `\"SIDE
+  EFFECTS\"`.)"
     (doseq [b proj/badge-set]
       (let [l (badge/label b)]
         (is (string? l)
@@ -49,7 +50,7 @@
   (testing "known badges resolve to specific token keys"
     (is (= :accent (badge/token-key :HANDLER)))
     (is (= :accent (badge/token-key :FLOW)))
-    (is (= :orange (badge/token-key :FX)))
+    (is (= :orange (badge/token-key :SIDE-EFFECTS)))
     (is (= :success (badge/token-key :VIEWS)))))
 
 (deftest coeffect-and-subscriptions-pull-distinct-tokens-test

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -1195,84 +1195,174 @@
       (is (= 4 (:derived (:db-post-flow f)))
           "post-flow :derived = the flow's recomputed value"))))
 
-;; ---- FX -----------------------------------------------------------------
+;; ---- SIDE EFFECTS step (rf2-kt6js) --------------------------------------
+;;
+;; The pre-rf2-kt6js single `:fx` step (`proj/fx-step`) became the SIDE
+;; EFFECTS step (`proj/side-effects-step`) with three optional sub-steps —
+;; `:db` / `:fx` / other — each reusing the shared rf2-ahhgn `:status`
+;; primitive for its per-effect tick. See the projection ns's SIDE EFFECTS
+;; settle-first note for what's recorded vs derived.
 
-(deftest fx-step-conditional-test
-  (testing "no fx events → step is OMITTED"
-    (is (nil? (proj/fx-step []))))
+(defn- sub-rows
+  "Pull the SIDE EFFECTS sub-step rows of `kind` (`:db / :fx / :other`)
+  off a projected `side-effects-step`. Empty vec when the sub-step is
+  absent."
+  [step kind]
+  (proj/sub-rows-of step kind))
 
-  (testing "fx-handled events → step rendered with status"
-    (let [s (proj/fx-step [(fx-handled-ev :db nil 0.2)
-                           (fx-handled-ev :http/post {:url "/x"} 12.0)])]
-      (is (= :fx (:step s)))
-      (is (= :FX (:badge s)))
-      (is (= 2 (count (:rows s))))
-      (is (= :ok (-> s :rows first :status))))))
+(defn- has-sub?
+  "True iff the projected `side-effects-step` carries a `kind` sub-step."
+  [step kind]
+  (boolean (some #{kind} (:sub-kinds step))))
 
-(deftest fx-rows-reads-canonical-elapsed-ms-test
-  (testing "rf2-ipaza — substrate stamps the per-fx-handler invocation
-            duration as `:rf.fx/elapsed-ms` on `:rf.fx/handled`
-            (rf2-hhh92 · `re-frame.fx`; spec 009 §241). The pre-rf2-ipaza
-            reader looked for the never-emitted `:duration-ms` — every
-            FX row showed nil duration."
-    (let [ev {:op-type   :rf.fx
-              :operation :rf.fx/handled
-              :tags      {:rf.fx/id         :http/post
-                          :rf.fx/args       {:url "/x"}
-                          :rf.fx/elapsed-ms 3.4}}
-          s (proj/fx-step [ev])]
-      (is (= 3.4 (-> s :rows first :duration-ms))
-          "FX row duration resolves through canonical :rf.fx/elapsed-ms")))
+(defn- sub-status
+  "The per-effect status rollup for the `kind` sub-step of a projected
+  `side-effects-step`."
+  [step kind]
+  (proj/sub-step-status (sub-rows step kind)))
 
-  (testing "rf2-ipaza — fixture-compat: a runtime that still stamps
-            `:duration-ms` falls through the preserved fallback"
-    (let [ev {:op-type   :rf.fx
-              :operation :rf.fx/handled
-              :tags      {:rf.fx/id    :http/get
-                          :duration-ms 7.7}}
-          s (proj/fx-step [ev])]
-      (is (= 7.7 (-> s :rows first :duration-ms))
+(deftest side-effects-step-conditional-test
+  (testing "no side effect at all → step is OMITTED"
+    (is (nil? (proj/side-effects-step []))))
+
+  (testing ":fx-vector entries → step rendered as SIDE EFFECTS with a
+            :fx sub-step"
+    (let [s (proj/side-effects-step
+              [(fx-handled-ev :http/post {:url "/x"} 12.0)
+               (fx-handled-ev :navigate {:to :home} 0.4)])]
+      (is (= :side-effects (:step s)))
+      (is (= :SIDE-EFFECTS (:badge s)))
+      (is (not (has-sub? s :db)) "no :db commit → no :db sub-step")
+      (is (has-sub? s :fx) ":fx sub-step present")
+      (is (= 2 (count (sub-rows s :fx))))
+      (is (= :ok (sub-status s :fx)) "all fx ran → sub-step :ok")
+      (is (= :ok (-> (sub-rows s :fx) first :status))))))
+
+;; ---- :db sub-step — pass / schema-fail (rf2-kt6js) ----------------------
+
+(deftest side-effects-db-sub-step-pass-test
+  (testing "rf2-kt6js — a bare reg-event-db (only :db, NO :fx) STILL
+            shows the SIDE EFFECTS step with a passing :db sub-step.
+            The :db commit is keyed off `:rf.event/db-changed` — the
+            ALWAYS-APPEARS contract. Pre-rf2-kt6js this showed nothing."
+    (let [s (proj/side-effects-step [(db-changed-ev [[[:counter] 0 1 :edit]])])]
+      (is (= :side-effects (:step s)) "SIDE EFFECTS step present on a bare :db")
+      (is (has-sub? s :db) ":db sub-step present")
+      (is (= 1 (count (sub-rows s :db))))
+      (is (= :db (-> (sub-rows s :db) first :fx-id)))
+      (is (= :ok (-> (sub-rows s :db) first :status)) ":db committed → ✓")
+      (is (= :ok (sub-status s :db)) ":db sub-step :ok")
+      (is (not (has-sub? s :fx)) "no :fx → no :fx sub-step"))))
+
+(deftest side-effects-db-sub-step-schema-fail-test
+  (testing "rf2-kt6js — a post-commit app-db schema failure that rolled
+            the cascade back paints the :db sub-step ✗ (:status :error)
+            so `step-status` reads :error and the :where :app-db reason
+            box attaches to the :db row"
+    (let [s (proj/side-effects-step
+              [(db-changed-ev [])
+               (schema-violation-ev :app-db :counter/inc [:counter] -3 true)])]
+      (is (has-sub? s :db) ":db sub-step present on a rolled-back commit")
+      (is (= :error (-> (sub-rows s :db) first :status)) ":db row ✗ on schema-fail")
+      (is (= :error (sub-status s :db)) ":db sub-step :error"))))
+
+;; ---- :fx sub-step — per-effect tick (rf2-kt6js) -------------------------
+
+(deftest side-effects-fx-sub-step-per-effect-tick-test
+  (testing "rf2-kt6js — each :fx entry carries a per-effect tick:
+            ✓ ran / ✗ threw / ↺ overridden / · skipped-on-platform.
+            Per-fx success is ALREADY RECORDED on the trace stream."
+    (let [s  (proj/side-effects-step
+               [(fx-handled-ev :http/post {} 1.0)
+                (ev :rf.fx :rf.fx/override-applied {:rf.fx/id :metrics})
+                (ev :warning :rf.fx/skipped-on-platform {:rf.fx/id :clipboard})
+                (ev :error :rf.error/fx-handler-exception {:rf.fx/id :bad-fx})])
+          rows (sub-rows s :fx)
+          by   (into {} (map (juxt :fx-id :status) rows))]
+      (is (= 4 (count rows)))
+      (is (= :ok         (:http/post by)) ":rf.fx/handled → :ok")
+      (is (= :overridden (:metrics   by)) ":rf.fx/override-applied → :overridden")
+      (is (= :skipped    (:clipboard by)) ":rf.fx/skipped-on-platform → :skipped")
+      (is (= :error      (:bad-fx    by)) "fx-handler-exception → :error")
+      (is (= :error (sub-status s :fx)) "any ✗ fx → sub-step :error")
+      (is (= 1 (:threw s)) "threw count = the one fx that threw"))))
+
+(deftest side-effects-fx-reads-canonical-elapsed-ms-test
+  (testing "rf2-ipaza — :fx row duration resolves through the canonical
+            `:rf.fx/elapsed-ms`; legacy `:duration-ms` is a fallback"
+    (let [s (proj/side-effects-step
+              [{:op-type :rf.fx :operation :rf.fx/handled
+                :tags {:rf.fx/id :http/post :rf.fx/elapsed-ms 3.4}}])]
+      (is (= 3.4 (-> (sub-rows s :fx) first :duration-ms))))
+    (let [s (proj/side-effects-step
+              [{:op-type :rf.fx :operation :rf.fx/handled
+                :tags {:rf.fx/id :http/get :duration-ms 7.7}}])]
+      (is (= 7.7 (-> (sub-rows s :fx) first :duration-ms))
           "legacy :duration-ms fallback retained for older fixtures"))))
 
-;; ---- rf2-uffov — FX section header split + per-action attribution -----
-
-(deftest fx-step-header-counter-split-test
-  (testing "rf2-uffov — FX step header carries split counts
-            (succeeded / threw / skipped)"
-    (let [s (proj/fx-step
-              [(fx-handled-ev :db nil 0.1)
-               (fx-handled-ev :http/post {} 1.0)
-               (ev :error :rf.error/fx-handler-exception
-                   {:rf.fx/id :bad-fx})])]
-      (is (= 2 (:succeeded s))
-          ":ok rows roll into :succeeded")
-      (is (= 1 (:threw s))
-          ":error rows roll into :threw"))))
-
-(deftest fx-step-attribution-from-machine-actions-test
+(deftest side-effects-fx-attribution-from-machine-actions-test
   (testing "rf2-uffov — when a machine action's outcome :fx emits a
-            fx-id, the corresponding FX row carries :attributed-to"
+            fx-id, the corresponding :fx sub-step row carries
+            :attributed-to"
     (let [evs [(ev :rf.machine :rf.machine/action-ran
                    {:action-id :open-socket
                     :phase     :entry
                     :outcome   {:fx [[:http/get {:url "/x"}]]}
                     :input     {:data {} :event nil}})
                (fx-handled-ev :http/get {:url "/x"} 5.0)]
-          s   (proj/fx-step evs)
-          row (-> s :rows first)]
+          row (-> (proj/side-effects-step evs) (sub-rows :fx) first)]
       (is (= :http/get (:fx-id row)))
-      (is (some? (:attributed-to row))
-          "FX row carries :attributed-to for machine-emitted fx")
       (is (= :open-socket (-> row :attributed-to :action-id)))
-      (is (= :entry       (-> row :attributed-to :phase))))))
+      (is (= :entry       (-> row :attributed-to :phase)))))
 
-(deftest fx-step-no-attribution-for-non-machine-cascades-test
   (testing "rf2-uffov — pure reg-event-fx cascades have no per-action
             attribution; the slot stays absent"
-    (let [s (proj/fx-step [(fx-handled-ev :db nil 0.1)])
-          row (-> s :rows first)]
-      (is (not (contains? row :attributed-to))
-          "no machine actions → no :attributed-to slot"))))
+    (let [row (-> (proj/side-effects-step [(fx-handled-ev :http/post {} 0.1)])
+                  (sub-rows :fx) first)]
+      (is (not (contains? row :attributed-to))))))
+
+;; ---- other sub-step — dropped top-level effects (rf2-kt6js) -------------
+
+(deftest side-effects-other-sub-step-test
+  (testing "rf2-kt6js — a top-level effect key beyond :db/:fx on the
+            handler's returned map is surfaced in the `other` sub-step
+            as a :skipped (not-run) DIAGNOSTIC. re-frame2's effect map
+            is the closed {:db :fx} shape — `run-fx-effects!` reads only
+            :fx — so any other key is DROPPED (never executed/traced).
+            The `other` sub-step flags the dropped effect rather than
+            leaving the operator to wonder why nothing fired."
+    (let [;; `:rf.event/fx` is stamped as the FULL effects map on the
+          ;; do-fx marker only in the legacy/defensive shape; `effects-
+          ;; decomp` reads the map form and projects MINUS :db/:fx.
+          s     (proj/side-effects-step
+                  [(do-fx-ev {:db {:n 1}
+                              :fx [[:http/post {}]]
+                              :legacy/persist {:to :disk}})
+                   (db-changed-ev [])
+                   (fx-handled-ev :http/post {} 1.0)])
+          rows  (sub-rows s :other)]
+      (is (has-sub? s :other) "other sub-step present when a non-:db/:fx key exists")
+      (is (= 1 (count rows)))
+      (is (= :legacy/persist (-> rows first :fx-id)))
+      (is (= :skipped (-> rows first :status)) "dropped effect = :skipped")
+      (is (= {:to :disk} (-> rows first :value)))))
+
+  (testing "rf2-kt6js — the canonical {:db :fx} shape yields NO other
+            sub-step (the common case)"
+    (let [s (proj/side-effects-step
+              [(do-fx-ev {:db {:n 1} :fx [[:http/post {}]]})
+               (db-changed-ev [])
+               (fx-handled-ev :http/post {} 1.0)])]
+      (is (not (has-sub? s :other))
+          "closed {:db :fx} shape → no other sub-step"))))
+
+(deftest side-effects-sub-step-order-test
+  (testing "rf2-kt6js — sub-steps render in fixed order :db → :fx → other"
+    (let [s (proj/side-effects-step
+              [(do-fx-ev {:db {} :fx [[:http/post {}]] :legacy/x 1})
+               (db-changed-ev [])
+               (fx-handled-ev :http/post {} 1.0)])]
+      (is (= [:db :fx :other] (:sub-kinds s))))))
 
 ;; ---- SUBSCRIPTIONS ------------------------------------------------------
 
@@ -1577,18 +1667,35 @@
 ;; ---- top-level project --------------------------------------------------
 
 (deftest project-minimal-test
-  (testing "minimal epoch (dispatch + handler, no cofx/flow/fx/sub/view).
+  (testing "minimal epoch (dispatch + handler + a :db write, no
+            cofx/flow/user-fx/sub/view).
 
-  Post pair-debug 2026-05-26 (commit ee9def224 / 862288aca): the
-  standalone APP-DB DIFF step (rf2-rrykz) was retired — the HANDLER
-  step's `:db` sub-section with `[diff][all]` toggle surfaces the
-  same data in-context. The minimal cascade is now :dispatch +
-  :handler only."
+  rf2-kt6js — the SIDE EFFECTS step ALWAYS appears when a `:db` commit
+  happened, INCLUDING a bare reg-event-db with no `:fx` (`db-commit?`
+  keys off `:rf.event/db-changed`). Pre-rf2-kt6js a plain reg-event-db
+  surfaced NO side-effects step at all (the FX step keyed off a
+  non-existent fx-id-less `:rf.fx/handled`). The minimal :db-writing
+  cascade is now :dispatch + :handler + :side-effects (a :db sub-step
+  only)."
     (let [rec   (record [(dispatched-ev [:counter-inc] :ui nil)
                          (db-changed-ev [[[:counter] 5 6 :modified]])])
+          steps (proj/project rec)
+          se    (some #(when (= :side-effects (:step %)) %) steps)]
+      (is (= 3 (count steps)))
+      (is (= [:dispatch :handler :side-effects] (mapv :step steps)))
+      (is (some? se) "SIDE EFFECTS step present on a bare :db write")
+      (is (= [:db] (:sub-kinds se))
+          "only the :db sub-step — no :fx, no other"))))
+
+(deftest project-no-db-no-fx-omits-side-effects-test
+  (testing "rf2-kt6js — a cascade with NO :db commit and NO :fx (e.g. a
+            handler that returned nothing) omits the SIDE EFFECTS step
+            entirely — silence is correct when nothing happened"
+    (let [rec   (record [(dispatched-ev [:noop] :ui nil)
+                         (run-end-ev 0.3)])
           steps (proj/project rec)]
-      (is (= 2 (count steps)))
-      (is (= [:dispatch :handler] (mapv :step steps))))))
+      (is (not-any? #(= :side-effects (:step %)) steps)
+          "no side effect → no SIDE EFFECTS step"))))
 
 (deftest project-full-pipeline-test
   (testing "full epoch with every cascade step.
@@ -1610,20 +1717,24 @@
                          (view-render-ev ::cart-view [:total])])
           steps (proj/project rec)
           kws   (mapv :step steps)]
-      (is (= [:dispatch :coeffect :handler :flow :fx
+      (is (= [:dispatch :coeffect :handler :flow :side-effects
               :subscriptions :views]
-             kws))
+             kws)
+          "rf2-kt6js — the :fx step is now the :side-effects step")
       (is (= 7 (count steps))))))
 
 (deftest project-numbered-test
-  (testing "number-steps assigns sequential 1..N regardless of omissions"
+  (testing "number-steps assigns sequential 1..N regardless of omissions.
+            rf2-kt6js — the `:db` write surfaces the SIDE EFFECTS step
+            between HANDLER and SUBSCRIPTIONS."
     (let [rec   (record [(dispatched-ev [:counter-inc] :ui nil)
                          (db-changed-ev [])
                          (sub-run-ev [:total] true 1 2)])
           steps (proj/project-numbered rec)]
-      (is (= 3 (count steps)))
-      (is (= [1 2 3] (mapv :step-number steps)))
-      (is (= [:dispatch :handler :subscriptions] (mapv :step steps))))))
+      (is (= 4 (count steps)))
+      (is (= [1 2 3 4] (mapv :step-number steps)))
+      (is (= [:dispatch :handler :side-effects :subscriptions]
+             (mapv :step steps))))))
 
 (deftest project-machine-test
   (testing "machine event handler → reg-machine flavour + machine block"
@@ -1792,16 +1903,15 @@
           "matching cofx step attached"))))
 
 (deftest attach-violations-app-db-to-fx-db-row-test
-  (testing "rf2-8resu — `:app-db` violation attaches to the FX step's
-            `:db` row (the implicit commit fx). The commit IS an fx —
-            the framework treats `:db` as the first, implicit fx —
-            so the schema violation belongs on the row representing
-            the failed commit, not on HANDLER (which describes what
-            the handler RETURNED). HANDLER + DISPATCH stay clean."
+  (testing "rf2-8resu / rf2-kt6js — `:app-db` violation attaches to the
+            SIDE EFFECTS step's `:db` row (the handler's app-db write).
+            The schema violation belongs on the row representing the
+            failed commit, not on HANDLER (which describes what the
+            handler RETURNED). HANDLER + DISPATCH stay clean."
     (let [steps  [{:step :dispatch :badge :DISPATCH}
                   {:step :handler  :badge :HANDLER}
-                  {:step :fx       :badge :FX
-                   :rows [{:fx-id :db :status :rollback}]}]
+                  {:step :side-effects :badge :SIDE-EFFECTS
+                   :rows [{:fx-id :db :status :error}]}]
           rows   [{:where :app-db :failing-id :counter/inc :rollback? true}]
           out    (proj/attach-violations steps rows)
           fx     (nth out 2)]
@@ -1810,15 +1920,15 @@
       (is (nil? (:violations (nth out 1)))
           "HANDLER step untouched — the violation no longer attaches here")
       (is (nil? (:violations fx))
-          "FX step-level :violations untouched — the violation routes
-           into the :db row, not the step")
+          "SIDE EFFECTS step-level :violations untouched — the violation
+           routes into the :db row, not the step")
       (is (= 1 (count (:violations (first (:rows fx)))))
-          "FX :db row carries the attached violation"))))
+          "SIDE EFFECTS :db row carries the attached violation"))))
 
 (deftest attach-violations-fx-row-test
-  (testing "rf2-xgeag — `:fx-args` violation attaches to the FX row whose
-            `:fx-id` matches `:failing-id`"
-    (let [steps  [{:step :fx :badge :FX
+  (testing "rf2-xgeag / rf2-kt6js — `:fx-args` violation attaches to the
+            SIDE EFFECTS row whose `:fx-id` matches `:failing-id`"
+    (let [steps  [{:step :side-effects :badge :SIDE-EFFECTS
                    :rows [{:fx-id :http/post :status :ok}
                           {:fx-id :db        :status :ok}]}]
           rows   [{:where :fx-args :failing-id :http/post}]
@@ -1854,14 +1964,15 @@
                   [{:where :app-db :rollback? true}])))))
 
 (deftest mark-rolled-back-downstream-test
-  (testing "rf2-8resu — rollback flags every step AFTER the FX step
-            (not after HANDLER). The FX step itself is NOT muted —
-            its `:db` row IS the visible rollback indicator (red ✗ +
-            violation sub-block); muting the entire FX step would hide
-            the signal. DISPATCH + HANDLER are upstream of the failed
-            commit so they stay unmuted too — they ran for real."
+  (testing "rf2-8resu / rf2-kt6js — rollback flags every step AFTER the
+            SIDE EFFECTS step (not after HANDLER). The SIDE EFFECTS step
+            itself is NOT muted — its `:db` row IS the visible rollback
+            indicator (red ✗ + violation sub-block); muting the entire
+            step would hide the signal. DISPATCH + HANDLER are upstream
+            of the failed commit so they stay unmuted too — they ran for
+            real."
     (let [steps [{:step :dispatch} {:step :handler}
-                 {:step :fx}       {:step :subscriptions}
+                 {:step :side-effects} {:step :subscriptions}
                  {:step :views}]
           rows  [{:where :app-db :rollback? true}]
           out   (proj/mark-rolled-back-downstream steps rows)]
@@ -1870,14 +1981,14 @@
       (is (nil? (:rolled-back? (nth out 1)))
           "HANDLER untouched (described what it RETURNED; that ran)")
       (is (nil? (:rolled-back? (nth out 2)))
-          "FX step itself NOT muted — its :db row is the visible signal")
+          "SIDE EFFECTS step itself NOT muted — its :db row is the signal")
       (is (true? (:rolled-back? (nth out 3)))
-          "SUBSCRIPTIONS downstream of FX gets muted")
+          "SUBSCRIPTIONS downstream of SIDE EFFECTS gets muted")
       (is (true? (:rolled-back? (nth out 4)))
-          "VIEWS downstream of FX gets muted")))
+          "VIEWS downstream of SIDE EFFECTS gets muted")))
 
   (testing "rf2-xgeag — no rollback → no `:rolled-back?` flags"
-    (let [steps [{:step :dispatch} {:step :handler} {:step :fx}]
+    (let [steps [{:step :dispatch} {:step :handler} {:step :side-effects}]
           rows  [{:where :sub-return :rollback? true}]
           out   (proj/mark-rolled-back-downstream steps rows)]
       (is (every? #(nil? (:rolled-back? %)) out)))))
@@ -2022,37 +2133,40 @@
 ;; helpers section.
 
 (deftest project-attaches-app-db-violation-to-fx-db-row-test
-  (testing "rf2-8resu — top-level `project` attaches `:app-db`
-            boundary violations to the FX step's `:db` row (the
-            implicit-commit fx). The FX step is synthesised even when
-            no user-fx fired — the `:where :app-db` violation alone
-            is sufficient signal that a `:db` commit was attempted
-            (the framework suppresses user-fx on rollback per Spec
-            010, so the `:rf.fx/handled` trace doesn't emit; the
-            violation IS the signal). The FX step contains exactly
-            one row — the synthesised `:db` row, `:status :rollback`,
-            carrying the violation. HANDLER stays clean — it
-            describes what the handler RETURNED; the commit outcome
-            is the FX step's `:db` row's concern."
+  (testing "rf2-8resu / rf2-kt6js — top-level `project` attaches
+            `:app-db` boundary violations to the SIDE EFFECTS step's
+            `:db` row (the handler's app-db write). The step is
+            synthesised when a `:db` commit was attempted (here both a
+            `:rf.event/db-changed` AND a `:where :app-db` rollback fire).
+            The `:db` sub-step's row carries `:status :error` (✗ on the
+            schema-fail rollback) + the attached violation. HANDLER stays
+            clean — it describes what the handler RETURNED; the commit
+            outcome is the SIDE EFFECTS `:db` row's concern."
     (let [rec     (record [(dispatched-ev [:counter/inc] :ui nil)
                            (db-changed-ev [[[:count] 0 "boom" :modified]])
                            (schema-violation-ev :app-db :counter/inc
                                                 [:count] "boom" true)])
           steps   (proj/project rec)
           handler (some #(when (= :handler (:step %)) %) steps)
-          fx      (some #(when (= :fx (:step %)) %) steps)
-          db-row  (some #(when (= :db (:fx-id %)) %) (:rows fx))]
+          se      (some #(when (= :side-effects (:step %)) %) steps)
+          db-rows (proj/sub-rows-of se :db)
+          db-row  (first db-rows)]
       (is (some? handler))
       (is (nil? (:violations handler))
-          "HANDLER step carries no violations — routing moved to FX :db row")
-      (is (some? fx)
-          "FX step is synthesised when a :where :app-db rollback fires
-           even with no user-emitted fx")
+          "HANDLER step carries no violations — routing moved to the :db row")
+      (is (some? se)
+          "SIDE EFFECTS step is synthesised when a :where :app-db rollback
+           fires even with no user-emitted fx")
+      (is (some? (some #{:db} (:sub-kinds se))) ":db sub-step present")
+      (is (= :error (proj/sub-step-status db-rows))
+          ":db sub-step :error on rollback — the attached violation lifts it")
       (is (some? db-row)
-          "the FX step's first row is the synthesised :db row")
-      (is (= :rollback (:status db-row))
-          "the :db row's status reflects the rollback")
-      (is (= 1 (count (:violations db-row))))
+          "the SIDE EFFECTS step's :db sub-step carries the :db row")
+      (is (= :error (:status db-row))
+          "the :db row's status reflects the schema-fail rollback")
+      (is (= 1 (count (:violations db-row)))
+          "the :app-db violation attached to the :db row flows through to the
+           rendered sub-step (single-source-of-truth :rows slot)")
       (is (true? (-> db-row :violations first :rollback?)))
       (is (not-any? #(= :schema-violations (:step %)) steps)
           "the retired aggregate SCHEMA-VIOLATIONS step never appears")
@@ -2140,7 +2254,7 @@
             HANDLER step's `:errors` + stamps `:status :error`"
     (let [steps [{:step :dispatch :badge :DISPATCH}
                  {:step :handler  :badge :HANDLER}
-                 {:step :fx       :badge :FX :rows []}]
+                 {:step :side-effects :badge :SIDE-EFFECTS :rows []}]
           rows  [(proj/exception-row
                    (handler-exception-ev :e "boom" {:file "a.cljs" :line 1}))]
           out   (proj/attach-exceptions steps rows)
@@ -2151,9 +2265,10 @@
       (is (nil? (:status (nth out 0))) "DISPATCH not flagged"))))
 
 (deftest attach-exceptions-fx-row-test
-  (testing "rf2-ahhgn — a `:rf.error/fx-handler-exception` attaches to the
-            FX step's matching `:fx-id` row + stamps the step `:status :error`"
-    (let [steps [{:step :fx :badge :FX
+  (testing "rf2-ahhgn / rf2-kt6js — a `:rf.error/fx-handler-exception`
+            attaches to the SIDE EFFECTS step's matching `:fx-id` row +
+            stamps the step `:status :error`"
+    (let [steps [{:step :side-effects :badge :SIDE-EFFECTS
                   :rows [{:fx-id :db :status :ok}
                          {:fx-id :http/post :status :error}]}]
           rows  [(proj/exception-row
@@ -2166,8 +2281,8 @@
           "http/post row carries the exception")))
 
   (testing "rf2-ahhgn — an fx exception with no matching row falls back to
-            the FX step-level `:errors`"
-    (let [steps [{:step :fx :badge :FX :rows [{:fx-id :db}]}]
+            the SIDE EFFECTS step-level `:errors`"
+    (let [steps [{:step :side-effects :badge :SIDE-EFFECTS :rows [{:fx-id :db}]}]
           rows  [(proj/exception-row
                    (fx-handler-exception-ev :unknown/fx "boom" nil))]
           out   (proj/attach-exceptions steps rows)]
@@ -2184,11 +2299,11 @@
     (is (= :error (proj/step-status {:step :handler :status :error})))
     (is (= :error (proj/step-status {:step :handler :errors [{:message "x"}]})))
     (is (= :error (proj/step-status {:step :handler :violations [{:where :app-db}]})))
-    (is (= :error (proj/step-status {:step :fx :rows [{:fx-id :db :errors [{}]}]}))
+    (is (= :error (proj/step-status {:step :side-effects :rows [{:fx-id :db :errors [{}]}]}))
         "row-level :errors lift the step to :error")
-    (is (= :error (proj/step-status {:step :fx :rows [{:fx-id :db :violations [{}]}]}))
+    (is (= :error (proj/step-status {:step :side-effects :rows [{:fx-id :db :violations [{}]}]}))
         "row-level :violations lift the step to :error")
-    (is (= :ok (proj/step-status {:step :fx :rows [{:fx-id :db}]}))
+    (is (= :ok (proj/step-status {:step :side-effects :rows [{:fx-id :db}]}))
         "clean rows keep :ok")))
 
 (deftest epoch-outcome-test

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -889,61 +889,72 @@
 ;; `project-attaches-app-db-violation-to-fx-db-row-test` pins down
 ;; that no tail step is appended.
 
-;; ---- rf2-uffov — FX section header + per-action attribution ----------
+;; ---- rf2-kt6js — SIDE EFFECTS step (:db / :fx / other sub-steps) ------
+;; rf2-uffov — per-action attribution + the threw-count header chip;
+;; rf2-g1mfc — per-:fx-row open-code chip; rf2-kt6js — the :fx step
+;; became the SIDE EFFECTS step.
 
-(deftest fx-step-header-shows-outcome-split-test
-  (testing "rf2-uffov — FX step header surfaces the threw-count when
-            non-zero, beside the subdued `(side effects)` caption.
+(defn- side-effects-step
+  "Build a projected SIDE EFFECTS step for the view tests (rf2-kt6js) —
+  the step the `render-side-effects-step` renderer consumes. `subs` is
+  a vec of `{:kind :rows}` groups in render order; this flattens them
+  into the single tagged `:rows` slot + the `:sub-kinds` order vec the
+  renderer reads (mirrors `projection/side-effects-step`'s output
+  shape — one row vector, each row tagged `:sub-kind`)."
+  ([subs] (side-effects-step subs 0))
+  ([subs threw]
+   {:step :side-effects :badge :SIDE-EFFECTS :step-number 4
+    :sub-kinds (mapv :kind subs)
+    :rows (vec (mapcat (fn [{:keys [kind rows]}]
+                         (mapv #(assoc % :sub-kind kind) rows))
+                       subs))
+    :threw threw}))
 
-            Post pair-debug 2026-05-26 (commits 862288aca / adaabb8aa):
-            the prior `N fired (M succeeded, K threw)` verb was
-            dropped — the per-row ✓/✗ glyphs already convey per-fx
-            outcome; the count summary was noise. The header now
-            renders a subdued `(side effects)` caption beside the
-            badge, with a red `K threw` chip only when fx errored.
-            `N fired` + `M succeeded` are no longer surfaced in the
-            header."
-    (let [step {:step :fx :badge :FX :step-number 4
-                :rows [{:fx-id :db :status :ok}
-                       {:fx-id :http/get :status :ok}
-                       {:fx-id :bad :status :error}]
-                :succeeded 2 :threw 1 :skipped 0}
-          tree (view/render-fx-step step)
-          header (text-of tree "rf-xray-epoch-fx-header")]
-      (is (string/includes? header "(side effects)")
+(deftest side-effects-step-header-shows-outcome-split-test
+  (testing "rf2-kt6js / rf2-uffov — SIDE EFFECTS step header surfaces the
+            threw-count when non-zero, beside the subdued `(post-commit)`
+            caption. The per-row ✓/✗ glyphs convey per-effect outcome;
+            the header carries only the at-a-glance error chip."
+    (let [step (side-effects-step
+                 [{:kind :db :status :ok :rows [{:fx-id :db :status :ok}]}
+                  {:kind :fx :status :error
+                   :rows [{:fx-id :http/get :status :ok}
+                          {:fx-id :bad :status :error}]}]
+                 1)
+          tree (view/render-side-effects-step step)
+          header (text-of tree "rf-xray-epoch-side-effects-header")]
+      (is (string/includes? header "(post-commit)")
           "the subdued caption rides beside the badge")
       (is (string/includes? header "1 threw")
           "threw-count chip surfaces in the header when non-zero"))))
 
-(deftest fx-row-shows-attribution-chip-test
-  (testing "rf2-uffov — when an FX row carries :attributed-to, the
-            attribution chip renders alongside"
-    (let [step {:step :fx :badge :FX :step-number 4
-                :rows [{:fx-id :http/get :status :ok
-                        :attributed-to {:action-id :open-socket
-                                        :phase :entry}}]
-                :succeeded 1 :threw 0 :skipped 0}
-          tree (view/render-fx-step step)
+(deftest side-effects-fx-row-shows-attribution-chip-test
+  (testing "rf2-uffov — when an :fx sub-step row carries :attributed-to,
+            the attribution chip renders alongside"
+    (let [step (side-effects-step
+                 [{:kind :fx :status :ok
+                   :rows [{:fx-id :http/get :status :ok
+                           :attributed-to {:action-id :open-socket
+                                           :phase :entry}}]}])
+          tree (view/render-side-effects-step step)
           chip (th/find-by-testid tree "rf-xray-epoch-fx-row-attribution-0")]
       (is (some? chip) "the attribution chip is present")
       (is (string/includes? (th/text-content chip) ":open-socket")
           "the action-id rides the chip"))))
 
-(deftest fx-row-omits-attribution-chip-when-none-test
-  (testing "rf2-uffov — FX row without :attributed-to omits the chip"
-    (let [step {:step :fx :badge :FX :step-number 4
-                :rows [{:fx-id :db :status :ok}]
-                :succeeded 1 :threw 0 :skipped 0}
-          tree (view/render-fx-step step)]
+(deftest side-effects-fx-row-omits-attribution-chip-when-none-test
+  (testing "rf2-uffov — :fx sub-step row without :attributed-to omits
+            the chip"
+    (let [step (side-effects-step
+                 [{:kind :db :status :ok :rows [{:fx-id :db :status :ok}]}])
+          tree (view/render-side-effects-step step)]
       (is (nil? (th/find-by-testid tree "rf-xray-epoch-fx-row-attribution-0"))))))
 
-(deftest fx-row-mounts-coord-chip-when-meta-resolves-test
-  (testing "rf2-g1mfc — each FX-step row routes its fx-id through
+(deftest side-effects-fx-row-mounts-coord-chip-when-meta-resolves-test
+  (testing "rf2-g1mfc — each :fx sub-step row routes its fx-id through
             `coord-chip/coord-chip` to surface a click-to-source
             affordance for the `reg-fx` registration (parity with the
-            SUBSCRIPTIONS / VIEWS rows + the HANDLER verb). Pre-fix the
-            fx row rendered the fx-id with NO open-code affordance at
-            all — the affordance was inconsistent across pipeline steps.
+            SUBSCRIPTIONS / VIEWS rows + the HANDLER verb).
 
             The chip's <button> mounts when `(rf/handler-meta :fx
             fx-id)` resolves a `:file` coord. CLJS macro-form `reg-fx`
@@ -957,10 +968,10 @@
         (fn [_ctx _args] nil))
       (let [meta-resolved? (boolean (some-> (rf/handler-meta :fx :rf.g1mfc-fixture/ping)
                                             :file string?))
-            step {:step :fx :badge :FX :step-number 4
-                  :rows [{:fx-id :rf.g1mfc-fixture/ping :status :ok}]
-                  :succeeded 1 :threw 0 :skipped 0}
-            tree (view/render-fx-step step)]
+            step (side-effects-step
+                   [{:kind :fx :status :ok
+                     :rows [{:fx-id :rf.g1mfc-fixture/ping :status :ok}]}])
+            tree (view/render-side-effects-step step)]
         (is (some? (th/find-by-testid tree "rf-xray-epoch-fx-row-0"))
             "the fx row itself renders")
         ;; If the test harness captured a source coord the chip mounts;
@@ -1469,22 +1480,21 @@
       (is (string/includes? (th/text-content oth-sec) "1 entry")
           "the other sub-header carries the singular entry chip"))))
 
-(deftest fx-step-args-route-through-edn-inspector-test
-  (testing "rf2-ef2hy — FX step row's args render through the
-            edn-inspector widget with `:default-expanded-depth 1`,
-            replacing the prior rf2-8w8er mini rendering. Top-level
-            map keys (`:strategy`, `:from`, `:to`) are visible inline;
-            nested maps collapse to a clickable chevron so the
-            operator can drill into a complex args map.
+(deftest side-effects-fx-args-route-through-edn-inspector-test
+  (testing "rf2-ef2hy — :fx sub-step row's args render through the
+            edn-inspector widget with `:default-expanded-depth 1`. Top-
+            level map keys are visible inline; nested maps collapse to a
+            clickable chevron so the operator can drill into a complex
+            args map.
 
             Sibling rendering for the HANDLER step's `:fx` section
             (rf2-p2zy0) uses the same widget with depth 16 (full-
             expand). Both share the widget; per-call-site depth
             reflects each section's role."
-    (let [tree (view/render-fx-step
-                 {:step :fx :badge :FX :step-number 4
-                  :rows [{:fx-id :http/get :status :ok :args {:url "/x"}}]
-                  :succeeded 1 :threw 0 :skipped 0})
+    (let [tree (view/render-side-effects-step
+                 (side-effects-step
+                   [{:kind :fx :status :ok
+                     :rows [{:fx-id :http/get :status :ok :args {:url "/x"}}]}]))
           row  (th/find-by-testid tree "rf-xray-epoch-fx-row-0")]
       (is (some? row))
       (is (pos? (count (ei-mounts row)))
@@ -2370,19 +2380,24 @@
       (is (nil? (th/find-by-testid tree "rf-xray-epoch-errors-handler"))
           "a clean step renders no error block"))))
 
-(deftest fx-step-renders-per-row-exception-test
-  (testing "rf2-ahhgn — a throwing fx (button-18) surfaces its message on
-            its own FX row via `fx-row-with-violations`"
-    (let [step {:step :fx :badge :FX :step-number 4 :threw 1
-                :rows [{:fx-id :db :status :ok}
-                       {:fx-id :button-deck/ping :status :error
-                        :errors [{:operation :rf.error/fx-handler-exception
-                                  :message "fx threw on purpose"
-                                  :failing-id :button-deck/ping
-                                  :recovery :no-recovery}]}]}
-          tree (view/render-fx-step step)]
+(deftest side-effects-renders-per-row-exception-test
+  (testing "rf2-ahhgn / rf2-kt6js — a throwing fx (button-18) surfaces
+            its message on its own :fx sub-step row via
+            `fx-row-with-violations`. The per-row testids use the GLOBAL
+            flat-row index, so the :fx row after the :db row lands at
+            index 1."
+    (let [step (side-effects-step
+                 [{:kind :db :rows [{:fx-id :db :status :ok}]}
+                  {:kind :fx
+                   :rows [{:fx-id :button-deck/ping :status :error
+                           :errors [{:operation :rf.error/fx-handler-exception
+                                     :message "fx threw on purpose"
+                                     :failing-id :button-deck/ping
+                                     :recovery :no-recovery}]}]}]
+                 1)
+          tree (view/render-side-effects-step step)]
       (is (some? (th/find-by-testid tree "rf-xray-epoch-error-fx-row-1-0"))
-          "the throwing fx row carries its inline error card")
+          "the throwing fx row (global index 1) carries its inline error card")
       (is (string/includes?
             (text-of tree "rf-xray-epoch-error-fx-row-1-0-message")
             "fx threw on purpose")))))

--- a/tools/xray/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/xray/testbeds/feature_matrix/scenarios.cjs
@@ -1198,14 +1198,15 @@ async function runHttpToggle(page) {
   // in this epoch" surface. Per rf2-639lc the panel default-focuses
   // the head (most-recent) cascade on mount — opening the tab after
   // the last `:go` dispatch surfaces its full numbered cascade.
-  // Assert the rendered panel carries an FX step (the `:rf.fx/handled`
-  // emits for the dispatched `:go` event are projected into the FX
-  // step of the cascade).
+  // Assert the rendered panel carries the SIDE EFFECTS step (rf2-kt6js;
+  // the `:rf.fx/handled` emits for the dispatched `:go` event are
+  // projected into the step's `:fx` sub-step). The step header reads
+  // "SIDE EFFECTS" and the `:fx` sub-header reads ":fx".
   await clickTab(page, 'epoch', 'rf-xray-epoch-panel');
   await expectVisible(page.locator('[data-testid="rf-xray-epoch-panel"]'), 5000);
   const epochText = ((await page.locator('[data-testid="rf-xray-epoch-panel"]').textContent()) || '').toLowerCase();
   if (!epochText.includes('fx') && !epochText.includes('effects')) {
-    failWithDetails('Epoch panel did not surface the FX step', {
+    failWithDetails('Epoch panel did not surface the SIDE EFFECTS step', {
       epochText: epochText.slice(0, 800),
     });
   }


### PR DESCRIPTION
Replaces the Epoch panel''s single `:fx` step with a **SIDE EFFECTS** step composed of up to three OPTIONAL sub-steps in fixed order `:db → :fx → other`, each reusing the shared rf2-ahhgn per-step `:status` (`:ok`/`:error`) primitive + `badge/step-status-*` resolver for its per-effect tick.

- **`:db`** — handler app-db write; `✓` on commit, `✗` on a post-commit app-db schema-fail rollback (the `:where :app-db` reason box attaches to the `:db` row). **ALWAYS appears when a `:db` commit happened — including a bare reg-event-db with no `:fx`.**
- **`:fx`** — the handler''s `:fx`-vector entries; each carries the rf2-g1mfc open-code chip + a per-effect tick (`✓` ran / `✗` threw / `↺` overridden / `·` skipped-on-platform). Async/deferred fx `✓` = ACTIONED, not awaited.
- **other** — top-level non-`:db`/`:fx` effect keys, rendered `·` not-run DIAGNOSTIC (see settle-first).

**ALWAYS-APPEARS fix:** the pre-rf2-kt6js `:fx` step keyed the implicit `:db` row off a fx-id-less `:rf.fx/handled` that the substrate NEVER emits (`emit-handled!` always stamps `:rf.fx/id`; `commit-db-effect!` routes `:db` through `:rf.event/db-changed`, not the fx pipeline). So a clean reg-event-db surfaced no side-effects step at all. `db-commit?` now keys off `:rf.event/db-changed`.

**Single-source-of-truth row shape:** one flat `:rows` slot (each row tagged `:sub-kind`) + `:sub-kinds` order vec; the view groups via `sub-rows-of` and rolls status via `sub-step-status`. This lets the rf2-ahhgn/rf2-xgeag attachment machinery (`attach-to-fx-db-row` / `attach-to-fx-row` / `attach-to-fx-error-row`), which mutates `:rows`, flow through to the rendered sub-step unchanged.

Reconciles with rf2-4wywy: the `:db` sub-step is the HANDLER db write; the FLOW `:db` diff stays a separate step.

**Surface lane:** `panels/epoch/{view.cljs,projection.cljc,badge.cljc}` + `tools/xray/spec/021` (badge taxonomy `:FX`→`:SIDE-EFFECTS`; new §9.1.10.6 SIDE EFFECTS step; attachment + rollback-mute sections) + tests + the feature-matrix scenario. No `tools/story` touch (disjoint from PR #2532 / qk0h9).

## Settle-first finding

This is a PRESENTATION over already-recorded data — **TOOL-SIDE only, NO (A) framework-instrumentation change, no core / spec-009 edit**. Confirmed against the live substrate on a fresh build:

- **Per-`:fx` success is ALREADY RECORDED:** every `:fx`-vector entry emits one of `:rf.fx/handled` / `:rf.fx/override-applied` / `:rf.fx/skipped-on-platform` / `:rf.error/fx-handler-exception` / `:rf.error/no-such-fx` (`handle-one-fx`).
- **The `:db` commit + schema-fail are recorded** by `:rf.event/db-changed` (+ a second `:rf.trace/phase :rollback`) + `:rf.error/schema-validation-failure :where :app-db`.
- **"Other" top-level effects DO NOT EXIST in re-frame2:** the effect map is the closed `{:db :fx}` shape (spec/002 — "the v1 `:dispatch-n` top-level key is gone"); `run-fx-effects!` reads ONLY `:fx`; `:rf.event/fx` on `:rf.fx/do-fx` is the `:fx` VECTOR. The runtime silently drops any other top-level key — so the `other` sub-step is a diagnostic for the legacy/defensive map-shaped return (surfaced from `effects-decomp`''s `:other-effects`, marked `:skipped`/not-run). Nothing records them because the runtime never touches them.

**(A) framework-instrumentation half: NOT NEEDED.** No hot-zone touch. No stop-valve required.

## Quality gates

- `npm run test:cljs` — **5077 tests, 0 failures, 0 errors, 0 warnings** (new tests: `:db`-pass, `:db`-schema-fail, per-`:fx` tick, `other` sub-step, sub-step order, always-appears-on-bare-`:db`, omit-when-no-effect, attachment-flows-through-to-rendered-`:db`-row)
- `npm run test:xray-feature-gate` — **14 scenarios, 0 failures, 13 matrix rows**
- `npm run test:bundle-isolation` — **PASS**
- clj-kondo — **0 new warnings** (15 pre-existing baseline)
- No core/spec-009 touched (B-only) — no JVM-core gate required