### PR TITLE
fix(examples): test:examples picks a non-colliding port + pre-flights with a clear message (rf2-0u6ce)

### DIFF
--- a/docs/scripts/generate-tutorial-screenshots.cjs
+++ b/docs/scripts/generate-tutorial-screenshots.cjs
@@ -8,7 +8,9 @@
  *
  * Pipeline:
  *   1. The orchestrator at examples/scripts/serve-and-run-examples-tests.cjs
- *      builds + serves every example bundle on http://127.0.0.1:8030.
+ *      builds + serves every example bundle on http://127.0.0.1:8040
+ *      (its default port; override with EXAMPLES_PORT, and point this
+ *      script at the same port via SCREENSHOT_BASE_URL).
  *      We assume the same orchestrator has already been run (or we invoke
  *      `npm run test:examples -- --serve-only` in a future iteration).
  *   2. For each declared scene, we navigate to the testbed URL, drive
@@ -32,7 +34,7 @@
  *
  * How to run (from repo root):
  *
- *   # one-time, builds the example bundles and serves them on :8030
+ *   # one-time, builds the example bundles and serves them on :8040
  *   cd implementation && npm run test:examples:serve-only &
  *
  *   # then, from repo root:
@@ -62,7 +64,7 @@ const ANNOTATION_SPEC = path.join(__dirname, 'tutorial-annotation-spec.json');
 
 const { chromium } = require(require.resolve('playwright', { paths: [IMPL_ROOT] }));
 
-const BASE_URL = process.env.SCREENSHOT_BASE_URL || 'http://127.0.0.1:8030';
+const BASE_URL = process.env.SCREENSHOT_BASE_URL || 'http://127.0.0.1:8040';
 const VIEWPORT = { width: 1280, height: 800 };
 
 // ---------------------------------------------------------------------------

--- a/docs/xray/05-click-to-source.md
+++ b/docs/xray/05-click-to-source.md
@@ -116,7 +116,7 @@ Click-to-source is the gesture that gets you from a rendered pixel to its source
 
 The five clicks:
 
-1. **Open the testbed.** Run `npm run test:examples` from `implementation/`, then visit `http://127.0.0.1:8030/parallel-frames/`. Two stacked panels appear — `:above` and `:below` — each carrying its own counter, clock and title.
+1. **Open the testbed.** Run `npm run test:examples` from `implementation/`, then visit `http://127.0.0.1:8040/parallel-frames/` (the harness serves on 8040 by default; override with `EXAMPLES_PORT`). Two stacked panels appear — `:above` and `:below` — each carrying its own counter, clock and title.
 
 2. **The coord on the wire.** Right-click the title text inside `:above`, *Copy element*. The HTML carries `data-rf2-source-coord="parallel-frames.core:title-view:198:4"`. The coord routes you to the `title-view` reg-view in `tools/xray/testbeds/parallel_frames/core.cljs`. Now right-click the same title text in `:below` — same coord. One source, two live mounts; the coord is the source identity.
 

--- a/examples/reagent/README.md
+++ b/examples/reagent/README.md
@@ -40,7 +40,7 @@ From `implementation/`:
 npm run test:examples
 ```
 
-That compiles every Reagent build under `out/examples/<name>/`, stages the hand-written `index.html` next to `main.js`, and serves the output on port 8030 so you can open each example in a browser. Examples are test-free — real-regression coverage lives in the substrate contract tests and framework gates, not under `examples/`. See [examples/README.md §End-to-end verification](../README.md#end-to-end-verification) for orchestrator details.
+That compiles every Reagent build under `out/examples/<name>/`, stages the hand-written `index.html` next to `main.js`, and serves the output on `127.0.0.1:8040` (override with `EXAMPLES_PORT`; the harness scans forward if 8040 is taken) so you can open each example in a browser. Examples are test-free — real-regression coverage lives in the substrate contract tests and framework gates, not under `examples/`. See [examples/README.md §End-to-end verification](../README.md#end-to-end-verification) for orchestrator details.
 
 To iterate on one example interactively, watch its build directly from `implementation/`:
 

--- a/examples/reagent/websocket/README.md
+++ b/examples/reagent/websocket/README.md
@@ -58,13 +58,13 @@ The example is wired into the canonical examples harness. From `implementation/`
 npm run test:examples
 ```
 
