### PR TITLE
ci(story): upload the run-artifact on browser-gate failure (rf2-315cf, Option B)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1339,6 +1339,33 @@ jobs:
       - name: Run Story :play-script CI-as-test gate
         run: npm run test:story-play-scripts
 
+      # rf2-315cf (Option B) — on a RED browser gate, upload the failed-run
+      # evidence so the failure is a downloadable, off-CI post-mortem
+      # (spec/017 §Failed-run artifacts in CI). Two paths are surfaced:
+      #   - implementation/out/story-play-scripts/ — the play-script run
+      #     evidence (per-row expected/actual + per-step diagnostics) the
+      #     runner persists ONLY when a play deviates from its expected
+      #     status (rf2-5x1wt.7 run-evidence projection).
+      #   - implementation/out/xray-feature-gate-artifacts/ — the Xray
+      #     feature-gate failure screenshots + diagnostics the gate already
+      #     writes on a failing scenario.
+      # `if: failure()` scopes the upload to a red run; `if-no-files-found:
+      # ignore` keeps a partial failure (e.g. the xray step failed before
+      # the play-scripts step ran, or vice versa) from turning the upload
+      # itself red. The dedicated capability-routed (:pixels / :a11y-engine)
+      # browser-tier gate is DEFERRED per Mike's 2026-05-31 ruling — this
+      # bead wires ONLY the failed-run artifact upload on the existing gate.
+      - name: Upload failed browser-gate run evidence (rf2-315cf)
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: story-xray-browser-failed-run-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            implementation/out/story-play-scripts/
+            implementation/out/xray-feature-gate-artifacts/
+          if-no-files-found: ignore
+          retention-days: 14
+
   cljs-reagent-slim-bundle-isolation:
     name: CLJS Reagent Slim bundle isolation (adapter-owned, rf2-2ppcv)
     needs: detect_changed_surfaces

--- a/examples/scripts/serve-and-run-story-play-scripts.cjs
+++ b/examples/scripts/serve-and-run-story-play-scripts.cjs
@@ -53,6 +53,20 @@ const { resolveStoryFeatureLoadPort } = require('./story-feature-load-port.cjs')
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
 const IMPL_ROOT = path.join(REPO_ROOT, 'implementation');
 const OUT_ROOT = path.join(IMPL_ROOT, 'out', 'examples');
