### PR TITLE
feat(examples): nine_states Story+Xray showcase — reg-story variants for the nine RemoteData states (rf2-rgyia)

### DIFF
--- a/examples/reagent/nine_states/stories.cljs
+++ b/examples/reagent/nine_states/stories.cljs
@@ -1,0 +1,382 @@
+(ns nine-states.stories
+  "Story showcase for the **Nine States of UI** worked example.
+
+   The nine canonical UI states (Nothing / Loading / Empty / One /
+   Some / Too Many / Incorrect / Correct / Done) form a natural Story
+   VARIANT SET — Story's core strength is enumerating a single view's
+   view-states side by side. This file registers one `reg-variant`
+   per render-model keyword the root view `case`s over, so the Story
+   controls panel flips the page through every state without the
+   reader hand-driving the machine.
+
+   ## Where the nine come from
+
+   `nine-states.core` collapses the `:ui/nine-states` machine's
+   parallel-region tag union into ONE render-model keyword via the
+   `:ui/render` selector sub (consulting the `render-priority`
+   table). The root view's `case` has exactly ten arms — the nine
+   canonical states plus the `:error` branch. The nine canonical
+   variants below map 1:1 onto the nine canonical render keywords:
+
+     :nothing :loading :empty :one :some :too-many
+     :incorrect :correct :done
+
+   The `:error` branch is the tenth render arm; it lives on a
+   SEPARATE `:story.nine-states-lifecycle` story (below) alongside
+   `:loading`/`:some` so the async **load → loading → loaded/error**
+   cascade reads as one lifecycle the reader can step through and
+   inspect in Xray (the bead's Xray-rich requirement). Keeping it off
+   the canonical nine keeps that set a clean 1:1 with the render
+   keywords.
+
+   ## Fidelity — reach each state via real events
+
+   Every variant drives its state through REAL events into the
+   `:ui/nine-states` machine — the highest-fidelity path, so the
+   Story canvas shows exactly what the live app shows and Xray's
+   Epoch / Trace / Side Effects panels carry the genuine cascade:
+
+   - Nothing      — `[:nine-states.app/initialise]` (machine `:reset`).
+   - Loading       — `[:ui/nine-states [:fetch-started]]` parks the
+                     `:data` region at `:loading` (no reply dispatched).
+   - Empty/One/Some/Too Many — the `:nine-states.story/load` cascade
+                     below: a real `:rf.http/managed` fx whose reply
+                     folds back through `:fetch-succeeded`, so the
+                     `:data` region's `:always`-cascade picks the
+                     cardinality bucket from the item count.
+   - Incorrect     — edit a too-short title + submit → `:submit-invalid`.
+   - Correct       — edit a valid title + submit → `:submit-valid`.
+   - Done          — load + archive → the `:mode` region reaches `:done`.
+
+   NO `:db-seed` / `:sub-overrides` are needed: every state is
+   reachable through an event path, so the fidelity is uniformly
+   `:event` (Story's controls panel + the Xray cascade tell the
+   truth on their own — no synthetic seeding to disclose).
+
+   ## Xray-richness — the managed-HTTP cascade
+
+   Story allocates each variant its own frame under `:preset :story`
+   (spec/002 §Frame presets), which redirects `:rf.http/managed` to
+   the framework-shipped `:rf.http/managed-canned-success` /
+   `-canned-failure` stubs. `:nine-states.story/load` issues a real
+   `:rf.http/managed` request carrying the synthetic todos on the
+   request's `:value` slot (the slot the canned-success stub echoes
+   back), so the FULL fetch lifecycle runs:
+
+       :nine-states.story/load
+         → [:ui/nine-states [:fetch-started]]        (→ :loading)
+         → [:rf.http/managed {...}]                  (a real fx)
+             → canned-success reply                  (Side Effects panel)
+             → [:nine-states.demo/loaded {:value …}]
+                 → [:ui/nine-states [:fetch-succeeded …]]
+                     → :resolving → :always cardinality bucket
+
+   That whole chain lands on the Epoch tape + the Trace stream, and
+   the `:rf.http/managed` fx shows in the Side Effects panel — so a
+   reader can pick the `:some` or `:error` variant and watch the
+   RemoteData fetch light up Xray end to end.
+
+   ## Authoring discipline
+
+   Per spec/007 §Variants every variant body is plain data — no
+   fn-slots. The view at the centre of each variant is the example's
+   own `nine-states.core/root-view`, referenced by id. The canonical
+   Story tags auto-install on the first `reg-*` call (rf2-p1ydc), so
+   no explicit boot step is needed."
+  (:require [re-frame.core :as rf]
+            [re-frame.story :as story]
+            ;; Source the example's registrations (the machine, the
+            ;; demo events/subs/views, the `:ui/render` selector). The
+            ;; variant bodies below reference its event-ids + the
+            ;; `root-view` view-id as plain keywords; requiring the ns
+            ;; fires every `reg-*` so those ids resolve.
+            [nine-states.core]))
+
+;; ---------------------------------------------------------------------------
+;; Story-side load event — the Xray-rich managed-HTTP cascade
+;;
+;; The live example's `:nine-states.demo/load` builds its request with
+;; `:query {:n N}` and lets the app's own `:nine-states.http/managed-demo`
+;; fx-override read `:n` to synthesise todos. Inside the Story shell the
+;; per-variant frame runs under `:preset :story`, which redirects
+;; `:rf.http/managed` to the framework-shipped `:rf.http/managed-canned-
+;; success` stub instead — that stub echoes the request's `:value` slot
+;; back as the success payload (Spec 014 §Testing). So the Story load
+;; event puts the synthetic todos directly on `:value`, keeping the SAME
+;; real `:rf.http/managed` fx cascade the live app uses (visible in
+;; Xray's Side Effects panel) while staying deterministic under the
+;; canned stub — no app-side fx-override required.
+;; ---------------------------------------------------------------------------
+
+(defn- gen-todos
+  "Synthesise N demo todos. Mirrors the live example's private
+   generator; kept local so the story file does not reach into
+   `nine-states.core`'s implementation namespace."
+  [n]
+  (vec (for [i (range n)]
+         {:id (random-uuid) :title (str "Todo #" (inc i)) :done? false})))
+
+(rf/reg-event-fx :nine-states.story/load
+  {:doc "Story-shell variant of `:nine-states.demo/load`. Drives the
+         same real fetch cascade — `:fetch-started` → `:rf.http/managed`
+         → reply → `:fetch-succeeded` — but carries the synthetic todos
+         on the request's `:value` slot so the `:preset :story` frame's
+         canned-success stub returns them. `n` items lands the `:data`
+         region in the matching cardinality bucket via the
+         `:always`-cascade."}
+  (fn handler-story-load [_ [_ {:keys [n]}]]
+    {:fx [[:dispatch [:ui/nine-states [:fetch-started]]]
+          [:rf.http/managed
+           {:request    {:method :get :url "/api/todos" :query {:n (or n 0)}}
+            :value      (gen-todos (or n 0))
+            :decode     :json
+            :on-success [:nine-states.demo/loaded]
+            :on-failure [:nine-states.demo/load-failed]}]]}))
+
+(rf/reg-event-fx :nine-states.story/load-failing
+  {:doc "Story-shell variant of `:nine-states.demo/load-with-failure`.
+         Drives the real fetch cascade into the `:error` branch — the
+         `:rf.http/managed` request carries no `:value` and routes
+         through the `:preset :story` frame's canned-FAILURE stub by
+         declaring `:on-failure` against a request the stub cannot
+         satisfy, so `:fetch-failed` fires and the `:data` region
+         lands at `:error`."}
+  (fn handler-story-load-failing [_ _]
+    {:fx [[:dispatch [:ui/nine-states [:fetch-started]]]
+          [:rf.http/managed
+           {:request    {:method :get :url "/api/todos/fail"}
+            :failure    {:kind :rf.http/transport
+                         :message "Network unreachable."}
+            :decode     :json
+            :on-success [:nine-states.demo/loaded]
+            :on-failure [:nine-states.demo/load-failed]}]]}))
+
+;; ---------------------------------------------------------------------------
+;; register-all!
+;;
+;; Wrap every registration in a top-level fn so a test fixture (none
+;; here — examples are test-free, rf2-8cevm) or a hot-reload could
+;; re-fire the lot after a clear-all!. The fn fires once at namespace
+;; load via the trailing call, so consumers who just `:require` this ns
+;; get the side-table populated.
+;; ---------------------------------------------------------------------------
+
+(defn register-all!
+  "Register the nine-states example's Story artefacts. Idempotent.
+   The canonical vocabulary auto-installs on the first `reg-*` call
+   (rf2-p1ydc) — no explicit boot step required."
+  []
+
+  ;; -------------------------------------------------------------------------
+  ;; reg-tag — a project tag marking the canonical screenshot variant.
+  ;; -------------------------------------------------------------------------
+
+  (story/reg-tag :nine-states/canonical
+    {:doc "Marks the variant that ships as the example's canonical
+          screenshot — the `:some` standard-list state."})
+
+  ;; -------------------------------------------------------------------------
+  ;; reg-story — the parent story. Its `:component` (the example's
+  ;; `root-view`) and `:tags` inherit down to every variant below; the
+  ;; per-state setup lives on the variants.
+  ;; -------------------------------------------------------------------------
+
+  (story/reg-story :story.nine-states
+    {:doc        "The Nine States of UI — every canonical view-state of
+                 the todos page, driven through the `:ui/nine-states`
+                 parallel machine."
+     :component  :nine-states.core/root-view
+     :tags       #{:dev :docs}
+     :substrates #{:reagent}})
+
+  (story/reg-story :story.nine-states-lifecycle
+    {:doc        "The RemoteData fetch lifecycle as a stepped cascade —
+                 load → loading → loaded / error. Kept separate from the
+                 canonical nine so the async path (and its Xray Epoch /
+                 Trace / Side Effects trail) reads as one story the
+                 reader can step through."
+     :component  :nine-states.core/root-view
+     :tags       #{:dev :docs}
+     :substrates #{:reagent}})
+
+  ;; -------------------------------------------------------------------------
+  ;; reg-variant — the nine canonical states, one per render keyword.
+  ;;
+  ;; Each `:setup` drives the machine to its state through REAL events
+  ;; (fidelity `:event`); no `:db-seed` / `:sub-overrides`.
+  ;; -------------------------------------------------------------------------
+
+  ;; State 1 — Nothing. Initialise the form slice + reset the machine.
+  (story/reg-variant :story.nine-states/nothing
+    {:doc        "State 1 — Nothing. Never fetched; the `:data` region
+                 sits at `:nothing`. The blank-slate welcome view with a
+                 'Get started' CTA."
+     :setup      [[:nine-states.app/initialise]]
+     :tags       #{:dev :docs}
+     :substrates #{:reagent}})
+
+  ;; State 2 — Loading. `:fetch-started` parks the `:data` region at
+  ;; `:loading`; no reply is dispatched so it stays there for the
+  ;; screenshot.
+  (story/reg-variant :story.nine-states/loading
+    {:doc        "State 2 — Loading. A first fetch is in flight; the
+                 `:data` region is parked at `:loading` (the
+                 `:fetch-started` event with no reply). Spinner view."
+     :setup      [[:nine-states.app/initialise]
+                  [:ui/nine-states [:fetch-started]]]
+     :tags       #{:dev :docs}
+     :substrates #{:reagent}})
+
+  ;; State 3 — Empty. Load zero todos; the `:always`-cascade picks `:empty`.
+  (story/reg-variant :story.nine-states/empty
+    {:doc        "State 3 — Empty. Fetched, but the result is the empty
+                 list. The `:always`-cascade picks `:empty` from a
+                 zero count."
+     :setup      [[:nine-states.app/initialise]
+                  [:nine-states.story/load {:n 0}]]
+     :tags       #{:dev :docs}
+     :substrates #{:reagent}})
+
+  ;; State 4 — One. Exactly one todo; the cascade picks `:one`.
+  (story/reg-variant :story.nine-states/one
+    {:doc        "State 4 — One. Exactly one todo; the focused
+                 single-item layout (`:one` cardinality bucket)."
+     :setup      [[:nine-states.app/initialise]
+                  [:nine-states.story/load {:n 1}]]
+     :tags       #{:dev :docs}
+     :substrates #{:reagent}})
+
+  ;; State 5 — Some. A small, manageable list; the canonical screenshot.
+  (story/reg-variant :story.nine-states/some
+    {:doc        "State 5 — Some. A small, manageable list rendered
+                 plainly (`:some` cardinality bucket). The example's
+                 canonical screenshot."
+     :setup      [[:nine-states.app/initialise]
+                  [:nine-states.story/load {:n 4}]]
+     :tags       #{:dev :docs :nine-states/canonical}
+     :substrates #{:reagent}})
+
+  ;; State 6 — Too Many. Beyond the threshold; search + truncation.
+  (story/reg-variant :story.nine-states/too-many
+    {:doc        "State 6 — Too Many. More items than the too-many
+                 threshold (7); the view shows search + truncation
+                 (`:too-many` cardinality bucket)."
+     :setup      [[:nine-states.app/initialise]
+                  [:nine-states.story/load {:n 25}]]
+     :tags       #{:dev :docs}
+     :substrates #{:reagent}})
+
+  ;; State 7 — Incorrect. A too-short title + submit → `:submit-invalid`.
+  (story/reg-variant :story.nine-states/incorrect
+    {:doc        "State 7 — Incorrect. A too-short title fails the form
+                 validator on submit; the `:form` region lands at
+                 `:incorrect` (`:submit-invalid`), showing the inline
+                 per-field error."
+     :setup      [[:nine-states.app/initialise]
+                  [:new-todo/edit-field :title "no"]
+                  [:new-todo/submit]]
+     :tags       #{:dev :docs}
+     :substrates #{:reagent}})
+
+  ;; State 8 — Correct. A valid title + submit → `:submit-valid`.
+  (story/reg-variant :story.nine-states/correct
+    {:doc        "State 8 — Correct. A valid title passes the form
+                 validator on submit; the `:form` region lands at
+                 `:correct` (`:submit-valid`), showing the success
+                 acknowledgement."
+     :setup      [[:nine-states.app/initialise]
+                  [:new-todo/edit-field :title "Buy milk"]
+                  [:new-todo/submit]]
+     :tags       #{:dev :docs}
+     :substrates #{:reagent}})
+
+  ;; State 9 — Done. Load some items, then archive → `:mode` at `:done`.
+  (story/reg-variant :story.nine-states/done
+    {:doc        "State 9 — Done. After loading some todos the list is
+                 archived; the `:mode` region reaches the terminal,
+                 read-only `:done` state and the form + controls
+                 disable themselves."
+     :setup      [[:nine-states.app/initialise]
+                  [:nine-states.story/load {:n 4}]
+                  [:ui/nine-states [:archive {}]]]
+     :tags       #{:dev :docs}
+     :substrates #{:reagent}})
+
+  ;; -------------------------------------------------------------------------
+  ;; The :error branch — the tenth render arm. Lives on the lifecycle
+  ;; story so the async failure cascade reads alongside :loading / :some.
+  ;; -------------------------------------------------------------------------
+
+  (story/reg-variant :story.nine-states-lifecycle/loading
+    {:doc        "Lifecycle — the in-flight `:loading` step. Same as the
+                 canonical Loading variant, shown here as the first arm
+                 of the fetch cascade."
+     :setup      [[:nine-states.app/initialise]
+                  [:ui/nine-states [:fetch-started]]]
+     :tags       #{:dev :docs}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.nine-states-lifecycle/loaded
+    {:doc        "Lifecycle — the resolved `:some` step. The full
+                 `:rf.http/managed` cascade runs in `:setup`; pick this
+                 variant and inspect the fetch in Xray's Epoch / Trace /
+                 Side Effects panels."
+     :setup      [[:nine-states.app/initialise]
+                  [:nine-states.story/load {:n 4}]]
+     :tags       #{:dev :docs}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.nine-states-lifecycle/error
+    {:doc        "Lifecycle — the `:error` branch. The `:rf.http/managed`
+                 request fails; `:fetch-failed` lands the `:data` region
+                 at `:error`. The failure cascade lights up Xray's Side
+                 Effects + Trace panels alongside the success path."
+     :setup      [[:nine-states.app/initialise]
+                  [:nine-states.story/load-failing]]
+     :tags       #{:dev :docs}
+     :substrates #{:reagent}})
+
+  ;; -------------------------------------------------------------------------
+  ;; reg-workspace — two layouts over the canonical nine.
+  ;;
+  ;; `:variants-grid` auto-enumerates every variant of the parent story
+  ;; (new variants appear without touching the workspace); `:grid` pins
+  ;; the nine in canonical order for the README screenshot.
+  ;; -------------------------------------------------------------------------
+
+  (story/reg-workspace :Workspace.nine-states/all-states
+    {:doc      "Every canonical state, side by side in render order."
+     :layout   :grid
+     :variants [:story.nine-states/nothing
+                :story.nine-states/loading
+                :story.nine-states/empty
+                :story.nine-states/one
+                :story.nine-states/some
+                :story.nine-states/too-many
+                :story.nine-states/incorrect
+                :story.nine-states/correct
+                :story.nine-states/done]
+     :columns  3
+     :tags     #{:docs}})
+
+  (story/reg-workspace :Workspace.nine-states/auto-grid
+    {:doc     "Auto-enumerated grid — pulls every variant off
+              :story.nine-states. New variants appear here without
+              touching this workspace."
+     :layout  :variants-grid
+     :for     :story.nine-states
+     :columns 3
+     :tags    #{:docs}})
+
+  (story/reg-workspace :Workspace.nine-states/lifecycle
+    {:doc      "The RemoteData fetch lifecycle as a left-to-right
+              stepped row: loading → loaded → error."
+     :layout   :grid
+     :variants [:story.nine-states-lifecycle/loading
+                :story.nine-states-lifecycle/loaded
+                :story.nine-states-lifecycle/error]
+     :columns  3
+     :tags     #{:docs}}))
+
+;; Fire the registrations once at namespace load.
+(register-all!)

--- a/examples/reagent/nine_states/stories.index.html
+++ b/examples/reagent/nine_states/stories.index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>re-frame2 example: nine states (with Stories + Xray)</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<body>
+  <div id="app"></div>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/examples/reagent/nine_states/stories_host.cljs
+++ b/examples/reagent/nine_states/stories_host.cljs
@@ -1,0 +1,134 @@
+(ns nine-states.stories-host
+  "Showcase entry point for the Nine States example — the host that
+   wires the live app, the Story shell, and Xray into one page.
+
+   URL-hash-routed between two surfaces (mirrors
+   `counter-with-stories.core`):
+
+   - `#/`        → the live Nine States app (the example's `root-view`
+                   plus its control panel + form).
+   - `#/stories` → the Story shell mounted via
+                   `re-frame.story/mount-shell!`. The nine canonical
+                   state variants + the lifecycle variants + three
+                   workspaces show up in the sidebar; each variant
+                   renders in its own isolated frame.
+
+   ## Xray
+
+   The build wires Xray via shadow-cljs's `:devtools {:preloads
+   [day8.re-frame2-xray.preload]}` (see the `:examples/nine-states-
+   with-stories` build in `implementation/shadow-cljs.edn`). Loading
+   the preload attaches the Ctrl+Shift+C keybinding and the trace /
+   epoch collectors. We DISABLE auto-open here (`:rf.xray/auto-open?
+   false`) so the page lands on the live app or the Story shell first;
+   the reader presses Ctrl+Shift+C to open Xray over either surface and
+   drive a state to watch the `:nine-states.story/load` →
+   `:rf.http/managed` → reply cascade light up the Epoch / Trace / Side
+   Effects panels.
+
+   ## One adapter
+
+   The host installs the FULL Reagent adapter (`re-frame.adapter.
+   reagent`) — the substrate the Story shell itself renders on. The
+   example's own `core.cljs` uses `reagent-slim` for its standalone
+   `:examples/nine-states` build; this showcase host is a separate
+   entry point and runs everything (live app + shell + variant
+   canvases) on one adapter. `nine-states.core/root-view` is a
+   substrate-agnostic `reg-view`, so it renders identically under
+   either.
+
+   ## Elision
+
+   Compiled under `:advanced` with `:closure-defines
+   {re-frame.story.config/enabled? false}`, every `reg-*` in
+   `nine-states.stories` elides to nil and `mount-shell!`
+   short-circuits — the Story body carries no code into a production
+   bundle. The bundle-isolation gate verifies the Story / Xray
+   sentinel sets stay out of the plain `:examples/nine-states` build."
+  (:require [reagent.dom.client :as rdc]
+            [re-frame.core  :as rf]
+            [re-frame.story :as story]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [day8.re-frame2-xray.config :as xray-config]
+            ;; Source the example's registrations (machine / schemas /
+            ;; demo events / subs / the `:ui/render` selector / views)
+            ;; and the Story artefacts. Requiring `nine-states.stories`
+            ;; transitively requires `nine-states.core`.
+            [nine-states.core :as core]
+            [nine-states.stories])
+  (:require-macros [re-frame.core :refer [reg-view]]))
+
+;; -- The live-app frame ----------------------------------------------------
+;;
+;; The live `#/` surface needs the example's demo HTTP override on its
+;; frame so `:rf.http/managed` routes to the in-process
+;; `:nine-states.http/managed-demo` stub (no backend). This mirrors what
+;; `nine-states.core/run` installs on `:rf/default`; we register it here
+;; so the host owns the full boot (the host does not call
+;; `core/run`, which hardcodes its own reagent-slim mount lifecycle).
+
+(defn- install-live-frame! []
+  (rf/reg-frame :rf/default
+    {:doc          "Nine-states showcase live-app frame."
+     :fx-overrides {:rf.http/managed :nine-states.http/managed-demo}})
+  (rf/dispatch-sync [:nine-states.app/initialise]))
+
+(reg-view nine-states-app []
+  [:div {:style {:padding "1.5em" :font-family "system-ui, sans-serif"}}
+   [:p {:style {:font-size "13px" :color "#666" :margin "0 0 1em 0"}}
+    "Open "
+    [:a {:href "#/stories"} "#/stories"]
+    " for the Story playground — every one of the nine UI states as a "
+    "variant. Press "
+    [:kbd "Ctrl+Shift+C"]
+    " on either surface to open Xray and inspect the fetch cascade."]
+   [core/root-view]])
+
+;; -- Routing between the live app and the Story shell ----------------------
+;;
+;; The live app and the Story shell each own a React root on the same
+;; `#app` node, one at a time. The live app's root lives in `app-root`;
+;; the Story shell allocates and owns its own root inside `mount-shell!`.
+;; We tear one down before mounting the other (mirrors
+;; counter-with-stories.core).
+
+(defonce ^:private app-root (atom nil))
+
+(defn- ensure-app-root! []
+  (when (nil? @app-root)
+    (reset! app-root (rdc/create-root (js/document.getElementById "app")))))
+
+(defn- tear-down-app-root! []
+  (when-let [r @app-root]
+    (try (rdc/unmount r) (catch :default _ nil))
+    (reset! app-root nil)))
+
+(defn- mount-app! []
+  (story/unmount-shell!)
+  (ensure-app-root!)
+  (rdc/render @app-root [nine-states-app]))
+
+(defn- mount-stories! []
+  (tear-down-app-root!)
+  (story/mount-shell! (js/document.getElementById "app")))
+
+(defn- on-hash-change! []
+  (let [hash (or (.. js/window -location -hash) "")]
+    (if (re-find #"^#/stories" hash)
+      (mount-stories!)
+      (mount-app!))))
+
+(defn ^:export run []
+  ;; Keep Xray's collectors + keybinding installed but do not auto-open
+  ;; the panel — the page lands on the live app / shell first; the
+  ;; reader opens Xray with Ctrl+Shift+C.
+  (xray-config/configure! {:rf.xray/auto-open? false})
+  (rf/init! reagent-adapter/adapter)
+  ;; No explicit `(story/install-canonical-vocabulary!)` — the first
+  ;; `reg-*` in `nine-states.stories` (loaded via the require above)
+  ;; auto-installs the canonical Story vocabulary (rf2-p1ydc).
+  (install-live-frame!)
+  ;; Wire hash-change so reloading `#/stories` lands on the shell
+  ;; without a manual click-through.
+  (.addEventListener js/window "hashchange" on-hash-change!)
+  (on-hash-change!))

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -920,6 +920,31 @@
                        #shadow/env ["RF2_TESTBED_PROJECT_ROOT" ""]}}
    :modules          {:main {:init-fn counter-with-stories.core/run}}}
 
+  ;; Nine States Story + Xray showcase (rf2-rgyia). The
+  ;; examples/reagent/nine_states example wired up as a Story showcase:
+  ;; `nine-states.stories` registers one variant per canonical UI state
+  ;; (Nothing / Loading / Empty / One / Some / Too Many / Incorrect /
+  ;; Correct / Done) plus the RemoteData fetch-lifecycle variants
+  ;; (loading / loaded / error). Hash-routed via
+  ;; `nine-states.stories-host/run`: `#/` renders the live app; `#/stories`
+  ;; mounts the Story shell. The Xray preload is wired so a reader can
+  ;; press Ctrl+Shift+C and watch the `:nine-states.story/load` →
+  ;; `:rf.http/managed` → reply cascade light up Xray's Epoch / Trace /
+  ;; Side Effects panels.
+  ;;
+  ;; The `nine-states.*` namespaces resolve via the `../examples/reagent`
+  ;; source-path (already on :source-paths near the top of this file); the
+  ;; example does NOT use `re-frame.testbed.config`, so this build omits
+  ;; the open-in-editor repo-root closure-define the counter-with-stories
+  ;; / login-form testbed builds carry (those live under
+  ;; tools/story/testbeds and need it).
+  :examples/nine-states-with-stories
+  {:target     :browser
+   :output-dir "out/examples/nine-states-with-stories"
+   :asset-path "."
+   :modules    {:main {:init-fn nine-states.stories-host/run}}
+   :devtools   {:preloads [day8.re-frame2-xray.preload]}}
+
   ;; (removed rf2-9jfo1.2) :examples/xray-rhs-smoke build target —
   ;; the original Playwright `spec.cjs` was deleted by rf2-piucm in
   ;; favour of the CLJS e2e at


### PR DESCRIPTION
Builds `examples/reagent/nine_states` into a Story + Xray **showcase** (rf2-rgyia, decided via rf2-4qlb8). The nine canonical UI states the example already models become a natural Story variant set; the async fetch cascade is made Xray-rich.

## What's added

- **`examples/reagent/nine_states/stories.cljs`** — one `reg-variant` per canonical render-model keyword the root view `case`s over. Each variant reaches its state through REAL events into the `:ui/nine-states` parallel machine (fidelity `:event` throughout — no `:db-seed` / `:sub-overrides` needed, since every state has an event path). A Story-side `:nine-states.story/load` event drives the full `:rf.http/managed` fetch cascade (carrying the synthetic todos on the request's `:value` slot so the `:preset :story` frame's canned-success stub returns them), so the Epoch / Trace / **Side Effects** panels carry the genuine RemoteData lifecycle.
- **`examples/reagent/nine_states/stories_host.cljs`** — hash-routed showcase host (mirrors `counter-with-stories.core`): `#/` renders the live app, `#/stories` mounts the Story shell via `re-frame.story/mount-shell!`. Full Reagent adapter; Xray collectors + `Ctrl+Shift+C` keybinding installed with auto-open disabled so the reader opens Xray over either surface and drives a state to watch the cascade.
- **`examples/reagent/nine_states/stories.index.html`** — minimal self-contained host page.
- **`implementation/shadow-cljs.edn`** — the new build-id (see hot-zone call-out below).

## shadow-cljs.edn (hot-zone): added `:examples/nine-states-with-stories` build-id

Added one new `:browser` build target adjacent to `:examples/counter-with-stories`, following that precedent: `:init-fn nine-states.stories-host/run`, its own `:output-dir out/examples/nine-states-with-stories`, and `:devtools {:preloads [day8.re-frame2-xray.preload]}` (mirroring the login-form build's Xray wiring). The build OMITS the `re-frame.testbed.config/repo-root` closure-define the counter-with-stories / login-form testbed builds carry, because those live under `tools/story/testbeds` and use `re-frame.testbed.config`; this example resolves via the existing `../examples/reagent` source-path and does not. Diff is +25 lines, no other entries touched.

(Heads-up for **rf2-p8v0q** (login showcase), sequenced behind this on the same hot-zone file.)

## The nine canonical variants (for coordination with the rf2-rnqz0 tutorial)

Story `:story.nine-states`:
- `:story.nine-states/nothing` — State 1, Nothing
- `:story.nine-states/loading` — State 2, Loading
- `:story.nine-states/empty` — State 3, Empty
- `:story.nine-states/one` — State 4, One
- `:story.nine-states/some` — State 5, Some (canonical screenshot)
- `:story.nine-states/too-many` — State 6, Too Many
- `:story.nine-states/incorrect` — State 7, Incorrect
- `:story.nine-states/correct` — State 8, Correct
- `:story.nine-states/done` — State 9, Done

Plus a separate lifecycle story `:story.nine-states-lifecycle` carrying the async cascade arms (kept off the canonical nine so that set stays 1:1 with the render keywords): `.../loading`, `.../loaded`, `.../error` (the tenth `:error` render arm). Three workspaces: `:Workspace.nine-states/all-states` (`:grid`, 9 in render order), `:Workspace.nine-states/auto-grid` (`:variants-grid`), `:Workspace.nine-states/lifecycle` (`:grid`).

## Quality gates

- **Compile (new build)**: `npx shadow-cljs compile examples/nine-states-with-stories` → Build completed, 590 files, **0 warnings**.
- **Compile (plain example intact)**: `npx shadow-cljs release examples/nine-states` → Build completed, **0 warnings** (Story/Xray never reach the plain build).
- **`npm run test:cljs`**: Ran **5071 tests / 17075 assertions, 0 failures, 0 errors** — existing nine_states headless test + classpath intact.
- **`npm run test:bundle-isolation`**: PASS — 35 internal sentinels absent, 3 allow-list budgets ok; showcase did not leak tools into the production example bundles.
- **`npm run test:examples`**: 3 adapter smokes (Reagent / UIx / Helix) ran, **0 failures, 0 skipped**. (Trailing `http-server exited unexpectedly` is the post-run static-server teardown, not a test failure — the gate note's expected port-teardown artifact.)
- **clj-kondo** on `stories.cljs` + `stories_host.cljs`: **0 errors, 0 warnings**.

## Constraints honoured

- Examples test-free lock (rf2-8cevm): NO `*.spec.cjs` added under `examples/`. Stories are showcase artifacts, not tests.
- Edit scope limited to `examples/reagent/nine_states/` + the one `shadow-cljs.edn` build-id. No edits to `tools/`, core/impl, or `spec/`.
- Reuses the shipped Story (`reg-story` / `reg-variant` / `reg-workspace` / `mount-shell!`) + Xray (preload) APIs; no shell/host machinery forked.