### PR TITLE
fix(xray/epoch): exception-thrown block + collapsible details, no phantom :db / spurious rollback (rf2-wnvid)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -2356,8 +2356,8 @@ matching row's `:errors` (FX row-level) AND `:status :error`.
 | Trace op | Owning step | Granularity |
 |----------|-------------|-------------|
 | `:rf.error/handler-exception` | HANDLER | step-level (handler / interceptor / coeffect throw — the chain is the unit that threw) |
-| `:rf.error/fx-handler-exception` | FX, row whose `:fx-id` = `:failing-id` | row-level (fallback step-level) |
-| `:rf.error/no-such-fx` | FX | step-level (fallback) |
+| `:rf.error/fx-handler-exception` | SIDE EFFECTS, row whose `:fx-id` = `:failing-id` | row-level (fallback step-level) |
+| `:rf.error/no-such-fx` | SIDE EFFECTS | step-level (fallback) |
 | `:rf.error/flow-eval-exception` | FLOW | step-level (fallback HANDLER when no FLOW step) |
 
 The error MESSAGE rides `[:tags :exception-message]` (handler / fx
@@ -2370,28 +2370,70 @@ Issues panel's `short-description` / `source-coord` read — the bead's
 original probe checked `:message` / `:source` / `:error-id`, which
 the substrate does not stamp (the empty-tags symptom).
 
-**Inline error card.** `view/error-block` renders a red-edged card
-(sibling to the amber schema-violation card; `:bg-violation`
-background, `:error` border) carrying: a `✗ Exception` title bar +
-`Rolled back` recovery chip; a one-line human headline keyed off the
-op + interceptor `:phase` ("The event handler threw." / "An
-interceptor / coeffect threw (:before)." / "The :http/post effect
-threw."); the verbatim `ex-info` message (monospace); and a
-jump-to-source link reading `file:line` (the shared `coord-link`,
-degrading to muted "source unavailable" when no coord was captured).
-HANDLER / FLOW inject `(error-blocks step-key errors)` under their
-body; FX injects per-row cards via `fx-row-with-violations` plus a
-step-level `(error-blocks :fx errors)` for unmatched fx ids.
+**Inline error card (rf2-ahhgn · refined rf2-wnvid).** `view/error-block`
+renders a red-edged card (sibling to the amber schema-violation card;
+`:bg-violation` background, `:error` border) for ALL exception kinds,
+carrying:
+
+1. a `✗ Exception Thrown` title bar + a `Rolled back` recovery chip
+   that paints **ONLY** when a `:db` actually committed before the
+   throw (`db-committed?` — the cascade-level presence of a
+   `:rf.event/db-changed` / schema rollback, stamped onto each
+   exception row by `attach-exceptions`). The substrate stamps
+   `:recovery :no-recovery` on EVERY `:rf.error/handler-exception`, so
+   keying the chip off recovery alone painted a **spurious** "Rolled
+   back" on button-15 — the handler threw before producing any `:db`,
+   so nothing committed and nothing reverted (rf2-wnvid fix);
+2. a one-line human headline derived from the OP, **not** the
+   interceptor `:phase` ("The event handler threw." / "The :http/post
+   effect threw." / "A flow's computation threw."). The substrate
+   routes a handler / interceptor / injected-coeffect throw ALL through
+   `:rf.error/handler-exception` with `:reason "Event handler threw."`
+   and `:phase :before` (the handler is the terminal `:before`
+   interceptor), so the pre-rf2-wnvid `:phase`-keyed wording mislabelled
+   a plain handler throw as "An interceptor / coeffect threw (:before)."
+   — the headline now reads off the op and matches the substrate's own
+   `:reason` (rf2-wnvid fix);
+3. the verbatim `ex-info` message (monospace); and
+4. a **collapsible** `<details>` disclosure ("Details", collapsed by
+   default) carrying the exception's `ex-data` (via `ei/edn-inspector`)
+   + its stack trace (monospace `<pre>`), read off the raw `:exception`
+   object the projection lifts onto the exception row (rf2-wnvid).
+
+The pre-rf2-wnvid always-expanded **jump-to-source link is DROPPED**:
+it duplicated the HANDLER step's verb link (the canonical
+jump-to-source) and, on a handler throw where the trace carried no
+coord, degraded to a useless "source unavailable" (rf2-wnvid). HANDLER /
+FLOW inject `(error-blocks step-key errors)` under their body; the SIDE
+EFFECTS step injects per-row cards via `fx-row-with-violations` plus a
+step-level `(error-blocks :side-effects errors)` for unmatched fx ids.
+
+**HANDLER `:db` — no phantom `:db` (rf2-wnvid).** The HANDLER step's
+`:db` sub-section (`view/handler-db-diff-block`) renders a
+`— no :db (handler threw)` / `— no :db (handler returned no :db)`
+placeholder when the handler wrote NO `:db` effect (the projection's
+`:db-write?` slot, from `projection/handler-wrote-db?`: t1
+`:rf.event/db-pending` OR a `:rf.event/db-changed` commit fired). The
+pre-rf2-wnvid code fell back to the record's full post-cascade
+`:db-after` whenever the post-handler db value was nil — painting the
+ENTIRE app-db tree under the HANDLER step as if the handler had returned
+it (the phantom `:db`, most visible on button-15 where the handler
+mutated nothing).
 
 ### §9.1.10.5 Epoch outcome — tool-side, NOT the framework slot (rf2-ahhgn)
 
 The `:rf.xray/epoch-pipeline` composite sub carries an `:outcome`
 (`:ok` / `:error`) from `projection/epoch-outcome` — `:error` when
-ANY projected step reads `step-status :error`. The Panel paints a
-red **outcome banner** above the pipeline on `:error` ("This event
-failed — see the ✗ step below.") and stamps `data-rf-xray-outcome`
-on the panel root; a clean cascade paints no banner (silence is the
-success signal — no green reassurance chrome on the common case).
+ANY projected step reads `step-status :error`. The Panel stamps
+`data-rf-xray-outcome` on the panel root (tools / e2e read the
+tool-side outcome there). The failure surfaces **inline**: the failing
+step paints the red ✗ glyph (the per-step `step-status` primitive) and
+the inline "Exception Thrown" card sits right under it.
+
+The pre-rf2-wnvid top-of-pipeline **outcome banner** ("This event
+failed — see the ✗ step below.") is **RETIRED** (rf2-wnvid): it merely
+restated the inline signal — the ✗ glyph + the error card already name
+and locate the failure — and pushed the actual cascade content down.
 
 **This is the TOOL-SIDE outcome** — the same trace-derived
 `:error`/`:ok` signal `event-status-colour/cascade-outcome` already

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -924,6 +924,31 @@
       (no-db-effect-with-flow? events) db-before
       :else                            nil)))
 
+(defn handler-wrote-db?
+  "True iff the handler actually wrote a `:db` effect this cascade
+  (rf2-wnvid). The discriminator off the trace stream:
+
+  1. t1 (`:rf.event/db-pending`) fired → the handler returned a `:db`
+     effect (the canonical post-rf2-ta0y7 signal).
+  2. No t1 (pre-rf2-ta0y7 runtime, or no `:rf.event/db-pending` on the
+     stream) but a `:rf.event/db-changed` commit fired → the runtime
+     installed a `:db` from the handler.
+
+  FALSE when the handler returned NO `:db` — INCLUDING the
+  handler-threw case (button-15 `:button-deck/throw-handler`: the
+  handler threw before returning, db-before == db-after, no t1, no
+  db-changed). The HANDLER step's `:db` sub-section keys off this to
+  show 'no :db (handler threw / returned no :db)' rather than falling
+  back to the full post-cascade app-db — the rf2-wnvid PHANTOM-`:db`
+  fix. Distinct from `effective-post-handler-db`, which resolves the
+  db VALUE (and returns db-before in the no-db-with-flow edge case);
+  this predicate answers the orthogonal 'did the handler write a `:db`
+  AT ALL' question the view needs to choose between a diff and the
+  no-write placeholder."
+  [events]
+  (or (some? (db-pending-t1 events))
+      (some? (find-op events :rf.event/db-changed))))
+
 (defn handler-row
   "Build the step-N HANDLER row. ALWAYS present (every epoch has a
   dispatched event therefore a handler). Adapts to the trace stream's
@@ -996,6 +1021,13 @@
                      ;; leaves the slot nil and the view falls back to the
                      ;; record's `:db-after`.
                      :db-post-handler db-post-handler
+                     ;; rf2-wnvid — did the handler write a `:db` effect
+                     ;; AT ALL this cascade? FALSE when it threw before
+                     ;; returning (button-15) or returned only `:fx`. The
+                     ;; view's `:db` sub-section keys off this to render the
+                     ;; no-write placeholder rather than the spurious full
+                     ;; post-cascade app-db (PHANTOM-`:db` fix).
+                     :db-write?      (handler-wrote-db? events)
                      :db-diff        (db-diff-paths db-before db-handler)
                      ;; :fx — legacy flat-entries slot (kept for non-view
                      ;; consumers; tests + pre-rf2-p2zy0 callers).
@@ -1917,10 +1949,18 @@
        :failing-id <kw-or-nil>             ;; the failing handler / fx id
        :phase      <kw-or-nil>             ;; :before / :after (interceptor)
        :recovery   <kw-or-nil>             ;; e.g. :no-recovery
+       :exception  <Throwable-or-nil>      ;; rf2-wnvid — the raw exception
+                                           ;; object (carries the stack)
        :raw        <trace-event>}          ;; the underlying trace event
 