-That compiles every example (this one builds under shadow-cljs id `examples/websocket`), stages its `index.html` into `out/examples/websocket/`, and serves the lot on port 8030.
+That compiles every example (this one builds under shadow-cljs id `examples/websocket`), stages its `index.html` into `out/examples/websocket/`, and serves the lot on `127.0.0.1:8040` (override with `EXAMPLES_PORT`).
 
 To iterate on the source alone, watch the build directly from `implementation/`:
 
 ```bash
 shadow-cljs watch examples/websocket
-# then visit http://127.0.0.1:8030/websocket/ once the harness is running
+# then visit http://127.0.0.1:8040/websocket/ once the harness is running
 ```
 
 ## Headless tests

--- a/examples/scripts/examples-port.cjs
+++ b/examples/scripts/examples-port.cjs
@@ -1,0 +1,121 @@
+/*
+ * Port resolver for the adapter-smoke orchestrator
+ * (serve-and-run-examples-tests.cjs).
+ *
+ * Why this exists (rf2-0u6ce). The orchestrator used to hard-bind
+ * 0.0.0.0:8030. But 8030 is ALSO claimed by the top-level :dev-http map
+ * in implementation/shadow-cljs.edn (8030 = the two_frame_isolation
+ * testbed) — so the moment ANY `shadow-cljs watch` is running, 8030 is
+ * already taken. The orchestrator's second bind then failed with a
+ * cryptic `Error: listen EACCES 0.0.0.0:8030` on Windows (the dual-stack
+ * 0.0.0.0/:: listener returns EACCES, not the clearer EADDRINUSE), which
+ * gave no hint that the dev's own watch session was the cause.
+ *
+ * This resolver fixes both halves:
+ *   1. DEFAULT_PORT is 8040 — outside the top-level :dev-http set
+ *      (8765 / 8031 / 8030), so the common "watch + test:examples"
+ *      dev state no longer collides at all.
+ *   2. It PRE-FLIGHTS the port (binds-and-releases on 127.0.0.1). If the
+ *      preferred port is busy and no explicit EXAMPLES_PORT was set, it
+ *      scans forward to the next free port. If an explicit EXAMPLES_PORT
+ *      IS busy, it throws an actionable message rather than letting the
+ *      raw EACCES stack escape.
+ *
+ * The orchestrator binds http-server on 127.0.0.1 (not 0.0.0.0) — the
+ * Playwright specs only ever hit localhost, and the loopback-only bind
+ * also sidesteps the Windows dual-stack EACCES surprise.
+ *
+ * Shape mirrors examples/scripts/story-feature-load-port.cjs (the Story
+ * feature-load gate's resolver) deliberately, so the two sibling
+ * orchestrators handle port contention identically.
+ */
+
+'use strict';
+
+const net = require('net');
+
+// Default outside the top-level :dev-http set (8765 / 8031 / 8030) so a
+// running `shadow-cljs watch` never pre-claims the orchestrator's port.
+const DEFAULT_PORT = 8040;
+const MAX_PORT_ATTEMPTS = 200;
+
+// Build an Error tagged `.actionable = true`. The orchestrator's bottom
+// .catch prints just `err.message` (no stack) for tagged errors, so a
+// port clash surfaces as a clean one-liner instead of a raw EACCES dump.
+function actionableError(message) {
+  const err = new Error(message);
+  err.actionable = true;
+  return err;
+}
+
+function parseExplicitPort(raw) {
+  if (raw == null || String(raw).trim() === '') return null;
+  const n = Number(String(raw).trim());
+  if (!Number.isInteger(n) || n < 1 || n > 65535) {
+    throw actionableError(
+      `EXAMPLES_PORT must be an integer in 1..65535; got ${JSON.stringify(raw)}`,
+    );
+  }
+  return n;
+}
+
+// Bind-and-release probe on 127.0.0.1. Resolves true when the port is
+// free, false when it is taken (any bind error — EADDRINUSE on
+// Mac/Linux, EACCES for a dual-stack listener on Windows).
+function canListen(port, host = '127.0.0.1') {
+  return new Promise((resolve) => {
+    const server = net.createServer();
+    server.once('error', () => resolve(false));
+    server.listen(port, host, () => {
+      server.close(() => resolve(true));
+    });
+  });
+}
+
+async function findAvailablePort(startPort, opts = {}) {
+  const host = opts.host || '127.0.0.1';
+  const attempts = opts.attempts || MAX_PORT_ATTEMPTS;
+  for (let i = 0; i < attempts; i += 1) {
+    const port = startPort + i;
+    if (port > 65535) break;
+    if (await canListen(port, host)) return port;
+  }
+  throw actionableError(
+    `No free examples port found from ${startPort} after ${attempts} attempts. ` +
+      `Set EXAMPLES_PORT to an unused port.`,
+  );
+}
+
+/*
+ * Resolve the port the orchestrator should serve on.
+ *
+ *   - EXAMPLES_PORT set + free  → that port.
+ *   - EXAMPLES_PORT set + busy  → throw an actionable message (the
+ *     caller prints `err.message` and exits non-zero — no raw stack).
+ *   - EXAMPLES_PORT unset       → DEFAULT_PORT if free, else the next
+ *     free port scanning forward.
+ */
+async function resolveExamplesPort({ env = process.env } = {}) {
+  const explicit = parseExplicitPort(env.EXAMPLES_PORT);
+  if (explicit != null) {
+    if (!(await canListen(explicit))) {
+      throw actionableError(
+        `EXAMPLES_PORT=${explicit} is already in use. Is a 'shadow-cljs watch' ` +
+          `running? The top-level :dev-http map (implementation/shadow-cljs.edn) ` +
+          `claims 8765 / 8031 / 8030 whenever a watch is up. Stop the watch, or ` +
+          `set EXAMPLES_PORT to a free port.`,
+      );
+    }
+    return explicit;
+  }
+  return findAvailablePort(DEFAULT_PORT);
+}
+
+module.exports = {
+  DEFAULT_PORT,
+  MAX_PORT_ATTEMPTS,
+  canListen,
+  findAvailablePort,
+  parseExplicitPort,
+  resolveExamplesPort,
+};

