### PR TITLE
feat(xray/epoch): light-pink row bg for events whose epoch has an issue (rf2-b8guz, supersedes tszij)

### DIFF
--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/theme/tokens.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/theme/tokens.cljc
@@ -113,6 +113,13 @@
    ;; violation wash (rf2-xgeag · key parity mirror with Xray)
    :bg-violation   "#3a1f25"
 
+   ;; L2 issue-row wash (rf2-b8guz · key parity mirror with Xray) — the
+   ;; light-pink wash Xray paints behind an L2 event row whose epoch
+   ;; contains an issue. machines-viz never paints it, but the drift gate
+   ;; (rf2-z7ms8) requires the dark-palette key set to match Xray's, so the
+   ;; token is mirrored here at its Xray value.
+   :bg-issue-row   "#f8514926"
+
    ;; functional categorical hues (spec/022 carve-out)
    ;; Two pink/violet-family hues — see Xray's `dark-palette` block for
    ;; rationale. The drift gate (rf2-z7ms8) requires these to match Xray's
@@ -209,6 +216,12 @@
 
    ;; violation wash (rf2-xgeag · key parity mirror with Xray)
    :bg-violation   "#fde0e3"
+
+   ;; L2 issue-row wash (rf2-b8guz · key parity mirror with Xray) — the
+   ;; light-theme mirror of Xray's `:bg-issue-row`. machines-viz never
+   ;; paints it; mirrored here at its Xray value so the two light palettes
+   ;; stay symmetric (the dark drift gate asserts full key-set parity).
+   :bg-issue-row   "#c844442e"
 
    ;; functional categorical hues
    ;; Two pink/violet-family hues — see Xray's `light-palette` block for

--- a/tools/xray/spec/018-Event-Spine.md
+++ b/tools/xray/spec/018-Event-Spine.md
@@ -361,6 +361,39 @@ in the L4 Event + Issues + Trace panels (the panels read the cascade's
 silent-by-default indicator on the chrome ribbon; see §12 for the full
 data-classification rendering contract.
 
+#### Issue-epoch row wash (rf2-b8guz)
+
+A row whose epoch **contains an issue** carries a **light-pink row
+background wash** — the per-event "something went wrong here" signal at the
+spine, surfaced where the operator is already looking rather than gated
+behind the Issues tab. This is the chosen visual for the event-row issue
+signal (it **supersedes** the earlier "warning indicator / icon" idea
+rf2-tszij — a wash, not a glyph, because the L2 row is intentionally
+glyph-free post-rf2-pjjwh).
+
+- **"contains an issue"** is the SAME set the Issues ribbon/feed aggregates
+  — errors + warnings + schema violations + hydration mismatches +
+  perf-budget overruns + app console errors. The renderer reuses the
+  canonical Issues predicate (`issues-ribbon-helpers/issue-event?`, applied
+  over the cascade's `:other` bucket via
+  `l2-timeline/cascade-has-issue?`) rather than re-enumerating what counts
+  as an issue, so the wash stays in lockstep with the ribbon/feed by
+  construction. It is the SAME trace-derived signal the Epoch panel's
+  per-step `:status` + `epoch-outcome` and `event-status-colour/
+  cascade-outcome` key off (rf2-ahhgn): a cascade carrying any issue trace
+  lights up. ONE light pink for ANY issue (Mike default — warnings are not
+  given a distinct shade from errors).
+- **Colour** is the `:bg-issue-row` theme token (a low-opacity rose wash —
+  the same hue family as the `:bg-violation` schema-violation wash, rendered
+  through the per-theme CSS variable so it reads rose in both light + dark
+  themes). See [`022-Design-Tokens.md`](022-Design-Tokens.md).
+- **Composes, does not clobber:** the wash is painted as a flat
+  `background-image` gradient layer over the row's `background-color`, so it
+  coexists with the selected/focused-row highlight (an issue row reads pink
+  whether focused or not, with the focus state intact underneath), the LIVE
+  head-pulse, and any cross-epoch perf-budget chrome. A clean (non-issue)
+  row carries no wash.
+
 ### Row variants
 
 ONE shape, decorated:

--- a/tools/xray/spec/022-Design-Tokens.md
+++ b/tools/xray/spec/022-Design-Tokens.md
@@ -87,6 +87,16 @@ one edit per token.
   `info`). `info` shares `advisory`'s hue — both are the GitHub syntax-number blue.
 - **app-db diff:** added → `success`, removed → `error`, changed → `warning` (reuse the
   semantic tokens; no new colours).