-  Pure-data; the view's `error-block` renders message + coord + jump-to-
-  source. Empty slots are tolerated absent by the view."
+  Pure-data; the view's `error-block` renders the message + the
+  collapsible details (stack / ex-data). Empty slots are tolerated
+  absent by the view.
+
+  rf2-wnvid — the cascade-level `:db-committed?` slot is stamped LATER
+  by `attach-exceptions` (it needs the whole event stream, not the one
+  exception event); it gates the view's 'Rolled back' chip so the chip
+  only paints when a `:db` install actually preceded the throw."
   [ev]
   {:operation  (op ev)
    :message    (exception-message ev)
@@ -1930,6 +1970,7 @@
                    (common/tag-of ev :handler-id))
    :phase      (common/tag-of ev :phase)
    :recovery   (or (:recovery ev) (common/tag-of ev :recovery))
+   :exception  (common/tag-of ev :exception)
    :raw        ev})
 
 (defn exception-rows
@@ -2368,7 +2409,16 @@
                                  (assoc :db-post-flow flow-db-post)))
                              (flow-rows events))
             violations (schema-violation-rows events)
-            exceptions (exception-rows events)
+            ;; rf2-wnvid — stamp the cascade-level `:db-committed?` onto
+            ;; every exception row so the view's 'Rolled back' chip paints
+            ;; ONLY when a `:db` install actually preceded the throw (a real
+            ;; commit there is something to roll back). `db-commit?` keys off
+            ;; `:rf.event/db-changed` / a schema rollback — both absent on a
+            ;; handler that threw before returning (button-15), so the chip
+            ;; correctly stays off there (NO SPURIOUS 'Rolled back').
+            db-committed? (db-commit? events)
+            exceptions (mapv #(assoc % :db-committed? db-committed?)
+                             (exception-rows events))
             base-steps (vec
                         (concat
                           [(dispatch-row events fallback)]

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -1166,24 +1166,10 @@
    :font-style "italic"
    :font-size  "10px"})
 
