### PR TITLE
feat(xray/epoch): exceptions render under their step + new INTERCEPTOR step + skipped-as-skipped (rf2-yz57h)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1307,10 +1307,11 @@ is rendered iff its driving trace events surfaced in this epoch:
 | Step | Driving trace | Conditional |
 |------|---------------|-------------|
 | **DISPATCH** | `:rf.event/dispatched` | always (every epoch starts here) |
-| **COEFFECT** | `:rf.cofx/run` (or `:rf.event/run-end` `:rf.event/coeffects` fallback) | **one COEFFECT step per user-injected coeffect** (rf2-s1jw4 · Mike pair-debug 2026-05-26, commit `ee9def224`). SYSTEM defaults `:db / :event / :frame / :source / :trace-id` are filtered at projection time (rf2-cq0ch). A cascade with 3 user cofx injections renders 3 numbered COEFFECT entries, not 1 entry containing 3 rows. |
-| **HANDLER** | every epoch settles through a handler | always |
+| **COEFFECT** | `:rf.cofx/run` (or `:rf.event/run-end` `:rf.event/coeffects` fallback) | **one COEFFECT step per user-injected coeffect** (rf2-s1jw4 · Mike pair-debug 2026-05-26, commit `ee9def224`). SYSTEM defaults `:db / :event / :frame / :source / :trace-id` are filtered at projection time (rf2-cq0ch). A cascade with 3 user cofx injections renders 3 numbered COEFFECT entries, not 1 entry containing 3 rows. A coeffect that THREW on injection (`:rf.error/coeffect-exception`) but produced no `:rf.cofx/run` gets a synthesised placeholder COEFFECT step (rf2-yz57h) so the exception card has a home. |
+| **INTERCEPTOR** | `:rf.error/interceptor-exception` (rf2-mszrz) | **only when a user interceptor threw** (rf2-yz57h). The substrate emits no per-interceptor "ran" trace (the chain runs as one unit), so a clean chain leaves nothing to show — the step is exception-only. One row per throwing interceptor: id + `:before`/`:after` phase chip + the shared exception card. Sits between COEFFECTS and HANDLER (the chain's cascade position). |
+| **HANDLER** | every epoch settles through a handler | always (but rendered as **SKIPPED** — rf2-yz57h — when an upstream `:before`-chain throw aborted the cascade before the handler ran) |
 | **FLOW** | `:rf.flow/recomputed` | only when flows fired |
-| **FX** | `:rf.fx/handled` / `:rf.fx/override-applied` / `:rf.fx/skipped-on-platform` | only when fx-handlers fired |
+| **FX** | `:rf.fx/handled` / `:rf.fx/override-applied` / `:rf.fx/skipped-on-platform` | only when fx-handlers fired (rendered as **SKIPPED** when an upstream `:before`-chain throw aborted the cascade) |
 | **SUBSCRIPTIONS** | `:rf.sub/run` / `:rf.sub/skip` | only when subs recomputed |
 | **VIEWS** | `:rf.view/render` | only when views re-rendered |
 
@@ -1320,7 +1321,7 @@ empty-state line. This matches the §2.2 dynamic-numbering contract
 from the Event lens — both panels share the same "absence is
 silence" rhythm.
 
-### §9.1.4 Badge taxonomy (the 8-badge inventory)
+### §9.1.4 Badge taxonomy (the 9-badge inventory)
 
 Each step renders a uppercase badge pill at its numbered circle:
 
@@ -1328,6 +1329,7 @@ Each step renders a uppercase badge pill at its numbered circle:
 |-------|-------|------------|
 | `:DISPATCH`           | `:text-tertiary` | muted grey |
 | `:COEFFECT`           | `:magenta`       | purple |
+| `:INTERCEPTOR`        | `:accent`        | blue (rf2-yz57h — the chain WRAPS the handler; one identity family) |
 | `:HANDLER`            | `:accent`        | blue (single Xray accent) |
 | `:FLOW`               | `:accent`        | blue (paired with HANDLER) |
 | `:SIDE-EFFECTS`       | `:orange`        | functional amber (post-commit irreversible; the pre-rf2-kt6js `:FX` step) |
@@ -1343,7 +1345,8 @@ Each step renders a uppercase badge pill at its numbered circle:
 > in commit `ee9def224`) is redundant with the HANDLER step's `:db`
 > sub-section (§9.1.5.1, FULL+DIFF single rendering post-rf2-vv3m6),
 > which surfaces the same data in-context. The projection's `badge-
-> set` enforces the 8-entry inventory.
+> set` enforces the inventory (9 entries with rf2-yz57h's
+> conditional `:INTERCEPTOR`).
 
 The inventory is LOCKED — the projection's `badge-set` enforces
 that every emitted step's `:badge` is a member, and the view's
@@ -2352,11 +2355,23 @@ primitive, not a one-off.**
 to its owning step via `attach-exceptions` (a sibling of
 `attach-violations`, run immediately after it). Each touched step
 gains the attached record under `:errors` (step-level) or its
-matching row's `:errors` (FX row-level) AND `:status :error`.
+matching row's `:errors` (FX / interceptor row-level) AND
+`:status :error`.
+
+**Per-step placement (rf2-yz57h + framework attribution rf2-mszrz).**
+rf2-mszrz split the pre-mszrz blanket `:rf.error/handler-exception`
+(which the router used to emit for EVERY interceptor-chain throw —
+handler, user interceptor, coeffect injector alike) into THREE
+component-attributed ops via `classify-pipeline-exception`. rf2-yz57h
+places each exception **under the step where it actually occurred**
+rather than collapsing them all onto HANDLER (the pre-rf2-yz57h
+mis-render):
 
 | Trace op | Owning step | Granularity |
 |----------|-------------|-------------|
-| `:rf.error/handler-exception` | HANDLER | step-level (handler / interceptor / coeffect throw — the chain is the unit that threw) |
+| `:rf.error/coeffect-exception` | COEFFECT, the step whose `:id` = `:failing-id` (cofx id) | step-level; falls back to the first COEFFECT step. When the throwing cofx produced no `:rf.cofx/run` (it threw on injection), `project` synthesises a placeholder COEFFECT step (`:no-value? true`) so the card has a home |
+| `:rf.error/interceptor-exception` | INTERCEPTOR (NEW) | step-level; the row matching `:failing-id` to `:interceptor-id` carries the card |
+| `:rf.error/handler-exception` | HANDLER | step-level (only the event handler itself now) |
 | `:rf.error/fx-handler-exception` | SIDE EFFECTS, row whose `:fx-id` = `:failing-id` | row-level (fallback step-level) |
 | `:rf.error/no-such-fx` | SIDE EFFECTS | step-level (fallback) |
 | `:rf.error/flow-eval-exception` | FLOW | step-level (fallback HANDLER when no FLOW step) |
@@ -2370,6 +2385,43 @@ failing handler's SOURCE-COORD rides the hoisted top-level
 Issues panel's `short-description` / `source-coord` read — the bead's
 original probe checked `:message` / `:source` / `:error-id`, which
 the substrate does not stamp (the empty-tags symptom).
