### PR TITLE
feat(xray/epoch): flat per-effect SIDE EFFECTS ledger + single badge + :db→app-db marker (rf2-j630b, supersedes kt6js 3-tier)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -389,7 +389,8 @@ the optional sections are simply omitted, so the visible steps renumber `①②�
 | DISPATCH `FROM: <source>` link | Open-in-editor (Xray's existing `:rf.xray/open-in-editor`) at the dispatch-origin call-site |
 | COEFFECTS / AFTER-INTERCEPTORS id ↗ | Open-in-editor at the coeffect / interceptor registration file:line |
 | EVENT HANDLER ↗ | Open-in-editor at handler file:line |
-| FX row fx-id ↗ (rf2-g1mfc) | Open-in-editor at the `reg-fx` registration file:line (shared `coord-chip`, parity with the HANDLER verb + SUBSCRIPTIONS / VIEWS rows; sources the absolute coord off `(rf/handler-meta :fx <fx-id>)`) |
+| SIDE EFFECTS `:db` row `→ app-db` marker (rf2-j630b) | Switch to the **App-db** panel for the focused epoch (`[:rf.xray/select-tab :app-db]`; the panel reads the same shared focus). The marker is a DESTINATION pointer — the committed db diff lives in the App-db panel, not duplicated in the ledger |
+| SIDE EFFECTS `:fx` row fx-id ↗ (rf2-g1mfc) | Open-in-editor at the `reg-fx` registration file:line (shared `coord-chip`, parity with the HANDLER verb + SUBSCRIPTIONS / VIEWS rows; sources the absolute coord off `(rf/handler-meta :fx <fx-id>)`) |
 | FX row | Switch to **Trace** panel, scrolled to the `:rf.fx/do-fx` / `:rf.fx/handled` op for that fx; if `:http/managed`, the badge offers the wire-trace popover |
 | FLOWS row | Switch to **App-db** panel, scrolled to the path that flow wrote |
 | Click any path segment in a COEFFECTS / DB CHANGES value | Cross-panel propagation per §10.5 (App-db ↔ View); no other value interactions |
@@ -2455,45 +2456,83 @@ outcome chips + MCP wire consumers + the pinned
 `outcome-enum-projection-pins-mapping` test. No spec/009 /
 Spec-Schemas edit was needed (rf2-ahhgn settle-first finding).
 
-### §9.1.10.6 SIDE EFFECTS step — `:db` / `:fx` / other sub-steps (rf2-kt6js · rf2-uffov · rf2-m8ac9)
+### §9.1.10.6 SIDE EFFECTS step — flat per-effect ledger (rf2-j630b, supersedes the rf2-kt6js 3-tier · rf2-uffov · rf2-m8ac9)
 
 The pre-rf2-kt6js single `:fx` step became the **SIDE EFFECTS** step
-(badge `:SIDE-EFFECTS`, the same `:orange` post-commit hue). It is the
-cascade's post-commit-effects lens, composed of up to **three OPTIONAL
-sub-steps in fixed order `:db → :fx → other`**, each shown only when it
-has rows and each carrying its own per-effect `✓/✗` tick (reusing the
-shared rf2-ahhgn `step-status` + `badge/step-status-*` primitive —
-**not a one-off**):
+(badge `:SIDE-EFFECTS`, the same `:orange` hue). rf2-j630b supersedes the
+rf2-kt6js 3-tier `:db` / `:fx` / other sub-step presentation with a
+**FLAT per-effect ledger**: ONE row per effect, down the page, in
+EXECUTION order, with **NO `:db` / `:fx` / other group headers**. The
+leading per-row status glyph + effect-id + args edn-inspector + the row
+order carry the structure.
 
-- **`:db` sub-step** — the handler's app-db write (the `:db` effect).
-  `✓` on a successful commit; `✗` when the post-commit app-db schema
-  check rejected the write and the cascade rolled back — the `:where
-  :app-db` violation reason box attaches to the `:db` row via
-  `attach-to-fx-db-row`. The `:db` sub-step ALWAYS appears when a `:db`
-  commit happened, **including a plain reg-event-db that returns only
-  `:db`** (no `:fx`). Reconciles with rf2-4wywy: this is the HANDLER db
+**Single badge status (no labels).** After the "SIDE EFFECTS" badge the
+header paints **ONE overall glyph** — `✓` when every present row
+succeeded, `✗` when one or more FAILED (`projection/side-effects-badge-
+status` = the AND of the present rows; the view reads it via the generic
+`step-status`, reusing the shared rf2-ahhgn `badge/step-status-*`
+primitive). **All post-commit / best-effort labels and the threw-count
+chip are dropped** — the single badge + the per-row glyphs are the whole
+signal. SKIPPED rows are **NEUTRAL** — they do not trip the badge to
+cross.
+
+**Row order (execution order).** The flat `:rows` slot is
+`[synthesised :db row, if present] + [:fx rows, in order] + [other rows]`:
+
+- **`:db` row** (FIRST, when present) — the handler's app-db write (the
+  `:db` effect). `✓` on a successful commit; `✗` when the post-commit
+  app-db schema check rejected the write and the cascade rolled back —
+  the `:where :app-db` violation reason box attaches to the `:db` row via
+  `attach-to-fx-db-row`. Its **args slot is the `→ app-db` DESTINATION
+  marker** — NOT the db diff (the actual change lives in the App-db panel;
+  no duplication). The marker is clickable: it jumps to the App-db panel
+  for the focused epoch (a `[:rf.xray/select-tab :app-db]` dispatch; the
+  App-db panel reads the same shared focus). The `:db` row appears
+  whenever a `:db` commit happened, **including a plain reg-event-db that
+  returns only `:db`** (no `:fx`); it is **ABSENT** when the handler
+  returned only `:fx` / only other / nothing, or THREW (no phantom
+  `:db`, rf2-wnvid). Reconciles with rf2-4wywy: this is the HANDLER db
   write (post-handler / pre-flow); the FLOW step's own `:db` diff (the
   flow's t1→t2 reshape) stays a SEPARATE step.
-- **`:fx` sub-step** — one row per entry in the handler's `:fx` vector,
-  each carrying the rf2-g1mfc open-code chip + a per-effect success
-  tick: `✓` ran / `✗` threw / `↺` overridden / `·` skipped-on-platform.
-  For ASYNC / deferred fx (`dispatch-later`, `http`, a slow fx) the `✓`
-  means **ACTIONED** (the fx handler was invoked ok), not awaited —
-  matching the trace's `:rf.fx/handled` semantics.
-- **`other` sub-step** — one row per TOP-LEVEL effect key on the
+- **`:fx` rows** — one row per entry in the handler's `:fx` vector, in
+  order, each carrying the rf2-g1mfc open-code chip + a per-effect glyph:
+  `✓` ran / `✗` threw / `↺` overridden / `–` skipped-on-platform (the
+  muted en-dash "n/a", with the hover "skipped on this platform — gated,
+  didn't run here"; the en-dash avoids the `·` middle-dot, which is the
+  `:cancelled` cascade-row glyph, and the circled-slash, which reads
+  error-ish). For ASYNC / deferred fx (`dispatch-later`, `http`, a slow
+  fx) the `✓` means **ACTIONED** (the fx handler was invoked ok), not
+  awaited — matching the trace's `:rf.fx/handled` semantics.
+- **`other` rows** (LAST) — one row per TOP-LEVEL effect key on the
   handler's returned map beyond `:db` / `:fx` (the historical
   `{:db .. :fx .. :other-key ..}` form). In re-frame2 the effect map is
   the closed `{:db :fx}` shape (spec/002 §The binary fx-handler
   signature — "the v1 :dispatch-n top-level key is gone") and the
   runtime's `run-fx-effects!` reads ONLY `:fx`; any other key is
   silently DROPPED — never executed, never traced. So each `other` row
-  is a `·` not-run **DIAGNOSTIC** flagging a declared effect the runtime
-  ignored (almost always a bug — the effect belongs inside `:fx`). In
-  the canonical `{:db :fx}` shape there are NO `other` rows.
+  is a `–` (skipped) not-run **DIAGNOSTIC** flagging a declared effect
+  the runtime ignored (almost always a bug — the effect belongs inside
+  `:fx`); it is NEUTRAL. In the canonical `{:db :fx}` shape there are NO
+  `other` rows.
+
+**Atomicity governs which rows appear.** A `:db` schema-fail (pre-commit
+transactional) rolls the cascade back BEFORE any `:fx` ran (spec/002
+atomicity; spec/010 — `:fx` doesn't walk on a rollback) — so the ledger
+carries just the `:db` CROSS row and the badge reads cross, with NO fx
+rows.
+
+**Exceptions.** A row that threw is a `✗` row whose expand is wnvid's
+shared "Exception Thrown" card (collapsible details — stack + ex-data —
+no redundant source link; the owning row provides context).
+`attach-to-fx-error-row` matches the throwing fx by `:fx-id` against the
+flat `:rows`; an unmatched fx exception (e.g. no-such-fx) attaches to the
+step level. This per-row rendering is compatible with rf2-yz57h's
+exception-under-step rendering.
 
 **ALWAYS APPEARS.** Unlike the pre-rf2-kt6js `:fx` step (which showed
 only when an `:fx` fired), the SIDE EFFECTS step appears whenever ANY
-side effect occurred. The `:db`-commit signal is the framework's
+side effect occurred (a `:db` commit — including a bare reg-event-db —
+and/or `:fx` and/or other). The `:db`-commit signal is the framework's
 `:rf.event/db-changed` trace (a second one with `:rf.trace/phase
 :rollback` flags a schema-fail rollback) — NOT a fx-id-less
 `:rf.fx/handled` (which the substrate never emits; `re-frame.fx/emit-
@@ -2513,16 +2552,19 @@ recorded by `:rf.event/db-changed` + `:rf.error/schema-validation-
 failure :where :app-db`. "Other" effects don't exist on the trace
 stream because the runtime never touches them. So the whole step is a
 PRESENTATION over already-recorded data — implemented tool-side in
-`projection/side-effects-step`, no core / spec-009 edit.
+`projection/side-effects-step`, no core / spec-009 edit. rf2-j630b only
+reshapes that presentation (3-tier → flat ledger); the data source is
+unchanged.
 
-**Header chrome** — badge `:SIDE-EFFECTS`, a muted-italic
-`(post-commit)` caption, and a threw-count chip in `:error` tone that
-surfaces **only when non-zero**. The per-row + per-sub-step glyphs
-(`✓ / ✗`) carry per-effect outcome; the count summary is omitted as
-noise (the rf2-m8ac9 rationale carries over).
+**Header chrome** — badge `:SIDE-EFFECTS` + the single overall `✓ / ✗`
+badge glyph (rf2-j630b). No verb, no `(post-commit)` caption, no
+threw-count chip — the per-row glyphs carry per-effect outcome and the
+single badge carries the at-a-glance overall outcome (the rf2-m8ac9
+"count summary is noise" rationale carries through; rf2-j630b extends it
+to drop the post-commit labels too).
 
 **Per-action attribution** — when the cascade was driven by a machine
-handler, each `:fx` sub-step row that maps to a fx-id emitted by an
+handler, each `:fx` ledger row that maps to a fx-id emitted by an
 action's outcome `:fx` slot carries `:attributed-to {:action-id …,
 :phase …}` (rf2-9c27r + rf2-uffov). The view renders an italic
 `← <action-id> (<phase>)` chip. First-attribution wins (cascade order).
@@ -2530,9 +2572,10 @@ action's outcome `:fx` slot carries `:attributed-to {:action-id …,
 **Args rendering (rf2-ef2hy)** — each `:fx` / `other` row's args/value
 mount the shared edn-inspector widget with `:default-expanded-depth 1`
 (scan-then-drill); `:zoomable?` opens the popup overlay for a complex
-map. Sibling: the HANDLER step's `:fx` section (§9.1.10.5 lineage,
-rf2-p2zy0) uses depth 16 (full-expand) — HANDLER reads INTENT, SIDE
-EFFECTS reads EXECUTION.
+map (the `:db` row's slot is the `→ app-db` destination marker, not an
+edn-inspector). Sibling: the HANDLER step's `:fx` section (§9.1.10.5
+lineage, rf2-p2zy0) uses depth 16 (full-expand) — HANDLER reads INTENT,
+SIDE EFFECTS reads EXECUTION.
 
 ### §9.1.10.7 COEFFECT step chrome (rf2-s1jw4 · pair-debug 2026-05-26)
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/badge.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/badge.cljc
@@ -399,3 +399,75 @@
   (case status
     :error "✗"
     "✓"))
