### PR TITLE
fix(xray/timing): bump Timing-tab text to the Xray type scale (rf2-zyjm7)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/chart/timing_waterfall.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/chart/timing_waterfall.cljc
@@ -40,6 +40,16 @@
 
 ;; ---- visual constants --------------------------------------------------
 
+;; SVG `<text>` does not inherit the panel's CSS font-size cascade, so the
+;; waterfall must paint a literal size. It reads the shared `:caption`
+;; type-scale token (≈11px at the default knob) — the panel's
+;; secondary-label level — rather than the `:micro` refused-floor (≈10px)
+;; the labels used to sit at, which read uncomfortably small in live use
+;; (rf2-zyjm7). A token (calc-string) keeps the chart on the one-knob
+;; `--rf-xray-font-size` scale with the rest of the shell. Fits the 16px
+;; `row-height` comfortably.
+(def ^:private label-font-size (:caption tokens/type-scale))
+
 (def ^:private row-height 16)
 (def ^:private label-width 80)
 (def ^:private value-width 60)
@@ -163,7 +173,7 @@
                  ;; left label
                  [:text {:x 4
                          :y (+ y (- row-height 4))
-                         :font-size 10
+                         :font-size label-font-size
                          :fill (:text-secondary tokens/tokens)}
                   (phase-label row)]
                  ;; track background
@@ -185,7 +195,7 @@
                  ;; right value
                  [:text {:x (+ bar-x bar-area-w bar-padding)
                          :y (+ y (- row-height 4))
-                         :font-size 10
+                         :font-size label-font-size
                          :fill (if slow?
                                  (:yellow tokens/tokens)
                                  (:text-tertiary tokens/tokens))}


### PR DESCRIPTION
## What

Mike (live use, 2026-05-31): the text in the Xray **Timing tab** is too small to read comfortably.

The Timing tab's wire-timing **waterfall** chart
(`tools/xray/src/day8/re_frame2_xray/chart/timing_waterfall.cljc`,
hosted by the managed-fx panel's `wire-section`) painted its SVG
`<text>` row/stage labels and duration values at a hardcoded
`:font-size 10` — the `:micro` **refused-floor** (~10px). Because SVG
`<text>` does not inherit the panel's CSS font-size cascade, that text
stayed a full notch below the surrounding panel chrome (which sits at
11–12px), so it read uncomfortably small.

## Change

Both `<text>` elements now read the shared **`:caption`** type-scale
token (~11px at the default knob) via `tokens/type-scale` — the panel's
secondary-label level, one step above the refused `:micro` floor. The
token is a `calc(var(--rf-xray-font-size, 13px) * …)` string, so the
chart text rides the **one-knob `--rf-xray-font-size` scale** in lockstep
with the rest of the shell rather than a magic px literal.

Introduced a single `^:private label-font-size` constant (with a comment
explaining the SVG-no-inherit reason) and referenced it from both text
elements. Chart geometry is untouched — caption fits the 16px
`row-height` comfortably.

### Text elements bumped (from → to)

| Element | Before | After |
|---|---|---|
| Left row/stage label (`phase-label`) | `:font-size 10` (literal px ≈ `:micro` floor) | `(:caption tokens/type-scale)` (~11px) |
| Right duration value (`duration-label` + `← slow`) | `:font-size 10` | `(:caption tokens/type-scale)` (~11px) |

### Shared-token impact

No shared token was *modified*. The fix only **consumes** the existing
`:caption` entry from `theme/tokens/type-scale`; it does not change any
token value, so no other panel is shrink- or grow-affected. The only
edited file is the Timing waterfall chart source.

## Quality gates

Run from `implementation/` (fresh worktree — one-time `npm install` done):

| Gate | Result |
|---|---|
| `npm run test:cljs` | green — 5091 tests / 17181 assertions, 0 failures, 0 errors |
| `npm run test:xray-feature-gate` | green — 14 scenarios, 0 failures, 12 matrix rows; npm exit 0 |
| `clj-kondo --lint` (changed file) | **0 errors** (1 pre-existing `clojure.string`-unused warning, present on origin/main, untouched — out of scope for this styling fix) |

Browser eyeball: not run interactively, but the change is a pure
type-token bump (10px refused-floor → ~11px caption); the xray feature
gate compiles + exercises the panel-gallery + http-toggle testbeds that
render the waterfall, all green.

## Spec

Spec unchanged — styling only. No documented sizing contract in
`tools/xray/spec/*` changes.
