### PR TITLE
refactor(xray/testbed): refresh panel_gallery fixtures to current panel shapes + feature edn-inspector (rf2-6jkrm)

### DIFF
--- a/tools/xray/testbeds/panel_gallery/core.cljs
+++ b/tools/xray/testbeds/panel_gallery/core.cljs
@@ -5,18 +5,27 @@
 
   ## What this testbed is
 
-  A visual gallery of the seven L4 tab panels (Epoch / App-db / Views
-  / Trace / Machines / Routing / Issues) plus the full 4-layer Xray
-  chrome, framed exactly like Storybook frames UI components. Scroll
-  the workspace; see what each panel looks like under varying state
-  magnitude / payload shape / privacy posture. The gallery IS the
-  surface a developer (Mike first) reaches for when asking 'what
+  A visual gallery of the six L4 tab panels (Epoch · App-db · Reactive
+  · Trace · Machines · Routing) plus the full 4-layer Xray chrome,
+  framed exactly like Storybook frames UI components. Issues is NOT a
+  tab (rf2-gbz39 — Option (c)): issue surfacing folds INLINE into the
+  Epoch panel + the L2 event-row pink-wash + the always-on issues
+  ribbon signal, so there is no standalone Issues panel to gallery.
+  Scroll the workspace; see what each panel looks like under varying
+  state magnitude / payload shape / privacy posture. The gallery IS
+  the surface a developer (Mike first) reaches for when asking 'what
   does this look like under load X?'.
+
+  The standout is the **edn-inspector** widget gallery — the single
+  CLJS-value renderer behind every panel (App-db, Trace payloads,
+  Reactive sub values, Machine snapshots, Routing diffs). Its
+  dedicated workspace exercises every input shape + the full opts
+  surface in isolation; it is the gem of this testbed.
 
   Per `tools/xray/spec/018-Event-Spine.md` the chrome is four stacked
   layers — top ribbon + event list + tab bar + detail panel — with
-  seven L4 tabs replacing the legacy sidebar's 16+ panels. Time Travel
-  is folded into the spine.
+  six L4 tabs replacing the legacy sidebar's 16+ panels (Issues folded
+  inline per rf2-gbz39). Time Travel is folded into the spine.
 
   ## Per-variant frame isolation (de-singletoned shell — rf2-1w07r)
 
