### PR TITLE
feat(xray/trace): flatten the Trace panel to a single row list + stage column + colour-coded edge + click-to-edn (rf2-aqusw)

### DIFF
--- a/tools/xray/spec/023-Trace-Panel.md
+++ b/tools/xray/spec/023-Trace-Panel.md
@@ -26,46 +26,54 @@ Owner: tools/xray.
 
 ## §1 Purpose & scope
 
-The Trace panel renders the **complete trace arc of a single epoch** — every trace operation the substrate emits during the epoch, in fire order, organised by the epoch's phase shape. It is the comprehensive lens on what happened, complementing:
+The Trace panel renders the **complete trace of a single epoch** — every trace operation the substrate emits during the epoch, in fire order, as a **single flat list of rows** (rf2-aqusw). It is the comprehensive lens on what happened, complementing:
 - the **Epoch panel** (curated handling-pipeline narrative — [`021`](./021-Dynamic-Panel-Designs.md) §9.1), and
 - the **Views panel** (the reactive subgraph as a graph — [`021`](./021-Dynamic-Panel-Designs.md) §3).
 
 The Trace panel's contract is **completeness**: it must surface *every* op-family in the Spec-009 trace vocabulary, including lifecycle ops other panels omit (view unmounted, sub disposed, coeffect run, view mounted).
 
-## §2 Layout
+## §2 Layout (flat list — rf2-aqusw)
 
