### PR TITLE
docs(skills): fix stale §Keybindings in xray-replaces-10x.md vs keybinding.cljs (rf2-19z4q)

### DIFF
--- a/skills/re-frame-migration/references/xray-replaces-10x.md
+++ b/skills/re-frame-migration/references/xray-replaces-10x.md
@@ -53,7 +53,7 @@ Xray is **dev-only by construction** — production builds elide every byte of i
 {:builds {:app {:devtools {:preloads [day8.re-frame2-xray.preload]}}}}
 ```
 
-The preload registers Xray's listeners under `register-listener!` and `register-epoch-listener!`, attaches the `Ctrl+Shift+C` keybinding, and auto-opens the panel into the layout host after `rf/init!`. No `(require '[day8.re-frame2-xray.core])`. No `init!` call. The preload plus the host element are the full integration surface.
+The preload registers Xray's listeners under `register-listener!` and `register-epoch-listener!`, attaches the global keydown listener (`Ctrl+Shift+C` and the rest — see [Keybindings](#keybindings-whats-actually-wired)), and auto-opens the panel into the layout host after `rf/init!`. No `(require '[day8.re-frame2-xray.core])`. No `init!` call. The preload plus the host element are the full integration surface.
 
 ---
 
@@ -103,15 +103,30 @@ The resize *handle* (a vertical splitter that writes the property), the per-rout
 
 ## Keybindings (what's actually wired)
 
-One keybinding ships in `tools/xray/src/day8/re_frame2_xray/keybinding.cljs` today:
+The global keydown listener in `tools/xray/src/day8/re_frame2_xray/keybinding.cljs` wires three modifier chords (always live whenever the listener is attached) plus a set of focus-gated bare keys (live only inside the Xray shell).
+
+**Global chords** — fire anywhere on the page:
 
 | Action | Keys | Notes |
 |---|---|---|
-| Toggle the Xray panel (show / hide) | `Ctrl+Shift+C` | Toggles visibility of the mounted shell; does not unmount. |
+| Toggle the Xray panel (show / hide) | `Ctrl+Shift+C` | Toggles visibility of the mounted shell; does not unmount. `Ctrl` only — see Cross-OS below. |
+| Toggle Dynamic ↔ Static mode | `Cmd+Shift+M` / `Ctrl+Shift+M` | Dispatches `:rf.xray/toggle-mode` on the `:rf/xray` frame. Accepts either Cmd (macOS) or Ctrl. |
+| Toggle the command palette | `Cmd+K` / `Ctrl+K` | Dispatches `:rf.xray/palette-toggle` on the `:rf/xray` frame; opens the shell first if it isn't visible. Accepts either Cmd (macOS muscle-memory) or Ctrl (Windows/Linux). |
 
-**Cross-OS:** Xray uses `Ctrl` (not `Cmd`) on every host OS. macOS Safari sometimes maps `Cmd+Shift+C` to dev-tools' Inspect; the `Ctrl` modifier avoids that collision. macOS users who prefer `Cmd+Shift+C` can rebind in their browser's keyboard-shortcut UI.
+**Spine / shell bare keys** — fire ONLY when the shell is visible, the keydown target is inside the Xray shell DOM (`[data-testid="rf-xray-shell"]`), the target is not an editable element (`<input>` / `<textarea>` / `<select>` / `contenteditable`), and the target is not inside an Xray modal (Settings popup or command palette). No modifier:
 
-**Not currently wired as keybindings:** `Ctrl+Shift+P` (pop-out to second window) and `Ctrl+K` (command palette) appear in some docs and spec tables, but the keydown listener in `keybinding.cljs` does not currently handle them. Pop-out is reachable programmatically via `window.day8.re_frame2_xray.popout_BANG_()` (or `(xray/popout!)` from CLJS); the command palette is shell-internal. If the author asks specifically about either, point them at the programmatic surface and note the keybinding gap. Do not claim Xray supports a keybinding it doesn't.
+| Action | Keys | Dispatches |
+|---|---|---|
+| Pause / resume the LIVE feed | `Space` | `:rf.xray/toggle-live-pause` |
+| Snap to LIVE (follow head) | `L` | `:rf.xray/follow-head` |
+| Fast-forward to head ("Go to head") | `Shift+G` | `:rf.xray/follow-head` |
+| Step backward through events | `j` | `:rf.xray/focus-cascade-prev` |
+| Step forward through events | `k` | `:rf.xray/focus-cascade-next` |
+| Toggle the Settings popup | `,` or `s` | `:rf.xray/settings-toggle` |
+
+**Cross-OS:** the shell-toggle is `Ctrl+Shift+C` (not `Cmd`) on every host OS. macOS Safari sometimes maps `Cmd+Shift+C` to dev-tools' Inspect; the `Ctrl` modifier avoids that collision. macOS users who prefer `Cmd+Shift+C` can rebind in their browser's keyboard-shortcut UI. The mode-toggle and command-palette chords intentionally accept *either* Cmd or Ctrl, so macOS users get the muscle-memory Cmd form and Windows/Linux users get Ctrl.
+
+**Pop-out is NOT a keybinding.** Pop-out to a second window is reachable programmatically via `window.day8.re_frame2_xray.popout_BANG_()` (or `(xray/popout!)` from CLJS); the keydown listener does not handle a pop-out chord. The command palette, by contrast, IS wired (`Cmd/Ctrl+K`, above). Do not claim a pop-out keybinding exists.
 
 The earlier `Ctrl+Shift+/` co-pilot keybinding has been removed —
 the AI co-pilot rail no longer ships; AI integration lives in


### PR DESCRIPTION
@
Closes rf2-19z4q.

The §Keybindings section of `skills/re-frame-migration/references/xray-replaces-10x.md` was stale: it claimed only `Ctrl+Shift+C` is wired and that `Ctrl+K` (command palette) and pop-out are NOT keybindings. The truth — verified against `tools/xray/src/day8/re_frame2_xray/keybinding.cljs` — is that the listener wires three global modifier chords plus six focus-gated bare keys. (Only pop-out is genuinely not a keybinding; that caveat is kept, the false `Ctrl+K` claim is corrected.)

Doc-only / skill-only change. Edits confined to the one file.

## Quality gates

Authority: `tools/xray/src/day8/re_frame2_xray/keybinding.cljs`. Every binding written is verifiable there.

### Before → after

**Before** (stale): a single-row table —

| Action | Keys |
|---|---|
| Toggle the Xray panel | `Ctrl+Shift+C` |

…plus a "Not currently wired" note asserting `Ctrl+Shift+P` (pop-out) **and** `Ctrl+K` (command palette) are NOT handled by the listener.

**After** (matches source): three global chords + six focus-gated bare keys, and the caveat narrowed to pop-out only.

### Each binding ↔ keybinding.cljs line verified

Global chords (always live while the listener is attached — see `handle-keydown`, lines 232-281):

| Binding (after) | Predicate / dispatch | keybinding.cljs lines |
|---|---|---|
| `Ctrl+Shift+C` → toggle shell (`mount/toggle!`) | `xray-toggle-key?` (Ctrl+Shift, no Meta/Alt; C via key/code) | 82-90 (pred), 234-237 (dispatch) |
| `Cmd/Ctrl+Shift+M` → `:rf.xray/toggle-mode` | `mode-toggle-key?` (Ctrl XOR Meta, Shift, no Alt; M via key/code) | 92-118 (pred), 243-247 (dispatch on `:rf/xray`) |
| `Cmd/Ctrl+K` → `:rf.xray/palette-toggle`; opens shell first if hidden | `palette-toggle-key?` (Ctrl XOR Meta, no Shift/Alt; K via key/code) | 120-148 (pred), 249-260 (dispatch on `:rf/xray`, `mount/open!` if not visible) |

Focus-gated bare keys (fire only when shell visible AND target inside `[data-testid="rf-xray-shell"]` AND not editable AND not inside an Xray modal — gate at lines 272-281; gate helpers `target-inside-xray?` 150-156, `target-editable?` 158-169, `target-inside-modal?` 171-183):

| Binding (after) | Dispatch | keybinding.cljs lines (`spine-key-id`) |
|---|---|---|
| `Space` | `:rf.xray/toggle-live-pause` | 199-201 |
| `L` (lowercase, unshifted) | `:rf.xray/follow-head` | 203-205 |
| `Shift+G` | `:rf.xray/follow-head` | 207-209 |
| `j` | `:rf.xray/focus-cascade-prev` | 211-213 |
| `k` | `:rf.xray/focus-cascade-next` | 215-217 |
| `,` or `s` | `:rf.xray/settings-toggle` | 219-230 |

Pop-out caveat kept: the listener has no pop-out chord; pop-out is programmatic only (`window.day8.re_frame2_xray.popout_BANG_()`). Confirmed by absence of any pop-out predicate in `handle-keydown` (232-281).

Also corrected: the §The swap preload-wire sentence (was "attaches the `Ctrl+Shift+C` keybinding"; now "attaches the global keydown listener (`Ctrl+Shift+C` and the rest)") — `attach!` installs one `handle-keydown` listener covering all bindings (lines 283-299).

Internal consistency: re-read the section; chord/bare-key split, dispatch ids, and the anchor link (`#keybindings-whats-actually-wired`) all check out. No code gate applies (skill-doc path; CI skills-structural job does not cover it).
@