+
+**INTERCEPTOR step (NEW, rf2-yz57h).** The pipeline had no distinct
+interceptor step before rf2-yz57h — interceptors WRAP the handler chain
+rather than appearing as their own cascade entry, so a user-interceptor
+`:before` / `:after` throw had no home. The INTERCEPTOR step
+(`projection/interceptor-step` → `view/render-interceptor-step`) sits
+between COEFFECTS and HANDLER (the cascade position of the chain:
+`:before` runs after coeffects, before the handler). It is
+**CONDITIONAL** — the substrate emits no per-interceptor "ran" trace
+(the chain runs as one unit; only a throw surfaces a trace), so the
+step renders ONLY when an interceptor threw this cascade. Each row is a
+throwing interceptor: the interceptor `:id` (click-to-source via
+`handler-meta`, degrading to plain text since interceptors are plain
+`->interceptor` records and carry no registered coord) + a `:before` /
+`:after` phase chip + the shared "Exception Thrown" card. Badge:
+`:INTERCEPTOR` pulls the `:accent` token (the chain WRAPS the handler;
+they read as one identity family). A `:before` throw skips the handler;
+an `:after` throw runs the handler first, then throws on the way out.
+
+**SKIPPED steps (rf2-yz57h).** When an UPSTREAM `:before`-chain throw
+aborts the cascade — a coeffect injector (`:rf.error/coeffect-exception`)
+or a user interceptor `:before` (`:rf.error/interceptor-exception` +
+`:phase :before`) — the event HANDLER never runs. Pre-rf2-yz57h the
+HANDLER step still rendered its body and the `:db` sub-section read
+"— no :db (handler returned no :db)" — WRONG: the handler's body returns
+a `:db` (e.g. via `bump`), it simply never executed (verified bug,
+buttons 17 / coeffect throw). `projection/mark-skipped-handler` now
+stamps the HANDLER + SIDE EFFECTS steps `:status :skipped` (the
+`handler-skipped-by-upstream?` discriminator). The view renders a SKIPPED
+placeholder body ("The handler did not run — an upstream step threw
+before this step could execute.") instead of the normal body. An
+interceptor `:after` throw is NOT a skip — the handler ran first; the
+throw fired on the way out. `step-status` gains a third value `:skipped`
+(distinct from `:ok` / `:error`); the header glyph is a muted `⊘`
+(`badge/step-status-glyph :skipped`, `:text-tertiary` tone) — a skip is
+NEUTRAL, not a failure, so it does NOT inflate the epoch outcome (the
+failing COEFFECT / INTERCEPTOR step is the load-bearing `:error` signal).
 
 **Inline error card (rf2-ahhgn · refined rf2-wnvid).** `view/error-block`
 renders a red-edged card (sibling to the amber schema-violation card;
@@ -2385,16 +2437,16 @@ carrying:
    keying the chip off recovery alone painted a **spurious** "Rolled
    back" on button-15 — the handler threw before producing any `:db`,
    so nothing committed and nothing reverted (rf2-wnvid fix);
-2. a one-line human headline derived from the OP, **not** the
-   interceptor `:phase` ("The event handler threw." / "The :http/post
-   effect threw." / "A flow's computation threw."). The substrate
-   routes a handler / interceptor / injected-coeffect throw ALL through
-   `:rf.error/handler-exception` with `:reason "Event handler threw."`
-   and `:phase :before` (the handler is the terminal `:before`
-   interceptor), so the pre-rf2-wnvid `:phase`-keyed wording mislabelled
-   a plain handler throw as "An interceptor / coeffect threw (:before)."
-   — the headline now reads off the op and matches the substrate's own
-   `:reason` (rf2-wnvid fix);
+2. a one-line human headline derived from the OP (`error-block-label`),
+   naming the TRUE failing component (rf2-mszrz attribution): "The
+   :button-deck/throwing-cofx coeffect threw during injection." / "The
+   :app/auth interceptor threw on the way in (:before)." / "The event
+   handler threw." / "The :http/post effect threw." / "A flow's
+   computation threw." Pre-mszrz the router routed handler / interceptor /
+   coeffect throws ALL through `:rf.error/handler-exception`, so the
+   headline could only ever read "The event handler threw."; with the
+   rf2-mszrz split the headline reads off the component-attributed op and
+   `:phase`;
 3. the verbatim `ex-info` message (monospace); and
 4. a **collapsible** `<details>` disclosure ("Details", collapsed by
    default) carrying the exception's `ex-data` (via `ei/edn-inspector`)
@@ -2404,10 +2456,12 @@ carrying:
 The pre-rf2-wnvid always-expanded **jump-to-source link is DROPPED**:
 it duplicated the HANDLER step's verb link (the canonical
 jump-to-source) and, on a handler throw where the trace carried no
-coord, degraded to a useless "source unavailable" (rf2-wnvid). HANDLER /
-FLOW inject `(error-blocks step-key errors)` under their body; the SIDE
-EFFECTS step injects per-row cards via `fx-row-with-violations` plus a
-step-level `(error-blocks :side-effects errors)` for unmatched fx ids.
+coord, degraded to a useless "source unavailable" (rf2-wnvid). COEFFECT /
+INTERCEPTOR / HANDLER / FLOW inject `(error-blocks step-key errors)` under
+their body (rf2-yz57h routes coeffect / interceptor throws to their own
+steps); the SIDE EFFECTS step injects per-row cards via
+`fx-row-with-violations` plus a step-level
+`(error-blocks :side-effects errors)` for unmatched fx ids.
 
 **HANDLER `:db` — no phantom `:db` (rf2-wnvid).** The HANDLER step's
 `:db` sub-section (`view/handler-db-diff-block`) renders a

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/badge.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/badge.cljc
@@ -85,9 +85,13 @@
   rf2-yx1ae — CHILD-DISPATCHES pulls `:text-tertiary` (the same muted
   grey as DISPATCH — same hue family, same cascade-link semantics).
   rf2-rrykz — APP-DB-DIFF pulls `:accent` (the same blue as HANDLER /
-  FLOW — same state-mutation lens semantics)."
+  FLOW — same state-mutation lens semantics).
+  rf2-yz57h — INTERCEPTOR pulls `:accent` (the same blue as HANDLER —
+  the interceptor chain WRAPS the handler; they read as one identity
+  family in the cascade, the chain around the handler body)."
   {:DISPATCH          :text-tertiary
    :COEFFECT          :magenta
+   :INTERCEPTOR       :accent
    :HANDLER           :accent
    :FLOW              :accent
    :SIDE-EFFECTS      :orange
@@ -102,6 +106,7 @@
   pill. Pure data."
   {:DISPATCH          "DISPATCH"
    :COEFFECT          "COEFFECT"
+   :INTERCEPTOR       "INTERCEPTOR"
    :HANDLER           "HANDLER"
    :FLOW              "FLOW"
    :SIDE-EFFECTS      "SIDE EFFECTS"
@@ -364,9 +369,14 @@
 ;; ✗ red); a step with no failure reads `:ok` and paints the quiet ✓.
 
 (def step-status-set
-  "Closed set of per-step statuses (rf2-ahhgn). Tests + the view's
-  glyph-resolver bail-out read this set."
-  #{:ok :error})
+  "Closed set of per-step statuses (rf2-ahhgn · rf2-yz57h). Tests + the
+  view's glyph-resolver bail-out read this set.
+
+  rf2-yz57h adds `:skipped` — a step that never RAN because an upstream
+  `:before`-chain throw aborted the cascade (the handler is skipped when a
+  coeffect injector or a `:before` interceptor throws). Distinct from `:ok`
+  (the step ran cleanly) and `:error` (the step ran + failed)."
+  #{:ok :error :skipped})
 
 (defn step-status?
   "Predicate — `status` keyword is a member of `step-status-set`."
@@ -374,14 +384,18 @@
   (contains? step-status-set status))
 
 (defn step-status-token-key
-  "Theme-token keyword for a per-step status glyph colour (rf2-ahhgn):
-    :ok    → :success  (✓ green)
-    :error → :error    (✗ red)
+  "Theme-token keyword for a per-step status glyph colour (rf2-ahhgn ·
+  rf2-yz57h):
+    :ok      → :success         (✓ green)
+    :error   → :error           (✗ red)
+    :skipped → :text-tertiary   (⊘ muted — neutral; the step didn't run,
+                                  it is NOT a failure)
   Falls back to `:success` for unknown statuses so a never-failed step
   paints the quiet success tick."
   [status]
   (case status
-    :error :error
+    :error   :error
+    :skipped :text-tertiary
     :success))
 
 (defn step-status-colour
@@ -391,13 +405,15 @@
        (get tokens/tokens :success)))
 
 (defn step-status-glyph
-  "Single-char glyph for a per-step status (rf2-ahhgn):
-    :ok    → \"✓\"
-    :error → \"✗\"
+  "Single-char glyph for a per-step status (rf2-ahhgn · rf2-yz57h):
+    :ok      → \"✓\"
+    :error   → \"✗\"
+    :skipped → \"⊘\"  (circled-slash — 'did not run', muted/neutral)
   Defaults to the success tick for unknown statuses."
   [status]
   (case status
-    :error "✗"
+    :error   "✗"
+    :skipped "⊘"
     "✓"))
 
 ;; ---- Flat SIDE EFFECTS ledger row glyphs (rf2-j630b) --------------------

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -1894,16 +1894,32 @@
 
 (def cascade-exception-ops
   "Closed set of cascade-level `:rf.error/*` trace ops the Epoch panel
-  surfaces as INLINE per-step exceptions (rf2-ahhgn). Schema-validation
+  surfaces as INLINE per-step exceptions (rf2-ahhgn · per-component
+  attribution rf2-mszrz / placement rf2-yz57h). Schema-validation
   failures are NOT here — they ride the distinct `schema-violation-rows`
   + `attach-violations` path (they carry `:explain` + `:where` + recovery
   chrome, not an exception message). New exception ops extend this set
   AND the `exception-op->step` table in lockstep.
 
-  - `:rf.error/handler-exception` — a handler / interceptor `:before` or
-    `:after` / injected-coeffect threw; the chain captured it into
-    `:rf/interceptor-error` and the router emitted this op (the `:db`/`:fx`
-    did NOT apply — db rolled back). Owns the HANDLER step.
+  rf2-mszrz split the pre-existing blanket `:rf.error/handler-exception`
+  (which the pre-mszrz router emitted for EVERY interceptor-chain throw —
+  handler, user interceptor, coeffect injector alike) into THREE
+  component-attributed ops. The Epoch panel now places each under the
+  step where it actually occurred (rf2-yz57h) instead of collapsing them
+  all onto HANDLER:
+
+  - `:rf.error/coeffect-exception` (rf2-mszrz) — a coeffect injector threw
+    during `:before`-chain coeffect injection. `:failing-id` = the cofx id.
+    Owns the COEFFECT step (the matching cofx's step; falls back to any
+    COEFFECT step / step-level). The handler never ran.
+  - `:rf.error/interceptor-exception` (rf2-mszrz) — a USER interceptor threw
+    in its `:before` or `:after` phase (`:phase` discriminates). `:failing-id`
+    = the interceptor `:id`. Owns the INTERCEPTOR step (NEW, rf2-yz57h). A
+    `:before` throw skips the handler; an `:after` throw runs the handler
+    first, then throws on the way out.
+  - `:rf.error/handler-exception` — the event HANDLER itself threw. The chain
+    captured it into `:rf/interceptor-error` and the router emitted this op
+    (the `:db`/`:fx` did NOT apply — db rolled back). Owns the HANDLER step.
   - `:rf.error/fx-handler-exception` — a registered fx-handler threw during
     the post-commit fx walk. Owns the SIDE EFFECTS step (best-effort
     per-row match on `:rf.fx/id`; falls back to step-level).
@@ -1912,19 +1928,27 @@
   - `:rf.error/flow-eval-exception` — a flow's compute fn threw (pre-commit
     abort). Owns the FLOW step (step-level; the throwing flow aborted the
     cascade)."
-  #{:rf.error/handler-exception
+  #{:rf.error/coeffect-exception
+    :rf.error/interceptor-exception
+    :rf.error/handler-exception
     :rf.error/fx-handler-exception
     :rf.error/no-such-fx
     :rf.error/flow-eval-exception})
 
 (def ^:private exception-op->step
   "Map a cascade-exception trace op → the `:step` keyword of the pipeline
-  step it attaches to (rf2-ahhgn). The router emits a handler / interceptor
-  / coeffect throw all as `:rf.error/handler-exception` (the interceptor
-  chain is the unit that threw), so all three attach to HANDLER — correct
-  for the headline button-15 (handler) + button-16 (interceptor) cases and
-  acceptable for button-17 (the coeffect throw aborts the handler chain)."
-  {:rf.error/handler-exception    :handler
+  step it attaches to (rf2-ahhgn · rf2-mszrz · rf2-yz57h). Each
+  component-attributed op (rf2-mszrz) lands under the step where it
+  actually occurred (rf2-yz57h) rather than all collapsing onto HANDLER:
+
+    - coeffect injector throw → COEFFECT step
+    - user-interceptor :before/:after throw → INTERCEPTOR step (NEW)
+    - event handler throw → HANDLER step
+    - fx-handler throw / no-such-fx → SIDE EFFECTS step
+    - flow compute throw → FLOW step"
+  {:rf.error/coeffect-exception   :coeffect
+   :rf.error/interceptor-exception :interceptor
+   :rf.error/handler-exception    :handler
    :rf.error/fx-handler-exception :side-effects
    :rf.error/no-such-fx           :side-effects
    :rf.error/flow-eval-exception  :flow})
@@ -1998,6 +2022,102 @@
           :when (contains? cascade-exception-ops (op ev))]
       (exception-row ev))))
 