-- **No top chrome.** No title bar, no filter bar, no summary/profile strip. The panel opens directly on the arc.
-- **Arc envelope.** An `EPOCH OPEN` row and an `EPOCH CLOSE` row bracket the arc and carry the epoch-lifecycle ops (`:rf.epoch/*`): open shows epoch id · event · frame · `snapshotted` (from `:rf.epoch/snapshotted`); close shows `:rf.epoch/outcome` (the consumer-facing summary `:ok` / `:blocked` / `:error` per [Spec 009 §`:rf.epoch/*`](../../../spec/009-Instrumentation.md#op-type-vocabulary) — rf2-18g1w / rf2-jppad). Restore/replay/db-replaced lifecycle ops, when they occur, render in the envelope.
-- **Four phase bands** (collapsible), in arc order:
-  - **① DISPATCH** — the event dispatched (trigger + origin).
-  - **② EVENT HANDLING** — coeffects (injected inputs) → handler ran → **flows** (transform the pending `:db`, right after the handler per rf2-u0zz5) → db changed (net, at install). (Interceptors are not separately traced; before-interceptor injection surfaces as COEFFECT rows, after-interceptor effects as the FX/DB rows they produce.)
-  - **③ EFFECTS / FX** — fx handlers (db install + fx execution; flows are NOT here — they run in ② after the handler).
-  - **④ REACTIVE RENDERING** — the reactive flush: subscriptions → views.
-- **Chronological within and across bands** — every row carries a Δt from epoch open; ordering is strict fire order.
+- **No top chrome.** No title bar, no filter bar, no summary/profile strip. The panel opens directly on the list.
+- **A single flat list — no hierarchy.** Every op the focused epoch emitted is one row, in strict fire order (oldest-first). There is **no envelope** and **no phase-band nesting** — the 4-band hierarchy was replaced (rf2-aqusw) because it was hard to scan. The epoch-lifecycle ops (`:rf.epoch/*` — snapshotted / outcome / restore / replay / db-replaced) render as **ordinary rows** in the flat list (no longer bracketed in an envelope); `:rf.epoch/outcome` carries the consumer-facing summary `:ok` / `:blocked` / `:error` per [Spec 009 §`:rf.epoch/*`](../../../spec/009-Instrumentation.md#op-type-vocabulary) (rf2-18g1w / rf2-jppad).
+- **Stage recovers the phase shape flatly (§3a).** The phase information the bands conveyed is recovered per-row by a **stage column** + a **colour-coded left edge** — each row names the Epoch-panel pipeline step it belongs to.
+- **Chronological** — every row carries a Δt from the epoch's first op; ordering is strict fire order.
 - **Show every op** — no default filtering or collapse (completeness-first).
 
 ## §3 Row anatomy
 
-Columns: **Δt · area badge · what-happened · target/detail · duration**.
+Columns: **Δt · stage · area badge · what-happened · target/detail · duration**.
 
-- **Δt** — ms offset from `EPOCH OPEN`.
+- **Δt** — ms offset from the epoch's first op.
+- **stage** — the Epoch-panel pipeline step this op belongs to (§3a): `DISPATCH` · `COEFFECT` · `HANDLER` · `FLOW` · `SIDE EFFECTS` · `SUBSCRIPTIONS` · `VIEWS`. The label rides the step's own colour.
 - **area badge** — a neutral text badge (no per-family colour): `EVENT` · `COEFFECT` · `DB` · `FX` · `FLOW` · `SUB` · `VIEW` · `MACHINE` · `ROUTING` · `EPOCH` · `ERROR` · `WARNING`.
 - **what-happened** — the per-area verb (§5).
 - **target/detail** — the op's subject: event vector, `fx-id → arg`, `sub-id  old→new`, `view-id ← cause-sub`, route id, path, etc.
 - **duration** — a number in **ms**, or `—` when the substrate supplies no timing (§6).
-- **Row click → expand** the full raw trace-event EDN inline (`:op-type` · `:operation` · `:tags` · timing · `:rf.trace/dispatch-id` …) via the first-class edn-inspector widget — the canonical CLJS-value renderer (the shared widget contract — [`021`](./021-Dynamic-Panel-Designs.md) §10, in particular §10.0 + §10.0.2 acceptance properties). The trace panel calls `[ei/edn-inspector value {:panel-id :rf.xray.trace/row-<id> …}]` directly (no facade hop); each row independently collapsible (the per-row `panel-id` qualifier scopes expansion state to that row, on top of the widget's own per-mount UUID).
+- **Colour-coded left edge** — a 3px left border in the row's **stage** colour (§3a). Error / warning rows override the stage colour with their severity colour so a failure stands out (§7).
+- **Row click → open the edn-inspector on the raw trace MAP** inline (`:op-type` · `:operation` · `:tags` · timing · `:rf.trace/dispatch-id` …) via the first-class edn-inspector widget — the canonical CLJS-value renderer (the shared widget contract — [`021`](./021-Dynamic-Panel-Designs.md) §10, in particular §10.0 + §10.0.2 acceptance properties). The trace panel calls `[ei/edn-inspector value {:panel-id :rf.xray.trace/row-<id> …}]` directly (no facade hop); each row independently collapsible (the per-row `panel-id` qualifier scopes expansion state to that row, on top of the widget's own per-mount UUID).
 
-## §4 Phase → op-family placement
+## §3a Stage column + colour-coded left edge (rf2-aqusw)
 
-| Phase | Op-families |
+The flat list recovers the phase information the removed bands conveyed by mapping each op to one of the **7 Epoch-panel pipeline steps** and surfacing it as both an explicit **stage column** (the label) and a **colour-coded left edge** (the at-a-glance colour). The label and colour are reused from the Epoch panel's own badge taxonomy (`panels.epoch.badge`) — **not** a parallel palette — so the Trace stage column + edge match the Epoch numbered cascade exactly. One step model, DRY.
+
+The op → stage mapping (the coarse projection of the §3 area badge onto the 7 Epoch steps):
+
+| Op (area / operation) | Epoch stage |
 |---|---|
-| envelope | `:rf.epoch/*` (open/close/restore/replay/db-replaced) |
-| ① DISPATCH | `:rf.event/dispatched` |
-| ② EVENT HANDLING | `:rf.cofx/*` · `:rf.event/run-start`·`run-end` · **`:rf.flow/*`** (right after handler) · `:rf.event/db-changed` · machine-as-handler transitions (`:rf.machine/*`, `:rf.machine.microstep/*`). Interceptors not separately traced. |
-| ③ EFFECTS / FX | `:rf.fx/*` (one row per fx-id) · machine `:after`/spawn/timer effects (`:rf.machine.timer/*`, `:rf.machine.spawn*/*`, lifecycle) · routing nav (`:rf.route/*`) |
-| ④ REACTIVE RENDERING | `:rf.sub/*` · `:rf.view/*` |
+| `:rf.event/dispatched` | DISPATCH |
+| `:rf.event/run-start` · `run-end` (handler body) | HANDLER |
+| `:rf.cofx/*` (COEFFECT) | COEFFECT |
+| `:rf.flow/*` (FLOW) | FLOW |
+| `:rf.machine/*` (machine-as-handler) | HANDLER |
+| `:rf.event/db-changed` (DB) | SIDE EFFECTS |
+| `:rf.fx/*` (FX) | SIDE EFFECTS |
+| `:rf.route/*` (ROUTING) | SIDE EFFECTS |
+| `:rf.sub/*` (SUB) | SUBSCRIPTIONS |
+| `:rf.view/*` (VIEW) | VIEWS |
+| `:rf.epoch/*` (EPOCH lifecycle) | DISPATCH (muted grey) |
 
-Errors & warnings are cross-cutting — see §7. Child epochs spawned by a `:dispatch` fx link/nest from their originating fx row (§12).
+Errors / warnings are cross-cutting (§7): the stage column still labels the step where the op chronologically occurred, but the left edge rides the severity colour.
 
 ## §5 What-happened verb taxonomy
 
@@ -92,40 +100,38 @@ Registration ops (`:rf.flow/registered`, `:rf.route/registered`, `:rf.fx/reg-flo
 
 ## §7 Errors & warnings
 
-Cross-cutting, **not a phase**. An `:rf.error/*` / `:rf.warning/*` op renders **inline at its chronological point** within whatever band it occurred in, visually emphasised so failures stand out while scanning (and error vs warning distinguishable) — exact treatment delegated to Figma (§8). It carries the failing op's context (the `:rf.error/*` operation id + ex-data). The same diagnostics also populate the Issues panel ([`021`](./021-Dynamic-Panel-Designs.md) §8).
+Cross-cutting, **not a stage**. An `:rf.error/*` / `:rf.warning/*` op renders **inline at its chronological point** in the flat list, visually emphasised so failures stand out while scanning (and error vs warning distinguishable) — the row's left edge rides the severity colour over the stage colour; exact treatment delegated to Figma (§8). It carries the failing op's context (the `:rf.error/*` operation id + ex-data). The same diagnostics also populate the Issues panel ([`021`](./021-Dynamic-Panel-Designs.md) §8).
 
 ## §8 Visual encoding (delegated to Figma)
 
 Colour and visual styling are intentionally **not specified here** — to be designed in Figma. The design must, however, make these dimensions visually distinguishable:
 
-- **Phase band** — each of the 4 bands (plus the epoch envelope) reads as a distinct segment of the arc (e.g. a band header + left rail).
+- **Stage** — each row names its Epoch pipeline step (§3a) in the **stage column** and a **colour-coded left edge** reusing the Epoch step palette (`panels.epoch.badge`). The stage column + edge must read together at a glance.
 - **Op-family** — the area badge identifies the family (EVENT · COEFFECT · DB · FX · FLOW · SUB · VIEW · MACHINE · ROUTING · EPOCH).
 - **Outcome** — the what-happened state is legible at a glance, with at least these tiers distinguished: created/changed/recalculated/mounted · cache-hit/ran-unchanged/skipped · disposed/unmounted · queued/pending.
-- **Errors / warnings** — clearly emphasised, distinct from normal ops and from each other.
+- **Errors / warnings** — clearly emphasised, distinct from normal ops and from each other (the edge rides the severity colour).
 
-## §9 Canonical layout
+## §9 Canonical layout (flat list — rf2-aqusw)
 
 ```
-○ EPOCH OPEN   #42 :counter-inc · frame :rf/default · snapshotted
-▾ ① DISPATCH
-    +0.0  EVENT     dispatched      [:counter-inc] from view↗           —
-▾ ② EVENT HANDLING
-    +0.0  COEFFECT  run             :now → #inst…                      0.1 ms
-    +0.1  EVENT     handler ran     reg-event-db                       0.2 ms
-    +0.3  FLOW      computed        :totals → [:totals]                1.5 ms
-    +1.8  DB        changed         [:counter] 1 → 2 · [:totals] 42      —
-▾ ③ EFFECTS / FX
-    +1.9  FX        :http-xhrio     GET /api/data (queued)              —
-    !2.5  ERROR     fx-handler-exc  :bad-fx "No such fx"               —
-▾ ④ REACTIVE RENDERING
-    +2.6  SUB       recalculated    :counter/value 1→2                 0.3 ms
-    +2.9  SUB       ran · unchanged :counter/parity                    0.1 ms
-    +3.0  SUB       disposed        :cart/preview (no readers)          —
-    +3.1  VIEW      re-rendered     counter-display ← :counter/value   1.8 ms
-    +4.9  VIEW      unmounted       old-tooltip                         —
-    +4.9  VIEW      mounted         new-tooltip                        0.4 ms
-● EPOCH CLOSE  outcome :ok
++0.0  DISPATCH       EVENT     dispatched      [:counter-inc] from view↗       —
++0.0  EPOCH          EPOCH     snapshotted     #42 · frame :rf/default          —
++0.0  COEFFECT       COEFFECT  run             :now → #inst…                   0.1 ms
++0.1  HANDLER        EVENT     handler ran     reg-event-db                    0.2 ms
++0.3  FLOW           FLOW      computed        :totals → [:totals]             1.5 ms
++1.8  SIDE EFFECTS   DB        changed         [:counter] 1 → 2 · [:totals] 42  —
++1.9  SIDE EFFECTS   FX        :http-xhrio     GET /api/data (queued)           —
+!2.5  SIDE EFFECTS   ERROR     fx-handler-exc  :bad-fx "No such fx"             —
++2.6  SUBSCRIPTIONS  SUB       recalculated    :counter/value 1→2              0.3 ms
++2.9  SUBSCRIPTIONS  SUB       ran · unchanged :counter/parity                 0.1 ms
++3.0  SUBSCRIPTIONS  SUB       disposed        :cart/preview (no readers)       —
++3.1  VIEWS          VIEW      re-rendered     counter-display ← :counter/value 1.8 ms
++4.9  VIEWS          VIEW      unmounted       old-tooltip                      —
++4.9  VIEWS          VIEW      mounted         new-tooltip                     0.4 ms
++5.0  DISPATCH       EPOCH     outcome :ok     #42                              —
 ```
+
+The stage column (DISPATCH / COEFFECT / HANDLER / FLOW / SIDE EFFECTS / SUBSCRIPTIONS / VIEWS) + the colour-coded left edge recover, flatly, the phase shape the removed bands carried.
 
 ## §10 Data sources (grounding)
 
@@ -147,25 +153,24 @@ The `:rf.event/db-changed` trace event carries only `:event` + `:frame` — **no
 
 ## §12 Child & nested epochs
 
-The panel renders **one** epoch's arc; work that produces *other* epochs is shown by relationship, never absorbed:
-- **Same-epoch work renders inline** — machine microsteps (`:always` / `:raise` cascades) and any synchronous sub-steps that share this epoch's `dispatch-id` are ordinary rows in their phase.
-- **Separate epochs render as a `↗` link** on the originating op row — `:dispatch` / `:dispatch-later` fx, async responses (`:http-xhrio` → on-success/on-failure), routing `:rf.route/handle-url-change`, and machine `:after` / spawn / timer-fired. The row shows the spawning op + the child epoch id; clicking jumps the panel to that epoch. The child's own arc is **not** inlined (it has its own envelope).
-- **Parent breadcrumb** — EPOCH OPEN shows `◂ from #N :parent-event` when this epoch was spawned by another, so causality is traceable both directions.
+The panel renders **one** epoch's trace; work that produces *other* epochs is shown by relationship, never absorbed:
+- **Same-epoch work renders inline** — machine microsteps (`:always` / `:raise` cascades) and any synchronous sub-steps that share this epoch's `dispatch-id` are ordinary rows at their fire-order position (their stage column labels the step).
+- **Separate epochs render as a `↗` link** on the originating op row — `:dispatch` / `:dispatch-later` fx, async responses (`:http-xhrio` → on-success/on-failure), routing `:rf.route/handle-url-change`, and machine `:after` / spawn / timer-fired. The row shows the spawning op + the child epoch id; clicking jumps the panel to that epoch. The child's own trace is **not** inlined (it has its own focused-epoch scope).
+- **Parent breadcrumb** — the `:rf.epoch/snapshotted` row shows `◂ from #N :parent-event` when this epoch was spawned by another, so causality is traceable both directions.
 
-## §13 Empty bands, outcomes & short-circuit
+## §13 Outcomes & short-circuit
 
-- **Empty phase bands** render their header dimmed with `(none)` — never hidden — so the 4-phase shape is always legible and the absence is itself information (a no-op event has empty ③④; a blocked navigation has empty ④).
-- **Outcome** — EPOCH CLOSE reads the `:outcome` tag off the `:rf.epoch/outcome` trace op (the consumer-facing summary the runtime emits paired with `:rf.epoch/snapshotted` per [Spec 009 §`:rf.epoch/*`](../../../spec/009-Instrumentation.md#op-type-vocabulary) — rf2-18g1w / rf2-jppad): `:ok` · `:blocked` (e.g. routing `:can-leave` rejected, drain depth-limit tripped, frame destroyed mid-drain) · `:error` (handler/fx threw — schema-reserved cause, not currently emitted) · plus a **platform tag** for server epochs. The runtime does the cause→summary projection; the panel reads the summary directly. This is a trace fact (not an aggregate), so it stays despite §2's "no summary."
-- **Short-circuit** — on a throw (`:rf.error/*`) the arc stops at the failing op (inline error row); later phases simply have no ops; outcome `:error`. No fabricated rows.
+- **No empty-band scaffolding (rf2-aqusw).** With the bands removed, there is no dimmed `(none)` placeholder — an op simply has a row or it does not. A no-op event renders only the ops it produced (its absence of SIDE EFFECTS / SUBSCRIPTIONS / VIEWS rows is itself information). The stage column makes "which steps ran" legible without empty scaffolding.
+- **Outcome** — the `:rf.epoch/outcome` op renders as an ordinary row carrying the `:outcome` tag (the consumer-facing summary the runtime emits paired with `:rf.epoch/snapshotted` per [Spec 009 §`:rf.epoch/*`](../../../spec/009-Instrumentation.md#op-type-vocabulary) — rf2-18g1w / rf2-jppad): `:ok` · `:blocked` (e.g. routing `:can-leave` rejected, drain depth-limit tripped, frame destroyed mid-drain) · `:error` (handler/fx threw — schema-reserved cause, not currently emitted) · plus a **platform tag** for server epochs. The runtime does the cause→summary projection; the panel reads the summary directly. This is a trace fact (not an aggregate), so it stays despite §2's "no summary."
+- **Short-circuit** — on a throw (`:rf.error/*`) the list stops at the failing op (inline error row); later steps simply have no rows; outcome `:error`. No fabricated rows.
 
 ## §14 States & responsive
 
 - **No epoch selected** — "Select an event to see its trace arc."
-- **Collapsed band** — header + per-band op count.
-- **Expanded row** — inline EDN block (data-inspector) between the row and the next.
-- **Long arc** — panel scrolls; **band headers are sticky** so the current phase stays labelled (show-all can be 100+ rows).
+- **Expanded row** — inline EDN block (the edn-inspector on the raw trace map) between the row and the next.
+- **Long list** — panel scrolls (show-all can be 100+ rows); the stage column on every row keeps the pipeline step labelled without sticky headers.
 - **Truncation** — long target/detail values truncate with ellipsis in the row; full value via row-expand (EDN) or hover.
-- **Responsive / docked width** — must stay usable at Xray's narrow docked width (≈420px). Δt + area-badge + verb columns are fixed/compact; the **target/detail column is the flexible one and truncates first**; duration right-aligns and may hide under a width threshold. No horizontal scroll of the row grid, no wrapping that breaks the band rhythm.
+- **Responsive / docked width** — must stay usable at Xray's narrow docked width (≈420px). Δt + stage + area-badge + verb columns are fixed/compact; the **target/detail column is the flexible one and truncates first**; duration right-aligns and may hide under a width threshold. No horizontal scroll of the row grid, no wrapping that breaks the row rhythm.
 
 ## §15 Cross-panel navigation (v1 map)
 
@@ -183,6 +188,13 @@ Linkable rows carry a `↗` jump affordance to the relevant panel (restoring/ext
 This is **interaction wiring, not visual** — Figma need only render a generic `↗` affordance on linkable rows; the destination map above is the behavioral spec and each target panel must accept a "focus on X" anchor (App-db scroll-to-path, Machine focus-at-state, …). The exact wiring is an implementation concern that can refine post-Figma without affecting the visual design.
 
 ## §16 Worked epoch shapes (so the design isn't over-fit to the counter)
+
+> The band groupings (`▾ ② EVENT HANDLING …`) below are **illustrative
+> only** — they show *which ops a given epoch produces*, not the layout.
+> Post-rf2-aqusw the panel renders these ops as one flat list; the stage
+> column on each row carries the step (EVENT HANDLING ops split across the
+> HANDLER / COEFFECT / FLOW stages, EFFECTS ops onto SIDE EFFECTS, etc.
+> per §3a).
 
 **Routing** `[:rf.route/navigate :app/settings]`:
 ```
@@ -210,7 +222,7 @@ This is **interaction wiring, not visual** — Figma need only render a generic 
 ▾ ④ REACTIVE  VIEW rendered-to-string (one-shot — no re-render cascade)
 ● EPOCH CLOSE outcome :ok   (platform :server)
 ```
-**Async** — `:http-xhrio` shows `queued`; the response lands as a separate epoch (`↗`). **Throw** — `ERROR handler-exception` inline in ②, arc short-circuits, outcome `:error`. **No-op** — only ② populated; ③④ dimmed `(none)`.
+**Async** — `:http-xhrio` shows `queued`; the response lands as a separate epoch (`↗`). **Throw** — `ERROR handler-exception` inline at its fire-order point, list short-circuits, outcome `:error`. **No-op** — only DISPATCH + HANDLER rows; no SIDE EFFECTS / SUBSCRIPTIONS / VIEWS rows (their absence is the signal — no empty-band scaffolding post-rf2-aqusw).
 
 ## §17 Design-system conformance
 
@@ -218,53 +230,53 @@ Type scale, spacing, density, iconography, base surfaces/borders MUST conform to
 
 ## Appendix A — Op-handling matrix (the "covers ALL trace" checklist)
 
-Every Spec-009 trace operation → its row. `dur?` = number once timing instrumentation lands (§6), else `—`. Errors/warnings collapse to one generic rule each; registration/boot ops are out of scope.
+Every Spec-009 trace operation → its row. The **Stage** column is the Epoch pipeline step each op maps to (§3a — the flat panel's stage column + colour-coded edge). `dur?` = number once timing instrumentation lands (§6), else `—`. Errors/warnings collapse to one generic rule each; registration/boot ops are out of scope.
 
-| Operation | Phase | Area | Row label | Target / detail | Dur |
+| Operation | Stage (§3a) | Area | Row label | Target / detail | Dur |
 |---|---|---|---|---|---|
-| `:rf.epoch/snapshotted` | envelope | EPOCH | snapshotted | frame · snapshot | — |
-| `:rf.epoch/outcome` | envelope | EPOCH | outcome `:ok/:blocked/:error` | outcome (+platform) | — |
-| `:rf.epoch/restored` · `db-replaced` · `replay-conflict` · `reset-*` | envelope | EPOCH | restored / db-replaced / replay-conflict / reset | reason | — |
-| `:rf.event/dispatched` | ① | EVENT | dispatched | event-vector + origin | — |
-| `:rf.cofx` (inject) | ② | COEFFECT | run | cofx-id → value | dur? |
-| `:rf.cofx/skipped-on-platform` | ② | COEFFECT | skipped-on-platform | cofx-id | — |
-| `:rf.event/run-start`+`run-end` | ② | EVENT | handler ran | handler flavour (`:rf.event/sync?` flag if dispatch-sync) | dur (run-end−run-start) |
-| `:rf.event/db-changed` | ② | DB | changed | path old → new | — |
-| `:rf.machine/event-received` | ② | MACHINE | event-received | event | — |
-| `:rf.machine/guard-evaluated` | ② | MACHINE | guard-evaluated | guard-id ✓/✗ | — |
-| `:rf.machine.microstep/transition` · `:rf.machine/transition` | ② | MACHINE | transition (×microsteps) | from → to | — |
-| `:rf.machine/action-ran` | ② | MACHINE | action-ran | action-id | dur? |
-| `:rf.machine.lifecycle/created` | ② | MACHINE | created | machine-id | — |
-| `:rf.machine/system-id-bound` · `system-id-released` | ② | MACHINE | system-id-bound/released | system-id | — |
-| `:rf.machine/snapshot-updated` | ② | MACHINE | snapshot-updated | (or fold into DB) | — |
-| `:rf.fx/handled` (per fx-id) | ③ | FX | `<fx-id>` | fx-id → arg · queued/landed | dur? |
-| `:rf.fx/do-fx` | ③ | FX | (fx batch; usually elided to per-fx rows) | — | — |
-| `:rf.fx/override-applied` | ③ | FX | override-applied | fx-id | — |
-| `:rf.fx/skipped-on-platform` | ③ | FX | skipped-on-platform | fx-id | — |
-| `:rf.flow/computed` | ② | FLOW | computed | flow-id → path | dur? |
-| `:rf.flow/cleared` · `failed` · `skip` | ② | FLOW | cleared / failed / skipped | flow-id | — |
-| `:rf.route/activated` · `deactivated` · `cleared` · `fragment-changed` | ③ | ROUTING | activated / deactivated / cleared / fragment-changed | route-id / fragment | — |
-| `:rf.route/navigation-blocked` | ② / ③ | ROUTING | navigation-blocked | route-id (guard) | — (→ outcome :blocked) |
-| `:rf.warning/no-not-found-route` | inline (its phase) | WARNING | no-not-found-route | url (unmatched, no `:rf.route/not-found` route registered) | — |
-| `:rf.event/dispatched [:rf.route/handle-url-change …]` | ① | EVENT | dispatched | url (the URL-change EVENT — **not** a standalone trace op; it rides the `:rf.event/dispatched` row above) | — (↗ child) |
-| `:rf.machine.timer/scheduled` | ③ | MACHINE | timer-scheduled | delay · state | — (↗ future epoch) |
-| `:rf.machine.timer/fired` | own epoch | MACHINE | timer-fired | delay · state | — |
-| `:rf.machine.timer/stale-after` · `cancelled` (rf2-82a0u — unified, `:reason` discriminates) | ③ | MACHINE | timer-stale / timer-cancelled | state | — |
-| `:rf.machine.timer/skipped-on-server` | ③ | MACHINE | timer-skipped-on-server | state | — |
-| `:rf.machine/spawned` · `:rf.machine.spawn/cancelled-on-join-resolution` · `:rf.machine.spawn-all/*` | ③ | MACHINE | spawned / spawn-cancelled / spawn-all-started/completed/failed | invoke-id | — (↗ child) |
-| `:rf.machine/after` · `done` · `finished` | ② / ③ | MACHINE | after / done / finished | delay / output | — |
-| `:rf.sub/create` | ④ | SUB | created | sub-id | — |
-| `:rf.sub/run`+`computed` (value-changed? ✓) | ④ | SUB | recalculated | sub-id  old → new | dur? |
-| `:rf.sub/run`+`computed` (value-changed? ✗) | ④ | SUB | ran-unchanged | sub-id | dur? |
-| `:rf.sub/skip` · `skipped` | ④ | SUB | cache-hit | sub-id | — |
-| `:rf.sub/dispose` | ④ | SUB | disposed | sub-id · query-v · `:reason` (closed set `:no-more-derefers / :hot-reload / :cache-clear`) · frame | — |
-| `:rf.view/render`+`rendered` (mount? ✗) | ④ | VIEW | re-rendered | view-id ← cause-sub | `elapsed-ms` |
-| `:rf.view/render` (mount? ✓) | ④ | VIEW | mounted | view-id | `elapsed-ms` |
-| `:rf.view/skip` | ④ | VIEW | skipped | view-id | — |
-| `:rf.view/unmounted` | ④ | VIEW | unmounted | view-id | — |
-| `:rf.view/dropped-after` · `rendered-cap-reached` | ④ | VIEW | dropped / cap-reached | view-id | — |
-| **`:rf.error/*`** (any) | inline (its phase) | ERROR | the `operation` id | ex-data | — |
-| **`:rf.warning/*`** (any) | inline (its phase) | WARNING | the `operation` id | context | — |
+| `:rf.epoch/snapshotted` | DISPATCH | EPOCH | snapshotted | frame · snapshot | — |
+| `:rf.epoch/outcome` | DISPATCH | EPOCH | outcome `:ok/:blocked/:error` | outcome (+platform) | — |
+| `:rf.epoch/restored` · `db-replaced` · `replay-conflict` · `reset-*` | DISPATCH | EPOCH | restored / db-replaced / replay-conflict / reset | reason | — |
+| `:rf.event/dispatched` | DISPATCH | EVENT | dispatched | event-vector + origin | — |
+| `:rf.cofx` (inject) | COEFFECT | COEFFECT | run | cofx-id → value | dur? |
+| `:rf.cofx/skipped-on-platform` | COEFFECT | COEFFECT | skipped-on-platform | cofx-id | — |
+| `:rf.event/run-start`+`run-end` | HANDLER | EVENT | handler ran | handler flavour (`:rf.event/sync?` flag if dispatch-sync) | dur (run-end−run-start) |
+| `:rf.event/db-changed` | SIDE EFFECTS | DB | changed | path old → new | — |
+| `:rf.machine/event-received` | HANDLER | MACHINE | event-received | event | — |
+| `:rf.machine/guard-evaluated` | HANDLER | MACHINE | guard-evaluated | guard-id ✓/✗ | — |
+| `:rf.machine.microstep/transition` · `:rf.machine/transition` | HANDLER | MACHINE | transition (×microsteps) | from → to | — |
+| `:rf.machine/action-ran` | HANDLER | MACHINE | action-ran | action-id | dur? |
+| `:rf.machine.lifecycle/created` | HANDLER | MACHINE | created | machine-id | — |
+| `:rf.machine/system-id-bound` · `system-id-released` | HANDLER | MACHINE | system-id-bound/released | system-id | — |
+| `:rf.machine/snapshot-updated` | HANDLER | MACHINE | snapshot-updated | (or fold into DB) | — |
+| `:rf.fx/handled` (per fx-id) | SIDE EFFECTS | FX | `<fx-id>` | fx-id → arg · queued/landed | dur? |
+| `:rf.fx/do-fx` | SIDE EFFECTS | FX | (fx batch; usually elided to per-fx rows) | — | — |
+| `:rf.fx/override-applied` | SIDE EFFECTS | FX | override-applied | fx-id | — |
+| `:rf.fx/skipped-on-platform` | SIDE EFFECTS | FX | skipped-on-platform | fx-id | — |
+| `:rf.flow/computed` | FLOW | FLOW | computed | flow-id → path | dur? |
+| `:rf.flow/cleared` · `failed` · `skip` | FLOW | FLOW | cleared / failed / skipped | flow-id | — |
+| `:rf.route/activated` · `deactivated` · `cleared` · `fragment-changed` | SIDE EFFECTS | ROUTING | activated / deactivated / cleared / fragment-changed | route-id / fragment | — |
+| `:rf.route/navigation-blocked` | SIDE EFFECTS | ROUTING | navigation-blocked | route-id (guard) | — (→ outcome :blocked) |
+| `:rf.warning/no-not-found-route` | inline (its stage) | WARNING | no-not-found-route | url (unmatched, no `:rf.route/not-found` route registered) | — |
+| `:rf.event/dispatched [:rf.route/handle-url-change …]` | DISPATCH | EVENT | dispatched | url (the URL-change EVENT — **not** a standalone trace op; it rides the `:rf.event/dispatched` row above) | — (↗ child) |
+| `:rf.machine.timer/scheduled` | SIDE EFFECTS | MACHINE | timer-scheduled | delay · state | — (↗ future epoch) |
+| `:rf.machine.timer/fired` | SIDE EFFECTS | MACHINE | timer-fired | delay · state | — |
+| `:rf.machine.timer/stale-after` · `cancelled` (rf2-82a0u — unified, `:reason` discriminates) | SIDE EFFECTS | MACHINE | timer-stale / timer-cancelled | state | — |
+| `:rf.machine.timer/skipped-on-server` | SIDE EFFECTS | MACHINE | timer-skipped-on-server | state | — |
+| `:rf.machine/spawned` · `:rf.machine.spawn/cancelled-on-join-resolution` · `:rf.machine.spawn-all/*` | SIDE EFFECTS | MACHINE | spawned / spawn-cancelled / spawn-all-started/completed/failed | invoke-id | — (↗ child) |
+| `:rf.machine/after` · `done` · `finished` | SIDE EFFECTS | MACHINE | after / done / finished | delay / output | — |
+| `:rf.sub/create` | SUBSCRIPTIONS | SUB | created | sub-id | — |
+| `:rf.sub/run`+`computed` (value-changed? ✓) | SUBSCRIPTIONS | SUB | recalculated | sub-id  old → new | dur? |
+| `:rf.sub/run`+`computed` (value-changed? ✗) | SUBSCRIPTIONS | SUB | ran-unchanged | sub-id | dur? |
+| `:rf.sub/skip` · `skipped` | SUBSCRIPTIONS | SUB | cache-hit | sub-id | — |
+| `:rf.sub/dispose` | SUBSCRIPTIONS | SUB | disposed | sub-id · query-v · `:reason` (closed set `:no-more-derefers / :hot-reload / :cache-clear`) · frame | — |
+| `:rf.view/render`+`rendered` (mount? ✗) | VIEWS | VIEW | re-rendered | view-id ← cause-sub | `elapsed-ms` |
+| `:rf.view/render` (mount? ✓) | VIEWS | VIEW | mounted | view-id | `elapsed-ms` |
+| `:rf.view/skip` | VIEWS | VIEW | skipped | view-id | — |
+| `:rf.view/unmounted` | VIEWS | VIEW | unmounted | view-id | — |
+| `:rf.view/dropped-after` · `rendered-cap-reached` | VIEWS | VIEW | dropped / cap-reached | view-id | — |
+| **`:rf.error/*`** (any) | inline (its stage) | ERROR | the `operation` id | ex-data | — |
+| **`:rf.warning/*`** (any) | inline (its stage) | WARNING | the `operation` id | context | — |
 | **Registration/boot** — `:rf.fx/reg-flow` · `:rf.fx/registered-platforms` · `:rf.cofx/registered-platforms` · `:rf.flow/registered` · `:rf.route/registered` · `:rf.machine.registrar/*` | — | — | OUT OF SCOPE (boot-time, not per-epoch) | — | — |
 
 > Generic rules: any `:rf.error/*` → ERROR row (emphasised, inline, → Issues panel); any `:rf.warning/*` → WARNING row (inline, → Issues). The implementer cross-checks this matrix against the live trace-emit sites; new ops get a row before shipping (the completeness contract, §1).

--- a/tools/xray/src/day8/re_frame2_xray/panels.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels.cljs
@@ -70,7 +70,7 @@
   | **epoch-panel** | `:rf.xray/focus` · `:rf.xray/epoch-history` (via `panels.shared.focus-resolver`) | `:rf.xray.epoch/toggle-row-expand` · `:rf.xray.epoch/set-subs-filter-mode` |
   | **app-db (current-state inspector)** | `:rf.xray/app-db-state` (current-state section model over the observed frame's live app-db, sectioned by reserved `:rf/*` area — rf2-okvit) | `:rf.xray/open-segment-inspector` |
   | **reactive-panel** | `:rf.xray/reactive-data` (composite over focused cascade's `:trace-events`) | `:rf.xray/reactive-toggle-unchanged` |
-  | **trace** | `:rf.xray/trace-feed` (epoch-scoped — projects the focused epoch's `:trace-events` into the whole-epoch arc: envelope + 4 phase bands, spec/023) | `:rf.xray/toggle-trace-row-expand` · `:rf.xray/toggle-trace-band-collapse` · `:rf.xray/open-in-editor` |
+  | **trace** | `:rf.xray/trace-feed` (epoch-scoped — projects the focused epoch's `:trace-events` into a flat list of rows, each with a stage column + colour-coded left edge, spec/023 · rf2-aqusw) | `:rf.xray/toggle-trace-row-expand` · `:rf.xray/open-in-editor` |
   | **machine-inspector** | `:rf.xray/machine-chart-data` · `:rf.xray/active-timers-for-focused-machine` · `:rf.xray/machine-scrubber-position` | scrubber events · `:rf.xray/focus-cascade` |
   | **routing** | `:rf.xray/registered-routes` · `:rf.xray/current-route-slice` · `:rf.xray/routing-tab-data` | route-simulation events |
   | **segment-inspector** | `:rf.xray/segment-inspector-open?` · `:rf.xray/segment-inspector-value` | `:rf.xray/close-segment-inspector` |

--- a/tools/xray/src/day8/re_frame2_xray/panels/trace.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/trace.cljs
@@ -1,55 +1,57 @@
 (ns day8.re-frame2-xray.panels.trace
-  "Trace panel — the whole-epoch trace ARC (spec/023-Trace-Panel.md).
+  "Trace panel — the whole-epoch trace as a FLAT list (spec/023-Trace-Panel.md).
 
   ## What this panel shows
 
-  The complete trace arc of a single epoch — every trace operation the
-  substrate emits during the focused epoch, in fire order, organised by
-  the epoch's phase shape (spec/023 §1). Its contract is COMPLETENESS:
-  every op-family in the Spec-009 vocabulary surfaces.
+  Every trace operation the substrate emits during the focused epoch, in
+  fire order, as a SINGLE FLAT LIST of rows (rf2-aqusw — the 4-band
+  hierarchy is gone). Its contract is COMPLETENESS: every op-family in
+  the Spec-009 vocabulary surfaces.
 
-  The arc reads top-down:
+  The list reads top-down, oldest-first:
 
-      ○ EPOCH OPEN   #N :event · frame · snapshotted    (the envelope)
-      ▾ ① DISPATCH
-          +0.0  EVENT     dispatched   [:counter-inc] from view↗   —
-      ▾ ② EVENT HANDLING
-          +0.1  COEFFECT  run          :now → #inst…              0.1 ms
-          +0.2  EVENT     handler ran  reg-event-db               0.2 ms
-          +0.3  FLOW      computed     :totals → [:totals]        1.5 ms
-          +1.8  DB        changed      [:counter] 1 → 2             —
-      ▾ ③ EFFECTS / FX
-          +1.9  FX        :http-xhrio  GET /api/data (queued)      —
-      ▾ ④ REACTIVE RENDERING
-          +2.6  SUB       recalculated :counter/value 1→2         0.3 ms
-          +3.1  VIEW      re-rendered  counter-display            1.8 ms
-      ● EPOCH CLOSE  outcome :ok
+      +0.0  DISPATCH       EVENT     dispatched   [:counter-inc]      —
+      +0.1  COEFFECT       COEFFECT  run          :now -> #inst      0.1 ms
+      +0.2  HANDLER        EVENT     handler ran  reg-event-db       0.2 ms
+      +0.3  FLOW           FLOW      computed     :totals            1.5 ms
+      +1.8  SIDE EFFECTS   DB        changed      [:counter] 1 -> 2   —
+      +1.9  SIDE EFFECTS   FX        :http-xhrio  GET /api/data       —
+      +2.6  SUBSCRIPTIONS  SUB       recalculated :counter/value     0.3 ms
+      +3.1  VIEWS          VIEW      re-rendered  counter-display    1.8 ms
 
-  Each op is a row of five columns (spec/023 §3):
+  Each op is a row of six columns (rf2-aqusw):
 
-      Δt · area badge · what-happened · target/detail · duration
+      Δt · stage · area badge · what-happened · target/detail · duration
+
+  ## Stage column + colour-coded left edge (rf2-aqusw)
+
+  The STAGE column names the Epoch-panel pipeline step each op belongs
+  to — DISPATCH · COEFFECT · HANDLER · FLOW · SIDE EFFECTS ·
+  SUBSCRIPTIONS · VIEWS — and the row's left EDGE is colour-coded with
+  that step's colour. Both the label and the colour resolve through the
+  Epoch panel's own `panels.epoch.badge` taxonomy (NOT a parallel
+  palette) so the Trace stage column + edge match the Epoch numbered
+  cascade exactly — one step model, DRY. The flat list recovers, at a
+  glance, the phase information the removed hierarchy conveyed.
 
   The area badge is a NEUTRAL text badge (EVENT · COEFFECT · DB · FX ·
   FLOW · SUB · VIEW · MACHINE · ROUTING · EPOCH · ERROR · WARNING) — no
-  per-family colour; the family identity rides a 3px left-border band
-  instead. The four phase bands are COLLAPSIBLE with sticky headers
-  (spec/023 §2 / §14); empty bands render dimmed with `(none)` so the
-  4-phase shape is always legible (spec/023 §13).
+  per-family colour.
 
   Errors / warnings are cross-cutting (spec/023 §7) — they render inline
-  at their chronological point within whatever band they occurred,
-  emphasised so failures stand out. Clicking any row expands its raw
-  trace-event EDN inline (spec/023 §3) via the first-class edn-inspector
+  at their chronological point in the flat list, emphasised so failures
+  stand out (the left edge rides the severity colour over the stage
+  colour). Clicking any row opens the edn-inspector on its raw
+  trace-event MAP inline (spec/023 §3) via the first-class edn-inspector
   widget (spec/021 §10 / `views.edn-inspector`).
 
   ## Design system (PR #2089 · Handler panel idiom)
 
-  The arc is rendered in the established Xray devtools design language —
+  The list is rendered in the established Xray devtools design language —
   the `--devtools-*` dark tokens via `theme/tokens`, the 13/12/11/10
-  type scale, mono font for the data columns, the numbered uppercase
-  band headers + thin left rail (mirroring the Handler panel's numbered
-  step-circle pipeline in `panels/event_detail.cljs`), and the
-  `+`/`~`/`-` diff idiom for DB rows.
+  type scale, mono font for the data columns, and the `+`/`~`/`-` diff
+  idiom for DB rows. The stage column + colour-coded left edge reuse the
+  Epoch panel's `panels.epoch.badge` step taxonomy (rf2-aqusw).
 
   ## Epoch-scoped feed (spec/018 §6)
 
@@ -63,9 +65,9 @@
 
   ## Empty states
 
-    :no-events     → 'No events.' (focused epoch carries no trace events)
-    :no-focus      → 'Select an event to see its trace arc.' (spec/023 §14)
-    :epoch-evicted → the focused epoch aged out of the ring buffer.
+    :no-events     -> 'No events.' (focused epoch carries no trace events)
+    :no-focus      -> 'Select an event to see its trace arc.' (spec/023 §14)
+    :epoch-evicted -> the focused epoch aged out of the ring buffer.
 
   ## Pure hiccup
 
@@ -75,10 +77,12 @@
 
   ## Helpers
 
-  All pure-data logic — row projection, area / phase / verb / target
-  classification, band projection, epoch-scoped feed, empty-state
-  classification — lives in `trace_helpers.cljc` so the algebra runs
-  under the JVM unit-test target."
+  All pure-data logic — row projection, area / stage / verb / target
+  classification, the stage column + edge colour (via
+  `panels.epoch.badge`), epoch-scoped feed, empty-state classification —
+  lives in `trace_helpers.cljc` so the algebra runs under the JVM
+  unit-test target. (The band-projection helpers are retained there for
+  cross-panel consumers + tests; the flat panel no longer renders them.)"
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
@@ -95,42 +99,37 @@
             [day8.re-frame2-xray.views.edn-widget.widget :as edn]
             [day8.re-frame2-xray.views.resizable-table :as rt]))
 
-;; ---- row grid template (spec/023 §3 · §14) -----------------------------
+;; ---- resizable-table columns (rf2-jnxfj · rf2-aqusw) --------------------
 ;;
-;; Δt · area badge · what-happened · target/detail · duration. Δt +
-;; badge + verb columns are fixed/compact; the target/detail column is
-;; the flexible one and truncates first (spec/023 §14 — usable at the
-;; ≈420px docked width, no horizontal scroll); duration right-aligns.
-
-(def ^:private row-grid-columns
-  "The 5-column grid template for an op row (spec/023 §3)."
-  "56px 64px 92px minmax(0, 1fr) auto")
-
-;; ---- resizable-table columns (rf2-jnxfj) --------------------------------
+;; The op-row's 6-column grid — Δt · stage · area badge · what-happened ·
+;; target/detail · duration — is driven by the shared `rt/resizable-table`
+;; view. Δt + stage + badge + verb columns are fixed/compact; the
+;; target/detail column is the flexible one and truncates first (spec/023
+;; §14 — usable at the ≈420px docked width, no horizontal scroll);
+;; duration right-aligns. The STAGE column (rf2-aqusw) names the Epoch
+;; pipeline step each op belongs to — DISPATCH / COEFFECT / HANDLER /
+;; FLOW / SIDE EFFECTS / SUBSCRIPTIONS / VIEWS — recovering flatly the
+;; phase information the (now-removed) hierarchy conveyed.
 ;;
-;; The op-row's 5-column grid is now driven by the shared
-;; `rt/resizable-table` view. One `:table-id :rf.xray.trace/ops` is
-;; shared between the single header bar at the top of the panel and
-;; every phase band's rows, so a drag in the header live-resizes every
-;; row in the arc. Column widths persist via the rf2-xzg1y
-;; localStorage round-trip.
-;;
-;; Defaults mirror the pre-conversion `row-grid-columns` template so
-;; the first paint reads identically. The `minmax(0, 1fr)` on the
-;; target column survives the resolver because `build-template` passes
-;; the `:default-flex` string through verbatim when no px override is
-;; in the slot.
+;; One `:table-id :rf.xray.trace/ops` is shared between the single header
+;; bar at the top of the panel and the flat row list, so a drag in the
+;; header live-resizes every row. Column widths persist via the rf2-xzg1y
+;; localStorage round-trip. The `minmax(0, 1fr)` on the target column
+;; survives the resolver because `build-template` passes the
+;; `:default-flex` string through verbatim when no px override is in the
+;; slot.
 
 (def ^:private trace-op-columns
   [{:id :time     :label "Δt"       :default-flex "56px"}
+   {:id :stage    :label "stage"    :default-flex "104px"}
    {:id :badge    :label "area"     :default-flex "64px"}
    {:id :verb     :label "what"     :default-flex "92px"}
    {:id :target   :label "target"   :default-flex "minmax(0, 1fr)"}
    {:id :duration :label "duration" :default-flex "70px"}])
 
 (def trace-ops-table-id
-  "Shared table-id every band reads against so a drag updates one slot
-  that the header + every row reads."
+  "Shared table-id the header + the flat row list read against so a drag
+  updates one slot that both read."
   :rf.xray.trace/ops)
 
 (def ^:private trace-header-cell-style
@@ -227,13 +226,6 @@
    :font-size     "12px"
    :line-height   1.35})
 
-(def ^:private op-row-summary-grid-style
-  {:display               "grid"
-   :grid-template-columns row-grid-columns
-   :gap                   "10px"
-   :align-items           "baseline"
-   :padding               "5px 16px 5px 8px"})
-
 (def ^:private op-row-time-base-style
   {:font-size   "11px"
    :white-space "nowrap"
@@ -244,6 +236,22 @@
 ;; `assoc` over the base.
 (def ^:private op-row-time-default-style
   (assoc op-row-time-base-style :color (:text-tertiary tokens)))
+
+;; ---- stage column (rf2-aqusw) -------------------------------------------
+;;
+;; The flat list's STAGE column names the Epoch pipeline step (DISPATCH /
+;; COEFFECT / HANDLER / FLOW / SIDE EFFECTS / SUBSCRIPTIONS / VIEWS). The
+;; label rides the step's own colour (from `panels.epoch.badge`, the same
+;; hue the colour-coded left edge paints) so the column reads as a tinted
+;; pill-less label that ties to the edge at a glance.
+
+(def ^:private op-row-stage-base-style
+  {:font-size      "10px"
+   :font-weight    600
+   :letter-spacing "0.4px"
+   :white-space    "nowrap"
+   :overflow       "hidden"
+   :text-overflow  "ellipsis"})
 
 (def ^:private op-row-badge-base-style
   {:font-size      "10px"
@@ -310,74 +318,15 @@
 (def ^:private op-row-bg-warning
   "color-mix(in srgb, var(--rf-xray-yellow) 9%, transparent)")
 
-;; ---- band-header (spec/023 §13 · §14) -----------------------------------
+;; ---- flat row list (rf2-aqusw) ------------------------------------------
+;;
+;; The flat list (rf2-aqusw) renders every row in one container — no band
+;; rails, no envelope chrome. The list reads top-down oldest-first; the
+;; per-row STAGE column + colour-coded left edge recover the phase shape
+;; the removed bands carried.
 
-(def ^:private band-header-base-style
-  {:position       "sticky"
-   :top            0
-   :z-index        1
-   :display        "flex"
-   :align-items    "center"
-   :gap            "8px"
-   :padding        "6px 16px 6px 8px"
-   :background     (:bg-2 tokens)
-   :border-bottom  (str "1px solid " (:border-subtle tokens))
-   :user-select    "none"
-   :font-family    sans-stack
-   :font-size      "11px"
-   :font-weight    600
-   :letter-spacing "0.6px"
-   :text-transform "uppercase"})
-
-(def ^:private band-header-chevron-style
-  {:color (:text-tertiary tokens) :font-size "10px"})
-
-(def ^:private band-header-count-style
-  {:color          (:text-tertiary tokens)
-   :font-weight    400
-   :font-size      "10px"
-   :letter-spacing "0"
-   :text-transform "none"})
-
-;; ---- phase-band (spec/023 §8 · §13) -------------------------------------
-
-(def ^:private phase-band-container-style
-  {:margin-bottom "4px"})
-
-(def ^:private phase-band-rows-style
-  {:list-style  "none"
-   :margin      0
-   :padding     "4px 8px 4px 8px"
-   :border-left (str "1px solid " (:border-subtle tokens))
-   :margin-left "8px"})
-
-;; ---- envelope-row (spec/023 §2) -----------------------------------------
-
-(def ^:private envelope-container-style
-  {:display        "flex"
-   :align-items    "center"
-   :gap            "10px"
-   :padding        "8px 16px 8px 8px"
-   :font-family    sans-stack
-   :font-size      "12px"
-   :font-weight    600
-   :letter-spacing "0.4px"
-   :color          (:text-primary tokens)})
-
-(def ^:private envelope-marker-base-style
-  {:font-size "14px"})
-
-(def ^:private envelope-label-style
-  {:text-transform "uppercase" :font-size "11px"})
-
-(def ^:private envelope-outcome-base-style
-  {:font-family    mono-stack
-   :font-size      "11px"
-   :font-weight    600
-   :letter-spacing "0"})
-
-(def ^:private envelope-rows-list-style
-  {:list-style "none" :margin 0 :padding 0 :flex 1 :min-width 0})
+(def ^:private flat-rows-container-style
+  {:list-style "none" :margin 0 :padding 0})
 
 ;; ---- empty-state-message (spec/023 §14) ---------------------------------
 
@@ -573,8 +522,8 @@
 
 (defn- op-row-attrs
   "Per-row attrs for the resizable-table — preserves the click /
-  context-menu handlers + the op-family colour band + severity /
-  expansion backgrounds.
+  context-menu handlers + the colour-coded STAGE left edge (rf2-aqusw)
+  + severity / expansion backgrounds.
 
   Stamps `:key` into the attrs map alongside the meta-key
   resizable-table emits, so the rf2-l2f2g React-key contract surface
@@ -582,14 +531,13 @@
   is observable in the rendered hiccup — the test corpus reads
   `:key` from the row attrs map because the framework hiccup walker
   rebuilds inner vectors via `mapv` and drops their metadata."
-  [{:keys [id operation area dispatch-id] :as row} expanded?]
+  [{:keys [id operation area stage stage-colour dispatch-id] :as row} expanded?]
   ;; rf2-nesy9 — capture the surrounding instance frame at render time
   ;; so the deferred row handlers dispatch into it, not a `:rf/xray`
   ;; literal. op-row-attrs is invoked during the Trace Panel reg-view's
   ;; render, so `current-frame` resolves through the React-context tier.
   (let [frame       (rf/current-frame)
         row-test-id (str "rf-xray-trace-row-" id)
-        band-colour (h/op-family-colour row)
         severity?   (#{:error :warning} area)
         sev-colour  (when severity?
                       (get tokens (if (= area :error) :red :yellow)))
@@ -598,7 +546,8 @@
      :data-testid           row-test-id
      :data-rf-xray-expanded (boolean expanded?)
      :data-rf-xray-area     (some-> area name)
-     :data-rf-xray-op-family (some-> (h/op-family row) name)
+     ;; rf2-aqusw — the Epoch pipeline STAGE drives the column + edge.
+     :data-rf-xray-stage    (some-> stage name)
      :data-rf-xray-severity (when severity? (name area))
      :on-click              (fn []
                               (rf/dispatch [:rf.xray/toggle-trace-row-expand id]
@@ -611,14 +560,16 @@
                                   [:rf.xray/cancellation-cascade-open
                                    {:kind :dispatch-id :id dispatch-id}]
                                   {:frame frame})))
-     ;; op-family colour band — 3px LEFT-BORDER (error / warning
-     ;; override the band so a failure stands out · spec/023 §7).
-     ;; Severity rows carry a faint tinted fill (spec/023 §7);
-     ;; expanded rows show a bg-1 backdrop.
+     ;; rf2-aqusw — colour-coded STAGE left edge: a 3px LEFT-BORDER in
+     ;; the Epoch pipeline step's colour (reused via `panels.epoch.badge`
+     ;; through `h/stage-colour`). Error / warning override the stage
+     ;; colour so a failure stands out (spec/023 §7). Severity rows carry
+     ;; a faint tinted fill (spec/023 §7); expanded rows show a bg-1
+     ;; backdrop.
      :style                 (cond-> (assoc op-row-container-base-style
                                            :border-left
                                            (str "3px solid "
-                                                (or sev-colour band-colour)))
+                                                (or sev-colour stage-colour)))
                               expanded?
                               (assoc :background (:bg-1 tokens))
                               (and (not expanded?) (= area :error))
@@ -627,13 +578,14 @@
                               (assoc :background op-row-bg-warning))}))
 
 (defn- op-row-cells
-  "Per-row cells — the 5 hiccup nodes resizable-table interleaves into
-  the grid template. Each carries `data-rf-xray-resizable-col` so the
+  "Per-row cells — the 6 hiccup nodes resizable-table interleaves into
+  the grid template (rf2-aqusw — Δt · stage · badge · verb · target ·
+  duration). Each carries `data-rf-xray-resizable-col` so the
   pointer-down handler can locate the adjacent cell off the live DOM,
   AND keeps the original `data-testid` so the trace_view tests resolve
   unchanged."
-  [{:keys [id operation rel-time time area area-badge verb target
-           duration-ms source-coord dispatch-id]
+  [{:keys [id operation rel-time time area area-badge stage-label
+           stage-colour verb target duration-ms source-coord dispatch-id]
     :as row}]
   ;; rf2-nesy9 — render-time frame capture for the deferred cell handlers.
   (let [frame       (rf/current-frame)
@@ -643,7 +595,7 @@
         sev-colour  (when severity?
                       (get tokens (if (= area :error) :red :yellow)))
         destroy?    (cancellation-cascade-helpers/destroy-event? {:operation operation})]
-    [;; ① Δt — ms offset from EPOCH OPEN; `!` lead for severity rows.
+    [;; ① Δt — ms offset from the epoch origin; `!` lead for severity rows.
      [:span {:data-rf-xray-resizable-col "time"
              :data-testid (str row-test-id "-time")
              :title       (or (h/format-time time) "")
@@ -656,7 +608,16 @@
         (and severity? rel-time) (str "!" (subs rel-time 1))
         rel-time                 rel-time
         :else                    "—")]
-     ;; ② area badge — neutral uppercase text badge (spec/023 §3); the
+     ;; ② stage — the Epoch pipeline step (DISPATCH / COEFFECT / HANDLER /
+     ;; FLOW / SIDE EFFECTS / SUBSCRIPTIONS / VIEWS) the op belongs to,
+     ;; tinted with the step's own colour (rf2-aqusw — same hue the
+     ;; colour-coded left edge paints, both via `panels.epoch.badge`).
+     [:span {:data-rf-xray-resizable-col "stage"
+             :data-testid (str row-test-id "-stage")
+             :title       stage-label
+             :style       (assoc op-row-stage-base-style :color stage-colour)}
+      stage-label]
+     ;; ③ area badge — neutral uppercase text badge (spec/023 §3); the
      ;; severity tiers ride their semantic colour so a failure's family
      ;; is unmistakeable (spec/023 §7 / §8).
      [:span {:data-rf-xray-resizable-col "badge"
@@ -665,14 +626,14 @@
                             (assoc op-row-badge-base-style :color sev-colour)
                             op-row-badge-default-style)}
       area-badge]
-     ;; ③ what-happened — the per-area verb, tinted by outcome tier.
+     ;; ④ what-happened — the per-area verb, tinted by outcome tier.
      [:span {:data-rf-xray-resizable-col "verb"
              :data-testid (str row-test-id "-verb")
              :style       (assoc op-row-verb-base-style
                                  :color (if severity? sev-colour verb-colour))
              :title       verb}
       verb]
-     ;; ④ target / detail — the op's subject; the flexible column that
+     ;; ⑤ target / detail — the op's subject; the flexible column that
      ;; truncates first (spec/023 §14). Source-coord ↗ rides at its end.
      [:span {:data-rf-xray-resizable-col "target"
              :data-testid (str row-test-id "-target")
@@ -706,7 +667,7 @@
                                    {:frame frame}))
                   :style       op-row-cancellation-button-style}
          "⟲"])]
-     ;; ⑤ duration — `N.N ms` when timed, em-dash otherwise (spec/023 §6).
+     ;; ⑥ duration — `N.N ms` when timed, em-dash otherwise (spec/023 §6).
      [:span {:data-rf-xray-resizable-col "duration"
              :data-testid (str row-test-id "-duration")
              :style       op-row-duration-style}
@@ -728,126 +689,42 @@
       payload              payload
       :else                nil)))
 
-;; ---- phase band (spec/023 §2 · §13 · §14) -------------------------------
+;; ---- flat row list (rf2-aqusw) ------------------------------------------
+;;
+;; The 4-band hierarchy + EPOCH OPEN / CLOSE envelope are GONE (rf2-aqusw).
+;; Every op the focused epoch emitted — including the `:rf.epoch/*`
+;; lifecycle ops (snapshotted / outcome / restored / …) that used to live
+;; in the envelope — renders as an ORDINARY row in one flat list, in fire
+;; order (oldest-first), exactly as the feed's `:rows` are ordered. The
+;; epoch-lifecycle ops classify to the DISPATCH stage (their muted grey
+;; edge), so the open/close lifecycle still surfaces, flatly. The phase
+;; information the bands conveyed is recovered by each row's STAGE column
+;; + colour-coded left edge.
 
-(defn- band-header
-  "A collapsible phase-band header — the numbered uppercase label
-  (`① DISPATCH`, …) with a chevron + per-band op count, STICKY so the
-  current phase stays labelled while a long arc scrolls (spec/023 §14).
-  An empty band's header is dimmed (spec/023 §13)."
-  [{:keys [id label count empty?]} expanded?]
-  ;; rf2-nesy9 — render-time frame capture for the deferred collapse click.
-  (let [frame (rf/current-frame)]
-   [:div {:data-testid (str "rf-xray-trace-band-header-" (name id))
-         :data-rf-xray-band id
-         :data-rf-xray-empty (boolean empty?)
-         :on-click    (when-not empty?
-                        (fn []
-                          (rf/dispatch [:rf.xray/toggle-trace-band-collapse id]
-                                       {:frame frame})))
-         :style       (assoc band-header-base-style
-                             :cursor (if empty? "default" "pointer")
-                             :color  (if empty?
-                                       (:text-tertiary tokens)
-                                       (:text-secondary tokens)))}
-   (when-not empty?
-     [:span {:aria-hidden "true"
-             :style band-header-chevron-style}
-      (if expanded? "▾" "▸")])
-   [:span label]
-   [:span {:data-testid (str "rf-xray-trace-band-count-" (name id))
-           :style band-header-count-style}
-    (if empty? "(none)" (str count))]]))
-
-(defn- phase-band
-  "Render one phase band — its sticky numbered header + its op rows in
-  fire order (oldest-first). Empty bands render their dimmed header with
-  `(none)` and no rows (spec/023 §13); collapsed bands render the header
-  alone. A thin left rail (mirroring the Handler panel's pipeline rail)
-  runs down the band's rows so the phase reads as a distinct segment of
-  the arc (spec/023 §8).
-
-  rf2-jnxfj — rows mount through `rt/resizable-table` with `:header?
-  false` (the header lives once at the top of the panel) so every band
-  shares the same `:rf.xray.trace/ops` column-widths slot — a drag on
-  the panel header re-aligns every band's rows live."
-  [{:keys [id rows empty?] :as band} {:keys [expanded? expanded-row-ids]}]
-  [:section {:data-testid (str "rf-xray-trace-band-" (name id))
-             :data-rf-xray-band id
-             :style phase-band-container-style}
-   (band-header band expanded?)
-   (when (and expanded? (not empty?))
-     [rt/resizable-table
-      {:table-id        trace-ops-table-id
-       :header?         false
-       :columns         trace-op-columns
-       :container-attrs {:data-testid (str "rf-xray-trace-band-rows-" (name id))
-                         :style       phase-band-rows-style}
-       :rows            rows
-       :row-key         (fn [row _i] (h/row-key row))
-       :row-attrs       (fn [row _i]
-                          (op-row-attrs row
-                                        (contains? (or expanded-row-ids #{})
-                                                   (:id row))))
-       :row-cells       (fn [row _i] (op-row-cells row))
-       :row-extras      (fn [row _i]
-                          (op-row-extras row
-                                         (contains? (or expanded-row-ids #{})
-                                                    (:id row))))}])])
-
-;; ---- epoch envelope (spec/023 §2) ---------------------------------------
-
-(defn- envelope-row
-  "Render the EPOCH OPEN / CLOSE envelope band that brackets the arc
-  (spec/023 §2). EPOCH OPEN carries the epoch id · event · frame ·
-  `snapshotted`; EPOCH CLOSE shows the `:rf.epoch/outcome`. The marker
-  glyph (`○` open · `●` close) + the outcome tag distinguish them. The
-  envelope's `:rf.epoch/*` ops render as ordinary rows beneath the
-  marker so restore/replay lifecycle ops surface (spec/023 §2)."
-  [{:keys [kind label outcome rows expanded-row-ids]}]
-  (let [open?       (= kind :open)
-        outcome-kw  outcome
-        outcome-hex (case outcome-kw
-                      :ok      (:success tokens)
-                      :blocked (:warning tokens)
-                      :error   (:error tokens)
-                      (:text-tertiary tokens))]
-    [:div {:data-testid (str "rf-xray-trace-envelope-" (name kind))
-           :data-rf-xray-envelope kind
-           :style envelope-container-style}
-     [:span {:aria-hidden "true"
-             :style (assoc envelope-marker-base-style
-                           :color (if open? (:accent tokens) outcome-hex))}
-      (if open? "○" "●")]
-     [:span {:style envelope-label-style}
-      label]
-     (when (and (not open?) outcome-kw)
-       [:span {:data-testid (str "rf-xray-trace-outcome-" (name outcome-kw))
-               :data-rf-xray-outcome outcome-kw
-               :style (assoc envelope-outcome-base-style :color outcome-hex)}
-        (str "outcome " outcome-kw)])
-     (when (seq rows)
-       ;; rf2-jnxfj — envelope rows mount through the shared resizable-
-       ;; table view (same `:rf.xray.trace/ops` table-id every band reads)
-       ;; so a single drag on the panel header re-aligns the OPEN/CLOSE
-       ;; envelope rows alongside every phase band.
-       [rt/resizable-table
-        {:table-id        trace-ops-table-id
-         :header?         false
-         :columns         trace-op-columns
-         :container-attrs {:data-testid (str "rf-xray-trace-envelope-rows-" (name kind))
-                           :style       envelope-rows-list-style}
-         :rows            rows
-         :row-key         (fn [row _i] (h/row-key row))
-         :row-attrs       (fn [row _i]
-                            (op-row-attrs row
-                                          (contains? (or expanded-row-ids #{})
-                                                     (:id row))))
-         :row-cells       (fn [row _i] (op-row-cells row))
-         :row-extras      (fn [row _i]
-                            (op-row-extras row
-                                           (contains? (or expanded-row-ids #{})
-                                                      (:id row))))}])]))
+(defn- flat-row-list
+  "Render the focused epoch's whole trace as a SINGLE flat list of op
+  rows (rf2-aqusw). Rows mount through `rt/resizable-table` with
+  `:header? false` (the header lives once at the top of the panel) so
+  the list shares the `:rf.xray.trace/ops` column-widths slot — a drag
+  on the panel header re-aligns every row live."
+  [rows expanded-row-ids]
+  [rt/resizable-table
+   {:table-id        trace-ops-table-id
+    :header?         false
+    :columns         trace-op-columns
+    :container-attrs {:data-testid "rf-xray-trace-rows"
+                      :style       flat-rows-container-style}
+    :rows            rows
+    :row-key         (fn [row _i] (h/row-key row))
+    :row-attrs       (fn [row _i]
+                       (op-row-attrs row
+                                     (contains? (or expanded-row-ids #{})
+                                                (:id row))))
+    :row-cells       (fn [row _i] (op-row-cells row))
+    :row-extras      (fn [row _i]
+                       (op-row-extras row
+                                      (contains? (or expanded-row-ids #{})
+                                                 (:id row))))}])
 
 ;; ---- empty states (spec/023 §14) ----------------------------------------
 
@@ -897,15 +774,16 @@
 ;; ---- public view --------------------------------------------------------
 
 (rf/reg-view Panel
-  "The Trace panel's root view — the whole-epoch trace arc
-  (spec/023-Trace-Panel.md). Subscribes to `:rf.xray/trace-feed` (the
-  epoch-scoped feed) and renders the focused epoch's arc: the EPOCH OPEN
-  envelope, the four collapsible phase bands (① DISPATCH · ② EVENT
-  HANDLING · ③ EFFECTS / FX · ④ REACTIVE RENDERING) in arc order, and
-  the EPOCH CLOSE outcome. Empty bands render dimmed `(none)`
-  (spec/023 §13). No mock data — fed by real trace data throughout."
+  "The Trace panel's root view — the focused epoch's whole trace as a
+  FLAT list (spec/023-Trace-Panel.md · rf2-aqusw). Subscribes to
+  `:rf.xray/trace-feed` (the epoch-scoped feed) and renders the focused
+  epoch's `:rows` as a single oldest-first list of op rows: each row
+  carries a STAGE column + colour-coded left edge (the Epoch pipeline
+  step, via `panels.epoch.badge`). Clicking a row opens the edn-inspector
+  on its raw trace MAP inline. No bands, no envelope, no hierarchy. No
+  mock data — fed by real trace data throughout."
   []
-  (let [{:keys [envelope outcome bands empty-kind] :as _data}
+  (let [{:keys [rows empty-kind] :as _data}
         @(rf/subscribe [:rf.xray/trace-feed])
         ;; rf2-wcfsy — focused-cascade is a layer-3 composite over
         ;; `:rf.xray/cascades` + `:rf.xray/focus`, NOT an inline scan in
@@ -914,8 +792,7 @@
         ;; actually change (rather than every Panel render).
         focus           @(rf/subscribe [:rf.xray/focus])
         focused-cascade @(rf/subscribe [:rf.xray.trace/focused-cascade])
-        expanded-ids    @(rf/subscribe [:rf.xray/trace-expanded-row-ids])
-        collapsed-bands @(rf/subscribe [:rf.xray/trace-collapsed-band-ids])]
+        expanded-ids    @(rf/subscribe [:rf.xray/trace-expanded-row-ids])]
     [:section {:data-testid "rf-xray-trace"
                :style       panel-root-style}
      (when focused-cascade
@@ -926,54 +803,30 @@
         :no-focus      (empty-state-no-focus)
         :epoch-evicted (empty-state-epoch-evicted)
         nil
-        ;; The arc container keeps the `rf-xray-trace-feed` testid as the
-        ;; external "the arc rendered rows" contract surface. Every arc
-        ;; child carries an explicit React key (the column-widths
-        ;; header · envelope-open · the four bands · envelope-close) so
-        ;; the reconciler keys the whole sibling list uniformly.
-        (into
-          [:div {:data-testid "rf-xray-trace-feed"
-                 :style panel-feed-container-style}
-           ;; rf2-jnxfj — column-widths drag-handle bar. One header
-           ;; bar at the top of the arc carries the gutter handles for
-           ;; the shared `:rf.xray.trace/ops` table-id; every band's
-           ;; rows render their own resizable-tables with `:header?
-           ;; false` reading the SAME slot, so a drag here re-aligns
-           ;; every row in the arc.
-           ^{:key "ops-header"}
-           [rt/resizable-table
-            {:table-id        trace-ops-table-id
-             :columns         trace-op-columns
-             :rows            []
-             :row-key         (fn [_ _] "")
-             :row-cells       (fn [_ _] [])
-             :header-attrs    trace-header-attrs
-             :header-cell-style trace-header-cell-style}]
-           ;; ○ EPOCH OPEN — the arc's opening bracket (spec/023 §2).
-           ^{:key "envelope-open"}
-           (envelope-row {:kind            :open
-                          :label           "Epoch open"
-                          :rows            (filterv #(not= :rf.epoch/outcome
-                                                           (:operation %))
-                                                    envelope)
-                          :expanded-row-ids expanded-ids})]
-          ;; ①–④ the four phase bands, in arc order (spec/023 §2 / §4),
-          ;; then the EPOCH CLOSE outcome (spec/023 §13).
-          (conj
-            (mapv (fn [{:keys [id] :as band}]
-                    ^{:key (name id)}
-                    (phase-band band
-                                {:expanded?        (not (contains?
-                                                          (or collapsed-bands #{})
-                                                          id))
-                                 :expanded-row-ids expanded-ids}))
-                  bands)
-            ^{:key "envelope-close"}
-            (envelope-row {:kind    :close
-                           :label   "Epoch close"
-                           :outcome outcome
-                           :rows    []
-                           :expanded-row-ids expanded-ids}))))]]))
+        ;; The feed container keeps the `rf-xray-trace-feed` testid as the
+        ;; external "the rows rendered" contract surface. Two children,
+        ;; each explicitly keyed: the column-widths header bar + the flat
+        ;; row list.
+        [:div {:data-testid "rf-xray-trace-feed"
+               :style panel-feed-container-style}
+         ;; rf2-jnxfj — column-widths drag-handle bar. One header bar at
+         ;; the top carries the gutter handles for the shared
+         ;; `:rf.xray.trace/ops` table-id; the flat row list renders its
+         ;; own resizable-table with `:header? false` reading the SAME
+         ;; slot, so a drag here re-aligns every row.
+         ^{:key "ops-header"}
+         [rt/resizable-table
+          {:table-id        trace-ops-table-id
+           :columns         trace-op-columns
+           :rows            []
+           :row-key         (fn [_ _] "")
+           :row-cells       (fn [_ _] [])
+           :header-attrs    trace-header-attrs
+           :header-cell-style trace-header-cell-style}]
+         ;; rf2-aqusw — the flat list of every op the focused epoch
+         ;; emitted, in fire order (oldest-first). No bands, no envelope.
+         ^{:key "rows"}
+         (flat-row-list rows expanded-ids)])]]))
 
 ;; ---- registration entry --------------------------------------------------
 
@@ -993,14 +846,18 @@
   ;; `panels.shared.focus-resolver` — which classifies the focus status
   ;; (`:no-focus` / `:focused` / `:epoch-evicted`) and looks up the
   ;; record. `h/project-feed-from-epoch` projects that record's
-  ;; `:trace-events` into the arc shape (envelope + 4 phase bands).
+  ;; `:trace-events` into the feed shape. The flat panel (rf2-aqusw)
+  ;; reads only `:rows` + `:empty-kind`; the `:envelope` / `:bands` /
+  ;; `:outcome` slots are RETAINED for cross-panel consumers + the
+  ;; band-projection helper tests, but the view no longer renders them.
   ;;
   ;; Shape of `:rf.xray/trace-feed`:
   ;;
   ;;     {:rows       [<row> ...]   ;; the epoch's domino trail, oldest-first
-  ;;      :envelope   [<row> ...]   ;; the EPOCH OPEN / CLOSE :rf.epoch/* ops
-  ;;      :outcome    <:ok/:blocked/:error-or-nil>
-  ;;      :bands      [{:id :label :rows :count :empty?} ...]  ;; 4 phase bands
+  ;;                                ;; (the flat list the panel renders)
+  ;;      :envelope   [<row> ...]   ;; the :rf.epoch/* ops (retained — not rendered)
+  ;;      :outcome    <:ok/:blocked/:error-or-nil>  ;; (retained — not rendered)
+  ;;      :bands      [{:id :label :rows :count :empty?} ...]  ;; (retained — not rendered)
   ;;      :total      <int>         ;; the epoch's trace-event count
   ;;      :rendered   <int>         ;; same as :total (no filtering)
   ;;      :epoch-id   <int-or-nil>  ;; the focused epoch's id
@@ -1062,33 +919,14 @@
                  (disj current row-id)
                  (conj current row-id))))))
 
+  ;; rf2-aqusw — the flat list lost the collapsible phase bands; the
+  ;; expand set is the only per-row UI state left to clear.
   (rf/reg-event-db :rf.xray/clear-trace-expand
     (fn [db _event]
-      (dissoc db :trace-expanded-row-ids :trace-collapsed-band-ids)))
-
-  ;; ---- collapsible phase bands (spec/023 §2 · §14) -------------------
-  ;;
-  ;; The four phase bands are collapsible (default: all expanded). The
-  ;; COLLAPSED set lives in app-db (keyed by the band id) so a band stays
-  ;; collapsed across sub-recomputes. An empty band's header is inert —
-  ;; the view only dispatches the toggle for a non-empty band.
-
-  (rf/reg-sub :rf.xray/trace-collapsed-band-ids
-    (fn [db _query]
-      (get db :trace-collapsed-band-ids #{})))
-
-  (rf/reg-event-db :rf.xray/toggle-trace-band-collapse
-    (fn [db [_ band-id]]
-      (let [current (get db :trace-collapsed-band-ids #{})]
-        (assoc db :trace-collapsed-band-ids
-               (if (contains? current band-id)
-                 (disj current band-id)
-                 (conj current band-id))))))
+      (dissoc db :trace-expanded-row-ids)))
 
   ;; rf2-2moh1 — register the Dynamic Trace tab with the internal L4
-  ;; tab registry. Flows render right after the handler (spec/023 §2 —
-  ;; the FLOW rows live in ② EVENT HANDLING), and the tab keeps its
-  ;; `t` mnemonic + order-3 placement.
+  ;; tab registry. The tab keeps its `t` mnemonic + order-3 placement.
   (panel-registry/reg-l4-tab!
     {:id    :trace
      :label "Trace"

--- a/tools/xray/src/day8/re_frame2_xray/panels/trace_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/trace_helpers.cljc
@@ -56,6 +56,7 @@
   (:require [clojure.string :as str]
             [day8.re-frame2-xray.panels.app-db-diff-helpers :as diff-h]
             [day8.re-frame2-xray.panels.common-helpers :as common]
+            [day8.re-frame2-xray.panels.epoch.badge :as epoch-badge]
             [day8.re-frame2-xray.theme.tokens :as tokens]))
 
 ;; ---- area-badge classification (spec/023 §3 · §5) -----------------------
@@ -315,6 +316,96 @@
   [row-or-ev]
   (get tokens/tokens
        (get outcome-tier->token (outcome-tier row-or-ev) :text-primary)))
+
+;; ---- pipeline stage (flat list · rf2-aqusw) -----------------------------
+;;
+;; The flat Trace panel (rf2-aqusw) loses the 4-band hierarchy in favour
+;; of a single list of rows, each carrying a STAGE column + a colour-coded
+;; left edge. The stage is the Epoch panel's pipeline step — DISPATCH /
+;; COEFFECT / HANDLER / FLOW / SIDE-EFFECTS / SUBSCRIPTIONS / VIEWS — so
+;; the Trace stage column + edge match the Epoch panel's numbered cascade
+;; exactly. ONE mental model, DRY: the label + colour are resolved
+;; through `panels.epoch.badge` (the Epoch panel's own badge taxonomy),
+;; never a parallel palette.
+;;
+;; Mapping a trace op to its Epoch stage is a coarse projection of the
+;; 12-area badge onto the 7 Epoch steps:
+;;
+;;   :event (dispatched)         → :DISPATCH       (the trigger)
+;;   :event (run-start/run-end)  → :HANDLER        (the handler body ran)
+;;   :coeffect                   → :COEFFECT       (injected inputs)
+;;   :flow                       → :FLOW           (db transform after handler)
+;;   :machine                    → :HANDLER        (machine-as-handler)
+;;   :db                         → :SIDE-EFFECTS   (the :db commit — Epoch's
+;;                                                  SIDE EFFECTS :db sub-step)
+;;   :fx                         → :SIDE-EFFECTS   (effect execution)
+;;   :routing                    → :SIDE-EFFECTS   (routing nav effect)
+;;   :sub                        → :SUBSCRIPTIONS  (the reactive recompute)
+;;   :view                       → :VIEWS          (the reactive render)
+;;   :epoch                      → :DISPATCH       (envelope lifecycle —
+;;                                                  rides DISPATCH's muted
+;;                                                  grey, the same hue the
+;;                                                  Epoch panel gives the
+;;                                                  dispatch-link family)
+;;
+;; Errors / warnings are cross-cutting (spec/023 §7) — the STAGE is the
+;; step where the op chronologically occurred (so the column still labels
+;; its phase), but the row's left EDGE rides the severity colour in the
+;; view so a failure stands out (the view layers `:error` / `:warning`
+;; over `stage-colour` exactly as it did over `op-family-colour`).
+
+(def area->stage
+  "Map a trace AREA keyword to its Epoch-panel pipeline STAGE keyword
+  (one of the 7 `epoch.badge` step badges). Pure data. `:event` is
+  resolved by operation in `stage` (dispatched → :DISPATCH, otherwise
+  the handler body → :HANDLER), so it is intentionally absent here."
+  {:coeffect :COEFFECT
+   :flow     :FLOW
+   :machine  :HANDLER
+   :db       :SIDE-EFFECTS
+   :fx       :SIDE-EFFECTS
+   :routing  :SIDE-EFFECTS
+   :sub      :SUBSCRIPTIONS
+   :view     :VIEWS
+   :epoch    :DISPATCH})
+
+(defn stage
+  "Classify a projected row (or raw event) into its Epoch-panel pipeline
+  STAGE — one of the 7 `epoch.badge` step badges (`:DISPATCH` ·
+  `:COEFFECT` · `:HANDLER` · `:FLOW` · `:SIDE-EFFECTS` · `:SUBSCRIPTIONS`
+  · `:VIEWS`). The flat Trace panel (rf2-aqusw) reads this for both the
+  stage column and the colour-coded left edge so the two panels share one
+  step model. Pure data → keyword; JVM-testable.
+
+  `:event` is resolved by operation: `:rf.event/dispatched` is the
+  DISPATCH trigger, every other event op (run-start / run-end) is the
+  HANDLER body. Errors / warnings classify by the stage where they
+  occurred (their area's mapping), defaulting to HANDLER — the view
+  rides the severity colour on the edge regardless (spec/023 §7)."
+  [{:keys [operation] :as row-or-ev}]
+  (let [a (area row-or-ev)]
+    (case a
+      :event   (if (= operation :rf.event/dispatched) :DISPATCH :HANDLER)
+      :error   :HANDLER
+      :warning :HANDLER
+      (get area->stage a :HANDLER))))
+
+(defn stage-label
+  "The uppercase stage label for a row's STAGE — the Epoch panel's own
+  badge label (`DISPATCH`, `SIDE EFFECTS`, `SUBSCRIPTIONS`, …) resolved
+  through `epoch.badge/label` so the Trace stage column reads identically
+  to the Epoch cascade. Pure data → string; JVM-testable."
+  [row-or-ev]
+  (epoch-badge/label (stage row-or-ev)))
+
+(defn stage-colour
+  "Resolve the colour-coded left-edge CSS-var string for a row's STAGE —
+  the Epoch panel's own badge colour resolved through
+  `epoch.badge/colour` so the Trace left edge matches the Epoch step
+  pills exactly (one palette, no parallel scheme — rf2-aqusw). Pure data
+  → CSS-var string; JVM-testable."
+  [row-or-ev]
+  (epoch-badge/colour (stage row-or-ev)))
 
 ;; ---- what-happened verb (spec/023 §5) -----------------------------------
 ;;
@@ -648,6 +739,10 @@
                           :machine/:routing/:epoch/:error/:warning>
        :area-badge      <string>            ;; the uppercase neutral badge
        :phase           <:envelope/:dispatch/:event-handling/:effects/:reactive>
+       :stage           <:DISPATCH/:COEFFECT/:HANDLER/:FLOW/:SIDE-EFFECTS/
+                          :SUBSCRIPTIONS/:VIEWS>  ;; the Epoch pipeline step
+       :stage-label     <string>            ;; the Epoch step label (DRY)
+       :stage-colour    <string>            ;; the Epoch step colour (left edge)
        :op-family       <:dispatch/:db/:fx/:reactive/:machine/:error/:warning>
        :outcome-tier    <:active/:inert/:gone/:pending/:error/:warning>
        :verb            <string>            ;; the what-happened verb
@@ -666,11 +761,15 @@
        :tags            <map>               ;; full tags for the detail view
        :raw             <trace-event>}
 
-  The 5-column row (spec/023 §3) reads `:rel-time` (stamped by
-  `with-rel-times`) · `:area-badge` · `:verb` · `:target` ·
-  `:duration-ms`. `:phase` drives band placement; `:op-family` drives
-  the 3px left-border band; `:outcome-tier` drives the verb's colour
-  tint (spec/023 §8). Pure data → data; JVM-testable."
+  The flat row (rf2-aqusw) reads `:rel-time` (stamped by
+  `with-rel-times`) · `:stage-label` · `:area-badge` · `:verb` ·
+  `:target` · `:duration-ms`, with `:stage-colour` painting the
+  colour-coded left edge. `:phase` is retained for cross-panel
+  consumers + the band-projection helpers; `:stage` drives the flat
+  panel's stage column + edge (the Epoch pipeline step, DRY);
+  `:op-family` is retained for cross-panel consumers; `:outcome-tier`
+  drives the verb's colour tint (spec/023 §8). Pure data → data;
+  JVM-testable."
   [{:keys [id time op-type operation source tags] :as ev}]
   {:id              id
    :time            time
@@ -679,6 +778,9 @@
    :area            (area ev)
    :area-badge      (area-badge ev)
    :phase           (phase ev)
+   :stage           (stage ev)
+   :stage-label     (stage-label ev)
+   :stage-colour    (stage-colour ev)
    :op-family       (op-family ev)
    :outcome-tier    (outcome-tier ev)
    :verb            (what-happened ev)

--- a/tools/xray/test/day8/re_frame2_xray/panels/trace_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/trace_helpers_cljs_test.cljc
@@ -27,6 +27,7 @@
        (spec/018 §6)."
   (:require #?(:clj  [clojure.test :refer [deftest is testing]]
                :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [day8.re-frame2-xray.panels.epoch.badge :as epoch-badge]
             [day8.re-frame2-xray.panels.trace-helpers :as h]
             [day8.re-frame2-xray.theme.tokens :as tokens]))
 
@@ -290,6 +291,81 @@
          (h/outcome-colour {:operation :rf.sub/dispose})))
   (is (= (:red tokens/tokens)
          (h/outcome-colour {:op-type :error :operation :rf.error/x}))))
+
+;; ---- (7b) pipeline stage — flat list (rf2-aqusw) ----------------------
+
+(deftest stage-maps-ops-to-the-epoch-pipeline-steps
+  (testing "rf2-aqusw: each trace op classifies to one of the 7 Epoch
+            pipeline steps — DISPATCH / COEFFECT / HANDLER / FLOW /
+            SIDE-EFFECTS / SUBSCRIPTIONS / VIEWS"
+    (is (= :DISPATCH (h/stage {:op-type :rf.event :operation :rf.event/dispatched}))
+        "the dispatched event is the DISPATCH trigger")
+    (is (= :HANDLER (h/stage {:op-type :rf.event :operation :rf.event/run-end}))
+        "a non-dispatched event op (the handler body) is HANDLER")
+    (is (= :COEFFECT (h/stage {:op-type :rf.event :operation :rf.cofx/run})))
+    (is (= :FLOW (h/stage {:op-type :rf.event :operation :rf.flow/computed})))
+    (is (= :HANDLER (h/stage {:op-type :rf.machine :operation :rf.machine/transition}))
+        "a machine-as-handler op is HANDLER")
+    (is (= :SIDE-EFFECTS (h/stage {:op-type :rf.event :operation :rf.event/db-changed}))
+        "the :db commit is a SIDE EFFECT (the Epoch SIDE-EFFECTS :db sub-step)")
+    (is (= :SIDE-EFFECTS (h/stage {:op-type :rf.fx :operation :rf.fx/handled})))
+    (is (= :SIDE-EFFECTS (h/stage {:op-type :rf.event :operation :rf.route/activated})))
+    (is (= :SUBSCRIPTIONS (h/stage {:op-type :rf.sub :operation :rf.sub/run})))
+    (is (= :VIEWS (h/stage {:op-type :rf.view :operation :rf.view/render})))
+    (is (= :DISPATCH (h/stage {:op-type :rf.epoch :operation :rf.epoch/snapshotted}))
+        "epoch-lifecycle ops ride the DISPATCH step's muted grey")))
+
+(deftest stage-cross-cutting-error-warning-classify-by-occurrence
+  (testing "rf2-aqusw: error / warning ops still classify to a stage so
+            the column labels their phase; the view rides the severity
+            colour on the edge (spec/023 §7)"
+    (is (= :HANDLER (h/stage {:op-type :error :operation :rf.error/x})))
+    (is (= :HANDLER (h/stage {:op-type :warning :operation :rf.warning/x})))))
+
+(deftest stage-label-reuses-the-epoch-badge-label
+  (testing "rf2-aqusw: the stage column label IS the Epoch panel's own
+            badge label (DRY via panels.epoch.badge)"
+    (is (= "DISPATCH"
+           (h/stage-label {:op-type :rf.event :operation :rf.event/dispatched})))
+    (is (= "SIDE EFFECTS"
+           (h/stage-label {:op-type :rf.fx :operation :rf.fx/handled}))
+        "SIDE-EFFECTS renders the Epoch label 'SIDE EFFECTS' (spaced)")
+    (is (= "SUBSCRIPTIONS"
+           (h/stage-label {:op-type :rf.sub :operation :rf.sub/run})))
+    (is (= "VIEWS"
+           (h/stage-label {:op-type :rf.view :operation :rf.view/render})))))
+
+(deftest stage-colour-reuses-the-epoch-badge-colour
+  (testing "rf2-aqusw: the colour-coded left edge IS the Epoch step's
+            badge colour (reused, not a parallel palette)"
+    (is (= (epoch-badge/colour :DISPATCH)
+           (h/stage-colour {:op-type :rf.event :operation :rf.event/dispatched})))
+    (is (= (epoch-badge/colour :SIDE-EFFECTS)
+           (h/stage-colour {:op-type :rf.fx :operation :rf.fx/handled})))
+    (is (= (epoch-badge/colour :SUBSCRIPTIONS)
+           (h/stage-colour {:op-type :rf.sub :operation :rf.sub/run})))
+    (is (= (epoch-badge/colour :VIEWS)
+           (h/stage-colour {:op-type :rf.view :operation :rf.view/render})))
+    (testing "the 7 stage colours match the Epoch step palette exactly"
+      (doseq [[ot op stage] [[:rf.event :rf.event/dispatched :DISPATCH]
+                             [:rf.event :rf.cofx/run :COEFFECT]
+                             [:rf.event :rf.event/run-end :HANDLER]
+                             [:rf.event :rf.flow/computed :FLOW]
+                             [:rf.fx :rf.fx/handled :SIDE-EFFECTS]
+                             [:rf.sub :rf.sub/run :SUBSCRIPTIONS]
+                             [:rf.view :rf.view/render :VIEWS]]]
+        (is (= (epoch-badge/colour stage)
+               (h/stage-colour {:op-type ot :operation op})))))))
+
+(deftest project-row-carries-stage-label-and-colour
+  (testing "rf2-aqusw: project-row stamps :stage / :stage-label /
+            :stage-colour for the flat list's stage column + edge"
+    (let [row (h/project-row (ev {:id 1 :op-type :rf.fx
+                                  :operation :rf.fx/handled
+                                  :tags {:rf.fx/id :http-xhrio}}))]
+      (is (= :SIDE-EFFECTS (:stage row)))
+      (is (= "SIDE EFFECTS" (:stage-label row)))
+      (is (= (epoch-badge/colour :SIDE-EFFECTS) (:stage-colour row))))))
 
 ;; ---- (8) band projection — spec/023 §2 / §13 --------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/trace_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/trace_view_cljs_test.cljs
@@ -140,7 +140,7 @@
 
 (deftest registry-installs-trace-handlers
   (testing "register-xray-handlers! installs the epoch-scoped composite
-            sub + the row-expand + band-collapse events"
+            sub + the row-expand event"
     (registry/register-xray-handlers!)
     (is (some? (registrar/handler :sub :rf.xray/trace-feed))
         ":rf.xray/trace-feed sub registered")
@@ -148,12 +148,17 @@
         ":rf.xray.trace/focused-cascade layer-3 sub registered (rf2-wcfsy)")
     (is (some? (registrar/handler :sub :rf.xray/trace-expanded-row-ids))
         ":rf.xray/trace-expanded-row-ids sub registered")
-    (is (some? (registrar/handler :sub :rf.xray/trace-collapsed-band-ids))
-        ":rf.xray/trace-collapsed-band-ids sub registered")
     (is (some? (registrar/handler :event :rf.xray/toggle-trace-row-expand))
-        ":rf.xray/toggle-trace-row-expand event registered")
-    (is (some? (registrar/handler :event :rf.xray/toggle-trace-band-collapse))
-        ":rf.xray/toggle-trace-band-collapse event registered")))
+        ":rf.xray/toggle-trace-row-expand event registered")))
+
+(deftest band-collapse-handlers-are-gone
+  (testing "rf2-aqusw — the flat list lost the phase-band hierarchy, so
+            the band-collapse sub + event MUST NOT register"
+    (registry/register-xray-handlers!)
+    (is (nil? (registrar/handler :sub :rf.xray/trace-collapsed-band-ids))
+        ":rf.xray/trace-collapsed-band-ids sub removed with the bands")
+    (is (nil? (registrar/handler :event :rf.xray/toggle-trace-band-collapse))
+        ":rf.xray/toggle-trace-band-collapse event removed with the bands")))
 
 (deftest filter-handlers-are-gone
   (testing "the chip-filter subs + events MUST NOT register"
@@ -219,10 +224,10 @@
         (is (nil? (find-by-testid tree "rf-xray-trace-axis-row-op-type")))
         (is (nil? (find-by-testid tree "rf-xray-trace-clear-filters")))))))
 
-(deftest arc-renders-envelope-bands-and-rows
-  (testing "spec/023 §2: a focused epoch renders the EPOCH OPEN/CLOSE
-            envelope, the four phase bands in arc order, and the op rows
-            in their bands"
+(deftest flat-list-renders-every-op-as-a-row
+  (testing "rf2-aqusw: a focused epoch renders ALL its ops as a single
+            flat list of rows — no envelope, no phase bands. The
+            epoch-lifecycle ops surface as ordinary rows."
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
       (seed-history!
@@ -238,29 +243,28 @@
                                :time 121 :tags {:rf.epoch/outcome :ok}})])])
       (focus! 1)
       (let [tree (trace/Panel)]
-        (is (some? (find-by-testid tree "rf-xray-trace-feed")) "arc container present")
-        (is (some? (find-by-testid tree "rf-xray-trace-envelope-open"))
-            "EPOCH OPEN envelope present")
-        (is (some? (find-by-testid tree "rf-xray-trace-envelope-close"))
-            "EPOCH CLOSE envelope present")
-        (is (some? (find-by-testid tree "rf-xray-trace-outcome-ok"))
-            "the :ok outcome renders on the close envelope")
-        (testing "all four phase bands render"
-          (is (some? (find-by-testid tree "rf-xray-trace-band-dispatch")))
-          (is (some? (find-by-testid tree "rf-xray-trace-band-event-handling")))
-          (is (some? (find-by-testid tree "rf-xray-trace-band-effects")))
-          (is (some? (find-by-testid tree "rf-xray-trace-band-reactive")))
-          (is (some? (find-by-testid tree "rf-xray-trace-band-header-dispatch"))))
-        (testing "the op rows land in their bands"
-          (is (some? (find-by-testid tree "rf-xray-trace-row-1"))
-              "the dispatch row renders")
-          (is (some? (find-by-testid tree "rf-xray-trace-row-2"))
-              "the fx row renders")
-          (is (some? (find-by-testid tree "rf-xray-trace-row-3"))
-              "the reactive sub row renders"))))))
+        (is (some? (find-by-testid tree "rf-xray-trace-feed")) "feed container present")
+        (is (some? (find-by-testid tree "rf-xray-trace-rows"))
+            "the flat row list container renders")
+        (testing "the hierarchy chrome is GONE (rf2-aqusw)"
+          (is (nil? (find-by-testid tree "rf-xray-trace-envelope-open")))
+          (is (nil? (find-by-testid tree "rf-xray-trace-envelope-close")))
+          (is (nil? (find-by-testid tree "rf-xray-trace-band-dispatch")))
+          (is (nil? (find-by-testid tree "rf-xray-trace-band-event-handling")))
+          (is (nil? (find-by-testid tree "rf-xray-trace-band-effects")))
+          (is (nil? (find-by-testid tree "rf-xray-trace-band-reactive")))
+          (is (nil? (find-by-testid tree "rf-xray-trace-band-header-dispatch"))))
+        (testing "every op — including the epoch-lifecycle ops — is a flat row"
+          (is (some? (find-by-testid tree "rf-xray-trace-row-0"))
+              "the EPOCH snapshotted lifecycle op is an ordinary row")
+          (is (some? (find-by-testid tree "rf-xray-trace-row-1")) "dispatch row")
+          (is (some? (find-by-testid tree "rf-xray-trace-row-2")) "fx row")
+          (is (some? (find-by-testid tree "rf-xray-trace-row-3")) "sub row")
+          (is (some? (find-by-testid tree "rf-xray-trace-row-8"))
+              "the EPOCH outcome lifecycle op is an ordinary row"))))))
 
-(deftest op-row-renders-the-five-columns
-  (testing "spec/023 §3: each op row carries Δt · area badge ·
+(deftest op-row-renders-the-six-columns
+  (testing "rf2-aqusw: each op row carries Δt · stage · area badge ·
             what-happened · target/detail · duration"
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
@@ -276,6 +280,10 @@
       (let [tree (trace/Panel)]
         (is (= "+0.0" (last (find-by-testid tree "rf-xray-trace-row-1-time")))
             "Δt column reads +0.0 relative to the epoch origin")
+        (is (= "DISPATCH" (last (find-by-testid tree "rf-xray-trace-row-1-stage")))
+            "stage column reads the Epoch DISPATCH step (dispatched op)")
+        (is (= "VIEWS" (last (find-by-testid tree "rf-xray-trace-row-2-stage")))
+            "stage column reads the Epoch VIEWS step (view render op)")
         (is (= "EVENT" (last (find-by-testid tree "rf-xray-trace-row-1-badge")))
             "area badge column reads the neutral EVENT badge")
         (is (= "dispatched" (last (find-by-testid tree "rf-xray-trace-row-1-verb")))
@@ -287,9 +295,9 @@
         (is (= "—" (last (find-by-testid tree "rf-xray-trace-row-1-duration")))
             "an untimed op renders an em-dash duration")))))
 
-(deftest op-row-carries-op-family-left-border-and-area-attr
-  (testing "spec/023 §3: rows band by op-family 3px left-border + carry
-            data attrs for area + op-family"
+(deftest op-row-carries-colour-coded-stage-edge-and-attrs
+  (testing "rf2-aqusw: rows carry a 3px colour-coded left edge keyed to
+            the Epoch pipeline stage + data attrs for area + stage"
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
       (seed-history!
@@ -299,18 +307,28 @@
                     (mk-trace {:id 2 :op-type :rf.event :operation :rf.event/db-changed
                                :dispatch-id 1})
                     (mk-trace {:id 3 :op-type :rf.fx :operation :rf.fx/handled
-                               :dispatch-id 1})])])
+                               :dispatch-id 1})
+                    (mk-trace {:id 4 :op-type :rf.sub :operation :rf.sub/run})])])
       (focus! 1)
       (let [tree (trace/Panel)]
         (is (= "event" (:data-rf-xray-area (node-attrs tree "rf-xray-trace-row-1"))))
         (is (= "db" (:data-rf-xray-area (node-attrs tree "rf-xray-trace-row-2"))))
         (is (= "fx" (:data-rf-xray-area (node-attrs tree "rf-xray-trace-row-3"))))
-        (is (= "dispatch" (:data-rf-xray-op-family
-                            (node-attrs tree "rf-xray-trace-row-1"))))
+        (testing "the stage data-attr names the Epoch pipeline step"
+          (is (= "DISPATCH" (:data-rf-xray-stage
+                              (node-attrs tree "rf-xray-trace-row-1"))))
+          (is (= "SIDE-EFFECTS" (:data-rf-xray-stage
+                                 (node-attrs tree "rf-xray-trace-row-2")))
+              "the :db commit maps to the Epoch SIDE-EFFECTS step")
+          (is (= "SIDE-EFFECTS" (:data-rf-xray-stage
+                                 (node-attrs tree "rf-xray-trace-row-3")))
+              "the fx op maps to the Epoch SIDE-EFFECTS step")
+          (is (= "SUBSCRIPTIONS" (:data-rf-xray-stage
+                                  (node-attrs tree "rf-xray-trace-row-4")))))
         (let [border (get-in (node-attrs tree "rf-xray-trace-row-1")
                              [:style :border-left])]
           (is (and (string? border) (re-find #"^3px solid " border))
-              "the op-family band is a 3px left-border on the row"))))))
+              "the colour-coded stage band is a 3px left-border on the row"))))))
 
 (deftest error-rows-are-emphasised-inline
   (testing "spec/023 §7: an error op renders inline at its chronological
@@ -784,83 +802,41 @@
             ":rf.xray/open-in-editor fired with the projected coord")
         (is @stop-evt "stopPropagation was called")))))
 
-;; ---- (6) phase bands — spec/023 §13 / §14 -----------------------------
+;; ---- (6) flat list, no hierarchy — rf2-aqusw --------------------------
 
-(deftest empty-band-renders-dimmed-none
-  (testing "spec/023 §13: a no-op event keeps ③④ present with a `(none)`
-            count, never hidden"
+(deftest flat-list-preserves-fire-order-across-stages
+  (testing "rf2-aqusw: ops from different pipeline stages render in ONE
+            flat list, in fire order (oldest-first) — not regrouped into
+            bands. A no-op event no longer renders empty phase bands."
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
       (seed-history!
         [(mk-epoch 1 1
                    [(mk-trace {:id 1 :op-type :rf.event :operation :rf.event/dispatched
-                               :time 100 :dispatch-id 1})])])
+                               :time 100 :dispatch-id 1})
+                    (mk-trace {:id 2 :op-type :rf.sub :operation :rf.sub/run :time 110})
+                    (mk-trace {:id 3 :op-type :rf.fx :operation :rf.fx/handled
+                               :time 120 :dispatch-id 1})])])
       (focus! 1)
       (let [tree (trace/Panel)]
-        (is (some? (find-by-testid tree "rf-xray-trace-band-effects"))
-            "③ EFFECTS band present even when empty")
-        (is (= "(none)" (last (find-by-testid tree "rf-xray-trace-band-count-effects")))
-            "an empty band's count reads (none)")
-        (is (true? (:data-rf-xray-empty
-                     (node-attrs tree "rf-xray-trace-band-header-effects")))
-            "the empty band header carries the empty attr")))))
-
-(deftest collapsing-a-band-hides-its-rows
-  (testing "spec/023 §2 / §14: collapsing a band hides its rows; the
-            header stays"
-    (setup-xray-frame!)
-    (rf/with-frame :rf/xray
-      (seed-history!
-        [(mk-epoch 1 1
-                   [(mk-trace {:id 1 :op-type :rf.event :operation :rf.event/dispatched
-                               :time 100 :dispatch-id 1})])])
-      (focus! 1)
-      ;; expanded by default — the dispatch row + its band rows ul render
-      (let [tree (trace/Panel)]
-        (is (some? (find-by-testid tree "rf-xray-trace-band-rows-dispatch")))
-        (is (some? (find-by-testid tree "rf-xray-trace-row-1"))))
-      ;; collapse the dispatch band → rows hidden, header remains
-      (rf/dispatch-sync [:rf.xray/toggle-trace-band-collapse :dispatch])
-      (let [tree (trace/Panel)]
-        (is (nil? (find-by-testid tree "rf-xray-trace-band-rows-dispatch"))
-            "collapsed band hides its rows ul")
-        (is (nil? (find-by-testid tree "rf-xray-trace-row-1"))
-            "the band's row is hidden when collapsed")
-        (is (some? (find-by-testid tree "rf-xray-trace-band-header-dispatch"))
-            "the band header stays so the phase is still labelled")))))
-
-(deftest band-header-click-fires-toggle-event
-  (testing "spec/023 §2: clicking a non-empty band header dispatches
-            :rf.xray/toggle-trace-band-collapse with the band id"
-    (setup-xray-frame!)
-    (rf/with-frame :rf/xray
-      (seed-history!
-        [(mk-epoch 1 1
-                   [(mk-trace {:id 1 :op-type :rf.event :operation :rf.event/dispatched
-                               :time 100 :dispatch-id 1})])])
-      (focus! 1)
-      (let [dispatches (atom [])]
-        (with-redefs [rf/dispatch* (fn
-                                     ([ev]    (swap! dispatches conj ev) nil)
-                                     ([ev _o] (swap! dispatches conj ev) nil))]
-          (let [tree    (trace/Panel)
-                header  (find-by-testid tree "rf-xray-trace-band-header-dispatch")
-                handler (:on-click (second header))]
-            (is (some? header))
-            (is (some? handler) "non-empty band header carries on-click")
-            (when handler (handler))))
-        (is (some #(= [:rf.xray/toggle-trace-band-collapse :dispatch] %)
-                  @dispatches)
-            "band header click fires the toggle with the band id")))))
-
-(deftest toggle-trace-band-collapse-event-mutates-set
-  (testing ":rf.xray/toggle-trace-band-collapse toggles membership"
-    (setup-xray-frame!)
-    (rf/with-frame :rf/xray
-      (rf/dispatch-sync [:rf.xray/toggle-trace-band-collapse :effects])
-      (is (= #{:effects} @(rf/subscribe [:rf.xray/trace-collapsed-band-ids])))
-      (rf/dispatch-sync [:rf.xray/toggle-trace-band-collapse :effects])
-      (is (= #{} @(rf/subscribe [:rf.xray/trace-collapsed-band-ids]))))))
+        ;; no band chrome at all (rf2-aqusw)
+        (is (nil? (find-by-testid tree "rf-xray-trace-band-effects")))
+        (is (nil? (find-by-testid tree "rf-xray-trace-band-count-effects")))
+        (is (nil? (find-by-testid tree "rf-xray-trace-band-rows-dispatch")))
+        ;; the rows render in seeded fire order — the reactive SUB op
+        ;; lands BETWEEN the dispatch and the fx, not regrouped to the end
+        (let [rows-container (find-by-testid tree "rf-xray-trace-rows")
+              row-ids (->> (hiccup-seq rows-container)
+                           (keep (fn [n]
+                                   (when (and (vector? n) (map? (second n)))
+                                     (let [tid (:data-testid (second n))]
+                                       (when (and (string? tid)
+                                                  (re-find #"^rf-xray-trace-row-\d+$" tid))
+                                         (subs tid (count "rf-xray-trace-row-")))))))
+                           (distinct)
+                           (vec))]
+          (is (= ["1" "2" "3"] row-ids)
+              "rows are flat + in fire order, not regrouped into bands"))))))
 
 ;; ---- (7) frame isolation ------------------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -369,10 +369,9 @@
    ;; rf2-l2f2g — per-row inline raw-EDN payload expansion state
    ;; (spec/023-Trace-Panel.md §3 — row click → raw EDN).
    :rf.xray/trace-expanded-row-ids
-   ;; rf2-l2f2g — per-band collapse state (spec/023 §2 / §14 —
-   ;; collapsible phase bands; default all-expanded, this set tracks the
-   ;; COLLAPSED bands).
-   :rf.xray/trace-collapsed-band-ids
+   ;; rf2-aqusw — the per-band collapse state sub
+   ;; (`:rf.xray/trace-collapsed-band-ids`) was REMOVED with the phase-band
+   ;; hierarchy; the flat Trace panel has no collapsible bands.
    ;; rf2-td380 — epoch-scoped feed (reads the focused epoch record's
    ;; `:trace-events` directly). The `:rf.xray/trace-feed-state`
    ;; buffer snapshot + `:rf.xray/trace-filters` chip-filter slot were
@@ -693,9 +692,9 @@
    ;; rf2-l2f2g — toggle the inline raw-EDN payload expansion for one
    ;; trace row (spec/023-Trace-Panel.md §3 — Row click → raw EDN).
    :rf.xray/toggle-trace-row-expand
-   ;; rf2-l2f2g — toggle one phase band's collapse state (spec/023 §2 /
-   ;; §14 — the four phase bands are collapsible).
-   :rf.xray/toggle-trace-band-collapse
+   ;; rf2-aqusw — the per-band collapse-toggle event
+   ;; (`:rf.xray/toggle-trace-band-collapse`) was REMOVED with the
+   ;; phase-band hierarchy; the flat Trace panel has no collapsible bands.
    ;; Reactive panel events (rf2-wyvf2 · spec/021 §3 · renamed from
    ;; Views per §11.5; tab key stays `:views`).
    :rf.xray/reactive-set-unchanged


### PR DESCRIPTION
Redesigns the Xray **Trace panel** from its hierarchical 4-band + epoch-envelope structure to a **single flat list of trace rows** (rf2-aqusw).

## What changed

- **Lose the hierarchy.** Every op the focused epoch emitted renders as one ordinary row, oldest-first. The `:rf.epoch/*` lifecycle ops (snapshotted / outcome / restore / …) that used to live in the EPOCH OPEN / CLOSE envelope are now ordinary rows. No bands, no envelope, no collapse machinery, no `(none)` empty-band scaffolding.
- **Stage column + colour-coded left edge.** Each row names the **Epoch-panel pipeline step** it belongs to — DISPATCH / COEFFECT / HANDLER / FLOW / SIDE EFFECTS / SUBSCRIPTIONS / VIEWS — in a new stage column, and the row's 3px left edge is colour-coded with that step's colour. Both the label and the colour are **reused from the Epoch panel's own `panels.epoch.badge` taxonomy** (no parallel palette), so the Trace stage column + edge match the Epoch numbered cascade exactly. One step model, DRY. The phase information the bands conveyed is recovered flatly.
- **Click → edn-inspector.** Clicking a row opens the existing first-class edn-inspector widget on the raw trace MAP inline (unchanged behaviour).
- Error / warning rows keep their cross-cutting inline emphasis — the left edge rides the severity colour over the stage colour.

## Implementation

- `panels/trace_helpers.cljc`: new `stage` (trace area → Epoch step), `stage-label` / `stage-colour` (resolved via `epoch.badge`, DRY), stamped onto each projected row as `:stage` / `:stage-label` / `:stage-colour`. The `build-bands` / envelope / phase projection helpers are **retained** for cross-panel consumers + the helper tests; the view simply no longer renders them.
- `panels/trace.cljs`: 6-column flat row grid (Δt · stage · area badge · what-happened · target/detail · duration); the `flat-row-list` renders all `:rows` via the shared `rt/resizable-table`. Removed the `band-header` / `phase-band` / `envelope-row` renderers + their styles + the now-dead `op-row-summary-grid-style` / `row-grid-columns`. Removed the band-collapse sub + event (`:rf.xray/trace-collapsed-band-ids` / `:rf.xray/toggle-trace-band-collapse`); `clear-trace-expand` no longer touches the band set.
- `registry_cljs_test.cljs`: dropped the two removed ids from the canonical registration snapshot.
- `spec/023-Trace-Panel.md`: updated for the flat-list redesign (§1/§2/§3 + new §3a stage mapping, §7/§8/§9/§13/§14/§16 + the Appendix Stage column).

## Settle-first

Read `trace.cljs` + `trace_helpers.cljc` + the trace-collector row shape, the Epoch panel's `panels.epoch.badge` stage colour/label tokens (reused, not duplicated), and `spec/023-Trace-Panel.md`. Confirmed the trace-row `:raw` map feeds the edn-inspector unchanged.

## Quality gates

- `npm run test:cljs` — 5064 tests, 17037 assertions, **0 failures** (incl. the new flat-list view tests: flat list renders, stage column + data-attr present, colour-coded edge present, click → edn-inspector opens the trace map; + the new helper tests for `stage` / `stage-label` / `stage-colour`)
- `npm run test:xray-feature-gate` — 14 scenarios, **0 failures**
- clj-kondo — **0 errors, 0 warnings** on changed files
- `npm run test:bundle-isolation` — **PASS**