+- **Low-opacity row washes:** a few surfaces tint a whole ROW rather than colour text — the
+  schema-violation sub-block wash (`bg-violation`, a rose surface), the app-db-diff per-op
+  washes (`diff-added-wash` / `diff-modified-wash` / `diff-removed-wash`, 8-digit-hex
+  `#RRGGBBAA` at ~10-12%), and the **L2 issue-epoch row wash** (`bg-issue-row`, rf2-b8guz — a
+  light-pink rose wash, same hue family as `bg-violation`, painted behind any L2 event row whose
+  epoch carries an issue per the canonical Issues predicate; see
+  [`018-Event-Spine.md`](018-Event-Spine.md) §Issue-epoch row wash). Washes are deliberately low
+  alpha so the row text + other row signals stay legible and the wash COMPOSES over the
+  selected/focused-row background. Full hex values live in `theme/tokens.cljc` (the source of
+  truth for every token).
 - **Views / recompute:** changed/recomputed highlight → `changed` (= `accent`); unchanged /
   short-circuited → `unchanged` (= `dim`). Use the accent sparingly (the changed node, not whole
   rows) so the UI doesn't over-saturate.

--- a/tools/xray/src/day8/re_frame2_xray/panels/l2_timeline.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/l2_timeline.cljc
@@ -77,7 +77,8 @@
   | `:machine-spawn`                                                 | `:machine-spawn`| `i` chip   |
   | `:websocket`                                                     | `:websocket`    | `🌊` glyph |
   | unknown / nil                                                    | nil             | (nothing)  |"
-  (:require [clojure.string :as str]))
+  (:require [clojure.string :as str]
+            [day8.re-frame2-xray.panels.issues-ribbon-helpers :as issues]))
 
 ;; ---- 1. source prefix (post-rf2-1ve9h) ----------------------------------
 
@@ -360,6 +361,45 @@
      :http?    (has-http-op? others)
      :timer?   (or (has-timer-op? others) (= :timer bucket))
      :fx-emit? (= :fx-emit bucket)}))
