### PR TITLE
refactor(xray/testbed): rename button_deck → standard_epochs (full sweep, rf2-zthnj)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/standard_epochs_views_subs_lifecycle_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/standard_epochs_views_subs_lifecycle_cljs_test.cljs
@@ -1,8 +1,8 @@
-(ns re-frame.button-deck-views-subs-lifecycle-cljs-test
-  "Per rf2-fqzmb — substrate contract coverage for the button-deck
+(ns re-frame.standard-epochs-views-subs-lifecycle-cljs-test
+  "Per rf2-fqzmb — substrate contract coverage for the standard-epochs
   Views/subscriptions section's view + subscription LIFECYCLE.
 
-  The button-deck testbed (`tools/xray/testbeds/button_deck/core.cljs`)
+  The standard-epochs testbed (`tools/xray/testbeds/standard_epochs/core.cljs`)
   is test-free (locked, rf2-8cevm): its BUTTONS demonstrate the
   behaviour for Xray + re-frame2-pair inspection. The hard ASSERTIONS
   live here — the substrate subs/views contract suite — exactly
@@ -15,15 +15,15 @@
 
     Child A — SUBSCRIPTION-driven. Subscribes an own L1→L2→L3 chain
               (`:chain-root` → `:chain-doubled` → `:chain-labelled`)
-              PLUS the arg-keyed `[:button-deck/greater-than? N]` sub.
+              PLUS the arg-keyed `[:standard-epochs/greater-than? N]` sub.
     Child B — PROPS-driven. Receives a prop, subscribes NOTHING.
 
   The five contract assertions (one per acceptance item):
 
     1. Mounting A creates A's sub-cache entries — the chain L1/L2/L3
-       AND `[:button-deck/greater-than? 5]`.
+       AND `[:standard-epochs/greater-than? 5]`.
     2. Changing the sub-arg N (5 → 10) creates a DISTINCT
-       `[:button-deck/greater-than? 10]` cache entry — the
+       `[:standard-epochs/greater-than? 10]` cache entry — the
        parameterized-sub cache is keyed by arg.
     3. Changing a chain input recomputes L1→L2→L3 (invalidation
        propagation down the chain).
@@ -51,7 +51,7 @@
   `:rf.view/triggered-by` from the in-flight buffer.
 
   The subs / views here are byte-for-byte the testbed's, registered
-  under the same `:button-deck/*` ids, so a drift between the testbed
+  under the same `:standard-epochs/*` ids, so a drift between the testbed
   and this contract surfaces as a failure here.
 
   ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
@@ -67,33 +67,33 @@
     {:adapter reagent-adapter/adapter}))
 
 ;; ===========================================================================