@@ -145,9 +154,17 @@
 (defn- landing-view []
   [:div {:class "gallery-landing"}
    [:h1 "Xray panel gallery"]
-   [:p "A visual gallery of the new 7-tab Xray chrome (per "
+   [:p "A visual gallery of the 6-tab Xray chrome (per "
     [:code "tools/xray/spec/018-Event-Spine.md"]
-    ") and each of the seven L4 tab panels."]
+    ") and each of the six L4 tab panels — Epoch · App-db · Reactive ·
+    Trace · Machines · Routing. Issues is not a tab; it surfaces inline
+    in the Epoch panel + the L2 event-row pink-wash + the ribbon signal
+    (rf2-gbz39)."]
+   [:p "The centrepiece is the "
+    [:strong "edn-inspector"]
+    " widget gallery — the single CLJS-value renderer behind every
+    panel — exercised in isolation across every input shape + the full
+    opts surface."]
    [:p "Open the gallery at "
     [:a {:href "#/stories"} [:code "#/stories"]]
     " to scroll the workspaces."]

--- a/tools/xray/testbeds/panel_gallery/fixtures.cljs
+++ b/tools/xray/testbeds/panel_gallery/fixtures.cljs
@@ -499,8 +499,9 @@
 
 (defn event-lens-handler-threw-buffer
   "Event lens fixture — handler threw mid-run. §5 + §6 should be
-  ABSENT; the cascade-outcome glyph is ✗ red and the Issues-tab
-  footer is the only inline cross-reference."
+  ABSENT; the cascade-outcome glyph is ✗ red and the failure surfaces
+  inline (rf2-gbz39 — Issues is no longer a tab; issues fold into the
+  Epoch panel + the L2 pink-wash + the ribbon signal)."
   []
   (let [dispatch-id 300
         id-base     300
@@ -520,7 +521,8 @@
 (defn event-lens-hydration-completed-buffer
   "Event lens fixture — a :rf.ssr/hydrated completion event. Renders
   the SSR✓ outcome-line badge plus the hydration-outcome row inside
-  §5. With :mismatches 0 there's no jump-to-Issues affordance."
+  §5. With :mismatches 0 there's no issue cross-reference (rf2-gbz39 —
+  issues surface inline, not via a tab)."
   []
   (let [dispatch-id 400
         id-base     400
@@ -539,7 +541,8 @@
 
 (defn event-lens-hydration-mismatch-buffer
   "Event lens fixture — hydration completed WITH mismatches. The
-  hydration-outcome row carries the jump-to-Issues affordance."
+  hydration-outcome row carries the inline issue cross-reference
+  (rf2-gbz39 — issues surface inline, not via a dedicated tab)."
   []
   (let [dispatch-id 401
         id-base     410

--- a/tools/xray/testbeds/panel_gallery/fixtures_edn_inspector.cljs
+++ b/tools/xray/testbeds/panel_gallery/fixtures_edn_inspector.cljs
@@ -4,8 +4,9 @@
 
   The edn-inspector widget (`day8.re-frame2-xray.views.edn-inspector`)
   is exercised indirectly by every L4 panel that mounts it — App-DB,
-  Reactive, Trace, Machines, Issues, Routing all route their CLJS
-  value rendering through it. The dedicated gallery here gives the
+  Reactive, Trace, Machines, Routing (plus the Epoch panel's inline
+  exception / value surfaces) all route their CLJS value rendering
+  through it. The dedicated gallery here gives the
   widget its own isolated surface: one variant per value shape /
   opts combination, side-by-side, so an operator can scan the
   renderer's response without the surrounding panel chrome.

--- a/tools/xray/testbeds/panel_gallery/fixtures_epoch.cljs
+++ b/tools/xray/testbeds/panel_gallery/fixtures_epoch.cljs
@@ -7,10 +7,11 @@
   epoch's complete computational timeline as a numbered vertical
   cascade: DISPATCH → COEFFECT (one per cofx) → HANDLER → FLOW
   (one per flow, rf2-xnb1x) → FX → SUBSCRIPTIONS → VIEWS. Runtime-
-  boundary schema violations attach as inline sub-blocks under
-  their owning step (rf2-xgeag + rf2-8resu); hot-reload drift
-  surfaces via the Issues panel exclusively (rf2-7gf7v retired the
-  standalone SCHEMA HOT-RELOAD tail step). Each step is
+  boundary schema violations + cascade exceptions attach as inline
+  sub-blocks UNDER their owning step (rf2-xgeag + rf2-8resu +
+  rf2-yz57h); hot-reload drift surfaces inline (rf2-gbz39 — Issues is
+  no longer a tab; rf2-7gf7v retired the standalone SCHEMA HOT-RELOAD
+  tail step). Each step is
   CONDITIONAL — only the steps whose driving trace events surfaced
   get rendered (per
   `tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc`).
@@ -194,6 +195,47 @@
      true  (assoc :recovery :no-recovery)
      coord (assoc :rf.trace/trigger-handler {:kind         :event
                                              :id           event-id
+                                             :source-coord coord}))))
+
+(defn- coeffect-exception-ev
+  "`:rf.error/coeffect-exception` trace (rf2-mszrz · rf2-yz57h) — a
+  coeffect injector threw during `:before`-chain injection. `:failing-id`
+  = the cofx id, so the projection attaches the inline 'Exception Thrown'
+  card to the matching COEFFECT step (synthesising a placeholder COEFFECT
+  step when the throwing cofx produced no `:rf.cofx/run` trace). Because
+  this is an UPSTREAM `:before`-chain throw, `handler-skipped-by-upstream?`
+  marks the HANDLER + SIDE EFFECTS steps `:status :skipped` (⊘) — they
+  never ran."
+  ([cofx-id message] (coeffect-exception-ev cofx-id message nil))
+  ([cofx-id message coord]
+   (cond-> (ev :error :rf.error/coeffect-exception
+               {:failing-id        cofx-id
+                :exception-message message
+                :reason            "Coeffect injector threw."})
+     true  (assoc :recovery :no-recovery)
+     coord (assoc :rf.trace/trigger-handler {:kind         :cofx
+                                             :id           cofx-id
+                                             :source-coord coord}))))
+
+(defn- interceptor-exception-ev
+  "`:rf.error/interceptor-exception` trace (rf2-mszrz · rf2-yz57h) — a
+  USER interceptor threw in its `:before` or `:after` phase (`:phase`
+  discriminates). `:failing-id` = the interceptor `:id`, so the
+  projection's conditional INTERCEPTOR step (`interceptor-step`) renders
+  a row carrying the interceptor id + phase + the inline 'Exception
+  Thrown' card. A `:before` throw additionally marks the HANDLER + SIDE
+  EFFECTS steps SKIPPED (the handler never ran); an `:after` throw runs
+  the handler first, then throws on the way out (handler NOT skipped)."
+  ([interceptor-id phase message] (interceptor-exception-ev interceptor-id phase message nil))
+  ([interceptor-id phase message coord]
+   (cond-> (ev :error :rf.error/interceptor-exception
+               {:failing-id        interceptor-id
+                :phase             phase
+                :exception-message message
+                :reason            "Interceptor threw."})
+     true  (assoc :recovery :no-recovery)
+     coord (assoc :rf.trace/trigger-handler {:kind         :interceptor
+                                             :id           interceptor-id
                                              :source-coord coord}))))
 
 (defn- db-pending-ev
@@ -384,9 +426,10 @@
 
 ;; `schema-hot-reload-ev` retired per rf2-w8evg — the standalone
 ;; SCHEMA HOT-RELOAD tail step was retired in rf2-7gf7v; hot-reload
-;; drift now surfaces via the Issues panel exclusively, so a fixture
-;; helper that synthesises a tail-step trace is dead weight. If the
-;; Issues-panel gallery needs an equivalent it lives there.
+;; drift now surfaces inline (rf2-gbz39 — Issues is no longer a tab;
+;; issues fold into the Epoch panel + the L2 pink-wash + the ribbon
+;; signal), so a fixture helper that synthesises a tail-step trace is
+;; dead weight.
 
 ;; ---- epoch-record builder ------------------------------------------------
 
@@ -1238,3 +1281,96 @@
         ;; t2 — POST-flow, PRE-commit: the flow-augmented :total.
         (db-pending-post-flow-ev t2)
         (run-end-ev 0.7)]})))
+
+;; ---- VARIANT 21: INTERCEPTOR :after throw (rf2-yz57h · rf2-mszrz) --------
+;;
+;; Section coverage: the NEW conditional INTERCEPTOR step (rf2-yz57h).
+;; A user interceptor threw in its `:after` phase — the handler RAN
+;; successfully (the throw fired on the way OUT), so:
+;;
+;;   - the projection's `interceptor-step` renders (CONDITIONAL — only
+;;     present when an interceptor threw); its row carries the
+;;     interceptor `:interceptor-id` + the `:phase :after`.
+;;   - `attach-exceptions` places the `:rf.error/interceptor-exception`
+;;     UNDER the INTERCEPTOR step (per `exception-op->step`, rf2-yz57h —
+;;     no longer collapsing onto HANDLER) + stamps `:status :error`, so
+;;     the step header paints ✗ + carries the inline 'Exception Thrown'
+;;     card; the epoch `:outcome` flips `:error`.
+;;   - the HANDLER step is NOT skipped (an `:after` throw runs the
+;;     handler first), so its `:db` write still renders normally.
+;;
+;; The INTERCEPTOR step rides BETWEEN COEFFECT and HANDLER in the
+;; numbered cascade (the chain's `:before` runs after coeffects, before
+;; the handler; the step position reflects that).
+
+(defn interceptor-after-throw-history
+  "Cascade where a user interceptor (`:audit/trail`) threw in its
+  `:after` phase AFTER the handler ran cleanly. Exercises the NEW
+  conditional INTERCEPTOR step (rf2-yz57h): the step renders ✗ with the
+  interceptor id + `:after` phase + the inline 'Exception Thrown' card,
+  while the HANDLER step's `:db` write still rendered (the handler ran —
+  an `:after` throw fires on the way out, so the handler is NOT skipped).
+  The epoch `:outcome` flips `:error`."
+  []
+  (single-epoch-history
+    {:epoch-id  29
+     :event     [:counter/inc 1]
+     :db-before {:counter 5}
+     :db-after  {:counter 6}
+     :trace-events
+     [(dispatched-ev [:counter/inc 1] :ui)
+      ;; the handler ran cleanly + wrote :db (t1 present → db-write?).
+      (db-pending-ev {:counter 6})
+      (db-changed-ev [[[:counter] 5 6 :modified]])
+      (run-end-ev 0.4)
+      ;; an `:after`-phase user interceptor threw on the way out — owns
+      ;; the INTERCEPTOR step; the handler is NOT skipped (it ran first).
+      (interceptor-exception-ev
+        :audit/trail :after
+        "Audit sink unreachable (POST /audit 503)"
+        {:file "src/app/interceptors.cljs" :line 31})]}))
+
+;; ---- VARIANT 22: upstream :before throw — HANDLER SKIPPED (rf2-yz57h) -----
+;;
+;; Section coverage: the `:skipped` per-step status (rf2-yz57h ⊘ glyph)
+;; + per-step exception placement UNDER the COEFFECT step. A coeffect
+;; injector threw on the way IN, so:
+;;
+;;   - the projection synthesises a placeholder COEFFECT step keyed on
+;;     the throwing cofx id (the injector threw before producing a
+;;     `:rf.cofx/run` trace) so the inline 'Exception Thrown' card has a
+;;     home UNDER the COEFFECT step (rf2-yz57h) rather than on HANDLER.
+;;   - `handler-skipped-by-upstream?` is true (a `:before`-chain throw),
+;;     so `mark-skipped-handler` stamps the HANDLER + SIDE EFFECTS steps
+;;     `:status :skipped` → the view renders them as SKIPPED (⊘ muted),
+;;     NOT 'ran, returned no :db'. (The handler's body would have written
+;;     a `:db`, but it never executed.)
+;;   - the COEFFECT step paints ✗; the epoch `:outcome` flips `:error`.
+
+(defn coeffect-throw-skipped-history
+  "Cascade where a coeffect injector (`:session`) threw on the way IN,
+  so the event handler never ran. Exercises the rf2-yz57h skip path: the
+  throwing cofx's COEFFECT step carries the inline 'Exception Thrown'
+  card (✗), and the downstream HANDLER + SIDE EFFECTS steps render as
+  SKIPPED (⊘) — the handler body never executed, so it must NOT read
+  'ran, returned no :db'. The epoch `:outcome` flips `:error`."
+  []
+  (single-epoch-history
+    {:epoch-id  30
+     :event     [:dashboard/load {:tenant :acme}]
+     ;; db-before == db-after — the handler never ran, so nothing
+     ;; mutated. There is NO db-pending (t1) and NO db-changed.
+     :db-before {:dashboard {:status :idle}}
+     :db-after  {:dashboard {:status :idle}}
+     :trace-events
+     [(dispatched-ev [:dashboard/load {:tenant :acme}] :ui)
+      ;; the :session coeffect injector threw before resolving — it
+      ;; emits NO :rf.cofx/run trace; the projection synthesises a
+      ;; placeholder COEFFECT step for it so the card has a home.
+      (coeffect-exception-ev
+        :session
+        "No auth token in storage (session injector threw)"
+        {:file "src/app/cofx.cljs" :line 17})
+      ;; NO run-end (the handler never ran). The HANDLER + SIDE EFFECTS
+      ;; steps are marked :skipped by `mark-skipped-handler`.
+      ]}))

--- a/tools/xray/testbeds/panel_gallery/fixtures_trace.cljs
+++ b/tools/xray/testbeds/panel_gallery/fixtures_trace.cljs
@@ -75,10 +75,16 @@
                      :reason                <string>
                      ...}}
 
-  The fixtures here keep the shape minimal but exercise all 9 filter
-  axes the trace panel renders chip rows for: op-type / severity /
-  source / origin / frame / operation / event-id / handler-id /
-  dispatch-id.")
+  The flat Trace panel (rf2-aqusw) projects each raw event into a row
+  carrying `Δt · stage · area-badge · what-happened · target/detail ·
+  duration` via `trace_helpers/project-feed-from-epoch`. There is no
+  chip-filtering UI (the focused epoch IS the scope, rf2-gkczt) — the
+  fixtures keep the event shape minimal but exercise the full op-family
+  vocabulary so the STAGE column + colour-coded left edge (resolved
+  through the Epoch panel's `panels.epoch.badge` taxonomy) light up
+  across the canonical pipeline steps: DISPATCH · COEFFECT · HANDLER ·
+  FLOW · SIDE EFFECTS · SUBSCRIPTIONS · VIEWS, plus the cross-cutting
+  ERROR / WARNING severity tiers.")
 
 ;; ---- per-event builders -------------------------------------------------
 
@@ -116,8 +122,9 @@
 
 (defn ten-events-buffer
   "Ten events spanning the canonical op-types and a couple of frames /
-  origins. Each row distinguishable; chip rows surface op-type +
-  source + origin + frame axes with ≥2 values each."
+  origins. Each row distinguishable; the STAGE column + colour-coded
+  left edge light up across DISPATCH / HANDLER / SIDE EFFECTS /
+  SUBSCRIPTIONS / VIEWS plus the ERROR / WARNING severity tiers."
   []
   (vec
     (concat
@@ -149,7 +156,7 @@
        (ev {:id 8 :time 1102 :op-type :rf.fx :operation :rf.fx/handled
             :source :after-timer :origin :story :frame :rf/xray
             :event-id :story/tick :dispatch-id 101 :fx-id :dispatch})]
-      ;; Warning + error rows surface the severity axis chip-row.
+      ;; Warning + error rows ride the severity colour on the left edge.
       [(ev {:id 9 :time 1200 :op-type :warning :operation :rf.warning/large-value-unschema'd
             :source :http :origin :app :frame :rf/default :dispatch-id 100
             :sub-id :user/profile :severity :warning
@@ -195,24 +202,22 @@
 
 (defn hundred-events-buffer
   "One hundred events spanning all four op-types, three frames, three
-  origins, four sources. The cap (200 per common/panel-row-cap) is not
-  hit; cap-eviction indicator stays quiet."
+  origins, four sources. A mid-density epoch — the flat list renders
+  every row (no row cap, rf2-aqusw)."
   []
   (n-events 100))
 
 (defn thousand-events-buffer
-  "One thousand events — exercises the 200-row cap (common/panel-row-cap)
-  and surfaces the overflow indicator. Per
-  `overflow_indicator.cljc` §capped-list, the panel renders 200 rows +
-  one '... N rows hidden' indicator row at the head."
+  "One thousand events — a deep epoch. The flat list (rf2-aqusw)
+  renders the whole epoch's trace in fire order; exercises the panel +
+  the shared resizable-table under a large row count."
   []
   (n-events 1000))
 
 (defn filtered-active-buffer
-  "A buffer with two op-types and a pre-active filter (set by the
-  variant after seeding via :rf.xray/set-trace-filter). The panel
-  renders the chip ladder with the active chip highlit. Returns the
-  buffer; the variant fires the filter event after seed."
+  "A buffer mixing two op-types (events + fx). The flat panel renders
+  every row (no chip-filtering post-rf2-gkczt — the focused epoch IS
+  the scope); used by the mixed-op-types variant."
   []
   (vec
     (concat
@@ -227,9 +232,10 @@
 
 (defn redacted-buffer
   "A buffer whose dispatched-event payload carries `:rf/redacted`
-  markers (per Spec 009 §Privacy). The panel's description column
-  renders the marker verbatim — the upstream emit sets it; the panel
-  surfaces it."
+  markers (per Spec 009 §Privacy). The row's target/detail column
+  renders the event vector with the marker verbatim, and clicking the
+  row opens the edn-inspector on the raw trace MAP (the marker survives
+  there too) — the upstream emit sets it; the panel surfaces it."
   []
   [(ev {:id 1 :time 1000 :op-type :rf.event :operation :rf.event/dispatched
         :source :ui :origin :app :frame :rf/default
@@ -246,7 +252,9 @@
 
 (defn error-buffer
   "A buffer where every row is an issue (error / warning / info) —
-  exercises the severity chip row with all three levels populated."
+  exercises the cross-cutting severity rendering: the left EDGE rides
+  the severity colour over the stage colour and the Δt leads with `!`
+  so a failure stands out (spec/023 §7), across all three levels."
   []
   [(ev {:id 1 :time 1000 :op-type :error :operation :rf.error/handler-exception
         :source :ui :origin :app :frame :rf/default
@@ -272,15 +280,17 @@
 ;;
 ;; Two extra axes the trace panel uniquely exercises:
 ;;
-;;   A. Cross-frame mix — the :frame chip row surfaces 3+ values
-;;      side-by-side (per Spec 009 §Canonical per-frame routing key).
+;;   A. Cross-frame mix — the per-row `:frame` projection surfaces 3+
+;;      frames across the flat list (per Spec 009 §Canonical per-frame
+;;      routing key).
 ;;   B. Source-coord population — every emit inside a dispatch carries
-;;      :rf.trace/trigger-handler :source-coord; the per-row source-
-;;      coord chip is the trace panel's signature affordance.
+;;      :rf.trace/trigger-handler :source-coord; the per-row `↗`
+;;      open-in-editor glyph (riding the target/detail column) is the
+;;      trace panel's jump-to-source affordance.
 
 (defn cross-frame-buffer
-  "Buffer spanning three frames evenly — exercises the panel's :frame
-  chip row at full ladder. Panel-specific axis A."
+  "Buffer spanning three frames evenly — exercises the panel's per-row
+  `:frame` projection across the flat list. Panel-specific axis A."
   []
   (vec
     (for [i (range 12)]
@@ -293,7 +303,7 @@
 (defn source-coord-buffer
   "Buffer where every event carries a `:rf.trace/trigger-handler`
   `:source-coord` slot (per Spec 009 §Source-coord). Exercises the
-  panel-specific source-coord chip rendering. Panel-specific axis B."
+  panel's per-row `↗` open-in-editor glyph. Panel-specific axis B."
   []
   (vec
     (for [i (range 6)]
@@ -395,16 +405,16 @@
      :trace-events (ten-events-buffer)}))
 
 (defn medium-trace-history
-  "One epoch carrying a 100-row domino trail. The cap (200) is not hit;
-  the overflow indicator stays quiet."
+  "One epoch carrying a 100-row domino trail. A mid-density epoch —
+  the flat list renders every row (no row cap, rf2-aqusw)."
   []
   (single-epoch-history
     {:epoch-id 3 :event [:dashboard/recompute-all]
      :trace-events (hundred-events-buffer)}))
 
 (defn long-trace-history
-  "One epoch carrying a 1000-row trail — exercises the 200-row cap and
-  the overflow indicator at the head of the feed."
+  "One epoch carrying a 1000-row trail — a deep epoch. The flat list
+  renders the whole epoch's trace in fire order (oldest-first)."
   []
   (single-epoch-history
     {:epoch-id 4 :event [:storm/replay]
@@ -458,7 +468,7 @@
 
 (defn source-coord-history
   "One epoch whose every row carries a `:source-coord` slot — exercises
-  the panel's clickable source-coord chip (jump-to-editor affordance)."
+  the panel's per-row `↗` open-in-editor glyph (jump-to-editor)."
   []
   (single-epoch-history
     {:epoch-id 11 :event [:counter/inc]

--- a/tools/xray/testbeds/panel_gallery/gallery_edn_inspector.cljs
+++ b/tools/xray/testbeds/panel_gallery/gallery_edn_inspector.cljs
@@ -90,11 +90,16 @@
             shallow-depth)."})
 
   (story/reg-story :story.xray.edn-inspector
-    {:doc        "Visual gallery of the edn-inspector widget under
-                 varying input shapes + opts combinations. One
+    {:doc        "THE GEM of this testbed — the edn-inspector widget,
+                 the single CLJS-value renderer behind every Xray panel
+                 (App-db, Trace payloads, Reactive sub values, Machine
+                 snapshots, Routing diffs). Exercised here in isolation
+                 across every input shape + the full opts surface
+                 (`:zoomable?`, `:popup-affordance?`, `:card?`,
+                 `:header`, `:site-id`, `:default-expanded-depth`). One
                  variant per shape / opts pin; side-by-side in the
-                 workspace so the renderer's response is visible at
-                 a glance."
+                 workspace so the renderer's response is visible at a
+                 glance."
      :component  :panel-gallery.edn-inspector/Panel
      :tags       #{:dev :feature/xray-edn-inspector}
      :substrates #{:reagent}})

--- a/tools/xray/testbeds/panel_gallery/gallery_epoch.cljs
+++ b/tools/xray/testbeds/panel_gallery/gallery_epoch.cljs
@@ -16,10 +16,12 @@
   |--------------------------|----------------------------------------------------|
   | `vanilla-db`             | DISPATCH · COEFFECT · HANDLER (db FULL+DIFF) · SIDE EFFECTS (flat ledger: `:db` ✓ → app-db) · SUBSCRIPTIONS · VIEWS |
   | `side-effects`           | DISPATCH · HANDLER (fx) · SIDE EFFECTS — FLAT per-effect ledger (rf2-j630b): one row per effect in execution order — `:db` ✓ → app-db, then the `:fx` rows (✓ ran · ↺ overridden · – skipped-on-platform), then the dropped `other` row (–). Single badge ✓/✗ (AND-of-rows; skipped neutral) |
-  | `machine-driven`         | DISPATCH · HANDLER (machine cascade: GUARDS · LIFECYCLE · TRANSITION · AFTER-TIMERS) · SIDE EFFECTS |
+  | `machine-driven`         | DISPATCH · HANDLER (machine cascade: a SINGLE time-ordered row stream — guard · action(phase) · transition · timer — rf2-u69j7) · SIDE EFFECTS |
   | `db-schema-fail`         | DISPATCH · HANDLER (db) · SIDE EFFECTS (flat ledger: `:db` ✗ schema-fail rollback ONLY — the `:where :app-db` violation reason box rides the `:db` row, badge + row paint ✗, no fx rows ran, `:outcome :error`, SUBSCRIPTIONS / VIEWS mute downstream — rf2-j630b / rf2-8resu) |
-  | `exception`              | DISPATCH · HANDLER (✗ — inline 'Exception Thrown' block: message + collapsible stack/ex-data, `— no :db (handler threw)` placeholder, NO 'Rolled back' chip, `:outcome :error` — rf2-ahhgn / rf2-wnvid) |
+  | `exception`              | DISPATCH · HANDLER (✗ — inline 'Exception Thrown' block UNDER the HANDLER step: message + collapsible stack/ex-data, `— no :db (handler threw)` placeholder, NO 'Rolled back' chip, `:outcome :error` — rf2-ahhgn / rf2-wnvid / rf2-yz57h) |
   | `fx-exception`           | DISPATCH · HANDLER (db) · SIDE EFFECTS (flat ledger: `:db` ✓ then the `:fx` rows; the throwing `:email/send` row ✗ with its inline 'Exception Thrown' card; badge ✗; committed `:db` NOT rolled back — rf2-ahhgn / rf2-j630b) |
+  | `interceptor-exception`  | DISPATCH · COEFFECT · INTERCEPTOR (✗ — NEW conditional step rf2-yz57h, `:audit/trail` threw `:after`; inline 'Exception Thrown' card UNDER the INTERCEPTOR step) · HANDLER (db — ran; `:after` throw doesn't skip it) · `:outcome :error` |
+  | `coeffect-throw-skipped` | DISPATCH · COEFFECT (✗ — `:session` injector threw on the way IN; inline 'Exception Thrown' card UNDER the COEFFECT step) · HANDLER (⊘ SKIPPED — handler never ran, rf2-yz57h `mark-skipped-handler`) · `:outcome :error` |
   | `caused-by-subs`         | DISPATCH · HANDLER (db) · SUBSCRIPTIONS — `caused by <event-id>` cell (rf2-1cc03) + static `:input-signals` inputs column (layer-1 → `app-db`, derived → upstream sub-ids — rf2-87c8a) |
   | `handler-flow-db`        | DISPATCH · HANDLER (`:db` diff = handler-only, t1) · FLOW (`:db` diff = flow's t1→t2 reshape) — the two `:db` contributions as SEPARATE steps (rf2-4wywy / rf2-48oc4) |
   | `child-dispatches`       | DISPATCH · HANDLER (fx) · SIDE EFFECTS · CHILD DISPATCHES (resolved + not-in-buffer) |
@@ -119,10 +121,13 @@
   (story/reg-variant :story.xray.epoch/machine-driven
     {:doc        "Machine-handler cascade for a :ws/connection machine
                  (`:ws/open` transitions :connecting → :open).
-                 Exercises the rich machine-handler section — TRANSITION,
-                 GUARDS, LIFECYCLE (across :exit / :transition / :entry
-                 / :always phases), AFTER-TIMERS, DATA-REDUCTION,
-                 SNAPSHOT-DIFF (the rf2-9c27r full design)."
+                 Exercises the rich machine-handler section as a SINGLE
+                 TIME-ORDERED CASCADE (rf2-u69j7) — one row per substrate
+                 emit in trace order: guard (pass/fail) · action (across
+                 :exit / :transition / :entry / :always / :after-action
+                 phases, with per-action data + fx attribution) ·
+                 transition · timer-cancel — replacing the pre-rf2-u69j7
+                 category roll-up."
      :events     [[:rf.xray/sync-epoch-history (fixtures/machine-history)]]
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
@@ -138,8 +143,9 @@
                  attaches to it with its reason box; the single badge +
                  the `:db` row both paint ✗; the epoch `:outcome` flips
                  `:error`; SUBSCRIPTIONS / VIEWS mute downstream.
-                 Hot-reload drift is an Issues-panel concern (rf2-7gf7v)
-                 — no cascade step surfaces it."
+                 Hot-reload drift surfaces inline (rf2-gbz39 — Issues
+                 is no longer a tab; rf2-7gf7v) — no cascade step
+                 surfaces it."
      :events     [[:rf.xray/sync-epoch-history (fixtures/schema-violations-history)]]
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
@@ -175,7 +181,38 @@
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
 
-  ;; ----- 4c. subscriptions caused-by + input-signals ----------------
+  ;; ----- 4d. INTERCEPTOR step — :after throw (rf2-yz57h · rf2-mszrz) -
+  (story/reg-variant :story.xray.epoch/interceptor-exception
+    {:doc        "Cascade where a user interceptor (`:audit/trail`) threw
+                 in its `:after` phase (`:rf.error/interceptor-exception`)
+                 AFTER the handler ran cleanly. Exercises the NEW
+                 conditional INTERCEPTOR step (rf2-yz57h): the step renders
+                 between COEFFECT and HANDLER, paints ✗, and carries the
+                 interceptor id + `:after` phase + the inline 'Exception
+                 Thrown' card placed UNDER the INTERCEPTOR step (rf2-yz57h
+                 per-step placement, no longer collapsing onto HANDLER).
+                 The HANDLER step is NOT skipped — an `:after` throw runs
+                 the handler first — so its `:db` write still renders; the
+                 epoch `:outcome` flips `:error`."
+     :events     [[:rf.xray/sync-epoch-history (fixtures/interceptor-after-throw-history)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 4e. upstream :before throw — HANDLER SKIPPED (rf2-yz57h) ----
+  (story/reg-variant :story.xray.epoch/coeffect-throw-skipped
+    {:doc        "Cascade where a coeffect injector (`:session`) threw on
+                 the way IN (`:rf.error/coeffect-exception`), so the event
+                 handler never ran. Exercises the rf2-yz57h skip path: the
+                 throwing cofx's (synthesised placeholder) COEFFECT step
+                 paints ✗ with the inline 'Exception Thrown' card UNDER it,
+                 and the downstream HANDLER step renders as SKIPPED (⊘
+                 muted) — NOT 'ran, returned no :db' (the handler body
+                 never executed). The epoch `:outcome` flips `:error`."
+     :events     [[:rf.xray/sync-epoch-history (fixtures/coeffect-throw-skipped-history)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 4f. subscriptions caused-by + input-signals ----------------
   ;;          (rf2-1cc03 · rf2-87c8a)
   (story/reg-variant :story.xray.epoch/caused-by-subs
     {:doc        "Cascade where `:cart/add` invalidates the layer-1
@@ -341,20 +378,24 @@
 
   ;; ----- workspace ---------------------------------------------------
   (story/reg-workspace :Workspace.xray.epoch/all
-    {:doc      "All twenty Epoch panel variants in one auto-grid. Scroll
-                to see the cascade across vanilla-db / side-effects /
-                machine-driven / db-schema-fail / exception /
-                fx-exception / caused-by-subs / handler-flow-db /
-                child-dispatches / long-step / flow-firing / empty /
+    {:doc      "All twenty-two Epoch panel variants in one auto-grid.
+                Scroll to see the cascade across vanilla-db /
+                side-effects / machine-driven / db-schema-fail /
+                exception / fx-exception / interceptor-exception /
+                coeffect-throw-skipped / caused-by-subs / handler-flow-db
+                / child-dispatches / long-step / flow-firing / empty /
                 no-events / unmounted-views / disposed-subs and the
                 rf2-5qp4g per-source-kind enrichment variants
                 (after-timer / machine-spawn / fx-dispatch /
-                fx-dispatch-later / fx-dispatch-orphan). The
-                rf2-j630b refresh surfaces the SIDE EFFECTS step as a
-                FLAT per-effect ledger (one row per effect in execution
-                order + a single ✓/✗ badge + the `:db` → app-db marker +
-                the `:db` schema-fail rollback), the inline 'Exception
-                Thrown' block (handler + fx throws), the subscriptions
+                fx-dispatch-later / fx-dispatch-orphan). The rf2-yz57h
+                refresh surfaces exceptions UNDER the step where they
+                occurred (the NEW conditional INTERCEPTOR step + the
+                per-step ✓/✗/⊘ status), an upstream `:before`-chain
+                throw marking the HANDLER SKIPPED (⊘). The rf2-j630b
+                refresh surfaces the SIDE EFFECTS step as a FLAT
+                per-effect ledger (one row per effect in execution order
+                + a single ✓/✗ badge + the `:db` → app-db marker + the
+                `:db` schema-fail rollback). Plus the subscriptions
                 `caused by <event-id>` cell + static `:input-signals`
                 inputs column, and the handler-`:db` vs flow-`:db`-diff
                 split."

--- a/tools/xray/testbeds/panel_gallery/gallery_routing.cljs
+++ b/tools/xray/testbeds/panel_gallery/gallery_routing.cljs
@@ -1,5 +1,5 @@
 (ns panel-gallery.gallery-routing
-  "Story coverage for the **Routes tab** of the 7-tab Xray chrome
+  "Story coverage for the **Routes tab** of the 6-tab Xray chrome
   (rf2-nrbs9, reshaped per rf2-lq0ef).
 
   The Routes tab body is the `routing/Panel` view. The panel reads:

--- a/tools/xray/testbeds/panel_gallery/gallery_trace.cljs
+++ b/tools/xray/testbeds/panel_gallery/gallery_trace.cljs
@@ -1,13 +1,29 @@
 (ns panel-gallery.gallery-trace
-  "Story coverage for the **Trace tab** of the new 6-tab Xray chrome
+  "Story coverage for the **Trace tab** of the 6-tab Xray chrome
   (rf2-sszlr — gallery rebuild for spec/018-Event-Spine; epoch-scoped
-  rewire rf2-ofoqu).
+  rewire rf2-ofoqu; FLAT-list refresh rf2-aqusw).
 
-  The Trace tab body is the `trace/Panel` view: the raw-event ribbon
-  scoped to the spine's FOCUSED EPOCH (rf2-td380). The panel reads the
-  focused epoch's `:trace-events` slice — resolved via the shared
-  `focus-resolver` over `:rf.xray/focus` + `:rf.xray/epoch-history` —
-  NOT the trace bus.
+  The Trace tab body is the `trace/Panel` view: the focused epoch's
+  whole trace as a SINGLE FLAT LIST of op rows (rf2-aqusw — the prior
+  4-band hierarchy is gone), scoped to the spine's FOCUSED EPOCH
+  (rf2-td380). The panel reads the focused epoch's `:trace-events`
+  slice — resolved via the shared `focus-resolver` over
+  `:rf.xray/focus` + `:rf.xray/epoch-history` — NOT the trace bus.
+
+  ## The flat row shape (rf2-aqusw)
+
+  The list reads top-down, OLDEST-FIRST. Each op is a row of six
+  columns — `Δt · stage · area badge · what-happened · target/detail ·
+  duration`. The STAGE column names the Epoch-panel pipeline step the
+  op belongs to (DISPATCH · COEFFECT · HANDLER · FLOW · SIDE EFFECTS ·
+  SUBSCRIPTIONS · VIEWS) and the row's left EDGE is colour-coded with
+  that step's colour — both resolved through the Epoch panel's own
+  `panels.epoch.badge` taxonomy (one step model, DRY). Errors /
+  warnings render inline at their chronological point; the left edge
+  rides the severity colour over the stage colour so a failure stands
+  out. Clicking any row opens the edn-inspector on its raw trace MAP
+  inline (spec/023 §3). No chip-filtering (the focused epoch IS the
+  scope, rf2-gkczt); no row cap (every op renders).
 
   ## Why seed via `:rf.xray/sync-epoch-history` (rf2-ofoqu)
 
@@ -40,12 +56,14 @@
             (per spec/018-Event-Spine §5.4 + rf2-td380)."})
 
   (story/reg-story :story.xray.trace
-    {:doc        "Visual gallery of the Xray Trace tab under varying
+    {:doc        "Visual gallery of the Xray Trace tab (the FLAT
+                 oldest-first op-row list, rf2-aqusw) under varying
                  epoch trace-event depth + shape. Each variant seeds
                  its frame's :epoch-history via
                  :rf.xray/sync-epoch-history; the panel reads the
                  focused epoch's :trace-events from the variant frame
-                 in isolation."
+                 in isolation and projects each op into a row with a
+                 STAGE column + colour-coded left edge."
      :component  :panel-gallery.trace/Panel
      :tags       #{:dev :feature/xray-trace}
      :substrates #{:reagent}})
@@ -63,7 +81,8 @@
   (story/reg-variant :story.xray.trace/short-trace
     {:doc        "A normal cascade — the focused epoch's domino trail
                  is ten events spanning every canonical op-type. One
-                 row per event, newest first."
+                 row per event, oldest-first, each carrying its STAGE
+                 column + colour-coded left edge."
      :events     [[:rf.xray/sync-epoch-history (fixtures/short-trace-history)]]
      :tags       #{:dev :state/small}
      :substrates #{:reagent}})
@@ -71,17 +90,19 @@
   ;; ----- 3. medium trace (100 rows) ----------------------------------
   (story/reg-variant :story.xray.trace/medium-trace
     {:doc        "Focused epoch with a 100-row domino trail spanning
-                 all four op-types. The 200-row cap is not hit; the
-                 overflow indicator stays quiet."
+                 all four op-types. The flat list renders every row
+                 (no row cap, rf2-aqusw); exercises the panel under a
+                 mid-density epoch with the full stage taxonomy."
      :events     [[:rf.xray/sync-epoch-history (fixtures/medium-trace-history)]]
      :tags       #{:dev :state/medium}
      :substrates #{:reagent}})
 
-  ;; ----- 4. long trace (1000 rows; cap-eviction) ---------------------
+  ;; ----- 4. long trace (1000 rows) -----------------------------------
   (story/reg-variant :story.xray.trace/long-trace
-    {:doc        "Focused epoch with a 1000-row trail — exercises the
-                 200-row cap and surfaces the overflow indicator at the
-                 head of the feed."
+    {:doc        "Focused epoch with a 1000-row trail — the flat list
+                 renders the whole epoch's trace in fire order
+                 (oldest-first); exercises the panel + the shared
+                 resizable-table under a deep epoch."
      :events     [[:rf.xray/sync-epoch-history (fixtures/long-trace-history)]]
      :tags       #{:dev :state/large}
      :substrates #{:reagent}})
@@ -89,8 +110,11 @@
   ;; ----- 5. trace with errors ----------------------------------------
   (story/reg-variant :story.xray.trace/trace-with-errors
     {:doc        "Focused epoch whose every row is an issue: two
-                 errors, two warnings, one info. Per-row dot colours
-                 match the severity tiers."
+                 errors, two warnings, one info. Errors / warnings
+                 render inline at their chronological point; the row's
+                 left EDGE rides the severity colour over the stage
+                 colour and the Δt leads with `!` so a failure stands
+                 out (spec/023 §7)."
      :events     [[:rf.xray/sync-epoch-history (fixtures/errors-trace-history)]]
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
@@ -126,8 +150,10 @@
   (story/reg-variant :story.xray.trace/redacted
     {:doc        "Focused epoch whose dispatched event payload carries
                  `:rf/redacted` markers on `:password` + `:totp`. The
-                 panel's description column renders the marker verbatim
-                 per Spec 009 §Privacy."
+                 row's target/detail column renders the dispatched
+                 event vector with the marker verbatim per Spec 009
+                 §Privacy; clicking the row opens the edn-inspector on
+                 the raw trace MAP (the marker survives there too)."
      :events     [[:rf.xray/sync-epoch-history (fixtures/redacted-trace-history)]]
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
@@ -144,8 +170,9 @@
   ;; ----- 10. source-coord --------------------------------------------
   (story/reg-variant :story.xray.trace/source-coord
     {:doc        "Focused epoch whose every row carries a
-                 `:source-coord` slot (file + line). The per-row
-                 source-coord chip renders with the cyan accent and is
+                 `:source-coord` slot (file + line). The per-row `↗`
+                 open-in-editor glyph rides the end of the
+                 target/detail column with the accent colour and is
                  clickable. Panel-specific axis: jump-to-editor."
      :events     [[:rf.xray/sync-epoch-history (fixtures/source-coord-history)]]
      :tags       #{:dev :state/special}
@@ -153,10 +180,12 @@
 
   ;; ----- workspace ---------------------------------------------------
   (story/reg-workspace :Workspace.xray.trace/all
-    {:doc      "All ten Trace tab variants in one auto-grid. Scroll
-                to see the panel's response across empty / short /
-                medium / long / errors / flows / mixed-op-types /
-                redacted / cross-frame / source-coord."
+    {:doc      "All ten Trace tab variants (the FLAT oldest-first
+                op-row list, rf2-aqusw) in one auto-grid. Scroll to see
+                the panel's response across empty / short / medium /
+                long / errors / flows / mixed-op-types / redacted /
+                cross-frame / source-coord — each row carrying its
+                STAGE column + colour-coded left edge."
      :layout   :variants-grid
      :story    :story.xray.trace
      :columns  2

--- a/tools/xray/testbeds/panel_gallery/gallery_views.cljs
+++ b/tools/xray/testbeds/panel_gallery/gallery_views.cljs
@@ -1,87 +1,194 @@
 (ns panel-gallery.gallery-views
   "Story coverage for the **Reactive tab** of the Xray chrome
-  (rf2-wyvf2 · spec/021 §3 · renamed from Views per §11.5).
+  (rf2-wyvf2 · spec/021 §3 · renamed from Views per §11.5; render-cause
+  refresh rf2-bhi3t).
 
   The Reactive tab body is the `reactive-panel/Panel` view. It reads
   `:rf.xray/reactive-data`, a composite over the spine's
-  `:rf.xray/focus` + the focused cascade's `:trace-events`. Each
+  `:rf.xray/focus` + the focused epoch record's `:sub-runs` /
+  `:renders` structured projections + its raw `:trace-events`. Each
   variant seeds the variant frame's `:epoch-history` directly with a
-  vector of synthetic epoch records carrying `:trace-events` shaped
-  per the substrate trace ops landed in PRs #1728 + #1729."
+  vector of synthetic epoch records.
+
+  ## Record shape the panel reads (per spec/018 + reactive_panel_subs)
+
+  `project-record` reads:
+
+    - `:sub-runs`     — `[{:sub-id :query-v :recomputed? :value-changed?
+                           :value :prev-value} ...]`; drives the L1/L2
+                        sub tables + the `changed-set` that classifies
+                        each view's render reason.
+    - `:trace-events` — the view-side capture ops the flow graph reads:
+                        `:rf.view/rendered` (with `:rf.view/id` /
+                        `:rf.view/render-key` / `:rf.view/mount?` /
+                        `:rf.view/deref-subs` / `:rf.view/triggered-by`
+                        / `:rf.view/elapsed-ms`) + `:rf.view/unmounted`
+                        + `:rf.sub/dispose`.
+    - `:event`        — the trigger event (the cascade's seed).
+
+  ## Render-cause chips (rf2-bhi3t)
+
+  A view re-renders for exactly one of two reasons — a SUBSCRIPTION it
+  derefs changed value, or its PROPS changed (the orthogonal
+  `:rf/props` channel). The view-node's cause sub-label attributes
+  which: `← :sub-id` when the render carries a `:rf.view/triggered-by`
+  cause sub, `← props` on a re-render whose own derefed subs all held
+  value (so the cause is the props channel). A mount carries no cause
+  (the `(mounted)` label conveys the first render). The
+  `render-cause` variant below pins all three states side-by-side."
   (:require [re-frame.story :as story]
             [panel-gallery.panel-views :as panel-views]))
 
 (defn register-gallery-view! []
   (panel-views/register!))
 
-;; ---- pure fixture builders ---------------------------------------------
+;; ---- pure fixture builders ----------------------------------------------
+;;
+;; The fixtures build `:rf/epoch-record`-shaped maps. The panel reads
+;; the structured `:sub-runs` projection (for the L1/L2 sub tables +
+;; the changed-set) and the raw `:trace-events` (for the flow-graph
+;; view nodes + their render-cause chips). Each builder mirrors the
+;; substrate emit-site shape `reactive_panel_subs` reads.
 
-(defn- trace-event
-  [op payload]
-  {:operation op
-   :payload   payload})
+(defn- sub-run
+  "One `:sub-runs` entry. `recomputed?` splits genuine recomputes
+  (subs-ran) from memo-hit skips (subs-skipped); `value-changed?`
+  feeds the per-view render-reason `changed-set`."
+  [sub-id recomputed? value-changed? prev-value value]
+  {:sub-id         sub-id
+   :query-v        [sub-id]
+   :recomputed?    recomputed?
+   :value-changed? value-changed?
+   :prev-value     prev-value
+   :value          value})
+
+(defn- rendered-ev
+  "A `:rf.view/rendered` trace event in the shape `view-rows` reads.
+  `:rf.view/mount?` true → a mount (no cause); false → a re-render.
+  `triggered-by` (a sub-id) drives the `← :sub-id` cause chip; omit it
+  on a re-render to drive the `← props` chip (the props channel)."
+  ([view-id render-key mount? deref-subs elapsed-ms]
+   (rendered-ev view-id render-key mount? deref-subs elapsed-ms nil))
+  ([view-id render-key mount? deref-subs elapsed-ms triggered-by]
+   {:operation :rf.view/rendered
+    :tags      (cond-> {:rf.view/id         view-id
+                        :rf.view/render-key render-key
+                        :rf.view/mount?     mount?
+                        :rf.view/deref-subs deref-subs
+                        :rf.view/elapsed-ms elapsed-ms}
+                 (some? triggered-by)
+                 (assoc :rf.view/triggered-by triggered-by))}))
+
+(defn- unmounted-ev
+  "A `:rf.view/unmounted` teardown trace event — drives a view-row's
+  `:unmount` action + the UNMOUNTED VIEWS section."
+  [view-id render-key]
+  {:operation :rf.view/unmounted
+   :tags      {:rf.view/id view-id :rf.view/render-key render-key}})
+
+(defn- dispose-ev
+  "A `:rf.sub/dispose` teardown trace event — drives the DESTROYED
+  SUBSCRIPTIONS section."
+  [sub-id]
+  {:operation :rf.sub/dispose
+   :tags      {:rf.sub/id sub-id :rf.sub/query-v [sub-id]}})
+
+(defn- record
+  "Wrap a one-record `:epoch-history` (the focus-resolver head-fallback
+  resolves to `(peek epoch-history)`)."
+  [{:keys [event sub-runs trace-events]}]
+  [{:epoch-id     1
+    :dispatch-id  1
+    :event        event
+    :sub-runs     (vec sub-runs)
+    :trace-events (vec trace-events)}])
 
 (defn- empty-buffer [] [])
 
-(defn- sparse-cascade-buffer []
-  [{:epoch-id     :ep-1
-    :dispatch-id  :dispatch-1
-    :event        [:checkout/submit {:id 42}]
-    :trace-events [(trace-event :rf.sub/computed {:sub-id :cart/state})
-                   (trace-event :rf.view/rendered
-                                {:view-id :cart.banner/StateBanner
-                                 :file    "views/cart/banner.cljs"
-                                 :line    14
-                                 :caused-by-sub :cart/state})]}])
+(defn- sparse-cascade-buffer
+  "Single sub recomputed (changed) + single view re-rendered, caused by
+  that sub — the resting-density render. The view node reads
+  `← :cart/state`."
+  []
+  (record
+    {:event    [:checkout/submit {:id 42}]
+     :sub-runs [(sub-run :cart/state true true {:phase :idle} {:phase :submitting})]
+     :trace-events
+     [(rendered-ev :cart.banner/StateBanner [:StateBanner 0] false
+                   [[:cart/state]] 0.6 :cart/state)]}))
 
-(defn- dense-cascade-buffer []
-  [{:epoch-id     :ep-1
-    :dispatch-id  :dispatch-1
-    :event        [:checkout/submit {:id 42}]
-    :trace-events
-    (vec
-      (concat
-        [(trace-event :rf.sub/computed {:sub-id :cart/state})
-         (trace-event :rf.sub/computed {:sub-id :cart/can-submit?})
-         (trace-event :rf.sub/computed {:sub-id :cart/items})
-         (trace-event :rf.sub/computed {:sub-id :cart/total})
-         (trace-event :rf.sub/skipped {:sub-id :user/name
-                                       :reason :input-unchanged})
-         (trace-event :rf.sub/skipped {:sub-id :cart/eligibility
-                                       :reason :input-unchanged})]
-        [(trace-event :rf.view/rendered
-                      {:view-id :checkout/CheckoutButton
-                       :file    "views/checkout.cljs"
-                       :line    88
-                       :caused-by-sub :cart/can-submit?
-                       :caused-by-paths [[:cart :state]]})
-         (trace-event :rf.view/rendered
-                      {:view-id :cart.banner/StateBanner
-                       :file    "views/cart/banner.cljs"
-                       :line    14
-                       :caused-by-sub :cart/state
-                       :caused-by-paths [[:cart :state]]})
-         (trace-event :rf.view/rendered
-                      {:view-id :cart.totals/TotalsRow
-                       :file    "views/cart/totals.cljs"
-                       :line    22
-                       :caused-by-sub :cart/total
-                       :caused-by-paths [[:cart :total]]})]
-        [(trace-event :rf.cascade/captured
-                      {:subs-ran        4
-                       :subs-skipped    2
-                       :views-rendered  3
-                       :flows-recomputed 0})]))}])
+(defn- dense-cascade-buffer
+  "Mid-load: 4 subs ran (2 changed) · 2 memo-hit skips · 3 views
+  re-rendered. The view nodes exercise the full render-cause taxonomy
+  (rf2-bhi3t): two `← :sub-id` causes + one `← props` re-render."
+  []
+  (record
+    {:event [:checkout/submit {:id 42}]
+     :sub-runs
+     [(sub-run :cart/state       true  true  {:phase :idle} {:phase :submitting})
+      (sub-run :cart/can-submit? true  true  false true)
+      (sub-run :cart/items       true  false [{:id :apple}] [{:id :apple}])
+      (sub-run :cart/total       true  false 195 195)
+      (sub-run :user/name        false false "Ada" "Ada")
+      (sub-run :cart/eligibility false false true true)]
+     :trace-events
+     [(rendered-ev :checkout/CheckoutButton [:CheckoutButton 0] false
+                   [[:cart/can-submit?]] 0.9 :cart/can-submit?)
+      (rendered-ev :cart.banner/StateBanner [:StateBanner 0] false
+                   [[:cart/state]] 0.7 :cart/state)
+      ;; A re-render whose own derefed subs ALL held value — the cause
+      ;; is the props channel, so the node reads `← props` (rf2-bhi3t).
+      (rendered-ev :cart.totals/TotalsRow [:TotalsRow 0] false
+                   [[:cart/total]] 0.5)]}))
 
-(defn- silent-cascade-buffer []
-  [{:epoch-id     :ep-1
-    :dispatch-id  :dispatch-1
-    :event        [:ping/tick]
-    :trace-events [(trace-event :rf.cascade/captured
-                                {:subs-ran        0
-                                 :subs-skipped    0
-                                 :views-rendered  0
-                                 :flows-recomputed 0})]}])
+(defn- render-cause-buffer
+  "Pins all three render-cause states side-by-side (rf2-bhi3t):
+   - a MOUNT (no cause; the `(mounted)` label conveys the first render)
+   - a SUBSCRIPTION-driven re-render (`← :route/current`)
+   - a PROPS-driven re-render (`← props` — its derefed sub held value)."
+  []
+  (record
+    {:event [:route/change :dashboard]
+     :sub-runs
+     [(sub-run :route/current true true :checkout :dashboard)
+      (sub-run :user/prefs    true false {:theme :dark} {:theme :dark})]
+     :trace-events
+     [;; mount — first render of the new route's page; no cause chip.
+      (rendered-ev :app.dashboard/Page [:Page 0] true
+                   [[:route/current]] 1.1)
+      ;; subscription-driven re-render — its deref of :route/current
+      ;; changed value → `← :route/current`.
+      (rendered-ev :app.nav/Breadcrumb [:Breadcrumb 0] false
+                   [[:route/current]] 0.4 :route/current)
+      ;; props-driven re-render — :user/prefs held value, so none of the
+      ;; view's own subs changed → `← props`.
+      (rendered-ev :app.dashboard/Toolbar [:Toolbar 0] false
+                   [[:user/prefs]] 0.3)]}))
+
+(defn- teardown-cascade-buffer
+  "A route change tears down two views + disposes two subs while one
+  new view mounts. Exercises the UNMOUNTED VIEWS + DESTROYED
+  SUBSCRIPTIONS sections alongside a mount."
+  []
+  (record
+    {:event [:route/change :reports]
+     :sub-runs
+     [(sub-run :route/current true true :checkout :reports)]
+     :trace-events
+     [(rendered-ev :app.reports/Page [:Page 0] true [[:route/current]] 1.0)
+      (unmounted-ev :app.checkout/Modal       [:Modal 0])
+      (unmounted-ev :app.sidebar/CheckoutItem [:CheckoutItem 0])
+      (dispose-ev :checkout/total)
+      (dispose-ev :checkout/line-items)]}))
+
+(defn- silent-cascade-buffer
+  "Sparse case from spec/021 §3.2 — the epoch's db change touched no
+  subscribed paths, so no sub recomputed and no view re-rendered."
+  []
+  (record
+    {:event        [:ping/tick]
+     :sub-runs     []
+     :trace-events []}))
 
 (defn register-all!
   "Register the Reactive tab Story surface. Idempotent."
@@ -92,13 +199,17 @@
   (story/reg-tag :feature/xray-reactive
     {:axis :feature
      :doc  "Xray Reactive tab — sub-cascade + view-re-render
-            visualisation per spec/021 §3 (rf2-wyvf2)."})
+            visualisation per spec/021 §3 (rf2-wyvf2); per-view
+            render-cause attribution (rf2-bhi3t)."})
 
   (story/reg-story :story.xray.reactive
     {:doc        "Visual gallery of the Xray Reactive tab under
-                 varying cascade magnitude. Each variant seeds the
-                 variant frame's :epoch-history directly with
-                 synthetic epoch records carrying :trace-events."
+                 varying cascade magnitude + render-cause shape. Each
+                 variant seeds the variant frame's :epoch-history
+                 directly with a synthetic epoch record carrying
+                 :sub-runs + :trace-events; the flow graph paints one
+                 node per sub / view with the per-view render-cause
+                 chip (← :sub-id / ← props)."
      :component  :panel-gallery.reactive/Panel
      :tags       #{:dev :feature/xray-reactive}
      :substrates #{:reagent}})
@@ -111,18 +222,43 @@
      :substrates #{:reagent}})
 
   (story/reg-variant :story.xray.reactive/sparse
-    {:doc        "Single sub recomputed + single view re-rendered.
-                 Pins the resting-density render."
+    {:doc        "Single sub recomputed (changed) + single view
+                 re-rendered caused by that sub. Pins the
+                 resting-density render — the view node reads
+                 `← :cart/state`."
      :events     [[:rf.xray/sync-epoch-history (sparse-cascade-buffer)]]
      :tags       #{:dev :state/small}
      :substrates #{:reagent}})
 
   (story/reg-variant :story.xray.reactive/dense
-    {:doc        "Mid-load: 4 subs ran · 2 skipped · 3 views
-                 re-rendered + a :rf.cascade/captured aggregate.
-                 The dense-but-typical cascade."
+    {:doc        "Mid-load: 4 subs ran (2 changed) · 2 memo-hit skips ·
+                 3 views re-rendered. The view nodes exercise the full
+                 render-cause taxonomy (rf2-bhi3t) — two `← :sub-id`
+                 causes + one `← props` re-render."
      :events     [[:rf.xray/sync-epoch-history (dense-cascade-buffer)]]
      :tags       #{:dev :state/medium}
+     :substrates #{:reagent}})
+
+  ;; ----- render-cause chips (rf2-bhi3t) ------------------------------
+  (story/reg-variant :story.xray.reactive/render-cause
+    {:doc        "All three render-cause states side-by-side (rf2-bhi3t):
+                 a MOUNT (no cause — the `(mounted)` label), a
+                 SUBSCRIPTION-driven re-render (`← :route/current`), and
+                 a PROPS-driven re-render (`← props`, its derefed sub
+                 held value so the cause is the orthogonal props
+                 channel)."
+     :events     [[:rf.xray/sync-epoch-history (render-cause-buffer)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- teardown sections -------------------------------------------
+  (story/reg-variant :story.xray.reactive/teardown
+    {:doc        "Route change: one new view mounts while two views
+                 unmount + two subs dispose. Exercises the UNMOUNTED
+                 VIEWS + DESTROYED SUBSCRIPTIONS sections (spec/021
+                 §3.2) beneath the live cascade graph."
+     :events     [[:rf.xray/sync-epoch-history (teardown-cascade-buffer)]]
+     :tags       #{:dev :state/special}
      :substrates #{:reagent}})
 
   (story/reg-variant :story.xray.reactive/silent
@@ -134,7 +270,10 @@
      :substrates #{:reagent}})
 
   (story/reg-workspace :Workspace.xray.reactive/all
-    {:doc      "All four Reactive tab variants in one auto-grid."
+    {:doc      "All six Reactive tab variants in one auto-grid — empty /
+                sparse / dense / render-cause / teardown / silent. The
+                render-cause + dense variants pin the rf2-bhi3t per-view
+                cause chips (← :sub-id / ← props)."
      :layout   :variants-grid
      :story    :story.xray.reactive
      :columns  2

--- a/tools/xray/testbeds/panel_gallery/panel_views.cljs
+++ b/tools/xray/testbeds/panel_gallery/panel_views.cljs
@@ -1,8 +1,8 @@
 (ns panel-gallery.panel-views
   "Registered re-frame views referenced by Story variant `:component`
-  slots in the Xray panel gallery (rf2-sszlr — rebuilt for the new
-  7-tab Xray shape; rf2-5gl5r retired the Event/Handler tab in
-  favour of the Epoch panel).
+  slots in the Xray panel gallery (rf2-sszlr — rebuilt for the
+  6-tab Xray shape; rf2-5gl5r retired the Event/Handler tab in
+  favour of the Epoch panel; rf2-gbz39 folded Issues inline).
 
   Story canvas resolves `:component` to a registered re-frame view
   via `(rf/view <id>)` (per


### PR DESCRIPTION
MEDIUM content refresh (Mike-ruled depth) of the existing `panel_gallery`
Story workspace (`tools/xray/testbeds/panel_gallery/`). NOT a rebuild — the
Story-host rebuild already shipped (durls #2530). This brings the fixtures
+ variant docs current for the panels that changed this session and
features the edn-inspector. Edits are confined to
`tools/xray/testbeds/panel_gallery/` (11 files).

## Per-item summary

**Trace** — refreshed gallery + fixture docs to the post-rf2-aqusw FLAT
shape: a single oldest-first op-row list, each row carrying a STAGE column
+ colour-coded left edge resolved through the Epoch panel's
`panels.epoch.badge` taxonomy, click → edn-inspector. Dropped the stale
"newest-first / 200-row cap / overflow indicator / per-row dot colours /
chip-row" wording (the flat list renders every row, no cap; severity rides
the left edge); described the per-row `↗` open-in-editor glyph. Verified
against `panels/trace.cljs` + `trace_helpers.cljc` (the fixtures feed raw
trace-events through `project-feed-from-epoch`, so they stay functionally
valid — only the descriptive shape was stale).

**Epoch-exceptions** — added two variants for the post-rf2-yz57h shape:
- `interceptor-exception` exercises the NEW conditional INTERCEPTOR step
  (an `:after`-phase interceptor throw renders UNDER that step; the
  handler ran, so it is NOT skipped).
- `coeffect-throw-skipped` exercises an upstream `:before`-chain throw
  (coeffect injector) that marks the HANDLER step SKIPPED (⊘), with the
  exception card placed UNDER the (synthesised) COEFFECT step.
Added the `coeffect-exception-ev` / `interceptor-exception-ev` fixture
primitives. Refreshed the `machine-driven` row to the rf2-u69j7
time-ordered cascade wording (was the pre-u69j7 category roll-up); updated
the section-coverage table + workspace doc (twenty → twenty-two). The
SIDE-EFFECTS flat ledger (j630b) was already current — left untouched.

**Issues-inline** — scrubbed residual wording implying an Issues tab/panel
(`fixtures_epoch` hot-reload notes, `fixtures.cljs` hydration
"jump-to-Issues" / "Issues-tab footer", `fixtures_edn_inspector` panel
list) to the rf2-gbz39 inline-surfacing reality (Epoch panel + L2
pink-wash + ribbon signal). No standalone Issues variant/fixture remained
(its `gallery_issues` ns + `issues-tab-panel` were already removed).

**render-cause (Reactive/Views)** — rebuilt the `gallery_views` fixtures
onto the record shape the current panel reads (`:sub-runs` +
`:rf.view/rendered` trace ops). The prior synthetic `:payload` shape
(`:rf.sub/computed` / `:caused-by-sub`) no longer matched the
`reactive_panel_subs` read path — those variants rendered incomplete and
did not exercise the rf2-bhi3t chips. Added a `render-cause` variant
pinning all three states side-by-side (a MOUNT with no cause, a
`← :route/current` subscription-driven re-render, a `← props` props-driven
re-render) + a `teardown` variant (UNMOUNTED VIEWS + DESTROYED SUBS).

**docstring** — fixed the `core.cljs` "seven L4 tabs … plus Issues"
residue + landing view to the 6-tab reality (Epoch · App-db · Reactive ·
Trace · Machines · Routing; Issues inline) and featured the edn-inspector
as the gem. Fixed two stale "7-tab" count references in `panel_views.cljs`
+ `gallery_routing.cljs`.

**edn-inspector-featuring** — enriched the `core.cljs` landing page + the
edn-inspector story `:doc` to call out the widget as the centrepiece (the
single CLJS-value renderer behind every panel). The 54 variants + their
workspace were already comprehensive; light curation only (no reordering —
the Story sidebar sorts workspaces alphabetically by id, so featuring is
done via prose, not an `:order` slot which does not exist).

spec unchanged (fixture content-refresh; gallery contract unchanged)

## Quality gates

| Gate | Result |
|------|--------|
| `npx shadow-cljs compile testbeds/panel-gallery` | PASS — 0 warnings (590 files, 589 compiled) |
| `npm run test:cljs` | PASS — 0 failures, 0 errors (5087 tests, 17158 assertions) |
| `npm run test:xray-feature-gate` | PASS — 0 failures (14 scenarios, 12 matrix rows) |
| `npm run test:bundle-isolation` | PASS — 17 artefact entries, 35 sentinels absent, allow-list ok |
| clj-kondo on changed cljs | PASS — 0 errors, 0 warnings (1 pre-existing info note, untouched line) |

Constraints honoured: edits confined to `tools/xray/testbeds/panel_gallery/`;
`tools/xray/spec/*` untouched (5crg4 owns the spec inventory);
`implementation/shadow-cljs.edn` untouched (reuses `:testbeds/panel-gallery @ 8765`);
test-free testbed (no `*.spec.cjs`).
