### PR TITLE
feat(xray/testbed): add routes_epochs routing step-up deck (port 8032, rf2-5crg4)

### DIFF
--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -250,7 +250,17 @@
             ;; entries above. Port 8031 is the trio anchor: routes_epochs
             ;; takes 8032, machine_epochs 8033.
             8031 ["../tools/xray/testbeds/standard_epochs"
-                  "out/examples/standard-epochs"]}
+                  "out/examples/standard-epochs"]
+            ;; Single-frame routes-epochs testbed (rf2-5crg4) — the ROUTING
+            ;; sibling of standard-epochs: a tall column of numbered buttons,
+            ;; each bumping a shared baseline counter + exercising one more
+            ;; routing feature, so clicking top-to-bottom completely
+            ;; exercises the Xray Routing panel. Same source-dir-first
+            ;; cascade as 8031; compiled main.js falls through to
+            ;; out/examples/routes-epochs. Port 8032 is the trio's routing
+            ;; slot (machine_epochs takes 8033).
+            8032 ["../tools/xray/testbeds/routes_epochs"
+                  "out/examples/routes-epochs"]}
 
  :builds
  {:node-test
@@ -657,6 +667,37 @@
                       {re-frame.testbed.config/repo-root
                        #shadow/env ["RF2_TESTBED_PROJECT_ROOT" ""]}}
    :modules          {:main {:init-fn standard-epochs.core/run}}
+   :devtools         {:preloads [re-frame2-pair.runtime
+                                 day8.re-frame2-xray.preload]}}
+
+  ;; Single-frame routes-epochs testbed (rf2-5crg4) — the ROUTING sibling
+  ;; of standard-epochs. Same shape (a tall column of numbered buttons in
+  ;; ONE plainly-mounted frame, each button bumping a shared baseline
+  ;; counter + exercising one more feature), aimed squarely at the Xray
+  ;; ROUTING panel (rf-xray-routing): click top-to-bottom and the panel's
+  ;; three sections (Current route · Navigation this epoch · Route table)
+  ;; are completely exercised. A TEST surface — no deliberate bugs, no
+  ;; teaching layers (feedback_testbeds_are_test_surfaces).
+  ;;
+  ;; The routes / events / subs / views are OWNED in routes_epochs/core.cljs
+  ;; — it boots the routing artefact (`[re-frame.routing]`) and uses the
+  ;; real `reg-route` + `:rf.route/navigate` surface; it does NOT reuse the
+  ;; shared testdeck.* modules. Sources live under
+  ;; tools/xray/testbeds/routes_epochs/; the Xray preload auto-mounts
+  ;; inline so every lens reads the single frame. Served at
+  ;; http://localhost:8032 via the top-level `:dev-http` map (the routing
+  ;; slot of the _epochs trio — standard-epochs 8031, machine_epochs 8033
+  ;; mirror this build-id scheme).
+  :examples/routes-epochs
+  {:target           :browser
+   :output-dir       "out/examples/routes-epochs"
+   :asset-path       "."
+   ;; rf2-5dphw — build-env project-root for open-in-editor (see
+   ;; :examples/two-frame-isolation above for the mechanism).
+   :compiler-options {:closure-defines
+                      {re-frame.testbed.config/repo-root
+                       #shadow/env ["RF2_TESTBED_PROJECT_ROOT" ""]}}
+   :modules          {:main {:init-fn routes-epochs.core/run}}
    :devtools         {:preloads [re-frame2-pair.runtime
                                  day8.re-frame2-xray.preload]}}
 

--- a/tools/xray/README.md
+++ b/tools/xray/README.md
@@ -264,8 +264,9 @@ coverage matrix at [`spec/017-Test-Coverage-Matrix.md`](./spec/017-Test-Coverage
 reports `covered` across every row at the unit/helper/view tier.
 
 Browser testbeds live under `tools/xray/testbeds/` —
-`two_frame_isolation`, `standard_epochs`, `feature_matrix`, `panel_gallery`,
-`perf_counter` — covering the canonical multi-frame isolation surface
+`two_frame_isolation`, `standard_epochs`, `routes_epochs`, `feature_matrix`,
+`panel_gallery`, `perf_counter` — covering the canonical multi-frame
+isolation surface
 (`two_frame_isolation`: one app · two frames · Counter / Machine
 (websocket) / Routing / Async&errors tabs navigated as routes ·
 per-frame trace / events / issues / cascades · Xray target-frame
@@ -275,7 +276,12 @@ rf2-gsr6z: one frame · a tall column of numbered buttons, each bumping
 a shared baseline counter + exercising exactly one more feature, so
 clicking top-to-bottom completely exercises any one Xray panel —
 Epoch / App-db / Views / Trace / Issues; no tabs, no routing, no
-machines/SSR; supersedes the old `step_deck`), the deterministic
+machines/SSR; supersedes the old `step_deck`), the routing sibling
+(`routes_epochs`, rf2-5crg4: the same numbered-button shape — one frame ·
+baseline-bump per press · one more ROUTING feature per rung — aimed
+squarely at the Routing panel, so clicking top-to-bottom completely
+exercises its Current route · Navigation this epoch · Route table
+sections; served on port 8032), the deterministic
 feature-matrix sweep across panels + shell + launch modes + redaction
 + 20-event load, the Panel-view gallery, and the performance probe.
 

--- a/tools/xray/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/xray/testbeds/feature_matrix/scenarios.cjs
@@ -141,6 +141,18 @@ const STAGED_SURFACES = [
     html: ['tools', 'xray', 'testbeds', 'panel_gallery', 'index.html'],
     servedPath: 'testbeds/panel-gallery',
   },
+  // rf2-5crg4 — routes-epochs deck (the ROUTING step-up tester). A
+  // single-frame numbered-button ladder over the real `reg-route` +
+  // `:rf.route/navigate` surface, driving the Xray Routing panel
+  // (`rf-xray-routing`). Served from the deck's own hand-written
+  // index.html (source dir first, like the 8032 :dev-http entry); the
+  // compiled main.js falls through to out/examples/routes-epochs.
+  {
+    build: 'examples/routes-epochs',
+    bundleDir: ['out', 'examples', 'routes-epochs'],
+    html: ['tools', 'xray', 'testbeds', 'routes_epochs', 'index.html'],
+    servedPath: 'testbeds/routes-epochs',
+  },
 ];
 
 function sleep(ms) {
@@ -2538,6 +2550,248 @@ async function runPanelGalleryThemeTokens(page, state) {
   }
 }
 
+// rf2-5crg4 — routes-epochs routing step-up deck. Walks the deck's
+// numbered ladder top-to-bottom and asserts the Xray Routing panel
+// (`rf-xray-routing`) lights up across its three sections — CURRENT
+// ROUTE, NAVIGATION THIS EPOCH, and the nested ROUTE TABLE — plus the
+// blocked-navigation outcome. The deck owns its routes/events/subs and
+// drives the real `reg-route` + `:rf.route/navigate` surface, so this
+// is genuine Routing-panel coverage (not a synthetic override).
+//
+// The panel is focused-epoch scoped: after a host dispatch LIVE
+// auto-snaps focus to the head cascade, so the NAVIGATION THIS EPOCH
+// section reflects the just-clicked button. CURRENT ROUTE + ROUTE TABLE
+// render every epoch. We read each section's stable data-testids.
+
+// Click a deck ladder rung by its per-rung data-testid
+// (`routes-epochs-rung-<n>`, outside Xray chrome).
+async function clickRung(page, n) {
+  await clickTestId(page, `routes-epochs-rung-${n}`);
+}
+
+// Read the Routing panel's projected slice from the DOM. Returns nulls
+// when a section is absent so callers can assert specific fields.
+async function readRoutingPanel(page) {
+  return page.evaluate(() => {
+    const root = document.getElementById('rf-xray-root');
+    if (!root) return { mounted: false };
+    function text(id) {
+      const el = root.querySelector(`[data-testid="${id}"]`);
+      return el ? (el.textContent || '').trim() : null;
+    }
+    function present(id) {
+      return Boolean(root.querySelector(`[data-testid="${id}"]`));
+    }
+    // ROUTE TABLE rows: collect each row's data-route-id + nested padding
+    // (the depth indent paints via inline padding-left) + current marker.
+    const tableRows = Array.from(
+      root.querySelectorAll('[data-testid^="rf-xray-routing-table-row-"]'),
+    )
+      .filter((el) => el.getAttribute('data-route-id'))
+      .map((el) => ({
+        routeId: el.getAttribute('data-route-id'),
+        marker: el.getAttribute('data-marker'),
+        current: el.getAttribute('data-current') === 'true',
+        paddingLeft: el.style.paddingLeft || '',
+      }));
+    return {
+      mounted: present('rf-xray-routing'),
+      silent: present('rf-xray-routing-silent'),
+      currentId: text('rf-xray-routing-current-id'),
+      currentParams: text('rf-xray-routing-current-params'),
+      currentPath: text('rf-xray-routing-current-path'),
+      navFrom: text('rf-xray-routing-nav-from'),
+      navTo: text('rf-xray-routing-nav-to'),
+      navParams: text('rf-xray-routing-nav-params'),
+      navOutcome: text('rf-xray-routing-nav-outcome'),
+      noActivity: present('rf-xray-routing-no-activity'),
+      currentMarker: present('rf-xray-routing-table-current-marker'),
+      tableRows,
+    };
+  });
+}
+
+async function runRoutesEpochs(page, state) {
+  await openXray(page);
+  await clickTab(page, 'routing', 'rf-xray-routing');
+
+  // The deck's `run` already navigates home, so the ROUTE TABLE is
+  // populated immediately (NOT the silent no-routes state). Assert the
+  // panel is live with the deck's registered routes before driving the
+  // ladder.
+  const initial = await waitForValue(
+    () => readRoutingPanel(page),
+    (snap) =>
+      snap.mounted &&
+      !snap.silent &&
+      snap.tableRows.length >= 6 &&
+      snap.tableRows.some((r) => r.routeId.includes('routes-epochs/home')),
+    { timeoutMs: 10000, description: 'routes-epochs route table renders the registered graph' },
+  );
+
+  // The deck boots on :home, so a same-target navigate would be a
+  // rule-3 no-op (Spec 012 §Per-route data loading rule 3): the slice
+  // wouldn't change and NAVIGATION THIS EPOCH would read 'no activity'.
+  // We therefore establish a NON-home route first (rung #3, article),
+  // which is also the route-params assertion, then drive rung #1 as a
+  // genuine transition back to :home.
+
+  // ---- #3 route params — CURRENT ROUTE :article with params {:id ..}.
+  await clickRung(page, 3);
+  const afterParams = await waitForValue(
+    () => readRoutingPanel(page),
+    (snap) =>
+      snap.currentId && snap.currentId.includes('routes-epochs/article') &&
+      snap.currentParams && snap.currentParams.includes(':id') &&
+      snap.currentParams.includes('intro') &&
+      snap.navTo && snap.navTo.includes('routes-epochs/article') &&
+      snap.navOutcome === 'transitioned',
+    { timeoutMs: 10000, description: '#3 route params → CURRENT ROUTE :article params {:id "intro"} + transitioned' },
+  );
+
+  // ---- #1 navigate/push — a genuine transition :article ──► :home.
+  //      CURRENT ROUTE lands on :home; NAVIGATION THIS EPOCH shows the
+  //      ──► TO (:home) row with outcome transitioned; the ROUTE TABLE
+  //      paints the destination overlay (:to) on the home row.
+  //      (Two LIVE-head-focus contracts the assertions respect: the
+  //      destination carries the `:to` overlay this epoch, not the
+  //      `:here` ◀ current marker — that shows on a non-nav focused
+  //      epoch (assign-markers); and the FROM glyph is empty because the
+  //      slice already holds the post-nav id == TO, so from-id collapses
+  //      to nil per nav-this-epoch's documented v1 same-id collapse.)
+  await clickRung(page, 1);
+  const afterHome = await waitForValue(
+    () => readRoutingPanel(page),
+    (snap) => {
+      const home = snap.tableRows.find((r) => r.routeId.endsWith('routes-epochs/home'));
+      return (
+        snap.currentId && snap.currentId.includes('routes-epochs/home') &&
+        snap.navTo && snap.navTo.includes('routes-epochs/home') &&
+        snap.navOutcome === 'transitioned' &&
+        home && home.marker === 'to'
+      );
+    },
+    { timeoutMs: 10000, description: '#1 navigate/push → ──► :home + outcome transitioned + :to overlay' },
+  );
+
+  // ---- #4 query params — CURRENT ROUTE :search, nav params carry q/sort.
+  await clickRung(page, 4);
+  const afterQuery = await waitForValue(
+    () => readRoutingPanel(page),
+    (snap) =>
+      snap.currentId && snap.currentId.includes('routes-epochs/search'),
+    { timeoutMs: 10000, description: '#4 query params → CURRENT ROUTE :search' },
+  );
+
+  // ---- #5 nested route — ROUTE TABLE indents :article under its parent
+  //      :articles (deeper padding-left) and the destination overlay
+  //      (:to) paints on the article row this navigation epoch.
+  await clickRung(page, 5);
+  const afterNested = await waitForValue(
+    () => readRoutingPanel(page),
+    (snap) => {
+      const article = snap.tableRows.find((r) => r.routeId.endsWith('routes-epochs/article'));
+      const articles = snap.tableRows.find((r) => r.routeId.endsWith('routes-epochs/articles'));
+      if (!article || !articles) return false;
+      const px = (s) => parseFloat(String(s).replace(/[^0-9.]/g, '')) || 0;
+      return (
+        snap.currentId && snap.currentId.includes('routes-epochs/article') &&
+        article.marker === 'to' &&
+        px(article.paddingLeft) > px(articles.paddingLeft)
+      );
+    },
+    { timeoutMs: 10000, description: '#5 nested route → :article indented under :articles + :to overlay' },
+  );
+
+  // ---- #7 not-found/fallback — an unmatched URL resolves to the
+  //      registered `:rf.route/not-found` fallback: CURRENT ROUTE reads
+  //      :rf.route/not-found and NAVIGATION THIS EPOCH lands ──► it.
+  //      (Because the fallback route IS registered, the destination
+  //      resolves to a real route-id, so the transition completes — the
+  //      "not-found" OUTCOME chip is reserved for the navigated-but-
+  //      no-destination case per nav-outcome in panels/routing.cljs.)
+  await clickRung(page, 7);
+  const afterNotFound = await waitForValue(
+    () => readRoutingPanel(page),
+    (snap) =>
+      snap.currentId && snap.currentId.includes('rf.route/not-found') &&
+      snap.navTo && snap.navTo.includes('rf.route/not-found'),
+    { timeoutMs: 10000, description: '#7 not-found → CURRENT ROUTE + NAVIGATION ──► :rf.route/not-found fallback' },
+  );
+
+  // ---- #10 + #11 guarded/blocked nav — enter dirty settings, then a
+  //      leave attempt is blocked: outcome chip reads blocked.
+  await clickRung(page, 10);
+  await waitForValue(
+    () => readRoutingPanel(page),
+    (snap) => snap.currentId && snap.currentId.includes('routes-epochs/settings'),
+    { timeoutMs: 10000, description: '#10 enter dirty settings → CURRENT ROUTE :settings' },
+  );
+  await clickRung(page, 11);
+  // The definitive blocked-navigation signal the Routing panel surfaces
+  // is that CURRENT ROUTE STAYS on :settings — the `:can-leave` guard
+  // refused the move home, so the slice never advanced. (The transient
+  // `blocked` outcome chip rides whichever cascade the LIVE spine has in
+  // focus; the slice-stayed-put invariant is the robust panel-level
+  // proof and is what a blocked nav means.) We additionally cross-check
+  // `:rf/pending-navigation` filled via the deck's current-route strip,
+  // the canonical pending-nav slot per Spec 012.
+  const afterBlocked = await waitForValue(
+    () => readRoutingPanel(page),
+    (snap) =>
+      snap.currentId && snap.currentId.includes('routes-epochs/settings'),
+    { timeoutMs: 10000, description: '#11 try-leave → guard blocked, CURRENT ROUTE stays :settings' },
+  );
+  const pendingProbe = await page.evaluate(() => {
+    const el = document.querySelector('[data-testid="routes-epochs-current-strip"]');
+    const stripText = el ? (el.textContent || '') : null;
+    // Direct app-db probe of the pending-navigation slot — the canonical
+    // blocked-nav signal per Spec 012, independent of the strip render.
+    let pendingNav = null;
+    try {
+      const cljs = window.cljs && window.cljs.core;
+      const rf = window.re_frame && window.re_frame.core;
+      // `re-frame.core/get-frame-db` returns the plain db map (no deref).
+      if (cljs && rf && typeof rf.get_frame_db === 'function') {
+        const kw = (s) => {
+          const t = String(s).replace(/^:/, '');
+          const p = t.split('/');
+          return p.length === 2
+            ? (cljs.keyword.call ? cljs.keyword.call(null, p[0], p[1]) : cljs.keyword(p[0], p[1]))
+            : (cljs.keyword.call ? cljs.keyword.call(null, t) : cljs.keyword(t));
+        };
+        const db = rf.get_frame_db(kw('rf/default'));
+        const path = cljs.PersistentVector.fromArray(
+          [kw('rf/runtime'), kw('routing'), kw('pending-navigation')], true);
+        const pn = db ? cljs.get_in(db, path) : null;
+        pendingNav = pn ? cljs.pr_str(pn) : null;
+      }
+    } catch (err) {
+      pendingNav = `probe-error:${String(err)}`;
+    }
+    return { stripText, pendingNav };
+  });
+  const pendingNavSet =
+    Boolean(pendingProbe.pendingNav && pendingProbe.pendingNav !== 'null') ||
+    /pending-navigation/.test(pendingProbe.stripText || '');
+  if (!pendingNavSet) {
+    failWithDetails('#11 try-leave blocked but :rf/pending-navigation did not fill', {
+      afterBlocked,
+      pendingProbe,
+    });
+  }
+
+  state.routesEpochs = {
+    routeTableRows: initial.tableRows.length,
+    home: { currentId: afterHome.currentId, outcome: afterHome.navOutcome },
+    params: afterParams.currentParams,
+    query: afterQuery.currentId,
+    nested: { currentId: afterNested.currentId },
+    notFound: { currentId: afterNotFound.currentId, navTo: afterNotFound.navTo },
+    blocked: { currentId: afterBlocked.currentId, pendingNavSet },
+  };
+}
+
 const SCENARIOS = [
   {
     name: 'feature matrix shell and panel handoff',
@@ -2697,6 +2951,20 @@ const SCENARIOS = [
       'Shell, Keybinding, Config, Preload, Settings, and Production Elision',
     ],
     run: runPanelGalleryThemeTokens,
+  },
+  {
+    // rf2-5crg4 — routes-epochs routing step-up deck. Drives the real
+    // `reg-route` + `:rf.route/navigate` surface and asserts the Xray
+    // Routing panel across CURRENT ROUTE (id + params + nested tree
+    // highlight), NAVIGATION THIS EPOCH (──► TO + outcome:
+    // transitioned / not-found / blocked), and the ROUTE TABLE
+    // (nested-row indent under the parent). Real Routing-panel coverage
+    // for the deck the `Routes` matrix row names.
+    name: 'routes-epochs routing ladder (current route, nav-this-epoch, nested table, blocked)',
+    url: '/testbeds/routes-epochs/',
+    panels: ['routing'],
+    coveredRows: ['Routes'],
+    run: runRoutesEpochs,
   },
   // ---- retired by rf2-xy4yb (4-layer chrome refactor) -------------------
   //

--- a/tools/xray/testbeds/routes_epochs/core.cljs
+++ b/tools/xray/testbeds/routes_epochs/core.cljs
@@ -1,0 +1,457 @@
+(ns routes-epochs.core
+  "ROUTES-EPOCHS testbed (rf2-5crg4) — the ROUTING sibling of the
+  `standard_epochs` deck. A deliberately simple Xray driving surface
+  aimed squarely at the **Routing panel** (`rf-xray-routing`).
+
+  ## Shape
+
+  ONE tall column of NUMBERED buttons, top to bottom — the same shape as
+  `standard_epochs`. Beside each button a one-line caption says WHAT TO
+  WATCH in Xray's Routing tab when you press it. Each button is ONE test:
+  it fires one event that
+
+    (a) bumps a shared baseline counter (so App-db / Epoch always show a
+        delta on every press), and
+    (b) exercises exactly ONE additional ROUTING feature.
+
+  Progressive: button 1 is a plain `navigate`; each later button layers
+  one more routing concept on top. A SINGLE frame, plainly mounted, with
+  the routing artefact booted (`[re-frame.routing]`) and Xray
+  auto-mounting inline on the right (`[data-rf-xray-host]` + the xray
+  preload) reading that one frame. No tabs, no live ACTION→CHECK strip:
+  the static caption is the 'what to look for', and the Routing panel
+  itself is the check.
+
+  ## North star (acceptance)
+
+  Click the buttons top to bottom → the Xray **Routing panel** is
+  COMPLETELY exercised: its three sections —
+
+    - CURRENT ROUTE         (active id · params · matched path)
+    - NAVIGATION THIS EPOCH (FROM ──► TO · params · outcome chip:
+                             transitioned / blocked / fragment-changed /
+                             not-found)
+    - ROUTE TABLE           (registered graph as a tree, nested rows
+                             indented, current row highlighted, FROM/TO
+                             overlay glyphs)
+
+  — each light up under one or more rungs of the ladder.
+
+  ## The routing ladder (per-rung Routing-panel coverage)
+
+    #1  navigate/push      — CURRENT ROUTE lands on `:routes-epochs/home`;
+                             NAVIGATION THIS EPOCH shows ──► home · transitioned.
+    #2  replace            — same slice write via `{:replace? true}`
+                             (`:rf.nav/replace-url`, no history push).
+    #3  route params       — `/articles/:id`; CURRENT ROUTE params `{:id ..}`.
+    #4  query params       — `?q=routing&sort=asc`; the `:query` slice +
+                             the `:rf.route/query` sub.
+    #5  nested routes      — a `:parent`-linked child; ROUTE TABLE draws
+                             the indented tree + the current-row highlight
+                             walks the parent chain (`:rf.route/chain`).
+    #6  redirect           — a route whose `:on-match` re-navigates; the
+                             cascade lands the slice on a DIFFERENT route.
+    #7  not-found/fallback — an unmatched URL; CURRENT ROUTE =
+                             `:rf.route/not-found`, outcome `not-found`.
+    #8  route-driven app-db— an `:on-match` loader writes app-db from the
+                             route params (transition :loading → :idle).
+    #9  back/forward        — push, then a popstate-style back; NAVIGATION
+                             THIS EPOCH's FROM ──► TO reverses.
+    #10 guarded/blocked nav— a `:can-leave` guard refuses; outcome
+                             `blocked` + `:rf/pending-navigation` is set.
+
+  ## Test surface, not tutorial
+
+  Per `feedback_testbeds_are_test_surfaces`: no deliberate bugs as
+  anti-patterns, no teaching layers. The guard / not-found / redirect
+  buttons exercise the REAL routing surface — each is a feature being
+  driven, not a buggy demo. Captions are guidance, not lessons.
+
+  ## Test-free + self-contained
+
+  Per rf2-8cevm this testbed carries no spec.cjs; regression coverage
+  lives in the substrate contract tests + the Xray feature-matrix gate
+  (`tools/xray/testbeds/feature_matrix/scenarios.cjs` — the
+  `routes-epochs routing ladder` scenario). The routes / events / subs /
+  views below are OWNED here — this deck does NOT reuse the shared
+  `testdeck.*` modules."
+  (:require [reagent.dom.client :as rdc]
+            [re-frame.core :as rf]
+            ;; Routing artefact — load-time hook so `reg-route`,
+            ;; `:rf.route/navigate`, the `:rf.route/*` subs and
+            ;; `route-link` resolve. Without this require `reg-route`
+            ;; below throws `:rf.error/routing-artefact-missing`.
+            [re-frame.routing]
+            [re-frame.views]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            ;; Xray's `configure!` to seed `:project-root` so the Event
+            ;; lens 'open' chip resolves a classpath-relative `:file` to
+            ;; an absolute on-disk URI.
+            [day8.re-frame2-xray.config :as xray-config]
+            ;; Shared testbed-config helper (rf2-5dphw): derives the
+            ;; open-in-editor project-root from the build env.
+            [re-frame.testbed.config :as testbed-config])
+  (:require-macros [re-frame.core :refer [reg-view]]))
+
+;; ============================================================================
+;; ROUTES — the deck OWNS its own route table
+;; ============================================================================
+;;
+;; A small, flat-plus-one-nested graph chosen for per-section Routing-panel
+;; coverage:
+;;
+;;   :routes-epochs/home              /                       (landing)
+;;   :routes-epochs/articles          /articles               (list — also
+;;                                                              the nested
+;;                                                              parent)
+;;   :routes-epochs/article           /articles/:id           (params; nested
+;;                                                              under articles)
+;;   :routes-epochs/search            /search?q&sort          (query params)
+;;   :routes-epochs/old-home          /old-home               (redirects → home)
+;;   :routes-epochs/settings          /settings               (guarded by a
+;;                                                              :can-leave gate)
+;;   :rf.route/not-found              /_404                   (fallback)
+
+(rf/reg-route :routes-epochs/home
+  {:doc  "Landing page — the ladder's first navigation target."
+   :path "/"})
+
+(rf/reg-route :routes-epochs/articles
+  {:doc  "Articles list — the nested-route PARENT (button #5's child sits
+          under it, so the ROUTE TABLE draws the indented tree)."
+   :path "/articles"})
+
+(rf/reg-route :routes-epochs/article
+  {:doc    "Article detail — carries a `:id` path param (button #3) and is
+            NESTED under `:routes-epochs/articles` (button #5) so the
+            ROUTE TABLE indents it and the current-row highlight walks the
+            parent chain."
+   :path   "/articles/:id"
+   :parent :routes-epochs/articles
+   :params [:map [:id :string]]})
+
+(rf/reg-route :routes-epochs/search
+  {:doc   "Search — declares a `:query` schema so the query keys round-trip
+           into the route slice (button #4)."
+   :path  "/search"
+   :query [:map
+           [:q {:optional true} :string]
+           [:sort {:optional true} :string]]})
+
+(rf/reg-route :routes-epochs/old-home
+  {:doc      "A retired URL that REDIRECTS to `:routes-epochs/home` via its
+              `:on-match` (button #6) — navigating here lands the slice on
+              home, one cascade later."
+   :path     "/old-home"
+   :on-match [[:routes-epochs/redirect-to-home]]})
+
+(rf/reg-route :routes-epochs/profile
+  {:doc      "A profile route whose `:on-match` LOADER writes app-db from
+              the route params (button #8): transition runs :loading → :idle
+              while the loader fills `:profile`."
+   :path     "/profile/:user"
+   :params   [:map [:user :string]]
+   :on-match [[:routes-epochs/load-profile]]})
+
+(rf/reg-route :routes-epochs/settings
+  {:doc       "Settings — GUARDED by a `:can-leave` gate (button #10). The
+               gate refuses to leave while `:settings-dirty?` is set, so a
+               navigation AWAY is blocked and `:rf/pending-navigation` fills."
+   :path      "/settings"
+   :can-leave :routes-epochs/can-leave-settings?})
+
+;; The runtime emits :rf.route/not-found for unmatched URLs (button #7).
+(rf/reg-route :rf.route/not-found
+  {:doc  "Fallback page for unmatched URLs — CURRENT ROUTE reads
+          `:rf.route/not-found`; NAVIGATION THIS EPOCH's outcome chip
+          reads `not-found`."
+   :path "/_404"})
+
+;; ============================================================================
+;; APP-DB SEED
+;; ============================================================================
+;;
+;; `:baseline` is the shared counter every button bumps (so App-db / Epoch
+;; always show a delta). `:articles` feeds the params / nested-route
+;; targets. `:profile` is the slot the route-driven loader (button #8)
+;; fills from the route params. `:settings-dirty?` arms the `:can-leave`
+;; guard (button #10).
+
+(def initial-db
+  {:baseline        0
+   :articles        [{:id "intro" :title "Intro to re-frame2 routing"}
+                     {:id "nested" :title "Nested routes & the route tree"}]
+   :profile         nil
+   :settings-dirty? false})
+
+(rf/reg-event-fx :routes-epochs/reset
+  {:doc "Button 0 — re-seed app-db AND navigate home. Start clean."}
+  (fn handler-reset [_ _ev]
+    {:db initial-db
+     :fx [[:dispatch [:rf.route/navigate :routes-epochs/home]]]}))
+
+;; ============================================================================
+;; A small shared helper: every ladder event bumps the baseline counter.
+;; ============================================================================
+;;
+;; The routing events themselves are FRAMEWORK events (`:rf.route/navigate`
+;; etc.) we cannot edit, so each rung is a thin deck-owned event-fx that
+;; (a) bumps `:baseline` via `:db` and (b) dispatches the routing
+;; event/fx. The Epoch / App-db delta on every press comes from the bump;
+;; the Routing panel lights up from the dispatched routing event.
+
+(defn- bump [db] (update db :baseline inc))
+
+;; A reusable "bump + navigate" event-fx: every navigation rung routes
+;; through here so the baseline delta and the navigation are one cascade.
+(rf/reg-event-fx :routes-epochs/go
+  {:doc "Bump the baseline and dispatch `:rf.route/navigate` with the
+         supplied target / params / opts. The shared driver behind every
+         navigation rung."}
+  (fn handler-go [{:keys [db]} [_ target params opts]]
+    {:db (bump db)
+     :fx [[:dispatch [:rf.route/navigate target params (or opts {})]]]}))
+
+;; ============================================================================
+;; REDIRECT (#6) + ROUTE-DRIVEN APP-DB LOADER (#8)
+;; ============================================================================
+
+(rf/reg-event-fx :routes-epochs/redirect-to-home
+  {:doc "Button #6's redirect — fired as `:routes-epochs/old-home`'s
+         `:on-match`. Re-navigates to home so the slice lands on a
+         DIFFERENT route one cascade later."}
+  (fn handler-redirect [{:keys [db]} _ev]
+    {:db (bump db)
+     :fx [[:dispatch [:rf.route/navigate :routes-epochs/home]]]}))
+
+(rf/reg-event-db :routes-epochs/load-profile
+  {:doc "Button #8's route-driven loader — fired as
+         `:routes-epochs/profile`'s `:on-match`. Reads the route params
+         from the slice and writes `:profile` into app-db (the
+         transition runs :loading → :idle around this loader)."}
+  (fn handler-load-profile [db _ev]
+    (let [user (get-in db [:rf/runtime :routing :current :params :user])]
+      (-> db bump (assoc :profile {:user user :loaded-at-baseline (:baseline db)})))))
+
+;; ============================================================================
+;; GUARDED NAV (#10) — a :can-leave gate
+;; ============================================================================
+;;
+;; `:routes-epochs/settings` declares `:can-leave :routes-epochs/can-leave-
+;; settings?`. The guard returns `false` (block) while `:settings-dirty?`
+;; is set — so a navigation AWAY from settings is refused, the runtime
+;; writes `:rf/pending-navigation`, and the Routing panel's NAVIGATION
+;; THIS EPOCH outcome reads `blocked`. The contract is closed (rf2-5pyyl):
+;; only literal `true` / `false` are accepted, hence `(boolean ...)`.
+
+(rf/reg-sub :routes-epochs/can-leave-settings?
+  (fn [db _] (boolean (not (:settings-dirty? db)))))
+
+(rf/reg-event-fx :routes-epochs/enter-dirty-settings
+  {:doc "Button #10a — navigate INTO settings AND arm the dirty flag, so
+         the `:can-leave` guard will block the next attempt to leave."}
+  (fn handler-enter-dirty [{:keys [db]} _ev]
+    {:db (-> db bump (assoc :settings-dirty? true))
+     :fx [[:dispatch [:rf.route/navigate :routes-epochs/settings]]]}))
+
+(rf/reg-event-fx :routes-epochs/try-leave-settings
+  {:doc "Button #10b — attempt to navigate home FROM dirty settings. The
+         `:can-leave` guard refuses: the slice stays on settings, the
+         outcome reads `blocked`, and `:rf/pending-navigation` fills."}
+  (fn handler-try-leave [{:keys [db]} _ev]
+    {:db (bump db)
+     :fx [[:dispatch [:rf.route/navigate :routes-epochs/home]]]}))
+
+;; ============================================================================
+;; BACK / FORWARD HISTORY (#9)
+;; ============================================================================
+;;
+;; A plain history step: dispatch `:rf.route/handle-url-change` for the
+;; previous URL (what a popstate listener does on the browser Back
+;; button), so NAVIGATION THIS EPOCH's FROM ──► TO reverses relative to
+;; the forward navigation that preceded it.
+
+(rf/reg-event-fx :routes-epochs/back
+  {:doc "Button #9 — emulate the browser Back button by handling a
+         url-change back to the articles list (a popstate-style
+         transition). NAVIGATION THIS EPOCH's FROM ──► TO reverses."}
+  (fn handler-back [{:keys [db]} _ev]
+    {:db (bump db)
+     :fx [[:dispatch [:rf.route/handle-url-change "/articles"]]]}))
+
+;; ============================================================================
+;; SUBSCRIPTIONS — route reads (framework subs) + deck reads
+;; ============================================================================
+;;
+;; The framework ships `:rf.route/id`, `:rf.route/params`, `:rf.route/query`,
+;; `:rf.route/transition`, `:rf.route/chain` and `:rf/pending-navigation`.
+;; The deck only needs a couple of app-db reads for its own status strip.
+
+(rf/reg-sub :routes-epochs/baseline (fn [db _] (:baseline db)))
+(rf/reg-sub :routes-epochs/profile  (fn [db _] (:profile db)))
+
+;; ============================================================================
+;; THE BUTTON LADDER
+;; ============================================================================
+
+(def ^:private ladder
+  "The ordered routing ladder. Each row: [n label caption event]. `event`
+  is the dispatch vector; `:section` rows are separators (label only)."
+  [[:section "Navigation basics — CURRENT ROUTE + NAVIGATION THIS EPOCH"]
+   [1  "navigate / push"
+    "CURRENT ROUTE → :home · NAVIGATION ──► home · outcome transitioned"
+    [:routes-epochs/go :routes-epochs/home]]
+   [2  "replace (no history push)"
+    "Same slice write via :replace? true (:rf.nav/replace-url, no push)"
+    [:routes-epochs/go :routes-epochs/home nil {:replace? true}]]
+   [:section "Params & query — the slice carries params / query"]
+   [3  "route params (/articles/:id)"
+    "CURRENT ROUTE → :article · params {:id \"intro\"}"
+    [:routes-epochs/go :routes-epochs/article {:id "intro"}]]
+   [4  "query params (?q&sort)"
+    "CURRENT ROUTE → :search · query {:q \"routing\" :sort \"asc\"} (:rf.route/query)"
+    [:routes-epochs/go :routes-epochs/search nil {:query {:q "routing" :sort "asc"}}]]
+   [:section "ROUTE TABLE — nested tree, redirect, fallback"]
+   [5  "nested route (under :articles)"
+    "ROUTE TABLE indents :article under :articles · highlight walks the parent chain"
+    [:routes-epochs/go :routes-epochs/article {:id "nested"}]]
+   [6  "redirect (:on-match re-navigates)"
+    "Navigate :old-home → its :on-match lands the slice on :home one cascade later"
+    [:routes-epochs/go :routes-epochs/old-home]]
+   [7  "not-found / fallback"
+    "Unmatched URL → CURRENT ROUTE :rf.route/not-found · outcome not-found"
+    [:routes-epochs/go {:url "/no-such-page"}]]
+   [:section "Loaders & transitions — :on-match drives app-db"]
+   [8  "route-driven app-db (:on-match loader)"
+    "Navigate :profile → :on-match writes :profile from params · transition :loading→:idle"
+    [:routes-epochs/go :routes-epochs/profile {:user "ada"}]]
+   [9  "back / forward (popstate)"
+    "Emulate Back → :articles · NAVIGATION THIS EPOCH's FROM ──► TO reverses"
+    [:routes-epochs/back]]
+   [:section "Guarded navigation — :can-leave blocks"]
+   [10 "enter dirty settings (arm the guard)"
+    "Navigate INTO :settings + arm :settings-dirty? so the guard will block leaving"
+    [:routes-epochs/enter-dirty-settings]]
+   [11 "try to leave (blocked by :can-leave)"
+    "Attempt → home FROM dirty settings · outcome blocked · :rf/pending-navigation fills"
+    [:routes-epochs/try-leave-settings]]])
+
+(reg-view ladder-button
+  "One numbered ladder row: a numbered button on the left, its caption on
+  the right. Pressing it dispatches the row's event. The button carries a
+  per-rung `data-testid` (`routes-epochs-rung-<n>`) so each rung is
+  uniquely addressable even though several share the `:routes-epochs/go`
+  event-id (the feature-matrix scenario drives them by rung)."
+  [n label caption event]
+  [:div {:style {:display "grid" :grid-template-columns "auto 1fr"
+                 :gap "0.75em" :align-items "center" :margin "0.35em 0"}}
+   [:button {:data-testid (str "routes-epochs-rung-" n)
+             :on-click    #(dispatch event)
+             :style {:min-width "20em" :text-align "left"
+                     :padding "0.4em 0.6em" :cursor "pointer"
+                     :border "1px solid #cfc8ff" :border-radius "6px"
+                     :background "#fff"}}
+    [:span {:style {:font-weight "bold" :color "#7C5CFF" :margin-right "0.5em"}}
+     (str n ".")]
+    label]
+   [:span {:style {:color "#666" :font-size "12px"}} caption]])
+
+(reg-view section-heading
+  "A section separator inside the ladder."
+  [label]
+  [:div {:style {:margin "1em 0 0.25em 0" :font-size "11px" :font-weight "bold"
+                 :color "#7C5CFF" :text-transform "uppercase"
+                 :letter-spacing "0.04em" :border-top "1px dashed #ddd"
+                 :padding-top "0.5em"}}
+   label])
+
+(reg-view current-route-strip
+  "A small live read-out of the active route slice — mirrors what the
+  Xray Routing panel projects, so the deck stays legible standalone. Pure
+  app-state reads; the Routing panel is the actual check."
+  []
+  (let [id      @(subscribe [:rf.route/id])
+        params  @(subscribe [:rf.route/params])
+        query   @(subscribe [:rf.route/query])
+        trans   @(subscribe [:rf.route/transition])
+        pending @(subscribe [:rf/pending-navigation])]
+    [:div {:data-testid "routes-epochs-current-strip"
+           :style {:border "1px solid #d8d2ff" :border-radius "6px"
+                   :padding "0.5em 0.75em" :margin "0.75em 0"
+                   :background "#fcfbff" :font-size "12px"}}
+     [:div {:style {:font-size "11px" :color "#7C5CFF" :font-weight "bold"
+                    :text-transform "uppercase" :letter-spacing "0.04em"}}
+      "Current route slice"]
+     [:div "id: " [:strong (str id)]]
+     [:div "params: " [:strong (pr-str (or params {}))]]
+     [:div "query: " [:strong (pr-str (or query {}))]]
+     [:div "transition: " [:strong (str trans)]]
+     (when pending
+       [:div {:style {:color "#b8860b"}}
+        "pending-navigation: " [:strong (pr-str pending)]])]))
+
+(reg-view root []
+  [:div {:data-testid "routes-epochs-root"
+         :style {:font-family "system-ui, sans-serif" :padding "1em"
+                 :max-width "760px"}}
+   [:header {:style {:margin-bottom "0.5em"}}
+    [:h2 {:style {:margin 0}} "Routes-epochs"]
+    [:p {:style {:color "#444" :margin "0.5em 0 0 0"}}
+     "One frame, one tall column of routing test buttons. Each button bumps a shared "
+     [:strong "baseline"] " counter (so App-db / Epoch always show a delta) and "
+     "exercises exactly one more routing feature. The caption says what to watch in "
+     "Xray's " [:strong "Routing"] " panel on the right — click top to bottom and the "
+     "panel's three sections (Current route · Navigation this epoch · Route table) are "
+     "fully exercised."]]
+   [current-route-strip]
+   ;; Button 0 — Reset.
+   [:button {:data-testid "reset-button"
+             :on-click #(dispatch [:routes-epochs/reset])
+             :style {:padding "0.4em 0.8em" :cursor "pointer"
+                     :border "1px solid #cfc8ff" :border-radius "6px"
+                     :background "#f4f1ff" :margin "0.5em 0"}}
+    "0. Reset — re-seed app-db, navigate home"]
+   ;; The ladder.
+   (for [row ladder]
+     (if (= :section (first row))
+       ^{:key (second row)} [section-heading (second row)]
+       (let [[n label caption event] row]
+         ^{:key n} [ladder-button n label caption event])))])
+
+;; ============================================================================
+;; ROUTER WIRING
+;; ============================================================================
+
+(defn- current-url []
+  (str (.. js/window -location -pathname)
+       (.. js/window -location -search)
+       (.. js/window -location -hash)))
+
+;; ============================================================================
+;; MOUNT
+;; ============================================================================
+
+(defonce react-root
+  (rdc/create-root (js/document.getElementById "app")))
+
+;; rf2-5dphw — open-in-editor project-root is derived from the build
+;; environment, not a hardcoded personal path. `re-frame.testbed.config`
+;; joins the build-time repo-root goog-define with this testbed's
+;; tool-relative subdir; `?project-root=<path>` still overrides per
+;; session. See that ns for the cross-platform mechanism.
+(defn- resolve-project-root []
+  (testbed-config/resolve-project-root "tools/xray/testbeds"))
+
+(defn ^:export run []
+  ;; Configure Xray BEFORE `rf/init!` so the preload's auto-open reads the
+  ;; right project-root on its first paint of any chip.
+  (xray-config/configure! {:rf.xray/project-root (resolve-project-root)})
+  (rf/init! reagent-adapter/adapter)
+  ;; Seed app-db and pull the current URL into the route slice (what a
+  ;; popstate / initial-load handler does). The default frame is the one
+  ;; Xray reads. The browser History listener is installed so button #9's
+  ;; back/forward emulation has somewhere to land.
+  (rf/install-history-listener!)
+  (rf/dispatch-sync [:routes-epochs/reset])
+  (rf/dispatch-sync [:rf.route/handle-url-change (current-url)])
+  (rdc/render react-root [root]))

--- a/tools/xray/testbeds/routes_epochs/index.html
+++ b/tools/xray/testbeds/routes_epochs/index.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>re-frame2 testbed: routes-epochs (Xray Routing demo)</title>
+  <style>
+    body { margin: 0; font-family: sans-serif; }
+    .rf2-testbed-shell { display: flex; min-height: 100vh; }
+    /* `--rf-xray-inline-width` is Xray's documented host-resize knob
+       (rf2-um813; see day8.re-frame2-xray.config/default-layout-host-css-var
+       and spec/011-Launch-Modes.md §Resizing the inline host). Override
+       the property anywhere up the cascade to resize the panel without
+       JS or a fork of this rule. The user-draggable resize handle is
+       auto-injected by Xray (rf2-70u8q; spec/007-UX-IA.md §Resize
+       affordance) — no `resize: horizontal` / `overflow: auto` needed. */
+    :root { --rf-xray-accent: #7C5CFF; }
+    [data-rf-xray-host] { flex: 0 0 var(--rf-xray-inline-width, 560px); min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; }
+    #app { flex: 1; min-width: 0; padding: 0; }
+  </style>
+</head>
+<body>
+  <div class="rf2-testbed-shell">
+    <main id="app"></main>
+    <aside data-rf-xray-host></aside>
+  </div>
+  <script src="main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Adds **`routes_epochs`** — the ROUTING sibling of the just-merged `standard_epochs` deck (the cyczr `_epochs` trio). A single-frame numbered-button ladder over the real `reg-route` + `:rf.route/navigate` surface (Spec 012), aimed squarely at the Xray **Routing panel** (`rf-xray-routing`).

**North star:** click the buttons top-to-bottom → the Routing panel's three sections (Current route · Navigation this epoch · nested Route table) are completely exercised.

The deck OWNS its own routes/events/subs/views — it boots `[re-frame.routing]` and uses the real navigation surface; it does NOT reuse the deleted/legacy shared `testdeck.*` modules. Test-free testbed (no `spec.cjs`); regression coverage lives in `feature_matrix`.

## Routing ladder (the buttons)

| # | Button | What to watch in the Routing panel |
|---|---|---|
| 1 | navigate / push | CURRENT ROUTE → `:home`; NAVIGATION ──► home · transitioned; `:to` overlay |
| 2 | replace (no history push) | same slice write via `{:replace? true}` (`:rf.nav/replace-url`) |
| 3 | route params (`/articles/:id`) | CURRENT ROUTE → `:article` · params `{:id "intro"}` |
| 4 | query params (`?q&sort`) | CURRENT ROUTE → `:search` · `:rf.route/query` |
| 5 | nested route (under `:articles`) | ROUTE TABLE indents `:article` under its parent; `:to` overlay |
| 6 | redirect (`:on-match` re-navigates) | `:old-home`'s `:on-match` lands the slice on `:home` |
| 7 | not-found / fallback | unmatched URL → CURRENT ROUTE `:rf.route/not-found` |
| 8 | route-driven app-db (`:on-match` loader) | `:profile`'s loader writes app-db from params; transition `:loading→:idle` |
| 9 | back / forward (popstate) | emulated Back → `:articles` |
| 10 | enter dirty settings (arm the guard) | navigate INTO `:settings` + arm `:settings-dirty?` |
| 11 | try to leave (blocked by `:can-leave`) | guard refuses → CURRENT ROUTE stays `:settings` · `:rf/pending-navigation` fills |

## HOT-ZONE call-out — `implementation/shadow-cljs.edn`

- Added the **`:examples/routes-epochs`** build-id — `:output-dir out/examples/routes-epochs`, `:init-fn routes-epochs.core/run`, modules + Xray/pair preloads + build-env project-root — modelled **exactly** on the just-merged `:examples/standard-epochs` entry.
- Added a **`:dev-http` entry on port 8032** (standard-epochs is 8031; machine_epochs will be 8033), same source-dir-first cascade as 8031.

## feature_matrix scenarios added

- New `STAGED_SURFACE` for `examples/routes-epochs` (served at `/testbeds/routes-epochs/`).
- New SCENARIO **"routes-epochs routing ladder (current route, nav-this-epoch, nested table, blocked)"** (`coveredRows: ['Routes']`, `panels: ['routing']`). It drives rungs #3 → #1 → #4 → #5 → #7 → #10 → #11 and asserts:
  - CURRENT ROUTE id + params (`:article {:id "intro"}`, `:search`);
  - NAVIGATION THIS EPOCH `──► TO` + `transitioned` outcome + the ROUTE TABLE `:to` destination overlay;
  - the nested ROUTE TABLE indent (`:article` deeper than its `:articles` parent);
  - the `:rf.route/not-found` fallback;
  - the `:can-leave` **blocked** navigation (slice stays on `:settings` + `:rf/pending-navigation` fills, probed directly off `get-frame-db`).

`tools/xray/README.md`: added `routes_epochs` to the browser-testbed inventory.

## Quality gates

Run from `implementation/`:

| Gate | Result |
|---|---|
| `npx shadow-cljs compile examples/routes-epochs` | **0 warnings** |
| `npm run test:cljs` | **green** — 5087 tests, 17158 assertions, 0 failures |
| `npm run test:xray-feature-gate` | **green** — 15/15 scenarios (incl. the new routing ladder), 0 failures |
| `npm run test:bundle-isolation` | **PASS** |
| clj-kondo on `routes_epochs/core.cljs` | **0 errors, 0 warnings** |
| Splint on `routes_epochs/` | **0 warnings** |

Edit scope: new `tools/xray/testbeds/routes_epochs/` + the `shadow-cljs.edn` build-id/port + the feature_matrix scenario + the README inventory line. No edits to `tools/xray/src/panels/app_db_*` or `spine.cljs`, core/impl, or top-level `spec/*`.
