### PR TITLE
fix(xray/app-db): atomic focused-epoch before-image — kill the 1-frame stale-diff flash on zoom nav (rf2-yng0y)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff.cljs
@@ -90,7 +90,13 @@
   comparison-context `:full` lacked, so the three-mode toggle (and its
   sub/event/slot trio) is gone."
   []
-  (let [section-model @(rf/subscribe [:rf.xray/app-db-state])]
+  (let [section-model @(rf/subscribe [:rf.xray/app-db-state])
+        ;; rf2-yng0y — the focused epoch-id, sourced from the SAME
+        ;; atomic sub the section model derives from
+        ;; (`:rf.xray/app-db-current+diff`), so the render key and the
+        ;; threaded `:before` move in lockstep — they can never name
+        ;; different epochs on the same frame.
+        selected-epoch-id (:epoch-id @(rf/subscribe [:rf.xray/app-db-current+diff]))]
     [:section {:data-testid "rf-xray-app-db-diff"
                ;; rf2-xvu24 — canonical `data-rf-xray-diff-mode` axis on
                ;; the enclosing section. FULL+DIFF is the single mode
@@ -102,7 +108,21 @@
      ;; rf2-6xezz — the L4 tab strip is the panel-name source-of-truth;
      ;; content starts immediately under the tab bar.
      [:div {:style panel-body-host-style}
-      (state/state-body section-model)]]))
+      ;; rf2-5kfxe.2 / rf2-yng0y — key the state body by the focused
+      ;; epoch-id so each epoch navigation forces a clean React re-mount
+      ;; per cascade (replaying the diff-flash CSS animation as
+      ;; originally intended, and flushing any per-mount carryover). This
+      ;; is a COMPLEMENT to the atomic sub above, not a substitute: a
+      ;; remount alone does not fix a sub-level stale-`before` (a fresh
+      ;; mount would still receive whatever `before` the sub hands it) —
+      ;; the atomic sub guarantees that `before` is never stale; the key
+      ;; guarantees a clean per-epoch mount. Zoom + expansion survive the
+      ;; remount because both are keyed by the stable `:site-id
+      ;; [:rf.xray/app-db render-id]` (e.g. ["top"]) in the `:rf/xray`
+      ;; frame's app-db (value-body, app_db_diff_state.cljs), not by
+      ;; React component identity.
+      ^{:key selected-epoch-id}
+      [state/state-body section-model]]]))
 
 (defn install!
   "Idempotent install for the app-db tab's Xray-side registrations.

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_subs.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_subs.cljs
@@ -286,35 +286,92 @@
         (h/epochs-touching-path history focused-path)
         [])))
 
-  ;; ---- rf2-okvit / rf2-ad7zx.11 — current-state + inline-diff sections -
+  ;; ---- rf2-yng0y — ATOMIC current-state + focused-epoch before-image --
   ;;
   ;; The app-db tab is a CURRENT-STATE inspector (re-frame-10x style)
   ;; that ALSO carries the focused epoch's diff inline (spec/021 §4.1 —
-  ;; "what does state LOOK LIKE — and what just changed?"). This sub
-  ;; decomposes the observed frame's LIVE app-db
-  ;; (`:rf.xray/target-frame-db`, which follows the picker / focused
-  ;; frame) into the section model `current-state-sections` produces:
-  ;; the TOP user-domain section (app-db minus reserved keys) + one
-  ;; section per reserved `:rf/*` area (machines/spawned fan out per
-  ;; instance; route + the other slices are singletons).
+  ;; "what does state LOOK LIKE — and what just changed?"):
   ;;
