### PR TITLE
feat(examples): login Story+Xray showcase — form-state variants + auth-submit cascade in Xray (rf2-p8v0q)

### DIFF
--- a/examples/reagent/login/stories.cljs
+++ b/examples/reagent/login/stories.cljs
@@ -1,0 +1,322 @@
+(ns login.stories
+  "Story showcase for the **login** worked example.
+
+   The login form's view-states form a natural Story VARIANT SET —
+   Story's core strength is enumerating a single view's view-states
+   side by side. This file registers one `reg-variant` per reachable
+   state of the example's `:auth.login/flow` machine so the Story
+   controls panel flips the page through every state without the
+   reader hand-driving the form.
+
+   ## The variant set — grounded in the example's real machine
+
+   `login.core` models the login flow as the five-state
+   `:auth.login/flow` machine (`spec/005`):
+
+       :idle → :submitting → {:error-shown | :authed | :locked-out}
+
+   The variants below map onto the states a reader actually reaches,
+   driven through REAL events (fidelity `:event`) — the bead's
+   highest-fidelity requirement, mirroring the nine_states showcase:
+
+     :story.login/empty               — fresh `:idle` form.
+     :story.login/submitting          — request in flight, `:submitting`
+                                        (`:auth/busy`), inputs disabled.
+     :story.login/invalid-credentials — a malformed `:submit` rejected
+                                        at the schema boundary; lights
+                                        Xray's Issues ribbon.
+     :story.login/auth-error          — `:error-shown` after a 401.
+     :story.login/locked-out          — `:locked-out` after the retry
+                                        limit is exceeded (the example's
+                                        distinctive fourth terminal
+                                        state — no testbed counterpart).
+     :story.login/success             — `:authed` welcome banner; the
+                                        canonical screenshot.
+
+   ### Why no `:filled` variant
+
+   The bead's conceptual list names a `filled` state. In this example
+   the form's email/password live in a component-LOCAL Reagent atom
+   (idiomatic Form-2; see `login.core/login-form`), NOT in app-db. A
+   Story `:setup` drives EVENTS, which cannot seed component-local
+   state — so `:filled` (and a free-standing `:validating` /
+   `:invalid-field` form state) is not event-reachable here. Rather
+   than synthetically seed it (which the fidelity rule forbids), the
+   form's input/validation story collapses onto `:invalid-credentials`
+   — a real schema-boundary rejection — keeping every variant honest
+   at fidelity `:event`.
+
+   ## Xray-richness — the auth-submit cascade
+
+   Story allocates each variant its own frame under `:preset :story`
+   (spec/002 §Frame presets), which redirects `:rf.http/managed` to
+   the framework-shipped `:rf.http/managed-canned-success` stub. So a
+   real submit runs the FULL auth cascade end to end:
+
+       [:auth.login/flow [:auth.login/submit creds]]   (→ :submitting)
+         → machine `:issue-request` action
+             → [:rf.http/managed {…}]                  (a real fx)
+                 → canned-success reply                (Side Effects panel)
+                 → [:auth.login/flow [:auth.login/success …]]
+                     → :authed
+
+   That whole chain lands on the Epoch tape + the Trace stream, and the
+   `:rf.http/managed` fx shows in the Side Effects panel — pick the
+   `:success` variant, press Ctrl+Shift+C, and watch the submit cascade
+   light up Xray end to end.
+
+   Two variants light Xray's Issues ribbon (the bead's failure-path
+   requirement):
+     - `:invalid-credentials` — the malformed `:submit` is rejected by
+       the `Credentials` schema at the event boundary (`:no-recovery`);
+       the handler never runs and an Issue is raised.
+     - `:auth-error` / `:locked-out` — a 401 failure cascade; the
+       `:rf.http/managed` request fires (Side Effects) and the
+       `:auth.login/failure` follow-on records the error.
+
+   ## Authoring discipline
+
+   Per spec/007 §Variants every variant body is plain data — no
+   fn-slots. The view at the centre of each variant is the example's
+   own `login.core/root-view`, referenced by id. The canonical Story
+   tags auto-install on the first `reg-*` call (rf2-p1ydc), so no
+   explicit boot step is needed.
+
+   This is a parallel SHOWCASE to the gate-side `login_form` testbed
+   (`tools/story/testbeds/login_form`), which stays the fixture for
+   Story's own tests. Examples are test-free (rf2-8cevm): these
+   stories carry NO `:script` / `:rf.assert/*` — they are a showcase,
+   not a test surface."
+  (:require [re-frame.core :as rf]
+            [re-frame.story :as story]
+            ;; Source the example's registrations (the machine, schemas,
+            ;; demo fx, subs, views). The variant bodies below reference
+            ;; its event-ids + the `root-view` view-id as plain keywords;
+            ;; requiring the ns fires every `reg-*` so those ids resolve.
+            [login.core]))
+
+;; ---------------------------------------------------------------------------
+;; Story-side submit event — the Xray-rich auth-submit cascade.
+;;
+;; The live example's machine `:issue-request` action issues a real
+;; `:rf.http/managed` request to `/api/login` and routes the reply back
+;; through `:auth.login/success` / `:auth.login/failure`. In the live
+;; `#/` app, `login.core/run` redirects `:rf.http/managed` to the demo
+;; stub. Inside the Story shell each variant frame runs under
+;; `:preset :story`, which redirects `:rf.http/managed` to the
+;; framework-shipped `:rf.http/managed-canned-success` stub instead —
+;; that stub echoes the request's `:value` slot back as the success
+;; payload (Spec 014 §Testing).
+;;
+;; So this Story submit event simply dispatches the real
+;; `:auth.login/submit` sub-event: the SAME machine action fires the
+;; SAME real `:rf.http/managed` fx (visible in Xray's Side Effects
+;; panel), and the canned-success stub resolves it deterministically —
+;; no app-side fx-override required. The success reply's `:value` is the
+;; stub's echo of the (absent) request `:value`, i.e. nil; the welcome
+;; banner keys off the `:auth/authenticated` tag, not the value, so the
+;; cascade lands cleanly at `:authed`.
+;; ---------------------------------------------------------------------------
+
+(rf/reg-event-fx :login.story/submit
+  {:doc "Story-shell driver for the auth-submit cascade. Dispatches the
+         real `:auth.login/submit` sub-event so the machine's
+         `:issue-request` action fires the real `:rf.http/managed` fx;
+         under the `:preset :story` frame the canned-success stub
+         resolves it and the `:auth.login/success` follow-on lands the
+         flow at `:authed`. The whole chain shows in Xray's Epoch /
+         Trace / Side Effects panels."}
+  (fn handler-story-submit [_ [_ creds]]
+    {:fx [[:dispatch [:auth.login/flow [:auth.login/submit creds]]]]}))
+
+;; ---------------------------------------------------------------------------
+;; register-all!
+;;
+;; Wrap every registration in a top-level fn so a hot-reload could
+;; re-fire the lot after a clear-all!. The fn fires once at namespace
+;; load via the trailing call, so consumers who just `:require` this ns
+;; get the side-table populated. (No test fixture — examples are
+;; test-free, rf2-8cevm.)
+;; ---------------------------------------------------------------------------
+
+(def ^:private good-creds
+  "Credentials the demo accepts (mirrors `login.core/good-password`).
+   Only used to shape the submit payload past the `Credentials`
+   boundary schema; the canned-success stub ignores them."
+  {:email "ada@example.com" :password "correct-horse"})
+
+(defn register-all!
+  "Register the login example's Story artefacts. Idempotent.
+   The canonical vocabulary auto-installs on the first `reg-*` call
+   (rf2-p1ydc) — no explicit boot step required."
+  []
+
+  ;; -------------------------------------------------------------------------
+  ;; reg-tag — a project tag marking the canonical screenshot variant.
+  ;; -------------------------------------------------------------------------
+
+  (story/reg-tag :login/canonical
+    {:doc "Marks the variant that ships as the example's canonical
+          screenshot — the `:success` welcome-banner state."})
+
+  ;; -------------------------------------------------------------------------
+  ;; reg-story — the parent story. Its `:component` (the example's
+  ;; `root-view`) and `:tags` inherit down to every variant below; the
+  ;; per-state setup lives on the variants.
+  ;; -------------------------------------------------------------------------
+
+  (story/reg-story :story.login
+    {:doc        "The login form — every reachable state of the
+                 `:auth.login/flow` machine, as runnable variants."
+     :component  :login.core/root-view
+     :tags       #{:dev :docs}
+     :substrates #{:reagent}})
+
+  ;; -------------------------------------------------------------------------
+  ;; reg-variant — the reachable states, each driven through REAL events
+  ;; (fidelity `:event`); no `:db-seed` / `:sub-overrides`.
+  ;; -------------------------------------------------------------------------
+
+  ;; Empty — the entry state. The variant fires a no-op
+  ;; `:auth.login/dismiss` so the machine's `:initial` cascade seeds the
+  ;; snapshot; without it the `[:rf/runtime :machines :snapshots
+  ;; :auth.login/flow]` slot is nil until the first real event.
+  (story/reg-variant :story.login/empty
+    {:doc        "Fresh form, nothing typed, no submit clicked — the
+                 `:idle` entry state a user lands on. Email + password
+                 inputs + an enabled 'Sign in' button."
+     :setup      [[:auth.login/flow [:auth.login/dismiss]]]
+     :tags       #{:dev :docs}
+     :substrates #{:reagent}})
+
+  ;; Submitting — a submit is in flight. `force-fx-stub` intercepts the
+  ;; `:rf.http/managed` fx the `:issue-request` action emits: the stub
+  ;; records the call (visible in Side Effects) but resolves NOTHING, so
+  ;; no `:success` / `:failure` follow-on fires and the canvas locks at
+  ;; `:submitting` (`:auth/busy`) — inputs disabled, button reads
+  ;; "Signing in…".
+  (story/reg-variant :story.login/submitting
+    {:doc        "First submit; the HTTP request is in flight. Inputs
+                 are disabled and the button reads 'Signing in…'. The
+                 fx-stub records the `:rf.http/managed` request and
+                 resolves nothing, so the canvas locks in `:submitting`."
+     :setup      [[:auth.login/flow [:auth.login/submit good-creds]]]
+     :decorators [[story/force-fx-stub-id :rf.http/managed {}]]
+     :tags       #{:dev :docs}
+     :substrates #{:reagent}})
+
+  ;; Invalid credentials — a malformed `:submit` (short password, bad
+  ;; email) is rejected by the `Credentials` boundary schema BEFORE the
+  ;; handler runs (Spec 010 §Validation order step 1; recovery
+  ;; `:no-recovery`). The machine never transitions out of `:idle`; the
+  ;; rejection raises an Issue that lights Xray's Issues ribbon.
+  (story/reg-variant :story.login/invalid-credentials
+    {:doc        "A malformed submit (too-short password) is rejected at
+                 the event-schema boundary — the `:auth.login/flow`
+                 handler never runs and the flow stays at `:idle`. Open
+                 Xray (Ctrl+Shift+C): the rejection lights the Issues
+                 ribbon, showing schema enforcement at the boundary."
+     :setup      [[:auth.login/flow [:auth.login/submit {:email    "nope"
+                                                          :password "short"}]]]
+     :tags       #{:dev :docs}
+     :substrates #{:reagent}})
+
+  ;; Auth error — the server rejected the credentials. The fx-stub
+  ;; intercepts the real request (recorded in Side Effects), then the
+  ;; variant manually drives the `:auth.login/failure` sub-event the
+  ;; stubbed-out request would otherwise have triggered — the canonical
+  ;; Story shape for pinning a specific terminal state regardless of
+  ;; timing. The machine lands at `:error-shown` with the error surfaced.
+  (story/reg-variant :story.login/auth-error
+    {:doc        "Server rejected the credentials. The form is
+                 re-enabled and the error message surfaces under the
+                 submit button (`:error-shown`). The real
+                 `:rf.http/managed` request shows in Xray's Side Effects
+                 panel; the manually-driven `:failure` follow-on records
+                 the error."
+     :setup      [[:auth.login/flow [:auth.login/submit good-creds]]
+                  [:auth.login/flow [:auth.login/failure
+                                     {:failure {:status  401
+                                                :message "Invalid credentials."}}]]]
+     :decorators [[story/force-fx-stub-id :rf.http/managed {}]]
+     :tags       #{:dev :docs}
+     :substrates #{:reagent}})
+
+  ;; Locked out — the example's distinctive fourth terminal state. Once
+  ;; the flow has had three prior failed attempts the `:under-retry-limit`
+  ;; guard fails, so the next failure routes to `:locked-out` (and the
+  ;; `:lock-account` action fires a real `:rf.http/managed` lock request).
+  ;; The variant sequences submit → failure four times to exhaust the
+  ;; limit. No testbed counterpart — unique to this example's machine.
+  (story/reg-variant :story.login/locked-out
+    {:doc        "Too many failed attempts — the `:under-retry-limit`
+                 guard fails on the fourth failure and the flow reaches
+                 the terminal `:locked-out` state, firing the
+                 `:lock-account` request (visible in Xray's Side Effects
+                 panel). The account is locked; the form no longer
+                 retries."
+     :setup      [[:auth.login/flow [:auth.login/submit good-creds]]
+                  [:auth.login/flow [:auth.login/failure
+                                     {:failure {:status 401 :message "Invalid credentials."}}]]
+                  [:auth.login/flow [:auth.login/submit good-creds]]
+                  [:auth.login/flow [:auth.login/failure
+                                     {:failure {:status 401 :message "Invalid credentials."}}]]
+                  [:auth.login/flow [:auth.login/submit good-creds]]
+                  [:auth.login/flow [:auth.login/failure
+                                     {:failure {:status 401 :message "Invalid credentials."}}]]
+                  [:auth.login/flow [:auth.login/submit good-creds]]
+                  [:auth.login/flow [:auth.login/failure
+                                     {:failure {:status 423 :message "Account locked."}}]]]
+     :decorators [[story/force-fx-stub-id :rf.http/managed {}]]
+     :tags       #{:dev :docs}
+     :substrates #{:reagent}})
+
+  ;; Success — the canonical screenshot. The full real auth cascade runs
+  ;; through `:login.story/submit`: real submit → `:issue-request` →
+  ;; real `:rf.http/managed` fx → canned-success reply →
+  ;; `:auth.login/success` → `:authed`. Pick this variant + Ctrl+Shift+C
+  ;; to watch the whole cascade light up Xray's Epoch / Trace / Side
+  ;; Effects panels.
+  (story/reg-variant :story.login/success
+    {:doc        "Server accepted the credentials. The form is replaced
+                 by the 'Welcome!' banner (`:authed`). The full
+                 auth-submit cascade — submit → `:rf.http/managed` →
+                 canned reply → `:success` — runs through real events;
+                 inspect it in Xray. The canonical screenshot."
+     :setup      [[:login.story/submit good-creds]]
+     :tags       #{:dev :docs :login/canonical}
+     :substrates #{:reagent}})
+
+  ;; -------------------------------------------------------------------------
+  ;; reg-workspace — two layouts over the variant set.
+  ;;
+  ;; `:grid` pins the states in narrative order for the README
+  ;; screenshot; `:variants-grid` auto-enumerates every variant of the
+  ;; parent story (new variants appear without touching the workspace).
+  ;; -------------------------------------------------------------------------
+
+  (story/reg-workspace :Workspace.login/all-states
+    {:doc      "Every login state, side by side in narrative order:
+               empty → submitting → invalid → auth-error → locked-out
+               → success."
+     :layout   :grid
+     :variants [:story.login/empty
+                :story.login/submitting
+                :story.login/invalid-credentials
+                :story.login/auth-error
+                :story.login/locked-out
+                :story.login/success]
+     :columns  3
+     :tags     #{:docs}})
+
+  (story/reg-workspace :Workspace.login/auto-grid
+    {:doc     "Auto-enumerated grid — pulls every variant off
+              :story.login. New variants appear here without touching
+              this workspace."
+     :layout  :variants-grid
+     :for     :story.login
+     :columns 3
+     :tags    #{:docs}}))
+
+;; Fire the registrations once at namespace load.
+(register-all!)

--- a/examples/reagent/login/stories.index.html
+++ b/examples/reagent/login/stories.index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>re-frame2 example: login (with Stories + Xray)</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<body>
+  <div id="app"></div>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/examples/reagent/login/stories_host.cljs
+++ b/examples/reagent/login/stories_host.cljs
@@ -1,0 +1,130 @@
+(ns login.stories-host
+  "Showcase entry point for the login example — the host that wires the
+   live app, the Story shell, and Xray into one page.
+
+   URL-hash-routed between two surfaces (mirrors
+   `nine-states.stories-host`):
+
+   - `#/`        → the live login app (the example's `root-view`).
+   - `#/stories` → the Story shell mounted via
+                   `re-frame.story/mount-shell!`. The reachable
+                   form-state variants + two workspaces show up in the
+                   sidebar; each variant renders in its own isolated
+                   frame.
+
+   ## Xray
+
+   The build wires Xray via shadow-cljs's `:devtools {:preloads
+   [day8.re-frame2-xray.preload]}` (see the `:examples/login-with-
+   stories` build in `implementation/shadow-cljs.edn`). Loading the
+   preload attaches the Ctrl+Shift+C keybinding and the trace / epoch
+   collectors. We DISABLE auto-open here (`:rf.xray/auto-open? false`)
+   so the page lands on the live app or the Story shell first; the
+   reader presses Ctrl+Shift+C to open Xray over either surface and
+   drive a submit to watch the `:auth.login/submit` →
+   `:rf.http/managed` → reply cascade light up the Epoch / Trace / Side
+   Effects panels (and the schema-rejection / failure paths light the
+   Issues ribbon).
+
+   ## One adapter
+
+   The host installs the FULL Reagent adapter (`re-frame.adapter.
+   reagent`) — the substrate the Story shell itself renders on. The
+   example's own `core.cljs` already runs on stock Reagent (it is the
+   cross-substrate reference base), so the live app + shell + variant
+   canvases all render on one adapter. `login.core/root-view` is a
+   substrate-agnostic `reg-view`.
+
+   ## Elision
+
+   Compiled under `:advanced` with `:closure-defines
+   {re-frame.story.config/enabled? false}`, every `reg-*` in
+   `login.stories` elides to nil and `mount-shell!` short-circuits —
+   the Story body carries no code into a production bundle. The
+   bundle-isolation gate verifies the Story / Xray sentinel sets stay
+   out of the plain `:examples/login` build."
+  (:require [reagent.dom.client :as rdc]
+            [re-frame.core  :as rf]
+            [re-frame.story :as story]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [day8.re-frame2-xray.config :as xray-config]
+            ;; Source the example's registrations (machine / schemas /
+            ;; demo fx / subs / views) and the Story artefacts. Requiring
+            ;; `login.stories` transitively requires `login.core`.
+            [login.core :as core]
+            [login.stories])
+  (:require-macros [re-frame.core :refer [reg-view]]))
+
+;; -- The live-app frame ----------------------------------------------------
+;;
+;; The live `#/` surface needs the example's demo HTTP override on its
+;; frame so `:rf.http/managed` routes to the in-process
+;; `:auth.login.demo/managed-stub` (no backend). This mirrors what
+;; `login.core/run` installs on `:rf/default`; we register it here so
+;; the host owns the full boot (the host does not call `core/run`,
+;; which hardcodes its own mount lifecycle).
+
+(defn- install-live-frame! []
+  (rf/reg-frame :rf/default
+    {:doc          "Login showcase live-app frame."
+     :fx-overrides {:rf.http/managed :auth.login.demo/managed-stub}}))
+
+(reg-view login-app []
+  [:div {:style {:padding "1.5em" :font-family "system-ui, sans-serif"}}
+   [:p {:style {:font-size "13px" :color "#666" :margin "0 0 1em 0"}}
+    "Open "
+    [:a {:href "#/stories"} "#/stories"]
+    " for the Story playground — every reachable login state as a "
+    "variant. Press "
+    [:kbd "Ctrl+Shift+C"]
+    " on either surface to open Xray and inspect the auth-submit cascade."]
+   [core/root-view]])
+
+;; -- Routing between the live app and the Story shell ----------------------
+;;
+;; The live app and the Story shell each own a React root on the same
+;; `#app` node, one at a time. The live app's root lives in `app-root`;
+;; the Story shell allocates and owns its own root inside `mount-shell!`.
+;; We tear one down before mounting the other (mirrors
+;; nine-states.stories-host).
+
+(defonce ^:private app-root (atom nil))
+
+(defn- ensure-app-root! []
+  (when (nil? @app-root)
+    (reset! app-root (rdc/create-root (js/document.getElementById "app")))))
+
+(defn- tear-down-app-root! []
+  (when-let [r @app-root]
+    (try (rdc/unmount r) (catch :default _ nil))
+    (reset! app-root nil)))
+
+(defn- mount-app! []
+  (story/unmount-shell!)
+  (ensure-app-root!)
+  (rdc/render @app-root [login-app]))
+
+(defn- mount-stories! []
+  (tear-down-app-root!)
+  (story/mount-shell! (js/document.getElementById "app")))
+
+(defn- on-hash-change! []
+  (let [hash (or (.. js/window -location -hash) "")]
+    (if (re-find #"^#/stories" hash)
+      (mount-stories!)
+      (mount-app!))))
+
+(defn ^:export run []
+  ;; Keep Xray's collectors + keybinding installed but do not auto-open
+  ;; the panel — the page lands on the live app / shell first; the
+  ;; reader opens Xray with Ctrl+Shift+C.
+  (xray-config/configure! {:rf.xray/auto-open? false})
+  (rf/init! reagent-adapter/adapter)
+  ;; No explicit `(story/install-canonical-vocabulary!)` — the first
+  ;; `reg-*` in `login.stories` (loaded via the require above)
+  ;; auto-installs the canonical Story vocabulary (rf2-p1ydc).
+  (install-live-frame!)
+  ;; Wire hash-change so reloading `#/stories` lands on the shell
+  ;; without a manual click-through.
+  (.addEventListener js/window "hashchange" on-hash-change!)
+  (on-hash-change!))

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -945,6 +945,32 @@
    :modules    {:main {:init-fn nine-states.stories-host/run}}
    :devtools   {:preloads [day8.re-frame2-xray.preload]}}
 
+  ;; Login Story + Xray showcase (rf2-p8v0q). The examples/reagent/login
+  ;; example wired up as a Story showcase: `login.stories` registers one
+  ;; variant per reachable state of the `:auth.login/flow` machine (empty
+  ;; / submitting / invalid-credentials / auth-error / locked-out /
+  ;; success) plus two workspaces. Hash-routed via
+  ;; `login.stories-host/run`: `#/` renders the live app; `#/stories`
+  ;; mounts the Story shell. The Xray preload is wired so a reader can
+  ;; press Ctrl+Shift+C and watch the auth-submit cascade —
+  ;; `:auth.login/submit` → `:rf.http/managed` → reply → success/failure
+  ;; — light up Xray's Epoch / Trace / Side Effects panels (and the
+  ;; schema-rejection / 401 paths light the Issues ribbon).
+  ;;
+  ;; The `login.*` namespaces resolve via the `../examples/reagent`
+  ;; source-path (already on :source-paths near the top of this file); the
+  ;; example does NOT use `re-frame.testbed.config`, so this build omits
+  ;; the open-in-editor repo-root closure-define the counter-with-stories
+  ;; / login-form testbed builds carry (those live under
+  ;; tools/story/testbeds and need it). Mirrors
+  ;; :examples/nine-states-with-stories above.
+  :examples/login-with-stories
+  {:target     :browser
+   :output-dir "out/examples/login-with-stories"
+   :asset-path "."
+   :modules    {:main {:init-fn login.stories-host/run}}
+   :devtools   {:preloads [day8.re-frame2-xray.preload]}}
+
   ;; (removed rf2-9jfo1.2) :examples/xray-rhs-smoke build target —
   ;; the original Playwright `spec.cjs` was deleted by rf2-piucm in
   ;; favour of the CLJS e2e at


### PR DESCRIPTION
Wires `examples/reagent/login` as a **Story + Xray showcase**, mirroring the just-merged `nine_states` showcase (rf2-rgyia). The `login_form` testbed (`tools/story/testbeds/login_form`) **stays** the gate-side fixture; this is a *parallel* showcase in the example. Decided via rf2-4qlb8 (build BOTH nine_states + login).

## What changed

- **`examples/reagent/login/stories.cljs`** (new) — six `reg-variant` entries over the reachable states of the example's `:auth.login/flow` machine, each driven through **real events** (fidelity `:event`), plus a `:login.story/submit` driver for the full auth-submit cascade and two `reg-workspace` layouts.
- **`examples/reagent/login/stories_host.cljs`** (new) — hash-routed host (`#/` live app, `#/stories` Story shell) on the full Reagent adapter; Xray preload wired with auto-open disabled (reader presses `Ctrl+Shift+C`). Installs the example's `:auth.login.demo/managed-stub` on the live `#/` frame.
- **`examples/reagent/login/stories.index.html`** (new) — minimal showcase host page.
- **`implementation/shadow-cljs.edn`** — see hot-zone call-out below.

## shadow-cljs.edn (hot-zone): added `:examples/login-with-stories` build-id

Added one build entry, modelled **exactly** on the just-merged `:examples/nine-states-with-stories`: own `:output-dir` (`out/examples/login-with-stories`), `:init-fn login.stories-host/run`, `:devtools {:preloads [day8.re-frame2-xray.preload]}`. No other entry touched. I was the sole toucher of this file this session.

## Variant ids registered (for rf2-rnqz0 tutorial coordination)

- `:story.login/empty` — fresh `:idle` form.
- `:story.login/submitting` — request in flight, `:submitting` / `:auth/busy` (fx-stub no-op pins it).
- `:story.login/invalid-credentials` — malformed `:submit` rejected at the `Credentials` schema boundary; lights Xray's **Issues** ribbon.
- `:story.login/auth-error` — `:error-shown` after a 401; real `:rf.http/managed` fx in Side Effects + manual `:failure` follow-on.
- `:story.login/locked-out` — `:locked-out` after the retry limit is exceeded (the example's distinctive 4th terminal state; no testbed counterpart).
- `:story.login/success` — `:authed` welcome banner; the canonical screenshot (tag `:login/canonical`). Full real cascade `submit → :rf.http/managed → canned-success → :auth.login/success`.

Parent story `:story.login`; project tag `:login/canonical`; workspaces `:Workspace.login/all-states` (grid) + `:Workspace.login/auto-grid` (variants-grid).

### Variant-set reconciliation

The bead's conceptual list named empty / filled / validating / invalid-field / submitting / auth-error / success. The example holds form input in a **component-local Reagent atom** (idiomatic Form-2), not app-db — so `filled` / `validating` / `invalid-field` are not event-reachable without synthetic seeding (which the fidelity rule forbids). They collapse onto the honest `:invalid-credentials` schema-boundary rejection. `:locked-out` is added because the example's machine has it. Rationale is documented in the `stories.cljs` ns docstring.

## Xray showcase

The auth-submit cascade is the Xray showcase. Under each variant's `:preset :story` frame, `:rf.http/managed` redirects to the framework-shipped canned-success stub, so a real submit runs `[:auth.login/submit] → :issue-request → :rf.http/managed (real fx) → reply → :auth.login/success → :authed` — visible across **Epoch / Trace / Side Effects**. The `:invalid-credentials` (schema reject, `:no-recovery`) and 401-failure paths light the **Issues** ribbon.

## Quality gates

All run locally from `implementation/` (fresh worktree needed a one-time `npm install` for react + shadow-cljs, per the rgyia precedent — no source impact):

- `npx shadow-cljs compile examples/login-with-stories` — **Build completed, 0 warnings** (583 files).
- `npx shadow-cljs compile examples/login` (plain build still clean) — **Build completed, 0 warnings** (175 files).
- `npm run test:cljs` — **green**: 5071 tests / 17075 assertions, 0 failures, 0 errors.
- `npm run test:bundle-isolation` — **PASS** (17 artefact entries, 35 sentinels absent; no tool leak into a production example bundle).
- `npm run test:examples` — **0 failures, 0 skipped** (3 adapter smokes). (Trailing `http-server exited unexpectedly` is post-run teardown noise after the specs passed.)
- `clj-kondo --lint` on the two new cljs files — **0 errors, 0 warnings**.

## Constraints honoured

- Examples test-free lock (rf2-8cevm): no `*.spec.cjs` under `examples/` (confirmed by glob).
- Edit scope limited to `examples/reagent/login/` + the one shadow-cljs.edn build-id. The `login_form` testbed, tools/, core/impl, and spec/* untouched. No changes to `login/core.cljs` were needed.