+
+;; ---- Flat SIDE EFFECTS ledger row glyphs (rf2-j630b) --------------------
+;;
+;; The flat per-effect ledger (rf2-j630b, supersedes the kt6js 3-tier
+;; presentation) leads each row with a status glyph. The closed set
+;; extends the rf2-ahhgn `:ok` / `:error` pair with the three fx-outcome
+;; statuses the projection produces (`fx-outcome-op->status`):
+;;
+;;   :ok         → ✓ (success)   — fx handler ran ok / :db committed
+;;   :error      → ✗ (error)     — fx handler threw / no-such-fx
+;;   :rollback   → ✗ (error)     — :db schema-fail rollback (red, same as
+;;                                 :error; the row's reason box carries the
+;;                                 "rolled back" detail)
+;;   :overridden → ↺ (accent)    — fx override applied
+;;   :skipped    → – (tertiary)  — :skipped-on-platform (gated, didn't run
+;;                                 here) OR a dropped `other` effect. A
+;;                                 distinct MUTED en-dash "n/a" — NEUTRAL,
+;;                                 never trips the badge to cross. The
+;;                                 en-dash avoids the middle-dot (= the
+;;                                 `:cancelled` cascade glyph above) and the
+;;                                 circled-slash (reads error-ish).
+
+(def skipped-glyph
+  "The muted en-dash glyph for a SKIPPED ledger row (rf2-j630b) —
+  `:skipped-on-platform` (gated, didn't run here) or a dropped `other`
+  effect. Distinct from the `:cancelled` middle-dot; reads NEUTRAL."
+  "–")
+
+(def skipped-hover
+  "Hover/title text for a `:skipped-on-platform` ledger row (rf2-j630b)."
+  "skipped on this platform — gated, didn't run here")
+
+(defn fx-row-status-glyph
+  "Single-char leading glyph for a flat SIDE EFFECTS ledger row
+  (rf2-j630b). Closed set over the `fx-outcome-op->status` outcomes plus
+  the synthesised `:db` row's `:ok` / `:rollback`:
+    :ok / :db-commit → ✓
+    :error / :rollback → ✗
+    :overridden      → ↺
+    :skipped         → – (muted en-dash, NEUTRAL)
+  Defaults to the success tick for unknown statuses."
+  [status]
+  (case status
+    :error      "✗"
+    :rollback   "✗"
+    :overridden "↺"
+    :skipped    skipped-glyph
+    "✓"))
+
+(defn fx-row-status-token-key
+  "Theme-token keyword for a flat SIDE EFFECTS ledger row's glyph colour
+  (rf2-j630b):
+    :ok         → :success
+    :error      → :error
+    :rollback   → :error
+    :overridden → :accent
+    :skipped    → :text-tertiary  (muted/tertiary — NEUTRAL)
+  Falls back to `:success` for unknown statuses (the quiet tick)."
+  [status]
+  (case status
+    :error      :error
+    :rollback   :error
+    :overridden :accent
+    :skipped    :text-tertiary
+    :success))
+
+(defn fx-row-status-colour
+  "CSS-variable string for a flat SIDE EFFECTS ledger row's glyph
+  (rf2-j630b)."
+  [status]
+  (get tokens/tokens (fx-row-status-token-key status)
+       (get tokens/tokens :success)))

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -1092,26 +1092,39 @@
 ;; with rf2-xnb1x; the splicing in `project` consumes `flow-rows`
 ;; directly.
 
-;; ---- SIDE EFFECTS step (rf2-kt6js) --------------------------------------
+;; ---- SIDE EFFECTS step (rf2-j630b — supersedes rf2-kt6js 3-tier) --------
 ;;
-;; The cascade's post-commit side effects render as ONE numbered step —
-;; SIDE EFFECTS — composed of THREE optional sub-steps, each reusing the
-;; shared per-step `:status` (`:ok` / `:error`) primitive (rf2-ahhgn) for
-;; its per-effect tick:
+;; The cascade's side effects render as ONE numbered step — SIDE EFFECTS —
+;; whose body is a FLAT per-effect ledger (rf2-j630b, supersedes the
+;; rf2-kt6js 3-tier `:db` / `:fx` / other sub-step grouping). One row per
+;; effect, down the page, in EXECUTION order; NO group headers. Each row
+;; carries a leading status glyph + the effect-id + the effect ARGS in an
+;; edn-inspector. After the "SIDE EFFECTS" badge the view paints ONE
+;; overall glyph — TICK when every present row succeeded, CROSS when one
+;; or more FAILED (SKIPPED rows are NEUTRAL). No post-commit / best-effort
+;; labels. Each row reuses the shared per-step `:status` (`:ok` /
+;; `:error`) primitive (rf2-ahhgn) for its per-effect tick:
 ;;
-;;   :db    — the handler's app-db write (the `:db` effect). PASS on a
-;;            successful commit; FAILED when the post-commit app-db schema
-;;            check rejected the write and the cascade rolled back. Shown
-;;            whenever a `:db` commit was attempted — INCLUDING a plain
-;;            reg-event-db that returns only `:db` (no `:fx`).
-;;   :fx    — the entries in the handler's `:fx` vector, each `[fx-id arg]`
-;;            with the rf2-g1mfc open-code chip + a per-effect success tick
-;;            (✓ ran / ✗ threw / ↺ overridden / · skipped-on-platform).
+;;   :db    — the handler's app-db write (the `:db` effect), FIRST in the
+;;            ledger when present. ✓ on a successful commit; ✗ when the
+;;            post-commit app-db schema check rejected the write and the
+;;            cascade rolled back. Shown whenever a `:db` commit was
+;;            attempted — INCLUDING a plain reg-event-db that returns only
+;;            `:db` (no `:fx`); ABSENT when the handler returned only
+;;            `:fx` / only other / nothing, or THREW (no phantom `:db`,
+;;            rf2-wnvid). Its args slot is the DESTINATION marker
+;;            "→ app-db" (the actual db diff lives in the App-db panel —
+;;            no duplication here), made clickable to jump there.
+;;   :fx    — the entries in the handler's `:fx` vector, in order, each
+;;            `[fx-id arg]` with the rf2-g1mfc open-code chip + a per-effect
+;;            tick (✓ ran / ✗ threw / ↺ overridden / – skipped-on-platform).
 ;;   other  — any TOP-LEVEL effect key beyond `:db` / `:fx` on the
 ;;            handler's returned map (the historical
-;;            `{:db .. :fx .. :other-key ..}` form).
+;;            `{:db .. :fx .. :other-key ..}` form), last in the ledger.
 ;;