--- a/examples/scripts/run-examples-tests.cjs
+++ b/examples/scripts/run-examples-tests.cjs
@@ -58,7 +58,12 @@ const fs = require('fs');
 const IMPL_ROOT = path.resolve(__dirname, '..', '..', 'implementation');
 const { chromium } = require(require.resolve('playwright', { paths: [IMPL_ROOT] }));
 
-const BASE_URL = process.env.EXAMPLES_BASE_URL || 'http://127.0.0.1:8030';
+// EXAMPLES_BASE_URL is always set by the orchestrator
+// (serve-and-run-examples-tests.cjs) to the port it actually resolved.
+// The fallback below only applies when this runner is invoked
+// standalone; it tracks the orchestrator's default port (8040 — outside
+// the top-level :dev-http set 8765/8031/8030; see examples-port.cjs).
+const BASE_URL = process.env.EXAMPLES_BASE_URL || 'http://127.0.0.1:8040';
 // `EXAMPLES_FILTER` narrows the spec set. When set, only spec files whose
 // path includes the substring are loaded. Composes with the
 // orchestrator's compile/stage filter so a narrow run only exercises

--- a/examples/scripts/serve-and-run-examples-tests.cjs
+++ b/examples/scripts/serve-and-run-examples-tests.cjs
@@ -14,7 +14,9 @@
  * 1. Compiles each surface's shadow-cljs build (one per smoke).
  * 2. Stages each surface's hand-written index.html into its
  *    out/examples/<name>/ directory next to main.js.