-(def ^:private schema-violation-action-link-style
-  {:background    "transparent"
-   :border        "none"
-   :padding       0
-   :margin        0
-   :color         accent-colour
-   :cursor        "pointer"
-   :font-family   mono-stack
-   :font-size     "11px"
-   :display       "inline-flex"
-   :align-items   "center"
-   :gap           "4px"
-   :text-align    "left"})
-
-(def ^:private schema-violation-actions-style
-  {:display     "flex"
-   :gap         "16px"
-   :flex-wrap   "wrap"})
+;; `schema-violation-action-link-style` + `schema-violation-actions-style`
+;; retired (rf2-wnvid) — they backed the error-card's jump-to-source
+;; action row, which rf2-wnvid dropped as redundant with the HANDLER
+;; step's verb link.
 
 (def ^:private schema-violation-explain-toggle-style
   {:background  "transparent"
@@ -1236,6 +1222,47 @@
 (def ^:private error-block-recovery-chip-style
   (assoc schema-violation-rollback-chip-style
          :text-transform "none"))
+
+;; rf2-wnvid — collapsible exception details (`<details>`/`<summary>`).
+;; The stack trace + ex-data are diagnostic depth the operator wants on
+;; demand, not always-expanded clutter under every failed step. A native
+;; `<details>` element gives a zero-app-db-state, accessible disclosure;
+;; the summary row is the clickable affordance.
+(def ^:private error-block-details-style
+  {:margin "4px 0 0 0"})
+
+(def ^:private error-block-summary-style
+  {:cursor      "pointer"
+   :color       text-secondary-colour
+   :font-family sans-stack
+   :font-size   "11px"
+   :user-select "none"
+   :outline     "none"})
+
+(def ^:private error-block-stack-style
+  ;; The stack trace is verbatim multi-line text — render it monospace
+  ;; in a scrollable, pre-wrapped block so long stacks don't blow out the
+  ;; panel width.
+  {:color          text-tertiary-colour
+   :font-family    mono-stack
+   :font-size      "11px"
+   :line-height    1.45
+   :white-space    "pre-wrap"
+   :word-break     "break-word"
+   :max-height     "240px"
+   :overflow       "auto"
+   :margin         "4px 0 0 0"
+   :padding        "6px 8px"
+   :background     bg-1-colour
+   :border-radius  "3px"})
+
+(def ^:private error-block-data-label-style
+  {:color          text-tertiary-colour
+   :font-family    sans-stack
+   :font-size      "10px"
+   :text-transform "uppercase"
+   :letter-spacing "0.5px"
+   :margin         "6px 0 2px 0"})
 
 (def ^:private rolled-back-mute-style
   {:opacity 0.55})
@@ -1338,26 +1365,12 @@
 (def ^:private panel-scroll-style
   {:flex 1 :overflow "auto" :padding "21px"})
 
-;; rf2-ahhgn — epoch outcome banner. A failed cascade (an exception or
-;; schema violation fired) paints a thin red banner at the top of the
-;; pipeline so the operator reads "this event failed" the moment they
-;; land on the panel — without scanning for the ✗ step. The per-step
-;; ✗ glyphs + inline error cards then pinpoint WHERE. A clean cascade
-;; renders NO banner (silence is the success signal — no green
-;; reassurance chrome cluttering the common case).
-(def ^:private outcome-banner-error-style
-  {:display       "flex"
-   :align-items   "center"
-   :gap           "8px"
-   :padding       "6px 10px"
-   :margin-bottom "13px"
-   :background    bg-violation-colour
-   :border        (str "1px solid " error-colour)
-   :border-radius "3px"
-   :color         error-colour
-   :font-family   sans-stack
-   :font-size     "12px"
-   :font-weight   600})
+;; rf2-ahhgn epoch outcome banner — RETIRED (rf2-wnvid). The top-of-
+;; pipeline "This event failed — see the ✗ step below." banner restated
+;; what the cascade now shows inline (the failing step's red ✗ glyph +
+;; the 'Exception Thrown' card). `outcome-banner-error-style` +
+;; `outcome-banner` are gone; the panel root keeps `data-rf-xray-outcome`
+;; for tools / e2e.
 
 ;; ---- expansion state helpers ---------------------------------------------
 ;;
@@ -2594,16 +2607,28 @@
   The `:db-diff` arg is unused under the single rendering but stays in
   the parent's `handler-body` signature for projection compatibility.
 
+  rf2-wnvid — PHANTOM-`:db` fix. When the handler wrote NO `:db` effect
+  (`db-write?` false — it threw before returning, per button-15, or
+  returned only `:fx`), the block renders a `— no :db (…)` placeholder
+  instead of falling back to the record's full post-cascade `:db-after`.
+  The pre-rf2-wnvid fallback painted the ENTIRE app-db tree under the
+  HANDLER step as if the handler had returned it — misleading on a
+  thrown handler that mutated nothing. `threw?` tunes the placeholder
+  wording so a handler-exception reads 'no :db (handler threw)'.
+
   Suppressed for machine handlers — per design §Section 3 §DB DIFF
   the snapshot IS the db change (at `[:rf/runtime :machines :snapshots <id>]`) so the
   slot folds into SNAPSHOT DIFF rather than carrying a redundant
   standalone slot."
-  [_db-diff db-post-handler]
+  [_db-diff db-post-handler db-write? threw?]
   (let [record    @(rf/subscribe [:rf.xray/selected-epoch-record])
         db-before (:db-before record)
         ;; rf2-4wywy — t1 (post-handler, pre-flow) is the authoritative
         ;; HANDLER `:db`; fall back to the record's post-flow `:db-after`
-        ;; only when the runtime stamped no t1.
+        ;; only when the runtime stamped no t1 — but ONLY when the handler
+        ;; actually wrote a `:db` (rf2-wnvid). A handler that wrote no
+        ;; `:db` resolves the no-write placeholder below, never the
+        ;; phantom full-app-db fallback.
         db-after  (if (some? db-post-handler)
                     db-post-handler
                     (:db-after record))]
@@ -2611,15 +2636,27 @@
            ;; rf2-xvu24 — canonical `data-rf-xray-diff-mode` axis. Now
            ;; a constant post-rf2-vv3m6; kept for selector compatibility
            ;; (tools / e2e can still pin the FULL+DIFF rendering).
-           :data-rf-xray-diff-mode "full+diff"}
+           :data-rf-xray-diff-mode "full+diff"
+           :data-rf-xray-db-write (str (boolean db-write?))}
      (sub-header ":db" nil)
-     (if (some? db-after)
+     (cond
+       ;; rf2-wnvid — the handler wrote no `:db` → no phantom app-db.
+       (not db-write?)
+       [:span {:data-testid "rf-xray-epoch-handler-db-no-write"
+               :style handler-db-all-missing-style}
+        (if threw?
+          "— no :db (handler threw)"
+          "— no :db (handler returned no :db)")]
+
+       (some? db-after)
        [:div {:data-testid "rf-xray-epoch-handler-db-full-with-diff"
               :style handler-db-all-style}
         [ei/edn-inspector db-after
          {:site-id [:rf.xray.epoch/handler-db-full-with-diff (:epoch-id record)]
           :before db-before
           :default-expanded-depth 3}]]
+
+       :else
        [:span {:data-testid "rf-xray-epoch-handler-db-full-with-diff-missing"
                :style handler-db-all-missing-style}
         "— db-after not available in epoch record"])]))
@@ -2655,8 +2692,13 @@
   Either, both, or neither may render — sections are
   `seq`-conditioned. The `:db` part stays in its own dedicated
   block (the [diff][full][full+diff] toggle) above."