+
+;; ---- 2b. epoch-has-an-issue signal (rf2-b8guz) --------------------------
+;;
+;; The L2 row paints a light-pink WASH (theme token `:bg-issue-row`) when
+;; the event's epoch CONTAINS AN ISSUE — the cross-epoch "this event had a
+;; problem" cue at the spine, surfaced where the operator is already
+;; looking rather than gated behind the Issues tab.
+;;
+;; "CONTAINS AN ISSUE" is the SAME set the Issues ribbon/feed aggregates:
+;; errors + warnings + schema violations + hydration mismatches +
+;; perf-budget overruns + app console errors. We reuse the canonical
+;; `issues-ribbon-helpers/issue-event?` predicate (severity-driven off
+;; `:op-type`, per Spec 009) rather than re-enumerating what counts as an
+;; issue — so the wash stays in lockstep with the ribbon/feed by
+;; construction. This is the SAME trace-derived signal the Epoch panel's
+;; `epoch-outcome` + `event-status-colour/cascade-outcome` key off
+;; (rf2-ahhgn): a cascade carrying any issue trace lights up.
+;;
+;; Source of the issue traces on a cascade record: every non-domino trace
+;; event (errors / warnings / …) lands in the cascade's `:other` bucket
+;; (`re-frame.trace.projection/group-cascades` · `domino-bucket` →
+;; `:other`); the cascade's existing `:errors` slot is checked too for
+;; defence in depth (synthetic fixtures / older traces that populated it
+;; directly).
+
+(defn cascade-has-issue?
+  "True iff this cascade's epoch CONTAINS AN ISSUE — i.e. any trace event
+  in the cascade's `:other` bucket (or its `:errors` slot) is an issue per
+  the canonical `issues-ribbon-helpers/issue-event?` predicate (errors +
+  warnings + advisories — the SAME set the Issues ribbon/feed aggregates,
+  reused rather than re-enumerated). Drives the L2 row's light-pink
+  `:bg-issue-row` wash (rf2-b8guz).
+
+  Pure data → bool; nil-safe on missing slots; JVM-runnable."
+  [cascade]
+  (boolean
+    (when (map? cascade)
+      (or (some issues/issue-event? (:other cascade))
+          (seq (:errors cascade))))))
 
 (def activity-badge-glyphs
   "Pure-data badge map. Render order is fixed — issues first (the

--- a/tools/xray/src/day8/re_frame2_xray/shell.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/shell.cljs
@@ -1443,6 +1443,21 @@
         ;; No border ring, no trailing status stripe — those are not in
         ;; the mock.
         bg          (if focused? (:hover tokens) "transparent")
+        ;; rf2-b8guz — light-pink WASH when this event's epoch CONTAINS
+        ;; AN ISSUE (any error / warning / schema-violation / … — the
+        ;; SAME set the Issues ribbon/feed aggregates, via the canonical
+        ;; `l2-timeline/cascade-has-issue?` predicate). The cross-epoch
+        ;; "this event had a problem" cue at the spine. Painted as a flat
+        ;; `:background-image` gradient layer (the `:bg-issue-row` token,
+        ;; a low-opacity rose wash) so it COMPOSES OVER the focused-row /
+        ;; hover `:background-color` rather than clobbering it — an issue
+        ;; row reads pink whether focused or not, and the focus highlight
+        ;; survives underneath. Nil when no issue, so a clean row paints
+        ;; only its base background.
+        has-issue?  (l2-timeline/cascade-has-issue? cascade)
+        issue-wash  (when has-issue?
+                      (str "linear-gradient(" (:bg-issue-row tokens) ", "
+                           (:bg-issue-row tokens) ")"))
         ;; rf2-ieg6d Bug 1 — only the focused row in the LIVE-at-head
         ;; auto-tracking branch carries a ref. RETRO and non-focused rows
         ;; get nil (no DOM-side scroll work, no per-render cost).
@@ -1469,6 +1484,11 @@
     ;; right-click users get. The audit (2026-05-20) flagged this
     ;; surface as P1 because the menu's actions had no keyboard path.
     [:li (cond-> {:data-testid (str "rf-xray-event-row-" (str id))
+                  ;; rf2-b8guz — machine-readable issue-row flag so the
+                  ;; light-pink-wash contract is pinnable from a CLJS unit
+                  ;; test (issue epoch → "true"; clean row → absent) without
+                  ;; parsing the inline gradient string.
+                  :data-rf-xray-issue-row (when has-issue? "true")
                   :role        "button"
                   :tab-index   "0"
                   :aria-label  (if ev-id
@@ -1552,7 +1572,15 @@
                           ;; ONLY. The `1px solid transparent` border
                           ;; keeps border-box alignment with the header so
                           ;; columns never drift.
-                          :background    bg
+                          ;;
+                          ;; rf2-b8guz — split into `:background-color`
+                          ;; (the focus / hover highlight) + a flat
+                          ;; `:background-image` wash layer (the issue-row
+                          ;; rose, nil when no issue). The wash COMPOSITES
+                          ;; over the highlight so an issue row reads pink
+                          ;; with the focus state intact underneath.
+                          :background-color bg
+                          :background-image issue-wash
                           :border        "1px solid transparent"
                           :border-radius "2px"
                           :font-family   mono-stack

--- a/tools/xray/src/day8/re_frame2_xray/theme/tokens.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/theme/tokens.cljc
@@ -123,6 +123,21 @@
    ;; without overpowering the cascade.
    :bg-violation   "#3a1f25"   ; deep-rose-muted (dark)
 
+   ;; ── L2 issue-row wash (rf2-b8guz) ──
+   ;; Light-pink LOW-OPACITY wash painted as the background of an L2
+   ;; event row whose epoch CONTAINS AN ISSUE (any error / warning /
+   ;; schema-violation / hydration-mismatch / perf-overrun trace — the
+   ;; SAME set the Issues ribbon/feed aggregates, keyed off the
+   ;; trace-derived per-cascade issue signal). The cross-epoch
+   ;; "this event had a problem" cue at the spine — surfaced where the
+   ;; operator is already looking, not gated behind the Issues tab.
+   ;; Same rose hue as `:bg-violation` but as an 8-digit-hex wash
+   ;; (#RRGGBBAA, mirroring the `:diff-*-wash` pattern) so it COMPOSES
+   ;; over the focused-row / hover background without clobbering it.
+   ;; Alpha `26` = 38/255 ≈ 15% — operator-noticeable over the dark
+   ;; canvas while the row text + existing L2 signals stay legible.
+   :bg-issue-row   "#f8514926"  ; :error rose @ ~15% (dark)
+
    ;; ── functional categorical hues (spec/022 carve-out · spec 007) ──
    ;; These do REAL semantic work — perf tiers, machine state, route
    ;; side-channel, redaction, op-family legends — and are NOT collapsed
@@ -299,6 +314,15 @@
    ;; Light-theme mirror of the dark `:bg-violation`. A soft rose
    ;; pink — alert-grade on white without overpowering the cascade.
    :bg-violation   "#fde0e3"   ; soft-rose (light)
+
+   ;; ── L2 issue-row wash (rf2-b8guz) ──
+   ;; Light-theme mirror of the dark `:bg-issue-row`. The light-pink
+   ;; wash painted behind an L2 row whose epoch contains an issue. An
+   ;; 8-digit-hex wash (#RRGGBBAA) so it composes over the focused-row
+   ;; / hover background. Light-theme washes need a touch more alpha
+   ;; than dark ones to read over the near-white canvas — alpha `2e` =
+   ;; 46/255 ≈ 18% of the light-error rose.
+   :bg-issue-row   "#c844442e"  ; :error rose @ ~18% (light)
 
    ;; ── functional categorical hues (spec/022 carve-out · spec 007) ──
    :green          "#1a7f37"

--- a/tools/xray/test/day8/re_frame2_xray/panels/l2_timeline_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/l2_timeline_cljs_test.cljc
@@ -331,6 +331,53 @@
               :timer? false :fx-emit? true}
              flags)))))
 
+;; ---- 4b. epoch-has-an-issue signal (rf2-b8guz) --------------------------
+;;
+;; `cascade-has-issue?` drives the L2 row's light-pink `:bg-issue-row`
+;; wash. It must light up for EXACTLY the set the Issues ribbon/feed
+;; aggregates — it reuses `issues-ribbon-helpers/issue-event?`, which is
+;; severity-driven off `:op-type` (`:error` / `:warning` / `:info`), so a
+;; lifecycle / success-path trace (no severity `:op-type`) is NOT an issue.
+
+(deftest cascade-has-issue?-clean-test
+  (testing "a clean cascade (no issue traces) → false; nil-safe"
+    (is (false? (l2/cascade-has-issue? {})))
+    (is (false? (l2/cascade-has-issue? nil)))
+    (is (false? (l2/cascade-has-issue? "not a cascade")))
+    (is (false? (l2/cascade-has-issue? (cascade-with-source :ui))))
+    ;; lifecycle / success-path traces in :other are NOT issues — the
+    ;; row must stay unstyled (no wash) for a clean cascade that merely
+    ;; carried machine / frame / registry chatter.
+    (is (false? (l2/cascade-has-issue?
+                 {:other [(ev :rf.machine/transition :op-type :rf.machine)
+                          (ev :rf.frame/created      :op-type :rf.frame)]})))))
+
+(deftest cascade-has-issue?-issue-test
+  (testing "an error trace (`:op-type :error`) in :other → true"
+    (is (true? (l2/cascade-has-issue?
+                {:other [(ev :rf.error/handler-exception :op-type :error)]}))))
+
+  (testing "a warning trace (`:op-type :warning`) in :other → true"
+    (is (true? (l2/cascade-has-issue?
+                {:other [(ev :rf.warning/schema-violation :op-type :warning)]}))))
+
+  (testing "an advisory trace (`:op-type :info`) in :other → true — the
+            wash covers the FULL Issues set (error + warning + advisory),
+            matching the Issues ribbon/feed"
+    (is (true? (l2/cascade-has-issue?
+                {:other [(ev :rf.ssr/hydration-mismatch :op-type :info)]}))))
+
+  (testing "the cascade's legacy :errors slot alone → true (defence in
+            depth for synthetic / older traces that populate it directly)"
+    (is (true? (l2/cascade-has-issue?
+                {:errors [{:operation :rf.error/no-such-fx}]}))))
+
+  (testing "an issue mixed with lifecycle chatter still lights up"
+    (let [c (-> (cascade-with-source :fx-dispatch)
+                (assoc :other [(ev :rf.machine/transition :op-type :rf.machine)
+                               (ev :rf.error/handler-exception :op-type :error)]))]
+      (is (true? (l2/cascade-has-issue? c))))))
+
 ;; ---- 5. activity-badges projection --------------------------------------
 
 (deftest activity-badges-empty-test

--- a/tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs
@@ -1158,6 +1158,59 @@
                (:text-align (style-of r-duration)))
             "header duration and row duration both right-align")))))
 