+;; ---- INTERCEPTOR step (rf2-yz57h) ---------------------------------------
+;;
+;; The pipeline had no distinct interceptor step before rf2-yz57h —
+;; interceptors WRAP the handler chain rather than appearing as their own
+;; cascade entry, so a user-interceptor `:before` / `:after` throw
+;; (rf2-mszrz `:rf.error/interceptor-exception`) had no home and collapsed
+;; onto HANDLER.
+;;
+;; The substrate does NOT emit a per-interceptor "ran" trace (the chain
+;; runs as one unit; only a throw surfaces a trace), so the INTERCEPTOR
+;; step is CONDITIONAL: it renders ONLY when an interceptor exception fired
+;; this cascade, and its rows are the throwing interceptor(s) — each row
+;; carries the interceptor `:id` + the `:phase` (`:before` / `:after`) it
+;; threw in, so the operator reads WHICH interceptor failed on WHICH side
+;; of the chain. The view resolves a jump-to-source coord off
+;; `handler-meta` at render time (degrades to plain text when none is
+;; registered — interceptors are plain `->interceptor` records, not always
+;; coord-stamped). The shared "Exception Thrown" card (rf2-wnvid) attaches
+;; per the standard `attach-exceptions` path.
+
+(defn interceptor-exception-rows
+  "The `:rf.error/interceptor-exception` subset of `exception-rows`
+  (rf2-yz57h / rf2-mszrz) — one per user-interceptor throw, in trace
+  order. Empty vec when no interceptor threw."
+  [events]
+  (filterv #(= :rf.error/interceptor-exception (op (:raw %)))
+           (exception-rows events)))
+
+(defn interceptor-step
+  "Build the INTERCEPTOR step, or nil when no interceptor exception fired
+  this cascade (the step is OMITTED — conditional, rf2-yz57h). The step's
+  `:rows` are the throwing interceptors (one per
+  `:rf.error/interceptor-exception`), each carrying the interceptor
+  `:interceptor-id` (== the exception row's `:failing-id`) + the `:phase`
+  it threw in. The shared exception card attaches to this step via
+  `attach-exceptions`."
+  [events]
+  (let [exc (interceptor-exception-rows events)]
+    (when (seq exc)
+      {:step  :interceptor
+       :badge :INTERCEPTOR
+       :rows  (mapv (fn [{:keys [failing-id phase]}]
+                      {:interceptor-id failing-id
+                       :phase          phase})
+                    exc)})))
+
+;; ---- SKIPPED-step marking (rf2-yz57h) -----------------------------------
+;;
+;; When an EARLIER pipeline step throws on the way IN — a coeffect injector
+;; (`:rf.error/coeffect-exception`) or a user-interceptor `:before`
+;; (`:rf.error/interceptor-exception` with `:phase :before`) — the event
+;; HANDLER never runs. Pre-rf2-yz57h the HANDLER step still rendered its
+;; body and the `:db` sub-section read "— no :db (handler returned no :db)"
+;; — WRONG: the handler's body returns a `:db` via `bump`, it simply never
+;; executed (buttons 17 / coeffect throw). The fix marks the HANDLER step
+;; (and the SIDE EFFECTS step, which equally never ran) `:status :skipped`
+;; so the view renders it as SKIPPED rather than "ran, returned no :db".
+;;
+;; An interceptor `:after` throw is NOT a skip-the-handler case — the
+;; handler ran successfully and the throw fired on the way OUT — so it does
+;; NOT mark the handler skipped.
+
+(defn handler-skipped-by-upstream?
+  "True iff an UPSTREAM `:before`-chain throw skipped the event handler
+  this cascade (rf2-yz57h): a coeffect injector threw
+  (`:rf.error/coeffect-exception`), or a user interceptor threw in its
+  `:before` phase (`:rf.error/interceptor-exception` + `:phase :before`).
+  Both abort the chain on the way IN, so the handler body never executes.
+
+  An interceptor `:after` throw is excluded — the handler ran first; the
+  throw fired on the way out."
+  [events]
+  (boolean
+    (some (fn [ev]
+            (let [o (op ev)]
+              (or (= :rf.error/coeffect-exception o)
+                  (and (= :rf.error/interceptor-exception o)
+                       (= :before (common/tag-of ev :phase))))))
+          events)))
+
+(defn mark-skipped-handler
+  "When an upstream `:before`-chain throw skipped the handler
+  (`handler-skipped-by-upstream?`), stamp the HANDLER step + the SIDE
+  EFFECTS step (which equally never ran) with `:status :skipped`
+  (rf2-yz57h). The view reads `:skipped` to render the step as SKIPPED
+  rather than 'ran, returned no :db'. Pure fn over the step vector; a
+  cascade with no upstream skip returns `steps` unchanged."
+  [steps events]
+  (if (handler-skipped-by-upstream? events)
+    (mapv (fn [step]
+            (if (contains? #{:handler :side-effects} (:step step))
+              (assoc step :status :skipped)
+              step))
+          steps)
+    steps))
+
 (defn- attach-to-fx-error-row
   "Attach an fx exception row to the SIDE EFFECTS step's matching
   `:fx-id` row (rf2-ahhgn / rf2-kt6js). When `:failing-id` matches a
@@ -2015,25 +2135,56 @@
                       rows)))
       (update step :errors (fnil conj []) row))))
 