-  [{:keys [flavour event-id db-diff db-post-handler fx-vec other-effects machine] :as _row}]
-  (let [machine? (= :reg-machine flavour)]
+  [{:keys [flavour event-id db-diff db-post-handler db-write? fx-vec other-effects
+           machine errors] :as _row}]
+  (let [machine? (= :reg-machine flavour)
+        ;; rf2-wnvid — the handler threw iff a `:rf.error/handler-exception`
+        ;; attached to this step (`:errors`). Tunes the no-`:db` placeholder
+        ;; wording ('handler threw' vs 'returned no :db').
+        threw?   (boolean (seq errors))]
     [:div {:data-testid "rf-xray-epoch-handler-body"}
      ;; Source / machine spec block — rf2-66wis
      (handler-source-block flavour event-id)
@@ -2669,7 +2711,7 @@
      ;; post-handler (t1) db is threaded so the diff shows ONLY the
      ;; handler's contribution, not the post-flow state.
      (when-not machine?
-       (handler-db-diff-block db-diff db-post-handler))
+       (handler-db-diff-block db-diff db-post-handler db-write? threw?))
      ;; :fx — the canonical vector-of-vectors, FULL via edn-inspector.
      ;; rf2-5t8y8 — sub-header carries a trailing entry-count chip ("N
      ;; entr{y,ies}") that the edn-inspector vector-header chrome alone
@@ -3796,22 +3838,10 @@
     (keyword? recovery)    (name recovery)
     :else                  nil))
 
-(defn- violation-open-source-action
-  "Click-to-source button. `coord` is `{:file :line}` or nil; when
-  nil renders a muted plain-text fallback (graceful degrade — the
-  framework may not yet stamp coords for some surfaces).
-
-  rf2-vw5pi — routes through the shared `coord-link` with
-  `:glyph-leading?` (the schema-violation grammar leads with the
-  glyph: `↗ <failing-id>`). The muted plain fallback overlays the
-  link style with `:text-tertiary` + `default` cursor."
-  [{:keys [label coord testid]}]
-  (coord-link/coord-link coord label testid
-                         {:style          schema-violation-action-link-style
-                          :plain-style    (assoc schema-violation-action-link-style
-                                                 :color  text-tertiary-colour
-                                                 :cursor "default")
-                          :glyph-leading? true}))
+;; `violation-open-source-action` retired (rf2-wnvid) — its only caller
+;; was the error-card's jump-to-source link, which rf2-wnvid dropped as
+;; redundant with the HANDLER step's verb link. The schema-violation
+;; block's `schema check` link routes through `coord-link` directly.
 
 (defn- violation-kind-coord
   "Resolve a `(rf/handler-meta <kind> <id>)` coord, returning
@@ -4052,27 +4082,42 @@
 ;; ---- inline EXCEPTION card (rf2-ahhgn) ----------------------------------
 
 (defn- error-recovery-label
-  "Short recovery chip text for an exception card (rf2-ahhgn). A handler
-  exception rolls back the cascade (`:no-recovery`) — render that as the
-  red `Rolled back` chip so the operator reads the blast radius. Other
-  recovery keywords render name-d; nil recovery omits the chip."
-  [recovery]
+  "Short recovery chip text for an exception card (rf2-ahhgn / rf2-wnvid).
+
+  rf2-wnvid — `db-committed?` gates the `Rolled back` chip: it paints
+  ONLY when a `:db` install actually preceded the throw (so there was a
+  commit to revert). The substrate stamps `:recovery :no-recovery` on
+  EVERY `:rf.error/handler-exception`, so keying off recovery alone
+  painted a SPURIOUS `Rolled back` on button-15 — the handler threw
+  before producing any `:db`, so nothing committed + nothing reverted.
+  With no commit, the chip is omitted (the headline already says the
+  handler threw; there is no rollback to surface). Other recovery
+  keywords render name-d; nil recovery omits the chip."
+  [recovery db-committed?]
   (case recovery
-    :no-recovery "Rolled back"
+    :no-recovery (when db-committed? "Rolled back")
     (when (keyword? recovery) (name recovery))))
 
 (defn- error-block-label
-  "Render the card's one-line failure headline (rf2-ahhgn) — the failing
-  unit + a human verb keyed off the exception op + phase. E.g.
-  'The event handler threw.' / 'An interceptor threw (:before).' /
-  'The :http/post effect threw.'"
-  [{:keys [operation phase failing-id]}]
+  "Render the card's one-line failure headline (rf2-ahhgn / rf2-wnvid) —
+  the failing unit + a human verb keyed off the exception OP. E.g.
+  'The event handler threw.' / 'The :http/post effect threw.'
+
+  rf2-wnvid — attribution derives from `:operation` (== the trace
+  `:category` / `:reason` family), NOT the interceptor `:phase`. The
+  substrate routes a handler / interceptor / injected-coeffect throw ALL
+  through `:rf.error/handler-exception` with `:reason \"Event handler
+  threw.\"` and `:phase :before` (the handler is the terminal `:before`
+  interceptor — `re-frame.router/emit-handler-exception!`). The
+  pre-rf2-wnvid code read `:phase :before` and mislabelled button-15 (a
+  plain handler throw) as 'An interceptor / coeffect threw (:before).'
+  Since the substrate cannot distinguish the three sub-kinds, the
+  headline reads off the op and says 'The event handler threw.' —
+  matching the substrate's own `:reason`."
+  [{:keys [operation failing-id]}]
   (case operation
     :rf.error/handler-exception
-    (cond
-      (= :before phase) "An interceptor / coeffect threw (:before)."
-      (= :after phase)  "An interceptor threw (:after)."
-      :else             "The event handler threw.")
+    "The event handler threw."
     :rf.error/fx-handler-exception
     (str "The " (proj/ns-keyword failing-id) " effect threw.")
     :rf.error/no-such-fx
@@ -4081,34 +4126,91 @@
     "A flow's computation threw."
     "An exception was thrown."))
 
-(defn error-block
-  "Render one inline EXCEPTION card (rf2-ahhgn) for a projected
-  `exception-row`. Four pieces, top to bottom:
+(defn- exception-stack
+  "Lift the stack trace string off a thrown exception object (rf2-wnvid).
+  CLJS errors carry `.-stack` (the panel runs in the browser). nil-safe —
+  returns nil for a non-error / stack-less exception."
+  [exception]
+  (when (some? exception)
+    (let [s (try (.-stack ^js exception)
+                 (catch :default _ nil))]
+      (when (and (string? s) (not (str/blank? s))) s))))
 
-    1. Title bar: `✗` + 'Exception' + right-aligned recovery chip
-       (`Rolled back` for a handler exception).
-    2. Failure headline: a one-line human verb (`error-block-label`).
+(defn- exception-ex-data
+  "Lift the `ex-data` map off a thrown exception object (rf2-wnvid).
+  nil-safe — returns nil when the exception carries no ex-data (a bare
+  `(throw (js/Error. …))` rather than an `ex-info`)."
+  [exception]
+  (when (some? exception)
+    (let [d (try (ex-data exception) (catch :default _ nil))]
+      (when (seq d) d))))
+
+(defn- error-block-details
+  "Render the collapsible EXCEPTION details (rf2-wnvid) — a native
+  `<details>` disclosure carrying the stack trace + any `ex-data`,
+  collapsed by default. Replaces the pre-rf2-wnvid always-expanded
+  source link (which was REDUNDANT — the HANDLER step's verb already
+  jumps to the handler's reg-site, and on a handler throw the error
+  card's own coord was usually nil → a useless 'source unavailable'
+  link). The depth lives behind one click; the common read is the
+  headline + message above. Returns nil when neither a stack nor
+  ex-data is available (nothing to disclose)."
+  [testid-base {:keys [exception]}]
+  (let [stack   (exception-stack exception)
+        ex-data* (exception-ex-data exception)]
+    (when (or stack (seq ex-data*))
+      [:details {:data-testid (str testid-base "-details")
+                 :style error-block-details-style}
+       [:summary {:data-testid (str testid-base "-details-summary")
+                  :style error-block-summary-style}
+        "Details"]
+       (when (seq ex-data*)
+         [:div {:data-testid (str testid-base "-ex-data")}
+          [:div {:style error-block-data-label-style} "ex-data"]
+          [ei/edn-inspector ex-data*
+           {:site-id [:rf.xray.epoch/error-ex-data testid-base]
+            :card?   false
+            :default-expanded-depth 1}]])
+       (when stack
+         [:div {:data-testid (str testid-base "-stack")}
+          [:div {:style error-block-data-label-style} "stack"]
+          [:pre {:style error-block-stack-style} stack]])])))
+
+(defn error-block
+  "Render one inline EXCEPTION card (rf2-ahhgn / rf2-wnvid) for a
+  projected `exception-row`. Top to bottom:
+
+    1. Title bar: `✗` + 'Exception Thrown' + right-aligned recovery chip
+       (`Rolled back`, painted ONLY when a `:db` actually committed +
+       rolled back — `db-committed?`; rf2-wnvid drops the spurious chip
+       on a handler that threw before any commit).
+    2. Failure headline: a one-line human verb (`error-block-label`),
+       attributed off the op (NOT the interceptor `:phase` — rf2-wnvid).
     3. Exception message: the verbatim `ex-info` message (monospace).
-    4. Source-coord jump-to-source link: `↗ file:line` opening the
-       failing handler's registration site via `:rf.xray/open-in-editor`
-       (the same coord-link the schema-violation card uses); omitted
-       when no coord was captured (fn-form / production build).
+    4. Collapsible details (`error-block-details`): the stack trace +
+       any `ex-data`, collapsed behind a `<details>` disclosure.
+
+  rf2-wnvid — the pre-existing always-expanded jump-to-source link is
+  DROPPED: it duplicated the HANDLER step's verb link (the canonical
+  jump-to-source) and, on a handler throw where the trace carried no
+  coord, degraded to a useless 'source unavailable'. The depth that
+  matters (stack / ex-data) now rides the collapsible.
 
   `step-key` + `idx` give stable test ids. The card paints the failing
   step's blast radius right where the work happened — the inline half of
-  rf2-ahhgn."
-  [step-key idx {:keys [message coord recovery] :as row}]
-  (let [recovery-label (error-recovery-label recovery)
+  rf2-ahhgn, polished by rf2-wnvid for ALL exception kinds."
+  [step-key idx {:keys [message recovery db-committed?] :as row}]
+  (let [recovery-label (error-recovery-label recovery db-committed?)
         testid-base    (str "rf-xray-epoch-error-"
                             (name (or step-key :unknown)) "-" idx)]
     [:div {:key (str "error-" step-key "-" idx)
            :data-testid testid-base
            :data-error-op (when (:operation row) (name (:operation row)))
            :style error-block-style}
-     ;; 1. Title bar — ✗ + 'Exception' + recovery chip
+     ;; 1. Title bar — ✗ + 'Exception Thrown' + recovery chip
      [:div {:style error-block-title-style}
       [:span {:aria-hidden true} "✗"]
-      [:span {:data-testid (str testid-base "-title")} "Exception"]
+      [:span {:data-testid (str testid-base "-title")} "Exception Thrown"]
       [:span {:style schema-violation-title-spacer-style}]
       (when recovery-label
         [:span {:data-testid (str testid-base "-recovery")
@@ -4123,15 +4225,8 @@
        [:div {:data-testid (str testid-base "-message")
               :style error-block-message-style}
         message])
-     ;; 4. Jump-to-source — failing handler's reg-site coord
-     [:div {:style schema-violation-actions-style}
-      (violation-open-source-action
-        {:label  (let [{:keys [file line]} coord]
-                   (if file
-                     (cond-> file line (str ":" line))
-                     "source unavailable"))
-         :coord  coord
-         :testid (str testid-base "-source")})]]))
+     ;; 4. Collapsible details — stack + ex-data behind a disclosure
+     (error-block-details testid-base row)]))
 
 (defn error-blocks
   "Render every exception in `errors` as an inline card inside the
@@ -4371,18 +4466,15 @@
            :style empty-state-style}
      msg]))
 
-(defn outcome-banner
-  "Render the top-of-cascade outcome banner (rf2-ahhgn). Painted only
-  when `outcome` is `:error` — a failed cascade. A clean cascade renders
-  nothing (silence is the success signal). The banner names the failure
-  at a glance; the per-step ✗ glyphs + inline error cards locate it."
-  [outcome]
-  (when (= :error outcome)
-    [:div {:data-testid "rf-xray-epoch-outcome-banner"
-           :data-rf-xray-outcome "error"
-           :style outcome-banner-error-style}
-     [:span {:aria-hidden true} "✗"]
-     [:span "This event failed — see the ✗ step below."]]))
+;; rf2-wnvid — the top-of-cascade outcome banner ("This event failed —
+;; see the ✗ step below.") is RETIRED (Mike pair-debug 2026-05-31). It
+;; was redundant: the failure now surfaces inline in the cascade — the
+;; failing step paints the red ✗ glyph (rf2-ahhgn `step-status`) and the
+;; inline 'Exception Thrown' card sits right under it. The banner
+;; restated what the cascade already shows, pushing the actual content
+;; down. The panel root still stamps `data-rf-xray-outcome` (tools / e2e
+;; read the tool-side outcome there); the banner element + its style are
+;; gone.
 
 ;; ---- public Panel --------------------------------------------------------
 
@@ -4393,9 +4485,11 @@
   the numbered cascade when steps are present; an empty-state when
   the focus carries no record or the record carries no trace events.
 
-  rf2-ahhgn — when the cascade failed (`:outcome :error`) a red banner
-  rides above the pipeline so the failure is visible the moment the
-  operator lands on the panel."
+  rf2-ahhgn / rf2-wnvid — when the cascade failed (`:outcome :error`)
+  the failure surfaces INLINE: the failing step paints the red ✗ glyph
+  and the inline 'Exception Thrown' card sits under it. The panel root
+  stamps `data-rf-xray-outcome` for tools / e2e; the pre-rf2-wnvid
+  top banner is retired (it merely restated the inline signal)."
   []
   (let [{:keys [status steps dispatch-id epoch-history outcome]}
         @(rf/subscribe [:rf.xray/epoch-pipeline])]
@@ -4407,7 +4501,6 @@
         (= :focused status)
         (if (seq steps)
           [:<>
-           (outcome-banner outcome)
            ;; rf2-x25e0 — build the `{dispatch-id → epoch-id}` index
            ;; once per panel render. Threaded through `ctx` to the
            ;; DISPATCH step's `:fx-dispatch` / `:fx-dispatch-later`

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -2231,7 +2231,58 @@
           row (proj/exception-row ev)]
       ;; handler-exception-ev stamps `:reason "Event handler threw."`
       (is (= "Event handler threw." (:message row)))
-      (is (nil? (:coord row))))))
+      (is (nil? (:coord row)))))
+
+  (testing "rf2-wnvid — `exception-row` lifts the raw `:exception` object
+            off `[:tags :exception]` (the view's collapsible details read
+            the stack / ex-data off it)"
+    (let [boom (ex-info "boom" {:surface :handler-exception})
+          ev   (handler-exception-ev :e "boom" nil nil boom)
+          row  (proj/exception-row ev)]
+      (is (identical? boom (:exception row))
+          "the raw exception object rides the row")))
+
+  (testing "rf2-wnvid — no `:exception` tag → `:exception` slot is nil"
+    (let [row (proj/exception-row (handler-exception-ev :e "boom"))]
+      (is (nil? (:exception row))))))
+
+(deftest handler-wrote-db?-test
+  (testing "rf2-wnvid — true when t1 (`:rf.event/db-pending`) fired"
+    (is (true? (proj/handler-wrote-db?
+                 [(db-pending-ev {:count 1})]))))
+  (testing "rf2-wnvid — true when a `:rf.event/db-changed` commit fired"
+    (is (true? (proj/handler-wrote-db?
+                 [(db-changed-ev [[[:count] 0 1 :modified]])]))))
+  (testing "rf2-wnvid — FALSE for the handler-threw shape (button-15: no
+            t1, no db-changed — handler threw before returning a :db)"
+    (is (false? (proj/handler-wrote-db?
+                  [(dispatched-ev [:button-deck/throw-handler] :ui nil)
+                   (handler-exception-ev :button-deck/throw-handler "boom" nil)
+                   (run-end-ev 1)]))))
+  (testing "rf2-wnvid — FALSE for a reg-event-fx that returned only :fx"
+    (is (false? (proj/handler-wrote-db?
+                  [(do-fx-ev {:fx [[:navigate "/x"]]})
+                   (run-end-ev 1)])))))
+
+(deftest handler-row-db-write?-slot-test
+  (testing "rf2-wnvid — the HANDLER row carries `:db-write?` so the view's
+            `:db` sub-section chooses the no-write placeholder over the
+            phantom full-app-db fallback"
+    (let [threw (proj/handler-row
+                  [(dispatched-ev [:button-deck/throw-handler] :ui nil)
+                   (handler-exception-ev :button-deck/throw-handler "boom" nil)
+                   (run-end-ev 1)]
+                  :button-deck/throw-handler
+                  {:n 1} {:n 1})]
+      (is (false? (:db-write? threw))
+          "handler that threw before returning a :db → db-write? false"))
+    (let [wrote (proj/handler-row
+                  [(db-pending-ev {:count 1})
+                   (db-changed-ev [[[:count] 0 1 :modified]])
+                   (run-end-ev 1)]
+                  :counter/inc {:count 0} {:count 1})]
+      (is (true? (:db-write? wrote))
+          "handler that wrote a :db → db-write? true"))))
 
 (deftest exception-rows-harvests-cascade-exceptions-test
   (testing "rf2-ahhgn — `exception-rows` harvests the `cascade-exception-ops`
@@ -2340,7 +2391,22 @@
       (let [err (first (:errors handler))]
         (is (= "button-deck / handler (intentional — exercises the handler error surface)"
                (:message err)))
-        (is (= {:file "button_deck/core.cljs" :line 322} (:coord err))))
+        (is (= {:file "button_deck/core.cljs" :line 322} (:coord err)))
+        ;; rf2-wnvid — the live button-15 had NO :db commit (handler
+        ;; threw before returning), so the exception row's cascade-level
+        ;; `:db-committed?` is false → the view omits the spurious
+        ;; 'Rolled back' chip.
+        (is (false? (:db-committed? err))
+            "no :db commit preceded the throw → :db-committed? false (no spurious rollback)"))
+      ;; rf2-wnvid — the HANDLER step carries :db-write? false (it threw
+      ;; before producing a :db), so the view shows 'no :db (handler
+      ;; threw)' rather than the phantom full app-db.
+      (is (false? (:db-write? handler))
+          "no :db write → :db-write? false (no phantom :db)")
+      ;; rf2-wnvid — no schema rollback fired, so NO step is marked
+      ;; rolled-back (the downstream-mute path is correctly inert).
+      (is (every? #(nil? (:rolled-back? %)) steps)
+          "no schema rollback → no :rolled-back? flags (no spurious rollback chrome)")
       (is (= :error (proj/epoch-outcome steps))
           "the epoch outcome reflects the exception (NOT :ok)")))
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -569,9 +569,12 @@
                      {:step :handler :badge :HANDLER :step-number 3
                       :flavour :reg-event-db :event-id :counter/inc
                       :db-diff [[[:counter :value] 5 6 :modified]]
+                      :db-post-handler {:counter {:value 6}} :db-write? true
                       :fx [] :machine nil}))
             slot (th/find-by-testid tree "rf-xray-epoch-handler-db-diff")]