+;; ---- rf2-b8guz — light-pink row bg for issue-bearing epochs -------------
+;;
+;; The L2 row paints a light-pink WASH (`:bg-issue-row` token, painted as a
+;; flat `:background-image` gradient layer so it composes OVER the focus /
+;; hover `:background-color`) when its epoch CONTAINS AN ISSUE — keyed off
+;; the canonical `l2-timeline/cascade-has-issue?` predicate, which reuses
+;; the same Issues-ribbon `issue-event?` set. The `:li` carries
+;; `data-rf-xray-issue-row="true"` for the issue case (absent otherwise) so
+;; the contract is pinnable without parsing the inline gradient string.
+
+(defn- error-trace-ev
+  "An `:rf.error/*` trace event (`:op-type :error`) carrying the SAME
+  `:rf.trace/dispatch-id` as a cascade so `group-cascades` buckets it into
+  that cascade's `:other` slot — the canonical 'this epoch had an issue'
+  signal (mirrors button-15's `:rf.error/handler-exception`)."
+  [id]
+  {:id           (+ id 2000)
+   :op-type      :error
+   :operation    :rf.error/handler-exception
+   :tags         {:frame                :rf/default
+                  :rf.trace/dispatch-id id}})
+
+(deftest event-row-issue-epoch-gets-pink-wash
+  (testing "rf2-b8guz — a row whose epoch carries an issue trace gets the
+            light-pink `:bg-issue-row` wash (painted as a `:background-
+            image` layer) + the `data-rf-xray-issue-row` flag. A clean row
+            carries neither — the wash is the per-event 'something went
+            wrong here' signal at the spine."
+    (xray-setup!)
+    ;; cascade 1 — clean. cascade 2 — carries an :rf.error/* trace.
+    (trace-collector/seed-trace-for-test! (dispatch-trace-ev 1 [:cart/add-item]))
+    (trace-collector/seed-trace-for-test! (dispatch-trace-ev 2 [:button-deck/throw-handler]))
+    (trace-collector/seed-trace-for-test! (error-trace-ev 2))
+    (rf/with-frame :rf/xray
+      (let [tree       (shell/shell-view)
+            clean-row  (find-by-testid tree "rf-xray-event-row-1")
+            issue-row  (find-by-testid tree "rf-xray-event-row-2")]
+        (is (some? clean-row) "the clean cascade's row renders")
+        (is (some? issue-row) "the issue cascade's row renders")
+        ;; issue row — flagged + washed
+        (is (= "true" (:data-rf-xray-issue-row (second issue-row)))
+            "issue row carries data-rf-xray-issue-row=true")
+        (is (some? (:background-image (style-of issue-row)))
+            "issue row paints the pink wash via :background-image")
+        (is (re-find #"--rf-xray-bg-issue-row"
+                     (str (:background-image (style-of issue-row))))
+            "the wash reads the :bg-issue-row theme token (rose in both themes)")
+        ;; clean row — neither flag nor wash
+        (is (nil? (:data-rf-xray-issue-row (second clean-row)))
+            "clean row carries no issue flag")
+        (is (nil? (:background-image (style-of clean-row)))
+            "clean row paints no wash")))))
+
 (deftest event-list-suppresses-ungrouped-cascade-placeholder
   (testing "per rf2-639lc Bug 1 the L2 list filters out the `:ungrouped`
             cascade produced by group-cascades for registry-time emits /
@@ -2508,8 +2561,16 @@
             row   (find-by-testid tree "rf-xray-event-row-1")
             style (:style (second row))]
         (is (some? row) "the focused row renders")
-        (is (= (:hover tokens) (:background style))
+        ;; rf2-b8guz — the row's fill moved from the `:background`
+        ;; shorthand to an explicit `:background-color` so the issue-row
+        ;; wash can ride as a separate `:background-image` layer that
+        ;; composes over (not clobbers) the focus highlight.
+        (is (= (:hover tokens) (:background-color style))
             "focused row background is the subtle :hover fill")
+        ;; a clean focused cascade carries NO issue wash — only the
+        ;; focus-highlight background-color, no overlay layer.
+        (is (nil? (:background-image style))
+            "a clean focused row paints no issue wash")
         (is (= "1px solid transparent" (:border style))
             "focused row border is the transparent base — NO blue ring")
         (is (not= (str "1px solid " (:accent tokens)) (:border style))


### PR DESCRIPTION
## What

The Xray **L2 events list** now paints a **light-pink row-background WASH** on any event row whose epoch **contains an issue** — the per-event "something went wrong here" signal surfaced at the spine, where the operator is already looking, rather than gated behind the Issues tab. Implements rf2-b8guz.

NOT an icon — a wash. The L2 row is intentionally glyph-free post-rf2-pjjwh; the issue cue is a background tint, ONE light pink for ANY issue (Mike default — no distinct error/warning shade).

## Issue signal keyed off (settle-first)

The canonical **Issues predicate**, reused not reinvented:

- New pure helper `l2-timeline/cascade-has-issue?` applies `issues-ribbon-helpers/issue-event?` over the cascade's `:other` bucket (where errors / warnings / advisories land per `re-frame.trace.projection/group-cascades`) plus the `:errors` slot for defence in depth.
- This is the **same trace-derived `:error`/issue signal** the Epoch panel's per-step `:status` + `epoch-outcome` and `event-status-colour/cascade-outcome` compute (the tool-side cascade-outcome shipped by **rf2-ahhgn #2527**). A cascade carrying any `:rf.error/*` / `:op-type :error|:warning|:info` trace lights up — **no new instrumentation**.
- The wash set is therefore in lockstep with the Issues ribbon/feed (errors + warnings + advisories) by construction.

## Token used

New `:bg-issue-row` theme token — a low-opacity rose wash (same hue family as the existing `:bg-violation` schema-violation wash), as 8-digit-hex (`#RRGGBBAA`) mirroring the `:diff-*-wash` pattern so it satisfies the rf2-on4cm palette-hex gate. `#f8514926` (~15%) dark / `#c844442e` (~18%) light. Added to both Xray palettes and **mirrored into the machines-viz palette** to keep the rf2-z7ms8 key-set drift gate green.

## Composes, does not clobber

The row's fill moved from the `:background` shorthand to an explicit `:background-color` (focus / hover highlight) plus a flat `:background-image` gradient wash layer that composites **over** it — an issue row reads pink whether focused or not, with the focus highlight intact underneath. A `data-rf-xray-issue-row="true"` attribute makes the state machine-pinnable.

## Supersedes rf2-tszij

This **supersedes rf2-tszij** (which proposed a warning *indicator / icon* on the event row). b8guz = the chosen visual = pink row background, not a glyph. Per the brief, the **mayor closes tszij on merge** — not closed here.

## Spec

- `tools/xray/spec/018-Event-Spine.md` — new "Issue-epoch row wash" subsection in the L2 row chrome section (the owning event-spine doc).
- `tools/xray/spec/022-Design-Tokens.md` — `:bg-issue-row` noted in the low-opacity-row-washes paragraph.

## Quality gates

- `npm run test:cljs` — **5084 tests / 17109 assertions, 0 failures, 0 errors**. New pins: `cascade-has-issue?` clean/issue/advisory/`:errors`-slot cases (l2_timeline test); `event-row-issue-epoch-gets-pink-wash` (issue row → `data-rf-xray-issue-row=true` + `:background-image` reading the `:bg-issue-row` token; clean row → neither). Updated the existing `focused-row-uses-hover-fill-not-blue-ring` test to read `:background-color`.
- `npm run test:xray-feature-gate` — **EXIT 0**, 14 scenarios, 0 failures, 13 matrix rows.
- `clj-kondo` — **0 errors, 0 new warnings** (4 pre-existing findings confirmed against the origin/main baseline).
- `npm run test:bundle-isolation` — **EXIT 0**, both bundle checks PASS.