- * 3. Spawns http-server over out/examples on port 8030.
+ * 3. Resolves a free port (default 8040 — outside the top-level
+ *    :dev-http set 8765/8031/8030; see examples-port.cjs) and spawns
+ *    http-server over out/examples on 127.0.0.1:<port>.
  * 4. Waits for it to be reachable, then runs the Playwright runner
  *    (run-examples-tests.cjs).
  * 5. Always tears the server down.
@@ -31,6 +33,7 @@
 const { spawnSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
+const { resolveExamplesPort } = require('./examples-port.cjs');
 const {
   createHarnessCleanup,
   spawnHarnessProcess,
@@ -81,12 +84,13 @@ function parseFilterPatterns(raw) {
   return raw.split(',').map((s) => s.trim()).filter((s) => s.length > 0);
 }
 const FILTER_PATTERNS = parseFilterPatterns(FILTER);
-// `EXAMPLES_PORT` env-var override defaults to 8030. Lets parallel
-// workers / contended dev sessions (e.g. a long-running `shadow-cljs
-// watch` on the two-frame-isolation testbed at 8030) retarget this
-// orchestrator to a free port without editing the script. No CLI
-// surface is added.
-const PORT = Number(process.env.EXAMPLES_PORT || 8030);
+// Port resolution lives in examples-port.cjs (resolveExamplesPort, called
+// at the top of main()). Default is 8040 — outside the top-level
+// :dev-http set (8765/8031/8030) so a running `shadow-cljs watch` no
+// longer pre-claims the orchestrator's port. `EXAMPLES_PORT` overrides
+// the default; when unset the resolver scans forward from 8040 to the
+// next free port, and when set-but-busy it throws an actionable message
+// (no raw EACCES stack). No CLI surface is added.
 // __dirname is <repo>/examples/scripts. IMPL_ROOT is <repo>/implementation
 // (where shadow-cljs runs and node_modules lives); REPO_ROOT is <repo>.
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
@@ -257,10 +261,21 @@ function stageHtml() {
 }
 
 async function main() {
+  // Pre-flight the port before any compile work: the resolver binds-and-
+  // releases on 127.0.0.1, picks the next free port from 8040 when
+  // EXAMPLES_PORT is unset, and throws an actionable message (caught by
+  // the bottom .catch, which prints err.message + exits 1) when an
+  // explicit EXAMPLES_PORT is busy. Resolving first means a port clash
+  // fails fast with a clear message instead of after a slow shadow build.
+  const PORT = await resolveExamplesPort({ env: process.env });
+
   compileAll();
   stageHtml();
 
-  const server = cleanup.trackProcess(spawnHarnessProcess(process.execPath, [HTTP_SERVER_BIN, OUT_ROOT, '-p', String(PORT), '-s', '-c-1'], {
+  // Bind 127.0.0.1 (not 0.0.0.0): the Playwright specs only ever hit
+  // localhost, and the loopback-only bind sidesteps the Windows
+  // dual-stack EACCES surprise that made the old 8030 clash cryptic.
+  const server = cleanup.trackProcess(spawnHarnessProcess(process.execPath, [HTTP_SERVER_BIN, OUT_ROOT, '-a', '127.0.0.1', '-p', String(PORT), '-s', '-c-1'], {
     cwd: IMPL_ROOT,
     stdio: ['ignore', 'inherit', 'inherit'],
   }));
@@ -303,7 +318,14 @@ main().then(async (code) => {
   await cleanup.cleanup();
   process.exit(code);
 }).catch(async (err) => {
-  console.error(err);
+  // Actionable errors (e.g. a port clash from resolveExamplesPort) carry
+  // a fully-formed user-facing message — print just that, no raw stack.
+  // Everything else prints in full for debugging.
+  if (err && err.actionable) {
+    console.error(err.message);
+  } else {
+    console.error(err);
+  }
   await cleanup.cleanup();
   process.exit(1);
 });


### PR DESCRIPTION
## What

`npm run test:examples` died with a cryptic `Error: listen EACCES 0.0.0.0:8030` whenever a `shadow-cljs watch` was running.

**Root.** The adapter-smoke orchestrator (`examples/scripts/serve-and-run-examples-tests.cjs`) hard-bound `http-server` on `0.0.0.0:8030`. But `8030` is *also* claimed by the **top-level `:dev-http` map** in `implementation/shadow-cljs.edn` (`8030 = two_frame_isolation` testbed) — so the moment any `shadow-cljs watch` is up, `8030` is already taken. The orchestrator's second bind then failed. On Windows the dual-stack `0.0.0.0`/`::` listener returns **EACCES** (not the clearer EADDRINUSE), with no hint that the dev's own watch session was the cause.

## Fix (script-side only — no hot-zone edit)

- **New `examples/scripts/examples-port.cjs`** — a port resolver mirroring the existing `story-feature-load-port.cjs`:
  - **Default port `8040`** — outside the top-level `:dev-http` set (`8765`/`8031`/`8030`), so the common "watch + test:examples" dev state no longer collides at all.
  - **Pre-flights** the port (bind-and-release on `127.0.0.1`). `EXAMPLES_PORT` unset → scans forward from `8040` to the next free port. `EXAMPLES_PORT` set-but-busy → throws an **actionable message** naming the likely `shadow-cljs watch`.
- **Orchestrator** resolves the port *before* compiling (fail-fast), and binds `http-server` on **`127.0.0.1`** (`-a 127.0.0.1`) instead of `0.0.0.0` — the specs only hit localhost, and the loopback-only bind also sidesteps the Windows dual-stack EACCES.
- Actionable errors print as a **clean one-liner** (no raw stack) via an `.actionable` flag on the Error.
- Kept the runner's standalone fallback `BASE_URL` (`run-examples-tests.cjs`) and the manual-browse doc references (`examples/reagent/README.md`, `examples/reagent/websocket/README.md`, `docs/xray/05-click-to-source.md`, `docs/scripts/generate-tutorial-screenshots.cjs`) in sync with the new `8040` default.

`implementation/shadow-cljs.edn` (hot-zone) is **not** touched — the two_frame_isolation `8030` assignment is unchanged.

### Before / after

| | Before | After |
|---|---|---|
| Default port | `0.0.0.0:8030` (clashes with `:dev-http`) | `127.0.0.1:8040` (outside the `:dev-http` set) |
| Watch running | `Error: listen EACCES 0.0.0.0:8030` + raw stack | no clash (8040 free) |
| `EXAMPLES_PORT` set + busy | raw EACCES stack | `EXAMPLES_PORT=N is already in use. Is a 'shadow-cljs watch' running? …` + exit 1 |

## Quality gates

Chosen port/address: **`127.0.0.1:8040`** (default; `EXAMPLES_PORT` overrides, resolver scans forward when unset).

- **Happy path** — `npm run test:examples` from `implementation/` (no watch): **PASS**. `Ran 3 example specs. 0 failures, 0 skipped.` Overall exit code `0`. Served on the resolved `8040`.
- **Busy-port path** — simulated by holding `8040` and running with `EXAMPLES_PORT=8040`: prints the clean one-liner (`EXAMPLES_PORT=8040 is already in use. Is a 'shadow-cljs watch' running? …`), **no raw stack**, exit code `1`. Verified the resolver pre-flight matrix: default→8040, default-with-8040-busy→8041, explicit-free→pass-through, explicit-busy→actionable throw, invalid→validation throw.
- `node --check` clean on all 4 modified `.cjs` files.

Closes rf2-0u6ce.