-        (is (some? slot))))
+        (is (some? slot))
+        (is (= "true" (-> slot second :data-rf-xray-db-write))
+            "a handler that wrote :db reports db-write? true")))
     (testing "reg-event-fx with empty diff still renders the slot"
       (let [tree (rf/with-frame :rf/xray
                    (view/render-handler-step
@@ -582,6 +585,42 @@
             slot (th/find-by-testid tree "rf-xray-epoch-handler-db-diff")]
         (is (some? slot)
             "even reg-event-fx that returned no :db gets the sub-section")))))
+
+(deftest handler-db-no-write-renders-placeholder-not-phantom-test
+  (testing "rf2-wnvid — PHANTOM-`:db` fix. A handler that wrote NO :db
+            (`:db-write?` false — button-15: it threw before returning)
+            renders the `— no :db` placeholder, NOT the full post-cascade
+            app-db (the pre-rf2-wnvid `:db-after` fallback)."
+    (epoch-orchestrator/install!)
+    (frame/reg-frame :rf/xray {})
+    (testing "handler threw → 'handler threw' wording"
+      (let [tree (rf/with-frame :rf/xray
+                   (view/render-handler-step
+                     {:step :handler :badge :HANDLER :step-number 3
+                      :flavour :reg-event-db :event-id :button-deck/throw-handler
+                      :db-diff [] :db-write? false :fx [] :machine nil
+                      :status :error
+                      :errors [{:operation :rf.error/handler-exception
+                                :message "boom"}]}))]
+        (is (some? (th/find-by-testid tree "rf-xray-epoch-handler-db-no-write"))
+            "the no-write placeholder renders")
+        (is (nil? (th/find-by-testid tree "rf-xray-epoch-handler-db-full-with-diff"))
+            "NO phantom full-app-db block")
+        (is (string/includes?
+              (text-of tree "rf-xray-epoch-handler-db-no-write")
+              "handler threw")
+            "placeholder wording names the throw")))
+    (testing "clean handler returning no :db → 'returned no :db' wording"
+      (let [tree (rf/with-frame :rf/xray
+                   (view/render-handler-step
+                     {:step :handler :badge :HANDLER :step-number 3
+                      :flavour :reg-event-fx :event-id :navigate
+                      :db-diff [] :db-write? false
+                      :fx [{:fx-id :navigate :value "/x"}] :machine nil}))]
+        (is (string/includes?
+              (text-of tree "rf-xray-epoch-handler-db-no-write")
+              "returned no :db")
+            "a clean no-:db handler reads 'returned no :db'")))))
 
 (deftest handler-db-diff-suppressed-for-machine-handlers-test
   (testing "rf2-93436 — for machine handlers the standalone `:db diff`
@@ -2289,32 +2328,80 @@
 
 ;; ---- rf2-ahhgn — inline exception card + per-step ✓/✗ + outcome banner ---
 
-(deftest error-block-renders-message-and-coord-test
-  (testing "rf2-ahhgn — `error-block` renders the red exception card with
-            the title, human headline, the verbatim message, and a
-            jump-to-source link reading `file:line`"
+(deftest error-block-renders-message-and-title-test
+  (testing "rf2-ahhgn / rf2-wnvid — `error-block` renders the red card with
+            the 'Exception Thrown' title, the op-derived human headline,
+            and the verbatim message. The redundant jump-to-source link is
+            DROPPED (rf2-wnvid — the HANDLER verb is the canonical link)."
     (let [row  {:operation :rf.error/handler-exception
                 :message "button-deck / handler (intentional — exercises the handler error surface)"
-                :coord {:file "button_deck/core.cljs" :line 322}
                 :failing-id :button-deck/throw-handler
-                :recovery :no-recovery}
+                :recovery :no-recovery
+                ;; a committed-then-rolled-back db → the chip is legitimate
+                :db-committed? true}
           tree (view/error-block :handler 0 row)
           base "rf-xray-epoch-error-handler-0"]
       (is (some? (th/find-by-testid tree base))
           "the exception card wrapper renders")
-      (is (string/includes? (text-of tree (str base "-title")) "Exception")
-          "title reads 'Exception'")
+      (is (string/includes? (text-of tree (str base "-title")) "Exception Thrown")
+          "title reads 'Exception Thrown'")
       (is (string/includes? (text-of tree (str base "-recovery")) "Rolled back")
-          ":no-recovery → 'Rolled back' chip")
+          ":no-recovery + db-committed? → 'Rolled back' chip")
       (is (string/includes? (text-of tree (str base "-headline"))
                             "event handler threw")
           "headline names the handler failure")
       (is (string/includes? (text-of tree (str base "-message"))
                             "intentional")
           "the verbatim ex-info message renders")
-      (is (string/includes? (text-of tree (str base "-source"))
-                            "button_deck/core.cljs:322")
-          "the jump-to-source link reads file:line"))))
+      (is (nil? (th/find-by-testid tree (str base "-source")))
+          "rf2-wnvid — the redundant jump-to-source link is dropped"))))
+
+(deftest error-block-handler-headline-ignores-phase-test
+  (testing "rf2-wnvid — a `:phase :before` handler-exception (button-15's
+            live shape — the handler runs as the terminal :before
+            interceptor) reads 'The event handler threw.', NOT the
+            pre-rf2-wnvid 'An interceptor / coeffect threw (:before).'"
+    (let [tree (view/error-block :handler 0
+                 {:operation :rf.error/handler-exception
+                  :message "boom" :phase :before
+                  :failing-id :button-deck/throw-handler})
+          head (text-of tree "rf-xray-epoch-error-handler-0-headline")]
+      (is (string/includes? head "event handler threw"))
+      (is (not (string/includes? head "interceptor"))
+          "no spurious interceptor/coeffect attribution from :phase"))))
+
+(deftest error-block-no-spurious-rolled-back-test
+  (testing "rf2-wnvid — when NO :db committed (`db-committed?` false /
+            absent — button-15: the handler threw before producing any
+            :db), the 'Rolled back' chip is OMITTED even though the
+            substrate stamped :recovery :no-recovery (nothing to revert)."
+    (let [tree (view/error-block :handler 0
+                 {:operation :rf.error/handler-exception
+                  :message "boom"
+                  :recovery :no-recovery
+                  :db-committed? false})]
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-error-handler-0-recovery"))
+          "no commit → no spurious 'Rolled back' chip"))))
+
+(deftest error-block-collapsible-details-test
+  (testing "rf2-wnvid — when the exception carries a stack / ex-data, the
+            card renders a collapsed `<details>` disclosure rather than an
+            always-expanded block."
+    (let [ex   (ex-info "boom" {:surface :handler-exception})
+          tree (view/error-block :handler 0
+                 {:operation :rf.error/handler-exception
+                  :message "boom"
+                  :exception ex})
+          base "rf-xray-epoch-error-handler-0"]
+      (is (some? (th/find-by-testid tree (str base "-details")))
+          "the collapsible details disclosure renders")
+      (is (some? (th/find-by-testid tree (str base "-ex-data")))
+          "ex-data is surfaced inside the disclosure")))
+  (testing "rf2-wnvid — no exception object → no details disclosure"
+    (let [tree (view/error-block :handler 0
+                 {:operation :rf.error/handler-exception :message "boom"})]
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-error-handler-0-details"))
+          "nothing to disclose → the details element is omitted"))))
 
 (deftest error-block-fx-headline-test
   (testing "rf2-ahhgn — an fx-handler exception names the failing fx-id"
@@ -2325,16 +2412,6 @@
       (is (string/includes? (text-of tree "rf-xray-epoch-error-fx-0-headline")
                             ":http/post")
           "headline names the failing effect"))))