+// rf2-315cf: on a RED gate, persist the per-row run evidence the runner
+// already computed to a stable path so the browser-gate workflow can
+// upload it as a downloadable post-mortem (spec/017
+// §Failed-run artifacts in CI). The substrate guarantees the low-level
+// `:rf.test/run-artifact` (seed / event-program / epoch tape) EXISTS and
+// is canonicalizable, but the play-scripts CI hook surfaces only the
+// projected run-state (status + per-step results) — that projection is
+// the failure record this gate genuinely holds, and serialising the
+// full replayable artifact is a substrate change, not CI mechanics.
+const FAILURE_REPORT_DIR = path.join(IMPL_ROOT, 'out', 'story-play-scripts');
+const FAILURE_REPORT_PATH = path.join(
+  FAILURE_REPORT_DIR,
+  'failure-report.json',
+);
 const TESTBED_BUILD = 'examples/counter-with-stories';
 const TESTBED_DIR_NAME = 'counter-with-stories';
 const TESTBED_HTML = path.join(
@@ -337,6 +351,49 @@ function summariseResults(results) {
 }
 
 /**
+ * rf2-315cf — persist the run evidence for a RED gate to a stable path
+ * so the browser-gate workflow's `if: failure()` upload step can surface
+ * it as a downloadable post-mortem (spec/017 §Failed-run artifacts in CI).
+ *
+ * This is the projected run-state evidence the runner already computed:
+ * per-row expected/actual status plus the per-step diagnostics
+ * (idx / type / message / expected / actual). It is NOT the full
+ * low-level `:rf.test/run-artifact` (seed / event-program / epoch tape) —
+ * the play-scripts CI hook surfaces only the projected state, and
+ * serialising the replayable artifact is a substrate change, not CI
+ * mechanics. The play's `:script` (the event program) lives in the
+ * variant body, so a maintainer can pair this report with the named
+ * variant/play to reproduce off-CI.
+ *
+ * Best-effort: a write failure here must never mask the real gate verdict,
+ * so it is logged and swallowed.
+ */
+function writeFailureReport(failures, allResults, browserMessages) {
+  const report = {
+    gate: 'story-play-scripts',
+    bead: 'rf2-5x1wt.7 / rf2-315cf',
+    capturedAt: new Date().toISOString(),
+    totalRows: allResults.length,
+    unexpectedOutcomes: failures.length,
+    failures: failures.map((r) => ({
+      variantId: r.variantId,
+      playKey: r.playKey || null,
+      expected: r.expected,
+      actual: (r.runState && r.runState.status) || 'no-state',
+      steps: (r.runState && r.runState.results) || [],
+    })),
+    browserDiagnostics: browserMessages.slice(-40),
+  };
+  try {
+    fs.mkdirSync(FAILURE_REPORT_DIR, { recursive: true });
+    fs.writeFileSync(FAILURE_REPORT_PATH, `${JSON.stringify(report, null, 2)}\n`);
+    log(`Wrote failed-run evidence to ${FAILURE_REPORT_PATH}`);
+  } catch (err) {
+    log(`(warning) could not write failure report: ${err.message}`);
+  }
+}
+
+/**
  * Group ci-rows by variant id so we navigate ONCE per variant and
  * then drive each row's play locally.
  */
@@ -444,6 +501,9 @@ async function runAllVariants(browser, baseUrl) {
     if (failures.length > 0 && browserMessages.length > 0) {
       log('--- browser diagnostics ---');
       for (const msg of browserMessages.slice(-40)) log(msg);
+    }
+    if (failures.length > 0) {
+      writeFailureReport(failures, results, browserMessages);
     }
     return failures.length === 0 ? 0 : 1;
   } finally {


### PR DESCRIPTION
Implements **rf2-315cf — Option B** (Mike RULED 2026-05-31): wire ONLY the failed-run artifact upload on the **existing** browser gate. The dedicated capability-routed (`:pixels` / `:a11y-engine`) browser-tier gate is **deliberately deferred** per the ruling (the costly half — CI minutes — not worth it while the coarse `story-xray-browser` PR-smoke split already runs the browser tests).

## What changed

On the existing `story-xray-browser` PR-smoke job in `.github/workflows/test.yml` (the job that runs `test:xray-feature-gate:smoke` + `test:story-play-scripts`), add an `if: failure()` step that uploads the failed browser-gate run evidence as a downloadable CI artifact, so a red gate yields a replayable, off-CI post-mortem (spec/017 §*Failed-run artifacts in CI*).

Two paths are uploaded:
- `implementation/out/story-play-scripts/failure-report.json`
- `implementation/out/xray-feature-gate-artifacts/` (screenshots + diagnostics the Xray gate already writes on a failing scenario)

### Settle-first finding (artifact path)

The `story-play-scripts` runner did **not** previously persist anything to disk — it only logged to stdout, and the CI hook (`window.__rf2_story_ci`) surfaces only the projected run-state (status + per-step results), **not** the full low-level `:rf.test/run-artifact` (seed / event-program / epoch tape). Per the task's settle-first clause ("wire the minimal step to surface it"), this PR makes `serve-and-run-story-play-scripts.cjs` write the projected run-state evidence it **already computes** to a stable path — `implementation/out/story-play-scripts/failure-report.json` — **only when a play deviates from its expected status**. That projection (per-row expected/actual + per-step idx/type/message/expected/actual) is the failure record this gate genuinely holds.

I did **not** invent a seed/event-program/epoch-tape serialization the gate never captures. spec/017 guarantees the `:rf.test/run-artifact` *exists and is canonicalizable*, but serializing the full replayable artifact from this gate is a **substrate** change, not CI mechanics — out of scope for this CI-only bead. The play's `:script` (the event program) lives in the variant body, so a maintainer pairs the report's named variant/play with the registered body to reproduce off-CI.

`if-no-files-found: ignore` keeps a partial failure (e.g. the xray step fails before the play-scripts step runs) from reddening the upload itself.

## HOT-ZONE flag

`.github/workflows/*` is on the fixed hot-zone list. This PR touches `.github/workflows/test.yml`. I was the sole workflow-toucher for this dispatch. **Do not `--admin` past any workflow-gate failure** — investigate instead.

## Deferred (per Mike)

The dedicated capability-routed (`:pixels` / `:a11y-engine`) browser-tier gate that selects variants by `:required-runner` and runs them under a real-browser runner is **NOT** wired here — explicitly deferred. spec/017 §*Browser-tier gate policy* already scopes that wiring out of the spec.

## Quality gates

- **actionlint 1.7.7**: clean (exit 0) on `test.yml` + `expensive-tests.yml`, and across all `.github/workflows/`. Includes the shellcheck pass on `run:` blocks.
- **`node --check`** on `serve-and-run-story-play-scripts.cjs`: OK.
- **YAML parse**: `yaml.safe_load(test.yml)` OK.
- **`actions/upload-artifact` SHA pin**: `ea165f8d65b6e75b540449e92b4886f43607fa02` verified as the genuine `v4.6.2` tag commit via the GitHub API (matches the repo's SHA-pin convention).
- **Cannot exercise a real CI failure locally** — the new `if: failure()` step and the runner's on-failure write path are CI-verified on the next red browser-gate run. The runner change is inert on a green run (no failures → no report written → `if-no-files-found: ignore`).