-  ;; The focused epoch record's `:db-before` is threaded as the diff
-  ;; PRE-IMAGE (spec/021 §4.3) so each section's changed nodes carry the
-  ;; inline `← was X` annotation in place. When no epoch is
-  ;; focusable (cold boot, no cascades) the record is nil and the
-  ;; sections render plain current-state — `current-state-sections`
-  ;; falls back to its `no-diff` sentinel automatically.
+  ;;   :value  = the observed frame's LIVE app-db (constant as you scrub)
+  ;;   :before = the focused epoch's `:db-before` (the inline-diff
+  ;;             pre-image — the ONLY thing that changes per epoch)
+  ;;
+  ;; ## Why one sub, not a 5-deep chain (rf2-yng0y root-cause fix)
+  ;;
+  ;; Previously the section model resolved through a deep composed
+  ;; chain — `:rf.xray/focus → :rf.xray/focus-epoch-id →
+  ;; :rf.xray/selected-epoch-record → :rf.xray/app-db-state`. Under
+  ;; real mouse timing (dispatches landing mid-frame relative to
+  ;; Reagent's rAF-batched flush) the panel could paint ONE frame
+  ;; (~17–22 ms) reading `app-db-state` while the focus→record chain was
+  ;; still propagating, so the rendered `:before`/diff lagged the focus
+  ;; by a frame — the previous epoch's diff flashing as "stuck", most
+  ;; visible when zoomed into a subtree (the stale frame IS the entire
+  ;; visible content).
+  ;;
+  ;; This sub collapses the chain: it joins the live db, the epoch
+  ;; history, and the spine `:rf.xray/focus` map DIRECTLY, then resolves
+  ;; the focused record's `:db-before` and `:epoch-id` together in ONE
+  ;; computation. `:before` and `:epoch-id` are pulled from the SAME
+  ;; `record`, so they can NEVER disagree — there is no intermediate
+  ;; reaction layer carrying a stale `:before` for a frame, and so no
+  ;; stale projection can paint. (Note: `(peek history)` is NOT a
+  ;; fallback here — the App-DB before-image follows the FOCUSED epoch;
+  ;; the `(peek history)` fallback that `:rf.xray/selected-epoch-diff`
+  ;; uses is a separate Epoch-panel/MCP concern.)
+  ;;
+  ;; ATOMICITY INVARIANT (asserted by the deterministic unit test):
+  ;;   for any returned map, `(= :before (:db-before <record of
+  ;;   :epoch-id>))` — `:before` is, by construction, the `:db-before`
+  ;;   of the epoch named by `:epoch-id`. When no epoch is focused
+  ;;   (cold boot, no cascades) both are nil and the panel renders plain
+  ;;   current-state.
+  (rf/reg-sub :rf.xray/app-db-current+diff
+    :<- [:rf.xray/target-frame-db]
+    :<- [:rf.xray/epoch-history]
+    :<- [:rf.xray/focus]
+    (fn [[db history focus] _query]
+      (let [epoch-id (:epoch-id focus)
+            record   (when epoch-id (find-epoch-in-history history epoch-id))
+            before   (when record (:db-before record))]
+        {:value    db
+         ;; `:before` and `:epoch-id` come from the SAME record — they
+         ;; move together, never one-frame apart.
+         :before   before
+         :epoch-id (when record epoch-id)})))
+
+  ;; ---- rf2-okvit / rf2-ad7zx.11 — current-state section model ---------
+  ;;
+  ;; Decomposes the atomic `{:value :before :epoch-id}` (above) into the
+  ;; section model `current-state-sections` produces: the TOP
+  ;; user-domain section (app-db minus reserved keys) + one section per
+  ;; reserved `:rf/*` area (machines/spawned fan out per instance; route
+  ;; + the other slices are singletons).
+  ;;
+  ;; The focused epoch's `:db-before` is threaded as the diff PRE-IMAGE
+  ;; (spec/021 §4.3) so each section's changed nodes carry the inline
+  ;; `← was X` annotation in place. Because this derives from the atomic
+  ;; sub, the section model's `:before-top` / per-area `:before` slices
+  ;; ALWAYS belong to the focused `:epoch-id` — no stale-`before`
+  ;; intermediate frame (rf2-yng0y).
   ;;
   ;; nil-safe — an absent / empty db yields an empty TOP + zero
   ;; reserved-area entries (rf2-jcdvo — empty areas are filtered at
   ;; projection time so the renderer never draws placeholder cards).
   (rf/reg-sub :rf.xray/app-db-state
-    :<- [:rf.xray/target-frame-db]
-    :<- [:rf.xray/selected-epoch-record]
-    (fn [[db record] _query]
-      (if-let [before (:db-before record)]
-        (h/current-state-sections db before)
-        (h/current-state-sections db))))
+    :<- [:rf.xray/app-db-current+diff]
+    (fn [{:keys [value before]} _query]
+      ;; Diff-mode is entered iff a real pre-image is present, mirroring
+      ;; the pre-rf2-yng0y `(if-let [before (:db-before record)] …)`
+      ;; contract: an absent / nil `:db-before` (cold boot, or a record
+      ;; with no pre-image slot) renders plain current-state. The atomic
+      ;; sub carries `before` = the focused record's `:db-before` (or nil
+      ;; when no epoch is focused), so this preserves the exact prior
+      ;; diff/no-diff behaviour while inheriting the atomic sub's
+      ;; stale-`before`-free contract.
+      (if (some? before)
+        (h/current-state-sections value before)
+        (h/current-state-sections value))))
 
   ;; rf2-fvplw — `:target-frame` in the composite output is the
   ;; *observed* frame (picker-selected / focused-cascade frame), not