-
-(deftest error-block-degrades-when-coord-absent-test
-  (testing "rf2-ahhgn — no coord → the source link reads a muted
-            'source unavailable' fallback rather than a dead link"
-    (let [tree (view/error-block :handler 0
-                 {:operation :rf.error/handler-exception
-                  :message "boom" :coord nil})]
-      (is (string/includes?
-            (text-of tree "rf-xray-epoch-error-handler-0-source")
-            "source unavailable")))))
 
 (deftest error-blocks-nil-safe-test
   (testing "rf2-ahhgn — `error-blocks` renders nothing for empty / nil"
@@ -2402,13 +2479,7 @@
             (text-of tree "rf-xray-epoch-error-fx-row-1-0-message")
             "fx threw on purpose")))))
 
-(deftest outcome-banner-renders-on-error-test
-  (testing "rf2-ahhgn — the outcome banner renders for `:error` and is
-            absent for `:ok` (silence is the success signal)"
-    (is (some? (th/find-by-testid (view/outcome-banner :error)
-                                  "rf-xray-epoch-outcome-banner"))
-        "an errored cascade paints the red banner")
-    (is (nil? (view/outcome-banner :ok))
-        "a clean cascade paints no banner")
-    (is (nil? (view/outcome-banner nil))
-        "a nil outcome paints no banner")))
+;; `outcome-banner-renders-on-error-test` retired (rf2-wnvid) — the
+;; top-of-pipeline "This event failed" banner is gone; the failure
+;; surfaces inline (the failing step's ✗ glyph + the 'Exception Thrown'
+;; card). The panel root still stamps `data-rf-xray-outcome`.