-;; The button-deck Views/subs section, replicated verbatim
+;; The standard-epochs Views/subs section, replicated verbatim
 ;; ===========================================================================
 ;;
 ;; Child A's own L1→L2→L3 chain rooted at :views/chain-input (NOT :base —
 ;; that feeds the testbed's flow), plus the arg-keyed greater-than? sub.
 
 (defn- register-section-subs! []
-  (rf/reg-sub :button-deck/chain-root            ;; L1
+  (rf/reg-sub :standard-epochs/chain-root            ;; L1
     (fn [db _] (get-in db [:views :chain-input])))
-  (rf/reg-sub :button-deck/chain-doubled         ;; L2
-    :<- [:button-deck/chain-root]
+  (rf/reg-sub :standard-epochs/chain-doubled         ;; L2
+    :<- [:standard-epochs/chain-root]
     (fn [root _] (* 2 root)))
-  (rf/reg-sub :button-deck/chain-labelled        ;; L3
-    :<- [:button-deck/chain-doubled]
+  (rf/reg-sub :standard-epochs/chain-labelled        ;; L3
+    :<- [:standard-epochs/chain-doubled]
     (fn [doubled _] (str "2×input = " doubled)))
-  (rf/reg-sub :button-deck/greater-than?         ;; DYNAMIC, arg-keyed
-    :<- [:button-deck/chain-root]
+  (rf/reg-sub :standard-epochs/greater-than?         ;; DYNAMIC, arg-keyed
+    :<- [:standard-epochs/chain-root]
     (fn [root [_ threshold]] (> root threshold))))
 
 (defn- register-section-events! []
-  (rf/reg-event-db :button-deck/seed
+  (rf/reg-event-db :standard-epochs/seed
     (fn [_ _] {:views {:a-mounted?  false
                        :b-mounted?  false
                        :threshold   5
                        :chain-input 1
                        :b-prop      "alpha"}}))
-  (rf/reg-event-db :button-deck/perturb-chain
+  (rf/reg-event-db :standard-epochs/perturb-chain
     (fn [db _] (update-in db [:views :chain-input] inc))))
 
 ;; Child A's full read-set, stood up as the view's mount-time subscribes.
@@ -101,15 +101,15 @@
 ;; mount → unmount pair. `threshold` is A's prop (the arg-key driver).
 (defn- mount-a!
   [threshold]
-  {:chain     (rf/subscribe [:button-deck/chain-labelled])
-   :gt        (rf/subscribe [:button-deck/greater-than? threshold])
+  {:chain     (rf/subscribe [:standard-epochs/chain-labelled])
+   :gt        (rf/subscribe [:standard-epochs/greater-than? threshold])
    :threshold threshold})
 
 (defn- unmount-a!
   "The unmount path: every subscribe A made on mount drops its derefer."
   [{:keys [threshold]}]
-  (rf/unsubscribe [:button-deck/chain-labelled])
-  (rf/unsubscribe [:button-deck/greater-than? threshold]))
+  (rf/unsubscribe [:standard-epochs/chain-labelled])
+  (rf/unsubscribe [:standard-epochs/greater-than? threshold]))
 
 (defn- sub-cache
   "The frame's live sub-cache map (cache-key → entry). Keys are the
@@ -128,13 +128,13 @@
 
 (deftest mounting-a-creates-chain-and-arg-keyed-cache-entries
   (testing "rf2-fqzmb #1: mounting Child A subscribes its own L1→L2→L3
-   chain AND the arg-keyed [:button-deck/greater-than? 5] sub — every
+   chain AND the arg-keyed [:standard-epochs/greater-than? 5] sub — every
    one lands a sub-cache entry. The chain's intermediate L1 (:chain-root)
    + L2 (:chain-doubled) materialise via the cascade even though A only
    names the L3 + the gt? sub directly."
     (register-section-subs!)
     (register-section-events!)
-    (rf/dispatch-sync [:button-deck/seed])
+    (rf/dispatch-sync [:standard-epochs/seed])
 
     (is (empty? (sub-cache)) "precondition: cold cache before mount")
 
@@ -145,13 +145,13 @@
           "gt? 5: chain-root 1 is NOT > 5")
 
       ;; A's whole read-set is cached, including the cascaded chain inputs.
-      (is (cached? [:button-deck/chain-labelled])
+      (is (cached? [:standard-epochs/chain-labelled])
           "L3 :chain-labelled cached (A's direct deref)")
-      (is (cached? [:button-deck/chain-doubled])
+      (is (cached? [:standard-epochs/chain-doubled])
           "L2 :chain-doubled cached (cascaded input)")
-      (is (cached? [:button-deck/chain-root])
+      (is (cached? [:standard-epochs/chain-root])
           "L1 :chain-root cached (cascaded input)")
-      (is (cached? [:button-deck/greater-than? 5])
+      (is (cached? [:standard-epochs/greater-than? 5])
           "arg-keyed [:gt? 5] cached")
 
       (unmount-a! held))))
@@ -163,27 +163,27 @@
 (deftest changing-the-arg-creates-a-distinct-cache-entry
   (testing "rf2-fqzmb #2: the parameterized-sub cache is keyed by arg.
    With A mounted at N=5, changing the arg to N=10 (the testbed's
-   button 11) materialises a NEW [:button-deck/greater-than? 10] entry
-   ALONGSIDE the original [:button-deck/greater-than? 5] — two distinct
+   button 11) materialises a NEW [:standard-epochs/greater-than? 10] entry
+   ALONGSIDE the original [:standard-epochs/greater-than? 5] — two distinct
    slots over the one registration."
     (register-section-subs!)
     (register-section-events!)
-    (rf/dispatch-sync [:button-deck/seed])
+    (rf/dispatch-sync [:standard-epochs/seed])
 
     (let [held-5 (mount-a! 5)]
       @(:gt held-5)
-      (is (cached? [:button-deck/greater-than? 5])
+      (is (cached? [:standard-epochs/greater-than? 5])
           "[:gt? 5] cached after the N=5 mount")
-      (is (not (cached? [:button-deck/greater-than? 10]))
+      (is (not (cached? [:standard-epochs/greater-than? 10]))
           "precondition: no [:gt? 10] slot yet")
 
       ;; The arg changes (5 → 10): the root re-renders A with the new
       ;; prop, so A subscribes the new query-vector.
       (let [held-10 (mount-a! 10)]
         @(:gt held-10)
-        (is (cached? [:button-deck/greater-than? 10])
+        (is (cached? [:standard-epochs/greater-than? 10])
             "[:gt? 10] is a NEW, distinct cache entry — cache keyed by arg")
-        (is (cached? [:button-deck/greater-than? 5])
+        (is (cached? [:standard-epochs/greater-than? 5])
             "[:gt? 5] still present — distinct slot, not overwritten")
         (is (not (identical? (:gt held-5) (:gt held-10)))
             "the two args yield two distinct reactions")
@@ -202,7 +202,7 @@
    reads reflects the new root — the recompute reached the leaf."
     (register-section-subs!)
     (register-section-events!)
-    (rf/dispatch-sync [:button-deck/seed])
+    (rf/dispatch-sync [:standard-epochs/seed])
 
     (let [held (mount-a! 5)]
       (is (= "2×input = 2" @(:chain held))
@@ -210,7 +210,7 @@
 
       ;; Perturb the L1 root. The chain reaction graph invalidates and
       ;; recomputes through to the leaf the view derefs.
-      (rf/dispatch-sync [:button-deck/perturb-chain])
+      (rf/dispatch-sync [:standard-epochs/perturb-chain])
 
       (is (= 2 (get-in (frame/frame-app-db-value :rf/default)
                        [:views :chain-input]))
@@ -226,10 +226,10 @@
    threshold the arg-keyed sub flips — same shared L1 drives both legs."
     (register-section-subs!)
     (register-section-events!)
-    (rf/dispatch-sync [:button-deck/seed])
+    (rf/dispatch-sync [:standard-epochs/seed])
     (let [held (mount-a! 1)]
       (is (false? @(:gt held)) "precondition: root 1 is not > 1")
-      (rf/dispatch-sync [:button-deck/perturb-chain]) ;; root → 2
+      (rf/dispatch-sync [:standard-epochs/perturb-chain]) ;; root → 2
       (is (true? @(:gt held)) "[:gt? 1] flipped true after root 1 → 2")
       (unmount-a! held))))
 
@@ -245,7 +245,7 @@
    RECORDED on the :rf.sub/dispose trace stream."
     (register-section-subs!)
     (register-section-events!)
-    (rf/dispatch-sync [:button-deck/seed])
+    (rf/dispatch-sync [:standard-epochs/seed])
 
     ;; Mount A, change the arg (so TWO [:gt? N] entries accumulate), then
     ;; unmount — the full set must dispose.
@@ -254,11 +254,11 @@
           held-10 (mount-a! 10)
           _       (do @(:chain held-10) @(:gt held-10))]
       ;; Precondition: the whole accumulated read-set is cached.
-      (doseq [k [[:button-deck/chain-labelled]
-                 [:button-deck/chain-doubled]
-                 [:button-deck/chain-root]
-                 [:button-deck/greater-than? 5]
-                 [:button-deck/greater-than? 10]]]
+      (doseq [k [[:standard-epochs/chain-labelled]
+                 [:standard-epochs/chain-doubled]
+                 [:standard-epochs/chain-root]
+                 [:standard-epochs/greater-than? 5]
+                 [:standard-epochs/greater-than? 10]]]
         (is (cached? k) (str "precondition: " (pr-str k) " cached")))
 
       (with-trace-recorder! [disposes {:pred #(= :rf.sub/dispose (:operation %))}]
@@ -266,16 +266,16 @@
         ;; mounts (ref-count 2), so it disposes only on the LAST drop —
         ;; pinning the last-reader-gone invariant.
         (unmount-a! held-5)
-        (is (cached? [:button-deck/chain-labelled])
+        (is (cached? [:standard-epochs/chain-labelled])
             "chain L3 still cached after the first unmount — ref-count 2→1")
         (unmount-a! held-10)
 
         ;; Every slot A held is gone.
-        (doseq [k [[:button-deck/chain-labelled]
-                   [:button-deck/chain-doubled]
-                   [:button-deck/chain-root]
-                   [:button-deck/greater-than? 5]
-                   [:button-deck/greater-than? 10]]]
+        (doseq [k [[:standard-epochs/chain-labelled]
+                   [:standard-epochs/chain-doubled]
+                   [:standard-epochs/chain-root]
+                   [:standard-epochs/greater-than? 5]
+                   [:standard-epochs/greater-than? 10]]]
           (is (not (cached? k))
               (str (pr-str k) " disposed — last reader gone")))
         (is (empty? (sub-cache))
@@ -284,13 +284,13 @@
         ;; The unmount is RECORDED: a :rf.sub/dispose fired for each
         ;; evicted sub-id with the ref-count-drop reason.
         (let [ids (into #{} (map #(get-in % [:tags :rf.sub/id])) @disposes)]
-          (is (contains? ids :button-deck/chain-labelled)
+          (is (contains? ids :standard-epochs/chain-labelled)
               ":rf.sub/dispose recorded for the chain L3")
-          (is (contains? ids :button-deck/chain-doubled)
+          (is (contains? ids :standard-epochs/chain-doubled)
               ":rf.sub/dispose recorded for the chain L2")
-          (is (contains? ids :button-deck/chain-root)
+          (is (contains? ids :standard-epochs/chain-root)
               ":rf.sub/dispose recorded for the chain L1")
-          (is (contains? ids :button-deck/greater-than?)
+          (is (contains? ids :standard-epochs/greater-than?)
               ":rf.sub/dispose recorded for the arg-keyed sub"))
         (is (every? #(= :no-more-derefers (get-in % [:tags :rf.sub/reason]))
                     @disposes)
@@ -317,47 +317,47 @@
    render-cause attribution."
     (register-section-subs!)
     (register-section-events!)
-    (rf/dispatch-sync [:button-deck/seed])
+    (rf/dispatch-sync [:standard-epochs/seed])
 
     ;; Child A — subscription-driven. Derefs the chain leaf.
-    (rf/reg-view ^{:rf/id :button-deck/child-a} child-a [_threshold]
-      [:div @(rf/subscribe [:button-deck/chain-labelled])])
+    (rf/reg-view ^{:rf/id :standard-epochs/child-a} child-a [_threshold]
+      [:div @(rf/subscribe [:standard-epochs/chain-labelled])])
 
     ;; Child B — props-driven. Subscribes nothing; renders its prop.
-    (rf/reg-view ^{:rf/id :button-deck/child-b} child-b [prop]
+    (rf/reg-view ^{:rf/id :standard-epochs/child-b} child-b [prop]
       [:div prop])
 
     (with-trace-recorder! [traces {:pred view-rendered-pred}]
       ;; A renders INSIDE the perturb cascade: the handler bumps the
       ;; chain root (its first recompute reports value-changed? into the
       ;; in-flight buffer), then A renders and its deref-sink records
-      ;; [:button-deck/chain-labelled]. The intersection resolves
+      ;; [:standard-epochs/chain-labelled]. The intersection resolves
       ;; :triggered-by to A's own changed sub.
-      (let [render-a (rf/view :button-deck/child-a)]
-        (rf/reg-event-fx :button-deck/perturb-then-render-a
+      (let [render-a (rf/view :standard-epochs/child-a)]
+        (rf/reg-event-fx :standard-epochs/perturb-then-render-a
           (fn [_ _]
-            @(rf/subscribe [:button-deck/chain-labelled])
+            @(rf/subscribe [:standard-epochs/chain-labelled])
             (render-a 5)
             {}))
-        (rf/dispatch-sync [:button-deck/perturb-then-render-a]))
+        (rf/dispatch-sync [:standard-epochs/perturb-then-render-a]))
 
       ;; B renders INSIDE a cascade too, but reads NO sub. Its render
       ;; is driven by the prop it was handed.
-      (let [render-b (rf/view :button-deck/child-b)]
-        (rf/reg-event-fx :button-deck/render-b
+      (let [render-b (rf/view :standard-epochs/child-b)]
+        (rf/reg-event-fx :standard-epochs/render-b
           (fn [_ _]
             (render-b "beta")
             {}))
-        (rf/dispatch-sync [:button-deck/render-b]))
+        (rf/dispatch-sync [:standard-epochs/render-b]))
 
-      (let [a-ev (first (filter #(= :button-deck/child-a
+      (let [a-ev (first (filter #(= :standard-epochs/child-a
                                     (get-in % [:tags :rf.view/id]))
                                 @traces))
-            b-ev (first (filter #(= :button-deck/child-b
+            b-ev (first (filter #(= :standard-epochs/child-b
                                     (get-in % [:tags :rf.view/id]))
                                 @traces))]
         (is (some? a-ev) "Child A emitted :rf.view/rendered")
-        (is (= :button-deck/chain-labelled
+        (is (= :standard-epochs/chain-labelled
                (get-in a-ev [:tags :rf.view/triggered-by]))
             "A re-render is attributed to its own changed sub (sub-driven)")
 

--- a/implementation/core/src/re_frame/core_reg_view_macro.cljc
+++ b/implementation/core/src/re_frame/core_reg_view_macro.cljc
@@ -95,7 +95,7 @@
            ;; Per rf2-quir9: the CLJS analyzer's indexing reader stamps
            ;; `:file` / `:line` / `:column` (+ `:source` / `:end-*`) onto
            ;; the view SYMBOL, and that `:file` is CLASSPATH-RELATIVE
-           ;; (`"button_deck/core.cljs"`). If we let those ride into the
+           ;; (`"standard_epochs/core.cljs"`). If we let those ride into the
            ;; registry slot they become `user-meta` in
            ;; `source-coords/merge-coords`, where user keys WIN over the
            ;; pending coords — so the relative reader `:file` clobbers the

--- a/implementation/core/test/re_frame/source_coords_test.clj
+++ b/implementation/core/test/re_frame/source_coords_test.clj
@@ -333,12 +333,12 @@
   indexing reader produces."
     (let [reader-sym (with-meta 'child-view
                        {:source 'child-view
-                        :file   "button_deck/core.cljs"   ;; RELATIVE — the trap
+                        :file   "standard_epochs/core.cljs"   ;; RELATIVE — the trap
                         :line   1 :column 11
                         :end-line 1 :end-column 21
                         :doc    "a real slot-meta key — must survive"})
-          exp        (rvm/expand-reg-view {:line 1 :column 1 :file "button_deck/core.cljs"}
-                                          'button-deck.core "button_deck/core.cljs"
+          exp        (rvm/expand-reg-view {:line 1 :column 1 :file "standard_epochs/core.cljs"}
+                                          'standard-epochs.core "standard_epochs/core.cljs"
                                           reader-sym '([] [:div]))
           ;; expansion: (do (binding [...] (reg-view* id slot-meta fn)) (def ...) id)
           binding-form (nth exp 1)

--- a/implementation/epoch/test/re_frame/epoch_attribution_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_attribution_test.clj
@@ -813,7 +813,7 @@
 ;;                cross-frame / observer sibling of inv-3)
 ;; ===========================================================================
 ;;
-;; The LIVE repro (build :examples/button-deck): the :rf/default boot epoch's
+;; The LIVE repro (build :examples/standard-epochs): the :rf/default boot epoch's
 ;; :renders carried ["shell-view" 27] (mount + update) — Xray's OWN shell-view,
 ;; the observer, leaking into the observed app's render tape. Root cause:
 ;; `shell-view` is a `reg-view` (its :rf.view/rendered carries

--- a/implementation/scripts/dev-testbed.cjs
+++ b/implementation/scripts/dev-testbed.cjs
@@ -19,7 +19,7 @@
  *
  * Usage:
  *
- *   npm run dev -- :examples/button-deck
+ *   npm run dev -- :examples/standard-epochs
  *   npm run dev -- :testbeds/panel-gallery
  *   npm run dev -- :examples/counter-with-stories :examples/login-form
  *
@@ -38,7 +38,7 @@ const builds = process.argv.slice(2);
 if (builds.length === 0) {
   console.error(
     'Usage: npm run dev -- <build> [<build>...]\n' +
-      '  e.g. npm run dev -- :examples/button-deck',
+      '  e.g. npm run dev -- :examples/standard-epochs',
   );
   process.exit(1);
 }

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -241,14 +241,16 @@
             ;; per the same cascade as :testbeds/panel-gallery above.
             8030 ["../tools/xray/testbeds/two_frame_isolation"
                   "out/examples/two-frame-isolation"]
-            ;; Single-frame button-deck testbed (rf2-gsr6z) — the
-            ;; deliberately simple Xray driving surface that superseded
-            ;; the old step-deck. Source dir first so the hand-written
-            ;; index.html resolves at `/`; the compiled main.js falls
-            ;; through to out/examples/button-deck per the same cascade
-            ;; as the entries above.
-            8031 ["../tools/xray/testbeds/button_deck"
-                  "out/examples/button-deck"]}
+            ;; Single-frame standard-epochs testbed (rf2-gsr6z; renamed
+            ;; per rf2-zthnj) — the deliberately simple Xray driving
+            ;; surface that superseded the old step-deck.
+            ;; Source dir first so the hand-written index.html resolves at
+            ;; `/`; the compiled main.js falls through to
+            ;; out/examples/standard-epochs per the same cascade as the
+            ;; entries above. Port 8031 is the trio anchor: routes_epochs
+            ;; takes 8032, machine_epochs 8033.
+            8031 ["../tools/xray/testbeds/standard_epochs"
+                  "out/examples/standard-epochs"]}
 
  :builds
  {:node-test
@@ -600,7 +602,7 @@
   ;; testdeck/) — Counter / Machine / Routing / Async&errors tabs
   ;; navigated AS ROUTES. This testbed is now the sole consumer of the
   ;; shared testdeck.* modules; it covers the multi-frame isolation +
-  ;; routing surface the deliberately-simple single-frame button-deck
+  ;; routing surface the deliberately-simple single-frame standard-epochs
   ;; (rf2-gsr6z) intentionally drops. Both frames are registered
   ;; :url-bound? false (Spec 012 §Multi-frame routing) so per-frame tab
   ;; nav does not fight over the single browser URL. No deliberate bugs,
@@ -627,31 +629,34 @@
    :devtools         {:preloads [re-frame2-pair.runtime
                                  day8.re-frame2-xray.preload]}}
 
-  ;; Single-frame button-deck testbed (rf2-gsr6z) — the deliberately
-  ;; simple Xray driving surface that SUPERSEDES the old step-deck. A
-  ;; tall column of numbered buttons in ONE plainly-mounted frame; each
-  ;; button bumps a shared baseline counter and exercises exactly one
-  ;; more feature, so clicking top-to-bottom completely exercises any one
-  ;; Xray panel (Epoch / App-db / Views / Trace / Issues). No tabs, no
-  ;; URL machinery, no machines / routes / SSR. A TEST surface — no
-  ;; deliberate bugs, no teaching layers (feedback_testbeds_are_test_surfaces).
+  ;; Single-frame standard-epochs testbed (rf2-gsr6z; renamed per
+  ;; rf2-zthnj) — the deliberately simple Xray driving surface that
+  ;; SUPERSEDES the old step-deck. A tall column of numbered
+  ;; buttons in ONE plainly-mounted frame; each button bumps a shared
+  ;; baseline counter and exercises exactly one more feature, so clicking
+  ;; top-to-bottom completely exercises any one Xray panel (Epoch / App-db
+  ;; / Views / Trace / Issues). No tabs, no URL machinery, no machines /
+  ;; routes / SSR. A TEST surface — no deliberate bugs, no teaching layers
+  ;; (feedback_testbeds_are_test_surfaces).
   ;;
-  ;; The events / subs / views are OWNED in button_deck/core.cljs — it
+  ;; The events / subs / views are OWNED in standard_epochs/core.cljs — it
   ;; does NOT reuse the shared testdeck.* modules (those still back the
   ;; two-frame-isolation testbed for the multi-frame + routing surface).
-  ;; Sources live under tools/xray/testbeds/button_deck/; the Xray
+  ;; Sources live under tools/xray/testbeds/standard_epochs/; the Xray
   ;; preload auto-mounts inline so every lens reads the single frame.
   ;; Served at http://localhost:8031 via the top-level `:dev-http` map.
-  :examples/button-deck
+  ;; This is the anchor of the _epochs trio (routes_epochs on 8032,
+  ;; machine_epochs on 8033 mirror this build-id scheme).
+  :examples/standard-epochs
   {:target           :browser
-   :output-dir       "out/examples/button-deck"
+   :output-dir       "out/examples/standard-epochs"
    :asset-path       "."
    ;; rf2-5dphw — build-env project-root for open-in-editor (see
    ;; :examples/two-frame-isolation above for the mechanism).
    :compiler-options {:closure-defines
                       {re-frame.testbed.config/repo-root
                        #shadow/env ["RF2_TESTBED_PROJECT_ROOT" ""]}}
-   :modules          {:main {:init-fn button-deck.core/run}}
+   :modules          {:main {:init-fn standard-epochs.core/run}}
    :devtools         {:preloads [re-frame2-pair.runtime
                                  day8.re-frame2-xray.preload]}}
 

--- a/tools/testbed-support/src/re_frame/testbed/config.cljs
+++ b/tools/testbed-support/src/re_frame/testbed/config.cljs
@@ -5,7 +5,7 @@
 
   ## Why this exists
 
-  Xray and Story turn a source-coord (`button_deck/core.cljs:42`) into an
+  Xray and Story turn a source-coord (`standard_epochs/core.cljs:42`) into an
   editor URI by prepending an on-disk *project-root*. SHIPPED code reads
   that root from host config (`xray-config/configure!` /
   `story/configure!`); there is no baked default. But the dev testbeds

--- a/tools/xray/README.md
+++ b/tools/xray/README.md
@@ -264,13 +264,13 @@ coverage matrix at [`spec/017-Test-Coverage-Matrix.md`](./spec/017-Test-Coverage
 reports `covered` across every row at the unit/helper/view tier.
 
 Browser testbeds live under `tools/xray/testbeds/` —
-`two_frame_isolation`, `button_deck`, `feature_matrix`, `panel_gallery`,
+`two_frame_isolation`, `standard_epochs`, `feature_matrix`, `panel_gallery`,
 `perf_counter` — covering the canonical multi-frame isolation surface
 (`two_frame_isolation`: one app · two frames · Counter / Machine
 (websocket) / Routing / Async&errors tabs navigated as routes ·
 per-frame trace / events / issues / cascades · Xray target-frame
 round-trip; built from the shared `testdeck/` modules), the
-deliberately-simple single-frame driving surface (`button_deck`,
+deliberately-simple single-frame driving surface (`standard_epochs`,
 rf2-gsr6z: one frame · a tall column of numbered buttons, each bumping
 a shared baseline counter + exercising exactly one more feature, so
 clicking top-to-bottom completely exercises any one Xray panel —

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1849,7 +1849,7 @@ into a single canonical home at
   SUB-ID off `(rf/handler-meta :sub <sub-id>)` via the `sub-input-signals`
   helper (parity with the `sub-coord` lookup, which also keys by sub-id).
   `:input-signals` is registered on the sub-id, so every parameterized
-  instance (`[:button-deck/greater-than? 5]`) shows its REAL input sub
+  instance (`[:standard-epochs/greater-than? 5]`) shows its REAL input sub
   (`chain-root`) regardless of whether it re-ran inside a cascade this
   epoch. Each input sub-id paints through `edn-inspector/mini`. The
   `app-db` label renders ONLY for a genuine Level-1 reader (empty
@@ -2069,7 +2069,7 @@ and silently rendered empty rows. The binding inventory:
 | `:handler` machine cascade (rf2-u69j7) | `:rf.machine/guard-evaluated` · `:rf.machine/action-ran` · `:rf.machine/transition` · `:rf.machine.timer/cancelled` (closed set: `machine-cascade-trace-ops`) | guard rows read `:guard-id`, `:outcome` (closed set `:pass / :fail / :threw` — rf2-82a0u); action rows read `:action-id`, `:phase` (closed set `:exit / :transition / :entry / :always / :after-action / :initial-entry / :destroy-exit` — rf2-82a0u), `:outcome` (rich map; `:fx` + `:data` hoisted onto the row), `:input`, `:exception`; transition rows read `:machine-id`, `:event`, `:before`, `:after`, `:microsteps` (state vectors hoisted off `:before`/`:after`); timer rows read `:state`, `:delay`, `:reason` (closed set `:on-exit / :on-destroy / :on-resolution / :on-supersede / :on-frame-destroy` — rf2-82a0u). Source-coord lookup reads `(rf/handler-meta :machine id) → :rf/machine → :rf.machine/source-coords` (rf2-8bp3), keyed by `[:actions <id>] | [:guards <id>]`. |
 | `:flow` | `:rf.flow/computed` (NOT `:rf.flow/recomputed` — rf2-yhgk8 aligned the read against `re-frame.flows`'s canonical emit) | `:flow-id`, `:path`, `:before`, `:result` (the view-side `:after` slot maps to the substrate's `:result`), `:elapsed-ms` |
 | `:fx` | `:rf.fx/handled` / `:rf.fx/override-applied` / `:rf.fx/skipped-on-platform` | `:rf.fx/id`, `:rf.fx/args`, `:rf.fx/elapsed-ms` (rf2-ipaza aligned the duration read against the substrate's canonical name) |
-| `:subscriptions` | `:rf.sub/run` / `:rf.sub/skip` | `:rf.sub/id`, `:rf.sub/query-v`, `:rf.sub/value-changed?`, `:rf.sub/prev-value`, `:rf.sub/value`, `:rf.sub/cascade?`, `:rf.sub/cause-sub`, `:rf.sub/elapsed-ms` (rf2-kfh1v aligned the reads against these). **`inputs` column source (rf2-87c8a):** the column is NOT trace-sourced — the view resolves the sub's STATIC input topology via `(rf/handler-meta :sub <sub-id>) → :input-signals` keyed by the SUB-ID (first element of the query-v), so every parameterized instance `[:sub-id arg…]` shows its REAL input sub. `app-db` is the label only for a genuine Level-1 reader (`:input-signals` empty). The `:rf.sub/cause-sub` cascade attribution feeds the `caused by <event-id>` chrome (rf2-1cc03), not the `inputs` column — pre-rf2-87c8a the projection's `:inputs` slot sourced from `:rf.sub/cause-sub`, which was OMITTED outside an in-flight cascade and so mislabeled fresh-run derived/parameterized subs (`[:button-deck/greater-than? 5]`) as `app-db`. |
+| `:subscriptions` | `:rf.sub/run` / `:rf.sub/skip` | `:rf.sub/id`, `:rf.sub/query-v`, `:rf.sub/value-changed?`, `:rf.sub/prev-value`, `:rf.sub/value`, `:rf.sub/cascade?`, `:rf.sub/cause-sub`, `:rf.sub/elapsed-ms` (rf2-kfh1v aligned the reads against these). **`inputs` column source (rf2-87c8a):** the column is NOT trace-sourced — the view resolves the sub's STATIC input topology via `(rf/handler-meta :sub <sub-id>) → :input-signals` keyed by the SUB-ID (first element of the query-v), so every parameterized instance `[:sub-id arg…]` shows its REAL input sub. `app-db` is the label only for a genuine Level-1 reader (`:input-signals` empty). The `:rf.sub/cause-sub` cascade attribution feeds the `caused by <event-id>` chrome (rf2-1cc03), not the `inputs` column — pre-rf2-87c8a the projection's `:inputs` slot sourced from `:rf.sub/cause-sub`, which was OMITTED outside an in-flight cascade and so mislabeled fresh-run derived/parameterized subs (`[:standard-epochs/greater-than? 5]`) as `app-db`. |
 | `:subscriptions` disposed (rf2-wpfjo) | `:rf.sub/dispose` (emitted by `re-frame.subs.cache/emit-dispose!` per rf2-mrnur — every cache eviction site funnels through ONE emit shape) | `:rf.sub/id`, `:rf.sub/query-v`, `:rf.sub/reason` (closed set `:no-more-derefers / :hot-reload / :cache-clear`), `:frame`. Surfaced via `projection/disposed-subs-rows`; the SUBSCRIPTIONS step carries an optional `:disposed-rows` slot (omit-by-absence). The step renders a DISPOSED sub-section when populated and reads `N recomputed (...); L disposed` in its header. A dispose-only cascade (no run/skip) still renders the step. |
 | `:views` | `:rf.view/rendered` (NOT the simpler `:rf.view/render` marker) | `:rf.view/id`, `:rf.view/deref-subs`, `:rf.view/elapsed-ms`, `:rf.view/mount?`, `:rf.view/triggered-by` (rf2-6djth aligned the read against the rich marker). The projection derives a `:cause` slot per row (rf2-bhi3t) from `:rf.view/mount?` + `:rf.view/triggered-by` — `:mount` (first render) / `{:kind :sub :sub-id <id>}` (a deref'd sub changed value) / `:props` (a re-render with no own sub change → the orthogonal `:rf/props` channel). The VIEWS table paints it as a `← :sub-id` / `← props` chip; no substrate/instrumentation change — fully tool-side inference. |
 | `:views` unmounted (rf2-gmw1i) | `:rf.view/unmounted` (already emitted by `re-frame.views/emit-view-unmounted!` per rf2-9hoos + rf2-te71r) | `:rf.view/id`, `:rf.view/render-key`, `:frame`. Surfaced via `projection/unmounted-views-rows`; the VIEWS step carries an optional `:unmounted-rows` slot (omit-by-absence when none fired). The step renders an UNMOUNTED sub-section when populated and reads `N re-rendered; M unmounted` in its header. |
@@ -2327,7 +2327,7 @@ Issues panel only.
 > EXCEPTION (distinct from a schema VIOLATION) leaves a
 > `:rf.error/*` cascade trace but, pre-rf2-ahhgn, surfaced
 > NOWHERE in the Epoch panel — the cascade rendered as if it ran
-> clean. Clicking button-15 (`:button-deck/throw-handler`) showed
+> clean. Clicking button-15 (`:standard-epochs/throw-handler`) showed
 > nothing explaining the failure, and the framework epoch
 > `:outcome` read `:ok`. This section adds inline per-step error
 > cards + a per-step pass/fail glyph + a tool-side outcome so a
@@ -2439,7 +2439,7 @@ carrying:
    so nothing committed and nothing reverted (rf2-wnvid fix);
 2. a one-line human headline derived from the OP (`error-block-label`),
    naming the TRUE failing component (rf2-mszrz attribution): "The
-   :button-deck/throwing-cofx coeffect threw during injection." / "The
+   :standard-epochs/throwing-cofx coeffect threw during injection." / "The
    :app/auth interceptor threw on the way in (:before)." / "The event
    handler threw." / "The :http/post effect threw." / "A flow's
    computation threw." Pre-mszrz the router routed handler / interceptor /

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -935,7 +935,7 @@
      installed a `:db` from the handler.
 
   FALSE when the handler returned NO `:db` — INCLUDING the
-  handler-threw case (button-15 `:button-deck/throw-handler`: the
+  handler-threw case (button-15 `:standard-epochs/throw-handler`: the
   handler threw before returning, db-before == db-after, no t1, no
   db-changed). The HANDLER step's `:db` sub-section keys off this to
   show 'no :db (handler threw / returned no :db)' rather than falling

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -3455,7 +3455,7 @@
   projection sources purely from `:rf.sub/cause-sub` (the cascade
   attribution — which upstream sub's value-change drove THIS re-run).
   That tag is OMITTED outside an in-flight cascade, so any derived sub
-  that ran fresh (e.g. the parameterized `[:button-deck/greater-than? 5]`
+  that ran fresh (e.g. the parameterized `[:standard-epochs/greater-than? 5]`
   on first mount) fell through to the `app-db` fallback and was mislabeled
   a Level-1 reader. The cascade attribution still surfaces — via the
   `caused by <event-id>` chrome (rf2-1cc03) — it is just no longer the

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -962,8 +962,8 @@
 
 ;; ---- t1 / t2 db attribution (rf2-4wywy) ---------------------------------
 ;;
-;; button-deck button 5 (`:button-deck/increment-flow`): the handler bumps
-;; `:base`; the `:button-deck/derived` flow then recomputes `:derived =
+;; standard-epochs button 5 (`:standard-epochs/increment-flow`): the handler bumps
+;; `:base`; the `:standard-epochs/derived` flow then recomputes `:derived =
 ;; 2 × :base` into app-db AFTER the handler. The HANDLER step's `:db` must
 ;; reflect ONLY the handler's change (`:base` bumped, NO `:derived`); the
 ;; FLOW step must show the flow's OWN contribution (`:derived` recomputed)
@@ -996,13 +996,13 @@
             the authoritative HANDLER `:db`."
     (let [t1     {:base 2 :baseline 1 :derived 2}  ; post-handler: :base/:baseline bumped, :derived UNTOUCHED (still 2)
           t2     {:base 2 :baseline 1 :derived 4}  ; post-flow: :derived recomputed 2 → 4
-          record {:event-id     :button-deck/increment-flow
+          record {:event-id     :standard-epochs/increment-flow
                   :db-before    {:base 1 :baseline 0 :derived 2}
                   ;; the record's :db-after is the FINAL post-flow state
                   :db-after     t2
-                  :trace-events [(dispatched-ev [:button-deck/increment-flow])
+                  :trace-events [(dispatched-ev [:standard-epochs/increment-flow])
                                  (db-pending-ev t1)
-                                 (flow-recomputed-ev :button-deck/derived [:derived] 2 4)
+                                 (flow-recomputed-ev :standard-epochs/derived [:derived] 2 4)
                                  (db-pending-post-flow-ev t2)
                                  (run-end-ev 0.3)]}
           steps  (proj/project record)
@@ -1029,19 +1029,19 @@
             handler's change."
     (let [t1     {:base 2 :baseline 1 :derived 2}  ; pre-flow: :derived still 2
           t2     {:base 2 :baseline 1 :derived 4}  ; post-flow: :derived recomputed
-          record {:event-id     :button-deck/increment-flow
+          record {:event-id     :standard-epochs/increment-flow
                   :db-before    {:base 1 :baseline 0 :derived 2}
                   :db-after     t2
-                  :trace-events [(dispatched-ev [:button-deck/increment-flow])
+                  :trace-events [(dispatched-ev [:standard-epochs/increment-flow])
                                  (db-pending-ev t1)
-                                 (flow-recomputed-ev :button-deck/derived [:derived] 2 4)
+                                 (flow-recomputed-ev :standard-epochs/derived [:derived] 2 4)
                                  (db-pending-post-flow-ev t2)
                                  (run-end-ev 0.3)]}
           steps  (proj/project record)
           flows  (filter #(= :flow (:step %)) steps)
           f      (first flows)]
       (is (= 1 (count flows)) "one FLOW step for the single recompute")
-      (is (= :button-deck/derived (:flow-id f)))
+      (is (= :standard-epochs/derived (:flow-id f)))
       (is (= [:derived] (:path f)))
       (is (= t1 (:db-pre-flow f))
           "FLOW step carries t1 (pre-flow) so the view diff's `:before` =
@@ -2216,7 +2216,7 @@
 
 ;; ---- rf2-ahhgn — inline exception attachment + per-step status ----------
 ;;
-;; The live button-15 (`:button-deck/throw-handler`) scenario: the handler
+;; The live button-15 (`:standard-epochs/throw-handler`) scenario: the handler
 ;; threw, the router caught it (db rolled back), the epoch settled with the
 ;; framework `:outcome :ok` (by spec — the reference runtime recovers + does
 ;; NOT emit `:halted-handler-exception`) and a `:rf.error/handler-exception`
@@ -2231,17 +2231,17 @@
             the wrong key) and the source-coord off the hoisted
             `:rf.trace/trigger-handler :source-coord`"
     (let [ev  (handler-exception-ev
-                :button-deck/throw-handler
-                "button-deck / handler (intentional — exercises the handler error surface)"
-                {:file "button_deck/core.cljs" :line 322})
+                :standard-epochs/throw-handler
+                "standard-epochs / handler (intentional — exercises the handler error surface)"
+                {:file "standard_epochs/core.cljs" :line 322})
           row (proj/exception-row ev)]
       (is (= :rf.error/handler-exception (:operation row)))
-      (is (= "button-deck / handler (intentional — exercises the handler error surface)"
+      (is (= "standard-epochs / handler (intentional — exercises the handler error surface)"
              (:message row))
           "message resolves through :exception-message")
-      (is (= {:file "button_deck/core.cljs" :line 322} (:coord row))
+      (is (= {:file "standard_epochs/core.cljs" :line 322} (:coord row))
           "coord resolves through :rf.trace/trigger-handler :source-coord")
-      (is (= :button-deck/throw-handler (:failing-id row)))
+      (is (= :standard-epochs/throw-handler (:failing-id row)))
       (is (= :no-recovery (:recovery row)))))
 
   (testing "rf2-ahhgn — falls back to `:reason` for the message + nil-safe
@@ -2275,8 +2275,8 @@
   (testing "rf2-wnvid — FALSE for the handler-threw shape (button-15: no
             t1, no db-changed — handler threw before returning a :db)"
     (is (false? (proj/handler-wrote-db?
-                  [(dispatched-ev [:button-deck/throw-handler] :ui nil)
-                   (handler-exception-ev :button-deck/throw-handler "boom" nil)
+                  [(dispatched-ev [:standard-epochs/throw-handler] :ui nil)
+                   (handler-exception-ev :standard-epochs/throw-handler "boom" nil)
                    (run-end-ev 1)]))))
   (testing "rf2-wnvid — FALSE for a reg-event-fx that returned only :fx"
     (is (false? (proj/handler-wrote-db?
@@ -2288,10 +2288,10 @@
             `:db` sub-section chooses the no-write placeholder over the
             phantom full-app-db fallback"
     (let [threw (proj/handler-row
-                  [(dispatched-ev [:button-deck/throw-handler] :ui nil)
-                   (handler-exception-ev :button-deck/throw-handler "boom" nil)
+                  [(dispatched-ev [:standard-epochs/throw-handler] :ui nil)
+                   (handler-exception-ev :standard-epochs/throw-handler "boom" nil)
                    (run-end-ev 1)]
-                  :button-deck/throw-handler
+                  :standard-epochs/throw-handler
                   {:n 1} {:n 1})]
       (is (false? (:db-write? threw))
           "handler that threw before returning a :db → db-write? false"))
@@ -2391,13 +2391,13 @@
             trace under `:trace-events` surfaces on the HANDLER step inline
             (message + coord) AND the projected cascade reads `:error`. The
             handler step also carries `:status :error` so the view paints ✗."
-    (let [rec   (record [(dispatched-ev [:button-deck/throw-handler] :ui
+    (let [rec   (record [(dispatched-ev [:standard-epochs/throw-handler] :ui
                                         {:file "core.cljs" :line 481})
                          (handler-exception-ev
-                           :button-deck/throw-handler
-                           "button-deck / handler (intentional — exercises the handler error surface)"
-                           {:file "button_deck/core.cljs" :line 322})]
-                        :button-deck/throw-handler)
+                           :standard-epochs/throw-handler
+                           "standard-epochs / handler (intentional — exercises the handler error surface)"
+                           {:file "standard_epochs/core.cljs" :line 322})]
+                        :standard-epochs/throw-handler)
           steps   (proj/project rec)
           handler (some #(when (= :handler (:step %)) %) steps)]
       (is (some? handler))
@@ -2408,9 +2408,9 @@
       (is (= 1 (count (:errors handler)))
           "the handler-exception attached as an inline error")
       (let [err (first (:errors handler))]
-        (is (= "button-deck / handler (intentional — exercises the handler error surface)"
+        (is (= "standard-epochs / handler (intentional — exercises the handler error surface)"
                (:message err)))
-        (is (= {:file "button_deck/core.cljs" :line 322} (:coord err)))
+        (is (= {:file "standard_epochs/core.cljs" :line 322} (:coord err)))
         ;; rf2-wnvid — the live button-15 had NO :db commit (handler
         ;; threw before returning), so the exception row's cascade-level
         ;; `:db-committed?` is false → the view omits the spurious
@@ -2484,15 +2484,15 @@
   (testing "rf2-yz57h — a coeffect-exception with NO matching :rf.cofx/run
             synthesises a placeholder COEFFECT step (no value), carries the
             exception, and marks the HANDLER + SIDE EFFECTS skipped"
-    (let [rec   (record [(dispatched-ev [:button-deck/throw-cofx] :ui nil)
-                         (coeffect-exception-ev :button-deck/throwing-cofx
+    (let [rec   (record [(dispatched-ev [:standard-epochs/throw-cofx] :ui nil)
+                         (coeffect-exception-ev :standard-epochs/throwing-cofx
                                                 "cofx boom")]
-                        :button-deck/throw-cofx)
+                        :standard-epochs/throw-cofx)
           steps (proj/project rec)
           cofx  (some #(when (= :coeffect (:step %)) %) steps)
           h     (some #(when (= :handler (:step %)) %) steps)]
       (is (some? cofx) "a COEFFECT step exists for the throwing cofx")
-      (is (= :button-deck/throwing-cofx (:id cofx)))
+      (is (= :standard-epochs/throwing-cofx (:id cofx)))
       (is (true? (:no-value? cofx)) "placeholder carries :no-value? (no resolved value)")
       (is (= 1 (count (:errors cofx))) "the exception lands under COEFFECT")
       (is (= :error (proj/step-status cofx)) "COEFFECT reads :error")
@@ -2537,11 +2537,11 @@
   (testing "rf2-yz57h — button-17 live scenario: a `:before` interceptor
             threw → INTERCEPTOR step present, carries the exception, HANDLER
             skipped"
-    (let [rec   (record [(dispatched-ev [:button-deck/throw-interceptor] :ui nil)
+    (let [rec   (record [(dispatched-ev [:standard-epochs/throw-interceptor] :ui nil)
                          (interceptor-exception-ev
-                           :button-deck/throwing-interceptor :before
+                           :standard-epochs/throwing-interceptor :before
                            "interceptor :before boom")]
-                        :button-deck/throw-interceptor)
+                        :standard-epochs/throw-interceptor)
           steps (proj/project rec)
           intc  (some #(when (= :interceptor (:step %)) %) steps)
           h     (some #(when (= :handler (:step %)) %) steps)]
@@ -2562,15 +2562,15 @@
   (testing "rf2-yz57h — button-18 live scenario: an `:after` interceptor
             threw → INTERCEPTOR step present, HANDLER NOT skipped (it ran
             first; the throw fired on the way out)"
-    (let [rec   (record [(dispatched-ev [:button-deck/throw-interceptor-after] :ui nil)
+    (let [rec   (record [(dispatched-ev [:standard-epochs/throw-interceptor-after] :ui nil)
                          ;; the handler ran + committed a :db on the way in
                          (db-pending-ev {:n 1})
                          (db-changed-ev [[[:n] 0 1 :modified]])
                          (run-end-ev 1)
                          (interceptor-exception-ev
-                           :button-deck/throwing-interceptor-after :after
+                           :standard-epochs/throwing-interceptor-after :after
                            "interceptor :after boom")]
-                        :button-deck/throw-interceptor-after)
+                        :standard-epochs/throw-interceptor-after)
           steps (proj/project rec)
           intc  (some #(when (= :interceptor (:step %)) %) steps)
           h     (some #(when (= :handler (:step %)) %) steps)]

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/real_substrate_projection_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/real_substrate_projection_cljs_test.cljs
@@ -142,7 +142,7 @@
 
 ;; ---- rf2-4wywy — live t1/t2 db attribution ------------------------------
 ;;
-;; button-deck button 5 shape: a reg-event-db handler bumps `:base`; a
+;; standard-epochs button 5 shape: a reg-event-db handler bumps `:base`; a
 ;; reg-flow recomputes `:derived = 2 × :base` into app-db AFTER the
 ;; handler. The fix relies on the router stamping `:rf.event/db-pending`
 ;; (t1, post-handler/pre-flow) + `:rf.event/db-pending-post-flow` (t2,

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -598,7 +598,7 @@
       (let [tree (rf/with-frame :rf/xray
                    (view/render-handler-step
                      {:step :handler :badge :HANDLER :step-number 3
-                      :flavour :reg-event-db :event-id :button-deck/throw-handler
+                      :flavour :reg-event-db :event-id :standard-epochs/throw-handler
                       :db-diff [] :db-write? false :fx [] :machine nil
                       :status :error
                       :errors [{:operation :rf.error/handler-exception
@@ -650,11 +650,11 @@
             before→after line. This is what keeps the flow's `:derived`
             recompute SEPARATE from the HANDLER step's `:db`."
     (frame/reg-frame :rf/xray {})
-    ;; testids embed `(name flow-id)` — `:button-deck/derived` → `derived`.
+    ;; testids embed `(name flow-id)` — `:standard-epochs/derived` → `derived`.
     (let [tree (rf/with-frame :rf/xray
                  (view/render-flow-step
                    {:step :flow :badge :FLOW :step-number 4
-                    :flow-id :button-deck/derived
+                    :flow-id :standard-epochs/derived
                     :path [:derived] :before 2 :after 4
                     :db-pre-flow  {:base 2 :baseline 1 :derived 2}
                     :db-post-flow {:base 2 :baseline 1 :derived 4}}))]
@@ -2390,8 +2390,8 @@
             and the verbatim message. The redundant jump-to-source link is
             DROPPED (rf2-wnvid — the HANDLER verb is the canonical link)."
     (let [row  {:operation :rf.error/handler-exception
-                :message "button-deck / handler (intentional — exercises the handler error surface)"
-                :failing-id :button-deck/throw-handler
+                :message "standard-epochs / handler (intentional — exercises the handler error surface)"
+                :failing-id :standard-epochs/throw-handler
                 :recovery :no-recovery
                 ;; a committed-then-rolled-back db → the chip is legitimate
                 :db-committed? true}
@@ -2420,7 +2420,7 @@
     (let [tree (view/error-block :handler 0
                  {:operation :rf.error/handler-exception
                   :message "boom" :phase :before
-                  :failing-id :button-deck/throw-handler})
+                  :failing-id :standard-epochs/throw-handler})
           head (text-of tree "rf-xray-epoch-error-handler-0-headline")]
       (is (string/includes? head "event handler threw"))
       (is (not (string/includes? head "interceptor"))
@@ -2479,13 +2479,13 @@
             an attached exception renders the inline error card AND the
             header's ✗ status glyph"
     (let [step {:step :handler :badge :HANDLER :step-number 3
-                :flavour :reg-event-db :event-id :button-deck/throw-handler
+                :flavour :reg-event-db :event-id :standard-epochs/throw-handler
                 :db-diff [] :fx [] :machine nil
                 :status :error
                 :errors [{:operation :rf.error/handler-exception
                           :message "boom in handler"
                           :coord {:file "core.cljs" :line 322}
-                          :failing-id :button-deck/throw-handler
+                          :failing-id :standard-epochs/throw-handler
                           :recovery :no-recovery}]}
           tree (view/render-handler-step step)]
       (is (some? (th/find-by-testid tree "rf-xray-epoch-error-handler-0"))
@@ -2522,10 +2522,10 @@
             at index 1 (compatible with yz57h's exception-under-step)."
     (let [step (side-effects-step
                  [{:fx-id :db :status :ok}
-                  {:fx-id :button-deck/ping :status :error
+                  {:fx-id :standard-epochs/ping :status :error
                    :errors [{:operation :rf.error/fx-handler-exception
                              :message "fx threw on purpose"
-                             :failing-id :button-deck/ping
+                             :failing-id :standard-epochs/ping
                              :recovery :no-recovery}]}]
                  1)
           tree (view/render-side-effects-step step)]
@@ -2554,11 +2554,11 @@
     (let [tree (rf/with-frame :rf/xray
                  (view/render-coeffect-step
                    {:step :coeffect :badge :COEFFECT :step-number 2
-                    :id :button-deck/throwing-cofx :no-value? true :threw? true
+                    :id :standard-epochs/throwing-cofx :no-value? true :threw? true
                     :status :error
                     :errors [{:operation :rf.error/coeffect-exception
                               :message "cofx threw on purpose"
-                              :failing-id :button-deck/throwing-cofx
+                              :failing-id :standard-epochs/throwing-cofx
                               :recovery :no-recovery}]}))]
       ;; the failed-injection body, NOT a `+ [id] value` diff line.
       ;; (testids key off `(name id)` — the namespace is stripped.)
@@ -2589,11 +2589,11 @@
                  (view/render-interceptor-step
                    {:step :interceptor :badge :INTERCEPTOR :step-number 3
                     :status :error
-                    :rows [{:interceptor-id :button-deck/throwing-interceptor
+                    :rows [{:interceptor-id :standard-epochs/throwing-interceptor
                             :phase :before}]
                     :errors [{:operation :rf.error/interceptor-exception
                               :message "interceptor :before boom"
-                              :failing-id :button-deck/throwing-interceptor
+                              :failing-id :standard-epochs/throwing-interceptor
                               :phase :before
                               :recovery :no-recovery}]}))]
       (is (some? (th/find-by-testid tree "rf-xray-epoch-step-interceptor"))
@@ -2641,7 +2641,7 @@
     (let [tree (rf/with-frame :rf/xray
                  (view/render-handler-step
                    {:step :handler :badge :HANDLER :step-number 4
-                    :flavour :reg-event-db :event-id :button-deck/throw-interceptor
+                    :flavour :reg-event-db :event-id :standard-epochs/throw-interceptor
                     :db-diff [] :db-write? true :fx [] :machine nil
                     :status :skipped}))]
       (is (some? (th/find-by-testid tree "rf-xray-epoch-handler-skipped"))

--- a/tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs
@@ -1193,7 +1193,7 @@
     (xray-setup!)
     ;; cascade 1 — clean. cascade 2 — carries an :rf.error/* trace.
     (trace-collector/seed-trace-for-test! (dispatch-trace-ev 1 [:cart/add-item]))
-    (trace-collector/seed-trace-for-test! (dispatch-trace-ev 2 [:button-deck/throw-handler]))
+    (trace-collector/seed-trace-for-test! (dispatch-trace-ev 2 [:standard-epochs/throw-handler]))
     (trace-collector/seed-trace-for-test! (error-trace-ev 2))
     (rf/with-frame :rf/xray
       (let [tree       (shell/shell-view)

--- a/tools/xray/testbeds/panel_gallery/core.cljs
+++ b/tools/xray/testbeds/panel_gallery/core.cljs
@@ -182,7 +182,7 @@
 ;; Per the rf2-5m5n2 contract Xray exposes `:rf.xray/project-root`. The
 ;; panel-gallery boots with its known on-disk repo position by default; a
 ;; `?project-root=<path>` query string overrides for cross-machine portability
-;; (mirroring the `button_deck` testbed's resolver).
+;; (mirroring the `standard_epochs` testbed's resolver).
 ;;
 ;; The URI build is invariant to the host page URL — `resolve-uri` reads the
 ;; configured root, not `window.location`. The query-param branch only

--- a/tools/xray/testbeds/standard_epochs/core.cljs
+++ b/tools/xray/testbeds/standard_epochs/core.cljs
@@ -1,5 +1,5 @@
-(ns button-deck.core
-  "BUTTON-DECK testbed (rf2-gsr6z) — a deliberately simple Xray driving
+(ns standard-epochs.core
+  "STANDARD-EPOCHS testbed (rf2-gsr6z) — a deliberately simple Xray driving
   surface that supersedes the step-deck.
 
   ## Shape
@@ -36,7 +36,7 @@
               writes a derived slot.
     Views   — two children make re-render CAUSES separable. Child A is
               SUBSCRIPTION-driven (an own L1→L2→L3 chain + the arg-keyed
-              `[:button-deck/greater-than? N]` sub); Child B is
+              `[:standard-epochs/greater-than? N]` sub); Child B is
               PROPS-driven (a prop, NO subs). #10 mount A (node + the
               sub-cache entries appear) · #11 change the arg N (a NEW
               [:gt? N] cache entry — cache keyed by arg) · #12 change a
@@ -110,7 +110,7 @@
 ;;
 ;;   :a-mounted? / :b-mounted?  — the two children's mount slots.
 ;;   :threshold                 — N, the changeable arg to the dynamic
-;;                                sub `[:button-deck/greater-than? N]`.
+;;                                sub `[:standard-epochs/greater-than? N]`.
 ;;   :chain-input               — the root of Child A's own L1→L2→L3
 ;;                                chain (button #12 perturbs it).
 ;;   :b-prop                    — the prop fed to the props-driven
@@ -127,7 +127,7 @@
               :chain-input 1
               :b-prop      "alpha"}})
 
-(rf/reg-event-db :button-deck/reset
+(rf/reg-event-db :standard-epochs/reset
   {:doc "Button 0 — re-seed app-db and unmount both child views. Start clean."}
   (fn handler-reset [_db _ev]
     initial-db))
@@ -155,26 +155,26 @@
 (rf/reg-app-schema [:auth] AuthSlice)
 
 ;; ============================================================================
-;; COEFFECT — :button-deck/now  (button #2)
+;; COEFFECT — :standard-epochs/now  (button #2)
 ;; ============================================================================
 ;;
 ;; A wall-clock injection point so the handler stays a pure fn of
 ;; (coeffects, event). Xray's Epoch event-detail shows this coeffect
 ;; feeding the handler.
 
-(rf/reg-cofx :button-deck/now
+(rf/reg-cofx :standard-epochs/now
   {:doc "Inject the current wall-clock time (ms since epoch) under
-         `:button-deck/now`."}
+         `:standard-epochs/now`."}
   (fn cofx-now [ctx]
-    (rf/assoc-coeffect ctx :button-deck/now (.getTime (js/Date.)))))
+    (rf/assoc-coeffect ctx :standard-epochs/now (.getTime (js/Date.)))))
 
 ;; A coeffect that throws on injection (button #19). A FEATURE being
 ;; exercised — the supported way to light up the cofx error surface.
-(rf/reg-cofx :button-deck/throwing-cofx
+(rf/reg-cofx :standard-epochs/throwing-cofx
   {:doc "Throws during coeffect injection so Xray's Issues lens surfaces
          a cofx error. A feature being exercised, not a buggy demo."}
   (fn cofx-throws [_ctx]
-    (throw (ex-info "button-deck / coeffect (intentional — exercises the cofx error surface)"
+    (throw (ex-info "standard-epochs / coeffect (intentional — exercises the cofx error surface)"
                     {:surface :coeffect-exception}))))
 
 ;; ============================================================================
@@ -192,9 +192,9 @@
 ;; Throws in :before — aborts before the handler runs (button #17).
 (def throwing-interceptor
   (rf/->interceptor
-    :id     :button-deck/throwing-interceptor
+    :id     :standard-epochs/throwing-interceptor
     :before (fn interceptor-before-throws [_ctx]
-              (throw (ex-info "button-deck / interceptor :before (intentional — exercises the interceptor :before error surface)"
+              (throw (ex-info "standard-epochs / interceptor :before (intentional — exercises the interceptor :before error surface)"
                               {:surface :interceptor-exception :phase :before})))))
 
 ;; Throws in :after — the handler runs to completion first, THEN this
@@ -206,9 +206,9 @@
 ;; exception (rf2-mszrz).
 (def throwing-interceptor-after
   (rf/->interceptor
-    :id    :button-deck/throwing-interceptor-after
+    :id    :standard-epochs/throwing-interceptor-after
     :after (fn interceptor-after-throws [_ctx]
-             (throw (ex-info "button-deck / interceptor :after (intentional — exercises the interceptor :after error surface)"
+             (throw (ex-info "standard-epochs / interceptor :after (intentional — exercises the interceptor :after error surface)"
                              {:surface :interceptor-exception :phase :after})))))
 
 ;; ============================================================================
@@ -218,7 +218,7 @@
 ;; A one-shot, instantaneous fx (button #3). Records its calls so the
 ;; effect genuinely runs; Xray's Trace / Effects show it fire this epoch.
 (defonce ping-log (atom []))
-(rf/reg-fx :button-deck/ping
+(rf/reg-fx :standard-epochs/ping
   (fn fx-ping [_ctx args]
     (swap! ping-log conj args)))
 
@@ -227,19 +227,19 @@
 ;; Spec 009's slow-effect threshold, so Xray's Issues lens flags it as a
 ;; (non-bug) slow effect; the status moves :loading -> :loaded.
 (def SLOW-MS 600)
-(rf/reg-fx :button-deck/slow-fetch
+(rf/reg-fx :standard-epochs/slow-fetch
   (fn fx-slow-fetch [{:keys [frame]} _args]
     (js/setTimeout
-      (fn [] (rf/dispatch [:button-deck/slow-done] {:frame frame}))
+      (fn [] (rf/dispatch [:standard-epochs/slow-done] {:frame frame}))
       SLOW-MS)))
 
 ;; An fx whose body throws (button #20). The handler's :db commits first;
 ;; the throw fires later, during the post-commit fx walk — best-effort
 ;; per the FX atomicity asymmetry — so Xray's Issues lens shows the fx
 ;; error while the baseline bump survives.
-(rf/reg-fx :button-deck/boom
+(rf/reg-fx :standard-epochs/boom
   (fn fx-boom [_ctx _args]
-    (throw (ex-info "button-deck / effect (intentional — exercises the fx error surface)"
+    (throw (ex-info "standard-epochs / effect (intentional — exercises the fx error surface)"
                     {:surface :effect-exception}))))
 
 ;; ============================================================================
@@ -251,7 +251,7 @@
 ;; and Trace shows the flow run.
 
 (rf/reg-flow
-  {:id     :button-deck/derived
+  {:id     :standard-epochs/derived
    :inputs [[:base]]
    :output (fn [base] (* 2 (or base 0)))
    :path   [:derived]
@@ -262,55 +262,55 @@
 ;; ============================================================================
 
 ;; -- 1. plain increment ------------------------------------------------------
-(rf/reg-event-db :button-deck/increment
+(rf/reg-event-db :standard-epochs/increment
   {:doc "Button 1 — a plain event. App-db :baseline ++ ; Epoch shows the
          event with db-before / db-after."}
   (fn handler-increment [db _ev] (bump db)))
 
 ;; -- 2. increment + coeffect -------------------------------------------------
-(rf/reg-event-fx :button-deck/increment-cofx
-  {:doc "Button 2 — inject the `:button-deck/now` cofx. Epoch's event
+(rf/reg-event-fx :standard-epochs/increment-cofx
+  {:doc "Button 2 — inject the `:standard-epochs/now` cofx. Epoch's event
          detail shows the coeffect feeding the handler."}
-  [(rf/inject-cofx :button-deck/now)]
-  (fn handler-increment-cofx [{:keys [db button-deck/now]} _ev]
+  [(rf/inject-cofx :standard-epochs/now)]
+  (fn handler-increment-cofx [{:keys [db standard-epochs/now]} _ev]
     {:db (-> db bump (assoc :last-clicked now))}))
 
 ;; -- 3. increment + effect ---------------------------------------------------
-(rf/reg-event-fx :button-deck/increment-fx
+(rf/reg-event-fx :standard-epochs/increment-fx
   {:doc "Button 3 — return a one-shot fx. Effects / Trace show
-         `:button-deck/ping` fire this epoch."}
+         `:standard-epochs/ping` fire this epoch."}
   (fn handler-increment-fx [{:keys [db]} _ev]
     {:db (bump db)
-     :fx [[:button-deck/ping {:at (.getTime (js/Date.))}]]}))
+     :fx [[:standard-epochs/ping {:at (.getTime (js/Date.))}]]}))
 
 ;; -- 4. increment + cascade --------------------------------------------------
-(rf/reg-event-fx :button-deck/increment-cascade
+(rf/reg-event-fx :standard-epochs/increment-cascade
   {:doc "Button 4 — dispatch a follow-on event. Epoch's dispatch-id tree
-         shows the cascade (this event → :button-deck/cascade-tail)."}
+         shows the cascade (this event → :standard-epochs/cascade-tail)."}
   (fn handler-increment-cascade [{:keys [db]} _ev]
     {:db (bump db)
-     :fx [[:dispatch [:button-deck/cascade-tail]]]}))
+     :fx [[:dispatch [:standard-epochs/cascade-tail]]]}))
 
-(rf/reg-event-db :button-deck/cascade-tail
+(rf/reg-event-db :standard-epochs/cascade-tail
   {:doc "The follow-on event dispatched by button 4. Bumps baseline again
          so the cascade has two epochs under one root dispatch-id."}
   (fn handler-cascade-tail [db _ev] (bump db)))
 
 ;; -- 5. increment + flow -----------------------------------------------------
-(rf/reg-event-db :button-deck/increment-flow
-  {:doc "Button 5 — perturb :base so the `:button-deck/derived` flow
+(rf/reg-event-db :standard-epochs/increment-flow
+  {:doc "Button 5 — perturb :base so the `:standard-epochs/derived` flow
          recomputes a derived slot into app-db; App-db / Trace show it."}
   (fn handler-increment-flow [db _ev]
     (-> db bump (update :base inc))))
 
 ;; -- 6. add a nested key (assoc-in) → App-db diff: added ---------------------
-(rf/reg-event-db :button-deck/add-key
+(rf/reg-event-db :standard-epochs/add-key
   {:doc "Button 6 — assoc-in a new nested key. App-db diff: added."}
   (fn handler-add-key [db _ev]
     (-> db bump (assoc-in [:shapes :added] {:label "added" :n 42}))))
 
 ;; -- 7. remove a key (dissoc) → App-db diff: removed -------------------------
-(rf/reg-event-db :button-deck/remove-key
+(rf/reg-event-db :standard-epochs/remove-key
   {:doc "Button 7 — dissoc a key. App-db diff: removed. (Adds a key first
          if absent so there is always something to remove.)"}
   (fn handler-remove-key [db _ev]
@@ -320,14 +320,14 @@
         (assoc-in db [:shapes :removed-marker] true)))))
 
 ;; -- 8. change a nested value (update-in) → App-db diff: changed -------------
-(rf/reg-event-db :button-deck/change-value
+(rf/reg-event-db :standard-epochs/change-value
   {:doc "Button 8 — update-in a nested value. App-db diff: changed
          (diff-mode-3 shows the in-place value delta)."}
   (fn handler-change-value [db _ev]
     (-> db bump (update-in [:shapes :counter] (fnil inc 0)))))
 
 ;; -- 9. write a large collection → edn-inspector collapse/expand + elision --
-(rf/reg-event-db :button-deck/write-large
+(rf/reg-event-db :standard-epochs/write-large
   {:doc "Button 9 — write a large collection. The edn-inspector
          collapses / expands it and elides past its threshold."}
   (fn handler-write-large [db _ev]
@@ -341,32 +341,32 @@
 ;; CAUSE — Child A re-renders ← a SUB changed (#12); Child B re-renders ←
 ;; PROPS changed (#15).
 
-(rf/reg-event-db :button-deck/mount-a
+(rf/reg-event-db :standard-epochs/mount-a
   {:doc "Button 10 — mount the SUBSCRIPTION-driven Child A (sets
          :views/a-mounted? true). On mount A subscribes its own
          L1→L2→L3 chain (:chain-root → :chain-doubled → :chain-labelled)
-         PLUS the arg-keyed `[:button-deck/greater-than? N]` sub — so
+         PLUS the arg-keyed `[:standard-epochs/greater-than? N]` sub — so
          Views shows the node and those sub-cache entries appear."}
   (fn handler-mount-a [db _ev]
     (-> db bump (assoc-in [:views :a-mounted?] true))))
 
-(rf/reg-event-db :button-deck/set-threshold
-  {:doc "Button 11 — change the sub-arg N (5 → 10). `[:button-deck/
+(rf/reg-event-db :standard-epochs/set-threshold
+  {:doc "Button 11 — change the sub-arg N (5 → 10). `[:standard-epochs/
          greater-than? N]` is keyed by its arg, so the new N is a NEW,
          distinct sub-cache entry alongside the old one."}
   (fn handler-set-threshold [db [_ n]]
     (-> db bump (assoc-in [:views :threshold] n))))
 
-(rf/reg-event-db :button-deck/perturb-chain
+(rf/reg-event-db :standard-epochs/perturb-chain
   {:doc "Button 12 — perturb Child A's chain input (:views/chain-input).
          With A mounted, Views shows the L1 (:chain-root) → L2
          (:chain-doubled) → L3 (:chain-labelled) invalidation recompute,
-         and A re-renders BECAUSE A SUB CHANGED (← :button-deck/chain-
+         and A re-renders BECAUSE A SUB CHANGED (← :standard-epochs/chain-
          labelled), not because its props changed."}
   (fn handler-perturb-chain [db _ev]
     (-> db bump (update-in [:views :chain-input] inc))))
 
-(rf/reg-event-db :button-deck/unmount-a
+(rf/reg-event-db :standard-epochs/unmount-a
   {:doc "Button 13 — unmount Child A (sets :views/a-mounted? false). The
          node disappears and ALL of A's subs are disposed once the last
          reader is gone (the chain L1/L2/L3 + every [:gt? N] cache
@@ -374,7 +374,7 @@
   (fn handler-unmount-a [db _ev]
     (-> db bump (assoc-in [:views :a-mounted?] false))))
 
-(rf/reg-event-db :button-deck/mount-b
+(rf/reg-event-db :standard-epochs/mount-b
   {:doc "Button 14 — mount the PROPS-driven Child B (sets
          :views/b-mounted? true). B receives a prop and subscribes
          NOTHING, so Views shows the node appear with NO new sub-cache
@@ -382,7 +382,7 @@
   (fn handler-mount-b [db _ev]
     (-> db bump (assoc-in [:views :b-mounted?] true))))
 
-(rf/reg-event-db :button-deck/set-b-prop
+(rf/reg-event-db :standard-epochs/set-b-prop
   {:doc "Button 15 — change Child B's prop. B re-renders BECAUSE ITS
          PROPS CHANGED (no sub cause) — the foil to button 12's
          sub-driven re-render."}
@@ -391,17 +391,17 @@
                            {"alpha" "beta" "beta" "gamma" "gamma" "alpha"}))))
 
 ;; -- 16. exception in the handler → Issues: handler-exception, db rolls back -
-(rf/reg-event-db :button-deck/throw-handler
+(rf/reg-event-db :standard-epochs/throw-handler
   {:doc "Button 16 — throw in the handler. The router catches it; the :db
          effect (the baseline bump) rolls back; Issues shows
          `:rf.error/handler-exception` with the source coord."}
   (fn handler-throw [db _ev]
     (bump db) ;; would bump, but the throw below aborts the commit
-    (throw (ex-info "button-deck / handler (intentional — exercises the handler error surface)"
+    (throw (ex-info "standard-epochs / handler (intentional — exercises the handler error surface)"
                     {:surface :handler-exception}))))
 
 ;; -- 17. exception in an interceptor :before → Issues: interceptor exc. ------
-(rf/reg-event-db :button-deck/throw-interceptor
+(rf/reg-event-db :standard-epochs/throw-interceptor
   {:doc "Button 17 — an interceptor throws in :before. The chain aborts on
          the way IN; Issues shows the interceptor :before exception and the
          handler never runs."}
@@ -409,7 +409,7 @@
   (fn handler-after-throwing-interceptor [db _ev] (bump db)))
 
 ;; -- 18. exception in an interceptor :after → Issues: interceptor exc. -------
-(rf/reg-event-db :button-deck/throw-interceptor-after
+(rf/reg-event-db :standard-epochs/throw-interceptor-after
   {:doc "Button 18 — an interceptor throws in :after. The foil to button
          17: the handler runs to completion (the :db is computed), THEN the
          interceptor throws on the way OUT. Issues shows the interceptor
@@ -419,46 +419,46 @@
   (fn handler-before-throwing-after-interceptor [db _ev] (bump db)))
 
 ;; -- 19. exception in a coeffect handler → Issues: cofx error ----------------
-(rf/reg-event-fx :button-deck/throw-cofx
+(rf/reg-event-fx :standard-epochs/throw-cofx
   {:doc "Button 19 — a coeffect throws on injection. Issues shows the
          cofx error; the handler never runs."}
-  [(rf/inject-cofx :button-deck/throwing-cofx)]
+  [(rf/inject-cofx :standard-epochs/throwing-cofx)]
   (fn handler-after-throwing-cofx [{:keys [db]} _ev] {:db (bump db)}))
 
 ;; -- 20. exception in an effect handler (post-commit) → Issues: fx error -----
-(rf/reg-event-fx :button-deck/throw-fx
+(rf/reg-event-fx :standard-epochs/throw-fx
   {:doc "Button 20 — the :db commits (baseline bumps), then a post-commit
          fx throws. Issues shows the fx error; post-commit fx are
          best-effort per the FX atomicity asymmetry, so the db delta
          survives."}
   (fn handler-throw-fx [{:keys [db]} _ev]
     {:db (bump db)
-     :fx [[:button-deck/boom {}]]}))
+     :fx [[:standard-epochs/boom {}]]}))
 
 ;; -- 21. slow effect (~600ms managed fx) → Issues: slow-fx flagged -----------
-(rf/reg-event-fx :button-deck/slow
+(rf/reg-event-fx :standard-epochs/slow
   {:doc "Button 21 — issue a ~600ms managed fx. Status moves :loading;
          Issues flags the slow fx; the reply lands :loaded ~600ms later."}
   (fn handler-slow [{:keys [db]} _ev]
     {:db (-> db bump (assoc :slow-status :loading))
-     :fx [[:button-deck/slow-fetch {}]]}))
+     :fx [[:standard-epochs/slow-fetch {}]]}))
 
-(rf/reg-event-db :button-deck/slow-done
+(rf/reg-event-db :standard-epochs/slow-done
   {:doc "The deferred reply from the slow fx. Lands on the originating
          frame and flips status to :loaded."}
   (fn handler-slow-done [db _ev]
     (assoc db :slow-status :loaded)))
 
 ;; -- 22. schema violation, bad event args → Issues / Schema-timeline ---------
-(rf/reg-event-db :button-deck/bad-event-args
+(rf/reg-event-db :standard-epochs/bad-event-args
   {:doc "Button 22 — dispatched with a bad arg (a string where a pos-int
          is required). The handler is skipped; Issues / Schema-timeline
          shows `:rf.error/schema-validation-failure :where :event`."
-   :schema [:cat [:= :button-deck/bad-event-args] pos-int?]}
+   :schema [:cat [:= :standard-epochs/bad-event-args] pos-int?]}
   (fn handler-bad-event-args [db _ev] (bump db)))
 
 ;; -- 23. schema violation, app-db write → Issues: app-db schema failure ------
-(rf/reg-event-db :button-deck/bad-app-db-write
+(rf/reg-event-db :standard-epochs/bad-app-db-write
   {:doc "Button 23 — write an int into [:auth :token] (the registered
          app-schema requires a string). The post-handler app-db
          validation rolls the :db back; Issues shows the app-db schema
@@ -471,34 +471,34 @@
 ;; ============================================================================
 
 ;; L1 — read app-db directly.
-(rf/reg-sub :button-deck/baseline    (fn [db _] (:baseline db)))
-(rf/reg-sub :button-deck/a-mounted?  (fn [db _] (get-in db [:views :a-mounted?])))
-(rf/reg-sub :button-deck/b-mounted?  (fn [db _] (get-in db [:views :b-mounted?])))
-(rf/reg-sub :button-deck/threshold   (fn [db _] (get-in db [:views :threshold])))
-(rf/reg-sub :button-deck/b-prop      (fn [db _] (get-in db [:views :b-prop])))
+(rf/reg-sub :standard-epochs/baseline    (fn [db _] (:baseline db)))
+(rf/reg-sub :standard-epochs/a-mounted?  (fn [db _] (get-in db [:views :a-mounted?])))
+(rf/reg-sub :standard-epochs/b-mounted?  (fn [db _] (get-in db [:views :b-mounted?])))
+(rf/reg-sub :standard-epochs/threshold   (fn [db _] (get-in db [:views :threshold])))
+(rf/reg-sub :standard-epochs/b-prop      (fn [db _] (get-in db [:views :b-prop])))
 
 ;; Child A's OWN L1 → L2 → L3 chain, rooted at :views/chain-input (NOT
 ;; :base — that feeds button #5's flow). Button #12 perturbs the root;
 ;; with A mounted, Views shows the L1 → L2 → L3 invalidation recompute.
-(rf/reg-sub :button-deck/chain-root            ;; L1
+(rf/reg-sub :standard-epochs/chain-root            ;; L1
   (fn [db _] (get-in db [:views :chain-input])))
 
-(rf/reg-sub :button-deck/chain-doubled         ;; L2
-  :<- [:button-deck/chain-root]
+(rf/reg-sub :standard-epochs/chain-doubled         ;; L2
+  :<- [:standard-epochs/chain-root]
   (fn [root _] (* 2 root)))
 
-(rf/reg-sub :button-deck/chain-labelled        ;; L3
-  :<- [:button-deck/chain-doubled]
+(rf/reg-sub :standard-epochs/chain-labelled        ;; L3
+  :<- [:standard-epochs/chain-doubled]
   (fn [doubled _] (str "2×input = " doubled)))
 
 ;; DYNAMIC, parameterised by the threshold N carried in the query
-;; vector: `[:button-deck/greater-than? n]`. It cascades from the chain
+;; vector: `[:standard-epochs/greater-than? n]`. It cascades from the chain
 ;; root (a section-owned value, so the sub's behaviour is NOT linked to
 ;; a counter value). A different n is a DISTINCT cache entry over the
 ;; same registration — button #11 (5 → 10) creates a new [:gt? 10]
 ;; entry alongside the original [:gt? 5].
-(rf/reg-sub :button-deck/greater-than?
-  :<- [:button-deck/chain-root]
+(rf/reg-sub :standard-epochs/greater-than?
+  :<- [:standard-epochs/chain-root]
   (fn [root [_ threshold]] (> root threshold)))
 
 ;; ============================================================================
@@ -512,7 +512,7 @@
 ;; --- Child A — subscription-driven -----------------------------------------
 ;;
 ;; On mount A subscribes its own L1→L2→L3 chain AND the arg-keyed
-;; `[:button-deck/greater-than? threshold]` sub — so the Views lens
+;; `[:standard-epochs/greater-than? threshold]` sub — so the Views lens
 ;; shows the node + those sub-cache entries appear, the chain recompute
 ;; (button #12), and a NEW [:gt? N] cache entry when the arg changes
 ;; (button #11). `threshold` arrives as a PROP from the root (which
@@ -520,9 +520,9 @@
 ;; while the deref itself is A's own subscription.
 
 (reg-view child-a [threshold]
-  (let [labelled @(subscribe [:button-deck/chain-labelled])
-        over?    @(subscribe [:button-deck/greater-than? threshold])]
-    [:div {:data-testid "button-deck-child-a"
+  (let [labelled @(subscribe [:standard-epochs/chain-labelled])
+        over?    @(subscribe [:standard-epochs/greater-than? threshold])]
+    [:div {:data-testid "standard-epochs-child-a"
            :style {:border "1px solid #d8d2ff" :border-radius "6px"
                    :padding "0.5em 0.75em" :margin "0.5em 0"
                    :background "#fcfbff"}}
@@ -540,7 +540,7 @@
 ;; re-render.
 
 (reg-view child-b [prop]
-  [:div {:data-testid "button-deck-child-b"
+  [:div {:data-testid "standard-epochs-child-b"
          :style {:border "1px solid #d8efd8" :border-radius "6px"
                  :padding "0.5em 0.75em" :margin "0.5em 0"
                  :background "#fbfffb"}}
@@ -558,54 +558,54 @@
   is the dispatch vector; nil rows are section separators (label only)."
   [[:section "Events — Epoch / Trace / App-db scalar"]
    [1  "Increment"             "App-db :baseline ++ · Epoch: the event, db-before/after"
-    [:button-deck/increment]]
+    [:standard-epochs/increment]]
    [2  "Increment + coeffect"  "Epoch event-detail: a `now` coeffect feeds the handler"
-    [:button-deck/increment-cofx]]
+    [:standard-epochs/increment-cofx]]
    [3  "Increment + effect"    "Effects / Trace: a one-shot fx fires this epoch"
-    [:button-deck/increment-fx]]
+    [:standard-epochs/increment-fx]]
    [4  "Increment + cascade"   "Epoch: the dispatch-id tree — a follow-on event"
-    [:button-deck/increment-cascade]]
+    [:standard-epochs/increment-cascade]]
    [5  "Increment + flow"      "App-db: a reg-flow-derived slot recomputes; Trace shows it"
-    [:button-deck/increment-flow]]
+    [:standard-epochs/increment-flow]]
    [:section "App-db shapes — diff modes / edn-inspector"]
    [6  "Add a nested key"      "App-db diff: added (assoc-in)"
-    [:button-deck/add-key]]
+    [:standard-epochs/add-key]]
    [7  "Remove a key"          "App-db diff: removed (dissoc)"
-    [:button-deck/remove-key]]
+    [:standard-epochs/remove-key]]
    [8  "Change a nested value" "App-db diff: changed (update-in, diff-mode-3)"
-    [:button-deck/change-value]]
+    [:standard-epochs/change-value]]
    [9  "Write a large collection" "edn-inspector: collapse / expand + elision"
-    [:button-deck/write-large]]
+    [:standard-epochs/write-large]]
    [:section "Views / subscriptions — sub-driven A vs props-driven B"]
    [10 "Mount Child A (sub-driven)"  "Views: node + A's sub-cache entries appear (chain L1/L2/L3 + [:gt? 5])"
-    [:button-deck/mount-a]]
+    [:standard-epochs/mount-a]]
    [11 "Change the sub-arg N → 10"   "Views: a NEW cache entry [:gt? 10] (parameterized-sub cache keyed by arg)"
-    [:button-deck/set-threshold 10]]
+    [:standard-epochs/set-threshold 10]]
    [12 "Perturb A's chain input"     "Views: L1→L2→L3 invalidation recompute; A re-renders ← a SUB changed"
-    [:button-deck/perturb-chain]]
+    [:standard-epochs/perturb-chain]]
    [13 "Unmount Child A"             "Views: node gone; ALL of A's subs disposed (last reader gone); unmount recorded"
-    [:button-deck/unmount-a]]
+    [:standard-epochs/unmount-a]]
    [14 "Mount Child B (props-driven)" "Views: node appears with NO subs created"
-    [:button-deck/mount-b]]
+    [:standard-epochs/mount-b]]
    [15 "Change B's prop"             "Views: B re-renders ← PROPS changed (foil to #12's sub-driven re-render)"
-    [:button-deck/set-b-prop]]
+    [:standard-epochs/set-b-prop]]
    [:section "Errors / Issues — each a real feature, not a buggy demo"]
    [16 "Exception in the handler"     "Issues: handler-exception + source coord; db rolls back"
-    [:button-deck/throw-handler]]
+    [:standard-epochs/throw-handler]]
    [17 "Exception in an interceptor :before" "Issues: interceptor :before exception; handler skipped"
-    [:button-deck/throw-interceptor]]
+    [:standard-epochs/throw-interceptor]]
    [18 "Exception in an interceptor :after"  "Issues: interceptor :after exception; handler ran, threw on the way out (foil to #17)"
-    [:button-deck/throw-interceptor-after]]
+    [:standard-epochs/throw-interceptor-after]]
    [19 "Exception in a coeffect"      "Issues: cofx error; handler skipped"
-    [:button-deck/throw-cofx]]
+    [:standard-epochs/throw-cofx]]
    [20 "Exception in an effect"       "Issues: fx error (post-commit, best-effort); db delta survives"
-    [:button-deck/throw-fx]]
+    [:standard-epochs/throw-fx]]
    [21 "Slow effect (~600ms)"         "Issues: slow-fx flagged; status loading → loaded"
-    [:button-deck/slow]]
+    [:standard-epochs/slow]]
    [22 "Bad event args"               "Issues / Schema-timeline: event-args schema failure"
-    [:button-deck/bad-event-args "not-a-number"]]
+    [:standard-epochs/bad-event-args "not-a-number"]]
    [23 "Bad app-db write"             "Issues: app-db schema failure (survives rollback)"
-    [:button-deck/bad-app-db-write]]])
+    [:standard-epochs/bad-app-db-write]]])
 
 (defn- testid-for [event]
   (-> (first event) name (str "-button")))
@@ -637,11 +637,11 @@
    label])
 
 (reg-view root []
-  [:div {:data-testid "button-deck-root"
+  [:div {:data-testid "standard-epochs-root"
          :style {:font-family "system-ui, sans-serif" :padding "1em"
                  :max-width "720px"}}
    [:header {:style {:margin-bottom "0.5em"}}
-    [:h2 {:style {:margin 0}} "Button-deck"]
+    [:h2 {:style {:margin 0}} "Standard-epochs"]
     [:p {:style {:color "#444" :margin "0.5em 0 0 0"}}
      "One frame, one tall column of test buttons. Each button bumps a shared "
      [:strong "baseline"] " counter (so App-db / Epoch always show a delta) and "
@@ -650,7 +650,7 @@
      "exercised."]]
    ;; Button 0 — Reset.
    [:button {:data-testid "reset-button"
-             :on-click #(dispatch [:button-deck/reset])
+             :on-click #(dispatch [:standard-epochs/reset])
              :style {:padding "0.4em 0.8em" :cursor "pointer"
                      :border "1px solid #cfc8ff" :border-radius "6px"
                      :background "#f4f1ff" :margin "0.5em 0"}}
@@ -666,10 +666,10 @@
    ;; :views/threshold here so the arg-key is driven by app-db state
    ;; while A owns the actual deref. Child B (props-driven) takes its
    ;; prop directly.
-   (when @(subscribe [:button-deck/a-mounted?])
-     [child-a @(subscribe [:button-deck/threshold])])
-   (when @(subscribe [:button-deck/b-mounted?])
-     [child-b @(subscribe [:button-deck/b-prop])])])
+   (when @(subscribe [:standard-epochs/a-mounted?])
+     [child-a @(subscribe [:standard-epochs/threshold])])
+   (when @(subscribe [:standard-epochs/b-mounted?])
+     [child-b @(subscribe [:standard-epochs/b-prop])])])
 
 ;; ============================================================================
 ;; MOUNT
@@ -693,5 +693,5 @@
   (rf/init! reagent-adapter/adapter)
   ;; Single, plain frame — no URL machinery, no history listener (there is
   ;; no routing here). The default frame is the one Xray reads.
-  (rf/dispatch-sync [:button-deck/reset])
+  (rf/dispatch-sync [:standard-epochs/reset])
   (rdc/render react-root [root]))

--- a/tools/xray/testbeds/standard_epochs/index.html
+++ b/tools/xray/testbeds/standard_epochs/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>re-frame2 testbed: button-deck (Xray demo)</title>
+  <title>re-frame2 testbed: standard-epochs (Xray demo)</title>
   <style>
     body { margin: 0; font-family: sans-serif; }
     .rf2-testbed-shell { display: flex; min-height: 100vh; }


### PR DESCRIPTION
Pure rename + reference sweep: `button_deck` → `standard_epochs` across the full surface. **Behaviour unchanged, no new buttons.** First of the `_epochs` trio cluster (rf2-cyczr) — sets the build-id scheme `routes_epochs` (8032) and `machine_epochs` (8033) will mirror.

## What changed

- `git mv tools/xray/testbeds/button_deck → standard_epochs` (history preserved, 83%/94% rename similarity). Namespace `button-deck.core` → `standard-epochs.core`; every `:button-deck/*` id, ex-info message (`"button-deck / …"` → `"standard-epochs / …"`), and `data-testid` (`button-deck-root`/`-child-a`/`-child-b` → `standard-epochs-*`).
- `git mv` the adapters/reagent substrate-contract test (it mirrors the testbed's subs/views section byte-for-byte) → `standard_epochs_views_subs_lifecycle_cljs_test.cljs`; ns + all `:standard-epochs/*` ids follow.
- Xray src/test fixtures (`panels/epoch/{projection,view}` + tests, `shell_cljs_test`) and core/epoch test fixtures/comments that used `:button-deck/*` ids or `button_deck/core.cljs` source-coord strings, repointed for corpus consistency.
- README + testbed-support config comment + `dev-testbed.cjs` usage string + panel_gallery comment.

## HOT-ZONE files touched

- **`implementation/shadow-cljs.edn`** — build-id `:examples/button-deck` → `:examples/standard-epochs`; `:output-dir` `out/examples/standard-epochs`; `:init-fn standard-epochs.core/run`; `:dev-http` source-path `../tools/xray/testbeds/standard_epochs`. **Port 8031 unchanged** (the trio anchor; comment notes routes→8032, machine→8033 mirror the scheme).
- **`tools/xray/spec/021-Dynamic-Panel-Designs.md`** — the only `tools/xray/spec/*` doc carrying `:button-deck/*` example ids (UX-IA / inventory / test-coverage-matrix had none). Updated in-PR.

## Quality gates

| Gate | Result |
|------|--------|
| `npx shadow-cljs compile examples/standard-epochs` (new id) | ✅ 423 files, 0 warnings |
| `npm run test:cljs` | ✅ 5087 tests / 17158 assertions, 0 failures, 0 errors |
| `npm run test:xray-feature-gate` | ✅ 14 scenarios, 0 failures, 12 matrix rows (exit 0) |
| `npm run test:bundle-isolation` | ✅ PASS (17 entries, 35 sentinels absent; uix/helix reagent-free) |
| clj-kondo on changed files | ✅ **0 errors** (18 warnings, all pre-existing unused-var/require, unrelated to the rename) |

## Grep-clean confirmation

`git grep -n "button_deck\|button-deck\|:examples/button-deck"` over tracked files (excluding `.beads/`) returns **ZERO hits**.

Note: `8031` references in pair-MCP / pair-skill / Story / examples-port surfaces use the separate stale placeholder `:examples/step-deck` (not `button_deck`) and are out of this bead's literal sweep scope; the `skills/re-frame2-xray/` skill carries no `button_deck`/`8031` refs.

## Out-of-worktree note

The north-star note in `ai/findings/better-testdeck-for-xray/design.md` (the design doc the bead references) lives in the mayor's local-only gitignored `ai/` tree — not in this worktree — and is **left for the mayor to update**.

Closes rf2-zthnj.