--- a/tools/xray/src/day8/re_frame2_xray/spine.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/spine.cljs
@@ -621,13 +621,33 @@
 (defn preview-cascade-reducer
   "Pure reducer for `:rf.xray/preview-cascade <id>`. Sets `:previewing?
   true` and writes `:dispatch-id` transiently. nil `id` clears the
-  preview without changing the committed selection."
-  [db dispatch-id]
-  (if (nil? dispatch-id)
-    (assoc-in db [:focus :previewing?] false)
-    (-> db
-        (assoc-in [:focus :previewing?] true)
-        (assoc-in [:focus :dispatch-id] dispatch-id))))
+  preview without changing the committed selection.
+
+  ## rf2-yng0y — write `:epoch-id` alongside `:dispatch-id`
+
+  Pre-fix this reducer wrote ONLY `:dispatch-id`, leaving `:epoch-id`
+  pointing at the prior (committed) epoch. Harmless in RETRO (the
+  App-DB before-image now derives directly from `:epoch-id`, so a
+  stale-`:epoch-id` preview just shows the committed epoch's diff), but
+  in LIVE mode `compose-focus` re-derives `:epoch-id` from the
+  perturbed `:dispatch-id` via `epoch-id-for-cascade` — so previewing
+  one cascade while focused on another desynced the two axes mid-
+  interaction. Writing the resolved `:epoch-id` in lockstep with
+  `:dispatch-id` keeps the two axes consistent through the whole
+  preview gesture, matching `focus-cascade-reducer`'s write contract.
+
+  The 1-arity arity (caller has no epoch buffer handy) leaves
+  `:epoch-id` untouched — back-compat for the pure-shape callers; the
+  2-arity (resolved `epoch-id`) is the production path the event
+  handler drives."
+  ([db dispatch-id] (preview-cascade-reducer db dispatch-id nil))
+  ([db dispatch-id epoch-id]
+   (if (nil? dispatch-id)
+     (assoc-in db [:focus :previewing?] false)
+     (cond-> db
+       true     (assoc-in [:focus :previewing?] true)
+       true     (assoc-in [:focus :dispatch-id] dispatch-id)
+       epoch-id (assoc-in [:focus :epoch-id] epoch-id)))))
 
 ;; ---- registration --------------------------------------------------------
 
@@ -782,6 +802,13 @@
 
   (rf/reg-event-db :rf.xray/preview-cascade
     (fn [db [_ dispatch-id]]
-      (preview-cascade-reducer db dispatch-id)))
+      ;; rf2-yng0y — resolve the previewed cascade's settling epoch-id
+      ;; from the per-frame ring and write it in lockstep with
+      ;; `:dispatch-id` so the spine's two axes never desync mid-
+      ;; preview (the App-DB before-image follows `:epoch-id`). nil
+      ;; dispatch-id (preview-clear) resolves to nil and the reducer
+      ;; leaves the committed epoch untouched.
+      (let [epoch-id (epoch-id-for-cascade (db->epoch-history db) dispatch-id)]
+        (preview-cascade-reducer db dispatch-id epoch-id))))
 
   nil)

--- a/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_cljs_test.cljs
@@ -45,6 +45,7 @@
             [day8.re-frame2-xray.test-support :as xray-test-support]
             [day8.re-frame2-xray.trace-collector :as trace-collector]
             [day8.re-frame2-xray.panels.app-db-diff :as app-db-diff]
+            [day8.re-frame2-xray.panels.app-db-diff-state :as state]
             [day8.re-frame2-xray.panels.app-db-diff-subs
              :as app-db-diff-subs]))
 
@@ -124,14 +125,46 @@
 
 ;; ---- hiccup walker (mirrors event_detail_cljs_test.cljs) ----------------
 
+(defn- structural-component?
+  "True when `node` is one of the App-DB Panel's OWN pure-hiccup
+  structural fn-components — currently just `state/state-body`, the
+  per-epoch keyed body wrapper the Panel mounts (rf2-yng0y). These
+  realize to plain section `:div`s carrying the `data-testid` hooks the
+  assertions below pin. Leaf widgets like the `edn-inspector` (which
+  produce render-context-bound wrapper fns that are not ISeqable) are
+  deliberately NOT structural — they stay un-expanded so the walker
+  treats them as leaves, exactly as the pre-rf2-yng0y shallow walker
+  did when `state-body` was called inline."
+  [node]
+  (and (vector? node) (= state/state-body (first node))))
+
 (defn- expand-fn-component [node]
   (if (and (vector? node) (fn? (first node)))
     (apply (first node) (rest node))
     node))
 
-(defn- hiccup-seq [tree]
-  (->> (tree-seq (some-fn vector? seq?) seq (expand-fn-component tree))
-       (map expand-fn-component)))
+(defn- hiccup-seq
+  "Walk a (possibly component-wrapped) hiccup tree, expanding the
+  Panel's own structural fn-components (see `structural-component?`) AS
+  the walk descends so their nested section testids are realized.
+
+  rf2-yng0y — the App-DB Panel now wraps its body as a KEYED component
+  `^{:key epoch-id} [state/state-body model]` (to force a clean per-epoch
+  React remount). The pre-rf2-yng0y walker expanded one component deep at
+  each leaf, which sufficed when `state-body` was called inline; the new
+  wrapper hides the section testids one level down. Expanding the
+  structural wrapper during descent restores full visibility while
+  leaving the leaf widgets (edn-inspector) un-expanded, as before."
+  [tree]
+  (let [descend (fn [node]
+                  (seq (if (structural-component? node)
+                         (expand-fn-component node)
+                         node)))
+        seed    (if (structural-component? tree)
+                  (expand-fn-component tree)
+                  tree)]
+    (->> (tree-seq (some-fn vector? seq?) descend seed)
+         (map expand-fn-component))))
 
 (defn- find-by-testid [tree testid]
   (some (fn [node]

--- a/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_subs_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_subs_cljs_test.cljs
@@ -36,7 +36,12 @@
   ;; rf2-s8r6c — flow-writes projection sub for the origin-tag chip.
   (is (some? (registrar/handler :sub :rf.xray/selected-epoch-flow-writes)))
   (is (some? (registrar/handler :sub :rf.xray/app-db-diff)))
-  ;; rf2-okvit — the current-state inspector's section-model sub.
+  ;; rf2-yng0y — the atomic current-state + focused-epoch before-image
+  ;; sub the panel pivots on (collapses the former 5-deep focus chain so
+  ;; `:before` / `:epoch-id` move together — no stale-`before` frame).
+  (is (some? (registrar/handler :sub :rf.xray/app-db-current+diff)))
+  ;; rf2-okvit — the current-state inspector's section-model sub (now
+  ;; derived from the atomic sub above).
   (is (some? (registrar/handler :sub :rf.xray/app-db-state)))
   ;; rf2-e9tb0 — pinned-slices subs are gone.
   (is (nil? (registrar/handler :sub :rf.xray/pinned-slices-store)))

--- a/tools/xray/test/day8/re_frame2_xray/panels/reactivity/app_db_diff_reactivity_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/reactivity/app_db_diff_reactivity_cljs_test.cljs
@@ -24,7 +24,6 @@
   reactivity); this file extends the guard to the panel surface that
   consumes the spine sub."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.core :as rf]
             [day8.re-frame2-xray.test-helpers.sub-reactivity :as h]))
 
 (use-fixtures :each h/fixture)
@@ -114,3 +113,103 @@
         (is (not= sig-1 sig-2)
             "rf2-70tkv — LIVE mode auto-follows the head cascade; the
              App-db Diff panel rebinds to the new head's diff")))))
+
+;; ---- rf2-yng0y — atomic focused-epoch before-image ----------------------
+;;
+;; The zoom-nav stale-frame flash (rf2-yng0y) was a stale `:before` that
+;; lagged the focused `:epoch-id` by one animation frame, because the
+;; before-image resolved through a deep composed chain
+;; (`:focus → focus-epoch-id → selected-epoch-record → app-db-state`).
+;; The fix collapses that chain into ONE sub
+;; (`:rf.xray/app-db-current+diff`) that resolves `:before` and
+;; `:epoch-id` from the SAME epoch record in a single computation, so
+;; they can never disagree.
+;;
+;; The flash itself is timing-sensitive (it only paints under real mouse
+;; timing vs rAF batching, which a unit test cannot reproduce
+;; deterministically). What we CAN assert deterministically is the
+;; ATOMICITY INVARIANT that makes the flash impossible by construction:
+;; the sub never returns a `{:before :epoch-id}` pair where `:before`
+;; differs from the `:db-before` of the record named by `:epoch-id`.
+
+(defn- db-before-of
+  "The `:db-before` of the `epoch-id` record in the fixture history,
+  or nil when `epoch-id` is nil / absent."
+  [epoch-id]
+  (some (fn [r] (when (= epoch-id (:epoch-id r)) (:db-before r)))
+        epoch-history))
+
+(defn- assert-atomic!
+  "Read `:rf.xray/app-db-current+diff` and assert the atomicity
+  invariant: `:before` equals the `:db-before` of `:epoch-id`."
+  [label]
+  (let [{:keys [before epoch-id]} (h/read-sub :rf.xray/app-db-current+diff)]
+    (is (= (db-before-of epoch-id) before)
+        (str label " — :before must equal the :db-before of :epoch-id "
+             "(atomicity invariant rf2-yng0y); got before=" (pr-str before)
+             " epoch-id=" (pr-str epoch-id)))
+    epoch-id))
+
+(deftest current+diff-before-is-atomic-with-epoch-id
+  (testing "rf2-yng0y — the atomic sub's `:before` is ALWAYS the
+            `:db-before` of its own `:epoch-id`, across every focus
+            selection. There is no `{:before :epoch-id}` pair where the
+            two name different epochs — the stale-`before` glitch is
+            impossible by construction."
+    (h/setup-xray-frame!)
+    (h/seed-cascades! cascades)
+    (h/seed-epoch-history! epoch-history)
+    ;; Focus :c1 (epoch :e1, db-before {}).
+    (h/focus-cascade! :c1)
+    (is (= :e1 (assert-atomic! "focus :c1")))
+    (let [{:keys [before epoch-id]} (h/read-sub :rf.xray/app-db-current+diff)]
+      (is (= :e1 epoch-id))
+      (is (= {} before) ":e1's db-before is the empty map"))
+    ;; Flip to :c2 (epoch :e2, db-before {:counter 1}) — the slot the
+    ;; flash used to surface on. before + epoch-id move together.
+    (h/focus-cascade! :c2)
+    (is (= :e2 (assert-atomic! "focus :c2")))
+    (let [{:keys [before epoch-id]} (h/read-sub :rf.xray/app-db-current+diff)]
+      (is (= :e2 epoch-id))
+      (is (= {:counter 1} before) ":e2's db-before is {:counter 1}"))
+    ;; Flip back — invariant holds in both directions.
+    (h/focus-cascade! :c1)
+    (is (= :e1 (assert-atomic! "focus :c1 (return)")))))
+
+(deftest current+diff-value-is-stable-while-before-tracks-focus
+  (testing "rf2-yng0y — the App-DB tab is a CURRENT-STATE inspector:
+            `:value` is the live target-frame-db (constant as the
+            operator scrubs epochs); only `:before` moves per epoch.
+            Confirms the panel's atomic contract — value steady, before
+            tracking — so the diff overlay is the sole per-epoch change."
+    (h/setup-xray-frame!)
+    (h/seed-cascades! cascades)
+    (h/seed-epoch-history! epoch-history)
+    (h/focus-cascade! :c1)
+    (let [v1 (:value (h/read-sub :rf.xray/app-db-current+diff))
+          b1 (:before (h/read-sub :rf.xray/app-db-current+diff))]
+      (h/focus-cascade! :c2)
+      (let [v2 (:value (h/read-sub :rf.xray/app-db-current+diff))
+            b2 (:before (h/read-sub :rf.xray/app-db-current+diff))]
+        (is (= v1 v2)
+            ":value is constant across the scrub (live target-frame-db)")
+        (is (not= b1 b2)
+            ":before moves with the focused epoch — the diff overlay is
+             the only per-epoch change")))))
+
+(deftest app-db-state-section-model-tracks-focused-before
+  (testing "rf2-yng0y — `:rf.xray/app-db-state` (the panel's consumed
+            section model, now derived from the atomic sub) carries the
+            focused epoch's `:db-before` as the diff pre-image. The
+            section model's `:before-top` reflects the focused epoch and
+            moves atomically with the focus flip — no stale carryover."
+    (h/setup-xray-frame!)
+    (h/seed-cascades! cascades)
+    (h/seed-epoch-history! epoch-history)
+    (h/focus-cascade! :c1)
+    (let [m1 (h/read-sub :rf.xray/app-db-state)]
+      (h/focus-cascade! :c2)
+      (let [m2 (h/read-sub :rf.xray/app-db-state)]
+        (is (not= (:before-top m1) (:before-top m2))
+            "section model's :before-top re-derives per focused epoch
+             (atomic with the focus flip — no stale before)")))))

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -114,7 +114,12 @@
    ;; rf2-7hwwe — Machine Inspector `:after` countdown rings.
    :rf.xray/active-timers-for-focused-machine
    :rf.xray/app-db-diff
-   ;; rf2-okvit — app-db tab current-state inspector section model.
+   ;; rf2-yng0y — atomic current-state + focused-epoch before-image
+   ;; (collapses the former 5-deep focus chain so `:before` / `:epoch-id`
+   ;; move together — no stale-`before` frame on zoom navigation).
+   :rf.xray/app-db-current+diff
+   ;; rf2-okvit — app-db tab current-state inspector section model
+   ;; (derived from the atomic sub above).
    :rf.xray/app-db-state
    :rf.xray/cascades
    ;; First-class edn-inspector widget owns the WHOLE renderer contract

--- a/tools/xray/test/day8/re_frame2_xray/spine_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/spine_cljs_test.cljs
@@ -425,6 +425,36 @@
     (is (= :c1 (get-in r [:focus :dispatch-id]))
         "committed selection survives preview-clear")))
 
+(deftest preview-cascade-reducer-writes-epoch-id-rf2-yng0y
+  (testing "rf2-yng0y — the 3-arity preview reducer writes :epoch-id in
+            lockstep with :dispatch-id so the spine's two focus axes
+            never desync mid-preview (the App-DB before-image follows
+            :epoch-id). Pre-fix the preview wrote :dispatch-id alone,
+            leaving :epoch-id pinned to the committed epoch — a latent
+            LIVE-mode correctness bug."
+    (let [db {:focus {:dispatch-id :c1 :epoch-id :e1 :mode :live}}
+          r  (spine/preview-cascade-reducer db :c2 :e2)]
+      (is (true? (get-in r [:focus :previewing?])))
+      (is (= :c2 (get-in r [:focus :dispatch-id]))
+          ":dispatch-id moved to the previewed cascade")
+      (is (= :e2 (get-in r [:focus :epoch-id]))
+          ":epoch-id moved with it — the two axes stay in lockstep")))
+  (testing "rf2-yng0y — nil epoch-id (the 2-arity delegate, or an
+            unresolved preview) leaves :epoch-id untouched rather than
+            clobbering it to nil; the before-image stays on the last
+            resolved epoch until a real epoch resolves."
+    (let [db {:focus {:dispatch-id :c1 :epoch-id :e1 :mode :live}}
+          r  (spine/preview-cascade-reducer db :c2 nil)]
+      (is (= :c2 (get-in r [:focus :dispatch-id])))
+      (is (= :e1 (get-in r [:focus :epoch-id]))
+          "unresolved preview epoch-id is non-destructive")))
+  (testing "rf2-yng0y — the 2-arity arity is preserved (back-compat) and
+            leaves :epoch-id untouched."
+    (let [db {:focus {:epoch-id :e1}}
+          r  (spine/preview-cascade-reducer db :c2)]
+      (is (= :c2 (get-in r [:focus :dispatch-id])))
+      (is (= :e1 (get-in r [:focus :epoch-id]))))))
+
 ;; -------------------------------------------------------------------------
 ;; (8) Registered :rf.xray/focus sub — reactive composition
 ;; -------------------------------------------------------------------------


### PR DESCRIPTION
## What & why

In Xray's App-DB panel, zooming into a subtree then clicking through events made the zoomed pane flash the **previous** epoch's diff for one animation frame (~17-22 ms), reading as "stuck". Root cause is a reactive glitch: the panel's before-image resolved through a 5-deep composed focus chain

```
raw :focus slot → :rf.xray/focus → :rf.xray/focus-epoch-id
  → :rf.xray/selected-epoch-record → :rf.xray/app-db-state → panel
```

so under real mouse timing (dispatches landing mid-frame vs Reagent's rAF-batched flush) the panel could paint one frame with a `before` image that lagged the focused `:epoch-id`. The App-DB tab is a current-state inspector — `value` is the live target-frame-db (constant as you scrub), `before` is the focused epoch's `:db-before` — so the stale frame is a stale **`before`/projection**, not a stale value.

## The three-part fix

1. **Atomic sub (root cause).** New `:rf.xray/app-db-current+diff` joins the live `target-frame-db` + `epoch-history` + the spine `:rf.xray/focus` map **directly** and resolves `:before` and `:epoch-id` from the **same** epoch record in one computation. They can never disagree by construction, so no stale projection can paint. `:rf.xray/app-db-state` (the panel's consumed section model) now derives from it. The deep `selected-epoch-*` chain survives for the Epoch panel + MCP exporter — only the panel's render path was rerouted.

2. **Render key (complement).** The panel keys its body `^{:key selected-epoch-id} [state/state-body model]`, sourced from the **same** atomic sub, to force a clean per-epoch React remount. Zoom + expansion survive the remount because both are keyed by the stable `:site-id [:rf.xray/app-db render-id]` in the `:rf/xray` frame's app-db, not by React component identity. (A remount alone does **not** fix the sub-level stale-`before` — it complements the atomic sub.)

3. **preview-cascade desync.** `preview-cascade-reducer` now writes `:epoch-id` in lockstep with `:dispatch-id` (resolved via `epoch-id-for-cascade` in the event handler), so a hover-preview no longer perturbs the focus sub's epoch axis mid-interaction — a latent LIVE-mode correctness bug.

## Proving the atomicity invariant

The flash itself is timing-sensitive (only paints under real mouse timing vs rAF batching), so the deterministic test asserts the **invariant that makes it impossible by construction**: the sub never returns a `{:before :epoch-id}` pair where `:before` differs from the `:db-before` of the record named by `:epoch-id`. New tests in `app_db_diff_reactivity_cljs_test.cljs`:

- `current+diff-before-is-atomic-with-epoch-id` — `:before` always equals the `:db-before` of its own `:epoch-id`, across forward + backward focus flips.
- `current+diff-value-is-stable-while-before-tracks-focus` — `:value` constant across the scrub; only `:before` moves per epoch.
- `app-db-state-section-model-tracks-focused-before` — the derived section model's `:before-top` re-derives atomically per focused epoch.

Plus `preview-cascade-reducer-writes-epoch-id-rf2-yng0y` (3-arity epoch-id write, non-destructive nil, 2-arity back-compat) in `spine_cljs_test.cljs`, and the registry-snapshot + leaf-install contracts updated for the new sub.

## Quality gates

| Gate | Result |
| --- | --- |
| `npm run test:cljs` | **PASS** — 5091 tests, 17181 assertions, 0 failures, 0 errors (incl. the new atomicity + preview-reducer tests) |
| `npm run test:xray-feature-gate` | **PASS** — 14 scenarios, 0 failures, 12 matrix rows, exit 0 |
| `npm run test:bundle-isolation` | **PASS** — 17 artefact entries, 35 internal sentinels absent, uix/helix reagent-free |
| clj-kondo (changed files) | **0 errors** (3 warnings are all pre-existing on origin/main; none introduced) |

The panel-tree test walker (`app_db_diff_cljs_test.cljs`) now expands the keyed structural body wrapper during descent so nested section testids stay visible; render-context-bound leaf widgets (edn-inspector) stay un-expanded as before.

spec unchanged (internal reactivity refactor; panel contract unchanged)

Closes rf2-yng0y.