--- a/tools/xray/test/day8/re_frame2_xray/test_helpers/trace_event_builders.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/test_helpers/trace_event_builders.cljc
@@ -384,17 +384,21 @@
   Drives the HANDLER step's inline error card + the per-step ✗ status.
 
   2-arg form: event-id + message. The 3-arg form adds the source-coord;
-  the 4-arg form adds the interceptor `:phase` (`:before` / `:after`)."
-  ([event-id message] (handler-exception-ev event-id message nil nil))
-  ([event-id message coord] (handler-exception-ev event-id message coord nil))
-  ([event-id message coord phase]
+  the 4-arg form adds the interceptor `:phase` (`:before` / `:after`);
+  the 5-arg form adds the raw `:exception` object (rf2-wnvid — the Epoch
+  card's collapsible details read the stack / ex-data off it)."
+  ([event-id message] (handler-exception-ev event-id message nil nil nil))
+  ([event-id message coord] (handler-exception-ev event-id message coord nil nil))
+  ([event-id message coord phase] (handler-exception-ev event-id message coord phase nil))
+  ([event-id message coord phase exception]
    (cond-> (ev :error :rf.error/handler-exception
                (cond-> {:event-id          event-id
                         :handler-id        event-id
                         :failing-id        event-id
                         :exception-message message
                         :reason            "Event handler threw."}
-                 phase (assoc :phase phase)))
+                 phase     (assoc :phase phase)
+                 exception (assoc :exception exception)))
      true     (assoc :recovery :no-recovery)
      coord    (assoc :rf.trace/trigger-handler {:kind         :event
                                                 :id           event-id


### PR DESCRIPTION
Refines the inline exception rendering rf2-ahhgn shipped (#2527) and reconciles with rf2-kt6js's SIDE EFFECTS `:db` sub-step (#2533). Polishes the handler-exception presentation Mike exercised live on button-15 (`:button-deck/throw-handler`).

## Settle-first findings (post-kt6js, live button-15 via re-frame2-pair)

Verified the live throw-handler epoch on the running `examples/button-deck` build: `:db-before == :db-after`, `:effects []`, framework `:outcome :ok`, trace ops `[:rf.event/dispatched :rf.event/run-start :rf.flow/skip :rf.error/handler-exception :rf.event/run-end]`, handler-exception tags `{:category :rf.error/handler-exception :phase :before :reason "Event handler threw." :recovery :no-recovery}`, `:rf.trace/trigger-handler` / `:call-site` both nil, exception object at `[:tags :exception]` with a `.stack`.

All four symptoms **still reproduced** after kt6js:

- **Phantom `:db`** — kt6js correctly omits the SIDE EFFECTS `:db` row (`db-commit?` keys off `:rf.event/db-changed`, absent here). But the **HANDLER step's own `:db` sub-section** fell back to the record's full post-cascade `:db-after` when `:db-post-handler` was nil, painting the entire app-db as if the handler returned it.
- **Wrong cause text** — the card read "An interceptor / coeffect threw (:before)." for a plain handler throw, because it keyed off `:phase :before` (the handler runs as the terminal `:before` interceptor; the substrate routes handler/interceptor/cofx throws ALL through `:rf.error/handler-exception` with the same `:reason` + `:phase`).
- **Spurious "Rolled back"** — the chip painted off `:recovery :no-recovery` (stamped on every handler-exception) even though nothing committed (`:effects []`, db unchanged → nothing to revert).
- **Top banner + redundant source link** — the banner ("This event failed…") was present; the error-card source link resolved to a useless "source unavailable" on the live trace (no coord), duplicating the HANDLER verb's canonical jump-to-source.

## Fixes

- **No phantom `:db`** — `projection/handler-wrote-db?` + a `:db-write?` HANDLER-row slot; the view renders `— no :db (handler threw)` / `— no :db (handler returned no :db)` instead of the full app-db fallback.
- **Cause text** — `error-block-label` derives attribution from `:operation`, NOT `:phase` → "The event handler threw."
- **No spurious "Rolled back"** — the chip is gated on a cascade-level `:db-committed?` (presence of a `:rf.event/db-changed` commit / schema rollback), stamped onto each exception row in `project`. No commit → no chip.
- **"Exception Thrown" block + collapsible details (ALL kinds)** — title renamed; the redundant jump-to-source link dropped; a native `<details>` disclosure (collapsed) now carries the exception's stack + `ex-data` (the projection lifts the raw `:exception` object onto the row).
- **Top banner retired** — the inline ✗ glyph + error card already name and locate the failure.

Reuses ahhgn's `step-status` + `badge/step-status-*` + kt6js's SIDE-EFFECTS row structure. Dead styles/helpers removed. `spec/021` §9.1.10.4 / §9.1.10.5 updated (incl. fixing the FX→SIDE EFFECTS attachment-table staleness from kt6js).

## Quality gates

- `npm run test:cljs` — **5081 tests, 17072 assertions, 0 failures / 0 errors**. New tests: `handler-wrote-db?`, `:db-write?` slot, no-phantom-`:db` placeholder (threw + clean-no-db wording), `exception-row` `:exception` lift, headline-ignores-phase, no-spurious-rolled-back, collapsible details, end-to-end `:db-committed?` + no `:rolled-back?` flags.
- `npm run test:xray-feature-gate` — **14 scenarios, 0 failures, 13 matrix rows** (incl. the `deliberate-throw` exception surface).
- `npm run test:bundle-isolation` — **PASS** (tools absent from production bundles).
- clj-kondo — **0 errors, 0 new warnings** (src warnings identical to base; test-file warnings reduced 3→2 by removing the dead `outcome-banner` reference).