-;; SETTLE-FIRST (rf2-kt6js, confirmed against the live substrate):
+;; SETTLE-FIRST (rf2-kt6js, confirmed against the live substrate; carried
+;; through rf2-j630b — the data source is unchanged, only the presentation
+;; flattens):
 ;;
 ;; - PER-`:fx` SUCCESS IS ALREADY RECORDED. Every entry in the `:fx`
 ;;   vector emits exactly one of `:rf.fx/handled` / `:rf.fx/override-
@@ -1138,7 +1151,7 @@
 ;;   spec/002 §`:fx` ordering and atomicity guarantees). `re-frame.router/
 ;;   run-fx-effects!` reads ONLY `(:fx effects)`; `:db` commits separately;
 ;;   any other top-level key is silently ignored (no trace, no run). So
-;;   "other" is a DIAGNOSTIC sub-step: when the handler's returned map
+;;   "other" is a DIAGNOSTIC: when the handler's returned map
 ;;   (off the `:effects-decomp` `:other-effects` slot) carries a key
 ;;   beyond `:db` / `:fx`, surface it as a `:skipped` (not-run) effect so
 ;;   the operator sees the dropped effect rather than wondering why
@@ -1218,12 +1231,16 @@
       (some? (find-op events :rf.event/db-changed))))
 
 (defn db-effect-row
-  "The `:db` sub-step row — the handler's app-db write rendered as a
-  single per-effect tick (rf2-kt6js). nil when no `:db` commit was
-  attempted (a reg-event-fx that returned no `:db`). `:status` is
-  `:error` on a schema-fail rollback (so `step-status` paints ✗ and the
-  attached `:where :app-db` violation carries the reason box), else
-  `:ok`.
+  "The synthesised `:db` row — the handler's app-db write, leading the
+  flat SIDE EFFECTS ledger (rf2-kt6js synthesis · rf2-j630b ledger).
+  nil when no `:db` commit was attempted (a reg-event-fx that returned no
+  `:db`, or a handler that threw — no phantom `:db`, rf2-wnvid). `:status`
+  is `:error` on a schema-fail rollback (so the badge / `step-status`
+  paints ✗ and the attached `:where :app-db` violation carries the reason
+  box), else `:ok`. Carries the `:fx-id :db` marker — the view renders
+  its args slot as the clickable \"→ app-db\" DESTINATION marker (the
+  actual db diff lives in the App-db panel; no duplication) and the
+  attachment machinery matches `:fx-id :db` for the rollback reason box.
 
   Reconciles with rf2-4wywy: this is the HANDLER db write (the post-
   handler / pre-flow `:db` effect). The FLOW step's `:db` diff (the
@@ -1292,95 +1309,93 @@
               :status :skipped}))
       [])))
 
-(def side-effects-sub-kind-order
-  "The fixed render order of SIDE EFFECTS sub-steps (rf2-kt6js):
-  `:db → :fx → other`. Drives both the step's `:sub-kinds` slot and the
-  view's `sub-rows-of` grouping."
-  [:db :fx :other])
+(defn row-failed?
+  "True iff a SIDE EFFECTS ledger row is a REAL failure (rf2-j630b) —
+  its own `:status` is `:error` / `:rollback`, OR it carries an attached
+  `:errors` (exception) / `:violations` (schema) vec. A `:skipped` row
+  (`:skipped-on-platform`, or a dropped `other` effect) is NOT a failure
+  — it is NEUTRAL and never trips the badge to cross.
 
-(defn sub-rows-of
-  "The flat `:rows` of a (post-attachment) SIDE EFFECTS `step` belonging
-  to sub-step `kind` (`:db / :fx / :other`), in row order (rf2-kt6js).
-  Each row carries a `:sub-kind` tag the view groups by. Reading the
-  flat slot — rather than a duplicated per-sub-step row vector — is what
-  lets the rf2-ahhgn / rf2-xgeag attachment machinery
-  (`attach-to-fx-db-row` / `attach-to-fx-row` / `attach-to-fx-error-row`,
-  all of which mutate the step's `:rows`) flow through to the rendered
-  sub-step unchanged."
-  [step kind]
-  (filterv #(= kind (:sub-kind %)) (:rows step)))
+  Reads the post-attachment row shape so an exception / violation that
+  `attach-*` lands on a row AFTER `side-effects-step` built it still
+  counts."
+  [row]
+  (or (contains? #{:error :rollback} (:status row))
+      (seq (:errors row))
+      (seq (:violations row))))
 
-(defn sub-step-status
-  "The per-effect `:status` rollup for a SIDE EFFECTS sub-step (rf2-kt6js)
-  — `:error` iff any of its (post-attachment) rows reads `:error` via the
-  shared `step-status`-style scan (its own `:status` is `:error` /
-  `:rollback`, OR it carries an attached `:errors` / `:violations`), else
-  `:ok`. Reuses the rf2-ahhgn closed `:ok` / `:error` shape so the view
-  paints a sub-step ✓/✗ off `badge/step-status-*` alongside the per-row
-  ticks. Defined over the flat-row group so attached errors/violations
-  (which land AFTER `side-effects-step` builds the step) lift the
-  sub-step to `:error`."
+(defn side-effects-badge-status
+  "The SINGLE overall badge status for the flat SIDE EFFECTS ledger
+  (rf2-j630b) — `:error` iff ANY present row is a real failure
+  (`row-failed?`), else `:ok`. The AND-of-rows: TICK when every present
+  row succeeded, CROSS when one or more FAILED. `:skipped` rows are
+  NEUTRAL — they do not trip the badge.
+
+  Reuses the rf2-ahhgn closed `:ok` / `:error` shape so the view paints
+  the badge ✓/✗ off the same `badge/step-status-*` primitive the other
+  step headers use. Defined over the step's flat `:rows` so attached
+  errors / violations (which land AFTER `side-effects-step` builds the
+  step) lift the badge to `:error`. The view reads this via the generic
+  `step-status` (which dispatches to the same scan); this fn names the
+  contract for tests."
   [rows]
-  (if (some (fn [r]
-              (or (contains? #{:error :rollback} (:status r))
-                  (seq (:errors r))
-                  (seq (:violations r))))
-            rows)
-    :error
-    :ok))
+  (if (some row-failed? rows) :error :ok))
 
 (defn side-effects-step
-  "The SIDE EFFECTS step (rf2-kt6js) — replaces the pre-rf2-kt6js single
-  `:fx` step. Composed of up to three OPTIONAL sub-steps in fixed order
-  `:db → :fx → other`, each shown only when it has rows:
+  "The SIDE EFFECTS step (rf2-j630b — supersedes the rf2-kt6js 3-tier
+  `:db` / `:fx` / other sub-step presentation). A FLAT per-effect ledger:
+  ONE row per effect, down the page, in EXECUTION order:
 
-    :db    — the handler's app-db write (`db-effect-row`).
-    :fx    — the `:fx`-vector entries (`fx-effect-rows`).
-    other  — top-level non-`:db`/`:fx` effects (`other-effect-rows`).
+    1. the synthesised `:db` row (`db-effect-row`) — WHEN a `:db` commit
+       was attempted (often present; absent when the handler returned
+       only `:fx` / only other / nothing, or THREW — no phantom `:db`,
+       per rf2-wnvid);
+    2. the handler's `:fx`-vector entries (`fx-effect-rows`) in order;
+    3. any top-level non-`:db`/`:fx` effects (`other-effect-rows`).
+
+  There are NO `:db` / `:fx` / other group headers — the leading status
+  glyph + effect-id + args edn-inspector on each row + the execution
+  order carry the structure. After the \"SIDE EFFECTS\" badge the view
+  paints ONE overall glyph: TICK when every present row succeeded, CROSS
+  when one or more FAILED (`side-effects-badge-status`; SKIPPED rows are
+  NEUTRAL). No post-commit / best-effort labels.
 
   nil (step OMITTED) when NO side effect occurred — no `:db` commit, no
-  `:fx`, no other effect. Unlike the pre-rf2-kt6js `:fx` step, this
-  ALWAYS appears when a `:db` commit happened, INCLUDING a plain
-  reg-event-db with no `:fx` (`db-commit?` keys off `:rf.event/db-
-  changed`).
+  `:fx`, no other effect. ALWAYS appears when a `:db` commit happened,
+  INCLUDING a plain reg-event-db with no `:fx` (`db-commit?` keys off
+  `:rf.event/db-changed`).
+
+  ## Atomicity
+
+  A `:db` schema-fail (pre-commit transactional) rolls the cascade back
+  BEFORE any `:fx` ran (Spec 002 atomicity; Spec 010 — `:fx` doesn't walk
+  on a rollback) — so the ledger carries just the `:db` CROSS row and the
+  badge reads cross, with NO fx rows.
 
   ## Single-source-of-truth row shape
 
-  The step carries ONE flat `:rows` slot (`:db` row first, then `:fx`
-  rows, then `other` rows), each row tagged with `:sub-kind`
-  (`:db / :fx / :other`); plus `:sub-kinds` — the ordered vec of the
-  kinds present. The view groups rows back into sub-steps via
-  `sub-rows-of` and computes each sub-step's ✓/✗ via `sub-step-status`.
+  The step carries ONE flat `:rows` slot in execution order. This is
+  load-bearing: the rf2-ahhgn / rf2-xgeag attachment machinery
+  (`attach-to-fx-db-row` / `attach-to-fx-row` / `attach-to-fx-error-row`)
+  runs in `project` AFTER this builder and mutates the step's `:rows` to
+  attach schema violations + exceptions by matching `:failing-id` against
+  a row's `:fx-id`. The flat ledger renders the SAME `:rows`, so an
+  attached violation / exception surfaces inline on the owning row — the
+  per-row exception expand is wnvid's shared 'Exception Thrown' card
+  (compatible with yz57h's exception-under-step rendering).
 
-  This single-row-vector shape is load-bearing: the rf2-ahhgn /
-  rf2-xgeag attachment machinery (`attach-to-fx-db-row` /
-  `attach-to-fx-row` / `attach-to-fx-error-row`) runs in `project`
-  AFTER this builder and mutates the step's `:rows` to attach schema
-  violations + exceptions by matching `:failing-id` against a row's
-  `:fx-id`. Because the rendered sub-steps READ THE SAME `:rows`
-  (not a duplicated copy), those attachments surface inline on the
-  right sub-step row without the attachment code needing to know
-  sub-steps exist.
-
-  The header carries a threw-count chip (`:threw`) that surfaces only
-  when non-zero."
+  `:threw` is the count of rows that threw — retained for non-view
+  consumers; the single badge glyph carries the at-a-glance signal."
   [events]
-  (let [db-row   (db-effect-row events)
-        fx-rows  (fx-effect-rows events)
-        other    (other-effect-rows events)
-        tag      (fn [kind rows] (mapv #(assoc % :sub-kind kind) rows))
-        all-rows (vec (concat (tag :db (when db-row [db-row]))
-                              (tag :fx fx-rows)
-                              (tag :other other)))]
-    (when (seq all-rows)
-      (let [present (filterv #(seq (sub-rows-of {:rows all-rows} %))
-                             side-effects-sub-kind-order)
-            threw   (count (filter #(= :error (:status %)) all-rows))]
-        {:step      :side-effects
-         :badge     :SIDE-EFFECTS
-         :sub-kinds present
-         :rows      all-rows
-         :threw     threw}))))
+  (let [db-row  (db-effect-row events)
+        fx-rows (fx-effect-rows events)
+        other   (other-effect-rows events)
+        rows    (vec (concat (when db-row [db-row]) fx-rows other))]
+    (when (seq rows)
+      {:step  :side-effects
+       :badge :SIDE-EFFECTS
+       :rows  rows
+       :threw (count (filter #(= :error (:status %)) rows))})))
 
 ;; ---- SUBSCRIPTIONS step --------------------------------------------------
 
@@ -1811,12 +1826,12 @@
                 s)))
 
           :app-db
-          ;; rf2-8resu / rf2-kt6js — :where :app-db violations attach to
-          ;; the SIDE EFFECTS step's :db row (the handler's app-db write).
-          ;; Was the FX step's :db row pre-rf2-kt6js; the :fx step became
-          ;; the SIDE EFFECTS step (`:db` / `:fx` / other sub-steps), and
-          ;; the :db row still carries the `:fx-id :db` marker so the
-          ;; row-level attach matches unchanged.
+          ;; rf2-8resu / rf2-kt6js / rf2-j630b — :where :app-db violations
+          ;; attach to the SIDE EFFECTS step's :db row (the handler's
+          ;; app-db write). The :db row leads the flat ledger and still
+          ;; carries the `:fx-id :db` marker, so the row-level attach
+          ;; (`attach-to-fx-db-row`, matching `:fx-id :db` over the flat
+          ;; `:rows`) matches unchanged across the kt6js→j630b flatten.
           (let [i (index-of #(= :side-effects (:step %)) s)]
             (if i
               (update s i attach-to-fx-db-row row)
@@ -2105,13 +2120,13 @@
   The view paints those steps with mute chrome. Pure fn over the step
   vector.
 
-  Per rf2-8resu / rf2-kt6js: the SIDE EFFECTS step itself is NOT marked
-  rolled-back — its `:db` row carries the red ✗ + violation sub-block
-  that's the visible rollback indicator. Muting the entire step would
-  hide the very signal the operator needs. User-fx rows don't exist in
-  a rollback cascade (per Spec 010, `:fx` doesn't walk when the commit
-  rolls back) — so the SIDE EFFECTS step in a rollback carries only the
-  :db sub-step, visibly red."
+  Per rf2-8resu / rf2-kt6js / rf2-j630b: the SIDE EFFECTS step itself is
+  NOT marked rolled-back — its `:db` row carries the red ✗ + violation
+  reason box that's the visible rollback indicator. Muting the entire
+  step would hide the very signal the operator needs. User-fx rows don't
+  exist in a rollback cascade (per Spec 010, `:fx` doesn't walk when the
+  commit rolls back) — so the flat ledger in a rollback carries only the
+  `:db` CROSS row, visibly red."
   [steps rows]
   (if (cascade-rolled-back? rows)
     (let [fx-idx (index-of #(= :side-effects (:step %)) steps)]

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -686,6 +686,23 @@
    :flex       1
    :word-break "break-word"})
 
+(def ^:private db-destination-style
+  "The `:db` ledger row's args slot — the clickable '→ app-db'
+  DESTINATION marker (rf2-j630b). A bare-button affordance styled as an
+  inline link in the accent hue (the db-mutation lens colour) — clicking
+  it jumps to the App-db panel for this epoch (the actual db diff lives
+  there; no duplication in the ledger)."
+  {:appearance       "none"
+   :background       "none"
+   :border           "none"
+   :padding          0
+   :margin           0
+   :font             "inherit"
+   :color            accent-colour
+   :cursor           "pointer"
+   :text-decoration  "none"
+   :white-space      "nowrap"})
+
 (def ^:private fx-row-duration-style
   {:color       text-tertiary-colour
    :margin-left "8px"
@@ -704,19 +721,11 @@
 (def ^:private fx-row-attribution-phase-style
   {:color text-tertiary-colour})
 
-(def ^:private fx-verb-style
-  {:display     "inline-flex"
-   :align-items "center"
-   :gap         "8px"})
-
-(def ^:private fx-caption-style
-  {:color       text-tertiary-colour
-   :font-family sans-stack
-   :font-size   "11px"
-   :font-style  "italic"})
-
-(def ^:private fx-threw-style
-  {:color error-colour :font-weight 700})
+;; The flat SIDE EFFECTS ledger (rf2-j630b) carries NO header verb /
+;; caption — the single badge ✓/✗ + the per-row glyphs are the whole
+;; signal. The pre-rf2-j630b `(post-commit)` caption + `N threw` chip
+;; styles (`fx-verb-style` / `fx-caption-style` / `fx-threw-style`)
+;; retired with the 3-tier presentation.
 
 (def ^:private margin-top-5-style
   {:margin-top "5px"})
@@ -2905,12 +2914,43 @@
       (when (and m (string? (:file m)) (seq (:file m)))
         {:file (:file m) :line (:line m) :ns (:ns m)}))))
 
+(defn- db-destination-marker
+  "Render the `:db` ledger row's args slot — the clickable '→ app-db'
+  DESTINATION marker (rf2-j630b). NOT the db diff: the actual change
+  lives in the App-db panel; this marker jumps there for the focused
+  epoch (the panel reads the same shared focus, so flipping the L3 tab
+  to `:app-db` is the whole navigation). Render-time frame capture
+  mirrors the CHILD-DISPATCHES jump affordance."
+  [idx]
+  (let [frame (rf/current-frame)]
+    [:button {:data-testid (str "rf-xray-epoch-fx-row-db-destination-" idx)
+              :aria-label "jump to the App-db panel for this epoch"
+              :title "the committed db change is shown in the App-db panel"
+              :on-click (fn [e]
+                          (.stopPropagation e)
+                          (rf/dispatch [:rf.xray/select-tab :app-db]
+                                       {:frame frame}))
+              :style db-destination-style}
+     "→ app-db"]))
+
 (defn- fx-row-view
-  "Render one fx-handler row inside the SIDE EFFECTS step's :db / :fx
-  sub-steps — per-effect tick glyph + fx-id + truncated args.
+  "Render one row of the flat SIDE EFFECTS ledger (rf2-j630b) — a leading
+  per-effect status glyph + the effect-id + the effect args. One row per
+  effect, in execution order; the `:db` row leads (when present), then
+  the `:fx` entries, then `other` rows.
 
   Argument order matches `map-indexed`'s `(f idx item)` convention
   (rf2-cq0ch — companion swap with `coeffect-row-view`).
+
+  The leading glyph + colour resolve off the shared
+  `badge/fx-row-status-*` primitive (rf2-j630b): ✓ :ok / ✗ :error /
+  ✗ :rollback / ↺ :overridden / – :skipped (the muted en-dash 'n/a',
+  NEUTRAL — `:skipped-on-platform` carries the hover explainer).
+
+  The `:db` row's args slot renders the clickable '→ app-db' DESTINATION
+  marker (NOT the db diff — that lives in the App-db panel; no
+  duplication). Every other row renders its args through the
+  edn-inspector.
 
   Per rf2-uffov: when the row carries `:attributed-to`, a muted
   `← <action-id>` attribution chip rides alongside so the operator
@@ -2921,60 +2961,50 @@
   + the HANDLER verb), sourcing the fx registration coord off
   `(rf/handler-meta :fx fx-id)` via `fx-coord`. The chip drops out
   cleanly when no coord was captured (framework-shipped fx with no
-  user source, production builds without coords)."
-  [idx {:keys [fx-id status args duration-ms attributed-to]}]
-  (let [glyph    (case status
-                   :ok          "✓"
-                   :overridden  "↺"
-                   :skipped     "·"
-                   :error       "✗"
-                   ;; rf2-8resu — :rollback applies to the synthesised
-                   ;; :db row when the commit's schema check failed +
-                   ;; the cascade was rolled back. Visually red ✗ same
-                   ;; as :error; the row's :violations sub-block
-                   ;; carries the "rolled back" detail.
-                   :rollback    "✗"
-                   "·")
-        colour   (case status
-                   :ok          success-colour
-                   :overridden  accent-colour
-                   :skipped     text-tertiary-colour
-                   :error       error-colour
-                   :rollback    error-colour
-                   text-secondary-colour)]
+  user source, production builds without coords; the synthesised `:db`
+  row has no reg-site)."
+  [idx {:keys [fx-id status args value duration-ms attributed-to]}]
+  (let [db-row?  (= :db fx-id)
+        skipped? (= :skipped status)
+        ;; :fx rows carry `:args`; `other` (dropped top-level) rows carry
+        ;; `:value` — both render through the same edn-inspector slot.
+        payload  (if (some? args) args value)]
     [:div {:key (str "fx-" idx)
            :data-testid (str "rf-xray-epoch-fx-row-" idx)
            :data-fx-status (when (keyword? status) (name status))
            :data-fx-attributed (str (some? attributed-to))
            :style fx-row-style}
-     [:span {:style (assoc diff-glyph-bold-style :color colour)} glyph]
+     [:span {:style (assoc diff-glyph-bold-style
+                           :color (badge/fx-row-status-colour status))
+             :title (when skipped? badge/skipped-hover)}
+      (badge/fx-row-status-glyph status)]
      [:span {:style fx-row-id-style}
       (proj/ns-keyword fx-id)
       ;; rf2-g1mfc — click-to-source via the shared `coord-chip`, exact
       ;; parity with the SUBSCRIPTIONS (~3000) + VIEWS rows + the HANDLER
       ;; verb. The coord lookup keys off `fx-id` and resolves the
       ;; `reg-fx` REGISTRATION site (absolute `:file`, rf2-wvsxg). Chip
-      ;; drops out cleanly when no coord was captured.
+      ;; drops out cleanly when no coord was captured (incl. the
+      ;; synthesised :db row, which has no reg-site).
       (coord-chip/coord-chip (fx-coord fx-id)
                              (str "rf-xray-epoch-fx-row-coord-" idx))]
-     ;; rf2-ef2hy — args render through edn-inspector with
-     ;; `:default-expanded-depth 1` so the top-level fx-call surface is
-     ;; visible inline (`:strategy :top`) and nested maps collapse to
-     ;; clickable chevrons (`{…1 keys}`). The operator scans the FX-step
-     ;; table dense, then drills into a row's args via the chevron or
-     ;; the popup-overlay (`:zoomable?`).
-     ;;
-     ;; Sibling rendering for the HANDLER step's `:fx` section
-     ;; (rf2-p2zy0) uses the same widget with `:default-expanded-depth 16`
-     ;; (full-expand). Both paths share the widget; the per-call-site
-     ;; `:default-expanded-depth` reflects each section's role.
-     (when (some? args)
-       [:span {:style fx-row-args-style}
-        [ei/edn-inspector args
-         {:site-id [:rf.xray.epoch/fx-row-args fx-id idx]
-          :card? false
-          :zoomable? true
-          :default-expanded-depth 1}]])
+     ;; The :db row's args slot is the '→ app-db' DESTINATION marker, NOT
+     ;; the db diff (rf2-j630b). Every other row renders its args through
+     ;; the edn-inspector with `:default-expanded-depth 1` (rf2-ef2hy) so
+     ;; the top-level fx-call surface is visible inline and nested maps
+     ;; collapse to clickable chevrons. The operator scans the dense
+     ;; ledger, then drills into a row's args via the chevron or the
+     ;; popup-overlay (`:zoomable?`). Sibling rendering for the HANDLER
+     ;; step's `:fx` section (rf2-p2zy0) uses `:default-expanded-depth 16`
+     ;; (full-expand) — HANDLER reads INTENT, the ledger reads EXECUTION.
+     (cond
+       db-row?         (db-destination-marker idx)
+       (some? payload) [:span {:style fx-row-args-style}
+                        [ei/edn-inspector payload
+                         {:site-id [:rf.xray.epoch/fx-row-args fx-id idx]
+                          :card? false
+                          :zoomable? true
+                          :default-expanded-depth 1}]])
      (when (number? duration-ms)
        [:span {:style fx-row-duration-style}
         (proj/format-duration-ms duration-ms)])
@@ -3004,140 +3034,65 @@
    (error-blocks (keyword (str "fx-row-" idx)) (:errors row))
    (violation-blocks (keyword (str "fx-row-" idx)) (:violations row))])
 
-;; ---- SIDE EFFECTS sub-steps (rf2-kt6js) ---------------------------------
-
-(def ^:private side-effects-sub-label
-  "Map a SIDE EFFECTS sub-step `:kind` → its sub-header label. `:db` and
-  `:fx` render as the literal keyword (lowercase, matching the
-  `sub-header` keyword-identity convention); `other` renders as the
-  plain word."
-  {:db    ":db"
-   :fx    ":fx"
-   :other "other"})
-
-(defn- sub-step-header
-  "Render a SIDE EFFECTS sub-step header (rf2-kt6js) — the
-  corner-down-right sub-header glyph + the shared per-step ✓/✗ status
-  glyph (rf2-ahhgn `step-status-glyph`, the exact primitive the
-  top-level step headers reuse) + the sub-step label + a trailing
-  entry-count chip. `kind` is `:db / :fx / :other`; `status` is the
-  sub-step's `:ok` / `:error` rollup; `n` is the row count."
-  [kind status n]
-  (let [testid (str "rf-xray-epoch-side-effects-sub-" (name kind))]
-    [:div {:data-testid (str testid "-header")
-           :style sub-header-style}
-     [:span {:style sub-header-glyph-style}
-      (icons/corner-down-right)]
-     (step-status-glyph status testid)
-     [:span (get side-effects-sub-label kind (name kind))]
-     [:span {:style sub-header-trailing-style}
-      (str n " effect" (when (not= 1 n) "s"))]]))
-
-(defn- other-effect-row-view
-  "Render one `other` sub-step row (rf2-kt6js) — a top-level effect key
-  the runtime DID NOT execute (re-frame2's effect map is the closed
-  `{:db :fx}` shape; any other key is dropped). The `·` skipped glyph +
-  muted tone signal not-run; the fx-id + value render so the operator
-  sees exactly which declared effect the runtime ignored."
-  [idx {:keys [fx-id value]}]
-  [:div {:key (str "other-" idx)
-         :data-testid (str "rf-xray-epoch-side-effects-other-row-" idx)
-         :data-fx-status "skipped"
-         :style fx-row-style}
-   [:span {:style (assoc diff-glyph-bold-style :color text-tertiary-colour)
-           :title "this effect was not run — re-frame2 executes only :db and :fx"}
-    "·"]
-   [:span {:style fx-row-id-style}
-    (proj/ns-keyword fx-id)]
-   (when (some? value)
-     [:span {:style fx-row-args-style}
-      [ei/edn-inspector value
-       {:site-id [:rf.xray.epoch/other-effect-row fx-id idx]
-        :card? false
-        :zoomable? true
-        :default-expanded-depth 1}]])])
-
-(defn- render-side-effects-sub-step
-  "Render one SIDE EFFECTS sub-step group (rf2-kt6js): its
-  status-bearing sub-header + its rows. `:db` / `:fx` rows render via
-  `fx-row-with-violations` (the per-effect ✓/✗ tick + open-code chip +
-  inline error / violation cards); `other` rows render via
-  `other-effect-row-view` (the `·` not-run diagnostic).
-
-  `step` is the WHOLE side-effects step; `kind` selects the group. Rows
-  are read off the step's flat `:rows` via `proj/sub-rows-of` (so
-  post-attachment errors / violations surface inline) and rendered at
-  their GLOBAL flat-row index so the per-row testids are stable across
-  groups + match the index the attachment machinery resolved by
-  `:fx-id`."
-  [step kind]
-  (let [rows   (proj/sub-rows-of step kind)
-        all    (:rows step)
-        ;; global flat-row index of each sub-row (identity-stable —
-        ;; rows are distinct maps once tagged with :sub-kind).
-        idx-of (fn [row] (some (fn [[i r]] (when (identical? r row) i))
-                               (map-indexed vector all)))]
-    [:div {:data-testid (str "rf-xray-epoch-side-effects-sub-" (name kind))}
-     (sub-step-header kind (proj/sub-step-status rows) (count rows))
-     [:div {:style margin-top-5-style}
-      (for [row rows
-            :let [i (idx-of row)]]
-        ^{:key (str (name kind) "-" i)}
-        [(if (= :other kind) other-effect-row-view fx-row-with-violations)
-         i row])]]))
+;; ---- SIDE EFFECTS flat ledger (rf2-j630b — supersedes kt6js 3-tier) -----
 
 (defn render-side-effects-step
-  "Render the SIDE EFFECTS step (rf2-kt6js — replaces the pre-rf2-kt6js
-  FX step). ALWAYS present when ANY side effect occurred — including a
-  bare reg-event-db that returns only `:db` (the step's `:db` sub-step
-  keys off `:rf.event/db-changed`, not a non-existent fx-id-less
-  `:rf.fx/handled`).
+  "Render the SIDE EFFECTS step as a FLAT per-effect ledger (rf2-j630b —
+  supersedes the rf2-kt6js 3-tier `:db` / `:fx` / other sub-step
+  presentation). ALWAYS present when ANY side effect occurred — including
+  a bare reg-event-db that returns only `:db` (`db-commit?` keys off
+  `:rf.event/db-changed`).
 
-  Composed of up to three OPTIONAL sub-step groups in fixed order
-  `:db → :fx → other` (`:sub-kinds`), each shown only when it has rows,
-  each carrying its own per-effect ✓/✗ tick (reusing the shared
-  rf2-ahhgn `step-status` primitive via `proj/sub-step-status`):
+  After the 'SIDE EFFECTS' badge the header paints ONE overall glyph —
+  TICK when every present row succeeded, CROSS when one or more FAILED
+  (`proj/side-effects-badge-status` is the AND of the flat `:rows`;
+  SKIPPED rows are NEUTRAL).
+  There are NO post-commit / best-effort labels and NO group headers: the
+  body is one row per effect, in EXECUTION order, each via
+  `fx-row-with-violations`:
 
-    :db    — the handler's app-db write — ✓ committed / ✗ schema-fail
-             rollback (the `:where :app-db` violation reason box rides
-             the row via `attach-to-fx-db-row`).
-    :fx    — the `:fx`-vector entries — each with the rf2-g1mfc
-             open-code chip + a per-effect tick (✓ ran / ✗ threw / ↺
-             overridden / · skipped-on-platform). For async / deferred
-             fx the ✓ means ACTIONED (handler invoked ok), not awaited.
-    other  — top-level non-`:db`/`:fx` effects the runtime DROPPED —
-             rendered `·` not-run (diagnostic).
+    1. the `:db` row (when a `:db` commit was attempted) — leading glyph
+       ✓ committed / ✗ schema-fail rollback (the `:where :app-db`
+       violation reason box rides the row via `attach-to-fx-db-row`), its
+       args slot the clickable '→ app-db' DESTINATION marker;
+    2. the `:fx`-vector entries in order — each with the rf2-g1mfc
+       open-code chip + a per-effect glyph (✓ ran / ✗ threw / ↺ overridden
+       / – skipped-on-platform). For async / deferred fx the ✓ means
+       ACTIONED (handler invoked ok), not awaited;
+    3. any top-level non-`:db`/`:fx` effects the runtime DROPPED — the
+       muted – not-run diagnostic.
 
-  Threw-count chip surfaces only when non-zero. `:fx-args` / fx
-  exception attachments that didn't match a row attach to the step
-  level (rf2-xgeag / rf2-ahhgn) and render at the foot."
-  [{:keys [sub-kinds step-number threw violations errors] :as step}]
-  (let [k (or threw 0)]
-    [:div {:data-testid "rf-xray-epoch-step-side-effects"
-           :data-step-kw "side-effects"
-           :data-fx-threw (str k)}
-     (numbered-circle step-number :SIDE-EFFECTS)
-     (step-header
-       {:step :side-effects
-        :badge :SIDE-EFFECTS
-        :verb [:span {:style fx-verb-style}
-               [:span {:data-testid "rf-xray-epoch-side-effects-caption"
-                       :style fx-caption-style}
-                "(post-commit)"]
-               (when (pos? k)
-                 [:span {:style fx-threw-style}
-                  (str k " threw")])]
-        :expandable? false
-        :testid "rf-xray-epoch-side-effects"
-        :status (proj/step-status step)}
-       nil)
-     (for [kind sub-kinds]
-       ^{:key (name kind)}
-       [render-side-effects-sub-step step kind])
-     ;; rf2-ahhgn — fx exceptions that didn't match a row (no-such-fx,
-     ;; or an fx-id absent from `:rows`) attach to the step level.
-     (error-blocks :side-effects errors)
-     (violation-blocks :side-effects violations)]))
+  A throwing row's expand is wnvid's shared 'Exception Thrown' card
+  (`fx-row-with-violations` → `error-blocks`), compatible with yz57h's
+  exception-under-step rendering. `:fx-args` / fx exception attachments
+  that didn't match a row attach to the step level (rf2-xgeag /
+  rf2-ahhgn) and render at the foot. `:db` schema-fail (pre-commit) →
+  just the `:db` CROSS row + badge cross, no fx rows (atomicity)."
+  [{:keys [rows step-number threw violations errors]}]
+  [:div {:data-testid "rf-xray-epoch-step-side-effects"
+         :data-step-kw "side-effects"
+         :data-fx-threw (str (or threw 0))}
+   (numbered-circle step-number :SIDE-EFFECTS)
+   (step-header
+     {:step :side-effects
+      :badge :SIDE-EFFECTS
+      :expandable? false
+      :testid "rf-xray-epoch-side-effects"
+      ;; rf2-j630b — the single overall badge glyph is the AND of the
+      ;; present ledger rows (`side-effects-badge-status`): cross iff a
+      ;; row is a real failure (its `:status` is `:error` / `:rollback`,
+      ;; or it carries an attached exception / violation); SKIPPED rows
+      ;; are neutral. Distinct from the generic `step-status` (which keys
+      ;; off the step's own `:status` + attachments only) because a
+      ;; row's `:status :error` / `:rollback` must trip the badge too.
+      :status (proj/side-effects-badge-status rows)}
+     nil)
+   [:div {:style margin-top-5-style}
+    (map-indexed (fn [i row] (fx-row-with-violations i row)) rows)]
+   ;; rf2-ahhgn — fx exceptions that didn't match a row (no-such-fx,
+   ;; or an fx-id absent from `:rows`) attach to the step level.
+   (error-blocks :side-effects errors)
+   (violation-blocks :side-effects violations)])
 
 ;; ---- SUBSCRIPTIONS step --------------------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/badge_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/badge_cljs_test.cljc
@@ -186,3 +186,43 @@
         (is (string? c))
         (is (re-find #"var\(--rf-xray-" c)
             (str "expected CSS variable for " s ", got " c))))))
+
+;; ---- flat SIDE EFFECTS ledger row glyphs (rf2-j630b) --------------------
+
+(deftest fx-row-status-glyph-test
+  (testing "rf2-j630b — the flat-ledger per-effect glyph closed set:
+            ✓ :ok / ✗ :error / ✗ :rollback / ↺ :overridden / – :skipped"
+    (is (= "✓" (badge/fx-row-status-glyph :ok)))
+    (is (= "✗" (badge/fx-row-status-glyph :error)))
+    (is (= "✗" (badge/fx-row-status-glyph :rollback)))
+    (is (= "↺" (badge/fx-row-status-glyph :overridden)))
+    (is (= "–" (badge/fx-row-status-glyph :skipped))
+        "skipped is the muted en-dash 'n/a'")
+    (is (= "✓" (badge/fx-row-status-glyph :whatever)) "quiet default")))
+
+(deftest skipped-glyph-distinct-from-cancelled-test
+  (testing "rf2-j630b — the skipped en-dash avoids the :cancelled
+            middle-dot (`·`) used by the machine-cascade outcome chip"
+    (is (= "–" badge/skipped-glyph))
+    (is (not= badge/skipped-glyph (badge/cascade-outcome-glyph :cancelled))
+        "the skipped glyph and the :cancelled middle-dot are distinct")
+    (is (string? badge/skipped-hover))))
+
+(deftest fx-row-status-token-key-test
+  (testing "rf2-j630b — :error/:rollback → :error; :overridden → :accent;
+            :skipped → :text-tertiary (muted, NEUTRAL); else → :success"
+    (is (= :error         (badge/fx-row-status-token-key :error)))
+    (is (= :error         (badge/fx-row-status-token-key :rollback)))
+    (is (= :accent        (badge/fx-row-status-token-key :overridden)))
+    (is (= :text-tertiary (badge/fx-row-status-token-key :skipped)))
+    (is (= :success       (badge/fx-row-status-token-key :ok)))
+    (is (= :success       (badge/fx-row-status-token-key nil)))))
+
+(deftest fx-row-status-colour-resolves-css-var-test
+  (testing "rf2-j630b — the row glyph colour resolver returns a
+            CSS-variable string for every ledger status (theme-driven)"
+    (doseq [s [:ok :error :rollback :overridden :skipped]]
+      (let [c (badge/fx-row-status-colour s)]
+        (is (string? c))
+        (is (re-find #"var\(--rf-xray-" c)
+            (str "expected CSS variable for " s ", got " c))))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -1195,97 +1195,126 @@
       (is (= 4 (:derived (:db-post-flow f)))
           "post-flow :derived = the flow's recomputed value"))))
 
-;; ---- SIDE EFFECTS step (rf2-kt6js) --------------------------------------
+;; ---- SIDE EFFECTS step — flat ledger (rf2-j630b) ------------------------
 ;;
-;; The pre-rf2-kt6js single `:fx` step (`proj/fx-step`) became the SIDE
-;; EFFECTS step (`proj/side-effects-step`) with three optional sub-steps —
-;; `:db` / `:fx` / other — each reusing the shared rf2-ahhgn `:status`
-;; primitive for its per-effect tick. See the projection ns's SIDE EFFECTS
-;; settle-first note for what's recorded vs derived.
+;; The rf2-kt6js 3-tier `:db` / `:fx` / other sub-step presentation became
+;; a FLAT per-effect ledger (rf2-j630b): `proj/side-effects-step` returns
+;; ONE `:rows` vec in EXECUTION order — synthesised `:db` row first (when
+;; present), then the `:fx`-vector rows in order, then `other` rows. NO
+;; `:sub-kinds` slot. The single badge status is `proj/side-effects-badge-
+;; status` (AND-of-rows; SKIPPED neutral); each row keeps the rf2-ahhgn
+;; `:status`. See the projection ns's SIDE EFFECTS settle-first note for
+;; what's recorded vs derived.
 
-(defn- sub-rows
-  "Pull the SIDE EFFECTS sub-step rows of `kind` (`:db / :fx / :other`)
-  off a projected `side-effects-step`. Empty vec when the sub-step is
-  absent."
-  [step kind]
-  (proj/sub-rows-of step kind))
+(defn- ids-of
+  "The `:fx-id`s of a projected `side-effects-step`'s flat `:rows`, in
+  ledger (execution) order."
+  [step]
+  (mapv :fx-id (:rows step)))
 
-(defn- has-sub?
-  "True iff the projected `side-effects-step` carries a `kind` sub-step."
-  [step kind]
-  (boolean (some #{kind} (:sub-kinds step))))
-
-(defn- sub-status
-  "The per-effect status rollup for the `kind` sub-step of a projected
-  `side-effects-step`."
-  [step kind]
-  (proj/sub-step-status (sub-rows step kind)))
+(defn- row-with-id
+  "The flat ledger row whose `:fx-id` = `id`, or nil."
+  [step id]
+  (some #(when (= id (:fx-id %)) %) (:rows step)))
 
 (deftest side-effects-step-conditional-test
   (testing "no side effect at all → step is OMITTED"
     (is (nil? (proj/side-effects-step []))))
 
-  (testing ":fx-vector entries → step rendered as SIDE EFFECTS with a
-            :fx sub-step"
+  (testing "rf2-j630b — :fx-vector entries → SIDE EFFECTS step with one
+            flat row per fx in execution order (no :db row when no commit)"
     (let [s (proj/side-effects-step
               [(fx-handled-ev :http/post {:url "/x"} 12.0)
                (fx-handled-ev :navigate {:to :home} 0.4)])]
       (is (= :side-effects (:step s)))
       (is (= :SIDE-EFFECTS (:badge s)))
-      (is (not (has-sub? s :db)) "no :db commit → no :db sub-step")
-      (is (has-sub? s :fx) ":fx sub-step present")
-      (is (= 2 (count (sub-rows s :fx))))
-      (is (= :ok (sub-status s :fx)) "all fx ran → sub-step :ok")
-      (is (= :ok (-> (sub-rows s :fx) first :status))))))
+      (is (= [:http/post :navigate] (ids-of s)) "flat rows in :fx order")
+      (is (not-any? #{:db} (ids-of s)) "no :db commit → no :db row")
+      (is (= :ok (proj/side-effects-badge-status (:rows s)))
+          "all fx ran → badge :ok")
+      (is (= :ok (-> s :rows first :status))))))
 
-;; ---- :db sub-step — pass / schema-fail (rf2-kt6js) ----------------------
+;; ---- :db row — FIRST, pass / schema-fail (rf2-j630b) --------------------
 
-(deftest side-effects-db-sub-step-pass-test
-  (testing "rf2-kt6js — a bare reg-event-db (only :db, NO :fx) STILL
-            shows the SIDE EFFECTS step with a passing :db sub-step.
-            The :db commit is keyed off `:rf.event/db-changed` — the
-            ALWAYS-APPEARS contract. Pre-rf2-kt6js this showed nothing."
+(deftest side-effects-db-row-first-and-pass-test
+  (testing "rf2-j630b — a bare reg-event-db (only :db, NO :fx) STILL shows
+            the SIDE EFFECTS step with a passing :db row, FIRST in the
+            ledger. The :db commit is keyed off `:rf.event/db-changed` —
+            the ALWAYS-APPEARS contract."
     (let [s (proj/side-effects-step [(db-changed-ev [[[:counter] 0 1 :edit]])])]
       (is (= :side-effects (:step s)) "SIDE EFFECTS step present on a bare :db")
-      (is (has-sub? s :db) ":db sub-step present")
-      (is (= 1 (count (sub-rows s :db))))
-      (is (= :db (-> (sub-rows s :db) first :fx-id)))
-      (is (= :ok (-> (sub-rows s :db) first :status)) ":db committed → ✓")
-      (is (= :ok (sub-status s :db)) ":db sub-step :ok")
-      (is (not (has-sub? s :fx)) "no :fx → no :fx sub-step"))))
+      (is (= [:db] (ids-of s)) "the only row is the :db row")
+      (is (= :ok (-> (row-with-id s :db) :status)) ":db committed → ✓")
+      (is (= :ok (proj/side-effects-badge-status (:rows s)))) ))
 
-(deftest side-effects-db-sub-step-schema-fail-test
-  (testing "rf2-kt6js — a post-commit app-db schema failure that rolled
-            the cascade back paints the :db sub-step ✗ (:status :error)
-            so `step-status` reads :error and the :where :app-db reason
-            box attaches to the :db row"
+  (testing "rf2-j630b — :db row leads, then the :fx rows in order"
+    (let [s (proj/side-effects-step
+              [(do-fx-ev {:db {:n 1} :fx [[:http/post {}] [:navigate {}]]})
+               (db-changed-ev [[[:n] 0 1 :edit]])
+               (fx-handled-ev :http/post {} 1.0)
+               (fx-handled-ev :navigate {} 0.2)])]
+      (is (= [:db :http/post :navigate] (ids-of s))
+          ":db first, then :fx vector in execution order"))))
+
+(deftest side-effects-db-row-schema-fail-only-test
+  (testing "rf2-j630b — a :db schema-fail (pre-commit transactional)
+            rolls back BEFORE any :fx ran (atomicity): the ledger carries
+            just the :db CROSS row + badge cross, NO fx rows"
     (let [s (proj/side-effects-step
               [(db-changed-ev [])
                (schema-violation-ev :app-db :counter/inc [:counter] -3 true)])]
-      (is (has-sub? s :db) ":db sub-step present on a rolled-back commit")
-      (is (= :error (-> (sub-rows s :db) first :status)) ":db row ✗ on schema-fail")
-      (is (= :error (sub-status s :db)) ":db sub-step :error"))))
+      (is (= [:db] (ids-of s)) ":db-only ledger on a rolled-back commit")
+      (is (= :error (-> (row-with-id s :db) :status)) ":db row ✗ on schema-fail")
+      (is (= :error (proj/side-effects-badge-status (:rows s)))
+          "badge cross when the :db row failed"))))
 
-;; ---- :fx sub-step — per-effect tick (rf2-kt6js) -------------------------
+;; ---- per-row glyph + badge AND-of-rows (rf2-j630b) ----------------------
 
-(deftest side-effects-fx-sub-step-per-effect-tick-test
-  (testing "rf2-kt6js — each :fx entry carries a per-effect tick:
-            ✓ ran / ✗ threw / ↺ overridden / · skipped-on-platform.
+(deftest side-effects-per-row-status-test
+  (testing "rf2-j630b — each :fx row carries a per-effect status:
+            :ok ran / :error threw / :overridden / :skipped on-platform.
             Per-fx success is ALREADY RECORDED on the trace stream."
     (let [s  (proj/side-effects-step
                [(fx-handled-ev :http/post {} 1.0)
                 (ev :rf.fx :rf.fx/override-applied {:rf.fx/id :metrics})
                 (ev :warning :rf.fx/skipped-on-platform {:rf.fx/id :clipboard})
                 (ev :error :rf.error/fx-handler-exception {:rf.fx/id :bad-fx})])
-          rows (sub-rows s :fx)
-          by   (into {} (map (juxt :fx-id :status) rows))]
-      (is (= 4 (count rows)))
+          by (into {} (map (juxt :fx-id :status) (:rows s)))]
+      (is (= 4 (count (:rows s))))
       (is (= :ok         (:http/post by)) ":rf.fx/handled → :ok")
       (is (= :overridden (:metrics   by)) ":rf.fx/override-applied → :overridden")
       (is (= :skipped    (:clipboard by)) ":rf.fx/skipped-on-platform → :skipped")
       (is (= :error      (:bad-fx    by)) "fx-handler-exception → :error")
-      (is (= :error (sub-status s :fx)) "any ✗ fx → sub-step :error")
       (is (= 1 (:threw s)) "threw count = the one fx that threw"))))
+
+(deftest side-effects-badge-and-of-rows-test
+  (testing "rf2-j630b — the badge is the AND of the present rows: cross
+            iff ≥1 real failure; SKIPPED rows are NEUTRAL (don't trip it)"
+    ;; all ✓ → :ok
+    (is (= :ok (proj/side-effects-badge-status
+                 (:rows (proj/side-effects-step
+                          [(fx-handled-ev :http/post {} 1.0)])))))
+    ;; a SKIPPED row alongside an ✓ row stays :ok (skipped is neutral)
+    (is (= :ok (proj/side-effects-badge-status
+                 (:rows (proj/side-effects-step
+                          [(fx-handled-ev :http/post {} 1.0)
+                           (ev :warning :rf.fx/skipped-on-platform
+                               {:rf.fx/id :clipboard})]))))
+        "a skipped row is neutral — badge stays ✓")
+    ;; one ✗ row trips the badge to cross even alongside ✓ + skipped rows
+    (is (= :error (proj/side-effects-badge-status
+                    (:rows (proj/side-effects-step
+                             [(fx-handled-ev :http/post {} 1.0)
+                              (ev :warning :rf.fx/skipped-on-platform
+                                  {:rf.fx/id :clipboard})
+                              (ev :error :rf.error/fx-handler-exception
+                                  {:rf.fx/id :bad-fx})])))))
+    ;; an attached exception (post-build) lifts the badge even if the row
+    ;; status itself was :ok at build time
+    (is (= :error (proj/side-effects-badge-status
+                    [{:fx-id :http/get :status :ok
+                      :errors [{:operation :rf.error/fx-handler-exception}]}]))
+        "an attached :errors vec lifts the badge to cross")))
 
 (deftest side-effects-fx-reads-canonical-elapsed-ms-test
   (testing "rf2-ipaza — :fx row duration resolves through the canonical
@@ -1293,24 +1322,23 @@
     (let [s (proj/side-effects-step
               [{:op-type :rf.fx :operation :rf.fx/handled
                 :tags {:rf.fx/id :http/post :rf.fx/elapsed-ms 3.4}}])]
-      (is (= 3.4 (-> (sub-rows s :fx) first :duration-ms))))
+      (is (= 3.4 (-> s :rows first :duration-ms))))
     (let [s (proj/side-effects-step
               [{:op-type :rf.fx :operation :rf.fx/handled
                 :tags {:rf.fx/id :http/get :duration-ms 7.7}}])]
-      (is (= 7.7 (-> (sub-rows s :fx) first :duration-ms))
+      (is (= 7.7 (-> s :rows first :duration-ms))
           "legacy :duration-ms fallback retained for older fixtures"))))
 
 (deftest side-effects-fx-attribution-from-machine-actions-test
   (testing "rf2-uffov — when a machine action's outcome :fx emits a
-            fx-id, the corresponding :fx sub-step row carries
-            :attributed-to"
+            fx-id, the corresponding :fx ledger row carries :attributed-to"
     (let [evs [(ev :rf.machine :rf.machine/action-ran
                    {:action-id :open-socket
                     :phase     :entry
                     :outcome   {:fx [[:http/get {:url "/x"}]]}
                     :input     {:data {} :event nil}})
                (fx-handled-ev :http/get {:url "/x"} 5.0)]
-          row (-> (proj/side-effects-step evs) (sub-rows :fx) first)]
+          row (row-with-id (proj/side-effects-step evs) :http/get)]
       (is (= :http/get (:fx-id row)))
       (is (= :open-socket (-> row :attributed-to :action-id)))
       (is (= :entry       (-> row :attributed-to :phase)))))
@@ -1318,51 +1346,39 @@
   (testing "rf2-uffov — pure reg-event-fx cascades have no per-action
             attribution; the slot stays absent"
     (let [row (-> (proj/side-effects-step [(fx-handled-ev :http/post {} 0.1)])
-                  (sub-rows :fx) first)]
+                  :rows first)]
       (is (not (contains? row :attributed-to))))))
 
-;; ---- other sub-step — dropped top-level effects (rf2-kt6js) -------------
+;; ---- other (dropped top-level) rows (rf2-j630b) -------------------------
 
-(deftest side-effects-other-sub-step-test
-  (testing "rf2-kt6js — a top-level effect key beyond :db/:fx on the
-            handler's returned map is surfaced in the `other` sub-step
-            as a :skipped (not-run) DIAGNOSTIC. re-frame2's effect map
-            is the closed {:db :fx} shape — `run-fx-effects!` reads only
-            :fx — so any other key is DROPPED (never executed/traced).
-            The `other` sub-step flags the dropped effect rather than
-            leaving the operator to wonder why nothing fired."
-    (let [;; `:rf.event/fx` is stamped as the FULL effects map on the
-          ;; do-fx marker only in the legacy/defensive shape; `effects-
-          ;; decomp` reads the map form and projects MINUS :db/:fx.
-          s     (proj/side-effects-step
-                  [(do-fx-ev {:db {:n 1}
-                              :fx [[:http/post {}]]
-                              :legacy/persist {:to :disk}})
-                   (db-changed-ev [])
-                   (fx-handled-ev :http/post {} 1.0)])
-          rows  (sub-rows s :other)]
-      (is (has-sub? s :other) "other sub-step present when a non-:db/:fx key exists")
-      (is (= 1 (count rows)))
-      (is (= :legacy/persist (-> rows first :fx-id)))
-      (is (= :skipped (-> rows first :status)) "dropped effect = :skipped")
-      (is (= {:to :disk} (-> rows first :value)))))
+(deftest side-effects-other-rows-test
+  (testing "rf2-j630b — a top-level effect key beyond :db/:fx on the
+            handler's returned map is surfaced as a :skipped (not-run)
+            DIAGNOSTIC row at the END of the ledger. re-frame2's effect
+            map is the closed {:db :fx} shape — `run-fx-effects!` reads
+            only :fx — so any other key is DROPPED (never executed)."
+    (let [s    (proj/side-effects-step
+                 [(do-fx-ev {:db {:n 1}
+                             :fx [[:http/post {}]]
+                             :legacy/persist {:to :disk}})
+                  (db-changed-ev [])
+                  (fx-handled-ev :http/post {} 1.0)])
+          row  (row-with-id s :legacy/persist)]
+      (is (= [:db :http/post :legacy/persist] (ids-of s))
+          ":db first, :fx next, dropped `other` effect last")
+      (is (= :skipped (:status row)) "dropped effect = :skipped")
+      (is (= {:to :disk} (:value row)))
+      (is (= :ok (proj/side-effects-badge-status (:rows s)))
+          "a dropped (skipped) `other` row is neutral — badge stays ✓")))
 
-  (testing "rf2-kt6js — the canonical {:db :fx} shape yields NO other
-            sub-step (the common case)"
+  (testing "rf2-j630b — the canonical {:db :fx} shape yields NO `other`
+            rows (the common case)"
     (let [s (proj/side-effects-step
               [(do-fx-ev {:db {:n 1} :fx [[:http/post {}]]})
                (db-changed-ev [])
                (fx-handled-ev :http/post {} 1.0)])]
-      (is (not (has-sub? s :other))
-          "closed {:db :fx} shape → no other sub-step"))))
-
-(deftest side-effects-sub-step-order-test
-  (testing "rf2-kt6js — sub-steps render in fixed order :db → :fx → other"
-    (let [s (proj/side-effects-step
-              [(do-fx-ev {:db {} :fx [[:http/post {}]] :legacy/x 1})
-               (db-changed-ev [])
-               (fx-handled-ev :http/post {} 1.0)])]
-      (is (= [:db :fx :other] (:sub-kinds s))))))
+      (is (= [:db :http/post] (ids-of s))
+          "closed {:db :fx} shape → no `other` rows"))))
 
 ;; ---- SUBSCRIPTIONS ------------------------------------------------------
 
@@ -1674,9 +1690,9 @@
   happened, INCLUDING a bare reg-event-db with no `:fx` (`db-commit?`
   keys off `:rf.event/db-changed`). Pre-rf2-kt6js a plain reg-event-db
   surfaced NO side-effects step at all (the FX step keyed off a
-  non-existent fx-id-less `:rf.fx/handled`). The minimal :db-writing
-  cascade is now :dispatch + :handler + :side-effects (a :db sub-step
-  only)."
+  non-existent fx-id-less `:rf.fx/handled`). rf2-j630b — the minimal
+  :db-writing cascade is :dispatch + :handler + :side-effects (a flat
+  ledger with the single :db row)."
     (let [rec   (record [(dispatched-ev [:counter-inc] :ui nil)
                          (db-changed-ev [[[:counter] 5 6 :modified]])])
           steps (proj/project rec)
@@ -1684,8 +1700,8 @@
       (is (= 3 (count steps)))
       (is (= [:dispatch :handler :side-effects] (mapv :step steps)))
       (is (some? se) "SIDE EFFECTS step present on a bare :db write")
-      (is (= [:db] (:sub-kinds se))
-          "only the :db sub-step — no :fx, no other"))))
+      (is (= [:db] (mapv :fx-id (:rows se)))
+          "the flat ledger carries the single :db row — no :fx, no other"))))
 
 (deftest project-no-db-no-fx-omits-side-effects-test
   (testing "rf2-kt6js — a cascade with NO :db commit and NO :fx (e.g. a
@@ -2133,15 +2149,16 @@
 ;; helpers section.
 
 (deftest project-attaches-app-db-violation-to-fx-db-row-test
-  (testing "rf2-8resu / rf2-kt6js — top-level `project` attaches
-            `:app-db` boundary violations to the SIDE EFFECTS step's
-            `:db` row (the handler's app-db write). The step is
-            synthesised when a `:db` commit was attempted (here both a
-            `:rf.event/db-changed` AND a `:where :app-db` rollback fire).
-            The `:db` sub-step's row carries `:status :error` (✗ on the
-            schema-fail rollback) + the attached violation. HANDLER stays
-            clean — it describes what the handler RETURNED; the commit
-            outcome is the SIDE EFFECTS `:db` row's concern."
+  (testing "rf2-8resu / rf2-kt6js / rf2-j630b — top-level `project`
+            attaches `:app-db` boundary violations to the SIDE EFFECTS
+            step's `:db` row (the handler's app-db write, leading the flat
+            ledger). The step is synthesised when a `:db` commit was
+            attempted (here both a `:rf.event/db-changed` AND a `:where
+            :app-db` rollback fire). The `:db` row carries `:status
+            :error` (✗ on the schema-fail rollback) + the attached
+            violation, and is the ONLY row (atomicity — no fx ran).
+            HANDLER stays clean — it describes what the handler RETURNED;
+            the commit outcome is the SIDE EFFECTS `:db` row's concern."
     (let [rec     (record [(dispatched-ev [:counter/inc] :ui nil)
                            (db-changed-ev [[[:count] 0 "boom" :modified]])
                            (schema-violation-ev :app-db :counter/inc
@@ -2149,24 +2166,24 @@
           steps   (proj/project rec)
           handler (some #(when (= :handler (:step %)) %) steps)
           se      (some #(when (= :side-effects (:step %)) %) steps)
-          db-rows (proj/sub-rows-of se :db)
-          db-row  (first db-rows)]
+          db-row  (some #(when (= :db (:fx-id %)) %) (:rows se))]
       (is (some? handler))
       (is (nil? (:violations handler))
           "HANDLER step carries no violations — routing moved to the :db row")
       (is (some? se)
           "SIDE EFFECTS step is synthesised when a :where :app-db rollback
            fires even with no user-emitted fx")
-      (is (some? (some #{:db} (:sub-kinds se))) ":db sub-step present")
-      (is (= :error (proj/sub-step-status db-rows))
-          ":db sub-step :error on rollback — the attached violation lifts it")
+      (is (= [:db] (mapv :fx-id (:rows se)))
+          ":db-only flat ledger on a rolled-back commit")
+      (is (= :error (proj/side-effects-badge-status (:rows se)))
+          "badge :error on rollback — the attached violation lifts it")
       (is (some? db-row)
-          "the SIDE EFFECTS step's :db sub-step carries the :db row")
+          "the SIDE EFFECTS step's flat ledger carries the :db row")
       (is (= :error (:status db-row))
           "the :db row's status reflects the schema-fail rollback")
       (is (= 1 (count (:violations db-row)))
           "the :app-db violation attached to the :db row flows through to the
-           rendered sub-step (single-source-of-truth :rows slot)")
+           rendered ledger row (single-source-of-truth :rows slot)")
       (is (true? (-> db-row :violations first :rollback?)))
       (is (not-any? #(= :schema-violations (:step %)) steps)
           "the retired aggregate SCHEMA-VIOLATIONS step never appears")

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -14,6 +14,7 @@
             [re-frame.substrate.plain-atom :as plain-atom]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]
+            [day8.re-frame2-xray.panels.epoch.badge :as badge]
             [day8.re-frame2-xray.panels.epoch.view :as view]
             [day8.re-frame2-xray.panels.epoch-panel :as epoch-orchestrator]))
 
@@ -928,53 +929,111 @@
 ;; `project-attaches-app-db-violation-to-fx-db-row-test` pins down
 ;; that no tail step is appended.
 
-;; ---- rf2-kt6js — SIDE EFFECTS step (:db / :fx / other sub-steps) ------
-;; rf2-uffov — per-action attribution + the threw-count header chip;
-;; rf2-g1mfc — per-:fx-row open-code chip; rf2-kt6js — the :fx step
-;; became the SIDE EFFECTS step.
+;; ---- rf2-j630b — SIDE EFFECTS flat per-effect ledger ------------------
+;; rf2-uffov — per-action attribution; rf2-g1mfc — per-row open-code chip;
+;; rf2-kt6js — the :fx step became the SIDE EFFECTS step; rf2-j630b — the
+;; 3-tier :db/:fx/other sub-steps became a FLAT ledger + single badge.
 
 (defn- side-effects-step
-  "Build a projected SIDE EFFECTS step for the view tests (rf2-kt6js) —
-  the step the `render-side-effects-step` renderer consumes. `subs` is
-  a vec of `{:kind :rows}` groups in render order; this flattens them
-  into the single tagged `:rows` slot + the `:sub-kinds` order vec the
-  renderer reads (mirrors `projection/side-effects-step`'s output
-  shape — one row vector, each row tagged `:sub-kind`)."
-  ([subs] (side-effects-step subs 0))
-  ([subs threw]
+  "Build a projected SIDE EFFECTS step for the view tests (rf2-j630b) —
+  the FLAT-ledger step the `render-side-effects-step` renderer consumes.
+  `rows` is the flat `:rows` vec in execution order (mirrors
+  `projection/side-effects-step`'s output shape — one row vector, no
+  `:sub-kinds`)."
+  ([rows] (side-effects-step rows 0))
+  ([rows threw]
    {:step :side-effects :badge :SIDE-EFFECTS :step-number 4
-    :sub-kinds (mapv :kind subs)
-    :rows (vec (mapcat (fn [{:keys [kind rows]}]
-                         (mapv #(assoc % :sub-kind kind) rows))
-                       subs))
+    :rows (vec rows)
     :threw threw}))
 
-(deftest side-effects-step-header-shows-outcome-split-test
-  (testing "rf2-kt6js / rf2-uffov — SIDE EFFECTS step header surfaces the
-            threw-count when non-zero, beside the subdued `(post-commit)`
-            caption. The per-row ✓/✗ glyphs convey per-effect outcome;
-            the header carries only the at-a-glance error chip."
-    (let [step (side-effects-step
-                 [{:kind :db :status :ok :rows [{:fx-id :db :status :ok}]}
-                  {:kind :fx :status :error
-                   :rows [{:fx-id :http/get :status :ok}
-                          {:fx-id :bad :status :error}]}]
-                 1)
-          tree (view/render-side-effects-step step)
-          header (text-of tree "rf-xray-epoch-side-effects-header")]
-      (is (string/includes? header "(post-commit)")
-          "the subdued caption rides beside the badge")
-      (is (string/includes? header "1 threw")
-          "threw-count chip surfaces in the header when non-zero"))))
+(deftest side-effects-badge-single-status-test
+  (testing "rf2-j630b — after the SIDE EFFECTS badge the header paints ONE
+            overall glyph (no post-commit / best-effort labels, no threw
+            chip): CROSS when any row failed, TICK when all succeeded.
+            The per-row glyphs carry per-effect outcome."
+    (let [tree   (view/render-side-effects-step
+                   (side-effects-step
+                     [{:fx-id :db :status :ok}
+                      {:fx-id :http/get :status :ok}
+                      {:fx-id :bad :status :error}]
+                     1))
+          header (text-of tree "rf-xray-epoch-side-effects-header")
+          status (th/find-by-testid tree "rf-xray-epoch-side-effects-status")]
+      (is (not (string/includes? header "(post-commit)"))
+          "the post-commit caption is dropped (rf2-j630b)")
+      (is (not (string/includes? header "threw"))
+          "the threw-count chip is dropped — the single badge carries it")
+      (is (= "error" (:data-rf-xray-step-status (second status)))
+          "the single badge reads ✗ when a row failed")))
+
+  (testing "rf2-j630b — all-clean ledger → badge ✓"
+    (let [tree   (view/render-side-effects-step
+                   (side-effects-step
+                     [{:fx-id :db :status :ok}
+                      {:fx-id :http/get :status :ok}]))
+          status (th/find-by-testid tree "rf-xray-epoch-side-effects-status")]
+      (is (= "ok" (:data-rf-xray-step-status (second status))))))
+
+  (testing "rf2-j630b — a SKIPPED row is NEUTRAL — badge stays ✓"
+    (let [tree   (view/render-side-effects-step
+                   (side-effects-step
+                     [{:fx-id :http/get :status :ok}
+                      {:fx-id :clipboard/write :status :skipped}]))
+          status (th/find-by-testid tree "rf-xray-epoch-side-effects-status")]
+      (is (= "ok" (:data-rf-xray-step-status (second status)))
+          "skipped does not trip the badge to cross"))))
+
+(deftest side-effects-flat-ledger-order-test
+  (testing "rf2-j630b — rows render flat in execution order: :db first,
+            then the :fx entries, then `other`. No sub-step group
+            headers. Each row gets the global flat-row index for testids."
+    (let [tree (view/render-side-effects-step
+                 (side-effects-step
+                   [{:fx-id :db :status :ok}
+                    {:fx-id :http/post :status :ok :args {:url "/x"}}
+                    {:fx-id :legacy/persist :status :skipped :value {:to :disk}}]))]
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-fx-row-0")) ":db row at 0")
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-fx-row-1")) ":fx row at 1")
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-fx-row-2")) "other row at 2")
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-side-effects-sub-db-header"))
+          "no :db sub-step header — the ledger is flat"))))
+
+(deftest side-effects-db-row-renders-app-db-destination-marker-test
+  (testing "rf2-j630b — the :db row's args slot is the clickable
+            '→ app-db' DESTINATION marker (NOT the db diff — that lives in
+            the App-db panel). Clicking it jumps to the App-db tab."
+    (frame/reg-frame :rf/xray {})
+    (rf/with-frame :rf/xray
+      (let [tree   (view/render-side-effects-step
+                     (side-effects-step [{:fx-id :db :status :ok}]))
+            marker (th/find-by-testid tree "rf-xray-epoch-fx-row-db-destination-0")]
+        (is (some? marker) "the :db row carries the destination marker")
+        (is (= :button (first marker)) "marker is a clickable <button>")
+        (is (string/includes? (th/text-content marker) "→ app-db"))
+        (is (fn? (:on-click (second marker)))
+            "marker carries an on-click that jumps to the App-db panel")))))
+
+(deftest side-effects-skipped-row-uses-muted-en-dash-glyph-test
+  (testing "rf2-j630b — a :skipped-on-platform row leads with the muted
+            en-dash 'n/a' glyph + the gated-skip hover (NOT the
+            middle-dot, which is the :cancelled cascade glyph)"
+    (let [tree (view/render-side-effects-step
+                 (side-effects-step
+                   [{:fx-id :clipboard/write :status :skipped}]))
+          row  (th/find-by-testid tree "rf-xray-epoch-fx-row-0")]
+      (is (some? row))
+      (is (string/includes? (th/text-content row) badge/skipped-glyph)
+          "the skipped row leads with the en-dash glyph")
+      (is (not (string/includes? (th/text-content row) "·"))
+          "NOT the :cancelled middle-dot"))))
 
 (deftest side-effects-fx-row-shows-attribution-chip-test
-  (testing "rf2-uffov — when an :fx sub-step row carries :attributed-to,
+  (testing "rf2-uffov — when an :fx ledger row carries :attributed-to,
             the attribution chip renders alongside"
     (let [step (side-effects-step
-                 [{:kind :fx :status :ok
-                   :rows [{:fx-id :http/get :status :ok
-                           :attributed-to {:action-id :open-socket
-                                           :phase :entry}}]}])
+                 [{:fx-id :http/get :status :ok
+                   :attributed-to {:action-id :open-socket
+                                   :phase :entry}}])
           tree (view/render-side-effects-step step)
           chip (th/find-by-testid tree "rf-xray-epoch-fx-row-attribution-0")]
       (is (some? chip) "the attribution chip is present")
@@ -982,15 +1041,14 @@
           "the action-id rides the chip"))))
 
 (deftest side-effects-fx-row-omits-attribution-chip-when-none-test
-  (testing "rf2-uffov — :fx sub-step row without :attributed-to omits
+  (testing "rf2-uffov — :fx ledger row without :attributed-to omits
             the chip"
-    (let [step (side-effects-step
-                 [{:kind :db :status :ok :rows [{:fx-id :db :status :ok}]}])
+    (let [step (side-effects-step [{:fx-id :db :status :ok}])
           tree (view/render-side-effects-step step)]
       (is (nil? (th/find-by-testid tree "rf-xray-epoch-fx-row-attribution-0"))))))
 
 (deftest side-effects-fx-row-mounts-coord-chip-when-meta-resolves-test
-  (testing "rf2-g1mfc — each :fx sub-step row routes its fx-id through
+  (testing "rf2-g1mfc — each :fx ledger row routes its fx-id through
             `coord-chip/coord-chip` to surface a click-to-source
             affordance for the `reg-fx` registration (parity with the
             SUBSCRIPTIONS / VIEWS rows + the HANDLER verb).
@@ -1008,8 +1066,7 @@
       (let [meta-resolved? (boolean (some-> (rf/handler-meta :fx :rf.g1mfc-fixture/ping)
                                             :file string?))
             step (side-effects-step
-                   [{:kind :fx :status :ok
-                     :rows [{:fx-id :rf.g1mfc-fixture/ping :status :ok}]}])
+                   [{:fx-id :rf.g1mfc-fixture/ping :status :ok}])
             tree (view/render-side-effects-step step)]
         (is (some? (th/find-by-testid tree "rf-xray-epoch-fx-row-0"))
             "the fx row itself renders")
@@ -1520,7 +1577,7 @@
           "the other sub-header carries the singular entry chip"))))
 
 (deftest side-effects-fx-args-route-through-edn-inspector-test
-  (testing "rf2-ef2hy — :fx sub-step row's args render through the
+  (testing "rf2-ef2hy — an :fx ledger row's args render through the
             edn-inspector widget with `:default-expanded-depth 1`. Top-
             level map keys are visible inline; nested maps collapse to a
             clickable chevron so the operator can drill into a complex
@@ -1532,8 +1589,7 @@
             reflects each section's role."
     (let [tree (view/render-side-effects-step
                  (side-effects-step
-                   [{:kind :fx :status :ok
-                     :rows [{:fx-id :http/get :status :ok :args {:url "/x"}}]}]))
+                   [{:fx-id :http/get :status :ok :args {:url "/x"}}]))
           row  (th/find-by-testid tree "rf-xray-epoch-fx-row-0")]
       (is (some? row))
       (is (pos? (count (ei-mounts row)))
@@ -2458,23 +2514,27 @@
           "a clean step renders no error block"))))
 
 (deftest side-effects-renders-per-row-exception-test
-  (testing "rf2-ahhgn / rf2-kt6js — a throwing fx (button-18) surfaces
-            its message on its own :fx sub-step row via
-            `fx-row-with-violations`. The per-row testids use the GLOBAL
-            flat-row index, so the :fx row after the :db row lands at
-            index 1."
+  (testing "rf2-ahhgn / rf2-kt6js / rf2-j630b — a throwing fx (button-18)
+            surfaces its message on its OWN ledger row via
+            `fx-row-with-violations` — the per-row expand is wnvid's
+            shared 'Exception Thrown' card. The per-row testids use the
+            GLOBAL flat-row index, so the :fx row after the :db row lands
+            at index 1 (compatible with yz57h's exception-under-step)."
     (let [step (side-effects-step
-                 [{:kind :db :rows [{:fx-id :db :status :ok}]}
-                  {:kind :fx
-                   :rows [{:fx-id :button-deck/ping :status :error
-                           :errors [{:operation :rf.error/fx-handler-exception
-                                     :message "fx threw on purpose"
-                                     :failing-id :button-deck/ping
-                                     :recovery :no-recovery}]}]}]
+                 [{:fx-id :db :status :ok}
+                  {:fx-id :button-deck/ping :status :error
+                   :errors [{:operation :rf.error/fx-handler-exception
+                             :message "fx threw on purpose"
+                             :failing-id :button-deck/ping
+                             :recovery :no-recovery}]}]
                  1)
           tree (view/render-side-effects-step step)]
       (is (some? (th/find-by-testid tree "rf-xray-epoch-error-fx-row-1-0"))
           "the throwing fx row (global index 1) carries its inline error card")
+      (is (string/includes?
+            (text-of tree "rf-xray-epoch-error-fx-row-1-0-title")
+            "Exception Thrown")
+          "the per-row expand is the shared 'Exception Thrown' card (wnvid)")
       (is (string/includes?
             (text-of tree "rf-xray-epoch-error-fx-row-1-0-message")
             "fx threw on purpose")))))

--- a/tools/xray/testbeds/panel_gallery/fixtures_epoch.cljs
+++ b/tools/xray/testbeds/panel_gallery/fixtures_epoch.cljs
@@ -466,18 +466,26 @@
 ;; its own per-effect ✓/✗ tick (the shared rf2-ahhgn `:status`
 ;; primitive) AND a sub-step ✓/✗ rollup in its header:
 ;;
-;;   :db    — the handler's app-db write. ✓ committed (no rollback this
-;;            variant — the schema-fail rollback rides VARIANT 4b).
-;;   :fx    — the handler's `:fx` vector entries, one row each, exercising
-;;            the full per-effect tick set the projection's
+;; rf2-j630b — the SIDE EFFECTS step renders these as a FLAT ledger (one
+;; row per effect in execution order; no group headers):
+;;
+;;   :db    — the handler's app-db write, FIRST in the ledger. ✓ committed
+;;            (no rollback this variant — the schema-fail rollback rides
+;;            VARIANT 4b). Its args slot is the clickable `→ app-db`
+;;            destination marker (the diff lives in the App-db panel).
+;;   :fx    — the handler's `:fx` vector entries, one row each in order,
+;;            exercising the full per-effect glyph set the projection's
 ;;            `fx-outcome-op->status` maps:
 ;;              ✓ ran        (`:rf.fx/handled`)
 ;;              ↺ overridden (`:rf.fx/override-applied`)
-;;              · skipped    (`:rf.fx/skipped-on-platform`)
+;;              – skipped    (`:rf.fx/skipped-on-platform`; NEUTRAL)
 ;;   other  — a TOP-LEVEL effect key beyond `:db` / `:fx` on the returned
-;;            map. re-frame2's effect map is the closed `{:db :fx}` shape;
-;;            the runtime DROPS any other key, so the row renders the `·`
-;;            not-run diagnostic (the operator sees the dropped effect).
+;;            map, LAST in the ledger. re-frame2's effect map is the closed
+;;            `{:db :fx}` shape; the runtime DROPS any other key, so the
+;;            row renders the muted `–` not-run diagnostic (NEUTRAL).
+;;
+;; The single SIDE EFFECTS badge is the AND-of-rows: this all-actioned
+;; ledger (the skipped + dropped rows are neutral) reads ✓.
 ;;
 ;; rf2-4wywy — db snapshots + t1 so the HANDLER `:db` FULL+DIFF block
 ;; renders alongside the SIDE EFFECTS `:db` ✓ row.
@@ -486,8 +494,9 @@
   "`reg-event-fx` cascade that returns `:db` + a three-entry `:fx`
   vector (a ran effect, an overridden effect, a platform-skipped
   effect) + a stray top-level `:analytics` effect the runtime drops.
-  Exercises the SIDE EFFECTS step's `:db` / `:fx` / other sub-steps,
-  each per-effect tick variant, and the `other` not-run diagnostic."
+  Exercises the SIDE EFFECTS flat ledger (rf2-j630b) — the `:db` →
+  app-db row, each per-effect glyph variant, and the `other` not-run
+  diagnostic — under one ✓/✗ badge."
   []
   (single-epoch-history
     {:epoch-id  2

--- a/tools/xray/testbeds/panel_gallery/gallery_epoch.cljs
+++ b/tools/xray/testbeds/panel_gallery/gallery_epoch.cljs
@@ -14,12 +14,12 @@
 
   | Variant                  | Sections exercised                                 |
   |--------------------------|----------------------------------------------------|
-  | `vanilla-db`             | DISPATCH · COEFFECT · HANDLER (db FULL+DIFF) · SIDE EFFECTS (`:db` ✓) · SUBSCRIPTIONS · VIEWS |
-  | `side-effects`           | DISPATCH · HANDLER (fx) · SIDE EFFECTS — `:db` ✓ + `:fx` (✓ ran · ↺ overridden · · skipped) + other (· dropped) sub-steps, each with its per-effect tick + sub-step ✓/✗ rollup (rf2-kt6js) |
+  | `vanilla-db`             | DISPATCH · COEFFECT · HANDLER (db FULL+DIFF) · SIDE EFFECTS (flat ledger: `:db` ✓ → app-db) · SUBSCRIPTIONS · VIEWS |
+  | `side-effects`           | DISPATCH · HANDLER (fx) · SIDE EFFECTS — FLAT per-effect ledger (rf2-j630b): one row per effect in execution order — `:db` ✓ → app-db, then the `:fx` rows (✓ ran · ↺ overridden · – skipped-on-platform), then the dropped `other` row (–). Single badge ✓/✗ (AND-of-rows; skipped neutral) |
   | `machine-driven`         | DISPATCH · HANDLER (machine cascade: GUARDS · LIFECYCLE · TRANSITION · AFTER-TIMERS) · SIDE EFFECTS |
-  | `db-schema-fail`         | DISPATCH · HANDLER (db) · SIDE EFFECTS (`:db` ✗ schema-fail rollback — the `:where :app-db` violation reason box rides the `:db` row, step + sub-step + tick paint ✗, `:outcome :error`, SUBSCRIPTIONS / VIEWS mute downstream — rf2-kt6js / rf2-8resu) |
+  | `db-schema-fail`         | DISPATCH · HANDLER (db) · SIDE EFFECTS (flat ledger: `:db` ✗ schema-fail rollback ONLY — the `:where :app-db` violation reason box rides the `:db` row, badge + row paint ✗, no fx rows ran, `:outcome :error`, SUBSCRIPTIONS / VIEWS mute downstream — rf2-j630b / rf2-8resu) |
   | `exception`              | DISPATCH · HANDLER (✗ — inline 'Exception Thrown' block: message + collapsible stack/ex-data, `— no :db (handler threw)` placeholder, NO 'Rolled back' chip, `:outcome :error` — rf2-ahhgn / rf2-wnvid) |
-  | `fx-exception`           | DISPATCH · HANDLER (db) · SIDE EFFECTS (`:fx` row ✗ — inline 'Exception Thrown' card on the throwing `:email/send` row, `1 threw` header chip, committed `:db` NOT rolled back — rf2-ahhgn) |
+  | `fx-exception`           | DISPATCH · HANDLER (db) · SIDE EFFECTS (flat ledger: `:db` ✓ then the `:fx` rows; the throwing `:email/send` row ✗ with its inline 'Exception Thrown' card; badge ✗; committed `:db` NOT rolled back — rf2-ahhgn / rf2-j630b) |
   | `caused-by-subs`         | DISPATCH · HANDLER (db) · SUBSCRIPTIONS — `caused by <event-id>` cell (rf2-1cc03) + static `:input-signals` inputs column (layer-1 → `app-db`, derived → upstream sub-ids — rf2-87c8a) |
   | `handler-flow-db`        | DISPATCH · HANDLER (`:db` diff = handler-only, t1) · FLOW (`:db` diff = flow's t1→t2 reshape) — the two `:db` contributions as SEPARATE steps (rf2-4wywy / rf2-48oc4) |
   | `child-dispatches`       | DISPATCH · HANDLER (fx) · SIDE EFFECTS · CHILD DISPATCHES (resolved + not-in-buffer) |
@@ -89,26 +89,28 @@
   (story/reg-variant :story.xray.epoch/vanilla-db
     {:doc        "Vanilla `reg-event-db` cascade — counter-inc shape.
                  Exercises DISPATCH + COEFFECT + HANDLER (db FULL+DIFF
-                 sub-section) + SIDE EFFECTS (`:db` ✓ — a bare
-                 reg-event-db that returns only `:db` now lights the
-                 step's `:db` sub-step, rf2-kt6js) + SUBSCRIPTIONS +
-                 VIEWS."
+                 sub-section) + SIDE EFFECTS (flat ledger with a single
+                 `:db` ✓ → app-db row — a bare reg-event-db that returns
+                 only `:db` still lights the step, rf2-kt6js / rf2-j630b)
+                 + SUBSCRIPTIONS + VIEWS."
      :events     [[:rf.xray/sync-epoch-history (fixtures/vanilla-db-history)]]
      :tags       #{:dev :state/small}
      :substrates #{:reagent}})
 
-  ;; ----- 2. SIDE EFFECTS step (rf2-kt6js) ----------------------------
+  ;; ----- 2. SIDE EFFECTS flat ledger (rf2-j630b) ---------------------
   (story/reg-variant :story.xray.epoch/side-effects
-    {:doc        "SIDE EFFECTS step showcase (rf2-kt6js) — handler
+    {:doc        "SIDE EFFECTS flat per-effect ledger (rf2-j630b,
+                 supersedes the rf2-kt6js 3-tier sub-steps) — handler
                  returns `:db` + a three-entry `:fx` vector + a stray
-                 top-level `:analytics` effect. Exercises all three
-                 sub-steps in fixed order `:db → :fx → other`, each
-                 with its per-effect tick: `:db` ✓ committed; `:fx`
-                 ✓ ran (`:http/post`) · ↺ overridden (`:analytics/track`)
-                 · · skipped-on-platform (`:clipboard/write`); other
-                 `:analytics` · dropped (the runtime executes only
-                 `{:db :fx}`). Each sub-step carries a ✓/✗ rollup in its
-                 header off the shared rf2-ahhgn `:status` primitive."
+                 top-level `:analytics` effect. Exercises the flat ledger:
+                 ONE row per effect in execution order, NO group headers —
+                 `:db` ✓ → app-db (the clickable destination marker, not
+                 the diff), then `:http/post` ✓ ran · `:analytics/track`
+                 ↺ overridden · `:clipboard/write` – skipped-on-platform,
+                 then `:analytics` – dropped (the runtime executes only
+                 `{:db :fx}`). After the badge: ONE overall ✓/✗ glyph
+                 (AND-of-rows; the skipped + dropped rows are NEUTRAL, so
+                 this all-actioned ledger reads ✓). No post-commit labels."
      :events     [[:rf.xray/sync-epoch-history (fixtures/reg-event-fx-history)]]
      :tags       #{:dev :state/small}
      :substrates #{:reagent}})
@@ -125,16 +127,17 @@
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
 
-  ;; ----- 4. SIDE EFFECTS `:db` schema-fail rollback (rf2-kt6js) ------
+  ;; ----- 4. SIDE EFFECTS `:db` schema-fail rollback (rf2-j630b) ------
   (story/reg-variant :story.xray.epoch/db-schema-fail
     {:doc        "Cascade where the app-db boundary schema rejected the
                  handler's `:db` write and rolled the cascade back.
-                 Exercises the SIDE EFFECTS step's `:db` ✗ schema-fail
-                 state (rf2-kt6js / rf2-8resu): the `:where :app-db`
-                 violation attaches to the `:db` row with its reason
-                 box; the step header + the `:db` sub-step + the
-                 per-effect tick all paint ✗; the epoch `:outcome`
-                 flips `:error`; SUBSCRIPTIONS / VIEWS mute downstream.
+                 Exercises the flat ledger's `:db` ✗ schema-fail state
+                 (rf2-j630b / rf2-8resu) under ATOMICITY: the pre-commit
+                 rollback fires BEFORE any `:fx`, so the ledger carries
+                 just the `:db` CROSS row — the `:where :app-db` violation
+                 attaches to it with its reason box; the single badge +
+                 the `:db` row both paint ✗; the epoch `:outcome` flips
+                 `:error`; SUBSCRIPTIONS / VIEWS mute downstream.
                  Hot-reload drift is an Issues-panel concern (rf2-7gf7v)
                  — no cascade step surfaces it."
      :events     [[:rf.xray/sync-epoch-history (fixtures/schema-violations-history)]]
@@ -157,16 +160,17 @@
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
 
-  ;; ----- 4b. fx-handler-threw EXCEPTION (rf2-ahhgn) -----------------
+  ;; ----- 4b. fx-handler-threw EXCEPTION (rf2-ahhgn · rf2-j630b) ------
   (story/reg-variant :story.xray.epoch/fx-exception
     {:doc        "`reg-event-fx` cascade whose `:db` committed cleanly
                  but a post-commit `:fx` handler (`:email/send`) threw
-                 (`:rf.error/fx-handler-exception`). Exercises the SIDE
-                 EFFECTS step's per-`:fx`-row 'Exception Thrown' card
-                 (`attach-to-fx-error-row` matches the throwing row by
-                 `:fx-id`), the row's ✗ tick, the `1 threw` header chip,
-                 and the contract that the committed `:db` is NOT rolled
-                 back on a post-commit fx throw (rf2-wnvid)."
+                 (`:rf.error/fx-handler-exception`). Exercises the flat
+                 ledger's per-row exception: `:db` ✓ leads, then the `:fx`
+                 rows, with the throwing `:email/send` row ✗ carrying its
+                 inline 'Exception Thrown' card (`attach-to-fx-error-row`
+                 matches the row by `:fx-id`); the single badge reads ✗;
+                 the committed `:db` is NOT rolled back on a post-commit
+                 fx throw (rf2-wnvid)."
      :events     [[:rf.xray/sync-epoch-history (fixtures/fx-exception-history)]]
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
@@ -346,10 +350,11 @@
                 rf2-5qp4g per-source-kind enrichment variants
                 (after-timer / machine-spawn / fx-dispatch /
                 fx-dispatch-later / fx-dispatch-orphan). The
-                rf2-rmg2k refresh surfaces the SIDE EFFECTS step
-                (`:db`/`:fx`/other sub-steps + per-effect ticks +
-                `:db` schema-fail), the inline 'Exception Thrown'
-                block (handler + fx throws), the subscriptions
+                rf2-j630b refresh surfaces the SIDE EFFECTS step as a
+                FLAT per-effect ledger (one row per effect in execution
+                order + a single ✓/✗ badge + the `:db` → app-db marker +
+                the `:db` schema-fail rollback), the inline 'Exception
+                Thrown' block (handler + fx throws), the subscriptions
                 `caused by <event-id>` cell + static `:input-signals`
                 inputs column, and the handler-`:db` vs flow-`:db`-diff
                 split."


### PR DESCRIPTION
Redesigns the Epoch panel SIDE EFFECTS step (rf2-kt6js's 3-tier `:db` / `:fx` / other sub-steps + post-commit labels, #2533) into a **FLAT per-effect ledger** per the rf2-j630b live walkthrough with Mike. Supersedes the kt6js presentation; subsumes the closed rf2-jizpb (`:db` row absent when the handler threw).

## Design as built

- **Single badge status.** After "SIDE EFFECTS" the header paints ONE overall glyph — `✓` when every present row succeeded, `✗` when one or more FAILED (`projection/side-effects-badge-status` = the AND of the present rows; SKIPPED rows are NEUTRAL and never trip it). All post-commit / best-effort labels + the `(post-commit)` caption + the threw-count chip are dropped.
- **Flat ledger.** One row per effect, in EXECUTION order, with NO group headers: synthesised `:db` row first (when present), then the `:fx` vector in order, then `other`. Each row = leading status glyph + effect-id + args edn-inspector, via `fx-row-with-violations`.
- **Glyphs.** `✓` :ok / `✗` :error|:rollback / `↺` :overridden / `–` :skipped — the muted en-dash "n/a" (tertiary tone, hover "skipped on this platform — gated, didn't run here"). Avoids the `·` middle-dot (the `:cancelled` cascade glyph) and the circled-slash (reads error-ish). Centralised in `badge.cljc` (`fx-row-status-glyph` / `-colour` / `-token-key` + `skipped-glyph` / `skipped-hover`).
- **`:db` row.** Its args slot is the clickable `→ app-db` DESTINATION marker — NOT the db diff (that lives in the App-db panel; no duplication). Clicking dispatches `[:rf.xray/select-tab :app-db]` (the App-db panel reads the same shared focus). The `:db` row is OPTIONAL: present on any `:db` commit (incl. a bare reg-event-db), ABSENT when the handler returned only `:fx` / nothing or THREW (no phantom `:db`, rf2-wnvid).
- **Atomicity.** A `:db` schema-fail (pre-commit transactional) rolls back BEFORE any `:fx` ran → the ledger carries just the `:db` CROSS row + badge cross, no fx rows.
- **Exceptions.** A throwing row's expand is wnvid's shared "Exception Thrown" card (`attach-to-fx-error-row` matches by `:fx-id`; unmatched fx errors attach at step level). Per-row rendering kept compatible with the held rf2-yz57h (exception-under-step).
- **Always appears** on any effect (db / fx / other); absent if none.

Retired the 3-tier helpers (`side-effects-sub-kind-order` / `sub-rows-of` / `sub-step-status` in projection; `side-effects-sub-label` / `sub-step-header` / `other-effect-row-view` / `render-side-effects-sub-step` + the orphaned `fx-verb`/`fx-caption`/`fx-threw` styles in view).

## Settle-first note

Read the kt6js 3-tier code in `panels/epoch/{projection.cljc,view.cljs,badge.cljc}` and reused ahhgn's `step-status` / `badge/step-status-*` primitive. The DATA SOURCE is UNCHANGED — only the presentation flattens: the `:effects` projection still gives `{:fx-id :args :outcome}` per fx (`:ok` / `:error` / `:skipped-on-platform`); the `:db` row stays SYNTHESISED from the db change + commit status (rf2-8resu `db-effect-row`, NOT in `:effects`). No core / spec-009 edit. Reconciled with rf2-4wywy (HANDLER `:db` vs FLOW `:db`-diff stay separate steps).

Also refreshed `tools/xray/testbeds/panel_gallery/{gallery_epoch,fixtures_epoch}.cljs` (the rmg2k 3-tier refresh) to the flat ledger, and updated `tools/xray/spec/021` §9.1.10.6 + the cross-panel-navigation table.

## Quality gates

- `npm run test:cljs` — **5068 tests / 17049 assertions, 0 failures, 0 errors**. New tests: flat order (`:db` first), per-row tick/cross/skipped, badge AND-of-rows (skipped neutral), `:db` schema-fail → `:db`-cross-only (atomicity), `:db`-absent-when-threw, the `→ app-db` marker (clickable button), per-row "Exception Thrown" card, the en-dash skipped glyph distinct from `:cancelled`.
- `npm run test:xray-feature-gate` — **14 scenarios, 0 failures** (12 matrix rows).
- `npm run test:bundle-isolation` — **PASS** (bundle-isolation + uix-helix-reagent-free).
- clj-kondo — **0 errors, 0 new warnings** (the 3 remaining warnings are pre-existing on origin/main).
- `testbeds/panel-gallery` build — **clean** (590 files, 0 warnings).

Closes rf2-j630b.