+(defn- coeffect-exception-target
+  "Index of the COEFFECT step a `:rf.error/coeffect-exception` row attaches
+  to (rf2-yz57h). Prefers the step whose `:id` == the row's `:failing-id`
+  (the cofx that threw); falls back to the FIRST COEFFECT step when the
+  throwing cofx produced no `:rf.cofx/run` step (it threw on injection, so
+  the granular cofx-run trace may be absent — `project` synthesises a
+  placeholder COEFFECT step in that case so there is always a home).
+  Returns nil when no COEFFECT step exists at all."
+  [steps failing-id]
+  (or (index-of #(and (= :coeffect (:step %)) (= failing-id (:id %))) steps)
+      (index-of #(= :coeffect (:step %)) steps)))
+
 (defn attach-exceptions
   "Take a projected step vector + a vec of `exception-row` records and
   return the step vector with each exception attached to its owning step
-  (rf2-ahhgn — per `exception-op->step`). Returns `steps` unchanged when
+  (rf2-ahhgn · rf2-mszrz component attribution · rf2-yz57h per-step
+  placement — per `exception-op->step`). Returns `steps` unchanged when
   `rows` is empty.
 
-  Attachment is step-level for HANDLER / FLOW (the exception aborted that
-  step's work) and row-level (matching `:fx-id`) for FX, falling back to
-  step-level when no row matches. Each touched step additionally gains
-  `:status :error` so the per-step ✓/✗ primitive paints the failure
-  glyph; the same `:status` slot is what rf2-kt6js's SIDE-EFFECTS sub-
-  steps will reuse."
+  Placement (rf2-yz57h — each under the step where it actually occurred):
+
+    - COEFFECT exception → the matching COEFFECT step (by `:failing-id` =
+      cofx `:id`; falls back to the first COEFFECT step), step-level.
+    - INTERCEPTOR exception → the INTERCEPTOR step, step-level.
+    - HANDLER / FLOW exception → that step, step-level (the exception
+      aborted the step's work).
+    - FX exception → the SIDE EFFECTS row whose `:fx-id` = `:failing-id`
+      (row-level), falling back to step-level when no row matches.
+
+  Each touched step additionally gains `:status :error` so the per-step
+  ✓/✗ primitive paints the failure glyph; the same `:status` slot is what
+  rf2-kt6js's SIDE-EFFECTS sub-steps reuse.
+
+  Catch-all: when the owning step is absent from the cascade (e.g. a
+  flow-eval throw with no FLOW step projected) the exception attaches to
+  the HANDLER step so the failure never disappears entirely. `project`
+  guarantees a COEFFECT placeholder + an INTERCEPTOR step exist whenever
+  the matching exception fired, so those two never hit the catch-all."
   [steps rows]
   (if (empty? rows)
     steps
     (reduce
       (fn [s row]
-        (let [target-step (get exception-op->step (:operation row))
-              i           (index-of #(= target-step (:step %)) s)]
+        (let [op-kw       (:operation row)
+              target-step (get exception-op->step op-kw)
+              i           (cond
+                            (= :coeffect target-step)
+                            (coeffect-exception-target s (:failing-id row))
+                            :else
+                            (index-of #(= target-step (:step %)) s))]
           (if i
             (update s i
                     (fn [step]
@@ -2057,25 +2208,42 @@
 ;; ---- per-step status + epoch outcome (rf2-ahhgn) ------------------------
 
 (defn step-status
-  "The pass/fail status of a projected step (rf2-ahhgn) — `:error` when
-  the step (or any of its rows) carries an attached exception or schema
-  violation, else `:ok`. The view paints a ✓ (`:ok`) / ✗ (`:error`)
-  glyph on every step header off this primitive; rf2-kt6js's SIDE-EFFECTS
-  sub-steps reuse the same shape for their per-effect ticks.
+  "The status of a projected step (rf2-ahhgn · rf2-yz57h) — one of:
 
-  Reads the step's own `:status` slot first (stamped by `attach-
-  exceptions`), then falls back to scanning the step-level + row-level
-  `:errors` / `:violations` vecs so a step that gained a violation via
-  `attach-violations` (which does not stamp `:status`) still reads
-  `:error`. Pure-data over an already-attached step."
+    `:error`   — the step (or any of its rows) carries an attached
+                 exception or schema violation.
+    `:skipped` — the step never RAN because an upstream `:before`-chain
+                 throw aborted the cascade (rf2-yz57h `mark-skipped-handler`
+                 stamps `:status :skipped` on the HANDLER + SIDE EFFECTS
+                 steps). Distinct from `:ok` — the step did NOT run, so it
+                 must NOT read as 'ran, returned no :db'.
+    `:ok`      — otherwise (the step ran cleanly).
+
+  The view paints a ✓ (`:ok`) / ✗ (`:error`) / ⊘ (`:skipped`) glyph on
+  every step header off this primitive; rf2-kt6js's SIDE-EFFECTS sub-steps
+  reuse the same shape for their per-effect ticks.
+
+  A failure (`:error`) takes precedence over a skip — a step that both was
+  marked skipped AND carries an attached error reads `:error` (the error is
+  the load-bearing signal). Reads the step's own `:status` slot (stamped by
+  `attach-exceptions` / `mark-skipped-handler`), then falls back to scanning
+  the step-level + row-level `:errors` / `:violations` vecs so a step that
+  gained a violation via `attach-violations` (which does not stamp
+  `:status`) still reads `:error`. Pure-data over an already-attached step."
   [step]
   (let [row-has? (fn [k] (some #(seq (get % k)) (:rows step)))]
-    (if (or (= :error (:status step))
-            (seq (:errors step))
-            (seq (:violations step))
-            (row-has? :errors)
-            (row-has? :violations))
+    (cond
+      (or (= :error (:status step))
+          (seq (:errors step))
+          (seq (:violations step))
+          (row-has? :errors)
+          (row-has? :violations))
       :error
+
+      (= :skipped (:status step))
+      :skipped
+
+      :else
       :ok)))
 
 (defn epoch-outcome
@@ -2383,6 +2551,32 @@
                                  (some? duration-ms)
                                  (assoc :duration-ms duration-ms)))
                              cofx-rows)
+            ;; rf2-yz57h — a coeffect that throws ON INJECTION
+            ;; (`:rf.error/coeffect-exception`) produces NO `:rf.cofx/run`
+            ;; trace (it threw before completing), so `cofx-steps` carries no
+            ;; step for it. Synthesise a placeholder COEFFECT step (no
+            ;; resolved value — it never produced one) keyed on the throwing
+            ;; cofx id so the shared exception card has a home UNDER the
+            ;; COEFFECT step rather than collapsing onto HANDLER. Skipped when
+            ;; an existing cofx-step already covers the failing id.
+            cofx-exc-ids (->> (exception-rows events)
+                              (filter #(= :rf.error/coeffect-exception
+                                          (op (:raw %))))
+                              (map :failing-id)
+                              (remove nil?)
+                              distinct)
+            cofx-step-ids (set (map :id cofx-steps))
+            cofx-placeholder-steps
+            (vec (for [id   cofx-exc-ids
+                       :when (not (contains? cofx-step-ids id))]
+                   {:step      :coeffect
+                    :badge     :COEFFECT
+                    :id        id
+                    :threw?    true
+                    ;; no `:value` — the injector threw before resolving one;
+                    ;; the view renders the failed-injection body, not a
+                    ;; `+ [id] <value>` line.
+                    :no-value? true}))
             ;; rf2-xnb1x — one FLOW step per flow that fired (mirror
             ;; of the cofx-steps splat above). The operator counts
             ;; flows by counting numbered circles in the cascade
@@ -2438,7 +2632,15 @@
                         (concat
                           [(dispatch-row events fallback)]
                           cofx-steps
-                          [(handler-row events event-id db-before db-after)]
+                          cofx-placeholder-steps
+                          ;; rf2-yz57h — the INTERCEPTOR step rides between
+                          ;; COEFFECTS and HANDLER (the cascade position of
+                          ;; the interceptor chain: `:before` runs after
+                          ;; coeffects, before the handler). Conditional —
+                          ;; nil (filtered out below) when no interceptor
+                          ;; threw this cascade.
+                          [(interceptor-step events)
+                           (handler-row events event-id db-before db-after)]
                           ;; APP-DB DIFF removed pair-debug 2026-05-26 —
                           ;; redundant with the HANDLER step's `:db`
                           ;; sub-section's [diff][all] toggle which
@@ -2458,13 +2660,19 @@
                            ]))
             present    (filterv some? base-steps)
             attached   (attach-violations present violations)
-            ;; rf2-ahhgn — attach cascade-level exceptions (handler /
-            ;; interceptor / coeffect / fx / flow throws) to their owning
-            ;; step AFTER schema violations so both inline-failure surfaces
-            ;; coexist; `attach-exceptions` additionally stamps `:status
-            ;; :error` on each touched step for the per-step ✓/✗ primitive.
+            ;; rf2-ahhgn · rf2-mszrz · rf2-yz57h — attach cascade-level
+            ;; exceptions (coeffect / interceptor / handler / fx / flow
+            ;; throws) to the step where each actually occurred AFTER schema
+            ;; violations so both inline-failure surfaces coexist;
+            ;; `attach-exceptions` additionally stamps `:status :error` on
+            ;; each touched step for the per-step ✓/✗ primitive.
             with-errs  (attach-exceptions attached exceptions)
-            steps      (mark-rolled-back-downstream with-errs violations)]
+            ;; rf2-yz57h — when an upstream `:before`-chain throw (coeffect /
+            ;; interceptor :before) skipped the handler, mark the HANDLER +
+            ;; SIDE EFFECTS steps `:status :skipped` so the view renders them
+            ;; as SKIPPED rather than 'ran, returned no :db'.
+            skipped    (mark-skipped-handler with-errs events)
+            steps      (mark-rolled-back-downstream skipped violations)]
         steps))))
 
 (defn number-steps
@@ -2762,10 +2970,14 @@
     standalone tail step (drift has no owning cascade step).
   - rf2-kt6js: FX → SIDE-EFFECTS (the single :fx step became the SIDE
     EFFECTS step with :db / :fx / other sub-steps).
+  - rf2-yz57h: + INTERCEPTOR (conditional — present only when a user
+    interceptor threw this cascade; the throwing interceptor's :before /
+    :after row carries the shared 'Exception Thrown' card).
 
   The view's badge resolver bails to `:text-tertiary` on an unknown
   badge, so adding to this set is purely additive."
-  #{:DISPATCH :COEFFECT :HANDLER :FLOW :SIDE-EFFECTS :SUBSCRIPTIONS :VIEWS
+  #{:DISPATCH :COEFFECT :INTERCEPTOR :HANDLER :FLOW :SIDE-EFFECTS
+    :SUBSCRIPTIONS :VIEWS
     :SCHEMA-HOT-RELOAD :CHILD-DISPATCHES :APP-DB-DIFF})
 
 (defn valid-badge?

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -1276,6 +1276,35 @@
 (def ^:private rolled-back-mute-style
   {:opacity 0.55})
 
+;; rf2-yz57h — SKIPPED-step body. When an upstream `:before`-chain throw
+;; (coeffect injector / `:before` interceptor) aborts the cascade, the
+;; HANDLER + SIDE EFFECTS steps never run. The view renders a SKIPPED
+;; placeholder body — a muted italic line stating the step did not run —
+;; instead of the normal body (whose `:db` sub-section would otherwise read
+;; the misleading "— no :db (handler returned no :db)" even though the
+;; handler's body DOES return a :db; it simply never executed). The header
+;; glyph is the muted ⊘ (`badge/step-status-glyph :skipped`).
+(def ^:private skipped-body-style
+  {:margin-top  "5px"
+   :padding     "6px 8px"
+   :background  bg-1-colour
+   :border      border-subtle-1px
+   :border-radius "3px"
+   :font-family sans-stack
+   :font-size   "12px"
+   :font-style  "italic"
+   :color       text-tertiary-colour})
+
+(defn- skipped-body
+  "Render a SKIPPED step's body (rf2-yz57h) — a muted italic line stating
+  the step did not run because an upstream step threw. `what` names the
+  step for the operator (e.g. \"The handler\" / \"Side effects\")."
+  [testid what]
+  [:div {:data-testid (str testid "-skipped")
+         :data-rf-xray-step-skipped "true"
+         :style skipped-body-style}
+   (str what " did not run — an upstream step threw before this step could execute.")])
+
 ;; `rolled-back-banner-style` + the `rolled-back-banner` render fn
 ;; were retired (rf2-w8evg) — the rf2-7gf7v / rf2-8resu redesign moves
 ;; the :app-db violation to the FX step's :db row (the implicit
@@ -1518,20 +1547,27 @@
 ;; which match this panel's prior shape exactly.
 
 (defn- step-status-glyph
-  "Render the per-step ✓/✗ pass-fail glyph (rf2-ahhgn). `status` is the
-  `:ok` / `:error` keyword from `projection/step-status`; the colour +
-  glyph resolve off the shared `badge/step-status-*` primitive (the
-  same one rf2-kt6js's SIDE-EFFECTS sub-steps reuse). `testid` keys the
+  "Render the per-step ✓/✗/⊘ status glyph (rf2-ahhgn · rf2-yz57h).
+  `status` is the `:ok` / `:error` / `:skipped` keyword from
+  `projection/step-status`; the colour + glyph resolve off the shared
+  `badge/step-status-*` primitive (the same one rf2-kt6js's SIDE-EFFECTS
+  sub-steps reuse). `:skipped` (rf2-yz57h) is the step that never RAN
+  because an upstream `:before`-chain throw aborted the cascade — a muted
+  ⊘ that reads as 'did not run', NOT a failure. `testid` keys the
   `-status` suffix + the `data-rf-xray-step-status` attribute tests +
   the issues-ribbon eye-scan read."
   [status testid]
-  [:span {:data-testid (str testid "-status")
-          :data-rf-xray-step-status (name (or status :ok))
-          :aria-label (if (= :error status) "step failed" "step ok")
-          :title (if (= :error status) "this step failed" "this step ran cleanly")
-          :style (assoc step-header-status-glyph-base-style
-                        :color (badge/step-status-colour status))}
-   (badge/step-status-glyph status)])
+  (let [[aria title] (case status
+                       :error   ["step failed"  "this step failed"]
+                       :skipped ["step skipped" "this step was skipped — an upstream step threw before it could run"]
+                       ["step ok" "this step ran cleanly"])]
+    [:span {:data-testid (str testid "-status")
+            :data-rf-xray-step-status (name (or status :ok))
+            :aria-label aria
+            :title title
+            :style (assoc step-header-status-glyph-base-style
+                          :color (badge/step-status-colour status))}
+     (badge/step-status-glyph status)]))
 
 (defn- step-header
   "Render a step's header row — badge pill + per-step ✓/✗ status glyph
@@ -1960,7 +1996,7 @@
   injecting N user-defined cofx; system-injected cofx (e.g.
   framework-auto `:db`, `:event`) are filtered at projection time
   (rf2-cq0ch + the `system-cofx-ids` set)."
-  [{:keys [id value step-number violations] :as step}]
+  [{:keys [id value no-value? step-number violations errors] :as step}]
   (let [cofx-meta  (when (keyword? id)
                      (try (rf/handler-meta :cofx id)
                           (catch :default _ nil)))
@@ -1990,16 +2026,139 @@
      ;; 2026-05-26 the body sits left-aligned with the badge (no
      ;; indent) so the diff-line reads at the same column as the
      ;; header's badge pill.
-     [:div {:data-testid (str "rf-xray-epoch-coeffect-value-" (name id))
-            :style coeffect-body-style}
-      [:span {:style coeffect-body-plus-style} "+"]
-      [:span {:style coeffect-body-path-style}
-       (str "[" (proj/ns-keyword id) "]")]
-      [:span {:style coeffect-body-value-style}
-       [ei/mini value 80]]]
+     ;;
+     ;; rf2-yz57h — a coeffect that THREW on injection
+     ;; (`:rf.error/coeffect-exception`, button-19) produced no resolved
+     ;; value, so the projection stamps `:no-value?` + omits `:value`. The
+     ;; diff-line is replaced by a muted "injection failed" line; the shared
+     ;; 'Exception Thrown' card below carries the message + details.
+     (if no-value?
+       [:div {:data-testid (str "rf-xray-epoch-coeffect-failed-" (name id))
+              :style coeffect-body-style}
+        [:span {:style coeffect-body-path-style}
+         (str "injection of [" (proj/ns-keyword id) "] threw")]]
+       [:div {:data-testid (str "rf-xray-epoch-coeffect-value-" (name id))
+              :style coeffect-body-style}
+        [:span {:style coeffect-body-plus-style} "+"]
+        [:span {:style coeffect-body-path-style}
+         (str "[" (proj/ns-keyword id) "]")]
+        [:span {:style coeffect-body-value-style}
+         [ei/mini value 80]]])
+     ;; rf2-yz57h — a coeffect-injection EXCEPTION attaches here as the
+     ;; shared inline 'Exception Thrown' card (button-19), under the
+     ;; COEFFECT step where it occurred (no longer collapsed onto HANDLER).
+     (error-blocks :coeffect errors)
      ;; rf2-xgeag — `:cofx` boundary violations attach to the matching
      ;; COEFFECT step by cofx-id.
      (violation-blocks :coeffect violations)]))
+
+;; ---- INTERCEPTOR step (rf2-yz57h) ---------------------------------------
+;;
+;; The pipeline had no distinct interceptor step before rf2-yz57h —
+;; interceptors WRAP the handler chain rather than appearing as their own
+;; cascade entry. A user-interceptor `:before` / `:after` throw
+;; (rf2-mszrz `:rf.error/interceptor-exception`) therefore had no home and
+;; collapsed onto HANDLER. The INTERCEPTOR step gives those exceptions a
+;; home (between COEFFECTS and HANDLER — the cascade position of the chain)
+;; and makes the throwing interceptor + its phase visible.
+;;
+;; CONDITIONAL — the projection emits the step only when an interceptor
+;; threw this cascade (the substrate emits no per-interceptor "ran" trace,
+;; so a clean chain leaves nothing to show). One row per throwing
+;; interceptor: the interceptor id (click-to-source via `handler-meta`,
+;; degrading to plain text) + a `:before` / `:after` phase chip + the
+;; shared 'Exception Thrown' card (rf2-wnvid).
+
+(def ^:private interceptor-row-style
+  {:display     "flex"
+   :align-items "center"
+   :gap         "8px"
+   :padding     "3px 0"
+   :font-family mono-stack
+   :font-size   "12px"
+   :flex-wrap   "wrap"})
+
+(def ^:private interceptor-phase-chip-style
+  {:display        "inline-flex"
+   :align-items    "center"
+   :background     bg-3-colour
+   :color          text-tertiary-colour
+   :border         border-subtle-1px
+   :border-radius  "2px"
+   :padding        "1px 5px"
+   :font-family    mono-stack
+   :font-size      "10px"
+   :font-weight    600
+   :letter-spacing "0.3px"
+   :white-space    "nowrap"})
+
+(defn- interceptor-phase-label
+  "Render an interceptor exception row's `:phase` as a UI chip label
+  (rf2-yz57h). `:before` (threw on the way IN — handler skipped) /
+  `:after` (threw on the way OUT — handler ran first). nil → no chip."
+  [phase]
+  (case phase
+    :before "before"
+    :after  "after"
+    (when (keyword? phase) (name phase))))
+
+(defn- interceptor-row-view
+  "Render one INTERCEPTOR-step row (rf2-yz57h) — the throwing interceptor's
+  id (click-to-source when `handler-meta` carries a coord) + a `:before` /
+  `:after` phase chip + the shared inline 'Exception Thrown' card."
+  [idx {:keys [interceptor-id phase errors]}]
+  (let [intc-meta (when (keyword? interceptor-id)
+                    (try (rf/handler-meta :interceptor interceptor-id)
+                         (catch :default _ nil)))
+        coord     (when (and intc-meta (string? (:file intc-meta)))
+                    {:file (:file intc-meta) :line (:line intc-meta)})
+        label     (proj/ns-keyword interceptor-id)]
+    [:div {:key (str "interceptor-row-" idx)
+           :data-testid (str "rf-xray-epoch-interceptor-row-" idx)
+           :data-interceptor-phase (when phase (name phase))}
+     [:div {:style interceptor-row-style}
+      (coord-link/coord-link coord label
+                             (str "rf-xray-epoch-interceptor-id-" idx)
+                             {:style       coeffect-verb-link-button-style
+                              :plain-style coeffect-verb-plain-style})
+      (when-let [pl (interceptor-phase-label phase)]
+        [:span {:data-testid (str "rf-xray-epoch-interceptor-phase-" idx)
+                :style interceptor-phase-chip-style}
+         pl])]
+     ;; rf2-yz57h — the interceptor EXCEPTION attaches here as the shared
+     ;; inline 'Exception Thrown' card (button-17 :before / button-18
+     ;; :after), under the INTERCEPTOR step where it occurred.
+     (error-blocks (keyword (str "interceptor-row-" idx)) errors)]))
+
+(defn render-interceptor-step
+  "Render the INTERCEPTOR step (rf2-yz57h — present ONLY when a user
+  interceptor threw this cascade). One row per throwing interceptor; each
+  carries the interceptor id (click-to-source) + a `:before` / `:after`
+  phase chip + the shared 'Exception Thrown' card. The step's `:errors`
+  slot (attached by `attach-exceptions`) is rendered per-row by matching
+  the exception's `:failing-id` to the row's `:interceptor-id`."
+  [{:keys [rows step-number errors] :as step}]
+  ;; The step-level `:errors` (from `attach-exceptions`) carry the exception
+  ;; records; thread each onto its matching row by `:failing-id`.
+  (let [rows* (mapv (fn [row]
+                      (assoc row :errors
+                             (filterv #(= (:interceptor-id row) (:failing-id %))
+                                      errors)))
+                    rows)]
+    [:div {:data-testid "rf-xray-epoch-step-interceptor"
+           :data-step-kw "interceptor"}
+     (numbered-circle step-number :INTERCEPTOR)
+     (step-header
+       {:step :interceptor
+        :badge :INTERCEPTOR
+        :verb (str (count rows) " interceptor"
+                   (when (not= 1 (count rows)) "s") " threw")
+        :expandable? false
+        :testid "rf-xray-epoch-interceptor"
+        :status (proj/step-status step)}
+       nil)
+     [:div {:style margin-top-5-style}
+      (map-indexed (fn [i row] (interceptor-row-view i row)) rows*)]]))
 
 ;; ---- HANDLER step --------------------------------------------------------
 
@@ -2762,26 +2921,39 @@
   violation kinds attach here."
   [{:keys [flavour event-id duration-ms step-number violations errors]
     :as step}]
-  [:div {:data-testid "rf-xray-epoch-step-handler"
-         :data-step-kw "handler"
-         :data-handler-flavour (when flavour (name flavour))}
-   (numbered-circle step-number :HANDLER)
-   (step-header
-     {:step :handler
-      :badge :HANDLER
-      :verb (handler-verb-link flavour event-id)
-      :expandable? false
-      :testid "rf-xray-epoch-handler"
-      :status (proj/step-status step)
-      :duration-ms duration-ms}
-     nil)
-   (handler-body step)
-   ;; rf2-ahhgn — a handler / interceptor / coeffect EXCEPTION attaches
-   ;; here as an inline error card (button-15/16/17). Rendered BELOW the
-   ;; handler body so the operator reads what the handler tried to do,
-   ;; then the failure that aborted it.
-   (error-blocks :handler errors)
-   (violation-blocks :handler violations)])
+  (let [status   (proj/step-status step)
+        skipped? (= :skipped status)]
+    [:div {:data-testid "rf-xray-epoch-step-handler"
+           :data-step-kw "handler"
+           :data-handler-flavour (when flavour (name flavour))}
+     (numbered-circle step-number :HANDLER)
+     (step-header
+       {:step :handler
+        :badge :HANDLER
+        :verb (handler-verb-link flavour event-id)
+        :expandable? false
+        :testid "rf-xray-epoch-handler"
+        :status status
+        ;; rf2-yz57h — a skipped handler has no real duration (it never
+        ;; ran); elide the chip.
+        :duration-ms (when-not skipped? duration-ms)}
+       nil)
+     (if skipped?
+       ;; rf2-yz57h — the handler was skipped (a `:before` interceptor /
+       ;; coeffect threw upstream). Render the SKIPPED placeholder instead
+       ;; of the normal body — the prior body's `:db` sub-section read
+       ;; "— no :db (handler returned no :db)" which was WRONG: the handler
+       ;; body returns a :db (via `bump`), it just never executed.
+       (skipped-body "rf-xray-epoch-handler" "The handler")
+       (handler-body step))
+     ;; rf2-ahhgn — a handler EXCEPTION attaches here as an inline error
+     ;; card (button-16). Rendered BELOW the handler body so the operator
+     ;; reads what the handler tried to do, then the failure that aborted
+     ;; it. (Coeffect / interceptor exceptions now land under their OWN
+     ;; steps per rf2-yz57h, so this slot carries only genuine handler
+     ;; throws.)
+     (error-blocks :handler errors)
+     (violation-blocks :handler violations)]))
 
 ;; ---- FLOW step -----------------------------------------------------------
 
@@ -3068,31 +3240,39 @@
   that didn't match a row attach to the step level (rf2-xgeag /
   rf2-ahhgn) and render at the foot. `:db` schema-fail (pre-commit) →
   just the `:db` CROSS row + badge cross, no fx rows (atomicity)."
-  [{:keys [rows step-number threw violations errors]}]
-  [:div {:data-testid "rf-xray-epoch-step-side-effects"
-         :data-step-kw "side-effects"
-         :data-fx-threw (str (or threw 0))}
-   (numbered-circle step-number :SIDE-EFFECTS)
-   (step-header
-     {:step :side-effects
-      :badge :SIDE-EFFECTS
-      :expandable? false
-      :testid "rf-xray-epoch-side-effects"
-      ;; rf2-j630b — the single overall badge glyph is the AND of the
-      ;; present ledger rows (`side-effects-badge-status`): cross iff a
-      ;; row is a real failure (its `:status` is `:error` / `:rollback`,
-      ;; or it carries an attached exception / violation); SKIPPED rows
-      ;; are neutral. Distinct from the generic `step-status` (which keys
-      ;; off the step's own `:status` + attachments only) because a
-      ;; row's `:status :error` / `:rollback` must trip the badge too.
-      :status (proj/side-effects-badge-status rows)}
-     nil)
-   [:div {:style margin-top-5-style}
-    (map-indexed (fn [i row] (fx-row-with-violations i row)) rows)]
-   ;; rf2-ahhgn — fx exceptions that didn't match a row (no-such-fx,
-   ;; or an fx-id absent from `:rows`) attach to the step level.
-   (error-blocks :side-effects errors)
-   (violation-blocks :side-effects violations)])
+  [{:keys [rows step-number threw violations errors] :as step}]
+  (let [skipped? (= :skipped (proj/step-status step))]
+    [:div {:data-testid "rf-xray-epoch-step-side-effects"
+           :data-step-kw "side-effects"
+           :data-fx-threw (str (or threw 0))}
+     (numbered-circle step-number :SIDE-EFFECTS)
+     (step-header
+       {:step :side-effects
+        :badge :SIDE-EFFECTS
+        :expandable? false
+        :testid "rf-xray-epoch-side-effects"
+        ;; rf2-yz57h — when the step was skipped (an upstream `:before`-chain
+        ;; throw aborted the cascade before any side effect ran) the header
+        ;; glyph is the muted ⊘ via the generic `step-status`. Otherwise the
+        ;; single overall badge glyph is the AND of the present ledger rows
+        ;; (`side-effects-badge-status`, rf2-j630b): cross iff a row is a real
+        ;; failure (its `:status` is `:error` / `:rollback`, or it carries an
+        ;; attached exception / violation); SKIPPED-on-platform rows are
+        ;; neutral. The row-level AND is distinct from the generic
+        ;; `step-status` (which keys off the step's own `:status` +
+        ;; attachments only) because a row's `:status :error` / `:rollback`
+        ;; must trip the badge too.
+        :status (if skipped? :skipped (proj/side-effects-badge-status rows))}
+       nil)
+     (if skipped?
+       ;; rf2-yz57h — side effects never ran (upstream `:before`-chain throw).
+       (skipped-body "rf-xray-epoch-side-effects" "Side effects")
+       [:div {:style margin-top-5-style}
+        (map-indexed (fn [i row] (fx-row-with-violations i row)) rows)])
+     ;; rf2-ahhgn — fx exceptions that didn't match a row (no-such-fx,
+     ;; or an fx-id absent from `:rows`) attach to the step level.
+     (error-blocks :side-effects errors)
+     (violation-blocks :side-effects violations)]))
 
 ;; ---- SUBSCRIPTIONS step --------------------------------------------------
 
@@ -4054,23 +4234,32 @@
     (when (keyword? recovery) (name recovery))))
 
 (defn- error-block-label
-  "Render the card's one-line failure headline (rf2-ahhgn / rf2-wnvid) —
-  the failing unit + a human verb keyed off the exception OP. E.g.
-  'The event handler threw.' / 'The :http/post effect threw.'
+  "Render the card's one-line failure headline (rf2-ahhgn / rf2-wnvid /
+  rf2-mszrz attribution / rf2-yz57h placement) — the failing unit + a
+  human verb keyed off the exception OP. E.g. 'The event handler threw.' /
+  'The :http/post effect threw.'
 
-  rf2-wnvid — attribution derives from `:operation` (== the trace
-  `:category` / `:reason` family), NOT the interceptor `:phase`. The
-  substrate routes a handler / interceptor / injected-coeffect throw ALL
-  through `:rf.error/handler-exception` with `:reason \"Event handler
-  threw.\"` and `:phase :before` (the handler is the terminal `:before`
-  interceptor — `re-frame.router/emit-handler-exception!`). The
-  pre-rf2-wnvid code read `:phase :before` and mislabelled button-15 (a
-  plain handler throw) as 'An interceptor / coeffect threw (:before).'
-  Since the substrate cannot distinguish the three sub-kinds, the
-  headline reads off the op and says 'The event handler threw.' —
-  matching the substrate's own `:reason`."
-  [{:keys [operation failing-id]}]
+  Attribution derives from `:operation` (== the trace `:category` /
+  `:reason` family). rf2-mszrz split the pre-mszrz blanket
+  `:rf.error/handler-exception` (the router used to route handler /
+  interceptor / injected-coeffect throws ALL through it) into
+  component-attributed ops, so the headline now names the TRUE failing
+  component: a coeffect injector (`:rf.error/coeffect-exception`, by cofx
+  id), a user interceptor (`:rf.error/interceptor-exception`, by
+  interceptor id + `:phase`), or the event handler itself
+  (`:rf.error/handler-exception`). The card is rendered UNDER the step
+  where the throw occurred (rf2-yz57h), so the headline reinforces that
+  placement rather than re-attributing."
+  [{:keys [operation failing-id phase]}]
   (case operation
+    :rf.error/coeffect-exception
+    (str "The " (proj/ns-keyword failing-id) " coeffect threw during injection.")
+    :rf.error/interceptor-exception
+    (str "The " (proj/ns-keyword failing-id) " interceptor threw"
+         (case phase
+           :before " on the way in (:before)."
+           :after  " on the way out (:after)."
+           "."))
     :rf.error/handler-exception
     "The event handler threw."
     :rf.error/fx-handler-exception
@@ -4331,6 +4520,7 @@
   (case (:step step)
     :dispatch          (render-dispatch-step step (:dispatch-id->epoch-id ctx))
     :coeffect          (render-coeffect-step step)
+    :interceptor       (render-interceptor-step step)
     :handler           (render-handler-step step)
     :flow              (render-flow-step step)
     :side-effects      (render-side-effects-step step)

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/badge_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/badge_cljs_test.cljc
@@ -159,10 +159,13 @@
 ;; ---- rf2-ahhgn — per-step pass/fail status primitive --------------------
 
 (deftest step-status-set-test
-  (testing "rf2-ahhgn — the per-step status closed set is {:ok :error}"
-    (is (= #{:ok :error} badge/step-status-set))
+  (testing "rf2-ahhgn · rf2-yz57h — the per-step status closed set is
+            {:ok :error :skipped} (:skipped added rf2-yz57h for steps that
+            never ran because an upstream :before-chain throw aborted)"
+    (is (= #{:ok :error :skipped} badge/step-status-set))
     (is (badge/step-status? :ok))
     (is (badge/step-status? :error))
+    (is (badge/step-status? :skipped))
     (is (not (badge/step-status? :NOT-A-STATUS)))))
 
 (deftest step-status-glyph-test

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -71,6 +71,8 @@
 (def ^:private schema-hot-reload-ev    teb/schema-hot-reload-ev)
 (def ^:private handler-exception-ev    teb/handler-exception-ev)
 (def ^:private fx-handler-exception-ev teb/fx-handler-exception-ev)
+(def ^:private coeffect-exception-ev   teb/coeffect-exception-ev)
+(def ^:private interceptor-exception-ev teb/interceptor-exception-ev)
 
 (defn- record
   "Build a synthetic `:rf/epoch-record` for projection."
@@ -1781,9 +1783,9 @@
                          (view-render-ev ::v [:s])])
           steps (proj/project rec)]
       (is (every? proj/valid-badge? (map :badge steps)))
-      (is (= 10 (count proj/badge-set))
+      (is (= 11 (count proj/badge-set))
           "rf2-sc3r1 7 + rf2-yx1ae + rf2-rrykz + rf2-xgeag (SCHEMA-HOT-RELOAD,
-           renamed from SCHEMA-VIOLATIONS) = 10 badges"))))
+           renamed from SCHEMA-VIOLATIONS) + rf2-yz57h (INTERCEPTOR) = 11 badges"))))
 
 ;; ---- formatting helpers --------------------------------------------------
 
@@ -2436,3 +2438,206 @@
       (is (= :ok (proj/epoch-outcome steps)))
       (is (every? #(nil? (:errors %)) steps))
       (is (every? #(= :ok (proj/step-status %)) steps)))))
+
+;; ---- rf2-yz57h — per-step exception placement + INTERCEPTOR step --------
+;;
+;; rf2-mszrz split the blanket `:rf.error/handler-exception` into three
+;; component-attributed ops; rf2-yz57h places each under the step where it
+;; actually occurred (coeffect → COEFFECT, interceptor → INTERCEPTOR,
+;; handler → HANDLER) and renders an upstream-skipped HANDLER / SIDE
+;; EFFECTS step as SKIPPED rather than 'ran, returned no :db'.
+
+(deftest exception-op->step-covers-new-ops-test
+  (testing "rf2-yz57h — the new component-attributed ops are in the
+            exception set"
+    (is (contains? proj/cascade-exception-ops :rf.error/coeffect-exception))
+    (is (contains? proj/cascade-exception-ops :rf.error/interceptor-exception))
+    (is (contains? proj/cascade-exception-ops :rf.error/handler-exception))))
+
+;; -- COEFFECT placement (button-19) --------------------------------------
+
+(deftest attach-coeffect-exception-to-matching-step-test
+  (testing "rf2-yz57h — a `:rf.error/coeffect-exception` attaches to the
+            COEFFECT step whose :id matches :failing-id (not HANDLER)"
+    (let [steps [{:step :coeffect :badge :COEFFECT :id :other/cofx}
+                 {:step :coeffect :badge :COEFFECT :id :app/session}
+                 {:step :handler  :badge :HANDLER}]
+          rows  [(proj/exception-row
+                   (coeffect-exception-ev :app/session "cofx boom"))]
+          out   (proj/attach-exceptions steps rows)]
+      (is (nil? (:errors (nth out 0))) "non-matching COEFFECT untouched")
+      (is (= 1 (count (:errors (nth out 1)))) "matching COEFFECT carries it")
+      (is (= :error (:status (nth out 1))) "matching COEFFECT stamped :error")
+      (is (nil? (:errors (nth out 2))) "HANDLER does NOT carry it")))
+
+  (testing "rf2-yz57h — falls back to the FIRST COEFFECT step when no :id
+            matches (e.g. the throwing cofx produced no :rf.cofx/run)"
+    (let [steps [{:step :coeffect :badge :COEFFECT :id :app/session}
+                 {:step :handler  :badge :HANDLER}]
+          rows  [(proj/exception-row
+                   (coeffect-exception-ev :app/missing "cofx boom"))]
+          out   (proj/attach-exceptions steps rows)]
+      (is (= 1 (count (:errors (nth out 0)))))
+      (is (nil? (:errors (nth out 1)))))))
+
+(deftest project-synthesises-coeffect-placeholder-on-throwing-cofx-test
+  (testing "rf2-yz57h — a coeffect-exception with NO matching :rf.cofx/run
+            synthesises a placeholder COEFFECT step (no value), carries the
+            exception, and marks the HANDLER + SIDE EFFECTS skipped"
+    (let [rec   (record [(dispatched-ev [:button-deck/throw-cofx] :ui nil)
+                         (coeffect-exception-ev :button-deck/throwing-cofx
+                                                "cofx boom")]
+                        :button-deck/throw-cofx)
+          steps (proj/project rec)
+          cofx  (some #(when (= :coeffect (:step %)) %) steps)
+          h     (some #(when (= :handler (:step %)) %) steps)]
+      (is (some? cofx) "a COEFFECT step exists for the throwing cofx")
+      (is (= :button-deck/throwing-cofx (:id cofx)))
+      (is (true? (:no-value? cofx)) "placeholder carries :no-value? (no resolved value)")
+      (is (= 1 (count (:errors cofx))) "the exception lands under COEFFECT")
+      (is (= :error (proj/step-status cofx)) "COEFFECT reads :error")
+      (is (some? h) "HANDLER step still present")
+      (is (= :skipped (proj/step-status h))
+          "HANDLER reads :skipped (it never ran — upstream cofx threw)")
+      (is (empty? (:errors h)) "HANDLER carries NO exception (it's under COEFFECT)")
+      (is (= :error (proj/epoch-outcome steps))
+          "epoch outcome reflects the coeffect exception"))))
+
+;; -- INTERCEPTOR step (button-17 :before / button-18 :after) -------------
+
+(deftest interceptor-step-projection-test
+  (testing "rf2-yz57h — `interceptor-step` is nil when no interceptor threw"
+    (is (nil? (proj/interceptor-step [(dispatched-ev [:x] :ui nil)
+                                      (run-end-ev 1)]))))
+
+  (testing "rf2-yz57h — `interceptor-step` projects one row per throwing
+            interceptor, carrying :interceptor-id + :phase"
+    (let [events [(interceptor-exception-ev :app/auth :before "intc boom")]
+          step   (proj/interceptor-step events)]
+      (is (= :interceptor (:step step)))
+      (is (= :INTERCEPTOR (:badge step)))
+      (is (= 1 (count (:rows step))))
+      (is (= :app/auth (:interceptor-id (first (:rows step)))))
+      (is (= :before   (:phase (first (:rows step))))))))
+
+(deftest attach-interceptor-exception-to-interceptor-step-test
+  (testing "rf2-yz57h — a `:rf.error/interceptor-exception` attaches to the
+            INTERCEPTOR step (not HANDLER)"
+    (let [steps [{:step :interceptor :badge :INTERCEPTOR
+                  :rows [{:interceptor-id :app/auth :phase :before}]}
+                 {:step :handler :badge :HANDLER}]
+          rows  [(proj/exception-row
+                   (interceptor-exception-ev :app/auth :before "intc boom"))]
+          out   (proj/attach-exceptions steps rows)]
+      (is (= 1 (count (:errors (nth out 0)))) "INTERCEPTOR carries the exception")
+      (is (= :error (:status (nth out 0))) "INTERCEPTOR stamped :error")
+      (is (nil? (:errors (nth out 1))) "HANDLER untouched"))))
+
+(deftest project-interceptor-before-end-to-end-test
+  (testing "rf2-yz57h — button-17 live scenario: a `:before` interceptor
+            threw → INTERCEPTOR step present, carries the exception, HANDLER
+            skipped"
+    (let [rec   (record [(dispatched-ev [:button-deck/throw-interceptor] :ui nil)
+                         (interceptor-exception-ev
+                           :button-deck/throwing-interceptor :before
+                           "interceptor :before boom")]
+                        :button-deck/throw-interceptor)
+          steps (proj/project rec)
+          intc  (some #(when (= :interceptor (:step %)) %) steps)
+          h     (some #(when (= :handler (:step %)) %) steps)]
+      (is (some? intc) "INTERCEPTOR step present")
+      (is (= 1 (count (:errors intc))) "exception under INTERCEPTOR")
+      (is (= :error (proj/step-status intc)))
+      (is (= :skipped (proj/step-status h))
+          "HANDLER skipped — a :before interceptor threw on the way in")
+      (is (empty? (:errors h)) "HANDLER carries no exception")
+      ;; cascade-position: INTERCEPTOR sits BEFORE HANDLER
+      (let [step-kws (mapv :step steps)
+            i-idx    (.indexOf step-kws :interceptor)
+            h-idx    (.indexOf step-kws :handler)]
+        (is (< i-idx h-idx) "INTERCEPTOR renders before HANDLER"))
+      (is (= :error (proj/epoch-outcome steps))))))
+
+(deftest project-interceptor-after-end-to-end-test
+  (testing "rf2-yz57h — button-18 live scenario: an `:after` interceptor
+            threw → INTERCEPTOR step present, HANDLER NOT skipped (it ran
+            first; the throw fired on the way out)"
+    (let [rec   (record [(dispatched-ev [:button-deck/throw-interceptor-after] :ui nil)
+                         ;; the handler ran + committed a :db on the way in
+                         (db-pending-ev {:n 1})
+                         (db-changed-ev [[[:n] 0 1 :modified]])
+                         (run-end-ev 1)
+                         (interceptor-exception-ev
+                           :button-deck/throwing-interceptor-after :after
+                           "interceptor :after boom")]
+                        :button-deck/throw-interceptor-after)
+          steps (proj/project rec)
+          intc  (some #(when (= :interceptor (:step %)) %) steps)
+          h     (some #(when (= :handler (:step %)) %) steps)]
+      (is (some? intc) "INTERCEPTOR step present")
+      (is (= :after (:phase (first (:rows intc)))) "the row records the :after phase")
+      (is (= 1 (count (:errors intc))) "exception under INTERCEPTOR")
+      (is (not= :skipped (proj/step-status h))
+          "HANDLER NOT skipped — it ran before the :after interceptor threw")
+      (is (true? (:db-write? h)) "the handler DID write a :db (it ran)")
+      (is (= :error (proj/epoch-outcome steps))))))
+
+;; -- SKIPPED-step marking -------------------------------------------------
+
+(deftest mark-skipped-handler-test
+  (testing "rf2-yz57h — a coeffect throw marks HANDLER + SIDE EFFECTS skipped"
+    (let [steps  [{:step :handler} {:step :side-effects} {:step :subscriptions}]
+          events [(coeffect-exception-ev :app/session "boom")]
+          out    (proj/mark-skipped-handler steps events)]
+      (is (= :skipped (:status (nth out 0))) "HANDLER skipped")
+      (is (= :skipped (:status (nth out 1))) "SIDE EFFECTS skipped")
+      (is (nil? (:status (nth out 2))) "SUBSCRIPTIONS not stamped here")))
+
+  (testing "rf2-yz57h — a :before interceptor throw marks the handler skipped"
+    (let [out (proj/mark-skipped-handler
+                [{:step :handler}]
+                [(interceptor-exception-ev :app/auth :before "boom")])]
+      (is (= :skipped (:status (first out))))))
+
+  (testing "rf2-yz57h — an :after interceptor throw does NOT mark skipped
+            (the handler ran)"
+    (let [out (proj/mark-skipped-handler
+                [{:step :handler}]
+                [(interceptor-exception-ev :app/auth :after "boom")])]
+      (is (nil? (:status (first out))))))
+
+  (testing "rf2-yz57h — a plain handler throw does NOT mark skipped (the
+            handler ran, then threw)"
+    (let [out (proj/mark-skipped-handler
+                [{:step :handler}]
+                [(handler-exception-ev :e "boom")])]
+      (is (nil? (:status (first out))))))
+
+  (testing "rf2-yz57h — a clean cascade leaves steps untouched"
+    (let [steps [{:step :handler} {:step :side-effects}]]
+      (is (= steps (proj/mark-skipped-handler steps [(run-end-ev 1)]))))))
+
+(deftest step-status-skipped-test
+  (testing "rf2-yz57h — `:skipped` status reads through `step-status`"
+    (is (= :skipped (proj/step-status {:step :handler :status :skipped})))
+    (is (= :ok (proj/step-status {:step :handler})))
+    ;; a step both skipped AND carrying an error reads :error (error wins)
+    (is (= :error (proj/step-status {:step :handler :status :skipped
+                                     :errors [{:message "x"}]})))))
+
+(deftest skipped-handler-not-flagged-error-test
+  (testing "rf2-yz57h — the SKIPPED handler does NOT inflate the epoch
+            outcome (the failing COEFFECT/INTERCEPTOR step is the :error
+            signal; a skip is neutral)"
+    (let [;; clean handler step that was skipped + no real exception on it
+          steps [{:step :coeffect :badge :COEFFECT :id :c :status :error
+                  :errors [{:message "boom"}]}
+                 {:step :handler :status :skipped}]
+          out   (proj/epoch-outcome steps)]
+      (is (= :error out) "the coeffect error drives the outcome")
+      (is (= :skipped (proj/step-status (second steps)))
+          "the skipped handler reads :skipped, not :error"))))
+
+(deftest interceptor-badge-in-badge-set-test
+  (testing "rf2-yz57h — :INTERCEPTOR is a valid badge"
+    (is (proj/valid-badge? :INTERCEPTOR))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -2543,3 +2543,136 @@
 ;; top-of-pipeline "This event failed" banner is gone; the failure
 ;; surfaces inline (the failing step's ✗ glyph + the 'Exception Thrown'
 ;; card). The panel root still stamps `data-rf-xray-outcome`.
+
+;; ---- rf2-yz57h — per-step exception placement + INTERCEPTOR + skipped ---
+
+(deftest coeffect-step-renders-exception-card-test
+  (testing "rf2-yz57h — a coeffect-injection exception renders the shared
+            'Exception Thrown' card UNDER the COEFFECT step (button-19)"
+    (epoch-orchestrator/install!)
+    (frame/reg-frame :rf/xray {})
+    (let [tree (rf/with-frame :rf/xray
+                 (view/render-coeffect-step
+                   {:step :coeffect :badge :COEFFECT :step-number 2
+                    :id :button-deck/throwing-cofx :no-value? true :threw? true
+                    :status :error
+                    :errors [{:operation :rf.error/coeffect-exception
+                              :message "cofx threw on purpose"
+                              :failing-id :button-deck/throwing-cofx
+                              :recovery :no-recovery}]}))]
+      ;; the failed-injection body, NOT a `+ [id] value` diff line.
+      ;; (testids key off `(name id)` — the namespace is stripped.)
+      (is (some? (th/find-by-testid
+                   tree "rf-xray-epoch-coeffect-failed-throwing-cofx"))
+          "renders the 'injection threw' body (no value)")
+      (is (nil? (th/find-by-testid
+                  tree "rf-xray-epoch-coeffect-value-throwing-cofx"))
+          "no `+ [id] value` diff line — the injector threw before resolving")
+      ;; the shared 'Exception Thrown' card (wnvid) is under the COEFFECT step
+      (is (string/includes?
+            (text-of tree "rf-xray-epoch-error-coeffect-0-title")
+            "Exception Thrown"))
+      (is (string/includes?
+            (text-of tree "rf-xray-epoch-error-coeffect-0-message")
+            "cofx threw on purpose"))
+      ;; header glyph is ✗ (error)
+      (let [status (th/find-by-testid tree "rf-xray-epoch-coeffect-throwing-cofx-status")]
+        (is (= "error" (:data-rf-xray-step-status (second status))))))))
+
+(deftest interceptor-step-renders-row-and-exception-card-test
+  (testing "rf2-yz57h — the INTERCEPTOR step renders the throwing
+            interceptor's id + phase chip + the shared 'Exception Thrown'
+            card (button-17 :before)"
+    (epoch-orchestrator/install!)
+    (frame/reg-frame :rf/xray {})
+    (let [tree (rf/with-frame :rf/xray
+                 (view/render-interceptor-step
+                   {:step :interceptor :badge :INTERCEPTOR :step-number 3
+                    :status :error
+                    :rows [{:interceptor-id :button-deck/throwing-interceptor
+                            :phase :before}]
+                    :errors [{:operation :rf.error/interceptor-exception
+                              :message "interceptor :before boom"
+                              :failing-id :button-deck/throwing-interceptor
+                              :phase :before
+                              :recovery :no-recovery}]}))]
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-step-interceptor"))
+          "the INTERCEPTOR step renders")
+      (is (string/includes?
+            (text-of tree "rf-xray-epoch-interceptor-row-0")
+            "throwing-interceptor")
+          "the throwing interceptor id renders")
+      (is (string/includes?
+            (text-of tree "rf-xray-epoch-interceptor-phase-0")
+            "before")
+          "the :before phase chip renders")
+      ;; the shared card under the interceptor row
+      (is (string/includes?
+            (text-of tree "rf-xray-epoch-error-interceptor-row-0-0-title")
+            "Exception Thrown"))
+      (is (string/includes?
+            (text-of tree "rf-xray-epoch-error-interceptor-row-0-0-message")
+            "interceptor :before boom"))
+      (let [badge-pill (th/find-by-testid tree "rf-xray-epoch-badge-interceptor")]
+        (is (some? badge-pill) "the INTERCEPTOR badge pill renders")
+        (is (= "INTERCEPTOR" (badge/label :INTERCEPTOR))))))
+
+  (testing "rf2-yz57h — an :after interceptor row carries the :after chip"
+    (epoch-orchestrator/install!)
+    (frame/reg-frame :rf/xray {})
+    (let [tree (rf/with-frame :rf/xray
+                 (view/render-interceptor-step
+                   {:step :interceptor :badge :INTERCEPTOR :step-number 3
+                    :status :error
+                    :rows [{:interceptor-id :app/auditor :phase :after}]
+                    :errors [{:operation :rf.error/interceptor-exception
+                              :message "after boom"
+                              :failing-id :app/auditor :phase :after}]}))]
+      (is (string/includes?
+            (text-of tree "rf-xray-epoch-interceptor-phase-0")
+            "after")))))
+
+(deftest handler-skipped-renders-as-skipped-not-no-db-test
+  (testing "rf2-yz57h — a HANDLER marked :skipped (upstream :before-chain
+            threw) renders the SKIPPED body, NOT the misleading
+            'returned no :db' (buttons 17/19)"
+    (epoch-orchestrator/install!)
+    (frame/reg-frame :rf/xray {})
+    (let [tree (rf/with-frame :rf/xray
+                 (view/render-handler-step
+                   {:step :handler :badge :HANDLER :step-number 4
+                    :flavour :reg-event-db :event-id :button-deck/throw-interceptor
+                    :db-diff [] :db-write? true :fx [] :machine nil
+                    :status :skipped}))]
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-handler-skipped"))
+          "the SKIPPED body renders")
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-handler-db-no-write"))
+          "the 'no :db (returned no :db)' placeholder does NOT render")
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-handler-db-full-with-diff"))
+          "no phantom :db block")
+      (is (string/includes?
+            (text-of tree "rf-xray-epoch-handler-skipped")
+            "did not run")
+          "the body states the handler did not run")
+      (let [status (th/find-by-testid tree "rf-xray-epoch-handler-status")]
+        (is (= "skipped" (:data-rf-xray-step-status (second status)))
+            "the header glyph reads :skipped (⊘), not ✗/✓")))))
+
+(deftest side-effects-skipped-renders-as-skipped-test
+  (testing "rf2-yz57h — a SIDE EFFECTS step marked :skipped renders the
+            SKIPPED body, not the ledger"
+    (let [tree (view/render-side-effects-step
+                 {:step :side-effects :badge :SIDE-EFFECTS :step-number 5
+                  :rows [{:fx-id :db :status :ok}]
+                  :status :skipped})]
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-side-effects-skipped"))
+          "the SKIPPED body renders")
+      (let [status (th/find-by-testid tree "rf-xray-epoch-side-effects-status")]
+        (is (= "skipped" (:data-rf-xray-step-status (second status))))))))
+
+(deftest step-status-glyph-skipped-test
+  (testing "rf2-yz57h — the badge primitive paints ⊘ (muted) for :skipped"
+    (is (= "⊘" (badge/step-status-glyph :skipped)))
+    (is (= "✓" (badge/step-status-glyph :ok)))
+    (is (= "✗" (badge/step-status-glyph :error)))
+    (is (badge/step-status? :skipped))))

--- a/tools/xray/test/day8/re_frame2_xray/test_helpers/trace_event_builders.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/test_helpers/trace_event_builders.cljc
@@ -59,7 +59,11 @@
   | `machine-action-ev`            | `:rf.machine/action-ran`               | HANDLER LIFECYCLE                   |
   | `machine-timer-cancel-ev`      | `:rf.machine.timer/cancelled`          | HANDLER AFTER-TIMERS                |
   | `schema-violation-ev`          | `:rf.error/schema-validation-failure`  | SCHEMA VIOLATIONS                   |
-  | `schema-hot-reload-ev`         | `:rf.schema/violation`                 | SCHEMA HOT-RELOAD                   |"
+  | `schema-hot-reload-ev`         | `:rf.schema/violation`                 | SCHEMA HOT-RELOAD                   |
+  | `handler-exception-ev`         | `:rf.error/handler-exception`          | HANDLER inline error card           |
+  | `coeffect-exception-ev`        | `:rf.error/coeffect-exception`         | COEFFECT inline error card (rf2-yz57h) |
+  | `interceptor-exception-ev`     | `:rf.error/interceptor-exception`      | INTERCEPTOR step (rf2-yz57h)        |
+  | `fx-handler-exception-ev`      | `:rf.error/fx-handler-exception`       | SIDE EFFECTS inline error card      |"
   (:refer-clojure :exclude [ev]))
 
 ;; ---- low-level primitive -----------------------------------------------
@@ -422,3 +426,42 @@
      coord (assoc :rf.trace/trigger-handler {:kind         :fx
                                              :id           fx-id
                                              :source-coord coord}))))
+
+(defn coeffect-exception-ev
+  "`:rf.error/coeffect-exception` trace (rf2-mszrz / rf2-yz57h) — a
+  coeffect INJECTOR threw during `:before`-chain coeffect injection. The
+  cofx id rides `[:tags :failing-id]`; the message rides
+  `[:tags :exception-message]`. The router emits this from
+  `emit-pipeline-exception!` after `classify-pipeline-exception` reads the
+  throwing interceptor's captured `:rf/cofx-id`. Drives the COEFFECT
+  step's inline 'Exception Thrown' card (rf2-yz57h)."
+  ([cofx-id message] (coeffect-exception-ev cofx-id message nil))
+  ([cofx-id message exception]
+   (cond-> (ev :error :rf.error/coeffect-exception
+               (cond-> {:failing-id        cofx-id
+                        :exception-message message
+                        :reason            (str "Coeffect injection for `"
+                                                cofx-id "` threw.")}
+                 exception (assoc :exception exception)))
+     true (assoc :recovery :no-recovery))))
+
+(defn interceptor-exception-ev
+  "`:rf.error/interceptor-exception` trace (rf2-mszrz / rf2-yz57h) — a USER
+  interceptor threw in its `:before` or `:after` phase. The interceptor id
+  rides `[:tags :failing-id]`, the phase rides `[:tags :phase]`
+  (`:before` / `:after`), and the message rides `[:tags :exception-message]`.
+  The router emits this from `emit-pipeline-exception!` after
+  `classify-pipeline-exception` finds a captured `:id` that is neither a
+  handler-wrapper nor a cofx injector. Drives the INTERCEPTOR step's inline
+  'Exception Thrown' card (rf2-yz57h)."
+  ([intc-id phase message] (interceptor-exception-ev intc-id phase message nil))
+  ([intc-id phase message exception]
+   (cond-> (ev :error :rf.error/interceptor-exception
+               (cond-> {:failing-id        intc-id
+                        :phase             phase
+                        :exception-message message
+                        :reason            (str "Interceptor `" intc-id
+                                                "` threw in its `" (name phase)
+                                                "` phase.")}
+                 exception (assoc :exception exception)))
+     true (assoc :recovery :no-recovery))))


### PR DESCRIPTION
## What

Xray Epoch panel: exceptions now render UNDER the step where they occurred, not all collapsed under HANDLER. Consumes the rf2-mszrz framework attribution (merged) that split the blanket `:rf.error/handler-exception` into component-attributed ops.

Per-exception-kind placement:

| Exception | Step |
|-----------|------|
| `:rf.error/coeffect-exception` | COEFFECT step (by cofx id; synthesises a placeholder COEFFECT step when the throwing cofx produced no `:rf.cofx/run`) |
| `:rf.error/interceptor-exception` | **INTERCEPTOR** step (NEW) — `:before`/`:after` phase chip per row |
| `:rf.error/handler-exception` | HANDLER step (handler only now) |
| `:rf.error/fx-handler-exception` | SIDE EFFECTS row (unchanged — existing `attach-to-fx-error-row` / `fx-row-with-violations`) |
| `:rf.error/flow-eval-exception` | FLOW step (unchanged) |

**New INTERCEPTOR step** — conditional (exception-only; the substrate emits no per-interceptor "ran" trace), sits between COEFFECTS and HANDLER (the chain's cascade position). One row per throwing interceptor: id (click-to-source, degrades to plain text) + `:before`/`:after` phase chip + the shared "Exception Thrown" card.

**SKIPPED steps** — when an upstream `:before`-chain throw (coeffect / `:before` interceptor) aborts the cascade, the HANDLER + SIDE EFFECTS steps are marked `:status :skipped` and render a "did not run" placeholder. Fixes the **verified bug** where buttons 17/19 wrongly showed HANDLER as "returned no :db" when it was actually skipped (the handler body returns a `:db` via `bump` but never ran). An `:after` interceptor throw does NOT skip the handler (it ran first, then threw on the way out).

`step-status` gains a third value `:skipped` (muted neutral `⊘`; does not inflate the epoch outcome — the failing COEFFECT/INTERCEPTOR step is the load-bearing `:error` signal). `badge-set` gains `:INTERCEPTOR`; `step-status-set` gains `:skipped`.

## Reuse (no parallel machinery)

- The shared rf2-wnvid "Exception Thrown" card (`error-block` / `error-blocks`).
- The rf2-j630b flat ledger + `fx-row-with-violations` / `attach-to-fx-error-row` (fx path untouched).
- The rf2-ahhgn per-step `:status` primitive (`step-status` / `badge/step-status-*`), extended with `:skipped`.

## Scope

Edits confined to the two epoch panel files + their tests + `tools/xray/spec/021` (per-step placement table, INTERCEPTOR step, SKIPPED rendering, 9-badge inventory, 3-value step-status set). Also touches `panels/epoch/badge.cljc` (the panel-local badge taxonomy that the two epoch files already depend on — `:INTERCEPTOR` badge + `:skipped` status glyph). NO core/impl changes (the attribution landed in rf2-mszrz); NO top-level `spec/*`. panel_gallery fixtures unchanged — they drive only handler/fx exceptions, whose rendered output is unaffected.

## Quality gates

Run locally from `implementation/`:

- `npm run test:cljs` — **5084 tests, 17132 assertions, 0 failures, 0 errors** (PASS). Includes the new rf2-yz57h projection + view + badge unit tests.
- `npm run test:xray-feature-gate` — **14 scenarios, 0 failures, 12 matrix rows** (PASS). All testbeds incl. panel-gallery compiled 0 warnings.
- `npm run test:bundle-isolation` — **PASS** (17 artefact entries, 35 internal sentinels absent, 3 allow-list budgets ok; uix/helix/reagent bundles clean). No tool leakage.
- clj-kondo on all changed source + test files — **0 errors** (the only warnings are pre-existing unused-private-var entries + the pre-existing `registry`-unused require; none introduced here).

## Per-exception-kind placement verification

Verified against the button-deck testbed scenarios (driven through unit tests with real trace-event shapes mirroring the live substrate emits):

- **Button 16** (`:button-deck/throw-handler`) — handler exception lands under HANDLER; handler NOT skipped (it ran, then threw); `:db-write?` false (no phantom :db).
- **Button 17** (`:button-deck/throw-interceptor`, `:before`) — interceptor exception lands under the new INTERCEPTOR step; INTERCEPTOR renders before HANDLER in the cascade; HANDLER reads **SKIPPED** (not "returned no :db").
- **Button 18** (`:button-deck/throw-interceptor-after`, `:after`) — interceptor exception lands under INTERCEPTOR with the `:after` phase chip; HANDLER NOT skipped (`:db-write?` true — it ran first).
- **Button 19** (`:button-deck/throw-cofx`) — coeffect exception lands under a synthesised COEFFECT placeholder step (no value); HANDLER + SIDE EFFECTS read **SKIPPED**.

bead: rf2-yz57h